### PR TITLE
README: real diagram images from the design handoff

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,9 @@
   <a href="https://x.com/lixCCS"><img src="https://img.shields.io/badge/Follow-@lixCCS-black?logo=x&logoColor=white" alt="X (Twitter)"></a>
 </p>
 
-Code lives in version control. The documents, spreadsheets, and data a company runs on do not.
+Agents and tools work with files. Applications need a database. Teams need version control. Lix combines all three: normal files for tools, SQL rows for apps, and version control for every change.
 
-Lix is a version control system for files and data beyond code: one repository that combines files, a database, and version control.
+<img src="./website/public/assets/lix-triad.svg" alt="Lix is a filesystem, a database, and version control in one system" width="760" />
 
 - 📄 **Works with any file format.** Plugins map DOCX, CSV, Markdown, or your own format to versioned entities.
 - 🔍 **Semantic changes.** Review the clause, cell, or row that changed, not lines of bytes.
@@ -32,9 +32,9 @@ Lix is a version control system for files and data beyond code: one repository t
 
 <p>
   <img src="https://cdn.simpleicons.org/javascript/F7DF1E" alt="JavaScript" width="18" height="18" /> JavaScript ·
-  <a href="https://github.com/opral/lix/issues/373"><img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/python/python-original.svg" alt="Python" width="18" height="18" /> Python</a> ·
-  <a href="https://github.com/opral/lix/issues/371"><img src="https://cdn.simpleicons.org/rust/CE422B" alt="Rust" width="18" height="18" /> Rust</a> ·
-  <a href="https://github.com/opral/lix/issues/370"><img src="https://cdn.simpleicons.org/go/00ADD8" alt="Go" width="18" height="18" /> Go</a>
+  <a href="https://github.com/opral/lix/issues/373" title="The Python SDK is planned. Upvote the issue on GitHub."><img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/python/python-original.svg" alt="Python" width="18" height="18" /> Python</a> ·
+  <a href="https://github.com/opral/lix/issues/371" title="The Rust SDK is planned. Upvote the issue on GitHub."><img src="https://cdn.simpleicons.org/rust/CE422B" alt="Rust" width="18" height="18" /> Rust</a> ·
+  <a href="https://github.com/opral/lix/issues/370" title="The Go SDK is planned. Upvote the issue on GitHub."><img src="https://cdn.simpleicons.org/go/00ADD8" alt="Go" width="18" height="18" /> Go</a>
 </p>
 
 ```bash
@@ -81,9 +81,9 @@ The SDK includes plugins for Markdown and CSV. Add a plugin for other formats, s
 
 ### Pluggable storage
 
-Lix embeds in your app and runs on storage adapters: in memory, on the local filesystem, or on an S3 bucket.
+Lix embeds in your product and runs on storage adapters: in memory, on the local filesystem, or on an S3 bucket.
 
-<img src="./website/public/assets/pluggable-storage.svg" alt="Lix embeds in your app and runs on a storage adapter: in memory, local filesystem, or S3 bucket" width="760" />
+<img src="./website/public/assets/pluggable-storage.svg" alt="Lix embeds in your product and runs on a storage adapter: in memory, local filesystem, or S3 bucket" width="760" />
 
 Existing VCS like Git assume a local POSIX filesystem, which makes them hard to embed and scale. See the [Persistence and Storage](https://lix.dev/docs/persistence) docs.
 
@@ -91,19 +91,7 @@ Existing VCS like Git assume a local POSIX filesystem, which makes them hard to 
 
 Git versions files but cannot query them. PostgreSQL and SQLite query rows but have no files and no history. Lix does both.
 
-```text
-                     database
-                         │
-   PostgreSQL / SQLite   │        ★ Lix
-   rows, no history      │     rows + files,
-                         │       versioned
-                         │
-   ──────────────────────┼──────────────────▶  version control
-                         │
-                         │          Git
-                         │    text files only
-                         │
-```
+<img src="./website/public/assets/comparison-quadrant.svg" alt="Quadrant chart: database capability on the vertical axis, version control on the horizontal axis. PostgreSQL and SQLite sit top left, Git bottom right, Lix top right." width="760" />
 
 | Capability                    | Git             | PostgreSQL / SQLite | Lix                 |
 | ----------------------------- | --------------- | ------------------- | ------------------- |
@@ -114,6 +102,28 @@ Git versions files but cannot query them. PostgreSQL and SQLite query rows but h
 | Pluggable storage             | No              | No                  | Yes                 |
 
 ### Prime use cases
+
+#### Automation repository for your customers
+
+LLMs let your product write automations for customers. Automations are code, so every customer needs a repository. Lix is simpler than git here: it embeds in your product, and your customers review and undo changes without branch, merge, or pull request vocabulary.
+
+```ts
+// One Lix repository per customer, hosted on your server (for example backed by S3).
+const lix = await openLix({
+  server: {
+    mode: "remote",
+    url: "https://lix.example.com/customers/acme",
+  },
+});
+
+// The agent writes an automation. Lix records the change, no commit needed.
+await lix.execute("INSERT INTO lix_file (path, content) VALUES ($1, $2)", [
+  "/automations/booking.ts",
+  code,
+]);
+
+// Your UI shows the diff. The customer clicks accept or undo.
+```
 
 #### Give agents safe, isolated workspaces
 
@@ -133,21 +143,6 @@ if (preview.conflicts.length === 0) {
   await lix.mergeBranch({ sourceBranchId: task.id });
 }
 ```
