### PR TITLE
refactor(lix): own SQL writes above TableProvider

### DIFF
--- a/packages/lix/src/sql2/context.rs
+++ b/packages/lix/src/sql2/context.rs
@@ -315,6 +315,7 @@ pub(crate) struct SqlWriteContext {
     ptr: Arc<SqlWriteContextPtr>,
     gate: Arc<Mutex<()>>,
     explicit_insert_columns: Option<Arc<BTreeSet<String>>>,
+    write_targets: Option<Arc<super::providers::WriteTargetRegistry>>,
 }
 
 struct SqlWriteContextPtr(NonNull<dyn SqlWriteExecutionContext>);
@@ -338,6 +339,7 @@ impl SqlWriteContext {
             ptr: Arc::new(SqlWriteContextPtr(ptr)),
             gate: Arc::new(Mutex::new(())),
             explicit_insert_columns: None,
+            write_targets: Some(Arc::new(super::providers::WriteTargetRegistry::default())),
         }
     }
 
@@ -351,6 +353,19 @@ impl SqlWriteContext {
 
     pub(crate) fn explicit_insert_columns(&self) -> Option<&BTreeSet<String>> {
         self.explicit_insert_columns.as_deref()
+    }
+
+    pub(crate) fn write_targets(
+        &self,
+    ) -> Result<Arc<super::providers::WriteTargetRegistry>, LixError> {
+        self.write_targets.clone().ok_or_else(|| {
+            LixError::unknown("physical SQL write target cannot own a write-target registry")
+        })
+    }
+
+    pub(crate) fn into_physical_target(mut self) -> Self {
+        self.write_targets = None;
+        self
     }
 
     pub(crate) fn functions(&self) -> FunctionProviderHandle {
@@ -527,20 +542,11 @@ impl WriteAccess {
         Self::Write { ctx }
     }
 
-    pub(crate) fn require_write(
-        &self,
-        action: &str,
-    ) -> Result<SqlWriteContext, datafusion::error::DataFusionError> {
+    pub(crate) fn into_write_context(self) -> Option<SqlWriteContext> {
         match self {
-            Self::Write { ctx } => Ok(ctx.clone()),
-            Self::ReadOnly => Err(datafusion::error::DataFusionError::Execution(format!(
-                "{action} requires a write transaction"
-            ))),
+            Self::ReadOnly => None,
+            Self::Write { ctx } => Some(ctx),
         }
-    }
-
-    pub(crate) fn is_write(&self) -> bool {
-        matches!(self, Self::Write { .. })
     }
 }
 

--- a/packages/lix/src/sql2/exec/datafusion.rs
+++ b/packages/lix/src/sql2/exec/datafusion.rs
@@ -27,7 +27,6 @@ use datafusion::common::metadata::{FieldMetadata, ScalarAndMetadata};
 use datafusion::common::tree_node::{Transformed, TreeNode, TreeNodeRecursion};
 use datafusion::common::{Column, DFSchema, DFSchemaRef, JoinType, ParamValues, ScalarValue};
 use datafusion::datasource::{empty::EmptyTable, provider_as_source};
-use datafusion::logical_expr::dml::InsertOp;
 use datafusion::logical_expr::expr::{BinaryExpr, Cast, InList, Like, ScalarFunction};
 use datafusion::logical_expr::registry::FunctionRegistry;
 use datafusion::logical_expr::{Expr, ExprSchemable, LogicalPlan, LogicalPlanBuilder, Operator};
@@ -1538,6 +1537,7 @@ pub(crate) async fn execute_datafusion_write_logical_plan(
         .table_provider(&table_name)
         .await
         .map_err(datafusion_error_to_lix_error)?;
+    let write_target = session.write_target(&table_name)?;
     let table_schema = table.schema();
     let state = session.state();
     // Diff command sinks own their dedicated RETURNING contract. Every
@@ -1570,8 +1570,10 @@ pub(crate) async fn execute_datafusion_write_logical_plan(
                     .iter()
                     .map(|column| column.name.clone())
                     .collect();
-                crate::sql2::providers::validate_spec_upsert(&table, &input, &target_columns)
-                    .await?;
+                write_target
+                    .validate_upsert_target(&input, &target_columns)
+                    .await
+                    .map_err(datafusion_error_to_lix_error)?;
                 let proposed_batches = crate::sql2::runtime::collect_input_plan(
                     std::sync::Arc::clone(&input),
                     session.task_ctx(),
@@ -1594,27 +1596,20 @@ pub(crate) async fn execute_datafusion_write_logical_plan(
                     }
                 };
                 let rows_affected = match &returning {
-                    Some(returning) => {
-                        crate::sql2::providers::execute_spec_upsert_with_returning(
-                            &table,
+                    Some(returning) => write_target
+                        .execute_upsert_with_returning(
                             &input,
                             proposed_batches,
                             &target_columns,
                             &action,
                             returning.clone(),
                         )
-                        .await?
-                    }
-                    None => {
-                        crate::sql2::providers::execute_spec_upsert(
-                            &table,
-                            &input,
-                            proposed_batches,
-                            &target_columns,
-                            &action,
-                        )
-                        .await?
-                    }
+                        .await
+                        .map_err(datafusion_error_to_lix_error)?,
+                    None => write_target
+                        .execute_upsert(&input, proposed_batches, &target_columns, &action)
+                        .await
+                        .map_err(datafusion_error_to_lix_error)?,
                 };
                 return match returning.as_ref() {
                     Some(returning) => {
@@ -1624,17 +1619,12 @@ pub(crate) async fn execute_datafusion_write_logical_plan(
                 };
             }
             match &returning {
-                Some(returning) => {
-                    crate::sql2::providers::execute_spec_insert_with_returning(
-                        &table,
-                        &state,
-                        input,
-                        returning.clone(),
-                    )
+                Some(returning) => write_target
+                    .insert_with_returning(&state, input, returning.clone())
                     .await
-                }
-                None => table
-                    .insert_into(&state, input, InsertOp::Append)
+                    .map_err(datafusion_error_to_lix_error),
+                None => write_target
+                    .insert(input)
                     .await
                     .map_err(datafusion_error_to_lix_error),
             }
@@ -1647,17 +1637,11 @@ pub(crate) async fn execute_datafusion_write_logical_plan(
                 return sql_write_empty_returning_result(returning.as_ref());
             }
             match &returning {
-                Some(returning) => {
-                    crate::sql2::providers::execute_spec_update_with_returning(
-                        &table,
-                        &state,
-                        assignments,
-                        filters,
-                        returning.clone(),
-                    )
+                Some(returning) => write_target
+                    .update_with_returning(&state, assignments, filters, returning.clone())
                     .await
-                }
-                None => table
+                    .map_err(datafusion_error_to_lix_error),
+                None => write_target
                     .update(&state, assignments, filters)
                     .await
                     .map_err(datafusion_error_to_lix_error),
@@ -1669,17 +1653,12 @@ pub(crate) async fn execute_datafusion_write_logical_plan(
                 return sql_write_empty_returning_result(returning.as_ref());
             }
             match &returning {
-                Some(returning) => {
-                    crate::sql2::providers::execute_spec_delete_with_returning(
-                        &table,
-                        &state,
-                        filters,
-                        returning.clone(),
-                    )
+                Some(returning) => write_target
+                    .delete_with_returning(&state, filters, returning.clone())
                     .await
-                }
-                None => table
-                    .delete_from(&state, filters)
+                    .map_err(datafusion_error_to_lix_error),
+                None => write_target
+                    .delete(&state, filters)
                     .await
                     .map_err(datafusion_error_to_lix_error),
             }

--- a/packages/lix/src/sql2/providers/diff.rs
+++ b/packages/lix/src/sql2/providers/diff.rs
@@ -11,9 +11,9 @@ use datafusion::logical_expr::{Expr, TableProviderFilterPushDown};
 
 use crate::checkpoint::CHECKPOINT_MARKER_SCHEMA_KEY;
 use crate::entity_pk::EntityPk;
+use crate::sql2::SqlChangelogQuerySource;
 use crate::sql2::error::lix_error_to_datafusion_error;
 use crate::sql2::result_metadata::json_field;
-use crate::sql2::{SqlChangelogQuerySource, WriteAccess};
 use crate::storage_adapter::StorageAdapterRead;
 use crate::tracked_state::encode_diff_id;
 use crate::tracked_state::{
@@ -64,14 +64,11 @@ where
         };
         let from_commit_id = commit_id_argument(from_commit_id, 1)?;
         let to_commit_id = commit_id_argument(to_commit_id, 2)?;
-        Ok(Arc::new(SpecTableProvider::new(
-            Arc::new(DiffSpec {
-                store: self.store.clone(),
-                from_commit_id,
-                to_commit_id,
-            }),
-            WriteAccess::read_only(),
-        )))
+        Ok(Arc::new(SpecTableProvider::new(Arc::new(DiffSpec {
+            store: self.store.clone(),
+            from_commit_id,
+            to_commit_id,
+        }))))
     }
 }
 

--- a/packages/lix/src/sql2/providers/directory.rs
+++ b/packages/lix/src/sql2/providers/directory.rs
@@ -2386,6 +2386,7 @@ mod tests {
     use datafusion::arrow::datatypes::{DataType, Field, Schema};
     use datafusion::arrow::record_batch::RecordBatch;
     use datafusion::common::{Column, ScalarValue};
+    use datafusion::datasource::TableProvider;
     use datafusion::execution::context::ExecutionProps;
     use datafusion::logical_expr::expr::BinaryExpr;
     use datafusion::logical_expr::{Expr, Operator};
@@ -2412,7 +2413,7 @@ mod tests {
     use super::super::spec::{SpecTableProvider, TableSpec};
     use super::{
         BranchBinding, DirectoryDescriptorRecord, LixDirectorySpec, UpsertConflictTarget,
-        UpsertSupport, WriteAccess, derive_directory_paths, lix_directory_by_branch_schema,
+        UpsertSupport, derive_directory_paths, lix_directory_by_branch_schema,
         lix_directory_insert_origin, lix_directory_record_batch,
         lix_directory_recursive_delete_rows_from_batch, lix_directory_write_rows_from_batch,
         lix_directory_write_rows_from_batch_with_path_resolvers,
@@ -3644,7 +3645,7 @@ mod tests {
     }
 
     #[test]
-    fn directory_provider_is_writable_when_given_write_access() {
+    fn directory_provider_keeps_no_write_authority() {
         let mut write_context = CapturingWriteContext::default();
         let write_ctx = SqlWriteContext::new(&mut write_context);
         let live_state = Arc::new(crate::sql2::WriteContextLiveStateReader::new(
@@ -3654,16 +3655,16 @@ mod tests {
             write_ctx.clone(),
         ));
         let filesystem_path_index: Arc<dyn FilesystemPathIndexReader> = live_state.clone();
-        let provider = SpecTableProvider::new(
-            Arc::new(LixDirectorySpec::active_branch(
-                write_ctx.active_branch_id(),
-                live_state,
-                filesystem_path_index,
-                branch_ref,
-                test_functions(),
-            )),
-            WriteAccess::write(write_ctx),
+        let provider = SpecTableProvider::new(Arc::new(LixDirectorySpec::active_branch(
+            write_ctx.active_branch_id(),
+            live_state,
+            filesystem_path_index,
+            branch_ref,
+            test_functions(),
+        )));
+        assert_eq!(
+            provider.table_type(),
+            datafusion::datasource::TableType::Base
         );
-        assert!(provider.is_write());
     }
 }

--- a/packages/lix/src/sql2/providers/entity.rs
+++ b/packages/lix/src/sql2/providers/entity.rs
@@ -3055,7 +3055,6 @@ mod tests {
         LiveStateFilter, LiveStateProjection, LiveStateReader, LiveStateRowFilter,
         LiveStateScanRequest, MaterializedLiveStateBatch, MaterializedLiveStateRow,
     };
-    use crate::sql2::WriteAccess;
     use crate::sql2::catalog::{
         EntityColumnType, EntitySurfaceShape, derive_entity_surface_spec_from_schema,
         entity_surface_schema, schema_exposed_as_entity_history_surface,
@@ -3225,14 +3224,11 @@ mod tests {
         let session = datafusion::prelude::SessionContext::new();
         let mut write_context = DummyWriteContext;
         let write_ctx = crate::sql2::SqlWriteContext::new(&mut write_context);
-        let provider = SpecTableProvider::new(
-            Arc::new(super::EntitySpec::active_with_write(
-                entity_insert_spec_with_primary_key(),
-                write_ctx.clone(),
-                empty_branch_ref(),
-            )),
-            WriteAccess::write(write_ctx),
-        );
+        let provider = SpecTableProvider::new(Arc::new(super::EntitySpec::active_with_write(
+            entity_insert_spec_with_primary_key(),
+            write_ctx.clone(),
+            empty_branch_ref(),
+        )));
         let input = Arc::new(datafusion::physical_plan::empty::EmptyExec::new(
             provider.schema(),
         )) as Arc<dyn datafusion::physical_plan::ExecutionPlan>;
@@ -3254,9 +3250,7 @@ mod tests {
             "rejection should keep the NotImplemented error type: {error:?}"
         );
         assert!(
-            error
-                .to_string()
-                .contains("raw DataFusion INSERT is disabled; use the sql2 bound write pipeline"),
+            error.to_string().contains("not implemented"),
             "unexpected error: {error}"
         );
     }
@@ -4094,15 +4088,12 @@ mod tests {
             }))
             .expect("schema should derive entity surface spec"),
         );
-        let provider = SpecTableProvider::new(
-            Arc::new(super::EntitySpec::by_branch(
-                spec,
-                Arc::new(EmptyLiveStateReader) as Arc<dyn LiveStateReader>,
-                empty_branch_ref(),
-                None,
-            )),
-            WriteAccess::read_only(),
-        );
+        let provider = SpecTableProvider::new(Arc::new(super::EntitySpec::by_branch(
+            spec,
+            Arc::new(EmptyLiveStateReader) as Arc<dyn LiveStateReader>,
+            empty_branch_ref(),
+            None,
+        )));
 
         assert!(
             provider

--- a/packages/lix/src/sql2/providers/mod.rs
+++ b/packages/lix/src/sql2/providers/mod.rs
@@ -3,7 +3,6 @@
 use std::collections::BTreeSet;
 use std::sync::Arc;
 
-use datafusion::physical_plan::ExecutionPlan;
 use datafusion::prelude::SessionContext;
 
 use crate::LixError;
@@ -36,7 +35,6 @@ use crate::sql2::catalog::{PublicCatalog, PublicSurfaceContract, PublicSurfaceKi
 use crate::sql2::session::SqlWriteSessionOptions;
 use crate::sql2::{SqlExecutionContext, SqlWriteContext};
 
-use datafusion::catalog::TableProvider;
 use datafusion::datasource::DefaultTableSource;
 use datafusion::logical_expr::TableSource;
 
@@ -51,7 +49,7 @@ pub(crate) use file::{
 };
 #[cfg(test)]
 pub(crate) use filesystem_working_diff::filesystem_working_diff_schema;
-pub(crate) use spec::DmlReturning;
+pub(crate) use spec::{DmlReturning, SpecWriteTarget, WriteTargetRegistry};
 pub(crate) use upsert::{UpsertAction, excluded_field_name};
 
 pub(crate) fn history_anchor_column(source: &dyn TableSource) -> Option<&'static str> {
@@ -61,151 +59,6 @@ pub(crate) fn history_anchor_column(source: &dyn TableSource) -> Option<&'static
         .as_any()
         .downcast_ref::<spec::SpecTableProvider>()?;
     provider.history_anchor_column()
-}
-
-/// Execute an `INSERT ... ON CONFLICT` against a registered table provider.
-/// The four builtin writable surfaces are all [`spec::SpecTableProvider`]s.
-pub(crate) async fn execute_spec_upsert(
-    table: &Arc<dyn TableProvider>,
-    input: &Arc<dyn ExecutionPlan>,
-    proposed_batches: Vec<datafusion::arrow::record_batch::RecordBatch>,
-    target_columns: &[String],
-    action: &UpsertAction,
-) -> Result<u64, LixError> {
-    let provider = table
-        .as_any()
-        .downcast_ref::<spec::SpecTableProvider>()
-        .ok_or_else(|| {
-            LixError::new(
-                LixError::CODE_UNSUPPORTED_SQL,
-                "INSERT ON CONFLICT is not supported on this table",
-            )
-        })?;
-    provider
-        .execute_upsert(input, proposed_batches, target_columns, action)
-        .await
-        .map_err(crate::sql2::error::datafusion_error_to_lix_error)
-}
-
-/// Execute an `INSERT ... ON CONFLICT ... RETURNING` against a registered
-/// provider. The provider must capture an exact post-image; this helper does
-/// not permit a successful mutation to return only its affected count.
-pub(crate) async fn execute_spec_upsert_with_returning(
-    table: &Arc<dyn TableProvider>,
-    input: &Arc<dyn ExecutionPlan>,
-    proposed_batches: Vec<datafusion::arrow::record_batch::RecordBatch>,
-    target_columns: &[String],
-    action: &UpsertAction,
-    returning: DmlReturning,
-) -> Result<u64, LixError> {
-    let provider = table
-        .as_any()
-        .downcast_ref::<spec::SpecTableProvider>()
-        .ok_or_else(|| {
-            LixError::new(
-                LixError::CODE_UNSUPPORTED_SQL,
-                "INSERT ON CONFLICT RETURNING is not supported on this table",
-            )
-        })?;
-    provider
-        .execute_upsert_with_returning(input, proposed_batches, target_columns, action, returning)
-        .await
-        .map_err(crate::sql2::error::datafusion_error_to_lix_error)
-}
-
-/// Plan an `INSERT ... RETURNING` against a registered table provider. The
-/// provider must explicitly implement post-image capture; this helper does
-/// not fall back to a count-only insert plan.
-pub(crate) async fn execute_spec_insert_with_returning(
-    table: &Arc<dyn TableProvider>,
-    state: &dyn datafusion::catalog::Session,
-    input: Arc<dyn ExecutionPlan>,
-    returning: DmlReturning,
-) -> Result<Arc<dyn ExecutionPlan>, LixError> {
-    let provider = table
-        .as_any()
-        .downcast_ref::<spec::SpecTableProvider>()
-        .ok_or_else(|| {
-            LixError::new(
-                LixError::CODE_UNSUPPORTED_SQL,
-                "INSERT RETURNING is not supported on this table",
-            )
-        })?;
-    provider
-        .insert_with_returning(state, input, returning)
-        .await
-        .map_err(crate::sql2::error::datafusion_error_to_lix_error)
-}
-
-/// Plan an `UPDATE ... RETURNING` against a registered table provider. The
-/// provider must explicitly implement post-image capture; this helper does
-/// not fall back to a count-only update plan.
-pub(crate) async fn execute_spec_update_with_returning(
-    table: &Arc<dyn TableProvider>,
-    state: &dyn datafusion::catalog::Session,
-    assignments: Vec<(String, datafusion::logical_expr::Expr)>,
-    filters: Vec<datafusion::logical_expr::Expr>,
-    returning: DmlReturning,
-) -> Result<Arc<dyn ExecutionPlan>, LixError> {
-    let provider = table
-        .as_any()
-        .downcast_ref::<spec::SpecTableProvider>()
-        .ok_or_else(|| {
-            LixError::new(
-                LixError::CODE_UNSUPPORTED_SQL,
-                "UPDATE RETURNING is not supported on this table",
-            )
-        })?;
-    provider
-        .update_with_returning(state, assignments, filters, returning)
-        .await
-        .map_err(crate::sql2::error::datafusion_error_to_lix_error)
-}
-
-/// Validate an `INSERT ... ON CONFLICT` against a registered table provider.
-pub(crate) async fn validate_spec_upsert(
-    table: &Arc<dyn TableProvider>,
-    input: &Arc<dyn ExecutionPlan>,
-    target_columns: &[String],
-) -> Result<(), LixError> {
-    let provider = table
-        .as_any()
-        .downcast_ref::<spec::SpecTableProvider>()
-        .ok_or_else(|| {
-            LixError::new(
-                LixError::CODE_UNSUPPORTED_SQL,
-                "INSERT ON CONFLICT is not supported on this table",
-            )
-        })?;
-    let _ = provider
-        .validate_upsert(input, target_columns)
-        .await
-        .map_err(crate::sql2::error::datafusion_error_to_lix_error)?;
-    Ok(())
-}
-
-/// Plan a DELETE with a pre-delete `RETURNING` projection against a registered
-/// spec provider.  The projection is captured by the provider's existing
-/// one-pass DML executor, not by a separate SELECT.
-pub(crate) async fn execute_spec_delete_with_returning(
-    table: &Arc<dyn TableProvider>,
-    state: &dyn datafusion::catalog::Session,
-    filters: Vec<datafusion::logical_expr::Expr>,
-    returning: DmlReturning,
-) -> Result<Arc<dyn ExecutionPlan>, LixError> {
-    let provider = table
-        .as_any()
-        .downcast_ref::<spec::SpecTableProvider>()
-        .ok_or_else(|| {
-            LixError::new(
-                LixError::CODE_UNSUPPORTED_SQL,
-                "DELETE RETURNING is not supported on this table",
-            )
-        })?;
-    provider
-        .delete_with_returning(state, filters, returning)
-        .await
-        .map_err(crate::sql2::error::datafusion_error_to_lix_error)
 }
 
 pub(crate) async fn register_read<C>(

--- a/packages/lix/src/sql2/providers/spec.rs
+++ b/packages/lix/src/sql2/providers/spec.rs
@@ -10,7 +10,7 @@
 //! per row, so the indirection has no effect on scan or write throughput.
 
 use std::any::Any;
-use std::collections::BTreeSet;
+use std::collections::{BTreeMap, BTreeSet};
 use std::future::Future;
 use std::ops::Range;
 use std::sync::atomic::{AtomicU64, Ordering as AtomicOrdering};
@@ -22,11 +22,10 @@ use datafusion::arrow::compute::{SortOptions, and, filter_record_batch, take};
 use datafusion::arrow::datatypes::{DataType, Field, Schema, SchemaRef};
 use datafusion::arrow::record_batch::RecordBatch;
 use datafusion::catalog::{Session, TableProvider};
-use datafusion::common::{DFSchema, DataFusionError, Result, SchemaExt, not_impl_err};
+use datafusion::common::{DFSchema, DataFusionError, Result, SchemaExt};
 use datafusion::datasource::TableType;
 use datafusion::execution::TaskContext;
 use datafusion::execution::context::ExecutionProps;
-use datafusion::logical_expr::dml::InsertOp;
 use datafusion::logical_expr::{Expr, TableProviderFilterPushDown};
 use datafusion::physical_expr::expressions::Column;
 use datafusion::physical_expr::{
@@ -510,7 +509,16 @@ pub(super) fn register_spec_table(
     spec: Arc<dyn TableSpec>,
     write_access: WriteAccess,
 ) -> Result<(), LixError> {
-    let provider = Arc::new(SpecTableProvider::new(spec, write_access));
+    if let Some(write_ctx) = write_access.into_write_context() {
+        write_ctx.write_targets()?.register(
+            surface_name,
+            Arc::new(SpecWriteTarget::new(
+                Arc::clone(&spec),
+                write_ctx.into_physical_target(),
+            )),
+        )?;
+    }
+    let provider = Arc::new(SpecTableProvider::new(spec));
     if let Some(anchor_column) = provider.history_anchor_column() {
         return super::history_table_function::register_history_table_function(
             session,
@@ -529,27 +537,158 @@ pub(super) struct SpecTableProvider {
     provider_id: u64,
     spec: Arc<dyn TableSpec>,
     schema: SchemaRef,
-    write_access: WriteAccess,
 }
 
 impl SpecTableProvider {
-    pub(super) fn new(spec: Arc<dyn TableSpec>, write_access: WriteAccess) -> Self {
+    pub(super) fn new(spec: Arc<dyn TableSpec>) -> Self {
         static NEXT_PROVIDER_ID: AtomicU64 = AtomicU64::new(0);
         Self {
             provider_id: NEXT_PROVIDER_ID.fetch_add(1, AtomicOrdering::Relaxed),
             schema: spec.schema(),
             spec,
-            write_access,
         }
     }
 
     pub(super) fn history_anchor_column(&self) -> Option<&'static str> {
         self.spec.history_anchor_column()
     }
+}
 
-    #[cfg(test)]
-    pub(super) fn is_write(&self) -> bool {
-        self.write_access.is_write()
+/// Transaction-scoped physical targets selected by Lix's bound write plan.
+///
+/// DataFusion table providers never receive this registry and therefore cannot
+/// acquire mutation authority through the public `TableProvider` boundary.
+#[derive(Default)]
+pub(crate) struct WriteTargetRegistry {
+    targets: Mutex<BTreeMap<String, Arc<SpecWriteTarget>>>,
+}
+
+impl WriteTargetRegistry {
+    fn register(&self, name: &str, target: Arc<SpecWriteTarget>) -> Result<(), LixError> {
+        let mut targets = self.targets.lock().map_err(|_| {
+            LixError::unknown("SQL physical write-target registry lock was poisoned")
+        })?;
+        if targets.insert(name.to_string(), target).is_some() {
+            return Err(LixError::unknown(format!(
+                "SQL physical write target '{name}' was registered more than once"
+            )));
+        }
+        Ok(())
+    }
+
+    pub(crate) fn target(&self, name: &str) -> Result<Arc<SpecWriteTarget>, LixError> {
+        self.targets
+            .lock()
+            .map_err(|_| LixError::unknown("SQL physical write-target registry lock was poisoned"))?
+            .get(name)
+            .cloned()
+            .ok_or_else(|| {
+                LixError::new(
+                    LixError::CODE_UNSUPPORTED_SQL,
+                    format!("SQL table '{name}' is not a writable Lix surface"),
+                )
+            })
+    }
+}
+
+/// The physical mutation capability behind one bound Lix SQL surface.
+///
+/// RETURNING and ON CONFLICT semantics remain in Lix's bound executor; this
+/// target only plans and stages the selected surface's physical operation.
+pub(crate) struct SpecWriteTarget {
+    spec: Arc<dyn TableSpec>,
+    schema: SchemaRef,
+    write_ctx: SqlWriteContext,
+}
+
+impl SpecWriteTarget {
+    fn new(spec: Arc<dyn TableSpec>, write_ctx: SqlWriteContext) -> Self {
+        Self {
+            schema: spec.schema(),
+            spec,
+            write_ctx,
+        }
+    }
+
+    pub(crate) async fn insert(
+        &self,
+        input: Arc<dyn ExecutionPlan>,
+    ) -> Result<Arc<dyn ExecutionPlan>> {
+        let table = self.spec.table_name();
+        self.schema
+            .logically_equivalent_names_and_types(&input.schema())?;
+        let omitted_insert_columns = self.write_ctx.explicit_insert_columns().map_or_else(
+            || InsertColumnIntents::from_input(&input).omitted_columns(self.schema.as_ref()),
+            |explicit_columns| {
+                self.schema
+                    .fields()
+                    .iter()
+                    .filter(|field| !explicit_columns.contains(field.name().as_str()))
+                    .map(|field| field.name().clone())
+                    .collect()
+            },
+        );
+        let sink: Arc<dyn InsertSink> = match self
+            .spec
+            .plan_insert(self.write_ctx.clone(), &input)
+            .await?
+        {
+            Some(apply) => Arc::new(PlannedInsertSink {
+                table: table.into(),
+                apply,
+                omitted_insert_columns,
+            }),
+            None => Arc::new(SpecInsertSink {
+                spec: Arc::clone(&self.spec),
+                write_ctx: self.write_ctx.clone(),
+                omitted_insert_columns,
+            }),
+        };
+        Ok(Arc::new(InsertExec::new(input, sink)))
+    }
+
+    pub(crate) async fn update(
+        &self,
+        state: &dyn Session,
+        assignments: Vec<(String, Expr)>,
+        filters: Vec<Expr>,
+    ) -> Result<Arc<dyn ExecutionPlan>> {
+        let table = self.spec.table_name();
+        self.spec.validate_update_assignments(&assignments)?;
+        let filters = self.spec.prepare_write_filters(filters)?;
+        let df_schema = DFSchema::try_from(Arc::clone(&self.schema))?;
+        let physical_assignments = assignments
+            .iter()
+            .map(|(column_name, expr)| {
+                Ok((
+                    column_name.clone(),
+                    create_physical_expr(expr, &df_schema, state.execution_props())?,
+                ))
+            })
+            .collect::<Result<Vec<_>>>()?;
+        let physical_filters = filters
+            .iter()
+            .map(|expr| create_physical_expr(expr, &df_schema, state.execution_props()))
+            .collect::<Result<Vec<_>>>()?;
+        let planned = self
+            .spec
+            .plan_update(self.write_ctx.clone(), physical_assignments, &filters)
+            .await?;
+        Ok(Arc::new(SpecDmlExec::new(
+            table.into(),
+            "UPDATE",
+            planned,
+            physical_filters,
+            None,
+        )))
+    }
+
+    pub(crate) async fn delete(
+        &self,
+        state: &dyn Session,
+        filters: Vec<Expr>,
+    ) -> Result<Arc<dyn ExecutionPlan>> {
+        self.delete_impl(state, filters, None).await
     }
 
     /// Execute an `INSERT ... ON CONFLICT` against this table. The conflict
@@ -562,8 +701,8 @@ impl SpecTableProvider {
         target_columns: &[String],
         action: &upsert::UpsertAction,
     ) -> Result<u64> {
-        let (write_ctx, support, target) = self.validate_upsert(input, target_columns).await?;
-        upsert::execute_upsert(support, &write_ctx, proposed_batches, &target, action).await
+        let (support, target) = self.validate_upsert(input, target_columns).await?;
+        upsert::execute_upsert(support, &self.write_ctx, proposed_batches, &target, action).await
     }
 
     /// Execute an `INSERT ... ON CONFLICT ... RETURNING` through the shared
@@ -577,10 +716,10 @@ impl SpecTableProvider {
         action: &upsert::UpsertAction,
         returning: DmlReturning,
     ) -> Result<u64> {
-        let (write_ctx, support, target) = self.validate_upsert(input, target_columns).await?;
+        let (support, target) = self.validate_upsert(input, target_columns).await?;
         upsert::execute_upsert_with_returning(
             support,
-            &write_ctx,
+            &self.write_ctx,
             proposed_batches,
             &target,
             action,
@@ -589,27 +728,28 @@ impl SpecTableProvider {
         .await
     }
 
-    pub(crate) async fn validate_upsert(
+    async fn validate_upsert(
         &self,
         input: &Arc<dyn ExecutionPlan>,
         target_columns: &[String],
-    ) -> Result<(
-        SqlWriteContext,
-        &dyn upsert::UpsertSupport,
-        upsert::UpsertConflictTarget,
-    )> {
+    ) -> Result<(&dyn upsert::UpsertSupport, upsert::UpsertConflictTarget)> {
         let table = self.spec.table_name();
-        let write_ctx = self
-            .write_access
-            .require_write(&format!("INSERT into {table}"))?;
         self.schema
             .logically_equivalent_names_and_types(&input.schema())?;
         let support = self.spec.upsert_support().ok_or_else(|| {
             DataFusionError::Execution(format!("INSERT ON CONFLICT is not supported on {table}"))
         })?;
         let target = support.resolve_conflict_target(table, target_columns)?;
-        self.spec.plan_insert(write_ctx.clone(), input).await?;
-        Ok((write_ctx, support, target))
+        self.spec.plan_insert(self.write_ctx.clone(), input).await?;
+        Ok((support, target))
+    }
+
+    pub(crate) async fn validate_upsert_target(
+        &self,
+        input: &Arc<dyn ExecutionPlan>,
+        target_columns: &[String],
+    ) -> Result<()> {
+        self.validate_upsert(input, target_columns).await.map(drop)
     }
 
     pub(crate) async fn delete_with_returning(
@@ -632,12 +772,9 @@ impl SpecTableProvider {
         returning: DmlReturning,
     ) -> Result<Arc<dyn ExecutionPlan>> {
         let table = self.spec.table_name();
-        let write_ctx = self
-            .write_access
-            .require_write(&format!("INSERT into {table}"))?;
         self.schema
             .logically_equivalent_names_and_types(&input.schema())?;
-        let omitted_insert_columns = write_ctx.explicit_insert_columns().map_or_else(
+        let omitted_insert_columns = self.write_ctx.explicit_insert_columns().map_or_else(
             || InsertColumnIntents::from_input(&input).omitted_columns(self.schema.as_ref()),
             |explicit_columns| {
                 self.schema
@@ -650,7 +787,7 @@ impl SpecTableProvider {
         );
         let apply = self
             .spec
-            .plan_insert_with_returning(write_ctx, &input, returning)
+            .plan_insert_with_returning(self.write_ctx.clone(), &input, returning)
             .await?;
         let sink: Arc<dyn InsertSink> = Arc::new(PlannedInsertSink {
             table: table.into(),
@@ -671,9 +808,6 @@ impl SpecTableProvider {
         returning: DmlReturning,
     ) -> Result<Arc<dyn ExecutionPlan>> {
         let table = self.spec.table_name();
-        let write_ctx = self
-            .write_access
-            .require_write(&format!("UPDATE {table}"))?;
         self.spec.validate_update_assignments(&assignments)?;
         let filters = self.spec.prepare_write_filters(filters)?;
         let df_schema = DFSchema::try_from(Arc::clone(&self.schema))?;
@@ -692,7 +826,12 @@ impl SpecTableProvider {
             .collect::<Result<Vec<_>>>()?;
         let planned = self
             .spec
-            .plan_update_with_returning(write_ctx, physical_assignments, &filters, returning)
+            .plan_update_with_returning(
+                self.write_ctx.clone(),
+                physical_assignments,
+                &filters,
+                returning,
+            )
             .await?;
         Ok(Arc::new(SpecDmlExec::new(
             table.into(),
@@ -710,15 +849,12 @@ impl SpecTableProvider {
         returning: Option<DmlReturning>,
     ) -> Result<Arc<dyn ExecutionPlan>> {
         let table = self.spec.table_name();
-        let write_ctx = self
-            .write_access
-            .require_write(&format!("DELETE FROM {table}"))?;
         let filters = self.spec.prepare_write_filters(filters)?;
         let physical_filters = physical_filters(&self.schema, &filters, state)?;
         let planned = self
             .spec
             .plan_delete_with_options(
-                write_ctx,
+                self.write_ctx.clone(),
                 &filters,
                 DmlPlanOptions::from_returning(returning.as_ref()),
             )
@@ -737,7 +873,6 @@ impl std::fmt::Debug for SpecTableProvider {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("SpecTableProvider")
             .field("table", &self.spec.table_name())
-            .field("write", &self.write_access.is_write())
             .finish_non_exhaustive()
     }
 }
@@ -801,95 +936,6 @@ impl TableProvider for SpecTableProvider {
             state.config().target_partitions(),
             statement_cache_key,
             physical_cache_key,
-        )))
-    }
-
-    async fn insert_into(
-        &self,
-        _state: &dyn Session,
-        input: Arc<dyn ExecutionPlan>,
-        insert_op: InsertOp,
-    ) -> Result<Arc<dyn ExecutionPlan>> {
-        let table = self.spec.table_name();
-        if insert_op != InsertOp::Append {
-            return not_impl_err!("{insert_op} not implemented for {table} yet");
-        }
-        let write_ctx = self
-            .write_access
-            .require_write(&format!("INSERT into {table}"))?;
-        self.schema
-            .logically_equivalent_names_and_types(&input.schema())?;
-        let omitted_insert_columns = write_ctx.explicit_insert_columns().map_or_else(
-            || InsertColumnIntents::from_input(&input).omitted_columns(self.schema.as_ref()),
-            |explicit_columns| {
-                self.schema
-                    .fields()
-                    .iter()
-                    .filter(|field| !explicit_columns.contains(field.name().as_str()))
-                    .map(|field| field.name().clone())
-                    .collect()
-            },
-        );
-        let sink: Arc<dyn InsertSink> =
-            match self.spec.plan_insert(write_ctx.clone(), &input).await? {
-                Some(apply) => Arc::new(PlannedInsertSink {
-                    table: table.into(),
-                    apply,
-                    omitted_insert_columns,
-                }),
-                None => Arc::new(SpecInsertSink {
-                    spec: Arc::clone(&self.spec),
-                    write_ctx,
-                    omitted_insert_columns,
-                }),
-            };
-        Ok(Arc::new(InsertExec::new(input, sink)))
-    }
-
-    async fn delete_from(
-        &self,
-        state: &dyn Session,
-        filters: Vec<Expr>,
-    ) -> Result<Arc<dyn ExecutionPlan>> {
-        self.delete_impl(state, filters, None).await
-    }
-
-    async fn update(
-        &self,
-        state: &dyn Session,
-        assignments: Vec<(String, Expr)>,
-        filters: Vec<Expr>,
-    ) -> Result<Arc<dyn ExecutionPlan>> {
-        let table = self.spec.table_name();
-        let write_ctx = self
-            .write_access
-            .require_write(&format!("UPDATE {table}"))?;
-        self.spec.validate_update_assignments(&assignments)?;
-        let filters = self.spec.prepare_write_filters(filters)?;
-        let df_schema = DFSchema::try_from(Arc::clone(&self.schema))?;
-        let physical_assignments = assignments
-            .iter()
-            .map(|(column_name, expr)| {
-                Ok((
-                    column_name.clone(),
-                    create_physical_expr(expr, &df_schema, state.execution_props())?,
-                ))
-            })
-            .collect::<Result<Vec<_>>>()?;
-        let physical_filters = filters
-            .iter()
-            .map(|expr| create_physical_expr(expr, &df_schema, state.execution_props()))
-            .collect::<Result<Vec<_>>>()?;
-        let planned = self
-            .spec
-            .plan_update(write_ctx, physical_assignments, &filters)
-            .await?;
-        Ok(Arc::new(SpecDmlExec::new(
-            table.into(),
-            "UPDATE",
-            planned,
-            physical_filters,
-            None,
         )))
     }
 }
@@ -1576,10 +1622,7 @@ mod scan_source_tests {
         });
         let session = crate::sql2::session::new_sql_session_context();
         session
-            .register_table(
-                "counted",
-                Arc::new(SpecTableProvider::new(spec, WriteAccess::read_only())),
-            )
+            .register_table("counted", Arc::new(SpecTableProvider::new(spec)))
             .expect("counted test table should register");
         let dataframe = session
             .sql(

--- a/packages/lix/src/sql2/session.rs
+++ b/packages/lix/src/sql2/session.rs
@@ -2,6 +2,7 @@ use datafusion::execution::session_state::SessionStateBuilder;
 use datafusion::prelude::{SessionConfig, SessionContext};
 use datafusion::sql::parser::Statement as DataFusionStatement;
 use std::collections::BTreeSet;
+use std::ops::Deref;
 use std::sync::Arc;
 
 use crate::LixError;
@@ -134,14 +135,37 @@ pub(crate) struct SqlWriteSessionOptions {
     pub(crate) explicit_insert_columns: Option<BTreeSet<String>>,
 }
 
+pub(crate) struct SqlWriteSession {
+    datafusion: SessionContext,
+    write_targets: Arc<providers::WriteTargetRegistry>,
+}
+
+impl SqlWriteSession {
+    pub(crate) fn write_target(
+        &self,
+        table_name: &str,
+    ) -> Result<Arc<providers::SpecWriteTarget>, LixError> {
+        self.write_targets.target(table_name)
+    }
+}
+
+impl Deref for SqlWriteSession {
+    type Target = SessionContext;
+
+    fn deref(&self) -> &Self::Target {
+        &self.datafusion
+    }
+}
+
 pub(crate) async fn build_write_session_with_options(
     ctx: &mut dyn SqlWriteExecutionContext,
     options: SqlWriteSessionOptions,
     provider_selection: &providers::ProviderSelection,
-) -> Result<SessionContext, LixError> {
+) -> Result<SqlWriteSession, LixError> {
     let session = ctx.datafusion_session();
     let write_ctx = SqlWriteContext::new(ctx)
         .with_explicit_insert_columns(options.explicit_insert_columns.clone());
+    let write_targets = write_ctx.write_targets()?;
     let active_branch_id = write_ctx.active_branch_id();
     let branch_ref: Arc<dyn BranchRefReader> = Arc::new(CachingBranchRefReader::new(Arc::new(
         super::WriteContextBranchRefReader::new(write_ctx.clone()),
@@ -166,7 +190,10 @@ pub(crate) async fn build_write_session_with_options(
     );
     providers::register_write(&session, write_ctx, branch_ref, options, provider_selection).await?;
 
-    Ok(session)
+    Ok(SqlWriteSession {
+        datafusion: session,
+        write_targets,
+    })
 }
 
 pub(crate) fn new_sql_session_context() -> SessionContext {

--- a/packages/rs-sdk-tests/tests/e2e.rs
+++ b/packages/rs-sdk-tests/tests/e2e.rs
@@ -14,9 +14,9 @@ use lix::wasm::{
     WasmTransitionLimits,
 };
 use lix::{
-    CreateBranchOptions, ExecuteOptions, ExecuteStatementMetadata, Lix, LixError,
-    MergeBranchOptions, MergeBranchPreviewOptions, MergeConflictChangeKind, MutationIdentity,
-    RequestBlobSpliceProvenance, SwitchBranchOptions, VerifiedRequestBlob,
+    CreateBranchOptions, ExecuteBatchStatement, ExecuteOptions, ExecuteStatementMetadata, Lix,
+    LixError, MergeBranchOptions, MergeBranchPreviewOptions, MergeConflictChangeKind,
+    MutationIdentity, RequestBlobSpliceProvenance, SwitchBranchOptions, VerifiedRequestBlob,
 };
 use lix::{Value, open_lix};
 use lix_storage_filesystem::LocalFilesystem;
@@ -8760,6 +8760,242 @@ async fn open_slatedb_lix(path: &Path) -> Lix<SlateDB> {
         .with_storage(storage)
         .await
         .expect("open Lix workspace")
+}
+
+async fn qualify_lix_owned_sql_write_semantics<S>(lix: &Lix<S>, prefix: &str)
+where
+    S: Storage + Clone + Send + Sync + 'static,
+{
+    lix.execute(
+        "INSERT INTO lix_registered_schema (value) VALUES (lix_json($1))",
+        &[Value::Text(
+            r#"{"x-lix-key":"write_owner_task","x-lix-primary-key":["/id"],"type":"object","properties":{"id":{"type":"string","x-lix-default":"lix_uuid_v7()"},"title":{"type":"string"}},"required":["id","title"],"additionalProperties":false}"#.to_string(),
+        )],
+    )
+    .await
+    .expect("register generated-default write-owner schema");
+    lix.execute(
+        "INSERT INTO lix_registered_schema (value) VALUES (lix_json($1)), (lix_json($2))",
+        &[
+            Value::Text(
+                r#"{"x-lix-key":"write_owner_parent","x-lix-primary-key":["/id"],"type":"object","properties":{"id":{"type":"string"}},"required":["id"],"additionalProperties":false}"#.to_string(),
+            ),
+            Value::Text(
+                r#"{"x-lix-key":"write_owner_child","x-lix-primary-key":["/id"],"x-lix-foreign-keys":[{"properties":["/parent_id"],"references":{"schemaKey":"write_owner_parent","properties":["/id"]}}],"type":"object","properties":{"id":{"type":"string"},"parent_id":{"type":"string"}},"required":["id","parent_id"],"additionalProperties":false}"#.to_string(),
+            ),
+        ],
+    )
+    .await
+    .expect("register foreign-key write-owner schemas");
+
+    let inserted = lix
+        .execute(
+            "INSERT INTO write_owner_task (title) VALUES ($1) RETURNING id, title",
+            &[Value::Text(format!("{prefix}-inserted"))],
+        )
+        .await
+        .expect("INSERT RETURNING with generated default");
+    assert_eq!(inserted.rows_affected(), 1);
+    let id = inserted.rows()[0]
+        .get::<String>("id")
+        .expect("generated RETURNING id");
+
+    let updated = lix
+        .execute(
+            "UPDATE write_owner_task SET title = $1 WHERE id = $2 RETURNING id, title",
+            &[
+                Value::Text(format!("{prefix}-updated")),
+                Value::Text(id.clone()),
+            ],
+        )
+        .await
+        .expect("UPDATE RETURNING");
+    assert_eq!(updated.rows_affected(), 1);
+
+    let upserted = lix
+        .execute(
+            "INSERT INTO write_owner_task (id, title) VALUES ($1, $2) \
+             ON CONFLICT (id) DO UPDATE SET title = excluded.title RETURNING id, title",
+            &[
+                Value::Text(id.clone()),
+                Value::Text(format!("{prefix}-upserted")),
+            ],
+        )
+        .await
+        .expect("ON CONFLICT RETURNING");
+    assert_eq!(upserted.rows_affected(), 1);
+    assert_eq!(
+        upserted.rows()[0].get::<String>("title").unwrap(),
+        format!("{prefix}-upserted")
+    );
+
+    let deleted = lix
+        .execute(
+            "DELETE FROM write_owner_task WHERE id = $1 RETURNING id, title",
+            &[Value::Text(id)],
+        )
+        .await
+        .expect("DELETE RETURNING");
+    assert_eq!(deleted.rows_affected(), 1);
+    assert_eq!(deleted.rows().len(), 1);
+
+    let fk_error = lix
+        .execute(
+            "INSERT INTO write_owner_child (id, parent_id) VALUES ($1, $2)",
+            &[
+                Value::Text(format!("{prefix}-child")),
+                Value::Text(format!("{prefix}-missing-parent")),
+            ],
+        )
+        .await
+        .expect_err("missing foreign-key owner must fail");
+    assert_eq!(fk_error.code, LixError::CODE_FOREIGN_KEY);
+
+    let batch_key = format!("{prefix}-batch");
+    let batch = lix
+        .execute_batch(&[
+            ExecuteBatchStatement {
+                label: Some("write".to_string()),
+                sql: "INSERT INTO lix_key_value (key, value) VALUES ($1, $2) RETURNING key, value"
+                    .to_string(),
+                params: vec![
+                    Value::Text(batch_key.clone()),
+                    Value::Text("one".to_string()),
+                ],
+            },
+            ExecuteBatchStatement {
+                label: Some("upsert".to_string()),
+                sql: "INSERT INTO lix_key_value (key, value) VALUES ($1, $2) \
+                      ON CONFLICT (key) DO UPDATE SET value = excluded.value RETURNING key, value"
+                    .to_string(),
+                params: vec![
+                    Value::Text(batch_key.clone()),
+                    Value::Text("two".to_string()),
+                ],
+            },
+        ])
+        .await
+        .expect("execute_batch write semantics");
+    assert_eq!(batch.len(), 2);
+    assert_eq!(batch[0].statement_index(), Some(0));
+    assert_eq!(batch[0].label(), Some("write"));
+    assert_eq!(batch[1].statement_index(), Some(1));
+    assert_eq!(batch[1].label(), Some("upsert"));
+
+    let rollback_key = format!("{prefix}-rollback");
+    let mut rollback = lix.begin_transaction().await.expect("begin rollback tx");
+    rollback
+        .execute(
+            "INSERT INTO lix_key_value (key, value) VALUES ($1, 'rollback') RETURNING key",
+            &[Value::Text(rollback_key.clone())],
+        )
+        .await
+        .expect("stage rollback RETURNING");
+    rollback
+        .rollback()
+        .await
+        .expect("rollback write transaction");
+    assert!(
+        lix.execute(
+            "SELECT key FROM lix_key_value WHERE key = $1",
+            &[Value::Text(rollback_key)],
+        )
+        .await
+        .unwrap()
+        .is_empty()
+    );
+}
+
+async fn qualify_stale_sql_write_owner<S>(stale_lix: &Lix<S>, winner_lix: &Lix<S>, prefix: &str)
+where
+    S: Storage + Clone + Send + Sync + 'static,
+{
+    let stale_key = format!("{prefix}-stale");
+    let mut stale = stale_lix.begin_transaction().await.expect("begin stale tx");
+    stale
+        .execute(
+            "INSERT INTO lix_key_value (key, value) VALUES ($1, 'stale')",
+            &[Value::Text(stale_key.clone())],
+        )
+        .await
+        .expect("stage stale owner");
+    winner_lix
+        .execute(
+            "INSERT INTO lix_key_value (key, value) VALUES ($1, 'winner')",
+            &[Value::Text(stale_key)],
+        )
+        .await
+        .expect("publish winner owner");
+    assert_eq!(
+        stale
+            .commit()
+            .await
+            .expect_err("stale owner must conflict")
+            .code,
+        LixError::CODE_UNIQUE
+    );
+}
+
+#[tokio::test]
+async fn lix_owned_sql_write_semantics_rocksdb_reopen() {
+    let root = tempfile::tempdir().expect("create SQL write-owner RocksDB directory");
+    let lix = open_rocksdb_lix(root.path()).await;
+    qualify_lix_owned_sql_write_semantics(&lix, "rocks").await;
+    let winner = lix
+        .open_workspace_session()
+        .await
+        .expect("open winner RocksDB session");
+    qualify_stale_sql_write_owner(&lix, &winner, "rocks").await;
+    winner.close().await.expect("close winner RocksDB handle");
+    lix.close().await.expect("close SQL write-owner RocksDB");
+    let reopened = open_rocksdb_lix(root.path()).await;
+    let result = reopened
+        .execute(
+            "SELECT value FROM lix_key_value WHERE key = 'rocks-batch'",
+            &[],
+        )
+        .await
+        .expect("read SQL write-owner RocksDB after reopen");
+    assert_eq!(
+        result.rows()[0].get::<serde_json::Value>("value").unwrap(),
+        serde_json::json!("two")
+    );
+    reopened.close().await.unwrap();
+}
+
+#[tokio::test]
+async fn lix_owned_sql_write_semantics_slatedb_reopen() {
+    let root = tempfile::tempdir().expect("create SQL write-owner SlateDB directory");
+    let storage = SlateDB::open(root.path().join(".lix")).expect("open SQL write-owner SlateDB");
+    let lix = open_lix()
+        .with_storage(storage.clone())
+        .await
+        .expect("open SQL write-owner workspace");
+    qualify_lix_owned_sql_write_semantics(&lix, "slate").await;
+    let winner = lix
+        .open_workspace_session()
+        .await
+        .expect("open winner SlateDB session");
+    qualify_stale_sql_write_owner(&lix, &winner, "slate").await;
+    winner.close().await.expect("close winner SlateDB handle");
+    storage
+        .flush()
+        .await
+        .expect("flush SQL write-owner SlateDB before reopen");
+    lix.close().await.expect("close SQL write-owner SlateDB");
+    let reopened = open_slatedb_lix(root.path()).await;
+    let result = reopened
+        .execute(
+            "SELECT value FROM lix_key_value WHERE key = 'slate-batch'",
+            &[],
+        )
+        .await
+        .expect("read SQL write-owner SlateDB after reopen");
+    assert_eq!(
+        result.rows()[0].get::<serde_json::Value>("value").unwrap(),
+        serde_json::json!("two")
+    );
+    reopened.close().await.unwrap();
 }
 
 fn p50_ms(sorted: &[f64]) -> f64 {


### PR DESCRIPTION
## Summary

- keep Lix's existing parser, binder, logical write plan, and dispatcher as the sole semantic owner for `RETURNING` and `INSERT ... ON CONFLICT`
- make DataFusion `TableProvider` implementations read-only and register exact transaction-scoped physical write targets separately
- delete provider mutation methods and the provider-downcast helper path; preserve the existing single transaction staging/commit boundary
- add public-API RocksDB and SlateDB coverage for generated defaults, FK errors, RETURNING/UPSERT, batch identity, rollback, stale writers, and cold reopen

## Authority checklist

- [x] no DataFusion `TableProvider` INSERT/UPDATE/DELETE implementation remains
- [x] no mutation capability is recovered by provider downcast
- [x] bound target selection chooses exactly one physical target
- [x] physical targets cannot own the target registry (acyclic session → registry → target → transaction capability)
- [x] no cache, compatibility route, mirror writer, persisted format, or second commit boundary
- [x] public APIs and observable SQL behavior preserved
- [x] no ForkTree, tracked-state, or storage-layout source touched

## Immutable provenance

- Exact performance baseline: `4763408467d265b288a124e24b1d47be423f5d17` (tree `a2a261220fb08f88ac44ca7776b2bc7ba7d6441c`)
- One-time integration base: `e8713ed191e05d29c44dbc8e7ce1d6b1a11695e7` (tree `ce241a0af016cadcb0c21d2d754eb3d4291cf79c`)
- Exact final head: `97c0f98088798232eacb16bc555a72ed59d62e46` (tree `2ae6ffd8faef595ca9bf2e60447ef31a8922b92f`)
- Integration parents: (`7061aad7f4b14e611b32bbe5493f39253b826378`, `e8713ed191e05d29c44dbc8e7ce1d6b1a11695e7`)
- Final base..head full-index binary diff SHA-256: `fa74c557636e14493a937a6e46dc77c26acb3f0938659eb93be64633956c951d`
- Stable patch ID: `30715df6569090e30c4520bf3e055bb67ff74049`

## Complexity

Current and proposed row/expression complexity is unchanged at `O(R + E)`, where `R` is affected/input rows and `E` is expression/filter work. Physical-target selection is one statement-level lookup and adds no per-row, adapter, or disk work. This is an authority deletion, not a speed claim.

## Exact RocksDB + SlateDB A/B

The external identical harness ran public `INSERT/UPDATE/DELETE ... RETURNING`, `ON CONFLICT DO UPDATE`, `ON CONFLICT DO NOTHING`, and one atomic 18-statement `execute_batch`. Setup, hashing, reopen/flush, and disk settling were outside the measured operation. 1K used 11 samples per exact revision; 10K used 7. Values below are p50 wall milliseconds, baseline → head (change).

| Backend / rows | INSERT | UPDATE | DELETE | CONFLICT UPDATE | DO NOTHING | batch-18 |
| --- | ---: | ---: | ---: | ---: | ---: | ---: |
| RocksDB / 1K | 8.409 → 8.310 (-1.175%) | 5.414 → 5.372 (-0.773%) | 8.019 → 8.295 (**+3.448%**) | 10.736 → 10.655 (-0.752%) | 6.774 → 6.844 (+1.024%) | 8.594 → 8.533 (-0.717%) |
| SlateDB / 1K | 8.583 → 8.569 (-0.169%) | 5.696 → 5.765 (+1.220%) | 8.456 → 8.424 (-0.373%) | 10.972 → 10.854 (-1.072%) | 6.945 → 6.927 (-0.261%) | 8.821 → 8.793 (-0.314%) |
| RocksDB / 10K | 57.502 → 56.055 (-2.517%) | 42.859 → 42.818 (-0.097%) | 68.869 → 67.916 (-1.384%) | 288.674 → 287.394 (-0.443%) | 250.650 → 252.522 (+0.747%) | 52.947 → 53.141 (+0.366%) |
| SlateDB / 10K | 59.518 → 60.937 (+2.385%) | 43.413 → 43.211 (-0.465%) | 67.746 → 67.658 (-0.129%) | 287.669 → 286.994 (-0.235%) | 249.972 → 252.629 (+1.063%) | 53.154 → 53.095 (-0.111%) |

No critical axis regressed by 5%:

- worst wall tradeoff: **+3.448%**; worst process CPU: +3.369%
- allocation calls: at most +0.011%; allocated bytes: at most +0.011%; peak live allocation: identical
- absolute peak RSS: at most +1.777% (largest absolute change was a 4.401% reduction)
- logical backend calls/rows: identical; read/write bytes changed by at most 0.012% absolute
- SlateDB physical read/write object counts: identical; physical bytes changed by at most 0.012% absolute
- settled disk: worst regression +0.026%; largest absolute change 0.160%

All 432 measured records had exact affected-row counts, RETURNING shape/order, final state, and `execute_batch` statement-index/label ordering. Every backend/scale/workload group produced one shared result digest and one shared final-state digest across baseline and head.

## Verification

- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo check -p lix --lib --no-default-features`
- `cargo check -p lix --lib`
- `cargo clippy --profile test --workspace --all-targets --all-features -- -D warnings`
- `cargo test -p lix --lib sql2::` — 459 passed, 1 ignored benchmark probe
- `cargo test -p lix --lib execute_batch` — 22 passed
- `cargo test -p lix --test integration sql::write_returning::` — 4 passed
- `cargo test -p lix --features all-simulations --test integration sql::write_returning::` — 8 passed
- `cargo test -p lix_tests --test rust_sdk_api execute_batch_is_atomic_and_returns_ordered_results`
- `cargo test -p lix_tests --test rust_sdk_api execute_batch_indexes_all_eighteen_writes_and_echoes_labels`
- `cargo test -p lix_tests --test e2e lix_owned_sql_write_semantics_ -- --nocapture` — RocksDB + SlateDB, including cold reopen
- Hosted CI: run `31221205962`, 8/8 success at exact final head

The actual one-time #1260 integration tree `2ae6ffd8faef595ca9bf2e60447ef31a8922b92f` passed the conflict-sensitive SQL-write, branch-control, GC/CAS ownership, dual-adapter corruption, fmt/diff, and canonical warnings-denied Clippy gates. No production correction was required.

## Independent review

Ryzen-I returned immutable **APPROVE** for exact head `7061aad7f4b14e611b32bbe5493f39253b826378`, covering source authority, Memory/local-adapter/sql2 correctness, hosted 8/8 CI, and the frozen RocksDB/SlateDB A/B package.

