### PR TITLE
perf(binary-cas): carry authenticated chunk receipts

### DIFF
--- a/packages/engine-benchmarks/tests/large_payload_read_qualification.rs
+++ b/packages/engine-benchmarks/tests/large_payload_read_qualification.rs
@@ -367,8 +367,8 @@ async fn large_media_foreground_lifecycle() {
         .and_then(|value| value.parse::<usize>().ok())
         .unwrap_or(64);
     assert!(
-        matches!(size_mib, 64 | 512),
-        "qualification size must be 64 or 512 MiB"
+        matches!(size_mib, 64 | 256 | 512),
+        "qualification size must be 64, 256, or 512 MiB"
     );
     let temp = tempfile::tempdir().expect("create media qualification directory");
     let database = temp.path().join("database");

--- a/packages/lix/src/binary_cas/context.rs
+++ b/packages/lix/src/binary_cas/context.rs
@@ -191,8 +191,7 @@ where
             self.writes,
             &mut self.blob_hashes,
             &mut self.chunk_keys,
-            payload.bytes(),
-            payload.hash(),
+            payload,
         )
         .await
     }

--- a/packages/lix/src/binary_cas/kv.rs
+++ b/packages/lix/src/binary_cas/kv.rs
@@ -1864,12 +1864,13 @@ pub(in crate::binary_cas) async fn stage_blob_write_skipping_existing_chunks<S>(
     writes: &mut StorageWriteSet,
     blob_hashes: &mut HashSet<[u8; 32]>,
     chunk_keys: &mut HashSet<Vec<u8>>,
-    bytes: &[u8],
-    precomputed_hash: Option<BlobId>,
+    payload: &crate::binary_cas::BlobPayload,
 ) -> Result<BlobWriteReceipt, LixError>
 where
     S: StorageAdapterRead + ?Sized,
 {
+    let bytes = payload.bytes();
+    let precomputed_hash = payload.hash();
     if let Some(hash) = precomputed_hash
         && let Some(metadata) = load_metadata_many(store, &[hash])
             .await?
@@ -1893,13 +1894,13 @@ where
             layout: metadata.layout,
         });
     }
-    let plan = prepare_blob_write(chunking, bytes, precomputed_hash)?;
+    let plan = prepare_blob_write(chunking, payload)?;
     let receipt = plan.receipt.clone();
     if !blob_hashes.insert(plan.blob_hash.into_bytes()) {
         return Ok(receipt);
     }
 
