### PR TITLE
perf(binary-cas): parallelize large blob identity hashing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3357,6 +3357,7 @@ dependencies = [
  "paste",
  "plugin_csv",
  "plugin_json",
+ "rayon",
  "ruzstd",
  "serde",
  "serde_json",

--- a/packages/engine-benchmarks/tests/large_payload_read_qualification.rs
+++ b/packages/engine-benchmarks/tests/large_payload_read_qualification.rs
@@ -34,7 +34,7 @@ const MANIFEST_CHUNK_SPACE: SpaceId = SpaceId(0x0005_0002);
 const PAYLOAD_SPACE: SpaceId = SpaceId(0x0005_0003);
 const PRESENCE_SPACE: SpaceId = SpaceId(0x0005_0004);
 const PATH: &str = "/media/foreground.mov";
-const EDIT_BYTES: usize = 4 * 1024;
+const DEFAULT_EDIT_BYTES: usize = 4 * 1024;
 const RANGE_BYTES: u64 = 4 * 1024;
 const SEED: u64 = 0x89a3_10fd_4242_73c1;
 const SOURCE_BRANCH_ID: &str = "01980000-0000-7000-8000-000000000064";
@@ -319,6 +319,8 @@ struct PreparedPayload {
     parts: Vec<Bytes>,
     size: usize,
     edit_offset: usize,
+    edit_bytes: usize,
+    edit: Bytes,
     base_blake3: String,
     base_sha256: String,
     edited_blake3: String,
@@ -596,7 +598,7 @@ where
     )
     .await;
     assert_eq!(verified_base.sha256(), prepared.base_sha256);
-    let suffix_bytes = prepared.size - prepared.edit_offset - EDIT_BYTES;
+    let suffix_bytes = prepared.size - prepared.edit_offset - prepared.edit_bytes;
     let (verified_result, provenance) = measured(
         backend,
         size_mib,
@@ -610,7 +612,7 @@ where
                 &prepared.edited_sha256,
                 prepared.edit_offset,
                 suffix_bytes,
-                vec![0xa5; EDIT_BYTES].into(),
+                prepared.edit.clone().into(),
             )
         },
     )
@@ -654,12 +656,13 @@ where
         branch_layout,
         edit_layout,
     );
+    let changed_chunk_ceiling = prepared.edit_bytes.div_ceil(1024 * 1024) as u64 + 1;
     assert!(
         edit_layout
             .payload
             .rows
             .saturating_sub(branch_layout.payload.rows)
-            <= 1,
+            <= changed_chunk_ceiling,
         "localized edit rewrote unchanged payload chunks"
     );
 
