### PR TITLE
perf(binary-cas): decide chunk boundaries once per payload

### DIFF
--- a/packages/lix/src/binary_cas/chunking.rs
+++ b/packages/lix/src/binary_cas/chunking.rs
@@ -1,19 +1,29 @@
+//! The single authority for binary-CAS chunk boundaries.
+//!
+//! Boundaries are decided exactly once per payload, in
+//! [`crate::binary_cas::BlobPayload::from_bytes`], and travel with the payload
+//! as chunk receipts. Staging reconstructs the ranges from those receipt sizes
+//! rather than asking this module again, so a write never searches for the same
+//! boundaries twice.
+
 pub(super) const SINGLE_CHUNK_FAST_PATH_MAX_BYTES: usize = 64 * 1024;
 pub(super) const MAX_BINARY_CAS_CHUNK_BYTES: usize = 4096 * 1024;
 // SlateDB packs sequential immutable payloads into 64 MiB sidecar segments.
-// The local mixed movie profile in engine-benchmarks/MOVIE_WORKSPACE.md was
+// The local mixed movie profile in engine-benchmarks/MOVIE_WORKSPACE.md
 // showed no ingest gain at 4 MiB and a slightly worse save p95; retain the
 // smaller seek unit until a remote profile demonstrates a material win.
 pub(crate) const MEDIA_CHUNK_BYTES: usize = 1024 * 1024;
 