-    let chunks = prepare_chunks(bytes, &plan);
+    let chunks = prepare_chunks(payload, &plan)?;
     let mut chunk_hashes_to_stage = missing_chunk_hashes(store, chunk_keys, &plan, &chunks).await?;
     stage_prepared_blob_write(writes, bytes, &plan, &chunks, |chunk_hash| {
         Ok(chunk_hashes_to_stage.remove(&chunk_hash))
@@ -2257,27 +2258,32 @@ fn normalize_delta_segments(segments: Vec<BlobDeltaSegment>) -> Vec<BlobDeltaSeg
 
 fn prepare_blob_write(
     chunking: BinaryCasChunking,
-    bytes: &[u8],
-    precomputed_hash: Option<BlobId>,
+    payload: &crate::binary_cas::BlobPayload,
 ) -> Result<BlobWritePlan, LixError> {
-    let blob_hash = precomputed_hash.unwrap_or_else(|| BlobId::from_content(bytes));
-    if cfg!(debug_assertions)
-        && precomputed_hash.is_some()
-        && BlobId::from_content(bytes) != blob_hash
-    {
-        return Err(LixError::new(
-            "LIX_ERROR_UNKNOWN",
-            "binary CAS blob hash does not match blob contents".to_string(),
-        ));
-    }
+    let bytes = payload.bytes();
+    let blob_hash = payload
+        .hash()
+        .unwrap_or_else(|| BlobId::from_content(bytes));
     let (chunk_ranges, layout) = if bytes.is_empty() {
+        if !payload.chunks().is_empty() {
+            return Err(LixError::new(
+                "LIX_ERROR_UNKNOWN",
+                "empty binary CAS payload unexpectedly has chunk receipts".to_string(),
+            ));
+        }
         (Vec::new(), BlobLayout::Empty)
     } else {
         let chunk_ranges = fastcdc_chunk_ranges_with_chunking(bytes, chunking);
+        if chunk_ranges.len() != payload.chunks().len() {
+            return Err(LixError::new(
+                "LIX_ERROR_UNKNOWN",
+                "binary CAS payload chunk receipts disagree with canonical chunking".to_string(),
+            ));
+        }
         let layout = match chunk_ranges.as_slice() {
             [] => unreachable!("non-empty blobs always have at least one chunk"),
-            [(start, end)] => BlobLayout::SingleChunk {
-                chunk_hash: ChunkHash::from_content(&bytes[*start..*end]),
+            [_] => BlobLayout::SingleChunk {
+                chunk_hash: payload.chunks()[0].hash,
             },
             _ => BlobLayout::Chunked {
                 chunk_count: u32::try_from(chunk_ranges.len()).map_err(|_| {
@@ -2304,23 +2310,31 @@ fn prepare_blob_write(
     })
 }
 
-fn prepare_chunks(bytes: &[u8], plan: &BlobWritePlan) -> Vec<PreparedChunk> {
+fn prepare_chunks(
+    payload: &crate::binary_cas::BlobPayload,
+    plan: &BlobWritePlan,
+) -> Result<Vec<PreparedChunk>, LixError> {
     if !matches!(plan.layout, BlobLayout::Chunked { .. }) {
-        return Vec::new();
+        return Ok(Vec::new());
     }
 
-    plan.chunk_ranges
+    let chunks = plan
+        .chunk_ranges
         .iter()
-        .map(|&(start, end)| PreparedChunk {
+        .zip(payload.chunks())
+        .map(|(&(start, end), receipt)| PreparedChunk {
             start,
             end,
-            hash: if start == 0 && end == bytes.len() {
-                ChunkHash::from_content(bytes)
-            } else {
-                ChunkHash::from_content(&bytes[start..end])
-            },
+            hash: receipt.hash,
         })
-        .collect()
+        .collect::<Vec<_>>();
+    if chunks.len() != plan.chunk_ranges.len() {
+        return Err(LixError::new(
+            "LIX_ERROR_UNKNOWN",
+            "binary CAS payload omitted canonical chunk receipts".to_string(),
+        ));
+    }
+    Ok(chunks)
 }
 
 fn stage_prepared_blob_write(
@@ -3820,8 +3834,8 @@ mod tests {
     #[test]
     fn every_non_empty_blob_is_out_of_line() {
         for size in [1, 32 * 1024, 128 * 1024] {
-            let bytes = vec![b'a'; size];
-            let plan = prepare_blob_write(BinaryCasChunking::default(), &bytes, None)
+            let payload = BlobPayload::from_bytes(vec![b'a'; size]);
+            let plan = prepare_blob_write(BinaryCasChunking::default(), &payload)
                 .expect("non-empty blob should plan");
             assert!(!plan.chunk_ranges.is_empty());
             assert!(matches!(
@@ -3943,7 +3957,7 @@ mod tests {
         );
     }
     #[tokio::test]
-    async fn existing_chunk_aware_writer_batches_persisted_chunk_checks_without_a_hash() {
+    async fn existing_chunk_aware_writer_batches_persisted_chunk_checks_from_payload_receipts() {
         let storage = StorageAdapter::new(Memory::new());
         let data = definitely_multi_chunk_blob_bytes();
         let payload = BlobPayload::from_bytes(data.clone());
@@ -3964,6 +3978,15 @@ mod tests {
                 .expect("initial blob write should commit");
         }
 
+        // Keep the immutable chunks but remove the top-level manifest so the
+        // second publication must exercise the batched presence checks.
+        let mut remove_manifest = storage.new_write_set();
+        remove_manifest.delete(BINARY_CAS_MANIFEST_SPACE, key(manifest_key(blob_hash)));
+        storage
+            .commit_write_set(remove_manifest, StorageWriteOptions::default())
+            .await
+            .expect("manifest removal should commit");
+
         crate::binary_cas::metrics::reset_binary_cas_write_metrics();
         let store = storage
             .begin_read(StorageReadOptions::default())
@@ -3976,8 +3999,7 @@ mod tests {
             &mut writes,
             &mut HashSet::new(),
             &mut HashSet::new(),
-            &data,
-            None,
+            &payload,
         )
         .await
         .expect("repeat blob write should stage");

--- a/packages/lix/src/binary_cas/types.rs
+++ b/packages/lix/src/binary_cas/types.rs
@@ -3,6 +3,7 @@ use crate::binary_cas::chunking::MEDIA_CHUNK_BYTES;
 use crate::binary_cas::codec::BinaryChunkCodec;
 use crate::binary_cas::codec::{binary_blob_hash_bytes, hash_bytes_to_hex, hash_hex_to_bytes};
 use std::ops::Range;
+use std::sync::Arc;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub(crate) struct BlobId([u8; 32]);
@@ -128,13 +129,32 @@ impl BlobSameLengthSplice {
 pub(crate) struct BlobPayload {
     bytes: crate::Blob,
     hash: Option<BlobId>,
+    chunks: Arc<[BlobChunkReceipt]>,
 }
 
 impl BlobPayload {
     pub(crate) fn from_bytes(bytes: impl Into<crate::Blob>) -> Self {
         let bytes = bytes.into();
-        let hash = (!bytes.is_empty()).then(|| BlobId::from_content(&bytes));
-        Self { bytes, hash }
+        let chunks = bytes
+            .chunks(MEDIA_CHUNK_BYTES)
+            .map(|chunk| BlobChunkReceipt {
+                hash: ChunkHash::from_content(chunk),
+                size_bytes: chunk.len() as u64,
+            })
+            .collect::<Arc<[_]>>();
+        let hash = match chunks.as_ref() {
+            [] => None,
+            [chunk] => Some(BlobId::from_single_chunk(chunk.hash)),
+            chunks => Some(BlobId::from_chunks(
+                bytes.len() as u64,
+                chunks.iter().map(|chunk| (chunk.hash, chunk.size_bytes)),
+            )),
+        };
+        Self {
+            bytes,
+            hash,
+            chunks,
+        }
     }
 
     pub(crate) fn bytes(&self) -> &[u8] {
@@ -147,6 +167,13 @@ impl BlobPayload {
 
     pub(crate) fn hash(&self) -> Option<BlobId> {
         self.hash
+    }
+
+    /// Canonical fixed-chunk identities derived from these exact immutable
+    /// bytes. Keeping the receipts inside the payload prevents CAS staging
+    /// from hashing every large-file chunk a second time.
+    pub(crate) fn chunks(&self) -> &[BlobChunkReceipt] {
+        &self.chunks
     }
 
     pub(crate) fn len(&self) -> usize {
@@ -268,4 +295,34 @@ pub(crate) struct BinaryCasChunkView<'a> {
     pub(crate) uncompressed_len: u64,
     #[musli(bytes)]
     pub(crate) payload: &'a [u8],
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn payload_carries_exact_canonical_chunk_receipts() {
+        let bytes = (0..MEDIA_CHUNK_BYTES * 2 + 17)
+            .map(|index| (index as u8).wrapping_mul(31))
+            .collect::<Vec<_>>();
+        let payload = BlobPayload::from_bytes(bytes.clone());
+
+        assert_eq!(payload.chunks().len(), 3);
+        assert_eq!(payload.chunks()[0].size_bytes, MEDIA_CHUNK_BYTES as u64);
+        assert_eq!(payload.chunks()[1].size_bytes, MEDIA_CHUNK_BYTES as u64);
+        assert_eq!(payload.chunks()[2].size_bytes, 17);
+        assert_eq!(payload.hash(), Some(BlobId::from_content(&bytes)));
+        for (receipt, chunk) in payload.chunks().iter().zip(bytes.chunks(MEDIA_CHUNK_BYTES)) {
+            assert_eq!(receipt.hash, ChunkHash::from_content(chunk));
+            assert_eq!(receipt.size_bytes, chunk.len() as u64);
+        }
+
+        let clone = payload.clone();
+        assert!(std::ptr::eq(
+            payload.chunks().as_ptr(),
+            clone.chunks().as_ptr()
+        ));
+        assert_eq!(payload.bytes(), clone.bytes());
+    }
 }


### PR DESCRIPTION
## Traceability

Hard cut from exact main `1d406823f3fd5428a63066978ed5a52ab5ceaa72`, composed without conflict onto exact shared head `23352270b4b315c508a5b7f5ceaf07e2f7431543`.

`BlobPayload` now carries the authenticated fixed-1MiB chunk receipts computed while deriving its canonical `BlobId`; CAS publication reuses those receipts rather than hashing every payload chunk a second time. Persistent formats, readers, corruption checks, and reclamation authority are unchanged. No fallback, cache, compatibility path, or dual authority.

## Qualification

- `cargo check -p lix --lib --all-features`: PASS
- Binary CAS focused tests: 45/45 PASS
- Public large-media lifecycle: RocksDB and SlateDB at 64/256 MiB PASS, including localized overwrite (one new chunk), branch shared reference, diff/merge, exact digest, and cold reopen
- Two independent local reviews: SOURCE/AUTHORITY APPROVE and PERFORMANCE APPROVE
- Crossover A/B: two 10-sample passes per binary in opposite order, exact-main and candidate binaries hash-bound
- Combined p50: Rocks initial 64 MiB -12.1%, Rocks rewrite 256 MiB -11.1%, Slate initial 64 MiB -38.0%, Slate rewrite 64 MiB -34.7%; geometric mean across all eight cells -14.6%; worst combined regression +1.9%
- Storage rows/bytes and lookup counts equivalent

Full-index patch SHA-256: `5fe2b5fbc01d773bbb44046ed1b67cb0617964e765e6bfd3c9aa07519673ff25`
Stable patch-id: `2a4e25e06d4b94ea05174d2cad8953611a5563ef`