### PR TITLE
perf(branch): root-back explicit head moves instead of materializing the working set

### DIFF
--- a/.changenotes/root-backed-branch-head-moves.md
+++ b/.changenotes/root-backed-branch-head-moves.md
@@ -1,0 +1,7 @@
+---
+type: patch
+---
+
+Moving a branch head — most visibly a fast-forward merge — no longer copies the whole working set into storage.
+
+Creating a branch already published a single reference to the shared, immutable state at its head. Moving an existing branch's head did not: it wrote one row per tracked entity into that branch's private serving storage, so a fast-forward merge of a ten-row change in a hundred-thousand-row workspace grew the repository by roughly ten times its own size. Head moves now publish the same one-reference form, and the cost of a merge tracks the size of the merge rather than the size of the repository.

--- a/packages/engine-benchmarks/Cargo.toml
+++ b/packages/engine-benchmarks/Cargo.toml
@@ -276,6 +276,12 @@ harness = false
 required-features = ["storage-benches", "slatedb"]
 
 [[bench]]
+name = "branch_storage_sharing"
+path = "benches/branch_storage_sharing.rs"
+harness = false
+required-features = ["storage-benches", "slatedb"]
+
+[[bench]]
 name = "fixed_live_history_scale"
 path = "benches/fixed_live_history_scale.rs"
 harness = false

