### PR TITLE
perf(vcs): collapse rootless merge replay

### DIFF
--- a/packages/lix/src/tracked_state/commit_root_rebuild.rs
+++ b/packages/lix/src/tracked_state/commit_root_rebuild.rs
@@ -378,8 +378,9 @@ where
 /// commit-delta authority remains the source of every mutation, while only the
 /// terminal root is needed as the parent of the publication being assembled.
 /// Applying the latest authenticated delta for each key once changes replay
-/// from O(H * D * log N) frontier rewrites to O(H * D + U * log N), where U is
-/// the number of unique keys in the interval.
+/// from O(H * D * log N) frontier rewrites to
+/// O(H * D * log U + U * log N), where U is the number of unique keys in the
+/// interval.
 ///
 /// File-descriptor deletion has ordered cascade semantics, so those uncommon
 /// intervals stay on the canonical sequential algorithm.
@@ -412,14 +413,26 @@ where
     let mut terminal_by_key = BTreeMap::<TrackedStateKey, CommitRootRebuildDelta>::new();
     for plan in plans.iter().rev() {
         for delta in &plan.deltas {
-            terminal_by_key.insert(
-                TrackedStateKey {
-                    schema_key: delta.schema_key.clone(),
-                    file_id: delta.file_id.clone(),
-                    entity_pk: delta.entity_pk.clone(),
-                },
-                delta.clone(),
-            );
+            let key = TrackedStateKey {
+                schema_key: delta.schema_key.clone(),
+                file_id: delta.file_id.clone(),
+                entity_pk: delta.entity_pk.clone(),
+            };
+            match terminal_by_key.entry(key) {
+                std::collections::btree_map::Entry::Vacant(entry) => {
+                    entry.insert(delta.clone());
+                }
+                std::collections::btree_map::Entry::Occupied(mut entry) => {
+                    let created_at = entry.get().created_at;
+                    let mut terminal = delta.clone();
+                    // Sequential replay preserves the first visible lifecycle
+                    // timestamp across every later update, tombstone, and
+                    // reinsert. The durable base, when present, may replace it
+                    // once more inside the canonical root writer.
+                    terminal.created_at = created_at;
+                    entry.insert(terminal);
+                }
+            }
         }
     }
     let deltas = terminal_by_key
