### PR TITLE
perf(lix): bound depth-limited history traversal

### DIFF
--- a/packages/lix/src/commit_graph/context.rs
+++ b/packages/lix/src/commit_graph/context.rs
@@ -14,7 +14,9 @@ use crate::changelog::{
     ChangeId, ChangeRecord, ChangelogContext, ChangelogReader, CommitId, CommitRecord,
     CommitScanRequest,
 };
-use crate::commit_graph::walker::{best_common_ancestors, walk_reachable_nodes};
+use crate::commit_graph::walker::{
+    best_common_ancestors, walk_reachable_nodes, walk_reachable_nodes_through_depth,
+};
 use crate::commit_graph::{
     CommitGraphChange, CommitGraphChangeHistoryEntry, CommitGraphChangeHistoryRequest,
     CommitGraphHistory, CommitGraphNode, CommitGraphReader, ReachableCommitGraphNode,
@@ -419,7 +421,11 @@ where
         start_commit_id: &CommitId,
         request: &CommitGraphChangeHistoryRequest,
     ) -> Result<CommitGraphHistory, LixError> {
-        let nodes = self.reachable_nodes(start_commit_id).await?;
+        let nodes = if let Some(max_depth) = request.max_depth {
+            Arc::from(walk_reachable_nodes_through_depth(self, start_commit_id, max_depth).await?)
+        } else {
+            self.reachable_nodes(start_commit_id).await?
+        };
         let member_schema_keys = request
             .schema_keys
             .iter()
@@ -737,6 +743,7 @@ mod tests {
     #[derive(Clone)]
     struct CountingMemoryRead {
         inner: MemoryRead,
+        commit_get_many_keys: Arc<AtomicUsize>,
         change_get_many_calls: Arc<AtomicUsize>,
         member_segment_get_many_calls: Arc<AtomicUsize>,
         commit_state_manifest_get_many_calls: Arc<AtomicUsize>,
@@ -747,6 +754,14 @@ mod tests {
             &self,
             requests: &[crate::storage::GetManyRequest<'_>],
         ) -> Result<GetManyResult, StorageError> {
+            self.commit_get_many_keys.fetch_add(
+                requests
+                    .iter()
+                    .filter(|request| request.space == crate::changelog::COMMIT_SPACE)
+                    .map(|request| request.keys.len())
+                    .sum::<usize>(),
+                Ordering::Relaxed,
+            );
             if requests
                 .iter()
                 .any(|request| request.space == crate::changelog::CHANGE_SPACE)
@@ -1068,6 +1083,61 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn depth_bounded_history_does_not_load_ancestry_below_its_frontier() {
+        let memory = Memory::new();
+        let storage = StorageAdapter::new(memory.clone());
+        append_changes(
+            &storage,
+            &[
+                commit_change("commit-root-change", "commit-root", &[], &[]),
+                commit_change(
+                    "commit-parent-change",
+                    "commit-parent",
+                    &[],
+                    &["commit-root"],
+                ),
+                commit_change("commit-head-change", "commit-head", &[], &["commit-parent"]),
+            ],
+        )
+        .await;
+
+        let commit_get_many_keys = Arc::new(AtomicUsize::new(0));
+        let read = memory
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("read should open");
+        let mut reader =
+            CommitGraphContext::new().reader(StorageAdapterReadScope::new(CountingMemoryRead {
+                inner: read,
+                commit_get_many_keys: Arc::clone(&commit_get_many_keys),
+                change_get_many_calls: Arc::new(AtomicUsize::new(0)),
+                member_segment_get_many_calls: Arc::new(AtomicUsize::new(0)),
+                commit_state_manifest_get_many_calls: Arc::new(AtomicUsize::new(0)),
+            }));
+        let history = reader
+            .change_history_from_commit(
+                &commit_id("commit-head"),
+                &CommitGraphChangeHistoryRequest {
+                    schema_keys: vec![super::COMMIT_SCHEMA_KEY.to_string()],
+                    max_depth: Some(0),
+                    include_tombstones: true,
+                    ..CommitGraphChangeHistoryRequest::default()
+                },
+            )
+            .await
+            .expect("bounded history should resolve");
+
+        assert_eq!(history.entries.len(), 1);
+        assert_eq!(history.reachable_nodes.len(), 1);
+        assert_eq!(history.reachable_nodes[0].depth, 0);
+        assert_eq!(
+            commit_get_many_keys.load(Ordering::Relaxed),
+            1,
+            "depth zero history must load only its anchor commit",
+        );
+    }
+
+    #[tokio::test]
     async fn change_history_reuses_canonical_changes_across_requests() {
         let memory = Memory::new();
         let storage = StorageAdapter::new(memory.clone());
@@ -1096,6 +1166,7 @@ mod tests {
         let graph = CommitGraphContext::new();
         let mut reader = graph.reader(StorageAdapterReadScope::new(CountingMemoryRead {
             inner: read,
+            commit_get_many_keys: Arc::new(AtomicUsize::new(0)),
             change_get_many_calls: Arc::clone(&change_get_many_calls),
             member_segment_get_many_calls,
             commit_state_manifest_get_many_calls: Arc::new(AtomicUsize::new(0)),
@@ -1334,6 +1405,7 @@ mod tests {
         let mut reader =
             CommitGraphContext::new().reader(StorageAdapterReadScope::new(CountingMemoryRead {
                 inner: read,
+                commit_get_many_keys: Arc::new(AtomicUsize::new(0)),
                 change_get_many_calls: Arc::new(AtomicUsize::new(0)),
                 member_segment_get_many_calls: Arc::clone(&member_segment_get_many_calls),
                 commit_state_manifest_get_many_calls: Arc::clone(

--- a/packages/lix/src/commit_graph/walker.rs
+++ b/packages/lix/src/commit_graph/walker.rs
@@ -21,7 +21,24 @@ where
     S: StorageAdapterRead,
 {
     let mut loader = NodeTraversalLoader::new(reader);
-    loader.walk(head_commit_id).await
+    loader.walk(head_commit_id, None).await
+}
+
+/// Walks only the reachable prefix whose nearest depth is at most `max_depth`.
+///
+/// History queries with an explicit depth ceiling must not validate or load
+/// ancestry they cannot return. The unbounded graph API above keeps its full
+/// reachability contract; this private variant is the bounded history route.
+pub(crate) async fn walk_reachable_nodes_through_depth<S>(
+    reader: &mut CommitGraphStoreReader<S>,
+    head_commit_id: &CommitId,
+    max_depth: u32,
+) -> Result<Vec<ReachableCommitGraphNode>, LixError>
+where
+    S: StorageAdapterRead,
+{
+    let mut loader = NodeTraversalLoader::new(reader);
+    loader.walk(head_commit_id, Some(max_depth)).await
 }
 
 /// Returns the best common ancestors shared by two commit heads.
@@ -143,11 +160,18 @@ where
     async fn walk(
         &mut self,
         head_commit_id: &CommitId,
+        max_depth: Option<u32>,
     ) -> Result<Vec<ReachableCommitGraphNode>, LixError> {
         let mut visiting = BTreeSet::new();
         let mut nearest_depths = BTreeMap::new();
-        self.walk_commit(head_commit_id, 0, &mut visiting, &mut nearest_depths)
-            .await?;
+        self.walk_commit(
+            head_commit_id,
+            0,
+            max_depth,
+            &mut visiting,
+            &mut nearest_depths,
+        )
+        .await?;
         let mut commits = Vec::with_capacity(nearest_depths.len());
         for (commit_id, depth) in nearest_depths {
             commits.push(ReachableCommitGraphNode {
@@ -167,6 +191,7 @@ where
         &mut self,
         commit_id: &CommitId,
         depth: u32,
+        max_depth: Option<u32>,
         visiting: &mut BTreeSet<CommitId>,
         nearest_depths: &mut BTreeMap<CommitId, u32>,
     ) -> Result<(), LixError> {
@@ -200,6 +225,20 @@ where
 
             let commit = self.load_node(&frame.commit_id).await?;
             nearest_depths.insert(frame.commit_id, frame.depth);
+
+            if max_depth.is_some_and(|max_depth| frame.depth >= max_depth) {
+                if let Some(parent_commit_id) = commit
+                    .parent_commit_ids
+                    .iter()
+                    .find(|parent_commit_id| visiting.contains(parent_commit_id))
+                {
+                    return Err(LixError::new(
+                        "LIX_ERROR_UNKNOWN",
+                        format!("commit_graph cycle detected at commit '{parent_commit_id}'"),
+                    ));
+                }
+                continue;
+            }
 
             visiting.insert(frame.commit_id);
             stack.push(TraversalFrame {
@@ -571,6 +610,192 @@ mod tests {
                 .collect::<Vec<_>>(),
             expected
         );
+    }
+
+    #[tokio::test]
+    async fn bounded_reachable_nodes_match_unbounded_prefix_for_a_diamond() {
+        let storage = StorageAdapter::new(Memory::new());
+        append_changes(
+            &storage,
+            &[
+                commit_change("commit-root-change", "commit-root", &[], &[]),
+                commit_change("commit-left-change", "commit-left", &[], &["commit-root"]),
+                commit_change("commit-right-change", "commit-right", &[], &["commit-root"]),
+                commit_change(
+                    "commit-head-change",
+                    "commit-head",
+                    &[],
+                    &["commit-left", "commit-right"],
+                ),
+            ],
+        )
+        .await;
+
+        let read = storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("read should open");
+        let mut reader = CommitGraphContext::new().reader(read);
+        let head = commit_id("commit-head");
+        let full = reader
+            .reachable_nodes(&head)
+            .await
+            .expect("full diamond should load");
+        for max_depth in [0, 1, 2] {
+            let bounded = super::walk_reachable_nodes_through_depth(&mut reader, &head, max_depth)
+                .await
+                .expect("bounded diamond should load");
+            let expected = full
+                .iter()
+                .filter(|reachable| reachable.depth <= max_depth)
+                .cloned()
+                .collect::<Vec<_>>();
+            assert_eq!(bounded, expected);
+        }
+    }
+
+    #[tokio::test]
+    async fn bounded_reachable_nodes_match_unbounded_prefix_for_linear_history() {
+        let storage = StorageAdapter::new(Memory::new());
+        append_changes(
+            &storage,
+            &[
+                commit_change("commit-root-change", "commit-root", &[], &[]),
+                commit_change(
+                    "commit-parent-change",
+                    "commit-parent",
+                    &[],
+                    &["commit-root"],
+                ),
+                commit_change("commit-head-change", "commit-head", &[], &["commit-parent"]),
+            ],
+        )
+        .await;
+
+        let read = storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("read should open");
+        let mut reader = CommitGraphContext::new().reader(read);
+        let head = commit_id("commit-head");
+        let full = reader
+            .reachable_nodes(&head)
+            .await
+            .expect("full linear history should load");
+        for max_depth in [0, 1, 2] {
+            let bounded = super::walk_reachable_nodes_through_depth(&mut reader, &head, max_depth)
+                .await
+                .expect("bounded linear history should load");
+            let expected = full
+                .iter()
+                .filter(|reachable| reachable.depth <= max_depth)
+                .cloned()
+                .collect::<Vec<_>>();
+            assert_eq!(bounded, expected);
+        }
+    }
+
+    #[tokio::test]
+    async fn bounded_reachable_nodes_validate_only_parents_inside_the_frontier() {
+        let storage = StorageAdapter::new(Memory::new());
+        append_changes(
+            &storage,
+            &[
+                commit_change("commit-root-change", "commit-root", &[], &[]),
+                commit_change(
+                    "commit-parent-change",
+                    "commit-parent",
+                    &[],
+                    &["commit-root"],
+                ),
+                commit_change("commit-head-change", "commit-head", &[], &["commit-parent"]),
+            ],
+        )
+        .await;
+        let root = commit_id("commit-root");
+        let mut writes = storage.new_write_set();
+        writes.delete(
+            crate::changelog::COMMIT_SPACE,
+            StorageKey(Bytes::copy_from_slice(root.as_uuid().as_bytes())),
+        );
+        storage
+            .commit_write_set(writes, StorageWriteOptions::default())
+            .await
+            .expect("old ancestry corruption should stage");
+
+        let head = commit_id("commit-head");
+        let read = storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("read should open");
+        let mut reader = CommitGraphContext::new().reader(read);
+        let bounded = super::walk_reachable_nodes_through_depth(&mut reader, &head, 1)
+            .await
+            .expect("parent below the frontier must not load");
+        assert_eq!(bounded.len(), 2);
+
+        let read = storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("read should open");
+        let mut reader = CommitGraphContext::new().reader(read);
+        let error = super::walk_reachable_nodes_through_depth(&mut reader, &head, 2)
+            .await
+            .expect_err("missing parent inside the frontier must fail");
+        assert!(error.message.contains(&root.to_string()));
+    }
+
+    #[tokio::test]
+    async fn bounded_reachable_nodes_reject_cycles_closed_at_the_frontier() {
+        let storage = StorageAdapter::new(Memory::new());
+        append_changes(
+            &storage,
+            &[commit_change("commit-root-change", "commit-root", &[], &[])],
+        )
+        .await;
+        let root = commit_id("commit-root");
+        let left = commit_id("commit-cycle-left");
+        let right = commit_id("commit-cycle-right");
+        let record = |commit_id, change_label: &str, parents| CommitRecord {
+            format_version: 3,
+            commit_id,
+            generation: 2,
+            parent_commit_ids: parents,
+            first_parent_jump_commit_id: commit_id,
+            first_parent_jump_span: 0,
+            change_id: ChangeId::for_test_label(change_label),
+            account_id: crate::ANONYMOUS_ACCOUNT_ID.to_string(),
+            created_at: ts("2026-01-01T00:00:00Z"),
+        };
+        let records = [
+            record(left, "commit-cycle-left-change", vec![right, root]),
+            record(right, "commit-cycle-right-change", vec![left, root]),
+        ];
+        let mut writes = storage.new_write_set();
+        for record in records {
+            writes.put(
+                crate::changelog::COMMIT_SPACE,
+                StorageKey(Bytes::copy_from_slice(
+                    record.commit_id.as_uuid().as_bytes(),
+                )),
+                crate::changelog::encode_commit_record(&record)
+                    .expect("cyclic record should encode"),
+            );
+        }
+        storage
+            .commit_write_set(writes, StorageWriteOptions::default())
+            .await
+            .expect("cycle should persist");
+
+        let read = storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("read should open");
+        let mut reader = CommitGraphContext::new().reader(read);
+        let error = super::walk_reachable_nodes_through_depth(&mut reader, &left, 1)
+            .await
+            .expect_err("cycle closed at the frontier must fail");
+        assert!(error.message.contains("cycle detected"));
     }
 
     #[tokio::test]


### PR DESCRIPTION
This hard cut makes depth-limited history traversal stop at the requested frontier instead of materializing and caching the full reachable graph.

## Complexity

- Before: O(H) commit reads and memory for a history of height H, even for max_depth = D.
- After: O(min(H, D + 1)) reads and memory.
- Unbounded history traversal keeps its existing cached path.
- Public API is unchanged.

## A/B evidence (H = 100,000)

| Adapter | Query | Before | After | Read calls |
|---|---:|---:|---:|---:|
| RocksDB | D=0 | 222 ms | 4.26 us | 100,001 -> 1 |
| RocksDB | D=10 | 223.3 ms | 27.3 us | 100,001 -> 11 |
| SlateDB | D=0 | 1.078 s | 2.47 us | 100,001 -> 1 |
| SlateDB | D=10 | 1.082 s | 12.1 us | 100,001 -> 11 |

Allocations at D=0 fall from 260.8 MB to 6.4 KB on RocksDB and from 2.34 GB to 5.9 KB on SlateDB. Warm SlateDB physical work falls from about 4,773 objects / 6.8 MB to zero beyond the requested commit.

## Guardrails

- Merge-base counters unchanged; wall time +3.3% RocksDB / +2.4% SlateDB.
- Recent-commit preparation counters unchanged and wall time flat.
- OLTP: RocksDB +1.5% insert / +1.1% update; SlateDB +1.2% insert / -0.4% update.
- Bounded results and ordering match filtered unbounded traversal for linear and diamond graphs.
- Corruption within the requested depth still errors; unreachable corruption beyond it is not read.
- Frontier cycles still error.
- Full test suite and all simulations pass.