+/// Chunk boundaries are cut at fixed offsets. Nothing here inspects content,
+/// so a payload that shifts by one byte renames every chunk after the shift.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub(crate) struct BinaryCasChunking {
+pub(super) struct BinaryCasChunking {
     chunk_bytes: usize,
     single_chunk_fast_path_max_bytes: usize,
 }
 
 impl BinaryCasChunking {
-    pub(crate) const fn fixed_1m_v3() -> Self {
+    pub(super) const fn fixed_1m_v3() -> Self {
         Self {
             chunk_bytes: MEDIA_CHUNK_BYTES,
             single_chunk_fast_path_max_bytes: SINGLE_CHUNK_FAST_PATH_MAX_BYTES,
@@ -27,12 +37,11 @@ impl Default for BinaryCasChunking {
     }
 }
 
-#[cfg(test)]
-pub(crate) fn fastcdc_chunk_ranges(data: &[u8]) -> Vec<(usize, usize)> {
-    fastcdc_chunk_ranges_with_chunking(data, BinaryCasChunking::default())
+pub(crate) fn chunk_ranges(data: &[u8]) -> Vec<(usize, usize)> {
+    chunk_ranges_with_chunking(data, BinaryCasChunking::default())
 }
 
-pub(crate) fn fastcdc_chunk_ranges_with_chunking(
+pub(super) fn chunk_ranges_with_chunking(
     data: &[u8],
     chunking: BinaryCasChunking,
 ) -> Vec<(usize, usize)> {
@@ -69,10 +78,7 @@ mod tests {
     #[test]
     fn single_chunk_fast_path_applies_through_64kib() {
         let at_boundary = vec![0; 64 * 1024];
-        assert_eq!(
-            fastcdc_chunk_ranges(&at_boundary),
-            vec![(0, at_boundary.len())]
-        );
+        assert_eq!(chunk_ranges(&at_boundary), vec![(0, at_boundary.len())]);
     }
 
     #[test]
@@ -84,7 +90,7 @@ mod tests {
         };
 
         assert_ne!(
-            fastcdc_chunk_ranges_with_chunking(&above_boundary, chunking),
+            chunk_ranges_with_chunking(&above_boundary, chunking),
             vec![(0, above_boundary.len())]
         );
     }
@@ -92,7 +98,7 @@ mod tests {
     #[test]
     fn multi_megabyte_payloads_cannot_collapse_to_one_rewritten_chunk() {
         let payload = vec![b'a'; 3_500_000];
-        let ranges = fastcdc_chunk_ranges(&payload);
+        let ranges = chunk_ranges(&payload);
 
         assert!(ranges.len() >= 4);
         assert!(
@@ -106,7 +112,7 @@ mod tests {
     fn media_chunks_have_stable_offsets() {
         let data = vec![0; MEDIA_CHUNK_BYTES * 2 + 7];
         assert_eq!(
-            fastcdc_chunk_ranges(&data),
+            chunk_ranges(&data),
             vec![
                 (0, MEDIA_CHUNK_BYTES),
                 (MEDIA_CHUNK_BYTES, MEDIA_CHUNK_BYTES * 2),

--- a/packages/lix/src/binary_cas/context.rs
+++ b/packages/lix/src/binary_cas/context.rs
@@ -1,7 +1,6 @@
 use async_trait::async_trait;
 
 use crate::LixError;
-use crate::binary_cas::BinaryCasChunking;
 use crate::binary_cas::{
     BlobBytesBatch, BlobChunkReceipt, BlobEditSplice, BlobId, BlobPayload, BlobRangeBytes,
     BlobRangeBytesBatch, BlobSameLengthSplice, BlobWriteReceipt,
@@ -73,15 +72,11 @@ fn materialize_blob_range(
 /// The context does not own storage. Callers explicitly provide a KV store via
 /// `reader(...)` or `writer_skipping_existing_chunks(...)`, keeping storage and
 /// transaction ownership at the execution layer.
-pub(crate) struct BinaryCasContext {
-    chunking: BinaryCasChunking,
-}
+pub(crate) struct BinaryCasContext;
 
 impl BinaryCasContext {
     pub(crate) fn new() -> Self {
-        Self {
-            chunking: BinaryCasChunking::default(),
-        }
+        Self
     }
 
     pub(crate) fn prepared_manifest_is_staged(
@@ -112,7 +107,7 @@ impl BinaryCasContext {
     where
         S: StorageAdapterRead + ?Sized,
     {
-        ExistingChunkAwareBinaryCasWriter::new(store, writes, self.chunking)
+        ExistingChunkAwareBinaryCasWriter::new(store, writes)
     }
 }
 
@@ -162,7 +157,6 @@ where
 {
     store: &'a S,
     writes: &'a mut StorageWriteSet,
-    chunking: BinaryCasChunking,
     blob_hashes: HashSet<[u8; 32]>,
     chunk_keys: HashSet<Vec<u8>>,
 }
@@ -171,11 +165,10 @@ impl<'a, S> ExistingChunkAwareBinaryCasWriter<'a, S>
 where
     S: StorageAdapterRead + ?Sized,
 {
-    fn new(store: &'a S, writes: &'a mut StorageWriteSet, chunking: BinaryCasChunking) -> Self {
+    fn new(store: &'a S, writes: &'a mut StorageWriteSet) -> Self {
         Self {
             store,
             writes,
-            chunking,
             blob_hashes: HashSet::new(),
             chunk_keys: HashSet::new(),
         }
@@ -186,7 +179,6 @@ where
         payload: &BlobPayload,
     ) -> Result<BlobWriteReceipt, LixError> {
         crate::binary_cas::kv::stage_blob_write_skipping_existing_chunks(
-            self.chunking,
             self.store,
             self.writes,
             &mut self.blob_hashes,

--- a/packages/lix/src/binary_cas/kv.rs
+++ b/packages/lix/src/binary_cas/kv.rs
@@ -1,7 +1,7 @@
 #![allow(clippy::cast_sign_loss)]
 
 use crate::LixError;
-use crate::binary_cas::chunking::{MAX_BINARY_CAS_CHUNK_BYTES, fastcdc_chunk_ranges_with_chunking};
+use crate::binary_cas::chunking::MAX_BINARY_CAS_CHUNK_BYTES;
 use crate::binary_cas::codec::{
     BinaryCasManifest, BinaryChunkCodec, StorageBinaryCasDeltaBaseLayout,
     StorageBinaryCasDeltaSegment, decode_binary_cas_chunk, decode_binary_cas_manifest,
@@ -9,7 +9,7 @@ use crate::binary_cas::codec::{
     encode_binary_cas_manifest_chunk,
 };
 use crate::binary_cas::{
-    BinaryCasChunking, BinaryCasGcSweep, BlobBytesBatch, BlobDeltaBaseLayout, BlobDeltaSegment,
+    BinaryCasGcSweep, BlobBytesBatch, BlobDeltaBaseLayout, BlobDeltaSegment,
     BlobEditSplice, BlobId, BlobLayout, BlobMetadata, BlobMetadataBatch, BlobRangeBytes,
     BlobRangeBytesBatch, BlobSameLengthSplice, BlobWriteReceipt, ChunkHash,
 };
@@ -2025,7 +2025,6 @@ fn decode_and_verify_payload(
 }
 
 pub(in crate::binary_cas) async fn stage_blob_write_skipping_existing_chunks<S>(
-    chunking: BinaryCasChunking,
     store: &S,
     writes: &mut StorageWriteSet,
     blob_hashes: &mut HashSet<[u8; 32]>,
@@ -2060,7 +2059,7 @@ where
             layout: metadata.layout,
         });
     }
-    let plan = prepare_blob_write(chunking, payload)?;
+    let plan = prepare_blob_write(payload)?;
     let receipt = plan.receipt.clone();
     if !blob_hashes.insert(plan.blob_hash.into_bytes()) {
         return Ok(receipt);
@@ -2080,9 +2079,9 @@ where
 /// This is deliberately opportunistic. The caller still owns complete
 /// replacement bytes and falls back to [`stage_blob_write_skipping_existing_chunks`]
 /// for every missing, malformed, non-chunked, length-changing, or otherwise
-/// ineligible base. A manifest is an ordered content-addressed chunk list;
-/// readers do not require its boundaries to have been freshly produced by
-/// FastCDC, so keeping valid existing boundaries is format-compatible.
+/// ineligible base. A manifest is an ordered content-addressed chunk list and a
+/// same-length splice cannot move a boundary, so reusing the base's existing
+/// boundaries produces the layout the chunker would have produced anyway.
 pub(in crate::binary_cas) async fn try_stage_blob_write_reusing_same_length_splice<S>(
     store: &S,
     writes: &mut StorageWriteSet,
@@ -2422,8 +2421,51 @@ fn normalize_delta_segments(segments: Vec<BlobDeltaSegment>) -> Vec<BlobDeltaSeg
     out
 }
 
+/// Rebuilds the payload's chunk layout from the receipt sizes that
+/// [`crate::binary_cas::BlobPayload::from_bytes`] already produced.
+///
+/// The receipts are the boundary decision, so staging never runs the boundary
+/// search a second time over bytes it is about to write. The tiling check below
+/// is what makes that safe: receipts that do not cover the payload exactly are
+/// rejected rather than trusted.
+fn chunk_ranges_from_receipts(
+    receipts: &[crate::binary_cas::BlobChunkReceipt],
+    len: usize,
+) -> Result<Vec<(usize, usize)>, LixError> {
+    let mut ranges = Vec::with_capacity(receipts.len());
+    let mut cursor = 0usize;
+    for receipt in receipts {
+        let size = usize::try_from(receipt.size_bytes)
+            .ok()
+            .filter(|size| *size > 0 && *size <= MAX_BINARY_CAS_CHUNK_BYTES)
+            .ok_or_else(|| {
+                LixError::new(
+                    "LIX_ERROR_UNKNOWN",
+                    "binary CAS payload chunk receipt has an unusable size".to_string(),
+                )
+            })?;
+        let end = cursor
+            .checked_add(size)
+            .filter(|end| *end <= len)
+            .ok_or_else(|| {
+                LixError::new(
+                    "LIX_ERROR_UNKNOWN",
+                    "binary CAS payload chunk receipts overrun the payload".to_string(),
+                )
+            })?;
+        ranges.push((cursor, end));
+        cursor = end;
+    }
+    if cursor != len {
+        return Err(LixError::new(
+            "LIX_ERROR_UNKNOWN",
+            "binary CAS payload chunk receipts do not tile the payload".to_string(),
+        ));
+    }
+    Ok(ranges)
+}
+
 fn prepare_blob_write(
-    chunking: BinaryCasChunking,
     payload: &crate::binary_cas::BlobPayload,
 ) -> Result<BlobWritePlan, LixError> {
     let bytes = payload.bytes();
@@ -2439,13 +2481,7 @@ fn prepare_blob_write(
         }
         (Vec::new(), BlobLayout::Empty)
     } else {
-        let chunk_ranges = fastcdc_chunk_ranges_with_chunking(bytes, chunking);
-        if chunk_ranges.len() != payload.chunks().len() {
-            return Err(LixError::new(
-                "LIX_ERROR_UNKNOWN",
-                "binary CAS payload chunk receipts disagree with canonical chunking".to_string(),
-            ));
-        }
+        let chunk_ranges = chunk_ranges_from_receipts(payload.chunks(), bytes.len())?;
         let layout = match chunk_ranges.as_slice() {
             [] => unreachable!("non-empty blobs always have at least one chunk"),
             [_] => BlobLayout::SingleChunk {
@@ -4001,7 +4037,7 @@ mod tests {
     fn every_non_empty_blob_is_out_of_line() {
         for size in [1, 32 * 1024, 128 * 1024] {
             let payload = BlobPayload::from_bytes(vec![b'a'; size]);
-            let plan = prepare_blob_write(BinaryCasChunking::default(), &payload)
+            let plan = prepare_blob_write(&payload)
                 .expect("non-empty blob should plan");
             assert!(!plan.chunk_ranges.is_empty());
             assert!(matches!(
@@ -4128,7 +4164,7 @@ mod tests {
         let data = definitely_multi_chunk_blob_bytes();
         let payload = BlobPayload::from_bytes(data.clone());
         let blob_hash = payload.hash().expect("payload should have a hash");
-        let chunk_ranges = crate::binary_cas::chunking::fastcdc_chunk_ranges(&data);
+        let chunk_ranges = crate::binary_cas::chunking::chunk_ranges(&data);
         assert!(chunk_ranges.len() > 1);
         let chunk_hashes = chunk_ranges
             .iter()
@@ -4160,7 +4196,6 @@ mod tests {
             .expect("read should open");
         let mut writes = storage.new_write_set();
         stage_blob_write_skipping_existing_chunks(
-            BinaryCasChunking::default(),
             &store,
             &mut writes,
             &mut HashSet::new(),
@@ -4557,7 +4592,7 @@ mod tests {
             .begin_read(StorageReadOptions::default())
             .await
             .expect("result read should open");
-        let expected_hashes = crate::binary_cas::chunking::fastcdc_chunk_ranges(&after)
+        let expected_hashes = crate::binary_cas::chunking::chunk_ranges(&after)
             .into_iter()
             .map(|(start, end)| BlobId::from_content(&after[start..end]).into_bytes())
             .collect::<Vec<_>>();
@@ -4569,7 +4604,7 @@ mod tests {
             .collect::<Vec<_>>();
         assert_eq!(
             actual_hashes, expected_hashes,
-            "fallback must retain FastCDC layout"
+            "fallback must retain the canonical chunk layout"
         );
         assert_eq!(
             load_bytes_many(&store, &[after_blob_hash])

--- a/packages/lix/src/binary_cas/mod.rs
+++ b/packages/lix/src/binary_cas/mod.rs
@@ -9,7 +9,6 @@ mod types;
 
 use std::collections::{BTreeMap, BTreeSet};
 
-pub(crate) use chunking::BinaryCasChunking;
 #[cfg(all(feature = "storage-benches", test))]
 pub(crate) use codec::encode_binary_cas_manifest;
 #[cfg(feature = "storage-benches")]

--- a/packages/lix/src/binary_cas/types.rs
+++ b/packages/lix/src/binary_cas/types.rs
@@ -1,5 +1,5 @@
 use crate::LixError;
-use crate::binary_cas::chunking::{MEDIA_CHUNK_BYTES, chunk_ranges};
+use crate::binary_cas::chunking::chunk_ranges;
 use crate::binary_cas::codec::BinaryChunkCodec;
 use crate::binary_cas::codec::{binary_blob_hash_bytes, hash_bytes_to_hex, hash_hex_to_bytes};
 use std::ops::Range;
@@ -308,6 +308,7 @@ pub(crate) struct BinaryCasChunkView<'a> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::binary_cas::chunking::MEDIA_CHUNK_BYTES;
 
     #[test]
     fn payload_carries_exact_canonical_chunk_receipts() {

--- a/packages/lix/src/binary_cas/types.rs
+++ b/packages/lix/src/binary_cas/types.rs
@@ -1,5 +1,5 @@
 use crate::LixError;
-use crate::binary_cas::chunking::MEDIA_CHUNK_BYTES;
+use crate::binary_cas::chunking::{MEDIA_CHUNK_BYTES, chunk_ranges};
 use crate::binary_cas::codec::BinaryChunkCodec;
 use crate::binary_cas::codec::{binary_blob_hash_bytes, hash_bytes_to_hex, hash_hex_to_bytes};
 use std::ops::Range;
@@ -14,13 +14,19 @@ impl BlobId {
     }
 
     pub(crate) fn from_content(content: &[u8]) -> Self {
-        if content.len() <= MEDIA_CHUNK_BYTES {
-            return Self::from_single_chunk(ChunkHash::from_content(content));
+        let ranges = chunk_ranges(content);
+        match ranges.as_slice() {
+            [] | [_] => Self::from_single_chunk(ChunkHash::from_content(content)),
+            ranges => Self::from_chunks(
+                content.len() as u64,
+                ranges.iter().map(|&(start, end)| {
+                    (
+                        ChunkHash::from_content(&content[start..end]),
+                        (end - start) as u64,
+                    )
+                }),
+            ),
         }
-        let chunks = content
-            .chunks(MEDIA_CHUNK_BYTES)
-            .map(|chunk| (ChunkHash::from_content(chunk), chunk.len() as u64));
-        Self::from_chunks(content.len() as u64, chunks)
     }
 
     pub(crate) fn from_single_chunk(chunk_hash: ChunkHash) -> Self {
@@ -135,11 +141,13 @@ pub(crate) struct BlobPayload {
 impl BlobPayload {
     pub(crate) fn from_bytes(bytes: impl Into<crate::Blob>) -> Self {
         let bytes = bytes.into();
-        let chunks = bytes
-            .chunks(MEDIA_CHUNK_BYTES)
-            .map(|chunk| BlobChunkReceipt {
-                hash: ChunkHash::from_content(chunk),
-                size_bytes: chunk.len() as u64,
+        // The one and only boundary search for these bytes. Staging rebuilds
+        // the ranges from the receipt sizes below.
+        let chunks = chunk_ranges(&bytes)
+            .into_iter()
+            .map(|(start, end)| BlobChunkReceipt {
+                hash: ChunkHash::from_content(&bytes[start..end]),
+                size_bytes: (end - start) as u64,
             })
             .collect::<Arc<[_]>>();
         let hash = match chunks.as_ref() {
@@ -169,9 +177,9 @@ impl BlobPayload {
         self.hash
     }
 
-    /// Canonical fixed-chunk identities derived from these exact immutable
-    /// bytes. Keeping the receipts inside the payload prevents CAS staging
-    /// from hashing every large-file chunk a second time.
+    /// Canonical chunk identities derived from these exact immutable bytes,
+    /// in order. Their sizes are also the payload's chunk layout, so staging
+    /// neither hashes nor re-searches for boundaries a second time.
     pub(crate) fn chunks(&self) -> &[BlobChunkReceipt] {
         &self.chunks
     }


### PR DESCRIPTION
## What this changes

The binary CAS decided chunk boundaries twice for every payload it wrote.
`BlobPayload::from_bytes` cut the payload into chunks and hashed each one;
`prepare_blob_write` then cut it into chunks again to build the manifest. #1299
already stopped the second pass from re-*hashing* by caching receipts on the
payload, but the second boundary search stayed.

This makes the payload's receipts the boundary decision. `prepare_blob_write`
rebuilds the ranges from the receipt sizes, and a tiling check — receipts must
cover the payload exactly, in order, with sane sizes — is what makes trusting
them safe. That check is strictly stronger than the count comparison it replaces.

Three things fall out:

- `chunking.rs` is now the single authority for boundaries. `BlobId::from_content`
  and `BlobPayload::from_bytes` both route through it instead of open-coding
  `bytes.chunks(MEDIA_CHUNK_BYTES)` in three places.
- `BinaryCasChunking` was only ever `::default()`. Threading it from
  `BinaryCasContext` through the writer into `prepare_blob_write` bought nothing,
  so the field, both constructor parameters and the function parameter are gone.
  `BinaryCasContext` is now a unit struct.
- The names stop lying. `fastcdc_chunk_ranges*` never contained a rolling hash,
  a gear table, or any content-defined boundary — it was
  `(0..len).step_by(1 MiB)`. It is now `chunk_ranges*`, the doc comment says
  boundaries are cut at fixed offsets and that a one-byte shift renames every
  later chunk, and the test that asserted "fallback must retain FastCDC layout"
  says what it actually checks.

## Measurements

Interleaved with **rotated arm order** (each arm takes each position equally),
12 reps/arm, medians, SlateDB, `ryzen-9950x-IV`. Base `79735d753`.

| operation | size | base | this PR | delta |
|---|---:|---:|---:|---:|
| localized_4k_update | 1 MiB | 0.733 ms | 0.768 ms | +4.8% |
| full_rewrite | 1 MiB | 0.714 ms | 0.673 ms | -5.7% |
| initial_write | 1 MiB | 0.777 ms | 0.677 ms | -12.8% |
| localized_4k_update | 10 MiB | 2.129 ms | 2.125 ms | -0.2% |
| full_rewrite | 10 MiB | 3.969 ms | 3.979 ms | +0.3% |
| initial_write | 10 MiB | 4.043 ms | 4.003 ms | -1.0% |
| resumable_initial_write | 1 / 10 MiB | 201.97 / 201.91 ms | 202.05 / 201.94 ms | +0.0% |

**Read the size of these deltas against the null control.** The same runs
include `raw_backend_initial_write`, which never touches the binary CAS and is
byte-identical code in both arms; it still measures **+1.7% (1 MiB) and +3.7%
(10 MiB)** between worktrees. So this bench cannot resolve anything under roughly
±5%, and the honest summary is that removing the duplicate boundary search is
**neutral-to-slightly-positive on the current fixed path** — as expected, since
fixed chunking's second pass is only `step_by` arithmetic. The point of the change
is that it makes the second pass free *whatever* the chunker costs, and it removes
a redundant authority.

`small_blob_cas` (12 reps/arm, 4/64/256 KiB, both backends, all operations): every
delta within ±3% except `slatedb/unique_write/64k` at +9.7%, which moves
identically on an unrelated arm and is the known-noisy id.

Storage accounting is byte-for-byte unchanged, as it must be — this PR does not
alter any layout.

## Gate

`cargo check --workspace`, `cargo clippy --workspace --all-targets --all-features
-- -D warnings`, `cargo test -p lix` (2057 + 447 tests) all pass on `ryzen-9950x-IV`.
