### PR TITLE
perf(lix): pack direct commit-delta change IDs

### DIFF
--- a/packages/engine-benchmarks/benches/tracked_state_crud/main.rs
+++ b/packages/engine-benchmarks/benches/tracked_state_crud/main.rs
@@ -909,13 +909,17 @@ fn profile_sql_session_operation(
     if std::env::var_os("LIX_TRACKED_STATE_CRUD_PROFILE_ROUTE_ACCOUNTING").is_some() {
         let accounting = lix::storage_bench::take_crud_current_state_scoped_range_accounting();
         println!(
-            "tracked_state_crud current-state scoped-range accounting: attempts={} hits={} errors={} sealed_manifest_loads={} replay_manifest_loads={} ordered_delta_fallbacks={}",
+            "tracked_state_crud current-state scoped-range accounting: attempts={} hits={} errors={} sealed_manifest_loads={} replay_manifest_loads={} ordered_delta_fallbacks={} commit_delta_direct_segments={} commit_delta_direct_rows={} commit_delta_generic_segments={} commit_delta_generic_rows={}",
             accounting.attempts,
             accounting.hits,
             accounting.errors,
             accounting.sealed_manifest_loads,
             accounting.replay_manifest_loads,
             accounting.ordered_delta_fallbacks,
+            accounting.commit_delta_direct_segments,
+            accounting.commit_delta_direct_rows,
+            accounting.commit_delta_generic_segments,
+            accounting.commit_delta_generic_rows,
         );
     }
 }

