### PR TITLE
perf(tracked-state): quantify commit-delta segment duplication (negative result)

### DIFF
--- a/packages/engine-benchmarks/Cargo.toml
+++ b/packages/engine-benchmarks/Cargo.toml
@@ -66,6 +66,11 @@ path = "examples/space_growth.rs"
 required-features = ["storage-benches"]
 
 [[example]]
+name = "delta_segment_duplication"
+path = "examples/delta_segment_duplication.rs"
+required-features = ["storage-benches"]
+
+[[example]]
 name = "storage_layout"
 path = "examples/storage_layout.rs"
 required-features = ["storage-benches", "slatedb"]

--- a/packages/engine-benchmarks/benches/packed_history_scale.rs
+++ b/packages/engine-benchmarks/benches/packed_history_scale.rs
@@ -310,9 +310,9 @@ async fn run_case<S, Flush, FlushFuture>(
     );
     let lifecycle_write_amplification = ratio(lifecycle_io.write_bytes, logical_written_bytes);
     let storage_amplification = ratio(backend_bytes, logical_written_bytes);
-    let manifest = find_layout(&layout, "tracked_state.commit_delta_manifest.v2");
-    let segments = find_layout(&layout, "tracked_state.commit_delta_segment.v2");
-    let locators = find_layout(&layout, "tracked_state.change_locator.v1");
+    let manifest = find_layout(&layout, "tracked_state.commit_state_manifest.v7");
+    let segments = find_layout(&layout, "tracked_state.commit_delta_segment.v6");
+    let locators = find_layout(&layout, "tracked_state.change_locator.v2");
     let json_payloads = find_layout(&layout, "json_store.json");
 
     println!(
@@ -385,17 +385,22 @@ async fn run_case<S, Flush, FlushFuture>(
     );
 }
 
