### PR TITLE
perf: bound authenticated tracked-root reuse

### DIFF
--- a/packages/lix/src/tracked_state/commit_root_rebuild.rs
+++ b/packages/lix/src/tracked_state/commit_root_rebuild.rs
@@ -71,7 +71,8 @@ where
     S: StorageAdapterRead + ?Sized,
 {
     let plans =
-        load_rebuild_plans_to_nearest_available_root(rebuilder.store, commit_id, true).await?;
+        load_rebuild_plans_to_nearest_available_root_for_repair(rebuilder.store, commit_id, true)
+            .await?;
     let mut report = None;
     let context = TrackedStateContext::new();
     let mut state = TrackedStateTransientRebuildState::default();
@@ -179,6 +180,49 @@ where
                 .is_some()
         {
             break;
+        }
+        let plan = load_commit_root_rebuild_plan(store, &current_commit_id).await?;
+        let parent_commit_id = plan.parent_commit_id;
+        plans.push(plan);
+        let Some(parent_commit_id) = parent_commit_id else {
+            break;
+        };
+        current_commit_id = parent_commit_id.to_string();
+        force_current = false;
+    }
+    Ok(plans)
+}
+
+/// Explicit recovery may use immutable changelog facts to replace a missing or
+/// corrupt serving root. Ordinary publication must use the strict function
+/// above and fail closed instead. Keeping this recovery-only discovery route
+/// separate prevents repair semantics from becoming a hot-path fallback.
+async fn load_rebuild_plans_to_nearest_available_root_for_repair<S>(
+    store: &S,
+    commit_id: &str,
+    force_head: bool,
+) -> Result<Vec<CommitRootRebuildPlan>, LixError>
+where
+    S: StorageAdapterRead + ?Sized,
+{
+    let mut plans = Vec::new();
+    let mut current_commit_id = commit_id.to_string();
+    let mut force_current = force_head;
+    let mut seen_commit_ids = HashSet::new();
+    loop {
+        if !seen_commit_ids.insert(current_commit_id.clone()) {
+            return Err(LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                format!(
+                    "cannot repair tracked_state commit_root for commit '{commit_id}': first-parent cycle includes commit '{current_commit_id}'"
+                ),
+            ));
+        }
+        if !force_current {
+            match load_available_root(store, &current_commit_id).await {
+                Ok(Some(_)) => break,
+                Ok(None) | Err(_) => {}
+            }
         }
         let plan = load_commit_root_rebuild_plan(store, &current_commit_id).await?;
         let parent_commit_id = plan.parent_commit_id;

--- a/packages/lix/src/tracked_state/commit_root_rebuild.rs
+++ b/packages/lix/src/tracked_state/commit_root_rebuild.rs
@@ -220,7 +220,17 @@ where
         }
         if !force_current {
             match load_available_root(store, &current_commit_id).await {
-                Ok(Some(_)) => break,
+                Ok(Some(_)) => {
+                    // Repair discovery is allowed to walk the immutable
+                    // changelog beyond an available serving root.  Validate
+                    // that boundary before using it as the replay base so a
+                    // corrupt first-parent cycle cannot be converted into an
+                    // authority-mismatch error (or silently terminate
+                    // recovery).  This is recovery-only; ordinary hot-path
+                    // root reuse remains bounded by `load_available_root`.
+                    validate_first_parent_acyclic_for_repair(store, &current_commit_id).await?;
+                    break;
+                }
                 Ok(None) | Err(_) => {}
             }
         }
@@ -234,6 +244,54 @@ where
         force_current = false;
     }
     Ok(plans)
