### PR TITLE
Linearize live-state authority reconciliation

### DIFF
--- a/packages/cli/src/commands/exp/git_replay.rs
+++ b/packages/cli/src/commands/exp/git_replay.rs
@@ -3717,9 +3717,10 @@ mod tests {
                 )))],
             ))
             .expect("reopened Git-text rows should query");
-            assert!(
-                !semantic_rows.rows().is_empty(),
-                "text semantic rows should persist for {path}"
+            assert_eq!(
+                semantic_rows.rows().len(),
+                1,
+                "exactly one text semantic row should persist for {path}"
             );
         }
         db::block_on(lix.close()).expect("reopened Lix should close");

--- a/packages/lix/src/live_state/tracked_head/hot.rs
+++ b/packages/lix/src/live_state/tracked_head/hot.rs
@@ -3929,6 +3929,39 @@ fn merge_ordered_live_batches(
     merged.finish()
 }
 
+/// Removes rows whose identity is already owned by another identity-ordered
+/// authority batch. Both inputs are scan results in canonical identity order,
+/// so one forward cursor replaces a per-row tree lookup and owned identity.
+fn exclude_ordered_live_batch_identities(
+    rows: MaterializedLiveStateBatch,
+    authority: &MaterializedLiveStateBatch,
+) -> MaterializedLiveStateBatch {
+    if rows.is_empty() || authority.is_empty() {
+        return rows;
+    }
+    debug_assert!((1..rows.len()).all(|index| {
+        compare_materialized_live_identity_refs(rows.row(index - 1), rows.row(index)).is_lt()
+    }));
+    debug_assert!((1..authority.len()).all(|index| {
+        compare_materialized_live_identity_refs(authority.row(index - 1), authority.row(index))
+            .is_lt()
+    }));
+    let mut authority_index = 0usize;
+    rows.filter(
+        |row| loop {
+            let Some(authority_row) = authority.get(authority_index) else {
+                return true;
+            };
+            match compare_materialized_live_identity_refs(authority_row, row) {
+                Ordering::Less => authority_index += 1,
+                Ordering::Equal => return false,
+                Ordering::Greater => return true,
+            }
+        },
+        None,
+    )
+}
+
 /// Direct reader for one published hot generation.
 pub(crate) struct HotStateStoreReader<S> {
     pub(super) store: S,
@@ -4735,20 +4768,8 @@ where
             },
             None,
         );
