### PR TITLE
refactor(engine): isolate untracked state physically

### DIFF
--- a/packages/engine/src/branch/control.rs
+++ b/packages/engine/src/branch/control.rs
@@ -90,10 +90,6 @@ impl BranchHeadControl {
         }
     }
 
-    pub(crate) fn reset_schema_presence(&mut self) {
-        self.schema_presence_bloom = [0; SCHEMA_PRESENCE_BLOOM_WORDS];
-    }
-
     pub(crate) fn may_have_schema(&self, schema_key: &str) -> bool {
         let hash = xxh3_64(schema_key.as_bytes()).to_be_bytes();
         hash.chunks_exact(2).all(|pair| {
@@ -356,9 +352,6 @@ mod tests {
         presence.note_schema("present");
         assert!(presence.may_have_schema("present"));
         assert!(!presence.may_have_schema("absent"));
-        presence.reset_schema_presence();
-        assert!(!presence.may_have_schema("present"));
-
         let mut writes = storage.new_write_set();
         stage_branch_head_control(&mut writes, &branch_b, first)
             .expect("branch b control should stage");

--- a/packages/engine/src/engine.rs
+++ b/packages/engine/src/engine.rs
@@ -498,6 +498,26 @@ mod tests {
         StorageProjectedValue, StorageScanOptions, StorageSpace, StorageSpaceId, StorageValue,
     };
 
+    async fn space_row_count(storage: &Memory, space: StorageSpace) -> usize {
+        let adapter = StorageAdapter::new(storage.clone());
+        let read = adapter
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("space inventory read should open");
+        ScanPlan::prefix(
+            space,
+            StoragePrefix {
+                bytes: Bytes::new(),
+            },
+        )
+        .collect(&read, StorageScanOptions::default())
+        .await
+        .expect("space inventory should scan")
+        .value
+        .entries
+        .len()
+    }
+
     async fn register_json_pointer_schema_in_scope(session: &SessionContext<Memory>, global: bool) {
         let schema = json!({
             "x-lix-key": "json_pointer",
@@ -737,6 +757,30 @@ mod tests {
 
         let Err(error) = Engine::new(storage).await else {
             panic!("V21 repositories must fail closed before hot rows are decoded");
+        };
+        assert_eq!(error.code, "LIX_ERROR_UNSUPPORTED_STORAGE_FORMAT");
+    }
+
+    #[tokio::test]
+    async fn predecessor_v57_unified_untracked_protocol_is_rejected() {
+        let storage = Memory::new();
+        Engine::initialize(storage.clone())
+            .await
+            .expect("engine should initialize");
+        let adapter = StorageAdapter::new(storage.clone());
+        let mut writes = adapter.new_write_set();
+        writes.put(
+            crate::init::REPOSITORY_PROTOCOL_SPACE,
+            crate::init::REPOSITORY_PROTOCOL_KEY,
+            &b"immutable-physical-commit-state.v57"[..],
+        );
+        adapter
+            .commit_write_set(writes, StorageWriteOptions::default())
+            .await
+            .expect("V57 protocol marker should commit");
+
+        let Err(error) = Engine::new(storage).await else {
+            panic!("V57 repositories must fail closed before unified HOT rows are decoded");
         };
         assert_eq!(error.code, "LIX_ERROR_UNSUPPORTED_STORAGE_FORMAT");
     }
@@ -1093,7 +1137,7 @@ mod tests {
         Engine::initialize(storage.clone())
             .await
             .expect("engine should initialize");
-        let engine = Engine::new(storage)
+        let engine = Engine::new(storage.clone())
             .await
             .expect("initialized engine should open");
         let session = engine
@@ -1109,6 +1153,10 @@ mod tests {
             )
             .await
             .expect("write tracked entity row");
+        let hot_rows_before_untracked =
+            space_row_count(&storage, crate::live_state::HOT_ROW_SPACE).await;
+        let untracked_rows_before =
+            space_row_count(&storage, crate::live_state::UNTRACKED_ROW_SPACE).await;
         session
             .execute(
                 "INSERT INTO json_pointer (path, value, lixcol_untracked) \
@@ -1117,6 +1165,16 @@ mod tests {
             )
             .await
             .expect("write untracked entity row");
+        assert_eq!(
+            space_row_count(&storage, crate::live_state::HOT_ROW_SPACE).await,
+            hot_rows_before_untracked,
+            "untracked writes must not mutate generation-scoped HOT rows"
+        );
+        assert_eq!(
+            space_row_count(&storage, crate::live_state::UNTRACKED_ROW_SPACE).await,
+            untracked_rows_before + 1,
+            "untracked writes must add one branch-stable physical row"
+        );
 
         let rows = session
             .execute("SELECT path, value FROM json_pointer ORDER BY path", &[])
@@ -1404,6 +1462,51 @@ mod tests {
                 .map(|row| row.get::<String>("path").expect("row path"))
                 .collect::<Vec<_>>(),
             ["/after-checkpoint", "/checkpointed", "/workspace"]
+        );
+    }
+
+    #[tokio::test]
+    async fn checkpoint_preserves_untracked_only_schema_presence() {
+        let storage = Memory::new();
+        Engine::initialize(storage.clone())
+            .await
+            .expect("engine should initialize");
+        let engine = Engine::new(storage)
+            .await
+            .expect("initialized engine should open");
+        let session = engine
+            .open_workspace_session()
+            .await
+            .expect("workspace session should open");
+        register_json_pointer_schema(&session).await;
+        session
+            .execute(
+                "INSERT INTO json_pointer (path, value, lixcol_untracked) \
+                 VALUES ('/survives-checkpoint', lix_json('{\"owner\":\"workspace\"}'), true)",
+                &[],
+            )
+            .await
+            .expect("insert branch-local untracked row");
+
+        session
+            .create_checkpoint()
+            .await
+            .expect("checkpoint should rotate the tracked generation");
+
+        let row = session
+            .execute(
+                "SELECT value FROM json_pointer \
+                 WHERE path = '/survives-checkpoint' AND lixcol_untracked = true",
+                &[],
+            )
+            .await
+            .expect("constrained read should retain untracked schema presence");
+        assert_eq!(row.rows().len(), 1);
+        assert_eq!(
+            row.rows()[0]
+                .get::<serde_json::Value>("value")
+                .expect("workspace JSON value"),
+            json!({"owner": "workspace"})
         );
     }
 

--- a/packages/engine/src/functions/context.rs
+++ b/packages/engine/src/functions/context.rs
@@ -122,8 +122,7 @@ mod tests {
     use crate::entity_pk::EntityPk;
     use crate::functions::state::{DETERMINISTIC_MODE_KEY, DETERMINISTIC_SEQUENCE_KEY};
     use crate::functions::{DeterministicSequence, state::load_sequence};
-    use crate::live_state::LiveStateContext;
-    use crate::live_state::{CurrentStateDeltaRef, TrackedHeadContext, WorkingDiffIndexCoverage};
+    use crate::live_state::{CurrentStateDeltaRef, LiveStateContext};
     use crate::storage_adapter::StorageAdapter;
     use crate::storage_adapter::{Memory, StorageReadOptions, StorageWriteOptions};
 
@@ -354,35 +353,28 @@ mod tests {
             .expect("global branch control should load")
             .expect("global branch control should exist");
         let snapshot = crate::json_store::JsonSlot::from_json(&snapshot_content);
-        let mut working_diff_coverage = WorkingDiffIndexCoverage::default();
-        TrackedHeadContext::new()
-            .writer(&read, &mut writes)
-            .stage_current_state_with_working_diff(
-                GLOBAL_BRANCH_ID,
-                Some(control.generation),
-                control.head_commit_id,
-                &[CurrentStateDeltaRef {
-                    schema_key: "lix_key_value",
-                    file_id: None,
-                    entity_pk: &entity_pk,
-                    change_id: None,
-                    commit_id: None,
-                    untracked: true,
-                    deleted: false,
-                    created_at: timestamp,
-                    updated_at: timestamp,
-                    snapshot: snapshot.as_ref_slot(),
-                    metadata: crate::json_store::JsonSlotRef::None,
-                    columnar_base_coordinate: None,
-                }],
-                &std::collections::BTreeSet::new(),
-                None,
-                None,
-                None,
-                &mut working_diff_coverage,
-            )
-            .await
-            .expect("test key-value current row should stage");
+        crate::live_state::stage_untracked_deltas(
+            &read,
+            &mut writes,
+            GLOBAL_BRANCH_ID,
+            &[CurrentStateDeltaRef {
+                schema_key: "lix_key_value",
+                file_id: None,
+                entity_pk: &entity_pk,
+                change_id: None,
+                commit_id: None,
+                untracked: true,
+                deleted: false,
+                created_at: timestamp,
+                updated_at: timestamp,
+                snapshot: snapshot.as_ref_slot(),
+                metadata: crate::json_store::JsonSlotRef::None,
+                columnar_base_coordinate: None,
+            }],
+            &[false],
+        )
+        .await
+        .expect("test key-value current row should stage");
         stage_branch_head_control(
             &mut writes,
             GLOBAL_BRANCH_ID,

--- a/packages/engine/src/functions/state.rs
+++ b/packages/engine/src/functions/state.rs
@@ -6,16 +6,15 @@ use crate::LixError;
 use crate::branch::{
     BranchHeadControlContext, branch_head_control_precondition, stage_branch_head_control,
 };
-use crate::changelog::{ChangeId, ChangeRecordProjection};
+use crate::changelog::ChangeId;
 use crate::common::LixTimestamp;
 use crate::entity_pk::EntityPk;
 use crate::functions::{DeterministicMode, DeterministicSequence};
 use crate::json_store::{
     JsonSlot, JsonStoreContext, JsonWritePlacementRef, NormalizedJson, NormalizedJsonRef,
 };
-use crate::live_state::{CurrentStateDeltaRef, MaterializedLiveStateRow, TrackedHeadContext};
+use crate::live_state::{CurrentStateDeltaRef, MaterializedLiveStateRow};
 use crate::storage_adapter::{StorageAdapterRead, StoragePrecondition, StorageWriteSet};
-use crate::tracked_state::TrackedStateKey;
 
 pub(crate) const DETERMINISTIC_MODE_KEY: &str = "lix_deterministic_mode";
 pub(crate) const DETERMINISTIC_SEQUENCE_KEY: &str = "lix_deterministic_sequence_number";
@@ -92,34 +91,27 @@ pub(crate) async fn stage_sequence(
         [NormalizedJsonRef::from(&snapshot)],
     )?;
     let snapshot_slot = JsonSlot::from_json(snapshot.as_str());
-    let mut working_diff_coverage = crate::live_state::WorkingDiffIndexCoverage::default();
-    TrackedHeadContext::new()
-        .writer(read, writes)
-        .stage_current_state_with_working_diff(
-            GLOBAL_BRANCH_ID,
-            Some(control.generation),
-            control.head_commit_id,
-            &[CurrentStateDeltaRef {
-                schema_key: KEY_VALUE_SCHEMA_KEY,
-                file_id: None,
-                entity_pk: &entity_pk,
-                change_id: None,
-                commit_id: None,
-                untracked: true,
-                deleted: false,
-                created_at: timestamp,
-                updated_at: timestamp,
-                snapshot: snapshot_slot.as_ref_slot(),
-                metadata: crate::json_store::JsonSlotRef::None,
-                columnar_base_coordinate: None,
-            }],
-            &std::collections::BTreeSet::new(),
-            None,
-            None,
-            None,
-            &mut working_diff_coverage,
-        )
-        .await?;
+    crate::live_state::stage_untracked_deltas(
+        read,
+        writes,
+        GLOBAL_BRANCH_ID,
+        &[CurrentStateDeltaRef {
+            schema_key: KEY_VALUE_SCHEMA_KEY,
+            file_id: None,
+            entity_pk: &entity_pk,
+            change_id: None,
+            commit_id: None,
+            untracked: true,
+            deleted: false,
+            created_at: timestamp,
+            updated_at: timestamp,
+            snapshot: snapshot_slot.as_ref_slot(),
+            metadata: crate::json_store::JsonSlotRef::None,
+            columnar_base_coordinate: None,
+        }],
+        &[false],
+    )
+    .await?;
     // The hot-state mutation is fenced by an actual control-byte
     // change. Merely restaging the old control would let two writers both
     // satisfy the same CAS after the first write, losing one group update.
@@ -135,31 +127,23 @@ async fn load_key_value_row(
     read: &(impl StorageAdapterRead + ?Sized),
     key: &str,
 ) -> Result<Option<MaterializedLiveStateRow>, LixError> {
-    let Some(control) = BranchHeadControlContext::new()
-        .reader(read)
-        .load(GLOBAL_BRANCH_ID)
-        .await?
-    else {
-        return Ok(None);
+    let request = crate::live_state::LiveStateExactBatchRequest {
+        rows: vec![crate::live_state::LiveStateExactRowRequest {
+            schema_key: KEY_VALUE_SCHEMA_KEY.to_string(),
+            branch_id: GLOBAL_BRANCH_ID.to_string(),
+            entity_pk: EntityPk::single(key),
+            file_id: None,
+        }],
+        projection: crate::live_state::LiveStateProjection {
+            columns: vec!["snapshot_content".to_string()],
+        },
+        untracked: Some(true),
+        include_tombstones: false,
     };
-    let keys = [TrackedStateKey {
-        schema_key: KEY_VALUE_SCHEMA_KEY.to_string(),
-        entity_pk: EntityPk::single(key),
-        file_id: None,
-    }];
-    let projection = ChangeRecordProjection {
-        snapshot_content: true,
-        metadata: false,
-    };
-    let reader = TrackedHeadContext::new().reader(read);
-    let rows = reader
-        .load_projected_live_rows(GLOBAL_BRANCH_ID, control, &keys, &projection)
-        .await?;
-    Ok(rows
-        .into_iter()
-        .next()
-        .flatten()
-        .filter(|row| row.untracked && !row.deleted))
+    let visible_branch_ids = std::collections::BTreeSet::from([GLOBAL_BRANCH_ID.to_string()]);
+    let rows =
+        crate::live_state::load_untracked_exact_batch(read, &request, &visible_branch_ids).await?;
+    Ok(rows.row(0).map(|row| row.to_owned()))
 }
 
 fn key_value_payload(row: &MaterializedLiveStateRow, key: &str) -> Result<JsonValue, LixError> {
@@ -346,6 +330,26 @@ mod tests {
             .await
             .expect("sequence should commit");
 
+        let updated_at = LixTimestamp::expect_parse("timestamp", "1970-01-01T00:00:01.000Z");
+        let mut writes = storage.new_write_set();
+        let read = storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("update read should open");
+        stage_sequence(
+            &read,
+            &mut writes,
+            DeterministicSequence { highest_seen: 8 },
+            updated_at,
+            ChangeId::for_test_label("sequence-change-8"),
+        )
+        .await
+        .expect("sequence update should stage");
+        storage
+            .commit_write_set(writes, StorageWriteOptions::default())
+            .await
+            .expect("sequence update should commit");
+
         let reader = live_state.reader(
             storage
                 .begin_read(StorageReadOptions::default())
@@ -366,9 +370,11 @@ mod tests {
         assert!(row.global);
         assert_eq!(row.change_id, None);
         assert_eq!(row.commit_id, None);
+        assert_eq!(row.created_at, test_timestamp());
+        assert_eq!(row.updated_at, updated_at);
         assert_eq!(
             row.snapshot_content.as_deref(),
-            Some("{\"key\":\"lix_deterministic_sequence_number\",\"value\":7}")
+            Some("{\"key\":\"lix_deterministic_sequence_number\",\"value\":8}")
         );
     }
 
@@ -384,42 +390,29 @@ mod tests {
             .await
             .expect("read should open");
         let mut writes = storage.new_write_set();
-        let control = BranchHeadControlContext::new()
-            .reader(&read)
-            .load(GLOBAL_BRANCH_ID)
-            .await
-            .expect("global control should load")
-            .expect("global control should exist");
         let snapshot = JsonSlot::from_json(&snapshot_content);
-        let mut working_diff_coverage = crate::live_state::WorkingDiffIndexCoverage::default();
-        TrackedHeadContext::new()
-            .writer(&read, &mut writes)
-            .stage_current_state_with_working_diff(
-                GLOBAL_BRANCH_ID,
-                Some(control.generation),
-                control.head_commit_id,
-                &[CurrentStateDeltaRef {
-                    schema_key: KEY_VALUE_SCHEMA_KEY,
-                    file_id: None,
-                    entity_pk: &entity_pk,
-                    change_id: None,
-                    commit_id: None,
-                    untracked: true,
-                    deleted: false,
-                    created_at: test_timestamp(),
-                    updated_at: test_timestamp(),
-                    snapshot: snapshot.as_ref_slot(),
-                    metadata: crate::json_store::JsonSlotRef::None,
-                    columnar_base_coordinate: None,
-                }],
-                &std::collections::BTreeSet::new(),
-                None,
-                None,
-                None,
-                &mut working_diff_coverage,
-            )
-            .await
-            .expect("test key-value current row should stage");
+        crate::live_state::stage_untracked_deltas(
+            &read,
+            &mut writes,
+            GLOBAL_BRANCH_ID,
+            &[CurrentStateDeltaRef {
+                schema_key: KEY_VALUE_SCHEMA_KEY,
+                file_id: None,
+                entity_pk: &entity_pk,
+                change_id: None,
+                commit_id: None,
+                untracked: true,
+                deleted: false,
+                created_at: test_timestamp(),
+                updated_at: test_timestamp(),
+                snapshot: snapshot.as_ref_slot(),
+                metadata: crate::json_store::JsonSlotRef::None,
+                columnar_base_coordinate: None,
+            }],
+            &[false],
+        )
+        .await
+        .expect("test key-value current row should stage");
         storage
             .commit_write_set(writes, StorageWriteOptions::default())
             .await

--- a/packages/engine/src/gc.rs
+++ b/packages/engine/src/gc.rs
@@ -434,9 +434,7 @@ where
         .reader(store.clone())
         .scan()
         .await?;
-    let mut roots = TrackedHeadContext::new()
-        .reader(store.clone())
-        .untracked_json_refs(&controls)
+    let mut roots = crate::live_state::untracked_json_refs(&store)
         .await?
         .into_iter()
         .map(GcRoot::CurrentPayload)
@@ -1228,7 +1226,7 @@ mod tests {
     use std::collections::{BTreeMap, BTreeSet};
     use std::sync::Arc;
 
-    use crate::branch::{BranchHeadControlContext, stage_branch_head_control};
+    use crate::branch::BranchHeadControlContext;
     use crate::changelog::{
         ChangeId, ChangeLoadRequest, ChangeRecord, ChangelogAppend, ChangelogContext,
         ChangelogReader, ChangelogWriter, CommitId, CommitLoadRequest, CommitRecord, GcRoot,
@@ -1239,7 +1237,7 @@ mod tests {
         JsonRef, JsonSlot, JsonStoreContext, JsonWritePlacementRef, NormalizedJson,
         NormalizedJsonRef, UNTRACKED_JSON_RECLAIM_CANDIDATE_SPACE,
     };
-    use crate::live_state::{CurrentStateDeltaRef, TrackedHeadContext, WorkingDiffIndexCoverage};
+    use crate::live_state::CurrentStateDeltaRef;
     use crate::storage_adapter::{
         Memory, PointReadPlan, SharedStorageAdapterRead, StorageAdapter, StorageGetOptions,
         StorageKey, StorageReadOptions, StorageSpace, StorageValue, StorageWriteOptions,
@@ -2248,54 +2246,33 @@ mod tests {
             .begin_read(StorageReadOptions::default())
             .await
             .expect("current-state owner read should open");
-        let control = BranchHeadControlContext::new()
-            .reader(&read)
-            .load(GLOBAL_BRANCH_ID)
-            .await
-            .expect("global control should load")
-            .expect("global control should exist");
         let entity_pk = EntityPk::single(entity_pk_value);
         let snapshot_slot = snapshot.map_or(JsonSlot::None, JsonSlot::Ref);
         let timestamp =
             LixTimestamp::expect_parse("untracked GC owner timestamp", "2026-01-01T00:00:00Z");
         let mut writes = storage_adapter.new_write_set();
-        let mut coverage = WorkingDiffIndexCoverage::default();
-        TrackedHeadContext::new()
-            .writer(&read, &mut writes)
-            .stage_current_state_with_working_diff(
-                GLOBAL_BRANCH_ID,
-                Some(control.generation),
-                control.head_commit_id,
-                &[CurrentStateDeltaRef {
-                    schema_key: "gc_untracked_owner",
-                    file_id: None,
-                    entity_pk: &entity_pk,
-                    change_id: None,
-                    commit_id: None,
-                    untracked: true,
-                    deleted: snapshot.is_none(),
-                    created_at: timestamp,
-                    updated_at: timestamp,
-                    snapshot: snapshot_slot.as_ref_slot(),
-                    metadata: crate::json_store::JsonSlotRef::None,
-                    columnar_base_coordinate: None,
-                }],
-                &BTreeSet::new(),
-                None,
-                None,
-                None,
-                &mut coverage,
-            )
-            .await
-            .expect("untracked current-state owner should stage");
-        stage_branch_head_control(
+        crate::live_state::stage_untracked_deltas(
+            &read,
             &mut writes,
             GLOBAL_BRANCH_ID,
-            control
-                .next_current_state_revision()
-                .expect("current-state revision should advance"),
+            &[CurrentStateDeltaRef {
+                schema_key: "gc_untracked_owner",
+                file_id: None,
+                entity_pk: &entity_pk,
+                change_id: None,
+                commit_id: None,
+                untracked: true,
+                deleted: snapshot.is_none(),
+                created_at: timestamp,
+                updated_at: timestamp,
+                snapshot: snapshot_slot.as_ref_slot(),
+                metadata: crate::json_store::JsonSlotRef::None,
+                columnar_base_coordinate: None,
+            }],
+            &[false],
         )
-        .expect("current-state control should stage");
+        .await
+        .expect("untracked current-state owner should stage");
         storage_adapter
             .commit_write_set(writes, StorageWriteOptions::default())
             .await

--- a/packages/engine/src/init.rs
+++ b/packages/engine/src/init.rs
@@ -42,13 +42,13 @@ const REGISTERED_SCHEMA_KEY: &str = "lix_registered_schema";
 
 /// Repository-wide compatibility gate for physical storage protocols.
 ///
-/// V57 makes commit-state manifests immutable physical authority. Semantic
-/// commit facts remain owned exclusively by `changelog.commit`, while the
-/// rebuildable snapshot-root projection lives in its own mutable space.
+/// V58 separates history-free rows from the generation-scoped tracked HOT
+/// plane. It is an intentional hard cut: repositories with unified V57 rows
+/// are rejected instead of migrated or dual-read.
 pub(crate) const REPOSITORY_PROTOCOL_SPACE: StorageSpace =
     StorageSpace::mutable(StorageSpaceId(0x0004_0011), "repository.protocol.v1");
 pub(crate) const REPOSITORY_PROTOCOL_KEY: &[u8] = b"current";
-const REPOSITORY_PROTOCOL_VALUE: &[u8] = b"immutable-physical-commit-state.v57";
+const REPOSITORY_PROTOCOL_VALUE: &[u8] = b"physical-untracked-state.v58";
 
 /// Raw status of the repository protocol marker. Engine opening consults this
 /// before it touches any tracked-head space, whose physical IDs deliberately
@@ -452,24 +452,40 @@ where
             .collect::<Vec<_>>();
         let tracked_head = TrackedHeadContext::new();
         let absence_guards = std::collections::BTreeSet::default();
+        let init_untracked_snapshots = plan
+            .untracked_rows
+            .iter()
+            .map(|row| crate::json_store::JsonSlot::from_json(&row.snapshot_content))
+            .collect::<Vec<_>>();
+        let init_untracked_deltas = plan
+            .untracked_rows
+            .iter()
+            .zip(&init_untracked_snapshots)
+            .map(|(row, snapshot)| CurrentStateDeltaRef {
+                schema_key: &row.schema_key,
+                file_id: None,
+                entity_pk: &row.entity_pk,
+                change_id: None,
+                commit_id: None,
+                untracked: true,
+                deleted: false,
+                created_at: row.created_at,
+                updated_at: row.updated_at,
+                snapshot: snapshot.as_ref_slot(),
+                metadata: crate::json_store::JsonSlotRef::None,
+                columnar_base_coordinate: None,
+            })
+            .collect::<Vec<_>>();
+        let init_untracked_known_absent = vec![true; init_untracked_deltas.len()];
+        crate::live_state::stage_untracked_deltas(
+            &read,
+            &mut writes,
+            GLOBAL_BRANCH_ID,
+            &init_untracked_deltas,
+            &init_untracked_known_absent,
+        )
+        .await?;
         for branch in &plan.branch_controls {
-            let mut head_deltas = tracked_head_deltas.clone();
-            if branch.branch_id == GLOBAL_BRANCH_ID {
-                head_deltas.extend(plan.untracked_rows.iter().map(|row| CurrentStateDeltaRef {
-                    schema_key: &row.schema_key,
-                    file_id: None,
-                    entity_pk: &row.entity_pk,
-                    change_id: None,
-                    commit_id: None,
-                    untracked: true,
-                    deleted: false,
-                    created_at: row.created_at,
-                    updated_at: row.updated_at,
-                    snapshot: crate::json_store::JsonSlotRef::Inline(&row.snapshot_content),
-                    metadata: crate::json_store::JsonSlotRef::None,
-                    columnar_base_coordinate: None,
-                }));
-            }
             let mut working_diff_coverage = WorkingDiffIndexCoverage::default();
             tracked_head
                 .writer(&read, &mut writes)
@@ -477,7 +493,7 @@ where
                     &branch.branch_id,
                     None,
                     plan.commit.id,
-                    &head_deltas,
+                    &tracked_head_deltas,
                     &absence_guards,
                     None,
                     None,
@@ -495,7 +511,18 @@ where
                 },
             )?;
             let mut control = branch.control;
-            control.note_schemas(head_deltas.iter().map(|delta| delta.schema_key));
+            control.note_schemas(
+                tracked_head_deltas
+                    .iter()
+                    .map(|delta| delta.schema_key)
+                    .chain(
+                        (branch.branch_id == GLOBAL_BRANCH_ID)
+                            .then_some(init_untracked_deltas.iter())
+                            .into_iter()
+                            .flatten()
+                            .map(|delta| delta.schema_key),
+                    ),
+            );
             stage_branch_head_control(&mut writes, &branch.branch_id, control)?;
         }
     }

--- a/packages/engine/src/live_state/context.rs
+++ b/packages/engine/src/live_state/context.rs
@@ -545,7 +545,7 @@ where
             || request.limit.is_some()
             || !matches!(request.filter.rows, LiveStateRowFilter::All)
             || request.filter.include_tombstones
-            || request.filter.untracked.is_some()
+            || request.filter.untracked != Some(false)
             || !request.filter.file_ids.is_empty()
             || !request.filter.constraints.is_empty()
         {
@@ -629,9 +629,10 @@ where
         &self,
         request: &LiveStateScanRequest,
     ) -> Result<Option<(String, BranchHeadControl, String)>, LixError> {
-        // The hot index carries tracked and untracked rows in one serving
-        // plane, so this route never probes a separate retention index.
-        if request.filter.untracked.is_some() || request_may_include_derived(request) {
+        // Direct snapshots and columnar layouts cover only tracked HOT state.
+        // A retention-agnostic scan must also consult the dedicated untracked
+        // plane, so only an explicitly tracked request may take this route.
+        if request.filter.untracked != Some(false) || request_may_include_derived(request) {
             return Ok(None);
         }
         let [schema_key] = request.filter.schema_keys.as_slice() else {

--- a/packages/engine/src/live_state/context.rs
+++ b/packages/engine/src/live_state/context.rs
@@ -1993,6 +1993,7 @@ mod tests {
                     schema_keys: vec![schema_key.to_string()],
                     entity_pks: entity_pks.to_vec(),
                     branch_ids: vec![branch_id.to_string()],
+                    untracked: Some(false),
                     ..LiveStateFilter::default()
                 },
                 ..LiveStateScanRequest::default()
@@ -2118,34 +2119,32 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn direct_entity_snapshots_fall_back_for_retention_scoped_reads() {
+    async fn direct_entity_snapshots_fall_back_for_untracked_reads() {
         let storage = StorageAdapter::new(Memory::new());
         let live_state = live_state_context();
-        for untracked in [false, true] {
-            let snapshots = live_state
-                .reader(
-                    storage
-                        .begin_read(StorageReadOptions::default())
-                        .await
-                        .expect("open retention-scoped entity read"),
-                )
-                .scan_direct_entity_snapshots(&LiveStateScanRequest {
-                    filter: LiveStateFilter {
-                        schema_keys: vec!["schema".to_string()],
-                        entity_pks: vec![EntityPk::single("row")],
-                        branch_ids: vec!["branch".to_string()],
-                        untracked: Some(untracked),
-                        ..LiveStateFilter::default()
-                    },
-                    ..LiveStateScanRequest::default()
-                })
-                .await
-                .expect("retention-scoped entity read should execute");
-            assert!(
-                snapshots.is_none(),
-                "raw snapshot serving must not bypass retention filtering"
-            );
-        }
+        let snapshots = live_state
+            .reader(
+                storage
+                    .begin_read(StorageReadOptions::default())
+                    .await
+                    .expect("open untracked entity read"),
+            )
+            .scan_direct_entity_snapshots(&LiveStateScanRequest {
+                filter: LiveStateFilter {
+                    schema_keys: vec!["schema".to_string()],
+                    entity_pks: vec![EntityPk::single("row")],
+                    branch_ids: vec!["branch".to_string()],
+                    untracked: Some(true),
+                    ..LiveStateFilter::default()
+                },
+                ..LiveStateScanRequest::default()
+            })
+            .await
+            .expect("untracked entity read should execute");
+        assert!(
+            snapshots.is_none(),
+            "tracked raw snapshot serving must not answer untracked reads"
+        );
     }
 
     #[tokio::test]

--- a/packages/engine/src/live_state/context.rs
+++ b/packages/engine/src/live_state/context.rs
@@ -697,7 +697,9 @@ where
         if skip_proven_empty_schema && !scope_may_have_schema_rows(request, &scope) {
             return Ok(MaterializedLiveStateBatch::default());
         }
-        if let Some(rows) = self.scan_direct_entity_pk_batch(request, &scope).await? {
+        if request.filter.untracked == Some(false)
+            && let Some(rows) = self.scan_direct_entity_pk_batch(request, &scope).await?
+        {
             return Ok(rows);
         }
         let derived_rows = MaterializedLiveStateBatch::from_rows(
@@ -711,15 +713,22 @@ where
             )
             .await?,
         );
-        let mut hot_branch_rows = if !is_derived_only_request(request) {
-            self.scan_hot_branch_rows(request, &scope).await?
+        let mut hot_branch_rows =
+            if !is_derived_only_request(request) && request.filter.untracked != Some(true) {
+                self.scan_hot_branch_rows(request, &scope).await?
+            } else {
+                Vec::new()
+            };
+        let untracked_rows = if !is_derived_only_request(request) {
+            crate::live_state::scan_untracked_batch(store, request, &scope.storage_branch_ids)
+                .await?
         } else {
-            Vec::new()
+            MaterializedLiveStateBatch::default()
         };
         // The ordered single-branch route bypasses the generic visibility
         // resolver, so apply the retention predicate before taking that fast
         // path. Otherwise `untracked = Some(..)` accidentally returned both
-        // member kinds from an already-unified group.
+        // member kinds from the tracked HOT lane.
         if request.filter.untracked.is_some() {
             for branch_rows in &mut hot_branch_rows {
                 branch_rows.rows = filter_current_row_retention(
@@ -729,6 +738,7 @@ where
             }
         }
         if derived_rows.is_empty()
+            && untracked_rows.is_empty()
             && let Some(index) =
                 ordered_unique_branch_row_index(&hot_branch_rows, &scope.projection_branch_ids)
         {
@@ -739,11 +749,13 @@ where
             ));
         }
         let rows = concat_live_state_batches(
-            std::iter::once(derived_rows).chain(
-                hot_branch_rows
-                    .into_iter()
-                    .map(|branch_rows| branch_rows.rows),
-            ),
+            std::iter::once(derived_rows)
+                .chain(std::iter::once(untracked_rows))
+                .chain(
+                    hot_branch_rows
+                        .into_iter()
+                        .map(|branch_rows| branch_rows.rows),
+                ),
         );
         Ok(resolve_visible_batch(
             rows,
@@ -873,13 +885,16 @@ where
         if request.rows.is_empty() {
             return Ok(MaterializedLiveStateExactBatch::default());
         }
-        // Derived rows are synthesized rather than stored under the
-        // requested identity. Preserve their exact scan semantics without
-        // widening the optimized durable-state batch.
-        if request
-            .rows
-            .iter()
-            .any(|row| is_derived_schema(&row.schema_key))
+        // Derived rows are synthesized rather than stored under the requested
+        // identity. A retention-agnostic request also spans two deliberately
+        // separate physical planes, so preserve visibility/collision
+        // semantics through the common scan path. Retention-specific CRUD
+        // stays on the batched point-read paths below.
+        if request.untracked.is_none()
+            || request
+                .rows
+                .iter()
+                .any(|row| is_derived_schema(&row.schema_key))
         {
             let mut builder = MaterializedLiveStateBatchBuilder::with_capacity(request.rows.len());
             let mut slots = Vec::with_capacity(request.rows.len());
@@ -932,6 +947,15 @@ where
             .iter()
             .cloned()
             .collect::<std::collections::BTreeSet<_>>();
+
+        if request.untracked == Some(true) {
+            return crate::live_state::load_untracked_exact_batch(
+                &self.store,
+                request,
+                &visible_branch_ids,
+            )
+            .await;
+        }
 
         let mut storage_identities = Vec::with_capacity(request.rows.len().saturating_mul(2));
         for row in &request.rows {

--- a/packages/engine/src/live_state/mod.rs
+++ b/packages/engine/src/live_state/mod.rs
@@ -6,6 +6,7 @@ mod entity_decoded_column_cache;
 mod reader;
 mod tracked_head;
 mod types;
+mod untracked_state;
 pub(crate) mod visibility;
 
 #[allow(unused_imports)]
@@ -46,6 +47,11 @@ pub(crate) use types::{
     LiveStateScanRequest, MaterializedLiveStateBatch, MaterializedLiveStateBatchBuilder,
     MaterializedLiveStateExactBatch, MaterializedLiveStateRow, MaterializedLiveStateRowRef,
     ScanConstraint, ScanField, ScanOperator,
+};
+#[allow(unused_imports)]
+pub(crate) use untracked_state::{
+    UNTRACKED_FILE_FANOUT_SPACE, UNTRACKED_ROW_SPACE, load_untracked_exact_batch,
+    scan_untracked_batch, stage_untracked_deltas, untracked_json_refs,
 };
 #[allow(unused_imports)]
 pub(crate) use visibility::{

--- a/packages/engine/src/live_state/tracked_head.rs
+++ b/packages/engine/src/live_state/tracked_head.rs
@@ -321,9 +321,9 @@ impl<'a> TrackedHeadDeltaRef<'a> {
 /// One mutation of the authoritative current serving state.
 ///
 /// `tracked` mutations have both IDs and may create tombstones. `untracked`
-/// mutations have neither ID; deletion removes the member physically. This
-/// is deliberately the single write representation for the hot state plane,
-/// so callers never stage a separate untracked overlay.
+/// mutations have neither ID; deletion removes the member physically. This is
+/// the common logical write representation lowered into separate tracked HOT
+/// and branch-stable untracked physical planes.
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct CurrentStateDeltaRef<'a> {
     pub(crate) schema_key: &'a str,

--- a/packages/engine/src/live_state/tracked_head/hot.rs
+++ b/packages/engine/src/live_state/tracked_head/hot.rs
@@ -4900,6 +4900,7 @@ where
         ))
     }
 
+    #[cfg(test)]
     pub(crate) async fn load_projected_live_rows(
         &self,
         branch_id: &str,
@@ -4912,6 +4913,7 @@ where
             .map(MaterializedLiveStateExactBatch::into_rows)
     }
 
+    #[cfg(test)]
     pub(crate) async fn load_projected_live_batch(
         &self,
         branch_id: &str,

--- a/packages/engine/src/live_state/tracked_head/hot.rs
+++ b/packages/engine/src/live_state/tracked_head/hot.rs
@@ -4128,6 +4128,7 @@ where
         .await
     }
 
+    #[cfg(test)]
     pub(crate) async fn scan_live_rows(
         &self,
         branch_id: &str,
@@ -5191,17 +5192,17 @@ where
         load_tracked_working_diff_epoch(&self.store, branch_id).await
     }
 
+    #[cfg(test)]
     pub(crate) async fn untracked_json_refs(
         &self,
         controls: &[(String, BranchHeadControl)],
     ) -> Result<Vec<JsonRef>, LixError> {
         let mut refs = BTreeSet::new();
         for (branch_id, control) in controls {
-            let scope = hot_scope_prefix(branch_id, control.generation);
             let plan = ScanPlan::prefix(
                 HOT_ROW_SPACE,
                 StoragePrefix {
-                    bytes: Bytes::from(scope),
+                    bytes: Bytes::from(hot_scope_prefix(branch_id, control.generation)),
                 },
             );
             let mut resume_after = None;
@@ -5218,8 +5219,7 @@ where
                 resume_after = page.value.entries.last().map(|entry| entry.key.clone());
                 for entry in page.value.entries {
                     let bytes = full_value_bytes(entry.value)?;
-                    let value = decode_head_value(&bytes)?;
-                    collect_hot_untracked_refs(value, &mut refs);
+                    collect_hot_untracked_refs(decode_head_value(&bytes)?, &mut refs);
                 }
                 if !page.value.has_more || resume_after.is_none() {
                     break;
@@ -6708,48 +6708,24 @@ where
 
     /// Publishes a complete replacement generation for a lifecycle event.
     ///
-    /// The supplied snapshot is the target commit's tracked portion.  Any
-    /// branch-local untracked rows are copied from the previous generation,
-    /// then this transaction's untracked mutations are applied before its
-    /// tracked mutations.  That order admits the one legitimate mixed case:
-    /// deleting an untracked row and selecting a tracked row with the same
-    /// identity in the same atomic publication.  Every other retention
-    /// collision fails before the new control can become visible.
+    /// The supplied snapshot is the target commit's complete tracked portion.
+    /// History-free rows have a separate branch-stable physical owner and are
+    /// deliberately absent from every replacement generation.
     #[allow(clippy::too_many_arguments)]
     pub(crate) async fn stage_complete_current_state_with_working_diff(
         &mut self,
         branch_id: &str,
         generation: CommitId,
         parent_tracked: HotTrackedSnapshot,
-        preserved_untracked_generation: Option<CommitId>,
         tracked_deltas: &[CurrentStateDeltaRef<'_>],
-        untracked_deltas: &[CurrentStateDeltaRef<'_>],
         absence_guards: &BTreeSet<TrackedStateKey>,
         working_diff_capture_checkpoint_commit_id: Option<CommitId>,
         coverage: &mut WorkingDiffIndexCoverage,
     ) -> Result<(HotTrackedSnapshot, BTreeSet<String>), LixError> {
         let mut rows = parent_tracked.rows;
-        let mut untracked_rows = match preserved_untracked_generation {
-            Some(previous_generation) => {
-                load_hot_untracked_generation(self.store, branch_id, previous_generation).await?
-            }
-            None => BTreeMap::new(),
-        };
-
-        let sorted_untracked = sorted_lifecycle_hot_deltas(untracked_deltas, true)?;
         let sorted_tracked = sorted_lifecycle_hot_deltas(tracked_deltas, false)?;
-        reject_lifecycle_retention_collisions(&sorted_untracked, &sorted_tracked)?;
 
         let mut retired_untracked_json_refs = BTreeSet::new();
-        for delta in &sorted_untracked {
-            apply_complete_hot_snapshot_delta(
-                &mut untracked_rows,
-                delta,
-                absence_guards,
-                &mut retired_untracked_json_refs,
-            )?;
-        }
-        merge_final_untracked_rows(&mut rows, untracked_rows)?;
         for delta in &sorted_tracked {
             apply_complete_hot_snapshot_delta(
                 &mut rows,
@@ -7160,76 +7136,6 @@ fn next_columnar_base_coordinate(
         .and_then(|value| value.columnar_base_coordinate)))
 }
 
-async fn load_hot_untracked_generation(
-    store: &(impl StorageAdapterRead + ?Sized),
-    branch_id: &str,
-    generation: CommitId,
-) -> Result<HotRowMap, LixError> {
-    let filter = TrackedStateFilter {
-        include_tombstones: true,
-        ..TrackedStateFilter::default()
-    };
-    let HotScanEntries::Decoded(entries) =
-        hot_scan_entries(store, branch_id, generation, &filter, None, None)
-            .await?
-            .expect("unbounded HOT scan cannot exhaust a byte budget")
-    else {
-        unreachable!("an unconstrained HOT scan cannot select the finite point-read route");
-    };
-    let mut rows = BTreeMap::new();
-    for (identity, bytes) in entries {
-        let value = decode_head_value(bytes.as_ref())?;
-        if !value.untracked {
-            continue;
-        }
-        if value.deleted {
-            return Err(head_value_error(
-                "untracked hot row must be physically removed rather than tombstoned",
-            ));
-        }
-        match rows.entry(identity.into_row_identity()) {
-            std::collections::btree_map::Entry::Vacant(entry) => {
-                entry.insert(bytes);
-            }
-            std::collections::btree_map::Entry::Occupied(entry) => {
-                let identity = entry.key();
-                return Err(LixError::new(
-                    LixError::CODE_UNIQUE,
-                    format!(
-                        "hot generation contains duplicate untracked identity in schema '{}' entity_pk {:?}",
-                        identity.schema_key, identity.entity_pk
-                    ),
-                ));
-            }
-        }
-    }
-    Ok(rows)
-}
-
-fn merge_final_untracked_rows(
-    rows: &mut HotRowMap,
-    untracked_rows: HotRowMap,
-) -> Result<(), LixError> {
-    for (identity, bytes) in untracked_rows {
-        match rows.entry(identity) {
-            std::collections::btree_map::Entry::Vacant(entry) => {
-                entry.insert(bytes);
-            }
-            std::collections::btree_map::Entry::Occupied(entry) => {
-                let identity = entry.key();
-                return Err(LixError::new(
-                    LixError::CODE_UNIQUE,
-                    format!(
-                        "cannot materialize tracked and untracked hot rows with the same identity in schema '{}' entity_pk {:?}",
-                        identity.schema_key, identity.entity_pk
-                    ),
-                ));
-            }
-        }
-    }
-    Ok(())
-}
-
 fn sorted_lifecycle_hot_deltas<'a>(
     deltas: &'a [CurrentStateDeltaRef<'a>],
     expect_untracked: bool,
@@ -7253,28 +7159,6 @@ fn sorted_lifecycle_hot_deltas<'a>(
         }
     }
     Ok(sorted)
-}
-
-fn reject_lifecycle_retention_collisions(
-    untracked: &[&CurrentStateDeltaRef<'_>],
-    tracked: &[&CurrentStateDeltaRef<'_>],
-) -> Result<(), LixError> {
-    let mut untracked_index = 0;
-    let mut tracked_index = 0;
-    while untracked_index < untracked.len() && tracked_index < tracked.len() {
-        match compare_hot_deltas(untracked[untracked_index], tracked[tracked_index]) {
-            Ordering::Less => untracked_index += 1,
-            Ordering::Greater => tracked_index += 1,
-            Ordering::Equal => {
-                if !untracked[untracked_index].physically_deletes() {
-                    return Err(current_state_duplicate_delta_error(tracked[tracked_index]));
-                }
-                untracked_index += 1;
-                tracked_index += 1;
-            }
-        }
-    }
-    Ok(())
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -8368,17 +8252,6 @@ impl HotScanString {
         }
     }
 
-    fn into_string(self, key: &Bytes) -> String {
-        match self {
-            Self::Borrowed(range) => {
-                let range = range.start as usize..range.end as usize;
-                // SAFETY: the decoder validated this exact range.
-                unsafe { std::str::from_utf8_unchecked(&key[range]) }.to_owned()
-            }
-            Self::Owned(value) => value,
-        }
-    }
-
     #[cfg(test)]
     fn owns_fallback_buffer(&self) -> bool {
         matches!(self, Self::Owned(_))
@@ -8409,20 +8282,6 @@ impl HotScanIdentity {
                     NullableKeyFilter::Null => self.file_id().is_none(),
                     NullableKeyFilter::Value(value) => self.file_id() == Some(value.as_str()),
                 }))
-    }
-
-    fn into_row_identity(self) -> HeadRowIdentity {
-        let Self {
-            key,
-            schema_key,
-            entity_pk,
-            file_id,
-        } = self;
-        HeadRowIdentity {
-            schema_key: schema_key.into_string(&key),
-            entity_pk,
-            file_id: file_id.map(|file_id| file_id.into_string(&key)),
-        }
     }
 
     #[cfg(test)]

--- a/packages/engine/src/live_state/untracked_state.rs
+++ b/packages/engine/src/live_state/untracked_state.rs
@@ -1,0 +1,999 @@
+//! Branch-stable physical state for history-free rows.
+//!
+//! Untracked rows do not participate in commit history, merge, diff, working
+//! diff, or generation rotation. Their storage identity is therefore exactly
+//! `(branch, schema, entity, file)` and a delete removes that key physically.
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::ops::Range;
+use std::sync::Arc;
+
+use bytes::Bytes;
+
+use crate::NullableKeyFilter;
+use crate::common::{LixTimestamp, SharedStr};
+use crate::entity_pk::EntityPk;
+use crate::json_store::{
+    JsonLoadRequestRef, JsonReadScopeRef, JsonRef, JsonSlotRef, JsonStoreContext,
+};
+use crate::live_state::{
+    CurrentStateDeltaRef, LiveStateExactBatchRequest, LiveStateScanRequest,
+    MaterializedLiveStateBatch, MaterializedLiveStateBatchBuilder, MaterializedLiveStateExactBatch,
+    MaterializedLiveStateRow,
+};
+use crate::storage_adapter::{
+    PointReadPlan, ScanPlan, StorageAdapterRead, StorageGetOptions, StorageKey, StoragePrefix,
+    StorageProjectedValue, StorageScanOptions, StorageSpace, StorageSpaceId, StorageValue,
+    StorageWriteSet,
+};
+use crate::{GLOBAL_BRANCH_ID, LixError};
+
+pub(crate) const UNTRACKED_ROW_SPACE: StorageSpace =
+    StorageSpace::mutable(StorageSpaceId(0x0004_0033), "live_state.untracked_row.v1");
+pub(crate) const UNTRACKED_FILE_FANOUT_SPACE: StorageSpace = StorageSpace::mutable(
+    StorageSpaceId(0x0004_0034),
+    "live_state.untracked_file_fanout.v1",
+);
+
+const VALUE_VERSION: u8 = 1;
+const FLAG_GLOBAL: u8 = 1;
+const SLOT_NONE: u8 = 0;
+const SLOT_REF: u8 = 1;
+const SLOT_INLINE: u8 = 2;
+const FILE_DESCRIPTOR_SCHEMA_KEY: &str = "lix_file_descriptor";
+
+pub(crate) async fn stage_untracked_deltas(
+    store: &(impl StorageAdapterRead + ?Sized),
+    writes: &mut StorageWriteSet,
+    branch_id: &str,
+    deltas: &[CurrentStateDeltaRef<'_>],
+    known_absent: &[bool],
+) -> Result<(), LixError> {
+    if known_absent.len() != deltas.len() {
+        return Err(codec_error(
+            "untracked absence certificates do not align with deltas",
+        ));
+    }
+    let mut mutations = BTreeMap::<StorageKey, Option<StorageValue>>::new();
+    let mut retired_refs = BTreeSet::new();
+    let untracked = deltas
+        .iter()
+        .zip(known_absent)
+        .filter(|(delta, absent)| delta.untracked && !**absent)
+        .map(|(delta, _)| delta)
+        .collect::<Vec<_>>();
+    let mut keys = untracked
+        .iter()
+        .map(|delta| {
+            encode_key(branch_id, delta.schema_key, delta.file_id, delta.entity_pk)
+                .map(|key| StorageKey(Bytes::from(key)))
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+    keys.sort_unstable();
+    keys.dedup();
+    let previous = PointReadPlan::from_unique_keys(UNTRACKED_ROW_SPACE, keys.clone())
+        .materialize(store, StorageGetOptions::default())
+        .await?
+        .value;
+    let mut previous_keys = BTreeSet::new();
+    for (key, value) in keys.into_iter().zip(previous) {
+        let Some(StorageProjectedValue::FullValue(value)) = value else {
+            if value.is_some() {
+                return Err(codec_error("untracked point read omitted its row value"));
+            }
+            continue;
+        };
+        previous_keys.insert(key);
+        collect_value_refs(&decode_value(value)?, &mut retired_refs);
+    }
+    for delta in deltas {
+        if !delta.untracked {
+            continue;
+        }
+        if delta.change_id.is_some() || delta.commit_id.is_some() {
+            return Err(codec_error(
+                "dedicated untracked row carried commit identity",
+            ));
+        }
+        let key = StorageKey(Bytes::from(encode_key(
+            branch_id,
+            delta.schema_key,
+            delta.file_id,
+            delta.entity_pk,
+        )?));
+        if delta.deleted {
+            mutations.insert(key, None);
+        } else {
+            mutations.insert(
+                key,
+                Some(StorageValue {
+                    bytes: Bytes::from(encode_value(branch_id, *delta)?),
+                }),
+            );
+        }
+    }
+
+    let deleted_file_ids = deltas
+        .iter()
+        .filter(|delta| delta.schema_key == FILE_DESCRIPTOR_SCHEMA_KEY && delta.deleted)
+        .map(|delta| delta.entity_pk.as_single_string_owned())
+        .collect::<Result<BTreeSet<_>, _>>()?;
+    if !deleted_file_ids.is_empty() {
+        for (key, value) in scan_raw_prefix(store, &branch_prefix(branch_id)?).await? {
+            let identity = decode_key(&key.0)?;
+            if identity
+                .file_id
+                .as_ref()
+                .is_some_and(|file_id| deleted_file_ids.contains(file_id))
+            {
+                collect_value_refs(&decode_value(value)?, &mut retired_refs);
+                previous_keys.insert(key.clone());
+                mutations.insert(key, None);
+            }
+        }
+        for (key, value) in &mut mutations {
+            let identity = decode_key(&key.0)?;
+            if identity
+                .file_id
+                .as_ref()
+                .is_some_and(|file_id| deleted_file_ids.contains(file_id))
+            {
+                if let Some(value) = value.take() {
+                    collect_value_refs(&decode_value(value.bytes)?, &mut retired_refs);
+                }
+            }
+        }
+    }
+
+    if !deleted_file_ids.is_empty()
+        || deltas
+            .iter()
+            .any(|delta| delta.untracked && delta.file_id.is_some())
+    {
+        stage_file_fanout_changes(store, writes, &previous_keys, &mutations).await?;
+    }
+
+    for (key, value) in mutations {
+        match value {
+            Some(value) => writes.put(UNTRACKED_ROW_SPACE, key, value),
+            None => writes.delete(UNTRACKED_ROW_SPACE, key),
+        }
+    }
+    crate::json_store::JsonStoreWriter::stage_untracked_reclaim_candidates(
+        writes,
+        retired_refs.into_iter().map(JsonRef::from_hash_bytes),
+    );
+    Ok(())
+}
+
+async fn stage_file_fanout_changes(
+    store: &(impl StorageAdapterRead + ?Sized),
+    writes: &mut StorageWriteSet,
+    previous_keys: &BTreeSet<StorageKey>,
+    mutations: &BTreeMap<StorageKey, Option<StorageValue>>,
+) -> Result<(), LixError> {
+    let mut changes = BTreeMap::<StorageKey, (BTreeSet<String>, BTreeSet<String>)>::new();
+    for (key, value) in mutations {
+        let identity = decode_key(&key.0)?;
+        let Some(file_id) = identity.file_id else {
+            continue;
+        };
+        let existed = previous_keys.contains(key);
+        let exists = value.is_some();
+        if existed == exists {
+            continue;
+        }
+        let fanout_key = StorageKey(Bytes::from(entity_prefix(
+            &identity.branch_id,
+            &identity.schema_key,
+            &identity.entity_pk,
+        )?));
+        let (adds, removes) = changes.entry(fanout_key).or_default();
+        if exists {
+            adds.insert(file_id);
+        } else {
+            removes.insert(file_id);
+        }
+    }
+    if changes.is_empty() {
+        return Ok(());
+    }
+
+    let keys = changes.keys().cloned().collect::<Vec<_>>();
+    let previous = PointReadPlan::from_unique_keys(UNTRACKED_FILE_FANOUT_SPACE, keys.clone())
+        .materialize(store, StorageGetOptions::default())
+        .await?
+        .value;
+    for ((key, (adds, removes)), previous) in changes.into_iter().zip(previous) {
+        let mut file_ids = match previous {
+            None => BTreeSet::new(),
+            Some(StorageProjectedValue::FullValue(value)) => decode_file_fanout(&value)?,
+            Some(StorageProjectedValue::KeyOnly) => {
+                return Err(codec_error("untracked fanout read omitted its value"));
+            }
+        };
+        for file_id in removes {
+            file_ids.remove(&file_id);
+        }
+        file_ids.extend(adds);
+        if file_ids.is_empty() {
+            writes.delete(UNTRACKED_FILE_FANOUT_SPACE, key);
+        } else {
+            writes.put(
+                UNTRACKED_FILE_FANOUT_SPACE,
+                key,
+                StorageValue {
+                    bytes: Bytes::from(encode_file_fanout(&file_ids)?),
+                },
+            );
+        }
+    }
+    Ok(())
+}
+
+fn encode_file_fanout(file_ids: &BTreeSet<String>) -> Result<Vec<u8>, LixError> {
+    let count = u32::try_from(file_ids.len())
+        .map_err(|_| codec_error("untracked file fanout has too many members"))?;
+    let mut out = Vec::new();
+    out.extend_from_slice(&count.to_be_bytes());
+    for file_id in file_ids {
+        push_text(&mut out, file_id)?;
+    }
+    Ok(out)
+}
+
+fn decode_file_fanout(bytes: &Bytes) -> Result<BTreeSet<String>, LixError> {
+    let mut offset = 0;
+    let count = u32::from_be_bytes(
+        take(bytes, &mut offset, 4, "fanout count")?
+            .try_into()
+            .expect("four bytes"),
+    );
+    let mut file_ids = BTreeSet::new();
+    for _ in 0..count {
+        if !file_ids.insert(read_text(bytes, &mut offset, "fanout file")?) {
+            return Err(codec_error("untracked file fanout contains a duplicate"));
+        }
+    }
+    if offset != bytes.len() {
+        return Err(codec_error("untracked file fanout has trailing bytes"));
+    }
+    Ok(file_ids)
+}
+
+async fn scan_raw_prefix(
+    store: &(impl StorageAdapterRead + ?Sized),
+    prefix: &[u8],
+) -> Result<Vec<(StorageKey, Bytes)>, LixError> {
+    let plan = ScanPlan::prefix(
+        UNTRACKED_ROW_SPACE,
+        StoragePrefix {
+            bytes: Bytes::copy_from_slice(prefix),
+        },
+    );
+    let mut rows = Vec::new();
+    let mut resume_after = None;
+    loop {
+        let page = plan
+            .collect(
+                store,
+                StorageScanOptions {
+                    resume_after: resume_after.clone(),
+                    ..StorageScanOptions::default()
+                },
+            )
+            .await?;
+        resume_after = page.value.entries.last().map(|entry| entry.key.clone());
+        for entry in page.value.entries {
+            let StorageProjectedValue::FullValue(value) = entry.value else {
+                return Err(codec_error("untracked scan omitted its row value"));
+            };
+            rows.push((entry.key, value));
+        }
+        if !page.value.has_more || resume_after.is_none() {
+            break;
+        }
+    }
+    Ok(rows)
+}
+
+pub(crate) async fn scan_untracked_batch(
+    store: &(impl StorageAdapterRead + ?Sized),
+    request: &LiveStateScanRequest,
+    branch_ids: &[String],
+) -> Result<MaterializedLiveStateBatch, LixError> {
+    if matches!(
+        request.filter.rows,
+        crate::live_state::LiveStateRowFilter::None
+    ) || request.filter.untracked == Some(false)
+    {
+        return Ok(MaterializedLiveStateBatch::default());
+    }
+    if !request.filter.schema_keys.is_empty() && !request.filter.entity_pks.is_empty() {
+        if let Some(file_ids) = exact_file_filters(&request.filter.file_ids) {
+            return load_untracked_points(
+                store,
+                request,
+                branch_ids,
+                &request.filter.schema_keys,
+                &request.filter.entity_pks,
+                &file_ids,
+            )
+            .await;
+        }
+        return load_untracked_entities(store, request, branch_ids).await;
+    }
+    let mut decoded = Vec::new();
+    for branch_id in branch_ids {
+        if request.filter.schema_keys.is_empty() {
+            scan_prefix(store, &branch_prefix(branch_id)?, request, &mut decoded).await?;
+        } else {
+            for schema_key in &request.filter.schema_keys {
+                scan_prefix(
+                    store,
+                    &schema_prefix(branch_id, schema_key)?,
+                    request,
+                    &mut decoded,
+                )
+                .await?;
+            }
+        }
+    }
+    materialize_rows(store, decoded).await
+}
+
+async fn load_untracked_entities(
+    store: &(impl StorageAdapterRead + ?Sized),
+    request: &LiveStateScanRequest,
+    branch_ids: &[String],
+) -> Result<MaterializedLiveStateBatch, LixError> {
+    let mut lookups = BTreeMap::new();
+    for branch_id in branch_ids {
+        for schema_key in &request.filter.schema_keys {
+            for entity_pk in &request.filter.entity_pks {
+                let fanout_key = StorageKey(Bytes::from(entity_prefix(
+                    branch_id, schema_key, entity_pk,
+                )?));
+                lookups
+                    .entry(fanout_key)
+                    .or_insert_with(|| (branch_id.clone(), schema_key.clone(), entity_pk.clone()));
+            }
+        }
+    }
+    let fanout_keys = lookups.keys().cloned().collect::<Vec<_>>();
+    let null_keys = lookups
+        .values()
+        .map(|(branch_id, schema_key, entity_pk)| {
+            encode_key(branch_id, schema_key, None, entity_pk)
+                .map(|key| StorageKey(Bytes::from(key)))
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+    let null_read = PointReadPlan::from_unique_keys(UNTRACKED_ROW_SPACE, null_keys.clone());
+    let fanout_read = PointReadPlan::from_unique_keys(UNTRACKED_FILE_FANOUT_SPACE, fanout_keys);
+    let (null_values, fanouts) = tokio::try_join!(
+        async {
+            Ok::<_, LixError>(
+                null_read
+                    .materialize(store, StorageGetOptions::default())
+                    .await?
+                    .value,
+            )
+        },
+        async {
+            Ok::<_, LixError>(
+                fanout_read
+                    .materialize(store, StorageGetOptions::default())
+                    .await?
+                    .value,
+            )
+        }
+    )?;
+
+    let mut decoded = Vec::new();
+    for (key, value) in null_keys.into_iter().zip(null_values) {
+        let Some(StorageProjectedValue::FullValue(value)) = value else {
+            if value.is_some() {
+                return Err(codec_error("untracked null-row read omitted its value"));
+            }
+            continue;
+        };
+        let identity = decode_key(&key.0)?;
+        decoded.push(DecodedRow {
+            branch_id: identity.branch_id,
+            schema_key: identity.schema_key,
+            file_id: None,
+            entity_pk: identity.entity_pk,
+            value: decode_value(value)?,
+        });
+    }
+
+    let mut variant_keys = Vec::new();
+    for ((_, (branch_id, schema_key, entity_pk)), fanout) in lookups.into_iter().zip(fanouts) {
+        let Some(StorageProjectedValue::FullValue(value)) = fanout else {
+            if fanout.is_some() {
+                return Err(codec_error("untracked fanout read omitted its value"));
+            }
+            continue;
+        };
+        for file_id in decode_file_fanout(&value)? {
+            variant_keys.push(StorageKey(Bytes::from(encode_key(
+                &branch_id,
+                &schema_key,
+                Some(&file_id),
+                &entity_pk,
+            )?)));
+        }
+    }
+    variant_keys.sort_unstable();
+    variant_keys.dedup();
+    if variant_keys.is_empty() {
+        return materialize_rows(store, decoded).await;
+    }
+    let variant_values = PointReadPlan::from_unique_keys(UNTRACKED_ROW_SPACE, variant_keys.clone())
+        .materialize(store, StorageGetOptions::default())
+        .await?
+        .value;
+    for (key, value) in variant_keys.into_iter().zip(variant_values) {
+        let Some(StorageProjectedValue::FullValue(value)) = value else {
+            return Err(codec_error(
+                "untracked fanout points at a missing row value",
+            ));
+        };
+        let identity = decode_key(&key.0)?;
+        if matches_filter(&identity, request) {
+            decoded.push(DecodedRow {
+                branch_id: identity.branch_id,
+                schema_key: identity.schema_key,
+                file_id: identity.file_id,
+                entity_pk: identity.entity_pk,
+                value: decode_value(value)?,
+            });
+        }
+    }
+    materialize_rows(store, decoded).await
+}
+
+fn exact_file_filters(filters: &[NullableKeyFilter<String>]) -> Option<Vec<Option<&str>>> {
+    if filters.is_empty()
+        || filters
+            .iter()
+            .any(|filter| matches!(filter, NullableKeyFilter::Any))
+    {
+        return None;
+    }
+    Some(
+        filters
+            .iter()
+            .map(|filter| match filter {
+                NullableKeyFilter::Null => None,
+                NullableKeyFilter::Value(value) => Some(value.as_str()),
+                NullableKeyFilter::Any => unreachable!("Any was rejected above"),
+            })
+            .collect(),
+    )
+}
+
+async fn load_untracked_points(
+    store: &(impl StorageAdapterRead + ?Sized),
+    request: &LiveStateScanRequest,
+    branch_ids: &[String],
+    schema_keys: &[String],
+    entity_pks: &[EntityPk],
+    file_ids: &[Option<&str>],
+) -> Result<MaterializedLiveStateBatch, LixError> {
+    let mut keys = Vec::new();
+    for branch_id in branch_ids {
+        for schema_key in schema_keys {
+            for file_id in file_ids {
+                for entity_pk in entity_pks {
+                    keys.push(StorageKey(Bytes::from(encode_key(
+                        branch_id, schema_key, *file_id, entity_pk,
+                    )?)));
+                }
+            }
+        }
+    }
+    keys.sort_unstable();
+    keys.dedup();
+    let values = PointReadPlan::from_unique_keys(UNTRACKED_ROW_SPACE, keys.clone())
+        .materialize(store, StorageGetOptions::default())
+        .await?
+        .value;
+    let mut decoded = Vec::new();
+    for (key, value) in keys.into_iter().zip(values) {
+        let Some(StorageProjectedValue::FullValue(value)) = value else {
+            continue;
+        };
+        let identity = decode_key(&key.0)?;
+        if matches_filter(&identity, request) {
+            decoded.push(DecodedRow {
+                branch_id: identity.branch_id,
+                schema_key: identity.schema_key,
+                file_id: identity.file_id,
+                entity_pk: identity.entity_pk,
+                value: decode_value(value)?,
+            });
+        }
+    }
+    materialize_rows(store, decoded).await
+}
+
+pub(crate) async fn load_untracked_exact_batch(
+    store: &(impl StorageAdapterRead + ?Sized),
+    request: &LiveStateExactBatchRequest,
+    visible_branch_ids: &BTreeSet<String>,
+) -> Result<MaterializedLiveStateExactBatch, LixError> {
+    let mut keys = Vec::with_capacity(request.rows.len().saturating_mul(2));
+    let mut requested_key_pairs = Vec::with_capacity(request.rows.len());
+    for row in &request.rows {
+        if !visible_branch_ids.contains(&row.branch_id) {
+            requested_key_pairs.push(None);
+            continue;
+        }
+        let branch = StorageKey(Bytes::from(encode_key(
+            &row.branch_id,
+            &row.schema_key,
+            row.file_id.as_deref(),
+            &row.entity_pk,
+        )?));
+        let branch_index = keys.len();
+        keys.push(branch);
+        let global_index = if row.branch_id == GLOBAL_BRANCH_ID {
+            branch_index
+        } else {
+            let index = keys.len();
+            keys.push(StorageKey(Bytes::from(encode_key(
+                GLOBAL_BRANCH_ID,
+                &row.schema_key,
+                row.file_id.as_deref(),
+                &row.entity_pk,
+            )?)));
+            index
+        };
+        requested_key_pairs.push(Some((branch_index, global_index)));
+    }
+    let values = PointReadPlan::new(UNTRACKED_ROW_SPACE, &keys)
+        .materialize(store, StorageGetOptions::default())
+        .await?
+        .value;
+    let mut decoded = Vec::new();
+    let mut selected = Vec::with_capacity(request.rows.len());
+    for (requested, pair) in request.rows.iter().zip(requested_key_pairs) {
+        let Some((branch_index, global_index)) = pair else {
+            selected.push(None);
+            continue;
+        };
+        let chosen = values[branch_index]
+            .as_ref()
+            .or_else(|| values[global_index].as_ref());
+        let Some(StorageProjectedValue::FullValue(value)) = chosen else {
+            selected.push(None);
+            continue;
+        };
+        let (branch_id, branch_override) = if values[branch_index].is_some() {
+            (requested.branch_id.clone(), None)
+        } else {
+            (
+                GLOBAL_BRANCH_ID.to_owned(),
+                Some(requested.branch_id.clone()),
+            )
+        };
+        let index = decoded.len();
+        decoded.push(DecodedRow {
+            branch_id,
+            schema_key: requested.schema_key.clone(),
+            file_id: requested.file_id.clone(),
+            entity_pk: requested.entity_pk.clone(),
+            value: decode_value(value.clone())?,
+        });
+        selected.push(Some((index, branch_override)));
+    }
+    let rows = materialize_rows(store, decoded).await?;
+    let mut builder = MaterializedLiveStateBatchBuilder::with_capacity(rows.len());
+    let mut slots = Vec::with_capacity(selected.len());
+    for selection in selected {
+        slots.push(selection.map(|(index, branch_override)| {
+            let ordinal = u32::try_from(builder.len()).expect("untracked exact batch exceeds u32");
+            builder.push_ref(rows.row(index), branch_override.as_deref());
+            ordinal
+        }));
+    }
+    MaterializedLiveStateExactBatch::new(builder.finish(), slots)
+}
+
+pub(crate) async fn untracked_json_refs(
+    store: &(impl StorageAdapterRead + ?Sized),
+) -> Result<Vec<JsonRef>, LixError> {
+    let mut refs = BTreeSet::new();
+    for (_, value) in scan_raw_prefix(store, &[]).await? {
+        collect_value_refs(&decode_value(value)?, &mut refs);
+    }
+    Ok(refs.into_iter().map(JsonRef::from_hash_bytes).collect())
+}
+
+async fn scan_prefix(
+    store: &(impl StorageAdapterRead + ?Sized),
+    prefix: &[u8],
+    request: &LiveStateScanRequest,
+    decoded: &mut Vec<DecodedRow>,
+) -> Result<(), LixError> {
+    let plan = ScanPlan::prefix(
+        UNTRACKED_ROW_SPACE,
+        StoragePrefix {
+            bytes: Bytes::copy_from_slice(prefix),
+        },
+    );
+    let mut resume_after = None;
+    loop {
+        let page = plan
+            .collect(
+                store,
+                StorageScanOptions {
+                    resume_after: resume_after.clone(),
+                    ..StorageScanOptions::default()
+                },
+            )
+            .await?;
+        resume_after = page.value.entries.last().map(|entry| entry.key.clone());
+        for entry in page.value.entries {
+            let identity = decode_key(&entry.key.0)?;
+            if !matches_filter(&identity, request) {
+                continue;
+            }
+            let StorageProjectedValue::FullValue(value) = entry.value else {
+                return Err(codec_error("untracked scan omitted its row value"));
+            };
+            decoded.push(DecodedRow {
+                branch_id: identity.branch_id,
+                schema_key: identity.schema_key,
+                file_id: identity.file_id,
+                entity_pk: identity.entity_pk,
+                value: decode_value(value)?,
+            });
+        }
+        if !page.value.has_more {
+            break;
+        }
+    }
+    Ok(())
+}
+
+fn matches_filter(identity: &DecodedIdentity, request: &LiveStateScanRequest) -> bool {
+    (request.filter.entity_pks.is_empty()
+        || request.filter.entity_pks.contains(&identity.entity_pk))
+        && (request.filter.file_ids.is_empty()
+            || request.filter.file_ids.iter().any(|filter| match filter {
+                NullableKeyFilter::Any => true,
+                NullableKeyFilter::Null => identity.file_id.is_none(),
+                NullableKeyFilter::Value(value) => identity.file_id.as_ref() == Some(value),
+            }))
+}
+
+async fn materialize_rows(
+    store: &(impl StorageAdapterRead + ?Sized),
+    mut rows: Vec<DecodedRow>,
+) -> Result<MaterializedLiveStateBatch, LixError> {
+    let refs = rows
+        .iter()
+        .flat_map(|row| [&row.value.snapshot, &row.value.metadata])
+        .filter_map(|slot| match slot {
+            DecodedSlot::Ref(value) => Some(*value),
+            DecodedSlot::None | DecodedSlot::Inline(_) => None,
+        })
+        .collect::<Vec<_>>();
+    let loaded = if refs.is_empty() {
+        Vec::new()
+    } else {
+        JsonStoreContext::new()
+            .load_bytes_many(
+                store,
+                JsonLoadRequestRef {
+                    refs: &refs,
+                    scope: JsonReadScopeRef::OutOfBand,
+                },
+            )
+            .await?
+            .into_values()
+    };
+    let mut loaded = loaded.into_iter();
+    let mut builder = MaterializedLiveStateBatchBuilder::with_capacity(rows.len());
+    for row in &mut rows {
+        let snapshot = materialize_slot(&mut row.value.snapshot, &mut loaded)?;
+        let metadata = materialize_slot(&mut row.value.metadata, &mut loaded)?;
+        builder.push_owned(MaterializedLiveStateRow {
+            entity_pk: row.entity_pk.clone(),
+            schema_key: std::mem::take(&mut row.schema_key),
+            file_id: row.file_id.take(),
+            snapshot_content: snapshot,
+            metadata,
+            deleted: false,
+            created_at: row.value.created_at,
+            updated_at: row.value.updated_at,
+            global: row.value.global,
+            change_id: None,
+            commit_id: None,
+            untracked: true,
+            branch_id: Arc::from(std::mem::take(&mut row.branch_id)),
+        });
+    }
+    Ok(builder.finish())
+}
+
+fn materialize_slot(
+    slot: &mut DecodedSlot,
+    loaded: &mut impl Iterator<Item = Option<Bytes>>,
+) -> Result<Option<SharedStr>, LixError> {
+    match slot {
+        DecodedSlot::None => Ok(None),
+        DecodedSlot::Inline(value) => Ok(Some(value.clone())),
+        DecodedSlot::Ref(_) => {
+            let bytes = loaded
+                .next()
+                .flatten()
+                .ok_or_else(|| codec_error("untracked JSON payload is missing"))?;
+            SharedStr::from_utf8(bytes)
+                .map(Some)
+                .map_err(|_| codec_error("untracked JSON payload is not UTF-8"))
+        }
+    }
+}
+
+struct DecodedIdentity {
+    branch_id: String,
+    schema_key: String,
+    file_id: Option<String>,
+    entity_pk: EntityPk,
+}
+
+struct DecodedRow {
+    branch_id: String,
+    schema_key: String,
+    file_id: Option<String>,
+    entity_pk: EntityPk,
+    value: DecodedValue,
+}
+
+struct DecodedValue {
+    created_at: LixTimestamp,
+    updated_at: LixTimestamp,
+    global: bool,
+    snapshot: DecodedSlot,
+    metadata: DecodedSlot,
+}
+
+fn collect_value_refs(value: &DecodedValue, refs: &mut BTreeSet<[u8; 32]>) {
+    for slot in [&value.snapshot, &value.metadata] {
+        if let DecodedSlot::Ref(json_ref) = slot {
+            refs.insert(*json_ref.as_hash_array());
+        }
+    }
+}
+
+enum DecodedSlot {
+    None,
+    Ref(JsonRef),
+    Inline(SharedStr),
+}
+
+fn encode_key(
+    branch_id: &str,
+    schema_key: &str,
+    file_id: Option<&str>,
+    entity_pk: &EntityPk,
+) -> Result<Vec<u8>, LixError> {
+    let mut out = branch_prefix(branch_id)?;
+    push_text(&mut out, schema_key)?;
+    let entity_pk = crate::storage_codec::encode("untracked entity key", entity_pk)?;
+    push_bytes(&mut out, &entity_pk)?;
+    match file_id {
+        None => out.push(0),
+        Some(value) => {
+            out.push(1);
+            push_text(&mut out, value)?;
+        }
+    }
+    Ok(out)
+}
+
+fn branch_prefix(branch_id: &str) -> Result<Vec<u8>, LixError> {
+    let mut out = Vec::with_capacity(branch_id.len() + 4);
+    push_text(&mut out, branch_id)?;
+    Ok(out)
+}
+
+fn schema_prefix(branch_id: &str, schema_key: &str) -> Result<Vec<u8>, LixError> {
+    let mut out = branch_prefix(branch_id)?;
+    push_text(&mut out, schema_key)?;
+    Ok(out)
+}
+
+fn entity_prefix(
+    branch_id: &str,
+    schema_key: &str,
+    entity_pk: &EntityPk,
+) -> Result<Vec<u8>, LixError> {
+    let mut out = schema_prefix(branch_id, schema_key)?;
+    let entity_pk = crate::storage_codec::encode("untracked entity key", entity_pk)?;
+    push_bytes(&mut out, &entity_pk)?;
+    Ok(out)
+}
+
+fn push_text(out: &mut Vec<u8>, value: &str) -> Result<(), LixError> {
+    let len =
+        u32::try_from(value.len()).map_err(|_| codec_error("untracked key text is too long"))?;
+    out.extend_from_slice(&len.to_be_bytes());
+    out.extend_from_slice(value.as_bytes());
+    Ok(())
+}
+
+fn push_bytes(out: &mut Vec<u8>, value: &[u8]) -> Result<(), LixError> {
+    let len = u32::try_from(value.len())
+        .map_err(|_| codec_error("untracked key component is too long"))?;
+    out.extend_from_slice(&len.to_be_bytes());
+    out.extend_from_slice(value);
+    Ok(())
+}
+
+fn decode_key(bytes: &Bytes) -> Result<DecodedIdentity, LixError> {
+    let mut offset = 0;
+    let branch_id = read_text(bytes, &mut offset, "branch")?;
+    let schema_key = read_text(bytes, &mut offset, "schema")?;
+    let entity_pk_bytes = read_bytes(bytes, &mut offset, "entity")?;
+    let entity_pk = crate::storage_codec::decode("untracked entity key", entity_pk_bytes)?;
+    let file_id = match take(bytes, &mut offset, 1, "file tag")?[0] {
+        0 => None,
+        1 => Some(read_text(bytes, &mut offset, "file")?),
+        _ => return Err(codec_error("untracked key has an invalid file tag")),
+    };
+    if offset != bytes.len() {
+        return Err(codec_error("untracked row key has trailing bytes"));
+    }
+    Ok(DecodedIdentity {
+        branch_id,
+        schema_key,
+        file_id,
+        entity_pk,
+    })
+}
+
+fn read_bytes<'a>(bytes: &'a [u8], offset: &mut usize, field: &str) -> Result<&'a [u8], LixError> {
+    let len = take(bytes, offset, 4, field)?;
+    let len = u32::from_be_bytes(len.try_into().expect("four bytes")) as usize;
+    take(bytes, offset, len, field)
+}
+
+fn read_text(bytes: &[u8], offset: &mut usize, field: &str) -> Result<String, LixError> {
+    let len = take(bytes, offset, 4, field)?;
+    let len = u32::from_be_bytes(len.try_into().expect("four bytes")) as usize;
+    let value = take(bytes, offset, len, field)?;
+    String::from_utf8(value.to_vec())
+        .map_err(|_| codec_error(format!("untracked {field} is not UTF-8")))
+}
+
+fn encode_value(branch_id: &str, delta: CurrentStateDeltaRef<'_>) -> Result<Vec<u8>, LixError> {
+    let mut out = Vec::with_capacity(18 + slot_len(delta.snapshot) + slot_len(delta.metadata));
+    out.push(VALUE_VERSION);
+    out.push(if branch_id == GLOBAL_BRANCH_ID {
+        FLAG_GLOBAL
+    } else {
+        0
+    });
+    out.extend_from_slice(&delta.created_at.packed().to_le_bytes());
+    out.extend_from_slice(&delta.updated_at.packed().to_le_bytes());
+    encode_slot(&mut out, delta.snapshot)?;
+    encode_slot(&mut out, delta.metadata)?;
+    Ok(out)
+}
+
+fn slot_len(slot: JsonSlotRef<'_>) -> usize {
+    match slot {
+        JsonSlotRef::None => 1,
+        JsonSlotRef::Ref(_) => 33,
+        JsonSlotRef::Inline(value) => 5 + value.len(),
+    }
+}
+
+fn encode_slot(out: &mut Vec<u8>, slot: JsonSlotRef<'_>) -> Result<(), LixError> {
+    match slot {
+        JsonSlotRef::None => out.push(SLOT_NONE),
+        JsonSlotRef::Ref(value) => {
+            out.push(SLOT_REF);
+            out.extend_from_slice(value.as_hash_bytes());
+        }
+        JsonSlotRef::Inline(value) => {
+            out.push(SLOT_INLINE);
+            let len = u32::try_from(value.len())
+                .map_err(|_| codec_error("untracked inline JSON is too long"))?;
+            out.extend_from_slice(&len.to_le_bytes());
+            out.extend_from_slice(value.as_bytes());
+        }
+    }
+    Ok(())
+}
+
+fn decode_value(bytes: Bytes) -> Result<DecodedValue, LixError> {
+    let mut offset = 0;
+    if take(&bytes, &mut offset, 1, "value version")?[0] != VALUE_VERSION {
+        return Err(codec_error(
+            "untracked row has an unsupported value version",
+        ));
+    }
+    let flags = take(&bytes, &mut offset, 1, "value flags")?[0];
+    let created_at = LixTimestamp::from_packed(u64::from_le_bytes(
+        take(&bytes, &mut offset, 8, "created_at")?
+            .try_into()
+            .expect("eight bytes"),
+    ))
+    .map_err(codec_error)?;
+    let updated_at = LixTimestamp::from_packed(u64::from_le_bytes(
+        take(&bytes, &mut offset, 8, "updated_at")?
+            .try_into()
+            .expect("eight bytes"),
+    ))
+    .map_err(codec_error)?;
+    let snapshot = decode_slot(&bytes, &mut offset)?;
+    let metadata = decode_slot(&bytes, &mut offset)?;
+    if offset != bytes.len() {
+        return Err(codec_error("untracked row value has trailing bytes"));
+    }
+    Ok(DecodedValue {
+        created_at,
+        updated_at,
+        global: flags & FLAG_GLOBAL != 0,
+        snapshot,
+        metadata,
+    })
+}
+
+fn decode_slot(bytes: &Bytes, offset: &mut usize) -> Result<DecodedSlot, LixError> {
+    match take(bytes, offset, 1, "JSON slot tag")?[0] {
+        SLOT_NONE => Ok(DecodedSlot::None),
+        SLOT_REF => {
+            let hash: [u8; 32] = take(bytes, offset, 32, "JSON ref")?
+                .try_into()
+                .expect("32 bytes");
+            Ok(DecodedSlot::Ref(JsonRef::from_hash_bytes(hash)))
+        }
+        SLOT_INLINE => {
+            let len = u32::from_le_bytes(
+                take(bytes, offset, 4, "inline JSON length")?
+                    .try_into()
+                    .expect("four bytes"),
+            ) as usize;
+            let range = take_range(bytes, offset, len, "inline JSON")?;
+            let value = SharedStr::from_utf8(bytes.slice(range))
+                .map_err(|_| codec_error("untracked inline JSON is not UTF-8"))?;
+            Ok(DecodedSlot::Inline(value))
+        }
+        _ => Err(codec_error("untracked row has an invalid JSON slot tag")),
+    }
+}
+
+fn take<'a>(
+    bytes: &'a [u8],
+    offset: &mut usize,
+    len: usize,
+    field: &str,
+) -> Result<&'a [u8], LixError> {
+    let range = take_range(bytes, offset, len, field)?;
+    Ok(&bytes[range])
+}
+
+fn take_range(
+    bytes: &[u8],
+    offset: &mut usize,
+    len: usize,
+    field: &str,
+) -> Result<Range<usize>, LixError> {
+    let end = offset
+        .checked_add(len)
+        .filter(|end| *end <= bytes.len())
+        .ok_or_else(|| codec_error(format!("untracked {field} is truncated")))?;
+    let range = *offset..end;
+    *offset = end;
+    Ok(range)
+}
+
+fn codec_error(message: impl Into<String>) -> LixError {
+    LixError::new(LixError::CODE_INTERNAL_ERROR, message.into())
+}

--- a/packages/engine/src/live_state/untracked_state.rs
+++ b/packages/engine/src/live_state/untracked_state.rs
@@ -76,6 +76,7 @@ pub(crate) async fn stage_untracked_deltas(
         .await?
         .value;
     let mut previous_keys = BTreeSet::new();
+    let mut previous_created_at = BTreeMap::new();
     for (key, value) in keys.into_iter().zip(previous) {
         let Some(StorageProjectedValue::FullValue(value)) = value else {
             if value.is_some() {
@@ -83,8 +84,10 @@ pub(crate) async fn stage_untracked_deltas(
             }
             continue;
         };
+        let decoded = decode_value(value)?;
+        collect_value_refs(&decoded, &mut retired_refs);
+        previous_created_at.insert(key.clone(), decoded.created_at);
         previous_keys.insert(key);
-        collect_value_refs(&decode_value(value)?, &mut retired_refs);
     }
     for delta in deltas {
         if !delta.untracked {
@@ -104,10 +107,14 @@ pub(crate) async fn stage_untracked_deltas(
         if delta.deleted {
             mutations.insert(key, None);
         } else {
+            let created_at = previous_created_at
+                .get(&key)
+                .copied()
+                .unwrap_or(delta.created_at);
             mutations.insert(
                 key,
                 Some(StorageValue {
-                    bytes: Bytes::from(encode_value(branch_id, *delta)?),
+                    bytes: Bytes::from(encode_value(branch_id, *delta, created_at)?),
                 }),
             );
         }
@@ -870,7 +877,11 @@ fn read_text(bytes: &[u8], offset: &mut usize, field: &str) -> Result<String, Li
         .map_err(|_| codec_error(format!("untracked {field} is not UTF-8")))
 }
 
-fn encode_value(branch_id: &str, delta: CurrentStateDeltaRef<'_>) -> Result<Vec<u8>, LixError> {
+fn encode_value(
+    branch_id: &str,
+    delta: CurrentStateDeltaRef<'_>,
+    created_at: LixTimestamp,
+) -> Result<Vec<u8>, LixError> {
     let mut out = Vec::with_capacity(18 + slot_len(delta.snapshot) + slot_len(delta.metadata));
     out.push(VALUE_VERSION);
     out.push(if branch_id == GLOBAL_BRANCH_ID {
@@ -878,7 +889,7 @@ fn encode_value(branch_id: &str, delta: CurrentStateDeltaRef<'_>) -> Result<Vec<
     } else {
         0
     });
-    out.extend_from_slice(&delta.created_at.packed().to_le_bytes());
+    out.extend_from_slice(&created_at.packed().to_le_bytes());
     out.extend_from_slice(&delta.updated_at.packed().to_le_bytes());
     encode_slot(&mut out, delta.snapshot)?;
     encode_slot(&mut out, delta.metadata)?;

--- a/packages/engine/src/sql2/entity_batch.rs
+++ b/packages/engine/src/sql2/entity_batch.rs
@@ -433,7 +433,7 @@ fn entity_columnar_mask_error(message: &str) -> LixError {
 fn direct_entity_snapshot_request(request: &LiveStateScanRequest) -> bool {
     matches!(request.filter.rows, LiveStateRowFilter::All)
         && !request.filter.include_tombstones
-        && request.filter.untracked.is_none()
+        && request.filter.untracked == Some(false)
         && request.filter.file_ids.is_empty()
         && request.filter.constraints.is_empty()
 }
@@ -483,6 +483,7 @@ mod tests {
     #[test]
     fn exact_primary_key_and_limit_bypass_columnar_scan() {
         let mut request = LiveStateScanRequest::default();
+        request.filter.untracked = Some(false);
         assert!(direct_entity_columnar_request(&request));
 
         request

--- a/packages/engine/src/sql2/exec/bound_public_write.rs
+++ b/packages/engine/src/sql2/exec/bound_public_write.rs
@@ -2878,6 +2878,13 @@ async fn try_execute_direct_path_value_replacement(
     spec: &EntitySurfaceSpec,
     params: &[Value],
 ) -> Result<Option<SqlWriteResult>, LixError> {
+    // The certified replacement program writes ordinary tracked rows. Avoid
+    // probing the mixed-retention serving path when the predicate already
+    // proves this is an untracked replacement; the canonical entity route
+    // below can point-read the dedicated physical plane directly.
+    if bound_untracked_from_predicate(&plan.bound.predicate, params) == Some(true) {
+        return Ok(None);
+    }
     let Some(program) = prepare_path_value_replacement_program(ctx, plan, spec) else {
         return Ok(None);
     };
@@ -3922,7 +3929,55 @@ async fn scan_entity_candidates(
         }
         request.filter.entity_pks = entity_pks;
     }
+    request.filter.untracked = bound_untracked_from_predicate(&plan.bound.predicate, params);
     ctx.scan_live_state_batch(&request).await
+}
+
+fn bound_untracked_from_predicate(predicate: &BoundPredicate, params: &[Value]) -> Option<bool> {
+    match predicate {
+        BoundPredicate::And(predicates) => {
+            let mut constraint = None;
+            for predicate in predicates {
+                let Some(value) = bound_untracked_from_predicate(predicate, params) else {
+                    continue;
+                };
+                if constraint.is_some_and(|existing| existing != value) {
+                    return None;
+                }
+                constraint = Some(value);
+            }
+            constraint
+        }
+        BoundPredicate::Eq(left, right) => bound_untracked_column_value(left, right, params)
+            .or_else(|| bound_untracked_column_value(right, left, params)),
+        _ => None,
+    }
+}
+
+fn bound_untracked_column_value(
+    column: &BoundExpr,
+    value: &BoundExpr,
+    params: &[Value],
+) -> Option<bool> {
+    let BoundExpr::Column(column) = column else {
+        return None;
+    };
+    if column.name != "lixcol_untracked" {
+        return None;
+    }
+    bound_untracked_bool_value(value, params)
+}
+
+fn bound_untracked_bool_value(value: &BoundExpr, params: &[Value]) -> Option<bool> {
+    match value {
+        BoundExpr::Literal(BoundLiteral::Bool(value)) => Some(*value),
+        BoundExpr::Param(param) => match params.get(param.index.saturating_sub(1)) {
+            Some(Value::Boolean(value)) => Some(*value),
+            _ => None,
+        },
+        BoundExpr::Cast { expr, .. } => bound_untracked_bool_value(expr, params),
+        _ => None,
+    }
 }
 
 async fn scan_entity_candidates_for_pks(
@@ -7207,6 +7262,25 @@ mod primary_key_route_tests {
             TYPED_CERTIFIED_INSERT_MIN_ROWS - 1
         ));
         assert!(use_typed_certified_insert(TYPED_CERTIFIED_INSERT_MIN_ROWS));
+    }
+
+    #[test]
+    fn bound_untracked_constraint_uses_one_based_parameter_indexes() {
+        let predicate = BoundPredicate::Eq(
+            BoundExpr::Column(BoundColumnRef {
+                table: "json_pointer".to_string(),
+                column_id: 9,
+                name: "lixcol_untracked".to_string(),
+            }),
+            BoundExpr::Param(BoundParamRef { index: 1 }),
+        );
+        assert_eq!(
+            bound_untracked_from_predicate(
+                &predicate,
+                &[Value::Boolean(true), Value::Boolean(false)]
+            ),
+            Some(true)
+        );
     }
 
     #[test]

--- a/packages/engine/src/sql2/providers/entity.rs
+++ b/packages/engine/src/sql2/providers/entity.rs
@@ -307,6 +307,7 @@ impl EntitySpec {
         .map_err(lix_error_to_datafusion_error)?;
         apply_exact_branch_id_filter(&mut request, exact_branch_ids);
         apply_exact_entity_pk_filters(&mut request, &self.spec, filters)?;
+        apply_exact_untracked_filter(&mut request, filters);
         Ok((projected_schema, request, row_filters))
     }
 
@@ -521,6 +522,10 @@ impl TableSpec for EntitySpec {
         let row_filter_analyzer = EntityRowFilterAnalyzer::new(&self.spec);
         if ExactBranchIdFilterAnalyzer.supports(filter) || primary_key_analyzer.supports(filter) {
             TableProviderFilterPushDown::Exact
+        } else if exact_untracked_constraint(filter) != ExactUntrackedConstraint::Unconstrained {
+            // The physical lane can be pruned exactly, while DataFusion keeps
+            // the expression as a residual for mixed conjuncts.
+            TableProviderFilterPushDown::Inexact
         } else if row_filter_analyzer.supports(filter) {
             // Retain a DataFusion residual even when the row-shaped fallback
             // also evaluates the predicate. Immutable columnar layouts use
@@ -1667,6 +1672,94 @@ fn apply_exact_entity_pk_filters(
         request.filter.entity_pks = entity_pks;
     }
     Ok(())
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum ExactUntrackedConstraint {
+    Unconstrained,
+    Value(bool),
+    Empty,
+}
+
+fn apply_exact_untracked_filter(request: &mut LiveStateScanRequest, filters: &[Expr]) {
+    let constraint = filters.iter().fold(
+        ExactUntrackedConstraint::Unconstrained,
+        |current, filter| {
+            combine_untracked_constraints(current, exact_untracked_constraint(filter))
+        },
+    );
+    match constraint {
+        ExactUntrackedConstraint::Unconstrained => {}
+        ExactUntrackedConstraint::Value(value) => request.filter.untracked = Some(value),
+        ExactUntrackedConstraint::Empty => request.filter.rows = LiveStateRowFilter::None,
+    }
+}
+
+fn exact_untracked_constraint(expr: &Expr) -> ExactUntrackedConstraint {
+    match expr {
+        Expr::Column(column) if column.name == "lixcol_untracked" => {
+            ExactUntrackedConstraint::Value(true)
+        }
+        Expr::Alias(alias) => exact_untracked_constraint(&alias.expr),
+        Expr::Not(inner) | Expr::IsFalse(inner) | Expr::IsNotTrue(inner) => {
+            invert_untracked_constraint(exact_untracked_constraint(inner))
+        }
+        Expr::IsTrue(inner) | Expr::IsNotFalse(inner) => exact_untracked_constraint(inner),
+        Expr::BinaryExpr(binary) if binary.op == Operator::And => combine_untracked_constraints(
+            exact_untracked_constraint(&binary.left),
+            exact_untracked_constraint(&binary.right),
+        ),
+        Expr::BinaryExpr(binary) if binary.op == Operator::Eq => {
+            untracked_column_literal(&binary.left, &binary.right)
+                .or_else(|| untracked_column_literal(&binary.right, &binary.left))
+                .map_or(
+                    ExactUntrackedConstraint::Unconstrained,
+                    ExactUntrackedConstraint::Value,
+                )
+        }
+        _ => ExactUntrackedConstraint::Unconstrained,
+    }
+}
+
+fn invert_untracked_constraint(constraint: ExactUntrackedConstraint) -> ExactUntrackedConstraint {
+    match constraint {
+        ExactUntrackedConstraint::Unconstrained => ExactUntrackedConstraint::Unconstrained,
+        ExactUntrackedConstraint::Value(value) => ExactUntrackedConstraint::Value(!value),
+        ExactUntrackedConstraint::Empty => ExactUntrackedConstraint::Empty,
+    }
+}
+
+fn combine_untracked_constraints(
+    left: ExactUntrackedConstraint,
+    right: ExactUntrackedConstraint,
+) -> ExactUntrackedConstraint {
+    match (left, right) {
+        (ExactUntrackedConstraint::Empty, _) | (_, ExactUntrackedConstraint::Empty) => {
+            ExactUntrackedConstraint::Empty
+        }
+        (ExactUntrackedConstraint::Unconstrained, value)
+        | (value, ExactUntrackedConstraint::Unconstrained) => value,
+        (ExactUntrackedConstraint::Value(left), ExactUntrackedConstraint::Value(right)) => {
+            if left == right {
+                ExactUntrackedConstraint::Value(left)
+            } else {
+                ExactUntrackedConstraint::Empty
+            }
+        }
+    }
+}
+
+fn untracked_column_literal(column: &Expr, literal: &Expr) -> Option<bool> {
+    let Expr::Column(column) = column else {
+        return None;
+    };
+    if column.name != "lixcol_untracked" {
+        return None;
+    }
+    let Expr::Literal(ScalarValue::Boolean(Some(value)), _) = literal else {
+        return None;
+    };
+    Some(*value)
 }
 
 fn exact_branch_ids_from_filters(filters: &[Expr]) -> Result<Option<Vec<String>>> {
@@ -3561,6 +3654,53 @@ mod tests {
             Operator::Eq,
             Box::new(string_literal(value)),
         ))
+    }
+
+    fn bool_eq_filter(column_name: &str, value: bool) -> Expr {
+        Expr::BinaryExpr(BinaryExpr::new(
+            Box::new(column(column_name)),
+            Operator::Eq,
+            Box::new(Expr::Literal(ScalarValue::Boolean(Some(value)), None)),
+        ))
+    }
+
+    #[test]
+    fn untracked_filter_pushdown_extracts_conjuncts_and_conflicts() {
+        let untracked = bool_eq_filter("lixcol_untracked", true);
+        let key = eq_filter("id", "row-1");
+        let conjunct = Expr::BinaryExpr(BinaryExpr::new(
+            Box::new(key),
+            Operator::And,
+            Box::new(untracked.clone()),
+        ));
+        assert_eq!(
+            super::exact_untracked_constraint(&conjunct),
+            super::ExactUntrackedConstraint::Value(true)
+        );
+        assert_eq!(
+            super::combine_untracked_constraints(
+                super::exact_untracked_constraint(&untracked),
+                super::exact_untracked_constraint(&bool_eq_filter("lixcol_untracked", false)),
+            ),
+            super::ExactUntrackedConstraint::Empty
+        );
+        let bare = Expr::Column(Column::from_name("lixcol_untracked"));
+        assert_eq!(
+            super::exact_untracked_constraint(&bare),
+            super::ExactUntrackedConstraint::Value(true)
+        );
+        assert_eq!(
+            super::exact_untracked_constraint(&Expr::Not(Box::new(bare.clone()))),
+            super::ExactUntrackedConstraint::Value(false)
+        );
+        assert_eq!(
+            super::exact_untracked_constraint(&Expr::IsFalse(Box::new(bare.clone()))),
+            super::ExactUntrackedConstraint::Value(false)
+        );
+        assert_eq!(
+            super::exact_untracked_constraint(&Expr::IsTrue(Box::new(bare))),
+            super::ExactUntrackedConstraint::Value(true)
+        );
     }
 
     #[test]

--- a/packages/engine/src/storage_bench.rs
+++ b/packages/engine/src/storage_bench.rs
@@ -1454,6 +1454,8 @@ fn native_storage_spaces() -> &'static [crate::storage_adapter::StorageSpace] {
     &[
         crate::init::REPOSITORY_PROTOCOL_SPACE,
         crate::branch::BRANCH_HEAD_CONTROL_SPACE,
+        crate::live_state::UNTRACKED_ROW_SPACE,
+        crate::live_state::UNTRACKED_FILE_FANOUT_SPACE,
         crate::live_state::HOT_ROW_SPACE,
         crate::live_state::HOT_FILE_SPACE,
         crate::live_state::HOT_DIFF_SPACE,

--- a/packages/engine/src/transaction/commit.rs
+++ b/packages/engine/src/transaction/commit.rs
@@ -135,8 +135,8 @@ pub(crate) fn take_direct_journal_replacement_publications(schema_key: &str) -> 
         .unwrap_or_default()
 }
 
-/// Commits prepared transaction rows into tracked history and unified current
-/// live state.
+/// Commits prepared transaction rows into tracked history and current live
+/// state.
 ///
 /// Providers decode DataFusion DML into a hydrated `PreparedStateBatch`. Tracked
 /// rows become changelog facts, commit members, immutable history roots, and
@@ -3367,6 +3367,47 @@ async fn stage_tracked_head(
         "lix.perf.materialization.tracked_head.lifecycle"
     ))
     .await?;
+    // History-free rows have one branch-stable physical owner. Stage them
+    // before tracked publication so no commit/generation path can absorb or
+    // copy them into HOT state.
+    let untracked_branches = state_rows
+        .iter()
+        .filter(|row| {
+            (row.untracked && row.schema_key != BRANCH_REF_SCHEMA_KEY)
+                || (row.schema_key == FILE_DESCRIPTOR_SCHEMA_KEY && row.snapshot.is_none())
+        })
+        .map(|row| row.branch_id.as_str())
+        .chain(engine_rows.iter().map(|row| row.branch_id.as_str()))
+        .collect::<BTreeSet<_>>();
+    for branch_id in untracked_branches {
+        let selected_rows = state_rows
+            .iter()
+            .enumerate()
+            .filter(|row| {
+                row.1.branch_id == branch_id
+                    && ((row.1.untracked && row.1.schema_key != BRANCH_REF_SCHEMA_KEY)
+                        || (row.1.schema_key == FILE_DESCRIPTOR_SCHEMA_KEY
+                            && row.1.snapshot.is_none()))
+            })
+            .collect::<Vec<_>>();
+        let mut deltas = selected_rows
+            .iter()
+            .map(|(_, row)| current_state_delta_from_state_row(*row))
+            .collect::<Result<Vec<_>, _>>()?;
+        let mut known_absent = selected_rows
+            .iter()
+            .map(|(row_index, row)| row.untracked && insert_selection.contains(*row_index))
+            .collect::<Vec<_>>();
+        deltas.extend(
+            engine_rows
+                .iter()
+                .filter(|row| row.branch_id == branch_id)
+                .map(current_state_delta_from_engine_row),
+        );
+        known_absent.resize(deltas.len(), false);
+        crate::live_state::stage_untracked_deltas(read, writes, branch_id, &deltas, &known_absent)
+            .await?;
+    }
     let explicit_branches = explicit_branch_targets
         .keys()
         .map(String::as_str)
@@ -3547,6 +3588,7 @@ async fn stage_tracked_head(
                     certified_fresh_plugin_file_id,
                 )
             };
+        reject_untracked_absence_guard_collisions(read, &root.branch_id, &absence_guards).await?;
         let parent_generation = match (root.parent_commit_id, parent_control) {
             (_, Some(control)) if is_checkpoint_publication => Some(control.generation),
             (Some(parent_commit_id), Some(control))
@@ -3580,9 +3622,7 @@ async fn stage_tracked_head(
                     &root.branch_id,
                     generation,
                     final_tracked,
-                    parent_control.map(|control| control.generation),
                     &[],
-                    &untracked_deltas,
                     &owned_absence_guards,
                     checkpoint_commit_id,
                     &mut coverage,
@@ -3590,8 +3630,15 @@ async fn stage_tracked_head(
                 .await?;
             let mut control =
                 normal_branch_head_control(root, parent_control, generation, checkpoint_commit_id)?;
-            control.reset_schema_presence();
-            control.note_schemas(schema_keys.iter().map(String::as_str));
+            // Dedicated history-free rows survive generation rotation. Keep
+            // the predecessor bloom conservatively: stale positives are safe,
+            // while resetting it would hide untouched untracked schemas.
+            control.note_schemas(
+                schema_keys
+                    .iter()
+                    .map(String::as_str)
+                    .chain(untracked_deltas.iter().map(|delta| delta.schema_key)),
+            );
             tracked_snapshots.insert(root.commit_id, final_tracked);
             insert_direct_branch_control(&mut controls, &root.branch_id, control)?;
             continue;
@@ -3932,6 +3979,7 @@ async fn stage_tracked_head(
                     }),
             );
         }
+        reject_untracked_delta_collisions(read, &root.branch_id, &tracked_deltas).await?;
         let mut durable_predecessors = state_row_indices
             .iter()
             .filter_map(|&row_index| {
@@ -4000,8 +4048,7 @@ async fn stage_tracked_head(
             durable_predecessor_count = durable_predecessors.len(),
             "packed current-base route decision"
         );
-        let mut deltas = tracked_deltas.clone();
-        deltas.extend_from_slice(&untracked_deltas);
+        let deltas = tracked_deltas.clone();
         // Every absence guard above is derived from one of these exact
         // transaction deltas. The fresh-file certificate likewise proves its
         // complete file-scoped namespace absent. The branch-control CAS
@@ -4044,25 +4091,6 @@ async fn stage_tracked_head(
                     "lix.perf.materialization.tracked_head.stage_packed_current_base"
                 ))
                 .await?;
-            if !untracked_deltas.is_empty() {
-                writer
-                    .stage_current_state_with_working_diff(
-                        &root.branch_id,
-                        Some(parent_generation),
-                        root.commit_id,
-                        &untracked_deltas,
-                        &BTreeSet::new(),
-                        None,
-                        None,
-                        None,
-                        &mut coverage,
-                    )
-                    .instrument(tracing::debug_span!(
-                        target: "lix_perf",
-                        "lix.perf.materialization.tracked_head.stage_current_overlay"
-                    ))
-                    .await?;
-            }
             generation
         } else if let Some(certified_live_increments) =
             host_certified_live_increments.get(&root.branch_id)
@@ -4139,7 +4167,12 @@ async fn stage_tracked_head(
             generation,
             working_diff_checkpoint_commit_id,
         )?;
-        control.note_schemas(deltas.iter().map(|delta| delta.schema_key));
+        control.note_schemas(
+            deltas
+                .iter()
+                .chain(&untracked_deltas)
+                .map(|delta| delta.schema_key),
+        );
         insert_direct_branch_control(&mut controls, &root.branch_id, control)?;
     }
 
@@ -4190,41 +4223,6 @@ async fn stage_tracked_head(
                 .filter(|row| row.branch_id == branch_id)
                 .map(current_state_delta_from_engine_row),
         );
-        let absence_guards =
-            tracked_head_absence_guards(state_rows, insert_selection, branch_id, None);
-        let mut coverage = WorkingDiffIndexCoverage::default();
-        let mut writer = tracked_head.writer(read, writes);
-        if absence_guards.is_empty() {
-            let no_absence_guards = BTreeSet::new();
-            writer
-                .stage_current_state_with_working_diff(
-                    branch_id,
-                    Some(control.generation),
-                    control.head_commit_id,
-                    &deltas,
-                    &no_absence_guards,
-                    None,
-                    None,
-                    None,
-                    &mut coverage,
-                )
-                .await?;
-        } else {
-            writer
-                .stage_validated_insert_current_state_with_working_diff(
-                    branch_id,
-                    Some(control.generation),
-                    control.head_commit_id,
-                    &deltas,
-                    &absence_guards,
-                    None,
-                    None,
-                    None,
-                    &mut coverage,
-                    None,
-                )
-                .await?;
-        }
         let mut control = control.next_current_state_revision()?;
         control.note_schemas(deltas.iter().map(|delta| delta.schema_key));
         insert_direct_branch_control(&mut controls, branch_id, control)?;
@@ -4310,9 +4308,64 @@ fn packed_current_base_guards_match(
     delta_identities == guard_identities
 }
 
+async fn reject_untracked_absence_guard_collisions(
+    read: &(impl StorageAdapterRead + ?Sized),
+    branch_id: &str,
+    guards: &[TrackedStateKeyRef<'_>],
+) -> Result<(), LixError> {
+    if guards.is_empty() {
+        return Ok(());
+    }
+    let request = crate::live_state::LiveStateExactBatchRequest {
+        rows: guards
+            .iter()
+            .map(|guard| crate::live_state::LiveStateExactRowRequest {
+                schema_key: guard.schema_key.to_owned(),
+                branch_id: branch_id.to_owned(),
+                entity_pk: guard.entity_pk.clone(),
+                file_id: guard.file_id.map(str::to_owned),
+            })
+            .collect(),
+        untracked: Some(true),
+        ..crate::live_state::LiveStateExactBatchRequest::default()
+    };
+    let visible = [branch_id.to_owned()].into_iter().collect();
+    let existing = crate::live_state::load_untracked_exact_batch(read, &request, &visible).await?;
+    if let Some((guard, _)) = guards
+        .iter()
+        .zip(existing.into_rows())
+        .find(|(_, row)| row.is_some())
+    {
+        return Err(LixError::new(
+            LixError::CODE_UNIQUE,
+            format!(
+                "cannot insert tracked row in schema '{}' entity_pk {:?}: a canonical untracked row already exists; delete it first",
+                guard.schema_key, guard.entity_pk,
+            ),
+        ));
+    }
+    Ok(())
+}
+
+async fn reject_untracked_delta_collisions(
+    read: &(impl StorageAdapterRead + ?Sized),
+    branch_id: &str,
+    deltas: &[crate::live_state::CurrentStateDeltaRef<'_>],
+) -> Result<(), LixError> {
+    let guards = deltas
+        .iter()
+        .map(|delta| TrackedStateKeyRef {
+            schema_key: delta.schema_key,
+            entity_pk: delta.entity_pk,
+            file_id: delta.file_id,
+        })
+        .collect::<Vec<_>>();
+    reject_untracked_absence_guard_collisions(read, branch_id, &guards).await
+}
+
 /// A selected historical change becomes visible through a newly materialized
-/// hot generation while that publication retains the branch's untracked
-/// members. The two retention modes must never own the same logical identity.
+/// hot generation while branch-stable untracked state remains independently
+/// visible. The two retention modes must never own the same logical identity.
 ///
 /// This is a merge/checkpoint lifecycle fence, not a normal CRUD-path check.
 /// Point-loading only the selected identities keeps large untracked workspaces
@@ -4337,22 +4390,26 @@ async fn reject_selected_tracked_refs_with_untracked_rows(
     }
 
     let selected_keys = selected_identities.iter().cloned().collect::<Vec<_>>();
-    let mut untracked_identities = if let Some(control) = control {
-        TrackedHeadContext::new()
-            .reader(read)
-            .load_projected_live_rows(
-                branch_id,
-                control,
-                &selected_keys,
-                &ChangeRecordProjection {
-                    snapshot_content: false,
-                    metadata: false,
-                },
-            )
+    let mut untracked_identities = if control.is_some() {
+        let request = crate::live_state::LiveStateExactBatchRequest {
+            rows: selected_keys
+                .iter()
+                .map(|key| crate::live_state::LiveStateExactRowRequest {
+                    schema_key: key.schema_key.clone(),
+                    branch_id: branch_id.to_owned(),
+                    entity_pk: key.entity_pk.clone(),
+                    file_id: key.file_id.clone(),
+                })
+                .collect(),
+            untracked: Some(true),
+            ..crate::live_state::LiveStateExactBatchRequest::default()
+        };
+        let visible = [branch_id.to_owned()].into_iter().collect();
+        crate::live_state::load_untracked_exact_batch(read, &request, &visible)
             .await?
+            .into_rows()
             .into_iter()
             .flatten()
-            .filter(|row| row.untracked)
             .map(|row| TrackedStateKey {
                 schema_key: row.schema_key,
                 file_id: row.file_id,
@@ -4617,22 +4674,7 @@ async fn stage_root_backed_branch_publication(
         )
         .collect::<Result<Vec<_>, _>>()?;
     if !untracked_deltas.is_empty() {
-        let mut coverage = WorkingDiffIndexCoverage::default();
-        let (_, schemas) = tracked_head
-            .writer(read, writes)
-            .stage_complete_current_state_with_working_diff(
-                branch_id,
-                generation,
-                HotTrackedSnapshot::default(),
-                None,
-                &[],
-                &untracked_deltas,
-                &BTreeSet::new(),
-                None,
-                &mut coverage,
-            )
-            .await?;
-        control.note_schemas(schemas.iter().map(String::as_str));
+        control.note_schemas(untracked_deltas.iter().map(|delta| delta.schema_key));
     }
     Ok(control)
 }
@@ -4746,9 +4788,7 @@ async fn stage_branch_head_control_publications(
                             &branch_id,
                             generation,
                             tracked,
-                            existing.map(|control| control.generation),
                             &[],
-                            &untracked_deltas,
                             &absence_guards,
                             None,
                             &mut coverage,
@@ -4778,7 +4818,12 @@ async fn stage_branch_head_control_publications(
                             .expect("existing lifecycle publication was handled above")
                             .schema_presence_bloom,
                     };
-                    control.note_schemas(schema_keys.iter().map(String::as_str));
+                    control.note_schemas(
+                        schema_keys
+                            .iter()
+                            .map(String::as_str)
+                            .chain(untracked_deltas.iter().map(|delta| delta.schema_key)),
+                    );
                     Some(control)
                 }
             }
@@ -5062,7 +5107,6 @@ async fn reject_explicit_branch_ref_lifecycle_with_untracked_rows(
     explicit_branch_targets: &BTreeMap<String, ExplicitBranchHeadTarget>,
     observations: &BTreeMap<String, BranchHeadControlObservation>,
 ) -> Result<(), LixError> {
-    let current_state = TrackedHeadContext::new().reader(read);
     for (branch_id, target) in explicit_branch_targets {
         let Some(existing) = observations
             .get(branch_id)
@@ -5076,28 +5120,28 @@ async fn reject_explicit_branch_ref_lifecycle_with_untracked_rows(
         if !destructive {
             continue;
         }
-        let mut untracked_identities = current_state
-            .scan_live_rows(
-                branch_id,
-                existing,
-                &TrackedStateScanRequest {
-                    filter: TrackedStateFilter {
-                        include_tombstones: true,
-                        ..TrackedStateFilter::default()
-                    },
-                    read_columns: TrackedStateReadColumns::default(),
-                    limit: None,
+        let mut untracked_identities = crate::live_state::scan_untracked_batch(
+            read,
+            &crate::live_state::LiveStateScanRequest {
+                filter: crate::live_state::LiveStateFilter {
+                    branch_ids: vec![branch_id.clone()],
+                    untracked: Some(true),
+                    include_tombstones: true,
+                    ..crate::live_state::LiveStateFilter::default()
                 },
-            )
-            .await?
-            .into_iter()
-            .filter(|row| row.untracked)
-            .map(|row| TrackedStateKey {
-                schema_key: row.schema_key,
-                entity_pk: row.entity_pk,
-                file_id: row.file_id,
-            })
-            .collect();
+                ..crate::live_state::LiveStateScanRequest::default()
+            },
+            std::slice::from_ref(branch_id),
+        )
+        .await?
+        .into_rows()
+        .into_iter()
+        .map(|row| TrackedStateKey {
+            schema_key: row.schema_key,
+            entity_pk: row.entity_pk,
+            file_id: row.file_id,
+        })
+        .collect();
         apply_pending_untracked_identities(
             &mut untracked_identities,
             branch_id,

--- a/packages/engine/tests/integration/sql/lix_registered_schema.rs
+++ b/packages/engine/tests/integration/sql/lix_registered_schema.rs
@@ -2449,3 +2449,67 @@ simulation_test!(
         );
     }
 );
+
+simulation_test!(
+    tracked_file_delete_cascades_file_scoped_untracked_entity,
+    |sim| async move {
+        let engine = sim.boot_engine().await;
+        let session = sim.wrap_session(
+            engine
+                .open_workspace_session()
+                .await
+                .expect("main session should open"),
+            &engine,
+        );
+
+        session
+            .execute(
+                "INSERT INTO lix_registered_schema (value, lixcol_global, lixcol_untracked) \
+                 VALUES (\
+                 lix_json('{\"x-lix-key\":\"engine_untracked_file_cascade_schema\",\"x-lix-primary-key\":[\"/id\"],\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\"}},\"required\":[\"id\"],\"additionalProperties\":false}'),\
+                 false, false)",
+                &[],
+            )
+            .await
+            .expect("register file-scoped entity schema");
+        session
+            .execute(
+                "INSERT INTO lix_file (id, path, content) \
+                 VALUES ('66696c65-2d63-8173-8363-616465000000', '/cascade.txt', X'31')",
+                &[],
+            )
+            .await
+            .expect("insert tracked file");
+        session
+            .execute(
+                "INSERT INTO engine_untracked_file_cascade_schema \
+                 (id, lixcol_file_id, lixcol_untracked) \
+                 VALUES ('owned-row', '66696c65-2d63-8173-8363-616465000000', true)",
+                &[],
+            )
+            .await
+            .expect("insert file-owned untracked row");
+
+        session
+            .execute(
+                "DELETE FROM lix_file \
+                 WHERE id = '66696c65-2d63-8173-8363-616465000000'",
+                &[],
+            )
+            .await
+            .expect("delete tracked file");
+
+        let rows = session
+            .execute(
+                "SELECT id FROM engine_untracked_file_cascade_schema \
+                 WHERE id = 'owned-row'",
+                &[],
+            )
+            .await
+            .expect("read cascaded untracked row");
+        assert!(
+            rows.is_empty(),
+            "file deletion must remove owned untracked rows"
+        );
+    }
+);


### PR DESCRIPTION
## Summary

- hard-cut repository protocol V57 to V58 with no migration or compatibility shim
- move history-free rows into a dedicated branch-stable physical row space keyed by branch/schema/entity/file
- add a sparse file-fanout locator only for file-owned variants; fileless CRUD stays point-addressed without index writes
- remove untracked rows from tracked HOT generations, working diff, history, merge, and diff while preserving last-edit-wins visibility and collision fences
- keep GC JSON ownership, file-delete cascade, checkpoint schema presence, and branch CAS publication atomic across RocksDB and SlateDB
- push exact `lixcol_untracked` predicates, including normalized boolean forms and bound parameters, into the physical read lane

## Stack

1. #1207 immutable commit state
2. #1208 raw SQLite / RocksDB / SlateDB untracked CRUD scorecard
3. this PR: physical untracked layout and profiler-driven cut

## Profile evidence (1k rows, release)

Raw SQLite is the scorecard reference, not the storage-adapter diagnostic lane. Session execution still includes SQL planning/validation and therefore is not claimed to be raw-SQLite latency parity in this PR.

| operation | raw SQLite | unified RocksDB baseline | physical RocksDB | unified SlateDB baseline | physical SlateDB |
| --- | ---: | ---: | ---: | ---: | ---: |
| insert all | 1.676 ms | 27.770 ms | 28.488 ms | 26.104 ms | 30.536 ms |
| insert one | 14.54 us | 6.526 ms | 6.273 ms | 6.505 ms | 5.826 ms |
| select all | 456.8 us | 10.165 ms | 10.438 ms | 11.866 ms | 9.111 ms |
| select one | 27.37 us | 2.098 ms | 2.061 ms | 2.189 ms | 1.951 ms |
| update all | 2.731 ms | 45.917 ms | 44.337 ms | 41.866 ms | 52.947 ms |
| update one | 30.92 us | 3.843 ms | 3.426 ms | 3.799 ms | 3.426 ms |
| delete all | 35.33 us | 11.694 ms | 11.519 ms | 11.199 ms | 11.779 ms |
| delete one | 26.82 us | 1.101 ms | 1.098 ms | 1.150 ms | 0.797 ms |

The final parameterized bulk-update cut reduced logical storage calls from 15,043 to 3,043 and scan calls from 2,000 to 0 on both adapters. RocksDB bulk update is 3.4% faster than the unified baseline. SlateDB retains a measured bulk-write regression called out above; point update is 9.8% faster and all physical scan amplification is removed.

## Validation

- 20 focused untracked integration tests
- GC retirement/ownership and checkpoint schema-presence regressions
- boolean pushdown and 1-based bound-parameter regression
- `cargo clippy -p lix_engine --all-features --all-targets -- -D warnings`
- formatting and `git diff --check`
- independent correctness and performance reviews clear after fixes