@@ -448,4 +461,175 @@ where
 
 fn first_parent_commit_id(commit: &CommitRecord) -> Option<CommitId> {
     commit.parent_commit_ids.first().copied()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::common::LixTimestamp;
+    use crate::storage_adapter::{Memory, StorageAdapter, StorageReadOptions};
+
+    fn delta(
+        key: &str,
+        commit: &str,
+        created_millis: i64,
+        updated_millis: i64,
+        deleted: bool,
+    ) -> CommitRootRebuildDelta {
+        CommitRootRebuildDelta {
+            schema_key: "test_entity".to_owned(),
+            file_id: None,
+            entity_pk: EntityPk::single(key),
+            change_id: ChangeId::for_test_label(&format!("{commit}-{key}")),
+            commit_id: CommitId::for_test_label(commit),
+            deleted,
+            created_at: LixTimestamp::from_unix_millis_utc_lossy(created_millis),
+            updated_at: LixTimestamp::from_unix_millis_utc_lossy(updated_millis),
+        }
+    }
+
+    fn plan(
+        commit: &str,
+        parent: Option<&str>,
+        deltas: Vec<CommitRootRebuildDelta>,
+    ) -> CommitRootRebuildPlan {
+        CommitRootRebuildPlan {
+            commit_id: CommitId::for_test_label(commit),
+            parent_commit_id: parent.map(CommitId::for_test_label),
+            deltas,
+        }
+    }
+
+    async fn sequential_and_collapsed_roots(
+        plans: &[CommitRootRebuildPlan],
+    ) -> (TrackedStateRootId, TrackedStateRootId) {
+        let storage = StorageAdapter::new(Memory::new());
+        let read = storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("test read should open");
+        let context = TrackedStateContext::new();
+
+        let mut sequential_writes = StorageWriteSet::new();
+        let mut sequential = context.writer(&read, &mut sequential_writes);
+        let mut sequential_report = None;
+        for plan in plans.iter().rev() {
+            sequential_report = Some(
+                stage_rebuild_plan_with_writer(&mut sequential, plan)
+                    .await
+                    .expect("sequential replay should stage"),
+            );
+        }
+
+        let mut collapsed_writes = StorageWriteSet::new();
+        let mut collapsed = context.writer(&read, &mut collapsed_writes);
+        let collapsed_report = try_stage_collapsed_rebuild_plans_with_writer(&mut collapsed, plans)
+            .await
+            .expect("collapsed replay should validate")
+            .expect("multi-plan ordinary replay should collapse");
+        (
+            sequential_report
+                .expect("sequential replay has a root")
+                .root_id,
+            collapsed_report.root_id,
+        )
+    }
+
+    #[tokio::test]
+    async fn collapsed_replay_matches_sequential_lifecycle_roots() {
+        for terminal in [
+            delta("row", "second-update", 20, 20, false),
+            delta("row", "second-delete", 20, 20, true),
+        ] {
+            let plans = vec![
+                plan("second", Some("first"), vec![terminal]),
+                plan("first", None, vec![delta("row", "first", 10, 10, false)]),
+            ];
+            let (sequential, collapsed) = sequential_and_collapsed_roots(&plans).await;
+            assert_eq!(collapsed, sequential);
+        }
+
+        let plans = vec![
+            plan(
+                "third",
+                Some("second"),
+                vec![delta("row", "third", 30, 30, false)],
+            ),
+            plan(
+                "second",
+                Some("first"),
+                vec![delta("row", "second", 20, 20, true)],
+            ),
+            plan("first", None, vec![delta("row", "first", 10, 10, false)]),
+        ];
+        let (sequential, collapsed) = sequential_and_collapsed_roots(&plans).await;
+        assert_eq!(collapsed, sequential);
+    }
+
+    #[tokio::test]
+    async fn shared_rootless_suffixes_stage_independent_terminal_and_child_roots() {
+        let storage = StorageAdapter::new(Memory::new());
+        let read = storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("test read should open");
+        let context = TrackedStateContext::new();
+        let mut writes = StorageWriteSet::new();
+        let mut writer = context.writer(&read, &mut writes);
+        let suffix = vec![
+            plan(
+                "suffix-new",
+                Some("suffix-old"),
+                vec![delta("shared-new", "suffix-new", 20, 20, false)],
+            ),
+            plan(
+                "suffix-old",
+                None,
+                vec![delta("shared-old", "suffix-old", 10, 10, false)],
+            ),
+        ];
+        let mut left = vec![plan(
+            "left",
+            Some("suffix-new"),
+            vec![delta("left", "left", 30, 30, false)],
+        )];
+        left.extend(suffix.clone());
+        let mut right = vec![plan(
+            "right",
+            Some("suffix-new"),
+            vec![delta("right", "right", 30, 30, false)],
+        )];
+        right.extend(suffix);
+
+        let left_report = try_stage_collapsed_rebuild_plans_with_writer(&mut writer, &left)
+            .await
+            .expect("left collapse should validate")
+            .expect("left collapse should stage");
+        let right_report = try_stage_collapsed_rebuild_plans_with_writer(&mut writer, &right)
+            .await
+            .expect("right collapse should validate")
+            .expect("right collapse should stage");
+        assert_ne!(left_report.root_id, right_report.root_id);
+
+        for (parent, child) in [("left", "left-child"), ("right", "right-child")] {
+            let child_delta = delta(child, child, 40, 40, false);
+            writer
+                .stage_commit_root(
+                    &CommitId::for_test_label(child).to_string(),
+                    Some(&CommitId::for_test_label(parent).to_string()),
+                    [TrackedStateDeltaRef {
+                        schema_key: &child_delta.schema_key,
+                        file_id: child_delta.file_id.as_deref(),
+                        entity_pk: &child_delta.entity_pk,
+                        change_id: child_delta.change_id,
+                        commit_id: child_delta.commit_id,
+                        deleted: child_delta.deleted,
+                        created_at: child_delta.created_at,
+                        updated_at: child_delta.updated_at,
+                    }],
+                )
+                .await
+                .expect("child should use its independently staged parent root");
+        }
+    }
 }

