### PR TITLE
Profile pull-based SQL result streaming

### DIFF
--- a/packages/lix/Cargo.toml
+++ b/packages/lix/Cargo.toml
@@ -52,6 +52,12 @@ path = "tests/semantic_merge.rs"
 name = "send_futures"
 path = "tests/send_futures.rs"
 
+[[bench]]
+name = "profile_sql_result_streaming"
+path = "benches/profile_sql_result_streaming.rs"
+harness = false
+required-features = ["storage-benches"]
+
 [[test]]
 name = "plugin_arena_scorecard"
 path = "tests/plugin_arena_scorecard.rs"

--- a/packages/lix/benches/profile_sql_result_streaming.md
+++ b/packages/lix/benches/profile_sql_result_streaming.md
@@ -1,0 +1,105 @@
+# SQL result streaming profile
+
+This benchmark compares the current eager public result path with two internal
+prototypes. It does not change `ExecuteResult` or expose streaming publicly.
+Every mode uses the same fixture and SQL statement, and the profile scope
+includes snapshot acquisition, execution, and result consumption.
+
+The fixture query is an unordered `UNION ALL` over eight distinct registered
+entity tables. Do not add a global `ORDER BY` when measuring early stop: a sort
+must consume all input before it can emit a first batch and would intentionally
+hide cancellation. Distinct child tables create independent DataFusion output
+batches so Lix's identical-scan cache cannot merge them back into one eager
+scan.
+
+The modes are:
+
+- `full`: current behavior; convert and retain every public `Row`.
+- `stream`: collect all DataFusion batches as the eager engine does, then
+  convert one row at a time and drop it immediately. This isolates retained
+  public-row allocation from execution and is the collected-batch control.
+- `live`: pull the benchmark-only DataFusion batch stream before collection;
+  dropping after a row limit drops the underlying scan inside the scoped
+  storage read.
+- `count_only`: skip scalar conversion; use it as the execution ceiling.
+
+Run the same command shape for each mode:
+
+```text
+LIX_SQL_PROFILE_RESULT_MODE=full \
+  LIX_SQL_PROFILE_ROWS=131072 LIX_SQL_PROFILE_ROUNDS=15 \
+  cargo bench -p lix --no-default-features --features storage-benches \
+  --bench profile_sql_result_streaming
+
+LIX_SQL_PROFILE_RESULT_MODE=stream \
+  LIX_SQL_PROFILE_ROWS=131072 LIX_SQL_PROFILE_ROUNDS=15 \
+  cargo bench -p lix --no-default-features --features storage-benches \
+  --bench profile_sql_result_streaming
+
+LIX_SQL_PROFILE_RESULT_MODE=stream LIX_SQL_PROFILE_ROW_LIMIT=100 \
+  LIX_SQL_PROFILE_ROWS=131072 LIX_SQL_PROFILE_ROUNDS=15 \
+  cargo bench -p lix --no-default-features --features storage-benches \
+  --bench profile_sql_result_streaming
+
+LIX_SQL_PROFILE_RESULT_MODE=live LIX_SQL_PROFILE_ROW_LIMIT=100 \
+  LIX_SQL_PROFILE_ROWS=131072 LIX_SQL_PROFILE_ROUNDS=15 \
+  cargo bench -p lix --no-default-features --features storage-benches \
+  --bench profile_sql_result_streaming
+
+LIX_SQL_PROFILE_RESULT_MODE=count_only \
+  LIX_SQL_PROFILE_ROWS=131072 LIX_SQL_PROFILE_ROUNDS=15 \
+  cargo bench -p lix --no-default-features --features storage-benches \
+  --bench profile_sql_result_streaming
+```
+
+Interpret the output as follows:
+
+- `arrow_execution_us` changes only if the engine itself can stop producing
+  batches. The collected `stream` mode is expected not to lower this number;
+  the live mode should.
+- `public_result_materialization_us` is the row conversion cost. A streaming
+  win should reduce this for early stop and avoid the full-result allocation.
+- `result_rows_materialized` counts owned scalar rows: all rows for `full`,
+  consumed rows for `stream`/`live`, and zero for `count_only`.
+- `result_rows_retained` counts rows kept through consumption: all rows for
+  `full` and zero for cursor modes.
+- `scan_rows` in `live` is bounded by the first batch that contains the row
+  limit; it need not equal the exact row limit.
+- `wall_median_us` is the end-to-end number to use for a ship/no-ship decision.
+
+For CPU attribution, build once and profile the same binary with `samply` or
+Instruments. For allocation and peak-memory attribution, use the benchmark
+crate's `system-allocation-profiler` feature or run the binary under
+`heaptrack`; compare `full` and `stream` with identical row counts and warmups.
+
+## Decision matrix with RSS
+
+Use the fresh-process matrix when evaluating whether a future explicit,
+read-only `stream()` capability is worthwhile. It randomizes
+scenario order for every repetition, runs each scenario in a separate process,
+captures maximum RSS with `/usr/bin/time -l`, and emits CSV suitable for a
+spreadsheet or statistical analysis:
+
+```text
+LIX_SQL_PROFILE_ROWS=32768 \
+LIX_SQL_PROFILE_REPETITIONS=5 \
+LIX_SQL_PROFILE_WARMUPS=1 \
+scripts/profile_sql_streaming_matrix.sh > streaming-matrix.csv
+```
+
+The matrix includes a `fixture_only` RSS baseline plus `full_all`,
+`full_early`, `collected_all`, `collected_early`, `live_all`, `live_early`, and
+`count_all`. Every non-count query scenario validates a deterministic checksum
+over all projected values before emitting its row. Compare medians and spread
+by scenario. Evidence for a separate streaming capability requires a material
+end-to-end win for `live_early`, lower query-over-baseline `max_rss_bytes` for
+retained result cases, and no checksum or row-count failures. RSS is process
+maximum RSS, so allocator high-water behavior can still mask deltas; keep
+fixture size, warmups, build mode, and host conditions fixed.
+
+The A/B is meaningful only at the same consumption point. `full` calls the
+normal eager `execute()` and then `rows()`. `stream` takes the ordinary
+collect-all-batches path without retaining public rows. `live` consumes the
+pull-based DataFusion stream directly. The live result and its borrowed row
+cursor are dropped before the storage-read closure returns, so the benchmark
+does not let the existing lifetime erasure escape.

