### PR TITLE
perf(lix): retain shared decoded payload owners

### DIFF
--- a/packages/lix/src/transaction/types.rs
+++ b/packages/lix/src/transaction/types.rs
@@ -2381,6 +2381,27 @@ pub(crate) fn canonicalize_transaction_json_batch<'a>(
     slots: impl IntoIterator<Item = &'a mut Option<TransactionJson>>,
     context: &str,
 ) -> Result<(), LixError> {
+    enum DecodedCanonicalValue {
+        Owned(JsonValue),
+        Shared(Arc<JsonValue>),
+    }
+
+    impl DecodedCanonicalValue {
+        fn as_value(&self) -> &JsonValue {
+            match self {
+                Self::Owned(value) => value,
+                Self::Shared(value) => value.as_ref(),
+            }
+        }
+
+        fn into_shared(self) -> Arc<JsonValue> {
+            match self {
+                Self::Owned(value) => Arc::new(value),
+                Self::Shared(value) => value,
+            }
+        }
+    }
+
     let mut slots = slots.into_iter().collect::<Vec<_>>();
     let decoded_count = slots
         .iter()
@@ -2391,6 +2412,7 @@ pub(crate) fn canonicalize_transaction_json_batch<'a>(
         })
         .count();
     let mut values = Vec::with_capacity(decoded_count);
