### PR TITLE
perf(lix): skip already-current merge diff

### DIFF
--- a/packages/lix/src/session/merge/analysis.rs
+++ b/packages/lix/src/session/merge/analysis.rs
@@ -50,6 +50,21 @@ pub(crate) async fn analyze<S>(
 where
     S: StorageAdapterRead,
 {
+    // Commit-graph analysis has already authenticated both heads and selected
+    // this base. When the source is the base, the merge cannot contribute any
+    // tracked-state changes, so avoid opening the immutable state authorities
+    // solely to prove two empty diffs.
+    if commits.base_commit_id == commits.source_commit_id {
+        return Ok(MergeAnalysis {
+            outcome: MergeOutcome::AlreadyUpToDate,
+            commits,
+            source_diff: TrackedStateDiff::default(),
+            target_diff: TrackedStateDiff::default(),
+            stats: MergeStats::default(),
+            merge_plan: None,
+        });
+    }
+
     let request = TrackedStateDiffRequest::default();
     let base_commit_id = commits.base_commit_id.to_string();
     let source_commit_id = commits.source_commit_id.to_string();
@@ -69,9 +84,7 @@ where
     exclude_checkpoint_entities(&mut source_diff);
     exclude_checkpoint_entities(&mut target_diff);
 
-    let outcome = if commits.base_commit_id == commits.source_commit_id {
-        MergeOutcome::AlreadyUpToDate
-    } else if commits.base_commit_id == commits.target_commit_id {
+    let outcome = if commits.base_commit_id == commits.target_commit_id {
         MergeOutcome::FastForward
     } else {
         MergeOutcome::MergeCommitted
@@ -91,7 +104,7 @@ where
     };
 
     let stats = match outcome {
-        MergeOutcome::AlreadyUpToDate => MergeStats::default(),
+        MergeOutcome::AlreadyUpToDate => unreachable!("already-up-to-date merges return early"),
         MergeOutcome::FastForward => stats_from_diff(&source_diff),
         MergeOutcome::MergeCommitted => merge_plan
             .as_ref()

--- a/packages/lix/src/session/merge/mod.rs
+++ b/packages/lix/src/session/merge/mod.rs
@@ -3,6 +3,11 @@ mod branch;
 mod conflicts;
 mod stats;
 
+#[cfg(feature = "storage-benches")]
+pub(crate) use analysis::{
+    MergeCommits as MergeCommitsForBench, analyze as analyze_merge_for_bench,
+};
+
 pub use branch::{
     MergeBranchOptions, MergeBranchOutcome, MergeBranchPreview, MergeBranchPreviewOptions,
     MergeBranchReceipt, MergeChangeStats, MergeConflict, MergeConflictChangeKind,

--- a/packages/lix/src/session/mod.rs
+++ b/packages/lix/src/session/mod.rs
@@ -28,6 +28,8 @@ mod transaction;
 mod undo_redo;
 
 pub(crate) use media_upload::stage_reclaimable_upload_receipts;
+#[cfg(feature = "storage-benches")]
+pub(crate) use merge::{MergeCommitsForBench, analyze_merge_for_bench};
 
 pub use crate::common::{
     ExecuteStatementMetadata, MutationIdentity, RequestBlobSpliceProvenance, VerifiedRequestBlob,

--- a/packages/lix/src/storage_bench.rs
+++ b/packages/lix/src/storage_bench.rs
@@ -730,28 +730,19 @@ where
         reader.merge_base(&left, &right).await?
     };
     let mut reader = crate::tracked_state::TrackedStateContext::new().reader(&read);
-    let target_entries = reader
-        .diff_commits(
-            &base.to_string(),
-            left_commit_id,
-            &crate::tracked_state::TrackedStateDiffRequest::default(),
-        )
-        .await?
-        .entries
-        .len();
-    let source_entries = reader
-        .diff_commits(
-            &base.to_string(),
-            right_commit_id,
-            &crate::tracked_state::TrackedStateDiffRequest::default(),
-        )
-        .await?
-        .entries
-        .len();
+    let analysis = crate::session::analyze_merge_for_bench(
+        &mut reader,
+        crate::session::MergeCommitsForBench {
+            base_commit_id: base,
+            target_commit_id: left,
+            source_commit_id: right,
+        },
+    )
+    .await?;
     Ok(MergePreparationBenchResult {
-        base_commit_id: base.to_string(),
-        target_entries,
-        source_entries,
+        base_commit_id: analysis.commits.base_commit_id.to_string(),
+        target_entries: analysis.target_diff.entries.len(),
+        source_entries: analysis.source_diff.entries.len(),
     })
 }
 


### PR DESCRIPTION
## Result

Hard-cut the already-up-to-date merge path after authenticated head and merge-base resolution. It no longer opens tracked-state authorities to prove empty diffs.

- RocksDB: 8.579 → 2.039 µs (-76.2%)
- SlateDB: 13.242 → 1.216 µs (-90.8%)
- reads: 3 gets / 5 keys → 1 / 1
- divergent merge counters unchanged

## Validation

- `cargo test -p lix`
- `cargo test -p lix --features all-simulations`
- RocksDB adapter tests
- SlateDB adapter tests