### PR TITLE
Fail closed on invalid client-state headers

### DIFF
--- a/packages/js-sdk/src/client-state.ts
+++ b/packages/js-sdk/src/client-state.ts
@@ -356,7 +356,9 @@ function decodeStoredClientState(
 	let parsed: unknown;
 	try {
 		parsed = JSON.parse(
-			new TextDecoder().decode(snapshot.subarray(header.length)),
+			new TextDecoder("utf-8", { fatal: true }).decode(
+				snapshot.subarray(header.length),
+			),
 		);
 	} catch (error) {
 		throw new Error("Stored Lix client state is invalid", { cause: error });

--- a/packages/js-sdk/src/client-state.ts
+++ b/packages/js-sdk/src/client-state.ts
@@ -350,10 +350,7 @@ function decodeStoredClientState(
 		snapshot.length < header.length ||
 		header.some((byte, index) => snapshot[index] !== byte)
 	) {
-		// Remote storage previously contained a full Lix snapshot. Backward
-		// compatibility is intentionally not provided: start with empty state and
-		// replace it on the next write.
-		return new Map();
+		throw new Error("Stored Lix client state header is invalid");
 	}
 
 	let parsed: unknown;

--- a/packages/js-sdk/src/stored-client-state.test.ts
+++ b/packages/js-sdk/src/stored-client-state.test.ts
@@ -1,13 +1,11 @@
-import { expect, test } from "vitest";
+import { expect, test, vi } from "vitest";
 import { openStoredClientState } from "./client-state.js";
 import type { LixSnapshotStorage } from "./types.js";
 
-test("stored client state replaces an unsupported legacy snapshot", async () => {
-	let snapshot: Uint8Array | undefined = new TextEncoder().encode(
-		"SQLite format 3",
-	);
+test("stored client state persists an absent snapshot and survives reopen", async () => {
+	let snapshot: Uint8Array | undefined;
 	const storage: LixSnapshotStorage = {
-		load: async () => snapshot,
+		load: async () => snapshot?.slice(),
 		save: async (_namespace, nextSnapshot) => {
 			snapshot = nextSnapshot.slice();
 		},
@@ -17,9 +15,11 @@ test("stored client state replaces an unsupported legacy snapshot", async () => 
 		storage,
 		namespace: "remote:https://example.com/workspace",
 	});
-	expect(first.get("legacy")).toBeUndefined();
+	expect(first.get("atelier")).toBeUndefined();
 	await first.set("atelier", { focusedPanel: "right" });
 	await first.close();
+	expect(new TextDecoder().decode(snapshot).startsWith("lix-client-state-v1\n"))
+		.toBe(true);
 
 	const reopened = await openStoredClientState({
 		storage,
@@ -27,4 +27,48 @@ test("stored client state replaces an unsupported legacy snapshot", async () => 
 	});
 	expect(reopened.get("atelier")).toEqual({ focusedPanel: "right" });
 	await reopened.close();
+});
+
+test("stored client state rejects a missing v1 header without resetting storage", async () => {
+	const original = new TextEncoder().encode(
+		'[["preserved",{"focusedPanel":"right"}]]',
+	);
+	const snapshot = original.slice();
+	const save = vi.fn(async () => undefined);
+	const storage: LixSnapshotStorage = {
+		load: async () => snapshot,
+		save,
+	};
+
+	await expect(
+		openStoredClientState({
+			storage,
+			namespace: "remote:https://example.com/workspace",
+		}),
+	).rejects.toThrow("Stored Lix client state header is invalid");
+	expect(save).not.toHaveBeenCalled();
+	expect(snapshot).toEqual(original);
+});
+
+test("stored client state rejects a corrupt v1 header without resetting storage", async () => {
+	const corrupt = new TextEncoder().encode(
+		'lix-client-state-v1\n[["preserved",true]]',
+	);
+	corrupt[4] ^= 0xff;
+	const original = corrupt.slice();
+	const snapshot = corrupt.slice();
+	const save = vi.fn(async () => undefined);
+	const storage: LixSnapshotStorage = {
+		load: async () => snapshot,
+		save,
+	};
+
+	await expect(
+		openStoredClientState({
+			storage,
+			namespace: "remote:https://example.com/workspace",
+		}),
+	).rejects.toThrow("Stored Lix client state header is invalid");
+	expect(save).not.toHaveBeenCalled();
+	expect(snapshot).toEqual(original);
 });

--- a/packages/js-sdk/src/stored-client-state.test.ts
+++ b/packages/js-sdk/src/stored-client-state.test.ts
@@ -72,3 +72,27 @@ test("stored client state rejects a corrupt v1 header without resetting storage"
 	expect(save).not.toHaveBeenCalled();
 	expect(snapshot).toEqual(original);
 });
+
+test("stored client state rejects invalid utf-8 without resetting storage", async () => {
+	const prefix = new TextEncoder().encode('lix-client-state-v1\n[["key","');
+	const suffix = new TextEncoder().encode('"]]');
+	const snapshot = new Uint8Array(prefix.length + 1 + suffix.length);
+	snapshot.set(prefix);
+	snapshot[prefix.length] = 0xff;
+	snapshot.set(suffix, prefix.length + 1);
+	const original = snapshot.slice();
+	const save = vi.fn(async () => undefined);
+	const storage: LixSnapshotStorage = {
+		load: async () => snapshot,
+		save,
+	};
+
+	await expect(
+		openStoredClientState({
+			storage,
+			namespace: "remote:https://example.com/workspace",
+		}),
+	).rejects.toThrow("Stored Lix client state is invalid");
+	expect(save).not.toHaveBeenCalled();
+	expect(snapshot).toEqual(original);
+});


### PR DESCRIPTION
## What changed

- Remove the sole decoder branch that treated every present snapshot without the exact `lix-client-state-v1\n` header as empty state.
- Reject missing, truncated, or mismatched headers before constructing client state.
- Decode the v1 payload as strict UTF-8 so malformed persisted bytes cannot be replaced with U+FFFD and accepted as valid JSON.
- Replace the legacy-reset regression with focused absent-state, invalid-header, invalid-UTF-8, byte-preservation, and valid-v1 reopen coverage.

## Why

`LixSnapshotStorage.load(namespace)` is the authority for client-local bytes. `undefined` means no snapshot exists; any returned `Uint8Array` is authoritative persisted state. The previous fallback silently conflated legacy, truncated, and corrupt bytes with an empty snapshot and overwrote them on the next mutation.

Independent review of the first head found that non-fatal `TextDecoder` behavior accepted invalid UTF-8 inside an otherwise valid JSON string, then allowed `openLix()` to reach the remote server. The corrected decoder uses `fatal: true` and reports the existing invalid-state error.

This is an intentional hard cut. There is no compatibility decoder, migration, reset fallback, or dual behavior.

## Observable impact

- `undefined` still initializes empty client state.
- Every present non-v1 or corrupt payload rejects `openLix()` before opening the remote session.
- Rejected bytes are not saved, reset, or mutated.
- Valid v1 snapshots retain their existing persistence and reopen behavior.

## Provenance

- Original base: `e7897b8a869b267b126e08b7150e986c1ffe1a9c`
- Initially reviewed head: `ecb5461b64999ebef837d9f99df460dc6c1bb2cb`
- Corrected pre-integration head: `c6f5bb157453cbabc2e2a3df33210e2bffbedbc4`
- Final integrated base: `e70b4cf738d456efc0f4993f84f685ab49f064d6`
- Final head: `06baa13f056cacef98d8a09ccc83e37415097bc2`
- Tree: `218e2535a1328ad2a05ec0aab449fb727f34990a`
- Focused diff hash: `8c641518e9cc3dddbaa680d43190cd9d8d33a8e0`

Current main was merged exactly once at final integration with no conflicts.

## Validation

Independent review on the final integrated head:

- `npx vitest run src/stored-client-state.test.ts` — 4 passed
- Public `openLix()` boundary smoke — 9 invalid payload classes each rejected after one load with zero server fetches, zero saves, and byte-identical persisted input
- `cargo fmt --all -- --check`
- `git diff --check origin/main...HEAD`

The scripts-disabled low-memory local setup could not run standalone `npm run typecheck` because generated `#worker-factory` and `#binding` declarations were intentionally absent. Pre-integration corrected-head run [31148476539](https://github.com/opral/lix/actions/runs/31148476539) was 8/8 green. Final exact-head run [31149007173](https://github.com/opral/lix/actions/runs/31149007173) is the required refreshed qualification.

Ordered predecessor #1237 release workflows [31148771903](https://github.com/opral/lix/actions/runs/31148771903) and [31148771913](https://github.com/opral/lix/actions/runs/31148771913) are terminal green; post-merge CI [31148771933](https://github.com/opral/lix/actions/runs/31148771933) must also be terminal green before merge.