### PR TITLE
bench(binary-cas): measure real-file chunk reuse and compare chunking policies

### DIFF
--- a/packages/engine-benchmarks/Cargo.toml
+++ b/packages/engine-benchmarks/Cargo.toml
@@ -44,6 +44,7 @@ ahash = "0.8"
 async-trait = "0.1"
 blake3 = "1"
 bytes = "1"
+fastcdc = "3"
 criterion = { package = "codspeed-criterion-compat", version = "*" }
 datafusion = { version = "53.0.0", default-features = false, features = ["sql"] }
 futures-util = { version = "0.3", default-features = false, features = ["std"] }
@@ -68,6 +69,10 @@ required-features = ["storage-benches", "slatedb"]
 name = "revision_pack_oracle"
 path = "examples/revision_pack_oracle.rs"
 required-features = ["storage-benches", "slatedb"]
+
+[[example]]
+name = "chunking_oracle"
+path = "examples/chunking_oracle.rs"
 
 [[example]]
 name = "cas_sharing"

--- a/packages/engine-benchmarks/Cargo.toml
+++ b/packages/engine-benchmarks/Cargo.toml
@@ -70,6 +70,11 @@ path = "examples/revision_pack_oracle.rs"
 required-features = ["storage-benches", "slatedb"]
 
 [[example]]
+name = "cas_sharing"
+path = "examples/cas_sharing.rs"
+required-features = ["storage-benches", "slatedb"]
+
+[[example]]
 name = "cas_gc_qualification"
 path = "examples/cas_gc_qualification.rs"
 required-features = ["storage-benches", "slatedb"]