--- a/packages/lix/benches/profile_sql_result_streaming.rs
+++ b/packages/lix/benches/profile_sql_result_streaming.rs
@@ -1,0 +1,320 @@
+//! Profile internal eager, collected-batch, and live-batch result paths.
+//!
+//! This keeps SQL execution and result consumption in the same profile scope.
+//! `full` is the current materialized public result path; `stream` converts
+//! one row at a time after DataFusion collection; `live` consumes the
+//! benchmark-only physical batch stream before collection; `count_only` skips
+//! scalar conversion altogether. The public eager `ExecuteResult` API is not
+//! changed by this benchmark. A numeric `LIX_SQL_PROFILE_ROW_LIMIT` models an
+//! early stop by an eventual explicit read-stream API.
+//!
+//! ```text
+//! LIX_SQL_PROFILE_RESULT_MODE=full \
+//!   cargo bench -p lix --no-default-features --features storage-benches \
+//!   --bench profile_sql_result_streaming
+//! LIX_SQL_PROFILE_RESULT_MODE=stream LIX_SQL_PROFILE_ROW_LIMIT=100 \
+//!   cargo bench -p lix --no-default-features --features storage-benches \
+//!   --bench profile_sql_result_streaming
+//! LIX_SQL_PROFILE_RESULT_MODE=live LIX_SQL_PROFILE_ROW_LIMIT=100 \
+//!   cargo bench -p lix --no-default-features --features storage-benches \
+//!   --bench profile_sql_result_streaming
+//! ```
+
+use std::hint::black_box;
+use std::time::{Duration, Instant};
+
+use lix::Value;
+use lix::integration::{Engine, SessionContext};
+use lix::storage::Memory;
+
+const DEFAULT_ROWS: usize = 131_072;
+const DEFAULT_ROUNDS: usize = 9;
+const DEFAULT_WARMUPS: usize = 2;
+const BATCH_ROWS: usize = 500;
+const PARTITIONS: usize = 8;
+const TABLE_PREFIX: &str = "profile_result_row";
+const REGISTER_SCHEMA_SQL: &str = "INSERT INTO lix_registered_schema (value) VALUES (lix_json($1))";
+// Keep a pullable scan at the root. A global ORDER BY would make DataFusion's
+// sort operator consume the complete input before emitting its first batch,
+// masking whether dropping the live stream cancels the scan. The fixture uses
+// distinct registered tables below so Lix's identical-scan cache cannot merge
+// the children back into one eager scan.
+
+#[derive(Clone, Copy, Debug)]
+struct Config {
+    rows: usize,
+    rounds: usize,
+    warmups: usize,
+    limit: Option<usize>,
+}
+
+#[derive(Clone, Copy, Debug)]
+struct Sample {
+    wall: Duration,
+    profile: lix::SqlReadProfile,
+}
+
+#[tokio::main(flavor = "current_thread")]
+async fn main() {
+    let mode = std::env::var("LIX_SQL_PROFILE_RESULT_MODE").unwrap_or_default();
+    if !matches!(
+        mode.as_str(),
+        "full" | "stream" | "live" | "count_only" | "fixture_only"
+    ) {
+        eprintln!(
+            "set LIX_SQL_PROFILE_RESULT_MODE to full, stream, live, count_only, or fixture_only; \
+             set LIX_SQL_PROFILE_ROW_LIMIT=100 to model early stop"
+        );
+        return;
+    }
+    let config = Config::from_env();
+    let session = seed_fixture(config.rows).await;
+    if mode == "fixture_only" {
+        println!(
+            "execute_result_streaming_profile mode=fixture_only rows={} limit=all rounds=0 \
+             wall_median_us=0 profile_total_us=0 logical_us=0 physical_us=0 \
+             arrow_execution_us=0 public_result_materialization_us=0 other_us=0 \
+             scan_rows=0 scan_batches=0 scan_arrow_bytes=0 result_rows_consumed=0 \
+             result_rows_materialized=0 result_rows_retained=0 result_checksum=0",
+            config.rows
+        );
+        black_box(session);
+        return;
+    }
+    let select_sql = select_sql(config.rows);
+    let expected_rows = if mode == "count_only" {
+        config.rows
+    } else {
+        config
+            .limit
+            .map_or(config.rows, |limit| limit.min(config.rows))
+    };
+
+    for _ in 0..config.warmups {
+        let profile = session
+            .execute_result_streaming_profiled(&select_sql, &[], &mode, config.limit)
+            .await
+            .expect("warmup profile query");
+        black_box(profile);
+    }
+
+    let mut samples = Vec::with_capacity(config.rounds);
+    for _ in 0..config.rounds {
+        let started = Instant::now();
+        let profile = session
+            .execute_result_streaming_profiled(&select_sql, &[], &mode, config.limit)
+            .await
+            .expect("profile query");
+        black_box(profile);
+        samples.push(Sample {
+            wall: started.elapsed(),
+            profile,
+        });
+    }
+    samples.sort_by_key(|sample| sample.wall);
+
+    let median = samples[samples.len() / 2];
+    assert_eq!(median.profile.result_rows_consumed as usize, expected_rows);
+    if mode != "count_only" {
+        assert_eq!(
+            median.profile.result_checksum,
+            expected_checksum(expected_rows),
+            "result checksum must match the deterministic fixture"
+        );
+    }
+    let expected_materialized = if mode == "count_only" {
+        0
+    } else if mode == "full" {
+        config.rows
+    } else {
+        expected_rows
+    };
+    assert_eq!(
+        median.profile.result_rows_materialized as usize,
+        expected_materialized
+    );
+    assert_eq!(
+        median.profile.result_rows_retained as usize,
+        usize::from(mode == "full") * config.rows
+    );
+    println!(
+        "execute_result_streaming_profile mode={mode} rows={} limit={} rounds={} \
+         wall_median_us={:.3} profile_total_us={:.3} logical_us={:.3} physical_us={:.3} \
+         arrow_execution_us={:.3} public_result_materialization_us={:.3} \
+         other_us={:.3} scan_rows={} scan_batches={} scan_arrow_bytes={} \
+         result_rows_consumed={} result_rows_materialized={} result_rows_retained={} \
+         result_checksum={}",
+        config.rows,
+        config
+            .limit
+            .map_or_else(|| "all".to_string(), |limit| limit.to_string()),
+        config.rounds,
+        micros(median.wall),
+        micros(median.profile.total),
+        micros(median.profile.logical_planning),
+        micros(median.profile.physical_planning),
+        micros(median.profile.arrow_execution),
+        micros(median.profile.public_result_materialization),
+        micros(median.profile.unattributed_overhead()),
+        median.profile.scan_rows,
+        median.profile.scan_batches,
+        median.profile.scan_arrow_bytes,
+        median.profile.result_rows_consumed,
+        median.profile.result_rows_materialized,
+        median.profile.result_rows_retained,
+        median.profile.result_checksum,
+    );
+}
+
+fn expected_checksum(rows: usize) -> u64 {
+    (0..rows).fold(0u64, |checksum, ordinal| {
+        fixture_row_checksum(
+            checksum,
+            &format!("row-{ordinal:08}"),
+            ordinal as i64,
+            &format!("payload-{ordinal:08}"),
+        )
+    })
+}
+
+fn fixture_row_checksum(checksum: u64, id: &str, ordinal: i64, payload: &str) -> u64 {
+    let mut checksum = if checksum == 0 {
+        0xcbf2_9ce4_8422_2325
+    } else {
+        checksum
+    };
+    checksum = checksum_bytes(checksum, &[0xff]);
+    checksum = checksum_sized_bytes(checksum, 4, id.as_bytes());
+    checksum = checksum_bytes(checksum, &[2]);
+    checksum = checksum_bytes(checksum, &ordinal.to_le_bytes());
+    checksum_sized_bytes(checksum, 4, payload.as_bytes())
+}
+
+fn checksum_sized_bytes(checksum: u64, tag: u8, bytes: &[u8]) -> u64 {
+    let checksum = checksum_bytes(checksum, &[tag]);
+    let checksum = checksum_bytes(checksum, &(bytes.len() as u64).to_le_bytes());
+    checksum_bytes(checksum, bytes)
+}
+
+fn checksum_bytes(mut checksum: u64, bytes: &[u8]) -> u64 {
+    for byte in bytes {
+        checksum ^= u64::from(*byte);
+        checksum = checksum.wrapping_mul(0x0000_0100_0000_01b3);
+    }
+    checksum
+}
+
+fn select_sql(rows: usize) -> String {
+    let rows_per_table = rows.div_ceil(PARTITIONS);
+    (0..PARTITIONS)
+        .filter_map(|partition| {
+            let start = partition * rows_per_table;
+            (start < rows).then(|| {
+                let table = format!("{TABLE_PREFIX}_{partition}");
+                format!("SELECT id, ordinal, payload FROM {table}")
+            })
+        })
+        .collect::<Vec<_>>()
+        .join(" UNION ALL ")
+}
+
+impl Config {
+    fn from_env() -> Self {
+        Self {
+            rows: positive_env_usize("LIX_SQL_PROFILE_ROWS", DEFAULT_ROWS),
+            rounds: positive_env_usize("LIX_SQL_PROFILE_ROUNDS", DEFAULT_ROUNDS),
+            warmups: positive_env_usize("LIX_SQL_PROFILE_WARMUPS", DEFAULT_WARMUPS),
+            limit: match std::env::var("LIX_SQL_PROFILE_ROW_LIMIT") {
+                Ok(value) if value == "all" => None,
+                Ok(value) => {
+                    Some(value.parse::<usize>().expect(
+                        "LIX_SQL_PROFILE_ROW_LIMIT must be a non-negative integer or 'all'",
+                    ))
+                }
+                Err(std::env::VarError::NotPresent) => None,
+                Err(std::env::VarError::NotUnicode(_)) => {
+                    panic!("LIX_SQL_PROFILE_ROW_LIMIT must be valid UTF-8")
+                }
+            },
+        }
+    }
+}
+
+async fn seed_fixture(rows: usize) -> SessionContext<Memory> {
+    let storage = Memory::new();
+    Engine::initialize(storage.clone())
+        .await
+        .expect("initialize result streaming profile storage");
+    let engine = Engine::new(storage)
+        .await
+        .expect("open result streaming profile engine");
+    let session = engine
+        .open_workspace_session()
+        .await
+        .expect("open result streaming profile session");
+    let rows_per_table = rows.div_ceil(PARTITIONS);
+    for partition in 0..PARTITIONS {
+        let table = format!("{TABLE_PREFIX}_{partition}");
+        let schema = serde_json::json!({
+            "x-lix-key": table,
+            "x-lix-primary-key": ["/id"],
+            "type": "object",
+            "properties": {
+                "id": { "type": "string" },
+                "ordinal": { "type": "integer" },
+                "payload": { "type": "string" }
+            },
+            "required": ["id", "ordinal", "payload"],
+            "additionalProperties": false
+        });
+        session
+            .execute(REGISTER_SCHEMA_SQL, &[Value::Text(schema.to_string())])
+            .await
+            .expect("register result streaming profile schema");
+
+        let start = partition * rows_per_table;
+        let end = (start + rows_per_table).min(rows);
+        for batch_start in (start..end).step_by(BATCH_ROWS) {
+            let batch_end = (batch_start + BATCH_ROWS).min(end);
+            let mut sql = format!("INSERT INTO {table} (id, ordinal, payload) VALUES ");
+            let mut params = Vec::with_capacity((batch_end - batch_start) * 3);
+            for (offset, ordinal) in (batch_start..batch_end).enumerate() {
+                if offset > 0 {
+                    sql.push(',');
+                }
+                let parameter = offset * 3;
+                sql.push_str(&format!(
+                    "(${}, ${}, ${})",
+                    parameter + 1,
+                    parameter + 2,
+                    parameter + 3
+                ));
+                params.push(Value::Text(format!("row-{ordinal:08}")));
+                params.push(Value::Integer(ordinal as i64));
+                params.push(Value::Text(format!("payload-{ordinal:08}")));
+            }
+            session
+                .execute(&sql, &params)
+                .await
+                .expect("seed result streaming profile rows");
+        }
+    }
+    session
+}
+
+fn positive_env_usize(name: &str, default: usize) -> usize {
+    std::env::var(name)
+        .ok()
+        .map(|value| {
+            let parsed = value
+                .parse::<usize>()
+                .expect("profile value must be an integer");
+            assert!(parsed > 0, "profile value must be positive");
+            parsed
+        })
+        .unwrap_or(default)
+}
+
+fn micros(duration: Duration) -> f64 {
+    duration.as_secs_f64() * 1_000_000.0
+}

