### PR TITLE
fix undo redo canonical current-state publication

### DIFF
--- a/packages/lix/src/transaction/commit.rs
+++ b/packages/lix/src/transaction/commit.rs
@@ -1053,7 +1053,6 @@ struct StagedChangelogCommit {
     replay_debt: CommitStateReplayDebt,
     change_count: usize,
     selected_change_batches: Vec<StagedCommitChangeBatch>,
-    current_state_base_commit_id: Option<CommitId>,
 }
 
 struct StagedCommitDeltaIndex {
@@ -1471,7 +1470,6 @@ async fn stage_changelog_commits(
                 },
                 change_count,
                 selected_change_batches: commit_row.selected_change_batches.clone(),
-                current_state_base_commit_id: commit_row.current_state_base_commit_id,
             },
         );
     }
@@ -3638,95 +3636,6 @@ async fn stage_tracked_head(
                 engine_rows,
             )
             .await?;
-        }
-
-        if let Some(base_commit_id) = staged.current_state_base_commit_id {
-            if is_checkpoint_publication
-                || selected_materialization.is_some()
-                || !staged.selected_change_batches.is_empty()
-                || !untracked_deltas.is_empty()
-                || !engine_rows.is_empty()
-                || !explicit_branch_targets.is_empty()
-                || certified_fresh_plugin_file_id.is_some()
-                || host_certified_live_increments.contains_key(&root.branch_id)
-                || state_row_indices.is_empty()
-                || state_row_indices.iter().any(|&row_index| {
-                    let row = state_rows.row(row_index);
-                    row.global
-                        || row.untracked
-                        || row.branch_id.as_str() != root.branch_id
-                        || row.commit_id != Some(root.commit_id)
-                })
-                || !state_row_indices.iter().any(|&row_index| {
-                    state_rows.row(row_index).schema_key
-                        != crate::undo_redo::UNDO_REDO_MARKER_SCHEMA_KEY
-                })
-            {
-                return Err(LixError::new(
-                    LixError::CODE_INTERNAL_ERROR,
-                    "certified current-state base overlaps an unsupported publication shape",
-                ));
-            }
-            let generation =
-                lifecycle_generation(&root.branch_id, root.commit_id, root.ref_change_id);
-            let mut coverage = WorkingDiffIndexCoverage::default();
-            let mut writer = tracked_head.writer(read, writes);
-            writer.stage_root_current_base(&root.branch_id, generation, base_commit_id);
-            let overlay_deltas = state_row_indices
-                .iter()
-                .filter_map(|&row_index| {
-                    let row = state_rows.row(row_index);
-                    (row.schema_key == crate::undo_redo::UNDO_REDO_MARKER_SCHEMA_KEY)
-                        .then(|| current_state_delta_from_state_row(row))
-                })
-                .collect::<Result<Vec<_>, _>>()?;
-            if !overlay_deltas.is_empty() {
-                writer
-                    .stage_current_state_with_certified_predecessors(
-                        &root.branch_id,
-                        Some(generation),
-                        root.commit_id,
-                        &overlay_deltas,
-                        &[],
-                        &BTreeSet::new(),
-                        None,
-                        None,
-                        None,
-                        &mut coverage,
-                    )
-                    .instrument(tracing::debug_span!(
-                        target: "lix_perf",
-                        "lix.perf.materialization.tracked_head.stage_transition_base_overlay"
-                    ))
-                    .await?;
-            }
-            let mut control = normal_branch_head_control(root, parent_control, generation, None)?;
-            if let Some(parent) = parent_control
-                .filter(|parent| parent.tracked_generation == parent.untracked_generation)
-            {
-                let next_untracked_generation = untracked_lifecycle_generation(
-                    &root.branch_id,
-                    parent.untracked_generation,
-                    control.current_state_revision,
-                );
-                writer
-                    .stage_untracked_generation(
-                        &root.branch_id,
-                        parent.untracked_generation,
-                        next_untracked_generation,
-                        &[],
-                        &BTreeSet::new(),
-                    )
-                    .await?;
-                control.untracked_generation = next_untracked_generation;
-            }
-            control.note_schemas(
-                state_row_indices
-                    .iter()
-                    .map(|&row_index| state_rows.row(row_index).schema_key.as_str()),
-            );
-            insert_direct_branch_control(&mut controls, &root.branch_id, control)?;
-            continue;
         }
 
         if let Some(final_tracked) = tracked_snapshots.get(&root.commit_id).cloned() {
@@ -6195,7 +6104,6 @@ struct FinalizedCommitRow {
     created_at: LixTimestamp,
     change_id: ChangeId,
     selected_change_batches: Vec<StagedCommitChangeBatch>,
-    current_state_base_commit_id: Option<CommitId>,
 }
 
 struct PendingTrackedRoot {
@@ -6224,7 +6132,6 @@ async fn finalize_commit_rows(
         let created_at = change_refs.created_at;
         let commit_change_id = change_refs.commit_change_id;
         let branch_ref_change_id = change_refs.branch_ref_change_id;
-        let current_state_base_commit_id = change_refs.current_state_base_commit_id();
         let selected_change_batches = change_refs.into_selected_change_batches();
         commit_rows.push(FinalizedCommitRow {
             commit_id,
@@ -6232,7 +6139,6 @@ async fn finalize_commit_rows(
             created_at,
             change_id: commit_change_id,
             selected_change_batches,
-            current_state_base_commit_id,
         });
         tracked_roots.push(PendingTrackedRoot {
             branch_id: intermediate.branch_id,
@@ -6253,7 +6159,6 @@ async fn finalize_commit_rows(
         let commit_change_id = change_refs.commit_change_id;
         let branch_ref_change_id = change_refs.branch_ref_change_id;
         let timestamp = change_refs.created_at;
-        let current_state_base_commit_id = change_refs.current_state_base_commit_id();
         let selected_change_batches = change_refs.into_selected_change_batches();
         let parent_commit_ids =
             if let Some(parent) = first_commit_parent_override_by_branch.get(&branch_id) {
@@ -6286,7 +6191,6 @@ async fn finalize_commit_rows(
             created_at: timestamp,
             change_id: commit_change_id,
             selected_change_batches,
-            current_state_base_commit_id,
         });
         tracked_roots.push(PendingTrackedRoot {
             branch_id,
@@ -7174,7 +7078,6 @@ mod tests {
             created_at: timestamp,
             change_id: change_id("mixed-certified-commit"),
             selected_change_batches: Vec::new(),
-            current_state_base_commit_id: None,
         }];
         let read = storage
             .begin_read(StorageReadOptions::default())
@@ -9248,7 +9151,6 @@ mod tests {
                 created_at: ts("2026-01-01T00:00:01Z"),
                 change_id: ChangeId::for_test_label("child-commit-change"),
                 selected_change_batches: Vec::new(),
-                current_state_base_commit_id: None,
             },
             FinalizedCommitRow {
                 commit_id: CommitId::for_test_label("parent-commit"),
@@ -9256,7 +9158,6 @@ mod tests {
                 created_at: ts("2026-01-01T00:00:00Z"),
                 change_id: ChangeId::for_test_label("parent-commit-change"),
                 selected_change_batches: Vec::new(),
-                current_state_base_commit_id: None,
             },
         ];
         let mut rootless_commit_ids = BTreeSet::from([CommitId::for_test_label("parent-commit")]);
@@ -9394,7 +9295,6 @@ mod tests {
                 created_at: ts("2026-01-01T00:00:00Z"),
                 change_id: ChangeId::for_test_label(&format!("staged-fence-record-{index}")),
                 selected_change_batches: Vec::new(),
-                current_state_base_commit_id: None,
             })
             .collect::<Vec<_>>();
         let row_indices = commit_ids

--- a/packages/lix/src/transaction/context.rs
+++ b/packages/lix/src/transaction/context.rs
@@ -550,10 +550,6 @@ pub(crate) struct Transaction<StorageImpl: Storage + 'static = Memory> {
     /// validation or staging step rejects those buffers, this transaction can
     /// no longer provide statement atomicity and must remain rollback-only.
     mutation_journal_terminal_error: Option<LixError>,
-    /// Immutable logical state certified by the internal undo/redo transition
-    /// as the complete derived current-state base. Any later non-marker write
-    /// clears this proof before commit.
-    certified_current_state_base_commit_id: Option<CommitId>,
     staged_writes: Arc<TransactionWriteBuffer>,
     filesystem_path_index_cache: Arc<FilesystemPathIndexCache>,
     filesystem_path_index_epoch: Arc<AtomicUsize>,
@@ -670,7 +666,6 @@ struct TypedStateTransitionTarget {
 /// write has been staged in an explicit SQL transaction.
 pub(crate) struct SqlStatementCheckpoint {
     staged_writes: TransactionWriteBufferCheckpoint,
-    certified_current_state_base_commit_id: Option<CommitId>,
     filesystem_path_index_epoch: usize,
     pending_file_view_mutations: BTreeMap<SessionFileViewKey, SessionFileViewMutation>,
     trust_filesystem_planner: bool,
@@ -1495,7 +1490,6 @@ where
                 mutation_journal_sealed_rows: 0,
                 mutation_journal_seal_prefix_open: true,
                 mutation_journal_terminal_error: None,
-                certified_current_state_base_commit_id: None,
                 staged_writes,
                 filesystem_path_index_cache: Arc::new(FilesystemPathIndexCache::default()),
                 filesystem_path_index_epoch: Arc::new(AtomicUsize::new(0)),
@@ -1533,7 +1527,7 @@ where
         runtime_functions: &FunctionContext,
     ) -> Result<TransactionCommitOutcome, LixError> {
         let mut transaction = self;
-        let mut prepared_writes = match transaction.staged_writes.drain() {
+        let prepared_writes = match transaction.staged_writes.drain() {
             Ok(prepared_writes) => prepared_writes,
             Err(error) => {
                 transaction
@@ -1542,26 +1536,6 @@ where
                 return Err(error);
             }
         };
-        if let Some(base_commit_id) = transaction.certified_current_state_base_commit_id.take() {
-            let Some(change_refs) = prepared_writes
-                .commit_change_refs_by_branch
-                .get_mut(&transaction.active_branch_id)
-            else {
-                transaction
-                    .discard_pending_plugin_actor_publications()
-                    .await;
-                return Err(LixError::new(
-                    LixError::CODE_INTERNAL_ERROR,
-                    "certified current-state base has no staged semantic commit",
-                ));
-            };
-            if let Err(error) = change_refs.certify_current_state_base(base_commit_id) {
-                transaction
-                    .discard_pending_plugin_actor_publications()
-                    .await;
-                return Err(error);
-            }
-        }
         transaction
             .commit_prepared(runtime_functions, prepared_writes)
             .await
@@ -1919,7 +1893,6 @@ where
     ) -> Result<SqlStatementCheckpoint, LixError> {
         Ok(SqlStatementCheckpoint {
             staged_writes: self.staged_writes.checkpoint()?,
-            certified_current_state_base_commit_id: self.certified_current_state_base_commit_id,
             filesystem_path_index_epoch: self.filesystem_path_index_epoch.load(Ordering::SeqCst),
             pending_file_view_mutations: self.pending_file_view_mutations.clone(),
             trust_filesystem_planner: self.trust_filesystem_planner,
@@ -1934,13 +1907,11 @@ where
     ) -> Result<(), LixError> {
         let SqlStatementCheckpoint {
             staged_writes,
-            certified_current_state_base_commit_id,
             filesystem_path_index_epoch,
             pending_file_view_mutations,
             trust_filesystem_planner,
         } = checkpoint;
         self.staged_writes.restore(staged_writes)?;
-        self.certified_current_state_base_commit_id = certified_current_state_base_commit_id;
         self.filesystem_path_index_epoch
             .store(filesystem_path_index_epoch, Ordering::SeqCst);
         // The cache is derived from the discarded post-image. Evict it rather
@@ -2126,20 +2097,6 @@ where
         write: TransactionWrite,
         statement_indices: Option<Vec<u32>>,
     ) -> Result<TransactionWriteOutcome, LixError> {
-        if self.certified_current_state_base_commit_id.is_some() {
-            let preserves_transition_base = match &write {
-                TransactionWrite::Rows { rows, .. } => rows.iter().all(|row| {
-                    !row.global
-                        && !row.untracked
-                        && row.branch_id.as_str() == self.active_branch_id
-                        && row.schema_key.as_str() == crate::undo_redo::UNDO_REDO_MARKER_SCHEMA_KEY
-                }),
-                TransactionWrite::RowsWithFileContent { .. } => false,
-            };
-            if !preserves_transition_base {
-                self.certified_current_state_base_commit_id = None;
-            }
-        }
         if let Some(statement_indices) = &statement_indices {
             debug_assert_eq!(statement_indices.len(), transaction_write_row_count(&write));
         }
@@ -7598,7 +7555,6 @@ where
             rows,
         })
         .await?;
-        self.certified_current_state_base_commit_id = Some(desired_commit_id);
         Ok(crate::sql2::DiffCommandOutcome {
             rows_affected,
             commit_id: self

--- a/packages/lix/src/transaction/types.rs
+++ b/packages/lix/src/transaction/types.rs
@@ -4050,9 +4050,6 @@ pub(crate) struct StagedCommitChangeRefs {
     /// separate so staging/finalization clones only `Arc` owners rather than
     /// copying schema/file/entity or metadata columns.
     selected_change_batches: Vec<StagedCommitChangeBatch>,
-    /// Immutable commit whose complete logical state is certified as the
-    /// current-state base of this new semantic commit.
-    current_state_base_commit_id: Option<CommitId>,
     /// Certified immutable mutation columns for this commit. This owner is
     /// attached only at drain, after complete-replacement certification, and
     /// is cloned through commit finalization in O(1).
@@ -4069,7 +4066,6 @@ impl Default for StagedCommitChangeRefs {
             created_at: LixTimestamp::expect_parse("created_at", "1970-01-01T00:00:00.000Z"),
             tracked_change_count: 0,
             selected_change_batches: Vec::new(),
-            current_state_base_commit_id: None,
             ordered_mutation_journal: None,
             allow_empty: false,
         }
@@ -4079,11 +4075,8 @@ impl Default for StagedCommitChangeRefs {
 impl StagedCommitChangeRefs {
     pub(crate) fn absorb_cohort_membership(&mut self, mut other: Self) {
         debug_assert!(
-            self.ordered_mutation_journal.is_none()
-                && other.ordered_mutation_journal.is_none()
-                && self.current_state_base_commit_id.is_none()
-                && other.current_state_base_commit_id.is_none(),
-            "certified publication routes cannot join commit cohorts"
+            self.ordered_mutation_journal.is_none() && other.ordered_mutation_journal.is_none(),
+            "immutable replacement journals cannot join commit cohorts"
         );
         self.tracked_change_count = self
             .tracked_change_count
@@ -4313,27 +4306,6 @@ impl StagedCommitChangeRefs {
         self.ordered_mutation_journal.take()
     }
 
-    pub(crate) fn certify_current_state_base(
-        &mut self,
-        commit_id: CommitId,
-    ) -> Result<(), LixError> {
-        if self
-            .current_state_base_commit_id
-            .replace(commit_id)
-            .is_some()
-        {
-            return Err(LixError::new(
-                LixError::CODE_INTERNAL_ERROR,
-                "commit received more than one certified current-state base",
-            ));
-        }
-        Ok(())
-    }
-
-    pub(crate) fn current_state_base_commit_id(&self) -> Option<CommitId> {
-        self.current_state_base_commit_id
-    }
-
     pub(crate) fn new(
         commit_id: CommitId,
         commit_change_id: ChangeId,
@@ -4347,7 +4319,6 @@ impl StagedCommitChangeRefs {
             created_at,
             tracked_change_count: 0,
             selected_change_batches: Vec::new(),
-            current_state_base_commit_id: None,
             ordered_mutation_journal: None,
             allow_empty: false,
         }

--- a/packages/lix/tests/adapter_undo_redo_checkpoint.rs
+++ b/packages/lix/tests/adapter_undo_redo_checkpoint.rs
@@ -1,0 +1,111 @@
+use lix::Value;
+use lix::integration::{Engine, SessionContext};
+use lix::storage::Storage;
+
+const A_KEY: &str = "checkpointed-a";
+const B_KEY: &str = "undo-target-b";
+
+async fn value<S>(session: &SessionContext<S>, key: &str) -> Option<String>
+where
+    S: Storage + Clone + Send + Sync + 'static,
+{
+    let result = session
+        .execute(
+            "SELECT value FROM lix_key_value WHERE key = $1",
+            &[Value::Text(key.to_string())],
+        )
+        .await
+        .expect("key-value row reads");
+    result
+        .rows()
+        .first()
+        .and_then(|row| row.get::<Value>("value").ok())
+        .and_then(|value| match value {
+            Value::Text(value) => Some(value),
+            Value::Json(value) => value.as_str().map(ToOwned::to_owned),
+            _ => None,
+        })
+}
+
+async fn assert_values<S>(session: &SessionContext<S>, a: &str, b: &str)
+where
+    S: Storage + Clone + Send + Sync + 'static,
+{
+    assert_eq!(value(session, A_KEY).await.as_deref(), Some(a));
+    assert_eq!(value(session, B_KEY).await.as_deref(), Some(b));
+}
+
+pub async fn stage_checkpointed_a_and_undo_b<S>(engine: &Engine<S>) -> String
+where
+    S: Storage + Clone + Send + Sync + 'static,
+{
+    let session = engine
+        .open_workspace_session()
+        .await
+        .expect("workspace session opens");
+    session
+        .execute(
+            "INSERT INTO lix_key_value (key, value) VALUES ($1, 'a0'), ($2, 'b0')",
+            &[
+                Value::Text(A_KEY.to_string()),
+                Value::Text(B_KEY.to_string()),
+            ],
+        )
+        .await
+        .expect("seed rows commit");
+    session
+        .create_checkpoint()
+        .await
+        .expect("seed checkpoint commits");
+    session
+        .execute(
+            "UPDATE lix_key_value SET value = 'a1' WHERE key = $1",
+            &[Value::Text(A_KEY.to_string())],
+        )
+        .await
+        .expect("A commits");
+    session
+        .create_checkpoint()
+        .await
+        .expect("A checkpoint commits");
+    session
+        .execute(
+            "UPDATE lix_key_value SET value = 'b1' WHERE key = $1",
+            &[Value::Text(B_KEY.to_string())],
+        )
+        .await
+        .expect("B commits");
+    assert_values(&session, "a1", "b1").await;
+
+    session.undo().await.expect("B undoes");
+    assert_values(&session, "a1", "b0").await;
+
+    session
+        .active_branch_id()
+        .await
+        .expect("active branch resolves")
+}
+
+pub async fn assert_cold_undo_then_redo<S>(engine: &Engine<S>, branch_id: String)
+where
+    S: Storage + Clone + Send + Sync + 'static,
+{
+    let session = engine
+        .open_session(branch_id)
+        .await
+        .expect("cold session opens after undo");
+    assert_values(&session, "a1", "b0").await;
+    session.redo().await.expect("B redoes after cold reopen");
+    assert_values(&session, "a1", "b1").await;
+}
+
+pub async fn assert_cold_redo<S>(engine: &Engine<S>, branch_id: String)
+where
+    S: Storage + Clone + Send + Sync + 'static,
+{
+    let session = engine
+        .open_session(branch_id)
+        .await
+        .expect("cold session opens after redo");
+    assert_values(&session, "a1", "b1").await;
+}

--- a/packages/rocksdb-storage/tests/storage/main.rs
+++ b/packages/rocksdb-storage/tests/storage/main.rs
@@ -2,7 +2,10 @@ mod file_sql;
 mod native_file_read;
 mod native_file_upsert;
 mod rocksdb_specific;
+#[path = "../../../lix/tests/adapter_undo_redo_checkpoint.rs"]
+mod undo_redo_checkpoint;
 
+use lix::integration::Engine;
 use lix::storage::conformance::run_storage_conformance;
 use lix_storage_rocksdb::{RocksDB, RocksDBFactory};
 
@@ -22,4 +25,34 @@ fn rocksdb_exposes_database_path_and_flushes() {
     storage.flush().expect("flush rocksdb storage");
 
     assert_eq!(storage.path(), path.as_path());
+}
+
+#[tokio::test]
+async fn checkpointed_state_survives_undo_redo_and_cold_reopen_on_rocksdb() {
+    let temp_dir = tempfile::tempdir().expect("create RocksDB temp directory");
+    let path = temp_dir.path().join("undo-redo.rocksdb");
+    let storage = RocksDB::open(&path).expect("open RocksDB storage");
+    Engine::initialize(storage.clone())
+        .await
+        .expect("initialize RocksDB storage");
+    let engine = Engine::new(storage.clone()).await.expect("open engine");
+    let branch_id = undo_redo_checkpoint::stage_checkpointed_a_and_undo_b(&engine).await;
+    drop(engine);
+    storage.flush().expect("flush undo state");
+    drop(storage);
+
+    let storage = RocksDB::open(&path).expect("reopen RocksDB after undo");
+    let engine = Engine::new(storage.clone())
+        .await
+        .expect("reopen engine after undo");
+    undo_redo_checkpoint::assert_cold_undo_then_redo(&engine, branch_id.clone()).await;
+    drop(engine);
+    storage.flush().expect("flush redo state");
+    drop(storage);
+
+    let storage = RocksDB::open(&path).expect("reopen RocksDB after redo");
+    let engine = Engine::new(storage)
+        .await
+        .expect("reopen engine after redo");
+    undo_redo_checkpoint::assert_cold_redo(&engine, branch_id).await;
 }

--- a/packages/slatedb-storage/tests/storage.rs
+++ b/packages/slatedb-storage/tests/storage.rs
@@ -3,6 +3,9 @@
     reason = "test fixtures mirror explicit Send future signatures from StorageFixture"
 )]
 
+#[path = "../../lix/tests/adapter_undo_redo_checkpoint.rs"]
+mod undo_redo_checkpoint;
+
 use async_trait::async_trait;
 use bytes::Bytes;
 use futures_util::stream::{self, BoxStream};
@@ -150,6 +153,36 @@ async fn slatedb_exposes_database_path_and_flushes() {
     storage.flush().await.expect("flush slatedb storage");
 
     assert_eq!(storage.path(), path.as_path());
+}
+
+#[tokio::test]
+async fn checkpointed_state_survives_undo_redo_and_cold_reopen_on_slatedb() {
+    let temp_dir = tempfile::tempdir().expect("create SlateDB temp directory");
+    let path = temp_dir.path().join("undo-redo.slatedb");
+    let storage = SlateDB::open(&path).expect("open SlateDB storage");
+    Engine::initialize(storage.clone())
+        .await
+        .expect("initialize SlateDB storage");
+    let engine = Engine::new(storage.clone()).await.expect("open engine");
+    let branch_id = undo_redo_checkpoint::stage_checkpointed_a_and_undo_b(&engine).await;
+    drop(engine);
+    storage.flush().await.expect("flush undo state");
+    drop(storage);
+
+    let storage = SlateDB::open(&path).expect("reopen SlateDB after undo");
+    let engine = Engine::new(storage.clone())
+        .await
+        .expect("reopen engine after undo");
+    undo_redo_checkpoint::assert_cold_undo_then_redo(&engine, branch_id.clone()).await;
+    drop(engine);
+    storage.flush().await.expect("flush redo state");
+    drop(storage);
+
+    let storage = SlateDB::open(&path).expect("reopen SlateDB after redo");
+    let engine = Engine::new(storage)
+        .await
+        .expect("reopen engine after redo");
+    undo_redo_checkpoint::assert_cold_redo(&engine, branch_id).await;
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

Public undo/redo now publishes through the one canonical authenticated current-state path used by ordinary semantic writes.

The deleted undo/redo-only route treated a historical desired commit as a complete current-state base and overlaid only the undo marker. After `A -> checkpoint -> B -> undo(B)`, that specialized publication omitted checkpointed `A`, so an immediate read could revert `A` to its seed value on both RocksDB and SlateDB.

## Hard-cut scope

- Delete `certified_current_state_base_commit_id` from transaction context, statement checkpoints, staged commit types, finalization, and commit publication.
- Delete its certifier, invalidation rules, marker-only overlay, and specialized `stage_root_current_base` branch completely.
- Route undo/redo typed transition rows and their marker through the existing canonical current-state delta publication, preserving the authenticated checkpoint generation plus the complete undo/redo post-image.
- Add one shared deterministic `A -> checkpoint -> B -> undo -> cold reopen -> redo -> cold reopen` oracle, exercised by RocksDB and SlateDB.
- Retain no compatibility reader, fallback, dual writer, feature flag, migration, or superseded implementation.

## Final provenance

- Current main merged exactly once: `9f02a720308a5398b038d20dc84b1ef8ae24740e` (tree `2efe4529b2161e39bf00dd0d6da4a6042c4ff469`)
- Independently approved pre-integration head: `522019220bb25dda2baff51498b9a177628e9136` (tree `4898418bad2ae37953742c67c53b5e5137756ed0`)
- Final head: `09e043006aefccb6eb9a45d69342ad2761b38953` (tree `8da56ca4e5d77aa25e57e611fbf4aaad4c01dd10`)
- Final merge parents: `522019220bb25dda2baff51498b9a177628e9136 9f02a720308a5398b038d20dc84b1ef8ae24740e`
- Preserved `packages/lix/src/live_state/tracked_head/hot.rs` blob: `7b42d16fa81cdd289132eedeaa3057fe840b7546`
- Canonical main-relative binary diff hash (`git diff --binary 9f02a720..HEAD | git hash-object --stdin`): `ff50a89d1f9d699ccf336ed2ec7541c17242ffc4`
- Main-relative scope: exactly six files, 180 insertions and 176 deletions; `hot.rs` is absent from the PR diff.

The one integration conflict was main's new transaction-open runtime-boundary return shape overlapping the obsolete certified-base initializer. Resolution preserved main's complete return shape and removed only the deleted initializer. No other manual integration edit was made.

## Final correctness evidence

All commands were bounded below 20 minutes and rerun after the final main merge.

- RocksDB deterministic hot/cold undo/redo regression: 1/1 green.
- SlateDB deterministic hot/cold undo/redo regression: 1/1 green.
- Public diff apply/revert/checkpoint selection, base + tracked-state rebuild: 2/2 green.
- Checkpoint projection, base + tracked-state rebuild: 2/2 green.
- Checkpoint-GC recovery, base + tracked-state rebuild: 2/2 green.
- Deterministic transaction corruption sequence, base + tracked-state rebuild: 2/2 green.
- `cargo fmt --all -- --check`: green.
- `git diff --check 9f02a720..HEAD`: green.
- Full obsolete-identifier residue audit: empty.
- `CARGO_BUILD_JOBS=1 cargo clippy --profile test --workspace --all-targets --all-features -- -D warnings`: green.

## Impact

Public undo/redo semantics remain unchanged except that checkpointed unrelated state is no longer lost. Publication remains `O(k log N)` in the changed identities through the canonical delta path, instead of retaining a second incomplete `O(1) + marker-overlay` authority. The correctness cut removes 176 lines of specialized production responsibility and introduces no persisted format or migration.

Draft only. The pre-integration head received independent approval; this exact final head must remain unmerged for final-head review and hosted qualification.
