### PR TITLE
Retain large SQL results as columnar batches

### DIFF
--- a/packages/engine-benchmarks/benches/tracked_state_crud/main.rs
+++ b/packages/engine-benchmarks/benches/tracked_state_crud/main.rs
@@ -158,6 +158,12 @@ fn tracked_state_crud_benches(c: &mut Criterion) {
             return;
         }
         let rows = fixture_rows(row_count);
+        if std::env::var("LIX_TRACKED_STATE_CRUD_PROFILE_OP").as_deref()
+            == Ok("olap_result_ceiling")
+        {
+            profile_olap_result_ceiling(&runtime, &rows, profile_sql_session_storage());
+            return;
+        }
         profile_operation(&runtime, &rows);
         return;
     }
@@ -176,6 +182,60 @@ fn tracked_state_crud_benches(c: &mut Criterion) {
             bench_sql_session(c, &runtime, profile, &rows[..row_count], label);
         }
     }
+}
+
+/// Measures the unavoidable Arrow-to-public-result conversion separately from
+/// query execution. `RESULT_MODE=count_only` is a benchmark-only causal
+/// ceiling: it retains RecordBatch owners and counts rows without converting
+/// them into public row/value vectors. It is not semantic qualification data.
+fn profile_olap_result_ceiling(
+    runtime: &tokio::runtime::Runtime,
+    rows: &[WorkloadRow],
+    profile: StorageProfile,
+) {
+    let shape = sql_session::selected_olap_read_shape().unwrap_or(sql_session::OlapReadShape::Scan);
+    let repeats = profile_sample_count();
+    let fixture = runtime.block_on(sql_session::seeded_fixture_with_read_many_pk_count(
+        profile,
+        rows,
+        READ_MANY_PK_COUNT.min(rows.len()),
+    ));
+    let _ = runtime.block_on(fixture.read_olap_profiled(shape));
+    let mut samples = Vec::with_capacity(repeats);
+    let mut profiles = Vec::with_capacity(repeats);
+    for _ in 0..repeats {
+        reset_allocation_accounting();
+        maybe_print_profile_rss_phase("before_result");
+        let started = Instant::now();
+        let (count, detail) = runtime.block_on(fixture.read_olap_profiled(shape));
+        samples.push(started.elapsed());
+        profiles.push(detail);
+        black_box(count);
+        maybe_print_profile_rss_phase("after_result");
+        print_allocation_accounting("result");
+    }
+    samples.sort_unstable();
+    profiles.sort_by_key(|profile| profile.total);
+    let median = &profiles[profiles.len() / 2];
+    println!(
+        "tracked_state_crud result ceiling: storage={} shape={} mode={} samples={} wall_median={:?} wall_min={:?} wall_max={:?} profile_total={:?} arrow_execution={:?} public_result_materialization={:?} rows={} batches={} arrow_bytes={} count_only_rows={} count_only_batches={}",
+        profile.name(),
+        shape.label(),
+        std::env::var("LIX_TRACKED_STATE_CRUD_PROFILE_RESULT_MODE")
+            .unwrap_or_else(|_| "full".into()),
+        repeats,
+        samples[samples.len() / 2],
+        samples[0],
+        samples[samples.len() - 1],
+        median.total,
+        median.arrow_execution,
+        median.public_result_materialization,
+        median.scan_rows,
+        median.scan_batches,
+        median.scan_arrow_bytes,
+        median.result_count_only_rows,
+        median.result_count_only_batches,
+    );
 }
 
 fn accounting_row_count() -> usize {

--- a/packages/engine-benchmarks/benches/tracked_state_crud/sql_session.rs
+++ b/packages/engine-benchmarks/benches/tracked_state_crud/sql_session.rs
@@ -41,15 +41,17 @@ pub(crate) enum OlapReadShape {
     Sort,
     Group,
     Aggregate,
+    Join,
 }
 
 impl OlapReadShape {
-    pub(crate) const ALL: [Self; 5] = [
+    pub(crate) const ALL: [Self; 6] = [
         Self::Scan,
         Self::Filter,
         Self::Sort,
         Self::Group,
         Self::Aggregate,
+        Self::Join,
     ];
 
     pub(crate) const fn label(self) -> &'static str {
@@ -59,6 +61,7 @@ impl OlapReadShape {
             Self::Sort => "olap_sort",
             Self::Group => "olap_group",
             Self::Aggregate => "olap_aggregate",
+            Self::Join => "olap_join",
         }
     }
 
@@ -84,6 +87,11 @@ impl OlapReadShape {
                 "SELECT COUNT(*) AS rows, SUM(ordinal) AS ordinal_sum, AVG(score) AS score_avg, \
                  MIN(ordinal) AS min_ordinal, MAX(ordinal) AS max_ordinal \
                  FROM olap_row WHERE active = TRUE"
+            }
+            Self::Join => {
+                "SELECT left_row.id, right_row.score FROM olap_row AS left_row \
+                 JOIN olap_row AS right_row ON left_row.id = right_row.id \
+                 WHERE left_row.active = TRUE ORDER BY left_row.ordinal"
             }
         }
     }
