### PR TITLE
fix(js-sdk): convert wasm JSON values into lix::Json

### DIFF
--- a/packages/js-sdk/native/wasm.rs
+++ b/packages/js-sdk/native/wasm.rs
@@ -727,7 +727,9 @@ impl TryFrom<LixValueDto> for Value {
                 .and_then(|value| value.as_str().map(ToOwned::to_owned))
                 .map(Self::Text)
                 .ok_or_else(|| invalid_param("text value must be a string")),
-            "json" => Ok(Self::Json(value.value.unwrap_or(serde_json::Value::Null))),
+            "json" => Ok(Self::Json(
+                value.value.unwrap_or(serde_json::Value::Null).into(),
+            )),
             "blob" => value
                 .blob
                 .map(|bytes| Self::Blob(bytes.into_vec().into()))


### PR DESCRIPTION
## The bug

PR #1286 changed `Value::Json` to carry the `lix::Json` newtype and updated the napi bridge
(`packages/js-sdk/native/napi.rs:1806` has `.into()`), but the wasm bridge was missed:

```rust
// packages/js-sdk/native/wasm.rs:730 — before
"json" => Ok(Self::Json(value.value.unwrap_or(serde_json::Value::Null))),
```

`cargo check --workspace` cannot catch this because `wasm.rs` only compiles for `wasm32`, which is
why the Native suite passed while **JS SDK Browser Test** failed. The failure predates this PR on
`claude-3-optimizations` and reproduces identically on #1298, #1299 and #1300.

## Verification

`cargo check -p lix_js_sdk --target wasm32-unknown-unknown` — **clean** (finished in 1m04s, no errors;
3 pre-existing unrelated warnings in `lix`). Verified on `ryzen-9950x-V`.

Exactly one error existed and this is its one-line fix.

## Follow-up worth doing separately

The workspace CI gate should compile the wasm target so a `cfg`-gated bridge cannot regress silently
again — that is what let this slip through in the first place.