### PR TITLE
perf(engine): reuse transaction mode snapshot

### DIFF
--- a/packages/lix/src/functions/context.rs
+++ b/packages/lix/src/functions/context.rs
@@ -16,6 +16,7 @@ use crate::storage_adapter::{StorageAdapterRead, StoragePrecondition, StorageWri
 pub(crate) struct FunctionContext {
     functions: FunctionProviderHandle,
     bookkeeping_timestamp: LixTimestamp,
+    deterministic_mode_enabled: bool,
 }
 
 impl FunctionContext {
@@ -27,6 +28,7 @@ impl FunctionContext {
         Self {
             functions: FunctionProviderHandle::system(),
             bookkeeping_timestamp: bookkeeping_functions.timestamp(),
+            deterministic_mode_enabled: false,
         }
     }
 
@@ -59,7 +61,12 @@ impl FunctionContext {
             ))
                 as Box<dyn FunctionProvider + Send>),
             bookkeeping_timestamp,
+            deterministic_mode_enabled: true,
         })
+    }
+
+    pub(crate) fn deterministic_mode_enabled(&self) -> bool {
+        self.deterministic_mode_enabled
     }
 
     /// Returns the engine-owned provider used by SQL and transaction staging.

--- a/packages/lix/src/functions/mod.rs
+++ b/packages/lix/src/functions/mod.rs
@@ -21,9 +21,3 @@ pub(crate) use state::DETERMINISTIC_SEQUENCE_KEY;
 pub(crate) use types::{DeterministicMode, DeterministicSequence};
 
 pub(crate) type DeterministicRuntimeGuard = tokio::sync::OwnedMutexGuard<()>;
-
-pub(crate) async fn deterministic_mode_enabled(
-    read: &(impl crate::storage_adapter::StorageAdapterRead + ?Sized),
-) -> Result<bool, crate::LixError> {
-    Ok(state::load_mode(read).await?.enabled)
-}

--- a/packages/lix/src/session/context.rs
+++ b/packages/lix/src/session/context.rs
@@ -367,15 +367,6 @@ where
         self.transaction_manager.ensure_open()
     }
 
-    pub(super) async fn deterministic_mode_enabled(&self) -> Result<bool, LixError> {
-        let read = SharedStorageAdapterRead::new(
-            self.storage
-                .begin_read(StorageReadOptions::default())
-                .await?,
-        );
-        crate::functions::deterministic_mode_enabled(&read).await
-    }
-
     pub(super) async fn lock_deterministic_runtime(
         &self,
     ) -> crate::functions::DeterministicRuntimeGuard {
@@ -624,6 +615,10 @@ impl SessionWriteAccess {
                     .await,
             );
         }
+    }
+
+    pub(super) fn release_collaboration_write_serialization(&mut self) {
+        self.collaboration_write_guard.take();
     }
 }
 

--- a/packages/lix/src/session/transaction.rs
+++ b/packages/lix/src/session/transaction.rs
@@ -15,7 +15,8 @@ use crate::LixError;
 #[cfg(test)]
 use crate::transaction::CommitBoundaryGuard;
 use crate::transaction::{
-    CommitBoundaryState, Transaction, TransactionCommitBoundary, open_transaction,
+    CommitBoundaryState, Transaction, TransactionCommitBoundary,
+    open_transaction_with_runtime_boundary,
 };
 
 use super::SessionContext;