-        let overlay_commits = rows
-            .iter()
-            .map(|row| {
-                (
-                    (
-                        row.schema_key().to_owned(),
-                        row.entity_pk().clone(),
-                        row.file_id().map(str::to_owned),
-                    ),
-                    row.commit_id(),
-                )
-            })
-            .collect::<BTreeMap<_, _>>();
-        let packed_limit = if overlay_commits.is_empty() && replaced_generation.is_none() {
+        let has_overlay_rows = !rows.is_empty();
+        let packed_limit = if !has_overlay_rows && replaced_generation.is_none() {
             request.limit.map(|limit| limit.saturating_sub(rows.len()))
         } else {
             None
@@ -4777,60 +4798,7 @@ where
         } else {
             scan_packed_current_base_rows(&self.store, branch_id, generation, request, packed_limit)
                 .await?
-        }
-        .filter(
-            |row| {
-                overlay_commits.is_empty() || {
-                    let identity = (
-                        row.schema_key().to_owned(),
-                        row.entity_pk().clone(),
-                        row.file_id().map(str::to_owned),
-                    );
-                    overlay_commits.get(&identity).is_none_or(|overlay_commit| {
-                        overlay_commit.is_some_and(|overlay_commit| {
-                            row.commit_id()
-                                .is_some_and(|packed_commit| packed_commit > overlay_commit)
-                        })
-                    })
-                }
-            },
-            None,
-        );
-        let packed_commits = if rows.is_empty() {
-            BTreeMap::new()
-        } else {
-            packed_rows
-                .iter()
-                .map(|row| {
-                    (
-                        (
-                            row.schema_key().to_owned(),
-                            row.entity_pk().clone(),
-                            row.file_id().map(str::to_owned),
-                        ),
-                        row.commit_id(),
-                    )
-                })
-                .collect::<BTreeMap<_, _>>()
         };
-        let rows = rows.filter(
-            |row| {
-                packed_commits.is_empty() || {
-                    let identity = (
-                        row.schema_key().to_owned(),
-                        row.entity_pk().clone(),
-                        row.file_id().map(str::to_owned),
-                    );
-                    packed_commits.get(&identity).is_none_or(|packed_commit| {
-                        !packed_commit.is_some_and(|packed_commit| {
-                            row.commit_id()
-                                .is_some_and(|overlay_commit| packed_commit > overlay_commit)
-                        })
-                    })
-                }
-            },
-            None,
-        );
         // Format plugins cannot publish engine-owned schemas. Do not even
         // inspect certified semantic manifests for a scan that can only match
         // engine rows such as file descriptors or blob materializations.
@@ -4848,7 +4816,7 @@ where
                 branch_id,
                 generation,
                 request,
-                if overlay_commits.is_empty() {
+                if !has_overlay_rows {
                     request.limit.map(|limit| limit.saturating_sub(rows.len()))
                 } else {
                     None
@@ -4856,43 +4824,6 @@ where
                 self.transaction_cache.as_deref(),
             )
             .await?
-            .filter(
-                |row| {
-                    overlay_commits.is_empty() || {
-                        let identity = (
-                            row.schema_key().to_owned(),
-                            row.entity_pk().clone(),
-                            row.file_id().map(str::to_owned),
-                        );
-                        !overlay_commits.contains_key(&identity)
-                    }
-                },
-                None,
-            )
-        };
-        let certified_rows = if certified_rows.is_empty() || packed_rows.is_empty() {
-            certified_rows
-        } else {
-            let packed_identities = packed_rows
-                .iter()
-                .map(|row| {
-                    (
-                        row.schema_key().to_owned(),
-                        row.entity_pk().clone(),
-                        row.file_id().map(str::to_owned),
-                    )
-                })
-                .collect::<BTreeSet<_>>();
-            certified_rows.filter(
-                |row| {
-                    !packed_identities.contains(&(
-                        row.schema_key().to_owned(),
-                        row.entity_pk().clone(),
-                        row.file_id().map(str::to_owned),
-                    ))
-                },
-                None,
-            )
         };
         // A pristine root-backed generation has no possible shadowing winner,
         // so preserve bounded-read behavior by pushing LIMIT into the tracked
@@ -4909,7 +4840,12 @@ where
                 .saturating_add(certified_rows.len()),
         ))
         .await?;
+        // HOT and packed rows carry comparable commit ownership; their
+        // existing ordered merge selects the newest authority directly.
+        // Certified rows remain subordinate to either authority regardless of
+        // commit ID, so exclude their collisions with one linear cursor.
         let combined = merge_ordered_live_batches(rows, packed_rows);
+        let certified_rows = exclude_ordered_live_batch_identities(certified_rows, &combined);
         let combined = merge_ordered_live_batches(combined, root_rows);
         let rows = merge_ordered_live_batches(combined, certified_rows);
         if request.filter.include_tombstones
@@ -11347,6 +11283,34 @@ mod tests {
                 .map(|row| row.entity_pk.as_single_string_owned().expect("single key"))
                 .collect::<Vec<_>>(),
             ["a", "b", "c"]
+        );
+    }
+
+    #[test]
+    fn ordered_authority_exclusion_removes_only_identity_collisions() {
+        let rows = MaterializedLiveStateBatch::from_rows(vec![
+            live_row("a", "candidate-a"),
+            live_row("b", "candidate-b"),
+            live_row("c", "candidate-c"),
+            live_row("d", "candidate-d"),
+        ]);
+        let authority = MaterializedLiveStateBatch::from_rows(vec![
+            live_row("a", "authority-a"),
+            live_row("c", "authority-c"),
+        ]);
+
+        let filtered = exclude_ordered_live_batch_identities(rows, &authority);
+
+        assert_eq!(
+            filtered
+                .iter()
+                .map(|row| {
+                    row.entity_pk()
+                        .as_single_string_owned()
+                        .expect("single key")
+                })
+                .collect::<Vec<_>>(),
+            ["b", "d"]
         );
     }
 

