### PR TITLE
perf(slatedb): slice single immutable read extents

### DIFF
--- a/packages/slatedb-storage/src/slatedb.rs
+++ b/packages/slatedb-storage/src/slatedb.rs
@@ -363,31 +363,8 @@ impl ImmutableValueStore {
                         .into_iter()
                         .zip(plan.placements)
                         .map(|((index, requested), fragments)| {
-                            let mut encoded = BytesMut::with_capacity(requested.len());
-                            for (span_index, range) in fragments {
-                                let span = spans
-                                    .get(span_index)
-                                    .and_then(Option::as_ref)
-                                    .ok_or_else(|| {
-                                        StorageError::Corruption(
-                                            "immutable segment read omitted a requested extent"
-                                                .to_string(),
-                                        )
-                                    })?;
-                                if range.end > span.len() {
-                                    return Err(StorageError::Corruption(
-                                        "immutable segment extent is truncated".to_string(),
-                                    ));
-                                }
-                                encoded.extend_from_slice(&span[range]);
-                            }
-                            if encoded.len() != requested.len() {
-                                return Err(StorageError::Corruption(
-                                    "immutable extents did not reconstruct the requested value"
-                                        .to_string(),
-                                ));
-                            }
-                            Ok((index, encoded.freeze()))
+                            materialize_immutable_request(&spans, &requested, &fragments)
+                                .map(|value| (index, value))
                         })
                         .collect::<Result<Vec<_>, StorageError>>()
                 }
@@ -453,6 +430,53 @@ impl ImmutableValueStore {
         }
         Ok(())
     }
+}
+
+fn materialize_immutable_request(
+    spans: &[Option<Bytes>],
+    requested: &Range<usize>,
+    fragments: &[(usize, Range<usize>)],
+) -> Result<Bytes, StorageError> {
+    if let [(span_index, range)] = fragments {
+        let span = spans
+            .get(*span_index)
+            .and_then(Option::as_ref)
+            .ok_or_else(|| {
+                StorageError::Corruption(
+                    "immutable segment read omitted a requested extent".to_string(),
+                )
+            })?;
+        if range.end > span.len() || range.len() != requested.len() {
+            return Err(StorageError::Corruption(
+                "immutable segment extent is truncated".to_string(),
+            ));
+        }
+        return Ok(span.slice(range.clone()));
+    }
+
+    let mut encoded = BytesMut::with_capacity(requested.len());
+    for (span_index, range) in fragments {
+        let span = spans
+            .get(*span_index)
+            .and_then(Option::as_ref)
+            .ok_or_else(|| {
+                StorageError::Corruption(
+                    "immutable segment read omitted a requested extent".to_string(),
+                )
+            })?;
+        if range.end > span.len() {
+            return Err(StorageError::Corruption(
+                "immutable segment extent is truncated".to_string(),
+            ));
+        }
+        encoded.extend_from_slice(&span[range.clone()]);
+    }
+    if encoded.len() != requested.len() {
+        return Err(StorageError::Corruption(
+            "immutable extents did not reconstruct the requested value".to_string(),
+        ));
+    }
+    Ok(encoded.freeze())
 }
 
 #[derive(Debug, PartialEq, Eq)]
@@ -4691,6 +4715,32 @@ mod tests {
         let range = segment.values[0].1.clone();
         let bytes = Bytes::from(segment.frames.into_iter().collect::<PutPayload>());
         (segment.id, bytes, range)
+    }
+
+    #[test]
+    fn single_immutable_extent_reuses_the_fetched_span() {
+        let span = Bytes::from_static(b"0123456789");
+        let expected_ptr = span.slice(2..5).as_ptr();
+        let value = materialize_immutable_request(&[Some(span)], &(100..103), &[(0, 2..5)])
+            .expect("materialize one immutable extent");
+
+        assert_eq!(value, Bytes::from_static(b"234"));
+        assert_eq!(value.as_ptr(), expected_ptr);
+    }
+
+    #[test]
+    fn fragmented_immutable_extents_still_reconstruct_one_value() {
+        let value = materialize_immutable_request(
+            &[
+                Some(Bytes::from_static(b"abc")),
+                Some(Bytes::from_static(b"def")),
+            ],
+            &(100..104),
+            &[(0, 1..3), (1, 0..2)],
+        )
+        .expect("materialize fragmented immutable extents");
+
+        assert_eq!(value, Bytes::from_static(b"bcde"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- return a `Bytes::slice` when one immutable value is wholly contained in one fetched/coalesced extent
- retain the existing copy-and-concatenate path for fragmented values
- remove one payload-sized SlateDB allocation without changing disk layout, storage contracts, or public APIs

## Profile evidence

Exact baseline: `1d406823f3fd5428a63066978ed5a52ab5ceaa72`, uncontended `hetzner-II`, release build, 64 MiB file lifecycle. Heaptrack attributes the removed copy to `ImmutableValueStore::get_many`: coalesced object-store span -> per-request `BytesMut` -> final public blob.

| SlateDB operation | Baseline allocation | Candidate allocation | Change |
|---|---:|---:|---:|
| 64 MiB full read | ~202 MiB | ~135 MiB | -33% (3x -> 2x payload) |
| 4 KiB range, first | ~2.93 MiB | ~1.88 MiB | -36% |
| 4 KiB range, warm | ~3.37 MiB | ~2.32 MiB | -31% |

Full-read wall time remained flat within run variance: approximately 43/35 ms first/warm before and 44/33 ms after. RocksDB is unchanged. Physical bytes and I/O request counts are unchanged.

Raw heaptrack/profile evidence is retained on `hetzner-II` under `/root/evidence/codex2-1d406-hetzner2/`.

## Validation

- focused pointer-ownership test proves the single-fragment result shares the fetched extent
- focused fragmented reconstruction test preserves the fallback path
- `cargo fmt --check`
- `cargo test -p lix-storage-slatedb` (65 unit + 11 adapter/integration tests, including cached/uncached storage conformance and reopen)