### PR TITLE
experiment: give untracked rows terminal change ids

### DIFF
--- a/packages/lix/src/changelog/context.rs
+++ b/packages/lix/src/changelog/context.rs
@@ -28,7 +28,7 @@ use crate::changelog::{
     ChangeId, ChangeLoadBatch, ChangeLoadRequest, ChangeRecord, ChangeScanBatch, ChangeScanRequest,
     ChangelogAppend, ChangelogReader, ChangelogWriter, CommitId, CommitLoadBatch,
     CommitLoadRequest, CommitRecord, CommitScanBatch, CommitScanRequest,
-    TransactionChangelogAppend,
+    TransactionChangeRecordRef, TransactionChangelogAppend,
 };
 use crate::json_store::JsonSlotRef;
 use crate::storage_adapter::Storage;
@@ -48,6 +48,23 @@ pub(crate) struct ChangelogContext;
 impl ChangelogContext {
     pub(crate) fn new() -> Self {
         Self
+    }
+
+    /// Stages one normalized standalone change in the caller's existing
+    /// publication write set. This is the no-second-read terminal path for
+    /// engine-owned untracked current state.
+    pub(crate) fn stage_terminal_standalone_change(
+        &self,
+        writes: &mut StorageWriteSet,
+        change: TransactionChangeRecordRef<'_>,
+    ) -> Result<(), LixError> {
+        let mut batch =
+            EncodedChangelogBatch::with_capacity(1, 16, transaction_change_value_capacity(&change));
+        batch.try_put(change.change_id.as_uuid().as_bytes(), |bytes| {
+            append_transaction_change_record(bytes, &change)
+        })?;
+        batch.stage(writes, CHANGE_SPACE);
+        Ok(())
     }
 
     pub(crate) fn reader<S>(&self, store: S) -> ChangelogStoreReader<S>
@@ -142,9 +159,7 @@ impl EncodedChangelogBatch {
     }
 }
 
