### PR TITLE
perf(storage_adapter): hash only keys when coalescing content-addressed puts

### DIFF
--- a/.changenotes/faster-content-addressed-write-staging.md
+++ b/.changenotes/faster-content-addressed-write-staging.md
@@ -1,0 +1,7 @@
+---
+type: patch
+---
+
+Faster writes for transactions that stage large amounts of tracked state.
+
+Coalescing content-addressed puts now hashes only the content key instead of the key together with the whole payload, so staging a commit no longer runs every tracked-state tree chunk through the hasher twice.

--- a/packages/lix/src/storage_adapter/write_set.rs
+++ b/packages/lix/src/storage_adapter/write_set.rs
@@ -1,4 +1,5 @@
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
+use std::collections::hash_map::Entry;
 use std::fmt;
 use std::sync::atomic::{AtomicU64, Ordering};
 
@@ -186,10 +187,31 @@ enum MutationIndex {
     Delete(usize),
 }
 
-#[derive(Hash, PartialEq, Eq)]
-struct ContentAddressedRef<'a> {
+/// Staged content-addressed puts indexed by key.
+///
+/// A content-addressed space derives its key from the value, so the key alone
+/// identifies the content. Hashing only the key keeps coalescing proportional
+/// to the key bytes instead of the whole staged payload; the retained value is
+/// compared directly when a key repeats, which is the only case where the
+/// distinction between "identical entry" and "conflicting mutation" matters.
+type ContentAddressedIndex<'a> = HashMap<&'a [u8], &'a [u8], FastHashBuilder>;
+
+/// Returns whether the put must stay staged.
+///
+/// An identical entry is coalesced. A same-key/different-value entry is kept
+/// so the canonical validator still rejects it as a duplicate mutation.
+fn retain_content_addressed_put<'a>(
+    index: &mut ContentAddressedIndex<'a>,
     key: &'a [u8],
     value: &'a [u8],
