### PR TITLE
fix: preserve checkpointed branch merge ancestry

### DIFF
--- a/packages/engine-benchmarks/Cargo.toml
+++ b/packages/engine-benchmarks/Cargo.toml
@@ -115,6 +115,11 @@ path = "tests/checkpoint_gc_replay_reopen.rs"
 required-features = ["rocksdb", "slatedb"]
 
 [[test]]
+name = "checkpoint_branch_merge_reopen"
+path = "tests/checkpoint_branch_merge_reopen.rs"
+required-features = ["rocksdb", "slatedb"]
+
+[[test]]
 name = "cas_gc_history_retention"
 path = "tests/cas_gc_history_retention.rs"
 required-features = ["storage-benches", "slatedb"]

--- a/packages/engine-benchmarks/tests/checkpoint_branch_merge_reopen.rs
+++ b/packages/engine-benchmarks/tests/checkpoint_branch_merge_reopen.rs
@@ -1,0 +1,245 @@
+use std::path::Path;
+
+use async_trait::async_trait;
+use lix::storage::Storage;
+use lix::{
+    CreateBranchOptions, Lix, MergeBranchOptions, MergeBranchOutcome, MergeBranchPreviewOptions,
+    MergeChangeStats, Value, open_lix,
+};
+use lix_storage_rocksdb::RocksDB;
+use lix_storage_slatedb::SlateDB;
+
+const SOURCE_BRANCH_ID: &str = "01990000-0000-7000-8000-0000000000c1";
+const SOURCE_KEY: &str = "checkpoint-fork-source";
+const TARGET_KEY: &str = "checkpoint-fork-target";
+
+#[async_trait]
+trait ReopenStorage: Storage + Clone + Send + Sync + Sized + 'static {
+    fn open(path: &Path) -> Self;
+    async fn flush(&self);
+}
+
+#[async_trait]
+impl ReopenStorage for RocksDB {
+    fn open(path: &Path) -> Self {
+        Self::open(path).expect("open RocksDB checkpoint-merge fixture")
+    }
+
+    async fn flush(&self) {
+        self.flush()
+            .expect("flush RocksDB checkpoint-merge fixture");
+    }
+}
+
+#[async_trait]
+impl ReopenStorage for SlateDB {
+    fn open(path: &Path) -> Self {
+        Self::open(path).expect("open SlateDB checkpoint-merge fixture")
+    }
+
+    async fn flush(&self) {
+        self.flush()
+            .await
+            .expect("flush SlateDB checkpoint-merge fixture");
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn rocksdb_checkpoint_preserves_branch_merge_base_after_reopen() {
+    checkpoint_preserves_branch_merge_base_after_reopen::<RocksDB>().await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn slatedb_checkpoint_preserves_branch_merge_base_after_reopen() {
+    checkpoint_preserves_branch_merge_base_after_reopen::<SlateDB>().await;
+}
+
+async fn checkpoint_preserves_branch_merge_base_after_reopen<S: ReopenStorage>() {
+    let temp = tempfile::tempdir().expect("create checkpoint-merge fixture");
+    let path = temp.path().join("database");
+    let initial_commit_id;
+    let fork_commit_id;
+    let checkpoint_commit_id;
+    let source_commit_id;
+
+    {
+        let storage = S::open(&path);
+        let main = open_lix()
+            .with_storage(storage.clone())
+            .await
+            .expect("initialize durable checkpoint-merge Lix");
+        initial_commit_id = active_commit_id(&main).await;
+        main.execute(
+            "INSERT INTO lix_key_value (key, value) VALUES \
+             ($1, 'shared-source'), ($2, 'shared-target')",
+            &[
+                Value::Text(SOURCE_KEY.to_owned()),
+                Value::Text(TARGET_KEY.to_owned()),
+            ],
+        )
+        .await
+        .expect("insert shared rows");
+        fork_commit_id = active_commit_id(&main).await;
+        checkpoint_commit_id = main
+            .create_checkpoint()
+            .await
+            .expect("checkpoint target branch")
+            .commit_id;
+        assert_eq!(
+            commit_parent_edges(&main, &checkpoint_commit_id).await,
+            vec![(initial_commit_id.clone(), 0)],
+        );
+
+        let branch = main
+            .create_branch(CreateBranchOptions {
+                id: Some(SOURCE_BRANCH_ID.to_owned()),
+                name: "Checkpoint merge source".to_owned(),
+                from_commit_id: Some(fork_commit_id.clone()),
+            })
+            .await
+            .expect("create source branch at pre-checkpoint head");
+        assert_eq!(branch.commit_id, fork_commit_id);
+
+        let source = main
+            .open_session(SOURCE_BRANCH_ID)
+            .await
+            .expect("open source branch");
+        source
+            .execute(
+                "UPDATE lix_key_value SET value = 'source' WHERE key = $1",
+                &[Value::Text(SOURCE_KEY.to_owned())],
+            )
+            .await
+            .expect("publish disjoint source edit");
+        source_commit_id = active_commit_id(&source).await;
+        assert_eq!(
+            commit_parent_edges(&main, &source_commit_id).await,
+            vec![
+                (fork_commit_id.clone(), 0),
+                (checkpoint_commit_id.clone(), 1),
+            ],
+        );
+        main.execute(
+            "UPDATE lix_key_value SET value = 'target' WHERE key = $1",
+            &[Value::Text(TARGET_KEY.to_owned())],
+        )
+        .await
+        .expect("publish disjoint target edit");
+
+        source.close().await.expect("close source session");
+        main.close().await.expect("close main session");
+        drop(source);
+        drop(main);
+        storage.flush().await;
+    }
+
+    let storage = S::open(&path);
+    let main = open_lix()
+        .with_storage(storage.clone())
+        .await
+        .expect("cold reopen durable checkpoint-merge Lix");
+    assert_eq!(
+        commit_parent_edges(&main, &checkpoint_commit_id).await,
+        vec![(initial_commit_id, 0)],
+    );
+    assert_eq!(
+        commit_parent_edges(&main, &source_commit_id).await,
+        vec![
+            (fork_commit_id.clone(), 0),
+            (checkpoint_commit_id.clone(), 1),
+        ],
+    );
+    let preview = main
+        .merge_branch_preview(MergeBranchPreviewOptions {
+            source_branch_id: SOURCE_BRANCH_ID.to_owned(),
+        })
+        .await
+        .expect("disjoint merge preview after cold reopen");
+    assert_eq!(preview.base_commit_id, checkpoint_commit_id);
+    assert_eq!(preview.outcome, MergeBranchOutcome::MergeCommitted);
+    assert!(preview.conflicts.is_empty());
+    assert_eq!(
+        preview.change_stats,
+        MergeChangeStats {
+            total: 1,
+            added: 0,
+            modified: 1,
+            removed: 0,
+        }
+    );
+
+    let receipt = main
+        .merge_branch(MergeBranchOptions {
+            source_branch_id: SOURCE_BRANCH_ID.to_owned(),
+        })
+        .await
+        .expect("merge disjoint source after cold reopen");
+    assert_eq!(receipt.base_commit_id, preview.base_commit_id);
+    assert_value(&main, SOURCE_KEY, "source").await;
+    assert_value(&main, TARGET_KEY, "target").await;
+    main.close().await.expect("close reopened main session");
+    drop(main);
+    storage.flush().await;
+}
+
+async fn active_commit_id<S>(lix: &Lix<S>) -> String
+where
+    S: Storage + Clone + Send + Sync + 'static,
+{
+    let branch_id = lix
+        .active_branch_id()
+        .await
+        .expect("active branch resolves");
+    let result = lix
+        .execute(
+            "SELECT commit_id FROM lix_branch WHERE id = $1",
+            &[Value::Text(branch_id)],
+        )
+        .await
+        .expect("active commit reads");
+    result.rows()[0]
+        .get::<String>("commit_id")
+        .expect("active commit id decodes")
+}
+
+async fn commit_parent_edges<S>(lix: &Lix<S>, commit_id: &str) -> Vec<(String, i64)>
+where
+    S: Storage + Clone + Send + Sync + 'static,
+{
+    lix.execute(
+        "SELECT parent_id, parent_order FROM lix_commit_edge \
+         WHERE child_id = $1 ORDER BY parent_order",
+        &[Value::Text(commit_id.to_owned())],
+    )
+    .await
+    .expect("checkpoint parent edges read")
+    .rows()
+    .iter()
+    .map(|row| {
+        (
+            row.get::<String>("parent_id").expect("parent id decodes"),
+            row.get::<i64>("parent_order")
+                .expect("parent order decodes"),
+        )
+    })
+    .collect()
+}
+
+async fn assert_value<S>(lix: &Lix<S>, key: &str, expected: &str)
+where
+    S: Storage + Clone + Send + Sync + 'static,
+{
+    let result = lix
+        .execute(
+            "SELECT value FROM lix_key_value WHERE key = $1",
+            &[Value::Text(key.to_owned())],
+        )
+        .await
+        .expect("merged value reads");
+    assert_eq!(
+        result.rows()[0]
+            .get::<serde_json::Value>("value")
+            .expect("merged value decodes"),
+        serde_json::Value::String(expected.to_owned()),
+    );
+}

--- a/packages/lix/src/gc.rs
+++ b/packages/lix/src/gc.rs
@@ -347,6 +347,20 @@ pub(crate) struct RootReachabilityDelta {
     pub(crate) new_control_digest: [u8; 32],
 }
 
+/// One authenticated checkpoint replacement that is still pending physical
+/// retirement.
+///
+/// Callers receive only the typed canonical replacement. The queue remains
+/// GC-owned maintenance state and never becomes a merge-time chronology
+/// reader. A caller may use this proof only while publishing from the same
+/// coherent read: the ordinary reachability-batch writer then CASes the exact
+/// queue row observed by this resolver.
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub(crate) struct PendingCheckpointReplacement {
+    pub(crate) checkpoint_commit_id: CommitId,
+    pub(crate) checkpoint_branch_id: String,
+}
+
 /// Stages one branch's recovery-root rotation.
 ///
 /// The caller owns the surrounding transaction. Replacing the key drops the
@@ -379,6 +393,20 @@ pub(crate) fn stage_recovery_ref_rotation(
         StorageValue {
             bytes: Bytes::from(value),
         },
+    );
+    Ok(())
+}
+
+/// Retires branch-local checkpoint serving context with its canonical branch
+/// control. A deleted branch must not keep recovered history or compacted
+/// checkpoints live through an orphan recovery row.
+pub(crate) fn stage_delete_recovery_ref(
+    writes: &mut StorageWriteSet,
+    branch_id: &str,
+) -> Result<(), LixError> {
+    writes.delete(
+        CHECKPOINT_RECOVERY_REF_SPACE,
+        StorageKey(Bytes::from(recovery_ref_key(branch_id)?)),
     );
     Ok(())
 }
@@ -774,6 +802,106 @@ where
         },
     )
     .await
