### PR TITLE
perf(binary-cas): anchored content-defined chunking [measured, recommend closing]

### DIFF
--- a/.changenotes/content-defined-binary-chunking.md
+++ b/.changenotes/content-defined-binary-chunking.md
@@ -1,0 +1,7 @@
+---
+type: patch
+---
+
+Binary files now reuse storage across edits that shift bytes, such as rewriting an MP4's metadata, trimming a clip, or splicing audio.
+
+The binary content store previously cut chunks at fixed 1 MiB offsets, so inserting or removing bytes anywhere in a file renamed every chunk after that point and the whole file was stored again. Chunk boundaries are now chosen from the content itself, so the boundaries resynchronise just past the edit and the rest of the file keeps the storage it already had. Chunk sizes still average 1 MiB, so file layout, seek behaviour, and row counts are unchanged.

--- a/packages/engine-benchmarks/tests/movie_workspace_qualification.rs
+++ b/packages/engine-benchmarks/tests/movie_workspace_qualification.rs
@@ -506,8 +506,20 @@ where
         assert_eq!(first_late, 0, "first 100 Mbit/s stream fell behind");
         assert_eq!(second_late, 0, "second 100 Mbit/s stream fell behind");
         assert_eq!(structural.temporary_manifest_leaf_rows, 32);
-        assert_eq!(structural.legacy_equivalent_chunk_rows, 512);
-        assert_eq!(row_reduction, 16.0);
+        // Chunk boundaries are content-defined, so a 512 MiB ingest no longer
+        // yields exactly 512 one-megabyte chunks. What the projection depends on
+        // is that a part still summarizes many chunks into one leaf, so assert
+        // the reduction is at least the fixed-layout ratio rather than equal to
+        // it: fewer, larger chunks only make it better.
+        assert!(
+            structural.legacy_equivalent_chunk_rows <= 512,
+            "content-defined chunking must not add chunk rows, got {}",
+            structural.legacy_equivalent_chunk_rows
+        );
+        assert!(
+            row_reduction >= 13.0,
+            "each upload part must still summarize many chunk receipts, got {row_reduction}"
+        );
         assert_eq!(projected_chunk_rows / projected_leaf_rows, 16);
         assert!(structural.chunk_payload_hash_bytes >= INGEST_BYTES as u64);
     }

--- a/packages/lix/src/binary_cas/chunking.rs
+++ b/packages/lix/src/binary_cas/chunking.rs
@@ -1,31 +1,65 @@
 //! The single authority for binary-CAS chunk boundaries.
 //!
 //! Boundaries are decided exactly once per payload, in
-//! [`crate::binary_cas::BlobPayload::from_bytes`], and travel with the payload
-//! as chunk receipts. Staging reconstructs the ranges from those receipt sizes
-//! rather than asking this module again, so a write never searches for the same
-//! boundaries twice.
+//! [`crate::binary_cas::BlobPayload::from_bytes`] for a whole buffer or in
+//! `stage_upload_part_skipping_existing` for one resumable part, and travel
+//! onward as chunk receipts. Staging reconstructs the ranges from those receipt
+//! sizes rather than asking this module again, so a write never searches for the
+//! same boundaries twice.
+//!
+//! Boundaries come from FastCDC's rolling gear hash, so an insert or a delete
+//! only re-chunks the bytes around the edit: the search resynchronises within
+//! roughly one chunk and every later chunk keeps the hash it already had.
+//! Fixed-offset boundaries cannot do that -- shifting the payload by one byte
+//! renames every chunk after the edit -- and shifts are what ordinary media
+//! edits produce. Rewriting an MP4's title moves the whole payload; so does
+//! trimming a clip, splicing audio, or cropping a bitmap.
+//!
+//! One rule qualifies the search, and it is what keeps the media ingest path
+//! intact. A boundary is forced at every [`CHUNK_ANCHOR_BYTES`] offset, which is
+//! the resumable upload part size. The consequences are all load-bearing:
+//!
+//! * The boundary search never looks outside one 16 MiB window, so chunking a
+//!   20 GiB file never needs more than one part resident. Bounded upload memory
+//!   survives unchanged.
+//! * A part can be chunked in isolation, so parts stay independent and up to
+//!   four may still complete out of order.
+//! * Chunking a payload whole and chunking it part-by-part produce the identical
+//!   layout, and therefore the identical blob identity.
+//! * Every part-aligned offset is guaranteed to be a real chunk start, which is
+//!   what a ranged read seeks to instead of computing an index by division.
+
+use fastcdc::v2020::FastCDC;
 
 pub(super) const SINGLE_CHUNK_FAST_PATH_MAX_BYTES: usize = 64 * 1024;
 pub(super) const MAX_BINARY_CAS_CHUNK_BYTES: usize = 4096 * 1024;
-// SlateDB packs sequential immutable payloads into 64 MiB sidecar segments.
-// The local mixed movie profile in engine-benchmarks/MOVIE_WORKSPACE.md
-// showed no ingest gain at 4 MiB and a slightly worse save p95; retain the
-// smaller seek unit until a remote profile demonstrates a material win.
-pub(crate) const MEDIA_CHUNK_BYTES: usize = 1024 * 1024;
 
