### PR TITLE
Hydrate selected compact replacement parts directly

### DIFF
--- a/packages/engine/src/tracked_state/storage.rs
+++ b/packages/engine/src/tracked_state/storage.rs
@@ -5914,30 +5914,122 @@ async fn load_physical_direct_change_records(
         let bytes = value.and_then(full_value_bytes).ok_or_else(|| {
             replacement_payload_error("direct coordinate references a missing immutable part")
         })?;
-        let (bounds, direct_row_count) = match run.entry {
+        let (bounds, direct_row_count) = match &run.entry {
             super::mutation_directory::MutationDirectoryEntry::Bounded {
                 part,
                 direct_row_count,
             } => (
                 CommitDeltaSegmentBounds {
-                    first_key: part.first_key,
-                    last_key: part.last_key,
-                    replacement_part: part.replacement_part,
+                    first_key: part.first_key.clone(),
+                    last_key: part.last_key.clone(),
+                    replacement_part: part.replacement_part.clone(),
                 },
-                direct_row_count,
+                *direct_row_count,
             ),
             super::mutation_directory::MutationDirectoryEntry::CompactReplacement {
                 content_digest,
                 direct_row_count,
-            } => (
-                compact_replacement_bounds_for_selected_part(
-                    state,
-                    run.entry_index,
+            } => {
+                let generation =
+                    state
+                        .mutations
+                        .replacement_generation
+                        .as_ref()
+                        .ok_or_else(|| {
+                            replacement_payload_error("compact part omitted its generation")
+                        })?;
+                let lifecycle = state.mutations.lifecycle_summary.as_ref().ok_or_else(|| {
+                    replacement_payload_error("compact part omitted lifecycle metadata")
+                })?;
+                let authority = state.mutations.replacement_parts.as_ref().ok_or_else(|| {
+                    replacement_payload_error("compact part omitted payload authority")
+                })?;
+                if generation.owner_commit_id != *state.commit_id.as_uuid().as_bytes()
+                    || generation.integrity_digest
+                        != replacement_generation_integrity_digest(generation, lifecycle, authority)
+                {
+                    return Err(replacement_payload_error(
+                        "compact part generation authority is invalid",
+                    ));
+                }
+                let decoded = crate::tracked_state::replacement_part::decode_replacement_part(
                     content_digest,
                     &bytes,
-                )?,
-                direct_row_count,
-            ),
+                )?;
+                if decoded.len() != usize::from(*direct_row_count) {
+                    return Err(replacement_payload_error(
+                        "compact immutable part row count disagrees with directory authority",
+                    ));
+                }
+                #[cfg(any(test, feature = "storage-benches"))]
+                super::mutation_directory::record_direct_part_decoded(
+                    decoded.len(),
+                    bytes.len(),
+                    decoded.len(),
+                );
+                for output_index in run.selector_span.clone() {
+                    let coordinate = coordinates[output_index];
+                    let locator = locators[output_index];
+                    if coordinate.part_index != run.entry_index
+                        || coordinate.local_row != locator.ordinal
+                    {
+                        return Err(replacement_payload_error(
+                            "direct-coordinate run disagrees with its physical locator",
+                        ));
+                    }
+                    let packed = run
+                        .entry_index
+                        .checked_mul(
+                            u32::try_from(COMMIT_DELTA_SEGMENT_MAX_ROWS)
+                                .expect("replacement row bound fits u32"),
+                        )
+                        .and_then(|base| base.checked_add(u32::from(locator.ordinal)))
+                        .and_then(|address| address.checked_add(1))
+                        .ok_or_else(|| {
+                            replacement_payload_error("replacement address overflows")
+                        })?;
+                    if locator.change_id != change_id_from_packed_address(state.commit_id, packed) {
+                        return Err(replacement_payload_error(
+                            "compact locator change id disagrees with its physical address",
+                        ));
+                    }
+                    let encoded_key =
+                        decoded.key(usize::from(locator.ordinal))?.ok_or_else(|| {
+                            replacement_payload_error("replacement part omitted a key")
+                        })?;
+                    let key = decode_key(encoded_key)?;
+                    let snapshot = owned_scoped_json_slot(
+                        decoded
+                            .snapshot(usize::from(locator.ordinal))?
+                            .ok_or_else(|| {
+                                replacement_payload_error("replacement part omitted a snapshot")
+                            })?,
+                    );
+                    let metadata = owned_scoped_json_slot(
+                        decoded
+                            .metadata(usize::from(locator.ordinal))?
+                            .ok_or_else(|| {
+                                replacement_payload_error("replacement part omitted metadata")
+                            })?,
+                    );
+                    output.push((
+                        output_index,
+                        crate::changelog::ChangeRecord {
+                            account_id: state.change_account_id.clone(),
+                            format_version: 2,
+                            change_id: locator.change_id,
+                            schema_key: key.schema_key,
+                            entity_pk: key.entity_pk,
+                            file_id: key.file_id,
+                            snapshot,
+                            metadata,
+                            created_at: lifecycle.uniform_created_at,
+                            origin_key: None,
+                        },
+                    ));
+                }
+                continue;
+            }
             super::mutation_directory::MutationDirectoryEntry::DirectAddress { .. } => {
                 return Err(replacement_payload_error(
                     "non-columnar direct authority selected an address-only entry",
@@ -5977,55 +6069,6 @@ async fn load_physical_direct_change_records(
         }
     }
     Ok(output)
-}
-
-fn compact_replacement_bounds_for_selected_part(
-    state: &AuthenticatedReplayCommitStateManifest,
-    part_index: u32,
-    content_digest: [u8; 32],
-    bytes: &[u8],
-) -> Result<CommitDeltaSegmentBounds, LixError> {
-    let generation = state
-        .mutations
-        .replacement_generation
-        .as_ref()
-        .ok_or_else(|| replacement_payload_error("compact part omitted its generation"))?;
-    let lifecycle = state
-        .mutations
-        .lifecycle_summary
-        .as_ref()
-        .ok_or_else(|| replacement_payload_error("compact part omitted lifecycle metadata"))?;
-    let authority = state
-        .mutations
-        .replacement_parts
-        .as_ref()
-        .ok_or_else(|| replacement_payload_error("compact part omitted payload authority"))?;
-    let decoded =
-        crate::tracked_state::replacement_part::decode_replacement_part(&content_digest, bytes)?;
-    let first_key = decoded
-        .first_key()
-        .ok_or_else(|| replacement_payload_error("replacement part is empty"))?
-        .to_vec();
-    let last_key = decoded
-        .last_key()
-        .ok_or_else(|| replacement_payload_error("replacement part is empty"))?
-        .to_vec();
-    let first_address = part_index
-        .checked_mul(
-            u32::try_from(COMMIT_DELTA_SEGMENT_MAX_ROWS).expect("replacement row bound fits u32"),
-        )
-        .ok_or_else(|| replacement_payload_error("replacement address overflows"))?;
-    Ok(CommitDeltaSegmentBounds {
-        first_key,
-        last_key,
-        replacement_part: Some(StoredReplacementPart {
-            content_digest,
-            owner_commit_id: generation.owner_commit_id,
-            first_address,
-            uniform_created_at: lifecycle.uniform_created_at,
-            uniform_updated_at: authority.uniform_updated_at,
-        }),
-    })
 }
 
 async fn load_change_records_by_ids(
@@ -6136,18 +6179,22 @@ async fn load_explicit_change_records_at_locators(
     store: &(impl StorageAdapterRead + ?Sized),
     locators: &[CommitDeltaChangeLocator],
 ) -> Result<Vec<crate::changelog::ChangeRecord>, LixError> {
+    load_explicit_change_records_at_locators_selected(store, locators).await
+}
+
+async fn load_explicit_change_records_at_locators_selected(
+    store: &(impl StorageAdapterRead + ?Sized),
+    locators: &[CommitDeltaChangeLocator],
+) -> Result<Vec<crate::changelog::ChangeRecord>, LixError> {
     let commit_ids = locators
         .iter()
         .map(|locator| locator.commit_id)
-        .collect::<BTreeSet<_>>()
-        .into_iter()
-        .collect::<Vec<_>>();
-    let manifest_values = load_commit_delta_manifests(store, &commit_ids).await?;
-    let manifests = commit_ids
-        .into_iter()
-        .zip(manifest_values)
-        .map(|(commit_id, value)| {
-            let manifest = value.ok_or_else(|| {
+        .collect::<BTreeSet<_>>();
+    let mut states = BTreeMap::<CommitId, AuthenticatedReplayCommitStateManifest>::new();
+    for commit_id in commit_ids {
+        let state = load_point_replay_commit_state(store, commit_id)
+            .await?
+            .ok_or_else(|| {
                 LixError::new(
                     LixError::CODE_INTERNAL_ERROR,
                     format!(
@@ -6155,185 +6202,40 @@ async fn load_explicit_change_records_at_locators(
                     ),
                 )
             })?;
-            Ok((commit_id, manifest))
-        })
-        .collect::<Result<BTreeMap<_, _>, LixError>>()?;
+        if let Some(source_commit_id) = state.mutations.selected_source_commit_id() {
+            let source = load_point_replay_commit_state(store, source_commit_id)
+                .await?
+                .ok_or_else(|| {
+                    replacement_payload_error(&format!(
+                        "selected-source commit '{}' references missing authority '{}'",
+                        state.commit_id, source_commit_id
+                    ))
+                })?;
+            if source.mutations.selected_source_commit_id().is_some() {
+                return Err(replacement_payload_error(
+                    "selected-source mutation authority cannot alias another source",
+                ));
+            }
+        }
+        states.insert(commit_id, state);
+    }
 
     let mut loaded = (0..locators.len()).map(|_| None).collect::<Vec<_>>();
-    let mut columnar_by_commit = BTreeMap::<CommitId, Vec<usize>>::new();
-    for (locator_index, locator) in locators.iter().enumerate() {
-        if manifests[&locator.commit_id].columnar_parts.is_some() {
-            columnar_by_commit
-                .entry(locator.commit_id)
-                .or_default()
-                .push(locator_index);
-        }
+    let mut by_commit = BTreeMap::<CommitId, Vec<usize>>::new();
+    for (index, locator) in locators.iter().enumerate() {
+        by_commit.entry(locator.commit_id).or_default().push(index);
     }
-    for (commit_id, locator_indices) in columnar_by_commit {
-        let parts = manifests[&commit_id]
-            .columnar_parts
-            .as_ref()
-            .expect("columnar locator group was selected from this manifest");
-        let id = crate::columnar_row_group::RowGroupSetId::new(parts.row_group_set_id);
-        let row_group_manifest = crate::columnar_row_group::load_row_group_manifest(store, id)
-            .await?
-            .ok_or_else(|| replacement_payload_error("columnar mutation manifest is missing"))?;
-        validate_columnar_mutation_manifest(&row_group_manifest, parts)?;
-        let projection = (0..row_group_manifest.fields.len()).collect::<Vec<_>>();
-        let mut page_groups = BTreeMap::<(usize, usize), Vec<(usize, usize)>>::new();
-        for locator_index in locator_indices {
-            let locator = locators[locator_index];
-            let logical_ordinal = usize::try_from(locator.segment_index)
-                .expect("u32 segment fits usize")
-                .checked_mul(COMMIT_DELTA_SEGMENT_MAX_ROWS)
-                .and_then(|base| base.checked_add(usize::from(locator.ordinal)))
-                .ok_or_else(|| replacement_payload_error("columnar mutation address overflows"))?;
-            if logical_ordinal >= parts.row_count as usize {
-                return Err(replacement_payload_error(
-                    "columnar mutation locator is outside its inventory",
-                ));
-            }
-            let packed = u32::try_from(logical_ordinal)
-                .map_err(|_| replacement_payload_error("columnar mutation address exceeds u32"))?
-                .checked_add(1)
-                .ok_or_else(|| replacement_payload_error("columnar mutation address overflows"))?;
-            if locator.change_id != change_id_from_packed_address(commit_id, packed) {
-                return Err(replacement_payload_error(
-                    "columnar mutation locator change id disagrees with its ordinal",
-                ));
-            }
-            let group_index = logical_ordinal / crate::columnar_row_group::ROW_GROUP_MAX_ROWS;
-            let row_in_group = logical_ordinal % crate::columnar_row_group::ROW_GROUP_MAX_ROWS;
-            let page_index = row_in_group / crate::columnar_row_group::ROW_GROUP_PAGE_ROWS;
-            let row_in_page = row_in_group % crate::columnar_row_group::ROW_GROUP_PAGE_ROWS;
-            page_groups
-                .entry((group_index, page_index))
-                .or_default()
-                .push((locator_index, row_in_page));
-        }
-        let page_coordinates = page_groups.keys().copied().collect::<Vec<_>>();
-        crate::columnar_row_group::visit_row_group_pages(
-            store,
-            id,
-            &row_group_manifest,
-            &page_coordinates,
-            &projection,
-            |coordinate, batch| {
-                for &(locator_index, row_in_page) in &page_groups[&coordinate] {
-                    let locator = locators[locator_index];
-                    loaded[locator_index] = Some(decode_columnar_change_record(
-                        &row_group_manifest,
-                        &batch,
-                        row_in_page,
-                        parts,
-                        locator.change_id,
-                        &manifests[&commit_id].account_id,
-                    )?);
-                }
-                Ok(())
-            },
-        )
-        .await?;
-    }
-
-    let routes = locators
-        .iter()
-        .filter_map(|locator| {
-            let manifest = &manifests[&locator.commit_id];
-            (manifest.columnar_parts.is_none() && manifest.inline_segment().is_none()).then_some((
-                locator.commit_id,
-                usize::try_from(locator.segment_index).expect("u32 fits usize"),
-            ))
-        })
-        .collect::<BTreeSet<_>>()
-        .into_iter()
-        .collect::<Vec<_>>();
-    let segment_keys = routes
-        .iter()
-        .map(|&(commit_id, segment_index)| {
-            let bounds = manifests[&commit_id].segments.get(segment_index).ok_or_else(|| {
-                LixError::new(
-                    LixError::CODE_INTERNAL_ERROR,
-                    format!(
-                        "tracked_state selected change references out-of-range segment {segment_index} of commit '{commit_id}'"
-                    ),
-                )
-            })?;
-            commit_delta_segment_key_for_bounds(
-                commit_id,
-                segment_index,
-                bounds,
-            )
-            .map(|key| StorageKey(Bytes::from(key)))
-        })
-        .collect::<Result<Vec<_>, _>>()?;
-    let segment_values =
-        PointReadPlan::new(TRACKED_STATE_COMMIT_DELTA_SEGMENT_SPACE, &segment_keys)
-            .materialize(store, StorageGetOptions::default())
-            .await?;
-    let segments = routes
-        .into_iter()
-        .zip(segment_values.value)
-        .map(|(route, value)| {
-            value
-                .and_then(full_value_bytes)
-                .map(|bytes| (route, bytes))
-                .ok_or_else(|| {
-                    LixError::new(
-                        LixError::CODE_INTERNAL_ERROR,
-                        format!(
-                            "tracked_state selected change references absent segment {} of commit '{}'",
-                            route.1, route.0
-                        ),
-                    )
-                })
-        })
-        .collect::<Result<BTreeMap<_, _>, _>>()?;
-
-    let mut locator_groups = BTreeMap::<(CommitId, usize), Vec<usize>>::new();
-    for (locator_index, locator) in locators.iter().enumerate() {
-        if manifests[&locator.commit_id].columnar_parts.is_some() {
-            continue;
-        }
-        locator_groups
-            .entry((
-                locator.commit_id,
-                usize::try_from(locator.segment_index).expect("u32 fits usize"),
-            ))
-            .or_default()
-            .push(locator_index);
-    }
-    for ((commit_id, segment_index), locator_indices) in locator_groups {
-        let manifest = &manifests[&commit_id];
-        let (bytes, bounds) = if let Some(inline) = manifest.inline_segment() {
-            if segment_index != 0 {
-                return Err(LixError::new(
-                    LixError::CODE_INTERNAL_ERROR,
-                    "tracked_state selected change references a nonzero inline segment",
-                ));
-            }
-            (inline, None)
-        } else {
-            let bounds = manifest.segments.get(segment_index).ok_or_else(|| {
-                LixError::new(
-                    LixError::CODE_INTERNAL_ERROR,
-                    "tracked_state selected change references an undeclared segment",
-                )
-            })?;
-            (segments[&(commit_id, segment_index)].as_ref(), Some(bounds))
-        };
-        let (leaf, payloads) = decode_commit_delta_with_payloads(bytes, bounds)?;
-        for locator_index in locator_indices {
-            let locator = locators[locator_index];
-            loaded[locator_index] = Some(
-                decode_change_at_locator_from_decoded(
-                    &leaf,
-                    &payloads,
-                    locator,
-                    &manifest.account_id,
-                )?
-                .change_record,
-            );
+    for (commit_id, indices) in by_commit {
+        let state = states
+            .get(&commit_id)
+            .expect("every selected locator has an authenticated state");
+        let requested = indices
+            .iter()
+            .map(|&index| locators[index])
+            .collect::<Vec<_>>();
+        let records = load_selected_change_records_from_state(store, state, &requested).await?;
+        for (index, record) in indices.into_iter().zip(records) {
+            loaded[index] = Some(record);
         }
     }
     loaded
@@ -6344,6 +6246,159 @@ async fn load_explicit_change_records_at_locators(
                     LixError::CODE_INTERNAL_ERROR,
                     "tracked_state authoritative change unexpectedly disappeared",
                 )
+            })
+        })
+        .collect()
+}
+
+async fn load_selected_change_records_from_state(
+    store: &(impl StorageAdapterRead + ?Sized),
+    state: &AuthenticatedReplayCommitStateManifest,
+    locators: &[CommitDeltaChangeLocator],
+) -> Result<Vec<crate::changelog::ChangeRecord>, LixError> {
+    if locators.is_empty() {
+        return Ok(Vec::new());
+    }
+    if locators
+        .iter()
+        .any(|locator| locator.commit_id != state.commit_id)
+    {
+        return Err(replacement_payload_error(
+            "selected change locator disagrees with its authenticated owner",
+        ));
+    }
+    #[cfg(any(test, feature = "storage-benches"))]
+    let mut accounting_guard = super::mutation_directory::DirectRouteAccountingGuard::new();
+    #[cfg(any(test, feature = "storage-benches"))]
+    super::mutation_directory::record_direct_route_start(locators.len());
+
+    let mut request_indices = (0..locators.len()).collect::<Vec<_>>();
+    request_indices.sort_by_key(|&index| {
+        let locator = locators[index];
+        (locator.segment_index, locator.ordinal, locator.change_id)
+    });
+    let mut unique_indices = Vec::with_capacity(request_indices.len());
+    let mut scatter = Vec::with_capacity(request_indices.len());
+    for request_index in request_indices {
+        let unique_index = if unique_indices
+            .last()
+            .is_some_and(|&previous| locators[previous] == locators[request_index])
+        {
+            unique_indices.len() - 1
+        } else {
+            unique_indices.push(request_index);
+            unique_indices.len() - 1
+        };
+        scatter.push((request_index, unique_index));
+    }
+    let unique_locators = unique_indices
+        .iter()
+        .map(|&index| locators[index])
+        .collect::<Vec<_>>();
+    #[cfg(any(test, feature = "storage-benches"))]
+    super::mutation_directory::record_direct_route_unique_rows(unique_locators.len());
+
+    let unique_records = if let Some(root) = state.mutation_directory_root.as_ref() {
+        let coordinates = unique_locators
+            .iter()
+            .map(
+                |locator| super::mutation_directory::MutationDirectoryDirectCoordinate {
+                    part_index: locator.segment_index,
+                    local_row: locator.ordinal,
+                },
+            )
+            .collect::<Vec<_>>();
+        let (runs, not_owned) = super::mutation_directory::load_mutation_part_read_plan(
+            store,
+            root,
+            super::mutation_directory::MutationDirectoryReadSelection::SortedUniqueDirectCoordinates(
+                &coordinates,
+            ),
+        )
+        .await?
+        .into_direct_routes();
+        if let Some(route) = not_owned.into_iter().next() {
+            return Err(replacement_payload_error(&format!(
+                "selected change locator is not owned by its authenticated directory ({:?})",
+                route.reason
+            )));
+        }
+        #[cfg(any(test, feature = "storage-benches"))]
+        super::mutation_directory::record_direct_route_claimed_rows(unique_locators.len());
+        if let Some(parts) = state.mutations.columnar_parts.as_ref() {
+            load_columnar_direct_change_records(store, state, parts, &unique_locators).await?
+        } else {
+            let routed = load_physical_direct_change_records(
+                store,
+                state,
+                &coordinates,
+                &unique_locators,
+                runs,
+            )
+            .await?;
+            let mut records = (0..unique_locators.len()).map(|_| None).collect::<Vec<_>>();
+            for (index, record) in routed {
+                records[index] = Some(record);
+            }
+            records
+                .into_iter()
+                .map(|record| {
+                    record.ok_or_else(|| {
+                        replacement_payload_error(
+                            "selected change directory route lost a requested row",
+                        )
+                    })
+                })
+                .collect::<Result<Vec<_>, _>>()?
+        }
+    } else if let Some(parts) = state.mutations.columnar_parts.as_ref() {
+        load_columnar_direct_change_records(store, state, parts, &unique_locators).await?
+    } else {
+        if state.mutations.inline_part.is_empty() {
+            return Err(replacement_payload_error(
+                "selected change owner has no authenticated physical authority",
+            ));
+        }
+        let (leaf, payloads) =
+            decode_commit_delta_with_payloads(&state.mutations.inline_part, None)?;
+        if leaf.len() != state.mutations.member_count as usize {
+            return Err(replacement_payload_error(
+                "inline selected change authority row count disagrees with its header",
+            ));
+        }
+        unique_locators
+            .iter()
+            .map(|&locator| {
+                if locator.segment_index != 0 {
+                    return Err(replacement_payload_error(
+                        "inline selected change locator names a nonzero segment",
+                    ));
+                }
+                Ok(decode_change_at_locator_from_decoded(
+                    &leaf,
+                    &payloads,
+                    locator,
+                    &state.change_account_id,
+                )?
+                .change_record)
+            })
+            .collect::<Result<Vec<_>, LixError>>()?
+    };
+
+    let mut output = (0..locators.len()).map(|_| None).collect::<Vec<_>>();
+    for (request_index, unique_index) in scatter {
+        output[request_index] = Some(unique_records[unique_index].clone());
+    }
+    #[cfg(any(test, feature = "storage-benches"))]
+    {
+        super::mutation_directory::record_direct_route_scattered_rows(locators.len());
+        accounting_guard.finish();
+    }
+    output
+        .into_iter()
+        .map(|record| {
+            record.ok_or_else(|| {
+                replacement_payload_error("selected change scatter lost a requested row")
             })
         })
         .collect()

--- a/packages/engine/src/tracked_state/storage.rs
+++ b/packages/engine/src/tracked_state/storage.rs
@@ -5914,120 +5914,38 @@ async fn load_physical_direct_change_records(
         let bytes = value.and_then(full_value_bytes).ok_or_else(|| {
             replacement_payload_error("direct coordinate references a missing immutable part")
         })?;
-        let (bounds, direct_row_count) = match &run.entry {
+        let super::mutation_directory::MutationDirectoryPartRun {
+            entry_index,
+            entry,
+            selector_span,
+        } = run;
+        let (bounds, direct_row_count) = match entry {
             super::mutation_directory::MutationDirectoryEntry::Bounded {
                 part,
                 direct_row_count,
             } => (
                 CommitDeltaSegmentBounds {
-                    first_key: part.first_key.clone(),
-                    last_key: part.last_key.clone(),
-                    replacement_part: part.replacement_part.clone(),
+                    first_key: part.first_key,
+                    last_key: part.last_key,
+                    replacement_part: part.replacement_part,
                 },
-                *direct_row_count,
+                direct_row_count,
             ),
             super::mutation_directory::MutationDirectoryEntry::CompactReplacement {
                 content_digest,
                 direct_row_count,
             } => {
-                let generation =
-                    state
-                        .mutations
-                        .replacement_generation
-                        .as_ref()
-                        .ok_or_else(|| {
-                            replacement_payload_error("compact part omitted its generation")
-                        })?;
-                let lifecycle = state.mutations.lifecycle_summary.as_ref().ok_or_else(|| {
-                    replacement_payload_error("compact part omitted lifecycle metadata")
-                })?;
-                let authority = state.mutations.replacement_parts.as_ref().ok_or_else(|| {
-                    replacement_payload_error("compact part omitted payload authority")
-                })?;
-                if generation.owner_commit_id != *state.commit_id.as_uuid().as_bytes()
-                    || generation.integrity_digest
-                        != replacement_generation_integrity_digest(generation, lifecycle, authority)
-                {
-                    return Err(replacement_payload_error(
-                        "compact part generation authority is invalid",
-                    ));
-                }
-                let decoded = crate::tracked_state::replacement_part::decode_replacement_part(
+                hydrate_compact_replacement_direct_run(
+                    state,
+                    entry_index,
+                    selector_span,
                     content_digest,
+                    direct_row_count,
                     &bytes,
+                    coordinates,
+                    locators,
+                    &mut output,
                 )?;
-                if decoded.len() != usize::from(*direct_row_count) {
-                    return Err(replacement_payload_error(
-                        "compact immutable part row count disagrees with directory authority",
-                    ));
-                }
-                #[cfg(any(test, feature = "storage-benches"))]
-                super::mutation_directory::record_direct_part_decoded(
-                    decoded.len(),
-                    bytes.len(),
-                    decoded.len(),
-                );
-                for output_index in run.selector_span.clone() {
-                    let coordinate = coordinates[output_index];
-                    let locator = locators[output_index];
-                    if coordinate.part_index != run.entry_index
-                        || coordinate.local_row != locator.ordinal
-                    {
-                        return Err(replacement_payload_error(
-                            "direct-coordinate run disagrees with its physical locator",
-                        ));
-                    }
-                    let packed = run
-                        .entry_index
-                        .checked_mul(
-                            u32::try_from(COMMIT_DELTA_SEGMENT_MAX_ROWS)
-                                .expect("replacement row bound fits u32"),
-                        )
-                        .and_then(|base| base.checked_add(u32::from(locator.ordinal)))
-                        .and_then(|address| address.checked_add(1))
-                        .ok_or_else(|| {
-                            replacement_payload_error("replacement address overflows")
-                        })?;
-                    if locator.change_id != change_id_from_packed_address(state.commit_id, packed) {
-                        return Err(replacement_payload_error(
-                            "compact locator change id disagrees with its physical address",
-                        ));
-                    }
-                    let encoded_key =
-                        decoded.key(usize::from(locator.ordinal))?.ok_or_else(|| {
-                            replacement_payload_error("replacement part omitted a key")
-                        })?;
-                    let key = decode_key(encoded_key)?;
-                    let snapshot = owned_scoped_json_slot(
-                        decoded
-                            .snapshot(usize::from(locator.ordinal))?
-                            .ok_or_else(|| {
-                                replacement_payload_error("replacement part omitted a snapshot")
-                            })?,
-                    );
-                    let metadata = owned_scoped_json_slot(
-                        decoded
-                            .metadata(usize::from(locator.ordinal))?
-                            .ok_or_else(|| {
-                                replacement_payload_error("replacement part omitted metadata")
-                            })?,
-                    );
-                    output.push((
-                        output_index,
-                        crate::changelog::ChangeRecord {
-                            account_id: state.change_account_id.clone(),
-                            format_version: 2,
-                            change_id: locator.change_id,
-                            schema_key: key.schema_key,
-                            entity_pk: key.entity_pk,
-                            file_id: key.file_id,
-                            snapshot,
-                            metadata,
-                            created_at: lifecycle.uniform_created_at,
-                            origin_key: None,
-                        },
-                    ));
-                }
                 continue;
             }
             super::mutation_directory::MutationDirectoryEntry::DirectAddress { .. } => {
@@ -6048,10 +5966,10 @@ async fn load_physical_direct_change_records(
             bytes.len(),
             leaf.resident_bytes() + payloads.resident_bytes(),
         );
-        for output_index in run.selector_span {
+        for output_index in selector_span {
             let coordinate = coordinates[output_index];
             let locator = locators[output_index];
-            if coordinate.part_index != run.entry_index || coordinate.local_row != locator.ordinal {
+            if coordinate.part_index != entry_index || coordinate.local_row != locator.ordinal {
                 return Err(replacement_payload_error(
                     "direct-coordinate run disagrees with its physical locator",
                 ));
@@ -6069,6 +5987,108 @@ async fn load_physical_direct_change_records(
         }
     }
     Ok(output)
+}
+
+#[inline(never)]
+fn hydrate_compact_replacement_direct_run(
+    state: &AuthenticatedReplayCommitStateManifest,
+    entry_index: u32,
+    selector_span: Range<usize>,
+    content_digest: [u8; 32],
+    direct_row_count: u16,
+    bytes: &[u8],
+    coordinates: &[super::mutation_directory::MutationDirectoryDirectCoordinate],
+    locators: &[CommitDeltaChangeLocator],
+    output: &mut Vec<(usize, crate::changelog::ChangeRecord)>,
+) -> Result<(), LixError> {
+    let generation = state
+        .mutations
+        .replacement_generation
+        .as_ref()
+        .ok_or_else(|| replacement_payload_error("compact part omitted its generation"))?;
+    let lifecycle = state
+        .mutations
+        .lifecycle_summary
+        .as_ref()
+        .ok_or_else(|| replacement_payload_error("compact part omitted lifecycle metadata"))?;
+    let authority = state
+        .mutations
+        .replacement_parts
+        .as_ref()
+        .ok_or_else(|| replacement_payload_error("compact part omitted payload authority"))?;
+    if generation.owner_commit_id != *state.commit_id.as_uuid().as_bytes()
+        || generation.integrity_digest
+            != replacement_generation_integrity_digest(generation, lifecycle, authority)
+    {
+        return Err(replacement_payload_error(
+            "compact part generation authority is invalid",
+        ));
+    }
+    let decoded =
+        crate::tracked_state::replacement_part::decode_replacement_part(&content_digest, bytes)?;
+    if decoded.len() != usize::from(direct_row_count) {
+        return Err(replacement_payload_error(
+            "compact immutable part row count disagrees with directory authority",
+        ));
+    }
+    #[cfg(any(test, feature = "storage-benches"))]
+    super::mutation_directory::record_direct_part_decoded(
+        decoded.len(),
+        bytes.len(),
+        decoded.len(),
+    );
+    for output_index in selector_span {
+        let coordinate = coordinates[output_index];
+        let locator = locators[output_index];
+        if coordinate.part_index != entry_index || coordinate.local_row != locator.ordinal {
+            return Err(replacement_payload_error(
+                "direct-coordinate run disagrees with its physical locator",
+            ));
+        }
+        let packed = entry_index
+            .checked_mul(
+                u32::try_from(COMMIT_DELTA_SEGMENT_MAX_ROWS)
+                    .expect("replacement row bound fits u32"),
+            )
+            .and_then(|base| base.checked_add(u32::from(locator.ordinal)))
+            .and_then(|address| address.checked_add(1))
+            .ok_or_else(|| replacement_payload_error("replacement address overflows"))?;
+        if locator.change_id != change_id_from_packed_address(state.commit_id, packed) {
+            return Err(replacement_payload_error(
+                "compact locator change id disagrees with its physical address",
+            ));
+        }
+        let encoded_key = decoded
+            .key(usize::from(locator.ordinal))?
+            .ok_or_else(|| replacement_payload_error("replacement part omitted a key"))?;
+        let key = decode_key(encoded_key)?;
+        let snapshot = owned_scoped_json_slot(
+            decoded
+                .snapshot(usize::from(locator.ordinal))?
+                .ok_or_else(|| replacement_payload_error("replacement part omitted a snapshot"))?,
+        );
+        let metadata = owned_scoped_json_slot(
+            decoded
+                .metadata(usize::from(locator.ordinal))?
+                .ok_or_else(|| replacement_payload_error("replacement part omitted metadata"))?,
+        );
+        output.push((
+            output_index,
+            crate::changelog::ChangeRecord {
+                account_id: state.change_account_id.clone(),
+                format_version: 2,
+                change_id: locator.change_id,
+                schema_key: key.schema_key,
+                entity_pk: key.entity_pk,
+                file_id: key.file_id,
+                snapshot,
+                metadata,
+                created_at: lifecycle.uniform_created_at,
+                origin_key: None,
+            },
+        ));
+    }
+    Ok(())
 }
 
 async fn load_change_records_by_ids(


### PR DESCRIPTION
## Qualified head

Qualified successor: `7fd0a950a98bba1fb2e5adf83c50940e2ddb8779`

- Original compact-point cut: `b377aab8f2447e803692ea0c3e13b81d5215b5a2`
- Exact parent/main: `4fafa449136b6001c63ff6e1505db112fb3c5ff7`
- Production ownership: `packages/engine/src/tracked_state/storage.rs` only, +288/-213 across both commits
- Successor-only production diff SHA-256: `a5c5600a48524b606f871ae89415d4282ea7faf2c389b55ccf88a29d441cb14f`

`b377` is preserved as the original point-hydration cut. `7fd0` is the qualified PR head and adds the history/diff regression correction.

## What changed

The original cut hydrates compact replacement point requests directly from authenticated selected-part locators. It removes the bounds-first second decode and keeps full-manifest expansion at zero on the point path.

Exact profiling showed that the sparse-history regression was not extra backend work: before/after both performed 100 requested/unique rows, one point selector, one direct selector, two hierarchy levels/batches/gets, one part read/decode, 512 decoded rows, 14,998 raw bytes, 87,040 resident bytes, and zero `All`/full-manifest or explicit-fallback rows.

The `7fd0` successor therefore keeps the direct compact route but consumes bounded run metadata by value instead of cloning its keys/bounds/replacement descriptor, and moves the compact decoder into a non-inlined helper so the large decoder state is not carried through the bounded history async state. There is still one authority and one direct hydration route: no compatibility path, fallback, alternate codec, or persisted-format change.

## Direct-point win retained

Setup is excluded. Baseline and successor use the identical external overlay and emit runtime backend identity.

| Backend / scale | Baseline p50 / p95 | `7fd0` p50 / p95 | p50 delta |
|---|---:|---:|---:|
| RocksDB 10K | 279.817 / 280.049 ms | 42.159 / 43.085 ms | -84.93% |
| SlateDB 10K | 305.740 / 312.105 ms | 58.355 / 60.207 ms | -80.91% |
| RocksDB 1M | 2328.930 / 2376.273 ms | 535.744 / 561.520 ms | -77.00% |
| SlateDB 1M | 2523.436 / 2524.838 ms | 670.526 / 699.318 ms | -73.43% |

Exact result/order hashes match before/after and after reopen. Arbitrary order and duplicates pass; `full_manifest_roots=0`, explicit fallback=0, and corruption outcomes=0 on healthy cells.

## Final 10K history/diff/selected-source/merge veto

History/diff values are the median of three true alternating process pairs, with 11 operation samples per process. Merge uses three alternating pairs with seven operation samples per process. Setup is excluded.

| Operation | Backend | Baseline p50 | `7fd0` p50 | Delta |
|---|---|---:|---:|---:|
| Sparse history, 100 selected rows | RocksDB | 3.447 ms | 3.498 ms | +1.48% |
| Sparse history, 100 selected rows | SlateDB | 4.950 ms | 4.886 ms | -1.29% |
| Sparse diff, 100 rows | RocksDB | 2.046 ms | 1.958 ms | -4.30% |
| Sparse diff, 100 rows | SlateDB | 2.167 ms | 2.084 ms | -3.83% |
| Dense diff, 10K rows | RocksDB | 112.514 ms | 112.034 ms | -0.43% |
| Dense diff, 10K rows | SlateDB | 242.091 ms | 243.525 ms | +0.59% |
| Dense history, 10K rows | RocksDB | 227.726 ms | 229.157 ms | +0.63% |
| Dense history, 10K rows | SlateDB | 233.182 ms | 231.459 ms | -0.74% |
| Selected-source, 8 owners, external wall | RocksDB | 0.26 s | 0.25 s | -3.85% |
| Selected-source, 8 owners, external wall | SlateDB | 0.26 s | 0.27 s | +3.85% |
| Merge preview, 10 commits/side | RocksDB | 8.787 ms | 8.082 ms | -8.02% |
| Merge preview, 10 commits/side | SlateDB | 15.416 ms | 15.571 ms | +1.01% |

Selected-source RSS medians are 126,176 -> 128,180 KiB (+1.59%) on RocksDB and 154,196 -> 161,192 KiB (+4.54%) on SlateDB. Merge RSS medians are 182,584 -> 187,412 KiB (+2.64%) and 193,416 -> 200,820 KiB (+3.83%). Exact output/order/authority hashes match.

The seven-sample merge p95 estimate remains explicitly disclosed: median-of-three p95 is +12.0% RocksDB and +5.8% SlateDB, but it is not monotonic across pairs and the successor's absolute worst Rocks sample is lower, 10.941 vs 12.371 ms. It is retained as noisy tail risk, not represented as a p95 win. No confirmed critical p50 or RSS regression exceeds 5%.

Focused direct hydration, multi-owner duplicate/order, hole/out-of-range/NotOwned, selected-source, corruption, and reopen tests pass. Rust allocator and native WAL/SST/object/compaction counters are unavailable in this focused external harness.

## Complexity and tradeoffs

For `K` requested change IDs, `V` authenticated directory nodes visited, and `B` selected payload bytes, request canonicalization remains `O(K log K)`, authenticated traversal remains `O(V)`, and selected payload work remains `O(B + K)`. Worst-case time is unchanged.

The original cut eliminates a second decode and simultaneous selected-payload materialization. The successor eliminates bounded metadata cloning and removes large decoder state from the history async frame. Persisted bytes, authority, selected bytes, and backend round trips are unchanged.

## Frozen provenance and raw artifacts

- Report: `/root/projects/lix-draft1212/artifacts/b377-successor-gate-20260806T0513Z/REPORT.md`
- Report SHA-256: `462b4bd6fbbb938f33de0883ecd9b3e2a0dec842750d0e9142aeada073ccdb0e`
- Common overlay SHA-256: `09f8cf2998482bb1b87402b662d767c6aa049c03131092f82c348abe304cb610`
- Baseline binary SHA-256: `ad8ed8c63d05e2b4c9d1cbe0c49c23f97a50ad40c87a4ca1efb8512ab20f6681`
- Original b377 binary SHA-256: `1bd9ac87f0482a1896579840460bfed77373713a41eeccbec2315888fe022925`
- Qualified 7fd0 binary SHA-256: `fe667024822f89e7bd65d18929f4608a0dc5e39023e9e21f5c2f26285d75b127`
- Sparse-history raw set: `e842de194c2df591a211d401cf504760cdf6e5b89c38feb383694d3431804746`
- History/diff veto raw set: `f4a0087809e54b107699b45026dd1ed5cab78e572a98001882cc1fe3f7e267e0`
- Selected-source raw set: `1b9eb53f24cf7c4af8f034dbcd97a62d0fbb37c903bf5021a5e079972b514a46`
- Merge raw set: `8b08bf62730966b6cf5b8ba90b3ba17b304ef6a9fdf537b0d3b65a57d721f81d`
- Point raw set: `786ba1ec2b18703ffd094d28a68051c720680c5cc33687b164d496911c47a29a`