+}
+
+/// Resolves a still-pending checkpoint replacement for an explicit branch
+/// source, or proves that the source remains reachable through ordinary
+/// canonical chronology.
+///
+/// A checkpoint replacement is accepted only when one authenticated pending
+/// batch binds `source_commit_id -> checkpoint_commit_id` through matching
+/// branch controls and includes that checkpoint in the same batch's root set.
+/// Branch publication must retain this read through the ordinary reachability
+/// batch writer, whose queue CAS prevents GC consumption and branch creation
+/// from both committing from the same observation.
+pub(crate) async fn resolve_pending_checkpoint_replacement<S>(
+    store: &S,
+    source_commit_id: CommitId,
+) -> Result<Option<PendingCheckpointReplacement>, LixError>
+where
+    S: StorageAdapterRead + Clone + Send + Sync,
+{
+    let (queue, _) = load_reachability_queue(store).await?;
+    let candidates =
+        fold_reachability_batches(store, &queue, None, Vec::new(), |candidates, _, batch| {
+            let checkpoint_roots = batch
+                .checkpoint_roots
+                .iter()
+                .copied()
+                .collect::<BTreeSet<_>>();
+            for delta in &batch.deltas {
+                validate_stored_root_reachability_delta(delta)?;
+                if delta.old_root != Some(source_commit_id) {
+                    continue;
+                }
+                let Some(checkpoint_commit_id) = delta.new_root else {
+                    continue;
+                };
+                let Some(new_control) = delta.new_control else {
+                    continue;
+                };
+                if new_control.working_diff_checkpoint_commit_id == Some(checkpoint_commit_id)
+                    && checkpoint_roots.contains(&checkpoint_commit_id)
+                {
+                    candidates.push((checkpoint_commit_id, delta.branch_id.clone()));
+                }
+            }
+            Ok(())
+        })
+        .await?;
+    match candidates.len() {
+        0 => {}
+        1 => {
+            let (checkpoint_commit_id, checkpoint_branch_id) = candidates
+                .into_iter()
+                .next()
+                .expect("single checkpoint replacement candidate");
+            return Ok(Some(PendingCheckpointReplacement {
+                checkpoint_commit_id,
+                checkpoint_branch_id,
+            }));
+        }
+        _ => {
+            return Err(LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                format!(
+                    "commit '{source_commit_id}' has ambiguous pending checkpoint replacements"
+                ),
+            ));
+        }
+    }
+
+    let controls = BranchHeadControlContext::new()
+        .reader(store.clone())
+        .scan()
+        .await?;
+    let roots = controls
+        .into_iter()
+        .flat_map(|(_, control)| control.tracked_reachability().chronology_roots)
+        .flatten()
+        .collect::<BTreeSet<_>>();
+    if roots.contains(&source_commit_id) {
+        return Ok(None);
+    }
+    let mut graph = CommitGraphContext::new().reader(store.clone());
+    for root in roots {
+        if graph
+            .reachable_nodes(&root)
+            .await?
+            .iter()
+            .any(|reachable| reachable.commit.commit_id == source_commit_id)
+        {
+            return Ok(None);
+        }
+    }
+    Err(LixError::commit_not_found(
+        source_commit_id.to_string(),
+        "create_branch",
+        "commit_source",
+    )
+    .with_hint(
+        "The commit is no longer an authenticated branchable root after checkpoint compaction.",
+    ))
 }
 
 #[allow(dead_code)]
@@ -1554,6 +1682,36 @@ pub(crate) async fn load_recovery_ref(
         checkpoint_commit_id: stored.checkpoint_commit_id,
         interval_has_commits: stored.interval_has_commits,
     }))
