### PR TITLE
fix(gc): retain authenticated serving-state dependencies

### DIFF
--- a/packages/engine-benchmarks/Cargo.toml
+++ b/packages/engine-benchmarks/Cargo.toml
@@ -90,6 +90,11 @@ path = "tests/certified_replacement_delete_reopen.rs"
 required-features = ["rocksdb", "slatedb"]
 
 [[test]]
+name = "checkpoint_gc_replay_reopen"
+path = "tests/checkpoint_gc_replay_reopen.rs"
+required-features = ["rocksdb", "slatedb"]
+
+[[test]]
 name = "tpch_overlay_helpers"
 path = "tests/tpch_overlay_helpers.rs"
 

--- a/packages/engine-benchmarks/tests/checkpoint_gc_replay_reopen.rs
+++ b/packages/engine-benchmarks/tests/checkpoint_gc_replay_reopen.rs
@@ -1,0 +1,305 @@
+use std::future::Future;
+use std::path::Path;
+use std::time::Duration;
+
+use async_trait::async_trait;
+use lix::storage::Storage;
+use lix::{Value, open_lix};
+use lix_storage_rocksdb::RocksDB;
+use lix_storage_slatedb::SlateDB;
+
+const CHECKPOINT_GC_INTERVAL: usize = 64;
+const ROW_COUNT: usize = 100;
+const SCHEMA_KEY: &str = "checkpoint_gc_replay_row";
+
+#[async_trait]
+trait ReopenStorage: Storage + Clone + Send + Sync + Sized + 'static {
+    fn open(path: &Path) -> Self;
+    async fn flush(&self);
+}
+
+#[async_trait]
+impl ReopenStorage for RocksDB {
+    fn open(path: &Path) -> Self {
+        Self::open(path).expect("open checkpoint-GC RocksDB fixture")
+    }
+
+    async fn flush(&self) {
+        self.flush().expect("flush checkpoint-GC RocksDB fixture");
+    }
+}
+
+#[async_trait]
+impl ReopenStorage for SlateDB {
+    fn open(path: &Path) -> Self {
+        Self::open(path).expect("open checkpoint-GC SlateDB fixture")
+    }
+
+    async fn flush(&self) {
+        self.flush()
+            .await
+            .expect("flush checkpoint-GC SlateDB fixture");
+    }
+}
+
+#[test]
+fn rocksdb_checkpoint_gc_retains_replay_and_selected_owners_after_reopen() {
+    run_on_large_stack(|| {
+        checkpoint_gc_retains_replay_and_selected_owners_after_reopen::<RocksDB>()
+    });
+}
+
+#[test]
+fn slatedb_checkpoint_gc_retains_replay_and_selected_owners_after_reopen() {
+    run_on_large_stack(|| {
+        checkpoint_gc_retains_replay_and_selected_owners_after_reopen::<SlateDB>()
+    });
+}
+
+fn run_on_large_stack<F, Fut>(make_future: F)
+where
+    F: FnOnce() -> Fut + Send + 'static,
+    Fut: Future<Output = ()> + 'static,
+{
+    std::thread::Builder::new()
+        .name("checkpoint-gc-replay".to_owned())
+        .stack_size(16 * 1024 * 1024)
+        .spawn(move || {
+            tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .expect("build checkpoint-GC test runtime")
+                .block_on(make_future());
+        })
+        .expect("spawn checkpoint-GC test thread")
+        .join()
+        .expect("checkpoint-GC test thread should not panic");
+}
+
+async fn checkpoint_gc_retains_replay_and_selected_owners_after_reopen<S: ReopenStorage>() {
+    let temp = tempfile::tempdir().expect("create durable checkpoint-GC fixture");
+    let path = temp.path().join("database");
+    {
+        let storage = S::open(&path);
+        let lix = open_lix()
+            .with_storage(storage.clone())
+            .await
+            .expect("initialize durable checkpoint-GC Lix");
+        register_schema(&lix).await;
+        seed_rows(&lix).await;
+        let _seed_head = newest_commit_id(&lix).await;
+        churn_once(&lix, 1, false).await;
+        let _first_head = newest_commit_id(&lix).await;
+        churn_once(&lix, 2, true).await;
+        let retired_head = newest_commit_id(&lix).await;
+
+        lix.undo().await.expect("undo second churn commit");
+        assert_generation(&lix, 1, false).await;
+        lix.redo().await.expect("redo second churn commit");
+        assert_generation(&lix, 2, true).await;
+
+        lix.create_checkpoint()
+            .await
+            .expect("create compacting checkpoint");
+        for _ in 1..CHECKPOINT_GC_INTERVAL {
+            lix.create_checkpoint()
+                .await
+                .expect("advance production checkpoint-GC cadence");
+        }
+        // The 64th checkpoint schedules production GC. Its oldest queue batch
+        // must remain blocked while `tracked_generation` and native current
+        // rows still name this commit, so reclamation is not a progress oracle.
+        tokio::time::sleep(Duration::from_millis(250)).await;
+        assert_commit_present(&lix, &retired_head).await;
+        assert_generation(&lix, 2, true).await;
+        assert_history_readable(&lix).await;
+
+        lix.close().await.expect("close checkpoint-GC Lix");
+        drop(lix);
+        storage.flush().await;
+    }
+
+    let storage = S::open(&path);
+    let lix = open_lix()
+        .with_storage(storage.clone())
+        .await
+        .expect("cold reopen checkpoint-GC Lix");
+    assert_generation(&lix, 2, true).await;
+    assert_history_readable(&lix).await;
+    lix.close().await.expect("close reopened checkpoint-GC Lix");
+    drop(lix);
+    storage.flush().await;
+}
+
+async fn register_schema<S: Storage + Clone + Send + Sync + 'static>(lix: &lix::Lix<S>) {
+    let schema = serde_json::json!({
+        "x-lix-key": SCHEMA_KEY,
+        "x-lix-primary-key": ["/id"],
+        "x-lix-unique": [["/indexed_value"]],
+        "type": "object",
+        "required": ["id", "indexed_value", "note", "generation"],
+        "properties": {
+            "id": { "type": "string" },
+            "indexed_value": { "type": "string" },
+            "note": { "type": "string" },
+            "generation": { "type": "integer" }
+        },
+        "additionalProperties": false
+    });
+    lix.execute(
+        "INSERT INTO lix_registered_schema (value, lixcol_global, lixcol_untracked) VALUES (lix_json($1), false, false)",
+        &[Value::Text(schema.to_string())],
+    )
+    .await
+    .expect("register checkpoint-GC schema");
+}
+
+async fn seed_rows<S: Storage + Clone + Send + Sync + 'static>(lix: &lix::Lix<S>) {
+    let mut transaction = lix
+        .begin_transaction()
+        .await
+        .expect("begin checkpoint-GC seed");
+    for index in 0..ROW_COUNT {
+        transaction
+            .execute(
+                &format!(
+                    "INSERT INTO {SCHEMA_KEY} (id, indexed_value, note, generation) VALUES ($1, $2, $3, 0)"
+                ),
+                &[
+                    Value::Text(format!("row-{index}")),
+                    Value::Text(format!("indexed-{index}-0")),
+                    Value::Text(format!("seed-{index}")),
+                ],
+            )
+            .await
+            .expect("seed checkpoint-GC row");
+    }
+    transaction
+        .commit()
+        .await
+        .expect("commit checkpoint-GC seed");
+}
+
+async fn churn_once<S: Storage + Clone + Send + Sync + 'static>(
+    lix: &lix::Lix<S>,
+    generation: usize,
+    insert_replacement: bool,
+) {
+    let mut transaction = lix
+        .begin_transaction()
+        .await
+        .expect("begin checkpoint-GC churn");
+    transaction
+        .execute(
+            &format!(
+                "UPDATE {SCHEMA_KEY} SET indexed_value = $1, generation = $2 WHERE id = 'row-0'"
+            ),
+            &[
+                Value::Text(format!("indexed-0-{generation}")),
+                Value::Integer(generation as i64),
+            ],
+        )
+        .await
+        .expect("update indexed checkpoint-GC row");
+    transaction
+        .execute(
+            &format!("UPDATE {SCHEMA_KEY} SET note = $1, generation = $2 WHERE id = 'row-1'"),
+            &[
+                Value::Text(if generation == 1 { "one" } else { "two" }.to_owned()),
+                Value::Integer(generation as i64),
+            ],
+        )
+        .await
+        .expect("update nonindexed checkpoint-GC row");
+    if insert_replacement {
+        transaction
+            .execute(
+                &format!(
+                    "INSERT INTO {SCHEMA_KEY} (id, indexed_value, note, generation) VALUES ('row-99', 'indexed-99-2', 'replacement', 2)"
+                ),
+                &[],
+            )
+            .await
+            .expect("insert checkpoint-GC replacement row");
+    } else {
+        transaction
+            .execute(
+                &format!("DELETE FROM {SCHEMA_KEY} WHERE id = 'row-99'"),
+                &[],
+            )
+            .await
+            .expect("delete checkpoint-GC replacement row");
+    }
+    transaction
+        .commit()
+        .await
+        .expect("commit checkpoint-GC churn");
+}
+
+async fn newest_commit_id<S: Storage + Clone + Send + Sync + 'static>(lix: &lix::Lix<S>) -> String {
+    let result = lix
+        .execute("SELECT id FROM lix_commit ORDER BY id DESC LIMIT 1", &[])
+        .await
+        .expect("load newest checkpoint-GC commit");
+    result.rows()[0]
+        .get::<String>("id")
+        .expect("decode newest checkpoint-GC commit")
+}
+
+async fn assert_commit_present<S: Storage + Clone + Send + Sync + 'static>(
+    lix: &lix::Lix<S>,
+    commit_id: &str,
+) {
+    let result = lix
+        .execute(
+            &format!("SELECT id FROM lix_commit WHERE id = '{commit_id}'"),
+            &[],
+        )
+        .await
+        .expect("query retained checkpoint-GC commit");
+    assert!(
+        !result.is_empty(),
+        "live state owner {commit_id} was reclaimed"
+    );
+}
+
+async fn assert_generation<S: Storage + Clone + Send + Sync + 'static>(
+    lix: &lix::Lix<S>,
+    generation: i64,
+    replacement_present: bool,
+) {
+    let state = lix
+        .execute(
+            &format!("SELECT indexed_value, note, generation FROM {SCHEMA_KEY} WHERE id = 'row-1'"),
+            &[],
+        )
+        .await
+        .expect("read checkpoint-GC live state");
+    assert_eq!(
+        state.rows()[0].get::<i64>("generation").unwrap(),
+        generation
+    );
+    assert_eq!(
+        state.rows()[0].get::<String>("note").unwrap(),
+        if generation == 1 { "one" } else { "two" }
+    );
+    let replacement = lix
+        .execute(
+            &format!("SELECT id FROM {SCHEMA_KEY} WHERE id = 'row-99'"),
+            &[],
+        )
+        .await
+        .expect("read checkpoint-GC replacement row");
+    assert_eq!(!replacement.is_empty(), replacement_present);
+}
+
+async fn assert_history_readable<S: Storage + Clone + Send + Sync + 'static>(lix: &lix::Lix<S>) {
+    let history = lix
+        .execute(
+            &format!("SELECT note FROM {SCHEMA_KEY}_history() WHERE id = 'row-1'"),
+            &[],
+        )
+        .await
+        .expect("read compacted checkpoint-GC history");
+    assert!(!history.is_empty());
+}

--- a/packages/lix/src/branch/control.rs
+++ b/packages/lix/src/branch/control.rs
@@ -61,7 +61,42 @@ pub(crate) struct BranchHeadControl {
     pub(crate) schema_presence_bloom: [u64; SCHEMA_PRESENCE_BLOOM_WORDS],
 }
 
