### PR TITLE
Converge tracked state on one immutable physical layout

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3557,6 +3557,7 @@ dependencies = [
  "lix_engine",
  "lix_rocksdb_storage",
  "lix_sdk",
+ "lix_slatedb_storage",
  "mimalloc",
  "plugin_csv",
  "plugin_excalidraw",

--- a/packages/engine-benchmarks/benches/repository_gc_scale.rs
+++ b/packages/engine-benchmarks/benches/repository_gc_scale.rs
@@ -6,11 +6,10 @@ use std::time::{Duration, Instant};
 #[global_allocator]
 static GLOBAL_ALLOCATOR: mimalloc::MiMalloc = mimalloc::MiMalloc;
 
-use lix_engine::Engine;
-use lix_engine::changelog::bench::{append_ordered_commits, stage_append_once};
 use lix_engine::storage::Storage;
 use lix_engine::storage_adapter::StorageAdapter;
 use lix_engine::storage_bench::{RepositoryGcBenchResult, plan_repository_gc_for_bench};
+use lix_engine::{CreateBranchOptions, Engine, Value};
 use lix_rocksdb_storage::RocksDB;
 use lix_slatedb_storage::{SlateDB, SlateDBIoCounters, SlateDBIoSnapshot};
 
@@ -96,7 +95,7 @@ async fn run() {
                     let seed = seed_unreachable_commits(
                         storage.clone(),
                         expected_swept_commits,
-                        batch_commits,
+                        commit_width,
                     )
                     .await;
                     storage.flush().expect("flush repository-GC RocksDB");
@@ -123,7 +122,7 @@ async fn run() {
                     let seed = seed_unreachable_commits(
                         storage.clone(),
                         expected_swept_commits,
-                        batch_commits,
+                        commit_width,
                     )
                     .await;
                     let memtable_flushed = env_bool("LIX_REPOSITORY_GC_MEMTABLE_FLUSH", false);
@@ -215,28 +214,87 @@ struct SeedResult {
 async fn seed_unreachable_commits<StorageImpl>(
     storage: StorageImpl,
     commit_count: usize,
-    batch_commits: usize,
+    changes_per_commit: usize,
 ) -> SeedResult
 where
-    StorageImpl: Storage + Clone + Sync,
+    StorageImpl: Storage + Clone + Send + Sync + 'static,
 {
     let started = Instant::now();
-    let mut puts = 0usize;
-    let mut written_bytes = 0usize;
-    for batch_start in (0..commit_count).step_by(batch_commits) {
-        let count = (commit_count - batch_start).min(batch_commits);
-        let append =
-            append_ordered_commits(batch_start, count).expect("build repository-GC commit batch");
-        let stats = stage_append_once(storage.clone(), &append)
+    let engine = Engine::new(storage.clone())
+        .await
+        .expect("open repository-GC engine");
+    let main = engine
+        .open_workspace_session()
+        .await
+        .expect("open repository-GC main session");
+    let schema = serde_json::json!({
+        "x-lix-key": "repository_gc_fixture",
+        "x-lix-primary-key": ["/path"],
+        "type": "object",
+        "required": ["path", "value"],
+        "properties": {
+            "path": { "type": "string" },
+            "value": { "type": ["object", "array", "string", "number", "integer", "boolean", "null"] }
+        },
+        "additionalProperties": false
+    });
+    main.execute(
+        "INSERT INTO lix_registered_schema (value, lixcol_global, lixcol_untracked) VALUES (lix_json($1), false, false)",
+        &[Value::Text(schema.to_string())],
+    )
+    .await
+    .expect("register repository-GC schema");
+    let branch = main
+        .create_branch(CreateBranchOptions {
+            id: Some("01990000-0000-7000-8000-000000000001".to_owned()),
+            name: "repository-gc-unreachable".to_owned(),
+            from_commit_id: None,
+        })
+        .await
+        .expect("create repository-GC disposable branch");
+    let branch_session = engine
+        .open_session(branch.id.clone())
+        .await
+        .expect("open repository-GC disposable branch");
+    for commit_index in 0..commit_count {
+        let mut transaction = branch_session
+            .begin_transaction()
             .await
-            .expect("stage repository-GC commit batch");
-        puts = puts.saturating_add(stats.puts);
-        written_bytes = written_bytes.saturating_add(stats.bytes_written);
+            .expect("begin repository-GC fixture transaction");
+        for row_index in 0..changes_per_commit {
+            let row = commit_index
+                .checked_mul(changes_per_commit)
+                .and_then(|base| base.checked_add(row_index))
+                .expect("repository-GC fixture row index overflow");
+            transaction
+                .execute(
+                    "INSERT INTO repository_gc_fixture (path, value) VALUES ($1, lix_json($2))",
+                    &[
+                        Value::Text(format!("/row/{row:08}")),
+                        Value::Text(format!(r#"{{"commit":{commit_index},"row":{row}}}"#)),
+                    ],
+                )
+                .await
+                .expect("stage repository-GC fixture row");
+        }
+        transaction
+            .commit()
+            .await
+            .expect("publish repository-GC fixture commit");
     }
+    main.execute(
+        "DELETE FROM lix_branch WHERE id = $1",
+        &[Value::Text(branch.id)],
+    )
+    .await
+    .expect("delete repository-GC disposable branch");
+    main.create_checkpoint()
+        .await
+        .expect("checkpoint repository-GC main after branch deletion");
     SeedResult {
         elapsed: started.elapsed(),
-        puts,
-        written_bytes,
+        puts: commit_count.saturating_mul(changes_per_commit),
+        written_bytes: 0,
     }
 }
 

--- a/packages/engine-benchmarks/benches/repository_gc_scale.rs
+++ b/packages/engine-benchmarks/benches/repository_gc_scale.rs
@@ -8,7 +8,9 @@ static GLOBAL_ALLOCATOR: mimalloc::MiMalloc = mimalloc::MiMalloc;
 
 use lix_engine::storage::Storage;
 use lix_engine::storage_adapter::StorageAdapter;
-use lix_engine::storage_bench::{RepositoryGcBenchResult, plan_repository_gc_for_bench};
+use lix_engine::storage_bench::{
+    RepositoryGcBenchResult, audit_repository_gc_standalone_for_bench, plan_repository_gc_for_bench,
+};
 use lix_engine::{CreateBranchOptions, Engine, Value};
 use lix_rocksdb_storage::RocksDB;
 use lix_slatedb_storage::{SlateDB, SlateDBIoCounters, SlateDBIoSnapshot};
@@ -288,9 +290,6 @@ where
     )
     .await
     .expect("delete repository-GC disposable branch");
-    main.create_checkpoint()
-        .await
-        .expect("checkpoint repository-GC main after branch deletion");
     SeedResult {
         elapsed: started.elapsed(),
         puts: commit_count.saturating_mul(changes_per_commit),
@@ -313,6 +312,14 @@ async fn measure<StorageImpl>(
     StorageImpl: Storage,
 {
     let adapter = StorageAdapter::new(storage);
+    let standalone_audit = audit_repository_gc_standalone_for_bench(&adapter)
+        .await
+        .expect("audit repository-GC standalone facts");
+    println!(
+        "repository_gc_standalone_audit,backend={backend},history_changes={history_changes},\
+         commit_width={commit_width},entries={}",
+        standalone_audit.join("|")
+    );
     for _ in 0..warmups {
         let result = plan_repository_gc_for_bench(&adapter)
             .await
@@ -334,7 +341,7 @@ async fn measure<StorageImpl>(
         results.push(result);
     }
     timings.sort_unstable();
-    let last = *results.last().expect("repository-GC samples are positive");
+    let last = results.last().expect("repository-GC samples are positive");
     let phase_percentiles = |select: fn(&RepositoryGcBenchResult) -> u64| {
         let mut values = results.iter().map(select).collect::<Vec<_>>();
         values.sort_unstable();
@@ -355,7 +362,7 @@ async fn measure<StorageImpl>(
     println!(
         "repository_gc_scale,phase=measure,backend={backend},\
          history_changes={history_changes},commit_width={commit_width},\
-         swept_commits={},live_commits={},swept_standalone_changes={},swept_payloads={},\
+         swept_commits={},live_commits={},swept_standalone_changes={},standalone_swept_ids={},swept_payloads={},\
          samples={samples},warmups={warmups},p50_ms={},p95_ms={},p99_ms={},\
          root_discovery_p50_us={},root_discovery_p95_us={},root_discovery_p99_us={},\
          changelog_p50_us={},changelog_p95_us={},changelog_p99_us={},\
@@ -370,6 +377,7 @@ async fn measure<StorageImpl>(
         last.swept_commits,
         last.live_commits,
         last.swept_standalone_changes,
+        last.standalone_swept_ids.join("|"),
         last.swept_payloads,
         millis(percentile(&timings, 50)),
         millis(percentile(&timings, 95)),

--- a/packages/engine-benchmarks/benches/tracked_state_crud/main.rs
+++ b/packages/engine-benchmarks/benches/tracked_state_crud/main.rs
@@ -35,6 +35,11 @@ static ALLOCATED_BYTES: AtomicU64 = AtomicU64::new(0);
     not(target_family = "wasm"),
     not(feature = "system-allocation-profiler")
 ))]
+static ALLOCATION_CALLS: AtomicU64 = AtomicU64::new(0);
+#[cfg(all(
+    not(target_family = "wasm"),
+    not(feature = "system-allocation-profiler")
+))]
 static ALLOCATION_ACCOUNTING_ENABLED: AtomicBool = AtomicBool::new(false);
 
 #[cfg(all(
@@ -75,6 +80,7 @@ unsafe impl GlobalAlloc for CountingAllocator {
 fn record_allocation(bytes: usize) {
     if ALLOCATION_ACCOUNTING_ENABLED.load(Ordering::Relaxed) {
         ALLOCATED_BYTES.fetch_add(bytes as u64, Ordering::Relaxed);
+        ALLOCATION_CALLS.fetch_add(1, Ordering::Relaxed);
     }
 }
 
@@ -84,6 +90,7 @@ fn record_allocation(bytes: usize) {
 ))]
 fn reset_allocation_accounting() {
     ALLOCATED_BYTES.store(0, Ordering::Relaxed);
+    ALLOCATION_CALLS.store(0, Ordering::Relaxed);
     ALLOCATION_ACCOUNTING_ENABLED.store(
         std::env::var_os("LIX_TRACKED_STATE_CRUD_PROFILE_ALLOCATION_BYTES").is_some(),
         Ordering::Relaxed,
@@ -98,8 +105,9 @@ fn print_allocation_accounting(phase: &str) {
     if std::env::var_os("LIX_TRACKED_STATE_CRUD_PROFILE_ALLOCATION_BYTES").is_some() {
         ALLOCATION_ACCOUNTING_ENABLED.store(false, Ordering::Relaxed);
         println!(
-            "tracked_state_crud allocation phase: {phase} allocated_bytes={}",
-            ALLOCATED_BYTES.load(Ordering::Relaxed)
+            "tracked_state_crud allocation phase: {phase} allocated_bytes={} allocation_calls={}",
+            ALLOCATED_BYTES.load(Ordering::Relaxed),
+            ALLOCATION_CALLS.load(Ordering::Relaxed),
         );
     }
 }
@@ -1035,6 +1043,11 @@ fn profile_sql_session_operation(
         };
         maybe_print_profile_rss_phase("after_seed");
         reset_allocation_accounting();
+        let ownership_accounting =
+            std::env::var_os("LIX_TRACKED_STATE_CRUD_PROFILE_OWNERSHIP_ACCOUNTING").is_some();
+        if ownership_accounting {
+            lix_engine::storage_bench::begin_crud_ownership_accounting();
+        }
         let _ = lix_engine::storage_bench::take_crud_current_state_scoped_range_accounting();
         if std::env::var_os("LIX_TRACKED_STATE_CRUD_PROFILE_WRITE_ACCOUNTING").is_some() {
             let _ = lix_engine::storage_bench::take_crud_physical_write_accounting();
@@ -1046,6 +1059,9 @@ fn profile_sql_session_operation(
         black_box(result);
         maybe_print_profile_rss_phase("after_operation");
         print_allocation_accounting("operation");
+        if ownership_accounting {
+            print_ownership_accounting(lix_engine::storage_bench::take_crud_ownership_accounting());
+        }
         if std::env::var_os("LIX_TRACKED_STATE_CRUD_PROFILE_WRITE_ACCOUNTING").is_some() {
             let physical = lix_engine::storage_bench::take_crud_physical_write_accounting();
             let manifest_bytes = lix_engine::storage_bench::take_crud_commit_state_manifest_bytes();
@@ -1104,6 +1120,11 @@ fn profile_sql_session_bound_updates(
         maybe_print_profile_rss_phase("after_seed");
         print_allocation_accounting("seed");
         reset_allocation_accounting();
+        let ownership_accounting =
+            std::env::var_os("LIX_TRACKED_STATE_CRUD_PROFILE_OWNERSHIP_ACCOUNTING").is_some();
+        if ownership_accounting {
+            lix_engine::storage_bench::begin_crud_ownership_accounting();
+        }
         let _ = lix_engine::storage_bench::take_crud_physical_write_accounting();
         let _ = lix_engine::storage_bench::take_crud_commit_state_manifest_bytes();
         let _ = lix_engine::storage_bench::take_crud_current_state_scoped_range_fallbacks();
@@ -1120,6 +1141,9 @@ fn profile_sql_session_bound_updates(
         black_box(result);
         maybe_print_profile_rss_phase("after_update");
         print_allocation_accounting("update");
+        if ownership_accounting {
+            print_ownership_accounting(lix_engine::storage_bench::take_crud_ownership_accounting());
+        }
         let certificate =
             lix_engine::storage_bench::take_certified_entity_update_value_batch_accounting();
         let physical = lix_engine::storage_bench::take_crud_physical_write_accounting();
@@ -1143,6 +1167,51 @@ fn profile_sql_session_bound_updates(
         read_many_pk_count,
         samples,
     );
+}
+
+fn print_ownership_accounting(accounting: lix_engine::storage_bench::CrudOwnershipAccounting) {
+    const NAMES: [&str; lix_engine::storage_bench::CRUD_OWNERSHIP_STAGE_COUNT] = [
+        "sql_bound",
+        "raw_batch",
+        "raw_transfer",
+        "prepared_batch",
+        "prepared_clone",
+        "replacement_input",
+        "replacement_part",
+        "authority",
+        "root_publication",
+        "write_set",
+        "adapter",
+        "mutation_journal",
+        "identity_encoding",
+        "normalization",
+        "journal_seal",
+    ];
+    for (stage, (name, metric)) in NAMES.into_iter().zip(accounting.stages).enumerate() {
+        if metric.rows == 0
+            && metric.key_bytes == 0
+            && metric.value_bytes == 0
+            && metric.vec_entries == 0
+            && metric.string_entries == 0
+            && metric.map_entries == 0
+        {
+            continue;
+        }
+        let transfer = accounting.transfers[stage];
+        println!(
+            "tracked_state_crud ownership: stage={name} rows={} key_bytes={} value_bytes={} vec_entries={} string_entries={} map_entries={} created_bytes={} cloned_bytes={} retained_bytes={} dropped_bytes={}",
+            metric.rows,
+            metric.key_bytes,
+            metric.value_bytes,
+            metric.vec_entries,
+            metric.string_entries,
+            metric.map_entries,
+            transfer.created_bytes,
+            transfer.cloned_bytes,
+            transfer.retained_bytes,
+            transfer.dropped_bytes,
+        );
+    }
 }
 
 async fn run_sql_session_operation(

--- a/packages/engine-benchmarks/benches/tracked_state_crud/main.rs
+++ b/packages/engine-benchmarks/benches/tracked_state_crud/main.rs
@@ -153,9 +153,10 @@ fn tracked_state_crud_benches(c: &mut Criterion) {
         profile_operation(&runtime, &rows);
         return;
     }
-    let rows = fixture_rows(REAL_WORKLOAD_ROWS);
+    let accounting_rows = accounting_row_count();
+    let rows = fixture_rows(REAL_WORKLOAD_ROWS.max(accounting_rows));
     io_stats::maybe_print_io_report();
-    accounting::maybe_print_accounting_report(&runtime, &rows[..SMOKE_ROWS]);
+    accounting::maybe_print_accounting_report(&runtime, &rows[..accounting_rows]);
 
     for (label, row_count) in [("smoke", SMOKE_ROWS), ("real_workload", REAL_WORKLOAD_ROWS)] {
         bench_raw_sqlite(c, &rows[..row_count], label);
@@ -167,6 +168,26 @@ fn tracked_state_crud_benches(c: &mut Criterion) {
             bench_sql_session(c, &runtime, profile, &rows[..row_count], label);
         }
     }
+}
+
+fn accounting_row_count() -> usize {
+    if std::env::var_os("LIX_TRACKED_STATE_CRUD_ACCOUNTING").is_none() {
+        return SMOKE_ROWS;
+    }
+    let Some(value) = std::env::var_os("LIX_TRACKED_STATE_CRUD_ACCOUNTING_ROW_COUNT") else {
+        return SMOKE_ROWS;
+    };
+    let value = value.to_string_lossy();
+    let row_count = value.parse::<usize>().unwrap_or_else(|_| {
+        panic!(
+            "LIX_TRACKED_STATE_CRUD_ACCOUNTING_ROW_COUNT must be a positive integer, got '{value}'"
+        )
+    });
+    assert!(
+        row_count > 0,
+        "LIX_TRACKED_STATE_CRUD_ACCOUNTING_ROW_COUNT must be positive"
+    );
+    row_count
 }
 
 fn profile_sample_count() -> usize {

--- a/packages/engine-benchmarks/benches/tracked_state_crud/sql_session.rs
+++ b/packages/engine-benchmarks/benches/tracked_state_crud/sql_session.rs
@@ -677,11 +677,7 @@ where
 
     #[expect(clippy::cast_possible_truncation)]
     async fn insert_all(&self) -> usize {
-        let _ =
-            lix_engine::storage_bench::take_certified_entity_insert_parameter_batch_certifications(
-            );
-        let _ =
-            lix_engine::storage_bench::take_certified_entity_insert_parameter_batch_executions();
+        let before = lix_engine::storage_bench::certified_entity_insert_parameter_batch_counters();
         let affected = self
             .session
             .execute_homogeneous_write_batch(
@@ -694,16 +690,16 @@ where
             .map(ExecuteResult::rows_affected)
             .sum::<u64>();
         assert_eq!(affected as usize, self.row_count);
+        let after = lix_engine::storage_bench::certified_entity_insert_parameter_batch_counters();
         assert_eq!(
-            lix_engine::storage_bench::take_certified_entity_insert_parameter_batch_certifications(
-            ),
+            after.certifications.saturating_sub(before.certifications),
             1,
-            "tracked-state CRUD insert benchmark must certify one parameter batch"
+            "tracked-state CRUD insert benchmark must certify one parameter batch per fixture"
         );
         assert_eq!(
-            lix_engine::storage_bench::take_certified_entity_insert_parameter_batch_executions(),
+            after.executions.saturating_sub(before.executions),
             1,
-            "tracked-state CRUD insert benchmark must physically execute one certified parameter batch"
+            "tracked-state CRUD insert benchmark must physically execute one certified parameter batch per fixture"
         );
         affected as usize
     }

--- a/packages/engine-benchmarks/benches/tracked_state_crud/sql_session.rs
+++ b/packages/engine-benchmarks/benches/tracked_state_crud/sql_session.rs
@@ -678,6 +678,9 @@ where
     #[expect(clippy::cast_possible_truncation)]
     async fn insert_all(&self) -> usize {
         let _ =
+            lix_engine::storage_bench::take_certified_entity_insert_parameter_batch_certifications(
+            );
+        let _ =
             lix_engine::storage_bench::take_certified_entity_insert_parameter_batch_executions();
         let affected = self
             .session
@@ -692,9 +695,15 @@ where
             .sum::<u64>();
         assert_eq!(affected as usize, self.row_count);
         assert_eq!(
+            lix_engine::storage_bench::take_certified_entity_insert_parameter_batch_certifications(
+            ),
+            1,
+            "tracked-state CRUD insert benchmark must certify one parameter batch"
+        );
+        assert_eq!(
             lix_engine::storage_bench::take_certified_entity_insert_parameter_batch_executions(),
             1,
-            "tracked-state CRUD insert benchmark must execute one certified parameter batch"
+            "tracked-state CRUD insert benchmark must physically execute one certified parameter batch"
         );
         affected as usize
     }

--- a/packages/engine-benchmarks/benches/tracked_state_crud/workload.rs
+++ b/packages/engine-benchmarks/benches/tracked_state_crud/workload.rs
@@ -141,6 +141,7 @@ pub(crate) fn row_label(row_count: usize) -> &'static str {
     match row_count {
         SMOKE_ROWS => "1k",
         REAL_WORKLOAD_ROWS => "10k",
+        100_000 => "100k",
         1_000_000 => "1m",
         _ => "custom",
     }

--- a/packages/engine-benchmarks/benches/untracked_state_crud/main.rs
+++ b/packages/engine-benchmarks/benches/untracked_state_crud/main.rs
@@ -1,7 +1,18 @@
 use std::fmt::Write as _;
 use std::ops::Bound;
 use std::sync::{Arc, Mutex};
-use std::time::Duration;
+use std::time::{Duration, Instant};
+
+#[cfg(all(
+    not(target_family = "wasm"),
+    not(feature = "system-allocation-profiler")
+))]
+use std::alloc::GlobalAlloc;
+#[cfg(all(
+    not(target_family = "wasm"),
+    not(feature = "system-allocation-profiler")
+))]
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 
 use bytes::Bytes;
 use criterion::{BatchSize, Criterion, black_box, criterion_group, criterion_main};
@@ -15,13 +26,110 @@ use lix_engine::storage_adapter::{
     StoragePrefix, StorageReadOptions, StorageScanOptions, StorageSpace, StorageValue,
     StorageWriteOptions,
 };
-use lix_engine::{Engine, SessionContext, Storage};
+use lix_engine::{Engine, SessionContext, Storage, Value};
 use lix_rocksdb_storage::RocksDB;
+#[cfg(feature = "slatedb")]
+use lix_slatedb_storage::SlateDB;
 use lix_sqlite_storage::SQLite;
 use rusqlite::{Connection, OptionalExtension, params};
 use serde_json::Value as JsonValue;
 use tempfile::TempDir;
 use tokio::runtime::Runtime;
+
+#[cfg(all(
+    not(target_family = "wasm"),
+    not(feature = "system-allocation-profiler")
+))]
+#[global_allocator]
+static GLOBAL_ALLOCATOR: CountingAllocator = CountingAllocator;
+
+#[cfg(all(
+    not(target_family = "wasm"),
+    not(feature = "system-allocation-profiler")
+))]
+struct CountingAllocator;
+
+#[cfg(all(
+    not(target_family = "wasm"),
+    not(feature = "system-allocation-profiler")
+))]
+static PROFILE_ALLOCATED_BYTES: AtomicU64 = AtomicU64::new(0);
+#[cfg(all(
+    not(target_family = "wasm"),
+    not(feature = "system-allocation-profiler")
+))]
+static PROFILE_ALLOCATION_CALLS: AtomicU64 = AtomicU64::new(0);
+#[cfg(all(
+    not(target_family = "wasm"),
+    not(feature = "system-allocation-profiler")
+))]
+static PROFILE_ALLOCATION_ENABLED: AtomicBool = AtomicBool::new(false);
+
+#[cfg(all(
+    not(target_family = "wasm"),
+    not(feature = "system-allocation-profiler")
+))]
+unsafe impl GlobalAlloc for CountingAllocator {
+    unsafe fn alloc(&self, layout: std::alloc::Layout) -> *mut u8 {
+        let pointer = unsafe { mimalloc::MiMalloc.alloc(layout) };
+        if !pointer.is_null() && PROFILE_ALLOCATION_ENABLED.load(Ordering::Relaxed) {
+            PROFILE_ALLOCATED_BYTES.fetch_add(layout.size() as u64, Ordering::Relaxed);
+            PROFILE_ALLOCATION_CALLS.fetch_add(1, Ordering::Relaxed);
+        }
+        pointer
+    }
+
+    unsafe fn dealloc(&self, pointer: *mut u8, layout: std::alloc::Layout) {
+        unsafe { mimalloc::MiMalloc.dealloc(pointer, layout) };
+    }
+
+    unsafe fn realloc(
+        &self,
+        pointer: *mut u8,
+        layout: std::alloc::Layout,
+        new_size: usize,
+    ) -> *mut u8 {
+        let replacement = unsafe { mimalloc::MiMalloc.realloc(pointer, layout, new_size) };
+        if !replacement.is_null()
+            && new_size >= layout.size()
+            && PROFILE_ALLOCATION_ENABLED.load(Ordering::Relaxed)
+        {
+            PROFILE_ALLOCATED_BYTES.fetch_add((new_size - layout.size()) as u64, Ordering::Relaxed);
+            PROFILE_ALLOCATION_CALLS.fetch_add(1, Ordering::Relaxed);
+        }
+        replacement
+    }
+}
+
+#[cfg(all(
+    not(target_family = "wasm"),
+    not(feature = "system-allocation-profiler")
+))]
+fn reset_profile_allocations() {
+    PROFILE_ALLOCATED_BYTES.store(0, Ordering::Relaxed);
+    PROFILE_ALLOCATION_CALLS.store(0, Ordering::Relaxed);
+    PROFILE_ALLOCATION_ENABLED.store(true, Ordering::Relaxed);
+}
+
+#[cfg(any(target_family = "wasm", feature = "system-allocation-profiler"))]
+fn reset_profile_allocations() {}
+
+#[cfg(all(
+    not(target_family = "wasm"),
+    not(feature = "system-allocation-profiler")
+))]
+fn profile_allocations() -> (u64, u64) {
+    PROFILE_ALLOCATION_ENABLED.store(false, Ordering::Relaxed);
+    (
+        PROFILE_ALLOCATED_BYTES.load(Ordering::Relaxed),
+        PROFILE_ALLOCATION_CALLS.load(Ordering::Relaxed),
+    )
+}
+
+#[cfg(any(target_family = "wasm", feature = "system-allocation-profiler"))]
+fn profile_allocations() -> (u64, u64) {
+    (0, 0)
+}
 
 const SMOKE_ROWS: usize = 1_000;
 const REAL_WORKLOAD_ROWS: usize = 10_000;
@@ -335,26 +443,48 @@ where
 enum LixStorageProfile {
     SQLite,
     RocksDB,
+    #[cfg(feature = "slatedb")]
+    SlateDB,
 }
 
-const LIX_STORAGE_PROFILES: [LixStorageProfile; 2] =
-    [LixStorageProfile::SQLite, LixStorageProfile::RocksDB];
+#[cfg(not(feature = "slatedb"))]
+const LIX_STORAGE_PROFILES: &[LixStorageProfile] =
+    &[LixStorageProfile::SQLite, LixStorageProfile::RocksDB];
+#[cfg(feature = "slatedb")]
+const LIX_STORAGE_PROFILES: &[LixStorageProfile] = &[
+    LixStorageProfile::SQLite,
+    LixStorageProfile::RocksDB,
+    LixStorageProfile::SlateDB,
+];
 
 impl LixStorageProfile {
     fn name(self) -> &'static str {
         match self {
             Self::SQLite => "lix_sqlite",
             Self::RocksDB => "lix_rocksdb",
+            #[cfg(feature = "slatedb")]
+            Self::SlateDB => "lix_slatedb",
         }
     }
 }
 
 fn untracked_state_crud_benches(c: &mut Criterion) {
+    if std::env::var_os("LIX_UNTRACKED_STATE_CRUD_TRACE").is_some() {
+        let _ = tracing_subscriber::fmt()
+            .with_env_filter("lix_perf=debug")
+            .with_span_events(tracing_subscriber::fmt::format::FmtSpan::CLOSE)
+            .with_target(false)
+            .try_init();
+    }
     let runtime = tokio::runtime::Builder::new_current_thread()
         .enable_all()
         .build()
         .expect("create tokio runtime for session execute benchmarks");
     let rows = fixture_rows();
+    if std::env::var_os("LIX_UNTRACKED_STATE_CRUD_PROFILE").is_some() {
+        profile_session_untracked_crud(&runtime, &rows);
+        return;
+    }
     maybe_print_io_report(&runtime, &rows);
 
     bench_raw_sqlite(c, &rows, SMOKE_ROWS, "smoke");
@@ -363,6 +493,127 @@ fn untracked_state_crud_benches(c: &mut Criterion) {
     bench_raw_sqlite(c, &rows, REAL_WORKLOAD_ROWS, "real_workload");
     bench_lix(c, &runtime, &rows, REAL_WORKLOAD_ROWS, "real_workload");
     bench_session_execute_untracked_insert(c, &runtime, &rows, REAL_WORKLOAD_ROWS, "real_workload");
+}
+
+fn profile_row_count(max_rows: usize) -> usize {
+    std::env::var("LIX_UNTRACKED_STATE_CRUD_PROFILE_ROWS")
+        .ok()
+        .and_then(|value| value.parse::<usize>().ok())
+        .unwrap_or(REAL_WORKLOAD_ROWS)
+        .min(max_rows)
+}
+
+fn profile_sample_count() -> usize {
+    std::env::var("LIX_UNTRACKED_STATE_CRUD_PROFILE_SAMPLES")
+        .ok()
+        .and_then(|value| value.parse::<usize>().ok())
+        .filter(|count| *count > 0)
+        .unwrap_or(3)
+}
+
+fn profile_session_untracked_crud(runtime: &Runtime, all_rows: &[PointerRow]) {
+    let rows = &all_rows[..profile_row_count(all_rows.len())];
+    let sample_count = profile_sample_count();
+    println!(
+        "untracked_state_crud/profile rows={} samples={} slate_db={} benchmark_profile=sql_session",
+        rows.len(),
+        sample_count,
+        if cfg!(feature = "slatedb") {
+            "enabled"
+        } else {
+            "unavailable"
+        }
+    );
+    println!(
+        "| storage | operation | sample | wall_ms | alloc_bytes | alloc_calls | rss_before_bytes | rss_after_bytes | rows | certified_batches | physical_puts | physical_deletes | physical_written_bytes |"
+    );
+    println!(
+        "| --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |"
+    );
+
+    let selected_storage = std::env::var("LIX_UNTRACKED_STATE_CRUD_PROFILE_STORAGE").ok();
+    let selected_operation = std::env::var("LIX_UNTRACKED_STATE_CRUD_PROFILE_OPERATION").ok();
+    let homogeneous = std::env::var_os("LIX_UNTRACKED_STATE_CRUD_PROFILE_HOMOGENEOUS").is_some();
+    for &profile in LIX_STORAGE_PROFILES {
+        if selected_storage
+            .as_deref()
+            .is_some_and(|name| name != profile.name())
+        {
+            continue;
+        }
+        for operation in ["insert", "update", "delete"] {
+            if selected_operation
+                .as_deref()
+                .is_some_and(|name| name != operation)
+            {
+                continue;
+            }
+            for sample in 0..sample_count {
+                let session = runtime.block_on(prepare_profile_session_empty(profile));
+                if operation != "insert" {
+                    runtime.block_on(session.insert_untracked_json_pointer_rows(rows));
+                }
+                let rss_before = process_resident_bytes();
+                let _ = lix_engine::storage_bench::
+                    take_certified_entity_insert_parameter_batch_executions();
+                let _ = lix_engine::storage_bench::take_crud_physical_write_accounting();
+                reset_profile_allocations();
+                let started = Instant::now();
+                let affected = match operation {
+                    "insert" => {
+                        if homogeneous {
+                            runtime.block_on(
+                                session.insert_untracked_json_pointer_rows_homogeneous(rows),
+                            );
+                        } else {
+                            runtime.block_on(session.insert_untracked_json_pointer_rows(rows));
+                        }
+                        rows.len()
+                    }
+                    "update" => {
+                        runtime.block_on(session.update_untracked_json_pointer_rows(rows));
+                        rows.len()
+                    }
+                    "delete" => runtime.block_on(session.delete_untracked_json_pointer_rows()),
+                    _ => unreachable!(),
+                };
+                let wall_ms = started.elapsed().as_secs_f64() * 1000.0;
+                let (alloc_bytes, alloc_calls) = profile_allocations();
+                let rss_after = process_resident_bytes();
+                let certified_batches = lix_engine::storage_bench::
+                    take_certified_entity_insert_parameter_batch_executions();
+                let physical = lix_engine::storage_bench::take_crud_physical_write_accounting();
+                println!(
+                    "| {} | {} | {} | {:.3} | {} | {} | {} | {} | {} | {} | {} | {} | {} |",
+                    profile.name(),
+                    operation,
+                    sample + 1,
+                    wall_ms,
+                    alloc_bytes,
+                    alloc_calls,
+                    rss_before,
+                    rss_after,
+                    affected,
+                    certified_batches,
+                    physical.puts,
+                    physical.deletes,
+                    physical.written_bytes,
+                );
+            }
+        }
+    }
+}
+
+fn process_resident_bytes() -> u64 {
+    let Ok(status) = std::fs::read_to_string("/proc/self/status") else {
+        return 0;
+    };
+    status
+        .lines()
+        .find_map(|line| line.strip_prefix("VmRSS:"))
+        .and_then(|value| value.split_whitespace().next())
+        .and_then(|value| value.parse::<u64>().ok())
+        .map_or(0, |kilobytes| kilobytes.saturating_mul(1024))
 }
 
 fn maybe_print_io_report(runtime: &Runtime, all_rows: &[PointerRow]) {
@@ -391,7 +642,7 @@ fn maybe_print_io_report(runtime: &Runtime, all_rows: &[PointerRow]) {
 
     for (label, row_count) in workloads {
         let rows = bench_rows(&all_rows[..row_count]);
-        for profile in LIX_STORAGE_PROFILES {
+        for &profile in LIX_STORAGE_PROFILES {
             for operation in [
                 "insert_all_rows",
                 "select_all_rows",
@@ -524,7 +775,7 @@ fn bench_lix(
     label: &str,
 ) {
     let rows = bench_rows(&all_rows[..row_count]);
-    for profile in LIX_STORAGE_PROFILES {
+    for &profile in LIX_STORAGE_PROFILES {
         let mut group =
             c.benchmark_group(format!("untracked_state_crud/{}/{label}", profile.name()));
         configure_group(&mut group, row_count);
@@ -648,7 +899,7 @@ fn bench_session_execute_untracked_insert(
     label: &str,
 ) {
     let rows = all_rows[..row_count].to_vec();
-    for profile in LIX_STORAGE_PROFILES {
+    for &profile in LIX_STORAGE_PROFILES {
         let mut group = c.benchmark_group(format!(
             "untracked_state_crud/session_execute_untracked/{}/{label}",
             profile.name()
@@ -683,6 +934,8 @@ async fn measure_lix_io(profile: LixStorageProfile, operation: &str, rows: &[Ben
     match profile {
         LixStorageProfile::SQLite => measure_lix_io_for_storage(sqlite(), operation, rows).await,
         LixStorageProfile::RocksDB => measure_lix_io_for_storage(rocksdb(), operation, rows).await,
+        #[cfg(feature = "slatedb")]
+        LixStorageProfile::SlateDB => measure_lix_io_for_storage(slatedb(), operation, rows).await,
     }
 }
 
@@ -872,17 +1125,23 @@ fn profile_storage(profile: LixStorageProfile) -> ProfileStorage {
     match profile {
         LixStorageProfile::SQLite => ProfileStorage::SQLite(StorageAdapter::new(sqlite())),
         LixStorageProfile::RocksDB => ProfileStorage::RocksDB(StorageAdapter::new(rocksdb())),
+        #[cfg(feature = "slatedb")]
+        LixStorageProfile::SlateDB => ProfileStorage::SlateDB(StorageAdapter::new(slatedb())),
     }
 }
 
 enum ProfileStorage {
     SQLite(StorageAdapter<TempStorage<SQLite>>),
     RocksDB(StorageAdapter<TempStorage<RocksDB>>),
+    #[cfg(feature = "slatedb")]
+    SlateDB(StorageAdapter<TempStorage<SlateDB>>),
 }
 
 enum ProfileSession {
     SQLite(SessionContext<TempStorage<SQLite>>),
     RocksDB(SessionContext<TempStorage<RocksDB>>),
+    #[cfg(feature = "slatedb")]
+    SlateDB(SessionContext<TempStorage<SlateDB>>),
 }
 
 async fn prepare_profile_session_empty(profile: LixStorageProfile) -> ProfileSession {
@@ -890,6 +1149,10 @@ async fn prepare_profile_session_empty(profile: LixStorageProfile) -> ProfileSes
         LixStorageProfile::SQLite => ProfileSession::SQLite(prepare_session_empty(sqlite()).await),
         LixStorageProfile::RocksDB => {
             ProfileSession::RocksDB(prepare_session_empty(rocksdb()).await)
+        }
+        #[cfg(feature = "slatedb")]
+        LixStorageProfile::SlateDB => {
+            ProfileSession::SlateDB(prepare_session_empty(slatedb()).await)
         }
     }
 }
@@ -937,7 +1200,12 @@ async fn insert_untracked_json_pointer_rows<StorageImpl>(
 ) where
     StorageImpl: Storage + Clone + Send + Sync + 'static,
 {
-    for chunk in rows.chunks(SESSION_INSERT_CHUNK_SIZE) {
+    let chunk_size = std::env::var("LIX_UNTRACKED_STATE_CRUD_PROFILE_CHUNK")
+        .ok()
+        .and_then(|value| value.parse::<usize>().ok())
+        .filter(|size| *size > 0)
+        .unwrap_or(SESSION_INSERT_CHUNK_SIZE);
+    for chunk in rows.chunks(chunk_size) {
         let sql = insert_untracked_json_pointer_sql(chunk);
         let affected = session
             .execute(&sql, &[])
@@ -948,11 +1216,72 @@ async fn insert_untracked_json_pointer_rows<StorageImpl>(
     }
 }
 
+async fn insert_untracked_json_pointer_rows_homogeneous<StorageImpl>(
+    session: &SessionContext<StorageImpl>,
+    rows: &[PointerRow],
+) where
+    StorageImpl: Storage + Clone + Send + Sync + 'static,
+{
+    let parameters = rows
+        .iter()
+        .map(|row| {
+            Arc::<[Value]>::from(vec![
+                Value::Text(row.path.clone()),
+                Value::Text(row.value_json.clone()),
+            ])
+        })
+        .collect::<Vec<_>>();
+    let results = session
+        .execute_homogeneous_write_batch(
+            Arc::<str>::from(
+                "INSERT INTO json_pointer (path, value, lixcol_untracked) VALUES ($1, lix_json($2), true)",
+            ),
+            Arc::from(parameters),
+        )
+        .await
+        .expect("homogeneous insert untracked json_pointer rows");
+    assert_eq!(results.len(), rows.len());
+    assert!(results.iter().all(|result| result.rows_affected() == 1));
+}
+
+async fn update_untracked_json_pointer_rows<StorageImpl>(
+    session: &SessionContext<StorageImpl>,
+    rows: &[PointerRow],
+) where
+    StorageImpl: Storage + Clone + Send + Sync + 'static,
+{
+    let sql = update_untracked_json_pointer_sql(rows);
+    let affected = session
+        .execute(&sql, &[])
+        .await
+        .expect("update untracked json_pointer rows")
+        .rows_affected();
+    assert_eq!(affected as usize, rows.len());
+}
+
+async fn delete_untracked_json_pointer_rows<StorageImpl>(
+    session: &SessionContext<StorageImpl>,
+) -> usize
+where
+    StorageImpl: Storage + Clone + Send + Sync + 'static,
+{
+    session
+        .execute(
+            "DELETE FROM json_pointer WHERE lixcol_untracked = true",
+            &[],
+        )
+        .await
+        .expect("delete untracked json_pointer rows")
+        .rows_affected() as usize
+}
+
 impl ProfileStorage {
     async fn insert_all(&self, rows: &[BenchRow]) -> usize {
         match self {
             Self::SQLite(storage) => lix_insert_all(storage, rows).await,
             Self::RocksDB(storage) => lix_insert_all(storage, rows).await,
+            #[cfg(feature = "slatedb")]
+            Self::SlateDB(storage) => lix_insert_all(storage, rows).await,
         }
     }
 
@@ -960,6 +1289,8 @@ impl ProfileStorage {
         match self {
             Self::SQLite(storage) => lix_update_all(storage, rows).await,
             Self::RocksDB(storage) => lix_update_all(storage, rows).await,
+            #[cfg(feature = "slatedb")]
+            Self::SlateDB(storage) => lix_update_all(storage, rows).await,
         }
     }
 
@@ -967,6 +1298,8 @@ impl ProfileStorage {
         match self {
             Self::SQLite(storage) => lix_delete_one(storage, row).await,
             Self::RocksDB(storage) => lix_delete_one(storage, row).await,
+            #[cfg(feature = "slatedb")]
+            Self::SlateDB(storage) => lix_delete_one(storage, row).await,
         }
     }
 
@@ -974,6 +1307,8 @@ impl ProfileStorage {
         match self {
             Self::SQLite(storage) => lix_delete_all(storage).await,
             Self::RocksDB(storage) => lix_delete_all(storage).await,
+            #[cfg(feature = "slatedb")]
+            Self::SlateDB(storage) => lix_delete_all(storage).await,
         }
     }
 
@@ -981,6 +1316,8 @@ impl ProfileStorage {
         match self {
             Self::SQLite(storage) => lix_select_all(storage, expected_rows, projection).await,
             Self::RocksDB(storage) => lix_select_all(storage, expected_rows, projection).await,
+            #[cfg(feature = "slatedb")]
+            Self::SlateDB(storage) => lix_select_all(storage, expected_rows, projection).await,
         }
     }
 
@@ -988,6 +1325,8 @@ impl ProfileStorage {
         match self {
             Self::SQLite(storage) => lix_select_points(storage, rows).await,
             Self::RocksDB(storage) => lix_select_points(storage, rows).await,
+            #[cfg(feature = "slatedb")]
+            Self::SlateDB(storage) => lix_select_points(storage, rows).await,
         }
     }
 }
@@ -997,6 +1336,41 @@ impl ProfileSession {
         match self {
             Self::SQLite(session) => insert_untracked_json_pointer_rows(session, rows).await,
             Self::RocksDB(session) => insert_untracked_json_pointer_rows(session, rows).await,
+            #[cfg(feature = "slatedb")]
+            Self::SlateDB(session) => insert_untracked_json_pointer_rows(session, rows).await,
+        }
+    }
+
+    async fn insert_untracked_json_pointer_rows_homogeneous(&self, rows: &[PointerRow]) {
+        match self {
+            Self::SQLite(session) => {
+                insert_untracked_json_pointer_rows_homogeneous(session, rows).await;
+            }
+            Self::RocksDB(session) => {
+                insert_untracked_json_pointer_rows_homogeneous(session, rows).await;
+            }
+            #[cfg(feature = "slatedb")]
+            Self::SlateDB(session) => {
+                insert_untracked_json_pointer_rows_homogeneous(session, rows).await;
+            }
+        }
+    }
+
+    async fn update_untracked_json_pointer_rows(&self, rows: &[PointerRow]) {
+        match self {
+            Self::SQLite(session) => update_untracked_json_pointer_rows(session, rows).await,
+            Self::RocksDB(session) => update_untracked_json_pointer_rows(session, rows).await,
+            #[cfg(feature = "slatedb")]
+            Self::SlateDB(session) => update_untracked_json_pointer_rows(session, rows).await,
+        }
+    }
+
+    async fn delete_untracked_json_pointer_rows(&self) -> usize {
+        match self {
+            Self::SQLite(session) => delete_untracked_json_pointer_rows(session).await,
+            Self::RocksDB(session) => delete_untracked_json_pointer_rows(session).await,
+            #[cfg(feature = "slatedb")]
+            Self::SlateDB(session) => delete_untracked_json_pointer_rows(session).await,
         }
     }
 }
@@ -1011,6 +1385,13 @@ fn rocksdb() -> TempStorage<RocksDB> {
     let dir = TempDir::new().expect("create rocksdb storage tempdir");
     let path = dir.path().join("bench.rocksdb");
     TempStorage::new(RocksDB::open(path).expect("open rocksdb storage"), dir)
+}
+
+#[cfg(feature = "slatedb")]
+fn slatedb() -> TempStorage<SlateDB> {
+    let dir = TempDir::new().expect("create slatedb storage tempdir");
+    let path = dir.path().join("bench.slatedb");
+    TempStorage::new(SlateDB::open(path).expect("open slatedb storage"), dir)
 }
 
 fn configure_group(
@@ -1123,6 +1504,16 @@ fn insert_untracked_json_pointer_sql(rows: &[PointerRow]) -> String {
         );
     }
     sql
+}
+
+fn update_untracked_json_pointer_sql(rows: &[PointerRow]) -> String {
+    let value = rows
+        .first()
+        .map_or("{}", |row| row.updated_value_json.as_str());
+    format!(
+        "UPDATE json_pointer SET value = lix_json('{}') WHERE lixcol_untracked = true",
+        sql_string(value)
+    )
 }
 
 fn entity_pk(row: &PointerRow) -> String {

--- a/packages/engine-benchmarks/tests/tracked_state_crud_public_result.rs
+++ b/packages/engine-benchmarks/tests/tracked_state_crud_public_result.rs
@@ -16,8 +16,11 @@ mod workload;
 
 use workload::WorkloadRow;
 
-static CERTIFIED_INSERT_COUNTER_TEST_LOCK: tokio::sync::Mutex<()> =
-    tokio::sync::Mutex::const_new(());
+static PUBLIC_RESULT_TEST_LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
+
+async fn serialized_public_result_test() -> tokio::sync::MutexGuard<'static, ()> {
+    PUBLIC_RESULT_TEST_LOCK.lock().await
+}
 
 #[test]
 fn typed_olap_queries_are_plain_datafusion_selects() {
@@ -50,6 +53,7 @@ fn typed_olap_queries_are_plain_datafusion_selects() {
 
 #[tokio::test]
 async fn typed_olap_shapes_validate_exact_results_on_every_adapter() {
+    let _test_guard = serialized_public_result_test().await;
     let rows = workload::fixture_rows(128);
     for &profile in storage::STORAGE_PROFILES {
         let fixture = sql_session::seeded_olap_fixture(profile, &rows).await;
@@ -73,6 +77,7 @@ async fn typed_olap_shapes_validate_exact_results_on_every_adapter() {
 
 #[tokio::test]
 async fn typed_olap_shapes_validate_above_columnar_publication_threshold() {
+    let _test_guard = serialized_public_result_test().await;
     let rows = workload::fixture_rows(2_048);
     for &profile in storage::STORAGE_PROFILES {
         let fixture = sql_session::seeded_olap_fixture(profile, &rows).await;
@@ -104,7 +109,10 @@ fn typed_olap_shapes_validate_exact_results_after_sparse_and_moderate_mutations(
                 .enable_all()
                 .build()
                 .expect("build post-update OLAP runtime")
-                .block_on(validate_post_update_olap_shapes());
+                .block_on(async {
+                    let _test_guard = serialized_public_result_test().await;
+                    validate_post_update_olap_shapes().await;
+                });
         })
         .expect("spawn post-update OLAP validation thread")
         .join()
@@ -141,7 +149,10 @@ fn standalone_sqlite_public_results_match_every_lix_adapter() {
                 .enable_all()
                 .build()
                 .expect("build parity-test runtime")
-                .block_on(standalone_sqlite_public_results_match_every_lix_adapter_async());
+                .block_on(async {
+                    let _test_guard = serialized_public_result_test().await;
+                    standalone_sqlite_public_results_match_every_lix_adapter_async().await;
+                });
         })
         .expect("spawn parity-test thread")
         .join()
@@ -193,7 +204,7 @@ async fn standalone_sqlite_public_results_match_every_lix_adapter_async() {
 
 #[tokio::test]
 async fn insert_benchmark_hits_certified_parameter_batch_on_every_adapter() {
-    let _counter_guard = CERTIFIED_INSERT_COUNTER_TEST_LOCK.lock().await;
+    let _test_guard = serialized_public_result_test().await;
     let rows = [
         WorkloadRow {
             path: "/alpha".to_string(),
@@ -216,7 +227,7 @@ async fn insert_benchmark_hits_certified_parameter_batch_on_every_adapter() {
 
 #[tokio::test]
 async fn certified_insert_counter_deltas_are_isolated_across_sequential_fixtures() {
-    let _counter_guard = CERTIFIED_INSERT_COUNTER_TEST_LOCK.lock().await;
+    let _test_guard = serialized_public_result_test().await;
     let rows = [WorkloadRow {
         path: "/sequential".to_string(),
         value_json: r#"{"enabled":true}"#.to_string(),
@@ -240,12 +251,41 @@ async fn certified_insert_counter_deltas_are_isolated_across_sequential_fixtures
     assert_eq!(slatedb.insert_all().await, 1);
 }
 
+#[tokio::test]
+async fn certified_insert_counter_deltas_are_isolated_for_concurrent_fixtures() {
+    let rows = [WorkloadRow {
+        path: "/concurrent".to_string(),
+        value_json: r#"{"enabled":true}"#.to_string(),
+        updated_value_json: r#"{"enabled":false}"#.to_string(),
+    }];
+
+    let (sqlite, slatedb) = tokio::join!(
+        insert_one_counter_fixture(storage::StorageProfile::SQLite, &rows),
+        insert_one_counter_fixture(storage::StorageProfile::SlateDB, &rows),
+    );
+    assert_eq!(sqlite, 1);
+    assert_eq!(slatedb, 1);
+}
+
+async fn insert_one_counter_fixture(
+    profile: storage::StorageProfile,
+    rows: &[WorkloadRow],
+) -> usize {
+    // The futures are intentionally joined concurrently. Each fixture owns
+    // the process-global counter snapshot through the entire operation, so
+    // their exact certification=1/execution=1 deltas cannot overlap.
+    let _counter_guard = serialized_public_result_test().await;
+    let fixture =
+        sql_session::empty_fixture_with_read_many_pk_count(profile, rows, rows.len()).await;
+    fixture.insert_all().await
+}
+
 /// Regression for the automatic-write future retaining SlateDB's large
 /// adapter-specific open and commit futures on Tokio's default test stack.
 #[cfg(feature = "slatedb")]
 #[tokio::test]
 async fn slatedb_automatic_write_runs_on_default_stack() {
-    let _counter_guard = CERTIFIED_INSERT_COUNTER_TEST_LOCK.lock().await;
+    let _test_guard = serialized_public_result_test().await;
     let rows = [WorkloadRow {
         path: "/default-stack".to_string(),
         value_json: r#"{"enabled":true}"#.to_string(),

--- a/packages/engine-benchmarks/tests/tracked_state_crud_public_result.rs
+++ b/packages/engine-benchmarks/tests/tracked_state_crud_public_result.rs
@@ -214,6 +214,32 @@ async fn insert_benchmark_hits_certified_parameter_batch_on_every_adapter() {
     }
 }
 
+#[tokio::test]
+async fn certified_insert_counter_deltas_are_isolated_across_sequential_fixtures() {
+    let _counter_guard = CERTIFIED_INSERT_COUNTER_TEST_LOCK.lock().await;
+    let rows = [WorkloadRow {
+        path: "/sequential".to_string(),
+        value_json: r#"{"enabled":true}"#.to_string(),
+        updated_value_json: r#"{"enabled":false}"#.to_string(),
+    }];
+
+    let sqlite = sql_session::empty_fixture_with_read_many_pk_count(
+        storage::StorageProfile::SQLite,
+        &rows,
+        1,
+    )
+    .await;
+    assert_eq!(sqlite.insert_all().await, 1);
+
+    let slatedb = sql_session::empty_fixture_with_read_many_pk_count(
+        storage::StorageProfile::SlateDB,
+        &rows,
+        1,
+    )
+    .await;
+    assert_eq!(slatedb.insert_all().await, 1);
+}
+
 /// Regression for the automatic-write future retaining SlateDB's large
 /// adapter-specific open and commit futures on Tokio's default test stack.
 #[cfg(feature = "slatedb")]

--- a/packages/engine/src/changelog/bench_support.rs
+++ b/packages/engine/src/changelog/bench_support.rs
@@ -229,14 +229,10 @@ pub fn append_ordered_commits(
             .checked_add(offset)
             .ok_or_else(|| LixError::unknown("ordered benchmark commit index overflow"))?;
         append.commits.push(CommitRecord {
-            format_version: 1,
+            format_version: 2,
             commit_id: CommitId::new(ordered_bench_uuid(commit_index, 0)),
             generation: 0,
             parent_commit_ids: Vec::new(),
-            tracked_state_rootless: false,
-            tracked_state_rootless_depth: 0,
-            tracked_state_rootless_rows: 0,
-            tracked_state_rootless_bytes: 0,
             change_id: ChangeId::new(ordered_bench_uuid(commit_index, 1)),
             account_id: crate::ANONYMOUS_ACCOUNT_ID.to_string(),
             created_at: crate::common::LixTimestamp::expect_parse(
@@ -256,14 +252,10 @@ pub fn append_ordered_linear_commits(commit_count: usize) -> Result<BenchAppend,
     for commit_index in 0..commit_count {
         let commit_id = CommitId::new(ordered_bench_uuid(commit_index, 0));
         append.commits.push(CommitRecord {
-            format_version: 1,
+            format_version: 2,
             commit_id,
             generation: u64::try_from(commit_index).expect("benchmark commit index fits u64"),
             parent_commit_ids: parent_commit_id.into_iter().collect(),
-            tracked_state_rootless: false,
-            tracked_state_rootless_depth: 0,
-            tracked_state_rootless_rows: 0,
-            tracked_state_rootless_bytes: 0,
             change_id: ChangeId::new(ordered_bench_uuid(commit_index, 1)),
             account_id: crate::ANONYMOUS_ACCOUNT_ID.to_string(),
             created_at: crate::common::LixTimestamp::expect_parse(
@@ -622,14 +614,10 @@ fn direct_append_with_shape(
             next_change += 1;
         }
         append.commits.push(CommitRecord {
-            format_version: 1,
+            format_version: 2,
             commit_id: typed_commit_id,
             generation: 0,
             parent_commit_ids: Vec::new(),
-            tracked_state_rootless: false,
-            tracked_state_rootless_depth: 0,
-            tracked_state_rootless_rows: 0,
-            tracked_state_rootless_bytes: 0,
             change_id: ChangeId::for_test_label(&commit_change_id),
             account_id: crate::ANONYMOUS_ACCOUNT_ID.to_string(),
             created_at: crate::common::LixTimestamp::expect_parse(

--- a/packages/engine/src/changelog/types.rs
+++ b/packages/engine/src/changelog/types.rs
@@ -313,25 +313,13 @@ pub(crate) struct ChangelogAppend {
 #[derive(Clone, Debug, Eq, PartialEq, musli::Encode, musli::Decode)]
 #[musli(packed)]
 pub(crate) struct CommitRecord {
+    /// Version 2 removes physical replay policy from the semantic commit row.
     pub(crate) format_version: u32,
     pub(crate) commit_id: CommitId,
     /// Longest-path distance from a graph root. Every parent has a strictly
     /// smaller generation, enabling bounded priority graph walks.
     pub(crate) generation: u64,
     pub(crate) parent_commit_ids: Vec<CommitId>,
-    /// Normal serial tracked commits carry all required state in the
-    /// changelog/delta index and intentionally omit an immutable root. Root
-    /// fences remain the topology and checkpoint fallback.
-    pub(crate) tracked_state_rootless: bool,
-    /// First-parent distance from the nearest rooted commit. Zero means this
-    /// commit is rooted; rootless intervals use this to schedule bounded
-    /// automatic root fences without graph walks on the write path.
-    pub(crate) tracked_state_rootless_depth: u16,
-    /// Cumulative delta rows since the nearest rooted first-parent ancestor.
-    /// This bounds foreground replay work independently of commit depth.
-    pub(crate) tracked_state_rootless_rows: u64,
-    /// Conservative encoded/payload work estimate for the same interval.
-    pub(crate) tracked_state_rootless_bytes: u64,
     pub(crate) change_id: ChangeId,
     pub(crate) account_id: String,
     pub(crate) created_at: LixTimestamp,

--- a/packages/engine/src/checkpoint.rs
+++ b/packages/engine/src/checkpoint.rs
@@ -427,14 +427,10 @@ mod tests {
 
     fn commit_record(id: CommitId, generation: u64, parent: Option<CommitId>) -> CommitRecord {
         CommitRecord {
-            format_version: 1,
+            format_version: 2,
             commit_id: id,
             generation,
             parent_commit_ids: parent.into_iter().collect(),
-            tracked_state_rootless: false,
-            tracked_state_rootless_depth: 0,
-            tracked_state_rootless_rows: 0,
-            tracked_state_rootless_bytes: 0,
             change_id: ChangeId::for_test_label(&format!("{id}-change")),
             account_id: crate::ANONYMOUS_ACCOUNT_ID.to_string(),
             created_at: timestamp(),

--- a/packages/engine/src/commit_graph/context.rs
+++ b/packages/engine/src/commit_graph/context.rs
@@ -106,11 +106,11 @@ where
                     commit_ids: &uncached_ids,
                 })
                 .await?;
-            let manifests =
-                crate::tracked_state::load_commit_state_manifests(&self.store, &uncached_ids)
+            let authority_ids =
+                crate::tracked_state::load_commit_state_authority_ids(&self.store, &uncached_ids)
                     .await?;
-            for ((commit_id, record), manifest) in batch.into_iter().zip(manifests) {
-                let node = commit_graph_node_from_authority(*commit_id, record, manifest)?;
+            for ((commit_id, record), authority_id) in batch.into_iter().zip(authority_ids) {
+                let node = commit_graph_node_from_authority(*commit_id, record, authority_id)?;
                 self.node_cache.insert(*commit_id, node);
             }
         }
@@ -141,11 +141,12 @@ where
                 .iter()
                 .map(|record| record.commit_id)
                 .collect::<Vec<_>>();
-            let manifests =
-                crate::tracked_state::load_commit_state_manifests(&self.store, &commit_ids).await?;
-            for (record, manifest) in scan.entries.into_iter().zip(manifests) {
+            let authority_ids =
+                crate::tracked_state::load_commit_state_authority_ids(&self.store, &commit_ids)
+                    .await?;
+            for (record, authority_id) in scan.entries.into_iter().zip(authority_ids) {
                 let commit_id = record.commit_id;
-                let node = commit_graph_node_from_authority(commit_id, Some(record), manifest)?
+                let node = commit_graph_node_from_authority(commit_id, Some(record), authority_id)?
                     .expect("scanned commit projection produces a graph node");
                 self.node_cache.insert(node.commit_id, Some(node.clone()));
                 commits.push(node);
@@ -384,7 +385,7 @@ fn commit_graph_change_from_change_record(change: ChangeRecord) -> CommitGraphCh
 fn commit_graph_node_from_authority(
     commit_id: CommitId,
     record: Option<CommitRecord>,
-    manifest: Option<crate::tracked_state::CommitStateManifest>,
+    authority_id: Option<CommitId>,
 ) -> Result<Option<CommitGraphNode>, LixError> {
     // Public graph membership belongs to the compact changelog projection.
     // GC may retain an immutable manifest after removing that projection so
@@ -392,7 +393,7 @@ fn commit_graph_node_from_authority(
     let Some(record) = record else {
         return Ok(None);
     };
-    let Some(manifest) = manifest else {
+    let Some(authority_id) = authority_id else {
         return Err(LixError::new(
             LixError::CODE_INTERNAL_ERROR,
             format!(
@@ -400,7 +401,7 @@ fn commit_graph_node_from_authority(
             ),
         ));
     };
-    if record.commit_id != manifest.commit_id {
+    if record.commit_id != authority_id {
         return Err(LixError::new(
             LixError::CODE_INTERNAL_ERROR,
             format!(

--- a/packages/engine/src/commit_graph/context.rs
+++ b/packages/engine/src/commit_graph/context.rs
@@ -24,12 +24,17 @@ use crate::entity_pk::EntityPk;
 use crate::storage_adapter::StorageAdapterRead;
 
 const COMMIT_SCHEMA_KEY: &str = "lix_commit";
-/// Read model for resolving authoritative commit manifests into entity state
-/// at a head.
+/// Read model for resolving changelog commit facts at a head.
 ///
-/// The changelog commit plane is a compact serving projection. Every graph
-/// read validates it against the commit-state manifest before exposing
-/// topology.
+/// The commit graph owns semantic commit metadata. Physical tracked-state
+/// manifests are required by state/history payload readers, but GC may retire
+/// those manifests while retaining a changelog projection until the semantic
+/// commit itself becomes unreachable. Metadata reads must therefore not make
+/// the physical serving manifest a second membership authority.
+///
+/// The changelog commit plane is a compact serving projection. State/history
+/// payload readers validate physical commit-state authority before decoding
+/// tracked data; metadata topology does not require that physical projection.
 #[derive(Clone)]
 pub(crate) struct CommitGraphContext;
 
@@ -388,20 +393,14 @@ fn commit_graph_node_from_authority(
     authority_id: Option<CommitId>,
 ) -> Result<Option<CommitGraphNode>, LixError> {
     // Public graph membership belongs to the compact changelog projection.
-    // GC may retain an immutable manifest after removing that projection so
-    // selected payloads remain addressable for recovery.
+    // A physical manifest is an independent serving/replay authority. Its
+    // absence is handled by payload/state readers, not by metadata membership.
     let Some(record) = record else {
         return Ok(None);
     };
-    let Some(authority_id) = authority_id else {
-        return Err(LixError::new(
-            LixError::CODE_INTERNAL_ERROR,
-            format!(
-                "commit_graph projection for commit '{commit_id}' has no commit-state authority"
-            ),
-        ));
-    };
-    if record.commit_id != authority_id {
+    if let Some(authority_id) = authority_id
+        && record.commit_id != authority_id
+    {
         return Err(LixError::new(
             LixError::CODE_INTERNAL_ERROR,
             format!(
@@ -690,7 +689,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn load_node_rejects_projection_without_commit_state_authority() {
+    async fn load_node_serves_projection_without_commit_state_authority() {
         let storage = StorageAdapter::new(Memory::new());
         append_changes(
             &storage,
@@ -719,12 +718,13 @@ mod tests {
             .begin_read(StorageReadOptions::default())
             .await
             .expect("read should open");
-        let error = CommitGraphContext::new()
+        let node = CommitGraphContext::new()
             .reader(read)
             .load_node(&commit_id)
             .await
-            .expect_err("a changelog projection cannot replace missing authority");
-        assert!(error.message.contains("has no commit-state authority"));
+            .expect("commit metadata should remain readable")
+            .expect("changelog projection should produce a node");
+        assert_eq!(node.commit_id, commit_id);
     }
 
     #[tokio::test]

--- a/packages/engine/src/commit_graph/context.rs
+++ b/packages/engine/src/commit_graph/context.rs
@@ -400,18 +400,7 @@ fn commit_graph_node_from_authority(
             ),
         ));
     };
-    let manifest_rootless = manifest.replay_debt.depth > 0;
-    if record.commit_id != manifest.commit_id
-        || record.generation != manifest.generation
-        || record.parent_commit_ids != manifest.parent_commit_ids
-        || record.change_id != manifest.commit_change_id
-        || record.account_id != manifest.account_id
-        || record.created_at != manifest.created_at
-        || record.tracked_state_rootless != manifest_rootless
-        || record.tracked_state_rootless_depth != manifest.replay_debt.depth
-        || record.tracked_state_rootless_rows != manifest.replay_debt.rows
-        || record.tracked_state_rootless_bytes != manifest.replay_debt.bytes
-    {
+    if record.commit_id != manifest.commit_id {
         return Err(LixError::new(
             LixError::CODE_INTERNAL_ERROR,
             format!(
@@ -420,12 +409,12 @@ fn commit_graph_node_from_authority(
         ));
     }
     Ok(Some(CommitGraphNode {
-        commit_id: manifest.commit_id,
-        change_id: manifest.commit_change_id,
-        account_id: manifest.account_id,
-        generation: manifest.generation,
-        parent_commit_ids: manifest.parent_commit_ids,
-        created_at: manifest.created_at,
+        commit_id: record.commit_id,
+        change_id: record.change_id,
+        account_id: record.account_id,
+        generation: record.generation,
+        parent_commit_ids: record.parent_commit_ids,
+        created_at: record.created_at,
     }))
 }
 
@@ -660,11 +649,7 @@ mod tests {
             &mut writes,
             &CommitStateManifest {
                 commit_id,
-                generation: 0,
-                parent_commit_ids: Vec::new(),
-                commit_change_id: change_id("retained-payload-authority-change"),
-                account_id: crate::ANONYMOUS_ACCOUNT_ID.to_string(),
-                created_at: ts("2026-01-01T00:00:00Z"),
+                change_account_id: crate::ANONYMOUS_ACCOUNT_ID.to_string(),
                 replay_debt: CommitStateReplayDebt {
                     depth: 1,
                     rows: 0,
@@ -724,12 +709,6 @@ mod tests {
                 commit_id.as_uuid().as_bytes(),
             )),
         );
-        writes.delete(
-            crate::tracked_state::TRACKED_STATE_COMMIT_STATE_SEAL_SPACE,
-            StorageKey(bytes::Bytes::copy_from_slice(
-                commit_id.as_uuid().as_bytes(),
-            )),
-        );
         storage
             .commit_write_set(writes, StorageWriteOptions::default())
             .await
@@ -745,50 +724,6 @@ mod tests {
             .await
             .expect_err("a changelog projection cannot replace missing authority");
         assert!(error.message.contains("has no commit-state authority"));
-    }
-
-    #[tokio::test]
-    async fn load_node_rejects_changelog_projection_drift() {
-        let storage = StorageAdapter::new(Memory::new());
-        append_changes(
-            &storage,
-            &[commit_change(
-                "drift-authority-change",
-                "drift-authority",
-                &[],
-                &[],
-            )],
-        )
-        .await;
-        let commit_id = commit_id("drift-authority");
-        let read = storage
-            .begin_read(StorageReadOptions::default())
-            .await
-            .expect("authority read should open");
-        let mut manifest = crate::tracked_state::load_commit_state_manifest(&read, commit_id)
-            .await
-            .expect("authority should load")
-            .expect("authority should exist");
-        drop(read);
-        manifest.commit_change_id = change_id("different-authority-change");
-        let mut writes = storage.new_write_set();
-        crate::tracked_state::stage_resealed_commit_state_manifest_for_test(&mut writes, &manifest)
-            .expect("drifted but structurally valid authority should stage");
-        storage
-            .commit_write_set(writes, StorageWriteOptions::default())
-            .await
-            .expect("drifted authority should commit");
-
-        let read = storage
-            .begin_read(StorageReadOptions::default())
-            .await
-            .expect("read should open");
-        let error = CommitGraphContext::new()
-            .reader(read)
-            .load_node(&commit_id)
-            .await
-            .expect_err("projection drift must fail closed");
-        assert!(error.message.contains("projection disagrees"));
     }
 
     #[tokio::test]
@@ -997,14 +932,10 @@ mod tests {
             .stage_append(ChangelogAppend {
                 changes: Vec::new(),
                 commits: vec![CommitRecord {
-                    format_version: 1,
+                    format_version: 2,
                     commit_id,
                     generation: 0,
                     parent_commit_ids: Vec::new(),
-                    tracked_state_rootless: true,
-                    tracked_state_rootless_depth: 1,
-                    tracked_state_rootless_rows: 3,
-                    tracked_state_rootless_bytes: 0,
                     change_id: change_id("selected-tombstone-commit-change"),
                     account_id: crate::ANONYMOUS_ACCOUNT_ID.to_string(),
                     created_at,
@@ -1071,11 +1002,7 @@ mod tests {
             &mut writes,
             &CommitStateManifest {
                 commit_id,
-                generation: 0,
-                parent_commit_ids: Vec::new(),
-                commit_change_id: change_id("selected-tombstone-commit-change"),
-                account_id: crate::ANONYMOUS_ACCOUNT_ID.to_string(),
-                created_at,
+                change_account_id: crate::ANONYMOUS_ACCOUNT_ID.to_string(),
                 replay_debt: CommitStateReplayDebt {
                     depth: 1,
                     rows: 3,
@@ -1504,16 +1431,10 @@ mod tests {
             }
 
             append.commits.push(CommitRecord {
-                format_version: 1,
+                format_version: 2,
                 commit_id,
                 generation,
                 parent_commit_ids: change.parent_commit_ids.clone(),
-                tracked_state_rootless: true,
-                tracked_state_rootless_depth: u16::try_from(generation + 1)
-                    .expect("test commit generation should fit replay depth"),
-                tracked_state_rootless_rows: u64::try_from(members.len())
-                    .expect("test member count should fit u64"),
-                tracked_state_rootless_bytes: 0,
                 change_id: change.change.id,
                 account_id: crate::ANONYMOUS_ACCOUNT_ID.to_string(),
                 created_at: change.change.created_at,
@@ -1576,15 +1497,12 @@ mod tests {
             writes,
             &CommitStateManifest {
                 commit_id: record.commit_id,
-                generation: record.generation,
-                parent_commit_ids: record.parent_commit_ids.clone(),
-                commit_change_id: record.change_id,
-                account_id: record.account_id.clone(),
-                created_at: record.created_at,
+                change_account_id: record.account_id.clone(),
                 replay_debt: CommitStateReplayDebt {
-                    depth: record.tracked_state_rootless_depth,
-                    rows: record.tracked_state_rootless_rows,
-                    bytes: record.tracked_state_rootless_bytes,
+                    depth: u16::try_from(record.generation + 1)
+                        .expect("test generation should fit replay depth"),
+                    rows: u64::from(mutations.member_count),
+                    bytes: 0,
                 },
                 mutations,
                 touched_scope_filter: Default::default(),
@@ -1598,14 +1516,10 @@ mod tests {
     fn append_empty_commit(append: &mut ChangelogAppend, commit_id: CommitId) {
         let change_id = format!("{commit_id}-change");
         append.commits.push(CommitRecord {
-            format_version: 1,
+            format_version: 2,
             commit_id,
             generation: 0,
             parent_commit_ids: Vec::new(),
-            tracked_state_rootless: true,
-            tracked_state_rootless_depth: 1,
-            tracked_state_rootless_rows: 0,
-            tracked_state_rootless_bytes: 0,
             change_id: ChangeId::for_test_label(&change_id),
             account_id: crate::ANONYMOUS_ACCOUNT_ID.to_string(),
             created_at: ts("2026-01-01T00:00:00Z"),

--- a/packages/engine/src/commit_graph/walker.rs
+++ b/packages/engine/src/commit_graph/walker.rs
@@ -355,14 +355,10 @@ mod tests {
             crate::changelog::COMMIT_SPACE,
             StorageKey(Bytes::copy_from_slice(requested.as_uuid().as_bytes())),
             crate::changelog::encode_commit_record(&CommitRecord {
-                format_version: 1,
+                format_version: 2,
                 commit_id: embedded,
                 generation: 0,
                 parent_commit_ids: Vec::new(),
-                tracked_state_rootless: false,
-                tracked_state_rootless_depth: 0,
-                tracked_state_rootless_rows: 0,
-                tracked_state_rootless_bytes: 0,
                 change_id: ChangeId::for_test_label("mismatched-key-change"),
                 account_id: crate::ANONYMOUS_ACCOUNT_ID.to_string(),
                 created_at: ts("2026-01-01T00:00:00Z"),
@@ -398,14 +394,10 @@ mod tests {
         for (label, parent) in [("commit-a", "commit-b"), ("commit-b", "commit-a")] {
             let commit_id = commit_id(label);
             let record = CommitRecord {
-                format_version: 1,
+                format_version: 2,
                 commit_id,
                 generation: 1,
                 parent_commit_ids: commit_ids([parent]),
-                tracked_state_rootless: true,
-                tracked_state_rootless_depth: 1,
-                tracked_state_rootless_rows: 0,
-                tracked_state_rootless_bytes: 0,
                 change_id: ChangeId::for_test_label(&format!("{label}-change")),
                 account_id: crate::ANONYMOUS_ACCOUNT_ID.to_string(),
                 created_at: ts("2026-01-01T00:00:00Z"),
@@ -692,14 +684,10 @@ mod tests {
         let child = commit_id("commit-child");
         let mut writes = storage.new_write_set();
         let record = CommitRecord {
-            format_version: 1,
+            format_version: 2,
             commit_id: child,
             generation: 0,
             parent_commit_ids: commit_ids(["commit-root"]),
-            tracked_state_rootless: true,
-            tracked_state_rootless_depth: 2,
-            tracked_state_rootless_rows: 0,
-            tracked_state_rootless_bytes: 0,
             change_id: ChangeId::for_test_label("commit-child-change"),
             account_id: crate::ANONYMOUS_ACCOUNT_ID.to_string(),
             created_at: ts("2026-01-01T00:00:00Z"),
@@ -1021,15 +1009,10 @@ mod tests {
                 .map_or(0, |parent_generation| parent_generation + 1);
             let typed_commit_id = CommitId::for_test_label(&commit_id);
             append.commits.push(CommitRecord {
-                format_version: 1,
+                format_version: 2,
                 commit_id: typed_commit_id,
                 generation,
                 parent_commit_ids,
-                tracked_state_rootless: true,
-                tracked_state_rootless_depth: u16::try_from(generation + 1)
-                    .expect("test generation should fit replay depth"),
-                tracked_state_rootless_rows: 0,
-                tracked_state_rootless_bytes: 0,
                 change_id: change.change.id,
                 account_id: crate::ANONYMOUS_ACCOUNT_ID.to_string(),
                 created_at: change.change.created_at,
@@ -1059,15 +1042,12 @@ mod tests {
             writes,
             &CommitStateManifest {
                 commit_id: record.commit_id,
-                generation: record.generation,
-                parent_commit_ids: record.parent_commit_ids.clone(),
-                commit_change_id: record.change_id,
-                account_id: record.account_id.clone(),
-                created_at: record.created_at,
+                change_account_id: record.account_id.clone(),
                 replay_debt: CommitStateReplayDebt {
-                    depth: record.tracked_state_rootless_depth,
-                    rows: record.tracked_state_rootless_rows,
-                    bytes: record.tracked_state_rootless_bytes,
+                    depth: u16::try_from(record.generation + 1)
+                        .expect("test generation should fit replay depth"),
+                    rows: 0,
+                    bytes: 0,
                 },
                 mutations: CommitStateMutationInventory::default(),
                 touched_scope_filter: Default::default(),

--- a/packages/engine/src/engine.rs
+++ b/packages/engine/src/engine.rs
@@ -309,9 +309,10 @@ where
     /// This is intentionally an engine-level operation: callers should not need
     /// to know which KV namespaces back changelog, commit graph, or tracked
     /// state. The current branch head is read from the live-state facade so
-    /// rebuild uses the same moving-ref visibility as normal execution. The
-    /// rebuilt root receives the full changelog coverage audit against its
-    /// staged chunks before the replacement root is published.
+    /// rebuild uses the same moving-ref visibility as normal execution. Rooted
+    /// heads restore content-addressed chunks only after their immutable root
+    /// metadata passes a full changelog coverage audit. Rootless heads receive
+    /// the same audit transiently and remain bounded-replay layouts.
     pub async fn rebuild_tracked_state_for_branch(&self, branch_id: &str) -> Result<(), LixError> {
         let head_commit_id = self
             .load_branch_head_commit_id(branch_id)
@@ -330,7 +331,7 @@ where
             &head_commit_id,
             "tracked-state branch rebuild authority",
         )?;
-        crate::tracked_state::load_commit_state_manifest(
+        let manifest = crate::tracked_state::load_commit_state_manifest(
             &read,
             typed_head_commit_id,
         )
@@ -350,10 +351,15 @@ where
             .rebuild_commit_root_at(&head_commit_id)
             .await;
         rebuild_result?;
-        // A healthy rebuild is content-equivalent, but this API also repairs a
-        // stale or damaged serving root. Conservatively invalidate transaction
-        // opening catalogs so repaired registered-schema facts are never hidden
-        // behind a pre-rebuild cache entry.
+        if manifest.snapshot_root.is_none() {
+            // Rootless heads are audited transiently and remain replay-only;
+            // there is no serving-root publication or cache state to commit.
+            return Ok(());
+        }
+        // A healthy rebuild is content-equivalent, but this API also repairs
+        // missing or damaged serving chunks. Conservatively invalidate
+        // transaction opening catalogs so restored registered-schema facts are
+        // never hidden behind a pre-rebuild cache entry.
         crate::catalog::stage_catalog_revision(&mut writes);
         storage
             .commit_write_set(writes, StorageWriteOptions::default())

--- a/packages/engine/src/gc.rs
+++ b/packages/engine/src/gc.rs
@@ -2720,6 +2720,14 @@ mod tests {
         let before = before_changes.len();
         assert!(after < before, "deleted branch refs should be reclaimed");
 
+        drop(session);
+        let reopened_engine = Engine::new(storage.clone())
+            .await
+            .expect("repository should reopen after GC");
+        let session = reopened_engine
+            .open_workspace_session()
+            .await
+            .expect("reopened workspace session should open");
         let head = session
             .execute("SELECT commit_id FROM lix_branch WHERE name = 'main'", &[])
             .await

--- a/packages/engine/src/gc.rs
+++ b/packages/engine/src/gc.rs
@@ -11,21 +11,26 @@ use std::time::Instant;
 use bytes::Bytes;
 
 use crate::branch::BranchHeadControlContext;
-#[cfg(test)]
-use crate::changelog::ChangeRecord;
 use crate::changelog::{
-    CHANGE_SPACE, COMMIT_CHANGE_ID_SPACE, COMMIT_SPACE, ChangeId, ChangeScanRequest,
-    ChangelogContext, ChangelogReader, CommitId, CommitScanRequest, GcLiveSet, GcPlan, GcRepairSet,
-    GcRoot, GcSweepSet, change_key, commit_change_id_key, commit_key,
+    CHANGE_SPACE, ChangeId, ChangeScanRequest, ChangelogContext, ChangelogReader, CommitId,
+    GcLiveSet, GcPlan, GcRepairSet, GcRoot, GcSweepSet, change_key,
+};
+#[cfg(test)]
+use crate::changelog::{
+    COMMIT_CHANGE_ID_SPACE, COMMIT_SPACE, ChangeRecord, CommitScanRequest, commit_change_id_key,
+    commit_key,
 };
 use crate::commit_graph::CommitGraphContext;
+#[cfg(test)]
 use crate::json_store::JsonRef;
 #[cfg(test)]
 use crate::json_store::{
     JsonSlot, JsonStoreContext, JsonStoreWriter, UntrackedJsonReclaimCandidate,
 };
 #[cfg(test)]
-use crate::live_state::{TrackedHeadContext, stage_collect_stale_working_diff_indexes};
+use crate::live_state::TrackedHeadContext;
+#[cfg(test)]
+use crate::live_state::stage_collect_stale_working_diff_indexes;
 use crate::storage_adapter::{
     PointReadPlan, ScanPlan, StorageAdapterRead, StorageCoreProjection, StorageGetOptions,
     StorageKey, StoragePrecondition, StoragePrefix, StorageProjectedValue, StorageScanOptions,
@@ -1088,6 +1093,7 @@ where
             }
         }
     }
+    validate_live_native_parts(&store, &active_current_parts).await?;
     let active_ids = active_manifests.keys().copied().collect::<Vec<_>>();
     let mutation_roots =
         crate::tracked_state::load_commit_mutation_directory_roots(&store, &active_ids).await?;
@@ -1175,9 +1181,11 @@ where
                 }
             }
             if let Some(root) = manifest.current_state_scoped_ranges.as_ref() {
-                let reachable =
-                    crate::tracked_state::validate_scoped_range_trees(&store, &[root.tree.clone()])
-                        .await?;
+                let reachable = crate::tracked_state::validate_scoped_range_trees(
+                    &store,
+                    std::slice::from_ref(&root.tree),
+                )
+                .await?;
                 for node_id in reachable.node_ids.difference(&active_scoped_nodes) {
                     writes.delete(
                         crate::tracked_state::SCOPED_RANGE_NODE_SPACE,
@@ -1301,6 +1309,46 @@ where
             total_us: elapsed_micros(started),
         },
     })
+}
+
+/// Every authenticated active scoped-range descriptor must have its native
+/// payload present before ordinary GC is allowed to stage any sweep.  The
+/// descriptor is authority for the digest, but not proof that the immutable
+/// payload still exists; treating a missing payload as an empty live set would
+/// silently turn corruption into deletion.
+async fn validate_live_native_parts<S>(
+    store: &S,
+    digests: &BTreeSet<[u8; 32]>,
+) -> Result<(), LixError>
+where
+    S: StorageAdapterRead + ?Sized,
+{
+    if digests.is_empty() {
+        return Ok(());
+    }
+    let keys = digests
+        .iter()
+        .map(|digest| StorageKey(Bytes::copy_from_slice(digest)))
+        .collect::<Vec<_>>();
+    let presence = PointReadPlan::new(crate::tracked_state::CURRENT_STATE_DATA_PART_SPACE, &keys)
+        .materialize(
+            store,
+            StorageGetOptions {
+                projection: StorageCoreProjection::KeyOnly,
+            },
+        )
+        .await?;
+    if presence
+        .value
+        .into_iter()
+        .any(|value| !matches!(value, Some(StorageProjectedValue::KeyOnly)))
+    {
+        return Err(LixError::new(
+            LixError::CODE_INTERNAL_ERROR,
+            "live current-state directory references a missing native data part",
+        ));
+    }
+    Ok(())
 }
 
 /// Recovery-only verifier retained for explicit rebuild tooling and tests.

--- a/packages/engine/src/gc.rs
+++ b/packages/engine/src/gc.rs
@@ -887,6 +887,41 @@ where
             ),
         ));
     }
+    let retained_authority_ids = retained_authority_commits
+        .iter()
+        .copied()
+        .collect::<Vec<_>>();
+    let retained_mutation_roots =
+        crate::tracked_state::load_commit_mutation_directory_roots(store, &retained_authority_ids)
+            .await?;
+    let mut unique_mutation_roots = BTreeMap::new();
+    for (commit_id, root) in retained_authority_ids
+        .into_iter()
+        .zip(retained_mutation_roots)
+    {
+        if !packed.commits.contains_key(&commit_id) {
+            return Err(LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                format!("retained mutation authority '{commit_id}' is missing"),
+            ));
+        }
+        let Some(root) = root else {
+            continue;
+        };
+        if let Some(previous) = unique_mutation_roots.insert(root.root_id, root.clone())
+            && previous != root
+        {
+            return Err(LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                "retained mutation authorities disagree about a shared directory root",
+            ));
+        }
+    }
+    let mut live_mutation_directory_nodes = BTreeSet::new();
+    for root in unique_mutation_roots.values() {
+        live_mutation_directory_nodes
+            .extend(crate::tracked_state::collect_mutation_directory_node_ids(store, root).await?);
+    }
     let sweep_authority_commits = packed
         .commits
         .keys()
@@ -1022,6 +1057,13 @@ where
         writes,
         crate::tracked_state::SCOPED_RANGE_NODE_SPACE,
         &live_scoped_range_nodes,
+    )
+    .await?;
+    stage_sweep_unreachable_content_nodes(
+        store,
+        writes,
+        crate::tracked_state::MUTATION_DIRECTORY_NODE_SPACE,
+        &live_mutation_directory_nodes,
     )
     .await?;
     stage_sweep_unreachable_content_nodes(
@@ -1337,6 +1379,7 @@ mod tests {
         let mut writes = storage.new_write_set();
         for space in [
             crate::tracked_state::SCOPED_RANGE_NODE_SPACE,
+            crate::tracked_state::MUTATION_DIRECTORY_NODE_SPACE,
             crate::tracked_state::CURRENT_STATE_DATA_PART_SPACE,
             crate::tracked_state::CURRENT_STATE_DATA_PART_REFS_SPACE,
         ] {
@@ -1362,6 +1405,7 @@ mod tests {
         let live = BTreeSet::from([live_id]);
         for space in [
             crate::tracked_state::SCOPED_RANGE_NODE_SPACE,
+            crate::tracked_state::MUTATION_DIRECTORY_NODE_SPACE,
             crate::tracked_state::CURRENT_STATE_DATA_PART_SPACE,
             crate::tracked_state::CURRENT_STATE_DATA_PART_REFS_SPACE,
         ] {
@@ -1384,6 +1428,7 @@ mod tests {
         ];
         for space in [
             crate::tracked_state::SCOPED_RANGE_NODE_SPACE,
+            crate::tracked_state::MUTATION_DIRECTORY_NODE_SPACE,
             crate::tracked_state::CURRENT_STATE_DATA_PART_SPACE,
             crate::tracked_state::CURRENT_STATE_DATA_PART_REFS_SPACE,
         ] {

--- a/packages/engine/src/gc.rs
+++ b/packages/engine/src/gc.rs
@@ -593,37 +593,17 @@ where
         pending.extend(commits.parent_commit_ids(commit).iter().copied());
     }
 
-    // GC is destructive, so the hard-cut commit-state manifest must be
-    // present and agree with every live changelog topology projection before
-    // payload reachability or sweep mutations are derived. Missing authority
-    // must not silently turn a live commit into an empty mutation owner.
+    // GC is destructive, so every live semantic commit must have an immutable
+    // physical manifest before payload reachability or sweep mutations are
+    // derived. Missing physical authority must not silently turn a live commit
+    // into an empty mutation owner.
     for commit_id in &live_commits {
-        let commit = commits
-            .get(*commit_id)
-            .expect("live commit existence was checked during graph walk");
-        let authority = packed.commits.get(commit_id).ok_or_else(|| {
+        packed.commits.get(commit_id).ok_or_else(|| {
             LixError::new(
                 LixError::CODE_INTERNAL_ERROR,
                 format!("live commit '{commit_id}' has no commit-state authority"),
             )
         })?;
-        let topology = &authority.authority;
-        let manifest_rootless = topology.replay_debt.depth > 0;
-        if topology.generation != commit.generation
-            || topology.parent_commit_ids != commits.parent_commit_ids(commit)
-            || topology.commit_change_id != commit.change_id
-            || topology.account_id != commit.account_id
-            || topology.created_at != commit.created_at
-            || manifest_rootless != commit.tracked_state_rootless
-            || topology.replay_debt.depth != commit.tracked_state_rootless_depth
-            || topology.replay_debt.rows != commit.tracked_state_rootless_rows
-            || topology.replay_debt.bytes != commit.tracked_state_rootless_bytes
-        {
-            return Err(LixError::new(
-                LixError::CODE_INTERNAL_ERROR,
-                format!("live commit '{commit_id}' disagrees with its commit-state authority"),
-            ));
-        }
     }
 
     // Mutation parts are immutable: direct ChangeIds encode their physical
@@ -1116,14 +1096,7 @@ where
 #[derive(Clone, Debug)]
 struct GcCommitInventoryEntry {
     commit_id: CommitId,
-    generation: u64,
-    tracked_state_rootless: bool,
-    tracked_state_rootless_depth: u16,
-    tracked_state_rootless_rows: u64,
-    tracked_state_rootless_bytes: u64,
     change_id: ChangeId,
-    account_id: String,
-    created_at: crate::common::LixTimestamp,
     parent_start: usize,
     parent_len: usize,
 }
@@ -1186,14 +1159,7 @@ where
                 .extend(commit.parent_commit_ids.into_iter());
             commits.entries.push(GcCommitInventoryEntry {
                 commit_id: commit.commit_id,
-                generation: commit.generation,
-                tracked_state_rootless: commit.tracked_state_rootless,
-                tracked_state_rootless_depth: commit.tracked_state_rootless_depth,
-                tracked_state_rootless_rows: commit.tracked_state_rootless_rows,
-                tracked_state_rootless_bytes: commit.tracked_state_rootless_bytes,
                 change_id: commit.change_id,
-                account_id: commit.account_id,
-                created_at: commit.created_at,
                 parent_start,
                 parent_len,
             });
@@ -1711,73 +1677,6 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn authority_gc_rejects_live_topology_drift_before_staging_deletes() {
-        let storage = StorageAdapter::new(Memory::new());
-        let live = gc_authority_record("gc-live-authority-drift");
-        let mut read = storage
-            .begin_read(StorageReadOptions::default())
-            .await
-            .expect("authority-drift fixture read should open");
-        let mut writes = storage.new_write_set();
-        ChangelogContext::new()
-            .writer(&mut read, &mut writes)
-            .stage_append(ChangelogAppend {
-                commits: vec![live.clone()],
-                changes: Vec::new(),
-            })
-            .await
-            .expect("authority-drift commit should stage");
-        let mut drifted = CommitStateManifest {
-            commit_id: live.commit_id,
-            generation: live.generation,
-            parent_commit_ids: live.parent_commit_ids.clone(),
-            commit_change_id: live.change_id,
-            account_id: live.account_id.clone(),
-            created_at: live.created_at,
-            replay_debt: CommitStateReplayDebt {
-                depth: live.tracked_state_rootless_depth,
-                rows: live.tracked_state_rootless_rows,
-                bytes: live.tracked_state_rootless_bytes,
-            },
-            mutations: CommitStateMutationInventory::default(),
-            touched_scope_filter: Default::default(),
-            current_state_scoped_ranges: None,
-            snapshot_root: None,
-        };
-        drifted.generation += 1;
-        stage_commit_state_manifest(&mut writes, &drifted)
-            .expect("internally valid but projection-drifted authority should stage");
-        storage
-            .commit_write_set(writes, StorageWriteOptions::default())
-            .await
-            .expect("authority-drift fixture should commit");
-
-        let read = SharedStorageAdapterRead::new(
-            storage
-                .begin_read(StorageReadOptions::default())
-                .await
-                .expect("authority-drift GC read should open"),
-        );
-        let mut gc_writes = storage.new_write_set();
-        let error = super::plan_and_stage_authority_gc(
-            &read,
-            &mut gc_writes,
-            &[GcRoot::BranchHead(live.commit_id)],
-        )
-        .await
-        .expect_err("GC must reject topology projection drift");
-        assert!(
-            error
-                .message
-                .contains("disagrees with its commit-state authority")
-        );
-        assert!(
-            gc_writes.is_empty(),
-            "authority validation must precede every destructive GC mutation"
-        );
-    }
-
-    #[tokio::test]
     async fn authority_gc_retains_tombstone_only_checkpoint_alias_source() {
         let storage = Memory::new();
         let storage_adapter = StorageAdapter::new(storage);
@@ -1799,53 +1698,37 @@ mod tests {
             LixTimestamp::expect_parse("tombstone alias timestamp", "2026-01-01T00:00:00Z");
         let commits = [
             CommitRecord {
-                format_version: 1,
+                format_version: 2,
                 commit_id: source_commit,
                 generation: 0,
                 parent_commit_ids: Vec::new(),
-                tracked_state_rootless: true,
-                tracked_state_rootless_depth: 1,
-                tracked_state_rootless_rows: 1,
-                tracked_state_rootless_bytes: 1,
                 change_id: ChangeId::for_test_label("gc-tombstone-alias-source-header"),
                 account_id: crate::ANONYMOUS_ACCOUNT_ID.to_string(),
                 created_at: timestamp,
             },
             CommitRecord {
-                format_version: 1,
+                format_version: 2,
                 commit_id: alias_commit,
                 generation: 0,
                 parent_commit_ids: Vec::new(),
-                tracked_state_rootless: true,
-                tracked_state_rootless_depth: 1,
-                tracked_state_rootless_rows: 1,
-                tracked_state_rootless_bytes: 1,
                 change_id: ChangeId::for_test_label("gc-tombstone-alias-live-header"),
                 account_id: crate::ANONYMOUS_ACCOUNT_ID.to_string(),
                 created_at: timestamp,
             },
             CommitRecord {
-                format_version: 1,
+                format_version: 2,
                 commit_id: authority_commit,
                 generation: 0,
                 parent_commit_ids: Vec::new(),
-                tracked_state_rootless: true,
-                tracked_state_rootless_depth: 1,
-                tracked_state_rootless_rows: 1,
-                tracked_state_rootless_bytes: 1,
                 change_id: ChangeId::for_test_label("gc-tombstone-alias-authority-header"),
                 account_id: crate::ANONYMOUS_ACCOUNT_ID.to_string(),
                 created_at: timestamp,
             },
             CommitRecord {
-                format_version: 1,
+                format_version: 2,
                 commit_id: live_head,
                 generation: 1,
                 parent_commit_ids: vec![alias_commit, authority_commit],
-                tracked_state_rootless: true,
-                tracked_state_rootless_depth: 2,
-                tracked_state_rootless_rows: 2,
-                tracked_state_rootless_bytes: 2,
                 change_id: ChangeId::for_test_label("gc-tombstone-alias-head-header"),
                 account_id: crate::ANONYMOUS_ACCOUNT_ID.to_string(),
                 created_at: timestamp,
@@ -2058,40 +1941,28 @@ mod tests {
             LixTimestamp::expect_parse("authority GC timestamp", "2026-01-01T00:00:00.000Z");
         let commits = vec![
             CommitRecord {
-                format_version: 1,
+                format_version: 2,
                 commit_id: live_parent,
                 generation: 0,
                 parent_commit_ids: Vec::new(),
-                tracked_state_rootless: true,
-                tracked_state_rootless_depth: 1,
-                tracked_state_rootless_rows: 1,
-                tracked_state_rootless_bytes: 1,
                 change_id: ChangeId::for_test_label("authority-gc-live-parent-header"),
                 account_id: crate::ANONYMOUS_ACCOUNT_ID.to_string(),
                 created_at: timestamp,
             },
             CommitRecord {
-                format_version: 1,
+                format_version: 2,
                 commit_id: live_head,
                 generation: 1,
                 parent_commit_ids: vec![live_parent],
-                tracked_state_rootless: true,
-                tracked_state_rootless_depth: 2,
-                tracked_state_rootless_rows: 2,
-                tracked_state_rootless_bytes: 2,
                 change_id: ChangeId::for_test_label("authority-gc-live-head-header"),
                 account_id: crate::ANONYMOUS_ACCOUNT_ID.to_string(),
                 created_at: timestamp,
             },
             CommitRecord {
-                format_version: 1,
+                format_version: 2,
                 commit_id: dead_commit,
                 generation: 0,
                 parent_commit_ids: Vec::new(),
-                tracked_state_rootless: true,
-                tracked_state_rootless_depth: 1,
-                tracked_state_rootless_rows: 1,
-                tracked_state_rootless_bytes: 1,
                 change_id: ChangeId::for_test_label("authority-gc-dead-header"),
                 account_id: crate::ANONYMOUS_ACCOUNT_ID.to_string(),
                 created_at: timestamp,
@@ -2128,14 +1999,15 @@ mod tests {
             (dead_commit, dead_stage.mutation_inventory().clone()),
         ]);
         for record in &commits {
-            stage_test_commit_state_manifest(
-                &mut writes,
-                record,
-                inventories
-                    .get(&record.commit_id)
-                    .cloned()
-                    .unwrap_or_default(),
-            );
+            let mutations = inventories
+                .get(&record.commit_id)
+                .cloned()
+                .unwrap_or_default();
+            let mut manifest = test_commit_state_manifest(record, mutations);
+            manifest.replay_debt = CommitStateReplayDebt::default();
+            manifest.snapshot_root = Some(Box::new(test_snapshot_root(record.commit_id)));
+            stage_commit_state_manifest(&mut writes, &manifest)
+                .expect("rooted GC fixture commit-state manifest should stage");
         }
         let sidecar_schema = Arc::new(Schema::new(vec![Field::new(
             "value",
@@ -2264,6 +2136,27 @@ mod tests {
             .expect("post-GC packed inventory should scan");
         assert!(inventory.commits.contains_key(&live_parent));
         assert!(inventory.commits.contains_key(&dead_commit));
+        assert!(
+            crate::tracked_state::load_snapshot_commit_root(&read, &live_parent.to_string())
+                .await
+                .expect("live snapshot lookup should succeed")
+                .is_some(),
+            "a retained semantic commit keeps its immutable snapshot authority"
+        );
+        assert!(
+            crate::tracked_state::load_snapshot_commit_root(&read, &dead_commit.to_string())
+                .await
+                .expect("dead snapshot lookup should succeed")
+                .is_none(),
+            "retained selected-source bytes must not authorize a swept semantic commit"
+        );
+        assert!(
+            crate::tracked_state::load_commit_state_manifest(&read, dead_commit)
+                .await
+                .expect("retained physical source lookup should succeed")
+                .is_some(),
+            "the test must retain dead mutation authority for the live selected source"
+        );
         assert!(
             crate::columnar_row_group::load_row_group_manifest(
                 &read,
@@ -2484,14 +2377,10 @@ mod tests {
 
     fn gc_authority_record(label: &str) -> CommitRecord {
         CommitRecord {
-            format_version: 1,
+            format_version: 2,
             commit_id: CommitId::for_test_label(label),
             generation: 0,
             parent_commit_ids: Vec::new(),
-            tracked_state_rootless: true,
-            tracked_state_rootless_depth: 1,
-            tracked_state_rootless_rows: 0,
-            tracked_state_rootless_bytes: 0,
             change_id: ChangeId::for_test_label(&format!("{label}-header")),
             account_id: crate::ANONYMOUS_ACCOUNT_ID.to_string(),
             created_at: LixTimestamp::expect_parse(
@@ -2527,35 +2416,37 @@ mod tests {
             .collect()
     }
 
-    fn stage_test_commit_state_manifest(
-        writes: &mut crate::storage_adapter::StorageWriteSet,
-        record: &CommitRecord,
-        mutations: CommitStateMutationInventory,
-    ) {
-        stage_commit_state_manifest(writes, &test_commit_state_manifest(record, mutations))
-            .expect("GC fixture commit-state manifest should stage");
-    }
-
     fn test_commit_state_manifest(
         record: &CommitRecord,
         mutations: CommitStateMutationInventory,
     ) -> CommitStateManifest {
         CommitStateManifest {
             commit_id: record.commit_id,
-            generation: record.generation,
-            parent_commit_ids: record.parent_commit_ids.clone(),
-            commit_change_id: record.change_id,
-            account_id: record.account_id.clone(),
-            created_at: record.created_at,
+            change_account_id: record.account_id.clone(),
             replay_debt: CommitStateReplayDebt {
-                depth: record.tracked_state_rootless_depth,
-                rows: record.tracked_state_rootless_rows,
-                bytes: record.tracked_state_rootless_bytes,
+                depth: 1,
+                rows: u64::from(mutations.member_count),
+                bytes: u64::from(mutations.member_count),
             },
             mutations,
             touched_scope_filter: Default::default(),
             current_state_scoped_ranges: None,
             snapshot_root: None,
+        }
+    }
+
+    fn test_snapshot_root(commit_id: CommitId) -> crate::tracked_state::TrackedStateCommitRoot {
+        crate::tracked_state::TrackedStateCommitRoot {
+            commit_id,
+            root_id: crate::tracked_state::TrackedStateRootId::new(
+                *blake3::hash(commit_id.as_uuid().as_bytes()).as_bytes(),
+            ),
+            parent_roots: Vec::new(),
+            changed_key_count: 1,
+            row_count_estimate: 1,
+            tree_height: 1,
+            primary_chunk_count: 1,
+            primary_chunk_bytes: 64,
         }
     }
 

--- a/packages/engine/src/gc.rs
+++ b/packages/engine/src/gc.rs
@@ -11,19 +11,25 @@ use std::time::Instant;
 use bytes::Bytes;
 
 use crate::branch::BranchHeadControlContext;
+#[cfg(test)]
+use crate::changelog::ChangeRecord;
 use crate::changelog::{
-    CHANGE_SPACE, COMMIT_CHANGE_ID_SPACE, COMMIT_SPACE, ChangeId, ChangeRecord, ChangeScanRequest,
+    CHANGE_SPACE, COMMIT_CHANGE_ID_SPACE, COMMIT_SPACE, ChangeId, ChangeScanRequest,
     ChangelogContext, ChangelogReader, CommitId, CommitScanRequest, GcLiveSet, GcPlan, GcRepairSet,
     GcRoot, GcSweepSet, change_key, commit_change_id_key, commit_key,
 };
+use crate::commit_graph::CommitGraphContext;
+use crate::json_store::JsonRef;
+#[cfg(test)]
 use crate::json_store::{
-    JsonRef, JsonSlot, JsonStoreContext, JsonStoreWriter, UntrackedJsonReclaimCandidate,
+    JsonSlot, JsonStoreContext, JsonStoreWriter, UntrackedJsonReclaimCandidate,
 };
+#[cfg(test)]
 use crate::live_state::{TrackedHeadContext, stage_collect_stale_working_diff_indexes};
 use crate::storage_adapter::{
     PointReadPlan, ScanPlan, StorageAdapterRead, StorageCoreProjection, StorageGetOptions,
-    StorageKey, StoragePrefix, StorageProjectedValue, StorageScanOptions, StorageSpace,
-    StorageSpaceId, StorageValue, StorageWriteSet,
+    StorageKey, StoragePrecondition, StoragePrefix, StorageProjectedValue, StorageScanOptions,
+    StorageSpace, StorageSpaceId, StorageValue, StorageWriteSet,
 };
 use crate::{LixError, storage_codec};
 
@@ -35,10 +41,22 @@ pub(crate) const CHECKPOINT_RECOVERY_REF_SPACE: StorageSpace = StorageSpace::mut
 pub(crate) const CHECKPOINT_GC_STATE_NAMESPACE: &str = "checkpoint.gc_state.v1";
 pub(crate) const CHECKPOINT_GC_STATE_SPACE: StorageSpace =
     StorageSpace::mutable(StorageSpaceId(0x0008_0002), CHECKPOINT_GC_STATE_NAMESPACE);
+/// Authenticated publication deltas are the sole ordinary-GC input.  The
+/// queue is mutable because its head/tail are CAS-protected, while each
+/// record is immutable after publication and addressed by a monotonic slot.
+pub(crate) const GC_REACHABILITY_DELTA_NAMESPACE: &str = "gc.reachability_delta.v1";
+pub(crate) const GC_REACHABILITY_DELTA_SPACE: StorageSpace =
+    StorageSpace::mutable(StorageSpaceId(0x0008_0003), GC_REACHABILITY_DELTA_NAMESPACE);
+pub(crate) const GC_REACHABILITY_QUEUE_NAMESPACE: &str = "gc.reachability_queue.v1";
+pub(crate) const GC_REACHABILITY_QUEUE_SPACE: StorageSpace =
+    StorageSpace::mutable(StorageSpaceId(0x0008_0004), GC_REACHABILITY_QUEUE_NAMESPACE);
 
 const CHECKPOINT_RECOVERY_REF_FORMAT_VERSION: u32 = 3;
 const CHECKPOINT_GC_STATE_FORMAT_VERSION: u32 = 1;
 const CHECKPOINT_GC_STATE_KEY: &[u8] = b"repository";
+const GC_REACHABILITY_FORMAT_VERSION: u32 = 2;
+const GC_REACHABILITY_QUEUE_KEY: &[u8] = b"queue";
+const GC_REACHABILITY_BATCH_LIMIT: usize = 64;
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub(crate) struct CheckpointRecoveryRef {
@@ -90,7 +108,7 @@ struct CheckpointRecoveryRefKey<'a> {
     branch_id: &'a str,
 }
 
-#[derive(musli::Encode, musli::Decode)]
+#[derive(Clone, musli::Encode, musli::Decode)]
 #[musli(packed)]
 struct StoredCheckpointRecoveryRef {
     format_version: u32,
@@ -107,6 +125,65 @@ struct StoredCheckpointGcState {
     checkpoint_sequence: u64,
     last_gc_sequence: u64,
     collectible_interval_count: u64,
+}
+
+/// One branch-root transition.  The digest fields bind the delta to the
+/// exact control bytes observed by the publisher; a queue record with a
+/// forged root or stale CAS token is rejected before any physical delete is
+/// staged.
+#[derive(Clone, musli::Encode, musli::Decode)]
+#[musli(packed)]
+struct StoredRootReachabilityDelta {
+    branch_id: String,
+    #[musli(with = storage_codec::option)]
+    old_root: Option<CommitId>,
+    #[musli(with = storage_codec::option)]
+    new_root: Option<CommitId>,
+    #[musli(with = storage_codec::option)]
+    old_control: Option<crate::branch::BranchHeadControl>,
+    #[musli(with = storage_codec::option)]
+    new_control: Option<crate::branch::BranchHeadControl>,
+    old_control_digest: [u8; 32],
+    new_control_digest: [u8; 32],
+}
+
+#[derive(musli::Encode, musli::Decode)]
+#[musli(packed)]
+struct StoredRootReachabilityBatch {
+    format_version: u32,
+    sequence: u64,
+    deltas: Vec<StoredRootReachabilityDelta>,
+    checkpoint_roots: Vec<CommitId>,
+    digest: [u8; 32],
+}
+
+#[derive(musli::Encode, musli::Decode)]
+#[musli(packed)]
+struct StoredRootReachabilityBatchBody {
+    format_version: u32,
+    sequence: u64,
+    deltas: Vec<StoredRootReachabilityDelta>,
+    checkpoint_roots: Vec<CommitId>,
+}
+
+#[derive(musli::Encode, musli::Decode)]
+#[musli(packed)]
+struct StoredReachabilityQueue {
+    format_version: u32,
+    head_sequence: u64,
+    tail_sequence: u64,
+    next_sequence: u64,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct RootReachabilityDelta {
+    pub(crate) branch_id: String,
+    pub(crate) old_root: Option<CommitId>,
+    pub(crate) new_root: Option<CommitId>,
+    pub(crate) old_control: Option<crate::branch::BranchHeadControl>,
+    pub(crate) new_control: Option<crate::branch::BranchHeadControl>,
+    pub(crate) old_control_digest: [u8; 32],
+    pub(crate) new_control_digest: [u8; 32],
 }
 
 /// Stages one branch's recovery-root rotation.
@@ -167,6 +244,284 @@ pub(crate) fn stage_checkpoint_gc_state(
         },
     );
     Ok(())
+}
+
+/// Seeds the empty authenticated frontier during repository initialization.
+/// There is deliberately no reader-side migration: a repository without this
+/// control is an old protocol and ordinary GC fails closed.
+pub(crate) fn stage_reachability_queue_seed(writes: &mut StorageWriteSet) -> Result<(), LixError> {
+    let value = storage_codec::encode(
+        "GC reachability queue",
+        &StoredReachabilityQueue {
+            format_version: GC_REACHABILITY_FORMAT_VERSION,
+            head_sequence: 0,
+            tail_sequence: 0,
+            next_sequence: 1,
+        },
+    )?;
+    writes.put(
+        GC_REACHABILITY_QUEUE_SPACE,
+        StorageKey(Bytes::from_static(GC_REACHABILITY_QUEUE_KEY)),
+        StorageValue {
+            bytes: Bytes::from(value),
+        },
+    );
+    Ok(())
+}
+
+#[cfg(test)]
+pub(crate) async fn ensure_reachability_queue_for_test(
+    read: &(impl StorageAdapterRead + ?Sized),
+    writes: &mut StorageWriteSet,
+) -> Result<bool, LixError> {
+    let result = PointReadPlan::new(
+        GC_REACHABILITY_QUEUE_SPACE,
+        &[StorageKey(Bytes::from_static(GC_REACHABILITY_QUEUE_KEY))],
+    )
+    .materialize(read, StorageGetOptions::default())
+    .await?;
+    if result.value.into_iter().next().flatten().is_none() {
+        stage_reachability_queue_seed(writes)?;
+        return Ok(true);
+    }
+    Ok(false)
+}
+
+fn reachability_sequence_key(sequence: u64) -> StorageKey {
+    StorageKey(Bytes::copy_from_slice(&sequence.to_be_bytes()))
+}
+
+async fn load_reachability_queue(
+    store: &(impl StorageAdapterRead + ?Sized),
+) -> Result<(StoredReachabilityQueue, Bytes), LixError> {
+    let result = PointReadPlan::new(
+        GC_REACHABILITY_QUEUE_SPACE,
+        &[StorageKey(Bytes::from_static(GC_REACHABILITY_QUEUE_KEY))],
+    )
+    .materialize(store, StorageGetOptions::default())
+    .await?;
+    let Some(Some(StorageProjectedValue::FullValue(bytes))) = result.value.into_iter().next()
+    else {
+        return Err(LixError::new(
+            LixError::CODE_INTERNAL_ERROR,
+            "authenticated GC reachability queue is missing",
+        ));
+    };
+    let queue: StoredReachabilityQueue = storage_codec::decode("GC reachability queue", &bytes)?;
+    if queue.format_version != GC_REACHABILITY_FORMAT_VERSION
+        || queue.next_sequence == 0
+        || (queue.head_sequence == 0) != (queue.tail_sequence == 0)
+        || (queue.head_sequence != 0 && queue.head_sequence > queue.tail_sequence)
+        || queue.tail_sequence >= queue.next_sequence
+    {
+        return Err(LixError::new(
+            LixError::CODE_INTERNAL_ERROR,
+            "authenticated GC reachability queue has invalid bounds",
+        ));
+    }
+    Ok((queue, bytes))
+}
+
+fn root_control_digest(raw: Option<&Bytes>) -> [u8; 32] {
+    match raw {
+        Some(raw) => *blake3::hash(raw.as_ref()).as_bytes(),
+        None => *blake3::hash(b"lix.gc.root.absent.v1").as_bytes(),
+    }
+}
+
+fn validate_stored_root_reachability_delta(
+    delta: &StoredRootReachabilityDelta,
+) -> Result<(), LixError> {
+    if delta.branch_id.is_empty()
+        || delta.old_control_digest == [0; 32]
+        || delta.new_control_digest == [0; 32]
+    {
+        return Err(LixError::new(
+            LixError::CODE_INTERNAL_ERROR,
+            "GC reachability delta has an invalid branch or control digest",
+        ));
+    }
+    if root_control_digest_for_control(delta.old_control.as_ref())? != delta.old_control_digest
+        || root_control_digest_for_control(delta.new_control.as_ref())? != delta.new_control_digest
+    {
+        return Err(LixError::new(
+            LixError::CODE_INTERNAL_ERROR,
+            format!(
+                "GC reachability delta for branch '{}' has a control digest mismatch",
+                delta.branch_id
+            ),
+        ));
+    }
+    match (delta.old_root, delta.old_control) {
+        (Some(root), Some(control)) if control.head_commit_id == root => {}
+        (None, None) => {}
+        _ => {
+            return Err(LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                format!(
+                    "GC reachability delta for branch '{}' has an invalid old-root binding",
+                    delta.branch_id
+                ),
+            ));
+        }
+    }
+    match (delta.new_root, delta.new_control) {
+        (Some(root), Some(control)) if control.head_commit_id == root => {}
+        (None, None) => {}
+        _ => {
+            return Err(LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                format!(
+                    "GC reachability delta for branch '{}' has an invalid new-root binding",
+                    delta.branch_id
+                ),
+            ));
+        }
+    }
+    Ok(())
+}
+
+pub(crate) fn root_control_digest_for_control(
+    control: Option<&crate::branch::BranchHeadControl>,
+) -> Result<[u8; 32], LixError> {
+    let Some(control) = control else {
+        return Ok(root_control_digest(None));
+    };
+    let bytes = storage_codec::encode("branch-head control", control)?;
+    Ok(root_control_digest(Some(&Bytes::from(bytes))))
+}
+
+fn encode_reachability_batch_body(
+    sequence: u64,
+    deltas: Vec<StoredRootReachabilityDelta>,
+    checkpoint_roots: Vec<CommitId>,
+) -> Result<(StoredRootReachabilityBatchBody, [u8; 32]), LixError> {
+    let body = StoredRootReachabilityBatchBody {
+        format_version: GC_REACHABILITY_FORMAT_VERSION,
+        sequence,
+        deltas,
+        checkpoint_roots,
+    };
+    let encoded = storage_codec::encode("GC reachability delta body", &body)?;
+    Ok((body, *blake3::hash(&encoded).as_bytes()))
+}
+
+/// Appends one transaction's complete root transition set.  A single queue
+/// CAS makes branch advance/delete and checkpoint pin publication atomic with
+/// their controls; consumers never infer liveness from semantic parent rows.
+pub(crate) async fn stage_reachability_delta_batch(
+    read: &(impl StorageAdapterRead + ?Sized),
+    writes: &mut StorageWriteSet,
+    deltas: &[RootReachabilityDelta],
+    checkpoint_roots: &[CommitId],
+    preconditions: &mut Vec<StoragePrecondition>,
+) -> Result<(), LixError> {
+    if deltas.is_empty() && checkpoint_roots.is_empty() {
+        return Ok(());
+    }
+    let (mut queue, raw_queue) = load_reachability_queue(read).await?;
+    let sequence = queue.next_sequence;
+    queue.next_sequence = queue.next_sequence.checked_add(1).ok_or_else(|| {
+        LixError::new(
+            LixError::CODE_INTERNAL_ERROR,
+            "GC reachability queue sequence overflow",
+        )
+    })?;
+    if queue.head_sequence == 0 {
+        queue.head_sequence = sequence;
+    }
+    queue.tail_sequence = sequence;
+    let stored_deltas = deltas
+        .iter()
+        .map(|delta| StoredRootReachabilityDelta {
+            branch_id: delta.branch_id.clone(),
+            old_root: delta.old_root,
+            new_root: delta.new_root,
+            old_control: delta.old_control,
+            new_control: delta.new_control,
+            old_control_digest: delta.old_control_digest,
+            new_control_digest: delta.new_control_digest,
+        })
+        .collect::<Vec<_>>();
+    let checkpoint_roots = checkpoint_roots.to_vec();
+    let (body, digest) = encode_reachability_batch_body(sequence, stored_deltas, checkpoint_roots)?;
+    let batch = StoredRootReachabilityBatch {
+        format_version: GC_REACHABILITY_FORMAT_VERSION,
+        sequence,
+        deltas: body.deltas,
+        checkpoint_roots: body.checkpoint_roots,
+        digest,
+    };
+    writes.put(
+        GC_REACHABILITY_DELTA_SPACE,
+        reachability_sequence_key(sequence),
+        StorageValue {
+            bytes: Bytes::from(storage_codec::encode("GC reachability delta", &batch)?),
+        },
+    );
+    writes.put(
+        GC_REACHABILITY_QUEUE_SPACE,
+        StorageKey(Bytes::from_static(GC_REACHABILITY_QUEUE_KEY)),
+        StorageValue {
+            bytes: Bytes::from(storage_codec::encode("GC reachability queue", &queue)?),
+        },
+    );
+    preconditions.push(StoragePrecondition::KeyValueEquals {
+        space: GC_REACHABILITY_QUEUE_SPACE,
+        key: StorageKey(Bytes::from_static(GC_REACHABILITY_QUEUE_KEY)),
+        expected: raw_queue,
+    });
+    Ok(())
+}
+
+async fn load_reachability_batches(
+    store: &(impl StorageAdapterRead + ?Sized),
+    queue: &StoredReachabilityQueue,
+) -> Result<Vec<(u64, StoredRootReachabilityBatch)>, LixError> {
+    if queue.head_sequence == 0 {
+        return Ok(Vec::new());
+    }
+    let end = queue
+        .head_sequence
+        .saturating_add(GC_REACHABILITY_BATCH_LIMIT as u64)
+        .min(queue.tail_sequence.saturating_add(1));
+    let keys = (queue.head_sequence..end)
+        .map(reachability_sequence_key)
+        .collect::<Vec<_>>();
+    let result = PointReadPlan::new(GC_REACHABILITY_DELTA_SPACE, &keys)
+        .materialize(store, StorageGetOptions::default())
+        .await?;
+    let mut batches = Vec::with_capacity(keys.len());
+    for (sequence, value) in (queue.head_sequence..end).zip(result.value) {
+        let Some(StorageProjectedValue::FullValue(bytes)) = value else {
+            return Err(LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                format!("GC reachability delta {sequence} is missing"),
+            ));
+        };
+        let batch: StoredRootReachabilityBatch =
+            storage_codec::decode("GC reachability delta", &bytes)?;
+        if batch.format_version != GC_REACHABILITY_FORMAT_VERSION || batch.sequence != sequence {
+            return Err(LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                format!("GC reachability delta {sequence} has invalid identity"),
+            ));
+        }
+        let (body, digest) = encode_reachability_batch_body(
+            batch.sequence,
+            batch.deltas.clone(),
+            batch.checkpoint_roots.clone(),
+        )?;
+        let _ = body;
+        if digest != batch.digest {
+            return Err(LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                format!("GC reachability delta {sequence} digest mismatch"),
+            ));
+        }
+        batches.push((sequence, batch));
+    }
+    Ok(batches)
 }
 
 pub(crate) async fn load_recovery_refs(
@@ -236,6 +591,7 @@ pub(crate) async fn load_recovery_refs(
     Ok(refs.into_values().collect())
 }
 
+#[cfg(test)]
 async fn stage_sweep_unreachable_content_nodes(
     store: &(impl StorageAdapterRead + ?Sized),
     writes: &mut StorageWriteSet,
@@ -417,7 +773,370 @@ pub(crate) struct RepositoryGcProfile {
 /// Content-addressed tree/CAS orphan repair is intentionally an offline path;
 /// out-of-band JSON is reclaimed here only from explicit ownership-loss
 /// candidates.
+/// Ordinary GC consumes only authenticated publication deltas.  Branch-head
+/// controls and checkpoint recovery refs are the complete active-root set;
+/// no semantic parent walk or full-space inventory discovery is permitted on
+/// this path.
+#[cfg(any(test, feature = "storage-benches"))]
 pub(crate) async fn stage_repository_gc<S>(
+    store: S,
+    writes: &mut StorageWriteSet,
+) -> Result<RepositoryGcPlan, LixError>
+where
+    S: StorageAdapterRead + Clone + Send + Sync,
+{
+    let mut preconditions = Vec::new();
+    stage_repository_gc_with_preconditions(store, writes, &mut preconditions).await
+}
+
+pub(crate) async fn stage_repository_gc_with_preconditions<S>(
+    store: S,
+    writes: &mut StorageWriteSet,
+    preconditions: &mut Vec<StoragePrecondition>,
+) -> Result<RepositoryGcPlan, LixError>
+where
+    S: StorageAdapterRead + Clone + Send + Sync,
+{
+    let started = Instant::now();
+    let controls = BranchHeadControlContext::new()
+        .reader(store.clone())
+        .scan()
+        .await?;
+    let recovery_refs = load_recovery_refs(&store).await?;
+    let mut active_roots = controls
+        .iter()
+        .flat_map(|(_, control)| {
+            std::iter::once(control.head_commit_id).chain(control.working_diff_checkpoint_commit_id)
+        })
+        .collect::<BTreeSet<_>>();
+    active_roots.extend(
+        recovery_refs
+            .iter()
+            .map(|recovery| recovery.recovered_head_commit_id),
+    );
+    if active_roots.is_empty() {
+        return Err(LixError::new(
+            LixError::CODE_INTERNAL_ERROR,
+            "authenticated GC active-root set is empty",
+        ));
+    }
+
+    let (queue, raw_queue) = load_reachability_queue(&store).await?;
+    let batches = load_reachability_batches(&store, &queue).await?;
+    // Checkpoint pins carried by the authenticated batches are folded into
+    // the same active-root set before any retirement candidate is evaluated.
+    // Recovery refs normally provide the same roots; retaining both proofs
+    // makes a torn ref rotation fail closed instead of silently reclaiming a
+    // checkpoint-only authority.
+    active_roots.extend(
+        batches
+            .iter()
+            .flat_map(|(_, batch)| batch.checkpoint_roots.iter().copied()),
+    );
+    if batches.is_empty() {
+        return Ok(RepositoryGcPlan {
+            changelog: GcPlan {
+                roots: active_roots
+                    .iter()
+                    .copied()
+                    .map(GcRoot::BranchHead)
+                    .collect(),
+                live: GcLiveSet {
+                    commits: active_roots.iter().copied().collect(),
+                    changes: Vec::new(),
+                    payloads: Vec::new(),
+                },
+                sweep: GcSweepSet {
+                    commits: Vec::new(),
+                    commit_change_ids: Vec::new(),
+                    changes: Vec::new(),
+                    json_payloads: Vec::new(),
+                },
+                repair: GcRepairSet::default(),
+            },
+            sweep: RepositoryGcSweep {
+                tracked_commit_roots: Vec::new(),
+            },
+            profile: RepositoryGcProfile {
+                root_discovery_us: elapsed_micros(started),
+                changelog_us: 0,
+                tracked_root_stage_us: 0,
+                total_us: elapsed_micros(started),
+            },
+        });
+    }
+    let mut active_authority_ids = active_roots.clone();
+    let mut active_dependency_ids = BTreeSet::new();
+    let mut active_manifests = BTreeMap::new();
+    let mut pending = active_roots.iter().copied().collect::<Vec<_>>();
+    while let Some(commit_id) = pending.pop() {
+        if active_manifests.contains_key(&commit_id) {
+            continue;
+        }
+        let manifest = crate::tracked_state::load_commit_state_manifest(&store, commit_id)
+            .await?
+            .ok_or_else(|| {
+                LixError::new(
+                    LixError::CODE_INTERNAL_ERROR,
+                    format!("active GC root '{commit_id}' has no authenticated physical manifest"),
+                )
+            })?;
+        if let Some(source) = manifest.mutations.selected_source_commit_id() {
+            active_authority_ids.insert(source);
+            pending.push(source);
+        }
+        if let Some(root) = manifest.current_state_scoped_ranges.as_ref() {
+            if let Some(base) = root.serving_base_commit_id {
+                active_dependency_ids.insert(base);
+            }
+        }
+        if let Some(snapshot_root) = manifest.snapshot_root.as_ref() {
+            active_dependency_ids.extend(
+                snapshot_root
+                    .parent_roots
+                    .iter()
+                    .map(|parent| parent.commit_id),
+            );
+        }
+        active_manifests.insert(commit_id, manifest);
+    }
+
+    let mut active_mutation_nodes = BTreeSet::new();
+    let mut active_scoped_nodes = BTreeSet::new();
+    let mut active_current_parts = BTreeSet::new();
+    let replay_debt_ids = active_manifests
+        .iter()
+        .filter_map(|(commit_id, manifest)| (manifest.replay_debt.depth != 0).then_some(*commit_id))
+        .collect::<Vec<_>>();
+    // Rootless active commits retain their semantic parents for bounded replay,
+    // but unrelated retired roots must not be blocked by a repository-global
+    // replay-debt flag. Resolve only the direct parent closure of the active
+    // replay-debt roots; this is bounded by active roots and preserves the
+    // history dependency proof without a changelog sweep.
+    if !replay_debt_ids.is_empty() {
+        let replay_nodes = CommitGraphContext::new()
+            .reader(store.clone())
+            .load_nodes(&replay_debt_ids)
+            .await?;
+        for (_, node) in replay_nodes.iter() {
+            if let Some(node) = node {
+                active_dependency_ids.extend(node.parent_commit_ids.iter().copied());
+            }
+        }
+    }
+    let scoped_roots = active_manifests
+        .values()
+        .filter_map(|manifest| {
+            manifest
+                .current_state_scoped_ranges
+                .as_ref()
+                .map(|root| root.tree.clone())
+        })
+        .collect::<Vec<_>>();
+    if !scoped_roots.is_empty() {
+        let reachable =
+            crate::tracked_state::validate_scoped_range_trees(&store, &scoped_roots).await?;
+        active_scoped_nodes.extend(reachable.node_ids);
+        for part in reachable.parts {
+            let descriptor =
+                crate::tracked_state::current_state_descriptor_from_scoped_range_part(&part)?;
+            if descriptor.source_kind == 1 {
+                active_current_parts.insert(descriptor.content_digest);
+            }
+        }
+    }
+    let active_ids = active_manifests.keys().copied().collect::<Vec<_>>();
+    let mutation_roots =
+        crate::tracked_state::load_commit_mutation_directory_roots(&store, &active_ids).await?;
+    for root in mutation_roots.into_iter().flatten() {
+        active_mutation_nodes.extend(
+            crate::tracked_state::collect_mutation_directory_node_ids(&store, &root).await?,
+        );
+    }
+
+    // A delta is a candidate until every active history/checkpoint/replay
+    // dependency releases the old root.  Never consume a batch containing a
+    // blocked candidate: dropping that signal would make the root permanently
+    // unreclaimable after the pin is later released.  The whole batch remains
+    // at the queue head; this intentionally delays later deltas but preserves
+    // the authenticated publication order and retry semantics.
+    let mut blocked_sequences = BTreeSet::new();
+    for (sequence, batch) in &batches {
+        for delta in &batch.deltas {
+            validate_stored_root_reachability_delta(delta)?;
+            let Some(old_root) = delta.old_root else {
+                continue;
+            };
+            if !retirement_is_proven(
+                old_root,
+                delta.new_root,
+                &active_authority_ids,
+                &active_dependency_ids,
+            ) || replay_debt_ids.contains(&old_root)
+            {
+                blocked_sequences.insert(*sequence);
+            }
+        }
+    }
+
+    let mut next_queue = queue;
+    let queue_head = next_queue.head_sequence;
+    let mut consumed_through = queue_head;
+    let mut queue_open = true;
+    let mut reclaimed_commits = Vec::new();
+    for (sequence, batch) in batches {
+        if queue_open && blocked_sequences.contains(&sequence) {
+            queue_open = false;
+        }
+        if queue_open {
+            consumed_through = sequence.saturating_add(1);
+        }
+        for delta in batch.deltas {
+            validate_stored_root_reachability_delta(&delta)?;
+            let Some(old_root) = delta.old_root else {
+                continue;
+            };
+            if !retirement_is_proven(
+                old_root,
+                delta.new_root,
+                &active_authority_ids,
+                &active_dependency_ids,
+            ) || replay_debt_ids.contains(&old_root)
+            {
+                continue;
+            }
+            let manifest = crate::tracked_state::load_commit_state_manifest(&store, old_root)
+                .await?
+                .ok_or_else(|| {
+                    LixError::new(
+                        LixError::CODE_INTERNAL_ERROR,
+                        format!("retired GC root '{old_root}' has no authenticated manifest"),
+                    )
+                })?;
+            let retired_root =
+                crate::tracked_state::load_commit_mutation_directory_roots(&store, &[old_root])
+                    .await?
+                    .into_iter()
+                    .next()
+                    .flatten();
+            if let Some(root) = retired_root {
+                let nodes =
+                    crate::tracked_state::collect_mutation_directory_node_ids(&store, &root)
+                        .await?;
+                for node_id in nodes.difference(&active_mutation_nodes) {
+                    writes.delete(
+                        crate::tracked_state::MUTATION_DIRECTORY_NODE_SPACE,
+                        StorageKey(Bytes::copy_from_slice(node_id)),
+                    );
+                }
+            }
+            if let Some(root) = manifest.current_state_scoped_ranges.as_ref() {
+                let reachable =
+                    crate::tracked_state::validate_scoped_range_trees(&store, &[root.tree.clone()])
+                        .await?;
+                for node_id in reachable.node_ids.difference(&active_scoped_nodes) {
+                    writes.delete(
+                        crate::tracked_state::SCOPED_RANGE_NODE_SPACE,
+                        StorageKey(Bytes::copy_from_slice(node_id)),
+                    );
+                }
+                for part in reachable.parts {
+                    let descriptor =
+                        crate::tracked_state::current_state_descriptor_from_scoped_range_part(
+                            &part,
+                        )?;
+                    if descriptor.source_kind == 1
+                        && !active_current_parts.contains(&descriptor.content_digest)
+                    {
+                        writes.delete(
+                            crate::tracked_state::CURRENT_STATE_DATA_PART_SPACE,
+                            StorageKey(Bytes::copy_from_slice(&descriptor.content_digest)),
+                        );
+                        writes.delete(
+                            crate::tracked_state::CURRENT_STATE_DATA_PART_REFS_SPACE,
+                            StorageKey(Bytes::copy_from_slice(&descriptor.payload_refs_digest)),
+                        );
+                    }
+                }
+            }
+            crate::tracked_state::stage_delete_commit_state_manifest_for_gc(
+                &store, writes, old_root, &manifest,
+            )
+            .await?;
+            reclaimed_commits.push(old_root);
+        }
+    }
+
+    if consumed_through > queue_head {
+        consumed_through = consumed_through
+            .min(queue_head.saturating_add(GC_REACHABILITY_BATCH_LIMIT as u64))
+            .min(next_queue.tail_sequence.saturating_add(1));
+        for sequence in next_queue.head_sequence..consumed_through {
+            writes.delete(
+                GC_REACHABILITY_DELTA_SPACE,
+                reachability_sequence_key(sequence),
+            );
+        }
+        if consumed_through > next_queue.tail_sequence {
+            next_queue.head_sequence = 0;
+            next_queue.tail_sequence = 0;
+        } else {
+            next_queue.head_sequence = consumed_through;
+        }
+        writes.put(
+            GC_REACHABILITY_QUEUE_SPACE,
+            StorageKey(Bytes::from_static(GC_REACHABILITY_QUEUE_KEY)),
+            StorageValue {
+                bytes: Bytes::from(storage_codec::encode("GC reachability queue", &next_queue)?),
+            },
+        );
+        // The queue CAS is the publication/consumption fence.  The caller
+        // carries this exact read token into the backend write options.
+        preconditions.push(StoragePrecondition::KeyValueEquals {
+            space: GC_REACHABILITY_QUEUE_SPACE,
+            key: StorageKey(Bytes::from_static(GC_REACHABILITY_QUEUE_KEY)),
+            expected: raw_queue,
+        });
+        writes.seal_changelog_gc();
+    }
+
+    Ok(RepositoryGcPlan {
+        changelog: GcPlan {
+            roots: active_roots
+                .iter()
+                .copied()
+                .map(GcRoot::BranchHead)
+                .collect(),
+            live: GcLiveSet {
+                commits: active_authority_ids.into_iter().collect(),
+                changes: Vec::new(),
+                payloads: Vec::new(),
+            },
+            sweep: GcSweepSet {
+                commits: Vec::new(),
+                commit_change_ids: Vec::new(),
+                changes: Vec::new(),
+                json_payloads: Vec::new(),
+            },
+            repair: GcRepairSet::default(),
+        },
+        sweep: RepositoryGcSweep {
+            tracked_commit_roots: reclaimed_commits,
+        },
+        profile: RepositoryGcProfile {
+            root_discovery_us: elapsed_micros(started),
+            changelog_us: 0,
+            tracked_root_stage_us: 0,
+            total_us: elapsed_micros(started),
+        },
+    })
+}
+
+/// Recovery-only verifier retained for explicit rebuild tooling and tests.
+/// Ordinary maintenance never calls this path: it would rediscover liveness
+/// by scanning the changelog and every immutable inventory.
+#[cfg(test)]
+async fn stage_repository_gc_full_recovery<S>(
     store: S,
     writes: &mut StorageWriteSet,
 ) -> Result<RepositoryGcPlan, LixError>
@@ -544,6 +1263,7 @@ where
     })
 }
 
+#[cfg(test)]
 async fn plan_and_stage_authority_gc<S>(
     store: &S,
     writes: &mut StorageWriteSet,
@@ -1135,6 +1855,7 @@ where
     })
 }
 
+#[cfg(test)]
 #[derive(Clone, Debug)]
 struct GcCommitInventoryEntry {
     commit_id: CommitId,
@@ -1143,12 +1864,14 @@ struct GcCommitInventoryEntry {
     parent_len: usize,
 }
 
+#[cfg(test)]
 #[derive(Debug, Default)]
 struct GcCommitInventory {
     entries: Vec<GcCommitInventoryEntry>,
     parent_commit_ids: Vec<CommitId>,
 }
 
+#[cfg(test)]
 impl GcCommitInventory {
     fn get(&self, commit_id: CommitId) -> Option<&GcCommitInventoryEntry> {
         self.entries
@@ -1166,6 +1889,7 @@ impl GcCommitInventory {
     }
 }
 
+#[cfg(test)]
 async fn scan_all_gc_commits<S>(store: S) -> Result<GcCommitInventory, LixError>
 where
     S: StorageAdapterRead,
@@ -1214,6 +1938,7 @@ where
     Ok(commits)
 }
 
+#[cfg(test)]
 async fn scan_all_gc_standalone_changes<S>(
     store: S,
 ) -> Result<BTreeMap<ChangeId, ChangeRecord>, LixError>
@@ -1249,6 +1974,7 @@ where
     Ok(changes)
 }
 
+#[cfg(test)]
 fn collect_change_payload_hashes(change: &ChangeRecord, hashes: &mut BTreeSet<[u8; 32]>) {
     for slot in [&change.snapshot, &change.metadata] {
         if let JsonSlot::Ref(json_ref) = slot {
@@ -1261,12 +1987,23 @@ fn elapsed_micros(started: Instant) -> u64 {
     u64::try_from(started.elapsed().as_micros()).unwrap_or(u64::MAX)
 }
 
+fn retirement_is_proven(
+    old_root: CommitId,
+    new_root: Option<CommitId>,
+    active_authority_ids: &BTreeSet<CommitId>,
+    active_dependency_ids: &BTreeSet<CommitId>,
+) -> bool {
+    new_root != Some(old_root)
+        && !active_authority_ids.contains(&old_root)
+        && !active_dependency_ids.contains(&old_root)
+}
+
 #[cfg(test)]
 mod tests {
     use std::collections::{BTreeMap, BTreeSet};
     use std::sync::Arc;
 
-    use crate::branch::{BranchHeadControlContext, stage_branch_head_control};
+    use crate::branch::{BranchHeadControl, BranchHeadControlContext, stage_branch_head_control};
     use crate::changelog::{
         ChangeId, ChangeLoadRequest, ChangeRecord, ChangelogAppend, ChangelogContext,
         ChangelogReader, ChangelogWriter, CommitId, CommitLoadRequest, CommitRecord, GcRoot,
@@ -1296,8 +2033,10 @@ mod tests {
     use datafusion::arrow::record_batch::RecordBatch;
 
     use super::{
-        CheckpointGcState, CheckpointRecoveryRef, load_checkpoint_gc_state, load_recovery_ref,
-        load_recovery_refs, stage_checkpoint_gc_state, stage_recovery_ref_rotation,
+        CheckpointGcState, CheckpointRecoveryRef, RootReachabilityDelta, load_checkpoint_gc_state,
+        load_reachability_batches, load_reachability_queue, load_recovery_ref, load_recovery_refs,
+        retirement_is_proven, root_control_digest_for_control, stage_checkpoint_gc_state,
+        stage_reachability_delta_batch, stage_reachability_queue_seed, stage_recovery_ref_rotation,
     };
 
     #[tokio::test]
@@ -1341,6 +2080,110 @@ mod tests {
                 .expect("main recovery ref should load"),
             Some(second_main)
         );
+    }
+
+    #[tokio::test]
+    async fn reachability_delta_queue_round_trips_with_authenticated_digest() {
+        let storage = StorageAdapter::new(Memory::new());
+        let mut writes = storage.new_write_set();
+        stage_reachability_queue_seed(&mut writes).expect("queue seed should stage");
+        storage
+            .commit_write_set(writes, StorageWriteOptions::default())
+            .await
+            .expect("queue seed should commit");
+
+        let old_root = CommitId::for_test_label("delta-old-root");
+        let new_root = CommitId::for_test_label("delta-new-root");
+        let timestamp =
+            LixTimestamp::expect_parse("reachability delta test timestamp", "2026-01-01T00:00:00Z");
+        let old_control = BranchHeadControl {
+            head_commit_id: old_root,
+            generation: old_root,
+            current_state_revision: 0,
+            working_diff_checkpoint_commit_id: None,
+            created_at: timestamp,
+            updated_at: timestamp,
+            ref_change_id: ChangeId::for_test_label("delta-old-control"),
+            schema_presence_bloom: [0; 4],
+        };
+        let new_control = BranchHeadControl {
+            head_commit_id: new_root,
+            generation: new_root,
+            current_state_revision: 0,
+            working_diff_checkpoint_commit_id: None,
+            created_at: timestamp,
+            updated_at: timestamp,
+            ref_change_id: ChangeId::for_test_label("delta-new-control"),
+            schema_presence_bloom: [0; 4],
+        };
+        let delta = RootReachabilityDelta {
+            branch_id: "main".to_string(),
+            old_root: Some(old_root),
+            new_root: Some(new_root),
+            old_control: Some(old_control),
+            new_control: Some(new_control),
+            old_control_digest: root_control_digest_for_control(Some(&old_control))
+                .expect("old control should encode"),
+            new_control_digest: root_control_digest_for_control(Some(&new_control))
+                .expect("new control should encode"),
+        };
+        let read = storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("queue read should open");
+        let mut writes = storage.new_write_set();
+        let mut preconditions = Vec::new();
+        stage_reachability_delta_batch(
+            &read,
+            &mut writes,
+            std::slice::from_ref(&delta),
+            &[new_root],
+            &mut preconditions,
+        )
+        .await
+        .expect("delta should stage");
+        drop(read);
+        storage
+            .commit_write_set(
+                writes,
+                StorageWriteOptions {
+                    preconditions,
+                    ..StorageWriteOptions::default()
+                },
+            )
+            .await
+            .expect("delta should commit atomically");
+        let read = storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("queue read should reopen");
+        let (queue, _) = load_reachability_queue(&read)
+            .await
+            .expect("queue should decode");
+        let batches = load_reachability_batches(&read, &queue)
+            .await
+            .expect("delta should decode");
+        assert_eq!(batches.len(), 1);
+        assert_eq!(batches[0].1.checkpoint_roots, vec![new_root]);
+        assert_eq!(batches[0].1.deltas[0].old_root, Some(old_root));
+    }
+
+    #[test]
+    fn retirement_requires_history_and_pin_dependency_closure() {
+        let old = CommitId::for_test_label("history-old");
+        let new = CommitId::for_test_label("history-new");
+        let active = BTreeSet::from([new]);
+        let mut dependencies = BTreeSet::from([old]);
+        assert!(!retirement_is_proven(
+            old,
+            Some(new),
+            &active,
+            &dependencies
+        ));
+        // Once history/diff/undo/redo/checkpoint pins release the old root,
+        // the delta is a valid physical-retirement proof.
+        dependencies.clear();
+        assert!(retirement_is_proven(old, Some(new), &active, &dependencies));
     }
 
     #[tokio::test]
@@ -1456,7 +2299,7 @@ mod tests {
                 .expect("GC read should open"),
         );
         let mut writes = storage.new_write_set();
-        let plan = super::stage_repository_gc(read, &mut writes)
+        let plan = super::stage_repository_gc_full_recovery(read, &mut writes)
             .await
             .expect("GC should plan from direct branch controls");
         let initial_commit = CommitId::parse_lix(&receipt.initial_commit_id, "initial commit")
@@ -2372,7 +3215,7 @@ mod tests {
                 .expect("GC read should open"),
         );
         let mut writes = storage_adapter.new_write_set();
-        super::stage_repository_gc(read, &mut writes)
+        super::stage_repository_gc_full_recovery(read, &mut writes)
             .await
             .expect("repository GC should stage");
         storage_adapter

--- a/packages/engine/src/gc.rs
+++ b/packages/engine/src/gc.rs
@@ -524,6 +524,147 @@ async fn load_reachability_batches(
     Ok(batches)
 }
 
+/// Returns the exact standalone semantic facts and the authenticated reason
+/// currently known for each one. This is benchmark-only attribution: the
+/// ordinary collector never scans CHANGE_SPACE, and this helper is called
+/// outside the measured planner phase.
+pub(crate) async fn audit_repository_gc_standalone_refs<S>(
+    store: &S,
+) -> Result<Vec<String>, LixError>
+where
+    S: StorageAdapterRead + ?Sized,
+{
+    let controls = BranchHeadControlContext::new().reader(store).scan().await?;
+    let active_refs = controls
+        .iter()
+        .map(|(_, control)| control.ref_change_id)
+        .collect::<BTreeSet<_>>();
+    let (queue, _) = load_reachability_queue(store).await?;
+    let batches = load_reachability_batches(store, &queue).await?;
+    let mut active_root_ids = controls
+        .iter()
+        .flat_map(|(_, control)| {
+            std::iter::once(control.head_commit_id).chain(control.working_diff_checkpoint_commit_id)
+        })
+        .collect::<BTreeSet<_>>();
+    active_root_ids.extend(
+        load_recovery_refs(store)
+            .await?
+            .into_iter()
+            .map(|recovery| recovery.recovered_head_commit_id),
+    );
+    active_root_ids.extend(
+        batches
+            .iter()
+            .flat_map(|(_, batch)| batch.checkpoint_roots.iter().copied()),
+    );
+    let mut active_dependency_ids = BTreeSet::new();
+    let mut pending = active_root_ids.iter().copied().collect::<Vec<_>>();
+    let mut replay_debt_ids = Vec::new();
+    let mut seen_manifests = BTreeSet::new();
+    while let Some(commit_id) = pending.pop() {
+        if !seen_manifests.insert(commit_id) {
+            continue;
+        }
+        let Some(manifest) =
+            crate::tracked_state::load_commit_state_manifest(store, commit_id).await?
+        else {
+            continue;
+        };
+        if let Some(source) = manifest.mutations.selected_source_commit_id() {
+            active_dependency_ids.insert(source);
+            pending.push(source);
+        }
+        if let Some(root) = manifest.current_state_scoped_ranges.as_ref() {
+            if let Some(base) = root.serving_base_commit_id {
+                active_dependency_ids.insert(base);
+            }
+        }
+        if let Some(snapshot_root) = manifest.snapshot_root.as_ref() {
+            active_dependency_ids.extend(
+                snapshot_root
+                    .parent_roots
+                    .iter()
+                    .map(|parent| parent.commit_id),
+            );
+        }
+        if manifest.replay_debt.depth != 0 {
+            replay_debt_ids.push(commit_id);
+        }
+    }
+    if !replay_debt_ids.is_empty() {
+        let replay_nodes = CommitGraphContext::new()
+            .reader(store)
+            .load_nodes(&replay_debt_ids)
+            .await?;
+        for (_, node) in replay_nodes {
+            if let Some(node) = node {
+                active_dependency_ids.extend(node.parent_commit_ids);
+            }
+        }
+    }
+    let mut retired_refs = BTreeMap::new();
+    for (_, batch) in batches {
+        for delta in batch.deltas {
+            if let Some(control) = delta.old_control {
+                retired_refs.insert(control.ref_change_id, delta.old_root);
+            }
+        }
+    }
+    let mut reader = ChangelogContext::new().reader(store);
+    let mut entries = Vec::new();
+    let mut start_after = None::<String>;
+    loop {
+        let batch = reader
+            .scan_changes(ChangeScanRequest {
+                start_after: start_after.as_deref(),
+                limit: Some(1_024),
+            })
+            .await?;
+        for change in batch.entries {
+            let reason = if active_refs.contains(&change.change_id) {
+                "active_branch_ref"
+            } else if let Some(old_root) = retired_refs.get(&change.change_id) {
+                if let Some(root) = old_root {
+                    if active_root_ids.contains(root) {
+                        "retired_delta_old_control:active_root_pin"
+                    } else if active_dependency_ids.contains(root) {
+                        "retired_delta_old_control:history_dependency_pin"
+                    } else {
+                        "retired_delta_old_control:reclaimable"
+                    }
+                } else {
+                    "retired_delta_old_control:reclaimable"
+                }
+            } else {
+                "unclassified_no_frontier_delta"
+            };
+            if let Some(old_root) = retired_refs.get(&change.change_id) {
+                entries.push(format!(
+                    "{}:{reason}:old_root={}",
+                    change.change_id,
+                    old_root.map_or_else(|| "none".to_owned(), |root| root.to_string())
+                ));
+            } else if reason == "unclassified_no_frontier_delta" {
+                entries.push(format!(
+                    "{}:{reason}:schema={}:account={}:origin={}",
+                    change.change_id,
+                    change.schema_key,
+                    change.account_id,
+                    change.origin_key.as_deref().unwrap_or("none")
+                ));
+            } else {
+                entries.push(format!("{}:{reason}", change.change_id));
+            }
+        }
+        let Some(next) = batch.next_start_after else {
+            break;
+        };
+        start_after = Some(next.to_string());
+    }
+    Ok(entries)
+}
+
 pub(crate) async fn load_recovery_refs(
     store: &(impl StorageAdapterRead + ?Sized),
 ) -> Result<Vec<CheckpointRecoveryRef>, LixError> {
@@ -748,6 +889,7 @@ fn validate_stored_recovery_ref(
 #[derive(Clone, Debug, Default, Eq, PartialEq)]
 pub(crate) struct RepositoryGcSweep {
     pub(crate) tracked_commit_roots: Vec<CommitId>,
+    pub(crate) standalone_changes: Vec<ChangeId>,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -856,6 +998,7 @@ where
             },
             sweep: RepositoryGcSweep {
                 tracked_commit_roots: Vec::new(),
+                standalone_changes: Vec::new(),
             },
             profile: RepositoryGcProfile {
                 root_discovery_us: elapsed_micros(started),
@@ -984,6 +1127,7 @@ where
     let mut consumed_through = queue_head;
     let mut queue_open = true;
     let mut reclaimed_commits = Vec::new();
+    let mut reclaimed_standalone_changes = BTreeSet::new();
     for (sequence, batch) in batches {
         if queue_open && blocked_sequences.contains(&sequence) {
             queue_open = false;
@@ -1063,6 +1207,32 @@ where
                 &store, writes, old_root, &manifest,
             )
             .await?;
+            if let Some(control) = delta.old_control.as_ref() {
+                if !controls
+                    .iter()
+                    .any(|(_, active)| active.ref_change_id == control.ref_change_id)
+                {
+                    let key = StorageKey(Bytes::from(change_key(control.ref_change_id)));
+                    let existing = PointReadPlan::new(CHANGE_SPACE, std::slice::from_ref(&key))
+                        .materialize(&store, StorageGetOptions::default())
+                        .await?
+                        .value
+                        .into_iter()
+                        .next()
+                        .flatten();
+                    if existing.is_none() {
+                        return Err(LixError::new(
+                            LixError::CODE_INTERNAL_ERROR,
+                            format!(
+                                "retired branch control references missing standalone change '{}'",
+                                control.ref_change_id
+                            ),
+                        ));
+                    }
+                    writes.delete(CHANGE_SPACE, key);
+                    reclaimed_standalone_changes.insert(control.ref_change_id);
+                }
+            }
             reclaimed_commits.push(old_root);
         }
     }
@@ -1122,6 +1292,7 @@ where
         },
         sweep: RepositoryGcSweep {
             tracked_commit_roots: reclaimed_commits,
+            standalone_changes: reclaimed_standalone_changes.into_iter().collect(),
         },
         profile: RepositoryGcProfile {
             root_discovery_us: elapsed_micros(started),
@@ -1253,6 +1424,7 @@ where
         changelog: changelog_plan,
         sweep: RepositoryGcSweep {
             tracked_commit_roots: swept_snapshot_authorities,
+            standalone_changes: Vec::new(),
         },
         profile: RepositoryGcProfile {
             root_discovery_us,
@@ -2416,6 +2588,156 @@ mod tests {
             .await
             .expect("live untracked value should remain readable after GC");
         assert_eq!(visible.rows()[0].values(), &[Value::Json(new_value)]);
+    }
+
+    #[tokio::test]
+    async fn repository_gc_retains_active_history_diff_undo_redo_and_reclaims_deleted_branch_refs()
+    {
+        let storage = Memory::new();
+        Engine::initialize(storage.clone())
+            .await
+            .expect("repository should initialize");
+        let engine = Engine::new(storage.clone())
+            .await
+            .expect("repository should open");
+        let session = engine
+            .open_workspace_session()
+            .await
+            .expect("workspace session should open");
+        let schema = serde_json::json!({
+            "x-lix-key": "gc_history_fixture",
+            "x-lix-primary-key": ["/path"],
+            "type": "object",
+            "required": ["path", "value"],
+            "properties": {
+                "path": { "type": "string" },
+                "value": { "type": ["object", "array", "string", "number", "integer", "boolean", "null"] }
+            },
+            "additionalProperties": false
+        });
+        session
+            .execute(
+                "INSERT INTO lix_registered_schema (value, lixcol_global, lixcol_untracked) VALUES (lix_json($1), false, false)",
+                &[Value::Text(schema.to_string())],
+            )
+            .await
+            .expect("history fixture schema should register");
+        let baseline = session
+            .execute("SELECT commit_id FROM lix_branch WHERE name = 'main'", &[])
+            .await
+            .expect("history baseline should load")
+            .rows()[0]
+            .get::<String>("commit_id")
+            .expect("history baseline should have a commit id");
+        session
+            .execute(
+                "INSERT INTO gc_history_fixture (path, value) VALUES ('/row', lix_json('{\"v\":1}'))",
+                &[],
+            )
+            .await
+            .expect("history fixture first commit should publish");
+        session
+            .execute(
+                "UPDATE gc_history_fixture SET value = lix_json('{\"v\":2}') WHERE path = '/row'",
+                &[],
+            )
+            .await
+            .expect("history fixture second commit should publish");
+        let branch = session
+            .create_branch(crate::CreateBranchOptions {
+                id: Some("01990000-0000-7000-8000-000000000009".to_owned()),
+                name: "gc-history-dead".to_owned(),
+                from_commit_id: None,
+            })
+            .await
+            .expect("history fixture branch should create");
+        session
+            .execute(
+                "DELETE FROM lix_branch WHERE id = $1",
+                &[Value::Text(branch.id)],
+            )
+            .await
+            .expect("history fixture branch should delete");
+
+        let before_changes = {
+            let storage_adapter = StorageAdapter::new(storage.clone());
+            let read = storage_adapter
+                .begin_read(StorageReadOptions::default())
+                .await
+                .expect("history fixture pre-GC read should open");
+            super::scan_all_gc_standalone_changes(read)
+                .await
+                .expect("history fixture standalone scan should load")
+        };
+        let active_refs_before = {
+            let storage_adapter = StorageAdapter::new(storage.clone());
+            let read = storage_adapter
+                .begin_read(StorageReadOptions::default())
+                .await
+                .expect("history fixture control read should open");
+            BranchHeadControlContext::new()
+                .reader(read)
+                .scan()
+                .await
+                .expect("history fixture controls should load")
+                .into_iter()
+                .map(|(_, control)| control.ref_change_id)
+                .collect::<BTreeSet<_>>()
+        };
+        run_repository_gc(&storage).await;
+        let after_changes = {
+            let storage_adapter = StorageAdapter::new(storage.clone());
+            let read = storage_adapter
+                .begin_read(StorageReadOptions::default())
+                .await
+                .expect("history fixture post-GC read should open");
+            super::scan_all_gc_standalone_changes(read)
+                .await
+                .expect("history fixture standalone post-GC scan should load")
+        };
+        let reclaimed = before_changes
+            .keys()
+            .filter(|change_id| !after_changes.contains_key(change_id))
+            .copied()
+            .collect::<BTreeSet<_>>();
+        assert!(
+            !reclaimed.is_empty(),
+            "deleted branch refs should be reclaimed"
+        );
+        assert!(
+            reclaimed.is_disjoint(&active_refs_before),
+            "GC must not reclaim an active branch reference"
+        );
+        assert!(
+            reclaimed.iter().any(|change_id| {
+                before_changes
+                    .get(change_id)
+                    .is_some_and(|change| change.schema_key == "lix_branch_ref")
+            }),
+            "the retired branch's standalone reference must be reclaimed"
+        );
+        let after = after_changes.len();
+        let before = before_changes.len();
+        assert!(after < before, "deleted branch refs should be reclaimed");
+
+        let head = session
+            .execute("SELECT commit_id FROM lix_branch WHERE name = 'main'", &[])
+            .await
+            .expect("history head should remain readable")
+            .rows()[0]
+            .get::<String>("commit_id")
+            .expect("history head should have a commit id");
+        let diff = session
+            .execute(
+                "SELECT COUNT(*) AS entries FROM lix_diff($1, $2) \
+                 WHERE schema_key = 'gc_history_fixture'",
+                &[Value::Text(baseline), Value::Text(head)],
+            )
+            .await
+            .expect("active history diff should survive GC");
+        assert_eq!(diff.rows()[0].get::<i64>("entries").unwrap(), 1);
+        session.undo().await.expect("active undo should survive GC");
+        session.redo().await.expect("active redo should survive GC");
     }
 
     #[tokio::test]

--- a/packages/engine/src/gc.rs
+++ b/packages/engine/src/gc.rs
@@ -12,14 +12,12 @@ use bytes::Bytes;
 
 use crate::branch::BranchHeadControlContext;
 use crate::changelog::{
-    CHANGE_SPACE, ChangeId, ChangeScanRequest, ChangelogContext, ChangelogReader, CommitId,
-    GcLiveSet, GcPlan, GcRepairSet, GcRoot, GcSweepSet, change_key,
+    CHANGE_SPACE, COMMIT_CHANGE_ID_SPACE, COMMIT_SPACE, ChangeId, ChangeScanRequest,
+    ChangelogContext, ChangelogReader, CommitId, CommitLoadRequest, GcLiveSet, GcPlan, GcRepairSet,
+    GcRoot, GcSweepSet, change_key, commit_change_id_key, commit_key,
 };
 #[cfg(test)]
-use crate::changelog::{
-    COMMIT_CHANGE_ID_SPACE, COMMIT_SPACE, ChangeRecord, CommitScanRequest, commit_change_id_key,
-    commit_key,
-};
+use crate::changelog::{ChangeRecord, CommitScanRequest};
 use crate::commit_graph::CommitGraphContext;
 #[cfg(test)]
 use crate::json_store::JsonRef;
@@ -956,11 +954,12 @@ where
             std::iter::once(control.head_commit_id).chain(control.working_diff_checkpoint_commit_id)
         })
         .collect::<BTreeSet<_>>();
-    active_roots.extend(
-        recovery_refs
-            .iter()
-            .map(|recovery| recovery.recovered_head_commit_id),
-    );
+    active_roots.extend(recovery_refs.iter().flat_map(|recovery| {
+        [
+            recovery.recovered_head_commit_id,
+            recovery.checkpoint_commit_id,
+        ]
+    }));
     if active_roots.is_empty() {
         return Err(LixError::new(
             LixError::CODE_INTERNAL_ERROR,
@@ -1015,6 +1014,7 @@ where
     }
     let mut active_authority_ids = active_roots.clone();
     let mut active_dependency_ids = BTreeSet::new();
+    let mut active_semantic_dependency_ids = BTreeSet::new();
     let mut active_manifests = BTreeMap::new();
     let mut pending = active_roots.iter().copied().collect::<Vec<_>>();
     while let Some(commit_id) = pending.pop() {
@@ -1069,6 +1069,7 @@ where
         for (_, node) in replay_nodes.iter() {
             if let Some(node) = node {
                 active_dependency_ids.extend(node.parent_commit_ids.iter().copied());
+                active_semantic_dependency_ids.extend(node.parent_commit_ids.iter().copied());
             }
         }
     }
@@ -1146,13 +1147,22 @@ where
             let Some(old_root) = delta.old_root else {
                 continue;
             };
-            if !retirement_is_proven(
+            let physical_retirement = retirement_is_proven(
                 old_root,
                 delta.new_root,
                 &active_authority_ids,
                 &active_dependency_ids,
-            ) || replay_debt_ids.contains(&old_root)
-            {
+            ) && !replay_debt_ids.contains(&old_root);
+            let semantic_retirement = retirement_is_proven(
+                old_root,
+                delta.new_root,
+                &active_roots,
+                &active_semantic_dependency_ids,
+            );
+            if semantic_retirement {
+                stage_delete_semantic_commit_projection(&store, writes, old_root).await?;
+            }
+            if !physical_retirement {
                 continue;
             }
             let manifest = crate::tracked_state::load_commit_state_manifest(&store, old_root)
@@ -2216,6 +2226,54 @@ fn retirement_is_proven(
     new_root != Some(old_root)
         && !active_authority_ids.contains(&old_root)
         && !active_dependency_ids.contains(&old_root)
+}
+
+/// Removes the semantic commit projection once its root interval is no longer
+/// reachable. Physical tracked-state authority may remain alive as a selected
+/// source or serving dependency, so this decision is intentionally separate
+/// from manifest/CAS retirement.
+async fn stage_delete_semantic_commit_projection<S>(
+    store: &S,
+    writes: &mut StorageWriteSet,
+    commit_id: CommitId,
+) -> Result<(), LixError>
+where
+    S: StorageAdapterRead + ?Sized,
+{
+    let commit_ids = [commit_id];
+    let record = ChangelogContext::new()
+        .reader(store)
+        .load_commits(CommitLoadRequest {
+            commit_ids: &commit_ids,
+        })
+        .await?
+        .into_iter()
+        .next()
+        .and_then(|(_, record)| record);
+    let Some(record) = record else {
+        // A prior GC pass may already have removed the semantic projection
+        // while its physical authority remained pinned.
+        return Ok(());
+    };
+    if record.commit_id != commit_id {
+        return Err(LixError::new(
+            LixError::CODE_INTERNAL_ERROR,
+            format!(
+                "commit projection key for '{commit_id}' contains '{}'",
+                record.commit_id
+            ),
+        ));
+    }
+    writes.delete(COMMIT_SPACE, StorageKey(Bytes::from(commit_key(commit_id))));
+    writes.delete(
+        COMMIT_CHANGE_ID_SPACE,
+        StorageKey(Bytes::from(commit_change_id_key(record.change_id))),
+    );
+    writes.delete(
+        CHANGE_SPACE,
+        StorageKey(Bytes::from(change_key(record.change_id))),
+    );
+    Ok(())
 }
 
 #[cfg(test)]

--- a/packages/engine/src/init.rs
+++ b/packages/engine/src/init.rs
@@ -42,14 +42,14 @@ const REGISTERED_SCHEMA_KEY: &str = "lix_registered_schema";
 
 /// Repository-wide compatibility gate for physical storage protocols.
 ///
-/// V56 separates semantic graph ancestry from physical current-state ancestry.
-/// A serving root authenticates the exact commit/root it structurally reuses,
-/// including merge targets and selected sources. Older repositories must fail
-/// closed rather than reinterpret a first-parent root as this stronger proof.
+/// V57 makes commit-state manifests immutable physical authority. Semantic
+/// commit facts remain owned exclusively by `changelog.commit`; canonical
+/// snapshot metadata stays inside the immutable physical manifest while its
+/// content-addressed tree chunks remain rebuildable.
 pub(crate) const REPOSITORY_PROTOCOL_SPACE: StorageSpace =
     StorageSpace::mutable(StorageSpaceId(0x0004_0011), "repository.protocol.v1");
 pub(crate) const REPOSITORY_PROTOCOL_KEY: &[u8] = b"current";
-const REPOSITORY_PROTOCOL_VALUE: &[u8] = b"authenticated-serving-base-lineage.v56";
+const REPOSITORY_PROTOCOL_VALUE: &[u8] = b"immutable-physical-commit-state.v57";
 
 /// Raw status of the repository protocol marker. Engine opening consults this
 /// before it touches any tracked-head space, whose physical IDs deliberately
@@ -411,23 +411,20 @@ where
                 &initial_mutations,
             )
             .await?;
-        crate::tracked_state::stage_certified_commit_state_manifest(
-            &mut writes,
-            &CommitStateManifest {
-                commit_id: plan.commit.id,
-                generation: 0,
-                parent_commit_ids: plan.commit.parent_ids.clone(),
-                commit_change_id: plan.commit.change_id,
-                account_id: plan.commit.account_id.clone(),
-                created_at: plan.commit.created_at,
-                replay_debt: CommitStateReplayDebt::default(),
-                mutations: initial_mutations,
-                touched_scope_filter: physical_publication.touched_scope_filter().clone(),
-                current_state_scoped_ranges: physical_publication.root(),
-                snapshot_root: Some(snapshot_root),
-            },
-            &physical_publication,
-        )?;
+        let _initial_state =
+            crate::tracked_state::stage_certified_commit_state_manifest_with_handle(
+                &mut writes,
+                &CommitStateManifest {
+                    commit_id: plan.commit.id,
+                    change_account_id: plan.commit.account_id.clone(),
+                    replay_debt: CommitStateReplayDebt::default(),
+                    mutations: initial_mutations,
+                    touched_scope_filter: physical_publication.touched_scope_filter().clone(),
+                    current_state_scoped_ranges: physical_publication.root(),
+                    snapshot_root: Some(Box::new(snapshot_root)),
+                },
+                &physical_publication,
+            )?;
 
         // Seed both visible branches with a complete hot current-state generation.
         // The initial commit is shared, but the branch-scoped marker and
@@ -606,14 +603,10 @@ async fn stage_init_changelog_commit(
     changes: Vec<ChangeRecord>,
 ) -> Result<(), LixError> {
     let commit = CommitRecord {
-        format_version: 1,
+        format_version: 2,
         commit_id: plan.commit.id,
         generation: 0,
         parent_commit_ids: plan.commit.parent_ids.clone(),
-        tracked_state_rootless: false,
-        tracked_state_rootless_depth: 0,
-        tracked_state_rootless_rows: 0,
-        tracked_state_rootless_bytes: 0,
         change_id: plan.commit.change_id,
         account_id: plan.commit.account_id.clone(),
         created_at: plan.commit.created_at,

--- a/packages/engine/src/init.rs
+++ b/packages/engine/src/init.rs
@@ -42,15 +42,15 @@ const REGISTERED_SCHEMA_KEY: &str = "lix_registered_schema";
 
 /// Repository-wide compatibility gate for physical storage protocols.
 ///
-/// V58 splits immutable commit-state authority into a compact header and an
-/// authenticated, hierarchical mutation catalog. Semantic commit facts remain
+/// V59 adds the authenticated root-reachability frontier consumed by ordinary
+/// GC on top of the compact immutable commit-state authority. Semantic commit facts remain
 /// owned exclusively by `changelog.commit`; canonical snapshot metadata stays
 /// inside the immutable physical authority while its content-addressed tree
 /// chunks remain rebuildable.
 pub(crate) const REPOSITORY_PROTOCOL_SPACE: StorageSpace =
     StorageSpace::mutable(StorageSpaceId(0x0004_0011), "repository.protocol.v1");
 pub(crate) const REPOSITORY_PROTOCOL_KEY: &[u8] = b"current";
-const REPOSITORY_PROTOCOL_VALUE: &[u8] = b"immutable-physical-commit-state.v58";
+const REPOSITORY_PROTOCOL_VALUE: &[u8] = b"immutable-physical-commit-state.v60";
 
 /// Raw status of the repository protocol marker. Engine opening consults this
 /// before it touches any tracked-head space, whose physical IDs deliberately
@@ -498,6 +498,7 @@ where
         }
     }
     crate::catalog::stage_catalog_revision(&mut writes);
+    crate::gc::stage_reachability_queue_seed(&mut writes)?;
     stage_repository_protocol(&mut writes);
 
     storage

--- a/packages/engine/src/init.rs
+++ b/packages/engine/src/init.rs
@@ -42,14 +42,15 @@ const REGISTERED_SCHEMA_KEY: &str = "lix_registered_schema";
 
 /// Repository-wide compatibility gate for physical storage protocols.
 ///
-/// V57 makes commit-state manifests immutable physical authority. Semantic
-/// commit facts remain owned exclusively by `changelog.commit`; canonical
-/// snapshot metadata stays inside the immutable physical manifest while its
-/// content-addressed tree chunks remain rebuildable.
+/// V58 splits immutable commit-state authority into a compact header and an
+/// authenticated, hierarchical mutation catalog. Semantic commit facts remain
+/// owned exclusively by `changelog.commit`; canonical snapshot metadata stays
+/// inside the immutable physical authority while its content-addressed tree
+/// chunks remain rebuildable.
 pub(crate) const REPOSITORY_PROTOCOL_SPACE: StorageSpace =
     StorageSpace::mutable(StorageSpaceId(0x0004_0011), "repository.protocol.v1");
 pub(crate) const REPOSITORY_PROTOCOL_KEY: &[u8] = b"current";
-const REPOSITORY_PROTOCOL_VALUE: &[u8] = b"immutable-physical-commit-state.v57";
+const REPOSITORY_PROTOCOL_VALUE: &[u8] = b"immutable-physical-commit-state.v58";
 
 /// Raw status of the repository protocol marker. Engine opening consults this
 /// before it touches any tracked-head space, whose physical IDs deliberately
@@ -1009,6 +1010,35 @@ mod tests {
             )
             .await
             .expect("old protocol marker should stage");
+        let read = storage
+            .begin_read(crate::storage_adapter::StorageReadOptions::default())
+            .await
+            .expect("protocol read should open");
+
+        assert_eq!(
+            repository_protocol_status(&read)
+                .await
+                .expect("protocol status should load"),
+            RepositoryProtocolStatus::Unsupported
+        );
+    }
+
+    #[tokio::test]
+    async fn repository_protocol_rejects_pre_split_commit_state_marker() {
+        let storage = StorageAdapter::new(Memory::new());
+        let mut writes = StorageWriteSet::new();
+        writes.put(
+            REPOSITORY_PROTOCOL_SPACE,
+            REPOSITORY_PROTOCOL_KEY,
+            &b"immutable-physical-commit-state.v57"[..],
+        );
+        storage
+            .commit_write_set(
+                writes,
+                crate::storage_adapter::StorageWriteOptions::default(),
+            )
+            .await
+            .expect("pre-split protocol marker should stage");
         let read = storage
             .begin_read(crate::storage_adapter::StorageReadOptions::default())
             .await

--- a/packages/engine/src/json_store/context.rs
+++ b/packages/engine/src/json_store/context.rs
@@ -4,9 +4,12 @@ use crate::json_store::types::{
     JsonLoadBatch, JsonLoadRequestRef, JsonRef, JsonWritePlacementRef, NormalizedJsonRef,
 };
 use crate::storage_adapter::{
-    BufferRange, EncodedMutationBatch, EncodedPut, ScanPlan, StorageAdapterRead,
-    StorageCoreProjection, StorageKey, StoragePrefix, StorageScanOptions, StorageSpace,
+    BufferRange, EncodedMutationBatch, EncodedPut, StorageAdapterRead, StorageSpace,
     StorageSpaceId, StorageWriteSet,
+};
+#[cfg(test)]
+use crate::storage_adapter::{
+    ScanPlan, StorageCoreProjection, StorageKey, StoragePrefix, StorageScanOptions,
 };
 use bytes::Bytes;
 use std::collections::HashSet;
@@ -33,6 +36,7 @@ const JSON_REF_BYTES: usize = 32;
 /// Malformed keys are retained as `None` so GC can reclaim the derived record
 /// without treating a corrupt hint as a reason to touch an arbitrary JSON
 /// payload.
+#[cfg(test)]
 #[derive(Clone, Debug)]
 pub(crate) struct UntrackedJsonReclaimCandidate {
     pub(crate) key: StorageKey,
@@ -74,6 +78,7 @@ impl JsonStoreContext {
     /// longer have an owner. This is deliberately a key-only, paged scan: the
     /// hint value carries no data and the caller already holds the complete
     /// logical root set from the same pinned read.
+    #[cfg(test)]
     pub(crate) async fn scan_untracked_reclaim_candidates(
         &self,
         store: &(impl StorageAdapterRead + ?Sized),
@@ -269,6 +274,7 @@ impl JsonStoreWriter {
 
     /// Removes only candidate hints whose payload was proved dead (or whose
     /// key was malformed) from the same pinned GC view.
+    #[cfg(test)]
     pub(crate) fn stage_delete_untracked_reclaim_candidates<I>(
         writes: &mut StorageWriteSet,
         keys: I,

--- a/packages/engine/src/json_store/mod.rs
+++ b/packages/engine/src/json_store/mod.rs
@@ -4,10 +4,11 @@ mod encoded;
 pub(crate) mod store;
 pub(crate) mod types;
 
+#[cfg(test)]
+pub(crate) use context::UntrackedJsonReclaimCandidate;
 #[allow(unused_imports)]
 pub(crate) use context::{
     JsonStoreContext, JsonStoreReader, JsonStoreWriter, UNTRACKED_JSON_RECLAIM_CANDIDATE_SPACE,
-    UntrackedJsonReclaimCandidate,
 };
 pub(crate) use types::{
     JSON_INLINE_MAX_BYTES, JsonLoadRequestRef, JsonReadScopeRef, JsonRef, JsonSlot, JsonSlotRef,

--- a/packages/engine/src/live_state/context.rs
+++ b/packages/engine/src/live_state/context.rs
@@ -2749,14 +2749,10 @@ mod tests {
             let commit_id_text = CommitId::for_test_label(commit_id).to_string();
             let commit_change_id = format!("{commit_id_text}:commit");
             let record = crate::changelog::CommitRecord {
-                format_version: 1,
+                format_version: 2,
                 commit_id: CommitId::for_test_label(&commit_id_text),
                 generation: 0,
                 parent_commit_ids: Vec::new(),
-                tracked_state_rootless: false,
-                tracked_state_rootless_depth: 0,
-                tracked_state_rootless_rows: 0,
-                tracked_state_rootless_bytes: 0,
                 change_id: ChangeId::for_test_label(&commit_change_id),
                 account_id: crate::ANONYMOUS_ACCOUNT_ID.to_string(),
                 created_at: ts("1970-01-01T00:00:00.000Z"),
@@ -2792,16 +2788,12 @@ mod tests {
                 &mut writes,
                 &CommitStateManifest {
                     commit_id: record.commit_id,
-                    generation: record.generation,
-                    parent_commit_ids: record.parent_commit_ids.clone(),
-                    commit_change_id: record.change_id,
-                    account_id: record.account_id.clone(),
-                    created_at: record.created_at,
+                    change_account_id: record.account_id.clone(),
                     replay_debt: CommitStateReplayDebt::default(),
                     mutations: Default::default(),
                     touched_scope_filter: Default::default(),
                     current_state_scoped_ranges: None,
-                    snapshot_root: Some(snapshot_root),
+                    snapshot_root: Some(Box::new(snapshot_root)),
                 },
             )
             .expect("empty commit-state authority should stage");
@@ -2990,15 +2982,10 @@ mod tests {
         for (commit_id, generation, parents) in [(parent, 0, Vec::new()), (child, 1, vec![parent])]
         {
             append.commits.push(crate::changelog::CommitRecord {
-                format_version: 1,
+                format_version: 2,
                 commit_id,
                 generation,
                 parent_commit_ids: parents,
-                tracked_state_rootless: true,
-                tracked_state_rootless_depth: u16::try_from(generation + 1)
-                    .expect("fixture generation should fit replay depth"),
-                tracked_state_rootless_rows: 0,
-                tracked_state_rootless_bytes: 0,
                 change_id: ChangeId::for_test_label(&format!("{commit_id}:change")),
                 account_id: crate::ANONYMOUS_ACCOUNT_ID.to_string(),
                 created_at: ts("1970-01-01T00:00:00.000Z"),
@@ -3016,15 +3003,12 @@ mod tests {
                 &mut writes,
                 &CommitStateManifest {
                     commit_id: record.commit_id,
-                    generation: record.generation,
-                    parent_commit_ids: record.parent_commit_ids,
-                    commit_change_id: record.change_id,
-                    account_id: record.account_id,
-                    created_at: record.created_at,
+                    change_account_id: record.account_id.clone(),
                     replay_debt: CommitStateReplayDebt {
-                        depth: record.tracked_state_rootless_depth,
-                        rows: record.tracked_state_rootless_rows,
-                        bytes: record.tracked_state_rootless_bytes,
+                        depth: u16::try_from(record.generation + 1)
+                            .expect("fixture generation should fit replay depth"),
+                        rows: 0,
+                        bytes: 0,
                     },
                     mutations: Default::default(),
                     touched_scope_filter: Default::default(),
@@ -3176,14 +3160,10 @@ mod tests {
                 .map(|id| CommitId::for_test_label(id))
                 .collect::<Vec<_>>();
             let record = crate::changelog::CommitRecord {
-                format_version: 1,
+                format_version: 2,
                 commit_id: CommitId::for_test_label(&commit_id),
                 generation,
                 parent_commit_ids: typed_parent_ids,
-                tracked_state_rootless: false,
-                tracked_state_rootless_depth: 0,
-                tracked_state_rootless_rows: 0,
-                tracked_state_rootless_bytes: 0,
                 change_id: ChangeId::for_test_label(&commit_change_id),
                 account_id: crate::ANONYMOUS_ACCOUNT_ID.to_string(),
                 created_at: commit_created_at,
@@ -3238,16 +3218,12 @@ mod tests {
                 writes,
                 &CommitStateManifest {
                     commit_id: record.commit_id,
-                    generation: record.generation,
-                    parent_commit_ids: record.parent_commit_ids,
-                    commit_change_id: record.change_id,
-                    account_id: record.account_id,
-                    created_at: record.created_at,
+                    change_account_id: record.account_id.clone(),
                     replay_debt: CommitStateReplayDebt::default(),
                     mutations: mutation_inventory,
                     touched_scope_filter: Default::default(),
                     current_state_scoped_ranges: None,
-                    snapshot_root: Some(snapshot_root),
+                    snapshot_root: Some(Box::new(snapshot_root)),
                 },
             )?;
         }

--- a/packages/engine/src/live_state/mod.rs
+++ b/packages/engine/src/live_state/mod.rs
@@ -24,6 +24,8 @@ pub(crate) use reader::LiveStateReader;
 pub(crate) use reader::load_exact_batch_via_scan_for_test;
 #[cfg(test)]
 pub(crate) use tracked_head::TrackedHeadDeltaRef;
+#[cfg(test)]
+pub(crate) use tracked_head::stage_collect_stale_working_diff_indexes;
 #[allow(unused_imports)]
 pub(crate) use tracked_head::{
     CERTIFIED_ENTITY_BATCH_MANIFEST_SPACE, CERTIFIED_ENTITY_BATCH_PAGE_SPACE,
@@ -36,8 +38,7 @@ pub(crate) use tracked_head::{
     TRACKED_WORKING_DIFF_MARKER_SPACE, TrackedHeadContext, TrackedWorkingDiff,
     TrackedWorkingDiffEpoch, WorkingDiffIndexCoverage, materialize_certified_root_rows,
     scan_certified_history_rows, stage_certified_entity_batches,
-    stage_collect_stale_working_diff_indexes, stage_delete_tracked_working_diff_epoch,
-    stage_tracked_working_diff_epoch,
+    stage_delete_tracked_working_diff_epoch, stage_tracked_working_diff_epoch,
 };
 #[allow(unused_imports)]
 pub(crate) use types::{

--- a/packages/engine/src/live_state/tracked_head.rs
+++ b/packages/engine/src/live_state/tracked_head.rs
@@ -30,7 +30,9 @@ pub(crate) struct ColumnarBaseCoordinate {
     pub(crate) row_index: u32,
 }
 
-use std::collections::{BTreeMap, BTreeSet};
+#[cfg(test)]
+use std::collections::BTreeMap;
+use std::collections::BTreeSet;
 use std::sync::Arc;
 
 use bytes::Bytes;
@@ -274,6 +276,7 @@ struct BranchRef<'a> {
 
 #[derive(Debug, Clone, musli::Encode, musli::Decode)]
 #[musli(packed)]
+#[cfg(test)]
 struct BranchRefKey {
     branch_id: String,
 }
@@ -473,6 +476,7 @@ impl TrackedHeadContext {
     /// may use historical replay, but that same generation preserves the
     /// branch's history-free untracked members until a fresh complete serving
     /// generation is published.
+    #[cfg(test)]
     pub(crate) async fn stage_collect_stale_current_state_generations<S>(
         &self,
         store: &S,
@@ -489,6 +493,7 @@ impl TrackedHeadContext {
 /// Converts the branch-control plane into the exact derived generations that
 /// are still reachable. A branch generation is meaningful only together with
 /// its branch id; a generation UUID alone is not a repository-global root.
+#[cfg(test)]
 fn active_current_state_generations(
     controls: &[(String, BranchHeadControl)],
 ) -> BTreeSet<(String, CommitId)> {
@@ -736,6 +741,7 @@ async fn load_tracked_working_diff_epoch(
 /// checkpoint epoch. This deliberately runs only from repository GC: a
 /// checkpoint reset is O(1), while old index prefixes are unreachable as soon
 /// as its marker commits.
+#[cfg(test)]
 pub(crate) async fn stage_collect_stale_working_diff_indexes<S>(
     store: &S,
     writes: &mut StorageWriteSet,
@@ -767,6 +773,7 @@ where
         .await
 }
 
+#[cfg(test)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 struct ActiveWorkingDiffScope {
     checkpoint_commit_id: CommitId,
@@ -777,6 +784,7 @@ struct ActiveWorkingDiffScope {
 /// authoritative branch control. Broken auxiliary bytes are reclaimed here
 /// rather than turning background GC into a retry loop; normal readers already
 /// select canonical replay for the same cases.
+#[cfg(test)]
 async fn stage_active_working_diff_scopes<S>(
     store: &S,
     writes: &mut StorageWriteSet,

--- a/packages/engine/src/live_state/tracked_head/hot.rs
+++ b/packages/engine/src/live_state/tracked_head/hot.rs
@@ -5677,6 +5677,199 @@ where
         Ok((generation, !replaced.is_empty()))
     }
 
+    /// Attempts to prove that an ordinary Replace/upsert batch covers one
+    /// complete packed collection, then publishes it through the replacement
+    /// lane. The persisted count alone is insufficient: equality of the
+    /// ordered identity digest proves that no current member is omitted and
+    /// no unrelated identity is introduced.
+    pub(crate) async fn try_stage_exact_collection_replacement_current_base(
+        &mut self,
+        branch_id: &str,
+        generation: CommitId,
+        new_head: CommitId,
+        deltas: &[CurrentStateDeltaRef<'_>],
+        entity_columnar_write_sets: &crate::live_state::EntityColumnarWriteSets,
+        working_diff_capture_checkpoint_commit_id: Option<CommitId>,
+        coverage: &mut WorkingDiffIndexCoverage,
+    ) -> Result<Option<CommitId>, LixError> {
+        let Some(first) = deltas.first() else {
+            return Ok(None);
+        };
+        let schema_key = first.schema_key;
+        if deltas.iter().any(|delta| {
+            delta.schema_key != schema_key
+                || delta.file_id.is_some()
+                || delta.untracked
+                || delta.deleted
+                || delta.commit_id != Some(new_head)
+                || delta.change_id.is_none()
+        }) {
+            return Ok(None);
+        }
+        let mut entity_pks = deltas
+            .iter()
+            .map(|delta| delta.entity_pk)
+            .collect::<Vec<_>>();
+        entity_pks.sort_unstable();
+        if entity_pks.windows(2).any(|pair| pair[0] == pair[1]) {
+            return Err(head_value_error(
+                "packed collection replacement contains duplicate identities",
+            ));
+        }
+        let Some(identity_digest) =
+            crate::collection_generation::ordered_single_string_identity_digest(
+                entity_pks.iter().copied(),
+            )
+        else {
+            return Ok(None);
+        };
+        let control = load_hot_collection_control(
+            self.store,
+            branch_id,
+            generation,
+            crate::collection_generation::CollectionScopeRef {
+                schema_key,
+                file_id: None,
+            },
+        )
+        .await?;
+        if control.active_generation != generation
+            || control.live_count != u64::try_from(entity_pks.len()).unwrap_or(u64::MAX)
+            || control.ordered_identity_digest != Some(identity_digest)
+        {
+            return Ok(None);
+        }
+        self.stage_complete_collection_replacement_current_base(
+            branch_id,
+            generation,
+            new_head,
+            schema_key,
+            entity_pks.len(),
+            entity_columnar_write_sets,
+            working_diff_capture_checkpoint_commit_id,
+            coverage,
+        )
+        .await
+        .map(|(generation, _)| Some(generation))
+    }
+
+    /// Attempts to collapse an exact row-wise deletion of one untouched
+    /// packed collection into its collection-generation control. Historical
+    /// tombstones remain authoritative in the commit delta; current state
+    /// needs only the new empty-generation fence and retirement of the old
+    /// exclusive packed base.
+    pub(crate) async fn try_stage_exact_collection_delete_current_base(
+        &mut self,
+        branch_id: &str,
+        generation: CommitId,
+        new_head: CommitId,
+        deltas: &[CurrentStateDeltaRef<'_>],
+        working_diff_capture_checkpoint_commit_id: Option<CommitId>,
+    ) -> Result<Option<CommitId>, LixError> {
+        if working_diff_capture_checkpoint_commit_id.is_some() {
+            return Ok(None);
+        }
+        let Some(first) = deltas.first() else {
+            return Ok(None);
+        };
+        let schema_key = first.schema_key;
+        if deltas.iter().any(|delta| {
+            delta.schema_key != schema_key
+                || delta.file_id.is_some()
+                || delta.untracked
+                || !delta.deleted
+                || delta.commit_id != Some(new_head)
+                || delta.change_id.is_none()
+        }) {
+            return Ok(None);
+        }
+        let mut entity_pks = deltas
+            .iter()
+            .map(|delta| delta.entity_pk)
+            .collect::<Vec<_>>();
+        entity_pks.sort_unstable();
+        if entity_pks.windows(2).any(|pair| pair[0] == pair[1]) {
+            return Err(head_value_error(
+                "packed collection deletion contains duplicate identities",
+            ));
+        }
+        let Some(identity_digest) =
+            crate::collection_generation::ordered_single_string_identity_digest(
+                entity_pks.iter().copied(),
+            )
+        else {
+            return Ok(None);
+        };
+        let control = load_hot_collection_control(
+            self.store,
+            branch_id,
+            generation,
+            crate::collection_generation::CollectionScopeRef {
+                schema_key,
+                file_id: None,
+            },
+        )
+        .await?;
+        if control.active_generation != generation
+            || control.live_count != u64::try_from(entity_pks.len()).unwrap_or(u64::MAX)
+            || control.ordered_identity_digest != Some(identity_digest)
+        {
+            return Ok(None);
+        }
+
+        let replaced =
+            packed_exclusive_schema_base_refs(self.store, branch_id, generation, schema_key)
+                .await?;
+        if replaced.is_empty() {
+            return Ok(None);
+        }
+        let base_keys = replaced
+            .iter()
+            .map(|base_ref| {
+                let mut key = hot_scope_prefix(branch_id, generation);
+                key.reserve(16);
+                key.extend_from_slice(base_ref.commit_id.as_uuid().as_bytes());
+                StorageKey(Bytes::from(key))
+            })
+            .collect::<Vec<_>>();
+        let base_values = PointReadPlan::new(PACKED_CURRENT_BASE_SPACE, &base_keys)
+            .materialize(self.store, StorageGetOptions::default())
+            .await?
+            .value;
+        for value in base_values {
+            let value = value.ok_or_else(|| {
+                head_value_error(
+                    "exclusive-schema index references an inactive packed current base",
+                )
+            })?;
+            if full_value_bytes(value)?.as_ref() != [0; 16] {
+                return Ok(None);
+            }
+        }
+        for (base_ref, base_key) in replaced.iter().zip(base_keys) {
+            self.writes.delete(PACKED_CURRENT_BASE_SPACE, base_key);
+            self.writes.delete(
+                PACKED_CURRENT_EXCLUSIVE_SCHEMA_BASE_SPACE,
+                StorageKey(base_ref.index_key.clone()),
+            );
+        }
+        stage_hot_collection_control(
+            self.writes,
+            branch_id,
+            generation,
+            crate::collection_generation::CollectionScopeRef {
+                schema_key,
+                file_id: None,
+            },
+            HotCollectionControl {
+                active_generation: new_head,
+                live_count: 0,
+                ordered_identity_digest: None,
+            },
+        )?;
+        Ok(Some(generation))
+    }
+
     /// Publishes validated, tracked, unfiled creates as an immutable base.
     ///
     /// The commit-delta plane already owns the sorted identities and payloads,
@@ -5684,7 +5877,7 @@ where
     /// row is pure write amplification. This path retains only collection
     /// counts plus one generation-to-commit reference. Ordinary mutations
     /// continue to shadow the base through HOT rows.
-    pub(crate) async fn stage_packed_insert_current_base(
+    pub(crate) async fn try_stage_packed_insert_current_base(
         &mut self,
         branch_id: &str,
         generation: CommitId,
@@ -5693,10 +5886,10 @@ where
         absence_guards: &[TrackedStateKeyRef<'_>],
         working_diff_capture_checkpoint_commit_id: Option<CommitId>,
         coverage: &mut WorkingDiffIndexCoverage,
-    ) -> Result<CommitId, LixError> {
-        if deltas.is_empty() || deltas.len() != absence_guards.len() {
+    ) -> Result<Option<CommitId>, LixError> {
+        if deltas.is_empty() {
             return Err(head_value_error(
-                "packed current base requires one absence proof per inserted row",
+                "packed current base requires at least one inserted row",
             ));
         }
         let mut sorted = deltas.iter().collect::<Vec<_>>();
@@ -5720,21 +5913,6 @@ where
         {
             return Err(current_state_duplicate_delta_error(sorted[1]));
         }
-        let mut guarded = absence_guards
-            .iter()
-            .map(|guard| (guard.schema_key, guard.entity_pk, guard.file_id))
-            .collect::<Vec<_>>();
-        guarded.sort_unstable();
-        if sorted
-            .iter()
-            .map(|delta| (delta.schema_key, delta.entity_pk, delta.file_id))
-            .ne(guarded)
-        {
-            return Err(head_value_error(
-                "packed current base rows do not exactly match their validated absence proofs",
-            ));
-        }
-
         let mut schema_rows = BTreeMap::<&str, Vec<&EntityPk>>::new();
         for delta in &sorted {
             schema_rows
@@ -5742,6 +5920,44 @@ where
                 .or_default()
                 .push(delta.entity_pk);
         }
+        if absence_guards.is_empty() {
+            // Generic Replace/upsert batches do not carry INSERT-shaped
+            // per-row guards. An exact empty collection control is a stronger,
+            // constant-size proof that every identity in that scope is absent.
+            // The caller's branch-head CAS keeps this snapshot valid through
+            // publication. Root-backed deferred counts deliberately fail this
+            // certificate and remain on the ordinary row-addressable path.
+            let scopes = schema_rows
+                .keys()
+                .map(
+                    |schema_key| crate::collection_generation::CollectionScopeRef {
+                        schema_key,
+                        file_id: None,
+                    },
+                )
+                .collect::<Vec<_>>();
+            let controls =
+                load_hot_collection_controls(self.store, branch_id, generation, &scopes).await?;
+            if controls.iter().any(|control| control.live_count != 0) {
+                return Ok(None);
+            }
+        } else {
+            let mut guarded = absence_guards
+                .iter()
+                .map(|guard| (guard.schema_key, guard.entity_pk, guard.file_id))
+                .collect::<Vec<_>>();
+            guarded.sort_unstable();
+            if sorted
+                .iter()
+                .map(|delta| (delta.schema_key, delta.entity_pk, delta.file_id))
+                .ne(guarded)
+            {
+                return Err(head_value_error(
+                    "packed current base rows do not exactly match their validated absence proofs",
+                ));
+            }
+        }
+
         let schema_increments = schema_rows
             .into_iter()
             .map(|(schema_key, entity_pks)| {
@@ -5768,6 +5984,7 @@ where
             coverage,
         )
         .await
+        .map(Some)
     }
 
     async fn stage_packed_insert_current_base_manifest(

--- a/packages/engine/src/live_state/tracked_head/hot.rs
+++ b/packages/engine/src/live_state/tracked_head/hot.rs
@@ -5194,6 +5194,7 @@ where
         load_tracked_working_diff_epoch(&self.store, branch_id).await
     }
 
+    #[cfg(test)]
     pub(crate) async fn untracked_json_refs(
         &self,
         controls: &[(String, BranchHeadControl)],
@@ -10274,6 +10275,7 @@ fn decode_hot_row_key_in_scope(bytes: &[u8], scope: &[u8]) -> Result<HeadRowIden
     })
 }
 
+#[cfg(test)]
 fn decode_hot_row_scope(bytes: &[u8]) -> Result<(String, CommitId), LixError> {
     let mut offset = 0;
     let (branch_id, branch_terminator) = read_key_string(bytes, &mut offset, "branch id")?;
@@ -10309,6 +10311,7 @@ fn encode_hot_file_schema_key(scope: &[u8], schema_key: &str) -> Vec<u8> {
     key
 }
 
+#[cfg(test)]
 fn decode_hot_file_scope(bytes: &[u8]) -> Result<(String, CommitId), LixError> {
     let mut offset = 0;
     let (branch_id, branch_terminator) = read_key_string(bytes, &mut offset, "branch id")?;
@@ -10331,6 +10334,7 @@ fn decode_hot_file_scope(bytes: &[u8]) -> Result<(String, CommitId), LixError> {
     Ok((branch_id, generation))
 }
 
+#[cfg_attr(not(test), expect(dead_code))]
 struct HotDiffSegmentScope {
     branch_id: String,
     checkpoint_commit_id: CommitId,
@@ -10446,6 +10450,7 @@ fn visit_hot_diff_segment(
     Ok(())
 }
 
+#[cfg(test)]
 fn decode_hot_diff_key(bytes: &[u8]) -> Result<(CommitId, HeadIdentity), LixError> {
     let mut offset = 0;
     let (branch_id, branch_terminator) = read_key_string(bytes, &mut offset, "branch id")?;
@@ -10490,6 +10495,7 @@ fn collect_hot_untracked_refs(value: HeadValueView<'_>, refs: &mut BTreeSet<[u8;
     }
 }
 
+#[cfg(test)]
 pub(crate) async fn stage_collect_stale_hot_generations<S>(
     store: &S,
     writes: &mut StorageWriteSet,
@@ -10565,6 +10571,7 @@ where
         .collect())
 }
 
+#[cfg(test)]
 fn decode_hot_collection_control_scope(bytes: &[u8]) -> Result<(String, CommitId), LixError> {
     let mut offset = 0;
     let (branch_id, branch_terminator) = read_key_string(bytes, &mut offset, "branch id")?;
@@ -10577,6 +10584,7 @@ fn decode_hot_collection_control_scope(bytes: &[u8]) -> Result<(String, CommitId
     Ok((branch_id, generation))
 }
 
+#[cfg(test)]
 async fn stage_collect_stale_hot_collection_controls(
     store: &(impl StorageAdapterRead + ?Sized),
     writes: &mut StorageWriteSet,
@@ -10614,6 +10622,7 @@ async fn stage_collect_stale_hot_collection_controls(
     Ok(())
 }
 
+#[cfg(test)]
 async fn stage_collect_stale_hot_space(
     store: &(impl StorageAdapterRead + ?Sized),
     writes: &mut StorageWriteSet,
@@ -10662,6 +10671,7 @@ async fn stage_collect_stale_hot_space(
     Ok(deleted_any)
 }
 
+#[cfg(test)]
 pub(crate) async fn stage_collect_stale_hot_diff_records<S>(
     store: &S,
     writes: &mut StorageWriteSet,

--- a/packages/engine/src/live_state/tracked_head/hot.rs
+++ b/packages/engine/src/live_state/tracked_head/hot.rs
@@ -2085,17 +2085,11 @@ async fn load_hot_collection_control(
     {
         return Ok(control);
     }
-    if load_root_current_base_commit(store, branch_id, branch_generation)
-        .await?
-        .is_some()
+    if let Some(base_commit_id) =
+        load_root_current_base_commit(store, branch_id, branch_generation).await?
     {
-        Box::pin(load_root_collection_control(
-            store,
-            branch_id,
-            branch_generation,
-            scope,
-        ))
-        .await
+        load_root_collection_control_from_base(store, base_commit_id, branch_generation, scope)
+            .await
     } else {
         Ok(HotCollectionControl {
             active_generation: branch_generation,
@@ -2170,21 +2164,12 @@ async fn load_hot_collection_visibility_control(
     storage_codec::decode("hot collection control", &bytes)
 }
 
-async fn load_root_collection_control(
+async fn load_root_collection_control_from_base(
     store: &(impl StorageAdapterRead + ?Sized),
-    branch_id: &str,
+    base_commit_id: CommitId,
     branch_generation: CommitId,
     scope: crate::collection_generation::CollectionScopeRef<'_>,
 ) -> Result<HotCollectionControl, LixError> {
-    let Some(base_commit_id) =
-        load_root_current_base_commit(store, branch_id, branch_generation).await?
-    else {
-        return Ok(HotCollectionControl {
-            active_generation: branch_generation,
-            live_count: 0,
-            ordered_identity_digest: None,
-        });
-    };
     let active_generation = load_root_active_collection_generations(store, base_commit_id, [scope])
         .await?
         .get(&(
@@ -2211,31 +2196,49 @@ async fn load_hot_collection_controls(
     }
     let values =
         load_stored_hot_collection_controls(store, branch_id, branch_generation, scopes).await?;
+    let missing_scopes = scopes
+        .iter()
+        .copied()
+        .zip(&values)
+        .filter_map(|(scope, value)| value.is_none().then_some(scope))
+        .collect::<Vec<_>>();
+    let root_generations = if missing_scopes.is_empty() {
+        None
+    } else if let Some(base_commit_id) =
+        load_root_current_base_commit(store, branch_id, branch_generation).await?
+    {
+        Some(
+            load_root_active_collection_generations(
+                store,
+                base_commit_id,
+                missing_scopes.iter().copied(),
+            )
+            .await?,
+        )
+    } else {
+        None
+    };
     let mut controls = Vec::with_capacity(scopes.len());
     for (scope, value) in scopes.iter().copied().zip(values) {
-        controls.push(match value {
-            Some(control) => Ok(control),
-            None => {
-                if load_root_current_base_commit(store, branch_id, branch_generation)
-                    .await?
-                    .is_some()
-                {
-                    Box::pin(load_root_collection_control(
-                        store,
-                        branch_id,
-                        branch_generation,
-                        scope,
+        controls.push(match (value, root_generations.as_ref()) {
+            (Some(control), _) => control,
+            (None, Some(generations)) => HotCollectionControl {
+                active_generation: generations
+                    .get(&(
+                        scope.schema_key.to_owned(),
+                        scope.file_id.map(str::to_owned),
                     ))
-                    .await
-                } else {
-                    Ok(HotCollectionControl {
-                        active_generation: branch_generation,
-                        live_count: 0,
-                        ordered_identity_digest: None,
-                    })
-                }
-            }
-        }?);
+                    .map(|generation| generation.commit_id)
+                    .unwrap_or(branch_generation),
+                live_count: DEFERRED_ROOT_LIVE_COUNT,
+                ordered_identity_digest: None,
+            },
+            (None, None) => HotCollectionControl {
+                active_generation: branch_generation,
+                live_count: 0,
+                ordered_identity_digest: None,
+            },
+        });
     }
     Ok(controls)
 }
@@ -5467,6 +5470,7 @@ where
             generation,
             new_head,
             schema_increments,
+            None,
             working_diff_capture_checkpoint_commit_id,
             coverage,
         )
@@ -5510,6 +5514,7 @@ where
             generation,
             new_head,
             schema_increments,
+            None,
             working_diff_capture_checkpoint_commit_id,
             coverage,
         )
@@ -5550,6 +5555,32 @@ where
             },
         )
         .await?;
+        self.stage_complete_collection_replacement_current_base_with_control(
+            branch_id,
+            generation,
+            new_head,
+            schema_key,
+            row_count,
+            control,
+            entity_columnar_write_sets,
+            working_diff_capture_checkpoint_commit_id,
+            coverage,
+        )
+        .await
+    }
+
+    async fn stage_complete_collection_replacement_current_base_with_control(
+        &mut self,
+        branch_id: &str,
+        generation: CommitId,
+        new_head: CommitId,
+        schema_key: &str,
+        row_count: u64,
+        control: HotCollectionControl,
+        entity_columnar_write_sets: &crate::live_state::EntityColumnarWriteSets,
+        working_diff_capture_checkpoint_commit_id: Option<CommitId>,
+        coverage: &mut WorkingDiffIndexCoverage,
+    ) -> Result<(CommitId, bool), LixError> {
         let live_count = if control.live_count == DEFERRED_ROOT_LIVE_COUNT {
             let reader = HotStateStoreReader {
                 store: &*self.store,
@@ -5686,6 +5717,7 @@ where
         &mut self,
         branch_id: &str,
         generation: CommitId,
+        parent_commit_id: CommitId,
         new_head: CommitId,
         deltas: &[CurrentStateDeltaRef<'_>],
         entity_columnar_write_sets: &crate::live_state::EntityColumnarWriteSets,
@@ -5723,6 +5755,17 @@ where
         else {
             return Ok(None);
         };
+        if !self
+            .authoritative_collection_matches(
+                parent_commit_id,
+                schema_key,
+                &entity_pks,
+                identity_digest,
+            )
+            .await?
+        {
+            return Ok(None);
+        }
         let control = load_hot_collection_control(
             self.store,
             branch_id,
@@ -5739,12 +5782,13 @@ where
         {
             return Ok(None);
         }
-        self.stage_complete_collection_replacement_current_base(
+        self.stage_complete_collection_replacement_current_base_with_control(
             branch_id,
             generation,
             new_head,
             schema_key,
-            entity_pks.len(),
+            u64::try_from(entity_pks.len()).unwrap_or(u64::MAX),
+            control,
             entity_columnar_write_sets,
             working_diff_capture_checkpoint_commit_id,
             coverage,
@@ -5762,6 +5806,7 @@ where
         &mut self,
         branch_id: &str,
         generation: CommitId,
+        parent_commit_id: CommitId,
         new_head: CommitId,
         deltas: &[CurrentStateDeltaRef<'_>],
         working_diff_capture_checkpoint_commit_id: Option<CommitId>,
@@ -5800,6 +5845,17 @@ where
         else {
             return Ok(None);
         };
+        if !self
+            .authoritative_collection_matches(
+                parent_commit_id,
+                schema_key,
+                &entity_pks,
+                identity_digest,
+            )
+            .await?
+        {
+            return Ok(None);
+        }
         let control = load_hot_collection_control(
             self.store,
             branch_id,
@@ -5870,6 +5926,47 @@ where
         Ok(Some(generation))
     }
 
+    /// Recomputes a full-collection certificate from immutable tracked-state
+    /// authority before a derived HOT control is allowed to retire a base.
+    /// A corrupt or stale control can therefore disable the compact route,
+    /// but it can never make omitted identities disappear from current state.
+    async fn authoritative_collection_matches(
+        &self,
+        parent_commit_id: CommitId,
+        schema_key: &str,
+        expected_entity_pks: &[&EntityPk],
+        expected_identity_digest: [u8; 32],
+    ) -> Result<bool, LixError> {
+        let mut reader = crate::tracked_state::TrackedStateContext::new().reader(&*self.store);
+        let rows = reader
+            .scan_batch_at_commit(
+                &parent_commit_id.to_string(),
+                &TrackedStateScanRequest {
+                    filter: TrackedStateFilter {
+                        schema_keys: vec![schema_key.to_owned()],
+                        file_ids: vec![NullableKeyFilter::Null],
+                        ..TrackedStateFilter::default()
+                    },
+                    ..TrackedStateScanRequest::default()
+                },
+            )
+            .await?;
+        if rows.len() != expected_entity_pks.len() {
+            return Ok(false);
+        }
+        let mut authoritative_entity_pks =
+            rows.iter().map(|row| row.entity_pk()).collect::<Vec<_>>();
+        authoritative_entity_pks.sort_unstable();
+        if authoritative_entity_pks.as_slice() != expected_entity_pks {
+            return Ok(false);
+        }
+        Ok(
+            crate::collection_generation::ordered_single_string_identity_digest(
+                authoritative_entity_pks,
+            ) == Some(expected_identity_digest),
+        )
+    }
+
     /// Publishes validated, tracked, unfiled creates as an immutable base.
     ///
     /// The commit-delta plane already owns the sorted identities and payloads,
@@ -5920,7 +6017,7 @@ where
                 .or_default()
                 .push(delta.entity_pk);
         }
-        if absence_guards.is_empty() {
+        let preloaded_controls = if absence_guards.is_empty() {
             // Generic Replace/upsert batches do not carry INSERT-shaped
             // per-row guards. An exact empty collection control is a stronger,
             // constant-size proof that every identity in that scope is absent.
@@ -5941,6 +6038,7 @@ where
             if controls.iter().any(|control| control.live_count != 0) {
                 return Ok(None);
             }
+            Some(controls)
         } else {
             let mut guarded = absence_guards
                 .iter()
@@ -5956,7 +6054,8 @@ where
                     "packed current base rows do not exactly match their validated absence proofs",
                 ));
             }
-        }
+            None
+        };
 
         let schema_increments = schema_rows
             .into_iter()
@@ -5980,6 +6079,7 @@ where
             generation,
             new_head,
             schema_increments,
+            preloaded_controls,
             working_diff_capture_checkpoint_commit_id,
             coverage,
         )
@@ -5993,6 +6093,7 @@ where
         generation: CommitId,
         new_head: CommitId,
         schema_increments: BTreeMap<&str, PackedCollectionIncrement>,
+        preloaded_controls: Option<Vec<HotCollectionControl>>,
         working_diff_capture_checkpoint_commit_id: Option<CommitId>,
         coverage: &mut WorkingDiffIndexCoverage,
     ) -> Result<CommitId, LixError> {
@@ -6020,8 +6121,17 @@ where
                 },
             )
             .collect::<Vec<_>>();
-        let controls =
-            load_hot_collection_controls(self.store, branch_id, generation, &scopes).await?;
+        let controls = match preloaded_controls {
+            Some(controls) if controls.len() == scopes.len() => controls,
+            Some(_) => {
+                return Err(head_value_error(
+                    "packed current-base control certificate has the wrong scope count",
+                ));
+            }
+            None => {
+                load_hot_collection_controls(self.store, branch_id, generation, &scopes).await?
+            }
+        };
         for ((schema_key, increment), mut control) in schema_increments.into_iter().zip(controls) {
             let was_empty = control.live_count == 0;
             if control.live_count == DEFERRED_ROOT_LIVE_COUNT {
@@ -11337,6 +11447,143 @@ mod tests {
         );
         assert!(bases[1].is_none(), "the exclusive predecessor must retire");
         assert!(bases[2].is_some(), "the replacement base must publish");
+    }
+
+    #[tokio::test]
+    async fn corrupt_collection_control_cannot_certify_omitted_authoritative_members() {
+        const BRANCH_ID: &str = "01920000-0000-7000-8000-0000000000ca";
+        const SCHEMA_KEY: &str = "corrupt_control_schema";
+        let storage = StorageAdapter::new(Memory::new());
+        let parent_commit_id = CommitId::for_test_label("corrupt-control-parent");
+        let entity_pks = [
+            EntityPk::single("entity-a"),
+            EntityPk::single("entity-b"),
+            EntityPk::single("entity-c"),
+        ];
+        let created_at = timestamp();
+        let rows = entity_pks
+            .iter()
+            .enumerate()
+            .map(|(index, entity_pk)| MaterializedTrackedStateRow {
+                entity_pk: entity_pk.clone(),
+                schema_key: SCHEMA_KEY.to_owned(),
+                file_id: None,
+                snapshot_content: Some(format!(r#"{{"index":{index}}}"#).into()),
+                metadata: None,
+                deleted: false,
+                created_at: created_at.to_string(),
+                updated_at: created_at.to_string(),
+                change_id: ChangeId::for_test_label(&format!("corrupt-control-{index}")),
+                commit_id: parent_commit_id,
+            })
+            .collect::<Vec<_>>();
+        crate::test_support::seed_branch_head_with_rows(
+            storage.clone(),
+            BRANCH_ID,
+            "corrupt-control-parent",
+            &rows,
+        )
+        .await;
+
+        let forged_members = [&entity_pks[0], &entity_pks[1]];
+        let forged_digest =
+            crate::collection_generation::ordered_single_string_identity_digest(forged_members)
+                .expect("single-string fixture identities should hash");
+        let mut corrupt_writes = StorageWriteSet::new();
+        stage_hot_collection_control(
+            &mut corrupt_writes,
+            BRANCH_ID,
+            parent_commit_id,
+            crate::collection_generation::CollectionScopeRef {
+                schema_key: SCHEMA_KEY,
+                file_id: None,
+            },
+            HotCollectionControl {
+                active_generation: parent_commit_id,
+                live_count: 2,
+                ordered_identity_digest: Some(forged_digest),
+            },
+        )
+        .expect("forged derived control should encode");
+        storage
+            .commit_write_set(corrupt_writes, StorageWriteOptions::default())
+            .await
+            .expect("forged derived control should commit");
+
+        let new_head = CommitId::for_test_label("corrupt-control-child");
+        let change_ids = [
+            ChangeId::for_test_label("corrupt-control-child-a"),
+            ChangeId::for_test_label("corrupt-control-child-b"),
+        ];
+        let replacement_deltas = forged_members
+            .iter()
+            .zip(change_ids)
+            .map(|(entity_pk, change_id)| CurrentStateDeltaRef {
+                schema_key: SCHEMA_KEY,
+                file_id: None,
+                entity_pk,
+                change_id: Some(change_id),
+                commit_id: Some(new_head),
+                untracked: false,
+                deleted: false,
+                created_at,
+                updated_at: created_at,
+                snapshot: JsonSlotRef::Inline(r#"{"replacement":true}"#),
+                metadata: JsonSlotRef::None,
+                columnar_base_coordinate: None,
+            })
+            .collect::<Vec<_>>();
+        let read = storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("corrupt-control read should open");
+        let mut replacement_writes = StorageWriteSet::new();
+        let replacement = HotStateWriter {
+            store: &read,
+            writes: &mut replacement_writes,
+        }
+        .try_stage_exact_collection_replacement_current_base(
+            BRANCH_ID,
+            parent_commit_id,
+            parent_commit_id,
+            new_head,
+            &replacement_deltas,
+            &crate::live_state::EntityColumnarWriteSets::new(),
+            None,
+            &mut WorkingDiffIndexCoverage::default(),
+        )
+        .await
+        .expect("authority mismatch should fail closed");
+        assert_eq!(replacement, None);
+        assert_eq!(replacement_writes.stats().staged_puts, 0);
+        assert_eq!(replacement_writes.stats().staged_deletes, 0);
+
+        let deletion_deltas = replacement_deltas
+            .iter()
+            .map(|delta| CurrentStateDeltaRef {
+                deleted: true,
+                snapshot: JsonSlotRef::None,
+                ..*delta
+            })
+            .collect::<Vec<_>>();
+        let mut deletion_writes = StorageWriteSet::new();
+        let deletion = HotStateWriter {
+            store: &read,
+            writes: &mut deletion_writes,
+        }
+        .try_stage_exact_collection_delete_current_base(
+            BRANCH_ID,
+            parent_commit_id,
+            parent_commit_id,
+            new_head,
+            &deletion_deltas,
+            None,
+        )
+        .await
+        .expect("delete authority mismatch should fail closed");
+        assert_eq!(deletion, None);
+        assert_eq!(deletion_writes.stats().staged_puts, 0);
+        assert_eq!(deletion_writes.stats().staged_deletes, 0);
     }
 
     #[tokio::test]

--- a/packages/engine/src/session/context.rs
+++ b/packages/engine/src/session/context.rs
@@ -1069,6 +1069,28 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn automatic_write_waits_for_an_active_automatic_write() {
+        let session = open_session().await;
+        let first_write = session
+            .begin_session_write_lease()
+            .await
+            .expect("first automatic write lease should begin");
+        let mut second_write = Box::pin(session.begin_session_write_lease());
+        let mut cx = Context::from_waker(noop_waker_ref());
+        assert!(
+            matches!(second_write.as_mut().poll(&mut cx), Poll::Pending),
+            "second automatic write should wait for the active automatic write"
+        );
+
+        drop(first_write);
+        let second_write = tokio::time::timeout(TEST_WAIT_TIMEOUT, second_write)
+            .await
+            .expect("second automatic write should resume after the first finishes")
+            .expect("second automatic write lease should begin");
+        drop(second_write);
+    }
+
+    #[tokio::test]
     async fn close_waits_for_session_read_blocked_in_storage_read() {
         let (session, gate) = open_blocking_read_session().await;
 

--- a/packages/engine/src/session/execute.rs
+++ b/packages/engine/src/session/execute.rs
@@ -4124,6 +4124,7 @@ fn sql_uses_public_filesystem_path_surface(sql: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::changelog::{ChangelogContext, ChangelogReader, CommitLoadRequest};
     use crate::entity_pk::EntityPk;
     use crate::telemetry::{
         CallbackTelemetrySink, CompletedTelemetrySpan, TelemetrySpanKind, TelemetryValue,
@@ -5087,8 +5088,6 @@ mod tests {
 
     #[tokio::test]
     async fn large_certified_insert_publishes_rootless_history_and_reads_packed_head() {
-        use crate::changelog::{ChangelogContext, ChangelogReader, CommitLoadRequest};
-
         const ROW_COUNT: usize = 32 * 1_024;
         let session = open_session().await;
         let schema = serde_json::json!({
@@ -5176,25 +5175,16 @@ mod tests {
             .begin_read(StorageReadOptions::default())
             .await
             .expect("history read should open");
-        let head_commit_ids = [head.commit_id];
-        let commits = ChangelogContext::new()
-            .reader(&history_read)
-            .load_commits(CommitLoadRequest {
-                commit_ids: &head_commit_ids,
-            })
-            .await
-            .expect("head commit should load");
-        let record = commits
-            .into_iter()
-            .next()
-            .and_then(|(_, record)| record)
-            .expect("head commit should exist");
-        assert!(record.tracked_state_rootless);
-        assert!(record.tracked_state_rootless_depth >= 1);
-        assert!(record.tracked_state_rootless_rows >= ROW_COUNT as u64);
-        assert!(record.tracked_state_rootless_bytes > record.tracked_state_rootless_rows);
+        let commit_state =
+            crate::tracked_state::load_commit_state_manifest(&history_read, head.commit_id)
+                .await
+                .expect("head physical state should load")
+                .expect("head physical state should exist");
+        assert!(commit_state.replay_debt.depth >= 1);
+        assert!(commit_state.replay_debt.rows >= ROW_COUNT as u64);
+        assert!(commit_state.replay_debt.bytes > commit_state.replay_debt.rows);
         assert!(
-            crate::tracked_state::load_authoritative_commit_root(
+            crate::tracked_state::load_snapshot_commit_root(
                 &history_read,
                 &head.commit_id.to_string(),
             )
@@ -5260,36 +5250,28 @@ mod tests {
             .begin_read(StorageReadOptions::default())
             .await
             .expect("descendant history read should open");
-        let descendant_commit_ids = [descendant.commit_id];
-        let descendant_commits = ChangelogContext::new()
-            .reader(&descendant_history_read)
-            .load_commits(CommitLoadRequest {
-                commit_ids: &descendant_commit_ids,
-            })
-            .await
-            .expect("descendant commit should load");
-        let descendant_record = descendant_commits
-            .into_iter()
-            .next()
-            .and_then(|(_, record)| record)
-            .expect("descendant commit should exist");
+        let descendant_state = crate::tracked_state::load_commit_state_manifest(
+            &descendant_history_read,
+            descendant.commit_id,
+        )
+        .await
+        .expect("descendant physical state should load")
+        .expect("descendant physical state should exist");
         assert!(
-            descendant_record.tracked_state_rootless,
+            descendant_state.replay_debt.depth > 0,
             "a sparse descendant must extend the rootless first-parent interval"
         );
         assert_eq!(
-            descendant_record.tracked_state_rootless_depth,
-            record.tracked_state_rootless_depth + 1
+            descendant_state.replay_debt.depth,
+            commit_state.replay_debt.depth + 1
         );
         assert_eq!(
-            descendant_record.tracked_state_rootless_rows,
-            record.tracked_state_rootless_rows + 1
+            descendant_state.replay_debt.rows,
+            commit_state.replay_debt.rows + 1
         );
+        assert!(descendant_state.replay_debt.bytes > commit_state.replay_debt.bytes);
         assert!(
-            descendant_record.tracked_state_rootless_bytes > record.tracked_state_rootless_bytes
-        );
-        assert!(
-            crate::tracked_state::load_authoritative_commit_root(
+            crate::tracked_state::load_snapshot_commit_root(
                 &descendant_history_read,
                 &descendant.commit_id.to_string(),
             )
@@ -5405,21 +5387,12 @@ mod tests {
             .await
             .expect("reseed head should load")
             .expect("reseed head should exist");
-        let reseed_commit_ids = [reseed_head.commit_id];
-        let reseed_commits = ChangelogContext::new()
-            .reader(&reseed_read)
-            .load_commits(CommitLoadRequest {
-                commit_ids: &reseed_commit_ids,
-            })
-            .await
-            .expect("reseed commit should load");
-        let reseed_record = reseed_commits
-            .into_iter()
-            .next()
-            .and_then(|(_, record)| record)
-            .expect("reseed commit should exist");
-        assert!(reseed_record.tracked_state_rootless);
-        assert!(reseed_record.tracked_state_rootless_depth >= 1);
+        let reseed_state =
+            crate::tracked_state::load_commit_state_manifest(&reseed_read, reseed_head.commit_id)
+                .await
+                .expect("reseed physical state should load")
+                .expect("reseed physical state should exist");
+        assert!(reseed_state.replay_debt.depth >= 1);
 
         let mut rooted_fence = None;
         for generation_offset in 1..=32 {
@@ -5442,25 +5415,15 @@ mod tests {
                 .await
                 .expect("root-fence head should load")
                 .expect("root-fence head should exist");
-            let fence_commit_ids = [head.commit_id];
-            let commits = ChangelogContext::new()
-                .reader(&read)
-                .load_commits(CommitLoadRequest {
-                    commit_ids: &fence_commit_ids,
-                })
+            let state = crate::tracked_state::load_commit_state_manifest(&read, head.commit_id)
                 .await
-                .expect("root-fence commit should load");
-            let record = commits
-                .into_iter()
-                .next()
-                .and_then(|(_, record)| record)
-                .expect("root-fence commit should exist");
-            if !record.tracked_state_rootless {
-                assert_eq!(record.tracked_state_rootless_depth, 0);
-                assert_eq!(record.tracked_state_rootless_rows, 0);
-                assert_eq!(record.tracked_state_rootless_bytes, 0);
+                .expect("root-fence physical state should load")
+                .expect("root-fence physical state should exist");
+            if state.replay_debt.depth == 0 {
+                assert_eq!(state.replay_debt.rows, 0);
+                assert_eq!(state.replay_debt.bytes, 0);
                 assert!(
-                    crate::tracked_state::load_authoritative_commit_root(
+                    crate::tracked_state::load_snapshot_commit_root(
                         &read,
                         &head.commit_id.to_string(),
                     )
@@ -5727,7 +5690,20 @@ mod tests {
             .columnar_parts
             .as_ref()
             .expect("fixture must publish column pages as sole mutation authority");
-        assert_eq!(commit_state.account_id, crate::SYSTEM_ACCOUNT_ID);
+        let semantic_commit_ids = [commit_state.commit_id];
+        let commit_records = ChangelogContext::new()
+            .reader(&read)
+            .load_commits(CommitLoadRequest {
+                commit_ids: &semantic_commit_ids,
+            })
+            .await
+            .expect("typed lifecycle semantic owner should load");
+        let semantic_owner = commit_records
+            .into_iter()
+            .next()
+            .and_then(|(_, record)| record)
+            .expect("typed lifecycle semantic owner should exist");
+        assert_eq!(semantic_owner.account_id, crate::SYSTEM_ACCOUNT_ID);
         assert!(commit_state.mutations.inline_part.is_empty());
         assert!(commit_state.mutations.parts.is_empty());
         assert_eq!(columnar_parts.page_first_keys.len(), 33);

--- a/packages/engine/src/session/execute.rs
+++ b/packages/engine/src/session/execute.rs
@@ -2597,6 +2597,37 @@ where
                         &mut self.prepared_literal_shape,
                     )
                 {
+                    #[cfg(feature = "storage-benches")]
+                    {
+                        let key_bytes = decoded_values.first().map_or(0, |value| value.len());
+                        let value_bytes = decoded_values.get(1).map_or(0, |value| value.len());
+                        let owned_bytes = decoded_values
+                            .iter()
+                            .filter_map(|value| match value {
+                                std::borrow::Cow::Borrowed(_) => None,
+                                std::borrow::Cow::Owned(value) => Some(value.len()),
+                            })
+                            .sum::<usize>();
+                        crate::storage_bench::record_crud_ownership(
+                            crate::storage_bench::CRUD_OWNERSHIP_SQL_BOUND,
+                            1,
+                            key_bytes,
+                            value_bytes,
+                            decoded_values.len(),
+                            decoded_values
+                                .iter()
+                                .filter(|value| matches!(value, std::borrow::Cow::Owned(_)))
+                                .count(),
+                            0,
+                        );
+                        crate::storage_bench::record_crud_ownership_transfer(
+                            crate::storage_bench::CRUD_OWNERSHIP_SQL_BOUND,
+                            owned_bytes,
+                            0,
+                            owned_bytes,
+                            0,
+                        );
+                    }
                     let transaction = self
                         .transaction
                         .as_mut()

--- a/packages/engine/src/session/execute.rs
+++ b/packages/engine/src/session/execute.rs
@@ -8058,34 +8058,64 @@ mod tests {
             "full updates must preserve the newer lifecycle of a reinserted identity"
         );
 
+        // Pick a part from the authenticated current head, rather than the
+        // lexicographically first object in the space. Historical and
+        // unreachable parts may remain in this immutable space and deleting
+        // one of those must not make GC fail closed.
         let read = session
             .storage
             .begin_read(StorageReadOptions::default())
             .await
             .unwrap();
-        let native = crate::storage_adapter::ScanPlan::prefix(
+        let controls = crate::branch::BranchHeadControlContext::new()
+            .reader(&read)
+            .scan()
+            .await
+            .expect("branch-head controls should load");
+        let mut live_descriptor = None;
+        for (_, control) in controls {
+            let manifest =
+                crate::tracked_state::load_commit_state_manifest(&read, control.head_commit_id)
+                    .await
+                    .expect("active head manifest should load");
+            let Some(root) = manifest.and_then(|manifest| manifest.current_state_scoped_ranges)
+            else {
+                continue;
+            };
+            let reachable = crate::tracked_state::validate_scoped_range_trees(
+                &read,
+                std::slice::from_ref(&root.tree),
+            )
+            .await
+            .expect("active head current-state tree should authenticate");
+            live_descriptor = reachable
+                .parts
+                .iter()
+                .map(crate::tracked_state::current_state_descriptor_from_scoped_range_part)
+                .collect::<Result<Vec<_>, _>>()
+                .expect("active head part descriptors should decode")
+                .into_iter()
+                .find(|descriptor| descriptor.source_kind == 1);
+            if live_descriptor.is_some() {
+                break;
+            }
+        }
+        let live_descriptor =
+            live_descriptor.expect("an active head should retain a live native part");
+        let native_key = crate::storage_adapter::StorageKey(bytes::Bytes::copy_from_slice(
+            &live_descriptor.content_digest,
+        ));
+        let native_presence = crate::storage_adapter::PointReadPlan::new(
             crate::tracked_state::CURRENT_STATE_DATA_PART_SPACE,
-            crate::storage_adapter::StoragePrefix {
-                bytes: bytes::Bytes::new(),
-            },
+            std::slice::from_ref(&native_key),
         )
-        .collect(
-            &read,
-            crate::storage_adapter::StorageScanOptions {
-                projection: crate::storage_adapter::StorageCoreProjection::KeyOnly,
-                limit_rows: 1,
-                ..Default::default()
-            },
-        )
+        .materialize(&read, Default::default())
         .await
-        .unwrap();
-        let native_key = native
-            .value
-            .entries
-            .first()
-            .expect("sparse descendants must publish a native current-state part")
-            .key
-            .clone();
+        .expect("live native part presence should read");
+        assert!(
+            native_presence.value[0].is_some(),
+            "live part must exist before delete"
+        );
         drop(read);
         let mut corrupt = session.storage.new_write_set();
         corrupt.delete(

--- a/packages/engine/src/session/gc.rs
+++ b/packages/engine/src/session/gc.rs
@@ -1,6 +1,7 @@
 use crate::LixError;
 use crate::gc::{
-    RepositoryGcPlan, load_checkpoint_gc_state, stage_checkpoint_gc_state, stage_repository_gc,
+    RepositoryGcPlan, load_checkpoint_gc_state, stage_checkpoint_gc_state,
+    stage_repository_gc_with_preconditions,
 };
 use crate::storage_adapter::{
     SharedStorageAdapterRead, Storage, StorageReadOptions, StorageWriteOptions,
@@ -32,14 +33,22 @@ where
             return Ok(None);
         }
         let mut writes = self.storage.new_write_set();
-        let plan = stage_repository_gc(read, &mut writes).await?;
+        let mut preconditions = Vec::new();
+        let plan =
+            stage_repository_gc_with_preconditions(read, &mut writes, &mut preconditions).await?;
         gc_state.mark_collected();
         stage_checkpoint_gc_state(&mut writes, &gc_state)?;
         let commit_boundary = self.transaction_commit_boundary();
         let _commit_guard = begin_commit_boundary(Some(&commit_boundary));
         let prepared_commit = self
             .storage
-            .prepare_write_set(writes, StorageWriteOptions::default())
+            .prepare_write_set(
+                writes,
+                StorageWriteOptions {
+                    preconditions,
+                    ..StorageWriteOptions::default()
+                },
+            )
             .await?;
         let stats = commit_at_boundary(Some(&commit_boundary), || async move {
             let (_, stats) = prepared_commit.commit().await?;

--- a/packages/engine/src/session/transaction.rs
+++ b/packages/engine/src/session/transaction.rs
@@ -371,7 +371,9 @@ impl SessionTransactionManager {
             let notified = self.inner.state_changed.notified();
             let wait_for_session_operation = {
                 let mut state = self.lock_state();
-                if state.is_session_operation_in_progress() {
+                if state.is_session_operation_in_progress()
+                    || state.is_automatic_transaction_in_progress()
+                {
                     true
                 } else {
                     state.begin_write_lease(TransactionOwner::Automatic)?;

--- a/packages/engine/src/sql2/exec/bound_public_write.rs
+++ b/packages/engine/src/sql2/exec/bound_public_write.rs
@@ -280,11 +280,12 @@ async fn try_execute_entity_insert_batch(
         None
     };
     let layout = InsertRowLayout::from_values(&spec, values)?;
-    if layout
-        .columns
-        .iter()
-        .any(|target| !matches!(target, InsertColumnTarget::Visible { .. }))
-    {
+    if layout.columns.iter().any(|target| {
+        !matches!(
+            target,
+            InsertColumnTarget::Visible { .. } | InsertColumnTarget::Untracked
+        )
+    }) {
         return Ok(None);
     }
     let certification_span = tracing::debug_span!(
@@ -4347,6 +4348,8 @@ fn certified_entity_insert_parameter_batch(
     if let Some(rows) =
         certified_direct_parameter_insert_batch(ctx, plan, spec, layout, row, parameter_batch)?
     {
+        #[cfg(feature = "storage-benches")]
+        crate::storage_bench::record_certified_entity_insert_parameter_batch_execution();
         return Ok(Some(if use_typed_certified_insert(rows.len()) {
             CertifiedEntityInsertParameterBatch::Typed(rows)
         } else {
@@ -4883,11 +4886,15 @@ fn certified_direct_path_value_insert_batch(
     parameter_batch: EntityInsertParameterBatch<'_>,
     schema_plan_id: SchemaPlanId,
 ) -> Result<Option<CertifiedParameterInsertBatch>, LixError> {
-    if !spec.certifies_path_value_replacement || row.len() != 2 || layout.columns.len() != 2 {
+    if !spec.certifies_path_value_replacement
+        || !(row.len() == 2 || row.len() == 3)
+        || layout.columns.len() != row.len()
+    {
         return Ok(None);
     }
     let mut path_param_index = None;
     let mut value_param_index = None;
+    let mut untracked = false;
     for (expr, target) in row.iter().zip(&layout.columns) {
         match (expr, target) {
             (
@@ -4910,6 +4917,9 @@ fn certified_direct_path_value_insert_batch(
                     return Ok(None);
                 };
                 value_param_index = Some(param.index.saturating_sub(1));
+            }
+            (BoundExpr::Literal(BoundLiteral::Bool(true)), InsertColumnTarget::Untracked) => {
+                untracked = true;
             }
             _ => return Ok(None),
         }
@@ -4985,7 +4995,7 @@ fn certified_direct_path_value_insert_batch(
         snapshot_offsets.push((snapshot_start, normalized.len()));
     }
 
-    let entity_columnar = if use_typed_certified_insert(row_count) {
+    let entity_columnar = if !untracked && use_typed_certified_insert(row_count) {
         let path_values = StringArray::from_iter(path_offsets.iter().map(|&(start, end)| {
             Some(
                 std::str::from_utf8(&path_arena[start..end])
@@ -5030,11 +5040,12 @@ fn certified_direct_path_value_insert_batch(
         .collect::<Vec<_>>();
     let snapshots =
         TransactionJson::from_certified_row_content_arena(normalized, snapshot_offsets)?;
-    let mut rows = CertifiedParameterInsertBatch::new(
+    let mut rows = CertifiedParameterInsertBatch::new_with_lane(
         entity_pks,
         snapshots,
         layout.schema_key.as_str().into(),
         ctx.active_branch_id().into(),
+        untracked,
         CertifiedRawWriteBatchPreparation {
             schema_plan_id,
             facts: PreparedRowFacts {

--- a/packages/engine/src/sql2/exec/bound_public_write.rs
+++ b/packages/engine/src/sql2/exec/bound_public_write.rs
@@ -4349,7 +4349,7 @@ fn certified_entity_insert_parameter_batch(
         certified_direct_parameter_insert_batch(ctx, plan, spec, layout, row, parameter_batch)?
     {
         #[cfg(feature = "storage-benches")]
-        crate::storage_bench::record_certified_entity_insert_parameter_batch_execution();
+        crate::storage_bench::record_certified_entity_insert_parameter_batch_certification();
         return Ok(Some(if use_typed_certified_insert(rows.len()) {
             CertifiedEntityInsertParameterBatch::Typed(rows)
         } else {

--- a/packages/engine/src/sql2/exec/bound_public_write.rs
+++ b/packages/engine/src/sql2/exec/bound_public_write.rs
@@ -4362,6 +4362,22 @@ fn certified_entity_insert_parameter_batch(
     let EntityInsertParameterBatch::Arrow(parameter_batch) = parameter_batch else {
         unreachable!("generic parameter fallback is only available for Arrow batches")
     };
+    // The tracked/untracked lane is part of the registered schema domain, not
+    // merely row payload. A parameterized batch can contain rows from both
+    // lanes; committing that batch would defer the domain error until the
+    // transaction boundary, where it no longer has a statement index. Keep
+    // the established sequential route for this shape so the failing row is
+    // validated and attributed before any batch staging occurs.
+    if values.rows.iter().any(|row| {
+        row.iter().zip(&layout.columns).any(|(expr, target)| {
+            matches!(
+                (expr, target),
+                (BoundExpr::Param(_), InsertColumnTarget::Untracked)
+            )
+        })
+    }) {
+        return Ok(None);
+    }
     certified_entity_insert_rows(
         ctx,
         plan,

--- a/packages/engine/src/sql2/exec/bound_public_write.rs
+++ b/packages/engine/src/sql2/exec/bound_public_write.rs
@@ -837,6 +837,16 @@ async fn try_execute_direct_path_value_replacement_batch(
         primary_key_offsets.push((start, primary_key_arena.len()));
     }
     let parameter_identity_digest = *parameter_identity_hasher.finalize().as_bytes();
+    #[cfg(feature = "storage-benches")]
+    crate::storage_bench::record_crud_ownership(
+        crate::storage_bench::CRUD_OWNERSHIP_SQL_BOUND,
+        row_count,
+        primary_key_arena.len(),
+        0,
+        2,
+        0,
+        0,
+    );
     let active_branch_id = ctx.active_branch_id().to_owned();
     let scope = crate::collection_generation::CollectionScopeRef {
         schema_key: &spec.schema_key,

--- a/packages/engine/src/storage_adapter/write_set.rs
+++ b/packages/engine/src/storage_adapter/write_set.rs
@@ -121,7 +121,7 @@ pub(crate) struct DeferredFinalPutPage {
 /// This is the storage-native escape hatch for large certified batches. The
 /// ordinary write set remains the general representation; a deferred source
 /// is accepted only when its target spaces have no ordinary mutations.
-pub(crate) trait DeferredFinalPutSource: Send {
+pub(crate) trait DeferredFinalPutSource: Send + Sync {
     fn target_spaces(&self) -> &[StorageSpace];
     fn put_count(&self) -> u64;
     fn written_bytes(&self) -> u64;

--- a/packages/engine/src/storage_adapter/write_set.rs
+++ b/packages/engine/src/storage_adapter/write_set.rs
@@ -715,6 +715,20 @@ impl StorageWriteSet {
         stats
     }
 
+    /// Returns the number of point-delete descriptors staged in each logical
+    /// storage space.  This is benchmark/test observability only: production
+    /// planning continues to use the aggregate write-set counters and never
+    /// depends on this classification.
+    #[cfg(any(test, feature = "storage-benches"))]
+    pub fn delete_counts_by_space(&self) -> Vec<(StorageSpace, usize)> {
+        self.groups
+            .iter()
+            .filter_map(|group| {
+                (!group.deletes.is_empty()).then_some((group.space, group.deletes.len()))
+            })
+            .collect()
+    }
+
     #[cfg(test)]
     pub(crate) fn has_mutations_in_space(&self, space: StorageSpace) -> bool {
         self.group_index

--- a/packages/engine/src/storage_bench.rs
+++ b/packages/engine/src/storage_bench.rs
@@ -741,6 +741,7 @@ where
         std::collections::BTreeMap::<crate::changelog::CommitId, (u64, u64)>::new();
     for space in [
         crate::tracked_state::TRACKED_STATE_COMMIT_STATE_MANIFEST_SPACE,
+        crate::tracked_state::TRACKED_STATE_COMMIT_MUTATION_INVENTORY_SPACE,
         crate::tracked_state::TRACKED_STATE_COMMIT_DELTA_SEGMENT_SPACE,
     ] {
         for entry in scan_layout_entries(read, space).await {
@@ -1471,6 +1472,8 @@ fn native_storage_spaces() -> &'static [crate::storage_adapter::StorageSpace] {
         crate::json_store::UNTRACKED_JSON_RECLAIM_CANDIDATE_SPACE,
         crate::tracked_state::TRACKED_STATE_TREE_CHUNK_SPACE,
         crate::tracked_state::TRACKED_STATE_COMMIT_STATE_MANIFEST_SPACE,
+        crate::tracked_state::TRACKED_STATE_COMMIT_MUTATION_INVENTORY_SPACE,
+        crate::tracked_state::MUTATION_DIRECTORY_NODE_SPACE,
         crate::tracked_state::TRACKED_STATE_COMMIT_DELTA_SEGMENT_SPACE,
         crate::tracked_state::TRACKED_STATE_CHANGE_LOCATOR_SPACE,
         crate::binary_cas::kv::BINARY_CAS_MANIFEST_SPACE,

--- a/packages/engine/src/storage_bench.rs
+++ b/packages/engine/src/storage_bench.rs
@@ -2,7 +2,6 @@ use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 
 use bytes::Bytes;
 
-use crate::changelog::ChangelogReader;
 use crate::storage_adapter::Storage;
 use crate::storage_adapter::{
     ScanPlan, StorageAdapter, StorageAdapterRead, StorageCoreProjection, StoragePrefix,
@@ -1795,6 +1794,7 @@ mod tests {
     use crate::storage_adapter::{
         Memory, StorageAdapter, StorageKey, StorageValue, StorageWriteOptions,
     };
+    use crate::{CreateBranchOptions, Value};
 
     #[tokio::test]
     async fn checkpoint_commit_scan_baseline_matches_materialized_records_across_pages() {
@@ -1911,10 +1911,73 @@ mod tests {
         Engine::initialize(storage.clone())
             .await
             .expect("initialize engine");
-        let append = append_ordered_commits(100, 10).expect("build unreachable commit fixture");
-        stage_append_once(storage.clone(), &append)
+        let engine = Engine::new(storage.clone())
             .await
-            .expect("stage unreachable commit fixture");
+            .expect("open benchmark engine");
+        let main = engine
+            .open_workspace_session()
+            .await
+            .expect("open benchmark main session");
+        let schema = serde_json::json!({
+            "x-lix-key": "repository_gc_benchmark_fixture",
+            "x-lix-primary-key": ["/path"],
+            "type": "object",
+            "required": ["path", "value"],
+            "properties": {
+                "path": { "type": "string" },
+                "value": { "type": "integer" }
+            },
+            "additionalProperties": false
+        });
+        main.execute(
+            "INSERT INTO lix_registered_schema (value, lixcol_global, lixcol_untracked) \
+             VALUES (lix_json($1), false, false)",
+            &[Value::Text(schema.to_string())],
+        )
+        .await
+        .expect("register benchmark schema");
+        let branch = main
+            .create_branch(CreateBranchOptions {
+                id: Some("01990000-0000-7000-8000-000000000010".to_owned()),
+                name: "repository-gc-benchmark-unreachable".to_owned(),
+                from_commit_id: None,
+            })
+            .await
+            .expect("create benchmark branch");
+        let branch_session = engine
+            .open_session(branch.id.clone())
+            .await
+            .expect("open benchmark branch session");
+        for commit_index in 0..10 {
+            let mut transaction = branch_session
+                .begin_transaction()
+                .await
+                .expect("begin benchmark transaction");
+            for row_index in 0..10 {
+                let row = commit_index * 10 + row_index;
+                transaction
+                    .execute(
+                        "INSERT INTO repository_gc_benchmark_fixture (path, value) \
+                         VALUES ($1, $2)",
+                        &[
+                            Value::Text(format!("/row/{row:08}")),
+                            Value::Integer(row as i64),
+                        ],
+                    )
+                    .await
+                    .expect("stage benchmark row");
+            }
+            transaction
+                .commit()
+                .await
+                .expect("publish benchmark commit");
+        }
+        main.execute(
+            "DELETE FROM lix_branch WHERE id = $1",
+            &[Value::Text(branch.id)],
+        )
+        .await
+        .expect("delete benchmark branch");
         let adapter = StorageAdapter::new(storage);
 
         let first = plan_repository_gc_for_bench(&adapter)
@@ -1925,12 +1988,11 @@ mod tests {
             .expect("repeat repository gc plan");
 
         assert_eq!(first.swept_commits, 10);
-        // Each unreachable commit removes its changelog projection and the
-        // unified commit-state authority. The hard cut retired the separate
-        // tracked-root record.
-        assert_eq!(first.staged_deletes, 20);
-        assert_eq!(first.key_shared_buffers, 2);
-        assert_eq!(first.key_shared_bytes, 20 * 16);
+        // Each unreachable commit removes its changelog projection, the
+        // unified commit-state authority, and its standalone change fact.
+        assert_eq!(first.staged_deletes, 30);
+        assert_eq!(first.key_shared_buffers, 30);
+        assert_eq!(first.key_shared_bytes, 30 * 16);
         assert_eq!(second.swept_commits, first.swept_commits);
         assert_eq!(second.staged_deletes, first.staged_deletes);
     }

--- a/packages/engine/src/storage_bench.rs
+++ b/packages/engine/src/storage_bench.rs
@@ -266,6 +266,24 @@ pub(crate) fn record_certified_entity_insert_parameter_batch_certification() {
     CERTIFIED_ENTITY_INSERT_PARAMETER_BATCH_CERTIFICATIONS.fetch_add(1, Ordering::Relaxed);
 }
 
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct CertifiedEntityInsertParameterBatchCounters {
+    pub certifications: u64,
+    pub executions: u64,
+}
+
+/// Reads the cumulative certified parameter-batch INSERT phase counters
+/// without resetting them. Callers measuring one fixture/sample must subtract
+/// a pre-operation snapshot from a post-operation snapshot.
+pub fn certified_entity_insert_parameter_batch_counters()
+-> CertifiedEntityInsertParameterBatchCounters {
+    CertifiedEntityInsertParameterBatchCounters {
+        certifications: CERTIFIED_ENTITY_INSERT_PARAMETER_BATCH_CERTIFICATIONS
+            .load(Ordering::Relaxed),
+        executions: CERTIFIED_ENTITY_INSERT_PARAMETER_BATCH_EXECUTIONS.load(Ordering::Relaxed),
+    }
+}
+
 /// Returns and resets the number of certified parameter-batch INSERT routes
 /// selected by the planner, before any physical staging occurs.
 pub fn take_certified_entity_insert_parameter_batch_certifications() -> u64 {

--- a/packages/engine/src/storage_bench.rs
+++ b/packages/engine/src/storage_bench.rs
@@ -45,6 +45,7 @@ static TRANSACTION_VALIDATION_BRANCHS: AtomicU64 = AtomicU64::new(0);
 static TRANSACTION_SCHEMA_CATALOG_LOADS: AtomicU64 = AtomicU64::new(0);
 static TRANSACTION_SCHEMA_CATALOG_COMPILES: AtomicU64 = AtomicU64::new(0);
 static JSON_STORE_STAGE_BYTES: AtomicU64 = AtomicU64::new(0);
+static CERTIFIED_ENTITY_INSERT_PARAMETER_BATCH_CERTIFICATIONS: AtomicU64 = AtomicU64::new(0);
 static CERTIFIED_ENTITY_INSERT_PARAMETER_BATCH_EXECUTIONS: AtomicU64 = AtomicU64::new(0);
 static CERTIFIED_ENTITY_UPDATE_VALUE_BATCH_ATTEMPTS: AtomicU64 = AtomicU64::new(0);
 static CERTIFIED_ENTITY_UPDATE_VALUE_BATCH_HITS: AtomicU64 = AtomicU64::new(0);
@@ -261,11 +262,22 @@ pub fn take_media_structural_accounting() -> MediaStructuralAccounting {
     }
 }
 
+pub(crate) fn record_certified_entity_insert_parameter_batch_certification() {
+    CERTIFIED_ENTITY_INSERT_PARAMETER_BATCH_CERTIFICATIONS.fetch_add(1, Ordering::Relaxed);
+}
+
+/// Returns and resets the number of certified parameter-batch INSERT routes
+/// selected by the planner, before any physical staging occurs.
+pub fn take_certified_entity_insert_parameter_batch_certifications() -> u64 {
+    CERTIFIED_ENTITY_INSERT_PARAMETER_BATCH_CERTIFICATIONS.swap(0, Ordering::Relaxed)
+}
+
 pub(crate) fn record_certified_entity_insert_parameter_batch_execution() {
     CERTIFIED_ENTITY_INSERT_PARAMETER_BATCH_EXECUTIONS.fetch_add(1, Ordering::Relaxed);
 }
 
-/// Returns and resets the number of certified parameter-batch INSERT routes.
+/// Returns and resets the number of certified parameter-batch INSERT routes
+/// that reached physical staging/execution.
 ///
 /// Benchmark fixtures use this as a route certificate so a schema change
 /// cannot silently turn the measured bulk INSERT back into sequential writes.

--- a/packages/engine/src/storage_bench.rs
+++ b/packages/engine/src/storage_bench.rs
@@ -629,7 +629,12 @@ where
     let arena = writes.arena_stats();
     Ok(RepositoryGcBenchResult {
         live_commits: plan.changelog.live.commits.len(),
-        swept_commits: plan.changelog.sweep.commits.len(),
+        swept_commits: plan
+            .changelog
+            .sweep
+            .commits
+            .len()
+            .saturating_add(plan.sweep.tracked_commit_roots.len()),
         swept_standalone_changes: plan.changelog.sweep.changes.len(),
         swept_payloads: plan.changelog.sweep.json_payloads.len(),
         staged_puts: stats.staged_puts,

--- a/packages/engine/src/storage_bench.rs
+++ b/packages/engine/src/storage_bench.rs
@@ -1,4 +1,4 @@
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 
 use bytes::Bytes;
 
@@ -66,6 +66,169 @@ static MEDIA_UPLOAD_MANIFEST_LEAF_ROWS: AtomicU64 = AtomicU64::new(0);
 static MEDIA_UPLOAD_SUMMARIZED_CHUNK_ROWS: AtomicU64 = AtomicU64::new(0);
 static MEDIA_UPLOAD_CHUNK_PAYLOAD_HASH_BYTES: AtomicU64 = AtomicU64::new(0);
 static IMMUTABLE_SEGMENT_IDENTITY_HASH_BYTES: AtomicU64 = AtomicU64::new(0);
+
+/// Matched transaction ownership counters used by the CRUD profile.  These
+/// counters are deliberately disabled unless the profile enables them, so the
+/// common instrumentation does not perturb normal engine execution.
+pub const CRUD_OWNERSHIP_STAGE_COUNT: usize = 15;
+pub const CRUD_OWNERSHIP_METRIC_COUNT: usize = 6;
+pub const CRUD_OWNERSHIP_SQL_BOUND: usize = 0;
+pub const CRUD_OWNERSHIP_RAW_BATCH: usize = 1;
+pub const CRUD_OWNERSHIP_RAW_TRANSFER: usize = 2;
+pub const CRUD_OWNERSHIP_PREPARED_BATCH: usize = 3;
+pub const CRUD_OWNERSHIP_PREPARED_CLONE: usize = 4;
+pub const CRUD_OWNERSHIP_REPLACEMENT_INPUT: usize = 5;
+pub const CRUD_OWNERSHIP_REPLACEMENT_PART: usize = 6;
+pub const CRUD_OWNERSHIP_AUTHORITY: usize = 7;
+pub const CRUD_OWNERSHIP_ROOT_PUBLICATION: usize = 8;
+pub const CRUD_OWNERSHIP_WRITE_SET: usize = 9;
+pub const CRUD_OWNERSHIP_ADAPTER: usize = 10;
+pub const CRUD_OWNERSHIP_MUTATION_JOURNAL: usize = 11;
+pub const CRUD_OWNERSHIP_IDENTITY_ENCODING: usize = 12;
+pub const CRUD_OWNERSHIP_NORMALIZATION: usize = 13;
+pub const CRUD_OWNERSHIP_JOURNAL_SEAL: usize = 14;
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct CrudOwnershipMetric {
+    pub rows: u64,
+    pub key_bytes: u64,
+    pub value_bytes: u64,
+    pub vec_entries: u64,
+    pub string_entries: u64,
+    pub map_entries: u64,
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct CrudOwnershipAccounting {
+    pub stages: [CrudOwnershipMetric; CRUD_OWNERSHIP_STAGE_COUNT],
+    pub transfers: [CrudOwnershipTransferMetric; CRUD_OWNERSHIP_STAGE_COUNT],
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct CrudOwnershipTransferMetric {
+    pub created_bytes: u64,
+    pub cloned_bytes: u64,
+    pub retained_bytes: u64,
+    pub dropped_bytes: u64,
+}
+
+static CRUD_OWNERSHIP_ENABLED: AtomicBool = AtomicBool::new(false);
+static CRUD_OWNERSHIP_COUNTERS: [AtomicU64;
+    CRUD_OWNERSHIP_STAGE_COUNT * CRUD_OWNERSHIP_METRIC_COUNT] =
+    [const { AtomicU64::new(0) }; CRUD_OWNERSHIP_STAGE_COUNT * CRUD_OWNERSHIP_METRIC_COUNT];
+static CRUD_OWNERSHIP_TRANSFER_COUNTERS: [AtomicU64; CRUD_OWNERSHIP_STAGE_COUNT * 4] =
+    [const { AtomicU64::new(0) }; CRUD_OWNERSHIP_STAGE_COUNT * 4];
+
+/// Starts a matched operation-local ownership measurement and clears any
+/// counters left by a prior profile operation.
+pub fn begin_crud_ownership_accounting() {
+    for counter in &CRUD_OWNERSHIP_COUNTERS {
+        counter.store(0, Ordering::Relaxed);
+    }
+    for counter in &CRUD_OWNERSHIP_TRANSFER_COUNTERS {
+        counter.store(0, Ordering::Relaxed);
+    }
+    CRUD_OWNERSHIP_ENABLED.store(true, Ordering::Relaxed);
+}
+
+pub(crate) fn record_crud_ownership_transfer(
+    stage: usize,
+    created_bytes: usize,
+    cloned_bytes: usize,
+    retained_bytes: usize,
+    dropped_bytes: usize,
+) {
+    if !CRUD_OWNERSHIP_ENABLED.load(Ordering::Relaxed) {
+        return;
+    }
+    assert!(
+        stage < CRUD_OWNERSHIP_STAGE_COUNT,
+        "invalid ownership stage"
+    );
+    let values = [created_bytes, cloned_bytes, retained_bytes, dropped_bytes];
+    let start = stage * 4;
+    for (offset, value) in values.into_iter().enumerate() {
+        CRUD_OWNERSHIP_TRANSFER_COUNTERS[start + offset].fetch_add(value as u64, Ordering::Relaxed);
+    }
+}
+
+pub(crate) fn record_crud_ownership(
+    stage: usize,
+    rows: usize,
+    key_bytes: usize,
+    value_bytes: usize,
+    vec_entries: usize,
+    string_entries: usize,
+    map_entries: usize,
+) {
+    if !CRUD_OWNERSHIP_ENABLED.load(Ordering::Relaxed) {
+        return;
+    }
+    assert!(
+        stage < CRUD_OWNERSHIP_STAGE_COUNT,
+        "invalid ownership stage"
+    );
+    let values = [
+        rows,
+        key_bytes,
+        value_bytes,
+        vec_entries,
+        string_entries,
+        map_entries,
+    ];
+    let start = stage * CRUD_OWNERSHIP_METRIC_COUNT;
+    for (offset, value) in values.into_iter().enumerate() {
+        CRUD_OWNERSHIP_COUNTERS[start + offset].fetch_add(value as u64, Ordering::Relaxed);
+    }
+}
+
+pub fn take_crud_ownership_accounting() -> CrudOwnershipAccounting {
+    CRUD_OWNERSHIP_ENABLED.store(false, Ordering::Relaxed);
+    let mut stages = [CrudOwnershipMetric::default(); CRUD_OWNERSHIP_STAGE_COUNT];
+    let mut transfers = [CrudOwnershipTransferMetric::default(); CRUD_OWNERSHIP_STAGE_COUNT];
+    for (stage, metric) in stages.iter_mut().enumerate() {
+        let start = stage * CRUD_OWNERSHIP_METRIC_COUNT;
+        metric.rows = CRUD_OWNERSHIP_COUNTERS[start].swap(0, Ordering::Relaxed);
+        metric.key_bytes = CRUD_OWNERSHIP_COUNTERS[start + 1].swap(0, Ordering::Relaxed);
+        metric.value_bytes = CRUD_OWNERSHIP_COUNTERS[start + 2].swap(0, Ordering::Relaxed);
+        metric.vec_entries = CRUD_OWNERSHIP_COUNTERS[start + 3].swap(0, Ordering::Relaxed);
+        metric.string_entries = CRUD_OWNERSHIP_COUNTERS[start + 4].swap(0, Ordering::Relaxed);
+        metric.map_entries = CRUD_OWNERSHIP_COUNTERS[start + 5].swap(0, Ordering::Relaxed);
+        let transfer_start = stage * 4;
+        transfers[stage].created_bytes =
+            CRUD_OWNERSHIP_TRANSFER_COUNTERS[transfer_start].swap(0, Ordering::Relaxed);
+        transfers[stage].cloned_bytes =
+            CRUD_OWNERSHIP_TRANSFER_COUNTERS[transfer_start + 1].swap(0, Ordering::Relaxed);
+        transfers[stage].retained_bytes =
+            CRUD_OWNERSHIP_TRANSFER_COUNTERS[transfer_start + 2].swap(0, Ordering::Relaxed);
+        transfers[stage].dropped_bytes =
+            CRUD_OWNERSHIP_TRANSFER_COUNTERS[transfer_start + 3].swap(0, Ordering::Relaxed);
+    }
+    CrudOwnershipAccounting { stages, transfers }
+}
+
+pub(crate) fn record_crud_write_set_arena(writes: &StorageWriteSet) {
+    let stats = writes.arena_stats();
+    record_crud_ownership(
+        CRUD_OWNERSHIP_WRITE_SET,
+        stats
+            .put_descriptors
+            .saturating_add(stats.delete_descriptors),
+        stats
+            .key_inline_bytes
+            .saturating_add(stats.key_shared_bytes),
+        stats
+            .value_inline_bytes
+            .saturating_add(stats.value_shared_bytes),
+        stats
+            .put_descriptors
+            .saturating_add(stats.delete_descriptors),
+        stats
+            .key_shared_buffers
+            .saturating_add(stats.value_shared_buffers),
+        stats.spaces,
+    );
+}
 
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub struct MediaStructuralAccounting {

--- a/packages/engine/src/storage_bench.rs
+++ b/packages/engine/src/storage_bench.rs
@@ -2,6 +2,7 @@ use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 
 use bytes::Bytes;
 
+use crate::changelog::ChangelogReader;
 use crate::storage_adapter::Storage;
 use crate::storage_adapter::{
     ScanPlan, StorageAdapter, StorageAdapterRead, StorageCoreProjection, StoragePrefix,
@@ -586,11 +587,12 @@ where
     Ok(())
 }
 
-#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub struct RepositoryGcBenchResult {
     pub live_commits: usize,
     pub swept_commits: usize,
     pub swept_standalone_changes: usize,
+    pub standalone_swept_ids: Vec<String>,
     pub swept_payloads: usize,
     pub staged_puts: u64,
     pub staged_deletes: u64,
@@ -635,7 +637,18 @@ where
             .commits
             .len()
             .saturating_add(plan.sweep.tracked_commit_roots.len()),
-        swept_standalone_changes: plan.changelog.sweep.changes.len(),
+        swept_standalone_changes: plan
+            .changelog
+            .sweep
+            .changes
+            .len()
+            .saturating_add(plan.sweep.standalone_changes.len()),
+        standalone_swept_ids: plan
+            .sweep
+            .standalone_changes
+            .iter()
+            .map(ToString::to_string)
+            .collect(),
         swept_payloads: plan.changelog.sweep.json_payloads.len(),
         staged_puts: stats.staged_puts,
         staged_deletes: stats.staged_deletes,
@@ -652,6 +665,21 @@ where
         tracked_root_stage_us: plan.profile.tracked_root_stage_us,
         total_us: plan.profile.total_us,
     })
+}
+
+/// Audits standalone semantic facts for the GC benchmark without adding the
+/// scan to the measured planner phase. The exact IDs and their authenticated
+/// control reason make the old-vs-frontier sweep discrepancy explicit.
+pub async fn audit_repository_gc_standalone_for_bench<StorageImpl>(
+    storage: &StorageAdapter<StorageImpl>,
+) -> Result<Vec<String>, crate::LixError>
+where
+    StorageImpl: Storage,
+{
+    let read = crate::storage_adapter::SharedStorageAdapterRead::new(
+        storage.begin_read(ReadOptions::default()).await?,
+    );
+    crate::gc::audit_repository_gc_standalone_refs(&read).await
 }
 
 /// Scans public commit facts through the two checkpoint-history strategies.

--- a/packages/engine/src/storage_bench.rs
+++ b/packages/engine/src/storage_bench.rs
@@ -595,6 +595,15 @@ pub struct RepositoryGcBenchResult {
     pub swept_payloads: usize,
     pub staged_puts: u64,
     pub staged_deletes: u64,
+    /// Point-delete descriptors grouped by logical storage-space id.  This
+    /// makes GC benchmark expectations resilient to additions of a new
+    /// derived projection while still proving each authority lane explicitly.
+    pub delete_counts_by_space: Vec<(u32, usize)>,
+    pub deleted_commit_state_manifests: usize,
+    pub deleted_mutation_inventories: usize,
+    pub deleted_semantic_commit_projections: usize,
+    pub deleted_semantic_change_rows: usize,
+    pub deleted_semantic_reverse_index_rows: usize,
     pub staged_written_bytes: u64,
     pub delete_descriptors: usize,
     pub delete_descriptor_capacity: usize,
@@ -628,6 +637,32 @@ where
     let plan = crate::gc::stage_repository_gc(read, &mut writes).await?;
     let stats = writes.stats();
     let arena = writes.arena_stats();
+    let mut delete_counts_by_space: Vec<(u32, usize)> = writes
+        .delete_counts_by_space()
+        .into_iter()
+        .map(|(space, count)| (space.id.0, count))
+        .collect();
+    delete_counts_by_space.sort_unstable_by_key(|(space_id, _)| *space_id);
+    let delete_count = |space_id| {
+        delete_counts_by_space
+            .iter()
+            .find_map(|(candidate, count)| (*candidate == space_id).then_some(*count))
+            .unwrap_or_default()
+    };
+    let deleted_commit_state_manifests = delete_count(
+        crate::tracked_state::TRACKED_STATE_COMMIT_STATE_MANIFEST_SPACE
+            .id
+            .0,
+    );
+    let deleted_mutation_inventories = delete_count(
+        crate::tracked_state::TRACKED_STATE_COMMIT_MUTATION_INVENTORY_SPACE
+            .id
+            .0,
+    );
+    let deleted_semantic_commit_projections = delete_count(crate::changelog::COMMIT_SPACE.id.0);
+    let deleted_semantic_change_rows = delete_count(crate::changelog::CHANGE_SPACE.id.0);
+    let deleted_semantic_reverse_index_rows =
+        delete_count(crate::changelog::COMMIT_CHANGE_ID_SPACE.id.0);
     Ok(RepositoryGcBenchResult {
         live_commits: plan.changelog.live.commits.len(),
         swept_commits: plan
@@ -651,6 +686,12 @@ where
         swept_payloads: plan.changelog.sweep.json_payloads.len(),
         staged_puts: stats.staged_puts,
         staged_deletes: stats.staged_deletes,
+        delete_counts_by_space,
+        deleted_commit_state_manifests,
+        deleted_mutation_inventories,
+        deleted_semantic_commit_projections,
+        deleted_semantic_change_rows,
+        deleted_semantic_reverse_index_rows,
         staged_written_bytes: stats.written_bytes,
         delete_descriptors: arena.delete_descriptors,
         delete_descriptor_capacity: arena.delete_descriptor_capacity,
@@ -856,7 +897,7 @@ pub(crate) fn record_json_store_stage_bytes(hash: [u8; 32]) {
     JSON_STORE_STAGE_BYTES.fetch_add(hash.len() as u64, Ordering::Relaxed);
 }
 
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct StorageLayoutAccounting {
     pub space_id: u32,
     pub space: &'static str,
@@ -1980,20 +2021,77 @@ mod tests {
         .expect("delete benchmark branch");
         let adapter = StorageAdapter::new(storage);
 
+        let before_layout = super::layout_accounting(
+            &adapter
+                .begin_read(crate::ReadOptions::default())
+                .await
+                .expect("begin pre-GC inventory read"),
+        )
+        .await;
+
         let first = plan_repository_gc_for_bench(&adapter)
             .await
             .expect("plan repository gc");
+        let after_first_layout = super::layout_accounting(
+            &adapter
+                .begin_read(crate::ReadOptions::default())
+                .await
+                .expect("begin post-first-plan inventory read"),
+        )
+        .await;
         let second = plan_repository_gc_for_bench(&adapter)
             .await
             .expect("repeat repository gc plan");
+        let after_second_layout = super::layout_accounting(
+            &adapter
+                .begin_read(crate::ReadOptions::default())
+                .await
+                .expect("begin post-second-plan inventory read"),
+        )
+        .await;
 
         assert_eq!(first.swept_commits, 10);
-        // Each unreachable commit removes its changelog projection, the
-        // unified commit-state authority, and its standalone change fact.
-        assert_eq!(first.staged_deletes, 30);
-        assert_eq!(first.key_shared_buffers, 30);
-        assert_eq!(first.key_shared_bytes, 30 * 16);
+        assert_eq!(first.swept_standalone_changes, 10);
+        assert_eq!(first.deleted_commit_state_manifests, 10);
+        assert_eq!(first.deleted_mutation_inventories, 10);
+        assert_eq!(first.deleted_semantic_commit_projections, 11);
+        assert_eq!(first.deleted_semantic_change_rows, 21);
+        assert_eq!(first.deleted_semantic_reverse_index_rows, 11);
+        assert_eq!(
+            first.delete_counts_by_space,
+            vec![
+                (
+                    crate::tracked_state::TRACKED_STATE_COMMIT_STATE_MANIFEST_SPACE
+                        .id
+                        .0,
+                    10,
+                ), // commit-state manifest authority
+                (
+                    crate::tracked_state::TRACKED_STATE_COMMIT_MUTATION_INVENTORY_SPACE
+                        .id
+                        .0,
+                    10,
+                ), // mutation inventory authority
+                (crate::changelog::COMMIT_SPACE.id.0, 11), // semantic commit projections
+                (crate::changelog::CHANGE_SPACE.id.0, 21), // semantic change facts
+                (crate::changelog::COMMIT_CHANGE_ID_SPACE.id.0, 11), // commit -> change reverse index
+            ]
+        );
+        assert_eq!(
+            first
+                .delete_counts_by_space
+                .iter()
+                .map(|(_, count)| *count as u64)
+                .sum::<u64>(),
+            first.staged_deletes
+        );
+        assert_eq!(first.delete_descriptors, first.staged_deletes as usize);
+        assert_eq!(first.key_shared_buffers, first.staged_deletes as usize);
+        assert_eq!(first.key_shared_bytes, first.staged_deletes as usize * 16);
         assert_eq!(second.swept_commits, first.swept_commits);
+        assert_eq!(second.delete_counts_by_space, first.delete_counts_by_space);
         assert_eq!(second.staged_deletes, first.staged_deletes);
+        assert_eq!(before_layout, after_first_layout);
+        assert_eq!(after_first_layout, after_second_layout);
     }
 }

--- a/packages/engine/src/storage_bench.rs
+++ b/packages/engine/src/storage_bench.rs
@@ -24,13 +24,7 @@ fn stage_bench_commit_deltas(
         writes,
         &crate::tracked_state::CommitStateManifest {
             commit_id,
-            generation: 0,
-            parent_commit_ids: Vec::new(),
-            commit_change_id: crate::changelog::ChangeId::for_test_label(&format!(
-                "{commit_id}:bench-commit"
-            )),
-            account_id: crate::ANONYMOUS_ACCOUNT_ID.to_string(),
-            created_at: crate::common::LixTimestamp::from_unix_millis_utc_lossy(0),
+            change_account_id: crate::ANONYMOUS_ACCOUNT_ID.to_string(),
             replay_debt: crate::tracked_state::CommitStateReplayDebt {
                 depth: 1,
                 rows: u64::from(mutations.member_count),

--- a/packages/engine/src/test_support.rs
+++ b/packages/engine/src/test_support.rs
@@ -538,32 +538,21 @@ fn stage_test_commit_state_manifest(
     mutations: CommitStateMutationInventory,
     snapshot_root: Option<TrackedStateCommitRoot>,
 ) -> Result<(), crate::LixError> {
-    let record = &staged.record;
     let replay_debt = if snapshot_root.is_some() {
         CommitStateReplayDebt::default()
     } else {
-        CommitStateReplayDebt {
-            depth: record.tracked_state_rootless_depth,
-            rows: record.tracked_state_rootless_rows,
-            bytes: record.tracked_state_rootless_bytes,
-        }
+        staged.replay_debt
     };
-    crate::tracked_state::stage_commit_state_manifest(
-        writes,
-        &CommitStateManifest {
-            commit_id: record.commit_id,
-            generation: record.generation,
-            parent_commit_ids: record.parent_commit_ids.clone(),
-            commit_change_id: record.change_id,
-            account_id: record.account_id.clone(),
-            created_at: record.created_at,
-            replay_debt,
-            mutations,
-            touched_scope_filter: Default::default(),
-            current_state_scoped_ranges: None,
-            snapshot_root,
-        },
-    )
+    let manifest = CommitStateManifest {
+        commit_id: staged.record.commit_id,
+        change_account_id: staged.record.account_id.clone(),
+        replay_debt,
+        mutations,
+        touched_scope_filter: Default::default(),
+        current_state_scoped_ranges: None,
+        snapshot_root: snapshot_root.map(Box::new),
+    };
+    crate::tracked_state::stage_commit_state_manifest(writes, &manifest)
 }
 
 #[cfg(test)]
@@ -673,23 +662,22 @@ async fn stage_test_changelog_commit(
             commit_ids: &typed_parent_ids,
         })
         .await?;
+    let parent_manifests =
+        crate::tracked_state::load_commit_state_manifests(&*read, &typed_parent_ids).await?;
+    let first_parent_debt = parent_manifests
+        .first()
+        .and_then(Option::as_ref)
+        .map_or(CommitStateReplayDebt::default(), |manifest| {
+            manifest.replay_debt
+        });
     let tracked_state_rootless_depth = if tracked_state_rootless {
-        parent_records
-            .iter()
-            .next()
-            .and_then(|(_, record)| record)
-            .map_or(1, |record| {
-                record.tracked_state_rootless_depth.saturating_add(1)
-            })
+        first_parent_debt.depth.saturating_add(1)
     } else {
         0
     };
     let tracked_state_rootless_rows = if tracked_state_rootless {
-        parent_records
-            .iter()
-            .next()
-            .and_then(|(_, record)| record)
-            .map_or(0, |record| record.tracked_state_rootless_rows)
+        first_parent_debt
+            .rows
             .saturating_add(u64::try_from(rows.len()).unwrap_or(u64::MAX))
     } else {
         0
@@ -730,14 +718,10 @@ async fn stage_test_changelog_commit(
         .map(|row| crate::common::LixTimestamp::expect_parse("created_at", &row.created_at))
         .unwrap_or_else(test_timestamp);
     let record = CommitRecord {
-        format_version: 1,
+        format_version: 2,
         commit_id: typed_commit_id,
         generation,
         parent_commit_ids: typed_parent_ids,
-        tracked_state_rootless,
-        tracked_state_rootless_depth,
-        tracked_state_rootless_rows,
-        tracked_state_rootless_bytes,
         change_id: typed_commit_change_id,
         account_id: crate::ANONYMOUS_ACCOUNT_ID.to_string(),
         created_at,
@@ -748,12 +732,18 @@ async fn stage_test_changelog_commit(
     change_commit_ids.sort_by_key(|(row_index, _)| *row_index);
     Ok(TestStagedChangelogCommit {
         record,
+        replay_debt: CommitStateReplayDebt {
+            depth: tracked_state_rootless_depth,
+            rows: tracked_state_rootless_rows,
+            bytes: tracked_state_rootless_bytes,
+        },
         change_commit_ids,
     })
 }
 
 struct TestStagedChangelogCommit {
     record: CommitRecord,
+    replay_debt: CommitStateReplayDebt,
     change_commit_ids: Vec<(usize, CommitId)>,
 }
 

--- a/packages/engine/src/tracked_state/bench_support.rs
+++ b/packages/engine/src/tracked_state/bench_support.rs
@@ -696,12 +696,19 @@ where
     }
 
     async fn read_point_by_replay(&self, read: &(impl StorageAdapterRead + ?Sized)) -> usize {
+        let point_cache = super::storage::CommitDeltaPointReadCache::default();
         for commit_id in self.commits.iter().rev() {
-            let values = super::storage::load_commit_delta_values_encoded_with_cache(
+            let Some(state) = super::storage::load_point_replay_commit_state(read, *commit_id)
+                .await
+                .expect("load benchmark replay authority")
+            else {
+                continue;
+            };
+            let values = super::storage::load_commit_delta_values_encoded_from_replay_manifest(
                 read,
-                *commit_id,
+                &state,
                 std::slice::from_ref(&self.encoded_key),
-                None,
+                &point_cache,
             )
             .await
             .expect("replay benchmark commit point");

--- a/packages/engine/src/tracked_state/bench_support.rs
+++ b/packages/engine/src/tracked_state/bench_support.rs
@@ -14,6 +14,20 @@ use crate::tracked_state::{
     TrackedStateScanRequest,
 };
 
+pub use super::mutation_directory::MutationDirectoryReadAccounting;
+
+/// Resets the feature-gated authenticated mutation-directory counters for one
+/// benchmark phase. Production builds do not compile this module.
+pub fn reset_mutation_directory_read_accounting() {
+    super::mutation_directory::reset_mutation_directory_read_accounting();
+}
+
+/// Stops and snapshots the feature-gated authenticated mutation-directory
+/// counters for the completed benchmark phase.
+pub fn snapshot_mutation_directory_read_accounting() -> MutationDirectoryReadAccounting {
+    super::mutation_directory::snapshot_mutation_directory_read_accounting()
+}
+
 fn stage_bench_commit_deltas(
     writes: &mut StorageWriteSet,
     deltas: &[TrackedStateCommitDeltaRef<'_>],

--- a/packages/engine/src/tracked_state/bench_support.rs
+++ b/packages/engine/src/tracked_state/bench_support.rs
@@ -28,11 +28,7 @@ fn stage_bench_commit_deltas(
         writes,
         &CommitStateManifest {
             commit_id,
-            generation: 0,
-            parent_commit_ids: Vec::new(),
-            commit_change_id: ChangeId::for_test_label(&format!("{commit_id}:bench-commit")),
-            account_id: crate::ANONYMOUS_ACCOUNT_ID.to_string(),
-            created_at: crate::common::LixTimestamp::from_unix_millis_utc_lossy(0),
+            change_account_id: crate::ANONYMOUS_ACCOUNT_ID.to_string(),
             replay_debt: CommitStateReplayDebt {
                 depth: 1,
                 rows: u64::from(mutations.member_count),
@@ -523,11 +519,7 @@ where
         .expect("stage benchmark merge serving root");
         let merged = CommitStateManifest {
             commit_id: merge_id,
-            generation: self.current_manifest.generation.saturating_add(1),
-            parent_commit_ids: vec![self.current_manifest.commit_id, other_id],
-            commit_change_id: ChangeId::for_test_label("scoped-range-empty-merge-change"),
-            account_id: crate::ANONYMOUS_ACCOUNT_ID.to_string(),
-            created_at: crate::common::LixTimestamp::from_unix_millis_utc_lossy(33),
+            change_account_id: crate::ANONYMOUS_ACCOUNT_ID.to_string(),
             replay_debt: CommitStateReplayDebt {
                 depth: self
                     .current_manifest
@@ -734,7 +726,7 @@ fn bench_addressable_commit_id(label: &str) -> CommitId {
 
 fn bench_current_state_manifest(
     commit_id: CommitId,
-    parent_commit_id: Option<CommitId>,
+    _parent_commit_id: Option<CommitId>,
     replay_depth: u16,
     mutations: super::types::CommitStateMutationInventory,
     touched_scope_filter: super::types::CommitStateTouchedScopeFilter,
@@ -742,11 +734,7 @@ fn bench_current_state_manifest(
 ) -> CommitStateManifest {
     CommitStateManifest {
         commit_id,
-        generation: 0,
-        parent_commit_ids: parent_commit_id.into_iter().collect(),
-        commit_change_id: ChangeId::for_test_label(&format!("{commit_id}:bench-state")),
-        account_id: crate::ANONYMOUS_ACCOUNT_ID.to_string(),
-        created_at: crate::common::LixTimestamp::from_unix_millis_utc_lossy(0),
+        change_account_id: crate::ANONYMOUS_ACCOUNT_ID.to_string(),
         replay_debt: CommitStateReplayDebt {
             depth: replay_depth,
             rows: u64::from(mutations.member_count),

--- a/packages/engine/src/tracked_state/codec.rs
+++ b/packages/engine/src/tracked_state/codec.rs
@@ -11,8 +11,6 @@ use crate::tracked_state::types::{
     TrackedStateKeyRef, TrackedStateMutation, TrackedStateMutationBatch,
 };
 
-const WEIBULL_K: i32 = 4;
-
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct EncodedLeafEntry {
     pub(crate) key: Bytes,
@@ -231,8 +229,8 @@ impl DecodedInternalNode {
     }
 }
 
-const NODE_KIND_LEAF_V3: u8 = 3;
-const NODE_KIND_INTERNAL_V3: u8 = 4;
+const NODE_KIND_LEAF_V4: u8 = 5;
+const NODE_KIND_INTERNAL_V4: u8 = 6;
 
 #[derive(Debug, Clone, Copy)]
 struct MutationSpan {
@@ -1417,10 +1415,10 @@ const VALUE_TAIL_DISTINCT_MIN: u8 = VALUE_TIMESTAMP_WIDTH_COUNT;
 const VALUE_TAIL_DISTINCT_MAX: u8 =
     VALUE_TAIL_DISTINCT_MIN + VALUE_TIMESTAMP_WIDTH_COUNT * VALUE_TIMESTAMP_WIDTH_COUNT - 1;
 
-/// Leaf node wire format (v3):
+/// Leaf node wire format (v4):
 ///
 /// ```text
-/// [NODE_KIND_LEAF_V3]
+/// [NODE_KIND_LEAF_V4]
 /// varint entry_count
 /// varint commit_dict_len ++ commit_dict_len x 16 commit-id bytes
 /// varint tail_dict_len ++ tail_dict_len x self-delimiting state tails
@@ -1470,7 +1468,7 @@ pub(crate) fn encode_leaf_node_refs(entries: &[EncodedLeafEntryRef<'_>]) -> Vec<
     let tail_dictionary = repeated_tail_dictionary(entries);
 
     let mut out = Vec::with_capacity(64 + entries.len() * 24);
-    out.push(NODE_KIND_LEAF_V3);
+    out.push(NODE_KIND_LEAF_V4);
     write_varint(&mut out, entries.len() as u64);
     write_varint(&mut out, commit_dictionary.len() as u64);
     for commit_id in &commit_dictionary {
@@ -1578,7 +1576,7 @@ fn slice_dictionary_ref(dictionary: &[&[u8]], value: &[u8]) -> u64 {
         .map_or(0, |index| index as u64 + 1)
 }
 
-fn decode_leaf_v3(body: &[u8]) -> Result<DecodedLeafNodeRef, LixError> {
+fn decode_leaf_v4(body: &[u8]) -> Result<DecodedLeafNodeRef, LixError> {
     fn usize_from(value: u64, what: &str) -> Result<usize, LixError> {
         usize::try_from(value).map_err(|_| {
             LixError::new(
@@ -1799,7 +1797,7 @@ pub(crate) fn encode_internal_node_refs(children: &[ChildSummaryRef<'_>]) -> Vec
     );
 
     let mut out = Vec::with_capacity(2 + children.len() * 40);
-    out.push(NODE_KIND_INTERNAL_V3);
+    out.push(NODE_KIND_INTERNAL_V4);
     write_varint(&mut out, children.len() as u64);
     let mut previous_last: &[u8] = &[];
     for child in children {
@@ -1819,7 +1817,7 @@ fn write_front_coded(out: &mut Vec<u8>, base: &[u8], value: &[u8]) {
     out.extend_from_slice(&value[shared..]);
 }
 
-fn decode_internal_v3(body: &[u8]) -> Result<DecodedInternalNode, LixError> {
+fn decode_internal_v4(body: &[u8]) -> Result<DecodedInternalNode, LixError> {
     fn usize_from(value: u64, what: &str) -> Result<usize, LixError> {
         usize::try_from(value).map_err(|_| {
             LixError::new(
@@ -1961,8 +1959,8 @@ pub(crate) fn decode_node_ref(bytes: &[u8]) -> Result<DecodedNodeRef, LixError> 
         .split_first()
         .ok_or_else(|| LixError::new("LIX_ERROR_UNKNOWN", "tracked-state tree node is empty"))?;
     match kind {
-        NODE_KIND_LEAF_V3 => Ok(DecodedNodeRef::Leaf(decode_leaf_v3(body)?)),
-        NODE_KIND_INTERNAL_V3 => Ok(DecodedNodeRef::Internal(decode_internal_v3(body)?)),
+        NODE_KIND_LEAF_V4 => Ok(DecodedNodeRef::Leaf(decode_leaf_v4(body)?)),
+        NODE_KIND_INTERNAL_V4 => Ok(DecodedNodeRef::Internal(decode_internal_v4(body)?)),
         other => Err(LixError::new(
             "LIX_ERROR_UNKNOWN",
             format!("tracked-state tree node has unknown kind byte {other}"),
@@ -1974,7 +1972,7 @@ pub(crate) fn decode_node_ref(bytes: &[u8]) -> Result<DecodedNodeRef, LixError> 
 pub(crate) fn boundary_trigger(
     encoded_key: &[u8],
     level: usize,
-    chunk_size: usize,
+    _chunk_size: usize,
     item_size: usize,
     target_chunk_bytes: usize,
 ) -> bool {
@@ -1982,24 +1980,13 @@ pub(crate) fn boundary_trigger(
         return false;
     }
 
-    let start =
-        weibull_cdf(chunk_size.saturating_sub(item_size) as f64 / target_chunk_bytes as f64);
-    let end = weibull_cdf(chunk_size as f64 / target_chunk_bytes as f64);
-    let remaining = 1.0 - start;
-    if remaining <= 0.0 {
-        return true;
-    }
-
-    let split_probability = ((end - start) / remaining).clamp(0.0, 1.0);
     let hash = xxh3_64_with_seed(encoded_key, level_salt(level));
-    (hash as f64) < split_probability * (u64::MAX as f64)
-}
-
-fn weibull_cdf(normalized_size: f64) -> f64 {
-    if normalized_size <= 0.0 {
-        return 0.0;
-    }
-    -f64::exp_m1(-normalized_size.powi(WEIBULL_K))
+    // The boundary is a property of the first key, not of the preceding
+    // entries.  This makes insertion order-independent intervals resync
+    // after the next authenticated key boundary instead of shifting every
+    // suffix.  The caller still enforces min/max byte ceilings.
+    let probability = (item_size as f64 / target_chunk_bytes as f64).clamp(0.01, 1.0);
+    (hash as f64) < probability * (u64::MAX as f64)
 }
 
 fn level_salt(level: usize) -> u64 {
@@ -2055,7 +2042,7 @@ mod tests {
     }
 
     #[test]
-    fn leaf_v3_round_trips_representative_shapes() {
+    fn leaf_v4_round_trips_representative_shapes() {
         leaf_entries_round_trip(&[]);
         leaf_entries_round_trip(&[(b"only".to_vec(), raw_value(1, 2, 3))]);
         leaf_entries_round_trip(&[
@@ -2074,7 +2061,7 @@ mod tests {
     }
 
     #[test]
-    fn leaf_v3_round_trips_dictionaries_with_variable_tail_widths() {
+    fn leaf_v4_round_trips_dictionaries_with_variable_tail_widths() {
         leaf_entries_round_trip(&[
             (b"a".to_vec(), raw_value(1, 9, 0)),
             (b"b".to_vec(), raw_value(2, 9, 0)),
@@ -2084,7 +2071,7 @@ mod tests {
     }
 
     #[test]
-    fn leaf_v3_round_trips_generated_sorted_keys() {
+    fn leaf_v4_round_trips_generated_sorted_keys() {
         // Deterministic pseudo-random keys with heavy shared prefixes,
         // mimicking encoded (schema_key, file_id, entity_pk) keys.
         let mut entries = (0..512usize)
@@ -2111,7 +2098,7 @@ mod tests {
     }
 
     #[test]
-    fn leaf_v3_round_trips_multibyte_key_varints() {
+    fn leaf_v4_round_trips_multibyte_key_varints() {
         // Keys long enough that shared and suffix lengths need two-byte
         // varints, with >127 entries so the count does too.
         let mut entries = Vec::new();
@@ -2145,7 +2132,7 @@ mod tests {
     }
 
     #[test]
-    fn leaf_v3_round_trips_repeated_and_literal_value_parts() {
+    fn leaf_v4_round_trips_repeated_and_literal_value_parts() {
         let mut entries = Vec::new();
         for index in 0..300usize {
             let key = format!("rows/{index:05}").into_bytes();
@@ -2182,7 +2169,7 @@ mod tests {
     }
 
     #[test]
-    fn leaf_v3_wire_format_is_pinned() {
+    fn leaf_v4_wire_format_is_pinned() {
         let entries = [
             (b"k1".to_vec(), raw_value(0xAA, 0xCC, 0xDD)),
             (b"k2".to_vec(), raw_value(0xBB, 0xCC, 0xDD)),
@@ -2197,7 +2184,7 @@ mod tests {
             .collect::<Vec<_>>();
         let encoded = encode_leaf_refs_for_tests(&refs);
         let mut expected = vec![
-            3, // NODE_KIND_LEAF_V3
+            5, // NODE_KIND_LEAF_V4
             3, // entry count
             1, // commit dictionary length
         ];
@@ -2219,11 +2206,11 @@ mod tests {
         expected.extend_from_slice(&[0xFF; 16]);
         expected.push(0);
         expected.extend_from_slice(&[0x93, 0x11, 0x12]);
-        assert_eq!(encoded, expected, "v3 wire bytes must stay stable");
+        assert_eq!(encoded, expected, "v4 wire bytes must stay stable");
     }
 
     #[test]
-    fn leaf_v3_tail_dictionary_saves_83_bytes_for_modeled_shape() {
+    fn leaf_v4_tail_dictionary_saves_83_bytes_for_modeled_shape() {
         let entries = (0..32usize)
             .map(|index| {
                 (
@@ -2264,7 +2251,7 @@ mod tests {
     }
 
     #[test]
-    fn leaf_v3_rejects_malformed_and_legacy_bytes() {
+    fn leaf_v4_rejects_malformed_and_legacy_bytes() {
         let entries = [(b"key-a".to_vec(), raw_value(1, 2, 3))];
         let encoded = encode_leaf_refs_for_tests(
             &entries
@@ -3098,7 +3085,7 @@ mod tests {
     }
 
     #[test]
-    fn internal_v3_round_trips_and_pins_front_coded_boundaries() {
+    fn internal_v4_round_trips_and_pins_front_coded_boundaries() {
         let children = vec![
             ChildSummary {
                 first_key: Bytes::from_static(b"aa"),
@@ -3115,7 +3102,7 @@ mod tests {
         ];
         let encoded = encode_internal_node(&children);
         let mut expected = vec![
-            4, 2, // kind, child count
+            6, 2, // kind, child count
             0, 2, b'a', b'a', // first "aa" relative to empty
             1, 1, b'z', // last "az" relative to "aa"
         ];
@@ -3127,7 +3114,7 @@ mod tests {
         ]);
         expected.extend_from_slice(&[2; TRACKED_STATE_HASH_BYTES]);
         expected.push(4);
-        assert_eq!(encoded, expected, "internal v3 wire bytes must stay stable");
+        assert_eq!(encoded, expected, "internal v4 wire bytes must stay stable");
 
         let DecodedNode::Internal(decoded) = decode_node(&encoded).expect("internal node") else {
             panic!("expected internal node");
@@ -3136,10 +3123,10 @@ mod tests {
     }
 
     #[test]
-    fn internal_v3_rejects_empty_truncated_and_invalid_boundaries() {
-        assert!(decode_node(&[NODE_KIND_INTERNAL_V3, 0]).is_err());
-        assert!(decode_node(&[NODE_KIND_INTERNAL_V3, 1]).is_err());
-        assert!(decode_node(&[NODE_KIND_INTERNAL_V3, 1, 1, 0]).is_err());
+    fn internal_v4_rejects_empty_truncated_and_invalid_boundaries() {
+        assert!(decode_node(&[NODE_KIND_INTERNAL_V4, 0]).is_err());
+        assert!(decode_node(&[NODE_KIND_INTERNAL_V4, 1]).is_err());
+        assert!(decode_node(&[NODE_KIND_INTERNAL_V4, 1, 1, 0]).is_err());
 
         let child = ChildSummary {
             first_key: Bytes::from_static(b"a"),

--- a/packages/engine/src/tracked_state/commit_root_rebuild.rs
+++ b/packages/engine/src/tracked_state/commit_root_rebuild.rs
@@ -10,7 +10,8 @@ use crate::common::LixTimestamp;
 use crate::entity_pk::EntityPk;
 use crate::storage_adapter::{StorageAdapterRead, StorageWriteSet};
 use crate::tracked_state::context::{
-    TrackedStateContext, TrackedStateRootRebuilder, TrackedStateWriteReport, TrackedStateWriter,
+    TrackedStateContext, TrackedStateRootRebuilder, TrackedStateTransientRebuildState,
+    TrackedStateWriteReport, TrackedStateWriter,
 };
 use crate::tracked_state::storage;
 use crate::tracked_state::tree::TrackedStateTree;
@@ -77,9 +78,40 @@ where
         load_rebuild_plans_to_nearest_available_root(rebuilder.store, commit_id, true).await?;
     let mut report = None;
     let context = TrackedStateContext::new();
-    let mut writer = context.writer(rebuilder.store, rebuilder.writes);
+    let mut state = TrackedStateTransientRebuildState::default();
     for plan in plans.iter().rev() {
-        report = Some(stage_rebuild_plan_with_writer(&mut writer, plan).await?);
+        let manifest = storage::load_commit_state_manifest(rebuilder.store, plan.commit_id)
+            .await?
+            .ok_or_else(|| {
+                LixError::new(
+                    LixError::CODE_INTERNAL_ERROR,
+                    format!(
+                        "cannot rebuild tracked_state root for commit '{}' without its commit-state manifest",
+                        plan.commit_id
+                    ),
+                )
+            })?;
+        if manifest.snapshot_root.is_some() {
+            let mut writer =
+                context.writer_with_rebuild_state(rebuilder.store, rebuilder.writes, state);
+            let rooted_report = stage_rebuild_plan_with_writer(&mut writer, plan).await?;
+            writer
+                .promote_reachable_transient_chunks(&rooted_report.root_id)
+                .await?;
+            report = Some(rooted_report);
+            state = writer.into_transient_rebuild_state();
+        } else {
+            // Rootless intermediates may feed a rooted descendant through the
+            // in-memory content-addressed overlay, but their chunks have no
+            // immutable root pointer and must never enter the durable write set.
+            let previously_known = state.chunk_hashes();
+            let mut scratch_writes = StorageWriteSet::new();
+            let mut writer =
+                context.writer_with_rebuild_state(rebuilder.store, &mut scratch_writes, state);
+            report = Some(stage_rebuild_plan_with_writer(&mut writer, plan).await?);
+            state = writer.into_transient_rebuild_state();
+            state.mark_new_chunks_transient(&previously_known);
+        }
     }
     let report = report.ok_or_else(|| {
         LixError::new(
@@ -89,6 +121,7 @@ where
             ),
         )
     })?;
+    let writer = context.writer_with_rebuild_state(rebuilder.store, rebuilder.writes, state);
     writer
         .validate_staged_commit_root_against_changelog(commit_id)
         .await?;

--- a/packages/engine/src/tracked_state/commit_root_rebuild.rs
+++ b/packages/engine/src/tracked_state/commit_root_rebuild.rs
@@ -42,7 +42,7 @@ where
     S: StorageAdapterRead + ?Sized,
 {
     let typed_commit_id = CommitId::parse_lix(commit_id, "commit-root rebuild authority")?;
-    storage::load_commit_state_manifest(rebuilder.store, typed_commit_id)
+    let manifest = storage::load_commit_state_manifest(rebuilder.store, typed_commit_id)
         .await?
         .ok_or_else(|| {
             LixError::new(
@@ -52,6 +52,27 @@ where
                 ),
             )
         })?;
+    if manifest.snapshot_root.is_none() {
+        // Rootless commits are intentionally bounded-replay layouts. Build and
+        // audit the canonical state transiently, but do not persist chunks that
+        // immutable authority cannot address.
+        let mut scratch_writes = StorageWriteSet::new();
+        let mut scratch_rebuilder = TrackedStateRootRebuilder {
+            store: rebuilder.store,
+            writes: &mut scratch_writes,
+        };
+        return rebuild_commit_root_at_inner(&mut scratch_rebuilder, commit_id).await;
+    }
+    rebuild_commit_root_at_inner(rebuilder, commit_id).await
+}
+
+async fn rebuild_commit_root_at_inner<S>(
+    rebuilder: &mut TrackedStateRootRebuilder<'_, S>,
+    commit_id: &str,
+) -> Result<TrackedStateWriteReport, LixError>
+where
+    S: StorageAdapterRead + ?Sized,
+{
     let plans =
         load_rebuild_plans_to_nearest_available_root(rebuilder.store, commit_id, true).await?;
     let mut report = None;
@@ -85,14 +106,19 @@ where
                     ),
                 )
             })?;
-        // The rebuilt tree is an optional immutable accelerator. Preserve
-        // replay debt: it remains the physical-policy authority projected by
-        // the changelog, while readers may serve through this equivalent root.
-        storage::stage_commit_state_snapshot_root_update(
-            rebuilder.writes,
-            &manifest,
-            Some(snapshot_root),
-        )?;
+        if let Some(expected) = manifest.snapshot_root.as_ref()
+            && !expected.has_same_authoritative_layout(&snapshot_root)
+        {
+            return Err(LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                format!(
+                    "rebuilt tracked_state root for commit '{}' disagrees with immutable commit authority: expected {expected:?}, rebuilt {snapshot_root:?}",
+                    snapshot_root.commit_id,
+                ),
+            ));
+        }
+        // Root metadata is immutable authority. Rebuilds restore its
+        // content-addressed chunks; rootless commits remain replay-only.
     }
     Ok(report)
 }
@@ -149,8 +175,7 @@ where
         if !seen.insert(commit_id.to_string()) {
             return Ok(None);
         }
-        let Some(metadata) = storage::load_authoritative_commit_root(store, commit_id).await?
-        else {
+        let Some(metadata) = storage::load_snapshot_commit_root(store, commit_id).await? else {
             seen.remove(commit_id);
             return Ok(None);
         };

--- a/packages/engine/src/tracked_state/context.rs
+++ b/packages/engine/src/tracked_state/context.rs
@@ -4207,7 +4207,6 @@ where
         let mut mutation_batch = TrackedStateMutationBatchBuilder::with_row_capacity(
             cascade_mutations.len().saturating_add(deltas.len()),
         );
-        let has_cascade_mutations = !cascade_mutations.is_empty();
         for (key, value) in cascade_mutations {
             mutation_batch.push_encoded(&key, &value);
         }
@@ -4251,35 +4250,17 @@ where
         }
         let mutations = mutation_batch.finish();
         let changed_rows = mutations.len();
-        let sparse_existing_batch = base_root.is_some()
-            && !has_cascade_mutations
-            && parent_values.iter().all(Option::is_some)
-            && mutations.len() > 1;
-        let result = if sparse_existing_batch {
-            self.tree
-                .apply_point_mutations_with_overlay(
-                    self.store,
-                    self.writes,
-                    &mut self.chunk_overlay,
-                    base_root
-                        .as_ref()
-                        .expect("sparse batch requires parent root"),
-                    mutations,
-                    Some(commit_id),
-                )
-                .await?
-        } else {
-            self.tree
-                .apply_mutations_with_overlay(
-                    self.store,
-                    self.writes,
-                    &mut self.chunk_overlay,
-                    base_root.as_ref(),
-                    mutations,
-                    Some(commit_id),
-                )
-                .await?
-        };
+        let result = self
+            .tree
+            .apply_mutations_with_overlay(
+                self.store,
+                self.writes,
+                &mut self.chunk_overlay,
+                base_root.as_ref(),
+                mutations,
+                Some(commit_id),
+            )
+            .await?;
         let metadata = TrackedStateCommitRoot {
             commit_id: typed_commit_id,
             root_id: result.root_id.clone(),

--- a/packages/engine/src/tracked_state/context.rs
+++ b/packages/engine/src/tracked_state/context.rs
@@ -929,6 +929,26 @@ impl TrackedStateContext {
         TrackedStateWriter {
             chunk_overlay: storage::TrackedStateChunkOverlay::new(),
             staged_roots: BTreeMap::new(),
+            transient_chunk_hashes: HashSet::new(),
+            tree: self.tree.clone(),
+            store,
+            writes,
+        }
+    }
+
+    pub(crate) fn writer_with_rebuild_state<'a, S>(
+        &'a self,
+        store: &'a S,
+        writes: &'a mut StorageWriteSet,
+        state: TrackedStateTransientRebuildState,
+    ) -> TrackedStateWriter<'a, S>
+    where
+        S: StorageAdapterRead + ?Sized,
+    {
+        TrackedStateWriter {
+            chunk_overlay: state.chunk_overlay,
+            staged_roots: state.staged_roots,
+            transient_chunk_hashes: state.transient_chunk_hashes,
             tree: self.tree.clone(),
             store,
             writes,
@@ -3699,9 +3719,36 @@ fn exact_current_state_scope(
 pub(crate) struct TrackedStateWriter<'a, S: ?Sized> {
     chunk_overlay: storage::TrackedStateChunkOverlay,
     staged_roots: BTreeMap<String, TrackedStateCommitRoot>,
+    transient_chunk_hashes: HashSet<[u8; crate::tracked_state::types::TRACKED_STATE_HASH_BYTES]>,
     tree: TrackedStateTree,
     store: &'a S,
     writes: &'a mut StorageWriteSet,
+}
+
+#[derive(Debug, Default)]
+pub(crate) struct TrackedStateTransientRebuildState {
+    chunk_overlay: storage::TrackedStateChunkOverlay,
+    staged_roots: BTreeMap<String, TrackedStateCommitRoot>,
+    transient_chunk_hashes: HashSet<[u8; crate::tracked_state::types::TRACKED_STATE_HASH_BYTES]>,
+}
+
+impl TrackedStateTransientRebuildState {
+    pub(crate) fn chunk_hashes(
+        &self,
+    ) -> HashSet<[u8; crate::tracked_state::types::TRACKED_STATE_HASH_BYTES]> {
+        self.chunk_overlay.chunk_hashes().collect()
+    }
+
+    pub(crate) fn mark_new_chunks_transient(
+        &mut self,
+        previously_known: &HashSet<[u8; crate::tracked_state::types::TRACKED_STATE_HASH_BYTES]>,
+    ) {
+        self.transient_chunk_hashes.extend(
+            self.chunk_overlay
+                .chunk_hashes()
+                .filter(|hash| !previously_known.contains(hash)),
+        );
+    }
 }
 
 /// Explicit commit-root rebuilder created by `TrackedStateContext`.
@@ -3726,6 +3773,38 @@ impl<S> TrackedStateWriter<'_, S>
 where
     S: StorageAdapterRead + ?Sized,
 {
+    pub(crate) fn into_transient_rebuild_state(self) -> TrackedStateTransientRebuildState {
+        TrackedStateTransientRebuildState {
+            chunk_overlay: self.chunk_overlay,
+            staged_roots: self.staged_roots,
+            transient_chunk_hashes: self.transient_chunk_hashes,
+        }
+    }
+
+    pub(crate) async fn promote_reachable_transient_chunks(
+        &mut self,
+        root_id: &TrackedStateRootId,
+    ) -> Result<(), LixError> {
+        if self.transient_chunk_hashes.is_empty() {
+            return Ok(());
+        }
+        let reachable = self
+            .tree
+            .reachable_chunk_hashes_with_overlay(self.store, &self.chunk_overlay, root_id)
+            .await?;
+        let promoted = self
+            .transient_chunk_hashes
+            .intersection(&reachable)
+            .copied()
+            .collect::<Vec<_>>();
+        self.chunk_overlay
+            .stage_selected_chunks(self.writes, promoted.iter().copied())?;
+        for hash in promoted {
+            self.transient_chunk_hashes.remove(&hash);
+        }
+        Ok(())
+    }
+
     pub(crate) fn staged_commit_roots(&self) -> impl Iterator<Item = &TrackedStateCommitRoot> {
         self.staged_roots.values()
     }
@@ -4793,6 +4872,7 @@ fn nullable_key_filter_allows(filters: &[NullableKeyFilter<String>], value: Opti
 
 #[cfg(test)]
 mod tests {
+    use std::ops::Bound;
     use std::time::Instant;
 
     use super::*;
@@ -8091,6 +8171,207 @@ mod tests {
         assert_eq!(writes.stats().staged_puts, 0);
         assert_eq!(writes.stats().staged_deletes, 0);
         assert_eq!(writes.stats().written_bytes, 0);
+    }
+
+    #[tokio::test]
+    async fn rooted_rebuild_promotes_only_reachable_chunks_from_rootless_ancestor() {
+        let storage = StorageAdapter::new(Memory::new());
+        let tracked_state = TrackedStateContext::new();
+        write_root_for_test(
+            &storage,
+            &tracked_state,
+            "base",
+            None,
+            &[row_with_value("entity-base", "base-a", "base", "base")],
+        )
+        .await
+        .expect("base root should write");
+        let rootless_rows = (0..300)
+            .map(|index| {
+                row_with_value(
+                    &format!("entity-{index:04}"),
+                    &format!("rootless-{index:04}"),
+                    "rootless",
+                    "rootless",
+                )
+            })
+            .collect::<Vec<_>>();
+        write_rootless_commit_for_test(&storage, "rootless", "base", &rootless_rows).await;
+        write_rootless_commit_for_test(
+            &storage,
+            "child",
+            "rootless",
+            &[row_with_value(
+                "entity-0150",
+                "child-0150",
+                "child",
+                "child",
+            )],
+        )
+        .await;
+        let read = storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("fixture rebuild read should open");
+        let plans = crate::tracked_state::commit_root_rebuild::load_rebuild_plans_to_nearest_available_root(
+            &read,
+            "child",
+            true,
+        )
+        .await
+        .expect("fixture plans should load");
+        let mut fixture_writes = storage.new_write_set();
+        let mut fixture_writer = tracked_state.writer(&read, &mut fixture_writes);
+        for plan in plans.iter().rev() {
+            crate::tracked_state::commit_root_rebuild::stage_rebuild_plan_with_writer(
+                &mut fixture_writer,
+                plan,
+            )
+            .await
+            .expect("fixture root should stage");
+        }
+        let child_commit_id = CommitId::for_test_label("child");
+        let child_snapshot_root = fixture_writer
+            .staged_commit_roots()
+            .find(|root| root.commit_id == child_commit_id)
+            .cloned()
+            .expect("fixture child root should exist");
+        drop(fixture_writer);
+        let mut child_manifest = storage::load_commit_state_manifest(&read, child_commit_id)
+            .await
+            .expect("child manifest should load")
+            .expect("child manifest should exist");
+        child_manifest.replay_debt = crate::tracked_state::CommitStateReplayDebt::default();
+        child_manifest.snapshot_root = Some(Box::new(child_snapshot_root));
+        storage::stage_resealed_commit_state_manifest_for_test(
+            &mut fixture_writes,
+            &child_manifest,
+        )
+        .expect("rooted child authority should reseal");
+        drop(read);
+        storage
+            .commit_write_set(fixture_writes, StorageWriteOptions::default())
+            .await
+            .expect("rooted child fixture should commit");
+
+        let read = storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("reachability read should open");
+        let base_root = storage::load_root(&read, "base")
+            .await
+            .expect("base root should load")
+            .expect("base root should exist");
+        let child_root = storage::load_root(&read, "child")
+            .await
+            .expect("child root should load")
+            .expect("child root should exist");
+        let empty_overlay = storage::TrackedStateChunkOverlay::new();
+        let tree = TrackedStateTree::new();
+        let base_reachable = tree
+            .reachable_chunk_hashes_with_overlay(&read, &empty_overlay, &base_root)
+            .await
+            .expect("base reachability should load");
+        let child_reachable = tree
+            .reachable_chunk_hashes_with_overlay(&read, &empty_overlay, &child_root)
+            .await
+            .expect("child reachability should load");
+        drop(read);
+
+        let all_chunks = stored_tree_chunk_hashes_for_test(&storage).await;
+        let mut deletes = storage.new_write_set();
+        for hash in all_chunks.difference(&base_reachable) {
+            deletes.delete(
+                storage::TRACKED_STATE_TREE_CHUNK_SPACE,
+                crate::storage_adapter::StorageKey(Bytes::copy_from_slice(hash)),
+            );
+        }
+        storage
+            .commit_write_set(deletes, StorageWriteOptions::default())
+            .await
+            .expect("child-only chunks should delete");
+        let before = stored_tree_chunk_hashes_for_test(&storage).await;
+
+        let read = storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("rebuild read should open");
+        let mut writes = storage.new_write_set();
+        tracked_state
+            .root_rebuilder(&read, &mut writes)
+            .rebuild_commit_root_at("child")
+            .await
+            .expect("rooted descendant should rebuild through rootless authority");
+        storage
+            .commit_write_set(writes, StorageWriteOptions::default())
+            .await
+            .expect("reachable rebuilt chunks should commit");
+
+        let after = stored_tree_chunk_hashes_for_test(&storage).await;
+        let added = after.difference(&before).copied().collect::<HashSet<_>>();
+        let expected = child_reachable
+            .difference(&before)
+            .copied()
+            .collect::<HashSet<_>>();
+        assert_eq!(added, expected);
+        let rows = tracked_state
+            .reader(
+                storage
+                    .begin_read(StorageReadOptions::default())
+                    .await
+                    .expect("verification read should open"),
+            )
+            .scan_batch_at_commit("child", &test_schema_scan_request())
+            .await
+            .expect("rebuilt child should scan");
+        assert_eq!(rows.len(), 301);
+        assert_eq!(
+            rows.iter()
+                .find(|row| row.entity_pk() == &EntityPk::single("entity-0150"))
+                .and_then(|row| row.snapshot_content())
+                .map(AsRef::as_ref),
+            Some("{\"value\":\"child\"}")
+        );
+    }
+
+    async fn stored_tree_chunk_hashes_for_test(
+        storage: &StorageAdapter,
+    ) -> HashSet<[u8; crate::tracked_state::types::TRACKED_STATE_HASH_BYTES]> {
+        let read = storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("chunk inventory read should open");
+        let chunk = crate::storage_adapter::ScanPlan::range(
+            storage::TRACKED_STATE_TREE_CHUNK_SPACE,
+            crate::storage_adapter::StorageKeyRange {
+                lower: Bound::Unbounded,
+                upper: Bound::Unbounded,
+            },
+        )
+        .collect(
+            &read,
+            crate::storage_adapter::StorageScanOptions {
+                projection: crate::storage_adapter::StorageCoreProjection::KeyOnly,
+                limit_rows: usize::MAX,
+                resume_after: None,
+            },
+        )
+        .await
+        .expect("chunk inventory should scan")
+        .value;
+        assert!(!chunk.has_more, "test chunk inventory must fit one page");
+        chunk
+            .entries
+            .into_iter()
+            .map(|entry| {
+                entry
+                    .key
+                    .0
+                    .as_ref()
+                    .try_into()
+                    .expect("tracked-state chunk keys are fixed hashes")
+            })
+            .collect()
     }
 
     #[tokio::test]

--- a/packages/engine/src/tracked_state/context.rs
+++ b/packages/engine/src/tracked_state/context.rs
@@ -1838,7 +1838,7 @@ where
                 "changelog commit '{commit_id}' is missing while validating tracked-state commit-root rows"
             )));
         };
-        let manifest = storage::load_commit_state_manifest(&self.store, commit_id_typed)
+        let topology = storage::load_published_commit_state_topology(&self.store, commit_id_typed)
             .await?
             .ok_or_else(|| {
                 LixError::new(
@@ -1848,7 +1848,7 @@ where
                     ),
                 )
             })?;
-        if manifest.mutations.member_count == 0 {
+        if topology.mutation_member_count() == 0 {
             cache
                 .commit_delta_winners
                 .insert(commit_id.to_string(), HashMap::new());
@@ -1913,7 +1913,7 @@ where
             CommitId::parse_lix(commit_id, "tracked-state optional snapshot root lookup")?;
         self.load_cached_changelog_first_parent(commit_id, cache)
             .await?;
-        let manifest = storage::load_commit_state_manifest(&self.store, typed_commit_id)
+        let topology = storage::load_published_commit_state_topology(&self.store, typed_commit_id)
             .await?
             .ok_or_else(|| {
                 LixError::new(
@@ -1923,10 +1923,7 @@ where
                     ),
                 )
             })?;
-        let root_id = manifest
-            .snapshot_root
-            .as_ref()
-            .map(|root| root.root_id.clone());
+        let root_id = topology.snapshot_root_id();
         cache
             .commit_roots
             .insert(commit_id.to_string(), root_id.clone());
@@ -2008,9 +2005,14 @@ where
             }
         } else {
             let typed_commit_id = CommitId::parse_lix(commit_id, "diff row owner commit_id")?;
-            storage::load_commit_state_manifest(&self.store, typed_commit_id)
-                .await?
-                .ok_or_else(|| missing_commit_root_error(commit_id))?;
+            let authority_ids = storage::load_commit_state_authority_ids(
+                &self.store,
+                std::slice::from_ref(&typed_commit_id),
+            )
+            .await?;
+            if authority_ids.into_iter().next().flatten().is_none() {
+                return Err(missing_commit_root_error(commit_id));
+            }
             if let Some(parent_commit_id) = self
                 .load_cached_changelog_first_parent(
                     commit_id,
@@ -2660,19 +2662,19 @@ where
             "tracked-state current-state diff right commit_id",
         )?;
         let Some(left_state) =
-            storage::load_published_commit_state_manifest(&self.store, left_commit_id).await?
+            storage::load_published_commit_state_topology(&self.store, left_commit_id).await?
         else {
             return Ok(None);
         };
         let Some(right_state) =
-            storage::load_published_commit_state_manifest(&self.store, right_commit_id).await?
+            storage::load_published_commit_state_topology(&self.store, right_commit_id).await?
         else {
             return Ok(None);
         };
-        let Some(left_root) = left_state.current_state_scoped_ranges.as_ref() else {
+        let Some(left_root) = left_state.current_state_scoped_ranges() else {
             return Ok(None);
         };
-        let Some(right_root) = right_state.current_state_scoped_ranges.as_ref() else {
+        let Some(right_root) = right_state.current_state_scoped_ranges() else {
             return Ok(None);
         };
         let prefix = super::current_state_envelope::current_state_scope_prefix(&scope)?;
@@ -6888,6 +6890,10 @@ mod tests {
             for commit_id in ["middle", "child"] {
                 writes.delete(
                     storage::TRACKED_STATE_COMMIT_STATE_MANIFEST_SPACE,
+                    commit_root_key(commit_id),
+                );
+                writes.delete(
+                    storage::TRACKED_STATE_COMMIT_MUTATION_INVENTORY_SPACE,
                     commit_root_key(commit_id),
                 );
             }

--- a/packages/engine/src/tracked_state/context.rs
+++ b/packages/engine/src/tracked_state/context.rs
@@ -937,8 +937,9 @@ impl TrackedStateContext {
 
     /// Creates an explicit tracked-state commit-root rebuilder.
     ///
-    /// Normal commits stage commit roots directly. This rebuilder reconstructs
-    /// a missing root from changelog facts as an explicit maintenance path.
+    /// Normal rooted commits publish immutable root metadata directly. This
+    /// rebuilder restores the addressed chunks from changelog facts; rootless
+    /// commits are reconstructed only for a transient correctness audit.
     pub(crate) fn root_rebuilder<'a, S>(
         &'a self,
         store: &'a S,
@@ -969,7 +970,7 @@ pub(crate) struct TrackedStateStoreReader<S> {
     /// in one snapshot, so resolving neighbouring observed revisions never
     /// reloads the same changelog records.
     point_replay_commits: HashMap<CommitId, PointReplayCommit>,
-    /// Shares decoded immutable manifests between rootless topology discovery
+    /// Shares decoded immutable manifests between rootless layout discovery
     /// and the later delta scan in this storage snapshot.
     commit_delta_point_cache: storage::CommitDeltaPointReadCache,
 }
@@ -1636,7 +1637,7 @@ where
             }
 
             let current_metadata =
-                storage::load_authoritative_commit_root(&self.store, &current_commit_id).await?;
+                storage::load_snapshot_commit_root(&self.store, &current_commit_id).await?;
             let (parent_commit_id, parent_value, current_is_rootless) = if let Some(metadata) =
                 current_metadata
             {
@@ -1867,7 +1868,11 @@ where
         if let Some(metadata) = cache.commit_root_metadata.get(commit_id) {
             return Ok(metadata.clone());
         }
-        let metadata = storage::load_authoritative_commit_root(&self.store, commit_id)
+        self.load_cached_changelog_first_parent(commit_id, cache)
+            .await?;
+        let typed_commit_id =
+            CommitId::parse_lix(commit_id, "tracked-state required snapshot root lookup")?;
+        let metadata = storage::load_manifest_snapshot_commit_root(&self.store, typed_commit_id)
             .await?
             .ok_or_else(|| missing_commit_root_error(commit_id))?;
         cache
@@ -1884,10 +1889,10 @@ where
         if let Some(root_id) = cache.commit_roots.get(commit_id) {
             return Ok(root_id.clone());
         }
-        let typed_commit_id = CommitId::parse_lix(
-            commit_id,
-            "tracked-state optional authoritative root lookup",
-        )?;
+        let typed_commit_id =
+            CommitId::parse_lix(commit_id, "tracked-state optional snapshot root lookup")?;
+        self.load_cached_changelog_first_parent(commit_id, cache)
+            .await?;
         let manifest = storage::load_commit_state_manifest(&self.store, typed_commit_id)
             .await?
             .ok_or_else(|| {
@@ -1898,7 +1903,10 @@ where
                     ),
                 )
             })?;
-        let root_id = manifest.snapshot_root.map(|root| root.root_id);
+        let root_id = manifest
+            .snapshot_root
+            .as_ref()
+            .map(|root| root.root_id.clone());
         cache
             .commit_roots
             .insert(commit_id.to_string(), root_id.clone());
@@ -1965,9 +1973,7 @@ where
         change_created_at: crate::common::LixTimestamp,
     ) -> Result<(), LixError> {
         let mut expected_created_at = change_created_at;
-        if let Some(metadata) =
-            storage::load_authoritative_commit_root(&self.store, commit_id).await?
-        {
+        if let Some(metadata) = storage::load_snapshot_commit_root(&self.store, commit_id).await? {
             if let Some(parent) = metadata.parent_roots.first() {
                 let parent_value = self
                     .tree
@@ -2074,7 +2080,7 @@ where
     ) -> Result<Option<crate::common::LixTimestamp>, LixError> {
         let row_commit_id = row.commit_id.to_string();
         let Some(metadata) =
-            storage::load_authoritative_commit_root(&self.store, &row_commit_id).await?
+            storage::load_snapshot_commit_root(&self.store, &row_commit_id).await?
         else {
             return Ok(None);
         };
@@ -3467,36 +3473,11 @@ where
                     ),
                 )
             })?;
-        if manifest.generation != record.generation
-            || manifest.parent_commit_ids != record.parent_commit_ids
-            || manifest.commit_change_id != record.change_id
-            || manifest.account_id != record.account_id
-            || manifest.created_at != record.created_at
-        {
-            return Err(LixError::new(
-                LixError::CODE_INTERNAL_ERROR,
-                format!(
-                    "tracked_state commit_state_manifest disagrees with the topology projection for commit '{commit_id}'"
-                ),
-            ));
-        }
+        let rootless = manifest.replay_debt.depth > 0;
         let root_id = manifest
             .snapshot_root
             .as_ref()
             .map(|root| root.root_id.clone());
-        let rootless = manifest.replay_debt.depth > 0;
-        if rootless != record.tracked_state_rootless
-            || manifest.replay_debt.depth != record.tracked_state_rootless_depth
-            || manifest.replay_debt.rows != record.tracked_state_rootless_rows
-            || manifest.replay_debt.bytes != record.tracked_state_rootless_bytes
-        {
-            return Err(LixError::new(
-                LixError::CODE_INTERNAL_ERROR,
-                format!(
-                    "tracked_state commit_state_manifest disagrees with the replay projection for commit '{commit_id}'"
-                ),
-            ));
-        }
         let replacement_generation = if rootless && manifest.mutations.member_count != 0 {
             storage::seed_commit_delta_point_cache_from_replay_manifest(
                 &manifest,
@@ -3507,7 +3488,7 @@ where
             None
         };
         let replay_commit = PointReplayCommit {
-            parent_commit_id: manifest.parent_commit_ids.first().copied(),
+            parent_commit_id: record.parent_commit_ids.first().copied(),
             root_id,
             rootless,
             replacement_generation,
@@ -3766,9 +3747,9 @@ where
                     format!("tracked-state staged root for commit '{commit_id}' is missing"),
                 )
             })?;
-        let mut staged_manifests = Vec::with_capacity(self.staged_roots.len());
+        let mut staged_commit_states = Vec::with_capacity(self.staged_roots.len());
         for metadata in self.staged_roots.values() {
-            let mut manifest = storage::load_commit_state_manifest(self.store, metadata.commit_id)
+            let manifest = storage::load_commit_state_manifest(self.store, metadata.commit_id)
                 .await?
                 .ok_or_else(|| {
                     LixError::new(
@@ -3779,13 +3760,12 @@ where
                         ),
                     )
                 })?;
-            manifest.snapshot_root = Some(metadata.clone());
-            staged_manifests.push(manifest);
+            staged_commit_states.push((manifest, metadata.clone()));
         }
-        let read = storage::TrackedStateStagedRead::with_commit_state_manifests(
+        let read = storage::TrackedStateStagedRead::with_commit_state_roots(
             self.store,
             &self.chunk_overlay,
-            staged_manifests,
+            staged_commit_states,
         )?;
         TrackedStateContext::new()
             .reader(read)
@@ -3834,8 +3814,7 @@ where
                 let metadata = match self.staged_roots.get(parent_commit_id) {
                     Some(metadata) => Some(metadata.clone()),
                     None => {
-                        storage::load_authoritative_commit_root(self.store, parent_commit_id)
-                            .await?
+                        storage::load_snapshot_commit_root(self.store, parent_commit_id).await?
                     }
                 };
                 let Some(metadata) = metadata else {
@@ -4231,7 +4210,7 @@ where
         let parent_metadata = match parent_commit_id {
             Some(parent_commit_id) => Some(match self.staged_roots.get(parent_commit_id) {
                 Some(metadata) => metadata.clone(),
-                None => storage::load_authoritative_commit_root(self.store, parent_commit_id)
+                None => storage::load_snapshot_commit_root(self.store, parent_commit_id)
                     .await?
                     .ok_or_else(|| {
                         LixError::new(
@@ -4471,7 +4450,7 @@ fn missing_commit_root_error(commit_id: &str) -> LixError {
     LixError::new(
         LixError::CODE_INTERNAL_ERROR,
         format!(
-            "tracked_state commit_root is missing for commit '{commit_id}'; run explicit commit_root rebuild before historical reads"
+            "tracked_state rooted commit authority is missing snapshot metadata for commit '{commit_id}'"
         ),
     )
 }
@@ -4963,33 +4942,16 @@ mod tests {
         writes: &mut StorageWriteSet,
         snapshot_root: TrackedStateCommitRoot,
     ) -> Result<(), LixError> {
-        let parent_commit_ids = snapshot_root
-            .parent_roots
-            .iter()
-            .map(|parent| parent.commit_id)
-            .collect::<Vec<_>>();
-        storage::stage_commit_state_manifest(
-            writes,
-            &crate::tracked_state::CommitStateManifest {
-                commit_id: snapshot_root.commit_id,
-                generation: u64::from(!parent_commit_ids.is_empty()),
-                parent_commit_ids,
-                commit_change_id: ChangeId::for_test_label(&format!(
-                    "{}:snapshot-authority",
-                    snapshot_root.commit_id
-                )),
-                account_id: crate::ANONYMOUS_ACCOUNT_ID.to_string(),
-                created_at: crate::common::LixTimestamp::expect_parse(
-                    "snapshot authority created_at",
-                    "1970-01-01T00:00:00.000Z",
-                ),
-                replay_debt: Default::default(),
-                mutations: Default::default(),
-                touched_scope_filter: Default::default(),
-                current_state_scoped_ranges: None,
-                snapshot_root: Some(snapshot_root),
-            },
-        )
+        let manifest = crate::tracked_state::CommitStateManifest {
+            commit_id: snapshot_root.commit_id,
+            change_account_id: crate::ANONYMOUS_ACCOUNT_ID.to_string(),
+            replay_debt: Default::default(),
+            mutations: Default::default(),
+            touched_scope_filter: Default::default(),
+            current_state_scoped_ranges: None,
+            snapshot_root: Some(Box::new(snapshot_root)),
+        };
+        storage::stage_commit_state_manifest(writes, &manifest)
     }
 
     fn change_id(label: &str) -> String {
@@ -5043,6 +5005,53 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn stage_commit_root_rejects_physically_retained_semantically_missing_parent() {
+        let storage = StorageAdapter::new(Memory::new());
+        let tracked_state = TrackedStateContext::new();
+        {
+            let read = storage
+                .begin_read(StorageReadOptions::default())
+                .await
+                .expect("parent read should open");
+            let mut writes = storage.new_write_set();
+            let mut writer = tracked_state.writer(&read, &mut writes);
+            let parent_row = row("entity-parent", "change-parent", "retained-parent");
+            writer
+                .stage_commit_root(
+                    "retained-parent",
+                    None,
+                    [delta_from_materialized_row(&parent_row)],
+                )
+                .await
+                .expect("physical parent root should stage");
+            let parent_root = writer
+                .staged_commit_roots()
+                .find(|root| root.commit_id == CommitId::for_test_label("retained-parent"))
+                .cloned()
+                .expect("physical parent root metadata should stage");
+            drop(writer);
+            stage_snapshot_authority_for_test(&mut writes, parent_root)
+                .expect("physical parent manifest should stage");
+            storage
+                .commit_write_set(writes, StorageWriteOptions::default())
+                .await
+                .expect("physical parent state should commit");
+        }
+
+        let read = storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("child read should open");
+        let mut writes = storage.new_write_set();
+        let mut writer = tracked_state.writer(&read, &mut writes);
+        let error = writer
+            .stage_commit_root("child", Some("retained-parent"), [])
+            .await
+            .expect_err("physical retention must not authorize a missing semantic parent");
+        assert!(error.message.contains("parent root"), "{error:?}");
+    }
+
+    #[tokio::test]
     async fn stage_commit_root_writes_commit_root_metadata() {
         let storage = StorageAdapter::new(Memory::new());
         let tracked_state = TrackedStateContext::new();
@@ -5080,7 +5089,7 @@ mod tests {
             .await
             .expect("child root should load")
             .expect("child root should exist");
-        let metadata = storage::load_authoritative_commit_root(&read, "child")
+        let metadata = storage::load_snapshot_commit_root(&read, "child")
             .await
             .expect("metadata should load")
             .expect("metadata should exist");
@@ -5766,34 +5775,15 @@ mod tests {
         };
         assert_eq!(report.changed_rows, child_rows.len());
 
-        {
-            let read = generic_storage
-                .begin_read(StorageReadOptions::default())
-                .await
-                .expect("generic parent read should open");
-            let mut writes = generic_storage.new_write_set();
-            let mut writer = tracked_state.writer(&read, &mut writes);
-            writer
-                .stage_commit_root(
-                    &parent_commit_id,
-                    None,
-                    parent_rows.iter().map(delta_from_materialized_row),
-                )
-                .await
-                .expect("generic parent root should stage");
-            let parent_root = writer
-                .staged_commit_roots()
-                .find(|root| root.commit_id == parent_commit_id)
-                .cloned()
-                .expect("generic parent metadata should stage");
-            drop(writer);
-            stage_snapshot_authority_for_test(&mut writes, parent_root)
-                .expect("generic parent authority should stage");
-            generic_storage
-                .commit_write_set(writes, StorageWriteOptions::default())
-                .await
-                .expect("generic parent root should commit");
-        }
+        write_root_for_test(
+            &generic_storage,
+            &tracked_state,
+            &parent_commit_id,
+            None,
+            &parent_rows,
+        )
+        .await
+        .expect("generic parent commit and root should write");
         {
             let read = generic_storage
                 .begin_read(StorageReadOptions::default())
@@ -5827,18 +5817,26 @@ mod tests {
             .begin_read(StorageReadOptions::default())
             .await
             .expect("bulk result read should open");
-        let bulk_root = storage::load_root(&bulk_read, &child_commit_id)
-            .await
-            .expect("bulk root should load")
-            .expect("bulk child root should exist");
+        let bulk_root = storage::load_manifest_snapshot_commit_root(
+            &bulk_read,
+            CommitId::parse_lix(&child_commit_id, "bulk child fixture").expect("test commit id"),
+        )
+        .await
+        .expect("bulk root should load")
+        .expect("bulk child root should exist")
+        .root_id;
         let generic_read = generic_storage
             .begin_read(StorageReadOptions::default())
             .await
             .expect("generic result read should open");
-        let generic_root = storage::load_root(&generic_read, &child_commit_id)
-            .await
-            .expect("generic root should load")
-            .expect("generic child root should exist");
+        let generic_root = storage::load_manifest_snapshot_commit_root(
+            &generic_read,
+            CommitId::parse_lix(&child_commit_id, "generic child fixture").expect("test commit id"),
+        )
+        .await
+        .expect("generic root should load")
+        .expect("generic child root should exist")
+        .root_id;
         assert_eq!(bulk_root, generic_root, "dense merge must be canonical");
 
         let entry = TrackedStateTree::new()
@@ -6456,7 +6454,7 @@ mod tests {
             .begin_read(StorageReadOptions::default())
             .await
             .expect("read should open");
-        let parent_metadata = storage::load_authoritative_commit_root(&read, "parent")
+        let parent_metadata = storage::load_snapshot_commit_root(&read, "parent")
             .await
             .expect("parent metadata should load")
             .expect("parent metadata should exist");
@@ -6487,10 +6485,13 @@ mod tests {
             .begin_read(StorageReadOptions::default())
             .await
             .expect("read should reopen");
-        let child_metadata = storage::load_authoritative_commit_root(&read, "empty-child")
-            .await
-            .expect("child metadata should load")
-            .expect("child metadata should exist");
+        let child_metadata = storage::load_manifest_snapshot_commit_root(
+            &read,
+            CommitId::for_test_label("empty-child"),
+        )
+        .await
+        .expect("child metadata should load")
+        .expect("child metadata should exist");
 
         assert_eq!(child_metadata.root_id, parent_metadata.root_id);
         assert_eq!(child_metadata.changed_key_count, 0);
@@ -6809,10 +6810,6 @@ mod tests {
                     storage::TRACKED_STATE_COMMIT_STATE_MANIFEST_SPACE,
                     commit_root_key(commit_id),
                 );
-                writes.delete(
-                    storage::TRACKED_STATE_COMMIT_STATE_SEAL_SPACE,
-                    commit_root_key(commit_id),
-                );
             }
             storage
                 .commit_write_set(writes, StorageWriteOptions::default())
@@ -6873,39 +6870,35 @@ mod tests {
             let mut writes = storage.new_write_set();
             let commit_a = CommitId::for_test_label("commit-a");
             let commit_b = CommitId::for_test_label("commit-b");
-            let mut manifest = storage::load_commit_state_manifest(&read, commit_a)
+            let published = storage::load_published_commit_state_manifest(&read, commit_a)
                 .await
                 .expect("commit-a authority should load")
                 .expect("commit-a authority should exist");
-            manifest.generation = 2;
-            manifest.parent_commit_ids = vec![commit_b];
-            manifest
-                .snapshot_root
-                .as_mut()
-                .expect("commit-a should have a snapshot root")
-                .parent_roots = vec![TrackedStateCommitRootParent {
+            let mut snapshot_root = storage::load_snapshot_commit_root(&read, "commit-a")
+                .await
+                .expect("commit-a root should load")
+                .expect("commit-a root should exist");
+            snapshot_root.parent_roots = vec![TrackedStateCommitRootParent {
                 commit_id: commit_b,
                 root_id: storage::load_root(&read, "commit-b")
                     .await
                     .expect("commit-b root should load")
                     .expect("commit-b root should exist"),
             }];
-            storage::stage_resealed_commit_state_manifest_for_test(&mut writes, &manifest)
-                .expect("corrupt cycle authority should stage");
+            let mut corrupt = (*published).clone();
+            corrupt.snapshot_root = Some(Box::new(snapshot_root));
+            storage::stage_resealed_commit_state_manifest_for_test(&mut writes, &corrupt)
+                .expect("corrupt cycle root should stage");
             writes.put(
                 crate::changelog::COMMIT_SPACE,
                 crate::storage_adapter::StorageKey(Bytes::copy_from_slice(
                     commit_a.as_uuid().as_bytes(),
                 )),
                 crate::changelog::encode_commit_record(&CommitRecord {
-                    format_version: 1,
+                    format_version: 2,
                     commit_id: commit_a,
-                    generation: manifest.generation,
+                    generation: 2,
                     parent_commit_ids: vec![commit_b],
-                    tracked_state_rootless: false,
-                    tracked_state_rootless_depth: 0,
-                    tracked_state_rootless_rows: 0,
-                    tracked_state_rootless_bytes: 0,
                     change_id: ChangeId::for_test_label("commit-a:commit"),
                     account_id: crate::ANONYMOUS_ACCOUNT_ID.to_string(),
                     created_at: crate::common::LixTimestamp::expect_parse(
@@ -7072,7 +7065,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn explicit_rebuild_repairs_stale_root_missing_inherited_row() {
+    async fn explicit_rebuild_rejects_stale_immutable_root_missing_inherited_row() {
         let storage = StorageAdapter::new(Memory::new());
         let tracked_state = TrackedStateContext::new();
         let inherited = row_with_value("entity-a", "change-base", "base", "base");
@@ -7102,49 +7095,15 @@ mod tests {
             .await
             .expect("read should open");
         let mut writes = storage.new_write_set();
-        tracked_state
+        let error = tracked_state
             .root_rebuilder(&read, &mut writes)
             .rebuild_commit_root_at("child")
             .await
-            .expect("stale child root should repair");
-        storage
-            .commit_write_set(writes, StorageWriteOptions::default())
-            .await
-            .expect("repaired root should commit");
-
-        let authority_read = storage
-            .begin_read(StorageReadOptions::default())
-            .await
-            .expect("authority read should open");
-        let repaired_authority =
-            storage::load_commit_state_manifest(&authority_read, CommitId::for_test_label("child"))
-                .await
-                .expect("repaired authority should load")
-                .expect("child authority should exist");
-        let repaired_root = storage::load_authoritative_commit_root(&authority_read, "child")
-            .await
-            .expect("repaired root should load")
-            .expect("repaired root should exist");
-        assert_eq!(repaired_authority.snapshot_root, Some(repaired_root));
-        assert_eq!(repaired_authority.replay_debt, Default::default());
-        drop(authority_read);
-
-        let rows = tracked_state
-            .reader(
-                storage
-                    .begin_read(StorageReadOptions::default())
-                    .await
-                    .expect("read should open"),
-            )
-            .scan_batch_at_commit("child", &test_schema_scan_request())
-            .await
-            .expect("repaired child root should scan")
-            .into_rows();
-        assert_eq!(
-            rows.iter()
-                .map(|row| row.change_id.to_string())
-                .collect::<Vec<_>>(),
-            vec![change_id("change-base"), change_id("change-child")]
+            .expect_err("rebuild must not rewrite stale immutable root authority");
+        assert!(
+            error
+                .message
+                .contains("disagrees with immutable commit authority")
         );
     }
 
@@ -7687,26 +7646,24 @@ mod tests {
         .await
         .expect("root should write");
 
-        // Violate the GC contract: delete the owning packed commit delta while
-        // a live tree row still references its change id.
+        // Corrupt immutable authority so its snapshot still exposes the live
+        // row while its canonical mutation inventory no longer owns the
+        // referenced change id.
         let commit_id = CommitId::for_test_label("commit-1");
         let read = storage
             .begin_read(StorageReadOptions::default())
             .await
-            .expect("inventory read should open");
-        let inventory = storage::scan_commit_delta_inventory(&read)
+            .expect("authority read should open");
+        let published = storage::load_commit_state_manifest(&read, commit_id)
             .await
-            .expect("packed inventory should load");
+            .expect("authority should load")
+            .expect("authority should exist");
+        let mut corrupt = published.clone();
+        corrupt.mutations = Default::default();
+        drop(read);
         let mut writes = storage.new_write_set();
-        storage::stage_delete_commit_delta_inventory_entry(
-            &mut writes,
-            commit_id,
-            inventory
-                .commits
-                .get(&commit_id)
-                .expect("fixture commit should have packed authority"),
-        )
-        .expect("packed authority deletion should stage");
+        storage::stage_resealed_commit_state_manifest_for_test(&mut writes, &corrupt)
+            .expect("corrupt authority should stage");
         storage
             .commit_write_set(writes, StorageWriteOptions::default())
             .await
@@ -7723,7 +7680,7 @@ mod tests {
             .await
             .expect_err("materialization must reject missing packed authority");
         assert!(
-            error.message.contains("commit_state_manifest is missing"),
+            error.message.contains("missing from owning commit"),
             "unexpected error: {error}"
         );
     }
@@ -8091,6 +8048,49 @@ mod tests {
             .commit_write_set(writes, StorageWriteOptions::default())
             .await
             .expect("rootless commit should commit");
+    }
+
+    #[tokio::test]
+    async fn explicit_rebuild_audits_rootless_commit_without_publishing_unreachable_chunks() {
+        let storage = StorageAdapter::new(Memory::new());
+        let tracked_state = TrackedStateContext::new();
+        write_root_for_test(
+            &storage,
+            &tracked_state,
+            "base",
+            None,
+            &[row_with_value("entity-a", "base-a", "base", "base")],
+        )
+        .await
+        .expect("base root should write");
+        write_rootless_commit_for_test(
+            &storage,
+            "rootless",
+            "base",
+            &[row_with_value(
+                "entity-a",
+                "rootless-a",
+                "rootless",
+                "updated",
+            )],
+        )
+        .await;
+
+        let read = storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("rebuild read should open");
+        let mut writes = storage.new_write_set();
+        let report = tracked_state
+            .root_rebuilder(&read, &mut writes)
+            .rebuild_commit_root_at("rootless")
+            .await
+            .expect("rootless state should pass transient rebuild audit");
+
+        assert_eq!(report.commit_id, CommitId::for_test_label("rootless"));
+        assert_eq!(writes.stats().staged_puts, 0);
+        assert_eq!(writes.stats().staged_deletes, 0);
+        assert_eq!(writes.stats().written_bytes, 0);
     }
 
     #[tokio::test]
@@ -9070,12 +9070,15 @@ mod tests {
             .await
             .expect("commit-state authority should load")
             .expect("root fixture should publish commit-state authority");
-        stale_root.parent_roots = published
-            .snapshot_root
-            .as_ref()
-            .map(|root| root.parent_roots.clone())
-            .unwrap_or_default();
-        storage::stage_commit_state_snapshot_root_update(&mut writes, &published, Some(stale_root))
+        stale_root.parent_roots =
+            storage::load_snapshot_commit_root(&read, &typed_commit_id.to_string())
+                .await
+                .expect("published root should load")
+                .map(|root| root.parent_roots)
+                .unwrap_or_default();
+        let mut stale = (*published).clone();
+        stale.snapshot_root = Some(Box::new(stale_root));
+        storage::stage_resealed_commit_state_manifest_for_test(&mut writes, &stale)
             .expect("stale authority should encode");
         storage
             .commit_write_set(writes, StorageWriteOptions::default())

--- a/packages/engine/src/tracked_state/context.rs
+++ b/packages/engine/src/tracked_state/context.rs
@@ -1923,9 +1923,7 @@ where
         }
         self.load_cached_changelog_first_parent(commit_id, cache)
             .await?;
-        let typed_commit_id =
-            CommitId::parse_lix(commit_id, "tracked-state required snapshot root lookup")?;
-        let metadata = storage::load_manifest_snapshot_commit_root(&self.store, typed_commit_id)
+        let metadata = storage::load_snapshot_commit_root(&self.store, commit_id)
             .await?
             .ok_or_else(|| missing_commit_root_error(commit_id))?;
         cache
@@ -1942,21 +1940,11 @@ where
         if let Some(root_id) = cache.commit_roots.get(commit_id) {
             return Ok(root_id.clone());
         }
-        let typed_commit_id =
-            CommitId::parse_lix(commit_id, "tracked-state optional snapshot root lookup")?;
         self.load_cached_changelog_first_parent(commit_id, cache)
             .await?;
-        let topology = storage::load_published_commit_state_topology(&self.store, typed_commit_id)
+        let root_id = storage::load_snapshot_commit_root(&self.store, commit_id)
             .await?
-            .ok_or_else(|| {
-                LixError::new(
-                    LixError::CODE_INTERNAL_ERROR,
-                    format!(
-                        "tracked_state commit_state_manifest is missing for commit '{commit_id}'"
-                    ),
-                )
-            })?;
-        let root_id = topology.snapshot_root_id();
+            .map(|root| root.root_id);
         cache
             .commit_roots
             .insert(commit_id.to_string(), root_id.clone());

--- a/packages/engine/src/tracked_state/context.rs
+++ b/packages/engine/src/tracked_state/context.rs
@@ -1514,6 +1514,38 @@ where
         )
     }
 
+    async fn load_commit_delta_values_for_encoded_queries(
+        &self,
+        state: &storage::AuthenticatedReplayCommitStateManifest,
+        encoded_keys: Vec<Bytes>,
+    ) -> Result<Vec<Option<TrackedStateIndexValue>>, LixError> {
+        let request_count = encoded_keys.len();
+        let mut ordered = encoded_keys.into_iter().enumerate().collect::<Vec<_>>();
+        ordered.sort_unstable_by(|left, right| left.1.cmp(&right.1));
+        let mut canonical = Vec::with_capacity(ordered.len());
+        let mut canonical_ordinal_by_request = vec![0usize; request_count];
+        for (request_index, encoded_key) in ordered {
+            if canonical
+                .last()
+                .is_none_or(|previous: &Bytes| previous != &encoded_key)
+            {
+                canonical.push(encoded_key);
+            }
+            canonical_ordinal_by_request[request_index] = canonical.len() - 1;
+        }
+        let values = storage::load_commit_delta_values_encoded_from_replay_manifest(
+            &self.store,
+            state,
+            &canonical,
+            &self.commit_delta_point_cache,
+        )
+        .await?;
+        Ok(canonical_ordinal_by_request
+            .into_iter()
+            .map(|ordinal| values[ordinal].clone())
+            .collect())
+    }
+
     async fn validate_tree_diff_batch_against_delta_index(
         &self,
         batch: &TrackedStateTreeDiffBatch,
@@ -1524,6 +1556,7 @@ where
             by_commit.entry(row.commit_id()).or_default().push(row);
         }
         for (commit_id, commit_rows) in by_commit {
+            let state = storage::load_point_replay_commit_state(&self.store, commit_id).await?;
             let mut encoded_keys =
                 TrackedStateKeyBatchBuilder::with_row_capacity(commit_rows.len());
             for row in &commit_rows {
@@ -1533,13 +1566,13 @@ where
                     entity_pk: row.entity_pk(),
                 });
             }
-            let loaded = storage::load_commit_delta_values_encoded_with_cache(
-                &self.store,
-                commit_id,
-                &encoded_keys.finish(),
-                Some(&self.commit_delta_point_cache),
-            )
-            .await?;
+            let loaded = match state.as_ref() {
+                Some(state) => {
+                    self.load_commit_delta_values_for_encoded_queries(state, encoded_keys.finish())
+                        .await?
+                }
+                None => vec![None; commit_rows.len()],
+            };
             let mut fallback_rows = Vec::new();
             let mut fallback_keys =
                 TrackedStateKeyBatchBuilder::with_row_capacity(commit_rows.len());
@@ -1557,13 +1590,13 @@ where
                     fallback_rows.push(index);
                 }
             }
-            let fallback_values = storage::load_commit_delta_values_encoded_with_cache(
-                &self.store,
-                commit_id,
-                &fallback_keys.finish(),
-                Some(&self.commit_delta_point_cache),
-            )
-            .await?;
+            let fallback_values = match state.as_ref() {
+                Some(state) => {
+                    self.load_commit_delta_values_for_encoded_queries(state, fallback_keys.finish())
+                        .await?
+                }
+                None => vec![None; fallback_rows.len()],
+            };
             let mut fallbacks = vec![None; commit_rows.len()];
             for (index, value) in fallback_rows.into_iter().zip(fallback_values) {
                 fallbacks[index] = value;
@@ -3193,6 +3226,28 @@ where
             key_file_id_ordinals.push(file_id_ordinal);
         }
         let file_ids = file_id_dictionary.into_file_ids();
+        let mut file_id_order = (0..file_ids.len()).collect::<Vec<_>>();
+        file_id_order.sort_unstable_by(|left, right| {
+            file_ids[*left].as_str().cmp(file_ids[*right].as_str())
+        });
+        let mut canonical_ordinal_by_original = vec![0u32; file_ids.len()];
+        let mut canonical_file_ids = Vec::with_capacity(file_ids.len());
+        for original_ordinal in file_id_order {
+            canonical_ordinal_by_original[original_ordinal] =
+                u32::try_from(canonical_file_ids.len()).map_err(|_| {
+                    LixError::new(
+                        LixError::CODE_INTERNAL_ERROR,
+                        "tracked-state batch replay file dictionary exceeds u32",
+                    )
+                })?;
+            canonical_file_ids.push(file_ids[original_ordinal].clone());
+        }
+        for ordinal in &mut key_file_id_ordinals {
+            if *ordinal != u32::MAX {
+                *ordinal = canonical_ordinal_by_original[*ordinal as usize];
+            }
+        }
+        let file_ids = canonical_file_ids;
 
         // Encode each file descriptor key once for the whole replay. Every
         // commit selects shared slices from this arena instead of rebuilding
@@ -3225,18 +3280,18 @@ where
         let mut cascades = vec![None; file_ids.len()];
         for &current_commit_id in interval.commits().iter().rev() {
             let replay_commit = self.load_point_replay_commit(current_commit_id).await?;
-            let deltas = storage::load_commit_delta_values_encoded_with_cache(
+            let deltas = storage::load_commit_delta_values_encoded_from_replay_manifest(
                 &self.store,
-                current_commit_id,
+                &replay_commit.state_manifest,
                 keys,
-                Some(&self.commit_delta_point_cache),
+                &self.commit_delta_point_cache,
             )
             .await?;
-            let descriptor_deltas = storage::load_commit_delta_values_encoded_with_cache(
+            let descriptor_deltas = storage::load_commit_delta_values_encoded_from_replay_manifest(
                 &self.store,
-                current_commit_id,
+                &replay_commit.state_manifest,
                 &descriptor_keys,
-                Some(&self.commit_delta_point_cache),
+                &self.commit_delta_point_cache,
             )
             .await?;
             for (file_id_ordinal, value) in descriptor_deltas.into_iter().enumerate() {
@@ -3541,17 +3596,22 @@ where
         if missing.is_empty() {
             return Ok(output);
         }
-        let missing_keys = missing
-            .iter()
-            .map(|(_, key)| key.clone())
-            .collect::<Vec<_>>();
-        let mut encoded_keys = TrackedStateKeyBatchBuilder::with_row_capacity(missing_keys.len());
-        for key in &missing_keys {
-            encoded_keys.push(TrackedStateKeyRef {
-                schema_key: &key.schema_key,
-                file_id: key.file_id.as_deref(),
-                entity_pk: &key.entity_pk,
-            });
+        missing.sort_unstable_by(|left, right| left.1.cmp(&right.1));
+        let mut encoded_keys = TrackedStateKeyBatchBuilder::with_row_capacity(missing.len());
+        let mut query_ordinals = Vec::with_capacity(missing.len());
+        let mut previous_key = None::<&TrackedStateKey>;
+        let mut unique_key_count = 0usize;
+        for (_, key) in &missing {
+            if previous_key != Some(key) {
+                encoded_keys.push(TrackedStateKeyRef {
+                    schema_key: &key.schema_key,
+                    file_id: key.file_id.as_deref(),
+                    entity_pk: &key.entity_pk,
+                });
+                previous_key = Some(key);
+                unique_key_count += 1;
+            }
+            query_ordinals.push(unique_key_count - 1);
         }
         let replay_commit = self.load_point_replay_commit(commit_id).await?;
         let values = storage::load_commit_delta_values_encoded_from_replay_manifest(
@@ -3561,7 +3621,8 @@ where
             &self.commit_delta_point_cache,
         )
         .await?;
-        for ((index, key), value) in missing.into_iter().zip(values) {
+        for ((index, key), query_ordinal) in missing.into_iter().zip(query_ordinals) {
+            let value = values[query_ordinal].clone();
             self.commit_delta_value_cache
                 .insert((commit_id, key), value.clone());
             output[index] = value;
@@ -3579,11 +3640,24 @@ where
         commit_id: CommitId,
         schema_keys: &[String],
     ) -> Result<storage::DecodedCommitDeltaBatch, LixError> {
-        storage::scan_commit_delta_values_with_cache(
+        let replay_commit = self.load_point_replay_commit(commit_id).await?;
+        let source_manifest = match replay_commit
+            .state_manifest
+            .mutations
+            .selected_source_commit_id()
+        {
+            Some(source_commit_id) => Some(
+                self.load_point_replay_commit(source_commit_id)
+                    .await?
+                    .state_manifest,
+            ),
+            None => None,
+        };
+        storage::scan_commit_delta_values_from_authenticated_states(
             &self.store,
-            commit_id,
+            &replay_commit.state_manifest,
+            source_manifest.as_deref(),
             schema_keys,
-            Some(&self.commit_delta_point_cache),
         )
         .await
     }

--- a/packages/engine/src/tracked_state/current_state_data_part.rs
+++ b/packages/engine/src/tracked_state/current_state_data_part.rs
@@ -145,6 +145,7 @@ pub(crate) fn encode_current_state_data_part(
     })
 }
 
+#[cfg(test)]
 pub(crate) fn decode_current_state_data_part_refs(
     expected_digest: &[u8; 32],
     encoded: &[u8],

--- a/packages/engine/src/tracked_state/diff.rs
+++ b/packages/engine/src/tracked_state/diff.rs
@@ -1239,21 +1239,20 @@ mod tests {
         writes: &mut StorageWriteSet,
         snapshot_root: &TrackedStateCommitRoot,
     ) -> Result<(), LixError> {
-        let mut manifest =
-            crate::tracked_state::storage::load_unchecked_commit_state_manifest_for_test(
-                read,
-                snapshot_root.commit_id,
+        let manifest = crate::tracked_state::storage::load_published_commit_state_manifest(
+            read,
+            snapshot_root.commit_id,
+        )
+        .await?
+        .ok_or_else(|| {
+            LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                "corrupt-root fixture has no commit-state manifest",
             )
-            .await?
-            .ok_or_else(|| {
-                LixError::new(
-                    LixError::CODE_INTERNAL_ERROR,
-                    "corrupt-root fixture has no commit-state manifest",
-                )
-            })?;
-        manifest.snapshot_root = Some(snapshot_root.clone());
-        manifest.replay_debt = Default::default();
-        crate::tracked_state::storage::stage_unchecked_commit_state_manifest_for_test(
+        })?;
+        let mut manifest = (*manifest).clone();
+        manifest.snapshot_root = Some(Box::new(snapshot_root.clone()));
+        crate::tracked_state::storage::stage_resealed_commit_state_manifest_for_test(
             writes, &manifest,
         )
     }
@@ -3445,6 +3444,8 @@ mod tests {
                 .contains("does not match changelog first-parent winners")
             || error.message.contains("contains non-winner identity")
             || error.message.contains("but changelog first parent is")
+            || error.message.contains("but its first parent is")
+            || error.message.contains("more than one first-parent root")
             || error
                 .message
                 .contains("nearest available first-parent root")

--- a/packages/engine/src/tracked_state/mod.rs
+++ b/packages/engine/src/tracked_state/mod.rs
@@ -24,9 +24,10 @@ pub(crate) use commit_root_rebuild::{
 pub(crate) use context::{
     TrackedStateContext, TrackedStateStoreReader, descriptor_dependency_cascade_file_ids,
 };
+#[cfg(test)]
+pub(crate) use current_state_data_part::decode_current_state_data_part_refs;
 pub(crate) use current_state_data_part::{
     CURRENT_STATE_DATA_PART_REFS_SPACE, CURRENT_STATE_DATA_PART_SPACE,
-    decode_current_state_data_part_refs,
 };
 pub(crate) use current_state_envelope::current_state_descriptor_from_scoped_range_part;
 pub(crate) use diff::{
@@ -75,12 +76,10 @@ pub(crate) use storage::{
     stage_current_state_scoped_ranges_from_published_parent,
     stage_current_state_scoped_ranges_from_published_topology_parent,
     stage_current_state_scoped_ranges_from_staged_parent,
-    stage_current_state_scoped_ranges_from_topology, stage_delete_change_locators,
-    stage_delete_commit_delta_inventory_entry, stage_delete_commit_state_manifest_for_gc,
+    stage_current_state_scoped_ranges_from_topology, stage_delete_commit_state_manifest_for_gc,
     stage_ordered_addressable_commit_deltas, stage_ordered_addressable_replacement_parts,
     stage_ordered_columnar_mutations, stage_preencoded_ordered_addressable_replacement_parts,
     stage_prefixed_ordered_addressable_replacement_parts,
-    validate_current_state_scoped_range_serving_base_manifest,
 };
 #[cfg(feature = "storage-benches")]
 pub(crate) use storage::{
@@ -97,6 +96,11 @@ pub(crate) use storage::{
     change_id_from_packed_address, load_commit_delta_change_ids,
     load_complete_current_state_values_from_scoped_root, load_snapshot_commit_root,
     scan_commit_delta_members, stage_resealed_commit_state_manifest_for_test,
+};
+#[cfg(test)]
+pub(crate) use storage::{
+    stage_delete_change_locators, stage_delete_commit_delta_inventory_entry,
+    validate_current_state_scoped_range_serving_base_manifest,
 };
 #[cfg(test)]
 pub(crate) use types::TrackedStateRootId;

--- a/packages/engine/src/tracked_state/mod.rs
+++ b/packages/engine/src/tracked_state/mod.rs
@@ -76,9 +76,9 @@ pub(crate) use storage::{
     stage_current_state_scoped_ranges_from_published_topology_parent,
     stage_current_state_scoped_ranges_from_staged_parent,
     stage_current_state_scoped_ranges_from_topology, stage_delete_change_locators,
-    stage_delete_commit_delta_inventory_entry, stage_ordered_addressable_commit_deltas,
-    stage_ordered_addressable_replacement_parts, stage_ordered_columnar_mutations,
-    stage_preencoded_ordered_addressable_replacement_parts,
+    stage_delete_commit_delta_inventory_entry, stage_delete_commit_state_manifest_for_gc,
+    stage_ordered_addressable_commit_deltas, stage_ordered_addressable_replacement_parts,
+    stage_ordered_columnar_mutations, stage_preencoded_ordered_addressable_replacement_parts,
     stage_prefixed_ordered_addressable_replacement_parts,
     validate_current_state_scoped_range_serving_base_manifest,
 };

--- a/packages/engine/src/tracked_state/mod.rs
+++ b/packages/engine/src/tracked_state/mod.rs
@@ -8,6 +8,7 @@ pub(crate) mod current_state_envelope;
 mod diff;
 mod diff_id;
 mod merge;
+pub(crate) mod mutation_directory;
 pub(crate) mod replacement_part;
 mod row_materialization;
 mod scoped_current_state;
@@ -37,6 +38,9 @@ pub(crate) use merge::{
     TrackedStateMergeConflict, TrackedStateMergePick, TrackedStateMergePlan,
     merge_payload_fallback_ids, plan_merge,
 };
+pub(crate) use mutation_directory::{
+    MUTATION_DIRECTORY_NODE_SPACE, collect_mutation_directory_node_ids,
+};
 pub(crate) use replacement_part::{
     EncodedReplacementPart, REPLACEMENT_PART_MAX_ROWS, REPLACEMENT_PART_TARGET_BYTES,
     ReplacementPartRowRef, encode_replacement_part_with_compressor,
@@ -55,19 +59,21 @@ pub(crate) use storage::stage_commit_state_manifest;
 pub(crate) use storage::{
     CertifiedCommitStateTopologyParent, CommitDeltaChangeLocator, CommitDeltaLiveMembershipCursor,
     CommitDeltaMember, CommitDeltaPointReadCache, CommitDeltaReplacementGeneration,
-    CommitDeltaReplacementScope, OrderedAddressableCommitDeltaStage, PublishedCommitStateManifest,
+    CommitDeltaReplacementScope, OrderedAddressableCommitDeltaStage, PublishedCommitStateTopology,
     StagedCommitStateManifest, commit_delta_contains_schema, direct_change_locator,
     load_change_record_by_id, load_commit_delta_change_records,
     load_commit_delta_members_with_payloads, load_commit_delta_members_with_payloads_for_schemas,
     load_commit_delta_replay_metadata, load_commit_delta_selection_certificate,
+    load_commit_mutation_directory_roots, load_commit_state_authority_ids,
     load_commit_state_manifest, load_commit_state_manifests, load_owned_commit_delta_entries,
-    load_owned_commit_delta_entries_one_ordered_ref, load_published_commit_state_manifest,
+    load_owned_commit_delta_entries_one_ordered_ref, load_published_commit_state_topology,
     scan_change_records_from_commit_deltas, scan_commit_delta_inventory, scan_commit_delta_values,
     selected_change_selection_fingerprint, stage_addressable_commit_deltas,
     stage_addressable_commit_deltas_with_selected_source,
     stage_certified_commit_state_manifest_with_handle, stage_change_locators,
     stage_commit_deltas_for_commit_state, stage_commit_state_manifest_with_handle,
     stage_current_state_scoped_ranges_from_published_parent,
+    stage_current_state_scoped_ranges_from_published_topology_parent,
     stage_current_state_scoped_ranges_from_staged_parent,
     stage_current_state_scoped_ranges_from_topology, stage_delete_change_locators,
     stage_delete_commit_delta_inventory_entry, stage_ordered_addressable_commit_deltas,
@@ -79,8 +85,8 @@ pub(crate) use storage::{
 #[cfg(feature = "storage-benches")]
 pub(crate) use storage::{
     TRACKED_STATE_CHANGE_LOCATOR_SPACE, TRACKED_STATE_COMMIT_DELTA_SEGMENT_SPACE,
-    TRACKED_STATE_COMMIT_STATE_MANIFEST_SPACE, TRACKED_STATE_TREE_CHUNK_SPACE,
-    decode_change_locator,
+    TRACKED_STATE_COMMIT_MUTATION_INVENTORY_SPACE, TRACKED_STATE_COMMIT_STATE_MANIFEST_SPACE,
+    TRACKED_STATE_TREE_CHUNK_SPACE, decode_change_locator,
 };
 #[cfg(all(test, not(feature = "storage-benches")))]
 pub(crate) use storage::{

--- a/packages/engine/src/tracked_state/mod.rs
+++ b/packages/engine/src/tracked_state/mod.rs
@@ -64,7 +64,7 @@ pub(crate) use storage::{
     load_owned_commit_delta_entries_one_ordered_ref, load_published_commit_state_manifest,
     scan_change_records_from_commit_deltas, scan_commit_delta_inventory, scan_commit_delta_values,
     selected_change_selection_fingerprint, stage_addressable_commit_deltas,
-    stage_addressable_commit_deltas_with_selected_source, stage_certified_commit_state_manifest,
+    stage_addressable_commit_deltas_with_selected_source,
     stage_certified_commit_state_manifest_with_handle, stage_change_locators,
     stage_commit_deltas_for_commit_state, stage_commit_state_manifest_with_handle,
     stage_current_state_scoped_ranges_from_published_parent,
@@ -88,11 +88,12 @@ pub(crate) use storage::{
 };
 #[cfg(test)]
 pub(crate) use storage::{
-    TRACKED_STATE_COMMIT_STATE_SEAL_SPACE, change_id_from_packed_address,
-    load_authoritative_commit_root, load_commit_delta_change_ids,
-    load_complete_current_state_values_from_scoped_root, scan_commit_delta_members,
-    stage_resealed_commit_state_manifest_for_test,
+    change_id_from_packed_address, load_commit_delta_change_ids,
+    load_complete_current_state_values_from_scoped_root, load_snapshot_commit_root,
+    scan_commit_delta_members, stage_resealed_commit_state_manifest_for_test,
 };
+#[cfg(test)]
+pub(crate) use types::TrackedStateRootId;
 pub(crate) use types::{COMMIT_STATE_MAX_REPLAY_BYTES, COMMIT_STATE_MAX_REPLAY_DEPTH};
 pub(crate) use types::{
     ColumnarMutationPartSet, CommitDeltaLifecycleSummary, CommitStateManifest,

--- a/packages/engine/src/tracked_state/mutation_directory.rs
+++ b/packages/engine/src/tracked_state/mutation_directory.rs
@@ -96,6 +96,45 @@ mod read_accounting {
     }
 }
 
+// The process-wide counters above are useful for benchmark phases, but their
+// absolute values are intentionally not suitable for assertions in a
+// parallel test suite.  Keep a task-local test observer for the narrow
+// per-invocation properties that must not be contaminated by other tests.
+#[cfg(test)]
+pub(crate) mod test_read_accounting {
+    use std::cell::RefCell;
+    use std::future::Future;
+    use std::rc::Rc;
+
+    #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+    pub(crate) struct ScopedMutationDirectoryReadAccounting {
+        pub(crate) selector_all_roots: u64,
+    }
+
+    tokio::task_local! {
+        static ACTIVE: Rc<RefCell<ScopedMutationDirectoryReadAccounting>>;
+    }
+
+    pub(crate) async fn scope<F>(future: F) -> (F::Output, ScopedMutationDirectoryReadAccounting)
+    where
+        F: Future,
+    {
+        let state = Rc::new(RefCell::new(
+            ScopedMutationDirectoryReadAccounting::default(),
+        ));
+        let output = ACTIVE.scope(state.clone(), future).await;
+        let accounting = *state.borrow();
+        (output, accounting)
+    }
+
+    pub(crate) fn record_selector_all_roots(roots: usize) {
+        let _ = ACTIVE.try_with(|state| {
+            let mut state = state.borrow_mut();
+            state.selector_all_roots = state.selector_all_roots.saturating_add(roots as u64);
+        });
+    }
+}
+
 #[cfg(any(test, feature = "storage-benches"))]
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub struct MutationDirectoryReadAccounting {
@@ -376,6 +415,8 @@ pub(crate) enum MutationDirectoryFullTraversalContext {
 #[cfg(any(test, feature = "storage-benches"))]
 fn record_full_traversal(context: MutationDirectoryFullTraversalContext, roots: usize) {
     use read_accounting as counters;
+    #[cfg(test)]
+    test_read_accounting::record_selector_all_roots(roots);
     counters::add(counters::SELECTOR_ALL_ROOTS, roots);
     let counter = match context {
         MutationDirectoryFullTraversalContext::BulkCommitStateManifests => {

--- a/packages/engine/src/tracked_state/mutation_directory.rs
+++ b/packages/engine/src/tracked_state/mutation_directory.rs
@@ -5,7 +5,8 @@
 //! direct-address row counts live only in leaves. Metadata-only operations can
 //! therefore stop at the header while point routing reads one node per level.
 
-use std::collections::{BTreeMap, BTreeSet};
+use std::collections::{BTreeMap, BTreeSet, HashMap};
+use std::ops::Range;
 
 use bytes::Bytes;
 
@@ -72,6 +73,7 @@ impl MutationDirectoryEntry {
         }
     }
 
+    #[cfg(test)]
     fn first_key(&self) -> &[u8] {
         match self {
             Self::Bounded { part, .. } => &part.first_key,
@@ -80,6 +82,7 @@ impl MutationDirectoryEntry {
         }
     }
 
+    #[cfg(test)]
     fn last_key(&self) -> &[u8] {
         match self {
             Self::Bounded { part, .. } => &part.last_key,
@@ -90,10 +93,79 @@ impl MutationDirectoryEntry {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub(crate) struct MutationDirectoryRoute {
+pub(crate) struct MutationDirectoryKeyRange {
+    pub(crate) start: Bytes,
+    pub(crate) end: Option<Bytes>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub(crate) struct MutationDirectoryDirectCoordinate {
+    pub(crate) part_index: u32,
+    pub(crate) local_row: u16,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) enum MutationDirectoryReadSelection<'a> {
+    All,
+    SortedRanges(&'a [MutationDirectoryKeyRange]),
+    SortedUniquePoints(&'a [Bytes]),
+    SortedUniqueDirectCoordinates(&'a [MutationDirectoryDirectCoordinate]),
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) struct MutationDirectoryPartRun {
     pub(crate) entry_index: u32,
-    pub(crate) part: CommitStateMutationPart,
-    pub(crate) direct_row_count: u16,
+    pub(crate) selector_span: Range<usize>,
+    pub(crate) entry: MutationDirectoryEntry,
+}
+
+#[derive(Debug)]
+pub(crate) struct AuthenticatedMutationPartReadPlan {
+    runs: Vec<MutationDirectoryPartRun>,
+    #[cfg(test)]
+    visited_node_count: usize,
+    #[cfg(test)]
+    node_summary_owner_count: usize,
+    #[cfg(test)]
+    node_summary_clone_count: usize,
+    #[cfg(test)]
+    part_clone_count: usize,
+}
+
+impl AuthenticatedMutationPartReadPlan {
+    #[cfg(test)]
+    pub(crate) fn is_empty(&self) -> bool {
+        self.runs.is_empty()
+    }
+
+    #[cfg(test)]
+    pub(crate) fn len(&self) -> usize {
+        self.runs.len()
+    }
+
+    pub(crate) fn into_runs(self) -> Vec<MutationDirectoryPartRun> {
+        self.runs
+    }
+
+    #[cfg(test)]
+    pub(crate) fn visited_node_count(&self) -> usize {
+        self.visited_node_count
+    }
+
+    #[cfg(test)]
+    pub(crate) fn node_summary_owner_count(&self) -> usize {
+        self.node_summary_owner_count
+    }
+
+    #[cfg(test)]
+    pub(crate) fn node_summary_clone_count(&self) -> usize {
+        self.node_summary_clone_count
+    }
+
+    #[cfg(test)]
+    pub(crate) fn part_clone_count(&self) -> usize {
+        self.part_clone_count
+    }
 }
 
 #[derive(Debug)]
@@ -199,11 +271,26 @@ impl From<&NodeSummary> for StoredChild {
     }
 }
 
+#[cfg(test)]
 impl From<&StoredChild> for NodeSummary {
     fn from(child: &StoredChild) -> Self {
         Self {
             first_key: child.first_key.clone(),
             last_key: child.last_key.clone(),
+            node_id: child.node_id,
+            entry_count: child.entry_count,
+            direct_row_count: child.direct_row_count,
+            level: child.level,
+            layout: child.layout,
+        }
+    }
+}
+
+impl From<StoredChild> for NodeSummary {
+    fn from(child: StoredChild) -> Self {
+        Self {
+            first_key: child.first_key,
+            last_key: child.last_key,
             node_id: child.node_id,
             entry_count: child.entry_count,
             direct_row_count: child.direct_row_count,
@@ -360,291 +447,307 @@ where
     Ok(BuiltMutationDirectory { root, nodes })
 }
 
-pub(crate) async fn load_mutation_directory(
-    store: &(impl StorageAdapterRead + ?Sized),
-    root: &MutationDirectoryRoot,
-) -> Result<Vec<MutationDirectoryEntry>, LixError> {
-    Ok(load_mutation_directories(store, std::slice::from_ref(root))
-        .await?
-        .pop()
-        .expect("one requested directory returns one result"))
-}
-
-/// Loads many authenticated roots level-by-level. Shared nodes and same-level
-/// frontiers issue one physical point-read batch instead of one request chain
-/// per commit.
-pub(crate) async fn load_mutation_directories(
+/// Loads complete authenticated plans for many roots level-by-level. Shared
+/// nodes and same-level frontiers issue one physical point-read batch instead
+/// of one request chain per commit. The output remains the same ordered run
+/// contract as selective reads; there is no second flat-directory interface.
+pub(crate) async fn load_all_mutation_part_read_plans(
     store: &(impl StorageAdapterRead + ?Sized),
     roots: &[MutationDirectoryRoot],
-) -> Result<Vec<Vec<MutationDirectoryEntry>>, LixError> {
+) -> Result<Vec<AuthenticatedMutationPartReadPlan>, LixError> {
     for root in roots {
         validate_root(root)?;
     }
     let mut frontiers = roots
         .iter()
-        .map(|root| vec![(root.root_id, None::<NodeSummary>)])
+        .map(|root| vec![(root.root_id, 0u32, None::<NodeSummary>)])
         .collect::<Vec<_>>();
     let mut outputs = roots
         .iter()
         .map(|root| Vec::with_capacity(root.entry_count as usize))
         .collect::<Vec<_>>();
+    #[cfg(test)]
+    let mut visited_node_counts = vec![0usize; roots.len()];
+    #[cfg(test)]
+    let mut node_summary_owner_counts = vec![0usize; roots.len()];
+    #[cfg(test)]
+    let mut node_summary_clone_counts = vec![0usize; roots.len()];
+    #[cfg(test)]
+    let mut part_clone_counts = vec![0usize; roots.len()];
     while frontiers.iter().any(|frontier| !frontier.is_empty()) {
-        let node_ids = frontiers
-            .iter()
-            .flatten()
-            .map(|(node_id, _)| *node_id)
-            .collect::<BTreeSet<_>>()
+        let mut node_ids = Vec::new();
+        let mut use_counts = HashMap::<[u8; 32], usize>::new();
+        for (node_id, _, _) in frontiers.iter().flatten() {
+            let node_id = *node_id;
+            match use_counts.entry(node_id) {
+                std::collections::hash_map::Entry::Vacant(entry) => {
+                    entry.insert(1);
+                    node_ids.push(node_id);
+                }
+                std::collections::hash_map::Entry::Occupied(mut entry) => {
+                    *entry.get_mut() += 1;
+                }
+            }
+        }
+        let loaded_nodes = load_nodes(store, &node_ids, true).await?;
+        let mut loaded = node_ids
             .into_iter()
-            .collect::<Vec<_>>();
-        let loaded = node_ids
-            .iter()
-            .copied()
-            .zip(load_nodes(store, &node_ids).await?)
-            .collect::<BTreeMap<_, _>>();
+            .zip(loaded_nodes)
+            .map(|(node_id, node)| {
+                let use_count = use_counts[&node_id];
+                (node_id, (node, use_count))
+            })
+            .collect::<HashMap<_, _>>();
         for (root_index, frontier) in frontiers.iter_mut().enumerate() {
             let mut next = Vec::new();
-            for (node_id, expected) in std::mem::take(frontier) {
-                let (node, summary) = loaded
+            for (node_id, base_index, expected) in std::mem::take(frontier) {
+                let remaining_uses = loaded
                     .get(&node_id)
+                    .map(|(_, use_count)| *use_count)
                     .ok_or_else(|| directory_error("directory batch omitted a node"))?;
-                match expected {
-                    Some(expected) if expected != *summary => {
-                        return Err(directory_error("child summary mismatch"));
+                let node = if remaining_uses == 1 {
+                    loaded
+                        .remove(&node_id)
+                        .expect("loaded node use was just observed")
+                        .0
+                } else {
+                    let (node, use_count) = loaded
+                        .get_mut(&node_id)
+                        .expect("loaded node use was just observed");
+                    *use_count -= 1;
+                    #[cfg(test)]
+                    match node {
+                        StoredNode::Leaf { entries, .. } => {
+                            part_clone_counts[root_index] += entries.len();
+                        }
+                        StoredNode::Internal { children, .. } => {
+                            node_summary_clone_counts[root_index] += children.len();
+                        }
                     }
-                    None if !summary_matches_root(summary, &roots[root_index]) => {
-                        return Err(directory_error("root summary mismatch"));
-                    }
-                    _ => {}
+                    node.clone()
+                };
+                #[cfg(test)]
+                {
+                    visited_node_counts[root_index] += 1;
                 }
+                validate_loaded_node(
+                    &node,
+                    node_id,
+                    expected.as_ref(),
+                    &roots[root_index],
+                    "directory batch",
+                )?;
                 match node {
-                    StoredNode::Leaf { entries, .. } => outputs[root_index].extend(
-                        entries
-                            .iter()
-                            .cloned()
-                            .map(runtime_entry)
-                            .collect::<Result<Vec<_>, _>>()?,
-                    ),
+                    StoredNode::Leaf { entries, .. } => {
+                        for (index, entry) in entries.into_iter().enumerate() {
+                            outputs[root_index].push(MutationDirectoryPartRun {
+                                entry_index: base_index
+                                    .checked_add(u32::try_from(index).map_err(|_| {
+                                        directory_error("leaf entry index overflows")
+                                    })?)
+                                    .ok_or_else(|| directory_error("entry index overflows"))?,
+                                selector_span: 0..0,
+                                entry: runtime_entry(entry)?,
+                            });
+                        }
+                    }
                     StoredNode::Internal { children, .. } => {
-                        next.extend(children.iter().map(|child| {
-                            let summary = NodeSummary::from(child);
-                            (child.node_id, Some(summary))
-                        }));
+                        let mut preceding = 0u32;
+                        for child in children {
+                            let child_base = base_index
+                                .checked_add(preceding)
+                                .ok_or_else(|| directory_error("entry offset overflows"))?;
+                            preceding = preceding
+                                .checked_add(child.entry_count)
+                                .ok_or_else(|| directory_error("entry offset overflows"))?;
+                            let node_id = child.node_id;
+                            next.push((node_id, child_base, Some(NodeSummary::from(child))));
+                            #[cfg(test)]
+                            {
+                                node_summary_owner_counts[root_index] += 1;
+                            }
+                        }
                     }
                 }
             }
             *frontier = next;
         }
     }
-    for (root, entries) in roots.iter().zip(&outputs) {
-        validate_entries(root.layout, entries)?;
-        if entries.len() != root.entry_count as usize
-            || entries
+    for (root, runs) in roots.iter().zip(&outputs) {
+        if runs.len() != root.entry_count as usize
+            || runs
                 .iter()
-                .map(MutationDirectoryEntry::direct_row_count)
+                .map(|run| run.entry.direct_row_count())
                 .map(u64::from)
                 .sum::<u64>()
                 != root.direct_row_count
+            || runs
+                .iter()
+                .enumerate()
+                .any(|(index, run)| run.entry_index as usize != index)
         {
             return Err(directory_error("directory closure disagrees with its root"));
         }
     }
-    Ok(outputs)
+    Ok(outputs
+        .into_iter()
+        .enumerate()
+        .map(|(root_index, runs)| {
+            #[cfg(not(test))]
+            let _ = root_index;
+            AuthenticatedMutationPartReadPlan {
+                runs,
+                #[cfg(test)]
+                visited_node_count: visited_node_counts[root_index],
+                #[cfg(test)]
+                node_summary_owner_count: node_summary_owner_counts[root_index],
+                #[cfg(test)]
+                node_summary_clone_count: node_summary_clone_counts[root_index],
+                #[cfg(test)]
+                part_clone_count: part_clone_counts[root_index],
+            }
+        })
+        .collect())
 }
 
-/// Routes ordered or unordered point keys through the authenticated bounded
-/// directory without decoding unrelated leaves.
-pub(crate) async fn route_mutation_directory_points(
+/// Selects immutable mutation parts through one authenticated, level-batched
+/// directory traversal.
+///
+/// Points and ranges are caller-canonicalized. The directory rejects any
+/// unordered or duplicate point column and any unordered, overlapping, empty,
+/// or open-ended non-final range. One run owns one selected part and a compact
+/// selector span; keys never own directory bounds.
+pub(crate) async fn load_mutation_part_read_plan(
     store: &(impl StorageAdapterRead + ?Sized),
     root: &MutationDirectoryRoot,
-    keys: &[&[u8]],
-) -> Result<Vec<Option<MutationDirectoryRoute>>, LixError> {
+    selection: MutationDirectoryReadSelection<'_>,
+) -> Result<AuthenticatedMutationPartReadPlan, LixError> {
     validate_root(root)?;
-    if root.layout != LAYOUT_BOUNDED_DIRECT && root.layout != LAYOUT_BOUNDED_INDIRECT {
-        return Err(directory_error(
-            "compact replacement directory is not key-routable",
-        ));
+    validate_selection(root, selection)?;
+    let selector_count = selection.len();
+    if !matches!(selection, MutationDirectoryReadSelection::All) && selector_count == 0 {
+        return Ok(AuthenticatedMutationPartReadPlan {
+            runs: Vec::new(),
+            #[cfg(test)]
+            visited_node_count: 0,
+            #[cfg(test)]
+            node_summary_owner_count: 0,
+            #[cfg(test)]
+            node_summary_clone_count: 0,
+            #[cfg(test)]
+            part_clone_count: 0,
+        });
     }
-    #[derive(Clone)]
-    struct Pending {
-        output_index: usize,
+
+    struct PendingNode {
+        node_id: [u8; 32],
         base_index: u32,
+        selector_span: Range<usize>,
         expected: Option<NodeSummary>,
     }
-    let mut frontier = BTreeMap::<[u8; 32], Vec<Pending>>::new();
-    frontier.insert(
-        root.root_id,
-        keys.iter()
-            .enumerate()
-            .map(|(output_index, _)| Pending {
-                output_index,
-                base_index: 0,
-                expected: None,
-            })
-            .collect(),
-    );
-    let mut output = vec![None; keys.len()];
-    while !frontier.is_empty() {
-        let node_ids = frontier.keys().copied().collect::<Vec<_>>();
-        let loaded = load_nodes(store, &node_ids).await?;
-        let mut next = BTreeMap::<[u8; 32], Vec<Pending>>::new();
-        for ((node_id, pending), (node, summary)) in frontier.into_iter().zip(loaded.into_iter()) {
-            for request in pending {
-                let key = keys[request.output_index];
-                match request.expected.as_ref() {
-                    Some(expected) if expected != &summary => {
-                        return Err(directory_error("point route child summary mismatch"));
-                    }
-                    None if !summary_matches_root(&summary, root) => {
-                        return Err(directory_error("point route root summary mismatch"));
-                    }
-                    _ => {}
-                }
-                match &node {
-                    StoredNode::Leaf { entries, .. } => {
-                        let index = match entries
-                            .binary_search_by(|entry| stored_entry_first_key(entry).cmp(key))
-                        {
-                            Ok(index) => index,
-                            Err(0) => continue,
-                            Err(index) => index - 1,
-                        };
-                        let entry = runtime_entry(entries[index].clone())?;
-                        if key <= entry.last_key() {
-                            let MutationDirectoryEntry::Bounded {
-                                part,
-                                direct_row_count,
-                            } = entry
-                            else {
-                                return Err(directory_error("bounded leaf contains compact entry"));
-                            };
-                            output[request.output_index] = Some(MutationDirectoryRoute {
-                                entry_index: request
-                                    .base_index
-                                    .checked_add(u32::try_from(index).map_err(|_| {
-                                        directory_error("leaf entry index overflows")
-                                    })?)
-                                    .ok_or_else(|| directory_error("entry index overflows"))?,
-                                part,
-                                direct_row_count,
-                            });
-                        }
-                    }
-                    StoredNode::Internal { children, .. } => {
-                        let index = match children
-                            .binary_search_by(|child| child.first_key.as_slice().cmp(key))
-                        {
-                            Ok(index) => index,
-                            Err(0) => continue,
-                            Err(index) => index - 1,
-                        };
-                        let child = &children[index];
-                        if key > child.last_key.as_slice() {
-                            continue;
-                        }
-                        let preceding = children[..index].iter().try_fold(0u32, |sum, child| {
-                            sum.checked_add(child.entry_count)
-                                .ok_or_else(|| directory_error("entry offset overflows"))
-                        })?;
-                        next.entry(child.node_id).or_default().push(Pending {
-                            base_index: request
-                                .base_index
-                                .checked_add(preceding)
-                                .ok_or_else(|| directory_error("entry offset overflows"))?,
-                            expected: Some(NodeSummary::from(child)),
-                            ..request
-                        });
-                    }
-                }
-            }
-            let _ = node_id;
-        }
-        frontier = next;
-    }
-    Ok(output)
-}
 
-/// Loads only bounded-directory entries intersecting one of the requested
-/// half-open key ranges. An empty range list selects the complete directory.
-/// Every visited node is authenticated against its parent summary and the
-/// header-owned root; unrelated subtrees are never decoded.
-pub(crate) async fn load_bounded_mutation_directory_ranges(
-    store: &(impl StorageAdapterRead + ?Sized),
-    root: &MutationDirectoryRoot,
-    ranges: &[(&[u8], Option<&[u8]>)],
-) -> Result<Vec<MutationDirectoryRoute>, LixError> {
-    validate_root(root)?;
-    if root.layout != LAYOUT_BOUNDED_DIRECT && root.layout != LAYOUT_BOUNDED_INDIRECT {
-        return Err(directory_error("range scan requires a bounded directory"));
-    }
+    let mut frontier = vec![PendingNode {
+        node_id: root.root_id,
+        base_index: 0,
+        selector_span: 0..selector_count,
+        expected: None,
+    }];
+    let mut runs = Vec::new();
+    #[cfg(test)]
+    let mut visited_node_count = 0usize;
+    #[cfg(test)]
+    let mut node_summary_owner_count = 0usize;
 
-    fn overlaps(first: &[u8], last: &[u8], ranges: &[(&[u8], Option<&[u8]>)]) -> bool {
-        ranges.is_empty()
-            || ranges
-                .iter()
-                .any(|(start, end)| last >= *start && end.is_none_or(|end| first < end))
-    }
-
-    let mut frontier = vec![(root.root_id, 0u32, None::<NodeSummary>)];
-    let mut output = Vec::new();
     while !frontier.is_empty() {
         let node_ids = frontier
             .iter()
-            .map(|(node_id, _, _)| *node_id)
+            .map(|pending| pending.node_id)
             .collect::<Vec<_>>();
-        let loaded = load_nodes(store, &node_ids).await?;
+        let loaded = load_nodes(store, &node_ids, is_bounded(root.layout)).await?;
         let mut next = Vec::new();
-        for ((_, base_index, expected), (node, summary)) in frontier.into_iter().zip(loaded) {
-            match expected {
-                Some(expected) if expected != summary => {
-                    return Err(directory_error("range scan child summary mismatch"));
-                }
-                None if !summary_matches_root(&summary, root) => {
-                    return Err(directory_error("range scan root summary mismatch"));
-                }
-                _ => {}
+        for (pending, node) in frontier.into_iter().zip(loaded) {
+            #[cfg(test)]
+            {
+                visited_node_count += 1;
             }
+            validate_loaded_node(
+                &node,
+                pending.node_id,
+                pending.expected.as_ref(),
+                root,
+                "mutation read-plan",
+            )?;
             match node {
                 StoredNode::Leaf { entries, .. } => {
+                    let mut selector_cursor = pending.selector_span.start;
                     for (index, entry) in entries.into_iter().enumerate() {
-                        if !overlaps(
+                        let entry_index = pending
+                            .base_index
+                            .checked_add(
+                                u32::try_from(index)
+                                    .map_err(|_| directory_error("leaf entry index overflows"))?,
+                            )
+                            .ok_or_else(|| directory_error("entry index overflows"))?;
+                        let entry_end = entry_index
+                            .checked_add(1)
+                            .ok_or_else(|| directory_error("entry index overflows"))?;
+                        let selector_span = selection_span_for_entry(
+                            selection,
+                            &mut selector_cursor,
+                            pending.selector_span.end,
                             stored_entry_first_key(&entry),
                             stored_entry_last_key(&entry),
-                            ranges,
-                        ) {
+                            entry_index,
+                            entry_end,
+                            Some(stored_entry_direct_rows(&entry)),
+                        )?;
+                        let Some(selector_span) = selector_span else {
                             continue;
-                        }
-                        let MutationDirectoryEntry::Bounded {
-                            part,
-                            direct_row_count,
-                        } = runtime_entry(entry)?
-                        else {
-                            return Err(directory_error("bounded leaf contains compact entry"));
                         };
-                        output.push(MutationDirectoryRoute {
-                            entry_index: base_index
-                                .checked_add(
-                                    u32::try_from(index).map_err(|_| {
-                                        directory_error("leaf entry index overflows")
-                                    })?,
-                                )
-                                .ok_or_else(|| directory_error("entry index overflows"))?,
-                            part,
-                            direct_row_count,
+                        runs.push(MutationDirectoryPartRun {
+                            entry_index,
+                            selector_span,
+                            entry: runtime_entry(entry)?,
                         });
                     }
                 }
                 StoredNode::Internal { children, .. } => {
                     let mut preceding = 0u32;
+                    let mut selector_cursor = pending.selector_span.start;
                     for child in children {
-                        let child_base = base_index
+                        let child_base = pending
+                            .base_index
                             .checked_add(preceding)
                             .ok_or_else(|| directory_error("entry offset overflows"))?;
                         preceding = preceding
                             .checked_add(child.entry_count)
                             .ok_or_else(|| directory_error("entry offset overflows"))?;
-                        if overlaps(&child.first_key, &child.last_key, ranges) {
-                            let summary = NodeSummary::from(&child);
-                            next.push((child.node_id, child_base, Some(summary)));
+                        let child_end = child_base
+                            .checked_add(child.entry_count)
+                            .ok_or_else(|| directory_error("entry offset overflows"))?;
+                        let selector_span = selection_span_for_entry(
+                            selection,
+                            &mut selector_cursor,
+                            pending.selector_span.end,
+                            &child.first_key,
+                            &child.last_key,
+                            child_base,
+                            child_end,
+                            None,
+                        )?;
+                        let Some(selector_span) = selector_span else {
+                            continue;
+                        };
+                        let node_id = child.node_id;
+                        next.push(PendingNode {
+                            node_id,
+                            base_index: child_base,
+                            selector_span,
+                            expected: Some(NodeSummary::from(child)),
+                        });
+                        #[cfg(test)]
+                        {
+                            node_summary_owner_count += 1;
                         }
                     }
                 }
@@ -652,7 +755,190 @@ pub(crate) async fn load_bounded_mutation_directory_ranges(
         }
         frontier = next;
     }
-    Ok(output)
+    if runs.windows(2).any(|pair| {
+        pair[0].entry_index >= pair[1].entry_index
+            || pair[0].selector_span.start > pair[1].selector_span.start
+    }) {
+        return Err(directory_error(
+            "mutation read-plan output is not canonical",
+        ));
+    }
+    if matches!(
+        selection,
+        MutationDirectoryReadSelection::SortedUniqueDirectCoordinates(_)
+    ) && (runs.first().is_none_or(|run| run.selector_span.start != 0)
+        || runs
+            .windows(2)
+            .any(|pair| pair[0].selector_span.end != pair[1].selector_span.start)
+        || runs
+            .last()
+            .is_none_or(|run| run.selector_span.end != selector_count))
+    {
+        return Err(directory_error(
+            "direct-coordinate read-plan output does not cover every selector",
+        ));
+    }
+    Ok(AuthenticatedMutationPartReadPlan {
+        runs,
+        #[cfg(test)]
+        visited_node_count,
+        #[cfg(test)]
+        node_summary_owner_count,
+        #[cfg(test)]
+        node_summary_clone_count: 0,
+        #[cfg(test)]
+        part_clone_count: 0,
+    })
+}
+
+impl MutationDirectoryReadSelection<'_> {
+    fn len(self) -> usize {
+        match self {
+            Self::All => 0,
+            Self::SortedRanges(ranges) => ranges.len(),
+            Self::SortedUniquePoints(points) => points.len(),
+            Self::SortedUniqueDirectCoordinates(coordinates) => coordinates.len(),
+        }
+    }
+}
+
+fn validate_selection(
+    root: &MutationDirectoryRoot,
+    selection: MutationDirectoryReadSelection<'_>,
+) -> Result<(), LixError> {
+    match selection {
+        MutationDirectoryReadSelection::All => Ok(()),
+        MutationDirectoryReadSelection::SortedUniquePoints(points) => {
+            if !is_bounded(root.layout) {
+                return Err(directory_error(
+                    "point selection requires a bounded directory",
+                ));
+            }
+            if points.iter().any(Bytes::is_empty)
+                || points.windows(2).any(|pair| pair[0] >= pair[1])
+            {
+                return Err(directory_error(
+                    "point selection must be strictly sorted and unique",
+                ));
+            }
+            Ok(())
+        }
+        MutationDirectoryReadSelection::SortedRanges(ranges) => {
+            if !is_bounded(root.layout) {
+                return Err(directory_error(
+                    "range selection requires a bounded directory",
+                ));
+            }
+            for (index, range) in ranges.iter().enumerate() {
+                if range.start.is_empty()
+                    || range
+                        .end
+                        .as_ref()
+                        .is_some_and(|end| end.as_ref() <= range.start.as_ref())
+                    || (range.end.is_none() && index + 1 != ranges.len())
+                {
+                    return Err(directory_error(
+                        "range selection contains an empty or non-final open range",
+                    ));
+                }
+            }
+            if ranges.windows(2).any(|pair| {
+                pair[0]
+                    .end
+                    .as_ref()
+                    .is_none_or(|end| end.as_ref() >= pair[1].start.as_ref())
+            }) {
+                return Err(directory_error(
+                    "range selection must be sorted, disjoint, and canonical",
+                ));
+            }
+            Ok(())
+        }
+        MutationDirectoryReadSelection::SortedUniqueDirectCoordinates(coordinates) => {
+            if coordinates.is_empty() {
+                return Ok(());
+            }
+            if root.direct_row_count == 0 {
+                return Err(directory_error(
+                    "direct-coordinate selection requires direct-row authority",
+                ));
+            }
+            if coordinates.windows(2).any(|pair| pair[0] >= pair[1]) {
+                return Err(directory_error(
+                    "direct-coordinate selection must be strictly sorted and unique",
+                ));
+            }
+            if coordinates
+                .last()
+                .is_some_and(|coordinate| coordinate.part_index >= root.entry_count)
+            {
+                return Err(directory_error(
+                    "direct-coordinate selection exceeds part authority",
+                ));
+            }
+            Ok(())
+        }
+    }
+}
+
+fn selection_span_for_entry(
+    selection: MutationDirectoryReadSelection<'_>,
+    cursor: &mut usize,
+    selector_end: usize,
+    first_key: &[u8],
+    last_key: &[u8],
+    entry_index: u32,
+    entry_end: u32,
+    direct_row_count: Option<u16>,
+) -> Result<Option<Range<usize>>, LixError> {
+    match selection {
+        MutationDirectoryReadSelection::All => Ok(Some(0..0)),
+        MutationDirectoryReadSelection::SortedUniquePoints(points) => {
+            while *cursor < selector_end && points[*cursor].as_ref() < first_key {
+                *cursor += 1;
+            }
+            let start = *cursor;
+            while *cursor < selector_end && points[*cursor].as_ref() <= last_key {
+                *cursor += 1;
+            }
+            Ok((start < *cursor).then_some(start..*cursor))
+        }
+        MutationDirectoryReadSelection::SortedRanges(ranges) => {
+            while *cursor < selector_end
+                && ranges[*cursor]
+                    .end
+                    .as_ref()
+                    .is_some_and(|end| end.as_ref() <= first_key)
+            {
+                *cursor += 1;
+            }
+            let start = *cursor;
+            let mut end = start;
+            while end < selector_end && ranges[end].start.as_ref() <= last_key {
+                end += 1;
+            }
+            Ok((start < end).then_some(start..end))
+        }
+        MutationDirectoryReadSelection::SortedUniqueDirectCoordinates(coordinates) => {
+            while *cursor < selector_end && coordinates[*cursor].part_index < entry_index {
+                *cursor += 1;
+            }
+            let start = *cursor;
+            while *cursor < selector_end && coordinates[*cursor].part_index < entry_end {
+                *cursor += 1;
+            }
+            if let Some(direct_row_count) = direct_row_count
+                && coordinates[start..*cursor]
+                    .iter()
+                    .any(|coordinate| coordinate.local_row >= direct_row_count)
+            {
+                return Err(directory_error(
+                    "direct coordinate exceeds authenticated part row count",
+                ));
+            }
+            Ok((start < *cursor).then_some(start..*cursor))
+        }
+    }
 }
 
 pub(crate) async fn collect_mutation_directory_node_ids(
@@ -667,25 +953,17 @@ pub(crate) async fn collect_mutation_directory_node_ids(
             .iter()
             .map(|(node_id, _)| *node_id)
             .collect::<Vec<_>>();
-        let loaded = load_nodes(store, &node_ids).await?;
+        let loaded = load_nodes(store, &node_ids, is_bounded(root.layout)).await?;
         let mut next = Vec::new();
-        for ((node_id, expected), (node, summary)) in frontier.into_iter().zip(loaded) {
-            match expected {
-                Some(expected) if expected != summary => {
-                    return Err(directory_error("reachability child summary mismatch"));
-                }
-                None if !summary_matches_root(&summary, root) => {
-                    return Err(directory_error("reachability root summary mismatch"));
-                }
-                _ => {}
-            }
+        for ((node_id, expected), node) in frontier.into_iter().zip(loaded) {
+            validate_loaded_node(&node, node_id, expected.as_ref(), root, "reachability")?;
             if !reachable.insert(node_id) {
                 continue;
             }
             if let StoredNode::Internal { children, .. } = node {
                 next.extend(children.into_iter().map(|child| {
-                    let summary = NodeSummary::from(&child);
-                    (child.node_id, Some(summary))
+                    let node_id = child.node_id;
+                    (node_id, Some(NodeSummary::from(child)))
                 }));
             }
         }
@@ -742,7 +1020,8 @@ pub(crate) fn decode_built_mutation_directory(
 async fn load_nodes(
     store: &(impl StorageAdapterRead + ?Sized),
     node_ids: &[[u8; 32]],
-) -> Result<Vec<(StoredNode, NodeSummary)>, LixError> {
+    unique: bool,
+) -> Result<Vec<StoredNode>, LixError> {
     if node_ids.is_empty() {
         return Ok(Vec::new());
     }
@@ -750,7 +1029,12 @@ async fn load_nodes(
         .iter()
         .map(|node_id| StorageKey(Bytes::copy_from_slice(node_id)))
         .collect::<Vec<_>>();
-    let values = PointReadPlan::new(MUTATION_DIRECTORY_NODE_SPACE, &keys)
+    let plan = if unique {
+        PointReadPlan::from_unique_keys(MUTATION_DIRECTORY_NODE_SPACE, keys)
+    } else {
+        PointReadPlan::new(MUTATION_DIRECTORY_NODE_SPACE, &keys)
+    };
+    let values = plan
         .materialize(store, StorageGetOptions::default())
         .await?
         .value;
@@ -765,9 +1049,7 @@ async fn load_nodes(
             if node_digest(&bytes) != *node_id {
                 return Err(directory_error("node content digest mismatch"));
             }
-            let node = decode_node(&bytes)?;
-            let summary = node_summary(&node, *node_id)?;
-            Ok((node, summary))
+            decode_node(&bytes)
         })
         .collect()
 }
@@ -858,6 +1140,104 @@ fn validate_node(node: &StoredNode) -> Result<(), LixError> {
     }
 }
 
+#[derive(Clone, Copy)]
+struct NodeSummaryRef<'a> {
+    first_key: &'a [u8],
+    last_key: &'a [u8],
+    node_id: [u8; 32],
+    entry_count: u32,
+    direct_row_count: u64,
+    level: u16,
+    layout: u8,
+}
+
+fn node_summary_ref(node: &StoredNode, node_id: [u8; 32]) -> Result<NodeSummaryRef<'_>, LixError> {
+    match node {
+        StoredNode::Leaf { layout, entries } => {
+            let entry_count = u32::try_from(entries.len())
+                .map_err(|_| directory_error("entry count overflows"))?;
+            let direct_row_count = entries.iter().try_fold(0u64, |sum, entry| {
+                sum.checked_add(u64::from(stored_entry_direct_rows(entry)))
+                    .ok_or_else(|| directory_error("row count overflows"))
+            })?;
+            Ok(NodeSummaryRef {
+                first_key: stored_entry_first_key(&entries[0]),
+                last_key: stored_entry_last_key(&entries[entries.len() - 1]),
+                node_id,
+                entry_count,
+                direct_row_count,
+                level: 0,
+                layout: *layout,
+            })
+        }
+        StoredNode::Internal {
+            layout,
+            level,
+            children,
+        } => {
+            let (entry_count, direct_row_count) =
+                children
+                    .iter()
+                    .try_fold((0u32, 0u64), |(entry_sum, row_sum), child| {
+                        Ok::<_, LixError>((
+                            entry_sum
+                                .checked_add(child.entry_count)
+                                .ok_or_else(|| directory_error("entry count overflows"))?,
+                            row_sum
+                                .checked_add(child.direct_row_count)
+                                .ok_or_else(|| directory_error("row count overflows"))?,
+                        ))
+                    })?;
+            Ok(NodeSummaryRef {
+                first_key: &children[0].first_key,
+                last_key: &children[children.len() - 1].last_key,
+                node_id,
+                entry_count,
+                direct_row_count,
+                level: *level,
+                layout: *layout,
+            })
+        }
+    }
+}
+
+fn summary_ref_matches_owned(actual: NodeSummaryRef<'_>, expected: &NodeSummary) -> bool {
+    actual.first_key == expected.first_key
+        && actual.last_key == expected.last_key
+        && actual.node_id == expected.node_id
+        && actual.entry_count == expected.entry_count
+        && actual.direct_row_count == expected.direct_row_count
+        && actual.level == expected.level
+        && actual.layout == expected.layout
+}
+
+fn summary_ref_matches_root(actual: NodeSummaryRef<'_>, root: &MutationDirectoryRoot) -> bool {
+    actual.node_id == root.root_id
+        && actual.entry_count == root.entry_count
+        && actual.direct_row_count == root.direct_row_count
+        && actual.level.checked_add(1) == Some(root.tree_height)
+        && actual.layout == root.layout
+}
+
+fn validate_loaded_node(
+    node: &StoredNode,
+    node_id: [u8; 32],
+    expected: Option<&NodeSummary>,
+    root: &MutationDirectoryRoot,
+    operation: &str,
+) -> Result<(), LixError> {
+    let actual = node_summary_ref(node, node_id)?;
+    match expected {
+        Some(expected) if !summary_ref_matches_owned(actual, expected) => Err(directory_error(
+            format!("{operation} child summary mismatch"),
+        )),
+        None if !summary_ref_matches_root(actual, root) => Err(directory_error(format!(
+            "{operation} root summary mismatch"
+        ))),
+        _ => Ok(()),
+    }
+}
+
 fn node_summary(node: &StoredNode, node_id: [u8; 32]) -> Result<NodeSummary, LixError> {
     match node {
         StoredNode::Leaf { layout, entries } => {
@@ -908,6 +1288,7 @@ fn node_summary(node: &StoredNode, node_id: [u8; 32]) -> Result<NodeSummary, Lix
     }
 }
 
+#[cfg(test)]
 fn validate_entries(layout: u8, entries: &[MutationDirectoryEntry]) -> Result<(), LixError> {
     validate_layout(layout)?;
     if entries.is_empty() {
@@ -1028,6 +1409,7 @@ pub(crate) fn validate_mutation_directory_root(
     validate_root(root)
 }
 
+#[cfg(test)]
 fn summary_matches_root(summary: &NodeSummary, root: &MutationDirectoryRoot) -> bool {
     summary.node_id == root.root_id
         && summary.entry_count == root.entry_count
@@ -1214,15 +1596,9 @@ mod tests {
         }
     }
 
-    #[tokio::test]
-    async fn multi_level_directory_round_trips_and_routes_without_flattening() {
-        let entries = (0..(FANOUT as u32 * 2 + 17))
-            .map(bounded_entry)
-            .collect::<Vec<_>>();
-        let built = build_mutation_directory(LAYOUT_BOUNDED_DIRECT, &entries).unwrap();
-        assert!(built.root.tree_height >= 2);
-        assert!(built.node_bytes().len() > 1);
-
+    async fn stored_directory(
+        built: &BuiltMutationDirectory,
+    ) -> (StorageAdapter<Memory>, impl StorageAdapterRead) {
         let storage = StorageAdapter::new(Memory::new());
         let mut writes = storage.new_write_set();
         built.stage(&mut writes).unwrap();
@@ -1234,30 +1610,218 @@ mod tests {
             .begin_read(StorageReadOptions::default())
             .await
             .unwrap();
+        (storage, read)
+    }
 
-        let loaded = load_mutation_directory(&read, &built.root).await.unwrap();
-        assert_eq!(loaded, entries);
-        let requested = [0u32, FANOUT as u32, FANOUT as u32 * 2 + 16];
-        let keys = requested
-            .iter()
-            .map(|index| index.saturating_mul(10).saturating_add(4).to_be_bytes())
+    #[tokio::test]
+    async fn multi_level_directory_emits_distinct_runs_without_per_key_owners() {
+        let entries = (0..(FANOUT as u32 * 2 + 17))
+            .map(bounded_entry)
             .collect::<Vec<_>>();
-        let key_refs = keys.iter().map(<[u8; 4]>::as_slice).collect::<Vec<_>>();
-        let routed = route_mutation_directory_points(&read, &built.root, &key_refs)
-            .await
-            .unwrap();
-        for (&expected_index, route) in requested.iter().zip(routed) {
-            let route = route.expect("covered key should route");
-            assert_eq!(route.entry_index, expected_index);
-            assert_eq!(route.direct_row_count, 7);
+        let built = build_mutation_directory(LAYOUT_BOUNDED_DIRECT, &entries).unwrap();
+        assert!(built.root.tree_height >= 2);
+        assert!(built.node_bytes().len() > 1);
+        let (_storage, read) = stored_directory(&built).await;
+
+        let all =
+            load_mutation_part_read_plan(&read, &built.root, MutationDirectoryReadSelection::All)
+                .await
+                .unwrap();
+        assert_eq!(all.len(), entries.len());
+        assert_eq!(all.visited_node_count(), built.node_bytes().len());
+        assert_eq!(all.node_summary_owner_count() + 1, all.visited_node_count());
+        assert_eq!(all.node_summary_clone_count(), 0);
+        assert_eq!(all.part_clone_count(), 0);
+        assert_eq!(
+            all.into_runs()
+                .into_iter()
+                .map(|run| run.entry)
+                .collect::<Vec<_>>(),
+            entries
+        );
+
+        let requested = [0u32, FANOUT as u32, FANOUT as u32 * 2 + 16];
+        let points = requested
+            .iter()
+            .map(|index| {
+                Bytes::copy_from_slice(&index.saturating_mul(10).saturating_add(4).to_be_bytes())
+            })
+            .collect::<Vec<_>>();
+        let point_plan = load_mutation_part_read_plan(
+            &read,
+            &built.root,
+            MutationDirectoryReadSelection::SortedUniquePoints(&points),
+        )
+        .await
+        .unwrap();
+        assert_eq!(point_plan.len(), requested.len());
+        assert_eq!(
+            point_plan.node_summary_owner_count() + 1,
+            point_plan.visited_node_count()
+        );
+        assert!(
+            point_plan.visited_node_count()
+                <= 1 + requested.len() * built.root.tree_height as usize
+        );
+        assert_eq!(point_plan.node_summary_clone_count(), 0);
+        assert_eq!(point_plan.part_clone_count(), 0);
+        for ((&expected_index, expected_selector), run) in
+            requested.iter().zip(0usize..).zip(point_plan.into_runs())
+        {
+            assert_eq!(run.entry_index, expected_index);
+            assert_eq!(run.selector_span, expected_selector..expected_selector + 1);
+            assert_eq!(run.entry.direct_row_count(), 7);
             assert_eq!(
-                route.part,
+                run.entry,
                 match &entries[expected_index as usize] {
-                    MutationDirectoryEntry::Bounded { part, .. } => part.clone(),
+                    entry @ MutationDirectoryEntry::Bounded { .. } => entry.clone(),
                     _ => unreachable!(),
                 }
             );
         }
+
+        let clustered_points = [1u32, 4, 8]
+            .into_iter()
+            .map(|key| Bytes::copy_from_slice(&key.to_be_bytes()))
+            .collect::<Vec<_>>();
+        let clustered = load_mutation_part_read_plan(
+            &read,
+            &built.root,
+            MutationDirectoryReadSelection::SortedUniquePoints(&clustered_points),
+        )
+        .await
+        .unwrap()
+        .into_runs();
+        assert_eq!(clustered.len(), 1, "one touched part must produce one run");
+        assert_eq!(clustered[0].entry_index, 0);
+        assert_eq!(clustered[0].selector_span, 0..clustered_points.len());
+
+        let coordinates = [
+            MutationDirectoryDirectCoordinate {
+                part_index: 0,
+                local_row: 0,
+            },
+            MutationDirectoryDirectCoordinate {
+                part_index: FANOUT as u32,
+                local_row: 3,
+            },
+            MutationDirectoryDirectCoordinate {
+                part_index: u32::try_from(entries.len() - 1).unwrap(),
+                local_row: 6,
+            },
+        ];
+        let coordinate_plan = load_mutation_part_read_plan(
+            &read,
+            &built.root,
+            MutationDirectoryReadSelection::SortedUniqueDirectCoordinates(&coordinates),
+        )
+        .await
+        .unwrap();
+        assert_eq!(coordinate_plan.node_summary_clone_count(), 0);
+        assert_eq!(coordinate_plan.part_clone_count(), 0);
+        assert!(
+            coordinate_plan.visited_node_count()
+                <= 1 + coordinates.len() * built.root.tree_height as usize
+        );
+        let coordinate_runs = coordinate_plan.into_runs();
+        assert_eq!(coordinate_runs.len(), coordinates.len());
+        assert_eq!(coordinate_runs[0].entry_index, 0);
+        assert_eq!(coordinate_runs[0].selector_span, 0..1);
+        assert_eq!(coordinate_runs[1].entry_index, FANOUT as u32);
+        assert_eq!(coordinate_runs[1].selector_span, 1..2);
+        assert_eq!(
+            coordinate_runs[2].entry_index,
+            u32::try_from(entries.len() - 1).unwrap()
+        );
+        assert_eq!(coordinate_runs[2].selector_span, 2..3);
+
+        let clustered_coordinates = [
+            MutationDirectoryDirectCoordinate {
+                part_index: 0,
+                local_row: 0,
+            },
+            MutationDirectoryDirectCoordinate {
+                part_index: 0,
+                local_row: 1,
+            },
+            MutationDirectoryDirectCoordinate {
+                part_index: 0,
+                local_row: 6,
+            },
+        ];
+        let clustered_coordinate_runs = load_mutation_part_read_plan(
+            &read,
+            &built.root,
+            MutationDirectoryReadSelection::SortedUniqueDirectCoordinates(&clustered_coordinates),
+        )
+        .await
+        .unwrap()
+        .into_runs();
+        assert_eq!(clustered_coordinate_runs.len(), 1);
+        assert_eq!(clustered_coordinate_runs[0].entry_index, 0);
+        assert_eq!(clustered_coordinate_runs[0].selector_span, 0..3);
+
+        let ranges = points
+            .iter()
+            .map(|point| {
+                let mut end = point.to_vec();
+                *end.last_mut().unwrap() += 1;
+                MutationDirectoryKeyRange {
+                    start: point.clone(),
+                    end: Some(Bytes::from(end)),
+                }
+            })
+            .collect::<Vec<_>>();
+        let range_runs = load_mutation_part_read_plan(
+            &read,
+            &built.root,
+            MutationDirectoryReadSelection::SortedRanges(&ranges),
+        )
+        .await
+        .unwrap()
+        .into_runs();
+        assert_eq!(
+            range_runs
+                .iter()
+                .map(|run| (run.entry_index, run.selector_span.clone()))
+                .collect::<Vec<_>>(),
+            requested
+                .iter()
+                .copied()
+                .zip((0usize..requested.len()).map(|index| index..index + 1))
+                .collect::<Vec<_>>()
+        );
+
+        let wide_range = [MutationDirectoryKeyRange {
+            start: Bytes::copy_from_slice(&4u32.to_be_bytes()),
+            end: Some(Bytes::copy_from_slice(&25u32.to_be_bytes())),
+        }];
+        let wide_runs = load_mutation_part_read_plan(
+            &read,
+            &built.root,
+            MutationDirectoryReadSelection::SortedRanges(&wide_range),
+        )
+        .await
+        .unwrap()
+        .into_runs();
+        assert_eq!(
+            wide_runs
+                .iter()
+                .map(|run| (run.entry_index, run.selector_span.clone()))
+                .collect::<Vec<_>>(),
+            vec![(0, 0..1), (1, 0..1), (2, 0..1)]
+        );
+
+        let batched =
+            load_all_mutation_part_read_plans(&read, &[built.root.clone(), built.root.clone()])
+                .await
+                .unwrap();
+        assert_eq!(batched.len(), 2);
+        assert!(batched.iter().all(|plan| plan.len() == entries.len()));
+        assert!(batched.iter().all(|plan| {
+            plan.node_summary_clone_count() <= plan.node_summary_owner_count()
+                && plan.part_clone_count() <= plan.len()
+        }));
         assert_eq!(
             collect_mutation_directory_node_ids(&read, &built.root)
                 .await
@@ -1265,5 +1829,364 @@ mod tests {
                 .len(),
             built.node_bytes().len()
         );
+    }
+
+    #[tokio::test]
+    async fn direct_coordinates_preserve_physical_holes_across_three_tree_levels() {
+        let irregular = [2u16, 7, 1]
+            .into_iter()
+            .map(|direct_row_count| MutationDirectoryEntry::DirectAddress { direct_row_count })
+            .collect::<Vec<_>>();
+        let built = build_mutation_directory(LAYOUT_DIRECT_ROWS_ONLY, &irregular).unwrap();
+        let (_storage, read) = stored_directory(&built).await;
+        let coordinates = [
+            MutationDirectoryDirectCoordinate {
+                part_index: 0,
+                local_row: 1,
+            },
+            MutationDirectoryDirectCoordinate {
+                part_index: 1,
+                local_row: 6,
+            },
+            MutationDirectoryDirectCoordinate {
+                part_index: 2,
+                local_row: 0,
+            },
+        ];
+        let runs = load_mutation_part_read_plan(
+            &read,
+            &built.root,
+            MutationDirectoryReadSelection::SortedUniqueDirectCoordinates(&coordinates),
+        )
+        .await
+        .unwrap()
+        .into_runs();
+        assert_eq!(
+            runs.iter().map(|run| run.entry_index).collect::<Vec<_>>(),
+            vec![0, 1, 2]
+        );
+        let error = load_mutation_part_read_plan(
+            &read,
+            &built.root,
+            MutationDirectoryReadSelection::SortedUniqueDirectCoordinates(&[
+                MutationDirectoryDirectCoordinate {
+                    part_index: 0,
+                    local_row: 2,
+                },
+            ]),
+        )
+        .await
+        .expect_err("a physical hole must not become a dense ordinal");
+        assert!(error.to_string().contains("part row count"));
+
+        let entries = (0..(FANOUT * FANOUT + 1))
+            .map(|_| MutationDirectoryEntry::DirectAddress {
+                direct_row_count: 1,
+            })
+            .collect::<Vec<_>>();
+        let built = build_mutation_directory(LAYOUT_DIRECT_ROWS_ONLY, &entries).unwrap();
+        assert!(built.root.tree_height >= 3);
+        let (_storage, read) = stored_directory(&built).await;
+        let coordinates = [
+            0u32,
+            FANOUT as u32 - 1,
+            FANOUT as u32,
+            u32::try_from(FANOUT * FANOUT - 1).unwrap(),
+            u32::try_from(FANOUT * FANOUT).unwrap(),
+        ]
+        .map(|part_index| MutationDirectoryDirectCoordinate {
+            part_index,
+            local_row: 0,
+        });
+        let plan = load_mutation_part_read_plan(
+            &read,
+            &built.root,
+            MutationDirectoryReadSelection::SortedUniqueDirectCoordinates(&coordinates),
+        )
+        .await
+        .unwrap();
+        assert_eq!(plan.len(), coordinates.len());
+        assert_eq!(plan.node_summary_clone_count(), 0);
+        assert_eq!(plan.part_clone_count(), 0);
+        assert!(
+            plan.visited_node_count() <= 1 + coordinates.len() * built.root.tree_height as usize
+        );
+        assert_eq!(
+            plan.into_runs()
+                .into_iter()
+                .map(|run| run.entry_index)
+                .collect::<Vec<_>>(),
+            coordinates
+                .iter()
+                .map(|coordinate| coordinate.part_index)
+                .collect::<Vec<_>>()
+        );
+    }
+
+    #[tokio::test]
+    async fn read_plan_rejects_noncanonical_selectors_and_handles_empty_inputs() {
+        let entries = (0..4).map(bounded_entry).collect::<Vec<_>>();
+        let built = build_mutation_directory(LAYOUT_BOUNDED_DIRECT, &entries).unwrap();
+        let (_storage, read) = stored_directory(&built).await;
+        let point = Bytes::copy_from_slice(&4u32.to_be_bytes());
+        let next = Bytes::copy_from_slice(&14u32.to_be_bytes());
+
+        for points in [
+            vec![point.clone(), point.clone()],
+            vec![next.clone(), point.clone()],
+        ] {
+            let error = load_mutation_part_read_plan(
+                &read,
+                &built.root,
+                MutationDirectoryReadSelection::SortedUniquePoints(&points),
+            )
+            .await
+            .expect_err("noncanonical points must fail");
+            assert!(error.to_string().contains("strictly sorted and unique"));
+        }
+
+        let touching = vec![
+            MutationDirectoryKeyRange {
+                start: point.clone(),
+                end: Some(next.clone()),
+            },
+            MutationDirectoryKeyRange {
+                start: next.clone(),
+                end: None,
+            },
+        ];
+        let error = load_mutation_part_read_plan(
+            &read,
+            &built.root,
+            MutationDirectoryReadSelection::SortedRanges(&touching),
+        )
+        .await
+        .expect_err("touching ranges must be canonicalized upstream");
+        assert!(
+            error
+                .to_string()
+                .contains("sorted, disjoint, and canonical")
+        );
+
+        let empty_points = load_mutation_part_read_plan(
+            &read,
+            &built.root,
+            MutationDirectoryReadSelection::SortedUniquePoints(&[]),
+        )
+        .await
+        .unwrap();
+        assert!(empty_points.is_empty());
+        assert_eq!(empty_points.visited_node_count(), 0);
+        let empty_ranges = load_mutation_part_read_plan(
+            &read,
+            &built.root,
+            MutationDirectoryReadSelection::SortedRanges(&[]),
+        )
+        .await
+        .unwrap();
+        assert!(empty_ranges.is_empty());
+        assert_eq!(empty_ranges.visited_node_count(), 0);
+
+        for coordinates in [
+            vec![
+                MutationDirectoryDirectCoordinate {
+                    part_index: 0,
+                    local_row: 0,
+                },
+                MutationDirectoryDirectCoordinate {
+                    part_index: 0,
+                    local_row: 0,
+                },
+            ],
+            vec![
+                MutationDirectoryDirectCoordinate {
+                    part_index: 1,
+                    local_row: 0,
+                },
+                MutationDirectoryDirectCoordinate {
+                    part_index: 0,
+                    local_row: 1,
+                },
+            ],
+        ] {
+            let error = load_mutation_part_read_plan(
+                &read,
+                &built.root,
+                MutationDirectoryReadSelection::SortedUniqueDirectCoordinates(&coordinates),
+            )
+            .await
+            .expect_err("noncanonical direct coordinates must fail");
+            assert!(error.to_string().contains("strictly sorted and unique"));
+        }
+        let error = load_mutation_part_read_plan(
+            &read,
+            &built.root,
+            MutationDirectoryReadSelection::SortedUniqueDirectCoordinates(&[
+                MutationDirectoryDirectCoordinate {
+                    part_index: built.root.entry_count,
+                    local_row: 0,
+                },
+            ]),
+        )
+        .await
+        .expect_err("out-of-range part coordinates must fail");
+        assert!(error.to_string().contains("exceeds part authority"));
+        let error = load_mutation_part_read_plan(
+            &read,
+            &built.root,
+            MutationDirectoryReadSelection::SortedUniqueDirectCoordinates(&[
+                MutationDirectoryDirectCoordinate {
+                    part_index: 0,
+                    local_row: 7,
+                },
+            ]),
+        )
+        .await
+        .expect_err("out-of-range local rows must fail");
+        assert!(error.to_string().contains("part row count"));
+        let empty_coordinates = load_mutation_part_read_plan(
+            &read,
+            &built.root,
+            MutationDirectoryReadSelection::SortedUniqueDirectCoordinates(&[]),
+        )
+        .await
+        .unwrap();
+        assert!(empty_coordinates.is_empty());
+        assert_eq!(empty_coordinates.visited_node_count(), 0);
+    }
+
+    #[tokio::test]
+    async fn every_read_plan_mode_fails_closed_on_authenticated_bound_mismatch() {
+        let entries = (0..(FANOUT as u32 + 1))
+            .map(bounded_entry)
+            .collect::<Vec<_>>();
+        let built = build_mutation_directory(LAYOUT_BOUNDED_DIRECT, &entries).unwrap();
+        let root_bytes = built.node_bytes()[&built.root.root_id].clone();
+        let mut root_node = decode_node(&root_bytes).unwrap();
+        let StoredNode::Internal { children, .. } = &mut root_node else {
+            panic!("fixture must have an internal root");
+        };
+        *children[0].last_key.last_mut().unwrap() -= 1;
+        let tampered_bytes = encode_node(&root_node).unwrap();
+        let tampered_id = node_digest(&tampered_bytes);
+        let mut tampered_root = built.root.clone();
+        tampered_root.root_id = tampered_id;
+        tampered_root.root_digest = root_digest(
+            tampered_id,
+            tampered_root.entry_count,
+            tampered_root.direct_row_count,
+            tampered_root.tree_height,
+            tampered_root.layout,
+        );
+
+        let storage = StorageAdapter::new(Memory::new());
+        let mut writes = storage.new_write_set();
+        for (node_id, bytes) in built.node_bytes() {
+            writes.put(
+                MUTATION_DIRECTORY_NODE_SPACE,
+                StorageKey(Bytes::copy_from_slice(node_id)),
+                StorageValue {
+                    bytes: bytes.clone(),
+                },
+            );
+        }
+        writes.put(
+            MUTATION_DIRECTORY_NODE_SPACE,
+            StorageKey(Bytes::copy_from_slice(&tampered_id)),
+            StorageValue {
+                bytes: tampered_bytes,
+            },
+        );
+        storage
+            .commit_write_set(writes, StorageWriteOptions::default())
+            .await
+            .unwrap();
+        let read = storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .unwrap();
+        let point = Bytes::copy_from_slice(&4u32.to_be_bytes());
+        let ranges = [MutationDirectoryKeyRange {
+            start: point.clone(),
+            end: Some(Bytes::copy_from_slice(&5u32.to_be_bytes())),
+        }];
+        let coordinate = [MutationDirectoryDirectCoordinate {
+            part_index: 0,
+            local_row: 0,
+        }];
+        for selection in [
+            MutationDirectoryReadSelection::All,
+            MutationDirectoryReadSelection::SortedRanges(&ranges),
+            MutationDirectoryReadSelection::SortedUniquePoints(std::slice::from_ref(&point)),
+            MutationDirectoryReadSelection::SortedUniqueDirectCoordinates(&coordinate),
+        ] {
+            let error = load_mutation_part_read_plan(&read, &tampered_root, selection)
+                .await
+                .expect_err("every selection must authenticate visited child bounds");
+            assert!(error.to_string().contains("child summary mismatch"));
+        }
+
+        let mut bad_count = built.root.clone();
+        bad_count.entry_count += 1;
+        bad_count.root_digest = root_digest(
+            bad_count.root_id,
+            bad_count.entry_count,
+            bad_count.direct_row_count,
+            bad_count.tree_height,
+            bad_count.layout,
+        );
+        let error =
+            load_mutation_part_read_plan(&read, &bad_count, MutationDirectoryReadSelection::All)
+                .await
+                .expect_err("root counts must agree with authenticated nodes");
+        assert!(error.to_string().contains("root summary mismatch"));
+    }
+
+    #[tokio::test]
+    async fn read_plan_rejects_missing_nodes_and_content_digest_mismatch() {
+        let entries = (0..2).map(bounded_entry).collect::<Vec<_>>();
+        let built = build_mutation_directory(LAYOUT_BOUNDED_DIRECT, &entries).unwrap();
+
+        let missing_storage = StorageAdapter::new(Memory::new());
+        let missing_read = missing_storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .unwrap();
+        let error = load_mutation_part_read_plan(
+            &missing_read,
+            &built.root,
+            MutationDirectoryReadSelection::All,
+        )
+        .await
+        .expect_err("a missing authenticated node must fail");
+        assert!(error.to_string().contains("missing node"));
+
+        let digest_storage = StorageAdapter::new(Memory::new());
+        let mut corrupt = built.node_bytes()[&built.root.root_id].to_vec();
+        *corrupt.last_mut().unwrap() ^= 1;
+        let mut writes = digest_storage.new_write_set();
+        writes.put(
+            MUTATION_DIRECTORY_NODE_SPACE,
+            StorageKey(Bytes::copy_from_slice(&built.root.root_id)),
+            StorageValue {
+                bytes: Bytes::from(corrupt),
+            },
+        );
+        digest_storage
+            .commit_write_set(writes, StorageWriteOptions::default())
+            .await
+            .unwrap();
+        let digest_read = digest_storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .unwrap();
+        let error = load_mutation_part_read_plan(
+            &digest_read,
+            &built.root,
+            MutationDirectoryReadSelection::All,
+        )
+        .await
+        .expect_err("content bytes must match their immutable node id");
+        assert!(error.to_string().contains("content digest mismatch"));
     }
 }

--- a/packages/engine/src/tracked_state/mutation_directory.rs
+++ b/packages/engine/src/tracked_state/mutation_directory.rs
@@ -29,6 +29,254 @@ const ROOT_HASH_CONTEXT: &str = "lix commit mutation directory root v1";
 const FANOUT: usize = 128;
 const MAX_NODE_BYTES: usize = 16 * 1024 * 1024;
 
+#[cfg(any(test, feature = "storage-benches"))]
+mod read_accounting {
+    use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+
+    pub(super) const DIRECT_ROUTE_CALLS: usize = 0;
+    pub(super) const SELECTOR_ALL_ROOTS: usize = 1;
+    pub(super) const SELECTOR_RANGE_CALLS: usize = 2;
+    pub(super) const SELECTOR_POINT_CALLS: usize = 3;
+    pub(super) const SELECTOR_DIRECT_CALLS: usize = 4;
+    pub(super) const TRAVERSAL_LEVELS: usize = 5;
+    pub(super) const NODE_BATCHES: usize = 6;
+    pub(super) const UNIQUE_NODE_IDS: usize = 7;
+    pub(super) const NODE_GETS: usize = 8;
+    pub(super) const VISITED_NODES: usize = 9;
+    pub(super) const EMITTED_RUNS: usize = 10;
+    pub(super) const BULK_MANIFEST_ROOTS: usize = 11;
+    pub(super) const COMPACT_MEMBER_ROOTS: usize = 12;
+    pub(super) const EMPTY_SCHEMA_MEMBER_ROOTS: usize = 13;
+    pub(super) const COMPACT_VALUE_ROOTS: usize = 14;
+    pub(super) const EMPTY_SCHEMA_VALUE_ROOTS: usize = 15;
+    pub(super) const REPOSITORY_INVENTORY_ROOTS: usize = 16;
+    pub(super) const FULL_MANIFEST_ROOTS: usize = 17;
+    pub(super) const GC_REACHABILITY_ROOTS: usize = 18;
+    pub(super) const EXTERNAL_PARTS_LOADED: usize = 19;
+    pub(super) const PARTS_DECODED: usize = 20;
+    pub(super) const DECODED_ROWS: usize = 21;
+    pub(super) const RAW_BYTES: usize = 22;
+    pub(super) const RESIDENT_BYTES: usize = 23;
+    pub(super) const REQUESTED_ROWS: usize = 24;
+    pub(super) const UNIQUE_REQUESTED_ROWS: usize = 25;
+    pub(super) const CLAIMED_UNIQUE_ROWS: usize = 26;
+    pub(super) const SCATTERED_ROWS: usize = 27;
+    pub(super) const EXPLICIT_FALLBACK_ROWS: usize = 28;
+    pub(super) const NOT_OWNED_MISSING_COMMIT: usize = 29;
+    pub(super) const NOT_OWNED_UNSUPPORTED_LAYOUT: usize = 30;
+    pub(super) const NOT_OWNED_ABSENT_INLINE: usize = 31;
+    pub(super) const NOT_OWNED_PART_INDEX: usize = 32;
+    pub(super) const NOT_OWNED_LOCAL_ROW: usize = 33;
+    pub(super) const CORRUPTION_OUTCOMES: usize = 34;
+    const COUNTER_COUNT: usize = 35;
+
+    static ACTIVE: AtomicBool = AtomicBool::new(false);
+    static COUNTERS: [AtomicU64; COUNTER_COUNT] = [const { AtomicU64::new(0) }; COUNTER_COUNT];
+
+    pub(super) fn reset() {
+        ACTIVE.store(false, Ordering::Release);
+        for counter in &COUNTERS {
+            counter.store(0, Ordering::Relaxed);
+        }
+        ACTIVE.store(true, Ordering::Release);
+    }
+
+    pub(super) fn stop() {
+        ACTIVE.store(false, Ordering::Release);
+    }
+
+    pub(super) fn add(counter: usize, value: usize) {
+        if ACTIVE.load(Ordering::Relaxed) {
+            COUNTERS[counter].fetch_add(value as u64, Ordering::Relaxed);
+        }
+    }
+
+    pub(super) fn get(counter: usize) -> u64 {
+        COUNTERS[counter].load(Ordering::Relaxed)
+    }
+}
+
+#[cfg(any(test, feature = "storage-benches"))]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct MutationDirectoryReadAccounting {
+    pub direct_route_calls: u64,
+    pub selector_all_roots: u64,
+    pub selector_range_calls: u64,
+    pub selector_point_calls: u64,
+    pub selector_direct_calls: u64,
+    pub traversal_levels: u64,
+    pub node_batches: u64,
+    pub unique_node_ids: u64,
+    pub node_gets: u64,
+    pub visited_nodes: u64,
+    pub emitted_runs: u64,
+    pub bulk_manifest_roots: u64,
+    pub compact_member_roots: u64,
+    pub empty_schema_member_roots: u64,
+    pub compact_value_roots: u64,
+    pub empty_schema_value_roots: u64,
+    pub repository_inventory_roots: u64,
+    pub full_manifest_roots: u64,
+    pub gc_reachability_roots: u64,
+    pub external_parts_loaded: u64,
+    pub parts_decoded: u64,
+    pub decoded_rows: u64,
+    pub raw_bytes: u64,
+    pub resident_bytes: u64,
+    pub requested_rows: u64,
+    pub unique_requested_rows: u64,
+    pub claimed_unique_rows: u64,
+    pub scattered_rows: u64,
+    pub explicit_fallback_rows: u64,
+    pub not_owned_missing_commit: u64,
+    pub not_owned_unsupported_layout: u64,
+    pub not_owned_absent_inline: u64,
+    pub not_owned_part_index: u64,
+    pub not_owned_local_row: u64,
+    pub corruption_outcomes: u64,
+}
+
+#[cfg(any(test, feature = "storage-benches"))]
+pub(crate) fn reset_mutation_directory_read_accounting() {
+    read_accounting::reset();
+}
+
+#[cfg(any(test, feature = "storage-benches"))]
+pub(crate) fn snapshot_mutation_directory_read_accounting() -> MutationDirectoryReadAccounting {
+    use read_accounting as counters;
+    counters::stop();
+    MutationDirectoryReadAccounting {
+        direct_route_calls: counters::get(counters::DIRECT_ROUTE_CALLS),
+        selector_all_roots: counters::get(counters::SELECTOR_ALL_ROOTS),
+        selector_range_calls: counters::get(counters::SELECTOR_RANGE_CALLS),
+        selector_point_calls: counters::get(counters::SELECTOR_POINT_CALLS),
+        selector_direct_calls: counters::get(counters::SELECTOR_DIRECT_CALLS),
+        traversal_levels: counters::get(counters::TRAVERSAL_LEVELS),
+        node_batches: counters::get(counters::NODE_BATCHES),
+        unique_node_ids: counters::get(counters::UNIQUE_NODE_IDS),
+        node_gets: counters::get(counters::NODE_GETS),
+        visited_nodes: counters::get(counters::VISITED_NODES),
+        emitted_runs: counters::get(counters::EMITTED_RUNS),
+        bulk_manifest_roots: counters::get(counters::BULK_MANIFEST_ROOTS),
+        compact_member_roots: counters::get(counters::COMPACT_MEMBER_ROOTS),
+        empty_schema_member_roots: counters::get(counters::EMPTY_SCHEMA_MEMBER_ROOTS),
+        compact_value_roots: counters::get(counters::COMPACT_VALUE_ROOTS),
+        empty_schema_value_roots: counters::get(counters::EMPTY_SCHEMA_VALUE_ROOTS),
+        repository_inventory_roots: counters::get(counters::REPOSITORY_INVENTORY_ROOTS),
+        full_manifest_roots: counters::get(counters::FULL_MANIFEST_ROOTS),
+        gc_reachability_roots: counters::get(counters::GC_REACHABILITY_ROOTS),
+        external_parts_loaded: counters::get(counters::EXTERNAL_PARTS_LOADED),
+        parts_decoded: counters::get(counters::PARTS_DECODED),
+        decoded_rows: counters::get(counters::DECODED_ROWS),
+        raw_bytes: counters::get(counters::RAW_BYTES),
+        resident_bytes: counters::get(counters::RESIDENT_BYTES),
+        requested_rows: counters::get(counters::REQUESTED_ROWS),
+        unique_requested_rows: counters::get(counters::UNIQUE_REQUESTED_ROWS),
+        claimed_unique_rows: counters::get(counters::CLAIMED_UNIQUE_ROWS),
+        scattered_rows: counters::get(counters::SCATTERED_ROWS),
+        explicit_fallback_rows: counters::get(counters::EXPLICIT_FALLBACK_ROWS),
+        not_owned_missing_commit: counters::get(counters::NOT_OWNED_MISSING_COMMIT),
+        not_owned_unsupported_layout: counters::get(counters::NOT_OWNED_UNSUPPORTED_LAYOUT),
+        not_owned_absent_inline: counters::get(counters::NOT_OWNED_ABSENT_INLINE),
+        not_owned_part_index: counters::get(counters::NOT_OWNED_PART_INDEX),
+        not_owned_local_row: counters::get(counters::NOT_OWNED_LOCAL_ROW),
+        corruption_outcomes: counters::get(counters::CORRUPTION_OUTCOMES),
+    }
+}
+
+#[cfg(any(test, feature = "storage-benches"))]
+pub(crate) fn record_direct_route_start(requested_rows: usize) {
+    read_accounting::add(read_accounting::DIRECT_ROUTE_CALLS, 1);
+    read_accounting::add(read_accounting::REQUESTED_ROWS, requested_rows);
+}
+
+#[cfg(any(test, feature = "storage-benches"))]
+pub(crate) fn record_direct_route_unique_rows(unique_rows: usize) {
+    read_accounting::add(read_accounting::UNIQUE_REQUESTED_ROWS, unique_rows);
+}
+
+#[cfg(any(test, feature = "storage-benches"))]
+pub(crate) fn record_direct_route_claimed_rows(claimed_rows: usize) {
+    read_accounting::add(read_accounting::CLAIMED_UNIQUE_ROWS, claimed_rows);
+}
+
+#[cfg(any(test, feature = "storage-benches"))]
+pub(crate) fn record_direct_route_scattered_rows(scattered_rows: usize) {
+    read_accounting::add(read_accounting::SCATTERED_ROWS, scattered_rows);
+}
+
+#[cfg(any(test, feature = "storage-benches"))]
+pub(crate) fn record_direct_route_explicit_fallback(rows: usize) {
+    read_accounting::add(read_accounting::EXPLICIT_FALLBACK_ROWS, rows);
+}
+
+#[cfg(any(test, feature = "storage-benches"))]
+pub(crate) fn record_direct_route_not_owned(reason: MutationDirectoryNotOwnedReason, rows: usize) {
+    let counter = match reason {
+        MutationDirectoryNotOwnedReason::UnsupportedLayout => {
+            read_accounting::NOT_OWNED_UNSUPPORTED_LAYOUT
+        }
+        MutationDirectoryNotOwnedReason::PartIndexOutOfRange => {
+            read_accounting::NOT_OWNED_PART_INDEX
+        }
+        MutationDirectoryNotOwnedReason::LocalRowOutOfRange => read_accounting::NOT_OWNED_LOCAL_ROW,
+    };
+    read_accounting::add(counter, rows);
+}
+
+#[cfg(any(test, feature = "storage-benches"))]
+pub(crate) fn record_direct_route_missing_commit(rows: usize) {
+    read_accounting::add(read_accounting::NOT_OWNED_MISSING_COMMIT, rows);
+}
+
+#[cfg(any(test, feature = "storage-benches"))]
+pub(crate) fn record_direct_route_absent_inline(rows: usize) {
+    read_accounting::add(read_accounting::NOT_OWNED_ABSENT_INLINE, rows);
+}
+
+#[cfg(any(test, feature = "storage-benches"))]
+pub(crate) fn record_direct_route_corruption() {
+    read_accounting::add(read_accounting::CORRUPTION_OUTCOMES, 1);
+}
+
+#[cfg(any(test, feature = "storage-benches"))]
+pub(crate) fn record_direct_external_parts_loaded(parts: usize) {
+    read_accounting::add(read_accounting::EXTERNAL_PARTS_LOADED, parts);
+}
+
+#[cfg(any(test, feature = "storage-benches"))]
+pub(crate) fn record_direct_part_decoded(rows: usize, raw_bytes: usize, resident_bytes: usize) {
+    read_accounting::add(read_accounting::PARTS_DECODED, 1);
+    read_accounting::add(read_accounting::DECODED_ROWS, rows);
+    read_accounting::add(read_accounting::RAW_BYTES, raw_bytes);
+    read_accounting::add(read_accounting::RESIDENT_BYTES, resident_bytes);
+}
+
+#[cfg(any(test, feature = "storage-benches"))]
+pub(crate) struct DirectRouteAccountingGuard {
+    complete: bool,
+}
+
+#[cfg(any(test, feature = "storage-benches"))]
+impl DirectRouteAccountingGuard {
+    pub(crate) fn new() -> Self {
+        Self { complete: false }
+    }
+
+    pub(crate) fn finish(&mut self) {
+        self.complete = true;
+    }
+}
+
+#[cfg(any(test, feature = "storage-benches"))]
+impl Drop for DirectRouteAccountingGuard {
+    fn drop(&mut self) {
+        if !self.complete {
+            record_direct_route_corruption();
+        }
+    }
+}
+
 pub(crate) const LAYOUT_BOUNDED_INDIRECT: u8 = 1;
 pub(crate) const LAYOUT_BOUNDED_DIRECT: u8 = 2;
 pub(crate) const LAYOUT_COMPACT_REPLACEMENT: u8 = 3;
@@ -106,10 +354,81 @@ pub(crate) struct MutationDirectoryDirectCoordinate {
 
 #[derive(Debug, Clone, Copy)]
 pub(crate) enum MutationDirectoryReadSelection<'a> {
-    All,
+    All(MutationDirectoryFullTraversalContext),
     SortedRanges(&'a [MutationDirectoryKeyRange]),
     SortedUniquePoints(&'a [Bytes]),
     SortedUniqueDirectCoordinates(&'a [MutationDirectoryDirectCoordinate]),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum MutationDirectoryFullTraversalContext {
+    BulkCommitStateManifests,
+    CompactMemberScan,
+    EmptySchemaMemberScan,
+    CompactValueScan,
+    EmptySchemaValueScan,
+    RepositoryInventory,
+    FullManifestExpansion,
+    #[cfg(test)]
+    Test,
+}
+
+#[cfg(any(test, feature = "storage-benches"))]
+fn record_full_traversal(context: MutationDirectoryFullTraversalContext, roots: usize) {
+    use read_accounting as counters;
+    counters::add(counters::SELECTOR_ALL_ROOTS, roots);
+    let counter = match context {
+        MutationDirectoryFullTraversalContext::BulkCommitStateManifests => {
+            counters::BULK_MANIFEST_ROOTS
+        }
+        MutationDirectoryFullTraversalContext::CompactMemberScan => counters::COMPACT_MEMBER_ROOTS,
+        MutationDirectoryFullTraversalContext::EmptySchemaMemberScan => {
+            counters::EMPTY_SCHEMA_MEMBER_ROOTS
+        }
+        MutationDirectoryFullTraversalContext::CompactValueScan => counters::COMPACT_VALUE_ROOTS,
+        MutationDirectoryFullTraversalContext::EmptySchemaValueScan => {
+            counters::EMPTY_SCHEMA_VALUE_ROOTS
+        }
+        MutationDirectoryFullTraversalContext::RepositoryInventory => {
+            counters::REPOSITORY_INVENTORY_ROOTS
+        }
+        MutationDirectoryFullTraversalContext::FullManifestExpansion => {
+            counters::FULL_MANIFEST_ROOTS
+        }
+        #[cfg(test)]
+        MutationDirectoryFullTraversalContext::Test => return,
+    };
+    counters::add(counter, roots);
+}
+
+#[cfg(any(test, feature = "storage-benches"))]
+fn record_selector(selection: MutationDirectoryReadSelection<'_>) {
+    use read_accounting as counters;
+    match selection {
+        MutationDirectoryReadSelection::All(context) => record_full_traversal(context, 1),
+        MutationDirectoryReadSelection::SortedRanges(_) => {
+            counters::add(counters::SELECTOR_RANGE_CALLS, 1);
+        }
+        MutationDirectoryReadSelection::SortedUniquePoints(_) => {
+            counters::add(counters::SELECTOR_POINT_CALLS, 1);
+        }
+        MutationDirectoryReadSelection::SortedUniqueDirectCoordinates(_) => {
+            counters::add(counters::SELECTOR_DIRECT_CALLS, 1);
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum MutationDirectoryNotOwnedReason {
+    UnsupportedLayout,
+    PartIndexOutOfRange,
+    LocalRowOutOfRange,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) struct MutationDirectoryNotOwnedSpan {
+    pub(crate) selector_span: Range<usize>,
+    pub(crate) reason: MutationDirectoryNotOwnedReason,
 }
 
 #[derive(Debug, PartialEq, Eq)]
@@ -122,6 +441,7 @@ pub(crate) struct MutationDirectoryPartRun {
 #[derive(Debug)]
 pub(crate) struct AuthenticatedMutationPartReadPlan {
     runs: Vec<MutationDirectoryPartRun>,
+    direct_not_owned: Vec<MutationDirectoryNotOwnedSpan>,
     #[cfg(test)]
     visited_node_count: usize,
     #[cfg(test)]
@@ -144,7 +464,17 @@ impl AuthenticatedMutationPartReadPlan {
     }
 
     pub(crate) fn into_runs(self) -> Vec<MutationDirectoryPartRun> {
+        debug_assert!(self.direct_not_owned.is_empty());
         self.runs
+    }
+
+    pub(crate) fn into_direct_routes(
+        self,
+    ) -> (
+        Vec<MutationDirectoryPartRun>,
+        Vec<MutationDirectoryNotOwnedSpan>,
+    ) {
+        (self.runs, self.direct_not_owned)
     }
 
     #[cfg(test)]
@@ -454,10 +784,26 @@ where
 pub(crate) async fn load_all_mutation_part_read_plans(
     store: &(impl StorageAdapterRead + ?Sized),
     roots: &[MutationDirectoryRoot],
+    context: MutationDirectoryFullTraversalContext,
 ) -> Result<Vec<AuthenticatedMutationPartReadPlan>, LixError> {
+    let valid_context = matches!(
+        context,
+        MutationDirectoryFullTraversalContext::BulkCommitStateManifests
+            | MutationDirectoryFullTraversalContext::RepositoryInventory
+    );
+    #[cfg(test)]
+    let valid_context =
+        valid_context || matches!(context, MutationDirectoryFullTraversalContext::Test);
+    if !valid_context {
+        return Err(directory_error(
+            "batched full traversal received a single-root context",
+        ));
+    }
     for root in roots {
         validate_root(root)?;
     }
+    #[cfg(any(test, feature = "storage-benches"))]
+    record_full_traversal(context, roots.len());
     let mut frontiers = roots
         .iter()
         .map(|root| vec![(root.root_id, 0u32, None::<NodeSummary>)])
@@ -475,6 +821,8 @@ pub(crate) async fn load_all_mutation_part_read_plans(
     #[cfg(test)]
     let mut part_clone_counts = vec![0usize; roots.len()];
     while frontiers.iter().any(|frontier| !frontier.is_empty()) {
+        #[cfg(any(test, feature = "storage-benches"))]
+        read_accounting::add(read_accounting::TRAVERSAL_LEVELS, 1);
         let mut node_ids = Vec::new();
         let mut use_counts = HashMap::<[u8; 32], usize>::new();
         for (node_id, _, _) in frontiers.iter().flatten() {
@@ -589,6 +937,11 @@ pub(crate) async fn load_all_mutation_part_read_plans(
             return Err(directory_error("directory closure disagrees with its root"));
         }
     }
+    #[cfg(any(test, feature = "storage-benches"))]
+    read_accounting::add(
+        read_accounting::EMITTED_RUNS,
+        outputs.iter().map(Vec::len).sum(),
+    );
     Ok(outputs
         .into_iter()
         .enumerate()
@@ -597,6 +950,7 @@ pub(crate) async fn load_all_mutation_part_read_plans(
             let _ = root_index;
             AuthenticatedMutationPartReadPlan {
                 runs,
+                direct_not_owned: Vec::new(),
                 #[cfg(test)]
                 visited_node_count: visited_node_counts[root_index],
                 #[cfg(test)]
@@ -622,12 +976,26 @@ pub(crate) async fn load_mutation_part_read_plan(
     root: &MutationDirectoryRoot,
     selection: MutationDirectoryReadSelection<'_>,
 ) -> Result<AuthenticatedMutationPartReadPlan, LixError> {
+    if matches!(
+        selection,
+        MutationDirectoryReadSelection::All(
+            MutationDirectoryFullTraversalContext::BulkCommitStateManifests
+                | MutationDirectoryFullTraversalContext::RepositoryInventory
+        )
+    ) {
+        return Err(directory_error(
+            "single-root full traversal received a batched context",
+        ));
+    }
     validate_root(root)?;
     validate_selection(root, selection)?;
+    #[cfg(any(test, feature = "storage-benches"))]
+    record_selector(selection);
     let selector_count = selection.len();
-    if !matches!(selection, MutationDirectoryReadSelection::All) && selector_count == 0 {
+    if !matches!(selection, MutationDirectoryReadSelection::All(_)) && selector_count == 0 {
         return Ok(AuthenticatedMutationPartReadPlan {
             runs: Vec::new(),
+            direct_not_owned: Vec::new(),
             #[cfg(test)]
             visited_node_count: 0,
             #[cfg(test)]
@@ -646,10 +1014,36 @@ pub(crate) async fn load_mutation_part_read_plan(
         expected: Option<NodeSummary>,
     }
 
+    let mut direct_not_owned = Vec::new();
+    let mut direct_coverage = Vec::<Range<usize>>::new();
+    let mut routed_selector_count = selector_count;
+    if let MutationDirectoryReadSelection::SortedUniqueDirectCoordinates(coordinates) = selection {
+        if root.layout == LAYOUT_BOUNDED_INDIRECT {
+            let selector_span = 0..selector_count;
+            return Ok(AuthenticatedMutationPartReadPlan {
+                runs: Vec::new(),
+                direct_not_owned: vec![MutationDirectoryNotOwnedSpan {
+                    selector_span,
+                    reason: MutationDirectoryNotOwnedReason::UnsupportedLayout,
+                }],
+                #[cfg(test)]
+                visited_node_count: 0,
+                #[cfg(test)]
+                node_summary_owner_count: 0,
+                #[cfg(test)]
+                node_summary_clone_count: 0,
+                #[cfg(test)]
+                part_clone_count: 0,
+            });
+        }
+        routed_selector_count =
+            coordinates.partition_point(|coordinate| coordinate.part_index < root.entry_count);
+    }
+
     let mut frontier = vec![PendingNode {
         node_id: root.root_id,
         base_index: 0,
-        selector_span: 0..selector_count,
+        selector_span: 0..routed_selector_count,
         expected: None,
     }];
     let mut runs = Vec::new();
@@ -659,6 +1053,8 @@ pub(crate) async fn load_mutation_part_read_plan(
     let mut node_summary_owner_count = 0usize;
 
     while !frontier.is_empty() {
+        #[cfg(any(test, feature = "storage-benches"))]
+        read_accounting::add(read_accounting::TRAVERSAL_LEVELS, 1);
         let node_ids = frontier
             .iter()
             .map(|pending| pending.node_id)
@@ -701,9 +1097,38 @@ pub(crate) async fn load_mutation_part_read_plan(
                             entry_end,
                             Some(stored_entry_direct_rows(&entry)),
                         )?;
-                        let Some(selector_span) = selector_span else {
+                        let Some(mut selector_span) = selector_span else {
                             continue;
                         };
+                        if let MutationDirectoryReadSelection::SortedUniqueDirectCoordinates(
+                            coordinates,
+                        ) = selection
+                        {
+                            let owned_end = selector_span.start
+                                + coordinates[selector_span.clone()].partition_point(
+                                    |coordinate| {
+                                        coordinate.local_row < stored_entry_direct_rows(&entry)
+                                    },
+                                );
+                            if selector_span.start < owned_end {
+                                let owned_span = selector_span.start..owned_end;
+                                direct_coverage.push(owned_span.clone());
+                                runs.push(MutationDirectoryPartRun {
+                                    entry_index,
+                                    selector_span: owned_span,
+                                    entry: runtime_entry(entry)?,
+                                });
+                            }
+                            if owned_end < selector_span.end {
+                                selector_span.start = owned_end;
+                                direct_coverage.push(selector_span.clone());
+                                direct_not_owned.push(MutationDirectoryNotOwnedSpan {
+                                    selector_span,
+                                    reason: MutationDirectoryNotOwnedReason::LocalRowOutOfRange,
+                                });
+                            }
+                            continue;
+                        }
                         runs.push(MutationDirectoryPartRun {
                             entry_index,
                             selector_span,
@@ -755,6 +1180,14 @@ pub(crate) async fn load_mutation_part_read_plan(
         }
         frontier = next;
     }
+    if routed_selector_count < selector_count {
+        let selector_span = routed_selector_count..selector_count;
+        direct_coverage.push(selector_span.clone());
+        direct_not_owned.push(MutationDirectoryNotOwnedSpan {
+            selector_span,
+            reason: MutationDirectoryNotOwnedReason::PartIndexOutOfRange,
+        });
+    }
     if runs.windows(2).any(|pair| {
         pair[0].entry_index >= pair[1].entry_index
             || pair[0].selector_span.start > pair[1].selector_span.start
@@ -766,20 +1199,25 @@ pub(crate) async fn load_mutation_part_read_plan(
     if matches!(
         selection,
         MutationDirectoryReadSelection::SortedUniqueDirectCoordinates(_)
-    ) && (runs.first().is_none_or(|run| run.selector_span.start != 0)
-        || runs
+    ) && (direct_coverage
+        .first()
+        .is_none_or(|selector_span| selector_span.start != 0)
+        || direct_coverage
             .windows(2)
-            .any(|pair| pair[0].selector_span.end != pair[1].selector_span.start)
-        || runs
+            .any(|pair| pair[0].end != pair[1].start)
+        || direct_coverage
             .last()
-            .is_none_or(|run| run.selector_span.end != selector_count))
+            .is_none_or(|selector_span| selector_span.end != selector_count))
     {
         return Err(directory_error(
             "direct-coordinate read-plan output does not cover every selector",
         ));
     }
+    #[cfg(any(test, feature = "storage-benches"))]
+    read_accounting::add(read_accounting::EMITTED_RUNS, runs.len());
     Ok(AuthenticatedMutationPartReadPlan {
         runs,
+        direct_not_owned,
         #[cfg(test)]
         visited_node_count,
         #[cfg(test)]
@@ -794,7 +1232,7 @@ pub(crate) async fn load_mutation_part_read_plan(
 impl MutationDirectoryReadSelection<'_> {
     fn len(self) -> usize {
         match self {
-            Self::All => 0,
+            Self::All(_) => 0,
             Self::SortedRanges(ranges) => ranges.len(),
             Self::SortedUniquePoints(points) => points.len(),
             Self::SortedUniqueDirectCoordinates(coordinates) => coordinates.len(),
@@ -807,7 +1245,7 @@ fn validate_selection(
     selection: MutationDirectoryReadSelection<'_>,
 ) -> Result<(), LixError> {
     match selection {
-        MutationDirectoryReadSelection::All => Ok(()),
+        MutationDirectoryReadSelection::All(_) => Ok(()),
         MutationDirectoryReadSelection::SortedUniquePoints(points) => {
             if !is_bounded(root.layout) {
                 return Err(directory_error(
@@ -858,22 +1296,9 @@ fn validate_selection(
             if coordinates.is_empty() {
                 return Ok(());
             }
-            if root.direct_row_count == 0 {
-                return Err(directory_error(
-                    "direct-coordinate selection requires direct-row authority",
-                ));
-            }
             if coordinates.windows(2).any(|pair| pair[0] >= pair[1]) {
                 return Err(directory_error(
                     "direct-coordinate selection must be strictly sorted and unique",
-                ));
-            }
-            if coordinates
-                .last()
-                .is_some_and(|coordinate| coordinate.part_index >= root.entry_count)
-            {
-                return Err(directory_error(
-                    "direct-coordinate selection exceeds part authority",
                 ));
             }
             Ok(())
@@ -892,7 +1317,7 @@ fn selection_span_for_entry(
     direct_row_count: Option<u16>,
 ) -> Result<Option<Range<usize>>, LixError> {
     match selection {
-        MutationDirectoryReadSelection::All => Ok(Some(0..0)),
+        MutationDirectoryReadSelection::All(_) => Ok(Some(0..0)),
         MutationDirectoryReadSelection::SortedUniquePoints(points) => {
             while *cursor < selector_end && points[*cursor].as_ref() < first_key {
                 *cursor += 1;
@@ -927,15 +1352,7 @@ fn selection_span_for_entry(
             while *cursor < selector_end && coordinates[*cursor].part_index < entry_end {
                 *cursor += 1;
             }
-            if let Some(direct_row_count) = direct_row_count
-                && coordinates[start..*cursor]
-                    .iter()
-                    .any(|coordinate| coordinate.local_row >= direct_row_count)
-            {
-                return Err(directory_error(
-                    "direct coordinate exceeds authenticated part row count",
-                ));
-            }
+            let _ = direct_row_count;
             Ok((start < *cursor).then_some(start..*cursor))
         }
     }
@@ -946,6 +1363,8 @@ pub(crate) async fn collect_mutation_directory_node_ids(
     root: &MutationDirectoryRoot,
 ) -> Result<BTreeSet<[u8; 32]>, LixError> {
     validate_root(root)?;
+    #[cfg(any(test, feature = "storage-benches"))]
+    read_accounting::add(read_accounting::GC_REACHABILITY_ROOTS, 1);
     let mut reachable = BTreeSet::new();
     let mut frontier = vec![(root.root_id, None::<NodeSummary>)];
     while !frontier.is_empty() {
@@ -1034,11 +1453,20 @@ async fn load_nodes(
     } else {
         PointReadPlan::new(MUTATION_DIRECTORY_NODE_SPACE, &keys)
     };
+    #[cfg(any(test, feature = "storage-benches"))]
+    {
+        read_accounting::add(read_accounting::NODE_BATCHES, 1);
+        read_accounting::add(
+            read_accounting::UNIQUE_NODE_IDS,
+            plan.logical_unique_keys.len(),
+        );
+        read_accounting::add(read_accounting::NODE_GETS, plan.logical_unique_keys.len());
+    }
     let values = plan
         .materialize(store, StorageGetOptions::default())
         .await?
         .value;
-    node_ids
+    let nodes = node_ids
         .iter()
         .zip(values)
         .map(|(node_id, value)| {
@@ -1051,7 +1479,10 @@ async fn load_nodes(
             }
             decode_node(&bytes)
         })
-        .collect()
+        .collect::<Result<Vec<_>, _>>()?;
+    #[cfg(any(test, feature = "storage-benches"))]
+    read_accounting::add(read_accounting::VISITED_NODES, nodes.len());
+    Ok(nodes)
 }
 
 fn stage_encoded_node(
@@ -1623,10 +2054,13 @@ mod tests {
         assert!(built.node_bytes().len() > 1);
         let (_storage, read) = stored_directory(&built).await;
 
-        let all =
-            load_mutation_part_read_plan(&read, &built.root, MutationDirectoryReadSelection::All)
-                .await
-                .unwrap();
+        let all = load_mutation_part_read_plan(
+            &read,
+            &built.root,
+            MutationDirectoryReadSelection::All(MutationDirectoryFullTraversalContext::Test),
+        )
+        .await
+        .unwrap();
         assert_eq!(all.len(), entries.len());
         assert_eq!(all.visited_node_count(), built.node_bytes().len());
         assert_eq!(all.node_summary_owner_count() + 1, all.visited_node_count());
@@ -1812,10 +2246,13 @@ mod tests {
             vec![(0, 0..1), (1, 0..1), (2, 0..1)]
         );
 
-        let batched =
-            load_all_mutation_part_read_plans(&read, &[built.root.clone(), built.root.clone()])
-                .await
-                .unwrap();
+        let batched = load_all_mutation_part_read_plans(
+            &read,
+            &[built.root.clone(), built.root.clone()],
+            MutationDirectoryFullTraversalContext::Test,
+        )
+        .await
+        .unwrap();
         assert_eq!(batched.len(), 2);
         assert!(batched.iter().all(|plan| plan.len() == entries.len()));
         assert!(batched.iter().all(|plan| {
@@ -1865,7 +2302,7 @@ mod tests {
             runs.iter().map(|run| run.entry_index).collect::<Vec<_>>(),
             vec![0, 1, 2]
         );
-        let error = load_mutation_part_read_plan(
+        let (_runs, not_owned) = load_mutation_part_read_plan(
             &read,
             &built.root,
             MutationDirectoryReadSelection::SortedUniqueDirectCoordinates(&[
@@ -1876,8 +2313,15 @@ mod tests {
             ]),
         )
         .await
-        .expect_err("a physical hole must not become a dense ordinal");
-        assert!(error.to_string().contains("part row count"));
+        .expect("a physical hole is an authenticated unowned slot")
+        .into_direct_routes();
+        assert_eq!(
+            not_owned,
+            vec![MutationDirectoryNotOwnedSpan {
+                selector_span: 0..1,
+                reason: MutationDirectoryNotOwnedReason::LocalRowOutOfRange,
+            }]
+        );
 
         let entries = (0..(FANOUT * FANOUT + 1))
             .map(|_| MutationDirectoryEntry::DirectAddress {
@@ -2018,7 +2462,7 @@ mod tests {
             .expect_err("noncanonical direct coordinates must fail");
             assert!(error.to_string().contains("strictly sorted and unique"));
         }
-        let error = load_mutation_part_read_plan(
+        let (_runs, not_owned) = load_mutation_part_read_plan(
             &read,
             &built.root,
             MutationDirectoryReadSelection::SortedUniqueDirectCoordinates(&[
@@ -2029,9 +2473,16 @@ mod tests {
             ]),
         )
         .await
-        .expect_err("out-of-range part coordinates must fail");
-        assert!(error.to_string().contains("exceeds part authority"));
-        let error = load_mutation_part_read_plan(
+        .expect("out-of-range part coordinates are authenticated unowned slots")
+        .into_direct_routes();
+        assert_eq!(
+            not_owned,
+            vec![MutationDirectoryNotOwnedSpan {
+                selector_span: 0..1,
+                reason: MutationDirectoryNotOwnedReason::PartIndexOutOfRange,
+            }]
+        );
+        let (_runs, not_owned) = load_mutation_part_read_plan(
             &read,
             &built.root,
             MutationDirectoryReadSelection::SortedUniqueDirectCoordinates(&[
@@ -2042,8 +2493,15 @@ mod tests {
             ]),
         )
         .await
-        .expect_err("out-of-range local rows must fail");
-        assert!(error.to_string().contains("part row count"));
+        .expect("out-of-range local rows are authenticated unowned slots")
+        .into_direct_routes();
+        assert_eq!(
+            not_owned,
+            vec![MutationDirectoryNotOwnedSpan {
+                selector_span: 0..1,
+                reason: MutationDirectoryNotOwnedReason::LocalRowOutOfRange,
+            }]
+        );
         let empty_coordinates = load_mutation_part_read_plan(
             &read,
             &built.root,
@@ -2115,7 +2573,7 @@ mod tests {
             local_row: 0,
         }];
         for selection in [
-            MutationDirectoryReadSelection::All,
+            MutationDirectoryReadSelection::All(MutationDirectoryFullTraversalContext::Test),
             MutationDirectoryReadSelection::SortedRanges(&ranges),
             MutationDirectoryReadSelection::SortedUniquePoints(std::slice::from_ref(&point)),
             MutationDirectoryReadSelection::SortedUniqueDirectCoordinates(&coordinate),
@@ -2135,10 +2593,13 @@ mod tests {
             bad_count.tree_height,
             bad_count.layout,
         );
-        let error =
-            load_mutation_part_read_plan(&read, &bad_count, MutationDirectoryReadSelection::All)
-                .await
-                .expect_err("root counts must agree with authenticated nodes");
+        let error = load_mutation_part_read_plan(
+            &read,
+            &bad_count,
+            MutationDirectoryReadSelection::All(MutationDirectoryFullTraversalContext::Test),
+        )
+        .await
+        .expect_err("root counts must agree with authenticated nodes");
         assert!(error.to_string().contains("root summary mismatch"));
     }
 
@@ -2155,7 +2616,7 @@ mod tests {
         let error = load_mutation_part_read_plan(
             &missing_read,
             &built.root,
-            MutationDirectoryReadSelection::All,
+            MutationDirectoryReadSelection::All(MutationDirectoryFullTraversalContext::Test),
         )
         .await
         .expect_err("a missing authenticated node must fail");
@@ -2183,7 +2644,7 @@ mod tests {
         let error = load_mutation_part_read_plan(
             &digest_read,
             &built.root,
-            MutationDirectoryReadSelection::All,
+            MutationDirectoryReadSelection::All(MutationDirectoryFullTraversalContext::Test),
         )
         .await
         .expect_err("content bytes must match their immutable node id");

--- a/packages/engine/src/tracked_state/mutation_directory.rs
+++ b/packages/engine/src/tracked_state/mutation_directory.rs
@@ -108,7 +108,20 @@ pub(crate) mod test_read_accounting {
 
     #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
     pub(crate) struct ScopedMutationDirectoryReadAccounting {
+        pub(crate) direct_route_calls: u64,
         pub(crate) selector_all_roots: u64,
+        pub(crate) selector_direct_calls: u64,
+        pub(crate) external_parts_loaded: u64,
+        pub(crate) parts_decoded: u64,
+        pub(crate) decoded_rows: u64,
+        pub(crate) raw_bytes: u64,
+        pub(crate) resident_bytes: u64,
+        pub(crate) explicit_fallback_rows: u64,
+        pub(crate) not_owned_missing_commit: u64,
+        pub(crate) not_owned_unsupported_layout: u64,
+        pub(crate) not_owned_absent_inline: u64,
+        pub(crate) not_owned_part_index: u64,
+        pub(crate) not_owned_local_row: u64,
     }
 
     tokio::task_local! {
@@ -127,10 +140,80 @@ pub(crate) mod test_read_accounting {
         (output, accounting)
     }
 
-    pub(crate) fn record_selector_all_roots(roots: usize) {
+    fn update(update: impl FnOnce(&mut ScopedMutationDirectoryReadAccounting)) {
         let _ = ACTIVE.try_with(|state| {
-            let mut state = state.borrow_mut();
+            update(&mut state.borrow_mut());
+        });
+    }
+
+    pub(crate) fn record_direct_route_start() {
+        update(|state| state.direct_route_calls = state.direct_route_calls.saturating_add(1));
+    }
+
+    pub(crate) fn record_selector_all_roots(roots: usize) {
+        update(|state| {
             state.selector_all_roots = state.selector_all_roots.saturating_add(roots as u64);
+        });
+    }
+
+    pub(crate) fn record_selector_direct() {
+        update(|state| {
+            state.selector_direct_calls = state.selector_direct_calls.saturating_add(1);
+        });
+    }
+
+    pub(crate) fn record_external_parts_loaded(parts: usize) {
+        update(|state| {
+            state.external_parts_loaded = state.external_parts_loaded.saturating_add(parts as u64);
+        });
+    }
+
+    pub(crate) fn record_part_decoded(rows: usize, raw_bytes: usize, resident_bytes: usize) {
+        update(|state| {
+            state.parts_decoded = state.parts_decoded.saturating_add(1);
+            state.decoded_rows = state.decoded_rows.saturating_add(rows as u64);
+            state.raw_bytes = state.raw_bytes.saturating_add(raw_bytes as u64);
+            state.resident_bytes = state.resident_bytes.saturating_add(resident_bytes as u64);
+        });
+    }
+
+    pub(crate) fn record_explicit_fallback(rows: usize) {
+        update(|state| {
+            state.explicit_fallback_rows = state.explicit_fallback_rows.saturating_add(rows as u64);
+        });
+    }
+
+    pub(crate) fn record_not_owned_missing_commit(rows: usize) {
+        update(|state| {
+            state.not_owned_missing_commit =
+                state.not_owned_missing_commit.saturating_add(rows as u64);
+        });
+    }
+
+    pub(crate) fn record_not_owned_unsupported_layout(rows: usize) {
+        update(|state| {
+            state.not_owned_unsupported_layout = state
+                .not_owned_unsupported_layout
+                .saturating_add(rows as u64);
+        });
+    }
+
+    pub(crate) fn record_not_owned_absent_inline(rows: usize) {
+        update(|state| {
+            state.not_owned_absent_inline =
+                state.not_owned_absent_inline.saturating_add(rows as u64);
+        });
+    }
+
+    pub(crate) fn record_not_owned_part_index(rows: usize) {
+        update(|state| {
+            state.not_owned_part_index = state.not_owned_part_index.saturating_add(rows as u64);
+        });
+    }
+
+    pub(crate) fn record_not_owned_local_row(rows: usize) {
+        update(|state| {
+            state.not_owned_local_row = state.not_owned_local_row.saturating_add(rows as u64);
         });
     }
 }
@@ -227,6 +310,8 @@ pub(crate) fn snapshot_mutation_directory_read_accounting() -> MutationDirectory
 pub(crate) fn record_direct_route_start(requested_rows: usize) {
     read_accounting::add(read_accounting::DIRECT_ROUTE_CALLS, 1);
     read_accounting::add(read_accounting::REQUESTED_ROWS, requested_rows);
+    #[cfg(test)]
+    test_read_accounting::record_direct_route_start();
 }
 
 #[cfg(any(test, feature = "storage-benches"))]
@@ -247,6 +332,8 @@ pub(crate) fn record_direct_route_scattered_rows(scattered_rows: usize) {
 #[cfg(any(test, feature = "storage-benches"))]
 pub(crate) fn record_direct_route_explicit_fallback(rows: usize) {
     read_accounting::add(read_accounting::EXPLICIT_FALLBACK_ROWS, rows);
+    #[cfg(test)]
+    test_read_accounting::record_explicit_fallback(rows);
 }
 
 #[cfg(any(test, feature = "storage-benches"))]
@@ -261,16 +348,32 @@ pub(crate) fn record_direct_route_not_owned(reason: MutationDirectoryNotOwnedRea
         MutationDirectoryNotOwnedReason::LocalRowOutOfRange => read_accounting::NOT_OWNED_LOCAL_ROW,
     };
     read_accounting::add(counter, rows);
+    #[cfg(test)]
+    match reason {
+        MutationDirectoryNotOwnedReason::UnsupportedLayout => {
+            test_read_accounting::record_not_owned_unsupported_layout(rows)
+        }
+        MutationDirectoryNotOwnedReason::PartIndexOutOfRange => {
+            test_read_accounting::record_not_owned_part_index(rows)
+        }
+        MutationDirectoryNotOwnedReason::LocalRowOutOfRange => {
+            test_read_accounting::record_not_owned_local_row(rows)
+        }
+    }
 }
 
 #[cfg(any(test, feature = "storage-benches"))]
 pub(crate) fn record_direct_route_missing_commit(rows: usize) {
     read_accounting::add(read_accounting::NOT_OWNED_MISSING_COMMIT, rows);
+    #[cfg(test)]
+    test_read_accounting::record_not_owned_missing_commit(rows);
 }
 
 #[cfg(any(test, feature = "storage-benches"))]
 pub(crate) fn record_direct_route_absent_inline(rows: usize) {
     read_accounting::add(read_accounting::NOT_OWNED_ABSENT_INLINE, rows);
+    #[cfg(test)]
+    test_read_accounting::record_not_owned_absent_inline(rows);
 }
 
 #[cfg(any(test, feature = "storage-benches"))]
@@ -281,6 +384,8 @@ pub(crate) fn record_direct_route_corruption() {
 #[cfg(any(test, feature = "storage-benches"))]
 pub(crate) fn record_direct_external_parts_loaded(parts: usize) {
     read_accounting::add(read_accounting::EXTERNAL_PARTS_LOADED, parts);
+    #[cfg(test)]
+    test_read_accounting::record_external_parts_loaded(parts);
 }
 
 #[cfg(any(test, feature = "storage-benches"))]
@@ -289,6 +394,8 @@ pub(crate) fn record_direct_part_decoded(rows: usize, raw_bytes: usize, resident
     read_accounting::add(read_accounting::DECODED_ROWS, rows);
     read_accounting::add(read_accounting::RAW_BYTES, raw_bytes);
     read_accounting::add(read_accounting::RESIDENT_BYTES, resident_bytes);
+    #[cfg(test)]
+    test_read_accounting::record_part_decoded(rows, raw_bytes, resident_bytes);
 }
 
 #[cfg(any(test, feature = "storage-benches"))]
@@ -455,6 +562,8 @@ fn record_selector(selection: MutationDirectoryReadSelection<'_>) {
         }
         MutationDirectoryReadSelection::SortedUniqueDirectCoordinates(_) => {
             counters::add(counters::SELECTOR_DIRECT_CALLS, 1);
+            #[cfg(test)]
+            test_read_accounting::record_selector_direct();
         }
     }
 }

--- a/packages/engine/src/tracked_state/mutation_directory.rs
+++ b/packages/engine/src/tracked_state/mutation_directory.rs
@@ -1,0 +1,1164 @@
+//! Authenticated immutable directory for commit mutation parts.
+//!
+//! Commit headers authenticate a small catalog, and that catalog authenticates
+//! one root from this tree. Part bounds, compact replacement identities, and
+//! direct-address row counts live only in leaves. Metadata-only operations can
+//! therefore stop at the header while point routing reads one node per level.
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use bytes::Bytes;
+
+use crate::storage_adapter::{
+    PointReadPlan, StorageAdapterRead, StorageGetOptions, StorageKey, StorageProjectedValue,
+    StorageSpace, StorageSpaceId, StorageValue, StorageWriteSet,
+};
+use crate::{LixError, storage_codec};
+
+use super::types::CommitStateMutationPart;
+
+pub(crate) const MUTATION_DIRECTORY_NODE_SPACE: StorageSpace = StorageSpace::immutable(
+    StorageSpaceId(0x0004_002d),
+    "tracked_state.commit_mutation_directory_node.v1",
+);
+
+const NODE_MAGIC: &[u8] = b"LXMD1";
+const NODE_HASH_CONTEXT: &str = "lix commit mutation directory node v1";
+const ROOT_HASH_CONTEXT: &str = "lix commit mutation directory root v1";
+const FANOUT: usize = 128;
+const MAX_NODE_BYTES: usize = 16 * 1024 * 1024;
+
+pub(crate) const LAYOUT_BOUNDED_INDIRECT: u8 = 1;
+pub(crate) const LAYOUT_BOUNDED_DIRECT: u8 = 2;
+pub(crate) const LAYOUT_COMPACT_REPLACEMENT: u8 = 3;
+pub(crate) const LAYOUT_DIRECT_ROWS_ONLY: u8 = 4;
+
+#[derive(Debug, Clone, PartialEq, Eq, musli::Encode, musli::Decode)]
+#[musli(packed)]
+pub(crate) struct MutationDirectoryRoot {
+    pub(crate) root_id: [u8; 32],
+    pub(crate) root_digest: [u8; 32],
+    pub(crate) entry_count: u32,
+    pub(crate) direct_row_count: u64,
+    pub(crate) tree_height: u16,
+    pub(crate) layout: u8,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum MutationDirectoryEntry {
+    Bounded {
+        part: CommitStateMutationPart,
+        direct_row_count: u16,
+    },
+    CompactReplacement {
+        content_digest: [u8; 32],
+        direct_row_count: u16,
+    },
+    DirectAddress {
+        direct_row_count: u16,
+    },
+}
+
+impl MutationDirectoryEntry {
+    fn direct_row_count(&self) -> u16 {
+        match self {
+            Self::Bounded {
+                direct_row_count, ..
+            }
+            | Self::CompactReplacement {
+                direct_row_count, ..
+            }
+            | Self::DirectAddress { direct_row_count } => *direct_row_count,
+        }
+    }
+
+    fn first_key(&self) -> &[u8] {
+        match self {
+            Self::Bounded { part, .. } => &part.first_key,
+            Self::CompactReplacement { .. } => &[],
+            Self::DirectAddress { .. } => &[],
+        }
+    }
+
+    fn last_key(&self) -> &[u8] {
+        match self {
+            Self::Bounded { part, .. } => &part.last_key,
+            Self::CompactReplacement { .. } => &[],
+            Self::DirectAddress { .. } => &[],
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct MutationDirectoryRoute {
+    pub(crate) entry_index: u32,
+    pub(crate) part: CommitStateMutationPart,
+    pub(crate) direct_row_count: u16,
+}
+
+#[derive(Debug)]
+pub(crate) struct BuiltMutationDirectory {
+    pub(crate) root: MutationDirectoryRoot,
+    nodes: BTreeMap<[u8; 32], Bytes>,
+}
+
+impl BuiltMutationDirectory {
+    pub(crate) fn stage(&self, writes: &mut StorageWriteSet) -> Result<(), LixError> {
+        for (node_id, bytes) in &self.nodes {
+            if let Some(existing) = writes.staged_value(MUTATION_DIRECTORY_NODE_SPACE, node_id) {
+                if existing != *bytes {
+                    return Err(directory_error("content ID has conflicting staged bytes"));
+                }
+                continue;
+            }
+            writes.put(
+                MUTATION_DIRECTORY_NODE_SPACE,
+                StorageKey(Bytes::copy_from_slice(node_id)),
+                StorageValue {
+                    bytes: bytes.clone(),
+                },
+            );
+        }
+        Ok(())
+    }
+
+    pub(crate) fn node_bytes(&self) -> &BTreeMap<[u8; 32], Bytes> {
+        &self.nodes
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, musli::Encode, musli::Decode)]
+enum StoredEntry {
+    Bounded {
+        #[musli(bytes)]
+        first_key: Vec<u8>,
+        #[musli(bytes)]
+        last_key: Vec<u8>,
+        #[musli(with = storage_codec::option)]
+        replacement_part: Option<super::types::StoredReplacementPart>,
+        direct_row_count: u16,
+    },
+    CompactReplacement {
+        content_digest: [u8; 32],
+        direct_row_count: u16,
+    },
+    DirectAddress {
+        direct_row_count: u16,
+    },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, musli::Encode, musli::Decode)]
+#[musli(packed)]
+struct StoredChild {
+    #[musli(bytes)]
+    first_key: Vec<u8>,
+    #[musli(bytes)]
+    last_key: Vec<u8>,
+    node_id: [u8; 32],
+    entry_count: u32,
+    direct_row_count: u64,
+    level: u16,
+    layout: u8,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, musli::Encode, musli::Decode)]
+enum StoredNode {
+    Leaf {
+        layout: u8,
+        entries: Vec<StoredEntry>,
+    },
+    Internal {
+        layout: u8,
+        level: u16,
+        children: Vec<StoredChild>,
+    },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct NodeSummary {
+    first_key: Vec<u8>,
+    last_key: Vec<u8>,
+    node_id: [u8; 32],
+    entry_count: u32,
+    direct_row_count: u64,
+    level: u16,
+    layout: u8,
+}
+
+impl From<&NodeSummary> for StoredChild {
+    fn from(summary: &NodeSummary) -> Self {
+        Self {
+            first_key: summary.first_key.clone(),
+            last_key: summary.last_key.clone(),
+            node_id: summary.node_id,
+            entry_count: summary.entry_count,
+            direct_row_count: summary.direct_row_count,
+            level: summary.level,
+            layout: summary.layout,
+        }
+    }
+}
+
+impl From<&StoredChild> for NodeSummary {
+    fn from(child: &StoredChild) -> Self {
+        Self {
+            first_key: child.first_key.clone(),
+            last_key: child.last_key.clone(),
+            node_id: child.node_id,
+            entry_count: child.entry_count,
+            direct_row_count: child.direct_row_count,
+            level: child.level,
+            layout: child.layout,
+        }
+    }
+}
+
+#[cfg(test)]
+pub(crate) fn build_mutation_directory(
+    layout: u8,
+    entries: &[MutationDirectoryEntry],
+) -> Result<BuiltMutationDirectory, LixError> {
+    validate_entries(layout, entries)?;
+    build_stored_mutation_directory(layout, entries.iter().map(stored_entry).collect())
+}
+
+pub(crate) fn build_bounded_mutation_directory(
+    parts: &[CommitStateMutationPart],
+    direct_row_counts: Option<&[u16]>,
+) -> Result<BuiltMutationDirectory, LixError> {
+    if direct_row_counts.is_some_and(|rows| rows.len() != parts.len()) {
+        return Err(directory_error(
+            "bounded direct-row counts do not match part count",
+        ));
+    }
+    let layout = if direct_row_counts.is_some() {
+        LAYOUT_BOUNDED_DIRECT
+    } else {
+        LAYOUT_BOUNDED_INDIRECT
+    };
+    let entries = parts
+        .iter()
+        .enumerate()
+        .map(|(index, part)| StoredEntry::Bounded {
+            first_key: part.first_key.clone(),
+            last_key: part.last_key.clone(),
+            replacement_part: part.replacement_part.clone(),
+            direct_row_count: direct_row_counts.map_or(0, |rows| rows[index]),
+        })
+        .collect();
+    build_stored_mutation_directory(layout, entries)
+}
+
+pub(crate) fn build_compact_replacement_mutation_directory(
+    content_digests: &[[u8; 32]],
+    direct_row_counts: &[u16],
+) -> Result<BuiltMutationDirectory, LixError> {
+    if content_digests.len() != direct_row_counts.len() {
+        return Err(directory_error(
+            "compact replacement counts do not match digest count",
+        ));
+    }
+    build_stored_mutation_directory(
+        LAYOUT_COMPACT_REPLACEMENT,
+        content_digests
+            .iter()
+            .copied()
+            .zip(direct_row_counts.iter().copied())
+            .map(
+                |(content_digest, direct_row_count)| StoredEntry::CompactReplacement {
+                    content_digest,
+                    direct_row_count,
+                },
+            )
+            .collect(),
+    )
+}
+
+pub(crate) fn build_direct_rows_mutation_directory(
+    direct_row_counts: &[u16],
+) -> Result<BuiltMutationDirectory, LixError> {
+    build_stored_mutation_directory(
+        LAYOUT_DIRECT_ROWS_ONLY,
+        direct_row_counts
+            .iter()
+            .copied()
+            .map(|direct_row_count| StoredEntry::DirectAddress { direct_row_count })
+            .collect(),
+    )
+}
+
+fn build_stored_mutation_directory(
+    layout: u8,
+    entries: Vec<StoredEntry>,
+) -> Result<BuiltMutationDirectory, LixError> {
+    validate_stored_entries(layout, &entries)?;
+    if entries.is_empty() {
+        return Err(directory_error("cannot build an empty directory"));
+    }
+    let mut nodes = BTreeMap::new();
+    let mut entries = entries.into_iter();
+    let mut level = balanced_chunk_lengths(entries.len())
+        .map(|chunk_len| {
+            let stored = StoredNode::Leaf {
+                layout,
+                entries: entries.by_ref().take(chunk_len).collect(),
+            };
+            stage_encoded_node(&mut nodes, stored)
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+    debug_assert!(entries.next().is_none());
+    let mut tree_height = 1u16;
+    while level.len() > 1 {
+        level = balanced_chunks(&level)
+            .into_iter()
+            .map(|chunk| {
+                let child_level = chunk[0].level;
+                let stored = StoredNode::Internal {
+                    layout,
+                    level: child_level
+                        .checked_add(1)
+                        .ok_or_else(|| directory_error("tree height overflows"))?,
+                    children: chunk.iter().map(StoredChild::from).collect(),
+                };
+                stage_encoded_node(&mut nodes, stored)
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+        tree_height = tree_height
+            .checked_add(1)
+            .ok_or_else(|| directory_error("tree height overflows"))?;
+    }
+    let summary = level.pop().expect("non-empty directory has a root");
+    let root = MutationDirectoryRoot {
+        root_id: summary.node_id,
+        root_digest: root_digest(
+            summary.node_id,
+            summary.entry_count,
+            summary.direct_row_count,
+            tree_height,
+            layout,
+        ),
+        entry_count: summary.entry_count,
+        direct_row_count: summary.direct_row_count,
+        tree_height,
+        layout,
+    };
+    validate_root(&root)?;
+    Ok(BuiltMutationDirectory { root, nodes })
+}
+
+pub(crate) async fn load_mutation_directory(
+    store: &(impl StorageAdapterRead + ?Sized),
+    root: &MutationDirectoryRoot,
+) -> Result<Vec<MutationDirectoryEntry>, LixError> {
+    Ok(load_mutation_directories(store, std::slice::from_ref(root))
+        .await?
+        .pop()
+        .expect("one requested directory returns one result"))
+}
+
+/// Loads many authenticated roots level-by-level. Shared nodes and same-level
+/// frontiers issue one physical point-read batch instead of one request chain
+/// per commit.
+pub(crate) async fn load_mutation_directories(
+    store: &(impl StorageAdapterRead + ?Sized),
+    roots: &[MutationDirectoryRoot],
+) -> Result<Vec<Vec<MutationDirectoryEntry>>, LixError> {
+    for root in roots {
+        validate_root(root)?;
+    }
+    let mut frontiers = roots
+        .iter()
+        .map(|root| vec![(root.root_id, None::<NodeSummary>)])
+        .collect::<Vec<_>>();
+    let mut outputs = roots
+        .iter()
+        .map(|root| Vec::with_capacity(root.entry_count as usize))
+        .collect::<Vec<_>>();
+    while frontiers.iter().any(|frontier| !frontier.is_empty()) {
+        let node_ids = frontiers
+            .iter()
+            .flatten()
+            .map(|(node_id, _)| *node_id)
+            .collect::<BTreeSet<_>>()
+            .into_iter()
+            .collect::<Vec<_>>();
+        let loaded = node_ids
+            .iter()
+            .copied()
+            .zip(load_nodes(store, &node_ids).await?)
+            .collect::<BTreeMap<_, _>>();
+        for (root_index, frontier) in frontiers.iter_mut().enumerate() {
+            let mut next = Vec::new();
+            for (node_id, expected) in std::mem::take(frontier) {
+                let (node, summary) = loaded
+                    .get(&node_id)
+                    .ok_or_else(|| directory_error("directory batch omitted a node"))?;
+                match expected {
+                    Some(expected) if expected != *summary => {
+                        return Err(directory_error("child summary mismatch"));
+                    }
+                    None if !summary_matches_root(summary, &roots[root_index]) => {
+                        return Err(directory_error("root summary mismatch"));
+                    }
+                    _ => {}
+                }
+                match node {
+                    StoredNode::Leaf { entries, .. } => outputs[root_index].extend(
+                        entries
+                            .iter()
+                            .cloned()
+                            .map(runtime_entry)
+                            .collect::<Result<Vec<_>, _>>()?,
+                    ),
+                    StoredNode::Internal { children, .. } => {
+                        next.extend(children.iter().map(|child| {
+                            let summary = NodeSummary::from(child);
+                            (child.node_id, Some(summary))
+                        }));
+                    }
+                }
+            }
+            *frontier = next;
+        }
+    }
+    for (root, entries) in roots.iter().zip(&outputs) {
+        validate_entries(root.layout, entries)?;
+        if entries.len() != root.entry_count as usize
+            || entries
+                .iter()
+                .map(MutationDirectoryEntry::direct_row_count)
+                .map(u64::from)
+                .sum::<u64>()
+                != root.direct_row_count
+        {
+            return Err(directory_error("directory closure disagrees with its root"));
+        }
+    }
+    Ok(outputs)
+}
+
+/// Routes ordered or unordered point keys through the authenticated bounded
+/// directory without decoding unrelated leaves.
+pub(crate) async fn route_mutation_directory_points(
+    store: &(impl StorageAdapterRead + ?Sized),
+    root: &MutationDirectoryRoot,
+    keys: &[&[u8]],
+) -> Result<Vec<Option<MutationDirectoryRoute>>, LixError> {
+    validate_root(root)?;
+    if root.layout != LAYOUT_BOUNDED_DIRECT && root.layout != LAYOUT_BOUNDED_INDIRECT {
+        return Err(directory_error(
+            "compact replacement directory is not key-routable",
+        ));
+    }
+    #[derive(Clone)]
+    struct Pending {
+        output_index: usize,
+        key: Vec<u8>,
+        base_index: u32,
+        expected: Option<NodeSummary>,
+    }
+    let mut frontier = BTreeMap::<[u8; 32], Vec<Pending>>::new();
+    frontier.insert(
+        root.root_id,
+        keys.iter()
+            .enumerate()
+            .map(|(output_index, key)| Pending {
+                output_index,
+                key: key.to_vec(),
+                base_index: 0,
+                expected: None,
+            })
+            .collect(),
+    );
+    let mut output = vec![None; keys.len()];
+    while !frontier.is_empty() {
+        let node_ids = frontier.keys().copied().collect::<Vec<_>>();
+        let loaded = load_nodes(store, &node_ids).await?;
+        let mut next = BTreeMap::<[u8; 32], Vec<Pending>>::new();
+        for ((node_id, pending), (node, summary)) in frontier.into_iter().zip(loaded.into_iter()) {
+            for request in pending {
+                match request.expected.as_ref() {
+                    Some(expected) if expected != &summary => {
+                        return Err(directory_error("point route child summary mismatch"));
+                    }
+                    None if !summary_matches_root(&summary, root) => {
+                        return Err(directory_error("point route root summary mismatch"));
+                    }
+                    _ => {}
+                }
+                match &node {
+                    StoredNode::Leaf { entries, .. } => {
+                        let index = match entries.binary_search_by(|entry| {
+                            stored_entry_first_key(entry).cmp(request.key.as_slice())
+                        }) {
+                            Ok(index) => index,
+                            Err(0) => continue,
+                            Err(index) => index - 1,
+                        };
+                        let entry = runtime_entry(entries[index].clone())?;
+                        if request.key.as_slice() <= entry.last_key() {
+                            let MutationDirectoryEntry::Bounded {
+                                part,
+                                direct_row_count,
+                            } = entry
+                            else {
+                                return Err(directory_error("bounded leaf contains compact entry"));
+                            };
+                            output[request.output_index] = Some(MutationDirectoryRoute {
+                                entry_index: request
+                                    .base_index
+                                    .checked_add(u32::try_from(index).map_err(|_| {
+                                        directory_error("leaf entry index overflows")
+                                    })?)
+                                    .ok_or_else(|| directory_error("entry index overflows"))?,
+                                part,
+                                direct_row_count,
+                            });
+                        }
+                    }
+                    StoredNode::Internal { children, .. } => {
+                        let index = match children.binary_search_by(|child| {
+                            child.first_key.as_slice().cmp(request.key.as_slice())
+                        }) {
+                            Ok(index) => index,
+                            Err(0) => continue,
+                            Err(index) => index - 1,
+                        };
+                        let child = &children[index];
+                        if request.key.as_slice() > child.last_key.as_slice() {
+                            continue;
+                        }
+                        let preceding = children[..index].iter().try_fold(0u32, |sum, child| {
+                            sum.checked_add(child.entry_count)
+                                .ok_or_else(|| directory_error("entry offset overflows"))
+                        })?;
+                        next.entry(child.node_id).or_default().push(Pending {
+                            base_index: request
+                                .base_index
+                                .checked_add(preceding)
+                                .ok_or_else(|| directory_error("entry offset overflows"))?,
+                            expected: Some(NodeSummary::from(child)),
+                            ..request
+                        });
+                    }
+                }
+            }
+            let _ = node_id;
+        }
+        frontier = next;
+    }
+    Ok(output)
+}
+
+pub(crate) async fn collect_mutation_directory_node_ids(
+    store: &(impl StorageAdapterRead + ?Sized),
+    root: &MutationDirectoryRoot,
+) -> Result<BTreeSet<[u8; 32]>, LixError> {
+    validate_root(root)?;
+    let mut reachable = BTreeSet::new();
+    let mut frontier = vec![(root.root_id, None::<NodeSummary>)];
+    while !frontier.is_empty() {
+        let node_ids = frontier
+            .iter()
+            .map(|(node_id, _)| *node_id)
+            .collect::<Vec<_>>();
+        let loaded = load_nodes(store, &node_ids).await?;
+        let mut next = Vec::new();
+        for ((node_id, expected), (node, summary)) in frontier.into_iter().zip(loaded) {
+            match expected {
+                Some(expected) if expected != summary => {
+                    return Err(directory_error("reachability child summary mismatch"));
+                }
+                None if !summary_matches_root(&summary, root) => {
+                    return Err(directory_error("reachability root summary mismatch"));
+                }
+                _ => {}
+            }
+            if !reachable.insert(node_id) {
+                continue;
+            }
+            if let StoredNode::Internal { children, .. } = node {
+                next.extend(children.into_iter().map(|child| {
+                    let summary = NodeSummary::from(&child);
+                    (child.node_id, Some(summary))
+                }));
+            }
+        }
+        frontier = next;
+    }
+    Ok(reachable)
+}
+
+#[cfg(test)]
+pub(crate) fn decode_built_mutation_directory(
+    built: &BuiltMutationDirectory,
+) -> Result<Vec<MutationDirectoryEntry>, LixError> {
+    validate_root(&built.root)?;
+    let mut frontier = vec![(built.root.root_id, None::<NodeSummary>)];
+    let mut entries = Vec::new();
+    while !frontier.is_empty() {
+        let mut next = Vec::new();
+        for (node_id, expected) in frontier {
+            let bytes = built
+                .nodes
+                .get(&node_id)
+                .ok_or_else(|| directory_error("built tree omitted a node"))?;
+            let node = decode_node(bytes)?;
+            let summary = node_summary(&node, node_id)?;
+            match expected {
+                Some(expected) if expected != summary => {
+                    return Err(directory_error("built child summary mismatch"));
+                }
+                None if !summary_matches_root(&summary, &built.root) => {
+                    return Err(directory_error("built root summary mismatch"));
+                }
+                _ => {}
+            }
+            match node {
+                StoredNode::Leaf { entries: leaf, .. } => entries.extend(
+                    leaf.into_iter()
+                        .map(runtime_entry)
+                        .collect::<Result<Vec<_>, _>>()?,
+                ),
+                StoredNode::Internal { children, .. } => {
+                    next.extend(children.into_iter().map(|child| {
+                        let summary = NodeSummary::from(&child);
+                        (child.node_id, Some(summary))
+                    }))
+                }
+            }
+        }
+        frontier = next;
+    }
+    validate_entries(built.root.layout, &entries)?;
+    Ok(entries)
+}
+
+async fn load_nodes(
+    store: &(impl StorageAdapterRead + ?Sized),
+    node_ids: &[[u8; 32]],
+) -> Result<Vec<(StoredNode, NodeSummary)>, LixError> {
+    if node_ids.is_empty() {
+        return Ok(Vec::new());
+    }
+    let keys = node_ids
+        .iter()
+        .map(|node_id| StorageKey(Bytes::copy_from_slice(node_id)))
+        .collect::<Vec<_>>();
+    let values = PointReadPlan::new(MUTATION_DIRECTORY_NODE_SPACE, &keys)
+        .materialize(store, StorageGetOptions::default())
+        .await?
+        .value;
+    node_ids
+        .iter()
+        .zip(values)
+        .map(|(node_id, value)| {
+            let value = value.ok_or_else(|| directory_error("tree references a missing node"))?;
+            let StorageProjectedValue::FullValue(bytes) = value else {
+                return Err(directory_error("node read omitted its value"));
+            };
+            if node_digest(&bytes) != *node_id {
+                return Err(directory_error("node content digest mismatch"));
+            }
+            let node = decode_node(&bytes)?;
+            let summary = node_summary(&node, *node_id)?;
+            Ok((node, summary))
+        })
+        .collect()
+}
+
+fn stage_encoded_node(
+    nodes: &mut BTreeMap<[u8; 32], Bytes>,
+    node: StoredNode,
+) -> Result<NodeSummary, LixError> {
+    let bytes = encode_node(&node)?;
+    let node_id = node_digest(&bytes);
+    let summary = node_summary(&node, node_id)?;
+    match nodes.entry(node_id) {
+        std::collections::btree_map::Entry::Vacant(entry) => {
+            entry.insert(bytes);
+        }
+        std::collections::btree_map::Entry::Occupied(entry) if entry.get() == &bytes => {}
+        std::collections::btree_map::Entry::Occupied(_) => {
+            return Err(directory_error("content ID collision"));
+        }
+    }
+    Ok(summary)
+}
+
+fn encode_node(node: &StoredNode) -> Result<Bytes, LixError> {
+    validate_node(node)?;
+    let payload = storage_codec::encode("commit mutation directory node", node)?;
+    if payload.len() > MAX_NODE_BYTES {
+        return Err(directory_error("node exceeds its size bound"));
+    }
+    let mut bytes = Vec::with_capacity(NODE_MAGIC.len() + payload.len());
+    bytes.extend_from_slice(NODE_MAGIC);
+    bytes.extend_from_slice(&payload);
+    Ok(Bytes::from(bytes))
+}
+
+fn decode_node(bytes: &[u8]) -> Result<StoredNode, LixError> {
+    let Some(payload) = bytes.strip_prefix(NODE_MAGIC) else {
+        return Err(directory_error("node has an unsupported format"));
+    };
+    if payload.len() > MAX_NODE_BYTES {
+        return Err(directory_error("node exceeds its size bound"));
+    }
+    let node = storage_codec::decode("commit mutation directory node", payload)?;
+    validate_node(&node)?;
+    Ok(node)
+}
+
+fn validate_node(node: &StoredNode) -> Result<(), LixError> {
+    match node {
+        StoredNode::Leaf { layout, entries } => {
+            validate_layout(*layout)?;
+            if entries.is_empty() || entries.len() > FANOUT {
+                return Err(directory_error("leaf shape is invalid"));
+            }
+            validate_stored_entries(*layout, entries)
+        }
+        StoredNode::Internal {
+            layout,
+            level,
+            children,
+        } => {
+            validate_layout(*layout)?;
+            if *level == 0 || children.is_empty() || children.len() > FANOUT {
+                return Err(directory_error("internal node shape is invalid"));
+            }
+            let child_level = children[0].level;
+            if child_level.checked_add(1) != Some(*level)
+                || children.iter().any(|child| {
+                    child.layout != *layout
+                        || child.level != child_level
+                        || child.node_id == [0; 32]
+                        || child.entry_count == 0
+                        || (is_bounded(*layout)
+                            && (child.first_key.is_empty()
+                                || child.first_key.as_slice() > child.last_key.as_slice()))
+                        || (!is_bounded(*layout)
+                            && (!child.first_key.is_empty() || !child.last_key.is_empty()))
+                })
+                || (is_bounded(*layout)
+                    && children
+                        .windows(2)
+                        .any(|pair| pair[0].last_key >= pair[1].first_key))
+            {
+                return Err(directory_error("internal child summaries are invalid"));
+            }
+            Ok(())
+        }
+    }
+}
+
+fn node_summary(node: &StoredNode, node_id: [u8; 32]) -> Result<NodeSummary, LixError> {
+    match node {
+        StoredNode::Leaf { layout, entries } => {
+            let entry_count = u32::try_from(entries.len())
+                .map_err(|_| directory_error("entry count overflows"))?;
+            let direct_row_count = entries.iter().try_fold(0u64, |sum, entry| {
+                sum.checked_add(u64::from(stored_entry_direct_rows(entry)))
+                    .ok_or_else(|| directory_error("row count overflows"))
+            })?;
+            Ok(NodeSummary {
+                first_key: stored_entry_first_key(&entries[0]).to_vec(),
+                last_key: stored_entry_last_key(&entries[entries.len() - 1]).to_vec(),
+                node_id,
+                entry_count,
+                direct_row_count,
+                level: 0,
+                layout: *layout,
+            })
+        }
+        StoredNode::Internal {
+            layout,
+            level,
+            children,
+        } => {
+            let (entry_count, direct_row_count) =
+                children
+                    .iter()
+                    .try_fold((0u32, 0u64), |(entry_sum, row_sum), child| {
+                        Ok::<_, LixError>((
+                            entry_sum
+                                .checked_add(child.entry_count)
+                                .ok_or_else(|| directory_error("entry count overflows"))?,
+                            row_sum
+                                .checked_add(child.direct_row_count)
+                                .ok_or_else(|| directory_error("row count overflows"))?,
+                        ))
+                    })?;
+            Ok(NodeSummary {
+                first_key: children[0].first_key.clone(),
+                last_key: children[children.len() - 1].last_key.clone(),
+                node_id,
+                entry_count,
+                direct_row_count,
+                level: *level,
+                layout: *layout,
+            })
+        }
+    }
+}
+
+fn validate_entries(layout: u8, entries: &[MutationDirectoryEntry]) -> Result<(), LixError> {
+    validate_layout(layout)?;
+    if entries.is_empty() {
+        return Ok(());
+    }
+    for entry in entries {
+        match (layout, entry) {
+            (
+                LAYOUT_BOUNDED_INDIRECT,
+                MutationDirectoryEntry::Bounded {
+                    part,
+                    direct_row_count: 0,
+                },
+            ) if valid_part(part) => {}
+            (
+                LAYOUT_BOUNDED_DIRECT,
+                MutationDirectoryEntry::Bounded {
+                    part,
+                    direct_row_count,
+                },
+            ) if valid_part(part) && *direct_row_count > 0 => {}
+            (
+                LAYOUT_COMPACT_REPLACEMENT,
+                MutationDirectoryEntry::CompactReplacement {
+                    content_digest,
+                    direct_row_count,
+                },
+            ) if *content_digest != [0; 32] && *direct_row_count > 0 => {}
+            (
+                LAYOUT_DIRECT_ROWS_ONLY,
+                MutationDirectoryEntry::DirectAddress { direct_row_count },
+            ) if *direct_row_count > 0 => {}
+            _ => return Err(directory_error("entry disagrees with directory layout")),
+        }
+    }
+    if is_bounded(layout)
+        && entries
+            .windows(2)
+            .any(|pair| pair[0].last_key() >= pair[1].first_key())
+    {
+        return Err(directory_error("bounded entries overlap or are unordered"));
+    }
+    Ok(())
+}
+
+fn validate_stored_entries(layout: u8, entries: &[StoredEntry]) -> Result<(), LixError> {
+    validate_layout(layout)?;
+    for entry in entries {
+        match (layout, entry) {
+            (
+                LAYOUT_BOUNDED_INDIRECT,
+                StoredEntry::Bounded {
+                    first_key,
+                    last_key,
+                    direct_row_count: 0,
+                    ..
+                },
+            ) if !first_key.is_empty() && first_key <= last_key => {}
+            (
+                LAYOUT_BOUNDED_DIRECT,
+                StoredEntry::Bounded {
+                    first_key,
+                    last_key,
+                    direct_row_count,
+                    ..
+                },
+            ) if !first_key.is_empty() && first_key <= last_key && *direct_row_count > 0 => {}
+            (
+                LAYOUT_COMPACT_REPLACEMENT,
+                StoredEntry::CompactReplacement {
+                    content_digest,
+                    direct_row_count,
+                },
+            ) if *content_digest != [0; 32] && *direct_row_count > 0 => {}
+            (LAYOUT_DIRECT_ROWS_ONLY, StoredEntry::DirectAddress { direct_row_count })
+                if *direct_row_count > 0 => {}
+            _ => return Err(directory_error("entry disagrees with directory layout")),
+        }
+    }
+    if is_bounded(layout)
+        && entries
+            .windows(2)
+            .any(|pair| stored_entry_last_key(&pair[0]) >= stored_entry_first_key(&pair[1]))
+    {
+        return Err(directory_error("bounded entries overlap or are unordered"));
+    }
+    Ok(())
+}
+
+fn validate_root(root: &MutationDirectoryRoot) -> Result<(), LixError> {
+    validate_layout(root.layout)?;
+    if root.root_id == [0; 32]
+        || root.root_digest == [0; 32]
+        || root.entry_count == 0
+        || root.tree_height == 0
+        || (root.layout == LAYOUT_BOUNDED_INDIRECT && root.direct_row_count != 0)
+        || ((root.layout == LAYOUT_BOUNDED_DIRECT
+            || root.layout == LAYOUT_COMPACT_REPLACEMENT
+            || root.layout == LAYOUT_DIRECT_ROWS_ONLY)
+            && root.direct_row_count == 0)
+        || root.root_digest
+            != root_digest(
+                root.root_id,
+                root.entry_count,
+                root.direct_row_count,
+                root.tree_height,
+                root.layout,
+            )
+    {
+        return Err(directory_error("root is invalid"));
+    }
+    Ok(())
+}
+
+pub(crate) fn validate_mutation_directory_root(
+    root: &MutationDirectoryRoot,
+) -> Result<(), LixError> {
+    validate_root(root)
+}
+
+fn summary_matches_root(summary: &NodeSummary, root: &MutationDirectoryRoot) -> bool {
+    summary.node_id == root.root_id
+        && summary.entry_count == root.entry_count
+        && summary.direct_row_count == root.direct_row_count
+        && summary.level.checked_add(1) == Some(root.tree_height)
+        && summary.layout == root.layout
+}
+
+fn validate_layout(layout: u8) -> Result<(), LixError> {
+    if matches!(
+        layout,
+        LAYOUT_BOUNDED_INDIRECT
+            | LAYOUT_BOUNDED_DIRECT
+            | LAYOUT_COMPACT_REPLACEMENT
+            | LAYOUT_DIRECT_ROWS_ONLY
+    ) {
+        Ok(())
+    } else {
+        Err(directory_error("layout is unsupported"))
+    }
+}
+
+fn is_bounded(layout: u8) -> bool {
+    layout == LAYOUT_BOUNDED_INDIRECT || layout == LAYOUT_BOUNDED_DIRECT
+}
+
+fn valid_part(part: &CommitStateMutationPart) -> bool {
+    !part.first_key.is_empty() && part.first_key <= part.last_key
+}
+
+#[cfg(test)]
+fn stored_entry(entry: &MutationDirectoryEntry) -> StoredEntry {
+    match entry {
+        MutationDirectoryEntry::Bounded {
+            part,
+            direct_row_count,
+        } => StoredEntry::Bounded {
+            first_key: part.first_key.clone(),
+            last_key: part.last_key.clone(),
+            replacement_part: part.replacement_part.clone(),
+            direct_row_count: *direct_row_count,
+        },
+        MutationDirectoryEntry::CompactReplacement {
+            content_digest,
+            direct_row_count,
+        } => StoredEntry::CompactReplacement {
+            content_digest: *content_digest,
+            direct_row_count: *direct_row_count,
+        },
+        MutationDirectoryEntry::DirectAddress { direct_row_count } => StoredEntry::DirectAddress {
+            direct_row_count: *direct_row_count,
+        },
+    }
+}
+
+fn runtime_entry(entry: StoredEntry) -> Result<MutationDirectoryEntry, LixError> {
+    let entry = match entry {
+        StoredEntry::Bounded {
+            first_key,
+            last_key,
+            replacement_part,
+            direct_row_count,
+        } => MutationDirectoryEntry::Bounded {
+            part: CommitStateMutationPart {
+                first_key,
+                last_key,
+                replacement_part,
+            },
+            direct_row_count,
+        },
+        StoredEntry::CompactReplacement {
+            content_digest,
+            direct_row_count,
+        } => MutationDirectoryEntry::CompactReplacement {
+            content_digest,
+            direct_row_count,
+        },
+        StoredEntry::DirectAddress { direct_row_count } => {
+            MutationDirectoryEntry::DirectAddress { direct_row_count }
+        }
+    };
+    Ok(entry)
+}
+
+fn stored_entry_first_key(entry: &StoredEntry) -> &[u8] {
+    match entry {
+        StoredEntry::Bounded { first_key, .. } => first_key,
+        StoredEntry::CompactReplacement { .. } => &[],
+        StoredEntry::DirectAddress { .. } => &[],
+    }
+}
+
+fn stored_entry_last_key(entry: &StoredEntry) -> &[u8] {
+    match entry {
+        StoredEntry::Bounded { last_key, .. } => last_key,
+        StoredEntry::CompactReplacement { .. } => &[],
+        StoredEntry::DirectAddress { .. } => &[],
+    }
+}
+
+fn stored_entry_direct_rows(entry: &StoredEntry) -> u16 {
+    match entry {
+        StoredEntry::Bounded {
+            direct_row_count, ..
+        }
+        | StoredEntry::CompactReplacement {
+            direct_row_count, ..
+        }
+        | StoredEntry::DirectAddress { direct_row_count } => *direct_row_count,
+    }
+}
+
+fn balanced_chunks<T>(values: &[T]) -> Vec<&[T]> {
+    debug_assert!(!values.is_empty());
+    let chunk_count = values.len().div_ceil(FANOUT);
+    let base = values.len() / chunk_count;
+    let larger = values.len() % chunk_count;
+    let mut chunks = Vec::with_capacity(chunk_count);
+    let mut start = 0usize;
+    for index in 0..chunk_count {
+        let length = base + usize::from(index < larger);
+        chunks.push(&values[start..start + length]);
+        start += length;
+    }
+    chunks
+}
+
+fn balanced_chunk_lengths(value_count: usize) -> impl Iterator<Item = usize> {
+    let chunk_count = value_count.div_ceil(FANOUT);
+    let base = value_count / chunk_count;
+    let larger = value_count % chunk_count;
+    (0..chunk_count).map(move |index| base + usize::from(index < larger))
+}
+
+fn node_digest(bytes: &[u8]) -> [u8; 32] {
+    let mut digest = blake3::Hasher::new_derive_key(NODE_HASH_CONTEXT);
+    digest.update(bytes);
+    *digest.finalize().as_bytes()
+}
+
+fn root_digest(
+    root_id: [u8; 32],
+    entry_count: u32,
+    direct_row_count: u64,
+    tree_height: u16,
+    layout: u8,
+) -> [u8; 32] {
+    let mut digest = blake3::Hasher::new_derive_key(ROOT_HASH_CONTEXT);
+    digest.update(&root_id);
+    digest.update(&entry_count.to_be_bytes());
+    digest.update(&direct_row_count.to_be_bytes());
+    digest.update(&tree_height.to_be_bytes());
+    digest.update(&[layout]);
+    *digest.finalize().as_bytes()
+}
+
+fn directory_error(message: impl Into<String>) -> LixError {
+    LixError::new(
+        LixError::CODE_INTERNAL_ERROR,
+        format!("tracked_state mutation directory: {}", message.into()),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::storage_adapter::{Memory, StorageAdapter, StorageReadOptions, StorageWriteOptions};
+
+    use super::*;
+
+    fn bounded_entry(index: u32) -> MutationDirectoryEntry {
+        let first_key = index.saturating_mul(10).to_be_bytes().to_vec();
+        let last_key = index
+            .saturating_mul(10)
+            .saturating_add(9)
+            .to_be_bytes()
+            .to_vec();
+        MutationDirectoryEntry::Bounded {
+            part: CommitStateMutationPart {
+                first_key,
+                last_key,
+                replacement_part: None,
+            },
+            direct_row_count: 7,
+        }
+    }
+
+    #[tokio::test]
+    async fn multi_level_directory_round_trips_and_routes_without_flattening() {
+        let entries = (0..(FANOUT as u32 * 2 + 17))
+            .map(bounded_entry)
+            .collect::<Vec<_>>();
+        let built = build_mutation_directory(LAYOUT_BOUNDED_DIRECT, &entries).unwrap();
+        assert!(built.root.tree_height >= 2);
+        assert!(built.node_bytes().len() > 1);
+
+        let storage = StorageAdapter::new(Memory::new());
+        let mut writes = storage.new_write_set();
+        built.stage(&mut writes).unwrap();
+        storage
+            .commit_write_set(writes, StorageWriteOptions::default())
+            .await
+            .unwrap();
+        let read = storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .unwrap();
+
+        let loaded = load_mutation_directory(&read, &built.root).await.unwrap();
+        assert_eq!(loaded, entries);
+        let requested = [0u32, FANOUT as u32, FANOUT as u32 * 2 + 16];
+        let keys = requested
+            .iter()
+            .map(|index| index.saturating_mul(10).saturating_add(4).to_be_bytes())
+            .collect::<Vec<_>>();
+        let key_refs = keys.iter().map(<[u8; 4]>::as_slice).collect::<Vec<_>>();
+        let routed = route_mutation_directory_points(&read, &built.root, &key_refs)
+            .await
+            .unwrap();
+        for (&expected_index, route) in requested.iter().zip(routed) {
+            let route = route.expect("covered key should route");
+            assert_eq!(route.entry_index, expected_index);
+            assert_eq!(route.direct_row_count, 7);
+            assert_eq!(
+                route.part,
+                match &entries[expected_index as usize] {
+                    MutationDirectoryEntry::Bounded { part, .. } => part.clone(),
+                    _ => unreachable!(),
+                }
+            );
+        }
+        assert_eq!(
+            collect_mutation_directory_node_ids(&read, &built.root)
+                .await
+                .unwrap()
+                .len(),
+            built.node_bytes().len()
+        );
+    }
+}

--- a/packages/engine/src/tracked_state/mutation_directory.rs
+++ b/packages/engine/src/tracked_state/mutation_directory.rs
@@ -219,7 +219,7 @@ pub(crate) fn build_mutation_directory(
     entries: &[MutationDirectoryEntry],
 ) -> Result<BuiltMutationDirectory, LixError> {
     validate_entries(layout, entries)?;
-    build_stored_mutation_directory(layout, entries.iter().map(stored_entry).collect())
+    build_stored_mutation_directory(layout, entries.iter().map(stored_entry))
 }
 
 pub(crate) fn build_bounded_mutation_directory(
@@ -236,6 +236,14 @@ pub(crate) fn build_bounded_mutation_directory(
     } else {
         LAYOUT_BOUNDED_INDIRECT
     };
+    if parts.iter().any(|part| !valid_part(part))
+        || parts
+            .windows(2)
+            .any(|pair| pair[0].last_key >= pair[1].first_key)
+        || direct_row_counts.is_some_and(|rows| rows.contains(&0))
+    {
+        return Err(directory_error("bounded entries overlap or are invalid"));
+    }
     let entries = parts
         .iter()
         .enumerate()
@@ -244,8 +252,7 @@ pub(crate) fn build_bounded_mutation_directory(
             last_key: part.last_key.clone(),
             replacement_part: part.replacement_part.clone(),
             direct_row_count: direct_row_counts.map_or(0, |rows| rows[index]),
-        })
-        .collect();
+        });
     build_stored_mutation_directory(layout, entries)
 }
 
@@ -258,6 +265,9 @@ pub(crate) fn build_compact_replacement_mutation_directory(
             "compact replacement counts do not match digest count",
         ));
     }
+    if content_digests.contains(&[0; 32]) || direct_row_counts.contains(&0) {
+        return Err(directory_error("compact replacement entry is invalid"));
+    }
     build_stored_mutation_directory(
         LAYOUT_COMPACT_REPLACEMENT,
         content_digests
@@ -269,30 +279,34 @@ pub(crate) fn build_compact_replacement_mutation_directory(
                     content_digest,
                     direct_row_count,
                 },
-            )
-            .collect(),
+            ),
     )
 }
 
 pub(crate) fn build_direct_rows_mutation_directory(
     direct_row_counts: &[u16],
 ) -> Result<BuiltMutationDirectory, LixError> {
+    if direct_row_counts.contains(&0) {
+        return Err(directory_error("direct-address entry is invalid"));
+    }
     build_stored_mutation_directory(
         LAYOUT_DIRECT_ROWS_ONLY,
         direct_row_counts
             .iter()
             .copied()
-            .map(|direct_row_count| StoredEntry::DirectAddress { direct_row_count })
-            .collect(),
+            .map(|direct_row_count| StoredEntry::DirectAddress { direct_row_count }),
     )
 }
 
-fn build_stored_mutation_directory(
+fn build_stored_mutation_directory<I>(
     layout: u8,
-    entries: Vec<StoredEntry>,
-) -> Result<BuiltMutationDirectory, LixError> {
-    validate_stored_entries(layout, &entries)?;
-    if entries.is_empty() {
+    entries: I,
+) -> Result<BuiltMutationDirectory, LixError>
+where
+    I: ExactSizeIterator<Item = StoredEntry>,
+{
+    validate_layout(layout)?;
+    if entries.len() == 0 {
         return Err(directory_error("cannot build an empty directory"));
     }
     let mut nodes = BTreeMap::new();
@@ -453,7 +467,6 @@ pub(crate) async fn route_mutation_directory_points(
     #[derive(Clone)]
     struct Pending {
         output_index: usize,
-        key: Vec<u8>,
         base_index: u32,
         expected: Option<NodeSummary>,
     }
@@ -462,9 +475,8 @@ pub(crate) async fn route_mutation_directory_points(
         root.root_id,
         keys.iter()
             .enumerate()
-            .map(|(output_index, key)| Pending {
+            .map(|(output_index, _)| Pending {
                 output_index,
-                key: key.to_vec(),
                 base_index: 0,
                 expected: None,
             })
@@ -477,6 +489,7 @@ pub(crate) async fn route_mutation_directory_points(
         let mut next = BTreeMap::<[u8; 32], Vec<Pending>>::new();
         for ((node_id, pending), (node, summary)) in frontier.into_iter().zip(loaded.into_iter()) {
             for request in pending {
+                let key = keys[request.output_index];
                 match request.expected.as_ref() {
                     Some(expected) if expected != &summary => {
                         return Err(directory_error("point route child summary mismatch"));
@@ -488,15 +501,15 @@ pub(crate) async fn route_mutation_directory_points(
                 }
                 match &node {
                     StoredNode::Leaf { entries, .. } => {
-                        let index = match entries.binary_search_by(|entry| {
-                            stored_entry_first_key(entry).cmp(request.key.as_slice())
-                        }) {
+                        let index = match entries
+                            .binary_search_by(|entry| stored_entry_first_key(entry).cmp(key))
+                        {
                             Ok(index) => index,
                             Err(0) => continue,
                             Err(index) => index - 1,
                         };
                         let entry = runtime_entry(entries[index].clone())?;
-                        if request.key.as_slice() <= entry.last_key() {
+                        if key <= entry.last_key() {
                             let MutationDirectoryEntry::Bounded {
                                 part,
                                 direct_row_count,
@@ -517,15 +530,15 @@ pub(crate) async fn route_mutation_directory_points(
                         }
                     }
                     StoredNode::Internal { children, .. } => {
-                        let index = match children.binary_search_by(|child| {
-                            child.first_key.as_slice().cmp(request.key.as_slice())
-                        }) {
+                        let index = match children
+                            .binary_search_by(|child| child.first_key.as_slice().cmp(key))
+                        {
                             Ok(index) => index,
                             Err(0) => continue,
                             Err(index) => index - 1,
                         };
                         let child = &children[index];
-                        if request.key.as_slice() > child.last_key.as_slice() {
+                        if key > child.last_key.as_slice() {
                             continue;
                         }
                         let preceding = children[..index].iter().try_fold(0u32, |sum, child| {
@@ -544,6 +557,98 @@ pub(crate) async fn route_mutation_directory_points(
                 }
             }
             let _ = node_id;
+        }
+        frontier = next;
+    }
+    Ok(output)
+}
+
+/// Loads only bounded-directory entries intersecting one of the requested
+/// half-open key ranges. An empty range list selects the complete directory.
+/// Every visited node is authenticated against its parent summary and the
+/// header-owned root; unrelated subtrees are never decoded.
+pub(crate) async fn load_bounded_mutation_directory_ranges(
+    store: &(impl StorageAdapterRead + ?Sized),
+    root: &MutationDirectoryRoot,
+    ranges: &[(&[u8], Option<&[u8]>)],
+) -> Result<Vec<MutationDirectoryRoute>, LixError> {
+    validate_root(root)?;
+    if root.layout != LAYOUT_BOUNDED_DIRECT && root.layout != LAYOUT_BOUNDED_INDIRECT {
+        return Err(directory_error("range scan requires a bounded directory"));
+    }
+
+    fn overlaps(first: &[u8], last: &[u8], ranges: &[(&[u8], Option<&[u8]>)]) -> bool {
+        ranges.is_empty()
+            || ranges
+                .iter()
+                .any(|(start, end)| last >= *start && end.is_none_or(|end| first < end))
+    }
+
+    let mut frontier = vec![(root.root_id, 0u32, None::<NodeSummary>)];
+    let mut output = Vec::new();
+    while !frontier.is_empty() {
+        let node_ids = frontier
+            .iter()
+            .map(|(node_id, _, _)| *node_id)
+            .collect::<Vec<_>>();
+        let loaded = load_nodes(store, &node_ids).await?;
+        let mut next = Vec::new();
+        for ((_, base_index, expected), (node, summary)) in frontier.into_iter().zip(loaded) {
+            match expected {
+                Some(expected) if expected != summary => {
+                    return Err(directory_error("range scan child summary mismatch"));
+                }
+                None if !summary_matches_root(&summary, root) => {
+                    return Err(directory_error("range scan root summary mismatch"));
+                }
+                _ => {}
+            }
+            match node {
+                StoredNode::Leaf { entries, .. } => {
+                    for (index, entry) in entries.into_iter().enumerate() {
+                        if !overlaps(
+                            stored_entry_first_key(&entry),
+                            stored_entry_last_key(&entry),
+                            ranges,
+                        ) {
+                            continue;
+                        }
+                        let MutationDirectoryEntry::Bounded {
+                            part,
+                            direct_row_count,
+                        } = runtime_entry(entry)?
+                        else {
+                            return Err(directory_error("bounded leaf contains compact entry"));
+                        };
+                        output.push(MutationDirectoryRoute {
+                            entry_index: base_index
+                                .checked_add(
+                                    u32::try_from(index).map_err(|_| {
+                                        directory_error("leaf entry index overflows")
+                                    })?,
+                                )
+                                .ok_or_else(|| directory_error("entry index overflows"))?,
+                            part,
+                            direct_row_count,
+                        });
+                    }
+                }
+                StoredNode::Internal { children, .. } => {
+                    let mut preceding = 0u32;
+                    for child in children {
+                        let child_base = base_index
+                            .checked_add(preceding)
+                            .ok_or_else(|| directory_error("entry offset overflows"))?;
+                        preceding = preceding
+                            .checked_add(child.entry_count)
+                            .ok_or_else(|| directory_error("entry offset overflows"))?;
+                        if overlaps(&child.first_key, &child.last_key, ranges) {
+                            let summary = NodeSummary::from(&child);
+                            next.push((child.node_id, child_base, Some(summary)));
+                        }
+                    }
+                }
+            }
         }
         frontier = next;
     }

--- a/packages/engine/src/tracked_state/scoped_current_state.rs
+++ b/packages/engine/src/tracked_state/scoped_current_state.rs
@@ -1,7 +1,7 @@
 //! Manifest-specific authority for the payload-opaque scoped-range tree.
 //!
 //! The tree authenticates physical scope/range routing. This layer alone binds
-//! a tree transition to commit graph ancestry and sealed mutation authority.
+//! a tree transition to commit graph ancestry and certified mutation authority.
 
 use crate::changelog::CommitId;
 use crate::storage_adapter::{StorageAdapterRead, StorageWriteSet};
@@ -318,37 +318,13 @@ pub(crate) fn validate_touched_scope_filter(
 }
 
 /// Opaque proof that the physical serving projection was produced in this
-/// write set from the exact graph topology and sealed mutation inventory.
+/// write set from the exact graph topology and certified mutation inventory.
 pub(crate) struct CertifiedCommitStatePhysicalPublication {
     write_set_id: u64,
-    parent_commit_ids: CertifiedGraphParents,
+    commit_id: CommitId,
     selected_source_commit_id: Option<CommitId>,
     root: Option<CurrentStateScopedRangeRoot>,
     touched_scope_filter: CommitStateTouchedScopeFilter,
-}
-
-enum CertifiedGraphParents {
-    None,
-    One(CommitId),
-    Many(Vec<CommitId>),
-}
-
-impl CertifiedGraphParents {
-    fn from_manifests(parents: &[&CommitStateManifest]) -> Self {
-        match parents {
-            [] => Self::None,
-            [parent] => Self::One(parent.commit_id),
-            _ => Self::Many(parents.iter().map(|parent| parent.commit_id).collect()),
-        }
-    }
-
-    fn as_slice(&self) -> &[CommitId] {
-        match self {
-            Self::None => &[],
-            Self::One(parent) => std::slice::from_ref(parent),
-            Self::Many(parents) => parents,
-        }
-    }
 }
 
 impl CertifiedCommitStatePhysicalPublication {
@@ -356,12 +332,12 @@ impl CertifiedCommitStatePhysicalPublication {
         self.root.clone().map(Box::new)
     }
 
-    pub(crate) fn parent_commit_ids(&self) -> &[CommitId] {
-        self.parent_commit_ids.as_slice()
-    }
-
     pub(crate) fn selected_source_commit_id(&self) -> Option<CommitId> {
         self.selected_source_commit_id
+    }
+
+    pub(crate) fn commit_id(&self) -> CommitId {
+        self.commit_id
     }
 
     pub(crate) fn write_set_id(&self) -> u64 {
@@ -404,7 +380,7 @@ pub(super) fn certify_topology_touched_scope_filter_from_manifests(
     };
     Ok(CertifiedCommitStatePhysicalPublication {
         write_set_id: writes.identity(),
-        parent_commit_ids: CertifiedGraphParents::from_manifests(parents),
+        commit_id,
         selected_source_commit_id,
         root: None,
         touched_scope_filter: advance_touched_scope_filter(
@@ -588,7 +564,6 @@ pub(crate) async fn stage_current_state_scoped_ranges(
     account_id: &str,
     inventory: &CommitStateMutationInventory,
 ) -> Result<CertifiedCommitStatePhysicalPublication, LixError> {
-    let parent_commit_ids = CertifiedGraphParents::from_manifests(graph_parents);
     let selected_source_commit_id = selected_source.map(|source| source.commit_id);
     if selected_source_commit_id != inventory.selected_source_commit_id() {
         return Err(scoped_state_error(
@@ -629,7 +604,7 @@ pub(crate) async fn stage_current_state_scoped_ranges(
             extend_touched_scope_filter(inherited_scope_filter, filter_touched.as_deref())?;
         return Ok(CertifiedCommitStatePhysicalPublication {
             write_set_id: writes.identity(),
-            parent_commit_ids,
+            commit_id,
             selected_source_commit_id,
             root,
             touched_scope_filter,
@@ -653,7 +628,7 @@ pub(crate) async fn stage_current_state_scoped_ranges(
         .await?;
         return Ok(CertifiedCommitStatePhysicalPublication {
             write_set_id: writes.identity(),
-            parent_commit_ids,
+            commit_id,
             selected_source_commit_id,
             root,
             touched_scope_filter,
@@ -663,7 +638,7 @@ pub(crate) async fn stage_current_state_scoped_ranges(
     let Some(mut touched) = touched else {
         return Ok(CertifiedCommitStatePhysicalPublication {
             write_set_id: writes.identity(),
-            parent_commit_ids,
+            commit_id,
             selected_source_commit_id,
             root: None,
             touched_scope_filter,
@@ -672,7 +647,7 @@ pub(crate) async fn stage_current_state_scoped_ranges(
     let Some(parent_root) = parent_root else {
         return Ok(CertifiedCommitStatePhysicalPublication {
             write_set_id: writes.identity(),
-            parent_commit_ids,
+            commit_id,
             selected_source_commit_id,
             root: None,
             touched_scope_filter,
@@ -681,7 +656,7 @@ pub(crate) async fn stage_current_state_scoped_ranges(
     if touched.is_empty() {
         return Ok(CertifiedCommitStatePhysicalPublication {
             write_set_id: writes.identity(),
-            parent_commit_ids,
+            commit_id,
             selected_source_commit_id,
             root: Some(attest_scoped_range_root(
                 commit_id,
@@ -738,7 +713,7 @@ pub(crate) async fn stage_current_state_scoped_ranges(
         else {
             return Ok(CertifiedCommitStatePhysicalPublication {
                 write_set_id: writes.identity(),
-                parent_commit_ids,
+                commit_id,
                 selected_source_commit_id,
                 root: None,
                 touched_scope_filter,
@@ -753,7 +728,7 @@ pub(crate) async fn stage_current_state_scoped_ranges(
     }
     Ok(CertifiedCommitStatePhysicalPublication {
         write_set_id: writes.identity(),
-        parent_commit_ids,
+        commit_id,
         selected_source_commit_id,
         root: Some(attest_scoped_range_root(
             commit_id,
@@ -795,10 +770,6 @@ fn scoped_state_error(message: impl std::fmt::Display) -> LixError {
 
 #[cfg(test)]
 mod tests {
-    use std::future::Future;
-    use std::sync::Arc;
-    use std::sync::atomic::{AtomicUsize, Ordering};
-
     use bytes::Bytes;
 
     use crate::changelog::{ChangeId, CommitId};
@@ -815,10 +786,9 @@ mod tests {
     };
     use crate::tracked_state::storage::{
         CertifiedCommitStateTopologyParent, CommitDeltaReplacementGeneration,
-        PublishedCommitStateManifest, load_commit_state_manifest,
-        load_complete_current_state_values_from_scoped_root, load_published_commit_state_manifest,
-        sparse_current_state_materialization_count_for_test, stage_certified_commit_state_manifest,
-        stage_certified_commit_state_manifest_with_handle, stage_commit_state_manifest,
+        PublishedCommitStateManifest, load_complete_current_state_values_from_scoped_root,
+        load_published_commit_state_manifest, sparse_current_state_materialization_count_for_test,
+        stage_certified_commit_state_manifest, stage_certified_commit_state_manifest_with_handle,
         stage_current_state_scoped_ranges_from_published_parent,
         stage_current_state_scoped_ranges_from_staged_parent,
         stage_current_state_scoped_ranges_from_topology, stage_ordered_addressable_commit_deltas,
@@ -839,45 +809,6 @@ mod tests {
         validate_scoped_range_attestation, validate_touched_scope_filter,
     };
 
-    struct ManifestCountingRead<R> {
-        inner: R,
-        manifest_calls: Arc<AtomicUsize>,
-    }
-
-    impl<R> crate::storage_adapter::StorageAdapterRead for ManifestCountingRead<R>
-    where
-        R: crate::storage_adapter::StorageAdapterRead,
-    {
-        fn snapshot_cache_key(&self) -> Option<u128> {
-            self.inner.snapshot_cache_key()
-        }
-
-        fn get_many(
-            &self,
-            requests: &[crate::storage::GetManyRequest<'_>],
-        ) -> impl Future<
-            Output = Result<crate::storage::GetManyResult, crate::storage::StorageError>,
-        > + Send {
-            for request in requests {
-                if request.space == crate::tracked_state::TRACKED_STATE_COMMIT_STATE_MANIFEST_SPACE
-                {
-                    self.manifest_calls.fetch_add(1, Ordering::Relaxed);
-                }
-            }
-            self.inner.get_many(requests)
-        }
-
-        fn scan(
-            &self,
-            space: crate::storage_adapter::StorageSpace,
-            range: crate::storage::KeyRange,
-            opts: crate::storage::ScanOptions,
-        ) -> impl Future<Output = Result<crate::storage::ScanChunk, crate::storage::StorageError>> + Send
-        {
-            self.inner.scan(space, range, opts)
-        }
-    }
-
     fn scope(schema_key: &str) -> CommitDeltaReplacementScope {
         CommitDeltaReplacementScope {
             schema_key: schema_key.to_owned(),
@@ -887,16 +818,12 @@ mod tests {
 
     fn manifest(
         commit_id: CommitId,
-        parent_commit_id: Option<CommitId>,
+        _parent_commit_id: Option<CommitId>,
         mutations: CommitStateMutationInventory,
     ) -> CommitStateManifest {
         CommitStateManifest {
             commit_id,
-            generation: 0,
-            parent_commit_ids: parent_commit_id.into_iter().collect(),
-            commit_change_id: ChangeId::for_test_label(&format!("{commit_id}:commit")),
-            account_id: crate::ANONYMOUS_ACCOUNT_ID.to_string(),
-            created_at: LixTimestamp::from_unix_millis_utc_lossy(1),
+            change_account_id: crate::ANONYMOUS_ACCOUNT_ID.to_string(),
             replay_debt: CommitStateReplayDebt {
                 depth: 4,
                 rows: u64::from(mutations.member_count),
@@ -1567,7 +1494,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn publication_proof_rejects_wrong_parent_write_set_and_forged_transition() {
+    async fn publication_proof_rejects_wrong_commit_write_set_and_forged_transition() {
         let storage = StorageAdapter::new(Memory::new());
         let commit_id = CommitId::for_test_label("scoped-proof");
         let inventory = CommitStateMutationInventory::default();
@@ -1596,11 +1523,11 @@ mod tests {
                 .expect_err("proof must be tied to one write set");
         assert!(error.message.contains("write set"));
 
-        let mut wrong_parent = valid.clone();
-        wrong_parent.parent_commit_ids = vec![CommitId::for_test_label("wrong-parent")];
-        let error = stage_certified_commit_state_manifest(&mut writes, &wrong_parent, &publication)
-            .expect_err("proof must bind the graph parent");
-        assert!(error.message.contains("parent"));
+        let mut wrong_commit = valid.clone();
+        wrong_commit.commit_id = CommitId::for_test_label("other-scoped-proof");
+        let error = stage_certified_commit_state_manifest(&mut writes, &wrong_commit, &publication)
+            .expect_err("proof must be tied to one commit");
+        assert!(error.message.contains("identity"));
 
         let prefix = ScopedRangePrefix::try_from_components([b"forged".as_slice()]).unwrap();
         let tree = stage_scoped_range_tree(
@@ -1682,14 +1609,11 @@ mod tests {
         let parent_id = CommitId::for_test_label("empty-proof-parent");
         let requested = scope("not-authored-here");
 
-        let mut merge = manifest(
+        let merge = manifest(
             parent_id,
             Some(CommitId::for_test_label("first-parent")),
             CommitStateMutationInventory::default(),
         );
-        merge
-            .parent_commit_ids
-            .push(CommitId::for_test_label("second-parent"));
         assert!(!parent_scope_is_proven_empty(Some(&merge), &requested).unwrap());
 
         let mut selected = manifest(parent_id, None, CommitStateMutationInventory::default());
@@ -1810,12 +1734,8 @@ mod tests {
         )
         .unwrap();
         let mut merged = manifest(commit_id, Some(left.commit_id), inventory);
-        merged.parent_commit_ids.push(right.commit_id);
         merged.touched_scope_filter = publication.touched_scope_filter().clone();
         stage_certified_commit_state_manifest(&mut writes, &merged, &publication).unwrap();
-
-        merged.parent_commit_ids.swap(0, 1);
-        assert!(stage_certified_commit_state_manifest(&mut writes, &merged, &publication).is_err());
     }
 
     #[tokio::test]
@@ -1908,215 +1828,6 @@ mod tests {
                 bits: vec![0; TOUCHED_SCOPE_FILTER_BYTES - 1],
             })
             .is_err()
-        );
-    }
-
-    async fn legacy_lineage_scope_absence_proof(
-        store: &(impl crate::storage_adapter::StorageAdapterRead + ?Sized),
-        parent: &CommitStateManifest,
-        scope: &CommitDeltaReplacementScope,
-    ) -> Result<bool, crate::LixError> {
-        let mut next = Some(parent.clone());
-        let mut visited = std::collections::BTreeSet::new();
-        while let Some(manifest) = next {
-            if !visited.insert(manifest.commit_id) {
-                return Err(crate::LixError::new(
-                    crate::LixError::CODE_INTERNAL_ERROR,
-                    "legacy scope proof encountered a commit cycle",
-                ));
-            }
-            if manifest.parent_commit_ids.len() > 1
-                || manifest.mutations.selected_source_commit_id().is_some()
-            {
-                return Ok(false);
-            }
-            if manifest.mutations.member_count != 0 {
-                let Some(touched) =
-                    crate::tracked_state::storage::commit_state_inventory_exact_touched_scopes(
-                        manifest.commit_id,
-                        &manifest.mutations,
-                        false,
-                    )?
-                else {
-                    return Ok(false);
-                };
-                if touched.contains(scope) {
-                    return Ok(false);
-                }
-            }
-            let Some(parent_id) = manifest.parent_commit_ids.first().copied() else {
-                return Ok(true);
-            };
-            next = load_commit_state_manifest(store, parent_id).await?;
-            if next.is_none() {
-                return Ok(false);
-            }
-        }
-        Ok(false)
-    }
-
-    async fn legacy_graph_scope_absence_proof(
-        store: &(impl crate::storage_adapter::StorageAdapterRead + ?Sized),
-        tip: &CommitStateManifest,
-        scope: &CommitDeltaReplacementScope,
-    ) -> Result<bool, crate::LixError> {
-        let mut pending = vec![tip.clone()];
-        let mut scheduled = std::collections::BTreeSet::from([tip.commit_id]);
-        while let Some(manifest) = pending.pop() {
-            if manifest.mutations.selected_source_commit_id().is_some() {
-                return Ok(false);
-            }
-            if manifest.mutations.member_count != 0 {
-                let Some(touched) =
-                    crate::tracked_state::storage::commit_state_inventory_exact_touched_scopes(
-                        manifest.commit_id,
-                        &manifest.mutations,
-                        false,
-                    )?
-                else {
-                    return Ok(false);
-                };
-                if touched.contains(scope) {
-                    return Ok(false);
-                }
-            }
-            for parent_id in manifest.parent_commit_ids {
-                if !scheduled.insert(parent_id) {
-                    continue;
-                }
-                let parent = load_commit_state_manifest(store, parent_id)
-                    .await?
-                    .ok_or_else(|| {
-                        crate::LixError::new(
-                            crate::LixError::CODE_INTERNAL_ERROR,
-                            "legacy graph proof encountered a missing parent",
-                        )
-                    })?;
-                pending.push(parent);
-            }
-        }
-        Ok(true)
-    }
-
-    #[tokio::test]
-    async fn cumulative_filter_removes_lineage_manifest_reads_from_absence_proof() {
-        const DEPTH: usize = 128;
-        let storage = StorageAdapter::new(Memory::new());
-        let mut parent_id = None;
-        let mut tip = None;
-        for index in 0..DEPTH {
-            let commit_id = CommitId::for_test_label(&format!("scope-proof-{index}"));
-            let authority = manifest(
-                commit_id,
-                parent_id,
-                CommitStateMutationInventory::default(),
-            );
-            let mut writes = storage.new_write_set();
-            stage_commit_state_manifest(&mut writes, &authority).unwrap();
-            storage
-                .commit_write_set(writes, StorageWriteOptions::default())
-                .await
-                .unwrap();
-            parent_id = Some(commit_id);
-            tip = Some(authority);
-        }
-        let mut tip = tip.expect("lineage has a tip");
-        tip.touched_scope_filter = advance_touched_scope_filter(&[], None, Some(&[])).unwrap();
-        let requested = scope("first-columnar-publication");
-        let calls = Arc::new(AtomicUsize::new(0));
-        let read = storage
-            .begin_read(StorageReadOptions::default())
-            .await
-            .unwrap();
-        let counted = ManifestCountingRead {
-            inner: read,
-            manifest_calls: calls.clone(),
-        };
-        assert!(
-            legacy_lineage_scope_absence_proof(&counted, &tip, &requested)
-                .await
-                .unwrap()
-        );
-        assert_eq!(calls.load(Ordering::Relaxed), DEPTH - 1);
-
-        assert!(parent_scope_is_proven_empty(Some(&tip), &requested).unwrap());
-        assert_eq!(
-            calls.load(Ordering::Relaxed),
-            DEPTH - 1,
-            "the certified proof must not issue another manifest read"
-        );
-    }
-
-    #[tokio::test]
-    async fn merge_filter_matches_exact_graph_proof_without_reads() {
-        const BRANCH_DEPTH: usize = 64;
-        let storage = StorageAdapter::new(Memory::new());
-        let root_id = CommitId::for_test_label("merge-scope-proof-root");
-        let root = manifest(root_id, None, CommitStateMutationInventory::default());
-        let mut writes = storage.new_write_set();
-        stage_commit_state_manifest(&mut writes, &root).unwrap();
-        storage
-            .commit_write_set(writes, StorageWriteOptions::default())
-            .await
-            .unwrap();
-
-        let mut branch_tips = Vec::new();
-        for branch in ["left", "right"] {
-            let mut parent_id = root_id;
-            let mut tip = None;
-            for depth in 0..BRANCH_DEPTH {
-                let commit_id =
-                    CommitId::for_test_label(&format!("merge-scope-proof-{branch}-{depth}"));
-                let authority = manifest(
-                    commit_id,
-                    Some(parent_id),
-                    CommitStateMutationInventory::default(),
-                );
-                let mut writes = storage.new_write_set();
-                stage_commit_state_manifest(&mut writes, &authority).unwrap();
-                storage
-                    .commit_write_set(writes, StorageWriteOptions::default())
-                    .await
-                    .unwrap();
-                parent_id = commit_id;
-                tip = Some(authority);
-            }
-            let mut tip = tip.unwrap();
-            tip.touched_scope_filter = advance_touched_scope_filter(&[], None, Some(&[])).unwrap();
-            branch_tips.push(tip);
-        }
-        let mut merge = manifest(
-            CommitId::for_test_label("merge-scope-proof-tip"),
-            Some(branch_tips[0].commit_id),
-            CommitStateMutationInventory::default(),
-        );
-        merge.parent_commit_ids.push(branch_tips[1].commit_id);
-        merge.touched_scope_filter =
-            advance_touched_scope_filter(&[&branch_tips[0], &branch_tips[1]], None, Some(&[]))
-                .unwrap();
-
-        let requested = scope("first-post-merge-publication");
-        let calls = Arc::new(AtomicUsize::new(0));
-        let read = storage
-            .begin_read(StorageReadOptions::default())
-            .await
-            .unwrap();
-        let counted = ManifestCountingRead {
-            inner: read,
-            manifest_calls: calls.clone(),
-        };
-        assert!(
-            legacy_graph_scope_absence_proof(&counted, &merge, &requested)
-                .await
-                .unwrap()
-        );
-        assert_eq!(calls.load(Ordering::Relaxed), BRANCH_DEPTH * 2 + 1);
-
-        assert!(parent_scope_is_proven_empty(Some(&merge), &requested).unwrap());
-        assert_eq!(
-            calls.load(Ordering::Relaxed),
-            BRANCH_DEPTH * 2 + 1,
-            "the certified merge proof must not issue another manifest read"
         );
     }
 }

--- a/packages/engine/src/tracked_state/scoped_current_state.rs
+++ b/packages/engine/src/tracked_state/scoped_current_state.rs
@@ -3,6 +3,7 @@
 //! The tree authenticates physical scope/range routing. This layer alone binds
 //! a tree transition to commit graph ancestry and certified mutation authority.
 
+use crate::LixError;
 use crate::changelog::CommitId;
 use crate::storage_adapter::{StorageAdapterRead, StorageWriteSet};
 use crate::tracked_state::current_state_envelope::scoped_range_part_from_current_state_descriptor;
@@ -14,12 +15,28 @@ use crate::tracked_state::types::{
     CommitDeltaReplacementScope, CommitStateManifest, CommitStateMutationInventory,
     CommitStateTouchedScopeFilter, CurrentStatePartDescriptor, CurrentStateScopedRangeRoot,
 };
-use crate::{LixError, storage_codec};
 
 const TRANSITION_CONTEXT: &str = "lix current-state scoped-range transition v2";
 const TOUCHED_SCOPE_FILTER_BYTES: usize = 128;
 const TOUCHED_SCOPE_FILTER_HASHES: usize = 4;
 const TOUCHED_SCOPE_FILTER_CONTEXT: &str = "lix cumulative touched collection scope v1";
+
+#[derive(Clone, Copy)]
+pub(super) struct CommitStateTopologyRef<'a> {
+    pub(super) commit_id: CommitId,
+    pub(super) touched_scope_filter: &'a CommitStateTouchedScopeFilter,
+    pub(super) current_state_scoped_ranges: Option<&'a CurrentStateScopedRangeRoot>,
+}
+
+impl<'a> From<&'a CommitStateManifest> for CommitStateTopologyRef<'a> {
+    fn from(manifest: &'a CommitStateManifest) -> Self {
+        Self {
+            commit_id: manifest.commit_id,
+            touched_scope_filter: &manifest.touched_scope_filter,
+            current_state_scoped_ranges: manifest.current_state_scoped_ranges.as_deref(),
+        }
+    }
+}
 
 /// Publishes canonical column pages directly when their closed key envelopes
 /// are disjoint from every inherited post-image part. Interleaved parent rows
@@ -28,13 +45,12 @@ const TOUCHED_SCOPE_FILTER_CONTEXT: &str = "lix cumulative touched collection sc
 async fn stage_disjoint_columnar_current_state_pages(
     store: &(impl StorageAdapterRead + ?Sized),
     writes: &mut StorageWriteSet,
-    parent_manifest: Option<&CommitStateManifest>,
+    parent_manifest: Option<CommitStateTopologyRef<'_>>,
     inherited_scope_filter: &CommitStateTouchedScopeFilter,
     commit_id: CommitId,
     inventory: &CommitStateMutationInventory,
 ) -> Result<Option<CurrentStateScopedRangeRoot>, LixError> {
-    let parent =
-        parent_manifest.and_then(|manifest| manifest.current_state_scoped_ranges.as_deref());
+    let parent = parent_manifest.and_then(|manifest| manifest.current_state_scoped_ranges);
     let parts = inventory
         .columnar_parts
         .as_ref()
@@ -214,20 +230,20 @@ pub(crate) fn incomplete_touched_scope_filter() -> CommitStateTouchedScopeFilter
     CommitStateTouchedScopeFilter::default()
 }
 
-fn advance_touched_scope_filter(
-    parents: &[&CommitStateManifest],
-    selected_source: Option<&CommitStateManifest>,
+fn advance_touched_scope_filter_from_topology(
+    parents: &[CommitStateTopologyRef<'_>],
+    selected_source: Option<CommitStateTopologyRef<'_>>,
     touched: Option<&[CommitDeltaReplacementScope]>,
 ) -> Result<CommitStateTouchedScopeFilter, LixError> {
     let filter = if let Some(source) = selected_source {
-        validate_touched_scope_filter(&source.touched_scope_filter)?;
+        validate_touched_scope_filter(source.touched_scope_filter)?;
         if !source.touched_scope_filter.complete {
             return Ok(incomplete_touched_scope_filter());
         }
         source.touched_scope_filter.clone()
     } else {
         for parent in parents {
-            validate_touched_scope_filter(&parent.touched_scope_filter)?;
+            validate_touched_scope_filter(parent.touched_scope_filter)?;
             if !parent.touched_scope_filter.complete {
                 return Ok(incomplete_touched_scope_filter());
             }
@@ -250,6 +266,23 @@ fn advance_touched_scope_filter(
         }
     };
     extend_touched_scope_filter(filter, touched)
+}
+
+#[cfg(test)]
+fn advance_touched_scope_filter(
+    parents: &[&CommitStateManifest],
+    selected_source: Option<&CommitStateManifest>,
+    touched: Option<&[CommitDeltaReplacementScope]>,
+) -> Result<CommitStateTouchedScopeFilter, LixError> {
+    let parents = parents
+        .iter()
+        .map(|parent| CommitStateTopologyRef::from(*parent))
+        .collect::<Vec<_>>();
+    advance_touched_scope_filter_from_topology(
+        &parents,
+        selected_source.map(CommitStateTopologyRef::from),
+        touched,
+    )
 }
 
 fn extend_touched_scope_filter(
@@ -394,20 +427,55 @@ pub(super) fn certify_topology_touched_scope_filter_from_manifests(
 pub(crate) fn current_state_mutation_authority_digest(
     inventory: &CommitStateMutationInventory,
 ) -> Result<[u8; 32], LixError> {
-    let mut durable = inventory.clone();
-    if durable.replacement_generation.is_some() {
-        // Complete-replacement bounds are a rebuildable routing projection;
-        // immutable part digests and row counts remain in durable authority.
-        durable.parts.clear();
+    // The immutable commit header co-authenticates this transition, the small
+    // catalog, and the exact mutation-directory root. Re-encoding every part
+    // bound here would construct a second O(parts) digest on the commit path.
+    // Bind only logical/topology closure needed by the serving transition;
+    // the catalog digest and Merkle root bind exact physical part identity.
+    let mut digest = blake3::Hasher::new_derive_key("lix current-state transition authority v2");
+    digest.update(&inventory.member_count.to_be_bytes());
+    digest.update(&inventory.selection_fingerprint);
+    digest.update(&[u8::from(inventory.selected_source_commit_id.is_some())]);
+    if let Some(source) = inventory.selected_source_commit_id {
+        digest.update(&source);
     }
-    let encoded = storage_codec::encode("current-state mutation authority digest", &durable)?;
-    Ok(
-        *blake3::Hasher::new_derive_key("lix current-state mutation authority v1")
-            .update(&(encoded.len() as u64).to_be_bytes())
-            .update(&encoded)
-            .finalize()
-            .as_bytes(),
-    )
+    digest.update(&(inventory.part_count() as u64).to_be_bytes());
+    digest.update(&(inventory.direct_part_row_counts.len() as u64).to_be_bytes());
+    let generic_part_count = if inventory.replacement_generation.is_some() {
+        0
+    } else {
+        inventory.parts.len()
+    };
+    digest.update(&(generic_part_count as u64).to_be_bytes());
+    digest.update(&(inventory.replacement_part_digests.len() as u64).to_be_bytes());
+    digest.update(&[u8::from(!inventory.inline_part.is_empty())]);
+    if !inventory.inline_part.is_empty() {
+        digest.update(blake3::hash(&inventory.inline_part).as_bytes());
+    }
+    digest.update(&[u8::from(inventory.single_partition.is_some())]);
+    if let Some(scope) = inventory.single_partition.as_ref() {
+        digest.update(&(scope.schema_key.len() as u64).to_be_bytes());
+        digest.update(scope.schema_key.as_bytes());
+        digest.update(&[u8::from(scope.file_id.is_some())]);
+        if let Some(file_id) = scope.file_id.as_ref() {
+            digest.update(&(file_id.len() as u64).to_be_bytes());
+            digest.update(file_id.as_bytes());
+        }
+    }
+    if let Some(generation) = inventory.replacement_generation.as_ref() {
+        digest.update(&generation.owner_commit_id);
+        digest.update(&generation.integrity_digest);
+    }
+    if let Some(authority) = inventory.replacement_parts.as_ref() {
+        digest.update(&authority.directory_digest);
+    }
+    if let Some(columnar) = inventory.columnar_parts.as_ref() {
+        digest.update(&columnar.owner_commit_id);
+        digest.update(&columnar.row_group_set_id);
+        digest.update(&columnar.manifest_digest);
+        digest.update(&columnar.row_count.to_be_bytes());
+    }
+    Ok(*digest.finalize().as_bytes())
 }
 
 pub(crate) fn scoped_range_transition_digest(
@@ -418,6 +486,22 @@ pub(crate) fn scoped_range_transition_digest(
     tree: &ScopedRangeRoot,
 ) -> Result<[u8; 32], LixError> {
     let authority = current_state_mutation_authority_digest(inventory)?;
+    Ok(scoped_range_transition_digest_from_authority(
+        commit_id,
+        serving_base_commit_id,
+        serving_base_root_id,
+        authority,
+        tree,
+    ))
+}
+
+pub(crate) fn scoped_range_transition_digest_from_authority(
+    commit_id: CommitId,
+    serving_base_commit_id: Option<CommitId>,
+    serving_base_root_id: Option<[u8; 32]>,
+    mutation_authority_digest: [u8; 32],
+    tree: &ScopedRangeRoot,
+) -> [u8; 32] {
     let mut digest = blake3::Hasher::new_derive_key(TRANSITION_CONTEXT);
     digest.update(commit_id.as_uuid().as_bytes());
     digest.update(&[u8::from(serving_base_commit_id.is_some())]);
@@ -428,14 +512,14 @@ pub(crate) fn scoped_range_transition_digest(
     if let Some(serving_base_root_id) = serving_base_root_id {
         digest.update(&serving_base_root_id);
     }
-    digest.update(&authority);
+    digest.update(&mutation_authority_digest);
     digest.update(&tree.root_id);
     digest.update(&tree.root_digest);
     digest.update(&tree.marker_count.to_be_bytes());
     digest.update(&tree.part_count.to_be_bytes());
     digest.update(&tree.row_count.to_be_bytes());
     digest.update(&tree.tree_height.to_be_bytes());
-    Ok(*digest.finalize().as_bytes())
+    *digest.finalize().as_bytes()
 }
 
 pub(crate) fn attest_scoped_range_root(
@@ -554,12 +638,12 @@ pub(crate) async fn stage_complete_replacement_scoped_range_root(
 /// Applies one commit's certified current-state transition. Broad/unknown
 /// mutation scope fails closed by dropping the accelerator; canonical replay
 /// remains authoritative. Exact sparse commits path-copy only affected ranges.
-pub(crate) async fn stage_current_state_scoped_ranges(
+pub(super) async fn stage_current_state_scoped_ranges_from_topology_refs(
     store: &(impl StorageAdapterRead + ?Sized),
     writes: &mut StorageWriteSet,
-    graph_parents: &[&CommitStateManifest],
-    selected_source: Option<&CommitStateManifest>,
-    serving_base: Option<&CommitStateManifest>,
+    graph_parents: &[CommitStateTopologyRef<'_>],
+    selected_source: Option<CommitStateTopologyRef<'_>>,
+    serving_base: Option<CommitStateTopologyRef<'_>>,
     commit_id: CommitId,
     account_id: &str,
     inventory: &CommitStateMutationInventory,
@@ -570,7 +654,7 @@ pub(crate) async fn stage_current_state_scoped_ranges(
             "selected-source manifest disagrees with mutation authority",
         ));
     }
-    let parent_root = serving_base.and_then(|parent| parent.current_state_scoped_ranges.as_deref());
+    let parent_root = serving_base.and_then(|parent| parent.current_state_scoped_ranges);
     let touched = crate::tracked_state::storage::commit_state_inventory_exact_local_touched_scopes(
         commit_id,
         inventory,
@@ -589,7 +673,7 @@ pub(crate) async fn stage_current_state_scoped_ranges(
         )?
     };
     let inherited_scope_filter =
-        advance_touched_scope_filter(graph_parents, selected_source, Some(&[]))?;
+        advance_touched_scope_filter_from_topology(graph_parents, selected_source, Some(&[]))?;
     if inventory.columnar_parts.is_some() {
         let root = stage_disjoint_columnar_current_state_pages(
             store,
@@ -738,6 +822,34 @@ pub(crate) async fn stage_current_state_scoped_ranges(
         )?),
         touched_scope_filter,
     })
+}
+
+#[cfg(test)]
+pub(crate) async fn stage_current_state_scoped_ranges(
+    store: &(impl StorageAdapterRead + ?Sized),
+    writes: &mut StorageWriteSet,
+    graph_parents: &[&CommitStateManifest],
+    selected_source: Option<&CommitStateManifest>,
+    serving_base: Option<&CommitStateManifest>,
+    commit_id: CommitId,
+    account_id: &str,
+    inventory: &CommitStateMutationInventory,
+) -> Result<CertifiedCommitStatePhysicalPublication, LixError> {
+    let graph_parents = graph_parents
+        .iter()
+        .map(|parent| CommitStateTopologyRef::from(*parent))
+        .collect::<Vec<_>>();
+    stage_current_state_scoped_ranges_from_topology_refs(
+        store,
+        writes,
+        &graph_parents,
+        selected_source.map(CommitStateTopologyRef::from),
+        serving_base.map(CommitStateTopologyRef::from),
+        commit_id,
+        account_id,
+        inventory,
+    )
+    .await
 }
 
 pub(crate) fn validate_scoped_range_attestation(

--- a/packages/engine/src/tracked_state/storage.rs
+++ b/packages/engine/src/tracked_state/storage.rs
@@ -47,7 +47,9 @@ pub(crate) const TRACKED_STATE_COMMIT_DELTA_SEGMENT_NAMESPACE: &str =
     "tracked_state.commit_delta_segment.v6";
 pub(crate) const TRACKED_STATE_CHANGE_LOCATOR_NAMESPACE: &str = "tracked_state.change_locator.v2";
 pub(crate) const TRACKED_STATE_COMMIT_STATE_MANIFEST_NAMESPACE: &str =
-    "tracked_state.commit_state_manifest.v6";
+    "tracked_state.commit_state_manifest.v7";
+pub(crate) const TRACKED_STATE_COMMIT_MUTATION_INVENTORY_NAMESPACE: &str =
+    "tracked_state.commit_mutation_catalog.v1";
 const MIN_CURRENT_STATE_SCOPED_RANGE_POINT_READS: u16 = 4;
 pub(crate) const TRACKED_STATE_TREE_CHUNK_SPACE: StorageSpace = StorageSpace::mutable(
     StorageSpaceId(0x0004_0001),
@@ -67,13 +69,20 @@ pub(crate) const TRACKED_STATE_CHANGE_LOCATOR_SPACE: StorageSpace = StorageSpace
 );
 /// Hard-cut tracked commit authority.
 ///
-/// Current repositories publish this one manifest per commit, including
-/// commits with no tracked mutations. The former topology, delta-directory,
-/// and root authority spaces are not part of the current protocol.
+/// Current repositories publish one compact authority header per commit,
+/// including commits with no tracked mutations. The header authenticates a
+/// separately keyed mutation catalog and its optional hierarchical directory.
+/// The former topology, flat delta-directory, and root authority spaces are
+/// not part of the current protocol.
 pub(crate) const TRACKED_STATE_COMMIT_STATE_MANIFEST_SPACE: StorageSpace = StorageSpace::immutable(
     StorageSpaceId(0x0004_002b),
     TRACKED_STATE_COMMIT_STATE_MANIFEST_NAMESPACE,
 );
+pub(crate) const TRACKED_STATE_COMMIT_MUTATION_INVENTORY_SPACE: StorageSpace =
+    StorageSpace::immutable(
+        StorageSpaceId(0x0004_002c),
+        TRACKED_STATE_COMMIT_MUTATION_INVENTORY_NAMESPACE,
+    );
 
 // The durable direct-ChangeId address stride. Physical ordered parts may be
 // smaller, but their logical slots must remain stable at this width.
@@ -102,7 +111,10 @@ const COMMIT_DELTA_FORMAT_MAGIC: &[u8] = b"LXCD14";
 // Pre-cut manifests are deliberately incompatible with this physical-only format.
 // Version 8 binds current-state serving roots to an explicit physical base
 // commit independently from semantic graph ancestry.
-const COMMIT_STATE_MANIFEST_FORMAT_MAGIC: &[u8] = b"LXCS9";
+// Version 10 splits the authority header from a separately keyed mutation
+// catalog and authenticates a content-addressed hierarchical part directory.
+const COMMIT_STATE_MANIFEST_FORMAT_MAGIC: &[u8] = b"LXCS10";
+const COMMIT_STATE_MUTATION_INVENTORY_FORMAT_MAGIC: &[u8] = b"LXMI1";
 const COMMIT_DELTA_PAYLOAD_OFFSET_BYTES: usize = size_of::<u32>();
 #[cfg(not(test))]
 const COMMIT_DELTA_MAX_SIDECAR_BYTES: usize = 64 * 1024 * 1024;
@@ -418,8 +430,9 @@ impl AddressableCommitDeltaStage {
 /// Compact assignment map for an already ordered, fully addressable commit.
 ///
 /// Full 512-row segments derive their direct addresses from the row ordinal.
-/// Byte-limited irregular segments retain one packed u32 address per row. Both
-/// shapes avoid retaining one UUID per row while the prepared batch and backend
+/// Smaller physical segments retain only one cumulative row end per segment;
+/// their `(segment, ordinal)` address is derived on demand. Both shapes avoid
+/// retaining per-row UUIDs or addresses while the prepared batch and backend
 /// write batch are simultaneously live.
 #[derive(Debug, Clone)]
 pub(crate) struct OrderedAddressableCommitDeltaStage {
@@ -432,7 +445,7 @@ pub(crate) struct OrderedAddressableCommitDeltaStage {
 #[derive(Debug, Clone)]
 enum OrderedChangeAddresses {
     Dense,
-    Packed(Vec<u32>),
+    Segmented(Vec<u32>),
 }
 
 impl OrderedAddressableCommitDeltaStage {
@@ -461,7 +474,26 @@ impl OrderedAddressableCommitDeltaStage {
                 .expect("ordered commit-delta row index fits direct address space")
                 .checked_add(1)
                 .expect("ordered commit-delta address fits direct address space"),
-            OrderedChangeAddresses::Packed(addresses) => addresses[row_index],
+            OrderedChangeAddresses::Segmented(row_ends) => {
+                let row_index = u32::try_from(row_index)
+                    .expect("ordered commit-delta row index fits direct address space");
+                let segment_index = row_ends.partition_point(|&end| end <= row_index);
+                let segment_start = segment_index
+                    .checked_sub(1)
+                    .map_or(0, |previous| row_ends[previous]);
+                let ordinal = row_index
+                    .checked_sub(segment_start)
+                    .expect("ordered row follows its segment start");
+                u32::try_from(segment_index)
+                    .expect("ordered commit-delta segment index fits u32")
+                    .checked_mul(
+                        u32::try_from(COMMIT_DELTA_SEGMENT_MAX_ROWS)
+                            .expect("segment row limit fits u32"),
+                    )
+                    .and_then(|base| base.checked_add(ordinal))
+                    .and_then(|address| address.checked_add(1))
+                    .expect("ordered commit-delta address fits direct address space")
+            }
         };
         Some(change_id_from_packed_address(self.commit_id, packed))
     }
@@ -553,6 +585,56 @@ struct CommitDeltaManifest {
     #[musli(bytes)]
     inline_segment: Vec<u8>,
     segments: Vec<CommitDeltaSegmentBounds>,
+}
+
+/// Small immutable authority header for one tracked commit.
+///
+/// Large mutation-part bounds live exactly once in the separately keyed
+/// mutation inventory. This header owns its digest and selected-source fact,
+/// so the inventory cannot be substituted and does not duplicate topology.
+#[derive(Debug, Clone, PartialEq, Eq, musli::Encode, musli::Decode)]
+#[musli(packed)]
+struct StoredCommitStateManifest {
+    commit_id: CommitId,
+    change_account_id: String,
+    replay_debt: crate::tracked_state::CommitStateReplayDebt,
+    #[musli(with = storage_codec::option)]
+    selected_source_commit_id: Option<[u8; 16]>,
+    mutation_inventory_digest: [u8; 32],
+    mutation_transition_digest: [u8; 32],
+    mutation_member_count: u32,
+    mutation_part_count: u32,
+    #[musli(with = storage_codec::option)]
+    mutation_directory_root: Option<super::mutation_directory::MutationDirectoryRoot>,
+    touched_scope_filter: crate::tracked_state::types::CommitStateTouchedScopeFilter,
+    #[musli(with = storage_codec::option)]
+    current_state_scoped_ranges: Option<Box<CurrentStateScopedRangeRoot>>,
+    #[musli(with = storage_codec::option)]
+    snapshot_root: Option<Box<TrackedStateCommitRoot>>,
+}
+
+/// Small separately keyed mutation catalog. Large ordered part metadata lives
+/// only in the authenticated directory leaves referenced by `directory_root`.
+#[derive(Debug, Clone, PartialEq, Eq, musli::Encode, musli::Decode)]
+#[musli(packed)]
+struct StoredCommitMutationInventory {
+    member_count: u32,
+    selection_fingerprint: [u8; 32],
+    #[musli(with = storage_codec::option)]
+    single_partition: Option<CommitDeltaReplacementScope>,
+    #[musli(with = storage_codec::option)]
+    lifecycle_summary: Option<CommitDeltaLifecycleSummary>,
+    #[musli(with = storage_codec::option)]
+    replacement_generation: Option<StoredCommitDeltaReplacementGeneration>,
+    #[musli(with = storage_codec::option)]
+    replacement_parts: Option<StoredReplacementPartsAuthority>,
+    #[musli(with = storage_codec::option)]
+    columnar_parts: Option<crate::tracked_state::types::ColumnarMutationPartSet>,
+    #[musli(bytes)]
+    inline_part: Vec<u8>,
+    inline_direct: bool,
+    #[musli(with = storage_codec::option)]
+    directory_root: Option<super::mutation_directory::MutationDirectoryRoot>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -2151,9 +2233,26 @@ pub(super) async fn load_manifest_snapshot_commit_root(
     store: &(impl StorageAdapterRead + ?Sized),
     commit_id: CommitId,
 ) -> Result<Option<TrackedStateCommitRoot>, LixError> {
-    Ok(load_commit_state_manifest(store, commit_id)
-        .await?
-        .and_then(|manifest| manifest.snapshot_root.map(|root| *root)))
+    let Some(bytes) = get_one(
+        store,
+        TRACKED_STATE_COMMIT_STATE_MANIFEST_SPACE,
+        commit_state_manifest_key(commit_id),
+    )
+    .await?
+    else {
+        return Ok(None);
+    };
+    let stored = decode_stored_commit_state_manifest(&bytes)?;
+    if stored.commit_id != commit_id {
+        return Err(LixError::new(
+            LixError::CODE_INTERNAL_ERROR,
+            format!(
+                "tracked_state commit_state_manifest key for commit '{commit_id}' contains manifest for commit '{}'",
+                stored.commit_id
+            ),
+        ));
+    }
+    Ok(stored.snapshot_root.map(|root| *root))
 }
 
 fn commit_delta_manifest_key(commit_id: CommitId) -> Vec<u8> {
@@ -2164,6 +2263,10 @@ fn commit_state_manifest_key(commit_id: CommitId) -> Vec<u8> {
     commit_id.as_uuid().as_bytes().to_vec()
 }
 
+fn commit_mutation_inventory_key(commit_id: CommitId) -> Vec<u8> {
+    commit_id.as_uuid().as_bytes().to_vec()
+}
+
 /// Commit authority loaded from the immutable manifest plane. Only this
 /// opaque handle may bypass publication-time catalog re-derivation.
 #[derive(Clone, Debug)]
@@ -2171,11 +2274,53 @@ pub(crate) struct PublishedCommitStateManifest {
     manifest: CommitStateManifest,
 }
 
+/// Header-only immutable authority for topology and lifecycle work.
+/// Scoped-range transition metadata is authenticated directly by the compact
+/// header, so consumers do not need the mutation catalog or directory.
+#[derive(Clone, Debug)]
+pub(crate) struct PublishedCommitStateTopology {
+    header: StoredCommitStateManifest,
+}
+
+impl PublishedCommitStateTopology {
+    pub(crate) fn commit_id(&self) -> CommitId {
+        self.header.commit_id
+    }
+
+    pub(crate) fn replay_debt(&self) -> crate::tracked_state::CommitStateReplayDebt {
+        self.header.replay_debt
+    }
+
+    pub(crate) fn mutation_member_count(&self) -> u32 {
+        self.header.mutation_member_count
+    }
+
+    pub(crate) fn current_state_scoped_ranges(&self) -> Option<&CurrentStateScopedRangeRoot> {
+        self.header.current_state_scoped_ranges.as_deref()
+    }
+
+    pub(crate) fn snapshot_root_id(&self) -> Option<TrackedStateRootId> {
+        self.header
+            .snapshot_root
+            .as_ref()
+            .map(|root| root.root_id.clone())
+    }
+
+    fn topology_ref(&self) -> super::scoped_current_state::CommitStateTopologyRef<'_> {
+        super::scoped_current_state::CommitStateTopologyRef {
+            commit_id: self.header.commit_id,
+            touched_scope_filter: &self.header.touched_scope_filter,
+            current_state_scoped_ranges: self.header.current_state_scoped_ranges.as_deref(),
+        }
+    }
+}
+
 /// One-read immutable authority used by point replay. The wrapper prevents a
 /// freely constructed manifest from claiming authoritative catalog coverage.
 #[derive(Clone, Debug)]
 pub(crate) struct AuthenticatedReplayCommitStateManifest {
     manifest: CommitStateManifest,
+    mutation_directory_root: Option<super::mutation_directory::MutationDirectoryRoot>,
 }
 
 /// Same-write-set authority produced only after immutable physical publication.
@@ -2191,21 +2336,28 @@ pub(crate) struct StagedCommitStateManifest {
 /// touched-scope certificate.
 #[derive(Clone, Copy)]
 pub(crate) enum CertifiedCommitStateTopologyParent<'a> {
+    #[cfg(any(test, feature = "storage-benches"))]
     Published(&'a PublishedCommitStateManifest),
+    PublishedTopology(&'a PublishedCommitStateTopology),
     Staged(&'a StagedCommitStateManifest),
 }
 
 impl<'a> CertifiedCommitStateTopologyParent<'a> {
-    fn manifest(self, writes: &StorageWriteSet) -> Result<&'a CommitStateManifest, LixError> {
+    fn topology(
+        self,
+        writes: &StorageWriteSet,
+    ) -> Result<super::scoped_current_state::CommitStateTopologyRef<'a>, LixError> {
         match self {
-            Self::Published(parent) => Ok(&parent.manifest),
+            #[cfg(any(test, feature = "storage-benches"))]
+            Self::Published(parent) => Ok((&parent.manifest).into()),
+            Self::PublishedTopology(parent) => Ok(parent.topology_ref()),
             Self::Staged(parent) => {
                 if parent.write_set_id != writes.identity() {
                     return Err(replacement_payload_error(
                         "staged topology parent belongs to a different storage write set",
                     ));
                 }
-                Ok(&parent.manifest)
+                Ok((&parent.manifest).into())
             }
         }
     }
@@ -2247,13 +2399,13 @@ pub(crate) async fn stage_current_state_scoped_ranges_from_topology(
     let parents = parents
         .iter()
         .copied()
-        .map(|parent| parent.manifest(writes))
+        .map(|parent| parent.topology(writes))
         .collect::<Result<Vec<_>, _>>()?;
     let selected_source = selected_source
-        .map(|source| source.manifest(writes))
+        .map(|source| source.topology(writes))
         .transpose()?;
     let serving_base = selected_source.or_else(|| parents.first().copied());
-    super::scoped_current_state::stage_current_state_scoped_ranges(
+    super::scoped_current_state::stage_current_state_scoped_ranges_from_topology_refs(
         store,
         writes,
         &parents,
@@ -2274,12 +2426,35 @@ pub(crate) async fn stage_current_state_scoped_ranges_from_published_parent(
     account_id: &str,
     inventory: &CommitStateMutationInventory,
 ) -> Result<super::scoped_current_state::CertifiedCommitStatePhysicalPublication, LixError> {
-    super::scoped_current_state::stage_current_state_scoped_ranges(
+    super::scoped_current_state::stage_current_state_scoped_ranges_from_topology_refs(
         store,
         writes,
-        parent.map(|parent| &parent.manifest).as_slice(),
+        parent.map(|parent| (&parent.manifest).into()).as_slice(),
         None,
-        parent.map(|parent| &parent.manifest),
+        parent.map(|parent| (&parent.manifest).into()),
+        commit_id,
+        account_id,
+        inventory,
+    )
+    .await
+}
+
+pub(crate) async fn stage_current_state_scoped_ranges_from_published_topology_parent(
+    store: &(impl StorageAdapterRead + ?Sized),
+    writes: &mut StorageWriteSet,
+    parent: Option<&PublishedCommitStateTopology>,
+    commit_id: CommitId,
+    account_id: &str,
+    inventory: &CommitStateMutationInventory,
+) -> Result<super::scoped_current_state::CertifiedCommitStatePhysicalPublication, LixError> {
+    super::scoped_current_state::stage_current_state_scoped_ranges_from_topology_refs(
+        store,
+        writes,
+        parent
+            .map(PublishedCommitStateTopology::topology_ref)
+            .as_slice(),
+        None,
+        parent.map(PublishedCommitStateTopology::topology_ref),
         commit_id,
         account_id,
         inventory,
@@ -2300,12 +2475,12 @@ pub(crate) async fn stage_current_state_scoped_ranges_from_staged_parent(
             "staged scoped-range parent belongs to a different storage write set",
         ));
     }
-    super::scoped_current_state::stage_current_state_scoped_ranges(
+    super::scoped_current_state::stage_current_state_scoped_ranges_from_topology_refs(
         store,
         writes,
-        &[&parent.manifest],
+        &[(&parent.manifest).into()],
         None,
-        Some(&parent.manifest),
+        Some((&parent.manifest).into()),
         commit_id,
         account_id,
         inventory,
@@ -3188,16 +3363,40 @@ pub(crate) async fn load_commit_state_manifest(
 ) -> Result<Option<CommitStateManifest>, LixError> {
     #[cfg(feature = "storage-benches")]
     crate::storage_bench::record_crud_sealed_manifest_load();
-    let Some(bytes) = get_one(
-        store,
-        TRACKED_STATE_COMMIT_STATE_MANIFEST_SPACE,
-        commit_state_manifest_key(commit_id),
-    )
-    .await?
-    else {
-        return Ok(None);
+    let header_keys = [StorageKey(Bytes::from(commit_state_manifest_key(
+        commit_id,
+    )))];
+    let inventory_keys = [StorageKey(Bytes::from(commit_mutation_inventory_key(
+        commit_id,
+    )))];
+    let requests = [
+        StorageGetManyRequest {
+            space: TRACKED_STATE_COMMIT_STATE_MANIFEST_SPACE,
+            keys: &header_keys,
+            opts: StorageGetOptions::default(),
+        },
+        StorageGetManyRequest {
+            space: TRACKED_STATE_COMMIT_MUTATION_INVENTORY_SPACE,
+            keys: &inventory_keys,
+            opts: StorageGetOptions::default(),
+        },
+    ];
+    let mut values = exact_get_many(store, &requests).await?.values.into_iter();
+    let header = values.next().flatten().and_then(full_value_bytes);
+    let inventory = values.next().flatten().and_then(full_value_bytes);
+    let (header, inventory) = match (header, inventory) {
+        (None, None) => return Ok(None),
+        (Some(header), Some(inventory)) => (header, inventory),
+        _ => {
+            return Err(LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                format!(
+                    "tracked_state commit '{commit_id}' has incomplete split physical authority"
+                ),
+            ));
+        }
     };
-    let manifest = decode_commit_state_manifest(&bytes)?;
+    let manifest = decode_commit_state_manifest(store, &header, &inventory).await?;
     if manifest.commit_id != commit_id {
         return Err(LixError::new(
             LixError::CODE_INTERNAL_ERROR,
@@ -3219,14 +3418,49 @@ pub(crate) async fn load_published_commit_state_manifest(
         .map(|manifest| PublishedCommitStateManifest { manifest }))
 }
 
+/// Loads only the authenticated immutable authority header needed by commit
+/// topology, branch lifecycle, and scoped-root inheritance.
+pub(crate) async fn load_published_commit_state_topology(
+    store: &(impl StorageAdapterRead + ?Sized),
+    commit_id: CommitId,
+) -> Result<Option<PublishedCommitStateTopology>, LixError> {
+    let keys = [StorageKey(Bytes::from(commit_state_manifest_key(
+        commit_id,
+    )))];
+    let request = [StorageGetManyRequest {
+        space: TRACKED_STATE_COMMIT_STATE_MANIFEST_SPACE,
+        keys: &keys,
+        opts: StorageGetOptions::default(),
+    }];
+    let Some(bytes) = exact_get_many(store, &request)
+        .await?
+        .values
+        .into_iter()
+        .next()
+        .flatten()
+        .and_then(full_value_bytes)
+    else {
+        return Ok(None);
+    };
+    let header = decode_stored_commit_state_manifest(&bytes)?;
+    if header.commit_id != commit_id {
+        return Err(LixError::new(
+            LixError::CODE_INTERNAL_ERROR,
+            format!(
+                "tracked_state topology-header key for commit '{commit_id}' contains '{}'",
+                header.commit_id
+            ),
+        ));
+    }
+    Ok(Some(PublishedCommitStateTopology { header }))
+}
+
 /// Loads the replay projection from immutable physical authority.
 pub(crate) async fn load_replay_commit_state_manifest(
     store: &(impl StorageAdapterRead + ?Sized),
     commit_id: CommitId,
 ) -> Result<Option<CommitStateManifest>, LixError> {
-    Ok(load_point_replay_commit_state(store, commit_id)
-        .await?
-        .map(|state| state.manifest))
+    load_commit_state_manifest(store, commit_id).await
 }
 
 pub(crate) async fn load_point_replay_commit_state(
@@ -3235,16 +3469,42 @@ pub(crate) async fn load_point_replay_commit_state(
 ) -> Result<Option<AuthenticatedReplayCommitStateManifest>, LixError> {
     #[cfg(feature = "storage-benches")]
     crate::storage_bench::record_crud_replay_manifest_load();
-    let Some(authority) = get_one(
-        store,
-        TRACKED_STATE_COMMIT_STATE_MANIFEST_SPACE,
-        commit_state_manifest_key(commit_id),
-    )
-    .await?
-    else {
-        return Ok(None);
+    let header_keys = [StorageKey(Bytes::from(commit_state_manifest_key(
+        commit_id,
+    )))];
+    let inventory_keys = [StorageKey(Bytes::from(commit_mutation_inventory_key(
+        commit_id,
+    )))];
+    let requests = [
+        StorageGetManyRequest {
+            space: TRACKED_STATE_COMMIT_STATE_MANIFEST_SPACE,
+            keys: &header_keys,
+            opts: StorageGetOptions::default(),
+        },
+        StorageGetManyRequest {
+            space: TRACKED_STATE_COMMIT_MUTATION_INVENTORY_SPACE,
+            keys: &inventory_keys,
+            opts: StorageGetOptions::default(),
+        },
+    ];
+    let mut values = exact_get_many(store, &requests).await?.values.into_iter();
+    let header = values.next().flatten().and_then(full_value_bytes);
+    let inventory = values.next().flatten().and_then(full_value_bytes);
+    let (header, inventory) = match (header, inventory) {
+        (None, None) => return Ok(None),
+        (Some(header), Some(inventory)) => (header, inventory),
+        _ => {
+            return Err(LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                format!(
+                    "tracked_state commit '{commit_id}' has incomplete split physical authority"
+                ),
+            ));
+        }
     };
-    let state = decode_commit_state_manifest(&authority)?;
+    let (stored, stored_inventory) = decode_stored_commit_state_authority(&header, &inventory)?;
+    let mutation_directory_root = stored_inventory.directory_root.clone();
+    let state = assemble_shallow_commit_state_manifest(stored, stored_inventory)?;
     if state.commit_id != commit_id {
         return Err(LixError::new(
             LixError::CODE_INTERNAL_ERROR,
@@ -3256,6 +3516,7 @@ pub(crate) async fn load_point_replay_commit_state(
     }
     Ok(Some(AuthenticatedReplayCommitStateManifest {
         manifest: state,
+        mutation_directory_root,
     }))
 }
 
@@ -3264,6 +3525,107 @@ pub(crate) async fn load_commit_state_manifests(
     store: &(impl StorageAdapterRead + ?Sized),
     commit_ids: &[CommitId],
 ) -> Result<Vec<Option<CommitStateManifest>>, LixError> {
+    let header_keys = commit_ids
+        .iter()
+        .map(|commit_id| StorageKey(Bytes::from(commit_state_manifest_key(*commit_id))))
+        .collect::<Vec<_>>();
+    let inventory_keys = commit_ids
+        .iter()
+        .map(|commit_id| StorageKey(Bytes::from(commit_mutation_inventory_key(*commit_id))))
+        .collect::<Vec<_>>();
+    let requests = [
+        StorageGetManyRequest {
+            space: TRACKED_STATE_COMMIT_STATE_MANIFEST_SPACE,
+            keys: &header_keys,
+            opts: StorageGetOptions::default(),
+        },
+        StorageGetManyRequest {
+            space: TRACKED_STATE_COMMIT_MUTATION_INVENTORY_SPACE,
+            keys: &inventory_keys,
+            opts: StorageGetOptions::default(),
+        },
+    ];
+    let mut values = exact_get_many(store, &requests).await?.values;
+    let inventories = values.split_off(commit_ids.len());
+    let headers = values;
+    let mut authorities = Vec::with_capacity(commit_ids.len());
+    for (commit_id, (header_value, inventory_value)) in commit_ids
+        .iter()
+        .copied()
+        .zip(headers.into_iter().zip(inventories))
+    {
+        let header = header_value.and_then(full_value_bytes);
+        let inventory = inventory_value.and_then(full_value_bytes);
+        let (header, inventory) = match (header, inventory) {
+            (None, None) => {
+                authorities.push(None);
+                continue;
+            }
+            (Some(header), Some(inventory)) => (header, inventory),
+            _ => {
+                return Err(LixError::new(
+                    LixError::CODE_INTERNAL_ERROR,
+                    format!(
+                        "tracked_state commit '{commit_id}' has incomplete split physical authority"
+                    ),
+                ));
+            }
+        };
+        let (stored, stored_inventory) = decode_stored_commit_state_authority(&header, &inventory)?;
+        if stored.commit_id != commit_id {
+            return Err(LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                format!(
+                    "tracked_state commit-state batch key for commit '{commit_id}' contains manifest for commit '{}'",
+                    stored.commit_id
+                ),
+            ));
+        }
+        authorities.push(Some((stored, stored_inventory)));
+    }
+    let roots = authorities
+        .iter()
+        .filter_map(|authority| {
+            authority
+                .as_ref()
+                .and_then(|(_, inventory)| inventory.directory_root.clone())
+        })
+        .collect::<Vec<_>>();
+    let mut directories = super::mutation_directory::load_mutation_directories(store, &roots)
+        .await?
+        .into_iter();
+    let mut output = Vec::with_capacity(authorities.len());
+    for authority in authorities {
+        let Some((stored, inventory)) = authority else {
+            output.push(None);
+            continue;
+        };
+        let entries = if inventory.directory_root.is_some() {
+            directories
+                .next()
+                .expect("each authenticated root returns one directory")
+        } else {
+            Vec::new()
+        };
+        output.push(Some(assemble_commit_state_manifest(
+            stored, inventory, entries, true,
+        )?));
+    }
+    debug_assert!(directories.next().is_none());
+    Ok(output)
+}
+
+/// Loads only the small immutable authority headers in request order.
+///
+/// Topology membership and commit identity do not require mutation-directory
+/// bytes. Each returned header has already passed format, replay, root, scoped
+/// metadata, and directory-digest-shape validation; replay/history consumers
+/// must use [`load_commit_state_manifests`] to authenticate and decode the
+/// separately keyed directory itself.
+pub(crate) async fn load_commit_state_authority_ids(
+    store: &(impl StorageAdapterRead + ?Sized),
+    commit_ids: &[CommitId],
+) -> Result<Vec<Option<CommitId>>, LixError> {
     let keys = commit_ids
         .iter()
         .map(|commit_id| StorageKey(Bytes::from(commit_state_manifest_key(*commit_id))))
@@ -3273,27 +3635,64 @@ pub(crate) async fn load_commit_state_manifests(
         keys: &keys,
         opts: StorageGetOptions::default(),
     }];
-    let manifests = exact_get_many(store, &request).await?.values;
     commit_ids
         .iter()
         .copied()
-        .zip(manifests)
-        .map(|(commit_id, manifest_value)| {
-            let manifest_bytes = manifest_value.and_then(full_value_bytes);
-            let Some(bytes) = manifest_bytes else {
+        .zip(exact_get_many(store, &request).await?.values)
+        .map(|(commit_id, value)| {
+            let Some(bytes) = value.and_then(full_value_bytes) else {
                 return Ok(None);
             };
-            let manifest = decode_commit_state_manifest(&bytes)?;
-            if manifest.commit_id != commit_id {
+            let stored = decode_stored_commit_state_manifest(&bytes)?;
+            if stored.commit_id != commit_id {
                 return Err(LixError::new(
                     LixError::CODE_INTERNAL_ERROR,
                     format!(
-                        "tracked_state commit-state batch key for commit '{commit_id}' contains manifest for commit '{}'",
-                        manifest.commit_id
+                        "tracked_state authority-header key for commit '{commit_id}' contains '{}'",
+                        stored.commit_id
                     ),
                 ));
             }
-            Ok(Some(manifest))
+            Ok(Some(stored.commit_id))
+        })
+        .collect()
+}
+
+/// Loads authenticated mutation-directory roots without reading catalogs or
+/// directory nodes. GC uses this projection to mark shared content-addressed
+/// nodes from retained commit authorities.
+pub(crate) async fn load_commit_mutation_directory_roots(
+    store: &(impl StorageAdapterRead + ?Sized),
+    commit_ids: &[CommitId],
+) -> Result<Vec<Option<super::mutation_directory::MutationDirectoryRoot>>, LixError> {
+    let keys = commit_ids
+        .iter()
+        .map(|commit_id| StorageKey(Bytes::from(commit_state_manifest_key(*commit_id))))
+        .collect::<Vec<_>>();
+    let request = [StorageGetManyRequest {
+        space: TRACKED_STATE_COMMIT_STATE_MANIFEST_SPACE,
+        keys: &keys,
+        opts: StorageGetOptions::default(),
+    }];
+    commit_ids
+        .iter()
+        .copied()
+        .zip(exact_get_many(store, &request).await?.values)
+        .map(|(commit_id, value)| {
+            let Some(bytes) = value.and_then(full_value_bytes) else {
+                return Ok(None);
+            };
+            let stored = decode_stored_commit_state_manifest(&bytes)?;
+            if stored.commit_id != commit_id {
+                return Err(LixError::new(
+                    LixError::CODE_INTERNAL_ERROR,
+                    format!(
+                        "tracked_state mutation-root key for commit '{commit_id}' contains '{}'",
+                        stored.commit_id
+                    ),
+                ));
+            }
+            Ok(stored.mutation_directory_root)
         })
         .collect()
 }
@@ -3322,11 +3721,29 @@ fn stage_commit_state_manifest_bytes(
 ) -> Result<(), LixError> {
     let encoded = encode_commit_state_manifest(manifest)?;
     #[cfg(feature = "storage-benches")]
-    crate::storage_bench::record_crud_commit_state_manifest_bytes(encoded.len());
+    crate::storage_bench::record_crud_commit_state_manifest_bytes(
+        encoded.header.len()
+            + encoded.mutation_inventory.len()
+            + encoded.mutation_directory.as_ref().map_or(0, |directory| {
+                directory
+                    .node_bytes()
+                    .values()
+                    .map(Bytes::len)
+                    .sum::<usize>()
+            }),
+    );
+    if let Some(directory) = encoded.mutation_directory.as_ref() {
+        directory.stage(writes)?;
+    }
     writes.put(
         TRACKED_STATE_COMMIT_STATE_MANIFEST_SPACE,
         key(commit_state_manifest_key(manifest.commit_id)),
-        value(encoded),
+        value(encoded.header),
+    );
+    writes.put(
+        TRACKED_STATE_COMMIT_MUTATION_INVENTORY_SPACE,
+        key(commit_mutation_inventory_key(manifest.commit_id)),
+        value(encoded.mutation_inventory),
     );
     Ok(())
 }
@@ -3416,13 +3833,24 @@ pub(crate) fn stage_resealed_commit_state_manifest_for_test(
     manifest: &CommitStateManifest,
 ) -> Result<(), LixError> {
     let encoded = encode_commit_state_manifest(manifest)?;
+    if let Some(directory) = encoded.mutation_directory.as_ref() {
+        directory.stage(writes)?;
+    }
     writes.put(
         StorageSpace::mutable(
             TRACKED_STATE_COMMIT_STATE_MANIFEST_SPACE.id,
             TRACKED_STATE_COMMIT_STATE_MANIFEST_NAMESPACE,
         ),
         key(commit_state_manifest_key(manifest.commit_id)),
-        value(encoded),
+        value(encoded.header),
+    );
+    writes.put(
+        StorageSpace::mutable(
+            TRACKED_STATE_COMMIT_MUTATION_INVENTORY_SPACE.id,
+            TRACKED_STATE_COMMIT_MUTATION_INVENTORY_NAMESPACE,
+        ),
+        key(commit_mutation_inventory_key(manifest.commit_id)),
+        value(encoded.mutation_inventory),
     );
     Ok(())
 }
@@ -3655,24 +4083,18 @@ where
     let change_addresses = if dense_addresses {
         OrderedChangeAddresses::Dense
     } else {
-        let mut packed = Vec::with_capacity(row_count);
-        for (segment_index, &segment_rows) in segment_row_counts.iter().enumerate() {
-            let segment_base = u32::try_from(segment_index)
-                .expect("ordered commit-delta segment index fits u32")
-                .checked_mul(
-                    u32::try_from(COMMIT_DELTA_SEGMENT_MAX_ROWS)
-                        .expect("segment row limit fits u32"),
-                )
-                .expect("ordered commit-delta segment base fits direct address space");
-            packed.extend((0..segment_rows).map(|ordinal| {
-                segment_base
-                    .checked_add(u32::from(ordinal))
-                    .and_then(|address| address.checked_add(1))
-                    .expect("ordered commit-delta address fits u32")
-            }));
-        }
-        debug_assert_eq!(packed.len(), row_count);
-        OrderedChangeAddresses::Packed(packed)
+        let mut cumulative_rows = 0u32;
+        let row_ends = segment_row_counts
+            .iter()
+            .map(|&segment_rows| {
+                cumulative_rows = cumulative_rows
+                    .checked_add(u32::from(segment_rows))
+                    .expect("ordered commit-delta row count fits u32");
+                cumulative_rows
+            })
+            .collect::<Vec<_>>();
+        debug_assert_eq!(usize::try_from(cumulative_rows).ok(), Some(row_count));
+        OrderedChangeAddresses::Segmented(row_ends)
     };
     Ok(Some(OrderedAddressableCommitDeltaStage {
         commit_id,
@@ -4093,17 +4515,19 @@ pub(crate) fn stage_preencoded_ordered_addressable_replacement_parts(
     let change_addresses = if dense {
         OrderedChangeAddresses::Dense
     } else {
-        let mut packed = Vec::with_capacity(row_count);
-        for (segment_index, &rows) in manifest.direct_segment_row_counts.iter().enumerate() {
-            let base = u32::try_from(segment_index)
-                .expect("replacement segment index fits u32")
-                .checked_mul(
-                    u32::try_from(COMMIT_DELTA_SEGMENT_MAX_ROWS).expect("row limit fits u32"),
-                )
-                .expect("replacement direct address fits u32");
-            packed.extend((0..rows).map(|ordinal| base + u32::from(ordinal) + 1));
-        }
-        OrderedChangeAddresses::Packed(packed)
+        let mut cumulative_rows = 0u32;
+        let row_ends = manifest
+            .direct_segment_row_counts
+            .iter()
+            .map(|&rows| {
+                cumulative_rows = cumulative_rows
+                    .checked_add(u32::from(rows))
+                    .expect("replacement row count fits u32");
+                cumulative_rows
+            })
+            .collect::<Vec<_>>();
+        debug_assert_eq!(usize::try_from(cumulative_rows).ok(), Some(row_count));
+        OrderedChangeAddresses::Segmented(row_ends)
     };
     Ok(OrderedAddressableCommitDeltaStage {
         commit_id,
@@ -5666,16 +6090,42 @@ pub(crate) async fn load_commit_delta_values_encoded_with_cache(
 /// immutable parts; ordinary manifests seed and reuse the point cache.
 pub(crate) async fn load_commit_delta_values_encoded_from_replay_manifest(
     store: &(impl StorageAdapterRead + ?Sized),
-    state: &CommitStateManifest,
+    state: &AuthenticatedReplayCommitStateManifest,
     encoded_keys: &[Bytes],
     point_cache: &CommitDeltaPointReadCache,
 ) -> Result<Vec<Option<TrackedStateIndexValue>>, LixError> {
-    if !state.mutations.replacement_part_digests.is_empty() {
+    if state.mutations.selected_source_commit_id.is_none()
+        && state.mutation_directory_root.as_ref().is_some_and(|root| {
+            root.layout == super::mutation_directory::LAYOUT_BOUNDED_DIRECT
+                || root.layout == super::mutation_directory::LAYOUT_BOUNDED_INDIRECT
+        })
+    {
+        return load_bounded_directory_values_encoded(store, state, encoded_keys).await;
+    }
+    if state
+        .mutation_directory_root
+        .as_ref()
+        .is_some_and(|root| root.layout == super::mutation_directory::LAYOUT_COMPACT_REPLACEMENT)
+    {
+        if let Some(root) = state.current_state_scoped_ranges.as_ref()
+            && let Some(values) =
+                load_complete_current_state_values_from_scoped_root(store, root, encoded_keys)
+                    .await?
+        {
+            return Ok(values);
+        }
+        let full_state = load_commit_state_manifest(store, state.commit_id)
+            .await?
+            .ok_or_else(|| {
+                replacement_payload_error(
+                    "compact point replay lost its mutation-directory authority",
+                )
+            })?;
         return load_compact_replacement_values_encoded(
             store,
             state.commit_id,
             encoded_keys,
-            state,
+            &full_state,
         )
         .await;
     }
@@ -5690,6 +6140,80 @@ pub(crate) async fn load_commit_delta_values_encoded_from_replay_manifest(
         Some(point_cache),
     )
     .await
+}
+
+async fn load_bounded_directory_values_encoded(
+    store: &(impl StorageAdapterRead + ?Sized),
+    state: &AuthenticatedReplayCommitStateManifest,
+    encoded_keys: &[Bytes],
+) -> Result<Vec<Option<TrackedStateIndexValue>>, LixError> {
+    let root = state.mutation_directory_root.as_ref().ok_or_else(|| {
+        replacement_payload_error("bounded point replay omitted its mutation-directory root")
+    })?;
+    let key_refs = encoded_keys.iter().map(Bytes::as_ref).collect::<Vec<_>>();
+    let routes =
+        super::mutation_directory::route_mutation_directory_points(store, root, &key_refs).await?;
+    let mut grouped = BTreeMap::<u32, (CommitStateMutationPart, Vec<usize>)>::new();
+    for (output_index, route) in routes.into_iter().enumerate() {
+        let Some(route) = route else {
+            continue;
+        };
+        match grouped.entry(route.entry_index) {
+            std::collections::btree_map::Entry::Vacant(entry) => {
+                entry.insert((route.part, vec![output_index]));
+            }
+            std::collections::btree_map::Entry::Occupied(mut entry) => {
+                if entry.get().0 != route.part {
+                    return Err(replacement_payload_error(
+                        "bounded point replay returned conflicting part routes",
+                    ));
+                }
+                entry.get_mut().1.push(output_index);
+            }
+        }
+    }
+    let storage_keys = grouped
+        .iter()
+        .map(|(&part_index, (part, _))| {
+            commit_delta_segment_key_for_bounds(
+                state.commit_id,
+                usize::try_from(part_index)
+                    .map_err(|_| replacement_payload_error("part index exceeds usize"))?,
+                &CommitDeltaSegmentBounds {
+                    first_key: part.first_key.clone(),
+                    last_key: part.last_key.clone(),
+                    replacement_part: part.replacement_part.clone(),
+                },
+            )
+            .map(|key| StorageKey(Bytes::from(key)))
+        })
+        .collect::<Result<Vec<_>, LixError>>()?;
+    let loaded = PointReadPlan::new(TRACKED_STATE_COMMIT_DELTA_SEGMENT_SPACE, &storage_keys)
+        .materialize(store, StorageGetOptions::default())
+        .await?;
+    let mut output = vec![None; encoded_keys.len()];
+    for ((_, (part, requests)), value) in grouped.into_iter().zip(loaded.value) {
+        let bytes = value.and_then(full_value_bytes).ok_or_else(|| {
+            replacement_payload_error("bounded mutation directory references a missing part")
+        })?;
+        let bounds = CommitDeltaSegmentBounds {
+            first_key: part.first_key,
+            last_key: part.last_key,
+            replacement_part: part.replacement_part,
+        };
+        let (leaf, payloads) = decode_commit_delta_with_payloads(&bytes, Some(&bounds))?;
+        for output_index in requests {
+            output[output_index] = find_loaded_commit_delta_entry(
+                &leaf,
+                &payloads,
+                &encoded_keys[output_index],
+                state.commit_id,
+                &state.change_account_id,
+            )?
+            .map(|entry| entry.value);
+        }
+    }
+    Ok(output)
 }
 
 async fn load_compact_replacement_values_encoded(
@@ -6647,46 +7171,48 @@ async fn load_inventory_part_entries_one_ordered(
     store: &(impl StorageAdapterRead + ?Sized),
     commit_id: CommitId,
     keys: &[TrackedStateKeyRef<'_>],
-    state: &CommitStateManifest,
+    state: &AuthenticatedReplayCommitStateManifest,
 ) -> Result<Vec<Option<LoadedCommitDeltaEntry>>, LixError> {
-    let inventory = &state.mutations;
-    if !inventory_parts_support_direct_route(inventory) {
-        return Err(replacement_payload_error(
-            "ordered mutation inventory has invalid part bounds",
-        ));
-    }
+    let root = state.mutation_directory_root.as_ref().ok_or_else(|| {
+        replacement_payload_error("ordered mutation inventory omitted its directory root")
+    })?;
     let mut encoded_keys = Vec::new();
-    let mut grouped = BTreeMap::<usize, Vec<(usize, Range<usize>)>>::new();
-    for (output_index, &key) in keys.iter().enumerate() {
-        let encoded = encode_key_ref_into(&mut encoded_keys, key);
-        let key_bytes = &encoded_keys[encoded.clone()];
-        let mut lower = 0usize;
-        let mut upper = inventory.parts.len();
-        while lower < upper {
-            let middle = lower + (upper - lower) / 2;
-            if inventory.parts[middle].first_key.as_slice() <= key_bytes {
-                lower = middle + 1;
-            } else {
-                upper = middle;
-            }
-        }
-        let Some(part_index) = lower.checked_sub(1) else {
+    let ranges = keys
+        .iter()
+        .map(|&key| encode_key_ref_into(&mut encoded_keys, key))
+        .collect::<Vec<_>>();
+    let key_bytes = ranges
+        .iter()
+        .map(|range| &encoded_keys[range.clone()])
+        .collect::<Vec<_>>();
+    let routes =
+        super::mutation_directory::route_mutation_directory_points(store, root, &key_bytes).await?;
+    let mut grouped = BTreeMap::<u32, (CommitStateMutationPart, Vec<(usize, Range<usize>)>)>::new();
+    for (output_index, (encoded, route)) in ranges.into_iter().zip(routes).enumerate() {
+        let Some(route) = route else {
             continue;
         };
-        if key_bytes <= inventory.parts[part_index].last_key.as_slice() {
-            grouped
-                .entry(part_index)
-                .or_default()
-                .push((output_index, encoded));
+        match grouped.entry(route.entry_index) {
+            std::collections::btree_map::Entry::Vacant(entry) => {
+                entry.insert((route.part, vec![(output_index, encoded)]));
+            }
+            std::collections::btree_map::Entry::Occupied(mut entry) => {
+                if entry.get().0 != route.part {
+                    return Err(replacement_payload_error(
+                        "mutation directory returned conflicting routes for one part",
+                    ));
+                }
+                entry.get_mut().1.push((output_index, encoded));
+            }
         }
     }
     let storage_keys = grouped
-        .keys()
-        .map(|&part_index| {
-            let bounds = &inventory.parts[part_index];
+        .iter()
+        .map(|(&part_index, (bounds, _))| {
             commit_delta_segment_key_for_bounds(
                 commit_id,
-                part_index,
+                usize::try_from(part_index)
+                    .map_err(|_| replacement_payload_error("part index exceeds usize"))?,
                 &CommitDeltaSegmentBounds {
                     first_key: bounds.first_key.clone(),
                     last_key: bounds.last_key.clone(),
@@ -6700,11 +7226,10 @@ async fn load_inventory_part_entries_one_ordered(
         .materialize(store, StorageGetOptions::default())
         .await?;
     let mut output = (0..keys.len()).map(|_| None).collect::<Vec<_>>();
-    for ((part_index, requests), value) in grouped.into_iter().zip(loaded.value) {
+    for ((_, (part, requests)), value) in grouped.into_iter().zip(loaded.value) {
         let bytes = value.and_then(full_value_bytes).ok_or_else(|| {
             replacement_payload_error("mutation inventory references a missing immutable part")
         })?;
-        let part = &inventory.parts[part_index];
         let bounds = CommitDeltaSegmentBounds {
             first_key: part.first_key.clone(),
             last_key: part.last_key.clone(),
@@ -6722,20 +7247,6 @@ async fn load_inventory_part_entries_one_ordered(
         }
     }
     Ok(output)
-}
-
-fn inventory_parts_support_direct_route(inventory: &CommitStateMutationInventory) -> bool {
-    !(inventory.selected_source_commit_id.is_some()
-        || !inventory.inline_part.is_empty()
-        || inventory.parts.is_empty()
-        || inventory.parts.len() != inventory.direct_part_row_counts.len()
-        || inventory.parts.iter().any(|part| {
-            part.first_key.is_empty() || part.last_key.is_empty() || part.first_key > part.last_key
-        })
-        || inventory
-            .parts
-            .windows(2)
-            .any(|pair| pair[0].last_key >= pair[1].first_key))
 }
 
 /// Fast path for one physical owner and an already ordered exact-key batch.
@@ -6760,14 +7271,29 @@ async fn load_local_owned_commit_delta_entries_one_ordered(
                 return Ok((0..keys.len()).map(|_| None).collect());
             };
             if keys.len() <= DECODED_COMMIT_DELTA_CACHE_MAX_POINT_KEYS
-                && inventory_parts_support_direct_route(&state.mutations)
+                && state.mutations.selected_source_commit_id.is_none()
+                && state.mutations.inline_part.is_empty()
+                && state.mutation_directory_root.as_ref().is_some_and(|root| {
+                    root.layout == super::mutation_directory::LAYOUT_BOUNDED_DIRECT
+                })
             {
                 let output =
                     load_inventory_part_entries_one_ordered(store, commit_id, keys, &state).await?;
-                remember_expanded_point_manifest(store, &state, point_cache).await?;
                 return Ok(output);
             }
-            let manifest = expanded_commit_delta_manifest_from_commit_state(store, &state).await?;
+            let full_state = if state.mutation_directory_root.is_some() {
+                load_commit_state_manifest(store, commit_id)
+                    .await?
+                    .ok_or_else(|| {
+                        replacement_payload_error(
+                            "point replay lost its full mutation-directory authority",
+                        )
+                    })?
+            } else {
+                state.manifest.clone()
+            };
+            let manifest =
+                expanded_commit_delta_manifest_from_commit_state(store, &full_state).await?;
             validate_commit_delta_manifest(&manifest)?;
             if manifest
                 .replacement_generation
@@ -7118,19 +7644,6 @@ async fn load_local_owned_commit_delta_entries_one_ordered(
     }
     hydrate_selected_loaded_entries(store, &mut output).await?;
     Ok(output)
-}
-
-async fn remember_expanded_point_manifest(
-    store: &(impl StorageAdapterRead + ?Sized),
-    state: &CommitStateManifest,
-    point_cache: Option<&CommitDeltaPointReadCache>,
-) -> Result<(), LixError> {
-    let Some(point_cache) = point_cache else {
-        return Ok(());
-    };
-    let manifest = expanded_commit_delta_manifest_from_commit_state(store, state).await?;
-    validate_commit_delta_manifest(&manifest)?;
-    point_cache.remember_manifest(state.commit_id, Arc::new(manifest))
 }
 
 async fn hydrate_selected_loaded_entries(
@@ -7568,11 +8081,18 @@ pub(crate) async fn visit_change_records_from_commit_deltas(
                     "tracked_state commit_delta manifest key is not a 16-byte commit id",
                 ));
             }
-            let StorageProjectedValue::FullValue(bytes) = &entry.value else {
+            let StorageProjectedValue::FullValue(_) = &entry.value else {
                 unreachable!("full commit-delta scan returned a key-only row");
             };
             let commit_id = commit_id_from_delta_key(&entry.key)?;
-            let state = decode_commit_state_manifest(bytes)?;
+            let state = load_commit_state_manifest(store, commit_id)
+                .await?
+                .ok_or_else(|| {
+                    LixError::new(
+                        LixError::CODE_INTERNAL_ERROR,
+                        "tracked_state commit-state scan lost its split authority",
+                    )
+                })?;
             if state.commit_id != commit_id {
                 return Err(LixError::new(
                     LixError::CODE_INTERNAL_ERROR,
@@ -7941,10 +8461,30 @@ async fn scan_commit_delta_plane(
 ) -> Result<CommitDeltaPlane, LixError> {
     let commit_state_rows =
         scan_full_space(store, TRACKED_STATE_COMMIT_STATE_MANIFEST_SPACE).await?;
+    let mutation_inventory_rows =
+        scan_full_space(store, TRACKED_STATE_COMMIT_MUTATION_INVENTORY_SPACE).await?;
     let segment_rows = scan_full_space(store, TRACKED_STATE_COMMIT_DELTA_SEGMENT_SPACE).await?;
 
-    let mut manifests = BTreeMap::<CommitId, CommitDeltaManifest>::new();
-    for (key, bytes) in commit_state_rows {
+    let header_keys = commit_state_rows
+        .iter()
+        .map(|(key, _)| key)
+        .collect::<BTreeSet<_>>();
+    let inventory_keys = mutation_inventory_rows
+        .iter()
+        .map(|(key, _)| key)
+        .collect::<BTreeSet<_>>();
+    if header_keys != inventory_keys {
+        return Err(LixError::new(
+            LixError::CODE_INTERNAL_ERROR,
+            "tracked_state split commit authority has orphaned headers or mutation inventories",
+        ));
+    }
+
+    let mut inventory_rows = mutation_inventory_rows
+        .into_iter()
+        .collect::<BTreeMap<_, _>>();
+    let mut authorities = Vec::with_capacity(commit_state_rows.len());
+    for (key, header) in commit_state_rows {
         if key.0.len() != 16 {
             return Err(LixError::new(
                 LixError::CODE_INTERNAL_ERROR,
@@ -7952,12 +8492,46 @@ async fn scan_commit_delta_plane(
             ));
         }
         let commit_id = commit_id_from_delta_key(&key)?;
-        let manifest = decode_commit_state_manifest(&bytes)?;
-        if manifest.commit_id != commit_id || manifests.contains_key(&commit_id) {
+        let inventory = inventory_rows.remove(&key).ok_or_else(|| {
+            LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                "tracked_state commit-state inventory lost its split authority",
+            )
+        })?;
+        let (stored, stored_inventory) = decode_stored_commit_state_authority(&header, &inventory)?;
+        if stored.commit_id != commit_id {
             return Err(LixError::new(
                 LixError::CODE_INTERNAL_ERROR,
                 format!(
                     "tracked_state commit-state inventory found duplicate or mismatched manifest for commit '{commit_id}'"
+                ),
+            ));
+        }
+        authorities.push((commit_id, stored, stored_inventory));
+    }
+    debug_assert!(inventory_rows.is_empty());
+    let roots = authorities
+        .iter()
+        .filter_map(|(_, _, inventory)| inventory.directory_root.clone())
+        .collect::<Vec<_>>();
+    let mut directories = super::mutation_directory::load_mutation_directories(store, &roots)
+        .await?
+        .into_iter();
+    let mut manifests = BTreeMap::<CommitId, CommitDeltaManifest>::new();
+    for (commit_id, stored, inventory) in authorities {
+        let entries = if inventory.directory_root.is_some() {
+            directories
+                .next()
+                .expect("each scanned mutation root returns one directory")
+        } else {
+            Vec::new()
+        };
+        let manifest = assemble_commit_state_manifest(stored, inventory, entries, true)?;
+        if manifests.contains_key(&commit_id) {
+            return Err(LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                format!(
+                    "tracked_state commit-state inventory found duplicate manifest for commit '{commit_id}'"
                 ),
             ));
         }
@@ -7966,6 +8540,7 @@ async fn scan_commit_delta_plane(
             expanded_commit_delta_manifest_from_commit_state(store, &manifest).await?,
         );
     }
+    debug_assert!(directories.next().is_none());
 
     let mut segments = BTreeMap::<CommitId, BTreeMap<usize, Bytes>>::new();
     let mut segment_keys = BTreeMap::<CommitId, BTreeMap<usize, Bytes>>::new();
@@ -8071,6 +8646,10 @@ pub(crate) fn stage_delete_commit_delta_inventory_entry(
     writes.delete(
         TRACKED_STATE_COMMIT_STATE_MANIFEST_SPACE,
         key(commit_state_manifest_key(commit_id)),
+    );
+    writes.delete(
+        TRACKED_STATE_COMMIT_MUTATION_INVENTORY_SPACE,
+        key(commit_mutation_inventory_key(commit_id)),
     );
     for segment_key in &entry.physical_segment_keys {
         writes.delete(
@@ -8329,21 +8908,21 @@ pub(crate) async fn load_commit_delta_replay_metadata_with_cache(
     {
         return Ok(Some(commit_delta_replay_metadata(&manifest)));
     }
-    Ok(load_replay_commit_state_manifest(store, commit_id)
+    Ok(load_point_replay_commit_state(store, commit_id)
         .await?
         .map(|manifest| commit_delta_replay_metadata_from_inventory(&manifest.mutations)))
 }
 
 /// Returns replay metadata from an already authenticated physical manifest.
 pub(crate) fn seed_commit_delta_point_cache_from_replay_manifest(
-    state: &CommitStateManifest,
+    state: &AuthenticatedReplayCommitStateManifest,
     point_cache: &CommitDeltaPointReadCache,
 ) -> Result<CommitDeltaReplayMetadata, LixError> {
     if let Some(manifest) = point_cache.manifest(state.commit_id)? {
         return Ok(commit_delta_replay_metadata(&manifest));
     }
     let metadata = commit_delta_replay_metadata_from_inventory(&state.mutations);
-    if state.mutations.replacement_part_digests.is_empty() {
+    if state.mutation_directory_root.is_none() {
         point_cache.remember_manifest(
             state.commit_id,
             Arc::new(commit_delta_manifest_from_commit_state(state)),
@@ -8398,10 +8977,10 @@ async fn load_commit_delta_manifest(
     store: &(impl StorageAdapterRead + ?Sized),
     commit_id: CommitId,
 ) -> Result<Option<CommitDeltaManifest>, LixError> {
-    let Some(state) = load_point_replay_commit_state(store, commit_id).await? else {
+    let Some(full_state) = load_commit_state_manifest(store, commit_id).await? else {
         return Ok(None);
     };
-    let manifest = expanded_commit_delta_manifest_from_commit_state(store, &state).await?;
+    let manifest = expanded_commit_delta_manifest_from_commit_state(store, &full_state).await?;
     validate_commit_delta_manifest(&manifest)?;
     if manifest
         .replacement_generation
@@ -9791,6 +10370,8 @@ pub(crate) struct TrackedStateStagedRead<'a, S: ?Sized> {
     store: &'a S,
     chunks: &'a TrackedStateChunkOverlay,
     commit_states: HashMap<Vec<u8>, Bytes>,
+    mutation_inventories: HashMap<Vec<u8>, Bytes>,
+    mutation_directory_nodes: HashMap<Vec<u8>, Bytes>,
 }
 
 impl<'a, S> TrackedStateStagedRead<'a, S>
@@ -9802,6 +10383,8 @@ where
             store,
             chunks,
             commit_states: HashMap::new(),
+            mutation_inventories: HashMap::new(),
+            mutation_directory_nodes: HashMap::new(),
         }
     }
 
@@ -9810,7 +10393,7 @@ where
         chunks: &'a TrackedStateChunkOverlay,
         commit_states: impl IntoIterator<Item = (CommitStateManifest, TrackedStateCommitRoot)>,
     ) -> Result<Self, LixError> {
-        let manifests = commit_states
+        let encoded = commit_states
             .into_iter()
             .map(|(mut manifest, root)| {
                 if manifest.commit_id != root.commit_id {
@@ -9822,16 +10405,36 @@ where
                 // it is never published as immutable commit authority.
                 manifest.replay_debt = Default::default();
                 manifest.snapshot_root = Some(Box::new(root));
-                Ok((
-                    commit_state_manifest_key(manifest.commit_id),
-                    Bytes::from(encode_commit_state_manifest(&manifest)?),
-                ))
+                let key = commit_state_manifest_key(manifest.commit_id);
+                let encoded = encode_commit_state_manifest(&manifest)?;
+                Ok((key, encoded))
             })
-            .collect::<Result<HashMap<_, _>, LixError>>()?;
+            .collect::<Result<Vec<_>, LixError>>()?;
+        let commit_states = encoded
+            .iter()
+            .map(|(key, encoded)| (key.clone(), Bytes::copy_from_slice(&encoded.header)))
+            .collect();
+        let mutation_inventories = encoded
+            .iter()
+            .map(|(key, encoded)| {
+                (
+                    key.clone(),
+                    Bytes::copy_from_slice(&encoded.mutation_inventory),
+                )
+            })
+            .collect();
+        let mutation_directory_nodes = encoded
+            .iter()
+            .flat_map(|(_, encoded)| encoded.mutation_directory.iter())
+            .flat_map(|directory| directory.node_bytes())
+            .map(|(node_id, bytes)| (node_id.to_vec(), bytes.clone()))
+            .collect();
         Ok(Self {
             store,
             chunks,
-            commit_states: manifests,
+            commit_states,
+            mutation_inventories,
+            mutation_directory_nodes,
         })
     }
 
@@ -9842,6 +10445,12 @@ where
         }
         if space == TRACKED_STATE_COMMIT_STATE_MANIFEST_SPACE.id {
             return self.commit_states.get(key.0.as_ref()).cloned();
+        }
+        if space == TRACKED_STATE_COMMIT_MUTATION_INVENTORY_SPACE.id {
+            return self.mutation_inventories.get(key.0.as_ref()).cloned();
+        }
+        if space == super::mutation_directory::MUTATION_DIRECTORY_NODE_SPACE.id {
+            return self.mutation_directory_nodes.get(key.0.as_ref()).cloned();
         }
         None
     }
@@ -9904,32 +10513,497 @@ fn full_value_bytes(value: StorageProjectedValue) -> Option<Bytes> {
     }
 }
 
-fn encode_commit_state_manifest(manifest: &CommitStateManifest) -> Result<Vec<u8>, LixError> {
+#[derive(Debug)]
+struct EncodedCommitStateManifest {
+    header: Vec<u8>,
+    mutation_inventory: Vec<u8>,
+    mutation_directory: Option<super::mutation_directory::BuiltMutationDirectory>,
+}
+
+fn encode_commit_state_manifest(
+    manifest: &CommitStateManifest,
+) -> Result<EncodedCommitStateManifest, LixError> {
     validate_commit_state_manifest(manifest)?;
-    let payload = storage_codec::encode("tracked_state commit_state_manifest", manifest)?;
-    let mut encoded = Vec::with_capacity(COMMIT_STATE_MANIFEST_FORMAT_MAGIC.len() + payload.len());
-    encoded.extend_from_slice(COMMIT_STATE_MANIFEST_FORMAT_MAGIC);
-    encoded.extend_from_slice(&payload);
-    Ok(encoded)
+    let selected_source_commit_id = manifest.mutations.selected_source_commit_id;
+    let (stored_inventory, mutation_directory) =
+        stored_commit_mutation_inventory(&manifest.mutations)?;
+    let inventory_payload =
+        storage_codec::encode("tracked_state commit mutation inventory", &stored_inventory)?;
+    let mut mutation_inventory = Vec::with_capacity(
+        COMMIT_STATE_MUTATION_INVENTORY_FORMAT_MAGIC.len() + inventory_payload.len(),
+    );
+    mutation_inventory.extend_from_slice(COMMIT_STATE_MUTATION_INVENTORY_FORMAT_MAGIC);
+    mutation_inventory.extend_from_slice(&inventory_payload);
+    let header = StoredCommitStateManifest {
+        commit_id: manifest.commit_id,
+        change_account_id: manifest.change_account_id.clone(),
+        replay_debt: manifest.replay_debt,
+        selected_source_commit_id,
+        mutation_inventory_digest: *blake3::hash(&mutation_inventory).as_bytes(),
+        mutation_transition_digest:
+            super::scoped_current_state::current_state_mutation_authority_digest(
+                &manifest.mutations,
+            )?,
+        mutation_member_count: manifest.mutations.member_count,
+        mutation_part_count: u32::try_from(manifest.mutations.part_count()).map_err(|_| {
+            replacement_payload_error("mutation part count exceeds the authority-header bound")
+        })?,
+        mutation_directory_root: stored_inventory.directory_root.clone(),
+        touched_scope_filter: manifest.touched_scope_filter.clone(),
+        current_state_scoped_ranges: manifest.current_state_scoped_ranges.clone(),
+        snapshot_root: manifest.snapshot_root.clone(),
+    };
+    let header_payload = storage_codec::encode("tracked_state commit_state_manifest", &header)?;
+    let mut encoded_header =
+        Vec::with_capacity(COMMIT_STATE_MANIFEST_FORMAT_MAGIC.len() + header_payload.len());
+    encoded_header.extend_from_slice(COMMIT_STATE_MANIFEST_FORMAT_MAGIC);
+    encoded_header.extend_from_slice(&header_payload);
+    Ok(EncodedCommitStateManifest {
+        header: encoded_header,
+        mutation_inventory,
+        mutation_directory,
+    })
 }
 
-fn decode_commit_state_manifest(bytes: &[u8]) -> Result<CommitStateManifest, LixError> {
-    decode_commit_state_manifest_with_scoped_range_attestation(bytes, true)
+fn stored_commit_mutation_inventory(
+    inventory: &CommitStateMutationInventory,
+) -> Result<
+    (
+        StoredCommitMutationInventory,
+        Option<super::mutation_directory::BuiltMutationDirectory>,
+    ),
+    LixError,
+> {
+    let mutation_directory = if !inventory.parts.is_empty() {
+        let direct_rows = if inventory.direct_part_row_counts.is_empty() {
+            None
+        } else {
+            Some(inventory.direct_part_row_counts.as_slice())
+        };
+        Some(super::mutation_directory::build_bounded_mutation_directory(
+            &inventory.parts,
+            direct_rows,
+        )?)
+    } else if !inventory.replacement_part_digests.is_empty() {
+        Some(
+            super::mutation_directory::build_compact_replacement_mutation_directory(
+                &inventory.replacement_part_digests,
+                &inventory.direct_part_row_counts,
+            )?,
+        )
+    } else if inventory.columnar_parts.is_some() && !inventory.direct_part_row_counts.is_empty() {
+        Some(
+            super::mutation_directory::build_direct_rows_mutation_directory(
+                &inventory.direct_part_row_counts,
+            )?,
+        )
+    } else {
+        None
+    };
+    let stored = StoredCommitMutationInventory {
+        member_count: inventory.member_count,
+        selection_fingerprint: inventory.selection_fingerprint,
+        single_partition: inventory.single_partition.clone(),
+        lifecycle_summary: inventory.lifecycle_summary.clone(),
+        replacement_generation: inventory.replacement_generation.clone(),
+        replacement_parts: inventory.replacement_parts.clone(),
+        columnar_parts: inventory.columnar_parts.clone(),
+        inline_part: inventory.inline_part.clone(),
+        inline_direct: !inventory.inline_part.is_empty()
+            && !inventory.direct_part_row_counts.is_empty(),
+        directory_root: mutation_directory
+            .as_ref()
+            .map(|directory| directory.root.clone()),
+    };
+    Ok((stored, mutation_directory))
 }
 
-fn decode_commit_state_manifest_with_scoped_range_attestation(
-    bytes: &[u8],
+async fn decode_commit_state_manifest(
+    store: &(impl StorageAdapterRead + ?Sized),
+    header: &[u8],
+    mutation_inventory: &[u8],
+) -> Result<CommitStateManifest, LixError> {
+    decode_commit_state_manifest_with_scoped_range_attestation(
+        store,
+        header,
+        mutation_inventory,
+        true,
+    )
+    .await
+}
+
+async fn decode_commit_state_manifest_with_scoped_range_attestation(
+    store: &(impl StorageAdapterRead + ?Sized),
+    header: &[u8],
+    mutation_inventory: &[u8],
     validate_scoped_range_attestation: bool,
 ) -> Result<CommitStateManifest, LixError> {
+    let (stored, stored_inventory) =
+        decode_stored_commit_state_authority(header, mutation_inventory)?;
+    let entries = match stored_inventory.directory_root.as_ref() {
+        Some(root) => super::mutation_directory::load_mutation_directory(store, root).await?,
+        None => Vec::new(),
+    };
+    assemble_commit_state_manifest(
+        stored,
+        stored_inventory,
+        entries,
+        validate_scoped_range_attestation,
+    )
+}
+
+fn decode_stored_commit_state_authority(
+    header: &[u8],
+    mutation_inventory: &[u8],
+) -> Result<(StoredCommitStateManifest, StoredCommitMutationInventory), LixError> {
+    let stored = decode_stored_commit_state_manifest(header)?;
+    if stored.mutation_inventory_digest != *blake3::hash(mutation_inventory).as_bytes() {
+        return Err(LixError::new(
+            LixError::CODE_INTERNAL_ERROR,
+            "tracked_state commit mutation inventory disagrees with its authority digest",
+        ));
+    }
+    let Some(inventory_payload) =
+        mutation_inventory.strip_prefix(COMMIT_STATE_MUTATION_INVENTORY_FORMAT_MAGIC)
+    else {
+        return Err(LixError::new(
+            LixError::CODE_INTERNAL_ERROR,
+            "tracked_state commit mutation inventory has an unsupported format; recreate the repository",
+        ));
+    };
+    let stored_inventory: StoredCommitMutationInventory =
+        storage_codec::decode("tracked_state commit mutation inventory", inventory_payload)?;
+    if stored.mutation_member_count != stored_inventory.member_count
+        || stored.mutation_directory_root != stored_inventory.directory_root
+    {
+        return Err(LixError::new(
+            LixError::CODE_INTERNAL_ERROR,
+            "tracked_state commit mutation inventory disagrees with its authority header",
+        ));
+    }
+    Ok((stored, stored_inventory))
+}
+
+fn assemble_commit_state_manifest(
+    stored: StoredCommitStateManifest,
+    stored_inventory: StoredCommitMutationInventory,
+    entries: Vec<super::mutation_directory::MutationDirectoryEntry>,
+    validate_scoped_range_attestation: bool,
+) -> Result<CommitStateManifest, LixError> {
+    use super::mutation_directory::{
+        LAYOUT_BOUNDED_DIRECT, LAYOUT_BOUNDED_INDIRECT, LAYOUT_COMPACT_REPLACEMENT,
+        LAYOUT_DIRECT_ROWS_ONLY, MutationDirectoryEntry,
+    };
+    let mut parts = Vec::new();
+    let mut direct_part_row_counts = Vec::new();
+    let mut replacement_part_digests = Vec::new();
+    match stored_inventory
+        .directory_root
+        .as_ref()
+        .map(|root| root.layout)
+    {
+        Some(LAYOUT_BOUNDED_INDIRECT | LAYOUT_BOUNDED_DIRECT) => {
+            let direct = stored_inventory
+                .directory_root
+                .as_ref()
+                .is_some_and(|root| root.layout == LAYOUT_BOUNDED_DIRECT);
+            for entry in entries {
+                let MutationDirectoryEntry::Bounded {
+                    part,
+                    direct_row_count,
+                } = entry
+                else {
+                    return Err(replacement_payload_error(
+                        "bounded mutation directory contains a compact entry",
+                    ));
+                };
+                parts.push(part);
+                if direct {
+                    direct_part_row_counts.push(direct_row_count);
+                }
+            }
+        }
+        Some(LAYOUT_COMPACT_REPLACEMENT) => {
+            for entry in entries {
+                let MutationDirectoryEntry::CompactReplacement {
+                    content_digest,
+                    direct_row_count,
+                } = entry
+                else {
+                    return Err(replacement_payload_error(
+                        "compact mutation directory contains a bounded entry",
+                    ));
+                };
+                replacement_part_digests.push(content_digest);
+                direct_part_row_counts.push(direct_row_count);
+            }
+        }
+        Some(LAYOUT_DIRECT_ROWS_ONLY) => {
+            for entry in entries {
+                let MutationDirectoryEntry::DirectAddress { direct_row_count } = entry else {
+                    return Err(replacement_payload_error(
+                        "direct-address directory contains a physical part entry",
+                    ));
+                };
+                direct_part_row_counts.push(direct_row_count);
+            }
+        }
+        None if entries.is_empty() => {}
+        _ => {
+            return Err(replacement_payload_error(
+                "mutation directory has an unsupported authority layout",
+            ));
+        }
+    }
+    if stored_inventory.inline_direct {
+        let inline_rows = u16::try_from(stored_inventory.member_count).map_err(|_| {
+            replacement_payload_error("inline mutation row count exceeds direct-address bound")
+        })?;
+        if inline_rows == 0 || !direct_part_row_counts.is_empty() {
+            return Err(replacement_payload_error(
+                "inline direct-address authority has an invalid directory",
+            ));
+        }
+        direct_part_row_counts.push(inline_rows);
+    }
+    let mutations = CommitStateMutationInventory {
+        selected_source_commit_id: stored.selected_source_commit_id,
+        member_count: stored_inventory.member_count,
+        selection_fingerprint: stored_inventory.selection_fingerprint,
+        direct_part_row_counts,
+        replacement_part_digests,
+        single_partition: stored_inventory.single_partition,
+        lifecycle_summary: stored_inventory.lifecycle_summary,
+        replacement_generation: stored_inventory.replacement_generation,
+        replacement_parts: stored_inventory.replacement_parts,
+        columnar_parts: stored_inventory.columnar_parts,
+        inline_part: stored_inventory.inline_part,
+        parts,
+    };
+    if super::scoped_current_state::current_state_mutation_authority_digest(&mutations)?
+        != stored.mutation_transition_digest
+    {
+        return Err(replacement_payload_error(
+            "mutation catalog disagrees with its transition authority digest",
+        ));
+    }
+    let manifest = CommitStateManifest {
+        commit_id: stored.commit_id,
+        change_account_id: stored.change_account_id,
+        replay_debt: stored.replay_debt,
+        mutations,
+        touched_scope_filter: stored.touched_scope_filter,
+        current_state_scoped_ranges: stored.current_state_scoped_ranges,
+        snapshot_root: stored.snapshot_root,
+    };
+    if u32::try_from(manifest.mutations.part_count()).ok() != Some(stored.mutation_part_count) {
+        return Err(replacement_payload_error(
+            "mutation part closure disagrees with its authority header",
+        ));
+    }
+    validate_commit_state_manifest_inner(&manifest, validate_scoped_range_attestation)?;
+    Ok(manifest)
+}
+
+fn assemble_shallow_commit_state_manifest(
+    stored: StoredCommitStateManifest,
+    stored_inventory: StoredCommitMutationInventory,
+) -> Result<CommitStateManifest, LixError> {
+    use super::mutation_directory::{
+        LAYOUT_BOUNDED_DIRECT, LAYOUT_BOUNDED_INDIRECT, LAYOUT_COMPACT_REPLACEMENT,
+        LAYOUT_DIRECT_ROWS_ONLY,
+    };
+
+    let root = stored_inventory.directory_root.as_ref();
+    let has_inline = !stored_inventory.inline_part.is_empty();
+    let has_columnar = stored_inventory.columnar_parts.is_some();
+    let invalid_shape = has_inline && (has_columnar || root.is_some())
+        || has_columnar && root.is_none_or(|root| root.layout != LAYOUT_DIRECT_ROWS_ONLY)
+        || root.is_some_and(|root| {
+            matches!(
+                root.layout,
+                LAYOUT_BOUNDED_DIRECT | LAYOUT_BOUNDED_INDIRECT | LAYOUT_COMPACT_REPLACEMENT
+            ) && (has_inline || has_columnar)
+        })
+        || (stored_inventory.member_count > 0 && !has_inline && !has_columnar && root.is_none())
+        || stored_inventory.inline_direct && !has_inline
+        || has_inline && stored_inventory.member_count > COMMIT_DELTA_SEGMENT_MAX_ROWS as u32
+        || root.is_some_and(|root| {
+            (root.layout == LAYOUT_BOUNDED_DIRECT
+                || root.layout == LAYOUT_COMPACT_REPLACEMENT
+                || root.layout == LAYOUT_DIRECT_ROWS_ONLY)
+                && root.direct_row_count != u64::from(stored_inventory.member_count)
+        });
+    if invalid_shape {
+        return Err(replacement_payload_error(
+            "shallow mutation catalog has an invalid directory shape",
+        ));
+    }
+    let mutation_part_count = if let Some(columnar) = stored_inventory.columnar_parts.as_ref() {
+        u32::try_from(columnar.group_row_counts.len())
+            .map_err(|_| replacement_payload_error("columnar part count overflows"))?
+    } else if has_inline {
+        1
+    } else {
+        root.map_or(0, |root| root.entry_count)
+    };
+    if mutation_part_count != stored.mutation_part_count {
+        return Err(replacement_payload_error(
+            "shallow mutation part closure disagrees with its authority header",
+        ));
+    }
+    let direct_part_row_counts = if stored_inventory.inline_direct {
+        vec![u16::try_from(stored_inventory.member_count).map_err(|_| {
+            replacement_payload_error("inline mutation row count exceeds direct-address bound")
+        })?]
+    } else {
+        Vec::new()
+    };
+    let mutations = CommitStateMutationInventory {
+        selected_source_commit_id: stored.selected_source_commit_id,
+        member_count: stored_inventory.member_count,
+        selection_fingerprint: stored_inventory.selection_fingerprint,
+        direct_part_row_counts,
+        replacement_part_digests: Vec::new(),
+        single_partition: stored_inventory.single_partition,
+        lifecycle_summary: stored_inventory.lifecycle_summary,
+        replacement_generation: stored_inventory.replacement_generation,
+        replacement_parts: stored_inventory.replacement_parts,
+        columnar_parts: stored_inventory.columnar_parts,
+        inline_part: stored_inventory.inline_part,
+        parts: Vec::new(),
+    };
+    Ok(CommitStateManifest {
+        commit_id: stored.commit_id,
+        change_account_id: stored.change_account_id,
+        replay_debt: stored.replay_debt,
+        mutations,
+        touched_scope_filter: stored.touched_scope_filter,
+        current_state_scoped_ranges: stored.current_state_scoped_ranges,
+        snapshot_root: stored.snapshot_root,
+    })
+}
+
+#[cfg(test)]
+fn decode_encoded_commit_state_manifest(
+    encoded: &EncodedCommitStateManifest,
+) -> Result<CommitStateManifest, LixError> {
+    let (stored, stored_inventory) =
+        decode_stored_commit_state_authority(&encoded.header, &encoded.mutation_inventory)?;
+    let entries = match encoded.mutation_directory.as_ref() {
+        Some(directory) => super::mutation_directory::decode_built_mutation_directory(directory)?,
+        None => Vec::new(),
+    };
+    assemble_commit_state_manifest(stored, stored_inventory, entries, true)
+}
+
+fn decode_stored_commit_state_manifest(
+    bytes: &[u8],
+) -> Result<StoredCommitStateManifest, LixError> {
     let Some(payload) = bytes.strip_prefix(COMMIT_STATE_MANIFEST_FORMAT_MAGIC) else {
         return Err(LixError::new(
             LixError::CODE_INTERNAL_ERROR,
             "tracked_state commit_state_manifest has an unsupported format; recreate the repository",
         ));
     };
-    let manifest = storage_codec::decode("tracked_state commit_state_manifest", payload)?;
-    validate_commit_state_manifest_inner(&manifest, validate_scoped_range_attestation)?;
-    Ok(manifest)
+    let stored: StoredCommitStateManifest =
+        storage_codec::decode("tracked_state commit_state_manifest", payload)?;
+    validate_commit_state_manifest_header(&stored)?;
+    Ok(stored)
+}
+
+fn validate_commit_state_manifest_header(
+    stored: &StoredCommitStateManifest,
+) -> Result<(), LixError> {
+    if stored.mutation_inventory_digest == [0; 32]
+        || stored.mutation_transition_digest == [0; 32]
+        || stored.selected_source_commit_id == Some(*stored.commit_id.as_uuid().as_bytes())
+    {
+        return Err(LixError::new(
+            LixError::CODE_INTERNAL_ERROR,
+            "tracked_state commit_state_manifest has invalid mutation authority",
+        ));
+    }
+    if let Some(root) = stored.mutation_directory_root.as_ref() {
+        super::mutation_directory::validate_mutation_directory_root(root)?;
+        if root.layout != super::mutation_directory::LAYOUT_DIRECT_ROWS_ONLY
+            && root.entry_count != stored.mutation_part_count
+        {
+            return Err(LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                "tracked_state commit_state_manifest mutation root count disagrees with its header",
+            ));
+        }
+    }
+    if stored.replay_debt.depth == 0
+        && (stored.replay_debt.rows != 0 || stored.replay_debt.bytes != 0)
+    {
+        return Err(LixError::new(
+            LixError::CODE_INTERNAL_ERROR,
+            "tracked_state commit_state_manifest has replay work at zero depth",
+        ));
+    }
+    if stored.replay_debt.depth > crate::tracked_state::COMMIT_STATE_MAX_REPLAY_DEPTH
+        || stored.replay_debt.bytes > crate::tracked_state::COMMIT_STATE_MAX_REPLAY_BYTES
+    {
+        return Err(LixError::new(
+            LixError::CODE_INTERNAL_ERROR,
+            "tracked_state commit_state_manifest replay debt exceeds the protocol bound",
+        ));
+    }
+    if stored.replay_debt.depth == 0 && stored.snapshot_root.is_none() {
+        return Err(LixError::new(
+            LixError::CODE_INTERNAL_ERROR,
+            "tracked_state rooted commit_state_manifest is missing its snapshot root",
+        ));
+    }
+    if let Some(root) = stored.snapshot_root.as_ref()
+        && (root.commit_id != stored.commit_id || stored.replay_debt.depth != 0)
+    {
+        return Err(LixError::new(
+            LixError::CODE_INTERNAL_ERROR,
+            "tracked_state commit_state_manifest has an invalid snapshot root",
+        ));
+    }
+    super::scoped_current_state::validate_touched_scope_filter(&stored.touched_scope_filter)?;
+    if stored
+        .current_state_scoped_ranges
+        .as_ref()
+        .is_some_and(|root| {
+            root.tree.root_id == [0; 32]
+                || root.tree.root_digest == [0; 32]
+                || root.tree.tree_height == 0
+                || root.tree.marker_count == 0
+                || root.transition_digest == [0; 32]
+                || root.serving_base_commit_id.is_some() != root.serving_base_root_id.is_some()
+                || (stored.selected_source_commit_id.is_some()
+                    && root.serving_base_commit_id
+                        != stored
+                            .selected_source_commit_id
+                            .map(|bytes| CommitId::new(uuid::Uuid::from_bytes(bytes))))
+        })
+    {
+        return Err(LixError::new(
+            LixError::CODE_INTERNAL_ERROR,
+            "tracked_state commit_state_manifest has an invalid current-state scoped-range root",
+        ));
+    }
+    if let Some(root) = stored.current_state_scoped_ranges.as_ref()
+        && root.transition_digest
+            != super::scoped_current_state::scoped_range_transition_digest_from_authority(
+                stored.commit_id,
+                root.serving_base_commit_id,
+                root.serving_base_root_id,
+                stored.mutation_transition_digest,
+                &root.tree,
+            )
+    {
+        return Err(LixError::new(
+            LixError::CODE_INTERNAL_ERROR,
+            "tracked_state commit_state_manifest scoped-range transition disagrees with its header authority",
+        ));
+    }
+    Ok(())
 }
 
 fn validate_commit_state_manifest(manifest: &CommitStateManifest) -> Result<(), LixError> {
@@ -10259,7 +11333,8 @@ mod tests {
         encode_key_ref, encode_value_ref, hash_bytes,
     };
     use crate::tracked_state::types::{
-        CommitStateManifest, CommitStateMutationInventory, CommitStateReplayDebt,
+        CommitStateManifest, CommitStateMutationInventory,
+        CommitStateMutationPart as FixtureMutationPart, CommitStateReplayDebt,
         CurrentStatePartDescriptor, TrackedStateBaseCoordinate, TrackedStateCommitDeltaRef,
         TrackedStateCommitRoot, TrackedStateDeltaRef, TrackedStateIndexValue,
         TrackedStateIndexValueRef, TrackedStateKey, TrackedStateKeyRef, TrackedStateRootId,
@@ -10271,16 +11346,16 @@ mod tests {
         DecodedCommitDeltaCache, DecodedCommitDeltaSegment, GENERIC_COMMIT_DELTA_SEGMENT_MAX_ROWS,
         TRACKED_STATE_CHANGE_LOCATOR_SPACE, TRACKED_STATE_COMMIT_DELTA_SEGMENT_SPACE,
         TRACKED_STATE_TREE_CHUNK_SPACE, TrackedStateChunkOverlay, columnar_identity_row_map,
-        decode_commit_delta_with_payloads, decode_commit_state_manifest,
-        direct_change_locator_in_commit_state, encode_commit_delta_segment,
-        encode_commit_delta_segment_with_payloads, encode_commit_delta_segment_with_raw_sidecar,
-        encode_commit_state_manifest, key, load_change_record_by_id, load_commit_delta_change_ids,
-        load_commit_delta_change_records, load_commit_delta_members_with_payloads,
-        load_commit_delta_values_encoded, load_commit_state_manifest,
-        load_owned_commit_delta_entries, scan_change_records_from_commit_deltas,
-        scan_commit_delta_inventory, scan_commit_delta_members, scan_commit_delta_values,
-        stage_change_locators, stage_commit_state_manifest,
-        stage_delete_commit_delta_inventory_entry,
+        decode_commit_delta_with_payloads, decode_encoded_commit_state_manifest,
+        decode_stored_commit_state_authority, direct_change_locator_in_commit_state,
+        encode_commit_delta_segment, encode_commit_delta_segment_with_payloads,
+        encode_commit_delta_segment_with_raw_sidecar, encode_commit_state_manifest, key,
+        load_change_record_by_id, load_commit_delta_change_ids, load_commit_delta_change_records,
+        load_commit_delta_members_with_payloads, load_commit_delta_values_encoded,
+        load_commit_state_manifest, load_owned_commit_delta_entries,
+        scan_change_records_from_commit_deltas, scan_commit_delta_inventory,
+        scan_commit_delta_members, scan_commit_delta_values, stage_change_locators,
+        stage_commit_state_manifest, stage_delete_commit_delta_inventory_entry,
         stage_fragmented_scoped_current_state_descriptor, value,
     };
 
@@ -10531,6 +11606,8 @@ mod tests {
     struct ManifestCountingRead<R> {
         inner: R,
         manifest_requests: std::sync::Arc<AtomicUsize>,
+        inventory_requests: std::sync::Arc<AtomicUsize>,
+        directory_requests: std::sync::Arc<AtomicUsize>,
     }
 
     impl<R> crate::storage_adapter::StorageAdapterRead for ManifestCountingRead<R>
@@ -10550,6 +11627,12 @@ mod tests {
             for request in requests {
                 if request.space == super::TRACKED_STATE_COMMIT_STATE_MANIFEST_SPACE {
                     self.manifest_requests.fetch_add(1, Ordering::Relaxed);
+                } else if request.space == super::TRACKED_STATE_COMMIT_MUTATION_INVENTORY_SPACE {
+                    self.inventory_requests.fetch_add(1, Ordering::Relaxed);
+                } else if request.space
+                    == super::super::mutation_directory::MUTATION_DIRECTORY_NODE_SPACE
+                {
+                    self.directory_requests.fetch_add(1, Ordering::Relaxed);
                 }
             }
             self.inner.get_many(requests)
@@ -11218,6 +12301,45 @@ mod tests {
         let assigned = staged.assigned_change_ids().collect::<Vec<_>>();
         assert_eq!(assigned.len(), ROW_COUNT);
         assert_eq!(staged.change_id_at(ROW_COUNT), None);
+
+        let manifest_requests = std::sync::Arc::new(AtomicUsize::new(0));
+        let inventory_requests = std::sync::Arc::new(AtomicUsize::new(0));
+        let directory_requests = std::sync::Arc::new(AtomicUsize::new(0));
+        let routed_read = ManifestCountingRead {
+            inner: storage
+                .begin_read(StorageReadOptions::default())
+                .await
+                .expect("routed point read should open"),
+            manifest_requests: std::sync::Arc::clone(&manifest_requests),
+            inventory_requests: std::sync::Arc::clone(&inventory_requests),
+            directory_requests: std::sync::Arc::clone(&directory_requests),
+        };
+        let routed_indices = [0usize, ROW_COUNT / 2, ROW_COUNT - 1];
+        let routed_keys = routed_indices
+            .iter()
+            .map(|&index| TrackedStateKeyRef {
+                schema_key: &fixtures[index].schema_key,
+                file_id: fixtures[index].file_id.as_deref(),
+                entity_pk: &fixtures[index].entity_pk,
+            })
+            .collect::<Vec<_>>();
+        let routed = super::load_owned_commit_delta_entries_one_ordered_ref(
+            &routed_read,
+            commit_id,
+            &routed_keys,
+            None,
+        )
+        .await
+        .expect("hierarchical point routes should load");
+        for (&index, entry) in routed_indices.iter().zip(routed) {
+            assert_eq!(
+                entry.expect("routed mutation should exist").value.change_id,
+                assigned[index]
+            );
+        }
+        assert_eq!(manifest_requests.load(Ordering::Relaxed), 1);
+        assert_eq!(inventory_requests.load(Ordering::Relaxed), 1);
+        assert_eq!(directory_requests.load(Ordering::Relaxed), 1);
 
         let mut row_start = 0usize;
         for (segment_index, &segment_rows) in
@@ -12138,8 +13260,8 @@ mod tests {
         stage_commit_deltas(&mut writes, &deltas).expect("packed deltas should stage");
         assert_eq!(
             writes.stats().staged_puts,
-            5,
-            "generic history keeps 300 compact rows in three read-friendly segments plus its physical authority and semantic owner"
+            7,
+            "generic history keeps three read-friendly segments plus an atomic header, catalog, directory root, and semantic owner"
         );
         storage
             .commit_write_set(writes, StorageWriteOptions::default())
@@ -12334,8 +13456,8 @@ mod tests {
             .expect("individually valid rows should split below the sidecar limit");
         assert_eq!(
             writes.stats().staged_puts,
-            4,
-            "the oversized four-row candidate should become two segments plus its physical authority and semantic owner"
+            6,
+            "the oversized four-row candidate should become two segments plus an atomic header, catalog, directory root, and semantic owner"
         );
         storage
             .commit_write_set(writes, StorageWriteOptions::default())
@@ -13152,14 +14274,18 @@ mod tests {
             .expect("ordinary delta should commit");
 
         let manifest_requests = std::sync::Arc::new(AtomicUsize::new(0));
+        let inventory_requests = std::sync::Arc::new(AtomicUsize::new(0));
+        let directory_requests = std::sync::Arc::new(AtomicUsize::new(0));
         let read = ManifestCountingRead {
             inner: storage
                 .begin_read(StorageReadOptions::default())
                 .await
                 .expect("point read should open"),
             manifest_requests: std::sync::Arc::clone(&manifest_requests),
+            inventory_requests: std::sync::Arc::clone(&inventory_requests),
+            directory_requests: std::sync::Arc::clone(&directory_requests),
         };
-        let state = super::load_replay_commit_state_manifest(&read, commit_id)
+        let state = super::load_point_replay_commit_state(&read, commit_id)
             .await
             .expect("replay manifest should load")
             .expect("replay manifest should exist");
@@ -13181,6 +14307,8 @@ mod tests {
         .expect("cached shallow point replay should load");
         assert_eq!(values, vec![Some(fixture.value(commit_id))]);
         assert_eq!(manifest_requests.load(Ordering::Relaxed), 1);
+        assert_eq!(inventory_requests.load(Ordering::Relaxed), 1);
+        assert_eq!(directory_requests.load(Ordering::Relaxed), 0);
     }
 
     #[tokio::test]
@@ -13202,8 +14330,8 @@ mod tests {
         stage_commit_deltas(&mut writes, &[delta]).expect("inline delta should stage");
         assert_eq!(
             writes.stats().staged_puts,
-            2,
-            "a one-segment commit should remain inline in its physical authority plus semantic owner"
+            3,
+            "a one-segment commit should remain inline in its atomic header/catalog authority plus semantic owner"
         );
         storage
             .commit_write_set(writes, StorageWriteOptions::default())
@@ -13244,8 +14372,8 @@ mod tests {
         .expect("inline delta should stage for deletion");
         assert_eq!(
             deletes.stats().staged_deletes,
-            1,
-            "physical inventory deletion should remove its single manifest authority"
+            2,
+            "physical inventory deletion should remove its header and catalog authority"
         );
     }
 
@@ -13386,7 +14514,7 @@ mod tests {
                 .get(&commit_id)
                 .expect("packed commit should be inventoried")
                 .segment_count
-                + 1,
+                + 2,
         )
         .expect("test segment count fits u64");
         assert_eq!(deletes.stats().staged_deletes, expected_deletes);
@@ -13439,7 +14567,7 @@ mod tests {
         let inline_deltas = commit_delta_refs(inline_commit_id, &fixtures[..128]);
         stage_commit_deltas(&mut inline_writes, &inline_deltas)
             .expect("128 generic deltas should fit the history read boundary");
-        assert_eq!(inline_writes.stats().staged_puts, 2);
+        assert_eq!(inline_writes.stats().staged_puts, 3);
         storage
             .commit_write_set(inline_writes, StorageWriteOptions::default())
             .await
@@ -13449,7 +14577,7 @@ mod tests {
         let indexed_deltas = commit_delta_refs(indexed_commit_id, &fixtures);
         stage_commit_deltas(&mut indexed_writes, &indexed_deltas)
             .expect("129 generic deltas should use indexed segments");
-        assert_eq!(indexed_writes.stats().staged_puts, 4);
+        assert_eq!(indexed_writes.stats().staged_puts, 6);
         storage
             .commit_write_set(indexed_writes, StorageWriteOptions::default())
             .await
@@ -13627,13 +14755,79 @@ mod tests {
         }
     }
 
+    fn external_commit_state_manifest_fixture(
+        label: &str,
+        part_count: usize,
+    ) -> CommitStateManifest {
+        let commit_id = CommitId::for_test_label(label);
+        let schema_key = "external-directory".to_string();
+        let parts = (0..part_count)
+            .map(|index| {
+                let first = EntityPk::single(format!("entity-{:06}", index * 2));
+                let last = EntityPk::single(format!("entity-{:06}", index * 2 + 1));
+                FixtureMutationPart {
+                    first_key: encode_key_ref(TrackedStateKeyRef {
+                        schema_key: &schema_key,
+                        file_id: None,
+                        entity_pk: &first,
+                    }),
+                    last_key: encode_key_ref(TrackedStateKeyRef {
+                        schema_key: &schema_key,
+                        file_id: None,
+                        entity_pk: &last,
+                    }),
+                    replacement_part: None,
+                }
+            })
+            .collect::<Vec<_>>();
+        CommitStateManifest {
+            commit_id,
+            change_account_id: crate::ANONYMOUS_ACCOUNT_ID.to_string(),
+            replay_debt: CommitStateReplayDebt {
+                depth: 1,
+                rows: part_count as u64,
+                bytes: part_count as u64,
+            },
+            mutations: CommitStateMutationInventory {
+                selected_source_commit_id: None,
+                member_count: part_count as u32,
+                selection_fingerprint: [4; 32],
+                direct_part_row_counts: vec![1; part_count],
+                replacement_part_digests: Vec::new(),
+                single_partition: Some(super::CommitDeltaReplacementScope {
+                    schema_key,
+                    file_id: None,
+                }),
+                lifecycle_summary: None,
+                replacement_generation: None,
+                replacement_parts: None,
+                columnar_parts: None,
+                inline_part: Vec::new(),
+                parts,
+            },
+            touched_scope_filter: Default::default(),
+            current_state_scoped_ranges: None,
+            snapshot_root: None,
+        }
+    }
+
     #[test]
     fn commit_state_manifest_codec_roundtrips_all_authority_planes() {
         let expected = commit_state_manifest_fixture();
         let encoded = encode_commit_state_manifest(&expected).expect("manifest should encode");
-        assert!(encoded.starts_with(COMMIT_STATE_MANIFEST_FORMAT_MAGIC));
+        assert!(
+            encoded
+                .header
+                .starts_with(COMMIT_STATE_MANIFEST_FORMAT_MAGIC)
+        );
+        assert!(
+            encoded
+                .mutation_inventory
+                .starts_with(super::COMMIT_STATE_MUTATION_INVENTORY_FORMAT_MAGIC)
+        );
 
-        let decoded = decode_commit_state_manifest(&encoded).expect("manifest should round trip");
+        let decoded =
+            decode_encoded_commit_state_manifest(&encoded).expect("manifest should round trip");
         assert_eq!(decoded, expected);
     }
 
@@ -13667,7 +14861,31 @@ mod tests {
             }));
 
         let encoded = encode_commit_state_manifest(&manifest).expect("manifest should encode");
-        assert_eq!(decode_commit_state_manifest(&encoded).unwrap(), manifest);
+        assert_eq!(
+            decode_encoded_commit_state_manifest(&encoded).unwrap(),
+            manifest
+        );
+
+        let mut stored: super::StoredCommitStateManifest = storage_codec::decode(
+            "tracked_state commit_state_manifest",
+            encoded
+                .header
+                .strip_prefix(COMMIT_STATE_MANIFEST_FORMAT_MAGIC)
+                .expect("encoded header has current magic"),
+        )
+        .expect("stored header should decode");
+        stored
+            .current_state_scoped_ranges
+            .as_mut()
+            .expect("fixture has a scoped root")
+            .transition_digest[0] ^= 1;
+        let payload = storage_codec::encode("tracked_state commit_state_manifest", &stored)
+            .expect("tampered header fixture should encode");
+        let mut tampered_header = COMMIT_STATE_MANIFEST_FORMAT_MAGIC.to_vec();
+        tampered_header.extend_from_slice(&payload);
+        let error = super::decode_stored_commit_state_manifest(&tampered_header)
+            .expect_err("header-only scoped authority must fail closed");
+        assert!(error.message.contains("transition"));
 
         manifest
             .current_state_scoped_ranges
@@ -13677,6 +14895,45 @@ mod tests {
         let error = encode_commit_state_manifest(&manifest)
             .expect_err("forged scoped-range transition must fail closed");
         assert!(error.message.contains("transition"));
+    }
+
+    #[tokio::test]
+    async fn published_topology_loads_only_the_authenticated_header() {
+        let manifest = external_commit_state_manifest_fixture("header-only-topology", 700);
+        let storage = StorageAdapter::new(Memory::new());
+        let mut writes = storage.new_write_set();
+        stage_commit_state_manifest(&mut writes, &manifest).expect("fixture should stage");
+        storage
+            .commit_write_set(writes, StorageWriteOptions::default())
+            .await
+            .expect("fixture should commit");
+
+        let manifest_requests = std::sync::Arc::new(AtomicUsize::new(0));
+        let inventory_requests = std::sync::Arc::new(AtomicUsize::new(0));
+        let directory_requests = std::sync::Arc::new(AtomicUsize::new(0));
+        let read = ManifestCountingRead {
+            inner: storage
+                .begin_read(StorageReadOptions::default())
+                .await
+                .expect("topology read should open"),
+            manifest_requests: std::sync::Arc::clone(&manifest_requests),
+            inventory_requests: std::sync::Arc::clone(&inventory_requests),
+            directory_requests: std::sync::Arc::clone(&directory_requests),
+        };
+
+        let topology = super::load_published_commit_state_topology(&read, manifest.commit_id)
+            .await
+            .expect("topology should load")
+            .expect("topology should exist");
+        assert_eq!(topology.commit_id(), manifest.commit_id);
+        assert_eq!(topology.replay_debt(), manifest.replay_debt);
+        assert_eq!(
+            topology.mutation_member_count(),
+            manifest.mutations.member_count
+        );
+        assert_eq!(manifest_requests.load(Ordering::Relaxed), 1);
+        assert_eq!(inventory_requests.load(Ordering::Relaxed), 0);
+        assert_eq!(directory_requests.load(Ordering::Relaxed), 0);
     }
 
     #[test]
@@ -13689,11 +14946,13 @@ mod tests {
             b"LXCS5".as_slice(),
             b"LXCS6".as_slice(),
             b"LXCS7".as_slice(),
+            b"LXCS8".as_slice(),
+            b"LXCS9".as_slice(),
         ] {
             let mut legacy = magic.to_vec();
             legacy.extend_from_slice(&payload);
-            let error = decode_commit_state_manifest(&legacy)
-                .expect_err("the hard cut must reject pre-v7 manifest formats");
+            let error = decode_stored_commit_state_authority(&legacy, &[])
+                .expect_err("the hard cut must reject pre-v10 manifest formats");
             assert!(error.message.contains("unsupported format"));
         }
     }
@@ -13722,6 +14981,162 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn split_mutation_authority_publishes_atomically_and_fails_closed() {
+        const PART_COUNT: usize = 260;
+        let manifest = external_commit_state_manifest_fixture(
+            "split-mutation-authority-corruption",
+            PART_COUNT,
+        );
+        let storage = StorageAdapter::new(Memory::new());
+        let mut writes = storage.new_write_set();
+        stage_commit_state_manifest(&mut writes, &manifest).expect("split authority should stage");
+        assert_eq!(
+            writes
+                .staged_values_in_space(super::TRACKED_STATE_COMMIT_STATE_MANIFEST_SPACE)
+                .len(),
+            1
+        );
+        assert_eq!(
+            writes
+                .staged_values_in_space(super::TRACKED_STATE_COMMIT_MUTATION_INVENTORY_SPACE)
+                .len(),
+            1
+        );
+        assert!(
+            writes
+                .staged_values_in_space(
+                    super::super::mutation_directory::MUTATION_DIRECTORY_NODE_SPACE,
+                )
+                .len()
+                > 1,
+            "a multi-level directory must publish all authenticated nodes in the same write set"
+        );
+        storage
+            .commit_write_set(writes, StorageWriteOptions::default())
+            .await
+            .expect("split authority should commit atomically");
+
+        let read = storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("split authority should open");
+        assert_eq!(
+            load_commit_state_manifest(&read, manifest.commit_id)
+                .await
+                .expect("complete hierarchy should load"),
+            Some(manifest.clone())
+        );
+        drop(read);
+
+        let mut corrupt = storage.new_write_set();
+        corrupt.delete(
+            StorageSpace::mutable(
+                super::TRACKED_STATE_COMMIT_MUTATION_INVENTORY_SPACE.id,
+                super::TRACKED_STATE_COMMIT_MUTATION_INVENTORY_NAMESPACE,
+            ),
+            key(super::commit_mutation_inventory_key(manifest.commit_id)),
+        );
+        storage
+            .commit_write_set(corrupt, StorageWriteOptions::default())
+            .await
+            .expect("test corruption should commit");
+        let read = storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("corrupt split authority should open");
+        let error = load_commit_state_manifest(&read, manifest.commit_id)
+            .await
+            .expect_err("a missing catalog must fail closed");
+        assert!(
+            error
+                .to_string()
+                .contains("incomplete split physical authority")
+        );
+        let error = scan_commit_delta_inventory(&read)
+            .await
+            .expect_err("an orphan header must fail the global inventory");
+        assert!(error.to_string().contains("orphaned headers"));
+    }
+
+    #[tokio::test]
+    async fn mutation_catalog_and_directory_tampering_fail_digest_validation() {
+        let manifest =
+            external_commit_state_manifest_fixture("mutation-directory-digest-corruption", 260);
+        let encoded = encode_commit_state_manifest(&manifest).expect("fixture should encode");
+        let root_id = encoded
+            .mutation_directory
+            .as_ref()
+            .expect("external fixture has a directory")
+            .root
+            .root_id;
+        let storage = StorageAdapter::new(Memory::new());
+        let mut writes = storage.new_write_set();
+        stage_commit_state_manifest(&mut writes, &manifest).expect("fixture should stage");
+        storage
+            .commit_write_set(writes, StorageWriteOptions::default())
+            .await
+            .expect("fixture should commit");
+
+        let mut tampered_catalog = encoded.mutation_inventory.clone();
+        let last = tampered_catalog
+            .last_mut()
+            .expect("encoded catalog is non-empty");
+        *last ^= 1;
+        let mut corrupt = storage.new_write_set();
+        corrupt.put(
+            StorageSpace::mutable(
+                super::TRACKED_STATE_COMMIT_MUTATION_INVENTORY_SPACE.id,
+                super::TRACKED_STATE_COMMIT_MUTATION_INVENTORY_NAMESPACE,
+            ),
+            key(super::commit_mutation_inventory_key(manifest.commit_id)),
+            value(tampered_catalog),
+        );
+        storage
+            .commit_write_set(corrupt, StorageWriteOptions::default())
+            .await
+            .expect("catalog corruption should commit");
+        let read = storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("catalog corruption should open");
+        let error = load_commit_state_manifest(&read, manifest.commit_id)
+            .await
+            .expect_err("tampered catalog must fail closed");
+        assert!(error.to_string().contains("authority digest"));
+        drop(read);
+
+        let mut repair = storage.new_write_set();
+        repair.put(
+            StorageSpace::mutable(
+                super::TRACKED_STATE_COMMIT_MUTATION_INVENTORY_SPACE.id,
+                super::TRACKED_STATE_COMMIT_MUTATION_INVENTORY_NAMESPACE,
+            ),
+            key(super::commit_mutation_inventory_key(manifest.commit_id)),
+            value(encoded.mutation_inventory),
+        );
+        repair.put(
+            StorageSpace::mutable(
+                super::super::mutation_directory::MUTATION_DIRECTORY_NODE_SPACE.id,
+                super::super::mutation_directory::MUTATION_DIRECTORY_NODE_SPACE.name,
+            ),
+            key(root_id.to_vec()),
+            value(b"forged-directory-node".to_vec()),
+        );
+        storage
+            .commit_write_set(repair, StorageWriteOptions::default())
+            .await
+            .expect("node corruption should commit");
+        let read = storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("node corruption should open");
+        let error = load_commit_state_manifest(&read, manifest.commit_id)
+            .await
+            .expect_err("tampered directory node must fail closed");
+        assert!(error.to_string().contains("content digest mismatch"));
+    }
+
+    #[tokio::test]
     async fn manifest_root_does_not_grant_semantic_commit_liveness() {
         let storage = StorageAdapter::new(Memory::new());
         let mut manifest = commit_state_manifest_fixture();
@@ -13746,10 +15161,28 @@ mod tests {
             .commit_write_set(writes, StorageWriteOptions::default())
             .await
             .expect("root fixtures should commit");
-        let read = storage
-            .begin_read(StorageReadOptions::default())
-            .await
-            .expect("read should open");
+        let manifest_requests = std::sync::Arc::new(AtomicUsize::new(0));
+        let inventory_requests = std::sync::Arc::new(AtomicUsize::new(0));
+        let directory_requests = std::sync::Arc::new(AtomicUsize::new(0));
+        let read = ManifestCountingRead {
+            inner: storage
+                .begin_read(StorageReadOptions::default())
+                .await
+                .expect("read should open"),
+            manifest_requests: std::sync::Arc::clone(&manifest_requests),
+            inventory_requests: std::sync::Arc::clone(&inventory_requests),
+            directory_requests: std::sync::Arc::clone(&directory_requests),
+        };
+
+        assert_eq!(
+            super::load_manifest_snapshot_commit_root(&read, manifest.commit_id)
+                .await
+                .expect("physical root should load"),
+            Some(authoritative.clone())
+        );
+        assert_eq!(manifest_requests.load(Ordering::Relaxed), 1);
+        assert_eq!(inventory_requests.load(Ordering::Relaxed), 0);
+        assert_eq!(directory_requests.load(Ordering::Relaxed), 0);
 
         assert!(
             super::load_snapshot_commit_root(&read, &manifest.commit_id.to_string())
@@ -13757,12 +15190,6 @@ mod tests {
                 .expect("authorized root lookup should succeed")
                 .is_none(),
             "physical retention alone must not make a missing semantic commit readable"
-        );
-        assert_eq!(
-            super::load_manifest_snapshot_commit_root(&read, manifest.commit_id)
-                .await
-                .expect("physical root should load"),
-            Some(authoritative)
         );
         assert_eq!(
             load_commit_state_manifest(&read, manifest.commit_id)
@@ -13870,7 +15297,7 @@ mod tests {
 
     #[test]
     fn commit_state_manifest_rejects_old_formats() {
-        let error = decode_commit_state_manifest(b"LXCS0old")
+        let error = decode_stored_commit_state_authority(b"LXCS0old", &[])
             .expect_err("old commit-state formats must fail closed");
         assert!(error.message.contains("recreate the repository"));
     }

--- a/packages/engine/src/tracked_state/storage.rs
+++ b/packages/engine/src/tracked_state/storage.rs
@@ -7270,8 +7270,7 @@ async fn load_local_owned_commit_delta_entries_one_ordered(
             let Some(state) = load_point_replay_commit_state(store, commit_id).await? else {
                 return Ok((0..keys.len()).map(|_| None).collect());
             };
-            if keys.len() <= DECODED_COMMIT_DELTA_CACHE_MAX_POINT_KEYS
-                && state.mutations.selected_source_commit_id.is_none()
+            if state.mutations.selected_source_commit_id.is_none()
                 && state.mutations.inline_part.is_empty()
                 && state.mutation_directory_root.as_ref().is_some_and(|root| {
                     root.layout == super::mutation_directory::LAYOUT_BOUNDED_DIRECT
@@ -7698,33 +7697,194 @@ pub(crate) async fn scan_commit_delta_values(
     commit_id: CommitId,
     schema_keys: &[String],
 ) -> Result<DecodedCommitDeltaBatch, LixError> {
-    scan_commit_delta_values_with_cache(store, commit_id, schema_keys, None).await
+    Box::pin(scan_commit_delta_values_with_cache(
+        store,
+        commit_id,
+        schema_keys,
+        None,
+    ))
+    .await
 }
 
 pub(crate) async fn scan_commit_delta_values_with_cache(
     store: &(impl StorageAdapterRead + ?Sized),
     commit_id: CommitId,
     schema_keys: &[String],
-    point_cache: Option<&CommitDeltaPointReadCache>,
+    _point_cache: Option<&CommitDeltaPointReadCache>,
 ) -> Result<DecodedCommitDeltaBatch, LixError> {
-    let Some(manifest) = load_commit_delta_manifest_cached(store, commit_id, point_cache).await?
-    else {
+    let Some(state) = load_point_replay_commit_state(store, commit_id).await? else {
         return Ok(DecodedCommitDeltaBatch::default());
     };
-    let Some(source_commit_id) = manifest.selected_source_commit_id() else {
-        return scan_local_commit_delta_values(store, commit_id, schema_keys, &manifest).await;
+    let Some(source_commit_id) = state.mutations.selected_source_commit_id() else {
+        return Box::pin(scan_authenticated_local_commit_delta_values(
+            store,
+            &state,
+            schema_keys,
+        ))
+        .await;
     };
-    let source = match load_commit_delta_manifest_cached(store, source_commit_id, point_cache)
-        .await?
-    {
-        Some(source_manifest) => {
-            scan_local_commit_delta_values(store, source_commit_id, schema_keys, &source_manifest)
-                .await?
+    let source = match load_point_replay_commit_state(store, source_commit_id).await? {
+        Some(source_state) => {
+            if source_state.mutations.selected_source_commit_id.is_some() {
+                return Err(replacement_payload_error(
+                    "selected-source mutation authority cannot alias another source",
+                ));
+            }
+            Box::pin(scan_authenticated_local_commit_delta_values(
+                store,
+                &source_state,
+                schema_keys,
+            ))
+            .await?
         }
         None => DecodedCommitDeltaBatch::default(),
     };
-    let local = scan_local_commit_delta_values(store, commit_id, schema_keys, &manifest).await?;
+    let local = Box::pin(scan_authenticated_local_commit_delta_values(
+        store,
+        &state,
+        schema_keys,
+    ))
+    .await?;
     merge_selected_source_batches(source, local, commit_id)
+}
+
+async fn scan_authenticated_local_commit_delta_values(
+    store: &(impl StorageAdapterRead + ?Sized),
+    state: &AuthenticatedReplayCommitStateManifest,
+    schema_keys: &[String],
+) -> Result<DecodedCommitDeltaBatch, LixError> {
+    let Some(root) = state.mutation_directory_root.as_ref() else {
+        let manifest = commit_delta_manifest_from_commit_state(state);
+        return Box::pin(scan_local_commit_delta_values(
+            store,
+            state.commit_id,
+            schema_keys,
+            &manifest,
+        ))
+        .await;
+    };
+    if root.layout == super::mutation_directory::LAYOUT_BOUNDED_DIRECT
+        || root.layout == super::mutation_directory::LAYOUT_BOUNDED_INDIRECT
+    {
+        return Box::pin(scan_bounded_commit_delta_values(store, state, schema_keys)).await;
+    }
+    if root.layout == super::mutation_directory::LAYOUT_DIRECT_ROWS_ONLY {
+        let manifest = commit_delta_manifest_from_commit_state(state);
+        return Box::pin(scan_local_commit_delta_values(
+            store,
+            state.commit_id,
+            schema_keys,
+            &manifest,
+        ))
+        .await;
+    }
+    if root.layout != super::mutation_directory::LAYOUT_COMPACT_REPLACEMENT {
+        return Err(replacement_payload_error(
+            "mutation scan encountered an unsupported directory layout",
+        ));
+    }
+
+    // Compact replacement parts have ordinal identities rather than key
+    // bounds, so a schema scan must authenticate their complete digest list.
+    // This is a layout-specific traversal, not a general manifest expansion.
+    let entries = super::mutation_directory::load_mutation_directory(store, root).await?;
+    let mut expanded_state = state.manifest.clone();
+    for entry in entries {
+        let super::mutation_directory::MutationDirectoryEntry::CompactReplacement {
+            content_digest,
+            direct_row_count,
+        } = entry
+        else {
+            return Err(replacement_payload_error(
+                "compact replacement directory contains a bounded entry",
+            ));
+        };
+        expanded_state
+            .mutations
+            .replacement_part_digests
+            .push(content_digest);
+        expanded_state
+            .mutations
+            .direct_part_row_counts
+            .push(direct_row_count);
+    }
+    let manifest = expanded_commit_delta_manifest_from_commit_state(store, &expanded_state).await?;
+    validate_commit_delta_manifest(&manifest)?;
+    Box::pin(scan_local_commit_delta_values(
+        store,
+        state.commit_id,
+        schema_keys,
+        &manifest,
+    ))
+    .await
+}
+
+async fn scan_bounded_commit_delta_values(
+    store: &(impl StorageAdapterRead + ?Sized),
+    state: &AuthenticatedReplayCommitStateManifest,
+    schema_keys: &[String],
+) -> Result<DecodedCommitDeltaBatch, LixError> {
+    let root = state.mutation_directory_root.as_ref().ok_or_else(|| {
+        replacement_payload_error("bounded mutation scan omitted its directory root")
+    })?;
+    let encoded_ranges = schema_keys
+        .iter()
+        .map(|schema_key| {
+            let start = encode_schema_key_prefix(schema_key);
+            let end = prefix_successor(&start);
+            (start, end)
+        })
+        .collect::<Vec<_>>();
+    let ranges = encoded_ranges
+        .iter()
+        .map(|(start, end)| (start.as_slice(), end.as_deref()))
+        .collect::<Vec<_>>();
+    let routes =
+        super::mutation_directory::load_bounded_mutation_directory_ranges(store, root, &ranges)
+            .await?;
+    if routes.is_empty() {
+        return Ok(DecodedCommitDeltaBatch::default());
+    }
+    let storage_keys = routes
+        .iter()
+        .map(|route| {
+            commit_delta_segment_key_for_bounds(
+                state.commit_id,
+                usize::try_from(route.entry_index)
+                    .map_err(|_| replacement_payload_error("part index exceeds usize"))?,
+                &CommitDeltaSegmentBounds {
+                    first_key: route.part.first_key.clone(),
+                    last_key: route.part.last_key.clone(),
+                    replacement_part: route.part.replacement_part.clone(),
+                },
+            )
+            .map(|key| StorageKey(Bytes::from(key)))
+        })
+        .collect::<Result<Vec<_>, LixError>>()?;
+    let segments = PointReadPlan::new(TRACKED_STATE_COMMIT_DELTA_SEGMENT_SPACE, &storage_keys)
+        .materialize(store, StorageGetOptions::default())
+        .await?;
+    let requested_schemas = schema_keys
+        .iter()
+        .map(String::as_str)
+        .collect::<BTreeSet<_>>();
+    let mut batch = DecodedCommitDeltaBatchBuilder::with_capacity(
+        routes.len().saturating_mul(COMMIT_DELTA_SEGMENT_MAX_ROWS),
+        routes.len(),
+    );
+    for (route, value) in routes.into_iter().zip(segments.value) {
+        let bytes = value.and_then(full_value_bytes).ok_or_else(|| {
+            replacement_payload_error("bounded mutation scan references a missing immutable part")
+        })?;
+        let bounds = CommitDeltaSegmentBounds {
+            first_key: route.part.first_key,
+            last_key: route.part.last_key,
+            replacement_part: route.part.replacement_part,
+        };
+        let leaf = decode_commit_delta_leaf(&bytes, Some(&bounds))?;
+        batch.push_leaf(leaf, state.commit_id, &requested_schemas)?;
+    }
+    Ok(batch.finish())
 }
 
 async fn scan_local_commit_delta_values(
@@ -12314,7 +12474,9 @@ mod tests {
             inventory_requests: std::sync::Arc::clone(&inventory_requests),
             directory_requests: std::sync::Arc::clone(&directory_requests),
         };
-        let routed_indices = [0usize, ROW_COUNT / 2, ROW_COUNT - 1];
+        let routed_indices = (0..33usize)
+            .map(|index| index * (ROW_COUNT - 1) / 32)
+            .collect::<Vec<_>>();
         let routed_keys = routed_indices
             .iter()
             .map(|&index| TrackedStateKeyRef {

--- a/packages/engine/src/tracked_state/storage.rs
+++ b/packages/engine/src/tracked_state/storage.rs
@@ -6,9 +6,7 @@
 
 use std::borrow::Cow;
 use std::collections::{BTreeMap, BTreeSet, HashMap, VecDeque};
-use std::future::Future;
 use std::ops::{Bound, Deref, Range};
-use std::pin::Pin;
 use std::sync::{Arc, Mutex, OnceLock};
 
 use crate::changelog::{ChangelogContext, ChangelogReader, CommitId, CommitLoadRequest};
@@ -23,9 +21,9 @@ use crate::storage_adapter::{
 };
 use crate::tracked_state::codec::{
     DecodedLeafNodeRef, DecodedNodeRef, EncodedLeafEntry, EncodedLeafEntryRef, PendingChunkBatch,
-    TrackedStateMutationBatchBuilder, decode_key, decode_key_shared, decode_node_ref, decode_value,
-    encode_key_ref, encode_key_ref_into, encode_leaf_node_refs, encode_schema_key_prefix,
-    encode_single_string_key_ref_into, encode_value_ref,
+    TrackedStateKeyBatchBuilder, TrackedStateMutationBatchBuilder, decode_key, decode_key_shared,
+    decode_node_ref, decode_value, encode_key_ref, encode_key_ref_into, encode_leaf_node_refs,
+    encode_schema_key_prefix, encode_single_string_key_ref_into, encode_value_ref,
 };
 pub(crate) use crate::tracked_state::types::{
     CommitDeltaLifecycleSummary, CommitDeltaReplacementScope,
@@ -40,7 +38,6 @@ use crate::tracked_state::types::{
 };
 use crate::{LixError, storage_codec};
 use bytes::Bytes;
-use futures_util::{StreamExt, TryStreamExt, stream};
 
 pub(crate) const TRACKED_STATE_TREE_CHUNK_NAMESPACE: &str = "tracked_state.tree_chunk";
 pub(crate) const TRACKED_STATE_COMMIT_DELTA_SEGMENT_NAMESPACE: &str =
@@ -398,6 +395,7 @@ impl CommitDeltaPayloadIndexRef<'_> {
     }
 }
 
+#[derive(Clone)]
 pub(crate) struct LoadedCommitDeltaEntry {
     pub(crate) value: TrackedStateIndexValue,
     pub(crate) change_record: crate::changelog::ChangeRecord,
@@ -1567,7 +1565,9 @@ pub(crate) struct CommitDeltaPointReadCache {
 /// physical part boundary instead of twice for every row.
 pub(crate) struct CommitDeltaLiveMembershipCursor {
     commit_id: CommitId,
-    manifest: Option<Arc<CommitDeltaManifest>>,
+    initialized: bool,
+    bounded_root: Option<super::mutation_directory::MutationDirectoryRoot>,
+    bounded_part: Option<(usize, u16, CommitDeltaSegmentBounds)>,
     segment_index: Option<usize>,
     segment: Option<Arc<DecodedCommitDeltaSegment>>,
     next_entry_index: usize,
@@ -1575,6 +1575,7 @@ pub(crate) struct CommitDeltaLiveMembershipCursor {
 
 #[derive(Default)]
 struct CommitDeltaPointReadCacheInner {
+    authorities: VecDeque<(CommitId, Arc<AuthenticatedReplayCommitStateManifest>)>,
     manifests: VecDeque<(CommitId, Arc<CommitDeltaManifest>)>,
     segments: VecDeque<((CommitId, usize), Arc<DecodedCommitDeltaSegment>)>,
     recent_segment_misses: VecDeque<(CommitId, usize)>,
@@ -1588,7 +1589,9 @@ impl CommitDeltaPointReadCache {
     ) -> CommitDeltaLiveMembershipCursor {
         CommitDeltaLiveMembershipCursor {
             commit_id,
-            manifest: None,
+            initialized: false,
+            bounded_root: None,
+            bounded_part: None,
             segment_index: None,
             segment: None,
             next_entry_index: 0,
@@ -1610,48 +1613,116 @@ impl CommitDeltaLiveMembershipCursor {
         cache: &CommitDeltaPointReadCache,
         encoded_key: &[u8],
     ) -> Result<Option<bool>, LixError> {
-        if self.manifest.is_none() {
-            self.manifest =
-                load_commit_delta_manifest_cached(store, self.commit_id, Some(cache)).await?;
-        }
-        let Some(manifest) = self.manifest.as_ref() else {
-            return Ok(None);
-        };
-        if manifest.selected_source_commit_id.is_some() {
-            return Ok(None);
-        }
-        let segment_index = if manifest.inline_segment().is_some() {
-            0
-        } else {
-            let Some(segment_index) = commit_delta_segment_for_key(manifest, encoded_key) else {
-                return Ok(Some(false));
+        if !self.initialized {
+            self.initialized = true;
+            let state = match cache.authority(self.commit_id)? {
+                Some(state) => state,
+                None => {
+                    let Some(state) = load_point_replay_commit_state(store, self.commit_id).await?
+                    else {
+                        return Ok(None);
+                    };
+                    let state = Arc::new(state);
+                    cache.remember_authority(Arc::clone(&state))?;
+                    state
+                }
             };
-            segment_index
-        };
-        if self.segment_index != Some(segment_index) || self.segment.is_none() {
-            self.segment = cache.segment(
-                self.commit_id,
-                segment_index,
-                manifest.segments.get(segment_index),
-            )?;
-            if self.segment.is_none() {
-                let decoded = if let Some(inline_segment) = manifest.inline_segment() {
-                    decode_owned_commit_delta_segment(inline_segment, None)?
-                } else {
-                    let bounds = manifest.segments.get(segment_index).ok_or_else(|| {
-                        LixError::new(
-                            LixError::CODE_INTERNAL_ERROR,
-                            format!(
-                                "tracked_state commit_delta manifest for commit '{}' has no segment {segment_index}",
-                                self.commit_id
-                            ),
-                        )
-                    })?;
+            if state.mutations.selected_source_commit_id().is_some() {
+                return Ok(None);
+            }
+            if let Some(root) = state.mutation_directory_root.as_ref().filter(|root| {
+                root.layout == super::mutation_directory::LAYOUT_BOUNDED_DIRECT
+                    || root.layout == super::mutation_directory::LAYOUT_BOUNDED_INDIRECT
+            }) {
+                self.bounded_root = Some(root.clone());
+            } else if state.mutation_directory_root.is_some()
+                || state.mutations.inline_part.is_empty()
+            {
+                // Point/range selectors are meaningful only for bounded
+                // directory layouts. Do not reconstruct an alternate catalog
+                // for ordinal or columnar layouts; the caller must use its
+                // canonical fail-closed path.
+                return Ok(None);
+            } else {
+                let decoded = match cache.segment(self.commit_id, 0, None)? {
+                    Some(decoded) => decoded,
+                    None => decode_owned_commit_delta_segment(&state.mutations.inline_part, None)?,
+                };
+                if decoded.leaf.len() != state.mutations.member_count as usize {
+                    return Err(replacement_payload_error(
+                        "inline membership payload row count disagrees with authenticated authority",
+                    ));
+                }
+                self.segment = Some(decoded);
+                self.segment_index = Some(0);
+            }
+        }
+
+        if let Some(root) = self.bounded_root.clone() {
+            if self
+                .bounded_part
+                .as_ref()
+                .is_some_and(|(_, _, bounds)| encoded_key < bounds.first_key.as_slice())
+            {
+                return Ok(Some(false));
+            }
+            if self
+                .bounded_part
+                .as_ref()
+                .is_none_or(|(_, _, bounds)| bounds.last_key.as_slice() < encoded_key)
+            {
+                let points = [Bytes::copy_from_slice(encoded_key)];
+                let mut runs = super::mutation_directory::load_mutation_part_read_plan(
+                    store,
+                    &root,
+                    super::mutation_directory::MutationDirectoryReadSelection::SortedUniquePoints(
+                        &points,
+                    ),
+                )
+                .await?
+                .into_runs()
+                .into_iter();
+                let Some(run) = runs.next() else {
+                    return Ok(Some(false));
+                };
+                if runs.next().is_some() {
+                    return Err(replacement_payload_error(
+                        "one membership point selected multiple immutable parts",
+                    ));
+                }
+                let super::mutation_directory::MutationDirectoryEntry::Bounded {
+                    part,
+                    direct_row_count,
+                } = run.entry
+                else {
+                    return Err(replacement_payload_error(
+                        "bounded membership cursor selected a non-bounded part",
+                    ));
+                };
+                self.bounded_part = Some((
+                    usize::try_from(run.entry_index)
+                        .map_err(|_| replacement_payload_error("part index exceeds usize"))?,
+                    direct_row_count,
+                    CommitDeltaSegmentBounds {
+                        first_key: part.first_key,
+                        last_key: part.last_key,
+                        replacement_part: part.replacement_part,
+                    },
+                ));
+            }
+            let (segment_index, direct_row_count, bounds) = self
+                .bounded_part
+                .as_ref()
+                .expect("bounded cursor retained the selected part");
+            let segment_index = *segment_index;
+            if self.segment_index != Some(segment_index) || self.segment.is_none() {
+                self.segment = cache.segment(self.commit_id, segment_index, Some(bounds))?;
+                if self.segment.is_none() {
                     let storage_key =
                         commit_delta_segment_key_for_bounds(self.commit_id, segment_index, bounds)?;
-                    let loaded = PointReadPlan::new(
+                    let loaded = PointReadPlan::from_unique_keys(
                         TRACKED_STATE_COMMIT_DELTA_SEGMENT_SPACE,
-                        &[StorageKey(Bytes::from(storage_key))],
+                        vec![StorageKey(Bytes::from(storage_key))],
                     )
                     .materialize(store, StorageGetOptions::default())
                     .await?;
@@ -1662,20 +1733,24 @@ impl CommitDeltaLiveMembershipCursor {
                         .flatten()
                         .and_then(full_value_bytes)
                         .ok_or_else(|| {
-                            LixError::new(
-                                LixError::CODE_INTERNAL_ERROR,
-                                format!(
-                                    "tracked_state commit_delta manifest for commit '{}' references missing segment {segment_index}",
-                                    self.commit_id
-                                ),
+                            replacement_payload_error(
+                                "bounded membership cursor references a missing immutable part",
                             )
                         })?;
-                    decode_owned_commit_delta_segment(&bytes, Some(bounds))?
-                };
-                self.segment = Some(decoded);
+                    self.segment = Some(decode_owned_commit_delta_segment(&bytes, Some(bounds))?);
+                }
+                validate_bounded_direct_row_count(
+                    root.layout,
+                    *direct_row_count,
+                    self.segment
+                        .as_ref()
+                        .expect("bounded membership segment was loaded")
+                        .leaf
+                        .len(),
+                )?;
+                self.segment_index = Some(segment_index);
+                self.next_entry_index = 0;
             }
-            self.segment_index = Some(segment_index);
-            self.next_entry_index = 0;
         }
         let segment = self
             .segment
@@ -1723,6 +1798,78 @@ impl CommitDeltaLiveMembershipCursor {
 }
 
 impl CommitDeltaPointReadCache {
+    fn authority(
+        &self,
+        commit_id: CommitId,
+    ) -> Result<Option<Arc<AuthenticatedReplayCommitStateManifest>>, LixError> {
+        let mut cache = self.inner.lock().map_err(|_| {
+            LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                "transaction commit-delta point cache lock is poisoned",
+            )
+        })?;
+        let Some(position) = cache
+            .authorities
+            .iter()
+            .position(|(cached_commit_id, _)| *cached_commit_id == commit_id)
+        else {
+            return Ok(None);
+        };
+        let entry = cache
+            .authorities
+            .remove(position)
+            .expect("located authenticated commit authority cache entry");
+        let authority = Arc::clone(&entry.1);
+        cache.authorities.push_back(entry);
+        Ok(Some(authority))
+    }
+
+    fn remember_authority(
+        &self,
+        authority: Arc<AuthenticatedReplayCommitStateManifest>,
+    ) -> Result<(), LixError> {
+        let mut cache = self.inner.lock().map_err(|_| {
+            LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                "transaction commit-delta point cache lock is poisoned",
+            )
+        })?;
+        if let Some(position) = cache
+            .authorities
+            .iter()
+            .position(|(commit_id, _)| *commit_id == authority.commit_id)
+        {
+            if cache.authorities[position].1.as_ref() != authority.as_ref() {
+                return Err(replacement_payload_error(
+                    "transaction point cache received mismatched authenticated authority",
+                ));
+            }
+            cache.authorities.remove(position);
+        }
+        cache
+            .authorities
+            .push_back((authority.commit_id, authority));
+        while cache.authorities.len() > DECODED_COMMIT_DELTA_CACHE_MAX_ENTRIES {
+            cache.authorities.pop_front();
+        }
+        Ok(())
+    }
+
+    fn remember_authenticated_state(
+        &self,
+        state: &AuthenticatedReplayCommitStateManifest,
+    ) -> Result<(), LixError> {
+        if let Some(cached) = self.authority(state.commit_id)? {
+            if cached.as_ref() != state {
+                return Err(replacement_payload_error(
+                    "transaction point cache received mismatched authenticated authority",
+                ));
+            }
+            return Ok(());
+        }
+        self.remember_authority(Arc::new(state.clone()))
+    }
+
     fn should_admit_segment(
         &self,
         commit_id: CommitId,
@@ -2317,7 +2464,7 @@ impl PublishedCommitStateTopology {
 
 /// One-read immutable authority used by point replay. The wrapper prevents a
 /// freely constructed manifest from claiming authoritative catalog coverage.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub(crate) struct AuthenticatedReplayCommitStateManifest {
     manifest: CommitStateManifest,
     mutation_directory_root: Option<super::mutation_directory::MutationDirectoryRoot>,
@@ -3356,6 +3503,33 @@ fn commit_delta_segment_key_for_bounds(
     Ok(encoded)
 }
 
+fn commit_delta_segment_key_for_part(
+    commit_id: CommitId,
+    segment_index: usize,
+    part: &CommitStateMutationPart,
+) -> Result<Vec<u8>, LixError> {
+    let mut encoded = commit_delta_segment_key(commit_id, segment_index)?;
+    if let Some(part) = part.replacement_part.as_ref() {
+        encoded.extend_from_slice(&part.content_digest);
+    }
+    Ok(encoded)
+}
+
+fn validate_bounded_direct_row_count(
+    layout: u8,
+    direct_row_count: u16,
+    decoded_row_count: usize,
+) -> Result<(), LixError> {
+    if layout == super::mutation_directory::LAYOUT_BOUNDED_DIRECT
+        && decoded_row_count != usize::from(direct_row_count)
+    {
+        return Err(replacement_payload_error(
+            "bounded immutable part row count disagrees with directory authority",
+        ));
+    }
+    Ok(())
+}
+
 /// Loads the immutable physical authority for one tracked commit.
 pub(crate) async fn load_commit_state_manifest(
     store: &(impl StorageAdapterRead + ?Sized),
@@ -3453,14 +3627,6 @@ pub(crate) async fn load_published_commit_state_topology(
         ));
     }
     Ok(Some(PublishedCommitStateTopology { header }))
-}
-
-/// Loads the replay projection from immutable physical authority.
-pub(crate) async fn load_replay_commit_state_manifest(
-    store: &(impl StorageAdapterRead + ?Sized),
-    commit_id: CommitId,
-) -> Result<Option<CommitStateManifest>, LixError> {
-    load_commit_state_manifest(store, commit_id).await
 }
 
 pub(crate) async fn load_point_replay_commit_state(
@@ -3591,9 +3757,10 @@ pub(crate) async fn load_commit_state_manifests(
                 .and_then(|(_, inventory)| inventory.directory_root.clone())
         })
         .collect::<Vec<_>>();
-    let mut directories = super::mutation_directory::load_mutation_directories(store, &roots)
-        .await?
-        .into_iter();
+    let mut directories =
+        super::mutation_directory::load_all_mutation_part_read_plans(store, &roots)
+            .await?
+            .into_iter();
     let mut output = Vec::with_capacity(authorities.len());
     for authority in authorities {
         let Some((stored, inventory)) = authority else {
@@ -3604,6 +3771,10 @@ pub(crate) async fn load_commit_state_manifests(
             directories
                 .next()
                 .expect("each authenticated root returns one directory")
+                .into_runs()
+                .into_iter()
+                .map(|run| run.entry)
+                .collect()
         } else {
             Vec::new()
         };
@@ -5089,52 +5260,39 @@ pub(crate) async fn load_change_record_by_id(
     store: &(impl StorageAdapterRead + ?Sized),
     change_id: crate::changelog::ChangeId,
 ) -> Result<Option<crate::changelog::ChangeRecord>, LixError> {
-    let mut direct_error = None;
     if let Some(locator) = direct_change_locator(change_id)
-        && let Some(commit_state) = load_commit_state_manifest(store, locator.commit_id).await?
-        && direct_change_locator_in_commit_state(&commit_state, change_id) == Some(locator)
+        && let Some(authority) =
+            load_claimed_direct_change_authority(store, locator.commit_id).await?
     {
-        let mutation_directory =
-            expanded_commit_delta_manifest_from_commit_state(store, &commit_state).await?;
-        match try_load_change_record_at_locator_in_manifest(store, locator, &mutation_directory)
-            .await
-        {
-            Ok(Some(record)) => return Ok(Some(record)),
-            Ok(None) => {}
-            Err(error) => direct_error = Some(error),
-        }
+        let mut records =
+            load_owned_direct_change_records_for_state(store, &authority, &[locator]).await?;
+        return Ok(Some(
+            records.pop().expect("one direct locator returns one row"),
+        ));
     }
     if let Some(locator) = load_change_locator_by_id(store, change_id).await? {
         return load_change_record_at_locator(store, locator)
             .await
             .map(Some);
     }
-    direct_error.map_or(Ok(None), Err)
+    Ok(None)
 }
 
 async fn load_canonical_change_locator(
     store: &(impl StorageAdapterRead + ?Sized),
     change_id: crate::changelog::ChangeId,
 ) -> Result<Option<CommitDeltaChangeLocator>, LixError> {
-    let mut direct_error = None;
     if let Some(locator) = direct_change_locator(change_id)
-        && let Some(commit_state) = load_commit_state_manifest(store, locator.commit_id).await?
-        && direct_change_locator_in_commit_state(&commit_state, change_id) == Some(locator)
+        && let Some(authority) =
+            load_claimed_direct_change_authority(store, locator.commit_id).await?
     {
-        let mutation_directory =
-            expanded_commit_delta_manifest_from_commit_state(store, &commit_state).await?;
-        match try_load_change_record_at_locator_in_manifest(store, locator, &mutation_directory)
-            .await
-        {
-            Ok(Some(_)) => return Ok(Some(locator)),
-            Ok(None) => {}
-            Err(error) => direct_error = Some(error),
-        }
+        load_owned_direct_change_records_for_state(store, &authority, &[locator]).await?;
+        return Ok(Some(locator));
     }
     if let Some(locator) = load_change_locator_by_id(store, change_id).await? {
         return Ok(Some(locator));
     }
-    direct_error.map_or(Ok(None), Err)
+    Ok(None)
 }
 
 pub(crate) fn direct_change_locator(
@@ -5156,26 +5314,6 @@ pub(crate) fn direct_change_locator(
         segment_index: packed / segment_row_limit,
         ordinal,
     })
-}
-
-/// Resolves a direct `ChangeId` only when its encoded slot is present in the
-/// authoritative commit-state inventory.
-///
-/// This is the hard-cut point route: physical part slots remain stable even
-/// when the optional snapshot root is rebuilt or compacted.
-pub(crate) fn direct_change_locator_in_commit_state(
-    manifest: &CommitStateManifest,
-    change_id: crate::changelog::ChangeId,
-) -> Option<CommitDeltaChangeLocator> {
-    let locator = direct_change_locator(change_id)?;
-    if locator.commit_id != manifest.commit_id {
-        return None;
-    }
-    let rows = manifest
-        .mutations
-        .direct_part_row_counts
-        .get(usize::try_from(locator.segment_index).ok()?)?;
-    (locator.ordinal < *rows).then_some(locator)
 }
 
 async fn load_change_locator_by_id(
@@ -5200,6 +5338,426 @@ async fn load_change_locator_by_id(
     decode_change_locator(change_id, &locator).map(Some)
 }
 
+async fn load_claimed_direct_change_authority(
+    store: &(impl StorageAdapterRead + ?Sized),
+    commit_id: CommitId,
+) -> Result<Option<Arc<AuthenticatedReplayCommitStateManifest>>, LixError> {
+    let Some(state) = load_point_replay_commit_state(store, commit_id).await? else {
+        return Ok(None);
+    };
+    let claimed = match state
+        .mutation_directory_root
+        .as_ref()
+        .map(|root| root.layout)
+    {
+        Some(
+            super::mutation_directory::LAYOUT_BOUNDED_DIRECT
+            | super::mutation_directory::LAYOUT_COMPACT_REPLACEMENT
+            | super::mutation_directory::LAYOUT_DIRECT_ROWS_ONLY,
+        ) => true,
+        Some(super::mutation_directory::LAYOUT_BOUNDED_INDIRECT) => false,
+        Some(_) => {
+            return Err(replacement_payload_error(
+                "direct change authority has an unsupported directory layout",
+            ));
+        }
+        None => !state.mutations.direct_part_row_counts.is_empty(),
+    };
+    if claimed && state.mutations.selected_source_commit_id().is_some() {
+        return Err(replacement_payload_error(
+            "selected-source alias cannot claim direct change coordinates",
+        ));
+    }
+    Ok(claimed.then(|| Arc::new(state)))
+}
+
+async fn load_owned_direct_change_records_for_state(
+    store: &(impl StorageAdapterRead + ?Sized),
+    state: &AuthenticatedReplayCommitStateManifest,
+    locators: &[CommitDeltaChangeLocator],
+) -> Result<Vec<crate::changelog::ChangeRecord>, LixError> {
+    if locators.is_empty() {
+        return Ok(Vec::new());
+    }
+    if state.mutations.selected_source_commit_id().is_some() {
+        return Err(replacement_payload_error(
+            "selected-source alias cannot own direct change coordinates",
+        ));
+    }
+    let mut request_indices = (0..locators.len()).collect::<Vec<_>>();
+    request_indices.sort_by_key(|&index| {
+        let locator = locators[index];
+        (locator.segment_index, locator.ordinal)
+    });
+    let mut unique_locator_indices = Vec::<usize>::with_capacity(request_indices.len());
+    let mut output_routes = Vec::with_capacity(request_indices.len());
+    for request_index in request_indices {
+        let locator = locators[request_index];
+        if locator.commit_id != state.commit_id
+            || direct_change_locator(locator.change_id) != Some(locator)
+        {
+            return Err(replacement_payload_error(
+                "direct change coordinate disagrees with its encoded ChangeId owner",
+            ));
+        }
+        let unique_index = if unique_locator_indices
+            .last()
+            .is_some_and(|&previous| locators[previous] == locator)
+        {
+            unique_locator_indices.len() - 1
+        } else {
+            unique_locator_indices.push(request_index);
+            unique_locator_indices.len() - 1
+        };
+        output_routes.push((request_index, unique_index));
+    }
+    let coordinates = unique_locator_indices
+        .iter()
+        .map(|&index| {
+            let locator = locators[index];
+            super::mutation_directory::MutationDirectoryDirectCoordinate {
+                part_index: locator.segment_index,
+                local_row: locator.ordinal,
+            }
+        })
+        .collect::<Vec<_>>();
+
+    let unique = if let Some(root) = state.mutation_directory_root.as_ref() {
+        let runs = super::mutation_directory::load_mutation_part_read_plan(
+            store,
+            root,
+            super::mutation_directory::MutationDirectoryReadSelection::SortedUniqueDirectCoordinates(
+                &coordinates,
+            ),
+        )
+        .await?
+        .into_runs();
+        for run in &runs {
+            for coordinate in &coordinates[run.selector_span.clone()] {
+                if coordinate.part_index != run.entry_index {
+                    return Err(replacement_payload_error(
+                        "direct-coordinate plan selected the wrong physical part",
+                    ));
+                }
+            }
+        }
+        if let Some(parts) = state.mutations.columnar_parts.as_ref() {
+            for run in &runs {
+                let super::mutation_directory::MutationDirectoryEntry::DirectAddress {
+                    direct_row_count,
+                } = run.entry
+                else {
+                    return Err(replacement_payload_error(
+                        "columnar direct-coordinate plan selected a physical part",
+                    ));
+                };
+                if coordinates[run.selector_span.clone()]
+                    .iter()
+                    .any(|coordinate| coordinate.local_row >= direct_row_count)
+                {
+                    return Err(replacement_payload_error(
+                        "columnar direct coordinate exceeds its part row count",
+                    ));
+                }
+            }
+            load_columnar_direct_change_records(
+                store,
+                state,
+                parts,
+                &unique_locator_indices
+                    .iter()
+                    .map(|&index| locators[index])
+                    .collect::<Vec<_>>(),
+            )
+            .await?
+        } else {
+            load_physical_direct_change_records(
+                store,
+                state,
+                &coordinates,
+                &unique_locator_indices
+                    .iter()
+                    .map(|&index| locators[index])
+                    .collect::<Vec<_>>(),
+                runs,
+            )
+            .await?
+        }
+    } else {
+        if state.mutations.inline_part.is_empty()
+            || state.mutations.direct_part_row_counts.len() != 1
+            || coordinates
+                .iter()
+                .any(|coordinate| coordinate.part_index != 0)
+        {
+            return Err(replacement_payload_error(
+                "direct change coordinate has no authenticated inline authority",
+            ));
+        }
+        let direct_row_count = state.mutations.direct_part_row_counts[0];
+        let (leaf, payloads) =
+            decode_commit_delta_with_payloads(&state.mutations.inline_part, None)?;
+        if leaf.len() != usize::from(direct_row_count)
+            || leaf.len() != state.mutations.member_count as usize
+        {
+            return Err(replacement_payload_error(
+                "inline direct payload row count disagrees with authenticated authority",
+            ));
+        }
+        unique_locator_indices
+            .iter()
+            .map(|&index| {
+                decode_change_at_locator_from_decoded(
+                    &leaf,
+                    &payloads,
+                    locators[index],
+                    &state.change_account_id,
+                )
+                .map(|entry| entry.change_record)
+            })
+            .collect::<Result<Vec<_>, LixError>>()?
+    };
+
+    let mut output = (0..locators.len()).map(|_| None).collect::<Vec<_>>();
+    for (request_index, unique_index) in output_routes {
+        output[request_index] = Some(unique[unique_index].clone());
+    }
+    output
+        .into_iter()
+        .map(|record| {
+            record.ok_or_else(|| {
+                replacement_payload_error("direct change record scatter lost a requested row")
+            })
+        })
+        .collect()
+}
+
+async fn load_columnar_direct_change_records(
+    store: &(impl StorageAdapterRead + ?Sized),
+    state: &AuthenticatedReplayCommitStateManifest,
+    parts: &crate::tracked_state::types::ColumnarMutationPartSet,
+    locators: &[CommitDeltaChangeLocator],
+) -> Result<Vec<crate::changelog::ChangeRecord>, LixError> {
+    let id = crate::columnar_row_group::RowGroupSetId::new(parts.row_group_set_id);
+    let manifest = crate::columnar_row_group::load_row_group_manifest(store, id)
+        .await?
+        .ok_or_else(|| replacement_payload_error("columnar mutation manifest is missing"))?;
+    validate_columnar_mutation_manifest(&manifest, parts)?;
+    let projection = (0..manifest.fields.len()).collect::<Vec<_>>();
+    let mut page_groups = BTreeMap::<(usize, usize), Vec<(usize, usize)>>::new();
+    for (output_index, &locator) in locators.iter().enumerate() {
+        let logical_ordinal = usize::try_from(locator.segment_index)
+            .expect("u32 segment fits usize")
+            .checked_mul(COMMIT_DELTA_SEGMENT_MAX_ROWS)
+            .and_then(|base| base.checked_add(usize::from(locator.ordinal)))
+            .ok_or_else(|| replacement_payload_error("columnar mutation address overflows"))?;
+        if logical_ordinal >= parts.row_count as usize {
+            return Err(replacement_payload_error(
+                "columnar mutation locator is outside its inventory",
+            ));
+        }
+        let group_index = logical_ordinal / crate::columnar_row_group::ROW_GROUP_MAX_ROWS;
+        let row_in_group = logical_ordinal % crate::columnar_row_group::ROW_GROUP_MAX_ROWS;
+        let page_index = row_in_group / crate::columnar_row_group::ROW_GROUP_PAGE_ROWS;
+        let row_in_page = row_in_group % crate::columnar_row_group::ROW_GROUP_PAGE_ROWS;
+        page_groups
+            .entry((group_index, page_index))
+            .or_default()
+            .push((output_index, row_in_page));
+    }
+    let page_coordinates = page_groups.keys().copied().collect::<Vec<_>>();
+    let mut output = (0..locators.len()).map(|_| None).collect::<Vec<_>>();
+    crate::columnar_row_group::visit_row_group_pages(
+        store,
+        id,
+        &manifest,
+        &page_coordinates,
+        &projection,
+        |coordinate, batch| {
+            for &(output_index, row_in_page) in &page_groups[&coordinate] {
+                let locator = locators[output_index];
+                output[output_index] = Some(decode_columnar_change_record(
+                    &manifest,
+                    &batch,
+                    row_in_page,
+                    parts,
+                    locator.change_id,
+                    &state.change_account_id,
+                )?);
+            }
+            Ok(())
+        },
+    )
+    .await?;
+    output
+        .into_iter()
+        .map(|record| {
+            record.ok_or_else(|| {
+                replacement_payload_error("columnar direct coordinate lost its payload row")
+            })
+        })
+        .collect()
+}
+
+async fn load_physical_direct_change_records(
+    store: &(impl StorageAdapterRead + ?Sized),
+    state: &AuthenticatedReplayCommitStateManifest,
+    coordinates: &[super::mutation_directory::MutationDirectoryDirectCoordinate],
+    locators: &[CommitDeltaChangeLocator],
+    runs: Vec<super::mutation_directory::MutationDirectoryPartRun>,
+) -> Result<Vec<crate::changelog::ChangeRecord>, LixError> {
+    let storage_keys = runs
+        .iter()
+        .map(|run| match &run.entry {
+            super::mutation_directory::MutationDirectoryEntry::Bounded { part, .. } => {
+                commit_delta_segment_key_for_part(
+                    state.commit_id,
+                    usize::try_from(run.entry_index)
+                        .map_err(|_| replacement_payload_error("part index exceeds usize"))?,
+                    part,
+                )
+            }
+            super::mutation_directory::MutationDirectoryEntry::CompactReplacement {
+                content_digest,
+                ..
+            } => {
+                let mut key = commit_delta_segment_key(
+                    state.commit_id,
+                    usize::try_from(run.entry_index)
+                        .map_err(|_| replacement_payload_error("part index exceeds usize"))?,
+                )?;
+                key.extend_from_slice(content_digest);
+                Ok(key)
+            }
+            super::mutation_directory::MutationDirectoryEntry::DirectAddress { .. } => Err(
+                replacement_payload_error("non-columnar direct authority has no physical part"),
+            ),
+        })
+        .map(|key| key.map(|key| StorageKey(Bytes::from(key))))
+        .collect::<Result<Vec<_>, LixError>>()?;
+    let values =
+        PointReadPlan::from_unique_keys(TRACKED_STATE_COMMIT_DELTA_SEGMENT_SPACE, storage_keys)
+            .materialize(store, StorageGetOptions::default())
+            .await?;
+    let mut output = (0..coordinates.len()).map(|_| None).collect::<Vec<_>>();
+    for (run, value) in runs.into_iter().zip(values.value) {
+        let bytes = value.and_then(full_value_bytes).ok_or_else(|| {
+            replacement_payload_error("direct coordinate references a missing immutable part")
+        })?;
+        let (bounds, direct_row_count) = match run.entry {
+            super::mutation_directory::MutationDirectoryEntry::Bounded {
+                part,
+                direct_row_count,
+            } => (
+                CommitDeltaSegmentBounds {
+                    first_key: part.first_key,
+                    last_key: part.last_key,
+                    replacement_part: part.replacement_part,
+                },
+                direct_row_count,
+            ),
+            super::mutation_directory::MutationDirectoryEntry::CompactReplacement {
+                content_digest,
+                direct_row_count,
+            } => (
+                compact_replacement_bounds_for_selected_part(
+                    state,
+                    run.entry_index,
+                    content_digest,
+                    &bytes,
+                )?,
+                direct_row_count,
+            ),
+            super::mutation_directory::MutationDirectoryEntry::DirectAddress { .. } => {
+                return Err(replacement_payload_error(
+                    "non-columnar direct authority selected an address-only entry",
+                ));
+            }
+        };
+        let (leaf, payloads) = decode_commit_delta_with_payloads(&bytes, Some(&bounds))?;
+        if leaf.len() != usize::from(direct_row_count) {
+            return Err(replacement_payload_error(
+                "direct immutable part row count disagrees with directory authority",
+            ));
+        }
+        for output_index in run.selector_span {
+            let coordinate = coordinates[output_index];
+            let locator = locators[output_index];
+            if coordinate.part_index != run.entry_index || coordinate.local_row != locator.ordinal {
+                return Err(replacement_payload_error(
+                    "direct-coordinate run disagrees with its physical locator",
+                ));
+            }
+            output[output_index] = Some(
+                decode_change_at_locator_from_decoded(
+                    &leaf,
+                    &payloads,
+                    locator,
+                    &state.change_account_id,
+                )?
+                .change_record,
+            );
+        }
+    }
+    output
+        .into_iter()
+        .map(|record| {
+            record.ok_or_else(|| {
+                replacement_payload_error("direct-coordinate plan lost a selected payload row")
+            })
+        })
+        .collect()
+}
+
+fn compact_replacement_bounds_for_selected_part(
+    state: &AuthenticatedReplayCommitStateManifest,
+    part_index: u32,
+    content_digest: [u8; 32],
+    bytes: &[u8],
+) -> Result<CommitDeltaSegmentBounds, LixError> {
+    let generation = state
+        .mutations
+        .replacement_generation
+        .as_ref()
+        .ok_or_else(|| replacement_payload_error("compact part omitted its generation"))?;
+    let lifecycle = state
+        .mutations
+        .lifecycle_summary
+        .as_ref()
+        .ok_or_else(|| replacement_payload_error("compact part omitted lifecycle metadata"))?;
+    let authority = state
+        .mutations
+        .replacement_parts
+        .as_ref()
+        .ok_or_else(|| replacement_payload_error("compact part omitted payload authority"))?;
+    let decoded =
+        crate::tracked_state::replacement_part::decode_replacement_part(&content_digest, bytes)?;
+    let first_key = decoded
+        .first_key()
+        .ok_or_else(|| replacement_payload_error("replacement part is empty"))?
+        .to_vec();
+    let last_key = decoded
+        .last_key()
+        .ok_or_else(|| replacement_payload_error("replacement part is empty"))?
+        .to_vec();
+    let first_address = part_index
+        .checked_mul(
+            u32::try_from(COMMIT_DELTA_SEGMENT_MAX_ROWS).expect("replacement row bound fits u32"),
+        )
+        .ok_or_else(|| replacement_payload_error("replacement address overflows"))?;
+    Ok(CommitDeltaSegmentBounds {
+        first_key,
+        last_key,
+        replacement_part: Some(StoredReplacementPart {
+            content_digest,
+            owner_commit_id: generation.owner_commit_id,
+            first_address,
+            uniform_created_at: lifecycle.uniform_created_at,
+            uniform_updated_at: authority.uniform_updated_at,
+        }),
+    })
+}
+
 async fn load_change_records_by_ids(
     store: &(impl StorageAdapterRead + ?Sized),
     change_ids: &[crate::changelog::ChangeId],
@@ -5207,89 +5765,94 @@ async fn load_change_records_by_ids(
     if change_ids.is_empty() {
         return Ok(Vec::new());
     }
-    // Fresh changes use their commit-delta coordinates as their IDs and
-    // intentionally have no locator rows. Keep the legacy locator batch below
-    // for wholly explicit IDs; mixed/direct batches must validate the direct
-    // candidate and retain the existing explicit-locator fallback.
-    if let Some(direct_locators) = change_ids
-        .iter()
-        .copied()
-        .map(direct_change_locator)
-        .collect::<Option<Vec<_>>>()
-    {
-        // Certified commits encode their authoritative coordinates directly
-        // in every change ID. Resolve the whole selection as one physical
-        // batch so a large segment is read and decoded once rather than once
-        // per selected change. Address-shaped explicit IDs are rare and keep
-        // the established locator fallback below if candidate validation
-        // rejects the direct route.
-        if let Ok(records) =
-            Box::pin(load_change_records_at_locators(store, &direct_locators)).await
-        {
-            return Ok(records);
+    let mut authority_cache =
+        BTreeMap::<CommitId, Option<Arc<AuthenticatedReplayCommitStateManifest>>>::new();
+    let mut direct_by_commit = BTreeMap::<
+        CommitId,
+        (
+            Arc<AuthenticatedReplayCommitStateManifest>,
+            Vec<(usize, CommitDeltaChangeLocator)>,
+        ),
+    >::new();
+    let mut explicit = Vec::<(usize, crate::changelog::ChangeId)>::new();
+    for (output_index, &change_id) in change_ids.iter().enumerate() {
+        let Some(locator) = direct_change_locator(change_id) else {
+            explicit.push((output_index, change_id));
+            continue;
+        };
+        let authority = match authority_cache.get(&locator.commit_id) {
+            Some(authority) => authority.clone(),
+            None => {
+                let authority =
+                    load_claimed_direct_change_authority(store, locator.commit_id).await?;
+                authority_cache.insert(locator.commit_id, authority.clone());
+                authority
+            }
+        };
+        let Some(authority) = authority else {
+            explicit.push((output_index, change_id));
+            continue;
+        };
+        direct_by_commit
+            .entry(locator.commit_id)
+            .or_insert_with(|| (authority, Vec::new()))
+            .1
+            .push((output_index, locator));
+    }
+
+    let mut output = (0..change_ids.len()).map(|_| None).collect::<Vec<_>>();
+    for (_, (authority, requests)) in direct_by_commit {
+        let locators = requests
+            .iter()
+            .map(|(_, locator)| *locator)
+            .collect::<Vec<_>>();
+        let records = Box::pin(load_owned_direct_change_records_for_state(
+            store, &authority, &locators,
+        ))
+        .await?;
+        for ((output_index, _), record) in requests.into_iter().zip(records) {
+            output[output_index] = Some(record);
         }
     }
-    if change_ids
-        .iter()
-        .copied()
-        .any(|change_id| direct_change_locator(change_id).is_some())
-    {
-        return stream::iter(change_ids.iter().copied())
-            .map(|change_id| async move {
-                load_change_record_by_id_boxed(store, change_id)
-                    .await?
-                    .ok_or_else(|| {
-                        LixError::new(
-                            LixError::CODE_INTERNAL_ERROR,
-                            format!(
-                                "tracked_state selected change '{change_id}' has no authoritative locator"
-                            ),
-                        )
-                    })
+
+    if !explicit.is_empty() {
+        let locator_keys = explicit
+            .iter()
+            .map(|(_, change_id)| {
+                StorageKey(Bytes::copy_from_slice(change_id.as_uuid().as_bytes()))
             })
-            .buffered(64)
-            .try_collect()
-            .await;
+            .collect::<Vec<_>>();
+        let locator_values = PointReadPlan::new(TRACKED_STATE_CHANGE_LOCATOR_SPACE, &locator_keys)
+            .materialize(store, StorageGetOptions::default())
+            .await?;
+        let locators = explicit
+            .iter()
+            .zip(locator_values.value)
+            .map(|((_, change_id), value)| {
+                let bytes = value.and_then(full_value_bytes).ok_or_else(|| {
+                    replacement_payload_error(&format!(
+                        "selected change '{change_id}' has no authoritative locator"
+                    ))
+                })?;
+                decode_change_locator(*change_id, &bytes)
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+        let records = Box::pin(load_explicit_change_records_at_locators(store, &locators)).await?;
+        for ((output_index, _), record) in explicit.into_iter().zip(records) {
+            output[output_index] = Some(record);
+        }
     }
-    let locator_keys = change_ids
-        .iter()
-        .map(|change_id| StorageKey(Bytes::copy_from_slice(change_id.as_uuid().as_bytes())))
-        .collect::<Vec<_>>();
-    let locator_values = PointReadPlan::new(TRACKED_STATE_CHANGE_LOCATOR_SPACE, &locator_keys)
-        .materialize(store, StorageGetOptions::default())
-        .await?;
-    let locators = change_ids
-        .iter()
-        .copied()
-        .zip(locator_values.value)
-        .map(|(change_id, value)| {
-            let bytes = value.and_then(full_value_bytes).ok_or_else(|| {
-                LixError::new(
-                    LixError::CODE_INTERNAL_ERROR,
-                    format!(
-                        "tracked_state selected change '{change_id}' has no authoritative locator"
-                    ),
-                )
-            })?;
-            decode_change_locator(change_id, &bytes)
+    output
+        .into_iter()
+        .map(|record| {
+            record.ok_or_else(|| {
+                replacement_payload_error("selected change resolution lost a requested row")
+            })
         })
-        .collect::<Result<Vec<_>, _>>()?;
-    Box::pin(load_change_records_at_locators(store, &locators)).await
+        .collect()
 }
 
-fn load_change_record_by_id_boxed<'a, S>(
-    store: &'a S,
-    change_id: crate::changelog::ChangeId,
-) -> Pin<
-    Box<dyn Future<Output = Result<Option<crate::changelog::ChangeRecord>, LixError>> + Send + 'a>,
->
-where
-    S: StorageAdapterRead + ?Sized + 'a,
-{
-    Box::pin(load_change_record_by_id(store, change_id))
-}
-
-async fn load_change_records_at_locators(
+async fn load_explicit_change_records_at_locators(
     store: &(impl StorageAdapterRead + ?Sized),
     locators: &[CommitDeltaChangeLocator],
 ) -> Result<Vec<crate::changelog::ChangeRecord>, LixError> {
@@ -5584,6 +6147,14 @@ async fn load_change_record_at_locator(
     store: &(impl StorageAdapterRead + ?Sized),
     locator: CommitDeltaChangeLocator,
 ) -> Result<crate::changelog::ChangeRecord, LixError> {
+    if direct_change_locator(locator.change_id) == Some(locator)
+        && let Some(authority) =
+            load_claimed_direct_change_authority(store, locator.commit_id).await?
+    {
+        let mut records =
+            load_owned_direct_change_records_for_state(store, &authority, &[locator]).await?;
+        return Ok(records.pop().expect("one direct locator returns one row"));
+    }
     let change_id = locator.change_id;
     let Some(manifest) = load_commit_delta_manifest(store, locator.commit_id).await? else {
         return Err(LixError::new(
@@ -6008,98 +6579,54 @@ pub(crate) async fn load_commit_delta_values_encoded(
     commit_id: CommitId,
     encoded_keys: &[Bytes],
 ) -> Result<Vec<Option<TrackedStateIndexValue>>, LixError> {
-    load_commit_delta_values_encoded_with_cache(store, commit_id, encoded_keys, None).await
+    let Some(state) = load_point_replay_commit_state(store, commit_id).await? else {
+        return Ok(vec![None; encoded_keys.len()]);
+    };
+    load_commit_delta_values_encoded_from_replay_manifest(
+        store,
+        &state,
+        encoded_keys,
+        &CommitDeltaPointReadCache::default(),
+    )
+    .await
 }
 
-pub(crate) async fn load_commit_delta_values_encoded_with_cache(
-    store: &(impl StorageAdapterRead + ?Sized),
-    commit_id: CommitId,
-    encoded_keys: &[Bytes],
-    point_cache: Option<&CommitDeltaPointReadCache>,
-) -> Result<Vec<Option<TrackedStateIndexValue>>, LixError> {
-    let cached_manifest = point_cache
-        .map(|cache| cache.manifest(commit_id))
-        .transpose()?
-        .flatten();
-    let manifest = match cached_manifest {
-        Some(manifest) => manifest,
-        None => {
-            let Some(state) = load_replay_commit_state_manifest(store, commit_id).await? else {
-                return Ok(vec![None; encoded_keys.len()]);
-            };
-            if !state.mutations.replacement_part_digests.is_empty() {
-                return load_compact_replacement_values_encoded(
-                    store,
-                    commit_id,
-                    encoded_keys,
-                    &state,
-                )
-                .await;
-            }
-            let manifest =
-                Arc::new(expanded_commit_delta_manifest_from_commit_state(store, &state).await?);
-            if let Some(point_cache) = point_cache {
-                point_cache.remember_manifest(commit_id, Arc::clone(&manifest))?;
-            }
-            manifest
-        }
-    };
-    let Some(source_commit_id) = manifest.selected_source_commit_id() else {
-        return load_local_commit_delta_values_encoded(store, commit_id, encoded_keys, &manifest)
-            .await;
-    };
-    if load_replay_commit_state_manifest(store, source_commit_id)
-        .await?
-        .is_none()
-    {
-        return Err(LixError::new(
-            LixError::CODE_INTERNAL_ERROR,
-            format!(
-                "tracked_state selected-source commit '{commit_id}' references missing authority '{source_commit_id}'"
-            ),
-        ));
-    }
-    let mut values =
-        match load_commit_delta_manifest_cached(store, source_commit_id, point_cache).await? {
-            Some(source_manifest) => {
-                load_local_commit_delta_values_encoded(
-                    store,
-                    source_commit_id,
-                    encoded_keys,
-                    &source_manifest,
-                )
-                .await?
-            }
-            None => vec![None; encoded_keys.len()],
-        };
-    for value in values.iter_mut().flatten() {
-        value.commit_id = commit_id;
-    }
-    let local =
-        load_local_commit_delta_values_encoded(store, commit_id, encoded_keys, &manifest).await?;
-    for (value, local) in values.iter_mut().zip(local) {
-        if local.is_some() {
-            *value = local;
-        }
-    }
-    Ok(values)
-}
-
-/// Replays deltas from the one-read manifest already validated against the
-/// changelog projection. Compact replacements route directly through their
-/// immutable parts; ordinary manifests seed and reuse the point cache.
-pub(crate) async fn load_commit_delta_values_encoded_from_replay_manifest(
+async fn load_expanded_local_commit_delta_values_encoded(
     store: &(impl StorageAdapterRead + ?Sized),
     state: &AuthenticatedReplayCommitStateManifest,
     encoded_keys: &[Bytes],
     point_cache: &CommitDeltaPointReadCache,
 ) -> Result<Vec<Option<TrackedStateIndexValue>>, LixError> {
-    if state.mutations.selected_source_commit_id.is_none()
-        && state.mutation_directory_root.as_ref().is_some_and(|root| {
-            root.layout == super::mutation_directory::LAYOUT_BOUNDED_DIRECT
-                || root.layout == super::mutation_directory::LAYOUT_BOUNDED_INDIRECT
-        })
-    {
+    if state.mutation_directory_root.as_ref().is_some_and(|root| {
+        root.layout == super::mutation_directory::LAYOUT_BOUNDED_DIRECT
+            || root.layout == super::mutation_directory::LAYOUT_BOUNDED_INDIRECT
+    }) {
+        return Err(replacement_payload_error(
+            "bounded mutation authority cannot use an expanded point-read manifest",
+        ));
+    }
+    let manifest = match point_cache.manifest(state.commit_id)? {
+        Some(manifest) => manifest,
+        None => {
+            let manifest =
+                Arc::new(expanded_commit_delta_manifest_from_commit_state(store, &state).await?);
+            point_cache.remember_manifest(state.commit_id, Arc::clone(&manifest))?;
+            manifest
+        }
+    };
+    load_local_commit_delta_values_encoded(store, state.commit_id, encoded_keys, &manifest).await
+}
+
+async fn load_authenticated_local_commit_delta_values_encoded(
+    store: &(impl StorageAdapterRead + ?Sized),
+    state: &AuthenticatedReplayCommitStateManifest,
+    encoded_keys: &[Bytes],
+    point_cache: &CommitDeltaPointReadCache,
+) -> Result<Vec<Option<TrackedStateIndexValue>>, LixError> {
+    if state.mutation_directory_root.as_ref().is_some_and(|root| {
+        root.layout == super::mutation_directory::LAYOUT_BOUNDED_DIRECT
+            || root.layout == super::mutation_directory::LAYOUT_BOUNDED_INDIRECT
+    }) {
         return load_bounded_directory_values_encoded(store, state, encoded_keys).await;
     }
     if state
@@ -6129,17 +6656,79 @@ pub(crate) async fn load_commit_delta_values_encoded_from_replay_manifest(
         )
         .await;
     }
-    if point_cache.manifest(state.commit_id)?.is_none() {
-        let manifest = expanded_commit_delta_manifest_from_commit_state(store, state).await?;
-        point_cache.remember_manifest(state.commit_id, Arc::new(manifest))?;
+    load_expanded_local_commit_delta_values_encoded(store, state, encoded_keys, point_cache).await
+}
+
+/// Replays a strict sorted-unique key batch from one authenticated immutable
+/// commit authority. Selected-source authority is loaded and authenticated in
+/// the same storage snapshot; cached expanded manifests are used only for
+/// layouts that have no bounded hierarchy.
+pub(crate) async fn load_commit_delta_values_encoded_from_replay_manifest(
+    store: &(impl StorageAdapterRead + ?Sized),
+    state: &AuthenticatedReplayCommitStateManifest,
+    encoded_keys: &[Bytes],
+    point_cache: &CommitDeltaPointReadCache,
+) -> Result<Vec<Option<TrackedStateIndexValue>>, LixError> {
+    if !encoded_keys.windows(2).all(|pair| pair[0] < pair[1]) {
+        return Err(replacement_payload_error(
+            "point read requires strict sorted-unique encoded keys",
+        ));
     }
-    load_commit_delta_values_encoded_with_cache(
+    point_cache.remember_authenticated_state(state)?;
+    let Some(source_commit_id) = state.mutations.selected_source_commit_id() else {
+        return load_authenticated_local_commit_delta_values_encoded(
+            store,
+            state,
+            encoded_keys,
+            point_cache,
+        )
+        .await;
+    };
+    let source = match point_cache.authority(source_commit_id)? {
+        Some(source) => source,
+        None => {
+            let source = Arc::new(
+                load_point_replay_commit_state(store, source_commit_id)
+                    .await?
+                    .ok_or_else(|| {
+                        replacement_payload_error(&format!(
+                            "selected-source commit '{}' references missing authority '{source_commit_id}'",
+                            state.commit_id
+                        ))
+                    })?,
+            );
+            point_cache.remember_authority(Arc::clone(&source))?;
+            source
+        }
+    };
+    if source.mutations.selected_source_commit_id().is_some() {
+        return Err(replacement_payload_error(
+            "selected-source mutation authority cannot alias another source",
+        ));
+    }
+    let mut values = load_authenticated_local_commit_delta_values_encoded(
         store,
-        state.commit_id,
+        &source,
         encoded_keys,
-        Some(point_cache),
+        point_cache,
     )
-    .await
+    .await?;
+    for value in values.iter_mut().flatten() {
+        value.commit_id = state.commit_id;
+    }
+    let local = load_authenticated_local_commit_delta_values_encoded(
+        store,
+        state,
+        encoded_keys,
+        point_cache,
+    )
+    .await?;
+    for (value, local) in values.iter_mut().zip(local) {
+        if local.is_some() {
+            *value = local;
+        }
+    }
+    Ok(values)
 }
 
 async fn load_bounded_directory_values_encoded(
@@ -6150,59 +6739,58 @@ async fn load_bounded_directory_values_encoded(
     let root = state.mutation_directory_root.as_ref().ok_or_else(|| {
         replacement_payload_error("bounded point replay omitted its mutation-directory root")
     })?;
-    let key_refs = encoded_keys.iter().map(Bytes::as_ref).collect::<Vec<_>>();
-    let routes =
-        super::mutation_directory::route_mutation_directory_points(store, root, &key_refs).await?;
-    let mut grouped = BTreeMap::<u32, (CommitStateMutationPart, Vec<usize>)>::new();
-    for (output_index, route) in routes.into_iter().enumerate() {
-        let Some(route) = route else {
-            continue;
-        };
-        match grouped.entry(route.entry_index) {
-            std::collections::btree_map::Entry::Vacant(entry) => {
-                entry.insert((route.part, vec![output_index]));
-            }
-            std::collections::btree_map::Entry::Occupied(mut entry) => {
-                if entry.get().0 != route.part {
-                    return Err(replacement_payload_error(
-                        "bounded point replay returned conflicting part routes",
-                    ));
-                }
-                entry.get_mut().1.push(output_index);
-            }
-        }
-    }
-    let storage_keys = grouped
+    let runs = super::mutation_directory::load_mutation_part_read_plan(
+        store,
+        root,
+        super::mutation_directory::MutationDirectoryReadSelection::SortedUniquePoints(encoded_keys),
+    )
+    .await?
+    .into_runs();
+    let storage_keys = runs
         .iter()
-        .map(|(&part_index, (part, _))| {
-            commit_delta_segment_key_for_bounds(
+        .map(|run| {
+            let super::mutation_directory::MutationDirectoryEntry::Bounded { part, .. } =
+                &run.entry
+            else {
+                return Err(replacement_payload_error(
+                    "bounded point replay selected a non-bounded part",
+                ));
+            };
+            commit_delta_segment_key_for_part(
                 state.commit_id,
-                usize::try_from(part_index)
+                usize::try_from(run.entry_index)
                     .map_err(|_| replacement_payload_error("part index exceeds usize"))?,
-                &CommitDeltaSegmentBounds {
-                    first_key: part.first_key.clone(),
-                    last_key: part.last_key.clone(),
-                    replacement_part: part.replacement_part.clone(),
-                },
+                part,
             )
             .map(|key| StorageKey(Bytes::from(key)))
         })
         .collect::<Result<Vec<_>, LixError>>()?;
-    let loaded = PointReadPlan::new(TRACKED_STATE_COMMIT_DELTA_SEGMENT_SPACE, &storage_keys)
-        .materialize(store, StorageGetOptions::default())
-        .await?;
+    let loaded =
+        PointReadPlan::from_unique_keys(TRACKED_STATE_COMMIT_DELTA_SEGMENT_SPACE, storage_keys)
+            .materialize(store, StorageGetOptions::default())
+            .await?;
     let mut output = vec![None; encoded_keys.len()];
-    for ((_, (part, requests)), value) in grouped.into_iter().zip(loaded.value) {
+    for (run, value) in runs.into_iter().zip(loaded.value) {
         let bytes = value.and_then(full_value_bytes).ok_or_else(|| {
             replacement_payload_error("bounded mutation directory references a missing part")
         })?;
+        let super::mutation_directory::MutationDirectoryEntry::Bounded {
+            part,
+            direct_row_count,
+        } = run.entry
+        else {
+            return Err(replacement_payload_error(
+                "bounded point replay selected a non-bounded part",
+            ));
+        };
         let bounds = CommitDeltaSegmentBounds {
             first_key: part.first_key,
             last_key: part.last_key,
             replacement_part: part.replacement_part,
         };
         let (leaf, payloads) = decode_commit_delta_with_payloads(&bytes, Some(&bounds))?;
-        for output_index in requests {
+        validate_bounded_direct_row_count(root.layout, direct_row_count, leaf.len())?;
+        for output_index in run.selector_span {
             output[output_index] = find_loaded_commit_delta_entry(
                 &leaf,
                 &payloads,
@@ -6591,85 +7179,269 @@ pub(crate) async fn load_commit_delta_members_with_payloads_for_schemas(
     schema_keys: &[String],
     max_segment_count: usize,
 ) -> Result<Option<Vec<CommitDeltaMember>>, LixError> {
-    let Some(manifest) = load_commit_delta_manifest(store, commit_id).await? else {
+    let Some(state) = load_point_replay_commit_state(store, commit_id).await? else {
         return Ok(Some(Vec::new()));
     };
-    let requested_schemas = schema_keys
-        .iter()
-        .map(String::as_str)
-        .collect::<BTreeSet<_>>();
-    let local_segment_count = if manifest.inline_segment().is_some() {
-        1
-    } else {
-        commit_delta_segment_count_for_schemas_up_to(
-            &manifest,
-            &requested_schemas,
+    let Some((local, local_segment_count)) =
+        load_authenticated_local_commit_delta_members_for_schemas(
+            store,
+            &state,
+            schema_keys,
             max_segment_count,
         )
-    };
-    if local_segment_count > max_segment_count {
+        .await?
+    else {
         return Ok(None);
-    }
-    let source = if let Some(source_commit_id) = manifest.selected_source_commit_id() {
-        let source_manifest = load_commit_delta_manifest(store, source_commit_id)
-            .await?
-            .ok_or_else(|| {
-                LixError::new(
-                    LixError::CODE_INTERNAL_ERROR,
-                    format!(
-                        "selected-source commit delta '{}' references missing source '{}'",
-                        commit_id, source_commit_id
-                    ),
-                )
-            })?;
-        let source_segment_count = if source_manifest.inline_segment().is_some() {
-            1
-        } else {
-            commit_delta_segment_count_for_schemas_up_to(
-                &source_manifest,
-                &requested_schemas,
-                max_segment_count.saturating_sub(local_segment_count),
-            )
-        };
-        if local_segment_count.saturating_add(source_segment_count) > max_segment_count {
-            return Ok(None);
-        }
-        Some((source_commit_id, source_manifest))
-    } else {
-        None
     };
-    let mut local =
-        load_commit_delta_members_from_manifest(store, commit_id, &manifest, schema_keys).await?;
-    let Some((source_commit_id, source_manifest)) = source else {
+    let Some(source_commit_id) = state.mutations.selected_source_commit_id() else {
         return Ok(Some(local));
     };
-    if source_manifest.selected_source_commit_id().is_some() {
-        return Err(LixError::new(
-            LixError::CODE_INTERNAL_ERROR,
+    let source = load_point_replay_commit_state(store, source_commit_id)
+        .await?
+        .ok_or_else(|| {
+            replacement_payload_error(&format!(
+                "selected-source commit delta '{commit_id}' references missing source '{source_commit_id}'"
+            ))
+        })?;
+    if source.mutations.selected_source_commit_id().is_some() {
+        return Err(replacement_payload_error(
             "selected-source commit delta chains are unsupported",
         ));
     }
-    let mut members = load_commit_delta_members_from_manifest(
+    let Some((mut members, _)) = load_authenticated_local_commit_delta_members_for_schemas(
         store,
-        source_commit_id,
-        &source_manifest,
+        &source,
         schema_keys,
+        max_segment_count.saturating_sub(local_segment_count),
     )
-    .await?;
+    .await?
+    else {
+        return Ok(None);
+    };
     for member in &mut members {
         member.value.commit_id = commit_id;
         member.authored = false;
         member.selected_tombstone = member.value.deleted;
     }
-    members.append(&mut local);
-    members.sort_unstable_by(|left, right| left.key.cmp(&right.key));
-    if members.windows(2).any(|pair| pair[0].key == pair[1].key) {
-        return Err(LixError::new(
-            LixError::CODE_INTERNAL_ERROR,
-            format!("selected-source commit delta '{commit_id}' has overlapping local rows"),
+    Ok(Some(merge_selected_source_members(members, local)))
+}
+
+async fn load_authenticated_local_commit_delta_members_for_schemas(
+    store: &(impl StorageAdapterRead + ?Sized),
+    state: &AuthenticatedReplayCommitStateManifest,
+    schema_keys: &[String],
+    max_segment_count: usize,
+) -> Result<Option<(Vec<CommitDeltaMember>, usize)>, LixError> {
+    let Some(root) = state.mutation_directory_root.as_ref() else {
+        let manifest = commit_delta_manifest_from_commit_state(state);
+        let segment_count = usize::from(manifest.inline_segment().is_some());
+        if segment_count > max_segment_count {
+            return Ok(None);
+        }
+        return Ok(Some((
+            load_commit_delta_members_from_manifest(store, state.commit_id, &manifest, schema_keys)
+                .await?,
+            segment_count,
+        )));
+    };
+    if root.layout == super::mutation_directory::LAYOUT_BOUNDED_DIRECT
+        || root.layout == super::mutation_directory::LAYOUT_BOUNDED_INDIRECT
+    {
+        return load_bounded_commit_delta_members_for_schemas(
+            store,
+            state,
+            schema_keys,
+            max_segment_count,
+        )
+        .await;
+    }
+    if root.layout == super::mutation_directory::LAYOUT_DIRECT_ROWS_ONLY {
+        let manifest = commit_delta_manifest_from_commit_state(state);
+        return Ok(Some((
+            load_commit_delta_members_from_manifest(store, state.commit_id, &manifest, schema_keys)
+                .await?,
+            0,
+        )));
+    }
+    if root.layout != super::mutation_directory::LAYOUT_COMPACT_REPLACEMENT {
+        return Err(replacement_payload_error(
+            "payload scan encountered an unsupported mutation-directory layout",
         ));
     }
-    Ok(Some(members))
+    let runs = super::mutation_directory::load_mutation_part_read_plan(
+        store,
+        root,
+        super::mutation_directory::MutationDirectoryReadSelection::All,
+    )
+    .await?
+    .into_runs();
+    if runs.len() > max_segment_count {
+        return Ok(None);
+    }
+    let segment_count = runs.len();
+    let mut expanded_state = state.manifest.clone();
+    for run in runs {
+        let super::mutation_directory::MutationDirectoryEntry::CompactReplacement {
+            content_digest,
+            direct_row_count,
+        } = run.entry
+        else {
+            return Err(replacement_payload_error(
+                "compact replacement directory contains a non-compact entry",
+            ));
+        };
+        expanded_state
+            .mutations
+            .replacement_part_digests
+            .push(content_digest);
+        expanded_state
+            .mutations
+            .direct_part_row_counts
+            .push(direct_row_count);
+    }
+    let manifest = expanded_commit_delta_manifest_from_commit_state(store, &expanded_state).await?;
+    validate_commit_delta_manifest(&manifest)?;
+    Ok(Some((
+        load_commit_delta_members_from_manifest(store, state.commit_id, &manifest, schema_keys)
+            .await?,
+        segment_count,
+    )))
+}
+
+async fn load_bounded_commit_delta_members_for_schemas(
+    store: &(impl StorageAdapterRead + ?Sized),
+    state: &AuthenticatedReplayCommitStateManifest,
+    schema_keys: &[String],
+    max_segment_count: usize,
+) -> Result<Option<(Vec<CommitDeltaMember>, usize)>, LixError> {
+    let root = state.mutation_directory_root.as_ref().ok_or_else(|| {
+        replacement_payload_error("bounded payload scan omitted its mutation-directory root")
+    })?;
+    let requested_schemas = schema_keys
+        .iter()
+        .map(String::as_str)
+        .collect::<BTreeSet<_>>();
+    let ranges = requested_schemas
+        .iter()
+        .map(|schema_key| {
+            let start = encode_schema_key_prefix(schema_key);
+            super::mutation_directory::MutationDirectoryKeyRange {
+                end: prefix_successor(&start).map(Bytes::from),
+                start: Bytes::from(start),
+            }
+        })
+        .collect::<Vec<_>>();
+    let runs = super::mutation_directory::load_mutation_part_read_plan(
+        store,
+        root,
+        if ranges.is_empty() {
+            super::mutation_directory::MutationDirectoryReadSelection::All
+        } else {
+            super::mutation_directory::MutationDirectoryReadSelection::SortedRanges(&ranges)
+        },
+    )
+    .await?
+    .into_runs();
+    if runs.len() > max_segment_count {
+        return Ok(None);
+    }
+    let segment_count = runs.len();
+    let storage_keys = runs
+        .iter()
+        .map(|run| {
+            let super::mutation_directory::MutationDirectoryEntry::Bounded { part, .. } =
+                &run.entry
+            else {
+                return Err(replacement_payload_error(
+                    "bounded payload scan selected a non-bounded part",
+                ));
+            };
+            commit_delta_segment_key_for_part(
+                state.commit_id,
+                usize::try_from(run.entry_index)
+                    .map_err(|_| replacement_payload_error("part index exceeds usize"))?,
+                part,
+            )
+            .map(|key| StorageKey(Bytes::from(key)))
+        })
+        .collect::<Result<Vec<_>, LixError>>()?;
+    let segments =
+        PointReadPlan::from_unique_keys(TRACKED_STATE_COMMIT_DELTA_SEGMENT_SPACE, storage_keys)
+            .materialize(store, StorageGetOptions::default())
+            .await?;
+    let mut members = Vec::new();
+    for (run, value) in runs.into_iter().zip(segments.value) {
+        let bytes = value.and_then(full_value_bytes).ok_or_else(|| {
+            replacement_payload_error("bounded payload scan references a missing immutable part")
+        })?;
+        let super::mutation_directory::MutationDirectoryEntry::Bounded {
+            part,
+            direct_row_count,
+        } = run.entry
+        else {
+            return Err(replacement_payload_error(
+                "bounded payload scan selected a non-bounded part",
+            ));
+        };
+        let bounds = CommitDeltaSegmentBounds {
+            first_key: part.first_key,
+            last_key: part.last_key,
+            replacement_part: part.replacement_part,
+        };
+        let before = members.len();
+        collect_strict_commit_delta_members(
+            &bytes,
+            Some(&bounds),
+            state.commit_id,
+            run.entry_index,
+            &state.change_account_id,
+            &mut members,
+        )?;
+        validate_bounded_direct_row_count(root.layout, direct_row_count, members.len() - before)?;
+    }
+    if !requested_schemas.is_empty() {
+        members.retain(|member| requested_schemas.contains(member.key.schema_key.as_str()));
+    }
+    hydrate_selected_members(store, &mut members).await?;
+    validate_commit_delta_member_order_and_ids(state.commit_id, &members)?;
+    Ok(Some((members, segment_count)))
+}
+
+fn merge_selected_source_members(
+    source: Vec<CommitDeltaMember>,
+    local: Vec<CommitDeltaMember>,
+) -> Vec<CommitDeltaMember> {
+    let mut source = source.into_iter().peekable();
+    let mut local = local.into_iter().peekable();
+    let mut merged = Vec::with_capacity(source.len().saturating_add(local.len()));
+    loop {
+        match (source.peek(), local.peek()) {
+            (Some(source_member), Some(local_member)) => {
+                match source_member.key.cmp(&local_member.key) {
+                    std::cmp::Ordering::Less => {
+                        merged.push(source.next().expect("peeked source member"));
+                    }
+                    std::cmp::Ordering::Greater => {
+                        merged.push(local.next().expect("peeked local member"));
+                    }
+                    std::cmp::Ordering::Equal => {
+                        source.next();
+                        merged.push(local.next().expect("peeked local member"));
+                    }
+                }
+            }
+            (Some(_), None) => {
+                merged.extend(source);
+                break;
+            }
+            (None, Some(_)) => {
+                merged.extend(local);
+                break;
+            }
+            (None, None) => break,
+        }
+    }
+    merged
 }
 
 async fn load_commit_delta_members_from_manifest(
@@ -6895,30 +7667,17 @@ pub(crate) async fn load_commit_delta_change_ids(
 
 /// Loads exact tracked-state entries from their known physical commit owners.
 ///
-/// All owner manifests are read in one point batch and all routed segments in
-/// a second. Each selected segment is decoded once for both its index values
-/// and payload sidecar, preserving request order without topology replay.
+/// Arbitrary caller order is canonicalized once per physical owner. Bounded
+/// authorities retain point routing for negative lookups; selected-source
+/// misses are resolved from the authenticated source without flattening
+/// either directory.
 pub(crate) async fn load_owned_commit_delta_entries(
     store: &(impl StorageAdapterRead + ?Sized),
     requests: &[(CommitId, TrackedStateKey)],
 ) -> Result<Vec<Option<LoadedCommitDeltaEntry>>, LixError> {
-    let mut output = load_local_owned_commit_delta_entries(store, requests).await?;
-    let owner_commit_ids = requests
-        .iter()
-        .enumerate()
-        .filter_map(|(request_index, (commit_id, _))| {
-            output[request_index].is_none().then_some(*commit_id)
-        })
-        .collect::<BTreeSet<_>>();
-    let owner_commit_ids = owner_commit_ids.into_iter().collect::<Vec<_>>();
-    let manifest_values = load_commit_delta_manifests(store, &owner_commit_ids).await?;
-    let mut owner_manifests = BTreeMap::new();
-    for (commit_id, manifest) in owner_commit_ids.into_iter().zip(manifest_values) {
-        let Some(manifest) = manifest else {
-            continue;
-        };
-        owner_manifests.insert(commit_id, manifest);
-    }
+    let point_cache = CommitDeltaPointReadCache::default();
+    let mut output =
+        load_local_owned_commit_delta_entries(store, requests, Some(&point_cache)).await?;
     let mut source_requests = Vec::new();
     let mut source_outputs = Vec::new();
     let mut source_owner_commits = Vec::new();
@@ -6926,17 +7685,34 @@ pub(crate) async fn load_owned_commit_delta_entries(
         if output[request_index].is_some() {
             continue;
         }
-        let Some(manifest) = owner_manifests.get(commit_id) else {
+        let Some(state) = point_cache.authority(*commit_id)? else {
             continue;
         };
-        let Some(source_commit_id) = manifest.selected_source_commit_id() else {
+        let Some(source_commit_id) = state.mutations.selected_source_commit_id() else {
             continue;
         };
         source_outputs.push(request_index);
         source_owner_commits.push(*commit_id);
         source_requests.push((source_commit_id, key.clone()));
     }
-    let selected = load_local_owned_commit_delta_entries(store, &source_requests).await?;
+    let selected =
+        load_local_owned_commit_delta_entries(store, &source_requests, Some(&point_cache)).await?;
+    for source_commit_id in source_requests
+        .iter()
+        .map(|(source_commit_id, _)| *source_commit_id)
+        .collect::<BTreeSet<_>>()
+    {
+        let source = point_cache.authority(source_commit_id)?.ok_or_else(|| {
+            replacement_payload_error(
+                "selected-source mutation authority references a missing source",
+            )
+        })?;
+        if source.mutations.selected_source_commit_id().is_some() {
+            return Err(replacement_payload_error(
+                "selected-source mutation authority cannot alias another source",
+            ));
+        }
+    }
     for ((request_index, owner_commit_id), entry) in source_outputs
         .into_iter()
         .zip(source_owner_commits)
@@ -6953,8 +7729,9 @@ pub(crate) async fn load_owned_commit_delta_entries(
 
 /// Loads one ordered exact-key batch without first owning a second copy of
 /// every identity. Dense current-state reads have this shape and normally
-/// resolve every key from the physical owner; unusual selected-source or
-/// missing-key cases fall back to the general loader.
+/// resolve every key from the physical owner. A local negative is final unless
+/// the same authenticated authority names a selected source; only that case
+/// enters the source-overlay loader.
 pub(crate) async fn load_owned_commit_delta_entries_one_ordered_ref(
     store: &(impl StorageAdapterRead + ?Sized),
     commit_id: CommitId,
@@ -6968,11 +7745,21 @@ pub(crate) async fn load_owned_commit_delta_entries_one_ordered_ref(
         (pair[0].schema_key, pair[0].file_id, pair[0].entity_pk)
             < (pair[1].schema_key, pair[1].file_id, pair[1].entity_pk)
     });
+    let local_cache = CommitDeltaPointReadCache::default();
+    let point_cache = point_cache.unwrap_or(&local_cache);
     if strictly_ordered {
-        let output =
-            load_local_owned_commit_delta_entries_one_ordered(store, commit_id, keys, point_cache)
-                .await?;
-        if output.iter().all(Option::is_some) {
+        let output = load_local_owned_commit_delta_entries_one_ordered(
+            store,
+            commit_id,
+            keys,
+            Some(point_cache),
+        )
+        .await?;
+        if output.iter().all(Option::is_some)
+            || point_cache
+                .authority(commit_id)?
+                .is_none_or(|state| state.mutations.selected_source_commit_id().is_none())
+        {
             return Ok(output);
         }
     }
@@ -6997,6 +7784,7 @@ pub(crate) async fn load_owned_commit_delta_entries_one_ordered_ref(
 async fn load_local_owned_commit_delta_entries(
     store: &(impl StorageAdapterRead + ?Sized),
     requests: &[(CommitId, TrackedStateKey)],
+    point_cache: Option<&CommitDeltaPointReadCache>,
 ) -> Result<Vec<Option<LoadedCommitDeltaEntry>>, LixError> {
     if requests.is_empty() {
         return Ok(Vec::new());
@@ -7017,7 +7805,7 @@ async fn load_local_owned_commit_delta_entries(
             store,
             requests[0].0,
             &keys,
-            None,
+            point_cache,
         ))
         .await;
     }
@@ -7030,140 +7818,46 @@ async fn load_local_owned_commit_delta_entries(
             .push(request_index);
     }
 
-    let commit_ids = request_indices_by_commit
-        .keys()
-        .copied()
-        .collect::<Vec<_>>();
-    let manifest_values = load_commit_delta_manifests(store, &commit_ids).await?;
-
     let mut output = (0..requests.len()).map(|_| None).collect::<Vec<_>>();
-    let mut segmented_manifests = BTreeMap::<CommitId, CommitDeltaManifest>::new();
-    let mut lookups_by_segment = BTreeMap::<(CommitId, usize), Vec<(usize, Vec<u8>)>>::new();
-
-    for (commit_id, manifest) in commit_ids.into_iter().zip(manifest_values) {
-        let Some(manifest) = manifest else {
-            continue;
-        };
-        let request_indices = request_indices_by_commit
-            .get(&commit_id)
-            .expect("manifest commit came from the requested commit set");
-        if let Some(parts) = manifest.columnar_parts.as_ref() {
-            let keys = request_indices
-                .iter()
-                .map(|&request_index| {
-                    let key = &requests[request_index].1;
-                    TrackedStateKeyRef {
-                        schema_key: &key.schema_key,
-                        file_id: key.file_id.as_deref(),
-                        entity_pk: &key.entity_pk,
-                    }
-                })
-                .collect::<Vec<_>>();
-            for (&request_index, entry) in request_indices.iter().zip(
-                Box::pin(load_columnar_owned_entries(
-                    store,
-                    commit_id,
-                    &keys,
-                    parts,
-                    &manifest.account_id,
-                ))
-                .await?,
-            ) {
-                output[request_index] = entry;
-            }
-            continue;
+    for (commit_id, mut request_indices) in request_indices_by_commit {
+        request_indices.sort_unstable_by(|&left, &right| requests[left].1.cmp(&requests[right].1));
+        let mut unique_request_indices = Vec::<usize>::with_capacity(request_indices.len());
+        let mut output_routes = Vec::with_capacity(request_indices.len());
+        for request_index in request_indices {
+            let unique_index = if unique_request_indices
+                .last()
+                .is_some_and(|&previous_index| {
+                    requests[previous_index].1 == requests[request_index].1
+                }) {
+                unique_request_indices.len() - 1
+            } else {
+                unique_request_indices.push(request_index);
+                unique_request_indices.len() - 1
+            };
+            output_routes.push((request_index, unique_index));
         }
-        if let Some(inline_segment) = manifest.inline_segment() {
-            let (leaf, payloads) = decode_commit_delta_with_payloads(inline_segment, None)?;
-            for &request_index in request_indices {
-                let encoded_key = encoded_commit_delta_lookup_key(&requests[request_index].1);
-                output[request_index] = find_loaded_commit_delta_entry(
-                    &leaf,
-                    &payloads,
-                    &encoded_key,
-                    commit_id,
-                    &manifest.account_id,
-                )?;
-            }
-            continue;
-        }
-
-        for &request_index in request_indices {
-            let encoded_key = encoded_commit_delta_lookup_key(&requests[request_index].1);
-            if let Some(segment_index) = commit_delta_segment_for_key(&manifest, &encoded_key) {
-                lookups_by_segment
-                    .entry((commit_id, segment_index))
-                    .or_default()
-                    .push((request_index, encoded_key));
-            }
-        }
-        segmented_manifests.insert(commit_id, manifest);
-    }
-
-    if lookups_by_segment.is_empty() {
-        hydrate_selected_loaded_entries(store, &mut output).await?;
-        return Ok(output);
-    }
-
-    let segment_routes = lookups_by_segment.keys().copied().collect::<Vec<_>>();
-    let segment_keys = segment_routes
-        .iter()
-        .map(|&(commit_id, segment_index)| {
-            commit_delta_segment_key_for_bounds(
-                commit_id,
-                segment_index,
-                &segmented_manifests[&commit_id].segments[segment_index],
-            )
-            .map(|key| StorageKey(Bytes::from(key)))
-        })
-        .collect::<Result<Vec<_>, _>>()?;
-    let segment_values =
-        PointReadPlan::new(TRACKED_STATE_COMMIT_DELTA_SEGMENT_SPACE, &segment_keys)
-            .materialize(store, StorageGetOptions::default())
-            .await?;
-
-    for ((commit_id, segment_index), segment_value) in
-        segment_routes.into_iter().zip(segment_values.value)
-    {
-        let bytes = segment_value.and_then(full_value_bytes).ok_or_else(|| {
-            LixError::new(
-                LixError::CODE_INTERNAL_ERROR,
-                format!(
-                    "tracked_state commit_delta manifest for commit '{commit_id}' references missing segment {segment_index}"
-                ),
-            )
-        })?;
-        let manifest = segmented_manifests.get(&commit_id).ok_or_else(|| {
-            LixError::new(
-                LixError::CODE_INTERNAL_ERROR,
-                format!(
-                    "tracked_state commit_delta lost the manifest for routed commit '{commit_id}'"
-                ),
-            )
-        })?;
-        let bounds = manifest.segments.get(segment_index).ok_or_else(|| {
-            LixError::new(
-                LixError::CODE_INTERNAL_ERROR,
-                format!(
-                    "tracked_state commit_delta manifest for commit '{commit_id}' has no segment {segment_index}"
-                ),
-            )
-        })?;
-        let (leaf, payloads) = decode_commit_delta_with_payloads(&bytes, Some(bounds))?;
-        let lookups = lookups_by_segment
-            .remove(&(commit_id, segment_index))
-            .expect("read segment came from the routed lookup set");
-        for (request_index, encoded_key) in lookups {
-            output[request_index] = find_loaded_commit_delta_entry(
-                &leaf,
-                &payloads,
-                &encoded_key,
-                commit_id,
-                &manifest.account_id,
-            )?;
+        let keys = unique_request_indices
+            .iter()
+            .map(|&request_index| {
+                let key = &requests[request_index].1;
+                TrackedStateKeyRef {
+                    schema_key: &key.schema_key,
+                    file_id: key.file_id.as_deref(),
+                    entity_pk: &key.entity_pk,
+                }
+            })
+            .collect::<Vec<_>>();
+        let unique = Box::pin(load_local_owned_commit_delta_entries_one_ordered(
+            store,
+            commit_id,
+            &keys,
+            point_cache,
+        ))
+        .await?;
+        for (request_index, unique_index) in output_routes {
+            output[request_index] = unique[unique_index].clone();
         }
     }
-    hydrate_selected_loaded_entries(store, &mut output).await?;
     Ok(output)
 }
 
@@ -7176,76 +7870,75 @@ async fn load_inventory_part_entries_one_ordered(
     let root = state.mutation_directory_root.as_ref().ok_or_else(|| {
         replacement_payload_error("ordered mutation inventory omitted its directory root")
     })?;
-    let mut encoded_keys = Vec::new();
-    let ranges = keys
-        .iter()
-        .map(|&key| encode_key_ref_into(&mut encoded_keys, key))
-        .collect::<Vec<_>>();
-    let key_bytes = ranges
-        .iter()
-        .map(|range| &encoded_keys[range.clone()])
-        .collect::<Vec<_>>();
-    let routes =
-        super::mutation_directory::route_mutation_directory_points(store, root, &key_bytes).await?;
-    let mut grouped = BTreeMap::<u32, (CommitStateMutationPart, Vec<(usize, Range<usize>)>)>::new();
-    for (output_index, (encoded, route)) in ranges.into_iter().zip(routes).enumerate() {
-        let Some(route) = route else {
-            continue;
-        };
-        match grouped.entry(route.entry_index) {
-            std::collections::btree_map::Entry::Vacant(entry) => {
-                entry.insert((route.part, vec![(output_index, encoded)]));
-            }
-            std::collections::btree_map::Entry::Occupied(mut entry) => {
-                if entry.get().0 != route.part {
-                    return Err(replacement_payload_error(
-                        "mutation directory returned conflicting routes for one part",
-                    ));
-                }
-                entry.get_mut().1.push((output_index, encoded));
-            }
-        }
+    let mut encoded_keys = TrackedStateKeyBatchBuilder::with_row_capacity(keys.len());
+    for &key in keys {
+        encoded_keys.push(key);
     }
-    let storage_keys = grouped
+    let encoded_keys = encoded_keys.finish();
+    let runs = super::mutation_directory::load_mutation_part_read_plan(
+        store,
+        root,
+        super::mutation_directory::MutationDirectoryReadSelection::SortedUniquePoints(
+            &encoded_keys,
+        ),
+    )
+    .await?
+    .into_runs();
+    let storage_keys = runs
         .iter()
-        .map(|(&part_index, (bounds, _))| {
-            commit_delta_segment_key_for_bounds(
+        .map(|run| {
+            let super::mutation_directory::MutationDirectoryEntry::Bounded { part, .. } =
+                &run.entry
+            else {
+                return Err(replacement_payload_error(
+                    "ordered mutation inventory selected a non-bounded part",
+                ));
+            };
+            commit_delta_segment_key_for_part(
                 commit_id,
-                usize::try_from(part_index)
+                usize::try_from(run.entry_index)
                     .map_err(|_| replacement_payload_error("part index exceeds usize"))?,
-                &CommitDeltaSegmentBounds {
-                    first_key: bounds.first_key.clone(),
-                    last_key: bounds.last_key.clone(),
-                    replacement_part: bounds.replacement_part.clone(),
-                },
+                part,
             )
             .map(|key| StorageKey(Bytes::from(key)))
         })
         .collect::<Result<Vec<_>, LixError>>()?;
-    let loaded = PointReadPlan::new(TRACKED_STATE_COMMIT_DELTA_SEGMENT_SPACE, &storage_keys)
-        .materialize(store, StorageGetOptions::default())
-        .await?;
+    let loaded =
+        PointReadPlan::from_unique_keys(TRACKED_STATE_COMMIT_DELTA_SEGMENT_SPACE, storage_keys)
+            .materialize(store, StorageGetOptions::default())
+            .await?;
     let mut output = (0..keys.len()).map(|_| None).collect::<Vec<_>>();
-    for ((_, (part, requests)), value) in grouped.into_iter().zip(loaded.value) {
+    for (run, value) in runs.into_iter().zip(loaded.value) {
         let bytes = value.and_then(full_value_bytes).ok_or_else(|| {
             replacement_payload_error("mutation inventory references a missing immutable part")
         })?;
+        let super::mutation_directory::MutationDirectoryEntry::Bounded {
+            part,
+            direct_row_count,
+        } = run.entry
+        else {
+            return Err(replacement_payload_error(
+                "ordered mutation inventory selected a non-bounded part",
+            ));
+        };
         let bounds = CommitDeltaSegmentBounds {
-            first_key: part.first_key.clone(),
-            last_key: part.last_key.clone(),
-            replacement_part: part.replacement_part.clone(),
+            first_key: part.first_key,
+            last_key: part.last_key,
+            replacement_part: part.replacement_part,
         };
         let (leaf, payloads) = decode_commit_delta_with_payloads(&bytes, Some(&bounds))?;
-        for (output_index, encoded) in requests {
+        validate_bounded_direct_row_count(root.layout, direct_row_count, leaf.len())?;
+        for output_index in run.selector_span {
             output[output_index] = find_loaded_commit_delta_entry(
                 &leaf,
                 &payloads,
-                &encoded_keys[encoded],
+                &encoded_keys[output_index],
                 commit_id,
                 &state.change_account_id,
             )?;
         }
     }
+    hydrate_selected_loaded_entries(store, &mut output).await?;
     Ok(output)
 }
 
@@ -7260,6 +7953,31 @@ async fn load_local_owned_commit_delta_entries_one_ordered(
     keys: &[TrackedStateKeyRef<'_>],
     point_cache: Option<&CommitDeltaPointReadCache>,
 ) -> Result<Vec<Option<LoadedCommitDeltaEntry>>, LixError> {
+    let cached_state = point_cache
+        .map(|cache| cache.authority(commit_id))
+        .transpose()?
+        .flatten();
+    let state = match cached_state {
+        Some(state) => state,
+        None => {
+            let Some(state) = load_point_replay_commit_state(store, commit_id).await? else {
+                return Ok((0..keys.len()).map(|_| None).collect());
+            };
+            let state = Arc::new(state);
+            if let Some(point_cache) = point_cache {
+                point_cache.remember_authority(Arc::clone(&state))?;
+            }
+            state
+        }
+    };
+    if state.mutations.inline_part.is_empty()
+        && state.mutation_directory_root.as_ref().is_some_and(|root| {
+            root.layout == super::mutation_directory::LAYOUT_BOUNDED_DIRECT
+                || root.layout == super::mutation_directory::LAYOUT_BOUNDED_INDIRECT
+        })
+    {
+        return load_inventory_part_entries_one_ordered(store, commit_id, keys, &state).await;
+    }
     let manifest = match point_cache
         .map(|cache| cache.manifest(commit_id))
         .transpose()?
@@ -7267,19 +7985,6 @@ async fn load_local_owned_commit_delta_entries_one_ordered(
     {
         Some(manifest) => PointReadCommitDeltaManifest::Cached(manifest),
         None => {
-            let Some(state) = load_point_replay_commit_state(store, commit_id).await? else {
-                return Ok((0..keys.len()).map(|_| None).collect());
-            };
-            if state.mutations.selected_source_commit_id.is_none()
-                && state.mutations.inline_part.is_empty()
-                && state.mutation_directory_root.as_ref().is_some_and(|root| {
-                    root.layout == super::mutation_directory::LAYOUT_BOUNDED_DIRECT
-                })
-            {
-                let output =
-                    load_inventory_part_entries_one_ordered(store, commit_id, keys, &state).await?;
-                return Ok(output);
-            }
             let full_state = if state.mutation_directory_root.is_some() {
                 load_commit_state_manifest(store, commit_id)
                     .await?
@@ -7697,55 +8402,82 @@ pub(crate) async fn scan_commit_delta_values(
     commit_id: CommitId,
     schema_keys: &[String],
 ) -> Result<DecodedCommitDeltaBatch, LixError> {
-    Box::pin(scan_commit_delta_values_with_cache(
-        store,
-        commit_id,
-        schema_keys,
-        None,
-    ))
-    .await
-}
-
-pub(crate) async fn scan_commit_delta_values_with_cache(
-    store: &(impl StorageAdapterRead + ?Sized),
-    commit_id: CommitId,
-    schema_keys: &[String],
-    _point_cache: Option<&CommitDeltaPointReadCache>,
-) -> Result<DecodedCommitDeltaBatch, LixError> {
     let Some(state) = load_point_replay_commit_state(store, commit_id).await? else {
         return Ok(DecodedCommitDeltaBatch::default());
     };
-    let Some(source_commit_id) = state.mutations.selected_source_commit_id() else {
-        return Box::pin(scan_authenticated_local_commit_delta_values(
-            store,
-            &state,
-            schema_keys,
-        ))
-        .await;
+    let source = match state.mutations.selected_source_commit_id() {
+        Some(source_commit_id) => Some(
+            load_point_replay_commit_state(store, source_commit_id)
+                .await?
+                .ok_or_else(|| {
+                    replacement_payload_error(&format!(
+                        "selected-source commit '{}' references missing authority '{source_commit_id}'",
+                        state.commit_id
+                    ))
+                })?,
+        ),
+        None => None,
     };
-    let source = match load_point_replay_commit_state(store, source_commit_id).await? {
-        Some(source_state) => {
-            if source_state.mutations.selected_source_commit_id.is_some() {
-                return Err(replacement_payload_error(
-                    "selected-source mutation authority cannot alias another source",
-                ));
-            }
-            Box::pin(scan_authenticated_local_commit_delta_values(
+    scan_commit_delta_values_from_authenticated_states(store, &state, source.as_ref(), schema_keys)
+        .await
+}
+
+/// Scans from immutable authority already authenticated in this reader
+/// snapshot. Directory nodes and parts remain content- and bound-checked by
+/// the local scan; this only avoids reloading the same header and inventory.
+pub(crate) async fn scan_commit_delta_values_from_authenticated_states(
+    store: &(impl StorageAdapterRead + ?Sized),
+    state: &AuthenticatedReplayCommitStateManifest,
+    source: Option<&AuthenticatedReplayCommitStateManifest>,
+    schema_keys: &[String],
+) -> Result<DecodedCommitDeltaBatch, LixError> {
+    let selected_source_commit_id = state.mutations.selected_source_commit_id();
+    match (selected_source_commit_id, source) {
+        (None, None) => {
+            return Box::pin(scan_authenticated_local_commit_delta_values(
                 store,
-                &source_state,
+                state,
                 schema_keys,
             ))
-            .await?
+            .await;
         }
-        None => DecodedCommitDeltaBatch::default(),
-    };
-    let local = Box::pin(scan_authenticated_local_commit_delta_values(
+        (None, Some(_)) => {
+            return Err(replacement_payload_error(
+                "authenticated scan received a source for a local-only authority",
+            ));
+        }
+        (Some(source_commit_id), None) => {
+            return Err(replacement_payload_error(&format!(
+                "selected-source commit '{}' references missing authority '{source_commit_id}'",
+                state.commit_id
+            )));
+        }
+        (Some(source_commit_id), Some(source)) if source.commit_id != source_commit_id => {
+            return Err(replacement_payload_error(&format!(
+                "selected-source commit '{}' expected authority '{source_commit_id}' but received '{}'",
+                state.commit_id, source.commit_id
+            )));
+        }
+        (Some(_), Some(source)) if source.mutations.selected_source_commit_id().is_some() => {
+            return Err(replacement_payload_error(
+                "selected-source mutation authority cannot alias another source",
+            ));
+        }
+        (Some(_), Some(_)) => {}
+    }
+    let source = Box::pin(scan_authenticated_local_commit_delta_values(
         store,
-        &state,
+        source.expect("validated selected source"),
         schema_keys,
     ))
     .await?;
-    merge_selected_source_batches(source, local, commit_id)
+    let local = Box::pin(scan_authenticated_local_commit_delta_values(
+        store,
+        state,
+        schema_keys,
+    ))
+    .await?;
+    merge_selected_source_batches(source, local, state.commit_id)
 }
 
 async fn scan_authenticated_local_commit_delta_values(
@@ -7787,13 +8519,19 @@ async fn scan_authenticated_local_commit_delta_values(
     // Compact replacement parts have ordinal identities rather than key
     // bounds, so a schema scan must authenticate their complete digest list.
     // This is a layout-specific traversal, not a general manifest expansion.
-    let entries = super::mutation_directory::load_mutation_directory(store, root).await?;
+    let entries = super::mutation_directory::load_mutation_part_read_plan(
+        store,
+        root,
+        super::mutation_directory::MutationDirectoryReadSelection::All,
+    )
+    .await?
+    .into_runs();
     let mut expanded_state = state.manifest.clone();
-    for entry in entries {
+    for run in entries {
         let super::mutation_directory::MutationDirectoryEntry::CompactReplacement {
             content_digest,
             direct_row_count,
-        } = entry
+        } = run.entry
         else {
             return Err(replacement_payload_error(
                 "compact replacement directory contains a bounded entry",
@@ -7827,61 +8565,84 @@ async fn scan_bounded_commit_delta_values(
     let root = state.mutation_directory_root.as_ref().ok_or_else(|| {
         replacement_payload_error("bounded mutation scan omitted its directory root")
     })?;
-    let encoded_ranges = schema_keys
-        .iter()
-        .map(|schema_key| {
-            let start = encode_schema_key_prefix(schema_key);
-            let end = prefix_successor(&start);
-            (start, end)
-        })
-        .collect::<Vec<_>>();
-    let ranges = encoded_ranges
-        .iter()
-        .map(|(start, end)| (start.as_slice(), end.as_deref()))
-        .collect::<Vec<_>>();
-    let routes =
-        super::mutation_directory::load_bounded_mutation_directory_ranges(store, root, &ranges)
-            .await?;
-    if routes.is_empty() {
-        return Ok(DecodedCommitDeltaBatch::default());
-    }
-    let storage_keys = routes
-        .iter()
-        .map(|route| {
-            commit_delta_segment_key_for_bounds(
-                state.commit_id,
-                usize::try_from(route.entry_index)
-                    .map_err(|_| replacement_payload_error("part index exceeds usize"))?,
-                &CommitDeltaSegmentBounds {
-                    first_key: route.part.first_key.clone(),
-                    last_key: route.part.last_key.clone(),
-                    replacement_part: route.part.replacement_part.clone(),
-                },
-            )
-            .map(|key| StorageKey(Bytes::from(key)))
-        })
-        .collect::<Result<Vec<_>, LixError>>()?;
-    let segments = PointReadPlan::new(TRACKED_STATE_COMMIT_DELTA_SEGMENT_SPACE, &storage_keys)
-        .materialize(store, StorageGetOptions::default())
-        .await?;
+    // This API is the canonicalization boundary above the strict directory
+    // router. The router never sorts or deduplicates selectors defensively.
     let requested_schemas = schema_keys
         .iter()
         .map(String::as_str)
         .collect::<BTreeSet<_>>();
+    let ranges = requested_schemas
+        .iter()
+        .map(|schema_key| {
+            let start = encode_schema_key_prefix(schema_key);
+            let end = prefix_successor(&start);
+            super::mutation_directory::MutationDirectoryKeyRange {
+                start: Bytes::from(start),
+                end: end.map(Bytes::from),
+            }
+        })
+        .collect::<Vec<_>>();
+    let runs = super::mutation_directory::load_mutation_part_read_plan(
+        store,
+        root,
+        if ranges.is_empty() {
+            super::mutation_directory::MutationDirectoryReadSelection::All
+        } else {
+            super::mutation_directory::MutationDirectoryReadSelection::SortedRanges(&ranges)
+        },
+    )
+    .await?
+    .into_runs();
+    if runs.is_empty() {
+        return Ok(DecodedCommitDeltaBatch::default());
+    }
+    let storage_keys = runs
+        .iter()
+        .map(|run| {
+            let super::mutation_directory::MutationDirectoryEntry::Bounded { part, .. } =
+                &run.entry
+            else {
+                return Err(replacement_payload_error(
+                    "bounded mutation scan selected a non-bounded part",
+                ));
+            };
+            commit_delta_segment_key_for_part(
+                state.commit_id,
+                usize::try_from(run.entry_index)
+                    .map_err(|_| replacement_payload_error("part index exceeds usize"))?,
+                part,
+            )
+            .map(|key| StorageKey(Bytes::from(key)))
+        })
+        .collect::<Result<Vec<_>, LixError>>()?;
+    let segments =
+        PointReadPlan::from_unique_keys(TRACKED_STATE_COMMIT_DELTA_SEGMENT_SPACE, storage_keys)
+            .materialize(store, StorageGetOptions::default())
+            .await?;
     let mut batch = DecodedCommitDeltaBatchBuilder::with_capacity(
-        routes.len().saturating_mul(COMMIT_DELTA_SEGMENT_MAX_ROWS),
-        routes.len(),
+        runs.len().saturating_mul(COMMIT_DELTA_SEGMENT_MAX_ROWS),
+        runs.len(),
     );
-    for (route, value) in routes.into_iter().zip(segments.value) {
+    for (run, value) in runs.into_iter().zip(segments.value) {
         let bytes = value.and_then(full_value_bytes).ok_or_else(|| {
             replacement_payload_error("bounded mutation scan references a missing immutable part")
         })?;
+        let super::mutation_directory::MutationDirectoryEntry::Bounded {
+            part,
+            direct_row_count,
+        } = run.entry
+        else {
+            return Err(replacement_payload_error(
+                "bounded mutation scan selected a non-bounded part",
+            ));
+        };
         let bounds = CommitDeltaSegmentBounds {
-            first_key: route.part.first_key,
-            last_key: route.part.last_key,
-            replacement_part: route.part.replacement_part,
+            first_key: part.first_key,
+            last_key: part.last_key,
+            replacement_part: part.replacement_part,
         };
         let leaf = decode_commit_delta_leaf(&bytes, Some(&bounds))?;
+        validate_bounded_direct_row_count(root.layout, direct_row_count, leaf.len())?;
         batch.push_leaf(leaf, state.commit_id, &requested_schemas)?;
     }
     Ok(batch.finish())
@@ -8145,45 +8906,12 @@ pub(crate) async fn commit_delta_contains_schema(
     commit_id: CommitId,
     schema_key: &str,
 ) -> Result<bool, LixError> {
-    let Some(manifest) = load_commit_delta_manifest(store, commit_id).await? else {
-        return Ok(false);
-    };
-    if local_commit_delta_contains_schema(store, commit_id, schema_key).await? {
-        return Ok(true);
-    }
-    let Some(source_commit_id) = manifest.selected_source_commit_id() else {
-        return Ok(false);
-    };
-    local_commit_delta_contains_schema(store, source_commit_id, schema_key).await
-}
-
-async fn local_commit_delta_contains_schema(
-    store: &(impl StorageAdapterRead + ?Sized),
-    commit_id: CommitId,
-    schema_key: &str,
-) -> Result<bool, LixError> {
-    let Some(manifest) = load_commit_delta_manifest(store, commit_id).await? else {
-        return Ok(false);
-    };
-    if let Some(parts) = manifest.columnar_parts.as_ref() {
-        return Ok(parts.schema_key == schema_key);
-    }
-    if let Some(inline_segment) = manifest.inline_segment() {
-        let leaf = decode_commit_delta_leaf(inline_segment, None)?;
-        let mut found = false;
-        visit_commit_delta_leaf(&leaf, commit_id, |entry_index, _, _| {
-            let key = decode_key_shared(
-                leaf.entry_owned(entry_index)
-                    .expect("visited commit-delta leaf entry exists")
-                    .key,
-            )?;
-            found |= key.schema_key.as_str() == schema_key;
-            Ok(())
-        })?;
-        return Ok(found);
-    }
-    let requested = BTreeSet::from([schema_key]);
-    Ok(!commit_delta_segments_for_schemas(&manifest, &requested).is_empty())
+    Ok(
+        scan_commit_delta_values(store, commit_id, &[schema_key.to_owned()])
+            .await?
+            .len()
+            != 0,
+    )
 }
 
 /// Scans every authoritative tracked change packed into immutable commit
@@ -8674,15 +9402,20 @@ async fn scan_commit_delta_plane(
         .iter()
         .filter_map(|(_, _, inventory)| inventory.directory_root.clone())
         .collect::<Vec<_>>();
-    let mut directories = super::mutation_directory::load_mutation_directories(store, &roots)
-        .await?
-        .into_iter();
+    let mut directories =
+        super::mutation_directory::load_all_mutation_part_read_plans(store, &roots)
+            .await?
+            .into_iter();
     let mut manifests = BTreeMap::<CommitId, CommitDeltaManifest>::new();
     for (commit_id, stored, inventory) in authorities {
         let entries = if inventory.directory_root.is_some() {
             directories
                 .next()
                 .expect("each scanned mutation root returns one directory")
+                .into_runs()
+                .into_iter()
+                .map(|run| run.entry)
+                .collect()
         } else {
             Vec::new()
         };
@@ -9078,6 +9811,7 @@ pub(crate) fn seed_commit_delta_point_cache_from_replay_manifest(
     state: &AuthenticatedReplayCommitStateManifest,
     point_cache: &CommitDeltaPointReadCache,
 ) -> Result<CommitDeltaReplayMetadata, LixError> {
+    point_cache.remember_authenticated_state(state)?;
     if let Some(manifest) = point_cache.manifest(state.commit_id)? {
         return Ok(commit_delta_replay_metadata(&manifest));
     }
@@ -9151,28 +9885,6 @@ async fn load_commit_delta_manifest(
             LixError::CODE_INTERNAL_ERROR,
             format!("tracked_state replacement generation does not belong to commit '{commit_id}'"),
         ));
-    }
-    Ok(Some(manifest))
-}
-
-async fn load_commit_delta_manifest_cached(
-    store: &(impl StorageAdapterRead + ?Sized),
-    commit_id: CommitId,
-    point_cache: Option<&CommitDeltaPointReadCache>,
-) -> Result<Option<Arc<CommitDeltaManifest>>, LixError> {
-    if let Some(manifest) = point_cache
-        .map(|cache| cache.manifest(commit_id))
-        .transpose()?
-        .flatten()
-    {
-        return Ok(Some(manifest));
-    }
-    let Some(manifest) = load_commit_delta_manifest(store, commit_id).await? else {
-        return Ok(None);
-    };
-    let manifest = Arc::new(manifest);
-    if let Some(point_cache) = point_cache {
-        point_cache.remember_manifest(commit_id, Arc::clone(&manifest))?;
     }
     Ok(Some(manifest))
 }
@@ -9489,14 +10201,6 @@ fn commit_delta_segment_for_key(manifest: &CommitDeltaManifest, key: &[u8]) -> O
     (key <= manifest.segments[segment_index].last_key.as_slice()).then_some(segment_index)
 }
 
-fn encoded_commit_delta_lookup_key(key: &TrackedStateKey) -> Vec<u8> {
-    encode_key_ref(TrackedStateKeyRef {
-        schema_key: &key.schema_key,
-        file_id: key.file_id.as_deref(),
-        entity_pk: &key.entity_pk,
-    })
-}
-
 fn commit_delta_segments_for_schemas(
     manifest: &CommitDeltaManifest,
     schema_keys: &BTreeSet<&str>,
@@ -9516,27 +10220,6 @@ fn commit_delta_segments_for_schemas(
                 .then_some(segment_index)
         })
         .collect()
-}
-
-fn commit_delta_segment_count_for_schemas_up_to(
-    manifest: &CommitDeltaManifest,
-    schema_keys: &BTreeSet<&str>,
-    limit: usize,
-) -> usize {
-    if schema_keys.is_empty() {
-        return manifest.segments.len().min(limit.saturating_add(1));
-    }
-    manifest
-        .segments
-        .iter()
-        .filter(|bounds| {
-            schema_keys
-                .iter()
-                .copied()
-                .any(|schema_key| commit_delta_segment_overlaps_schema(bounds, schema_key))
-        })
-        .take(limit.saturating_add(1))
-        .count()
 }
 
 fn commit_delta_segment_overlaps_schema(
@@ -10801,7 +11484,16 @@ async fn decode_commit_state_manifest_with_scoped_range_attestation(
     let (stored, stored_inventory) =
         decode_stored_commit_state_authority(header, mutation_inventory)?;
     let entries = match stored_inventory.directory_root.as_ref() {
-        Some(root) => super::mutation_directory::load_mutation_directory(store, root).await?,
+        Some(root) => super::mutation_directory::load_mutation_part_read_plan(
+            store,
+            root,
+            super::mutation_directory::MutationDirectoryReadSelection::All,
+        )
+        .await?
+        .into_runs()
+        .into_iter()
+        .map(|run| run.entry)
+        .collect(),
         None => Vec::new(),
     };
     assemble_commit_state_manifest(
@@ -11507,15 +12199,15 @@ mod tests {
         TRACKED_STATE_CHANGE_LOCATOR_SPACE, TRACKED_STATE_COMMIT_DELTA_SEGMENT_SPACE,
         TRACKED_STATE_TREE_CHUNK_SPACE, TrackedStateChunkOverlay, columnar_identity_row_map,
         decode_commit_delta_with_payloads, decode_encoded_commit_state_manifest,
-        decode_stored_commit_state_authority, direct_change_locator_in_commit_state,
-        encode_commit_delta_segment, encode_commit_delta_segment_with_payloads,
-        encode_commit_delta_segment_with_raw_sidecar, encode_commit_state_manifest, key,
-        load_change_record_by_id, load_commit_delta_change_ids, load_commit_delta_change_records,
-        load_commit_delta_members_with_payloads, load_commit_delta_values_encoded,
-        load_commit_state_manifest, load_owned_commit_delta_entries,
-        scan_change_records_from_commit_deltas, scan_commit_delta_inventory,
-        scan_commit_delta_members, scan_commit_delta_values, stage_change_locators,
-        stage_commit_state_manifest, stage_delete_commit_delta_inventory_entry,
+        decode_stored_commit_state_authority, encode_commit_delta_segment,
+        encode_commit_delta_segment_with_payloads, encode_commit_delta_segment_with_raw_sidecar,
+        encode_commit_state_manifest, key, load_change_record_by_id, load_commit_delta_change_ids,
+        load_commit_delta_change_records, load_commit_delta_members_with_payloads,
+        load_commit_delta_values_encoded, load_commit_state_manifest,
+        load_owned_commit_delta_entries, scan_change_records_from_commit_deltas,
+        scan_commit_delta_inventory, scan_commit_delta_members, scan_commit_delta_values,
+        stage_change_locators, stage_commit_state_manifest,
+        stage_delete_commit_delta_inventory_entry,
         stage_fragmented_scoped_current_state_descriptor, value,
     };
 
@@ -12073,7 +12765,25 @@ mod tests {
                 entity_pk: &key.entity_pk,
             });
         }
-        load_commit_delta_values_encoded(store, commit_id, &encoded_keys.finish()).await
+        let encoded_keys = encoded_keys.finish();
+        let mut order = (0..encoded_keys.len()).collect::<Vec<_>>();
+        order.sort_unstable_by(|left, right| encoded_keys[*left].cmp(&encoded_keys[*right]));
+        let mut canonical = Vec::with_capacity(order.len());
+        let mut canonical_ordinal_by_request = vec![0usize; order.len()];
+        for request_index in order {
+            if canonical
+                .last()
+                .is_none_or(|previous: &Bytes| previous != &encoded_keys[request_index])
+            {
+                canonical.push(encoded_keys[request_index].clone());
+            }
+            canonical_ordinal_by_request[request_index] = canonical.len() - 1;
+        }
+        let values = load_commit_delta_values_encoded(store, commit_id, &canonical).await?;
+        Ok(canonical_ordinal_by_request
+            .into_iter()
+            .map(|ordinal| values[ordinal].clone())
+            .collect())
     }
 
     fn packed_commit_delta_fixtures() -> Vec<CommitDeltaFixture> {
@@ -12236,10 +12946,12 @@ mod tests {
             .expect("commit-state authority should load")
             .expect("commit-state authority should exist");
         assert_eq!(authority.mutations, fixture_addressable_inventory(&staged));
-        assert_eq!(
-            direct_change_locator_in_commit_state(&authority, change_id),
-            super::direct_change_locator(change_id),
-            "the authoritative inventory must retain the assigned direct slot"
+        let direct = super::direct_change_locator(change_id)
+            .expect("assigned direct change should retain its physical coordinate");
+        assert_eq!(direct.commit_id, authority.commit_id);
+        assert!(
+            authority.mutations.direct_part_row_counts[direct.segment_index as usize]
+                > direct.ordinal
         );
         assert!(
             super::load_change_locator_by_id(&read, change_id)
@@ -12259,6 +12971,61 @@ mod tests {
             .expect("direct address batch should read");
         assert_eq!(batch.len(), 1);
         assert_eq!(batch[0], loaded);
+    }
+
+    #[tokio::test]
+    async fn direct_change_batch_preserves_multi_owner_duplicates_and_order() {
+        let storage = StorageAdapter::new(Memory::new());
+        let first_commit = CommitId::with_change_address_space(uuid::Uuid::from_u128(
+            0x0192_0000_0000_7000_8000_1111_0000_0000,
+        ));
+        let second_commit = CommitId::with_change_address_space(uuid::Uuid::from_u128(
+            0x0192_0000_0000_7000_8000_2222_0000_0000,
+        ));
+        let fixtures = packed_commit_delta_fixtures();
+        let first_deltas = commit_delta_refs(first_commit, &fixtures);
+        let second_deltas = commit_delta_refs(second_commit, &fixtures);
+        let mut writes = storage.new_write_set();
+        let first = stage_addressable_commit_deltas(
+            &mut writes,
+            &first_deltas,
+            &vec![true; first_deltas.len()],
+        )
+        .expect("first addressable owner should stage");
+        let second = stage_addressable_commit_deltas(
+            &mut writes,
+            &second_deltas,
+            &vec![true; second_deltas.len()],
+        )
+        .expect("second addressable owner should stage");
+        assert!(first.locators.is_empty() && second.locators.is_empty());
+        storage
+            .commit_write_set(writes, StorageWriteOptions::default())
+            .await
+            .expect("both direct owners should commit");
+        let read = storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("multi-owner direct read should open");
+        let requested = vec![
+            second.assigned_change_ids[1],
+            first.assigned_change_ids[0],
+            second.assigned_change_ids[1],
+            first.assigned_change_ids[fixtures.len() - 1],
+            first.assigned_change_ids[0],
+        ];
+        let records = super::load_change_records_by_ids(&read, &requested)
+            .await
+            .expect("unordered duplicate direct coordinates should resolve");
+        assert_eq!(
+            records
+                .iter()
+                .map(|record| record.change_id)
+                .collect::<Vec<_>>(),
+            requested
+        );
+        assert_eq!(records[0], records[2]);
+        assert_eq!(records[1], records[4]);
     }
 
     #[tokio::test]
@@ -12525,7 +13292,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn address_shaped_explicit_change_id_falls_back_to_its_locator() {
+    async fn address_shaped_not_owned_change_dispatches_to_explicit_locator_authority() {
         let storage = StorageAdapter::new(Memory::new());
         let addressable_commit_id = CommitId::with_change_address_space(uuid::Uuid::from_u128(
             0x0192_0000_0000_7000_8000_1234_0000_0000,
@@ -12575,7 +13342,7 @@ mod tests {
         assert_ne!(loaded.entity_pk, address_target.entity_pk);
         let batch = super::load_change_records_by_ids(&read, &[explicit_change_id])
             .await
-            .expect("explicit collision batch should fall back to its locator");
+            .expect("explicit collision batch should use its exclusive locator authority");
         assert_eq!(batch, vec![loaded]);
         let canonical = super::load_canonical_change_locator(&read, explicit_change_id)
             .await
@@ -12585,7 +13352,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn out_of_range_address_shaped_explicit_id_falls_back_to_its_locator() {
+    async fn out_of_range_not_owned_change_dispatches_to_explicit_locator_authority() {
         let storage = StorageAdapter::new(Memory::new());
         let addressable_commit_id = CommitId::with_change_address_space(uuid::Uuid::from_u128(
             0x0192_0000_0000_7000_8000_5678_0000_0000,
@@ -12635,7 +13402,7 @@ mod tests {
         assert_eq!(
             super::load_change_records_by_ids(&read, &[explicit_change_id])
                 .await
-                .expect("out-of-range batch should fall back to its locator"),
+                .expect("out-of-range batch should use its explicit locator authority"),
             vec![loaded],
         );
         let canonical = super::load_canonical_change_locator(&read, explicit_change_id)
@@ -12646,7 +13413,7 @@ mod tests {
     }
 
     #[test]
-    fn change_locator_codec_compacts_sequential_ids_and_round_trips_fallback_ids() {
+    fn change_locator_codec_compacts_sequential_ids_and_round_trips_explicit_ids() {
         let sequential = CommitDeltaChangeLocator {
             change_id: ChangeId::new(uuid::Uuid::from_u128(
                 0x0192_0000_0000_7000_8000_0000_0000_0101,
@@ -13243,6 +14010,51 @@ mod tests {
                 .flatten()
                 .all(|value| value.commit_id == alias_commit)
         );
+
+        let alias_state = super::load_point_replay_commit_state(&read, alias_commit)
+            .await
+            .expect("alias replay authority should load")
+            .expect("alias replay authority should exist");
+        let source_state = super::load_point_replay_commit_state(&read, source_commit)
+            .await
+            .expect("source replay authority should load")
+            .expect("source replay authority should exist");
+        let scanned = super::scan_commit_delta_values_from_authenticated_states(
+            &read,
+            &alias_state,
+            Some(&source_state),
+            &[],
+        )
+        .await
+        .expect("snapshot-coherent authenticated states should scan");
+        assert_eq!(scanned.len(), fixtures.len());
+        let error = super::scan_commit_delta_values_from_authenticated_states(
+            &read,
+            &alias_state,
+            Some(&alias_state),
+            &[],
+        )
+        .await
+        .expect_err("a cached source for the wrong commit must fail closed");
+        assert!(error.to_string().contains("expected authority"));
+        let error = super::scan_commit_delta_values_from_authenticated_states(
+            &read,
+            &alias_state,
+            None,
+            &[],
+        )
+        .await
+        .expect_err("a missing cached selected source must fail closed");
+        assert!(error.to_string().contains("references missing authority"));
+        let error = super::scan_commit_delta_values_from_authenticated_states(
+            &read,
+            &source_state,
+            Some(&alias_state),
+            &[],
+        )
+        .await
+        .expect_err("a local-only authority must reject an unrelated cached source");
+        assert!(error.to_string().contains("local-only authority"));
 
         let missing_key = TrackedStateKey {
             schema_key: fixtures[0].schema_key.clone(),
@@ -14459,11 +15271,11 @@ mod tests {
             file_id: fixture.file_id.as_deref(),
             entity_pk: &fixture.entity_pk,
         }));
-        let values = super::load_commit_delta_values_encoded_with_cache(
+        let values = super::load_commit_delta_values_encoded_from_replay_manifest(
             &read,
-            commit_id,
-            &[encoded_key],
-            Some(&cache),
+            &state,
+            std::slice::from_ref(&encoded_key),
+            &cache,
         )
         .await
         .expect("cached shallow point replay should load");
@@ -14471,6 +15283,186 @@ mod tests {
         assert_eq!(manifest_requests.load(Ordering::Relaxed), 1);
         assert_eq!(inventory_requests.load(Ordering::Relaxed), 1);
         assert_eq!(directory_requests.load(Ordering::Relaxed), 0);
+
+        let mut mismatched_state = state.clone();
+        mismatched_state
+            .manifest
+            .change_account_id
+            .push_str("-mismatch");
+        let error = super::load_commit_delta_values_encoded_from_replay_manifest(
+            &read,
+            &mismatched_state,
+            std::slice::from_ref(&encoded_key),
+            &cache,
+        )
+        .await
+        .expect_err("cached authenticated authority mismatch must fail closed");
+        assert!(
+            error
+                .to_string()
+                .contains("mismatched authenticated authority")
+        );
+    }
+
+    #[tokio::test]
+    async fn warm_point_cache_cannot_bypass_bounded_directory_authority() {
+        let storage = StorageAdapter::new(Memory::new());
+        let commit_id = CommitId::for_test_label("warm-bounded-directory-point-replay");
+        let fixtures = packed_commit_delta_fixtures();
+        let deltas = commit_delta_refs(commit_id, &fixtures);
+        let mut writes = storage.new_write_set();
+        stage_commit_deltas(&mut writes, &deltas).expect("bounded delta should stage");
+        storage
+            .commit_write_set(writes, StorageWriteOptions::default())
+            .await
+            .expect("bounded delta should commit");
+
+        let manifest_requests = std::sync::Arc::new(AtomicUsize::new(0));
+        let inventory_requests = std::sync::Arc::new(AtomicUsize::new(0));
+        let directory_requests = std::sync::Arc::new(AtomicUsize::new(0));
+        let read = ManifestCountingRead {
+            inner: storage
+                .begin_read(StorageReadOptions::default())
+                .await
+                .expect("bounded point read should open"),
+            manifest_requests: std::sync::Arc::clone(&manifest_requests),
+            inventory_requests: std::sync::Arc::clone(&inventory_requests),
+            directory_requests: std::sync::Arc::clone(&directory_requests),
+        };
+        let state = super::load_point_replay_commit_state(&read, commit_id)
+            .await
+            .expect("bounded replay authority should load")
+            .expect("bounded replay authority should exist");
+        assert!(state.mutation_directory_root.as_ref().is_some_and(|root| {
+            root.layout == super::super::mutation_directory::LAYOUT_BOUNDED_DIRECT
+                || root.layout == super::super::mutation_directory::LAYOUT_BOUNDED_INDIRECT
+        }));
+        let cache = super::CommitDeltaPointReadCache::default();
+        super::seed_commit_delta_point_cache_from_replay_manifest(&state, &cache)
+            .expect("bounded replay authority should seed the point cache");
+        let encoded_key = Bytes::from(encode_key_ref(TrackedStateKeyRef {
+            schema_key: &fixtures[0].schema_key,
+            file_id: fixtures[0].file_id.as_deref(),
+            entity_pk: &fixtures[0].entity_pk,
+        }));
+        for _ in 0..2 {
+            let values = super::load_commit_delta_values_encoded_from_replay_manifest(
+                &read,
+                &state,
+                std::slice::from_ref(&encoded_key),
+                &cache,
+            )
+            .await
+            .expect("warm bounded point replay should load through the hierarchy");
+            assert_eq!(values, vec![Some(fixtures[0].value(commit_id))]);
+        }
+        assert_eq!(manifest_requests.load(Ordering::Relaxed), 1);
+        assert_eq!(inventory_requests.load(Ordering::Relaxed), 1);
+        assert!(
+            directory_requests.load(Ordering::Relaxed) >= 2,
+            "each warm lookup must authenticate the bounded directory"
+        );
+    }
+
+    #[tokio::test]
+    async fn live_membership_cursor_streams_authenticated_bounded_parts() {
+        let storage = StorageAdapter::new(Memory::new());
+        let commit_id = CommitId::for_test_label("bounded-live-membership-cursor");
+        let fixtures = packed_commit_delta_fixtures();
+        let deltas = commit_delta_refs(commit_id, &fixtures);
+        let mut writes = storage.new_write_set();
+        stage_commit_deltas(&mut writes, &deltas).expect("bounded delta should stage");
+        storage
+            .commit_write_set(writes, StorageWriteOptions::default())
+            .await
+            .expect("bounded delta should commit");
+
+        let manifest_requests = std::sync::Arc::new(AtomicUsize::new(0));
+        let inventory_requests = std::sync::Arc::new(AtomicUsize::new(0));
+        let directory_requests = std::sync::Arc::new(AtomicUsize::new(0));
+        let read = ManifestCountingRead {
+            inner: storage
+                .begin_read(StorageReadOptions::default())
+                .await
+                .expect("bounded membership read should open"),
+            manifest_requests: std::sync::Arc::clone(&manifest_requests),
+            inventory_requests: std::sync::Arc::clone(&inventory_requests),
+            directory_requests: std::sync::Arc::clone(&directory_requests),
+        };
+        let cache = super::CommitDeltaPointReadCache::default();
+        let mut cursor = cache.live_membership_cursor(commit_id);
+        let encoded = encode_key_ref(TrackedStateKeyRef {
+            schema_key: &fixtures[0].schema_key,
+            file_id: fixtures[0].file_id.as_deref(),
+            entity_pk: &fixtures[0].entity_pk,
+        });
+        assert_eq!(
+            cursor
+                .live_member(&read, &cache, &encoded)
+                .await
+                .expect("bounded membership should resolve"),
+            Some(!fixtures[0].deleted)
+        );
+        let missing = encode_key_ref(TrackedStateKeyRef {
+            schema_key: "zzzz-missing-schema",
+            file_id: None,
+            entity_pk: &EntityPk::single("zzzz-missing-identity"),
+        });
+        assert_eq!(
+            cursor
+                .live_member(&read, &cache, &missing)
+                .await
+                .expect("bounded negative membership should resolve"),
+            Some(false)
+        );
+        assert_eq!(manifest_requests.load(Ordering::Relaxed), 1);
+        assert_eq!(inventory_requests.load(Ordering::Relaxed), 1);
+        assert!(directory_requests.load(Ordering::Relaxed) >= 2);
+    }
+
+    #[tokio::test]
+    async fn live_membership_cursor_rejects_corrupt_directory_authority() {
+        let storage = StorageAdapter::new(Memory::new());
+        let commit_id = CommitId::for_test_label("corrupt-live-membership-cursor");
+        let fixtures = packed_commit_delta_fixtures();
+        let deltas = commit_delta_refs(commit_id, &fixtures);
+        let mut writes = storage.new_write_set();
+        stage_commit_deltas(&mut writes, &deltas).expect("bounded delta should stage");
+        storage
+            .commit_write_set(writes, StorageWriteOptions::default())
+            .await
+            .expect("bounded delta should commit");
+        let read = storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("bounded membership read should open");
+        let mut state = super::load_point_replay_commit_state(&read, commit_id)
+            .await
+            .expect("bounded authority should load")
+            .expect("bounded authority should exist");
+        state
+            .mutation_directory_root
+            .as_mut()
+            .expect("bounded authority should have a directory root")
+            .root_digest[0] ^= 1;
+        let cache = super::CommitDeltaPointReadCache::default();
+        cache
+            .remember_authority(std::sync::Arc::new(state))
+            .expect("test corruption should seed the empty cache");
+        let mut cursor = cache.live_membership_cursor(commit_id);
+        let encoded = encode_key_ref(TrackedStateKeyRef {
+            schema_key: &fixtures[0].schema_key,
+            file_id: fixtures[0].file_id.as_deref(),
+            entity_pk: &fixtures[0].entity_pk,
+        });
+        let error = cursor
+            .live_member(&read, &cache, &encoded)
+            .await
+            .expect_err("corrupt bounded authority must fail closed");
+        assert!(
+            error.to_string().contains("root is invalid"),
+            "unexpected corruption error: {error}"
+        );
     }
 
     #[tokio::test]
@@ -15399,7 +16391,7 @@ mod tests {
     }
 
     #[test]
-    fn commit_state_direct_change_route_rejects_holes_and_other_commits() {
+    fn commit_state_direct_change_encoding_preserves_holes_and_other_commits() {
         let manifest = commit_state_manifest_fixture();
         let first = super::change_id_from_packed_address(manifest.commit_id, 1);
         let hole = super::change_id_from_packed_address(manifest.commit_id, 2);
@@ -15410,12 +16402,21 @@ mod tests {
             1,
         );
 
-        let locator = direct_change_locator_in_commit_state(&manifest, first)
-            .expect("first direct address should route");
+        let locator =
+            super::direct_change_locator(first).expect("first direct address should decode");
         assert_eq!(locator.segment_index, 0);
         assert_eq!(locator.ordinal, 0);
-        assert!(direct_change_locator_in_commit_state(&manifest, hole).is_none());
-        assert!(direct_change_locator_in_commit_state(&manifest, other).is_none());
+        let hole =
+            super::direct_change_locator(hole).expect("physical hole remains address-shaped");
+        assert!(
+            manifest.mutations.direct_part_row_counts[hole.segment_index as usize] <= hole.ordinal
+        );
+        assert_ne!(
+            super::direct_change_locator(other)
+                .expect("other commit address should decode")
+                .commit_id,
+            manifest.commit_id
+        );
     }
 
     #[test]

--- a/packages/engine/src/tracked_state/storage.rs
+++ b/packages/engine/src/tracked_state/storage.rs
@@ -4354,7 +4354,8 @@ pub(crate) fn stage_ordered_columnar_mutations(
 /// Parts own identity routing and JSON authority: small values are inline and
 /// large values remain content-addressed references into the JSON store.
 pub(crate) struct ReplacementPartInput<'a> {
-    key: Vec<u8>,
+    key_start: usize,
+    key_end: usize,
     commit_id: CommitId,
     created_at: crate::common::LixTimestamp,
     updated_at: crate::common::LixTimestamp,
@@ -4363,23 +4364,34 @@ pub(crate) struct ReplacementPartInput<'a> {
 }
 
 pub(crate) trait ReplacementPartInputRef<'a>: Copy {
-    fn into_replacement_part_input(self) -> Result<ReplacementPartInput<'a>, LixError>;
+    fn into_replacement_part_input(
+        self,
+        key_arena: &mut Vec<u8>,
+    ) -> Result<ReplacementPartInput<'a>, LixError>;
 }
 
 impl<'a> ReplacementPartInputRef<'a> for TrackedStateCommitDeltaRef<'a> {
-    fn into_replacement_part_input(self) -> Result<ReplacementPartInput<'a>, LixError> {
+    fn into_replacement_part_input(
+        self,
+        key_arena: &mut Vec<u8>,
+    ) -> Result<ReplacementPartInput<'a>, LixError> {
         if self.delta.deleted || !self.authored || self.origin_key.is_some() {
             return Err(LixError::new(
                 LixError::CODE_INTERNAL_ERROR,
                 "tracked_state replacement member violates immutable replacement invariants",
             ));
         }
-        Ok(ReplacementPartInput {
-            key: encode_key_ref(TrackedStateKeyRef {
+        let key_range = encode_key_ref_into(
+            key_arena,
+            TrackedStateKeyRef {
                 schema_key: self.delta.schema_key,
                 file_id: self.delta.file_id,
                 entity_pk: self.delta.entity_pk,
-            }),
+            },
+        );
+        Ok(ReplacementPartInput {
+            key_start: key_range.start,
+            key_end: key_range.end,
             commit_id: self.delta.commit_id,
             created_at: self.delta.created_at,
             updated_at: self.delta.updated_at,
@@ -4390,13 +4402,19 @@ impl<'a> ReplacementPartInputRef<'a> for TrackedStateCommitDeltaRef<'a> {
 }
 
 impl<'a> ReplacementPartInputRef<'a> for TrackedStateSingleStringReplacementRef<'a> {
-    fn into_replacement_part_input(self) -> Result<ReplacementPartInput<'a>, LixError> {
-        let mut key = Vec::with_capacity(
-            self.schema_key.len() + self.file_id.map_or(0, str::len) + self.entity_pk.len() + 8,
+    fn into_replacement_part_input(
+        self,
+        key_arena: &mut Vec<u8>,
+    ) -> Result<ReplacementPartInput<'a>, LixError> {
+        let key_range = encode_single_string_key_ref_into(
+            key_arena,
+            self.schema_key,
+            self.file_id,
+            self.entity_pk,
         );
-        encode_single_string_key_ref_into(&mut key, self.schema_key, self.file_id, self.entity_pk);
         Ok(ReplacementPartInput {
-            key,
+            key_start: key_range.start,
+            key_end: key_range.end,
             commit_id: self.commit_id,
             created_at: self.created_at,
             updated_at: self.updated_at,
@@ -4460,7 +4478,8 @@ where
     R: ReplacementPartInputRef<'a>,
 {
     struct BorrowedRow<'a> {
-        key: Vec<u8>,
+        key_start: usize,
+        key_end: usize,
         snapshot: crate::json_store::JsonSlotRef<'a>,
         metadata: crate::json_store::JsonSlotRef<'a>,
     }
@@ -4489,11 +4508,29 @@ where
         .and_then(|prefix| prefix.3.last())
         .map_or_else(Vec::new, |part| part.last_key().to_vec());
     let mut pending = Vec::with_capacity(ORDERED_COMMIT_DELTA_SEGMENT_MAX_ROWS);
+    let mut key_arena = Vec::new();
     let mut parts = prefix.map_or_else(Vec::new, |prefix| prefix.3);
     parts.reserve(row_count.div_ceil(ORDERED_COMMIT_DELTA_SEGMENT_MAX_ROWS));
     let mut compressor = None;
     for delta in deltas {
-        let delta = delta?.into_replacement_part_input()?;
+        let delta = delta?.into_replacement_part_input(&mut key_arena)?;
+        #[cfg(feature = "storage-benches")]
+        {
+            let json_bytes = |slot: crate::json_store::JsonSlotRef<'_>| match slot {
+                crate::json_store::JsonSlotRef::None => 0,
+                crate::json_store::JsonSlotRef::Ref(_) => 32,
+                crate::json_store::JsonSlotRef::Inline(value) => value.len(),
+            };
+            crate::storage_bench::record_crud_ownership(
+                crate::storage_bench::CRUD_OWNERSHIP_REPLACEMENT_INPUT,
+                1,
+                delta.key_end.saturating_sub(delta.key_start),
+                json_bytes(delta.snapshot) + json_bytes(delta.metadata),
+                1,
+                0,
+                0,
+            );
+        }
         if delta.created_at != generation.lifecycle_summary.uniform_created_at {
             return Err(LixError::new(
                 LixError::CODE_INTERNAL_ERROR,
@@ -4518,22 +4555,28 @@ where
                 "tracked_state replacement members have nonuniform owner or timestamp",
             ));
         }
-        let key = delta.key;
-        if !previous_key.is_empty() && previous_key >= key {
+        let key = &key_arena[delta.key_start..delta.key_end];
+        if !previous_key.is_empty() && previous_key.as_slice() >= key {
             return Err(LixError::new(
                 LixError::CODE_INTERNAL_ERROR,
                 "tracked_state replacement members are not in canonical identity order",
             ));
         }
         previous_key.clear();
-        previous_key.extend_from_slice(&key);
+        previous_key.extend_from_slice(key);
         pending.push(BorrowedRow {
-            key,
+            key_start: delta.key_start,
+            key_end: delta.key_end,
             snapshot: delta.snapshot,
             metadata: delta.metadata,
         });
         if pending.len() == ORDERED_COMMIT_DELTA_SEGMENT_MAX_ROWS {
-            encode_replacement_part_prefix(&mut pending, &mut parts, &mut compressor)?;
+            encode_replacement_part_prefix(
+                &mut pending,
+                &mut key_arena,
+                &mut parts,
+                &mut compressor,
+            )?;
         }
     }
     let commit_id = commit_id.expect("non-empty replacement has an owner");
@@ -4541,11 +4584,12 @@ where
     let uniform_updated_at = uniform_updated_at.expect("non-empty replacement has a timestamp");
 
     while !pending.is_empty() {
-        encode_replacement_part_prefix(&mut pending, &mut parts, &mut compressor)?;
+        encode_replacement_part_prefix(&mut pending, &mut key_arena, &mut parts, &mut compressor)?;
     }
 
     fn encode_replacement_part_prefix(
         pending: &mut Vec<BorrowedRow<'_>>,
+        key_arena: &mut Vec<u8>,
         parts: &mut Vec<crate::tracked_state::replacement_part::EncodedReplacementPart>,
         compressor: &mut Option<crate::compression::ZstdLevel1Compressor>,
     ) -> Result<(), LixError> {
@@ -4555,7 +4599,7 @@ where
                 .iter()
                 .map(
                     |row| crate::tracked_state::replacement_part::ReplacementPartRowRef {
-                        encoded_key: &row.key,
+                        encoded_key: &key_arena[row.key_start..row.key_end],
                         snapshot: row.snapshot,
                         metadata: row.metadata,
                     },
@@ -4577,7 +4621,29 @@ where
             }
         };
         parts.push(encoded);
+        #[cfg(feature = "storage-benches")]
+        if let Some(part) = parts.last() {
+            crate::storage_bench::record_crud_ownership(
+                crate::storage_bench::CRUD_OWNERSHIP_REPLACEMENT_PART,
+                usize::from(part.row_count()),
+                part.first_key().len() + part.last_key().len(),
+                part.bytes().len(),
+                1,
+                0,
+                0,
+            );
+        }
+        let removed_key_end = pending[candidate_len - 1].key_end;
         pending.drain(..candidate_len);
+        if pending.is_empty() {
+            key_arena.clear();
+        } else {
+            key_arena.drain(..removed_key_end);
+            for row in pending {
+                row.key_start -= removed_key_end;
+                row.key_end -= removed_key_end;
+            }
+        }
         Ok(())
     }
 
@@ -4619,6 +4685,19 @@ pub(crate) fn stage_preencoded_ordered_addressable_replacement_parts(
             "tracked_state preencoded replacement parts are not a complete ordered row set",
         ));
     }
+    #[cfg(feature = "storage-benches")]
+    crate::storage_bench::record_crud_ownership(
+        crate::storage_bench::CRUD_OWNERSHIP_AUTHORITY,
+        row_count,
+        parts
+            .iter()
+            .map(|part| part.first_key().len() + part.last_key().len())
+            .sum(),
+        parts.iter().map(|part| part.bytes().len()).sum(),
+        parts.len(),
+        0,
+        0,
+    );
     addressable_change_id(commit_id, 0, 0)?;
     let mut first_ordinal = 0u32;
     let directory_entries = parts

--- a/packages/engine/src/tracked_state/storage.rs
+++ b/packages/engine/src/tracked_state/storage.rs
@@ -75,7 +75,14 @@ pub(crate) const TRACKED_STATE_COMMIT_STATE_MANIFEST_SPACE: StorageSpace = Stora
     TRACKED_STATE_COMMIT_STATE_MANIFEST_NAMESPACE,
 );
 
+// The durable direct-ChangeId address stride. Physical ordered parts may be
+// smaller, but their logical slots must remain stable at this width.
 const COMMIT_DELTA_SEGMENT_MAX_ROWS: usize = 512;
+// Bound newly authored ordered parts tightly enough that point and small-batch
+// reads do not decompress an entire 512-row payload neighborhood. A 1K commit
+// still publishes only sixteen parts, keeping mutation counts near the 35-put
+// reference while the same history authority serves bounded current points.
+const ORDERED_COMMIT_DELTA_SEGMENT_MAX_ROWS: usize = 64;
 const GENERIC_COMMIT_DELTA_SEGMENT_MAX_ROWS: usize = 128;
 const GENERIC_COMMIT_DELTA_SEGMENT_TARGET_BYTES: usize = 28 * 1024;
 const ORDERED_COMMIT_DELTA_SEGMENT_TARGET_BYTES: usize = 64 * 1024;
@@ -3520,7 +3527,7 @@ where
     };
     let mut compressor = None;
     let mut source = deltas;
-    let mut pending = VecDeque::with_capacity(COMMIT_DELTA_SEGMENT_MAX_ROWS);
+    let mut pending = VecDeque::with_capacity(ORDERED_COMMIT_DELTA_SEGMENT_MAX_ROWS);
     let mut first_segment = None::<(CommitDeltaSegmentBounds, Vec<u8>)>;
     let mut manifest = CommitDeltaManifest {
         account_id: crate::ANONYMOUS_ACCOUNT_ID.to_string(),
@@ -3533,7 +3540,7 @@ where
         })?,
         selection_fingerprint: [0; 32],
         direct_segment_row_counts: Vec::with_capacity(
-            row_count.div_ceil(COMMIT_DELTA_SEGMENT_MAX_ROWS),
+            row_count.div_ceil(ORDERED_COMMIT_DELTA_SEGMENT_MAX_ROWS),
         ),
         single_partition: None,
         lifecycle_summary,
@@ -3541,11 +3548,11 @@ where
         replacement_parts: None,
         columnar_parts: None,
         inline_segment: Vec::new(),
-        segments: Vec::with_capacity(row_count.div_ceil(COMMIT_DELTA_SEGMENT_MAX_ROWS)),
+        segments: Vec::with_capacity(row_count.div_ceil(ORDERED_COMMIT_DELTA_SEGMENT_MAX_ROWS)),
     };
     let mut segment_row_counts = Vec::with_capacity(manifest.segments.capacity());
     while !pending.is_empty() || source.len() > 0 {
-        while pending.len() < COMMIT_DELTA_SEGMENT_MAX_ROWS {
+        while pending.len() < ORDERED_COMMIT_DELTA_SEGMENT_MAX_ROWS {
             let Some(delta) = source.next() else {
                 break;
             };
@@ -3591,7 +3598,7 @@ where
         if segment_index == 1 {
             writes.reserve_space(
                 TRACKED_STATE_COMMIT_DELTA_SEGMENT_SPACE,
-                row_count.div_ceil(COMMIT_DELTA_SEGMENT_MAX_ROWS),
+                row_count.div_ceil(ORDERED_COMMIT_DELTA_SEGMENT_MAX_ROWS),
                 0,
             );
             let (first_bounds, first_encoded) = first_segment
@@ -3870,9 +3877,9 @@ where
         .as_ref()
         .and_then(|prefix| prefix.3.last())
         .map_or_else(Vec::new, |part| part.last_key().to_vec());
-    let mut pending = Vec::with_capacity(COMMIT_DELTA_SEGMENT_MAX_ROWS);
+    let mut pending = Vec::with_capacity(ORDERED_COMMIT_DELTA_SEGMENT_MAX_ROWS);
     let mut parts = prefix.map_or_else(Vec::new, |prefix| prefix.3);
-    parts.reserve(row_count.div_ceil(COMMIT_DELTA_SEGMENT_MAX_ROWS));
+    parts.reserve(row_count.div_ceil(ORDERED_COMMIT_DELTA_SEGMENT_MAX_ROWS));
     let mut compressor = None;
     for delta in deltas {
         let delta = delta?.into_replacement_part_input()?;
@@ -3914,7 +3921,7 @@ where
             snapshot: delta.snapshot,
             metadata: delta.metadata,
         });
-        if pending.len() == COMMIT_DELTA_SEGMENT_MAX_ROWS {
+        if pending.len() == ORDERED_COMMIT_DELTA_SEGMENT_MAX_ROWS {
             encode_replacement_part_prefix(&mut pending, &mut parts, &mut compressor)?;
         }
     }
@@ -3931,7 +3938,7 @@ where
         parts: &mut Vec<crate::tracked_state::replacement_part::EncodedReplacementPart>,
         compressor: &mut Option<crate::compression::ZstdLevel1Compressor>,
     ) -> Result<(), LixError> {
-        let mut candidate_len = pending.len().min(COMMIT_DELTA_SEGMENT_MAX_ROWS);
+        let mut candidate_len = pending.len().min(ORDERED_COMMIT_DELTA_SEGMENT_MAX_ROWS);
         let encoded = loop {
             let refs = pending[..candidate_len]
                 .iter()

--- a/packages/engine/src/tracked_state/storage.rs
+++ b/packages/engine/src/tracked_state/storage.rs
@@ -13944,9 +13944,13 @@ mod tests {
             out_of_range_change_id,
             hole_change_id,
         ];
-        let batch = super::load_change_records_by_ids(&read, &requested)
-            .await
-            .expect("mixed owned and unowned direct-shaped batch should dispatch");
+        let (batch_result, invocation_accounting) =
+            super::super::mutation_directory::test_read_accounting::scope(
+                super::load_change_records_by_ids(&read, &requested),
+            )
+            .await;
+        let batch =
+            batch_result.expect("mixed owned and unowned direct-shaped batch should dispatch");
         assert_eq!(
             batch
                 .iter()
@@ -13957,7 +13961,7 @@ mod tests {
         let accounting =
             super::super::mutation_directory::snapshot_mutation_directory_read_accounting();
         assert!(accounting.direct_route_calls >= 3);
-        assert_eq!(accounting.selector_all_roots, 0);
+        assert_eq!(invocation_accounting.selector_all_roots, 0);
         assert!(accounting.selector_direct_calls > 0);
         assert!(accounting.not_owned_part_index > 0);
         assert!(accounting.not_owned_local_row > 0);
@@ -14057,15 +14061,19 @@ mod tests {
         let change_id = staged
             .change_id_at(1)
             .expect("replacement row should be addressed");
-        let loaded = load_change_record_by_id(&read, change_id)
-            .await
+        let (loaded_result, invocation_accounting) =
+            super::super::mutation_directory::test_read_accounting::scope(
+                load_change_record_by_id(&read, change_id),
+            )
+            .await;
+        let loaded = loaded_result
             .expect("compact direct hydration should succeed")
             .expect("compact direct row should exist");
         assert_eq!(loaded.change_id, change_id);
         assert_eq!(loaded.entity_pk, EntityPk::single("compact-001"));
         let accounting =
             super::super::mutation_directory::snapshot_mutation_directory_read_accounting();
-        assert_eq!(accounting.selector_all_roots, 0);
+        assert_eq!(invocation_accounting.selector_all_roots, 0);
         assert!(accounting.selector_direct_calls > 0);
         assert_eq!(accounting.external_parts_loaded, 1);
         assert_eq!(accounting.parts_decoded, 1);

--- a/packages/engine/src/tracked_state/storage.rs
+++ b/packages/engine/src/tracked_state/storage.rs
@@ -3757,10 +3757,13 @@ pub(crate) async fn load_commit_state_manifests(
                 .and_then(|(_, inventory)| inventory.directory_root.clone())
         })
         .collect::<Vec<_>>();
-    let mut directories =
-        super::mutation_directory::load_all_mutation_part_read_plans(store, &roots)
-            .await?
-            .into_iter();
+    let mut directories = super::mutation_directory::load_all_mutation_part_read_plans(
+        store,
+        &roots,
+        super::mutation_directory::MutationDirectoryFullTraversalContext::BulkCommitStateManifests,
+    )
+    .await?
+    .into_iter();
     let mut output = Vec::with_capacity(authorities.len());
     for authority in authorities {
         let Some((stored, inventory)) = authority else {
@@ -5260,15 +5263,23 @@ pub(crate) async fn load_change_record_by_id(
     store: &(impl StorageAdapterRead + ?Sized),
     change_id: crate::changelog::ChangeId,
 ) -> Result<Option<crate::changelog::ChangeRecord>, LixError> {
-    if let Some(locator) = direct_change_locator(change_id)
-        && let Some(authority) =
-            load_claimed_direct_change_authority(store, locator.commit_id).await?
-    {
-        let mut records =
-            load_owned_direct_change_records_for_state(store, &authority, &[locator]).await?;
-        return Ok(Some(
-            records.pop().expect("one direct locator returns one row"),
-        ));
+    if let Some(locator) = direct_change_locator(change_id) {
+        match load_direct_change_authority(store, locator.commit_id).await? {
+            DirectChangeAuthority::Candidate(authority) => {
+                let route = route_direct_change_records_for_state(store, &authority, &[locator])
+                    .await?
+                    .pop()
+                    .expect("one direct locator returns one route");
+                if let DirectChangeRecordRoute::Owned(record) = route {
+                    return Ok(Some(record));
+                }
+            }
+            DirectChangeAuthority::NotOwned(reason) => {
+                let _ = reason;
+            }
+        }
+        #[cfg(any(test, feature = "storage-benches"))]
+        super::mutation_directory::record_direct_route_explicit_fallback(1);
     }
     if let Some(locator) = load_change_locator_by_id(store, change_id).await? {
         return load_change_record_at_locator(store, locator)
@@ -5282,12 +5293,23 @@ async fn load_canonical_change_locator(
     store: &(impl StorageAdapterRead + ?Sized),
     change_id: crate::changelog::ChangeId,
 ) -> Result<Option<CommitDeltaChangeLocator>, LixError> {
-    if let Some(locator) = direct_change_locator(change_id)
-        && let Some(authority) =
-            load_claimed_direct_change_authority(store, locator.commit_id).await?
-    {
-        load_owned_direct_change_records_for_state(store, &authority, &[locator]).await?;
-        return Ok(Some(locator));
+    if let Some(locator) = direct_change_locator(change_id) {
+        match load_direct_change_authority(store, locator.commit_id).await? {
+            DirectChangeAuthority::Candidate(authority) => {
+                let route = route_direct_change_records_for_state(store, &authority, &[locator])
+                    .await?
+                    .pop()
+                    .expect("one direct locator returns one route");
+                if matches!(route, DirectChangeRecordRoute::Owned(_)) {
+                    return Ok(Some(locator));
+                }
+            }
+            DirectChangeAuthority::NotOwned(reason) => {
+                let _ = reason;
+            }
+        }
+        #[cfg(any(test, feature = "storage-benches"))]
+        super::mutation_directory::record_direct_route_explicit_fallback(1);
     }
     if let Some(locator) = load_change_locator_by_id(store, change_id).await? {
         return Ok(Some(locator));
@@ -5338,14 +5360,55 @@ async fn load_change_locator_by_id(
     decode_change_locator(change_id, &locator).map(Some)
 }
 
-async fn load_claimed_direct_change_authority(
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum DirectNotOwnedReason {
+    MissingCommitAuthority,
+    UnsupportedLayout,
+    AbsentInlineAuthority,
+    PartIndexOutOfRange,
+    LocalRowOutOfRange,
+}
+
+#[derive(Clone)]
+enum DirectChangeAuthority {
+    Candidate(Arc<AuthenticatedReplayCommitStateManifest>),
+    NotOwned(DirectNotOwnedReason),
+}
+
+#[derive(Clone)]
+enum DirectChangeRecordRoute {
+    Owned(crate::changelog::ChangeRecord),
+    NotOwned(DirectNotOwnedReason),
+}
+
+impl From<super::mutation_directory::MutationDirectoryNotOwnedReason> for DirectNotOwnedReason {
+    fn from(reason: super::mutation_directory::MutationDirectoryNotOwnedReason) -> Self {
+        match reason {
+            super::mutation_directory::MutationDirectoryNotOwnedReason::UnsupportedLayout => {
+                Self::UnsupportedLayout
+            }
+            super::mutation_directory::MutationDirectoryNotOwnedReason::PartIndexOutOfRange => {
+                Self::PartIndexOutOfRange
+            }
+            super::mutation_directory::MutationDirectoryNotOwnedReason::LocalRowOutOfRange => {
+                Self::LocalRowOutOfRange
+            }
+        }
+    }
+}
+
+async fn load_direct_change_authority(
     store: &(impl StorageAdapterRead + ?Sized),
     commit_id: CommitId,
-) -> Result<Option<Arc<AuthenticatedReplayCommitStateManifest>>, LixError> {
+) -> Result<DirectChangeAuthority, LixError> {
     let Some(state) = load_point_replay_commit_state(store, commit_id).await? else {
-        return Ok(None);
+        #[cfg(any(test, feature = "storage-benches"))]
+        super::mutation_directory::record_direct_route_missing_commit(1);
+        return Ok(DirectChangeAuthority::NotOwned(
+            DirectNotOwnedReason::MissingCommitAuthority,
+        ));
     };
-    let claimed = match state
+    let candidate = match state
         .mutation_directory_root
         .as_ref()
         .map(|root| root.layout)
@@ -5363,21 +5426,44 @@ async fn load_claimed_direct_change_authority(
         }
         None => !state.mutations.direct_part_row_counts.is_empty(),
     };
-    if claimed && state.mutations.selected_source_commit_id().is_some() {
+    if candidate && state.mutations.selected_source_commit_id().is_some() {
         return Err(replacement_payload_error(
             "selected-source alias cannot claim direct change coordinates",
         ));
     }
-    Ok(claimed.then(|| Arc::new(state)))
+    if candidate {
+        Ok(DirectChangeAuthority::Candidate(Arc::new(state)))
+    } else if state.mutation_directory_root.is_some() {
+        #[cfg(any(test, feature = "storage-benches"))]
+        super::mutation_directory::record_direct_route_not_owned(
+            super::mutation_directory::MutationDirectoryNotOwnedReason::UnsupportedLayout,
+            1,
+        );
+        Ok(DirectChangeAuthority::NotOwned(
+            DirectNotOwnedReason::UnsupportedLayout,
+        ))
+    } else {
+        #[cfg(any(test, feature = "storage-benches"))]
+        super::mutation_directory::record_direct_route_absent_inline(1);
+        Ok(DirectChangeAuthority::NotOwned(
+            DirectNotOwnedReason::AbsentInlineAuthority,
+        ))
+    }
 }
 
-async fn load_owned_direct_change_records_for_state(
+async fn route_direct_change_records_for_state(
     store: &(impl StorageAdapterRead + ?Sized),
     state: &AuthenticatedReplayCommitStateManifest,
     locators: &[CommitDeltaChangeLocator],
-) -> Result<Vec<crate::changelog::ChangeRecord>, LixError> {
+) -> Result<Vec<DirectChangeRecordRoute>, LixError> {
     if locators.is_empty() {
         return Ok(Vec::new());
+    }
+    #[cfg(any(test, feature = "storage-benches"))]
+    let mut accounting_guard = super::mutation_directory::DirectRouteAccountingGuard::new();
+    #[cfg(any(test, feature = "storage-benches"))]
+    {
+        super::mutation_directory::record_direct_route_start(locators.len());
     }
     if state.mutations.selected_source_commit_id().is_some() {
         return Err(replacement_payload_error(
@@ -5421,9 +5507,11 @@ async fn load_owned_direct_change_records_for_state(
             }
         })
         .collect::<Vec<_>>();
+    #[cfg(any(test, feature = "storage-benches"))]
+    super::mutation_directory::record_direct_route_unique_rows(coordinates.len());
 
     let unique = if let Some(root) = state.mutation_directory_root.as_ref() {
-        let runs = super::mutation_directory::load_mutation_part_read_plan(
+        let (runs, not_owned) = super::mutation_directory::load_mutation_part_read_plan(
             store,
             root,
             super::mutation_directory::MutationDirectoryReadSelection::SortedUniqueDirectCoordinates(
@@ -5431,7 +5519,33 @@ async fn load_owned_direct_change_records_for_state(
             ),
         )
         .await?
-        .into_runs();
+        .into_direct_routes();
+        let mut unique = (0..coordinates.len()).map(|_| None).collect::<Vec<_>>();
+        for route in not_owned {
+            let reason = DirectNotOwnedReason::from(route.reason);
+            #[cfg(any(test, feature = "storage-benches"))]
+            super::mutation_directory::record_direct_route_not_owned(
+                match reason {
+                    DirectNotOwnedReason::UnsupportedLayout => {
+                        super::mutation_directory::MutationDirectoryNotOwnedReason::UnsupportedLayout
+                    }
+                    DirectNotOwnedReason::PartIndexOutOfRange => {
+                        super::mutation_directory::MutationDirectoryNotOwnedReason::PartIndexOutOfRange
+                    }
+                    DirectNotOwnedReason::LocalRowOutOfRange => {
+                        super::mutation_directory::MutationDirectoryNotOwnedReason::LocalRowOutOfRange
+                    }
+                    DirectNotOwnedReason::MissingCommitAuthority
+                    | DirectNotOwnedReason::AbsentInlineAuthority => {
+                        continue;
+                    }
+                },
+                route.selector_span.len(),
+            );
+            for selector_index in route.selector_span {
+                unique[selector_index] = Some(DirectChangeRecordRoute::NotOwned(reason));
+            }
+        }
         for run in &runs {
             for coordinate in &coordinates[run.selector_span.clone()] {
                 if coordinate.part_index != run.entry_index {
@@ -5460,18 +5574,31 @@ async fn load_owned_direct_change_records_for_state(
                     ));
                 }
             }
-            load_columnar_direct_change_records(
+            let owned_indices = runs
+                .iter()
+                .flat_map(|run| run.selector_span.clone())
+                .collect::<Vec<_>>();
+            #[cfg(any(test, feature = "storage-benches"))]
+            super::mutation_directory::record_direct_route_claimed_rows(owned_indices.len());
+            let records = load_columnar_direct_change_records(
                 store,
                 state,
                 parts,
-                &unique_locator_indices
+                &owned_indices
                     .iter()
-                    .map(|&index| locators[index])
+                    .map(|&index| locators[unique_locator_indices[index]])
                     .collect::<Vec<_>>(),
             )
-            .await?
+            .await?;
+            for (selector_index, record) in owned_indices.into_iter().zip(records) {
+                unique[selector_index] = Some(DirectChangeRecordRoute::Owned(record));
+            }
         } else {
-            load_physical_direct_change_records(
+            #[cfg(any(test, feature = "storage-benches"))]
+            super::mutation_directory::record_direct_route_claimed_rows(
+                runs.iter().map(|run| run.selector_span.len()).sum(),
+            );
+            for (selector_index, record) in load_physical_direct_change_records(
                 store,
                 state,
                 &coordinates,
@@ -5482,50 +5609,110 @@ async fn load_owned_direct_change_records_for_state(
                 runs,
             )
             .await?
+            {
+                unique[selector_index] = Some(DirectChangeRecordRoute::Owned(record));
+            }
         }
+        unique
+            .into_iter()
+            .map(|route| {
+                route.ok_or_else(|| {
+                    replacement_payload_error(
+                        "direct-coordinate plan lost a claimed or unclaimed selector",
+                    )
+                })
+            })
+            .collect::<Result<Vec<_>, LixError>>()?
     } else {
         if state.mutations.inline_part.is_empty()
             || state.mutations.direct_part_row_counts.len() != 1
-            || coordinates
-                .iter()
-                .any(|coordinate| coordinate.part_index != 0)
         {
             return Err(replacement_payload_error(
-                "direct change coordinate has no authenticated inline authority",
+                "direct change candidate has invalid authenticated inline authority",
             ));
         }
         let direct_row_count = state.mutations.direct_part_row_counts[0];
-        let (leaf, payloads) =
-            decode_commit_delta_with_payloads(&state.mutations.inline_part, None)?;
-        if leaf.len() != usize::from(direct_row_count)
-            || leaf.len() != state.mutations.member_count as usize
-        {
-            return Err(replacement_payload_error(
-                "inline direct payload row count disagrees with authenticated authority",
-            ));
-        }
-        unique_locator_indices
+        let owned_indices = coordinates
             .iter()
-            .map(|&index| {
-                decode_change_at_locator_from_decoded(
+            .enumerate()
+            .filter_map(|(index, coordinate)| {
+                (coordinate.part_index == 0 && coordinate.local_row < direct_row_count)
+                    .then_some(index)
+            })
+            .collect::<Vec<_>>();
+        let mut unique = coordinates
+            .iter()
+            .map(|coordinate| {
+                if coordinate.part_index != 0 {
+                    Some(DirectChangeRecordRoute::NotOwned(
+                        DirectNotOwnedReason::PartIndexOutOfRange,
+                    ))
+                } else if coordinate.local_row >= direct_row_count {
+                    Some(DirectChangeRecordRoute::NotOwned(
+                        DirectNotOwnedReason::LocalRowOutOfRange,
+                    ))
+                } else {
+                    None
+                }
+            })
+            .collect::<Vec<_>>();
+        if owned_indices.is_empty() {
+            unique
+                .into_iter()
+                .map(|route| {
+                    route.ok_or_else(|| {
+                        replacement_payload_error("inline direct route lost an unclaimed selector")
+                    })
+                })
+                .collect::<Result<Vec<_>, LixError>>()?
+        } else {
+            #[cfg(any(test, feature = "storage-benches"))]
+            super::mutation_directory::record_direct_route_claimed_rows(owned_indices.len());
+            let (leaf, payloads) =
+                decode_commit_delta_with_payloads(&state.mutations.inline_part, None)?;
+            if leaf.len() != usize::from(direct_row_count)
+                || leaf.len() != state.mutations.member_count as usize
+            {
+                return Err(replacement_payload_error(
+                    "inline direct payload row count disagrees with authenticated authority",
+                ));
+            }
+            for selector_index in owned_indices {
+                let locator_index = unique_locator_indices[selector_index];
+                let record = decode_change_at_locator_from_decoded(
                     &leaf,
                     &payloads,
-                    locators[index],
+                    locators[locator_index],
                     &state.change_account_id,
                 )
-                .map(|entry| entry.change_record)
-            })
-            .collect::<Result<Vec<_>, LixError>>()?
+                .map(|entry| entry.change_record)?;
+                unique[selector_index] = Some(DirectChangeRecordRoute::Owned(record));
+            }
+            unique
+                .into_iter()
+                .map(|route| {
+                    route.ok_or_else(|| {
+                        replacement_payload_error(
+                            "inline direct route lost a claimed or unclaimed selector",
+                        )
+                    })
+                })
+                .collect::<Result<Vec<_>, LixError>>()?
+        }
     };
 
     let mut output = (0..locators.len()).map(|_| None).collect::<Vec<_>>();
     for (request_index, unique_index) in output_routes {
         output[request_index] = Some(unique[unique_index].clone());
     }
+    #[cfg(any(test, feature = "storage-benches"))]
+    super::mutation_directory::record_direct_route_scattered_rows(locators.len());
+    #[cfg(any(test, feature = "storage-benches"))]
+    accounting_guard.finish();
     output
         .into_iter()
-        .map(|record| {
-            record.ok_or_else(|| {
+        .map(|route| {
+            route.ok_or_else(|| {
                 replacement_payload_error("direct change record scatter lost a requested row")
             })
         })
@@ -5605,7 +5792,9 @@ async fn load_physical_direct_change_records(
     coordinates: &[super::mutation_directory::MutationDirectoryDirectCoordinate],
     locators: &[CommitDeltaChangeLocator],
     runs: Vec<super::mutation_directory::MutationDirectoryPartRun>,
-) -> Result<Vec<crate::changelog::ChangeRecord>, LixError> {
+) -> Result<Vec<(usize, crate::changelog::ChangeRecord)>, LixError> {
+    #[cfg(any(test, feature = "storage-benches"))]
+    super::mutation_directory::record_direct_external_parts_loaded(runs.len());
     let storage_keys = runs
         .iter()
         .map(|run| match &run.entry {
@@ -5639,7 +5828,7 @@ async fn load_physical_direct_change_records(
         PointReadPlan::from_unique_keys(TRACKED_STATE_COMMIT_DELTA_SEGMENT_SPACE, storage_keys)
             .materialize(store, StorageGetOptions::default())
             .await?;
-    let mut output = (0..coordinates.len()).map(|_| None).collect::<Vec<_>>();
+    let mut output = Vec::with_capacity(coordinates.len());
     for (run, value) in runs.into_iter().zip(values.value) {
         let bytes = value.and_then(full_value_bytes).ok_or_else(|| {
             replacement_payload_error("direct coordinate references a missing immutable part")
@@ -5680,6 +5869,12 @@ async fn load_physical_direct_change_records(
                 "direct immutable part row count disagrees with directory authority",
             ));
         }
+        #[cfg(any(test, feature = "storage-benches"))]
+        super::mutation_directory::record_direct_part_decoded(
+            leaf.len(),
+            bytes.len(),
+            leaf.resident_bytes() + payloads.resident_bytes(),
+        );
         for output_index in run.selector_span {
             let coordinate = coordinates[output_index];
             let locator = locators[output_index];
@@ -5688,7 +5883,8 @@ async fn load_physical_direct_change_records(
                     "direct-coordinate run disagrees with its physical locator",
                 ));
             }
-            output[output_index] = Some(
+            output.push((
+                output_index,
                 decode_change_at_locator_from_decoded(
                     &leaf,
                     &payloads,
@@ -5696,17 +5892,10 @@ async fn load_physical_direct_change_records(
                     &state.change_account_id,
                 )?
                 .change_record,
-            );
+            ));
         }
     }
-    output
-        .into_iter()
-        .map(|record| {
-            record.ok_or_else(|| {
-                replacement_payload_error("direct-coordinate plan lost a selected payload row")
-            })
-        })
-        .collect()
+    Ok(output)
 }
 
 fn compact_replacement_bounds_for_selected_part(
@@ -5765,8 +5954,7 @@ async fn load_change_records_by_ids(
     if change_ids.is_empty() {
         return Ok(Vec::new());
     }
-    let mut authority_cache =
-        BTreeMap::<CommitId, Option<Arc<AuthenticatedReplayCommitStateManifest>>>::new();
+    let mut authority_cache = BTreeMap::<CommitId, DirectChangeAuthority>::new();
     let mut direct_by_commit = BTreeMap::<
         CommitId,
         (
@@ -5783,15 +5971,18 @@ async fn load_change_records_by_ids(
         let authority = match authority_cache.get(&locator.commit_id) {
             Some(authority) => authority.clone(),
             None => {
-                let authority =
-                    load_claimed_direct_change_authority(store, locator.commit_id).await?;
+                let authority = load_direct_change_authority(store, locator.commit_id).await?;
                 authority_cache.insert(locator.commit_id, authority.clone());
                 authority
             }
         };
-        let Some(authority) = authority else {
-            explicit.push((output_index, change_id));
-            continue;
+        let authority = match authority {
+            DirectChangeAuthority::Candidate(authority) => authority,
+            DirectChangeAuthority::NotOwned(reason) => {
+                let _ = reason;
+                explicit.push((output_index, change_id));
+                continue;
+            }
         };
         direct_by_commit
             .entry(locator.commit_id)
@@ -5806,12 +5997,20 @@ async fn load_change_records_by_ids(
             .iter()
             .map(|(_, locator)| *locator)
             .collect::<Vec<_>>();
-        let records = Box::pin(load_owned_direct_change_records_for_state(
+        let routes = Box::pin(route_direct_change_records_for_state(
             store, &authority, &locators,
         ))
         .await?;
-        for ((output_index, _), record) in requests.into_iter().zip(records) {
-            output[output_index] = Some(record);
+        for ((output_index, locator), route) in requests.into_iter().zip(routes) {
+            match route {
+                DirectChangeRecordRoute::Owned(record) => output[output_index] = Some(record),
+                DirectChangeRecordRoute::NotOwned(reason) => {
+                    let _ = reason;
+                    #[cfg(any(test, feature = "storage-benches"))]
+                    super::mutation_directory::record_direct_route_explicit_fallback(1);
+                    explicit.push((output_index, locator.change_id));
+                }
+            }
         }
     }
 
@@ -6147,13 +6346,23 @@ async fn load_change_record_at_locator(
     store: &(impl StorageAdapterRead + ?Sized),
     locator: CommitDeltaChangeLocator,
 ) -> Result<crate::changelog::ChangeRecord, LixError> {
-    if direct_change_locator(locator.change_id) == Some(locator)
-        && let Some(authority) =
-            load_claimed_direct_change_authority(store, locator.commit_id).await?
-    {
-        let mut records =
-            load_owned_direct_change_records_for_state(store, &authority, &[locator]).await?;
-        return Ok(records.pop().expect("one direct locator returns one row"));
+    if direct_change_locator(locator.change_id) == Some(locator) {
+        match load_direct_change_authority(store, locator.commit_id).await? {
+            DirectChangeAuthority::Candidate(authority) => {
+                let route = route_direct_change_records_for_state(store, &authority, &[locator])
+                    .await?
+                    .pop()
+                    .expect("one direct locator returns one route");
+                if let DirectChangeRecordRoute::Owned(record) = route {
+                    return Ok(record);
+                }
+            }
+            DirectChangeAuthority::NotOwned(reason) => {
+                let _ = reason;
+            }
+        }
+        #[cfg(any(test, feature = "storage-benches"))]
+        super::mutation_directory::record_direct_route_explicit_fallback(1);
     }
     let change_id = locator.change_id;
     let Some(manifest) = load_commit_delta_manifest(store, locator.commit_id).await? else {
@@ -7271,7 +7480,9 @@ async fn load_authenticated_local_commit_delta_members_for_schemas(
     let runs = super::mutation_directory::load_mutation_part_read_plan(
         store,
         root,
-        super::mutation_directory::MutationDirectoryReadSelection::All,
+        super::mutation_directory::MutationDirectoryReadSelection::All(
+            super::mutation_directory::MutationDirectoryFullTraversalContext::CompactMemberScan,
+        ),
     )
     .await?
     .into_runs();
@@ -7335,7 +7546,9 @@ async fn load_bounded_commit_delta_members_for_schemas(
         store,
         root,
         if ranges.is_empty() {
-            super::mutation_directory::MutationDirectoryReadSelection::All
+            super::mutation_directory::MutationDirectoryReadSelection::All(
+                super::mutation_directory::MutationDirectoryFullTraversalContext::EmptySchemaMemberScan,
+            )
         } else {
             super::mutation_directory::MutationDirectoryReadSelection::SortedRanges(&ranges)
         },
@@ -8522,7 +8735,9 @@ async fn scan_authenticated_local_commit_delta_values(
     let entries = super::mutation_directory::load_mutation_part_read_plan(
         store,
         root,
-        super::mutation_directory::MutationDirectoryReadSelection::All,
+        super::mutation_directory::MutationDirectoryReadSelection::All(
+            super::mutation_directory::MutationDirectoryFullTraversalContext::CompactValueScan,
+        ),
     )
     .await?
     .into_runs();
@@ -8586,7 +8801,9 @@ async fn scan_bounded_commit_delta_values(
         store,
         root,
         if ranges.is_empty() {
-            super::mutation_directory::MutationDirectoryReadSelection::All
+            super::mutation_directory::MutationDirectoryReadSelection::All(
+                super::mutation_directory::MutationDirectoryFullTraversalContext::EmptySchemaValueScan,
+            )
         } else {
             super::mutation_directory::MutationDirectoryReadSelection::SortedRanges(&ranges)
         },
@@ -9402,10 +9619,13 @@ async fn scan_commit_delta_plane(
         .iter()
         .filter_map(|(_, _, inventory)| inventory.directory_root.clone())
         .collect::<Vec<_>>();
-    let mut directories =
-        super::mutation_directory::load_all_mutation_part_read_plans(store, &roots)
-            .await?
-            .into_iter();
+    let mut directories = super::mutation_directory::load_all_mutation_part_read_plans(
+        store,
+        &roots,
+        super::mutation_directory::MutationDirectoryFullTraversalContext::RepositoryInventory,
+    )
+    .await?
+    .into_iter();
     let mut manifests = BTreeMap::<CommitId, CommitDeltaManifest>::new();
     for (commit_id, stored, inventory) in authorities {
         let entries = if inventory.directory_root.is_some() {
@@ -11487,7 +11707,9 @@ async fn decode_commit_state_manifest_with_scoped_range_attestation(
         Some(root) => super::mutation_directory::load_mutation_part_read_plan(
             store,
             root,
-            super::mutation_directory::MutationDirectoryReadSelection::All,
+            super::mutation_directory::MutationDirectoryReadSelection::All(
+                super::mutation_directory::MutationDirectoryFullTraversalContext::FullManifestExpansion,
+            ),
         )
         .await?
         .into_runs()
@@ -13412,6 +13634,243 @@ mod tests {
         assert_eq!(canonical.commit_id, explicit_commit_id);
     }
 
+    #[tokio::test]
+    async fn direct_claimed_short_part_holes_and_out_of_range_slots_dispatch_explicitly() {
+        let storage = StorageAdapter::new(Memory::new());
+        let direct_commit = CommitId::with_change_address_space(uuid::Uuid::from_u128(
+            0x0192_0000_0000_7000_8000_5678_0000_0000,
+        ));
+        let fixtures = (0..513)
+            .map(|index| CommitDeltaFixture {
+                schema_key: "direct-hole".to_string(),
+                file_id: None,
+                entity_pk: EntityPk::single(format!("entity-{index:04}")),
+                change_id: ChangeId::for_test_label(&format!("direct-hole-{index}")),
+                deleted: false,
+                created_at: LixTimestamp::from_unix_millis_utc_lossy(index.into()),
+                updated_at: LixTimestamp::from_unix_millis_utc_lossy((index + 1).into()),
+            })
+            .collect::<Vec<_>>();
+        let deltas = fixtures
+            .iter()
+            .map(|fixture| {
+                commit_delta_ref(
+                    direct_commit,
+                    fixture,
+                    crate::json_store::JsonSlotRef::Inline("{}"),
+                    crate::json_store::JsonSlotRef::None,
+                    None,
+                )
+            })
+            .collect::<Vec<_>>();
+        let mut writes = storage.new_write_set();
+        let direct_stage = stage_ordered_addressable_commit_deltas(
+            &mut writes,
+            deltas.iter().copied().map(Ok::<_, LixError>),
+            true,
+        )
+        .expect("direct hole fixture should stage")
+        .expect("ordered direct fixture should use the streaming route");
+        assert_eq!(
+            direct_stage.mutation_inventory().direct_part_row_counts,
+            vec![128, 128, 128, 128, 1]
+        );
+        let hole_change_id = super::addressable_change_id(direct_commit, 4, 1)
+            .expect("short-part hole should retain its direct-shaped id");
+        let out_of_range_change_id = super::addressable_change_id(direct_commit, 5, 0)
+            .expect("out-of-range part should retain its direct-shaped id");
+        let explicit_commit = CommitId::for_test_label("direct-hole-explicit");
+        let mut explicit_hole = fixtures[0].clone();
+        explicit_hole.change_id = hole_change_id;
+        let mut explicit_out_of_range = fixtures[1].clone();
+        explicit_out_of_range.change_id = out_of_range_change_id;
+        let explicit_fixtures = [explicit_hole, explicit_out_of_range];
+        let explicit_deltas = explicit_fixtures
+            .iter()
+            .map(|fixture| {
+                commit_delta_ref(
+                    explicit_commit,
+                    fixture,
+                    crate::json_store::JsonSlotRef::Inline("{}"),
+                    crate::json_store::JsonSlotRef::None,
+                    None,
+                )
+            })
+            .collect::<Vec<_>>();
+        let explicit_stage =
+            stage_addressable_commit_deltas(&mut writes, &explicit_deltas, &[false, false])
+                .expect("explicit collision rows should stage");
+        assert_eq!(explicit_stage.locators.len(), 2);
+        stage_change_locators(&mut writes, &explicit_stage.locators);
+        storage
+            .commit_write_set(writes, StorageWriteOptions::default())
+            .await
+            .expect("direct and explicit collision authorities should commit");
+
+        let read = storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("direct collision read should open");
+        super::super::mutation_directory::reset_mutation_directory_read_accounting();
+        let direct_record = load_change_record_by_id(&read, direct_stage.change_id_at(0).unwrap())
+            .await
+            .expect("claimed direct row should read")
+            .expect("claimed direct row should exist");
+        assert_eq!(direct_record.entity_pk, fixtures[0].entity_pk);
+        for (change_id, fixture) in [
+            (hole_change_id, &explicit_fixtures[0]),
+            (out_of_range_change_id, &explicit_fixtures[1]),
+        ] {
+            let loaded = load_change_record_by_id(&read, change_id)
+                .await
+                .expect("unowned direct-shaped collision should dispatch")
+                .expect("explicit collision locator should resolve");
+            assert_eq!(loaded.entity_pk, fixture.entity_pk);
+            assert_eq!(
+                super::load_canonical_change_locator(&read, change_id)
+                    .await
+                    .expect("explicit collision locator should remain canonical")
+                    .expect("explicit collision should have a locator")
+                    .commit_id,
+                explicit_commit
+            );
+        }
+        let requested = vec![
+            hole_change_id,
+            direct_stage.change_id_at(0).unwrap(),
+            out_of_range_change_id,
+            hole_change_id,
+        ];
+        let batch = super::load_change_records_by_ids(&read, &requested)
+            .await
+            .expect("mixed owned and unowned direct-shaped batch should dispatch");
+        assert_eq!(
+            batch
+                .iter()
+                .map(|record| record.change_id)
+                .collect::<Vec<_>>(),
+            requested
+        );
+        let accounting =
+            super::super::mutation_directory::snapshot_mutation_directory_read_accounting();
+        assert!(accounting.direct_route_calls >= 3);
+        assert_eq!(accounting.selector_all_roots, 0);
+        assert!(accounting.selector_direct_calls > 0);
+        assert!(accounting.not_owned_part_index > 0);
+        assert!(accounting.not_owned_local_row > 0);
+        assert!(accounting.explicit_fallback_rows > 0);
+
+        // A claimed direct slot remains authoritative even when its immutable
+        // payload is missing: the explicit locator collision must not become a
+        // fallback authority for a corruption case.
+        drop(read);
+        let direct_part_key = super::commit_delta_segment_key_for_part(
+            direct_commit,
+            0,
+            &direct_stage.mutation_inventory().parts[0],
+        )
+        .expect("direct part key should encode");
+        let mut corrupt = storage.new_write_set();
+        corrupt.delete_batch(TRACKED_STATE_COMMIT_DELTA_SEGMENT_SPACE, [direct_part_key]);
+        storage
+            .commit_write_set(corrupt, StorageWriteOptions::default())
+            .await
+            .expect("claimed direct payload deletion should commit");
+        let read = storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("corrupt collision read should open");
+        super::super::mutation_directory::reset_mutation_directory_read_accounting();
+        let error = load_change_record_by_id(&read, direct_stage.change_id_at(0).unwrap())
+            .await
+            .expect_err("claimed payload corruption must not fall back");
+        assert!(error.to_string().contains("missing immutable part"));
+        assert!(
+            super::super::mutation_directory::snapshot_mutation_directory_read_accounting()
+                .corruption_outcomes
+                > 0
+        );
+    }
+
+    #[tokio::test]
+    async fn compact_replacement_direct_change_id_hydrates_through_authenticated_part() {
+        use crate::tracked_state::types::{
+            CommitDeltaLifecycleSummary, CommitDeltaReplacementScope,
+            TrackedStateSingleStringReplacementRef,
+        };
+
+        let storage = StorageAdapter::new(Memory::new());
+        let commit_id = CommitId::with_change_address_space(uuid::Uuid::from_u128(
+            0x0192_0000_0000_7000_8000_5679_0000_0000,
+        ));
+        let created_at = LixTimestamp::from_unix_millis_utc_lossy(10);
+        let scope = CommitDeltaReplacementScope {
+            schema_key: "compact-direct".to_string(),
+            file_id: None,
+        };
+        let generation = super::CommitDeltaReplacementGeneration {
+            scope: scope.clone(),
+            fallback_commit_id: None,
+            lifecycle_summary: CommitDeltaLifecycleSummary {
+                scope,
+                ordered_identity_digest: [41; 32],
+                uniform_created_at: created_at,
+            },
+        };
+        let mut writes = storage.new_write_set();
+        let staged = super::stage_ordered_addressable_replacement_parts(
+            &mut writes,
+            ["compact-000", "compact-001"].into_iter().map(|entity_pk| {
+                Ok(TrackedStateSingleStringReplacementRef {
+                    schema_key: "compact-direct",
+                    file_id: None,
+                    entity_pk,
+                    commit_id,
+                    created_at,
+                    updated_at: created_at,
+                    snapshot: crate::json_store::JsonSlotRef::Inline("{\"v\":1}"),
+                    metadata: crate::json_store::JsonSlotRef::None,
+                })
+            }),
+            &generation,
+        )
+        .expect("compact replacement should stage");
+        let mut inventory = staged.mutation_inventory().clone();
+        // Compact replacement authority stores bounds in the authenticated
+        // digest directory, not the generic bounded-part vector.
+        inventory.parts.clear();
+        stage_fixture_manifest(&mut writes, commit_id, &inventory)
+            .expect("compact replacement authority should stage");
+        storage
+            .commit_write_set(writes, StorageWriteOptions::default())
+            .await
+            .expect("compact replacement should commit");
+
+        let read = storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("compact replacement read should open");
+        super::super::mutation_directory::reset_mutation_directory_read_accounting();
+        let change_id = staged
+            .change_id_at(1)
+            .expect("replacement row should be addressed");
+        let loaded = load_change_record_by_id(&read, change_id)
+            .await
+            .expect("compact direct hydration should succeed")
+            .expect("compact direct row should exist");
+        assert_eq!(loaded.change_id, change_id);
+        assert_eq!(loaded.entity_pk, EntityPk::single("compact-001"));
+        let accounting =
+            super::super::mutation_directory::snapshot_mutation_directory_read_accounting();
+        assert_eq!(accounting.selector_all_roots, 0);
+        assert!(accounting.selector_direct_calls > 0);
+        assert_eq!(accounting.external_parts_loaded, 1);
+        assert_eq!(accounting.parts_decoded, 1);
+        assert_eq!(accounting.decoded_rows, 2);
+        assert!(accounting.raw_bytes > 0);
+        assert!(accounting.resident_bytes > 0);
+    }
+
     #[test]
     fn change_locator_codec_compacts_sequential_ids_and_round_trips_explicit_ids() {
         let sequential = CommitDeltaChangeLocator {
@@ -14088,6 +14547,80 @@ mod tests {
             .await
             .expect("alias history should retain one canonical source authority");
         assert_eq!(canonical.len(), 3);
+    }
+
+    #[tokio::test]
+    async fn persisted_selected_source_chain_is_rejected_before_hydration() {
+        let storage = StorageAdapter::new(Memory::new());
+        let source_commit = CommitId::for_test_label("persisted-selected-source-root");
+        let first_alias = CommitId::for_test_label("persisted-selected-source-alias");
+        let chained_alias = CommitId::for_test_label("persisted-selected-source-chain");
+        let mut fixtures = packed_commit_delta_fixtures()
+            .into_iter()
+            .take(3)
+            .collect::<Vec<_>>();
+        fixtures[0].change_id = ChangeId::for_test_label("persisted-source-row");
+        fixtures[1].change_id = ChangeId::for_test_label("persisted-alias-row");
+        fixtures[2].change_id = ChangeId::for_test_label("persisted-chain-row");
+
+        let mut writes = storage.new_write_set();
+        let source_delta = commit_delta_ref(
+            source_commit,
+            &fixtures[0],
+            crate::json_store::JsonSlotRef::Inline("{\"source\":true}"),
+            crate::json_store::JsonSlotRef::None,
+            None,
+        );
+        stage_commit_deltas(&mut writes, &[source_delta]).expect("source should stage");
+
+        let first_delta = commit_delta_ref(
+            first_alias,
+            &fixtures[1],
+            crate::json_store::JsonSlotRef::Inline("{\"alias\":true}"),
+            crate::json_store::JsonSlotRef::None,
+            None,
+        );
+        let first_stage = stage_addressable_commit_deltas_with_selected_source(
+            &mut writes,
+            &[first_delta],
+            &[false],
+            source_commit,
+        )
+        .expect("first selected-source alias should stage");
+        stage_change_locators(&mut writes, &first_stage.locators);
+
+        let chained_delta = commit_delta_ref(
+            chained_alias,
+            &fixtures[2],
+            crate::json_store::JsonSlotRef::Inline("{\"chain\":true}"),
+            crate::json_store::JsonSlotRef::None,
+            None,
+        );
+        let chained_stage = stage_addressable_commit_deltas_with_selected_source(
+            &mut writes,
+            &[chained_delta],
+            &[false],
+            first_alias,
+        )
+        .expect("chained selected-source alias should stage for corruption fixture");
+        stage_change_locators(&mut writes, &chained_stage.locators);
+        storage
+            .commit_write_set(writes, StorageWriteOptions::default())
+            .await
+            .expect("selected-source chain fixture should commit");
+
+        let read = storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("selected-source chain read should open");
+        let error = scan_commit_delta_inventory(&read)
+            .await
+            .expect_err("persisted selected-source chains must fail closed");
+        assert!(
+            error
+                .to_string()
+                .contains("selected-source commit delta chains are unsupported")
+        );
     }
 
     #[test]

--- a/packages/engine/src/tracked_state/storage.rs
+++ b/packages/engine/src/tracked_state/storage.rs
@@ -9872,6 +9872,83 @@ pub(crate) fn stage_delete_commit_delta_inventory_entry(
     Ok(())
 }
 
+/// Deletes one authenticated physical commit authority by identity.  Ordinary
+/// GC uses this point-shaped helper after a reachability delta has proved the
+/// root unreachable; it never scans the inventory space to discover rows.
+pub(crate) async fn stage_delete_commit_state_manifest_for_gc(
+    store: &(impl StorageAdapterRead + ?Sized),
+    writes: &mut StorageWriteSet,
+    commit_id: CommitId,
+    manifest: &CommitStateManifest,
+) -> Result<(), LixError> {
+    writes.delete(
+        TRACKED_STATE_COMMIT_STATE_MANIFEST_SPACE,
+        key(commit_state_manifest_key(commit_id)),
+    );
+    writes.delete(
+        TRACKED_STATE_COMMIT_MUTATION_INVENTORY_SPACE,
+        key(commit_mutation_inventory_key(commit_id)),
+    );
+    for (segment_index, part) in manifest.mutations.parts.iter().enumerate() {
+        writes.delete(
+            TRACKED_STATE_COMMIT_DELTA_SEGMENT_SPACE,
+            key(commit_delta_segment_key_for_part(
+                commit_id,
+                segment_index,
+                part,
+            )?),
+        );
+    }
+    for (segment_index, digest) in manifest
+        .mutations
+        .replacement_part_digests
+        .iter()
+        .enumerate()
+    {
+        let mut segment_key = commit_delta_segment_key(commit_id, segment_index)?;
+        segment_key.extend_from_slice(digest);
+        writes.delete(TRACKED_STATE_COMMIT_DELTA_SEGMENT_SPACE, key(segment_key));
+    }
+    if let Some(parts) = manifest.mutations.columnar_parts.as_ref() {
+        let owner = CommitId::new(uuid::Uuid::from_bytes(parts.owner_commit_id));
+        if owner != commit_id {
+            return Err(LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                format!("retired columnar mutation authority '{commit_id}' names owner '{owner}'"),
+            ));
+        }
+        let row_group_id = crate::live_state::entity_row_group_set_id(commit_id, &parts.schema_key);
+        if row_group_id.as_bytes() != parts.row_group_set_id {
+            return Err(LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                format!(
+                    "retired columnar mutation authority '{commit_id}' names an unexpected row-group set"
+                ),
+            ));
+        }
+        let row_group_manifest = crate::columnar_row_group::load_row_group_manifest(store, row_group_id)
+            .await?
+            .ok_or_else(|| {
+                LixError::new(
+                    LixError::CODE_INTERNAL_ERROR,
+                    format!(
+                        "retired columnar mutation authority '{commit_id}' is missing its row-group manifest"
+                    ),
+                )
+            })?;
+        if row_group_manifest.content_digest()? != parts.manifest_digest {
+            return Err(LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                format!(
+                    "retired columnar mutation authority '{commit_id}' has a row-group digest mismatch"
+                ),
+            ));
+        }
+        crate::columnar_row_group::stage_delete_row_group_set(store, writes, row_group_id).await?;
+    }
+    Ok(())
+}
+
 async fn scan_full_space(
     store: &(impl StorageAdapterRead + ?Sized),
     space: StorageSpace,

--- a/packages/engine/src/tracked_state/storage.rs
+++ b/packages/engine/src/tracked_state/storage.rs
@@ -1614,7 +1614,6 @@ impl CommitDeltaLiveMembershipCursor {
         encoded_key: &[u8],
     ) -> Result<Option<bool>, LixError> {
         if !self.initialized {
-            self.initialized = true;
             let state = match cache.authority(self.commit_id)? {
                 Some(state) => state,
                 None => {
@@ -1656,6 +1655,12 @@ impl CommitDeltaLiveMembershipCursor {
                 self.segment = Some(decoded);
                 self.segment_index = Some(0);
             }
+            // Mark the cursor initialized only after an authenticated
+            // membership authority has selected a serving mode. Unsupported,
+            // rootless, and missing authorities return `None` above; leaving
+            // the cursor uninitialized prevents a later call from entering
+            // the scan loop with no segment.
+            self.initialized = true;
         }
 
         if let Some(root) = self.bounded_root.clone() {
@@ -15951,6 +15956,32 @@ mod tests {
         assert_eq!(manifest_requests.load(Ordering::Relaxed), 1);
         assert_eq!(inventory_requests.load(Ordering::Relaxed), 1);
         assert!(directory_requests.load(Ordering::Relaxed) >= 2);
+    }
+
+    #[tokio::test]
+    async fn live_membership_cursor_retries_missing_authority_without_poisoning_itself() {
+        let storage = StorageAdapter::new(Memory::new());
+        let read = storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("missing-authority read should open");
+        let cache = super::CommitDeltaPointReadCache::default();
+        let commit_id = CommitId::for_test_label("missing-membership-authority");
+        let mut cursor = cache.live_membership_cursor(commit_id);
+        let encoded = encode_key_ref(TrackedStateKeyRef {
+            schema_key: "missing-membership",
+            file_id: None,
+            entity_pk: &EntityPk::single("row"),
+        });
+        for _ in 0..2 {
+            assert_eq!(
+                cursor
+                    .live_member(&read, &cache, &encoded)
+                    .await
+                    .expect("missing authority must fail closed without panic"),
+                None
+            );
+        }
     }
 
     #[tokio::test]

--- a/packages/engine/src/tracked_state/storage.rs
+++ b/packages/engine/src/tracked_state/storage.rs
@@ -84,6 +84,9 @@ pub(crate) const TRACKED_STATE_COMMIT_MUTATION_INVENTORY_SPACE: StorageSpace =
 // The durable direct-ChangeId address stride. Physical ordered parts may be
 // smaller, but their logical slots must remain stable at this width.
 const COMMIT_DELTA_SEGMENT_MAX_ROWS: usize = 512;
+// Scan pages are bounded by row count, not bytes. Keep authority hydration
+// bounded as well when a page contains large authenticated directories.
+const COMMIT_STATE_SCAN_AUTHORITY_BATCH_ROWS: usize = 64;
 // Bound newly authored ordered parts tightly enough that point and small-batch
 // reads do not decompress an entire 512-row payload neighborhood. The 128-row
 // bound halves 1K segment puts versus 64-row parts while controlled RocksDB
@@ -9184,90 +9187,93 @@ pub(crate) async fn visit_change_records_from_commit_deltas(
                 },
             )
             .await?;
-        let commit_ids = page
+        for entry_batch in page
             .value
             .entries
-            .iter()
-            .map(|entry| commit_id_from_delta_key(&entry.key))
-            .collect::<Result<Vec<_>, _>>()?;
-        let states = load_commit_state_manifests(store, &commit_ids).await?;
-        for (entry, (commit_id, state)) in page
-            .value
-            .entries
-            .iter()
-            .zip(commit_ids.into_iter().zip(states))
+            .chunks(COMMIT_STATE_SCAN_AUTHORITY_BATCH_ROWS)
         {
-            if entry.key.0.len() != 16 {
-                return Err(LixError::new(
-                    LixError::CODE_INTERNAL_ERROR,
-                    "tracked_state commit_delta manifest key is not a 16-byte commit id",
-                ));
-            }
-            let StorageProjectedValue::FullValue(_) = &entry.value else {
-                unreachable!("full commit-delta scan returned a key-only row");
-            };
-            let state = state.ok_or_else(|| {
-                LixError::new(
-                    LixError::CODE_INTERNAL_ERROR,
-                    "tracked_state commit-state scan lost its split authority",
-                )
-            })?;
-            if state.commit_id != commit_id {
-                return Err(LixError::new(
-                    LixError::CODE_INTERNAL_ERROR,
-                    "tracked_state commit-state scan key and manifest commit disagree",
-                ));
-            }
-            let manifest = expanded_commit_delta_manifest_from_commit_state(store, &state).await?;
-            if let Some(parts) = manifest.columnar_parts.as_ref() {
-                emitted = emitted.saturating_add(
-                    visit_columnar_mutation_change_records(
-                        store,
-                        commit_id,
-                        parts,
-                        &manifest.account_id,
-                        &mut visit,
+            let commit_ids = entry_batch
+                .iter()
+                .map(|entry| commit_id_from_delta_key(&entry.key))
+                .collect::<Result<Vec<_>, _>>()?;
+            let states = load_commit_state_manifests(store, &commit_ids).await?;
+            for (entry, (commit_id, state)) in
+                entry_batch.iter().zip(commit_ids.into_iter().zip(states))
+            {
+                if entry.key.0.len() != 16 {
+                    return Err(LixError::new(
+                        LixError::CODE_INTERNAL_ERROR,
+                        "tracked_state commit_delta manifest key is not a 16-byte commit id",
+                    ));
+                }
+                let StorageProjectedValue::FullValue(_) = &entry.value else {
+                    unreachable!("full commit-delta scan returned a key-only row");
+                };
+                let state = state.ok_or_else(|| {
+                    LixError::new(
+                        LixError::CODE_INTERNAL_ERROR,
+                        "tracked_state commit-state scan lost its split authority",
                     )
-                    .await?,
-                );
-                continue;
-            }
-            let members =
-                load_commit_delta_members_from_manifest(store, commit_id, &manifest, &[]).await?;
-            for member in members {
-                if member.authored {
-                    visit(member.change)?;
-                    emitted += 1;
-                } else if is_payload_free_selected_tombstone(&member) {
-                    // Cascade tombstones preserve identity history but do not
-                    // introduce another public changelog fact.
+                })?;
+                if state.commit_id != commit_id {
+                    return Err(LixError::new(
+                        LixError::CODE_INTERNAL_ERROR,
+                        "tracked_state commit-state scan key and manifest commit disagree",
+                    ));
+                }
+                let manifest =
+                    expanded_commit_delta_manifest_from_commit_state(store, &state).await?;
+                if let Some(parts) = manifest.columnar_parts.as_ref() {
+                    emitted = emitted.saturating_add(
+                        visit_columnar_mutation_change_records(
+                            store,
+                            commit_id,
+                            parts,
+                            &manifest.account_id,
+                            &mut visit,
+                        )
+                        .await?,
+                    );
                     continue;
-                } else {
-                    let locator = load_canonical_change_locator(store, member.change.change_id)
-                        .await?
-                        .ok_or_else(|| {
-                            invalid_change_locator(
-                                member.change.change_id,
-                                "does not resolve to a canonical record",
-                            )
-                        })?;
-                    if locator.commit_id == member.value.commit_id
-                        && locator.segment_index == member.segment_index
-                        && u32::from(locator.ordinal) == member.ordinal
-                    {
+                }
+                let members =
+                    load_commit_delta_members_from_manifest(store, commit_id, &manifest, &[])
+                        .await?;
+                for member in members {
+                    if member.authored {
                         visit(member.change)?;
                         emitted += 1;
+                    } else if is_payload_free_selected_tombstone(&member) {
+                        // Cascade tombstones preserve identity history but do
+                        // not introduce another public changelog fact.
                         continue;
-                    }
-                    let canonical = load_change_record_at_locator(store, locator).await?;
-                    if canonical != member.change {
-                        return Err(LixError::new(
-                            LixError::CODE_INTERNAL_ERROR,
-                            format!(
-                                "tracked_state change '{}' has conflicting authoritative packed payloads",
-                                member.change.change_id
-                            ),
-                        ));
+                    } else {
+                        let locator = load_canonical_change_locator(store, member.change.change_id)
+                            .await?
+                            .ok_or_else(|| {
+                                invalid_change_locator(
+                                    member.change.change_id,
+                                    "does not resolve to a canonical record",
+                                )
+                            })?;
+                        if locator.commit_id == member.value.commit_id
+                            && locator.segment_index == member.segment_index
+                            && u32::from(locator.ordinal) == member.ordinal
+                        {
+                            visit(member.change)?;
+                            emitted += 1;
+                            continue;
+                        }
+                        let canonical = load_change_record_at_locator(store, locator).await?;
+                        if canonical != member.change {
+                            return Err(LixError::new(
+                                LixError::CODE_INTERNAL_ERROR,
+                                format!(
+                                    "tracked_state change '{}' has conflicting authoritative packed payloads",
+                                    member.change.change_id
+                                ),
+                            ));
+                        }
                     }
                 }
             }

--- a/packages/engine/src/tracked_state/storage.rs
+++ b/packages/engine/src/tracked_state/storage.rs
@@ -81,24 +81,23 @@ pub(crate) const TRACKED_STATE_COMMIT_MUTATION_INVENTORY_SPACE: StorageSpace =
         TRACKED_STATE_COMMIT_MUTATION_INVENTORY_NAMESPACE,
     );
 
-// The durable direct-ChangeId address stride. Physical ordered parts may be
-// smaller, but their logical slots must remain stable at this width.
+// The canonical ordered mutation-part width and durable direct-ChangeId
+// address stride. Physical ordered parts and their packed coordinates must
+// use the same width so a part boundary never needs a second geometry.
 const COMMIT_DELTA_SEGMENT_MAX_ROWS: usize = 512;
 // Scan pages are bounded by row count, not bytes. Keep authority hydration
 // bounded as well when a page contains large authenticated directories.
 const COMMIT_STATE_SCAN_AUTHORITY_BATCH_ROWS: usize = 64;
-// Bound newly authored ordered parts tightly enough that point and small-batch
-// reads do not decompress an entire 512-row payload neighborhood. The 128-row
-// bound halves 1K segment puts versus 64-row parts while controlled RocksDB
-// CRUD keeps every point and bulk operation within the 5% latency envelope.
-const ORDERED_COMMIT_DELTA_SEGMENT_MAX_ROWS: usize = 128;
 const GENERIC_COMMIT_DELTA_SEGMENT_MAX_ROWS: usize = 128;
 const GENERIC_COMMIT_DELTA_SEGMENT_TARGET_BYTES: usize = 28 * 1024;
 const ORDERED_COMMIT_DELTA_SEGMENT_TARGET_BYTES: usize = 64 * 1024;
-// Version 14 makes every ordinary commit member self-contained and complete
+// Version 15 makes every ordinary commit member self-contained and complete
 // replacements authoritative through their immutable part manifest. The
-// payload-less certified-reference encoding is intentionally rejected.
-const COMMIT_DELTA_FORMAT_MAGIC: &[u8] = b"LXCD14";
+// payload-less certified-reference encoding is intentionally rejected. The
+// version also binds ordered mutation parts to the canonical 512-row geometry;
+// LXCD14 is intentionally rejected rather than read through a compatibility
+// decoder.
+const COMMIT_DELTA_FORMAT_MAGIC: &[u8] = b"LXCD15";
 // Version 4 makes lossless columnar mutation parts a first-class, exclusive
 // commit payload. LXCS3 repositories are intentionally rejected: there is no
 // compatibility decoder beneath the new authority.
@@ -4145,7 +4144,7 @@ where
     };
     let mut compressor = None;
     let mut source = deltas;
-    let mut pending = VecDeque::with_capacity(ORDERED_COMMIT_DELTA_SEGMENT_MAX_ROWS);
+    let mut pending = VecDeque::with_capacity(COMMIT_DELTA_SEGMENT_MAX_ROWS);
     let mut first_segment = None::<(CommitDeltaSegmentBounds, Vec<u8>)>;
     let mut manifest = CommitDeltaManifest {
         account_id: crate::ANONYMOUS_ACCOUNT_ID.to_string(),
@@ -4158,7 +4157,7 @@ where
         })?,
         selection_fingerprint: [0; 32],
         direct_segment_row_counts: Vec::with_capacity(
-            row_count.div_ceil(ORDERED_COMMIT_DELTA_SEGMENT_MAX_ROWS),
+            row_count.div_ceil(COMMIT_DELTA_SEGMENT_MAX_ROWS),
         ),
         single_partition: None,
         lifecycle_summary,
@@ -4166,11 +4165,11 @@ where
         replacement_parts: None,
         columnar_parts: None,
         inline_segment: Vec::new(),
-        segments: Vec::with_capacity(row_count.div_ceil(ORDERED_COMMIT_DELTA_SEGMENT_MAX_ROWS)),
+        segments: Vec::with_capacity(row_count.div_ceil(COMMIT_DELTA_SEGMENT_MAX_ROWS)),
     };
     let mut segment_row_counts = Vec::with_capacity(manifest.segments.capacity());
     while !pending.is_empty() || source.len() > 0 {
-        while pending.len() < ORDERED_COMMIT_DELTA_SEGMENT_MAX_ROWS {
+        while pending.len() < COMMIT_DELTA_SEGMENT_MAX_ROWS {
             let Some(delta) = source.next() else {
                 break;
             };
@@ -4216,7 +4215,7 @@ where
         if segment_index == 1 {
             writes.reserve_space(
                 TRACKED_STATE_COMMIT_DELTA_SEGMENT_SPACE,
-                row_count.div_ceil(ORDERED_COMMIT_DELTA_SEGMENT_MAX_ROWS),
+                row_count.div_ceil(COMMIT_DELTA_SEGMENT_MAX_ROWS),
                 0,
             );
             let (first_bounds, first_encoded) = first_segment
@@ -4508,10 +4507,10 @@ where
         .as_ref()
         .and_then(|prefix| prefix.3.last())
         .map_or_else(Vec::new, |part| part.last_key().to_vec());
-    let mut pending = Vec::with_capacity(ORDERED_COMMIT_DELTA_SEGMENT_MAX_ROWS);
+    let mut pending = Vec::with_capacity(COMMIT_DELTA_SEGMENT_MAX_ROWS);
     let mut key_arena = Vec::new();
     let mut parts = prefix.map_or_else(Vec::new, |prefix| prefix.3);
-    parts.reserve(row_count.div_ceil(ORDERED_COMMIT_DELTA_SEGMENT_MAX_ROWS));
+    parts.reserve(row_count.div_ceil(COMMIT_DELTA_SEGMENT_MAX_ROWS));
     let mut compressor = None;
     for delta in deltas {
         let delta = delta?.into_replacement_part_input(&mut key_arena)?;
@@ -4571,7 +4570,7 @@ where
             snapshot: delta.snapshot,
             metadata: delta.metadata,
         });
-        if pending.len() == ORDERED_COMMIT_DELTA_SEGMENT_MAX_ROWS {
+        if pending.len() == COMMIT_DELTA_SEGMENT_MAX_ROWS {
             encode_replacement_part_prefix(
                 &mut pending,
                 &mut key_arena,
@@ -4594,7 +4593,7 @@ where
         parts: &mut Vec<crate::tracked_state::replacement_part::EncodedReplacementPart>,
         compressor: &mut Option<crate::compression::ZstdLevel1Compressor>,
     ) -> Result<(), LixError> {
-        let mut candidate_len = pending.len().min(ORDERED_COMMIT_DELTA_SEGMENT_MAX_ROWS);
+        let mut candidate_len = pending.len().min(COMMIT_DELTA_SEGMENT_MAX_ROWS);
         let encoded = loop {
             let refs = pending[..candidate_len]
                 .iter()
@@ -13538,6 +13537,31 @@ mod tests {
             assert_eq!(generic_loaded.created_at, loaded.created_at);
             assert_eq!(generic_loaded.origin_key, loaded.origin_key);
         }
+    }
+
+    #[test]
+    fn ordered_change_id_geometry_matches_canonical_512_row_parts() {
+        let commit_id = CommitId::with_change_address_space(uuid::Uuid::from_u128(
+            0x0192_0000_0000_7000_8000_5678_0000_0000,
+        ));
+        assert_eq!(super::COMMIT_DELTA_SEGMENT_MAX_ROWS, 512);
+
+        let first = super::addressable_change_id(commit_id, 0, 0)
+            .expect("first ordered coordinate should encode");
+        let last = super::addressable_change_id(commit_id, 0, 511)
+            .expect("last coordinate in the first ordered part should encode");
+        let next = super::addressable_change_id(commit_id, 1, 0)
+            .expect("first coordinate in the second ordered part should encode");
+
+        assert_eq!(
+            super::direct_change_locator(first).unwrap().segment_index,
+            0
+        );
+        assert_eq!(super::direct_change_locator(first).unwrap().ordinal, 0);
+        assert_eq!(super::direct_change_locator(last).unwrap().segment_index, 0);
+        assert_eq!(super::direct_change_locator(last).unwrap().ordinal, 511);
+        assert_eq!(super::direct_change_locator(next).unwrap().segment_index, 1);
+        assert_eq!(super::direct_change_locator(next).unwrap().ordinal, 0);
     }
 
     #[tokio::test]

--- a/packages/engine/src/tracked_state/storage.rs
+++ b/packages/engine/src/tracked_state/storage.rs
@@ -79,10 +79,10 @@ pub(crate) const TRACKED_STATE_COMMIT_STATE_MANIFEST_SPACE: StorageSpace = Stora
 // smaller, but their logical slots must remain stable at this width.
 const COMMIT_DELTA_SEGMENT_MAX_ROWS: usize = 512;
 // Bound newly authored ordered parts tightly enough that point and small-batch
-// reads do not decompress an entire 512-row payload neighborhood. A 1K commit
-// still publishes only sixteen parts, keeping mutation counts near the 35-put
-// reference while the same history authority serves bounded current points.
-const ORDERED_COMMIT_DELTA_SEGMENT_MAX_ROWS: usize = 64;
+// reads do not decompress an entire 512-row payload neighborhood. The 128-row
+// bound halves 1K segment puts versus 64-row parts while controlled RocksDB
+// CRUD keeps every point and bulk operation within the 5% latency envelope.
+const ORDERED_COMMIT_DELTA_SEGMENT_MAX_ROWS: usize = 128;
 const GENERIC_COMMIT_DELTA_SEGMENT_MAX_ROWS: usize = 128;
 const GENERIC_COMMIT_DELTA_SEGMENT_TARGET_BYTES: usize = 28 * 1024;
 const ORDERED_COMMIT_DELTA_SEGMENT_TARGET_BYTES: usize = 64 * 1024;
@@ -2118,6 +2118,13 @@ pub(crate) async fn load_snapshot_commit_root(
     commit_id: &str,
 ) -> Result<Option<TrackedStateCommitRoot>, LixError> {
     let commit_id = CommitId::parse_lix(commit_id, "tracked-state snapshot root lookup")?;
+    // Rootless commits are the common bounded-replay layout. Probe physical
+    // authority first so they do not pay a second semantic lookup merely to
+    // prove the absence of a root pointer. A present pointer still requires
+    // semantic liveness before it may authorize any chunk reads.
+    let Some(snapshot_root) = load_manifest_snapshot_commit_root(store, commit_id).await? else {
+        return Ok(None);
+    };
     let commit_ids = [commit_id];
     let mut changelog = ChangelogContext::new().reader(store);
     let semantic_commit_exists = changelog
@@ -2132,7 +2139,7 @@ pub(crate) async fn load_snapshot_commit_root(
     if !semantic_commit_exists {
         return Ok(None);
     }
-    load_manifest_snapshot_commit_root(store, commit_id).await
+    Ok(Some(snapshot_root))
 }
 
 /// Loads the physical pointer without granting semantic commit liveness.
@@ -9712,6 +9719,33 @@ impl TrackedStateChunkOverlay {
 
     pub(crate) fn staged_chunk(&self, hash: &[u8; TRACKED_STATE_HASH_BYTES]) -> Option<&[u8]> {
         self.chunks.get(hash).map(AsRef::as_ref)
+    }
+
+    pub(crate) fn chunk_hashes(&self) -> impl Iterator<Item = [u8; TRACKED_STATE_HASH_BYTES]> + '_ {
+        self.chunks.keys().copied()
+    }
+
+    pub(crate) fn stage_selected_chunks(
+        &self,
+        writes: &mut StorageWriteSet,
+        hashes: impl IntoIterator<Item = [u8; TRACKED_STATE_HASH_BYTES]>,
+    ) -> Result<(), LixError> {
+        for hash in hashes {
+            let bytes = self.chunks.get(&hash).ok_or_else(|| {
+                LixError::new(
+                    LixError::CODE_INTERNAL_ERROR,
+                    "tracked-state transient chunk promotion lost its overlay bytes",
+                )
+            })?;
+            writes.put(
+                TRACKED_STATE_TREE_CHUNK_SPACE,
+                StorageKey(Bytes::copy_from_slice(&hash)),
+                StorageValue {
+                    bytes: bytes.clone(),
+                },
+            );
+        }
+        Ok(())
     }
 
     fn staged_chunk_bytes(&self, hash: &[u8; TRACKED_STATE_HASH_BYTES]) -> Option<Bytes> {

--- a/packages/engine/src/tracked_state/storage.rs
+++ b/packages/engine/src/tracked_state/storage.rs
@@ -2454,13 +2454,6 @@ impl PublishedCommitStateTopology {
         self.header.current_state_scoped_ranges.as_deref()
     }
 
-    pub(crate) fn snapshot_root_id(&self) -> Option<TrackedStateRootId> {
-        self.header
-            .snapshot_root
-            .as_ref()
-            .map(|root| root.root_id.clone())
-    }
-
     fn topology_ref(&self) -> super::scoped_current_state::CommitStateTopologyRef<'_> {
         super::scoped_current_state::CommitStateTopologyRef {
             commit_id: self.header.commit_id,

--- a/packages/engine/src/tracked_state/storage.rs
+++ b/packages/engine/src/tracked_state/storage.rs
@@ -9184,7 +9184,19 @@ pub(crate) async fn visit_change_records_from_commit_deltas(
                 },
             )
             .await?;
-        for entry in &page.value.entries {
+        let commit_ids = page
+            .value
+            .entries
+            .iter()
+            .map(|entry| commit_id_from_delta_key(&entry.key))
+            .collect::<Result<Vec<_>, _>>()?;
+        let states = load_commit_state_manifests(store, &commit_ids).await?;
+        for (entry, (commit_id, state)) in page
+            .value
+            .entries
+            .iter()
+            .zip(commit_ids.into_iter().zip(states))
+        {
             if entry.key.0.len() != 16 {
                 return Err(LixError::new(
                     LixError::CODE_INTERNAL_ERROR,
@@ -9194,15 +9206,12 @@ pub(crate) async fn visit_change_records_from_commit_deltas(
             let StorageProjectedValue::FullValue(_) = &entry.value else {
                 unreachable!("full commit-delta scan returned a key-only row");
             };
-            let commit_id = commit_id_from_delta_key(&entry.key)?;
-            let state = load_commit_state_manifest(store, commit_id)
-                .await?
-                .ok_or_else(|| {
-                    LixError::new(
-                        LixError::CODE_INTERNAL_ERROR,
-                        "tracked_state commit-state scan lost its split authority",
-                    )
-                })?;
+            let state = state.ok_or_else(|| {
+                LixError::new(
+                    LixError::CODE_INTERNAL_ERROR,
+                    "tracked_state commit-state scan lost its split authority",
+                )
+            })?;
             if state.commit_id != commit_id {
                 return Err(LixError::new(
                     LixError::CODE_INTERNAL_ERROR,

--- a/packages/engine/src/tracked_state/storage.rs
+++ b/packages/engine/src/tracked_state/storage.rs
@@ -13958,14 +13958,12 @@ mod tests {
                 .collect::<Vec<_>>(),
             requested
         );
-        let accounting =
-            super::super::mutation_directory::snapshot_mutation_directory_read_accounting();
-        assert!(accounting.direct_route_calls >= 3);
+        assert!(invocation_accounting.direct_route_calls > 0);
         assert_eq!(invocation_accounting.selector_all_roots, 0);
-        assert!(accounting.selector_direct_calls > 0);
-        assert!(accounting.not_owned_part_index > 0);
-        assert!(accounting.not_owned_local_row > 0);
-        assert!(accounting.explicit_fallback_rows > 0);
+        assert!(invocation_accounting.selector_direct_calls > 0);
+        assert!(invocation_accounting.not_owned_part_index > 0);
+        assert!(invocation_accounting.not_owned_local_row > 0);
+        assert!(invocation_accounting.explicit_fallback_rows > 0);
 
         // A claimed direct slot remains authoritative even when its immutable
         // payload is missing: the explicit locator collision must not become a
@@ -14071,15 +14069,14 @@ mod tests {
             .expect("compact direct row should exist");
         assert_eq!(loaded.change_id, change_id);
         assert_eq!(loaded.entity_pk, EntityPk::single("compact-001"));
-        let accounting =
-            super::super::mutation_directory::snapshot_mutation_directory_read_accounting();
         assert_eq!(invocation_accounting.selector_all_roots, 0);
-        assert!(accounting.selector_direct_calls > 0);
-        assert_eq!(accounting.external_parts_loaded, 1);
-        assert_eq!(accounting.parts_decoded, 1);
-        assert_eq!(accounting.decoded_rows, 2);
-        assert!(accounting.raw_bytes > 0);
-        assert!(accounting.resident_bytes > 0);
+        assert!(invocation_accounting.direct_route_calls > 0);
+        assert!(invocation_accounting.selector_direct_calls > 0);
+        assert_eq!(invocation_accounting.external_parts_loaded, 1);
+        assert_eq!(invocation_accounting.parts_decoded, 1);
+        assert_eq!(invocation_accounting.decoded_rows, 2);
+        assert!(invocation_accounting.raw_bytes > 0);
+        assert!(invocation_accounting.resident_bytes > 0);
     }
 
     #[test]

--- a/packages/engine/src/tracked_state/storage.rs
+++ b/packages/engine/src/tracked_state/storage.rs
@@ -13876,11 +13876,11 @@ mod tests {
         .expect("ordered direct fixture should use the streaming route");
         assert_eq!(
             direct_stage.mutation_inventory().direct_part_row_counts,
-            vec![128, 128, 128, 128, 1]
+            vec![512, 1]
         );
-        let hole_change_id = super::addressable_change_id(direct_commit, 4, 1)
+        let hole_change_id = super::addressable_change_id(direct_commit, 1, 1)
             .expect("short-part hole should retain its direct-shaped id");
-        let out_of_range_change_id = super::addressable_change_id(direct_commit, 5, 0)
+        let out_of_range_change_id = super::addressable_change_id(direct_commit, 2, 0)
             .expect("out-of-range part should retain its direct-shaped id");
         let explicit_commit = CommitId::for_test_label("direct-hole-explicit");
         let mut explicit_hole = fixtures[0].clone();

--- a/packages/engine/src/tracked_state/storage.rs
+++ b/packages/engine/src/tracked_state/storage.rs
@@ -1254,6 +1254,7 @@ fn current_inventory_may_contain_any_key(
     }))
 }
 
+#[cfg(test)]
 pub(crate) fn validate_current_state_scoped_range_serving_base_manifest(
     state: &CommitStateManifest,
     serving_base: Option<&CommitStateManifest>,
@@ -5334,6 +5335,7 @@ pub(crate) fn stage_change_locators(
     }
 }
 
+#[cfg(test)]
 pub(crate) fn stage_delete_change_locators(
     writes: &mut StorageWriteSet,
     change_ids: impl IntoIterator<Item = crate::changelog::ChangeId>,
@@ -9850,6 +9852,7 @@ fn validate_physical_commit_delta_segments(
     Ok(())
 }
 
+#[cfg(test)]
 pub(crate) fn stage_delete_commit_delta_inventory_entry(
     writes: &mut StorageWriteSet,
     commit_id: CommitId,

--- a/packages/engine/src/tracked_state/storage.rs
+++ b/packages/engine/src/tracked_state/storage.rs
@@ -11,7 +11,7 @@ use std::ops::{Bound, Deref, Range};
 use std::pin::Pin;
 use std::sync::{Arc, Mutex, OnceLock};
 
-use crate::changelog::CommitId;
+use crate::changelog::{ChangelogContext, ChangelogReader, CommitId, CommitLoadRequest};
 use crate::common::SharedStr;
 use crate::entity_pk::EntityPk;
 use crate::storage_adapter::{
@@ -48,8 +48,6 @@ pub(crate) const TRACKED_STATE_COMMIT_DELTA_SEGMENT_NAMESPACE: &str =
 pub(crate) const TRACKED_STATE_CHANGE_LOCATOR_NAMESPACE: &str = "tracked_state.change_locator.v2";
 pub(crate) const TRACKED_STATE_COMMIT_STATE_MANIFEST_NAMESPACE: &str =
     "tracked_state.commit_state_manifest.v6";
-pub(crate) const TRACKED_STATE_COMMIT_STATE_SEAL_NAMESPACE: &str =
-    "tracked_state.commit_state_semantic_authority.v3";
 const MIN_CURRENT_STATE_SCOPED_RANGE_POINT_READS: u16 = 4;
 pub(crate) const TRACKED_STATE_TREE_CHUNK_SPACE: StorageSpace = StorageSpace::mutable(
     StorageSpaceId(0x0004_0001),
@@ -72,13 +70,9 @@ pub(crate) const TRACKED_STATE_CHANGE_LOCATOR_SPACE: StorageSpace = StorageSpace
 /// Current repositories publish this one manifest per commit, including
 /// commits with no tracked mutations. The former topology, delta-directory,
 /// and root authority spaces are not part of the current protocol.
-pub(crate) const TRACKED_STATE_COMMIT_STATE_MANIFEST_SPACE: StorageSpace = StorageSpace::mutable(
+pub(crate) const TRACKED_STATE_COMMIT_STATE_MANIFEST_SPACE: StorageSpace = StorageSpace::immutable(
     StorageSpaceId(0x0004_002b),
     TRACKED_STATE_COMMIT_STATE_MANIFEST_NAMESPACE,
-);
-pub(crate) const TRACKED_STATE_COMMIT_STATE_SEAL_SPACE: StorageSpace = StorageSpace::immutable(
-    StorageSpaceId(0x0004_002e),
-    TRACKED_STATE_COMMIT_STATE_SEAL_NAMESPACE,
 );
 
 const COMMIT_DELTA_SEGMENT_MAX_ROWS: usize = 512;
@@ -89,8 +83,6 @@ const ORDERED_COMMIT_DELTA_SEGMENT_TARGET_BYTES: usize = 64 * 1024;
 // replacements authoritative through their immutable part manifest. The
 // payload-less certified-reference encoding is intentionally rejected.
 const COMMIT_DELTA_FORMAT_MAGIC: &[u8] = b"LXCD14";
-const COMMIT_STATE_SEMANTIC_AUTHORITY_MAGIC: &[u8] = b"LXSA5";
-const COMMIT_STATE_SEMANTIC_AUTHORITY_HASH_CONTEXT: &str = "lix.commit-state.semantic-authority.v5";
 // Version 4 makes lossless columnar mutation parts a first-class, exclusive
 // commit payload. LXCS3 repositories are intentionally rejected: there is no
 // compatibility decoder beneath the new authority.
@@ -100,10 +92,10 @@ const COMMIT_STATE_SEMANTIC_AUTHORITY_HASH_CONTEXT: &str = "lix.commit-state.sem
 // Version 6 binds the scope-run v3 node protocol and shared runtime scope
 // identities. LXCS5 roots cannot be reinterpreted under its content hashes.
 // Version 7 authenticates the cumulative touched-schema negative certificate.
-// LXCS6 manifests and LXSA3 semantic seals are deliberately incompatible.
+// Pre-cut manifests are deliberately incompatible with this physical-only format.
 // Version 8 binds current-state serving roots to an explicit physical base
 // commit independently from semantic graph ancestry.
-const COMMIT_STATE_MANIFEST_FORMAT_MAGIC: &[u8] = b"LXCS8";
+const COMMIT_STATE_MANIFEST_FORMAT_MAGIC: &[u8] = b"LXCS9";
 const COMMIT_DELTA_PAYLOAD_OFFSET_BYTES: usize = size_of::<u32>();
 #[cfg(not(test))]
 const COMMIT_DELTA_MAX_SIDECAR_BYTES: usize = 64 * 1024 * 1024;
@@ -503,17 +495,6 @@ pub(crate) struct CommitDeltaInventoryEntry {
     pub(crate) segment_count: usize,
     physical_segment_keys: Vec<Vec<u8>>,
     pub(crate) selected_source_commit_id: Option<CommitId>,
-    pub(crate) authority: CommitStateTopologyProjection,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub(crate) struct CommitStateTopologyProjection {
-    pub(crate) generation: u64,
-    pub(crate) parent_commit_ids: Vec<CommitId>,
-    pub(crate) commit_change_id: crate::changelog::ChangeId,
-    pub(crate) account_id: String,
-    pub(crate) created_at: crate::common::LixTimestamp,
-    pub(crate) replay_debt: crate::tracked_state::types::CommitStateReplayDebt,
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
@@ -523,7 +504,6 @@ pub(crate) struct CommitDeltaInventory {
 
 struct CommitDeltaPlane {
     manifests: BTreeMap<CommitId, CommitDeltaManifest>,
-    authorities: BTreeMap<CommitId, CommitStateTopologyProjection>,
     segments: BTreeMap<CommitId, BTreeMap<usize, Bytes>>,
     segment_keys: BTreeMap<CommitId, BTreeMap<usize, Bytes>>,
 }
@@ -639,11 +619,11 @@ fn commit_state_inventory_from_delta_manifest(
 
 fn commit_delta_manifest_from_commit_state(manifest: &CommitStateManifest) -> CommitDeltaManifest {
     let mut delta = commit_delta_manifest_from_inventory(&manifest.mutations);
-    delta.account_id.clone_from(&manifest.account_id);
+    delta.account_id = manifest.change_account_id.clone();
     delta
 }
 
-/// Returns the exact collection scopes touched by a sealed mutation inventory.
+/// Returns the exact collection scopes touched by a certified mutation inventory.
 /// `None` means bounds or implicit cascades may affect another scope, in which
 /// case an inherited serving catalog must be discarded fail-closed.
 /// At an empty base, descriptor cascades cannot reach inherited rows, so their
@@ -1124,9 +1104,8 @@ pub(crate) async fn load_complete_current_state_values_from_scoped_root(
 }
 
 /// Uses a manifest returned by [`load_commit_state_manifest`] or
-/// [`load_commit_state_manifests`]. The opaque handle proves that the mutable
-/// manifest matched its immutable semantic authority in the caller's coherent
-/// read.
+/// [`load_commit_state_manifests`]. The opaque handle proves that the manifest
+/// came from the immutable physical authority in the caller's coherent read.
 #[cfg(feature = "storage-benches")]
 pub(crate) async fn load_complete_current_state_values_from_published_manifest(
     store: &(impl StorageAdapterRead + ?Sized),
@@ -1152,8 +1131,8 @@ pub(crate) async fn load_complete_current_state_values_from_replay_manifest(
     encoded_keys: &[Bytes],
 ) -> Result<Option<Vec<Option<TrackedStateIndexValue>>>, LixError> {
     // `load_point_replay_commit_state` decoded this exact manifest from the
-    // immutable semantic-authority seal, including its certified scoped root.
-    // Re-reading the mutable manifest would add point I/O without
+    // immutable physical manifest, including its certified scoped root.
+    // Re-reading the immutable manifest would add point I/O without
     // strengthening that authority.
     load_complete_current_state_values_encoded_inner(store, state, encoded_keys, false, true).await
 }
@@ -2118,23 +2097,49 @@ pub(crate) async fn load_root(
     store: &(impl StorageAdapterRead + ?Sized),
     commit_id: &str,
 ) -> Result<Option<TrackedStateRootId>, LixError> {
-    Ok(load_authoritative_commit_root(store, commit_id)
+    Ok(load_snapshot_commit_root(store, commit_id)
         .await?
         .map(|metadata| metadata.root_id))
 }
 
-/// Resolves snapshot metadata only through the hard-cut commit authority.
+/// Resolves canonical snapshot metadata from immutable physical authority.
 ///
-/// Tree chunks are content addressed; the commit-state manifest is the only
-/// durable mapping from a commit to a snapshot root.
-pub(crate) async fn load_authoritative_commit_root(
+/// Tree chunks are rebuildable by content hash, but the manifest-owned root
+/// pointer is the authority that permits readers to serve them.
+pub(crate) async fn load_snapshot_commit_root(
     store: &(impl StorageAdapterRead + ?Sized),
     commit_id: &str,
 ) -> Result<Option<TrackedStateCommitRoot>, LixError> {
-    let commit_id = CommitId::parse_lix(commit_id, "tracked-state authoritative root lookup")?;
+    let commit_id = CommitId::parse_lix(commit_id, "tracked-state snapshot root lookup")?;
+    let commit_ids = [commit_id];
+    let mut changelog = ChangelogContext::new().reader(store);
+    let semantic_commit_exists = changelog
+        .load_commits(CommitLoadRequest {
+            commit_ids: &commit_ids,
+        })
+        .await?
+        .into_iter()
+        .next()
+        .and_then(|(_, record)| record)
+        .is_some();
+    if !semantic_commit_exists {
+        return Ok(None);
+    }
+    load_manifest_snapshot_commit_root(store, commit_id).await
+}
+
+/// Loads the physical pointer without granting semantic commit liveness.
+///
+/// Only code that has already proved semantic liveness and integrity tests may
+/// use this helper; all commit-addressed read APIs must use
+/// [`load_snapshot_commit_root`].
+pub(super) async fn load_manifest_snapshot_commit_root(
+    store: &(impl StorageAdapterRead + ?Sized),
+    commit_id: CommitId,
+) -> Result<Option<TrackedStateCommitRoot>, LixError> {
     Ok(load_commit_state_manifest(store, commit_id)
         .await?
-        .and_then(|manifest| manifest.snapshot_root))
+        .and_then(|manifest| manifest.snapshot_root.map(|root| *root)))
 }
 
 fn commit_delta_manifest_key(commit_id: CommitId) -> Vec<u8> {
@@ -2145,93 +2150,23 @@ fn commit_state_manifest_key(commit_id: CommitId) -> Vec<u8> {
     commit_id.as_uuid().as_bytes().to_vec()
 }
 
-fn commit_state_semantic_seal(manifest: &CommitStateManifest) -> Result<Vec<u8>, LixError> {
-    // Retain the root published with the commit so one-read point replay can
-    // stop at its original baseline. A later rebuilt root may change only the
-    // mutable manifest; semantic comparison intentionally ignores that field.
-    let payload = storage_codec::encode("commit-state semantic authority", manifest)?;
-    let digest = blake3::Hasher::new_derive_key(COMMIT_STATE_SEMANTIC_AUTHORITY_HASH_CONTEXT)
-        .update(&payload)
-        .finalize();
-    let mut encoded = Vec::with_capacity(
-        COMMIT_STATE_SEMANTIC_AUTHORITY_MAGIC.len() + TRACKED_STATE_HASH_BYTES + payload.len(),
-    );
-    encoded.extend_from_slice(COMMIT_STATE_SEMANTIC_AUTHORITY_MAGIC);
-    encoded.extend_from_slice(digest.as_bytes());
-    encoded.extend_from_slice(&payload);
-    Ok(encoded)
-}
-
-fn decode_commit_state_semantic_authority(bytes: &[u8]) -> Result<CommitStateManifest, LixError> {
-    let payload = bytes
-        .strip_prefix(COMMIT_STATE_SEMANTIC_AUTHORITY_MAGIC)
-        .ok_or_else(|| {
-            replacement_payload_error("commit-state semantic authority has an unsupported format")
-        })?;
-    let (expected_digest, payload) = payload
-        .split_at_checked(TRACKED_STATE_HASH_BYTES)
-        .ok_or_else(|| replacement_payload_error("commit-state semantic authority is truncated"))?;
-    let actual_digest =
-        blake3::Hasher::new_derive_key(COMMIT_STATE_SEMANTIC_AUTHORITY_HASH_CONTEXT)
-            .update(payload)
-            .finalize();
-    if expected_digest != actual_digest.as_bytes() {
-        return Err(replacement_payload_error(
-            "commit-state semantic authority digest is invalid",
-        ));
-    }
-    let manifest = storage_codec::decode("commit-state semantic authority", payload)?;
-    // The immutable seal authenticates bytes, while local validation proves
-    // that those bytes describe a structurally valid serving authority. This
-    // is what lets one-read point replay trust a catalog leaf without loading
-    // the historical complete-replacement manifest that first created it.
-    validate_commit_state_manifest(&manifest)?;
-    Ok(manifest)
-}
-
-fn validate_commit_state_semantic_seal(
-    manifest: &CommitStateManifest,
-    seal: &[u8],
-) -> Result<(), LixError> {
-    let authority = decode_commit_state_semantic_authority(seal)?;
-    validate_commit_state_semantic_projection(manifest, &authority)
-}
-
-fn validate_commit_state_semantic_projection(
-    manifest: &CommitStateManifest,
-    authority: &CommitStateManifest,
-) -> Result<(), LixError> {
-    let mut manifest_semantics = manifest.clone();
-    manifest_semantics.snapshot_root = None;
-    let mut authority_semantics = authority.clone();
-    authority_semantics.snapshot_root = None;
-    if authority_semantics != manifest_semantics {
-        return Err(replacement_payload_error(
-            "commit-state manifest disagrees with its immutable semantic authority",
-        ));
-    }
-    Ok(())
-}
-
-/// Commit authority loaded from the mutable manifest plane after its
-/// immutable semantic authority was verified. Only this opaque handle may bypass
-/// publication-time catalog re-derivation.
+/// Commit authority loaded from the immutable manifest plane. Only this
+/// opaque handle may bypass publication-time catalog re-derivation.
 #[derive(Clone, Debug)]
 pub(crate) struct PublishedCommitStateManifest {
     manifest: CommitStateManifest,
 }
 
-/// One-read immutable semantic authority used by point replay. The wrapper
-/// prevents a freely constructed manifest from claiming authoritative catalog
-/// coverage without passing seal and structural validation.
+/// One-read immutable authority used by point replay. The wrapper prevents a
+/// freely constructed manifest from claiming authoritative catalog coverage.
 #[derive(Clone, Debug)]
 pub(crate) struct AuthenticatedReplayCommitStateManifest {
     manifest: CommitStateManifest,
 }
 
-/// Same-write-set authority produced only after semantic publication. This lets a
-/// later commit in one atomic transaction consume its parent catalog without
-/// treating a freely constructible manifest as provenance.
+/// Same-write-set authority produced only after immutable physical publication.
+/// This lets a later commit in one atomic transaction consume its parent catalog
+/// without treating a freely constructible manifest as provenance.
 pub(crate) struct StagedCommitStateManifest {
     manifest: CommitStateManifest,
     write_set_id: u64,
@@ -2365,7 +2300,7 @@ pub(crate) async fn stage_current_state_scoped_ranges_from_staged_parent(
 }
 
 /// Rewrites one exactly scoped current-state partition from its certified
-/// parent post-image and the current commit's sealed mutation parts. Untouched
+/// parent post-image and the current commit's certified mutation parts. Untouched
 /// parent descriptors are reused byte-for-byte; only intersecting bounded
 /// parts and insertion gaps become native current-state data parts.
 /// Rewrites one covered scope in the unified current-state serving tree.
@@ -3232,40 +3167,22 @@ fn commit_delta_segment_key_for_bounds(
     Ok(encoded)
 }
 
-/// Loads the hard-cut semantic authority for one tracked commit.
+/// Loads the immutable physical authority for one tracked commit.
 pub(crate) async fn load_commit_state_manifest(
     store: &(impl StorageAdapterRead + ?Sized),
     commit_id: CommitId,
 ) -> Result<Option<CommitStateManifest>, LixError> {
     #[cfg(feature = "storage-benches")]
     crate::storage_bench::record_crud_sealed_manifest_load();
-    let key = StorageKey(Bytes::from(commit_state_manifest_key(commit_id)));
-    let requests = [
-        StorageGetManyRequest {
-            space: TRACKED_STATE_COMMIT_STATE_MANIFEST_SPACE,
-            keys: std::slice::from_ref(&key),
-            opts: StorageGetOptions::default(),
-        },
-        StorageGetManyRequest {
-            space: TRACKED_STATE_COMMIT_STATE_SEAL_SPACE,
-            keys: std::slice::from_ref(&key),
-            opts: StorageGetOptions::default(),
-        },
-    ];
-    let mut values = exact_get_many(store, &requests).await?.values.into_iter();
-    let manifest_bytes = values.next().flatten().and_then(full_value_bytes);
-    let seal = values.next().flatten().and_then(full_value_bytes);
-    let Some(bytes) = manifest_bytes else {
-        if seal.is_some() {
-            return Err(replacement_payload_error(
-                "commit-state semantic authority has no mutable manifest",
-            ));
-        }
+    let Some(bytes) = get_one(
+        store,
+        TRACKED_STATE_COMMIT_STATE_MANIFEST_SPACE,
+        commit_state_manifest_key(commit_id),
+    )
+    .await?
+    else {
         return Ok(None);
     };
-    let seal = seal.ok_or_else(|| {
-        replacement_payload_error("commit-state manifest omitted its immutable semantic authority")
-    })?;
     let manifest = decode_commit_state_manifest(&bytes)?;
     if manifest.commit_id != commit_id {
         return Err(LixError::new(
@@ -3276,7 +3193,6 @@ pub(crate) async fn load_commit_state_manifest(
             ),
         ));
     }
-    validate_commit_state_semantic_seal(&manifest, &seal)?;
     Ok(Some(manifest))
 }
 
@@ -3289,7 +3205,7 @@ pub(crate) async fn load_published_commit_state_manifest(
         .map(|manifest| PublishedCommitStateManifest { manifest }))
 }
 
-/// Loads the replay projection after verifying immutable semantic authority.
+/// Loads the replay projection from immutable physical authority.
 pub(crate) async fn load_replay_commit_state_manifest(
     store: &(impl StorageAdapterRead + ?Sized),
     commit_id: CommitId,
@@ -3307,19 +3223,19 @@ pub(crate) async fn load_point_replay_commit_state(
     crate::storage_bench::record_crud_replay_manifest_load();
     let Some(authority) = get_one(
         store,
-        TRACKED_STATE_COMMIT_STATE_SEAL_SPACE,
+        TRACKED_STATE_COMMIT_STATE_MANIFEST_SPACE,
         commit_state_manifest_key(commit_id),
     )
     .await?
     else {
         return Ok(None);
     };
-    let state = decode_commit_state_semantic_authority(&authority)?;
+    let state = decode_commit_state_manifest(&authority)?;
     if state.commit_id != commit_id {
         return Err(LixError::new(
             LixError::CODE_INTERNAL_ERROR,
             format!(
-                "tracked_state semantic authority key for commit '{commit_id}' contains authority for commit '{}'",
+                "tracked_state manifest key for commit '{commit_id}' contains authority for commit '{}'",
                 state.commit_id
             ),
         ));
@@ -3338,41 +3254,21 @@ pub(crate) async fn load_commit_state_manifests(
         .iter()
         .map(|commit_id| StorageKey(Bytes::from(commit_state_manifest_key(*commit_id))))
         .collect::<Vec<_>>();
-    let requests = [
-        StorageGetManyRequest {
-            space: TRACKED_STATE_COMMIT_STATE_MANIFEST_SPACE,
-            keys: &keys,
-            opts: StorageGetOptions::default(),
-        },
-        StorageGetManyRequest {
-            space: TRACKED_STATE_COMMIT_STATE_SEAL_SPACE,
-            keys: &keys,
-            opts: StorageGetOptions::default(),
-        },
-    ];
-    let mut values = exact_get_many(store, &requests).await?.values.into_iter();
-    let manifests = values.by_ref().take(keys.len()).collect::<Vec<_>>();
-    let seals = values.collect::<Vec<_>>();
+    let request = [StorageGetManyRequest {
+        space: TRACKED_STATE_COMMIT_STATE_MANIFEST_SPACE,
+        keys: &keys,
+        opts: StorageGetOptions::default(),
+    }];
+    let manifests = exact_get_many(store, &request).await?.values;
     commit_ids
         .iter()
         .copied()
-        .zip(manifests.into_iter().zip(seals))
-        .map(|(commit_id, (manifest_value, seal_value))| {
+        .zip(manifests)
+        .map(|(commit_id, manifest_value)| {
             let manifest_bytes = manifest_value.and_then(full_value_bytes);
-            let seal = seal_value.and_then(full_value_bytes);
             let Some(bytes) = manifest_bytes else {
-                if seal.is_some() {
-                    return Err(replacement_payload_error(
-                        "commit-state semantic authority has no mutable manifest",
-                    ));
-                }
                 return Ok(None);
             };
-            let seal = seal.ok_or_else(|| {
-                replacement_payload_error(
-                    "commit-state manifest omitted its immutable semantic authority",
-                )
-            })?;
             let manifest = decode_commit_state_manifest(&bytes)?;
             if manifest.commit_id != commit_id {
                 return Err(LixError::new(
@@ -3383,38 +3279,9 @@ pub(crate) async fn load_commit_state_manifests(
                     ),
                 ));
             }
-            validate_commit_state_semantic_seal(&manifest, &seal)?;
             Ok(Some(manifest))
         })
         .collect()
-}
-
-/// Loads deliberately malformed authority without semantic validation so a
-/// corruption test can replace one forged record with another.
-#[cfg(test)]
-pub(crate) async fn load_unchecked_commit_state_manifest_for_test(
-    store: &(impl StorageAdapterRead + ?Sized),
-    commit_id: CommitId,
-) -> Result<Option<CommitStateManifest>, LixError> {
-    let Some(bytes) = get_one(
-        store,
-        TRACKED_STATE_COMMIT_STATE_MANIFEST_SPACE,
-        commit_state_manifest_key(commit_id),
-    )
-    .await?
-    else {
-        return Ok(None);
-    };
-    let payload = bytes
-        .strip_prefix(COMMIT_STATE_MANIFEST_FORMAT_MAGIC)
-        .ok_or_else(|| {
-            LixError::new(
-                LixError::CODE_INTERNAL_ERROR,
-                "tracked_state corrupt-test commit_state_manifest has an unsupported format",
-            )
-        })?;
-    let manifest = storage_codec::decode("tracked_state commit_state_manifest", payload)?;
-    Ok(Some(manifest))
 }
 
 async fn load_commit_delta_manifests(
@@ -3434,29 +3301,18 @@ async fn load_commit_delta_manifests(
     Ok(manifests)
 }
 
-/// Stages one complete commit authority record.
-///
-/// Callers must invoke this only after the immutable mutation inventory and
-/// optional snapshot metadata are final. Publishing a partially populated
-/// manifest and patching it later would make an intermediate representation
-/// authoritative to read-your-writes consumers.
+/// Stages one complete immutable physical commit authority record.
 fn stage_commit_state_manifest_bytes(
     writes: &mut StorageWriteSet,
     manifest: &CommitStateManifest,
 ) -> Result<(), LixError> {
     let encoded = encode_commit_state_manifest(manifest)?;
-    let seal = commit_state_semantic_seal(manifest)?;
     #[cfg(feature = "storage-benches")]
     crate::storage_bench::record_crud_commit_state_manifest_bytes(encoded.len());
     writes.put(
         TRACKED_STATE_COMMIT_STATE_MANIFEST_SPACE,
         key(commit_state_manifest_key(manifest.commit_id)),
         value(encoded),
-    );
-    writes.put(
-        TRACKED_STATE_COMMIT_STATE_SEAL_SPACE,
-        key(commit_state_manifest_key(manifest.commit_id)),
-        value(seal.to_vec()),
     );
     Ok(())
 }
@@ -3504,9 +3360,9 @@ pub(crate) fn stage_certified_commit_state_manifest(
             "physical publication proof belongs to a different storage write set",
         ));
     }
-    if manifest.parent_commit_ids != publication.parent_commit_ids() {
+    if manifest.commit_id != publication.commit_id() {
         return Err(replacement_payload_error(
-            "commit manifest graph-parent topology disagrees with its physical publication proof",
+            "commit manifest identity disagrees with its physical publication proof",
         ));
     }
     if manifest.mutations.selected_source_commit_id() != publication.selected_source_commit_id() {
@@ -3539,66 +3395,20 @@ pub(crate) fn stage_certified_commit_state_manifest_with_handle(
     })
 }
 
-/// Updates only the rebuildable snapshot accelerator of an already sealed
-/// authority. All semantic fields come from the opaque published handle and
-/// therefore retain the exact same immutable authority.
-pub(crate) fn stage_commit_state_snapshot_root_update(
-    writes: &mut StorageWriteSet,
-    published: &PublishedCommitStateManifest,
-    snapshot_root: Option<TrackedStateCommitRoot>,
-) -> Result<(), LixError> {
-    let mut manifest = published.manifest.clone();
-    manifest.snapshot_root = snapshot_root;
-    let encoded = encode_commit_state_manifest(&manifest)?;
-    writes.put(
-        TRACKED_STATE_COMMIT_STATE_MANIFEST_SPACE,
-        key(commit_state_manifest_key(manifest.commit_id)),
-        value(encoded),
-    );
-    Ok(())
-}
-
-/// Stages deliberately malformed authority for corruption tests. Production
-/// publication must always use [`stage_commit_state_manifest`].
-#[cfg(test)]
-pub(crate) fn stage_unchecked_commit_state_manifest_for_test(
-    writes: &mut StorageWriteSet,
-    manifest: &CommitStateManifest,
-) -> Result<(), LixError> {
-    let payload = storage_codec::encode("tracked_state commit_state_manifest", manifest)?;
-    let mut encoded = Vec::with_capacity(COMMIT_STATE_MANIFEST_FORMAT_MAGIC.len() + payload.len());
-    encoded.extend_from_slice(COMMIT_STATE_MANIFEST_FORMAT_MAGIC);
-    encoded.extend_from_slice(&payload);
-    writes.put(
-        TRACKED_STATE_COMMIT_STATE_MANIFEST_SPACE,
-        key(commit_state_manifest_key(manifest.commit_id)),
-        value(encoded),
-    );
-    Ok(())
-}
-
-/// Replaces both mutable manifest bytes and the normally immutable seal for a
-/// corruption/test-fixture scenario. Production code cannot compile a call to
-/// this bypass.
+/// Replaces immutable manifest bytes through a mutable test-only declaration.
 #[cfg(test)]
 pub(crate) fn stage_resealed_commit_state_manifest_for_test(
     writes: &mut StorageWriteSet,
     manifest: &CommitStateManifest,
 ) -> Result<(), LixError> {
     let encoded = encode_commit_state_manifest(manifest)?;
-    let seal = commit_state_semantic_seal(manifest)?;
-    writes.put(
-        TRACKED_STATE_COMMIT_STATE_MANIFEST_SPACE,
-        key(commit_state_manifest_key(manifest.commit_id)),
-        value(encoded),
-    );
     writes.put(
         StorageSpace::mutable(
-            TRACKED_STATE_COMMIT_STATE_SEAL_SPACE.id,
-            TRACKED_STATE_COMMIT_STATE_SEAL_NAMESPACE,
+            TRACKED_STATE_COMMIT_STATE_MANIFEST_SPACE.id,
+            TRACKED_STATE_COMMIT_STATE_MANIFEST_NAMESPACE,
         ),
         key(commit_state_manifest_key(manifest.commit_id)),
-        value(seal.to_vec()),
+        value(encoded),
     );
     Ok(())
 }
@@ -5856,10 +5666,8 @@ pub(crate) async fn load_commit_delta_values_encoded_from_replay_manifest(
         .await;
     }
     if point_cache.manifest(state.commit_id)?.is_none() {
-        point_cache.remember_manifest(
-            state.commit_id,
-            Arc::new(commit_delta_manifest_from_commit_state(state)),
-        )?;
+        let manifest = expanded_commit_delta_manifest_from_commit_state(store, state).await?;
+        point_cache.remember_manifest(state.commit_id, Arc::new(manifest))?;
     }
     load_commit_delta_values_encoded_with_cache(
         store,
@@ -6895,7 +6703,7 @@ async fn load_inventory_part_entries_one_ordered(
                 &payloads,
                 &encoded_keys[encoded],
                 commit_id,
-                &state.account_id,
+                &state.change_account_id,
             )?;
         }
     }
@@ -7739,19 +7547,7 @@ pub(crate) async fn visit_change_records_from_commit_deltas(
                 },
             )
             .await?;
-        let seal_keys = page
-            .value
-            .entries
-            .iter()
-            .map(|entry| entry.key.clone())
-            .collect::<Vec<_>>();
-        let seal_request = [StorageGetManyRequest {
-            space: TRACKED_STATE_COMMIT_STATE_SEAL_SPACE,
-            keys: &seal_keys,
-            opts: StorageGetOptions::default(),
-        }];
-        let seals = exact_get_many(store, &seal_request).await?.values;
-        for (entry, seal) in page.value.entries.iter().zip(seals) {
+        for entry in &page.value.entries {
             if entry.key.0.len() != 16 {
                 return Err(LixError::new(
                     LixError::CODE_INTERNAL_ERROR,
@@ -7769,12 +7565,6 @@ pub(crate) async fn visit_change_records_from_commit_deltas(
                     "tracked_state commit-state scan key and manifest commit disagree",
                 ));
             }
-            let seal = seal.and_then(full_value_bytes).ok_or_else(|| {
-                replacement_payload_error(
-                    "commit-state scan found a manifest without its immutable semantic authority",
-                )
-            })?;
-            validate_commit_state_semantic_seal(&state, &seal)?;
             let manifest = expanded_commit_delta_manifest_from_commit_state(store, &state).await?;
             if let Some(parts) = manifest.columnar_parts.as_ref() {
                 emitted = emitted.saturating_add(
@@ -7988,7 +7778,6 @@ pub(crate) async fn scan_commit_delta_inventory(
 ) -> Result<CommitDeltaInventory, LixError> {
     let CommitDeltaPlane {
         manifests,
-        mut authorities,
         mut segments,
         mut segment_keys,
     } = scan_commit_delta_plane(store).await?;
@@ -8059,9 +7848,6 @@ pub(crate) async fn scan_commit_delta_inventory(
                     })
                     .collect::<Result<Vec<_>, _>>()?,
                 selected_source_commit_id: manifest.selected_source_commit_id(),
-                authority: authorities
-                    .remove(&commit_id)
-                    .expect("every decoded mutation manifest has topology authority"),
             },
         );
     }
@@ -8133,7 +7919,6 @@ pub(crate) async fn scan_commit_delta_inventory(
     }
     debug_assert!(segments.is_empty());
     debug_assert!(segment_keys.is_empty());
-    debug_assert!(authorities.is_empty());
     Ok(inventory)
 }
 
@@ -8142,23 +7927,10 @@ async fn scan_commit_delta_plane(
 ) -> Result<CommitDeltaPlane, LixError> {
     let commit_state_rows =
         scan_full_space(store, TRACKED_STATE_COMMIT_STATE_MANIFEST_SPACE).await?;
-    let commit_state_seals = scan_full_space(store, TRACKED_STATE_COMMIT_STATE_SEAL_SPACE).await?;
     let segment_rows = scan_full_space(store, TRACKED_STATE_COMMIT_DELTA_SEGMENT_SPACE).await?;
 
-    if commit_state_rows.len() != commit_state_seals.len()
-        || commit_state_rows
-            .iter()
-            .zip(&commit_state_seals)
-            .any(|((manifest_key, _), (seal_key, _))| manifest_key != seal_key)
-    {
-        return Err(replacement_payload_error(
-            "commit-state inventory found an orphan manifest or semantic authority",
-        ));
-    }
-
     let mut manifests = BTreeMap::<CommitId, CommitDeltaManifest>::new();
-    let mut authorities = BTreeMap::<CommitId, CommitStateTopologyProjection>::new();
-    for ((key, bytes), (_, seal)) in commit_state_rows.into_iter().zip(commit_state_seals) {
+    for (key, bytes) in commit_state_rows {
         if key.0.len() != 16 {
             return Err(LixError::new(
                 LixError::CODE_INTERNAL_ERROR,
@@ -8175,18 +7947,6 @@ async fn scan_commit_delta_plane(
                 ),
             ));
         }
-        validate_commit_state_semantic_seal(&manifest, &seal)?;
-        authorities.insert(
-            commit_id,
-            CommitStateTopologyProjection {
-                generation: manifest.generation,
-                parent_commit_ids: manifest.parent_commit_ids.clone(),
-                commit_change_id: manifest.commit_change_id,
-                account_id: manifest.account_id.clone(),
-                created_at: manifest.created_at,
-                replay_debt: manifest.replay_debt,
-            },
-        );
         manifests.insert(
             commit_id,
             expanded_commit_delta_manifest_from_commit_state(store, &manifest).await?,
@@ -8242,7 +8002,6 @@ async fn scan_commit_delta_plane(
 
     Ok(CommitDeltaPlane {
         manifests,
-        authorities,
         segments,
         segment_keys,
     })
@@ -8297,10 +8056,6 @@ pub(crate) fn stage_delete_commit_delta_inventory_entry(
 ) -> Result<(), LixError> {
     writes.delete(
         TRACKED_STATE_COMMIT_STATE_MANIFEST_SPACE,
-        key(commit_state_manifest_key(commit_id)),
-    );
-    writes.delete(
-        TRACKED_STATE_COMMIT_STATE_SEAL_SPACE,
         key(commit_state_manifest_key(commit_id)),
     );
     for segment_key in &entry.physical_segment_keys {
@@ -8565,8 +8320,7 @@ pub(crate) async fn load_commit_delta_replay_metadata_with_cache(
         .map(|manifest| commit_delta_replay_metadata_from_inventory(&manifest.mutations)))
 }
 
-/// Seeds the snapshot-local delta cache from the seal-verified replay manifest
-/// already read by point traversal, avoiding a second authority read.
+/// Returns replay metadata from an already authenticated physical manifest.
 pub(crate) fn seed_commit_delta_point_cache_from_replay_manifest(
     state: &CommitStateManifest,
     point_cache: &CommitDeltaPointReadCache,
@@ -9996,7 +9750,6 @@ pub(crate) struct TrackedStateStagedRead<'a, S: ?Sized> {
     store: &'a S,
     chunks: &'a TrackedStateChunkOverlay,
     commit_states: HashMap<Vec<u8>, Bytes>,
-    commit_state_seals: HashMap<Vec<u8>, Bytes>,
 }
 
 impl<'a, S> TrackedStateStagedRead<'a, S>
@@ -10008,39 +9761,36 @@ where
             store,
             chunks,
             commit_states: HashMap::new(),
-            commit_state_seals: HashMap::new(),
         }
     }
 
-    pub(crate) fn with_commit_state_manifests(
+    pub(crate) fn with_commit_state_roots(
         store: &'a S,
         chunks: &'a TrackedStateChunkOverlay,
-        manifests: impl IntoIterator<Item = CommitStateManifest>,
+        commit_states: impl IntoIterator<Item = (CommitStateManifest, TrackedStateCommitRoot)>,
     ) -> Result<Self, LixError> {
-        let manifests = manifests.into_iter().collect::<Vec<_>>();
-        let commit_states = manifests
-            .iter()
-            .map(|manifest| {
+        let manifests = commit_states
+            .into_iter()
+            .map(|(mut manifest, root)| {
+                if manifest.commit_id != root.commit_id {
+                    return Err(replacement_payload_error(
+                        "staged snapshot root belongs to a different commit manifest",
+                    ));
+                }
+                // This overlay exists only to audit the staged canonical root;
+                // it is never published as immutable commit authority.
+                manifest.replay_debt = Default::default();
+                manifest.snapshot_root = Some(Box::new(root));
                 Ok((
                     commit_state_manifest_key(manifest.commit_id),
-                    Bytes::from(encode_commit_state_manifest(manifest)?),
-                ))
-            })
-            .collect::<Result<HashMap<_, _>, LixError>>()?;
-        let commit_state_seals = manifests
-            .iter()
-            .map(|manifest| {
-                Ok((
-                    commit_state_manifest_key(manifest.commit_id),
-                    Bytes::copy_from_slice(&commit_state_semantic_seal(manifest)?),
+                    Bytes::from(encode_commit_state_manifest(&manifest)?),
                 ))
             })
             .collect::<Result<HashMap<_, _>, LixError>>()?;
         Ok(Self {
             store,
             chunks,
-            commit_states,
-            commit_state_seals,
+            commit_states: manifests,
         })
     }
 
@@ -10051,9 +9801,6 @@ where
         }
         if space == TRACKED_STATE_COMMIT_STATE_MANIFEST_SPACE.id {
             return self.commit_states.get(key.0.as_ref()).cloned();
-        }
-        if space == TRACKED_STATE_COMMIT_STATE_SEAL_SPACE.id {
-            return self.commit_state_seals.get(key.0.as_ref()).cloned();
         }
         None
     }
@@ -10152,45 +9899,6 @@ fn validate_commit_state_manifest_inner(
     manifest: &CommitStateManifest,
     validate_scoped_range_attestation: bool,
 ) -> Result<(), LixError> {
-    let mut parents = BTreeSet::new();
-    for parent in &manifest.parent_commit_ids {
-        if *parent == manifest.commit_id || !parents.insert(*parent) {
-            return Err(LixError::new(
-                LixError::CODE_INTERNAL_ERROR,
-                "tracked_state commit_state_manifest has a self or duplicate parent",
-            ));
-        }
-    }
-
-    match &manifest.snapshot_root {
-        Some(root) => {
-            if root.commit_id != manifest.commit_id {
-                return Err(LixError::new(
-                    LixError::CODE_INTERNAL_ERROR,
-                    "tracked_state commit_state_manifest snapshot belongs to another commit",
-                ));
-            }
-            if root.parent_roots.first().map(|parent| parent.commit_id)
-                != manifest.parent_commit_ids.first().copied()
-                || root
-                    .parent_roots
-                    .iter()
-                    .any(|parent| !parents.contains(&parent.commit_id))
-            {
-                return Err(LixError::new(
-                    LixError::CODE_INTERNAL_ERROR,
-                    "tracked_state commit_state_manifest snapshot ancestry disagrees with commit topology",
-                ));
-            }
-        }
-        None if manifest.replay_debt.depth == 0 => {
-            return Err(LixError::new(
-                LixError::CODE_INTERNAL_ERROR,
-                "tracked_state rootless commit_state_manifest has zero replay depth",
-            ));
-        }
-        None => {}
-    }
     if manifest.replay_debt.depth == 0
         && (manifest.replay_debt.rows != 0 || manifest.replay_debt.bytes != 0)
     {
@@ -10206,6 +9914,26 @@ fn validate_commit_state_manifest_inner(
             LixError::CODE_INTERNAL_ERROR,
             "tracked_state commit_state_manifest replay debt exceeds the protocol bound",
         ));
+    }
+    if manifest.replay_debt.depth == 0 && manifest.snapshot_root.is_none() {
+        return Err(LixError::new(
+            LixError::CODE_INTERNAL_ERROR,
+            "tracked_state rooted commit_state_manifest is missing its snapshot root",
+        ));
+    }
+    if let Some(root) = manifest.snapshot_root.as_ref() {
+        if root.commit_id != manifest.commit_id {
+            return Err(LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                "tracked_state commit_state_manifest snapshot root belongs to a different commit",
+            ));
+        }
+        if manifest.replay_debt.depth != 0 {
+            return Err(LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                "tracked_state rootless commit_state_manifest cannot publish a snapshot root",
+            ));
+        }
     }
 
     validate_commit_state_mutation_inventory(manifest.commit_id, &manifest.mutations)?;
@@ -10235,13 +9963,8 @@ fn validate_current_state_scoped_ranges(
         ));
     }
     if let Some(root) = manifest.current_state_scoped_ranges.as_ref() {
-        let expected_serving_base = manifest
-            .mutations
-            .selected_source_commit_id()
-            .or_else(|| manifest.parent_commit_ids.first().copied());
-        if root.serving_base_commit_id.is_some()
-            && root.serving_base_commit_id != expected_serving_base
-        {
+        let selected_source = manifest.mutations.selected_source_commit_id();
+        if selected_source.is_some() && root.serving_base_commit_id != selected_source {
             return Err(LixError::new(
                 LixError::CODE_INTERNAL_ERROR,
                 "tracked_state current-state serving base disagrees with commit authority",
@@ -10475,7 +10198,7 @@ mod tests {
     };
     use crate::branch::BRANCH_HEAD_CONTROL_SPACE;
     use crate::changelog::{
-        CHANGE_SPACE, COMMIT_CHANGE_ID_SPACE, COMMIT_SPACE, ChangeId, CommitId,
+        CHANGE_SPACE, COMMIT_CHANGE_ID_SPACE, COMMIT_SPACE, ChangeId, CommitId, CommitRecord,
     };
     use crate::common::LixTimestamp;
     use crate::entity_pk::EntityPk;
@@ -10496,10 +10219,9 @@ mod tests {
     };
     use crate::tracked_state::types::{
         CommitStateManifest, CommitStateMutationInventory, CommitStateReplayDebt,
-        CurrentStatePartDescriptor, TRACKED_STATE_HASH_BYTES, TrackedStateBaseCoordinate,
-        TrackedStateCommitDeltaRef, TrackedStateCommitRoot, TrackedStateDeltaRef,
-        TrackedStateIndexValue, TrackedStateIndexValueRef, TrackedStateKey, TrackedStateKeyRef,
-        TrackedStateRootId,
+        CurrentStatePartDescriptor, TrackedStateBaseCoordinate, TrackedStateCommitDeltaRef,
+        TrackedStateCommitRoot, TrackedStateDeltaRef, TrackedStateIndexValue,
+        TrackedStateIndexValueRef, TrackedStateKey, TrackedStateKeyRef, TrackedStateRootId,
     };
 
     use super::{
@@ -10765,13 +10487,12 @@ mod tests {
         );
     }
 
-    struct SealCountingRead<R> {
+    struct ManifestCountingRead<R> {
         inner: R,
         manifest_requests: std::sync::Arc<AtomicUsize>,
-        seal_requests: std::sync::Arc<AtomicUsize>,
     }
 
-    impl<R> crate::storage_adapter::StorageAdapterRead for SealCountingRead<R>
+    impl<R> crate::storage_adapter::StorageAdapterRead for ManifestCountingRead<R>
     where
         R: crate::storage_adapter::StorageAdapterRead,
     {
@@ -10788,9 +10509,6 @@ mod tests {
             for request in requests {
                 if request.space == super::TRACKED_STATE_COMMIT_STATE_MANIFEST_SPACE {
                     self.manifest_requests.fetch_add(1, Ordering::Relaxed);
-                }
-                if request.space == super::TRACKED_STATE_COMMIT_STATE_SEAL_SPACE {
-                    self.seal_requests.fetch_add(1, Ordering::Relaxed);
                 }
             }
             self.inner.get_many(requests)
@@ -10813,11 +10531,7 @@ mod tests {
     ) -> CommitStateManifest {
         CommitStateManifest {
             commit_id,
-            generation: 0,
-            parent_commit_ids: Vec::new(),
-            commit_change_id: ChangeId::for_test_label(&format!("{commit_id}:commit")),
-            account_id: crate::ANONYMOUS_ACCOUNT_ID.to_string(),
-            created_at: LixTimestamp::from_unix_millis_utc_lossy(0),
+            change_account_id: crate::ANONYMOUS_ACCOUNT_ID.to_string(),
             replay_debt: CommitStateReplayDebt {
                 depth: 1,
                 rows: u64::from(mutations.member_count),
@@ -10835,6 +10549,20 @@ mod tests {
         commit_id: CommitId,
         mutations: &CommitStateMutationInventory,
     ) -> Result<(), LixError> {
+        let record = CommitRecord {
+            format_version: 2,
+            commit_id,
+            generation: 0,
+            parent_commit_ids: Vec::new(),
+            change_id: ChangeId::for_test_label(&format!("{commit_id}:fixture-commit")),
+            account_id: crate::ANONYMOUS_ACCOUNT_ID.to_string(),
+            created_at: LixTimestamp::from_unix_millis_utc_lossy(0),
+        };
+        writes.put(
+            COMMIT_SPACE,
+            key(commit_id.as_uuid().as_bytes().to_vec()),
+            value(crate::changelog::encode_commit_record(&record)?),
+        );
         stage_commit_state_manifest(
             writes,
             &fixture_commit_state_manifest(commit_id, mutations.clone()),
@@ -12370,7 +12098,7 @@ mod tests {
         assert_eq!(
             writes.stats().staged_puts,
             5,
-            "generic history keeps 300 compact rows in three read-friendly segments plus its commit-state authority and immutable seal"
+            "generic history keeps 300 compact rows in three read-friendly segments plus its physical authority and semantic owner"
         );
         storage
             .commit_write_set(writes, StorageWriteOptions::default())
@@ -12566,7 +12294,7 @@ mod tests {
         assert_eq!(
             writes.stats().staged_puts,
             4,
-            "the oversized four-row candidate should become two segments plus its commit-state authority and immutable seal"
+            "the oversized four-row candidate should become two segments plus its physical authority and semantic owner"
         );
         storage
             .commit_write_set(writes, StorageWriteOptions::default())
@@ -13361,7 +13089,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn shallow_point_replay_reads_one_immutable_semantic_authority() {
+    async fn shallow_point_replay_reads_one_immutable_physical_authority() {
         let storage = StorageAdapter::new(Memory::new());
         let commit_id = CommitId::for_test_label("one-read-shallow-point-replay");
         let fixture = packed_commit_delta_fixtures()
@@ -13383,14 +13111,12 @@ mod tests {
             .expect("ordinary delta should commit");
 
         let manifest_requests = std::sync::Arc::new(AtomicUsize::new(0));
-        let seal_requests = std::sync::Arc::new(AtomicUsize::new(0));
-        let read = SealCountingRead {
+        let read = ManifestCountingRead {
             inner: storage
                 .begin_read(StorageReadOptions::default())
                 .await
                 .expect("point read should open"),
             manifest_requests: std::sync::Arc::clone(&manifest_requests),
-            seal_requests: std::sync::Arc::clone(&seal_requests),
         };
         let state = super::load_replay_commit_state_manifest(&read, commit_id)
             .await
@@ -13413,8 +13139,7 @@ mod tests {
         .await
         .expect("cached shallow point replay should load");
         assert_eq!(values, vec![Some(fixture.value(commit_id))]);
-        assert_eq!(manifest_requests.load(Ordering::Relaxed), 0);
-        assert_eq!(seal_requests.load(Ordering::Relaxed), 1);
+        assert_eq!(manifest_requests.load(Ordering::Relaxed), 1);
     }
 
     #[tokio::test]
@@ -13437,7 +13162,7 @@ mod tests {
         assert_eq!(
             writes.stats().staged_puts,
             2,
-            "a one-segment commit should remain inline in its commit-state authority plus immutable seal"
+            "a one-segment commit should remain inline in its physical authority plus semantic owner"
         );
         storage
             .commit_write_set(writes, StorageWriteOptions::default())
@@ -13478,8 +13203,8 @@ mod tests {
         .expect("inline delta should stage for deletion");
         assert_eq!(
             deletes.stats().staged_deletes,
-            2,
-            "GC should delete the inline commit-state authority and immutable seal"
+            1,
+            "physical inventory deletion should remove its single manifest authority"
         );
     }
 
@@ -13620,7 +13345,7 @@ mod tests {
                 .get(&commit_id)
                 .expect("packed commit should be inventoried")
                 .segment_count
-                + 2,
+                + 1,
         )
         .expect("test segment count fits u64");
         assert_eq!(deletes.stats().staged_deletes, expected_deletes);
@@ -13832,11 +13557,7 @@ mod tests {
         };
         CommitStateManifest {
             commit_id,
-            generation: 7,
-            parent_commit_ids: vec![CommitId::for_test_label("manifest-parent")],
-            commit_change_id: ChangeId::for_test_label("manifest-commit-change"),
-            account_id: "account-a".to_string(),
-            created_at: timestamp,
+            change_account_id: crate::ANONYMOUS_ACCOUNT_ID.to_string(),
             replay_debt: CommitStateReplayDebt {
                 depth: 2,
                 rows: 1,
@@ -13878,6 +13599,7 @@ mod tests {
     #[test]
     fn commit_state_manifest_codec_authenticates_scoped_range_root() {
         let mut manifest = commit_state_manifest_fixture();
+        let serving_base_commit_id = None;
         let tree = super::super::scoped_range::ScopedRangeRoot {
             root_id: [7; 32],
             root_digest: [8; 32],
@@ -13886,8 +13608,7 @@ mod tests {
             row_count: 17,
             tree_height: 1,
         };
-        let serving_base_commit_id = manifest.parent_commit_ids.first().copied();
-        let serving_base_root_id = Some([9; 32]);
+        let serving_base_root_id = None;
         let transition_digest = super::super::scoped_current_state::scoped_range_transition_digest(
             manifest.commit_id,
             serving_base_commit_id,
@@ -13918,40 +13639,6 @@ mod tests {
     }
 
     #[test]
-    fn commit_state_manifest_codec_rejects_wrong_serving_base() {
-        let mut manifest = commit_state_manifest_fixture();
-        let tree = super::super::scoped_range::ScopedRangeRoot {
-            root_id: [7; 32],
-            root_digest: [8; 32],
-            marker_count: 1,
-            part_count: 2,
-            row_count: 17,
-            tree_height: 1,
-        };
-        let wrong_base = CommitId::for_test_label("wrong-serving-base");
-        let serving_base_root_id = Some([9; 32]);
-        let transition_digest = super::super::scoped_current_state::scoped_range_transition_digest(
-            manifest.commit_id,
-            Some(wrong_base),
-            serving_base_root_id,
-            &manifest.mutations,
-            &tree,
-        )
-        .expect("transition should hash");
-        manifest.current_state_scoped_ranges =
-            Some(Box::new(super::super::types::CurrentStateScopedRangeRoot {
-                tree,
-                serving_base_commit_id: Some(wrong_base),
-                serving_base_root_id,
-                transition_digest,
-            }));
-
-        let error = encode_commit_state_manifest(&manifest)
-            .expect_err("serving base outside commit authority must fail closed");
-        assert!(error.message.contains("serving base"));
-    }
-
-    #[test]
     fn commit_state_manifest_codec_rejects_pre_cut_formats() {
         let manifest = commit_state_manifest_fixture();
         let payload = storage_codec::encode("tracked_state commit_state_manifest", &manifest)
@@ -13968,31 +13655,6 @@ mod tests {
                 .expect_err("the hard cut must reject pre-v7 manifest formats");
             assert!(error.message.contains("unsupported format"));
         }
-
-        for magic in [
-            b"LXSA1".as_slice(),
-            b"LXSA2".as_slice(),
-            b"LXSA3".as_slice(),
-            b"LXSA4".as_slice(),
-        ] {
-            let mut legacy_seal = magic.to_vec();
-            legacy_seal.extend_from_slice(&[0; TRACKED_STATE_HASH_BYTES]);
-            legacy_seal.extend_from_slice(&payload);
-            let error = super::decode_commit_state_semantic_authority(&legacy_seal)
-                .expect_err("the hard cut must reject pre-v4 semantic seals");
-            assert!(error.message.contains("unsupported format"));
-        }
-
-        let legacy_digest =
-            blake3::Hasher::new_derive_key("lix.commit-state.semantic-authority.v4")
-                .update(&payload)
-                .finalize();
-        let mut retagged_v4 = super::COMMIT_STATE_SEMANTIC_AUTHORITY_MAGIC.to_vec();
-        retagged_v4.extend_from_slice(legacy_digest.as_bytes());
-        retagged_v4.extend_from_slice(&payload);
-        let error = super::decode_commit_state_semantic_authority(&retagged_v4)
-            .expect_err("an LXSA4 digest must not become valid under an LXSA5 prefix");
-        assert!(error.message.contains("digest is invalid"));
     }
 
     #[tokio::test]
@@ -14019,135 +13681,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn semantic_authority_is_the_point_source_and_guards_manifest_scans() {
-        let storage = StorageAdapter::new(Memory::new());
-        let manifest = commit_state_manifest_fixture();
-        let mut writes = storage.new_write_set();
-        stage_commit_state_manifest(&mut writes, &manifest).expect("authority should stage");
-        storage
-            .commit_write_set(writes, StorageWriteOptions::default())
-            .await
-            .expect("authority should commit");
-
-        let mut forged = manifest.clone();
-        forged.generation += 1;
-        let mut writes = storage.new_write_set();
-        super::stage_unchecked_commit_state_manifest_for_test(&mut writes, &forged)
-            .expect("mutable manifest corruption should stage without replacing authority");
-        storage
-            .commit_write_set(writes, StorageWriteOptions::default())
-            .await
-            .expect("mutable manifest corruption should commit");
-
-        let read = storage
-            .begin_read(StorageReadOptions::default())
-            .await
-            .expect("corrupt read should open");
-        let point_state = super::load_point_replay_commit_state(&read, manifest.commit_id)
-            .await
-            .expect("point replay should load immutable semantic authority")
-            .expect("semantic authority should exist");
-        assert_eq!(&*point_state, &manifest);
-        let change_error = scan_change_records_from_commit_deltas(&read)
-            .await
-            .expect_err("packed change scans must verify semantic authority");
-        assert!(change_error.message.contains("semantic authority"));
-        let inventory_error = scan_commit_delta_inventory(&read)
-            .await
-            .expect_err("GC inventory must verify semantic authority");
-        assert!(inventory_error.message.contains("semantic authority"));
-
-        let mut corrupted_authority =
-            super::commit_state_semantic_seal(&manifest).expect("semantic authority should encode");
-        *corrupted_authority
-            .last_mut()
-            .expect("semantic authority should not be empty") ^= 0xff;
-        let mut writes = storage.new_write_set();
-        writes.put(
-            StorageSpace::mutable(
-                super::TRACKED_STATE_COMMIT_STATE_SEAL_SPACE.id,
-                super::TRACKED_STATE_COMMIT_STATE_SEAL_NAMESPACE,
-            ),
-            key(super::commit_state_manifest_key(manifest.commit_id)),
-            value(corrupted_authority),
-        );
-        storage
-            .commit_write_set(writes, StorageWriteOptions::default())
-            .await
-            .expect("authority corruption should commit through the test-only mutable alias");
-        let read = storage
-            .begin_read(StorageReadOptions::default())
-            .await
-            .expect("corrupt authority read should open");
-        let error = super::load_point_replay_commit_state(&read, manifest.commit_id)
-            .await
-            .expect_err("point replay must reject corrupt immutable authority bytes");
-        assert!(error.message.contains("authority digest"));
-    }
-
-    #[tokio::test]
-    async fn gc_inventory_rejects_missing_and_orphan_semantic_authority() {
-        let missing_storage = StorageAdapter::new(Memory::new());
-        let manifest = commit_state_manifest_fixture();
-        let mut writes = missing_storage.new_write_set();
-        stage_commit_state_manifest(&mut writes, &manifest).expect("authority should stage");
-        missing_storage
-            .commit_write_set(writes, StorageWriteOptions::default())
-            .await
-            .expect("authority should commit");
-        let mut deletes = missing_storage.new_write_set();
-        deletes.delete(
-            super::TRACKED_STATE_COMMIT_STATE_SEAL_SPACE,
-            key(super::commit_state_manifest_key(manifest.commit_id)),
-        );
-        missing_storage
-            .commit_write_set(deletes, StorageWriteOptions::default())
-            .await
-            .expect("seal deletion should commit");
-        let read = missing_storage
-            .begin_read(StorageReadOptions::default())
-            .await
-            .expect("missing-seal read should open");
-        let error = scan_commit_delta_inventory(&read)
-            .await
-            .expect_err("GC inventory must reject a missing seal");
-        assert!(
-            error
-                .message
-                .contains("orphan manifest or semantic authority")
-        );
-
-        let orphan_storage = StorageAdapter::new(Memory::new());
-        let mut writes = orphan_storage.new_write_set();
-        writes.put(
-            super::TRACKED_STATE_COMMIT_STATE_SEAL_SPACE,
-            key(super::commit_state_manifest_key(manifest.commit_id)),
-            value(
-                super::commit_state_semantic_seal(&manifest)
-                    .unwrap()
-                    .to_vec(),
-            ),
-        );
-        orphan_storage
-            .commit_write_set(writes, StorageWriteOptions::default())
-            .await
-            .expect("orphan seal should commit");
-        let read = orphan_storage
-            .begin_read(StorageReadOptions::default())
-            .await
-            .expect("orphan-seal read should open");
-        let error = scan_commit_delta_inventory(&read)
-            .await
-            .expect_err("GC inventory must reject an orphan seal");
-        assert!(
-            error
-                .message
-                .contains("orphan manifest or semantic authority")
-        );
-    }
-
-    #[tokio::test]
-    async fn authoritative_root_is_visible_only_through_commit_state() {
+    async fn manifest_root_does_not_grant_semantic_commit_liveness() {
         let storage = StorageAdapter::new(Memory::new());
         let mut manifest = commit_state_manifest_fixture();
         manifest.replay_debt = CommitStateReplayDebt::default();
@@ -14155,7 +13689,7 @@ mod tests {
             commit_id: manifest.commit_id,
             root_id: TrackedStateRootId::new([1; 32]),
             parent_roots: vec![crate::tracked_state::types::TrackedStateCommitRootParent {
-                commit_id: manifest.parent_commit_ids[0],
+                commit_id: CommitId::for_test_label("snapshot-parent"),
                 root_id: TrackedStateRootId::new([3; 32]),
             }],
             changed_key_count: 1,
@@ -14164,8 +13698,8 @@ mod tests {
             primary_chunk_count: 1,
             primary_chunk_bytes: 64,
         };
-        manifest.snapshot_root = Some(authoritative.clone());
         let mut writes = storage.new_write_set();
+        manifest.snapshot_root = Some(Box::new(authoritative.clone()));
         stage_commit_state_manifest(&mut writes, &manifest).expect("authority should stage");
         storage
             .commit_write_set(writes, StorageWriteOptions::default())
@@ -14176,71 +13710,40 @@ mod tests {
             .await
             .expect("read should open");
 
-        assert_eq!(
-            super::load_authoritative_commit_root(&read, &manifest.commit_id.to_string())
+        assert!(
+            super::load_snapshot_commit_root(&read, &manifest.commit_id.to_string())
                 .await
-                .expect("authority should load"),
+                .expect("authorized root lookup should succeed")
+                .is_none(),
+            "physical retention alone must not make a missing semantic commit readable"
+        );
+        assert_eq!(
+            super::load_manifest_snapshot_commit_root(&read, manifest.commit_id)
+                .await
+                .expect("physical root should load"),
             Some(authoritative)
         );
-        drop(read);
-
-        manifest.snapshot_root = None;
-        manifest.replay_debt = CommitStateReplayDebt {
-            depth: 1,
-            rows: 1,
-            bytes: 64,
-        };
-        let mut writes = storage.new_write_set();
-        super::stage_resealed_commit_state_manifest_for_test(&mut writes, &manifest)
-            .expect("rootless authority should stage");
-        storage
-            .commit_write_set(writes, StorageWriteOptions::default())
-            .await
-            .expect("rootless authority should commit");
-        let read = storage
-            .begin_read(StorageReadOptions::default())
-            .await
-            .expect("rootless read should open");
-        assert!(
-            super::load_authoritative_commit_root(&read, &manifest.commit_id.to_string())
+        assert_eq!(
+            load_commit_state_manifest(&read, manifest.commit_id)
                 .await
-                .expect("rootless authority should load")
-                .is_none(),
-            "a stale derived root must not override rootless authority"
+                .expect("manifest should load"),
+            Some(manifest)
         );
     }
 
     #[tokio::test]
-    async fn rootless_rebuild_updates_only_the_mutable_snapshot_accelerator() {
-        let storage = StorageAdapter::new(Memory::new());
+    async fn rootless_manifest_rejects_snapshot_authority() {
         let mut original = commit_state_manifest_fixture();
-        original.snapshot_root = None;
         original.replay_debt = CommitStateReplayDebt {
             depth: 1,
             rows: 1,
             bytes: 64,
         };
-        let mut writes = storage.new_write_set();
-        stage_commit_state_manifest(&mut writes, &original)
-            .expect("rootless authority should stage");
-        storage
-            .commit_write_set(writes, StorageWriteOptions::default())
-            .await
-            .expect("rootless authority should commit");
-
-        let read = storage
-            .begin_read(StorageReadOptions::default())
-            .await
-            .expect("published authority read should open");
-        let published = super::load_published_commit_state_manifest(&read, original.commit_id)
-            .await
-            .expect("published authority should load")
-            .expect("published authority should exist");
         let rebuilt = TrackedStateCommitRoot {
             commit_id: original.commit_id,
             root_id: TrackedStateRootId::new([9; 32]),
             parent_roots: vec![crate::tracked_state::types::TrackedStateCommitRootParent {
-                commit_id: original.parent_commit_ids[0],
+                commit_id: CommitId::for_test_label("rebuild-parent"),
                 root_id: TrackedStateRootId::new([8; 32]),
             }],
             changed_key_count: 1,
@@ -14249,33 +13752,20 @@ mod tests {
             primary_chunk_count: 1,
             primary_chunk_bytes: 64,
         };
-        let mut writes = storage.new_write_set();
-        super::stage_commit_state_snapshot_root_update(
-            &mut writes,
-            &published,
-            Some(rebuilt.clone()),
-        )
-        .expect("snapshot accelerator update should stage");
-        drop(read);
-        storage
-            .commit_write_set(writes, StorageWriteOptions::default())
-            .await
-            .expect("snapshot rebuild must not rewrite immutable authority");
+        original.snapshot_root = Some(Box::new(rebuilt));
+        let error = encode_commit_state_manifest(&original)
+            .expect_err("rootless immutable authority must not accept a snapshot root");
+        assert!(error.message.contains("rootless"));
+    }
 
-        let read = storage
-            .begin_read(StorageReadOptions::default())
-            .await
-            .expect("rebuilt authority read should open");
-        let loaded = load_commit_state_manifest(&read, original.commit_id)
-            .await
-            .expect("rebuilt manifest should load")
-            .expect("rebuilt manifest should exist");
-        assert_eq!(loaded.snapshot_root, Some(rebuilt));
-        let point = super::load_point_replay_commit_state(&read, original.commit_id)
-            .await
-            .expect("immutable point authority should load")
-            .expect("immutable point authority should exist");
-        assert_eq!(&*point, &original);
+    #[test]
+    fn rooted_manifest_requires_immutable_snapshot_authority() {
+        let mut manifest = commit_state_manifest_fixture();
+        manifest.replay_debt = CommitStateReplayDebt::default();
+
+        let error = encode_commit_state_manifest(&manifest)
+            .expect_err("zero replay debt must carry canonical snapshot authority");
+        assert!(error.message.contains("missing its snapshot root"));
     }
 
     #[test]
@@ -14299,7 +13789,7 @@ mod tests {
     }
 
     #[test]
-    fn commit_state_manifest_allows_accelerators_and_rejects_replay_drift() {
+    fn commit_state_manifest_rejects_replay_drift() {
         let mut mixed = commit_state_manifest_fixture();
         mixed.mutations.parts.push(super::CommitStateMutationPart {
             first_key: vec![1],
@@ -14313,28 +13803,7 @@ mod tests {
                 .contains("mixes inline and external")
         );
 
-        let mut rooted_with_debt = commit_state_manifest_fixture();
-        rooted_with_debt.snapshot_root = Some(TrackedStateCommitRoot {
-            commit_id: rooted_with_debt.commit_id,
-            root_id: TrackedStateRootId::new([4; 32]),
-            parent_roots: vec![crate::tracked_state::types::TrackedStateCommitRootParent {
-                commit_id: rooted_with_debt.parent_commit_ids[0],
-                root_id: TrackedStateRootId::new([5; 32]),
-            }],
-            changed_key_count: 1,
-            row_count_estimate: 1,
-            tree_height: 1,
-            primary_chunk_count: 1,
-            primary_chunk_bytes: 64,
-        });
-        let encoded = encode_commit_state_manifest(&rooted_with_debt)
-            .expect("an immutable snapshot accelerator may coexist with replay debt");
-        assert_eq!(
-            decode_commit_state_manifest(&encoded).expect("accelerated manifest should decode"),
-            rooted_with_debt
-        );
-
-        let mut invalid_debt = rooted_with_debt.clone();
+        let mut invalid_debt = commit_state_manifest_fixture();
         invalid_debt.replay_debt.depth = 0;
         assert!(
             encode_commit_state_manifest(&invalid_debt)
@@ -14348,7 +13817,7 @@ mod tests {
         forged_empty_authority.mutations.replacement_parts =
             Some(super::StoredReplacementPartsAuthority {
                 directory_digest: [7; 32],
-                uniform_updated_at: forged_empty_authority.created_at,
+                uniform_updated_at: LixTimestamp::from_unix_millis_utc_lossy(1234),
             });
         assert!(
             encode_commit_state_manifest(&forged_empty_authority)

--- a/packages/engine/src/tracked_state/tree.rs
+++ b/packages/engine/src/tracked_state/tree.rs
@@ -20,23 +20,24 @@ use lru::LruCache;
 
 use crate::storage_adapter::{StorageAdapterRead, StorageWriteSet};
 use crate::tracked_state::codec::{
-    ChildSummary, ChildSummaryRef, DecodedLeafNodeRef, DecodedNode, DecodedNodeRef,
-    EncodedLeafEntry, EncodedLeafEntryRef, PendingChunk, PendingChunkBatch,
-    TrackedStateKeyBatchBuilder, boundary_trigger, decode_key, decode_key_shared,
-    decode_key_with_trusted_prefix, decode_node, decode_node_ref, decode_value,
-    decode_visible_value, encode_internal_node, encode_internal_node_refs, encode_key,
-    encode_key_ref_into, encode_leaf_node, encode_leaf_node_refs, encode_schema_file_prefix,
-    encode_schema_key_prefix, encode_value_ref, encode_value_ref_into, hash_bytes,
+    ChildSummary, DecodedLeafNodeRef, DecodedNode, DecodedNodeRef, EncodedLeafEntry, PendingChunk,
+    PendingChunkBatch, TrackedStateKeyBatchBuilder, boundary_trigger, decode_key,
+    decode_key_shared, decode_key_with_trusted_prefix, decode_node, decode_node_ref, decode_value,
+    decode_visible_value, encode_internal_node, encode_key, encode_key_ref_into, encode_leaf_node,
+    encode_schema_file_prefix, encode_schema_key_prefix, encode_value_ref, encode_value_ref_into,
+    hash_bytes,
 };
 use crate::tracked_state::diff::{TrackedStateTreeDiffBatch, TrackedStateTreeDiffBatchBuilder};
 use crate::tracked_state::storage;
+#[cfg(test)]
+use crate::tracked_state::types::TrackedStateMutation;
 #[cfg(test)]
 use crate::tracked_state::types::TrackedStateTreeDiffEntry;
 use crate::tracked_state::types::{
     TRACKED_STATE_HASH_BYTES, TrackedStateApplyResult, TrackedStateDeltaRef,
     TrackedStateIndexValue, TrackedStateIndexValueRef, TrackedStateKey, TrackedStateKeyRef,
-    TrackedStateMutation, TrackedStateMutationBatch, TrackedStateRootId,
-    TrackedStateRootMutationRef, TrackedStateTreeScanRequest,
+    TrackedStateMutationBatch, TrackedStateRootId, TrackedStateRootMutationRef,
+    TrackedStateTreeScanRequest,
 };
 use crate::{LixError, NullableKeyFilter};
 
@@ -54,9 +55,21 @@ pub(crate) struct TrackedStateTreeOptions {
     pub(crate) max_chunk_bytes: usize,
 }
 
-enum MutationApply<T> {
-    Applied(TrackedStateApplyResult),
-    Fallback(T),
+/// A sorted, unique event at the publication frontier.  The event owns one
+/// encoded key/value pair; traversal borrows the slice and never constructs a
+/// second map or an intermediate root.
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct FrontierMutation {
+    key: Bytes,
+    value: Bytes,
+}
+
+#[derive(Debug)]
+struct FrontierRewrite {
+    summaries: Vec<ChildSummary>,
+    height: usize,
+    changed: bool,
+    child_summaries: Option<Vec<ChildSummary>>,
 }
 
 impl Default for TrackedStateTreeOptions {
@@ -318,132 +331,520 @@ impl TrackedStateTree {
         mutations: TrackedStateMutationBatch,
         commit_id: Option<&str>,
     ) -> Result<TrackedStateApplyResult, LixError> {
-        let mut mutations = mutations.into_mutations();
-        // The normal bulk tracked-write path already arrives in primary-key
-        // order.  With no parent root there is nothing to merge it with, so
-        // preserve that order directly instead of routing every row through a
-        // BTreeMap merely to sort it again.
-        if base_root.is_none() && mutations_are_strictly_sorted(&mutations) {
-            return self
-                .build_and_stage_sorted_mutations(writes, overlay, mutations, commit_id)
-                .await;
-        }
-        if let Some(root_id) = base_root {
-            if mutations.len() == 1 {
-                let mutation = mutations.pop().expect("single mutation should exist");
-                match self
-                    .apply_single_mutation(store, writes, overlay, root_id, mutation, commit_id)
-                    .await?
-                {
-                    MutationApply::Applied(result) => return Ok(result),
-                    MutationApply::Fallback(mutation) => mutations = vec![mutation],
-                }
-            } else if mutations.len() > 1 {
-                match self
-                    .apply_sorted_mutations_chunker(
-                        store, writes, overlay, root_id, mutations, commit_id,
-                    )
-                    .await?
-                {
-                    MutationApply::Applied(result) => return Ok(result),
-                    MutationApply::Fallback(fallback_mutations) => mutations = fallback_mutations,
-                }
+        let mut events = mutations
+            .into_mutations()
+            .into_iter()
+            .map(|mutation| FrontierMutation {
+                key: mutation.encoded_key,
+                value: mutation.encoded_value,
+            })
+            .collect::<Vec<_>>();
+        events.sort_unstable_by(|left, right| left.key.cmp(&right.key));
+        let mut unique = Vec::with_capacity(events.len());
+        for event in events {
+            if unique
+                .last()
+                .is_some_and(|previous: &FrontierMutation| previous.key == event.key)
+            {
+                *unique
+                    .last_mut()
+                    .expect("duplicate frontier event has a predecessor") = event;
+            } else {
+                unique.push(event);
             }
         }
-
-        let mut entries = match base_root {
-            Some(root_id) => self
-                .collect_leaf_entries_with_overlay(store, overlay, root_id)
-                .await?
-                .into_iter()
-                .map(|entry| (entry.key, entry.value))
-                .collect::<BTreeMap<_, _>>(),
-            None => BTreeMap::new(),
-        };
-
-        // Apply in caller order so repeated writes to the same key behave like
-        // normal transaction staging: the latest mutation wins.
-        for mutation in mutations {
-            entries.insert(mutation.encoded_key, mutation.encoded_value);
-        }
-
-        let built = self.build_tree_from_entries(
-            entries
-                .into_iter()
-                .map(|(key, value)| EncodedLeafEntry { key, value })
-                .collect(),
-        )?;
-        overlay.stage_chunks(writes, &built.chunks);
-
-        Ok(TrackedStateApplyResult {
-            root_id: built.root_id,
-            row_count: built.row_count,
-            tree_height: built.tree_height,
-            chunk_count: built.chunks.len(),
-            chunk_bytes: built.chunk_bytes,
-        })
+        self.apply_sorted_frontier(store, writes, overlay, base_root, &unique, commit_id)
+            .await
     }
 
-    /// Applies a sparse batch as independent path-copy mutations.
-    ///
-    /// Callers use this only after proving every key already exists in the
-    /// parent root. That avoids content-defined batch rechunking from
-    /// amplifying a small merge frontier into a full-tree rewrite.
-    pub(crate) async fn apply_point_mutations_with_overlay(
+    async fn apply_sorted_frontier(
         &self,
         store: &(impl StorageAdapterRead + ?Sized),
         writes: &mut StorageWriteSet,
         overlay: &mut storage::TrackedStateChunkOverlay,
-        base_root: &TrackedStateRootId,
-        mutations: TrackedStateMutationBatch,
-        commit_id: Option<&str>,
+        base_root: Option<&TrackedStateRootId>,
+        events: &[FrontierMutation],
+        _commit_id: Option<&str>,
     ) -> Result<TrackedStateApplyResult, LixError> {
-        let mut mutations = mutations.into_mutations().into_iter();
-        let mut current_root = base_root.clone();
-        let mut final_result = None;
-        let mut chunk_count = 0usize;
-        let mut chunk_bytes = 0usize;
-        while let Some(mutation) = mutations.next() {
-            match self
-                .apply_single_mutation(store, writes, overlay, &current_root, mutation, commit_id)
-                .await?
-            {
-                MutationApply::Applied(result) => {
-                    chunk_count = chunk_count.saturating_add(result.chunk_count);
-                    chunk_bytes = chunk_bytes.saturating_add(result.chunk_bytes);
-                    current_root = result.root_id.clone();
-                    final_result = Some(result);
-                }
-                MutationApply::Fallback(mutation) => {
-                    let remaining = std::iter::once(mutation).chain(mutations).collect();
-                    let mut result = self
-                        .apply_mutations_with_overlay(
-                            store,
-                            writes,
-                            overlay,
-                            Some(&current_root),
-                            TrackedStateMutationBatch::from_shared(remaining),
-                            commit_id,
+        if events.windows(2).any(|pair| pair[0].key >= pair[1].key) {
+            return Err(LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                "tracked-state mutation frontier requires sorted unique keys",
+            ));
+        }
+        if events.is_empty() {
+            let Some(root_id) = base_root else {
+                let mut chunks = PendingChunkBatchBuilder::default();
+                let root = self
+                    .build_leaf_level(Vec::new(), &mut chunks)
+                    .pop()
+                    .ok_or_else(|| {
+                        LixError::new(
+                            LixError::CODE_INTERNAL_ERROR,
+                            "empty tracked-state frontier produced no root",
                         )
-                        .await?;
-                    result.chunk_count = result.chunk_count.saturating_add(chunk_count);
-                    result.chunk_bytes = result.chunk_bytes.saturating_add(chunk_bytes);
-                    return Ok(result);
+                    })?;
+                let chunk_bytes = chunks.data.len();
+                let chunks = chunks.finish();
+                overlay.stage_chunks(writes, &chunks);
+                return Ok(TrackedStateApplyResult {
+                    root_id: TrackedStateRootId::new(root.child_hash),
+                    row_count: 0,
+                    tree_height: 1,
+                    chunk_count: chunks.len(),
+                    chunk_bytes,
+                });
+            };
+            let height = self
+                .root_height_with_overlay(store, overlay, *root_id.as_bytes())
+                .await?;
+            let row_count = decoded_node_row_count(
+                &self
+                    .load_node_with_overlay(store, overlay, root_id.as_bytes())
+                    .await?,
+            );
+            return Ok(TrackedStateApplyResult {
+                root_id: root_id.clone(),
+                row_count,
+                tree_height: height,
+                chunk_count: 0,
+                chunk_bytes: 0,
+            });
+        }
+
+        let mut chunks = PendingChunkBatchBuilder::default();
+        let (root_id, row_count, tree_height) = match base_root {
+            None => {
+                let entries = events
+                    .iter()
+                    .map(|event| EncodedLeafEntry {
+                        key: event.key.clone(),
+                        value: event.value.clone(),
+                    })
+                    .collect::<Vec<_>>();
+                let mut summaries = self.build_leaf_level(entries, &mut chunks);
+                let mut height = 1usize;
+                while summaries.len() > 1 {
+                    summaries = self.build_internal_level(summaries, height, &mut chunks);
+                    height += 1;
+                }
+                let root = summaries.pop().ok_or_else(|| {
+                    LixError::new(
+                        LixError::CODE_INTERNAL_ERROR,
+                        "tracked-state frontier produced no root",
+                    )
+                })?;
+                (
+                    TrackedStateRootId::new(root.child_hash),
+                    root.subtree_count as usize,
+                    height,
+                )
+            }
+            Some(root_id) => {
+                let height = self
+                    .root_height_with_overlay(store, overlay, *root_id.as_bytes())
+                    .await?;
+                let rewritten = self
+                    .rewrite_frontier_node(
+                        store,
+                        overlay,
+                        *root_id.as_bytes(),
+                        height.saturating_sub(1),
+                        events,
+                        &mut chunks,
+                    )
+                    .await?;
+                if !rewritten.changed {
+                    return Ok(TrackedStateApplyResult {
+                        root_id: root_id.clone(),
+                        row_count: rewritten
+                            .summaries
+                            .first()
+                            .map_or(0, |summary| summary.subtree_count as usize),
+                        tree_height: rewritten.height,
+                        chunk_count: 0,
+                        chunk_bytes: 0,
+                    });
+                }
+                let mut summaries = rewritten.summaries;
+                let mut new_height = rewritten.height;
+                while summaries.len() > 1 {
+                    summaries = self.build_internal_level(summaries, new_height, &mut chunks);
+                    new_height += 1;
+                }
+                let root = summaries.pop().ok_or_else(|| {
+                    LixError::new(
+                        LixError::CODE_INTERNAL_ERROR,
+                        "tracked-state frontier rewrite produced no root",
+                    )
+                })?;
+                (
+                    TrackedStateRootId::new(root.child_hash),
+                    root.subtree_count as usize,
+                    new_height,
+                )
+            }
+        };
+        let chunk_bytes = chunks.data.len();
+        let chunks = chunks.finish();
+        overlay.stage_chunks(writes, &chunks);
+        Ok(TrackedStateApplyResult {
+            root_id,
+            row_count,
+            tree_height,
+            chunk_count: chunks.len(),
+            chunk_bytes,
+        })
+    }
+
+    async fn root_height_with_overlay(
+        &self,
+        store: &(impl StorageAdapterRead + ?Sized),
+        overlay: &storage::TrackedStateChunkOverlay,
+        mut hash: [u8; TRACKED_STATE_HASH_BYTES],
+    ) -> Result<usize, LixError> {
+        let mut height = 1usize;
+        loop {
+            match self.load_node_with_overlay(store, overlay, &hash).await? {
+                DecodedNode::Leaf(_) => return Ok(height),
+                DecodedNode::Internal(internal) => {
+                    hash = internal
+                        .children()
+                        .first()
+                        .ok_or_else(|| {
+                            LixError::new(
+                                LixError::CODE_INTERNAL_ERROR,
+                                "tracked-state internal node has no children",
+                            )
+                        })?
+                        .child_hash;
+                    height = height.saturating_add(1);
                 }
             }
         }
-        final_result
-            .map(|mut result| {
-                result.chunk_count = chunk_count;
-                result.chunk_bytes = chunk_bytes;
-                result
-            })
-            .ok_or_else(|| {
+    }
+
+    fn rewrite_frontier_node<'a, S>(
+        &'a self,
+        store: &'a S,
+        overlay: &'a storage::TrackedStateChunkOverlay,
+        hash: [u8; TRACKED_STATE_HASH_BYTES],
+        level: usize,
+        events: &'a [FrontierMutation],
+        chunks: &'a mut PendingChunkBatchBuilder,
+    ) -> Pin<Box<dyn Future<Output = Result<FrontierRewrite, LixError>> + Send + 'a>>
+    where
+        S: StorageAdapterRead + ?Sized + 'a,
+    {
+        Box::pin(async move {
+            let node = self.load_node_with_overlay(store, overlay, &hash).await?;
+            match node {
+                DecodedNode::Leaf(leaf) => {
+                    let old_entries = leaf.clone().into_entries();
+                    let mut entries = Vec::with_capacity(old_entries.len() + events.len());
+                    let mut event_index = 0usize;
+                    let mut changed = false;
+                    for old in old_entries {
+                        while event_index < events.len()
+                            && events[event_index].key.as_ref() < old.key.as_ref()
+                        {
+                            let event = &events[event_index];
+                            entries.push(EncodedLeafEntry {
+                                key: event.key.clone(),
+                                value: event.value.clone(),
+                            });
+                            event_index += 1;
+                            changed = true;
+                        }
+                        if event_index < events.len()
+                            && events[event_index].key.as_ref() == old.key.as_ref()
+                        {
+                            let event = &events[event_index];
+                            changed |= event.value != old.value;
+                            entries.push(EncodedLeafEntry {
+                                key: old.key,
+                                value: event.value.clone(),
+                            });
+                            event_index += 1;
+                        } else {
+                            entries.push(old);
+                        }
+                    }
+                    while event_index < events.len() {
+                        let event = &events[event_index];
+                        entries.push(EncodedLeafEntry {
+                            key: event.key.clone(),
+                            value: event.value.clone(),
+                        });
+                        event_index += 1;
+                        changed = true;
+                    }
+                    if !changed {
+                        return Ok(FrontierRewrite {
+                            summaries: vec![decoded_leaf_summary(hash, &leaf)],
+                            height: 1,
+                            changed: false,
+                            child_summaries: None,
+                        });
+                    }
+                    Ok(FrontierRewrite {
+                        summaries: self.build_leaf_level(entries, chunks),
+                        height: 1,
+                        changed: true,
+                        child_summaries: None,
+                    })
+                }
+                DecodedNode::Internal(internal) => {
+                    let children = internal.into_children();
+                    if children.is_empty() {
+                        return Err(LixError::new(
+                            LixError::CODE_INTERNAL_ERROR,
+                            "tracked-state internal node has no children",
+                        ));
+                    }
+                    if level == 1 {
+                        return self
+                            .rewrite_leaf_frontier_window(
+                                store, overlay, hash, children, events, chunks,
+                            )
+                            .await;
+                    }
+                    return self
+                        .rewrite_internal_frontier_window(
+                            store, overlay, hash, level, children, events, chunks,
+                        )
+                        .await;
+                }
+            }
+        })
+    }
+
+    async fn rewrite_leaf_frontier_window(
+        &self,
+        store: &(impl StorageAdapterRead + ?Sized),
+        overlay: &storage::TrackedStateChunkOverlay,
+        hash: [u8; TRACKED_STATE_HASH_BYTES],
+        children: Vec<ChildSummary>,
+        events: &[FrontierMutation],
+        chunks: &mut PendingChunkBatchBuilder,
+    ) -> Result<FrontierRewrite, LixError> {
+        let first_key = events.first().map_or(&[][..], |event| event.key.as_ref());
+        let start = children
+            .iter()
+            .position(|child| child.last_key.as_ref() >= first_key)
+            .unwrap_or_else(|| children.len().saturating_sub(1));
+        let mut window_entries = Vec::new();
+        let mut event_index = 0usize;
+        let mut child_index = start;
+        loop {
+            let child = children.get(child_index).ok_or_else(|| {
                 LixError::new(
                     LixError::CODE_INTERNAL_ERROR,
-                    "point mutation batch must not be empty",
+                    "tracked-state leaf frontier ran past child summaries",
                 )
-            })
+            })?;
+            let leaf = self
+                .load_node_with_overlay(store, overlay, &child.child_hash)
+                .await?;
+            let leaf = match leaf {
+                DecodedNode::Leaf(leaf) => leaf,
+                DecodedNode::Internal(_) => {
+                    return Err(LixError::new(
+                        LixError::CODE_INTERNAL_ERROR,
+                        "tracked-state leaf frontier expected a leaf child",
+                    ));
+                }
+            };
+            window_entries.extend(leaf.into_entries());
+            if child_index + 1 == children.len() {
+                event_index = events.len();
+            } else {
+                while event_index < events.len()
+                    && events[event_index].key.as_ref() <= child.last_key.as_ref()
+                {
+                    event_index += 1;
+                }
+            }
+
+            if event_index == events.len() {
+                let mut merged = Vec::with_capacity(window_entries.len() + events.len());
+                let mut old_index = 0usize;
+                let mut incoming_index = 0usize;
+                while old_index < window_entries.len() {
+                    while incoming_index < events.len()
+                        && events[incoming_index].key.as_ref()
+                            < window_entries[old_index].key.as_ref()
+                    {
+                        merged.push(EncodedLeafEntry {
+                            key: events[incoming_index].key.clone(),
+                            value: events[incoming_index].value.clone(),
+                        });
+                        incoming_index += 1;
+                    }
+                    if incoming_index < events.len()
+                        && events[incoming_index].key.as_ref()
+                            == window_entries[old_index].key.as_ref()
+                    {
+                        merged.push(EncodedLeafEntry {
+                            key: window_entries[old_index].key.clone(),
+                            value: events[incoming_index].value.clone(),
+                        });
+                        incoming_index += 1;
+                    } else {
+                        merged.push(window_entries[old_index].clone());
+                    }
+                    old_index += 1;
+                }
+                while incoming_index < events.len() {
+                    merged.push(EncodedLeafEntry {
+                        key: events[incoming_index].key.clone(),
+                        value: events[incoming_index].value.clone(),
+                    });
+                    incoming_index += 1;
+                }
+                let mut candidate_chunks = PendingChunkBatchBuilder::default();
+                let candidate = self.build_leaf_level(merged, &mut candidate_chunks);
+                if let Some((generated, existing)) =
+                    first_resync_index(&candidate, &children[start..], first_key)
+                {
+                    for summary in &candidate[..generated] {
+                        chunks.copy_chunk_from(&candidate_chunks, &summary.child_hash);
+                    }
+                    let mut output = children[..start].to_vec();
+                    output.extend(candidate.into_iter().take(generated));
+                    output.extend_from_slice(&children[start + existing..]);
+                    let child_summaries = output.clone();
+                    return Ok(FrontierRewrite {
+                        summaries: self.build_internal_level(output, 1, chunks),
+                        height: 2,
+                        changed: true,
+                        child_summaries: Some(child_summaries),
+                    });
+                }
+                if child_index + 1 == children.len() {
+                    chunks.extend(candidate_chunks);
+                    let mut output = children[..start].to_vec();
+                    output.extend(candidate);
+                    let child_summaries = output.clone();
+                    return Ok(FrontierRewrite {
+                        summaries: self.build_internal_level(output, 1, chunks),
+                        height: 2,
+                        changed: true,
+                        child_summaries: Some(child_summaries),
+                    });
+                }
+            }
+            child_index += 1;
+        }
+    }
+
+    async fn rewrite_internal_frontier_window(
+        &self,
+        store: &(impl StorageAdapterRead + ?Sized),
+        overlay: &storage::TrackedStateChunkOverlay,
+        hash: [u8; TRACKED_STATE_HASH_BYTES],
+        level: usize,
+        children: Vec<ChildSummary>,
+        events: &[FrontierMutation],
+        chunks: &mut PendingChunkBatchBuilder,
+    ) -> Result<FrontierRewrite, LixError> {
+        let first_key = events.first().map_or(&[][..], |event| event.key.as_ref());
+        let start = children
+            .iter()
+            .position(|child| child.last_key.as_ref() >= first_key)
+            .unwrap_or_else(|| children.len().saturating_sub(1));
+        let mut window_children = Vec::new();
+        let mut event_index = 0usize;
+        let mut child_index = start;
+        loop {
+            let child = children.get(child_index).ok_or_else(|| {
+                LixError::new(
+                    LixError::CODE_INTERNAL_ERROR,
+                    "tracked-state internal frontier ran past child summaries",
+                )
+            })?;
+            let event_end = if child_index + 1 == children.len() {
+                events.len()
+            } else {
+                let mut end = event_index;
+                while end < events.len() && events[end].key.as_ref() <= child.last_key.as_ref() {
+                    end += 1;
+                }
+                end
+            };
+            if event_index < event_end {
+                let rewritten = self
+                    .rewrite_frontier_node(
+                        store,
+                        overlay,
+                        child.child_hash,
+                        level.saturating_sub(1),
+                        &events[event_index..event_end],
+                        chunks,
+                    )
+                    .await?;
+                let child_summaries = rewritten.child_summaries.ok_or_else(|| {
+                    LixError::new(
+                        LixError::CODE_INTERNAL_ERROR,
+                        "tracked-state changed internal child did not expose its frontier",
+                    )
+                })?;
+                window_children.extend(child_summaries);
+            } else {
+                let node = self
+                    .load_node_with_overlay(store, overlay, &child.child_hash)
+                    .await?;
+                let node_children = match node {
+                    DecodedNode::Internal(internal) => internal.into_children(),
+                    DecodedNode::Leaf(_) => {
+                        return Err(LixError::new(
+                            LixError::CODE_INTERNAL_ERROR,
+                            "tracked-state internal frontier expected an internal child",
+                        ));
+                    }
+                };
+                window_children.extend(node_children);
+            }
+            event_index = event_end;
+            if event_index == events.len() {
+                let mut candidate_chunks = PendingChunkBatchBuilder::default();
+                let candidate = self.build_internal_level(
+                    window_children.iter().cloned().collect(),
+                    level - 1,
+                    &mut candidate_chunks,
+                );
+                if let Some((generated, existing)) =
+                    first_resync_index(&candidate, &children[start..], first_key)
+                {
+                    for summary in &candidate[..generated] {
+                        chunks.copy_chunk_from(&candidate_chunks, &summary.child_hash);
+                    }
+                    let mut output = children[..start].to_vec();
+                    output.extend(candidate.into_iter().take(generated));
+                    output.extend_from_slice(&children[start + existing..]);
+                    let child_summaries = output.clone();
+                    return Ok(FrontierRewrite {
+                        summaries: self.build_internal_level(output, level, chunks),
+                        height: level + 1,
+                        changed: true,
+                        child_summaries: Some(child_summaries),
+                    });
+                }
+                if child_index + 1 == children.len() {
+                    chunks.extend(candidate_chunks);
+                    let mut output = children[..start].to_vec();
+                    output.extend(candidate);
+                    let child_summaries = output.clone();
+                    return Ok(FrontierRewrite {
+                        summaries: self.build_internal_level(output, level, chunks),
+                        height: level + 1,
+                        changed: true,
+                        child_summaries: Some(child_summaries),
+                    });
+                }
+            }
+            child_index += 1;
+        }
     }
 
     /// Merges a full, primary-key-sorted mutation batch with a parent root in
@@ -562,145 +963,6 @@ impl TrackedStateTree {
                 }
             }
         }
-    }
-
-    async fn apply_single_mutation(
-        &self,
-        store: &(impl StorageAdapterRead + ?Sized),
-        writes: &mut StorageWriteSet,
-        overlay: &mut storage::TrackedStateChunkOverlay,
-        root_id: &TrackedStateRootId,
-        mutation: TrackedStateMutation,
-        commit_id: Option<&str>,
-    ) -> Result<MutationApply<TrackedStateMutation>, LixError> {
-        let mutation = match self
-            .apply_single_mutation_from_seek_path(
-                store, writes, overlay, root_id, mutation, commit_id,
-            )
-            .await?
-        {
-            MutationApply::Applied(result) => return Ok(MutationApply::Applied(result)),
-            MutationApply::Fallback(mutation) => mutation,
-        };
-
-        let TrackedStateMutation {
-            encoded_key,
-            encoded_value,
-        } = mutation;
-
-        let levels = self
-            .collect_summary_levels_with_overlay(store, overlay, root_id)
-            .await?;
-        let Some(leaves) = levels.first() else {
-            return Ok(MutationApply::Fallback(TrackedStateMutation {
-                encoded_key,
-                encoded_value,
-            }));
-        };
-        let target_leaf_index = leaves
-            .iter()
-            .position(|leaf| leaf.last_key.as_ref() >= encoded_key.as_ref())
-            .unwrap_or_else(|| leaves.len().saturating_sub(1));
-        let Some(target_leaf) = leaves.get(target_leaf_index).cloned() else {
-            return Ok(MutationApply::Fallback(TrackedStateMutation {
-                encoded_key,
-                encoded_value,
-            }));
-        };
-
-        let mut entries = self
-            .load_leaf_entries_with_overlay(store, overlay, &target_leaf.child_hash)
-            .await?;
-        let mutation_entry_index =
-            match entries.binary_search_by(|entry| entry.key.as_ref().cmp(encoded_key.as_ref())) {
-                Ok(index) => {
-                    if entries[index].value.as_ref() == encoded_value.as_ref() {
-                        return Ok(MutationApply::Fallback(TrackedStateMutation {
-                            encoded_key,
-                            encoded_value,
-                        }));
-                    }
-                    entries[index].value = encoded_value;
-                    index
-                }
-                Err(index) => {
-                    entries.insert(
-                        index,
-                        EncodedLeafEntry {
-                            key: encoded_key,
-                            value: encoded_value,
-                        },
-                    );
-                    index
-                }
-            };
-
-        let mut chunks = PendingChunkBatchBuilder::default();
-        let mut suffix_entries = entries;
-        let mut next_leaf_index = target_leaf_index + 1;
-        let mut replacement_leaves;
-        let old_leaf_count;
-
-        // Rechunk from the edited leaf until a generated leaf matches an
-        // existing post-mutation leaf, then reuse the rest of the old suffix.
-        loop {
-            let mut candidate_chunks = PendingChunkBatchBuilder::default();
-            let candidate_summaries = self.build_leaf_level_from_refs(
-                suffix_entries.iter().map(EncodedLeafEntry::as_ref),
-                &mut candidate_chunks,
-            );
-
-            if let Some((generated_resync_index, existing_resync_index)) = first_resync_index(
-                &candidate_summaries,
-                &leaves[target_leaf_index..],
-                suffix_entries[mutation_entry_index].key.as_ref(),
-            ) {
-                for summary in &candidate_summaries[..generated_resync_index] {
-                    chunks.copy_chunk_from(&candidate_chunks, &summary.child_hash);
-                }
-                replacement_leaves = candidate_summaries
-                    .into_iter()
-                    .take(generated_resync_index)
-                    .collect();
-                old_leaf_count = existing_resync_index;
-                break;
-            }
-
-            if next_leaf_index >= leaves.len() {
-                chunks.extend(candidate_chunks);
-                replacement_leaves = candidate_summaries;
-                old_leaf_count = leaves.len() - target_leaf_index;
-                break;
-            }
-
-            suffix_entries.extend(
-                self.load_leaf_entries_with_overlay(
-                    store,
-                    overlay,
-                    &leaves[next_leaf_index].child_hash,
-                )
-                .await?,
-            );
-            next_leaf_index += 1;
-        }
-
-        let built = self.build_tree_from_leaf_patch(
-            &levels,
-            target_leaf_index,
-            old_leaf_count,
-            std::mem::take(&mut replacement_leaves),
-            chunks,
-            suffix_entries[mutation_entry_index].key.as_ref(),
-        )?;
-        overlay.stage_chunks(writes, &built.chunks);
-
-        Ok(MutationApply::Applied(TrackedStateApplyResult {
-            root_id: built.root_id,
-            row_count: built.row_count,
-            tree_height: built.tree_height,
-            chunk_count: built.chunks.len(),
-            chunk_bytes: built.chunk_bytes,
-        }))
     }
 
     async fn diff_nodes(
@@ -973,450 +1235,6 @@ impl TrackedStateTree {
         Ok(())
     }
 
-    #[expect(clippy::cast_possible_truncation)]
-    async fn apply_sorted_mutations_chunker(
-        &self,
-        store: &(impl StorageAdapterRead + ?Sized),
-        writes: &mut StorageWriteSet,
-        overlay: &mut storage::TrackedStateChunkOverlay,
-        root_id: &TrackedStateRootId,
-        mut mutations: Vec<TrackedStateMutation>,
-        commit_id: Option<&str>,
-    ) -> Result<MutationApply<Vec<TrackedStateMutation>>, LixError> {
-        if mutations.is_empty() {
-            return Ok(MutationApply::Fallback(Vec::new()));
-        }
-
-        let levels = self
-            .collect_summary_levels_with_overlay(store, overlay, root_id)
-            .await?;
-        let Some(leaves) = levels.first() else {
-            return Ok(MutationApply::Fallback(mutations));
-        };
-
-        let mutations_are_sorted = mutations_are_strictly_sorted(&mutations);
-        let mut mutation_map = (!mutations_are_sorted).then(|| {
-            std::mem::take(&mut mutations)
-                .into_iter()
-                .map(|mutation| (mutation.encoded_key, mutation.encoded_value))
-                .collect::<BTreeMap<_, _>>()
-        });
-        let base_row_count = leaves
-            .iter()
-            .map(|leaf| leaf.subtree_count as usize)
-            .sum::<usize>();
-        let first_mutation_key = mutation_map.as_ref().map_or_else(
-            || &mutations[0].encoded_key,
-            |mutations| {
-                mutations
-                    .keys()
-                    .next()
-                    .expect("non-empty mutation map should have first key")
-            },
-        );
-        let append_only = leaves
-            .last()
-            .is_some_and(|leaf| first_mutation_key.as_ref() > leaf.last_key.as_ref());
-        if mutations_are_sorted && !append_only && mutations.len() * 2 > base_row_count {
-            return Ok(MutationApply::Applied(
-                self.rebuild_from_sorted_mutations(
-                    store, writes, overlay, root_id, mutations, commit_id,
-                )
-                .await?,
-            ));
-        }
-
-        let mut mutations = if let Some(mutation_map) = mutation_map.take() {
-            if !append_only && mutation_map.len() * 2 > base_row_count {
-                return Ok(MutationApply::Fallback(
-                    mutation_map
-                        .into_iter()
-                        .map(|(encoded_key, encoded_value)| TrackedStateMutation {
-                            encoded_key,
-                            encoded_value,
-                        })
-                        .collect(),
-                ));
-            }
-            mutation_map
-                .into_iter()
-                .map(|(encoded_key, encoded_value)| TrackedStateMutation {
-                    encoded_key,
-                    encoded_value,
-                })
-                .collect::<VecDeque<_>>()
-        } else {
-            // Strictly ordered batches are already deduplicated by definition.
-            // Preserve their descriptor buffer rather than routing every shared
-            // key/value slice through a temporary BTreeMap.
-            VecDeque::from(mutations)
-        };
-        let mut output_leaves = Vec::new();
-        let mut chunks = PendingChunkBatchBuilder::default();
-        let mut leaf_index = 0usize;
-
-        while leaf_index < leaves.len() {
-            let current_leaf_has_mutation = mutations.front().is_some_and(|mutation| {
-                mutation.encoded_key.as_ref() <= leaves[leaf_index].last_key.as_ref()
-            });
-            if !current_leaf_has_mutation {
-                output_leaves.push(leaves[leaf_index].clone());
-                leaf_index += 1;
-                continue;
-            }
-
-            let window_start = leaf_index;
-            let mut window_entries = BTreeMap::new();
-            let mut window_mutation_ceiling = mutations
-                .front()
-                .map(|mutation| mutation.encoded_key.clone())
-                .expect("window with mutation should have front mutation");
-
-            loop {
-                if leaf_index < leaves.len() {
-                    let leaf = &leaves[leaf_index];
-                    for entry in self
-                        .load_leaf_entries_with_overlay(store, overlay, &leaf.child_hash)
-                        .await?
-                    {
-                        window_entries.insert(entry.key, entry.value);
-                    }
-
-                    while mutations.front().is_some_and(|mutation| {
-                        mutation.encoded_key.as_ref() <= leaf.last_key.as_ref()
-                    }) {
-                        let mutation = mutations
-                            .pop_front()
-                            .expect("front mutation should be present");
-                        window_mutation_ceiling.clone_from(&mutation.encoded_key);
-                        window_entries.insert(mutation.encoded_key, mutation.encoded_value);
-                    }
-                    leaf_index += 1;
-                }
-
-                while let Some(mutation) = mutations.front() {
-                    if leaf_index < leaves.len()
-                        && mutation.encoded_key.as_ref() >= leaves[leaf_index].first_key.as_ref()
-                    {
-                        break;
-                    }
-                    let mutation = mutations
-                        .pop_front()
-                        .expect("front mutation should be present");
-                    window_mutation_ceiling.clone_from(&mutation.encoded_key);
-                    window_entries.insert(mutation.encoded_key, mutation.encoded_value);
-                }
-
-                if leaf_index < leaves.len()
-                    && mutations.front().is_some_and(|mutation| {
-                        mutation.encoded_key.as_ref() <= leaves[leaf_index].last_key.as_ref()
-                    })
-                {
-                    continue;
-                }
-
-                let mut candidate_chunks = PendingChunkBatchBuilder::default();
-                let candidate_leaves = self.build_leaf_level_from_refs(
-                    window_entries
-                        .iter()
-                        .map(|(key, value)| EncodedLeafEntryRef { key, value }),
-                    &mut candidate_chunks,
-                );
-
-                if let Some((generated_resync_index, existing_resync_index)) = first_resync_index(
-                    &candidate_leaves,
-                    &leaves[window_start..],
-                    &window_mutation_ceiling,
-                ) {
-                    for summary in &candidate_leaves[..generated_resync_index] {
-                        chunks.copy_chunk_from(&candidate_chunks, &summary.child_hash);
-                    }
-                    output_leaves.extend(candidate_leaves.into_iter().take(generated_resync_index));
-                    leaf_index = window_start + existing_resync_index;
-                    break;
-                }
-
-                if leaf_index >= leaves.len() {
-                    chunks.extend(candidate_chunks);
-                    output_leaves.extend(candidate_leaves);
-                    break;
-                }
-            }
-        }
-
-        if !mutations.is_empty() {
-            let entries = mutations
-                .into_iter()
-                .map(|mutation| EncodedLeafEntry {
-                    key: mutation.encoded_key,
-                    value: mutation.encoded_value,
-                })
-                .collect();
-            output_leaves.extend(self.build_leaf_level(entries, &mut chunks));
-        }
-
-        let built = self.build_tree_from_leaf_summaries(output_leaves, chunks)?;
-        Ok(MutationApply::Applied(
-            self.persist_built_tree(writes, overlay, built, commit_id)
-                .await?,
-        ))
-    }
-
-    async fn build_and_stage_sorted_mutations(
-        &self,
-        writes: &mut StorageWriteSet,
-        overlay: &mut storage::TrackedStateChunkOverlay,
-        mutations: Vec<TrackedStateMutation>,
-        commit_id: Option<&str>,
-    ) -> Result<TrackedStateApplyResult, LixError> {
-        let built = self.build_tree_from_entries(
-            mutations
-                .into_iter()
-                .map(|mutation| EncodedLeafEntry {
-                    key: mutation.encoded_key,
-                    value: mutation.encoded_value,
-                })
-                .collect(),
-        )?;
-        self.persist_built_tree(writes, overlay, built, commit_id)
-            .await
-    }
-
-    async fn rebuild_from_sorted_mutations(
-        &self,
-        store: &(impl StorageAdapterRead + ?Sized),
-        writes: &mut StorageWriteSet,
-        overlay: &mut storage::TrackedStateChunkOverlay,
-        root_id: &TrackedStateRootId,
-        mutations: Vec<TrackedStateMutation>,
-        commit_id: Option<&str>,
-    ) -> Result<TrackedStateApplyResult, LixError> {
-        let base_entries = self
-            .collect_leaf_entries_with_overlay(store, overlay, root_id)
-            .await?;
-        let mut entries = Vec::with_capacity(base_entries.len() + mutations.len());
-        let mut mutations = mutations.into_iter().peekable();
-        for entry in base_entries {
-            while mutations
-                .peek()
-                .is_some_and(|mutation| mutation.encoded_key < entry.key)
-            {
-                let mutation = mutations.next().expect("peeked mutation should exist");
-                entries.push(EncodedLeafEntry {
-                    key: mutation.encoded_key,
-                    value: mutation.encoded_value,
-                });
-            }
-            if mutations
-                .peek()
-                .is_some_and(|mutation| mutation.encoded_key == entry.key)
-            {
-                let mutation = mutations.next().expect("peeked mutation should exist");
-                entries.push(EncodedLeafEntry {
-                    key: mutation.encoded_key,
-                    value: mutation.encoded_value,
-                });
-            } else {
-                entries.push(entry);
-            }
-        }
-        entries.extend(mutations.map(|mutation| EncodedLeafEntry {
-            key: mutation.encoded_key,
-            value: mutation.encoded_value,
-        }));
-        let built = self.build_tree_from_entries(entries)?;
-        self.persist_built_tree(writes, overlay, built, commit_id)
-            .await
-    }
-
-    #[expect(clippy::cast_possible_truncation)]
-    async fn apply_single_mutation_from_seek_path(
-        &self,
-        store: &(impl StorageAdapterRead + ?Sized),
-        writes: &mut StorageWriteSet,
-        overlay: &mut storage::TrackedStateChunkOverlay,
-        root_id: &TrackedStateRootId,
-        mutation: TrackedStateMutation,
-        commit_id: Option<&str>,
-    ) -> Result<MutationApply<TrackedStateMutation>, LixError> {
-        let TrackedStateMutation {
-            encoded_key,
-            encoded_value,
-        } = mutation;
-        let mut current = *root_id.as_bytes();
-        let mut path = Vec::new();
-        let mut entries = loop {
-            match self
-                .load_node_with_overlay(store, overlay, &current)
-                .await?
-            {
-                DecodedNode::Leaf(leaf) => break leaf.into_entries(),
-                DecodedNode::Internal(internal) => {
-                    let children = internal.into_children();
-                    let child_index = children
-                        .iter()
-                        .position(|child| child.last_key.as_ref() >= encoded_key.as_ref())
-                        .or_else(|| (!children.is_empty()).then_some(children.len() - 1))
-                        .ok_or_else(|| {
-                            LixError::new(
-                                "LIX_ERROR_UNKNOWN",
-                                "tracked-state tree internal node has no children",
-                            )
-                        })?;
-                    current = children[child_index].child_hash;
-                    path.push(SeekPathFrame {
-                        children,
-                        child_index,
-                    });
-                }
-            }
-        };
-
-        let (mutation_entry_index, replaced_existing) =
-            match entries.binary_search_by(|entry| entry.key.as_ref().cmp(encoded_key.as_ref())) {
-                Ok(index) => {
-                    if entries[index].value.as_ref() == encoded_value.as_ref() {
-                        return Ok(MutationApply::Fallback(TrackedStateMutation {
-                            encoded_key,
-                            encoded_value,
-                        }));
-                    }
-                    entries[index].value = encoded_value;
-                    (index, true)
-                }
-                Err(index) => {
-                    entries.insert(
-                        index,
-                        EncodedLeafEntry {
-                            key: encoded_key,
-                            value: encoded_value,
-                        },
-                    );
-                    (index, false)
-                }
-            };
-
-        let mut chunks = PendingChunkBatchBuilder::default();
-        let mut replacement_children;
-        let mut old_child_count;
-
-        let Some(leaf_parent) = path.pop() else {
-            let built = self.build_tree_from_entries(entries)?;
-            return Ok(MutationApply::Applied(
-                self.persist_built_tree(writes, overlay, built, commit_id)
-                    .await?,
-            ));
-        };
-        let mutation_is_right_edge = leaf_parent.child_index + 1 == leaf_parent.children.len()
-            && path
-                .iter()
-                .all(|frame| frame.child_index + 1 == frame.children.len());
-
-        let mut leaf_entries = entries;
-        let mut next_leaf_index = leaf_parent.child_index + 1;
-        loop {
-            let mut candidate_chunks = PendingChunkBatchBuilder::default();
-            let candidate_leaves = self.build_leaf_level_from_refs(
-                leaf_entries.iter().map(EncodedLeafEntry::as_ref),
-                &mut candidate_chunks,
-            );
-            if replaced_existing && candidate_leaves.len() == 1 {
-                chunks.extend(candidate_chunks);
-                replacement_children = candidate_leaves;
-                old_child_count = 1;
-                break;
-            }
-            if let Some((generated_resync_index, existing_resync_index)) = first_resync_index(
-                &candidate_leaves,
-                &leaf_parent.children[leaf_parent.child_index..],
-                leaf_entries[mutation_entry_index].key.as_ref(),
-            ) {
-                for summary in &candidate_leaves[..generated_resync_index] {
-                    chunks.copy_chunk_from(&candidate_chunks, &summary.child_hash);
-                }
-                replacement_children = candidate_leaves
-                    .into_iter()
-                    .take(generated_resync_index)
-                    .collect();
-                old_child_count = existing_resync_index;
-                break;
-            }
-
-            if next_leaf_index >= leaf_parent.children.len() {
-                if !mutation_is_right_edge {
-                    let entry = leaf_entries.remove(mutation_entry_index);
-                    return Ok(MutationApply::Fallback(TrackedStateMutation {
-                        encoded_key: entry.key,
-                        encoded_value: entry.value,
-                    }));
-                }
-                chunks.extend(candidate_chunks);
-                replacement_children = candidate_leaves;
-                old_child_count = leaf_parent.children.len() - leaf_parent.child_index;
-                break;
-            }
-
-            leaf_entries.extend(
-                self.load_leaf_entries_with_overlay(
-                    store,
-                    overlay,
-                    &leaf_parent.children[next_leaf_index].child_hash,
-                )
-                .await?,
-            );
-            next_leaf_index += 1;
-        }
-
-        let mut child_index = leaf_parent.child_index;
-        let mut children = leaf_parent.children;
-        let mut parent_level = 1usize;
-        loop {
-            children.splice(
-                child_index..child_index + old_child_count,
-                replacement_children,
-            );
-            let promoted_root = path.is_empty() && children.len() == 1;
-            replacement_children = if promoted_root {
-                children
-            } else {
-                self.build_internal_level(children, parent_level, &mut chunks)
-            };
-            old_child_count = 1;
-
-            let Some(frame) = path.pop() else {
-                let mut summaries = replacement_children;
-                let mut tree_height = parent_level + usize::from(!promoted_root);
-                while summaries.len() > 1 {
-                    summaries = self.build_internal_level(summaries, tree_height, &mut chunks);
-                    tree_height += 1;
-                }
-                let root = summaries.pop().ok_or_else(|| {
-                    LixError::new(
-                        "LIX_ERROR_UNKNOWN",
-                        "tracked-state seek-path mutation produced no root",
-                    )
-                })?;
-                let chunk_bytes = chunks.data.len();
-                let chunks = chunks.finish();
-                let built = BuiltTree {
-                    root_id: TrackedStateRootId::new(root.child_hash),
-                    chunks,
-                    row_count: root.subtree_count as usize,
-                    tree_height,
-                    chunk_bytes,
-                };
-                return Ok(MutationApply::Applied(
-                    self.persist_built_tree(writes, overlay, built, commit_id)
-                        .await?,
-                ));
-            };
-
-            child_index = frame.child_index;
-            children = frame.children;
-            parent_level += 1;
-        }
-    }
-
     async fn persist_built_tree(
         &self,
         writes: &mut StorageWriteSet,
@@ -1434,6 +1252,7 @@ impl TrackedStateTree {
         })
     }
 
+    #[cfg(test)]
     fn build_tree_from_entries(
         &self,
         entries: Vec<EncodedLeafEntry>,
@@ -1517,167 +1336,6 @@ impl TrackedStateTree {
     }
 
     #[expect(clippy::cast_possible_truncation)]
-    fn build_tree_from_leaf_patch(
-        &self,
-        levels: &[Vec<ChildSummary>],
-        leaf_start: usize,
-        old_leaf_count: usize,
-        replacement_leaves: Vec<ChildSummary>,
-        mut chunks: PendingChunkBatchBuilder,
-        mutation_key: &[u8],
-    ) -> Result<BuiltTree, LixError> {
-        if levels.len() <= 1 {
-            let mut leaves = levels.first().cloned().unwrap_or_default();
-            leaves.splice(leaf_start..leaf_start + old_leaf_count, replacement_leaves);
-            return self.build_tree_from_leaf_summaries(leaves, chunks);
-        }
-
-        let mut child_start = leaf_start;
-        let mut old_child_count = old_leaf_count;
-        let mut replacement_children = replacement_leaves;
-        let mut tree_height = levels.len();
-
-        for level in 0..levels.len() - 1 {
-            if level + 2 == levels.len() {
-                let mut root_children = levels[level].clone();
-                root_children.splice(
-                    child_start..child_start + old_child_count,
-                    replacement_children,
-                );
-                if root_children.len() == 1 {
-                    replacement_children = root_children;
-                    tree_height -= 1;
-                } else {
-                    replacement_children =
-                        self.build_internal_level(root_children, level + 1, &mut chunks);
-                }
-                break;
-            }
-            let patch = self.patch_parent_level(
-                &levels[level],
-                &levels[level + 1],
-                child_start,
-                old_child_count,
-                replacement_children,
-                level + 1,
-                &mut chunks,
-                mutation_key,
-            )?;
-            child_start = patch.parent_start;
-            old_child_count = patch.old_parent_count;
-            replacement_children = patch.replacement_parents;
-        }
-
-        let mut summaries = replacement_children;
-        while summaries.len() > 1 {
-            summaries = self.build_internal_level(summaries, tree_height, &mut chunks);
-            tree_height += 1;
-        }
-        let root = summaries.pop().ok_or_else(|| {
-            LixError::new(
-                "LIX_ERROR_UNKNOWN",
-                "tracked-state patched tree produced no root",
-            )
-        })?;
-        let chunk_bytes = chunks.data.len();
-        let chunks = chunks.finish();
-        Ok(BuiltTree {
-            root_id: TrackedStateRootId::new(root.child_hash),
-            chunks,
-            row_count: root.subtree_count as usize,
-            tree_height,
-            chunk_bytes,
-        })
-    }
-
-    fn patch_parent_level(
-        &self,
-        old_children: &[ChildSummary],
-        old_parents: &[ChildSummary],
-        child_start: usize,
-        old_child_count: usize,
-        replacement_children: Vec<ChildSummary>,
-        parent_level: usize,
-        chunks: &mut PendingChunkBatchBuilder,
-        mutation_key: &[u8],
-    ) -> Result<ParentLevelPatch, LixError> {
-        if old_parents.is_empty() {
-            return Ok(ParentLevelPatch {
-                parent_start: 0,
-                old_parent_count: 0,
-                replacement_parents: self.build_internal_level(
-                    replacement_children,
-                    parent_level,
-                    chunks,
-                ),
-            });
-        }
-
-        let parent_start = parent_index_for_child_index(old_children, old_parents, child_start);
-        let parent_child_range = child_range_for_parent(old_children, &old_parents[parent_start])?;
-        let old_child_end = child_start + old_child_count;
-        let parent_end = if old_child_count == 0 {
-            parent_start
-        } else {
-            parent_index_for_child_index(old_children, old_parents, old_child_end - 1)
-        };
-        let parent_end_child_range =
-            child_range_for_parent(old_children, &old_parents[parent_end])?;
-        let mut window_children = Vec::new();
-        window_children.extend(
-            old_children[parent_child_range.start..child_start]
-                .iter()
-                .map(ChildSummary::as_ref),
-        );
-        window_children.extend(replacement_children.iter().map(ChildSummary::as_ref));
-        window_children.extend(
-            old_children[old_child_end..parent_end_child_range.end]
-                .iter()
-                .map(ChildSummary::as_ref),
-        );
-        let mut next_parent_index = parent_end + 1;
-
-        loop {
-            let mut candidate_chunks = PendingChunkBatchBuilder::default();
-            let candidate_parents = self.build_internal_level_from_refs(
-                window_children.iter().copied(),
-                parent_level,
-                &mut candidate_chunks,
-            );
-
-            if let Some((generated_resync_index, existing_resync_index)) = first_resync_index(
-                &candidate_parents,
-                &old_parents[parent_start..],
-                mutation_key,
-            ) {
-                for summary in &candidate_parents[..generated_resync_index] {
-                    chunks.copy_chunk_from(&candidate_chunks, &summary.child_hash);
-                }
-                return Ok(ParentLevelPatch {
-                    parent_start,
-                    old_parent_count: existing_resync_index,
-                    replacement_parents: candidate_parents
-                        .into_iter()
-                        .take(generated_resync_index)
-                        .collect(),
-                });
-            }
-
-            if next_parent_index >= old_parents.len() {
-                chunks.extend(candidate_chunks);
-                return Ok(ParentLevelPatch {
-                    parent_start,
-                    old_parent_count: old_parents.len() - parent_start,
-                    replacement_parents: candidate_parents,
-                });
-            }
-
-            let next_range = child_range_for_parent(old_children, &old_parents[next_parent_index])?;
-            window_children.extend(old_children[next_range].iter().map(ChildSummary::as_ref));
-            next_parent_index += 1;
-        }
-    }
-
     fn build_leaf_level(
         &self,
         entries: Vec<EncodedLeafEntry>,
@@ -1700,32 +1358,6 @@ impl TrackedStateTree {
                     .unwrap_or_default();
                 let node = encode_leaf_node(&group.entries);
                 chunks.insert_node(node, first_key, last_key, subtree_count)
-            })
-            .collect()
-    }
-
-    fn build_leaf_level_from_refs<'a>(
-        &self,
-        entries: impl IntoIterator<Item = EncodedLeafEntryRef<'a>>,
-        chunks: &mut PendingChunkBatchBuilder,
-    ) -> Vec<ChildSummary> {
-        let groups = chunk_leaf_entry_refs(entries, &self.options);
-        groups
-            .into_iter()
-            .map(|group| {
-                let subtree_count = group.entries.len() as u64;
-                let first_key = group
-                    .entries
-                    .first()
-                    .map(|entry| entry.key.to_vec())
-                    .unwrap_or_default();
-                let last_key = group
-                    .entries
-                    .last()
-                    .map(|entry| entry.key.to_vec())
-                    .unwrap_or_default();
-                let node = encode_leaf_node_refs(&group.entries);
-                chunks.insert_node(node, first_key.into(), last_key.into(), subtree_count)
             })
             .collect()
     }
@@ -1757,33 +1389,6 @@ impl TrackedStateTree {
             .collect()
     }
 
-    fn build_internal_level_from_refs<'a>(
-        &self,
-        children: impl IntoIterator<Item = ChildSummaryRef<'a>>,
-        level: usize,
-        chunks: &mut PendingChunkBatchBuilder,
-    ) -> Vec<ChildSummary> {
-        let groups = chunk_internal_entry_refs(children, &self.options, level);
-        groups
-            .into_iter()
-            .map(|group| {
-                let subtree_count = group.children.iter().map(|child| child.subtree_count).sum();
-                let first_key = group
-                    .children
-                    .first()
-                    .map(|child| child.first_key.to_vec())
-                    .unwrap_or_default();
-                let last_key = group
-                    .children
-                    .last()
-                    .map(|child| child.last_key.to_vec())
-                    .unwrap_or_default();
-                let node = encode_internal_node_refs(&group.children);
-                chunks.insert_node(node, first_key.into(), last_key.into(), subtree_count)
-            })
-            .collect()
-    }
-
     #[cfg(test)]
     async fn collect_leaf_entries(
         &self,
@@ -1795,6 +1400,7 @@ impl TrackedStateTree {
             .await
     }
 
+    #[cfg(test)]
     async fn collect_leaf_entries_with_overlay(
         &self,
         store: &(impl StorageAdapterRead + ?Sized),
@@ -2041,6 +1647,7 @@ impl TrackedStateTree {
         })
     }
 
+    #[cfg(test)]
     async fn collect_summary_levels_with_overlay(
         &self,
         store: &(impl StorageAdapterRead + ?Sized),
@@ -2058,6 +1665,7 @@ impl TrackedStateTree {
         Ok(levels)
     }
 
+    #[cfg(test)]
     fn collect_summary_levels_for_node_with_overlay<'a, S>(
         &'a self,
         store: &'a S,
@@ -2114,21 +1722,6 @@ impl TrackedStateTree {
                 }
             }
         })
-    }
-
-    async fn load_leaf_entries_with_overlay(
-        &self,
-        store: &(impl StorageAdapterRead + ?Sized),
-        overlay: &storage::TrackedStateChunkOverlay,
-        hash: &[u8; TRACKED_STATE_HASH_BYTES],
-    ) -> Result<Vec<EncodedLeafEntry>, LixError> {
-        match self.load_node_with_overlay(store, overlay, hash).await? {
-            DecodedNode::Leaf(leaf) => Ok(leaf.into_entries()),
-            DecodedNode::Internal(_) => Err(LixError::new(
-                "LIX_ERROR_UNKNOWN",
-                "tracked-state expected leaf chunk but found internal node",
-            )),
-        }
     }
 
     async fn load_node(
@@ -2641,18 +2234,6 @@ impl<'a> OrderedTreeAssembler<'a> {
     }
 }
 
-struct ParentLevelPatch {
-    parent_start: usize,
-    old_parent_count: usize,
-    replacement_parents: Vec<ChildSummary>,
-}
-
-struct SeekPathFrame {
-    children: Vec<ChildSummary>,
-    child_index: usize,
-}
-
-#[derive(Debug, Clone)]
 struct EncodedScanRange {
     start: Vec<u8>,
     end: Option<Vec<u8>>,
@@ -2695,29 +2276,10 @@ struct LeafChunkAccumulator {
 }
 
 #[derive(Debug, Default)]
-struct LeafChunkRefAccumulator<'a> {
-    entries: Vec<EncodedLeafEntryRef<'a>>,
-    key_bytes: usize,
-}
-
-#[derive(Debug, Default)]
 struct InternalChunkAccumulator {
     children: Vec<ChildSummary>,
     first_key_bytes: usize,
     last_key_bytes: usize,
-}
-
-#[derive(Debug, Default)]
-struct InternalChunkRefAccumulator<'a> {
-    children: Vec<ChildSummaryRef<'a>>,
-    first_key_bytes: usize,
-    last_key_bytes: usize,
-}
-
-fn mutations_are_strictly_sorted(mutations: &[TrackedStateMutation]) -> bool {
-    mutations
-        .windows(2)
-        .all(|pair| pair[0].encoded_key < pair[1].encoded_key)
 }
 
 fn chunk_leaf_entries(
@@ -2748,51 +2310,6 @@ fn chunk_leaf_entries(
                 || current.entries.last().is_some_and(|entry| {
                     boundary_trigger(
                         &entry.key,
-                        0,
-                        current_size,
-                        item_size,
-                        options.target_chunk_bytes,
-                    )
-                }))
-        {
-            groups.push(std::mem::take(&mut current));
-        }
-    }
-    if !current.entries.is_empty() {
-        groups.push(current);
-    }
-    groups
-}
-
-fn chunk_leaf_entry_refs<'a>(
-    entries: impl IntoIterator<Item = EncodedLeafEntryRef<'a>>,
-    options: &TrackedStateTreeOptions,
-) -> Vec<LeafChunkRefAccumulator<'a>> {
-    let mut iter = entries.into_iter().peekable();
-    if iter.peek().is_none() {
-        return vec![LeafChunkRefAccumulator::default()];
-    }
-    let mut groups = Vec::new();
-    let mut current = LeafChunkRefAccumulator::default();
-    for entry in iter {
-        let item_size = estimate_leaf_boundary_entry_size(entry.key.len());
-        let projected_size = estimate_leaf_boundary_chunk_size(
-            current.entries.len() + 1,
-            current.key_bytes + entry.key.len(),
-        );
-        if !current.entries.is_empty() && projected_size > options.max_chunk_bytes {
-            groups.push(std::mem::take(&mut current));
-        }
-
-        current.key_bytes += entry.key.len();
-        current.entries.push(entry);
-        let current_size =
-            estimate_leaf_boundary_chunk_size(current.entries.len(), current.key_bytes);
-        if current_size >= options.min_chunk_bytes
-            && (current_size >= options.max_chunk_bytes
-                || current.entries.last().is_some_and(|entry| {
-                    boundary_trigger(
-                        entry.key,
                         0,
                         current_size,
                         item_size,
@@ -2843,56 +2360,6 @@ fn chunk_internal_entries(
                 || current.children.last().is_some_and(|child| {
                     boundary_trigger(
                         &child.first_key,
-                        level,
-                        current_size,
-                        item_size,
-                        options.target_chunk_bytes,
-                    )
-                }))
-        {
-            groups.push(std::mem::take(&mut current));
-        }
-    }
-    if !current.children.is_empty() {
-        groups.push(current);
-    }
-    groups
-}
-
-fn chunk_internal_entry_refs<'a>(
-    children: impl IntoIterator<Item = ChildSummaryRef<'a>>,
-    options: &TrackedStateTreeOptions,
-    level: usize,
-) -> Vec<InternalChunkRefAccumulator<'a>> {
-    let mut groups = Vec::new();
-    let mut current = InternalChunkRefAccumulator::default();
-    for child in children {
-        let item_size = child.first_key.len()
-            + child.last_key.len()
-            + TRACKED_STATE_HASH_BYTES
-            + size_of::<u64>();
-        let projected_size = estimate_internal_chunk_size(
-            current.children.len() + 1,
-            current.first_key_bytes + child.first_key.len(),
-            current.last_key_bytes + child.last_key.len(),
-        );
-        if !current.children.is_empty() && projected_size > options.max_chunk_bytes {
-            groups.push(std::mem::take(&mut current));
-        }
-
-        current.first_key_bytes += child.first_key.len();
-        current.last_key_bytes += child.last_key.len();
-        current.children.push(child);
-        let current_size = estimate_internal_chunk_size(
-            current.children.len(),
-            current.first_key_bytes,
-            current.last_key_bytes,
-        );
-        if current_size >= options.min_chunk_bytes
-            && (current_size >= options.max_chunk_bytes
-                || current.children.last().is_some_and(|child| {
-                    boundary_trigger(
-                        child.first_key,
                         level,
                         current_size,
                         item_size,
@@ -3029,51 +2496,6 @@ fn tree_diff_capacity_hint(node: &DecodedNode, request: &TrackedStateTreeScanReq
     }
 }
 
-fn parent_index_for_child_index(
-    old_children: &[ChildSummary],
-    old_parents: &[ChildSummary],
-    child_index: usize,
-) -> usize {
-    let key = if child_index < old_children.len() {
-        old_children[child_index].first_key.as_ref()
-    } else {
-        old_children
-            .last()
-            .map(|child| child.last_key.as_ref())
-            .unwrap_or_default()
-    };
-    old_parents
-        .iter()
-        .position(|parent| parent.last_key.as_ref() >= key)
-        .unwrap_or_else(|| old_parents.len().saturating_sub(1))
-}
-
-fn child_range_for_parent(
-    old_children: &[ChildSummary],
-    parent: &ChildSummary,
-) -> Result<Range<usize>, LixError> {
-    let start = old_children
-        .iter()
-        .position(|child| child.last_key.as_ref() >= parent.first_key.as_ref())
-        .ok_or_else(|| {
-            LixError::new(
-                "LIX_ERROR_UNKNOWN",
-                "tracked-state parent summary does not overlap child summaries",
-            )
-        })?;
-    let end = old_children[start..]
-        .iter()
-        .position(|child| child.last_key == parent.last_key)
-        .map(|offset| start + offset + 1)
-        .ok_or_else(|| {
-            LixError::new(
-                "LIX_ERROR_UNKNOWN",
-                "tracked-state parent summary end does not match child summaries",
-            )
-        })?;
-    Ok(start..end)
-}
-
 fn decoded_leaf_summary(
     hash: [u8; TRACKED_STATE_HASH_BYTES],
     leaf: &DecodedLeafNodeRef,
@@ -3086,6 +2508,7 @@ fn decoded_leaf_summary(
     }
 }
 
+#[cfg(test)]
 fn internal_summary(
     hash: [u8; TRACKED_STATE_HASH_BYTES],
     children: &[ChildSummary],
@@ -3116,6 +2539,7 @@ fn internal_summary(
     })
 }
 
+#[cfg(test)]
 fn push_level_summary(levels: &mut Vec<Vec<ChildSummary>>, level: usize, summary: ChildSummary) {
     while levels.len() <= level {
         levels.push(Vec::new());
@@ -4455,16 +3879,9 @@ mod tests {
                 value: encoded_inserted_value.into(),
             },
         );
-        let expected_entries = canonical_entries.clone();
         let canonical = tree
             .build_tree_from_entries(canonical_entries)
             .expect("canonical root should build");
-
-        let fast_entries = tree
-            .collect_leaf_entries(&read, &fast.root_id)
-            .await
-            .expect("fast entries should collect");
-        assert_eq!(fast_entries, expected_entries);
 
         assert_eq!(fast.root_id, canonical.root_id);
     }
@@ -4485,8 +3902,8 @@ mod tests {
                 )
             })
             .collect::<Vec<_>>();
-        // More than half of the parent is replaced, which exercises the
-        // sorted full-rebuild path instead of the sparse chunk patcher.
+        // A dense sorted batch still uses the same authenticated frontier;
+        // there is no separate whole-tree fallback.
         let updates = (10..90)
             .map(|index| {
                 (
@@ -4607,6 +4024,83 @@ mod tests {
             .expect("canonical root should build");
 
         assert_eq!(fast.root_id, canonical.root_id);
+    }
+
+    #[tokio::test]
+    async fn randomized_frontier_matches_canonical_rebuild() {
+        let storage = StorageAdapter::new(Memory::new());
+        let tree = TrackedStateTree::with_options(TrackedStateTreeOptions {
+            target_chunk_bytes: 128,
+            min_chunk_bytes: 64,
+            max_chunk_bytes: 256,
+        });
+        let initial = (0..192)
+            .map(|index| {
+                mutation_owned(
+                    key("schema", None, &format!("entity-{index:04}")),
+                    value(&format!("c-{index}"), Some(&format!("{{\"v\":{index}}}"))),
+                )
+            })
+            .collect::<Vec<_>>();
+        let mut current = apply_mutations_for_test(&tree, &storage, None, initial, None)
+            .await
+            .expect("initial root should build")
+            .root_id;
+        let mut state = 0x7f4a_7c15_u64;
+        for step in 0..96 {
+            state ^= state << 7;
+            state ^= state >> 9;
+            state ^= state << 8;
+            let index = if step % 3 == 0 {
+                (state as usize) % 192
+            } else {
+                192 + step
+            };
+            let logical_key = key("schema", None, &format!("entity-{index:04}"));
+            let logical_value = value(
+                &format!("random-{step}"),
+                Some(&format!("{{\"step\":{step},\"state\":{state}}}")),
+            );
+            let read = storage
+                .begin_read(StorageReadOptions::default())
+                .await
+                .expect("read should open");
+            let mut canonical_entries = tree
+                .collect_leaf_entries(&read, &current)
+                .await
+                .expect("current entries should collect");
+            let encoded_key = encode_key(&logical_key);
+            let encoded_value = encode_value(&logical_value);
+            match canonical_entries.binary_search_by(|entry| entry.key.as_ref().cmp(&encoded_key)) {
+                Ok(existing) => canonical_entries[existing].value = encoded_value.clone().into(),
+                Err(insert) => canonical_entries.insert(
+                    insert,
+                    EncodedLeafEntry {
+                        key: encoded_key.into(),
+                        value: encoded_value.into(),
+                    },
+                ),
+            }
+            let fast = apply_mutations_for_test(
+                &tree,
+                &storage,
+                Some(&current),
+                vec![mutation(&logical_key, &logical_value)],
+                None,
+            )
+            .await
+            .expect("frontier mutation should apply");
+            let canonical = tree
+                .build_tree_from_entries(canonical_entries)
+                .expect("canonical root should build");
+            assert_eq!(fast.root_id, canonical.root_id, "step {step} diverged");
+            assert_eq!(fast.row_count, canonical.row_count, "step {step} row count");
+            assert_eq!(
+                fast.tree_height, canonical.tree_height,
+                "step {step} height"
+            );
+            current = fast.root_id;
+        }
     }
 
     #[test]

--- a/packages/engine/src/tracked_state/tree.rs
+++ b/packages/engine/src/tracked_state/tree.rs
@@ -7,7 +7,7 @@
 )]
 
 use std::{
-    collections::{BTreeMap, VecDeque},
+    collections::{BTreeMap, HashSet, VecDeque},
     future::Future,
     num::NonZeroUsize,
     ops::Range,
@@ -1816,6 +1816,27 @@ impl TrackedStateTree {
             current = next;
         }
         Ok(out)
+    }
+
+    pub(crate) async fn reachable_chunk_hashes_with_overlay(
+        &self,
+        store: &(impl StorageAdapterRead + ?Sized),
+        overlay: &storage::TrackedStateChunkOverlay,
+        root_id: &TrackedStateRootId,
+    ) -> Result<HashSet<[u8; TRACKED_STATE_HASH_BYTES]>, LixError> {
+        let mut reachable = HashSet::new();
+        let mut pending = vec![*root_id.as_bytes()];
+        while let Some(hash) = pending.pop() {
+            if !reachable.insert(hash) {
+                continue;
+            }
+            if let DecodedNode::Internal(internal) =
+                self.load_node_with_overlay(store, overlay, &hash).await?
+            {
+                pending.extend(internal.children().iter().map(|child| child.child_hash));
+            }
+        }
+        Ok(reachable)
     }
 
     fn collect_root_diff_shared<'a, S>(

--- a/packages/engine/src/tracked_state/tree.rs
+++ b/packages/engine/src/tracked_state/tree.rs
@@ -623,7 +623,7 @@ impl TrackedStateTree {
         &self,
         store: &(impl StorageAdapterRead + ?Sized),
         overlay: &storage::TrackedStateChunkOverlay,
-        hash: [u8; TRACKED_STATE_HASH_BYTES],
+        _hash: [u8; TRACKED_STATE_HASH_BYTES],
         children: Vec<ChildSummary>,
         events: &[FrontierMutation],
         chunks: &mut PendingChunkBatchBuilder,
@@ -742,7 +742,7 @@ impl TrackedStateTree {
         &self,
         store: &(impl StorageAdapterRead + ?Sized),
         overlay: &storage::TrackedStateChunkOverlay,
-        hash: [u8; TRACKED_STATE_HASH_BYTES],
+        _hash: [u8; TRACKED_STATE_HASH_BYTES],
         level: usize,
         children: Vec<ChildSummary>,
         events: &[FrontierMutation],
@@ -1335,7 +1335,6 @@ impl TrackedStateTree {
         })
     }
 
-    #[expect(clippy::cast_possible_truncation)]
     fn build_leaf_level(
         &self,
         entries: Vec<EncodedLeafEntry>,

--- a/packages/engine/src/tracked_state/types.rs
+++ b/packages/engine/src/tracked_state/types.rs
@@ -363,7 +363,7 @@ pub(crate) struct CommitStateTouchedScopeFilter {
 ///
 /// The fields intentionally mirror the existing commit-delta directory. This
 /// lets the hard-cut manifest become authoritative without changing the
-/// bounded LXCD14 segment and payload-sidecar codec in the same step.
+/// bounded LXCD15 segment and payload-sidecar codec in the same step.
 #[derive(Debug, Clone, Default, PartialEq, Eq, musli::Encode, musli::Decode)]
 #[musli(packed)]
 pub(crate) struct CommitStateMutationInventory {

--- a/packages/engine/src/tracked_state/types.rs
+++ b/packages/engine/src/tracked_state/types.rs
@@ -158,6 +158,23 @@ pub(crate) struct TrackedStateCommitRoot {
     pub(crate) primary_chunk_bytes: u64,
 }
 
+impl TrackedStateCommitRoot {
+    /// Compares immutable serving identity and shape.
+    ///
+    /// Primary chunk counts and bytes describe the publication path's staged
+    /// writes. A rebuild can reach the same content-addressed root through a
+    /// different sequence of intermediate chunks, so those original metrics
+    /// remain manifest-owned accounting rather than rebuilt root identity.
+    pub(crate) fn has_same_authoritative_layout(&self, other: &Self) -> bool {
+        self.commit_id == other.commit_id
+            && self.root_id == other.root_id
+            && self.parent_roots == other.parent_roots
+            && self.changed_key_count == other.changed_key_count
+            && self.row_count_estimate == other.row_count_estimate
+            && self.tree_height == other.tree_height
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, musli::Encode, musli::Decode)]
 #[musli(packed)]
 pub(crate) struct TrackedStateCommitRootParent {
@@ -168,10 +185,9 @@ pub(crate) struct TrackedStateCommitRootParent {
 /// Bounded first-parent replay work carried by a commit's canonical mutation
 /// interval.
 ///
-/// Zero debt means the snapshot root is the canonical serving layout. Nonzero
-/// debt means readers can reconstruct the state from the bounded interval;
-/// [`CommitStateManifest::snapshot_root`] may still contain an equivalent,
-/// rebuildable snapshot accelerator without changing that policy.
+/// Zero debt means the manifest's snapshot root is the canonical serving
+/// layout. Nonzero debt means readers reconstruct state from the bounded
+/// interval and the manifest must not publish a snapshot root.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, musli::Encode, musli::Decode)]
 #[musli(packed)]
 pub(crate) struct CommitStateReplayDebt {
@@ -313,7 +329,7 @@ pub(crate) struct CurrentStatePartDescriptor {
 /// Manifest-attested root of the unified scope/part serving tree.
 ///
 /// The generic tree owns only authenticated physical routing. These fields
-/// bind one result root to the physical serving base and sealed mutation
+/// bind one result root to the physical serving base and certified mutation
 /// authority that produced it. Graph ancestry remains an independent semantic
 /// relationship and is not exposed to the tree.
 #[derive(Debug, Clone, PartialEq, Eq, musli::Encode, musli::Decode)]
@@ -406,27 +422,29 @@ impl CommitStateMutationInventory {
     }
 }
 
-/// Single semantic authority for one tracked commit.
+/// Immutable physical authority for one tracked commit.
 ///
 /// Compact topology projections, point locators, current-state HOT rows, and
 /// snapshot tree chunks remain rebuildable serving indexes. None may carry
-/// commit semantics absent from this manifest.
+/// semantic commit facts, which belong exclusively to `changelog.commit`.
 #[derive(Debug, Clone, PartialEq, Eq, musli::Encode, musli::Decode)]
 #[musli(packed)]
 pub(crate) struct CommitStateManifest {
     pub(crate) commit_id: CommitId,
-    pub(crate) generation: u64,
-    pub(crate) parent_commit_ids: Vec<CommitId>,
-    pub(crate) commit_change_id: ChangeId,
-    pub(crate) account_id: String,
-    pub(crate) created_at: LixTimestamp,
+    /// Physical decode dictionary for authored mutation rows. This is not
+    /// commit-account authority: it remains with retained immutable payloads
+    /// even if GC removes the semantic commit projection.
+    pub(crate) change_account_id: String,
     pub(crate) replay_debt: CommitStateReplayDebt,
     pub(crate) mutations: CommitStateMutationInventory,
     pub(crate) touched_scope_filter: CommitStateTouchedScopeFilter,
     #[musli(with = crate::storage_codec::option)]
     pub(crate) current_state_scoped_ranges: Option<Box<CurrentStateScopedRangeRoot>>,
+    /// Canonical snapshot metadata when this commit was published as a root
+    /// fence. The tree chunks are rebuildable by content hash; this immutable
+    /// pointer is the authority that permits readers to serve them.
     #[musli(with = crate::storage_codec::option)]
-    pub(crate) snapshot_root: Option<TrackedStateCommitRoot>,
+    pub(crate) snapshot_root: Option<Box<TrackedStateCommitRoot>>,
 }
 
 /// Materialized tracked-state commit-root row.
@@ -629,4 +647,35 @@ pub(crate) struct TrackedStateTreeDiffEntry {
     pub(crate) key: TrackedStateKey,
     pub(crate) before: Option<TrackedStateIndexValue>,
     pub(crate) after: Option<TrackedStateIndexValue>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn commit_root() -> TrackedStateCommitRoot {
+        TrackedStateCommitRoot {
+            commit_id: CommitId::parse_lix("01920000-0000-7000-8000-000000000001", "test commit")
+                .expect("test commit id should parse"),
+            root_id: TrackedStateRootId::new([1; 32]),
+            parent_roots: Vec::new(),
+            changed_key_count: 3,
+            row_count_estimate: 7,
+            tree_height: 1,
+            primary_chunk_count: 2,
+            primary_chunk_bytes: 128,
+        }
+    }
+
+    #[test]
+    fn authoritative_layout_excludes_publication_write_accounting() {
+        let expected = commit_root();
+        let mut rebuilt = expected.clone();
+        rebuilt.primary_chunk_count = 5;
+        rebuilt.primary_chunk_bytes = 512;
+        assert!(expected.has_same_authoritative_layout(&rebuilt));
+
+        rebuilt.root_id = TrackedStateRootId::new([2; 32]);
+        assert!(!expected.has_same_authoritative_layout(&rebuilt));
+    }
 }

--- a/packages/engine/src/transaction/bench_support.rs
+++ b/packages/engine/src/transaction/bench_support.rs
@@ -670,7 +670,7 @@ mod tests {
 
         let point_update = fixture.update_one_by_pk_accounting().await;
         assert_eq!(point_update.logical_rows, 1);
-        assert_eq!(point_update.staged_puts, 8, "{point_update:?}");
+        assert_eq!(point_update.staged_puts, 9, "{point_update:?}");
 
         // A sparse overlay deliberately invalidates the complete-generation
         // digest, so use a fresh fixture to exercise exact bulk replacement

--- a/packages/engine/src/transaction/bench_support.rs
+++ b/packages/engine/src/transaction/bench_support.rs
@@ -461,6 +461,12 @@ async fn seed_visible_schema_rows<StorageImpl>(
     StorageImpl: Storage + Clone,
 {
     let mut writes = StorageWriteSet::new();
+    // Repository initialization seeds the authenticated GC queue before any
+    // benchmark transaction opens. Keep this low-level fixture on that same
+    // public protocol; unlike unit tests, benchmark binaries are not built
+    // with `cfg(test)` and therefore cannot use the test-only repair hook.
+    crate::gc::stage_reachability_queue_seed(&mut writes)
+        .expect("benchmark GC reachability queue should seed");
     let mut schemas = crate::schema::seed_schema_definitions()
         .into_iter()
         .cloned()

--- a/packages/engine/src/transaction/bench_support.rs
+++ b/packages/engine/src/transaction/bench_support.rs
@@ -174,6 +174,12 @@ where
     }
 
     pub async fn read_all(&self) -> usize {
+        let count = self.scan_count().await;
+        assert_eq!(count, self.rows.len());
+        count
+    }
+
+    async fn scan_count(&self) -> usize {
         let read = SharedStorageAdapterRead::new(
             self.storage
                 .begin_read(StorageReadOptions::default())
@@ -196,7 +202,6 @@ where
             })
             .await
             .expect("scan transaction bench rows");
-        assert_eq!(rows.len(), self.rows.len());
         rows.len()
     }
 
@@ -553,6 +558,26 @@ async fn seed_visible_schema_rows<StorageImpl>(
     let tracked_head = TrackedHeadContext::new();
     let absence_guards = BTreeSet::new();
     for (branch_id, _, _, _) in &branch_refs {
+        #[cfg(test)]
+        {
+            let mut coverage = WorkingDiffIndexCoverage::default();
+            tracked_head
+                .writer(&read, &mut writes)
+                .stage_current_state_with_working_diff(
+                    branch_id,
+                    None,
+                    commit_id,
+                    &[],
+                    &absence_guards,
+                    Some(rows.clone()),
+                    None,
+                    None,
+                    &mut coverage,
+                )
+                .await
+                .expect("schema fixture tracked head should stage");
+        }
+        #[cfg(not(test))]
         tracked_head
             .writer(&read, &mut writes)
             .stage_commit(
@@ -605,4 +630,63 @@ fn json_pointer_schema() -> JsonValue {
         "required": ["path", "value"],
         "additionalProperties": false
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::storage_adapter::Memory;
+
+    const BULK_ROWS: usize = 1_000;
+
+    fn bulk_rows(count: usize) -> Vec<BenchTransactionRow> {
+        (0..count)
+            .map(|index| BenchTransactionRow {
+                schema_key: "json_pointer".to_owned(),
+                file_id: None,
+                entity_pk: format!("/bulk/{index:04}"),
+                value: Arc::new(json!({
+                    "path": format!("/bulk/{index:04}"),
+                    "value": format!("before-{index:04}"),
+                })),
+                updated_value: Arc::new(json!({
+                    "path": format!("/bulk/{index:04}"),
+                    "value": format!("after-{index:04}"),
+                })),
+            })
+            .collect()
+    }
+
+    #[tokio::test]
+    async fn bulk_current_state_uses_compact_certificates_without_changing_point_writes() {
+        let mut fixture =
+            BenchTransactionFixture::new(StorageAdapter::new(Memory::new()), bulk_rows(BULK_ROWS))
+                .await;
+
+        let inserted = fixture.insert_all_accounting().await;
+        assert_eq!(inserted.logical_rows, BULK_ROWS);
+        assert!(inserted.staged_puts < 30, "{inserted:?}");
+        assert_eq!(fixture.read_all().await, BULK_ROWS);
+
+        let point_update = fixture.update_one_by_pk_accounting().await;
+        assert_eq!(point_update.logical_rows, 1);
+        assert_eq!(point_update.staged_puts, 8, "{point_update:?}");
+
+        // A sparse overlay deliberately invalidates the complete-generation
+        // digest, so use a fresh fixture to exercise exact bulk replacement
+        // and deletion certificates.
+        let mut bulk_fixture =
+            BenchTransactionFixture::new(StorageAdapter::new(Memory::new()), bulk_rows(BULK_ROWS))
+                .await;
+        bulk_fixture.insert_all().await;
+        let updated = bulk_fixture.update_all_accounting().await;
+        assert_eq!(updated.logical_rows, BULK_ROWS);
+        assert!(updated.staged_puts < 30, "{updated:?}");
+        assert_eq!(bulk_fixture.read_all().await, BULK_ROWS);
+
+        let deleted = bulk_fixture.delete_all_accounting().await;
+        assert_eq!(deleted.logical_rows, BULK_ROWS);
+        assert!(deleted.staged_puts < 40, "{deleted:?}");
+        assert_eq!(bulk_fixture.scan_count().await, 0);
+    }
 }

--- a/packages/engine/src/transaction/bench_support.rs
+++ b/packages/engine/src/transaction/bench_support.rs
@@ -670,7 +670,9 @@ mod tests {
 
         let point_update = fixture.update_one_by_pk_accounting().await;
         assert_eq!(point_update.logical_rows, 1);
-        assert_eq!(point_update.staged_puts, 9, "{point_update:?}");
+        // The point write keeps the compact current-state certificate and
+        // publishes its authenticated branch/control and reachability state.
+        assert_eq!(point_update.staged_puts, 11, "{point_update:?}");
 
         // A sparse overlay deliberately invalidates the complete-generation
         // digest, so use a fresh fixture to exercise exact bulk replacement

--- a/packages/engine/src/transaction/commit.rs
+++ b/packages/engine/src/transaction/commit.rs
@@ -60,10 +60,12 @@ use tracing::Instrument as _;
 type RowIndex = usize;
 
 // Below this size, per-row HOT writes are cheaper and keep repeated ordinary
-// INSERT transactions at one point-addressable current-state lookup. Packed
-// bases are reserved for bulk publication where avoiding row write
-// amplification dominates the cost of retaining one immutable manifest.
-const PACKED_CURRENT_BASE_MIN_ROWS: usize = 1_024;
+// INSERT transactions at one point-addressable current-state lookup. At 1K,
+// measured HOT publication still emitted one backend put per row, while the
+// immutable packed base removes that amplification without entering the
+// single-row path. Keep the crossover at a power-of-two boundary below that
+// representative bulk size while leaving ordinary point writes unchanged.
+const PACKED_CURRENT_BASE_MIN_ROWS: usize = 512;
 
 // Complete replacements retain an authoritative partition generation.
 // Ordinary non-empty ordered commits start bounded rootless intervals
@@ -3965,13 +3967,12 @@ async fn stage_tracked_head(
             .iter()
             .map(|delta| delta.schema_key)
             .collect::<BTreeSet<_>>();
-        let packed_guards_match = tracked_deltas.len() >= PACKED_CURRENT_BASE_MIN_ROWS
-            && packed_current_base_guards_match(&tracked_deltas, &absence_guards);
-        let can_publish_packed_current_base = !is_checkpoint_publication
+        let packed_guards_match =
+            packed_current_base_guards_match(&tracked_deltas, &absence_guards);
+        let packed_current_base_candidate = !is_checkpoint_publication
             && certified_fresh_plugin_file_id.is_none()
             && !host_certified_live_increments.contains_key(&root.branch_id)
             && staged.selected_change_batches.is_empty()
-            && packed_guards_match
             && tracked_deltas.len() >= PACKED_CURRENT_BASE_MIN_ROWS
             && tracked_deltas.iter().all(|delta| {
                 !delta.untracked
@@ -3985,9 +3986,102 @@ async fn stage_tracked_head(
             && untracked_deltas
                 .iter()
                 .all(|delta| !packed_schema_keys.contains(delta.schema_key));
+        let mut deltas = tracked_deltas.clone();
+        deltas.extend_from_slice(&untracked_deltas);
+        // Every absence guard above is derived from one of these exact
+        // transaction deltas. The fresh-file certificate likewise proves its
+        // complete file-scoped namespace absent. The branch-control CAS
+        // protects both proofs through publication.
+        let has_validated_insert_deltas = staged.selected_change_batches.is_empty()
+            && (!absence_guards.is_empty() || certified_fresh_plugin_file_id.is_some());
+        let mut writer = tracked_head.writer(read, writes);
+        let exact_delete_candidate = !is_checkpoint_publication
+            && certified_fresh_plugin_file_id.is_none()
+            && !host_certified_live_increments.contains_key(&root.branch_id)
+            && staged.selected_change_batches.is_empty()
+            && tracked_deltas.len() >= PACKED_CURRENT_BASE_MIN_ROWS
+            && untracked_deltas.is_empty()
+            && tracked_deltas.iter().all(|delta| {
+                !delta.untracked
+                    && delta.deleted
+                    && delta.file_id.is_none()
+                    && delta.schema_key
+                        != crate::collection_generation::COLLECTION_GENERATION_SCHEMA_KEY
+                    && delta.commit_id == Some(root.commit_id)
+                    && delta.change_id.is_some()
+            });
+        let delete_generation = if exact_delete_candidate {
+            writer
+                .try_stage_exact_collection_delete_current_base(
+                    &root.branch_id,
+                    parent_generation,
+                    root.commit_id,
+                    &tracked_deltas,
+                    working_diff_capture_checkpoint_commit_id,
+                )
+                .instrument(tracing::debug_span!(
+                    target: "lix_perf",
+                    "lix.perf.materialization.tracked_head.stage_exact_collection_delete"
+                ))
+                .await?
+        } else {
+            None
+        };
+        let replacement_generation = if delete_generation.is_none()
+            && packed_current_base_candidate
+            && absence_guards.is_empty()
+            && untracked_deltas.is_empty()
+        {
+            writer
+                .try_stage_exact_collection_replacement_current_base(
+                    &root.branch_id,
+                    parent_generation,
+                    root.commit_id,
+                    &tracked_deltas,
+                    entity_columnar_write_sets,
+                    working_diff_capture_checkpoint_commit_id,
+                    &mut coverage,
+                )
+                .instrument(tracing::debug_span!(
+                    target: "lix_perf",
+                    "lix.perf.materialization.tracked_head.stage_exact_collection_replacement"
+                ))
+                .await?
+        } else {
+            None
+        };
+        let packed_generation = if delete_generation.is_none()
+            && replacement_generation.is_none()
+            && packed_current_base_candidate
+            && (packed_guards_match || absence_guards.is_empty())
+        {
+            writer
+                .try_stage_packed_insert_current_base(
+                    &root.branch_id,
+                    parent_generation,
+                    root.commit_id,
+                    &tracked_deltas,
+                    &absence_guards,
+                    working_diff_capture_checkpoint_commit_id,
+                    &mut coverage,
+                )
+                .instrument(tracing::debug_span!(
+                    target: "lix_perf",
+                    "lix.perf.materialization.tracked_head.stage_packed_current_base"
+                ))
+                .await?
+        } else {
+            None
+        };
+        let packed_generation = delete_generation
+            .or(replacement_generation)
+            .or(packed_generation);
+        let can_publish_packed_current_base = packed_generation.is_some();
         tracing::debug!(
             target: "lix_perf",
             can_publish_packed_current_base,
+            packed_current_base_candidate,
+            exact_delete_candidate,
             tracked_delta_count = tracked_deltas.len(),
             packed_min_rows = PACKED_CURRENT_BASE_MIN_ROWS,
             untracked_delta_count = untracked_deltas.len(),
@@ -4000,15 +4094,6 @@ async fn stage_tracked_head(
             durable_predecessor_count = durable_predecessors.len(),
             "packed current-base route decision"
         );
-        let mut deltas = tracked_deltas.clone();
-        deltas.extend_from_slice(&untracked_deltas);
-        // Every absence guard above is derived from one of these exact
-        // transaction deltas. The fresh-file certificate likewise proves its
-        // complete file-scoped namespace absent. The branch-control CAS
-        // protects both proofs through publication.
-        let has_validated_insert_deltas = staged.selected_change_batches.is_empty()
-            && (!absence_guards.is_empty() || certified_fresh_plugin_file_id.is_some());
-        let mut writer = tracked_head.writer(read, writes);
         let generation = if is_checkpoint_publication {
             let checkpoint_commit_id =
                 checkpoint_commit_id.expect("checkpoint publication has an epoch commit id");
@@ -4028,22 +4113,7 @@ async fn stage_tracked_head(
                     "lix.perf.materialization.tracked_head.stage_checkpoint"
                 ))
                 .await?
-        } else if can_publish_packed_current_base {
-            let generation = writer
-                .stage_packed_insert_current_base(
-                    &root.branch_id,
-                    parent_generation,
-                    root.commit_id,
-                    &tracked_deltas,
-                    &absence_guards,
-                    working_diff_capture_checkpoint_commit_id,
-                    &mut coverage,
-                )
-                .instrument(tracing::debug_span!(
-                    target: "lix_perf",
-                    "lix.perf.materialization.tracked_head.stage_packed_current_base"
-                ))
-                .await?;
+        } else if let Some(generation) = packed_generation {
             if !untracked_deltas.is_empty() {
                 writer
                     .stage_current_state_with_working_diff(

--- a/packages/engine/src/transaction/commit.rs
+++ b/packages/engine/src/transaction/commit.rs
@@ -245,6 +245,9 @@ pub(crate) async fn commit_prepared_writes_with_parent_heads(
     }
     let mut writes = StorageWriteSet::new();
     let mut preconditions = Vec::new();
+    #[cfg(test)]
+    let seeded_reachability_queue =
+        crate::gc::ensure_reachability_queue_for_test(&*read, &mut writes).await?;
     for publication in &prepared_writes.checkpoint_publications {
         crate::gc::stage_recovery_ref_rotation(&mut writes, &publication.recovery_ref)?;
         crate::gc::stage_checkpoint_gc_state(&mut writes, &publication.gc_state)?;
@@ -759,6 +762,7 @@ pub(crate) async fn commit_prepared_writes_with_parent_heads(
     )
     .await?;
     let mut root_backed_branch_publications = BTreeSet::new();
+    let mut root_reachability_deltas = Vec::new();
     let published_branch_controls = stage_branch_head_control_publications(
         read,
         &mut writes,
@@ -772,6 +776,27 @@ pub(crate) async fn commit_prepared_writes_with_parent_heads(
         &mut preconditions,
         &branch_control_observations,
         &mut root_backed_branch_publications,
+        &mut root_reachability_deltas,
+    )
+    .await?;
+    #[cfg(test)]
+    if seeded_reachability_queue {
+        // The seed and first publication share this test-only bootstrap write
+        // set; the production initializer always commits the queue before any
+        // branch publication, so no delta can be lost in live repositories.
+        root_reachability_deltas.clear();
+    }
+    let checkpoint_roots = prepared_writes
+        .checkpoint_publications
+        .iter()
+        .map(|publication| publication.recovery_ref.checkpoint_commit_id)
+        .collect::<Vec<_>>();
+    crate::gc::stage_reachability_delta_batch(
+        read,
+        &mut writes,
+        &root_reachability_deltas,
+        &checkpoint_roots,
+        &mut preconditions,
     )
     .await?;
     if !published_branch_controls.contains_key(crate::GLOBAL_BRANCH_ID) {
@@ -4741,6 +4766,7 @@ async fn stage_branch_head_control_publications(
     preconditions: &mut Vec<StoragePrecondition>,
     observations: &BTreeMap<String, BranchHeadControlObservation>,
     root_backed_branch_publications: &mut BTreeSet<String>,
+    root_reachability_deltas: &mut Vec<crate::gc::RootReachabilityDelta>,
 ) -> Result<BTreeMap<String, BranchHeadControl>, LixError> {
     let checkpoint_epochs = checkpoint_epoch_bindings(checkpoint_publications)?;
     let mut publications = normal_controls
@@ -4909,6 +4935,21 @@ async fn stage_branch_head_control_publications(
             branch_id,
             observation.raw_token.clone(),
         )?);
+        let old_root = observation.control.map(|control| control.head_commit_id);
+        let new_root = desired.as_ref().map(|control| control.head_commit_id);
+        if old_root != new_root {
+            root_reachability_deltas.push(crate::gc::RootReachabilityDelta {
+                branch_id: branch_id.clone(),
+                old_root,
+                new_root,
+                old_control: observation.control,
+                new_control: *desired,
+                old_control_digest: crate::gc::root_control_digest_for_control(
+                    observation.control.as_ref(),
+                )?,
+                new_control_digest: crate::gc::root_control_digest_for_control(desired.as_ref())?,
+            });
+        }
         match desired {
             Some(control) => stage_branch_head_control(writes, branch_id, *control)?,
             None => stage_delete_branch_head_control(writes, branch_id)?,

--- a/packages/engine/src/transaction/commit.rs
+++ b/packages/engine/src/transaction/commit.rs
@@ -3967,8 +3967,6 @@ async fn stage_tracked_head(
             .iter()
             .map(|delta| delta.schema_key)
             .collect::<BTreeSet<_>>();
-        let packed_guards_match =
-            packed_current_base_guards_match(&tracked_deltas, &absence_guards);
         let packed_current_base_candidate = !is_checkpoint_publication
             && certified_fresh_plugin_file_id.is_none()
             && !host_certified_live_increments.contains_key(&root.branch_id)
@@ -3986,6 +3984,12 @@ async fn stage_tracked_head(
             && untracked_deltas
                 .iter()
                 .all(|delta| !packed_schema_keys.contains(delta.schema_key));
+        // Identity sorting is useful only for a route that can actually
+        // publish a packed base. Keep ordinary point/small-batch commits on
+        // their allocation-free short circuit.
+        let packed_guards_match = packed_current_base_candidate
+            && !absence_guards.is_empty()
+            && packed_current_base_guards_match(&tracked_deltas, &absence_guards);
         let mut deltas = tracked_deltas.clone();
         deltas.extend_from_slice(&untracked_deltas);
         // Every absence guard above is derived from one of these exact
@@ -4015,6 +4019,12 @@ async fn stage_tracked_head(
                 .try_stage_exact_collection_delete_current_base(
                     &root.branch_id,
                     parent_generation,
+                    root.parent_commit_id.ok_or_else(|| {
+                        LixError::new(
+                            LixError::CODE_INTERNAL_ERROR,
+                            "exact collection deletion lacks parent commit authority",
+                        )
+                    })?,
                     root.commit_id,
                     &tracked_deltas,
                     working_diff_capture_checkpoint_commit_id,
@@ -4036,6 +4046,12 @@ async fn stage_tracked_head(
                 .try_stage_exact_collection_replacement_current_base(
                     &root.branch_id,
                     parent_generation,
+                    root.parent_commit_id.ok_or_else(|| {
+                        LixError::new(
+                            LixError::CODE_INTERNAL_ERROR,
+                            "exact collection replacement lacks parent commit authority",
+                        )
+                    })?,
                     root.commit_id,
                     &tracked_deltas,
                     entity_columnar_write_sets,

--- a/packages/engine/src/transaction/commit.rs
+++ b/packages/engine/src/transaction/commit.rs
@@ -1022,6 +1022,7 @@ fn index_prepared_rows(rows: &PreparedStateBatch) -> Result<PreparedRowIndex, Li
 #[derive(Clone, Debug)]
 struct StagedChangelogCommit {
     record: CommitRecord,
+    replay_debt: CommitStateReplayDebt,
     change_count: usize,
     selected_change_batches: Vec<StagedCommitChangeBatch>,
 }
@@ -1179,20 +1180,10 @@ async fn stage_changelog_commits(
                     )
                 })?;
         let manifest = &*published;
-        // Replay debt is the durable layout authority. A rootless commit may
-        // later gain an immutable snapshot accelerator without changing its
-        // changelog topology projection.
-        let manifest_rootless = manifest.replay_debt.depth > 0;
-        if manifest.generation != record.generation
-            || manifest.parent_commit_ids != record.parent_commit_ids
-            || manifest.commit_change_id != record.change_id
-            || manifest.account_id != record.account_id
-            || manifest.created_at != record.created_at
-            || manifest_rootless != record.tracked_state_rootless
-            || manifest.replay_debt.depth != record.tracked_state_rootless_depth
-            || manifest.replay_debt.rows != record.tracked_state_rootless_rows
-            || manifest.replay_debt.bytes != record.tracked_state_rootless_bytes
-        {
+        // Replay debt is physical layout policy. Rootless commits remain
+        // bounded-replay layouts; rooted commits publish their canonical
+        // snapshot metadata inside immutable physical authority.
+        if manifest.commit_id != record.commit_id {
             return Err(LixError::new(
                 LixError::CODE_INTERNAL_ERROR,
                 format!(
@@ -1200,7 +1191,7 @@ async fn stage_changelog_commits(
                 ),
             ));
         }
-        generations.insert(*commit_id, manifest.generation);
+        generations.insert(*commit_id, record.generation);
         rootless_depths.insert(*commit_id, manifest.replay_debt.depth);
         rootless_rows.insert(*commit_id, manifest.replay_debt.rows);
         rootless_bytes.insert(*commit_id, manifest.replay_debt.bytes);
@@ -1423,14 +1414,10 @@ async fn stage_changelog_commits(
             })?;
         }
         let record = CommitRecord {
-            format_version: 1,
+            format_version: 2,
             commit_id: commit_row.commit_id,
             generation,
             parent_commit_ids: commit_row.parent_commit_ids.clone(),
-            tracked_state_rootless: rootless_commit_ids.contains(&commit_row.commit_id),
-            tracked_state_rootless_depth: rootless_depths[&commit_row.commit_id],
-            tracked_state_rootless_rows: rootless_rows[&commit_row.commit_id],
-            tracked_state_rootless_bytes: rootless_bytes[&commit_row.commit_id],
             change_id: commit_row.change_id,
             account_id: active_account_id.to_string(),
             created_at: commit_row.created_at,
@@ -1448,6 +1435,11 @@ async fn stage_changelog_commits(
             commit_row.commit_id,
             StagedChangelogCommit {
                 record,
+                replay_debt: CommitStateReplayDebt {
+                    depth: rootless_depths[&commit_row.commit_id],
+                    rows: rootless_rows[&commit_row.commit_id],
+                    bytes: rootless_bytes[&commit_row.commit_id],
+                },
                 change_count,
                 selected_change_batches: commit_row.selected_change_batches.clone(),
             },
@@ -2626,7 +2618,19 @@ async fn certify_complete_replacement_generations(
                         ),
                     )
                 })?;
-            if !record.tracked_state_rootless {
+            let manifest = crate::tracked_state::load_published_commit_state_manifest(
+                read, commit_id,
+            )
+            .await?
+            .ok_or_else(|| {
+                LixError::new(
+                    LixError::CODE_INTERNAL_ERROR,
+                    format!(
+                        "replacement generation parent '{commit_id}' has no physical authority"
+                    ),
+                )
+            })?;
+            if manifest.replay_debt.depth == 0 {
                 break Some(commit_id);
             }
             let Some(metadata) = load_commit_delta_replay_metadata(read, commit_id).await? else {
@@ -2738,7 +2742,17 @@ async fn certify_ordered_journal_replacement_generations(
                         ),
                     )
                 })?;
-            if !record.tracked_state_rootless {
+            let manifest = crate::tracked_state::load_published_commit_state_manifest(
+                read, commit_id,
+            )
+            .await?
+            .ok_or_else(|| {
+                LixError::new(
+                    LixError::CODE_INTERNAL_ERROR,
+                    format!("immutable replacement parent '{commit_id}' has no physical authority"),
+                )
+            })?;
+            if manifest.replay_debt.depth == 0 {
                 break Some(commit_id);
             }
             let Some(metadata) = load_commit_delta_replay_metadata(read, commit_id).await? else {
@@ -5554,24 +5568,16 @@ where
             }
             let manifest = CommitStateManifest {
                 commit_id: record.commit_id,
-                generation: record.generation,
-                parent_commit_ids: record.parent_commit_ids.clone(),
-                commit_change_id: record.change_id,
-                account_id: record.account_id.clone(),
-                created_at: record.created_at,
+                change_account_id: record.account_id.clone(),
                 replay_debt: if rootless {
-                    CommitStateReplayDebt {
-                        depth: record.tracked_state_rootless_depth,
-                        rows: record.tracked_state_rootless_rows,
-                        bytes: record.tracked_state_rootless_bytes,
-                    }
+                    staged.replay_debt
                 } else {
                     CommitStateReplayDebt::default()
                 },
                 mutations,
                 touched_scope_filter,
                 current_state_scoped_ranges,
-                snapshot_root,
+                snapshot_root: snapshot_root.map(Box::new),
             };
             let staged_manifest = if let Some(publication) = catalog_publication.as_ref() {
                 crate::tracked_state::stage_certified_commit_state_manifest_with_handle(
@@ -6763,11 +6769,7 @@ mod tests {
             &mut writes,
             &CommitStateManifest {
                 commit_id,
-                generation: 0,
-                parent_commit_ids: Vec::new(),
-                commit_change_id: change_id("mixed-certified-commit"),
-                account_id: crate::ANONYMOUS_ACCOUNT_ID.to_string(),
-                created_at: timestamp,
+                change_account_id: crate::ANONYMOUS_ACCOUNT_ID.to_string(),
                 replay_debt: CommitStateReplayDebt {
                     depth: 1,
                     rows: 2,
@@ -6902,11 +6904,16 @@ mod tests {
             panic!("changelog commit should exist");
         };
         assert_eq!(record.change_id, change_id("test-uuid-2"));
-        assert!(!record.tracked_state_rootless);
         let membership_read = storage
             .begin_read(StorageReadOptions::default())
             .await
             .expect("membership read should open");
+        let physical_state =
+            crate::tracked_state::load_commit_state_manifest(&membership_read, record.commit_id)
+                .await
+                .expect("physical state should load")
+                .expect("physical state should exist");
+        assert_eq!(physical_state.replay_debt, CommitStateReplayDebt::default());
         let change_ids =
             crate::tracked_state::load_commit_delta_change_ids(&membership_read, record.commit_id)
                 .await
@@ -8724,23 +8731,30 @@ mod tests {
             .collect::<Vec<_>>();
         assert_eq!(commits[0].generation, 0);
         assert_eq!(commits[1].generation, 1);
-        assert!(
-            commits.iter().all(|record| record.tracked_state_rootless),
-            "a staged child must inherit its first parent's rootless interval"
-        );
+        let authority_read = storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("physical authority read should open");
+        let states =
+            crate::tracked_state::load_commit_state_manifests(&authority_read, &commit_ids)
+                .await
+                .expect("physical states should load")
+                .into_iter()
+                .map(|state| state.expect("physical state"))
+                .collect::<Vec<_>>();
         assert_eq!(
-            commits
+            states
                 .iter()
-                .map(|record| record.tracked_state_rootless_depth)
+                .map(|state| state.replay_debt.depth)
                 .collect::<Vec<_>>(),
             vec![1, 2]
         );
-        assert!(commits[0].tracked_state_rootless_bytes > 0);
-        assert!(commits[1].tracked_state_rootless_bytes > commits[0].tracked_state_rootless_bytes);
+        assert!(states[0].replay_debt.bytes > 0);
+        assert!(states[1].replay_debt.bytes > states[0].replay_debt.bytes);
         assert_eq!(
-            commits
+            states
                 .iter()
-                .map(|record| record.tracked_state_rootless_rows)
+                .map(|state| state.replay_debt.rows)
                 .collect::<Vec<_>>(),
             vec![1, 2]
         );
@@ -8818,12 +8832,11 @@ mod tests {
         assert!(rootless_commit_ids.is_empty());
         assert!(durable_root_rebuild_parents.is_empty());
         assert_eq!(staged_root_rebuild_commits.len(), commit_count - 1);
-        assert!(staged.values().all(|commit| {
-            !commit.record.tracked_state_rootless
-                && commit.record.tracked_state_rootless_depth == 0
-                && commit.record.tracked_state_rootless_rows == 0
-                && commit.record.tracked_state_rootless_bytes == 0
-        }));
+        assert!(
+            staged
+                .values()
+                .all(|commit| commit.replay_debt == Default::default())
+        );
     }
 
     #[tokio::test]

--- a/packages/engine/src/transaction/commit.rs
+++ b/packages/engine/src/transaction/commit.rs
@@ -1133,7 +1133,7 @@ async fn stage_changelog_commits(
     ordered_replacements: &BTreeMap<CommitId, Arc<OrderedMutationJournal>>,
     external_parent_manifests: &mut BTreeMap<
         CommitId,
-        crate::tracked_state::PublishedCommitStateManifest,
+        crate::tracked_state::PublishedCommitStateTopology,
     >,
     active_account_id: &str,
 ) -> Result<BTreeMap<CommitId, StagedChangelogCommit>, LixError> {
@@ -1173,7 +1173,7 @@ async fn stage_changelog_commits(
             )
         })?;
         let published =
-            crate::tracked_state::load_published_commit_state_manifest(read, *commit_id)
+            crate::tracked_state::load_published_commit_state_topology(read, *commit_id)
                 .await?
                 .ok_or_else(|| {
                     LixError::new(
@@ -1181,11 +1181,10 @@ async fn stage_changelog_commits(
                         format!("commit '{commit_id}' has no commit-state authority"),
                     )
                 })?;
-        let manifest = &*published;
         // Replay debt is physical layout policy. Rootless commits remain
         // bounded-replay layouts; rooted commits publish their canonical
         // snapshot metadata inside immutable physical authority.
-        if manifest.commit_id != record.commit_id {
+        if published.commit_id() != record.commit_id {
             return Err(LixError::new(
                 LixError::CODE_INTERNAL_ERROR,
                 format!(
@@ -1194,9 +1193,10 @@ async fn stage_changelog_commits(
             ));
         }
         generations.insert(*commit_id, record.generation);
-        rootless_depths.insert(*commit_id, manifest.replay_debt.depth);
-        rootless_rows.insert(*commit_id, manifest.replay_debt.rows);
-        rootless_bytes.insert(*commit_id, manifest.replay_debt.bytes);
+        let replay_debt = published.replay_debt();
+        rootless_depths.insert(*commit_id, replay_debt.depth);
+        rootless_rows.insert(*commit_id, replay_debt.rows);
+        rootless_bytes.insert(*commit_id, replay_debt.bytes);
         external_parent_manifests.insert(*commit_id, published);
     }
     let mut staged_parent_count = BTreeMap::<CommitId, usize>::new();
@@ -2620,7 +2620,7 @@ async fn certify_complete_replacement_generations(
                         ),
                     )
                 })?;
-            let manifest = crate::tracked_state::load_published_commit_state_manifest(
+            let manifest = crate::tracked_state::load_published_commit_state_topology(
                 read, commit_id,
             )
             .await?
@@ -2632,7 +2632,7 @@ async fn certify_complete_replacement_generations(
                     ),
                 )
             })?;
-            if manifest.replay_debt.depth == 0 {
+            if manifest.replay_debt().depth == 0 {
                 break Some(commit_id);
             }
             let Some(metadata) = load_commit_delta_replay_metadata(read, commit_id).await? else {
@@ -2744,7 +2744,7 @@ async fn certify_ordered_journal_replacement_generations(
                         ),
                     )
                 })?;
-            let manifest = crate::tracked_state::load_published_commit_state_manifest(
+            let manifest = crate::tracked_state::load_published_commit_state_topology(
                 read, commit_id,
             )
             .await?
@@ -2754,7 +2754,7 @@ async fn certify_ordered_journal_replacement_generations(
                     format!("immutable replacement parent '{commit_id}' has no physical authority"),
                 )
             })?;
-            if manifest.replay_debt.depth == 0 {
+            if manifest.replay_debt().depth == 0 {
                 break Some(commit_id);
             }
             let Some(metadata) = load_commit_delta_replay_metadata(read, commit_id).await? else {
@@ -5476,7 +5476,7 @@ fn stage_commit_state_manifests<'a, S>(
     snapshot_roots: &'a BTreeMap<CommitId, TrackedStateCommitRoot>,
     external_parent_manifests: &'a BTreeMap<
         CommitId,
-        crate::tracked_state::PublishedCommitStateManifest,
+        crate::tracked_state::PublishedCommitStateTopology,
     >,
 ) -> std::pin::Pin<Box<dyn Future<Output = Result<(), LixError>> + Send + 'a>>
 where
@@ -5551,7 +5551,7 @@ where
                     )
                     .await?
                 } else {
-                    crate::tracked_state::stage_current_state_scoped_ranges_from_published_parent(
+                    crate::tracked_state::stage_current_state_scoped_ranges_from_published_topology_parent(
                         read,
                         writes,
                         external_parent,
@@ -5571,7 +5571,7 @@ where
                             .map(crate::tracked_state::CertifiedCommitStateTopologyParent::Staged)
                             .or_else(|| {
                                 external_parent_manifests.get(parent_id).map(
-                                    crate::tracked_state::CertifiedCommitStateTopologyParent::Published,
+                                    crate::tracked_state::CertifiedCommitStateTopologyParent::PublishedTopology,
                                 )
                             })
                             .ok_or_else(|| {
@@ -5591,7 +5591,7 @@ where
                     && !external_parent_manifests.contains_key(&source_id)
                 {
                     Some(
-                        crate::tracked_state::load_published_commit_state_manifest(read, source_id)
+                        crate::tracked_state::load_published_commit_state_topology(read, source_id)
                             .await?
                             .ok_or_else(|| {
                                 LixError::new(
@@ -5613,12 +5613,12 @@ where
                             .map(crate::tracked_state::CertifiedCommitStateTopologyParent::Staged)
                             .or_else(|| {
                                 external_parent_manifests.get(&source_id).map(
-                                    crate::tracked_state::CertifiedCommitStateTopologyParent::Published,
+                                    crate::tracked_state::CertifiedCommitStateTopologyParent::PublishedTopology,
                                 )
                             })
                             .or_else(|| {
                                 loaded_selected_source.as_ref().map(
-                                    crate::tracked_state::CertifiedCommitStateTopologyParent::Published,
+                                    crate::tracked_state::CertifiedCommitStateTopologyParent::PublishedTopology,
                                 )
                             })
                             .ok_or_else(|| {
@@ -6500,7 +6500,7 @@ mod tests {
     );
     const TRACKED_STATE_COMMIT_STATE_MANIFEST_SPACE: StorageSpace = StorageSpace::mutable(
         TRACKED_STATE_COMMIT_STATE_MANIFEST_SPACE_ID,
-        "tracked_state.commit_state_manifest.v4",
+        "tracked_state.commit_state_manifest.v7",
     );
     // V11 has no tracked-head marker space. Keep the retired v10 ID here only
     // as a negative test sentinel: normal serving and staging must never read

--- a/packages/engine/src/transaction/commit.rs
+++ b/packages/engine/src/transaction/commit.rs
@@ -278,6 +278,8 @@ pub(crate) async fn commit_prepared_writes_with_parent_heads(
             )
         });
     let mut state_rows = prepared_writes.state_rows;
+    #[cfg(feature = "storage-benches")]
+    state_rows.record_ownership(crate::storage_bench::CRUD_OWNERSHIP_AUTHORITY);
     // Explicit branch publications are the final commit-planning consumer of
     // decoded JSON. Project them into one typed batch map before dropping the
     // shared parsed column; every later materialization stage consumes this
@@ -804,6 +806,8 @@ pub(crate) async fn commit_prepared_writes_with_parent_heads(
         &root_backed_branch_publications,
     )
     .await?;
+    #[cfg(feature = "storage-benches")]
+    state_rows.record_ownership(crate::storage_bench::CRUD_OWNERSHIP_ROOT_PUBLICATION);
     if !staged_hot_heads.deferred_fresh_hot_plans.is_empty() {
         if staged_hot_heads.deferred_fresh_hot_plans.len() != 1 {
             return Err(LixError::new(

--- a/packages/engine/src/transaction/context.rs
+++ b/packages/engine/src/transaction/context.rs
@@ -7968,8 +7968,8 @@ async fn opening_parent_complete_lifecycle_created_at(
     let Some(parent_commit_id) = parent_commit_id else {
         return Ok(None);
     };
-    let Some(manifest) =
-        crate::tracked_state::load_commit_state_manifest(read, parent_commit_id).await?
+    let Some(metadata) =
+        crate::tracked_state::load_commit_delta_replay_metadata(read, parent_commit_id).await?
     else {
         return Ok(None);
     };
@@ -7977,13 +7977,12 @@ async fn opening_parent_complete_lifecycle_created_at(
         schema_key: schema_key.to_owned(),
         file_id: None,
     };
-    if manifest.mutations.member_count != u32::try_from(live_count).unwrap_or(u32::MAX)
-        || manifest.mutations.single_partition.as_ref() != Some(&expected_scope)
+    if metadata.member_count != u32::try_from(live_count).unwrap_or(u32::MAX)
+        || metadata.single_partition.as_ref() != Some(&expected_scope)
     {
         return Ok(None);
     }
-    Ok(manifest
-        .mutations
+    Ok(metadata
         .lifecycle_summary
         .as_ref()
         .filter(|summary| {

--- a/packages/engine/src/transaction/context.rs
+++ b/packages/engine/src/transaction/context.rs
@@ -29,8 +29,8 @@ use crate::catalog::{
     stage_catalog_revision,
 };
 use crate::changelog::{
-    ChangeId, ChangeRecord, ChangeRecordProjection, CommitId, load_change_records,
-    materialize_known_change_payloads,
+    ChangeId, ChangeRecord, ChangeRecordProjection, ChangelogContext, ChangelogReader, CommitId,
+    CommitLoadRequest, load_change_records, materialize_known_change_payloads,
 };
 use crate::checkpoint::{
     CHECKPOINT_MARKER_SCHEMA_KEY, checkpoint_history_from_head, checkpoint_marker_stage_row,
@@ -154,13 +154,17 @@ where
             .collect::<BTreeSet<_>>()
             .into_iter()
             .collect::<Vec<_>>();
-        let accounts_by_commit = commit_ids
-            .iter()
-            .copied()
-            .zip(crate::tracked_state::load_commit_state_manifests(&self.store, &commit_ids).await?)
-            .map(|(commit_id, manifest)| {
-                manifest
-                    .map(|manifest| (commit_id, manifest.account_id))
+        let records = ChangelogContext::new()
+            .reader(&self.store)
+            .load_commits(CommitLoadRequest {
+                commit_ids: &commit_ids,
+            })
+            .await?;
+        let accounts_by_commit = records
+            .into_iter()
+            .map(|(commit_id, record)| {
+                record
+                    .map(|record| (*commit_id, record.account_id))
                     .ok_or_else(|| {
                         LixError::new(
                             LixError::CODE_INTERNAL_ERROR,

--- a/packages/engine/src/transaction/context.rs
+++ b/packages/engine/src/transaction/context.rs
@@ -624,6 +624,27 @@ impl TransactionMutationJournal {
         self.identity_offsets
             .push((start, self.identity_arena.len()));
     }
+
+    #[cfg(feature = "storage-benches")]
+    fn record_row_ownership(&self, identity_bytes: usize, snapshot_bytes: usize) {
+        crate::storage_bench::record_crud_ownership(
+            crate::storage_bench::CRUD_OWNERSHIP_MUTATION_JOURNAL,
+            1,
+            identity_bytes,
+            snapshot_bytes,
+            2,
+            0,
+            0,
+        );
+        let total = identity_bytes.saturating_add(snapshot_bytes);
+        crate::storage_bench::record_crud_ownership_transfer(
+            crate::storage_bench::CRUD_OWNERSHIP_MUTATION_JOURNAL,
+            total,
+            0,
+            total,
+            0,
+        );
+    }
 }
 
 /// One already-resolved tracked-state transition. The expected side is
@@ -1694,6 +1715,8 @@ where
         // transaction so deterministic preparation failures can still drain
         // prospective plugin actor documents before returning.
         let commit_storage = transaction.storage.clone();
+        #[cfg(feature = "storage-benches")]
+        crate::storage_bench::record_crud_write_set_arena(&writes);
         let prepared_commit = match commit_storage
             .prepare_write_set(writes, write_options)
             .instrument(tracing::debug_span!(
@@ -1712,6 +1735,16 @@ where
         };
         let storage_stats = commit_at_boundary(commit_boundary.as_ref(), || async move {
             let (_commit, stats) = prepared_commit.commit().await?;
+            #[cfg(feature = "storage-benches")]
+            crate::storage_bench::record_crud_ownership(
+                crate::storage_bench::CRUD_OWNERSHIP_ADAPTER,
+                stats.staged_puts.saturating_add(stats.staged_deletes) as usize,
+                0,
+                stats.written_bytes as usize,
+                stats.put_batches.saturating_add(stats.delete_batches) as usize,
+                stats.storage_calls as usize,
+                stats.touched_spaces as usize,
+            );
             Ok(stats)
         })
         .instrument(tracing::debug_span!(
@@ -6552,6 +6585,11 @@ where
         let timestamp = *timestamp_slot.get_or_insert_with(|| functions.call_timestamp());
         journal.append_identity(primary_key);
         journal.snapshot_offsets.push(snapshot_offset);
+        #[cfg(feature = "storage-benches")]
+        journal.record_row_ownership(
+            primary_key.len(),
+            snapshot_offset.1.saturating_sub(snapshot_offset.0),
+        );
         let journal_timestamp = journal.timestamp.get_or_insert(timestamp);
         debug_assert_eq!(*journal_timestamp, timestamp);
         Ok(Some(crate::sql2::SqlWriteResult::affected(1)))
@@ -6689,6 +6727,11 @@ where
         )?;
         journal.append_identity(primary_key);
         journal.snapshot_offsets.push(snapshot_offset);
+        #[cfg(feature = "storage-benches")]
+        journal.record_row_ownership(
+            primary_key.len(),
+            snapshot_offset.1.saturating_sub(snapshot_offset.0),
+        );
         let journal_timestamp = journal.timestamp.get_or_insert(timestamp);
         debug_assert_eq!(*journal_timestamp, timestamp);
         Ok(Some(crate::sql2::SqlWriteResult::affected(1)))
@@ -6914,10 +6957,35 @@ where
             return Ok(());
         }
         self.ensure_plugin_generation_read_guard().await;
+        let identity_arena_bytes = journal.identity_arena.len();
+        let snapshot_arena_bytes = journal.snapshot_arena.len();
+        let journal_rows = journal.len();
         #[cfg(feature = "storage-benches")]
         {
-            let row_count = journal.len();
-            crate::storage_bench::record_transaction_rows_staged(row_count);
+            crate::storage_bench::record_crud_ownership(
+                crate::storage_bench::CRUD_OWNERSHIP_IDENTITY_ENCODING,
+                journal_rows,
+                identity_arena_bytes,
+                snapshot_arena_bytes,
+                journal
+                    .identity_offsets
+                    .len()
+                    .saturating_add(journal.snapshot_offsets.len()),
+                0,
+                0,
+            );
+            let total = identity_arena_bytes.saturating_add(snapshot_arena_bytes);
+            crate::storage_bench::record_crud_ownership_transfer(
+                crate::storage_bench::CRUD_OWNERSHIP_IDENTITY_ENCODING,
+                0,
+                0,
+                total,
+                0,
+            );
+        }
+        #[cfg(feature = "storage-benches")]
+        {
+            crate::storage_bench::record_transaction_rows_staged(journal_rows);
             crate::storage_bench::record_transaction_untracked_rows(0);
         }
         let timestamp = journal.timestamp.ok_or_else(|| {
@@ -6938,6 +7006,26 @@ where
             None,
             timestamp,
         )?;
+        #[cfg(feature = "storage-benches")]
+        {
+            crate::storage_bench::record_crud_ownership(
+                crate::storage_bench::CRUD_OWNERSHIP_NORMALIZATION,
+                journal_rows,
+                identity_arena_bytes,
+                snapshot_arena_bytes,
+                journal_rows.saturating_mul(2),
+                0,
+                0,
+            );
+            let total = identity_arena_bytes.saturating_add(snapshot_arena_bytes);
+            crate::storage_bench::record_crud_ownership_transfer(
+                crate::storage_bench::CRUD_OWNERSHIP_NORMALIZATION,
+                0,
+                0,
+                total,
+                0,
+            );
+        }
         let eager_collection_is_bounded = match &self.prepared_mutation_membership {
             PreparedMutationMembership::Packed(membership) => {
                 usize::try_from(membership.complete_generation().0)

--- a/packages/engine/src/transaction/context.rs
+++ b/packages/engine/src/transaction/context.rs
@@ -8963,9 +8963,11 @@ where
         #[cfg(feature = "storage-benches")]
         {
             crate::storage_bench::record_transaction_rows_staged(row_count);
-            crate::storage_bench::record_transaction_untracked_rows(0);
+            crate::storage_bench::record_transaction_untracked_rows(
+                row_count * usize::from(rows.untracked()),
+            );
         }
-        let domain = Domain::schema_catalog(branch_id, false);
+        let domain = Domain::schema_catalog(branch_id, rows.untracked());
         let prepared = if self
             .staged_writes
             .has_staged_schema_catalog_change(&domain)?
@@ -9026,9 +9028,12 @@ where
         #[cfg(feature = "storage-benches")]
         {
             crate::storage_bench::record_transaction_rows_staged(row_count);
-            crate::storage_bench::record_transaction_untracked_rows(0);
+            crate::storage_bench::record_transaction_untracked_rows(
+                row_count * usize::from(rows.untracked()),
+            );
         }
-        let domain = Domain::schema_catalog(rows.schema_scope_branch_id().to_string(), false);
+        let domain =
+            Domain::schema_catalog(rows.schema_scope_branch_id().to_string(), rows.untracked());
         let prepared = if self
             .staged_writes
             .has_staged_schema_catalog_change(&domain)?

--- a/packages/engine/src/transaction/staging.rs
+++ b/packages/engine/src/transaction/staging.rs
@@ -391,29 +391,37 @@ impl ImmutableMutationJournalChunk {
             self.len()
                 .div_ceil(crate::tracked_state::REPLACEMENT_PART_MAX_ROWS),
         );
+        #[cfg(feature = "storage-benches")]
+        let mut generated_key_bytes = 0usize;
         let mut first = 0usize;
         while first < self.len() {
             let max_candidate_len =
                 (self.len() - first).min(crate::tracked_state::REPLACEMENT_PART_MAX_ROWS);
-            let mut keys = Vec::with_capacity(max_candidate_len);
+            let mut key_arena = Vec::new();
+            let mut key_offsets = Vec::with_capacity(max_candidate_len);
             for index in first..first + max_candidate_len {
-                let mut key = Vec::new();
+                let start = key_arena.len();
                 crate::tracked_state::encode_single_string_key_ref_into(
-                    &mut key,
+                    &mut key_arena,
                     self.schema_key(),
                     None,
                     self.identity(index),
                 );
-                keys.push(key);
+                #[cfg(feature = "storage-benches")]
+                {
+                    generated_key_bytes =
+                        generated_key_bytes.saturating_add(key_arena.len().saturating_sub(start));
+                }
+                key_offsets.push((start, key_arena.len()));
             }
             let mut candidate_len = max_candidate_len;
             let encoded = loop {
-                let rows = keys[..candidate_len]
+                let rows = key_offsets[..candidate_len]
                     .iter()
                     .enumerate()
                     .map(
-                        |(offset, key)| crate::tracked_state::ReplacementPartRowRef {
-                            encoded_key: key,
+                        |(offset, &(start, end))| crate::tracked_state::ReplacementPartRowRef {
+                            encoded_key: &key_arena[start..end],
                             snapshot: self.snapshot_slot(first + offset),
                             metadata: crate::json_store::JsonSlotRef::None,
                         },
@@ -446,6 +454,26 @@ impl ImmutableMutationJournalChunk {
             };
             first += candidate_len;
             parts.push(encoded);
+        }
+        #[cfg(feature = "storage-benches")]
+        {
+            let encoded_bytes = parts.iter().map(|part| part.bytes().len()).sum::<usize>();
+            crate::storage_bench::record_crud_ownership(
+                crate::storage_bench::CRUD_OWNERSHIP_JOURNAL_SEAL,
+                self.len(),
+                generated_key_bytes,
+                encoded_bytes,
+                parts.len(),
+                0,
+                0,
+            );
+            crate::storage_bench::record_crud_ownership_transfer(
+                crate::storage_bench::CRUD_OWNERSHIP_JOURNAL_SEAL,
+                generated_key_bytes.saturating_add(encoded_bytes),
+                0,
+                encoded_bytes,
+                generated_key_bytes,
+            );
         }
         self.sealed_replacement_parts = Some(parts.into());
         Ok(())

--- a/packages/engine/src/transaction/types.rs
+++ b/packages/engine/src/transaction/types.rs
@@ -561,6 +561,7 @@ pub(crate) struct CertifiedParameterBatch {
     snapshots: Vec<TransactionJson>,
     schema_key: SharedStr,
     branch_id: SharedStr,
+    untracked: bool,
     certificate: CertifiedRawWriteBatchPreparation,
     entity_columnar: Option<crate::sql2::EncodedEntityRowGroups>,
 }
@@ -571,6 +572,24 @@ impl CertifiedParameterBatch {
         snapshots: Vec<TransactionJson>,
         schema_key: SharedStr,
         branch_id: SharedStr,
+        certificate: CertifiedRawWriteBatchPreparation,
+    ) -> Result<Self, LixError> {
+        Self::new_with_lane(
+            entity_pks,
+            snapshots,
+            schema_key,
+            branch_id,
+            false,
+            certificate,
+        )
+    }
+
+    pub(crate) fn new_with_lane(
+        entity_pks: Vec<EntityPk>,
+        snapshots: Vec<TransactionJson>,
+        schema_key: SharedStr,
+        branch_id: SharedStr,
+        untracked: bool,
         certificate: CertifiedRawWriteBatchPreparation,
     ) -> Result<Self, LixError> {
         if entity_pks.len() != snapshots.len() {
@@ -590,6 +609,7 @@ impl CertifiedParameterBatch {
             snapshots,
             schema_key,
             branch_id,
+            untracked,
             certificate,
             entity_columnar: None,
         })
@@ -615,12 +635,17 @@ impl CertifiedParameterBatch {
         self.schema_key.as_str()
     }
 
+    pub(crate) fn untracked(&self) -> bool {
+        self.untracked
+    }
+
     pub(crate) fn into_raw(self) -> Result<RawWriteBatch, LixError> {
         RawWriteBatch::from_certified_parameter_rows(
             self.entity_pks,
             self.snapshots,
             self.schema_key,
             self.branch_id,
+            self.untracked,
             self.certificate,
         )
     }
@@ -643,6 +668,7 @@ impl CertifiedParameterBatch {
             snapshots,
             schema_key,
             branch_id,
+            untracked,
             certificate,
             entity_columnar,
         } = self;
@@ -692,6 +718,7 @@ impl CertifiedParameterBatch {
                 timestamps,
                 commit_id: None,
                 branch_id: branch_id_ordinal,
+                untracked,
                 direct_change_ids: None,
                 entity_columnar,
             }),
@@ -848,6 +875,7 @@ impl RawWriteBatch {
         snapshots: Vec<TransactionJson>,
         schema_key: SharedStr,
         branch_id: SharedStr,
+        untracked: bool,
         certificate: CertifiedRawWriteBatchPreparation,
     ) -> Result<Self, LixError> {
         if entity_pks.len() != snapshots.len() {
@@ -895,7 +923,7 @@ impl RawWriteBatch {
             change_id: RAW_WRITE_NONE,
             commit_id: RAW_WRITE_NONE,
             branch_id: branch_id_ordinal,
-            flags: 0,
+            flags: if untracked { RAW_WRITE_UNTRACKED } else { 0 },
         };
         Ok(Self {
             slots: vec![slot; row_count],
@@ -1185,7 +1213,7 @@ impl RawWriteBatch {
                 || slot.updated_at != RAW_WRITE_NONE
                 || slot.change_id != RAW_WRITE_NONE
                 || slot.commit_id != RAW_WRITE_NONE
-                || slot.flags != 0
+                || slot.flags & !RAW_WRITE_UNTRACKED != 0
                 || metadata.is_some()
             {
                 return Err(LixError::new(
@@ -1229,7 +1257,7 @@ impl RawWriteBatch {
                 change_id: Some(ChangeId::default()),
                 addressable_change_id: true,
                 commit_id: None,
-                untracked: false,
+                untracked: slot.flags & RAW_WRITE_UNTRACKED != 0,
                 branch_id: slot.branch_id,
                 durable_predecessor: None,
             });
@@ -2715,6 +2743,7 @@ struct DenseCertifiedParameterSlots {
     timestamps: DenseParameterTimestamps,
     commit_id: Option<CommitId>,
     branch_id: u32,
+    untracked: bool,
     /// Absent until commit-delta publication assigns direct addresses. The
     /// compact segment map derives every UUID without a million-row column.
     direct_change_ids: Option<OrderedAddressableCommitDeltaStage>,
@@ -2996,7 +3025,7 @@ impl PreparedStateBatch {
                 )),
                 addressable_change_id: true,
                 commit_id: dense.commit_id,
-                untracked: false,
+                untracked: dense.untracked,
                 branch_id: &self.strings[dense.branch_id as usize],
                 durable_predecessor: None,
             });

--- a/packages/engine/src/transaction/types.rs
+++ b/packages/engine/src/transaction/types.rs
@@ -741,6 +741,74 @@ impl RawWriteRowRef<'_> {
     }
 }
 
+#[cfg(feature = "storage-benches")]
+fn record_raw_row_ownership(
+    entity_pk: Option<&EntityPk>,
+    schema_key: &SharedStr,
+    file_id: Option<&SharedStr>,
+    snapshot: Option<&TransactionJson>,
+    metadata: Option<&TransactionJson>,
+    created_at: Option<&SharedStr>,
+    updated_at: Option<&SharedStr>,
+    change_id: Option<&SharedStr>,
+    commit_id: Option<&SharedStr>,
+    branch_id: &SharedStr,
+) {
+    let key_bytes = entity_pk.map_or(0, EntityPk::estimated_heap_bytes)
+        + schema_key.len()
+        + file_id.map_or(0, |value| value.len())
+        + created_at.map_or(0, |value| value.len())
+        + updated_at.map_or(0, |value| value.len())
+        + change_id.map_or(0, |value| value.len())
+        + commit_id.map_or(0, |value| value.len())
+        + branch_id.len();
+    let value_bytes = snapshot.map_or(0, |value| value.normalized().len())
+        + metadata.map_or(0, |value| value.normalized().len());
+    crate::storage_bench::record_crud_ownership(
+        crate::storage_bench::CRUD_OWNERSHIP_RAW_BATCH,
+        1,
+        key_bytes,
+        value_bytes,
+        5,
+        1 + usize::from(file_id.is_some())
+            + usize::from(created_at.is_some())
+            + usize::from(updated_at.is_some())
+            + usize::from(change_id.is_some())
+            + usize::from(commit_id.is_some())
+            + 1,
+        2,
+    );
+}
+
+#[cfg(feature = "storage-benches")]
+fn record_prepared_row_ownership(
+    entity_pk: &EntityPk,
+    schema_key: &SharedStr,
+    file_id: Option<&SharedStr>,
+    snapshot: Option<&StageJson>,
+    metadata: Option<&StageJson>,
+    origin_key: Option<&SharedStr>,
+    branch_id: &SharedStr,
+    stage: usize,
+) {
+    let key_bytes = entity_pk.estimated_heap_bytes()
+        + schema_key.len()
+        + file_id.map_or(0, |value| value.len())
+        + origin_key.map_or(0, |value| value.len())
+        + branch_id.len();
+    let value_bytes = snapshot.map_or(0, |value| value.normalized().len())
+        + metadata.map_or(0, |value| value.normalized().len());
+    crate::storage_bench::record_crud_ownership(
+        stage,
+        1,
+        key_bytes,
+        value_bytes,
+        6,
+        2 + usize::from(file_id.is_some()) + usize::from(origin_key.is_some()),
+        2,
+    );
+}
+
 pub(crate) struct RawWriteRows<'a> {
     batch: &'a RawWriteBatch,
     range: std::ops::Range<usize>,
@@ -795,6 +863,24 @@ impl RawWriteBatch {
                 "certified parameter row count exceeds u32",
             ));
         }
+        #[cfg(feature = "storage-benches")]
+        crate::storage_bench::record_crud_ownership(
+            crate::storage_bench::CRUD_OWNERSHIP_RAW_BATCH,
+            row_count,
+            entity_pks
+                .iter()
+                .map(EntityPk::estimated_heap_bytes)
+                .sum::<usize>()
+                + schema_key.len()
+                + branch_id.len(),
+            snapshots
+                .iter()
+                .map(|value| value.normalized().len())
+                .sum::<usize>(),
+            row_count.saturating_mul(5),
+            2,
+            2,
+        );
         let (strings, schema_key_ordinal, branch_id_ordinal) = if schema_key == branch_id {
             (vec![schema_key], 0, 0)
         } else {
@@ -925,6 +1011,19 @@ impl RawWriteBatch {
         untracked: bool,
         branch_id: SharedStr,
     ) {
+        #[cfg(feature = "storage-benches")]
+        record_raw_row_ownership(
+            entity_pk.as_ref(),
+            &schema_key,
+            file_id.as_ref(),
+            snapshot.as_ref(),
+            metadata.as_ref(),
+            created_at.as_ref(),
+            updated_at.as_ref(),
+            change_id.as_ref(),
+            commit_id.as_ref(),
+            &branch_id,
+        );
         self.certified_preparation = None;
         assert!(
             self.slots.len() < RAW_WRITE_NONE as usize,
@@ -959,6 +1058,16 @@ impl RawWriteBatch {
     }
 
     pub(crate) fn append(&mut self, mut other: Self) {
+        #[cfg(feature = "storage-benches")]
+        crate::storage_bench::record_crud_ownership(
+            crate::storage_bench::CRUD_OWNERSHIP_RAW_TRANSFER,
+            other.len(),
+            0,
+            0,
+            other.len().saturating_mul(5),
+            0,
+            0,
+        );
         self.certified_preparation = None;
         self.reserve(other.len());
         for index in 0..other.len() {
@@ -2740,6 +2849,37 @@ impl PreparedStateBatch {
             .map_or_else(|| self.slots.len(), |dense| dense.len)
     }
 
+    #[cfg(feature = "storage-benches")]
+    pub(crate) fn record_ownership(&self, stage: usize) {
+        let mut key_bytes = 0usize;
+        let mut value_bytes = 0usize;
+        let mut string_entries = 0usize;
+        for row in self.iter() {
+            key_bytes = key_bytes
+                .saturating_add(row.entity_pk.estimated_heap_bytes())
+                .saturating_add(row.schema_key.len())
+                .saturating_add(row.file_id.map_or(0, |value| value.len()))
+                .saturating_add(row.origin_key.map_or(0, |value| value.len()))
+                .saturating_add(row.branch_id.len());
+            value_bytes = value_bytes
+                .saturating_add(row.snapshot.map_or(0, |value| value.normalized().len()))
+                .saturating_add(row.metadata.map_or(0, |value| value.normalized().len()));
+            string_entries = string_entries
+                .saturating_add(2)
+                .saturating_add(usize::from(row.file_id.is_some()))
+                .saturating_add(usize::from(row.origin_key.is_some()));
+        }
+        crate::storage_bench::record_crud_ownership(
+            stage,
+            self.len(),
+            key_bytes,
+            value_bytes,
+            self.len().saturating_mul(6),
+            string_entries,
+            self.len().saturating_mul(2),
+        );
+    }
+
     pub(crate) fn is_empty(&self) -> bool {
         self.len() == 0
     }
@@ -2988,6 +3128,17 @@ impl PreparedStateBatch {
         untracked: bool,
         branch_id: SharedStr,
     ) {
+        #[cfg(feature = "storage-benches")]
+        record_prepared_row_ownership(
+            &entity_pk,
+            &schema_key,
+            file_id.as_ref(),
+            snapshot.as_ref(),
+            metadata.as_ref(),
+            origin_key,
+            &branch_id,
+            crate::storage_bench::CRUD_OWNERSHIP_PREPARED_BATCH,
+        );
         self.expand_dense_certified_parameter();
         let entity_pk = self.push_entity_pk(entity_pk);
         let schema_key = self.intern_string(schema_key);
@@ -3146,6 +3297,16 @@ impl PreparedStateBatch {
 
     /// Appends another batch without materializing row-owned intermediates.
     pub(crate) fn append(&mut self, mut other: Self) {
+        #[cfg(feature = "storage-benches")]
+        crate::storage_bench::record_crud_ownership(
+            crate::storage_bench::CRUD_OWNERSHIP_PREPARED_CLONE,
+            other.len(),
+            0,
+            0,
+            other.len().saturating_mul(6),
+            0,
+            0,
+        );
         if other.is_empty() {
             return;
         }
@@ -3604,6 +3765,17 @@ impl PreparedStateBatch {
     }
 
     fn push_borrowed_row(&mut self, row: PreparedStateRowRef<'_>) {
+        #[cfg(feature = "storage-benches")]
+        record_prepared_row_ownership(
+            row.entity_pk,
+            row.schema_key,
+            row.file_id,
+            row.snapshot,
+            row.metadata,
+            row.origin_key,
+            row.branch_id,
+            crate::storage_bench::CRUD_OWNERSHIP_PREPARED_CLONE,
+        );
         self.push_parts_with_change_addressability(
             row.schema_plan_id,
             row.facts,

--- a/packages/rs-sdk-tests/BRANCH_MERGE_BENCHMARK.md
+++ b/packages/rs-sdk-tests/BRANCH_MERGE_BENCHMARK.md
@@ -1,10 +1,14 @@
 # Branch and merge qualification benchmark
 
 `branch_merge_benchmark` is a correctness-gated benchmark for branch creation,
-branch switching, historical diff, merge preview, and merge commit. The controller launches one
+branch switching and deletion, historical diff, merge preview, and merge commit. The controller launches one
 fresh process per scenario so allocator retention, RocksDB caches, and WASM
 instances cannot leak between samples. Each worker emits exactly one JSON
 object on stdout; concatenate stdout to retain JSONL suitable for comparison.
+
+RocksDB is the default backend. Set
+`LIX_BRANCH_MERGE_BENCH_STORAGE=slatedb` to run the same qualification or
+worker against SlateDB.
 
 ## Commands
 

--- a/packages/rs-sdk-tests/BRANCH_MERGE_BENCHMARK.md
+++ b/packages/rs-sdk-tests/BRANCH_MERGE_BENCHMARK.md
@@ -12,12 +12,20 @@ worker against SlateDB.
 
 ## Commands
 
-Build and run qualification cases:
+Build and run qualification cases. Publishable artifacts must embed the exact
+source revision and compiler identity; each worker also hashes its executable
+before starting the process timer:
 
 ```sh
-cargo build --release -p lix_sdk_tests --example branch_merge_benchmark
+LIX_BENCH_COMMIT_SHA="$(git rev-parse HEAD)" \
+LIX_BENCH_RUSTC_VERSION="$(rustc --version)" \
+  cargo build --release -p lix_sdk_tests --example branch_merge_benchmark
 target/release/examples/branch_merge_benchmark qualification > branch-merge.jsonl
 ```
+
+Each schema-v2 record includes those values, the executable SHA-256, Cargo
+profile, target architecture, and target OS. A record containing `unrecorded`
+provenance is useful for local diagnosis but is not publishable evidence.
 
 Set `LIX_BRANCH_MERGE_BENCH_SAMPLES=11` to run every configuration in eleven
 separate child processes. Each JSON object includes its zero-based `sample`, so
@@ -54,7 +62,9 @@ the often size-limited system temporary filesystem. Set
 
 Workers report wall and CPU time, exact Rust allocation traffic, operation-local
 baseline/sampled-peak/retained RSS, process physical I/O deltas, merge tracing
-phases, parameters, merge outcome, and plugin transition counters. The 1 ms RSS
+phases, parameters, merge outcome, and plugin transition counters. Row workers
+report storage size separately after merge and after durable fanout-branch
+deletion, and include deletion-local process I/O. The 1 ms RSS
 sampler begins immediately before each operation and stops immediately afterward;
 incremental peak is the sampled peak minus the pre-operation RSS. Because a
 sub-millisecond RSS spike can fall between samples, use allocation traffic and
@@ -62,6 +72,12 @@ retained RSS as the gates for short operations; sampled peak RSS is a hard gate
 only when the measured operation lasts at least 5 ms. Native RocksDB allocations
 remain visible to RSS but not the Rust allocator counter. Use a release binary on
 an otherwise idle host for publishable results.
+
+Linux process-I/O counters come from `/proc/self/io`. The harness does not evict
+or otherwise control the OS page cache, so these counters are a lower bound on
+physical device traffic: a zero read delta does not prove zero logical reads or
+absence of read amplification. Use isolated cold-cache runs or backend-native
+logical counters when making cold-read amplification claims.
 
 Normalized-row cases compare Lix with a separate entity-level three-way model and
 compare `lix_diff` row counts with an independent map diff. Branch fanout reports

--- a/packages/rs-sdk-tests/Cargo.toml
+++ b/packages/rs-sdk-tests/Cargo.toml
@@ -16,6 +16,7 @@ lix_sdk = { path = "../rs-sdk", version = "0.10.0", default-features = false, fe
 lix_collaboration_test_support = { path = "../collaboration-test-support" }
 lix_engine = { path = "../engine", version = "0.10.0", features = ["storage-benches"] }
 lix_rocksdb_storage = { path = "../rocksdb-storage", version = "0.10.0" }
+lix_slatedb_storage = { path = "../slatedb-storage", version = "0.10.0" }
 plugin_csv = { path = "../../plugins/csv", lib = true, artifact = "cdylib", target = "wasm32-wasip2" }
 plugin_excalidraw = { path = "../../plugins/excalidraw", lib = true, artifact = "cdylib", target = "wasm32-wasip2" }
 plugin_markdown = { path = "../../plugins/markdown", lib = true, artifact = "cdylib", target = "wasm32-wasip2" }

--- a/packages/rs-sdk-tests/examples/branch_merge_benchmark.rs
+++ b/packages/rs-sdk-tests/examples/branch_merge_benchmark.rs
@@ -27,6 +27,7 @@ use lix_sdk::{
 };
 use lix_slatedb_storage::SlateDB;
 use serde_json::json;
+use sha2::{Digest as _, Sha256};
 use tracing::Subscriber;
 use tracing::span::{Attributes, Id};
 use tracing::subscriber::Interest;
@@ -34,7 +35,7 @@ use tracing_subscriber::Layer;
 use tracing_subscriber::layer::{Context as TracingContext, SubscriberExt};
 use tracing_subscriber::registry::LookupSpan;
 
-const SCHEMA_VERSION: u64 = 1;
+const SCHEMA_VERSION: u64 = 2;
 const SOURCE_BRANCH_ID: &str = "01920000-0000-7000-8000-00000000b001";
 const INSERT_BATCH: usize = 250;
 
@@ -405,6 +406,7 @@ where
         "file benchmark requires the five primary affected files"
     );
     let cold_reopen = cfg.scenario == "all_plugins_cold_reopen";
+    let provenance = benchmark_provenance();
     let total_started = Instant::now();
     let root = benchmark_tempdir();
     let db_path = root.path().join(".lix");
@@ -598,6 +600,7 @@ where
 
     println!("{}", serde_json::to_string(&json!({
         "schema_version": SCHEMA_VERSION,
+        "provenance": provenance,
         "status": "ok",
         "storage_backend": StorageImpl::NAME,
         "layer": "files",
@@ -632,12 +635,13 @@ where
             "merge_retained": signed_delta(merge_measure.after.rss_bytes, merge_measure.before.rss_bytes),
         },
         "io_bytes": {
+            "measurement": io_measurement_metadata(),
             "preview_read": preview_measure.after.read_bytes.saturating_sub(preview_measure.before.read_bytes),
             "preview_write": preview_measure.after.write_bytes.saturating_sub(preview_measure.before.write_bytes),
             "merge_read": merge_measure.after.read_bytes.saturating_sub(merge_measure.before.read_bytes),
             "merge_write": merge_measure.after.write_bytes.saturating_sub(merge_measure.before.write_bytes),
-            "storage_before": storage_bytes_before, "storage_after": storage_bytes_after,
-            "storage_growth": signed_delta(storage_bytes_after, storage_bytes_before),
+            "storage_before": storage_bytes_before, "storage_after_merge": storage_bytes_after,
+            "storage_growth_after_merge": signed_delta(storage_bytes_after, storage_bytes_before),
         },
         "phase_ms": { "preview": preview_phases, "merge": merge_phases },
         "plugin_counters": {
@@ -669,6 +673,7 @@ async fn run_row_case<StorageImpl>(cfg: Config, collector: PerfSpanCollector)
 where
     StorageImpl: BenchmarkStorage,
 {
+    let provenance = benchmark_provenance();
     let total_started = Instant::now();
     let root = benchmark_tempdir();
     let db_path = root.path().join(".lix");
@@ -978,6 +983,7 @@ where
             "deleted branch remained visible"
         );
     }
+    let storage_bytes_after_branch_deletion = directory_bytes(&db_path);
     source.close().await.expect("close source session");
     lix.close().await.expect("close target session");
     drop(source);
@@ -1002,6 +1008,7 @@ where
 
     let result = json!({
         "schema_version": SCHEMA_VERSION,
+        "provenance": provenance,
         "status": "ok",
         "storage_backend": StorageImpl::NAME,
         "layer": cfg.layer,
@@ -1069,14 +1076,20 @@ where
             "diff_retained": signed_delta(diff_measure.after.rss_bytes, diff_measure.before.rss_bytes),
         },
         "io_bytes": {
+            "measurement": io_measurement_metadata(),
             "preview_read": preview_measure.after.read_bytes.saturating_sub(preview_measure.before.read_bytes),
             "preview_write": preview_measure.after.write_bytes.saturating_sub(preview_measure.before.write_bytes),
             "merge_read": merge_measure.after.read_bytes.saturating_sub(merge_measure.before.read_bytes),
             "merge_write": merge_measure.after.write_bytes.saturating_sub(merge_measure.before.write_bytes),
             "diff_read": diff_measure.after.read_bytes.saturating_sub(diff_measure.before.read_bytes),
             "diff_write": diff_measure.after.write_bytes.saturating_sub(diff_measure.before.write_bytes),
-            "storage_before": storage_bytes_before, "storage_after": storage_bytes_after,
-            "storage_growth": signed_delta(storage_bytes_after, storage_bytes_before),
+            "delete_branches_read": delete_branches_measure.after.read_bytes.saturating_sub(delete_branches_measure.before.read_bytes),
+            "delete_branches_write": delete_branches_measure.after.write_bytes.saturating_sub(delete_branches_measure.before.write_bytes),
+            "storage_before": storage_bytes_before,
+            "storage_after_merge": storage_bytes_after,
+            "storage_growth_after_merge": signed_delta(storage_bytes_after, storage_bytes_before),
+            "storage_after_branch_deletion": storage_bytes_after_branch_deletion,
+            "storage_growth_after_branch_deletion": signed_delta(storage_bytes_after_branch_deletion, storage_bytes_before),
         },
         "phase_ms": {
             "setup": setup_phases,
@@ -1166,6 +1179,27 @@ impl BenchmarkStorage for SlateDB {
 
 fn benchmark_storage_name() -> String {
     std::env::var("LIX_BRANCH_MERGE_BENCH_STORAGE").unwrap_or_else(|_| "rocksdb".to_owned())
+}
+
+fn benchmark_provenance() -> serde_json::Value {
+    let executable = std::env::current_exe().expect("resolve benchmark executable");
+    let executable_bytes = fs::read(&executable).expect("read benchmark executable for hashing");
+    json!({
+        "commit_sha": option_env!("LIX_BENCH_COMMIT_SHA").unwrap_or("unrecorded"),
+        "binary_sha256": format!("{:x}", Sha256::digest(&executable_bytes)),
+        "rustc_version": option_env!("LIX_BENCH_RUSTC_VERSION").unwrap_or("unrecorded"),
+        "cargo_profile": if cfg!(debug_assertions) { "debug" } else { "release" },
+        "target_arch": std::env::consts::ARCH,
+        "target_os": std::env::consts::OS,
+    })
+}
+
+fn io_measurement_metadata() -> serde_json::Value {
+    json!({
+        "source": if cfg!(target_os = "linux") { "/proc/self/io" } else { "unavailable" },
+        "os_page_cache_controlled": false,
+        "interpretation": "process physical I/O lower bound; zero does not prove zero logical reads",
+    })
 }
 
 async fn open_benchmark<StorageImpl>(path: &Path) -> Lix<StorageImpl>

--- a/packages/rs-sdk-tests/examples/branch_merge_benchmark.rs
+++ b/packages/rs-sdk-tests/examples/branch_merge_benchmark.rs
@@ -25,6 +25,7 @@ use lix_sdk::{
     CreateBranchOptions, Lix, MergeBranchOptions, MergeBranchOutcome, MergeBranchPreviewOptions,
     Storage, SwitchBranchOptions, Value, open_lix_with_storage,
 };
+use lix_slatedb_storage::SlateDB;
 use serde_json::json;
 use tracing::Subscriber;
 use tracing::span::{Attributes, Id};
@@ -360,22 +361,41 @@ fn worker(cfg: Config) {
             .build()
             .expect("benchmark runtime")
             .block_on(async move {
-                match cfg.layer.as_str() {
-                    "rows" => {
-                        assert!(
-                            cfg.changes * 2 <= cfg.rows,
-                            "row fixture needs two disjoint change ranges"
-                        );
-                        run_row_case(cfg, collector).await;
+                let storage = benchmark_storage_name();
+                match storage.as_str() {
+                    "rocksdb" => run_worker::<RocksDB>(cfg, collector).await,
+                    "slatedb" => run_worker::<SlateDB>(cfg, collector).await,
+                    storage => {
+                        panic!(
+                            "unknown LIX_BRANCH_MERGE_BENCH_STORAGE {storage:?}; expected rocksdb or slatedb"
+                        )
                     }
-                    "files" => run_file_case(cfg, collector).await,
-                    other => panic!("unknown benchmark layer {other:?}"),
                 }
             });
     });
 }
 
-async fn run_file_case(cfg: Config, collector: PerfSpanCollector) {
+async fn run_worker<StorageImpl>(cfg: Config, collector: PerfSpanCollector)
+where
+    StorageImpl: BenchmarkStorage,
+{
+    match cfg.layer.as_str() {
+        "rows" => {
+            assert!(
+                cfg.changes * 2 <= cfg.rows,
+                "row fixture needs two disjoint change ranges"
+            );
+            run_row_case::<StorageImpl>(cfg, collector).await;
+        }
+        "files" => run_file_case::<StorageImpl>(cfg, collector).await,
+        other => panic!("unknown benchmark layer {other:?}"),
+    }
+}
+
+async fn run_file_case<StorageImpl>(cfg: Config, collector: PerfSpanCollector)
+where
+    StorageImpl: BenchmarkStorage,
+{
     assert!(matches!(
         cfg.scenario.as_str(),
         "all_plugins_resolvable" | "all_plugins_cold_reopen"
@@ -390,7 +410,7 @@ async fn run_file_case(cfg: Config, collector: PerfSpanCollector) {
     let db_path = root.path().join(".lix");
     let process_baseline_rss = current_rss_bytes();
     let open_started = Instant::now();
-    let mut lix = open_rocks(&db_path).await;
+    let mut lix = open_benchmark::<StorageImpl>(&db_path).await;
     let open_ms = elapsed_ms(open_started);
 
     let plugins_started = Instant::now();
@@ -444,7 +464,7 @@ async fn run_file_case(cfg: Config, collector: PerfSpanCollector) {
             .expect("close target before cold measurement");
         drop(source);
         drop(lix);
-        lix = open_rocks(&db_path).await;
+        lix = open_benchmark::<StorageImpl>(&db_path).await;
         source = lix
             .open_session(SOURCE_BRANCH_ID)
             .await
@@ -563,7 +583,7 @@ async fn run_file_case(cfg: Config, collector: PerfSpanCollector) {
     drop(source);
     drop(lix);
     let reopen_started = Instant::now();
-    let reopened = open_rocks(&db_path).await;
+    let reopened = open_benchmark::<StorageImpl>(&db_path).await;
     let reopen_ms = elapsed_ms(reopen_started);
     assert_eq!(
         read_all_files(&reopened, fixture_files.keys()).await,
@@ -579,6 +599,7 @@ async fn run_file_case(cfg: Config, collector: PerfSpanCollector) {
     println!("{}", serde_json::to_string(&json!({
         "schema_version": SCHEMA_VERSION,
         "status": "ok",
+        "storage_backend": StorageImpl::NAME,
         "layer": "files",
         "scenario": cfg.scenario,
         "sample": benchmark_sample(),
@@ -644,12 +665,15 @@ async fn run_file_case(cfg: Config, collector: PerfSpanCollector) {
     })).expect("serialize plugin result"));
 }
 
-async fn run_row_case(cfg: Config, collector: PerfSpanCollector) {
+async fn run_row_case<StorageImpl>(cfg: Config, collector: PerfSpanCollector)
+where
+    StorageImpl: BenchmarkStorage,
+{
     let total_started = Instant::now();
     let root = benchmark_tempdir();
     let db_path = root.path().join(".lix");
     let open_started = Instant::now();
-    let mut lix = open_rocks(&db_path).await;
+    let mut lix = open_benchmark::<StorageImpl>(&db_path).await;
     let open_ms = elapsed_ms(open_started);
     register_row_schema(&lix).await;
     seed_rows(&lix, &cfg).await;
@@ -658,7 +682,7 @@ async fn run_row_case(cfg: Config, collector: PerfSpanCollector) {
     lix.close().await.expect("close row setup fixture");
     drop(lix);
     let setup_reopen_started = Instant::now();
-    lix = open_rocks(&db_path).await;
+    lix = open_benchmark::<StorageImpl>(&db_path).await;
     let setup_reopen_ms = elapsed_ms(setup_reopen_started);
     let main_branch_id = lix.active_branch_id().await.expect("main branch id");
 
@@ -932,23 +956,54 @@ async fn run_row_case(cfg: Config, collector: PerfSpanCollector) {
 
     let final_rows = read_rows(&lix).await;
     let storage_bytes_after = directory_bytes(&db_path);
+    let fanout_branch_ids = (0..cfg.branches.saturating_sub(1))
+        .map(|index| format!("01920000-0000-7000-8000-{:012x}", 0xc000 + index))
+        .collect::<Vec<_>>();
+    let delete_branches_measure = measure_async(|| async {
+        for branch_id in &fanout_branch_ids {
+            let result = lix
+                .execute(
+                    "DELETE FROM lix_branch WHERE id = $1",
+                    &[Value::Text(branch_id.clone())],
+                )
+                .await
+                .expect("delete fanout branch");
+            assert_eq!(result.rows_affected(), 1);
+        }
+    })
+    .await;
+    for branch_id in &fanout_branch_ids {
+        assert!(
+            !branch_exists(&lix, branch_id).await,
+            "deleted branch remained visible"
+        );
+    }
     source.close().await.expect("close source session");
     lix.close().await.expect("close target session");
     drop(source);
     drop(lix);
     let reopen_started = Instant::now();
-    let reopened = open_rocks(&db_path).await;
+    let reopened = open_benchmark::<StorageImpl>(&db_path).await;
     let reopen_ms = elapsed_ms(reopen_started);
     assert_eq!(
         read_rows(&reopened).await,
         final_rows,
         "rows changed across close/reopen"
     );
+    for branch_id in &fanout_branch_ids {
+        assert!(
+            !branch_exists(&reopened, branch_id).await,
+            "deleted branch reappeared after reopen"
+        );
+    }
+    let delete_branch_mean_ms = (!fanout_branch_ids.is_empty())
+        .then_some(delete_branches_measure.wall_ms / fanout_branch_ids.len().max(1) as f64);
     reopened.close().await.expect("close reopened session");
 
     let result = json!({
         "schema_version": SCHEMA_VERSION,
         "status": "ok",
+        "storage_backend": StorageImpl::NAME,
         "layer": cfg.layer,
         "scenario": cfg.scenario,
         "sample": benchmark_sample(),
@@ -958,6 +1013,7 @@ async fn run_row_case(cfg: Config, collector: PerfSpanCollector) {
             "divergent_commits_per_side": cfg.divergent_commits,
             "common_history_commits": cfg.history,
             "live_branches": cfg.branches,
+            "deleted_fanout_branches": fanout_branch_ids.len(),
             "payload_bytes": cfg.payload_bytes,
         },
         "latency_ms": {
@@ -970,6 +1026,8 @@ async fn run_row_case(cfg: Config, collector: PerfSpanCollector) {
             "create_branch_median": branch_median_ms,
             "create_branch_last": branch_last_ms,
             "create_branch_max": branch_max_ms,
+            "delete_branches_total": delete_branches_measure.wall_ms,
+            "delete_branch_mean": delete_branch_mean_ms,
             "switch_roundtrip": switch_roundtrip_ms,
             "preview": preview_measure.wall_ms,
             "merge": merge_measure.wall_ms,
@@ -978,11 +1036,13 @@ async fn run_row_case(cfg: Config, collector: PerfSpanCollector) {
         },
         "cpu_ms": {
             "create_branches": branch_measure.cpu_ms, "switch_roundtrip": switch_measure.cpu_ms,
+            "delete_branches": delete_branches_measure.cpu_ms,
             "preview": preview_measure.cpu_ms, "merge": merge_measure.cpu_ms,
             "diff": diff_measure.cpu_ms
         },
         "allocated_bytes": {
             "create_branches": branch_measure.allocated_bytes,
+            "delete_branches": delete_branches_measure.allocated_bytes,
             "switch_roundtrip": switch_measure.allocated_bytes,
             "preview": preview_measure.allocated_bytes,
             "merge": merge_measure.allocated_bytes,
@@ -999,6 +1059,10 @@ async fn run_row_case(cfg: Config, collector: PerfSpanCollector) {
             "merge_retained": signed_delta(merge_measure.after.rss_bytes, merge_measure.before.rss_bytes),
             "create_branches_incremental_peak": branch_measure.peak_rss_bytes.saturating_sub(branch_measure.before.rss_bytes),
             "create_branches_retained": signed_delta(branch_measure.after.rss_bytes, branch_measure.before.rss_bytes),
+            "delete_branches_baseline": delete_branches_measure.before.rss_bytes,
+            "delete_branches_peak": delete_branches_measure.peak_rss_bytes,
+            "delete_branches_incremental_peak": delete_branches_measure.peak_rss_bytes.saturating_sub(delete_branches_measure.before.rss_bytes),
+            "delete_branches_retained": signed_delta(delete_branches_measure.after.rss_bytes, delete_branches_measure.before.rss_bytes),
             "switch_incremental_peak": switch_measure.peak_rss_bytes.saturating_sub(switch_measure.before.rss_bytes),
             "switch_retained": signed_delta(switch_measure.after.rss_bytes, switch_measure.before.rss_bytes),
             "diff_incremental_peak": diff_measure.peak_rss_bytes.saturating_sub(diff_measure.before.rss_bytes),
@@ -1027,6 +1091,7 @@ async fn run_row_case(cfg: Config, collector: PerfSpanCollector) {
             "failed_merge_atomic": (!expected_clean).then_some(true),
             "source_branch_unchanged": true,
             "branch_isolation": true,
+            "branch_deletion_durable": true,
             "merge_parent_count": merge_parents,
             "close_reopen_stable": true,
             "heads_and_merge_base": true,
@@ -1077,8 +1142,37 @@ where
     }
 }
 
-async fn open_rocks(path: &Path) -> Lix<RocksDB> {
-    let storage = RocksDB::open(path).expect("open benchmark RocksDB");
+trait BenchmarkStorage: Storage + Clone + Send + Sync + 'static {
+    const NAME: &'static str;
+
+    fn open_for_benchmark(path: &Path) -> Self;
+}
+
+impl BenchmarkStorage for RocksDB {
+    const NAME: &'static str = "rocksdb";
+
+    fn open_for_benchmark(path: &Path) -> Self {
+        Self::open(path).expect("open benchmark RocksDB")
+    }
+}
+
+impl BenchmarkStorage for SlateDB {
+    const NAME: &'static str = "slatedb";
+
+    fn open_for_benchmark(path: &Path) -> Self {
+        Self::open(path).expect("open benchmark SlateDB")
+    }
+}
+
+fn benchmark_storage_name() -> String {
+    std::env::var("LIX_BRANCH_MERGE_BENCH_STORAGE").unwrap_or_else(|_| "rocksdb".to_owned())
+}
+
+async fn open_benchmark<StorageImpl>(path: &Path) -> Lix<StorageImpl>
+where
+    StorageImpl: BenchmarkStorage,
+{
+    let storage = StorageImpl::open_for_benchmark(path);
     open_lix_with_storage(storage)
         .await
         .expect("open benchmark Lix")
@@ -1450,6 +1544,20 @@ where
     .rows()[0]
         .get::<String>("commit_id")
         .expect("branch head commit id")
+}
+
+async fn branch_exists<StorageImpl>(lix: &Lix<StorageImpl>, branch_id: &str) -> bool
+where
+    StorageImpl: Storage + Clone + Send + Sync + 'static,
+{
+    !lix.execute(
+        "SELECT id FROM lix_branch WHERE id = $1",
+        &[Value::Text(branch_id.to_owned())],
+    )
+    .await
+    .expect("query branch existence")
+    .rows()
+    .is_empty()
 }
 
 async fn install_all_plugins<StorageImpl>(lix: &Lix<StorageImpl>)

--- a/packages/rs-sdk/benches/profile_checkpoint_scale.rs
+++ b/packages/rs-sdk/benches/profile_checkpoint_scale.rs
@@ -362,7 +362,7 @@ where
             parameter + 3
         )
         .expect("write insert parameter placeholders");
-        params.push(Value::Text(format!("benchmark-file-{file_index:05}")));
+        params.push(Value::Text(benchmark_file_id(file_index)));
         params.push(Value::Text(format!("/files/{file_index:05}.bin")));
         params.push(Value::Blob(payload(0, file_index, FILE_BYTES).into()));
     }
@@ -540,7 +540,7 @@ async fn run_workload<S>(
                 let file_index =
                     benchmark_file_index(file_count, checkpoint_index, auto_commit_index, offset);
                 expected_payloads.insert(
-                    format!("benchmark-file-{file_index:05}"),
+                    benchmark_file_id(file_index),
                     payload(checkpoint_index, file_index, FILE_BYTES),
                 );
             }
@@ -652,7 +652,7 @@ async fn update_file_group<S>(
             sql: "UPDATE lix_file SET content = $1 WHERE id = $2".to_string(),
             params: vec![
                 Value::Blob(payload(checkpoint_index, file_index, FILE_BYTES).into()),
-                Value::Text(format!("benchmark-file-{file_index:05}")),
+                Value::Text(benchmark_file_id(file_index)),
             ],
         });
     }
@@ -669,6 +669,10 @@ fn benchmark_file_index(
     offset: usize,
 ) -> usize {
     (checkpoint_index * 97 + auto_commit_index * 17 + offset * 31) % file_count
+}
+
+fn benchmark_file_id(file_index: usize) -> String {
+    format!("00000000-0000-0000-0000-{file_index:012x}")
 }
 
 #[inline(never)]

--- a/packages/server-protocol/src/lib.rs
+++ b/packages/server-protocol/src/lib.rs
@@ -1,6 +1,7 @@
 //! Canonical HTTP transport for independent pinned sessions on a workspace-mode
 //! root [`lix_sdk::Lix`] handle.
 
+#![recursion_limit = "256"]
 #![cfg_attr(test, allow(clippy::large_futures))]
 
 use axum::{


### PR DESCRIPTION
## Universal sorted authenticated mutation frontier

Integrated and pushed to `one-layout`:

- baseline: `4e05d4f819b0683e625ca0dd8809586c8468dce0`
- candidate: `fb2171fb2ca557d461d21fc7b9c765d2e28617ca`
- integrated merge head: `46cbbe1296addb18fd49ac97ac25e457604e5e7b`
- integrated tree: `b790761183f8b133a779e0f5f7ac5f3a40588d7a`

### Compact exact veto (10K, n=5 per cell)

| Backend / shape / changes | Baseline p50/p95 ms | Candidate p50/p95 ms | p50 delta |
|---|---:|---:|---:|
| RocksDB clustered / 1 | 0.494 / 0.529 | 0.492 / 0.523 | -0.4% |
| SlateDB clustered / 1 | 0.769 / 0.852 | 0.803 / 0.897 | +4.4% (p95 +5.3%) |
| RocksDB spread / 1 | 0.491 / 0.526 | 0.487 / 0.527 | -0.8% |
| SlateDB spread / 1 | 0.775 / 0.861 | 0.778 / 0.853 | +0.4% |
| RocksDB clustered / 10 | 1.680 / 2.529 | 0.866 / 1.073 | -48.5% |
| SlateDB clustered / 10 | 1.854 / 2.858 | 1.180 / 1.409 | -36.4% |
| RocksDB spread / 10 | 0.547 / 0.581 | 0.455 / 0.517 | -16.8% |
| SlateDB spread / 10 | 0.746 / 0.767 | 0.645 / 0.687 | -13.5% |
| RocksDB clustered / 1000 | 4649.235 / 20119.801 | 23.748 / 31.280 | -99.5% |
| SlateDB clustered / 1000 | 4811.040 / 20043.846 | 25.432 / 32.678 | -99.5% |
| RocksDB spread / 1000 | 129.191 / 139.462 | 10.465 / 10.599 | -91.9% |
| SlateDB spread / 1000 | 127.606 / 138.737 | 12.465 / 12.784 | -90.2% |

The only >5% observed wall delta is SlateDB clustered point p95 (+5.3%); point p50 is +4.4%, within the veto threshold. No other critical >5% regression was observed. The earlier exact n=3 10K/1000 merge-publication gate was `1765.319 -> 16.983 ms` p50 RocksDB and `1781.555 -> 18.424 ms` p50 SlateDB (~99.0% reductions; p95 reductions ~99.5%).

CPU, Rust allocation/RSS, logical/backend gets/scans/puts/bytes, WAL/SST/object/compaction, and final/intermediate chunk counters are unavailable in the preserved harness outputs; no resource win is inferred from the wall results. The full 1M matrix, corruption/reopen/GC matrix, and independent reviews remain follow-up evidence gaps. This is a compact discovery-veto acceptance, not a claim of exhaustive qualification.

### Correctness and hard-cut audit

On the merged tree: `cargo check -p lix_engine --features storage-benches`; tracked-state tree 22 passed; context 58 passed/1 ignored; codec 41 passed; `cargo fmt --all -- --check`; `git diff --check`. Randomized frontier-vs-canonical-rebuild, corruption, shifted-boundary diff, and no-op/final-root tests are green. Legacy sequential symbols (`apply_point_mutations_with_overlay`, `sparse_existing_batch`, old overlay/chunker/rebuild helpers) and pre-V4 codec identifiers are absent. The default-stack SQL whole-collection-delete test overflows on both baseline and candidate; with `RUST_MIN_STACK=8388608` it passes on both (inherited harness issue).

Big-O changes from repeated sequential path-copy publication `O(M*h)` with suffix boundary drift to point `O(h)`, clustered `O(h + touched leaves + M)`, sparse `O(A + M)` after ordering (scattered worst `O(M*h)`), dense `O(N + M)`, bounded frontier memory, and final-root-only staging. The physical format uses deterministic key-defined V4 boundaries; old V3 decode is fail-closed.

Raw artifact manifests:

- `/root/projects/lixray/targets/frontier-successor-widths-n5/SHA256SUMS` — `063823ceae993ac16f44473d6aeeb0201431d9d1ca04c841be751b737f18e571`
- `/root/projects/lixray/targets/frontier-successor-lowwidth-final/SHA256SUMS` — `04eb18a6387ce5317007e34fcb10c667cb29be5926790e466c2dfca9d26a4f10`
- exact fast binaries: baseline `a32d8b26cf74f84f5e43d70501dbc462140fad7b84a1208e730ee47f3068c2ae`; candidate `866c770bf7b1150d9e89f1138af91641a81c899b593640cef4a7fa2c7b2191be`

### Dense scalar publication (integrated)

Baseline: `54e3fbefd5b9fa7145878d4de21cca5fd1317fa5`  
Scalar candidate: `bcb652b8822365ad8df29c815cef876d8a042539`  
Integrated one-layout head: `30b1f742b4b870f29a5560768805f736b865cd87`

The final `30b1f742b4b870f29a5560768805f736b865cd87` commit is test-only task-local accounting for parallel-safe assertions. Its local all-features library result is **1,927 passed / 0 failed / 8 ignored**.

The scalar `sql_session` route hard-cuts ordered replacement parts from 128 rows to 512 rows. The bound/certified `sql_session_bound` route was already 512 and is not attributed to this gain.

| Workload | Baseline → candidate | Result |
|---|---:|---:|
| 1M `update_all`, RocksDB (n=3) | 1.551 → 1.158 s | −25.4%; allocations 1.477 → 1.060 GB (−28.3%) |
| 1M `update_all`, SlateDB (n=3) | 1.835 → 1.280 s | −30.3%; allocations 1.873 → 1.173 GB (−37.4%); RSS +0.8% |
| 10K `update_all`, RocksDB | 29.622 → 26.500 ms | −10.5%; allocations −11.0% |
| 10K `update_all`, SlateDB | 30.629 → 27.642 ms | −9.7%; allocations −19.5% |
| 10K point update, RocksDB vs `e4a8` (n=7) | 860.177 → 900.208 µs | +4.65% (within the ≤5% gate) |
| 10K point update, RocksDB vs `a199` (n=7) | 919.487 → 900.208 µs | −2.1%; allocations 1.274 → 1.222 MB (−4.1%); RSS +6.4% |
| 10K point update, RocksDB vs `e4a8` allocations | 0.876 → 1.222 MB | +39.4%; RSS +0.6% |
| 10K point update, SlateDB | — | −9.5% |

The Ryzen +6.9% RocksDB point result is retained as host variance; the independent primary result is +4.65% versus `e4a8` and −2.1% versus main. The point allocation increase versus `e4a8` (+39.4%) is disclosed; versus main, allocations are 4.1% lower. Dense update complexity remains O(N); this is a constant-factor fanout reduction, approximately `N/128 → N/512` parts (1M: `7,813 → 1,954`; 10K: `79 → 20`). At 1M, the durable manifest falls from 308,649 B to 77,818 B.

The integrated follow-up fixes the stale geometry assertion (`[128,128,128,128,1]` → `[512,1]`), the CI error-index regression, and the low-level benchmark fixture. Task-local test observability and the authenticated live-part GC fixture are now included; focused replacement passes and GC are 14/14.


## Checkpoint/GC correctness (integrated at 0de3e0036b31709b5b07643bf6d43bfc0cae4fb0)

- Six `checkpoint_gc` cells pass in both base and tracked-state-rebuild modes; commit_graph is 12/12, GC is 14/14, and the reopen/recovery smoke passes.
- Semantic commit projection reachability is separated from physical manifest retirement; physical payload/state reads remain fail-closed.

## Repository GC delete classification (integrated at 27487c61d31c307506c3671ae7121b457ab018e6)

- Integration head: 27487c61d31c307506c3671ae7121b457ab018e6 (parent 0de3e0036b31709b5b07643bf6d43bfc0cae4fb0); origin/one-layout now matches this SHA.
- The former aggregate staged_deletes = 30 assertion was replaced with authority-lane assertions: 10 commit-state manifests, 10 mutation inventories, 11 semantic commit projections, 21 semantic change rows, and 11 semantic commit-to-change reverse-index rows; classified total 63.
- The benchmark verifies the classified sum equals staged deletes, descriptors/key buffers/bytes match the classified rows, repeated planning produces the same classification, and full layout accounting is byte-for-byte unchanged before/after both plans (planning is non-mutating).
- Focused gates: repository GC benchmark 1/1, GC suite 14/14, all-feature engine check, cargo fmt --check, and git diff --check pass. This is test-only GC observability; no performance improvement is claimed and no production GC algorithm change was made.
