### PR TITLE
perf(lix): route branch ID reads to point lookups

### DIFF
--- a/packages/lix/src/sql2/providers/branch.rs
+++ b/packages/lix/src/sql2/providers/branch.rs
@@ -8,7 +8,7 @@ use datafusion::arrow::record_batch::RecordBatch;
 use datafusion::common::{DataFusionError, Result, ScalarValue};
 use datafusion::execution::context::ExecutionProps;
 use datafusion::logical_expr::expr::InList;
-use datafusion::logical_expr::{BinaryExpr, Expr, Operator};
+use datafusion::logical_expr::{BinaryExpr, Expr, Operator, TableProviderFilterPushDown};
 use datafusion::physical_expr::PhysicalExpr;
 use futures_util::FutureExt;
 use serde_json::Value as JsonValue;
@@ -108,14 +108,23 @@ impl TableSpec for BranchSpec {
         Some(self)
     }
 
+    fn filter_pushdown(&self, filter: &Expr) -> TableProviderFilterPushDown {
+        if exact_canonical_branch_ids_from_filters(std::slice::from_ref(filter)).is_some() {
+            TableProviderFilterPushDown::Exact
+        } else {
+            TableProviderFilterPushDown::Unsupported
+        }
+    }
+
     async fn plan_scan(
         &self,
         projection: Option<&Vec<usize>>,
-        _filters: &[Expr],
+        filters: &[Expr],
         _limit: Option<usize>,
         _props: &ExecutionProps,
     ) -> Result<PlannedScan> {
         let schema = projected_schema(&lix_branch_schema(), projection);
+        let descriptor_scope = BranchDescriptorScope::from_read_filters(filters);
         Ok(PlannedScan {
             schema: Arc::clone(&schema),
             ordering: None,
@@ -126,11 +135,17 @@ impl TableSpec for BranchSpec {
                     Arc::clone(&self.branch_ref),
                     schema,
                     self.head_read_strategy,
+                    descriptor_scope,
                 ),
-                |(live_state, branch_ref, schema, head_read_strategy)| async move {
-                    let rows = load_branch_rows(live_state, branch_ref, head_read_strategy)
-                        .await
-                        .map_err(lix_error_to_datafusion_error)?;
+                |(live_state, branch_ref, schema, head_read_strategy, descriptor_scope)| async move {
+                    let rows = load_branch_rows_scoped(
+                        live_state,
+                        branch_ref,
+                        head_read_strategy,
+                        descriptor_scope,
+                    )
+                    .await
+                    .map_err(lix_error_to_datafusion_error)?;
                     LIX_BRANCH_COLS
                         .build(schema, &rows)
                         .map_err(branch_batch_error)
@@ -413,7 +428,7 @@ impl TableSpec for BranchSpec {
 impl BranchSpec {
     /// Unprojected row source used as the UPDATE/DELETE candidate set.
     fn write_row_source(&self, filters: &[Expr]) -> super::spec::RowSource {
-        let descriptor_scope = BranchDescriptorScope::from_write_filters(filters);
+        let descriptor_scope = BranchDescriptorScope::from_filters(filters);
         row_source(
             (
                 Arc::clone(&self.live_state),
@@ -677,8 +692,12 @@ enum BranchDescriptorScope {
 }
 
 impl BranchDescriptorScope {
-    fn from_write_filters(filters: &[Expr]) -> Self {
-        exact_branch_ids_from_write_filters(filters).map_or(Self::All, Self::Ids)
+    fn from_read_filters(filters: &[Expr]) -> Self {
+        exact_canonical_branch_ids_from_filters(filters).map_or(Self::All, Self::Ids)
+    }
+
+    fn from_filters(filters: &[Expr]) -> Self {
+        exact_branch_ids_from_filters(filters).map_or(Self::All, Self::Ids)
     }
 }
 
@@ -755,13 +774,13 @@ async fn load_branch_rows_scoped(
     }
 }
 
-fn exact_branch_ids_from_write_filters(filters: &[Expr]) -> Option<BTreeSet<String>> {
+fn exact_branch_ids_from_filters(filters: &[Expr]) -> Option<BTreeSet<String>> {
     if filters.is_empty() {
         return None;
     }
     let mut ids = None::<BTreeSet<String>>;
     for filter in filters {
-        let filter_ids = exact_branch_ids_from_write_filter(filter)?;
+        let filter_ids = exact_branch_ids_from_filter(filter)?;
         ids = Some(match ids {
             Some(ids) => ids.intersection(&filter_ids).cloned().collect(),
             None => filter_ids,
@@ -770,11 +789,18 @@ fn exact_branch_ids_from_write_filters(filters: &[Expr]) -> Option<BTreeSet<Stri
     ids
 }
 
-fn exact_branch_ids_from_write_filter(filter: &Expr) -> Option<BTreeSet<String>> {
+fn exact_canonical_branch_ids_from_filters(filters: &[Expr]) -> Option<BTreeSet<String>> {
+    let ids = exact_branch_ids_from_filters(filters)?;
+    ids.iter()
+        .all(|id| EntityPk::uuid_from_canonical(id).is_ok())
+        .then_some(ids)
+}
+
+fn exact_branch_ids_from_filter(filter: &Expr) -> Option<BTreeSet<String>> {
     match filter {
         Expr::BinaryExpr(binary_expr) if binary_expr.op == Operator::And => {
-            let left = exact_branch_ids_from_write_filter(&binary_expr.left)?;
-            let right = exact_branch_ids_from_write_filter(&binary_expr.right)?;
+            let left = exact_branch_ids_from_filter(&binary_expr.left)?;
+            let right = exact_branch_ids_from_filter(&binary_expr.right)?;
             Some(left.intersection(&right).cloned().collect())
         }
         // Even an OR made only from id equalities falls back to the full
@@ -1453,6 +1479,51 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn branch_read_id_filter_routes_descriptor_and_head_point_reads() {
+        let (mut spec, live_state, branch_ref) = routing_spec();
+        spec.head_read_strategy = BranchHeadReadStrategy::Batch;
+        let filter = eq_filter("id", "01920000-0000-7000-8000-0000000000b1");
+        assert_eq!(
+            spec.filter_pushdown(&filter),
+            TableProviderFilterPushDown::Exact
+        );
+
+        let planned = spec
+            .plan_scan(None, &[filter], None, &ExecutionProps::new())
+            .await
+            .unwrap();
+        let batch = planned.source.load_single_batch().await.unwrap();
+
+        assert_eq!(batch.num_rows(), 1);
+        let requests = live_state.requests.lock().unwrap();
+        assert_eq!(requests.len(), 1);
+        assert_eq!(
+            requests[0].filter.entity_pks,
+            vec![
+                EntityPk::uuid_from_canonical("01920000-0000-7000-8000-0000000000b1")
+                    .expect("fixture branch ID")
+            ]
+        );
+        assert_eq!(
+            branch_ref.point_read_ids.lock().unwrap().as_slice(),
+            &["01920000-0000-7000-8000-0000000000b1".to_string()]
+        );
+    }
+
+    #[test]
+    fn branch_read_filter_pushdown_rejects_non_id_and_noncanonical_filters() {
+        let (spec, _, _) = routing_spec();
+        assert_eq!(
+            spec.filter_pushdown(&eq_filter("name", "Branch A")),
+            TableProviderFilterPushDown::Unsupported
+        );
+        assert_eq!(
+            spec.filter_pushdown(&eq_filter("id", "not-a-branch-id")),
+            TableProviderFilterPushDown::Unsupported
+        );
+    }
+
+    #[tokio::test]
     async fn branch_write_or_filter_falls_back_to_full_candidate_source() {
         let (spec, live_state, branch_ref) = routing_spec();
         let filter = Expr::BinaryExpr(BinaryExpr::new(
@@ -1489,7 +1560,7 @@ mod tests {
             false,
         ));
         assert_eq!(
-            exact_branch_ids_from_write_filters(&[in_filter]),
+            exact_branch_ids_from_filters(&[in_filter]),
             Some(BTreeSet::from([
                 "01920000-0000-7000-8000-0000000000a1".to_string(),
                 "01920000-0000-7000-8000-0000000000b1".to_string(),
@@ -1501,12 +1572,9 @@ mod tests {
             Operator::Eq,
             Box::new(column("name")),
         ));
+        assert_eq!(exact_branch_ids_from_filters(&[expression_filter]), None);
         assert_eq!(
-            exact_branch_ids_from_write_filters(&[expression_filter]),
-            None
-        );
-        assert_eq!(
-            exact_branch_ids_from_write_filters(&[eq_filter("name", "Branch A")]),
+            exact_branch_ids_from_filters(&[eq_filter("name", "Branch A")]),
             None
         );
     }

--- a/packages/lix/tests/integration/sql/lix_branch.rs
+++ b/packages/lix/tests/integration/sql/lix_branch.rs
@@ -42,6 +42,71 @@ simulation_test!(lix_branch_lists_descriptors_with_refs, |sim| async move {
 });
 
 simulation_test!(
+    lix_branch_exact_id_read_filters_preserve_semantics,
+    |sim| async move {
+        let engine = sim.boot_engine().await;
+        let session = sim.wrap_session(
+            engine
+                .open_session("ffffffff-ffff-7fff-bfff-ffffffffffff")
+                .await
+                .expect("global session should open"),
+            &engine,
+        );
+        let global_id = "ffffffff-ffff-7fff-bfff-ffffffffffff";
+        let main_id = sim.main_branch_id().to_string();
+
+        let exact = session
+            .execute(
+                "SELECT id, name FROM lix_branch WHERE id = ?",
+                &[Value::Text(main_id.clone())],
+            )
+            .await
+            .expect("exact branch ID should read");
+        assert_eq!(exact.len(), 1);
+        assert_eq!(
+            exact.rows()[0].values(),
+            &[
+                Value::Text(main_id.clone()),
+                Value::Text("main".to_string())
+            ]
+        );
+
+        let in_list = session
+            .execute(
+                "SELECT id FROM lix_branch WHERE id IN (?, ?) ORDER BY id",
+                &[
+                    Value::Text(global_id.to_string()),
+                    Value::Text(main_id.clone()),
+                ],
+            )
+            .await
+            .expect("branch ID list should read");
+        assert_eq!(in_list.len(), 2);
+        assert_eq!(
+            in_list
+                .rows()
+                .iter()
+                .map(|row| row.get::<String>("id").expect("id should be text"))
+                .collect::<Vec<_>>(),
+            {
+                let mut ids = vec![global_id.to_string(), main_id];
+                ids.sort();
+                ids
+            }
+        );
+
+        let invalid = session
+            .execute(
+                "SELECT id FROM lix_branch WHERE id = ?",
+                &[Value::Text("not-a-branch-id".to_string())],
+            )
+            .await
+            .expect("a noncanonical branch ID should remain a no-match query");
+        assert_eq!(invalid.len(), 0);
+    }
+);
+
+simulation_test!(
     lix_branch_count_star_handles_empty_projection,
     |sim| async move {
         let engine = sim.boot_engine().await;


### PR DESCRIPTION
## What changed

Route canonical exact-ID filters on `lix_branch` through the existing authoritative descriptor and branch-head point readers. Non-ID, expression, OR, and noncanonical-ID predicates retain the existing scan and residual-filter path.

Adds provider routing tests and a public SQL regression covering parameterized equality, `IN`, and invalid-ID no-match behavior.

## Why

An exact-ID branch read currently scans all branch descriptors and, once there are more than two descriptors, all branch heads. That makes a point read O(branches) in latency, allocations, and logical backend bytes.

This cut changes exact-ID reads from O(B) descriptor/head scans to O(1) point reads without adding a cache, authority, persisted format, or fallback path. Branch delete, GC/reclamation, merge-base ancestry, and storage ownership are untouched.

## Exact-SHA measurements

Base: `38848ef89534ad0dfb2ae30f3c34d888f219e0d3`
Head: `809dbbbc2e0cb65a1e5750934bb77ca7ebb3e9f8`

Matched 50-query, setup-excluded exact-ID reads:

| Adapter | Branches | Base ns/op | Head ns/op | Improvement | Allocation improvement | Logical-byte improvement |
| --- | ---: | ---: | ---: | ---: | ---: | ---: |
| RocksDB | 100 | 437,368 | 227,393 | 48.0% | 63.5% | 97.7% |
| RocksDB | 1,000 | 1,296,462 | 177,545 | 86.3% | 92.6% | 99.8% |
| SlateDB | 100 | 442,574 | 209,123 | 52.8% | 75.3% | 97.7% |
| SlateDB | 1,000 | 2,163,040 | 163,883 | 92.4% | 95.5% | 99.8% |

Backend scans fall from 100 scans / 10,200 or 100,200 entries to zero; the head performs 450 logical gets for 50 queries. CPU ticks fall 67–90%. RSS high-water is neutral-to-lower, SlateDB native object I/O remains zero for these cache-resident reads, and steady-state disk growth is unchanged. Repeated create/switch/checkpoint/reopen controls remained within 3.5% of exact base on both adapters.

## Validation

- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo clippy -p lix --lib -- -D warnings`
- `cargo test -p lix sql2::providers::branch::tests --lib` (11 passed)
- `cargo test -p lix --test integration sql::lix_branch` (21 passed)
- Exact-SHA RocksDB and SlateDB lifecycle benchmarks at 100 and 1,000 branches