-fn transaction_change_value_capacity(
-    change: &crate::changelog::TransactionChangeRecordRef<'_>,
-) -> usize {
+fn transaction_change_value_capacity(change: &TransactionChangeRecordRef<'_>) -> usize {
     96usize
         .saturating_add(change.schema_key.len())
         .saturating_add(change.entity_pk.estimated_heap_bytes())
@@ -155,7 +170,7 @@ fn transaction_change_value_capacity(
 }
 
 fn change_value_capacity(change: &ChangeRecord) -> usize {
-    let change = crate::changelog::TransactionChangeRecordRef::from(change);
+    let change = TransactionChangeRecordRef::from(change);
     transaction_change_value_capacity(&change)
 }
 

--- a/packages/lix/src/changelog/types.rs
+++ b/packages/lix/src/changelog/types.rs
@@ -491,9 +491,6 @@ pub(crate) struct RebuildIndexStats {
 pub(crate) enum GcRoot {
     BranchHead(CommitId),
     StandaloneChange(ChangeId),
-    /// A history-free untracked current-state member owns this payload
-    /// directly, without a changelog record to retain it.
-    CurrentPayload(JsonRef),
 }
 
 #[derive(Clone, Debug, Default, Eq, PartialEq)]

--- a/packages/lix/src/engine.rs
+++ b/packages/lix/src/engine.rs
@@ -1330,8 +1330,9 @@ mod tests {
             "an untracked-only write must not publish a new branch commit"
         );
         assert_eq!(
-            changes_after, changes_before,
-            "an untracked-only write must not append a changelog change"
+            changes_after,
+            changes_before + 1,
+            "an untracked-only write must publish exactly one standalone change"
         );
         assert_eq!(
             diff_after, diff_before,
@@ -1383,8 +1384,8 @@ mod tests {
             json!({"source": "tracked"})
         );
 
-        // A checkpointed branch remains writable. This history-free mutation
-        // updates the same complete hot generation without advancing history.
+        // A checkpointed branch remains writable. This untracked mutation
+        // updates the same complete hot generation without advancing commit history.
         session
             .execute(
                 "INSERT INTO json_pointer (path, value, lixcol_untracked) \
@@ -1407,7 +1408,7 @@ mod tests {
             json!({"source": "untracked"})
         );
 
-        // The next tracked child carries the history-free member forward.
+        // The next tracked child carries the untracked member forward.
         session
             .execute(
                 "INSERT INTO json_pointer (path, value) \

--- a/packages/lix/src/functions/context.rs
+++ b/packages/lix/src/functions/context.rs
@@ -1,5 +1,7 @@
 use crate::LixError;
 use crate::changelog::ChangeId;
+#[cfg(test)]
+use crate::changelog::{ChangelogContext, TransactionChangeRecordRef};
 use crate::common::LixTimestamp;
 use crate::functions::{
     DeterministicFunctionProvider, DeterministicSequence, FunctionProvider, FunctionProviderHandle,
@@ -363,6 +365,24 @@ mod tests {
             .expect("global branch control should load")
             .expect("global branch control should exist");
         let snapshot = crate::json_store::JsonSlot::from_json(&snapshot_content);
+        let change_id = ChangeId::for_test_label(&format!("function-context-{key}"));
+        ChangelogContext::new()
+            .stage_terminal_standalone_change(
+                &mut writes,
+                TransactionChangeRecordRef {
+                    format_version: 2,
+                    change_id,
+                    account_id: crate::SYSTEM_ACCOUNT_ID,
+                    entity_pk: &entity_pk,
+                    schema_key: "lix_key_value",
+                    file_id: None,
+                    snapshot: snapshot.as_ref_slot(),
+                    metadata: crate::json_store::JsonSlotRef::None,
+                    created_at: timestamp,
+                    origin_key: None,
+                },
+            )
+            .expect("test key-value change should stage");
         let mut next_control = control
             .next_current_state_revision()
             .expect("global control revision should advance");
@@ -381,7 +401,7 @@ mod tests {
                     schema_key: "lix_key_value",
                     file_id: None,
                     entity_pk: &entity_pk,
-                    change_id: None,
+                    change_id: Some(change_id),
                     commit_id: None,
                     untracked: true,
                     deleted: false,

--- a/packages/lix/src/functions/state.rs
+++ b/packages/lix/src/functions/state.rs
@@ -7,7 +7,9 @@ use crate::branch::{
     BranchHeadControlContext, branch_head_control_precondition, stage_branch_head_control,
     untracked_lifecycle_generation,
 };
-use crate::changelog::{ChangeId, ChangeRecordProjection};
+use crate::changelog::{
+    ChangeId, ChangeRecordProjection, ChangelogContext, TransactionChangeRecordRef,
+};
 use crate::common::LixTimestamp;
 use crate::entity_pk::EntityPk;
 use crate::functions::{DeterministicMode, DeterministicSequence};
@@ -30,7 +32,8 @@ const KEY_VALUE_SCHEMA_KEY: &str = "lix_key_value";
 ///
 /// Missing mode means deterministic execution is disabled. Malformed mode rows
 /// are errors because they would make runtime function behavior ambiguous. This
-/// is engine-owned global state and has no changelog or commit history.
+/// is engine-owned global state. Its current value owns one terminal
+/// standalone changelog record, but it never enters commit history.
 pub(crate) async fn load_mode(
     read: &(impl StorageAdapterRead + ?Sized),
 ) -> Result<DeterministicMode, LixError> {
@@ -57,14 +60,14 @@ pub(crate) async fn load_sequence(
 
 /// Persists the highest deterministic sequence value used by an execution.
 ///
-/// The row is untracked global `lix_key_value` current state. It never enters
-/// the changelog or commit graph.
+/// The row is untracked global `lix_key_value` current state. It owns one
+/// standalone change but never enters the commit graph.
 pub(crate) async fn stage_sequence(
     read: &(impl StorageAdapterRead + ?Sized),
     writes: &mut StorageWriteSet,
     sequence: DeterministicSequence,
     timestamp: LixTimestamp,
-    _change_id: ChangeId,
+    change_id: ChangeId,
 ) -> Result<StoragePrecondition, LixError> {
     let snapshot_content = serde_json::to_string(&serde_json::json!({
         "key": DETERMINISTIC_SEQUENCE_KEY,
@@ -95,6 +98,21 @@ pub(crate) async fn stage_sequence(
         [NormalizedJsonRef::from(&snapshot)],
     )?;
     let snapshot_slot = JsonSlot::from_json(snapshot.as_str());
+    ChangelogContext::new().stage_terminal_standalone_change(
+        writes,
+        TransactionChangeRecordRef {
+            format_version: 2,
+            change_id,
+            account_id: crate::SYSTEM_ACCOUNT_ID,
+            entity_pk: &entity_pk,
+            schema_key: KEY_VALUE_SCHEMA_KEY,
+            file_id: None,
+            snapshot: snapshot_slot.as_ref_slot(),
+            metadata: crate::json_store::JsonSlotRef::None,
+            created_at: timestamp,
+            origin_key: None,
+        },
+    )?;
     let next_revision = control
         .next_current_state_revision()?
         .current_state_revision;
@@ -113,7 +131,7 @@ pub(crate) async fn stage_sequence(
                 schema_key: KEY_VALUE_SCHEMA_KEY,
                 file_id: None,
                 entity_pk: &entity_pk,
-                change_id: None,
+                change_id: Some(change_id),
                 commit_id: None,
                 untracked: true,
                 deleted: false,
@@ -516,7 +534,10 @@ mod tests {
             .expect("sequence row should exist");
         assert!(row.untracked);
         assert!(row.global);
-        assert_eq!(row.change_id, None);
+        assert_eq!(
+            row.change_id,
+            Some(ChangeId::for_test_label("sequence-change-7"))
+        );
         assert_eq!(row.commit_id, None);
         assert_eq!(
             row.snapshot_content.as_deref(),
@@ -543,6 +564,24 @@ mod tests {
             .expect("global control should load")
             .expect("global control should exist");
         let snapshot = JsonSlot::from_json(&snapshot_content);
+        let change_id = ChangeId::for_test_label(&format!("test-key-value-{key}"));
+        ChangelogContext::new()
+            .stage_terminal_standalone_change(
+                &mut writes,
+                TransactionChangeRecordRef {
+                    format_version: 2,
+                    change_id,
+                    account_id: crate::SYSTEM_ACCOUNT_ID,
+                    entity_pk: &entity_pk,
+                    schema_key: KEY_VALUE_SCHEMA_KEY,
+                    file_id: None,
+                    snapshot: snapshot.as_ref_slot(),
+                    metadata: crate::json_store::JsonSlotRef::None,
+                    created_at: test_timestamp(),
+                    origin_key: None,
+                },
+            )
+            .expect("test key-value change should stage");
         let mut next_control = control
             .next_current_state_revision()
             .expect("global control revision should advance");
@@ -561,7 +600,7 @@ mod tests {
                     schema_key: KEY_VALUE_SCHEMA_KEY,
                     file_id: None,
                     entity_pk: &entity_pk,
-                    change_id: None,
+                    change_id: Some(change_id),
                     commit_id: None,
                     untracked: true,
                     deleted: false,

--- a/packages/lix/src/gc.rs
+++ b/packages/lix/src/gc.rs
@@ -2535,10 +2535,10 @@ where
         .await?;
     let mut roots = TrackedHeadContext::new()
         .reader(store.clone())
-        .untracked_json_refs(&controls)
+        .untracked_change_ids(&controls)
         .await?
         .into_iter()
-        .map(GcRoot::CurrentPayload)
+        .map(GcRoot::StandaloneChange)
         .collect::<Vec<_>>();
     // Branch controls, not their public `lix_branch_ref` projection rows,
     // are the authoritative tracked-history roots.
@@ -2679,7 +2679,7 @@ where
         .iter()
         .filter_map(|root| match root {
             GcRoot::BranchHead(commit_id) => Some(*commit_id),
-            GcRoot::StandaloneChange(_) | GcRoot::CurrentPayload(_) => None,
+            GcRoot::StandaloneChange(_) => None,
         })
         .collect::<Vec<_>>();
     while let Some(commit_id) = pending.pop() {
@@ -3035,7 +3035,7 @@ where
         .iter()
         .filter_map(|root| match root {
             GcRoot::StandaloneChange(change_id) => Some(*change_id),
-            GcRoot::BranchHead(_) | GcRoot::CurrentPayload(_) => None,
+            GcRoot::BranchHead(_) => None,
         })
         .collect::<BTreeSet<_>>();
     if let Some(change_id) = standalone_root_ids
@@ -3049,13 +3049,7 @@ where
     }
 
     let mut live_change_ids = standalone_root_ids.clone();
-    let mut live_payload_hashes = roots
-        .iter()
-        .filter_map(|root| match root {
-            GcRoot::CurrentPayload(json_ref) => Some(*json_ref.as_hash_array()),
-            GcRoot::BranchHead(_) | GcRoot::StandaloneChange(_) => None,
-        })
-        .collect::<BTreeSet<_>>();
+    let mut live_payload_hashes = BTreeSet::new();
     live_payload_hashes.extend(live_current_state_payload_hashes);
     for change_id in &standalone_root_ids {
         collect_change_payload_hashes(
@@ -3444,6 +3438,7 @@ mod tests {
     use crate::changelog::{
         ChangeId, ChangeLoadRequest, ChangeRecord, ChangelogAppend, ChangelogContext,
         ChangelogReader, ChangelogWriter, CommitId, CommitLoadRequest, CommitRecord, GcRoot,
+        TransactionChangeRecordRef,
     };
     use crate::common::LixTimestamp;
     use crate::entity_pk::EntityPk;
@@ -7536,7 +7531,30 @@ mod tests {
         let snapshot_slot = snapshot.map_or(JsonSlot::None, JsonSlot::Ref);
         let timestamp =
             LixTimestamp::expect_parse("untracked GC owner timestamp", "2026-01-01T00:00:00Z");
+        let change_id = ChangeId::for_test_label(&format!(
+            "gc-untracked-owner-{entity_pk_value}-{}",
+            if snapshot.is_some() { "live" } else { "delete" }
+        ));
         let mut writes = storage_adapter.new_write_set();
+        if snapshot.is_some() {
+            ChangelogContext::new()
+                .stage_terminal_standalone_change(
+                    &mut writes,
+                    TransactionChangeRecordRef {
+                        format_version: 2,
+                        change_id,
+                        account_id: crate::SYSTEM_ACCOUNT_ID,
+                        entity_pk: &entity_pk,
+                        schema_key: "gc_untracked_owner",
+                        file_id: None,
+                        snapshot: snapshot_slot.as_ref_slot(),
+                        metadata: JsonSlotRef::None,
+                        created_at: timestamp,
+                        origin_key: None,
+                    },
+                )
+                .expect("untracked current-state change should stage");
+        }
         let mut coverage = WorkingDiffIndexCoverage::default();
         TrackedHeadContext::new()
             .writer(&read, &mut writes)
@@ -7548,7 +7566,7 @@ mod tests {
                     schema_key: "gc_untracked_owner",
                     file_id: None,
                     entity_pk: &entity_pk,
-                    change_id: None,
+                    change_id: Some(change_id),
                     commit_id: None,
                     untracked: true,
                     deleted: snapshot.is_none(),

--- a/packages/lix/src/init.rs
+++ b/packages/lix/src/init.rs
@@ -321,7 +321,8 @@ pub(crate) fn plan_init_seed(functions: FunctionProviderHandle) -> Result<InitSe
 /// The pure seed planner decides which bootstrap facts exist. This function is
 /// only responsible for durably writing those facts to their owning stores:
 /// changelog for tracked changes, and live_state for the serving state
-/// plus untracked moving refs.
+/// plus untracked moving refs. Every live untracked seed owns one standalone
+/// changelog fact, without becoming a commit member.
 pub(crate) async fn initialize<StorageImpl>(
     storage: StorageAdapter<StorageImpl>,
     tracked_state: &TrackedStateContext,
@@ -350,15 +351,19 @@ where
         .iter()
         .map(|branch| seed_untracked_change_to_change_record(&branch.branch_ref_change))
         .collect::<Vec<_>>();
+    let standalone_untracked_changes = branch_ref_ledger_changes
+        .iter()
+        .cloned()
+        .chain(
+            plan.untracked_rows
+                .iter()
+                .map(seed_untracked_change_to_change_record),
+        )
+        .collect::<Vec<_>>();
 
     stage_init_json_payloads(&mut writes, &plan)?;
-    stage_init_changelog_commit(
-        &mut read,
-        &mut writes,
-        &plan,
-        branch_ref_ledger_changes.clone(),
-    )
-    .await?;
+    stage_init_changelog_commit(&mut read, &mut writes, &plan, standalone_untracked_changes)
+        .await?;
 
     {
         let root_deltas = authored_changes
@@ -458,7 +463,7 @@ where
                     schema_key: &row.schema_key,
                     file_id: None,
                     entity_pk: &row.entity_pk,
-                    change_id: None,
+                    change_id: Some(row.id),
                     commit_id: None,
                     untracked: true,
                     deleted: false,

--- a/packages/lix/src/live_state/context.rs
+++ b/packages/lix/src/live_state/context.rs
@@ -1749,6 +1749,18 @@ mod tests {
         ChangeId::for_test_label(label)
     }
 
+    fn untracked_fixture_change_id(row: &MaterializedUntrackedStateRow) -> ChangeId {
+        ChangeId::for_test_label(&format!(
+            "untracked-fixture:{}:{}:{}:{}",
+            row.branch_id,
+            row.schema_key,
+            row.file_id.as_deref().unwrap_or("<none>"),
+            row.entity_pk
+                .as_json_array_text()
+                .expect("fixture primary key should encode")
+        ))
+    }
+
     fn live_state_context() -> LiveStateContext {
         LiveStateContext::new(TrackedStateContext::new(), CommitGraphContext::new())
     }
@@ -2599,8 +2611,8 @@ mod tests {
 
         // A branch ref selects a fresh hot-state generation. Its tracked
         // portion is reconstructed from the immutable root and its untracked
-        // portion is materialized into the same snapshot; untracked rows have
-        // no changelog record.
+        // portion is materialized into the same snapshot; each durable
+        // untracked row owns one terminal standalone changelog record.
         for (branch_id, (head_commit_id, created_at, updated_at)) in branch_refs {
             let branch_rows = rows_by_branch.remove(&branch_id).unwrap_or_default();
             let head_commit_id_text = head_commit_id.to_string();
@@ -2654,7 +2666,7 @@ mod tests {
                     schema_key: &row.schema_key,
                     file_id: row.file_id.as_deref(),
                     entity_pk: &row.entity_pk,
-                    change_id: None,
+                    change_id: Some(untracked_fixture_change_id(row)),
                     commit_id: None,
                     untracked: true,
                     deleted: row.deleted,
@@ -2738,7 +2750,7 @@ mod tests {
                     schema_key: &row.schema_key,
                     file_id: row.file_id.as_deref(),
                     entity_pk: &row.entity_pk,
-                    change_id: None,
+                    change_id: Some(untracked_fixture_change_id(row)),
                     commit_id: None,
                     untracked: true,
                     deleted: row.deleted,
@@ -3370,7 +3382,7 @@ mod tests {
             Some("{\"value\":\"untracked-value\"}")
         );
         assert!(rows[0].untracked);
-        assert_eq!(rows[0].change_id, None);
+        assert!(rows[0].change_id.is_some());
 
         let loaded = live_state
             .reader(
@@ -3389,7 +3401,7 @@ mod tests {
             .expect("load should succeed")
             .expect("current row should be visible");
         assert!(loaded.untracked);
-        assert_eq!(loaded.change_id, None);
+        assert_eq!(loaded.change_id, rows[0].change_id);
         assert_eq!(
             loaded.snapshot_content.as_deref(),
             Some("{\"value\":\"untracked-value\"}")

--- a/packages/lix/src/live_state/tracked_head.rs
+++ b/packages/lix/src/live_state/tracked_head.rs
@@ -286,7 +286,7 @@ struct BranchRefKey {
 ///
 /// This narrow convenience type keeps historical writers explicit. Normal
 /// serving publication converts it to [`CurrentStateDeltaRef`], which is also
-/// able to carry history-free untracked mutations.
+/// able to carry untracked mutations outside commit history.
 #[cfg(any(test, feature = "storage-benches"))]
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct TrackedHeadDeltaRef<'a> {
@@ -325,7 +325,8 @@ impl<'a> TrackedHeadDeltaRef<'a> {
 /// One mutation of the authoritative current serving state.
 ///
 /// `tracked` mutations have both IDs and may create tombstones. `untracked`
-/// mutations have neither ID; deletion removes the member physically. This
+/// mutations carry a standalone change ID but no commit ID; deletion removes
+/// the member physically. This
 /// is deliberately the single write representation for the hot state plane,
 /// so callers never stage a separate untracked overlay.
 #[derive(Debug, Clone, Copy)]
@@ -404,12 +405,12 @@ impl<'a> CurrentStateDeltaRef<'a> {
 
     fn validate(self) -> Result<(), LixError> {
         match (self.untracked, self.change_id, self.commit_id, self.deleted) {
-            (false, Some(_), Some(_), _) | (true, None, None, false | true) => Ok(()),
+            (false, Some(_), Some(_), _) | (true, Some(_), None, false | true) => Ok(()),
             (false, _, _, _) => Err(head_value_error(
                 "tracked current-state mutation must carry change_id and commit_id",
             )),
             (true, _, _, _) => Err(head_value_error(
-                "untracked current-state mutation must not carry change_id or commit_id",
+                "untracked current-state mutation must carry change_id and no commit_id",
             )),
         }
     }
@@ -467,7 +468,7 @@ impl TrackedHeadContext {
     }
 
     /// Reclaims derived current-state generations that no durable branch
-    /// control can select and returns their history-free payload refs. Both
+    /// control can select and returns their terminal payload refs. Both
     /// the authoritative hot rows and their key-only file membership index are
     /// generation-scoped, so the control is the one ownership root for both
     /// spaces. The caller compares the returned refs with its complete live
@@ -475,7 +476,7 @@ impl TrackedHeadContext {
     ///
     /// A non-current control still owns its generation. Its tracked portion
     /// may use historical replay, but that same generation preserves the
-    /// branch's history-free untracked members until a fresh complete serving
+    /// branch's untracked members outside commit history until a fresh complete serving
     /// generation is published.
     #[cfg(test)]
     pub(crate) async fn stage_collect_stale_current_state_generations<S>(
@@ -1630,7 +1631,7 @@ fn append_head_value_parts(
         value.commit_id,
         value.deleted,
     ) {
-        (false, Some(_), Some(_), _) | (true, None, None, false) => {}
+        (false, Some(_), Some(_), _) | (true, Some(_), None, false) => {}
         (true, _, _, true) => {
             return Err(head_value_error(
                 "untracked current-state rows must be deleted physically",
@@ -1643,7 +1644,7 @@ fn append_head_value_parts(
         }
         (true, _, _, false) => {
             return Err(head_value_error(
-                "untracked current-state rows must not carry change_id or commit_id",
+                "untracked current-state rows must carry change_id and no commit_id",
             ));
         }
     }
@@ -1896,9 +1897,9 @@ fn decode_head_value(bytes: &[u8]) -> Result<HeadValueView<'_>, LixError> {
                 "untracked current-state rows must be deleted physically",
             ));
         }
-        if change_uuid != uuid::Uuid::nil() || commit_uuid != uuid::Uuid::nil() {
+        if change_uuid == uuid::Uuid::nil() || commit_uuid != uuid::Uuid::nil() {
             return Err(head_value_error(
-                "untracked current-state rows must use nil change and commit ids",
+                "untracked current-state rows must use a non-nil change id and nil commit id",
             ));
         }
         if working_diff_baseline != WorkingDiffBaseline::Disabled {
@@ -1911,7 +1912,7 @@ fn decode_head_value(bytes: &[u8]) -> Result<HeadValueView<'_>, LixError> {
                 "untracked current-state rows must not carry an columnar base coordinate",
             ));
         }
-        (None, None)
+        (Some(ChangeId::new(change_uuid)), None)
     } else {
         if change_uuid == uuid::Uuid::nil() || commit_uuid == uuid::Uuid::nil() {
             return Err(head_value_error(
@@ -5117,8 +5118,8 @@ mod tests {
         };
         let controls = vec![(branch_id.to_string(), active_control)];
 
-        let untracked = |snapshot| HeadValue {
-            change_id: None,
+        let untracked = |label, snapshot| HeadValue {
+            change_id: Some(ChangeId::for_test_label(label)),
             commit_id: None,
             untracked: true,
             deleted: false,
@@ -5129,10 +5130,18 @@ mod tests {
             columnar_base_coordinate: None,
         };
         let mut writes = StorageWriteSet::new();
-        stage_put(&mut writes, &active_identity, &untracked(active_snapshot))
-            .expect("stage active untracked hot row");
-        stage_put(&mut writes, &stale_identity, &untracked(stale_snapshot))
-            .expect("stage stale untracked hot row");
+        stage_put(
+            &mut writes,
+            &active_identity,
+            &untracked("active-untracked-change", active_snapshot),
+        )
+        .expect("stage active untracked hot row");
+        stage_put(
+            &mut writes,
+            &stale_identity,
+            &untracked("stale-untracked-change", stale_snapshot),
+        )
+        .expect("stage stale untracked hot row");
         stage_branch_head_control(&mut writes, branch_id, active_control)
             .expect("stage active branch control");
         storage
@@ -5148,10 +5157,13 @@ mod tests {
         );
         let rooted = TrackedHeadContext::new()
             .reader(read.clone())
-            .untracked_json_refs(&controls)
+            .untracked_change_ids(&controls)
             .await
-            .expect("discover active untracked payload roots");
-        assert_eq!(rooted, vec![active_snapshot]);
+            .expect("discover active untracked change roots");
+        assert_eq!(
+            rooted,
+            vec![ChangeId::for_test_label("active-untracked-change")]
+        );
 
         let mut gc_writes = StorageWriteSet::new();
         let stale_refs = TrackedHeadContext::new()

--- a/packages/lix/src/live_state/tracked_head/hot.rs
+++ b/packages/lix/src/live_state/tracked_head/hot.rs
@@ -27,6 +27,7 @@ use crate::tracked_state::TrackedStateReadColumns;
 use crate::wasm::WasmCertifiedEntityBatch;
 
 use super::*;
+use crate::changelog::{CHANGE_SPACE, change_key};
 
 pub(crate) const HOT_ROW_NAMESPACE: &str = "live_state.hot_row.v21";
 pub(crate) const HOT_FILE_NAMESPACE: &str = "live_state.hot_file_schema.v18";
@@ -5713,11 +5714,11 @@ where
     }
 
     #[cfg(test)]
-    pub(crate) async fn untracked_json_refs(
+    pub(crate) async fn untracked_change_ids(
         &self,
         controls: &[(String, BranchHeadControl)],
-    ) -> Result<Vec<JsonRef>, LixError> {
-        let mut refs = BTreeSet::new();
+    ) -> Result<Vec<ChangeId>, LixError> {
+        let mut change_ids = BTreeSet::new();
         for (branch_id, control) in controls {
             let scope = hot_scope_prefix(branch_id, control.untracked_generation);
             let range = StoragePrefix {
@@ -5735,14 +5736,18 @@ where
                 for entry in page.entries {
                     let bytes = full_value_bytes(entry.value)?;
                     let value = decode_head_value(&bytes)?;
-                    collect_hot_untracked_refs(value, &mut refs);
+                    if value.untracked {
+                        change_ids.insert(value.change_id.ok_or_else(|| {
+                            head_value_error("untracked current-state row is missing change_id")
+                        })?);
+                    }
                 }
                 if !page.has_more {
                     break;
                 }
             }
         }
-        Ok(refs.into_iter().map(JsonRef::from_hash_bytes).collect())
+        Ok(change_ids.into_iter().collect())
     }
 
     pub(crate) async fn working_diff_for_control(
@@ -6821,12 +6826,14 @@ where
         let mut rows =
             load_hot_untracked_generation(self.store, branch_id, previous_generation).await?;
         let mut retired_untracked_json_refs = BTreeSet::new();
+        let mut retired_untracked_change_ids = BTreeSet::new();
         for delta in sorted {
             apply_complete_hot_snapshot_delta(
                 &mut rows,
                 delta,
                 absence_guards,
                 &mut retired_untracked_json_refs,
+                &mut retired_untracked_change_ids,
             )?;
         }
         let has_key_value_scope = rows
@@ -6863,6 +6870,9 @@ where
                 .into_iter()
                 .map(JsonRef::from_hash_bytes),
         );
+        for change_id in retired_untracked_change_ids {
+            self.writes.delete(CHANGE_SPACE, change_key(change_id));
+        }
         Ok(new_generation)
     }
 
@@ -7363,6 +7373,7 @@ where
         }
         let mut created_ats = Vec::with_capacity(sorted.len());
         let mut retired_untracked_json_refs = BTreeSet::new();
+        let mut retired_untracked_change_ids = BTreeSet::new();
         for (delta, previous) in sorted.iter().zip(&previous_values) {
             let Some(previous) = previous else {
                 created_ats.push(delta.created_at);
@@ -7381,6 +7392,11 @@ where
                     delta,
                     &mut retired_untracked_json_refs,
                 );
+                if existing.change_id != delta.change_id {
+                    retired_untracked_change_ids.insert(existing.change_id.ok_or_else(|| {
+                        head_value_error("untracked predecessor is missing change_id")
+                    })?);
+                }
             }
             created_ats.push(if reset_working_diff_baselines && !delta.untracked {
                 // Checkpoint selection canonicalizes newly added rows to the
@@ -7598,6 +7614,7 @@ where
                 reset_working_diff_baselines,
                 &mut next_coverage,
                 &mut retired_untracked_json_refs,
+                &mut retired_untracked_change_ids,
             )
             .await
         }
@@ -7612,6 +7629,9 @@ where
                 .into_iter()
                 .map(JsonRef::from_hash_bytes),
         );
+        for change_id in retired_untracked_change_ids {
+            self.writes.delete(CHANGE_SPACE, change_key(change_id));
+        }
         *coverage = next_coverage;
         Ok(generation)
     }
@@ -7651,12 +7671,14 @@ where
         reject_lifecycle_retention_collisions(&sorted_untracked, &sorted_tracked)?;
 
         let mut retired_untracked_json_refs = BTreeSet::new();
+        let mut retired_untracked_change_ids = BTreeSet::new();
         for delta in &sorted_untracked {
             apply_complete_hot_snapshot_delta(
                 &mut untracked_rows,
                 delta,
                 absence_guards,
                 &mut retired_untracked_json_refs,
+                &mut retired_untracked_change_ids,
             )?;
         }
         merge_final_untracked_rows(&mut rows, untracked_rows)?;
@@ -7666,6 +7688,7 @@ where
                 delta,
                 absence_guards,
                 &mut retired_untracked_json_refs,
+                &mut retired_untracked_change_ids,
             )?;
         }
 
@@ -7697,6 +7720,9 @@ where
                 .into_iter()
                 .map(JsonRef::from_hash_bytes),
         );
+        for change_id in retired_untracked_change_ids {
+            self.writes.delete(CHANGE_SPACE, change_key(change_id));
+        }
         *coverage = WorkingDiffIndexCoverage::default();
         Ok((
             HotTrackedSnapshot {
@@ -7718,6 +7744,7 @@ async fn stage_incremental_file_delete_cascades(
     reset_working_diff_baselines: bool,
     coverage: &mut WorkingDiffIndexCoverage,
     retired_untracked_json_refs: &mut BTreeSet<[u8; JSON_REF_BYTES]>,
+    retired_untracked_change_ids: &mut BTreeSet<ChangeId>,
 ) -> Result<(), LixError> {
     let mut cascades = BTreeMap::<String, &CurrentStateDeltaRef<'_>>::new();
     for cascade in deltas {
@@ -7814,6 +7841,9 @@ async fn stage_incremental_file_delete_cascades(
         let row_key = BufferRange::new(row_start, mutations.key_bytes.len() - row_start);
         if existing.untracked {
             collect_hot_untracked_refs(existing, retired_untracked_json_refs);
+            retired_untracked_change_ids.insert(existing.change_id.ok_or_else(|| {
+                head_value_error("untracked cascade predecessor is missing change_id")
+            })?);
             mutations.row_deletes.push(row_key);
             continue;
         }
@@ -8193,8 +8223,14 @@ fn apply_complete_hot_snapshot_delta(
     delta: &CurrentStateDeltaRef<'_>,
     absence_guards: &BTreeSet<TrackedStateKey>,
     retired_untracked_json_refs: &mut BTreeSet<[u8; JSON_REF_BYTES]>,
+    retired_untracked_change_ids: &mut BTreeSet<ChangeId>,
 ) -> Result<(), LixError> {
-    apply_complete_file_delete_cascade(rows, delta, retired_untracked_json_refs)?;
+    apply_complete_file_delete_cascade(
+        rows,
+        delta,
+        retired_untracked_json_refs,
+        retired_untracked_change_ids,
+    )?;
     let identity = HeadRowIdentity {
         schema_key: delta.schema_key.to_string(),
         entity_pk: delta.entity_pk.clone(),
@@ -8207,6 +8243,11 @@ fn apply_complete_hot_snapshot_delta(
         reject_retention_change(delta, existing)?;
         if existing.untracked {
             collect_retired_untracked_json_refs(existing, delta, retired_untracked_json_refs);
+            if existing.change_id != delta.change_id {
+                retired_untracked_change_ids.insert(existing.change_id.ok_or_else(|| {
+                    head_value_error("untracked predecessor is missing change_id")
+                })?);
+            }
         }
     }
     if delta.physically_deletes() {
@@ -8232,6 +8273,7 @@ fn apply_complete_file_delete_cascade(
     rows: &mut HotRowMap,
     delta: &CurrentStateDeltaRef<'_>,
     retired_untracked_json_refs: &mut BTreeSet<[u8; JSON_REF_BYTES]>,
+    retired_untracked_change_ids: &mut BTreeSet<ChangeId>,
 ) -> Result<(), LixError> {
     let Some(file_id) = file_delete_cascade_id(delta)? else {
         return Ok(());
@@ -8251,6 +8293,9 @@ fn apply_complete_file_delete_cascade(
         }
         if existing.untracked {
             collect_hot_untracked_refs(existing, retired_untracked_json_refs);
+            retired_untracked_change_ids.insert(existing.change_id.ok_or_else(|| {
+                head_value_error("untracked cascade predecessor is missing change_id")
+            })?);
             rows.remove(&identity);
             continue;
         }
@@ -8962,7 +9007,7 @@ fn stage_hot_bootstrap(
             file_id: row.file_id,
         };
         let value = HeadValueRef {
-            change_id: None,
+            change_id: row.change_id,
             commit_id: None,
             untracked: true,
             deleted: false,
@@ -8990,8 +9035,14 @@ fn stage_hot_bootstrap(
         }
     }
     let mut retired_untracked_json_refs = BTreeSet::new();
+    let mut retired_untracked_change_ids = BTreeSet::new();
     for delta in deltas {
-        apply_complete_file_delete_cascade(&mut rows, delta, &mut retired_untracked_json_refs)?;
+        apply_complete_file_delete_cascade(
+            &mut rows,
+            delta,
+            &mut retired_untracked_json_refs,
+            &mut retired_untracked_change_ids,
+        )?;
         let identity = HeadRowIdentity {
             schema_key: delta.schema_key.to_string(),
             entity_pk: delta.entity_pk.clone(),
@@ -9008,6 +9059,11 @@ fn stage_hot_bootstrap(
                     delta,
                     &mut retired_untracked_json_refs,
                 );
+                if existing.change_id != delta.change_id {
+                    retired_untracked_change_ids.insert(existing.change_id.ok_or_else(|| {
+                        head_value_error("untracked predecessor is missing change_id")
+                    })?);
+                }
             }
         }
         if delta.physically_deletes() {
@@ -9042,6 +9098,9 @@ fn stage_hot_bootstrap(
             .into_iter()
             .map(JsonRef::from_hash_bytes),
     );
+    for change_id in retired_untracked_change_ids {
+        writes.delete(CHANGE_SPACE, change_key(change_id));
+    }
     *coverage = WorkingDiffIndexCoverage::default();
     Ok(())
 }
@@ -11800,7 +11859,7 @@ mod tests {
     fn encoded_test_hot_value(generation: CommitId, untracked: bool, deleted: bool) -> Bytes {
         Bytes::from(
             encode_head_value(&HeadValueRef {
-                change_id: (!untracked).then(|| ChangeId::for_test_label("closure-change")),
+                change_id: Some(ChangeId::for_test_label("closure-change")),
                 commit_id: (!untracked).then_some(generation),
                 untracked,
                 deleted,
@@ -14304,7 +14363,7 @@ mod tests {
             schema_key: "schema\0escaped",
             file_id: Some("file\0id"),
             entity_pk: &first_pk,
-            change_id: None,
+            change_id: Some(ChangeId::for_test_label("planned-untracked-change")),
             commit_id: None,
             untracked: true,
             deleted: false,
@@ -14318,7 +14377,7 @@ mod tests {
             schema_key: "schema_without_file",
             file_id: None,
             entity_pk: &second_pk,
-            change_id: None,
+            change_id: Some(ChangeId::for_test_label("planned-removed-change")),
             commit_id: None,
             untracked: true,
             deleted: false,
@@ -14437,7 +14496,7 @@ mod tests {
             schema_key: "untracked_schema",
             file_id: Some("untracked.json"),
             entity_pk: &untracked_pk,
-            change_id: None,
+            change_id: Some(ChangeId::for_test_label("planned-untracked-change")),
             commit_id: None,
             untracked: true,
             deleted: false,
@@ -14451,7 +14510,7 @@ mod tests {
             schema_key: "untracked_schema",
             file_id: Some("removed.json"),
             entity_pk: &removed_pk,
-            change_id: None,
+            change_id: Some(ChangeId::for_test_label("planned-removed-change")),
             commit_id: None,
             untracked: true,
             deleted: true,
@@ -14715,6 +14774,7 @@ mod tests {
         let mut writes = StorageWriteSet::new();
         let mut coverage = WorkingDiffIndexCoverage::default();
         let mut retired_untracked_json_refs = BTreeSet::new();
+        let mut retired_untracked_change_ids = BTreeSet::new();
         let explicit_index_builds = incremental_cascade_explicit_index_builds();
 
         stage_incremental_file_delete_cascades(
@@ -14727,6 +14787,7 @@ mod tests {
             false,
             &mut coverage,
             &mut retired_untracked_json_refs,
+            &mut retired_untracked_change_ids,
         )
         .await
         .expect("ordinary imports do not need file-delete cascade staging");

--- a/packages/lix/src/transaction/bench_support.rs
+++ b/packages/lix/src/transaction/bench_support.rs
@@ -10,6 +10,7 @@ use crate::branch::{
 use crate::catalog::CatalogContext;
 use crate::changelog::{
     ChangeId, ChangeRecord, ChangelogAppend, ChangelogContext, ChangelogWriter, CommitId,
+    TransactionChangeRecordRef,
 };
 use crate::common::LixTimestamp;
 use crate::entity_pk::EntityPk;
@@ -381,6 +382,24 @@ where
         .expect("global branch control should load")
         .expect("global branch control should exist");
     let snapshot = crate::json_store::JsonSlot::from_json(&snapshot_content);
+    let change_id = ChangeId::for_test_label("benchmark-deterministic-mode");
+    ChangelogContext::new()
+        .stage_terminal_standalone_change(
+            &mut writes,
+            TransactionChangeRecordRef {
+                format_version: 2,
+                change_id,
+                account_id: crate::SYSTEM_ACCOUNT_ID,
+                entity_pk: &entity_pk,
+                schema_key: "lix_key_value",
+                file_id: None,
+                snapshot: snapshot.as_ref_slot(),
+                metadata: crate::json_store::JsonSlotRef::None,
+                created_at: timestamp,
+                origin_key: None,
+            },
+        )
+        .expect("deterministic mode change should stage");
     let mut working_diff_coverage = WorkingDiffIndexCoverage::default();
     TrackedHeadContext::new()
         .writer(&read, &mut writes)
@@ -392,7 +411,7 @@ where
                 schema_key: "lix_key_value",
                 file_id: None,
                 entity_pk: &entity_pk,
-                change_id: None,
+                change_id: Some(change_id),
                 commit_id: None,
                 untracked: true,
                 deleted: false,

--- a/packages/lix/src/transaction/commit.rs
+++ b/packages/lix/src/transaction/commit.rs
@@ -1405,12 +1405,12 @@ async fn stage_changelog_commits(
     }
     let changes = state_rows
         .iter()
-        // Ordinary untracked members are intentionally current-state only in
-        // V16. `lix_branch_ref` is the one control-plane exception: its
-        // published control retains a public ref_change_id, so that immutable
-        // ledger fact must remain available to `lix_change` and GC even
-        // though it is not a commit member.
-        .filter(|row| row.untracked && row.schema_key == BRANCH_REF_SCHEMA_KEY)
+        // Each live untracked member owns one standalone changelog fact. A
+        // physical delete has no surviving current owner, except for the
+        // branch-control ledger whose immutable deletion fact is public.
+        .filter(|row| {
+            row.untracked && (row.snapshot.is_some() || row.schema_key == BRANCH_REF_SCHEMA_KEY)
+        })
         .map(|row| transaction_change_record_from_state_row(row, active_account_id))
         .chain(
             branch_head_changes
@@ -1837,7 +1837,7 @@ fn current_state_delta_from_state_row(
         schema_key: row.schema_key,
         file_id: row.file_id.map(crate::common::SharedStr::as_str),
         entity_pk: row.entity_pk,
-        change_id: (!row.untracked).then_some(change_id),
+        change_id: Some(change_id),
         commit_id,
         untracked: row.untracked,
         deleted: row.snapshot.is_none(),
@@ -1911,7 +1911,7 @@ fn current_state_delta_from_engine_row(
         schema_key: &row.change.schema_key,
         file_id: row.change.file_id.as_deref(),
         entity_pk: &row.change.entity_pk,
-        change_id: None,
+        change_id: Some(row.change.change_id),
         commit_id: None,
         untracked: true,
         deleted: row.change.snapshot == crate::json_store::JsonSlot::None,
@@ -9598,7 +9598,7 @@ mod tests {
             loaded.snapshot_content.as_deref(),
             Some("{\"value\":\"untracked\"}")
         );
-        assert_eq!(loaded.change_id, None);
+        assert_eq!(loaded.change_id, Some(change_id("change-untracked")));
 
         let mut changelog_reader = ChangelogContext::new().reader(
             storage
@@ -9614,9 +9614,13 @@ mod tests {
             .await
             .expect("untracked changelog lookup should load");
         assert_eq!(
-            changes.iter().all(|(_, value)| value.is_none()),
-            true,
-            "untracked state is history-free and must not enter the changelog"
+            changes
+                .iter()
+                .next()
+                .and_then(|(_, change)| change)
+                .map(|change| change.change_id),
+            Some(change_id("change-untracked")),
+            "the live untracked row must own one standalone changelog fact"
         );
     }
 
@@ -9884,7 +9888,7 @@ mod tests {
             untracked.snapshot_content.as_deref(),
             Some("{\"value\":\"untracked\"}")
         );
-        assert_eq!(untracked.change_id, None);
+        assert_eq!(untracked.change_id, Some(change_id("change-untracked")));
 
         let sequence_row = live_state
             .reader(

--- a/packages/lix/src/transaction/context.rs
+++ b/packages/lix/src/transaction/context.rs
@@ -12793,9 +12793,9 @@ mod tests {
             live_untracked_row.snapshot_content.as_deref(),
             Some(r#"{"key":"untracked-programmatic","value":"untracked"}"#)
         );
-        assert_eq!(
-            live_untracked_row.change_id, None,
-            "ordinary untracked rows must not enter the changelog"
+        assert!(
+            live_untracked_row.change_id.is_some(),
+            "ordinary untracked rows must publish a standalone change"
         );
         assert_eq!(
             live_untracked_row.commit_id, None,

--- a/packages/lix/tests/integration/sql/untracked_current_state.rs
+++ b/packages/lix/tests/integration/sql/untracked_current_state.rs
@@ -20,12 +20,13 @@ simulation_test!(untracked_insert_is_current_state_only, |sim| async move {
         .await
         .expect("untracked insert should succeed");
 
-    assert_untracked_current_state(&session, "untracked-current-insert").await;
+    let change_id = assert_untracked_current_state(&session, "untracked-current-insert").await;
     assert_eq!(
         change_count_for_key(&session, "untracked-current-insert").await,
-        0,
-        "ordinary untracked state must not create a lix_change record"
+        1,
+        "ordinary untracked state must own exactly one standalone lix_change record"
     );
+    assert!(change_exists(&session, &change_id).await);
     assert_eq!(
         branch_head(&session, sim.main_branch_id()).await,
         head_before,
@@ -54,6 +55,8 @@ simulation_test!(
             )
             .await
             .expect("initial untracked insert should succeed");
+        let initial_change_id =
+            assert_untracked_current_state(&session, "untracked-current-overwrite").await;
         session
             .execute(
                 "UPDATE lix_key_value SET value = 'two' \
@@ -75,12 +78,16 @@ simulation_test!(
             visible.rows()[0].values(),
             &[Value::Json(serde_json::json!("two"))]
         );
-        assert_untracked_current_state(&session, "untracked-current-overwrite").await;
+        let replacement_change_id =
+            assert_untracked_current_state(&session, "untracked-current-overwrite").await;
+        assert_ne!(replacement_change_id, initial_change_id);
         assert_eq!(
             change_count_for_key(&session, "untracked-current-overwrite").await,
-            0,
-            "untracked replacement must not create history"
+            1,
+            "untracked replacement must retain only its current logical change"
         );
+        assert!(!change_exists(&session, &initial_change_id).await);
+        assert!(change_exists(&session, &replacement_change_id).await);
 
         session
             .execute(
@@ -101,8 +108,9 @@ simulation_test!(
         assert_eq!(
             change_count_for_key(&session, "untracked-current-overwrite").await,
             0,
-            "untracked deletion must physically remove state without a tombstone change"
+            "untracked deletion must retire the final current change without a tombstone change"
         );
+        assert!(!change_exists(&session, &replacement_change_id).await);
         assert_eq!(
             branch_head(&session, sim.main_branch_id()).await,
             head_before,
@@ -298,7 +306,8 @@ simulation_test!(
         assert_untracked_current_state(&session, "untracked-current-tx-untracked").await;
         assert_eq!(
             change_count_for_key(&session, "untracked-current-tx-untracked").await,
-            0
+            1,
+            "mixed transactions retain one standalone current change for the untracked member"
         );
 
         let tracked_history = session
@@ -393,7 +402,7 @@ simulation_test!(
             session
                 .execute(sql, &[])
                 .await
-                .expect("history-free current-state mutation should succeed");
+                .expect("untracked current-state mutation should succeed");
             let working_diff = session
                 .execute("SELECT COUNT(*) FROM lix_working_diff", &[])
                 .await
@@ -430,7 +439,7 @@ async fn branch_head(
 async fn assert_untracked_current_state(
     session: &crate::support::simulation_test::engine::SimSession,
     key: &str,
-) {
+) -> String {
     let result = session
         .execute(
             &format!(
@@ -444,11 +453,10 @@ async fn assert_untracked_current_state(
     let [row] = result.rows() else {
         panic!("expected exactly one current row for key '{key}'");
     };
-    assert_eq!(
-        row.values(),
-        &[Value::Null, Value::Null, Value::Boolean(true)],
-        "ordinary untracked state must expose neither a change nor commit id"
-    );
+    let [Value::Text(change_id), Value::Null, Value::Boolean(true)] = row.values() else {
+        panic!("ordinary untracked state must expose a change id and no commit id");
+    };
+    change_id.clone()
 }
 
 async fn current_tracked_change_id(


### PR DESCRIPTION
## Experiment

This is a standalone experiment against `origin/main` (`dab4f5c686c2a65a4d422a2ffb696180d5eea2c4`). It is unrelated to the ForkTree draft.

It tests whether durable untracked current-state rows should participate in the same logical `lix_change` identity stream as tracked rows:

- every durable untracked row owns a non-nil `ChangeId` and no `CommitId`;
- the current change is visible through `lix_change` but is not a commit member;
- replacing a row atomically stages the new standalone change and eagerly retires the previous one;
- deleting a row retires its final change without creating tombstone history;
- GC roots an untracked payload through its standalone change rather than through a separate current-payload authority.

The resulting changelog cardinality is bounded by live untracked rows, not update count.

## Correctness

- `cargo check -p lix --tests --all-features`
- full `lix` lib suite: **2056 passed, 0 failed, 8 ignored**
- untracked SQL lifecycle: **14 passed, 0 failed**
- hot-state tests: **47 passed, 0 failed**
- insert/replace/delete tests prove one live change, old-ID retirement, no commit member, and no tracked working-diff entry.

## Paired benchmark

The existing byte-identical `untracked_state_crud` public SQL harness was compiled from both the parent and candidate. RocksDB and SlateDB each ran 3 warmups plus 20 measured 1K-row samples; setup was excluded. Harness SHA-256: `205ce053c79d3ed73edbeac07421b41d65498d15c4d420333e1e6aed9b944de4`.

| Backend | Operation | main median / p95 | candidate median / p95 | latency delta | written bytes main → candidate |
|---|---:|---:|---:|---:|---:|
| RocksDB | insert | 14.938 / 19.307 ms | 15.456 / 16.150 ms | +3.5% | 417,089 → 673,643 (+61.5%) |
| RocksDB | update | 47.665 / 47.837 ms | 47.511 / 47.786 ms | -0.3% | 1,541,552 → 1,692,796 (+9.8%) |
| RocksDB | delete | 4.814 / 4.986 ms | 5.188 / 5.294 ms | +7.8% | 222 → 222, plus 1,000 deletes |
| SlateDB | insert | 20.950 / 23.258 ms | 21.843 / 22.921 ms | +4.3% | 417,089 → 673,643 (+61.5%) |
| SlateDB | update | 47.782 / 48.460 ms | 47.704 / 48.997 ms | -0.2% | 1,541,552 → 1,692,796 (+9.8%) |
| SlateDB | delete | 6.408 / 6.611 ms | 6.235 / 7.162 ms | -2.7% | 222 → 222, plus 1,000 deletes |

Summary TSV SHA-256: `bcc1c19a61c8d09ddd9253b2c4a77207ffc4685196d772c0283f84cbb78fc063`.

## Data-driven verdict

The unified identity model is operationally viable: update latency is neutral and insert/delete regressions are small. It is not free, however. Persisting one terminal changelog object per live untracked row increases initial write bytes by ~61.5%; replacement adds ~9.8% write bytes and one delete per row.

This therefore supports the change only if the simpler single logical change stream is worth that storage/write amplification. It is not a performance optimization.

## Deliberate draft limitations

- Existing hot-row v8 data may contain nil IDs for untracked rows. This candidate fails closed on those rows; a repository migration must be designed before merge.
- The SQL `change_id` field remains nullable because pending tracked writes intentionally hide provisional IDs until commit assigns canonical ordering. All **durable** tracked and untracked rows have an ID. Making the schema globally non-null requires moving canonical tracked-ID assignment earlier and is a separate semantic change.
- Old standalone changes are retired eagerly in the replacement publication rather than by a later GC pass. This gives the requested bounded stream while avoiding a period with two public current changes.

## Provenance

- head: `0ec87b77bb85214f9c9eee168d3dcf65f92c122a`
- tree: `252ef39a3e7a2cf244663ffe7815ea08dd9751fc`
- parent: `dab4f5c686c2a65a4d422a2ffb696180d5eea2c4`
- parent..head full-index SHA-256: `8f66e485bfe14b76b226891ab170cf239e10411dc06bab8aa83cd1de520cac99`
- stable patch-id: `f5e4e4be8bf3104f916e8d76783f544030ee7e3c`