-
-#### Put your company's files under agent operation
-
-Agents already know how to read and write files. Put contracts, pricing sheets, and order data in a repository, and agents can work on them without custom integrations.
-
-Lix records every change automatically. When an agent updates an orders CSV, reviewers see the row field that changed before the change merges:
-
-```diff
-order_id 1002 status:
-
-- pending
-+ shipped
-```
-
-Merge good changes, discard bad ones, and restore any earlier state of the company.
 
 #### Build file-based apps with SQL and version control
 
@@ -172,24 +167,9 @@ Update Lix files and rows in one ACID transaction. Lix records the history autom
 
 ## Where this is going
 
-The goal is one repository for everything a company produces. Code lives in git. Contracts, spreadsheets, app data, and agent output get the same foundation with Lix: one history, queryable with SQL, safe to branch and merge.
+The goal is one repository for everything a company produces. Contracts, spreadsheets, app data, agent output, and the automations non-engineers now write with LLMs get the same foundation: one history, queryable with SQL, safe to branch and merge.
 
-```text
- contracts.docx    pricing.xlsx      app data     agent output
-       │                │              │              │
-       └────────────────┴───────┬──────┴──────────────┘
-                                ▼
-┌─────────────────── ONE LIX REPOSITORY ───────────────────┐
-│                                                          │
-│  ┌──────────────┐     ┌──────────────┐     ┌────────────┐ │
-│  │  FILESYSTEM  │  ×  │   DATABASE   │  ×  │  VERSION   │ │
-│  │              │     │              │     │  CONTROL   │ │
-│  │ tools and    │     │ SQL queries  │     │review/merge│ │
-│  │ agents       │     │ transactions │     │ rollback   │ │
-│  └──────────────┘     └──────────────┘     └────────────┘ │
-│                                                          │
-└──────────────────────────────────────────────────────────┘
-```
+<img src="./website/public/assets/one-repository.svg" alt="Automation product, agents, analytics, and knowledge search all build on one Lix repository holding automations, skills, sales data, and contracts" width="760" />
 
 ## Learn more
 

