### PR TITLE
Fix tracked-root repair coverage under shuffled filesystem writes

### DIFF
--- a/packages/lix/src/tracked_state/commit_root_rebuild.rs
+++ b/packages/lix/src/tracked_state/commit_root_rebuild.rs
@@ -1,4 +1,4 @@
-use std::collections::{BTreeMap, HashSet};
+use std::collections::HashSet;
 
 use crate::LixError;
 use crate::changelog::{
@@ -7,6 +7,7 @@ use crate::changelog::{
 use crate::common::LixTimestamp;
 use crate::entity_pk::EntityPk;
 use crate::storage_adapter::{StorageAdapterRead, StorageWriteSet};
+use crate::tracked_state::TrackedStateDeltaRef;
 use crate::tracked_state::context::{
     TrackedStateContext, TrackedStateRootRebuilder, TrackedStateTransientRebuildState,
     TrackedStateWriteReport, TrackedStateWriter,
@@ -15,9 +16,6 @@ use crate::tracked_state::storage;
 use crate::tracked_state::tree::TrackedStateTree;
 use crate::tracked_state::types::{
     TrackedStateCommitRoot, TrackedStateRootId, TrackedStateTreeScanRequest,
-};
-use crate::tracked_state::{
-    TrackedStateDeltaRef, TrackedStateKeyRef, TrackedStateRootMutationRef, encode_key_ref,
 };
 
 /// Owned delta used only by explicit commit-root rebuild.
@@ -362,95 +360,14 @@ where
         .collect::<Vec<_>>();
     let commit_id = plan.commit_id.to_string();
     let parent_commit_id = plan.parent_commit_id.map(|commit_id| commit_id.to_string());
-    let strictly_sorted = plan.deltas.windows(2).all(|pair| {
-        pair[0]
-            .schema_key
-            .cmp(&pair[1].schema_key)
-            .then_with(|| pair[0].file_id.cmp(&pair[1].file_id))
-            .then_with(|| pair[0].entity_pk.cmp(&pair[1].entity_pk))
-            .is_lt()
-    });
-    if strictly_sorted && plan.deltas.len() >= 2 {
-        let first = &plan.deltas[0];
-        let first_key = encode_key_ref(TrackedStateKeyRef {
-            schema_key: &first.schema_key,
-            file_id: first.file_id.as_deref(),
-            entity_pk: &first.entity_pk,
-        });
-        let file_delete_cascades = plan
-            .deltas
-            .iter()
-            .filter(|delta| delta.schema_key == "lix_file_descriptor" && delta.deleted)
-            .map(|delta| {
-                Ok((
-                    delta.entity_pk.as_single_string_owned().map_err(|error| {
-                        LixError::new(
-                            LixError::CODE_INTERNAL_ERROR,
-                            format!("file descriptor tombstone has invalid identity: {error}"),
-                        )
-                    })?,
-                    TrackedStateDeltaRef {
-                        schema_key: &delta.schema_key,
-                        file_id: delta.file_id.as_deref(),
-                        entity_pk: &delta.entity_pk,
-                        change_id: delta.change_id,
-                        commit_id: delta.commit_id,
-                        deleted: true,
-                        created_at: delta.created_at,
-                        updated_at: delta.updated_at,
-                    },
-                ))
-            })
-            .collect::<Result<BTreeMap<_, _>, LixError>>()?;
-        if let Some(report) = writer
-            .try_stage_bulk_parent_root_from_ordered_mutations(
-                &commit_id,
-                parent_commit_id.as_deref(),
-                deltas.len(),
-                &first_key,
-                &file_delete_cascades,
-                RebuildRootMutations::new(&deltas),
-            )
-            .await?
-        {
-            return Ok(report);
-        }
-    }
+    // Explicit repair must replay the same identity-aware path used by the
+    // canonical root writer. The ordered bulk merge is a publication
+    // optimization whose parent-stream assumptions are not sufficient for a
+    // repair frontier containing shuffled filesystem lifecycle changes.
     writer
         .stage_commit_root(&commit_id, parent_commit_id.as_deref(), deltas)
         .await
 }
-
-struct RebuildRootMutations<'iter, 'delta> {
-    inner: std::slice::Iter<'iter, TrackedStateDeltaRef<'delta>>,
-}
-
-impl<'iter, 'delta> RebuildRootMutations<'iter, 'delta> {
-    fn new(deltas: &'iter [TrackedStateDeltaRef<'delta>]) -> Self {
-        Self {
-            inner: deltas.iter(),
-        }
-    }
-}
-
-impl<'delta> Iterator for RebuildRootMutations<'_, 'delta> {
-    type Item = Result<TrackedStateRootMutationRef<'delta>, LixError>;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        self.inner.next().copied().map(|delta| {
-            Ok(TrackedStateRootMutationRef {
-                delta,
-                require_absence: false,
-            })
-        })
-    }
-
-    fn size_hint(&self) -> (usize, Option<usize>) {
-        self.inner.size_hint()
-    }
-}
-
-impl ExactSizeIterator for RebuildRootMutations<'_, '_> {}
 
 fn first_parent_commit_id(commit: &CommitRecord) -> Option<CommitId> {
     commit.parent_commit_ids.first().copied()


### PR DESCRIPTION
## Root cause

Explicit tracked-root repair reused the ordered bulk publication merge. Under deterministic timestamp shuffling and a filesystem lifecycle frontier, that specialized parent stream could omit the current commit's file-descriptor winner. The subsequent coverage audit correctly rejected the rebuilt root.

## Fix

Route explicit rebuild plans through the identity-aware canonical root writer and delete the repair-only ordered-mutation adapter. Normal publication remains unchanged.

## Evidence

- Baseline: [main run 31140702959](https://github.com/opral/lix/actions/runs/31140702959), [Cargo Test job 92749799738](https://github.com/opral/lix/actions/runs/31140702959/job/92749799738)
- Failure: `filesystem_fuzz::randomized_filesystem_mutations_preserve_bytes_and_atomicity_tracked_state_rebuild`, seed 0, step 25; rebuilt root omitted current `lix_file_descriptor` change
- Local non-native checks: `cargo fmt --all -- --check`; `git diff --check`
- Full native matrix: delegated to hosted CI because this host is resource constrained
