### PR TITLE
Run CI only for reviewable PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   pull_request:
-    types: [opened, reopened, synchronize]
+    types: [opened, reopened, synchronize, ready_for_review]
   push:
     branches:
       - main
@@ -20,6 +20,7 @@ defaults:
 jobs:
   changelog:
     name: Changelog
+    if: github.event_name == 'push' || github.event.pull_request.draft == false
     runs-on: blacksmith-32vcpu-ubuntu-2404
 
     steps:
@@ -31,6 +32,7 @@ jobs:
 
   cargo-config:
     name: Cargo config (${{ matrix.name }})
+    if: github.event_name == 'push' || github.event.pull_request.draft == false
     runs-on: ${{ matrix.runner }}
     strategy:
       fail-fast: false
@@ -52,6 +54,7 @@ jobs:
 
   cargo:
     name: Cargo ${{ matrix.name }}
+    if: github.event_name == 'push' || github.event.pull_request.draft == false
     runs-on: blacksmith-32vcpu-ubuntu-2404
     strategy:
       fail-fast: false
@@ -132,6 +135,7 @@ jobs:
 
   js-sdk-test:
     name: JS SDK ${{ matrix.name }} Test
+    if: github.event_name == 'push' || github.event.pull_request.draft == false
     runs-on: blacksmith-32vcpu-ubuntu-2404
     strategy:
       fail-fast: false


### PR DESCRIPTION
## What changed

- skip every CI job while a pull request is in draft
- trigger CI when a draft is marked ready for review
- preserve CI runs for pushes to `main` and `master`

## Why

Long-lived draft PRs, especially #1264, receive frequent synchronization events and currently consume the full CI matrix even though they are not ready for review.

## Impact

Draft PR updates will create only skipped jobs and consume no CI runners. Opening a non-draft PR or marking a draft ready will run the full suite, and later commits to reviewable PRs will continue to run it.

## Validation

- `actionlint .github/workflows/ci.yml`
- `git diff --check`