--- a/website/public/assets/comparison-quadrant.svg
+++ b/website/public/assets/comparison-quadrant.svg
@@ -1,0 +1,28 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 680 360" role="img" aria-label="Quadrant chart: database capability on the vertical axis, version control on the horizontal axis. PostgreSQL and SQLite sit top left, Git bottom right, Lix top right." font-family="ui-monospace, 'SF Mono', SFMono-Regular, Menlo, Consolas, monospace">
+  <defs>
+    <marker id="cmp-arr" markerWidth="8" markerHeight="8" refX="6" refY="4" orient="auto"><path d="M0 0 L7 4 L0 8 Z" fill="#8A8F96"></path></marker>
+  </defs>
+  <rect x="0.75" y="0.75" width="678.5" height="358.5" rx="10" fill="#F7F6F1" stroke="#EDEBE4" stroke-width="1.5"/>
+  <g transform="translate(20, 20)">
+    <line x1="320" y1="288" x2="320" y2="30" stroke="#8A8F96" stroke-width="1.4" marker-end="url(#cmp-arr)"></line>
+    <line x1="40" y1="160" x2="596" y2="160" stroke="#8A8F96" stroke-width="1.4" marker-end="url(#cmp-arr)"></line>
+    <text x="332" y="26" font-size="12" letter-spacing="1" fill="#8A8F96">DATABASE</text>
+    <text x="596" y="150" text-anchor="end" font-size="12" letter-spacing="1" fill="#8A8F96">VERSION CONTROL</text>
+    <g transform="translate(168, 88)">
+      <rect x="-112" y="-26" width="224" height="58" rx="8" fill="#FFFFFF" stroke="#E6E4DD"></rect>
+      <text x="0" y="-3" text-anchor="middle" font-size="13.5" font-weight="500" fill="#3D4046">PostgreSQL / SQLite</text>
+      <text x="0" y="18" text-anchor="middle" font-size="11.5" fill="#8A8F96">rows, no history</text>
+    </g>
+    <g transform="translate(470, 232)">
+      <rect x="-80" y="-26" width="160" height="58" rx="8" fill="#FFFFFF" stroke="#E6E4DD"></rect>
+      <text x="0" y="-3" text-anchor="middle" font-size="13.5" font-weight="500" fill="#3D4046">Git</text>
+      <text x="0" y="18" text-anchor="middle" font-size="11.5" fill="#8A8F96">text files only</text>
+    </g>
+    <g transform="translate(470, 88)">
+      <rect x="-100" y="-32" width="200" height="70" rx="8" fill="rgba(7,182,213,0.07)" stroke="#07B6D5" stroke-width="1.5"></rect>
+      <text x="0" y="-7" text-anchor="middle" font-size="14.5" font-weight="700" fill="#0891AC">★ lix</text>
+      <text x="0" y="13" text-anchor="middle" font-size="11.5" fill="#3D4046">rows + files,</text>
+      <text x="0" y="29" text-anchor="middle" font-size="11.5" fill="#3D4046">versioned</text>
+    </g>
+  </g>
+</svg>

--- a/website/public/assets/lix-triad.svg
+++ b/website/public/assets/lix-triad.svg
@@ -1,0 +1,22 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 680 150" role="img" aria-label="Lix is a filesystem, a database, and version control in one system" font-family="ui-monospace, 'SF Mono', SFMono-Regular, Menlo, Consolas, monospace">
+  <rect x="0.75" y="0.75" width="678.5" height="148.5" rx="10" fill="#F7F6F1" stroke="#EDEBE4" stroke-width="1.5"/>
+  <rect x="20" y="30" width="640" height="100" rx="12" fill="#F0FAFC" stroke="#07B6D5" stroke-width="1.5"/>
+  <rect x="310" y="22" width="60" height="16" fill="#F7F6F1"/>
+  <text x="340" y="34" text-anchor="middle" font-size="11.5" font-weight="700" letter-spacing="1" fill="#0891AC">LIX</text>
+
+  <rect x="44" y="52" width="180" height="56" rx="8" fill="#FFFFFF" stroke="#E6E4DD"/>
+  <text x="134" y="77" text-anchor="middle" font-size="12" font-weight="700" letter-spacing="0.8" fill="#15171B">FILESYSTEM</text>
+  <text x="134" y="96" text-anchor="middle" font-size="11" fill="#8A8F96">tools and agents</text>
+
+  <text x="240" y="84" text-anchor="middle" font-size="13" fill="#8A8F96">×</text>
+
+  <rect x="256" y="52" width="180" height="56" rx="8" fill="#FFFFFF" stroke="#E6E4DD"/>
+  <text x="346" y="77" text-anchor="middle" font-size="12" font-weight="700" letter-spacing="0.8" fill="#15171B">DATABASE</text>
+  <text x="346" y="96" text-anchor="middle" font-size="11" fill="#8A8F96">SQL queries, transactions</text>
+
+  <text x="452" y="84" text-anchor="middle" font-size="13" fill="#8A8F96">×</text>
+
+  <rect x="468" y="52" width="190" height="56" rx="8" fill="#FFFFFF" stroke="#E6E4DD"/>
+  <text x="563" y="77" text-anchor="middle" font-size="12" font-weight="700" letter-spacing="0.8" fill="#15171B">VERSION CONTROL</text>
+  <text x="563" y="96" text-anchor="middle" font-size="11" fill="#8A8F96">review/merge, rollback</text>
+</svg>