--- a/packages/lix/src/live_state/tracked_head/hot.rs
+++ b/packages/lix/src/live_state/tracked_head/hot.rs
@@ -9690,7 +9690,12 @@ async fn hot_scan_entries<'a>(
     prefixes.sort();
     prefixes.dedup();
     let mut rows = Vec::new();
+    let mut saw_file_backed_row = false;
     let mut retained_bytes = 0_usize;
+    // A fixed file bucket has the same physical and logical order. Every
+    // broader file domain must defer LIMIT until file-first storage order has
+    // been restored to canonical `(schema, entity_pk, file_id)` order.
+    let physical_limit = limit.filter(|_| hot_filter_has_one_fixed_file_bucket(filter));
     for prefix in prefixes {
         let plan = ScanPlan::prefix(
             HOT_ROW_SPACE,
@@ -9700,8 +9705,13 @@ async fn hot_scan_entries<'a>(
         );
         let mut resume_after = None;
         loop {
-            let remaining = limit.map(|limit| limit.saturating_sub(rows.len()));
+            let remaining = physical_limit.map(|limit| limit.saturating_sub(rows.len()));
             if matches!(remaining, Some(0)) {
+                let rows = if saw_file_backed_row {
+                    canonicalize_hot_scan_rows(rows, limit)?
+                } else {
+                    rows
+                };
                 return Ok(Some(HotScanEntries::Decoded(rows)));
             }
             let page = plan
@@ -9720,6 +9730,7 @@ async fn hot_scan_entries<'a>(
                 let encoded_key_bytes = entry.key.0.len();
                 let identity = decode_hot_scan_row_key_in_scope(entry.key.0, &scope)?;
                 if identity.matches_filter(filter) {
+                    saw_file_backed_row |= identity.file_id().is_some();
                     let value = full_value_bytes(entry.value)?;
                     retained_bytes = retained_bytes
                         .checked_add(encoded_key_bytes)
@@ -9730,7 +9741,12 @@ async fn hot_scan_entries<'a>(
                         return Ok(None);
                     }
                     rows.push((identity, value));
-                    if limit.is_some_and(|limit| rows.len() >= limit) {
+                    if physical_limit.is_some_and(|limit| rows.len() >= limit) {
+                        let rows = if saw_file_backed_row {
+                            canonicalize_hot_scan_rows(rows, limit)?
+                        } else {
+                            rows
+                        };
                         return Ok(Some(HotScanEntries::Decoded(rows)));
                     }
                 }
@@ -9740,7 +9756,58 @@ async fn hot_scan_entries<'a>(
             }
         }
     }
+    if saw_file_backed_row {
+        rows = canonicalize_hot_scan_rows(rows, limit)?;
+    } else if let Some(limit) = limit {
+        rows.truncate(limit);
+    }
     Ok(Some(HotScanEntries::Decoded(rows)))
