### PR TITLE
Collapse rootless debt into one authenticated frontier

### DIFF
--- a/packages/lix/src/tracked_state/commit_root_rebuild.rs
+++ b/packages/lix/src/tracked_state/commit_root_rebuild.rs
@@ -153,44 +153,147 @@ where
     Ok(report)
 }
 
-pub(crate) async fn load_rebuild_plans_to_nearest_available_root<S>(
+/// Loads the ordinary-publication rebuild frontier for all durable rootless
+/// parents in one request-local plan map.  Multiple rootless intervals often
+/// share a first-parent suffix; the previous per-parent loop reloaded that
+/// suffix for every interval before deduplicating it only at staging time.
+/// This frontier authenticates each commit/root boundary once, retains no
+/// authority outside the request, and returns unique plans child-first so the
+/// caller can replay them parent-first.  Explicit repair intentionally keeps
+/// its separate history-linear discovery path below.
+pub(crate) async fn load_rebuild_plan_frontier<S>(
     store: &S,
-    commit_id: &str,
+    commit_ids: &[CommitId],
     force_head: bool,
 ) -> Result<Vec<CommitRootRebuildPlan>, LixError>
 where
     S: StorageAdapterRead + ?Sized,
 {
-    let mut plans = Vec::new();
-    let mut current_commit_id = commit_id.to_string();
-    let mut force_current = force_head;
-    let mut seen_commit_ids = HashSet::new();
-    loop {
-        if !seen_commit_ids.insert(current_commit_id.clone()) {
-            return Err(LixError::new(
-                LixError::CODE_INTERNAL_ERROR,
-                format!(
-                    "cannot rebuild tracked_state commit_root for commit '{commit_id}': first-parent cycle includes commit '{current_commit_id}'"
-                ),
-            ));
+    let mut parent_by_id = BTreeMap::<CommitId, Option<CommitId>>::new();
+    let mut available_roots = BTreeMap::<CommitId, bool>::new();
+    for &root_commit_id in commit_ids {
+        let mut current_commit_id = root_commit_id;
+        let mut force_current = force_head;
+        let mut chain_seen = HashSet::new();
+        loop {
+            if !chain_seen.insert(current_commit_id) {
+                return Err(LixError::new(
+                    LixError::CODE_INTERNAL_ERROR,
+                    format!(
+                        "cannot rebuild tracked_state commit_root for commit '{root_commit_id}': first-parent cycle includes commit '{current_commit_id}'"
+                    ),
+                ));
+            }
+            if !force_current {
+                let available = match available_roots.get(&current_commit_id) {
+                    Some(available) => *available,
+                    None => {
+                        let available = load_available_root(store, &current_commit_id.to_string())
+                            .await?
+                            .is_some();
+                        available_roots.insert(current_commit_id, available);
+                        available
+                    }
+                };
+                if available {
+                    break;
+                }
+            }
+            let parent_commit_id = match parent_by_id.get(&current_commit_id) {
+                Some(parent_commit_id) => *parent_commit_id,
+                None => {
+                    let parent_commit_id =
+                        load_commit_root_rebuild_topology(store, &current_commit_id.to_string())
+                            .await?;
+                    parent_by_id.insert(current_commit_id, parent_commit_id);
+                    parent_commit_id
+                }
+            };
+            let Some(parent_commit_id) = parent_commit_id else {
+                break;
+            };
+            current_commit_id = parent_commit_id;
+            force_current = false;
         }
-        if !force_current
-            && load_available_root(store, &current_commit_id)
-                .await?
-                .is_some()
-        {
-            break;
-        }
-        let plan = load_commit_root_rebuild_plan(store, &current_commit_id).await?;
-        let parent_commit_id = plan.parent_commit_id;
-        plans.push(plan);
-        let Some(parent_commit_id) = parent_commit_id else {
-            break;
-        };
-        current_commit_id = parent_commit_id.to_string();
-        force_current = false;
     }
+
+    let commit_ids = parent_by_id.keys().copied().collect::<Vec<_>>();
+    let deltas_by_id = storage::load_commit_root_rebuild_deltas_batch(store, &commit_ids).await?;
+    let plans_by_id = parent_by_id
+        .into_iter()
+        .map(|(commit_id, parent_commit_id)| {
+            let deltas = deltas_by_id.get(&commit_id).cloned().ok_or_else(|| {
+                LixError::new(
+                    LixError::CODE_INTERNAL_ERROR,
+                    format!("tracked_state root rebuild batch omitted commit '{commit_id}'"),
+                )
+            })?;
+            Ok((
+                commit_id,
+                CommitRootRebuildPlan {
+                    commit_id,
+                    parent_commit_id,
+                    deltas: deltas
+                        .into_iter()
+                        .map(|(key, value)| CommitRootRebuildDelta {
+                            schema_key: key.schema_key,
+                            file_id: key.file_id,
+                            entity_pk: key.entity_pk,
+                            change_id: value.change_id,
+                            commit_id: value.commit_id,
+                            deleted: value.deleted,
+                            created_at: value.created_at,
+                            updated_at: value.updated_at,
+                        })
+                        .collect(),
+                },
+            ))
+        })
+        .collect::<Result<BTreeMap<_, _>, LixError>>()?;
+    let mut plans = plans_by_id.values().cloned().collect::<Vec<_>>();
+    plans.sort_by_key(|plan| {
+        let mut depth = 0usize;
+        let mut parent = plan.parent_commit_id;
+        while let Some(parent_commit_id) = parent {
+            let Some(parent_plan) = plans_by_id.get(&parent_commit_id) else {
+                break;
+            };
+            depth = depth.saturating_add(1);
+            parent = parent_plan.parent_commit_id;
+        }
+        std::cmp::Reverse(depth)
+    });
     Ok(plans)
+}
+
+/// Loads only immutable changelog topology for the ordinary publication
+/// frontier. Delta identity/value rows are fetched later in one authenticated
+/// batch after all required first-parent commits are known.
+async fn load_commit_root_rebuild_topology<S>(
+    store: &S,
+    commit_id: &str,
+) -> Result<Option<CommitId>, LixError>
+where
+    S: StorageAdapterRead + ?Sized,
+{
+    let mut reader = ChangelogContext::new().reader(store);
+    let commit_id = CommitId::parse_lix(commit_id, "commit-root rebuild commit_id")?;
+    let batch = reader
+        .load_commits(CommitLoadRequest {
+            commit_ids: std::slice::from_ref(&commit_id),
+        })
+        .await?;
+    let commit = batch
+        .into_iter()
+        .next()
+        .and_then(|(_, value)| value)
+        .ok_or_else(|| {
+            LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                format!("cannot rebuild tracked_state root for unknown commit '{commit_id}'"),
+            )
+        })?;
+    Ok(first_parent_commit_id(&commit))
 }
 
 /// Explicit recovery may use immutable changelog facts to replace a missing or

--- a/packages/lix/src/tracked_state/context.rs
+++ b/packages/lix/src/tracked_state/context.rs
@@ -7224,9 +7224,9 @@ mod tests {
             .begin_read(StorageReadOptions::default())
             .await
             .expect("root reuse read should open");
-        let error = crate::tracked_state::commit_root_rebuild::load_rebuild_plans_to_nearest_available_root(
+        let error = crate::tracked_state::commit_root_rebuild::load_rebuild_plan_frontier(
             &read,
-            "rootless-child",
+            &[CommitId::for_test_label("rootless-child")],
             true,
         )
         .await
@@ -7269,9 +7269,9 @@ mod tests {
             .begin_read(StorageReadOptions::default())
             .await
             .expect("root reuse read should open");
-        let error = crate::tracked_state::commit_root_rebuild::load_rebuild_plans_to_nearest_available_root(
+        let error = crate::tracked_state::commit_root_rebuild::load_rebuild_plan_frontier(
             &read,
-            "rootless-child",
+            &[CommitId::for_test_label("rootless-child")],
             true,
         )
         .await
@@ -7344,9 +7344,9 @@ mod tests {
             .begin_read(StorageReadOptions::default())
             .await
             .expect("hot reuse read should open");
-        let hot_error = crate::tracked_state::commit_root_rebuild::load_rebuild_plans_to_nearest_available_root(
+        let hot_error = crate::tracked_state::commit_root_rebuild::load_rebuild_plan_frontier(
             &read,
-            "target",
+            &[CommitId::for_test_label("target")],
             true,
         )
         .await
@@ -8466,9 +8466,9 @@ mod tests {
             .begin_read(StorageReadOptions::default())
             .await
             .expect("fixture rebuild read should open");
-        let plans = crate::tracked_state::commit_root_rebuild::load_rebuild_plans_to_nearest_available_root(
+        let plans = crate::tracked_state::commit_root_rebuild::load_rebuild_plan_frontier(
             &read,
-            "child",
+            &[CommitId::for_test_label("child")],
             true,
         )
         .await

--- a/packages/lix/src/tracked_state/mod.rs
+++ b/packages/lix/src/tracked_state/mod.rs
@@ -21,7 +21,8 @@ mod types;
 
 pub(crate) use codec::{encode_key_ref, encode_single_string_key_ref_into};
 pub(crate) use commit_root_rebuild::{
-    load_rebuild_plans_to_nearest_available_root, stage_rebuild_plan_with_writer,
+    CommitRootRebuildDelta, CommitRootRebuildPlan, load_rebuild_plan_frontier,
+    stage_rebuild_plan_with_writer,
 };
 pub(crate) use context::{
     TrackedStateContext, TrackedStateStoreReader, TrackedStateTransientRebuildState,

--- a/packages/lix/src/tracked_state/storage.rs
+++ b/packages/lix/src/tracked_state/storage.rs
@@ -3790,6 +3790,120 @@ pub(crate) async fn load_commit_state_manifests(
     Ok(output)
 }
 
+/// Loads the identity/value delta rows needed by ordinary tracked-root
+/// publication for a whole first-parent frontier.  The commit authorities and
+/// authenticated mutation-directory plans are resolved once, then every
+/// selected external segment is fetched in one unique point-read batch.  This
+/// path deliberately does not hydrate selected JSON payloads: root publication
+/// owns only the authenticated identity/index value, while explicit history
+/// consumers retain their payload-loading route.
+pub(crate) async fn load_commit_root_rebuild_deltas_batch(
+    store: &(impl StorageAdapterRead + ?Sized),
+    commit_ids: &[CommitId],
+) -> Result<BTreeMap<CommitId, Vec<(TrackedStateKey, TrackedStateIndexValue)>>, LixError> {
+    if commit_ids.is_empty() {
+        return Ok(BTreeMap::new());
+    }
+    let states = load_commit_state_manifests(store, commit_ids).await?;
+    let mut members_by_commit = BTreeMap::<CommitId, Vec<CommitDeltaMember>>::new();
+    let mut pending_segments = Vec::<(CommitId, usize, CommitDeltaSegmentBounds, String)>::new();
+    let mut segment_keys = Vec::new();
+
+    for (commit_id, state) in commit_ids.iter().copied().zip(states) {
+        let state = state.ok_or_else(|| {
+            LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                format!(
+                    "cannot rebuild tracked_state root for commit '{commit_id}' without its commit-state manifest"
+                ),
+            )
+        })?;
+        let manifest = expanded_commit_delta_manifest_from_commit_state(store, &state).await?;
+        let mut members = Vec::with_capacity(manifest.member_count as usize);
+        if let Some(parts) = manifest.columnar_parts.as_ref() {
+            members = load_columnar_mutation_members(store, commit_id, parts, &manifest.account_id)
+                .await?;
+        } else if let Some(inline) = manifest.inline_segment() {
+            collect_strict_commit_delta_members(
+                inline,
+                None,
+                commit_id,
+                0,
+                &manifest.account_id,
+                &mut members,
+            )?;
+        } else {
+            for (segment_index, bounds) in manifest.segments.iter().cloned().enumerate() {
+                let key = commit_delta_segment_key_for_bounds(commit_id, segment_index, &bounds)?;
+                segment_keys.push(StorageKey(Bytes::from(key)));
+                pending_segments.push((
+                    commit_id,
+                    segment_index,
+                    bounds,
+                    manifest.account_id.clone(),
+                ));
+            }
+        }
+        if !members.is_empty() {
+            members_by_commit.insert(commit_id, members);
+        } else {
+            members_by_commit.entry(commit_id).or_default();
+        }
+    }
+
+    if !segment_keys.is_empty() {
+        let values =
+            PointReadPlan::from_unique_keys(TRACKED_STATE_COMMIT_DELTA_SEGMENT_SPACE, segment_keys)
+                .materialize(store, StorageGetOptions::default())
+                .await?
+                .value;
+        if values.len() != pending_segments.len() {
+            return Err(LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                "tracked_state root rebuild segment batch returned an unexpected cardinality",
+            ));
+        }
+        for ((commit_id, segment_index, bounds, account_id), value) in
+            pending_segments.into_iter().zip(values)
+        {
+            let bytes = value.and_then(full_value_bytes).ok_or_else(|| {
+                LixError::new(
+                    LixError::CODE_INTERNAL_ERROR,
+                    format!(
+                        "tracked_state commit_delta manifest for commit '{commit_id}' references missing segment {segment_index}"
+                    ),
+                )
+            })?;
+            collect_strict_commit_delta_members(
+                &bytes,
+                Some(&bounds),
+                commit_id,
+                u32::try_from(segment_index).map_err(|_| {
+                    LixError::new(
+                        LixError::CODE_INTERNAL_ERROR,
+                        "tracked_state commit_delta segment index exceeds u32",
+                    )
+                })?,
+                &account_id,
+                members_by_commit.entry(commit_id).or_default(),
+            )?;
+        }
+    }
+
+    let mut output = BTreeMap::new();
+    for (commit_id, members) in members_by_commit {
+        validate_commit_delta_member_order_and_ids(commit_id, &members)?;
+        output.insert(
+            commit_id,
+            members
+                .into_iter()
+                .map(|member| (member.key, member.value))
+                .collect(),
+        );
+    }
+    Ok(output)
+}
+
 /// Loads only the small immutable authority headers in request order.
 ///
 /// Topology membership and commit identity do not require mutation-directory

--- a/packages/lix/src/transaction/commit.rs
+++ b/packages/lix/src/transaction/commit.rs
@@ -5662,29 +5662,53 @@ async fn stage_tracked_roots(
     // set. A rooted descendant promotes only transient chunks reachable from
     // its final authenticated root.
     let mut rebuild_state = TrackedStateTransientRebuildState::default();
-    let mut staged_rebuild_plan_ids = BTreeSet::new();
-    for parent_commit_id in durable_root_rebuild_parents {
-        let plans = crate::tracked_state::load_rebuild_plans_to_nearest_available_root(
-            read,
-            &parent_commit_id.to_string(),
-            true,
-        )
-        .await?;
+    let rebuild_parent_ids = durable_root_rebuild_parents
+        .iter()
+        .copied()
+        .collect::<Vec<_>>();
+    let plans =
+        crate::tracked_state::load_rebuild_plan_frontier(read, &rebuild_parent_ids, true).await?;
+    if let Some(final_plan) = plans.first() {
+        // The durable rootless interval is an ordered sequence of immutable
+        // deltas, but publication only needs its final authenticated state.
+        // Collapse each identity to the last value in parent-first order and
+        // rebuild once from the nearest available rooted parent. This keeps
+        // all semantic history in its immutable authorities while removing
+        // one tree traversal/re-encoding pass per replay-debt commit. The
+        // resulting plan retains the real deepest commit id, so downstream
+        // parent/root metadata remains coherent.
+        let mut final_deltas = BTreeMap::<
+            (String, Option<String>, EntityPk),
+            crate::tracked_state::CommitRootRebuildDelta,
+        >::new();
         for plan in plans.iter().rev() {
-            if staged_rebuild_plan_ids.insert(plan.commit_id) {
-                let previously_known = rebuild_state.chunk_hashes();
-                let mut scratch_writes = StorageWriteSet::new();
-                let mut transient_writer = tracked_state.writer_with_rebuild_state(
-                    read,
-                    &mut scratch_writes,
-                    rebuild_state,
+            for delta in &plan.deltas {
+                final_deltas.insert(
+                    (
+                        delta.schema_key.clone(),
+                        delta.file_id.clone(),
+                        delta.entity_pk.clone(),
+                    ),
+                    delta.clone(),
                 );
-                crate::tracked_state::stage_rebuild_plan_with_writer(&mut transient_writer, plan)
-                    .await?;
-                rebuild_state = transient_writer.into_transient_rebuild_state();
-                rebuild_state.mark_new_chunks_transient(&previously_known);
             }
         }
+        let collapsed_plan = crate::tracked_state::CommitRootRebuildPlan {
+            commit_id: final_plan.commit_id,
+            parent_commit_id: plans.last().and_then(|plan| plan.parent_commit_id),
+            deltas: final_deltas.into_values().collect(),
+        };
+        let previously_known = rebuild_state.chunk_hashes();
+        let mut scratch_writes = StorageWriteSet::new();
+        let mut transient_writer =
+            tracked_state.writer_with_rebuild_state(read, &mut scratch_writes, rebuild_state);
+        crate::tracked_state::stage_rebuild_plan_with_writer(
+            &mut transient_writer,
+            &collapsed_plan,
+        )
+        .await?;
+        rebuild_state = transient_writer.into_transient_rebuild_state();
+        rebuild_state.mark_new_chunks_transient(&previously_known);
     }
     let mut tracked_writer = tracked_state.writer_with_rebuild_state(read, writes, rebuild_state);
     let empty_certified_replacement_markers = BTreeSet::new();


### PR DESCRIPTION
## Summary

- Collapse the immutable rootless-debt suffix to its final per-identity state before rebuilding the authenticated tracked-state tree.
- Perform one transient authenticated frontier rebuild instead of one tree rebuild per debt commit.
- Preserve immutable semantic history, strict ordinary corruption handling, explicit repair, and final-root-only durable staging.
- Remove the superseded ordinary per-parent rebuild loop; no compatibility path, routing fallback, or second authority is introduced.

## Exact provenance

- Baseline/main: `36bc6a6260cfaba0a4c3343133919578affb0b4d`
- Candidate: `01d27472171e96c098bcb75a92ed632599a4b3b2`
- Candidate binary SHA-256: `89d8e337f4166b6e2b8e07b7a0ce0a31f9f890409851e914a7cd956838441cb6`
- Baseline binary SHA-256: `78d226bea4b4947c716d0ea41e0fedb9d7da9c37ed6fe21bca384a5dd1aa7fb7`
- Source diff SHA-256: `3a8c36c6fd73cc3c58a6a8f4fce09e86fcb4c874b5f4d6e36a8ed689e879860f`
- Raw aggregate SHA-256: `e552f307140ef215953f54c872c6f0ad62bcb451c1ea0c513011dc6afd6f338d`

## Before/after evidence

Exact setup-excluded alternating paired runs at 10K rows, 100 changed rows, and 100/1,000 retained history commits; n=3 per cell on both RocksDB and SlateDB.

| Backend | History | Merge p50 | Delta | Tracked-root p50 | Delta | Merge allocations | Delta |
|---|---:|---:|---:|---:|---:|---:|---:|
| RocksDB | 100 | 3.980 → 3.232 ms | -18.8% | 1.973 → 1.183 ms | -40.0% | 12.00 → 8.21 MB | -31.6% |
| RocksDB | 1,000 | 4.808 → 3.414 ms | -29.0% | 2.728 → 1.320 ms | -51.6% | 14.84 → 8.61 MB | -42.0% |
| SlateDB | 100 | 4.955 → 3.935 ms | -20.6% | 2.203 → 1.196 ms | -45.7% | 14.55 → 10.15 MB | -30.2% |
| SlateDB | 1,000 | 6.842 → 5.087 ms | -25.7% | 3.678 → 1.966 ms | -46.5% | 20.08 → 12.73 MB | -36.6% |

Process-total p50 changed by -0.4%/+0.2% at 100 commits and -12.2%/-6.5% at 1,000 commits on RocksDB/SlateDB. Diff and preview remained within 3%. The initial sub-millisecond SlateDB switch noise was rerun with a dedicated n=5 paired veto: 3.333 → 3.277 ms (-1.7%). No confirmed critical regression exceeded 5%.

## Complexity

Before, a rootless suffix of `D` commits caused one authenticated tree rebuild per debt commit. After, immutable debt records are loaded once, collapsed to `U` final identities, and applied through one authenticated frontier rebuild. Semantic history loading remains proportional to the debt suffix; repeated tree rebuild work changes from `D` rebuilds to one rebuild over the final unique mutation frontier. Explicit repair remains separate and may be history-linear.

## Correctness

Focused gates passed on the exact candidate:

- root/hash/state equivalence and root reuse
- final-root reachability and zero durable intermediate staging
- missing/hash-corrupt authority fails closed in ordinary publication
- explicit ancestor repair remains functional
- merge, diff, undo/redo, reopen, and recovery fixtures
- all 37 transaction-commit tests

## CI outage waiver

GitHub Actions/Blacksmith runners are currently unavailable. Per the active project instruction, this PR is being merged from the locally and remotely qualified immutable head without waiting for hosted CI. The exact source, binaries, paired raw artifacts, commands/results, and waiver are recorded above.