--- a/website/public/assets/one-repository.svg
+++ b/website/public/assets/one-repository.svg
@@ -1,0 +1,37 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 680 276" role="img" aria-label="Diagram: automation product, agents, analytics, and knowledge search all build on one Lix repository holding automations, skills, sales data, and contracts." font-family="ui-monospace, 'SF Mono', SFMono-Regular, Menlo, Consolas, monospace">
+  <defs>
+    <marker id="rep-arr" markerWidth="8" markerHeight="8" refX="6" refY="4" orient="auto"><path d="M0 0 L7 4 L0 8 Z" fill="#8A8F96"></path></marker>
+  </defs>
+  <rect x="0.75" y="0.75" width="678.5" height="274.5" rx="10" fill="#F7F6F1" stroke="#EDEBE4" stroke-width="1.5"/>
+  <g transform="translate(20, 20)">
+    <text x="120" y="26" text-anchor="middle" font-size="12.5" font-weight="500" fill="#15171B">automation product</text>
+    <line x1="120" y1="38" x2="120" y2="60" stroke="#8A8F96" stroke-width="1.2"></line>
+    <text x="268" y="26" text-anchor="middle" font-size="12.5" font-weight="500" fill="#15171B">agents</text>
+    <line x1="268" y1="38" x2="268" y2="60" stroke="#8A8F96" stroke-width="1.2"></line>
+    <text x="396" y="26" text-anchor="middle" font-size="12.5" font-weight="500" fill="#15171B">analytics</text>
+    <line x1="396" y1="38" x2="396" y2="60" stroke="#8A8F96" stroke-width="1.2"></line>
+    <text x="524" y="26" text-anchor="middle" font-size="12.5" font-weight="500" fill="#15171B">knowledge search</text>
+    <line x1="524" y1="38" x2="524" y2="60" stroke="#8A8F96" stroke-width="1.2"></line>
+    <path d="M120 60 L120 72 L524 72 L524 60 M268 60 L268 72 M396 60 L396 72" fill="none" stroke="#8A8F96" stroke-width="1.2"></path>
+    <line x1="320" y1="72" x2="320" y2="96" stroke="#8A8F96" stroke-width="1.2" marker-end="url(#rep-arr)"></line>
+    <rect x="24" y="106" width="592" height="122" rx="10" fill="rgba(7,182,213,0.05)" stroke="#07B6D5" stroke-width="1.5"></rect>
+    <rect x="252" y="98" width="136" height="16" fill="#F7F6F1"></rect>
+    <text x="320" y="111" text-anchor="middle" font-size="12" font-weight="700" letter-spacing="1" fill="#0891AC">LIX REPOSITORY</text>
+    <g transform="translate(96, 172)">
+      <rect x="-64" y="-24" width="128" height="48" rx="8" fill="#FFFFFF" stroke="#E6E4DD"></rect>
+      <text x="0" y="4" text-anchor="middle" font-size="11.5" fill="#3D4046">automations/</text>
+    </g>
+    <g transform="translate(245, 172)">
+      <rect x="-64" y="-24" width="128" height="48" rx="8" fill="#FFFFFF" stroke="#E6E4DD"></rect>
+      <text x="0" y="4" text-anchor="middle" font-size="11.5" fill="#3D4046">skills/</text>
+    </g>
+    <g transform="translate(394, 172)">
+      <rect x="-64" y="-24" width="128" height="48" rx="8" fill="#FFFFFF" stroke="#E6E4DD"></rect>
+      <text x="0" y="4" text-anchor="middle" font-size="11.5" fill="#3D4046">sales.xlsx</text>
+    </g>
+    <g transform="translate(543, 172)">
+      <rect x="-64" y="-24" width="128" height="48" rx="8" fill="#FFFFFF" stroke="#E6E4DD"></rect>
+      <text x="0" y="4" text-anchor="middle" font-size="11.5" fill="#3D4046">contracts/</text>
+    </g>
+  </g>
+</svg>