+}
+
+/// Returns the bounded checkpoint parent consumed by the first ordinary
+/// commit on a branch created from a recovered historical head.
+///
+/// The recovery row and branch control are serving context only. Once this
+/// returns, commit publication records the checkpoint as an ordinary graph
+/// parent; merge/history readers never consult either serving record.
+pub(crate) async fn resolve_checkpoint_branch_parent(
+    store: &(impl StorageAdapterRead + ?Sized),
+    branch_id: &str,
+    head_commit_id: CommitId,
+    working_diff_checkpoint_commit_id: Option<CommitId>,
+) -> Result<Option<CommitId>, LixError> {
+    let Some(recovery) = load_recovery_ref(store, branch_id).await? else {
+        return Ok(None);
+    };
+    if recovery.recovered_head_commit_id != head_commit_id {
+        return Ok(None);
+    }
+    if !recovery.interval_has_commits
+        || recovery.checkpoint_commit_id == head_commit_id
+        || working_diff_checkpoint_commit_id != Some(recovery.checkpoint_commit_id)
+    {
+        return Err(LixError::new(
+            LixError::CODE_INTERNAL_ERROR,
+            format!("branch '{branch_id}' has an invalid pending checkpoint ancestry bridge"),
+        ));
+    }
+    Ok(Some(recovery.checkpoint_commit_id))
 }
 
 pub(crate) async fn load_checkpoint_gc_state(
@@ -3469,7 +3627,7 @@ mod tests {
         stage_commit_deltas_for_commit_state, stage_commit_state_manifest,
         stage_ordered_addressable_replacement_parts,
     };
-    use crate::{GLOBAL_BRANCH_ID, Value, engine::Engine};
+    use crate::{GLOBAL_BRANCH_ID, LixError, Value, engine::Engine};
     use bytes::Bytes;
     use datafusion::arrow::array::StringArray;
     use datafusion::arrow::datatypes::{DataType, Field, Schema};
@@ -3481,9 +3639,11 @@ mod tests {
         RootReachabilityDelta, StoredTreeSweepMark, authenticated_control_commit_reachability,
         begin_tree_sweep_epoch, collect_all_reachability_checkpoint_roots,
         load_checkpoint_gc_state, load_reachability_batches, load_reachability_queue,
-        load_recovery_ref, load_recovery_refs, open_tree_sweep_epoch, retirement_is_proven,
-        root_control_digest_for_control, stage_checkpoint_gc_state, stage_reachability_delta_batch,
-        stage_reachability_queue_seed, stage_recovery_ref_rotation, stage_tree_sweep_epoch_page,
+        load_recovery_ref, load_recovery_refs, open_tree_sweep_epoch,
+        resolve_pending_checkpoint_replacement, retirement_is_proven,
+        root_control_digest_for_control, stage_checkpoint_gc_state, stage_delete_recovery_ref,
+        stage_reachability_delta_batch, stage_reachability_queue_seed, stage_recovery_ref_rotation,
+        stage_tree_sweep_epoch_page,
     };
 
     async fn append_checkpoint_batch(
@@ -5303,6 +5463,32 @@ mod tests {
                 .expect("main recovery ref should load"),
             Some(second_main)
         );
+        drop(read);
+
+        let mut writes = storage.new_write_set();
+        stage_delete_recovery_ref(&mut writes, "main")
+            .expect("deleted branch recovery ref should stage");
+        storage
+            .commit_write_set(writes, StorageWriteOptions::default())
+            .await
+            .expect("deleted branch recovery ref should commit");
+        let read = storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("retired recovery read should open");
+        assert_eq!(
+            load_recovery_ref(&read, "main")
+                .await
+                .expect("retired main recovery ref should load"),
+            None
+        );
+        assert!(
+            load_recovery_ref(&read, "other")
+                .await
+                .expect("other recovery ref should load")
+                .is_some(),
+            "retiring one branch must not remove another branch's serving context"
+        );
     }
 
     #[tokio::test]
@@ -5391,6 +5577,225 @@ mod tests {
         assert_eq!(batches.len(), 1);
         assert_eq!(batches[0].1.checkpoint_roots, vec![new_root]);
         assert_eq!(batches[0].1.deltas[0].old_root, Some(old_root));
+    }
+
+    fn checkpoint_replacement_delta(
+        label: &str,
+        old_root: CommitId,
+        new_root: CommitId,
+    ) -> RootReachabilityDelta {
+        let timestamp = LixTimestamp::expect_parse(
+            "checkpoint replacement test timestamp",
+            "2026-01-01T00:00:00Z",
+        );
+        let old_control = BranchHeadControl {
+            head_commit_id: old_root,
+            tracked_generation: old_root,
+            untracked_generation: old_root,
+            current_state_revision: 0,
+            working_diff_checkpoint_commit_id: None,
+            created_at: timestamp,
+            updated_at: timestamp,
+            ref_change_id: ChangeId::for_test_label(&format!("{label}-old-control")),
+            schema_presence_bloom: [0; 4],
+        };
+        let new_control = BranchHeadControl {
+            head_commit_id: new_root,
+            tracked_generation: new_root,
+            untracked_generation: new_root,
+            current_state_revision: 1,
+            working_diff_checkpoint_commit_id: Some(new_root),
+            created_at: timestamp,
+            updated_at: timestamp,
+            ref_change_id: ChangeId::for_test_label(&format!("{label}-new-control")),
+            schema_presence_bloom: [0; 4],
+        };
+        RootReachabilityDelta {
+            branch_id: label.to_owned(),
+            old_root: Some(old_root),
+            new_root: Some(new_root),
+            old_control: Some(old_control),
+            new_control: Some(new_control),
+            old_control_digest: root_control_digest_for_control(Some(&old_control))
+                .expect("old replacement control should encode"),
+            new_control_digest: root_control_digest_for_control(Some(&new_control))
+                .expect("new replacement control should encode"),
+        }
+    }
+
+    async fn append_replacement_delta(
+        storage: &StorageAdapter<Memory>,
+        delta: RootReachabilityDelta,
+    ) {
+        let read = storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("replacement publication read should open");
+        let checkpoint = delta.new_root.expect("replacement has a new root");
+        let mut writes = storage.new_write_set();
+        let mut preconditions = Vec::new();
+        stage_reachability_delta_batch(
+            &read,
+            &mut writes,
+            std::slice::from_ref(&delta),
+            &[checkpoint],
+            &mut preconditions,
+        )
+        .await
+        .expect("replacement delta should stage");
+        drop(read);
+        storage
+            .commit_write_set(
+                writes,
+                StorageWriteOptions {
+                    preconditions,
+                    ..StorageWriteOptions::default()
+                },
+            )
+            .await
+            .expect("replacement delta should commit");
+    }
+
+    #[tokio::test]
+    async fn pending_checkpoint_replacement_is_unique_and_queue_cas_fenced() {
+        let storage = StorageAdapter::new(Memory::new());
+        let mut seed = storage.new_write_set();
+        stage_reachability_queue_seed(&mut seed).expect("queue seed should stage");
+        storage
+            .commit_write_set(seed, StorageWriteOptions::default())
+            .await
+            .expect("queue seed should commit");
+
+        let recovered = CommitId::for_test_label("pending-replacement-recovered");
+        let checkpoint = CommitId::for_test_label("pending-replacement-checkpoint");
+        append_replacement_delta(
+            &storage,
+            checkpoint_replacement_delta("main", recovered, checkpoint),
+        )
+        .await;
+
+        let stale_read = SharedStorageAdapterRead::new(
+            storage
+                .begin_read(StorageReadOptions::default())
+                .await
+                .expect("branch publication read should open"),
+        );
+        let proof = resolve_pending_checkpoint_replacement(&stale_read, recovered)
+            .await
+            .expect("unique pending replacement should authenticate")
+            .expect("pending replacement should exist");
+        assert_eq!(proof.checkpoint_commit_id, checkpoint);
+        assert_eq!(proof.checkpoint_branch_id, "main");
+
+        let mut stale_writes = storage.new_write_set();
+        let mut stale_preconditions = Vec::new();
+        stage_reachability_delta_batch(
+            &stale_read,
+            &mut stale_writes,
+            &[],
+            &[checkpoint],
+            &mut stale_preconditions,
+        )
+        .await
+        .expect("branch-side queue fence should stage");
+
+        let second_checkpoint = CommitId::for_test_label("pending-replacement-checkpoint-2");
+        append_replacement_delta(
+            &storage,
+            checkpoint_replacement_delta("main", recovered, second_checkpoint),
+        )
+        .await;
+        let stale_error = storage
+            .commit_write_set(
+                stale_writes,
+                StorageWriteOptions {
+                    preconditions: stale_preconditions,
+                    ..StorageWriteOptions::default()
+                },
+            )
+            .await
+            .expect_err("stale branch publication must lose the queue CAS");
+        assert!(stale_error.to_string().contains("precondition"));
+
+        let read = SharedStorageAdapterRead::new(
+            storage
+                .begin_read(StorageReadOptions::default())
+                .await
+                .expect("ambiguous replacement read should open"),
+        );
+        let ambiguous = resolve_pending_checkpoint_replacement(&read, recovered)
+            .await
+            .expect_err("two pending direct replacements must fail closed");
+        assert!(ambiguous.message.contains("ambiguous"));
+    }
+
+    #[tokio::test]
+    async fn recovery_ref_without_pending_replacement_is_not_branchable_authority() {
+        let storage = StorageAdapter::new(Memory::new());
+        let mut writes = storage.new_write_set();
+        stage_reachability_queue_seed(&mut writes).expect("queue seed should stage");
+        let recovered = CommitId::for_test_label("consumed-replacement-recovered");
+        let checkpoint = CommitId::for_test_label("consumed-replacement-checkpoint");
+        stage_recovery_ref_rotation(
+            &mut writes,
+            &CheckpointRecoveryRef {
+                branch_id: "main".to_owned(),
+                recovered_head_commit_id: recovered,
+                checkpoint_commit_id: checkpoint,
+                interval_has_commits: true,
+            },
+        )
+        .expect("recovery ref should stage");
+        storage
+            .commit_write_set(writes, StorageWriteOptions::default())
+            .await
+            .expect("recovery-only fixture should commit");
+
+        let read = SharedStorageAdapterRead::new(
+            storage
+                .begin_read(StorageReadOptions::default())
+                .await
+                .expect("recovery-only read should open"),
+        );
+        let error = resolve_pending_checkpoint_replacement(&read, recovered)
+            .await
+            .expect_err("a mutable recovery ref must not replace a consumed queue proof");
+        assert_eq!(error.code, LixError::CODE_COMMIT_NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn malformed_pending_checkpoint_replacement_fails_closed() {
+        let storage = StorageAdapter::new(Memory::new());
+        let mut seed = storage.new_write_set();
+        stage_reachability_queue_seed(&mut seed).expect("queue seed should stage");
+        storage
+            .commit_write_set(seed, StorageWriteOptions::default())
+            .await
+            .expect("queue seed should commit");
+
+        let recovered = CommitId::for_test_label("malformed-replacement-recovered");
+        let checkpoint = CommitId::for_test_label("malformed-replacement-checkpoint");
+        let mut malformed = checkpoint_replacement_delta("main", recovered, checkpoint);
+        malformed
+            .new_control
+            .as_mut()
+            .expect("replacement has new control")
+            .working_diff_checkpoint_commit_id = None;
+        malformed.new_control_digest =
+            root_control_digest_for_control(malformed.new_control.as_ref())
+                .expect("malformed control should still encode");
+        append_replacement_delta(&storage, malformed).await;
+
+        let read = SharedStorageAdapterRead::new(
+            storage
+                .begin_read(StorageReadOptions::default())
+                .await
+                .expect("malformed replacement read should open"),
+        );
+        let error = resolve_pending_checkpoint_replacement(&read, recovered)
+            .await
+            .expect_err("mapping without an exact checkpoint baseline must fail closed");
+        assert_eq!(error.code, LixError::CODE_COMMIT_NOT_FOUND);
     }
 
     #[tokio::test]

--- a/packages/lix/src/session/create_branch.rs
+++ b/packages/lix/src/session/create_branch.rs
@@ -43,10 +43,15 @@ where
         options: CreateBranchOptions,
     ) -> Result<CreateBranchReceipt, LixError> {
         self.with_write_transaction_lending(async move |transaction| {
-            let branch_id = options
-                .id
-                .unwrap_or_else(|| transaction.functions().call_uuid_v7().to_string());
-            let source_head = if let Some(from_commit_id) = options.from_commit_id {
+            let CreateBranchOptions {
+                id,
+                name,
+                from_commit_id,
+            } = options;
+            let branch_id =
+                id.unwrap_or_else(|| transaction.functions().call_uuid_v7().to_string());
+            let explicit_historical_source = from_commit_id.is_some();
+            let source_head = if let Some(from_commit_id) = from_commit_id {
                 let from_commit_id = BranchLifecycle::parse_commit_id(
                     &from_commit_id,
                     BranchOperation::CreateBranch,
@@ -74,11 +79,7 @@ where
             };
 
             let mut rows = RawWriteBatch::with_capacity(2);
-            rows.push(branch_descriptor_stage_row(
-                &branch_id,
-                &options.name,
-                false,
-            ));
+            rows.push(branch_descriptor_stage_row(&branch_id, &name, false));
             rows.push(branch_ref_stage_row(&branch_id, &source_head));
             transaction
                 .stage_write(TransactionWrite::Rows {
@@ -86,10 +87,16 @@ where
                     rows,
                 })
                 .await?;
+            if explicit_historical_source {
+                transaction.stage_branch_checkpoint_replacement_resolution(
+                    branch_id.clone(),
+                    source_head,
+                )?;
+            }
 
             Ok(CreateBranchReceipt {
                 id: branch_id,
-                name: options.name,
+                name,
                 hidden: false,
                 commit_id: source_head.to_string(),
             })

--- a/packages/lix/src/transaction/commit.rs
+++ b/packages/lix/src/transaction/commit.rs
@@ -5216,7 +5216,10 @@ async fn stage_branch_head_control_publications(
         }
         match desired {
             Some(control) => stage_branch_head_control(writes, branch_id, *control)?,
-            None => stage_delete_branch_head_control(writes, branch_id)?,
+            None => {
+                stage_delete_branch_head_control(writes, branch_id)?;
+                crate::gc::stage_delete_recovery_ref(writes, branch_id)?;
+            }
         }
     }
     Ok(publications

--- a/packages/lix/src/transaction/commit.rs
+++ b/packages/lix/src/transaction/commit.rs
@@ -163,6 +163,7 @@ pub(crate) async fn commit_prepared_writes(
         crate::ANONYMOUS_ACCOUNT_ID,
         &commit_parent_heads,
         read,
+        &BTreeMap::new(),
         prepared_writes,
     )
     .await
@@ -178,6 +179,7 @@ pub(crate) async fn commit_prepared_writes_with_parent_heads(
     active_account_id: &str,
     commit_parent_heads: &BTreeMap<String, Option<CommitId>>,
     read: &mut impl StorageAdapterRead,
+    branch_checkpoint_bridges: &BTreeMap<String, crate::gc::CheckpointRecoveryRef>,
     prepared_writes: PreparedWriteSet,
 ) -> Result<(StorageWriteSet, Vec<StoragePrecondition>), LixError> {
     Box::pin(validate_active_account_and_account_rows(
@@ -770,6 +772,7 @@ pub(crate) async fn commit_prepared_writes_with_parent_heads(
         &explicit_branch_targets,
         &insert_selection,
         &prepared_writes.checkpoint_publications,
+        branch_checkpoint_bridges,
         &mut preconditions,
         &branch_control_observations,
         &mut root_backed_branch_publications,
@@ -4902,6 +4905,40 @@ fn insert_direct_branch_control(
     Ok(())
 }
 
+fn bind_branch_checkpoint_bridge(
+    branch_id: &str,
+    target: &ExplicitBranchHeadTarget,
+    existing: Option<BranchHeadControl>,
+    control: &mut BranchHeadControl,
+    bridge: &crate::gc::CheckpointRecoveryRef,
+) -> Result<TrackedWorkingDiffEpoch, LixError> {
+    let Some(target_head) = target.head_commit_id else {
+        return Err(LixError::new(
+            LixError::CODE_INTERNAL_ERROR,
+            format!("checkpoint ancestry bridge cannot delete branch '{branch_id}'"),
+        ));
+    };
+    if bridge.branch_id != branch_id
+        || existing.is_some()
+        || bridge.recovered_head_commit_id != target_head
+        || control.head_commit_id != target_head
+        || bridge.checkpoint_commit_id == target_head
+        || !bridge.interval_has_commits
+        || control.working_diff_checkpoint_commit_id.is_some()
+    {
+        return Err(LixError::new(
+            LixError::CODE_INTERNAL_ERROR,
+            format!("branch '{branch_id}' has an invalid checkpoint ancestry bridge"),
+        ));
+    }
+    control.working_diff_checkpoint_commit_id = Some(bridge.checkpoint_commit_id);
+    Ok(TrackedWorkingDiffEpoch {
+        checkpoint_commit_id: bridge.checkpoint_commit_id,
+        generation: control.tracked_generation,
+        coverage: WorkingDiffIndexCoverage::default(),
+    })
+}
+
 /// Publishes every current-state branch control under an exact-byte CAS token.
 ///
 /// Normal tracked commits arrive as `normal_controls`, built from the same
@@ -4993,17 +5030,30 @@ async fn stage_branch_head_control_publications(
     explicit_branch_targets: &BTreeMap<String, ExplicitBranchHeadTarget>,
     insert_selection: &PreparedInsertSelection,
     checkpoint_publications: &[crate::gc::CheckpointPublication],
+    branch_checkpoint_bridges: &BTreeMap<String, crate::gc::CheckpointRecoveryRef>,
     preconditions: &mut Vec<StoragePrecondition>,
     observations: &BTreeMap<String, BranchHeadControlObservation>,
     root_backed_branch_publications: &mut BTreeSet<String>,
     root_reachability_deltas: &mut Vec<crate::gc::RootReachabilityDelta>,
 ) -> Result<BTreeMap<String, BranchHeadControl>, LixError> {
     let checkpoint_epochs = checkpoint_epoch_bindings(checkpoint_publications)?;
+    if let Some(branch_id) = branch_checkpoint_bridges
+        .keys()
+        .find(|branch_id| checkpoint_epochs.contains_key(*branch_id))
+    {
+        return Err(LixError::new(
+            LixError::CODE_INTERNAL_ERROR,
+            format!(
+                "branch '{branch_id}' cannot publish a checkpoint and an ancestry bridge together"
+            ),
+        ));
+    }
     let mut publications = normal_controls
         .iter()
         .map(|(branch_id, control)| (branch_id.clone(), Some(*control)))
         .collect::<BTreeMap<String, Option<BranchHeadControl>>>();
     let tracked_head = TrackedHeadContext::new();
+    let mut consumed_checkpoint_bridges = BTreeSet::new();
     for (branch_id, target) in explicit_branch_targets {
         if publications.contains_key(branch_id) {
             return Err(LixError::new(
@@ -5024,7 +5074,7 @@ async fn stage_branch_head_control_publications(
                 )
             })?
             .control;
-        let desired = match target.head_commit_id {
+        let mut desired = match target.head_commit_id {
             None => None,
             Some(head_commit_id) => {
                 if existing.is_none() {
@@ -5158,7 +5208,34 @@ async fn stage_branch_head_control_publications(
                 }
             }
         };
+        if let Some(bridge) = branch_checkpoint_bridges.get(branch_id) {
+            let control = desired.as_mut().ok_or_else(|| {
+                LixError::new(
+                    LixError::CODE_INTERNAL_ERROR,
+                    format!(
+                        "checkpoint ancestry bridge has no branch publication for '{branch_id}'"
+                    ),
+                )
+            })?;
+            let epoch =
+                bind_branch_checkpoint_bridge(branch_id, target, existing, control, bridge)?;
+            stage_tracked_working_diff_epoch(writes, branch_id, epoch)?;
+            crate::gc::stage_recovery_ref_rotation(writes, bridge)?;
+            consumed_checkpoint_bridges.insert(branch_id.clone());
+        }
         publications.insert(branch_id.clone(), desired);
+    }
+    if consumed_checkpoint_bridges.len() != branch_checkpoint_bridges.len() {
+        let branch_id = branch_checkpoint_bridges
+            .keys()
+            .find(|branch_id| !consumed_checkpoint_bridges.contains(*branch_id))
+            .expect("bridge count differs only when one branch was not consumed");
+        return Err(LixError::new(
+            LixError::CODE_INTERNAL_ERROR,
+            format!(
+                "checkpoint ancestry bridge has no explicit branch publication for '{branch_id}'"
+            ),
+        ));
     }
 
     if publications.is_empty() {
@@ -6519,7 +6596,7 @@ fn account_has_changes_error(account_id: &str) -> LixError {
 
 #[cfg(test)]
 mod tests {
-    use std::collections::BTreeMap;
+    use std::collections::{BTreeMap, BTreeSet};
     use std::sync::{
         Arc,
         atomic::{AtomicUsize, Ordering},
@@ -6554,6 +6631,158 @@ mod tests {
 
     fn ts(value: &str) -> LixTimestamp {
         LixTimestamp::expect_parse("timestamp", value)
+    }
+
+    #[tokio::test]
+    async fn branch_creation_owner_publishes_checkpoint_serving_context() {
+        let storage = StorageAdapter::new(Memory::new());
+        let mut seed = storage.new_write_set();
+        crate::gc::stage_reachability_queue_seed(&mut seed)
+            .expect("reachability queue should seed");
+        storage
+            .commit_write_set(seed, StorageWriteOptions::default())
+            .await
+            .expect("reachability queue seed should commit");
+
+        let branch_id = "01960000-0000-7000-8000-0000000000b1";
+        let recovered_head = commit_id("branch-bridge-recovered-head");
+        let checkpoint = commit_id("branch-bridge-checkpoint");
+        let target = ExplicitBranchHeadTarget {
+            head_commit_id: Some(recovered_head),
+            ref_change_id: change_id("branch-bridge-ref-change"),
+            created_at: ts("2026-01-01T00:00:00Z"),
+            updated_at: ts("2026-01-01T00:00:00Z"),
+        };
+        let bridge = crate::gc::CheckpointRecoveryRef {
+            branch_id: branch_id.to_owned(),
+            recovered_head_commit_id: recovered_head,
+            checkpoint_commit_id: checkpoint,
+            interval_has_commits: true,
+        };
+        let read = storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("branch publication read should open");
+        let mut writes = storage.new_write_set();
+        let mut preconditions = Vec::new();
+        let mut root_backed = BTreeSet::new();
+        let mut reachability_deltas = Vec::new();
+        let controls = stage_branch_head_control_publications(
+            &read,
+            &mut writes,
+            &BTreeMap::new(),
+            &BTreeMap::new(),
+            &PreparedStateBatch::new(),
+            &[],
+            &BTreeMap::from([(branch_id.to_owned(), target)]),
+            &PreparedInsertSelection::new(),
+            &[],
+            &BTreeMap::from([(branch_id.to_owned(), bridge.clone())]),
+            &mut preconditions,
+            &BTreeMap::from([(
+                branch_id.to_owned(),
+                BranchHeadControlObservation {
+                    control: None,
+                    raw_token: None,
+                },
+            )]),
+            &mut root_backed,
+            &mut reachability_deltas,
+        )
+        .await
+        .expect("branch owner should stage checkpoint serving context");
+        let control = controls
+            .get(branch_id)
+            .copied()
+            .expect("created branch should have a complete control");
+        assert_eq!(control.head_commit_id, recovered_head);
+        assert_eq!(control.working_diff_checkpoint_commit_id, Some(checkpoint));
+        assert!(root_backed.contains(branch_id));
+        assert_eq!(reachability_deltas.len(), 1);
+        assert_eq!(reachability_deltas[0].old_root, None);
+        assert_eq!(reachability_deltas[0].new_root, Some(recovered_head));
+        assert_eq!(reachability_deltas[0].new_control, Some(control));
+        crate::gc::stage_reachability_delta_batch(
+            &read,
+            &mut writes,
+            &reachability_deltas,
+            &[],
+            &mut preconditions,
+        )
+        .await
+        .expect("branch publication should stage the exact queue fence");
+        drop(read);
+        storage
+            .commit_write_set(
+                writes,
+                StorageWriteOptions {
+                    preconditions,
+                    ..StorageWriteOptions::default()
+                },
+            )
+            .await
+            .expect("branch serving context should publish atomically");
+
+        let read = storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("branch serving verification read should open");
+        let persisted = BranchHeadControlContext::new()
+            .reader(&read)
+            .load(branch_id)
+            .await
+            .expect("created branch control should load")
+            .expect("created branch control should exist");
+        assert_eq!(persisted, control);
+        let epoch = TrackedHeadContext::new()
+            .reader(&read)
+            .working_diff_epoch(branch_id)
+            .await
+            .expect("branch working-diff epoch should load")
+            .expect("branch working-diff epoch should exist");
+        assert_eq!(epoch.checkpoint_commit_id, checkpoint);
+        assert_eq!(epoch.generation, control.tracked_generation);
+        assert_eq!(
+            crate::gc::resolve_checkpoint_branch_parent(
+                &read,
+                branch_id,
+                recovered_head,
+                control.working_diff_checkpoint_commit_id,
+            )
+            .await
+            .expect("branch serving context should validate"),
+            Some(checkpoint)
+        );
+    }
+
+    #[tokio::test]
+    async fn real_checkpoint_without_complete_hot_control_still_fails() {
+        let storage = StorageAdapter::new(Memory::new());
+        let read = storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("checkpoint validation read should open");
+        let mut writes = storage.new_write_set();
+        let checkpoint = commit_id("missing-hot-checkpoint");
+        let error = stage_checkpoint_working_diff_epochs(
+            &read,
+            &mut writes,
+            &[crate::gc::CheckpointPublication {
+                recovery_ref: crate::gc::CheckpointRecoveryRef {
+                    branch_id: "01960000-0000-7000-8000-0000000000b2".to_owned(),
+                    recovered_head_commit_id: commit_id("missing-hot-recovered-head"),
+                    checkpoint_commit_id: checkpoint,
+                    interval_has_commits: true,
+                },
+                gc_state: crate::gc::CheckpointGcState::default(),
+            }],
+            &BTreeMap::new(),
+            &BTreeMap::new(),
+        )
+        .await
+        .expect_err("real checkpoint publication without complete HOT control must fail");
+        assert_eq!(error.code, LixError::CODE_INTERNAL_ERROR);
+        assert!(error.message.contains("has no complete hot control"));
     }
 
     #[test]

--- a/packages/lix/src/transaction/context.rs
+++ b/packages/lix/src/transaction/context.rs
@@ -1490,7 +1490,6 @@ where
     }
 
     async fn attach_checkpoint_branch_parents<S>(
-        &self,
         read: &S,
         prepared_writes: &mut PreparedWriteSet,
         commit_parent_heads: &BTreeMap<String, Option<CommitId>>,
@@ -1809,9 +1808,12 @@ where
                 return Err(error);
             }
         };
-        if let Err(error) = transaction
-            .attach_checkpoint_branch_parents(&read, &mut prepared_writes, &commit_parent_heads)
-            .await
+        if let Err(error) = Self::attach_checkpoint_branch_parents(
+            &read,
+            &mut prepared_writes,
+            &commit_parent_heads,
+        )
+        .await
         {
             transaction
                 .discard_pending_plugin_actor_publications()

--- a/packages/lix/src/transaction/context.rs
+++ b/packages/lix/src/transaction/context.rs
@@ -1392,12 +1392,13 @@ where
     async fn resolve_pending_branch_checkpoint_replacements<S>(
         &mut self,
         read: &S,
-        prepared_writes: &mut PreparedWriteSet,
-    ) -> Result<(), LixError>
+        prepared_writes: &PreparedWriteSet,
+    ) -> Result<BTreeMap<String, CheckpointRecoveryRef>, LixError>
     where
         S: StorageAdapterRead + Clone + Send + Sync,
     {
         let requests = std::mem::take(&mut self.pending_branch_checkpoint_replacements);
+        let mut branch_checkpoint_bridges = BTreeMap::new();
         for (branch_id, source_commit_id) in requests {
             let Some(replacement) =
                 crate::gc::resolve_pending_checkpoint_replacement(read, source_commit_id).await?
@@ -1475,19 +1476,17 @@ where
                     format!("branch '{branch_id}' already staged checkpoint serving context"),
                 ));
             }
-            prepared_writes
-                .checkpoint_publications
-                .push(CheckpointPublication {
-                    recovery_ref: CheckpointRecoveryRef {
-                        branch_id,
-                        recovered_head_commit_id: source_commit_id,
-                        checkpoint_commit_id,
-                        interval_has_commits: true,
-                    },
-                    gc_state: load_checkpoint_gc_state(read).await?,
-                });
+            branch_checkpoint_bridges.insert(
+                branch_id.clone(),
+                CheckpointRecoveryRef {
+                    branch_id,
+                    recovered_head_commit_id: source_commit_id,
+                    checkpoint_commit_id,
+                    interval_has_commits: true,
+                },
+            );
         }
-        Ok(())
+        Ok(branch_checkpoint_bridges)
     }
 
     async fn attach_checkpoint_branch_parents<S>(
@@ -1782,15 +1781,18 @@ where
                 .await;
             return Err(error);
         }
-        if let Err(error) = transaction
-            .resolve_pending_branch_checkpoint_replacements(&read, &mut prepared_writes)
+        let branch_checkpoint_bridges = match transaction
+            .resolve_pending_branch_checkpoint_replacements(&read, &prepared_writes)
             .await
         {
-            transaction
-                .discard_pending_plugin_actor_publications()
-                .await;
-            return Err(error);
-        }
+            Ok(branch_checkpoint_bridges) => branch_checkpoint_bridges,
+            Err(error) => {
+                transaction
+                    .discard_pending_plugin_actor_publications()
+                    .await;
+                return Err(error);
+            }
+        };
         let commit_parent_heads = match commit::resolve_prepared_commit_parent_heads(
             transaction.branch_ctx.as_ref(),
             &read,
@@ -1861,6 +1863,7 @@ where
                 &transaction.active_account_id,
                 &commit_parent_heads,
                 &mut read,
+                &branch_checkpoint_bridges,
                 prepared_writes,
             )
             .instrument(tracing::debug_span!(

--- a/packages/lix/src/transaction/context.rs
+++ b/packages/lix/src/transaction/context.rs
@@ -263,6 +263,8 @@ where
         && b.atomic_metadata_writes.is_none()
         && a.atomic_metadata_preconditions.is_empty()
         && b.atomic_metadata_preconditions.is_empty()
+        && a.pending_branch_checkpoint_replacements.is_empty()
+        && b.pending_branch_checkpoint_replacements.is_empty()
         && !a.await_durable_commit
         && !b.await_durable_commit
         && eligible_a
@@ -581,6 +583,11 @@ pub(crate) struct Transaction<StorageImpl: Storage + 'static = Memory> {
     session_file_views: SessionFileViews,
     pending_file_view_mutations: BTreeMap<SessionFileViewKey, SessionFileViewMutation>,
     pending_plugin_actor_publications: Vec<PendingPluginActorPublication>,
+    /// Explicit historical branch sources whose branchability may be owned by
+    /// one still-pending authenticated checkpoint replacement. Resolution is
+    /// delayed to the coherent commit-boundary read so its queue observation
+    /// is fenced by the same branch publication batch.
+    pending_branch_checkpoint_replacements: BTreeMap<String, CommitId>,
     plugin_generation_read_guard: Option<tokio::sync::OwnedRwLockReadGuard<()>>,
     plugin_generation_upgrade_guard: Option<tokio::sync::OwnedRwLockWriteGuard<()>>,
 }
@@ -1369,6 +1376,154 @@ where
         Ok(())
     }
 
+    async fn resolve_pending_branch_checkpoint_replacements<S>(
+        &mut self,
+        read: &S,
+        prepared_writes: &mut PreparedWriteSet,
+    ) -> Result<(), LixError>
+    where
+        S: StorageAdapterRead + Clone + Send + Sync,
+    {
+        let requests = std::mem::take(&mut self.pending_branch_checkpoint_replacements);
+        for (branch_id, source_commit_id) in requests {
+            let Some(replacement) =
+                crate::gc::resolve_pending_checkpoint_replacement(read, source_commit_id).await?
+            else {
+                continue;
+            };
+            let checkpoint_commit_id = replacement.checkpoint_commit_id;
+            if checkpoint_commit_id == source_commit_id {
+                return Err(LixError::new(
+                    LixError::CODE_INTERNAL_ERROR,
+                    "checkpoint replacement cannot point to its recovered head",
+                ));
+            }
+
+            // The queue authenticates the root/control transition. Reading
+            // the complete semantic diff on this same snapshot additionally
+            // proves both manifests/roots are present and that compaction did
+            // not change any public tracked fact.
+            let mut tracked = self.tracked_state.reader(read.clone());
+            let diff = tracked
+                .diff_commits(
+                    &source_commit_id.to_string(),
+                    &checkpoint_commit_id.to_string(),
+                    &TrackedStateDiffRequest::default(),
+                )
+                .await?;
+            if let Some(entry) = diff.entries.iter().find(|entry| {
+                !matches!(
+                    entry.identity.schema_key(),
+                    CHECKPOINT_MARKER_SCHEMA_KEY | crate::undo_redo::UNDO_REDO_MARKER_SCHEMA_KEY
+                )
+            }) {
+                return Err(LixError::new(
+                    LixError::CODE_INTERNAL_ERROR,
+                    format!(
+                        "pending checkpoint replacement changes public tracked identity '{}'",
+                        entry.identity.schema_key()
+                    ),
+                ));
+            }
+            let marker_schemas = [CHECKPOINT_MARKER_SCHEMA_KEY.to_string()];
+            let checkpoint_delta = tracked
+                .commit_delta_values_for_schemas(checkpoint_commit_id, &marker_schemas)
+                .await?;
+            let owns_checkpoint_marker = checkpoint_delta.iter().any(|row| {
+                let key = row.key_ref();
+                !row.value().deleted
+                    && key.schema_key == CHECKPOINT_MARKER_SCHEMA_KEY
+                    && key.file_id.is_none()
+                    && key.entity_pk.as_single_string().ok()
+                        == Some(replacement.checkpoint_branch_id.as_str())
+            });
+            if !owns_checkpoint_marker {
+                return Err(LixError::new(
+                    LixError::CODE_INTERNAL_ERROR,
+                    format!(
+                        "checkpoint '{checkpoint_commit_id}' lacks its authenticated branch marker"
+                    ),
+                ));
+            }
+            if prepared_writes
+                .checkpoint_publications
+                .iter()
+                .any(|publication| publication.recovery_ref.branch_id == branch_id)
+            {
+                return Err(LixError::new(
+                    LixError::CODE_INTERNAL_ERROR,
+                    format!("branch '{branch_id}' already staged checkpoint serving context"),
+                ));
+            }
+            prepared_writes
+                .checkpoint_publications
+                .push(CheckpointPublication {
+                    recovery_ref: CheckpointRecoveryRef {
+                        branch_id,
+                        recovered_head_commit_id: source_commit_id,
+                        checkpoint_commit_id,
+                        interval_has_commits: true,
+                    },
+                    gc_state: load_checkpoint_gc_state(read).await?,
+                });
+        }
+        Ok(())
+    }
+
+    async fn attach_checkpoint_branch_parents<S>(
+        &self,
+        read: &S,
+        prepared_writes: &mut PreparedWriteSet,
+        commit_parent_heads: &BTreeMap<String, Option<CommitId>>,
+    ) -> Result<(), LixError>
+    where
+        S: StorageAdapterRead + Clone + Send + Sync,
+    {
+        let branch_ids = prepared_writes
+            .commit_change_refs_by_branch
+            .keys()
+            .filter(|branch_id| {
+                !prepared_writes
+                    .checkpoint_publications
+                    .iter()
+                    .any(|publication| publication.recovery_ref.branch_id == branch_id.as_str())
+            })
+            .cloned()
+            .collect::<Vec<_>>();
+        let controls = BranchHeadControlContext::new()
+            .reader(read.clone())
+            .load_many(&branch_ids)
+            .await?;
+        for (branch_id, control) in branch_ids.into_iter().zip(controls) {
+            let Some(control) = control else {
+                continue;
+            };
+            let Some(parent_head) = commit_parent_heads.get(&branch_id).copied().flatten() else {
+                continue;
+            };
+            let Some(checkpoint_parent) = crate::gc::resolve_checkpoint_branch_parent(
+                read,
+                &branch_id,
+                parent_head,
+                control.working_diff_checkpoint_commit_id,
+            )
+            .await?
+            else {
+                continue;
+            };
+            let parents = prepared_writes
+                .extra_commit_parents_by_branch
+                .entry(branch_id)
+                .or_default();
+            if !parents.contains(&checkpoint_parent) {
+                // The compacted checkpoint is the canonical ancestry bridge,
+                // so it precedes any merge parent already staged by callers.
+                parents.insert(0, checkpoint_parent);
+            }
+        }
+        Ok(())
+    }
+
     /// Opens an execution-scoped staging area for SQL/provider hooks.
     async fn open<T, F>(
         mode: &SessionMode,
@@ -1518,6 +1673,7 @@ where
                     session_file_views,
                     pending_file_view_mutations: BTreeMap::new(),
                     pending_plugin_actor_publications: Vec::new(),
+                    pending_branch_checkpoint_replacements: BTreeMap::new(),
                     plugin_generation_read_guard: None,
                     plugin_generation_upgrade_guard: None,
                 },
@@ -1606,6 +1762,15 @@ where
                 .await;
             return Err(error);
         }
+        if let Err(error) = transaction
+            .resolve_pending_branch_checkpoint_replacements(&read, &mut prepared_writes)
+            .await
+        {
+            transaction
+                .discard_pending_plugin_actor_publications()
+                .await;
+            return Err(error);
+        }
         let commit_parent_heads = match commit::resolve_prepared_commit_parent_heads(
             transaction.branch_ctx.as_ref(),
             &read,
@@ -1622,6 +1787,15 @@ where
                 return Err(error);
             }
         };
+        if let Err(error) = transaction
+            .attach_checkpoint_branch_parents(&read, &mut prepared_writes, &commit_parent_heads)
+            .await
+        {
+            transaction
+                .discard_pending_plugin_actor_publications()
+                .await;
+            return Err(error);
+        }
         if let Err(error) = transaction
             .validate_prepared_writes_by_branch(&read, &prepared_writes)
             .instrument(tracing::debug_span!(
@@ -6365,6 +6539,31 @@ where
     /// Returns the active branch resolved inside this write transaction.
     pub(crate) fn active_branch_id(&self) -> &str {
         &self.active_branch_id
+    }
+
+    /// Defers explicit historical-source branchability to the commit boundary.
+    ///
+    /// Ordinary reachable commits need no bridge. A compacted source is
+    /// accepted only through one pending authenticated GC transition observed
+    /// by the same read whose queue row fences branch publication.
+    pub(crate) fn stage_branch_checkpoint_replacement_resolution(
+        &mut self,
+        branch_id: String,
+        source_commit_id: CommitId,
+    ) -> Result<(), LixError> {
+        if self
+            .pending_branch_checkpoint_replacements
+            .insert(branch_id.clone(), source_commit_id)
+            .is_some()
+        {
+            return Err(LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                format!(
+                    "branch '{branch_id}' staged more than one checkpoint replacement resolution"
+                ),
+            ));
+        }
+        Ok(())
     }
 
     /// Reports whether visible untracked state is owned by any requested file.

--- a/packages/lix/src/transaction/context.rs
+++ b/packages/lix/src/transaction/context.rs
@@ -288,6 +288,19 @@ struct StaleConflictPayload {
     metadata: Option<SharedStr>,
 }
 
+fn checkpoint_marker_identity_matches_branch(
+    entity_pk: &EntityPk,
+    branch_id: &str,
+) -> Result<bool, LixError> {
+    let expected = EntityPk::uuid_from_canonical(branch_id).map_err(|error| {
+        LixError::new(
+            LixError::CODE_INTERNAL_ERROR,
+            format!("checkpoint branch id '{branch_id}' is not a canonical UUID: {error}"),
+        )
+    })?;
+    Ok(entity_pk == &expected)
+}
+
 struct StaleSemanticConflict {
     key: TrackedStateKey,
     base: Option<StaleConflictPayload>,
@@ -1429,14 +1442,21 @@ where
             let checkpoint_delta = tracked
                 .commit_delta_values_for_schemas(checkpoint_commit_id, &marker_schemas)
                 .await?;
-            let owns_checkpoint_marker = checkpoint_delta.iter().any(|row| {
+            let mut owns_checkpoint_marker = false;
+            for row in checkpoint_delta.iter() {
                 let key = row.key_ref();
-                !row.value().deleted
+                if !row.value().deleted
                     && key.schema_key == CHECKPOINT_MARKER_SCHEMA_KEY
                     && key.file_id.is_none()
-                    && key.entity_pk.as_single_string().ok()
-                        == Some(replacement.checkpoint_branch_id.as_str())
-            });
+                    && checkpoint_marker_identity_matches_branch(
+                        key.entity_pk,
+                        &replacement.checkpoint_branch_id,
+                    )?
+                {
+                    owns_checkpoint_marker = true;
+                    break;
+                }
+            }
             if !owns_checkpoint_marker {
                 return Err(LixError::new(
                     LixError::CODE_INTERNAL_ERROR,
@@ -11798,6 +11818,46 @@ mod tests {
     }
 
     const SCHEMA_FIXTURE_COMMIT_ID: &str = "01920000-0000-7000-8000-0000000000f1";
+
+    #[test]
+    fn checkpoint_marker_owner_requires_exact_typed_uuid_identity() {
+        const BRANCH_ID: &str = "01920000-0000-7000-8000-0000000000f2";
+        let valid = EntityPk::uuid_from_canonical(BRANCH_ID).expect("valid branch UUID");
+        assert!(
+            checkpoint_marker_identity_matches_branch(&valid, BRANCH_ID)
+                .expect("valid marker identity should compare")
+        );
+
+        let wrong_uuid = EntityPk::uuid_from_canonical("01920000-0000-7000-8000-0000000000f3")
+            .expect("wrong UUID fixture should parse");
+        assert!(
+            !checkpoint_marker_identity_matches_branch(&wrong_uuid, BRANCH_ID)
+                .expect("wrong UUID should compare without coercion")
+        );
+
+        let wrong_type = EntityPk::single(BRANCH_ID);
+        assert!(
+            !checkpoint_marker_identity_matches_branch(&wrong_type, BRANCH_ID)
+                .expect("string identity should compare without coercion")
+        );
+
+        let composite = EntityPk::from_external_parts(
+            vec![BRANCH_ID.to_owned(), "extra".to_owned()],
+            &[
+                crate::entity_pk::EntityPkComponentType::Uuid,
+                crate::entity_pk::EntityPkComponentType::String,
+            ],
+        )
+        .expect("composite fixture should parse");
+        assert!(
+            !checkpoint_marker_identity_matches_branch(&composite, BRANCH_ID)
+                .expect("composite identity should compare without coercion")
+        );
+        assert!(
+            checkpoint_marker_identity_matches_branch(&valid, "not-a-canonical-uuid").is_err(),
+            "malformed expected branch authority must fail closed"
+        );
+    }
 
     #[test]
     fn semantic_conflict_limits_scale_host_owned_records_but_not_bytes_or_deadline() {

--- a/packages/lix/tests/integration/branching.rs
+++ b/packages/lix/tests/integration/branching.rs
@@ -1057,6 +1057,203 @@ simulation_test!(
 );
 
 simulation_test!(
+    checkpoint_preserves_branch_fork_as_merge_ancestry,
+    |sim| async move {
+        let engine = sim.boot_engine().await;
+        let main = sim.wrap_session(
+            engine
+                .open_session(sim.main_branch_id())
+                .await
+                .expect("main session should open"),
+            &engine,
+        );
+        main.execute(
+            "INSERT INTO lix_key_value (key, value) VALUES \
+             ('checkpoint-fork-source', 'shared-source'), \
+             ('checkpoint-fork-target', 'shared-target')",
+            &[],
+        )
+        .await
+        .expect("shared rows should be inserted");
+        let fork_commit_id = engine
+            .load_branch_head_commit_id(sim.main_branch_id())
+            .await
+            .expect("main head should load")
+            .expect("main head should exist");
+        let checkpoint = main
+            .create_checkpoint()
+            .await
+            .expect("target checkpoint should succeed");
+        let branch = main
+            .create_branch(CreateBranchOptions {
+                id: Some("01930000-0000-7000-8000-000000000001".to_string()),
+                name: "Recovered source".to_string(),
+                from_commit_id: Some(fork_commit_id.clone()),
+            })
+            .await
+            .expect("historical recovered head should remain branchable while pending");
+        assert_eq!(branch.commit_id, fork_commit_id);
+        let draft = sim.wrap_session(
+            engine
+                .open_session("01930000-0000-7000-8000-000000000001")
+                .await
+                .expect("recovered source session should open"),
+            &engine,
+        );
+        draft
+            .execute(
+                "UPDATE lix_key_value SET value = 'source' \
+                 WHERE key = 'checkpoint-fork-source'",
+                &[],
+            )
+            .await
+            .expect("source edit should succeed");
+        let source_commit_id = engine
+            .load_branch_head_commit_id("01930000-0000-7000-8000-000000000001")
+            .await
+            .expect("source head should load")
+            .expect("source head should exist");
+        main.execute(
+            "UPDATE lix_key_value SET value = 'target' \
+             WHERE key = 'checkpoint-fork-target'",
+            &[],
+        )
+        .await
+        .expect("target edit should succeed");
+
+        let preview = main
+            .merge_branch_preview(MergeBranchPreviewOptions {
+                source_branch_id: "01930000-0000-7000-8000-000000000001".to_string(),
+            })
+            .await
+            .expect("disjoint changes should merge without conflicts");
+        assert_eq!(preview.base_commit_id, checkpoint.commit_id);
+        assert_eq!(preview.outcome, MergeBranchOutcome::MergeCommitted);
+        assert_eq!(preview.conflicts.len(), 0);
+        assert_eq!(
+            preview.change_stats,
+            MergeChangeStats {
+                total: 1,
+                added: 0,
+                modified: 1,
+                removed: 0,
+            }
+        );
+
+        let receipt = main
+            .merge_branch(MergeBranchOptions {
+                source_branch_id: "01930000-0000-7000-8000-000000000001".to_string(),
+            })
+            .await
+            .expect("disjoint changes should merge");
+        assert_eq!(receipt.base_commit_id, checkpoint.commit_id);
+        assert_key_value(&main, "checkpoint-fork-source", Some("\"source\"")).await;
+        assert_key_value(&main, "checkpoint-fork-target", Some("\"target\"")).await;
+
+        let global = sim.wrap_session(
+            engine
+                .open_session("ffffffff-ffff-7fff-bfff-ffffffffffff")
+                .await
+                .expect("global session should open"),
+            &engine,
+        );
+        assert_eq!(
+            commit_parent_edges(&global, &checkpoint.commit_id).await,
+            vec![(sim.initial_commit_id().to_string(), 0)],
+            "checkpoint compaction must not retain the recovered interval as permanent ancestry",
+        );
+        assert_eq!(
+            commit_parent_edges(&global, &source_commit_id).await,
+            vec![(fork_commit_id, 0), (checkpoint.commit_id, 1)],
+            "the first source commit should consume serving context into canonical graph parents",
+        );
+    }
+);
+
+simulation_test!(
+    checkpoint_branch_bridge_preserves_true_conflict,
+    |sim| async move {
+        let engine = sim.boot_engine().await;
+        let main = sim.wrap_session(
+            engine
+                .open_session(sim.main_branch_id())
+                .await
+                .expect("main session should open"),
+            &engine,
+        );
+        main.execute(
+            "INSERT INTO lix_key_value (key, value) VALUES ('checkpoint-bridge-conflict', 'base')",
+            &[],
+        )
+        .await
+        .expect("shared conflict row should insert");
+        let recovered_head = engine
+            .load_branch_head_commit_id(sim.main_branch_id())
+            .await
+            .expect("recovered head should load")
+            .expect("recovered head should exist");
+        let checkpoint = main
+            .create_checkpoint()
+            .await
+            .expect("checkpoint should succeed")
+            .commit_id;
+        main.create_branch(CreateBranchOptions {
+            id: Some("01930000-0000-7000-8000-000000000002".to_string()),
+            name: "Recovered conflict source".to_string(),
+            from_commit_id: Some(recovered_head.clone()),
+        })
+        .await
+        .expect("recovered conflict source should remain branchable");
+        let source = sim.wrap_session(
+            engine
+                .open_session("01930000-0000-7000-8000-000000000002")
+                .await
+                .expect("conflict source session should open"),
+            &engine,
+        );
+        source
+            .execute(
+                "UPDATE lix_key_value SET value = 'source' WHERE key = 'checkpoint-bridge-conflict'",
+                &[],
+            )
+            .await
+            .expect("source conflict edit should succeed");
+        let source_head = engine
+            .load_branch_head_commit_id("01930000-0000-7000-8000-000000000002")
+            .await
+            .expect("source conflict head should load")
+            .expect("source conflict head should exist");
+        main.execute(
+            "UPDATE lix_key_value SET value = 'target' WHERE key = 'checkpoint-bridge-conflict'",
+            &[],
+        )
+        .await
+        .expect("target conflict edit should succeed");
+
+        let preview = main
+            .merge_branch_preview(MergeBranchPreviewOptions {
+                source_branch_id: "01930000-0000-7000-8000-000000000002".to_string(),
+            })
+            .await
+            .expect("true conflict preview should succeed");
+        assert_eq!(preview.base_commit_id, checkpoint);
+        assert_eq!(preview.conflicts.len(), 1);
+        assert_eq!(
+            commit_parent_edges(&main, &source_head).await,
+            vec![(recovered_head, 0), (checkpoint, 1)]
+        );
+        let error = main
+            .merge_branch(MergeBranchOptions {
+                source_branch_id: "01930000-0000-7000-8000-000000000002".to_string(),
+            })
+            .await
+            .expect_err("same-identity changes must still conflict");
+        assert_merge_conflict_error(&error);
+        assert_key_value(&main, "checkpoint-bridge-conflict", Some("\"target\"")).await;
+    }
+);
+
+simulation_test!(
     merge_branch_selects_source_change_without_minting_equivalent_copy,
     |sim| async move {
         let (engine, main, draft) = create_draft_from_main(&sim).await;

--- a/packages/lix/tests/integration/checkpoint_gc.rs
+++ b/packages/lix/tests/integration/checkpoint_gc.rs
@@ -190,12 +190,9 @@ simulation_test!(
                 .await
                 .expect("post-delete GC checkpoint should succeed");
         }
-        wait_for_commits(
-            &main,
-            &[&protected_first, &protected_head, &source_head],
-            false,
-        )
-        .await;
+        // This contract covers the recovered pre-checkpoint interval. The
+        // deleted branch's final head has independent history/undo ownership.
+        wait_for_commits(&main, &[&protected_first, &protected_head], false).await;
     }
 );
 

--- a/packages/lix/tests/integration/checkpoint_gc.rs
+++ b/packages/lix/tests/integration/checkpoint_gc.rs
@@ -96,7 +96,7 @@ simulation_test!(
 );
 
 simulation_test!(
-    checkpoint_gc_keeps_commits_referenced_by_another_branch,
+    checkpoint_gc_keeps_then_reclaims_recovered_branch_interval,
     |sim| async move {
         let engine = sim.boot_engine().await;
         let main = sim.wrap_session(
@@ -121,9 +121,11 @@ simulation_test!(
         .await
         .expect("protected interval update should succeed");
         let protected_head = branch_head(&engine, sim.main_branch_id()).await;
-        main.create_checkpoint()
+        let compacted_checkpoint = main
+            .create_checkpoint()
             .await
-            .expect("checkpoint retaining the first interval should succeed");
+            .expect("checkpoint retaining the first interval should succeed")
+            .commit_id;
 
         main.create_branch(CreateBranchOptions {
             id: Some("01920000-0000-7000-8000-000000000510".to_string()),
@@ -132,6 +134,25 @@ simulation_test!(
         })
         .await
         .expect("branch should be created from the recoverable auto-commit");
+        let protected = sim.wrap_session(
+            engine
+                .open_session("01920000-0000-7000-8000-000000000510")
+                .await
+                .expect("protected branch session should open"),
+            &engine,
+        );
+        protected
+            .execute(
+                "UPDATE lix_key_value SET value = 'protected-source' WHERE key = 'branch-gc-key'",
+                &[],
+            )
+            .await
+            .expect("first source commit should consume the checkpoint bridge");
+        let source_head = branch_head(&engine, "01920000-0000-7000-8000-000000000510").await;
+        assert_eq!(
+            commit_parent_edges(&main, &source_head).await,
+            vec![(protected_head.clone(), 0), (compacted_checkpoint, 1),],
+        );
         advance_to_next_gc(&main, 1).await;
         main.execute(
             "INSERT INTO lix_key_value (key, value) VALUES ('main-after-branch', 'main')",
@@ -145,13 +166,6 @@ simulation_test!(
 
         assert_commits(&main, &[&protected_first, &protected_head], true).await;
 
-        let protected = sim.wrap_session(
-            engine
-                .open_session("01920000-0000-7000-8000-000000000510")
-                .await
-                .expect("protected branch session should open"),
-            &engine,
-        );
         let state = protected
             .execute(
                 "SELECT value FROM lix_key_value WHERE key = 'branch-gc-key'",
@@ -161,8 +175,27 @@ simulation_test!(
             .expect("protected branch state should remain readable");
         assert_eq!(
             state.rows()[0].values(),
-            &[Value::Json(json!("protected-head"))]
+            &[Value::Json(json!("protected-source"))]
         );
+
+        drop(protected);
+        main.execute(
+            "DELETE FROM lix_branch WHERE id = '01920000-0000-7000-8000-000000000510'",
+            &[],
+        )
+        .await
+        .expect("protected branch should delete");
+        for _ in 0..CHECKPOINT_GC_INTERVAL {
+            main.create_checkpoint()
+                .await
+                .expect("post-delete GC checkpoint should succeed");
+        }
+        wait_for_commits(
+            &main,
+            &[&protected_first, &protected_head, &source_head],
+            false,
+        )
+        .await;
     }
 );
 
@@ -462,6 +495,34 @@ async fn branch_head(engine: &lix::integration::Engine, branch_id: &str) -> Stri
         .await
         .expect("branch head should load")
         .expect("branch head should exist")
+}
+
+async fn commit_parent_edges(
+    session: &support::simulation_test::engine::SimSession,
+    commit_id: &str,
+) -> Vec<(String, i64)> {
+    session
+        .execute(
+            &format!(
+                "SELECT parent_id, parent_order FROM lix_commit_edge \
+                 WHERE child_id = '{commit_id}' ORDER BY parent_order"
+            ),
+            &[],
+        )
+        .await
+        .expect("commit parent edges should read")
+        .rows()
+        .iter()
+        .map(|row| {
+            let Value::Text(parent_id) = &row.values()[0] else {
+                panic!("parent id should be text");
+            };
+            let Value::Integer(parent_order) = row.values()[1] else {
+                panic!("parent order should be integer");
+            };
+            (parent_id.clone(), parent_order)
+        })
+        .collect()
 }
 
 async fn assert_commits(


### PR DESCRIPTION
## Summary

Preserve correct merge ancestry when a branch is created from a historical recovered head after checkpoint compaction, without retaining compacted intervals permanently or introducing a second chronology authority.

## Causal defect

Checkpoint compaction deliberately parents each checkpoint commit to the previous checkpoint, not to every recovered ordinary head. The authenticated recovery reference retains reconstruction authority, but it is not and must not become merge chronology. A branch created from recovered head `H` therefore descended directly from `H`, while the target branch descended from semantically equivalent compacted checkpoint `C`. Commit-graph merge-base selection retreated behind both, causing disjoint modifications to be misclassified as unrelated added/added conflicts.

The exact minimum reproducer is three rows, one ordinary history commit, one checkpoint, then distinct source/target edits. The no-checkpoint control passes.

## Hard correction

- Resolve exactly one still-pending authenticated reachability transition `H -> C` through the private GC owner facade under the commit boundary's coherent read.
- Require matching branch controls/digests, `C` in the same batch's checkpoint roots, complete H/C semantic equivalence, and the exact typed checkpoint-marker UUID identity.
- Consume the proof only in the existing explicit branch-creation publication owner. After it creates the complete root-backed control for `H`, bind `C` as its serving checkpoint and atomically stage the existing recovery row, empty working-diff epoch, branch control, root delta, and exact pending-queue CAS.
- The first ordinary source commit records canonical graph parents `[H, C]`; merge-base is `C`, never a later target head.
- Missing, malformed, ambiguous, stale, or GC-consumed proof fails closed. Branch deletion releases H for normal checkpoint GC.

`CheckpointPublication` remains exclusive to genuine checkpoints. Its complete-HOT invariant is unchanged; branch creation does not synthesize a checkpoint, HOT member, or incomplete control.

## Authority and format

The commit object's ordered parent list remains the sole merge/history chronology authority. Pending reachability state is construction-time proof; the branch recovery row/control is bounded serving context. Merge and history readers do not consult either.

No new storage space, persisted format, codec, migration, compatibility reader, fallback, cache, shadow index, or dual writer is introduced.

## Exact provenance

- Original base: `a12b76c8690130df5f9cb44a51e9cf3a3bcdb6b3`
- Rebased main: `b87e74909cd5ced4d9e02bf78c609255a59bf6a0`
- Rebased commits: `915562ce1`, `0be5bfd4f`, `fb4679925`, `8e529f306`, `253f7040c`
- Current PR head: `253f7040c10787db3941bbb9342a902cbd4cb1ec`
- Current PR head parent: `8e529f306a1a285b809a27d6b2d302119dae6460`
- Current PR tree: `1792085eb43a50cea578b4da4e0c96d1c678ad08`
- `main..head` full-index binary SHA-256: `f68725ed380f19ea3399cb20e7a4de1262527ae514352284c961832f514376d0`
- Full stable patch ID: `4c9a99d374c2023492415d2e14eba7fb0187d435`

The rebase preserved the reviewed runtime patch. A test-only follow-up narrows the deleted-branch GC assertion to the recovered interval covered by this change.

## CI successor correction

Hosted run `31233938849` on preserved head `279452652` exposed one candidate-owned compile boundary: `attach_checkpoint_branch_parents(&self, ...)` retained `&Transaction` across awaits, requiring `Transaction: Sync` even though `PendingPluginActorPublication` intentionally contains a non-`Sync` WASM actor. Cargo Test and Clippy therefore failed the existing public-future `Send` contract.

The direct successor removes only the unused `&self` receiver and calls the method as `Self::attach_checkpoint_branch_parents(...)`. It changes no runtime semantics, actor bounds, persisted state, authority, or test expectations. Successor scope is exactly one Rust file/blob (`packages/lix/src/transaction/context.rs`, blob `64a96f14a7be86df84ef3a096b777aff834b439b`) with `+6/-4` formatting-inclusive lines.

Focused successor gates:

- `cargo fmt --all -- --check`: green.
- `git diff --check`: green.
- `cargo test -p lix --test send_futures --all-features --no-run`: green in 2m49s, executable `send_futures-53c3701dbb367aad`.
- `cargo test -p lix --test send_futures --all-features -- --nocapture`: 3/3 green in 0.09s.

## Independent evidence

- Source/authority APPROVE on exact `743ab59d`/tree `fa020ef0`: report commit `f7a89a71267ca1b17017e5cfa0452585088923be`; report SHA-256 `cc7b324f84180e616dc693879c7748a9882b332185e3e84cc84534fa3ad6df9c`.
- Runtime APPROVE on exact `743ab59d`:
  - RocksDB public oracle: 1/1, 0.06 s test, 20.20 s total, 2,396,036 KiB peak RSS.
  - SlateDB public oracle: 1/1, 0.07 s test, 0.21 s total, 124,472 KiB peak RSS.
  - Owner/proof controls green: branch serving context, genuine checkpoint missing-HOT rejection, unique queue CAS, recovery-ref non-authority, malformed proof, and typed UUID identity.
  - Dual-adapter binary SHA-256 `6d1a0b80215dc76581cf6fd7345c769ba910b9bdf7b7dc29eb2ac63af3a30c7e`; lib-test binary SHA-256 `93a25938fbc417085185bd5bdf212978bb1273c86b2bc70b4a3192fe61eb7d68`.
  - Runtime report SHA-256 `2399a906af03ced41a0f11b0535032e0227eb0eb3668310b767ad1afe20d1c38`.
- Author report: `/root/repos/lix-evidence/checkpoint-ancestry-743ab5/REPORT.md`, SHA-256 `3204eebc2e5778c60e77917fe1819961a2c95701538878ea53b7b5365ed0882e`.

## Focused commands

```sh
cargo test -p lix --lib transaction::commit::tests::branch_creation_owner_publishes_checkpoint_serving_context -- --exact --nocapture --test-threads=1
cargo test -p lix --lib transaction::commit::tests::real_checkpoint_without_complete_hot_control_still_fails -- --exact --nocapture --test-threads=1
cargo test -p lix --lib transaction::context::tests::checkpoint_marker_owner_requires_exact_typed_uuid_identity -- --exact --nocapture --test-threads=1
cargo test -p lix --lib gc::tests::pending_checkpoint_replacement_is_unique_and_queue_cas_fenced -- --exact --nocapture --test-threads=1
cargo test -p lix --lib gc::tests::recovery_ref_without_pending_replacement_is_not_branchable_authority -- --exact --nocapture --test-threads=1
cargo test -p lix --lib gc::tests::malformed_pending_checkpoint_replacement_fails_closed -- --exact --nocapture --test-threads=1
cargo test -p lix_benchmarks --test checkpoint_branch_merge_reopen --features rocksdb,slatedb rocksdb_checkpoint_preserves_branch_merge_base_after_reopen -- --exact --nocapture --test-threads=1
cargo test -p lix_benchmarks --test checkpoint_branch_merge_reopen --features rocksdb,slatedb slatedb_checkpoint_preserves_branch_merge_base_after_reopen -- --exact --nocapture --test-threads=1
```

Hosted merge gate: every required check must be terminal green on exact head `253f7040c10787db3941bbb9342a902cbd4cb1ec`; merge must use that expected-head guard.