+/// Canonical classification of one authenticated branch control for
+/// destructive reachability work.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct BranchHeadTrackedReachability {
+    /// Semantic chronology roots. These must have commit graph and physical
+    /// manifest authority.
+    pub(crate) chronology_roots: [Option<CommitId>; 2],
+    /// Current-serving selector. This UUID is interpreted only with the
+    /// branch id through `TrackedHead`; it is not itself a semantic commit.
+    pub(crate) serving_generation: CommitId,
+    /// Checkpoint context required to interpret the serving generation's
+    /// sparse working-diff visibility. This is already a chronology root
+    /// above; carrying it here prevents serving-owner readers from selecting
+    /// control fields independently.
+    pub(crate) serving_checkpoint_commit_id: Option<CommitId>,
+}
+
 impl BranchHeadControl {
+    /// Canonical tracked projection for destructive reachability work.
+    ///
+    /// `tracked_generation` is the atomic serving selector, not chronology.
+    /// Its row/scoped owners are resolved through the authenticated
+    /// `TrackedHead` reader before GC evaluates retirement.
+    /// `untracked_generation` is intentionally absent: it names current-only
+    /// physical state and is not a semantic commit dependency.
+    pub(crate) fn tracked_reachability(self) -> BranchHeadTrackedReachability {
+        BranchHeadTrackedReachability {
+            chronology_roots: [
+                Some(self.head_commit_id),
+                self.working_diff_checkpoint_commit_id,
+            ],
+            serving_generation: self.tracked_generation,
+            serving_checkpoint_commit_id: self.working_diff_checkpoint_commit_id,
+        }
+    }
+
     /// Returns the same public branch ref with a fresh private current-state
     /// revision. A mutable hot-row write must publish this alongside its exact
     /// control precondition; otherwise two writers could both compare the

--- a/packages/lix/src/branch/mod.rs
+++ b/packages/lix/src/branch/mod.rs
@@ -10,8 +10,8 @@ pub(crate) use context::BranchContext;
 pub(crate) use control::BRANCH_HEAD_CONTROL_SPACE;
 pub(crate) use control::{
     BranchHeadControl, BranchHeadControlContext, BranchHeadControlObservation,
-    BranchHeadControlReader, branch_head_control_precondition, stage_branch_head_control,
-    stage_delete_branch_head_control, untracked_lifecycle_generation,
+    BranchHeadControlReader, BranchHeadTrackedReachability, branch_head_control_precondition,
+    stage_branch_head_control, stage_delete_branch_head_control, untracked_lifecycle_generation,
 };
 pub(crate) use lifecycle::{BranchLifecycle, BranchOperation, BranchReferenceRole};
 pub(crate) use stage_rows::{

--- a/packages/lix/src/gc.rs
+++ b/packages/lix/src/gc.rs
@@ -11,7 +11,7 @@ use std::time::Instant;
 
 use bytes::Bytes;
 
-use crate::branch::BranchHeadControlContext;
+use crate::branch::{BranchHeadControl, BranchHeadControlContext, BranchHeadTrackedReachability};
 #[cfg(any(test, feature = "storage-benches"))]
 use crate::changelog::ChangeScanRequest;
 use crate::changelog::{
@@ -28,7 +28,6 @@ use crate::json_store::JsonRef;
 use crate::json_store::{
     JsonSlot, JsonStoreContext, JsonStoreWriter, UntrackedJsonReclaimCandidate,
 };
-#[cfg(test)]
 use crate::live_state::TrackedHeadContext;
 #[cfg(test)]
 use crate::live_state::stage_collect_stale_working_diff_indexes;
@@ -85,6 +84,38 @@ const GC_TREE_SWEEP_CURSOR_KEY: &[u8] = b"cursor";
 const GC_TREE_SWEEP_FORMAT_VERSION: u32 = 1;
 #[allow(dead_code)]
 const GC_TREE_SWEEP_PAGE_ROWS: usize = 64;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct AuthenticatedControlCommitReachability {
+    chronology_roots: BTreeSet<CommitId>,
+    serving_dependencies: BTreeSet<CommitId>,
+}
+
+async fn authenticated_control_commit_reachability<S>(
+    store: &S,
+    controls: &[(String, BranchHeadControl)],
+) -> Result<AuthenticatedControlCommitReachability, LixError>
+where
+    S: StorageAdapterRead + ?Sized,
+{
+    let projections = controls
+        .iter()
+        .map(|(branch_id, control)| (branch_id.clone(), control.tracked_reachability()))
+        .collect::<Vec<(String, BranchHeadTrackedReachability)>>();
+    let chronology_roots = projections
+        .iter()
+        .flat_map(|(_, projection)| projection.chronology_roots)
+        .flatten()
+        .collect();
+    let serving_dependencies = TrackedHeadContext::new()
+        .reader(store)
+        .tracked_serving_commit_dependencies(&projections)
+        .await?;
+    Ok(AuthenticatedControlCommitReachability {
+        chronology_roots,
+        serving_dependencies,
+    })
+}
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub(crate) struct CheckpointRecoveryRef {
@@ -168,9 +199,9 @@ struct StoredRootReachabilityDelta {
     #[musli(with = storage_codec::option)]
     new_root: Option<CommitId>,
     #[musli(with = storage_codec::option)]
-    old_control: Option<crate::branch::BranchHeadControl>,
+    old_control: Option<BranchHeadControl>,
     #[musli(with = storage_codec::option)]
-    new_control: Option<crate::branch::BranchHeadControl>,
+    new_control: Option<BranchHeadControl>,
     old_control_digest: [u8; 32],
     new_control_digest: [u8; 32],
 }
@@ -263,8 +294,8 @@ pub(crate) struct RootReachabilityDelta {
     pub(crate) branch_id: String,
     pub(crate) old_root: Option<CommitId>,
     pub(crate) new_root: Option<CommitId>,
-    pub(crate) old_control: Option<crate::branch::BranchHeadControl>,
-    pub(crate) new_control: Option<crate::branch::BranchHeadControl>,
+    pub(crate) old_control: Option<BranchHeadControl>,
+    pub(crate) new_control: Option<BranchHeadControl>,
     pub(crate) old_control_digest: [u8; 32],
     pub(crate) new_control_digest: [u8; 32],
 }
@@ -465,7 +496,7 @@ fn validate_stored_root_reachability_delta(
 }
 
 pub(crate) fn root_control_digest_for_control(
-    control: Option<&crate::branch::BranchHeadControl>,
+    control: Option<&BranchHeadControl>,
 ) -> Result<[u8; 32], LixError> {
     let Some(control) = control else {
         return Ok(root_control_digest(None));
@@ -690,12 +721,9 @@ where
     let recovery_refs = load_recovery_refs(store).await?;
     let (queue, raw_queue) = load_reachability_queue(store).await?;
     let batches = load_all_reachability_batches_for_tree_sweep(store, &queue).await?;
-    let mut commits = controls
-        .iter()
-        .flat_map(|(_, control)| {
-            std::iter::once(control.head_commit_id).chain(control.working_diff_checkpoint_commit_id)
-        })
-        .collect::<BTreeSet<_>>();
+    let control_reachability = authenticated_control_commit_reachability(store, &controls).await?;
+    let mut commits = control_reachability.chronology_roots;
+    commits.extend(control_reachability.serving_dependencies);
     commits.extend(recovery_refs.iter().flat_map(|recovery| {
         [
             recovery.recovered_head_commit_id,
@@ -1295,12 +1323,9 @@ where
         .collect::<BTreeSet<_>>();
     let (queue, _) = load_reachability_queue(store).await?;
     let batches = load_reachability_batches(store, &queue).await?;
-    let mut active_root_ids = controls
-        .iter()
-        .flat_map(|(_, control)| {
-            std::iter::once(control.head_commit_id).chain(control.working_diff_checkpoint_commit_id)
-        })
-        .collect::<BTreeSet<_>>();
+    let control_reachability = authenticated_control_commit_reachability(store, &controls).await?;
+    let mut active_root_ids = control_reachability.chronology_roots;
+    active_root_ids.extend(control_reachability.serving_dependencies);
     active_root_ids.extend(
         load_recovery_refs(store)
             .await?
@@ -1661,6 +1686,156 @@ pub(crate) struct RepositoryGcProfile {
     pub(crate) total_us: u64,
 }
 
+/// Extends the existing retirement proof with every commit the point reader
+/// can still visit from an active rootless authority.
+///
+/// Semantic first-parent edges come only from the commit graph. A replacement
+/// generation may substitute its authenticated physical fallback, exactly as
+/// `TrackedStateStoreReader::point_replay_interval` does. Both authorities are
+/// required before collection can proceed; malformed debt, missing state, or a
+/// cycle aborts the complete GC transaction before any sweep is staged.
+async fn collect_active_point_replay_dependencies<S>(
+    store: &S,
+    active_manifests: &BTreeMap<CommitId, crate::tracked_state::CommitStateManifest>,
+    physical_dependencies: &mut BTreeSet<CommitId>,
+    semantic_dependencies: &mut BTreeSet<CommitId>,
+) -> Result<(), LixError>
+where
+    S: StorageAdapterRead + Clone + Send + Sync,
+{
+    let mut graph = CommitGraphContext::new().reader(store.clone());
+    let mut completed = BTreeSet::new();
+    let mut loaded_manifests = active_manifests.clone();
+
+    for start_commit_id in active_manifests
+        .iter()
+        .filter_map(|(commit_id, manifest)| (manifest.replay_debt.depth != 0).then_some(*commit_id))
+    {
+        let mut current_commit_id = start_commit_id;
+        let mut path = Vec::new();
+        let mut seen = BTreeSet::new();
+        loop {
+            if completed.contains(&current_commit_id) {
+                break;
+            }
+            if !seen.insert(current_commit_id) {
+                return Err(LixError::new(
+                    LixError::CODE_INTERNAL_ERROR,
+                    format!(
+                        "active GC point-replay dependency cycle from '{start_commit_id}' includes '{current_commit_id}'"
+                    ),
+                ));
+            }
+            path.push(current_commit_id);
+
+            let node = graph
+                .load_node(&current_commit_id)
+                .await?
+                .ok_or_else(|| {
+                    LixError::new(
+                        LixError::CODE_INTERNAL_ERROR,
+                        format!(
+                            "active GC point-replay commit '{current_commit_id}' has no authenticated graph node"
+                        ),
+                    )
+                })?;
+            let manifest = match loaded_manifests.get(&current_commit_id) {
+                Some(manifest) => manifest.clone(),
+                None => {
+                    let manifest = crate::tracked_state::load_commit_state_manifest(
+                        store,
+                        current_commit_id,
+                    )
+                    .await?
+                    .ok_or_else(|| {
+                        LixError::new(
+                            LixError::CODE_INTERNAL_ERROR,
+                            format!(
+                                "active GC point-replay commit '{current_commit_id}' has no authenticated physical manifest"
+                            ),
+                        )
+                    })?;
+                    loaded_manifests.insert(current_commit_id, manifest.clone());
+                    manifest
+                }
+            };
+            if manifest.replay_debt.depth == 0 {
+                break;
+            }
+
+            let replacement_fallback = manifest
+                .mutations
+                .replacement_generation
+                .as_ref()
+                .filter(|_| manifest.mutations.member_count != 0)
+                .map(|generation| {
+                    generation
+                        .fallback_commit_id
+                        .map(|bytes| CommitId::new(uuid::Uuid::from_bytes(bytes)))
+                });
+            let uses_replacement_fallback = replacement_fallback.is_some();
+            if uses_replacement_fallback && manifest.replay_debt.depth != 1 {
+                return Err(LixError::new(
+                    LixError::CODE_INTERNAL_ERROR,
+                    format!(
+                        "active GC replacement replay commit '{current_commit_id}' has malformed replay debt"
+                    ),
+                ));
+            }
+            let next_commit_id =
+                replacement_fallback.unwrap_or_else(|| node.parent_commit_ids.first().copied());
+            let Some(next_commit_id) = next_commit_id else {
+                if manifest.replay_debt.depth != 1 {
+                    return Err(LixError::new(
+                        LixError::CODE_INTERNAL_ERROR,
+                        format!(
+                            "active GC point-replay commit '{current_commit_id}' has unresolved replay debt"
+                        ),
+                    ));
+                }
+                break;
+            };
+
+            let next_manifest = match loaded_manifests.get(&next_commit_id) {
+                Some(manifest) => manifest.clone(),
+                None => {
+                    let manifest = crate::tracked_state::load_commit_state_manifest(
+                        store,
+                        next_commit_id,
+                    )
+                    .await?
+                    .ok_or_else(|| {
+                        LixError::new(
+                            LixError::CODE_INTERNAL_ERROR,
+                            format!(
+                                "active GC point-replay dependency '{next_commit_id}' has no authenticated physical manifest"
+                            ),
+                        )
+                    })?;
+                    loaded_manifests.insert(next_commit_id, manifest.clone());
+                    manifest
+                }
+            };
+            if !uses_replacement_fallback
+                && next_manifest.replay_debt.depth + 1 != manifest.replay_debt.depth
+            {
+                return Err(LixError::new(
+                    LixError::CODE_INTERNAL_ERROR,
+                    format!(
+                        "active GC point-replay debt disagrees across '{current_commit_id}' -> '{next_commit_id}'"
+                    ),
+                ));
+            }
+
+            physical_dependencies.insert(next_commit_id);
+            semantic_dependencies.insert(next_commit_id);
+            current_commit_id = next_commit_id;
+        }
+        completed.extend(path);
+    }
+    Ok(())
+}
+
 /// Plans and stages logical repository GC against one pinned read.
 ///
 /// The caller must serialize this operation with repository writes and commit
@@ -1669,10 +1844,10 @@ pub(crate) struct RepositoryGcProfile {
 /// Content-addressed tree/CAS orphan repair is intentionally an offline path;
 /// out-of-band JSON is reclaimed here only from explicit ownership-loss
 /// candidates.
-/// Ordinary GC consumes only authenticated publication deltas.  Branch-head
+/// Ordinary GC consumes only authenticated publication deltas. Branch-head
 /// controls and checkpoint recovery refs are the complete active-root set;
-/// no semantic parent walk or full-space inventory discovery is permitted on
-/// this path.
+/// the only semantic walk permitted here is the exact point-replay dependency
+/// closure of those roots. Full-space inventory discovery remains forbidden.
 #[cfg(any(test, feature = "storage-benches"))]
 pub(crate) async fn stage_repository_gc<S>(
     store: S,
@@ -1699,12 +1874,8 @@ where
         .scan()
         .await?;
     let recovery_refs = load_recovery_refs(&store).await?;
-    let mut active_roots = controls
-        .iter()
-        .flat_map(|(_, control)| {
-            std::iter::once(control.head_commit_id).chain(control.working_diff_checkpoint_commit_id)
-        })
-        .collect::<BTreeSet<_>>();
+    let control_reachability = authenticated_control_commit_reachability(&store, &controls).await?;
+    let mut active_roots = control_reachability.chronology_roots;
     active_roots.extend(recovery_refs.iter().flat_map(|recovery| {
         [
             recovery.recovered_head_commit_id,
@@ -1764,8 +1935,8 @@ where
         });
     }
     let mut active_authority_ids = active_roots.clone();
-    let mut active_dependency_ids = BTreeSet::new();
-    let mut active_semantic_dependency_ids = BTreeSet::new();
+    let mut active_dependency_ids = control_reachability.serving_dependencies.clone();
+    let mut active_semantic_dependency_ids = control_reachability.serving_dependencies;
     let mut active_manifests = BTreeMap::new();
     let mut pending = active_roots.iter().copied().collect::<Vec<_>>();
     while let Some(commit_id) = pending.pop() {
@@ -1803,27 +1974,6 @@ where
     let mut active_mutation_nodes = BTreeSet::new();
     let mut active_scoped_nodes = BTreeSet::new();
     let mut active_current_parts = BTreeSet::new();
-    let replay_debt_ids = active_manifests
-        .iter()
-        .filter_map(|(commit_id, manifest)| (manifest.replay_debt.depth != 0).then_some(*commit_id))
-        .collect::<Vec<_>>();
-    // Rootless active commits retain their semantic parents for bounded replay,
-    // but unrelated retired roots must not be blocked by a repository-global
-    // replay-debt flag. Resolve only the direct parent closure of the active
-    // replay-debt roots; this is bounded by active roots and preserves the
-    // history dependency proof without a changelog sweep.
-    if !replay_debt_ids.is_empty() {
-        let replay_nodes = CommitGraphContext::new()
-            .reader(store.clone())
-            .load_nodes(&replay_debt_ids)
-            .await?;
-        for (_, node) in replay_nodes.iter() {
-            if let Some(node) = node {
-                active_dependency_ids.extend(node.parent_commit_ids.iter().copied());
-                active_semantic_dependency_ids.extend(node.parent_commit_ids.iter().copied());
-            }
-        }
-    }
     let scoped_roots = active_manifests
         .values()
         .filter_map(|manifest| {
@@ -1840,15 +1990,119 @@ where
         for part in reachable.parts {
             let descriptor =
                 crate::tracked_state::current_state_descriptor_from_scoped_range_part(&part)?;
-            if descriptor.source_kind == 1 {
-                active_current_parts.insert(descriptor.content_digest);
+            match descriptor.source_kind {
+                0 | 2 => {
+                    let owner = CommitId::new(uuid::Uuid::from_bytes(descriptor.owner_commit_id));
+                    active_authority_ids.insert(owner);
+                }
+                1 => {
+                    active_current_parts.insert(descriptor.content_digest);
+                }
+                _ => {
+                    return Err(LixError::new(
+                        LixError::CODE_INTERNAL_ERROR,
+                        "active current-state scoped range has an unknown source kind",
+                    ));
+                }
             }
         }
     }
-    validate_live_native_parts(&store, &active_current_parts).await?;
-    let active_ids = active_manifests.keys().copied().collect::<Vec<_>>();
+    let native_commit_dependencies =
+        validate_live_native_parts(&store, &active_current_parts).await?;
+    active_dependency_ids.extend(native_commit_dependencies.iter().copied());
+    active_semantic_dependency_ids.extend(native_commit_dependencies);
+
+    let mut replay_manifests = active_manifests.clone();
+    let missing_replay_manifest_ids = active_dependency_ids
+        .iter()
+        .filter(|commit_id| !replay_manifests.contains_key(commit_id))
+        .copied()
+        .collect::<Vec<_>>();
+    let missing_replay_manifests =
+        crate::tracked_state::load_commit_state_manifests(&store, &missing_replay_manifest_ids)
+            .await?;
+    for (commit_id, manifest) in missing_replay_manifest_ids
+        .into_iter()
+        .zip(missing_replay_manifests)
+    {
+        let manifest = manifest.ok_or_else(|| {
+            LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                format!(
+                    "active GC serving dependency '{commit_id}' has no authenticated physical manifest"
+                ),
+            )
+        })?;
+        replay_manifests.insert(commit_id, manifest);
+    }
+    collect_active_point_replay_dependencies(
+        &store,
+        &replay_manifests,
+        &mut active_dependency_ids,
+        &mut active_semantic_dependency_ids,
+    )
+    .await?;
+
+    // Finite selected members carry canonical change identities, but their
+    // packed owner is intentionally not duplicated into the commit manifest.
+    // Resolve only the authenticated local inventories of already-retained
+    // commits and fold those owners into the same physical authority set.
+    let selected_owner_sources = active_authority_ids
+        .union(&active_dependency_ids)
+        .copied()
+        .collect::<Vec<_>>();
+    let selected_owner_source_manifests =
+        crate::tracked_state::load_commit_state_manifests(&store, &selected_owner_sources).await?;
+    for (commit_id, manifest) in selected_owner_sources
+        .iter()
+        .copied()
+        .zip(selected_owner_source_manifests)
+    {
+        let manifest = manifest.ok_or_else(|| {
+            LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                format!(
+                    "active GC dependency '{commit_id}' has no authenticated physical manifest"
+                ),
+            )
+        })?;
+        if !manifest.mutations.may_contain_finite_selected_members() {
+            continue;
+        }
+        active_authority_ids.extend(
+            crate::tracked_state::load_local_selected_change_owner_commit_ids(&store, commit_id)
+                .await?,
+        );
+    }
+
+    // Every physically retained authority participates in content-addressed
+    // mutation-node marking. This includes replay baselines and authenticated
+    // scoped-range owners even when their semantic commit is independently
+    // eligible for retirement.
+    let retained_physical_ids = active_authority_ids
+        .union(&active_dependency_ids)
+        .copied()
+        .collect::<Vec<_>>();
+    let additional_physical_ids = retained_physical_ids
+        .iter()
+        .filter(|commit_id| selected_owner_sources.binary_search(commit_id).is_err())
+        .copied()
+        .collect::<Vec<_>>();
+    let additional_manifests =
+        crate::tracked_state::load_commit_state_manifests(&store, &additional_physical_ids).await?;
+    if let Some(commit_id) = additional_physical_ids
+        .iter()
+        .zip(additional_manifests)
+        .find_map(|(commit_id, manifest)| manifest.is_none().then_some(*commit_id))
+    {
+        return Err(LixError::new(
+            LixError::CODE_INTERNAL_ERROR,
+            format!("active GC dependency '{commit_id}' has no authenticated physical manifest"),
+        ));
+    }
     let mutation_roots =
-        crate::tracked_state::load_commit_mutation_directory_roots(&store, &active_ids).await?;
+        crate::tracked_state::load_commit_mutation_directory_roots(&store, &retained_physical_ids)
+            .await?;
     for root in mutation_roots.into_iter().flatten() {
         active_mutation_nodes.extend(
             crate::tracked_state::collect_mutation_directory_node_ids(&store, &root).await?,
@@ -1873,8 +2127,7 @@ where
                 delta.new_root,
                 &active_authority_ids,
                 &active_dependency_ids,
-            ) || replay_debt_ids.contains(&old_root)
-            {
+            ) {
                 blocked_sequences.insert(*sequence);
             }
         }
@@ -1923,7 +2176,7 @@ where
                 delta.new_root,
                 &active_authority_ids,
                 &active_dependency_ids,
-            ) && !replay_debt_ids.contains(&old_root);
+            );
             let semantic_retirement = retirement_is_proven(
                 old_root,
                 delta.new_root,
@@ -2100,36 +2353,33 @@ where
 async fn validate_live_native_parts<S>(
     store: &S,
     digests: &BTreeSet<[u8; 32]>,
-) -> Result<(), LixError>
+) -> Result<BTreeSet<CommitId>, LixError>
 where
     S: StorageAdapterRead + ?Sized,
 {
     if digests.is_empty() {
-        return Ok(());
+        return Ok(BTreeSet::new());
     }
     let keys = digests
         .iter()
         .map(|digest| StorageKey(Bytes::copy_from_slice(digest)))
         .collect::<Vec<_>>();
-    let presence = PointReadPlan::new(crate::tracked_state::CURRENT_STATE_DATA_PART_SPACE, &keys)
-        .materialize(
-            store,
-            StorageGetOptions {
-                projection: StorageCoreProjection::KeyOnly,
-            },
-        )
+    let loaded = PointReadPlan::new(crate::tracked_state::CURRENT_STATE_DATA_PART_SPACE, &keys)
+        .materialize(store, StorageGetOptions::default())
         .await?;
-    if presence
-        .value
-        .into_iter()
-        .any(|value| !matches!(value, Some(StorageProjectedValue::KeyOnly)))
-    {
-        return Err(LixError::new(
-            LixError::CODE_INTERNAL_ERROR,
-            "live current-state directory references a missing native data part",
-        ));
+    let mut commit_ids = BTreeSet::new();
+    for (digest, value) in digests.iter().zip(loaded.value) {
+        let Some(StorageProjectedValue::FullValue(bytes)) = value else {
+            return Err(LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                "live current-state directory references a missing native data part",
+            ));
+        };
+        commit_ids.extend(
+            crate::tracked_state::decode_current_state_data_part_commit_ids(digest, &bytes)?,
+        );
     }
-    Ok(())
+    Ok(commit_ids)
 }
 
 /// Recovery-only verifier retained for explicit rebuild tooling and tests.
@@ -3060,7 +3310,7 @@ mod tests {
     use crate::common::LixTimestamp;
     use crate::entity_pk::EntityPk;
     use crate::json_store::{
-        JsonRef, JsonSlot, JsonStoreContext, JsonWritePlacementRef, NormalizedJson,
+        JsonRef, JsonSlot, JsonSlotRef, JsonStoreContext, JsonWritePlacementRef, NormalizedJson,
         NormalizedJsonRef, UNTRACKED_JSON_RECLAIM_CANDIDATE_SPACE,
     };
     use crate::live_state::{CurrentStateDeltaRef, TrackedHeadContext, WorkingDiffIndexCoverage};
@@ -3071,12 +3321,15 @@ mod tests {
     };
     use crate::storage_codec;
     use crate::tracked_state::{
+        CommitDeltaLifecycleSummary, CommitDeltaReplacementGeneration, CommitDeltaReplacementScope,
         CommitStateManifest, CommitStateMutationInventory, CommitStateReplayDebt,
         TrackedStateCommitDeltaRef, TrackedStateCommitRoot, TrackedStateCommitRootParent,
-        TrackedStateContext, TrackedStateDeltaRef, TrackedStateRootId, load_change_record_by_id,
+        TrackedStateContext, TrackedStateDeltaRef, TrackedStateIndexValue, TrackedStateRootId,
+        TrackedStateSingleStringReplacementRef, load_change_record_by_id,
         scan_change_records_from_commit_deltas, scan_commit_delta_inventory,
         stage_addressable_commit_deltas_with_selected_source, stage_change_locators,
         stage_commit_deltas_for_commit_state, stage_commit_state_manifest,
+        stage_ordered_addressable_replacement_parts,
     };
     use crate::{GLOBAL_BRANCH_ID, Value, engine::Engine};
     use bytes::Bytes;
@@ -3087,12 +3340,1085 @@ mod tests {
     use super::{
         CheckpointGcState, CheckpointRecoveryRef, GC_TREE_SWEEP_FORMAT_VERSION,
         GC_TREE_SWEEP_MARK_SPACE, RootReachabilityDelta, StoredTreeSweepMark,
-        begin_tree_sweep_epoch, load_checkpoint_gc_state, load_reachability_batches,
-        load_reachability_queue, load_recovery_ref, load_recovery_refs, open_tree_sweep_epoch,
-        retirement_is_proven, root_control_digest_for_control, stage_checkpoint_gc_state,
-        stage_reachability_delta_batch, stage_reachability_queue_seed, stage_recovery_ref_rotation,
-        stage_tree_sweep_epoch_page,
+        authenticated_control_commit_reachability, begin_tree_sweep_epoch,
+        load_checkpoint_gc_state, load_reachability_batches, load_reachability_queue,
+        load_recovery_ref, load_recovery_refs, open_tree_sweep_epoch, retirement_is_proven,
+        root_control_digest_for_control, stage_checkpoint_gc_state, stage_reachability_delta_batch,
+        stage_reachability_queue_seed, stage_recovery_ref_rotation, stage_tree_sweep_epoch_page,
     };
+
+    #[tokio::test]
+    async fn destructive_consumers_share_the_complete_tracked_control_projection() {
+        let head = CommitId::for_test_label("control-projection-head");
+        let tracked_generation = CommitId::for_test_label("control-projection-tracked");
+        let untracked_generation = CommitId::for_test_label("control-projection-untracked");
+        let working_diff = CommitId::for_test_label("control-projection-working-diff");
+        let timestamp =
+            LixTimestamp::expect_parse("control projection timestamp", "2026-01-01T00:00:00Z");
+        let controls = vec![(
+            "main".to_owned(),
+            BranchHeadControl {
+                head_commit_id: head,
+                tracked_generation,
+                untracked_generation,
+                current_state_revision: 7,
+                working_diff_checkpoint_commit_id: Some(working_diff),
+                created_at: timestamp,
+                updated_at: timestamp,
+                ref_change_id: ChangeId::for_test_label("control-projection-ref"),
+                schema_presence_bloom: [u64::MAX; 4],
+            },
+        )];
+
+        let projection = controls[0].1.tracked_reachability();
+        assert_eq!(
+            projection.chronology_roots,
+            [Some(head), Some(working_diff)]
+        );
+        assert_eq!(projection.serving_generation, tracked_generation);
+        assert_eq!(projection.serving_checkpoint_commit_id, Some(working_diff));
+
+        // A valid empty generation has no commit-state manifest because the
+        // selector UUID is not chronology. Its serving dependency projection
+        // is simply empty, while the semantic roots remain explicit.
+        let storage = StorageAdapter::new(Memory::new());
+        let read = storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("control projection read should open");
+        let reachability = authenticated_control_commit_reachability(&read, &controls)
+            .await
+            .expect("rootless serving generation should be valid");
+        assert_eq!(
+            reachability.chronology_roots,
+            BTreeSet::from([head, working_diff])
+        );
+        assert!(reachability.serving_dependencies.is_empty());
+        assert!(!reachability.chronology_roots.contains(&tracked_generation));
+        assert!(
+            !reachability
+                .chronology_roots
+                .contains(&untracked_generation)
+        );
+    }
+
+    #[tokio::test]
+    async fn ordinary_gc_accepts_rootless_tracked_serving_generation() {
+        let storage = StorageAdapter::new(Memory::new());
+        let timestamp = LixTimestamp::expect_parse(
+            "rootless serving generation timestamp",
+            "2026-01-01T00:00:00Z",
+        );
+        let old_root = replay_commit_record("rootless-serving-old", 0, None, timestamp);
+        let active = replay_commit_record(
+            "rootless-serving-active",
+            1,
+            Some(old_root.commit_id),
+            timestamp,
+        );
+        let mut old_manifest =
+            test_commit_state_manifest(&old_root, CommitStateMutationInventory::default());
+        old_manifest.replay_debt = CommitStateReplayDebt::default();
+        old_manifest.snapshot_root = Some(Box::new(test_snapshot_root(old_root.commit_id)));
+        let mut active_manifest =
+            test_commit_state_manifest(&active, CommitStateMutationInventory::default());
+        active_manifest.replay_debt = CommitStateReplayDebt::default();
+        active_manifest.snapshot_root = Some(Box::new(test_snapshot_root(active.commit_id)));
+
+        let control_ref = ChangeId::for_test_label("rootless-serving-control");
+        let old_control = replay_branch_control(old_root.commit_id, control_ref, timestamp);
+        let serving_generation = CommitId::for_test_label("rootless-serving-generation");
+        let mut active_control = replay_branch_control(active.commit_id, control_ref, timestamp);
+        active_control.tracked_generation = serving_generation;
+
+        let mut writes = storage.new_write_set();
+        stage_reachability_queue_seed(&mut writes).expect("rootless serving queue should seed");
+        stage_branch_head_control(&mut writes, "main", active_control)
+            .expect("rootless serving control should stage");
+        persist_replay_closure_fixture(
+            &storage,
+            writes,
+            &[old_root.clone(), active.clone()],
+            &[old_manifest, active_manifest],
+        )
+        .await;
+        stage_replay_root_delta(
+            &storage,
+            RootReachabilityDelta {
+                branch_id: "main".to_owned(),
+                old_root: Some(old_root.commit_id),
+                new_root: Some(active.commit_id),
+                old_control: Some(old_control),
+                new_control: Some(active_control),
+                old_control_digest: root_control_digest_for_control(Some(&old_control))
+                    .expect("old rootless serving control should encode"),
+                new_control_digest: root_control_digest_for_control(Some(&active_control))
+                    .expect("active rootless serving control should encode"),
+            },
+        )
+        .await;
+
+        let read = storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("rootless serving manifest read should open");
+        assert!(
+            crate::tracked_state::load_commit_state_manifest(&read, serving_generation)
+                .await
+                .expect("rootless serving manifest absence should load")
+                .is_none()
+        );
+        drop(read);
+
+        let plan = run_ordinary_repository_gc(&storage).await;
+        assert!(
+            plan.sweep
+                .tracked_commit_roots
+                .contains(&old_root.commit_id)
+        );
+        assert!(
+            !plan
+                .sweep
+                .tracked_commit_roots
+                .contains(&serving_generation)
+        );
+    }
+
+    #[tokio::test]
+    async fn active_point_replay_closure_uses_replacement_fallback_and_fails_closed() {
+        let timestamp =
+            LixTimestamp::expect_parse("replay closure timestamp", "2026-01-01T00:00:00Z");
+
+        // A certified replacement fallback is reader-equivalent chronology:
+        // retain that physical and semantic dependency instead of the graph
+        // parent used by ordinary first-parent replay.
+        let storage = StorageAdapter::new(Memory::new());
+        let root = replay_commit_record("replay-fallback-root", 0, None, timestamp);
+        let fallback =
+            replay_commit_record("replay-fallback-base", 1, Some(root.commit_id), timestamp);
+        let active =
+            replay_commit_record("replay-fallback-active", 1, Some(root.commit_id), timestamp);
+        let mut writes = storage.new_write_set();
+        let active_inventory = stage_replacement_inventory(
+            &mut writes,
+            active.commit_id,
+            Some(fallback.commit_id),
+            "replay-fallback",
+            timestamp,
+        );
+        let mut root_manifest =
+            test_commit_state_manifest(&root, CommitStateMutationInventory::default());
+        root_manifest.replay_debt = CommitStateReplayDebt::default();
+        root_manifest.snapshot_root = Some(Box::new(test_snapshot_root(root.commit_id)));
+        let mut fallback_manifest =
+            test_commit_state_manifest(&fallback, CommitStateMutationInventory::default());
+        fallback_manifest.replay_debt = CommitStateReplayDebt::default();
+        fallback_manifest.snapshot_root = Some(Box::new(test_snapshot_root(fallback.commit_id)));
+        let active_manifest = test_commit_state_manifest(&active, active_inventory);
+        persist_replay_closure_fixture(
+            &storage,
+            writes,
+            &[root.clone(), fallback.clone(), active.clone()],
+            &[root_manifest, fallback_manifest, active_manifest.clone()],
+        )
+        .await;
+        let read = SharedStorageAdapterRead::new(
+            storage
+                .begin_read(StorageReadOptions::default())
+                .await
+                .expect("replacement replay read should open"),
+        );
+        let mut physical = BTreeSet::new();
+        let mut semantic = BTreeSet::new();
+        super::collect_active_point_replay_dependencies(
+            &read,
+            &BTreeMap::from([(active.commit_id, active_manifest)]),
+            &mut physical,
+            &mut semantic,
+        )
+        .await
+        .expect("authenticated replacement fallback should close");
+        assert_eq!(physical, BTreeSet::from([fallback.commit_id]));
+        assert_eq!(semantic, BTreeSet::from([fallback.commit_id]));
+
+        // A physical root without its semantic graph node cannot silently
+        // become a root commit; the external retained-history oracle depends
+        // on this exact fail-closed boundary.
+        let storage = StorageAdapter::new(Memory::new());
+        let missing_graph = replay_commit_record("replay-missing-graph", 1, None, timestamp);
+        let missing_graph_manifest =
+            test_commit_state_manifest(&missing_graph, CommitStateMutationInventory::default());
+        let mut writes = storage.new_write_set();
+        crate::tracked_state::stage_resealed_commit_state_manifest_for_test(
+            &mut writes,
+            &missing_graph_manifest,
+        )
+        .expect("missing-graph physical manifest should stage");
+        storage
+            .commit_write_set(writes, StorageWriteOptions::default())
+            .await
+            .expect("missing-graph fixture should commit");
+        let read = SharedStorageAdapterRead::new(
+            storage
+                .begin_read(StorageReadOptions::default())
+                .await
+                .expect("missing-graph replay read should open"),
+        );
+        let error = super::collect_active_point_replay_dependencies(
+            &read,
+            &BTreeMap::from([(missing_graph.commit_id, missing_graph_manifest)]),
+            &mut BTreeSet::new(),
+            &mut BTreeSet::new(),
+        )
+        .await
+        .expect_err("missing semantic graph node must fail closed");
+        assert!(error.message.contains("no authenticated graph node"));
+
+        // The inverse omission is equally fatal: semantic chronology cannot
+        // authorize point replay through a missing physical manifest.
+        let storage = StorageAdapter::new(Memory::new());
+        let root = replay_commit_record("replay-missing-manifest-root", 0, None, timestamp);
+        let child = replay_commit_record(
+            "replay-missing-manifest-child",
+            1,
+            Some(root.commit_id),
+            timestamp,
+        );
+        let child_manifest =
+            test_commit_state_manifest(&child, CommitStateMutationInventory::default());
+        persist_replay_closure_fixture(
+            &storage,
+            storage.new_write_set(),
+            &[root, child.clone()],
+            std::slice::from_ref(&child_manifest),
+        )
+        .await;
+        let read = SharedStorageAdapterRead::new(
+            storage
+                .begin_read(StorageReadOptions::default())
+                .await
+                .expect("missing-manifest replay read should open"),
+        );
+        let mut physical = BTreeSet::new();
+        let mut semantic = BTreeSet::new();
+        let error = super::collect_active_point_replay_dependencies(
+            &read,
+            &BTreeMap::from([(child.commit_id, child_manifest)]),
+            &mut physical,
+            &mut semantic,
+        )
+        .await
+        .expect_err("missing physical replay manifest must fail closed");
+        assert!(error.message.contains("no authenticated physical manifest"));
+        assert!(physical.is_empty());
+        assert!(semantic.is_empty());
+
+        let storage = StorageAdapter::new(Memory::new());
+        let root = replay_commit_record("replay-malformed-root", 0, None, timestamp);
+        let fallback = replay_commit_record(
+            "replay-malformed-fallback",
+            1,
+            Some(root.commit_id),
+            timestamp,
+        );
+        let active = replay_commit_record(
+            "replay-malformed-replacement",
+            1,
+            Some(root.commit_id),
+            timestamp,
+        );
+        let mut writes = storage.new_write_set();
+        let inventory = stage_replacement_inventory(
+            &mut writes,
+            active.commit_id,
+            Some(fallback.commit_id),
+            "replay-malformed-replacement",
+            timestamp,
+        );
+        let mut root_manifest =
+            test_commit_state_manifest(&root, CommitStateMutationInventory::default());
+        root_manifest.replay_debt = CommitStateReplayDebt::default();
+        root_manifest.snapshot_root = Some(Box::new(test_snapshot_root(root.commit_id)));
+        let mut fallback_manifest =
+            test_commit_state_manifest(&fallback, CommitStateMutationInventory::default());
+        fallback_manifest.replay_debt = CommitStateReplayDebt::default();
+        fallback_manifest.snapshot_root = Some(Box::new(test_snapshot_root(fallback.commit_id)));
+        let mut active_manifest = test_commit_state_manifest(&active, inventory);
+        active_manifest.replay_debt.depth = 2;
+        persist_replay_closure_fixture(
+            &storage,
+            writes,
+            &[root, fallback, active.clone()],
+            &[root_manifest, fallback_manifest, active_manifest.clone()],
+        )
+        .await;
+        let read = SharedStorageAdapterRead::new(
+            storage
+                .begin_read(StorageReadOptions::default())
+                .await
+                .expect("malformed replacement read should open"),
+        );
+        let error = super::collect_active_point_replay_dependencies(
+            &read,
+            &BTreeMap::from([(active.commit_id, active_manifest)]),
+            &mut BTreeSet::new(),
+            &mut BTreeSet::new(),
+        )
+        .await
+        .expect_err("replacement replay depth other than one must fail closed");
+        assert!(error.message.contains("malformed replay debt"));
+
+        // Non-decreasing ordinary replay debt is malformed. Detection occurs
+        // before either dependency set can authorize a retirement.
+        let storage = StorageAdapter::new(Memory::new());
+        let root = replay_commit_record("replay-debt-root", 0, None, timestamp);
+        let child = replay_commit_record("replay-debt-child", 1, Some(root.commit_id), timestamp);
+        let mut root_manifest =
+            test_commit_state_manifest(&root, CommitStateMutationInventory::default());
+        root_manifest.replay_debt = CommitStateReplayDebt::default();
+        root_manifest.snapshot_root = Some(Box::new(test_snapshot_root(root.commit_id)));
+        let mut child_manifest =
+            test_commit_state_manifest(&child, CommitStateMutationInventory::default());
+        child_manifest.replay_debt.depth = 2;
+        persist_replay_closure_fixture(
+            &storage,
+            storage.new_write_set(),
+            &[root.clone(), child.clone()],
+            &[root_manifest, child_manifest.clone()],
+        )
+        .await;
+        let read = SharedStorageAdapterRead::new(
+            storage
+                .begin_read(StorageReadOptions::default())
+                .await
+                .expect("malformed replay read should open"),
+        );
+        let mut physical = BTreeSet::new();
+        let mut semantic = BTreeSet::new();
+        let error = super::collect_active_point_replay_dependencies(
+            &read,
+            &BTreeMap::from([(child.commit_id, child_manifest)]),
+            &mut physical,
+            &mut semantic,
+        )
+        .await
+        .expect_err("non-decreasing replay debt must fail closed");
+        assert!(error.message.contains("replay debt disagrees"));
+        assert!(physical.is_empty());
+        assert!(semantic.is_empty());
+
+        // Replacement fallbacks are authenticated physical links, but they
+        // are not allowed to form a second cyclic chronology.
+        let storage = StorageAdapter::new(Memory::new());
+        let root = replay_commit_record("replay-cycle-root", 0, None, timestamp);
+        let left = replay_commit_record("replay-cycle-left", 1, Some(root.commit_id), timestamp);
+        let right = replay_commit_record("replay-cycle-right", 1, Some(root.commit_id), timestamp);
+        let mut writes = storage.new_write_set();
+        let left_inventory = stage_replacement_inventory(
+            &mut writes,
+            left.commit_id,
+            Some(right.commit_id),
+            "replay-cycle-left",
+            timestamp,
+        );
+        let right_inventory = stage_replacement_inventory(
+            &mut writes,
+            right.commit_id,
+            Some(left.commit_id),
+            "replay-cycle-right",
+            timestamp,
+        );
+        let mut root_manifest =
+            test_commit_state_manifest(&root, CommitStateMutationInventory::default());
+        root_manifest.replay_debt = CommitStateReplayDebt::default();
+        root_manifest.snapshot_root = Some(Box::new(test_snapshot_root(root.commit_id)));
+        let left_manifest = test_commit_state_manifest(&left, left_inventory);
+        let right_manifest = test_commit_state_manifest(&right, right_inventory);
+        persist_replay_closure_fixture(
+            &storage,
+            writes,
+            &[root, left.clone(), right.clone()],
+            &[root_manifest, left_manifest.clone(), right_manifest],
+        )
+        .await;
+        let read = SharedStorageAdapterRead::new(
+            storage
+                .begin_read(StorageReadOptions::default())
+                .await
+                .expect("cyclic replay read should open"),
+        );
+        let error = super::collect_active_point_replay_dependencies(
+            &read,
+            &BTreeMap::from([(left.commit_id, left_manifest)]),
+            &mut BTreeSet::new(),
+            &mut BTreeSet::new(),
+        )
+        .await
+        .expect_err("replacement fallback cycle must fail closed");
+        assert!(error.message.contains("dependency cycle"));
+    }
+
+    #[tokio::test]
+    async fn ordinary_gc_releases_finite_selected_owner_only_after_checkpoint_release() {
+        let storage = StorageAdapter::new(Memory::new());
+        let timestamp =
+            LixTimestamp::expect_parse("selected owner timestamp", "2026-01-01T00:00:00Z");
+        let owner = replay_commit_record("selected-owner-source", 0, None, timestamp);
+        let checkpoint = replay_commit_record(
+            "selected-owner-checkpoint",
+            1,
+            Some(owner.commit_id),
+            timestamp,
+        );
+        let released = replay_commit_record(
+            "selected-owner-released",
+            2,
+            Some(checkpoint.commit_id),
+            timestamp,
+        );
+        let selected_change = packed_change(
+            "selected-owner-change",
+            "selected-owner-row",
+            JsonSlot::Inline(r#"{"selected":true}"#.into()),
+        );
+
+        let mut writes = storage.new_write_set();
+        stage_reachability_queue_seed(&mut writes).expect("selected-owner queue should seed");
+        let owner_deltas =
+            commit_delta_refs(owner.commit_id, std::slice::from_ref(&selected_change));
+        let owner_stage = stage_commit_deltas_for_commit_state(&mut writes, &owner_deltas)
+            .expect("selected owner payload should stage");
+        stage_change_locators(&mut writes, &owner_stage.locators);
+        let mut checkpoint_deltas =
+            commit_delta_refs(checkpoint.commit_id, std::slice::from_ref(&selected_change));
+        checkpoint_deltas[0].authored = false;
+        let checkpoint_stage =
+            stage_commit_deltas_for_commit_state(&mut writes, &checkpoint_deltas)
+                .expect("finite selected checkpoint member should stage");
+
+        let mut owner_manifest =
+            test_commit_state_manifest(&owner, owner_stage.mutation_inventory().clone());
+        owner_manifest.replay_debt = CommitStateReplayDebt::default();
+        owner_manifest.snapshot_root = Some(Box::new(test_snapshot_root(owner.commit_id)));
+        let mut checkpoint_manifest =
+            test_commit_state_manifest(&checkpoint, checkpoint_stage.mutation_inventory().clone());
+        checkpoint_manifest.replay_debt = CommitStateReplayDebt::default();
+        checkpoint_manifest.snapshot_root =
+            Some(Box::new(test_snapshot_root(checkpoint.commit_id)));
+        let mut released_manifest =
+            test_commit_state_manifest(&released, CommitStateMutationInventory::default());
+        released_manifest.replay_debt = CommitStateReplayDebt::default();
+        released_manifest.snapshot_root = Some(Box::new(test_snapshot_root(released.commit_id)));
+
+        let control_ref = ChangeId::for_test_label("selected-owner-control");
+        let owner_control = replay_branch_control(owner.commit_id, control_ref, timestamp);
+        let checkpoint_control =
+            replay_branch_control(checkpoint.commit_id, control_ref, timestamp);
+        let released_control = replay_branch_control(released.commit_id, control_ref, timestamp);
+        stage_branch_head_control(&mut writes, "main", checkpoint_control)
+            .expect("checkpoint control should stage");
+        persist_replay_closure_fixture(
+            &storage,
+            writes,
+            &[owner.clone(), checkpoint.clone(), released.clone()],
+            &[owner_manifest, checkpoint_manifest, released_manifest],
+        )
+        .await;
+        stage_replay_root_delta(
+            &storage,
+            RootReachabilityDelta {
+                branch_id: "main".to_owned(),
+                old_root: Some(owner.commit_id),
+                new_root: Some(checkpoint.commit_id),
+                old_control: Some(owner_control),
+                new_control: Some(checkpoint_control),
+                old_control_digest: root_control_digest_for_control(Some(&owner_control))
+                    .expect("owner control should encode"),
+                new_control_digest: root_control_digest_for_control(Some(&checkpoint_control))
+                    .expect("checkpoint control should encode"),
+            },
+        )
+        .await;
+
+        let read = storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("selected-owner dependency read should open");
+        assert_eq!(
+            crate::tracked_state::load_local_selected_change_owner_commit_ids(
+                &read,
+                checkpoint.commit_id,
+            )
+            .await
+            .expect("selected owner should resolve"),
+            BTreeSet::from([owner.commit_id])
+        );
+        drop(read);
+
+        let retained_plan = run_ordinary_repository_gc(&storage).await;
+        assert!(retained_plan.sweep.tracked_commit_roots.is_empty());
+        let read = storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("retained selected-owner read should open");
+        assert!(
+            crate::tracked_state::load_commit_state_manifest(&read, owner.commit_id)
+                .await
+                .expect("retained selected owner should load")
+                .is_some(),
+            "the finite selected locator keeps its physical owner live"
+        );
+        drop(read);
+
+        let mut writes = storage.new_write_set();
+        stage_branch_head_control(&mut writes, "main", released_control)
+            .expect("released control should stage");
+        let read = storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("selected-owner release read should open");
+        let mut preconditions = Vec::new();
+        stage_reachability_delta_batch(
+            &read,
+            &mut writes,
+            &[RootReachabilityDelta {
+                branch_id: "main".to_owned(),
+                old_root: Some(checkpoint.commit_id),
+                new_root: Some(released.commit_id),
+                old_control: Some(checkpoint_control),
+                new_control: Some(released_control),
+                old_control_digest: root_control_digest_for_control(Some(&checkpoint_control))
+                    .expect("checkpoint control should encode"),
+                new_control_digest: root_control_digest_for_control(Some(&released_control))
+                    .expect("released control should encode"),
+            }],
+            &[],
+            &mut preconditions,
+        )
+        .await
+        .expect("selected-owner release delta should stage");
+        drop(read);
+        storage
+            .commit_write_set(
+                writes,
+                StorageWriteOptions {
+                    preconditions,
+                    ..StorageWriteOptions::default()
+                },
+            )
+            .await
+            .expect("selected-owner release should publish atomically");
+
+        let released_plan = run_ordinary_repository_gc(&storage).await;
+        assert!(
+            released_plan
+                .sweep
+                .tracked_commit_roots
+                .contains(&owner.commit_id)
+        );
+        let read = storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("released selected-owner read should open");
+        assert!(
+            crate::tracked_state::load_commit_state_manifest(&read, owner.commit_id)
+                .await
+                .expect("released owner absence should load")
+                .is_none(),
+            "the owner is reclaimable after the final checkpoint releases the selection"
+        );
+    }
+
+    #[tokio::test]
+    async fn ordinary_gc_releases_scoped_descriptor_owner_only_after_root_release() {
+        let storage = StorageAdapter::new(Memory::new());
+        let timestamp =
+            LixTimestamp::expect_parse("scoped owner timestamp", "2026-01-01T00:00:00Z");
+        let owner = replay_commit_record("scoped-part-owner", 0, None, timestamp);
+        let checkpoint = replay_commit_record(
+            "scoped-part-checkpoint",
+            1,
+            Some(owner.commit_id),
+            timestamp,
+        );
+        let released = replay_commit_record(
+            "scoped-part-released",
+            2,
+            Some(checkpoint.commit_id),
+            timestamp,
+        );
+        let scope = CommitDeltaReplacementScope {
+            schema_key: "scoped_part_owner".to_owned(),
+            file_id: None,
+        };
+        let entity_pk = EntityPk::single("row");
+        let encoded_key =
+            crate::tracked_state::encode_key_ref(crate::tracked_state::TrackedStateKeyRef {
+                schema_key: &scope.schema_key,
+                file_id: None,
+                entity_pk: &entity_pk,
+            });
+
+        let mut writes = storage.new_write_set();
+        stage_reachability_queue_seed(&mut writes).expect("scoped owner queue should seed");
+        let owner_inventory = stage_replacement_inventory(
+            &mut writes,
+            owner.commit_id,
+            None,
+            &scope.schema_key,
+            timestamp,
+        );
+        let descriptor = crate::tracked_state::CurrentStatePartDescriptor {
+            first_key: encoded_key.clone(),
+            last_key: encoded_key,
+            content_digest: owner_inventory.replacement_part_digests[0],
+            payload_refs_digest: [0; 32],
+            source_kind: 0,
+            source_id: [0; 16],
+            owner_commit_id: *owner.commit_id.as_uuid().as_bytes(),
+            part_index: 0,
+            source_page_index: 0,
+            source_row_offset: 0,
+            row_count: 1,
+            fragmented: false,
+            uniform_created_at: timestamp,
+            uniform_updated_at: timestamp,
+        };
+        let part = crate::tracked_state::current_state_envelope::scoped_range_part_from_current_state_descriptor(
+            &scope,
+            &descriptor,
+        )
+        .expect("scoped owner descriptor should encode");
+        let marker = crate::tracked_state::scoped_range::ScopedRangeCoverageMarker {
+            scope: part.scope.clone(),
+            row_count: 1,
+            part_count: 1,
+        };
+        let tree = crate::tracked_state::scoped_range::stage_scoped_range_tree(
+            &mut writes,
+            [(marker, vec![part])],
+        )
+        .expect("scoped owner tree should stage");
+        let checkpoint_inventory = CommitStateMutationInventory::default();
+        let scoped_root = crate::tracked_state::attest_scoped_range_root(
+            checkpoint.commit_id,
+            None,
+            &checkpoint_inventory,
+            tree,
+        )
+        .expect("scoped owner root should attest");
+
+        let mut owner_manifest = test_commit_state_manifest(&owner, owner_inventory);
+        owner_manifest.replay_debt = CommitStateReplayDebt::default();
+        owner_manifest.snapshot_root = Some(Box::new(test_snapshot_root(owner.commit_id)));
+        let mut checkpoint_manifest = test_commit_state_manifest(&checkpoint, checkpoint_inventory);
+        checkpoint_manifest.replay_debt = CommitStateReplayDebt::default();
+        checkpoint_manifest.snapshot_root =
+            Some(Box::new(test_snapshot_root(checkpoint.commit_id)));
+        checkpoint_manifest.current_state_scoped_ranges = Some(Box::new(scoped_root));
+        let mut released_manifest =
+            test_commit_state_manifest(&released, CommitStateMutationInventory::default());
+        released_manifest.replay_debt = CommitStateReplayDebt::default();
+        released_manifest.snapshot_root = Some(Box::new(test_snapshot_root(released.commit_id)));
+
+        let control_ref = ChangeId::for_test_label("scoped-owner-control");
+        let owner_control = replay_branch_control(owner.commit_id, control_ref, timestamp);
+        let checkpoint_control =
+            replay_branch_control(checkpoint.commit_id, control_ref, timestamp);
+        let released_control = replay_branch_control(released.commit_id, control_ref, timestamp);
+        stage_branch_head_control(&mut writes, "main", checkpoint_control)
+            .expect("scoped owner checkpoint control should stage");
+        persist_replay_closure_fixture(
+            &storage,
+            writes,
+            &[owner.clone(), checkpoint.clone(), released.clone()],
+            &[owner_manifest, checkpoint_manifest, released_manifest],
+        )
+        .await;
+        stage_replay_root_delta(
+            &storage,
+            RootReachabilityDelta {
+                branch_id: "main".to_owned(),
+                old_root: Some(owner.commit_id),
+                new_root: Some(checkpoint.commit_id),
+                old_control: Some(owner_control),
+                new_control: Some(checkpoint_control),
+                old_control_digest: root_control_digest_for_control(Some(&owner_control))
+                    .expect("scoped owner control should encode"),
+                new_control_digest: root_control_digest_for_control(Some(&checkpoint_control))
+                    .expect("scoped checkpoint control should encode"),
+            },
+        )
+        .await;
+
+        assert!(
+            run_ordinary_repository_gc(&storage)
+                .await
+                .sweep
+                .tracked_commit_roots
+                .is_empty()
+        );
+        let read = storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("retained scoped owner read should open");
+        assert!(
+            crate::tracked_state::load_commit_state_manifest(&read, owner.commit_id)
+                .await
+                .expect("retained scoped owner should load")
+                .is_some()
+        );
+        drop(read);
+
+        publish_replay_root_release(&storage, "main", checkpoint_control, released_control).await;
+        let released_plan = run_ordinary_repository_gc(&storage).await;
+        assert!(
+            released_plan
+                .sweep
+                .tracked_commit_roots
+                .contains(&owner.commit_id)
+        );
+        let read = storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("released scoped owner read should open");
+        assert!(
+            crate::tracked_state::load_commit_state_manifest(&read, owner.commit_id)
+                .await
+                .expect("released scoped owner absence should load")
+                .is_none()
+        );
+    }
+
+    #[tokio::test]
+    async fn ordinary_gc_releases_native_row_owner_only_after_scoped_root_release() {
+        let storage = StorageAdapter::new(Memory::new());
+        let timestamp =
+            LixTimestamp::expect_parse("native row owner timestamp", "2026-01-01T00:00:00Z");
+        let owner = replay_commit_record("native-row-owner", 0, None, timestamp);
+        let checkpoint =
+            replay_commit_record("native-row-checkpoint", 1, Some(owner.commit_id), timestamp);
+        let released = replay_commit_record(
+            "native-row-released",
+            2,
+            Some(checkpoint.commit_id),
+            timestamp,
+        );
+        let row = crate::tracked_state::CurrentStateDataRow {
+            encoded_key: b"native-row".to_vec(),
+            value: TrackedStateIndexValue {
+                change_id: ChangeId::for_test_label("native-row-change"),
+                commit_id: owner.commit_id,
+                deleted: false,
+                created_at: timestamp,
+                updated_at: timestamp,
+            },
+            snapshot: JsonSlot::Inline(r#"{"native":true}"#.into()),
+            metadata: JsonSlot::None,
+        };
+        let encoded = crate::tracked_state::encode_current_state_data_part(
+            std::slice::from_ref(&row),
+            &mut None,
+        )
+        .expect("native row part should encode");
+        let scope = CommitDeltaReplacementScope {
+            schema_key: "native_row_owner".to_owned(),
+            file_id: None,
+        };
+        let descriptor = crate::tracked_state::CurrentStatePartDescriptor {
+            first_key: encoded.first_key.clone(),
+            last_key: encoded.last_key.clone(),
+            content_digest: encoded.digest,
+            payload_refs_digest: encoded.refs_digest,
+            source_kind: 1,
+            source_id: [0; 16],
+            owner_commit_id: [0; 16],
+            part_index: 0,
+            source_page_index: 0,
+            source_row_offset: 0,
+            row_count: encoded.row_count,
+            fragmented: false,
+            uniform_created_at: LixTimestamp::from_unix_millis_utc_lossy(0),
+            uniform_updated_at: LixTimestamp::from_unix_millis_utc_lossy(0),
+        };
+        let part = crate::tracked_state::current_state_envelope::scoped_range_part_from_current_state_descriptor(
+            &scope,
+            &descriptor,
+        )
+        .expect("native row descriptor should encode");
+        let marker = crate::tracked_state::scoped_range::ScopedRangeCoverageMarker {
+            scope: part.scope.clone(),
+            row_count: 1,
+            part_count: 1,
+        };
+
+        let mut writes = storage.new_write_set();
+        stage_reachability_queue_seed(&mut writes).expect("native row queue should seed");
+        writes.put(
+            crate::tracked_state::CURRENT_STATE_DATA_PART_SPACE,
+            StorageKey(Bytes::copy_from_slice(&encoded.digest)),
+            StorageValue {
+                bytes: encoded.bytes.clone(),
+            },
+        );
+        writes.put(
+            crate::tracked_state::CURRENT_STATE_DATA_PART_REFS_SPACE,
+            StorageKey(Bytes::copy_from_slice(&encoded.refs_digest)),
+            StorageValue {
+                bytes: encoded.refs_bytes,
+            },
+        );
+        let tree = crate::tracked_state::scoped_range::stage_scoped_range_tree(
+            &mut writes,
+            [(marker, vec![part])],
+        )
+        .expect("native row scoped tree should stage");
+        let snapshot_entity_pk = EntityPk::single("native-row");
+        let read = storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("native serving snapshot read should open");
+        let tracked_state = TrackedStateContext::new();
+        let mut snapshot_writer = tracked_state.writer(&read, &mut writes);
+        snapshot_writer
+            .stage_commit_root(
+                &checkpoint.commit_id.to_string(),
+                None,
+                [TrackedStateDeltaRef {
+                    schema_key: &scope.schema_key,
+                    file_id: None,
+                    entity_pk: &snapshot_entity_pk,
+                    change_id: row.value.change_id,
+                    commit_id: row.value.commit_id,
+                    deleted: false,
+                    created_at: timestamp,
+                    updated_at: timestamp,
+                }],
+            )
+            .await
+            .expect("native serving snapshot should stage");
+        let checkpoint_snapshot_root = snapshot_writer
+            .staged_commit_roots()
+            .find(|root| root.commit_id == checkpoint.commit_id)
+            .cloned()
+            .expect("native serving snapshot metadata should stage");
+        drop(snapshot_writer);
+        drop(read);
+        let inventory = CommitStateMutationInventory::default();
+        let scoped_root = crate::tracked_state::attest_scoped_range_root(
+            checkpoint.commit_id,
+            None,
+            &inventory,
+            tree,
+        )
+        .expect("native row scoped root should attest");
+
+        let mut owner_manifest =
+            test_commit_state_manifest(&owner, CommitStateMutationInventory::default());
+        owner_manifest.replay_debt = CommitStateReplayDebt::default();
+        owner_manifest.snapshot_root = Some(Box::new(test_snapshot_root(owner.commit_id)));
+        let mut checkpoint_manifest = test_commit_state_manifest(&checkpoint, inventory);
+        checkpoint_manifest.replay_debt = CommitStateReplayDebt::default();
+        checkpoint_manifest.snapshot_root = Some(Box::new(checkpoint_snapshot_root));
+        checkpoint_manifest.current_state_scoped_ranges = Some(Box::new(scoped_root));
+        let mut released_manifest =
+            test_commit_state_manifest(&released, CommitStateMutationInventory::default());
+        released_manifest.replay_debt = CommitStateReplayDebt::default();
+        released_manifest.snapshot_root = Some(Box::new(test_snapshot_root(released.commit_id)));
+
+        let control_ref = ChangeId::for_test_label("native-row-control");
+        let owner_control = replay_branch_control(owner.commit_id, control_ref, timestamp);
+        let mut checkpoint_control =
+            replay_branch_control(checkpoint.commit_id, control_ref, timestamp);
+        let serving_generation = CommitId::for_test_label("native-row-serving-generation");
+        checkpoint_control.tracked_generation = serving_generation;
+        let released_control = replay_branch_control(released.commit_id, control_ref, timestamp);
+        let read = storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("native serving-base read should open");
+        TrackedHeadContext::new()
+            .writer(&read, &mut writes)
+            .stage_root_current_base("main", serving_generation, checkpoint.commit_id);
+        drop(read);
+        stage_branch_head_control(&mut writes, "main", checkpoint_control)
+            .expect("native row checkpoint control should stage");
+        persist_replay_closure_fixture(
+            &storage,
+            writes,
+            &[owner.clone(), checkpoint.clone(), released.clone()],
+            &[owner_manifest, checkpoint_manifest, released_manifest],
+        )
+        .await;
+        stage_replay_root_delta(
+            &storage,
+            RootReachabilityDelta {
+                branch_id: "main".to_owned(),
+                old_root: Some(owner.commit_id),
+                new_root: Some(checkpoint.commit_id),
+                old_control: Some(owner_control),
+                new_control: Some(checkpoint_control),
+                old_control_digest: root_control_digest_for_control(Some(&owner_control))
+                    .expect("native owner control should encode"),
+                new_control_digest: root_control_digest_for_control(Some(&checkpoint_control))
+                    .expect("native checkpoint control should encode"),
+            },
+        )
+        .await;
+
+        let read = storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("native dependency read should open");
+        assert_eq!(
+            super::validate_live_native_parts(&read, &BTreeSet::from([encoded.digest]))
+                .await
+                .expect("native owner should decode"),
+            BTreeSet::from([owner.commit_id])
+        );
+        drop(read);
+
+        // A present native part is authenticated content, not presence-only
+        // liveness. Corrupt bytes must abort the complete plan before any
+        // queue consumption or retirement mutation is staged.
+        let native_key = StorageKey(Bytes::copy_from_slice(&encoded.digest));
+        let mut remove = storage.new_write_set();
+        remove.delete(
+            crate::tracked_state::CURRENT_STATE_DATA_PART_SPACE,
+            native_key.clone(),
+        );
+        storage
+            .commit_write_set(remove, StorageWriteOptions::default())
+            .await
+            .expect("native part removal should commit");
+        let mut corrupt = storage.new_write_set();
+        corrupt.put(
+            crate::tracked_state::CURRENT_STATE_DATA_PART_SPACE,
+            native_key.clone(),
+            StorageValue {
+                bytes: Bytes::from_static(b"malformed-native-current-state-part"),
+            },
+        );
+        storage
+            .commit_write_set(corrupt, StorageWriteOptions::default())
+            .await
+            .expect("malformed native part should commit");
+        let read = SharedStorageAdapterRead::new(
+            storage
+                .begin_read(StorageReadOptions::default())
+                .await
+                .expect("malformed native GC read should open"),
+        );
+        let mut failed_writes = storage.new_write_set();
+        let mut failed_preconditions = Vec::new();
+        super::stage_repository_gc_with_preconditions(
+            read,
+            &mut failed_writes,
+            &mut failed_preconditions,
+        )
+        .await
+        .expect_err("malformed native owner must fail the whole GC plan");
+        assert!(failed_writes.is_empty());
+        assert!(failed_preconditions.is_empty());
+
+        let mut remove = storage.new_write_set();
+        remove.delete(
+            crate::tracked_state::CURRENT_STATE_DATA_PART_SPACE,
+            native_key.clone(),
+        );
+        storage
+            .commit_write_set(remove, StorageWriteOptions::default())
+            .await
+            .expect("malformed native part removal should commit");
+        let mut restore = storage.new_write_set();
+        restore.put(
+            crate::tracked_state::CURRENT_STATE_DATA_PART_SPACE,
+            native_key,
+            StorageValue {
+                bytes: encoded.bytes.clone(),
+            },
+        );
+        storage
+            .commit_write_set(restore, StorageWriteOptions::default())
+            .await
+            .expect("authenticated native part restoration should commit");
+
+        assert!(
+            run_ordinary_repository_gc(&storage)
+                .await
+                .sweep
+                .tracked_commit_roots
+                .is_empty()
+        );
+        let read = storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("retained native owner read should open");
+        assert!(
+            crate::tracked_state::load_commit_state_manifest(&read, owner.commit_id)
+                .await
+                .expect("retained native owner should load")
+                .is_some()
+        );
+        drop(read);
+
+        let mut writes = storage.new_write_set();
+        stage_branch_head_control(&mut writes, "main", released_control)
+            .expect("native released control should stage");
+        let read = storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("native release read should open");
+        let mut preconditions = Vec::new();
+        stage_reachability_delta_batch(
+            &read,
+            &mut writes,
+            &[RootReachabilityDelta {
+                branch_id: "main".to_owned(),
+                old_root: Some(checkpoint.commit_id),
+                new_root: Some(released.commit_id),
+                old_control: Some(checkpoint_control),
+                new_control: Some(released_control),
+                old_control_digest: root_control_digest_for_control(Some(&checkpoint_control))
+                    .expect("native checkpoint control should encode"),
+                new_control_digest: root_control_digest_for_control(Some(&released_control))
+                    .expect("native released control should encode"),
+            }],
+            &[],
+            &mut preconditions,
+        )
+        .await
+        .expect("native owner release should stage");
+        drop(read);
+        storage
+            .commit_write_set(
+                writes,
+                StorageWriteOptions {
+                    preconditions,
+                    ..StorageWriteOptions::default()
+                },
+            )
+            .await
+            .expect("native owner release should publish");
+
+        let released_plan = run_ordinary_repository_gc(&storage).await;
+        assert!(
+            released_plan
+                .sweep
+                .tracked_commit_roots
+                .contains(&owner.commit_id)
+        );
+        let read = storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("released native owner read should open");
+        assert!(
+            crate::tracked_state::load_commit_state_manifest(&read, owner.commit_id)
+                .await
+                .expect("released native owner absence should load")
+                .is_none()
+        );
+    }
 
     async fn tree_sweep_fixture() -> (
         StorageAdapter<Memory>,
@@ -4714,7 +6040,7 @@ mod tests {
                     created_at: timestamp,
                     updated_at: timestamp,
                     snapshot: snapshot_slot.as_ref_slot(),
-                    metadata: crate::json_store::JsonSlotRef::None,
+                    metadata: JsonSlotRef::None,
                     columnar_base_coordinate: None,
                 }],
                 &BTreeSet::new(),
@@ -4822,6 +6148,221 @@ mod tests {
                 "2026-01-01T00:00:00.000Z",
             ),
         }
+    }
+
+    fn replay_commit_record(
+        label: &str,
+        generation: u64,
+        parent: Option<CommitId>,
+        created_at: LixTimestamp,
+    ) -> CommitRecord {
+        let commit_id =
+            CommitId::with_change_address_space(*CommitId::for_test_label(label).as_uuid());
+        CommitRecord {
+            format_version: 2,
+            commit_id,
+            generation,
+            parent_commit_ids: parent.into_iter().collect(),
+            change_id: ChangeId::for_test_label(&format!("{label}-header")),
+            account_id: crate::ANONYMOUS_ACCOUNT_ID.to_string(),
+            created_at,
+        }
+    }
+
+    fn replay_branch_control(
+        commit_id: CommitId,
+        ref_change_id: ChangeId,
+        timestamp: LixTimestamp,
+    ) -> BranchHeadControl {
+        BranchHeadControl {
+            head_commit_id: commit_id,
+            tracked_generation: commit_id,
+            untracked_generation: commit_id,
+            current_state_revision: 0,
+            working_diff_checkpoint_commit_id: None,
+            created_at: timestamp,
+            updated_at: timestamp,
+            ref_change_id,
+            schema_presence_bloom: [0; 4],
+        }
+    }
+
+    fn stage_replacement_inventory(
+        writes: &mut crate::storage_adapter::StorageWriteSet,
+        commit_id: CommitId,
+        fallback_commit_id: Option<CommitId>,
+        schema_key: &str,
+        timestamp: LixTimestamp,
+    ) -> CommitStateMutationInventory {
+        let scope = CommitDeltaReplacementScope {
+            schema_key: schema_key.to_owned(),
+            file_id: None,
+        };
+        let generation = CommitDeltaReplacementGeneration {
+            scope: scope.clone(),
+            fallback_commit_id,
+            lifecycle_summary: CommitDeltaLifecycleSummary {
+                scope,
+                ordered_identity_digest: *blake3::hash(schema_key.as_bytes()).as_bytes(),
+                uniform_created_at: timestamp,
+            },
+        };
+        let staged = stage_ordered_addressable_replacement_parts(
+            writes,
+            std::iter::once(Ok(TrackedStateSingleStringReplacementRef {
+                schema_key,
+                file_id: None,
+                entity_pk: "row",
+                commit_id,
+                created_at: timestamp,
+                updated_at: timestamp,
+                snapshot: JsonSlotRef::Inline("{}"),
+                metadata: JsonSlotRef::None,
+            })),
+            &generation,
+        )
+        .expect("replacement replay inventory should stage");
+        let mut inventory = staged.mutation_inventory().clone();
+        inventory.parts.clear();
+        inventory
+    }
+
+    async fn persist_replay_closure_fixture(
+        storage: &StorageAdapter<Memory>,
+        mut writes: crate::storage_adapter::StorageWriteSet,
+        records: &[CommitRecord],
+        manifests: &[CommitStateManifest],
+    ) {
+        let mut read = storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("replay fixture read should open");
+        ChangelogContext::new()
+            .writer(&mut read, &mut writes)
+            .stage_append(ChangelogAppend {
+                commits: records.to_vec(),
+                changes: Vec::new(),
+            })
+            .await
+            .expect("replay fixture commits should stage");
+        for manifest in manifests {
+            crate::tracked_state::stage_resealed_commit_state_manifest_for_test(
+                &mut writes,
+                manifest,
+            )
+            .expect("replay fixture manifest should stage");
+        }
+        drop(read);
+        storage
+            .commit_write_set(writes, StorageWriteOptions::default())
+            .await
+            .expect("replay fixture should commit");
+    }
+
+    async fn stage_replay_root_delta(
+        storage: &StorageAdapter<Memory>,
+        delta: RootReachabilityDelta,
+    ) {
+        let read = storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("replay delta read should open");
+        let mut writes = storage.new_write_set();
+        let mut preconditions = Vec::new();
+        stage_reachability_delta_batch(
+            &read,
+            &mut writes,
+            std::slice::from_ref(&delta),
+            &[],
+            &mut preconditions,
+        )
+        .await
+        .expect("replay delta should stage");
+        drop(read);
+        storage
+            .commit_write_set(
+                writes,
+                StorageWriteOptions {
+                    preconditions,
+                    ..StorageWriteOptions::default()
+                },
+            )
+            .await
+            .expect("replay delta should commit");
+    }
+
+    async fn publish_replay_root_release(
+        storage: &StorageAdapter<Memory>,
+        branch_id: &str,
+        old_control: BranchHeadControl,
+        new_control: BranchHeadControl,
+    ) {
+        let mut writes = storage.new_write_set();
+        stage_branch_head_control(&mut writes, branch_id, new_control)
+            .expect("released replay control should stage");
+        let read = storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("replay release read should open");
+        let mut preconditions = Vec::new();
+        stage_reachability_delta_batch(
+            &read,
+            &mut writes,
+            &[RootReachabilityDelta {
+                branch_id: branch_id.to_owned(),
+                old_root: Some(old_control.head_commit_id),
+                new_root: Some(new_control.head_commit_id),
+                old_control: Some(old_control),
+                new_control: Some(new_control),
+                old_control_digest: root_control_digest_for_control(Some(&old_control))
+                    .expect("old replay control should encode"),
+                new_control_digest: root_control_digest_for_control(Some(&new_control))
+                    .expect("new replay control should encode"),
+            }],
+            &[],
+            &mut preconditions,
+        )
+        .await
+        .expect("replay release delta should stage");
+        drop(read);
+        storage
+            .commit_write_set(
+                writes,
+                StorageWriteOptions {
+                    preconditions,
+                    ..StorageWriteOptions::default()
+                },
+            )
+            .await
+            .expect("replay release should publish");
+    }
+
+    async fn run_ordinary_repository_gc(
+        storage: &StorageAdapter<Memory>,
+    ) -> super::RepositoryGcPlan {
+        let read = SharedStorageAdapterRead::new(
+            storage
+                .begin_read(StorageReadOptions::default())
+                .await
+                .expect("ordinary GC read should open"),
+        );
+        let mut writes = storage.new_write_set();
+        let mut preconditions = Vec::new();
+        let plan =
+            super::stage_repository_gc_with_preconditions(read, &mut writes, &mut preconditions)
+                .await
+                .expect("ordinary GC should stage");
+        storage
+            .commit_write_set(
+                writes,
+                StorageWriteOptions {
+                    preconditions,
+                    ..StorageWriteOptions::default()
+                },
+            )
+            .await
+            .expect("ordinary GC should commit");
+        plan
     }
 
     fn commit_delta_refs<'a>(

--- a/packages/lix/src/live_state/tracked_head.rs
+++ b/packages/lix/src/live_state/tracked_head.rs
@@ -43,7 +43,7 @@ use crate::LixError;
 use crate::NullableKeyFilter;
 #[cfg(test)]
 use crate::branch::stage_branch_head_control;
-use crate::branch::{BranchHeadControl, BranchHeadControlContext};
+use crate::branch::{BranchHeadControl, BranchHeadControlContext, BranchHeadTrackedReachability};
 use crate::changelog::{ChangeId, ChangeRecordProjection, CommitId};
 use crate::common::{LixTimestamp, SharedStr};
 use crate::entity_pk::EntityPk;

--- a/packages/lix/src/live_state/tracked_head/hot.rs
+++ b/packages/lix/src/live_state/tracked_head/hot.rs
@@ -3401,6 +3401,12 @@ async fn scan_packed_current_base_rows(
     if base_refs.is_empty() {
         return Ok(MaterializedLiveStateBatch::default());
     }
+    if request.read_columns.columns.as_slice() == ["commit_id"] {
+        return scan_packed_current_base_provenance_rows(
+            store, branch_id, base_refs, request, limit,
+        )
+        .await;
+    }
     let single_base = base_refs.len() == 1;
     let mut winners = BTreeMap::new();
     let mut ordered_winners = None;
@@ -3602,6 +3608,83 @@ async fn scan_packed_current_base_rows(
             DeferredJsonField::Snapshot => rows.set_snapshot_content(deferred.row_index, json),
             DeferredJsonField::Metadata => rows.set_metadata(deferred.row_index, json),
         }
+    }
+    Ok(rows.finish())
+}
+
+/// Provenance-only scan for authenticated packed current-state bases.
+///
+/// The compact identity/value plane already carries the owning commit ID.
+/// Loading each payload-bearing commit member again would add one point-read
+/// request and decoded change record per live row even though destructive
+/// reachability needs no payload. Preserve the normal winner rule while
+/// decoding each packed segment once and materializing only fixed provenance.
+async fn scan_packed_current_base_provenance_rows(
+    store: &(impl StorageAdapterRead + ?Sized),
+    branch_id: &str,
+    base_refs: Vec<PackedCurrentBaseRef>,
+    request: &TrackedStateScanRequest,
+    limit: Option<usize>,
+) -> Result<MaterializedLiveStateBatch, LixError> {
+    let mut winners = BTreeMap::new();
+    for base_ref in base_refs {
+        let compact = crate::tracked_state::scan_commit_delta_values(
+            store,
+            base_ref.commit_id,
+            &request.filter.schema_keys,
+        )
+        .await?;
+        for row in compact.iter() {
+            let key = row.key_ref();
+            let value = row.value();
+            if value.deleted
+                || !packed_identity_matches_filter(
+                    key.schema_key,
+                    key.entity_pk,
+                    key.file_id,
+                    &request.filter,
+                )
+            {
+                continue;
+            }
+            let identity = (
+                key.schema_key.to_owned(),
+                key.entity_pk.clone(),
+                key.file_id.map(str::to_owned),
+            );
+            match winners.entry(identity) {
+                std::collections::btree_map::Entry::Vacant(entry) => {
+                    entry.insert(value.clone());
+                }
+                std::collections::btree_map::Entry::Occupied(mut entry)
+                    if entry.get().commit_id < value.commit_id =>
+                {
+                    entry.insert(value.clone());
+                }
+                std::collections::btree_map::Entry::Occupied(_) => {}
+            }
+        }
+    }
+
+    let row_capacity = limit.map_or(winners.len(), |limit| limit.min(winners.len()));
+    let mut rows = MaterializedLiveStateBatchBuilder::with_capacity(row_capacity);
+    let global = branch_id == crate::GLOBAL_BRANCH_ID;
+    for ((schema_key, entity_pk, file_id), value) in winners.into_iter().take(row_capacity) {
+        rows.push_materialized(
+            entity_pk,
+            schema_key,
+            file_id,
+            None,
+            None,
+            false,
+            value.created_at,
+            value.updated_at,
+            global,
+            Some(value.change_id),
+            Some(value.commit_id),
+            false,
+            branch_id,
+        );
     }
     Ok(rows.finish())
 }
@@ -4170,6 +4253,50 @@ where
             rows.push((branch_id.clone(), branch_rows));
         }
         Ok(rows)
+    }
+
+    /// Resolves the semantic owners named by every authenticated tracked
+    /// current-serving generation.
+    ///
+    /// A generation UUID is branch-scoped serving state, not a commit. Route
+    /// through the normal tracked reader so root-backed, packed, columnar, and
+    /// native parts all apply their existing authentication and visibility
+    /// rules. Only the fixed-width commit provenance column is requested; the
+    /// returned set is a read-only dependency projection for destructive GC.
+    pub(crate) async fn tracked_serving_commit_dependencies(
+        &self,
+        projections: &[(String, BranchHeadTrackedReachability)],
+    ) -> Result<BTreeSet<CommitId>, LixError> {
+        let request = TrackedStateScanRequest {
+            filter: TrackedStateFilter::default(),
+            read_columns: TrackedStateReadColumns {
+                columns: vec!["commit_id".to_owned()],
+            },
+            limit: None,
+        };
+        let mut dependencies = BTreeSet::new();
+        for (branch_id, projection) in projections {
+            let batch = self
+                .scan_live_batch_for_generation(
+                    branch_id,
+                    projection.serving_generation,
+                    projection.serving_checkpoint_commit_id,
+                    &request,
+                )
+                .await?;
+            for row in batch.iter() {
+                if row.untracked() {
+                    continue;
+                }
+                let commit_id = row.commit_id().ok_or_else(|| {
+                    head_value_error(
+                        "authenticated tracked current-state row has no semantic commit owner",
+                    )
+                })?;
+                dependencies.insert(commit_id);
+            }
+        }
+        Ok(dependencies)
     }
 
     pub(crate) async fn has_schema_rows(

--- a/packages/lix/src/tracked_state/current_state_data_part.rs
+++ b/packages/lix/src/tracked_state/current_state_data_part.rs
@@ -6,6 +6,7 @@
 //! a rebuildable serving accelerator.
 
 use std::borrow::Cow;
+use std::collections::BTreeSet;
 
 use bytes::Bytes;
 
@@ -227,6 +228,16 @@ pub(crate) fn decode_current_state_data_part(
         .collect::<Result<Vec<_>, LixError>>()?;
     validate_rows(&rows)?;
     Ok(rows)
+}
+
+pub(crate) fn decode_current_state_data_part_commit_ids(
+    expected_digest: &[u8; 32],
+    encoded: &[u8],
+) -> Result<BTreeSet<crate::changelog::CommitId>, LixError> {
+    Ok(decode_current_state_data_part(expected_digest, encoded)?
+        .into_iter()
+        .map(|row| row.value.commit_id)
+        .collect())
 }
 
 fn validate_rows(rows: &[CurrentStateDataRow]) -> Result<(), LixError> {

--- a/packages/lix/src/tracked_state/mod.rs
+++ b/packages/lix/src/tracked_state/mod.rs
@@ -30,10 +30,13 @@ pub(crate) use commit_root_rebuild::{
 pub(crate) use context::{
     TrackedStateContext, TrackedStateStoreReader, descriptor_dependency_cascade_file_ids,
 };
-#[cfg(test)]
-pub(crate) use current_state_data_part::decode_current_state_data_part_refs;
 pub(crate) use current_state_data_part::{
     CURRENT_STATE_DATA_PART_REFS_SPACE, CURRENT_STATE_DATA_PART_SPACE,
+    decode_current_state_data_part_commit_ids,
+};
+#[cfg(test)]
+pub(crate) use current_state_data_part::{
+    CurrentStateDataRow, decode_current_state_data_part_refs, encode_current_state_data_part,
 };
 pub(crate) use current_state_envelope::current_state_descriptor_from_scoped_range_part;
 pub(crate) use diff::{
@@ -76,10 +79,11 @@ pub(crate) use storage::{
     load_commit_delta_members_with_payloads_for_schemas, load_commit_delta_replay_metadata,
     load_commit_delta_selection_certificate, load_commit_mutation_directory_roots,
     load_commit_state_authority_ids, load_commit_state_manifest, load_commit_state_manifests,
-    load_owned_commit_delta_entries, load_owned_commit_delta_entries_one_ordered_ref,
-    load_published_commit_state_topology, scan_change_records_from_commit_deltas,
-    scan_commit_delta_inventory, scan_commit_delta_values, selected_change_selection_fingerprint,
-    stage_addressable_commit_deltas, stage_addressable_commit_deltas_with_selected_source,
+    load_local_selected_change_owner_commit_ids, load_owned_commit_delta_entries,
+    load_owned_commit_delta_entries_one_ordered_ref, load_published_commit_state_topology,
+    scan_change_records_from_commit_deltas, scan_commit_delta_inventory, scan_commit_delta_values,
+    selected_change_selection_fingerprint, stage_addressable_commit_deltas,
+    stage_addressable_commit_deltas_with_selected_source,
     stage_certified_commit_state_manifest_with_handle, stage_change_locators,
     stage_commit_deltas_for_commit_state, stage_commit_state_manifest_with_handle,
     stage_current_state_scoped_ranges_from_published_parent,
@@ -113,8 +117,6 @@ pub(crate) use storage::{
 };
 #[cfg(test)]
 pub(crate) use tree::test_gc_leaf_chunk;
-#[cfg(test)]
-pub(crate) use types::TrackedStateCommitRootParent;
 pub(crate) use types::TrackedStateRootId;
 pub(crate) use types::{COMMIT_STATE_MAX_REPLAY_BYTES, COMMIT_STATE_MAX_REPLAY_DEPTH};
 pub(crate) use types::{
@@ -124,6 +126,8 @@ pub(crate) use types::{
     TrackedStateDeltaRef, TrackedStateFilter, TrackedStateIndexValue, TrackedStateReadColumns,
     TrackedStateRootMutationRef, TrackedStateScanRequest, TrackedStateSingleStringReplacementRef,
 };
+#[cfg(test)]
+pub(crate) use types::{CurrentStatePartDescriptor, TrackedStateCommitRootParent};
 pub(crate) use types::{TrackedStateKey, TrackedStateKeyRef};
 
 /// Builds an authenticated content-addressed closure for a set of retained

--- a/packages/lix/src/tracked_state/storage.rs
+++ b/packages/lix/src/tracked_state/storage.rs
@@ -7562,6 +7562,7 @@ pub(crate) async fn load_commit_delta_members_with_payloads_for_schemas(
             &state,
             schema_keys,
             max_segment_count,
+            true,
         )
         .await?
     else {
@@ -7587,6 +7588,7 @@ pub(crate) async fn load_commit_delta_members_with_payloads_for_schemas(
         &source,
         schema_keys,
         max_segment_count.saturating_sub(local_segment_count),
+        true,
     )
     .await?
     else {
@@ -7600,11 +7602,197 @@ pub(crate) async fn load_commit_delta_members_with_payloads_for_schemas(
     Ok(Some(merge_selected_source_members(members, local)))
 }
 
+/// Resolves the immutable owners of finite selected members in one commit.
+///
+/// Whole-source aliases are already named by the authenticated manifest and
+/// are deliberately excluded here. Ordinary GC uses this bounded local
+/// inventory walk to retain canonical locator owners without scanning any
+/// repository-global change or commit space.
+pub(crate) async fn load_local_selected_change_owner_commit_ids(
+    store: &(impl StorageAdapterRead + ?Sized),
+    commit_id: CommitId,
+) -> Result<BTreeSet<CommitId>, LixError> {
+    let state = load_point_replay_commit_state(store, commit_id)
+        .await?
+        .ok_or_else(|| {
+            replacement_payload_error(&format!(
+                "selected-owner dependency commit '{commit_id}' has no physical authority"
+            ))
+        })?;
+    let Some((members, _)) = load_authenticated_local_commit_delta_members_for_schemas(
+        store,
+        &state,
+        &[],
+        usize::MAX,
+        false,
+    )
+    .await?
+    else {
+        unreachable!("unbounded selected-owner inventory cannot exceed its segment limit")
+    };
+    let selected = members
+        .into_iter()
+        .filter(|member| !member.authored && !member.selected_tombstone)
+        .collect::<Vec<_>>();
+    if selected.is_empty() {
+        return Ok(BTreeSet::new());
+    }
+
+    // Explicit locators are the canonical route for random change IDs. Probe
+    // them in one batch before trying the packed direct-address convention;
+    // otherwise each random UUID looks like a distinct speculative commit and
+    // turns one finite selection into one manifest probe per row.
+    let locator_keys = selected
+        .iter()
+        .map(|member| {
+            StorageKey(Bytes::copy_from_slice(
+                member.value.change_id.as_uuid().as_bytes(),
+            ))
+        })
+        .collect::<Vec<_>>();
+    let locator_values = PointReadPlan::new(TRACKED_STATE_CHANGE_LOCATOR_SPACE, &locator_keys)
+        .materialize(store, StorageGetOptions::default())
+        .await?;
+    let explicit_locators = selected
+        .iter()
+        .zip(locator_values.value)
+        .map(|(member, value)| {
+            value
+                .and_then(full_value_bytes)
+                .map(|bytes| decode_change_locator(member.value.change_id, &bytes))
+                .transpose()
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+    let direct_locators = selected
+        .iter()
+        .map(|member| direct_change_locator(member.value.change_id))
+        .collect::<Vec<_>>();
+
+    // Direct addressing remains canonical when its physical commit really
+    // owns the coordinate. Probe all syntactic candidates in one request so
+    // random explicit IDs cannot reintroduce one backend request per row.
+    let direct_candidate_ids = direct_locators
+        .iter()
+        .flatten()
+        .map(|locator| locator.commit_id)
+        .collect::<BTreeSet<_>>()
+        .into_iter()
+        .collect::<Vec<_>>();
+    let direct_candidate_manifests =
+        load_commit_state_manifests(store, &direct_candidate_ids).await?;
+    let present_direct_candidates = direct_candidate_ids
+        .into_iter()
+        .zip(direct_candidate_manifests)
+        .filter_map(|(commit_id, manifest)| manifest.map(|_| commit_id))
+        .collect::<BTreeSet<_>>();
+
+    let mut direct_by_commit = BTreeMap::<
+        CommitId,
+        (
+            Arc<AuthenticatedReplayCommitStateManifest>,
+            Vec<(usize, CommitDeltaChangeLocator)>,
+        ),
+    >::new();
+    let mut non_owning_direct_candidates = BTreeSet::new();
+    let mut explicit_indices = BTreeSet::new();
+    for (index, locator) in direct_locators.iter().copied().enumerate() {
+        let Some(locator) =
+            locator.filter(|locator| present_direct_candidates.contains(&locator.commit_id))
+        else {
+            explicit_indices.insert(index);
+            continue;
+        };
+        if let Some((_, requests)) = direct_by_commit.get_mut(&locator.commit_id) {
+            requests.push((index, locator));
+            continue;
+        }
+        if non_owning_direct_candidates.contains(&locator.commit_id) {
+            explicit_indices.insert(index);
+            continue;
+        }
+        match load_direct_change_authority(store, locator.commit_id).await? {
+            DirectChangeAuthority::Candidate(authority) => {
+                direct_by_commit
+                    .entry(locator.commit_id)
+                    .or_insert_with(|| (authority, Vec::new()))
+                    .1
+                    .push((index, locator));
+            }
+            DirectChangeAuthority::NotOwned(_) => {
+                non_owning_direct_candidates.insert(locator.commit_id);
+                explicit_indices.insert(index);
+            }
+        }
+    }
+
+    let mut owners = BTreeSet::new();
+    for (commit_id, (authority, requests)) in direct_by_commit {
+        let locators = requests
+            .iter()
+            .map(|(_, locator)| *locator)
+            .collect::<Vec<_>>();
+        let routes = route_direct_change_records_for_state(store, &authority, &locators).await?;
+        for ((index, _), route) in requests.into_iter().zip(routes) {
+            match route {
+                DirectChangeRecordRoute::Owned(record) => {
+                    validate_selected_owner_record(&selected[index], &record)?;
+                    owners.insert(commit_id);
+                }
+                DirectChangeRecordRoute::NotOwned(_) => {
+                    explicit_indices.insert(index);
+                }
+            }
+        }
+    }
+
+    let explicit = explicit_indices
+        .into_iter()
+        .map(|index| {
+            explicit_locators[index]
+                .map(|locator| (index, locator))
+                .ok_or_else(|| {
+                    replacement_payload_error(&format!(
+                        "selected change '{}' has no authoritative locator",
+                        selected[index].value.change_id
+                    ))
+                })
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+    let locators = explicit
+        .iter()
+        .map(|(_, locator)| *locator)
+        .collect::<Vec<_>>();
+    let records = load_explicit_change_records_at_locators(store, &locators).await?;
+    for ((index, locator), record) in explicit.into_iter().zip(records) {
+        validate_selected_owner_record(&selected[index], &record)?;
+        owners.insert(locator.commit_id);
+    }
+    Ok(owners)
+}
+
+fn validate_selected_owner_record(
+    member: &CommitDeltaMember,
+    record: &crate::changelog::ChangeRecord,
+) -> Result<(), LixError> {
+    if record.change_id != member.value.change_id
+        || record.schema_key != member.key.schema_key
+        || record.file_id != member.key.file_id
+        || record.entity_pk != member.key.entity_pk
+    {
+        return Err(replacement_payload_error(&format!(
+            "selected change '{}' references canonical authority for a different identity",
+            member.value.change_id
+        )));
+    }
+    Ok(())
+}
+
 async fn load_authenticated_local_commit_delta_members_for_schemas(
     store: &(impl StorageAdapterRead + ?Sized),
     state: &AuthenticatedReplayCommitStateManifest,
     schema_keys: &[String],
     max_segment_count: usize,
+    hydrate_selected_payloads: bool,
 ) -> Result<Option<(Vec<CommitDeltaMember>, usize)>, LixError> {
     let Some(root) = state.mutation_directory_root.as_ref() else {
         let manifest = commit_delta_manifest_from_commit_state(state);
@@ -7613,8 +7801,14 @@ async fn load_authenticated_local_commit_delta_members_for_schemas(
             return Ok(None);
         }
         return Ok(Some((
-            load_commit_delta_members_from_manifest(store, state.commit_id, &manifest, schema_keys)
-                .await?,
+            load_commit_delta_members_from_manifest(
+                store,
+                state.commit_id,
+                &manifest,
+                schema_keys,
+                hydrate_selected_payloads,
+            )
+            .await?,
             segment_count,
         )));
     };
@@ -7626,14 +7820,21 @@ async fn load_authenticated_local_commit_delta_members_for_schemas(
             state,
             schema_keys,
             max_segment_count,
+            hydrate_selected_payloads,
         )
         .await;
     }
     if root.layout == super::mutation_directory::LAYOUT_DIRECT_ROWS_ONLY {
         let manifest = commit_delta_manifest_from_commit_state(state);
         return Ok(Some((
-            load_commit_delta_members_from_manifest(store, state.commit_id, &manifest, schema_keys)
-                .await?,
+            load_commit_delta_members_from_manifest(
+                store,
+                state.commit_id,
+                &manifest,
+                schema_keys,
+                hydrate_selected_payloads,
+            )
+            .await?,
             0,
         )));
     }
@@ -7678,8 +7879,14 @@ async fn load_authenticated_local_commit_delta_members_for_schemas(
     let manifest = expanded_commit_delta_manifest_from_commit_state(store, &expanded_state).await?;
     validate_commit_delta_manifest(&manifest)?;
     Ok(Some((
-        load_commit_delta_members_from_manifest(store, state.commit_id, &manifest, schema_keys)
-            .await?,
+        load_commit_delta_members_from_manifest(
+            store,
+            state.commit_id,
+            &manifest,
+            schema_keys,
+            hydrate_selected_payloads,
+        )
+        .await?,
         segment_count,
     )))
 }
@@ -7689,6 +7896,7 @@ async fn load_bounded_commit_delta_members_for_schemas(
     state: &AuthenticatedReplayCommitStateManifest,
     schema_keys: &[String],
     max_segment_count: usize,
+    hydrate_selected_payloads: bool,
 ) -> Result<Option<(Vec<CommitDeltaMember>, usize)>, LixError> {
     let root = state.mutation_directory_root.as_ref().ok_or_else(|| {
         replacement_payload_error("bounded payload scan omitted its mutation-directory root")
@@ -7780,7 +7988,9 @@ async fn load_bounded_commit_delta_members_for_schemas(
     if !requested_schemas.is_empty() {
         members.retain(|member| requested_schemas.contains(member.key.schema_key.as_str()));
     }
-    hydrate_selected_members(store, &mut members).await?;
+    if hydrate_selected_payloads {
+        hydrate_selected_members(store, &mut members).await?;
+    }
     validate_commit_delta_member_order_and_ids(state.commit_id, &members)?;
     Ok(Some((members, segment_count)))
 }
@@ -7827,6 +8037,7 @@ async fn load_commit_delta_members_from_manifest(
     commit_id: CommitId,
     manifest: &CommitDeltaManifest,
     schema_keys: &[String],
+    hydrate_selected_payloads: bool,
 ) -> Result<Vec<CommitDeltaMember>, LixError> {
     if let Some(parts) = manifest.columnar_parts.as_ref() {
         if !schema_keys.is_empty() && !schema_keys.iter().any(|schema| schema == &parts.schema_key)
@@ -7887,7 +8098,9 @@ async fn load_commit_delta_members_from_manifest(
     if !requested_schemas.is_empty() {
         members.retain(|member| requested_schemas.contains(member.key.schema_key.as_str()));
     }
-    hydrate_selected_members(store, &mut members).await?;
+    if hydrate_selected_payloads {
+        hydrate_selected_members(store, &mut members).await?;
+    }
     validate_commit_delta_member_order_and_ids(commit_id, &members)?;
     Ok(members)
 }
@@ -9394,7 +9607,7 @@ pub(crate) async fn visit_change_records_from_commit_deltas(
                     continue;
                 }
                 let members =
-                    load_commit_delta_members_from_manifest(store, commit_id, &manifest, &[])
+                    load_commit_delta_members_from_manifest(store, commit_id, &manifest, &[], true)
                         .await?;
                 for member in members {
                     if member.authored {

--- a/packages/lix/src/tracked_state/types.rs
+++ b/packages/lix/src/tracked_state/types.rs
@@ -420,6 +420,21 @@ impl CommitStateMutationInventory {
                 self.replacement_part_digests.len()
             }
     }
+
+    /// Whether this local inventory can contain a finite selected member whose
+    /// payload owner must be resolved through the canonical change locator.
+    ///
+    /// A selected-source alias is whole-source authority, not a finite
+    /// selection. A non-empty direct-address inventory proves every member
+    /// owns its encoded slot, and columnar parts are authored history by
+    /// contract. Only the remaining mixed/generic layouts require decoding
+    /// local members to distinguish authored rows from finite selections.
+    pub(crate) fn may_contain_finite_selected_members(&self) -> bool {
+        self.member_count != 0
+            && self.selected_source_commit_id.is_none()
+            && self.direct_part_row_counts.is_empty()
+            && self.columnar_parts.is_none()
+    }
 }
 
 /// Immutable physical authority for one tracked commit.

--- a/packages/lix/tests/integration/checkpoint_gc.rs
+++ b/packages/lix/tests/integration/checkpoint_gc.rs
@@ -4,6 +4,7 @@ use serde_json::json;
 use tokio::time::{Duration, Instant};
 
 const CHECKPOINT_GC_INTERVAL: u64 = 64;
+const REPLAY_GC_SCHEMA_KEY: &str = "checkpoint_replay_gc_row";
 
 simulation_test!(
     checkpoint_gc_keeps_one_recovery_interval_then_sweeps_it,
@@ -231,6 +232,184 @@ simulation_test!(
         wait_for_commits(&main, &[&main_auto_commit, &other_auto_commit], false).await;
     }
 );
+
+simulation_test!(
+    checkpoint_gc_retains_full_active_replay_interval,
+    |sim| async move {
+        let engine = sim.boot_engine().await;
+        let session = sim.wrap_session(
+            engine
+                .open_workspace_session()
+                .await
+                .expect("workspace session should open"),
+            &engine,
+        );
+
+        register_replay_gc_schema(&session).await;
+        let mut seed = session
+            .begin_transaction()
+            .await
+            .expect("replay fixture seed transaction should begin");
+        for index in 0..100 {
+            seed.execute(
+                &format!(
+                    "INSERT INTO {REPLAY_GC_SCHEMA_KEY} (id, indexed_value, note, generation) VALUES ($1, $2, $3, 0)"
+                ),
+                &[
+                    Value::Text(format!("row-{index}")),
+                    Value::Text(format!("indexed-{index}-0")),
+                    Value::Text(format!("seed-{index}")),
+                ],
+            )
+            .await
+            .expect("replay fixture seed should succeed");
+        }
+        seed.commit()
+            .await
+            .expect("replay fixture seed should commit");
+        let mut first = session
+            .begin_transaction()
+            .await
+            .expect("first churn transaction should begin");
+        first
+            .execute(
+                &format!(
+                    "UPDATE {REPLAY_GC_SCHEMA_KEY} SET indexed_value = 'indexed-0-1', generation = 1 WHERE id = 'row-0'"
+                ),
+                &[],
+            )
+            .await
+            .expect("first indexed churn should succeed");
+        first
+            .execute(
+                &format!(
+                    "UPDATE {REPLAY_GC_SCHEMA_KEY} SET note = 'one', generation = 1 WHERE id = 'row-1'"
+                ),
+                &[],
+            )
+            .await
+            .expect("first nonindexed churn should succeed");
+        first
+            .execute(
+                &format!("DELETE FROM {REPLAY_GC_SCHEMA_KEY} WHERE id = 'row-99'"),
+                &[],
+            )
+            .await
+            .expect("replacement delete should succeed");
+        first.commit().await.expect("first churn should commit");
+
+        let mut second = session
+            .begin_transaction()
+            .await
+            .expect("second churn transaction should begin");
+        second
+            .execute(
+                &format!(
+                    "UPDATE {REPLAY_GC_SCHEMA_KEY} SET indexed_value = 'indexed-0-2', generation = 2 WHERE id = 'row-0'"
+                ),
+                &[],
+            )
+            .await
+            .expect("second indexed churn should succeed");
+        second
+            .execute(
+                &format!(
+                    "UPDATE {REPLAY_GC_SCHEMA_KEY} SET note = 'two', generation = 2 WHERE id = 'row-1'"
+                ),
+                &[],
+            )
+            .await
+            .expect("second nonindexed churn should succeed");
+        second
+            .execute(
+                &format!(
+                    "INSERT INTO {REPLAY_GC_SCHEMA_KEY} (id, indexed_value, note, generation) VALUES ('row-99', 'indexed-99-2', 'replacement', 2)"
+                ),
+                &[],
+            )
+            .await
+            .expect("replacement insert should succeed");
+        second.commit().await.expect("second churn should commit");
+        let retired_head = branch_head(&engine, sim.main_branch_id()).await;
+
+        session
+            .create_checkpoint()
+            .await
+            .expect("compacting checkpoint should succeed");
+        for _ in 1..CHECKPOINT_GC_INTERVAL {
+            session
+                .create_checkpoint()
+                .await
+                .expect("padding checkpoint should succeed");
+        }
+        wait_for_commits(&session, &[&retired_head], false).await;
+
+        assert_replay_gc_state(&session).await;
+        let history = session
+            .execute(
+                &format!("SELECT note FROM {REPLAY_GC_SCHEMA_KEY}_history() WHERE id = 'row-1'"),
+                &[],
+            )
+            .await
+            .expect("compacted history should remain readable after GC");
+        assert!(!history.is_empty());
+
+        let reopened_engine = sim
+            .reboot_engine_from_current_snapshot()
+            .await
+            .expect("engine should reopen after replay GC");
+        let reopened = sim.wrap_session(
+            reopened_engine
+                .open_workspace_session()
+                .await
+                .expect("reopened workspace session should open"),
+            &reopened_engine,
+        );
+        assert_replay_gc_state(&reopened).await;
+        reopened
+            .execute(
+                &format!("SELECT note FROM {REPLAY_GC_SCHEMA_KEY}_history() WHERE id = 'row-1'"),
+                &[],
+            )
+            .await
+            .expect("compacted history should remain readable after cold reopen");
+    }
+);
+
+async fn register_replay_gc_schema(session: &support::simulation_test::engine::SimSession) {
+    let schema = json!({
+        "x-lix-key": REPLAY_GC_SCHEMA_KEY,
+        "x-lix-primary-key": ["/id"],
+        "x-lix-unique": [["/indexed_value"]],
+        "type": "object",
+        "required": ["id", "indexed_value", "note", "generation"],
+        "properties": {
+            "id": { "type": "string" },
+            "indexed_value": { "type": "string" },
+            "note": { "type": "string" },
+            "generation": { "type": "integer" }
+        },
+        "additionalProperties": false
+    });
+    session
+        .execute(
+            "INSERT INTO lix_registered_schema (value, lixcol_global, lixcol_untracked) VALUES (lix_json($1), false, false)",
+            &[Value::Text(schema.to_string())],
+        )
+        .await
+        .expect("replay GC schema should register");
+}
+
+async fn assert_replay_gc_state(session: &support::simulation_test::engine::SimSession) {
+    let state = session
+        .execute(
+            &format!("SELECT note FROM {REPLAY_GC_SCHEMA_KEY} WHERE id = 'row-1'"),
+            &[],
+        )
+        .await
+        .expect("current state should remain readable after replay GC");
+    assert_eq!(state.rows()[0].values(), &[Value::Text("two".to_string())]);
+}
 
 async fn advance_to_next_gc(session: &support::simulation_test::engine::SimSession, sequence: u64) {
     for _ in (sequence + 1)..CHECKPOINT_GC_INTERVAL {


### PR DESCRIPTION
## What changed

Checkpoint GC now retains every authenticated commit dependency required to serve current tracked state before proving retirement:

- one canonical `BranchHeadControl::tracked_reachability` projection is shared by ordinary GC, offline tree sweep, and standalone audit;
- head and working-diff checkpoint remain semantic chronology roots;
- `tracked_generation` remains only the branch-scoped current-serving selector and is resolved through `TrackedHead`, never treated as a commit or new chronology authority;
- point replay dependencies are closed over authoritative semantic first-parent chronology with authenticated replacement fallback;
- scoped source-kind 0/2 descriptor owners, native current-part row owners, and finite selected-locator owners are folded into the existing physical and semantic retirement guards;
- missing, malformed, cyclic, or non-decreasing replay authority and malformed selected serving data fail the GC plan closed;
- a valid empty/rootless serving generation remains valid;
- no new persisted root, selector, format, retry, compatibility path, queue, or GC authority is introduced.

The implementation also batches finite selected-owner resolution while preserving canonical direct-address precedence and uses a provenance-only packed-current scan, avoiding payload hydration during destructive reachability planning.

## Root cause

The existing retirement proof rooted branch head/recovery authority but did not project all reader-equivalent dependencies of authenticated current-serving state. After a compacting checkpoint and 64 GC rotations, a live branch control could still select native/scoped/current rows whose semantic owner commit had been retired. The public read path then failed after GC or cold reopen with an unknown commit.

The hard cut makes the existing retirement proof complete: every live serving owner must be authenticated and retained, and any missing or malformed required authority rejects the whole plan before deletes are staged.

## Complexity and tradeoffs

Let:

- `R` = total rows decoded from retained native/current serving parts;
- `C` = semantic point-replay closure;
- `G` = distinct owner/part groups.

The previous implementation was effectively `O(C)` because it incorrectly omitted `R`. Correct behavior is `O(R + C)`; without introducing a second persisted summary authority, the row provenance decode is the correctness floor. The first correct prototype also incurred `O(R)` adapter request overhead. The accepted batched/provenance-only cut keeps CPU, allocation, and bytes at `O(R + C)` while reducing adapter requests to `O(G + C)`.

At 1K rows, the removed per-row request artifact fell from 32.897 ms / 172.31 MB allocated / 139,678 allocations / 3,200 GET calls to 6.743 ms / 10.06 MB / 39,808 / 212 GET calls on RocksDB: -79.5% latency, -94.2% allocation bytes, and -93.4% backend calls. Its measured perfect-elimination ceiling was approximately 87–94%.

Final planner accounting (setup excluded, no writes staged):

| Adapter | Rows | Latency | CPU ticks | Alloc bytes/calls | RSS delta | GET calls/keys | value+scan bytes | Writes | Settled disk delta |
|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| RocksDB | 100 | 3.117 ms | 0 | 3.74 MB / 17,872 | 10.98 MB | 197 / 745 | 251,451 | 0 | 0 |
| RocksDB | 1K | 6.743 ms | 0 | 10.06 MB / 39,808 | 24.48 MB | 212 / 1,669 | 434,901 | 0 | 0 |
| RocksDB | 50K | 194.607 ms | 19 | 383.61 MB / 1,247,990 | 182.59 MB | 216 / 51,260 | 13,300,354 | 0 | 0 |
| SlateDB | 100 | 11.495 ms | 1 | 27.13 MB / 89,195 | 17.66 MB | 197 / 745 | 251,445 | 0 | 0 |
| SlateDB | 1K | 17.884 ms | 2 | 49.04 MB / 180,356 | 35.32 MB | 212 / 1,669 | 434,973 | 0 | 0 |
| SlateDB | 50K | 305.283 ms | 32 | 1,167.38 MB / 4,659,746 | 170.28 MB | 216 / 51,260 | 13,300,492 | 0 | 0 |

Slate object-read accounting was 561/254,414 bytes, 587/314,484 bytes, and 609/6,225,929 bytes at 100/1K/50K respectively. All cells staged zero puts/deletes, performed no foreground flush, and left settled disk bytes unchanged.

## Validation

- [x] Exact-base reproduction on `bbff57ef5c55cdf3e8a2da2aafc3d0611ca18bd7`
- [x] Canonical control projection shared by ordinary GC, offline sweep, and audit
- [x] Authenticated replacement success
- [x] Missing, malformed, non-decreasing, and cyclic replay closure fail closed
- [x] Valid `tracked_generation` without a commit manifest succeeds
- [x] Malformed selected native part fails closed
- [x] Finite selected, scoped descriptor, and native-row owners retain while live and reclaim after release
- [x] Public seed + two churn commits + undo/redo + compacting checkpoint + exactly 64 rotations + live/history scan + cold reopen on RocksDB and SlateDB
- [x] `cargo test -p lix --lib gc::tests` — 23 passed
- [x] `cargo test -p lix --lib tracked_state::storage::tests` — 63 passed
- [x] `cargo test -p lix_benchmarks --test checkpoint_gc_replay_reopen --features "rocksdb slatedb" -- --nocapture` — 2 passed
- [x] `cargo test -p lix --test integration checkpoint_gc_ -- --nocapture` — 4 passed
- [x] Exact-base focused history/diff/undo/redo/commit suites — 14 + 36 + 37 passed
- [x] `cargo fmt --all -- --check`
- [x] `git diff --check`
- [x] `cargo clippy --profile test --workspace --all-targets --all-features -- -D warnings`
- [x] Stabilized `origin/main` `bc7e31158588e5722422b0f73ea95cebdb1ebe96` merged exactly once with no scoped conflict; conflict-sensitive gates rerun
- [ ] External held #1235 retained 64 MiB CAS/history oracle (the fixture remains owned by that lane and is not present in this branch)

## Immutable identities

- original base: `bbff57ef5c55cdf3e8a2da2aafc3d0611ca18bd7`
- exact-base repair: `ce1c7e6c14d4de64b0ad9fa273afb0a1183bae9e`
- exact-base repair tree: `52023c433cf49444d6a90596c3f08d37962e28f7`
- stabilized main: `bc7e31158588e5722422b0f73ea95cebdb1ebe96`
- integrated head: `f1ae6c649bd99d187a7c2e95ff3399f78f532f2b`
- integrated tree: `f00a7ffc7eddd107e071b82cb2f18de6ae1e8d15`
- binary PR diff SHA-256: `bd325050167f7620b41ca5c04b4e8ad98eb9201b7ea84f9301bc250c617407ce`
- stable patch-id: `96b1193c35b650522a70e83b481528f0a0d0bc47`