+}
+
+/// Checks the immutable first-parent chain at the explicit-repair boundary.
+///
+/// Unlike ordinary publication, recovery may spend O(history depth) proving
+/// that a serving root is a safe replay base.  This prevents a malformed
+/// changelog cycle hidden behind an otherwise valid root from being reported
+/// as a misleading root mismatch or from terminating repair early.
+async fn validate_first_parent_acyclic_for_repair<S>(
+    store: &S,
+    start_commit_id: &str,
+) -> Result<(), LixError>
+where
+    S: StorageAdapterRead + ?Sized,
+{
+    let mut seen_commit_ids = HashSet::new();
+    let mut current_commit_id = CommitId::parse_lix(
+        start_commit_id,
+        "explicit commit-root repair first-parent validation",
+    )?;
+    loop {
+        if !seen_commit_ids.insert(current_commit_id) {
+            return Err(LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                format!(
+                    "cannot repair tracked_state commit_root for commit '{start_commit_id}': first-parent cycle includes commit '{current_commit_id}'"
+                ),
+            ));
+        }
+        let mut reader = ChangelogContext::new().reader(store);
+        let batch = reader
+            .load_commits(CommitLoadRequest {
+                commit_ids: std::slice::from_ref(&current_commit_id),
+            })
+            .await?;
+        let Some(commit) = batch.into_iter().next().and_then(|(_, value)| value) else {
+            return Err(LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                format!(
+                    "cannot repair tracked_state commit_root for unknown commit '{current_commit_id}'"
+                ),
+            ));
+        };
+        let Some(parent_commit_id) = first_parent_commit_id(&commit) else {
+            return Ok(());
+        };
+        current_commit_id = parent_commit_id;
+    }
 }
 
 async fn load_available_root<S>(

--- a/packages/lix/src/tracked_state/commit_root_rebuild.rs
+++ b/packages/lix/src/tracked_state/commit_root_rebuild.rs
@@ -1,6 +1,4 @@
 use std::collections::{BTreeMap, HashSet};
-use std::future::Future;
-use std::pin::Pin;
 
 use crate::LixError;
 use crate::changelog::{
@@ -15,9 +13,7 @@ use crate::tracked_state::context::{
 };
 use crate::tracked_state::storage;
 use crate::tracked_state::tree::TrackedStateTree;
-use crate::tracked_state::types::{
-    TrackedStateCommitRoot, TrackedStateRootId, TrackedStateTreeScanRequest,
-};
+use crate::tracked_state::types::TrackedStateRootId;
 use crate::tracked_state::{
     TrackedStateDeltaRef, TrackedStateKeyRef, TrackedStateRootMutationRef, encode_key_ref,
 };
@@ -178,7 +174,7 @@ where
             ));
         }
         if !force_current
-            && load_available_root(store, &current_commit_id, &mut HashSet::new())
+            && load_available_root(store, &current_commit_id)
                 .await?
                 .is_some()
         {
@@ -196,84 +192,23 @@ where
     Ok(plans)
 }
 