@@ -47,39 +48,45 @@ where
     pub async fn begin_transaction(&self) -> Result<SessionTransaction<StorageImpl>, LixError> {
         self.ensure_open()?;
         let mut write_access = self.begin_explicit_session_write_access().await?;
-        let deterministic_runtime_guard = if self.deterministic_mode_enabled().await? {
-            // Bounded durable-runtime writes take the collaboration gate before
-            // the deterministic-runtime gate. Keep that order for explicit
-            // transactions as well, then retain both guards for their lifetime
-            // so commit cannot deadlock with a bounded writer holding one gate
-            // while waiting for the other.
-            write_access
-                .serialize_collaboration_writes(&self.collaboration_write_gate)
-                .await;
-            Some(self.lock_deterministic_runtime().await)
-        } else {
-            None
-        };
-        let mut opened = match open_transaction(
-            &self.mode,
-            self.active_account_id.to_string(),
-            self.storage.clone(),
-            Arc::clone(&self.live_state),
-            Arc::clone(&self.tracked_state),
-            Arc::clone(&self.binary_cas),
-            self.plugin_host.clone(),
-            Arc::clone(&self.branch_ctx),
-            Arc::clone(&self.catalog_context),
-            Arc::clone(&self.sql_planning_cache),
-            self.file_views.clone(),
-        )
-        .await
-        {
-            Ok(opened) => opened,
-            Err(error) => {
-                return Err(error);
-            }
-        };
+        // Mode and sequence are global write authority. Serialize through the
+        // same collaboration gate as every writer while the transaction's one
+        // retained opening snapshot loads them. The runtime boundary below is
+        // invoked immediately after that load: deterministic transactions keep
+        // collaboration serialization and then take the runtime gate in the
+        // global order, while ordinary transactions release serialization
+        // before catalog and branch-head setup continues on the same snapshot.
+        write_access
+            .serialize_collaboration_writes(&self.collaboration_write_gate)
+            .await;
+        let (mut opened, deterministic_runtime_guard) =
+            match open_transaction_with_runtime_boundary(
+                &self.mode,
+                self.active_account_id.to_string(),
+                self.storage.clone(),
+                Arc::clone(&self.live_state),
+                Arc::clone(&self.tracked_state),
+                Arc::clone(&self.binary_cas),
+                self.plugin_host.clone(),
+                Arc::clone(&self.branch_ctx),
+                Arc::clone(&self.catalog_context),
+                Arc::clone(&self.sql_planning_cache),
+                self.file_views.clone(),
+                async |runtime_functions| {
+                    if runtime_functions.deterministic_mode_enabled() {
+                        Ok(Some(self.lock_deterministic_runtime().await))
+                    } else {
+                        write_access.release_collaboration_write_serialization();
+                        Ok(None)
+                    }
+                },
+            )
+            .await
+            {
+                Ok(opened) => opened,
+                Err(error) => {
+                    return Err(error);
+                }
+            };
         self.ensure_open()?;
         opened
             .transaction

--- a/packages/lix/src/transaction/context.rs
+++ b/packages/lix/src/transaction/context.rs
@@ -1375,7 +1375,7 @@ where
     }
 
     /// Opens an execution-scoped staging area for SQL/provider hooks.
-    async fn open(
+    async fn open<T, F>(
         mode: &SessionMode,
         active_account_id: String,
         storage: StorageAdapter<StorageImpl>,
@@ -1387,7 +1387,11 @@ where
         catalog_context: Arc<CatalogContext>,
         sql_planning_cache: Arc<SqlPlanningCache<CatalogFingerprint>>,
         session_file_views: SessionFileViews,
-    ) -> Result<OpenTransaction<StorageImpl>, LixError> {
+        runtime_boundary: F,
+    ) -> Result<(OpenTransaction<StorageImpl>, T), LixError>
+    where
+        F: for<'runtime> AsyncFnOnce(&'runtime FunctionContext) -> Result<T, LixError>,
+    {
         let storage = Arc::new(storage);
         let read = storage.begin_read(StorageReadOptions::default()).await?;
         // SAFETY: `storage` is retained in the transaction behind an `Arc` and
@@ -1401,6 +1405,7 @@ where
                 resolve_active_branch_id(mode, live_state.as_ref(), branch_ctx.as_ref(), &read)
                     .await?;
             let runtime_functions = FunctionContext::prepare(&read).await?;
+            let runtime_boundary_result = runtime_boundary(&runtime_functions).await?;
             let functions = runtime_functions.provider();
             let (sql_schema_catalog, tracked_schema_catalog) = {
                 let catalog_revision = load_catalog_revision(&read).await?;
@@ -1445,6 +1450,7 @@ where
                 opening_tracked_mutation_revision,
                 opening_active_branch_head,
                 opening_global_branch_head,
+                runtime_boundary_result,
             ))
         }
         .await;
@@ -1457,6 +1463,7 @@ where
             opening_tracked_mutation_revision,
             opening_active_branch_head,
             opening_global_branch_head,