--- a/packages/engine-benchmarks/benches/branch_storage_sharing.rs
+++ b/packages/engine-benchmarks/benches/branch_storage_sharing.rs
@@ -1,0 +1,564 @@
+//! How much storage do two branches actually share?
+//!
+//! Seeds a realistic workspace through the real `SessionContext` SQL commit
+//! path, records settled bytes, then applies one branching scenario and records
+//! settled bytes again. The delta between the two snapshots is the price of the
+//! scenario.
+//!
+//! Two independent measurements are taken per snapshot:
+//!
+//! * `physical_bytes` — a recursive filesystem walk of the backend directory
+//!   after a memtable flush. Covers every byte the backend wrote, including
+//!   spaces that are absent from the layout catalog, but is subject to LSM
+//!   compaction timing.
+//! * `layout_accounting` — exact logical `rows / key_bytes / value_bytes` per
+//!   storage space. Deterministic and attributable: it says *which* plane paid.
+//!
+//! Run:
+//! ```text
+//! LIX_BRANCH_SHARING_ROWS=1000,10000,100000 \
+//! LIX_BRANCH_SHARING_BACKENDS=rocksdb,slatedb \
+//! cargo bench -p lix_benchmarks --features storage-benches,slatedb --bench branch_storage_sharing
+//! ```
+
+#![allow(clippy::large_futures)]
+
+use std::collections::BTreeMap;
+use std::path::Path;
+use std::time::{Duration, Instant};
+
+use lix::integration::{Engine, SessionContext};
+use lix::storage::{ReadOptions, Storage};
+use lix::storage_adapter::StorageAdapter;
+use lix::storage_bench::{collect_repository_gc_for_bench, layout_accounting};
+use lix::{CreateBranchOptions, MergeBranchOptions, Value};
+use lix_storage_rocksdb::RocksDB;
+use lix_storage_slatedb::SlateDB;
+
+const DEFAULT_SCENARIOS: &[&str] = &[
+    "base",
+    "branch_noop",
+    "branch_1row",
+    "branch_1pct",
+    "branch_10pct",
+    "branches_10",
+    "branches_100",
+    "branches_10_1row",
+    "merge_1pct",
+    "delete_gc_1pct",
+];
+
+const SEED_BATCH_ROWS: usize = 5_000;
+
+fn main() {
+    let rows_list = env_usizes("LIX_BRANCH_SHARING_ROWS", &[1_000, 10_000, 100_000]);
+    let scenarios: Vec<String> = std::env::var("LIX_BRANCH_SHARING_SCENARIOS")
+        .map(|value| {
+            value
+                .split(',')
+                .map(str::trim)
+                .filter(|value| !value.is_empty())
+                .map(str::to_owned)
+                .collect()
+        })
+        .unwrap_or_else(|_| DEFAULT_SCENARIOS.iter().map(|s| (*s).to_owned()).collect());
+    let settle_ms = env_u64("LIX_BRANCH_SHARING_SETTLE_MS", 250);
+    let repetition = env_usize("LIX_BRANCH_SHARING_REP", 0);
+
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("create branch-sharing runtime");
+
+    runtime.block_on(async {
+        for rows in rows_list {
+            for scenario in &scenarios {
+                if selected("LIX_BRANCH_SHARING_BACKENDS", "rocksdb") {
+                    let directory = tempfile::tempdir().expect("create RocksDB directory");
+                    let storage =
+                        RocksDB::open(directory.path()).expect("open branch-sharing RocksDB");
+                    run_case(
+                        "rocksdb",
+                        storage,
+                        directory.path(),
+                        rows,
+                        scenario,
+                        settle_ms,
+                        repetition,
+                    )
+                    .await;
+                }
+                if selected("LIX_BRANCH_SHARING_BACKENDS", "slatedb") {
+                    let directory = tempfile::tempdir().expect("create SlateDB directory");
+                    let storage =
+                        SlateDB::open(directory.path()).expect("open branch-sharing SlateDB");
+                    run_case(
+                        "slatedb",
+                        storage,
+                        directory.path(),
+                        rows,
+                        scenario,
+                        settle_ms,
+                        repetition,
+                    )
+                    .await;
+                }
+            }
+        }
+    });
+}
+
+/// Backend-specific settling so `physical_bytes` samples SST state rather than
+/// a memtable.
+trait BenchBackend: Storage + Clone + Send + Sync + 'static {
+    fn settle(&self) -> impl std::future::Future<Output = ()>;
+}
+
+impl BenchBackend for RocksDB {
+    async fn settle(&self) {
+        self.flush().expect("flush branch-sharing RocksDB");
+    }
+}
+
+impl BenchBackend for SlateDB {
+    async fn settle(&self) {
+        self.flush_memtable_for_diagnostics()
+            .await
+            .expect("flush branch-sharing SlateDB memtable");
+    }
+}
+
+#[derive(Clone, Default)]
+struct Snapshot {
+    physical_bytes: u64,
+    physical_objects: u64,
+    spaces: BTreeMap<&'static str, SpaceCounts>,
+}
+
+#[derive(Clone, Copy, Default)]
+struct SpaceCounts {
+    rows: u64,
+    key_bytes: u64,
+    value_bytes: u64,
+}
+
+impl Snapshot {
+    fn logical_rows(&self) -> u64 {
+        self.spaces.values().map(|counts| counts.rows).sum()
+    }
+
+    fn logical_bytes(&self) -> u64 {
+        self.spaces
+            .values()
+            .map(|counts| counts.key_bytes + counts.value_bytes)
+            .sum()
+    }
+}
+
+async fn snapshot<S>(storage: &S, directory: &Path, settle_ms: u64) -> Snapshot
+where
+    S: BenchBackend,
+{
+    storage.settle().await;
+    if settle_ms > 0 {
+        tokio::time::sleep(Duration::from_millis(settle_ms)).await;
+    }
+    let adapter = StorageAdapter::new(storage.clone());
+    let read = adapter
+        .begin_read(ReadOptions::default())
+        .await
+        .expect("open branch-sharing layout read");
+    let accounting = layout_accounting(&read).await;
+    drop(read);
+    let mut spaces = BTreeMap::new();
+    for entry in accounting {
+        spaces.insert(
+            entry.space,
+            SpaceCounts {
+                rows: entry.rows,
+                key_bytes: entry.key_bytes,
+                value_bytes: entry.value_bytes,
+            },
+        );
+    }
+    Snapshot {
+        physical_bytes: directory_bytes(directory),
+        physical_objects: directory_objects(directory),
+        spaces,
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn run_case<S>(
+    backend: &str,
+    storage: S,
+    directory: &Path,
+    rows: usize,
+    scenario: &str,
+    settle_ms: u64,
+    repetition: usize,
+) where
+    S: BenchBackend,
+{
+    Engine::initialize(storage.clone())
+        .await
+        .expect("initialize branch-sharing repository");
+    let engine = Engine::new(storage.clone())
+        .await
+        .expect("open branch-sharing engine");
+    let main = engine
+        .open_workspace_session()
+        .await
+        .expect("open branch-sharing workspace session");
+    register_schema(&main).await;
+    let seed_started = Instant::now();
+    seed_rows(&main, rows).await;
+    let seed_elapsed = seed_started.elapsed();
+
+    let base = snapshot(&storage, directory, settle_ms).await;
+
+    let scenario_started = Instant::now();
+    let branches = apply_scenario(&engine, &main, &storage, scenario, rows).await;
+    let scenario_elapsed = scenario_started.elapsed();
+
+    let after = snapshot(&storage, directory, settle_ms).await;
+
+    let changed_rows = scenario_changed_rows(scenario, rows);
+    let physical_delta = after.physical_bytes as i64 - base.physical_bytes as i64;
+    let logical_delta = after.logical_bytes() as i64 - base.logical_bytes() as i64;
+    let logical_row_delta = after.logical_rows() as i64 - base.logical_rows() as i64;
+
+    println!(
+        "branch_sharing,rep={repetition},backend={backend},rows={rows},scenario={scenario},\
+branches={branches},changed_rows={changed_rows},\
+base_physical_bytes={},after_physical_bytes={},delta_physical_bytes={physical_delta},\
+base_physical_objects={},after_physical_objects={},\
+base_logical_bytes={},after_logical_bytes={},delta_logical_bytes={logical_delta},\
+base_logical_rows={},after_logical_rows={},delta_logical_rows={logical_row_delta},\
+bytes_per_changed_row={:.2},seed_ms={:.3},scenario_ms={:.3}",
+        base.physical_bytes,
+        after.physical_bytes,
+        base.physical_objects,
+        after.physical_objects,
+        base.logical_bytes(),
+        after.logical_bytes(),
+        base.logical_rows(),
+        after.logical_rows(),
+        if changed_rows == 0 {
+            0.0
+        } else {
+            logical_delta as f64 / changed_rows as f64
+        },
+        seed_elapsed.as_secs_f64() * 1_000.0,
+        scenario_elapsed.as_secs_f64() * 1_000.0,
+    );
+
+    let mut names: Vec<&'static str> = base.spaces.keys().copied().collect();
+    for name in after.spaces.keys() {
+        if !names.contains(name) {
+            names.push(name);
+        }
+    }
+    names.sort_unstable();
+    for name in names {
+        let before = base.spaces.get(name).copied().unwrap_or_default();
+        let now = after.spaces.get(name).copied().unwrap_or_default();
+        let d_rows = now.rows as i64 - before.rows as i64;
+        let d_key = now.key_bytes as i64 - before.key_bytes as i64;
+        let d_value = now.value_bytes as i64 - before.value_bytes as i64;
+        if d_rows == 0 && d_key == 0 && d_value == 0 {
+            continue;
+        }
+        println!(
+            "branch_sharing_space,rep={repetition},backend={backend},rows={rows},scenario={scenario},\
+space={name},base_rows={},after_rows={},d_rows={d_rows},\
+base_bytes={},after_bytes={},d_bytes={}",
+            before.rows,
+            now.rows,
+            before.key_bytes + before.value_bytes,
+            now.key_bytes + now.value_bytes,
+            d_key + d_value,
+        );
+    }
+}
+
+fn scenario_changed_rows(scenario: &str, rows: usize) -> usize {
+    match scenario {
+        "branch_1row" => 1,
+        "branch_1pct" | "merge_1pct" | "delete_gc_1pct" => (rows / 100).max(1),
+        "branch_10pct" => (rows / 10).max(1),
+        "branches_10_1row" => 10,
+        _ => 0,
+    }
+}
+
+async fn apply_scenario<S>(
+    engine: &Engine<S>,
+    main: &SessionContext<S>,
+    storage: &S,
+    scenario: &str,
+    rows: usize,
+) -> usize
+where
+    S: Storage + Clone + Send + Sync + 'static,
+{
+    let one_percent = (rows / 100).max(1);
+    let ten_percent = (rows / 10).max(1);
+    match scenario {
+        "base" => 0,
+        "branch_noop" => {
+            create_branch(main, "branch-0").await;
+            1
+        }
+        "branch_1row" => {
+            let branch = create_branch(main, "branch-0").await;
+            modify_rows(engine, &branch, 0, 1).await;
+            1
+        }
+        "branch_1pct" => {
+            let branch = create_branch(main, "branch-0").await;
+            modify_rows(engine, &branch, 0, one_percent).await;
+            1
+        }
+        "branch_10pct" => {
+            let branch = create_branch(main, "branch-0").await;
+            modify_rows(engine, &branch, 0, ten_percent).await;
+            1
+        }
+        "branches_10" => {
+            for index in 0..10 {
+                create_branch(main, &format!("branch-{index}")).await;
+            }
+            10
+        }
+        "branches_100" => {
+            for index in 0..100 {
+                create_branch(main, &format!("branch-{index}")).await;
+            }
+            100
+        }
+        "branches_10_1row" => {
+            for index in 0..10 {
+                let branch = create_branch(main, &format!("branch-{index}")).await;
+                modify_rows(engine, &branch, index, 1).await;
+            }
+            10
+        }
+        "merge_1pct" => {
+            let branch = create_branch(main, "branch-0").await;
+            modify_rows(engine, &branch, 0, one_percent).await;
+            main.merge_branch(MergeBranchOptions {
+                source_branch_id: branch.clone(),
+            })
+            .await
+            .expect("merge branch-sharing branch");
+            1
+        }
+        "delete_gc_1pct" => {
+            let branch = create_branch(main, "branch-0").await;
+            modify_rows(engine, &branch, 0, one_percent).await;
+            main.execute(
+                "DELETE FROM lix_branch WHERE id = $1",
+                &[Value::Text(branch.clone())],
+            )
+            .await
+            .expect("delete branch-sharing branch");
+            let adapter = StorageAdapter::new(storage.clone());
+            collect_repository_gc_for_bench(&adapter)
+                .await
+                .expect("collect branch-sharing repository GC");
+            1
+        }
+        other => panic!("unknown LIX_BRANCH_SHARING_SCENARIOS entry '{other}'"),
+    }
+}
+
+async fn create_branch<S>(main: &SessionContext<S>, name: &str) -> String
+where
+    S: Storage + Clone + Send + Sync + 'static,
+{
+    main.create_branch(CreateBranchOptions {
+        id: None,
+        name: name.to_owned(),
+        from_commit_id: None,
+    })
+    .await
+    .expect("create branch-sharing branch")
+    .id
+}
+
+/// Updates `count` rows inside `branch`, offsetting the touched window per
+/// branch so concurrent branches touch disjoint rows.
+async fn modify_rows<S>(engine: &Engine<S>, branch: &str, branch_index: usize, count: usize)
+where
+    S: Storage + Clone + Send + Sync + 'static,
+{
+    let session = engine
+        .open_session(branch.to_owned())
+        .await
+        .expect("open branch-sharing branch session");
+    let mut written = 0usize;
+    while written < count {
+        let batch = (count - written).min(SEED_BATCH_ROWS);
+        let mut transaction = session
+            .begin_transaction()
+            .await
+            .expect("begin branch-sharing modification");
+        for offset in 0..batch {
+            let index = branch_index * 7 + written + offset;
+            transaction
+                .execute(
+                    "UPDATE branch_fixture SET value = lix_json($1) WHERE path = $2",
+                    &[
+                        Value::Text(format!(r#"{{"seed":{index},"pad":"{PAD}"}}"#)),
+                        Value::Text(row_path(index)),
+                    ],
+                )
+                .await
+                .expect("stage branch-sharing modification");
+        }
+        transaction
+            .commit()
+            .await
+            .expect("commit branch-sharing modification");
+        written += batch;
+    }
+}
+
+const PAD: &str = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+
+fn row_path(index: usize) -> String {
+    format!("/branch/fixture/{index:09}")
+}
+
+async fn register_schema<S>(session: &SessionContext<S>)
+where
+    S: Storage + Clone + Send + Sync + 'static,
+{
+    let schema = serde_json::json!({
+        "x-lix-key": "branch_fixture",
+        "x-lix-primary-key": ["/path"],
+        "type": "object",
+        "required": ["path", "value"],
+        "properties": {
+            "path": { "type": "string" },
+            "value": {
+                "type": ["object", "array", "string", "number", "integer", "boolean", "null"]
+            }
+        },
+        "additionalProperties": false
+    });
+    session
+        .execute(
+            "INSERT INTO lix_registered_schema (value, lixcol_global, lixcol_untracked) \
+             VALUES (lix_json($1), false, false)",
+            &[Value::Text(schema.to_string())],
+        )
+        .await
+        .expect("register branch-sharing schema");
+}
+
+async fn seed_rows<S>(session: &SessionContext<S>, rows: usize)
+where
+    S: Storage + Clone + Send + Sync + 'static,
+{
+    let mut written = 0usize;
+    while written < rows {
+        let batch = (rows - written).min(SEED_BATCH_ROWS);
+        let mut transaction = session
+            .begin_transaction()
+            .await
+            .expect("begin branch-sharing seed");
+        for offset in 0..batch {
+            let index = written + offset;
+            transaction
+                .execute(
+                    "INSERT INTO branch_fixture (path, value) VALUES ($1, lix_json($2))",
+                    &[
+                        Value::Text(row_path(index)),
+                        Value::Text(format!(r#"{{"seed":{index},"pad":"{PAD}"}}"#)),
+                    ],
+                )
+                .await
+                .expect("stage branch-sharing seed row");
+        }
+        transaction
+            .commit()
+            .await
+            .expect("commit branch-sharing seed");
+        written += batch;
+    }
+}
+
+fn directory_bytes(path: &Path) -> u64 {
+    std::fs::read_dir(path).map_or(0, |entries| {
+        entries
+            .flatten()
+            .map(|entry| {
+                let path = entry.path();
+                entry.metadata().map_or(0, |metadata| {
+                    if metadata.is_dir() {
+                        directory_bytes(&path)
+                    } else {
+                        metadata.len()
+                    }
+                })
+            })
+            .sum()
+    })
+}
+
+fn directory_objects(path: &Path) -> u64 {
+    std::fs::read_dir(path).map_or(0, |entries| {
+        entries
+            .flatten()
+            .map(|entry| {
+                let path = entry.path();
+                entry.metadata().map_or(0, |metadata| {
+                    if metadata.is_dir() {
+                        directory_objects(&path)
+                    } else {
+                        1
+                    }
+                })
+            })
+            .sum()
+    })
+}
+
+fn env_usize(name: &str, default: usize) -> usize {
+    std::env::var(name)
+        .ok()
+        .and_then(|value| value.parse().ok())
+        .unwrap_or(default)
+}
+
+fn env_u64(name: &str, default: u64) -> u64 {
+    std::env::var(name)
+        .ok()
+        .and_then(|value| value.parse().ok())
+        .unwrap_or(default)
+}
+
+fn env_usizes(name: &str, default: &[usize]) -> Vec<usize> {
+    std::env::var(name)
+        .ok()
+        .map(|value| {
+            value
+                .split(',')
+                .map(str::trim)
+                .filter(|value| !value.is_empty())
+                .map(|value| value.parse().expect("numeric branch-sharing list entry"))
+                .collect()
+        })
+        .unwrap_or_else(|| default.to_vec())
+}
+
+fn selected(name: &str, candidate: &str) -> bool {
+    std::env::var(name).map_or(true, |selection| {
+        selection
+            .split(',')
+            .map(str::trim)
+            .any(|value| value == candidate)
+    })
+}

--- a/packages/engine-benchmarks/benches/branch_storage_sharing.rs
+++ b/packages/engine-benchmarks/benches/branch_storage_sharing.rs
@@ -254,6 +254,19 @@ bytes_per_changed_row={:.2},seed_ms={:.3},scenario_ms={:.3}",
         scenario_elapsed.as_secs_f64() * 1_000.0,
     );
 
+    if scenario == "base" {
+        for (name, counts) in &base.spaces {
+            if counts.rows == 0 {
+                continue;
+            }
+            println!(
+                "branch_sharing_base_space,rep={repetition},backend={backend},rows={rows},\
+space={name},base_rows={},base_key_bytes={},base_value_bytes={}",
+                counts.rows, counts.key_bytes, counts.value_bytes,
+            );
+        }
+    }
+
     let mut names: Vec<&'static str> = base.spaces.keys().copied().collect();
     for name in after.spaces.keys() {
         if !names.contains(name) {

--- a/packages/engine-benchmarks/benches/branch_storage_sharing.rs
+++ b/packages/engine-benchmarks/benches/branch_storage_sharing.rs
@@ -24,6 +24,7 @@
 #![allow(clippy::large_futures)]
 
 use std::collections::BTreeMap;
+use std::future::Future;
 use std::path::Path;
 use std::time::{Duration, Instant};
 
@@ -111,7 +112,7 @@ fn main() {
 /// Backend-specific settling so `physical_bytes` samples SST state rather than
 /// a memtable.
 trait BenchBackend: Storage + Clone + Send + Sync + 'static {
-    fn settle(&self) -> impl std::future::Future<Output = ()>;
+    fn settle(&self) -> impl Future<Output = ()>;
 }
 
 impl BenchBackend for RocksDB {

--- a/packages/engine-benchmarks/benches/branch_storage_sharing.rs
+++ b/packages/engine-benchmarks/benches/branch_storage_sharing.rs
@@ -302,6 +302,7 @@ fn scenario_changed_rows(scenario: &str, rows: usize) -> usize {
         "branch_1pct" | "merge_1pct" | "delete_gc_1pct" => (rows / 100).max(1),
         "branch_10pct" => (rows / 10).max(1),
         "branches_10_1row" => 10,
+        "branches_2_disjoint_1pct" | "branches_2_identical_1pct" => 2 * (rows / 100).max(1),
         _ => 0,
     }
 }
@@ -354,9 +355,27 @@ where
         "branches_10_1row" => {
             for index in 0..10 {
                 let branch = create_branch(main, &format!("branch-{index}")).await;
-                modify_rows(engine, &branch, index, 1).await;
+                modify_rows(engine, &branch, index * 7, 1).await;
             }
             10
+        }
+        // Two branches, disjoint 1% windows: an honest two-diff price.
+        "branches_2_disjoint_1pct" => {
+            let first = create_branch(main, "branch-0").await;
+            modify_rows(engine, &first, 0, one_percent).await;
+            let second = create_branch(main, "branch-1").await;
+            modify_rows(engine, &second, one_percent, one_percent).await;
+            2
+        }
+        // Two branches making byte-identical edits to the same 1% window. If
+        // the payload planes were content-addressed end to end this would cost
+        // materially less than the disjoint case.
+        "branches_2_identical_1pct" => {
+            let first = create_branch(main, "branch-0").await;
+            modify_rows(engine, &first, 0, one_percent).await;
+            let second = create_branch(main, "branch-1").await;
+            modify_rows(engine, &second, 0, one_percent).await;
+            2
         }
         "merge_1pct" => {
             let branch = create_branch(main, "branch-0").await;
@@ -401,9 +420,11 @@ where
     .id
 }
 
-/// Updates `count` rows inside `branch`, offsetting the touched window per
-/// branch so concurrent branches touch disjoint rows.
-async fn modify_rows<S>(engine: &Engine<S>, branch: &str, branch_index: usize, count: usize)
+/// Updates the `count` rows starting at `start` inside `branch`. The written
+/// value depends only on the row index, so two branches given the same window
+/// produce byte-identical content — which is what makes cross-branch content
+/// dedup observable.
+async fn modify_rows<S>(engine: &Engine<S>, branch: &str, start: usize, count: usize)
 where
     S: Storage + Clone + Send + Sync + 'static,
 {
@@ -419,12 +440,12 @@ where
             .await
             .expect("begin branch-sharing modification");
         for offset in 0..batch {
-            let index = branch_index * 7 + written + offset;
+            let index = start + written + offset;
             transaction
                 .execute(
                     "UPDATE branch_fixture SET value = lix_json($1) WHERE path = $2",
                     &[
-                        Value::Text(format!(r#"{{"seed":{index},"pad":"{PAD}"}}"#)),
+                        Value::Text(format!(r#"{{"seed":{index},"edited":true,"pad":"{PAD}"}}"#)),
                         Value::Text(row_path(index)),
                     ],
                 )

--- a/packages/lix/src/transaction/commit.rs
+++ b/packages/lix/src/transaction/commit.rs
@@ -771,7 +771,6 @@ pub(crate) async fn commit_prepared_writes_with_parent_heads(
         read,
         &mut writes,
         &staged_hot_heads.controls,
-        &staged_hot_heads.tracked_snapshots,
         &state_rows,
         &engine_rows,
         &explicit_branch_targets,
@@ -5087,7 +5086,6 @@ async fn stage_branch_head_control_publications(
     read: &(impl StorageAdapterRead + ?Sized),
     writes: &mut StorageWriteSet,
     normal_controls: &BTreeMap<String, BranchHeadControl>,
-    tracked_snapshots: &BTreeMap<CommitId, HotTrackedSnapshot>,
     state_rows: &PreparedStateBatch,
     engine_rows: &[EngineCurrentRow],
     explicit_branch_targets: &BTreeMap<String, ExplicitBranchHeadTarget>,
@@ -5115,7 +5113,6 @@ async fn stage_branch_head_control_publications(
         .iter()
         .map(|(branch_id, control)| (branch_id.clone(), Some(*control)))
         .collect::<BTreeMap<String, Option<BranchHeadControl>>>();
-    let tracked_head = TrackedHeadContext::new();
     let mut consumed_checkpoint_bridges = BTreeSet::new();
     for (branch_id, target) in explicit_branch_targets {
         if publications.contains_key(branch_id) {

--- a/packages/lix/src/transaction/commit.rs
+++ b/packages/lix/src/transaction/commit.rs
@@ -6619,7 +6619,6 @@ mod tests {
             &read,
             &mut writes,
             &BTreeMap::new(),
-            &BTreeMap::new(),
             &PreparedStateBatch::new(),
             &[],
             &BTreeMap::from([(branch_id.to_owned(), target)]),

--- a/packages/lix/src/transaction/commit.rs
+++ b/packages/lix/src/transaction/commit.rs
@@ -2942,7 +2942,6 @@ fn select_new_rootless_ordered_commits(
 
 struct StagedHotHeads {
     controls: BTreeMap<String, BranchHeadControl>,
-    tracked_snapshots: BTreeMap<CommitId, HotTrackedSnapshot>,
     deferred_fresh_hot_plans: Vec<crate::live_state::DeferredFreshHotPlan>,
 }
 
@@ -4495,7 +4494,6 @@ async fn stage_tracked_head(
     }
     Ok(StagedHotHeads {
         controls,
-        tracked_snapshots,
         deferred_fresh_hot_plans,
     })
 }

--- a/packages/lix/src/transaction/commit.rs
+++ b/packages/lix/src/transaction/commit.rs
@@ -4974,6 +4974,7 @@ async fn stage_root_backed_branch_publication(
     stage_initial_working_diff_epoch: bool,
     state_rows: &PreparedStateBatch,
     engine_rows: &[EngineCurrentRow],
+    insert_selection: &PreparedInsertSelection,
 ) -> Result<BranchHeadControl, LixError> {
     let generation = lifecycle_generation(branch_id, head_commit_id, target.ref_change_id);
     let tracked_head = TrackedHeadContext::new();
@@ -4999,13 +5000,22 @@ async fn stage_root_backed_branch_publication(
         untracked_generation: previous_control
             .map(|control| control.untracked_generation)
             .unwrap_or(generation),
-        current_state_revision: previous_control
-            .map_or(0, |control| control.current_state_revision),
+        current_state_revision: match previous_control {
+            None => 0,
+            // An explicit move of an existing head is a new current-state
+            // revision for every reader holding the previous one.
+            Some(control) => next_current_state_revision(control.current_state_revision)?,
+        },
         // A branch is born at a complete authenticated root. Its private
         // working interval therefore starts at that exact head; no logical
         // checkpoint entity or history scan is needed to recover the cursor.
-        working_diff_checkpoint_commit_id: Some(head_commit_id),
-        created_at: target.created_at,
+        // Explicit lifecycle moves of an existing branch instead keep that
+        // branch's own compaction baseline.
+        working_diff_checkpoint_commit_id: match previous_control {
+            None => Some(head_commit_id),
+            Some(control) => control.working_diff_checkpoint_commit_id,
+        },
+        created_at: previous_control.map_or(target.created_at, |control| control.created_at),
         updated_at: target.updated_at,
         ref_change_id: target.ref_change_id,
         // Root reads answer schema presence directly. Keep the bloom
@@ -5028,11 +5038,34 @@ async fn stage_root_backed_branch_publication(
         )
         .collect::<Result<Vec<_>, _>>()?;
     if !untracked_deltas.is_empty() {
-        let next_generation = untracked_lifecycle_generation(
-            branch_id,
-            control.untracked_generation,
-            next_current_state_revision(control.current_state_revision)?,
-        );
+        // A new branch has not consumed its revision yet; an existing branch
+        // already advanced one above for this same publication.
+        let revision = match previous_control {
+            None => next_current_state_revision(control.current_state_revision)?,
+            Some(_) => control.current_state_revision,
+        };
+        let absence_guards = if insert_selection.is_empty() {
+            BTreeSet::new()
+        } else {
+            state_rows
+                .iter()
+                .enumerate()
+                .filter(|(row_index, row)| {
+                    row.untracked
+                        && row.branch_id.as_str() == branch_id
+                        && row.schema_key != BRANCH_REF_SCHEMA_KEY
+                        && row.snapshot.is_some()
+                        && insert_selection.contains(*row_index)
+                })
+                .map(|(_, row)| TrackedStateKey {
+                    schema_key: row.schema_key.to_string(),
+                    file_id: row.file_id.map(ToString::to_string),
+                    entity_pk: row.entity_pk.clone(),
+                })
+                .collect()
+        };
+        let next_generation =
+            untracked_lifecycle_generation(branch_id, control.untracked_generation, revision);
         tracked_head
             .writer(read, writes)
             .stage_untracked_generation(
@@ -5040,12 +5073,11 @@ async fn stage_root_backed_branch_publication(
                 control.untracked_generation,
                 next_generation,
                 &untracked_deltas,
-                &BTreeSet::new(),
+                &absence_guards,
             )
             .await?;
         control.untracked_generation = next_generation;
-        control.current_state_revision =
-            next_current_state_revision(control.current_state_revision)?;
+        control.current_state_revision = revision;
     }
     Ok(control)
 }
@@ -5108,144 +5140,25 @@ async fn stage_branch_head_control_publications(
         let mut desired = match target.head_commit_id {
             None => None,
             Some(head_commit_id) => {
-                if existing.is_none() {
-                    let control = Box::pin(stage_root_backed_branch_publication(
-                        read,
-                        writes,
-                        branch_id,
-                        head_commit_id,
-                        target,
-                        existing,
-                        !branch_checkpoint_bridges.contains_key(branch_id),
-                        state_rows,
-                        engine_rows,
-                    ))
-                    .await?;
-                    root_backed_branch_publications.insert(branch_id.clone());
-                    Some(control)
-                } else {
-                    let tracked = if let Some(snapshot) = tracked_snapshots.get(&head_commit_id) {
-                        snapshot.clone()
-                    } else {
-                        let rows = load_persisted_lifecycle_tracked_snapshot(
-                            read,
-                            branch_id,
-                            head_commit_id,
-                        )
-                        .await?;
-                        HotTrackedSnapshot::from_materialized_rows(rows.into_values().collect())?
-                    };
-                    let mut untracked_deltas = state_rows
-                        .iter()
-                        .filter(|row| {
-                            row.untracked
-                                && row.branch_id.as_str() == branch_id
-                                && row.schema_key != BRANCH_REF_SCHEMA_KEY
-                        })
-                        .map(current_state_delta_from_state_row)
-                        .collect::<Result<Vec<_>, _>>()?;
-                    untracked_deltas.extend(
-                        engine_rows
-                            .iter()
-                            .filter(|row| row.branch_id == *branch_id)
-                            .map(current_state_delta_from_engine_row),
-                    );
-                    let absence_guards = if insert_selection.is_empty() {
-                        BTreeSet::new()
-                    } else {
-                        state_rows
-                            .iter()
-                            .enumerate()
-                            .filter(|(row_index, row)| {
-                                row.untracked
-                                    && row.branch_id.as_str() == branch_id
-                                    && row.schema_key != BRANCH_REF_SCHEMA_KEY
-                                    && row.snapshot.is_some()
-                                    && insert_selection.contains(*row_index)
-                            })
-                            .map(|(_, row)| TrackedStateKey {
-                                schema_key: row.schema_key.to_string(),
-                                file_id: row.file_id.map(ToString::to_string),
-                                entity_pk: row.entity_pk.clone(),
-                            })
-                            .collect()
-                    };
-                    let generation =
-                        lifecycle_generation(&branch_id, head_commit_id, target.ref_change_id);
-                    let mut coverage = WorkingDiffIndexCoverage::default();
-                    let (_, schema_keys) = tracked_head
-                        .writer(read, writes)
-                        .stage_complete_current_state_with_working_diff(
-                            &branch_id,
-                            generation,
-                            tracked,
-                            existing.map(|control| control.tracked_generation),
-                            &[],
-                            &[],
-                            &absence_guards,
-                            None,
-                            &mut coverage,
-                        )
-                        .await?;
-                    let mut control = BranchHeadControl {
-                        head_commit_id,
-                        tracked_generation: generation,
-                        untracked_generation: existing
-                            .expect("existing lifecycle publication was handled above")
-                            .untracked_generation,
-                        current_state_revision: match existing {
-                            Some(control) => control
-                                .current_state_revision
-                                .checked_add(1)
-                                .ok_or_else(|| {
-                                    LixError::new(
-                                        LixError::CODE_INTERNAL_ERROR,
-                                        "branch current-state revision overflowed",
-                                    )
-                                })?,
-                            None => 0,
-                        },
-                        // Explicit lifecycle moves keep the branch's private
-                        // compaction baseline. New branches take the dedicated
-                        // root-backed path above and start clean at their head.
-                        working_diff_checkpoint_commit_id: existing
-                            .and_then(|control| control.working_diff_checkpoint_commit_id),
-                        created_at: existing
-                            .map_or(target.created_at, |control| control.created_at),
-                        updated_at: target.updated_at,
-                        ref_change_id: target.ref_change_id,
-                        schema_presence_bloom: existing
-                            .expect("existing lifecycle publication was handled above")
-                            .schema_presence_bloom,
-                    };
-                    if !untracked_deltas.is_empty() {
-                        let previous_untracked_generation = control.untracked_generation;
-                        let next_revision = control.current_state_revision;
-                        let next_untracked_generation = untracked_lifecycle_generation(
-                            &branch_id,
-                            previous_untracked_generation,
-                            next_revision,
-                        );
-                        tracked_head
-                            .writer(read, writes)
-                            .stage_untracked_generation(
-                                &branch_id,
-                                previous_untracked_generation,
-                                next_untracked_generation,
-                                &untracked_deltas,
-                                &absence_guards,
-                            )
-                            .await?;
-                        control.untracked_generation = next_untracked_generation;
-                    }
-                    control.note_schemas(
-                        schema_keys
-                            .iter()
-                            .map(String::as_str)
-                            .chain(untracked_deltas.iter().map(|delta| delta.schema_key)),
-                    );
-                    Some(control)
-                }
+                // Every explicit head move publishes one immutable tracked
+                // root reference. The head commit is already authoritative for
+                // every tracked identity, so materializing a branch-local copy
+                // of the whole working set would only restate it.
+                let control = Box::pin(stage_root_backed_branch_publication(
+                    read,
+                    writes,
+                    branch_id,
+                    head_commit_id,
+                    target,
+                    existing,
+                    existing.is_none() && !branch_checkpoint_bridges.contains_key(branch_id),
+                    state_rows,
+                    engine_rows,
+                    insert_selection,
+                ))
+                .await?;
+                root_backed_branch_publications.insert(branch_id.clone());
+                Some(control)
             }
         };
         if let Some(bridge) = branch_checkpoint_bridges.get(branch_id) {


### PR DESCRIPTION
## Question this answers

*When you branch, how much storage do the branches share?* Nobody had measured it. This PR adds the
harness that measures it, and fixes the one place where the answer was "none".

## What changed physically

`stage_branch_head_control_publications` (`packages/lix/src/transaction/commit.rs`) had two arms for
an explicit branch-head publication:

* **new branch** (`existing.is_none()`) → `stage_root_backed_branch_publication`: publish one 16-byte
  reference to the immutable tracked root at the head. O(1).
* **existing branch** (head *moves* — which is what a fast-forward merge does) → load
  `HotTrackedSnapshot` for the head and call `stage_complete_current_state_with_working_diff`, which
  writes **one `HOT_ROW` per tracked entity in the whole workspace**. O(state).

Both arms are now the root-backed one. The existing-branch bookkeeping the second arm carried
(`current_state_revision` increment, preserved `working_diff_checkpoint_commit_id`/`created_at`,
untracked-generation rollover, insert absence guards) moved into
`stage_root_backed_branch_publication`, which already took `previous_control: Option<_>`.

**Removed**: the ~120-line materializing arm; the `tracked_snapshots` parameter of
`stage_branch_head_control_publications`; the `StagedHotHeads::tracked_snapshots` field. Net
−156 lines in `commit.rs`. No shims, no dual path, no feature flag. Public API unchanged.

**Deliberate behaviour difference**: a root-backed publication sets `schema_presence_bloom` to all
ones (conservative "may contain any schema") instead of carrying the previous bloom forward. That can
only cost an extra probe, never hide a row.

## The measurement

New bench `packages/engine-benchmarks/benches/branch_storage_sharing.rs` (`harness = false`). It
seeds N rows through a real `SessionContext` SQL commit path, settles storage (memtable flush +
sleep), snapshots **both** a recursive filesystem byte walk and per-space
`rows / key_bytes / value_bytes` from `lix::storage_bench::layout_accounting`, applies one branching
scenario, and re-snapshots. Delta = the price of the scenario, attributed per storage space.

## A/B: settled logical bytes, delta vs the seeded base

Machine `ryzen-9950x-I`, interleaved base/cand, medians. Logical byte counts are deterministic —
RocksDB and SlateDB agree to within 1 byte on the same scenario, and per-rep values are identical.

### rocksdb

| scenario | rows | base Δbytes | cand Δbytes | delta |
|---|---:|---:|---:|---:|
| branch_noop | 1k / 10k / 100k | 2,916 | 2,916 | 0.0% |
| branch_1row | 1k / 10k | 4,265 / 4,266 | 4,265 / 4,266 | 0.0% |
| branch_1pct | 1k / 10k / 100k | 7,695 / 42,156 / 387,962 | identical | 0.0% |
| branch_10pct | 1k / 10k | 42,155 / 388,013 | 42,155 / 387,976 | 0.0% |
| branches_10 | 1k / 10k | 31,649 / 31,618 | 31,602 / 31,623 | ±0.1% |
| branches_100 | 1k / 10k | 563,212 / 430,222 | 541,696 / 456,049 | noise, see below |
| branches_10_1row | 1k / 10k | 45,186 / 45,202 | 45,186 / 45,205 | 0.0% |
| branches_2_disjoint_1pct | 1k / 10k | 15,459 / 84,446 | 15,459 / 84,431 | 0.0% |
| branches_2_identical_1pct | 1k / 10k | 15,446 / 84,384 | 15,446 / 84,369 | 0.0% |
| **merge_1pct** | **1k** | **320,065** | **7,990** | **−97.5%** |
| **merge_1pct** | **10k** | **3,001,786** | **42,436** | **−98.6%** |
| **merge_1pct** | **100k** | **29,910,193** | **388,272** | **−98.7%** |
| delete_gc_1pct | 1k / 10k / 100k | 8,072 / 39,932 / 359,432 | identical | 0.0% |

### slatedb

| scenario | rows | base Δbytes | cand Δbytes | delta |
|---|---:|---:|---:|---:|
| **merge_1pct** | **10k** | **3,001,778** | **42,451** | **−98.6%** |
| **merge_1pct** | **100k** | **29,910,192** | **388,272** | **−98.7%** |
| branches_100 | 10k / 100k | 486,871 / 436,323 | 484,655 / 436,704 | −0.5% / +0.1% |
| everything else | | | identical | 0.0% |

### Settled physical bytes (filesystem walk after memtable flush + 300 ms settle)

| scenario | rows | backend | base Δbytes | cand Δbytes | delta |
|---|---:|---|---:|---:|---:|
| merge_1pct | 10k | rocksdb | 315,266 | 33,420 | −89.4% |
| merge_1pct | 10k | slatedb | 543,235 | 40,261 | −92.6% |
| merge_1pct | 100k | rocksdb | 2,875,468 | 128,575 | −95.5% |
| merge_1pct | 100k | slatedb | 5,103,505 | 184,145 | −96.4% |

### Per-space attribution of the merge saving (rocksdb)

Every byte of the saving is in one space; nothing else moves.

| space | rows | base Δ | cand Δ |
|---|---:|---:|---:|
| `live_state.hot_row.v21` | 1k | 315,984 | 3,816 |
| `live_state.hot_row.v21` | 10k | 2,995,104 | 35,676 |
| `live_state.hot_row.v21` | 100k | 29,877,204 | 355,176 |
| `changelog.change` | any | 808 | 808 |
| `tracked_state.commit_state_manifest.v7` | any | 680–754 | 680–754 |
| `tracked_state.tree_chunk` | any | 881 | 881 |
| `tracked_state.commit_delta_segment.v6` | 100k | 29,032 | 29,047 |

The residual candidate `hot_row` delta is exactly the branch's own 1% edit — the same 355,176 bytes
that `branch_1pct` costs on its own. Merge itself is now free of state-sized writes.

`branches_100` varies 374k–569k **within the baseline arm alone** (branch ids are random UUIDv7 and
tracked-state Merkle chunk boundaries are content-dependent). Both arms execute byte-identical code
for branch *creation* — that path was already root-backed — so that column is fixture noise, not a
candidate effect. SlateDB, which chunked more stably in these runs, shows −0.5% / +0.1%.

## What regressed

Nothing measured. Every non-merge scenario is byte-identical or within run-to-run fixture noise on
both backends and both planes.

## Correctness gate (on `ryzen-9950x-I`)

* `cargo check --workspace` — clean
* `cargo clippy --workspace --all-targets --all-features -- -D warnings` — clean
* `cargo test -p lix` — **2,495 passed, 0 failed** across 10 test binaries, including the 2,031-test
  integration suite that contains `branching.rs`, `semantic_merge.rs`, `merge_fuzz.rs` and
  `checkpoint_gc.rs`.

## Bench commands

```sh
cargo bench -p lix_benchmarks --features storage-benches,slatedb --bench branch_storage_sharing
# env: LIX_BRANCH_SHARING_ROWS, _BACKENDS, _SCENARIOS, _SETTLE_MS, _REP
```