@@ -511,6 +519,21 @@ impl SqlFixture {
             Self::RocksDB(fixture) => fixture.read_olap(shape).await,
             #[cfg(feature = "slatedb")]
             Self::SlateDB(fixture) => fixture.read_olap(shape).await,
+        }
+    }
+
+    /// Executes one typed OLAP query through the profiled public session path.
+    /// In the count-only ceiling mode the engine intentionally returns no
+    /// public rows, so the profile's retained Arrow row count is the result.
+    pub(crate) async fn read_olap_profiled(
+        &self,
+        shape: OlapReadShape,
+    ) -> (usize, lix::SqlReadProfile) {
+        match self {
+            Self::SQLite(fixture) => fixture.read_olap_profiled(shape).await,
+            Self::RocksDB(fixture) => fixture.read_olap_profiled(shape).await,
+            #[cfg(feature = "slatedb")]
+            Self::SlateDB(fixture) => fixture.read_olap_profiled(shape).await,
         }
     }
 
@@ -957,8 +980,43 @@ where
             OlapReadShape::Sort => assert_olap_sort(&result, expected),
             OlapReadShape::Group => assert_olap_group(&result, expected),
             OlapReadShape::Aggregate => assert_olap_aggregate(&result, expected),
+            OlapReadShape::Join => assert_olap_join(&result, expected),
         }
         result.len()
+    }
+
+    async fn read_olap_profiled(&self, shape: OlapReadShape) -> (usize, lix::SqlReadProfile) {
+        let expected = self
+            .olap_expected
+            .as_ref()
+            .expect("typed OLAP query requires a typed OLAP fixture");
+        let (result, profile) = self
+            .session
+            .execute_profiled(shape.sql(), &[])
+            .await
+            .expect("profile typed OLAP query");
+        let expected_len = match shape {
+            OlapReadShape::Scan => expected.visible_rows,
+            OlapReadShape::Filter => expected.filtered_rows,
+            OlapReadShape::Sort => 10_000.min(expected.active_rows as usize),
+            OlapReadShape::Group => expected.groups.len(),
+            OlapReadShape::Aggregate => 1,
+            OlapReadShape::Join => expected.active_rows as usize,
+        };
+        if profile.result_count_only_rows > 0 {
+            assert_eq!(profile.result_count_only_rows as usize, expected_len);
+            (expected_len, profile)
+        } else {
+            match shape {
+                OlapReadShape::Scan => assert_olap_scan(&result, expected),
+                OlapReadShape::Filter => assert_olap_filter(&result, expected),
+                OlapReadShape::Sort => assert_olap_sort(&result, expected),
+                OlapReadShape::Group => assert_olap_group(&result, expected),
+                OlapReadShape::Aggregate => assert_olap_aggregate(&result, expected),
+                OlapReadShape::Join => assert_olap_join(&result, expected),
+            }
+            (result.len(), profile)
+        }
     }
 
     async fn read_olap_timed(&self, shape: OlapReadShape) -> usize {
@@ -973,6 +1031,7 @@ where
             OlapReadShape::Sort => 10_000.min(expected.active_rows as usize),
             OlapReadShape::Group => expected.groups.len(),
             OlapReadShape::Aggregate => 1,
+            OlapReadShape::Join => expected.active_rows as usize,
         };
         assert_eq!(result.len(), expected_len);
         result.len()
@@ -1547,6 +1606,27 @@ fn assert_olap_aggregate(result: &ExecuteResult, expected: &OlapExpected) {
     );
     assert_eq!(integer_at(result, 0, 3), expected.active_min_ordinal);
     assert_eq!(integer_at(result, 0, 4), expected.active_max_ordinal);
