### PR TITLE
Fix certified replacement coverage for later deletes

### DIFF
--- a/packages/engine-benchmarks/Cargo.toml
+++ b/packages/engine-benchmarks/Cargo.toml
@@ -85,6 +85,11 @@ path = "tests/movie_workspace_qualification.rs"
 required-features = ["storage-benches", "slatedb"]
 
 [[test]]
+name = "certified_replacement_delete_reopen"
+path = "tests/certified_replacement_delete_reopen.rs"
+required-features = ["rocksdb", "slatedb"]
+
+[[test]]
 name = "tpch_overlay_helpers"
 path = "tests/tpch_overlay_helpers.rs"
 

--- a/packages/engine-benchmarks/tests/certified_replacement_delete_reopen.rs
+++ b/packages/engine-benchmarks/tests/certified_replacement_delete_reopen.rs
@@ -1,0 +1,171 @@
+use std::path::Path;
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use lix::storage::Storage;
+use lix::{PreparedDmlParameterBatch, Value, open_lix};
+use lix_storage_rocksdb::RocksDB;
+use lix_storage_slatedb::SlateDB;
+
+const ROW_COUNT: usize = 512;
+const SCHEMA_KEY: &str = "certified_replacement_delete_probe";
+
+#[async_trait]
+trait ReopenStorage: Storage + Clone + Send + Sync + Sized + 'static {
+    fn open(path: &Path) -> Self;
+    async fn flush(&self);
+}
+
+#[async_trait]
+impl ReopenStorage for RocksDB {
+    fn open(path: &Path) -> Self {
+        Self::open(path).expect("open RocksDB fixture")
+    }
+
+    async fn flush(&self) {
+        self.flush().expect("flush RocksDB fixture");
+    }
+}
+
+#[async_trait]
+impl ReopenStorage for SlateDB {
+    fn open(path: &Path) -> Self {
+        Self::open(path).expect("open SlateDB fixture")
+    }
+
+    async fn flush(&self) {
+        self.flush().await.expect("flush SlateDB fixture");
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn rocksdb_reopens_after_certified_replacement_delete_checkpoint() {
+    replacement_delete_checkpoint_reopens::<RocksDB>().await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn slatedb_reopens_after_certified_replacement_delete_checkpoint() {
+    replacement_delete_checkpoint_reopens::<SlateDB>().await;
+}
+
+async fn replacement_delete_checkpoint_reopens<S: ReopenStorage>() {
+    let temp = tempfile::tempdir().expect("create durable replacement fixture");
+    let path = temp.path().join("database");
+    {
+        let storage = S::open(&path);
+        let lix = open_lix()
+            .with_storage(storage.clone())
+            .await
+            .expect("initialize durable Lix");
+        register_schema(&lix).await;
+
+        let inserts = PreparedDmlParameterBatch::from_rows((0..ROW_COUNT).map(|index| {
+            vec![
+                Value::Text(format!("/{index:04}")),
+                Value::Text(format!(r#"{{"generation":0,"index":{index}}}"#)),
+            ]
+        }))
+        .expect("build insert parameter batch");
+        let inserted = lix
+            .execute_prepared_dml_batch(
+                Arc::from(format!(
+                    "INSERT INTO {SCHEMA_KEY} (path, value) VALUES ($1, lix_json($2))"
+                )),
+                inserts,
+            )
+            .await
+            .expect("insert complete collection");
+        assert_eq!(
+            inserted
+                .iter()
+                .map(|result| result.rows_affected())
+                .sum::<u64>(),
+            ROW_COUNT as u64
+        );
+
+        let replacements = PreparedDmlParameterBatch::from_rows((0..ROW_COUNT).map(|index| {
+            vec![
+                Value::Text(format!(r#"{{"generation":1,"index":{index}}}"#)),
+                Value::Text(format!("/{index:04}")),
+            ]
+        }))
+        .expect("build replacement parameter batch");
+        let replaced = lix
+            .execute_prepared_dml_batch(
+                Arc::from(format!(
+                    "UPDATE {SCHEMA_KEY} SET value = lix_json($1) WHERE path = $2"
+                )),
+                replacements,
+            )
+            .await
+            .expect("replace complete collection");
+        assert_eq!(
+            replaced
+                .iter()
+                .map(|result| result.rows_affected())
+                .sum::<u64>(),
+            ROW_COUNT as u64
+        );
+
+        assert_eq!(
+            lix.execute(&format!("DELETE FROM {SCHEMA_KEY}"), &[])
+                .await
+                .expect("delete replacement collection")
+                .rows_affected(),
+            ROW_COUNT as u64
+        );
+        lix.create_checkpoint()
+            .await
+            .expect("checkpoint deleted replacement collection");
+        assert_collection_empty(&lix).await;
+
+        lix.close().await.expect("close durable Lix");
+        drop(lix);
+        storage.flush().await;
+    }
+
+    let storage = S::open(&path);
+    let lix = open_lix()
+        .with_storage(storage.clone())
+        .await
+        .expect("reopen durable Lix");
+    assert_collection_empty(&lix).await;
+    let checkpoints = lix
+        .execute("SELECT COUNT(*) AS count FROM lix_checkpoint", &[])
+        .await
+        .expect("read checkpoints after reopen");
+    assert!(checkpoints.rows()[0].get::<i64>("count").unwrap() >= 1);
+    lix.close().await.expect("close reopened durable Lix");
+    drop(lix);
+    storage.flush().await;
+}
+
+async fn register_schema<S: Storage + Clone + Send + Sync + 'static>(lix: &lix::Lix<S>) {
+    let schema = serde_json::json!({
+        "x-lix-key": SCHEMA_KEY,
+        "x-lix-primary-key": ["/path"],
+        "type": "object",
+        "properties": {
+            "path": { "type": "string" },
+            "value": {
+                "type": ["object", "array", "string", "number", "integer", "boolean", "null"]
+            }
+        },
+        "required": ["path", "value"],
+        "additionalProperties": false
+    });
+    lix.execute(
+        "INSERT INTO lix_registered_schema (value) VALUES (lix_json($1))",
+        &[Value::Text(schema.to_string())],
+    )
+    .await
+    .expect("register replacement schema");
+}
+
+async fn assert_collection_empty<S: Storage + Clone + Send + Sync + 'static>(lix: &lix::Lix<S>) {
+    let count = lix
+        .execute(&format!("SELECT COUNT(*) AS count FROM {SCHEMA_KEY}"), &[])
+        .await
+        .expect("read replacement collection count");
+    assert_eq!(count.rows()[0].get::<i64>("count").unwrap(), 0);
+}

--- a/packages/lix/src/tracked_state/scoped_current_state.rs
+++ b/packages/lix/src/tracked_state/scoped_current_state.rs
@@ -9,7 +9,7 @@ use crate::storage_adapter::{StorageAdapterRead, StorageWriteSet};
 use crate::tracked_state::current_state_envelope::scoped_range_part_from_current_state_descriptor;
 use crate::tracked_state::scoped_range::{
     ScopedRangeCoverageMarker, ScopedRangeRoot, load_scoped_range_coverage,
-    stage_replace_scoped_range, stage_scoped_range_tree,
+    load_scoped_range_coverage_with_staged, stage_replace_scoped_range, stage_scoped_range_tree,
 };
 use crate::tracked_state::types::{
     CommitDeltaReplacementScope, CommitStateManifest, CommitStateMutationInventory,
@@ -695,7 +695,7 @@ pub(super) async fn stage_current_state_scoped_ranges_from_topology_refs(
         });
     }
     let touched_scope_filter =
-        extend_touched_scope_filter(inherited_scope_filter, filter_touched.as_deref())?;
+        extend_touched_scope_filter(inherited_scope_filter.clone(), filter_touched.as_deref())?;
 
     if inventory.replacement_generation.is_some() {
         let root = stage_complete_replacement_scoped_range_root(
@@ -779,6 +779,35 @@ pub(super) async fn stage_current_state_scoped_ranges_from_topology_refs(
     }
     let mut tree = parent_root.tree.clone();
     for scope in touched {
+        let prefix =
+            crate::tracked_state::current_state_envelope::current_state_scope_prefix(&scope)?;
+        if load_scoped_range_coverage_with_staged(store, writes, &tree, &prefix)
+            .await?
+            .is_none()
+        {
+            if !touched_scope_filter_proves_absent(&inherited_scope_filter, &scope)? {
+                return Ok(CertifiedCommitStatePhysicalPublication {
+                    write_set_id: writes.identity(),
+                    commit_id,
+                    selected_source_commit_id,
+                    root: None,
+                    touched_scope_filter,
+                });
+            }
+            tree = stage_replace_scoped_range(
+                store,
+                writes,
+                &tree,
+                ScopedRangeCoverageMarker {
+                    scope: prefix,
+                    row_count: 0,
+                    part_count: 0,
+                },
+                Vec::new(),
+            )
+            .await?
+            .root;
+        }
         let transient = CurrentStateScopedRangeRoot {
             tree,
             serving_base_commit_id: parent_root.serving_base_commit_id,
@@ -892,9 +921,9 @@ mod tests {
     use crate::tracked_state::codec::encode_key_ref;
     use crate::tracked_state::scoped_range::{
         ScopedRangeCoverageMarker, ScopedRangePart, ScopedRangePartPayload, ScopedRangePrefix,
-        plan_scoped_range_part_splice, route_scoped_range_point, scan_scoped_range_interval,
-        snapshot_staged_scoped_range_nodes, stage_scoped_range_part_splice,
-        stage_scoped_range_tree, validate_scoped_range_tree,
+        load_scoped_range_coverage_with_staged, plan_scoped_range_part_splice,
+        route_scoped_range_point, scan_scoped_range_interval, snapshot_staged_scoped_range_nodes,
+        stage_scoped_range_part_splice, stage_scoped_range_tree, validate_scoped_range_tree,
     };
     use crate::tracked_state::storage::{
         CertifiedCommitStateTopologyParent, CommitDeltaReplacementGeneration,
@@ -1273,6 +1302,107 @@ mod tests {
             vec![(0, 0, 1, true), (0, 2, 1, true), (1, 0, 1, true)],
             "sparse delete/insert must retain two immutable source slices and write only the insert",
         );
+    }
+
+    #[tokio::test]
+    async fn sparse_new_scope_requires_cumulative_absence_proof() {
+        let storage = StorageAdapter::new(Memory::new());
+        let parent_id = CommitId::with_change_address_space(uuid::Uuid::from_u128(
+            0x0199_3050_0000_7000_8000_0000_0001_0000,
+        ));
+        let parent = publish_replacement_scope(&storage, None, parent_id, "covered-scope").await;
+        let child_id = CommitId::with_change_address_space(uuid::Uuid::from_u128(
+            0x0199_3050_0000_7000_8000_0000_0002_0000,
+        ));
+        let entity = EntityPk::single("entity-000");
+        let created_at = LixTimestamp::from_unix_millis_utc_lossy(10);
+        let updated_at = LixTimestamp::from_unix_millis_utc_lossy(20);
+        let change = TrackedStateCommitDeltaRef {
+            delta: TrackedStateDeltaRef {
+                schema_key: "certified-new-scope",
+                file_id: None,
+                entity_pk: &entity,
+                change_id: ChangeId::for_test_label("certified-new-scope-change"),
+                commit_id: child_id,
+                deleted: false,
+                created_at,
+                updated_at,
+            },
+            snapshot: JsonSlotRef::Inline("{\"version\":1}"),
+            metadata: JsonSlotRef::None,
+            origin_key: None,
+            base_coordinate: None,
+            authored: true,
+        };
+        let read = storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("new-scope read should open");
+
+        let mut unproven_parent = (*parent).clone();
+        unproven_parent.touched_scope_filter = CommitStateTouchedScopeFilter::default();
+        let mut fallback_writes = storage.new_write_set();
+        let fallback_stage = stage_ordered_addressable_commit_deltas(
+            &mut fallback_writes,
+            [Ok(change)].into_iter(),
+            true,
+            false,
+        )
+        .expect("unproven sparse mutation should stage")
+        .expect("unproven sparse mutation should be addressable");
+        let fallback = stage_current_state_scoped_ranges(
+            &read,
+            &mut fallback_writes,
+            &[&unproven_parent],
+            None,
+            Some(&unproven_parent),
+            child_id,
+            crate::ANONYMOUS_ACCOUNT_ID,
+            fallback_stage.mutation_inventory(),
+        )
+        .await
+        .expect("unproven missing scope should fall back without failing the commit");
+        assert!(
+            fallback.root().is_none(),
+            "a missing marker without cumulative absence authority must use canonical replay"
+        );
+
+        let mut certified_writes = storage.new_write_set();
+        let certified_stage = stage_ordered_addressable_commit_deltas(
+            &mut certified_writes,
+            [Ok(change)].into_iter(),
+            true,
+            false,
+        )
+        .expect("certified sparse mutation should stage")
+        .expect("certified sparse mutation should be addressable");
+        let certified = stage_current_state_scoped_ranges_from_published_parent(
+            &read,
+            &mut certified_writes,
+            Some(&parent),
+            child_id,
+            crate::ANONYMOUS_ACCOUNT_ID,
+            certified_stage.mutation_inventory(),
+        )
+        .await
+        .expect("certified absent scope should seed an authenticated marker");
+        let root = certified
+            .root()
+            .expect("certified scope should keep serving root");
+        let new_scope = crate::tracked_state::current_state_envelope::current_state_scope_prefix(
+            &scope("certified-new-scope"),
+        )
+        .unwrap();
+        let marker = load_scoped_range_coverage_with_staged(
+            &read,
+            &certified_writes,
+            &root.tree,
+            &new_scope,
+        )
+        .await
+        .expect("new-scope marker should authenticate")
+        .expect("new-scope marker should exist");
+        assert_eq!((marker.row_count, marker.part_count), (1, 1));
     }
 
     #[tokio::test]

--- a/packages/lix/src/tracked_state/scoped_range.rs
+++ b/packages/lix/src/tracked_state/scoped_range.rs
@@ -1596,6 +1596,23 @@ pub(crate) async fn load_scoped_range_coverage(
     }
 }
 
+/// Resolves one exact marker while accepting immutable nodes staged by the
+/// same physical publication.
+pub(crate) async fn load_scoped_range_coverage_with_staged(
+    store: &(impl StorageAdapterRead + ?Sized),
+    writes: &StorageWriteSet,
+    root: &ScopedRangeRoot,
+    scope: &ScopedRangePrefix,
+) -> Result<Option<ScopedRangeCoverageMarker>, LixError> {
+    match find_exact_with_staged(store, writes, root, &marker_route(scope)).await? {
+        Some(ScopedRangeEntry::Marker(marker)) if marker.scope == *scope => Ok(Some(marker)),
+        Some(ScopedRangeEntry::Marker(_)) | None => Ok(None),
+        Some(ScopedRangeEntry::Part(_)) => {
+            Err(scoped_range_error("scope marker route resolved a part"))
+        }
+    }
+}
+
 /// Returns every part in one exact scope without inventing a sentinel entity
 /// key. The synthetic route kind sorts after all part starts in that scope.
 #[cfg(any(test, feature = "storage-benches"))]
@@ -1951,7 +1968,7 @@ async fn find_exact(
     root: &ScopedRangeRoot,
     route: &ScopedRangeRoute,
 ) -> Result<Option<ScopedRangeEntry>, LixError> {
-    let leaf = load_routed_leaf(store, root, route).await?;
+    let leaf = load_routed_leaf_with_staged(store, None, root, route).await?;
     Ok(leaf
         .entries
         .binary_search_by_key(route, ScopedRangeEntry::route)
@@ -1959,15 +1976,36 @@ async fn find_exact(
         .map(|index| leaf.entries[index].clone()))
 }
 
-async fn load_routed_leaf(
+async fn find_exact_with_staged(
     store: &(impl StorageAdapterRead + ?Sized),
+    writes: &StorageWriteSet,
+    root: &ScopedRangeRoot,
+    route: &ScopedRangeRoute,
+) -> Result<Option<ScopedRangeEntry>, LixError> {
+    let leaf = load_routed_leaf_with_staged(store, Some(writes), root, route).await?;
+    Ok(leaf
+        .entries
+        .binary_search_by_key(route, ScopedRangeEntry::route)
+        .ok()
+        .map(|index| leaf.entries[index].clone()))
+}
+
+async fn load_routed_leaf_with_staged(
+    store: &(impl StorageAdapterRead + ?Sized),
+    writes: Option<&StorageWriteSet>,
     root: &ScopedRangeRoot,
     route: &ScopedRangeRoute,
 ) -> Result<ScopedRangeNode, LixError> {
     let mut node_id = root.root_id;
     let mut expected = None;
     loop {
-        let node = load_node(store, node_id).await?;
+        let node = match writes
+            .map(|writes| staged_node(writes, node_id))
+            .transpose()?
+        {
+            Some(Some(node)) => node,
+            Some(None) | None => load_node(store, node_id).await?,
+        };
         let summary = authenticated_node_summary(&node, node_id)?;
         if let Some(expected) = expected.take() {
             if summary != expected {


### PR DESCRIPTION
## Correctness

A certified complete replacement published an authenticated scoped-range tree for the application collection. A later full DELETE also authors the first `lix_collection_generation` control row. That control scope had no marker because the serving tree is intentionally partial, but sparse publication treated missing coverage as corruption and returned `tracked_state scoped range splice scope has no coverage marker`.

This change authenticates marker presence against persisted and same-write-set scoped-range nodes. When a marker is absent, it seeds an empty scope only if the inherited cumulative touched-scope filter proves that schema family was never authored. If that exact negative proof is unavailable, it drops the rebuildable serving root and leaves canonical replay authoritative.

There is no whole-collection read/rewrite shortcut, compatibility path, legacy format, second authority, or authentication relaxation.

## Scope

- Add one fail-closed staged-node marker lookup.
- Seed a newly authored sparse scope from the existing cumulative absence authority.
- Add a proof-level regression for certified absence versus incomplete authority.
- Add one public RocksDB/SlateDB regression covering certified full replacement -> DELETE -> checkpoint -> close/reopen.

## Complexity and resources

For `T` exact touched scopes and `N` scoped-range nodes, current sparse publication is `O(T log N + changed-part work)`. The proposed path remains the same asymptotic complexity: one authenticated `O(log N)` marker lookup per touched scope and, only for a newly proven-absent scope, one `O(log N)` path copy before the existing sparse splice. Persistent growth is one marker plus path-copied tree nodes for that new scope. It does not materialize or rewrite the existing collection.

## Provenance

- Base: `deea8a4ae9c7a948827dfe9f9a44879910247211`
- Head: `84352df33eda9bac8e341b7343ad4fe4c29096a4`
- Tree: `f417149195f5bba8aa2bdf8c2e2d0a4e94631267`
- Diff SHA-256: `3c7031f26089b2d84f81b163da6afc2730260018255ee80519fefb5580e6e9d6`
- Stable patch ID: `7d72bbfe98b392b79ee7e5dc0f9f0b0a10765351`

## Evidence

- Pre-fix exact `09d08b1c`: public regression failed on both RocksDB and SlateDB at DELETE with the missing-marker error.
- Patched exact current main: RocksDB and SlateDB public replacement/delete/checkpoint/cold-reopen regression 2/2 green.
- Proof-level tracked-state test: certified absence seeds coverage; incomplete authority drops the accelerator.
- Tracked-state namespace: 294 passed, 1 ignored.
- Full all-features integration binary in hosted-like parallel context: 813 passed, 2 ignored, including diff/history/checkpoint/recovery and constraint/corruption/filesystem/merge fuzz.
- Exact filesystem fuzz seed on exact main and patched head: base and tracked-state-rebuild variants green in isolated runs. Hosted main run 31151606003 failed the rebuild variant once; the exact-main isolated control did not reproduce it, while the patched full parallel integration run was green.
- `cargo fmt --all -- --check` and diff check: green.
- Canonical warnings-denied workspace/all-target/all-feature Clippy: green with `-j 1`. The initial parallel local attempt was killed by SIGKILL without diagnostics; serialized rerun preserved the full lint surface.

Independent review is required before merge.