@@ -891,8 +894,14 @@ where
 
 fn prepare_payload(size: usize) -> PreparedPayload {
     assert_eq!(size % FILE_UPLOAD_PART_BYTES, 0);
+    let edit_bytes = qualification_edit_bytes(size);
     let edit_offset = size / 2 + 12_345;
-    let edit_end = edit_offset + EDIT_BYTES;
+    let edit_end = edit_offset + edit_bytes;
+    assert!(edit_end <= size, "qualification edit must fit the payload");
+    let edit = Bytes::from(deterministic_bytes(
+        edit_bytes,
+        SEED ^ 0xa5a5_5a5a_0f0f_f0f0,
+    ));
     let mut parts = Vec::with_capacity(size / FILE_UPLOAD_PART_BYTES);
     let mut base_blake3 = blake3::Hasher::new();
     let mut edited_blake3 = blake3::Hasher::new();
@@ -906,7 +915,9 @@ fn prepare_payload(size: usize) -> PreparedPayload {
             let local_start = edit_offset.saturating_sub(offset);
             let local_end = (edit_end - offset).min(bytes.len());
             let mut edited = bytes.clone();
-            edited[local_start..local_end].fill(0xa5);
+            let edit_start = offset + local_start - edit_offset;
+            let edit_end = edit_start + local_end - local_start;
+            edited[local_start..local_end].copy_from_slice(&edit[edit_start..edit_end]);
             edited_blake3.update(&edited);
             edited_sha256.update(&edited);
         } else {
@@ -919,11 +930,30 @@ fn prepare_payload(size: usize) -> PreparedPayload {
         parts,
         size,
         edit_offset,
+        edit_bytes,
+        edit,
         base_blake3: base_blake3.finalize().to_hex().to_string(),
         base_sha256: format!("{:x}", base_sha256.finalize()),
         edited_blake3: edited_blake3.finalize().to_hex().to_string(),
         edited_sha256: format!("{:x}", edited_sha256.finalize()),
     }
+}
+
+fn qualification_edit_bytes(size: usize) -> usize {
+    let Some(percent) = std::env::var("LIX_MEDIA_QUAL_EDIT_PERCENT")
+        .ok()
+        .map(|value| {
+            value
+                .parse::<usize>()
+                .unwrap_or_else(|_| panic!("invalid LIX_MEDIA_QUAL_EDIT_PERCENT '{value}'"))
+        })
+    else {
+        return DEFAULT_EDIT_BYTES;
+    };
+    assert!(matches!(percent, 1 | 10), "edit percent must be 1 or 10");
+    size.checked_mul(percent)
+        .expect("qualification edit size overflow")
+        .div_ceil(100)
 }
 
 fn deterministic_bytes(len: usize, seed: u64) -> Vec<u8> {
@@ -990,8 +1020,12 @@ where
     let disk_after = directory_bytes(database);
     let cas = binary_cas_write_accounting();
     let structural = take_media_structural_accounting();
+    let edit_percent = std::env::var("LIX_MEDIA_QUAL_EDIT_PERCENT")
+        .ok()
+        .and_then(|value| value.parse::<usize>().ok())
+        .unwrap_or(0);
     println!(
-        "large_payload_read,backend={backend},size_mib={size_mib},operation={operation},\
+        "large_payload_read,backend={backend},size_mib={size_mib},edit_percent={edit_percent},operation={operation},\
          wall_ms={:.3},cpu_ticks={cpu_ticks},allocated_bytes={allocated_bytes},allocation_calls={allocation_calls},\
          rss_before_kib={rss_before},rss_after_kib={rss_after},peak_rss_kib={},hwm_kib={},\
          begin_reads={},begin_writes={},get_many_calls={},get_many_keys={},get_many_found={},get_many_value_bytes={},\

--- a/packages/lix/Cargo.toml
+++ b/packages/lix/Cargo.toml
@@ -112,6 +112,7 @@ wit-parser = "0.247"
 [target.'cfg(not(target_family = "wasm"))'.dependencies]
 zstd = "0.13"
 notify-debouncer-full = { version = "0.7.0", default-features = false, features = ["macos_kqueue"] }
+rayon = "1"
 tokio = { version = "1", features = ["rt", "sync"] }
 
 [target.'cfg(target_family = "wasm")'.dependencies]

--- a/packages/lix/src/binary_cas/types.rs
+++ b/packages/lix/src/binary_cas/types.rs
@@ -2,7 +2,39 @@ use crate::LixError;
 use crate::binary_cas::chunking::MEDIA_CHUNK_BYTES;
 use crate::binary_cas::codec::BinaryChunkCodec;
 use crate::binary_cas::codec::{binary_blob_hash_bytes, hash_bytes_to_hex, hash_hex_to_bytes};
+#[cfg(not(target_family = "wasm"))]
+use rayon::prelude::*;
 use std::ops::Range;
+#[cfg(not(target_family = "wasm"))]
+use std::sync::OnceLock;
+
+#[cfg(not(target_family = "wasm"))]
+// Below this point, bounded scheduling costs more than the independent chunk work.
+const PARALLEL_BLOB_ID_BYTES: usize = 16 * 1024 * 1024;
+#[cfg(not(target_family = "wasm"))]
+// Keep aggregate CPU and resident thread stacks bounded under concurrent writers.
+const MAX_BLOB_ID_HASH_THREADS: usize = 4;
+
+#[cfg(not(target_family = "wasm"))]
+fn blob_id_hash_pool() -> Option<&'static rayon::ThreadPool> {
+    static POOL: OnceLock<Option<rayon::ThreadPool>> = OnceLock::new();
+    POOL.get_or_init(|| {
+        let threads = std::thread::available_parallelism()
+            .map(usize::from)
+            .unwrap_or(1)
+            .min(MAX_BLOB_ID_HASH_THREADS);
+        (threads > 1)
+            .then(|| {
+                rayon::ThreadPoolBuilder::new()
+                    .num_threads(threads)
+                    .thread_name(|index| format!("lix-blob-id-{index}"))
+                    .build()
+                    .ok()
+            })
+            .flatten()
+    })
+    .as_ref()
+}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub(crate) struct BlobId([u8; 32]);
@@ -15,6 +47,22 @@ impl BlobId {
     pub(crate) fn from_content(content: &[u8]) -> Self {
         if content.len() <= MEDIA_CHUNK_BYTES {
             return Self::from_single_chunk(ChunkHash::from_content(content));
+        }
+        #[cfg(not(target_family = "wasm"))]
+        {
+            // Fixed-manifest chunk hashes are independent, while `from_chunks`
+            // below remains the sole ordered canonical identity derivation.
+            if content.len() >= PARALLEL_BLOB_ID_BYTES
+                && let Some(pool) = blob_id_hash_pool()
+            {
+                let chunks = pool.install(|| {
+                    content
+                        .par_chunks(MEDIA_CHUNK_BYTES)
+                        .map(|chunk| (ChunkHash::from_content(chunk), chunk.len() as u64))
+                        .collect::<Vec<_>>()
+                });
+                return Self::from_chunks(content.len() as u64, chunks);
+            }
         }
         let chunks = content
             .chunks(MEDIA_CHUNK_BYTES)
@@ -268,4 +316,37 @@ pub(crate) struct BinaryCasChunkView<'a> {
     pub(crate) uncompressed_len: u64,
     #[musli(bytes)]
     pub(crate) payload: &'a [u8],
+}
+
+#[cfg(all(test, not(target_family = "wasm")))]
+mod tests {
+    use super::*;
+
+    fn sequential_blob_id(content: &[u8]) -> BlobId {
+        if content.len() <= MEDIA_CHUNK_BYTES {
+            return BlobId::from_single_chunk(ChunkHash::from_content(content));
+        }
+        BlobId::from_chunks(
+            content.len() as u64,
+            content
+                .chunks(MEDIA_CHUNK_BYTES)
+                .map(|chunk| (ChunkHash::from_content(chunk), chunk.len() as u64)),
+        )
+    }
+
+    #[test]
+    fn parallel_blob_identity_is_byte_stable_at_routing_boundaries() {
+        for len in [
+            MEDIA_CHUNK_BYTES,
+            MEDIA_CHUNK_BYTES + 1,
+            PARALLEL_BLOB_ID_BYTES - 1,
+            PARALLEL_BLOB_ID_BYTES,
+            PARALLEL_BLOB_ID_BYTES + 1,
+        ] {
+            let content = (0..len)
+                .map(|index| (index as u8).wrapping_mul(31).wrapping_add(17))
+                .collect::<Vec<_>>();
+            assert_eq!(BlobId::from_content(&content), sequential_blob_id(&content));
+        }
+    }
 }


### PR DESCRIPTION
## What changed

- Compute independent 1 MiB binary-CAS chunk hashes in a bounded four-worker
  native pool for payloads at least 16 MiB.
- Keep the existing ordered `BlobId::from_chunks` derivation as the sole
  canonical identity; wasm and fail-soft/single-worker paths remain sequential.
- Add a byte-stability regression at the 1 MiB and 16 MiB routing boundaries.
- Extend the ignored large-media lifecycle harness with high-entropy 1% and 10%
  edit qualification.

There is no format, manifest, root, authority, cache, compatibility path, or
writer change.

## Why

Large selected-payload publication serially rehashed every byte before staging
already-chunked CAS writes. The canonical pass was the dominant removable wall
term: about 7.3 ms at 64 MiB and roughly 40 ms at 512 MiB, with a 25-37%
perfect-elimination ceiling.

Work remains `O(N + C + E)`, but native canonical-hash wall time approaches
`O(N/P)` for `P <= 4`; backend writes and disk remain `O(C + E)` and are
unchanged.

## Exact-base results

Qualified base: `02833eb457889f767bd177887bf177c17314a4e1`  
Candidate: `4a2e2ce01c06269b096ba6a504466928f68035c0`

| Adapter | Payload/edit | Publish latency |
|---|---|---:|
| RocksDB | 64 MiB / 1% | 18.320 -> 13.301 ms (-27.40%) |
| RocksDB | 64 MiB / 10% | 22.263 -> 19.695 ms (-11.53%) |
| SlateDB | 64 MiB / 1% | 17.462 -> 15.091 ms (-13.58%) |
| SlateDB | 64 MiB / 10% | 21.545 -> 16.922 ms (-21.46%) |
| RocksDB | 512 MiB / 1% | 116.987 -> 80.048 ms (-31.58%) |
| RocksDB | 512 MiB / 10% | 155.954 -> 118.144 ms (-24.24%) |
| SlateDB | 512 MiB / 1% | 115.569 -> 77.681 ms (-32.78%) |
| SlateDB | 512 MiB / 10% | 126.857 -> 89.295 ms (-29.61%) |

Allocations are neutral-to-lower and backend calls/bytes/writes, authenticated
CAS rows, changed chunks, ownership, and settled disk are unchanged. The first
parallel publication includes pool startup and can use 5-28% more CPU in the
short measured operation; three precise full-lifecycle pairs are +0.98%
RocksDB and +1.30% SlateDB aggregate CPU, below the 5% critical ceiling. RSS
shows no systematic regression.

## Validation

- [x] Format and diff checks
- [x] Canonical workspace/all-target/all-feature Clippy with `-D warnings`
- [x] 38 focused all-feature binary-CAS tests
- [x] Default and all-feature Lix library suites
- [x] Exact 64/512 MiB, 1/10%, RocksDB/SlateDB lifecycle gates
- [x] Branch, diff, merge, checkpoint, flush/drop, cold reopen, identity and
      owner-layout assertions in every lifecycle cell
- [x] Read-only prospective merge-tree against `9f02a720`: no conflicts and no
      shared paths (`9f02` changes only `live_state/tracked_head/hot.rs`)

This branch intentionally contains the one prior merge of `02833eb4`; it was
not merged or rebased again after main advanced to `9f02a720`.