+) -> bool {
+    match index.entry(key) {
+        Entry::Occupied(entry) => *entry.get() != value,
+        Entry::Vacant(entry) => {
+            entry.insert(value);
+            true
+        }
+    }
 }
 
 struct ArenaRemap {
@@ -348,24 +370,22 @@ impl StorageWriteSet {
 
         let keep = {
             let group = self.group_mut(space);
-            let mut existing = HashSet::with_capacity_and_hasher(
+            let mut existing = ContentAddressedIndex::with_capacity_and_hasher(
                 group.puts.len().saturating_add(entries.len()),
                 FastHashBuilder::with_seeds(0, 0, 0, 0),
             );
             for put in &group.puts {
-                existing.insert(ContentAddressedRef {
-                    key: group.key_bytes(put.key),
-                    value: group.value_bytes(put.value),
-                });
+                existing.insert(group.key_bytes(put.key), group.value_bytes(put.value));
             }
 
             entries
                 .iter()
                 .map(|(key, value)| {
-                    existing.insert(ContentAddressedRef {
-                        key: key.0.as_ref(),
-                        value: value.bytes.as_ref(),
-                    })
+                    retain_content_addressed_put(
+                        &mut existing,
+                        key.0.as_ref(),
+                        value.bytes.as_ref(),
+                    )
                 })
                 .collect::<Vec<_>>()
         };
@@ -469,24 +489,22 @@ impl StorageWriteSet {
         );
         let puts = {
             let group = self.group_mut(space);
-            let mut existing = HashSet::with_capacity_and_hasher(
+            let mut existing = ContentAddressedIndex::with_capacity_and_hasher(
                 group.puts.len().saturating_add(puts.len()),
                 FastHashBuilder::with_seeds(0, 0, 0, 0),
             );
             for put in &group.puts {
-                existing.insert(ContentAddressedRef {
-                    key: group.key_bytes(put.key),
-                    value: group.value_bytes(put.value),
-                });
+                existing.insert(group.key_bytes(put.key), group.value_bytes(put.value));
             }
             puts.into_iter()
                 .filter(|put| {
-                    existing.insert(ContentAddressedRef {
-                        key: &key_bytes
+                    retain_content_addressed_put(
+                        &mut existing,
+                        &key_bytes
                             [put.key.offset()..put.key.offset().saturating_add(put.key.len())],
-                        value: &value_bytes[put.value.offset()
+                        &value_bytes[put.value.offset()
                             ..put.value.offset().saturating_add(put.value.len())],
-                    })
+                    )
                 })
                 .collect::<Vec<_>>()
         };


### PR DESCRIPTION
## What changed

`StorageWriteSet::stage_content_addressed_encoded_batch` coalesced already-staged puts through a
`HashSet<ContentAddressedRef>` whose derived `Hash` covered **the key and the entire value**. Every
content-addressed batch therefore ran its whole payload through ahash twice per staging call: once to
re-index the already-staged lane, and once to filter the incoming batch. The only content-addressed
producer of any size is `TrackedStateChunkOverlay::stage_chunks`, so every tracked-state tree chunk
written by a commit was hashed end-to-end — on top of the blake3 that produced its key in the first
place.

A content-addressed space derives its key from its value; the key already *is* the digest. The dedup
index is now `HashMap<&[u8], &[u8]>` keyed by the content hash alone, and the retained value is
compared directly only when a key actually repeats.

**Removed:** the `ContentAddressedRef` struct and its whole-payload `Hash`/`Eq` derivation, and with
it the redundant second content hash over every staged tree chunk.

Semantics are unchanged and the two existing write-set tests pin them:
- identical entries still coalesce (`content_addressed_batch_coalesces_duplicates_across_staging_calls`);
- same-key/different-value entries are still *kept*, so the canonical validator still rejects them as
  `DuplicateMutation` (`content_addressed_batch_preserves_conflicting_hash_validation`).

## Why (profile)

Machine `ryzen-9950x-V`. Flat CPU profile, `tracked_state_crud` hot-repeat mode,
`sql_session` layer / rocksdb / 10k rows, `perf record -F 2999`.

`update_one_by_pk` **before**:

| symbol | self |
|---|---|
| `ahash::RandomState::hash_one::<&ContentAddressedRef>` | **53.89%** |
| `blake3_hash_many_avx512` | 4.37% |
| `_blake3_compress_in_place_avx512` | 2.69% |
| `HashMap<ContentAddressedRef, (), ahash>::…` | 1.76% |
| `TrackedStateTree::scan_node` | 1.90% |

`update_one_by_pk` **after** — the dedup step in total is now ~6.7%:

| symbol | self |
|---|---|
| `blake3_hash_many_avx512` | 9.91% |
| `_blake3_compress_in_place_avx512` | 5.38% |
| `TrackedStateTree::scan_node` | 3.62% |
| `HashMap<&[u8], &[u8], ahash>::insert` | 3.25% |
| `ahash::RandomState::hash_one::<&&[u8]>` | 1.97% |
| `StorageWriteSet::stage_content_addressed_encoded_batch` | 1.46% |

## A/B

Machine `ryzen-9950x-V` (32 cores, 186 GB), load average settled below 1.0 before the run.
Both worktrees built to completion with `cargo bench … --benches --no-run` **before** any timing.
Arms interleaved base, cand, base, cand … for 5 reps.

Command per sample (`op`/`rows` varied):

```
LIX_TRACKED_STATE_CRUD_PROFILE=1 \
LIX_TRACKED_STATE_CRUD_PROFILE_LAYER=sql_session \
LIX_TRACKED_STATE_CRUD_PROFILE_STORAGE=rocksdb \
LIX_TRACKED_STATE_CRUD_PROFILE_OP=<op> \
LIX_TRACKED_STATE_CRUD_PROFILE_ROW_COUNT=<rows> \
LIX_TRACKED_STATE_CRUD_PROFILE_HOT_REPEATS=<n> \
  target/release/deps/tracked_state_crud-… --bench
```

### Medians and p95 (per-operation latency)

| metric | base median | cand median | Δ median | base p95 | cand p95 |
|---|---|---|---|---|---|
| `update_one_by_pk` 1k | 7.3771 ms | **2.6807 ms** | **−63.7%** | 7.3943 ms | 2.6871 ms |
| `update_one_by_pk` 10k | 3.4577 ms | **2.1671 ms** | **−37.3%** | 3.4622 ms | 2.1786 ms |
| `read_one_by_pk` 1k | 307.53 µs | 302.82 µs | −1.5% | 314.36 µs | 307.66 µs |
| `read_one_by_pk` 10k | 309.62 µs | 311.99 µs | +0.8% | 313.55 µs | 312.84 µs |
| `read_many_by_pk` 1k | 384.42 µs | 383.49 µs | −0.2% | 391.00 µs | 386.87 µs |
| `read_many_by_pk` 10k | 390.01 µs | 389.48 µs | −0.1% | 392.14 µs | 392.00 µs |
| `read_all` 1k | 866.01 µs | 873.14 µs | +0.8% | 867.71 µs | 877.44 µs |
| `read_all` 10k | 3.0756 ms | 3.0873 ms | +0.4% | 3.0908 ms | 3.1045 ms |

### Raw per-rep numbers (µs)

```
base update_one_1k   7332.30 7377.11 7384.43 7373.53 7394.31
cand update_one_1k   2674.65 2679.18 2683.18 2687.11 2680.65
base update_one_10k  3462.20 3457.67 3460.50 3438.72 3438.58
cand update_one_10k  2167.12 2178.57 2165.82 2161.74 2158.70
base read_one_1k      314.36  308.54  307.53  303.32  304.96
cand read_one_1k      295.16  302.82  307.54  307.66  300.20
base read_one_10k     306.95  313.55  309.62  311.98  305.71
cand read_one_10k     311.99  312.84  307.85  307.95  312.61
base read_many_1k     381.62  381.46  391.00  384.42  386.08
cand read_many_1k     377.64  378.90  383.49  386.87  384.48
base read_many_10k    391.28  392.14  389.68  388.83  390.01
cand read_many_10k    384.73  392.00  389.48  391.89  385.73
base read_all_1k      853.33  867.24  856.78  866.01  867.71
cand read_all_1k      864.57  875.82  877.44  873.14  863.23
base read_all_10k    3030.28 3075.61 3090.05 3090.82 3062.97
cand read_all_10k    3085.02 3094.57 3087.26 3085.46 3104.48
```

### Guards

`cargo bench -p lix_benchmarks --features storage-benches,slatedb --bench multi_space_point_read`
(3 interleaved reps, representative rep shown):

| case | base p50 | cand p50 |
|---|---|---|
| rocksdb sequential | 1674 ns | 1683 ns |
| rocksdb batch | 1583 ns | 1633 ns |
| slatedb sequential | 471 ns | 471 ns |
| slatedb batch | 331 ns | 331 ns |

`--bench untracked_state_crud` (3 interleaved reps): flat or slightly better throughout, e.g.
`lix_rocksdb/smoke/insert_all_rows/1k` 704.95 µs → 671.30 µs, `select_all_rows/1k` 145.05 µs →
145.90 µs, `update_one_by_pk/1k` 11.515 µs → 11.467 µs. No case regressed beyond rep-to-rep spread.

`--bench diff_commands`:

| case | base | cand |
|---|---|---|
| `working_diff_1000` | 1.8780 ms | 1.8721 ms |
| `revert_100_of_1000` | 5.4400 ms | 5.4043 ms |
| `apply_100_of_1000` | 5.4812 ms | 5.4263 ms |
| `partial_checkpoint_500_of_1000` | 11.624 ms | 11.625 ms |

`packed_history_scale` (`LIX_PACKED_HISTORY_CHANGES=100000 LIX_PACKED_HISTORY_COMMIT_WIDTHS=10
LIX_PACKED_HISTORY_SAMPLES=3 LIX_PACKED_HISTORY_EXACT_SAMPLES=201`) — physical bytes are unchanged,
which is the direct evidence that dedup decisions are byte-identical:

| backend | base `backend_bytes` | cand `backend_bytes` | `storage_amplification` | `staged_puts` |
|---|---|---|---|---|
| rocksdb | 7 252 939 | 7 252 937 | 1.121 → 1.121 | 120 000 → 120 000 |
| slatedb | 6 872 574 | 6 872 573 | 1.062 → 1.062 | 120 000 → 120 000 |

`STORAGE_V2_BENCH_SMOKE=1 … --bench storage_v2` panics **identically on both arms** at
`packages/engine-benchmarks/benches/storage_v2.rs:1881` (`scan_chunking/…/drain_range_q10000_single`,
`left: 10, right: 1`). This is a pre-existing failure on `claude-3-optimizations`, not a regression
from this change; the identical `write_set_lowering` and `write_set_construction` groups that run
before it are unaffected.

## Regressions

None outside rep-to-rep noise. `read_all` is +0.4…0.8% and `read_one` 10k is +0.8%, both inside the
±1% spread the base arm itself shows across reps (`read_all` 10k base alone spans 3030–3091 µs).
Physical bytes are unchanged to within 2 bytes.

## Correctness gate

Run on `ryzen-9950x-V` against this branch:

- `cargo check --workspace` — clean
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` — clean
- `cargo test -p lix` — exit 0; 2026 + 445 + 19 tests passed, 0 failed