--- a/website/public/assets/pluggable-storage.svg
+++ b/website/public/assets/pluggable-storage.svg
@@ -1,34 +1,35 @@
-<svg viewBox="0 0 880 200" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Lix runs in your app on a storage adapter: in memory, local filesystem, or S3 bucket" font-family="ui-monospace, 'SF Mono', SFMono-Regular, Menlo, Consolas, monospace">
-  <rect x="0.75" y="0.75" width="878.5" height="198.5" rx="10" fill="#F7F6F1" stroke="#EDEBE4" stroke-width="1.5"/>
-
-  <!-- your app with lix embedded -->
-  <rect x="330" y="30" width="220" height="52" rx="8" fill="#FFFFFF" stroke="#8A8F96" stroke-width="1.5"/>
-  <text x="352" y="61" font-size="13" fill="#15171B">your app</text>
-  <rect x="466" y="40" width="52" height="32" rx="6" fill="rgba(7,182,213,0.14)" stroke="#07B6D5" stroke-width="1.5"/>
-  <text x="492" y="60" font-size="13" fill="#0891AC" text-anchor="middle">lix</text>
-
-  <!-- connector -->
-  <line x1="440" y1="82" x2="440" y2="120" stroke="#C9C7BF" stroke-width="1.5" stroke-dasharray="4 4"/>
-
-  <!-- in memory: chip icon -->
-  <rect x="110" y="120" width="200" height="50" rx="8" fill="#FFFFFF" stroke="#C9C7BF" stroke-width="1.5"/>
-  <rect x="162" y="137" width="16" height="14" rx="2" fill="none" stroke="#8A8F96" stroke-width="1.4"/>
-  <line x1="159" y1="140" x2="162" y2="140" stroke="#8A8F96" stroke-width="1.4"/>
-  <line x1="159" y1="144" x2="162" y2="144" stroke="#8A8F96" stroke-width="1.4"/>
-  <line x1="159" y1="148" x2="162" y2="148" stroke="#8A8F96" stroke-width="1.4"/>
-  <line x1="178" y1="140" x2="181" y2="140" stroke="#8A8F96" stroke-width="1.4"/>
-  <line x1="178" y1="144" x2="181" y2="144" stroke="#8A8F96" stroke-width="1.4"/>
-  <line x1="178" y1="148" x2="181" y2="148" stroke="#8A8F96" stroke-width="1.4"/>
-  <text x="190" y="150" font-size="13" fill="#6B7076">in memory</text>
-
-  <!-- local filesystem: folder icon -->
-  <rect x="340" y="120" width="200" height="50" rx="8" fill="rgba(7,182,213,0.08)" stroke="#07B6D5" stroke-width="1.5"/>
-  <path d="M364 140 a2 2 0 0 1 2 -2 h5 l2.5 3 h8.5 a2 2 0 0 1 2 2 v8 a2 2 0 0 1 -2 2 h-16 a2 2 0 0 1 -2 -2 Z" fill="none" stroke="#07B6D5" stroke-width="1.4" stroke-linejoin="round"/>
-  <text x="392" y="150" font-size="13" fill="#0891AC">local filesystem</text>
-
-  <!-- S3 bucket: bucket icon -->
-  <rect x="570" y="120" width="200" height="50" rx="8" fill="#FFFFFF" stroke="#C9C7BF" stroke-width="1.5"/>
-  <ellipse cx="631" cy="138" rx="9" ry="3" fill="#FFFFFF" stroke="#8A8F96" stroke-width="1.4"/>
-  <path d="M622 138 L624.5 153 a2 2 0 0 0 2 1.7 h9 a2 2 0 0 0 2 -1.7 L640 138" fill="none" stroke="#8A8F96" stroke-width="1.4"/>
-  <text x="648" y="150" font-size="13" fill="#6B7076">S3 bucket</text>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 680 320" role="img" aria-label="Lix embeds in your product and runs on a storage adapter: in memory, local filesystem, or S3 bucket." font-family="ui-monospace, 'SF Mono', SFMono-Regular, Menlo, Consolas, monospace">
+  <defs>
+    <marker id="ps-arr" markerWidth="8" markerHeight="8" refX="6" refY="4" orient="auto"><path d="M0 0 L7 4 L0 8 Z" fill="#8A8F96"></path></marker>
+  </defs>
+  <rect x="0.75" y="0.75" width="678.5" height="318.5" rx="10" fill="#F7F6F1" stroke="#EDEBE4" stroke-width="1.5"/>
+  <g transform="translate(20, 20)">
+    <rect x="150" y="24" width="340" height="120" rx="10" fill="#FFFFFF" stroke="#E6E4DD"></rect>
+    <text x="320" y="52" text-anchor="middle" font-size="12" font-weight="700" letter-spacing="1" fill="#15171B">YOUR PRODUCT</text>
+    <rect x="200" y="68" width="240" height="52" rx="8" fill="rgba(7,182,213,0.07)" stroke="#07B6D5" stroke-width="1.5"></rect>
+    <text x="320" y="91" text-anchor="middle" font-size="13" font-weight="700" fill="#0891AC">lix</text>
+    <text x="320" y="109" text-anchor="middle" font-size="11" fill="#3D4046">embedded</text>
+    <line x1="320" y1="144" x2="320" y2="162" stroke="#8A8F96" stroke-width="1.2"></line>
+    <line x1="128" y1="168" x2="512" y2="168" stroke="#8A8F96" stroke-width="1.2"></line>
+    <text x="530" y="172" font-size="10.5" letter-spacing="0.5" fill="#8A8F96">storage</text>
+    <text x="530" y="186" font-size="10.5" letter-spacing="0.5" fill="#8A8F96">adapters</text>
+    <g transform="translate(128, 232)">
+      <rect x="-78" y="-28" width="156" height="56" rx="8" fill="#FFFFFF" stroke="#E6E4DD"></rect>
+      <text x="0" y="-2" text-anchor="middle" font-size="12" font-weight="500" fill="#3D4046">in memory</text>
+      <text x="0" y="16" text-anchor="middle" font-size="11" fill="#8A8F96">tests, ephemeral</text>
+    </g>
+    <line x1="128" y1="168" x2="128" y2="196" stroke="#8A8F96" stroke-width="1.2" marker-end="url(#ps-arr)"></line>
+    <g transform="translate(320, 232)">
+      <rect x="-78" y="-28" width="156" height="56" rx="8" fill="#FFFFFF" stroke="#E6E4DD"></rect>
+      <text x="0" y="-2" text-anchor="middle" font-size="12" font-weight="500" fill="#3D4046">local filesystem</text>
+      <text x="0" y="16" text-anchor="middle" font-size="11" fill="#8A8F96">desktop, CLI</text>
+    </g>
+    <line x1="320" y1="168" x2="320" y2="196" stroke="#8A8F96" stroke-width="1.2" marker-end="url(#ps-arr)"></line>
+    <g transform="translate(512, 232)">
+      <rect x="-78" y="-28" width="156" height="56" rx="8" fill="#FFFFFF" stroke="#E6E4DD"></rect>
+      <text x="0" y="-2" text-anchor="middle" font-size="12" font-weight="500" fill="#3D4046">S3 bucket</text>
+      <text x="0" y="16" text-anchor="middle" font-size="11" fill="#8A8F96">server, scale</text>
+    </g>
+    <line x1="512" y1="168" x2="512" y2="196" stroke="#8A8F96" stroke-width="1.2" marker-end="url(#ps-arr)"></line>
+  </g>
 </svg>


