### PR TITLE
remove dead JSON cold scalar state

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3356,6 +3356,7 @@ dependencies = [
  "parking_lot",
  "paste",
  "plugin_csv",
+ "plugin_json",
  "ruzstd",
  "serde",
  "serde_json",

--- a/packages/lix/Cargo.toml
+++ b/packages/lix/Cargo.toml
@@ -105,6 +105,7 @@ paste = "1"
 tempfile = "3"
 tokio = { version = "1", features = ["rt", "macros", "sync", "time"] }
 plugin_csv = { path = "../../plugins/csv", lib = true, artifact = "cdylib", target = "wasm32-wasip2" }
+plugin_json = { path = "../../plugins/json", lib = true, artifact = "cdylib", target = "wasm32-wasip2" }
 wasm-encoder = "0.248"
 wit-parser = "0.247"
 

--- a/packages/lix/src/default_wasm_runtime/component_runtime.rs
+++ b/packages/lix/src/default_wasm_runtime/component_runtime.rs
@@ -4330,6 +4330,229 @@ fn component_transition_limits(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use lix::wasm::{
+        WasmByteSource, WasmEntityPage, WasmEntitySource, WasmFileDescriptor, WasmInputSplice,
+        WasmPluginSelection,
+    };
+
+    #[derive(Clone, Debug)]
+    struct JsonTestSource(Vec<u8>);
+
+    impl WasmByteSource for JsonTestSource {
+        fn len(&self) -> u64 {
+            self.0.len() as u64
+        }
+
+        fn read(&self, offset: u64, length: u32) -> Result<Vec<u8>, LixError> {
+            let start = usize::try_from(offset)
+                .map_err(|_| component_error("JSON test source offset exceeds usize"))?;
+            let end = start
+                .checked_add(length as usize)
+                .ok_or_else(|| component_error("JSON test source range overflowed"))?;
+            self.0
+                .get(start..end)
+                .map(<[u8]>::to_vec)
+                .ok_or_else(|| component_error("JSON test source range is out of bounds"))
+        }
+    }
+
+    struct JsonTestEntitySource {
+        entities: Option<Vec<WasmEntity<WasmHostBytes>>>,
+    }
+
+    impl WasmEntitySource for JsonTestEntitySource {
+        fn next_page(&mut self, _max_bytes: u32) -> Result<Option<WasmEntityPage>, LixError> {
+            Ok(self
+                .entities
+                .take()
+                .map(|entities| WasmEntityPage { entities }))
+        }
+    }
+
+    fn assert_json_full_fallback_state_only(checkpoint: &WasmDocumentCheckpoint) {
+        let root = checkpoint
+            .downcast_ref::<ArenaRoot>()
+            .expect("default runtime checkpoint should contain an arena root");
+        let keys = root.state.keys().collect::<Vec<_>>();
+        assert_eq!(
+            keys.len(),
+            3,
+            "cold fallback should retain only namespace, fallback manifest, and one fallback page"
+        );
+        assert!(keys.contains(&b"json/fallback-entities".as_slice()));
+        assert!(
+            keys.iter()
+                .any(|key| key.starts_with(b"json/fallback-entity-page/"))
+        );
+        assert!(!keys.contains(&b"json/scalar-index".as_slice()));
+        assert!(
+            !keys
+                .iter()
+                .any(|key| key.starts_with(b"json/scalar-index-page/"))
+        );
+        assert!(!keys.iter().any(|key| key.starts_with(b"json/scalar-page/")));
+    }
+
+    #[tokio::test]
+    async fn json_cold_full_fallback_checkpoint_omits_scalar_state() {
+        let wasm = std::fs::read(env!("CARGO_CDYLIB_FILE_PLUGIN_JSON_plugin_json"))
+            .expect("read JSON component");
+        let factory = crate::default_wasm_runtime()
+            .expect("default Wasm runtime")
+            .compile_component(wasm, WasmLimits::default())
+            .await
+            .expect("compile JSON component");
+        let descriptor = WasmFileDescriptor {
+            path: Some("/direct-cold-fallback.json".to_owned()),
+            plugin: WasmPluginSelection {
+                plugin_key: "plugin_json".to_owned(),
+                generation: "direct".to_owned(),
+            },
+        };
+        let creates = WasmCreateContext { high: 13, low: 17 };
+        let before = br#"{"a":"one","b":"two"}"#.to_vec();
+        let cold_after = br#"{"a":"ONE","b":"two"}"#.to_vec();
+        let entities = vec![
+            WasmEntity {
+                key: WasmEntityKey::from_owned_parts("json_root", vec!["root".to_owned()]),
+                snapshot_content: WasmHostBytes::Inline(Bytes::from_static(
+                    br#"{"id":"root","kind":"object"}"#,
+                )),
+            },
+            WasmEntity {
+                key: WasmEntityKey::from_owned_parts(
+                    "json_object_member",
+                    vec!["root".to_owned(), "a".to_owned()],
+                ),
+                snapshot_content: WasmHostBytes::Inline(Bytes::from_static(
+                    br#"{"parent_id":"root","key":"a","order_key":"40","kind":"string","scalar_json":"\"one\""}"#,
+                )),
+            },
+            WasmEntity {
+                key: WasmEntityKey::from_owned_parts(
+                    "json_object_member",
+                    vec!["root".to_owned(), "b".to_owned()],
+                ),
+                snapshot_content: WasmHostBytes::Inline(Bytes::from_static(
+                    br#"{"parent_id":"root","key":"b","order_key":"80","kind":"string","scalar_json":"\"two\""}"#,
+                )),
+            },
+        ];
+        let limits = WasmTransitionLimits::default();
+        let mut actor = factory.instantiate_actor().await.unwrap();
+        let cold = actor
+            .cold_file_changed(
+                limits,
+                WasmColdFileUpdate {
+                    before_descriptor: descriptor.clone(),
+                    after_descriptor: descriptor.clone(),
+                    before: Some(Arc::new(JsonTestSource(before))),
+                    edits: vec![WasmInputSplice {
+                        offset: 6,
+                        delete_len: 3,
+                        insert: WasmInputBytes::Inline(b"ONE".to_vec()),
+                    }],
+                    after: Arc::new(JsonTestSource(cold_after.clone())),
+                    creates,
+                    entities: Box::new(JsonTestEntitySource {
+                        entities: Some(entities),
+                    }),
+                },
+            )
+            .await
+            .expect("cold full-fallback transition should succeed");
+        while actor
+            .next_change_page(cold.transition, cold.changes, 2 * 1024 * 1024)
+            .await
+            .unwrap()
+            .is_some()
+        {}
+        actor.finish_transition(cold.transition).await.unwrap();
+
+        let checkpoint = actor
+            .checkpoint_document(cold.document)
+            .await
+            .unwrap()
+            .expect("component actor should expose a checkpoint");
+        assert_json_full_fallback_state_only(&checkpoint);
+        let durable = checkpoint
+            .durable_checkpoint()
+            .expect("small JSON checkpoint should be durable");
+        let decoded = WasmDurableDocumentCheckpoint::decode(durable.bytes().as_ref())
+            .expect("durable JSON checkpoint should decode");
+        actor.retire().await.unwrap();
+
+        let mut reopened = factory.instantiate_actor().await.unwrap();
+        let document = reopened
+            .restore_durable_document(&decoded, &cold_after)
+            .await
+            .expect("durable fallback checkpoint should reopen against accepted bytes");
+        let successor_after = br#"{"a":"ONE","b":"TWO"}"#.to_vec();
+        let edit_offset = cold_after
+            .windows(3)
+            .position(|window| window == b"two")
+            .expect("fixture should contain edited scalar");
+        let successor = reopened
+            .file_changed(
+                document,
+                limits,
+                WasmFileUpdate {
+                    before_descriptor: descriptor.clone(),
+                    after_descriptor: descriptor,
+                    before: Arc::new(JsonTestSource(cold_after)),
+                    edits: vec![WasmInputSplice {
+                        offset: edit_offset as u64,
+                        delete_len: 3,
+                        insert: WasmInputBytes::Inline(b"TWO".to_vec()),
+                    }],
+                    after: Arc::new(JsonTestSource(successor_after.clone())),
+                    creates,
+                },
+            )
+            .await
+            .expect("full-path successor should read fallback state");
+        let mut changes = Vec::new();
+        while let Some(page) = reopened
+            .next_change_page(successor.transition, successor.changes, 2 * 1024 * 1024)
+            .await
+            .unwrap()
+        {
+            changes.extend(page.changes.changes);
+        }
+        let counters = reopened
+            .finish_transition(successor.transition)
+            .await
+            .unwrap();
+        assert!(
+            counters.state_read_calls >= 3,
+            "reopened successor should read namespace, fallback manifest, and fallback page"
+        );
+        assert_eq!(changes.len(), 1);
+        let WasmEntityChange::Upsert { entity, effect } = &changes[0] else {
+            panic!("successor should upsert the edited JSON member");
+        };
+        assert_eq!(*effect, WasmChangeEffect::Content);
+        assert_eq!(entity.key.schema_key.as_str(), "json_object_member");
+        assert_eq!(entity.key.entity_pk[1].as_str(), "b");
+        let WasmGuestBytes::Inline(snapshot) = &entity.snapshot_content else {
+            panic!("small JSON snapshot should remain inline");
+        };
+        let snapshot: serde_json::Value =
+            serde_json::from_slice(snapshot).expect("successor snapshot should be JSON");
+        assert_eq!(snapshot["scalar_json"], r#""TWO""#);
+        assert_eq!(
+            serde_json::from_slice::<serde_json::Value>(&successor_after).unwrap(),
+            serde_json::json!({"a": "ONE", "b": "TWO"})
+        );
+
+        let successor_checkpoint = reopened
+            .checkpoint_document(successor.document)
+            .await
+            .unwrap()
+            .expect("successor should expose a checkpoint");
+        assert_json_full_fallback_state_only(&successor_checkpoint);
+        reopened.retire().await.unwrap();
+    }
 
     #[test]
     fn plugin_lifecycle_boundary_requires_a_resolved_path() {

--- a/packages/lix/src/default_wasm_runtime/component_runtime.rs
+++ b/packages/lix/src/default_wasm_runtime/component_runtime.rs
@@ -4330,10 +4330,7 @@ fn component_transition_limits(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use lix::wasm::{
-        WasmByteSource, WasmEntityPage, WasmEntitySource, WasmFileDescriptor, WasmInputSplice,
-        WasmPluginSelection,
-    };
+    use lix::wasm::{WasmByteSource, WasmFileDescriptor, WasmInputSplice, WasmPluginSelection};
 
     #[derive(Clone, Debug)]
     struct JsonTestSource(Vec<u8>);
@@ -4360,12 +4357,15 @@ mod tests {
         entities: Option<Vec<WasmEntity<WasmHostBytes>>>,
     }
 
-    impl WasmEntitySource for JsonTestEntitySource {
-        fn next_page(&mut self, _max_bytes: u32) -> Result<Option<WasmEntityPage>, LixError> {
+    impl lix::wasm::WasmEntitySource for JsonTestEntitySource {
+        fn next_page(
+            &mut self,
+            _max_bytes: u32,
+        ) -> Result<Option<lix::wasm::WasmEntityPage>, LixError> {
             Ok(self
                 .entities
                 .take()
-                .map(|entities| WasmEntityPage { entities }))
+                .map(|entities| lix::wasm::WasmEntityPage { entities }))
         }
     }
 

--- a/plugins/json/src/lib.rs
+++ b/plugins/json/src/lib.rs
@@ -76,7 +76,6 @@ impl sdk::Plugin for JsonPlugin {
                 .entity_records()
                 .map_err(sdk::Error::invalid_input)?,
         )?;
-        store_scalar_state(sink, &document)?;
         emit_changes(changes.into_iter().map(Ok), update.creates, sink)?;
         Ok(())
     }


### PR DESCRIPTION
## What changed

- Remove the dead `store_scalar_state(sink, &document)?` call from JSON `cold_file_changed` after the full fallback entity state has been emitted.
- Add a real Wasm runtime regression that:
  - forces the cold full-fallback route;
  - asserts the checkpoint contains the fallback manifest/page and no scalar manifest/index/page;
  - decodes and restores the durable checkpoint into a fresh actor;
  - applies a successor full-path byte edit and verifies the emitted JSON semantic upsert;
  - rechecks that the successor checkpoint remains fallback-only.

## Root cause

The cold path wrote `FALLBACK_ENTITIES_STATE` and then also wrote the scalar index. The only scalar reader is gated on `FALLBACK_ENTITIES_STATE` being absent, while fallback successors delete or bypass scalar state. The cold scalar state therefore had no reachable reader.

Current and proposed complexity are both O(N). For the focused two-member fixture, private state drops from six entries (namespace + fallback manifest/page + scalar manifest/index page/scalar page) to three. No backend-write counter is exposed by this harness; the regression asserts the exact retained state-key count instead.

## Provenance

- Original base: `b82b3c771dbbe9792b4036376bb64ee9f298e958`
- Final integrated base: `e7897b8a869b267b126e08b7150e986c1ffe1a9c`
- Head: `fb7c58b9befdae281113da6d49a7420abad49f91`
- Tree: `a84ac6a374bdacabd4b0e714dc05dec9b83736e2`
- Focused diff SHA-256: `cff9786aed8c08daec796ca58421c6a518c637c914afc6ab81166b831d1aeb75`

Main was merged exactly once at final integration, with no conflicts.

## Local validation

Green on the integrated source:

- `cargo test -p plugin_json --lib -j1` — 5 passed
- `cargo check -p plugin_json --lib -j1`
- `cargo clippy -p plugin_json --all-targets -j1 -- -D warnings`
- `cargo metadata --no-deps --format-version 1`
- `cargo fmt --all -- --check`
- `git diff --check origin/main...HEAD`

Host boundaries:

- The focused `lix_tests` e2e target hit its 20-minute cap while serialized `librocksdb-sys` C++ compilation was still active; no test binary ran.
- The lighter `lix` unit target hit its 10-minute cap while compiling Rust dependencies; no test binary ran.
- Neither route was retried.

## Hosted CI

The first hosted head `20b323824e8e09887d1a92981aeb45a5052ceccf` exposed two `unused_qualifications` errors in Cargo Clippy because the new test imported names already used fully qualified by an existing test. Commit `fb7c58b9befdae281113da6d49a7420abad49f91` removes those shared imports and fully qualifies only the new helper.

Exact-head run [31147336857](https://github.com/opral/lix/actions/runs/31147336857) is 8/8 green. Cargo Test passed in 9m56s and compiled/executed the real-Wasm restore/edit regression; Cargo Clippy, all three cargo-config platforms, Changelog, JS Browser, and JS Native also passed.