### PR TITLE
perf(lix): project identities for collection authority checks

### DIFF
--- a/packages/lix/src/live_state/tracked_head/hot.rs
+++ b/packages/lix/src/live_state/tracked_head/hot.rs
@@ -5879,6 +5879,21 @@ where
         }) {
             return Ok(None);
         }
+        let control = load_hot_collection_control(
+            self.store,
+            branch_id,
+            generation,
+            crate::collection_generation::CollectionScopeRef {
+                schema_key,
+                file_id: None,
+            },
+        )
+        .await?;
+        if control.active_generation != generation
+            || control.live_count != u64::try_from(deltas.len()).unwrap_or(u64::MAX)
+        {
+            return Ok(None);
+        }
         let mut entity_pks = deltas
             .iter()
             .map(|delta| delta.entity_pk)
@@ -5896,6 +5911,9 @@ where
         else {
             return Ok(None);
         };
+        if control.ordered_identity_digest != Some(identity_digest) {
+            return Ok(None);
+        }
         if !self
             .authoritative_collection_matches(
                 parent_commit_id,
@@ -5904,22 +5922,6 @@ where
                 identity_digest,
             )
             .await?
-        {
-            return Ok(None);
-        }
-        let control = load_hot_collection_control(
-            self.store,
-            branch_id,
-            generation,
-            crate::collection_generation::CollectionScopeRef {
-                schema_key,
-                file_id: None,
-            },
-        )
-        .await?;
-        if control.active_generation != generation
-            || control.live_count != u64::try_from(entity_pks.len()).unwrap_or(u64::MAX)
-            || control.ordered_identity_digest != Some(identity_digest)
         {
             return Ok(None);
         }
@@ -5969,6 +5971,21 @@ where
         }) {
             return Ok(None);
         }
+        let control = load_hot_collection_control(
+            self.store,
+            branch_id,
+            generation,
+            crate::collection_generation::CollectionScopeRef {
+                schema_key,
+                file_id: None,
+            },
+        )
+        .await?;
+        if control.active_generation != generation
+            || control.live_count != u64::try_from(deltas.len()).unwrap_or(u64::MAX)
+        {
+            return Ok(None);
+        }
         let mut entity_pks = deltas
             .iter()
             .map(|delta| delta.entity_pk)
@@ -5986,6 +6003,9 @@ where
         else {
             return Ok(None);
         };
+        if control.ordered_identity_digest != Some(identity_digest) {
+            return Ok(None);
+        }
         if !self
             .authoritative_collection_matches(
                 parent_commit_id,
@@ -5997,23 +6017,6 @@ where
         {
             return Ok(None);
         }
-        let control = load_hot_collection_control(
-            self.store,
-            branch_id,
-            generation,
-            crate::collection_generation::CollectionScopeRef {
-                schema_key,
-                file_id: None,
-            },
-        )
-        .await?;
-        if control.active_generation != generation
-            || control.live_count != u64::try_from(entity_pks.len()).unwrap_or(u64::MAX)
-            || control.ordered_identity_digest != Some(identity_digest)
-        {
-            return Ok(None);
-        }
-
         let replaced =
             packed_exclusive_schema_base_refs(self.store, branch_id, generation, schema_key)
                 .await?;
@@ -6068,7 +6071,9 @@ where
     }
 
     /// Recomputes a full-collection certificate from immutable tracked-state
-    /// authority before a derived HOT control is allowed to retire a base.
+    /// authority before a derived HOT control may retire a base. The scan
+    /// projects identity columns only: payloads remain in their canonical
+    /// owner and are neither fetched nor decoded for this set-equality proof.
     /// A corrupt or stale control can therefore disable the compact route,
     /// but it can never make omitted identities disappear from current state.
     async fn authoritative_collection_matches(
@@ -6088,7 +6093,10 @@ where
                         file_ids: vec![NullableKeyFilter::Null],
                         ..TrackedStateFilter::default()
                     },
-                    ..TrackedStateScanRequest::default()
+                    read_columns: TrackedStateReadColumns {
+                        columns: vec!["schema_key".to_owned()],
+                    },
+                    limit: None,
                 },
             )
             .await?;


### PR DESCRIPTION
## What changed

- Project exact collection authority checks to identity columns only instead of hydrating parent JSON payloads.
- Reject generation/count/digest mismatches before sorting and authenticated scanning.
- Preserve the existing authenticated full-set comparison, canonical payload authority, publication writes, persisted format, and public API.

## Why

The 50K replacement path loaded and retained every parent payload even though the publication proof consumed only identities. That duplicate materialization accounted for roughly 39–41% of end-to-end update latency.

## Impact

On exact-base A/B cells, setup-excluded 50K update medians improved:

- RocksDB: 254.5 ms to 191.8 ms (-24.6%)
- SlateDB: 261.6 ms to 189.7 ms (-27.5%)

Allocated bytes fell about 38%, allocation calls about 33%, returned backend value bytes 52%, and peak RSS 85–89 MiB. Backend point calls decreased 39 to 35; write geometry and settled disk were unchanged. 1K and insert controls retained performance.

## Validation

- `cargo fmt --all -- --check`
- `git diff --check`
- transaction ownership/materialization tests: 29 passed
- dual-adapter CRUD/public-result tests: 11 passed
- forged HOT control / omitted authoritative member fail-closed test: passed
- post-merge 1K/50K RocksDB and SlateDB confirmation: passed
- warnings-denied Clippy completed for affected `lix`, RocksDB, and SlateDB packages; the all-workspace all-features cell later hit its 20-minute cap while compiling native DuckDB, with no diagnostic

Exact evidence report SHA-256: `28f9fe309b1660be7434d99c9aa45ca1118357c9ac62717fa040d4258f23b787`.