### PR DESCRIPTION
## What changed

Applies the latest design handoff to the README (which is also the homepage body):

**Every remaining ascii diagram is now a real SVG** in the shared diagram style:
- `lix-triad.svg` — the filesystem × database × version control box, right after the intro
- `comparison-quadrant.svg` — database × version control axes with PostgreSQL/SQLite, Git, and ★ lix
- `one-repository.svg` — automation product, agents, analytics, and knowledge search on one Lix repository (automations/, skills/, sales.xlsx, contracts/)
- `pluggable-storage.svg` redrawn — lix embedded in YOUR PRODUCT, fanning out to in memory (tests, ephemeral), local filesystem (desktop, CLI), and S3 bucket (server, scale)

**Content updates from the handoff:**
- Intro is now the hero paragraph ("Agents and tools work with files…") + the triad image
- New first prime use case: **Automation repository for your customers** — LLMs write automations, every customer needs a repository, customers accept/undo without git vocabulary. Replaces "Put your company's files under agent operation"
- "Where this is going" now includes LLM-written automations in the one-repository story (and drops "Code lives in git")
- SDK issue links (Python/Rust/Go) carry "upvote the issue" tooltips

## Notes for review

- The handoff's code example used `new S3Storage({ bucket })`, which does not exist in the JS SDK — adapted to the real server-mode API (`openLix({ server: … })`) with a comment that the server can be backed by S3, matching the persistence docs
- All SVGs have opaque panel backgrounds so they render correctly on GitHub dark mode
- Website tests pass (29/29); all five README images verified loading in the browser preview

🤖 Generated with [Claude Code](https://claude.com/claude-code)