### PR TITLE
perf(lix): skip redundant UTF-8 arena rescans

### DIFF
--- a/packages/lix/src/common/types.rs
+++ b/packages/lix/src/common/types.rs
@@ -102,6 +102,25 @@ impl SharedStr {
         })
     }
 
+    /// Retains bytes whose producer already proved complete-buffer UTF-8.
+    ///
+    /// # Safety
+    ///
+    /// `bytes` must contain valid UTF-8. Callers should prefer [`Self::from_utf8`]
+    /// unless validity follows directly from construction from `str` slices or
+    /// a UTF-8 serializer.
+    pub(crate) unsafe fn from_utf8_unchecked(bytes: bytes::Bytes) -> Self {
+        debug_assert!(
+            std::str::from_utf8(&bytes).is_ok(),
+            "SharedStr trusted producer emitted invalid UTF-8"
+        );
+        let len = bytes.len();
+        Self {
+            bytes,
+            range: 0..len,
+        }
+    }
+
     /// Retains one UTF-8 range of an otherwise arbitrary shared buffer.
     #[cfg(test)]
     pub(crate) fn from_utf8_range(bytes: bytes::Bytes, range: Range<usize>) -> Option<Self> {

--- a/packages/lix/src/sql2/exec/bound_public_write.rs
+++ b/packages/lix/src/sql2/exec/bound_public_write.rs
@@ -784,7 +784,11 @@ async fn try_execute_entity_update_batch(
             }
             affected_by_statement.push(affected);
         }