--- a/packages/lix/src/engine.rs
+++ b/packages/lix/src/engine.rs
@@ -716,6 +716,30 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn predecessor_v64_direct_change_id_leaf_protocol_is_rejected() {
+        let storage = Memory::new();
+        Engine::initialize(storage.clone())
+            .await
+            .expect("engine should initialize");
+        let storage_adapter = StorageAdapter::new(storage.clone());
+        let mut writes = storage_adapter.new_write_set();
+        writes.put(
+            crate::init::REPOSITORY_PROTOCOL_SPACE,
+            crate::init::REPOSITORY_PROTOCOL_KEY,
+            &b"myers-first-parent-jump.v64"[..],
+        );
+        storage_adapter
+            .commit_write_set(writes, StorageWriteOptions::default())
+            .await
+            .expect("V64 protocol marker should commit");
+
+        let Err(error) = Engine::new(storage).await else {
+            panic!("V64 packed-history repositories must fail closed");
+        };
+        assert_eq!(error.code, "LIX_ERROR_UNSUPPORTED_STORAGE_FORMAT");
+    }
+
+    #[tokio::test]
     async fn predecessor_v15_protocol_is_rejected() {
         let storage = Memory::new();
         Engine::initialize(storage.clone())

--- a/packages/lix/src/init.rs
+++ b/packages/lix/src/init.rs
@@ -42,13 +42,13 @@ const REGISTERED_SCHEMA_KEY: &str = "lix_registered_schema";
 
 /// Repository-wide compatibility gate for physical storage protocols.
 ///
-/// V64 embeds the Myers first-parent jump in each immutable commit record.
-/// The hard cut rejects repositories whose commits predate that topology
-/// authority instead of maintaining a second derived index.
+/// V65 removes per-row ChangeId copies from directly addressable immutable
+/// mutation leaves. The hard cut rejects repositories whose packed history
+/// predates that physical authority instead of retaining a second decoder.
 pub(crate) const REPOSITORY_PROTOCOL_SPACE: StorageSpace =
     StorageSpace::mutable(StorageSpaceId(0x0004_0011), "repository.protocol.v1");
 pub(crate) const REPOSITORY_PROTOCOL_KEY: &[u8] = b"current";
-const REPOSITORY_PROTOCOL_VALUE: &[u8] = b"myers-first-parent-jump.v64";
+const REPOSITORY_PROTOCOL_VALUE: &[u8] = b"direct-change-id-leaf.v65";
 
 /// Raw status of the repository protocol marker. Engine opening consults this
 /// before it touches any tracked-head space, whose physical IDs deliberately

--- a/packages/lix/src/storage_bench.rs
+++ b/packages/lix/src/storage_bench.rs
@@ -63,6 +63,10 @@ static CRUD_CURRENT_STATE_SCOPED_RANGE_ERRORS: AtomicU64 = AtomicU64::new(0);
 static CRUD_SEALED_MANIFEST_LOADS: AtomicU64 = AtomicU64::new(0);
 static CRUD_REPLAY_MANIFEST_LOADS: AtomicU64 = AtomicU64::new(0);
 static CRUD_ORDERED_DELTA_FALLBACKS: AtomicU64 = AtomicU64::new(0);
+static COMMIT_DELTA_DIRECT_SEGMENTS: AtomicU64 = AtomicU64::new(0);
+static COMMIT_DELTA_DIRECT_ROWS: AtomicU64 = AtomicU64::new(0);
+static COMMIT_DELTA_GENERIC_SEGMENTS: AtomicU64 = AtomicU64::new(0);
+static COMMIT_DELTA_GENERIC_ROWS: AtomicU64 = AtomicU64::new(0);
 static MEDIA_UPLOAD_MANIFEST_LEAF_ROWS: AtomicU64 = AtomicU64::new(0);
 static MEDIA_UPLOAD_SUMMARIZED_CHUNK_ROWS: AtomicU64 = AtomicU64::new(0);
 static MEDIA_UPLOAD_CHUNK_PAYLOAD_HASH_BYTES: AtomicU64 = AtomicU64::new(0);
@@ -399,6 +403,20 @@ pub struct CrudCurrentStateScopedRangeAccounting {
     pub sealed_manifest_loads: u64,
     pub replay_manifest_loads: u64,
     pub ordered_delta_fallbacks: u64,
+    pub commit_delta_direct_segments: u64,
+    pub commit_delta_direct_rows: u64,
+    pub commit_delta_generic_segments: u64,
+    pub commit_delta_generic_rows: u64,
+}
+
+pub(crate) fn record_commit_delta_leaf_layout(rows: usize, direct: bool) {
+    let (segments, encoded_rows) = if direct {
+        (&COMMIT_DELTA_DIRECT_SEGMENTS, &COMMIT_DELTA_DIRECT_ROWS)
+    } else {
+        (&COMMIT_DELTA_GENERIC_SEGMENTS, &COMMIT_DELTA_GENERIC_ROWS)
+    };
+    segments.fetch_add(1, Ordering::Relaxed);
+    encoded_rows.fetch_add(rows as u64, Ordering::Relaxed);
 }
 
 pub(crate) fn record_crud_current_state_scoped_range_attempt() {
@@ -433,6 +451,10 @@ pub fn take_crud_current_state_scoped_range_accounting() -> CrudCurrentStateScop
         sealed_manifest_loads: CRUD_SEALED_MANIFEST_LOADS.swap(0, Ordering::Relaxed),
         replay_manifest_loads: CRUD_REPLAY_MANIFEST_LOADS.swap(0, Ordering::Relaxed),
         ordered_delta_fallbacks: CRUD_ORDERED_DELTA_FALLBACKS.swap(0, Ordering::Relaxed),
+        commit_delta_direct_segments: COMMIT_DELTA_DIRECT_SEGMENTS.swap(0, Ordering::Relaxed),
+        commit_delta_direct_rows: COMMIT_DELTA_DIRECT_ROWS.swap(0, Ordering::Relaxed),
+        commit_delta_generic_segments: COMMIT_DELTA_GENERIC_SEGMENTS.swap(0, Ordering::Relaxed),
+        commit_delta_generic_rows: COMMIT_DELTA_GENERIC_ROWS.swap(0, Ordering::Relaxed),
     }
 }
 

