### PR TITLE
fix(sql): stop the read plan cache from retaining snapshot-bound subquery scans

### DIFF
--- a/.changenotes/fix-subquery-read-plan-cache.md
+++ b/.changenotes/fix-subquery-read-plan-cache.md
@@ -1,0 +1,7 @@
+---
+type: patch
+---
+
+Fixed SQL reads that contain a subquery failing with `LIX_STORAGE_ERROR: shared storage read still has N active handles`.
+
+Statements using `IN (SELECT ...)`, `EXISTS (SELECT ...)` or a scalar subquery were placed in the query planning cache together with the storage read they were planned against, which kept that read alive after the query finished and made the statement error out. These statements now skip the planning cache, so they execute normally.

--- a/packages/lix/src/sql2/exec/datafusion.rs
+++ b/packages/lix/src/sql2/exec/datafusion.rs
@@ -424,7 +424,9 @@ async fn create_logical_plan_in_session_from_parsed(
     validate_history_anchor_predicates_in_logical_plan(&plan)?;
     let json_predicate_params = json_predicate_params_in_logical_plan(&plan);
 
-    let physical_plan_cacheable = cacheable_statement && !logical_plan_has_scalar_function(&plan);
+    let physical_plan_cacheable = cacheable_statement
+        && !logical_plan_has_scalar_function(&plan)
+        && !logical_plan_has_subquery_expression(&plan);
     if physical_plan_cacheable && let Some((cache, catalog)) = &session.planning_environment {
         cache.remember_read_plan(
             sql,
@@ -507,6 +509,43 @@ async fn rebind_cached_read_plan(
     })
     .map(|transformed| transformed.data)
     .map_err(datafusion_error_to_lix_error)
+}
+
+/// Reports whether any expression in `plan` carries a nested subquery plan.
+///
+/// `LogicalPlan`'s tree traversal walks plan inputs only; the plans hidden
+/// inside `Expr::ScalarSubquery`, `Expr::InSubquery` and `Expr::Exists` are
+/// invisible to it. `detach_cached_read_plan` therefore cannot swap their
+/// `TableScan` sources for placeholders, so caching such a plan would park
+/// live snapshot-bound providers in an engine-lifetime LRU: the read scope
+/// then fails `finish()` with leaked handles, and a later cache hit would
+/// execute against a storage read that has already been released.
+///
+/// Planning-cache participation is an optimization, so the safe answer is to
+/// keep these statements out of the cache entirely rather than grow a second
+/// subquery-aware rewrite path that has to stay in sync with `detach`/`rebind`.
+fn logical_plan_has_subquery_expression(plan: &LogicalPlan) -> bool {
+    let mut found = false;
+    let _ = plan.apply(|node| {
+        for expression in node.expressions() {
+            let _ = expression.apply(|expression| {
+                if matches!(
+                    expression,
+                    Expr::ScalarSubquery(_) | Expr::InSubquery(_) | Expr::Exists(_)
+                ) {
+                    found = true;
+                    Ok(TreeNodeRecursion::Stop)
+                } else {
+                    Ok(TreeNodeRecursion::Continue)
+                }
+            });
+            if found {
+                return Ok(TreeNodeRecursion::Stop);
+            }
+        }
+        Ok(TreeNodeRecursion::Continue)
+    });
+    found
 }
 
 fn logical_plan_has_scalar_function(plan: &LogicalPlan) -> bool {

--- a/packages/lix/tests/integration/sql.rs
+++ b/packages/lix/tests/integration/sql.rs
@@ -110,6 +110,7 @@ mod lix_key_value;
 mod lix_registered_schema;
 mod metadata;
 mod read_only;
+mod subquery_reads;
 mod udfs;
 mod untracked_current_state;
 mod write_returning;

--- a/packages/lix/tests/integration/sql/subquery_reads.rs
+++ b/packages/lix/tests/integration/sql/subquery_reads.rs
@@ -1,0 +1,64 @@
+use lix::Value;
+
+/// Reads whose logical plan carries a nested subquery plan must not park
+/// snapshot-bound table providers in the engine planning cache.
+///
+/// `LogicalPlan`'s tree traversal only walks plan inputs, so the plans inside
+/// `Expr::ScalarSubquery`, `Expr::InSubquery` and `Expr::Exists` never reach
+/// `detach_cached_read_plan`. Caching such a plan left live providers — and
+/// therefore live storage-read handles — in an engine-lifetime LRU, which made
+/// the read scope fail with `LIX_STORAGE_ERROR: shared storage read still has
+/// N active handles` and left a released read reachable from the cache.
+///
+/// Each statement is executed twice so a cache entry written by the first run
+/// would be exercised by the second.
+simulation_test!(subquery_reads_do_not_leak_storage_read_handles, |sim| async move {
+    let engine = sim.boot_engine().await;
+    let session = sim.wrap_session(
+        engine
+            .open_workspace_session()
+            .await
+            .expect("main session should open"),
+        &engine,
+    );
+
+    for (index, key) in ["sq-a", "sq-b", "sq-c"].into_iter().enumerate() {
+        session
+            .execute(
+                "INSERT INTO lix_key_value (key, value) VALUES (?, ?)",
+                &[
+                    Value::Text(key.to_string()),
+                    Value::Text(format!("value-{index}")),
+                ],
+            )
+            .await
+            .expect("seed insert should succeed");
+    }
+
+    let statements = [
+        "SELECT key FROM lix_key_value \
+         WHERE key IN (SELECT key FROM lix_key_value WHERE key = 'sq-a')",
+        "SELECT key FROM lix_key_value AS outer_kv \
+         WHERE EXISTS (SELECT 1 FROM lix_key_value AS inner_kv WHERE inner_kv.key = outer_kv.key) \
+           AND key = 'sq-b'",
+        "SELECT key FROM lix_key_value \
+         WHERE key = (SELECT MIN(key) FROM lix_key_value WHERE key LIKE 'sq-%')",
+        "SELECT key FROM lix_key_value \
+         WHERE key NOT IN (SELECT key FROM lix_key_value WHERE key <> 'sq-c') \
+           AND key LIKE 'sq-%'",
+    ];
+
+    for sql in statements {
+        for attempt in 0..2 {
+            let result = session
+                .execute(sql, &[])
+                .await
+                .unwrap_or_else(|error| panic!("attempt {attempt} of `{sql}` failed: {error:?}"));
+            assert_eq!(
+                result.len(),
+                1,
+                "attempt {attempt} of `{sql}` returned the wrong row count"
+            );
+        }
+    }
+});

--- a/packages/lix/tests/integration/sql/subquery_reads.rs
+++ b/packages/lix/tests/integration/sql/subquery_reads.rs
@@ -1,17 +1,17 @@
 use lix::Value;
 
-/// Reads whose logical plan carries a nested subquery plan must not park
-/// snapshot-bound table providers in the engine planning cache.
-///
-/// `LogicalPlan`'s tree traversal only walks plan inputs, so the plans inside
-/// `Expr::ScalarSubquery`, `Expr::InSubquery` and `Expr::Exists` never reach
-/// `detach_cached_read_plan`. Caching such a plan left live providers — and
-/// therefore live storage-read handles — in an engine-lifetime LRU, which made
-/// the read scope fail with `LIX_STORAGE_ERROR: shared storage read still has
-/// N active handles` and left a released read reachable from the cache.
-///
-/// Each statement is executed twice so a cache entry written by the first run
-/// would be exercised by the second.
+// Reads whose logical plan carries a nested subquery plan must not park
+// snapshot-bound table providers in the engine planning cache.
+//
+// `LogicalPlan`'s tree traversal only walks plan inputs, so the plans inside
+// `Expr::ScalarSubquery`, `Expr::InSubquery` and `Expr::Exists` never reach
+// `detach_cached_read_plan`. Caching such a plan left live providers — and
+// therefore live storage-read handles — in an engine-lifetime LRU, which made
+// the read scope fail with `LIX_STORAGE_ERROR: shared storage read still has
+// N active handles` and left a released read reachable from the cache.
+//
+// Each statement is executed twice so a cache entry written by the first run
+// would be exercised by the second.
 simulation_test!(subquery_reads_do_not_leak_storage_read_handles, |sim| async move {
     let engine = sim.boot_engine().await;
     let session = sim.wrap_session(


### PR DESCRIPTION
## The bug

`packages/lix/src/sql2/exec/datafusion.rs` caches session read plans. Because a `TableProvider` is
bound to one storage read snapshot, the cache stores a **detached** copy: `detach_cached_read_plan`
swaps every `TableScan` source for an `EmptyTable` placeholder, and `rebind_cached_read_plan` puts
the current session's providers back on a cache hit. That contract is what makes an
engine-lifetime LRU safe to hold plans at all.

`LogicalPlan`'s `TreeNode` traversal walks **plan inputs only**. The `LogicalPlan`s nested inside
`Expr::ScalarSubquery`, `Expr::InSubquery` and `Expr::Exists` are invisible to it, so their
`TableScan`s never reach the detach rewrite and were cached **with their live providers attached**.

Consequences, in order of severity:

1. `SharedStorageAdapterRead::finish()` (`storage_adapter/read_scope.rs:66-75`) found the escaped
   `Arc` clones and failed the whole statement with
   `LIX_STORAGE_ERROR: shared storage read still has 3 active handles`.
2. `with_static_session_sql_read` widens the storage read to `'static` behind `unsafe`
   (`session/execute.rs`) on the documented invariant that it is dropped before the call returns.
   `finish()` failing means that invariant was violated: a released read stayed reachable from an
   engine-lifetime cache. In the `tpch` bench this reliably ends in **SIGSEGV during unwinding**
   (`process didn't exit successfully: ... (signal: 11, SIGSEGV: invalid memory reference)`).

**Every session SQL read containing a subquery was broken**, not just the benchmark — there was no
end-to-end session test covering one. New regression test
`packages/lix/tests/integration/sql/subquery_reads.rs` fails on `claude-3-optimizations` with the
exact error and passes here:

```
thread '...' panicked at packages/lix/tests/integration/sql/subquery_reads.rs:56:41:
attempt 0 of `SELECT key FROM lix_key_value WHERE key IN (SELECT key FROM lix_key_value WHERE key = 'sq-a')`
failed: LixError { code: "LIX_STORAGE_ERROR", message: "io error: shared storage read still has 3 active handles" }
```

## The fix

`logical_plan_has_subquery_expression` gates `physical_plan_cacheable`, alongside the existing
`logical_plan_has_scalar_function` gate. Statements carrying a nested subquery plan skip
planning-cache participation entirely (both the logical `read_plans` LRU and the derived
`physical_read_plans` LRU).

**Deliberately not** a second subquery-aware rewrite path. `detach` and `rebind` must stay exactly
symmetric — if a future traversal reaches a scan on one side but not the other, the failure mode is
a silent `EmptyTable` execution returning **wrong rows**, not a loud error. Planning-cache
participation is an optimization; the read-scope invariant is not. Skipping is the cut that cannot
be got wrong.

No performance is lost relative to correct behaviour: these statements never completed before, so
they never benefited from the cache.

## What this unblocks: the OLAP axis

`tpch` aborted after Q1 on every branch to date (PR #1286 called it out as pre-existing).
**9 of 22 TPC-H queries abort on `claude-3-optimizations` @ `57e770a81`** — Q2, Q4, Q11, Q15, Q16,
Q17, Q18, Q20, Q21 — all with `still has 3 active handles`. Q22 survives only because it uses
`substr`, which already disqualified it via the scalar-function gate. The abort still reproduces
identically after #1295's physical-template work, so this is orthogonal to that change.

The full suite now runs end to end. `cargo bench -p lix_benchmarks --features storage-benches,tpch,slatedb --bench tpch`,
`LIX_TPCH_SAMPLES=11`, SF 0.01, pristine overlay, `ryzen-9950x-V` idle, single process Q1→Q22.
This is the project's first complete OLAP measurement:

| Q | duckdb med | rocksdb med | rocksdb p90 | slatedb med | slatedb p90 | lix/duckdb (rocks) | scan rows |
|---|---|---|---|---|---|---|---|
| 1 | 2.624 | 3.128 | 3.169 | 3.084 | 3.143 | 1.19x | 60175 |
| 2 | 2.082 | 5.403 | 5.439 | 5.926 | 5.974 | 2.59x | 10252 |
| 3 | 1.798 | 2.183 | 2.203 | 2.212 | 2.267 | 1.21x | 75512 |
| 4 | 2.245 | 1.527 | 1.543 | 1.566 | 1.575 | 0.68x | 75175 |
| 5 | 2.216 | 3.318 | 3.322 | 3.626 | 3.658 | 1.50x | 76801 |
| 6 | 0.783 | 1.079 | 1.097 | 1.091 | 1.103 | 1.38x | 60175 |
| 7 | 2.589 | 4.884 | 4.937 | 5.124 | 5.286 | 1.89x | 76779 |
| 8 | 2.363 | 5.111 | 5.131 | 5.468 | 5.508 | 2.16x | 78826 |
| 9 | 2.704 | 4.258 | 4.339 | 4.416 | 4.570 | 1.57x | 85300 |
| 10 | 2.593 | 3.108 | 3.188 | 3.200 | 3.295 | 1.20x | 31427 |
| 11 | 1.107 | 3.117 | 3.130 | 3.398 | 3.434 | 2.82x | 16102 |
| 12 | 2.518 | 2.810 | 2.856 | 2.864 | 2.911 | 1.12x | 75175 |
| 13 | 1.380 | 3.860 | 3.887 | 3.891 | 3.920 | 2.80x | 16500 |
| 14 | 1.170 | 1.456 | 1.464 | 1.459 | 1.487 | 1.24x | 62175 |
| 15 | 1.489 | 2.871 | 2.886 | 2.983 | 2.990 | 1.93x | 60275 |
| 16 | 1.503 | 2.379 | 2.404 | 2.457 | 2.463 | 1.58x | 10100 |
| 17 | 0.807 | 2.256 | 2.295 | 2.258 | 2.266 | 2.79x | 120588 |
| 18 | 2.204 | 4.215 | 4.317 | 4.107 | 4.221 | 1.91x | 76675 |
| 19 | 1.920 | 2.258 | 2.278 | 2.246 | 2.262 | 1.18x | 17023 |
| 20 | 2.314 | 3.262 | 3.279 | 3.431 | 3.473 | 1.41x | 70276 |
| 21 | 4.029 | 5.239 | 5.255 | 5.341 | 5.455 | 1.30x | 127755 |
| 22 | 1.297 | 2.185 | 2.205 | 2.152 | 2.171 | 1.69x | 18000 |
Both backends track each other closely (slatedb 0–9% behind rocksdb). Lix ranges from 0.68x
(Q4 — faster than DuckDB) to 2.82x DuckDB, median ~1.5x. The heaviest relative gaps are the
correlated-subquery and grouped-aggregate shapes: Q2 2.59x, Q11 2.82x, Q13 2.80x, Q17 2.79x.

## A/B: this change is perf-neutral

Per-query, interleaved base/cand, `LIX_TPCH_SAMPLES=11`, one process per query, base
`claude-3-optimizations` @ `57e770a81`. Nine queries have no base number because base aborts on them.

| Q | rocksdb base → cand | slatedb base → cand |
|---|---|---|
| 1 | 3.122 → 3.135 (+0.4%) | 3.080 → 3.093 (+0.4%) |
| 2 | **ABORT** → 5.322 | **ABORT** → 5.794 |
| 3 | 2.228 → 2.166 (-2.7%) | 2.257 → 2.215 (-1.9%) |
| 4 | **ABORT** → 1.603 | **ABORT** → 1.591 |
| 5 | 3.380 → 3.360 (-0.6%) | 3.667 → 3.621 (-1.2%) |
| 6 | 1.109 → 1.089 (-1.8%) | 1.089 → 1.084 (-0.5%) |
| 7 | 5.250 → 4.958 (-5.6%) | 5.353 → 5.186 (-3.1%) |
| 8 | 5.079 → 5.167 (+1.7%) | 5.389 → 5.568 (+3.3%) |
| 9 | 4.343 → 4.291 (-1.2%) | 4.529 → 4.335 (-4.3%) |
| 10 | 3.110 → 3.127 (+0.6%) | 3.140 → 3.142 (+0.1%) |
| 11 | **ABORT** → 3.184 | **ABORT** → 3.373 |
| 12 | 2.791 → 2.802 (+0.4%) | 2.841 → 2.813 (-1.0%) |
| 13 | 3.909 → 3.966 (+1.4%) | 3.913 → 3.913 (-0.0%) |
| 14 | 1.486 → 1.480 (-0.4%) | 1.451 → 1.452 (+0.1%) |
| 15 | **ABORT** → 2.912 | **ABORT** → 2.960 |
| 16 | **ABORT** → 2.371 | **ABORT** → 2.438 |
| 17 | **ABORT** → 2.186 | **ABORT** → 2.200 |
| 18 | **ABORT** → 4.400 | **ABORT** → 4.312 |
| 19 | 2.197 → 2.263 (+3.0%) | 2.173 → 2.263 (+4.1%) |
| 20 | **ABORT** → 3.247 | **ABORT** → 3.414 |
| 21 | **ABORT** → 5.445 | **ABORT** → 5.462 |
| 22 | 2.172 → 2.114 (-2.7%) | 2.125 → 2.123 (-0.1%) |
Eight ids fell outside ±2% at 1 rep/arm, in both directions (Q7 −5.6%, Q9 −4.3%, Q19 +4.1%,
Q8 +3.3%, Q3 −2.7%, Q22 −2.7%). Per the runbook's ≥9-rep floor for any claim under 20%, all six
affected queries were re-measured at **9 interleaved reps per arm**. Every one collapsed to within
±1.0%, with fully overlapping raw ranges:

| id | base med (n=9, range) | cand med (n=9, range) | delta |
|---|---|---|---|
| Q3 rocksdb | 2.217 (2.160-2.264) | 2.208 (2.156-2.259) | -0.4% |
| Q3 slatedb | 2.225 (2.201-2.277) | 2.230 (2.181-2.293) | +0.3% |
| Q7 rocksdb | 5.014 (4.953-5.122) | 5.066 (4.978-5.244) | +1.0% |
| Q7 slatedb | 5.241 (5.144-5.353) | 5.216 (5.158-5.328) | -0.5% |
| Q8 rocksdb | 5.132 (5.094-5.184) | 5.145 (5.105-5.226) | +0.3% |
| Q8 slatedb | 5.516 (5.417-5.548) | 5.530 (5.417-5.600) | +0.3% |
| Q9 rocksdb | 4.298 (4.249-4.336) | 4.323 (4.259-4.374) | +0.6% |
| Q9 slatedb | 4.427 (4.357-4.556) | 4.442 (4.338-4.542) | +0.3% |
| Q19 rocksdb | 2.220 (2.191-2.249) | 2.224 (2.208-2.268) | +0.2% |
| Q19 slatedb | 2.215 (2.171-2.241) | 2.225 (2.207-2.255) | +0.5% |
| Q22 rocksdb | 2.142 (2.090-2.184) | 2.146 (2.095-2.170) | +0.2% |
| Q22 slatedb | 2.109 (2.052-2.152) | 2.100 (2.088-2.133) | -0.4% |
That is the expected result: the gate adds one plan traversal at first-planning time, and none of
these six queries contains a subquery, so their caching behaviour is unchanged.

## What regressed

Nothing measurable. Subquery statements no longer reuse a cached plan, so they pay full logical and
physical planning on every execution — but they previously did not execute at all, so there is no
arm to regress against. If subquery plan caching later shows up in a profile, the follow-up is a
subquery-aware `detach`/`rebind` pair guarded by a post-detach assertion that no live provider
survived the rewrite.

## Public API

Unchanged. No exports, SQL surface, or JS SDK surface touched. Behaviourally this only turns
previously-failing statements into succeeding ones.

## Correctness

Run on `ryzen-9950x-V`, on the rebased branch:

- `cargo check --workspace` — clean
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` — clean
- `cargo test -p lix` — **2031 passed, 0 failed**, 8 ignored (plus every other target: 446, 5, 3, 3, 2, 2, 1, 1, 1 — all ok)
- New `sql::subquery_reads::subquery_reads_do_not_leak_storage_read_handles` — passes here, **fails on base**
- Full TPC-H Q1–Q22 completes, with per-query DuckDB result equivalence asserted by the bench itself
