### PR TITLE
perf(storage): consolidate five revision singletons into one space

### DIFF
--- a/.changenotes/consolidate-revision-singletons.md
+++ b/.changenotes/consolidate-revision-singletons.md
@@ -1,0 +1,13 @@
+---
+type: patch
+---
+
+Consolidated the five internal revision/epoch singletons into one storage space.
+
+Lix tracked "something changed here" with five separate singleton keys, each in
+its own storage space scattered across the physical keyspace. They now share one
+space and five adjacent keys, so a repository holds four fewer storage spaces,
+transaction open reads its catalog revision and tracked-mutation fence with a
+single batched lookup, and a commit writes its revisions into one contiguous
+region. Repositories written by earlier versions are not readable by this
+version.

--- a/packages/lix/src/binary_cas/kv.rs
+++ b/packages/lix/src/binary_cas/kv.rs
@@ -15,7 +15,10 @@ use crate::binary_cas::{
 };
 #[cfg(test)]
 use crate::storage_adapter::StoragePrefix;
-use crate::storage_adapter::{PointReadPlan, StorageAdapterRead, StorageSpace, StorageWriteSet};
+use crate::storage_adapter::{
+    PointReadPlan, REVISION_KEY_BINARY_CAS_EPOCH, REVISION_SPACE, StorageAdapterRead, StorageSpace,
+    StorageWriteSet, load_revision, revision_key,
+};
 use crate::storage_adapter::{
     StorageBeginScanOptions, StorageCoreProjection, StorageGetOptions, StorageKey, StorageKeyRange,
     StoragePrecondition, StorageProjectedValue, StorageSpaceId, StorageValue,
@@ -53,34 +56,12 @@ pub(crate) const BINARY_CAS_CHUNK_PRESENCE_SPACE: StorageSpace = StorageSpace::m
     StorageSpaceId(0x0005_0004),
     BINARY_CAS_CHUNK_PRESENCE_NAMESPACE,
 );