--- a/packages/engine-benchmarks/examples/cas_sharing.rs
+++ b/packages/engine-benchmarks/examples/cas_sharing.rs
@@ -1,0 +1,574 @@
+//! Measures how much a second write of a binary file shares with the first.
+//!
+//! The binary CAS stores a blob as an ordered list of content-addressed chunks.
+//! A second write only pays for the chunks whose hashes are new, so the useful
+//! question for media and other binaries is: after editing a file, how many of
+//! its bytes still land on chunks that are already stored?
+//!
+//! The harness answers that with the storage spaces themselves rather than with
+//! an in-process model. It writes v1 through the public SQL file surface, reads
+//! the binary-CAS payload space, writes v2 through the same surface, reads the
+//! payload space again, and reports the difference. `new_payload_bytes` is
+//! therefore exactly what v2 cost on disk in chunk content, and
+//! `shared_bytes = v2_len - new_payload_bytes` is what it reused.
+//!
+//! Every case is driven from a real file on disk. Shapes named `supplied/*`
+//! come from a second real file produced by a real tool (an ffmpeg re-export, a
+//! `git archive` of a later revision). Shapes named `derived/*` apply one
+//! byte-level edit -- overwrite, insert, delete, append -- to the real base so
+//! the four canonical edit geometries are covered for every case.
+//!
+//! ```sh
+//! cargo run -p lix_benchmarks --release --features storage-benches,slatedb \
+//!   --example cas_sharing -- <corpus-dir>
+//! ```
+//!
+//! The corpus directory holds one subdirectory per case containing `base.bin`
+//! and zero or more `v2_<shape>.bin` files.
+
+use std::fmt::{self, Display, Formatter};
+use std::fs;
+use std::ops::Bound;
+use std::path::{Path, PathBuf};
+use std::time::{Duration, Instant};
+
+use lix::integration::{Engine, SessionContext};
+use lix::storage::{
+    BeginScanOptions, CoreProjection, KeyRange, MAX_SCAN_PAGE_ROWS, ProjectedValue, ReadOptions,
+    SpaceId, Storage, StorageRead,
+};
+use lix::storage_adapter::StorageSpace;
+use lix::{CreateBranchOptions, Value};
+use lix_storage_rocksdb::RocksDB;
+use lix_storage_slatedb::SlateDB;
+
+const MANIFEST_SPACE: SpaceId = SpaceId(0x0005_0001);
+const MANIFEST_CHUNK_SPACE: SpaceId = SpaceId(0x0005_0002);
+const PAYLOAD_SPACE: SpaceId = SpaceId(0x0005_0003);
+const PRESENCE_SPACE: SpaceId = SpaceId(0x0005_0004);
+const FILE_PATH: &str = "/case.bin";
+const UPSERT_SQL: &str = "INSERT INTO lix_file (path, content) VALUES ($1, $2) \
+                          ON CONFLICT (path) DO UPDATE SET content = excluded.content";
+const BRANCH_A_ID: &str = "01990000-0000-7000-8000-0000000000a1";
+const BRANCH_B_ID: &str = "01990000-0000-7000-8000-0000000000b2";
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum Backend {
+    RocksDB,
+    SlateDB,
+}
+
+impl Backend {
+    fn parse(value: &str) -> Self {
+        match value {
+            "rocksdb" => Self::RocksDB,
+            "slatedb" => Self::SlateDB,
+            other => panic!("backend must be rocksdb or slatedb, got '{other}'"),
+        }
+    }
+}
+
+impl Display for Backend {
+    fn fmt(&self, formatter: &mut Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::RocksDB => formatter.write_str("rocksdb"),
+            Self::SlateDB => formatter.write_str("slatedb"),
+        }
+    }
+}
+
+fn main() {
+    let mut arguments = std::env::args().skip(1);
+    let corpus = PathBuf::from(
+        arguments
+            .next()
+            .expect("usage: cas_sharing <corpus-dir> [backends]"),
+    );
+    let backends = arguments
+        .next()
+        .unwrap_or_else(|| "slatedb".to_owned())
+        .split(',')
+        .map(Backend::parse)
+        .collect::<Vec<_>>();
+
+    let runtime = tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()
+        .expect("build cas sharing runtime");
+    runtime.block_on(run(&corpus, &backends));
+}
+
+async fn run(corpus: &Path, backends: &[Backend]) {
+    let mut cases = fs::read_dir(corpus)
+        .expect("read corpus directory")
+        .map(|entry| entry.expect("read corpus entry").path())
+        .filter(|path| path.is_dir())
+        .collect::<Vec<_>>();
+    cases.sort();
+
+    for case in cases {
+        let name = case
+            .file_name()
+            .expect("case directory name")
+            .to_string_lossy()
+            .into_owned();
+        let base = fs::read(case.join("base.bin")).expect("read case base.bin");
+
+        let mut supplied = fs::read_dir(&case)
+            .expect("read case directory")
+            .map(|entry| entry.expect("read case entry").path())
+            .filter(|path| {
+                path.file_name()
+                    .and_then(|value| value.to_str())
+                    .is_some_and(|value| value.starts_with("v2_") && value.ends_with(".bin"))
+            })
+            .collect::<Vec<_>>();
+        supplied.sort();
+
+        let mut shapes = Vec::new();
+        for path in &supplied {
+            let label = path
+                .file_name()
+                .and_then(|value| value.to_str())
+                .expect("supplied variant name")
+                .trim_start_matches("v2_")
+                .trim_end_matches(".bin")
+                .to_owned();
+            shapes.push((
+                format!("supplied/{label}"),
+                fs::read(path).expect("read supplied variant"),
+            ));
+        }
+        shapes.push(("derived/overwrite_4k_mid".to_owned(), overwrite(&base)));
+        shapes.push(("derived/insert_4k_at_1pct".to_owned(), insert(&base)));
+        shapes.push(("derived/delete_4k_at_1pct".to_owned(), delete(&base)));
+        shapes.push(("derived/append_1m".to_owned(), append(&base)));
+
+        for &backend in backends {
+            for (shape, v2) in &shapes {
+                let report = measure_pair(backend, &base, v2).await;
+                report.print(&name, backend, shape, base.len(), v2.len());
+            }
+            // Two branches holding different edits of the same base file.
+            let branch = measure_branches(backend, &base, &insert(&base), &overwrite(&base)).await;
+            branch.print(&name, backend, base.len());
+        }
+    }
+}
+
+/// One database, three measurement points: empty, after v1, after v2.
+struct PairReport {
+    after_v1: Layout,
+    after_v2: Layout,
+    physical_after_v1: u64,
+    physical_after_v2: u64,
+    v1_elapsed: Duration,
+    v2_elapsed: Duration,
+}
+
+impl PairReport {
+    fn print(&self, case: &str, backend: Backend, shape: &str, v1_len: usize, v2_len: usize) {
+        let new_payload_bytes = self
+            .after_v2
+            .payload_value_bytes
+            .saturating_sub(self.after_v1.payload_value_bytes);
+        let shared_bytes = (v2_len as u64).saturating_sub(new_payload_bytes);
+        let sharing_ratio = if v2_len == 0 {
+            0.0
+        } else {
+            shared_bytes as f64 / v2_len as f64
+        };
+        println!(
+            "cas_sharing,case={case},backend={backend},shape={shape},\
+             v1_bytes={v1_len},v2_bytes={v2_len},\
+             payload_rows_v1={},payload_bytes_v1={},payload_rows_v2={},payload_bytes_v2={},\
+             new_payload_rows={},new_payload_bytes={new_payload_bytes},\
+             shared_bytes={shared_bytes},sharing_ratio={sharing_ratio:.4},\
+             manifest_rows={},manifest_bytes={},manifest_chunk_rows={},manifest_chunk_bytes={},\
+             presence_rows={},physical_bytes_v1={},physical_bytes_v2={},\
+             physical_delta={},v1_ms={:.3},v2_ms={:.3}",
+            self.after_v1.payload_rows,
+            self.after_v1.payload_value_bytes,
+            self.after_v2.payload_rows,
+            self.after_v2.payload_value_bytes,
+            self.after_v2
+                .payload_rows
+                .saturating_sub(self.after_v1.payload_rows),
+            self.after_v2.manifest_rows,
+            self.after_v2.manifest_value_bytes,
+            self.after_v2.manifest_chunk_rows,
+            self.after_v2.manifest_chunk_value_bytes,
+            self.after_v2.presence_rows,
+            self.physical_after_v1,
+            self.physical_after_v2,
+            i128::from(self.physical_after_v2) - i128::from(self.physical_after_v1),
+            self.v1_elapsed.as_secs_f64() * 1_000.0,
+            self.v2_elapsed.as_secs_f64() * 1_000.0,
+        );
+    }
+}
+
+struct BranchReport {
+    after_base: Layout,
+    after_branches: Layout,
+    a_len: usize,
+    b_len: usize,
+}
+
+impl BranchReport {
+    fn print(&self, case: &str, backend: Backend, base_len: usize) {
+        let new_payload_bytes = self
+            .after_branches
+            .payload_value_bytes
+            .saturating_sub(self.after_base.payload_value_bytes);
+        let logical = (self.a_len + self.b_len) as u64;
+        let shared_bytes = logical.saturating_sub(new_payload_bytes);
+        let sharing_ratio = shared_bytes as f64 / logical as f64;
+        println!(
+            "cas_sharing,case={case},backend={backend},shape=branches/two_edits,\
+             v1_bytes={base_len},v2_bytes={logical},\
+             payload_rows_v1={},payload_bytes_v1={},payload_rows_v2={},payload_bytes_v2={},\
+             new_payload_rows={},new_payload_bytes={new_payload_bytes},\
+             shared_bytes={shared_bytes},sharing_ratio={sharing_ratio:.4},\
+             manifest_rows={},manifest_bytes={},manifest_chunk_rows={},manifest_chunk_bytes={},\
+             presence_rows={},physical_bytes_v1=0,physical_bytes_v2=0,physical_delta=0,\
+             v1_ms=0.000,v2_ms=0.000",
+            self.after_base.payload_rows,
+            self.after_base.payload_value_bytes,
+            self.after_branches.payload_rows,
+            self.after_branches.payload_value_bytes,
+            self.after_branches
+                .payload_rows
+                .saturating_sub(self.after_base.payload_rows),
+            self.after_branches.manifest_rows,
+            self.after_branches.manifest_value_bytes,
+            self.after_branches.manifest_chunk_rows,
+            self.after_branches.manifest_chunk_value_bytes,
+            self.after_branches.presence_rows,
+        );
+    }
+}
+
+async fn measure_pair(backend: Backend, v1: &[u8], v2: &[u8]) -> PairReport {
+    let fixture = Fixture::new(backend).await;
+    let v1_elapsed = fixture.write(FILE_PATH, v1).await;
+    fixture.flush().await;
+    let after_v1 = fixture.layout().await;
+    let physical_after_v1 = directory_bytes(fixture.root());
+
+    let v2_elapsed = fixture.write(FILE_PATH, v2).await;
+    fixture.flush().await;
+    let after_v2 = fixture.layout().await;
+    let physical_after_v2 = directory_bytes(fixture.root());
+
+    PairReport {
+        after_v1,
+        after_v2,
+        physical_after_v1,
+        physical_after_v2,
+        v1_elapsed,
+        v2_elapsed,
+    }
+}
+
+async fn measure_branches(backend: Backend, base: &[u8], a: &[u8], b: &[u8]) -> BranchReport {
+    let fixture = Fixture::new(backend).await;
+    fixture.write(FILE_PATH, base).await;
+    fixture.flush().await;
+    let after_base = fixture.layout().await;
+
+    fixture.write_on_branch(BRANCH_A_ID, "sharing-branch-a", FILE_PATH, a).await;
+    fixture.write_on_branch(BRANCH_B_ID, "sharing-branch-b", FILE_PATH, b).await;
+    fixture.flush().await;
+    let after_branches = fixture.layout().await;
+
+    BranchReport {
+        after_base,
+        after_branches,
+        a_len: a.len(),
+        b_len: b.len(),
+    }
+}
+
+#[derive(Clone, Copy, Debug, Default)]
+struct Layout {
+    manifest_rows: u64,
+    manifest_value_bytes: u64,
+    manifest_chunk_rows: u64,
+    manifest_chunk_value_bytes: u64,
+    payload_rows: u64,
+    payload_value_bytes: u64,
+    presence_rows: u64,
+}
+
+struct BackendFixture<S: Storage + 'static> {
+    engine: Engine<S>,
+    session: SessionContext<S>,
+    storage: S,
+    _temp_dir: tempfile::TempDir,
+    root: PathBuf,
+}
+
+impl<S> BackendFixture<S>
+where
+    S: Storage + Clone + Send + Sync + 'static,
+{
+    async fn create(storage: S, temp_dir: tempfile::TempDir) -> Self {
+        let root = temp_dir.path().to_owned();
+        let receipt = Engine::initialize(storage.clone())
+            .await
+            .expect("initialize cas sharing engine");
+        let engine = Engine::new(storage.clone())
+            .await
+            .expect("open cas sharing engine");
+        let session = engine
+            .open_session(receipt.main_branch_id)
+            .await
+            .expect("open cas sharing session");
+        Self {
+            engine,
+            session,
+            storage,
+            _temp_dir: temp_dir,
+            root,
+        }
+    }
+
+    async fn write(&self, path: &str, bytes: &[u8]) -> Duration {
+        let started = Instant::now();
+        let result = self
+            .session
+            .execute(
+                UPSERT_SQL,
+                &[
+                    Value::Text(path.to_owned()),
+                    Value::Blob(bytes.to_vec().into()),
+                ],
+            )
+            .await
+            .expect("write cas sharing blob");
+        let elapsed = started.elapsed();
+        assert_eq!(result.rows_affected(), 1);
+        elapsed
+    }
+
+    async fn write_on_branch(&self, id: &str, name: &str, path: &str, bytes: &[u8]) {
+        let branch = self
+            .session
+            .create_branch(CreateBranchOptions {
+                id: Some(id.to_owned()),
+                name: name.to_owned(),
+                from_commit_id: None,
+            })
+            .await
+            .expect("create cas sharing branch");
+        let session = self
+            .engine
+            .open_session(branch.id)
+            .await
+            .expect("open cas sharing branch session");
+        let result = session
+            .execute(
+                UPSERT_SQL,
+                &[
+                    Value::Text(path.to_owned()),
+                    Value::Blob(bytes.to_vec().into()),
+                ],
+            )
+            .await
+            .expect("write cas sharing branch blob");
+        assert_eq!(result.rows_affected(), 1);
+    }
+
+    async fn layout(&self) -> Layout {
+        let manifest = space_accounting(&self.storage, MANIFEST_SPACE).await;
+        let manifest_chunk = space_accounting(&self.storage, MANIFEST_CHUNK_SPACE).await;
+        let payload = space_accounting(&self.storage, PAYLOAD_SPACE).await;
+        let presence = space_accounting(&self.storage, PRESENCE_SPACE).await;
+        Layout {
+            manifest_rows: manifest.0,
+            manifest_value_bytes: manifest.1,
+            manifest_chunk_rows: manifest_chunk.0,
+            manifest_chunk_value_bytes: manifest_chunk.1,
+            payload_rows: payload.0,
+            payload_value_bytes: payload.1,
+            presence_rows: presence.0,
+        }
+    }
+}
+
+enum Fixture {
+    Rocks(BackendFixture<RocksDB>),
+    Slate(BackendFixture<SlateDB>),
+}
+
+impl Fixture {
+    async fn new(backend: Backend) -> Self {
+        let temp_dir = tempfile::tempdir().expect("create cas sharing directory");
+        let database_path = temp_dir.path().join("database");
+        match backend {
+            Backend::RocksDB => {
+                let storage = RocksDB::open(&database_path).expect("open cas sharing RocksDB");
+                Self::Rocks(BackendFixture::create(storage, temp_dir).await)
+            }
+            Backend::SlateDB => {
+                let storage = SlateDB::open(&database_path).expect("open cas sharing SlateDB");
+                Self::Slate(BackendFixture::create(storage, temp_dir).await)
+            }
+        }
+    }
+
+    async fn write(&self, path: &str, bytes: &[u8]) -> Duration {
+        match self {
+            Self::Rocks(fixture) => fixture.write(path, bytes).await,
+            Self::Slate(fixture) => fixture.write(path, bytes).await,
+        }
+    }
+
+    async fn write_on_branch(&self, id: &str, name: &str, path: &str, bytes: &[u8]) {
+        match self {
+            Self::Rocks(fixture) => fixture.write_on_branch(id, name, path, bytes).await,
+            Self::Slate(fixture) => fixture.write_on_branch(id, name, path, bytes).await,
+        }
+    }
+
+    async fn layout(&self) -> Layout {
+        match self {
+            Self::Rocks(fixture) => fixture.layout().await,
+            Self::Slate(fixture) => fixture.layout().await,
+        }
+    }
+
+    fn root(&self) -> &Path {
+        match self {
+            Self::Rocks(fixture) => &fixture.root,
+            Self::Slate(fixture) => &fixture.root,
+        }
+    }
+
+    async fn flush(&self) {
+        match self {
+            Self::Rocks(fixture) => fixture.storage.flush().expect("flush cas sharing RocksDB"),
+            Self::Slate(fixture) => fixture
+                .storage
+                .flush()
+                .await
+                .expect("flush cas sharing SlateDB"),
+        }
+    }
+}
+
+async fn space_accounting<S>(storage: &S, space: SpaceId) -> (u64, u64)
+where
+    S: Storage,
+{
+    let space = if space == PAYLOAD_SPACE {
+        StorageSpace::immutable(space, "benchmark.binary_cas_payload")
+    } else {
+        StorageSpace::mutable(space, "benchmark.binary_cas_metadata")
+    };
+    let read = storage
+        .begin_read(ReadOptions::default())
+        .await
+        .expect("open accounting read");
+    let mut rows = 0u64;
+    let mut value_bytes = 0u64;
+    let mut cursor = read
+        .begin_scan(
+            space,
+            KeyRange {
+                lower: Bound::Unbounded,
+                upper: Bound::Unbounded,
+            },
+            BeginScanOptions {
+                projection: CoreProjection::FullValue,
+                ..BeginScanOptions::default()
+            },
+        )
+        .await
+        .expect("begin accounting scan");
+    loop {
+        let page = cursor
+            .next_page(MAX_SCAN_PAGE_ROWS)
+            .await
+            .expect("scan accounting space");
+        rows += page.entries.len() as u64;
+        value_bytes += page
+            .entries
+            .iter()
+            .map(|entry| match &entry.value {
+                ProjectedValue::KeyOnly => 0,
+                ProjectedValue::FullValue(value) => value.len() as u64,
+            })
+            .sum::<u64>();
+        if !page.has_more {
+            break;
+        }
+    }
+    (rows, value_bytes)
+}
+
+const EDIT_BYTES: usize = 4 << 10;
+
+fn overwrite(base: &[u8]) -> Vec<u8> {
+    let mut out = base.to_vec();
+    let len = EDIT_BYTES.min(out.len());
+    let start = (out.len() - len) / 2;
+    fill(&mut out[start..start + len], 0x5a17_5a17_5a17_5a17);
+    out
+}
+
+fn insert(base: &[u8]) -> Vec<u8> {
+    let at = base.len() / 100;
+    let mut out = Vec::with_capacity(base.len() + EDIT_BYTES);
+    out.extend_from_slice(&base[..at]);
+    let mut patch = vec![0u8; EDIT_BYTES];
+    fill(&mut patch, 0x1234_5678_9abc_def0);
+    out.extend_from_slice(&patch);
+    out.extend_from_slice(&base[at..]);
+    out
+}
+
+fn delete(base: &[u8]) -> Vec<u8> {
+    let at = base.len() / 100;
+    let end = (at + EDIT_BYTES).min(base.len());
+    let mut out = Vec::with_capacity(base.len() - (end - at));
+    out.extend_from_slice(&base[..at]);
+    out.extend_from_slice(&base[end..]);
+    out
+}
+
+fn append(base: &[u8]) -> Vec<u8> {
+    let mut out = base.to_vec();
+    let mut patch = vec![0u8; 1 << 20];
+    fill(&mut patch, 0x0fed_cba9_8765_4321);
+    out.extend_from_slice(&patch);
+    out
+}
+
+fn fill(bytes: &mut [u8], seed: u64) {
+    let mut state = seed ^ 0xd1b5_4a32_d192_ed03;
+    for chunk in bytes.chunks_mut(8) {
+        state ^= state << 13;
+        state ^= state >> 7;
+        state ^= state << 17;
+        let generated = state.to_le_bytes();
+        chunk.copy_from_slice(&generated[..chunk.len()]);
+    }
+}
+
+fn directory_bytes(path: &Path) -> u64 {
+    let Ok(metadata) = fs::symlink_metadata(path) else {
+        return 0;
+    };
+    if metadata.is_file() {
+        return metadata.len();
+    }
+    if !metadata.is_dir() {
+        return 0;
+    }
+    fs::read_dir(path)
+        .expect("read cas sharing storage directory")
+        .map(|entry| directory_bytes(&entry.expect("read cas sharing directory entry").path()))
+        .sum()
+}

