### PR TITLE
perf(lix): remove fixed commit gather delay

### DIFF
--- a/packages/lix/src/transaction/commit_coordinator.rs
+++ b/packages/lix/src/transaction/commit_coordinator.rs
@@ -2,8 +2,6 @@ use std::collections::VecDeque;
 #[cfg(test)]
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
-use std::time::Duration;
-
 use tokio::sync::{Semaphore, oneshot};
 use tracing::Instrument as _;
 
@@ -18,8 +16,6 @@ use crate::storage_adapter::Storage;
 
 const COMMIT_QUEUE_CAPACITY: usize = 256;
 const COMMIT_COHORT_CAPACITY: usize = 256;
-const COMMIT_GATHER_WINDOW: Duration = Duration::from_millis(2);
-
 struct CommitRequest<StorageImpl>
 where
     StorageImpl: Storage + 'static,
@@ -134,7 +130,6 @@ where
             .name("lix-commit-coordinator".to_owned())
             .stack_size(16 * 1024 * 1024)
             .spawn(move || {
-                std::thread::sleep(COMMIT_GATHER_WINDOW);
                 runtime.block_on(coordinator.drive());
             })
             .map(|_| ())


### PR DESCRIPTION
## Summary

- remove the unconditional 2 ms sleep before the explicit-transaction commit coordinator drains
- retain the bounded queue, cohort compatibility rules, single collaboration gate, and dedicated driver thread
- no public API or storage-format change

## A/B profile

Exact base: `1d406823f3fd5428a63066978ed5a52ab5ceaa72`, uncontended Ryzen 9950X, release profile. Public file UPDATE was staged before timing; samples time `SessionTransaction::commit()`. Candidate differs only by removing the gather sleep.

| Backend | Workload | 2 ms gather p50 | no fixed gather p50 | Change |
|---|---:|---:|---:|---:|
| RocksDB | singleton explicit commit | 2.358 ms | 0.355 ms | -84.9% |
| SlateDB | singleton explicit commit | 2.465 ms | 0.366 ms | -85.1% |
| RocksDB | 32-writer cohort | 4.681 ms | 2.705 ms | -42.2% |
| SlateDB | 32-writer cohort | 4.650 ms | 2.626 ms | -43.5% |

Throughput at width 32 improved from 6.84k to 11.83k commits/s on RocksDB and from 6.88k to 12.19k commits/s on SlateDB. Widths 2, 4, 8, 16, and 32 all improved. Zero-delay traces still formed cohorts; occasional larger waves split, but total wall time remained lower. Normal automatic SQL CRUD bypasses this coordinator and is unchanged.

Reproduction probe command:

```bash
PROBE_BACKEND=rocksdb PROBE_SINGLE_SAMPLES=101 PROBE_COHORT_REPEATS=101 cargo run -p lix_benchmarks --example commit_coordinator_probe --profile bench --features "storage-benches,slatedb"
```

Repeat with `PROBE_BACKEND=slatedb`. Raw evidence is retained on `ryzen-3` under `/root/benchmarks/codex2-ryzen3-oltp-1d406823f/raw/`.

## Validation

- `cargo fmt --check`
- `cargo test -p lix`
- `cargo test -p lix --features all-simulations`