+}
+
+fn hot_filter_has_one_fixed_file_bucket(filter: &TrackedStateFilter) -> bool {
+    let Some(first) = filter.file_ids.first() else {
+        return false;
+    };
+    !matches!(first, NullableKeyFilter::Any)
+        && filter.file_ids.iter().all(|file_id| file_id == first)
+}
+
+/// Restores the logical live-state identity order before any caller observes
+/// rows or applies LIMIT.
+///
+/// One physical HOT primary key is the sole authority for its logical
+/// identity. Repeated scans may therefore collapse only byte-identical copies
+/// of that same key. Distinct keys or values for one logical identity are an
+/// invalid authority state and fail closed instead of selecting a second
+/// winner.
+fn canonicalize_hot_scan_rows(
+    mut rows: Vec<(HotScanIdentity, Bytes)>,
+    limit: Option<usize>,
+) -> Result<Vec<(HotScanIdentity, Bytes)>, LixError> {
+    let already_strictly_ordered = rows
+        .windows(2)
+        .all(|pair| pair[0].0.cmp(&pair[1].0).is_lt());
+    if !already_strictly_ordered {
+        rows.sort_unstable_by(|left, right| left.0.cmp(&right.0));
+        for pair in rows.windows(2) {
+            if pair[0].0 != pair[1].0 {
+                continue;
+            }
+            if pair[0].0.key != pair[1].0.key || pair[0].1 != pair[1].1 {
+                return Err(head_value_error(format!(
+                    "duplicate HOT authority for schema '{}' entity_pk {:?} file_id {:?} has different physical bytes",
+                    pair[0].0.schema_key(),
+                    pair[0].0.entity_pk,
+                    pair[0].0.file_id(),
+                )));
+            }
+        }
+        rows.dedup_by(|left, right| left.0 == right.0);
+    }
+    if let Some(limit) = limit {
+        rows.truncate(limit);
+    }
+    Ok(rows)
 }
 
 fn hot_scan_entries_fit_budget<'a>(
@@ -9964,14 +10031,8 @@ async fn scan_hot_file_entries(
         }
     }
     // Physical rows are ordered `(schema, file_id, entity_pk)`, while SQL rows