--- a/packages/lix/src/gc.rs
+++ b/packages/lix/src/gc.rs
@@ -77,9 +77,13 @@ const CHECKPOINT_GC_STATE_KEY: &[u8] = b"repository";
 const GC_REACHABILITY_FORMAT_VERSION: u32 = 2;
 const GC_REACHABILITY_QUEUE_KEY: &[u8] = b"queue";
 const GC_REACHABILITY_BATCH_LIMIT: usize = 64;
+#[allow(dead_code)]
 const GC_TREE_SWEEP_EPOCH_KEY: &[u8] = b"epoch";
+#[allow(dead_code)]
 const GC_TREE_SWEEP_CURSOR_KEY: &[u8] = b"cursor";
+#[allow(dead_code)]
 const GC_TREE_SWEEP_FORMAT_VERSION: u32 = 1;
+#[allow(dead_code)]
 const GC_TREE_SWEEP_PAGE_ROWS: usize = 64;
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -204,6 +208,7 @@ struct StoredReachabilityQueue {
 /// and branch/recovery controls remain the sole logical root authority.
 #[derive(Clone, Debug, Eq, PartialEq, musli::Encode, musli::Decode)]
 #[musli(packed)]
+#[allow(dead_code)]
 struct StoredTreeSweepEpoch {
     format_version: u32,
     epoch_id: u64,
@@ -218,6 +223,7 @@ struct StoredTreeSweepEpoch {
 /// distinguish a resumable epoch from a fresh one.
 #[derive(Clone, Debug, Eq, PartialEq, musli::Encode, musli::Decode)]
 #[musli(packed)]
+#[allow(dead_code)]
 struct StoredTreeSweepCursor {
     format_version: u32,
     epoch_id: u64,
@@ -233,6 +239,7 @@ struct StoredTreeSweepCursor {
 /// tree chunk.
 #[derive(Clone, Debug, Eq, PartialEq, musli::Encode, musli::Decode)]
 #[musli(packed)]
+#[allow(dead_code)]
 struct StoredTreeSweepMark {
     format_version: u32,
     epoch_id: u64,
@@ -243,6 +250,7 @@ struct StoredTreeSweepMark {
 /// and verified once when the session starts or reopens; ordinary queue-prefix
 /// GC never consults it.
 #[derive(Clone, Debug)]
+#[allow(dead_code)]
 pub(crate) struct TreeSweepEpochSession {
     epoch: StoredTreeSweepEpoch,
     cursor: StoredTreeSweepCursor,
@@ -599,10 +607,12 @@ async fn load_reachability_batches(
     Ok(batches)
 }
 
+#[allow(dead_code)]
 fn tree_sweep_error(message: impl Into<String>) -> LixError {
     LixError::new(LixError::CODE_INTERNAL_ERROR, message)
 }
 
+#[allow(dead_code)]
 fn tree_sweep_digest(hashes: &BTreeSet<[u8; 32]>) -> [u8; 32] {
     let mut hasher = blake3::Hasher::new();
     for hash in hashes {
@@ -611,6 +621,7 @@ fn tree_sweep_digest(hashes: &BTreeSet<[u8; 32]>) -> [u8; 32] {
     *hasher.finalize().as_bytes()
 }
 
+#[allow(dead_code)]
 async fn load_all_reachability_batches_for_tree_sweep<S>(
     store: &S,
     queue: &StoredReachabilityQueue,
@@ -665,6 +676,7 @@ where
     Ok(batches)
 }
 
+#[allow(dead_code)]
 async fn load_tree_sweep_root_closure<S>(
     store: &S,
 ) -> Result<([u8; 32], [u8; 32], Bytes, BTreeSet<[u8; 32]>), LixError>
@@ -751,6 +763,7 @@ where
     ))
 }
 
+#[allow(dead_code)]
 async fn scan_tree_sweep_marks<S>(
     store: &S,
     expected_epoch: Option<u64>,
@@ -838,6 +851,7 @@ where
     Ok((current, all))
 }
 
+#[allow(dead_code)]
 async fn load_optional_tree_sweep_row<S, T>(
     store: &S,
     space: StorageSpace,
@@ -866,6 +880,7 @@ where
 /// Starts a new authenticated tree sweep epoch. The expensive root closure
 /// and mark inventory are built once here; ordinary queue-prefix GC never
 /// calls this function.
+#[allow(dead_code)]
 pub(crate) async fn begin_tree_sweep_epoch<S>(
     store: &S,
     writes: &mut StorageWriteSet,
@@ -997,6 +1012,7 @@ where
 
 /// Reopens an active or completed epoch. Mark rows are fully authenticated
 /// against the persisted count/digest before any page may stage a delete.
+#[allow(dead_code)]
 pub(crate) async fn open_tree_sweep_epoch<S>(
     store: &S,
 ) -> Result<Option<TreeSweepEpochSession>, LixError>
@@ -1050,6 +1066,7 @@ where
 /// the authenticated epoch mark set. Every key/value and cursor transition is
 /// validated before staging; the queue and cursor CAS fences make interruption
 /// and root publication races fail closed.
+#[allow(dead_code)]
 pub(crate) async fn stage_tree_sweep_epoch_page<S>(
     store: &S,
     session: &mut TreeSweepEpochSession,
@@ -3155,7 +3172,7 @@ mod tests {
             .expect("fixture read should open");
         let mut writes = storage.new_write_set();
         let mut preconditions = Vec::<StoragePrecondition>::new();
-        let mut session = begin_tree_sweep_epoch(&&read, &mut writes, &mut preconditions)
+        let _session = begin_tree_sweep_epoch(&&read, &mut writes, &mut preconditions)
             .await
             .expect("epoch closure should build once");
         storage
@@ -4852,10 +4869,10 @@ mod tests {
         }
     }
 
-    fn test_snapshot_root(commit_id: CommitId) -> crate::tracked_state::TrackedStateCommitRoot {
-        crate::tracked_state::TrackedStateCommitRoot {
+    fn test_snapshot_root(commit_id: CommitId) -> TrackedStateCommitRoot {
+        TrackedStateCommitRoot {
             commit_id,
-            root_id: crate::tracked_state::TrackedStateRootId::new(
+            root_id: TrackedStateRootId::new(
                 *blake3::hash(commit_id.as_uuid().as_bytes()).as_bytes(),
             ),
             parent_roots: Vec::new(),

--- a/packages/lix/src/session/execute.rs
+++ b/packages/lix/src/session/execute.rs
@@ -28,6 +28,8 @@ use datafusion::sql::sqlparser::ast::{
     SelectFlavor, SelectItem, SetExpr, Statement as SqlStatement, TableAlias, TableFactor,
     Value as SqlValue, Visit, Visitor,
 };
+#[cfg(feature = "storage-benches")]
+use futures_util::TryStreamExt;
 use serde_json::{Map as JsonMap, Value as JsonValue};
 use tracing::Instrument as _;
 
@@ -763,6 +765,152 @@ where
     ) -> Result<(ExecuteResult, crate::SqlReadProfile), LixError> {
         let (result, profile) = crate::sql_profile::scope(self.execute(sql, params)).await;
         result.map(|result| (result, profile))
+    }
+
+    /// Benchmark-only comparison of the eager result path with internal
+    /// collected-batch and live-batch consumers. No stream escapes the scoped
+    /// storage read, and this does not change the public execution contract.
+    #[cfg(feature = "storage-benches")]
+    #[doc(hidden)]
+    pub async fn execute_result_streaming_profiled(
+        &self,
+        sql: &str,
+        params: &[Value],
+        mode: &str,
+        row_limit: Option<usize>,
+    ) -> Result<crate::SqlReadProfile, LixError> {
+        let (result, profile) = crate::sql_profile::scope(async {
+            if mode == "full" {
+                let result = self.execute(sql, params).await?;
+                let rows = result.rows();
+                let consumed = row_limit.map_or(rows.len(), |limit| limit.min(rows.len()));
+                let checksum = rows.iter().take(consumed).try_fold(0u64, |checksum, row| {
+                    profile_result_checksum(checksum, row.values())
+                })?;
+                crate::sql_profile::record_result_rows(consumed, rows.len(), rows.len());
+                crate::sql_profile::record_result_checksum(checksum);
+                return Ok(());
+            }
+
+            if !matches!(mode, "stream" | "live" | "count_only") {
+                return Err(LixError::new(
+                    LixError::CODE_INVALID_PARAM,
+                    format!("unknown result streaming profile mode '{mode}'"),
+                ));
+            }
+
+            self.ensure_open()?;
+            let statement = self.sql_planning_cache.parse_statement(sql)?;
+            if sql2::bind_statement_route(&statement)? != sql2::BoundStatementRoute::Read
+                || sql2::statement_has_durable_runtime_function(&statement)
+                || exact_filesystem_read_route(&statement, params).is_some()
+                || late_materialized_lix_file_content_read(&statement).is_some()
+            {
+                return Err(LixError::new(
+                    LixError::CODE_UNSUPPORTED_SQL,
+                    "result streaming profiler accepts only ordinary cancellable reads",
+                ));
+            }
+
+            let _operation_guard = self.begin_waitable_session_operation().await?;
+            let read_scope = self
+                .storage
+                .begin_read(StorageReadOptions::default())
+                .await?;
+            with_static_session_sql_read::<StorageImpl, _, _>(
+                read_scope,
+                |read_store: SharedStorageAdapterRead<StorageImpl::Read<'static>>| async move {
+                    let active_branch_id = self.active_branch_id_from_reader(&read_store).await?;
+                    let ctx = SessionSqlExecutionContext {
+                        active_branch_id: &active_branch_id,
+                        active_account_id: self.active_account_id(),
+                        read_store,
+                        live_state: Arc::clone(&self.live_state),
+                        binary_cas: Arc::clone(&self.binary_cas),
+                        branch_ctx: Arc::clone(&self.branch_ctx),
+                        catalog_context: Arc::clone(&self.catalog_context),
+                        sql_planning_cache: Arc::clone(&self.sql_planning_cache),
+                        functions: FunctionProviderHandle::system(),
+                        plugin_host: self.plugin_host.clone(),
+                        file_views: None,
+                    };
+                    let read_session =
+                        sql2::prepare_read_session(&ctx, std::slice::from_ref(&statement)).await?;
+
+                    match mode {
+                        "stream" => {
+                            let result =
+                                sql2::execute_read_statement_in_session_with_collected_batches(
+                                    &read_session,
+                                    sql,
+                                    statement,
+                                    params,
+                                )
+                                .await?;
+                            let _notice_count = result.notices.len();
+                            let mut cursor =
+                                sql2::BatchRowCursor::collected(&result.fields, &result.batches);
+                            consume_profile_cursor(&mut cursor, row_limit).await?;
+                        }
+                        "live" => {
+                            let mut result =
+                                sql2::execute_read_statement_in_session_with_batch_stream(
+                                    &read_session,
+                                    sql,
+                                    statement,
+                                    params,
+                                )
+                                .await?;
+                            let _notice_count = result.notices.len();
+                            let mut cursor = sql2::BatchRowCursor::live(&mut result);
+                            consume_profile_cursor(&mut cursor, row_limit).await?;
+                            drop(cursor);
+                            drop(result);
+                        }
+                        "count_only" => {
+                            let mut result =
+                                sql2::execute_read_statement_in_session_with_batch_stream(
+                                    &read_session,
+                                    sql,
+                                    statement,
+                                    params,
+                                )
+                                .await?;
+                            let _notice_count = result.notices.len();
+                            let mut rows = 0usize;
+                            let mut batches = 0usize;
+                            while let Some(batch) = {
+                                let started = std::time::Instant::now();
+                                let batch = result
+                                    .stream
+                                    .try_next()
+                                    .await
+                                    .map_err(sql2::datafusion_error_to_lix_error);
+                                crate::sql_profile::record_phase(
+                                    crate::sql_profile::Phase::ArrowExecution,
+                                    started.elapsed(),
+                                );
+                                batch?
+                            } {
+                                rows = rows.saturating_add(batch.num_rows());
+                                batches = batches.saturating_add(1);
+                            }
+                            crate::sql_profile::record_result_count_only(rows, batches);
+                            crate::sql_profile::record_result_rows(rows, 0, 0);
+                            drop(result);
+                        }
+                        _ => unreachable!("profile mode validated before opening read"),
+                    }
+                    drop(read_session);
+                    drop(ctx);
+                    Ok(())
+                },
+            )
+            .await
+        })
+        .await;
+        result?;
+        Ok(profile)
     }
 
     pub async fn execute_with_options(
@@ -2548,6 +2696,80 @@ async fn hydrate_lix_file_content_result(
         })?;
     }
     Ok(())
+}
+
+#[cfg(feature = "storage-benches")]
+async fn consume_profile_cursor(
+    cursor: &mut sql2::BatchRowCursor<'_>,
+    row_limit: Option<usize>,
+) -> Result<(), LixError> {
+    let limit = row_limit.unwrap_or(usize::MAX);
+    let mut consumed = 0usize;
+    let mut checksum = 0u64;
+    while consumed < limit {
+        let Some(values) = cursor.next_values().await? else {
+            break;
+        };
+        checksum = profile_result_checksum(checksum, &values)?;
+        consumed += 1;
+    }
+    crate::sql_profile::record_result_rows(consumed, consumed, 0);
+    crate::sql_profile::record_result_checksum(checksum);
+    Ok(())
+}
+
+#[cfg(feature = "storage-benches")]
+fn profile_result_checksum(checksum: u64, values: &[Value]) -> Result<u64, LixError> {
+    if values.len() != 3 {
+        return Err(LixError::new(
+            LixError::CODE_TYPE_MISMATCH,
+            "streaming profile expected exactly three projected values",
+        ));
+    }
+    let mut checksum = if checksum == 0 {
+        0xcbf2_9ce4_8422_2325
+    } else {
+        checksum
+    };
+    checksum = profile_checksum_bytes(checksum, &[0xff]);
+    for value in values {
+        checksum = match value {
+            Value::Null => profile_checksum_bytes(checksum, &[0]),
+            Value::Boolean(value) => profile_checksum_bytes(checksum, &[1, u8::from(*value)]),
+            Value::Integer(value) => {
+                let checksum = profile_checksum_bytes(checksum, &[2]);
+                profile_checksum_bytes(checksum, &value.to_le_bytes())
+            }
+            Value::Real(value) => {
+                let checksum = profile_checksum_bytes(checksum, &[3]);
+                profile_checksum_bytes(checksum, &value.to_bits().to_le_bytes())
+            }
+            Value::Text(value) => profile_checksum_sized_bytes(checksum, 4, value.as_bytes()),
+            Value::Json(value) => {
+                profile_checksum_sized_bytes(checksum, 5, value.to_string().as_bytes())
+            }
+            Value::Blob(value) => {
+                profile_checksum_sized_bytes(checksum, 6, value.as_bytes().as_ref())
+            }
+        };
+    }
+    Ok(checksum)
+}
+
+#[cfg(feature = "storage-benches")]
+fn profile_checksum_sized_bytes(checksum: u64, tag: u8, bytes: &[u8]) -> u64 {
+    let checksum = profile_checksum_bytes(checksum, &[tag]);
+    let checksum = profile_checksum_bytes(checksum, &(bytes.len() as u64).to_le_bytes());
+    profile_checksum_bytes(checksum, bytes)
+}
+
+#[cfg(feature = "storage-benches")]
+fn profile_checksum_bytes(mut checksum: u64, bytes: &[u8]) -> u64 {
+    for byte in bytes {
+        checksum ^= u64::from(*byte);
+        checksum = checksum.wrapping_mul(0x0000_0100_0000_01b3);
+    }
+    checksum
 }
 
 /// Runs one session SQL read using a widened storage-read lifetime.

--- a/packages/lix/src/sql2/exec/datafusion.rs
+++ b/packages/lix/src/sql2/exec/datafusion.rs
@@ -8,30 +8,6 @@
     clippy::unnecessary_wraps
 )]
 
-use datafusion::arrow::array::Array;
-use datafusion::arrow::datatypes::{DataType, Field, Schema, SchemaRef};
-use datafusion::arrow::record_batch::RecordBatch;
-use datafusion::common::metadata::{FieldMetadata, ScalarAndMetadata};
-use datafusion::common::tree_node::{Transformed, TreeNode, TreeNodeRecursion};
-use datafusion::common::{Column, DFSchema, DFSchemaRef, JoinType, ParamValues, ScalarValue};
-use datafusion::datasource::{empty::EmptyTable, provider_as_source};
-use datafusion::logical_expr::dml::InsertOp;
-use datafusion::logical_expr::expr::{BinaryExpr, Cast, InList, Like, ScalarFunction};
-use datafusion::logical_expr::registry::FunctionRegistry;
-use datafusion::logical_expr::{Expr, ExprSchemable, LogicalPlan, LogicalPlanBuilder, Operator};
-use datafusion::prelude::SessionContext;
-use datafusion::sql::parser::Statement as DataFusionStatement;
-use datafusion::sql::sqlparser::ast::{
-    Expr as SqlExpr, FunctionArg, FunctionArgExpr, TableFactor, Value as SqlValue, Visit, VisitMut,
-    Visitor, VisitorMut,
-};
-use serde_json::json;
-use std::collections::{BTreeMap, BTreeSet, HashSet};
-use std::marker::PhantomData;
-use std::ops::ControlFlow;
-#[cfg(feature = "storage-benches")]
-use std::time::Instant;
-
 use crate::branch::BranchHead;
 use crate::functions::FunctionContext;
 use crate::sql2::bind::expr::{BoundBinaryOperator, BoundCastType, BoundExpr, BoundLiteral};
@@ -44,6 +20,33 @@ use crate::sql2::plan::LogicalWritePlan;
 use crate::sql2::plan::branch_scope::BranchScope;
 use crate::sql2::plan::predicate::BoundPredicate;
 use crate::{GLOBAL_BRANCH_ID, LixError, LixNotice, SqlQueryResult, Value};
+use datafusion::arrow::array::Array;
+use datafusion::arrow::datatypes::{DataType, Field, Schema, SchemaRef};
+use datafusion::arrow::record_batch::RecordBatch;
+use datafusion::common::metadata::{FieldMetadata, ScalarAndMetadata};
+use datafusion::common::tree_node::{Transformed, TreeNode, TreeNodeRecursion};
+use datafusion::common::{Column, DFSchema, DFSchemaRef, JoinType, ParamValues, ScalarValue};
+use datafusion::datasource::{empty::EmptyTable, provider_as_source};
+use datafusion::logical_expr::dml::InsertOp;
+use datafusion::logical_expr::expr::{BinaryExpr, Cast, InList, Like, ScalarFunction};
+use datafusion::logical_expr::registry::FunctionRegistry;
+use datafusion::logical_expr::{Expr, ExprSchemable, LogicalPlan, LogicalPlanBuilder, Operator};
+#[cfg(any(feature = "storage-benches", test))]
+use datafusion::physical_plan::SendableRecordBatchStream;
+use datafusion::prelude::SessionContext;
+use datafusion::sql::parser::Statement as DataFusionStatement;
+use datafusion::sql::sqlparser::ast::{
+    Expr as SqlExpr, FunctionArg, FunctionArgExpr, TableFactor, Value as SqlValue, Visit, VisitMut,
+    Visitor, VisitorMut,
+};
+#[cfg(any(feature = "storage-benches", test))]
+use futures_util::TryStreamExt;
+use serde_json::json;
+use std::collections::{BTreeMap, BTreeSet, HashSet};
+use std::marker::PhantomData;
+use std::ops::ControlFlow;
+#[cfg(feature = "storage-benches")]
+use std::time::Instant;
 
 use crate::catalog::CatalogFingerprint;
 use crate::sql2::predicate_typecheck::{
@@ -82,6 +85,125 @@ pub(crate) struct DataFusionLogicalPlan {
 pub(crate) struct SessionReadSqlResult {
     pub(crate) runtime_functions: Option<FunctionContext>,
     pub(crate) query: SessionReadResult,
+}
+
+/// A live DataFusion result returned before any RecordBatch is collected or
+/// converted to public scalar rows.
+#[cfg(any(feature = "storage-benches", test))]
+pub(crate) struct SessionReadBatchStreamResult<'session> {
+    pub(crate) fields: Vec<Field>,
+    pub(crate) stream: SendableRecordBatchStream,
+    pub(crate) notices: Vec<LixNotice>,
+    _session: PhantomData<&'session ()>,
+}
+
+/// Benchmark control that always stops at collected Arrow batches and never
+/// applies the public result path's row-retention heuristic.
+#[cfg(feature = "storage-benches")]
+pub(crate) struct SessionReadCollectedBatchResult {
+    pub(crate) fields: Vec<Field>,
+    pub(crate) batches: std::sync::Arc<[RecordBatch]>,
+    pub(crate) notices: Vec<LixNotice>,
+}
+
+#[cfg(any(feature = "storage-benches", test))]
+enum BatchRowSource<'a> {
+    Collected {
+        batches: &'a [RecordBatch],
+        next_batch: usize,
+    },
+    Live(&'a mut SendableRecordBatchStream),
+}
+
+/// Internal row cursor over Arrow batches. It borrows its batch source, so a
+/// live cursor cannot escape the read session and storage snapshot that own
+/// the DataFusion stream.
+#[cfg(any(feature = "storage-benches", test))]
+pub(crate) struct BatchRowCursor<'a> {
+    fields: &'a [Field],
+    source: BatchRowSource<'a>,
+    current_batch: Option<RecordBatch>,
+    next_row: usize,
+}
+
+#[cfg(any(feature = "storage-benches", test))]
+impl<'a> BatchRowCursor<'a> {
+    pub(crate) fn collected(fields: &'a [Field], batches: &'a [RecordBatch]) -> Self {
+        Self {
+            fields,
+            source: BatchRowSource::Collected {
+                batches,
+                next_batch: 0,
+            },
+            current_batch: None,
+            next_row: 0,
+        }
+    }
+
+    pub(crate) fn live(result: &'a mut SessionReadBatchStreamResult<'_>) -> Self {
+        Self {
+            fields: &result.fields,
+            source: BatchRowSource::Live(&mut result.stream),
+            current_batch: None,
+            next_row: 0,
+        }
+    }
+
+    pub(crate) async fn next_values(&mut self) -> Result<Option<Vec<Value>>, LixError> {
+        loop {
+            if let Some(batch) = &self.current_batch
+                && self.next_row < batch.num_rows()
+            {
+                #[cfg(feature = "storage-benches")]
+                let started = crate::sql_profile::is_active().then(Instant::now);
+                let values = row_values_from_batch(self.fields, batch, self.next_row)?;
+                #[cfg(feature = "storage-benches")]
+                if let Some(started) = started {
+                    crate::sql_profile::record_phase(
+                        crate::sql_profile::Phase::PublicResultMaterialization,
+                        started.elapsed(),
+                    );
+                }
+                self.next_row += 1;
+                return Ok(Some(values));
+            }
+
+            self.current_batch = self.next_batch().await?;
+            self.next_row = 0;
+            if self.current_batch.is_none() {
+                return Ok(None);
+            }
+        }
+    }
+
+    async fn next_batch(&mut self) -> Result<Option<RecordBatch>, LixError> {
+        match &mut self.source {
+            BatchRowSource::Collected {
+                batches,
+                next_batch,
+            } => {
+                let batch = batches.get(*next_batch).cloned();
+                *next_batch += usize::from(batch.is_some());
+                Ok(batch)
+            }
+            BatchRowSource::Live(stream) => {
+                #[cfg(feature = "storage-benches")]
+                let started = crate::sql_profile::is_active().then(Instant::now);
+                let batch = stream
+                    .try_next()
+                    .await
+                    .map_err(datafusion_error_to_lix_error);
+                #[cfg(feature = "storage-benches")]
+                if let Some(started) = started {
+                    crate::sql_profile::record_phase(
+                        crate::sql_profile::Phase::ArrowExecution,
+                        started.elapsed(),
+                    );
+                }
+                batch
+            }
+        }
+    }
 }
 
 /// One read-result authority. DataFusion results remain owned by their
@@ -226,6 +348,44 @@ pub(crate) async fn execute_read_statement_in_session_with_result(
         runtime_functions: None,
         query: execute_logical_plan(plan, params).await?,
     })
+}
+
+#[cfg(feature = "storage-benches")]
+pub(crate) async fn execute_read_statement_in_session_with_batch_stream<'session>(
+    session: &'session ReadSqlSession<'_>,
+    sql: &str,
+    statement: DataFusionStatement,
+    params: &[Value],
+) -> Result<SessionReadBatchStreamResult<'session>, LixError> {
+    #[cfg(feature = "storage-benches")]
+    let started = crate::sql_profile::is_active().then(Instant::now);
+    let plan = create_logical_plan_in_session_from_parsed(session, sql, statement, params).await?;
+    #[cfg(feature = "storage-benches")]
+    if let Some(started) = started {
+        crate::sql_profile::record_phase(
+            crate::sql_profile::Phase::LogicalPlanning,
+            started.elapsed(),
+        );
+    }
+    execute_logical_plan_stream(plan, params, session).await
+}
+
+#[cfg(feature = "storage-benches")]
+pub(crate) async fn execute_read_statement_in_session_with_collected_batches(
+    session: &ReadSqlSession<'_>,
+    sql: &str,
+    statement: DataFusionStatement,
+    params: &[Value],
+) -> Result<SessionReadCollectedBatchResult, LixError> {
+    let started = crate::sql_profile::is_active().then(Instant::now);
+    let plan = create_logical_plan_in_session_from_parsed(session, sql, statement, params).await?;
+    if let Some(started) = started {
+        crate::sql_profile::record_phase(
+            crate::sql_profile::Phase::LogicalPlanning,
+            started.elapsed(),
+        );
+    }
+    execute_logical_plan_collected_batches(plan, params).await
 }
 
 async fn create_logical_plan_in_session_from_parsed(
@@ -1197,6 +1357,106 @@ async fn execute_logical_plan(
     }
     result.notices = notices;
     Ok(SessionReadResult::Rows(result))
+}
+
+#[cfg(feature = "storage-benches")]
+async fn execute_logical_plan_stream<'session>(
+    plan: SqlLogicalPlan,
+    params: &[Value],
+    _read_session: &'session ReadSqlSession<'_>,
+) -> Result<SessionReadBatchStreamResult<'session>, LixError> {
+    let SqlLogicalPlan::DataFusion(plan) = plan else {
+        return Err(LixError::new(
+            LixError::CODE_UNSUPPORTED_SQL,
+            "sql2 bound write execution is not wired yet",
+        ));
+    };
+    let SqlDataFusionLogicalPlan {
+        session,
+        plan,
+        notices,
+        json_predicate_params,
+        expected_parameter_count,
+        physical_planning_cache,
+    } = plan;
+    debug_assert_eq!(expected_parameter_count, params.len());
+    validate_json_predicate_params(&json_predicate_params, params)?;
+
+    let mut dataframe = session
+        .execute_logical_plan(plan)
+        .await
+        .map_err(datafusion_error_to_lix_error)?;
+    if !params.is_empty() {
+        dataframe = dataframe
+            .with_param_values(ParamValues::List(
+                params.iter().map(scalar_value_from_lix_value).collect(),
+            ))
+            .map_err(datafusion_error_to_lix_error)?;
+    }
+    let fields = dataframe
+        .schema()
+        .fields()
+        .iter()
+        .map(|field| field.as_ref().clone())
+        .collect::<Vec<_>>();
+    let stream = crate::sql2::runtime::stream_dataframe(dataframe, physical_planning_cache)
+        .await
+        .map_err(datafusion_error_to_lix_error)?;
+    Ok(SessionReadBatchStreamResult {
+        fields,
+        stream,
+        notices,
+        _session: PhantomData,
+    })
+}
+
+#[cfg(feature = "storage-benches")]
+async fn execute_logical_plan_collected_batches(
+    plan: SqlLogicalPlan,
+    params: &[Value],
+) -> Result<SessionReadCollectedBatchResult, LixError> {
+    let SqlLogicalPlan::DataFusion(plan) = plan else {
+        return Err(LixError::new(
+            LixError::CODE_UNSUPPORTED_SQL,
+            "sql2 bound write execution is not wired yet",
+        ));
+    };
+    let SqlDataFusionLogicalPlan {
+        session,
+        plan,
+        notices,
+        json_predicate_params,
+        expected_parameter_count,
+        physical_planning_cache,
+    } = plan;
+    debug_assert_eq!(expected_parameter_count, params.len());
+    validate_json_predicate_params(&json_predicate_params, params)?;
+
+    let mut dataframe = session
+        .execute_logical_plan(plan)
+        .await
+        .map_err(datafusion_error_to_lix_error)?;
+    if !params.is_empty() {
+        dataframe = dataframe
+            .with_param_values(ParamValues::List(
+                params.iter().map(scalar_value_from_lix_value).collect(),
+            ))
+            .map_err(datafusion_error_to_lix_error)?;
+    }
+    let fields = dataframe
+        .schema()
+        .fields()
+        .iter()
+        .map(|field| field.as_ref().clone())
+        .collect::<Vec<_>>();
+    let batches = crate::sql2::runtime::collect_dataframe(dataframe, physical_planning_cache)
+        .await
+        .map_err(datafusion_error_to_lix_error)?;
+    Ok(SessionReadCollectedBatchResult {
+        fields,
+        batches: std::sync::Arc::from(batches),
+        notices,
+    })
 }
 
 /// Keep large, ordinary Arrow result sets columnar until a caller requests a
@@ -2711,14 +2971,7 @@ pub(crate) fn query_result_from_batches(
     let mut rows = Vec::<Vec<Value>>::new();
     for batch in batches {
         for row_index in 0..batch.num_rows() {
-            let mut row = Vec::<Value>::with_capacity(batch.num_columns());
-            for (column_index, array) in batch.columns().iter().enumerate() {
-                let scalar = ScalarValue::try_from_array(array.as_ref(), row_index)
-                    .map_err(datafusion_error_to_lix_error)?;
-                let field = result_fields.get(column_index);
-                row.push(scalar_value_to_lix_value(scalar, field)?);
-            }
-            rows.push(row);
+            rows.push(row_values_from_batch(result_fields, batch, row_index)?);
         }
     }
 
@@ -2727,6 +2980,21 @@ pub(crate) fn query_result_from_batches(
         columns: result_columns.clone(),
         notices: Vec::new(),
     })
+}
+
+pub(crate) fn row_values_from_batch(
+    result_fields: &[Field],
+    batch: &RecordBatch,
+    row_index: usize,
+) -> Result<Vec<Value>, LixError> {
+    let mut row = Vec::<Value>::with_capacity(batch.num_columns());
+    for (column_index, array) in batch.columns().iter().enumerate() {
+        let scalar = ScalarValue::try_from_array(array.as_ref(), row_index)
+            .map_err(datafusion_error_to_lix_error)?;
+        let field = result_fields.get(column_index);
+        row.push(scalar_value_to_lix_value(scalar, field)?);
+    }
+    Ok(row)
 }
 
 fn scalar_value_to_lix_value(value: ScalarValue, field: Option<&Field>) -> Result<Value, LixError> {
@@ -2803,13 +3071,16 @@ fn string_scalar_to_lix_value(value: String, field: Option<&Field>) -> Result<Va
 #[cfg(test)]
 mod tests {
     use std::collections::BTreeSet;
+    use std::collections::VecDeque;
+    use std::pin::Pin;
     use std::sync::{
         Arc, Mutex,
-        atomic::{AtomicUsize, Ordering},
+        atomic::{AtomicBool, AtomicUsize, Ordering},
     };
+    use std::task::{Context, Poll};
 
     use async_trait::async_trait;
-    use futures_util::FutureExt;
+    use futures_util::{FutureExt, Stream};
     use serde_json::Value as JsonValue;
     use serde_json::json;
 
@@ -2850,7 +3121,12 @@ mod tests {
     };
     use crate::{LixError, NullableKeyFilter, Value};
     use bytes::Bytes;
+    use datafusion::arrow::array::Int64Array;
+    use datafusion::arrow::datatypes::{DataType, Field, Schema, SchemaRef};
+    use datafusion::arrow::record_batch::RecordBatch;
     use datafusion::common::ScalarValue;
+    use datafusion::error::DataFusionError;
+    use datafusion::physical_plan::RecordBatchStream;
 
     struct DummyBlobReader;
     struct StaticBlobReader {
@@ -2867,6 +3143,101 @@ mod tests {
     struct CountingRowsLiveStateReader {
         rows: Vec<MaterializedLiveStateRow>,
         scans: Arc<AtomicUsize>,
+    }
+    struct CountingBatchStream {
+        schema: SchemaRef,
+        batches: VecDeque<RecordBatch>,
+        polls: Arc<AtomicUsize>,
+        dropped: Arc<AtomicBool>,
+    }
+
+    impl Stream for CountingBatchStream {
+        type Item = Result<RecordBatch, DataFusionError>;
+
+        fn poll_next(mut self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+            self.polls.fetch_add(1, Ordering::SeqCst);
+            Poll::Ready(self.batches.pop_front().map(Ok))
+        }
+    }
+
+    impl RecordBatchStream for CountingBatchStream {
+        fn schema(&self) -> SchemaRef {
+            Arc::clone(&self.schema)
+        }
+    }
+
+    impl Drop for CountingBatchStream {
+        fn drop(&mut self) {
+            self.dropped.store(true, Ordering::SeqCst);
+        }
+    }
+
+    #[tokio::test]
+    async fn dropping_live_batch_cursor_stops_before_polling_later_batches() {
+        let field = Field::new("ordinal", DataType::Int64, false);
+        let schema = Arc::new(Schema::new(vec![field.clone()]));
+        let batches = [1i64, 2i64]
+            .into_iter()
+            .map(|value| {
+                RecordBatch::try_new(
+                    Arc::clone(&schema),
+                    vec![Arc::new(Int64Array::from(vec![value]))],
+                )
+                .expect("test batch should match schema")
+            })
+            .collect::<VecDeque<_>>();
+        let polls = Arc::new(AtomicUsize::new(0));
+        let dropped = Arc::new(AtomicBool::new(false));
+        let stream = CountingBatchStream {
+            schema,
+            batches,
+            polls: Arc::clone(&polls),
+            dropped: Arc::clone(&dropped),
+        };
+        let mut result = super::SessionReadBatchStreamResult {
+            fields: vec![field],
+            stream: Box::pin(stream),
+            notices: Vec::new(),
+            _session: std::marker::PhantomData,
+        };
+        assert!(result.notices.is_empty());
+
+        let mut cursor = super::BatchRowCursor::live(&mut result);
+        assert_eq!(
+            cursor.next_values().await.unwrap(),
+            Some(vec![Value::Integer(1)])
+        );
+        assert_eq!(polls.load(Ordering::SeqCst), 1);
+
+        drop(cursor);
+        drop(result);
+        assert_eq!(polls.load(Ordering::SeqCst), 1);
+        assert!(dropped.load(Ordering::SeqCst));
+    }
+
+    #[tokio::test]
+    async fn collected_batch_cursor_converts_rows_without_retaining_public_rows() {
+        let field = Field::new("ordinal", DataType::Int64, false);
+        let schema = Arc::new(Schema::new(vec![field.clone()]));
+        let batches = vec![
+            RecordBatch::try_new(
+                Arc::clone(&schema),
+                vec![Arc::new(Int64Array::from(vec![1i64, 2i64]))],
+            )
+            .expect("test batch should match schema"),
+        ];
+        let fields = vec![field];
+        let mut cursor = super::BatchRowCursor::collected(&fields, &batches);
+
+        assert_eq!(
+            cursor.next_values().await.unwrap(),
+            Some(vec![Value::Integer(1)])
+        );
+        assert_eq!(
+            cursor.next_values().await.unwrap(),
+            Some(vec![Value::Integer(2)])
+        );
+        assert_eq!(cursor.next_values().await.unwrap(), None);
     }
     struct RecordingEntitySnapshotReader {
         snapshots: Vec<Option<Bytes>>,

--- a/packages/lix/src/sql2/exec/mod.rs
+++ b/packages/lix/src/sql2/exec/mod.rs
@@ -68,6 +68,11 @@ impl SqlWriteResult {
     }
 }
 
+#[cfg(feature = "storage-benches")]
+pub(crate) use datafusion::{
+    BatchRowCursor, execute_read_statement_in_session_with_batch_stream,
+    execute_read_statement_in_session_with_collected_batches,
+};
 pub(crate) use datafusion::{
     DataFusionLogicalPlan as SqlDataFusionLogicalPlan, SessionReadResult, SessionReadSqlResult,
     execute_read_statement_in_session_from_parsed, execute_read_statement_in_session_with_result,

--- a/packages/lix/src/sql2/mod.rs
+++ b/packages/lix/src/sql2/mod.rs
@@ -30,6 +30,9 @@ mod udfs;
 mod value_contract;
 mod write_normalization;
 
+#[cfg(feature = "storage-benches")]
+pub(crate) use error::datafusion_error_to_lix_error;
+
 #[cfg(test)]
 pub(crate) use bind::bind_statement;
 pub(crate) use bind::{
@@ -57,6 +60,11 @@ pub(crate) use entity_columnar_layout::{
 };
 pub(crate) use entity_projection::EntityProjectionDecoder;
 pub(crate) use exec::bound_public_write::PreparedPathValueReplacementProgram;
+#[cfg(feature = "storage-benches")]
+pub(crate) use exec::{
+    BatchRowCursor, execute_read_statement_in_session_with_batch_stream,
+    execute_read_statement_in_session_with_collected_batches,
+};
 pub(crate) use exec::{SessionReadResult, SessionReadSqlResult, SqlWriteResult};
 #[allow(unused_imports)]
 pub(crate) use exec::{

--- a/packages/lix/src/sql2/runtime.rs
+++ b/packages/lix/src/sql2/runtime.rs
@@ -2,6 +2,8 @@ use std::any::Any;
 use std::collections::{HashMap, VecDeque};
 use std::fmt::Debug;
 use std::sync::Arc;
+#[cfg(feature = "storage-benches")]
+use std::time::Instant;
 
 use datafusion::arrow::record_batch::RecordBatch;
 use datafusion::catalog::ScanArgs;
@@ -25,8 +27,6 @@ use datafusion::physical_plan::{
     SendableRecordBatchStream, Statistics,
 };
 use futures_util::{StreamExt, TryStreamExt, stream};
-#[cfg(feature = "storage-benches")]
-use std::time::Instant;
 use tokio::sync::OnceCell;
 
 use crate::catalog::CatalogFingerprint;
@@ -66,6 +66,30 @@ pub(crate) async fn collect_dataframe(
         );
     }
     result
+}
+
+/// Create a pull-based stream from a DataFusion physical plan without
+/// collecting its output batches first. The caller owns the stream and may
+/// stop polling it early; dropping the stream then drops the underlying scan
+/// futures as well.
+#[cfg(feature = "storage-benches")]
+pub(crate) async fn stream_dataframe(
+    dataframe: DataFrame,
+    physical_planning_cache: Option<PhysicalPlanningCache>,
+) -> Result<SendableRecordBatchStream> {
+    let task_ctx = Arc::new(dataframe.task_ctx());
+    #[cfg(feature = "storage-benches")]
+    let started = crate::sql_profile::is_active().then(Instant::now);
+    let plan = create_or_rebind_physical_plan(dataframe, physical_planning_cache).await?;
+    let plan = adapt_runtime_plan(plan)?;
+    #[cfg(feature = "storage-benches")]
+    if let Some(started) = started {
+        crate::sql_profile::record_phase(
+            crate::sql_profile::Phase::PhysicalPlanning,
+            started.elapsed(),
+        );
+    }
+    stream_adapted_input_plan(plan, task_ctx)
 }
 
 async fn create_or_rebind_physical_plan(
@@ -310,6 +334,35 @@ async fn collect_adapted_input_plan(
         batches.extend(partition_batches);
     }
     Ok(batches)
+}
+
+#[cfg(feature = "storage-benches")]
+fn stream_adapted_input_plan(
+    plan: Arc<dyn ExecutionPlan>,
+    task_ctx: Arc<TaskContext>,
+) -> Result<SendableRecordBatchStream> {
+    let partition_count = plan.output_partitioning().partition_count();
+    if partition_count == 0 {
+        return internal_err!("execution plan exposes no output partitions");
+    }
+    if partition_count == 1 {
+        return plan.execute(0, task_ctx);
+    }
+
+    // Preserve Lix's serial partition semantics and defer even construction of
+    // each child stream until the flattened stream needs that partition.
+    // Dropping early therefore leaves later partitions unexecuted, not merely
+    // unpolled.
+    let schema = plan.schema();
+    let streams = stream::iter(0..partition_count).then(move |partition| {
+        let plan = Arc::clone(&plan);
+        let task_ctx = Arc::clone(&task_ctx);
+        async move { plan.execute(partition, task_ctx) }
+    });
+    Ok(Box::pin(RecordBatchStreamAdapter::new(
+        schema,
+        streams.try_flatten(),
+    )))
 }
 
 pub(crate) fn adapt_runtime_plan(plan: Arc<dyn ExecutionPlan>) -> Result<Arc<dyn ExecutionPlan>> {

--- a/packages/lix/src/sql_profile.rs
+++ b/packages/lix/src/sql_profile.rs
@@ -4,7 +4,7 @@ use std::cell::RefCell;
 use std::future::Future;
 use std::time::Duration;
 
-use crate::{ExecuteResult, LixError};
+use crate::LixError;
 
 tokio::task_local! {
     static ACTIVE_PROFILE: RefCell<SqlReadProfile>;
@@ -33,6 +33,17 @@ pub struct SqlReadProfile {
     /// it is never set by the production result path.
     pub result_count_only_rows: u64,
     pub result_count_only_batches: u64,
+    /// Number of public rows consumed while the profile scope was active.
+    pub result_rows_consumed: u64,
+    /// Number of rows materialized into the public `Vec<Row>` representation
+    /// or an owned benchmark scalar row while the profile scope was active.
+    pub result_rows_materialized: u64,
+    /// Number of owned rows retained through the end of result consumption.
+    /// Cursor modes materialize one scalar row at a time but retain none.
+    pub result_rows_retained: u64,
+    /// Checksum of consumed scalar values. This is a benchmark-only
+    /// correctness witness, not a public result API.
+    pub result_checksum: u64,
 }
 
 impl SqlReadProfile {
@@ -94,9 +105,29 @@ pub(crate) fn record_result_count_only(rows: usize, batches: usize) {
     });
 }
 
-pub(crate) async fn scope<F>(future: F) -> (Result<ExecuteResult, LixError>, SqlReadProfile)
+#[cfg(feature = "storage-benches")]
+pub(crate) fn record_result_rows(consumed: usize, materialized: usize, retained: usize) {
+    let _ = ACTIVE_PROFILE.try_with(|profile| {
+        let mut profile = profile.borrow_mut();
+        profile.result_rows_consumed = profile.result_rows_consumed.saturating_add(consumed as u64);
+        profile.result_rows_materialized = profile
+            .result_rows_materialized
+            .saturating_add(materialized as u64);
+        profile.result_rows_retained = profile.result_rows_retained.saturating_add(retained as u64);
+    });
+}
+
+#[cfg(feature = "storage-benches")]
+pub(crate) fn record_result_checksum(checksum: u64) {
+    let _ = ACTIVE_PROFILE.try_with(|profile| {
+        let mut profile = profile.borrow_mut();
+        profile.result_checksum = profile.result_checksum.wrapping_add(checksum);
+    });
+}
+
+pub(crate) async fn scope<T, F>(future: F) -> (Result<T, LixError>, SqlReadProfile)
 where
-    F: Future<Output = Result<ExecuteResult, LixError>>,
+    F: Future<Output = Result<T, LixError>>,
 {
     let started = std::time::Instant::now();
     let (result, mut profile) = ACTIVE_PROFILE
@@ -113,6 +144,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::ExecuteResult;
     use crate::{Memory, Value, engine::Engine};
 
     #[tokio::test]
@@ -242,5 +274,81 @@ mod tests {
             + profile.arrow_execution
             + profile.public_result_materialization;
         assert!(disjoint_phase_sum <= profile.total);
+    }
+
+    #[tokio::test]
+    async fn live_profile_early_drop_stops_before_later_datafusion_partition() {
+        let storage = Memory::default();
+        Engine::initialize(storage.clone())
+            .await
+            .expect("profile cancellation storage should initialize");
+        let engine = Engine::new(storage)
+            .await
+            .expect("profile cancellation engine should open");
+        let session = engine
+            .open_workspace_session()
+            .await
+            .expect("profile cancellation session should open");
+
+        for table in ["sql_profile_cancel_a", "sql_profile_cancel_b"] {
+            let schema = serde_json::json!({
+                "x-lix-key": table,
+                "x-lix-primary-key": ["/id"],
+                "type": "object",
+                "properties": {
+                    "id": { "type": "string" },
+                    "ordinal": { "type": "integer" },
+                    "payload": { "type": "string" }
+                },
+                "required": ["id", "ordinal", "payload"],
+                "additionalProperties": false
+            });
+            session
+                .execute(
+                    "INSERT INTO lix_registered_schema (value) VALUES (lix_json($1))",
+                    &[Value::Text(schema.to_string())],
+                )
+                .await
+                .expect("profile cancellation schema should register");
+        }
+        session
+            .execute(
+                "INSERT INTO sql_profile_cancel_a (id, ordinal, payload) VALUES \
+                 ('row-00000000', 0, 'payload-00000000'), \
+                 ('row-00000001', 1, 'payload-00000001'), \
+                 ('row-00000002', 2, 'payload-00000002'), \
+                 ('row-00000003', 3, 'payload-00000003')",
+                &[],
+            )
+            .await
+            .expect("first cancellation partition should seed");
+        session
+            .execute(
+                "INSERT INTO sql_profile_cancel_b (id, ordinal, payload) VALUES \
+                 ('row-00000004', 4, 'payload-00000004'), \
+                 ('row-00000005', 5, 'payload-00000005'), \
+                 ('row-00000006', 6, 'payload-00000006'), \
+                 ('row-00000007', 7, 'payload-00000007')",
+                &[],
+            )
+            .await
+            .expect("second cancellation partition should seed");
+
+        let profile = session
+            .execute_result_streaming_profiled(
+                "SELECT id, ordinal, payload FROM sql_profile_cancel_a \
+                 UNION ALL SELECT id, ordinal, payload FROM sql_profile_cancel_b",
+                &[],
+                "live",
+                Some(1),
+            )
+            .await
+            .expect("live cancellation profile should execute");
+
+        assert_eq!(profile.result_rows_consumed, 1);
+        assert_eq!(profile.result_rows_materialized, 1);
+        assert_eq!(profile.result_rows_retained, 0);
+        assert_eq!(profile.scan_rows, 4);
+        assert!(profile.scan_batches > 0);
     }
 }

--- a/packages/lix/src/tracked_state/mod.rs
+++ b/packages/lix/src/tracked_state/mod.rs
@@ -113,15 +113,16 @@ pub(crate) use storage::{
 };
 #[cfg(test)]
 pub(crate) use tree::test_gc_leaf_chunk;
+#[cfg(test)]
+pub(crate) use types::TrackedStateCommitRootParent;
 pub(crate) use types::TrackedStateRootId;
 pub(crate) use types::{COMMIT_STATE_MAX_REPLAY_BYTES, COMMIT_STATE_MAX_REPLAY_DEPTH};
 pub(crate) use types::{
     ColumnarMutationPartSet, CommitDeltaLifecycleSummary, CommitStateManifest,
     CommitStateMutationInventory, CommitStateReplayDebt, MaterializedTrackedStateRow,
     TrackedStateBaseCoordinate, TrackedStateCommitDeltaRef, TrackedStateCommitRoot,
-    TrackedStateCommitRootParent, TrackedStateDeltaRef, TrackedStateFilter, TrackedStateIndexValue,
-    TrackedStateReadColumns, TrackedStateRootMutationRef, TrackedStateScanRequest,
-    TrackedStateSingleStringReplacementRef,
+    TrackedStateDeltaRef, TrackedStateFilter, TrackedStateIndexValue, TrackedStateReadColumns,
+    TrackedStateRootMutationRef, TrackedStateScanRequest, TrackedStateSingleStringReplacementRef,
 };
 pub(crate) use types::{TrackedStateKey, TrackedStateKeyRef};
 
@@ -129,6 +130,7 @@ pub(crate) use types::{TrackedStateKey, TrackedStateKeyRef};
 /// tracked-state roots. This is deliberately a read-only maintenance helper:
 /// the returned hashes are a rebuildable sweep inventory, never serving
 /// authority or a replacement for the immutable root metadata.
+#[allow(dead_code)]
 pub(crate) async fn collect_reachable_tree_chunk_hashes<S>(
     store: &S,
     roots: &[TrackedStateRootId],

--- a/scripts/profile_sql_streaming_matrix.sh
+++ b/scripts/profile_sql_streaming_matrix.sh
@@ -1,0 +1,170 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$repo_dir"
+
+rows="${LIX_SQL_PROFILE_ROWS:-32768}"
+repetitions="${LIX_SQL_PROFILE_REPETITIONS:-5}"
+warmups="${LIX_SQL_PROFILE_WARMUPS:-1}"
+limit="${LIX_SQL_PROFILE_EARLY_LIMIT:-100}"
+
+build_log="$(mktemp)"
+trap 'rm -f "$build_log"' EXIT
+
+cargo bench -p lix \
+  --no-default-features \
+  --features storage-benches \
+  --bench profile_sql_result_streaming \
+  --no-run >"$build_log" 2>&1
+
+bench_bin="$(sed -nE \
+  's#.*\((target/release/deps/profile_sql_result_streaming-[^)]*)\).*#\1#p' \
+  "$build_log" | tail -1)"
+if [[ -z "$bench_bin" ]]; then
+    bench_bin="$(rg --files target/release/deps \
+        | rg '/profile_sql_result_streaming-[[:alnum:]]+$' \
+        | tail -1)"
+fi
+if [[ -z "$bench_bin" || ! -x "$bench_bin" ]]; then
+    printf 'could not locate compiled benchmark binary\n' >&2
+    exit 1
+fi
+
+printf '%s\n' \
+  'scenario,rep,rows,limit,wall_median_us,profile_total_us,arrow_execution_us,public_result_materialization_us,scan_rows,scan_batches,result_rows_consumed,result_rows_materialized,result_rows_retained,result_checksum,max_rss_bytes'
+
+scenarios=(
+    fixture_only
+    full_all
+    full_early
+    collected_all
+    collected_early
+    live_all
+    live_early
+    count_all
+)
+
+kv() {
+    local key="$1"
+    local line="$2"
+    sed -n "s/.* ${key}=\([^ ]*\).*/\1/p" <<<"$line"
+}
+
+rss_bytes() {
+    local time_output="$1"
+    local value
+    if rg -q 'Maximum resident set size' "$time_output"; then
+        value="$(awk '/Maximum resident set size/ {print $NF; exit}' "$time_output")"
+    else
+        value="$(awk '/maximum resident set size/ {print $1; exit}' "$time_output")"
+    fi
+    if [[ -z "$value" ]]; then
+        printf 'could not parse maximum RSS from %s\n' "$time_output" >&2
+        exit 1
+    fi
+    if rg -qi 'resident set size \(kbytes\)' "$time_output"; then
+        printf '%s\n' "$((value * 1024))"
+    else
+        printf '%s\n' "$value"
+    fi
+}
+
+for ((rep = 1; rep <= repetitions; rep++)); do
+    order="$(python3 - <<'PY'
+import random
+
+cases = [
+    "fixture_only",
+    "full_all",
+    "full_early",
+    "collected_all",
+    "collected_early",
+    "live_all",
+    "live_early",
+    "count_all",
+]
+random.shuffle(cases)
+print(" ".join(cases))
+PY
+)"
+
+    for scenario in $order; do
+        case "$scenario" in
+            fixture_only)
+                mode=fixture_only
+                row_limit=all
+                ;;
+            full_all)
+                mode=full
+                row_limit=all
+                ;;
+            full_early)
+                mode=full
+                row_limit="$limit"
+                ;;
+            collected_early)
+                mode=stream
+                row_limit="$limit"
+                ;;
+            collected_all)
+                mode=stream
+                row_limit=all
+                ;;
+            live_all)
+                mode=live
+                row_limit=all
+                ;;
+            live_early)
+                mode=live
+                row_limit="$limit"
+                ;;
+            count_all)
+                mode=count_only
+                row_limit=all
+                ;;
+            *)
+                printf 'unknown scenario: %s\n' "$scenario" >&2
+                exit 1
+                ;;
+        esac
+
+        output_file="$(mktemp)"
+        time_file="$(mktemp)"
+        trap 'rm -f "$output_file" "$time_file" "$build_log"' EXIT
+
+        /usr/bin/time -l env \
+            LIX_SQL_PROFILE_RESULT_MODE="$mode" \
+            LIX_SQL_PROFILE_ROW_LIMIT="$row_limit" \
+            LIX_SQL_PROFILE_ROWS="$rows" \
+            LIX_SQL_PROFILE_ROUNDS=1 \
+            LIX_SQL_PROFILE_WARMUPS="$warmups" \
+            "$bench_bin" >"$output_file" 2>"$time_file"
+
+        profile_line="$(rg '^execute_result_streaming_profile ' "$output_file" | tail -1)"
+        if [[ -z "$profile_line" ]]; then
+            printf 'benchmark produced no profile line for %s\n' "$scenario" >&2
+            exit 1
+        fi
+
+        printf '%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s\n' \
+            "$scenario" \
+            "$rep" \
+            "$rows" \
+            "$row_limit" \
+            "$(kv wall_median_us "$profile_line")" \
+            "$(kv profile_total_us "$profile_line")" \
+            "$(kv arrow_execution_us "$profile_line")" \
+            "$(kv public_result_materialization_us "$profile_line")" \
+            "$(kv scan_rows "$profile_line")" \
+            "$(kv scan_batches "$profile_line")" \
+            "$(kv result_rows_consumed "$profile_line")" \
+            "$(kv result_rows_materialized "$profile_line")" \
+            "$(kv result_rows_retained "$profile_line")" \
+            "$(kv result_checksum "$profile_line")" \
+            "$(rss_bytes "$time_file")"
+
+        rm -f "$output_file" "$time_file"
+    done
+done


