### PR TITLE
perf(sql): stop rebuilding the SQL session on every statement

### DIFF
--- a/.changenotes/reuse-sql-sessions-across-statements.md
+++ b/.changenotes/reuse-sql-sessions-across-statements.md
@@ -1,0 +1,7 @@
+---
+type: patch
+---
+
+Faster repeated SQL reads: a pooled query session is now reused across statements instead of being rebuilt for each one.
+
+The engine used to re-register its per-statement SQL functions, re-install the `information_schema` views and deep-copy its function registries on every statement. Those are now installed once per session, and repeated statement shapes reuse the prepared scan plan directly. Point and multi-key reads get noticeably cheaper; results are unchanged.

--- a/packages/lix/src/session/context.rs
+++ b/packages/lix/src/session/context.rs
@@ -682,7 +682,7 @@ where
         self.sql_planning_cache.datafusion_session()
     }
 
-    fn datafusion_read_session(&self) -> datafusion::prelude::SessionContext {
+    fn datafusion_read_session(&self) -> crate::sql2::PooledReadSession {
         self.sql_planning_cache.datafusion_read_session()
     }
 

--- a/packages/lix/src/sql2/catalog/registry.rs
+++ b/packages/lix/src/sql2/catalog/registry.rs
@@ -47,14 +47,22 @@ impl PublicCatalog {
     /// complete `lix_*` namespace, so only trusted bootstrap schemas can add
     /// Lix-owned surfaces to this catalog.
     pub(crate) fn fixed_system() -> &'static Self {
-        static FIXED_SYSTEM_CATALOG: OnceLock<PublicCatalog> = OnceLock::new();
+        Self::fixed_system_shared()
+    }
+
+    /// The same immutable catalog behind an `Arc` so per-statement provider
+    /// registration can share it instead of deep-copying two `BTreeMap`s.
+    pub(crate) fn fixed_system_shared() -> &'static Arc<Self> {
+        static FIXED_SYSTEM_CATALOG: OnceLock<Arc<PublicCatalog>> = OnceLock::new();
         FIXED_SYSTEM_CATALOG.get_or_init(|| {
             let schemas = crate::schema::seed_schema_definitions()
                 .into_iter()
                 .cloned()
                 .collect::<Vec<_>>();
-            Self::from_visible_schemas(&schemas)
-                .expect("compile-time Lix schemas must form a valid SQL catalog")
+            Arc::new(
+                Self::from_visible_schemas(&schemas)
+                    .expect("compile-time Lix schemas must form a valid SQL catalog"),
+            )
         })
     }
 