+}
+
+fn assert_olap_join(result: &ExecuteResult, expected: &OlapExpected) {
+    assert_eq!(result.len(), expected.active_rows as usize);
+    assert_eq!(result.columns(), ["id", "score"]);
+    for row_index in 0..result.len() {
+        let id = text_at(result, row_index, 0);
+        let score = real_at(result, row_index, 1);
+        let ordinal = id
+            .strip_prefix("/~lix-olap/")
+            .and_then(|value| value.parse::<usize>().ok())
+            .expect("join id should carry the fixture ordinal");
+        let expected_row = olap_expected_row(
+            expected.initial_row_count,
+            expected.mutation_profile,
+            ordinal,
+        )
+        .expect("join returned an unknown row");
+        assert!(expected_row.active);
+        assert_eq!(score, expected_row.score);
+    }
 }
 
 fn integer_at(result: &ExecuteResult, row: usize, column: usize) -> i64 {

--- a/packages/engine-benchmarks/tests/tracked_state_crud_public_result.rs
+++ b/packages/engine-benchmarks/tests/tracked_state_crud_public_result.rs
@@ -64,6 +64,7 @@ async fn typed_olap_shapes_validate_exact_results_on_every_adapter() {
                 sql_session::OlapReadShape::Sort => 85,
                 sql_session::OlapReadShape::Group => 32,
                 sql_session::OlapReadShape::Aggregate => 1,
+                sql_session::OlapReadShape::Join => 85,
             };
             assert_eq!(
                 fixture.read_olap(shape).await,
@@ -88,6 +89,7 @@ async fn typed_olap_shapes_validate_above_columnar_publication_threshold() {
                 sql_session::OlapReadShape::Sort => 1_365,
                 sql_session::OlapReadShape::Group => 32,
                 sql_session::OlapReadShape::Aggregate => 1,
+                sql_session::OlapReadShape::Join => 1_365,
             };
             assert_eq!(
                 fixture.read_olap(shape).await,

--- a/packages/lix/src/session/execute.rs
+++ b/packages/lix/src/session/execute.rs
@@ -2,8 +2,8 @@ use std::collections::{BTreeMap, BTreeSet};
 use std::future::Future;
 use std::ops::ControlFlow;
 use std::ops::Range;
-use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, OnceLock};
 
 use crate::binary_cas::BlobId;
 use crate::branch::BranchRefReader;
@@ -88,12 +88,19 @@ pub struct ExecuteResult {
 #[derive(Debug)]
 struct ExecuteResultBacking {
     columns: Arc<[String]>,
-    rows: Vec<Row>,
+    rows: OnceLock<Vec<Row>>,
+    columnar: Option<ColumnarResult>,
     notices: Vec<LixNotice>,
     // Observe evaluations can be shared across sessions. Carry the exact
     // rendered plugin state with the rows so each receiving session can
     // acknowledge it only when `ObserveEvents::next()` delivers the event.
     file_view_mutations: Vec<sql2::SessionFileViewMutation>,
+}
+
+#[derive(Debug)]
+struct ColumnarResult {
+    fields: Vec<Field>,
+    batches: Arc<[RecordBatch]>,
 }
 
 impl PartialEq for ExecuteResult {
@@ -153,6 +160,17 @@ impl FileRead {
 }
 
 impl ExecuteResult {
+    pub(crate) fn from_session_read_result(result: sql2::SessionReadSqlResult) -> Self {
+        match result.query {
+            sql2::SessionReadResult::Rows(result) => Self::from_sql_query_result(result),
+            sql2::SessionReadResult::Columnar {
+                fields,
+                batches,
+                notices,
+            } => Self::from_columnar_result(fields, batches, notices),
+        }
+    }
+
     fn from_sql_query_result(result: SqlQueryResult) -> Self {
         #[cfg(feature = "storage-benches")]
         let started = crate::sql_profile::is_active().then(std::time::Instant::now);
@@ -207,7 +225,7 @@ impl ExecuteResult {
         notices: Vec<LixNotice>,
     ) -> Self {
         let columns: Arc<[String]> = columns.into();
-        let rows = rows
+        let rows: Vec<Row> = rows
             .into_iter()
             .map(|values| Row {
                 columns: Arc::clone(&columns),
@@ -217,7 +235,8 @@ impl ExecuteResult {
         Self {
             backing: Some(Arc::new(ExecuteResultBacking {
                 columns,
-                rows,
+                rows: OnceLock::from(rows),
+                columnar: None,
                 notices,
                 file_view_mutations: Vec::new(),
             })),
@@ -225,11 +244,34 @@ impl ExecuteResult {
         }
     }
 
+    fn from_columnar_result(
+        fields: Vec<Field>,
+        batches: Arc<[RecordBatch]>,
+        notices: Vec<LixNotice>,
+    ) -> Self {
+        let columns = fields
+            .iter()
+            .map(|field| field.name().clone())
+            .collect::<Vec<_>>()
+            .into();
+        Self {
+            backing: Some(Arc::new(ExecuteResultBacking {
+                columns,
+                rows: OnceLock::new(),
+                columnar: Some(ColumnarResult { fields, batches }),
+                notices,
+                file_view_mutations: Vec::new(),
+            })),
+            rows_affected: 0,
+        }
+    }
+
     fn with_file_view_mutations(mut self, mutations: Vec<sql2::SessionFileViewMutation>) -> Self {
         let backing = self.backing.get_or_insert_with(|| {
             Arc::new(ExecuteResultBacking {
                 columns: Vec::new().into(),
-                rows: Vec::new(),
+                rows: OnceLock::from(Vec::new()),
+                columnar: None,
                 notices: Vec::new(),
                 file_view_mutations: Vec::new(),
             })
@@ -255,9 +297,12 @@ impl ExecuteResult {
 
     /// Returns the owned rows. Use `iter()` for name-based access.
     pub fn rows(&self) -> &[Row] {
-        self.backing
-            .as_deref()
-            .map_or(&[], |backing| backing.rows.as_slice())
+        self.backing.as_deref().map_or(&[], |backing| {
+            backing
+                .rows
+                .get_or_init(|| backing.materialize_rows())
+                .as_slice()
+        })
     }
 
     /// Iterates rows with borrowed access to the shared column metadata.
@@ -302,6 +347,33 @@ impl ExecuteResult {
         self.columns()
             .iter()
             .position(|column| column == column_name)
+    }
+}
+
+impl ExecuteResultBacking {
+    fn materialize_rows(&self) -> Vec<Row> {
+        let Some(columnar) = &self.columnar else {
+            return Vec::new();
+        };
+        #[cfg(feature = "storage-benches")]
+        let started = crate::sql_profile::is_active().then(std::time::Instant::now);
+        let result = sql2::query_result_from_batches(&columnar.fields, &columnar.batches)
+            .expect("columnar result was validated before public ownership transfer");
+        #[cfg(feature = "storage-benches")]
+        if let Some(started) = started {
+            crate::sql_profile::record_phase(
+                crate::sql_profile::Phase::PublicResultMaterialization,
+                started.elapsed(),
+            );
+        }
+        result
+            .rows
+            .into_iter()
+            .map(|values| Row {
+                columns: Arc::clone(&self.columns),
+                values,
+            })
+            .collect()
     }
 }
 
@@ -1103,7 +1175,7 @@ where
         if let Some(stats) = runtime_storage_stats {
             self.observe_invalidation.bump_if_storage_changed(&stats);
         }
-        let result = ExecuteResult::from_sql_query_result(read_result.query)
+        let result = ExecuteResult::from_session_read_result(read_result)
             .with_file_view_mutations(file_view_mutations);
         if !defer_file_view_acknowledgement {
             self.file_views
@@ -2118,7 +2190,7 @@ where
             return Ok((
                 sql2::SessionReadSqlResult {
                     runtime_functions: None,
-                    query,
+                    query: sql2::SessionReadResult::Rows(query),
                 },
                 file_view_mutations,
             ));
@@ -2154,8 +2226,16 @@ where
             file_views: file_view_collector.clone(),
         };
 
-        let mut query =
-            sql2::execute_read_statement_from_parsed(&ctx, sql, statement, params).await?;
+        let read_session =
+            sql2::prepare_read_session(&ctx, std::slice::from_ref(&statement)).await?;
+        let mut query = sql2::execute_read_statement_in_session_with_result(
+            &read_session,
+            sql,
+            statement,
+            params,
+        )
+        .await?;
+        drop(read_session);
         drop(ctx);
         if let Some(data_column_index) = late_file_content_column {
             let filesystem_path_index: Arc<dyn crate::filesystem::FilesystemPathIndexReader> =
@@ -2164,6 +2244,7 @@ where
                 Arc::new(self.branch_ctx.ref_reader(read_store.clone()));
             let blob_reader: Arc<dyn crate::binary_cas::BlobDataReader> =
                 Arc::new(self.binary_cas.reader(read_store));
+            let mut materialized = query.query.into_sql_query_result()?;
             hydrate_lix_file_content_result(
                 &active_branch_id,
                 Arc::clone(&live_state),
@@ -2172,10 +2253,11 @@ where
                 blob_reader,
                 self.plugin_host.clone(),
                 file_view_collector.clone(),
-                &mut query,
+                &mut materialized,
                 data_column_index,
             )
             .await?;
+            query.query = sql2::SessionReadResult::Rows(materialized);
         }
         drop(live_state);
         let file_view_mutations = file_view_collector
@@ -2184,7 +2266,7 @@ where
         Ok((
             sql2::SessionReadSqlResult {
                 runtime_functions,
-                query,
+                query: query.query,
             },
             file_view_mutations,
         ))
@@ -8963,6 +9045,31 @@ mod tests {
             row.value("title").unwrap(),
             &Value::Text("Hello".to_string())
         );
+    }
+
+    #[test]
+    fn columnar_result_keeps_batches_until_rows_are_requested() {
+        let fields = vec![
+            Field::new("id", DataType::Int64, false),
+            Field::new("title", DataType::Utf8, false),
+        ];
+        let batch = RecordBatch::try_new(
+            Arc::new(Schema::new(fields.clone())),
+            vec![
+                Arc::new(datafusion::arrow::array::Int64Array::from(vec![1, 2])),
+                Arc::new(datafusion::arrow::array::StringArray::from(vec!["a", "b"])),
+            ],
+        )
+        .expect("test columnar batch should be valid");
+        let batches: Arc<[RecordBatch]> = vec![batch].into();
+        let result = ExecuteResult::from_columnar_result(fields, batches, Vec::new());
+
+        assert_eq!(result.columns(), ["id", "title"]);
+        let rows = result.rows();
+        assert_eq!(rows.len(), 2);
+        assert_eq!(rows[0].get::<i64>("id").unwrap(), 1);
+        assert_eq!(rows[1].get::<String>("title").unwrap(), "b");
+        assert_eq!(result.rows().as_ptr(), rows.as_ptr());
     }
 
     #[test]

--- a/packages/lix/src/sql2/exec/datafusion.rs
+++ b/packages/lix/src/sql2/exec/datafusion.rs
@@ -8,6 +8,7 @@
     clippy::unnecessary_wraps
 )]
 
+use datafusion::arrow::array::Array;
 use datafusion::arrow::datatypes::{DataType, Field, Schema, SchemaRef};
 use datafusion::arrow::record_batch::RecordBatch;
 use datafusion::common::metadata::{FieldMetadata, ScalarAndMetadata};
@@ -75,7 +76,36 @@ pub(crate) struct DataFusionLogicalPlan {
 
 pub(crate) struct SessionReadSqlResult {
     pub(crate) runtime_functions: Option<FunctionContext>,
-    pub(crate) query: SqlQueryResult,
+    pub(crate) query: SessionReadResult,
+}
+
+/// One read-result authority. DataFusion results remain owned by their
+/// RecordBatches until a caller actually requests row views; small/native
+/// routes continue to carry their already-materialized rows.
+pub(crate) enum SessionReadResult {
+    Rows(SqlQueryResult),
+    Columnar {
+        fields: Vec<Field>,
+        batches: std::sync::Arc<[RecordBatch]>,
+        notices: Vec<LixNotice>,
+    },
+}
+
+impl SessionReadResult {
+    pub(crate) fn into_sql_query_result(self) -> Result<SqlQueryResult, LixError> {
+        match self {
+            Self::Rows(result) => Ok(result),
+            Self::Columnar {
+                fields,
+                batches,
+                notices,
+            } => {
+                let mut result = query_result_from_batches(&fields, &batches)?;
+                result.notices = notices;
+                Ok(result)
+            }
+        }
+    }
 }
 
 /// DataFusion catalog and providers scoped to one immutable storage read.
@@ -105,7 +135,8 @@ where
     execute_read_statement_from_parsed(ctx, sql, statement, params).await
 }
 
-pub(crate) async fn execute_read_statement_from_parsed<C>(
+#[cfg(test)]
+async fn execute_read_statement_from_parsed<C>(
     ctx: &C,
     sql: &str,
     statement: DataFusionStatement,
@@ -165,7 +196,31 @@ pub(crate) async fn execute_read_statement_in_session_from_parsed(
             started.elapsed(),
         );
     }
-    execute_logical_plan(plan, params).await
+    execute_logical_plan(plan, params)
+        .await?
+        .into_sql_query_result()
+}
+
+pub(crate) async fn execute_read_statement_in_session_with_result(
+    session: &ReadSqlSession<'_>,
+    sql: &str,
+    statement: DataFusionStatement,
+    params: &[Value],
+) -> Result<SessionReadSqlResult, LixError> {
+    #[cfg(feature = "storage-benches")]
+    let started = crate::sql_profile::is_active().then(Instant::now);
+    let plan = create_logical_plan_in_session_from_parsed(session, sql, statement, params).await?;
+    #[cfg(feature = "storage-benches")]
+    if let Some(started) = started {
+        crate::sql_profile::record_phase(
+            crate::sql_profile::Phase::LogicalPlanning,
+            started.elapsed(),
+        );
+    }
+    Ok(SessionReadSqlResult {
+        runtime_functions: None,
+        query: execute_logical_plan(plan, params).await?,
+    })
 }
 
 async fn create_logical_plan_in_session_from_parsed(
@@ -338,7 +393,9 @@ pub(crate) async fn execute_transaction_read_statement_from_parsed(
         SqlLogicalPlan::DataFusion(plan) => plan.session.clone(),
         _ => unreachable!("transaction reads are planned by DataFusion"),
     };
-    let result = execute_logical_plan(plan, params).await;
+    let result = execute_logical_plan(plan, params)
+        .await
+        .and_then(SessionReadResult::into_sql_query_result);
     if let Some((cache, _)) = planning_environment {
         cache.recycle_datafusion_read_session(session);
     }
@@ -1049,7 +1106,7 @@ fn validate_history_anchor_predicates_in_logical_plan(plan: &LogicalPlan) -> Res
 async fn execute_logical_plan(
     plan: SqlLogicalPlan,
     params: &[Value],
-) -> Result<SqlQueryResult, LixError> {
+) -> Result<SessionReadResult, LixError> {
     let SqlLogicalPlan::DataFusion(plan) = plan else {
         return Err(LixError::new(
             LixError::CODE_UNSUPPORTED_SQL,
@@ -1087,6 +1144,27 @@ async fn execute_logical_plan(
     let batches = crate::sql2::runtime::collect_dataframe(dataframe)
         .await
         .map_err(datafusion_error_to_lix_error)?;
+    // This is a benchmark-only causal ceiling probe. It keeps DataFusion's
+    // RecordBatch owners alive through execution, counts the rows/batches,
+    // and deliberately omits public scalar/row conversion. No production
+    // build can enter this branch because the symbol is feature-gated.
+    #[cfg(feature = "storage-benches")]
+    if std::env::var("LIX_TRACKED_STATE_CRUD_PROFILE_RESULT_MODE").as_deref() == Ok("count_only") {
+        let rows = batches.iter().map(RecordBatch::num_rows).sum::<usize>();
+        crate::sql_profile::record_result_count_only(rows, batches.len());
+        return Ok(SessionReadResult::Columnar {
+            fields: result_fields,
+            batches: std::sync::Arc::from(batches),
+            notices,
+        });
+    }
+    if retain_columnar_result(&result_fields, &batches) {
+        return Ok(SessionReadResult::Columnar {
+            fields: result_fields,
+            batches: std::sync::Arc::from(batches),
+            notices,
+        });
+    }
     #[cfg(feature = "storage-benches")]
     let started = crate::sql_profile::is_active().then(Instant::now);
     let mut result = query_result_from_batches(&result_fields, &batches)?;
@@ -1098,7 +1176,71 @@ async fn execute_logical_plan(
         );
     }
     result.notices = notices;
-    Ok(result)
+    Ok(SessionReadResult::Rows(result))
+}
+
+/// Keep large, ordinary Arrow result sets columnar until a caller requests a
+/// row view. The threshold is based only on output cells, not SQL shape or
+/// table identity; unsupported/JSON fields retain the fallible eager route so
+/// public error semantics remain unchanged.
+fn retain_columnar_result(fields: &[Field], batches: &[RecordBatch]) -> bool {
+    const COLUMNAR_CELL_THRESHOLD: usize = 4_096;
+    if fields.is_empty()
+        || fields.iter().any(|field| field_is_json(field))
+        || fields.iter().any(|field| {
+            !matches!(
+                field.data_type(),
+                DataType::Null
+                    | DataType::Boolean
+                    | DataType::Int8
+                    | DataType::Int16
+                    | DataType::Int32
+                    | DataType::Int64
+                    | DataType::UInt8
+                    | DataType::UInt16
+                    | DataType::UInt32
+                    | DataType::UInt64
+                    | DataType::Float32
+                    | DataType::Float64
+                    | DataType::Utf8
+                    | DataType::Utf8View
+                    | DataType::LargeUtf8
+                    | DataType::Binary
+                    | DataType::LargeBinary
+            )
+        })
+    {
+        return false;
+    }
+    if batches.iter().enumerate().any(|(_, batch)| {
+        fields.iter().enumerate().any(|(column_index, field)| {
+            let array = batch.column(column_index);
+            match field.data_type() {
+                DataType::Float32 => array
+                    .as_any()
+                    .downcast_ref::<datafusion::arrow::array::Float32Array>()
+                    .is_some_and(|values| {
+                        (0..values.len())
+                            .any(|index| values.is_valid(index) && !values.value(index).is_finite())
+                    }),
+                DataType::Float64 => array
+                    .as_any()
+                    .downcast_ref::<datafusion::arrow::array::Float64Array>()
+                    .is_some_and(|values| {
+                        (0..values.len())
+                            .any(|index| values.is_valid(index) && !values.value(index).is_finite())
+                    }),
+                _ => false,
+            }
+        })
+    }) {
+        return false;
+    }
+    batches
+        .iter()
+        .map(|batch| batch.num_rows().saturating_mul(batch.num_columns()))
+        .sum::<usize>()
+        >= COLUMNAR_CELL_THRESHOLD
 }
 
 pub(crate) async fn execute_datafusion_write_logical_plan(

--- a/packages/lix/src/sql2/exec/mod.rs
+++ b/packages/lix/src/sql2/exec/mod.rs
@@ -69,10 +69,10 @@ impl SqlWriteResult {
 }
 
 pub(crate) use datafusion::{
-    DataFusionLogicalPlan as SqlDataFusionLogicalPlan, SessionReadSqlResult,
-    execute_read_statement_from_parsed, execute_read_statement_in_session_from_parsed,
+    DataFusionLogicalPlan as SqlDataFusionLogicalPlan, SessionReadResult, SessionReadSqlResult,
+    execute_read_statement_in_session_from_parsed, execute_read_statement_in_session_with_result,
     execute_transaction_read_statement_from_parsed, prepare_read_session,
-    prepare_read_session_at_head,
+    prepare_read_session_at_head, query_result_from_batches,
 };
 #[cfg(test)]
 pub(crate) use write::{

--- a/packages/lix/src/sql2/mod.rs
+++ b/packages/lix/src/sql2/mod.rs
@@ -57,17 +57,18 @@ pub(crate) use entity_columnar_layout::{
 };
 pub(crate) use entity_projection::EntityProjectionDecoder;
 pub(crate) use exec::bound_public_write::PreparedPathValueReplacementProgram;
-pub(crate) use exec::{SessionReadSqlResult, SqlWriteResult};
+pub(crate) use exec::{SessionReadResult, SessionReadSqlResult, SqlWriteResult};
 #[allow(unused_imports)]
 pub(crate) use exec::{
     SqlLogicalPlan, append_path_value_replacement_snapshot,
     append_path_value_replacement_snapshot_text, create_write_logical_plan_from_template,
-    create_write_plan_template_from_parsed, diff_command_query, execute_read_statement_from_parsed,
-    execute_read_statement_in_session_from_parsed, execute_transaction_read_statement_from_parsed,
-    execute_write_logical_plan_parameter_batch, execute_write_logical_plan_prepared_dml_batch,
-    execute_write_logical_plan_result_with_metadata, execute_write_logical_plan_value_batch,
-    parameter_record_batch, parameter_row, prepare_path_value_replacement_program,
-    prepare_path_value_replacement_row, prepare_read_session, prepare_read_session_at_head,
+    create_write_plan_template_from_parsed, diff_command_query,
+    execute_read_statement_in_session_from_parsed, execute_read_statement_in_session_with_result,
+    execute_transaction_read_statement_from_parsed, execute_write_logical_plan_parameter_batch,
+    execute_write_logical_plan_prepared_dml_batch, execute_write_logical_plan_result_with_metadata,
+    execute_write_logical_plan_value_batch, parameter_record_batch, parameter_row,
+    prepare_path_value_replacement_program, prepare_path_value_replacement_row,
+    prepare_read_session, prepare_read_session_at_head, query_result_from_batches,
     write_plan_requires_post_stage_returning_checkpoint,
 };
 #[cfg(test)]

--- a/packages/lix/src/sql_profile.rs
+++ b/packages/lix/src/sql_profile.rs
@@ -28,6 +28,11 @@ pub struct SqlReadProfile {
     /// Sum of Arrow's in-memory array sizes at the scan output boundary.
     /// This is not the number of bytes read from the storage backend.
     pub scan_arrow_bytes: u64,
+    /// Number of rows retained by the benchmark-only result ceiling probe.
+    /// A nonzero value means result conversion was intentionally bypassed;
+    /// it is never set by the production result path.
+    pub result_count_only_rows: u64,
+    pub result_count_only_batches: u64,
 }
 
 impl SqlReadProfile {
@@ -75,6 +80,17 @@ pub(crate) fn record_scan(rows: usize, batches: usize, arrow_bytes: usize, elaps
         profile.scan_batches = profile.scan_batches.saturating_add(batches as u64);
         profile.scan_arrow_bytes = profile.scan_arrow_bytes.saturating_add(arrow_bytes as u64);
         profile.scan_elapsed += elapsed;
+    });
+}
+
+#[cfg(feature = "storage-benches")]
+pub(crate) fn record_result_count_only(rows: usize, batches: usize) {
+    let _ = ACTIVE_PROFILE.try_with(|profile| {
+        let mut profile = profile.borrow_mut();
+        profile.result_count_only_rows = profile.result_count_only_rows.saturating_add(rows as u64);
+        profile.result_count_only_batches = profile
+            .result_count_only_batches
+            .saturating_add(batches as u64);
     });
 }
 


### PR DESCRIPTION
## Summary

Keep large DataFusion `RecordBatch`/Arrow owners through the engine result boundary and lazily materialize `Vec<Row>` only when a row consumer calls `ExecuteResult::rows()`. The contract is one `SessionReadResult` authority (`Rows` or `Columnar`), with a general 4,096-cell threshold; JSON, unsupported types, and non-finite floats remain on the checked row conversion route. No query-specific shortcut, persisted format, compatibility dispatcher, or second result authority was added.

## Exact provenance

- Base main: `c32b1106f9c8a3e238c8ee29d3107e378dd35ac1`
- Discovery candidate: `629304559c654ed185b1a822b56bec441af54656`
- Integrated head: `3901626bc8c7d21fbb292aa777a4cff17511d0b5`
- Integrated parent fetched once: `6591176bc65806d780c4cf2b0d675f314c938a39`
- Final benchmark binary SHA-256: `4ebc32ee2f1647db3c7e7a562c29af7899157ab9e549598df69f20eaf8acf866`
- Integration diff SHA-256: `0eb5d21da36adf824dbccc9a06774b319c1653bbf29aa8f641a268dd37828921`

## Before / after causal ceiling

The control is eager scalar conversion; the candidate's low-copy consumer does not request rows. Setup is excluded from the operation phase. `p95` is unavailable for the n=1 1M confirmation cells; n=3 cells report min/max instead. Native RocksDB/SlateDB I/O counters are unavailable in this harness.

| backend / scale | baseline eager full | candidate low-copy count-only | result allocations | Arrow output |
|---|---:|---:|---:|---:|
| RocksDB 10K, n=3 | 14.523 ms p50; 5.064 MB | 2.974 ms p50; 1.230 MB | -75.7% | 10,000 rows / 16 batches / 522,864 B |
| SlateDB 10K, n=3 | 13.810 ms p50; 5.157 MB | 3.569 ms p50; 1.323 MB | -74.4% | 10,000 / 16 / 522,864 B |
| RocksDB 1M, n=3 control / n=1 merged confirmation | 1.410 s p50; 369.96 MB; 807.4 ms conversion | 3.481 ms; 0.749 MB; 0 ns conversion | -99.8% | 1,000,000 / 24 / 51,138,112 B |
| SlateDB 1M, n=3 control / n=1 merged confirmation | 1.260 s p50; 370.47 MB; 669.3 ms conversion | 3.683 ms; 0.853 MB; 0 ns conversion | -99.8% | 1,000,000 / 24 / 51,138,112 B |

The full row-consumer path remains semantically identical and still pays materialization at the final `rows()` boundary; this PR removes unconditional conversion and enables low-copy columnar consumers, not a claim that callers demanding every row become faster.

## Verification and vetoes

- `cargo fmt --all -- --check`, `cargo check --profile test -p lix --features storage-benches`, and benchmark `--no-run`: passed.
- Full merged-tree lib suite with `RUST_MIN_STACK=8388608`: `1993 passed; 0 failed; 8 ignored`.
- Merged 10K n=3 vetoes: update_all Rocks 57.531 ms / Slate 61.893 ms; point read Rocks 5.258 ms / Slate 4.695 ms; history Rocks 112.575 ms / Slate 114.246 ms; diff Rocks 148.940 ms / Slate 156.669 ms. Correctness and exact output/schema/order/null/blob/text/numeric semantics passed.
- Final merged 1M RocksDB+SlateDB full/count-only scan cells passed with 1,000,000 rows, 24 batches, and 51,138,112 Arrow bytes; full/count raw output is in the artifact directory.

## Complexity / tradeoffs

Both paths are O(cells) when row vectors are requested. The new columnar path is O(batches + retained Arrow bytes) for low-copy consumers and defers O(cells) scalar conversion until the last unavoidable row boundary. It avoids simultaneously retaining Arrow arrays and a second scalar row representation. Scan/storage traversal and DataFusion execution asymptotics are unchanged. Allocator/native backend counters beyond the allocation sampler are unavailable; no critical regression was observed.

## Artifacts

Artifact directory: `/root/projects/lix-draft1212/artifacts/result-columnar-c32-ceiling-20260806T000000Z/`

- `merged-10k-veto.log` SHA-256 `f193fc0c3bb5841c9f7551c2210c1857ee5f445a41bb8bce6c51cf2f0278dac4`
- `merged-1m-scan.log` SHA-256 `90d07906bdb4f8e411f68bcfeaf0de04c92630fbff6552969299f34eb21e2811`
- `SHA256SUMS` contains every raw diagnostic log; pre-integration manifest SHA-256 `f3899b4cf3d02db541f57412d2dc3a67d6aba384df05b31ddeb650aa9f90203d`
- `REPORT.md` is the complete causal report; pre-integration SHA-256 `2171030df984f2f25d6f835e9da8d93a04e676daec75f52a3e8ebfbfc6b4cca8`
