### PR TITLE
fix(bench): repair storage_v2 scan-chunking asserts and add a row-consuming read bench

### DIFF
--- a/packages/engine-benchmarks/benches/storage_v2.rs
+++ b/packages/engine-benchmarks/benches/storage_v2.rs
@@ -1935,15 +1935,19 @@ fn assert_scan_drain_stats(stats: &ScanDrainStats, case: &ScanChunkingCase) {
     assert_eq!(stats.read_stats.scan_full_value_chunks, 0);
 
     match case.scan {
+        // Only the prefix mode lowers a `Prefix` into a `KeyRange`, so
+        // `prefix_lowered` belongs to the prefix arm. The two expectations
+        // were swapped, which stayed invisible while the page-count assert
+        // above aborted the target first.
         ScanChunkingMode::Range => {
             assert_eq!(stats.read_stats.range_scan_chunks, expected_chunks as u64);
             assert_eq!(stats.read_stats.prefix_scan_chunks, 0);
-            assert_eq!(stats.read_stats.prefix_lowered, 1);
+            assert_eq!(stats.read_stats.prefix_lowered, 0);
         }
         ScanChunkingMode::Prefix => {
             assert_eq!(stats.read_stats.range_scan_chunks, 0);
             assert_eq!(stats.read_stats.prefix_scan_chunks, expected_chunks as u64);
-            assert_eq!(stats.read_stats.prefix_lowered, 0);
+            assert_eq!(stats.read_stats.prefix_lowered, 1);
         }
     }
 }

--- a/packages/engine-benchmarks/benches/storage_v2.rs
+++ b/packages/engine-benchmarks/benches/storage_v2.rs
@@ -16,9 +16,9 @@ use criterion::{
 };
 use lix::storage::{
     BeginScanOptions, CommitResult, CoreProjection, GetManyRequest, GetManyResult, GetOptions, Key,
-    KeyRange, Memory, Prefix, ProjectedValue, PutBatch, PutEntry, ReadOptions, ScanChunk,
-    ScanCursor, SpaceId, Storage, StorageError, StorageRead, StorageScanSource, StorageWrite,
-    StoredValue, WriteOptions, WriteStats,
+    KeyRange, MAX_SCAN_PAGE_ROWS, Memory, Prefix, ProjectedValue, PutBatch, PutEntry, ReadOptions,
+    ScanChunk, ScanCursor, SpaceId, Storage, StorageError, StorageRead, StorageScanSource,
+    StorageWrite, StoredValue, WriteOptions, WriteStats,
 };
 use lix::storage_adapter::{
     PointReadPlan, StorageAdapter, StorageAdapterRead, StorageAdapterReadScope, StorageReadStats,
@@ -119,6 +119,24 @@ struct ScanChunkingCase {
     rows: usize,
     chunk_size: usize,
     scan: ScanChunkingMode,
+}
+
+/// `ScanCursor::next_page` clamps the requested limit to
+/// [`MAX_SCAN_PAGE_ROWS`], so a case may request a larger page than the cursor
+/// will ever hand back. Every page-count expectation must be derived from the
+/// clamped size, not from the requested one.
+fn effective_page_rows(chunk_size: usize) -> usize {
+    chunk_size.min(MAX_SCAN_PAGE_ROWS)
+}
+
+impl ScanChunkingCase {
+    fn effective_chunk_size(&self) -> usize {
+        effective_page_rows(self.chunk_size)
+    }
+
+    fn expected_chunks(&self) -> usize {
+        self.rows.div_ceil(self.effective_chunk_size())
+    }
 }
 
 #[derive(Clone, Copy)]
@@ -348,6 +366,9 @@ const DELETE_RANGE_CASES: &[DeleteRangeCase] = &[
     },
 ];
 
+// The `_single` cases request a page larger than the whole seeded range on
+// purpose: they exercise the `ScanCursor` clamp to `MAX_SCAN_PAGE_ROWS`, so
+// they drain in `rows / MAX_SCAN_PAGE_ROWS` pages rather than one.
 const SCAN_CHUNKING_CASES: &[ScanChunkingCase] = &[
     ScanChunkingCase {
         name: "drain_range_q10000_single",
@@ -916,7 +937,10 @@ where
                     .expect("delete range fallback");
                     assert_eq!(stats.scanned, case.rows);
                     assert_eq!(stats.deleted, case.rows);
-                    assert_eq!(stats.chunks, case.rows.div_ceil(case.chunk_size));
+                    assert_eq!(
+                        stats.chunks,
+                        case.rows.div_ceil(effective_page_rows(case.chunk_size))
+                    );
                     assert_eq!(stats.write_stats.staged_deletes, case.rows as u64);
                     black_box(stats);
                 },
@@ -1094,7 +1118,7 @@ where
                     ))
                     .expect("drain chunked materialized scan");
                     assert_eq!(stats.scanned, case.rows);
