### PR TITLE
perf(lix): avoid empty transaction on pinned branch switch

### DIFF
--- a/packages/lix/src/session/switch_branch.rs
+++ b/packages/lix/src/session/switch_branch.rs
@@ -3,7 +3,7 @@ use serde_json::json;
 use crate::GLOBAL_BRANCH_ID;
 use crate::LixError;
 use crate::branch::{BranchLifecycle, BranchOperation, BranchReferenceRole};
-use crate::storage_adapter::Storage;
+use crate::storage_adapter::{SharedStorageAdapterRead, Storage, StorageReadOptions};
 use crate::transaction::types::{RawWriteBatch, TransactionJson, TransactionWriteRow};
 
 use super::context::{SessionContext, SessionMode, WORKSPACE_BRANCH_KEY};
@@ -45,32 +45,28 @@ where
             }
         };
         let observe_invalidation = self.observe_invalidation.clone();
-        let write_access = self.begin_session_write_access().await?;
-        self.with_write_transaction_reserved_lending(
-            write_access,
-            async move |transaction| {
-                {
-                    let reader = transaction.branch_ref_reader().await;
-                    BranchLifecycle::new(&reader)
-                        .require_existing_commit_id(
-                            &branch_id,
-                            BranchOperation::SwitchBranch,
-                            BranchReferenceRole::Target,
-                        )
-                        .await?
-                };
-
-                match &current_mode {
-                    SessionMode::Pinned { .. } => Ok(()),
-                    SessionMode::Workspace { .. } => {
-                        let mut rows = RawWriteBatch::with_capacity(1);
-                        rows.push(workspace_branch_stage_row(&branch_id)?);
-                        transaction.stage_rows(rows).await?;
-                        Ok(())
-                    }
-                }
-            },
-            |()| {
+        match current_mode {
+            SessionMode::Pinned { .. } => {
+                // A pinned switch changes only this session's in-memory
+                // selector. Keep the existing session/collaboration lease so
+                // branch deletion cannot race target validation, but do not
+                // open and commit an empty repository transaction: the target
+                // branch-head control is the sole authority this path needs.
+                let _write_access = self.begin_session_write_access().await?;
+                let read = SharedStorageAdapterRead::new(
+                    self.storage
+                        .begin_read(StorageReadOptions::default())
+                        .await?,
+                );
+                let reader = self.branch_ctx.ref_reader(&read);
+                BranchLifecycle::new(&reader)
+                    .require_existing_commit_id(
+                        &branch_id,
+                        BranchOperation::SwitchBranch,
+                        BranchReferenceRole::Target,
+                    )
+                    .await?;
+                self.ensure_open()?;
                 *selector.write().map_err(|_| {
                     LixError::new(
                         LixError::CODE_INTERNAL_ERROR,
@@ -78,10 +74,41 @@ where
                     )
                 })? = receipt_branch_id.clone();
                 observe_invalidation.bump();
-                Ok(())
-            },
-        )
-        .await?;
+            }
+            SessionMode::Workspace { .. } => {
+                let write_access = self.begin_session_write_access().await?;
+                self.with_write_transaction_reserved_lending(
+                    write_access,
+                    async move |transaction| {
+                        {
+                            let reader = transaction.branch_ref_reader().await;
+                            BranchLifecycle::new(&reader)
+                                .require_existing_commit_id(
+                                    &branch_id,
+                                    BranchOperation::SwitchBranch,
+                                    BranchReferenceRole::Target,
+                                )
+                                .await?
+                        };
+                        let mut rows = RawWriteBatch::with_capacity(1);
+                        rows.push(workspace_branch_stage_row(&branch_id)?);
+                        transaction.stage_rows(rows).await?;
+                        Ok(())
+                    },
+                    |()| {
+                        *selector.write().map_err(|_| {
+                            LixError::new(
+                                LixError::CODE_INTERNAL_ERROR,
+                                "session branch selector is poisoned",
+                            )
+                        })? = receipt_branch_id.clone();
+                        observe_invalidation.bump();
+                        Ok(())
+                    },
+                )
+                .await?;
+            }
+        }
 
         Ok(SwitchBranchReceipt {
             branch_id: receipt_branch_id,
@@ -109,4 +136,178 @@ fn workspace_branch_stage_row(branch_id: &str) -> Result<TransactionWriteRow, Li
         untracked: true,
         branch_id: GLOBAL_BRANCH_ID.into(),
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    use crate::CreateBranchOptions;
+    use crate::engine::Engine;
+    use crate::storage::{
+        GetManyRequest, GetManyResult, KeyRange, Memory, MemoryRead, MemoryWrite, ReadOptions,
+        ScanChunk, ScanOptions, Storage, StorageError, StorageRead, WriteOptions,
+    };
+
+    use super::*;
+
+    #[derive(Clone)]
+    struct CountingStorage {
+        inner: Memory,
+        counters: Arc<Counters>,
+    }
+
+    struct CountingRead {
+        inner: MemoryRead,
+        counters: Arc<Counters>,
+    }
+
+    #[derive(Default)]
+    struct Counters {
+        begin_reads: AtomicU64,
+        begin_writes: AtomicU64,
+        get_many_calls: AtomicU64,
+        get_many_keys: AtomicU64,
+        scan_calls: AtomicU64,
+    }
+
+    #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+    struct CounterSnapshot {
+        begin_reads: u64,
+        begin_writes: u64,
+        get_many_calls: u64,
+        get_many_keys: u64,
+        scan_calls: u64,
+    }
+
+    impl CountingStorage {
+        fn new() -> Self {
+            Self {
+                inner: Memory::new(),
+                counters: Arc::new(Counters::default()),
+            }
+        }
+
+        fn snapshot(&self) -> CounterSnapshot {
+            CounterSnapshot {
+                begin_reads: self.counters.begin_reads.load(Ordering::Relaxed),
+                begin_writes: self.counters.begin_writes.load(Ordering::Relaxed),
+                get_many_calls: self.counters.get_many_calls.load(Ordering::Relaxed),
+                get_many_keys: self.counters.get_many_keys.load(Ordering::Relaxed),
+                scan_calls: self.counters.scan_calls.load(Ordering::Relaxed),
+            }
+        }
+    }
+
+    impl CounterSnapshot {
+        fn delta_since(self, earlier: Self) -> Self {
+            Self {
+                begin_reads: self.begin_reads - earlier.begin_reads,
+                begin_writes: self.begin_writes - earlier.begin_writes,
+                get_many_calls: self.get_many_calls - earlier.get_many_calls,
+                get_many_keys: self.get_many_keys - earlier.get_many_keys,
+                scan_calls: self.scan_calls - earlier.scan_calls,
+            }
+        }
+    }
+
+    impl Storage for CountingStorage {
+        type Read<'a>
+            = CountingRead
+        where
+            Self: 'a;
+        type Write<'a>
+            = MemoryWrite
+        where
+            Self: 'a;
+
+        async fn begin_read(&self, options: ReadOptions) -> Result<Self::Read<'_>, StorageError> {
+            self.counters.begin_reads.fetch_add(1, Ordering::Relaxed);
+            Ok(CountingRead {
+                inner: self.inner.begin_read(options).await?,
+                counters: Arc::clone(&self.counters),
+            })
+        }
+
+        async fn begin_write(
+            &self,
+            options: WriteOptions,
+        ) -> Result<Self::Write<'_>, StorageError> {
+            self.counters.begin_writes.fetch_add(1, Ordering::Relaxed);
+            self.inner.begin_write(options).await
+        }
+    }
+
+    impl StorageRead for CountingRead {
+        async fn get_many(
+            &self,
+            requests: &[GetManyRequest<'_>],
+        ) -> Result<GetManyResult, StorageError> {
+            self.counters.get_many_calls.fetch_add(1, Ordering::Relaxed);
+            self.counters.get_many_keys.fetch_add(
+                requests
+                    .iter()
+                    .map(|request| request.keys.len() as u64)
+                    .sum(),
+                Ordering::Relaxed,
+            );
+            self.inner.get_many(requests).await
+        }
+
+        async fn scan(
+            &self,
+            space: crate::storage::StorageSpace,
+            range: KeyRange,
+            options: ScanOptions,
+        ) -> Result<ScanChunk, StorageError> {
+            self.counters.scan_calls.fetch_add(1, Ordering::Relaxed);
+            self.inner.scan(space, range, options).await
+        }
+    }
+
+    #[tokio::test]
+    async fn pinned_switch_reads_only_the_authoritative_target_control() {
+        let storage = CountingStorage::new();
+        let receipt = Engine::initialize(storage.clone())
+            .await
+            .expect("initialize switch benchmark storage");
+        let engine = Engine::new(storage.clone())
+            .await
+            .expect("open switch benchmark engine");
+        let session = engine
+            .open_session(&receipt.main_branch_id)
+            .await
+            .expect("open pinned main session");
+        let branch = session
+            .create_branch(CreateBranchOptions {
+                id: Some("01990000-0000-7000-8000-00000000c001".to_owned()),
+                name: "switch-control-read-test".to_owned(),
+                from_commit_id: None,
+            })
+            .await
+            .expect("create switch target");
+
+        let before = storage.snapshot();
+        let switched = session
+            .switch_branch(SwitchBranchOptions {
+                branch_id: branch.id.clone(),
+            })
+            .await
+            .expect("switch pinned session");
+        let delta = storage.snapshot().delta_since(before);
+
+        assert_eq!(switched.branch_id, branch.id);
+        assert_eq!(
+            delta,
+            CounterSnapshot {
+                begin_reads: 1,
+                begin_writes: 0,
+                get_many_calls: 1,
+                get_many_keys: 1,
+                scan_calls: 0,
+            },
+            "pinned switching must read only the target branch-head control"
+        );
+    }
 }

