### PR TITLE
perf(lix): co-load replay commit authorities

### DIFF
--- a/packages/lix/src/tracked_state/context.rs
+++ b/packages/lix/src/tracked_state/context.rs
@@ -3508,36 +3508,20 @@ where
         if let Some(cached) = self.point_replay_commits.get(&commit_id) {
             return Ok(cached.clone());
         }
-        let record = {
-            let commit_ids = [commit_id];
-            let mut reader = ChangelogContext::new().reader(&self.store);
-            let batch = reader
-                .load_commits(CommitLoadRequest {
-                    commit_ids: &commit_ids,
-                })
-                .await?;
-            match batch.into_iter().next().and_then(|(_, value)| value) {
-                Some(record) => record,
-                None => {
-                    return Err(LixError::new(
-                        LixError::CODE_INTERNAL_ERROR,
-                        format!(
-                            "cannot point-replay tracked_state for unknown commit '{commit_id}'"
-                        ),
-                    ));
-                }
-            }
-        };
-        let manifest = storage::load_point_replay_commit_state(&self.store, commit_id)
-            .await?
-            .ok_or_else(|| {
-                LixError::new(
-                    LixError::CODE_INTERNAL_ERROR,
-                    format!(
-                        "tracked_state commit_state_manifest is missing for commit '{commit_id}'"
-                    ),
-                )
-            })?;
+        let (record, manifest) =
+            storage::load_commit_record_and_point_replay_state(&self.store, commit_id).await?;
+        let record = record.ok_or_else(|| {
+            LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                format!("cannot point-replay tracked_state for unknown commit '{commit_id}'"),
+            )
+        })?;
+        let manifest = manifest.ok_or_else(|| {
+            LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                format!("tracked_state commit_state_manifest is missing for commit '{commit_id}'"),
+            )
+        })?;
         let rootless = manifest.replay_debt.depth > 0;
         let root_id = manifest
             .snapshot_root

--- a/packages/lix/src/tracked_state/storage.rs
+++ b/packages/lix/src/tracked_state/storage.rs
@@ -10,7 +10,10 @@ use std::ops::{Bound, Deref, Range};
 use std::sync::{Arc, Mutex, OnceLock};
 
 use crate::changelog::ChangeRecordProjection;
-use crate::changelog::{ChangelogContext, ChangelogReader, CommitId, CommitLoadRequest};
+use crate::changelog::{
+    COMMIT_SPACE, ChangelogContext, ChangelogReader, CommitId, CommitLoadRequest, CommitRecord,
+    commit_key,
+};
 use crate::common::SharedStr;
 use crate::entity_pk::EntityPk;
 use crate::storage_adapter::{
@@ -3665,8 +3668,91 @@ pub(crate) async fn load_point_replay_commit_state(
         },
     ];
     let mut values = exact_get_many(store, &requests).await?.values.into_iter();
