### PR TITLE
test(lix): guard trusted UTF-8 arena boundaries

### DIFF
--- a/packages/lix/src/transaction/staging.rs
+++ b/packages/lix/src/transaction/staging.rs
@@ -4430,6 +4430,44 @@ mod tests {
     }
 
     #[test]
+    fn immutable_journal_rejects_invalid_utf8_and_split_offsets() {
+        assert!(
+            ImmutableMutationJournalChunk::try_new_single_string_identities(
+                SchemaPlanId::for_test(0),
+                "schema".into(),
+                "branch".into(),
+                None,
+                vec![0xff],
+                vec![(0, 1)],
+                b"{}".to_vec(),
+                vec![(0, 2)],
+                None,
+                LixTimestamp::expect_parse("timestamp", "2026-01-01T00:00:00Z"),
+            )
+            .is_err(),
+            "the journal must reject an invalid identity arena"
+        );
+
+        let snapshots = "é".as_bytes().to_vec();
+        assert!(
+            ImmutableMutationJournalChunk::try_new_single_string_identities(
+                SchemaPlanId::for_test(0),
+                "schema".into(),
+                "branch".into(),
+                None,
+                b"ab".to_vec(),
+                vec![(0, 1), (1, 2)],
+                snapshots,
+                vec![(0, 1), (1, 2)],
+                None,
+                LixTimestamp::expect_parse("timestamp", "2026-01-01T00:00:00Z"),
+            )
+            .is_err(),
+            "the journal must reject snapshot offsets inside a UTF-8 scalar"
+        );
+    }
+
+    #[test]
     fn immutable_journal_large_snapshot_refs_support_more_than_u16_rows() {
         const ROW_COUNT: usize = 65_537;
         let mut identities = Vec::with_capacity(ROW_COUNT * 6);

--- a/packages/lix/src/transaction/types.rs
+++ b/packages/lix/src/transaction/types.rs
@@ -5566,6 +5566,37 @@ mod tests {
     }
 
     #[test]
+    fn certified_transaction_arena_preserves_utf8_and_offset_validation() {
+        assert!(
+            TransactionJson::from_certified_row_content_arena(vec![0xff], vec![(0, 1)]).is_err(),
+            "the fallible constructor must reject invalid producer bytes"
+        );
+
+        let normalized = "é".as_bytes().to_vec();
+        let split_offsets = vec![(0, 1), (1, normalized.len())];
+        assert!(
+            TransactionJson::from_certified_row_content_arena(
+                normalized.clone(),
+                split_offsets.clone(),
+            )
+            .is_err(),
+            "the fallible constructor must reject offsets inside a UTF-8 scalar"
+        );
+        // SAFETY: the complete arena is valid UTF-8. This intentionally gives
+        // the trusted constructor bad offsets to verify it still checks them.
+        assert!(
+            unsafe {
+                TransactionJson::from_validated_certified_row_content_arena(
+                    normalized,
+                    split_offsets,
+                )
+            }
+            .is_err(),
+            "the trusted constructor must retain UTF-8 boundary checks"
+        );
+    }
+
+    #[test]
     fn certified_row_content_remains_decodable_until_validation_release() {
         let normalized = br#"{"id":"entity-1"}"#.to_vec();
         let normalized_len = normalized.len();


### PR DESCRIPTION
Follow-up coverage for PR #1287.

- Proves the public/fallible certified-arena constructor still rejects invalid UTF-8.
- Proves both fallible and trusted paths reject offsets that split a UTF-8 scalar.
- Proves immutable mutation journals reject invalid identity bytes and invalid snapshot boundaries.

The two focused tests pass after clean cherry-pick onto the latest codex-2-optimizations base. This changes tests only.