--- a/packages/server-protocol/src/lib.rs
+++ b/packages/server-protocol/src/lib.rs
@@ -3963,8 +3963,9 @@ mod tests {
     use flate2::{Compression, read::GzDecoder, write::GzEncoder};
     use http_body_util::BodyExt as _;
     use lix::storage::{
-        CommitResult, Key, KeyRange, MemoryRead, MemoryWrite, PutBatch, ReadOptions, Storage,
-        StorageError, StorageSpace, StorageWrite, WriteOptions,
+        CommitResult, GetManyRequest, GetManyResult, Key, KeyRange, MemoryRead, MemoryWrite,
+        PutBatch, ReadOptions, ScanChunk, ScanOptions, Storage, StorageError, StorageRead,
+        StorageSpace, StorageWrite, WriteOptions,
     };
     use lix::telemetry::TracingTelemetrySink;
     use lix::{Blob, Memory, RequestBlobSpliceProvenance, open_lix};
@@ -4318,6 +4319,126 @@ mod tests {
                 return Err(StorageError::Fenced);
             }
             self.inner.begin_write(options).await
+        }
+    }
+
+    #[derive(Clone)]
+    struct BlockingFencedBranchControlReadStorage {
+        inner: Memory,
+        gate: Arc<BlockingFencedBranchControlReadGate>,
+    }
+
+    struct BlockingFencedBranchControlRead {
+        inner: MemoryRead,
+        gate: Arc<BlockingFencedBranchControlReadGate>,
+    }
+
+    struct BlockingFencedBranchControlReadGate {
+        remaining: AtomicUsize,
+        entered: AtomicBool,
+        entered_notify: Notify,
+        release: Notify,
+    }
+
+    impl BlockingFencedBranchControlReadStorage {
+        fn new() -> Self {
+            Self {
+                inner: Memory::new(),
+                gate: Arc::new(BlockingFencedBranchControlReadGate {
+                    remaining: AtomicUsize::new(0),
+                    entered: AtomicBool::new(false),
+                    entered_notify: Notify::new(),
+                    release: Notify::new(),
+                }),
+            }
+        }
+
+        fn block_next_branch_control_read(&self) {
+            assert_eq!(
+                self.gate.remaining.swap(1, Ordering::AcqRel),
+                0,
+                "test branch-control read gate must be idle before arming"
+            );
+            self.gate.entered.store(false, Ordering::Release);
+        }
+
+        async fn wait_for_blocked_branch_control_read(&self) {
+            loop {
+                let notified = self.gate.entered_notify.notified();
+                if self.gate.entered.load(Ordering::Acquire) {
+                    return;
+                }
+                notified.await;
+            }
+        }
+
+        fn release_blocked_branch_control_read(&self) {
+            self.gate.release.notify_waiters();
+        }
+    }
+
+    impl Storage for BlockingFencedBranchControlReadStorage {
+        type Read<'a>
+            = BlockingFencedBranchControlRead
+        where
+            Self: 'a;
+        type Write<'a>
+            = MemoryWrite
+        where
+            Self: 'a;
+
+        async fn begin_read(&self, options: ReadOptions) -> Result<Self::Read<'_>, StorageError> {
+            Ok(BlockingFencedBranchControlRead {
+                inner: self.inner.begin_read(options).await?,
+                gate: Arc::clone(&self.gate),
+            })
+        }
+
+        async fn begin_write(
+            &self,
+            options: WriteOptions,
+        ) -> Result<Self::Write<'_>, StorageError> {
+            self.inner.begin_write(options).await
+        }
+    }
+
+    impl StorageRead for BlockingFencedBranchControlRead {
+        fn snapshot_cache_key(&self) -> Option<u128> {
+            self.inner.snapshot_cache_key()
+        }
+
+        async fn get_many(
+            &self,
+            requests: &[GetManyRequest<'_>],
+        ) -> Result<GetManyResult, StorageError> {
+            let reads_branch_control = requests
+                .iter()
+                .any(|request| request.space.name == "branch.head_control.v9");
+            if reads_branch_control
+                && self
+                    .gate
+                    .remaining
+                    .fetch_update(Ordering::AcqRel, Ordering::Acquire, |remaining| {
+                        remaining.checked_sub(1)
+                    })
+                    .is_ok()
+            {
+                let release = self.gate.release.notified();
+                self.gate.entered.store(true, Ordering::Release);
+                self.gate.entered_notify.notify_waiters();
+                release.await;
+                return Err(StorageError::Fenced);
+            }
+            self.inner.get_many(requests).await
+        }
+
+        async fn scan(
+            &self,
+            space: StorageSpace,
+            range: KeyRange,
+            options: ScanOptions,
+        ) -> Result<ScanChunk, StorageError> {
+            self.inner.scan(space, range, options).await
         }
     }
 
@@ -10097,7 +10218,7 @@ mod tests {
 
     #[tokio::test]
     async fn cancelled_branch_switch_reports_terminal_storage_after_caller_cancellation() {
-        let storage = BlockingFencedWriteStorage::new();
+        let storage = BlockingFencedBranchControlReadStorage::new();
         let root = Arc::new(
             open_lix()
                 .with_storage(storage.clone())
@@ -10126,14 +10247,17 @@ mod tests {
             .lease(&session_id, Some(notifier))
             .await
             .expect("session lease");
-        storage.block_next_write();
+        storage.block_next_branch_control_read();
         let operation =
             tokio::spawn(
                 async move { lease.switch_branch(SwitchBranchOptions { branch_id }).await },
             );
-        tokio::time::timeout(Duration::from_secs(1), storage.wait_for_blocked_write())
-            .await
-            .expect("branch switch should begin its write");
+        tokio::time::timeout(
+            Duration::from_secs(1),
+            storage.wait_for_blocked_branch_control_read(),
+        )
+        .await
+        .expect("branch switch should begin its authoritative branch-control read");
 
         operation.abort();
         assert!(
@@ -10143,7 +10267,7 @@ mod tests {
                 .is_cancelled()
         );
 
-        storage.release_blocked_write();
+        storage.release_blocked_branch_control_read();
         assert!(
             tokio::time::timeout(Duration::from_secs(1), signal.wait_for_terminal_storage(),)
                 .await


### PR DESCRIPTION
## Summary

Hard-cut pinned `switch_branch` away from a full repository write transaction. A pinned switch now keeps the existing session write lease and collaboration gate, reads the single authoritative target branch-head control, validates it through `BranchLifecycle`, and updates the in-memory selector.

Workspace-session switching remains on the existing persisted transaction path. Public APIs and observable semantics are unchanged: missing targets still fail, cloned pinned sessions still observe the selector update, independently opened sessions remain pinned, observers are invalidated, and workspace selection still survives reopen.

There is no cache, second authority, fallback, compatibility path, format change, migration, dual writer, or deferred compilation.

The corrected head adds one server-protocol test-only commit. It retargets the cancellation fixture from the intentionally deleted empty write to the new authoritative `branch.head_control.v9` `get_many`. The fixture blocks that exact read, cancels the caller, releases it as `StorageError::Fenced`, and preserves the existing detached terminal-storage assertion. It delegates unrelated reads, scans, and every write; production source is byte-identical to the frozen cut.

## Exact frozen state

- Candidate base: `95478b1fa329f7608b2360554ca72fad782dfeb8`
- Base tree: `f417149195f5bba8aa2bdf8c2e2d0a4e94631267`
- Frozen production head: `f4f2c693500d02d1740dd0d28ef5669c8497c065`
- Frozen production tree: `96e950e90400736e5f2c0dad93127e67cd2ef646`
- Corrective commit / final head: `767116d3979b1338b6cd68fbad0498af8351109f`
- Final tree: `5200c1ad852a7527f1dab725c0b9a0fb7639fdd6`
- Final full binary diff SHA-256: `a98685134fa2512d7d0aa98b9ba8591dc78a7393eb571ec65bbcac9930e7a1fd`
- Final full stable patch ID: `6798a99e37367ea492148144d1733394026d8967`
- Test-only corrective binary delta SHA-256 (`f4f2c693..767116d3`): `9c0f2e09918d21e955bdece2f337a97c596efe532bc77522c63a96088840542d`
- Test-only corrective stable patch ID: `ea90a56ad85edb29790e0f5f07cf487a34c7a3cc`
- Production `switch_branch.rs` blob at both heads: `70591ef9b4fe011f08132c6c6217211b20ed3577`
- Scope: two files, 364 insertions and 39 deletions; the corrective commit changes only the server-protocol test module (132 insertions, 8 deletions)

Canonical binary-diff hashing commands:

```sh
git diff --binary 95478b1fa329f7608b2360554ca72fad782dfeb8..f4f2c693500d02d1740dd0d28ef5669c8497c065 | sha256sum
# a880b7f6b59f4bbb30206b51326d582167998974010012d0efbaa65c06773d05

git diff --binary 95478b1fa329f7608b2360554ca72fad782dfeb8..767116d3979b1338b6cd68fbad0498af8351109f | sha256sum
# a98685134fa2512d7d0aa98b9ba8591dc78a7393eb571ec65bbcac9930e7a1fd
```

The earlier `b01f...` value was not produced by the canonical binary-diff command and has been corrected above. The production-only stable patch ID remains `7d0704345fd7a27a190672e5c9a4ea19cea5e59a`.

The branch remains intentionally frozen on its assigned base. It has not merged or rebased current main.

## Causal term, complexity, and ceiling

Before this cut, pinned switching acquired the correct synchronization but then opened a complete repository write transaction, prepared transaction catalog/control state, staged zero rows, and committed an empty transaction. Per switch that cost three read snapshots, one write transaction, 19 point reads, and one empty commit. Only one target `branch.head_control` read is authoritative.

History scaling remains `O(1)` -> `O(1)` per switch and `O(M)` over M switches, independent of history length H. The hard cut deletes the removable constant term: 19 point reads become one, three snapshots become one, and the write transaction/commit disappear. The semantic perfect-elimination ceiling is the baseline minus the one required target-authority read; this candidate implements that honest minimum and captures 91.9-93.6% of wall time and 92.5-94.3% of CPU. Removing the final read would incorrectly accept missing branches.

Hot transaction-open and reopen profiling found zero catalog scans and no catalog compilation. Existing revision-keyed catalog caching is untouched. The next ranked transaction-open term is a duplicate deterministic-mode authority load (one snapshot and seven of 20 calls), but it is outside this one-candidate cut.

## Setup-excluded production-cut evidence

Seven samples x 1,000 measured operations after warming both branch catalogs; fixtures used 100 and 1,000 history commits. CPU was confirmed with three 100,000-operation samples. Every cell verified persisted state after reopen.

| Adapter / history | Base wall/op | Candidate wall/op | Delta | Allocation bytes | Allocation calls |
|---|---:|---:|---:|---:|---:|
| RocksDB H=100 | 34.811 us | 2.812 us | -91.92% | -98.95% | -93.77% |
| RocksDB H=1K | 35.430 us | 2.258 us | -93.63% | -98.95% | -93.77% |
| SlateDB H=100 | 24.016 us | 1.864 us | -92.24% | -98.46% | -93.24% |
| SlateDB H=1K | 19.691 us | 1.476 us | -92.50% | -98.46% | -93.24% |

| H=1K CPU | Base | Candidate | Delta |
|---|---:|---:|---:|
| RocksDB | 40.0 us/op | 2.3 us/op | -94.25% |
| SlateDB | 20.0 us/op | 1.5 us/op | -92.50% |

Backend effects per switch:

- read snapshots: 3 -> 1
- point-read calls/keys: 19/19 -> 1/1 (-94.74%)
- logical point-read key+value bytes: 1,797 -> 164 (-90.87%)
- write transactions and commits: 1 -> 0
- scans and logical write rows: zero before and after
- SlateDB writer-gate acquisitions: 1 -> 0
- warmed physical read objects/bytes: zero before and after
- median RSS growth: zero on both adapters
- RocksDB: baseline 20.48 OS write bytes/op and median +19,003 directory bytes per 1,000 switches -> zero medians
- SlateDB: no flushed disk delta before or after; empty writer/commit work is removed

## Corrected-head independent evidence

The corrective head reproduced the smallest H=1K gate after a full close/reopen, 1,000 history commits, both branch controls warmed, 1,000 alternating pinned switches, and a second cold reopen. The disposable measurement harness was removed before commit.

| Adapter | Wall/op | CPU ticks | Allocations / bytes | RSS delta | Logical backend | Physical effect |
|---|---:|---:|---:|---:|---|---|
| RocksDB | 18.968 us | 4 | 32,000 / 2,617,000 | +1,776 KiB | 1,000 snapshots; 1,000 calls/keys; 163,000 bytes; 0 writes/scans | +3,618 directory bytes; no logical write |
| SlateDB | 18.755 us | 2 | 20,002 / 4,179,048 | +64 KiB | 1,000 snapshots; 1,000 calls/keys; 163,000 bytes; 0 writes/scans | 3 manifest reads / 22,614 bytes; 0 writes, writer gates, or disk growth |

Correctness and build gates on the test-only corrected tree:

- exact formerly failing server test: 1/1 green
- all-feature branching suite: 68/68 green
- all-feature observe suite: 44/44 green
- public Send/cancellation suite: 3/3 green
- focused counting-adapter authority test: one snapshot/read/key, zero begin-write and scans
- `cargo fmt --all -- --check`
- `git diff --check`
- warnings-denied `cargo clippy -p lix-server-protocol --all-targets --all-features`
- warnings-denied `cargo clippy -p lix --all-targets --features storage-benches`
- RocksDB and SlateDB H=1K close/reopen gates above

The prior broad correctness evidence also remains intact: 5/5 focused base switch tests, 10/10 base + tracked-state-rebuild switch simulations, 34/34 branching integration tests, 25/25 observer tests, 2/2 semantic-merge tests, and both-adapter benchmark reopen assertions.

## Hosted checks and review status

The frozen production head's hosted run `31161103840` was 7/8 green; its sole failure was the stale server fixture waiting for the deleted `begin_write`. The exact corrected-head hosted run `31164496189` is terminal SUCCESS, 8/8, on `767116d3979b1338b6cd68fbad0498af8351109f`.

## Independent review

APPROVE on exact head `767116d3979b1338b6cd68fbad0498af8351109f`. The independent reviewer reproduced the authority and cancellation semantics, current-main merge tree, both-adapter H=1K performance gate, formatting, diff check, relevant warnings-denied Clippy, and confirmed hosted run `31164496189` is 8/8 green.

Portable full-index binary diff SHA-256 values:

- production base..production head: `349360095bdfc15001d62a9a253fae23180d8d1141d2ee02ced7541c2bda86bb`
- corrective production..final head: `71e6bf5983c19017fae8449d9a77786d08e417245a94892220c80f383708b311`
- full base..final head: `679e956003167d018b9a32d9c73b228defec868aae6c115bb22ee3bb03deb2fc`

These use `git diff --binary --full-index`; the earlier non-full-index hashes are Git abbreviation-setting dependent. This is provenance metadata only and does not change the reviewed tree.