--- a/packages/engine-benchmarks/examples/chunking_oracle.rs
+++ b/packages/engine-benchmarks/examples/chunking_oracle.rs
@@ -19,17 +19,32 @@ use std::fs;
 use std::path::{Path, PathBuf};
 use std::time::Instant;
 
+/// The resumable upload path accepts 16 MiB parts and completes up to four of
+/// them out of order, so a shipped CDC has to force a boundary at every part
+/// edge to keep parts independently chunkable. `anchor_bytes` models that.
 #[derive(Clone, Copy, Debug)]
 enum Policy {
-    Fixed { chunk_bytes: usize },
-    Cdc { avg_bytes: usize },
+    Fixed {
+        chunk_bytes: usize,
+    },
+    Cdc {
+        avg_bytes: usize,
+        anchor_bytes: Option<usize>,
+    },
 }
 
 impl Policy {
     fn label(&self) -> String {
         match self {
             Self::Fixed { chunk_bytes } => format!("fixed/{}", human(*chunk_bytes)),
-            Self::Cdc { avg_bytes } => format!("cdc/{}", human(*avg_bytes)),
+            Self::Cdc {
+                avg_bytes,
+                anchor_bytes: None,
+            } => format!("cdc/{}", human(*avg_bytes)),
+            Self::Cdc {
+                avg_bytes,
+                anchor_bytes: Some(anchor),
+            } => format!("cdc/{}@{}", human(*avg_bytes), human(*anchor)),
         }
     }
 
@@ -39,16 +54,36 @@ impl Policy {
                 .step_by(*chunk_bytes)
                 .map(|start| (start, start.saturating_add(*chunk_bytes).min(data.len())))
                 .collect(),
-            Self::Cdc { avg_bytes } => {
-                let min = (avg_bytes / 4).max(64) as u32;
-                let avg = *avg_bytes as u32;
-                let max = (avg_bytes * 4) as u32;
-                fastcdc::v2020::FastCDC::new(data, min, avg, max)
-                    .map(|chunk| (chunk.offset, chunk.offset + chunk.length))
-                    .collect()
+            Self::Cdc {
+                avg_bytes,
+                anchor_bytes,
+            } => {
+                let span = anchor_bytes.unwrap_or(usize::MAX);
+                let mut out = Vec::new();
+                let mut base = 0usize;
+                while base < data.len() {
+                    let end = base.saturating_add(span).min(data.len());
+                    out.extend(cdc_ranges(&data[base..end], *avg_bytes).into_iter().map(
+                        |(start, stop)| (base.saturating_add(start), base.saturating_add(stop)),
+                    ));
+                    base = end;
+                }
+                out
             }
         }
     }
+}
+
+fn cdc_ranges(data: &[u8], avg_bytes: usize) -> Vec<(usize, usize)> {
+    if data.is_empty() {
+        return Vec::new();
+    }
+    let min = (avg_bytes / 4).max(64) as u32;
+    let avg = avg_bytes as u32;
+    let max = (avg_bytes * 4) as u32;
+    fastcdc::v2020::FastCDC::new(data, min, avg, max)
+        .map(|chunk| (chunk.offset, chunk.offset + chunk.length))
+        .collect()
 }
 
 fn human(bytes: usize) -> String {
@@ -71,12 +106,23 @@ const POLICIES: &[Policy] = &[
     },
     Policy::Cdc {
         avg_bytes: 1 << 20,
+        anchor_bytes: None,
     },
     Policy::Cdc {
         avg_bytes: 256 << 10,
+        anchor_bytes: None,
     },
     Policy::Cdc {
         avg_bytes: 64 << 10,
+        anchor_bytes: None,
+    },
+    Policy::Cdc {
+        avg_bytes: 1 << 20,
+        anchor_bytes: Some(16 << 20),
+    },
+    Policy::Cdc {
+        avg_bytes: 256 << 10,
+        anchor_bytes: Some(16 << 20),
     },
 ];
 

