### PR TITLE
Fix release workspace dependency version sync

### DIFF
--- a/scripts/release.mjs
+++ b/scripts/release.mjs
@@ -173,7 +173,28 @@ export function updateCargoToml(root, version) {
 		/(\[workspace\.package\][\s\S]*?\nversion\s*=\s*")[^"]+(")/,
 		`$1${version}$2`,
 	);
+	text = updateWorkspaceVersionedDependencyRequirements(root, text, version);
 	writeText(root, "Cargo.toml", text);
+}
+
+function updateWorkspaceVersionedDependencyRequirements(root, text, version) {
+	return text.replace(
+		/\[workspace\.dependencies\][\s\S]*?(?=\n\[|$)/,
+		(dependencies) =>
+			dependencies.replace(/^[A-Za-z0-9_-]+\s*=\s*\{[^}\n]*\}$/gm, (line) => {
+				const path = line.match(/\bpath\s*=\s*"([^"]+)"/)?.[1];
+				if (!path || !/\bversion\s*=\s*"[^"]+"/.test(line)) return line;
+				const manifestPath = join(root, path, "Cargo.toml");
+				if (!existsSync(manifestPath)) return line;
+				const packageSection = readFileSync(manifestPath, "utf8").match(
+					/\[package\]([\s\S]*?)(?=\n\[|$)/,
+				)?.[1];
+				if (!packageSection || !/^version\.workspace\s*=\s*true\s*$/m.test(packageSection)) {
+					return line;
+				}
+				return line.replace(/(\bversion\s*=\s*")[^"]+(")/, `$1${version}$2`);
+			}),
+	);
 }
 
 export function updatePackageVersion(root, version) {

--- a/scripts/release.test.mjs
+++ b/scripts/release.test.mjs
@@ -166,6 +166,30 @@ test("updateCargoToml leaves independently released Rust packages untouched", ()
 	assert.match(readFileSync(join(root, "packages", "server-protocol", "Cargo.toml"), "utf8"), /lix = \{ path = "\.\.\/lix", version = "0\.6\.2"/);
 });
 
+test("updateCargoToml updates requirements for workspace-versioned packages", () => {
+	const root = mkdtempSync(join(tmpdir(), "lix-release-test-"));
+	mkdirSync(join(root, "packages", "plugin-api"), { recursive: true });
+	mkdirSync(join(root, "packages", "lix"), { recursive: true });
+	writeFileSync(
+		join(root, "Cargo.toml"),
+		`[workspace.package]\nversion = "0.6.2"\n\n[workspace.dependencies]\nlix_plugin_api = { path = "packages/plugin-api", version = "0.6.2" }\nlix = { path = "packages/lix", version = "0.6.2" }\n`,
+	);
+	writeFileSync(
+		join(root, "packages", "plugin-api", "Cargo.toml"),
+		`[package]\nname = "lix_plugin_api"\nversion.workspace = true\n`,
+	);
+	writeFileSync(
+		join(root, "packages", "lix", "Cargo.toml"),
+		`[package]\nname = "lix"\nversion = "0.6.2"\n`,
+	);
+
+	updateCargoToml(root, "0.7.0");
+
+	const rootCargoToml = readFileSync(join(root, "Cargo.toml"), "utf8");
+	assert.match(rootCargoToml, /lix_plugin_api = \{ path = "packages\/plugin-api", version = "0\.7\.0"/);
+	assert.match(rootCargoToml, /lix = \{ path = "packages\/lix", version = "0\.6\.2"/);
+});
+
 test("updatePackageVersion pins native optional dependencies", () => {
 	const root = mkdtempSync(join(tmpdir(), "lix-release-test-"));
 	mkdirSync(join(root, "packages", "js-sdk"), { recursive: true });


### PR DESCRIPTION
## Summary

- keep `[workspace.dependencies]` requirements aligned when their path package explicitly declares `version.workspace = true`
- leave independently versioned `lix`, storage, and server packages untouched
- add focused regression coverage for co-released versus fixed-version path packages

## Causal reproduction

Exact base: `b82b3c771dbbe9792b4036376bb64ee9f298e958`

`node scripts/prepare-release.mjs` exited 1 because the script advanced `[workspace.package]` to `0.11.0` but left `lix_plugin_api = ^0.10.0`; Cargo found only the local `lix_plugin_api 0.11.0`. The same failure occurred in inherited Release PR runs `31143471055` and `31144198948`.

The root workspace package version is authoritative. The fix inspects each referenced path manifest and updates only dependency requirements whose package inherits that version.

## Verification

- `node --test scripts/release.test.mjs`: 11 passed
- `node --check scripts/release.mjs`
- `node --check scripts/release.test.mjs`
- `cargo fmt --all -- --check`
- `git diff --check`
- exact `node scripts/prepare-release.mjs`: exit 0, `version=0.11.0`, `type=minor`
- generated-state `cargo metadata --format-version 1 --no-deps`: pass
- generated-state `cargo package --locked -p lix_plugin_api --allow-dirty --list`: contains `wit/lix-plugin.wit`
- generated-state `cargo check --locked -p lix_plugin_api`: pass at `lix_plugin_api v0.11.0`

## Frozen provenance

- base: `b82b3c771dbbe9792b4036376bb64ee9f298e958`
- head: `66f2cb44256420174f29741d6d588f78a7a91d1c`
- tree: `037e853755f8e70d35eb420e42e0b4027c63b563`
- normalized base..head diff SHA-256: `a793da189575de2ec21c450ab1d5f887b028092d03913c48e231f4bfa933b14c`

## Integration hold

Do not merge this PR ahead of P0 #1234. Keep this head frozen until coordinator release so #1234 does not need another avoidable CI refresh.