### PR TITLE
docs(live_state): document why HOT_DIFF key order need not match HOT_ROW

### DIFF
--- a/packages/lix/src/live_state/tracked_head/hot.rs
+++ b/packages/lix/src/live_state/tracked_head/hot.rs
@@ -10633,6 +10633,30 @@ fn encode_hot_diff_key_parts(
     key
 }
 
+/// Appends one dirty-row identity as a `HOT_DIFF` key (also used verbatim as
+/// the identity's coverage group key).
+///
+/// The component order after the scope — `schema_key ++ entity_pk ++ file_id`
+/// — deliberately does not mirror `HOT_ROW`'s `schema_key ++ file_id ++
+/// entity_pk`, and aligning them would buy nothing: no reader ever
+/// prefix-seeks `HOT_DIFF` below its `(branch, checkpoint, generation)`
+/// scope.
+///
+/// - `hot_working_diff_entries` must enumerate the entire scope to
+///   reconstruct the [`WorkingDiffIndexCoverage`] count/XOR proof before the
+///   sparse index may be trusted, so even file- or schema-filtered diff
+///   queries visit every entry and filter in memory. A sub-scope seek can
+///   never satisfy the proof.
+/// - Finite (schema + entity) diff queries bypass this space entirely and
+///   read the `working_diff_baseline` inline on primary `HOT_ROW` rows.
+/// - Batches of `HOT_DIFF_PACK_MIN_IDENTITIES` or more identities are packed
+///   into segments keyed by `scope ++ digest`; the identity components leave
+///   the key for the segment value altogether.
+///
+/// The order is therefore an arbitrary but load-bearing input to the
+/// coverage hash: every writer, the segment visitor, and the stored epoch
+/// coverage must produce these bytes identically. Change it only for a
+/// reason, and only everywhere at once.
 fn append_hot_diff_key_parts(
     key_bytes: &mut Vec<u8>,
     scope: &[u8],


### PR DESCRIPTION
## Verdict: the divergence is intentional — no reorder warranted

An audit flagged that `HOT_DIFF` orders its key `… schema_key ++ entity_pk ++ file_id` while
`HOT_ROW` orders `… schema_key ++ file_id ++ entity_pk`, on the theory that a file-scoped
working-diff read is forced to over-scan. **Investigation shows no reader can prefix-seek `HOT_DIFF`
below its `(branch, checkpoint, generation)` scope at all**, so the component order is unreachable
by any seek and aligning the two would buy nothing.

## Reader/writer inventory

**Readers**
| Site | Access shape |
|---|---|
| `hot.rs:9751` `hot_working_diff_entries` (scan `:9783`) | full-scope scan; the single production consumer |
| `hot.rs:9945` `hot_working_diff_entries_for_finite_filter` (routed `:9765`) | never touches HOT_DIFF — reads `working_diff_baseline` inline off primary `HOT_ROW` rows |
| `hot.rs:11426` `stage_delete_hot_diff_scope` (prefix `:11437`) | scope-prefix delete, `KeyOnly` |
| `hot.rs:11363` `stage_collect_stale_hot_diff_records` | whole-space sweep, `#[cfg(test)]`-gated |

**Writers** — all via the single encoder `append_hot_diff_key_parts` (`hot.rs:10660`):
`hot.rs:207`, `:404` (deferred fresh publication), `:7540` (newly-dirty on commit), `:7826`
(file cascade); packing at `stage_hot_diff_batch` (`hot.rs:8663`).

## Why a seek is impossible

1. **The coverage proof forces the full scan.** `hot_working_diff_entries` must rebuild
   `WorkingDiffIndexCoverage` — a count plus XOR-of-BLAKE3 over *every* group key
   (`tracked_head.rs:96-131`) — and match it against the epoch marker (`hot.rs:9889`); a mismatch
   returns `Ok(None)` and falls back to canonical replay. The SQL surface *does* push `file_id`
   down (`sql2/providers/working_diff.rs:243`), but it lands in an in-memory `matches_filter`
   (`hot.rs:9309`), not a seek. **The full scan is the completeness verification** — a sub-scope
   seek could never satisfy the proof. The O(changed rows since checkpoint) bound is therefore
   inherent, not an over-scan artifact.
2. **Finite (schema + entity) queries bypass the space entirely.**
3. **At scale there is no identity key to exploit** — batches of `HOT_DIFF_PACK_MIN_IDENTITIES`+
   identities pack into segments keyed `scope ++ blake3(value)` (`hot.rs:8754-8755`), with identity
   components living in the value.

Reordering would change nothing measurable while churning the coverage-XOR input bytes that every
writer, the segment visitor (`hot.rs:11142`) and the stored epoch coverage must agree on
byte-for-byte.

## What ships

A 24-line doc comment at the sole encoder recording the above, so the next audit does not re-flag it.
Public API untouched, zero behavioural change, no benchmarking warranted.

## Layout invariants

1-6 unchanged. (3) is *reaffirmed*: HOT_DIFF is scope-tagged, proved complete by the epoch coverage,
and every failure mode falls back to canonical replay — it is a cache, never an authority.

## Gate

`hetzner-cpx62-II`, rebased onto `6495bd9ef`: `cargo check --workspace`,
`cargo clippy --workspace --all-targets --all-features -- -D warnings`, `cargo test -p lix` —
green, 2057 + 447 + 5 doctests, 0 failures, both pre- and post-rebase.