--- a/packages/engine-benchmarks/examples/chunking_oracle.rs
+++ b/packages/engine-benchmarks/examples/chunking_oracle.rs
@@ -1,0 +1,245 @@
+//! Compares candidate binary-CAS chunking policies over a real-file corpus.
+//!
+//! `cas_sharing` measures what the engine stores today. This oracle answers the
+//! next question without changing the engine: for the same real file pairs, how
+//! much would each candidate policy have shared, how many chunk rows would it
+//! have produced, and how fast does the boundary search itself run?
+//!
+//! ```sh
+//! cargo run -p lix_benchmarks --release --features storage-benches,slatedb \
+//!   --example chunking_oracle -- <corpus-dir>
+//! ```
+//!
+//! Sharing is computed exactly the way the CAS computes it: chunk the base,
+//! chunk the variant, and charge the variant for every chunk whose content hash
+//! is not already in the base's chunk set.
+
+use std::collections::HashSet;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::time::Instant;
+
+#[derive(Clone, Copy, Debug)]
+enum Policy {
+    Fixed { chunk_bytes: usize },
+    Cdc { avg_bytes: usize },
+}
+
+impl Policy {
+    fn label(&self) -> String {
+        match self {
+            Self::Fixed { chunk_bytes } => format!("fixed/{}", human(*chunk_bytes)),
+            Self::Cdc { avg_bytes } => format!("cdc/{}", human(*avg_bytes)),
+        }
+    }
+
+    fn ranges(&self, data: &[u8]) -> Vec<(usize, usize)> {
+        match self {
+            Self::Fixed { chunk_bytes } => (0..data.len())
+                .step_by(*chunk_bytes)
+                .map(|start| (start, start.saturating_add(*chunk_bytes).min(data.len())))
+                .collect(),
+            Self::Cdc { avg_bytes } => {
+                let min = (avg_bytes / 4).max(64) as u32;
+                let avg = *avg_bytes as u32;
+                let max = (avg_bytes * 4) as u32;
+                fastcdc::v2020::FastCDC::new(data, min, avg, max)
+                    .map(|chunk| (chunk.offset, chunk.offset + chunk.length))
+                    .collect()
+            }
+        }
+    }
+}
+
+fn human(bytes: usize) -> String {
+    if bytes >= 1 << 20 {
+        format!("{}m", bytes >> 20)
+    } else {
+        format!("{}k", bytes >> 10)
+    }
+}
+
+const POLICIES: &[Policy] = &[
+    Policy::Fixed {
+        chunk_bytes: 1 << 20,
+    },
+    Policy::Fixed {
+        chunk_bytes: 256 << 10,
+    },
+    Policy::Fixed {
+        chunk_bytes: 64 << 10,
+    },
+    Policy::Cdc {
+        avg_bytes: 1 << 20,
+    },
+    Policy::Cdc {
+        avg_bytes: 256 << 10,
+    },
+    Policy::Cdc {
+        avg_bytes: 64 << 10,
+    },
+];
+
+const EDIT_BYTES: usize = 4 << 10;
+
+fn main() {
+    let corpus = PathBuf::from(
+        std::env::args()
+            .nth(1)
+            .expect("usage: chunking_oracle <corpus-dir>"),
+    );
+    let mut cases = fs::read_dir(&corpus)
+        .expect("read corpus directory")
+        .map(|entry| entry.expect("read corpus entry").path())
+        .filter(|path| path.is_dir())
+        .collect::<Vec<_>>();
+    cases.sort();
+
+    for case in cases {
+        let name = case
+            .file_name()
+            .expect("case directory name")
+            .to_string_lossy()
+            .into_owned();
+        let base = fs::read(case.join("base.bin")).expect("read case base.bin");
+        for (shape, v2) in shapes(&case, &base) {
+            for policy in POLICIES {
+                report(&name, &shape, *policy, &base, &v2);
+            }
+        }
+    }
+
+    // Boundary-search throughput, measured on the largest corpus file so the
+    // cost of the rolling hash is separated from any storage work.
+    let mut largest = Vec::new();
+    for case in fs::read_dir(&corpus).expect("read corpus directory") {
+        let path = case.expect("read corpus entry").path();
+        if !path.is_dir() {
+            continue;
+        }
+        let data = fs::read(path.join("base.bin")).expect("read case base.bin");
+        if data.len() > largest.len() {
+            largest = data;
+        }
+    }
+    for policy in POLICIES {
+        let mut best = f64::MAX;
+        for _ in 0..9 {
+            let started = Instant::now();
+            let ranges = policy.ranges(&largest);
+            let elapsed = started.elapsed().as_secs_f64();
+            std::hint::black_box(ranges.len());
+            best = best.min(elapsed);
+        }
+        println!(
+            "chunking_throughput,policy={},bytes={},best_ms={:.3},mib_per_s={:.1}",
+            policy.label(),
+            largest.len(),
+            best * 1_000.0,
+            (largest.len() as f64 / (1 << 20) as f64) / best,
+        );
+    }
+}
+
+fn shapes(case: &Path, base: &[u8]) -> Vec<(String, Vec<u8>)> {
+    let mut supplied = fs::read_dir(case)
+        .expect("read case directory")
+        .map(|entry| entry.expect("read case entry").path())
+        .filter(|path| {
+            path.file_name()
+                .and_then(|value| value.to_str())
+                .is_some_and(|value| value.starts_with("v2_") && value.ends_with(".bin"))
+        })
+        .collect::<Vec<_>>();
+    supplied.sort();
+
+    let mut shapes = supplied
+        .iter()
+        .map(|path| {
+            let label = path
+                .file_name()
+                .and_then(|value| value.to_str())
+                .expect("supplied variant name")
+                .trim_start_matches("v2_")
+                .trim_end_matches(".bin");
+            (
+                format!("supplied/{label}"),
+                fs::read(path).expect("read supplied variant"),
+            )
+        })
+        .collect::<Vec<_>>();
+
+    let mut overwrite = base.to_vec();
+    let len = EDIT_BYTES.min(overwrite.len());
+    let start = (overwrite.len() - len) / 2;
+    fill(&mut overwrite[start..start + len], 0x5a17_5a17_5a17_5a17);
+    shapes.push(("derived/overwrite_4k_mid".to_owned(), overwrite));
+
+    let at = base.len() / 100;
+    let mut inserted = Vec::with_capacity(base.len() + EDIT_BYTES);
+    inserted.extend_from_slice(&base[..at]);
+    let mut patch = vec![0u8; EDIT_BYTES];
+    fill(&mut patch, 0x1234_5678_9abc_def0);
+    inserted.extend_from_slice(&patch);
+    inserted.extend_from_slice(&base[at..]);
+    shapes.push(("derived/insert_4k_at_1pct".to_owned(), inserted));
+
+    let end = (at + EDIT_BYTES).min(base.len());
+    let mut deleted = Vec::with_capacity(base.len() - (end - at));
+    deleted.extend_from_slice(&base[..at]);
+    deleted.extend_from_slice(&base[end..]);
+    shapes.push(("derived/delete_4k_at_1pct".to_owned(), deleted));
+
+    let mut appended = base.to_vec();
+    let mut tail = vec![0u8; 1 << 20];
+    fill(&mut tail, 0x0fed_cba9_8765_4321);
+    appended.extend_from_slice(&tail);
+    shapes.push(("derived/append_1m".to_owned(), appended));
+
+    shapes
+}
+
+fn report(case: &str, shape: &str, policy: Policy, base: &[u8], v2: &[u8]) {
+    let base_ranges = policy.ranges(base);
+    let v2_ranges = policy.ranges(v2);
+    let known = base_ranges
+        .iter()
+        .map(|&(start, end)| *blake3::hash(&base[start..end]).as_bytes())
+        .collect::<HashSet<_>>();
+    let mut new_bytes = 0u64;
+    let mut new_chunks = 0u64;
+    let mut seen = HashSet::new();
+    for &(start, end) in &v2_ranges {
+        let hash = *blake3::hash(&v2[start..end]).as_bytes();
+        if known.contains(&hash) || !seen.insert(hash) {
+            continue;
+        }
+        new_bytes += (end - start) as u64;
+        new_chunks += 1;
+    }
+    let shared = (v2.len() as u64).saturating_sub(new_bytes);
+    println!(
+        "chunking_oracle,case={case},shape={shape},policy={},\
+         v1_bytes={},v2_bytes={},v1_chunks={},v2_chunks={},\
+         new_chunks={new_chunks},new_bytes={new_bytes},shared_bytes={shared},\
+         sharing_ratio={:.4},mean_chunk_bytes={}",
+        policy.label(),
+        base.len(),
+        v2.len(),
+        base_ranges.len(),
+        v2_ranges.len(),
+        shared as f64 / v2.len() as f64,
+        base.len() / base_ranges.len().max(1),
+    );
+}
+
+fn fill(bytes: &mut [u8], seed: u64) {
+    let mut state = seed ^ 0xd1b5_4a32_d192_ed03;
+    for chunk in bytes.chunks_mut(8) {
+        state ^= state << 13;
+        state ^= state >> 7;
+        state ^= state << 17;
+        let generated = state.to_le_bytes();
+        chunk.copy_from_slice(&generated[..chunk.len()]);
+    }
+}


