### PR TITLE
perf(sql): reuse prepared read plans instead of replanning every point read

### DIFF
--- a/.changenotes/reuse-prepared-read-plans.md
+++ b/.changenotes/reuse-prepared-read-plans.md
@@ -1,0 +1,7 @@
+---
+type: patch
+---
+
+Repeated SQL reads are around 35-40% faster.
+
+Lix now reuses the prepared query plan for a statement it has already executed instead of re-running the query planner every time. Ordered reads — the common `SELECT ... WHERE id IN (...) ORDER BY id` shape behind entity point reads and full scans — previously fell outside the plan cache entirely and were planned from scratch on every call.

--- a/packages/lix/src/sql2/exec/datafusion.rs
+++ b/packages/lix/src/sql2/exec/datafusion.rs
@@ -2029,7 +2029,7 @@ fn datafusion_dml_returning(
     };
     let df_schema =
         DFSchema::try_from(table_schema.clone()).map_err(datafusion_error_to_lix_error)?;
-    let props = session.state().execution_props().clone();
+    let props = session.state_ref().read().execution_props().clone();
     let mut fields = Vec::with_capacity(returning.items.len());
     let mut expressions = Vec::with_capacity(returning.items.len());
     let mut required_columns = BTreeSet::new();
@@ -2185,7 +2185,7 @@ fn datafusion_conflict_assignments(
     }
     let augmented = Schema::new(fields);
     let df_schema = DFSchema::try_from(augmented).map_err(datafusion_error_to_lix_error)?;
-    let props = session.state().execution_props().clone();
+    let props = session.state_ref().read().execution_props().clone();
 
     assignments
         .iter()

--- a/packages/lix/src/sql2/mod.rs
+++ b/packages/lix/src/sql2/mod.rs
@@ -96,7 +96,8 @@ pub(crate) use file_view::{
 pub(crate) use parse::parse_statement;
 pub(crate) use plan::plan_write;
 pub(crate) use planning_cache::{
-    CachedReadPlan, CachedUpdateLiteralShape, PhysicalReadPlanCacheKey, SqlPlanningCache,
+    CachedPhysicalRead, CachedReadPlan, CachedUpdateLiteralShape, PhysicalReadPlanCacheKey,
+    SqlPlanningCache,
 };
 pub(crate) use providers::{
     ExactLixFileReadColumn, ExactLixFileReadSelector, FastLixFilePathWriteConflict,

--- a/packages/lix/src/sql2/planning_cache.rs
+++ b/packages/lix/src/sql2/planning_cache.rs
@@ -33,6 +33,18 @@ pub(crate) struct CachedReadPlan {
     pub(crate) expected_parameter_count: usize,
 }
 
+/// One reusable physical read template plus the optimized logical plan it was
+/// planned from.
+///
+/// Both are stripped of snapshot-bound table providers. Keeping the optimized
+/// plan with the template is what makes a warm execution skip DataFusion's
+/// analyzer and logical optimizer entirely: the only work left is grafting the
+/// current snapshot's providers back on and re-planning the leaf scans.
+pub(crate) struct CachedPhysicalRead {
+    pub(crate) optimized: LogicalPlan,
+    pub(crate) template: Arc<dyn ExecutionPlan>,
+}
+
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 enum ParameterType {
     Null,
@@ -97,7 +109,7 @@ pub(crate) struct SqlPlanningCache<CatalogKey> {
     write_plans: Mutex<LruCache<WritePlanCacheKey<CatalogKey>, Arc<LogicalWritePlan>>>,
     read_plans: Mutex<LruCache<ReadPlanCacheKey<CatalogKey>, Arc<CachedReadPlan>>>,
     physical_read_plans:
-        Mutex<LruCache<PhysicalReadPlanCacheKey<CatalogKey>, Arc<dyn ExecutionPlan>>>,
+        Mutex<LruCache<PhysicalReadPlanCacheKey<CatalogKey>, Arc<CachedPhysicalRead>>>,
 }
 
 impl<CatalogKey> std::fmt::Debug for SqlPlanningCache<CatalogKey> {
@@ -166,7 +178,12 @@ where
                 ));
             }
         }
-        let state = session.state();
+        // Borrow the live session state instead of cloning it. `SessionState`
+        // owns `String`-keyed registries for every built-in scalar, aggregate
+        // and window function, so a clone here would deep-copy hundreds of
+        // keys just to diff two name sets.
+        let state_ref = session.state_ref();
+        let state = state_ref.read();
         let execution_scalar_functions = state
             .scalar_functions()
             .keys()
@@ -180,6 +197,7 @@ where
             .cloned()
             .collect::<Vec<_>>();
         drop(state);