-    // are ordered `(schema, entity_pk, file_id)`. Restore the public order
-    // after multi-file scans and defend against repeated predicates.
-    rows.sort_by(|left, right| left.0.cmp(&right.0));
-    rows.dedup_by(|left, right| left.0 == right.0);
-    if let Some(limit) = limit {
-        rows.truncate(limit);
-    }
-    Ok(rows)
+    // are ordered `(schema, entity_pk, file_id)`.
+    canonicalize_hot_scan_rows(rows, limit)
 }
 
 async fn hot_schema_has_file_members(
@@ -12910,6 +12971,77 @@ mod tests {
         assert_eq!(
             rows.row(0).file_id().expect("file").as_ptr(),
             rows.row(ROW_COUNT - 1).file_id().expect("file").as_ptr()
+        );
+    }
+
+    fn adversarial_hot_scan_entry(
+        generation: CommitId,
+        entity_pk: &str,
+        file_id: &str,
+        value: &'static [u8],
+    ) -> (HotScanIdentity, Bytes) {
+        let scope = hot_scope_prefix("branch", generation);
+        let key = Bytes::from(encode_hot_row_key_parts(
+            "branch",
+            generation,
+            "schema",
+            &EntityPk::single(entity_pk),
+            Some(file_id),
+        ));
+        let identity = decode_hot_scan_row_key_in_scope(key, &scope)
+            .expect("decode adversarial HOT scan identity");
+        (identity, Bytes::from_static(value))
+    }
+
+    #[test]
+    fn hot_scan_canonicalizes_before_limit_and_collapses_only_identical_duplicates() {
+        let generation = CommitId::for_test_label("adversarial-hot-canonical-order");
+        let physical_rows = || {
+            vec![
+                adversarial_hot_scan_entry(generation, "entity-z", "file-a", b"z"),
+                adversarial_hot_scan_entry(generation, "entity-z", "file-a", b"z"),
+                adversarial_hot_scan_entry(generation, "entity-a", "file-b", b"a"),
+            ]
+        };
+
+        let canonical = canonicalize_hot_scan_rows(physical_rows(), None)
+            .expect("identical repeated HOT observations should canonicalize");
+        assert_eq!(canonical.len(), 2);
+        assert_eq!(
+            canonical
+                .iter()
+                .map(|(identity, _)| (identity.entity_pk.clone(), identity.file_id()))
+                .collect::<Vec<_>>(),
+            [
+                (EntityPk::single("entity-a"), Some("file-b")),
+                (EntityPk::single("entity-z"), Some("file-a")),
+            ]
+        );
+
+        let limited = canonicalize_hot_scan_rows(physical_rows(), Some(1))
+            .expect("LIMIT should apply after HOT canonicalization");
+        assert_eq!(limited.len(), 1);
+        assert_eq!(limited[0].0.entity_pk, EntityPk::single("entity-a"));
+        assert_eq!(limited[0].0.file_id(), Some("file-b"));
+    }
+
+    #[test]
+    fn hot_scan_rejects_conflicting_duplicate_authority() {
+        let generation = CommitId::for_test_label("conflicting-hot-authority");
+        let error = canonicalize_hot_scan_rows(
+            vec![
+                adversarial_hot_scan_entry(generation, "entity", "file", b"older"),
+                adversarial_hot_scan_entry(generation, "entity", "file", b"newer"),
+            ],
+            None,
+        )
+        .expect_err("one HOT identity cannot have two authoritative byte values");
+
+        assert!(
+            error
+                .message
+                .contains("duplicate HOT authority for schema 'schema'"),
+            "unexpected duplicate-authority error: {error:?}"
         );
     }
 

--- a/packages/lix/src/live_state/tracked_head/hot.rs
+++ b/packages/lix/src/live_state/tracked_head/hot.rs
@@ -1032,7 +1032,6 @@ async fn scan_certified_entity_batch_rows(
         .await?
         .value;
     let content_count = contents.iter().flatten().count();
-    let decode_limit = (content_count <= 1).then_some(limit).flatten();
     let needs_snapshot = request.read_columns.columns.is_empty()
         || request
             .read_columns
@@ -1082,16 +1081,13 @@ async fn scan_certified_entity_batch_rows(
             request,
             &filter_index,
             needs_snapshot,
-            decode_limit,
+            None,
             &mut builder,
         )?;
-        if decode_limit.is_some_and(|limit| builder.len() >= limit) {
-            break;
-        }
     }
     let batch = builder.finish();
     if content_count <= 1 {
-        return Ok(batch);
+        return canonicalize_single_certified_batch(batch, limit);
     }
     let mut winners = BTreeMap::new();
     for row in batch.into_rows() {
@@ -3826,7 +3822,6 @@ async fn load_packed_current_base_exact_entries(
     Ok(winners)
 }
 
-#[cfg(test)]
 fn compare_materialized_live_identities(
     left: &MaterializedLiveStateRow,
     right: &MaterializedLiveStateRow,
@@ -3835,6 +3830,54 @@ fn compare_materialized_live_identities(
         .cmp(&right.schema_key)
         .then_with(|| left.entity_pk.cmp(&right.entity_pk))
         .then_with(|| left.file_id.cmp(&right.file_id))
+}
+
+/// Restores the identity-order contract at the producer boundary for one
+/// certified content object.
+///
+/// Certified packet order is plugin-defined and therefore cannot be used for
+/// SQL order or LIMIT. The common already-ordered batch remains borrowed and
+/// allocation-free. Only a noncanonical batch expands into owned rows for one
+/// sort. Repeated identities are valid only when every materialized payload
+/// byte and authority field is identical.
+fn canonicalize_single_certified_batch(
+    batch: MaterializedLiveStateBatch,
+    limit: Option<usize>,
+) -> Result<MaterializedLiveStateBatch, LixError> {
+    let already_strictly_ordered = (1..batch.len()).all(|index| {
+        compare_materialized_live_identity_refs(batch.row(index - 1), batch.row(index)).is_lt()
+    });
+    if already_strictly_ordered {
+        return Ok(if limit.is_some_and(|limit| batch.len() > limit) {
+            batch.filter(|_| true, limit)
+        } else {
+            batch
+        });
+    }
+
+    let mut rows = batch.into_rows();
+    rows.sort_unstable_by(compare_materialized_live_identities);
+    let mut canonical = Vec::with_capacity(rows.len());
+    for row in rows {
+        let Some(previous) = canonical.last() else {
+            canonical.push(row);
+            continue;
+        };
+        if compare_materialized_live_identities(previous, &row).is_ne() {
+            canonical.push(row);
+            continue;
+        }
+        if previous != &row {
+            return Err(head_value_error(format!(
+                "duplicate certified authority for schema '{}' entity_pk {:?} file_id {:?} has conflicting row bytes or authority evidence",
+                row.schema_key, row.entity_pk, row.file_id,
+            )));
+        }
+    }
+    if let Some(limit) = limit {
+        canonical.truncate(limit);
+    }
+    Ok(MaterializedLiveStateBatch::from_rows(canonical))
 }
 
 #[cfg(test)]
@@ -11380,6 +11423,49 @@ mod tests {
                 })
                 .collect::<Vec<_>>(),
             ["b", "d"]
+        );
+    }
+
+    #[test]
+    fn single_certified_batch_canonicalizes_before_limit_and_validates_duplicates() {
+        let mut root = live_row("root", "certified-order");
+        root.schema_key = "json_root".to_owned();
+        let mut member = live_row("member", "certified-order");
+        member.schema_key = "json_object_member".to_owned();
+
+        let canonical = canonicalize_single_certified_batch(
+            MaterializedLiveStateBatch::from_rows(vec![
+                root.clone(),
+                member.clone(),
+                member.clone(),
+            ]),
+            None,
+        )
+        .expect("identical duplicate certified rows should collapse");
+        assert_eq!(canonical.len(), 2);
+        assert_eq!(canonical.row(0).schema_key(), "json_object_member");
+        assert_eq!(canonical.row(1).schema_key(), "json_root");
+
+        let limited = canonicalize_single_certified_batch(
+            MaterializedLiveStateBatch::from_rows(vec![root.clone(), member.clone()]),
+            Some(1),
+        )
+        .expect("LIMIT should follow certified identity canonicalization");
+        assert_eq!(limited.len(), 1);
+        assert_eq!(limited.row(0).schema_key(), "json_object_member");
+
+        let mut conflicting = member.clone();
+        conflicting.metadata = Some(SharedStr::from("{\"conflict\":true}"));
+        let error = canonicalize_single_certified_batch(
+            MaterializedLiveStateBatch::from_rows(vec![member, conflicting]),
+            None,
+        )
+        .expect_err("conflicting duplicate certified authority must fail closed");
+        assert!(
+            error
+                .message
+                .contains("duplicate certified authority for schema 'json_object_member'"),
+            "unexpected duplicate-authority error: {error:?}"
         );
     }
 

