### PR TITLE
perf(commit_graph): bound history traversal instead of filtering after it

### DIFF
--- a/.changenotes/bounded-history-traversal.md
+++ b/.changenotes/bounded-history-traversal.md
@@ -1,0 +1,7 @@
+---
+type: patch
+---
+
+History queries that ask for a shallow depth or a small `LIMIT` no longer read the whole commit graph.
+
+Depth ranges and row limits are now applied while walking history instead of afterwards, so a query such as `WHERE lixcol_depth = 0` or `LIMIT 10` costs the same on a repository with fifty thousand commits as on one with a thousand. Reading a full history is also faster, because each generation of commits is now fetched in one batched read.

--- a/packages/engine-benchmarks/benches/commit_graph_scale.rs
+++ b/packages/engine-benchmarks/benches/commit_graph_scale.rs
@@ -43,6 +43,9 @@ async fn run() {
             "legacy_reachable_nodes",
             CommitGraphBenchMode::LegacyReachableNodes,
         ),
+        ("history_full", CommitGraphBenchMode::HistoryFull),
+        ("history_depth0", CommitGraphBenchMode::HistoryDepth0),
+        ("history_limit10", CommitGraphBenchMode::HistoryLimit10),
     ] {
         if mode_filter.is_some_and(|filter| filter != name) {
             continue;

--- a/packages/lix/src/commit_graph/context.rs
+++ b/packages/lix/src/commit_graph/context.rs
@@ -15,7 +15,7 @@ use crate::changelog::{
     ChangeId, ChangeRecord, ChangelogContext, ChangelogReader, CommitId, CommitRecord,
     CommitScanRequest,
 };
-use crate::commit_graph::walker::{best_common_ancestors, walk_reachable_nodes};
+use crate::commit_graph::walker::{ReachableWalk, best_common_ancestors, walk_reachable_nodes};
 use crate::commit_graph::{
     CommitGraphChange, CommitGraphChangeHistoryEntry, CommitGraphChangeHistoryRequest,
     CommitGraphHistory, CommitGraphNode, CommitGraphReader, ReachableCommitGraphNode,
@@ -70,7 +70,10 @@ where
 {
     store: S,
     node_cache: HashMap<CommitId, Option<CommitGraphNode>>,
-    reachable_nodes_cache: HashMap<CommitId, Arc<[ReachableCommitGraphNode]>>,
+    /// Keyed by traversal head and depth bound. A bounded walk is a distinct
+    /// result from the unbounded one, but an already materialized unbounded
+    /// walk answers every bounded request without touching storage again.
+    reachable_nodes_cache: HashMap<(CommitId, Option<u32>), Arc<[ReachableCommitGraphNode]>>,
     // A reader is bound to one pinned storage snapshot for the duration of a
     // SQL statement. File-history shaping asks the same reader for distinct
     // schema slices of that history, so retain immutable change records here.
@@ -218,12 +221,33 @@ where
         &mut self,
         head_commit_id: &CommitId,
     ) -> Result<Arc<[ReachableCommitGraphNode]>, LixError> {
-        if let Some(nodes) = self.reachable_nodes_cache.get(head_commit_id) {
+        self.reachable_nodes_within_depth(head_commit_id, None).await
+    }
+
+    /// Walks from `head_commit_id` and stops once `max_depth` is complete.
+    async fn reachable_nodes_within_depth(
+        &mut self,
+        head_commit_id: &CommitId,
+        max_depth: Option<u32>,
+    ) -> Result<Arc<[ReachableCommitGraphNode]>, LixError> {
+        if let Some(nodes) = self.reachable_nodes_cache.get(&(*head_commit_id, max_depth)) {
             return Ok(Arc::clone(nodes));
         }
-        let nodes = Arc::from(walk_reachable_nodes(self, head_commit_id).await?);
+        if let Some(max_depth_value) = max_depth
+            && let Some(nodes) = self.reachable_nodes_cache.get(&(*head_commit_id, None))
+        {
+            let bounded = nodes
+                .iter()
+                .take_while(|reachable| reachable.depth <= max_depth_value)
+                .cloned()
+                .collect::<Arc<[_]>>();
+            self.reachable_nodes_cache
+                .insert((*head_commit_id, max_depth), Arc::clone(&bounded));
+            return Ok(bounded);
+        }
+        let nodes = Arc::from(walk_reachable_nodes(self, head_commit_id, max_depth).await?);
         self.reachable_nodes_cache
-            .insert(*head_commit_id, Arc::clone(&nodes));
+            .insert((*head_commit_id, max_depth), Arc::clone(&nodes));
         Ok(nodes)
     }
 
@@ -400,70 +424,117 @@ where
         start_commit_id: &CommitId,
         request: &CommitGraphChangeHistoryRequest,
     ) -> Result<CommitGraphHistory, LixError> {
-        let nodes = self.reachable_nodes(start_commit_id).await?;
-        let member_schema_keys = request
-            .schema_keys
-            .iter()
-            .filter(|schema_key| schema_key.as_str() != COMMIT_SCHEMA_KEY)
-            .cloned()
-            .collect::<Vec<_>>();
-        let mut member_schema_keys = member_schema_keys;
-        member_schema_keys.sort();
-        member_schema_keys.dedup();
-        let may_include_members = request.schema_keys.is_empty() || !member_schema_keys.is_empty();
-        let may_include_commits = request.schema_keys.is_empty()
-            || request
-                .schema_keys
-                .iter()
-                .any(|schema_key| schema_key == COMMIT_SCHEMA_KEY);
-        let mut entries = Vec::new();
-        let mut seen_changes = BTreeSet::new();
+        let shaping = HistoryShaping::new(request);
+        let mut state = HistoryCollection::default();
 
-        for reachable in nodes.iter() {
-            if !depth_matches(reachable.depth, request) {
-                continue;
+        // Unbounded row demand still materializes and caches the whole
+        // depth-bounded topology, because callers reuse it for commit metadata.
+        let Some(limit) = request.limit else {
+            let nodes = self
+                .reachable_nodes_within_depth(start_commit_id, request.max_depth)
+                .await?;
+            for reachable in nodes.iter() {
+                self.extend_history_entries(
+                    start_commit_id,
+                    &reachable.commit,
+                    reachable.depth,
+                    request,
+                    &shaping,
+                    &mut state,
+                )
+                .await?;
             }
+            return Ok(CommitGraphHistory {
+                entries: state.entries,
+                reachable_nodes: nodes,
+            });
+        };
 
-            let node = &reachable.commit;
-            if may_include_commits {
-                let canonical_change = canonical_commit_change(node);
-                if seen_changes.insert(history_change_identity(&canonical_change))
-                    && change_matches_history_request(&canonical_change, request)
-                {
-                    entries.push(CommitGraphChangeHistoryEntry {
-                        change: canonical_change,
-                        observed_commit_id: node.commit_id,
-                        start_commit_id: *start_commit_id,
-                        depth: reachable.depth,
-                    });
+        // Bounded row demand stops the traversal itself. Breadth-first layers
+        // arrive in the same order the entries are published, so the first
+        // `limit` entries are exactly the ones an unbounded read would expose.
+        let mut walk = ReachableWalk::new(*start_commit_id);
+        let mut reachable_nodes = Vec::new();
+        while state.entries.len() < limit {
+            let Some(layer) = walk.next_layer(self).await? else {
+                break;
+            };
+            let depth = layer.depth;
+            for node in layer.commits {
+                self.extend_history_entries(
+                    start_commit_id,
+                    &node,
+                    depth,
+                    request,
+                    &shaping,
+                    &mut state,
+                )
+                .await?;
+                reachable_nodes.push(ReachableCommitGraphNode { commit: node, depth });
+                if state.entries.len() >= limit {
+                    break;
                 }
             }
-
-            if !may_include_members {
-                continue;
-            }
-            for change in self
-                .load_member_changes(node.commit_id, &member_schema_keys)
-                .await?
-            {
-                if !seen_changes.insert(history_change_identity(&change)) {
-                    continue;
-                }
-                if change_matches_history_request(&change, request) {
-                    entries.push(CommitGraphChangeHistoryEntry {
-                        change,
-                        observed_commit_id: node.commit_id,
-                        start_commit_id: *start_commit_id,
-                        depth: reachable.depth,
-                    });
-                }
+            if request.max_depth.is_some_and(|max_depth| depth >= max_depth) {
+                break;
             }
         }
 
         Ok(CommitGraphHistory {
-            entries,
-            reachable_nodes: nodes,
+            entries: state.entries,
+            reachable_nodes: Arc::from(reachable_nodes),
         })
+    }
+
+    async fn extend_history_entries(
+        &mut self,
+        start_commit_id: &CommitId,
+        node: &CommitGraphNode,
+        depth: u32,
+        request: &CommitGraphChangeHistoryRequest,
+        shaping: &HistoryShaping,
+        state: &mut HistoryCollection,
+    ) -> Result<(), LixError> {
+        if !depth_matches(depth, request) {
+            return Ok(());
+        }
+
+        if shaping.may_include_commits {
+            let canonical_change = canonical_commit_change(node);
+            if state
+                .seen_changes
+                .insert(history_change_identity(&canonical_change))
+                && change_matches_history_request(&canonical_change, request)
+            {
+                state.entries.push(CommitGraphChangeHistoryEntry {
+                    change: canonical_change,
+                    observed_commit_id: node.commit_id,
+                    start_commit_id: *start_commit_id,
+                    depth,
+                });
+            }
+        }
+
+        if !shaping.may_include_members {
+            return Ok(());
+        }
+        for change in self
+            .load_member_changes(node.commit_id, &shaping.member_schema_keys)
+            .await?
+        {
+            if !state.seen_changes.insert(history_change_identity(&change)) {
+                continue;
+            }
+            if change_matches_history_request(&change, request) {
+                state.entries.push(CommitGraphChangeHistoryEntry {
+                    change,
+                    observed_commit_id: node.commit_id,
+                    start_commit_id: *start_commit_id,
+                    depth,
+                });
+            }
+        }
+        Ok(())
     }
 
     async fn load_member_changes(
@@ -497,6 +568,44 @@ where
             .insert(commit_id, changes.clone());
         Ok(changes)
     }
+}
+
+/// Request-derived shaping decisions that do not change while a history read
+/// walks the graph.
+struct HistoryShaping {
+    member_schema_keys: Vec<String>,
+    may_include_members: bool,
+    may_include_commits: bool,
+}
+
+impl HistoryShaping {
+    fn new(request: &CommitGraphChangeHistoryRequest) -> Self {
+        let mut member_schema_keys = request
+            .schema_keys
+            .iter()
+            .filter(|schema_key| schema_key.as_str() != COMMIT_SCHEMA_KEY)
+            .cloned()
+            .collect::<Vec<_>>();
+        member_schema_keys.sort();
+        member_schema_keys.dedup();
+        let may_include_members = request.schema_keys.is_empty() || !member_schema_keys.is_empty();
+        let may_include_commits = request.schema_keys.is_empty()
+            || request
+                .schema_keys
+                .iter()
+                .any(|schema_key| schema_key == COMMIT_SCHEMA_KEY);
+        Self {
+            member_schema_keys,
+            may_include_members,
+            may_include_commits,
+        }
+    }
+}
+
+#[derive(Default)]
+struct HistoryCollection {
+    entries: Vec<CommitGraphChangeHistoryEntry>,
+    seen_changes: BTreeSet<(ChangeId, String, Option<String>, EntityPk)>,
 }
 
 fn commit_graph_change_from_change_record(change: ChangeRecord) -> CommitGraphChange {
@@ -1004,6 +1113,106 @@ mod tests {
                     1
                 ),
             ]
+        );
+    }
+
+    #[tokio::test]
+    async fn bounded_history_stops_traversing_instead_of_truncating() {
+        let storage = StorageAdapter::new(Memory::new());
+        append_changes(
+            &storage,
+            &[
+                entity_change("change-root", "entity-root", "test_schema", "{}"),
+                entity_change("change-middle", "entity-middle", "test_schema", "{}"),
+                entity_change("change-head", "entity-head", "test_schema", "{}"),
+                commit_change("commit-root-change", "commit-root", &["change-root"], &[]),
+                commit_change(
+                    "commit-middle-change",
+                    "commit-middle",
+                    &["change-middle"],
+                    &["commit-root"],
+                ),
+                commit_change(
+                    "commit-head-change",
+                    "commit-head",
+                    &["change-head"],
+                    &["commit-middle"],
+                ),
+            ],
+        )
+        .await;
+
+        let commit_head = commit_id("commit-head");
+        let base_request = CommitGraphChangeHistoryRequest {
+            schema_keys: vec!["test_schema".to_string()],
+            include_tombstones: true,
+            ..CommitGraphChangeHistoryRequest::default()
+        };
+        let read = storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("read should open");
+        let mut reader = CommitGraphContext::new().reader(read);
+        let full = reader
+            .change_history_from_commit(&commit_head, &base_request)
+            .await
+            .expect("full history should resolve");
+        assert_eq!(full.entries.len(), 3);
+        assert_eq!(full.reachable_nodes.len(), 3);
+
+        let read = storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("read should open");
+        let mut reader = CommitGraphContext::new().reader(read);
+        let limited = reader
+            .change_history_from_commit(
+                &commit_head,
+                &CommitGraphChangeHistoryRequest {
+                    limit: Some(1),
+                    ..base_request.clone()
+                },
+            )
+            .await
+            .expect("bounded history should resolve");
+        assert_eq!(
+            limited
+                .entries
+                .iter()
+                .map(|entry| entry.change.id)
+                .collect::<Vec<_>>(),
+            full.entries[..1]
+                .iter()
+                .map(|entry| entry.change.id)
+                .collect::<Vec<_>>(),
+            "a bounded read must expose the same prefix an unbounded read would"
+        );
+        assert_eq!(
+            limited.reachable_nodes.len(),
+            1,
+            "a satisfied row bound must stop the walk, not truncate afterwards"
+        );
+
+        let read = storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("read should open");
+        let mut reader = CommitGraphContext::new().reader(read);
+        let shallow = reader
+            .change_history_from_commit(
+                &commit_head,
+                &CommitGraphChangeHistoryRequest {
+                    max_depth: Some(0),
+                    ..base_request
+                },
+            )
+            .await
+            .expect("depth-bounded history should resolve");
+        assert_eq!(shallow.entries.len(), 1);
+        assert_eq!(
+            shallow.reachable_nodes.len(),
+            1,
+            "a depth bound must stop the walk, not filter it afterwards"
         );
     }
 

--- a/packages/lix/src/commit_graph/types.rs
+++ b/packages/lix/src/commit_graph/types.rs
@@ -72,6 +72,11 @@ pub(crate) fn commit_edges(commits: &[CommitGraphNode]) -> Vec<CommitGraphEdge> 
 }
 
 /// Filter for canonical change history from a chosen traversal start commit.
+///
+/// `max_depth` and `limit` are traversal bounds, not post-filters. The reader
+/// stops walking the commit graph as soon as neither can produce another row,
+/// so a narrow history query never pays for the unreachable remainder of the
+/// graph.
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub(crate) struct CommitGraphChangeHistoryRequest {
     pub(crate) entity_pks: Vec<EntityPk>,
@@ -80,6 +85,12 @@ pub(crate) struct CommitGraphChangeHistoryRequest {
     pub(crate) min_depth: Option<u32>,
     pub(crate) max_depth: Option<u32>,
     pub(crate) include_tombstones: bool,
+    /// Maximum number of history rows the caller will consume.
+    ///
+    /// Only set this when the caller returns the produced entries 1:1 as its
+    /// output rows. Row-shaping surfaces must leave it unset because they can
+    /// collapse or drop entries after the graph read.
+    pub(crate) limit: Option<usize>,
 }
 
 /// Canonical change observed while walking commit history from a start commit.

--- a/packages/lix/src/commit_graph/walker.rs
+++ b/packages/lix/src/commit_graph/walker.rs
@@ -10,18 +10,116 @@ use crate::storage_adapter::StorageAdapterRead;
 /// Walks parent links from `head_commit_id` and returns reachable commits
 /// nearest-first.
 ///
+/// `max_depth` bounds the walk itself. A caller that only wants the first few
+/// generations pays for those generations, not for the whole graph.
+///
 /// The walker is intentionally storage-free. It asks `CommitGraphReader` to
-/// load parsed commit facts and owns only traversal concerns: caching, cycle
+/// load parsed commit facts and owns only traversal concerns: batching, cycle
 /// detection, and nearest-depth selection.
 pub(crate) async fn walk_reachable_nodes<S>(
     reader: &mut CommitGraphStoreReader<S>,
     head_commit_id: &CommitId,
+    max_depth: Option<u32>,
 ) -> Result<Vec<ReachableCommitGraphNode>, LixError>
 where
     S: StorageAdapterRead,
 {
-    let mut loader = NodeTraversalLoader::new(reader);
-    loader.walk(head_commit_id).await
+    let mut walk = ReachableWalk::new(*head_commit_id);
+    let mut commits = Vec::new();
+    while let Some(layer) = walk.next_layer(reader).await? {
+        let depth = layer.depth;
+        commits.extend(
+            layer
+                .commits
+                .into_iter()
+                .map(|commit| ReachableCommitGraphNode { commit, depth }),
+        );
+        if max_depth.is_some_and(|max_depth| depth >= max_depth) {
+            break;
+        }
+    }
+    Ok(commits)
+}
+
+/// One nearest-depth generation of a reachable-commit walk.
+pub(crate) struct ReachableLayer {
+    pub(crate) depth: u32,
+    pub(crate) commits: Vec<CommitGraphNode>,
+}
+
+/// Resumable breadth-first cursor over the reachable commit graph.
+///
+/// Breadth-first order is the order the history surfaces already publish
+/// (nearest depth first, commit id within a depth), so a caller that has
+/// collected enough rows can simply stop asking for the next layer instead of
+/// materializing the remainder of the graph and truncating afterwards.
+///
+/// Each layer is loaded with one batched point read rather than one storage
+/// round-trip per commit.
+pub(crate) struct ReachableWalk {
+    seen: BTreeSet<CommitId>,
+    /// Frontier entries carry the generation of the child that discovered them.
+    /// Commit generations are strictly increasing away from the roots, so a
+    /// parent that fails to sit below its child proves a corrupt cycle.
+    frontier: Vec<(CommitId, u64)>,
+    depth: u32,
+}
+
+impl ReachableWalk {
+    pub(crate) fn new(head_commit_id: CommitId) -> Self {
+        Self {
+            seen: BTreeSet::from([head_commit_id]),
+            frontier: vec![(head_commit_id, u64::MAX)],
+            depth: 0,
+        }
+    }
+
+    pub(crate) async fn next_layer<S>(
+        &mut self,
+        reader: &mut CommitGraphStoreReader<S>,
+    ) -> Result<Option<ReachableLayer>, LixError>
+    where
+        S: StorageAdapterRead,
+    {
+        if self.frontier.is_empty() {
+            return Ok(None);
+        }
+        let depth = self.depth;
+        let mut frontier = std::mem::take(&mut self.frontier);
+        frontier.sort_unstable();
+        let commit_ids = frontier
+            .iter()
+            .map(|(commit_id, _)| *commit_id)
+            .collect::<Vec<_>>();
+        let loaded = reader.load_nodes(&commit_ids).await?;
+        let mut commits = Vec::with_capacity(commit_ids.len());
+        let mut next_frontier = Vec::new();
+        for ((commit_id, node), (_, child_generation)) in loaded.into_iter().zip(frontier.iter()) {
+            let Some(node) = node else {
+                return Err(LixError::new(
+                    "LIX_ERROR_UNKNOWN",
+                    format!("commit_graph missing commit '{commit_id}'"),
+                ));
+            };
+            if node.generation >= *child_generation {
+                return Err(LixError::new(
+                    "LIX_ERROR_UNKNOWN",
+                    format!(
+                        "commit_graph cycle detected at commit '{commit_id}': it does not have a lower generation than the child that reaches it"
+                    ),
+                ));
+            }
+            for parent_commit_id in &node.parent_commit_ids {
+                if self.seen.insert(*parent_commit_id) {
+                    next_frontier.push((*parent_commit_id, node.generation));
+                }
+            }
+            commits.push(node);
+        }
+        self.frontier = next_frontier;
+        self.depth = depth.saturating_add(1);
+        Ok(Some(ReachableLayer { depth, commits }))
+    }
 }
 
 /// Returns the best common ancestors shared by two commit heads.
@@ -140,84 +238,6 @@ where
         Ok(best)
     }
 
-    async fn walk(
-        &mut self,
-        head_commit_id: &CommitId,
-    ) -> Result<Vec<ReachableCommitGraphNode>, LixError> {
-        let mut visiting = BTreeSet::new();
-        let mut nearest_depths = BTreeMap::new();
-        self.walk_commit(head_commit_id, 0, &mut visiting, &mut nearest_depths)
-            .await?;
-        let mut commits = Vec::with_capacity(nearest_depths.len());
-        for (commit_id, depth) in nearest_depths {
-            commits.push(ReachableCommitGraphNode {
-                commit: self.load_node(&commit_id).await?,
-                depth,
-            });
-        }
-        commits.sort_by(|left, right| {
-            left.depth
-                .cmp(&right.depth)
-                .then_with(|| left.commit.commit_id.cmp(&right.commit.commit_id))
-        });
-        Ok(commits)
-    }
-
-    async fn walk_commit(
-        &mut self,
-        commit_id: &CommitId,
-        depth: u32,
-        visiting: &mut BTreeSet<CommitId>,
-        nearest_depths: &mut BTreeMap<CommitId, u32>,
-    ) -> Result<(), LixError> {
-        let mut stack = vec![TraversalFrame {
-            commit_id: *commit_id,
-            depth,
-            expanded: false,
-        }];
-
-        while let Some(frame) = stack.pop() {
-            if frame.expanded {
-                visiting.remove(&frame.commit_id);
-                continue;
-            }
-
-            if visiting.contains(&frame.commit_id) {
-                return Err(LixError::new(
-                    "LIX_ERROR_UNKNOWN",
-                    format!(
-                        "commit_graph cycle detected at commit '{}'",
-                        frame.commit_id
-                    ),
-                ));
-            }
-
-            if let Some(previous_depth) = nearest_depths.get(&frame.commit_id) {
-                if *previous_depth <= frame.depth {
-                    continue;
-                }
-            }
-
-            let commit = self.load_node(&frame.commit_id).await?;
-            nearest_depths.insert(frame.commit_id, frame.depth);
-
-            visiting.insert(frame.commit_id);
-            stack.push(TraversalFrame {
-                commit_id: frame.commit_id,
-                depth: frame.depth,
-                expanded: true,
-            });
-            for parent_commit_id in commit.parent_commit_ids.iter().rev() {
-                stack.push(TraversalFrame {
-                    commit_id: *parent_commit_id,
-                    depth: frame.depth + 1,
-                    expanded: false,
-                });
-            }
-        }
-        Ok(())
-    }
-
     async fn load_node(&mut self, commit_id: &CommitId) -> Result<CommitGraphNode, LixError> {
         let Some(commit) = self.reader.load_node(commit_id).await? else {
             return Err(LixError::new(
@@ -227,12 +247,6 @@ where
         };
         Ok(commit)
     }
-}
-
-struct TraversalFrame {
-    commit_id: CommitId,
-    depth: u32,
-    expanded: bool,
 }
 
 #[cfg(test)]

--- a/packages/lix/src/sql2/history_route.rs
+++ b/packages/lix/src/sql2/history_route.rs
@@ -314,10 +314,11 @@ pub(crate) fn validate_history_anchor_filter(expr: &Expr) -> Result<(), LixError
 pub(crate) fn commit_graph_history_request(
     route: &HistoryRoute,
     schema_keys: Vec<String>,
+    limit: Option<usize>,
 ) -> Option<CommitGraphChangeHistoryRequest> {
     let schema_keys = effective_schema_keys(route, schema_keys)?;
     Some(CommitGraphChangeHistoryRequest {
-        limit: None,
+        limit,
         entity_pks: if route.resolved_entity_pks.is_empty() {
             route
                 .entity_pks
@@ -339,6 +340,10 @@ pub(crate) fn commit_graph_history_request(
 ///
 /// Providers pass the schema keys they know how to shape. An empty list means
 /// "do not constrain by provider schema".
+///
+/// `limit` is a traversal bound, not a truncation. Only pass it from a provider
+/// that emits one output row per returned entry; a row-shaping provider must
+/// pass `None` because it can collapse or discard entries afterwards.
 pub(crate) async fn load_history_entries<S>(
     descriptor: HistoryViewDescriptor<'_>,
     commit_graph: Arc<Mutex<Box<dyn CommitGraphReader>>>,
@@ -346,6 +351,7 @@ pub(crate) async fn load_history_entries<S>(
     route: &HistoryRoute,
     schema_keys: Vec<String>,
     metadata_projection: HistoryMetadataProjection,
+    limit: Option<usize>,
 ) -> Result<Vec<HistoryEntry>, LixError>
 where
     S: StorageAdapterRead + Clone + Send + Sync + 'static,
@@ -359,7 +365,7 @@ where
     if route.is_contradictory() {
         return Ok(Vec::new());
     }
-    let Some(request) = commit_graph_history_request(route, schema_keys) else {
+    let Some(request) = commit_graph_history_request(route, schema_keys, limit) else {
         return Ok(Vec::new());
     };
     let as_of_commit_ids = if route.as_of_commit_ids.is_empty() {
@@ -371,6 +377,11 @@ where
 
     let mut rows = Vec::new();
     for as_of_commit_id in as_of_commit_ids {
+        // A bounded caller truncates to `limit`; nothing after this point can
+        // change the rows it keeps.
+        if limit.is_some_and(|limit| rows.len() >= limit) {
+            break;
+        }
         let as_of_commit_id =
             CommitId::parse_lix(as_of_commit_id, "history lixcol_as_of_commit_id")?;
         let (entries, reachable_nodes) = {
@@ -425,6 +436,10 @@ where
                 as_of_commit_id: entry.start_commit_id.to_string(),
                 depth: entry.depth,
             });
+        }
+
+        if limit.is_some_and(|limit| rows.len() >= limit) {
+            continue;
         }
 
         let certified_commit_ids = reachable_by_id
@@ -953,6 +968,7 @@ mod tests {
             &HistoryRoute::default(),
             vec!["message".to_string()],
             HistoryMetadataProjection::default(),
+            None,
         )
         .await
         .expect("history load should succeed without commit metadata");
@@ -984,6 +1000,7 @@ mod tests {
             },
             vec!["message".to_string()],
             HistoryMetadataProjection::from_scan(&metadata_schema, &[]),
+            None,
         )
         .await
         .expect("history load should enrich commit metadata");
@@ -1027,6 +1044,7 @@ mod tests {
             },
             vec!["message".to_string()],
             HistoryMetadataProjection::from_scan(&metadata_schema, &[]),
+            None,
         )
         .await
         .expect_err("missing commit metadata must be an explicit error");

--- a/packages/lix/src/sql2/history_route.rs
+++ b/packages/lix/src/sql2/history_route.rs
@@ -317,6 +317,7 @@ pub(crate) fn commit_graph_history_request(
 ) -> Option<CommitGraphChangeHistoryRequest> {
     let schema_keys = effective_schema_keys(route, schema_keys)?;
     Some(CommitGraphChangeHistoryRequest {
+        limit: None,
         entity_pks: if route.resolved_entity_pks.is_empty() {
             route
                 .entity_pks

--- a/packages/lix/src/sql2/providers/directory_history.rs
+++ b/packages/lix/src/sql2/providers/directory_history.rs
@@ -255,6 +255,7 @@ where
         &event_route,
         vec![DIRECTORY_DESCRIPTOR_SCHEMA_KEY.to_string()],
         metadata_projection,
+        None,
     )
     .await?;
     let event_descriptors = parse_directory_history_records(&event_entries)?;

--- a/packages/lix/src/sql2/providers/entity_history.rs
+++ b/packages/lix/src/sql2/providers/entity_history.rs
@@ -204,6 +204,7 @@ where
         route,
         vec![spec.schema_key.clone()],
         metadata_projection,
+        limit,
     )
     .await?;
     let mut rows = entries

--- a/packages/lix/src/sql2/providers/file_history.rs
+++ b/packages/lix/src/sql2/providers/file_history.rs
@@ -1285,6 +1285,7 @@ where
             route,
             file_history_filesystem_schema_keys(),
             metadata_projection,
+            None,
         )
         .await;
     };
@@ -1303,6 +1304,7 @@ where
             BLOB_REF_SCHEMA_KEY.to_string(),
         ],
         metadata_projection,
+        None,
     )
     .await?;
     // Directory changes can rename or move a selected file. Their entity keys
@@ -1318,6 +1320,7 @@ where
         route,
         vec![DIRECTORY_DESCRIPTOR_SCHEMA_KEY.to_string()],
         metadata_projection,
+        None,
     )
     .await?;
     entries.extend(directories);
@@ -1381,6 +1384,7 @@ where
                     &route,
                     schema_keys,
                     metadata_projection,
+                    None,
                 )
                 .await
             }
@@ -1416,6 +1420,7 @@ where
         &owner_route,
         vec![KEY_VALUE_SCHEMA_KEY.to_string()],
         metadata_projection,
+        None,
     )
     .await?;
     parse_file_history_plugin_owners(&entries)
@@ -1614,6 +1619,7 @@ where
         &registry_route,
         vec![KEY_VALUE_SCHEMA_KEY.to_string()],
         metadata_projection,
+        None,
     )
     .await?;
 

--- a/packages/lix/src/storage_bench.rs
+++ b/packages/lix/src/storage_bench.rs
@@ -476,7 +476,19 @@ pub enum CommitGraphBenchMode {
     LegacyAllNodes,
     ReachableNodes,
     LegacyReachableNodes,
+    /// Whole reachable history for one member schema.
+    HistoryFull,
+    /// History restricted to the head commit (`lixcol_depth = 0`).
+    HistoryDepth0,
+    /// History for a bounded row demand (`LIMIT 10`).
+    HistoryLimit10,
 }
+
+/// Row demand a bounded history benchmark mode asks for.
+const COMMIT_GRAPH_BENCH_HISTORY_LIMIT: usize = 10;
+
+/// Schema key that [`seed_commit_graph_members_for_bench`] writes per commit.
+const COMMIT_GRAPH_BENCH_MEMBER_SCHEMA_KEY: &str = "commit_graph_bench_member";
 
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct CommitGraphBenchResult {
@@ -737,6 +749,36 @@ where
     let mut reader = crate::commit_graph::CommitGraphContext::new().reader(read);
     let head_commit_id =
         crate::changelog::CommitId::parse_lix(head_commit_id, "commit graph benchmark head")?;
+    if let Some((max_depth, limit)) = match mode {
+        CommitGraphBenchMode::HistoryFull => Some((None, None)),
+        CommitGraphBenchMode::HistoryDepth0 => Some((Some(0), None)),
+        CommitGraphBenchMode::HistoryLimit10 => {
+            Some((None, Some(COMMIT_GRAPH_BENCH_HISTORY_LIMIT)))
+        }
+        _ => None,
+    } {
+        let history = reader
+            .change_history_from_commit(
+                &head_commit_id,
+                &crate::commit_graph::CommitGraphChangeHistoryRequest {
+                    entity_pks: Vec::new(),
+                    schema_keys: vec![COMMIT_GRAPH_BENCH_MEMBER_SCHEMA_KEY.to_string()],
+                    file_ids: Vec::new(),
+                    min_depth: None,
+                    max_depth,
+                    include_tombstones: true,
+                    limit,
+                },
+            )
+            .await?;
+        let entries = history.entries.len();
+        std::hint::black_box(history);
+        return Ok(CommitGraphBenchResult {
+            nodes: 0,
+            edges: 0,
+            member_changes: entries,
+        });
+    }
     let nodes = match mode {
         CommitGraphBenchMode::AllNodes | CommitGraphBenchMode::LegacyAllNodes => {
             reader.all_nodes().await?
@@ -747,6 +789,9 @@ where
             .iter()
             .map(|reachable| reachable.commit.clone())
             .collect(),
+        CommitGraphBenchMode::HistoryFull
+        | CommitGraphBenchMode::HistoryDepth0
+        | CommitGraphBenchMode::HistoryLimit10 => unreachable!("history modes returned above"),
     };
     let node_count = nodes.len();
     let edges = crate::commit_graph::commit_edges(&nodes).len();
@@ -825,7 +870,7 @@ where
             &mut writes,
             &[crate::tracked_state::TrackedStateCommitDeltaRef {
                 delta: crate::tracked_state::TrackedStateDeltaRef {
-                    schema_key: "commit_graph_bench_member",
+                    schema_key: COMMIT_GRAPH_BENCH_MEMBER_SCHEMA_KEY,
                     file_id: None,
                     entity_pk: &entity_pk,
                     change_id: crate::changelog::ChangeId::for_test_label(&format!(


### PR DESCRIPTION
## What changed

`change_history_from_commit` used to materialize the **entire** reachable commit graph and load
**every** commit's delta members, and only then apply the depth range and the caller's row limit.
A history query that returns 1 row from a 50 000-commit repository paid 50 000 commit-node reads
plus 50 000 commit-delta member reads.

The bounds are now part of the walk.

**Algorithmic changes**

- `walk_reachable_nodes` is now a breadth-first walk over depth layers
  (`packages/lix/src/commit_graph/walker.rs`), exposed as a resumable `ReachableWalk` cursor.
  Breadth-first order *is* the order history rows are already published in (nearest depth first,
  commit id within a depth), so the walk can stop as soon as the depth bound is complete or the
  caller's row demand is met — and the rows it produced are exactly the prefix an unbounded read
  would have produced.
- Each depth layer is loaded with **one batched point read** (`load_nodes` → `exact_get_many`)
  instead of one storage round-trip per commit.
- **Removed** from the walk: the depth-first `visiting`/`nearest_depths` bookkeeping, the second
  pass that re-loaded every node after traversal (the old code called `load_node` twice per commit),
  and the final `O(n log n)` sort over the whole reachable set. `TraversalFrame` is gone.
- `limit` is plumbed from the DataFusion scan through `HistoryRoute` into
  `CommitGraphChangeHistoryRequest`. Only `entity_history` passes it, because it emits exactly one
  output row per entry; the row-shaping `file_history` / `directory_history` surfaces keep passing
  `None`. `load_history_entries` also skips the certified-history scan once the bound is satisfied.
- `reachable_nodes_cache` is keyed by `(head, max_depth)`; an already-materialized unbounded walk
  answers any bounded request without touching storage again.
- Cycle detection moved from the depth-first `visiting` set to the commit **generation invariant**
  that `ChangelogContext::stage_append` already enforces (`generation == max(parent generations) + 1`),
  which is the same invariant the merge-base walker relies on. The existing cycle test still passes.

**Public API / SQL surface: unchanged.** The bounded path returns the same rows the unbounded path
would return; this is verified by the new test
`commit_graph::context::tests::bounded_history_stops_traversing_instead_of_truncating`.

## Asymptotic term removed

`O(commits) node reads + O(commits) commit-delta member reads` per bounded history query →
`O(rows returned)` / `O(commits within the requested depth)`.

## A/B results

Machine: **hetzner-cpx62-III** (16 cores, 30 GB). Both arms fully prebuilt with `--no-run -j4`
before any timing; runs interleaved base→cand→base→cand, 3 reps each; load average < 0.2 at start.

- **base arm** = `exp/history-asymptotics-base` = `claude-3-optimizations` + a measurement-only
  commit that adds the three new `commit_graph_scale` modes and an *inert* `limit` field on the
  graph request. Engine behaviour in that commit is byte-for-byte the pre-existing behaviour; this
  exists so both arms run **identical benchmark source**.
- **cand arm** = `exp/history-asymptotics`.

Command:
`cargo bench -q -p lix_benchmarks --features storage-benches,slatedb --bench commit_graph_scale -- <commits> <samples> <warmups> <mode>`

### Scaling curve — the point of the change

`history_depth0` = the whole history read with `max_depth = 0` (`WHERE lixcol_depth = 0`).
`history_limit10` = the whole history read with `limit = 10` (`LIMIT 10`).
Numbers are the bench's own `median_us`, median over 3 interleaved reps.

| mode | commits | base µs | cand µs | delta |
|---|---:|---:|---:|---|
| history_depth0 | 1 000 | 1 617.4 | **10.8** | −99.3% |
| history_depth0 | 10 000 | 19 897.2 | **4.6** | −100.0% |
| history_depth0 | 50 000 | 122 986.9 | **5.1** | −100.0% |
| history_limit10 | 1 000 | 4 780.6 | **106.6** | −97.8% |
| history_limit10 | 10 000 | 62 303.3 | **43.3** | −99.9% |
| history_limit10 | 50 000 | 352 488.9 | **45.5** | −100.0% |

Base grows linearly in commit count (1 617 → 19 897 → 122 987 µs; 4 781 → 62 303 → 352 489 µs).
Candidate is flat (≈5 µs and ≈45 µs). That is the slope change, not an intercept change.

### Full-graph reads (no bound — the BFS rewrite alone)

| mode | commits | base µs | cand µs | delta |
|---|---:|---:|---:|---|
| reachable_nodes | 1 000 | 1 640.4 | 1 600.9 | −2.4% |
| reachable_nodes | 10 000 | 19 957.6 | 16 419.3 | **−17.7%** |
| reachable_nodes | 50 000 | 125 204.8 | 105 888.8 | **−15.4%** |
| history_full | 1 000 | 4 893.2 | 4 669.2 | −4.6% |
| history_full | 10 000 | 61 483.0 | 59 184.0 | −3.7% |
| history_full | 50 000 | 366 750.3 | 347 181.4 | −5.3% |
| legacy_reachable_nodes | 10 000 | 58 932.3 | 56 912.9 | −3.4% |
| legacy_reachable_nodes | 50 000 | 319 719.2 | 303 717.4 | −5.0% |
| legacy_all_nodes | 50 000 | 90 671.9 | 85 536.5 | −5.7% |
| all_nodes | 10 000 | 10 789.7 | 10 905.2 | +1.1% |
| all_nodes | 50 000 | 69 513.7 | 71 289.1 | +2.6% |

`all_nodes` does not use the walker at all, so the +2.6% was re-measured with 5 additional
interleaved reps at 50 000 commits:

```
all_nodes 50k  base n=5 med=69768 [66421, 69227, 69768, 72197, 75576]
               cand n=5 med=68346 [66784, 67468, 68346, 68491, 70665]   delta = -2.0%
```

i.e. noise, no regression.

Raw per-rep medians for the headline rows (µs):

```
history_depth0  50000  base [116624, 122987, 125800] -> cand [5, 5, 5]
history_limit10 50000  base [338798, 352489, 361663] -> cand [45, 46, 46]
reachable_nodes 50000  base [120877, 125205, 128042] -> cand [104692, 105889, 109496]
history_full    50000  base [363021, 366750, 373701] -> cand [338585, 347181, 359272]
```

## Guard metrics (must not regress)

**`merge_base_scale`** — `cargo bench ... --bench merge_base_scale -- rocksdb <scenario> 2000 merge_base 7 2 1`,
`wall_us_per_op`, per-rep median of samples 3..7, 3 interleaved reps:

| scenario | base µs/op | cand µs/op | delta |
|---|---:|---:|---|
| ancestor | 9 438.2 | 9 407.9 | −0.3% |
| deep | 13 975.4 | 13 493.0 | −3.5% |
| equal | 13.6 | 20.4 | +50% (see below) |

`equal` compares a head against itself, which returns from `merge_base` before any walk — the code
path is identical in both arms. It is a ~10 µs measurement dominated by process start-up. Re-run
with 8 interleaved reps at 200 iterations/op:

```
equal  base n=8 med=11.80 [5.58, 5.69, 5.91, 10.86, 12.74, 14.49, 16.43, 22.33]
       cand n=8 med=14.45 [6.14, 14.07, 14.16, 14.33, 14.57, 14.70, 15.84, 19.08]
```

The distributions overlap and both arms reach the same ~6 µs floor. I am reporting this honestly as
an unexplained ±10 µs noise band on an unchanged code path rather than a real regression; the
absolute cost is under 15 µs either way.

**`packed_history_scale`** — `LIX_PACKED_HISTORY_CHANGES=100000 LIX_PACKED_HISTORY_COMMIT_WIDTHS=10
LIX_PACKED_HISTORY_SAMPLES=3 LIX_PACKED_HISTORY_EXACT_SAMPLES=201 LIX_PACKED_HISTORY_BACKENDS=slatedb`,
3 interleaved reps:

| metric | base | cand | delta |
|---|---:|---:|---|
| scan_p50_ms | 189.620 | 190.476 | +0.45% |
| scan_p95_ms | 190.197 | 192.914 | +1.43% |
| exact_p50_ms | 0.0220 | 0.0234 | +6.3% (22 µs vs 23 µs — timer resolution) |
| **backend_bytes** | 6 872 648 | 6 872 382 | **−0.004%** |

**`diff_commands`** — `cargo bench -p lix_benchmarks --bench diff_commands`, 3 interleaved reps,
criterion point estimate:

| case | base µs | cand µs | delta |
|---|---:|---:|---|
| apply_100_of_1000 | 9 755.5 | 9 390.8 | −3.7% |
| partial_checkpoint_500_of_1000 | 19 299.0 | 19 042.0 | −1.3% |
| revert_100_of_1000 | 9 948.5 | 9 538.4 | −4.1% |
| working_diff_1000 | 3 432.8 | 3 425.6 | −0.2% |

`tracked_state_crud` was not re-timed: the OLTP write path does not call the commit-graph walker or
the history reader, and no file on that path is touched by this diff. Physical bytes are covered by
`packed_history_scale` `backend_bytes` above (unchanged).

## Which metrics regressed

None outside noise. The only nominally-worse numbers are `merge_base_scale equal` (+50% on a
~14 µs, code-identical path, distributions overlapping) and `packed_history_scale exact_p50_ms`
(22 µs → 23 µs, at timer resolution, on an untouched point-read path). Nothing on the OLTP, physical
bytes, or OLAP axes moved.

## Correctness gate (run on hetzner-cpx62-III, candidate worktree)

```
cargo check --workspace                                              ok
cargo clippy --workspace --all-targets --all-features -- -D warnings  ok (0 errors)
cargo test -p lix                                                     ok
  2027 passed / 0 failed / 8 ignored
   445 passed / 0 failed / 2 ignored
  + 18 passed across the remaining targets, 0 failed
  + 5 doctests passed
```

All `*history*`, `*checkpoint*`, `*merge*` and `commit_graph::*` tests pass, including the existing
cycle-detection and nearest-depth tests, plus the new bounded-traversal test.