+            runtime_boundary_result,
         ) = match setup_result {
             Ok(result) => result,
             Err(error) => {
@@ -1474,53 +1481,56 @@ where
             tracked_schema_catalog,
         );
         let staged_writes = Arc::new(TransactionWriteBuffer::new(functions.clone()));
-        Ok(OpenTransaction {
-            transaction: Self {
-                active_branch_id,
-                active_account_id,
-                live_state,
-                tracked_state,
-                binary_cas,
-                plugin_host,
-                branch_ctx,
-                schema_resolver,
-                sql_schema_snapshot: sql_schema_catalog,
-                sql_planning_cache,
-                prepared_mutation_program: None,
-                prepared_mutation_membership: PreparedMutationMembership::Unprepared,
-                prepared_mutation_overlay_empty: false,
-                prepared_mutation_timestamp: None,
-                mutation_journal: None,
-                mutation_journal_compressor: None,
-                mutation_journal_sealed_rows: 0,
-                mutation_journal_seal_prefix_open: true,
-                mutation_journal_terminal_error: None,
-                certified_current_state_base_commit_id: None,
-                staged_writes,
-                filesystem_path_index_cache: Arc::new(FilesystemPathIndexCache::default()),
-                filesystem_path_index_epoch: Arc::new(AtomicUsize::new(0)),
-                branch_head_control_cache: Arc::new(BranchHeadControlCache::default()),
-                opening_read,
-                storage,
-                functions,
-                opening_tracked_mutation_revision,
-                opening_active_branch_head,
-                opening_global_branch_head,
-                commit_boundary: None,
-                trust_filesystem_planner: false,
-                origin_key: None,
-                idempotency_receipt: None,
-                atomic_metadata_writes: None,
-                atomic_metadata_preconditions: Vec::new(),
-                await_durable_commit: false,
-                session_file_views,
-                pending_file_view_mutations: BTreeMap::new(),
-                pending_plugin_actor_publications: Vec::new(),
-                plugin_generation_read_guard: None,
-                plugin_generation_upgrade_guard: None,
+        Ok((
+            OpenTransaction {
+                transaction: Self {
+                    active_branch_id,
+                    active_account_id,
+                    live_state,
+                    tracked_state,
+                    binary_cas,
+                    plugin_host,
+                    branch_ctx,
+                    schema_resolver,
+                    sql_schema_snapshot: sql_schema_catalog,
+                    sql_planning_cache,
+                    prepared_mutation_program: None,
+                    prepared_mutation_membership: PreparedMutationMembership::Unprepared,
+                    prepared_mutation_overlay_empty: false,
+                    prepared_mutation_timestamp: None,
+                    mutation_journal: None,
+                    mutation_journal_compressor: None,
+                    mutation_journal_sealed_rows: 0,
+                    mutation_journal_seal_prefix_open: true,
+                    mutation_journal_terminal_error: None,
+                    certified_current_state_base_commit_id: None,
+                    staged_writes,
+                    filesystem_path_index_cache: Arc::new(FilesystemPathIndexCache::default()),
+                    filesystem_path_index_epoch: Arc::new(AtomicUsize::new(0)),
+                    branch_head_control_cache: Arc::new(BranchHeadControlCache::default()),
+                    opening_read,
+                    storage,
+                    functions,
+                    opening_tracked_mutation_revision,
+                    opening_active_branch_head,
+                    opening_global_branch_head,
+                    commit_boundary: None,
+                    trust_filesystem_planner: false,
+                    origin_key: None,
+                    idempotency_receipt: None,
+                    atomic_metadata_writes: None,
+                    atomic_metadata_preconditions: Vec::new(),
+                    await_durable_commit: false,
+                    session_file_views,
+                    pending_file_view_mutations: BTreeMap::new(),
+                    pending_plugin_actor_publications: Vec::new(),
+                    plugin_generation_read_guard: None,
+                    plugin_generation_upgrade_guard: None,
+                },
+                runtime_functions,
             },
-            runtime_functions,
-        })
+            runtime_boundary_result,
+        ))
     }
 
     /// Commits prepared writes, runtime function state, and the storage transaction.
@@ -8733,6 +8743,42 @@ pub(crate) async fn open_transaction<StorageImpl>(
 where
     StorageImpl: Storage + Clone + Send + Sync + 'static,
 {
+    let (opened, ()) = Transaction::open(
+        mode,
+        active_account_id,
+        storage,
+        live_state,
+        tracked_state,
+        binary_cas,
+        plugin_host,
+        branch_ctx,
+        catalog_context,
+        sql_planning_cache,
+        session_file_views,
+        async |_| Ok(()),
+    )
+    .await?;
+    Ok(opened)
+}
+
+pub(crate) async fn open_transaction_with_runtime_boundary<StorageImpl, T, F>(
+    mode: &SessionMode,
+    active_account_id: String,
+    storage: StorageAdapter<StorageImpl>,
+    live_state: Arc<LiveStateContext>,
+    tracked_state: Arc<TrackedStateContext>,
+    binary_cas: Arc<BinaryCasContext>,
+    plugin_host: PluginRuntimeHost,
+    branch_ctx: Arc<BranchContext>,
+    catalog_context: Arc<CatalogContext>,
+    sql_planning_cache: Arc<SqlPlanningCache<CatalogFingerprint>>,
+    session_file_views: SessionFileViews,
+    runtime_boundary: F,
+) -> Result<(OpenTransaction<StorageImpl>, T), LixError>
+where
+    StorageImpl: Storage + Clone + Send + Sync + 'static,
+    F: for<'runtime> AsyncFnOnce(&'runtime FunctionContext) -> Result<T, LixError>,
+{
     Transaction::open(
         mode,
         active_account_id,
@@ -8745,6 +8791,7 @@ where
         catalog_context,
         sql_planning_cache,
         session_file_views,
+        runtime_boundary,
     )
     .await
 }

--- a/packages/lix/src/transaction/mod.rs
+++ b/packages/lix/src/transaction/mod.rs
@@ -40,6 +40,7 @@ pub(crate) use context::begin_commit_boundary;
 pub(crate) use context::commit_at_boundary;
 pub(crate) use context::commit_transaction_cohort;
 pub(crate) use context::open_transaction;
+pub(crate) use context::open_transaction_with_runtime_boundary;
 pub(crate) use context::transaction_is_file_cohort_eligible;
 pub(crate) use context::transactions_can_share_cohort;
 pub(crate) use plugin_checkpoint::stage_delete_branch_plugin_checkpoints;

--- a/packages/lix/tests/integration/transaction.rs
+++ b/packages/lix/tests/integration/transaction.rs
@@ -503,6 +503,51 @@ async fn existing_workspace_session_ignores_later_selector_corruption() {
 }
 
 #[tokio::test]
+async fn explicit_transaction_open_uses_one_authoritative_snapshot_in_every_session_mode() {
+    let storage = RecordingStorage::new();
+    let receipt = Engine::initialize(storage.clone())
+        .await
+        .expect("storage should initialize");
+    let engine = Engine::new(storage.clone())
+        .await
+        .expect("initialized storage should create an engine");
+    let workspace = engine
+        .open_workspace_session()
+        .await
+        .expect("workspace session should open");
+
+    let before = storage.stats();
+    let workspace_transaction = workspace
+        .begin_transaction()
+        .await
+        .expect("workspace transaction should open");
+    let delta = storage.stats().delta_since(&before);
+    assert_eq!(delta.read_opened, 1, "workspace open must own one snapshot");
+    assert_eq!(delta.write_opened, 0, "transaction open must not write");
+    workspace_transaction
+        .rollback()
+        .await
+        .expect("workspace transaction should roll back");
+
+    let pinned = engine
+        .open_session(receipt.main_branch_id)
+        .await
+        .expect("pinned session should open");
+    let before = storage.stats();
+    let pinned_transaction = pinned
+        .begin_transaction()
+        .await
+        .expect("pinned transaction should open");
+    let delta = storage.stats().delta_since(&before);
+    assert_eq!(delta.read_opened, 1, "pinned open must own one snapshot");
+    assert_eq!(delta.write_opened, 0, "transaction open must not write");
+    pinned_transaction
+        .rollback()
+        .await
+        .expect("pinned transaction should roll back");
+}
+
+#[tokio::test]
 async fn existing_workspace_session_writes_to_its_pinned_branch() {
     let storage = RecordingStorage::new();
     let _receipt = Engine::initialize(storage.clone())


### PR DESCRIPTION
## Summary

- delete the disposable deterministic-mode snapshot from explicit transaction open
- load deterministic mode once from the retained authoritative transaction snapshot
- hand that immutable result to the session boundary so deterministic opens keep the existing collaboration -> runtime lock order and ordinary opens release collaboration serialization before remaining setup
- add an oracle that workspace and pinned transaction opens each own exactly one storage snapshot

No public API, persisted format, cache, compatibility reader, secondary authority, or semantic behavior changes.

## Cause and complexity

Baseline explicit open loaded deterministic mode through a disposable snapshot, then loaded it again through the retained transaction snapshot during `FunctionContext::prepare`. Current and proposed complexity are both O(1) per open and O(M) for M opens, independent of history depth H. The measured perfect-elimination ceiling was 50% of snapshots and 38.1% of point calls. The candidate reaches one snapshot and 13 point calls from two snapshots and 21 calls.

## Exact provenance

- Qualified base: `bc7e31158588e5722422b0f73ea95cebdb1ebe96` / tree `5cb459d218bf071f89bfa08de2649bf67595507d`
- Qualified candidate: `2af8aeecbb1cf99543d703f90a208045ad725c0c` / tree `360dc2f47300c2b767c81246d739a267e9f07eec`
- Integrated main exactly once: `e9b3a6aaab8d621fd561e74768f4f05563291571` / tree `6423472d3031185114435e5842cef8fb77df215e`
- Final head: `f59a8b386d4b23eba07244d3128eeb9be1f44f1f`
- Final tree: `76a309b2fad2d62b0bafc2da245290018d81bfac`
- Merge parents: `(2af8aeecbb1cf99543d703f90a208045ad725c0c, e9b3a6aaab8d621fd561e74768f4f05563291571)`
- Main..head binary diff SHA-256: `126a1a3f9334bb8be23554ff8ed9c2fd3b4ff25fa21caec728d3ba6fc08fdb9a`
- Main..head full-index diff SHA-256: `a6b33fb07b4d3c5036d58a8628cd6bb405bb715971c35d524817e13dc784f908`
- Stable patch ID: `23d20e4ec1dc5e2da19a343c6d52504b99f56f2f`

The one-time merge was conflict-free. All seven candidate authority-path blobs remain byte-identical to `2af8aeec`; #1251 changed only disjoint benchmark/CAS paths.

## Setup-excluded A/B

Release-mode medians use samples 2-7 from seven samples of 10,000 public begin+rollback operations. Seed, flush, drop, and cold reopen are excluded.

| Adapter / history | begin p50 | open+rollback wall | allocation bytes/op | snapshots | point calls |
| --- | ---: | ---: | ---: | ---: | ---: |
| RocksDB / 100 | 25.944 -> 17.238 us (-33.6%) | 26.440 -> 17.687 us (-33.1%) | 56,803 -> 35,443 (-37.6%) | 2 -> 1 | 21 -> 13 |
| SlateDB / 100 | 11.787 -> 7.469 us (-36.6%) | 12.334 -> 7.978 us (-35.3%) | 66,490 -> 41,260 (-38.0%) | 2 -> 1 | 21 -> 13 |
| RocksDB / 1,000 | 28.279 -> 17.007 us (-39.9%) | 28.755 -> 17.459 us (-39.3%) | 56,805 -> 35,445 (-37.6%) | 2 -> 1 | 21 -> 13 |
| SlateDB / 1,000 | 11.933 -> 7.675 us (-35.7%) | 12.451 -> 8.188 us (-34.2%) | 66,490 -> 41,260 (-38.0%) | 2 -> 1 | 21 -> 13 |

Every timed cell had zero writes, scans, process I/O, SlateDB physical object I/O, and disk growth; all cold reopens succeeded. Repeated H=1,000 SlateDB peak RSS was +2.5%, and RocksDB was below +1%. Pinned controls improved about 37-38%; deterministic-mode controls improved about 25-28%.

Temporary harness SHA-256: `bd1f6663fdd400774c1c822f2fe115913784bafb990300e352c042dfea2e110e`. Exact benchmark binary and raw-cell hashes are frozen in the standalone evidence report SHA-256 `fbc62283b3d5036494ae2300afc2cc014126b111c947333d699d1443ee7eeec2`.

## Correctness and integration gates

- `cargo fmt --all -- --check`
- `git diff --check`
- canonical `cargo clippy --profile test --workspace --all-targets --all-features -- -D warnings`
- focused transaction module: 22/22 green before and after integration
- deterministic concurrency and explicit-runtime serialization: both base and tracked-state-rebuild simulations green
- cloned-session close ownership, workspace cold reopen, observers, and send/cancellation targets green
- `cargo test --profile test -p lix --features all-simulations`: 816 passed, 2 ignored; ancillary runtime/send-future/doc targets green
- RocksDB and SlateDB H=100/H=1,000 flush/drop/cold-reopen oracles green
- integrated-main hosted CI `31173283022`: 8/8 green
- fresh exact-head PR CI `31174231409`: 8/8 green

Draft only. Do not merge until independent review.