-fn load_available_root<'a, S>(
-    store: &'a S,
-    commit_id: &'a str,
-    seen: &'a mut HashSet<String>,
-) -> Pin<Box<dyn Future<Output = Result<Option<TrackedStateRootId>, LixError>> + Send + 'a>>
-where
-    S: StorageAdapterRead + ?Sized + 'a,
-{
-    Box::pin(async move {
-        if !seen.insert(commit_id.to_string()) {
-            return Ok(None);
-        }
-        let Some(metadata) = storage::load_snapshot_commit_root(store, commit_id).await? else {
-            seen.remove(commit_id);
-            return Ok(None);
-        };
-        if !commit_root_tree_is_readable(store, &metadata).await? {
-            seen.remove(commit_id);
-            return Ok(None);
-        }
-        if !commit_root_matches_canonical_rebuild(store, commit_id, &metadata, seen).await? {
-            seen.remove(commit_id);
-            return Ok(None);
-        }
-        seen.remove(commit_id);
-        Ok(Some(metadata.root_id))
-    })
-}
-
-async fn commit_root_tree_is_readable<S>(
-    store: &S,
-    metadata: &TrackedStateCommitRoot,
-) -> Result<bool, LixError>
-where
-    S: StorageAdapterRead + ?Sized,
-{
-    match TrackedStateTree::new()
-        .scan(
-            store,
-            &metadata.root_id,
-            &TrackedStateTreeScanRequest::default(),
-        )
-        .await
-    {
-        Ok(_) => Ok(true),
-        Err(_) => Ok(false),
-    }
-}
-
-async fn commit_root_matches_canonical_rebuild<S>(
+async fn load_available_root<S>(
     store: &S,
     commit_id: &str,
-    metadata: &TrackedStateCommitRoot,
-    seen: &mut HashSet<String>,
-) -> Result<bool, LixError>
+) -> Result<Option<TrackedStateRootId>, LixError>
 where
     S: StorageAdapterRead + ?Sized,
 {
-    let plan = load_commit_root_rebuild_plan(store, commit_id).await?;
-    if let Some(parent_commit_id) = plan.parent_commit_id.as_ref() {
-        let parent_commit_id_text = parent_commit_id.to_string();
-        let Some(parent_root_id) = load_available_root(store, &parent_commit_id_text, seen).await?
-        else {
-            return Ok(false);
-        };
-        match metadata.parent_roots.first() {
-            Some(parent)
-                if parent.commit_id == *parent_commit_id && parent.root_id == parent_root_id => {}
-            _ => return Ok(false),
-        }
-    } else if !metadata.parent_roots.is_empty() {
-        return Ok(false);
-    }
-    let mut scratch_writes = StorageWriteSet::new();
-    let context = TrackedStateContext::new();
-    let mut writer = context.writer(store, &mut scratch_writes);
-    let report = stage_rebuild_plan_with_writer(&mut writer, &plan).await?;
-    Ok(report.root_id == metadata.root_id)
+    let Some(metadata) = storage::load_snapshot_commit_root(store, commit_id).await? else {
+        return Ok(None);
+    };
+    // Immutable manifest/root metadata is the serving authority. Availability
+    // checks validate its bounded content-addressed closure; full canonical
+    // replay remains an explicit rebuild/integrity operation.
+    TrackedStateTree::new()
+        .validate_root_metadata(store, &metadata)
+        .await?;
+    Ok(Some(metadata.root_id))
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/packages/lix/src/tracked_state/context.rs
+++ b/packages/lix/src/tracked_state/context.rs
@@ -7284,6 +7284,120 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn explicit_rebuild_repairs_corrupt_rooted_ancestor_before_descendant() {
+        let storage = StorageAdapter::new(Memory::new());
+        let tracked_state = TrackedStateContext::new();
+        write_root_for_test(
+            &storage,
+            &tracked_state,
+            "base",
+            None,
+            &[row_with_value("entity-base", "change-base", "base", "base")],
+        )
+        .await
+        .expect("base root should write");
+        write_root_for_test(
+            &storage,
+            &tracked_state,
+            "intermediate",
+            Some("base"),
+            &[row_with_value(
+                "entity-intermediate",
+                "change-intermediate",
+                "intermediate",
+                "intermediate",
+            )],
+        )
+        .await
+        .expect("intermediate root should write");
+        write_root_for_test(
+            &storage,
+            &tracked_state,
+            "target",
+            Some("intermediate"),
+            &[row_with_value(
+                "entity-target",
+                "change-target",
+                "target",
+                "target",
+            )],
+        )
+        .await
+        .expect("target root should write");
+
+        let read = storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("root authority read should open");
+        let expected_intermediate_root = storage::load_root(&read, "intermediate")
+            .await
+            .expect("intermediate root metadata should load")
+            .expect("intermediate root should exist");
+        let expected_target_root = storage::load_root(&read, "target")
+            .await
+            .expect("target root metadata should load")
+            .expect("target root should exist");
+        drop(read);
+        corrupt_root_chunk_for_test(&storage, "intermediate").await;
+
+        let read = storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("hot reuse read should open");
+        let hot_error = crate::tracked_state::commit_root_rebuild::load_rebuild_plans_to_nearest_available_root(
+            &read,
+            "target",
+            true,
+        )
+        .await
+        .expect_err("ordinary reuse must fail closed on corrupt ancestor");
+        assert!(
+            hot_error.message.contains("hash") || hot_error.message.contains("digest"),
+            "unexpected hot reuse error: {hot_error:?}"
+        );
+        drop(read);
+
+        let read = storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("repair read should open");
+        let mut writes = storage.new_write_set();
+        tracked_state
+            .root_rebuilder(&read, &mut writes)
+            .rebuild_commit_root_at("target")
+            .await
+            .expect("explicit repair should rebuild through corrupt ancestor");
+        storage
+            .commit_write_set(writes, StorageWriteOptions::default())
+            .await
+            .expect("repaired roots should commit");
+
+        let read = storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("post-repair read should open");
+        assert_eq!(
+            storage::load_root(&read, "intermediate")
+                .await
+                .expect("repaired intermediate root should load"),
+            Some(expected_intermediate_root)
+        );
+        assert_eq!(
+            storage::load_root(&read, "target")
+                .await
+                .expect("repaired target root should load"),
+            Some(expected_target_root)
+        );
+        let rows = tracked_state
+            .reader(read)
+            .scan_batch_at_commit("target", &test_schema_scan_request())
+            .await
+            .expect("repaired target should scan")
+            .into_rows();
+        assert_eq!(rows.len(), 3);
+    }
+
+    #[tokio::test]
     async fn explicit_rebuild_rejects_stale_immutable_root_missing_inherited_row() {
         let storage = StorageAdapter::new(Memory::new());
         let tracked_state = TrackedStateContext::new();

--- a/packages/lix/src/tracked_state/context.rs
+++ b/packages/lix/src/tracked_state/context.rs
@@ -7194,6 +7194,96 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn ordinary_root_reuse_fails_closed_on_missing_authoritative_root_chunk() {
+        let storage = StorageAdapter::new(Memory::new());
+        let tracked_state = TrackedStateContext::new();
+        write_root_for_test(
+            &storage,
+            &tracked_state,
+            "base",
+            None,
+            &[row_with_value("entity-a", "change-base", "base", "base")],
+        )
+        .await
+        .expect("base root should write");
+        write_rootless_commit_for_test(
+            &storage,
+            "rootless-child",
+            "base",
+            &[row_with_value(
+                "entity-a",
+                "change-child",
+                "rootless-child",
+                "child",
+            )],
+        )
+        .await;
+        delete_root_chunk_for_test(&storage, "base").await;
+
+        let read = storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("root reuse read should open");
+        let error = crate::tracked_state::commit_root_rebuild::load_rebuild_plans_to_nearest_available_root(
+            &read,
+            "rootless-child",
+            true,
+        )
+        .await
+        .expect_err("missing authoritative root chunk must fail closed");
+
+        assert!(
+            error.message.contains("tree chunk is missing"),
+            "unexpected error: {error:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn ordinary_root_reuse_fails_closed_on_hash_corrupt_authoritative_root_chunk() {
+        let storage = StorageAdapter::new(Memory::new());
+        let tracked_state = TrackedStateContext::new();
+        write_root_for_test(
+            &storage,
+            &tracked_state,
+            "base",
+            None,
+            &[row_with_value("entity-a", "change-base", "base", "base")],
+        )
+        .await
+        .expect("base root should write");
+        write_rootless_commit_for_test(
+            &storage,
+            "rootless-child",
+            "base",
+            &[row_with_value(
+                "entity-a",
+                "change-child",
+                "rootless-child",
+                "child",
+            )],
+        )
+        .await;
+        corrupt_root_chunk_for_test(&storage, "base").await;
+
+        let read = storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("root reuse read should open");
+        let error = crate::tracked_state::commit_root_rebuild::load_rebuild_plans_to_nearest_available_root(
+            &read,
+            "rootless-child",
+            true,
+        )
+        .await
+        .expect_err("hash-corrupt authoritative root chunk must fail closed");
+
+        assert!(
+            error.message.contains("hash") || error.message.contains("digest"),
+            "unexpected error: {error:?}"
+        );
+    }
+
+    #[tokio::test]
     async fn explicit_rebuild_rejects_stale_immutable_root_missing_inherited_row() {
         let storage = StorageAdapter::new(Memory::new());
         let tracked_state = TrackedStateContext::new();

--- a/packages/lix/src/tracked_state/mod.rs
+++ b/packages/lix/src/tracked_state/mod.rs
@@ -24,7 +24,8 @@ pub(crate) use commit_root_rebuild::{
     load_rebuild_plans_to_nearest_available_root, stage_rebuild_plan_with_writer,
 };
 pub(crate) use context::{
-    TrackedStateContext, TrackedStateStoreReader, descriptor_dependency_cascade_file_ids,
+    TrackedStateContext, TrackedStateStoreReader, TrackedStateTransientRebuildState,
+    descriptor_dependency_cascade_file_ids,
 };
 #[cfg(test)]
 pub(crate) use current_state_data_part::decode_current_state_data_part_refs;

--- a/packages/lix/src/tracked_state/tree.rs
+++ b/packages/lix/src/tracked_state/tree.rs
@@ -34,9 +34,9 @@ use crate::tracked_state::types::TrackedStateMutation;
 #[cfg(test)]
 use crate::tracked_state::types::TrackedStateTreeDiffEntry;
 use crate::tracked_state::types::{
-    TRACKED_STATE_HASH_BYTES, TrackedStateApplyResult, TrackedStateDeltaRef,
-    TrackedStateIndexValue, TrackedStateIndexValueRef, TrackedStateKey, TrackedStateKeyRef,
-    TrackedStateMutationBatch, TrackedStateRootId, TrackedStateRootMutationRef,
+    TRACKED_STATE_HASH_BYTES, TrackedStateApplyResult, TrackedStateCommitRoot,
+    TrackedStateDeltaRef, TrackedStateIndexValue, TrackedStateIndexValueRef, TrackedStateKey,
+    TrackedStateKeyRef, TrackedStateMutationBatch, TrackedStateRootId, TrackedStateRootMutationRef,
     TrackedStateTreeScanRequest,
 };
 use crate::{LixError, NullableKeyFilter};
@@ -118,6 +118,65 @@ impl TrackedStateTree {
         commit_id: &str,
     ) -> Result<Option<TrackedStateRootId>, LixError> {
         storage::load_root(store, commit_id).await
+    }
+
+    /// Validates the bounded serving closure authenticated by immutable root
+    /// metadata.
+    ///
+    /// Ordinary publication needs to know that the authoritative root node is
+    /// present, content-addressed, and has the advertised shape. It must not
+    /// rescan every row or canonically replay every ancestor merely to reuse an
+    /// immutable root. Descendants are hash-verified when a point/frontier
+    /// traversal actually touches them; the left spine is sufficient to prove
+    /// the advertised height without making availability depend on tree size.
+    pub(crate) async fn validate_root_metadata(
+        &self,
+        store: &(impl StorageAdapterRead + ?Sized),
+        metadata: &TrackedStateCommitRoot,
+    ) -> Result<(), LixError> {
+        let mut hash = *metadata.root_id.as_bytes();
+        let mut height = 1_u32;
+        let root = self.load_node(store, &hash).await?;
+        let row_count = u64::try_from(decoded_node_row_count(&root)).map_err(|_| {
+            LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                "tracked-state root row count exceeds u64",
+            )
+        })?;
+        if row_count != metadata.row_count_estimate {
+            return Err(LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                "tracked-state root node count disagrees with immutable root metadata",
+            ));
+        }
+
+        let mut node = root;
+        while let DecodedNode::Internal(internal) = node {
+            hash = internal
+                .children()
+                .first()
+                .ok_or_else(|| {
+                    LixError::new(
+                        LixError::CODE_INTERNAL_ERROR,
+                        "tracked-state internal root node has no children",
+                    )
+                })?
+                .child_hash;
+            height = height.checked_add(1).ok_or_else(|| {
+                LixError::new(
+                    LixError::CODE_INTERNAL_ERROR,
+                    "tracked-state root height exceeds u32",
+                )
+            })?;
+            node = self.load_node(store, &hash).await?;
+        }
+        if height != metadata.tree_height {
+            return Err(LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                "tracked-state root height disagrees with immutable root metadata",
+            ));
+        }
+        Ok(())
     }
 
     #[cfg(test)]

--- a/packages/lix/src/transaction/commit.rs
+++ b/packages/lix/src/transaction/commit.rs
@@ -39,8 +39,8 @@ use crate::tracked_state::{
     TrackedStateCommitDeltaRef, TrackedStateCommitRoot, TrackedStateContext, TrackedStateDeltaRef,
     TrackedStateFilter, TrackedStateKey, TrackedStateKeyRef, TrackedStateReadColumns,
     TrackedStateRootMutationRef, TrackedStateScanRequest, TrackedStateSingleStringReplacementRef,
-    encode_key_ref, load_commit_delta_change_records, load_commit_delta_replay_metadata,
-    stage_addressable_commit_deltas, stage_change_locators,
+    TrackedStateTransientRebuildState, encode_key_ref, load_commit_delta_change_records,
+    load_commit_delta_replay_metadata, stage_addressable_commit_deltas, stage_change_locators,
     stage_ordered_addressable_commit_deltas,
 };
 use crate::transaction::staging::{
@@ -5656,7 +5656,12 @@ async fn stage_tracked_roots(
     if root_fence_ids.is_empty() {
         return Ok(BTreeMap::new());
     }
-    let mut tracked_writer = tracked_state.writer(read, writes);
+    // Reconstruct only the bounded rootless suffix in a transient
+    // content-addressed overlay. Rootless ancestors have no immutable root
+    // pointer, so their intermediate chunks must not enter the durable write
+    // set. A rooted descendant promotes only transient chunks reachable from
+    // its final authenticated root.
+    let mut rebuild_state = TrackedStateTransientRebuildState::default();
     let mut staged_rebuild_plan_ids = BTreeSet::new();
     for parent_commit_id in durable_root_rebuild_parents {
         let plans = crate::tracked_state::load_rebuild_plans_to_nearest_available_root(
@@ -5667,11 +5672,21 @@ async fn stage_tracked_roots(
         .await?;
         for plan in plans.iter().rev() {
             if staged_rebuild_plan_ids.insert(plan.commit_id) {
-                crate::tracked_state::stage_rebuild_plan_with_writer(&mut tracked_writer, plan)
+                let previously_known = rebuild_state.chunk_hashes();
+                let mut scratch_writes = StorageWriteSet::new();
+                let mut transient_writer = tracked_state.writer_with_rebuild_state(
+                    read,
+                    &mut scratch_writes,
+                    rebuild_state,
+                );
+                crate::tracked_state::stage_rebuild_plan_with_writer(&mut transient_writer, plan)
                     .await?;
+                rebuild_state = transient_writer.into_transient_rebuild_state();
+                rebuild_state.mark_new_chunks_transient(&previously_known);
             }
         }
     }
+    let mut tracked_writer = tracked_state.writer_with_rebuild_state(read, writes, rebuild_state);
     let empty_certified_replacement_markers = BTreeSet::new();
     for root in tracked_roots_parent_first(tracked_roots)? {
         if !root_fence_ids.contains(&root.commit_id) {
@@ -5749,7 +5764,7 @@ async fn stage_tracked_roots(
                 file_id: first_row.file_id.map(crate::common::SharedStr::as_str),
                 entity_pk: first_row.entity_pk,
             });
-            if tracked_writer
+            if let Some(report) = tracked_writer
                 .try_stage_bulk_parent_root_from_ordered_mutations(
                     &commit_id_text,
                     parent_commit_id_text.as_deref(),
@@ -5759,8 +5774,10 @@ async fn stage_tracked_roots(
                     OrderedStateRowMutations::new(state_row_indices, state_rows, insert_selection),
                 )
                 .await?
-                .is_some()
             {
+                tracked_writer
+                    .promote_reachable_transient_chunks(&report.root_id)
+                    .await?;
                 continue;
             }
         }
@@ -5804,7 +5821,7 @@ async fn stage_tracked_roots(
         // also preserves the one-mutation path for ordinary singleton writes.
         let commit_id_text = root.commit_id.to_string();
         let parent_commit_id_text = root.parent_commit_id.map(|id| id.to_string());
-        tracked_writer
+        let report = tracked_writer
             .stage_commit_root_with_absence_guards(
                 &commit_id_text,
                 parent_commit_id_text.as_deref(),
@@ -5812,6 +5829,9 @@ async fn stage_tracked_roots(
                 &absence_guards,
                 certified_replacement_markers,
             )
+            .await?;
+        tracked_writer
+            .promote_reachable_transient_chunks(&report.root_id)
             .await?;
     }
     Ok(tracked_writer


### PR DESCRIPTION
## Summary

This hard-cuts ordinary tracked-root publication from history-dependent canonical rebuilds to bounded authenticated root reuse. The immutable commit-state manifest/root metadata is the authority. Ordinary publication validates the authoritative root node and a bounded left-spine height/count witness, then lazily verifies descendants only when the mutation frontier touches them. Rootless suffix replay is transient; only chunks reachable from the final rooted commit are promoted to the durable write set.

The recovery policy is intentionally separate: explicit `rebuild_commit_root_at` uses a repair-only plan-discovery function that treats a missing/corrupt serving root as unavailable and reconstructs it from immutable changelog facts. Ordinary publication never uses that route and remains fail-closed.

## Exact source

- Base/main: `a3788dc3db261e225c5a42abead568fe81027214`
- Candidate: `8cf4df4b54b093ef819bd7beaa11b639407ddb04`
- Candidate tree: `69be6b0bb16319d2f110b0df93049d36ed3a77ce`
- Branch: `codex/tracked-root-hot-reuse-recovery-fix`
- Candidate-on-30f diff SHA-256: `fd599cfc2c7824fa65229bd35a4cb91749f784fc9a70dbd27c9ac7c4abb13642`

## Ownership/deletion surface

- `tracked_state/commit_root_rebuild.rs`: deleted `commit_root_tree_is_readable`, the full `TrackedStateTree::scan` availability predicate, recursive `commit_root_matches_canonical_rebuild`, and hot ancestor canonical replay. Added a separately named explicit-repair discovery path after the recovered ancestor-chain blocker.
- `tracked_state/tree.rs`: added bounded authenticated root metadata validation (root hash, row-count estimate, left-spine height).
- `transaction/commit.rs`: rootless rebuild plans now use scratch/transient content-addressed state; bulk and general final roots promote only final-root-reachable chunks. Durable intermediate-plan staging is deleted.
- `tracked_state/context.rs`: focused fail-closed, corruption, ancestor-repair, no-op, and reachability fixtures.
- `tracked_state/mod.rs`: exposes the transient rebuild state to the transaction owner.

No second authority, compatibility decoder, migration path, cache authority, dual writer, or hot fallback was added.

## Complexity

Before, ordinary reuse was `O(H × (N + replay))` in retained rooted-history depth `H`, with full-tree scans and recursive canonical ancestor rebuilds; intermediate plans were durably staged.

After, ordinary reuse is `O(h + R + F)` for tree height `h`, bounded rootless suffix `R`, and changed authenticated frontier `F`. Memory is bounded by suffix/frontier state and durable staging contains only final-root-reachable chunks. Explicit recovery remains `O(N + replay)` by design.

## Ryzen discovery screen

Workload: clean merge, 10K live rows, 100 changed rows per side, setup excluded. Baseline was exact main; candidate was the production-equivalent frozen implementation before the recovery-only successor.

| Backend/history | Merge wall | Merge CPU | Allocations | tracked_roots |
|---|---:|---:|---:|---:|
| Rocks/100 | 23.589 → 2.952 ms (-87.5%) | 23.889 → 3.129 ms (-86.9%) | 58.5 → 8.0 MB (-86.4%) | 20.555 → 1.187 ms (-94.2%) |
| Slate/100 | 23.484 → 3.299 ms (-86.0%) | 24.393 → 3.743 ms (-84.7%) | 68.6 → 9.0 MB (-86.8%) | 21.297 → 1.175 ms (-94.5%) |
| Rocks/1K | 393.439 → 3.747 ms (-99.0%) | 396.263 → 3.948 ms (-99.0%) | 634.1 → 10.8 MB (-98.3%) | 385.428 → 1.904 ms (-99.5%) |
| Slate/1K | 460.242 → 5.167 ms (-98.9%) | 463.359 → 5.589 ms (-98.8%) | 1,109.9 → 14.4 MB (-98.7%) | 456.926 → 2.660 ms (-99.4%) |

The isolated Rocks 1K diff +7.3% flag cleared under AB/BA confirmation (-1.5%, +2.5%); no critical diff regression was confirmed.

## IV final qualification

IV ran 16 AB/BA runs on both adapters, preserving 10K rows and result hash `cfd62914245ea5b998b766f4945d48c16d7932c6cdaf1e84d27a1a2945ee5b1c`.

| Backend/history | Wall | Publication | Allocations | Root-load/RSS term | Unreachable chunks |
|---|---:|---:|---:|---:|---:|
| Rocks/100 | -11.75% | included | — | — | 278 → 0 |
| Slate/100 | -15.83% | included | — | — | 278 → 0 |
| Rocks/1K | -81.47% | -77.64% | -21.41% | -93.54% | 2,795 → 0 |
| Slate/1K | -73.67% | -77.34% | -23.83% | -93.54% | 2,795 → 0 |

IV qualification artifacts:

- baseline binary SHA-256: `9807892acb1c27b4077703e1f78027d8c9ab143fcc49ef9aa4130f9e2f93baa4`
- candidate binary SHA-256: `f1faf966476e300f299e10c49c3a92fd467d78d1020a1b5a6a7f39d3855e21da`
- qualification report SHA-256: `61c0a63789dd63f6dd8f33e9cbc2707a28e7b9cc65e0dbeea60615a908d3efcf`

## Correctness

Passed focused tests for exact root/hash metadata validation, stale authority rejection, missing and hash-corrupt ordinary reuse fail-closed behavior, explicit repair of missing/corrupt roots, deleted middle/child ancestor-chain repair, exact restored root IDs/state, no-op zero tree chunks, rootless replay fencing, final-root reachability, serial history/diff, merge, undo/redo, reopen, checkpoint GC, and corruption. IV also passed no-op/replay/merge/corruption and explicit ancestor repair. All 16 IV runs preserved the expected result hash.

## Regressions and limitations

- Evidence is focused on 10K rows and 100/1K retained history; no broad or 1M qualification claim is made here.
- Short Slate RSS samples varied by 64–104 KiB; this is a sampling-floor tradeoff against the large wall/allocation wins.
- Logical adapter calls/keys/bytes, WAL/SST/object/compaction, and explicit intermediate-chunk counters are unavailable in the benchmark harness. Process I/O is only a lower bound. Final-only staging is proven structurally and by reachability tests.
- The recovery-only successor’s Slate 1K replay p50 was 5.497 ms versus 5.167 ms on the prior candidate, while remaining 98.8% below exact-main baseline; the changed recovery function is not on ordinary publication.

## Local evidence

- Full discovery report: `/tmp/tracked-root-hot-reuse-evidence.md`, SHA-256 `cd8c8d3a623040c1ea9561300a25b9bd5b28cead1352b4f02e7a9a2083d66269`
- Recovery addendum: `/tmp/tracked-root-hot-reuse-recovery-addendum.md`, SHA-256 `0cb665f2a96dcc226adf81d1da3a1fac22eb0f11359f33e10dce9e4fac471c16`
- Candidate release binary used for local successor recheck: SHA-256 `4e38808394d84cead904e3b99701fe24db5e7acf5f926e94ba7b7449e1d47c31`