-const BINARY_CAS_MUTATION_EPOCH_SPACE: StorageSpace =
-    StorageSpace::mutable(StorageSpaceId(0x0005_0005), "binary_cas.mutation_epoch.v1");
-const BINARY_CAS_MUTATION_EPOCH_KEY: &[u8] = b"epoch";
-
 pub(in crate::binary_cas) async fn load_mutation_epoch(
     store: &(impl StorageAdapterRead + ?Sized),
 ) -> Result<(u64, Option<Bytes>), LixError> {
-    let key = StorageKey(Bytes::from_static(BINARY_CAS_MUTATION_EPOCH_KEY));
-    let value = PointReadPlan::new(BINARY_CAS_MUTATION_EPOCH_SPACE, std::slice::from_ref(&key))
-        .materialize(
-            store,
-            StorageGetOptions {
-                projection: StorageCoreProjection::FullValue,
-            },
-        )
-        .await?
-        .value
-        .into_iter()
-        .next()
-        .flatten();
+    let value = load_revision(store, REVISION_KEY_BINARY_CAS_EPOCH).await?;
     let Some(value) = value else {
         return Ok((0, None));
-    };
-    let StorageProjectedValue::FullValue(value) = value else {
-        return Err(LixError::new(
-            LixError::CODE_STORAGE_ERROR,
-            "binary CAS mutation epoch omitted its value",
-        ));
     };
     if value.len() != 8 {
         return Err(LixError::new(
@@ -106,9 +87,9 @@ pub(in crate::binary_cas) fn stage_mutation_epoch(
             "binary CAS mutation epoch exhausted",
         )
     })?;
-    let key = StorageKey(Bytes::from_static(BINARY_CAS_MUTATION_EPOCH_KEY));
+    let key = revision_key(REVISION_KEY_BINARY_CAS_EPOCH);
     writes.put(
-        BINARY_CAS_MUTATION_EPOCH_SPACE,
+        REVISION_SPACE,
         key.clone(),
         StorageValue {
             bytes: Bytes::copy_from_slice(&next.to_be_bytes()),
@@ -116,12 +97,12 @@ pub(in crate::binary_cas) fn stage_mutation_epoch(
     );
     preconditions.push(match token {
         Some(expected) => StoragePrecondition::KeyValueEquals {
-            space: BINARY_CAS_MUTATION_EPOCH_SPACE,
+            space: REVISION_SPACE,
             key,
             expected,
         },
         None => StoragePrecondition::KeyAbsent {
-            space: BINARY_CAS_MUTATION_EPOCH_SPACE,
+            space: REVISION_SPACE,
             key,
         },
     });
@@ -2687,8 +2668,8 @@ mod tests {
         let storage = StorageAdapter::new(Memory::new());
         let mut corrupt = storage.new_write_set();
         corrupt.put(
-            BINARY_CAS_MUTATION_EPOCH_SPACE,
-            StorageKey(Bytes::from_static(BINARY_CAS_MUTATION_EPOCH_KEY)),
+            REVISION_SPACE,
+            revision_key(REVISION_KEY_BINARY_CAS_EPOCH),
             StorageValue {
                 bytes: Bytes::from_static(b"bad"),
             },

--- a/packages/lix/src/catalog/mod.rs
+++ b/packages/lix/src/catalog/mod.rs
@@ -4,7 +4,7 @@ mod schema;
 mod snapshot;
 
 pub(crate) use context::CatalogContext;
-pub(crate) use revision::{load_catalog_revision, stage_catalog_revision};
+pub(crate) use revision::{CatalogRevision, load_catalog_revision, stage_catalog_revision};
 pub(crate) use schema::{
     ForeignKeyPlan, SchemaCatalogFact, SchemaCatalogKey, SchemaPlan, SchemaPlanFingerprint,
     SchemaPlanId,

--- a/packages/lix/src/catalog/revision.rs
+++ b/packages/lix/src/catalog/revision.rs
@@ -2,13 +2,9 @@ use bytes::Bytes;
 
 use crate::LixError;
 use crate::storage_adapter::{
-    PointReadPlan, StorageAdapterRead, StorageCoreProjection, StorageGetOptions, StorageKey,
-    StorageProjectedValue, StorageSpace, StorageSpaceId, StorageValue, StorageWriteSet,
+    REVISION_KEY_CATALOG, REVISION_SPACE, StorageAdapterRead, StorageValue, StorageWriteSet,
+    load_revision, revision_key,
 };
-
-const CATALOG_REVISION_SPACE: StorageSpace =
-    StorageSpace::mutable(StorageSpaceId(0x0007_0003), "catalog.schema_revision");
-const CATALOG_REVISION_KEY: &[u8] = b"global";
 
 /// Storage-snapshot identity for the visible registered-schema catalog.
 ///
@@ -18,8 +14,12 @@ const CATALOG_REVISION_KEY: &[u8] = b"global";
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub(crate) struct CatalogRevision(Bytes);
 
-#[cfg(test)]
 impl CatalogRevision {
+    pub(crate) fn from_storage_bytes(bytes: Bytes) -> Self {
+        Self(bytes)
+    }
+
+    #[cfg(test)]
     pub(crate) fn for_test(value: &'static [u8]) -> Self {
         Self(Bytes::from_static(value))
     }
@@ -28,32 +28,15 @@ impl CatalogRevision {
 pub(crate) async fn load_catalog_revision(
     store: &(impl StorageAdapterRead + ?Sized),
 ) -> Result<Option<CatalogRevision>, LixError> {
-    let result = PointReadPlan::new(
-        CATALOG_REVISION_SPACE,
-        &[StorageKey(Bytes::from_static(CATALOG_REVISION_KEY))],
-    )
-    .materialize(
-        store,
-        StorageGetOptions {
-            projection: StorageCoreProjection::FullValue,
-        },
-    )
-    .await?;
-    Ok(result
-        .value
-        .into_iter()
-        .next()
-        .flatten()
-        .and_then(|value| match value {
-            StorageProjectedValue::FullValue(bytes) => Some(CatalogRevision(bytes)),
-            StorageProjectedValue::KeyOnly => None,
-        }))
+    Ok(load_revision(store, REVISION_KEY_CATALOG)
+        .await?
+        .map(CatalogRevision::from_storage_bytes))
 }
 
 pub(crate) fn stage_catalog_revision(writes: &mut StorageWriteSet) {
     writes.put(
-        CATALOG_REVISION_SPACE,
-        StorageKey(Bytes::from_static(CATALOG_REVISION_KEY)),
+        REVISION_SPACE,
+        revision_key(REVISION_KEY_CATALOG),
         StorageValue {
             bytes: Bytes::copy_from_slice(uuid::Uuid::now_v7().as_bytes()),
         },

--- a/packages/lix/src/filesystem/path_index.rs
+++ b/packages/lix/src/filesystem/path_index.rs
@@ -20,8 +20,8 @@ use crate::live_state::{
     MaterializedLiveStateRow,
 };
 use crate::storage_adapter::{
-    PointReadPlan, StorageAdapterRead, StorageCoreProjection, StorageGetOptions, StorageKey,
-    StorageProjectedValue, StorageSpace, StorageSpaceId, StorageValue, StorageWriteSet,
+    REVISION_KEY_FILESYSTEM_PATH, REVISION_SPACE, StorageAdapterRead, StorageValue,
+    StorageWriteSet, load_revision, revision_key,
 };
 
 use super::descriptor_path::{DirectoryPathRecord, derive_directory_paths};
@@ -31,11 +31,6 @@ use super::keys::{
 use super::persistent_map::PersistentMap;
 use super::planner::{FilesystemBlobRefKey, FilesystemDescriptorKey};
 
-const FILESYSTEM_PATH_REVISION_SPACE: StorageSpace = StorageSpace::mutable(
-    StorageSpaceId(0x0007_0002),
-    "filesystem.path_index_revision",
-);
-const FILESYSTEM_PATH_REVISION_KEY: &[u8] = b"global";
 const MAX_CACHE_BYTES: usize = 64 * 1024 * 1024;
 const MAX_EAGER_BLOB_BYTES: usize = 32 * 1024;
 const MAX_EAGER_BLOB_CACHE_BYTES: usize = 16 * 1024 * 1024;
@@ -1398,32 +1393,15 @@ impl FilesystemPathIndexCache {
 pub(crate) async fn load_path_index_revision(
     store: &(impl StorageAdapterRead + ?Sized),
 ) -> Result<Option<Vec<u8>>, LixError> {
-    let result = PointReadPlan::new(
-        FILESYSTEM_PATH_REVISION_SPACE,
-        &[StorageKey(Bytes::from_static(FILESYSTEM_PATH_REVISION_KEY))],
-    )
-    .materialize(
-        store,
-        StorageGetOptions {
-            projection: StorageCoreProjection::FullValue,
-        },
-    )
-    .await?;
-    Ok(result
-        .value
-        .into_iter()
-        .next()
-        .flatten()
-        .and_then(|value| match value {
-            StorageProjectedValue::FullValue(bytes) => Some(bytes.to_vec()),
-            StorageProjectedValue::KeyOnly => None,
-        }))
+    Ok(load_revision(store, REVISION_KEY_FILESYSTEM_PATH)
+        .await?
+        .map(|bytes| bytes.to_vec()))
 }
 
 pub(crate) fn stage_path_index_revision(writes: &mut StorageWriteSet) {
     writes.put(
-        FILESYSTEM_PATH_REVISION_SPACE,
-        StorageKey(Bytes::from_static(FILESYSTEM_PATH_REVISION_KEY)),
+        REVISION_SPACE,
+        revision_key(REVISION_KEY_FILESYSTEM_PATH),
         StorageValue {
             bytes: Bytes::copy_from_slice(uuid::Uuid::now_v7().as_bytes()),
         },

--- a/packages/lix/src/storage_adapter/context.rs
+++ b/packages/lix/src/storage_adapter/context.rs
@@ -4,8 +4,8 @@ use bytes::Bytes;
 use tracing::Instrument as _;
 
 use crate::storage::{
-    CommitResult, KeyRange, Memory, Precondition, Prefix, ReadOptions, Storage, StorageError,
-    StorageWrite, StoredValue, WriteOptions,
+    CommitResult, KeyRange, Memory, Precondition, Prefix, PutBatch, PutEntry, ReadOptions, Storage,
+    StorageError, StorageWrite, StoredValue, WriteOptions,
 };
 use crate::storage_adapter::{
     StorageAdapterRead, StorageAdapterReadScope, StorageSpace, StorageWriteSet,
@@ -84,16 +84,9 @@ where
 
     pub async fn prepare_write_set(
         &self,
-        mut write_set: StorageWriteSet,
+        write_set: StorageWriteSet,
         mut opts: WriteOptions,
     ) -> Result<PreparedStorageCommit<'_, StorageImpl>, StorageWriteSetError> {
-        // Every revision singleton lives in one space, so the adapter's own
-        // mutation token joins the transaction's already-staged revision puts
-        // and lowers as one contiguous batch instead of a trailing extra
-        // write into a separate space.
-        if write_set.has_staged_mutations() {
-            stage_mutation_revision(&mut write_set);
-        }
         opts.batch_capacity_hint_bytes = opts
             .batch_capacity_hint_bytes
             .max(write_set.backend_batch_capacity_hint_bytes());
@@ -106,7 +99,19 @@ where
             ))
             .await
             .map_err(StorageWriteSetError::Storage)?;
-        let lowered = async { write_set.lower_into(&mut write).await }
+        let lowered = async {
+            let stats = write_set.lower_into(&mut write).await?;
+            if stats.staged_puts > 0 || stats.staged_deletes > 0 {
+                // The adapter's own mutation token is not a caller mutation,
+                // so it stays out of the write set (and out of the returned
+                // stats). It now lands in the shared revision space, next to
+                // every other revision the same commit rotated.
+                stage_mutation_revision(&mut write)
+                    .await
+                    .map_err(StorageWriteSetError::Storage)?;
+            }
+            Ok::<_, StorageWriteSetError>(stats)
+        }
         .instrument(tracing::debug_span!(
             target: "lix_perf",
             "lix.perf.storage_lowering"
@@ -207,14 +212,23 @@ where
     }
 }
 
-fn stage_mutation_revision(write_set: &mut StorageWriteSet) {
-    write_set.put(
-        REVISION_SPACE,
-        revision_key(REVISION_KEY_MUTATION),
-        StoredValue {
-            bytes: Bytes::copy_from_slice(uuid::Uuid::now_v7().as_bytes()),
-        },
-    );
+async fn stage_mutation_revision<W>(write: &mut W) -> Result<(), StorageError>
+where
+    W: StorageWrite,
+{
+    write
+        .put_many(
+            REVISION_SPACE,
+            PutBatch {
+                entries: vec![PutEntry {
+                    key: revision_key(REVISION_KEY_MUTATION),
+                    value: StoredValue {
+                        bytes: Bytes::copy_from_slice(uuid::Uuid::now_v7().as_bytes()),
+                    },
+                }],
+            },
+        )
+        .await
 }
 
 impl<'a, StorageImpl> PreparedStorageCommit<'a, StorageImpl>

--- a/packages/lix/src/storage_adapter/context.rs
+++ b/packages/lix/src/storage_adapter/context.rs
@@ -4,19 +4,18 @@ use bytes::Bytes;
 use tracing::Instrument as _;
 
 use crate::storage::{
-    CommitResult, CoreProjection, GetOptions, Key, KeyRange, Memory, Precondition, Prefix,
-    ProjectedValue, PutBatch, PutEntry, ReadOptions, Storage, StorageError, StorageWrite,
-    StoredValue, WriteOptions,
+    CommitResult, KeyRange, Memory, Precondition, Prefix, ReadOptions, Storage, StorageError,
+    StorageWrite, StoredValue, WriteOptions,
 };
 use crate::storage_adapter::{
     StorageAdapterRead, StorageAdapterReadScope, StorageSpace, StorageWriteSet,
     StorageWriteSetError, StorageWriteSetStats,
 };
 
-use super::exact_get_many;
-use super::spaces::{MUTATION_REVISION_SPACE, TRACKED_MUTATION_REVISION_SPACE};
-
-const MUTATION_REVISION_KEY: &[u8] = b"global";
+use super::spaces::{
+    REVISION_KEY_MUTATION, REVISION_KEY_TRACKED_MUTATION, REVISION_SPACE, load_revision,
+    revision_key,
+};
 
 #[derive(Clone, Debug)]
 pub struct StorageAdapter<StorageImpl = Memory> {
@@ -85,9 +84,16 @@ where
 
     pub async fn prepare_write_set(
         &self,
-        write_set: StorageWriteSet,
+        mut write_set: StorageWriteSet,
         mut opts: WriteOptions,
     ) -> Result<PreparedStorageCommit<'_, StorageImpl>, StorageWriteSetError> {
+        // Every revision singleton lives in one space, so the adapter's own
+        // mutation token joins the transaction's already-staged revision puts
+        // and lowers as one contiguous batch instead of a trailing extra
+        // write into a separate space.
+        if write_set.has_staged_mutations() {
+            stage_mutation_revision(&mut write_set);
+        }
         opts.batch_capacity_hint_bytes = opts
             .batch_capacity_hint_bytes
             .max(write_set.backend_batch_capacity_hint_bytes());
@@ -100,15 +106,7 @@ where
             ))
             .await
             .map_err(StorageWriteSetError::Storage)?;
-        let lowered = async {
-            let stats = write_set.lower_into(&mut write).await?;
-            if stats.staged_puts > 0 || stats.staged_deletes > 0 {
-                stage_mutation_revision(&mut write)
-                    .await
-                    .map_err(StorageWriteSetError::Storage)?;
-            }
-            Ok::<_, StorageWriteSetError>(stats)
-        }
+        let lowered = async { write_set.lower_into(&mut write).await }
         .instrument(tracing::debug_span!(
             target: "lix_perf",
             "lix.perf.storage_lowering"
@@ -132,12 +130,12 @@ where
     pub(crate) fn tracked_mutation_revision_precondition(expected: Option<Bytes>) -> Precondition {
         expected.map_or_else(
             || Precondition::KeyAbsent {
-                space: TRACKED_MUTATION_REVISION_SPACE,
-                key: mutation_revision_key(),
+                space: REVISION_SPACE,
+                key: revision_key(REVISION_KEY_TRACKED_MUTATION),
             },
             |expected| Precondition::KeyValueEquals {
-                space: TRACKED_MUTATION_REVISION_SPACE,
-                key: mutation_revision_key(),
+                space: REVISION_SPACE,
+                key: revision_key(REVISION_KEY_TRACKED_MUTATION),
                 expected,
             },
         )
@@ -145,8 +143,8 @@ where
 
     pub(crate) fn stage_tracked_mutation_revision(write_set: &mut StorageWriteSet) {
         write_set.put(
-            TRACKED_MUTATION_REVISION_SPACE,
-            mutation_revision_key(),
+            REVISION_SPACE,
+            revision_key(REVISION_KEY_TRACKED_MUTATION),
             uuid::Uuid::now_v7().as_bytes().as_slice(),
         );
     }
@@ -157,26 +155,7 @@ where
     where
         R: StorageAdapterRead + ?Sized,
     {
-        let values = exact_get_many(
-            read,
-            &[crate::storage::GetManyRequest {
-                space: MUTATION_REVISION_SPACE,
-                keys: &[mutation_revision_key()],
-                opts: GetOptions {
-                    projection: CoreProjection::FullValue,
-                },
-            }],
-        )
-        .await?;
-        Ok(values
-            .values
-            .into_iter()
-            .next()
-            .flatten()
-            .and_then(|value| match value {
-                ProjectedValue::FullValue(bytes) => Some(bytes),
-                ProjectedValue::KeyOnly => None,
-            }))
+        load_revision(read, REVISION_KEY_MUTATION).await
     }
 
     pub(crate) async fn load_tracked_mutation_revision_from_read<R>(
@@ -185,26 +164,7 @@ where
     where
         R: StorageAdapterRead + ?Sized,
     {
-        let values = exact_get_many(
-            read,
-            &[crate::storage::GetManyRequest {
-                space: TRACKED_MUTATION_REVISION_SPACE,
-                keys: &[mutation_revision_key()],
-                opts: GetOptions {
-                    projection: CoreProjection::FullValue,
-                },
-            }],
-        )
-        .await?;
-        Ok(values
-            .values
-            .into_iter()
-            .next()
-            .flatten()
-            .and_then(|value| match value {
-                ProjectedValue::FullValue(bytes) => Some(bytes),
-                ProjectedValue::KeyOnly => None,
-            }))
+        load_revision(read, REVISION_KEY_TRACKED_MUTATION).await
     }
 
     pub async fn delete_range(
@@ -247,27 +207,14 @@ where
     }
 }
 
-fn mutation_revision_key() -> Key {
-    Key(Bytes::from_static(MUTATION_REVISION_KEY))
-}
-
-async fn stage_mutation_revision<W>(write: &mut W) -> Result<(), StorageError>
-where
-    W: StorageWrite,
-{
-    write
-        .put_many(
-            MUTATION_REVISION_SPACE,
-            PutBatch {
-                entries: vec![PutEntry {
-                    key: mutation_revision_key(),
-                    value: StoredValue {
-                        bytes: Bytes::copy_from_slice(uuid::Uuid::now_v7().as_bytes()),
-                    },
-                }],
-            },
-        )
-        .await
+fn stage_mutation_revision(write_set: &mut StorageWriteSet) {
+    write_set.put(
+        REVISION_SPACE,
+        revision_key(REVISION_KEY_MUTATION),
+        StoredValue {
+            bytes: Bytes::copy_from_slice(uuid::Uuid::now_v7().as_bytes()),
+        },
+    );
 }
 
 impl<'a, StorageImpl> PreparedStorageCommit<'a, StorageImpl>

--- a/packages/lix/src/storage_adapter/mod.rs
+++ b/packages/lix/src/storage_adapter/mod.rs
@@ -45,6 +45,10 @@ pub(crate) use point::exact_get_many;
 pub use point::{PointReadPlan, PointValues, RequestedToUnique, RequestedToUniqueRef};
 pub(crate) use read_scope::SharedStorageAdapterRead;
 pub use read_scope::{StorageAdapterRead, StorageAdapterReadScope};
+pub(crate) use spaces::{
+    REVISION_KEY_BINARY_CAS_EPOCH, REVISION_KEY_CATALOG, REVISION_KEY_FILESYSTEM_PATH,
+    REVISION_KEY_TRACKED_MUTATION, REVISION_SPACE, load_revision, load_revisions, revision_key,
+};
 pub use stats::{
     StorageReadResult, StorageReadStats, StorageReadStatsCollector, StorageWriteSetStats,
 };

--- a/packages/lix/src/storage_adapter/spaces.rs
+++ b/packages/lix/src/storage_adapter/spaces.rs
@@ -2,14 +2,89 @@ use std::ops::Bound;
 
 use bytes::{BufMut, Bytes, BytesMut};
 
-#[cfg(test)]
-use crate::storage::StorageError;
-use crate::storage::{Key, KeyRange, SpaceId, StorageSpace};
+use crate::storage::{
+    CoreProjection, GetManyRequest, GetOptions, Key, KeyRange, ProjectedValue, SpaceId,
+    StorageError, StorageSpace,
+};
+use crate::storage_adapter::{StorageAdapterRead, exact_get_many};
 
-pub(crate) const MUTATION_REVISION_SPACE: StorageSpace =
-    StorageSpace::mutable(SpaceId(0x0007_0001), "observe.mutation_revision");
-pub(crate) const TRACKED_MUTATION_REVISION_SPACE: StorageSpace =
-    StorageSpace::mutable(SpaceId(0x0007_0004), "transaction.tracked_revision");
+/// The single storage space holding every "something changed here" revision
+/// singleton.
+///
+/// Physical keys are `4-byte-BE space id ++ logical key`, so one space with
+/// one-byte logical keys puts all revision singletons in five adjacent
+/// physical keys. That is one SST block, one hot-key write region, and one
+/// batched point read instead of five scattered ones.
+///
+/// The value semantics stay per-key: the binary-CAS epoch is a CAS-guarded
+/// `u64` big-endian counter, the other four are opaque uuid-v7 tokens whose
+/// only meaningful operation is equality.
+pub(crate) const REVISION_SPACE: StorageSpace =
+    StorageSpace::mutable(SpaceId(0x0007_0000), "lix.revision.v1");
+
+/// Binary-CAS publication/reclamation epoch (`u64` BE, CAS-guarded).
+pub(crate) const REVISION_KEY_BINARY_CAS_EPOCH: &[u8] = b"b";
+/// Registered-schema catalog visibility token.
+pub(crate) const REVISION_KEY_CATALOG: &[u8] = b"c";
+/// Filesystem path-index cache-freshness token.
+pub(crate) const REVISION_KEY_FILESYSTEM_PATH: &[u8] = b"f";
+/// Any-storage-mutation token consumed by `observe`.
+pub(crate) const REVISION_KEY_MUTATION: &[u8] = b"m";
+/// Tracked-state mutation token used as the transaction snapshot fence.
+pub(crate) const REVISION_KEY_TRACKED_MUTATION: &[u8] = b"t";
+
+pub(crate) fn revision_key(key: &'static [u8]) -> Key {
+    Key(Bytes::from_static(key))
+}
+
+/// Loads `N` revision singletons with one batched point read against one space.
+///
+/// Callers that need more than one revision in the same read scope must use
+/// this instead of issuing separate point reads: the whole reason the
+/// singletons share a space is that the backend can serve them from one
+/// lookup over one contiguous key region.
+pub(crate) async fn load_revisions<R, const N: usize>(
+    read: &R,
+    keys: [&'static [u8]; N],
+) -> Result<[Option<Bytes>; N], StorageError>
+where
+    R: StorageAdapterRead + ?Sized,
+{
+    let keys: [Key; N] = keys.map(revision_key);
+    let result = exact_get_many(
+        read,
+        &[GetManyRequest {
+            space: REVISION_SPACE,
+            keys: &keys,
+            opts: GetOptions {
+                projection: CoreProjection::FullValue,
+            },
+        }],
+    )
+    .await?;
+    let mut values = result.values.into_iter();
+    Ok(std::array::from_fn(|_| {
+        values
+            .next()
+            .flatten()
+            .and_then(|value| match value {
+                ProjectedValue::FullValue(bytes) => Some(bytes),
+                ProjectedValue::KeyOnly => None,
+            })
+    }))
+}
+
+/// Loads exactly one revision singleton.
+pub(crate) async fn load_revision<R>(
+    read: &R,
+    key: &'static [u8],
+) -> Result<Option<Bytes>, StorageError>
+where
+    R: StorageAdapterRead + ?Sized,
+{
+    let [value] = load_revisions(read, [key]).await?;
+    Ok(value)
+}
 
 impl StorageSpace {
     pub const fn physical_prefix(&self) -> [u8; 4] {

--- a/packages/lix/src/storage_adapter/write_set.rs
+++ b/packages/lix/src/storage_adapter/write_set.rs
@@ -269,16 +269,6 @@ impl StorageWriteSet {
                 .all(|group| group.puts.is_empty() && group.deletes.is_empty())
     }
 
-    /// Whether this write set stages at least one point put or point delete.
-    ///
-    /// This is exactly the condition the adapter uses to decide whether a
-    /// commit advances the storage mutation revision. Lowering never changes
-    /// `staged_puts`/`staged_deletes`, so asking before lowering and asking
-    /// after lowering give the same answer.
-    pub(crate) fn has_staged_mutations(&self) -> bool {
-        self.stats.staged_puts > 0 || self.stats.staged_deletes > 0
-    }
-
     pub(crate) fn identity(&self) -> u64 {
         self.identity
     }

--- a/packages/lix/src/storage_adapter/write_set.rs
+++ b/packages/lix/src/storage_adapter/write_set.rs
@@ -269,6 +269,16 @@ impl StorageWriteSet {
                 .all(|group| group.puts.is_empty() && group.deletes.is_empty())
     }
 
+    /// Whether this write set stages at least one point put or point delete.
+    ///
+    /// This is exactly the condition the adapter uses to decide whether a
+    /// commit advances the storage mutation revision. Lowering never changes
+    /// `staged_puts`/`staged_deletes`, so asking before lowering and asking
+    /// after lowering give the same answer.
+    pub(crate) fn has_staged_mutations(&self) -> bool {
+        self.stats.staged_puts > 0 || self.stats.staged_deletes > 0
+    }
+
     pub(crate) fn identity(&self) -> u64 {
         self.identity
     }

--- a/packages/lix/src/transaction/bench_support.rs
+++ b/packages/lix/src/transaction/bench_support.rs
@@ -680,7 +680,15 @@ mod tests {
         // The point write keeps the compact current-state certificate,
         // publishes its authenticated branch/control and reachability state,
         // and rotates the mandatory binary-CAS publication/reclamation epoch.
-        assert_eq!(point_update.staged_puts, 12, "{point_update:?}");
+        // Thirteen staged puts against eleven spaces: every revision the
+        // commit rotates (binary-CAS epoch, tracked mutation fence, storage
+        // mutation token) is one key in the single revision space, so the
+        // adapter's own mutation token is staged here instead of being an
+        // extra trailing batch, and the commit issues eleven storage put
+        // batches where the scattered layout issued thirteen.
+        assert_eq!(point_update.staged_puts, 13, "{point_update:?}");
+        assert_eq!(point_update.touched_spaces, 11, "{point_update:?}");
+        assert_eq!(point_update.put_batches, 11, "{point_update:?}");
 
         // A sparse overlay deliberately invalidates the complete-generation
         // digest, so use a fresh fixture to exercise exact bulk replacement

--- a/packages/lix/src/transaction/bench_support.rs
+++ b/packages/lix/src/transaction/bench_support.rs
@@ -680,13 +680,10 @@ mod tests {
         // The point write keeps the compact current-state certificate,
         // publishes its authenticated branch/control and reachability state,
         // and rotates the mandatory binary-CAS publication/reclamation epoch.
-        // Thirteen staged puts against eleven spaces: every revision the
-        // commit rotates (binary-CAS epoch, tracked mutation fence, storage
-        // mutation token) is one key in the single revision space, so the
-        // adapter's own mutation token is staged here instead of being an
-        // extra trailing batch, and the commit issues eleven storage put
-        // batches where the scattered layout issued thirteen.
-        assert_eq!(point_update.staged_puts, 13, "{point_update:?}");
+        // The write set touches eleven spaces, not twelve: the binary-CAS
+        // epoch and the tracked mutation fence are now two keys in the one
+        // revision space rather than two separate spaces.
+        assert_eq!(point_update.staged_puts, 12, "{point_update:?}");
         assert_eq!(point_update.touched_spaces, 11, "{point_update:?}");
         assert_eq!(point_update.put_batches, 11, "{point_update:?}");
 

--- a/packages/lix/src/transaction/context.rs
+++ b/packages/lix/src/transaction/context.rs
@@ -25,7 +25,7 @@ use crate::branch::{
     BranchOperation, BranchRefReader, BranchReferenceRole, branch_ref_stage_row,
 };
 use crate::catalog::{
-    CatalogContext, CatalogFingerprint, CatalogSnapshot, SchemaPlanId, load_catalog_revision,
+    CatalogContext, CatalogFingerprint, CatalogRevision, CatalogSnapshot, SchemaPlanId,
     stage_catalog_revision,
 };
 use crate::changelog::{
@@ -94,7 +94,8 @@ use crate::storage_adapter::{
     StorageWriteSetStats,
 };
 use crate::storage_adapter::{
-    SharedStorageAdapterRead, StorageAdapter, StorageAdapterRead, StorageAdapterReadScope,
+    REVISION_KEY_CATALOG, REVISION_KEY_TRACKED_MUTATION, SharedStorageAdapterRead, StorageAdapter,
+    StorageAdapterRead, StorageAdapterReadScope, load_revisions,
 };
 use crate::tracked_state::{
     TrackedStateContext, TrackedStateDiffKind, TrackedStateDiffRequest, TrackedStateKey,
@@ -1537,8 +1538,17 @@ where
             let runtime_functions = FunctionContext::prepare(&read).await?;
             let runtime_boundary_result = runtime_boundary(&runtime_functions).await?;
             let functions = runtime_functions.provider();
+            // Transaction open needs the catalog revision and the tracked
+            // mutation fence from the same pinned snapshot. Both live in the
+            // one revision space, so one batched point read over two adjacent
+            // keys replaces two independent lookups.
+            let [catalog_revision, opening_tracked_mutation_revision] = load_revisions(
+                &read,
+                [REVISION_KEY_CATALOG, REVISION_KEY_TRACKED_MUTATION],
+            )
+            .await?;
+            let catalog_revision = catalog_revision.map(CatalogRevision::from_storage_bytes);
             let (sql_schema_catalog, tracked_schema_catalog) = {
-                let catalog_revision = load_catalog_revision(&read).await?;
                 let visible_live_state = live_state.reader(&read);
                 let sql_schema_catalog = catalog_context
                     .compiled_catalog_for_transaction_open(
@@ -1560,9 +1570,6 @@ where
                     .await?;
                 (sql_schema_catalog, tracked_schema_catalog)
             };
-            let opening_tracked_mutation_revision =
-                StorageAdapter::<StorageImpl>::load_tracked_mutation_revision_from_read(&read)
-                    .await?;
             let branch_reader = branch_ctx.ref_reader(&read);
             let opening_active_branch_head =
                 branch_reader.load_head_commit_id(&active_branch_id).await?;


### PR DESCRIPTION
## What changed

lix kept **five** independent "something changed here" revision/epoch singletons, each in its own storage
space with its own singleton key:

| Space id | Name | Key |
|---|---|---|
| `0x0005_0005` | `binary_cas.mutation_epoch.v1` | `b"epoch"` (u64 BE, CAS-guarded) |
| `0x0007_0001` | `observe.mutation_revision` | `b"global"` (uuid v7) |
| `0x0007_0002` | `filesystem.path_index_revision` | `b"global"` (uuid v7) |
| `0x0007_0003` | `catalog.schema_revision` | `b"global"` (uuid v7) |
| `0x0007_0004` | `transaction.tracked_revision` | `b"global"` (uuid v7) |

Physical keys are `4-byte-BE space id ++ logical key` (`storage_adapter/spaces.rs`), and both backends
(RocksDB and SlateDB) put every mutable space in one flat keyspace, so these five hot singletons were
scattered across five distant key regions.

They are now **one** space, `0x0007_0000` `lix.revision.v1`, holding five one-byte logical keys
(`b`, `c`, `f`, `m`, `t`) — five adjacent physical keys in one region.

**Removed:** the four retired space constants (`MUTATION_REVISION_SPACE`, `TRACKED_MUTATION_REVISION_SPACE`,
`FILESYSTEM_PATH_REVISION_SPACE`, `CATALOG_REVISION_SPACE`, `BINARY_CAS_MUTATION_EPOCH_SPACE`) are deleted
outright — no shims, no fallback readers, no migration path. A repository written by an older build is not
readable by this one.

Also:
- **Transaction open** loaded the catalog revision and the tracked-mutation fence as two independent point
  reads from the same pinned snapshot. They are now one batched `get_many` over two adjacent keys.
- The three single-key revision loads that went through `PointReadPlan::new` (which allocates a `HashMap`
  plus three `Vec`s per call, for one key) now use an allocation-free batched loader (`load_revision` /
  `load_revisions`).
- Value semantics are unchanged: the binary-CAS epoch keeps its u64-BE CAS-guarded counter and its
  `KeyValueEquals`/`KeyAbsent` preconditions; the other four keep opaque uuid-v7 tokens.
- Public API is unchanged (`lib.rs` exports, SQL surface, JS SDK surface).

## Why this lands as a cut, not a speed win

I profiled before writing the cut. Per-space `get_many` accounting on `tracked_state_crud`
(RocksDB, 1000 rows, `sql_session` layer), counting logical point reads and the time spent inside them:

| op | total `get_many` calls | revision-space calls | revision time | share of op |
|---|---|---|---|---|
| `insert_all` | 62 | 4 (3 spaces) | 8.5 µs | 0.06% of 13.8 ms |
| `update_one` | 45 | 4 (3 spaces) | 5.5 µs | 0.67% of 817 µs |
| `read_one` | 12 | 2 (1 space) | 6–12 µs | 0.4% of 1.83 ms |

So revision lookups are ~7–17% of the *point-read call count* but well under 1% of wall time, and the
transaction-open pair is the only genuine co-read — collapsing it removes exactly one call. `multi_space_point_read`
bounds that directly: collapsing 3 sequential point reads into 1 batched `get_many` is worth 90 ns on RocksDB
(1950→1860 ns p50) and 200 ns on SlateDB (690→490 ns p50).

**The prize is ~0.1–0.2% of a transaction. This cannot and does not clear the >10% bar.** It is submitted
under acceptance criterion 2: it removes four entire storage spaces and collapses five scattered write
regions into one, and the numbers below show it is not slower.

Post-cut, the same accounting shows the structural reduction:

| op | before | after |
|---|---|---|
| `insert_all` | 62 calls, 4 revision requests over 3 spaces | 61 calls, 3 revision requests over **1** space |
| `update_one` | 45 calls, 4 revision requests over 3 spaces | 44 calls, 3 revision requests over **1** space |

And on the write side, a point update (`transaction::bench_support`, memory backend):

| | before | after |
|---|---|---|
| write-set `touched_spaces` | 12 | **11** |
| write-set `put_batches` | 12 | **11** |
| `staged_puts` | 12 | 12 (unchanged) |

(In both arms one further `put_many` for the adapter's own mutation token is issued outside the write set
and is not counted in these stats. Real backend put batches per point-update commit: 13 → 12.)

## A/B results

Machine: `hetzner-cpx62-IV` (16 cores, 30 GB). Both worktrees built fully with `--no-run` before any timing.
All runs **interleaved** base/cand within each rep. Load average verified < 1.0 before each timing window.
Base = `claude-3-optimizations` @ `1d406823f` in `~/claude3/base`; cand = `exp/revision-singletons` in
`~/claude3/exp-revision-singletons`.

### Primary — `tracked_state_crud` (profile mode, `sql_session` layer)

`LIX_TRACKED_STATE_CRUD_PROFILE=1 LIX_TRACKED_STATE_CRUD_PROFILE_LAYER=sql_session LIX_TRACKED_STATE_CRUD_PROFILE_STORAGE=<be> LIX_TRACKED_STATE_CRUD_PROFILE_OP=<op> LIX_TRACKED_STATE_CRUD_PROFILE_ROW_COUNT=<n> LIX_TRACKED_STATE_CRUD_PROFILE_SAMPLES=<s>`
(each rep reports the median of `s` samples; the table reports the median and p95 across reps, in ms)

| storage | rows | op | reps | base med | cand med | delta | base p95 | cand p95 | P(cand>base) |
|---|---|---|---|---|---|---|---|---|---|
| rocksdb | 1000 | insert_all | 20 | 8.6373 | 8.6433 | **+0.07%** | 9.0864 | 9.0901 | 0.58 |
| rocksdb | 1000 | update_one | 20 | 0.8649 | 0.8444 | **−2.36%** | 1.4117 | 1.2473 | 0.47 |
| rocksdb | 1000 | read_one | 5 | 1.6380 | 1.5953 | −2.61% | 1.8058 | 1.6627 | 0.32 |
| rocksdb | 10000 | insert_all | 9 | 41.1939 | 40.4645 | **−1.77%** | 42.8384 | 42.6171 | 0.38 |
| rocksdb | 10000 | update_one | 9 | 1.2385 | 1.1917 | −3.78% | 1.3383 | 1.4912 | 0.33 |
| rocksdb | 10000 | read_one | 3 | 1.9368 | 1.8965 | −2.08% | 2.0514 | 1.9431 | 0.33 |
| slatedb | 1000 | insert_all | 3 | 8.7643 | 9.0259 | +2.98% | 8.7677 | 9.3812 | 0.67 |
| slatedb | 1000 | update_one | 3 | 1.4079 | 1.3291 | −5.59% | 1.7193 | 1.4316 | 0.44 |
| slatedb | 1000 | read_one | 3 | 1.8860 | 1.8301 | −2.96% | 1.9961 | 1.8725 | 0.00 |

Raw per-rep numbers for the two 20-rep primaries (ms):

```
rocksdb/1000/update_one
 base 1.4030 0.8705 1.4938 0.8820 0.7862 1.4117 0.7729 0.8326 0.9213 0.8610
      0.7323 1.0770 0.8533 0.8715 0.8688 0.7839 0.8034 0.8974 0.7898 0.7709
 cand 0.8427 0.7558 1.3434 0.7647 0.9515 0.9712 0.8035 1.2473 0.8178 0.8031
      0.7562 0.8268 1.0542 0.9856 0.8462 0.7331 0.8859 0.9291 0.7629 0.8711

rocksdb/1000/insert_all
 base 8.8696 8.4745 8.9755 8.3465 9.8368 8.5881 8.7064 8.0763 8.2630 8.9786
      8.8806 8.7246 9.0864 8.2767 8.7614 8.2125 8.2198 8.6864 8.4923 8.2223
 cand 8.5812 8.7655 9.3240 9.0174 8.9234 8.4372 8.4915 8.7797 8.3652 9.0901
      9.0561 8.5852 8.4910 8.3196 8.5268 8.8692 8.7088 8.7013 8.5418 8.3778
```

The first 5-rep pass on `rocksdb/1000/update_one` read +10.29% and `rocksdb/10000/insert_all` read +8.4%;
both collapsed to −2.4% and −1.8% once run to 20 and 9 reps respectively. Neither was real. This is why the
runbook's "run more reps before concluding" rule matters here — the effect being measured is smaller than
this harness's per-rep spread.

### Primary — `multi_space_point_read` (5 interleaved reps, p50 ns)

| backend | mode | base | cand | delta |
|---|---|---|---|---|
| rocksdb | sequential | 1950 | 1880 | −3.59% |
| rocksdb | batch | 1860 | 1810 | −2.69% |
| slatedb | sequential | 690 | 700 | +1.45% |
| slatedb | batch | 490 | 480 | −2.04% |

(This bench uses its own synthetic spaces and is unaffected by the cut; it is a guard, and it is flat.)

### Primary — `untracked_state_crud` (10 interleaved reps, criterion)

21 shared benchmarks. Median of per-benchmark median deltas **−0.45%**; median of per-benchmark mean deltas
+1.12%. Per-benchmark medians span −5.83% to +9.21%, with P(cand>base) between 0.34 and 0.70 — consistent
with noise, and the direction is not consistent across backends (e.g. `update_all_rows/1k` is +6.45% on
RocksDB and −0.21% on SlateDB by mean). Worst rows:

| benchmark | base | cand | median delta | P(cand>base) |
|---|---|---|---|---|
| lix_rocksdb/smoke/update_all_rows/1k | 1987.45 µs | 2170.50 µs | +9.21% | 0.68 |
| lix_rocksdb/smoke/update_one_by_pk/1k | 25.37 µs | 27.25 µs | +7.39% | 0.59 |
| lix_rocksdb/smoke/delete_one_by_pk/1k | 12.79 µs | 13.54 µs | +5.90% | 0.68 |
| lix_slatedb/smoke/select_one_by_pk/1k | 60.33 µs | 56.81 µs | −5.83% | 0.40 |
| lix_rocksdb/real_workload/insert_all_rows/10k | 11997.5 µs | 11969.5 µs | −0.23% | 0.45 |

The untracked adapter path changed in exactly one way — the trailing mutation-token `put_many` now targets a
different (5-byte-shorter) physical key — so there is no mechanism for a 6–9% write regression, and with 21
benchmarks a couple of rows at P≈0.68 is the expected multiple-comparison tail.

### Guard — `small_blob_cas` (9 interleaved reps, p50)

39 measurements, median of deltas **−0.02%**. This bench is strongly bimodal: several rows show ±50–125%
median deltas while P(cand>base) stays near 0.5 (e.g. `slatedb/dedupe_write/4096` median +124.94% at
P=0.52; `rocksdb/unique_write/4096` median −58.58% at P=0.32), i.e. the median lands on whichever mode
holds ≥5 of 9 samples. The most *consistent* rows are `rocksdb/hot_read/65536` +0.54% (P=0.94) and
`slatedb/visible_hot_batch_read/65536` +1.06% (P=0.79) — both ≤1.1%.

A first 3-rep pass on this bench showed apparent +99%/+139%/+146% regressions; all disappeared at 9 reps.

### Guard — `diff_commands` (3 interleaved reps, criterion)

| benchmark | base | cand | delta |
|---|---|---|---|
| working_diff_1000 | 3.9363 ms | 3.5856 ms | −8.91% |
| partial_checkpoint_500_of_1000 | 19.704 ms | 19.765 ms | +0.31% |
| revert_100_of_1000 | 9.4183 ms | 9.4844 ms | +0.70% |
| apply_100_of_1000 | 9.0185 ms | 9.2629 ms | **+2.71%** |

### Guard — `packed_history_scale` physical bytes (2 interleaved reps)

`LIX_PACKED_HISTORY_CHANGES=100000 LIX_PACKED_HISTORY_COMMIT_WIDTHS=10 LIX_PACKED_HISTORY_SAMPLES=3 LIX_PACKED_HISTORY_EXACT_SAMPLES=201`

| backend | metric | base | cand | delta |
|---|---|---|---|---|
| rocksdb | `backend_bytes` | 7,252,948 | 7,252,925 | **−23 B** |
| rocksdb | `storage_amplification` | 1.121 | 1.121 | 0 |
| rocksdb | `scan_p50_ms` | 114.20 | 110.16 | −3.5% |
| slatedb | `backend_bytes` | 6,872,278 | 6,872,252 | **−26 B** |
| slatedb | `storage_amplification` | 1.062 | 1.062 | 0 |
| slatedb | `scan_p50_ms` | 191.33 | 182.56 | −4.6% |

Bytes go down, as expected: the five logical keys shrink from `b"global"`×4 + `b"epoch"` (29 bytes) to five
one-byte keys, and four of the five 4-byte space prefixes are gone from the live set.

## Which metrics regressed, and why that is acceptable

Nothing regressed beyond noise. With adequate reps the largest credible move against the candidate is
`diff_commands/apply_100_of_1000` at +2.71% (3 reps) and `untracked_state_crud/lix_rocksdb/smoke/update_all_rows/1k`
at +6.45% by mean / +9.21% by median (10 reps, P=0.68) — both inside this harness's per-rep spread, both
without a mechanism, and both contradicted by the same operation on the other backend. Every metric with
n ≥ 9 lands between −3.8% and +0.1%.

The honest summary is: **this change is performance-neutral.** It is worth landing because it removes four
storage spaces and one class of scattered hot key, not because it is faster.

## Correctness gate

Run on `hetzner-cpx62-IV` against `exp/revision-singletons`:

```
cargo check --workspace                                              OK
cargo clippy --workspace --all-targets --all-features -- -D warnings OK
cargo test -p lix                                                    OK — 2489 passed, 0 failed
```

Two test expectations were updated, both physical-write-accounting assertions that the cut legitimately
changes: `transaction::bench_support` now pins `touched_spaces == 11` and `put_batches == 11` for a point
update (was 12/12), with `staged_puts` unchanged at 12.

## Note for reviewers

`assert_empty_repository_for_initialize` probes the storage mutation revision as a secondary "this is a
pre-protocol repository" signal. Because the space id moved, that probe no longer sees an old repository's
token. `repository_protocol_status` remains the primary check and still rejects such a repository. This is
intentional under the no-backward-compatibility rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
