### PR TITLE
perf(engine): batch physical untracked updates

### DIFF
--- a/packages/engine-benchmarks/benches/untracked_state_crud/main.rs
+++ b/packages/engine-benchmarks/benches/untracked_state_crud/main.rs
@@ -1259,29 +1259,27 @@ async fn update_untracked_json_pointer_rows<StorageImpl>(
 ) where
     StorageImpl: Storage + Clone + Send + Sync + 'static,
 {
-    let mut transaction = session
-        .begin_transaction()
-        .await
-        .expect("begin untracked update transaction");
-    for row in rows {
-        let affected = transaction
-            .execute(
+    let parameter_rows = rows
+        .iter()
+        .map(|row| {
+            Arc::<[Value]>::from([
+                Value::Text(row.updated_value_json.clone()),
+                Value::Text(row.path.clone()),
+            ])
+        })
+        .collect::<Vec<_>>();
+    let results = session
+        .execute_homogeneous_write_batch(
+            Arc::from(
                 "UPDATE json_pointer SET value = lix_json($1) \
                  WHERE path = $2 AND lixcol_untracked = true",
-                &[
-                    Value::Text(row.updated_value_json.clone()),
-                    Value::Text(row.path.clone()),
-                ],
-            )
-            .await
-            .expect("update untracked json_pointer rows")
-            .rows_affected();
-        assert_eq!(affected, 1);
-    }
-    transaction
-        .commit()
+            ),
+            Arc::from(parameter_rows),
+        )
         .await
-        .expect("commit untracked update transaction");
+        .expect("update untracked json_pointer parameter page");
+    assert_eq!(results.len(), rows.len());
+    assert!(results.iter().all(|result| result.rows_affected() == 1));
 }
 
 impl ProfileStorage {

--- a/packages/engine/src/session/execute.rs
+++ b/packages/engine/src/session/execute.rs
@@ -9424,6 +9424,148 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn homogeneous_untracked_json_pointer_updates_are_scoped_and_last_write_wins() {
+        let session = open_session().await;
+        let schema = serde_json::json!({
+            "x-lix-key": "physical_json_pointer",
+            "x-lix-primary-key": ["/path"],
+            "type": "object",
+            "required": ["path", "value"],
+            "properties": {
+                "path": { "type": "string" },
+                "value": {
+                    "type": ["object", "array", "string", "number", "integer", "boolean", "null"]
+                }
+            },
+            "additionalProperties": false
+        });
+        session
+            .execute(
+                "INSERT INTO lix_registered_schema (value) VALUES (lix_json($1))",
+                &[Value::Text(schema.to_string())],
+            )
+            .await
+            .expect("physical json pointer schema should register");
+        for (path, untracked) in [("/physical", true), ("/tracked", false)] {
+            session
+                .execute(
+                    "INSERT INTO physical_json_pointer (path, value, lixcol_untracked) \
+                     VALUES ($1, lix_json($2), $3)",
+                    &[
+                        Value::Text(path.to_string()),
+                        Value::Text("{\"step\":0}".to_string()),
+                        Value::Boolean(untracked),
+                    ],
+                )
+                .await
+                .expect("json pointer seed should commit");
+        }
+
+        let parameter_rows = vec![
+            Arc::<[Value]>::from([
+                Value::Text("{\"step\":1}".to_string()),
+                Value::Text("/physical".to_string()),
+            ]),
+            Arc::<[Value]>::from([
+                Value::Text("not valid JSON".to_string()),
+                Value::Text("/missing".to_string()),
+            ]),
+            Arc::<[Value]>::from([
+                Value::Text("{\"wrong_plane\":true}".to_string()),
+                Value::Text("/tracked".to_string()),
+            ]),
+            Arc::<[Value]>::from([
+                Value::Text("{\"step\":2}".to_string()),
+                Value::Text("/physical".to_string()),
+            ]),
+        ];
+        assert_eq!(
+            sql2::take_certified_untracked_replacement_batch_executions(),
+            0
+        );
+        let invalid = session
+            .execute_homogeneous_write_batch(
+                Arc::from(
+                    "UPDATE physical_json_pointer SET value = lix_json($1) \
+                     WHERE path = $2 AND lixcol_untracked = true",
+                ),
+                Arc::from(vec![
+                    Arc::<[Value]>::from([
+                        Value::Text("{\"step\":99}".to_string()),
+                        Value::Text("/physical".to_string()),
+                    ]),
+                    Arc::<[Value]>::from([
+                        Value::Text("not valid JSON".to_string()),
+                        Value::Text("/physical".to_string()),
+                    ]),
+                ]),
+            )
+            .await
+            .expect_err("a live invalid replacement must roll back the whole page");
+        assert_eq!(invalid.details.unwrap()["statementIndex"], 1);
+        let unchanged = session
+            .execute(
+                "SELECT value FROM physical_json_pointer \
+                 WHERE path = '/physical' AND lixcol_untracked = true",
+                &[],
+            )
+            .await
+            .expect("rolled-back physical row should remain readable");
+        assert_eq!(
+            unchanged.rows()[0]
+                .get::<serde_json::Value>("value")
+                .unwrap(),
+            serde_json::json!({"step": 0})
+        );
+        assert_eq!(
+            sql2::take_certified_untracked_replacement_batch_executions(),
+            0,
+            "failed normalization must happen before physical staging"
+        );
+        let results = session
+            .execute_homogeneous_write_batch(
+                Arc::from(
+                    "UPDATE physical_json_pointer SET value = lix_json($1) \
+                     WHERE path = $2 AND lixcol_untracked = true",
+                ),
+                Arc::from(parameter_rows),
+            )
+            .await
+            .expect("physical replacement page should commit atomically");
+        assert_eq!(
+            results
+                .iter()
+                .map(ExecuteResult::rows_affected)
+                .collect::<Vec<_>>(),
+            vec![1, 0, 0, 1]
+        );
+        assert_eq!(
+            sql2::take_certified_untracked_replacement_batch_executions(),
+            1,
+            "the parameter page must take the physical untracked certificate"
+        );
+
+        let rows = session
+            .execute(
+                "SELECT path, value, lixcol_untracked FROM physical_json_pointer ORDER BY path",
+                &[],
+            )
+            .await
+            .expect("both physical planes should remain readable");
+        assert_eq!(rows.len(), 2);
+        assert_eq!(
+            rows.rows()[0].get::<serde_json::Value>("value").unwrap(),
+            serde_json::json!({"step": 2})
+        );
+        assert!(rows.rows()[0].get::<bool>("lixcol_untracked").unwrap());
+        assert_eq!(
+            rows.rows()[1].get::<serde_json::Value>("value").unwrap(),
+            serde_json::json!({"step": 0})
+        );
+        assert!(!rows.rows()[1].get::<bool>("lixcol_untracked").unwrap());
+    }
+
+    #[tokio::test]
     async fn packed_mutation_membership_defers_to_transaction_overlay() {
         const ROW_COUNT: usize = 1_024;
         let session = open_session().await;

--- a/packages/engine/src/sql2/exec/bound_public_write.rs
+++ b/packages/engine/src/sql2/exec/bound_public_write.rs
@@ -58,6 +58,8 @@ std::thread_local! {
         const { std::cell::Cell::new(0) };
     static CERTIFIED_SINGLE_PATH_VALUE_REPLACEMENTS: std::cell::Cell<usize> =
         const { std::cell::Cell::new(0) };
+    static CERTIFIED_UNTRACKED_REPLACEMENT_BATCH_EXECUTIONS: std::cell::Cell<usize> =
+        const { std::cell::Cell::new(0) };
 }
 
 #[cfg(test)]
@@ -88,6 +90,11 @@ pub(crate) fn take_certified_generation_identity_replacements() -> usize {
 #[cfg(test)]
 pub(crate) fn take_certified_single_path_value_replacements() -> usize {
     CERTIFIED_SINGLE_PATH_VALUE_REPLACEMENTS.with(|executions| executions.replace(0))
+}
+
+#[cfg(test)]
+pub(crate) fn take_certified_untracked_replacement_batch_executions() -> usize {
+    CERTIFIED_UNTRACKED_REPLACEMENT_BATCH_EXECUTIONS.with(|executions| executions.replace(0))
 }
 
 #[cfg(test)]
@@ -590,6 +597,7 @@ pub(crate) async fn try_execute_entity_update_parameter_batch(
         &spec,
         scan_entity_pks,
         direct_replacement.is_some(),
+        None,
     )
     .await?;
     if direct_replacement.is_some()
@@ -838,6 +846,12 @@ async fn try_execute_direct_path_value_replacement_batch(
     }
     let parameter_identity_digest = *parameter_identity_hasher.finalize().as_bytes();
     let active_branch_id = ctx.active_branch_id().to_owned();
+    // A literal retention fence gives this certificate an exact physical
+    // scope. Parameterized or unconstrained retention stays on the generic
+    // route because different statements could otherwise address different
+    // physical planes.
+    let explicitly_untracked =
+        bound_untracked_from_predicate(&plan.bound.predicate, &[]) == Some(true);
     let scope = crate::collection_generation::CollectionScopeRef {
         schema_key: &spec.schema_key,
         file_id: None,
@@ -845,10 +859,15 @@ async fn try_execute_direct_path_value_replacement_batch(
     // Generation controls describe committed HOT state. Any staged member can
     // change the effective identity set, so it must force the overlay-aware
     // candidate scan instead of certifying the committed digest.
-    let has_staged_collection_rows = ctx.has_staged_collection_rows(&active_branch_id, scope)?;
-    let collection_generation = ctx
-        .load_collection_generation(&active_branch_id, scope)
-        .await?;
+    let (has_staged_collection_rows, collection_generation) = if explicitly_untracked {
+        (false, None)
+    } else {
+        (
+            ctx.has_staged_collection_rows(&active_branch_id, scope)?,
+            ctx.load_collection_generation(&active_branch_id, scope)
+                .await?,
+        )
+    };
     let certified_ordered_generation = primary_keys_strictly_ordered
         && !has_staged_collection_rows
         && collection_generation.is_some_and(|generation| {
@@ -997,20 +1016,26 @@ async fn try_execute_direct_path_value_replacement_batch(
     let candidates = if certified_generation_identity {
         MaterializedLiveStateBatch::default()
     } else {
-        let candidates =
-            scan_entity_candidates_for_pks(ctx, plan, &spec, unique_entity_pks.to_vec(), true)
-                .instrument(tracing::debug_span!(
-                    target: "lix_perf",
-                    "lix.perf.entity_update_value_batch.candidate_scan",
-                    row_count,
-                    unique_row_count
-                ))
-                .await?;
+        let candidates = scan_entity_candidates_for_pks(
+            ctx,
+            plan,
+            &spec,
+            unique_entity_pks.to_vec(),
+            true,
+            explicitly_untracked.then_some(true),
+        )
+        .instrument(tracing::debug_span!(
+            target: "lix_perf",
+            "lix.perf.entity_update_value_batch.candidate_scan",
+            row_count,
+            unique_row_count
+        ))
+        .await?;
         if candidates.iter().any(|candidate| {
-            candidate.untracked()
+            candidate.untracked() != explicitly_untracked
                 || candidate.global()
                 || candidate.file_id().is_some()
-                || candidate.metadata().is_some()
+                || (!explicitly_untracked && candidate.metadata().is_some())
         }) {
             return Ok(None);
         }
@@ -1094,6 +1119,8 @@ async fn try_execute_direct_path_value_replacement_batch(
     };
     let mut snapshot_offsets = Vec::with_capacity(replacement_capacity);
     let mut replacement_entity_pks = Vec::with_capacity(replacement_capacity);
+    let mut replacement_candidate_indices =
+        explicitly_untracked.then(|| Vec::with_capacity(replacement_capacity));
     let mut affected_by_statement =
         (!certified_generation_identity).then(|| vec![0_u64; row_count]);
     let mut candidate_index = 0;
@@ -1149,6 +1176,9 @@ async fn try_execute_direct_path_value_replacement_batch(
         normalized.push(b'}');
         snapshot_offsets.push((start, normalized.len()));
         replacement_entity_pks.push(entity_pk.clone());
+        if let Some(candidate_indices) = &mut replacement_candidate_indices {
+            candidate_indices.push(candidate_index);
+        }
         if let Some(ordinals) = &sorted_statement_ordinals {
             for &affected_statement in &ordinals[first_statement_index..=last_statement_index] {
                 if let Some(affected_by_statement) = &mut affected_by_statement {
@@ -1166,38 +1196,62 @@ async fn try_execute_direct_path_value_replacement_batch(
         let normalized_len = normalized.len();
         let snapshots =
             TransactionJson::from_certified_row_content_arena(normalized, snapshot_offsets)?;
-        let rows = CertifiedParameterReplacementBatch::new(
-            replacement_entity_pks,
-            snapshots,
-            spec.schema_key.as_str().into(),
-            active_branch_id.into(),
-            CertifiedRawWriteBatchPreparation {
-                schema_plan_id,
-                facts: PreparedRowFacts {
-                    row_content_validated: true,
-                    requires_transaction_validation: false,
-                },
-                tracked_keys_strictly_ordered: true,
-                complete_collection_replacement: replaces_complete_collection
-                    .then(|| {
-                        Some(CompleteCollectionReplacementProof {
-                            ordered_identity_digest: ordered_identity_digest?,
-                            replay_bytes: u64::try_from(
-                                replacement_identity_replay_bytes.checked_add(normalized_len)?,
-                            )
-                            .ok()?,
+        if let Some(candidate_indices) = replacement_candidate_indices {
+            let mut rows = RawWriteBatch::with_capacity(candidate_indices.len());
+            for (candidate_index, snapshot) in candidate_indices.into_iter().zip(snapshots) {
+                append_direct_path_value_replacement_prepared_row(
+                    &mut rows,
+                    &spec,
+                    EntityLiveRowRef::from(candidates.row(candidate_index)),
+                    snapshot,
+                )?;
+            }
+            stage_rows(ctx, TransactionWriteMode::Replace, rows)
+                .instrument(tracing::debug_span!(
+                    target: "lix_perf",
+                    "lix.perf.entity_update_value_batch.stage_untracked_rows",
+                    row_count
+                ))
+                .await?;
+            #[cfg(test)]
+            CERTIFIED_UNTRACKED_REPLACEMENT_BATCH_EXECUTIONS.with(|executions| {
+                executions.set(executions.get().saturating_add(1));
+            });
+        } else {
+            let rows = CertifiedParameterReplacementBatch::new(
+                replacement_entity_pks,
+                snapshots,
+                spec.schema_key.as_str().into(),
+                active_branch_id.into(),
+                CertifiedRawWriteBatchPreparation {
+                    schema_plan_id,
+                    facts: PreparedRowFacts {
+                        row_content_validated: true,
+                        requires_transaction_validation: false,
+                    },
+                    tracked_keys_strictly_ordered: true,
+                    complete_collection_replacement: replaces_complete_collection
+                        .then(|| {
+                            Some(CompleteCollectionReplacementProof {
+                                ordered_identity_digest: ordered_identity_digest?,
+                                replay_bytes: u64::try_from(
+                                    replacement_identity_replay_bytes
+                                        .checked_add(normalized_len)?,
+                                )
+                                .ok()?,
+                            })
                         })
-                    })
-                    .flatten(),
-            },
-        )?;
-        ctx.stage_certified_parameter_batch_replace(rows)
-            .instrument(tracing::debug_span!(
-                target: "lix_perf",
-                "lix.perf.entity_update_value_batch.stage_rows",
-                row_count
-            ))
-            .await?;
+                        .flatten(),
+                },
+            )?;
+            ctx.stage_certified_parameter_batch_replace(rows)
+                .instrument(tracing::debug_span!(
+                    target: "lix_perf",
+                    "lix.perf.entity_update_value_batch.stage_rows",
+                    row_count
+                ))
+                .await?;
+        }
     }
 
     #[cfg(test)]
@@ -1908,13 +1962,40 @@ fn bound_single_text_primary_key_param(
     };
     spec.visible_column(primary_key_column)
         .filter(|column| column.column_type == EntityColumnType::String)?;
+    if let BoundPredicate::And(predicates) = predicate {
+        let [first, second] = predicates.as_slice() else {
+            return None;
+        };
+        let first_primary_key = bound_text_primary_key_eq_param(primary_key_column, first);
+        let second_primary_key = bound_text_primary_key_eq_param(primary_key_column, second);
+        return match (first_primary_key, second_primary_key) {
+            (Some(param), None) if bound_literal_untracked_eq(second).is_some() => Some(param),
+            (None, Some(param)) if bound_literal_untracked_eq(first).is_some() => Some(param),
+            _ => None,
+        };
+    }
+    bound_text_primary_key_eq_param(primary_key_column, predicate)
+}
+
+fn bound_literal_untracked_eq(predicate: &BoundPredicate) -> Option<bool> {
+    let BoundPredicate::Eq(left, right) = predicate else {
+        return None;
+    };
+    bound_untracked_column_value(left, right, &[])
+        .or_else(|| bound_untracked_column_value(right, left, &[]))
+}
+
+fn bound_text_primary_key_eq_param(
+    primary_key_column: &str,
+    predicate: &BoundPredicate,
+) -> Option<usize> {
     let BoundPredicate::Eq(left, right) = predicate else {
         return None;
     };
     match (left, right) {
         (BoundExpr::Column(column), BoundExpr::Param(param))
         | (BoundExpr::Param(param), BoundExpr::Column(column))
-            if column.name == *primary_key_column =>
+            if column.name == primary_key_column =>
         {
             param.index.checked_sub(1)
         }
@@ -2980,7 +3061,8 @@ pub(crate) fn prepare_path_value_replacement_program(
     plan: &LogicalWritePlan,
     spec: &EntitySurfaceSpec,
 ) -> Option<PreparedPathValueReplacementProgram> {
-    if spec.has_inter_row_constraints
+    if bound_untracked_from_predicate(&plan.bound.predicate, &[]) == Some(true)
+        || spec.has_inter_row_constraints
         || !matches!(plan.bound.input, BoundWriteInput::None)
         || plan.bound.conflict.is_some()
         || plan.bound.returning.is_some()
@@ -3986,12 +4068,14 @@ async fn scan_entity_candidates_for_pks(
     spec: &EntitySurfaceSpec,
     entity_pks: Vec<EntityPk>,
     metadata_only: bool,
+    untracked: Option<bool>,
 ) -> Result<MaterializedLiveStateBatch, LixError> {
     ctx.scan_live_state_batch(&LiveStateScanRequest {
         filter: LiveStateFilter {
             schema_keys: vec![spec.schema_key.clone()],
             entity_pks,
             branch_ids: scan_branch_ids(&plan.bound.branch_scope)?,
+            untracked,
             include_tombstones: false,
             ..LiveStateFilter::default()
         },

--- a/packages/engine/src/sql2/exec/mod.rs
+++ b/packages/engine/src/sql2/exec/mod.rs
@@ -144,5 +144,7 @@ pub(crate) use bound_public_write::{
     take_certified_entity_insert_parameter_batch_executions,
     take_certified_generation_identity_replacements,
     take_certified_replacement_parameter_batch_executions,
-    take_certified_single_path_value_replacements, take_entity_update_parameter_batch_executions,
+    take_certified_single_path_value_replacements,
+    take_certified_untracked_replacement_batch_executions,
+    take_entity_update_parameter_batch_executions,
 };

--- a/packages/engine/src/sql2/mod.rs
+++ b/packages/engine/src/sql2/mod.rs
@@ -79,7 +79,9 @@ pub(crate) use exec::{
     take_certified_entity_insert_parameter_batch_executions,
     take_certified_generation_identity_replacements,
     take_certified_replacement_parameter_batch_executions,
-    take_certified_single_path_value_replacements, take_entity_update_parameter_batch_executions,
+    take_certified_single_path_value_replacements,
+    take_certified_untracked_replacement_batch_executions,
+    take_entity_update_parameter_batch_executions,
 };
 pub(crate) use file_view::{
     SessionFileViewKey, SessionFileViewMutation, SessionFileViews, SessionPluginFileView,

--- a/packages/engine/src/transaction/context.rs
+++ b/packages/engine/src/transaction/context.rs
@@ -6066,11 +6066,7 @@ where
             return rows.into_certified_prepared(certificate, self.origin_key.as_ref(), timestamp);
         }
         let staged = self.staged_writes.staging_overlay()?;
-        let read = SharedStorageAdapterRead::new(
-            self.storage
-                .begin_read(StorageReadOptions::default())
-                .await?,
-        );
+        let read = self.opening_read();
         let live_state = self.live_state.reader(&read);
         if allow_homogeneous && let Some(domain) = homogeneous_row_normalization_domain(&rows) {
             let functions = self.functions.clone();

--- a/packages/engine/tests/integration/execute_batch_benchmark.rs
+++ b/packages/engine/tests/integration/execute_batch_benchmark.rs
@@ -120,6 +120,66 @@ impl CounterSnapshot {
 }
 
 #[tokio::test(flavor = "current_thread")]
+async fn staged_untracked_writes_reuse_the_transaction_opening_read() {
+    let storage = CountingStorage::new();
+    Engine::initialize(storage.clone()).await.unwrap();
+    let engine = Engine::new(storage.clone()).await.unwrap();
+    let session = engine.open_workspace_session().await.unwrap();
+
+    session
+        .execute(
+            "INSERT INTO lix_registered_schema (value, lixcol_global, lixcol_untracked) \
+             VALUES (\
+             lix_json('{\"x-lix-key\":\"opening_read_note\",\"x-lix-primary-key\":[\"/id\"],\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\"},\"text\":{\"type\":\"string\"}},\"required\":[\"id\",\"text\"],\"additionalProperties\":false}'),\
+             false,\
+             true\
+             )",
+            &[],
+        )
+        .await
+        .unwrap();
+    session
+        .execute(
+            "INSERT INTO opening_read_note (id, text, lixcol_untracked) \
+             VALUES ('note-1', 'before-1', true), ('note-2', 'before-2', true)",
+            &[],
+        )
+        .await
+        .unwrap();
+
+    let mut transaction = session.begin_transaction().await.unwrap();
+    let before = storage.snapshot();
+    for (id, text) in [("note-1", "after-1"), ("note-2", "after-2")] {
+        let result = transaction
+            .execute(
+                "UPDATE opening_read_note SET text = $1 \
+                 WHERE id = $2 AND lixcol_untracked = true",
+                &[Value::Text(text.to_string()), Value::Text(id.to_string())],
+            )
+            .await
+            .unwrap();
+        assert_eq!(result.rows_affected(), 1);
+    }
+    let staged = storage.snapshot().delta(before);
+
+    assert_eq!(
+        staged.begin_reads, 0,
+        "staging against a transaction must not open per-statement storage snapshots"
+    );
+    transaction.commit().await.unwrap();
+
+    let rows = session
+        .execute("SELECT id, text FROM opening_read_note ORDER BY id", &[])
+        .await
+        .unwrap();
+    assert_eq!(rows.len(), 2);
+    assert_eq!(rows.rows()[0].get::<String>("id").unwrap(), "note-1");
+    assert_eq!(rows.rows()[0].get::<String>("text").unwrap(), "after-1");
+    assert_eq!(rows.rows()[1].get::<String>("id").unwrap(), "note-2");
+    assert_eq!(rows.rows()[1].get::<String>("text").unwrap(), "after-2");
+}
+
+#[tokio::test(flavor = "current_thread")]
 #[ignore = "manual performance probe; run with --ignored --nocapture"]
 async fn execute_batch_benchmark_probe() {
     let file_count = parse_usize_env(FILE_COUNT_ENV, 10_000);


### PR DESCRIPTION
## Summary
- certify explicit untracked JSON-pointer parameter pages as one physical replacement batch
- reuse the coherent transaction opening snapshot during row normalization
- preserve atomicity, affected counts, missing-row expression order, tracked-plane isolation, and duplicate last-edit-wins

## Performance (1k UPDATE, median)
- RocksDB: 42.07 ms to 16.12 ms (61.7% faster)
- SlateDB: 53.25 ms to 23.54 ms (55.8% faster)
- logical storage calls: 3043 to 29
- raw SQLite reference: 2.60 ms; this PR is a measured cut, not the final parity claim

## Validation
- focused homogeneous untracked scope/LWW/rollback test
- transaction opening-read counter and committed-value regression
- 21 untracked integration tests
- 20 merge tests
- 7 diff tests
- cargo fmt --all -- --check
- independent correctness and performance reviews