--- a/packages/lix/src/tracked_state/commit_root_rebuild.rs
+++ b/packages/lix/src/tracked_state/commit_root_rebuild.rs
@@ -1,4 +1,4 @@
-use std::collections::HashSet;
+use std::collections::{BTreeMap, HashSet};
 
 use crate::LixError;
 use crate::changelog::{
@@ -7,7 +7,6 @@ use crate::changelog::{
 use crate::common::LixTimestamp;
 use crate::entity_pk::EntityPk;
 use crate::storage_adapter::{StorageAdapterRead, StorageWriteSet};
-use crate::tracked_state::TrackedStateDeltaRef;
 use crate::tracked_state::context::{
     TrackedStateContext, TrackedStateRootRebuilder, TrackedStateTransientRebuildState,
     TrackedStateWriteReport, TrackedStateWriter,
@@ -17,6 +16,9 @@ use crate::tracked_state::tree::TrackedStateTree;
 use crate::tracked_state::types::{
     TrackedStateCommitRoot, TrackedStateRootId, TrackedStateTreeScanRequest,
 };
+use crate::tracked_state::{TrackedStateDeltaRef, TrackedStateKey};
+
+const FILE_DESCRIPTOR_SCHEMA_KEY: &str = "lix_file_descriptor";
 
 /// Owned delta used only by explicit commit-root rebuild.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -367,6 +369,81 @@ where
     writer
         .stage_commit_root(&commit_id, parent_commit_id.as_deref(), deltas)
         .await
+}
+
+/// Collapses one contiguous rootless first-parent replay interval into its
+/// canonical terminal root.
+///
+/// Rootless commit roots are transient implementation details: immutable
+/// commit-delta authority remains the source of every mutation, while only the
+/// terminal root is needed as the parent of the publication being assembled.
+/// Applying the latest authenticated delta for each key once changes replay
+/// from O(H * D * log N) frontier rewrites to O(H * D + U * log N), where U is
+/// the number of unique keys in the interval.
+///
+/// File-descriptor deletion has ordered cascade semantics, so those uncommon
+/// intervals stay on the canonical sequential algorithm.
+pub(crate) async fn try_stage_collapsed_rebuild_plans_with_writer<S>(
+    writer: &mut TrackedStateWriter<'_, S>,
+    plans: &[CommitRootRebuildPlan],
+) -> Result<Option<TrackedStateWriteReport>, LixError>
+where
+    S: StorageAdapterRead + ?Sized,
+{
+    if plans.len() < 2 {
+        return Ok(None);
+    }
+    for pair in plans.windows(2) {
+        if pair[0].parent_commit_id != Some(pair[1].commit_id) {
+            return Err(LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                "tracked-state collapsed rebuild plans are not one first-parent interval",
+            ));
+        }
+    }
+    if plans
+        .iter()
+        .flat_map(|plan| &plan.deltas)
+        .any(|delta| delta.deleted && delta.schema_key == FILE_DESCRIPTOR_SCHEMA_KEY)
+    {
+        return Ok(None);
+    }
+
+    let mut terminal_by_key = BTreeMap::<TrackedStateKey, CommitRootRebuildDelta>::new();
+    for plan in plans.iter().rev() {
+        for delta in &plan.deltas {
+            terminal_by_key.insert(
+                TrackedStateKey {
+                    schema_key: delta.schema_key.clone(),
+                    file_id: delta.file_id.clone(),
+                    entity_pk: delta.entity_pk.clone(),
+                },
+                delta.clone(),
+            );
+        }
+    }
+    let deltas = terminal_by_key
+        .values()
+        .map(|delta| TrackedStateDeltaRef {
+            schema_key: &delta.schema_key,
+            file_id: delta.file_id.as_deref(),
+            entity_pk: &delta.entity_pk,
+            change_id: delta.change_id,
+            commit_id: delta.commit_id,
+            deleted: delta.deleted,
+            created_at: delta.created_at,
+            updated_at: delta.updated_at,
+        })
+        .collect::<Vec<_>>();
+    let terminal_commit_id = plans[0].commit_id.to_string();
+    let base_commit_id = plans
+        .last()
+        .and_then(|plan| plan.parent_commit_id)
+        .map(|commit_id| commit_id.to_string());
+    writer
+        .stage_commit_root(&terminal_commit_id, base_commit_id.as_deref(), deltas)
+        .await
+        .map(Some)
 }
 
 fn first_parent_commit_id(commit: &CommitRecord) -> Option<CommitId> {

--- a/packages/lix/src/tracked_state/commit_root_rebuild.rs
+++ b/packages/lix/src/tracked_state/commit_root_rebuild.rs
@@ -402,11 +402,10 @@ where
             ));
         }
     }
-    if plans
-        .iter()
-        .flat_map(|plan| &plan.deltas)
-        .any(|delta| delta.deleted && delta.schema_key == FILE_DESCRIPTOR_SCHEMA_KEY)
-    {
+    if plans.iter().flat_map(|plan| &plan.deltas).any(|delta| {
+        (delta.deleted && delta.schema_key == FILE_DESCRIPTOR_SCHEMA_KEY)
+            || delta.schema_key == crate::collection_generation::COLLECTION_GENERATION_SCHEMA_KEY
+    }) {
         return Ok(None);
     }
 
@@ -630,6 +629,42 @@ mod tests {
                 )
                 .await
                 .expect("child should use its independently staged parent root");
+        }
+    }
+
+    #[tokio::test]
+    async fn order_sensitive_lifecycle_intervals_keep_sequential_replay() {
+        let storage = StorageAdapter::new(Memory::new());
+        let read = storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("test read should open");
+        let context = TrackedStateContext::new();
+        for sensitive_delta in [
+            CommitRootRebuildDelta {
+                schema_key: FILE_DESCRIPTOR_SCHEMA_KEY.to_owned(),
+                deleted: true,
+                ..delta("file", "file-delete", 20, 20, true)
+            },
+            CommitRootRebuildDelta {
+                schema_key: crate::collection_generation::COLLECTION_GENERATION_SCHEMA_KEY
+                    .to_owned(),
+                ..delta("replacement", "replacement", 20, 20, false)
+            },
+        ] {
+            let plans = vec![
+                plan("second", Some("first"), vec![sensitive_delta]),
+                plan("first", None, vec![delta("row", "first", 10, 10, false)]),
+            ];
+            let mut writes = StorageWriteSet::new();
+            let mut writer = context.writer(&read, &mut writes);
+            assert!(
+                try_stage_collapsed_rebuild_plans_with_writer(&mut writer, &plans)
+                    .await
+                    .expect("sensitive replay classification should validate")
+                    .is_none(),
+                "order-sensitive lifecycle replay must use the sequential writer"
+            );
         }
     }
 }