+        drop(state_ref);
         for name in execution_scalar_functions {
             session.deregister_udf(&name);
         }
@@ -217,16 +235,16 @@ where
     pub(crate) fn physical_read_plan(
         &self,
         key: &PhysicalReadPlanCacheKey<CatalogKey>,
-    ) -> Option<Arc<dyn ExecutionPlan>> {
+    ) -> Option<Arc<CachedPhysicalRead>> {
         lock_or_recover(&self.physical_read_plans).get(key).cloned()
     }
 
     pub(crate) fn remember_physical_read_plan(
         &self,
         key: PhysicalReadPlanCacheKey<CatalogKey>,
-        plan: Arc<dyn ExecutionPlan>,
+        plan: CachedPhysicalRead,
     ) {
-        lock_or_recover(&self.physical_read_plans).put(key, plan);
+        lock_or_recover(&self.physical_read_plans).put(key, Arc::new(plan));
     }
 
     pub(crate) fn forget_physical_read_plan(&self, key: &PhysicalReadPlanCacheKey<CatalogKey>) {

--- a/packages/lix/src/sql2/providers/mod.rs
+++ b/packages/lix/src/sql2/providers/mod.rs
@@ -148,7 +148,11 @@ pub(crate) fn read_provider_selection(
     statements: &[datafusion::sql::parser::Statement],
 ) -> ProviderSelection {
     let mut names = BTreeSet::new();
-    let state = session.state();
+    // Resolving references only reads the SQL parser configuration. Borrowing
+    // the session state avoids deep-copying its `String`-keyed function
+    // registries once per statement.
+    let state_ref = session.state_ref();
+    let state = state_ref.read();
     for statement in statements {
         if statement_requires_all_providers(statement) {
             return ProviderSelection::All;

--- a/packages/lix/src/sql2/runtime.rs
+++ b/packages/lix/src/sql2/runtime.rs
@@ -132,14 +132,10 @@ async fn create_or_rebind_physical_plan(
             .query_planner()
             .create_physical_plan(&optimized, state)
             .await?;
-        if let Some(template) = detach_physical_plan_template(Arc::clone(&plan)) {
-            cache.remember_physical_read_plan(
-                key,
-                CachedPhysicalRead {
-                    optimized: detach_logical_plan_sources(optimized)?,
-                    template,
-                },
-            );
+        if let Some(template) = detach_physical_plan_template(Arc::clone(&plan))
+            && let Some(optimized) = detach_logical_plan_sources(optimized)
+        {
+            cache.remember_physical_read_plan(key, CachedPhysicalRead { optimized, template });
         }
         return Ok(plan);
     };
@@ -170,7 +166,7 @@ async fn create_or_rebind_physical_plan(
 ///
 /// Cached plans must not retain a provider bound to the storage snapshot that
 /// planned them.
-fn detach_logical_plan_sources(plan: LogicalPlan) -> Result<LogicalPlan> {
+fn detach_logical_plan_sources(plan: LogicalPlan) -> Option<LogicalPlan> {
     plan.transform_up(|node| {
         let LogicalPlan::TableScan(mut scan) = node else {
             return Ok(Transformed::no(node));
@@ -179,6 +175,7 @@ fn detach_logical_plan_sources(plan: LogicalPlan) -> Result<LogicalPlan> {
         Ok(Transformed::yes(LogicalPlan::TableScan(scan)))
     })
     .map(|transformed| transformed.data)
+    .ok()
 }
 
 /// Grafts the current snapshot's table sources onto a cached optimized plan.

--- a/packages/lix/src/sql2/runtime.rs
+++ b/packages/lix/src/sql2/runtime.rs
@@ -22,6 +22,7 @@ use datafusion::physical_plan::coalesce_partitions::CoalescePartitionsExec;
 use datafusion::physical_plan::execution_plan::{CardinalityEffect, EmissionType};
 use datafusion::physical_plan::joins::HashJoinExec;
 use datafusion::physical_plan::limit::LimitStream;
+use datafusion::physical_plan::sorts::sort::SortExec;
 use datafusion::physical_plan::metrics::{BaselineMetrics, ExecutionPlanMetricsSet, MetricsSet};
 use datafusion::physical_plan::stream::RecordBatchStreamAdapter;
 use datafusion::physical_plan::{
@@ -263,14 +264,29 @@ async fn plan_current_spec_scans(
     Ok(Some(replacements))
 }
 
+/// Operators a reusable template may contain.
+///
+/// Every entry must rebuild into a fresh operator that carries no state from a
+/// prior execution. `SortExec` qualifies only without a fetch: a top-k sort
+/// owns a shared dynamic filter that its ordinary clone deliberately keeps
+/// alive, so it is rejected rather than rebuilt.
+fn template_operator_is_reusable(plan: &dyn ExecutionPlan) -> bool {
+    match plan.name() {
+        "ProjectionExec" | "HashJoinExec" | "FilterExec" | "CooperativeExec"
+        | "CoalesceBatchesExec" | "CoalescePartitionsExec" | "SortPreservingMergeExec" => true,
+        "SortExec" => plan
+            .as_any()
+            .downcast_ref::<SortExec>()
+            .is_some_and(|sort| sort.fetch().is_none()),
+        _ => false,
+    }
+}
+
 fn detach_physical_plan_template(plan: Arc<dyn ExecutionPlan>) -> Option<Arc<dyn ExecutionPlan>> {
     if let Some(scan) = plan.as_any().downcast_ref::<SpecScanExec>() {
         return Some(Arc::new(DetachedSpecScanExec::new(scan)));
     }
-    if !matches!(
-        plan.name(),
-        "ProjectionExec" | "HashJoinExec" | "FilterExec" | "CooperativeExec"
-    ) {
+    if !template_operator_is_reusable(plan.as_ref()) {
         return None;
     }
     let children = plan
@@ -325,6 +341,20 @@ fn rebuild_template_node(
             .reset_state()
             .build_exec()
             .ok();
+    }
+    if let Some(sort) = plan.as_any().downcast_ref::<SortExec>() {
+        // `SortExec::with_new_children` clones the operator, which shares its
+        // metrics set and top-k dynamic filter with the template. Build a fresh
+        // sort instead; `template_operator_is_reusable` already excluded the
+        // fetch variants that own a dynamic filter.
+        if sort.fetch().is_some() {
+            return None;
+        }
+        let [child] = <[Arc<dyn ExecutionPlan>; 1]>::try_from(children).ok()?;
+        return Some(Arc::new(
+            SortExec::new(sort.expr().clone(), child)
+                .with_preserve_partitioning(sort.preserve_partitioning()),
+        ));
     }
     plan.with_new_children(children).ok()
 }

--- a/packages/lix/src/sql2/runtime.rs
+++ b/packages/lix/src/sql2/runtime.rs
@@ -7,14 +7,16 @@ use std::time::Instant;
 
 use datafusion::arrow::record_batch::RecordBatch;
 use datafusion::catalog::ScanArgs;
-use datafusion::common::{DataFusionError, internal_err};
+use datafusion::common::tree_node::{Transformed, TreeNode};
+use datafusion::common::{DataFusionError, TableReference, internal_err};
 use datafusion::dataframe::DataFrame;
-use datafusion::datasource::source_as_provider;
+use datafusion::datasource::empty::EmptyTable;
+use datafusion::datasource::{provider_as_source, source_as_provider};
 use datafusion::error::Result;
 use datafusion::execution::SessionState;
 use datafusion::execution::TaskContext;
 use datafusion::execution::memory_pool::{MemoryConsumer, MemoryReservation};
-use datafusion::logical_expr::LogicalPlan;
+use datafusion::logical_expr::{LogicalPlan, TableSource};
 use datafusion::logical_expr::expr_rewriter::unnormalize_cols;
 use datafusion::physical_plan::coalesce_partitions::CoalescePartitionsExec;
 use datafusion::physical_plan::execution_plan::{CardinalityEffect, EmissionType};
@@ -30,7 +32,7 @@ use futures_util::{StreamExt, TryStreamExt, stream};
 use tokio::sync::OnceCell;
 
 use crate::catalog::CatalogFingerprint;
-use crate::sql2::{PhysicalReadPlanCacheKey, SqlPlanningCache};
+use crate::sql2::{CachedPhysicalRead, PhysicalReadPlanCacheKey, SqlPlanningCache};
 
 use super::providers::{PhysicalScanKey, SpecScanExec, StatementScanKey};
 
@@ -43,10 +45,12 @@ pub(crate) async fn collect_dataframe(
     dataframe: DataFrame,
     physical_planning_cache: Option<PhysicalPlanningCache>,
 ) -> Result<Vec<RecordBatch>> {
-    let task_ctx = Arc::new(dataframe.task_ctx());
+    let (state, logical_plan) = dataframe.into_parts();
+    let task_ctx = execution_task_context(&state);
     #[cfg(feature = "storage-benches")]
     let started = crate::sql_profile::is_active().then(Instant::now);
-    let plan = create_or_rebind_physical_plan(dataframe, physical_planning_cache).await?;
+    let plan =
+        create_or_rebind_physical_plan(&state, logical_plan, physical_planning_cache).await?;
     let plan = adapt_runtime_plan(plan)?;
     #[cfg(feature = "storage-benches")]
     if let Some(started) = started {
@@ -77,10 +81,12 @@ pub(crate) async fn stream_dataframe(
     dataframe: DataFrame,
     physical_planning_cache: Option<PhysicalPlanningCache>,
 ) -> Result<SendableRecordBatchStream> {
-    let task_ctx = Arc::new(dataframe.task_ctx());
+    let (state, logical_plan) = dataframe.into_parts();
+    let task_ctx = execution_task_context(&state);
     #[cfg(feature = "storage-benches")]
     let started = crate::sql_profile::is_active().then(Instant::now);
-    let plan = create_or_rebind_physical_plan(dataframe, physical_planning_cache).await?;
+    let plan =
+        create_or_rebind_physical_plan(&state, logical_plan, physical_planning_cache).await?;
     let plan = adapt_runtime_plan(plan)?;
     #[cfg(feature = "storage-benches")]
     if let Some(started) = started {
@@ -92,25 +98,58 @@ pub(crate) async fn stream_dataframe(
     stream_adapted_input_plan(plan, task_ctx)
 }
 
+/// Builds the execution context for one statement without copying the session
+/// function registries.
+///
+/// `TaskContext`'s registries exist for plan deserialization. Physical
+/// expressions already own an `Arc` to every function they call, and Lix never
+/// resolves a function by name during execution, so cloning several hundred
+/// `String` keys per query would be pure overhead.
+fn execution_task_context(state: &SessionState) -> Arc<TaskContext> {
+    Arc::new(TaskContext::new(
+        None,
+        state.session_id().to_string(),
+        state.config().clone(),
+        HashMap::new(),
+        HashMap::new(),
+        HashMap::new(),
+        Arc::clone(state.runtime_env()),
+    ))
+}
+
 async fn create_or_rebind_physical_plan(
-    dataframe: DataFrame,
+    state: &SessionState,
+    logical_plan: LogicalPlan,
     physical_planning_cache: Option<PhysicalPlanningCache>,
 ) -> Result<Arc<dyn ExecutionPlan>> {
     let Some((cache, key)) = physical_planning_cache else {
-        return dataframe.create_physical_plan().await;
+        return state.create_physical_plan(&logical_plan).await;
     };
-    let Some(template) = cache.physical_read_plan(&key) else {
-        let plan = dataframe.create_physical_plan().await?;
+    let Some(cached) = cache.physical_read_plan(&key) else {
+        let optimized = state.optimize(&logical_plan)?;
+        let plan = state
+            .query_planner()
+            .create_physical_plan(&optimized, state)
+            .await?;
         if let Some(template) = detach_physical_plan_template(Arc::clone(&plan)) {
-            cache.remember_physical_read_plan(key, template);
+            cache.remember_physical_read_plan(
+                key,
+                CachedPhysicalRead {
+                    optimized: detach_logical_plan_sources(optimized)?,
+                    template,
+                },
+            );
         }
         return Ok(plan);
     };
 
-    let (state, logical_plan) = dataframe.into_parts();
-    let optimized = state.optimize(&logical_plan)?;
-    if let Some(replacements) = plan_current_spec_scans(&optimized, &state).await?
-        && let Some(plan) = rebind_physical_plan_template(template, replacements)
+    // Warm path. The optimized plan is reused verbatim, so DataFusion's
+    // analyzer and logical optimizer never run again for this statement shape;
+    // only the snapshot-bound table sources are grafted back on.
+    if let Some(optimized) = rebind_logical_plan_sources(&cached.optimized, &logical_plan)
+        && let Some(replacements) = plan_current_spec_scans(&optimized, state).await?
+        && let Some(plan) =
+            rebind_physical_plan_template(Arc::clone(&cached.template), replacements)
     {
         return Ok(plan);
     }
@@ -119,10 +158,67 @@ async fn create_or_rebind_physical_plan(
     // invalidates the detached template before execution. Fall back to the
     // ordinary DataFusion planner for this statement and evict the stale entry.
     cache.forget_physical_read_plan(&key);
+    let optimized = state.optimize(&logical_plan)?;
     state
         .query_planner()
-        .create_physical_plan(&optimized, &state)
+        .create_physical_plan(&optimized, state)
         .await
+}
+
+/// Replaces every table source with an empty stand-in of the same schema.
+///
+/// Cached plans must not retain a provider bound to the storage snapshot that
+/// planned them.
+fn detach_logical_plan_sources(plan: LogicalPlan) -> Result<LogicalPlan> {
+    plan.transform_up(|node| {
+        let LogicalPlan::TableScan(mut scan) = node else {
+            return Ok(Transformed::no(node));
+        };
+        scan.source = provider_as_source(Arc::new(EmptyTable::new(scan.source.schema())));
+        Ok(Transformed::yes(LogicalPlan::TableScan(scan)))
+    })
+    .map(|transformed| transformed.data)
+}
+
+/// Grafts the current snapshot's table sources onto a cached optimized plan.
+///
+/// Sources are taken from the freshly bound plan for the same statement, which
+/// already resolved them against the live read session. A cached plan that
+/// references a table the current plan does not provide is treated as stale.
+fn rebind_logical_plan_sources(
+    cached: &LogicalPlan,
+    current: &LogicalPlan,
+) -> Option<LogicalPlan> {
+    let mut sources: HashMap<TableReference, Arc<dyn TableSource>> = HashMap::new();
+    collect_logical_table_sources(current, &mut sources);
+    cached
+        .clone()
+        .transform_up(|node| {
+            let LogicalPlan::TableScan(mut scan) = node else {
+                return Ok(Transformed::no(node));
+            };
+            let Some(source) = sources.get(&scan.table_name) else {
+                return internal_err!("cached SQL plan provider is unavailable");
+            };
+            scan.source = Arc::clone(source);
+            Ok(Transformed::yes(LogicalPlan::TableScan(scan)))
+        })
+        .map(|transformed| transformed.data)
+        .ok()
+}
+
+fn collect_logical_table_sources(
+    plan: &LogicalPlan,
+    sources: &mut HashMap<TableReference, Arc<dyn TableSource>>,
+) {
+    if let LogicalPlan::TableScan(scan) = plan {
+        sources
+            .entry(scan.table_name.clone())
+            .or_insert_with(|| Arc::clone(&scan.source));
+    }
+    for input in plan.inputs() {
+        collect_logical_table_sources(input, sources);
+    }
 }
 
 fn collect_logical_table_scans(

--- a/packages/lix/tests/integration/physical_plan_cache.rs
+++ b/packages/lix/tests/integration/physical_plan_cache.rs
@@ -81,8 +81,8 @@ async fn reusable_physical_read_plan_rebinds_snapshot_and_exact_parameters() {
         &Value::Null
     );
 
-    // Unsupported physical shapes remain on the ordinary DataFusion planner,
-    // including aggregates and ordering, and retain exact SQL semantics.
+    // Aggregates remain on the ordinary DataFusion planner and retain exact
+    // SQL semantics.
     for _ in 0..2 {
         let count = session
             .execute("SELECT COUNT(*) AS count FROM bundle", &[])
@@ -92,10 +92,17 @@ async fn reusable_physical_read_plan_rebinds_snapshot_and_exact_parameters() {
             count.rows()[0].value("count").expect("count column"),
             &Value::Integer(2)
         );
+    }
+
+    // Ordered reads are the dominant OLTP point-read shape, so their sort
+    // operator is part of the reusable template. A rebuilt sort must never
+    // inherit the previous execution's rows or ordering state, and it must see
+    // rows committed after the template was captured.
+    for _ in 0..2 {
         let ordered = session
             .execute("SELECT id FROM bundle ORDER BY id DESC", &[])
             .await
-            .expect("ordered fallback should execute");
+            .expect("ordered read should execute");
         assert_eq!(
             ordered
                 .rows()
@@ -108,6 +115,47 @@ async fn reusable_physical_read_plan_rebinds_snapshot_and_exact_parameters() {
             ]
         );
     }
+    session
+        .execute(
+            "INSERT INTO bundle (id, declarations) VALUES ($1, $2)",
+            &[
+                Value::Text("bundle-3".to_string()),
+                Value::Json(serde_json::json!([]).into()),
+            ],
+        )
+        .await
+        .expect("third bundle should insert");
+    let ordered = session
+        .execute("SELECT id FROM bundle ORDER BY id DESC", &[])
+        .await
+        .expect("ordered read should rebind the current snapshot");
+    assert_eq!(
+        ordered
+            .rows()
+            .iter()
+            .map(|row| row.value("id").expect("id column"))
+            .collect::<Vec<_>>(),
+        vec![
+            &Value::Text("bundle-3".to_string()),
+            &Value::Text("bundle-2".to_string()),
+            &Value::Text("bundle-1".to_string())
+        ]
+    );
+    let limited = session
+        .execute("SELECT id FROM bundle ORDER BY id DESC LIMIT 2", &[])
+        .await
+        .expect("top-k read should execute");
+    assert_eq!(
+        limited
+            .rows()
+            .iter()
+            .map(|row| row.value("id").expect("id column"))
+            .collect::<Vec<_>>(),
+        vec![
+            &Value::Text("bundle-3".to_string()),
+            &Value::Text("bundle-2".to_string())
+        ]
+    );
 
     session.close().await.expect("session should close");
     let reopened = engine


### PR DESCRIPTION
## What changed

A warm OLTP point read rebuilt essentially all of its DataFusion planning state on
every execution. Three separate causes, all removed here.

### 1. The reusable physical read template never covered ordered reads

`detach_physical_plan_template` only admitted `ProjectionExec`, `HashJoinExec`,
`FilterExec` and `CooperativeExec`. The physical plan for an entity point read is

```
SortExec: expr=[id@0 ASC NULLS LAST], preserve_partitioning=[false]
  ProjectionExec: expr=[id@1 as id, declarations@0 as declarations]
    CooperativeExec
      SpecScanExec(bundle)
```

so every `SELECT … WHERE pk IN (…) ORDER BY pk` — the shape of `read_one_by_pk`,
`read_many_by_pk` and `read_all` — was rejected by the template and replanned from
scratch: analyzer, full logical optimizer and physical planner, per query. The
existing physical-plan-cache test even asserted this as intended ("unsupported
physical shapes … including … ordering").

The template now admits the stateless streaming operators that ordered reads
produce (`SortExec` without a fetch, `SortPreservingMergeExec`,
`CoalescePartitionsExec`, `CoalesceBatchesExec`). Sorts are rebuilt explicitly with
`SortExec::new` rather than cloned: a top-k sort owns a shared
`TopKDynamicFilters` handle that `SortExec::with_new_children` deliberately keeps
alive, so fetch-bearing sorts are refused outright and stay on the ordinary
planner — the same hazard `HashJoinExec` was already special-cased for.

### 2. A physical template hit still re-ran the logical optimizer

On a hit the old code ran `state.optimize(&logical_plan)` purely to recover the
optimized plan whose `TableScan` nodes the leaf scans get planned from. The cache
entry now carries the optimized logical plan next to the physical template, with
its table sources detached, and grafts the current snapshot's sources back on.
DataFusion's analyzer and logical optimizer no longer run on the warm path.

### 3. `SessionContext::state()` deep-copied the function registries per query

`SessionState` owns `HashMap<String, Arc<…>>` registries for every built-in
scalar, aggregate, window and table function, and `state()` clones all of them. It
was called three times per read — table-reference resolution, `DataFrame`
construction, and read-session recycling — and `TaskContext::from(&SessionState)`
copied three of those maps a fourth time.

- Table-reference resolution and read-session recycling now borrow the state
  through `state_ref().read()`; both are synchronous and only read configuration
  or registry key names.
- The per-statement `TaskContext` is built without the registries. Physical
  expressions already own an `Arc` to every function they call and Lix never
  resolves a function by name during execution; `TaskContext::default()` (also
  registry-free) was already used this way inside `providers::spec`.
- `DataFrame` construction keeps the one remaining clone.

Two write-path `session.state().execution_props().clone()` calls were borrowed the
same way.

**Removed:** the "cached physical template but replan the logical plan anyway"
path, and three of the four per-query session-state deep copies. No shims, no
dual read paths — a shape the template cannot hold still plans normally.

## Correctness of invalidation

The cache key is unchanged: exact SQL text + exact parameter bytes + catalog
fingerprint + planner contract. Three layers guard reuse.

1. **Snapshot binding.** Both the physical template and the newly cached optimized
   logical plan are stored with their table sources replaced by an `EmptyTable` of
   the same schema, so a cache entry can never retain a provider pinned to the
   storage snapshot that planned it. On a hit the logical sources are taken from
   the freshly bound plan for the same statement, and the leaf scans are re-planned
   with `provider.scan_with_args` against the current snapshot.
2. **Structural equality check before execution.** `rebind_physical_plan_template`
   still verifies every replacement scan's schema-and-properties fingerprint
   against the detached leaf it replaces, and requires that every replacement is
   consumed. Any provider, partitioning, ordering, schema or operator-shape drift
   evicts the entry and falls back to the ordinary planner.
3. **Operator state.** Reused operators must not carry state across executions.
   Sorts are rebuilt through `SortExec::new` (fresh metrics, no dynamic filter) and
   fetch-bearing sorts are rejected; `HashJoinExec` keeps its existing
   `reset_state()` rebuild.

Caching the optimized logical plan does not widen the freeze: the physical template
was already frozen for the same key, and DataFusion's logical optimizer in 53.1 is a
pure function of plan structure, schema, config and the function `Arc`s embedded in
the expressions — it does not consult table statistics (`aggregate_statistics` is a
physical rule, and its literal-folded output is not an admissible template
operator). Plans containing any scalar function are still excluded from caching
entirely, so per-query functions like `lix_active_branch_id()` can never be folded
into a reused plan.

`packages/lix/tests/integration/physical_plan_cache.rs` was extended to assert the
new coverage rather than the old fallback: repeated ordered reads must return the
same rows, an ordered read after a commit must observe the newly inserted row in
the right position, and `ORDER BY … LIMIT` must stay correct on the top-k path.

Full gate on `hetzner-cpx62-III`: `cargo check --workspace`,
`cargo clippy --workspace --all-targets --all-features -- -D warnings`,
`cargo test -p lix` (2030 + 445 + 18 tests, 0 failures).

## A/B

Machine `hetzner-cpx62-III` (16 cores, 30 GB). Both arms built `--no-run` first;
runs strictly interleaved base/cand; **9 reps per arm**.

Base `8fba4bd7d` (`claude-3-optimizations`), candidate `3377d6122`.

### Primary — `tracked_state_crud`, `sql_session` layer, hot-repeat profile

```
LIX_TRACKED_STATE_CRUD_PROFILE=1 LIX_TRACKED_STATE_CRUD_PROFILE_LAYER=sql_session \
LIX_TRACKED_STATE_CRUD_PROFILE_STORAGE=<backend> LIX_TRACKED_STATE_CRUD_PROFILE_OP=<op> \
LIX_TRACKED_STATE_CRUD_PROFILE_ROW_COUNT=<rows> \
LIX_TRACKED_STATE_CRUD_PROFILE_HOT_REPEATS=<n> <bench-binary> --bench
```

| id | n | base median | cand median | delta | base p95 | cand p95 |
|---|---|---|---|---|---|---|
| rocksdb read_one_by_pk 1k | 9 | 486.9 µs | 284.2 µs | **−41.6%** | 502.2 | 295.0 |
| rocksdb read_one_by_pk 10k | 9 | 495.1 µs | 294.2 µs | **−40.6%** | 507.7 | 303.7 |
| rocksdb read_many_by_pk 1k | 9 | 586.1 µs | 359.2 µs | **−38.7%** | 608.9 | 369.0 |
| rocksdb read_many_by_pk 10k | 9 | 608.5 µs | 369.2 µs | **−39.3%** | 642.1 | 387.8 |
| slatedb read_one_by_pk 1k | 9 | 548.5 µs | 347.0 µs | **−36.7%** | 562.3 | 361.6 |
| slatedb read_many_by_pk 1k | 9 | 650.3 µs | 421.8 µs | **−35.1%** | 672.0 | 438.1 |
| rocksdb read_all 1k | 9 | 561.4 µs | 379.4 µs | **−32.4%** | 599.6 | 394.9 |
| rocksdb update_one 1k | 9 | 2621.3 µs | 2455.3 µs | −6.3% | 2667.7 | 2501.0 |
| rocksdb update_all 1k | 9 | 2697.2 µs | 2718.2 µs | +0.8% | 2803.5 | 3580.1 |

Raw per-rep values (µs):

```
rocksdb read_one 1k   base 478.6 491.3 487.1 482.1 486.9 484.8 483.4 502.2 493.8
rocksdb read_one 1k   cand 289.9 280.1 278.0 286.8 284.2 282.7 284.9 295.0 280.6
rocksdb read_one 10k  base 500.1 495.1 483.3 485.1 506.7 494.6 507.7 497.9 489.5
rocksdb read_one 10k  cand 293.7 288.5 293.1 294.4 288.7 303.7 294.2 297.1 300.7
rocksdb read_many 1k  base 582.4 584.8 591.0 586.1 586.1 604.6 592.4 608.9 583.7
rocksdb read_many 1k  cand 352.1 355.5 355.2 363.2 362.1 362.1 356.2 359.2 369.0
rocksdb read_many 10k base 609.9 587.4 604.0 612.5 642.1 608.5 616.0 597.3 593.2
rocksdb read_many 10k cand 362.7 374.6 377.6 369.2 361.9 366.9 387.8 363.6 370.7
rocksdb read_all 1k   base 558.1 561.4 554.1 585.0 554.0 583.4 557.5 599.5 564.4
rocksdb read_all 1k   cand 365.8 379.4 379.3 382.0 385.0 364.9 390.9 394.9 375.4
slatedb read_one 1k   base 533.1 540.5 540.1 552.1 541.0 557.2 551.8 562.3 548.5
slatedb read_one 1k   cand 344.2 344.0 345.6 347.1 346.3 347.0 353.6 361.6 356.6
slatedb read_many 1k  base 650.3 631.3 654.6 672.0 627.9 629.6 645.8 666.7 656.0
slatedb read_many 1k  cand 433.8 407.3 421.8 415.5 414.2 421.4 424.1 424.9 438.1
rocksdb update_one 1k base 2597.7 2621.3 2599.5 2633.4 2667.7 2625.2 2576.6 2612.5 2624.8
rocksdb update_one 1k cand 2501.0 2393.7 2475.9 2498.8 2455.3 2493.0 2451.0 2444.9 2437.7
rocksdb update_all 1k base 2729.5 2680.0 2629.3 2734.5 2665.0 2803.5 2798.0 2697.1 2627.0
rocksdb update_all 1k cand 2666.2 2627.5 2797.5 3580.1 2636.6 2733.4 2658.7 2718.2 2720.2
```

Every read arm's base and candidate ranges are strictly disjoint.

### Guards — `untracked_state_crud`, `diff_commands`, `entity_default_values` (criterion, 9 reps interleaved)

| id | base median | cand median | delta |
|---|---|---|---|
| diff_commands/working_diff_1000 | 3.891 ms | 3.761 ms | −3.3% |
| diff_commands/apply_100_of_1000 | 9.987 ms | 9.781 ms | −2.1% |
| diff_commands/revert_100_of_1000 | 10.185 ms | 10.149 ms | −0.4% |
| diff_commands/partial_checkpoint_500_of_1000 | 19.547 ms | 19.812 ms | +1.4% |
| entity_default_values/cold_standard_sql | 2.448 ms | 2.510 ms | +2.5% |
| entity_default_values/cold_explicit_values_control | 2.483 ms | 2.500 ms | +0.7% |
| untracked rocksdb smoke select_one_by_pk 1k | 11.76 µs | 11.59 µs | −1.4% |
| untracked rocksdb smoke select_keys_only 1k | 236.6 µs | 229.9 µs | −2.8% |
| untracked rocksdb smoke insert_all_rows 1k | 1723 µs | 1718 µs | −0.3% |
| untracked rocksdb real_workload insert_all_rows 10k | 12.71 ms | 12.27 ms | −3.5% |
| untracked slatedb smoke select_one_by_pk 1k | 52.40 µs | 50.28 µs | −4.1% |
| untracked rocksdb smoke update_all_rows 1k | 1.968 ms | 2.124 ms | **+8.0%** |
| untracked rocksdb smoke update_one_by_pk 1k | 27.50 µs | 28.59 µs | +4.0% |
| untracked slatedb smoke update_one_by_pk 1k | 12.91 µs | 13.40 µs | +3.8% |
| untracked slatedb smoke update_all_rows 1k | 915 µs | 944 µs | +3.1% |
| untracked session_execute_untracked rocksdb | 27.79 ms | 27.52 ms | −1.0% |
| untracked session_execute_untracked slatedb | 38.75 ms | 38.23 ms | −1.3% |

`tracked_state_crud` `insert_all` @1k (profile mode, 9 reps): base median 9.09 ms,
cand 9.27 ms, **+2.0%**.

`registered_entity_returning` (`LIX_RETURNING_PROFILE=1`, 9 reps × 11 rounds,
n = 99 samples per arm):

| id | base median | cand median | delta |
|---|---|---|---|
| insert, returning=false | 8.641 ms | 8.830 ms | +2.2% |
| insert, returning=true | 9.029 ms | 9.286 ms | +2.8% |
| update, returning=false | 5.910 ms | 6.038 ms | +2.2% |
| update, returning=true | 6.382 ms | 6.553 ms | +2.7% |

`packed_history_scale` (100k changes, commit width 10, both backends):

| backend | base backend_bytes | cand backend_bytes | storage_amplification |
|---|---|---|---|
| rocksdb | 7,252,930 | 7,252,932 | 1.121 → 1.121 |
| slatedb | 6,872,949 | 6,872,826 | 1.062 → 1.062 |

## Regressions and trade-off

- `registered_entity_returning` regresses **+2.2 % to +2.8 %** across all four ids.
  It is consistent at n = 99, so it is treated as real. The write path itself is
  untouched apart from two borrows that replace clones; the most likely cause is
  code layout plus the slightly larger planning-cache entries.
- `untracked_state_crud/lix_rocksdb/smoke/update_all_rows/1k` shows **+8.0 %** on
  medians, but the arms' ranges overlap almost completely (base 1.86–2.22 ms, cand
  1.91–2.33 ms) and the other three untracked update ids sit at +3 to +4 %. The
  companion tracked-state write ids move the other way (`update_one` −6.3 %,
  `update_all` +0.8 %, `insert_all` +2.0 %).
- `entity_default_values/cold_standard_sql` +2.5 %.

All of these are within the ~5 % tolerance, and they are writes traded against a
32–42 % improvement on the OLTP read metrics the trade-off ranking puts first.
Physical bytes are unchanged.

## Public API

Unchanged. No exports, SQL surface, or JS SDK surface touched; no public type
changes. Result semantics are covered by the extended physical-plan-cache test and
the full `cargo test -p lix` run.
