### PR TITLE
perf(forktree): bound GC mark validation work

### DIFF
--- a/packages/lix/src/forktree/gc_index.rs
+++ b/packages/lix/src/forktree/gc_index.rs
@@ -748,8 +748,11 @@ fn leaf_domain(kind: GcRadixKindV1) -> ObjectDomain {
 }
 
 fn leaf_limit(kind: GcRadixKindV1) -> usize {
+    // Keep path-copy insertion from repeatedly decoding and authenticating one
+    // growing mark pack. The wire-format maximum remains unchanged for reads.
+    const MARK_OPERATIONAL_LEAF_ENTRIES: usize = 64;
     match kind {
-        GcRadixKindV1::Mark => GcMarkPackV2::MAX_ENTRIES,
+        GcRadixKindV1::Mark => GcMarkPackV2::MAX_ENTRIES.min(MARK_OPERATIONAL_LEAF_ENTRIES),
         GcRadixKindV1::Queue => GcQueuePackV1::MAX_ENTRIES,
         GcRadixKindV1::LiveBranch => GcLiveBranchPackV1::MAX_ENTRIES,
     }

--- a/packages/lix/src/forktree/reachability.rs
+++ b/packages/lix/src/forktree/reachability.rs
@@ -1,4 +1,4 @@
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 use std::ops::Bound;
 
 use bytes::Bytes;
@@ -1109,9 +1109,83 @@ async fn validate_catalog_claims<R>(
 where
     R: StorageAdapterRead + ?Sized,
 {
+    let commit_entry_ids = commits
+        .iter()
+        .map(|(_, entry)| entry.commit_object_id)
+        .collect::<BTreeSet<_>>();
+    let member_owner_ids = changes
+        .iter()
+        .filter_map(|(_, entry)| match entry.owner {
+            ChangeCatalogOwner::CommitMember {
+                commit_object_id, ..
+            }
+            | ChangeCatalogOwner::PackedCommit {
+                commit_object_id, ..
+            } => Some(commit_object_id),
+            ChangeCatalogOwner::BranchRef { .. } => None,
+        })
+        .collect::<BTreeSet<_>>();
+    let ref_owner_ids = changes
+        .iter()
+        .filter_map(|(_, entry)| match entry.owner {
+            ChangeCatalogOwner::BranchRef {
+                ref_change_object_id,
+                ..
+            } => Some(ref_change_object_id),
+            ChangeCatalogOwner::CommitMember { .. } | ChangeCatalogOwner::PackedCommit { .. } => {
+                None
+            }
+        })
+        .collect::<BTreeSet<_>>();
+    if commit_entry_ids
+        .iter()
+        .chain(member_owner_ids.iter())
+        .any(|id| ref_owner_ids.contains(id))
+    {
+        return Err(corruption(
+            "catalog claims repeat one object as both commit and RefChange",
+        ));
+    }
+    let object_ids = commit_entry_ids
+        .iter()
+        .chain(member_owner_ids.iter())
+        .chain(ref_owner_ids.iter())
+        .copied()
+        .collect::<BTreeSet<_>>()
+        .into_iter()
+        .collect::<Vec<_>>();
+    let objects = load_object_bytes_many(read, &object_ids).await?;
+    let mut commit_cache = BTreeMap::new();
+    for id in commit_entry_ids.iter().chain(member_owner_ids.iter()) {
+        if commit_cache.contains_key(id) {
+            continue;
+        }
+        let bytes = objects
+            .get(id)
+            .ok_or_else(|| corruption("catalog commit batch omitted one object"))?;
+        commit_cache.insert(*id, CommitObjectV1::decode(*id, bytes)?);
+    }
+    let mut member_cache = BTreeMap::new();
+    for id in &member_owner_ids {
+        let commit = commit_cache
+            .get(id)
+            .ok_or_else(|| corruption("catalog member owner has no decoded commit"))?;
+        member_cache.insert(
+            *id,
+            super::serving::load_commit_members(read, commit).await?,
+        );
+    }
+    let mut ref_cache = BTreeMap::new();
+    for id in &ref_owner_ids {
+        let bytes = objects
+            .get(id)
+            .ok_or_else(|| corruption("catalog RefChange batch omitted one object"))?;
+        ref_cache.insert(*id, ChangeObjectV1::decode(*id, bytes)?);
+    }
     for (key, entry) in commits {
-        let bytes = load_object_bytes(read, entry.commit_object_id).await?;
-        let commit = CommitObjectV1::decode(entry.commit_object_id, &bytes)?;
+        let commit = commit_cache
+            .get(&entry.commit_object_id)
+            .ok_or_else(|| corruption("CommitCatalog claim has no decoded commit"))?;
         if commit.commit_id != *key {
             return Err(corruption("CommitCatalog key/object identity mismatch"));
         }
@@ -1122,9 +1196,9 @@ where
                 commit_object_id,
                 ordinal,
             } => {
-                let bytes = load_object_bytes(read, commit_object_id).await?;
-                let commit = CommitObjectV1::decode(commit_object_id, &bytes)?;
-                let members = super::serving::load_commit_members(read, &commit).await?;
+                let members = member_cache.get(&commit_object_id).ok_or_else(|| {
+                    corruption("ChangeCatalog commit owner has no decoded member closure")
+                })?;
                 let member = members
                     .get(ordinal as usize)
                     .ok_or_else(|| corruption("ChangeCatalog commit ordinal is absent"))?;
@@ -1138,8 +1212,9 @@ where
                 ref_change_object_id,
                 branch_id,
             } => {
-                let bytes = load_object_bytes(read, ref_change_object_id).await?;
-                let change = ChangeObjectV1::decode(ref_change_object_id, &bytes)?;
+                let change = ref_cache.get(&ref_change_object_id).ok_or_else(|| {
+                    corruption("ChangeCatalog branch-ref owner has no decoded object")
+                })?;
                 let ChangeObjectV1::BranchRef {
                     change_id,
                     branch_id: object_branch,
@@ -1150,7 +1225,7 @@ where
                         "branch-ref catalog owner names semantic payload",
                     ));
                 };
-                if change_id != *key || branch_id != object_branch {
+                if *change_id != *key || branch_id != *object_branch {
                     return Err(corruption("ChangeCatalog owner/back-edge mismatch"));
                 }
             }
@@ -1158,9 +1233,12 @@ where
                 commit_object_id,
                 member_count,
             } => {
-                let bytes = load_object_bytes(read, commit_object_id).await?;
-                let commit = CommitObjectV1::decode(commit_object_id, &bytes)?;
-                let members = super::serving::load_commit_members(read, &commit).await?;
+                let commit = commit_cache.get(&commit_object_id).ok_or_else(|| {
+                    corruption("packed ChangeCatalog owner has no decoded commit")
+                })?;
+                let members = member_cache.get(&commit_object_id).ok_or_else(|| {
+                    corruption("packed ChangeCatalog owner has no decoded member closure")
+                })?;
                 if commit.commit_id.as_bytes() != key.as_bytes()
                     || usize::try_from(member_count).ok() != Some(members.len())
                     || members.iter().enumerate().any(|(index, member)| {
@@ -1181,6 +1259,49 @@ where
         }
     }
     Ok(())
+}
+
+async fn load_object_bytes_many<R>(
+    read: &R,
+    ids: &[ObjectId],
+) -> Result<BTreeMap<ObjectId, Bytes>, StorageError>
+where
+    R: StorageAdapterRead + ?Sized,
+{
+    if ids.is_empty() {
+        return Ok(BTreeMap::new());
+    }
+    let keys = ids
+        .iter()
+        .map(|id| Key(Bytes::copy_from_slice(id.as_bytes())))
+        .collect::<Vec<_>>();
+    let loaded = read
+        .get_many(&[GetManyRequest {
+            space: OBJECT_SPACE,
+            keys: &keys,
+            opts: GetOptions {
+                projection: CoreProjection::FullValue,
+            },
+        }])
+        .await?;
+    if loaded.values.len() != ids.len() {
+        return Err(corruption(
+            "GC exact object batch returned the wrong slot count",
+        ));
+    }
+    ids.iter()
+        .copied()
+        .zip(loaded.values)
+        .map(|(id, value)| match value {
+            Some(ProjectedValue::FullValue(bytes)) => Ok((id, bytes)),
+            Some(ProjectedValue::KeyOnly) => {
+                Err(corruption("GC exact object batch returned key-only data"))
+            }
+            None => Err(corruption(format!(
+                "GC exact object batch omitted authenticated object {id}"
+            ))),
+        })
+        .collect()
 }
 
 async fn validate_chunk_sequence<R>(


### PR DESCRIPTION
## Summary

- batch authenticated CommitCatalog and ChangeCatalog owner validation per unique commit/ref object instead of reloading and decoding the same closure for every catalog entry
- cap writer-created GC mark leaves at 64 entries while retaining the existing 4096-entry decoder bound
- preserve owner, ordinal, back-edge, cardinality, corruption, retained-view, and publication authority checks

This PR targets the current ForkTree hard-cuts draft (#1264). It is exactly two production files and one commit beyond draft head 3471898b5.

## Measured impact

Full authenticated GC drain, old draft to corrected implementation:

| Scale | RocksDB | SlateDB |
|---|---:|---:|
| 1K | 63.636 ms -> 31.255 ms (-50.9%) | 88.819 ms -> 44.172 ms (-50.3%) |
| 10K | 1.671 s -> 280.148 ms (-83.2%) | 1.929 s -> 448.320 ms (-76.8%) |
| 100K | 10.084 s -> 2.439 s (-75.8%) | 12.990 s -> 4.269 s (-67.1%) |

At 100K SlateDB, reads fall 334,003 -> 142,715 (-57.3%) and read bytes 467.7 MB -> 296.1 MB (-36.7%). Exact full-drain counts remain marked/validated=12,006 and reclaimed=7,630 on both adapters. Settled bytes are essentially unchanged.

The raw main timing is not an equivalent full-drain comparator: main completes one partial pass and then fails its second pass with a missing authenticated manifest. This PR therefore does not claim to beat main raw one-pass latency; it fixes and accelerates the complete authenticated ForkTree drain.

## Verification

- cargo fmt --all -- --check: PASS
- git diff --check: PASS
- cargo check -p lix --lib --features all-simulations: PASS
- exact GC corruption, reader-pin reclamation, crash recovery, and concurrent publication tests: 4/4 PASS
- broader ForkTree suite: 57/61 PASS; the four failures reproduce on exact parent 3471898b5 and are stale-page fixture assumptions introduced by byte-paged commit members (expected 2/3 pages, actual 1), outside this two-file diff

Evidence report SHA-256: 9c1a1f86b37a40852d9994b65bf83b9de6fd35300b3c403438d8e662bccb3e3f
Patch ID: 774d1635c23fba41e11a4c76762a975ce0329153
Parent-to-head full-index diff SHA-256: 9d5013bf1931bf12760f4dd6dcbf07179439ba1e4416128b6eaab8f621ccd52f