### PR TITLE
perf: retain authenticated update predecessors

### DIFF
--- a/packages/lix/src/sql2/exec/bound_public_write.rs
+++ b/packages/lix/src/sql2/exec/bound_public_write.rs
@@ -1251,6 +1251,7 @@ async fn try_execute_direct_path_value_replacement_batch(
     };
     let mut snapshot_offsets = Vec::with_capacity(replacement_capacity);
     let mut replacement_entity_pks = Vec::with_capacity(replacement_capacity);
+    let mut replacement_predecessors = Vec::with_capacity(replacement_capacity);
     let mut affected_by_statement =
         (!certified_generation_identity).then(|| vec![0_u64; row_count]);
     let mut candidate_index = 0;
@@ -1306,6 +1307,16 @@ async fn try_execute_direct_path_value_replacement_batch(
         normalized.push(b'}');
         snapshot_offsets.push((start, normalized.len()));
         replacement_entity_pks.push(entity_pk.clone());
+        replacement_predecessors.push(
+            (!certified_generation_identity)
+                .then(|| {
+                    candidates
+                        .row(candidate_index)
+                        .durable_predecessor()
+                        .cloned()
+                })
+                .flatten(),
+        );
         if let Some(ordinals) = &sorted_statement_ordinals {
             for &affected_statement in &ordinals[first_statement_index..=last_statement_index] {
                 if let Some(affected_by_statement) = &mut affected_by_statement {
@@ -1323,7 +1334,7 @@ async fn try_execute_direct_path_value_replacement_batch(
         let normalized_len = normalized.len();
         let snapshots =
             TransactionJson::from_certified_row_content_arena(normalized, snapshot_offsets)?;
-        let rows = CertifiedParameterReplacementBatch::new(
+        let mut rows = CertifiedParameterReplacementBatch::new(
             replacement_entity_pks,
             snapshots,
             spec.schema_key.as_str().into(),
@@ -1348,6 +1359,9 @@ async fn try_execute_direct_path_value_replacement_batch(
                     .flatten(),
             },
         )?;
+        for (index, predecessor) in replacement_predecessors.into_iter().enumerate() {
+            rows.set_durable_predecessor(index, predecessor);
+        }
         ctx.stage_certified_parameter_batch_replace(rows)
             .instrument(tracing::debug_span!(
                 target: "lix_perf",

--- a/packages/lix/src/transaction/types.rs
+++ b/packages/lix/src/transaction/types.rs
@@ -559,6 +559,7 @@ impl TypedMutationJournalBatch {
 pub(crate) struct CertifiedParameterBatch {
     entity_pks: Vec<EntityPk>,
     snapshots: Vec<TransactionJson>,
+    durable_predecessors: Vec<Option<CertifiedCurrentStatePredecessor>>,
     schema_key: SharedStr,
     branch_id: SharedStr,
     untracked: bool,
@@ -605,6 +606,9 @@ impl CertifiedParameterBatch {
             ));
         }
         Ok(Self {
+            durable_predecessors: std::iter::repeat_with(|| None)
+                .take(entity_pks.len())
+                .collect(),
             entity_pks,
             snapshots,
             schema_key,
@@ -639,15 +643,27 @@ impl CertifiedParameterBatch {
         self.untracked
     }
 
+    pub(crate) fn set_durable_predecessor(
+        &mut self,
+        index: usize,
+        value: Option<CertifiedCurrentStatePredecessor>,
+    ) {
+        self.durable_predecessors[index] = value;
+    }
+
     pub(crate) fn into_raw(self) -> Result<RawWriteBatch, LixError> {
-        RawWriteBatch::from_certified_parameter_rows(
+        let mut rows = RawWriteBatch::from_certified_parameter_rows(
             self.entity_pks,
             self.snapshots,
             self.schema_key,
             self.branch_id,
             self.untracked,
             self.certificate,
-        )
+        )?;
+        for (index, predecessor) in self.durable_predecessors.into_iter().enumerate() {
+            rows.set_durable_predecessor(index, predecessor);
+        }
+        Ok(rows)
     }
 
     pub(crate) fn into_dense_prepared(
@@ -666,6 +682,7 @@ impl CertifiedParameterBatch {
         let Self {
             entity_pks,
             snapshots,
+            durable_predecessors,
             schema_key,
             branch_id,
             untracked,
@@ -673,6 +690,22 @@ impl CertifiedParameterBatch {
             entity_columnar,
         } = self;
         let row_count = entity_pks.len();
+        let predecessor_count = durable_predecessors
+            .iter()
+            .filter(|value| value.is_some())
+            .count();
+        let dense_durable_predecessors = if predecessor_count == row_count && row_count != 0 {
+            Some(
+                durable_predecessors
+                    .iter()
+                    .cloned()
+                    .map(|value| value.expect("every certified predecessor is present"))
+                    .collect::<Vec<_>>()
+                    .into(),
+            )
+        } else {
+            None
+        };
         let (mut strings, schema_key_ordinal, branch_id_ordinal) = if schema_key == branch_id {
             (vec![schema_key], 0_u32, 0_u32)
         } else {
@@ -707,7 +740,7 @@ impl CertifiedParameterBatch {
                 )
             })
             .collect();
-        Ok(PreparedStateBatch {
+        let mut prepared = PreparedStateBatch {
             slots: Vec::new(),
             dense_certified_parameter: Some(DenseCertifiedParameterSlots {
                 len: row_count,
@@ -721,6 +754,7 @@ impl CertifiedParameterBatch {
                 untracked,
                 direct_change_ids: None,
                 entity_columnar,
+                durable_predecessors: dense_durable_predecessors,
             }),
             entity_pks,
             strings,
@@ -733,7 +767,13 @@ impl CertifiedParameterBatch {
             origin_column_index: HashMap::new(),
             certified_tracked_keys_strictly_ordered: certificate.tracked_keys_strictly_ordered,
             complete_collection_replacement: certificate.complete_collection_replacement,
-        })
+        };
+        if predecessor_count != 0 && predecessor_count != row_count {
+            for (index, predecessor) in durable_predecessors.into_iter().enumerate() {
+                prepared.set_durable_predecessor(index, predecessor);
+            }
+        }
+        Ok(prepared)
     }
 }
 
@@ -2813,6 +2853,10 @@ struct DenseCertifiedParameterSlots {
     /// Frontend-built row groups over the same certified typed columns.
     /// Topology-changing operations drop this derived accelerator.
     entity_columnar: Option<crate::sql2::EncodedEntityRowGroups>,
+    /// Exact authenticated predecessor evidence is row-aligned with the
+    /// certified identity column. Ordinary replacement batches therefore
+    /// retain their compact representation through publication.
+    durable_predecessors: Option<Arc<[CertifiedCurrentStatePredecessor]>>,
 }
 
 #[derive(Debug, Clone)]
@@ -3090,7 +3134,10 @@ impl PreparedStateBatch {
                 commit_id: dense.commit_id,
                 untracked: dense.untracked,
                 branch_id: &self.strings[dense.branch_id as usize],
-                durable_predecessor: None,
+                durable_predecessor: dense
+                    .durable_predecessors
+                    .as_ref()
+                    .map(|values| &values[index]),
             });
         }
         let slot = *self.slots.get(index)?;
@@ -3273,6 +3320,12 @@ impl PreparedStateBatch {
         for row_index in 0..dense.len {
             let ordinal = u32::try_from(row_index)
                 .expect("dense certified parameter row ordinal must fit u32");
+            let durable_predecessor = dense.durable_predecessors.as_ref().map(|values| {
+                let index = u32::try_from(self.durable_predecessors.len())
+                    .expect("prepared durable predecessor column must fit u32");
+                self.durable_predecessors.push(values[row_index].clone());
+                index
+            });
             self.slots.push(PreparedStateSlot {
                 schema_plan_id: dense.schema_plan_id,
                 facts: dense.facts,
@@ -3298,7 +3351,7 @@ impl PreparedStateBatch {
                 commit_id: dense.commit_id,
                 untracked: false,
                 branch_id: dense.branch_id,
-                durable_predecessor: None,
+                durable_predecessor,
             });
         }
     }
@@ -3347,6 +3400,8 @@ impl PreparedStateBatch {
                     && right.direct_change_ids.is_none()
                     && left.entity_columnar.is_none()
                     && right.entity_columnar.is_none()
+                    && left.durable_predecessors.is_none()
+                    && right.durable_predecessors.is_none()
                     && self.durable_predecessors.is_empty()
                     && other.durable_predecessors.is_empty()
                     && self.origins.is_empty()
@@ -4553,6 +4608,70 @@ mod tests {
         assert_eq!(prepared.complete_collection_replacement_proof(), None);
         assert!(!prepared.certified_tracked_keys_strictly_ordered());
         assert_eq!(prepared.row(0).entity_pk, &EntityPk::single("a"));
+    }
+
+    #[test]
+    fn certified_replacement_keeps_authenticated_predecessors_dense_and_through_expansion() {
+        let snapshots = [r#"{"id":"a"}"#, r#"{"id":"b"}"#]
+            .into_iter()
+            .map(|value| {
+                TransactionJson::from_certified_shared_normalized_row_content(value.into())
+            })
+            .collect::<Vec<_>>();
+        let mut rows = CertifiedParameterReplacementBatch::new(
+            vec![EntityPk::single("a"), EntityPk::single("b")],
+            snapshots,
+            "dense_replacement".into(),
+            "main".into(),
+            CertifiedRawWriteBatchPreparation {
+                schema_plan_id: SchemaPlanId::for_test(10),
+                facts: PreparedRowFacts {
+                    row_content_validated: true,
+                    requires_transaction_validation: false,
+                },
+                tracked_keys_strictly_ordered: true,
+                complete_collection_replacement: None,
+            },
+        )
+        .expect("certified replacement should construct");
+        rows.set_durable_predecessor(
+            0,
+            Some(CertifiedCurrentStatePredecessor::Encoded(
+                Bytes::from_static(b"predecessor-a"),
+            )),
+        );
+        rows.set_durable_predecessor(
+            1,
+            Some(CertifiedCurrentStatePredecessor::Encoded(
+                Bytes::from_static(b"predecessor-b"),
+            )),
+        );
+
+        let mut prepared = rows
+            .into_dense_prepared(
+                None,
+                LixTimestamp::expect_parse("timestamp", "2026-08-02T00:00:00.000Z"),
+            )
+            .expect("certified replacement should prepare");
+        assert!(prepared.is_dense_certified_parameter());
+        assert!(matches!(
+            prepared.row(1).durable_predecessor,
+            Some(CertifiedCurrentStatePredecessor::Encoded(bytes))
+                if bytes.as_ref() == b"predecessor-b"
+        ));
+
+        prepared.set_requires_transaction_validation(0, true);
+        assert!(!prepared.is_dense_certified_parameter());
+        assert!(matches!(
+            prepared.row(0).durable_predecessor,
+            Some(CertifiedCurrentStatePredecessor::Encoded(bytes))
+                if bytes.as_ref() == b"predecessor-a"
+        ));
+        assert!(matches!(
+            prepared.row(1).durable_predecessor,
+            Some(CertifiedCurrentStatePredecessor::Encoded(bytes))
+                if bytes.as_ref() == b"predecessor-b"
+        ));
     }
 
     #[test]


### PR DESCRIPTION
## What

Preserve the authenticated current-state predecessor already returned by the
certified SQL update candidate scan through the dense transaction batch and
into ForkTree publication.

Previously the typed batch discarded this proof, so publication repeated the
same exact state lookup. This change uses the existing predecessor type and
publication validation; it adds no cache, fallback, authority, writer, or
storage-format path.

## Performance

Identical public SQL harness, setup excluded, five samples per candidate cell.
Exact base is `1d406823f3fd5428a63066978ed5a52ab5ceaa72`.

Representative D=100 update medians:

| Backend | N | Base | Candidate | Gain |
|---|---:|---:|---:|---:|
| RocksDB | 1K | 1.081 ms | 0.868 ms | 19.7% |
| RocksDB | 10K | 3.011 ms | 2.028 ms | 32.6% |
| RocksDB | 50K | 7.166 ms | 4.292 ms | 40.1% |
| SlateDB | 1K | 1.215 ms | 0.982 ms | 19.2% |
| SlateDB | 10K | 3.183 ms | 2.148 ms | 32.5% |
| SlateDB | 50K | 7.315 ms | 4.200 ms | 42.6% |

The complete N=1K/10K/50K, D=1/100/1K timing matrix is improved or neutral; D=1000
improves by up to 34.5% RocksDB and 32.1% SlateDB. At 50K/D100 allocations fall
from 32.8 MB/7011 calls to 17.1 MB/4994 calls on RocksDB and from 37.0 MB/8366
calls to 19.3 MB/5886 calls on SlateDB. Public result readback remains enabled.

## Gates

- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo check -p lix --lib --all-features`
- dense predecessor retention/expansion unit test: 1/1
- exact HOT/fallback authority test: 1/1
- certified-page corruption test: 1/1
- checkpoint/GC cold-reopen test: 1/1
- exact public D=100 post-update readback checks every path and JSON value on
  RocksDB and SlateDB: 2/2 adapters
- exact committed binary 50K/D100 confirmation: 34.7% faster RocksDB, 42.3%
  faster SlateDB

Independent source/authority and benchmark/evidence reviews are required before
merge.