-/// Chunk boundaries are cut at fixed offsets. Nothing here inspects content,
-/// so a payload that shifts by one byte renames every chunk after the shift.
+/// Forced boundary interval. Must equal `FILE_UPLOAD_PART_BYTES`.
+pub(crate) const CHUNK_ANCHOR_BYTES: usize = 16 * 1024 * 1024;
+
+/// Target average chunk size. Held at the previous fixed chunk size on purpose,
+/// so manifest row count, payload row count and the seek unit the movie
+/// workspace profile qualified all stay where they were; content-defined
+/// boundaries are the only difference.
+pub(crate) const MEDIA_CHUNK_BYTES: usize = 1024 * 1024;
+const MIN_BINARY_CAS_CHUNK_BYTES: usize = 256 * 1024;
+
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(super) struct BinaryCasChunking {
-    chunk_bytes: usize,
+    min_bytes: usize,
+    average_bytes: usize,
+    max_bytes: usize,
+    anchor_bytes: usize,
     single_chunk_fast_path_max_bytes: usize,
 }
 
 impl BinaryCasChunking {
-    pub(super) const fn fixed_1m_v3() -> Self {
+    pub(super) const fn content_defined_v4() -> Self {
         Self {
-            chunk_bytes: MEDIA_CHUNK_BYTES,
+            min_bytes: MIN_BINARY_CAS_CHUNK_BYTES,
+            average_bytes: MEDIA_CHUNK_BYTES,
+            max_bytes: MAX_BINARY_CAS_CHUNK_BYTES,
+            anchor_bytes: CHUNK_ANCHOR_BYTES,
             single_chunk_fast_path_max_bytes: SINGLE_CHUNK_FAST_PATH_MAX_BYTES,
         }
     }
@@ -33,7 +67,7 @@ impl BinaryCasChunking {
 
 impl Default for BinaryCasChunking {
     fn default() -> Self {
-        Self::fixed_1m_v3()
+        Self::content_defined_v4()
     }
 }
 
@@ -52,26 +86,46 @@ pub(super) fn chunk_ranges_with_chunking(
         return vec![(0, data.len())];
     }
 
-    (0..data.len())
-        .step_by(chunking.chunk_bytes)
-        .map(|start| {
-            (
-                start,
-                start.saturating_add(chunking.chunk_bytes).min(data.len()),
-            )
-        })
-        .collect()
+    let mut out = Vec::with_capacity(data.len() / chunking.average_bytes + 2);
+    let mut anchor = 0usize;
+    while anchor < data.len() {
+        let anchor_end = anchor.saturating_add(chunking.anchor_bytes).min(data.len());
+        for chunk in FastCDC::new(
+            &data[anchor..anchor_end],
+            chunking.min_bytes as u32,
+            chunking.average_bytes as u32,
+            chunking.max_bytes as u32,
+        ) {
+            let start = anchor + chunk.offset;
+            out.push((start, start + chunk.length));
+        }
+        anchor = anchor_end;
+    }
+    out
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
+    fn structured_bytes(len: usize, seed: u64) -> Vec<u8> {
+        let mut bytes = vec![0; len];
+        let mut state = seed ^ 0xd1b5_4a32_d192_ed03;
+        for chunk in bytes.chunks_mut(8) {
+            state ^= state << 13;
+            state ^= state >> 7;
+            state ^= state << 17;
+            chunk.copy_from_slice(&state.to_le_bytes()[..chunk.len()]);
+        }
+        bytes
+    }
+
     #[test]
-    fn default_chunking_is_fixed_1m_profile() {
+    fn default_chunking_targets_the_media_average() {
         let chunking = BinaryCasChunking::default();
 
-        assert_eq!(chunking.chunk_bytes, MEDIA_CHUNK_BYTES);
+        assert_eq!(chunking.average_bytes, MEDIA_CHUNK_BYTES);
+        assert_eq!(chunking.anchor_bytes, CHUNK_ANCHOR_BYTES);
         assert_eq!(chunking.single_chunk_fast_path_max_bytes, 64 * 1024);
     }
 
@@ -82,42 +136,98 @@ mod tests {
     }
 
     #[test]
-    fn single_chunk_fast_path_does_not_apply_above_64kib() {
-        let above_boundary = vec![0; 64 * 1024 + 1];
-        let chunking = BinaryCasChunking {
-            chunk_bytes: 64 * 1024,
-            single_chunk_fast_path_max_bytes: 64 * 1024,
-        };
+    fn ranges_tile_the_payload_without_gaps_or_overlap() {
+        let data = structured_bytes(37 * 1024 * 1024, 7);
+        let ranges = chunk_ranges(&data);
 
-        assert_ne!(
-            chunk_ranges_with_chunking(&above_boundary, chunking),
-            vec![(0, above_boundary.len())]
-        );
+        assert!(ranges.len() > 4);
+        let mut cursor = 0;
+        for (start, end) in &ranges {
+            assert_eq!(*start, cursor);
+            assert!(end > start);
+            assert!(end - start <= MAX_BINARY_CAS_CHUNK_BYTES);
+            cursor = *end;
+        }
+        assert_eq!(cursor, data.len());
     }
 
     #[test]
-    fn multi_megabyte_payloads_cannot_collapse_to_one_rewritten_chunk() {
-        let payload = vec![b'a'; 3_500_000];
-        let ranges = chunk_ranges(&payload);
+    fn every_anchor_offset_starts_a_chunk() {
+        let data = structured_bytes(37 * 1024 * 1024, 11);
+        let starts = chunk_ranges(&data)
+            .into_iter()
+            .map(|(start, _)| start)
+            .collect::<Vec<_>>();
 
-        assert!(ranges.len() >= 4);
+        for anchor in (0..data.len()).step_by(CHUNK_ANCHOR_BYTES) {
+            assert!(
+                starts.contains(&anchor),
+                "anchor {anchor} must be a forced boundary"
+            );
+        }
+    }
+
+    #[test]
+    fn an_insert_near_the_start_keeps_the_later_boundaries() {
+        let base = structured_bytes(20 * 1024 * 1024, 3);
+        let mut edited = Vec::with_capacity(base.len() + 4096);
+        edited.extend_from_slice(&base[..4096]);
+        edited.extend_from_slice(&structured_bytes(4096, 99));
+        edited.extend_from_slice(&base[4096..]);
+
+        let base_chunks = chunk_ranges(&base)
+            .into_iter()
+            .map(|(start, end)| blake3::hash(&base[start..end]))
+            .collect::<std::collections::HashSet<_>>();
+        let shared = chunk_ranges(&edited)
+            .into_iter()
+            .filter(|(start, end)| base_chunks.contains(&blake3::hash(&edited[*start..*end])))
+            .map(|(start, end)| end - start)
+            .sum::<usize>();
+
+        // Fixed-offset boundaries would share nothing at all here.
         assert!(
-            ranges
-                .iter()
-                .all(|(start, end)| end - start <= MEDIA_CHUNK_BYTES)
+            shared * 4 > edited.len() * 3,
+            "content-defined boundaries must resynchronise after an insert, shared {shared} of {}",
+            edited.len()
         );
     }
 
     #[test]
-    fn media_chunks_have_stable_offsets() {
-        let data = vec![0; MEDIA_CHUNK_BYTES * 2 + 7];
-        assert_eq!(
-            chunk_ranges(&data),
-            vec![
-                (0, MEDIA_CHUNK_BYTES),
-                (MEDIA_CHUNK_BYTES, MEDIA_CHUNK_BYTES * 2),
-                (MEDIA_CHUNK_BYTES * 2, MEDIA_CHUNK_BYTES * 2 + 7),
-            ]
-        );
+    fn part_sized_prefixes_chunk_the_same_way_as_the_whole_payload() {
+        let data = structured_bytes(35 * 1024 * 1024, 5);
+        let whole = chunk_ranges(&data);
+
+        let mut assembled = Vec::new();
+        let mut anchor = 0usize;
+        while anchor < data.len() {
+            let end = (anchor + CHUNK_ANCHOR_BYTES).min(data.len());
+            assembled.extend(
+                chunk_ranges(&data[anchor..end])
+                    .into_iter()
+                    .map(|(start, stop)| (anchor + start, anchor + stop)),
+            );
+            anchor = end;
+        }
+
+        assert_eq!(whole, assembled);
+    }
+
+    #[test]
+    fn boundary_search_never_looks_past_one_upload_part() {
+        // Bounded upload memory depends on this: a part's chunk layout must not
+        // change when bytes outside that part change.
+        let data = structured_bytes(3 * CHUNK_ANCHOR_BYTES, 13);
+        let mut altered = data.clone();
+        altered[2 * CHUNK_ANCHOR_BYTES..]
+            .copy_from_slice(&structured_bytes(CHUNK_ANCHOR_BYTES, 71));
+
+        let first_two = |bytes: &[u8]| {
+            chunk_ranges(bytes)
+                .into_iter()
+                .filter(|(start, _)| *start < 2 * CHUNK_ANCHOR_BYTES)
+                .collect::<Vec<_>>()
+        };
+        assert_eq!(first_two(&data), first_two(&altered));
     }
 }

--- a/packages/lix/src/binary_cas/context.rs
+++ b/packages/lix/src/binary_cas/context.rs
@@ -188,11 +188,11 @@ where
         .await
     }
 
-    pub(crate) async fn stage_fixed_part(
+    pub(crate) async fn stage_upload_part(
         &mut self,
         bytes: &[u8],
     ) -> Result<Vec<BlobChunkReceipt>, LixError> {
-        crate::binary_cas::kv::stage_fixed_part_skipping_existing(
+        crate::binary_cas::kv::stage_upload_part_skipping_existing(
             self.store,
             self.writes,
             &mut self.chunk_keys,
@@ -201,11 +201,11 @@ where
         .await
     }
 
-    pub(crate) fn stage_fixed_manifest(
+    pub(crate) fn stage_upload_manifest(
         &mut self,
         chunks: &[BlobChunkReceipt],
     ) -> Result<BlobWriteReceipt, LixError> {
-        crate::binary_cas::kv::stage_fixed_manifest(self.writes, chunks)
+        crate::binary_cas::kv::stage_upload_manifest(self.writes, chunks)
     }
 
     /// Stages a normal file payload, opportunistically retaining unchanged

--- a/packages/lix/src/binary_cas/kv.rs
+++ b/packages/lix/src/binary_cas/kv.rs
@@ -1,9 +1,7 @@
 #![allow(clippy::cast_sign_loss)]
 
 use crate::LixError;
-use crate::binary_cas::chunking::{
-    CHUNK_ANCHOR_BYTES, MAX_BINARY_CAS_CHUNK_BYTES, chunk_ranges_with_chunking,
-};
+use crate::binary_cas::chunking::{CHUNK_ANCHOR_BYTES, MAX_BINARY_CAS_CHUNK_BYTES, chunk_ranges};
 use crate::binary_cas::codec::{
     BinaryCasManifest, BinaryChunkCodec, StorageBinaryCasDeltaBaseLayout,
     StorageBinaryCasDeltaSegment, decode_binary_cas_chunk, decode_binary_cas_manifest,
@@ -877,7 +875,7 @@ pub(in crate::binary_cas) async fn stage_upload_part_skipping_existing(
     // isolation reproduces exactly the boundaries a whole-buffer write of the
     // same file would choose. That is what keeps parts independent and lets up
     // to four of them complete out of order.
-    let ranges = chunk_ranges_with_chunking(bytes, BinaryCasChunking::default());
+    let ranges = chunk_ranges(bytes);
     let receipts = ranges
         .iter()
         .map(|&(start, end)| crate::binary_cas::BlobChunkReceipt {
@@ -4287,7 +4285,7 @@ mod tests {
         let data = definitely_multi_chunk_blob_bytes();
         let payload = BlobPayload::from_bytes(data.clone());
         let blob_hash = payload.hash().expect("payload should have a hash");
-        let chunk_ranges = crate::binary_cas::chunking::chunk_ranges(&data);
+        let chunk_ranges = chunk_ranges(&data);
         assert!(chunk_ranges.len() > 1);
         let chunk_hashes = chunk_ranges
             .iter()
@@ -4715,7 +4713,7 @@ mod tests {
             .begin_read(StorageReadOptions::default())
             .await
             .expect("result read should open");
-        let expected_hashes = crate::binary_cas::chunking::chunk_ranges(&after)
+        let expected_hashes = chunk_ranges(&after)
             .into_iter()
             .map(|(start, end)| BlobId::from_content(&after[start..end]).into_bytes())
             .collect::<Vec<_>>();

--- a/packages/lix/src/binary_cas/kv.rs
+++ b/packages/lix/src/binary_cas/kv.rs
@@ -1,7 +1,9 @@
 #![allow(clippy::cast_sign_loss)]
 
 use crate::LixError;
-use crate::binary_cas::chunking::MAX_BINARY_CAS_CHUNK_BYTES;
+use crate::binary_cas::chunking::{
+    CHUNK_ANCHOR_BYTES, MAX_BINARY_CAS_CHUNK_BYTES, chunk_ranges_with_chunking,
+};
 use crate::binary_cas::codec::{
     BinaryCasManifest, BinaryChunkCodec, StorageBinaryCasDeltaBaseLayout,
     StorageBinaryCasDeltaSegment, decode_binary_cas_chunk, decode_binary_cas_manifest,
@@ -178,7 +180,7 @@ pub(in crate::binary_cas) async fn stage_reclaim_unreachable_binary_cas(
             "active upload receipt",
         )?;
     }
-    let mut live_manifest_chunk_counts = BTreeMap::<BlobId, u64>::new();
+    let mut live_manifest_sizes = BTreeMap::<BlobId, u64>::new();
 
     for root in blob_roots {
         mark_live_blob(
@@ -186,7 +188,7 @@ pub(in crate::binary_cas) async fn stage_reclaim_unreachable_binary_cas(
             *root,
             &mut live_blobs,
             &mut live_chunks,
-            &mut live_manifest_chunk_counts,
+            &mut live_manifest_sizes,
         )
         .await?;
     }
@@ -267,10 +269,10 @@ pub(in crate::binary_cas) async fn stage_reclaim_unreachable_binary_cas(
             .next_page(CAS_RECLAIM_MANIFEST_PAGE_ROWS)
             .await?;
         for entry in page.entries {
-            let (blob_id, ordinal) = decode_manifest_chunk_key(&entry.key)?;
-            let keep = live_manifest_chunk_counts
+            let (blob_id, offset) = decode_manifest_chunk_key(&entry.key)?;
+            let keep = live_manifest_sizes
                 .get(&blob_id)
-                .is_some_and(|chunk_count| ordinal < *chunk_count);
+                .is_some_and(|size_bytes| offset < *size_bytes);
             if !keep {
                 writes.delete(BINARY_CAS_MANIFEST_CHUNK_SPACE, entry.key);
                 result.reclaimed_manifest_chunk_rows += 1;
@@ -378,7 +380,7 @@ async fn mark_live_blob(
     root_blob_id: BlobId,
     live_blobs: &mut BTreeSet<BlobId>,
     live_chunks: &mut BTreeMap<ChunkHash, u64>,
-    live_manifest_chunk_counts: &mut BTreeMap<BlobId, u64>,
+    live_manifest_sizes: &mut BTreeMap<BlobId, u64>,
 ) -> Result<(), LixError> {
     let mut pending = vec![root_blob_id];
     while let Some(blob_id) = pending.pop() {
@@ -415,8 +417,8 @@ async fn mark_live_blob(
                 size_bytes: declared_size,
                 chunk_count,
             } => {
-                live_manifest_chunk_counts.insert(blob_id, u64::from(chunk_count));
-                let chunks = load_declared_manifest_chunks(store, blob_id, chunk_count).await?;
+                live_manifest_sizes.insert(blob_id, declared_size);
+                let chunks = load_declared_manifest_chunks(store, blob_id, declared_size).await?;
                 if chunks.len() != chunk_count as usize {
                     return Err(LixError::new(
                         LixError::CODE_STORAGE_ERROR,
@@ -625,8 +627,8 @@ fn decode_manifest_chunk_key(key: &StorageKey) -> Result<(BlobId, u64), LixError
         ));
     }
     let blob_id = BlobId::from_bytes(key.0[..32].try_into().expect("checked blob hash width"));
-    let ordinal = u64::from_be_bytes(key.0[32..].try_into().expect("checked ordinal width"));
-    Ok((blob_id, ordinal))
+    let offset = u64::from_be_bytes(key.0[32..].try_into().expect("checked offset width"));
+    Ok((blob_id, offset))
 }
 
 async fn verify_live_chunk_presence(
@@ -741,53 +743,36 @@ pub(crate) async fn scan_manifest_chunks(
 /// Blob roots are content-addressed by their complete bytes, while chunk rows
 /// are a mutable physical representation. A later valid writer may select a
 /// different layout for the same content hash. Restricting reads to the
-/// declared ordinal range keeps stale suffix rows harmless; the caller still
+/// declared byte extent keeps stale suffix rows harmless; the caller still
 /// rejects missing declared rows by comparing the resulting count.
 async fn load_declared_manifest_chunks(
     store: &(impl StorageAdapterRead + ?Sized),
     blob_hash: BlobId,
-    chunk_count: u32,
+    size_bytes: u64,
 ) -> Result<Vec<KvBlobManifestChunk>, LixError> {
-    if chunk_count == 0 {
-        return Ok(Vec::new());
-    }
-    let range = StorageKeyRange {
-        lower: Bound::Included(StorageKey(Bytes::from(manifest_chunk_key(blob_hash, 0)))),
-        upper: Bound::Excluded(StorageKey(Bytes::from(manifest_chunk_key(
-            blob_hash,
-            u64::from(chunk_count),
-        )))),
-    };
-    scan_all_values_for_range(store, BINARY_CAS_MANIFEST_CHUNK_SPACE, range)
-        .await?
-        .into_iter()
-        .map(|value| {
-            let (chunk_hash, chunk_size) = decode_binary_cas_manifest_chunk(&value)?;
-            Ok(KvBlobManifestChunk {
-                chunk_hash,
-                chunk_size,
-            })
-        })
-        .collect()
+    load_declared_manifest_chunk_range(store, blob_hash, 0, size_bytes).await
 }
 
-/// Loads one ordinal interval from a fixed-size media manifest.
+/// Loads the manifest rows covering one byte interval of a chunked blob.
+///
+/// `start_offset` must name a chunk start. Callers align it to
+/// [`CHUNK_ANCHOR_BYTES`], which the chunker forces to be a boundary.
 async fn load_declared_manifest_chunk_range(
     store: &(impl StorageAdapterRead + ?Sized),
     blob_hash: BlobId,
-    start_index: u64,
-    end_index: u64,
+    start_offset: u64,
+    end_offset: u64,
 ) -> Result<Vec<KvBlobManifestChunk>, LixError> {
-    if start_index >= end_index {
+    if start_offset >= end_offset {
         return Ok(Vec::new());
     }
     let range = StorageKeyRange {
         lower: Bound::Included(StorageKey(Bytes::from(manifest_chunk_key(
             blob_hash,
-            start_index,
+            start_offset,
         )))),
         upper: Bound::Excluded(StorageKey(Bytes::from(manifest_chunk_key(
-            blob_hash, end_index,
+            blob_hash, end_offset,
         )))),
     };
     scan_all_values_for_range(store, BINARY_CAS_MANIFEST_CHUNK_SPACE, range)
@@ -806,12 +791,12 @@ async fn load_declared_manifest_chunk_range(
 pub(crate) fn stage_manifest_chunk(
     writes: &mut StorageWriteSet,
     blob_hash: BlobId,
-    chunk_index: u64,
+    chunk_offset: u64,
     chunk: &KvBlobManifestChunk,
 ) {
     writes.put(
         BINARY_CAS_MANIFEST_CHUNK_SPACE,
-        key(manifest_chunk_key(blob_hash, chunk_index)),
+        key(manifest_chunk_key(blob_hash, chunk_offset)),
         value(encode_binary_cas_manifest_chunk(
             &chunk.chunk_hash,
             chunk.chunk_size,
@@ -874,7 +859,7 @@ fn stage_content_chunk(
     Ok(())
 }
 
-pub(in crate::binary_cas) async fn stage_fixed_part_skipping_existing(
+pub(in crate::binary_cas) async fn stage_upload_part_skipping_existing(
     store: &(impl StorageAdapterRead + ?Sized),
     writes: &mut StorageWriteSet,
     transaction_chunk_keys: &mut HashSet<Vec<u8>>,
@@ -888,11 +873,16 @@ pub(in crate::binary_cas) async fn stage_fixed_part_skipping_existing(
     }
     #[cfg(feature = "storage-benches")]
     crate::storage_bench::record_media_upload_chunk_payload_hash_bytes(bytes.len());
-    let receipts = bytes
-        .chunks(crate::binary_cas::chunking::MEDIA_CHUNK_BYTES)
-        .map(|chunk| crate::binary_cas::BlobChunkReceipt {
-            hash: ChunkHash::from_content(chunk),
-            size_bytes: chunk.len() as u64,
+    // A part is anchor-aligned and at most one anchor long, so chunking it in
+    // isolation reproduces exactly the boundaries a whole-buffer write of the
+    // same file would choose. That is what keeps parts independent and lets up
+    // to four of them complete out of order.
+    let ranges = chunk_ranges_with_chunking(bytes, BinaryCasChunking::default());
+    let receipts = ranges
+        .iter()
+        .map(|&(start, end)| crate::binary_cas::BlobChunkReceipt {
+            hash: ChunkHash::from_content(&bytes[start..end]),
+            size_bytes: (end - start) as u64,
         })
         .collect::<Vec<_>>();
     let mut candidates = Vec::with_capacity(receipts.len());
@@ -909,18 +899,15 @@ pub(in crate::binary_cas) async fn stage_fixed_part_skipping_existing(
         .zip(existing)
         .filter_map(|((hash, _), exists)| (!exists).then_some(hash))
         .collect::<HashSet<_>>();
-    for (chunk, receipt) in bytes
-        .chunks(crate::binary_cas::chunking::MEDIA_CHUNK_BYTES)
-        .zip(&receipts)
-    {
+    for (&(start, end), receipt) in ranges.iter().zip(&receipts) {
         if missing.remove(&receipt.hash) {
-            stage_content_chunk(writes, receipt.hash, chunk)?;
+            stage_content_chunk(writes, receipt.hash, &bytes[start..end])?;
         }
     }
     Ok(receipts)
 }
 
-pub(in crate::binary_cas) fn stage_fixed_manifest(
+pub(in crate::binary_cas) fn stage_upload_manifest(
     writes: &mut StorageWriteSet,
     chunks: &[crate::binary_cas::BlobChunkReceipt],
 ) -> Result<BlobWriteReceipt, LixError> {
@@ -931,16 +918,11 @@ pub(in crate::binary_cas) fn stage_fixed_manifest(
         )
     })?;
     let mut size_bytes = 0u64;
-    for (index, chunk) in chunks.iter().enumerate() {
-        let is_last = index + 1 == chunks.len();
-        if chunk.size_bytes == 0
-            || chunk.size_bytes > crate::binary_cas::chunking::MEDIA_CHUNK_BYTES as u64
-            || (!is_last
-                && chunk.size_bytes != crate::binary_cas::chunking::MEDIA_CHUNK_BYTES as u64)
-        {
+    for chunk in chunks.iter() {
+        if chunk.size_bytes == 0 || chunk.size_bytes > MAX_BINARY_CAS_CHUNK_BYTES as u64 {
             return Err(LixError::new(
                 LixError::CODE_INVALID_PARAM,
-                "resumable file receipts are not canonical fixed chunks",
+                "resumable file receipts are not canonical chunks",
             ));
         }
         size_bytes = size_bytes.checked_add(chunk.size_bytes).ok_or_else(|| {
@@ -986,19 +968,21 @@ pub(in crate::binary_cas) fn stage_fixed_manifest(
                     chunk_count: *chunk_count,
                 },
             );
-            for (index, chunk) in chunks.iter().enumerate() {
+            let mut chunk_offset = 0u64;
+            for chunk in chunks.iter() {
                 stage_manifest_chunk(
                     writes,
                     hash,
-                    index as u64,
+                    chunk_offset,
                     &KvBlobManifestChunk {
                         chunk_hash: chunk.hash.into_bytes(),
                         chunk_size: chunk.size_bytes,
                     },
                 );
+                chunk_offset += chunk.size_bytes;
             }
         }
-        BlobLayout::Delta { .. } => unreachable!("fixed upload cannot produce delta layout"),
+        BlobLayout::Delta { .. } => unreachable!("resumable upload cannot produce delta layout"),
     }
     Ok(BlobWriteReceipt {
         hash,
@@ -1176,7 +1160,7 @@ pub(crate) async fn load_bytes_many(
             };
             seen_manifest_hashes
                 .insert(metadata.hash)
-                .then_some((metadata.hash, *chunk_count))
+                .then_some((metadata.hash, *chunk_count, metadata.size_bytes))
         })
         .collect::<Vec<_>>();
     let scan_count = chunked_blobs.len();
@@ -1184,10 +1168,10 @@ pub(crate) async fn load_bytes_many(
     // the bounded window from refilling. Results cross the gate below only in
     // first-request order, preserving deterministic error selection.
     let mut scans = stream::iter(chunked_blobs.into_iter().enumerate())
-        .map(|(order, (blob_hash, chunk_count))| async move {
+        .map(|(order, (blob_hash, chunk_count, size_bytes))| async move {
             let result = async {
                 let manifest_chunks =
-                    load_declared_manifest_chunks(store, blob_hash, chunk_count).await?;
+                    load_declared_manifest_chunks(store, blob_hash, size_bytes).await?;
                 if manifest_chunks.len() != chunk_count as usize {
                     return Err(LixError::new(
                         "LIX_ERROR_UNKNOWN",
@@ -1450,75 +1434,67 @@ async fn load_blob_range(
             decoded[start..end].to_vec()
         }
         BlobLayout::Chunked { chunk_count } => {
-            let fixed_chunk_bytes = crate::binary_cas::chunking::MEDIA_CHUNK_BYTES as u64;
-            let first_chunk_index = range.start / fixed_chunk_bytes;
-            let end_chunk_index = range
-                .end
-                .div_ceil(fixed_chunk_bytes)
-                .min(u64::from(*chunk_count));
+            // Content-defined boundaries mean the chunk holding an offset
+            // cannot be named by division. The chunker forces a boundary at
+            // every anchor, so the anchor at or below the requested start is
+            // always an exact manifest key: one range scan from there covers
+            // the request without reading the whole manifest.
+            let anchor_bytes = CHUNK_ANCHOR_BYTES as u64;
+            let scan_start = range.start - range.start % anchor_bytes;
             let manifest = load_declared_manifest_chunk_range(
                 store,
                 metadata.hash,
-                first_chunk_index,
-                end_chunk_index,
+                scan_start,
+                range.end,
             )
             .await?;
-            let expected_manifest_len = usize::try_from(end_chunk_index - first_chunk_index)
-                .map_err(|_| {
-                    LixError::new(
-                        LixError::CODE_INTERNAL_ERROR,
-                        "binary CAS selected manifest range exceeds this runtime",
-                    )
-                })?;
-            if manifest.len() != expected_manifest_len {
+            if manifest.is_empty() || manifest.len() > *chunk_count as usize {
                 return Err(LixError::new(
                     "LIX_ERROR_UNKNOWN",
                     format!(
-                        "binary CAS blob '{}' expected {} selected chunks, found {}",
+                        "binary CAS blob '{}' has no usable manifest rows for the requested range",
                         metadata.hash.to_hex(),
-                        expected_manifest_len,
-                        manifest.len()
                     ),
                 ));
             }
             let mut selected = Vec::with_capacity(manifest.len());
-            for (selected_index, chunk) in manifest.into_iter().enumerate() {
-                let chunk_index = first_chunk_index
-                    + u64::try_from(selected_index).map_err(|_| {
-                        LixError::new(
-                            LixError::CODE_INTERNAL_ERROR,
-                            "binary CAS selected chunk index exceeds u64",
-                        )
-                    })?;
-                let chunk_start = chunk_index.checked_mul(fixed_chunk_bytes).ok_or_else(|| {
+            let mut cursor = scan_start;
+            for chunk in manifest {
+                let chunk_start = cursor;
+                cursor = chunk_start.checked_add(chunk.chunk_size).ok_or_else(|| {
                     LixError::new("LIX_ERROR_UNKNOWN", "binary CAS chunk offsets overflow u64")
                 })?;
-                let expected_chunk_size = if chunk_index + 1 == u64::from(*chunk_count) {
-                    metadata
-                        .size_bytes
-                        .checked_sub(chunk_start)
-                        .ok_or_else(|| {
-                            LixError::new(
-                                "LIX_ERROR_UNKNOWN",
-                                "binary CAS final chunk starts beyond the declared blob size",
-                            )
-                        })?
-                } else {
-                    fixed_chunk_bytes
-                };
-                if chunk.chunk_size != expected_chunk_size {
+                if chunk.chunk_size == 0
+                    || chunk.chunk_size > MAX_BINARY_CAS_CHUNK_BYTES as u64
+                    || cursor > metadata.size_bytes
+                {
                     return Err(LixError::new(
                         "LIX_ERROR_UNKNOWN",
                         format!(
-                            "binary CAS blob '{}' chunk {} has size {}, expected {}",
+                            "binary CAS blob '{}' chunk at offset {} has size {}",
                             metadata.hash.to_hex(),
-                            chunk_index,
+                            chunk_start,
                             chunk.chunk_size,
-                            expected_chunk_size,
                         ),
                     ));
                 }
-                selected.push((chunk_start, chunk));
+                if cursor > range.start {
+                    selected.push((chunk_start, chunk));
+                }
+                if cursor >= range.end {
+                    break;
+                }
+            }
+            if cursor < range.end {
+                return Err(LixError::new(
+                    "LIX_ERROR_UNKNOWN",
+                    format!(
+                        "binary CAS blob '{}' manifest ends at {} before the requested {}",
+                        metadata.hash.to_hex(),
+                        cursor,
+                        range.end,
+                    ),
+                ));
             }
             let hashes = selected
                 .iter()
@@ -2147,7 +2123,7 @@ where
     }
 
     let Ok(base_chunks) =
-        load_declared_manifest_chunks(&store, splice.base_blob_hash, chunk_count).await
+        load_declared_manifest_chunks(&store, splice.base_blob_hash, metadata.size_bytes).await
     else {
         return Ok(false);
     };
@@ -2205,7 +2181,7 @@ where
             chunk_count,
         },
     );
-    for (chunk_index, (chunk, changed)) in chunks.into_iter().enumerate() {
+    for (chunk, changed) in chunks {
         let chunk_data = &bytes[chunk.start..chunk.end];
         if changed && chunk_hashes_to_stage.remove(&chunk.hash) {
             stage_content_chunk(writes, chunk.hash, chunk_data)?;
@@ -2213,7 +2189,7 @@ where
         stage_manifest_chunk(
             writes,
             blob_hash,
-            chunk_index as u64,
+            chunk.start as u64,
             &KvBlobManifestChunk {
                 chunk_hash: *chunk.hash.as_bytes(),
                 chunk_size: chunk_data.len() as u64,
@@ -2605,7 +2581,7 @@ fn stage_prepared_blob_write(
                 },
             );
 
-            for (chunk_index, chunk) in chunks.iter().copied().enumerate() {
+            for chunk in chunks.iter().copied() {
                 let chunk_data = &bytes[chunk.start..chunk.end];
                 let chunk_hash = chunk.hash;
                 if should_stage_chunk(chunk_hash)? {
@@ -2615,7 +2591,7 @@ fn stage_prepared_blob_write(
                 stage_manifest_chunk(
                     writes,
                     plan.blob_hash,
-                    chunk_index as u64,
+                    chunk.start as u64,
                     &KvBlobManifestChunk {
                         chunk_hash: *chunk_hash.as_bytes(),
                         chunk_size: chunk_data.len() as u64,
@@ -2879,10 +2855,14 @@ fn manifest_chunk_prefix(blob_hash: BlobId) -> Vec<u8> {
     blob_hash.as_bytes().to_vec()
 }
 
-fn manifest_chunk_key(blob_hash: BlobId, chunk_index: u64) -> Vec<u8> {
+/// Manifest chunk rows are keyed by the chunk's byte offset in the blob rather
+/// than by its ordinal, because content-defined boundaries make the ordinal
+/// unrelated to the offset. Offsets keep a ranged read to one range scan that
+/// starts at a key the anchor rule guarantees exists.
+fn manifest_chunk_key(blob_hash: BlobId, chunk_offset: u64) -> Vec<u8> {
     let mut out = Vec::with_capacity(40);
     out.extend_from_slice(blob_hash.as_bytes());
-    out.extend_from_slice(&chunk_index.to_be_bytes());
+    out.extend_from_slice(&chunk_offset.to_be_bytes());
     out
 }
 
@@ -4726,7 +4706,7 @@ mod tests {
             .collect::<Vec<_>>();
         assert_eq!(
             actual_hashes, expected_hashes,
-            "fallback must retain the canonical chunk layout"
+            "fallback must retain the content-defined layout"
         );
         assert_eq!(
             load_bytes_many(&store, &[after_blob_hash])

--- a/packages/lix/src/binary_cas/kv.rs
+++ b/packages/lix/src/binary_cas/kv.rs
@@ -3169,12 +3169,13 @@ mod tests {
                     .expect("test chunk count should fit in u32"),
             },
         );
-        for (index, chunk) in chunks.iter().enumerate() {
+        let mut chunk_offset = 0u64;
+        for chunk in chunks.iter() {
             let chunk_hash = ChunkHash::from_content(chunk);
             stage_manifest_chunk(
                 writes,
                 blob_hash,
-                index as u64,
+                chunk_offset,
                 &KvBlobManifestChunk {
                     chunk_hash: chunk_hash.into_bytes(),
                     chunk_size: chunk.len() as u64,
@@ -3187,6 +3188,7 @@ mod tests {
                 chunk.len() as u64,
                 chunk,
             );
+            chunk_offset += chunk.len() as u64;
         }
         (blob_hash, bytes)
     }
@@ -3273,16 +3275,18 @@ mod tests {
                 chunk_count: chunks.len() as u32,
             },
         );
-        for (index, (chunk_hash, chunk_size)) in chunks.iter().copied().enumerate() {
+        let mut chunk_offset = 0u64;
+        for (chunk_hash, chunk_size) in chunks.iter().copied() {
             stage_manifest_chunk(
                 writes,
                 blob_id,
-                index as u64,
+                chunk_offset,
                 &KvBlobManifestChunk {
                     chunk_hash: chunk_hash.into_bytes(),
                     chunk_size,
                 },
             );
+            chunk_offset += chunk_size;
         }
         blob_id
     }
@@ -3763,7 +3767,7 @@ mod tests {
             stage_manifest_chunk(
                 &mut writes,
                 blob_hash,
-                1,
+                6,
                 &KvBlobManifestChunk {
                     chunk_hash: chunk_b_hash,
                     chunk_size: 6,
@@ -3827,7 +3831,7 @@ mod tests {
             stage_manifest_chunk(
                 &mut writes,
                 fixture.0,
-                2,
+                fixture.1.len() as u64,
                 &KvBlobManifestChunk {
                     chunk_hash: ChunkHash::from_content(b"stale manifest suffix").into_bytes(),
                     chunk_size: 1,
@@ -4097,7 +4101,7 @@ mod tests {
     }
 
     #[test]
-    fn binary_hash_keys_are_compact_and_manifest_chunks_sort_by_index() {
+    fn binary_hash_keys_are_compact_and_manifest_chunks_sort_by_offset() {
         let blob_hash = BlobId::from_content(b"blob");
         let manifest_key = manifest_key(blob_hash);
         let chunk_key = chunk_key(ChunkHash::from_content(b"chunk"));
@@ -4235,10 +4239,27 @@ mod tests {
             data[requested.start as usize..requested.end as usize]
         );
 
+        // Content-defined boundaries are not known statically, so locate the
+        // first manifest row that starts after the requested range and delete
+        // it: a ranged read must never need it.
+        let mut trailing_offset = 0u64;
+        for chunk in scan_manifest_chunks(&store, blob_hash)
+            .await
+            .expect("manifest rows should scan")
+        {
+            if trailing_offset >= requested.end {
+                break;
+            }
+            trailing_offset += chunk.chunk_size;
+        }
+        assert!(
+            trailing_offset < data.len() as u64,
+            "the fixture must have a manifest row past the requested range"
+        );
         let mut writes = storage.new_write_set();
         writes.delete(
             BINARY_CAS_MANIFEST_CHUNK_SPACE,
-            manifest_chunk_key(blob_hash, 2),
+            key(manifest_chunk_key(blob_hash, trailing_offset)),
         );
         storage
             .commit_write_set(writes, StorageWriteOptions::default())

--- a/packages/lix/src/binary_cas/types.rs
+++ b/packages/lix/src/binary_cas/types.rs
@@ -312,9 +312,17 @@ mod tests {
 
     #[test]
     fn payload_carries_exact_canonical_chunk_receipts() {
-        let bytes = (0..MEDIA_CHUNK_BYTES * 2 + 17)
-            .map(|index| (index as u8).wrapping_mul(31))
-            .collect::<Vec<_>>();
+        // A byte pattern with real variety: the gear hash finds no cut point in
+        // a short repeating sequence, so a periodic fixture would collapse to
+        // one max-sized chunk and prove nothing about receipt ordering.
+        let mut bytes = vec![0u8; MEDIA_CHUNK_BYTES * 5 + 17];
+        let mut state = 0x2545_f491_4f6c_dd1d_u64;
+        for chunk in bytes.chunks_mut(8) {
+            state ^= state << 13;
+            state ^= state >> 7;
+            state ^= state << 17;
+            chunk.copy_from_slice(&state.to_le_bytes()[..chunk.len()]);
+        }
         let payload = BlobPayload::from_bytes(bytes.clone());
 
         // Boundaries are content-defined, so the receipts are asserted by the

--- a/packages/lix/src/binary_cas/types.rs
+++ b/packages/lix/src/binary_cas/types.rs
@@ -317,15 +317,18 @@ mod tests {
             .collect::<Vec<_>>();
         let payload = BlobPayload::from_bytes(bytes.clone());
 
-        assert_eq!(payload.chunks().len(), 3);
-        assert_eq!(payload.chunks()[0].size_bytes, MEDIA_CHUNK_BYTES as u64);
-        assert_eq!(payload.chunks()[1].size_bytes, MEDIA_CHUNK_BYTES as u64);
-        assert_eq!(payload.chunks()[2].size_bytes, 17);
+        // Boundaries are content-defined, so the receipts are asserted by the
+        // properties staging relies on rather than by fixed sizes: they tile
+        // the payload in order and each names its own slice.
+        assert!(payload.chunks().len() > 1);
         assert_eq!(payload.hash(), Some(BlobId::from_content(&bytes)));
-        for (receipt, chunk) in payload.chunks().iter().zip(bytes.chunks(MEDIA_CHUNK_BYTES)) {
-            assert_eq!(receipt.hash, ChunkHash::from_content(chunk));
-            assert_eq!(receipt.size_bytes, chunk.len() as u64);
+        let mut cursor = 0usize;
+        for receipt in payload.chunks() {
+            let end = cursor + receipt.size_bytes as usize;
+            assert_eq!(receipt.hash, ChunkHash::from_content(&bytes[cursor..end]));
+            cursor = end;
         }
+        assert_eq!(cursor, bytes.len());
 
         let clone = payload.clone();
         assert!(std::ptr::eq(

--- a/packages/lix/src/session/media_upload.rs
+++ b/packages/lix/src/session/media_upload.rs
@@ -264,7 +264,7 @@ where
             let chunks = if content.is_empty() {
                 Vec::new()
             } else {
-                writer.stage_fixed_part(&content).await?
+                writer.stage_upload_part(&content).await?
             };
             drop(writer);
             let leaf = UploadManifestLeaf {
@@ -411,7 +411,7 @@ where
         let receipt = self
             .binary_cas
             .writer_skipping_existing_chunks(&read, &mut finalization_writes)
-            .stage_fixed_manifest(&receipts)?;
+            .stage_upload_manifest(&receipts)?;
         let complete = UploadState::Complete(UploadComplete {
             path: state.path.clone(),
             total_size: state.total_size,
@@ -905,7 +905,7 @@ mod tests {
         let mut writes = storage.new_write_set();
         let receipts = crate::binary_cas::BinaryCasContext::new()
             .writer_skipping_existing_chunks(&read, &mut writes)
-            .stage_fixed_part(payload)
+            .stage_upload_part(payload)
             .await
             .expect("orphan fixed chunk should stage");
         assert_eq!(receipts.len(), 1);
@@ -979,7 +979,7 @@ mod tests {
         let mut writes = storage.new_write_set();
         let chunks = crate::binary_cas::BinaryCasContext::new()
             .writer_skipping_existing_chunks(read, &mut writes)
-            .stage_fixed_part(payload)
+            .stage_upload_part(payload)
             .await
             .expect("deduplicated receipt chunk should stage");
         assert_eq!(

--- a/packages/lix/src/session/media_upload.rs
+++ b/packages/lix/src/session/media_upload.rs
@@ -1635,7 +1635,12 @@ mod tests {
                 panic!("manifest leaf scan must return values");
             };
             let leaf = decode_upload_manifest_leaf(&value).expect("decode manifest leaf");
-            assert_eq!(leaf.chunks.len(), FILE_UPLOAD_PART_BYTES / (1024 * 1024));
+            assert!(!leaf.chunks.is_empty());
+            assert_eq!(
+                leaf.chunks.iter().map(|chunk| chunk.size_bytes).sum::<u64>(),
+                FILE_UPLOAD_PART_BYTES as u64,
+                "a part's content-defined chunks must tile the part exactly"
+            );
         }
         drop(cursor);
         drop(read);

--- a/packages/lix/src/session/media_upload.rs
+++ b/packages/lix/src/session/media_upload.rs
@@ -659,12 +659,12 @@ fn decode_upload_manifest_leaf(value: &[u8]) -> Result<UploadManifestLeaf, LixEr
     let part_size = u64::from_be_bytes(
         value[8..16]
             .try_into()
-            .expect("fixed upload manifest leaf part size"),
+            .expect("upload manifest leaf part size"),
     );
     let chunk_count = u32::from_be_bytes(
         value[16..20]
             .try_into()
-            .expect("fixed upload manifest leaf chunk count"),
+            .expect("upload manifest leaf chunk count"),
     ) as usize;
     let expected_len = HEADER_BYTES
         .checked_add(chunk_count.saturating_mul(40))
@@ -682,7 +682,7 @@ fn decode_upload_manifest_leaf(value: &[u8]) -> Result<UploadManifestLeaf, LixEr
         let size_bytes = u64::from_be_bytes(
             encoded[32..]
                 .try_into()
-                .expect("fixed upload manifest leaf chunk size"),
+                .expect("upload manifest leaf chunk size"),
         );
         chunks.push(BlobChunkReceipt {
             hash: ChunkHash::from_bytes(hash),
@@ -907,13 +907,13 @@ mod tests {
             .writer_skipping_existing_chunks(&read, &mut writes)
             .stage_upload_part(payload)
             .await
-            .expect("orphan fixed chunk should stage");
+            .expect("orphan upload chunk should stage");
         assert_eq!(receipts.len(), 1);
         drop(read);
         storage
             .commit_write_set(writes, StorageWriteOptions::default())
             .await
-            .expect("orphan fixed chunk should commit");
+            .expect("orphan upload chunk should commit");
         receipts[0].hash
     }
 


### PR DESCRIPTION
> **Recommendation: close this PR.** The gate that would have made the trade
> acceptable — CDC on rewrites, fixed chunking on initial ingest — is not just
> awkward to implement, it is **measurably worse than doing nothing**. Numbers
> below. The measurement stands as the record; the durable parts of this work
> already landed in #1303 and #1309.

## Why the rewrite gate cannot work

Deduplication requires v1 and v2 of a file to be chunked **by the same rule**.
That is the entire mechanism: chunks match because boundaries land in the same
places. Gating the chunker on write context guarantees the opposite — the initial
write gets fixed 1 MiB boundaries, the rewrite gets content-defined ones, and a
content-defined boundary essentially never lands on a 1 MiB multiple.

Measured with `chunking_oracle` over the same real-file corpus (branch
`exp/chunking-oracle-gate`, scenario `mixed/fixed-v1_cdc-v2`):

| policy | stored bytes for v2 | shared |
|---|---:|---:|
| `fixed/1m` (today) | 529,835,742 | 0.451 |
| `cdc/1m@16m` (this PR) | 204,935,691 | **0.788** |
| **`mixed/fixed-v1_cdc-v2` (the gate)** | **964,697,149** | **0.001** |

The gate stores **+82% more bytes than shipping nothing at all**. Every shape
drops to 0.000 — including the ones fixed chunking already handled well, such as
`localized overwrite` (0.909 → 0.000) and `image_bmp/crop_8px` (0.975 → 0.000).

To be precise about what that row models: it is the **first** rewrite of a blob.
Under the gate, second and later rewrites would be CDC-vs-CDC and would dedup
normally. So the gate's real shape is "every blob pays one full rewrite the first
time it is edited, then behaves like CDC" — while still paying CDC's CPU on every
rewrite, which is where the cost is largest (`full_rewrite` +64%,
`localized_4k_update` +109%). It removes CPU only from the initial write (+55%),
which is exactly the lane you measured as gaining nothing.

There is a second, independent blocker: blob identity is *derived from the chunk
layout* (`BlobId::from_chunks`, keyed `"lix binary cas ... manifest"`). A
context-dependent layout gives identical bytes two different `BlobId`s, which
breaks cross-file dedup, the `prepare_blob_write` debug assertion comparing the
precomputed hash against `BlobId::from_content`, and the verification at
`filesystem/path_index.rs:633`. But the sharing table settles it without needing
that argument.

## The cheaper-CDC alternative, also measured, also insufficient

FastCDC skips `min` bytes without hashing at the start of each chunk, so raising
the minimum is directly less CPU:

| minimum | boundary search | corpus shared |
|---|---:|---:|
| avg/4 (this PR) | 4,474 MiB/s | 0.788 |
| avg/2 | 5,860 MiB/s | 0.785 |
| avg | **11,026 MiB/s** | 0.771 |

2.46x cheaper for 1.7 points of sharing — a good trade in isolation. But it only
takes the measured `initial_write` cost from +55% to roughly +23% (10 MiB: 4.04 ms
base, 2.24 ms of CDC at avg/4, 0.91 ms at avg). Still well outside the ±6%
null-control floor, still paid on a lane that your ingest run shows gains
**1.9 KB out of 675 MB**. It does not change the verdict.

## What the measurement established

Worth keeping in the record even though the change should not land:

- Fixed 1 MiB offsets share **exactly zero** on every insert and delete, and on a
  metadata-only MP4 remux that leaves the H.264 payload untouched. 21 of 47
  real-file case/shape pairs.
- Content-defined boundaries recover that: corpus stored bytes −66.5%, sharing
  0.459 → 0.818, and −57.6% on the rewrite lane specifically
  (`localized_4k_update` at 10 MiB, 12,596,217 → 5,338,799 bytes).
- That win is **confined to rewrites of an existing blob**. Initial ingest of
  unique footage has nothing to find, and pays +55%.
- Anchoring CDC at `FILE_UPLOAD_PART_BYTES` does preserve #1084's bounded upload
  memory and the four-part out-of-order window — the objection that removed
  FastCDC originally is answerable. It is the CPU-versus-benefit distribution,
  not memory, that sinks it.
- Under CDC a 512 MiB ingest produces 447 chunk rows rather than 512, i.e. ~13%
  *fewer* manifest rows. The qualification assertion is updated to a bound rather
  than an equality in this branch, since fewer, larger chunks only improve the
  projection.

## Branch state

Rebased onto `0839fdea7`. `cargo test -p lix` passes. Kept green and truthful so
it can be revisited if a workload appears whose dominant cost is repeated
rewriting of large binaries — that is the only profile this pays for.