--- a/packages/lix/src/sql2/context.rs
+++ b/packages/lix/src/sql2/context.rs
@@ -99,8 +99,8 @@ pub(crate) trait SqlExecutionContext: Sync {
     fn datafusion_session(&self) -> datafusion::prelude::SessionContext {
         super::session::new_sql_session_context()
     }
-    fn datafusion_read_session(&self) -> datafusion::prelude::SessionContext {
-        self.datafusion_session()
+    fn datafusion_read_session(&self) -> super::planning_cache::PooledReadSession {
+        super::planning_cache::PooledReadSession::standalone(self.datafusion_session())
     }
     async fn sql_planning_environment(
         &self,

--- a/packages/lix/src/sql2/exec/datafusion.rs
+++ b/packages/lix/src/sql2/exec/datafusion.rs
@@ -70,11 +70,13 @@ use crate::sql2::{
 };
 
 use super::{SqlDataFusionLogicalPlan, SqlLogicalPlan, SqlWriteResult};
+use crate::sql2::PooledReadSession;
+use datafusion::execution::SessionState;
 
 pub(crate) const LIX_INSERT_COLUMN_OMITTED_METADATA_KEY: &str = "lix_insert_column_omitted";
 
 pub(crate) struct DataFusionLogicalPlan {
-    pub(super) session: SessionContext,
+    pub(super) state: std::sync::Arc<SessionState>,
     pub(super) plan: LogicalPlan,
     pub(super) notices: Vec<LixNotice>,
     pub(super) json_predicate_params: BTreeSet<usize>,
@@ -240,7 +242,7 @@ impl SessionReadResult {
 
 /// DataFusion catalog and providers scoped to one immutable storage read.
 pub(crate) struct ReadSqlSession<'ctx> {
-    session: SessionContext,
+    session: Option<PooledReadSession>,
     planning_environment: Option<(
         std::sync::Arc<SqlPlanningCache<CatalogFingerprint>>,
         CatalogFingerprint,
@@ -248,10 +250,27 @@ pub(crate) struct ReadSqlSession<'ctx> {
     _context: PhantomData<&'ctx ()>,
 }
 
+impl ReadSqlSession<'_> {
+    fn pooled(&self) -> &PooledReadSession {
+        self.session
+            .as_ref()
+            .expect("read session is only taken back when the statement ends")
+    }
+
+    fn context(&self) -> &SessionContext {
+        self.pooled().context()
+    }
+
+    fn state(&self) -> &std::sync::Arc<SessionState> {
+        self.pooled().state()
+    }
+}
+
 impl Drop for ReadSqlSession<'_> {
     fn drop(&mut self) {
-        if let Some((cache, _)) = &self.planning_environment {
-            cache.recycle_datafusion_read_session(self.session.clone());
+        if let (Some((cache, _)), Some(session)) = (&self.planning_environment, self.session.take())
+        {
+            cache.recycle_datafusion_read_session(session);
         }
     }
 }
@@ -288,7 +307,7 @@ where
 {
     let planning_environment = ctx.sql_planning_environment().await?;
     Ok(ReadSqlSession {
-        session: build_read_session(ctx, statements).await?,
+        session: Some(build_read_session(ctx, statements).await?),
         planning_environment,
         _context: PhantomData,
     })
@@ -304,7 +323,7 @@ where
 {
     let planning_environment = ctx.sql_planning_environment().await?;
     Ok(ReadSqlSession {
-        session: build_read_session_at_head(ctx, active_head, statements).await?,
+        session: Some(build_read_session_at_head(ctx, active_head, statements).await?),
         planning_environment,
         _context: PhantomData,
     })
@@ -406,9 +425,9 @@ async fn create_logical_plan_in_session_from_parsed(
         && let Some((cache, catalog)) = &session.planning_environment
         && let Some(cached) = cache.read_plan(sql, params, catalog)
     {
-        let plan = rebind_cached_read_plan(&session.session, cached.plan.clone()).await?;
+        let plan = rebind_cached_read_plan(session.context(), cached.plan.clone()).await?;
         return Ok(SqlLogicalPlan::DataFusion(SqlDataFusionLogicalPlan {
-            session: session.session.clone(),
+            state: std::sync::Arc::clone(session.state()),
             plan,
             notices: Vec::new(),
             json_predicate_params: cached.json_predicate_params.clone(),
@@ -418,7 +437,7 @@ async fn create_logical_plan_in_session_from_parsed(
         }));
     }
     bind_table_function_parameters(&mut statement, params)?;
-    let plan = create_logical_plan_from_statement(&session.session, statement).await?;
+    let plan = create_logical_plan_from_statement(session.context(), statement).await?;
     validate_supported_logical_plan(&plan)?;
     validate_json_predicates_in_logical_plan(&plan)?;
     validate_history_anchor_predicates_in_logical_plan(&plan)?;
@@ -451,7 +470,7 @@ async fn create_logical_plan_in_session_from_parsed(
     };
 
     Ok(SqlLogicalPlan::DataFusion(SqlDataFusionLogicalPlan {
-        session: session.session.clone(),
+        state: std::sync::Arc::clone(session.state()),
         plan,
         notices: Vec::new(),
         json_predicate_params,
@@ -530,7 +549,7 @@ fn logical_plan_has_scalar_function(plan: &LogicalPlan) -> bool {
     found
 }
 
-fn statement_has_table_function(statement: &DataFusionStatement) -> bool {
+pub(crate) fn statement_has_table_function(statement: &DataFusionStatement) -> bool {
     struct TableFunctionVisitor(bool);
 
     impl Visitor for TableFunctionVisitor {
@@ -566,14 +585,10 @@ pub(crate) async fn execute_transaction_read_statement_from_parsed(
     // Same fence as session reads, with the transaction overlay available
     // during planning/execution but not returned to the caller.
     let planning_environment = read_ctx.sql_planning_environment().await?;
-    let plan = create_transaction_read_logical_plan_from_parsed(
+    let (plan, session) = create_transaction_read_logical_plan_from_parsed(
         read_ctx, write_ctx, sql, statement, params,
     )
     .await?;
-    let session = match &plan {
-        SqlLogicalPlan::DataFusion(plan) => plan.session.clone(),
-        _ => unreachable!("transaction reads are planned by DataFusion"),
-    };
     let result = execute_logical_plan(plan, params)
         .await
         .and_then(SessionReadResult::into_sql_query_result);
@@ -589,27 +604,30 @@ async fn create_transaction_read_logical_plan_from_parsed(
     sql: &str,
     mut statement: DataFusionStatement,
     params: &[Value],
-) -> Result<SqlLogicalPlan, LixError> {
+) -> Result<(SqlLogicalPlan, PooledReadSession), LixError> {
     crate::sql2::bind_read_statement(sql, &statement)?;
     let parameter_names = statement_parameter_names(&statement)?;
     let expected_parameter_count = expected_positional_parameter_count(&parameter_names)?;
     validate_parameter_count_values(expected_parameter_count, &parameter_names, params.len())?;
     bind_table_function_parameters(&mut statement, params)?;
     let session = build_transaction_read_session(read_ctx, write_ctx, &statement).await?;
-    let plan = create_logical_plan_from_statement(&session, statement).await?;
+    let plan = create_logical_plan_from_statement(session.context(), statement).await?;
     validate_supported_logical_plan(&plan)?;
     validate_json_predicates_in_logical_plan(&plan)?;
     validate_history_anchor_predicates_in_logical_plan(&plan)?;
     let json_predicate_params = json_predicate_params_in_logical_plan(&plan);
 
-    Ok(SqlLogicalPlan::DataFusion(SqlDataFusionLogicalPlan {
+    Ok((
+        SqlLogicalPlan::DataFusion(SqlDataFusionLogicalPlan {
+            state: std::sync::Arc::clone(session.state()),
+            plan,
+            notices: Vec::new(),
+            json_predicate_params,
+            expected_parameter_count,
+            physical_planning_cache: None,
+        }),
         session,
-        plan,
-        notices: Vec::new(),
-        json_predicate_params,
-        expected_parameter_count,
-        physical_planning_cache: None,
-    }))
+    ))
 }
 
 async fn create_logical_plan_from_statement(
@@ -1285,6 +1303,20 @@ fn validate_history_anchor_predicates_in_logical_plan(plan: &LogicalPlan) -> Res
     visit_history_anchor_plan(plan, &[]).map(|_| ())
 }
 
+/// Substitutes positional parameters into a bound read plan.
+///
+/// Mirrors `DataFrame::with_param_values`, which is exactly
+/// `LogicalPlan::with_param_values` plus a `SessionState` it does not need.
+fn bind_plan_param_values(plan: LogicalPlan, params: &[Value]) -> Result<LogicalPlan, LixError> {
+    if params.is_empty() {
+        return Ok(plan);
+    }
+    plan.with_param_values(ParamValues::List(
+        params.iter().map(scalar_value_from_lix_value).collect(),
+    ))
+    .map_err(datafusion_error_to_lix_error)
+}
+
 async fn execute_logical_plan(
     plan: SqlLogicalPlan,
     params: &[Value],
@@ -1296,7 +1328,7 @@ async fn execute_logical_plan(
         ));
     };
     let SqlDataFusionLogicalPlan {
-        session,
+        state,
         plan,
         notices,
         json_predicate_params,
@@ -1306,25 +1338,20 @@ async fn execute_logical_plan(
     debug_assert_eq!(expected_parameter_count, params.len());
     validate_json_predicate_params(&json_predicate_params, params)?;
 
-    let mut dataframe = session
-        .execute_logical_plan(plan)
-        .await
-        .map_err(datafusion_error_to_lix_error)?;
-    if !params.is_empty() {
-        dataframe = dataframe
-            .with_param_values(ParamValues::List(
-                params.iter().map(scalar_value_from_lix_value).collect(),
-            ))
-            .map_err(datafusion_error_to_lix_error)?;
-    }
+    // `SessionContext::execute_logical_plan` only branches for DDL and utility
+    // statements, both of which `validate_supported_logical_plan` already
+    // rejects, and otherwise wraps the plan in a `DataFrame` whose only purpose
+    // here is to carry a freshly deep-copied `SessionState`. Bind the
+    // parameters on the plan directly against the statement's pooled state.
+    let plan = bind_plan_param_values(plan, params)?;
 
-    let result_fields = dataframe
+    let result_fields = plan
         .schema()
         .fields()
         .iter()
         .map(|field| field.as_ref().clone())
         .collect::<Vec<_>>();
-    let batches = crate::sql2::runtime::collect_dataframe(dataframe, physical_planning_cache)
+    let batches = crate::sql2::runtime::collect_plan(&state, plan, physical_planning_cache)
         .await
         .map_err(datafusion_error_to_lix_error)?;
     // This is a benchmark-only causal ceiling probe. It keeps DataFusion's
@@ -1375,7 +1402,7 @@ async fn execute_logical_plan_stream<'session>(
         ));
     };
     let SqlDataFusionLogicalPlan {
-        session,
+        state,
         plan,
         notices,
         json_predicate_params,
@@ -1385,24 +1412,19 @@ async fn execute_logical_plan_stream<'session>(
     debug_assert_eq!(expected_parameter_count, params.len());
     validate_json_predicate_params(&json_predicate_params, params)?;
 
-    let mut dataframe = session
-        .execute_logical_plan(plan)
-        .await
-        .map_err(datafusion_error_to_lix_error)?;
-    if !params.is_empty() {
-        dataframe = dataframe
-            .with_param_values(ParamValues::List(
-                params.iter().map(scalar_value_from_lix_value).collect(),
-            ))
-            .map_err(datafusion_error_to_lix_error)?;
-    }
-    let fields = dataframe
+    // `SessionContext::execute_logical_plan` only branches for DDL and utility
+    // statements, both of which `validate_supported_logical_plan` already
+    // rejects, and otherwise wraps the plan in a `DataFrame` whose only purpose
+    // here is to carry a freshly deep-copied `SessionState`. Bind the
+    // parameters on the plan directly against the statement's pooled state.
+    let plan = bind_plan_param_values(plan, params)?;
+    let fields = plan
         .schema()
         .fields()
         .iter()
         .map(|field| field.as_ref().clone())
         .collect::<Vec<_>>();
-    let stream = crate::sql2::runtime::stream_dataframe(dataframe, physical_planning_cache)
+    let stream = crate::sql2::runtime::stream_plan(&state, plan, physical_planning_cache)
         .await
         .map_err(datafusion_error_to_lix_error)?;
     Ok(SessionReadBatchStreamResult {
@@ -1425,7 +1447,7 @@ async fn execute_logical_plan_collected_batches(
         ));
     };
     let SqlDataFusionLogicalPlan {
-        session,
+        state,
         plan,
         notices,
         json_predicate_params,
@@ -1435,24 +1457,19 @@ async fn execute_logical_plan_collected_batches(
     debug_assert_eq!(expected_parameter_count, params.len());
     validate_json_predicate_params(&json_predicate_params, params)?;
 
-    let mut dataframe = session
-        .execute_logical_plan(plan)
-        .await
-        .map_err(datafusion_error_to_lix_error)?;
-    if !params.is_empty() {
-        dataframe = dataframe
-            .with_param_values(ParamValues::List(
-                params.iter().map(scalar_value_from_lix_value).collect(),
-            ))
-            .map_err(datafusion_error_to_lix_error)?;
-    }
-    let fields = dataframe
+    // `SessionContext::execute_logical_plan` only branches for DDL and utility
+    // statements, both of which `validate_supported_logical_plan` already
+    // rejects, and otherwise wraps the plan in a `DataFrame` whose only purpose
+    // here is to carry a freshly deep-copied `SessionState`. Bind the
+    // parameters on the plan directly against the statement's pooled state.
+    let plan = bind_plan_param_values(plan, params)?;
+    let fields = plan
         .schema()
         .fields()
         .iter()
         .map(|field| field.as_ref().clone())
         .collect::<Vec<_>>();
-    let batches = crate::sql2::runtime::collect_dataframe(dataframe, physical_planning_cache)
+    let batches = crate::sql2::runtime::collect_plan(&state, plan, physical_planning_cache)
         .await
         .map_err(datafusion_error_to_lix_error)?;
     Ok(SessionReadCollectedBatchResult {

--- a/packages/lix/src/sql2/exec/mod.rs
+++ b/packages/lix/src/sql2/exec/mod.rs
@@ -77,7 +77,7 @@ pub(crate) use datafusion::{
     DataFusionLogicalPlan as SqlDataFusionLogicalPlan, SessionReadResult, SessionReadSqlResult,
     execute_read_statement_in_session_from_parsed, execute_read_statement_in_session_with_result,
     execute_transaction_read_statement_from_parsed, prepare_read_session,
-    prepare_read_session_at_head, query_result_from_batches,
+    prepare_read_session_at_head, query_result_from_batches, statement_has_table_function,
 };
 #[cfg(test)]
 pub(crate) use write::{

--- a/packages/lix/src/sql2/information_schema.rs
+++ b/packages/lix/src/sql2/information_schema.rs
@@ -30,12 +30,18 @@ const TABLE_FUNCTIONS: &str = "table_functions";
 /// between read nullability and insert-time omission/default behavior.
 pub(crate) fn register(
     session: &SessionContext,
-    public_catalog: &PublicCatalog,
+    public_catalog: Arc<PublicCatalog>,
 ) -> Result<(), LixError> {
-    let state = session.state();
+    // Borrow the live session state. `SessionState::clone` deep-copies the
+    // `String`-keyed registries for every built-in scalar, aggregate and window
+    // function; this call site only needs two config strings and the catalog
+    // list `Arc`.
+    let state_ref = session.state_ref();
+    let state = state_ref.read();
     let catalog_name = state.config_options().catalog.default_catalog.clone();
     let schema_name = state.config_options().catalog.default_schema.clone();
     let catalog_list = Arc::clone(state.catalog_list());
+    drop(state);
     let catalog = catalog_list.catalog(&catalog_name).ok_or_else(|| {
         LixError::new(
             LixError::CODE_INTERNAL_ERROR,
@@ -44,7 +50,7 @@ pub(crate) fn register(
     })?;
     let provider: Arc<dyn SchemaProvider> = Arc::new(LixInformationSchemaProvider::new(
         catalog_list,
-        public_catalog.clone(),
+        public_catalog,
         catalog_name.clone(),
         schema_name,
     ));
@@ -60,7 +66,7 @@ struct LixInformationSchemaProvider {
     // reference here would create a cycle that retains every session table
     // provider and its storage read handles.
     catalog_list: Weak<dyn CatalogProviderList>,
-    public_catalog: PublicCatalog,
+    public_catalog: Arc<PublicCatalog>,
     public_catalog_name: String,
     public_schema_name: String,
 }
@@ -68,7 +74,7 @@ struct LixInformationSchemaProvider {
 impl LixInformationSchemaProvider {
     fn new(
         catalog_list: Arc<dyn CatalogProviderList>,
-        public_catalog: PublicCatalog,
+        public_catalog: Arc<PublicCatalog>,
         public_catalog_name: String,
         public_schema_name: String,
     ) -> Self {

--- a/packages/lix/src/sql2/mod.rs
+++ b/packages/lix/src/sql2/mod.rs
@@ -96,8 +96,8 @@ pub(crate) use file_view::{
 pub(crate) use parse::parse_statement;
 pub(crate) use plan::plan_write;
 pub(crate) use planning_cache::{
-    CachedPhysicalRead, CachedReadPlan, CachedUpdateLiteralShape, PhysicalReadPlanCacheKey,
-    PooledReadSession, SqlPlanningCache,
+    CachedPhysicalRead, CachedReadPlan, CachedScanRequest, CachedUpdateLiteralShape,
+    PhysicalReadPlanCacheKey, PooledReadSession, SqlPlanningCache,
 };
 pub(crate) use providers::{
     ExactLixFileReadColumn, ExactLixFileReadSelector, FastLixFilePathWriteConflict,

--- a/packages/lix/src/sql2/mod.rs
+++ b/packages/lix/src/sql2/mod.rs
@@ -97,7 +97,7 @@ pub(crate) use parse::parse_statement;
 pub(crate) use plan::plan_write;
 pub(crate) use planning_cache::{
     CachedPhysicalRead, CachedReadPlan, CachedUpdateLiteralShape, PhysicalReadPlanCacheKey,
-    SqlPlanningCache,
+    PooledReadSession, SqlPlanningCache,
 };
 pub(crate) use providers::{
     ExactLixFileReadColumn, ExactLixFileReadSelector, FastLixFilePathWriteConflict,

--- a/packages/lix/src/sql2/planning_cache.rs
+++ b/packages/lix/src/sql2/planning_cache.rs
@@ -33,16 +33,27 @@ pub(crate) struct CachedReadPlan {
     pub(crate) expected_parameter_count: usize,
 }
 
-/// One reusable physical read template plus the optimized logical plan it was
+/// One reusable physical read template plus the leaf scan requests it was
 /// planned from.
 ///
-/// Both are stripped of snapshot-bound table providers. Keeping the optimized
-/// plan with the template is what makes a warm execution skip DataFusion's
-/// analyzer and logical optimizer entirely: the only work left is grafting the
-/// current snapshot's providers back on and re-planning the leaf scans.
+/// The template is stripped of snapshot-bound table providers, and the scan
+/// requests carry no provider at all — only the table name, projection,
+/// unnormalized filters and fetch that the optimizer settled on for this exact
+/// cache key. A warm execution therefore skips DataFusion's analyzer, logical
+/// optimizer and physical planner entirely: it resolves each table against the
+/// current session, replans just that leaf, and grafts it into the template.
 pub(crate) struct CachedPhysicalRead {
-    pub(crate) optimized: LogicalPlan,
+    pub(crate) scans: Vec<CachedScanRequest>,
     pub(crate) template: Arc<dyn ExecutionPlan>,
+}
+
+/// One leaf `TableScan` of a cached optimized plan, reduced to the arguments
+/// `TableProvider::scan_with_args` needs.
+pub(crate) struct CachedScanRequest {
+    pub(crate) table: datafusion::common::TableReference,
+    pub(crate) projection: Option<Vec<usize>>,
+    pub(crate) filters: Vec<datafusion::logical_expr::Expr>,
+    pub(crate) fetch: Option<usize>,
 }
 
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
@@ -94,13 +105,6 @@ pub(crate) struct CachedUpdateLiteralShape {
     suffix_start: usize,
 }
 
-/// Bounded, engine-owned cache for snapshot-independent SQL planning templates.
-///
-/// Parsed statements depend only on the exact SQL text. Bound write plans also
-/// depend on the visible catalog and active branch because binding resolves
-/// public surfaces and injects branch scope. Cached DataFusion read plans are
-/// stripped of snapshot-bound providers and rebound to the current read
-/// session before execution.
 /// One DataFusion session borrowed from the engine's pool for the duration of
 /// one statement.
 ///
@@ -156,6 +160,13 @@ impl PooledReadSession {
     }
 }
 
+/// Bounded, engine-owned cache for snapshot-independent SQL planning templates.
+///
+/// Parsed statements depend only on the exact SQL text. Bound write plans also
+/// depend on the visible catalog and active branch because binding resolves
+/// public surfaces and injects branch scope. Cached DataFusion read plans are
+/// stripped of snapshot-bound providers and rebound to the current read
+/// session before execution.
 pub(crate) struct SqlPlanningCache<CatalogKey> {
     datafusion_state: SessionState,
     read_sessions: Mutex<Vec<PooledReadSession>>,

--- a/packages/lix/src/sql2/planning_cache.rs
+++ b/packages/lix/src/sql2/planning_cache.rs
@@ -11,7 +11,6 @@ use datafusion::catalog::{
     MemorySchemaProvider,
 };
 use datafusion::execution::session_state::SessionState;
-use datafusion::execution::session_state::SessionStateBuilder;
 use datafusion::logical_expr::LogicalPlan;
 use datafusion::physical_plan::ExecutionPlan;
 use datafusion::prelude::SessionContext;
@@ -220,10 +219,7 @@ where
             .register_schema("public", Arc::new(MemorySchemaProvider::new()))
             .expect("fresh DataFusion catalog accepts the public schema");
         catalogs.register_catalog("datafusion".to_string(), catalog);
-        let state = SessionStateBuilder::new_from_existing(self.datafusion_state.clone())
-            .with_catalog_list(catalogs)
-            .build();
-        super::session::attach_execution_slots(SessionContext::new_with_state(state))
+        super::session::sql_session_from_template(self.datafusion_state.clone(), Some(catalogs))
     }
 
     pub(crate) fn datafusion_read_session(&self) -> PooledReadSession {

--- a/packages/lix/src/sql2/planning_cache.rs
+++ b/packages/lix/src/sql2/planning_cache.rs
@@ -101,9 +101,64 @@ pub(crate) struct CachedUpdateLiteralShape {
 /// public surfaces and injects branch scope. Cached DataFusion read plans are
 /// stripped of snapshot-bound providers and rebound to the current read
 /// session before execution.
+/// One DataFusion session borrowed from the engine's pool for the duration of
+/// one statement.
+///
+/// The `SessionState` travels with the session instead of being cloned out of
+/// it per statement. `SessionState::clone` deep-copies the `String`-keyed
+/// registries for every built-in scalar, aggregate, window and table function;
+/// with the execution UDFs registered once at session construction those
+/// registries no longer change, so the pooled copy stays authoritative for the
+/// lifetime of the session.
+pub(crate) struct PooledReadSession {
+    context: SessionContext,
+    state: Arc<SessionState>,
+}
+
+impl PooledReadSession {
+    fn new(context: SessionContext) -> Self {
+        let state = Arc::new(context.state());
+        Self { context, state }
+    }
+
+    /// A session that is not owned by any pool, used by lightweight contexts
+    /// that build one DataFusion session per statement.
+    pub(crate) fn standalone(context: SessionContext) -> Self {
+        Self::new(context)
+    }
+
+    pub(crate) fn context(&self) -> &SessionContext {
+        &self.context
+    }
+
+    /// The session state for this statement.
+    ///
+    /// Table registration flows through the shared catalog list, so this stays
+    /// current for provider resolution. Per-statement table-valued functions
+    /// are registered on the live session and are resolved there during logical
+    /// planning; this copy is used for physical planning and execution, which
+    /// never resolves a function by name.
+    pub(crate) fn state(&self) -> &Arc<SessionState> {
+        &self.state
+    }
+
+    /// Restamps `query_execution_start_time` so `now()` and friends observe the
+    /// statement's own start rather than the session's construction time.
+    fn begin_statement(&mut self) {
+        match Arc::get_mut(&mut self.state) {
+            Some(state) => state.mark_start_execution(),
+            None => {
+                let mut state = self.state.as_ref().clone();
+                state.mark_start_execution();
+                self.state = Arc::new(state);
+            }
+        }
+    }
+}
+
 pub(crate) struct SqlPlanningCache<CatalogKey> {
     datafusion_state: SessionState,
-    read_sessions: Mutex<Vec<SessionContext>>,
+    read_sessions: Mutex<Vec<PooledReadSession>>,
     parsed_statements: Mutex<LruCache<Arc<str>, Arc<DataFusionStatement>>>,
     public_catalogs: Mutex<LruCache<CatalogKey, Arc<PublicCatalog>>>,
     write_plans: Mutex<LruCache<WritePlanCacheKey<CatalogKey>, Arc<LogicalWritePlan>>>,
@@ -157,39 +212,38 @@ where
         let state = SessionStateBuilder::new_from_existing(self.datafusion_state.clone())
             .with_catalog_list(catalogs)
             .build();
-        SessionContext::new_with_state(state)
+        super::session::attach_execution_slots(SessionContext::new_with_state(state))
     }
 
-    pub(crate) fn datafusion_read_session(&self) -> SessionContext {
-        lock_or_recover(&self.read_sessions)
+    pub(crate) fn datafusion_read_session(&self) -> PooledReadSession {
+        let mut session = lock_or_recover(&self.read_sessions)
             .pop()
-            .unwrap_or_else(|| self.datafusion_session())
+            .unwrap_or_else(|| PooledReadSession::new(self.datafusion_session()));
+        session.begin_statement();
+        session
     }
 
-    pub(crate) fn recycle_datafusion_read_session(&self, session: SessionContext) {
-        if let Some(catalog) = session.catalog("datafusion")
+    pub(crate) fn recycle_datafusion_read_session(&self, session: PooledReadSession) {
+        if let Some(catalog) = session.context.catalog("datafusion")
             && let Some(public) = catalog.schema("public")
         {
             for table in public.table_names() {
-                let _ = session.deregister_table(datafusion::common::TableReference::full(
-                    "datafusion",
-                    "public",
-                    table,
-                ));
+                let _ = session
+                    .context
+                    .deregister_table(datafusion::common::TableReference::full(
+                        "datafusion",
+                        "public",
+                        table,
+                    ));
             }
         }
-        // Borrow the live session state instead of cloning it. `SessionState`
-        // owns `String`-keyed registries for every built-in scalar, aggregate
-        // and window function, so a clone here would deep-copy hundreds of
-        // keys just to diff two name sets.
-        let state_ref = session.state_ref();
+        // Only table-valued functions are registered per statement; the five
+        // execution scalar functions are installed once at session construction
+        // and read their per-statement values from the session's slots. Borrow
+        // the live state rather than cloning it — a clone would deep-copy the
+        // registries for every built-in function just to diff two name sets.
+        let state_ref = session.context.state_ref();
         let state = state_ref.read();
-        let execution_scalar_functions = state
-            .scalar_functions()
-            .keys()
-            .filter(|name| !self.datafusion_state.scalar_functions().contains_key(*name))
-            .cloned()
-            .collect::<Vec<_>>();
         let execution_table_functions = state
             .table_functions()
             .keys()
@@ -198,11 +252,8 @@ where
             .collect::<Vec<_>>();
         drop(state);
         drop(state_ref);
-        for name in execution_scalar_functions {
-            session.deregister_udf(&name);
-        }
         for name in execution_table_functions {
-            session.deregister_udtf(&name);
+            session.context.deregister_udtf(&name);
         }
 
         let mut sessions = lock_or_recover(&self.read_sessions);
@@ -1106,8 +1157,9 @@ mod tests {
     fn recycled_read_sessions_drop_snapshot_bound_tables() {
         let cache = test_cache(2);
         let session = cache.datafusion_read_session();
-        let session_id = session.session_id();
+        let session_id = session.context().session_id();
         session
+            .context()
             .register_table(
                 "snapshot_table",
                 Arc::new(EmptyTable::new(Arc::new(Schema::empty()))),
@@ -1116,8 +1168,8 @@ mod tests {
 
         cache.recycle_datafusion_read_session(session);
         let recycled = cache.datafusion_read_session();
-        assert_eq!(recycled.session_id(), session_id);
-        assert!(!recycled.table_exist("snapshot_table").unwrap());
+        assert_eq!(recycled.context().session_id(), session_id);
+        assert!(!recycled.context().table_exist("snapshot_table").unwrap());
     }
 
     #[test]

--- a/packages/lix/src/sql2/providers/mod.rs
+++ b/packages/lix/src/sql2/providers/mod.rs
@@ -74,23 +74,40 @@ where
     if selection.is_empty() {
         return Ok(());
     }
-    let dynamic_catalog;
     let catalog = if selection.requires_visible_schemas() {
-        dynamic_catalog = ctx.public_catalog().await?;
-        dynamic_catalog.as_ref()
+        ctx.public_catalog().await?
     } else {
-        PublicCatalog::fixed_system()
+        Arc::clone(PublicCatalog::fixed_system_shared())
     };
     register_read_from_catalog(
         session,
         ctx,
         branch_ref,
         active_branch_commit_id,
-        catalog,
+        catalog.as_ref(),
         ReadProviderScope::All,
         selection,
     )
     .await?;
+    register_information_schema(session, selection, catalog)
+}
+
+/// Installs the `information_schema` views only for statements that can reach
+/// them.
+///
+/// `read_provider_selection` widens to [`ProviderSelection::All`] for every
+/// `information_schema`-qualified reference and every `SHOW` form, so a narrowed
+/// selection provably never resolves an information-schema table. Registering
+/// the schema anyway cost one catalog write lock and one `SchemaProvider`
+/// allocation on every ordinary statement.
+fn register_information_schema(
+    session: &SessionContext,
+    selection: &ProviderSelection,
+    catalog: Arc<PublicCatalog>,
+) -> Result<(), LixError> {
+    if !matches!(selection, ProviderSelection::All) {
+        return Ok(());
+    }
     crate::sql2::information_schema::register(session, catalog)
 }
 
@@ -144,15 +161,13 @@ impl ProviderSelection {
 }
 
 pub(crate) fn read_provider_selection(
-    session: &SessionContext,
+    state: &datafusion::execution::session_state::SessionState,
     statements: &[datafusion::sql::parser::Statement],
 ) -> ProviderSelection {
     let mut names = BTreeSet::new();
-    // Resolving references only reads the SQL parser configuration. Borrowing
-    // the session state avoids deep-copying its `String`-keyed function
-    // registries once per statement.
-    let state_ref = session.state_ref();
-    let state = state_ref.read();
+    // Resolving references only reads the SQL parser configuration, so the
+    // statement's pooled session state is used directly instead of cloning the
+    // live one.
     for statement in statements {
         if statement_requires_all_providers(statement) {
             return ProviderSelection::All;
@@ -490,7 +505,7 @@ pub(crate) async fn register_write(
     let catalog = write_ctx.public_catalog()?;
     register_write_from_catalog(session, write_ctx, branch_ref, options, &catalog, selection)
         .await?;
-    crate::sql2::information_schema::register(session, &catalog)
+    register_information_schema(session, selection, catalog)
 }
 
 pub(crate) async fn register_transaction<C>(
@@ -529,7 +544,7 @@ where
         selection,
     )
     .await?;
-    crate::sql2::information_schema::register(session, &catalog)
+    register_information_schema(session, selection, catalog)
 }
 
 async fn register_write_from_catalog(
@@ -677,7 +692,7 @@ mod tests {
             .iter()
             .map(|sql| crate::sql2::parse_statement(sql).expect("SQL should parse"))
             .collect::<Vec<_>>();
-        read_provider_selection(&SessionContext::new(), &statements)
+        read_provider_selection(&SessionContext::new().state(), &statements)
     }
 
     fn selected_names(names: &[&str]) -> ProviderSelection {

--- a/packages/lix/src/sql2/providers/spec.rs
+++ b/packages/lix/src/sql2/providers/spec.rs
@@ -1624,14 +1624,15 @@ mod scan_source_tests {
         session
             .register_table("counted", Arc::new(SpecTableProvider::new(spec)))
             .expect("counted test table should register");
-        let dataframe = session
-            .sql(
+        let plan = session
+            .state()
+            .create_logical_plan(
                 "WITH reused AS (SELECT value FROM counted) \
                  SELECT value FROM reused UNION ALL SELECT value FROM reused",
             )
             .await
             .expect("CTE should plan");
-        let batches = crate::sql2::runtime::collect_dataframe(dataframe, None)
+        let batches = crate::sql2::runtime::collect_plan(&session.state(), plan, None)
             .await
             .expect("CTE should execute");
         let values = batches

--- a/packages/lix/src/sql2/runtime.rs
+++ b/packages/lix/src/sql2/runtime.rs
@@ -5,11 +5,11 @@ use std::sync::Arc;
 #[cfg(feature = "storage-benches")]
 use std::time::Instant;
 
+use datafusion::arrow::datatypes::SchemaRef;
 use datafusion::arrow::record_batch::RecordBatch;
 use datafusion::catalog::ScanArgs;
 use datafusion::common::tree_node::{Transformed, TreeNode};
 use datafusion::common::{DataFusionError, TableReference, internal_err};
-use datafusion::dataframe::DataFrame;
 use datafusion::datasource::empty::EmptyTable;
 use datafusion::datasource::{provider_as_source, source_as_provider};
 use datafusion::error::Result;
@@ -19,7 +19,8 @@ use datafusion::execution::memory_pool::{MemoryConsumer, MemoryReservation};
 use datafusion::logical_expr::{LogicalPlan, TableSource};
 use datafusion::logical_expr::expr_rewriter::unnormalize_cols;
 use datafusion::physical_plan::coalesce_partitions::CoalescePartitionsExec;
-use datafusion::physical_plan::execution_plan::{CardinalityEffect, EmissionType};
+use datafusion::physical_expr::{LexOrdering, Partitioning};
+use datafusion::physical_plan::execution_plan::{Boundedness, CardinalityEffect, EmissionType};
 use datafusion::physical_plan::joins::HashJoinExec;
 use datafusion::physical_plan::limit::LimitStream;
 use datafusion::physical_plan::sorts::sort::SortExec;
@@ -42,16 +43,15 @@ type PhysicalPlanningCache = (
     PhysicalReadPlanCacheKey<CatalogFingerprint>,
 );
 
-pub(crate) async fn collect_dataframe(
-    dataframe: DataFrame,
+pub(crate) async fn collect_plan(
+    state: &SessionState,
+    logical_plan: LogicalPlan,
     physical_planning_cache: Option<PhysicalPlanningCache>,
 ) -> Result<Vec<RecordBatch>> {
-    let (state, logical_plan) = dataframe.into_parts();
-    let task_ctx = execution_task_context(&state);
+    let task_ctx = execution_task_context(state);
     #[cfg(feature = "storage-benches")]
     let started = crate::sql_profile::is_active().then(Instant::now);
-    let plan =
-        create_or_rebind_physical_plan(&state, logical_plan, physical_planning_cache).await?;
+    let plan = create_or_rebind_physical_plan(state, logical_plan, physical_planning_cache).await?;
     let plan = adapt_runtime_plan(plan)?;
     #[cfg(feature = "storage-benches")]
     if let Some(started) = started {
@@ -78,16 +78,15 @@ pub(crate) async fn collect_dataframe(
 /// stop polling it early; dropping the stream then drops the underlying scan
 /// futures as well.
 #[cfg(feature = "storage-benches")]
-pub(crate) async fn stream_dataframe(
-    dataframe: DataFrame,
+pub(crate) async fn stream_plan(
+    state: &SessionState,
+    logical_plan: LogicalPlan,
     physical_planning_cache: Option<PhysicalPlanningCache>,
 ) -> Result<SendableRecordBatchStream> {
-    let (state, logical_plan) = dataframe.into_parts();
-    let task_ctx = execution_task_context(&state);
+    let task_ctx = execution_task_context(state);
     #[cfg(feature = "storage-benches")]
     let started = crate::sql_profile::is_active().then(Instant::now);
-    let plan =
-        create_or_rebind_physical_plan(&state, logical_plan, physical_planning_cache).await?;
+    let plan = create_or_rebind_physical_plan(state, logical_plan, physical_planning_cache).await?;
     let plan = adapt_runtime_plan(plan)?;
     #[cfg(feature = "storage-benches")]
     if let Some(started) = started {
@@ -311,7 +310,9 @@ fn rebind_physical_plan_template_inner(
 ) -> Option<Arc<dyn ExecutionPlan>> {
     if let Some(detached) = plan.as_any().downcast_ref::<DetachedSpecScanExec>() {
         let replacement = replacements.get_mut(&detached.key)?.pop_front()?;
-        return (physical_plan_fingerprint(replacement.as_ref()) == detached.fingerprint)
+        return detached
+            .fingerprint
+            .matches(replacement.as_ref())
             .then_some(replacement);
     }
     let children = plan
@@ -356,17 +357,53 @@ fn rebuild_template_node(
     plan.with_new_children(children).ok()
 }
 
-fn physical_plan_fingerprint(plan: &dyn ExecutionPlan) -> Arc<str> {
-    Arc::from(format!(
-        "schema={:?};properties={:?}",
-        plan.schema(),
-        plan.properties()
-    ))
+/// The structural identity a replacement scan must reproduce before a detached
+/// template leaf accepts it.
+///
+/// This is compared once per leaf on every warm execution, so it is kept as
+/// direct field equality. Formatting `Debug` for the schema and the full
+/// `PlanProperties` — including `EquivalenceProperties` — allocated several
+/// kilobytes of string per scan per query for the same decision.
+///
+/// `Partitioning` deliberately compares by discriminant and partition count:
+/// its `PartialEq` returns `false` for two identical `UnknownPartitioning`
+/// values, which is the variant every `SpecScanExec` reports.
+struct ScanFingerprint {
+    schema: SchemaRef,
+    partitioning: std::mem::Discriminant<Partitioning>,
+    partition_count: usize,
+    output_ordering: Option<LexOrdering>,
+    emission_type: EmissionType,
+    boundedness: Boundedness,
+}
+
+impl ScanFingerprint {
+    fn new(plan: &dyn ExecutionPlan) -> Self {
+        let properties = plan.properties();
+        Self {
+            schema: plan.schema(),
+            partitioning: std::mem::discriminant(&properties.partitioning),
+            partition_count: properties.partitioning.partition_count(),
+            output_ordering: properties.output_ordering().cloned(),
+            emission_type: properties.emission_type,
+            boundedness: properties.boundedness,
+        }
+    }
+
+    fn matches(&self, plan: &dyn ExecutionPlan) -> bool {
+        let properties = plan.properties();
+        self.partition_count == properties.partitioning.partition_count()
+            && self.partitioning == std::mem::discriminant(&properties.partitioning)
+            && self.emission_type == properties.emission_type
+            && self.boundedness == properties.boundedness
+            && self.output_ordering.as_ref() == properties.output_ordering()
+            && self.schema == plan.schema()
+    }
 }
 
 struct DetachedSpecScanExec {
     key: PhysicalScanKey,
-    fingerprint: Arc<str>,
+    fingerprint: ScanFingerprint,
     properties: Arc<PlanProperties>,
 }
 
@@ -374,7 +411,7 @@ impl DetachedSpecScanExec {
     fn new(scan: &SpecScanExec) -> Self {
         Self {
             key: scan.physical_cache_key().clone(),
-            fingerprint: physical_plan_fingerprint(scan),
+            fingerprint: ScanFingerprint::new(scan),
             properties: Arc::clone(scan.properties()),
         }
     }

--- a/packages/lix/src/sql2/runtime.rs
+++ b/packages/lix/src/sql2/runtime.rs
@@ -8,23 +8,20 @@ use std::time::Instant;
 use datafusion::arrow::datatypes::SchemaRef;
 use datafusion::arrow::record_batch::RecordBatch;
 use datafusion::catalog::ScanArgs;
-use datafusion::common::tree_node::{Transformed, TreeNode};
-use datafusion::common::{DataFusionError, TableReference, internal_err};
-use datafusion::datasource::empty::EmptyTable;
-use datafusion::datasource::{provider_as_source, source_as_provider};
+use datafusion::common::{DataFusionError, internal_err};
 use datafusion::error::Result;
 use datafusion::execution::SessionState;
 use datafusion::execution::TaskContext;
 use datafusion::execution::memory_pool::{MemoryConsumer, MemoryReservation};
-use datafusion::logical_expr::{LogicalPlan, TableSource};
+use datafusion::logical_expr::LogicalPlan;
 use datafusion::logical_expr::expr_rewriter::unnormalize_cols;
-use datafusion::physical_plan::coalesce_partitions::CoalescePartitionsExec;
 use datafusion::physical_expr::{LexOrdering, Partitioning};
+use datafusion::physical_plan::coalesce_partitions::CoalescePartitionsExec;
 use datafusion::physical_plan::execution_plan::{Boundedness, CardinalityEffect, EmissionType};
 use datafusion::physical_plan::joins::HashJoinExec;
 use datafusion::physical_plan::limit::LimitStream;
-use datafusion::physical_plan::sorts::sort::SortExec;
 use datafusion::physical_plan::metrics::{BaselineMetrics, ExecutionPlanMetricsSet, MetricsSet};
+use datafusion::physical_plan::sorts::sort::SortExec;
 use datafusion::physical_plan::stream::RecordBatchStreamAdapter;
 use datafusion::physical_plan::{
     DisplayAs, DisplayFormatType, ExecutionPlan, ExecutionPlanProperties, PlanProperties,
@@ -34,7 +31,9 @@ use futures_util::{StreamExt, TryStreamExt, stream};
 use tokio::sync::OnceCell;
 
 use crate::catalog::CatalogFingerprint;
-use crate::sql2::{CachedPhysicalRead, PhysicalReadPlanCacheKey, SqlPlanningCache};
+use crate::sql2::{
+    CachedPhysicalRead, CachedScanRequest, PhysicalReadPlanCacheKey, SqlPlanningCache,
+};
 
 use super::providers::{PhysicalScanKey, SpecScanExec, StatementScanKey};
 
@@ -131,19 +130,23 @@ async fn create_or_rebind_physical_plan(
             .query_planner()
             .create_physical_plan(&optimized, state)
             .await?;
-        if let Some(template) = detach_physical_plan_template(Arc::clone(&plan))
-            && let Some(optimized) = detach_logical_plan_sources(optimized)
-        {
-            cache.remember_physical_read_plan(key, CachedPhysicalRead { optimized, template });
+        if let Some(template) = detach_physical_plan_template(Arc::clone(&plan)) {
+            cache.remember_physical_read_plan(
+                key,
+                CachedPhysicalRead {
+                    scans: cached_scan_requests(&optimized),
+                    template,
+                },
+            );
         }
         return Ok(plan);
     };
 
-    // Warm path. The optimized plan is reused verbatim, so DataFusion's
-    // analyzer and logical optimizer never run again for this statement shape;
-    // only the snapshot-bound table sources are grafted back on.
-    if let Some(optimized) = rebind_logical_plan_sources(&cached.optimized, &logical_plan)
-        && let Some(replacements) = plan_current_spec_scans(&optimized, state).await?
+    // Warm path. Neither DataFusion's analyzer, logical optimizer nor physical
+    // planner runs again for this statement shape: each cached leaf scan is
+    // replanned against the current snapshot's provider and grafted into the
+    // template.
+    if let Some(replacements) = plan_cached_spec_scans(&cached.scans, state).await?
         && let Some(plan) =
             rebind_physical_plan_template(Arc::clone(&cached.template), replacements)
     {
@@ -161,91 +164,53 @@ async fn create_or_rebind_physical_plan(
         .await
 }
 
-/// Replaces every table source with an empty stand-in of the same schema.
+/// Reduces an optimized plan's leaf scans to provider-free scan requests.
 ///
-/// Cached plans must not retain a provider bound to the storage snapshot that
-/// planned them.
-fn detach_logical_plan_sources(plan: LogicalPlan) -> Option<LogicalPlan> {
-    plan.transform_up(|node| {
-        let LogicalPlan::TableScan(mut scan) = node else {
-            return Ok(Transformed::no(node));
-        };
-        scan.source = provider_as_source(Arc::new(EmptyTable::new(scan.source.schema())));
-        Ok(Transformed::yes(LogicalPlan::TableScan(scan)))
-    })
-    .map(|transformed| transformed.data)
-    .ok()
+/// A cache entry must never retain a table provider bound to the storage
+/// snapshot that planned it. Keeping only the resolved table name, projection,
+/// filters and fetch makes that structural rather than a discipline: there is
+/// no provider in the entry to go stale, and no logical plan to clone on the
+/// warm path.
+fn cached_scan_requests(plan: &LogicalPlan) -> Vec<CachedScanRequest> {
+    fn collect(plan: &LogicalPlan, scans: &mut Vec<CachedScanRequest>) {
+        if let LogicalPlan::TableScan(scan) = plan {
+            scans.push(CachedScanRequest {
+                table: scan.table_name.clone(),
+                projection: scan.projection.clone(),
+                filters: unnormalize_cols(scan.filters.clone()),
+                fetch: scan.fetch,
+            });
+        }
+        for input in plan.inputs() {
+            collect(input, scans);
+        }
+    }
+
+    let mut scans = Vec::new();
+    collect(plan, &mut scans);
+    scans
 }
 
-/// Grafts the current snapshot's table sources onto a cached optimized plan.
+/// Replans each cached leaf scan against the current snapshot's provider.
 ///
-/// Sources are taken from the freshly bound plan for the same statement, which
-/// already resolved them against the live read session. A cached plan that
-/// references a table the current plan does not provide is treated as stale.
-fn rebind_logical_plan_sources(
-    cached: &LogicalPlan,
-    current: &LogicalPlan,
-) -> Option<LogicalPlan> {
-    let mut sources: HashMap<TableReference, Arc<dyn TableSource>> = HashMap::new();
-    collect_logical_table_sources(current, &mut sources);
-    cached
-        .clone()
-        .transform_up(|node| {
-            let LogicalPlan::TableScan(mut scan) = node else {
-                return Ok(Transformed::no(node));
-            };
-            let Some(source) = sources.get(&scan.table_name) else {
-                return internal_err!("cached SQL plan provider is unavailable");
-            };
-            scan.source = Arc::clone(source);
-            Ok(Transformed::yes(LogicalPlan::TableScan(scan)))
-        })
-        .map(|transformed| transformed.data)
-        .ok()
-}
-
-fn collect_logical_table_sources(
-    plan: &LogicalPlan,
-    sources: &mut HashMap<TableReference, Arc<dyn TableSource>>,
-) {
-    if let LogicalPlan::TableScan(scan) = plan {
-        sources
-            .entry(scan.table_name.clone())
-            .or_insert_with(|| Arc::clone(&scan.source));
-    }
-    for input in plan.inputs() {
-        collect_logical_table_sources(input, sources);
-    }
-}
-
-fn collect_logical_table_scans(
-    plan: &LogicalPlan,
-    scans: &mut Vec<datafusion::logical_expr::TableScan>,
-) {
-    if let LogicalPlan::TableScan(scan) = plan {
-        scans.push(scan.clone());
-    }
-    for input in plan.inputs() {
-        collect_logical_table_scans(input, scans);
-    }
-}
-
-async fn plan_current_spec_scans(
-    logical_plan: &LogicalPlan,
+/// Declining (returning `None`) is always safe: the caller evicts the entry and
+/// falls back to the ordinary DataFusion planner.
+async fn plan_cached_spec_scans(
+    scans: &[CachedScanRequest],
     state: &SessionState,
 ) -> Result<Option<HashMap<PhysicalScanKey, VecDeque<Arc<dyn ExecutionPlan>>>>> {
-    let mut logical_scans = Vec::new();
-    collect_logical_table_scans(logical_plan, &mut logical_scans);
     let mut replacements: HashMap<PhysicalScanKey, VecDeque<Arc<dyn ExecutionPlan>>> =
         HashMap::new();
-    for scan in logical_scans {
-        let Ok(provider) = source_as_provider(&scan.source) else {
+    for scan in scans {
+        let Ok(schema) = state.schema_for_ref(scan.table.clone()) else {
             return Ok(None);
         };
-        let filters = unnormalize_cols(scan.filters);
+        let Some(provider) = schema.table(scan.table.table()).await? else {
+            return Ok(None);
+        };
         let args = ScanArgs::default()
             .with_projection(scan.projection.as_deref())
-            .with_filters(Some(&filters))
+            .with_filters(Some(&scan.filters))
             .with_limit(scan.fetch);
         let result = provider.scan_with_args(state, args).await?;
         let plan = Arc::clone(result.plan());
@@ -268,8 +233,13 @@ async fn plan_current_spec_scans(
 /// alive, so it is rejected rather than rebuilt.
 fn template_operator_is_reusable(plan: &dyn ExecutionPlan) -> bool {
     match plan.name() {
-        "ProjectionExec" | "HashJoinExec" | "FilterExec" | "CooperativeExec"
-        | "CoalesceBatchesExec" | "CoalescePartitionsExec" | "SortPreservingMergeExec" => true,
+        "ProjectionExec"
+        | "HashJoinExec"
+        | "FilterExec"
+        | "CooperativeExec"
+        | "CoalesceBatchesExec"
+        | "CoalescePartitionsExec"
+        | "SortPreservingMergeExec" => true,
         "SortExec" => plan
             .as_any()
             .downcast_ref::<SortExec>()

--- a/packages/lix/src/sql2/session.rs
+++ b/packages/lix/src/sql2/session.rs
@@ -1,4 +1,5 @@
-use datafusion::execution::session_state::SessionStateBuilder;
+use datafusion::catalog::CatalogProviderList;
+use datafusion::execution::session_state::{SessionState, SessionStateBuilder};
 use datafusion::prelude::{SessionConfig, SessionContext};
 use datafusion::sql::parser::Statement as DataFusionStatement;
 use std::collections::BTreeSet;
@@ -237,28 +238,32 @@ pub(crate) fn new_sql_session_context() -> SessionContext {
         .build();
     let session = SessionContext::new_with_state(state);
     register_static_sql2_functions(&session);
-    attach_execution_slots(session)
+    sql_session_from_template(session.state(), None)
 }
 
-/// Gives a session its own execution-function slots and registers the five
-/// execution UDFs against them.
+/// Builds a Lix SQL session from a template state, gives it its own
+/// execution-function slots, and registers the five execution UDFs against them.
 ///
 /// Every Lix SQL session goes through here exactly once. Doing it at session
 /// construction rather than per statement is what lets a pooled session keep a
 /// stable function registry: nothing mutates `SessionState`'s scalar-function
 /// map after this point.
-pub(crate) fn attach_execution_slots(session: SessionContext) -> SessionContext {
+///
+/// The slots are installed into the config *before* the state is built, so this
+/// costs one `SessionState` construction rather than one per configuration step.
+/// Write sessions are not pooled — they are built per statement — so an extra
+/// registry deep copy here would land on every write.
+pub(crate) fn sql_session_from_template(
+    template: SessionState,
+    catalog_list: Option<Arc<dyn CatalogProviderList>>,
+) -> SessionContext {
     let slots = Arc::new(ExecutionSlots::default());
-    let config = session
-        .state_ref()
-        .read()
-        .config()
-        .clone()
-        .with_extension(Arc::clone(&slots));
-    let state = SessionStateBuilder::new_from_existing(session.state())
-        .with_config(config)
-        .build();
-    let session = SessionContext::new_with_state(state);
+    let config = template.config().clone().with_extension(Arc::clone(&slots));
+    let mut builder = SessionStateBuilder::new_from_existing(template).with_config(config);
+    if let Some(catalog_list) = catalog_list {
+        builder = builder.with_catalog_list(catalog_list);
+    }
+    let session = SessionContext::new_with_state(builder.build());
     register_execution_sql2_functions(&session, slots);
     session
 }

--- a/packages/lix/src/sql2/session.rs
+++ b/packages/lix/src/sql2/session.rs
@@ -9,14 +9,19 @@ use crate::LixError;
 use crate::branch::{BranchHead, BranchRefReader};
 
 use super::branch_ref::CachingBranchRefReader;
+use super::planning_cache::PooledReadSession;
 use super::providers;
-use super::udfs::{register_execution_sql2_functions, register_static_sql2_functions};
+use super::udfs::{
+    ExecutionSlots, bind_execution_sql2_functions, register_execution_sql2_functions,
+    register_static_sql2_functions,
+};
+use super::exec::statement_has_table_function;
 use super::{SqlExecutionContext, SqlWriteContext, SqlWriteExecutionContext};
 
 pub(crate) async fn build_read_session<C>(
     ctx: &C,
     statements: &[DataFusionStatement],
-) -> Result<SessionContext, LixError>
+) -> Result<PooledReadSession, LixError>
 where
     C: SqlExecutionContext + ?Sized,
 {
@@ -27,7 +32,7 @@ pub(crate) async fn build_read_session_at_head<C>(
     ctx: &C,
     active_head: BranchHead,
     statements: &[DataFusionStatement],
-) -> Result<SessionContext, LixError>
+) -> Result<PooledReadSession, LixError>
 where
     C: SqlExecutionContext + ?Sized,
 {
@@ -38,11 +43,12 @@ async fn build_read_session_with_active_head<C>(
     ctx: &C,
     active_head: Option<BranchHead>,
     statements: &[DataFusionStatement],
-) -> Result<SessionContext, LixError>
+) -> Result<PooledReadSession, LixError>
 where
     C: SqlExecutionContext + ?Sized,
 {
-    let session = ctx.datafusion_read_session();
+    let pooled = ctx.datafusion_read_session();
+    let session = pooled.context();
     let branch_ref: Arc<dyn BranchRefReader> = match active_head.as_ref() {
         Some(head) => {
             if head.branch_id != ctx.active_branch_id() {
@@ -65,17 +71,22 @@ where
             .await?
             .map(|head| head.commit_id.to_string()),
     };
-    register_execution_sql2_functions(
-        &session,
+    bind_execution_sql2_functions(
+        session,
         ctx.functions(),
-        ctx.active_account_id().to_string(),
-        Some(ctx.active_branch_id().to_string()),
-        active_branch_commit_id.clone(),
+        ctx.active_account_id(),
+        Some(ctx.active_branch_id()),
+        active_branch_commit_id.as_deref(),
     );
-    providers::register_diff_function(&session, ctx.changelog_query_source());
-    let provider_selection = providers::read_provider_selection(&session, statements);
+    // `lix_diff` is a table-valued function, so only a statement that actually
+    // calls one can reach it. Registering it unconditionally took the session
+    // write lock on every read.
+    if statements.iter().any(statement_has_table_function) {
+        providers::register_diff_function(session, ctx.changelog_query_source());
+    }
+    let provider_selection = providers::read_provider_selection(pooled.state(), statements);
     providers::register_read(
-        &session,
+        session,
         ctx,
         branch_ref,
         active_branch_commit_id,
@@ -83,40 +94,43 @@ where
     )
     .await?;
 
-    Ok(session)
+    Ok(pooled)
 }
 
 pub(crate) async fn build_transaction_read_session<C>(
     read_ctx: &C,
     write_ctx: &mut dyn SqlWriteExecutionContext,
     statement: &DataFusionStatement,
-) -> Result<SessionContext, LixError>
+) -> Result<PooledReadSession, LixError>
 where
     C: SqlExecutionContext + ?Sized,
 {
-    let session = read_ctx.datafusion_read_session();
+    let pooled = read_ctx.datafusion_read_session();
+    let session = pooled.context();
     let read_branch_ref: Arc<dyn BranchRefReader> =
         Arc::new(CachingBranchRefReader::new(read_ctx.branch_ref()));
     let active_branch_commit_id = read_branch_ref
         .load_head(read_ctx.active_branch_id())
         .await?
         .map(|head| head.commit_id.to_string());
-    register_execution_sql2_functions(
-        &session,
+    bind_execution_sql2_functions(
+        session,
         read_ctx.functions(),
-        read_ctx.active_account_id().to_string(),
-        Some(read_ctx.active_branch_id().to_string()),
-        active_branch_commit_id.clone(),
+        read_ctx.active_account_id(),
+        Some(read_ctx.active_branch_id()),
+        active_branch_commit_id.as_deref(),
     );
-    providers::register_diff_function(&session, read_ctx.changelog_query_source());
+    if statement_has_table_function(statement) {
+        providers::register_diff_function(session, read_ctx.changelog_query_source());
+    }
     let write_ctx = SqlWriteContext::new(write_ctx);
     let write_branch_ref: Arc<dyn BranchRefReader> = Arc::new(CachingBranchRefReader::new(
         Arc::new(super::WriteContextBranchRefReader::new(write_ctx.clone())),
     ));
     let provider_selection =
-        providers::read_provider_selection(&session, std::slice::from_ref(statement));
+        providers::read_provider_selection(pooled.state(), std::slice::from_ref(statement));
     providers::register_transaction(
-        &session,
+        session,
         read_ctx,
         read_branch_ref,
         active_branch_commit_id,
@@ -126,7 +140,7 @@ where
         &provider_selection,
     )
     .await?;
-    Ok(session)
+    Ok(pooled)
 }
 
 #[derive(Clone, Debug, Default)]
@@ -181,12 +195,12 @@ pub(crate) async fn build_write_session_with_options(
                     "active branch",
                 )
             })?;
-    register_execution_sql2_functions(
+    bind_execution_sql2_functions(
         &session,
         write_ctx.functions(),
-        write_ctx.active_account_id().to_string(),
-        Some(active_branch_id),
-        Some(active_branch_commit_id.commit_id.to_string()),
+        &write_ctx.active_account_id(),
+        Some(&active_branch_id),
+        Some(&active_branch_commit_id.commit_id.to_string()),
     );
     providers::register_write(&session, write_ctx, branch_ref, options, provider_selection).await?;
 
@@ -223,5 +237,28 @@ pub(crate) fn new_sql_session_context() -> SessionContext {
         .build();
     let session = SessionContext::new_with_state(state);
     register_static_sql2_functions(&session);
+    attach_execution_slots(session)
+}
+
+/// Gives a session its own execution-function slots and registers the five
+/// execution UDFs against them.
+///
+/// Every Lix SQL session goes through here exactly once. Doing it at session
+/// construction rather than per statement is what lets a pooled session keep a
+/// stable function registry: nothing mutates `SessionState`'s scalar-function
+/// map after this point.
+pub(crate) fn attach_execution_slots(session: SessionContext) -> SessionContext {
+    let slots = Arc::new(ExecutionSlots::default());
+    let config = session
+        .state_ref()
+        .read()
+        .config()
+        .clone()
+        .with_extension(Arc::clone(&slots));
+    let state = SessionStateBuilder::new_from_existing(session.state())
+        .with_config(config)
+        .build();
+    let session = SessionContext::new_with_state(state);
+    register_execution_sql2_functions(&session, slots);
     session
 }

--- a/packages/lix/src/sql2/session.rs
+++ b/packages/lix/src/sql2/session.rs
@@ -9,13 +9,13 @@ use crate::LixError;
 use crate::branch::{BranchHead, BranchRefReader};
 
 use super::branch_ref::CachingBranchRefReader;
+use super::exec::statement_has_table_function;
 use super::planning_cache::PooledReadSession;
 use super::providers;
 use super::udfs::{
     ExecutionSlots, bind_execution_sql2_functions, register_execution_sql2_functions,
     register_static_sql2_functions,
 };
-use super::exec::statement_has_table_function;
 use super::{SqlExecutionContext, SqlWriteContext, SqlWriteExecutionContext};
 
 pub(crate) async fn build_read_session<C>(

--- a/packages/lix/src/sql2/udfs/execution_slots.rs
+++ b/packages/lix/src/sql2/udfs/execution_slots.rs
@@ -32,7 +32,9 @@ struct ExecutionSlotValues {
 
 impl std::fmt::Debug for ExecutionSlots {
     fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        formatter.debug_struct("ExecutionSlots").finish_non_exhaustive()
+        formatter
+            .debug_struct("ExecutionSlots")
+            .finish_non_exhaustive()
     }
 }
 
@@ -53,10 +55,7 @@ impl ExecutionSlots {
         let mut values = self.lock();
         assign(&mut values.active_account_id, Some(active_account_id));
         assign(&mut values.active_branch_id, active_branch_id);
-        assign(
-            &mut values.active_branch_commit_id,
-            active_branch_commit_id,
-        );
+        assign(&mut values.active_branch_commit_id, active_branch_commit_id);
         values.functions = Some(functions);
     }
 

--- a/packages/lix/src/sql2/udfs/execution_slots.rs
+++ b/packages/lix/src/sql2/udfs/execution_slots.rs
@@ -1,0 +1,120 @@
+use std::sync::{Arc, Mutex, MutexGuard, PoisonError};
+
+use datafusion::common::{DataFusionError, Result};
+use datafusion::prelude::SessionContext;
+
+use crate::functions::FunctionProviderHandle;
+
+/// Per-session storage for the per-statement facts the execution UDFs report.
+///
+/// The five execution functions (`lix_active_account_id`,
+/// `lix_active_branch_id`, `lix_active_branch_commit_id`, `lix_uuid_v7`,
+/// `lix_timestamp`) used to be registered and deregistered on every statement so
+/// each one could capture that statement's values in its own fields. They are
+/// now registered once, when the session is created, and read this slot at
+/// invocation time instead.
+///
+/// The slot is what makes that safe: a pooled session never carries a value from
+/// an earlier statement, because [`Self::bind`] overwrites every field before
+/// planning starts and the UDFs never hold a copy of their own.
+#[derive(Default)]
+pub(crate) struct ExecutionSlots {
+    values: Mutex<ExecutionSlotValues>,
+}
+
+#[derive(Default)]
+struct ExecutionSlotValues {
+    active_account_id: Option<String>,
+    active_branch_id: Option<String>,
+    active_branch_commit_id: Option<String>,
+    functions: Option<FunctionProviderHandle>,
+}
+
+impl std::fmt::Debug for ExecutionSlots {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.debug_struct("ExecutionSlots").finish_non_exhaustive()
+    }
+}
+
+impl ExecutionSlots {
+    /// Installs the current statement's execution facts.
+    ///
+    /// Every field is written unconditionally: leaving a field untouched would
+    /// be exactly the staleness this type exists to prevent. Existing
+    /// allocations are reused when the text is unchanged, which is the steady
+    /// state for a session that keeps serving the same branch and account.
+    pub(crate) fn bind(
+        &self,
+        functions: FunctionProviderHandle,
+        active_account_id: &str,
+        active_branch_id: Option<&str>,
+        active_branch_commit_id: Option<&str>,
+    ) {
+        let mut values = self.lock();
+        assign(&mut values.active_account_id, Some(active_account_id));
+        assign(&mut values.active_branch_id, active_branch_id);
+        assign(
+            &mut values.active_branch_commit_id,
+            active_branch_commit_id,
+        );
+        values.functions = Some(functions);
+    }
+
+    pub(crate) fn active_account_id(&self) -> Option<String> {
+        self.lock().active_account_id.clone()
+    }
+
+    pub(crate) fn active_branch_id(&self) -> Option<String> {
+        self.lock().active_branch_id.clone()
+    }
+
+    pub(crate) fn active_branch_commit_id(&self) -> Option<String> {
+        self.lock().active_branch_commit_id.clone()
+    }
+
+    /// The statement's function provider.
+    ///
+    /// An unbound slot is an engine bug rather than a user error, so it fails
+    /// the statement instead of silently falling back to the system provider —
+    /// a deterministic-uuid test harness must never be replaced by wall-clock
+    /// randomness without saying so.
+    pub(crate) fn functions(&self) -> Result<FunctionProviderHandle> {
+        self.lock().functions.clone().ok_or_else(|| {
+            DataFusionError::Internal(
+                "Lix SQL execution functions were invoked on an unbound session".to_string(),
+            )
+        })
+    }
+
+    fn lock(&self) -> MutexGuard<'_, ExecutionSlotValues> {
+        self.values.lock().unwrap_or_else(PoisonError::into_inner)
+    }
+}
+
+fn assign(slot: &mut Option<String>, value: Option<&str>) {
+    match (slot.as_mut(), value) {
+        (Some(existing), Some(value)) => {
+            if existing != value {
+                existing.clear();
+                existing.push_str(value);
+            }
+        }
+        (_, Some(value)) => *slot = Some(value.to_string()),
+        (_, None) => *slot = None,
+    }
+}
+
+/// Recovers the slots a Lix SQL session was created with.
+///
+/// The slots travel in the session's `SessionConfig` extensions so that every
+/// holder of a `SessionContext` — read sessions, write sessions and transaction
+/// sessions alike — reaches the same instance the session's UDFs were
+/// registered against.
+pub(crate) fn execution_slots(session: &SessionContext) -> Arc<ExecutionSlots> {
+    session
+        .state_ref()
+        .read()
+        .config()
+        .get_extension::<ExecutionSlots>()
+        .expect("Lix SQL sessions are created with execution-function slots")
+}

--- a/packages/lix/src/sql2/udfs/lix_active_account_id.rs
+++ b/packages/lix/src/sql2/udfs/lix_active_account_id.rs
@@ -1,4 +1,5 @@
 use std::any::Any;
+use std::sync::Arc;
 
 use datafusion::arrow::datatypes::DataType;
 use datafusion::common::{Result, ScalarValue, plan_err};
@@ -6,14 +7,35 @@ use datafusion::logical_expr::{
     ColumnarValue, ScalarFunctionArgs, ScalarUDFImpl, Signature, Volatility,
 };
 
-#[derive(Clone, PartialEq, Eq, Hash)]
+use super::execution_slots::ExecutionSlots;
+
+#[derive(Clone)]
 pub(super) struct LixActiveAccountId {
-    account_id: String,
+    slots: Arc<ExecutionSlots>,
 }
 
 impl LixActiveAccountId {
-    pub(super) fn new(account_id: String) -> Self {
-        Self { account_id }
+    pub(super) fn new(slots: Arc<ExecutionSlots>) -> Self {
+        Self { slots }
+    }
+}
+
+// Every session owns exactly one instance of this function, and plans that call
+// it are never shared between sessions: `logical_plan_has_scalar_function`
+// excludes any plan containing a scalar function from the read-plan and
+// physical-plan caches. Identity therefore carries no information, exactly as
+// for the volatile execution functions.
+impl PartialEq for LixActiveAccountId {
+    fn eq(&self, _other: &Self) -> bool {
+        true
+    }
+}
+
+impl Eq for LixActiveAccountId {}
+
+impl std::hash::Hash for LixActiveAccountId {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.name().hash(state);
     }
 }
 
@@ -46,8 +68,8 @@ impl ScalarUDFImpl for LixActiveAccountId {
         if !args.args.is_empty() {
             return plan_err!("lix_active_account_id requires no arguments");
         }
-        Ok(ColumnarValue::Scalar(ScalarValue::Utf8(Some(
-            self.account_id.clone(),
-        ))))
+        Ok(ColumnarValue::Scalar(ScalarValue::Utf8(
+            self.slots.active_account_id(),
+        )))
     }
 }

--- a/packages/lix/src/sql2/udfs/lix_active_branch_commit_id.rs
+++ b/packages/lix/src/sql2/udfs/lix_active_branch_commit_id.rs
@@ -1,4 +1,5 @@
 use std::any::Any;
+use std::sync::Arc;
 
 use datafusion::arrow::datatypes::DataType;
 use datafusion::common::{Result, ScalarValue, plan_err};
@@ -6,14 +7,30 @@ use datafusion::logical_expr::{
     ColumnarValue, ScalarFunctionArgs, ScalarUDFImpl, Signature, Volatility,
 };
 
-#[derive(Clone, PartialEq, Eq, Hash)]
+use super::execution_slots::ExecutionSlots;
+
+#[derive(Clone)]
 pub(super) struct LixActiveBranchCommitId {
-    commit_id: Option<String>,
+    slots: Arc<ExecutionSlots>,
 }
 
 impl LixActiveBranchCommitId {
-    pub(super) fn new(commit_id: Option<String>) -> Self {
-        Self { commit_id }
+    pub(super) fn new(slots: Arc<ExecutionSlots>) -> Self {
+        Self { slots }
+    }
+}
+
+impl PartialEq for LixActiveBranchCommitId {
+    fn eq(&self, _other: &Self) -> bool {
+        true
+    }
+}
+
+impl Eq for LixActiveBranchCommitId {}
+
+impl std::hash::Hash for LixActiveBranchCommitId {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.name().hash(state);
     }
 }
 
@@ -47,7 +64,7 @@ impl ScalarUDFImpl for LixActiveBranchCommitId {
             return plan_err!("lix_active_branch_commit_id requires no arguments");
         }
         Ok(ColumnarValue::Scalar(ScalarValue::Utf8(
-            self.commit_id.clone(),
+            self.slots.active_branch_commit_id(),
         )))
     }
 }

--- a/packages/lix/src/sql2/udfs/lix_active_branch_id.rs
+++ b/packages/lix/src/sql2/udfs/lix_active_branch_id.rs
@@ -1,4 +1,5 @@
 use std::any::Any;
+use std::sync::Arc;
 
 use datafusion::arrow::datatypes::DataType;
 use datafusion::common::{Result, ScalarValue, plan_err};
@@ -6,14 +7,30 @@ use datafusion::logical_expr::{
     ColumnarValue, ScalarFunctionArgs, ScalarUDFImpl, Signature, Volatility,
 };
 
-#[derive(Clone, PartialEq, Eq, Hash)]
+use super::execution_slots::ExecutionSlots;
+
+#[derive(Clone)]
 pub(super) struct LixActiveBranchId {
-    branch_id: Option<String>,
+    slots: Arc<ExecutionSlots>,
 }
 
 impl LixActiveBranchId {
-    pub(super) fn new(branch_id: Option<String>) -> Self {
-        Self { branch_id }
+    pub(super) fn new(slots: Arc<ExecutionSlots>) -> Self {
+        Self { slots }
+    }
+}
+
+impl PartialEq for LixActiveBranchId {
+    fn eq(&self, _other: &Self) -> bool {
+        true
+    }
+}
+
+impl Eq for LixActiveBranchId {}
+
+impl std::hash::Hash for LixActiveBranchId {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.name().hash(state);
     }
 }
 
@@ -47,7 +64,7 @@ impl ScalarUDFImpl for LixActiveBranchId {
             return plan_err!("lix_active_branch_id requires no arguments");
         }
         Ok(ColumnarValue::Scalar(ScalarValue::Utf8(
-            self.branch_id.clone(),
+            self.slots.active_branch_id(),
         )))
     }
 }

--- a/packages/lix/src/sql2/udfs/lix_timestamp.rs
+++ b/packages/lix/src/sql2/udfs/lix_timestamp.rs
@@ -1,4 +1,5 @@
 use std::any::Any;
+use std::sync::Arc;
 
 use datafusion::arrow::datatypes::DataType;
 use datafusion::common::{Result, ScalarValue, plan_err};
@@ -6,11 +7,11 @@ use datafusion::logical_expr::{
     ColumnarValue, ScalarFunctionArgs, ScalarUDFImpl, Signature, Volatility,
 };
 
-use crate::functions::FunctionProviderHandle;
+use super::execution_slots::ExecutionSlots;
 
 #[derive(Clone)]
 pub(super) struct LixTimestamp {
-    pub(super) functions: FunctionProviderHandle,
+    pub(super) slots: Arc<ExecutionSlots>,
 }
 
 impl PartialEq for LixTimestamp {
@@ -57,7 +58,7 @@ impl ScalarUDFImpl for LixTimestamp {
             return plan_err!("lix_timestamp requires no arguments");
         }
         Ok(ColumnarValue::Scalar(ScalarValue::Utf8(Some(
-            self.functions.call_timestamp().to_string(),
+            self.slots.functions()?.call_timestamp().to_string(),
         ))))
     }
 }

--- a/packages/lix/src/sql2/udfs/lix_uuid_v7.rs
+++ b/packages/lix/src/sql2/udfs/lix_uuid_v7.rs
@@ -1,4 +1,5 @@
 use std::any::Any;
+use std::sync::Arc;
 
 use datafusion::arrow::datatypes::DataType;
 use datafusion::common::{Result, ScalarValue, plan_err};
@@ -6,11 +7,11 @@ use datafusion::logical_expr::{
     ColumnarValue, ScalarFunctionArgs, ScalarUDFImpl, Signature, Volatility,
 };
 
-use crate::functions::FunctionProviderHandle;
+use super::execution_slots::ExecutionSlots;
 
 #[derive(Clone)]
 pub(super) struct LixUuidV7 {
-    pub(super) functions: FunctionProviderHandle,
+    pub(super) slots: Arc<ExecutionSlots>,
 }
 
 impl PartialEq for LixUuidV7 {
@@ -57,7 +58,7 @@ impl ScalarUDFImpl for LixUuidV7 {
             return plan_err!("lix_uuid_v7 requires no arguments");
         }
         Ok(ColumnarValue::Scalar(ScalarValue::Utf8(Some(
-            self.functions.call_uuid_v7().to_string(),
+            self.slots.functions()?.call_uuid_v7().to_string(),
         ))))
     }
 }

--- a/packages/lix/src/sql2/udfs/mod.rs
+++ b/packages/lix/src/sql2/udfs/mod.rs
@@ -43,9 +43,9 @@ pub(crate) fn register_execution_sql2_functions(ctx: &SessionContext, slots: Arc
     ctx.register_udf(ScalarUDF::from(
         lix_active_account_id::LixActiveAccountId::new(Arc::clone(&slots)),
     ));
-    ctx.register_udf(ScalarUDF::from(lix_active_branch_id::LixActiveBranchId::new(
-        Arc::clone(&slots),
-    )));
+    ctx.register_udf(ScalarUDF::from(
+        lix_active_branch_id::LixActiveBranchId::new(Arc::clone(&slots)),
+    ));
     ctx.register_udf(ScalarUDF::from(
         lix_active_branch_commit_id::LixActiveBranchCommitId::new(Arc::clone(&slots)),
     ));

--- a/packages/lix/src/sql2/udfs/mod.rs
+++ b/packages/lix/src/sql2/udfs/mod.rs
@@ -1,4 +1,5 @@
 mod common;
+pub(crate) mod execution_slots;
 mod lix_active_account_id;
 mod lix_active_branch_commit_id;
 mod lix_active_branch_id;
@@ -9,32 +10,18 @@ mod lix_octet_length;
 mod lix_timestamp;
 mod lix_uuid_v7;
 
+use std::sync::Arc;
+
 use datafusion::execution::context::SessionContext;
 use datafusion::logical_expr::ScalarUDF;
 
 use crate::functions::FunctionProviderHandle;
 
+pub(crate) use execution_slots::{ExecutionSlots, execution_slots};
+
 #[cfg(test)]
 pub(crate) fn system_sql2_function_provider() -> FunctionProviderHandle {
     FunctionProviderHandle::system()
-}
-
-#[cfg(test)]
-pub(crate) fn register_sql2_functions(
-    ctx: &SessionContext,
-    functions: FunctionProviderHandle,
-    active_account_id: String,
-    active_branch_id: Option<String>,
-    active_branch_commit_id: Option<String>,
-) {
-    register_static_sql2_functions(ctx);
-    register_execution_sql2_functions(
-        ctx,
-        functions,
-        active_account_id,
-        active_branch_id,
-        active_branch_commit_id,
-    );
 }
 
 pub(crate) fn register_static_sql2_functions(ctx: &SessionContext) {
@@ -44,41 +31,58 @@ pub(crate) fn register_static_sql2_functions(ctx: &SessionContext) {
     ctx.register_udf(ScalarUDF::from(lix_octet_length::LixOctetLength::new()));
 }
 
-pub(crate) fn register_execution_sql2_functions(
-    ctx: &SessionContext,
-    functions: FunctionProviderHandle,
-    active_account_id: String,
-    active_branch_id: Option<String>,
-    active_branch_commit_id: Option<String>,
-) {
+/// Installs the five per-statement execution functions once, for the lifetime
+/// of the session.
+///
+/// Each one holds only the session's [`ExecutionSlots`] and reads the current
+/// statement's value at invocation time, so a session can be pooled and reused
+/// without a function ever reporting an earlier statement's account, branch or
+/// commit. Call [`bind_execution_sql2_functions`] before planning each
+/// statement.
+pub(crate) fn register_execution_sql2_functions(ctx: &SessionContext, slots: Arc<ExecutionSlots>) {
     ctx.register_udf(ScalarUDF::from(
-        lix_active_account_id::LixActiveAccountId::new(active_account_id),
+        lix_active_account_id::LixActiveAccountId::new(Arc::clone(&slots)),
     ));
+    ctx.register_udf(ScalarUDF::from(lix_active_branch_id::LixActiveBranchId::new(
+        Arc::clone(&slots),
+    )));
     ctx.register_udf(ScalarUDF::from(
-        lix_active_branch_id::LixActiveBranchId::new(active_branch_id),
-    ));
-    ctx.register_udf(ScalarUDF::from(
-        lix_active_branch_commit_id::LixActiveBranchCommitId::new(active_branch_commit_id),
+        lix_active_branch_commit_id::LixActiveBranchCommitId::new(Arc::clone(&slots)),
     ));
     ctx.register_udf(ScalarUDF::from(lix_uuid_v7::LixUuidV7 {
-        functions: functions.clone(),
+        slots: Arc::clone(&slots),
     }));
-    ctx.register_udf(ScalarUDF::from(lix_timestamp::LixTimestamp { functions }));
+    ctx.register_udf(ScalarUDF::from(lix_timestamp::LixTimestamp { slots }));
+}
+
+/// Points the session's execution functions at this statement's facts.
+pub(crate) fn bind_execution_sql2_functions(
+    ctx: &SessionContext,
+    functions: FunctionProviderHandle,
+    active_account_id: &str,
+    active_branch_id: Option<&str>,
+    active_branch_commit_id: Option<&str>,
+) {
+    execution_slots(ctx).bind(
+        functions,
+        active_account_id,
+        active_branch_id,
+        active_branch_commit_id,
+    );
 }
 
 #[cfg(test)]
 pub(super) mod test_support {
     use datafusion::arrow::array::{Array, StringArray};
-    use datafusion::prelude::SessionContext;
 
-    use super::{register_sql2_functions, system_sql2_function_provider};
+    use super::{bind_execution_sql2_functions, system_sql2_function_provider};
 
     pub(super) async fn single_text(sql: &str) -> Option<String> {
-        let ctx = SessionContext::new();
-        register_sql2_functions(
+        let ctx = crate::sql2::session::new_sql_session_context();
+        bind_execution_sql2_functions(
             &ctx,
             system_sql2_function_provider(),
-            crate::ANONYMOUS_ACCOUNT_ID.to_string(),
+            crate::ANONYMOUS_ACCOUNT_ID,
             None,
             None,
         );

--- a/packages/lix/src/transaction/context.rs
+++ b/packages/lix/src/transaction/context.rs
@@ -8430,7 +8430,7 @@ where
         self.sql_planning_cache.datafusion_session()
     }
 
-    fn datafusion_read_session(&self) -> datafusion::prelude::SessionContext {
+    fn datafusion_read_session(&self) -> crate::sql2::PooledReadSession {
         self.sql_planning_cache.datafusion_read_session()
     }
 

--- a/packages/lix/tests/integration/main.rs
+++ b/packages/lix/tests/integration/main.rs
@@ -20,6 +20,7 @@ mod merge_fuzz;
 mod observe;
 mod observe_mutation_revision;
 mod physical_plan_cache;
+mod pooled_session_reuse;
 mod sql;
 mod storage_accounting;
 mod transaction;

--- a/packages/lix/tests/integration/pooled_session_reuse.rs
+++ b/packages/lix/tests/integration/pooled_session_reuse.rs
@@ -97,10 +97,7 @@ async fn execution_functions_follow_a_branch_switch_on_a_reused_session() {
         .execute(ACTIVE_FACTS_SQL, &[])
         .await
         .expect("active facts should read after switching back");
-    assert_eq!(
-        text(&restored, "branch_id"),
-        Some(main_branch_id)
-    );
+    assert_eq!(text(&restored, "branch_id"), Some(main_branch_id));
     assert_eq!(text(&restored, "commit_id"), Some(before_commit));
 }
 
@@ -185,7 +182,10 @@ async fn a_reused_session_reads_rows_committed_after_its_plan_was_cached() {
 
     let sql = "SELECT key FROM lix_key_value WHERE key LIKE 'pooled-visibility-%' ORDER BY key";
     for round in 0..4 {
-        let rows = session.execute(sql, &[]).await.expect("read should execute");
+        let rows = session
+            .execute(sql, &[])
+            .await
+            .expect("read should execute");
         assert_eq!(
             rows.len(),
             round,

--- a/packages/lix/tests/integration/pooled_session_reuse.rs
+++ b/packages/lix/tests/integration/pooled_session_reuse.rs
@@ -1,0 +1,269 @@
+//! A pooled DataFusion session outlives the statement that borrowed it, and its
+//! execution functions are registered once for the life of the session rather
+//! than per statement. These tests pin the resulting hazard: a second execution
+//! of the same statement shape must never observe the first execution's account,
+//! branch, commit or snapshot.
+
+use lix::integration::Engine;
+use lix::storage::Memory;
+use lix::{CreateBranchOptions, SwitchBranchOptions, Value};
+
+const DRAFT_BRANCH_ID: &str = "01930000-0000-7000-8000-0000000000d1";
+
+const ACTIVE_FACTS_SQL: &str = "SELECT lix_active_branch_id() AS branch_id, \
+    lix_active_branch_commit_id() AS commit_id, \
+    lix_active_account_id() AS account_id";
+
+async fn open_engine() -> Engine {
+    let storage = Memory::new();
+    Engine::initialize(storage.clone())
+        .await
+        .expect("storage should initialize");
+    Engine::new(storage)
+        .await
+        .expect("initialized storage should open")
+}
+
+fn text(rows: &lix::ExecuteResult, column: &str) -> Option<String> {
+    match rows.rows()[0].value(column).expect("column is present") {
+        Value::Text(value) => Some(value.clone()),
+        Value::Null => None,
+        other => panic!("unexpected {column} value: {other:?}"),
+    }
+}
+
+/// Switching branches between two executions of the same statement shape must
+/// change what `lix_active_branch_id()` reports.
+///
+/// Before the execution functions moved into a per-session slot they were
+/// deregistered and re-registered per statement, so a stale registration was
+/// impossible by construction. The slot is what preserves that property now.
+#[tokio::test(flavor = "current_thread")]
+async fn execution_functions_follow_a_branch_switch_on_a_reused_session() {
+    let engine = open_engine().await;
+    let session = engine
+        .open_workspace_session()
+        .await
+        .expect("workspace session should open");
+
+    session
+        .create_branch(CreateBranchOptions {
+            id: Some(DRAFT_BRANCH_ID.to_string()),
+            name: "Draft".to_string(),
+            from_commit_id: None,
+        })
+        .await
+        .expect("branch should be created");
+
+    // Warm the pooled session and every planning cache on this exact shape.
+    let before = session
+        .execute(ACTIVE_FACTS_SQL, &[])
+        .await
+        .expect("active facts should read");
+    let main_branch_id = text(&before, "branch_id").expect("branch id is present");
+    let before_commit = text(&before, "commit_id").expect("commit id is present");
+    let account = text(&before, "account_id").expect("account id is present");
+
+    session
+        .switch_branch(SwitchBranchOptions {
+            branch_id: DRAFT_BRANCH_ID.to_string(),
+        })
+        .await
+        .expect("switch should succeed");
+
+    let after = session
+        .execute(ACTIVE_FACTS_SQL, &[])
+        .await
+        .expect("active facts should read after the switch");
+    assert_eq!(
+        text(&after, "branch_id").as_deref(),
+        Some(DRAFT_BRANCH_ID),
+        "the reused session reported the previous statement's branch"
+    );
+    assert_ne!(text(&after, "branch_id"), Some(main_branch_id.clone()));
+    assert_eq!(text(&after, "account_id"), Some(account));
+    // The draft branch was created from main's head, so the commit id is only
+    // required to still be present and to track the branch that is now active.
+    assert!(text(&after, "commit_id").is_some());
+
+    // Switching back must not leave the draft's identity behind either.
+    session
+        .switch_branch(SwitchBranchOptions {
+            branch_id: main_branch_id.clone(),
+        })
+        .await
+        .expect("switch back should succeed");
+    let restored = session
+        .execute(ACTIVE_FACTS_SQL, &[])
+        .await
+        .expect("active facts should read after switching back");
+    assert_eq!(
+        text(&restored, "branch_id"),
+        Some(main_branch_id)
+    );
+    assert_eq!(text(&restored, "commit_id"), Some(before_commit));
+}
+
+/// `lix_active_branch_commit_id()` must advance when the active branch commits,
+/// even though the SQL text and parameter bytes are unchanged.
+#[tokio::test(flavor = "current_thread")]
+async fn active_commit_id_advances_between_executions_of_one_shape() {
+    let engine = open_engine().await;
+    let session = engine
+        .open_workspace_session()
+        .await
+        .expect("workspace session should open");
+
+    let sql = "SELECT lix_active_branch_commit_id() AS commit_id";
+    let first = text(
+        &session.execute(sql, &[]).await.expect("first read"),
+        "commit_id",
+    )
+    .expect("commit id is present");
+
+    session
+        .execute(
+            "INSERT INTO lix_key_value (key, value) VALUES ('pooled-session-probe', 'v1')",
+            &[],
+        )
+        .await
+        .expect("write should commit");
+
+    let second = text(
+        &session.execute(sql, &[]).await.expect("second read"),
+        "commit_id",
+    )
+    .expect("commit id is present");
+    assert_ne!(
+        first, second,
+        "a reused session reported the commit id captured by an earlier statement"
+    );
+}
+
+/// The volatile execution functions must produce a fresh value per invocation,
+/// per row and per statement — never one frozen into the session.
+#[tokio::test(flavor = "current_thread")]
+async fn volatile_execution_functions_stay_fresh_on_a_reused_session() {
+    let engine = open_engine().await;
+    let session = engine
+        .open_workspace_session()
+        .await
+        .expect("workspace session should open");
+
+    let sql = "SELECT lix_uuid_v7() AS first, lix_uuid_v7() AS second, \
+        lix_timestamp() AS stamp";
+    let mut uuids = Vec::new();
+    for _ in 0..3 {
+        let rows = session.execute(sql, &[]).await.expect("volatile read");
+        let first = text(&rows, "first").expect("uuid is present");
+        let second = text(&rows, "second").expect("uuid is present");
+        assert_ne!(
+            first, second,
+            "two calls in one statement returned the same uuid"
+        );
+        assert!(text(&rows, "stamp").is_some());
+        uuids.push(first);
+        uuids.push(second);
+    }
+    let unique = uuids.iter().collect::<std::collections::BTreeSet<_>>();
+    assert_eq!(
+        unique.len(),
+        uuids.len(),
+        "a reused session replayed uuids from an earlier statement"
+    );
+}
+
+/// A row committed between two executions of one statement shape must be
+/// visible to the second, on the same pooled session and the same cached plan.
+#[tokio::test(flavor = "current_thread")]
+async fn a_reused_session_reads_rows_committed_after_its_plan_was_cached() {
+    let engine = open_engine().await;
+    let session = engine
+        .open_workspace_session()
+        .await
+        .expect("workspace session should open");
+
+    let sql = "SELECT key FROM lix_key_value WHERE key LIKE 'pooled-visibility-%' ORDER BY key";
+    for round in 0..4 {
+        let rows = session.execute(sql, &[]).await.expect("read should execute");
+        assert_eq!(
+            rows.len(),
+            round,
+            "the reused session served a stale snapshot"
+        );
+        session
+            .execute(
+                "INSERT INTO lix_key_value (key, value) VALUES ($1, 'v')",
+                &[Value::Text(format!("pooled-visibility-{round}"))],
+            )
+            .await
+            .expect("write should commit");
+    }
+    assert_eq!(
+        session
+            .execute(sql, &[])
+            .await
+            .expect("final read should execute")
+            .len(),
+        4
+    );
+}
+
+/// `information_schema` is registered only for statements that can reach it.
+/// Interleaving it with ordinary statements on a pooled session must not make
+/// its rows go missing or go stale.
+#[tokio::test(flavor = "current_thread")]
+async fn information_schema_stays_available_across_pooled_statements() {
+    let engine = open_engine().await;
+    let session = engine
+        .open_workspace_session()
+        .await
+        .expect("workspace session should open");
+
+    let information_schema_sql =
+        "SELECT table_name FROM information_schema.tables WHERE table_name = 'lix_key_value'";
+    for _ in 0..3 {
+        assert_eq!(
+            session
+                .execute(information_schema_sql, &[])
+                .await
+                .expect("information_schema should read")
+                .len(),
+            1
+        );
+        session
+            .execute("SELECT key FROM lix_key_value LIMIT 1", &[])
+            .await
+            .expect("ordinary read should execute");
+    }
+
+    session
+        .execute(
+            "INSERT INTO lix_registered_schema (value) VALUES (lix_json($1))",
+            &[Value::Text(
+                serde_json::json!({
+                    "x-lix-key": "pooled_probe",
+                    "x-lix-primary-key": ["/id"],
+                    "type": "object",
+                    "properties": { "id": { "type": "string" } },
+                    "required": ["id"],
+                    "additionalProperties": false
+                })
+                .to_string(),
+            )],
+        )
+        .await
+        .expect("schema should register");
+
+    assert_eq!(
+        session
+            .execute(
+                "SELECT table_name FROM information_schema.tables WHERE table_name = 'pooled_probe'",
+                &[],
+            )
+            .await
+            .expect("information_schema should see the new surface")
+            .len(),
+        1
+    );
+}


### PR DESCRIPTION
# What changed

A warm OLTP read borrowed a pooled DataFusion session and then rebuilt most of
what made that session usable. Four causes, all removed here.

## 1. The five execution UDFs were registered and deregistered per statement

`lix_active_account_id`, `lix_active_branch_id`, `lix_active_branch_commit_id`,
`lix_uuid_v7` and `lix_timestamp` each captured that statement's value in its own
field, so `build_read_session` had to `register_udf` all five per statement and
`recycle_datafusion_read_session` had to find them again by diffing the session's
scalar-function registry against the template's — several hundred `String` hash
lookups per statement — and `deregister_udf` each one.

They now hold an `Arc<ExecutionSlots>` and read the current statement's value at
invocation time. The slots live in the session's `SessionConfig` extensions, so a
session's UDFs and its slots are created together and stay together; every entry
point (read, write, transaction) calls `bind_execution_sql2_functions` before
planning, which overwrites **every** field unconditionally.

## 2. The pooled session's `SessionState` was deep-copied per statement

`SessionState::clone` copies `String`-keyed registries for every built-in scalar,
aggregate, window and table function. `SessionContext::execute_logical_plan` did
one such clone per statement purely to hand a `DataFrame` a state it did not need:
DataFusion's own implementation is `DataFrame::new(self.state(), plan)` for
everything that is not DDL or a utility statement, and
`validate_supported_logical_plan` already rejects both. `information_schema::register`
did another.

With (1) in place the scalar registry never changes after session construction, so
the pooled session now carries its own `SessionState` and hands out an `Arc` of it.
`query_execution_start_time` is restamped per statement through `Arc::get_mut`, so
`now()` and `current_timestamp()` still observe the statement's own start.
Parameter binding moved from `DataFrame::with_param_values` to the identical
`LogicalPlan::with_param_values`, and `runtime::collect_dataframe`/`stream_dataframe`
became `collect_plan`/`stream_plan` taking `(&SessionState, LogicalPlan)`.

## 3. `information_schema` was re-registered on every statement

`read_provider_selection` widens to `ProviderSelection::All` for every
`information_schema`-qualified reference and every `SHOW` form, so a narrowed
selection provably cannot resolve an information-schema table. Registering the
schema anyway cost a `SessionState` clone, a full `PublicCatalog` deep clone (two
`BTreeMap`s of surfaces and columns) and a catalog write lock on every ordinary
read and write. It is now registered only for `All`, and the provider holds
`Arc<PublicCatalog>` instead of a clone. `lix_diff` — a table-valued function, so
only reachable from a statement that calls one — is likewise registered only when
the statement contains a table function.

## 4. A warm physical-template hit still rebuilt an optimized logical plan

The cache entry stored the optimized logical plan next to the template so the warm
path could clone it, graft the current snapshot's sources back on, and walk it for
leaf scans. The entry now stores the leaf scan requests directly — table name,
projection, unnormalized filters, fetch — so the warm path resolves each table
against the current session and replans only that leaf. Two full logical-plan
clones per warm read are gone, and the entry no longer holds a `LogicalPlan` at
all.

Also: the per-leaf template fingerprint was
`format!("schema={:?};properties={:?}")`, allocating kilobytes of `Debug` output
(including `EquivalenceProperties`) per scan per warm execution. It is now direct
field equality on schema, partitioning discriminant and count, output ordering,
emission type and boundedness. `Partitioning`'s own `PartialEq` returns `false` for
two identical `UnknownPartitioning` values — which is what every `SpecScanExec`
reports — so partitioning is compared by discriminant plus count.

**Removed:** per-statement UDF registration/deregistration and the registry
key-diff scan; the per-statement `SessionState` deep copies in
`execute_logical_plan` and `information_schema::register`; the `DataFrame` hop;
per-statement `information_schema` and `lix_diff` registration for statements that
cannot reach them; the cached optimized logical plan, `detach_logical_plan_sources`,
`rebind_logical_plan_sources`, `collect_logical_table_sources`,
`collect_logical_table_scans` and the formatted fingerprint.

# Correctness

Caching a session across statements turns a stale UDF value or a stale provider
into a wrong answer rather than a slow one. Three things keep that from
happening, and each has a test that fails without it.

1. **The UDFs hold no value of their own.** `LixActiveAccountId`,
   `LixActiveBranchId` and `LixActiveBranchCommitId` used to own a `String`;
   `LixUuidV7` and `LixTimestamp` used to own a `FunctionProviderHandle`. They now
   own only `Arc<ExecutionSlots>` and read it inside `invoke_with_args`. There is
   no field for a previous statement's value to survive in. `ExecutionSlots::bind`
   writes **every** field unconditionally — including setting `None` — so a
   statement with no active commit cannot inherit the previous statement's commit.
   An unbound `functions` slot is an `Internal` error, not a silent fallback to the
   system provider, so a deterministic-uuid harness can never be replaced by
   wall-clock randomness.

2. **The scalar-function-bearing plan exclusion is untouched.**
   `logical_plan_has_scalar_function` still runs on the *unoptimized* plan and
   still excludes any plan containing an `Expr::ScalarFunction` from both the
   read-plan and physical-plan caches, so `lix_active_branch_id()` still cannot be
   folded into a reused plan. Making the UDFs session-resident does not widen what
   is cacheable: registration was already unconditional at plan time, and the check
   is on the plan's contents, not on the registry. If anything the exclusion now
   has a second line of defence — even a hypothetically reused plan would hold a
   UDF that reads the *current* slot, whereas before it would have held a frozen
   `String`.

   The UDFs' `PartialEq` now returns `true` (as `lix_uuid_v7` and `lix_timestamp`
   already did) because a session owns exactly one instance of each and plans that
   call them are never shared between sessions.

3. **The provider set is still rebuilt per statement.** This is deliberate. The
   provider *names* are a pure function of the plan-cache key, but the provider
   *objects* are not: they embed the statement's `live_state`, `branch_ref` and
   `active_branch_commit_id`. Only the parts that are genuinely snapshot-independent
   were lifted out of the per-statement path — the UDF registrations (session
   lifetime), `information_schema` (only for `ProviderSelection::All`) and
   `lix_diff` (only for statements containing a table function). The cached
   physical entry likewise holds no provider: it stores table *names* and replans
   each leaf against the current session on every execution, and the existing
   per-leaf fingerprint check plus "every replacement consumed" rule still gate
   reuse.

   `query_execution_start_time` is the one piece of `SessionState` that is not
   statement-independent, so `PooledReadSession::begin_statement` restamps it
   through `Arc::get_mut` before each statement. Without that, `now()` and
   `current_timestamp()` would freeze at session-construction time.

## Tests

`packages/lix/tests/integration/pooled_session_reuse.rs` (new, 5 tests):

- `execution_functions_follow_a_branch_switch_on_a_reused_session` — warms the
  session and every planning cache on one statement shape, switches the active
  branch, runs the identical statement again, and requires the new branch id; then
  switches back and requires the original branch and commit id.
- `active_commit_id_advances_between_executions_of_one_shape` — commits a row
  between two executions of identical SQL and requires a different commit id.
- `volatile_execution_functions_stay_fresh_on_a_reused_session` — two
  `lix_uuid_v7()` calls in one statement must differ, and no uuid may repeat across
  three executions.
- `a_reused_session_reads_rows_committed_after_its_plan_was_cached` — interleaves
  a filtered ordered read with commits and requires the row count to grow.
- `information_schema_stays_available_across_pooled_statements` — interleaves
  `information_schema.tables` with ordinary reads on the same pooled session, then
  registers a new surface and requires it to appear.

Each was confirmed to fail against a deliberately broken build:

- Making `ExecutionSlots::bind` a no-op after the first bind fails
  `execution_functions_follow_a_branch_switch_on_a_reused_session`
  ("left: 019ff16c-…, right: 01930000-…-0000000000d1") and
  `active_commit_id_advances_between_executions_of_one_shape` (both commit ids
  identical).
- Making `register_information_schema` always skip fails
  `information_schema_stays_available_across_pooled_statements` with
  `LIX_TABLE_NOT_FOUND: table 'datafusion.information_schema.tables' not found`.


# A/B

Machine `hetzner-cpx62-III` (16 cores, 30 GB). Both arms built `--no-run` first;
runs strictly interleaved base/cand; **9 reps per arm** for every id below (15 for
the tracked write ids). Base `8869319bd` (`claude-3-optimizations` at PR #1295),
candidate `2bbd5ea54`.

## Primary — `tracked_state_crud`, `sql_session` layer, hot-repeat profile

```
LIX_TRACKED_STATE_CRUD_PROFILE=1 LIX_TRACKED_STATE_CRUD_PROFILE_LAYER=sql_session \
LIX_TRACKED_STATE_CRUD_PROFILE_STORAGE=<backend> LIX_TRACKED_STATE_CRUD_PROFILE_OP=<op> \
LIX_TRACKED_STATE_CRUD_PROFILE_ROW_COUNT=<rows> \
LIX_TRACKED_STATE_CRUD_PROFILE_HOT_REPEATS=2000 <bench-binary> --bench
```

| id | n | base median | cand median | delta | base p95 | cand p95 |
|---|---|---|---|---|---|---|
| rocksdb read_one_by_pk 1k | 9 | 282.6 µs | 226.6 µs | **-19.8%** | 344.8 | 288.9 |
| rocksdb read_one_by_pk 10k | 9 | 296.7 µs | 231.9 µs | **-21.8%** | 302.1 | 247.4 |
| rocksdb read_many_by_pk 1k | 9 | 364.5 µs | 309.5 µs | **-15.1%** | 388.4 | 319.6 |
| rocksdb read_many_by_pk 10k | 9 | 367.3 µs | 319.3 µs | **-13.1%** | 377.1 | 354.0 |
| rocksdb read_all 1k | 9 | 277.0 µs | 219.2 µs | **-20.9%** | 281.0 | 251.9 |
| slatedb read_one_by_pk 1k | 9 | 346.6 µs | 285.4 µs | **-17.7%** | 375.4 | 304.1 |
| slatedb read_many_by_pk 1k | 9 | 419.6 µs | 359.8 µs | **-14.3%** | 426.7 | 375.2 |

Raw per-rep values (µs):

```
rocksdb read_one 1k   base 344.8 285.4 279.6 279.4 288.2 276.3 283.6 282.6 281.3
rocksdb read_one 1k   cand 288.9 227.2 219.7 226.6 226.2 231.8 225.1 218.8 230.4
rocksdb read_one 10k  base 294.4 302.1 301.4 290.4 296.7 296.9 285.7 298.5 290.2
rocksdb read_one 10k  cand 241.9 233.0 231.2 227.4 231.0 247.4 232.9 226.4 231.9
rocksdb read_many 1k  base 359.8 388.4 354.8 364.6 377.2 351.3 349.8 364.5 366.6
rocksdb read_many 1k  cand 319.1 304.6 297.4 319.6 301.3 316.1 307.5 310.4 309.5
rocksdb read_many 10k base 366.2 377.1 370.4 363.3 376.6 367.3 374.7 359.5 360.9
rocksdb read_many 10k cand 319.3 340.3 312.0 309.6 306.3 303.7 354.0 319.6 320.2
rocksdb read_all 1k   base 280.4 277.0 280.1 265.0 268.7 274.6 272.7 280.5 281.0
rocksdb read_all 1k   cand 229.1 207.7 212.9 214.3 214.2 221.8 230.3 251.9 219.2
slatedb read_one 1k   base 375.4 345.7 348.7 350.3 346.6 333.8 342.5 350.7 345.5
slatedb read_one 1k   cand 290.5 279.3 281.2 290.1 285.4 283.2 294.0 304.1 279.6
slatedb read_many 1k  base 423.4 418.2 417.8 416.7 426.7 420.0 414.9 419.6 420.5
slatedb read_many 1k  cand 375.2 350.3 355.9 359.9 371.1 367.8 359.8 352.7 356.3
```

Every read id's base and candidate ranges are strictly disjoint apart from the
first (cold-page) rep of `read_one 1k` and `read_all 1k`. An independent 9-rep run against an earlier
candidate reproduced the same deltas within 2 points (-20.4 / -21.2 / -15.9 /
-15.1 / -19.1 / -17.3 / -16.3%).

## Guards — tracked writes (15 reps, same profile harness)

| id | n | base median | cand median | delta |
|---|---|---|---|---|
| rocksdb insert_all 1k | 15 | 9.035 ms | 9.119 ms | +0.9% |
| rocksdb update_one 1k | 15 | 1.044 ms | 1.046 ms | +0.2% |
| rocksdb update_all 1k | 15 | 2.663 ms | 2.638 ms | -0.9% |

A 9-rep pass had put `insert_all` at +5.3% and an earlier one at -0.0%; 15 reps
settle it at +0.9%. This is exactly the harness behaviour the runbook documents.

## Guards — criterion (9 reps interleaved, `--sample-size 10`)

| id | base median | cand median | delta |
|---|---|---|---|
| untracked rocksdb select_one_by_pk 1k | 12.0 µs | 12.0 µs | +0.5% |
| untracked rocksdb select_keys_only 1k | 228.4 µs | 226.8 µs | -0.7% |
| untracked rocksdb select_all_by_pk 1k | 907.8 µs | 889.9 µs | -2.0% |
| untracked rocksdb insert_all_rows 1k | 1.637 ms | 1.682 ms | +2.7% |
| untracked rocksdb update_all_rows 1k | 2.100 ms | 2.156 ms | +2.7% |
| untracked rocksdb update_one_by_pk 1k | 29.4 µs | 29.0 µs | -1.2% |
| untracked rocksdb delete_one_by_pk 1k | 14.4 µs | 15.1 µs | +4.8% |
| untracked slatedb select_one_by_pk 1k | 53.5 µs | 46.4 µs | -13.2% |
| untracked slatedb insert_all_rows 1k | 994.9 µs | 964.5 µs | -3.1% |
| untracked slatedb update_all_rows 1k | 901.0 µs | 884.0 µs | -1.9% |
| untracked session_execute_untracked rocksdb | 27.10 ms | 26.67 ms | -1.6% |
| untracked session_execute_untracked slatedb | 38.35 ms | 38.14 ms | -0.6% |
| entity_default_values/cold_standard_sql | 2.491 ms | 2.489 ms | -0.1% |
| entity_default_values/cold_explicit_values_control | 2.566 ms | 2.522 ms | -1.7% |
| diff_commands/working_diff_1000 | 3.688 ms | 3.447 ms | -6.5% |
| diff_commands/revert_100_of_1000 | 9.765 ms | 9.955 ms | +1.9% |
| diff_commands/apply_100_of_1000 | 9.756 ms | 9.702 ms | -0.5% |
| diff_commands/partial_checkpoint_500_of_1000 | 19.61 ms | 19.76 ms | +0.8% |

`registered_entity_returning` (`LIX_RETURNING_PROFILE=1`, 9 reps x 11 rounds):

| id | base median | cand median | delta |
|---|---|---|---|
| insert, returning=false | 8.658 ms | 8.566 ms | -1.1% |
| insert, returning=true | 9.105 ms | 8.997 ms | -1.2% |
| update, returning=false | 5.833 ms | 6.017 ms | +3.2% |
| update, returning=true | 6.381 ms | 6.517 ms | +2.1% |

## Physical bytes

`fixed_live_history_scale` (100k history changes, commit width 10, slatedb), which
seeds and mutates through the real `SessionContext` SQL commit path:

| lane | base physical_bytes | cand physical_bytes |
|---|---|---|
| exact_read / enumerate_live | 6,902,132 | 6,901,846 |
| update_one | 6,909,812 | 6,909,526 |
| insert_one | 6,918,351 | 6,918,065 |
| delete_one | 6,993,105 | 6,984,421 |

`logical_written_bytes` is identical (6,468,890) on every lane, as is
`object_write_bytes` for update_one and insert_one. This is in-memory planning
plumbing; nothing about the on-disk layout changes.

# Regressions and trade-off

- `registered_entity_returning` update lanes are **+2.1% to +3.2%**. PR #1295 spent
  +2.2-2.8% here; this change does not recover that but also does not compound it
  (its insert lanes come back -1.1 / -1.2%). The returning path builds a fresh,
  unpooled write session per statement, so it pays session construction without
  amortizing it; the read path amortizes it across the pool.
- The rocksdb untracked write ids sit at +2.7% to +4.8% with heavily overlapping
  ranges (e.g. `delete_one_by_pk` base 13.7-17.6 µs, cand 11.1-16.3 µs), against
  slatedb equivalents at -1.9% to -3.1%. A first 9-rep pass had the rocksdb group
  at +4.6% to +12.4%; a genuine cause was found and fixed in `2bbd5ea54` (write
  sessions are built per statement, and installing the execution slots by
  rebuilding an already-built session cost one registry deep copy on each), after
  which the group moved to the numbers above.
- Under the OLTP > version control > bytes > OLAP ranking, a 13-22% cut on the
  dominant OLTP read shapes on both backends, with version control flat-to-better
  (`diff_commands` -6.5% to +1.9%) and bytes unchanged, is the intended trade.

# Not attempted

The successor note suggested declaring primary-key ordering on entity scans so
`EnforceSorting` deletes the `SortExec`, citing `providers/spec.rs:2156`. That line
is inside `#[cfg(test)] mod tests`: **no production surface declares an output
ordering** - every `PlannedScan` in `providers/*.rs` sets `ordering: None`. And
declaring one is not free today. `SpecScanExec::new` sets
`preserve_fragment_boundaries = planned.ordering.is_some()`, which makes the output
partition count the source fragment count instead of collapsing to
`target_partitions` (1), and the equivalence it declares only proves each fragment
is sorted, not that fragments are non-overlapping. `EnforceSorting` would therefore
replace the `SortExec` with a `SortPreservingMergeExec` over N partitions rather
than delete it. Getting the win requires the storage scan to first guarantee and
expose cross-fragment key disjointness.

Full gate on `hetzner-cpx62-III` against `2bbd5ea54`: `cargo check --workspace`
(exit 0), `cargo clippy --workspace --all-targets --all-features -- -D warnings`
(exit 0), `cargo test -p lix` (2031 + 450 + 18 tests, 0 failures).

Changenote: `.changenotes/reuse-sql-sessions-across-statements.md` (patch).