-        let snapshots = TransactionJson::from_certified_row_content_arena(normalized, offsets)?;
+        // SAFETY: the arena contains only JSON syntax literals and text
+        // emitted by the canonical JSON append helpers above.
+        let snapshots = unsafe {
+            TransactionJson::from_validated_certified_row_content_arena(normalized, offsets)?
+        };
         for ((row_index, candidate), snapshot) in matched_candidates.into_iter().zip(snapshots) {
             append_direct_path_value_replacement_prepared_row(
                 &mut write_rows,
@@ -1321,8 +1325,14 @@ async fn try_execute_direct_path_value_replacement_batch(
     }
     if !replacement_entity_pks.is_empty() {
         let normalized_len = normalized.len();
-        let snapshots =
-            TransactionJson::from_certified_row_content_arena(normalized, snapshot_offsets)?;
+        // SAFETY: the arena contains only JSON syntax literals and text
+        // emitted by the canonical JSON append helpers above.
+        let snapshots = unsafe {
+            TransactionJson::from_validated_certified_row_content_arena(
+                normalized,
+                snapshot_offsets,
+            )?
+        };
         let rows = CertifiedParameterReplacementBatch::new(
             replacement_entity_pks,
             snapshots,
@@ -1594,12 +1604,9 @@ fn append_direct_path_value_replacement_row<'a>(
     let candidate = candidate.into();
     let mut normalized = Vec::new();
     append_direct_path_value_replacement_json(&mut normalized, candidate, params, replacement)?;
-    let normalized = SharedStr::from_utf8(bytes::Bytes::from(normalized)).map_err(|error| {
-        LixError::new(
-            LixError::CODE_UNKNOWN,
-            format!("certified replacement row is not UTF-8: {error}"),
-        )
-    })?;
+    // SAFETY: the row is assembled from UTF-8 literals, existing row text,
+    // and canonical JSON parameter text.
+    let normalized = unsafe { SharedStr::from_utf8_unchecked(bytes::Bytes::from(normalized)) };
     append_direct_path_value_replacement_prepared_row(
         rows,
         spec,
@@ -3262,10 +3269,13 @@ pub(crate) fn prepare_path_value_replacement_row_known_live(
     let mut normalized = Vec::with_capacity(primary_key.len().saturating_add(32));
     let (start, end) =
         append_path_value_replacement_snapshot(program, primary_key, params, &mut normalized)?;
-    let snapshot =
-        TransactionJson::from_certified_row_content_arena(normalized, vec![(start, end)])?
-            .pop()
-            .expect("one certified replacement snapshot");
+    // SAFETY: `append_path_value_replacement_snapshot` appends only UTF-8
+    // literals, `str` identities, and canonical JSON parameter text.
+    let snapshot = unsafe {
+        TransactionJson::from_validated_certified_row_content_arena(normalized, vec![(start, end)])?
+    }
+    .pop()
+    .expect("one certified replacement snapshot");
     Ok(PreparedPathValueReplacementRow {
         entity_pk,
         snapshot,
@@ -4963,7 +4973,11 @@ fn certified_direct_parameter_insert_batch(
     }
     let tracked_keys_strictly_ordered =
         shared_string_primary_keys || unordered_entity_pks.is_none();
-    let snapshots = TransactionJson::from_certified_row_content_arena(normalized, offsets)?;
+    // SAFETY: each row is assembled from UTF-8 literals, validated text
+    // parameters, and canonical JSON serializer output.
+    let snapshots = unsafe {
+        TransactionJson::from_validated_certified_row_content_arena(normalized, offsets)?
+    };
     let schema_key: SharedStr = layout.schema_key.as_str().into();
     let branch_id: SharedStr = ctx.active_branch_id().into();
     let certificate = CertifiedRawWriteBatchPreparation {
@@ -5213,8 +5227,11 @@ fn certified_direct_path_value_insert_batch(
             )
         })
         .collect::<Vec<_>>();
-    let snapshots =
-        TransactionJson::from_certified_row_content_arena(normalized, snapshot_offsets)?;
+    // SAFETY: each row is assembled from UTF-8 literals, `str` paths, and
+    // serde_json output.
+    let snapshots = unsafe {
+        TransactionJson::from_validated_certified_row_content_arena(normalized, snapshot_offsets)?
+    };
     let mut rows = CertifiedParameterInsertBatch::new_with_lane(
         entity_pks,
         snapshots,
@@ -5548,7 +5565,11 @@ fn certified_entity_insert_rows<'a>(
     }
 
     let row_count = offsets.len();
-    let snapshots = TransactionJson::from_certified_row_content_arena(normalized, offsets)?;
+    // SAFETY: each row is assembled from UTF-8 literals, validated text
+    // parameters, and canonical JSON serializer output.
+    let snapshots = unsafe {
+        TransactionJson::from_validated_certified_row_content_arena(normalized, offsets)?
+    };
     let mut rows = RawWriteBatch::with_capacity(row_count);
     for ((entity_pk, snapshot), row) in entity_pks.into_iter().zip(snapshots).zip(row_parts) {
         rows.push_parts(

--- a/packages/lix/src/transaction/staging.rs
+++ b/packages/lix/src/transaction/staging.rs
@@ -91,9 +91,9 @@ pub(crate) struct ImmutableMutationJournalChunk {
     schema_key: SharedStr,
     branch_id: SharedStr,
     origin_key: Option<SharedStr>,
-    identity_arena: Bytes,
+    identity_arena: SharedStr,
     identity_offsets: Arc<[(u32, u32)]>,
-    snapshot_arena: Bytes,
+    snapshot_arena: SharedStr,
     snapshot_offsets: Arc<[(u32, u32)]>,
     large_snapshot_refs: Arc<[(u32, crate::json_store::JsonRef)]>,
     sealed_replacement_parts: Option<Arc<[crate::tracked_state::EncodedReplacementPart]>>,
@@ -152,18 +152,23 @@ impl ImmutableMutationJournalChunk {
                 "immutable mutation identity arena is misaligned",
             ));
         }
-        let identity_bytes = Bytes::from(identity_arena);
+        let identity_arena = SharedStr::from_utf8(Bytes::from(identity_arena)).map_err(|_| {
+            LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                "immutable mutation identity arena is not UTF-8",
+            )
+        })?;
         let mut previous_end = 0usize;
         let mut offsets = Vec::with_capacity(identity_offsets.len());
         let mut previous_identity = None;
         for (start, end) in identity_offsets {
-            if start != previous_end || end < start || end > identity_bytes.len() {
+            if start != previous_end || end < start || end > identity_arena.len() {
                 return Err(LixError::new(
                     LixError::CODE_INTERNAL_ERROR,
                     "immutable mutation identity offsets are invalid",
                 ));
             }
-            let value = std::str::from_utf8(&identity_bytes[start..end]).map_err(|_| {
+            let value = identity_arena.as_str().get(start..end).ok_or_else(|| {
                 LixError::new(
                     LixError::CODE_INTERNAL_ERROR,
                     "immutable mutation identity offset splits UTF-8",
@@ -192,7 +197,7 @@ impl ImmutableMutationJournalChunk {
             previous_identity = Some(value);
             previous_end = end;
         }
-        if previous_end != identity_bytes.len() {
+        if previous_end != identity_arena.len() {
             return Err(LixError::new(
                 LixError::CODE_INTERNAL_ERROR,
                 "immutable mutation identity offsets do not cover the arena",
@@ -203,7 +208,7 @@ impl ImmutableMutationJournalChunk {
             schema_key,
             branch_id,
             origin_key,
-            identity_bytes,
+            identity_arena,
             offsets.into(),
             snapshot_arena,
             snapshot_offsets,
@@ -218,7 +223,7 @@ impl ImmutableMutationJournalChunk {
         schema_key: SharedStr,
         branch_id: SharedStr,
         origin_key: Option<SharedStr>,
-        identity_arena: Bytes,
+        identity_arena: SharedStr,
         identity_offsets: Arc<[(u32, u32)]>,
         snapshot_arena: Vec<u8>,
         snapshot_offsets: Vec<(usize, usize)>,
@@ -241,13 +246,13 @@ impl ImmutableMutationJournalChunk {
                 "immutable mutation predecessor column is misaligned",
             ));
         }
-        let arena_len = snapshot_arena.len();
-        std::str::from_utf8(&snapshot_arena).map_err(|_| {
+        let snapshot_arena = SharedStr::from_utf8(Bytes::from(snapshot_arena)).map_err(|_| {
             LixError::new(
                 LixError::CODE_INTERNAL_ERROR,
                 "immutable mutation journal arena is not UTF-8",
             )
         })?;
+        let arena_len = snapshot_arena.len();
         let mut previous_end = 0usize;
         let mut offsets = Vec::with_capacity(snapshot_offsets.len());
         for (start, end) in snapshot_offsets {
@@ -257,7 +262,7 @@ impl ImmutableMutationJournalChunk {
                     "immutable mutation journal offsets are invalid",
                 ));
             }
-            std::str::from_utf8(&snapshot_arena[start..end]).map_err(|_| {
+            snapshot_arena.as_str().get(start..end).ok_or_else(|| {
                 LixError::new(
                     LixError::CODE_INTERNAL_ERROR,
                     "immutable mutation journal offset splits UTF-8",
@@ -289,7 +294,7 @@ impl ImmutableMutationJournalChunk {
             .iter()
             .enumerate()
             .filter_map(|(index, &(start, end))| {
-                let bytes = &snapshot_arena[start as usize..end as usize];
+                let bytes = &snapshot_arena.as_bytes()[start as usize..end as usize];
                 (bytes.len() > crate::json_store::JSON_INLINE_MAX_BYTES).then(|| {
                     (
                         u32::try_from(index)
@@ -306,7 +311,7 @@ impl ImmutableMutationJournalChunk {
             origin_key,
             identity_arena,
             identity_offsets,
-            snapshot_arena: Bytes::from(snapshot_arena),
+            snapshot_arena,
             snapshot_offsets: offsets.into(),
             large_snapshot_refs: large_snapshot_refs.into(),
             sealed_replacement_parts: None,
@@ -323,9 +328,9 @@ impl ImmutableMutationJournalChunk {
         self.identity_offsets
             .iter()
             .map(|&(start, end)| {
-                let value = std::str::from_utf8(&self.identity_arena[start as usize..end as usize])
-                    .expect("validated immutable mutation identity UTF-8");
-                let value = SharedStr::from_utf8_slice(self.identity_arena.clone(), value)
+                let value = self
+                    .identity_arena
+                    .slice(start as usize..end as usize)
                     .expect("validated immutable mutation identity remains in its arena");
                 EntityPk::from_validated_shared_string(value)
             })
@@ -349,13 +354,17 @@ impl ImmutableMutationJournalChunk {
 
     fn identity(&self, index: usize) -> &str {
         let (start, end) = self.identity_offsets[index];
-        std::str::from_utf8(&self.identity_arena[start as usize..end as usize])
+        self.identity_arena
+            .as_str()
+            .get(start as usize..end as usize)
             .expect("validated immutable mutation identity UTF-8")
     }
 
     pub(crate) fn snapshot(&self, index: usize) -> &str {
         let (start, end) = self.snapshot_offsets[index];
-        std::str::from_utf8(&self.snapshot_arena[start as usize..end as usize])
+        self.snapshot_arena
+            .as_str()
+            .get(start as usize..end as usize)
             .expect("validated immutable mutation journal UTF-8")
     }
 
@@ -514,7 +523,7 @@ impl ImmutableMutationJournalChunk {
         let mut rows = CertifiedParameterReplacementBatch::new(
             entity_pks.iter().cloned().collect(),
             TransactionJson::from_certified_row_content_arena(
-                self.snapshot_arena.to_vec(),
+                self.snapshot_arena.as_bytes().to_vec(),
                 offsets,
             )?,
             self.schema_key,
@@ -3716,7 +3725,10 @@ fn ordered_mutation_journal_row<'a>(
     chunk
         .identity_offsets
         .binary_search_by(|&(start, end)| {
-            std::str::from_utf8(&chunk.identity_arena[start as usize..end as usize])
+            chunk
+                .identity_arena
+                .as_str()
+                .get(start as usize..end as usize)
                 .expect("validated immutable mutation identity UTF-8")
                 .cmp(entity_pk)
         })
@@ -3730,9 +3742,11 @@ fn push_ordered_mutation_materialized(
     chunk: &ImmutableMutationJournalChunk,
     row_index: usize,
 ) -> Result<usize, LixError> {
-    let snapshot = chunk.snapshot(row_index);
-    let snapshot =
-        SharedStr::from_utf8_slice(chunk.snapshot_arena.clone(), snapshot).ok_or_else(|| {
+    let (snapshot_start, snapshot_end) = chunk.snapshot_offsets[row_index];
+    let snapshot = chunk
+        .snapshot_arena
+        .slice(snapshot_start as usize..snapshot_end as usize)
+        .ok_or_else(|| {
             LixError::new(
                 LixError::CODE_INTERNAL_ERROR,
                 "immutable mutation snapshot escaped its shared arena",
@@ -3749,9 +3763,11 @@ fn push_ordered_mutation_materialized(
             .transpose()?
             .unwrap_or_else(|| chunk.timestamp())
     };
-    let identity = chunk.identity(row_index);
-    let identity =
-        SharedStr::from_utf8_slice(chunk.identity_arena.clone(), identity).ok_or_else(|| {
+    let (identity_start, identity_end) = chunk.identity_offsets[row_index];
+    let identity = chunk
+        .identity_arena
+        .slice(identity_start as usize..identity_end as usize)
+        .ok_or_else(|| {
             LixError::new(
                 LixError::CODE_INTERNAL_ERROR,
                 "immutable mutation identity escaped its shared arena",

--- a/packages/lix/src/transaction/types.rs
+++ b/packages/lix/src/transaction/types.rs
@@ -140,6 +140,33 @@ impl TransactionJson {
         let invalid_arena = |message| LixError::new(LixError::CODE_INVALID_PARAM, message);
         let arena = SharedStr::from_utf8(Bytes::from(normalized))
             .map_err(|_| invalid_arena("certified transaction JSON arena is not UTF-8"))?;
+        Self::from_certified_row_content_shared_arena(arena, offsets)
+    }
+
+    /// Constructs certified row content from a UTF-8 arena assembled from
+    /// already-valid string fragments by an engine-owned producer.
+    ///
+    /// Offsets remain checked for full, contiguous coverage and UTF-8 scalar
+    /// boundaries. Only the redundant complete-buffer validation pass is
+    /// skipped.
+    /// # Safety
+    ///
+    /// `normalized` must contain valid UTF-8. Offset coverage and character
+    /// boundaries are still checked before any row view is constructed.
+    pub(crate) unsafe fn from_validated_certified_row_content_arena(
+        normalized: Vec<u8>,
+        offsets: Vec<(usize, usize)>,
+    ) -> Result<Vec<Self>, LixError> {
+        // SAFETY: upheld by the caller contract above.
+        let arena = unsafe { SharedStr::from_utf8_unchecked(Bytes::from(normalized)) };
+        Self::from_certified_row_content_shared_arena(arena, offsets)
+    }
+
+    fn from_certified_row_content_shared_arena(
+        arena: SharedStr,
+        offsets: Vec<(usize, usize)>,
+    ) -> Result<Vec<Self>, LixError> {
+        let invalid_arena = |message| LixError::new(LixError::CODE_INVALID_PARAM, message);
         let arena_len = u32::try_from(arena.len())
             .map_err(|_| invalid_arena("certified transaction JSON arena exceeds u32"))?;
         let mut previous_end = 0_u32;
@@ -2547,13 +2574,10 @@ pub(crate) fn canonicalize_transaction_json_batch<'a>(
             *slots[position] = Some(TransactionJson::from_canonical_batch(row));
         }
     } else {
+        // SAFETY: every uncached row was written by serde_json and every
+        // cached row came from a previously validated TransactionJson.
         let normalized =
-            SharedStr::from_utf8(Bytes::from(normalized.into_bytes())).map_err(|_| {
-                LixError::new(
-                    LixError::CODE_UNKNOWN,
-                    format!("{context} canonical JSON batch is not UTF-8"),
-                )
-            })?;
+            unsafe { SharedStr::from_utf8_unchecked(Bytes::from(normalized.into_bytes())) };
         for ((position, value), (start, end)) in positions.into_iter().zip(values).zip(offsets) {
             let normalized = normalized
                 .slice(start as usize..end as usize)
@@ -3694,8 +3718,9 @@ impl PreparedStateBatch {
             for (_, value) in &normalized {
                 arena.extend_from_slice(value.as_bytes());
             }
-            let arena = SharedStr::from_utf8(Bytes::from(arena))
-                .expect("validated canonical JSON arena remains UTF-8");
+            // SAFETY: this arena is the concatenation of validated SharedStr
+            // values and therefore remains UTF-8.
+            let arena = unsafe { SharedStr::from_utf8_unchecked(Bytes::from(arena)) };
             let mut offset = 0usize;
             for (_, value) in &mut normalized {
                 let end = offset + value.len();


### PR DESCRIPTION
Internally assembled UTF-8/JSON arenas now cross an explicit trusted boundary instead of being rescanned after their producers have already guaranteed valid UTF-8. Public and fallible byte constructors retain full validation; offsets, contiguous coverage, bounds, and scalar boundaries remain checked.

## Complexity

- Before: each validated arena handoff performed an additional O(total payload bytes) UTF-8 pass, and some retained arenas repeated per-row UTF-8 checks.
- After: trusted complete-buffer handoff is O(1); row offset and boundary validation remains O(row count).
- Public API is unchanged.

## A/B evidence

Exact-base, counterbalanced 15-process runs at 10,000 rows:

| Adapter | Metric | Before | After | Delta |
|---|---|---:|---:|---:|
| RocksDB | median | 9.784 ms | 8.506 ms | -13.1% |
| RocksDB | p95 | 10.020 ms | 8.733 ms | -12.8% |
| SlateDB | median | 9.376 ms | 8.260 ms | -11.9% |
| SlateDB | p95 | 9.881 ms | 8.426 ms | -14.7% |

CPU cycles fell 4.599B -> 4.044B (-12.1%); from_utf8 share fell 11.75% -> 1.97%. At 1,000 and 100,000 rows the same cut remains non-regressive and improves medians by 3.1-8.4%, with compression dominant at the largest size.

## Safety and guardrails

- The unchecked constructor is crate-private and unsafe, with a safety proof at every call site.
- Every call site builds bytes only from str values, canonical JSON appenders, serde_json output, or already validated SharedStr values.
- Public/fallible input paths still validate complete-buffer UTF-8.
- Physical puts, deletes, manifests, and bytes are identical.
- VCS working diff, revert, apply, and checkpoint medians/p95 remain within about 1%.
- OLAP guardrail largest median delta is +2.2% on an unchanged read-only path.
- cargo test -p lix --features all-simulations passes: 2,038 unit tests and 818 integration tests, plus remaining targets and doctests.