### PR TITLE
perf(lix): stream flat-delta bases into result buffers

### DIFF
--- a/packages/lix/src/binary_cas/kv.rs
+++ b/packages/lix/src/binary_cas/kv.rs
@@ -1273,6 +1273,40 @@ pub(crate) async fn load_bytes_many(
         .iter()
         .map(|metadata| (metadata.hash, metadata.clone()))
         .collect::<HashMap<_, _>>();
+    // A batch can request many deltas against one physical base. Authenticate
+    // and decode that base once, then let every result borrow the same bounded
+    // chunk descriptors. Preserve failures in the map so output traversal
+    // below still selects errors in first-request order.
+    let mut decoded_delta_bases =
+        HashMap::<BlobId, Result<Vec<DecodedBlobChunk<'_>>, LixError>>::new();
+    for entry in metadata.iter().flatten() {
+        let BlobLayout::Delta { base_blob_hash, .. } = &entry.layout else {
+            continue;
+        };
+        if decoded_delta_bases.contains_key(base_blob_hash) {
+            continue;
+        }
+        let decoded = physical_metadata_by_hash
+            .get(base_blob_hash)
+            .ok_or_else(|| {
+                LixError::new(
+                    "LIX_ERROR_UNKNOWN",
+                    format!(
+                        "binary CAS delta '{}' is missing base '{}'",
+                        entry.hash.to_hex(),
+                        base_blob_hash.to_hex()
+                    ),
+                )
+            })
+            .and_then(|base_metadata| {
+                decode_delta_base_chunks(
+                    base_metadata,
+                    &chunk_rows_by_hash,
+                    chunked_manifests_by_hash.get(base_blob_hash),
+                )
+            });
+        decoded_delta_bases.insert(*base_blob_hash, decoded);
+    }
     let mut full_bytes_by_hash = HashMap::<BlobId, Vec<u8>>::new();
     for metadata in physical_metadata {
         let hash = metadata.hash;
@@ -1305,9 +1339,8 @@ pub(crate) async fn load_bytes_many(
                         segments,
                         ..
                     } => {
-                        let base_metadata = physical_metadata_by_hash
-                            .get(&base_blob_hash)
-                            .ok_or_else(|| {
+                        let decoded_base =
+                            decoded_delta_bases.get(&base_blob_hash).ok_or_else(|| {
                                 LixError::new(
                                     "LIX_ERROR_UNKNOWN",
                                     format!(
@@ -1317,13 +1350,16 @@ pub(crate) async fn load_bytes_many(
                                     ),
                                 )
                             })?;
+                        let base_chunks = decoded_base.as_ref().map_err(Clone::clone)?;
+                        let base_metadata = physical_metadata_by_hash
+                            .get(&base_blob_hash)
+                            .expect("decoded delta base has physical metadata");
                         apply_flat_delta_from_chunks(
                             metadata.hash,
                             metadata.size_bytes,
                             base_metadata,
                             &segments,
-                            &chunk_rows_by_hash,
-                            chunked_manifests_by_hash.get(&base_blob_hash),
+                            base_chunks,
                         )
                     }
                     _ if movable_full_hashes.contains(&metadata.hash) => {
@@ -1549,12 +1585,9 @@ fn apply_flat_delta_from_chunks(
     size_bytes: u64,
     base_metadata: &BlobMetadata,
     segments: &[BlobDeltaSegment],
-    chunk_rows_by_hash: &HashMap<ChunkHash, Option<Bytes>>,
-    chunked_manifest: Option<&Vec<KvBlobManifestChunk>>,
+    base_chunks: &[DecodedBlobChunk<'_>],
 ) -> Result<Vec<u8>, LixError> {
     let expected_size = persisted_size_to_usize(size_bytes, "binary CAS delta")?;
-    let base_chunks =
-        decode_delta_base_chunks(base_metadata, chunk_rows_by_hash, chunked_manifest)?;
     let mut out = Vec::with_capacity(expected_size);
     for segment in segments {
         match segment {
@@ -1565,7 +1598,7 @@ fn apply_flat_delta_from_chunks(
                     base_metadata,
                     *offset,
                     *length,
-                    &base_chunks,
+                    base_chunks,
                 )?;
             }
             BlobDeltaSegment::Insert { bytes } => out.extend_from_slice(bytes),
@@ -4406,6 +4439,80 @@ mod tests {
                 Some(third),
             ],
         );
+    }
+
+    #[tokio::test]
+    async fn batched_flat_delta_corruption_errors_follow_request_order() {
+        let storage = StorageAdapter::new(Memory::new());
+        let mut deltas = Vec::new();
+        let mut base_chunk_hashes = Vec::new();
+        let mut writes = storage.new_write_set();
+        for (expected, tampered) in [
+            (&b"first-base"[..], &b"FIRST-base"[..]),
+            (&b"second-base"[..], &b"SECOND-base"[..]),
+        ] {
+            let chunk_hash = ChunkHash::from_content(expected);
+            let base_hash = BlobId::from_single_chunk(chunk_hash);
+            let mut result = expected.to_vec();
+            result.push(b'!');
+            let delta_hash = BlobId::from_content(&result);
+            stage_manifest(
+                &mut writes,
+                base_hash,
+                &BinaryCasManifest::SingleChunk {
+                    size_bytes: expected.len() as u64,
+                    chunk_hash: chunk_hash.into_bytes(),
+                },
+            );
+            stage_chunk(
+                &mut writes,
+                chunk_hash,
+                BinaryChunkCodec::Raw,
+                tampered.len() as u64,
+                tampered,
+            );
+            stage_manifest(
+                &mut writes,
+                delta_hash,
+                &BinaryCasManifest::Delta {
+                    size_bytes: result.len() as u64,
+                    base_blob_hash: base_hash.into_bytes(),
+                    base_size_bytes: expected.len() as u64,
+                    base_layout: StorageBinaryCasDeltaBaseLayout::SingleChunk {
+                        chunk_hash: chunk_hash.into_bytes(),
+                    },
+                    segments: vec![
+                        StorageBinaryCasDeltaSegment::Copy {
+                            offset: 0,
+                            length: expected.len() as u64,
+                        },
+                        StorageBinaryCasDeltaSegment::Insert { bytes: vec![b'!'] },
+                    ],
+                },
+            );
+            deltas.push(delta_hash);
+            base_chunk_hashes.push(chunk_hash);
+        }
+        storage
+            .commit_write_set(writes, StorageWriteOptions::default())
+            .await
+            .expect("corrupt delta fixtures should commit");
+
+        for order in [[0usize, 1usize], [1usize, 0usize]] {
+            let read = storage
+                .begin_read(StorageReadOptions::default())
+                .await
+                .expect("corrupt delta read should open");
+            let error = load_bytes_many(&read, &[deltas[order[0]], deltas[order[1]]])
+                .await
+                .expect_err("corrupt delta base must fail closed");
+            assert!(
+                error
+                    .message
+                    .contains(&base_chunk_hashes[order[0]].to_hex()),
+                "first requested corrupt delta must select its base error: {error:?}",
+            );
+        }
     }
 
     #[tokio::test]

--- a/packages/lix/src/binary_cas/kv.rs
+++ b/packages/lix/src/binary_cas/kv.rs
@@ -1256,39 +1256,43 @@ pub(crate) async fn load_bytes_many(
         .zip(chunk_rows)
         .collect::<HashMap<_, _>>();
 
-    let mut full_bytes_by_hash = HashMap::<BlobId, Vec<u8>>::new();
-    for metadata in physical_metadata {
-        let hash = metadata.hash;
-        let bytes = assemble_blob_bytes(
-            metadata,
-            &chunk_rows_by_hash,
-            chunked_manifests_by_hash.get(&hash),
-        )?;
-        full_bytes_by_hash.insert(hash, bytes);
-    }
-
-    // Most reads request each full blob exactly once. Transfer that assembled
-    // buffer into its output slot instead of cloning every payload after it
-    // has already been authenticated and assembled. Repeated output slots
-    // still need independent `Vec` ownership, and delta bases must remain
-    // available until every dependent result has been reconstructed.
+    // Only materialize physical blobs that were requested directly. Delta
+    // copy segments can be reconstructed straight from their authenticated
+    // chunks into the final output buffer, avoiding a second full-size owner
+    // for the base while the delta result is assembled.
     let mut direct_output_counts = HashMap::<BlobId, usize>::new();
-    let mut delta_base_hashes = HashSet::<BlobId>::new();
     for entry in metadata.iter().flatten() {
         match &entry.layout {
-            BlobLayout::Delta { base_blob_hash, .. } => {
-                delta_base_hashes.insert(*base_blob_hash);
-            }
+            BlobLayout::Delta { .. } => {}
             _ => {
                 *direct_output_counts.entry(entry.hash).or_default() += 1;
             }
         }
     }
+    let physical_metadata_by_hash = physical_metadata
+        .iter()
+        .map(|metadata| (metadata.hash, metadata.clone()))
+        .collect::<HashMap<_, _>>();
+    let mut full_bytes_by_hash = HashMap::<BlobId, Vec<u8>>::new();
+    for metadata in physical_metadata {
+        let hash = metadata.hash;
+        if direct_output_counts.contains_key(&hash) {
+            let bytes = assemble_blob_bytes(
+                metadata,
+                &chunk_rows_by_hash,
+                chunked_manifests_by_hash.get(&hash),
+            )?;
+            full_bytes_by_hash.insert(hash, bytes);
+        }
+    }
+
+    // Most reads request each full blob exactly once. Transfer that assembled
+    // buffer into its output slot instead of cloning every payload after it
+    // has already been authenticated and assembled. Repeated output slots
+    // still need independent `Vec` ownership.
     let movable_full_hashes = direct_output_counts
         .into_iter()
-        .filter_map(|(hash, count)| {
-            (count == 1 && !delta_base_hashes.contains(&hash)).then_some(hash)
-        })
+        .filter_map(|(hash, count)| (count == 1).then_some(hash))
         .collect::<HashSet<_>>();
 
     let entries = metadata
@@ -1300,13 +1304,28 @@ pub(crate) async fn load_bytes_many(
                         base_blob_hash,
                         segments,
                         ..
-                    } => apply_flat_delta(
-                        metadata.hash,
-                        metadata.size_bytes,
-                        base_blob_hash,
-                        &segments,
-                        &full_bytes_by_hash,
-                    ),
+                    } => {
+                        let base_metadata = physical_metadata_by_hash
+                            .get(&base_blob_hash)
+                            .ok_or_else(|| {
+                                LixError::new(
+                                    "LIX_ERROR_UNKNOWN",
+                                    format!(
+                                        "binary CAS delta '{}' is missing base '{}'",
+                                        metadata.hash.to_hex(),
+                                        base_blob_hash.to_hex()
+                                    ),
+                                )
+                            })?;
+                        apply_flat_delta_from_chunks(
+                            metadata.hash,
+                            metadata.size_bytes,
+                            base_metadata,
+                            &segments,
+                            &chunk_rows_by_hash,
+                            chunked_manifests_by_hash.get(&base_blob_hash),
+                        )
+                    }
                     _ if movable_full_hashes.contains(&metadata.hash) => {
                         full_bytes_by_hash.remove(&metadata.hash).ok_or_else(|| {
                             LixError::new(
@@ -1525,49 +1544,29 @@ async fn load_blob_range(
     })
 }
 
-fn apply_flat_delta(
+fn apply_flat_delta_from_chunks(
     blob_hash: BlobId,
     size_bytes: u64,
-    base_blob_hash: BlobId,
+    base_metadata: &BlobMetadata,
     segments: &[BlobDeltaSegment],
-    full_bytes_by_hash: &HashMap<BlobId, Vec<u8>>,
+    chunk_rows_by_hash: &HashMap<ChunkHash, Option<Bytes>>,
+    chunked_manifest: Option<&Vec<KvBlobManifestChunk>>,
 ) -> Result<Vec<u8>, LixError> {
     let expected_size = persisted_size_to_usize(size_bytes, "binary CAS delta")?;
-    let Some(base) = full_bytes_by_hash.get(&base_blob_hash) else {
-        return Err(LixError::new(
-            "LIX_ERROR_UNKNOWN",
-            format!(
-                "binary CAS delta '{}' is missing base '{}'",
-                blob_hash.to_hex(),
-                base_blob_hash.to_hex()
-            ),
-        ));
-    };
+    let base_chunks =
+        decode_delta_base_chunks(base_metadata, chunk_rows_by_hash, chunked_manifest)?;
     let mut out = Vec::with_capacity(expected_size);
     for segment in segments {
         match segment {
             BlobDeltaSegment::Copy { offset, length } => {
-                let start = persisted_size_to_usize(*offset, "binary CAS delta copy offset")?;
-                let length = persisted_size_to_usize(*length, "binary CAS delta copy length")?;
-                let Some(end) = start.checked_add(length) else {
-                    return Err(LixError::new(
-                        "LIX_ERROR_UNKNOWN",
-                        format!(
-                            "binary CAS delta '{}' copy range overflowed",
-                            blob_hash.to_hex()
-                        ),
-                    ));
-                };
-                let Some(slice) = base.get(start..end) else {
-                    return Err(LixError::new(
-                        "LIX_ERROR_UNKNOWN",
-                        format!(
-                            "binary CAS delta '{}' has invalid copy ranges",
-                            blob_hash.to_hex()
-                        ),
-                    ));
-                };
-                out.extend_from_slice(slice);
+                append_blob_range_from_chunks(
+                    &mut out,
+                    blob_hash,
+                    base_metadata,
+                    *offset,
+                    *length,
+                    &base_chunks,
+                )?;
             }
             BlobDeltaSegment::Insert { bytes } => out.extend_from_slice(bytes),
         }
@@ -1602,6 +1601,159 @@ fn apply_flat_delta(
         ));
     }
     Ok(out)
+}
+
+struct DecodedBlobChunk<'a> {
+    range: Range<usize>,
+    bytes: Cow<'a, [u8]>,
+}
+
+fn decode_delta_base_chunks<'a>(
+    base_metadata: &BlobMetadata,
+    chunk_rows_by_hash: &'a HashMap<ChunkHash, Option<Bytes>>,
+    chunked_manifest: Option<&Vec<KvBlobManifestChunk>>,
+) -> Result<Vec<DecodedBlobChunk<'a>>, LixError> {
+    let base_size = persisted_size_to_usize(base_metadata.size_bytes, "binary CAS delta base")?;
+    let chunks = match &base_metadata.layout {
+        BlobLayout::SingleChunk { chunk_hash }
+            if BlobId::from_single_chunk(*chunk_hash) == base_metadata.hash =>
+        {
+            vec![DecodedBlobChunk {
+                range: 0..base_size,
+                bytes: decode_chunk_from_map(
+                    chunk_rows_by_hash,
+                    base_metadata.hash,
+                    *chunk_hash,
+                    base_size,
+                )?,
+            }]
+        }
+        BlobLayout::Chunked { chunk_count } => {
+            let Some(manifest_chunks) = chunked_manifest else {
+                return Err(LixError::new(
+                    "LIX_ERROR_UNKNOWN",
+                    format!(
+                        "binary CAS blob '{}' missing chunk manifest",
+                        base_metadata.hash.to_hex()
+                    ),
+                ));
+            };
+            if manifest_chunks.len() != *chunk_count as usize
+                || BlobId::from_chunks(
+                    base_metadata.size_bytes,
+                    manifest_chunks
+                        .iter()
+                        .map(|chunk| (ChunkHash::from_bytes(chunk.chunk_hash), chunk.chunk_size)),
+                ) != base_metadata.hash
+            {
+                return Err(LixError::new(
+                    "LIX_ERROR_UNKNOWN",
+                    format!(
+                        "binary CAS delta base '{}' failed manifest content-address verification",
+                        base_metadata.hash.to_hex()
+                    ),
+                ));
+            }
+            let mut chunks = Vec::with_capacity(manifest_chunks.len());
+            let mut chunk_start = 0usize;
+            for manifest_chunk in manifest_chunks {
+                let chunk_size =
+                    persisted_size_to_usize(manifest_chunk.chunk_size, "binary CAS chunk")?;
+                let chunk_end = chunk_start.checked_add(chunk_size).ok_or_else(|| {
+                    LixError::new("LIX_ERROR_UNKNOWN", "binary CAS chunk offsets overflowed")
+                })?;
+                let chunk_hash = ChunkHash::from_bytes(manifest_chunk.chunk_hash);
+                chunks.push(DecodedBlobChunk {
+                    range: chunk_start..chunk_end,
+                    bytes: decode_chunk_from_map(
+                        chunk_rows_by_hash,
+                        base_metadata.hash,
+                        chunk_hash,
+                        chunk_size,
+                    )?,
+                });
+                chunk_start = chunk_end;
+            }
+            if chunk_start != base_size {
+                return Err(LixError::new(
+                    "LIX_ERROR_UNKNOWN",
+                    format!(
+                        "binary CAS delta base '{}' has invalid chunk sizes",
+                        base_metadata.hash.to_hex()
+                    ),
+                ));
+            }
+            chunks
+        }
+        BlobLayout::Empty | BlobLayout::SingleChunk { .. } | BlobLayout::Delta { .. } => {
+            return Err(LixError::new(
+                "LIX_ERROR_UNKNOWN",
+                format!(
+                    "binary CAS delta base '{}' failed manifest content-address verification",
+                    base_metadata.hash.to_hex()
+                ),
+            ));
+        }
+    };
+    Ok(chunks)
+}
+
+fn append_blob_range_from_chunks(
+    out: &mut Vec<u8>,
+    delta_hash: BlobId,
+    base_metadata: &BlobMetadata,
+    offset: u64,
+    length: u64,
+    base_chunks: &[DecodedBlobChunk<'_>],
+) -> Result<(), LixError> {
+    let start = persisted_size_to_usize(offset, "binary CAS delta copy offset")?;
+    let length = persisted_size_to_usize(length, "binary CAS delta copy length")?;
+    let Some(end) = start.checked_add(length) else {
+        return Err(LixError::new(
+            "LIX_ERROR_UNKNOWN",
+            format!(
+                "binary CAS delta '{}' copy range overflowed",
+                delta_hash.to_hex()
+            ),
+        ));
+    };
+    let base_size = persisted_size_to_usize(base_metadata.size_bytes, "binary CAS delta base")?;
+    if end > base_size {
+        return Err(LixError::new(
+            "LIX_ERROR_UNKNOWN",
+            format!(
+                "binary CAS delta '{}' has invalid copy ranges",
+                delta_hash.to_hex()
+            ),
+        ));
+    }
+    if start == end {
+        return Ok(());
+    }
+
+    let output_start = out.len();
+    for chunk in base_chunks {
+        let selected_start = start.max(chunk.range.start);
+        let selected_end = end.min(chunk.range.end);
+        if selected_start < selected_end {
+            out.extend_from_slice(
+                &chunk.bytes[selected_start - chunk.range.start..selected_end - chunk.range.start],
+            );
+        }
+        if chunk.range.end >= end {
+            break;
+        }
+    }
+    if out.len().saturating_sub(output_start) != length {
+        return Err(LixError::new(
+            "LIX_ERROR_UNKNOWN",
+            format!(
+                "binary CAS delta '{}' has invalid copy ranges",
+                delta_hash.to_hex()
+            ),
+        ));
+    }
+    Ok(())
 }
 
 async fn load_chunk_rows(
@@ -4233,11 +4385,26 @@ mod tests {
         assert_eq!(base_blob_hash, full_base_hash);
         assert_eq!(segments.len(), 5);
         assert_eq!(
-            load_bytes_many(&store, &[first_hash, second_hash, third_hash, third_hash])
-                .await
-                .expect("flat deltas should load")
-                .into_vec(),
-            vec![Some(first), Some(second), Some(third.clone()), Some(third),],
+            load_bytes_many(
+                &store,
+                &[
+                    full_base_hash,
+                    first_hash,
+                    second_hash,
+                    third_hash,
+                    third_hash,
+                ],
+            )
+            .await
+            .expect("flat deltas should load")
+            .into_vec(),
+            vec![
+                Some(before),
+                Some(first),
+                Some(second),
+                Some(third.clone()),
+                Some(third),
+            ],
         );
     }
 


### PR DESCRIPTION
Flat-delta reads now decode and authenticate each unique physical base once per request batch, then copy requested ranges directly into final result buffers. They no longer materialize a full base Vec solely to copy it into another full result Vec.

No public API or storage format changes.

## Complexity and ownership

For a base/result of N bytes:

- Before: O(N) base assembly + O(N) delta assembly, with two full-size owners and an extra full copy.
- After: authenticated chunks are decoded once per unique base and copied directly into final outputs; the redundant O(N) base owner/pass is removed.
- Multiple deltas sharing one base reuse the same request-local decoded chunk descriptors.
- Final BlobId verification, manifest identity checks, chunk authentication, request-ordered errors, and exact result bytes remain.

## A/B evidence

RocksDB:

| Size | Allocated | Peak live | Cold | Warm p50 |
|---:|---:|---:|---:|---:|
| 1 MiB | -31.4% | -33.0% | -5.3% | -5.5% |
| 16 MiB | -33.3% | -33.3% | 24.658 -> 23.339 ms (-5.3%) | 16.575 -> 7.875 ms (-52.5%) |
| 64 MiB | -33.3% | -33.3% | 182.444 -> 111.418 ms (-38.9%) | 198.467 -> 153.524 ms (-22.6%) |

SlateDB:

| Size | Allocated | Peak live | Cold | Warm p50 |
|---:|---:|---:|---:|---:|
| 1 MiB | -33.1% | -33.2% | 1.391 -> 0.880 ms (-36.7%) | 1.627 -> 0.415 ms (-74.5%) |
| 16 MiB | -33.2% | -33.3% | -35.5% | 8.532 -> 7.891 ms (-7.5%) |
| 64 MiB | -33.3% | -33.3% | 138.849 -> 93.580 ms (-32.6%) | 133.697 -> 90.735 ms (-32.1%) |

Logical/physical storage rows and bytes are identical A/B. Instrumentation confirms exactly N redundant base-copy bytes removed.

## Correctness and guardrails

- Direct base + three same-base deltas + duplicate output batch returns exact bytes.
- Reversed corrupt-base requests preserve deterministic first-request error selection.
- Final content-address verification and manifest/chunk authentication remain.
- 34 focused binary-CAS tests pass.
- cargo test -p lix passes: 2,045 library and 445 main integration tests, plus all remaining targets/doctests.
- cargo test -p lix --features all-simulations passes: 2,045 library and 818 main integration tests, plus remaining targets/doctests.
- RocksDB adapter package: 3 unit + 15 integration tests pass.
- SlateDB adapter package: 65 unit + 11 integration tests pass.
- Public cross-adapter CRUD guard is running as a final non-blocking confirmation.