### PR TITLE
fix(lix): authenticate deterministic sequence member closure

### DIFF
--- a/packages/lix/Cargo.toml
+++ b/packages/lix/Cargo.toml
@@ -45,6 +45,10 @@ name = "runtime_contract"
 path = "tests/runtime_contract.rs"
 
 [[test]]
+name = "deterministic_sequence_corruption"
+path = "tests/deterministic_sequence_corruption.rs"
+
+[[test]]
 name = "semantic_merge"
 path = "tests/semantic_merge.rs"
 

--- a/packages/lix/src/functions/context.rs
+++ b/packages/lix/src/functions/context.rs
@@ -125,12 +125,14 @@ fn deterministic_sequence_change_id(highest_seen: i64) -> ChangeId {
 #[cfg(test)]
 mod tests {
     use crate::GLOBAL_BRANCH_ID;
-    use crate::branch::{BranchHeadControlContext, stage_branch_head_control};
+    use crate::branch::{
+        BranchHeadControlContext, stage_branch_head_control, untracked_lifecycle_generation,
+    };
     use crate::entity_pk::EntityPk;
     use crate::functions::state::{DETERMINISTIC_MODE_KEY, DETERMINISTIC_SEQUENCE_KEY};
     use crate::functions::{DeterministicSequence, state::load_sequence};
     use crate::live_state::LiveStateContext;
-    use crate::live_state::{CurrentStateDeltaRef, TrackedHeadContext, WorkingDiffIndexCoverage};
+    use crate::live_state::{CurrentStateDeltaRef, TrackedHeadContext};
     use crate::storage_adapter::StorageAdapter;
     use crate::storage_adapter::{Memory, StorageReadOptions, StorageWriteOptions};
 
@@ -361,13 +363,20 @@ mod tests {
             .expect("global branch control should load")
             .expect("global branch control should exist");
         let snapshot = crate::json_store::JsonSlot::from_json(&snapshot_content);
-        let mut working_diff_coverage = WorkingDiffIndexCoverage::default();
+        let mut next_control = control
+            .next_current_state_revision()
+            .expect("global control revision should advance");
+        let next_generation = untracked_lifecycle_generation(
+            GLOBAL_BRANCH_ID,
+            control.untracked_generation,
+            next_control.current_state_revision,
+        );
         TrackedHeadContext::new()
             .writer(&read, &mut writes)
-            .stage_current_state_with_working_diff(
+            .stage_untracked_generation(
                 GLOBAL_BRANCH_ID,
-                Some(control.tracked_generation),
-                control.head_commit_id,
+                control.untracked_generation,
+                next_generation,
                 &[CurrentStateDeltaRef {
                     schema_key: "lix_key_value",
                     file_id: None,
@@ -383,21 +392,13 @@ mod tests {
                     columnar_base_coordinate: None,
                 }],
                 &std::collections::BTreeSet::new(),
-                None,
-                None,
-                None,
-                &mut working_diff_coverage,
             )
             .await
             .expect("test key-value current row should stage");
-        stage_branch_head_control(
-            &mut writes,
-            GLOBAL_BRANCH_ID,
-            control
-                .next_current_state_revision()
-                .expect("global control revision should advance"),
-        )
-        .expect("global control should publish current state");
+        next_control.untracked_generation = next_generation;
+        next_control.note_schema("lix_key_value");
+        stage_branch_head_control(&mut writes, GLOBAL_BRANCH_ID, next_control)
+            .expect("global control should publish current state");
         storage
             .commit_write_set(writes, StorageWriteOptions::default())
             .await

--- a/packages/lix/src/functions/state.rs
+++ b/packages/lix/src/functions/state.rs
@@ -184,6 +184,9 @@ async fn load_key_value_row(
                     schema_key: KEY_VALUE_SCHEMA_KEY,
                     file_id: None,
                 },
+                key_refs[0],
+                LiveStateReadDomain::Untracked,
+                control.current_state_revision == 0,
             )
             .await?;
         return Ok(None);
@@ -265,7 +268,10 @@ mod tests {
     use crate::NullableKeyFilter;
     use crate::live_state::{LiveStateContext, LiveStateRowRequest};
     use crate::storage_adapter::StorageAdapter;
-    use crate::storage_adapter::{Memory, StorageReadOptions, StorageWriteOptions};
+    use crate::storage_adapter::{
+        Memory, StorageKey, StorageProjectedValue, StorageReadOptions, StorageValue,
+        StorageWriteOptions,
+    };
 
     use super::*;
 
@@ -335,7 +341,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn missing_selected_sequence_member_fails_collection_closure() {
+    async fn same_count_sequence_substitution_fails_identity_closure() {
         let memory = Memory::new();
         let storage = StorageAdapter::new(memory.clone());
         crate::test_support::seed_global_branch_head(storage.clone()).await;
@@ -373,7 +379,7 @@ mod tests {
             .begin_read(StorageReadOptions::default())
             .await
             .expect("reopened sequence storage should read");
-        let rows = crate::storage_adapter::ScanPlan::prefix(
+        let mut rows = crate::storage_adapter::ScanPlan::prefix(
             crate::live_state::HOT_ROW_SPACE,
             crate::storage_adapter::StoragePrefix {
                 bytes: bytes::Bytes::new(),
@@ -389,15 +395,37 @@ mod tests {
             1,
             "fixture should publish only the sequence member"
         );
-        let sequence_member_key = rows[0].key.clone();
+        let sequence_member = rows.pop().expect("one sequence member");
+        let StorageProjectedValue::FullValue(sequence_value) = sequence_member.value else {
+            panic!("sequence fixture should scan the full HOT row value");
+        };
+        let sequence_identity = DETERMINISTIC_SEQUENCE_KEY.as_bytes();
+        let unrelated_identity = b"lix_unrelated_sequence_substitute";
+        assert_eq!(sequence_identity.len(), unrelated_identity.len());
+        let identity_offset = sequence_member
+            .key
+            .0
+            .windows(sequence_identity.len())
+            .position(|candidate| candidate == sequence_identity)
+            .expect("sequence identity should be encoded in its HOT key");
+        let mut unrelated_key = sequence_member.key.0.to_vec();
+        unrelated_key[identity_offset..identity_offset + sequence_identity.len()]
+            .copy_from_slice(unrelated_identity);
         drop(read);
 
         let mut corrupt = storage.new_write_set();
-        corrupt.delete(crate::live_state::HOT_ROW_SPACE, sequence_member_key);
+        corrupt.delete(crate::live_state::HOT_ROW_SPACE, sequence_member.key);
+        corrupt.put(
+            crate::live_state::HOT_ROW_SPACE,
+            StorageKey(bytes::Bytes::from(unrelated_key)),
+            StorageValue {
+                bytes: sequence_value,
+            },
+        );
         storage
             .commit_write_set(corrupt, StorageWriteOptions::default())
             .await
-            .expect("physical sequence member deletion should commit");
+            .expect("same-count sequence member substitution should commit");
 
         let read = storage
             .begin_read(StorageReadOptions::default())
@@ -409,7 +437,7 @@ mod tests {
         assert!(
             error
                 .message
-                .contains("declares 1 live members but materializes 0"),
+                .contains("identity digest does not match its canonical members"),
             "unexpected closure error: {error:?}"
         );
     }

--- a/packages/lix/src/functions/state.rs
+++ b/packages/lix/src/functions/state.rs
@@ -535,13 +535,20 @@ mod tests {
             .expect("global control should load")
             .expect("global control should exist");
         let snapshot = JsonSlot::from_json(&snapshot_content);
-        let mut working_diff_coverage = crate::live_state::WorkingDiffIndexCoverage::default();
+        let mut next_control = control
+            .next_current_state_revision()
+            .expect("global control revision should advance");
+        let next_generation = untracked_lifecycle_generation(
+            GLOBAL_BRANCH_ID,
+            control.untracked_generation,
+            next_control.current_state_revision,
+        );
         TrackedHeadContext::new()
             .writer(&read, &mut writes)
-            .stage_current_state_with_working_diff(
+            .stage_untracked_generation(
                 GLOBAL_BRANCH_ID,
-                Some(control.tracked_generation),
-                control.head_commit_id,
+                control.untracked_generation,
+                next_generation,
                 &[CurrentStateDeltaRef {
                     schema_key: KEY_VALUE_SCHEMA_KEY,
                     file_id: None,
@@ -557,13 +564,13 @@ mod tests {
                     columnar_base_coordinate: None,
                 }],
                 &std::collections::BTreeSet::new(),
-                None,
-                None,
-                None,
-                &mut working_diff_coverage,
             )
             .await
             .expect("test key-value current row should stage");
+        next_control.untracked_generation = next_generation;
+        next_control.note_schema(KEY_VALUE_SCHEMA_KEY);
+        stage_branch_head_control(&mut writes, GLOBAL_BRANCH_ID, next_control)
+            .expect("global control should publish current state");
         storage
             .commit_write_set(writes, StorageWriteOptions::default())
             .await

--- a/packages/lix/src/functions/state.rs
+++ b/packages/lix/src/functions/state.rs
@@ -175,10 +175,26 @@ async fn load_key_value_row(
             LiveStateReadDomain::Untracked,
         )
         .await?;
-    Ok(rows
-        .row(0)
-        .map(|row| row.to_owned())
-        .filter(|row| row.untracked && !row.deleted))
+    let Some(row) = rows.row(0) else {
+        reader
+            .validate_exact_collection_closure(
+                GLOBAL_BRANCH_ID,
+                control.untracked_generation,
+                crate::collection_generation::CollectionScopeRef {
+                    schema_key: KEY_VALUE_SCHEMA_KEY,
+                    file_id: None,
+                },
+            )
+            .await?;
+        return Ok(None);
+    };
+    if !row.untracked() || row.deleted() {
+        return Err(LixError::new(
+            LixError::CODE_INTERNAL_ERROR,
+            format!("deterministic key-value row '{key}' is not a live untracked authority member"),
+        ));
+    }
+    Ok(Some(row.to_owned()))
 }
 
 fn key_value_payload(row: &MaterializedLiveStateRow, key: &str) -> Result<JsonValue, LixError> {
@@ -305,6 +321,7 @@ mod tests {
     #[tokio::test]
     async fn missing_sequence_is_uninitialized() {
         let storage = StorageAdapter::new(Memory::new());
+        crate::test_support::seed_global_branch_head(storage.clone()).await;
         let read = storage
             .begin_read(StorageReadOptions::default())
             .await
@@ -315,6 +332,86 @@ mod tests {
             .expect("missing sequence should decode");
 
         assert_eq!(sequence, DeterministicSequence::uninitialized());
+    }
+
+    #[tokio::test]
+    async fn missing_selected_sequence_member_fails_collection_closure() {
+        let memory = Memory::new();
+        let storage = StorageAdapter::new(memory.clone());
+        crate::test_support::seed_global_branch_head(storage.clone()).await;
+
+        let read = storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("sequence publication read should open");
+        let mut writes = storage.new_write_set();
+        stage_sequence(
+            &read,
+            &mut writes,
+            DeterministicSequence { highest_seen: 7 },
+            test_timestamp(),
+            ChangeId::for_test_label("sequence-corruption-change"),
+        )
+        .await
+        .expect("sequence should stage");
+        drop(read);
+        storage
+            .commit_write_set(writes, StorageWriteOptions::default())
+            .await
+            .expect("sequence should publish");
+
+        let snapshot = memory
+            .export_snapshot()
+            .expect("published sequence storage should snapshot");
+        drop(storage);
+        drop(memory);
+        let storage = StorageAdapter::new(
+            Memory::from_snapshot(&snapshot).expect("published sequence storage should reopen"),
+        );
+
+        let read = storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("reopened sequence storage should read");
+        let rows = crate::storage_adapter::ScanPlan::prefix(
+            crate::live_state::HOT_ROW_SPACE,
+            crate::storage_adapter::StoragePrefix {
+                bytes: bytes::Bytes::new(),
+            },
+        )
+        .collect(&read, crate::storage_adapter::StorageScanOptions::default())
+        .await
+        .expect("selected HOT members should scan")
+        .value
+        .entries;
+        assert_eq!(
+            rows.len(),
+            1,
+            "fixture should publish only the sequence member"
+        );
+        let sequence_member_key = rows[0].key.clone();
+        drop(read);
+
+        let mut corrupt = storage.new_write_set();
+        corrupt.delete(crate::live_state::HOT_ROW_SPACE, sequence_member_key);
+        storage
+            .commit_write_set(corrupt, StorageWriteOptions::default())
+            .await
+            .expect("physical sequence member deletion should commit");
+
+        let read = storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("corrupt sequence storage should read");
+        let error = load_sequence(&read)
+            .await
+            .expect_err("missing selected sequence member must fail closed");
+        assert!(
+            error
+                .message
+                .contains("declares 1 live members but materializes 0"),
+            "unexpected closure error: {error:?}"
+        );
     }
 
     #[tokio::test]

--- a/packages/lix/src/live_state/tracked_head/hot.rs
+++ b/packages/lix/src/live_state/tracked_head/hot.rs
@@ -1833,6 +1833,89 @@ struct HotCollectionControl {
     ordered_identity_digest: Option<[u8; 32]>,
 }
 
+const COMPLETE_HOT_COLLECTION_DIGEST_DOMAIN: &[u8] = b"lix.complete-hot-collection-identities.v1";
+
+/// Streaming certificate for one complete selected HOT collection.
+///
+/// Untouched unfiled single-string collections retain the historical compact
+/// digest used by packed replacement proofs. Every other collection hashes
+/// the complete canonical HOT key, including the file discriminator and the
+/// typed/composite entity-primary-key encoding. Callers feed keys in physical
+/// storage order; strict ordering makes duplicate identities fail closed.
+struct CompleteHotCollectionDigest {
+    canonical: blake3::Hasher,
+    single_string: blake3::Hasher,
+    single_string_compatible: bool,
+    previous_key: Vec<u8>,
+}
+
+impl CompleteHotCollectionDigest {
+    fn new(
+        branch_id: &str,
+        branch_generation: CommitId,
+        scope: crate::collection_generation::CollectionScopeRef<'_>,
+    ) -> Self {
+        let mut canonical = blake3::Hasher::new();
+        canonical.update(COMPLETE_HOT_COLLECTION_DIGEST_DOMAIN);
+        let scope_key = hot_collection_control_key(branch_id, branch_generation, scope);
+        canonical.update(&(scope_key.len() as u64).to_le_bytes());
+        canonical.update(&scope_key);
+        Self {
+            canonical,
+            single_string: blake3::Hasher::new(),
+            single_string_compatible: scope.file_id.is_none(),
+            previous_key: Vec::new(),
+        }
+    }
+
+    fn push(&mut self, identity: &HeadRowIdentity, canonical_key: &[u8]) -> Result<(), LixError> {
+        if !self.previous_key.is_empty() {
+            match self.previous_key.as_slice().cmp(canonical_key) {
+                Ordering::Less => {}
+                Ordering::Equal => {
+                    return Err(head_value_error(
+                        "complete collection contains a duplicate canonical identity",
+                    ));
+                }
+                Ordering::Greater => {
+                    return Err(head_value_error(
+                        "complete collection identities are not in canonical order",
+                    ));
+                }
+            }
+        }
+        self.previous_key.clear();
+        self.previous_key.extend_from_slice(canonical_key);
+
+        self.canonical
+            .update(&(canonical_key.len() as u64).to_le_bytes());
+        self.canonical.update(canonical_key);
+
+        if self.single_string_compatible {
+            match (
+                identity.file_id.as_deref(),
+                identity.entity_pk.as_single_string(),
+            ) {
+                (None, Ok(value)) => {
+                    self.single_string
+                        .update(&(value.len() as u64).to_le_bytes());
+                    self.single_string.update(value.as_bytes());
+                }
+                _ => self.single_string_compatible = false,
+            }
+        }
+        Ok(())
+    }
+
+    fn finish(self) -> [u8; 32] {
+        if self.single_string_compatible {
+            *self.single_string.finalize().as_bytes()
+        } else {
+            *self.canonical.finalize().as_bytes()
+        }
+    }
+}
+
 // Root-backed branches defer collection cardinality until an operation
 // actually asks for it. Ordinary sparse edits must not scan the immutable
 // root merely to maintain an eager count.
@@ -2517,6 +2600,7 @@ fn stage_complete_collection_controls(
     };
 
     let mut controls = BTreeMap::<(String, Option<String>), HotCollectionControl>::new();
+    let mut physical_buckets = BTreeMap::<(String, Option<String>), Vec<&HeadRowIdentity>>::new();
     for (identity, bytes) in rows {
         if identity.schema_key == COLLECTION_GENERATION_SCHEMA_KEY {
             let target = collection_scope_from_entity_pk(&identity.entity_pk)?;
@@ -2584,6 +2668,10 @@ fn stage_complete_collection_controls(
         if !visible_after_schema_generation || !visible_after_file_generation {
             continue;
         }
+        physical_buckets
+            .entry((identity.schema_key.clone(), identity.file_id.clone()))
+            .or_default()
+            .push(identity);
         for scope in [Some(schema_scope), file_scope].into_iter().flatten() {
             let control = controls
                 .get_mut(&scope)
@@ -2595,7 +2683,51 @@ fn stage_complete_collection_controls(
         }
     }
 
-    for ((schema_key, file_id), control) in controls {
+    let mut digests = controls
+        .keys()
+        .map(|(schema_key, file_id)| {
+            (
+                (schema_key.clone(), file_id.clone()),
+                CompleteHotCollectionDigest::new(
+                    branch_id,
+                    branch_generation,
+                    CollectionScopeRef {
+                        schema_key,
+                        file_id: file_id.as_deref(),
+                    },
+                ),
+            )
+        })
+        .collect::<BTreeMap<_, _>>();
+    for ((schema_key, file_id), identities) in physical_buckets {
+        for identity in identities {
+            let canonical_key = encode_hot_row_key_parts(
+                branch_id,
+                branch_generation,
+                &identity.schema_key,
+                &identity.entity_pk,
+                identity.file_id.as_deref(),
+            );
+            digests
+                .get_mut(&(schema_key.clone(), None))
+                .expect("complete row schema digest was initialized above")
+                .push(identity, &canonical_key)?;
+            if file_id.is_some() {
+                digests
+                    .get_mut(&(schema_key.clone(), file_id.clone()))
+                    .expect("complete row file digest was initialized above")
+                    .push(identity, &canonical_key)?;
+            }
+        }
+    }
+
+    for ((schema_key, file_id), mut control) in controls {
+        control.ordered_identity_digest = Some(
+            digests
+                .remove(&(schema_key.clone(), file_id.clone()))
+                .expect("complete collection digest was initialized above")
+                .finish(),
+        );
         stage_hot_collection_control(
             writes,
             branch_id,
@@ -4103,23 +4235,114 @@ where
         branch_id: &str,
         branch_generation: CommitId,
         scope: crate::collection_generation::CollectionScopeRef<'_>,
+        required_identity: TrackedStateKeyRef<'_>,
+        expected_domain: LiveStateReadDomain,
+        allow_bootstrap_absence: bool,
     ) -> Result<(), LixError> {
-        let control = self
-            .collection_control(branch_id, branch_generation, scope)
-            .await?;
-        if control.live_count == DEFERRED_ROOT_LIVE_COUNT {
+        let expected_untracked = match expected_domain {
+            LiveStateReadDomain::Tracked => false,
+            LiveStateReadDomain::Untracked => true,
+            LiveStateReadDomain::Combined => {
+                return Err(head_value_error(
+                    "exact collection closure requires one explicit state domain",
+                ));
+            }
+        };
+        let control =
+            load_stored_hot_collection_control(&self.store, branch_id, branch_generation, scope)
+                .await?;
+        if let Some(control) = control {
+            if control.active_generation != branch_generation {
+                return Err(head_value_error(format!(
+                    "selected collection '{}' control names stale generation {} instead of {branch_generation}",
+                    scope.schema_key, control.active_generation
+                )));
+            }
+            if control.live_count == DEFERRED_ROOT_LIVE_COUNT {
+                return Err(head_value_error(format!(
+                    "selected collection '{}' has no exact member count",
+                    scope.schema_key
+                )));
+            }
+            if control.ordered_identity_digest.is_none() {
+                return Err(head_value_error(format!(
+                    "selected collection '{}' has no exact identity digest",
+                    scope.schema_key
+                )));
+            }
+        }
+
+        let scope_prefix = hot_scope_prefix(branch_id, branch_generation);
+        let mut selected_prefix = scope_prefix.clone();
+        write_key_string(&mut selected_prefix, scope.schema_key, KEY_PART_FINAL);
+        if let Some(file_id) = scope.file_id {
+            write_file_id(&mut selected_prefix, Some(file_id));
+        }
+        let plan = ScanPlan::prefix(
+            HOT_ROW_SPACE,
+            StoragePrefix {
+                bytes: Bytes::from(selected_prefix),
+            },
+        );
+        let mut digest = CompleteHotCollectionDigest::new(branch_id, branch_generation, scope);
+        let mut actual = 0_u64;
+        let mut resume_after = None;
+        loop {
+            let page = plan
+                .collect(
+                    &self.store,
+                    StorageScanOptions {
+                        resume_after: resume_after.clone(),
+                        ..StorageScanOptions::default()
+                    },
+                )
+                .await?;
+            resume_after = page.value.entries.last().map(|entry| entry.key.clone());
+            for entry in page.value.entries {
+                let raw_key = entry.key.0;
+                let raw_value = full_value_bytes(entry.value)?;
+                let identity = validate_exact_collection_member(
+                    branch_id,
+                    branch_generation,
+                    &scope_prefix,
+                    scope,
+                    required_identity,
+                    expected_untracked,
+                    raw_key.as_ref(),
+                    raw_value.as_ref(),
+                )?;
+                if let Some(identity) = identity {
+                    digest.push(&identity, raw_key.as_ref())?;
+                    actual = actual
+                        .checked_add(1)
+                        .ok_or_else(|| head_value_error("hot collection live count exceeds u64"))?;
+                }
+            }
+            if !page.value.has_more || resume_after.is_none() {
+                break;
+            }
+        }
+        let actual_digest = digest.finish();
+
+        let Some(control) = control else {
+            if allow_bootstrap_absence && actual == 0 {
+                return Ok(());
+            }
             return Err(head_value_error(format!(
-                "selected collection '{}' has no exact member count",
+                "selected collection '{}' is missing its exact control",
                 scope.schema_key
             )));
-        }
-        let actual = self
-            .exact_collection_live_count(branch_id, branch_generation, scope)
-            .await?;
+        };
         if actual != control.live_count {
             return Err(head_value_error(format!(
                 "selected collection '{}' declares {} live members but materializes {actual}",
                 scope.schema_key, control.live_count
+            )));
+        }
+        if control.ordered_identity_digest != Some(actual_digest) {
+            return Err(head_value_error(format!(
+                "selected collection '{}' identity digest does not match its canonical members",
+                scope.schema_key
             )));
         }
         Ok(())
@@ -10133,7 +10356,6 @@ pub(super) fn encode_hot_row_key(identity: &HeadIdentity) -> Vec<u8> {
     )
 }
 
-#[cfg(test)]
 fn encode_hot_row_key_parts(
     branch_id: &str,
     generation: CommitId,
@@ -10146,6 +10368,71 @@ fn encode_hot_row_key_parts(
     write_file_id(&mut key, file_id);
     write_entity_pk(&mut key, entity_pk);
     key
+}
+
+fn validate_exact_collection_member(
+    branch_id: &str,
+    branch_generation: CommitId,
+    scope_prefix: &[u8],
+    scope: crate::collection_generation::CollectionScopeRef<'_>,
+    required_identity: TrackedStateKeyRef<'_>,
+    expected_untracked: bool,
+    raw_key: &[u8],
+    raw_value: &[u8],
+) -> Result<Option<HeadRowIdentity>, LixError> {
+    let identity = decode_hot_row_key_in_scope(raw_key, scope_prefix)?;
+    if identity.schema_key != scope.schema_key
+        || scope
+            .file_id
+            .is_some_and(|file_id| identity.file_id.as_deref() != Some(file_id))
+    {
+        return Err(head_value_error(
+            "selected collection scan escaped its exact scope",
+        ));
+    }
+    let canonical = encode_hot_row_key_parts(
+        branch_id,
+        branch_generation,
+        &identity.schema_key,
+        &identity.entity_pk,
+        identity.file_id.as_deref(),
+    );
+    validate_canonical_exact_collection_key(raw_key, &canonical)?;
+    let value = decode_head_value(raw_value)?;
+    let is_required_identity = identity.schema_key == required_identity.schema_key
+        && identity.entity_pk == *required_identity.entity_pk
+        && identity.file_id.as_deref() == required_identity.file_id;
+    if value.deleted {
+        if !is_required_identity {
+            return Ok(None);
+        }
+        return Err(head_value_error(
+            "required collection identity is a tombstone instead of a live member",
+        ));
+    }
+    if is_required_identity && value.untracked != expected_untracked {
+        return Err(head_value_error(
+            "required collection identity belongs to the wrong state domain",
+        ));
+    }
+    if is_required_identity {
+        return Err(head_value_error(
+            "required point miss omitted a live collection authority member",
+        ));
+    }
+    Ok(Some(identity))
+}
+
+fn validate_canonical_exact_collection_key(
+    raw_key: &[u8],
+    canonical_key: &[u8],
+) -> Result<(), LixError> {
+    if canonical_key != raw_key {
+        return Err(head_value_error(
+            "selected collection contains a non-canonical identity key",
+        ));
+    }
+    Ok(())
 }
 
 #[cfg(test)]
@@ -11356,6 +11643,400 @@ mod tests {
 
     fn timestamp() -> LixTimestamp {
         LixTimestamp::expect_parse("hot working-diff test timestamp", "2026-01-01T00:00:00Z")
+    }
+
+    fn encoded_test_hot_value(generation: CommitId, untracked: bool, deleted: bool) -> Bytes {
+        Bytes::from(
+            encode_head_value(&HeadValueRef {
+                change_id: (!untracked).then(|| ChangeId::for_test_label("closure-change")),
+                commit_id: (!untracked).then_some(generation),
+                untracked,
+                deleted,
+                created_at: timestamp(),
+                updated_at: timestamp(),
+                snapshot: JsonSlotRef::None,
+                metadata: JsonSlotRef::None,
+                columnar_base_coordinate: None,
+                working_diff_baseline: WorkingDiffBaseline::Disabled,
+            })
+            .expect("closure fixture HOT value should encode"),
+        )
+    }
+
+    #[test]
+    fn exact_collection_member_rejects_noncanonical_domain_tombstone_and_order() {
+        const BRANCH_ID: &str = "closure-member-branch";
+        const SCHEMA_KEY: &str = "closure_member_schema";
+        let generation = CommitId::for_test_label("closure-member-generation");
+        let scope = crate::collection_generation::CollectionScopeRef {
+            schema_key: SCHEMA_KEY,
+            file_id: None,
+        };
+        let scope_prefix = hot_scope_prefix(BRANCH_ID, generation);
+        let identity = HeadRowIdentity {
+            schema_key: SCHEMA_KEY.to_owned(),
+            entity_pk: EntityPk::single("member-a"),
+            file_id: None,
+        };
+        let missing_entity_pk = EntityPk::single("missing-member");
+        let missing_identity = TrackedStateKeyRef {
+            schema_key: SCHEMA_KEY,
+            entity_pk: &missing_entity_pk,
+            file_id: None,
+        };
+        let required_identity = TrackedStateKeyRef {
+            schema_key: SCHEMA_KEY,
+            entity_pk: &identity.entity_pk,
+            file_id: None,
+        };
+        let key =
+            encode_hot_row_key_parts(BRANCH_ID, generation, SCHEMA_KEY, &identity.entity_pk, None);
+        let untracked = encoded_test_hot_value(generation, true, false);
+        validate_exact_collection_member(
+            BRANCH_ID,
+            generation,
+            &scope_prefix,
+            scope,
+            missing_identity,
+            true,
+            &key,
+            &untracked,
+        )
+        .expect("live untracked member should validate");
+
+        let tracked = encoded_test_hot_value(generation, false, false);
+        let wrong_domain = validate_exact_collection_member(
+            BRANCH_ID,
+            generation,
+            &scope_prefix,
+            scope,
+            required_identity,
+            true,
+            &key,
+            &tracked,
+        )
+        .expect_err("tracked member must not satisfy an untracked closure");
+        assert!(wrong_domain.message.contains("wrong state domain"));
+
+        let tombstone = encoded_test_hot_value(generation, false, true);
+        let tombstone_error = validate_exact_collection_member(
+            BRANCH_ID,
+            generation,
+            &scope_prefix,
+            scope,
+            required_identity,
+            false,
+            &key,
+            &tombstone,
+        )
+        .expect_err("tombstone must not satisfy a live closure");
+        assert!(tombstone_error.message.contains("tombstone"));
+
+        let mut malformed = key.clone();
+        malformed.pop();
+        assert!(
+            validate_exact_collection_member(
+                BRANCH_ID,
+                generation,
+                &scope_prefix,
+                scope,
+                missing_identity,
+                true,
+                &malformed,
+                &untracked,
+            )
+            .is_err()
+        );
+        let mut noncanonical = key.clone();
+        noncanonical.push(0);
+        let noncanonical_error = validate_canonical_exact_collection_key(&noncanonical, &key)
+            .expect_err("raw and canonical encodings must match byte-for-byte");
+        assert!(noncanonical_error.message.contains("non-canonical"));
+
+        let mut digest = CompleteHotCollectionDigest::new(BRANCH_ID, generation, scope);
+        digest
+            .push(&identity, &key)
+            .expect("first canonical identity should hash");
+        let duplicate = digest
+            .push(&identity, &key)
+            .expect_err("duplicate canonical identity must fail");
+        assert!(duplicate.message.contains("duplicate canonical identity"));
+
+        let high_identity = HeadRowIdentity {
+            schema_key: SCHEMA_KEY.to_owned(),
+            entity_pk: EntityPk::single("member-z"),
+            file_id: None,
+        };
+        let high_key = encode_hot_row_key_parts(
+            BRANCH_ID,
+            generation,
+            SCHEMA_KEY,
+            &high_identity.entity_pk,
+            None,
+        );
+        let mut out_of_order = CompleteHotCollectionDigest::new(BRANCH_ID, generation, scope);
+        out_of_order
+            .push(&high_identity, &high_key)
+            .expect("first high identity should hash");
+        let ordering = out_of_order
+            .push(&identity, &key)
+            .expect_err("descending identity must fail");
+        assert!(ordering.message.contains("not in canonical order"));
+    }
+
+    #[tokio::test]
+    async fn complete_collection_digest_closes_typed_file_members_and_authenticated_empty() {
+        const BRANCH_ID: &str = "closure-file-branch";
+        const SCHEMA_KEY: &str = "closure_file_schema";
+        let generation = CommitId::for_test_label("closure-file-generation");
+        let mut rows = HotRowMap::new();
+        let typed_pk = EntityPk::from_components(smallvec::smallvec![
+            crate::entity_pk::EntityPkComponent::Integer(-7),
+            crate::entity_pk::EntityPkComponent::Bytes(Bytes::from_static(b"typed")),
+        ])
+        .expect("typed composite primary key");
+        for (entity_pk, file_id) in [
+            (EntityPk::single("unfiled"), None),
+            (typed_pk, Some("a.lix".to_owned())),
+            (EntityPk::single("file-string"), Some("b.lix".to_owned())),
+        ] {
+            rows.insert(
+                HeadRowIdentity {
+                    schema_key: SCHEMA_KEY.to_owned(),
+                    entity_pk,
+                    file_id,
+                },
+                encoded_test_hot_value(generation, false, false),
+            );
+        }
+        let storage = StorageAdapter::new(Memory::new());
+        let mut writes = StorageWriteSet::new();
+        stage_complete_collection_controls(&mut writes, BRANCH_ID, generation, &rows)
+            .expect("complete controls should stage");
+        stage_complete_hot_rows(&mut writes, BRANCH_ID, generation, rows);
+        storage
+            .commit_write_set(writes, StorageWriteOptions::default())
+            .await
+            .expect("typed file fixture should publish");
+        let read = storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("typed file fixture should read");
+        let reader = HotStateStoreReader {
+            store: &read,
+            transaction_cache: None,
+        };
+        let missing_entity_pk = EntityPk::single("missing-member");
+        let missing_identity = TrackedStateKeyRef {
+            schema_key: SCHEMA_KEY,
+            entity_pk: &missing_entity_pk,
+            file_id: None,
+        };
+        reader
+            .validate_exact_collection_closure(
+                BRANCH_ID,
+                generation,
+                crate::collection_generation::CollectionScopeRef {
+                    schema_key: SCHEMA_KEY,
+                    file_id: None,
+                },
+                missing_identity,
+                LiveStateReadDomain::Tracked,
+                false,
+            )
+            .await
+            .expect("schema scope should close in canonical file/member order");
+        reader
+            .validate_exact_collection_closure(
+                BRANCH_ID,
+                generation,
+                crate::collection_generation::CollectionScopeRef {
+                    schema_key: SCHEMA_KEY,
+                    file_id: Some("a.lix"),
+                },
+                TrackedStateKeyRef {
+                    schema_key: SCHEMA_KEY,
+                    entity_pk: &missing_entity_pk,
+                    file_id: Some("a.lix"),
+                },
+                LiveStateReadDomain::Tracked,
+                false,
+            )
+            .await
+            .expect("typed file scope should close with complete PK encoding");
+
+        const EMPTY_SCHEMA_KEY: &str = "authenticated_empty_schema";
+        let empty_scope = crate::collection_generation::CollectionScopeRef {
+            schema_key: EMPTY_SCHEMA_KEY,
+            file_id: None,
+        };
+        let marker_identity = HeadRowIdentity {
+            schema_key: crate::collection_generation::COLLECTION_GENERATION_SCHEMA_KEY.to_owned(),
+            entity_pk: EntityPk::single(crate::collection_generation::collection_scope_key(
+                empty_scope,
+            )),
+            file_id: None,
+        };
+        let marker_rows = HotRowMap::from([(
+            marker_identity,
+            encoded_test_hot_value(generation, false, false),
+        )]);
+        let mut writes = StorageWriteSet::new();
+        stage_complete_collection_controls(&mut writes, BRANCH_ID, generation, &marker_rows)
+            .expect("authenticated empty control should stage");
+        stage_complete_hot_rows(&mut writes, BRANCH_ID, generation, marker_rows);
+        storage
+            .commit_write_set(writes, StorageWriteOptions::default())
+            .await
+            .expect("authenticated empty fixture should publish");
+        let read = storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("authenticated empty fixture should read");
+        HotStateStoreReader {
+            store: &read,
+            transaction_cache: None,
+        }
+        .validate_exact_collection_closure(
+            BRANCH_ID,
+            generation,
+            empty_scope,
+            TrackedStateKeyRef {
+                schema_key: EMPTY_SCHEMA_KEY,
+                entity_pk: &missing_entity_pk,
+                file_id: None,
+            },
+            LiveStateReadDomain::Tracked,
+            false,
+        )
+        .await
+        .expect("explicit empty control should authenticate an empty scope");
+    }
+
+    #[tokio::test]
+    async fn exact_collection_closure_rejects_missing_malformed_stale_and_forged_controls() {
+        const BRANCH_ID: &str = "closure-control-branch";
+        const SCHEMA_KEY: &str = "closure_control_schema";
+        let generation = CommitId::for_test_label("closure-control-generation");
+        let scope = crate::collection_generation::CollectionScopeRef {
+            schema_key: SCHEMA_KEY,
+            file_id: None,
+        };
+        let rows = HotRowMap::from([(
+            HeadRowIdentity {
+                schema_key: SCHEMA_KEY.to_owned(),
+                entity_pk: EntityPk::single("member"),
+                file_id: None,
+            },
+            encoded_test_hot_value(generation, false, false),
+        )]);
+        let memory = Memory::new();
+        let storage = StorageAdapter::new(memory.clone());
+        let mut writes = StorageWriteSet::new();
+        stage_complete_collection_controls(&mut writes, BRANCH_ID, generation, &rows)
+            .expect("base control should stage");
+        stage_complete_hot_rows(&mut writes, BRANCH_ID, generation, rows);
+        storage
+            .commit_write_set(writes, StorageWriteOptions::default())
+            .await
+            .expect("base closure fixture should publish");
+        let snapshot = memory.export_snapshot().expect("base fixture snapshot");
+        drop(storage);
+        drop(memory);
+        let missing_entity_pk = EntityPk::single("missing-member");
+
+        for (label, expected) in [
+            ("missing", "missing its exact control"),
+            ("malformed", "hot collection control"),
+            ("stale", "stale generation"),
+            ("no-digest", "no exact identity digest"),
+            ("forged", "identity digest"),
+        ] {
+            let storage = StorageAdapter::new(
+                Memory::from_snapshot(&snapshot).expect("reopen base closure fixture"),
+            );
+            let control_key = StorageKey(Bytes::from(hot_collection_control_key(
+                BRANCH_ID, generation, scope,
+            )));
+            let mut writes = StorageWriteSet::new();
+            match label {
+                "missing" => writes.delete(HOT_COLLECTION_CONTROL_SPACE, control_key),
+                "malformed" => writes.put(
+                    HOT_COLLECTION_CONTROL_SPACE,
+                    control_key,
+                    StorageValue {
+                        bytes: Bytes::from_static(b"malformed-control"),
+                    },
+                ),
+                "stale" => stage_hot_collection_control(
+                    &mut writes,
+                    BRANCH_ID,
+                    generation,
+                    scope,
+                    HotCollectionControl {
+                        active_generation: CommitId::for_test_label("stale-generation"),
+                        live_count: 1,
+                        ordered_identity_digest: Some([0; 32]),
+                    },
+                )
+                .expect("stale control should encode"),
+                "no-digest" => stage_hot_collection_control(
+                    &mut writes,
+                    BRANCH_ID,
+                    generation,
+                    scope,
+                    HotCollectionControl {
+                        active_generation: generation,
+                        live_count: 1,
+                        ordered_identity_digest: None,
+                    },
+                )
+                .expect("digest-free control should encode"),
+                "forged" => stage_hot_collection_control(
+                    &mut writes,
+                    BRANCH_ID,
+                    generation,
+                    scope,
+                    HotCollectionControl {
+                        active_generation: generation,
+                        live_count: 1,
+                        ordered_identity_digest: Some([0; 32]),
+                    },
+                )
+                .expect("forged control should encode"),
+                _ => unreachable!("closed corruption fixture set"),
+            }
+            storage
+                .commit_write_set(writes, StorageWriteOptions::default())
+                .await
+                .expect("control corruption should publish below the reader");
+            let read = storage
+                .begin_read(StorageReadOptions::default())
+                .await
+                .expect("corrupt control fixture should read");
+            let error = HotStateStoreReader {
+                store: &read,
+                transaction_cache: None,
+            }
+            .validate_exact_collection_closure(
+                BRANCH_ID,
+                generation,
+                scope,
+                TrackedStateKeyRef {
+                    schema_key: SCHEMA_KEY,
+                    entity_pk: &missing_entity_pk,
+                    file_id: None,
+                },
+                LiveStateReadDomain::Tracked,
+                false,
+            )
+            .await
+            .expect_err("corrupt exact control must fail closed");
+            assert!(
+                error.message.contains(expected),
+                "unexpected {label} control error: {error:?}"
+            );
+        }
     }
 
     fn live_row(entity_pk: &str, commit_label: &str) -> MaterializedLiveStateRow {

--- a/packages/lix/src/live_state/tracked_head/hot.rs
+++ b/packages/lix/src/live_state/tracked_head/hot.rs
@@ -87,6 +87,7 @@ const HOT_DIFF_SEGMENT_MAX_IDENTITIES: u32 = 4_096;
 // storage amplification, so retain their allocation-free direct-key path.
 const HOT_DIFF_PACK_MIN_IDENTITIES: usize = 64;
 const FILE_DESCRIPTOR_SCHEMA_KEY: &str = "lix_file_descriptor";
+const KEY_VALUE_SCHEMA_KEY: &str = "lix_key_value";
 const CERTIFIED_ENTITY_BATCH_MAGIC_V2: &[u8; 4] = b"CEB2";
 pub(crate) const CERTIFIED_ENTITY_BATCH_SPACE: StorageSpace = StorageSpace::mutable(
     StorageSpaceId(0x0004_001f),
@@ -6693,7 +6694,33 @@ where
                 &mut retired_untracked_json_refs,
             )?;
         }
+        let has_key_value_scope = rows
+            .keys()
+            .any(|identity| identity.schema_key == KEY_VALUE_SCHEMA_KEY);
         stage_complete_collection_controls(self.writes, branch_id, new_generation, &rows)?;
+        // Deterministic runtime state performs required point reads in this
+        // engine-owned collection. A complete untracked generation must
+        // therefore authenticate its empty set as well as its present rows;
+        // absence without a control is reserved for revision-zero bootstrap.
+        if !has_key_value_scope {
+            let scope = crate::collection_generation::CollectionScopeRef {
+                schema_key: KEY_VALUE_SCHEMA_KEY,
+                file_id: None,
+            };
+            stage_hot_collection_control(
+                self.writes,
+                branch_id,
+                new_generation,
+                scope,
+                HotCollectionControl {
+                    active_generation: new_generation,
+                    live_count: 0,
+                    ordered_identity_digest: Some(
+                        CompleteHotCollectionDigest::new(branch_id, new_generation, scope).finish(),
+                    ),
+                },
+            )?;
+        }
         stage_complete_hot_rows(self.writes, branch_id, new_generation, rows);
         JsonStoreWriter::stage_untracked_reclaim_candidates(
             self.writes,
@@ -11951,6 +11978,94 @@ mod tests {
         )
         .await
         .expect("explicit empty control should authenticate an empty scope");
+    }
+
+    #[tokio::test]
+    async fn exact_collection_closure_distinguishes_bootstrap_from_published_missing_digest() {
+        const BRANCH_ID: &str = "closure-bootstrap-branch";
+        const SCHEMA_KEY: &str = "closure_bootstrap_schema";
+        let generation = CommitId::for_test_label("closure-bootstrap-generation");
+        let scope = crate::collection_generation::CollectionScopeRef {
+            schema_key: SCHEMA_KEY,
+            file_id: None,
+        };
+        let missing_entity_pk = EntityPk::single("missing-member");
+        let required_identity = TrackedStateKeyRef {
+            schema_key: SCHEMA_KEY,
+            entity_pk: &missing_entity_pk,
+            file_id: None,
+        };
+        let storage = StorageAdapter::new(Memory::new());
+
+        let read = storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("bootstrap read should open");
+        let reader = HotStateStoreReader {
+            store: &read,
+            transaction_cache: None,
+        };
+        reader
+            .validate_exact_collection_closure(
+                BRANCH_ID,
+                generation,
+                scope,
+                required_identity,
+                LiveStateReadDomain::Untracked,
+                true,
+            )
+            .await
+            .expect("an explicitly allowed empty bootstrap may omit its control");
+        let error = reader
+            .validate_exact_collection_closure(
+                BRANCH_ID,
+                generation,
+                scope,
+                required_identity,
+                LiveStateReadDomain::Untracked,
+                false,
+            )
+            .await
+            .expect_err("a published empty scope must carry its exact control");
+        assert!(error.message.contains("missing its exact control"));
+        drop(read);
+
+        let mut writes = StorageWriteSet::new();
+        stage_hot_collection_control(
+            &mut writes,
+            BRANCH_ID,
+            generation,
+            scope,
+            HotCollectionControl {
+                active_generation: generation,
+                live_count: 0,
+                ordered_identity_digest: None,
+            },
+        )
+        .expect("digestless published control should encode as a corruption fixture");
+        storage
+            .commit_write_set(writes, StorageWriteOptions::default())
+            .await
+            .expect("digestless corruption fixture should publish");
+        let read = storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("published corruption read should open");
+        let error = HotStateStoreReader {
+            store: &read,
+            transaction_cache: None,
+        }
+        .validate_exact_collection_closure(
+            BRANCH_ID,
+            generation,
+            scope,
+            required_identity,
+            LiveStateReadDomain::Untracked,
+            true,
+        )
+        .await
+        .expect_err("bootstrap allowance must not accept a published digestless control");
+        assert!(error.message.contains("no exact identity digest"));
     }
 
     #[tokio::test]

--- a/packages/lix/src/live_state/tracked_head/hot.rs
+++ b/packages/lix/src/live_state/tracked_head/hot.rs
@@ -4091,6 +4091,40 @@ where
             .map_err(|_| head_value_error("hot collection live count exceeds u64"))
     }
 
+    /// Validates that a selected generation's complete physical member set
+    /// still closes to its generation-local collection inventory.
+    ///
+    /// Exact point reads ordinarily treat a missing key as logical absence.
+    /// Required engine authority can call this after a point miss to
+    /// distinguish legitimate absence from a missing selected HOT member
+    /// without introducing another locator or persisted owner.
+    pub(crate) async fn validate_exact_collection_closure(
+        &self,
+        branch_id: &str,
+        branch_generation: CommitId,
+        scope: crate::collection_generation::CollectionScopeRef<'_>,
+    ) -> Result<(), LixError> {
+        let control = self
+            .collection_control(branch_id, branch_generation, scope)
+            .await?;
+        if control.live_count == DEFERRED_ROOT_LIVE_COUNT {
+            return Err(head_value_error(format!(
+                "selected collection '{}' has no exact member count",
+                scope.schema_key
+            )));
+        }
+        let actual = self
+            .exact_collection_live_count(branch_id, branch_generation, scope)
+            .await?;
+        if actual != control.live_count {
+            return Err(head_value_error(format!(
+                "selected collection '{}' declares {} live members but materializes {actual}",
+                scope.schema_key, control.live_count
+            )));
+        }
+        Ok(())
+    }
+
     pub(crate) async fn scan_live_batch_for_retention(
         &self,
         branch_id: &str,

--- a/packages/lix/src/live_state/tracked_head/hot.rs
+++ b/packages/lix/src/live_state/tracked_head/hot.rs
@@ -12005,7 +12005,7 @@ mod tests {
                     HOT_COLLECTION_CONTROL_SPACE,
                     control_key,
                     StorageValue {
-                        bytes: Bytes::from_static(b"malformed-control"),
+                        bytes: Bytes::from_static(b"\0"),
                     },
                 ),
                 "stale" => stage_hot_collection_control(

--- a/packages/lix/src/transaction/commit.rs
+++ b/packages/lix/src/transaction/commit.rs
@@ -3410,6 +3410,7 @@ async fn stage_tracked_head(
         .collect::<BTreeSet<_>>();
     let tracked_head = TrackedHeadContext::new();
     let mut controls = BTreeMap::new();
+    let mut key_value_control_mutations = BTreeSet::new();
     let mut deferred_fresh_hot_plans = Vec::new();
     let mut exclusive_certified_columnar_publication = false;
 
@@ -3481,6 +3482,15 @@ async fn stage_tracked_head(
         } else {
             None
         };
+        if state_row_indices.iter().any(|&row_index| {
+            let row = state_rows.row(row_index);
+            !row.untracked && row.schema_key == "lix_key_value"
+        }) || selected_materialization
+            .as_ref()
+            .is_some_and(|(rows, _, _)| rows.iter().any(|row| row.schema_key == "lix_key_value"))
+        {
+            key_value_control_mutations.insert(root.branch_id.as_str());
+        }
         let mut untracked_deltas = if certified_columnar_parts.is_some() {
             Vec::new()
         } else {
@@ -4347,6 +4357,44 @@ async fn stage_tracked_head(
                 .chain(untracked_deltas.iter().map(|delta| delta.schema_key)),
         );
         insert_direct_branch_control(&mut controls, &root.branch_id, control)?;
+    }
+
+    // Bootstrap may initially use one physical generation for both selector
+    // domains. A tracked-only publication mutates that generation in place,
+    // so preserve the complete untracked authority under its own selector
+    // before publishing the updated branch control. Subsequent publications
+    // already have disjoint selectors and pay no copy cost.
+    for (branch_id, control) in &mut controls {
+        if !key_value_control_mutations.contains(branch_id.as_str()) {
+            continue;
+        }
+        let Some(previous) = observations
+            .get(branch_id)
+            .and_then(|observation| observation.control)
+        else {
+            continue;
+        };
+        if control.tracked_generation != control.untracked_generation
+            || control.untracked_generation != previous.untracked_generation
+        {
+            continue;
+        }
+        let next_generation = untracked_lifecycle_generation(
+            branch_id,
+            previous.untracked_generation,
+            control.current_state_revision,
+        );
+        tracked_head
+            .writer(read, writes)
+            .stage_untracked_generation(
+                branch_id,
+                previous.untracked_generation,
+                next_generation,
+                &[],
+                &BTreeSet::new(),
+            )
+            .await?;
+        control.untracked_generation = next_generation;
     }
 
     // An untracked-only transaction touches the same hot rows without

--- a/packages/lix/tests/adapter_deterministic_sequence_corruption.rs
+++ b/packages/lix/tests/adapter_deterministic_sequence_corruption.rs
@@ -1,0 +1,139 @@
+use std::ops::Bound;
+
+use bytes::Bytes;
+use lix::integration::Engine;
+use lix::storage::{
+    CoreProjection, KeyRange, ReadOptions, ScanOptions, SpaceId, Storage, StorageRead,
+    StorageSpace, StorageWrite, WriteOptions,
+};
+
+const HOT_ROW_SPACE: StorageSpace =
+    StorageSpace::mutable(SpaceId(0x0004_001b), "live_state.hot_row.v21");
+const SEQUENCE_IDENTITY: &[u8] = b"lix_deterministic_sequence_number";
+
+pub async fn initialize_with_deterministic_mode<S>(storage: S)
+where
+    S: Storage + Clone + Send + Sync + 'static,
+{
+    Engine::initialize(storage.clone())
+        .await
+        .expect("storage should initialize");
+    let engine = Engine::new(storage).await.expect("engine should open");
+    let session = engine
+        .open_workspace_session()
+        .await
+        .expect("workspace session should open");
+    session
+        .execute(
+            "INSERT INTO lix_key_value (key, value, lixcol_global, lixcol_untracked) \
+             VALUES ('lix_deterministic_mode', lix_json('{\"enabled\":true}'), true, true)",
+            &[],
+        )
+        .await
+        .expect("deterministic mode should enable without publishing a sequence row");
+}
+
+pub async fn assert_next_uuid<S>(storage: S, suffix: &str)
+where
+    S: Storage + Clone + Send + Sync + 'static,
+{
+    let engine = Engine::new(storage).await.expect("engine should reopen");
+    let session = engine
+        .open_workspace_session()
+        .await
+        .expect("workspace session should reopen");
+    let result = session
+        .execute("SELECT lix_uuid_v7() AS value", &[])
+        .await
+        .expect("valid deterministic authority should produce the next UUID");
+    let value = result.rows()[0]
+        .get::<String>("value")
+        .expect("UUID should be text");
+    assert_eq!(value, format!("01920000-0000-7000-8000-{suffix}"));
+}
+
+pub async fn delete_selected_sequence_member<S>(storage: &S)
+where
+    S: Storage + Send + Sync,
+{
+    let read = storage
+        .begin_read(ReadOptions::default())
+        .await
+        .expect("selected HOT generation should read");
+    let range = KeyRange {
+        lower: Bound::Unbounded,
+        upper: Bound::Unbounded,
+    };
+    let mut resume_after = None;
+    let mut sequence_keys = Vec::new();
+    loop {
+        let page = read
+            .scan(
+                HOT_ROW_SPACE,
+                range.clone(),
+                ScanOptions {
+                    projection: CoreProjection::KeyOnly,
+                    resume_after: resume_after.clone(),
+                    ..ScanOptions::default()
+                },
+            )
+            .await
+            .expect("HOT members should scan");
+        resume_after = page.entries.last().map(|entry| entry.key.clone());
+        sequence_keys.extend(
+            page.entries
+                .into_iter()
+                .filter(|entry| contains_subslice(entry.key.0.as_ref(), SEQUENCE_IDENTITY))
+                .map(|entry| entry.key),
+        );
+        if !page.has_more || resume_after.is_none() {
+            break;
+        }
+    }
+    drop(read);
+    assert_eq!(
+        sequence_keys.len(),
+        1,
+        "fixture should have one selected sequence HOT member"
+    );
+
+    let mut write = storage
+        .begin_write(WriteOptions::default())
+        .await
+        .expect("physical corruption write should open");
+    write
+        .delete_many(HOT_ROW_SPACE, &sequence_keys)
+        .await
+        .expect("selected sequence member deletion should stage");
+    write
+        .commit()
+        .await
+        .expect("selected sequence member deletion should commit");
+}
+
+pub async fn assert_missing_sequence_member_fails_closed<S>(storage: S)
+where
+    S: Storage + Clone + Send + Sync + 'static,
+{
+    let engine = Engine::new(storage)
+        .await
+        .expect("member-corrupt repository should open structurally");
+    let session = engine
+        .open_workspace_session()
+        .await
+        .expect("member-corrupt session should open");
+    let error = session
+        .execute("SELECT lix_uuid_v7()", &[])
+        .await
+        .expect_err("missing selected sequence member must fail closed");
+    assert!(
+        error.message.contains("declares") && error.message.contains("but materializes"),
+        "unexpected member-closure error: {error:?}"
+    );
+}
+
+fn contains_subslice(haystack: &[u8], needle: &[u8]) -> bool {
+    haystack
+        .windows(needle.len())
+        .any(|candidate| candidate == needle)
+}

--- a/packages/lix/tests/adapter_deterministic_sequence_corruption.rs
+++ b/packages/lix/tests/adapter_deterministic_sequence_corruption.rs
@@ -3,13 +3,14 @@ use std::ops::Bound;
 use bytes::Bytes;
 use lix::integration::Engine;
 use lix::storage::{
-    CoreProjection, KeyRange, ReadOptions, ScanOptions, SpaceId, Storage, StorageRead,
-    StorageSpace, StorageWrite, WriteOptions,
+    CoreProjection, Key, KeyRange, ProjectedValue, PutBatch, PutEntry, ReadOptions, ScanOptions,
+    SpaceId, Storage, StorageRead, StorageSpace, StorageWrite, StoredValue, WriteOptions,
 };
 
 const HOT_ROW_SPACE: StorageSpace =
     StorageSpace::mutable(SpaceId(0x0004_001b), "live_state.hot_row.v21");
 const SEQUENCE_IDENTITY: &[u8] = b"lix_deterministic_sequence_number";
+const UNRELATED_IDENTITY: &[u8] = b"lix_unrelated_sequence_substitute";
 
 pub async fn initialize_with_deterministic_mode<S>(storage: S)
 where
@@ -52,7 +53,7 @@ where
     assert_eq!(value, format!("01920000-0000-7000-8000-{suffix}"));
 }
 
-pub async fn delete_selected_sequence_member<S>(storage: &S)
+pub async fn replace_selected_sequence_member_with_unrelated<S>(storage: &S)
 where
     S: Storage + Send + Sync,
 {
@@ -65,14 +66,14 @@ where
         upper: Bound::Unbounded,
     };
     let mut resume_after = None;
-    let mut sequence_keys = Vec::new();
+    let mut sequence_entries = Vec::new();
     loop {
         let page = read
             .scan(
                 HOT_ROW_SPACE,
                 range.clone(),
                 ScanOptions {
-                    projection: CoreProjection::KeyOnly,
+                    projection: CoreProjection::FullValue,
                     resume_after: resume_after.clone(),
                     ..ScanOptions::default()
                 },
@@ -80,11 +81,10 @@ where
             .await
             .expect("HOT members should scan");
         resume_after = page.entries.last().map(|entry| entry.key.clone());
-        sequence_keys.extend(
+        sequence_entries.extend(
             page.entries
                 .into_iter()
-                .filter(|entry| contains_subslice(entry.key.0.as_ref(), SEQUENCE_IDENTITY))
-                .map(|entry| entry.key),
+                .filter(|entry| contains_subslice(entry.key.0.as_ref(), SEQUENCE_IDENTITY)),
         );
         if !page.has_more || resume_after.is_none() {
             break;
@@ -92,23 +92,44 @@ where
     }
     drop(read);
     assert_eq!(
-        sequence_keys.len(),
+        sequence_entries.len(),
         1,
         "fixture should have one selected sequence HOT member"
     );
+    let sequence_entry = sequence_entries.pop().expect("one sequence entry");
+    let ProjectedValue::FullValue(value) = sequence_entry.value else {
+        panic!("sequence corruption fixture must read the full row value");
+    };
+    let replacement_key = Key(Bytes::from(replace_subslice(
+        sequence_entry.key.0.as_ref(),
+        SEQUENCE_IDENTITY,
+        UNRELATED_IDENTITY,
+    )));
 
     let mut write = storage
         .begin_write(WriteOptions::default())
         .await
         .expect("physical corruption write should open");
     write
-        .delete_many(HOT_ROW_SPACE, &sequence_keys)
+        .delete_many(HOT_ROW_SPACE, std::slice::from_ref(&sequence_entry.key))
         .await
         .expect("selected sequence member deletion should stage");
     write
+        .put_many(
+            HOT_ROW_SPACE,
+            PutBatch {
+                entries: vec![PutEntry {
+                    key: replacement_key,
+                    value: StoredValue { bytes: value },
+                }],
+            },
+        )
+        .await
+        .expect("unrelated same-count member should stage");
+    write
         .commit()
         .await
-        .expect("selected sequence member deletion should commit");
+        .expect("same-count sequence substitution should commit");
 }
 
 pub async fn assert_missing_sequence_member_fails_closed<S>(storage: S)
@@ -127,9 +148,26 @@ where
         .await
         .expect_err("missing selected sequence member must fail closed");
     assert!(
-        error.message.contains("declares") && error.message.contains("but materializes"),
+        error.message.contains("identity digest") && error.message.contains("canonical members"),
         "unexpected member-closure error: {error:?}"
     );
+}
+
+fn replace_subslice(haystack: &[u8], needle: &[u8], replacement: &[u8]) -> Vec<u8> {
+    assert_eq!(needle.len(), replacement.len());
+    let position = haystack
+        .windows(needle.len())
+        .position(|candidate| candidate == needle)
+        .expect("sequence identity should be present in its physical key");
+    assert!(
+        haystack[position + needle.len()..]
+            .windows(needle.len())
+            .all(|candidate| candidate != needle),
+        "sequence identity should occur exactly once in its physical key"
+    );
+    let mut replaced = haystack.to_vec();
+    replaced[position..position + needle.len()].copy_from_slice(replacement);
+    replaced
 }
 
 fn contains_subslice(haystack: &[u8], needle: &[u8]) -> bool {

--- a/packages/lix/tests/deterministic_sequence_corruption.rs
+++ b/packages/lix/tests/deterministic_sequence_corruption.rs
@@ -1,32 +1,36 @@
-#[path = "adapter_deterministic_sequence_corruption.rs"]
-mod deterministic_sequence_corruption;
+mod adapter_deterministic_sequence_corruption;
 
 use lix::storage::Memory;
 
 #[tokio::test]
 async fn memory_deterministic_sequence_member_closure_fails_closed() {
     let initial = Memory::new();
-    deterministic_sequence_corruption::initialize_with_deterministic_mode(initial.clone()).await;
+    adapter_deterministic_sequence_corruption::initialize_with_deterministic_mode(initial.clone())
+        .await;
     let snapshot = initial
         .export_snapshot()
         .expect("initial deterministic storage should snapshot");
     drop(initial);
     let initial = Memory::from_snapshot(&snapshot).expect("initial storage should reopen");
-    deterministic_sequence_corruption::assert_next_uuid(initial.clone(), "000000000000").await;
+    adapter_deterministic_sequence_corruption::assert_next_uuid(initial.clone(), "000000000000")
+        .await;
     let snapshot = initial
         .export_snapshot()
         .expect("published sequence should snapshot");
     drop(initial);
     let valid = Memory::from_snapshot(&snapshot).expect("published sequence should reopen");
-    deterministic_sequence_corruption::assert_next_uuid(valid, "000000000001").await;
+    adapter_deterministic_sequence_corruption::assert_next_uuid(valid, "000000000001").await;
 
     let corrupt = Memory::from_snapshot(&snapshot).expect("corruption fixture should reopen");
-    deterministic_sequence_corruption::replace_selected_sequence_member_with_unrelated(&corrupt)
-        .await;
+    adapter_deterministic_sequence_corruption::replace_selected_sequence_member_with_unrelated(
+        &corrupt,
+    )
+    .await;
     let snapshot = corrupt
         .export_snapshot()
         .expect("corrupt sequence storage should snapshot");
     drop(corrupt);
     let corrupt = Memory::from_snapshot(&snapshot).expect("corrupt storage should reopen");
-    deterministic_sequence_corruption::assert_missing_sequence_member_fails_closed(corrupt).await;
+    adapter_deterministic_sequence_corruption::assert_missing_sequence_member_fails_closed(corrupt)
+        .await;
 }

--- a/packages/lix/tests/deterministic_sequence_corruption.rs
+++ b/packages/lix/tests/deterministic_sequence_corruption.rs
@@ -1,0 +1,32 @@
+#[path = "adapter_deterministic_sequence_corruption.rs"]
+mod deterministic_sequence_corruption;
+
+use lix::storage::Memory;
+
+#[tokio::test]
+async fn memory_deterministic_sequence_member_closure_fails_closed() {
+    let initial = Memory::new();
+    deterministic_sequence_corruption::initialize_with_deterministic_mode(initial.clone()).await;
+    let snapshot = initial
+        .export_snapshot()
+        .expect("initial deterministic storage should snapshot");
+    drop(initial);
+    let initial = Memory::from_snapshot(&snapshot).expect("initial storage should reopen");
+    deterministic_sequence_corruption::assert_next_uuid(initial.clone(), "000000000000").await;
+    let snapshot = initial
+        .export_snapshot()
+        .expect("published sequence should snapshot");
+    drop(initial);
+    let valid = Memory::from_snapshot(&snapshot).expect("published sequence should reopen");
+    deterministic_sequence_corruption::assert_next_uuid(valid, "000000000001").await;
+
+    let corrupt = Memory::from_snapshot(&snapshot).expect("corruption fixture should reopen");
+    deterministic_sequence_corruption::replace_selected_sequence_member_with_unrelated(&corrupt)
+        .await;
+    let snapshot = corrupt
+        .export_snapshot()
+        .expect("corrupt sequence storage should snapshot");
+    drop(corrupt);
+    let corrupt = Memory::from_snapshot(&snapshot).expect("corrupt storage should reopen");
+    deterministic_sequence_corruption::assert_missing_sequence_member_fails_closed(corrupt).await;
+}

--- a/packages/lix/tests/integration/durable_function_fast_path.rs
+++ b/packages/lix/tests/integration/durable_function_fast_path.rs
@@ -140,7 +140,13 @@ async fn pure_read_skips_durable_function_state_storage_work() {
         "only the durable-function statement should load durable mode state: \
          pure={pure_reads:?}, durable={durable_reads:?}"
     );
-    assert_eq!(durable_reads.scan_calls, pure_reads.scan_calls);
+    assert_eq!(
+        durable_reads.scan_calls,
+        pure_reads.scan_calls + 1,
+        "a missing engine-owned durable key must validate its exact collection closure once, \
+         while a pure read must not scan durable state: \
+         pure={pure_reads:?}, durable={durable_reads:?}"
+    );
 }
 
 #[tokio::test]

--- a/packages/rocksdb-storage/tests/storage/main.rs
+++ b/packages/rocksdb-storage/tests/storage/main.rs
@@ -1,3 +1,5 @@
+#[path = "../../../lix/tests/adapter_deterministic_sequence_corruption.rs"]
+mod deterministic_sequence_corruption;
 mod file_sql;
 mod native_file_read;
 mod native_file_upsert;
@@ -55,4 +57,34 @@ async fn checkpointed_state_survives_undo_redo_and_cold_reopen_on_rocksdb() {
         .await
         .expect("reopen engine after redo");
     undo_redo_checkpoint::assert_cold_redo(&engine, branch_id).await;
+}
+
+#[tokio::test]
+async fn deterministic_sequence_member_corruption_fails_closed_on_rocksdb() {
+    let temp_dir = tempfile::tempdir().expect("create RocksDB temp directory");
+
+    let initial_path = temp_dir.path().join("sequence-initial.rocksdb");
+    let storage = RocksDB::open(&initial_path).expect("open initial RocksDB storage");
+    deterministic_sequence_corruption::initialize_with_deterministic_mode(storage.clone()).await;
+    storage.flush().expect("flush initial deterministic mode");
+    drop(storage);
+    let storage = RocksDB::open(&initial_path).expect("reopen initial RocksDB storage");
+    deterministic_sequence_corruption::assert_next_uuid(storage, "000000000000").await;
+
+    let corrupt_path = temp_dir.path().join("sequence-corrupt.rocksdb");
+    let storage = RocksDB::open(&corrupt_path).expect("open corruption RocksDB storage");
+    deterministic_sequence_corruption::initialize_with_deterministic_mode(storage.clone()).await;
+    deterministic_sequence_corruption::assert_next_uuid(storage.clone(), "000000000000").await;
+    storage.flush().expect("flush published sequence member");
+    drop(storage);
+
+    let storage = RocksDB::open(&corrupt_path).expect("reopen published sequence storage");
+    deterministic_sequence_corruption::delete_selected_sequence_member(&storage).await;
+    storage
+        .flush()
+        .expect("flush physical sequence member deletion");
+    drop(storage);
+
+    let storage = RocksDB::open(&corrupt_path).expect("reopen corrupt sequence storage");
+    deterministic_sequence_corruption::assert_missing_sequence_member_fails_closed(storage).await;
 }

--- a/packages/rocksdb-storage/tests/storage/main.rs
+++ b/packages/rocksdb-storage/tests/storage/main.rs
@@ -79,10 +79,11 @@ async fn deterministic_sequence_member_corruption_fails_closed_on_rocksdb() {
     drop(storage);
 
     let storage = RocksDB::open(&corrupt_path).expect("reopen published sequence storage");
-    deterministic_sequence_corruption::delete_selected_sequence_member(&storage).await;
+    deterministic_sequence_corruption::replace_selected_sequence_member_with_unrelated(&storage)
+        .await;
     storage
         .flush()
-        .expect("flush physical sequence member deletion");
+        .expect("flush same-count sequence member substitution");
     drop(storage);
 
     let storage = RocksDB::open(&corrupt_path).expect("reopen corrupt sequence storage");

--- a/packages/slatedb-storage/tests/storage.rs
+++ b/packages/slatedb-storage/tests/storage.rs
@@ -3,6 +3,8 @@
     reason = "test fixtures mirror explicit Send future signatures from StorageFixture"
 )]
 
+#[path = "../../lix/tests/adapter_deterministic_sequence_corruption.rs"]
+mod deterministic_sequence_corruption;
 #[path = "../../lix/tests/adapter_undo_redo_checkpoint.rs"]
 mod undo_redo_checkpoint;
 
@@ -183,6 +185,43 @@ async fn checkpointed_state_survives_undo_redo_and_cold_reopen_on_slatedb() {
         .await
         .expect("reopen engine after redo");
     undo_redo_checkpoint::assert_cold_redo(&engine, branch_id).await;
+}
+
+#[tokio::test]
+async fn deterministic_sequence_member_corruption_fails_closed_on_slatedb() {
+    let temp_dir = tempfile::tempdir().expect("create SlateDB temp directory");
+
+    let initial_path = temp_dir.path().join("sequence-initial.slatedb");
+    let storage = SlateDB::open(&initial_path).expect("open initial SlateDB storage");
+    deterministic_sequence_corruption::initialize_with_deterministic_mode(storage.clone()).await;
+    storage
+        .flush()
+        .await
+        .expect("flush initial deterministic mode");
+    drop(storage);
+    let storage = SlateDB::open(&initial_path).expect("reopen initial SlateDB storage");
+    deterministic_sequence_corruption::assert_next_uuid(storage, "000000000000").await;
+
+    let corrupt_path = temp_dir.path().join("sequence-corrupt.slatedb");
+    let storage = SlateDB::open(&corrupt_path).expect("open corruption SlateDB storage");
+    deterministic_sequence_corruption::initialize_with_deterministic_mode(storage.clone()).await;
+    deterministic_sequence_corruption::assert_next_uuid(storage.clone(), "000000000000").await;
+    storage
+        .flush()
+        .await
+        .expect("flush published sequence member");
+    drop(storage);
+
+    let storage = SlateDB::open(&corrupt_path).expect("reopen published sequence storage");
+    deterministic_sequence_corruption::delete_selected_sequence_member(&storage).await;
+    storage
+        .flush()
+        .await
+        .expect("flush physical sequence member deletion");
+    drop(storage);
+
+    let storage = SlateDB::open(&corrupt_path).expect("reopen corrupt sequence storage");
+    deterministic_sequence_corruption::assert_missing_sequence_member_fails_closed(storage).await;
 }
 
 #[tokio::test]

--- a/packages/slatedb-storage/tests/storage.rs
+++ b/packages/slatedb-storage/tests/storage.rs
@@ -213,11 +213,12 @@ async fn deterministic_sequence_member_corruption_fails_closed_on_slatedb() {
     drop(storage);
 
     let storage = SlateDB::open(&corrupt_path).expect("reopen published sequence storage");
-    deterministic_sequence_corruption::delete_selected_sequence_member(&storage).await;
+    deterministic_sequence_corruption::replace_selected_sequence_member_with_unrelated(&storage)
+        .await;
     storage
         .flush()
         .await
-        .expect("flush physical sequence member deletion");
+        .expect("flush same-count sequence member substitution");
     drop(storage);
 
     let storage = SlateDB::open(&corrupt_path).expect("reopen corrupt sequence storage");


### PR DESCRIPTION
# Sequence member closure qualification

## Immutable provenance

- Comparator/main: `f77f5b9e2ff582f749d1c487d95e6c0e8e4d3662`, tree `597b98f80dad062b4c0b244f2e59fa489a9d4ce9`.
- Frozen candidate: `31a58c8c5361a8424f6123a396afe2b7f6b9b3e5`, tree `856d53be8cec62f96dffaa5848cd80af56e2efed`.
- Candidate base: `8e3ffe632bc27e1ab84fe9a6102b099ab2e9f441`.
- Candidate stable patch ID: `3913ece84b32d378e9270ac0c9a5f9978f69e54e` (matches handoff).
- Handoff hash `f7bd11d3f21f1a447ca2518bf7c6fe0faca8924769ea0c598c603ff9eb8c2bc7` reproduces with ordinary/`--binary` diff. The actual `--full-index --binary` hash is `3c299cd989e203099ab5139421495cd314336fed5b8cb8ea8e3466c51f6b3a83`; the difference is expanded textual index lines, not content.

## Review result

APPROVE after one test-fixture-only repair.

`HotCollectionControl` remains the sole persisted generation-local inventory. A present deterministic-sequence point read is unchanged and O(1). A required miss loads the exact control and streams the selected HOT scope once: O(K) time, O(max encoded key) working state (O(1) in member count). It rejects missing controls outside bootstrap, malformed controls, stale generations, deferred counts, absent digests, count/digest mismatch, noncanonical or duplicate physical identities, tombstoned required identity, and wrong retention. Bootstrap absence is accepted only at revision zero with no control and zero physical members.

The digest writer and validator cover canonical physical keys. Those keys bind branch, generation, schema, file discriminator, and the complete order-preserving typed `EntityPk` encoding (UUID, signed integer, string, bytes, including composites). Legacy-compatible single-string/unfiled digests remain type-unambiguous within their exact scoped control; any file-backed or typed/composite member uses the canonical domain-separated digest. No locator, side index, cache, alternate authority, migration, or compatibility reader was added.

The #1257 interaction is clean: #1257 canonicalizes materialized SQL/HOT output, while closure validation hashes raw backend physical order. The complete-publication writer reconstructs that same file-first physical order before sealing its control. The original #1257 three-writer cohort and canonical ordering/duplicate gates pass.

## Candidate-head failure and repair

At exact candidate head, `exact_collection_closure_rejects_missing_malformed_stale_and_forged_controls` failed only for the fixture payload `malformed-control`: its 17 bytes happened to decode as a packed control and then correctly failed closed as a stale generation. This was an over-specific fixture expectation, not an accepting production path.

Current main was merged exactly once in merge commit `09837b657c8d0f8baeef7e66cc6680a933e2a90a` with parents `(31a58c8c5361a8424f6123a396afe2b7f6b9b3e5, f77f5b9e2ff582f749d1c487d95e6c0e8e4d3662)`. Test-only commit `7436ea51c90c1988ed42559671064b5392719a09` changes that payload to one truncated byte (`b"\0"`), forcing the packed decoder corruption path. Its full-index binary diff SHA-256 is `a14bb78ae85aa8e13919e7808434214898ffec26cf4f194b8a738a08a7bc375a`.

## Final identity

- Head: `7436ea51c90c1988ed42559671064b5392719a09`
- Tree: `04aea27d13b7b4adde84c3ab0d9e5f49817f51db`
- Ordinary binary diff SHA-256 vs f77: `b0c11b3653ba40a248f3a5c5e70069e7b2686abfb482c2029f3c1bdda2db81f1`
- Full-index binary diff SHA-256 vs f77: `1a3eedb9409f6750eb812d88c4214ef061057d09ace4d86a1b2bf9d22d479e93`
- Stable patch ID vs f77: `39968ba01e40250276595a9afed8229d55da625c`
- Binary format-patch SHA-256 vs f77: `5fa4793adb7151a3bdcd2df1a118ee67a1cbe5ca678e164451375343277f1aa1`

## Green gates

- `cargo fmt --all -- --check`
- `git diff --check f77..HEAD`
- canonical `cargo clippy --profile test --workspace --all-targets --all-features -- -D warnings` (4m03s)
- Internal exact-closure malformed/stale/missing/no-digest/forged controls
- Noncanonical, duplicate, tombstone, and wrong-retention controls
- Typed composite PK, file-scoped, and authenticated-empty controls
- Same-count direct substitution control
- Memory cold reopen/substitution oracle
- RocksDB cold reopen/substitution oracle
- SlateDB cold reopen/substitution oracle
- Deterministic all-simulations slice: 13 green across base and tracked-state rebuild
- #1257 canonical HOT/certified order and duplicate controls
- #1257 `same_base_three_writer_cohort_converges_and_reuses_follower_session`

No performance claim is made. Present-point behavior and ordinary reads are unchanged; the new O(K) scan occurs only after a required authority point miss. No backend writes, durable bytes, disk format, or steady-state cache are added beyond the authenticated digest already stored in the existing control.