+    let mut all_values_uniquely_owned = true;
     let mut cached_normalized = Vec::with_capacity(decoded_count);
     let mut positions = Vec::with_capacity(decoded_count);
     for (position, slot) in slots.iter_mut().enumerate() {
@@ -2399,7 +2421,13 @@ pub(crate) fn canonicalize_transaction_json_batch<'a>(
         };
         match json.storage {
             TransactionJsonStorage::Decoded { value, normalized } => {
-                let value = Arc::try_unwrap(value).unwrap_or_else(|value| value.as_ref().clone());
+                let value = match Arc::try_unwrap(value) {
+                    Ok(value) => DecodedCanonicalValue::Owned(value),
+                    Err(value) => {
+                        all_values_uniquely_owned = false;
+                        DecodedCanonicalValue::Shared(value)
+                    }
+                };
                 positions.push(position);
                 values.push(value);
                 cached_normalized.push(normalized.into_inner());
@@ -2476,7 +2504,7 @@ pub(crate) fn canonicalize_transaction_json_batch<'a>(
                 .append(cached.as_bytes())
                 .map_err(|failure| canonical_json_arena_error(context, failure))?;
         } else {
-            serde_json::to_writer(&mut normalized, value).map_err(|error| {
+            serde_json::to_writer(&mut normalized, value.as_value()).map_err(|error| {
                 normalized.failure().map_or_else(
                     || {
                         LixError::new(
@@ -2497,16 +2525,51 @@ pub(crate) fn canonicalize_transaction_json_batch<'a>(
         })?;
         offsets.push((start, end));
     }
-    let rows = WasmCanonicalJson::from_batch_parts(
-        values,
-        normalized.into_bytes(),
-        offsets,
-        positions.len(),
-        serialize_count,
-    )?;
-    for ((position, row), expected_row) in positions.into_iter().zip(rows).zip(0..) {
-        debug_assert_eq!(row.row_index(), expected_row);
-        *slots[position] = Some(TransactionJson::from_canonical_batch(row));
+    if all_values_uniquely_owned {
+        let values = values
+            .into_iter()
+            .map(|value| {
+                let DecodedCanonicalValue::Owned(value) = value else {
+                    unreachable!("unique canonicalization retained a shared decoded JSON owner")
+                };
+                value
+            })
+            .collect();
+        let rows = WasmCanonicalJson::from_batch_parts(
+            values,
+            normalized.into_bytes(),
+            offsets,
+            positions.len(),
+            serialize_count,
+        )?;
+        for ((position, row), expected_row) in positions.into_iter().zip(rows).zip(0..) {
+            debug_assert_eq!(row.row_index(), expected_row);
+            *slots[position] = Some(TransactionJson::from_canonical_batch(row));
+        }
+    } else {
+        let normalized =
+            SharedStr::from_utf8(Bytes::from(normalized.into_bytes())).map_err(|_| {
+                LixError::new(
+                    LixError::CODE_UNKNOWN,
+                    format!("{context} canonical JSON batch is not UTF-8"),
+                )
+            })?;
+        for ((position, value), (start, end)) in positions.into_iter().zip(values).zip(offsets) {
+            let normalized = normalized
+                .slice(start as usize..end as usize)
+                .ok_or_else(|| {
+                    LixError::new(
+                        LixError::CODE_UNKNOWN,
+                        format!("{context} canonical JSON batch offsets are invalid"),
+                    )
+                })?;
+            *slots[position] = Some(TransactionJson {
+                storage: TransactionJsonStorage::CanonicalShared {
+                    value: OnceLock::from(value.into_shared()),
+                    normalized,
+                },
+            });
+        }
     }
     Ok(())
 }
@@ -5706,6 +5769,51 @@ mod tests {
             first.normalized().len() + second.normalized().len()
         );
         assert_eq!(first.validation_counts(), (2, 2));
+    }
+
+    #[test]
+    fn shared_decoded_rows_retain_source_values_in_one_canonical_arena() {
+        let first_source = Arc::new(serde_json::json!({"id": "a", "value": "first"}));
+        let second_source = Arc::new(serde_json::json!({"id": "b", "value": "second"}));
+        let mut rows = vec![
+            Some(
+                TransactionJson::from_shared_value(Arc::clone(&first_source), "shared SQL fixture")
+                    .expect("shared first row"),
+            ),
+            Some(
+                TransactionJson::from_shared_value(
+                    Arc::clone(&second_source),
+                    "shared SQL fixture",
+                )
+                .expect("shared second row"),
+            ),
+        ];
+
+        canonicalize_transaction_json_batch(rows.iter_mut(), "shared SQL fixture")
+            .expect("canonicalize shared SQL batch");
+        let (first_value, first_normalized) = match &rows[0].as_ref().expect("first row").storage {
+            TransactionJsonStorage::CanonicalShared { value, normalized } => (
+                value.get().expect("first decoded owner"),
+                normalized.clone(),
+            ),
+            _ => panic!("shared decoded row must retain its source owner"),
+        };
+        let (second_value, second_normalized) = match &rows[1].as_ref().expect("second row").storage
+        {
+            TransactionJsonStorage::CanonicalShared { value, normalized } => (
+                value.get().expect("second decoded owner"),
+                normalized.clone(),
+            ),
+            _ => panic!("shared decoded row must retain its source owner"),
+        };
+
+        assert!(Arc::ptr_eq(first_value, &first_source));
+        assert!(Arc::ptr_eq(second_value, &second_source));
+        assert!(first_normalized.shares_buffer_with(&second_normalized));
+        assert_eq!(
+            first_normalized.retained_buffer_len(),
+            first_normalized.len() + second_normalized.len()
+        );
     }
 
     #[test]


### PR DESCRIPTION
## What changed

- retain shared decoded `Arc<JsonValue>` owners during batch canonicalization instead of deep-cloning every JSON tree when `Arc::try_unwrap` fails
- keep one canonical byte arena with per-row slices
- preserve the existing exact batch arena for uniquely owned decoded values
- add a deterministic pointer-identity and shared-arena regression

No storage format, persisted authority, cache, compatibility path, or writer changes.

## Root cause and complexity

The 50K initial-publication path retained caller-owned decoded values. Canonicalization attempted `Arc::try_unwrap`; all 50K attempts failed and the fallback deep-cloned every JSON tree before serializing it.

- before: `O(N + B + D)`, where `D` is the shared JSON node/string deep clone
- after: `O(N + B)`; canonical bytes remain the durable payload and decoded owners are released after validation
- measured perfect-elimination ceiling: row preparation was 55.2 ms / 40.6% of the focused operation

The separately proposed selected-change payload optimization was rejected and is not included: initial publication selected zero records and spent only 4–5 µs there.

## Performance

Setup excluded; exact-main baseline was `95478b1fa329f7608b2360554ca72fad782dfeb8`.

| Adapter / rows | Main | Candidate | Delta |
|---|---:|---:|---:|
| RocksDB / 50K | 127.353 ms | 104.247 ms | -18.1% |
| SlateDB / 50K | 124.147 ms | 104.651 ms | -15.7% |
| RocksDB / 1K | 5.830 ms | 5.882 ms | +0.9% |
| SlateDB / 1K | 6.694 ms | 6.497 ms | -2.9% |

50K warm allocations fell 33.2% on RocksDB and about 32.5% on SlateDB; allocation calls fell about 33% on both. Cold setup-to-operation RSS fell 30.7% and 37.7%, respectively.

Backend work was unchanged: 49 gets / 53 keys, six scans / 102 rows, 142 puts, 16 storage batches, and 1,925,521 staged bytes at 50K. Storage format and writer are untouched; logical disk/write amplification is neutral.

## Validation

- [x] `cargo fmt --all --check`
- [x] `git diff --check origin/main...HEAD`
- [x] `cargo clippy --profile test --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo test -p lix --lib transaction::types::tests --features storage-benches` (29 passed)
- [x] 1K bulk insert/read/update/delete regression
- [x] RocksDB + SlateDB checkpoint/reopen regression

Final integration merged current main `bbff57ef5c55cdf3e8a2da2aafc3d0611ca18bd7` exactly once; its two SQL branch-provider files did not overlap this diff. All checks above were rerun on final head `905fe90425f2aa6cf077bf268c718ee027ed792c`.