### PR DESCRIPTION
## What this adds

Two measurement tools for the binary CAS. No engine code changes.

The binary CAS stores a blob as an ordered list of content-addressed chunks, so a
second write only pays for the chunks whose hashes are new. Nothing in the
repository measured that. `benches/large_blob_updates.rs` has only
`localized_4k_update` and `full_rewrite`, both length-preserving, so the two edit
shapes that ordinary media edits actually produce — inserts and deletes — were
never exercised.

- `examples/cas_sharing.rs` writes v1 and then an edited v2 of a **real file**
  through the public `lix_file` SQL surface, reads the binary-CAS payload space
  before and after, and reports exactly how many chunk bytes v2 newly stored and
  how many it reused, plus settled bytes on disk. Corpus cases supply `base.bin`
  and any number of `v2_<shape>.bin` variants produced by a real tool; the harness
  additionally derives overwrite / insert / delete / append from the same base and
  measures a two-branch case.
- `examples/chunking_oracle.rs` replays the same file pairs through candidate
  chunking policies (fixed and FastCDC at several average sizes, with and without
  a forced boundary interval) and reports sharing ratio, chunk count and boundary
  search throughput, so a policy can be chosen before any storage change.

## Why it matters

Run against a corpus of real files (Big Buck Bunny re-encodes and remuxes, PCM
WAV, AAC, a 5120x2880 PNG and its BMP, `git archive` tarballs, a real ELF), the
harness shows the current fixed-offset chunking shares **exactly zero** bytes on
every insert or delete, including a metadata-only MP4 remux that leaves the entire
H.264 payload untouched. Full numbers are in the follow-up PR.

## How to run

```sh
cargo run -p lix_benchmarks --release --features storage-benches,slatedb \
  --example cas_sharing -- <corpus-dir> slatedb
cargo run -p lix_benchmarks --release --features storage-benches,slatedb \
  --example chunking_oracle -- <corpus-dir>
```

Machine: `ryzen-9950x-IV`. `cargo check --workspace`, `cargo clippy --workspace
--all-targets --all-features -- -D warnings` and `cargo test -p lix` all pass.