--- a/packages/lix/src/tracked_state/bench_support.rs
+++ b/packages/lix/src/tracked_state/bench_support.rs
@@ -32,12 +32,28 @@ fn stage_bench_commit_deltas(
     writes: &mut StorageWriteSet,
     deltas: &[TrackedStateCommitDeltaRef<'_>],
 ) -> Result<Vec<super::storage::CommitDeltaChangeLocator>, crate::LixError> {
-    let staged = super::storage::stage_commit_deltas_for_commit_state(writes, deltas)?;
+    let (mutations, locators) = if packed_history_addressable_ids() {
+        let staged = super::storage::stage_ordered_addressable_commit_deltas(
+            writes,
+            deltas.iter().copied().map(Ok),
+            false,
+            false,
+        )?
+        .ok_or_else(|| {
+            crate::LixError::new(
+                crate::LixError::CODE_INTERNAL_ERROR,
+                "addressable packed-history fixture is not strictly ordered",
+            )
+        })?;
+        (staged.mutation_inventory().clone(), Vec::new())
+    } else {
+        let staged = super::storage::stage_commit_deltas_for_commit_state(writes, deltas)?;
+        (staged.mutation_inventory().clone(), staged.locators)
+    };
     let commit_id = deltas
         .first()
         .map(|delta| delta.delta.commit_id)
         .unwrap_or_default();
-    let mutations = staged.mutation_inventory().clone();
     super::storage::stage_commit_state_manifest(
         writes,
         &CommitStateManifest {
@@ -54,7 +70,7 @@ fn stage_bench_commit_deltas(
             snapshot_root: None,
         },
     )?;
-    Ok(staged.locators)
+    Ok(locators)
 }
 
 #[derive(Clone, Debug)]
@@ -1069,11 +1085,11 @@ impl PackedHistoryDelta {
             .expect("packed-history change index should not overflow");
         let entity_pk = match options.shape {
             BenchPackedHistoryShape::UniqueInserts => {
-                format!("packed-history-entity-{commit_index}-{row_index}")
+                format!("packed-history-entity-{commit_index:012}-{row_index:012}")
             }
             BenchPackedHistoryShape::RepeatedUpdates | BenchPackedHistoryShape::DeleteReinsert => {
                 format!(
-                    "packed-history-entity-{}",
+                    "packed-history-entity-{:012}",
                     change_index % options.live_entities
                 )
             }
@@ -1082,7 +1098,7 @@ impl PackedHistoryDelta {
             && (change_index / options.live_entities) % 2 == 1;
         Self {
             change_id: packed_history_change_id(commit_index, row_index),
-            commit_id: CommitId::new(packed_history_uuid(commit_index, 0, 0x43)),
+            commit_id: packed_history_commit_id(commit_index),
             entity_pk: EntityPk::single(entity_pk),
             schema_key: "packed_history".to_string(),
             deleted,
@@ -1135,7 +1151,28 @@ impl PackedHistoryDelta {
 }
 
 fn packed_history_change_id(commit_index: usize, row_index: usize) -> ChangeId {
+    if packed_history_addressable_ids() {
+        return super::storage::change_id_from_packed_address(
+            packed_history_commit_id(commit_index),
+            u32::try_from(row_index)
+                .expect("packed-history row index fits u32")
+                .checked_add(1)
+                .expect("packed-history packed address fits u32"),
+        );
+    }
     ChangeId::new(packed_history_uuid(commit_index, row_index, 0x68))
+}
+
+fn packed_history_commit_id(commit_index: usize) -> CommitId {
+    let mut bytes = *packed_history_uuid(commit_index, 0, 0x43).as_bytes();
+    if packed_history_addressable_ids() {
+        bytes[12..].copy_from_slice(&0_u32.to_be_bytes());
+    }
+    CommitId::new(uuid::Uuid::from_bytes(bytes))
+}
+
+fn packed_history_addressable_ids() -> bool {
+    std::env::var("LIX_PACKED_HISTORY_ID_SHAPE").is_ok_and(|shape| shape == "addressable")
 }
 
 fn packed_history_uuid(commit_index: usize, ordinal: usize, discriminator: u8) -> uuid::Uuid {

--- a/packages/lix/src/tracked_state/codec.rs
+++ b/packages/lix/src/tracked_state/codec.rs
@@ -231,6 +231,14 @@ impl DecodedInternalNode {
 
 const NODE_KIND_LEAF_V4: u8 = 5;
 const NODE_KIND_INTERNAL_V4: u8 = 6;
+/// Packed direct-address leaves store the one shared commit id plus the first
+/// packed change ordinal. Every row's exact change id is reconstructed from
+/// that authenticated sequence instead of repeating another 16-byte UUID.
+const NODE_KIND_DIRECT_LEAF_V1: u8 = 7;
+
+pub(crate) fn leaf_uses_direct_address_layout(encoded: &[u8]) -> bool {
+    encoded.first() == Some(&NODE_KIND_DIRECT_LEAF_V1)
+}
 
 #[derive(Debug, Clone, Copy)]
 struct MutationSpan {
@@ -1464,6 +1472,9 @@ pub(crate) fn encode_leaf_node_refs(entries: &[EncodedLeafEntryRef<'_>]) -> Vec<
             );
         }
     }
+    if let Some((commit_id, first_packed)) = direct_leaf_sequence(entries) {
+        return encode_direct_leaf_v1(entries, commit_id, first_packed);
+    }
     let commit_dictionary = repeated_dictionary::<16>(entries, VALUE_COMMIT_ID_START);
     let tail_dictionary = repeated_tail_dictionary(entries);
 
@@ -1493,6 +1504,71 @@ pub(crate) fn encode_leaf_node_refs(entries: &[EncodedLeafEntryRef<'_>]) -> Vec<
         if commit_ref == 0 {
             out.extend_from_slice(&entry.value[VALUE_COMMIT_ID_START..VALUE_COMMIT_ID_END]);
         }
+        let tail = &entry.value[VALUE_STATE_TAIL_START..];
+        let tail_ref = slice_dictionary_ref(&tail_dictionary, tail);
+        write_varint(&mut out, tail_ref);
+        if tail_ref == 0 {
+            out.extend_from_slice(tail);
+        }
+        previous_key = entry.key;
+    }
+    #[cfg(debug_assertions)]
+    verify_leaf_round_trip(&out, entries);
+    out
+}
+
+fn direct_leaf_sequence(entries: &[EncodedLeafEntryRef<'_>]) -> Option<([u8; 16], u32)> {
+    let first = entries.first()?;
+    let commit_id: [u8; 16] = first.value[VALUE_COMMIT_ID_START..VALUE_COMMIT_ID_END]
+        .try_into()
+        .expect("validated tracked-state value has a commit id");
+    let first_change: [u8; 16] = first.value[..VALUE_CHANGE_ID_END]
+        .try_into()
+        .expect("validated tracked-state value has a change id");
+    if first_change[..12] != commit_id[..12] {
+        return None;
+    }
+    let first_packed = u32::from_be_bytes(
+        first_change[12..]
+            .try_into()
+            .expect("change-id suffix is a packed u32"),
+    );
+    for (ordinal, entry) in entries.iter().enumerate() {
+        if entry.value[VALUE_COMMIT_ID_START..VALUE_COMMIT_ID_END] != commit_id
+            || entry.value[..12] != commit_id[..12]
+            || u32::from_be_bytes(
+                entry.value[12..VALUE_CHANGE_ID_END]
+                    .try_into()
+                    .expect("change-id suffix is a packed u32"),
+            ) != first_packed.checked_add(u32::try_from(ordinal).ok()?)?
+        {
+            return None;
+        }
+    }
+    Some((commit_id, first_packed))
+}
+
+fn encode_direct_leaf_v1(
+    entries: &[EncodedLeafEntryRef<'_>],
+    commit_id: [u8; 16],
+    first_packed: u32,
+) -> Vec<u8> {
+    let tail_dictionary = repeated_tail_dictionary(entries);
+    let mut out = Vec::with_capacity(32 + entries.len() * 8);
+    out.push(NODE_KIND_DIRECT_LEAF_V1);
+    write_varint(&mut out, entries.len() as u64);
+    out.extend_from_slice(&commit_id);
+    out.extend_from_slice(&first_packed.to_be_bytes());
+    write_varint(&mut out, tail_dictionary.len() as u64);
+    for tail in &tail_dictionary {
+        out.extend_from_slice(tail);
+    }
+    let mut previous_key: &[u8] = &[];
+    for entry in entries {
+        let shared = shared_prefix_len(previous_key, entry.key);
+        write_varint(&mut out, shared as u64);
+        write_varint(&mut out, (entry.key.len() - shared) as u64);
+        out.extend_from_slice(&entry.key[shared..]);
         let tail = &entry.value[VALUE_STATE_TAIL_START..];
         let tail_ref = slice_dictionary_ref(&tail_dictionary, tail);
         write_varint(&mut out, tail_ref);
@@ -1720,6 +1796,151 @@ fn decode_leaf_v4(body: &[u8]) -> Result<DecodedLeafNodeRef, LixError> {
         return Err(LixError::new(
             "LIX_ERROR_UNKNOWN",
             "tracked-state leaf node has trailing bytes",
+        ));
+    }
+    Ok(DecodedLeafNodeRef {
+        arena: Bytes::from(arena),
+        entries,
+    })
+}
+
+fn decode_direct_leaf_v1(body: &[u8]) -> Result<DecodedLeafNodeRef, LixError> {
+    fn usize_from(value: u64, what: &str) -> Result<usize, LixError> {
+        usize::try_from(value).map_err(|_| {
+            LixError::new(
+                "LIX_ERROR_UNKNOWN",
+                format!("tracked-state direct leaf node {what} does not fit in usize"),
+            )
+        })
+    }
+    fn slice<'b>(body: &'b [u8], offset: &mut usize, len: usize) -> Result<&'b [u8], LixError> {
+        let end = offset.checked_add(len).ok_or_else(|| {
+            LixError::new(
+                "LIX_ERROR_UNKNOWN",
+                "tracked-state direct leaf node length overflow",
+            )
+        })?;
+        let bytes = body.get(*offset..end).ok_or_else(|| {
+            LixError::new(
+                "LIX_ERROR_UNKNOWN",
+                "tracked-state direct leaf node is truncated",
+            )
+        })?;
+        *offset = end;
+        Ok(bytes)
+    }
+
+    let mut offset = 0usize;
+    let entry_count = usize_from(
+        read_varint(body, &mut offset, "tracked-state direct leaf node")?,
+        "entry count",
+    )?;
+    if entry_count == 0 {
+        return Err(LixError::new(
+            "LIX_ERROR_UNKNOWN",
+            "tracked-state direct leaf node has no entries",
+        ));
+    }
+    let commit_id: [u8; 16] = slice(body, &mut offset, 16)?
+        .try_into()
+        .expect("fixed commit-id slice");
+    let first_packed = u32::from_be_bytes(
+        slice(body, &mut offset, 4)?
+            .try_into()
+            .expect("fixed packed-address slice"),
+    );
+    let tail_dict_len = usize_from(
+        read_varint(body, &mut offset, "tracked-state direct leaf node")?,
+        "tail dictionary length",
+    )?;
+    let mut tail_dictionary = Vec::with_capacity(tail_dict_len.min(body.len()));
+    for _ in 0..tail_dict_len {
+        tail_dictionary.push(read_value_tail(
+            body,
+            &mut offset,
+            "tracked-state direct leaf node",
+        )?);
+    }
+    let omitted_value_bytes = entry_count.min(body.len()).saturating_mul(VALUE_MAX_BYTES);
+    let mut arena = Vec::with_capacity(body.len().saturating_add(omitted_value_bytes));
+    let mut entries = Vec::with_capacity(entry_count.min(body.len()));
+    let mut previous_key_start = 0usize;
+    let mut previous_key_end = 0usize;
+    for ordinal in 0..entry_count {
+        let shared = usize_from(
+            read_varint(body, &mut offset, "tracked-state direct leaf node")?,
+            "shared key length",
+        )?;
+        let suffix_len = usize_from(
+            read_varint(body, &mut offset, "tracked-state direct leaf node")?,
+            "key suffix length",
+        )?;
+        let previous_key_len = previous_key_end - previous_key_start;
+        if shared > previous_key_len {
+            return Err(LixError::new(
+                "LIX_ERROR_UNKNOWN",
+                "tracked-state direct leaf node shares more key bytes than the previous key holds",
+            ));
+        }
+        let key_start = arena.len();
+        arena.extend_from_within(previous_key_start..previous_key_start + shared);
+        arena.extend_from_slice(slice(body, &mut offset, suffix_len)?);
+        let key_end = arena.len();
+        if !entries.is_empty()
+            && arena[previous_key_start..previous_key_end] >= arena[key_start..key_end]
+        {
+            return Err(LixError::new(
+                "LIX_ERROR_UNKNOWN",
+                "tracked-state direct leaf node keys are not strictly ordered",
+            ));
+        }
+        let tail_ref = usize_from(
+            read_varint(body, &mut offset, "tracked-state direct leaf node")?,
+            "tail dictionary ref",
+        )?;
+        let tail = if tail_ref == 0 {
+            read_value_tail(body, &mut offset, "tracked-state direct leaf node")?
+        } else {
+            if tail_ref > tail_dict_len {
+                return Err(LixError::new(
+                    "LIX_ERROR_UNKNOWN",
+                    "tracked-state direct leaf node tail dictionary ref is out of bounds",
+                ));
+            }
+            tail_dictionary[tail_ref - 1]
+        };
+        let packed = first_packed
+            .checked_add(u32::try_from(ordinal).map_err(|_| {
+                LixError::new(
+                    "LIX_ERROR_UNKNOWN",
+                    "tracked-state direct leaf node ordinal exceeds u32",
+                )
+            })?)
+            .ok_or_else(|| {
+                LixError::new(
+                    "LIX_ERROR_UNKNOWN",
+                    "tracked-state direct leaf node address overflows u32",
+                )
+            })?;
+        let value_start = arena.len();
+        arena.extend_from_slice(&commit_id[..12]);
+        arena.extend_from_slice(&packed.to_be_bytes());
+        arena.extend_from_slice(&commit_id);
+        arena.extend_from_slice(tail);
+        let value_end = arena.len();
+        entries.push(LeafEntrySpan {
+            key_start,
+            key_end,
+            value_start,
+            value_end,
+        });
+        previous_key_start = key_start;
+        previous_key_end = key_end;
+    }
+    if offset != body.len() {
+        return Err(LixError::new(
+            "LIX_ERROR_UNKNOWN",
+            "tracked-state direct leaf node has trailing bytes",
         ));
     }
     Ok(DecodedLeafNodeRef {
@@ -1961,6 +2182,7 @@ pub(crate) fn decode_node_ref(bytes: &[u8]) -> Result<DecodedNodeRef, LixError> 
     match kind {
         NODE_KIND_LEAF_V4 => Ok(DecodedNodeRef::Leaf(decode_leaf_v4(body)?)),
         NODE_KIND_INTERNAL_V4 => Ok(DecodedNodeRef::Internal(decode_internal_v4(body)?)),
+        NODE_KIND_DIRECT_LEAF_V1 => Ok(DecodedNodeRef::Leaf(decode_direct_leaf_v1(body)?)),
         other => Err(LixError::new(
             "LIX_ERROR_UNKNOWN",
             format!("tracked-state tree node has unknown kind byte {other}"),
@@ -2058,6 +2280,84 @@ mod tests {
             (vec![0x80, 0x01], raw_value(4, 5, 6)),
             (vec![0xff, 0xff, 0xff], raw_value(7, 8, 9)),
         ]);
+    }
+
+    #[test]
+    fn direct_leaf_reconstructs_exact_change_ids_without_per_row_uuid_bytes() {
+        let mut commit_id = [0x42; 16];
+        commit_id[12..].copy_from_slice(&0_u32.to_be_bytes());
+        let entries = (0_u32..128)
+            .map(|ordinal| {
+                let mut change_id = commit_id;
+                change_id[12..].copy_from_slice(&(513 + ordinal).to_be_bytes());
+                let mut value = Vec::new();
+                value.extend_from_slice(&change_id);
+                value.extend_from_slice(&commit_id);
+                write_value_tail(&mut value, false, 7, 7);
+                (format!("key-{ordinal:04}").into_bytes(), value)
+            })
+            .collect::<Vec<_>>();
+        let refs = entries
+            .iter()
+            .map(|(key, value)| EncodedLeafEntryRef { key, value })
+            .collect::<Vec<_>>();
+        let encoded = encode_leaf_refs_for_tests(&refs);
+        assert_eq!(encoded[0], NODE_KIND_DIRECT_LEAF_V1);
+        assert!(encoded.len() < entries.len() * 8);
+        leaf_entries_round_trip(&entries);
+    }
+
+    #[test]
+    fn direct_leaf_falls_back_for_mixed_or_nonsequential_change_ids() {
+        let mut commit_id = [0x42; 16];
+        commit_id[12..].copy_from_slice(&0_u32.to_be_bytes());
+        let mut entries = (0_u32..3)
+            .map(|ordinal| {
+                let mut change_id = commit_id;
+                change_id[12..].copy_from_slice(&(17 + ordinal).to_be_bytes());
+                let mut value = Vec::new();
+                value.extend_from_slice(&change_id);
+                value.extend_from_slice(&commit_id);
+                write_value_tail(&mut value, false, 9, 9);
+                (format!("key-{ordinal}").into_bytes(), value)
+            })
+            .collect::<Vec<_>>();
+        entries[1].1[0] ^= 0x80;
+        let refs = entries
+            .iter()
+            .map(|(key, value)| EncodedLeafEntryRef { key, value })
+            .collect::<Vec<_>>();
+
+        let encoded = encode_leaf_refs_for_tests(&refs);
+        assert_eq!(encoded[0], NODE_KIND_LEAF_V4);
+        leaf_entries_round_trip(&entries);
+    }
+
+    #[test]
+    fn direct_leaf_rejects_a_reconstructed_address_overflow() {
+        let mut commit_id = [0x42; 16];
+        commit_id[12..].copy_from_slice(&0_u32.to_be_bytes());
+        let entries = (0_u32..2)
+            .map(|ordinal| {
+                let mut change_id = commit_id;
+                change_id[12..].copy_from_slice(&(17 + ordinal).to_be_bytes());
+                let mut value = Vec::new();
+                value.extend_from_slice(&change_id);
+                value.extend_from_slice(&commit_id);
+                write_value_tail(&mut value, false, 9, 9);
+                (format!("key-{ordinal}").into_bytes(), value)
+            })
+            .collect::<Vec<_>>();
+        let refs = entries
+            .iter()
+            .map(|(key, value)| EncodedLeafEntryRef { key, value })
+            .collect::<Vec<_>>();
+        let mut encoded = encode_leaf_refs_for_tests(&refs);
+        // kind + one-byte entry count + shared commit id
+        encoded[18..22].copy_from_slice(&u32::MAX.to_be_bytes());
+
+        let error = decode_node_ref(&encoded).expect_err("second address must overflow");
+        assert!(error.message.contains("address overflows u32"));
     }
 
     #[test]

--- a/packages/lix/src/tracked_state/storage.rs
+++ b/packages/lix/src/tracked_state/storage.rs
@@ -100,8 +100,11 @@ const ORDERED_COMMIT_DELTA_SEGMENT_TARGET_BYTES: usize = 64 * 1024;
 // payload-less certified-reference encoding is intentionally rejected. The
 // version also binds ordered mutation parts to the canonical 512-row geometry;
 // LXCD14 is intentionally rejected rather than read through a compatibility
+// decoder. Version 16 permits direct-address leaves to reconstruct the exact
+// per-row ChangeId from one shared commit id and the first packed ordinal.
+// LXCD15 is deliberately rejected rather than read through a compatibility
 // decoder.
-const COMMIT_DELTA_FORMAT_MAGIC: &[u8] = b"LXCD15";
+const COMMIT_DELTA_FORMAT_MAGIC: &[u8] = b"LXCD16";
 // Version 4 makes lossless columnar mutation parts a first-class, exclusive
 // commit payload. LXCS3 repositories are intentionally rejected: there is no
 // compatibility decoder beneath the new authority.
@@ -11174,6 +11177,11 @@ fn encode_commit_delta_segment_layout(
 ) -> Result<Vec<u8>, CommitDeltaSegmentEncodeError> {
     debug_assert_eq!(entries.len(), payloads.len());
     let leaf = encode_leaf_node_refs(entries);
+    #[cfg(feature = "storage-benches")]
+    crate::storage_bench::record_commit_delta_leaf_layout(
+        entries.len(),
+        crate::tracked_state::codec::leaf_uses_direct_address_layout(&leaf),
+    );
     let authored_inline = payloads.iter().all(|payload| {
         payload.authored
             && matches!(payload.snapshot, crate::json_store::JsonSlotRef::Inline(_))

--- a/packages/lix/src/tracked_state/types.rs
+++ b/packages/lix/src/tracked_state/types.rs
@@ -363,7 +363,7 @@ pub(crate) struct CommitStateTouchedScopeFilter {
 ///
 /// The fields intentionally mirror the existing commit-delta directory. This
 /// lets the hard-cut manifest become authoritative without changing the
-/// bounded LXCD15 segment and payload-sidecar codec in the same step.
+/// bounded LXCD16 segment and payload-sidecar codec in the same step.
 #[derive(Debug, Clone, Default, PartialEq, Eq, musli::Encode, musli::Decode)]
 #[musli(packed)]
 pub(crate) struct CommitStateMutationInventory {


### PR DESCRIPTION
Direct-address commit-delta leaves now store one commit UUID plus the first packed ordinal and reconstruct every exact 128-bit ChangeId. The generic V4 leaf remains only for mixed, non-sequential, or caller-defined IDs.

This is an intentional hard cut to LXCD16 / repository protocol v65. No compatibility decoder or migration shim is retained. Public API behavior is unchanged.

## Physical layout

For an eligible N-row leaf:

- Before: 16 ChangeId bytes per row plus commit dictionary references.
- After: one 16-byte commit UUID + one 4-byte first ordinal for the leaf.
- ChangeId reconstruction remains O(1) per row.
- The layout removes approximately 16*N physical bytes while preserving exact IDs and sorted lookup geometry.

## A/B evidence

Public SQL 10K insert, three counterbalanced pairs:

- Staged value bytes: about 1,267,618 -> 1,097,675 (-13.4%) on both adapters.
- Eligibility: 20/20 segments and 10,000/10,000 rows; no fallback.
- RocksDB latency: 41.57 -> 41.09 ms (-1.2%).
- SlateDB latency: 40.74 -> 39.93 ms (-2.0%).

Storage-native history:

| Scale | RocksDB physical bytes | SlateDB physical bytes |
|---:|---:|---:|
| 100K changes | -46.6% | -47.2% |
| 1M changes | -47.3% | -47.2% |

At 1M changes, RocksDB scan/exact improve 7.2% / 14.4%; SlateDB scan/exact improve 2.0% / 4.9%. Wide insert/update/delete commits use about 64-66% fewer bytes. Singleton commits remain 3.5-4% smaller.

## Coverage and guardrails

- Public insert, point update/delete, and bulk-delete commit-delta rows were 100% eligible.
- Bulk update already uses a separate columnar replacement layout and is unchanged.
- Mixed/caller-defined IDs fall back without semantic change.
- Exact ID round-trip, mixed fallback, and overflow corruption tests pass.
- Update/delete/reinsert, history, diff, and both storage adapters were exercised.
- Worst observed scan delta was +5.3% on a manifest-dominated singleton shape; broad and large scans were flat or faster.
- cargo test -p lix --features all-simulations passes completely.
- After clean cherry-pick onto PR #1287, fmt and the focused all-simulations codec tests pass.