+/// `layout_accounting` enumerates every registered space, so a name that is not
+/// present is a stale namespace in this bench, not an empty space. Failing loudly
+/// is the only way the columns cannot silently rot into zeros the next time a
+/// namespace version is bumped.
 fn find_layout(layout: &[BenchLayoutAccounting], name: &str) -> BenchLayoutAccounting {
     layout
         .iter()
         .find(|space| space.space == name)
         .copied()
-        .unwrap_or(BenchLayoutAccounting {
-            space_id: 0,
-            space: "missing",
-            rows: 0,
-            key_bytes: 0,
-            value_bytes: 0,
+        .unwrap_or_else(|| {
+            let known = layout
+                .iter()
+                .map(|space| space.space)
+                .collect::<Vec<_>>()
+                .join(", ");
+            panic!("packed_history_scale asked for unregistered storage space '{name}'; registered: {known}")
         })
 }
 

--- a/packages/engine-benchmarks/examples/delta_segment_duplication.rs
+++ b/packages/engine-benchmarks/examples/delta_segment_duplication.rs
@@ -247,7 +247,9 @@ segment_dup_bytes={},segment_dup_pct={:.3},segment_max_occurrences={},\
 segment_share_of_settled_pct={:.2},\
 sim_distinct={},sim_same_length={},sim_pairs={},sim_near_identical={},\
 sim_min_differing_bytes={},sim_min_pair_len={},sim_min_pair_common_prefix={},\
-sim_min_pair_common_suffix={}",
+sim_min_pair_common_suffix={},\
+norm_dup_segments={},norm_dup_bytes={},norm_dup_pct_of_segment={:.2},\
+norm_dup_pct_of_settled={:.2},norm_shared_classes={}",
         directory_bytes(directory),
         percent(duplicate_bytes, settled_value_bytes),
         segment.rows,
@@ -266,6 +268,17 @@ sim_min_pair_common_suffix={}",
         similarity.min_differing_pair_len,
         similarity.min_differing_pair_common_prefix,
         similarity.min_differing_pair_common_suffix,
+        similarity.identity_normalized_duplicate_segments,
+        similarity.identity_normalized_duplicate_bytes,
+        percent(
+            similarity.identity_normalized_duplicate_bytes,
+            segment.value_bytes,
+        ),
+        percent(
+            similarity.identity_normalized_duplicate_bytes,
+            settled_value_bytes,
+        ),
+        similarity.identity_normalized_shared_classes,
     );
 
     let mut by_bytes: Vec<&StorageValueDuplication> = duplication

--- a/packages/engine-benchmarks/examples/delta_segment_duplication.rs
+++ b/packages/engine-benchmarks/examples/delta_segment_duplication.rs
@@ -70,6 +70,13 @@ async fn main() {
         .next()
         .and_then(|value| value.parse::<usize>().ok())
         .unwrap_or(10_000);
+    // Rows touched by one workload commit. The segment plane only receives a
+    // commit whose mutation count clears the ordered-part geometry, so the edit
+    // width is the variable that decides whether this plane is exercised at all.
+    let window = arguments
+        .next()
+        .and_then(|value| value.parse::<usize>().ok())
+        .unwrap_or_else(|| (rows / 100).max(1));
     let selected = arguments.next().map(|value| {
         value
             .split(',')
@@ -84,11 +91,11 @@ async fn main() {
         {
             continue;
         }
-        run_workload(workload, rows).await;
+        run_workload(workload, rows, window).await;
     }
 }
 
-async fn run_workload(workload: &str, rows: usize) {
+async fn run_workload(workload: &str, rows: usize, window: usize) {
     let directory = tempfile::tempdir().expect("create duplication-audit directory");
     let storage = RocksDB::open(directory.path()).expect("open duplication-audit RocksDB");
     Engine::initialize(storage.clone())
@@ -104,7 +111,6 @@ async fn run_workload(workload: &str, rows: usize) {
     register_schema(&main).await;
     seed_rows(&main, rows).await;
 
-    let window = (rows / 100).max(1);
     apply_workload(&engine, &main, workload, window).await;
 
     storage.flush().expect("flush duplication-audit RocksDB");

--- a/packages/engine-benchmarks/examples/delta_segment_duplication.rs
+++ b/packages/engine-benchmarks/examples/delta_segment_duplication.rs
@@ -240,7 +240,8 @@ segment_rows={},segment_value_bytes={},segment_distinct={},segment_dup_rows={},\
 segment_dup_bytes={},segment_dup_pct={:.3},segment_max_occurrences={},\
 segment_share_of_settled_pct={:.2},\
 sim_distinct={},sim_same_length={},sim_pairs={},sim_near_identical={},\
-sim_min_differing_bytes={},sim_min_pair_len={}",
+sim_min_differing_bytes={},sim_min_pair_len={},sim_min_pair_common_prefix={},\
+sim_min_pair_common_suffix={}",
         directory_bytes(directory),
         percent(duplicate_bytes, settled_value_bytes),
         segment.rows,
@@ -257,6 +258,8 @@ sim_min_differing_bytes={},sim_min_pair_len={}",
         similarity.near_identical_pairs,
         similarity.min_differing_bytes,
         similarity.min_differing_pair_len,
+        similarity.min_differing_pair_common_prefix,
+        similarity.min_differing_pair_common_suffix,
     );
 
     let mut by_bytes: Vec<&StorageValueDuplication> = duplication

--- a/packages/engine-benchmarks/examples/delta_segment_duplication.rs
+++ b/packages/engine-benchmarks/examples/delta_segment_duplication.rs
@@ -1,0 +1,470 @@
+//! How much of the settled repository is byte-identical duplicate content?
+//!
+//! The commit-delta segment plane is keyed `commit_id ++ segment_index`, not by
+//! a content digest, so nothing in the engine can notice that two commits wrote
+//! the same segment bytes. Every other high-volume immutable plane in the engine
+//! *is* content-addressed. The obvious question is whether that difference costs
+//! anything in practice.
+//!
+//! This example answers it by measurement rather than by assumption. Each
+//! workload builds a repository through the real `SessionContext` SQL commit
+//! path, then reads every storage space back and reports, per space:
+//!
+//! * `rows` / `value_bytes` — what settled.
+//! * `distinct` — distinct value byte strings.
+//! * `dup_bytes` — what a perfect content-addressed store would never have
+//!   written: `(occurrences - 1) * len` summed over distinct values. This is an
+//!   upper bound on the win, since it charges nothing for the indirection a real
+//!   content-addressed layout would need.
+//!
+//! For the delta-segment plane it additionally reports a nearest-neighbour
+//! analysis over equal-length segments: if two segments that "should" be
+//! identical differ in a handful of bytes, the payload carries per-commit
+//! identity that a naive CAS key would not have caught anyway.
+//!
+//! Usage:
+//! ```sh
+//! cargo run -p lix_benchmarks --release --features storage-benches \
+//!   --example delta_segment_duplication -- [rows] [workloads]
+//! ```
+//! `workloads` is a comma-separated subset of the names in `WORKLOADS`.
+
+use std::path::Path;
+
+use lix::integration::{Engine, SessionContext};
+use lix::storage::Storage;
+use lix::storage_adapter::{StorageAdapter, StorageReadOptions};
+use lix::storage_bench::{
+    CommitDeltaSegmentSimilarity, StorageValueDuplication, commit_delta_segment_similarity,
+    space_value_duplication,
+};
+use lix::{CreateBranchOptions, MergeBranchOptions, Value};
+use lix_storage_rocksdb::RocksDB;
+
+const WORKLOADS: &[&str] = &[
+    // Ordinary forward development: every commit writes new content.
+    "linear_disjoint",
+    "linear_hot_window",
+    // Real workloads that plausibly re-create content already stored.
+    "repeat_identical_write",
+    "revert_roundtrip",
+    "undo_roundtrip",
+    "merge_replay",
+    // Synthetic upper bound: N branches making byte-identical edits.
+    "branches_2_identical",
+    "branches_2_disjoint",
+    "branches_10_identical",
+    "branches_10_disjoint",
+];
+
+const PAD: &str = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+const SEED_BATCH_ROWS: usize = 5_000;
+/// Commits applied by every multi-commit workload, so their per-commit costs
+/// are directly comparable.
+const WORKLOAD_COMMITS: usize = 10;
+
+#[tokio::main(flavor = "current_thread")]
+async fn main() {
+    let mut arguments = std::env::args().skip(1);
+    let rows = arguments
+        .next()
+        .and_then(|value| value.parse::<usize>().ok())
+        .unwrap_or(10_000);
+    let selected = arguments.next().map(|value| {
+        value
+            .split(',')
+            .map(str::trim)
+            .map(str::to_owned)
+            .collect::<Vec<_>>()
+    });
+
+    for workload in WORKLOADS {
+        if let Some(selected) = selected.as_ref()
+            && !selected.iter().any(|value| value == workload)
+        {
+            continue;
+        }
+        run_workload(workload, rows).await;
+    }
+}
+
+async fn run_workload(workload: &str, rows: usize) {
+    let directory = tempfile::tempdir().expect("create duplication-audit directory");
+    let storage = RocksDB::open(directory.path()).expect("open duplication-audit RocksDB");
+    Engine::initialize(storage.clone())
+        .await
+        .expect("initialize duplication-audit repository");
+    let engine = Engine::new(storage.clone())
+        .await
+        .expect("open duplication-audit engine");
+    let main = engine
+        .open_workspace_session()
+        .await
+        .expect("open duplication-audit workspace");
+    register_schema(&main).await;
+    seed_rows(&main, rows).await;
+
+    let window = (rows / 100).max(1);
+    apply_workload(&engine, &main, workload, window).await;
+
+    storage.flush().expect("flush duplication-audit RocksDB");
+    let adapter = StorageAdapter::new(storage.clone());
+    let read = adapter
+        .begin_read(StorageReadOptions::default())
+        .await
+        .expect("open duplication-audit snapshot");
+    let duplication = space_value_duplication(&read).await;
+    let similarity = commit_delta_segment_similarity(&read).await;
+    drop(read);
+
+    report(
+        workload,
+        rows,
+        window,
+        directory.path(),
+        &duplication,
+        similarity,
+    );
+}
+
+async fn apply_workload<S>(
+    engine: &Engine<S>,
+    main: &SessionContext<S>,
+    workload: &str,
+    window: usize,
+) where
+    S: Storage + Clone + Send + Sync + 'static,
+{
+    match workload {
+        // Each commit edits a different window: no commit can repeat another.
+        "linear_disjoint" => {
+            for index in 0..WORKLOAD_COMMITS {
+                edit_rows(main, index * window, window, index + 1).await;
+            }
+        }
+        // Every commit rewrites the same rows with fresh content.
+        "linear_hot_window" => {
+            for index in 0..WORKLOAD_COMMITS {
+                edit_rows(main, 0, window, index + 1).await;
+            }
+        }
+        // The same statement, committed repeatedly. Every commit after the
+        // first re-states content the repository already holds.
+        "repeat_identical_write" => {
+            for _ in 0..WORKLOAD_COMMITS {
+                edit_rows(main, 0, window, 1).await;
+            }
+        }
+        // Edit away and back again. Every even commit restores content that the
+        // repository stored one commit earlier.
+        "revert_roundtrip" => {
+            for index in 0..WORKLOAD_COMMITS / 2 {
+                edit_rows(main, 0, window, index + 1).await;
+                restore_rows(main, 0, window).await;
+            }
+        }
+        // Same shape, driven through the engine's own undo path.
+        "undo_roundtrip" => {
+            for index in 0..WORKLOAD_COMMITS / 2 {
+                edit_rows(main, 0, window, index + 1).await;
+                main.undo().await.expect("undo duplication-audit commit");
+            }
+        }
+        // Two branches off the same base make the same edit; both are merged
+        // into main. The merge commits replay content already stored.
+        "merge_replay" => {
+            let first = create_branch(main, "replay-0").await;
+            edit_on_branch(engine, &first, 0, window, 1).await;
+            let second = create_branch(main, "replay-1").await;
+            edit_on_branch(engine, &second, 0, window, 1).await;
+            main.merge_branch(MergeBranchOptions {
+                source_branch_id: first,
+            })
+            .await
+            .expect("merge duplication-audit branch");
+            let _ = main
+                .merge_branch(MergeBranchOptions {
+                    source_branch_id: second,
+                })
+                .await;
+        }
+        "branches_2_identical" => branch_fanout(engine, main, 2, window, false).await,
+        "branches_2_disjoint" => branch_fanout(engine, main, 2, window, true).await,
+        "branches_10_identical" => branch_fanout(engine, main, 10, window, false).await,
+        "branches_10_disjoint" => branch_fanout(engine, main, 10, window, true).await,
+        other => panic!("unknown duplication-audit workload '{other}'"),
+    }
+}
+
+async fn branch_fanout<S>(
+    engine: &Engine<S>,
+    main: &SessionContext<S>,
+    branches: usize,
+    window: usize,
+    disjoint: bool,
+) where
+    S: Storage + Clone + Send + Sync + 'static,
+{
+    for index in 0..branches {
+        let branch = create_branch(main, &format!("fanout-{index}")).await;
+        let start = if disjoint { index * window } else { 0 };
+        edit_on_branch(engine, &branch, start, window, 1).await;
+    }
+}
+
+fn report(
+    workload: &str,
+    rows: usize,
+    window: usize,
+    directory: &Path,
+    duplication: &[StorageValueDuplication],
+    similarity: CommitDeltaSegmentSimilarity,
+) {
+    let settled_value_bytes: u64 = duplication.iter().map(|entry| entry.value_bytes).sum();
+    let settled_key_bytes: u64 = duplication.iter().map(|entry| entry.key_bytes).sum();
+    let duplicate_bytes: u64 = duplication
+        .iter()
+        .map(|entry| entry.duplicate_value_bytes)
+        .sum();
+    let segment = duplication
+        .iter()
+        .find(|entry| entry.space_id == 0x0004_001a)
+        .copied()
+        .unwrap_or_default();
+
+    println!(
+        "delta_dup,workload={workload},rows={rows},window={window},\
+physical_bytes={},settled_key_bytes={settled_key_bytes},settled_value_bytes={settled_value_bytes},\
+settled_dup_bytes={duplicate_bytes},settled_dup_pct={:.3},\
+segment_rows={},segment_value_bytes={},segment_distinct={},segment_dup_rows={},\
+segment_dup_bytes={},segment_dup_pct={:.3},segment_max_occurrences={},\
+segment_share_of_settled_pct={:.2},\
+sim_distinct={},sim_same_length={},sim_pairs={},sim_near_identical={},\
+sim_min_differing_bytes={},sim_min_pair_len={}",
+        directory_bytes(directory),
+        percent(duplicate_bytes, settled_value_bytes),
+        segment.rows,
+        segment.value_bytes,
+        segment.distinct_values,
+        segment.duplicate_rows,
+        segment.duplicate_value_bytes,
+        segment.duplicate_fraction() * 100.0,
+        segment.max_occurrences,
+        percent(segment.value_bytes, settled_value_bytes),
+        similarity.distinct_values,
+        similarity.same_length_distinct_values,
+        similarity.compared_pairs,
+        similarity.near_identical_pairs,
+        similarity.min_differing_bytes,
+        similarity.min_differing_pair_len,
+    );
+
+    let mut by_bytes: Vec<&StorageValueDuplication> = duplication
+        .iter()
+        .filter(|entry| entry.value_bytes > 0)
+        .collect();
+    by_bytes.sort_unstable_by_key(|entry| std::cmp::Reverse(entry.value_bytes));
+    for entry in by_bytes.iter().take(12) {
+        println!(
+            "  delta_dup_space,workload={workload},rows={rows},space=0x{:08x}/{},\
+rows={},key_bytes={},value_bytes={},distinct={},dup_rows={},dup_bytes={},dup_pct={:.3},\
+max_occurrences={}",
+            entry.space_id,
+            entry.space,
+            entry.rows,
+            entry.key_bytes,
+            entry.value_bytes,
+            entry.distinct_values,
+            entry.duplicate_rows,
+            entry.duplicate_value_bytes,
+            entry.duplicate_fraction() * 100.0,
+            entry.max_occurrences,
+        );
+    }
+}
+
+fn percent(part: u64, whole: u64) -> f64 {
+    if whole == 0 {
+        0.0
+    } else {
+        part as f64 * 100.0 / whole as f64
+    }
+}
+
+async fn create_branch<S>(main: &SessionContext<S>, name: &str) -> String
+where
+    S: Storage + Clone + Send + Sync + 'static,
+{
+    main.create_branch(CreateBranchOptions {
+        id: None,
+        name: name.to_owned(),
+        from_commit_id: None,
+    })
+    .await
+    .expect("create duplication-audit branch")
+    .id
+}
+
+async fn edit_on_branch<S>(
+    engine: &Engine<S>,
+    branch: &str,
+    start: usize,
+    count: usize,
+    generation: usize,
+) where
+    S: Storage + Clone + Send + Sync + 'static,
+{
+    let session = engine
+        .open_session(branch.to_owned())
+        .await
+        .expect("open duplication-audit branch session");
+    edit_rows(&session, start, count, generation).await;
+}
+
+/// The written value depends only on the row index and the generation, so two
+/// commits given the same `(start, count, generation)` produce byte-identical
+/// content whatever branch or order they run in.
+async fn edit_rows<S>(session: &SessionContext<S>, start: usize, count: usize, generation: usize)
+where
+    S: Storage + Clone + Send + Sync + 'static,
+{
+    let mut written = 0usize;
+    while written < count {
+        let batch = (count - written).min(SEED_BATCH_ROWS);
+        let mut transaction = session
+            .begin_transaction()
+            .await
+            .expect("begin duplication-audit edit");
+        for offset in 0..batch {
+            let index = start + written + offset;
+            transaction
+                .execute(
+                    "UPDATE dup_fixture SET value = lix_json($1) WHERE path = $2",
+                    &[
+                        Value::Text(format!(
+                            r#"{{"seed":{index},"generation":{generation},"pad":"{PAD}"}}"#
+                        )),
+                        Value::Text(row_path(index)),
+                    ],
+                )
+                .await
+                .expect("stage duplication-audit edit");
+        }
+        transaction
+            .commit()
+            .await
+            .expect("commit duplication-audit edit");
+        written += batch;
+    }
+}
+
+/// Restores the exact bytes `seed_rows` wrote, so the resulting commit's payload
+/// is content the repository already stored.
+async fn restore_rows<S>(session: &SessionContext<S>, start: usize, count: usize)
+where
+    S: Storage + Clone + Send + Sync + 'static,
+{
+    let mut transaction = session
+        .begin_transaction()
+        .await
+        .expect("begin duplication-audit restore");
+    for offset in 0..count {
+        let index = start + offset;
+        transaction
+            .execute(
+                "UPDATE dup_fixture SET value = lix_json($1) WHERE path = $2",
+                &[
+                    Value::Text(seed_value(index)),
+                    Value::Text(row_path(index)),
+                ],
+            )
+            .await
+            .expect("stage duplication-audit restore");
+    }
+    transaction
+        .commit()
+        .await
+        .expect("commit duplication-audit restore");
+}
+
+fn row_path(index: usize) -> String {
+    format!("/dup/fixture/{index:09}")
+}
+
+fn seed_value(index: usize) -> String {
+    format!(r#"{{"seed":{index},"pad":"{PAD}"}}"#)
+}
+
+async fn register_schema<S>(session: &SessionContext<S>)
+where
+    S: Storage + Clone + Send + Sync + 'static,
+{
+    let schema = serde_json::json!({
+        "x-lix-key": "dup_fixture",
+        "x-lix-primary-key": ["/path"],
+        "type": "object",
+        "required": ["path", "value"],
+        "properties": {
+            "path": { "type": "string" },
+            "value": {
+                "type": ["object", "array", "string", "number", "integer", "boolean", "null"]
+            }
+        },
+        "additionalProperties": false
+    });
+    session
+        .execute(
+            "INSERT INTO lix_registered_schema (value, lixcol_global, lixcol_untracked) \
+             VALUES (lix_json($1), false, false)",
+            &[Value::Text(schema.to_string())],
+        )
+        .await
+        .expect("register duplication-audit schema");
+}
+
+async fn seed_rows<S>(session: &SessionContext<S>, rows: usize)
+where
+    S: Storage + Clone + Send + Sync + 'static,
+{
+    let mut written = 0usize;
+    while written < rows {
+        let batch = (rows - written).min(SEED_BATCH_ROWS);
+        let mut transaction = session
+            .begin_transaction()
+            .await
+            .expect("begin duplication-audit seed");
+        for offset in 0..batch {
+            let index = written + offset;
+            transaction
+                .execute(
+                    "INSERT INTO dup_fixture (path, value) VALUES ($1, lix_json($2))",
+                    &[Value::Text(row_path(index)), Value::Text(seed_value(index))],
+                )
+                .await
+                .expect("stage duplication-audit seed row");
+        }
+        transaction
+            .commit()
+            .await
+            .expect("commit duplication-audit seed");
+        written += batch;
+    }
+}
+
+fn directory_bytes(path: &Path) -> u64 {
+    std::fs::read_dir(path).map_or(0, |entries| {
+        entries
+            .flatten()
+            .map(|entry| {
+                let path = entry.path();
+                entry.metadata().map_or(0, |metadata| {
+                    if metadata.is_dir() {
+                        directory_bytes(&path)
+                    } else {
+                        metadata.len()
+                    }
+                })
+            })
+            .sum()
+    })
+}

--- a/packages/lix/src/storage_bench.rs
+++ b/packages/lix/src/storage_bench.rs
@@ -1840,16 +1840,30 @@ pub struct CommitDeltaSegmentSimilarity {
     pub min_differing_pair_common_suffix: u64,
     /// Whether any pair was compared at all.
     pub compared_any: bool,
+    /// Segments that a content-addressed plane could have elided *if* the
+    /// format also hoisted per-commit identity out of the payload. Two segments
+    /// count as content-equal when they share a byte length and their differing
+    /// bytes all fall inside one window of at most
+    /// `SEGMENT_IDENTITY_WINDOW_BYTES`.
+    pub identity_normalized_duplicate_segments: u64,
+    pub identity_normalized_duplicate_bytes: u64,
+    /// Content-equivalence classes with more than one member.
+    pub identity_normalized_shared_classes: u64,
 }
 
 /// Cap on distinct same-length values compared pairwise per length bucket.
 const SEGMENT_SIMILARITY_BUCKET_CAP: usize = 128;
+/// How much per-segment identity a redesigned payload is allowed to hoist out.
+/// The LXCD16 direct leaf carries a 16-byte commit id, a 4-byte packed base and
+/// a small timestamp-tail dictionary; 128 bytes is a generous allowance for all
+/// of it, so this over-counts rather than under-counts the achievable win.
+const SEGMENT_IDENTITY_WINDOW_BYTES: usize = 128;
 
 pub async fn commit_delta_segment_similarity<R>(read: &R) -> CommitDeltaSegmentSimilarity
 where
     R: StorageAdapterRead,
 {
-    let mut distinct = std::collections::HashMap::<[u8; 32], Bytes>::new();
+    let mut distinct = std::collections::HashMap::<[u8; 32], (Bytes, u64)>::new();
     let mut segments = 0u64;
     for entry in scan_layout_entries(
         read,
@@ -1861,14 +1875,18 @@ where
         let StorageProjectedValue::FullValue(value) = entry.value else {
             continue;
         };
-        distinct
+        let slot = distinct
             .entry(*blake3::hash(&value).as_bytes())
-            .or_insert(value);
+            .or_insert((value, 0));
+        slot.1 += 1;
     }
 
-    let mut buckets = std::collections::BTreeMap::<usize, Vec<Bytes>>::new();
-    for value in distinct.into_values() {
-        buckets.entry(value.len()).or_default().push(value);
+    let mut buckets = std::collections::BTreeMap::<usize, Vec<(Bytes, u64)>>::new();
+    for (value, occurrences) in distinct.into_values() {
+        buckets
+            .entry(value.len())
+            .or_default()
+            .push((value, occurrences));
     }
 
     let mut similarity = CommitDeltaSegmentSimilarity {
@@ -1883,8 +1901,10 @@ where
         }
         similarity.same_length_distinct_values += values.len() as u64;
         let window = &values[..values.len().min(SEGMENT_SIMILARITY_BUCKET_CAP)];
-        for (index, left) in window.iter().enumerate() {
-            for right in &window[index + 1..] {
+        // Union-find over "content-equal once identity is hoisted out".
+        let mut class = (0..window.len()).collect::<Vec<_>>();
+        for (index, (left, _)) in window.iter().enumerate() {
+            for (offset, (right, _)) in window[index + 1..].iter().enumerate() {
                 let differing = left
                     .iter()
                     .zip(right.iter())
@@ -1895,21 +1915,41 @@ where
                 if differing * 100 <= left.len() as u64 {
                     similarity.near_identical_pairs += 1;
                 }
+                let common_prefix = left
+                    .iter()
+                    .zip(right.iter())
+                    .take_while(|(left, right)| left == right)
+                    .count();
+                let common_suffix = left
+                    .iter()
+                    .rev()
+                    .zip(right.iter().rev())
+                    .take_while(|(left, right)| left == right)
+                    .count();
+                if differing > 0
+                    && common_prefix + common_suffix + SEGMENT_IDENTITY_WINDOW_BYTES >= left.len()
+                {
+                    union(&mut class, index, index + 1 + offset);
+                }
                 if differing < similarity.min_differing_bytes {
                     similarity.min_differing_bytes = differing;
                     similarity.min_differing_pair_len = left.len() as u64;
-                    similarity.min_differing_pair_common_prefix = left
-                        .iter()
-                        .zip(right.iter())
-                        .take_while(|(left, right)| left == right)
-                        .count() as u64;
-                    similarity.min_differing_pair_common_suffix = left
-                        .iter()
-                        .rev()
-                        .zip(right.iter().rev())
-                        .take_while(|(left, right)| left == right)
-                        .count() as u64;
+                    similarity.min_differing_pair_common_prefix = common_prefix as u64;
+                    similarity.min_differing_pair_common_suffix = common_suffix as u64;
                 }
+            }
+        }
+        let mut members = std::collections::BTreeMap::<usize, (u64, u64)>::new();
+        for (index, (value, occurrences)) in window.iter().enumerate() {
+            let root = find(&mut class, index);
+            let slot = members.entry(root).or_insert((0, value.len() as u64));
+            slot.0 += occurrences;
+        }
+        for (occurrences, len) in members.into_values() {
+            if occurrences > 1 {
+                similarity.identity_normalized_shared_classes += 1;
+                similarity.identity_normalized_duplicate_segments += occurrences - 1;
+                similarity.identity_normalized_duplicate_bytes += (occurrences - 1) * len;
             }
         }
     }
@@ -1917,6 +1957,22 @@ where
         similarity.min_differing_bytes = 0;
     }
     similarity
+}
+
+fn find(class: &mut [usize], mut index: usize) -> usize {
+    while class[index] != index {
+        class[index] = class[class[index]];
+        index = class[index];
+    }
+    index
+}
+
+fn union(class: &mut [usize], left: usize, right: usize) {
+    let left = find(class, left);
+    let right = find(class, right);
+    if left != right {
+        class[right] = left;
+    }
 }
 
 pub async fn binary_manifest_layout_accounting<R>(

--- a/packages/lix/src/storage_bench.rs
+++ b/packages/lix/src/storage_bench.rs
@@ -1729,6 +1729,179 @@ where
     accounting
 }
 
+/// Exact value-level duplication for one storage space.
+///
+/// `duplicate_value_bytes` is what a perfect content-addressed store would not
+/// have had to write: for every distinct value byte string that occurs `n`
+/// times, `(n - 1) * len`. It is an upper bound on the win from content
+/// addressing that plane, because it ignores whatever indirection a real
+/// content-addressed layout would have to add.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct StorageValueDuplication {
+    pub space_id: u32,
+    pub space: &'static str,
+    pub rows: u64,
+    pub key_bytes: u64,
+    pub value_bytes: u64,
+    /// Distinct value byte strings in the space.
+    pub distinct_values: u64,
+    /// Rows whose value byte string also occurs on at least one other row.
+    pub duplicate_rows: u64,
+    pub duplicate_value_bytes: u64,
+    /// Largest number of rows sharing one value byte string.
+    pub max_occurrences: u64,
+}
+
+impl StorageValueDuplication {
+    /// Share of the space's value bytes a perfect CAS would have elided.
+    pub fn duplicate_fraction(&self) -> f64 {
+        if self.value_bytes == 0 {
+            0.0
+        } else {
+            self.duplicate_value_bytes as f64 / self.value_bytes as f64
+        }
+    }
+}
+
+/// Byte-exact duplication for every native storage space.
+pub async fn space_value_duplication<R>(read: &R) -> Vec<StorageValueDuplication>
+where
+    R: StorageAdapterRead,
+{
+    let mut accounting = Vec::with_capacity(native_storage_spaces().len());
+    for space in native_storage_spaces() {
+        accounting.push(scan_space_value_duplication(read, *space).await);
+    }
+    accounting
+}
+
+async fn scan_space_value_duplication<R>(
+    read: &R,
+    space: crate::storage_adapter::StorageSpace,
+) -> StorageValueDuplication
+where
+    R: StorageAdapterRead,
+{
+    let mut accounting = StorageValueDuplication {
+        space_id: space.id.0,
+        space: space.name,
+        ..StorageValueDuplication::default()
+    };
+    let mut occurrences = std::collections::HashMap::<[u8; 32], (u64, u64)>::new();
+    for entry in scan_layout_entries(read, space).await {
+        accounting.rows += 1;
+        accounting.key_bytes += entry.key.0.len() as u64 + 4;
+        let StorageProjectedValue::FullValue(value) = entry.value else {
+            continue;
+        };
+        accounting.value_bytes += value.len() as u64;
+        let digest = *blake3::hash(&value).as_bytes();
+        let slot = occurrences.entry(digest).or_insert((0, value.len() as u64));
+        slot.0 += 1;
+    }
+    accounting.distinct_values = occurrences.len() as u64;
+    for (count, len) in occurrences.into_values() {
+        accounting.max_occurrences = accounting.max_occurrences.max(count);
+        if count > 1 {
+            accounting.duplicate_rows += count - 1;
+            accounting.duplicate_value_bytes += (count - 1) * len;
+        }
+    }
+    accounting
+}
+
+/// Nearest-neighbour analysis of the commit-delta segment plane.
+///
+/// Byte-exact duplication answers "would a naive CAS dedup this". This answers
+/// the follow-up: when two segments are *not* byte-identical, how far apart are
+/// they? Two equal-length segments differing in a handful of bytes mean the
+/// payload carries per-commit identity (commit id, timestamps) that a redesign
+/// could hoist out; two segments differing in most of their bytes mean the
+/// content genuinely differs and no format change would help.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct CommitDeltaSegmentSimilarity {
+    pub segments: u64,
+    pub distinct_values: u64,
+    /// Distinct values that share their byte length with another distinct value.
+    pub same_length_distinct_values: u64,
+    /// Compared pairs of equal-length distinct values.
+    pub compared_pairs: u64,
+    /// Pairs differing in at most 1% of their bytes.
+    pub near_identical_pairs: u64,
+    /// Smallest positive byte-difference count over all compared pairs.
+    pub min_differing_bytes: u64,
+    /// Byte length of the pair that produced `min_differing_bytes`.
+    pub min_differing_pair_len: u64,
+    /// Whether any pair was compared at all.
+    pub compared_any: bool,
+}
+
+/// Cap on distinct same-length values compared pairwise per length bucket.
+const SEGMENT_SIMILARITY_BUCKET_CAP: usize = 128;
+
+pub async fn commit_delta_segment_similarity<R>(read: &R) -> CommitDeltaSegmentSimilarity
+where
+    R: StorageAdapterRead,
+{
+    let mut distinct = std::collections::HashMap::<[u8; 32], Bytes>::new();
+    let mut segments = 0u64;
+    for entry in scan_layout_entries(
+        read,
+        crate::tracked_state::TRACKED_STATE_COMMIT_DELTA_SEGMENT_SPACE,
+    )
+    .await
+    {
+        segments += 1;
+        let StorageProjectedValue::FullValue(value) = entry.value else {
+            continue;
+        };
+        distinct
+            .entry(*blake3::hash(&value).as_bytes())
+            .or_insert(value);
+    }
+
+    let mut buckets = std::collections::BTreeMap::<usize, Vec<Bytes>>::new();
+    for value in distinct.into_values() {
+        buckets.entry(value.len()).or_default().push(value);
+    }
+
+    let mut similarity = CommitDeltaSegmentSimilarity {
+        segments,
+        min_differing_bytes: u64::MAX,
+        ..CommitDeltaSegmentSimilarity::default()
+    };
+    for values in buckets.values() {
+        similarity.distinct_values += values.len() as u64;
+        if values.len() < 2 {
+            continue;
+        }
+        similarity.same_length_distinct_values += values.len() as u64;
+        let window = &values[..values.len().min(SEGMENT_SIMILARITY_BUCKET_CAP)];
+        for (index, left) in window.iter().enumerate() {
+            for right in &window[index + 1..] {
+                let differing = left
+                    .iter()
+                    .zip(right.iter())
+                    .filter(|(left, right)| left != right)
+                    .count() as u64;
+                similarity.compared_pairs += 1;
+                similarity.compared_any = true;
+                if differing * 100 <= left.len() as u64 {
+                    similarity.near_identical_pairs += 1;
+                }
+                if differing < similarity.min_differing_bytes {
+                    similarity.min_differing_bytes = differing;
+                    similarity.min_differing_pair_len = left.len() as u64;
+                }
+            }
+        }
+    }
+    if !similarity.compared_any {
+        similarity.min_differing_bytes = 0;
+    }
+    similarity
+}
+
 pub async fn binary_manifest_layout_accounting<R>(
     read: &R,
 ) -> Result<BinaryManifestLayoutAccounting, crate::LixError>

--- a/packages/lix/src/storage_bench.rs
+++ b/packages/lix/src/storage_bench.rs
@@ -1832,6 +1832,12 @@ pub struct CommitDeltaSegmentSimilarity {
     pub min_differing_bytes: u64,
     /// Byte length of the pair that produced `min_differing_bytes`.
     pub min_differing_pair_len: u64,
+    /// Shared leading bytes of the pair that produced `min_differing_bytes`.
+    pub min_differing_pair_common_prefix: u64,
+    /// Shared trailing bytes of the same pair. A long shared suffix next to a
+    /// short shared prefix is the signature of a small identity header in front
+    /// of otherwise identical content.
+    pub min_differing_pair_common_suffix: u64,
     /// Whether any pair was compared at all.
     pub compared_any: bool,
 }
@@ -1892,6 +1898,17 @@ where
                 if differing < similarity.min_differing_bytes {
                     similarity.min_differing_bytes = differing;
                     similarity.min_differing_pair_len = left.len() as u64;
+                    similarity.min_differing_pair_common_prefix = left
+                        .iter()
+                        .zip(right.iter())
+                        .take_while(|(left, right)| left == right)
+                        .count() as u64;
+                    similarity.min_differing_pair_common_suffix = left
+                        .iter()
+                        .rev()
+                        .zip(right.iter().rev())
+                        .take_while(|(left, right)| left == right)
+                        .count() as u64;
                 }
             }
         }


### PR DESCRIPTION
## Verdict: do not content-address the commit-delta segment plane. Measured, negative.

`TRACKED_STATE_COMMIT_DELTA_SEGMENT_SPACE` (`0x0004_001a`) is keyed `commit_id ++ segment_index`,
not by a content digest, while every other high-volume immutable plane is content-addressed. This PR
quantifies what that costs. The answer is **nothing**, and the reason is not the key.

**Byte-exact duplication in that plane is 0 in every workload measured — including the ones built
specifically to produce identical content.** Distinct value digests equal total rows in all 27
measured repositories. Content-addressing the key would therefore dedup literally zero bytes.

The PR ships the measurement tooling and one instrument fix. No engine code path changed.

---

## What changed

**Added** (all behind the existing `storage-benches` feature, no public API change):

- `lix::storage_bench::space_value_duplication` — byte-exact duplication for **every** registered
  storage space: rows, distinct value digests (blake3), duplicate rows, and `duplicate_value_bytes`
  = what a perfect content-addressed store would never have written.
- `lix::storage_bench::commit_delta_segment_similarity` — nearest-neighbour analysis of the segment
  plane, plus an **identity-normalized duplication oracle**: two equal-length segments count as
  content-equal when every differing byte falls inside one window of ≤128 bytes. That is a generous
  allowance for the LXCD16 direct-leaf identity header (commit id 16 B + packed change base 4 B +
  timestamp tail dictionary), so the number over-counts rather than under-counts the ceiling of a
  format redesign.
- `packages/engine-benchmarks/examples/delta_segment_duplication.rs` — drives ten workloads through
  the real `SessionContext` SQL commit path and reports both, per space.

**Fixed:** `packed_history_scale` had been printing `manifest_*`, `segment_*` and `locator_*` as
zeros through three namespace bumps (`commit_delta_manifest.v2` → `commit_state_manifest.v7`,
`commit_delta_segment.v2` → `.v6`, `change_locator.v1` → `.v2`). `find_layout` silently returned a
zeroed row. It now panics naming the unregistered space, so the columns cannot rot again.

---

## 1. Duplication per workload

`delta_segment_duplication 30000 1000` — 30 000 seeded rows, workload commits 1 000 rows wide
(2 segments per commit). RocksDB, `ryzen-9950x-I`.

| workload | segment rows | distinct | **byte-exact dup bytes** | identity-normalized dup segments | norm dup bytes | % of segment plane |
|---|---|---|---|---|---|---|
| `linear_disjoint` | 80 | 80 | **0** | 0 | 0 | 0.00 |
| `linear_hot_window` | 80 | 80 | **0** | 0 | 0 | 0.00 |
| `repeat_identical_write` | 80 | 80 | **0** | 18 | 107 748 | 19.54 |
| `revert_roundtrip` | 80 | 80 | **0** | 8 | 47 016 | 8.54 |
| `undo_roundtrip` | 80 | 80 | **0** | 4 | 24 268 | 4.40 |
| `merge_replay` | 64 | 64 | **0** | 2 | 11 972 | 2.63 |
| `branches_2_identical` | 64 | 64 | **0** | 2 | 11 972 | 2.63 |
| `branches_2_disjoint` | 64 | 64 | **0** | 0 | 0 | 0.00 |
| `branches_10_identical` | 80 | 80 | **0** | 18 | 107 748 | 19.54 |
| `branches_10_disjoint` | 80 | 80 | **0** | 0 | 0 | 0.00 |

`delta_segment_duplication 100000 5000` — 100 000 rows, 5 000-row commits (10 segments per commit):

| workload | segment rows | segment value bytes | byte-exact dup | norm dup segs | norm dup bytes | % plane | % settled |
|---|---|---|---|---|---|---|---|
| `linear_disjoint` | 300 | 2 027 121 | **0** | 0 | 0 | 0.00 | 0.00 |
| `linear_hot_window` | 300 | 2 040 790 | **0** | 0 | 0 | 0.00 | 0.00 |
| `repeat_identical_write` | 300 | 2 042 174 | **0** | 90 | 541 071 | 26.49 | 11.50 |
| `revert_roundtrip` | 300 | 2 021 263 | **0** | 36 | 201 568 | 9.97 | 4.37 |
| `undo_roundtrip` | 300 | 2 019 885 | **0** | 36 | 204 736 | 10.14 | 4.44 |
| `merge_replay` | 220 | 1 561 256 | **0** | 10 | 60 119 | 3.85 | 1.12 |
| `branches_2_identical` | 220 | 1 564 392 | **0** | 10 | 60 209 | 3.85 | 1.13 |

**Repository-wide:** duplicate bytes are 0.06 %–1.01 % of settled value bytes, and **all** of it sits
in `live_state.hot_row.v21` as a constant 8 851–10 494 bytes produced by bootstrap — identical in
every workload, so no workload creates duplicate content anywhere. Every other space reports
`dup_bytes = 0`.

## 2. Ordinary commits never touch this plane

`delta_segment_duplication 30000 100` — same ten workloads, 100-row commits:
**segment rows = 60 in all ten**, i.e. exactly the seed, unchanged by identical or disjoint branches.

A commit writes segment rows only when it encodes to **more than one** segment. One segment is
retained and carried inline in the mutation catalog instead
(`tracked_state/storage.rs:4356` ordered, `:5270` generic; field doc at `:600-604`). With
`COMMIT_DELTA_SEGMENT_MAX_ROWS = 512` that means the **513th mutation** is where the plane first
receives a row on the ordered path (129th on the generic path). Below that the whole payload lives in
`tracked_state.commit_mutation_catalog.v1`.

So the entire class of "two developers make the same ordinary edit on two branches" never reaches
this plane at all.

## 3. Why byte-exact addressing wins nothing — measured, not assumed

The segment value embeds per-commit identity. In `repeat_identical_write` (10 commits of the *same*
`UPDATE`), the closest pair of equal-length segments is:

```
length 4 659 B · differing bytes 11 · common prefix 17 B · common suffix 4 584 B
```

Every differing byte lies in a 58-byte window at offset 17 — the LXCD16 direct-leaf header:
`NODE_KIND_DIRECT_LEAF_V1` + varint count + **commit id (16 B)** + **first_packed (4 B)** +
timestamp tail dictionary (`tracked_state/codec.rs:1551-1583`). `undo_roundtrip`: 10 differing bytes
of 5 495. `revert_roundtrip`: 14 of 4 273. The payloads are 99.7-99.8 % identical and never
byte-equal.

The oracle is not merely "small diff": `linear_hot_window` has **185** pairs differing by ≤1 % and
**zero** normalized classes, because its differences are scattered rather than confined to a header.
`branches_2_disjoint` and `branches_10_disjoint` report zero on both measures. The oracle also
reproduces ground truth exactly — `repeat_identical_write` yields 10 classes of 10 at 100k, matching
its 10 identical commits.

Decoders additionally *enforce* the embedded commit id (`visit_commit_delta_leaf`
`storage.rs:11826-11834`, `find_commit_delta_value` `:11856-11864`), so bytes could not be shared
even if they happened to match.

## 4. The stated primary metric is attributed to the wrong plane

`branch_storage_sharing`, SlateDB, `ryzen-9950x-I`:

**`LIX_BRANCH_SHARING_ROWS=10000`** (1 % = 100 rows per branch)

| scenario | delta_logical_bytes | delta-segment bytes |
|---|---|---|
| `branches_2_identical_1pct` | 83 503 | **0 — the space does not appear in the per-space delta at all** |
| `branches_2_disjoint_1pct` | 83 610 | **0** |

The 83.5 KB is `live_state.hot_row.v21` 71 352 B (85.4 %), `commit_mutation_catalog.v1` 3 536 B,
`gc.reachability_delta.v1` 2 328 B, `tree_chunk` 1 819 B, `commit_state_manifest.v7` 1 362 B, rest
changelog/branch control. The previously reported 84 369 / 84 431 byte pair matches this 10 000-row
scale, so the "two branches stored two full copies of delta segments" reading was taken from a
scenario in which **no delta segment was written at all**.

**`LIX_BRANCH_SHARING_ROWS=100000`** (1 % = 1 000 rows per branch → 2 segments per commit)

| scenario | delta_logical_bytes | `commit_delta_segment.v6` Δ | `live_state.hot_row.v21` Δ |
|---|---|---|---|
| `branches_2_identical_1pct` | 744 298 | 24 076 (3.2 %) | 710 352 (95.4 %) |
| `branches_2_disjoint_1pct` | 745 643 | 24 057 (3.2 %) | 711 462 (95.4 %) |

The "no dedup at all" result replicates — identical edits cost **19 bytes more** than disjoint ones
in the segment plane — but the plane responsible for branch cost is `live_state.hot_row.v21`, which
shows the same zero sharing (0.16 % apart) and carries 30× more of the bill.

## 5. Reader access shapes — prefix locality is *not* the blocker

14 logical read sites, **all** exact-key `PointReadPlan` batches whose keys come from a
manifest/catalog/directory (`storage.rs` 912, 1330, 1748, 6017, 6699, 7242, 7361, 8166, 8287, 8709,
8969, 9055, 9425, 9494, plus `get_one` at 3170/3456 and staged lookups at 3164/3419).
`PointReadPlan` is `prefix_lowered: 0` and bottoms out in independent point gets
(`storage_adapter/point.rs:70-180`). **No logical reader depends on commit-prefix adjacency.**

Two unbounded full-space scans exist, both repository-wide audits, never per-commit:

- `validate_no_orphan_commit_delta_segments` (`storage.rs:9917`, scan at `:9925`) — uses adjacency
  only as a manifest-batching dedupe at `:9950`; correctness comes from a `BTreeMap` at `:9955`.
- `scan_commit_delta_plane` (`storage.rs:10157`) — buffers the plane and groups into
  `BTreeMap<CommitId, BTreeMap<usize, Bytes>>`; **no adjacency dependency at all**.

What *would* break is structural, not locality: both assert key length ∈ {20, 52}, decode
`commit_id` from `key[..16]` and `segment_index` from `key[16..20]`, and assert byte-equality against
`commit_delta_segment_key_for_bounds` (`:9983-9995`, `:10333-10345`).

`commit_graph/context.rs:875` is not a read site — it is `CountingMemoryRead` test instrumentation
inside `mod tests` (from `:821`); the real commit-graph read is `context.rs:571` →
`storage.rs:8287/8166`. Three tests assert its `get_many` batch counts.

**GC is the sharp edge.** Production reachability GC (`stage_delete_commit_state_manifest_for_gc`,
`storage.rs:10373`, called from `gc.rs:2541`) is manifest-driven and refcount-free: it rebuilds each
key from `manifest.mutations.parts` and deletes it. Two commits sharing one content-addressed key
would have it deleted out from under the survivor. A CAS re-key needs a presence/refcount plane
(cf. `BINARY_CAS_CHUNK_PRESENCE_SPACE`).

## 6. Why Phase 2 was not implemented

Any saving at all requires: an LXCD17 payload cut hoisting commit id, packed change base and
timestamp tails into the manifest; a refcount/presence plane for GC; change-locator entries carrying
content digests; and relaxing the orphan/duplicate/exact-key assertions in both audit scans. For a
measured ceiling of **0.00 % on ordinary development**, 2.63-3.85 % of the plane for two branches
making identical *bulk* edits, and 19.5-26.5 % only for pathologically repeated identical bulk
commits — on a plane that ordinary commits never write to. That does not clear the acceptance gate,
so the negative result is the deliverable.

The next place to look for branch sharing is `live_state.hot_row.v21`, which carries 95.4 % of the
two-branch scenario delta and shows the same zero cross-branch sharing.

---

## Layout invariants

1. **Single authority** — no new authority. Read-only bench accounting; adds no writer, no
   materialization, no index.
2. **Commit canonicality** — unchanged. No commit record, parent link or state root is touched.
3. **Derived views are caches** — unchanged. Nothing derived is created or promoted.
4. **Atomic publication** — unchanged. No write set is modified.
5. **GC from refs** — unchanged. The GC findings above are reported, not applied.
6. **SQL reads canonical records** — unchanged. No query surface is touched.

## Metrics and regressions

No engine code path changed, so there is nothing to A/B: every added symbol is reachable only behind
the `storage-benches` feature, and the only non-additive edit is the `packed_history_scale` instrument
fix, which corrects columns that were printing zeros. **No metric regressed.**

Gate on `ryzen-9950x-I`: `cargo check --workspace`, `cargo clippy --workspace --all-targets
--all-features -- -D warnings`, `cargo test -p lix`.

Bench commands used:

```sh
cargo run -p lix_benchmarks --release --features storage-benches,slatedb \
  --example delta_segment_duplication -- <rows> <commit_width>

LIX_BRANCH_SHARING_ROWS=10000,100000 \
LIX_BRANCH_SHARING_SCENARIOS=branches_2_identical_1pct,branches_2_disjoint_1pct \
LIX_BRANCH_SHARING_BACKENDS=slatedb \
cargo bench -p lix_benchmarks --features storage-benches,slatedb --bench branch_storage_sharing
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