-                    assert_eq!(stats.chunks, case.rows.div_ceil(case.chunk_size));
+                    assert_eq!(stats.chunks, case.expected_chunks());
                     assert_scan_drain_stats(&stats, case);
                     black_box(stats);
                 });
@@ -1829,6 +1853,10 @@ where
     R: StorageRead,
 {
     let mut stats = ScanDrainStats::default();
+    // The cursor clamps every requested page to `MAX_SCAN_PAGE_ROWS`; account
+    // for that here so the recorded limit stats describe the pages the cursor
+    // actually served.
+    let effective_chunk = effective_page_rows(chunk_size);
     let (range, prefix) = match scan {
         ScanChunkingMode::Range => (point_scan_range(), false),
         ScanChunkingMode::Prefix => (
@@ -1863,9 +1891,11 @@ where
         stats.read_stats.storage_calls += 1;
         stats.read_stats.scan_rows += entries.len() as u64;
         stats.read_stats.scan_has_more += u64::from(chunk.has_more);
-        stats.read_stats.scan_limit_rows_total += chunk_size as u64;
-        stats.read_stats.scan_limit_rows_max =
-            stats.read_stats.scan_limit_rows_max.max(chunk_size as u64);
+        stats.read_stats.scan_limit_rows_total += effective_chunk as u64;
+        stats.read_stats.scan_limit_rows_max = stats
+            .read_stats
+            .scan_limit_rows_max
+            .max(effective_chunk as u64);
         stats.read_stats.scan_key_only_chunks += 1;
         if prefix {
             stats.read_stats.prefix_scan_chunks += 1;
@@ -1880,13 +1910,14 @@ where
 
     assert_eq!(
         stats.storage_calls,
-        expected_rows.div_ceil(chunk_size) as u64
+        expected_rows.div_ceil(effective_chunk) as u64
     );
     Ok(stats)
 }
 
 fn assert_scan_drain_stats(stats: &ScanDrainStats, case: &ScanChunkingCase) {
-    let expected_chunks = case.rows.div_ceil(case.chunk_size);
+    let effective_chunk = case.effective_chunk_size();
+    let expected_chunks = case.expected_chunks();
     let expected_has_more = expected_chunks.saturating_sub(1) as u64;
 
     assert_eq!(stats.read_stats.storage_calls, expected_chunks as u64);
@@ -1894,9 +1925,9 @@ fn assert_scan_drain_stats(stats: &ScanDrainStats, case: &ScanChunkingCase) {
     assert_eq!(stats.read_stats.scan_has_more, expected_has_more);
     assert_eq!(
         stats.read_stats.scan_limit_rows_total,
-        (expected_chunks * case.chunk_size) as u64
+        (expected_chunks * effective_chunk) as u64
     );
-    assert_eq!(stats.read_stats.scan_limit_rows_max, case.chunk_size as u64);
+    assert_eq!(stats.read_stats.scan_limit_rows_max, effective_chunk as u64);
     assert_eq!(
         stats.read_stats.scan_key_only_chunks,
         expected_chunks as u64

--- a/packages/engine-benchmarks/benches/storage_v2.rs
+++ b/packages/engine-benchmarks/benches/storage_v2.rs
@@ -2008,7 +2008,7 @@ where
         .await?;
 
     loop {
-        let chunk = cursor.next_page(lix::storage::MAX_SCAN_PAGE_ROWS).await?;
+        let chunk = cursor.next_page(MAX_SCAN_PAGE_ROWS).await?;
         let has_more = chunk.has_more;
         entries.extend(chunk.entries);
 

--- a/packages/engine-benchmarks/benches/tracked_state_crud/main.rs
+++ b/packages/engine-benchmarks/benches/tracked_state_crud/main.rs
@@ -1289,6 +1289,16 @@ fn bench_sql_session(
             BatchSize::LargeInput,
         );
     });
+    group.bench_function(
+        format!("read_all_rows_consumed/{}", row_label(rows.len())),
+        |b| {
+            b.iter_batched_ref(
+                || runtime.block_on(sql_session::seeded_fixture(profile, &rows)),
+                |fixture| black_box(runtime.block_on(fixture.read_all_rows_consumed())),
+                BatchSize::LargeInput,
+            );
+        },
+    );
     group.bench_function(format!("read_one_by_pk/{}", row_label(rows.len())), |b| {
         b.iter_batched_ref(
             || runtime.block_on(sql_session::seeded_fixture(profile, &rows)),

--- a/packages/engine-benchmarks/benches/tracked_state_crud/sql_session.rs
+++ b/packages/engine-benchmarks/benches/tracked_state_crud/sql_session.rs
@@ -29,6 +29,33 @@ const GENERAL_AGGREGATE_SQL: &str = "SELECT COUNT(*) AS rows, MIN(path) AS first
     FROM json_pointer WHERE path IS NOT NULL";
 type SharedParameterBatch = PreparedDmlParameterBatch;
 
+/// Folds one public cell into an accumulator, reading the whole payload.
+///
+/// Every variant is walked byte by byte so a value that only *looks*
+/// materialized — a lazily decoded string, a JSON payload that still has to be
+/// realized, a blob that has not been copied yet — has to pay its real cost
+/// inside the timing window. The result is returned so nothing can be dropped
+/// as dead code.
+fn fold_value(accumulator: u64, value: &Value) -> u64 {
+    fn fold_bytes(mut accumulator: u64, tag: u8, bytes: &[u8]) -> u64 {
+        accumulator = accumulator.rotate_left(5) ^ u64::from(tag);
+        for byte in bytes {
+            accumulator = accumulator.wrapping_mul(0x0000_0100_0000_01b3) ^ u64::from(*byte);
+        }
+        accumulator
+    }
+
+    match value {
+        Value::Null => fold_bytes(accumulator, 0, &[]),
+        Value::Boolean(value) => fold_bytes(accumulator, 1, &[u8::from(*value)]),
+        Value::Integer(value) => fold_bytes(accumulator, 2, &value.to_le_bytes()),
+        Value::Real(value) => fold_bytes(accumulator, 3, &value.to_bits().to_le_bytes()),
+        Value::Text(value) => fold_bytes(accumulator, 4, value.as_bytes()),
+        Value::Json(value) => fold_bytes(accumulator, 5, value.as_bytes()),
+        Value::Blob(value) => fold_bytes(accumulator, 6, value.as_bytes()),
+    }
+}
+
 fn empty_parameter_batch() -> SharedParameterBatch {
     PreparedDmlParameterBatch::from_rows(std::iter::empty::<Vec<Value>>())
         .expect("empty prepared parameter batch is valid")
@@ -535,6 +562,14 @@ impl SqlFixture {
         }
     }
 
+    pub(crate) async fn read_all_rows_consumed(&self) -> u64 {
+        match self {
+            Self::RocksDB(fixture) => fixture.read_all_rows_consumed().await,
+            #[cfg(feature = "slatedb")]
+            Self::SlateDB(fixture) => fixture.read_all_rows_consumed().await,
+        }
+    }
+
     pub(crate) async fn read_many_by_pk(&self) -> usize {
         match self {
             Self::RocksDB(fixture) => fixture.read_many_by_pk().await,
@@ -1011,6 +1046,30 @@ where
 
     async fn read_all_result(&self) -> ExecuteResult {
         execute(&self.session, &self.select_all_sql).await
+    }
+
+    /// `read_all` stops at `ExecuteResult::len()`. That does force row
+    /// materialization, but nothing ever looks *inside* a row, so per-cell
+    /// consumer costs stay unmeasured and a change that defers work past
+    /// result construction could still show a win here. This variant walks
+    /// every row and every cell and folds each one into an accumulator, so
+    /// no deferred per-cell work can hide behind the timing window.
+    async fn read_all_rows_consumed(&self) -> u64 {
+        let result = self.read_all_result().await;
+        assert_eq!(result.len(), self.visible_row_count);
+        let columns = result.columns().len();
+        let mut consumed = 0_u64;
+        let mut cells = 0_usize;
+        for row in result.rows() {
+            let values = row.values();
+            assert_eq!(values.len(), columns);
+            for value in values {
+                consumed = fold_value(consumed, value);
+                cells += 1;
+            }
+        }
+        assert_eq!(cells, self.visible_row_count * columns);
+        std::hint::black_box(consumed)
     }
 
     async fn read_many_by_pk(&self) -> usize {


### PR DESCRIPTION
## What changed

Two dead benchmark targets, both broken by **benchmark assertions**, not by the engine.
Plus one new bench that measures something no existing bench measured.

### 1. `storage_v2` panicked at the first `scan_chunking` case (bench bug)

```
STORAGE_V2_BENCH_SMOKE=1 cargo bench -p lix_benchmarks --features storage-benches --bench storage_v2
thread 'main' panicked at packages/engine-benchmarks/benches/storage_v2.rs:1881:5:
assertion `left == right` failed
  left: 10
 right: 1
```

`storage_v2/scan_chunking/*/materialized/drain_range_q10000_single` seeds 10 000 rows and asks
for a page of 10 001, then asserts the drain took `rows.div_ceil(chunk_size)` = **1** page.

`ScanCursor::next_page` clamps every requested limit to `MAX_SCAN_PAGE_ROWS` (1024) — documented on
the method (`packages/lix/src/storage/cursor.rs:61-82`) and applied unconditionally
(`let page_size = limit_rows.min(MAX_SCAN_PAGE_ROWS)`). 10 000 rows therefore drain in
`10_000.div_ceil(1024)` = **10** pages. The engine did exactly what its contract says; the bench
modelled the *requested* page size instead of the served one.

Every page-count and limit-row expectation is now derived from the clamped size
(`effective_page_rows`), in the drain helper, in `assert_scan_drain_stats`, and in the
`delete_range_fallback` call site (whose cases are all ≤ 1024 today, so this is hardening).

The two `_single` cases are kept: asking for more than `MAX_SCAN_PAGE_ROWS` is the only coverage of
the clamp path, and that is now stated in a comment next to the case list.

### 2. A second, masked bench bug: swapped `prefix_lowered` expectations

Fixing (1) exposed a panic 60 lines further down:

```
packages/engine-benchmarks/benches/storage_v2.rs:1941: left: 0, right: 1
```

`assert_scan_drain_stats` expected `prefix_lowered == 1` for `ScanChunkingMode::Range` and `0` for
`ScanChunkingMode::Prefix`. Only the prefix mode lowers a `Prefix` into a `KeyRange`, and the drain
helper (correctly) sets the counter only there. The two expectations were swapped. This had never
been reachable because the case that panics in (1) is the first case in the matrix.

`storage_v2` now runs to completion.

### 3. New `read_all_rows_consumed` bench

`read_all` stops at `ExecuteResult::len()`. That is **not** a batch row-count shortcut — `len()`
goes through `rows()` → `OnceLock::get_or_init(materialize_rows)`, so rows are fully materialized
inside the timing window. But nothing ever looks *inside* a row, so per-cell consumer costs are
unmeasured, and a change that defers work past result construction would not be caught.

`read_all_rows_consumed/{1k,10k}` runs the same query and then walks every row and every cell,
folding each payload's bytes into an accumulator. Lazily realized text, JSON or blob payloads have to
be paid for inside the window.

What it buys us, on `ryzen-9950x-V` (median of 3 runs, `sql_session` layer):

| id | `read_all_rows` | `read_all_rows_consumed` | consumer-side cost |
|---|---|---|---|
| rocksdb/smoke/1k | 0.866 ms | 1.172 ms | +35.3% |
| slatedb/smoke/1k | 1.014 ms | 1.272 ms | +25.5% |
| rocksdb/real_workload/10k | 2.717 ms | 3.872 ms | +42.5% |
| slatedb/real_workload/10k | 2.739 ms | 3.898 ms | +42.3% |

Roughly 40% of end-to-end read cost at 10k sits *after* `len()` and was invisible to every existing
read benchmark.

## Public API

Unchanged. Bench-only.

## What regressed

Nothing. No engine code is touched, and no existing bench id changed shape or workload — only the
assertions around `scan_chunking` (which never produced a result before) and one added id.

## Correctness

- `cargo check --workspace` — clean
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` — clean
- `cargo test -p lix` — unaffected (no `packages/lix` change); run on `ryzen-9950x-V`
- `STORAGE_V2_BENCH_SMOKE=1 cargo bench ... --bench storage_v2` — runs to completion

Machine: `ryzen-9950x-V` (32 cores, 186 GB), idle.

## `scan_chunking` results, now that they exist

12 ids (2 storage families × 6 cases), 10 000 rows each, `STORAGE_V2_BENCH_SMOKE=1`:

| case | in_memory | rocksdb_temp |
|---|---|---|
| `drain_range_q10000_single` (req 10 001 → 1024) | 451.4 µs | 928.2 µs |
| `drain_range_q10000_chunk1` | 855.4 µs | 1.350 ms |
| `drain_range_q10000_chunk10` | 496.2 µs | 859.9 µs |
| `drain_range_q10000_chunk100` | 458.5 µs | 867.4 µs |
| `drain_prefix_q10000_chunk10` | 493.7 µs | 831.8 µs |
| `drain_prefix_q10000_single` (req 10 001 → 1024) | 452.0 µs | 911.3 µs |

The clamp is visible in the numbers: the `_single` cases match `chunk100` rather than beating it,
because they are really 1024-row pages, not one 10 000-row page.
