### PR TITLE
fix(lix): bound explicit transaction execute stack

### DIFF
--- a/packages/lix/src/session/execute.rs
+++ b/packages/lix/src/session/execute.rs
@@ -2889,8 +2889,7 @@ where
         sql: &str,
         params: &[Value],
     ) -> Result<ExecuteResult, LixError> {
-        self.execute_with_options_inner(sql, params, ExecuteOptions::default())
-            .await
+        Box::pin(self.execute_with_options_inner(sql, params, ExecuteOptions::default())).await
     }
 
     /// Executes one public prepared-DML parameter page inside this explicit

--- a/packages/lix/tests/integration/transaction.rs
+++ b/packages/lix/tests/integration/transaction.rs
@@ -229,6 +229,65 @@ async fn explicit_transaction_reads_stable_snapshot_and_own_writes() {
     transaction.rollback().await.unwrap();
 }
 
+simulation_test!(
+    explicit_transaction_collection_delete_is_visible_and_terminates,
+    |sim| async move {
+        let engine = sim.boot_engine().await;
+        let session = sim.wrap_session(
+            engine
+                .open_workspace_session()
+                .await
+                .expect("workspace session should open"),
+            &engine,
+        );
+        session
+            .execute(
+                r#"INSERT INTO lix_registered_schema (value, lixcol_global, lixcol_untracked)
+                   VALUES (lix_json('{"x-lix-key":"transaction_collection_delete","x-lix-primary-key":["/id"],"type":"object","properties":{"id":{"type":"string"}},"required":["id"],"additionalProperties":false}'), false, false)"#,
+                &[],
+            )
+            .await
+            .expect("collection schema should register");
+        session
+            .execute(
+                "INSERT INTO transaction_collection_delete (id) VALUES ('a'), ('b')",
+                &[],
+            )
+            .await
+            .expect("collection members should seed");
+
+        let mut transaction = session
+            .begin_transaction()
+            .await
+            .expect("explicit transaction should begin");
+        let deleted = transaction
+            .execute("DELETE FROM transaction_collection_delete", &[])
+            .await
+            .expect("whole collection delete should terminate");
+        assert_eq!(deleted.rows_affected(), 2);
+        let visible = transaction
+            .execute("SELECT id FROM transaction_collection_delete", &[])
+            .await
+            .expect("transaction should read its staged collection delete");
+        assert!(visible.rows().is_empty());
+        let deleted_again = transaction
+            .execute("DELETE FROM transaction_collection_delete", &[])
+            .await
+            .expect("repeated whole collection delete should terminate");
+        assert_eq!(deleted_again.rows_affected(), 0);
+        transaction
+            .commit()
+            .await
+            .expect("whole collection delete should commit");
+
+        let committed = session
+            .execute("SELECT id FROM transaction_collection_delete", &[])
+            .await
+            .expect("committed collection delete should remain visible");
+        assert!(committed.rows().is_empty());
+    }
+);
+
 #[tokio::test]
 async fn deferred_active_branch_check_rejects_deleted_branch_at_commit() {
     let storage = Memory::new();


### PR DESCRIPTION
## Summary

Fix the inherited SIGABRT in `whole_entity_collection_delete_is_visible_inside_explicit_transaction` by placing the large explicit-transaction SQL future behind the same heap-pinned boundary already used by ordinary session execution.

This is a one-authority correctness cut. It does not change transaction ownership, staging, overlay visibility, statement ordering, rollback, commit, persisted formats, or public APIs. There is no retry, recursion-limit/stack-size increase, compatibility path, or fallback.

## Exact revision

- Base: `bbff57ef5c55cdf3e8a2da2aafc3d0611ca18bd7`
- Base tree: `58b0d355322172aa8eda39ac2a55fd62dbd1a586`
- Head: `b3ae690fbb051dfdbc62aa9b5b4b63a4e4f4087c`
- Head tree: `5faf77740674253e32c5432df5bc1a86c79cdc88`
- Diff hash (`git diff base..head | git hash-object --stdin`): `a1a8f53fe5ebd5f7a4a2e5392d26a243f7b73dbd`
- Stable patch ID: `135d3761b52496b371170f013d47f028387b1c52`

## Cause and semantic invariant

Pristine base deterministically aborts with stack overflow/SIGABRT on the exact named test. Sampling and generated-code inspection found no recursion/cycle: this is finite async-future stack growth at `SessionTransaction::execute`. Its poll frame was 28,536 bytes because it embedded the 14,096-byte `execute_with_options_inner` future. Ordinary `SessionContext::execute` already boxes the equivalent boundary.

The authoritative invariant remains: each explicit-transaction statement exclusively borrows the transaction; writes stage in its overlay; subsequent reads observe staged effects; failures preserve statement rollback and final commit/rollback behavior. Heap placement is not authority.

Ryzen-III overlap was checked before editing. Their typed mutation-reconciliation work owns `packages/lix/src/transaction/types.rs`; this cut is confined to `packages/lix/src/session/execute.rs` plus its integration regression.

## Stack and resource effect

- Required test-thread stack, pristine base: fails at 2,228,224 bytes and passes at 2,359,296 bytes, so requirement is in `(2.125, 2.25] MiB`.
- Candidate: fails at 1,900,544 bytes and passes at 1,966,080 bytes, so requirement is in `(1.8125, 1.875] MiB`.
- Generated explicit execute poll frame: 28,536 -> 14,488 bytes.
- Tradeoff: one 14,096-byte heap allocation per explicit-transaction statement.
- Seven candidate default-stack runs: 0.04 s median elapsed, 0.03 s median user CPU, 110,916 KiB median max RSS.
- Diagnostic 8 MiB-stack control was within timing/RSS noise (candidate 0.04 s median, 0.03 s user CPU, 111,412 KiB median RSS; pristine reproduction was 0.05 s, 0.03 s user CPU, 111,552 KiB RSS).
- Storage/backend/disk work: unchanged; the cut is above SQL/storage execution and adds no reads or writes.

## Regression coverage

The bounded simulation test has a 120-second termination guard and verifies:

- whole-collection delete inside an explicit transaction;
- immediate read-your-own-delete visibility;
- deterministic repeated delete (`rowsAffected = 0`);
- committed visibility;
- base and tracked-state-rebuild simulation modes.

The original default-stack unit test remains unchanged and now passes, preserving a direct regression for the abort.

## Gates

- Exact named reproduction on pristine base: deterministic stack-overflow/SIGABRT.
- Exact named test on candidate/default stack: pass.
- `cargo test -p lix --lib collection_delete -- --nocapture`: 3 passed.
- `cargo test -p lix --test integration transaction:: -- --nocapture`: 20 passed.
- `cargo test -p lix --test integration --features all-simulations explicit_transaction_collection_delete_is_visible_and_terminates -- --nocapture`: 2 passed (base + tracked-state-rebuild).
- `cargo test -p lix`: 1,999 library tests, 443 integration tests, auxiliary suites, and doctests passed.
- `cargo fmt --all -- --check`: pass.
- `git diff --check`: pass.
- `cargo clippy --profile test --workspace --all-targets --all-features -- -D warnings`: pass.

Held as a draft for independent review. Do not merge without coordinator approval.