--- a/packages/lix/src/tracked_state/mod.rs
+++ b/packages/lix/src/tracked_state/mod.rs
@@ -26,6 +26,7 @@ mod types;
 pub(crate) use codec::{encode_key_ref, encode_single_string_key_ref_into};
 pub(crate) use commit_root_rebuild::{
     load_rebuild_plans_to_nearest_available_root, stage_rebuild_plan_with_writer,
+    try_stage_collapsed_rebuild_plans_with_writer,
 };
 pub(crate) use context::{
     TrackedStateContext, TrackedStateStoreReader, descriptor_dependency_cascade_file_ids,

--- a/packages/lix/src/transaction/commit.rs
+++ b/packages/lix/src/transaction/commit.rs
@@ -5742,6 +5742,20 @@ async fn stage_tracked_roots(
             true,
         )
         .await?;
+        let all_new = plans
+            .iter()
+            .all(|plan| !staged_rebuild_plan_ids.contains(&plan.commit_id));
+        if all_new
+            && crate::tracked_state::try_stage_collapsed_rebuild_plans_with_writer(
+                &mut tracked_writer,
+                &plans,
+            )
+            .await?
+            .is_some()
+        {
+            staged_rebuild_plan_ids.extend(plans.iter().map(|plan| plan.commit_id));
+            continue;
+        }
         for plan in plans.iter().rev() {
             if staged_rebuild_plan_ids.insert(plan.commit_id) {
                 crate::tracked_state::stage_rebuild_plan_with_writer(&mut tracked_writer, plan)

--- a/packages/lix/src/transaction/commit.rs
+++ b/packages/lix/src/transaction/commit.rs
@@ -5753,7 +5753,10 @@ async fn stage_tracked_roots(
             .await?
             .is_some()
         {
-            staged_rebuild_plan_ids.extend(plans.iter().map(|plan| plan.commit_id));
+            // A collapsed replay stages only its terminal root. Intermediate
+            // plan IDs remain unstaged so another rebuild parent sharing this
+            // suffix can independently collapse against immutable authority.
+            staged_rebuild_plan_ids.insert(plans[0].commit_id);
             continue;
         }
         for plan in plans.iter().rev() {


### PR DESCRIPTION
## Summary

Collapse contiguous ordinary first-parent rootless replay into one canonical transient tracked-state root during merge publication. Authentication and immutable plan loading remain unchanged; order-sensitive file-delete and collection-generation intervals use the canonical sequential path.

## Performance

Exact main `1d406823f`, globally ordered alternating five-sample A/B, 10K rows / 100 changes per side / 10 divergent commits / 100 history:

- RocksDB merge median: 25.667 -> 17.115 ms (-33.3%)
- SlateDB merge median: 27.261 -> 18.670 ms (-31.5%)
- Merge allocations: -37.3% RocksDB / -38.6% SlateDB
- Settled merge growth: -70.2% RocksDB / -79.9% SlateDB
- All 20 semantic, idempotency, branch-isolation, and cold-reopen records pass

Evidence SHA-256: `a027c81b114f2eb59a1b58e4c9e4ee7f7f081227cbf7c07bfd6e2ee41165078f`.

## Gates

- tracked-state: 298 passed, 1 ignored
- full branching review slice: 72/72
- exact-target classifier: 3/3
- exact-target branch merge: 4/4
- all-feature test binaries compile
- fmt and diff-check pass
- independent source/auth/corruption review: APPROVE
- independent performance/evidence review: APPROVE

Standalone immutable candidate: `b30bf633e59075666dbfc5a5ea28fa2822172b84`.
Exact-target integration head: `b737e47a431353a8ab09b8f6ada675123648dfe5` on base `3d1fdbab9e0fa902eb3ad7e8197039757d2b01a4`.