### PR DESCRIPTION
## Summary

- preserve the current eager `ExecuteResult` API while adding a benchmark-only pull-based DataFusion result primitive
- bind live batch results and the internal batch-to-row cursor to the read-session lifetime so borrowed storage reads cannot escape
- compare eager rows, collected Arrow batches, live batches, and count-only execution with distinct scanned/consumed/materialized/retained counters
- add a fresh-process randomized RSS/checksum matrix, including fixture-only and collected-all controls
- add synthetic cursor-drop coverage and a real SessionContext/DataFusion early-drop test

No JS, N-API, WASM, worker, remote, CLI, filesystem, storage, or integration-suite API migration is included.

## Validation

- `cargo check -p lix --no-default-features --features storage-benches --bench profile_sql_result_streaming`
- `cargo test -p lix --no-default-features --features storage-benches live_profile_early_drop_stops_before_later_datafusion_partition --lib`
- `cargo test -p lix --no-default-features batch_cursor --lib`
- `cargo test -p lix --no-default-features --features storage-benches sql_profile::tests --lib`
- reduced fresh-process eight-scenario matrix at 1,024 rows

The reduced matrix showed the intended causal separation for a 100-row early stop: eager and collected modes scanned all 1,024 rows, while live mode scanned one 128-row batch. Checksums over all projected values passed. RSS is reported against a fixture-only process baseline and remains a process high-water measurement.