--- a/packages/rs-sdk-tests/tests/crdt_benchmarks_baseline.rs
+++ b/packages/rs-sdk-tests/tests/crdt_benchmarks_baseline.rs
@@ -326,6 +326,7 @@ fn same_base_three_writer_cohort_converges_and_reuses_follower_session() {
                         .await
                         .unwrap();
                     let converged = read_file(&lix, path).await;
+                    assert_eq!(converged, br#"{"v":99}"#);
                     for peer in &peers {
                         assert_eq!(read_file(peer, path).await, converged);
                     }


### PR DESCRIPTION
## What changed

- replace per-row owned `BTreeMap` shadow maps for HOT/packed/certified current-state reconciliation with the existing commit-aware identity-ordered merge;
- replace the packed identity `BTreeSet` used to suppress subordinate rows with one forward cursor over canonical identity order;
- canonicalize every certified producer batch before `LIMIT`: retain an allocation-free strict-order fast path, otherwise sort by logical identity, collapse only byte/evidence-identical duplicates, and fail closed on conflicting authority;
- canonicalize file-backed HOT rows before `LIMIT` with the same strict duplicate rules;
- hard-delete the superseded tree-building/filtering path.

The producer correction fixes the exact hosted-CI failure in the same-base three-writer cohort: one certified packet arrived in plugin insertion order (`json_root` before `json_object_member`) even though the linear consumer correctly requires canonical `(schema, entity_pk, file_id)` order. The strict consumer assertion remains unchanged, and the regression now asserts the exact converged bytes `{"v":99}`.

No public API, persisted format, compatibility path, cache, index, or authority semantics change. Equal/newer HOT rows still win over packed rows by commit ID, certified rows remain subordinate, and public SQL identity order is preserved across physical file prefixes and single-content certified packets.

## Provenance

- Exact latest-main baseline: `8e3ffe632bc27e1ab84fe9a6102b099ab2e9f441`
- Previous PR head: `1cddb1512382f5d2515998cfa939b9078e3fdb27`
- Corrected candidate: `c83bb8b2ed6bf4c1c76c20e33ebe18a8777c37f7`
- Candidate tree: `597b98f80dad062b4c0b244f2e59fa489a9d4ce9`
- Base-to-head full-index diff SHA-256: `56872484b8f1052125019e4e8dd792a6ee55c0eaa5291e51728a6ceb4429c98a`
- Correction full-index diff SHA-256: `67516a039b874d728c0edceddc35cf62475e4457b0cc504b5a7bbd385dd55085`
- Evidence report SHA-256: `c6622e1b4578ce71762f78f843a966de26ee803202498cfd863fd001fdf06b59`
- Evidence manifest SHA-256: `dd05aeab1d048b52d062fc50c034c93e6535c648ffa83a95745e1f3c8c8d2c0b`

Latest main was merged exactly once in the integration lineage. The PR delta remains two reviewed files.

## Bottleneck and Big-O

The inputs are intended to be sorted, but the old path rebuilt owned identity trees and performed a tree lookup for each reconciled row: `O((N + K) log K)` time and `O(K)` auxiliary identity memory.

The cut performs ordered merge/exclusion in `O(N + K)`. Canonical producer batches take an allocation-free `O(H)` validation fast path; only noncanonical batches sort once in `O(H log H)`, validate/collapse duplicates in `O(H)`, and apply `LIMIT` afterward. Output-batch memory remains the dominant retained memory. The linked comparison/tree-search perfect-elimination ceiling measured about 19.6% on both adapters.

## Exact latest-main focused gate

50K canonical HOT-authority reconciliation, exact baseline → corrected head:

| Adapter | Wall | CPU | Allocation bytes | Allocation calls | RSS |
|---|---:|---:|---:|---:|---:|
| RocksDB | -14.30% | -2.27% | -12.72% | -11.79% | +0.12% |
| SlateDB | -13.42% | +1.70% | -12.01% | -10.11% | -0.45% |

Backend route/result counts, staged writes, and settled bytes on disk are identical/neutral. No confirmed critical regression exceeds 5%.

The earlier full 100K typed-OLAP matrix on exact base `95478b1fa329f7608b2360554ca72fad782dfeb8` improved all six shapes by 17.13–18.70% on RocksDB and 14.13–18.90% on SlateDB. It is supporting evidence only; the table above is the exact current-base qualification after the producer correction.

## Correctness

Passing on the exact corrected head:

- formatting and full diff checks;
- canonical workspace/all-targets/all-features Clippy with warnings denied (definitive warm confirmation exit 0);
- exact same-base three-writer cohort with final-byte assertion;
- single-certified-batch order-before-`LIMIT`, identical-duplicate collapse, and conflicting-duplicate fail-closed regressions;
- ordered authority exclusion and canonical HOT `LIMIT` controls;
- 100/100 replay commits, history/physical-group accounting, and reopen;
- typed current/diff/history lifecycle and corruption/reopen controls.

Hosted CI run `31195587654` is the required exact-head gate; there is no CI waiver.

## Tradeoffs

Noncanonical producer/file-backed batches now pay one in-place sort before `LIMIT`; already canonical batches retain the allocation-free linear path. This replaces the incorrect possibility of limiting or reconciling physical/plugin insertion order. There is no new durable data, disk amplification, backend write amplification, compatibility code, or alternate authority.