-    let header = values.next().flatten().and_then(full_value_bytes);
-    let inventory = values.next().flatten().and_then(full_value_bytes);
+    decode_point_replay_commit_state_values(
+        commit_id,
+        values.next().flatten(),
+        values.next().flatten(),
+    )
+}
+
+/// Co-loads the semantic commit record and its physical replay authority.
+///
+/// State reconstruction needs both independent authorities for every replayed
+/// commit. Keeping them in one adapter batch preserves that separation while
+/// avoiding a second backend round trip per first-parent step.
+pub(crate) async fn load_commit_record_and_point_replay_state(
+    store: &(impl StorageAdapterRead + ?Sized),
+    commit_id: CommitId,
+) -> Result<
+    (
+        Option<CommitRecord>,
+        Option<AuthenticatedReplayCommitStateManifest>,
+    ),
+    LixError,
+> {
+    #[cfg(feature = "storage-benches")]
+    crate::storage_bench::record_crud_replay_manifest_load();
+    let commit_keys = [StorageKey(Bytes::from(commit_key(commit_id)))];
+    let header_keys = [StorageKey(Bytes::from(commit_state_manifest_key(
+        commit_id,
+    )))];
+    let inventory_keys = [StorageKey(Bytes::from(commit_mutation_inventory_key(
+        commit_id,
+    )))];
+    let requests = [
+        StorageGetManyRequest {
+            space: COMMIT_SPACE,
+            keys: &commit_keys,
+            opts: StorageGetOptions::default(),
+        },
+        StorageGetManyRequest {
+            space: TRACKED_STATE_COMMIT_STATE_MANIFEST_SPACE,
+            keys: &header_keys,
+            opts: StorageGetOptions::default(),
+        },
+        StorageGetManyRequest {
+            space: TRACKED_STATE_COMMIT_MUTATION_INVENTORY_SPACE,
+            keys: &inventory_keys,
+            opts: StorageGetOptions::default(),
+        },
+    ];
+    let mut values = exact_get_many(store, &requests).await?.values.into_iter();
+    let record = values
+        .next()
+        .flatten()
+        .and_then(full_value_bytes)
+        .map(|bytes| storage_codec::decode::<CommitRecord>("commit record", &bytes))
+        .transpose()?;
+    if let Some(record) = record.as_ref()
+        && record.commit_id != commit_id
+    {
+        return Err(LixError::new(
+            LixError::CODE_INTERNAL_ERROR,
+            format!(
+                "changelog commit key for commit '{commit_id}' contains record for '{}'",
+                record.commit_id
+            ),
+        ));
+    }
+    if record.is_none() {
+        return Ok((None, None));
+    }
+    let state = decode_point_replay_commit_state_values(
+        commit_id,
+        values.next().flatten(),
+        values.next().flatten(),
+    )?;
+    debug_assert!(values.next().is_none());
+    Ok((record, state))
+}
+
+fn decode_point_replay_commit_state_values(
+    commit_id: CommitId,
+    header: Option<StorageProjectedValue>,
+    inventory: Option<StorageProjectedValue>,
+) -> Result<Option<AuthenticatedReplayCommitStateManifest>, LixError> {
+    let header = header.and_then(full_value_bytes);
+    let inventory = inventory.and_then(full_value_bytes);
     let (header, inventory) = match (header, inventory) {
         (None, None) => return Ok(None),
         (Some(header), Some(inventory)) => (header, inventory),
@@ -13259,6 +13345,7 @@ mod tests {
 
     struct ManifestCountingRead<R> {
         inner: R,
+        get_many_calls: std::sync::Arc<AtomicUsize>,
         manifest_requests: std::sync::Arc<AtomicUsize>,
         inventory_requests: std::sync::Arc<AtomicUsize>,
         directory_requests: std::sync::Arc<AtomicUsize>,
@@ -13278,6 +13365,7 @@ mod tests {
         ) -> impl Future<
             Output = Result<crate::storage::GetManyResult, crate::storage::StorageError>,
         > + Send {
+            self.get_many_calls.fetch_add(1, Ordering::Relaxed);
             for request in requests {
                 if request.space == super::TRACKED_STATE_COMMIT_STATE_MANIFEST_SPACE {
                     self.manifest_requests.fetch_add(1, Ordering::Relaxed);
@@ -14067,6 +14155,7 @@ mod tests {
                 .begin_read(StorageReadOptions::default())
                 .await
                 .expect("routed point read should open"),
+            get_many_calls: std::sync::Arc::new(AtomicUsize::new(0)),
             manifest_requests: std::sync::Arc::clone(&manifest_requests),
             inventory_requests: std::sync::Arc::clone(&inventory_requests),
             directory_requests: std::sync::Arc::clone(&directory_requests),
@@ -16372,6 +16461,49 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn point_replay_coloads_commit_and_state_authorities_in_one_batch() {
+        let storage = StorageAdapter::new(Memory::new());
+        let commit_id = CommitId::for_test_label("co-loaded-point-replay");
+        let mutations = CommitStateMutationInventory::default();
+        let mut writes = storage.new_write_set();
+        stage_fixture_manifest(&mut writes, commit_id, &mutations)
+            .expect("commit and physical authority should stage");
+        storage
+            .commit_write_set(writes, StorageWriteOptions::default())
+            .await
+            .expect("co-load fixture should commit");
+
+        let get_many_calls = std::sync::Arc::new(AtomicUsize::new(0));
+        let manifest_requests = std::sync::Arc::new(AtomicUsize::new(0));
+        let inventory_requests = std::sync::Arc::new(AtomicUsize::new(0));
+        let read = ManifestCountingRead {
+            inner: storage
+                .begin_read(StorageReadOptions::default())
+                .await
+                .expect("co-load read should open"),
+            get_many_calls: std::sync::Arc::clone(&get_many_calls),
+            manifest_requests: std::sync::Arc::clone(&manifest_requests),
+            inventory_requests: std::sync::Arc::clone(&inventory_requests),
+            directory_requests: std::sync::Arc::new(AtomicUsize::new(0)),
+        };
+        let (record, state) = super::load_commit_record_and_point_replay_state(&read, commit_id)
+            .await
+            .expect("co-loaded authorities should decode");
+
+        assert_eq!(
+            record.expect("semantic commit should exist").commit_id,
+            commit_id
+        );
+        assert_eq!(
+            state.expect("physical state should exist").commit_id,
+            commit_id
+        );
+        assert_eq!(get_many_calls.load(Ordering::Relaxed), 1);
+        assert_eq!(manifest_requests.load(Ordering::Relaxed), 1);
+        assert_eq!(inventory_requests.load(Ordering::Relaxed), 1);
+    }
+
+    #[tokio::test]
     async fn shallow_point_replay_reads_one_immutable_physical_authority() {
         let storage = StorageAdapter::new(Memory::new());
         let commit_id = CommitId::for_test_label("one-read-shallow-point-replay");
@@ -16401,6 +16533,7 @@ mod tests {
                 .begin_read(StorageReadOptions::default())
                 .await
                 .expect("point read should open"),
+            get_many_calls: std::sync::Arc::new(AtomicUsize::new(0)),
             manifest_requests: std::sync::Arc::clone(&manifest_requests),
             inventory_requests: std::sync::Arc::clone(&inventory_requests),
             directory_requests: std::sync::Arc::clone(&directory_requests),
@@ -16471,6 +16604,7 @@ mod tests {
                 .begin_read(StorageReadOptions::default())
                 .await
                 .expect("bounded point read should open"),
+            get_many_calls: std::sync::Arc::new(AtomicUsize::new(0)),
             manifest_requests: std::sync::Arc::clone(&manifest_requests),
             inventory_requests: std::sync::Arc::clone(&inventory_requests),
             directory_requests: std::sync::Arc::clone(&directory_requests),
@@ -16531,6 +16665,7 @@ mod tests {
                 .begin_read(StorageReadOptions::default())
                 .await
                 .expect("bounded membership read should open"),
+            get_many_calls: std::sync::Arc::new(AtomicUsize::new(0)),
             manifest_requests: std::sync::Arc::clone(&manifest_requests),
             inventory_requests: std::sync::Arc::clone(&inventory_requests),
             directory_requests: std::sync::Arc::clone(&directory_requests),
@@ -17242,6 +17377,7 @@ mod tests {
                 .begin_read(StorageReadOptions::default())
                 .await
                 .expect("topology read should open"),
+            get_many_calls: std::sync::Arc::new(AtomicUsize::new(0)),
             manifest_requests: std::sync::Arc::clone(&manifest_requests),
             inventory_requests: std::sync::Arc::clone(&inventory_requests),
             directory_requests: std::sync::Arc::clone(&directory_requests),
@@ -17495,6 +17631,7 @@ mod tests {
                 .begin_read(StorageReadOptions::default())
                 .await
                 .expect("read should open"),
+            get_many_calls: std::sync::Arc::new(AtomicUsize::new(0)),
             manifest_requests: std::sync::Arc::clone(&manifest_requests),
             inventory_requests: std::sync::Arc::clone(&inventory_requests),
             directory_requests: std::sync::Arc::clone(&directory_requests),


### PR DESCRIPTION
## Cut

Co-load the immutable changelog commit record and its tracked-state manifest/inventory in one adapter batch for each point-replay step. The semantic topology record and physical replay state remain independent authorities for different facts; this removes only the sequential backend round trip.

No public API, persisted layout, compatibility shim, or authority ownership changes.

## A/B evidence

Release-mode isolated runs on ryzen-4, exact base `3f9f73f3f0d94561225bfd72e2c42eda0ab02d91`, candidate `a0b7c4d634cebd951ef404b30d097e720c44987d`:

- Deep H10K replay `get_many` calls: 40,039 → 20,038 (-50%); keys unchanged.
- SlateDB deep prepare: H100 -27.4%, H1K -14.1%, H10K -15.6%.
- RocksDB deep prepare: H100 -12.4%, H1K +7.3%, H10K -7.5%.
- RocksDB H10K allocations: bytes -15.0%, calls -20.3%.
- Production-valid 32-commit checkpoint→rootless diff: RocksDB -1.5%, SlateDB -3.5%.
- Undo/redo chain calls: 924 → 753 (-18.5%), keys unchanged; RocksDB -5.1%, SlateDB flat.

## Regression gates

- Merge-base counters and latency unchanged within 10%.
- Diff operations within about 0–3%.
- Checkpoint query: RocksDB -3.5%, SlateDB -5.5%.
- Branch: RocksDB flat, SlateDB -3.2%.
- GC: RocksDB +1.7%, SlateDB +2.8%.
- OLTP update-all: RocksDB -7.0%, SlateDB -8.1%.
- Packed history neutral under interleaved confirmation.
- No higher-priority metric regressed by 10%.

## Correctness

- Added a counting test proving commit record, manifest, and inventory are fetched in one `get_many` call while each authority remains independently decoded and validated.
- `cargo fmt --check`
- `cargo check -p lix`
- `cargo test -p lix`: 2,031 unit tests plus integrations/docs, zero failures.
- `cargo test -p lix --features all-simulations`: 2,031 unit and 818 integration variants plus docs, zero failures.