### PR TITLE
perf(json-store): measure whether delta encoding pays for the JSON store

### DIFF
--- a/packages/engine-benchmarks/Cargo.toml
+++ b/packages/engine-benchmarks/Cargo.toml
@@ -81,6 +81,11 @@ path = "examples/duplicate_audit.rs"
 required-features = ["storage-benches", "slatedb"]
 
 [[example]]
+name = "expu_json_delta"
+path = "examples/expu_json_delta.rs"
+required-features = ["storage-benches", "slatedb"]
+
+[[example]]
 name = "revision_pack_oracle"
 path = "examples/revision_pack_oracle.rs"
 required-features = ["storage-benches", "slatedb"]

--- a/packages/engine-benchmarks/examples/expu_json_delta.rs
+++ b/packages/engine-benchmarks/examples/expu_json_delta.rs
@@ -1,0 +1,1114 @@
+//! Does delta encoding pay for the content-addressed JSON store?
+//!
+//! `duplicate_audit` established that `json_store.json` is full of *near*
+//! duplicates: distinct payloads that agree with a neighbour outside a narrow
+//! byte window. Near-duplication is a suggestive shape, not a case. The case
+//! needs three numbers the auditor cannot produce:
+//!
+//! 1. **Edit size relative to payload size.** A delta only pays when the
+//!    changed span is a small fraction of the document. The auditor probes
+//!    fixed 8/16/32/64-byte windows against the *stored* (already compressed)
+//!    bytes, so a "64-byte prefix" on a 181-byte compressed row is a third of
+//!    the row, not a rounding error.
+//! 2. **How much of that near-duplication zstd already captured.** Every
+//!    payload is individually zstd-compressed at level 1 today. A delta only
+//!    earns the bytes zstd left on the table.
+//! 3. **What a delta base costs to reach.** A payload's natural base is the
+//!    previous version of the same entity, which is a different content
+//!    address in the same space.
+//!
+//! Modes:
+//! ```text
+//! expu_json_delta build  <corpus> <dir> <writelog>  # seed via the real SQL commit path
+//! expu_json_delta oracle <writelog>                 # delta/dictionary/zstd accounting
+//! expu_json_delta store  <dir>                      # decode the settled JSON space
+//! expu_json_delta readcost <dir>                    # point-read cost versus chain depth
+//! ```
+//!
+//! Every corpus is seeded through `SessionContext` SQL, so the write log is
+//! exactly the payload stream an ordinary commit stages. The oracle never
+//! touches engine internals: it replays the store's own encoder rule
+//! (`>= 512` bytes, zstd level 1, keep raw unless it saves `>= 128` bytes,
+//! plus a 20-byte envelope) so "bytes today" is the real stored size.
+
+#![allow(clippy::large_futures)]
+
+use std::collections::{BTreeMap, HashMap, HashSet};
+use std::io::{Read, Write};
+use std::path::{Path, PathBuf};
+
+use lix::integration::{Engine, SessionContext};
+use lix::storage::Storage;
+use lix::storage_adapter::{
+    PointReadPlan, StorageAdapter, StorageGetOptions, StorageKey, StorageReadOptions,
+};
+use lix::storage_bench::{space_inventory, storage_space_by_name};
+use lix::Value;
+use lix_storage_slatedb::SlateDB;
+
+/// Mirrors `json_store::store`: magic + codec byte + u64 uncompressed length.
+const STORED_JSON_MAGIC: &[u8] = b"lix-json:v1";
+const STORED_JSON_HEADER_LEN: usize = STORED_JSON_MAGIC.len() + 1 + 8;
+/// Mirrors `json_store::store::ZSTD_MIN_JSON_BYTES`.
+const ZSTD_MIN_JSON_BYTES: usize = 512;
+/// Mirrors `json_store::store::MIN_ZSTD_SAVINGS_BYTES`.
+const MIN_ZSTD_SAVINGS_BYTES: usize = 128;
+/// Mirrors `json_store::types::JSON_INLINE_MAX_BYTES`.
+const JSON_INLINE_MAX_BYTES: usize = 1024;
+/// Mirrors the store's compression level.
+const ZSTD_LEVEL: i32 = 1;
+/// A delta row must name its base. One content address, 32 bytes.
+const DELTA_BASE_REF_BYTES: usize = 32;
+
+fn main() {
+    let args = std::env::args().collect::<Vec<_>>();
+    let usage =
+        "usage: expu_json_delta (build <corpus> <dir> <writelog> | oracle <writelog> | store <dir>)";
+    let mode = args.get(1).map(String::as_str).expect(usage);
+    match mode {
+        "build" => {
+            let corpus = args.get(2).map(String::as_str).expect(usage);
+            let dir = PathBuf::from(args.get(3).expect(usage));
+            let log = PathBuf::from(args.get(4).expect(usage));
+            let runtime = tokio::runtime::Builder::new_multi_thread()
+                .worker_threads(4)
+                .enable_all()
+                .build()
+                .expect("build runtime");
+            runtime.block_on(build(corpus, &dir, &log));
+        }
+        "oracle" => oracle(&PathBuf::from(args.get(2).expect(usage))),
+        "store" => {
+            let runtime = tokio::runtime::Builder::new_multi_thread()
+                .worker_threads(4)
+                .enable_all()
+                .build()
+                .expect("build runtime");
+            runtime.block_on(store_report(&PathBuf::from(args.get(2).expect(usage))));
+        }
+        "readcost" => {
+            let runtime = tokio::runtime::Builder::new_multi_thread()
+                .worker_threads(4)
+                .enable_all()
+                .build()
+                .expect("build runtime");
+            runtime.block_on(read_cost(&PathBuf::from(args.get(2).expect(usage))));
+        }
+        other => panic!("unknown mode '{other}'; {usage}"),
+    }
+}
+
+fn env_usize(name: &str, default: usize) -> usize {
+    std::env::var(name)
+        .ok()
+        .and_then(|value| value.parse().ok())
+        .filter(|value| *value > 0)
+        .unwrap_or(default)
+}
+
+// ---------------------------------------------------------------------------
+// Write log: the exact (entity, payload) stream the commit path staged.
+// ---------------------------------------------------------------------------
+
+struct WriteLog {
+    file: std::io::BufWriter<std::fs::File>,
+}
+
+impl WriteLog {
+    fn create(path: &Path) -> Self {
+        Self {
+            file: std::io::BufWriter::new(
+                std::fs::File::create(path).expect("create expU write log"),
+            ),
+        }
+    }
+
+    fn push(&mut self, entity: &str, json: &str) {
+        let entity = entity.as_bytes();
+        let json = json.as_bytes();
+        self.file
+            .write_all(&(entity.len() as u32).to_le_bytes())
+            .expect("write entity length");
+        self.file.write_all(entity).expect("write entity");
+        self.file
+            .write_all(&(json.len() as u32).to_le_bytes())
+            .expect("write payload length");
+        self.file.write_all(json).expect("write payload");
+    }
+
+    fn finish(mut self) {
+        self.file.flush().expect("flush expU write log");
+    }
+}
+
+fn read_write_log(path: &Path) -> Vec<(String, Vec<u8>)> {
+    let mut file =
+        std::io::BufReader::new(std::fs::File::open(path).expect("open expU write log"));
+    let mut entries = Vec::new();
+    let mut length = [0_u8; 4];
+    loop {
+        match file.read_exact(&mut length) {
+            Ok(()) => {}
+            Err(error) if error.kind() == std::io::ErrorKind::UnexpectedEof => break,
+            Err(error) => panic!("read expU write log: {error}"),
+        }
+        let mut entity = vec![0_u8; u32::from_le_bytes(length) as usize];
+        file.read_exact(&mut entity).expect("read entity");
+        file.read_exact(&mut length).expect("read payload length");
+        let mut json = vec![0_u8; u32::from_le_bytes(length) as usize];
+        file.read_exact(&mut json).expect("read payload");
+        entries.push((String::from_utf8(entity).expect("utf8 entity"), json));
+    }
+    entries
+}
+
+// ---------------------------------------------------------------------------
+// Corpora
+// ---------------------------------------------------------------------------
+
+/// A structured document with a realistic edit surface.
+///
+/// `blocks` dominates the byte count, so a one-block edit is the JSON analogue
+/// of "the user typed a sentence". `version`/`updated_at` sit in the header,
+/// which is what makes the *leading* bytes differ on every single edit even
+/// when the body is untouched — exactly the prefix-64 shape the auditor saw.
+struct DocShape {
+    blocks: usize,
+    block_bytes: usize,
+}
+
+impl DocShape {
+    /// Renders a document from its per-block revision vector.
+    ///
+    /// Edits *accumulate*: a block keeps the text it was last given. Two
+    /// consecutive versions therefore differ in exactly the block that was
+    /// edited plus the header, which is what makes the measured edit span an
+    /// honest number rather than the envelope of two unrelated changes.
+    fn document(&self, doc: usize, version: usize, block_revisions: &[usize]) -> String {
+        let mut out = String::with_capacity(self.blocks * (self.block_bytes + 64) + 256);
+        out.push_str(&format!(
+            r#"{{"id":"doc-{doc:06}","schema":"expu/document/v1","version":{version},"updated_at":"2026-08-{:02}T{:02}:{:02}:00Z","author":{{"id":"user-{:04}","name":"Contributor {:04}"}},"tags":["draft","review","expu"],"blocks":["#,
+            (version % 28) + 1,
+            version % 24,
+            version % 60,
+            doc % 64,
+            doc % 64,
+        ));
+        for (block, revision) in block_revisions.iter().enumerate() {
+            if block > 0 {
+                out.push(',');
+            }
+            out.push_str(&format!(
+                r#"{{"id":"blk-{block:04}","type":"paragraph","text":"{}"}}"#,
+                block_text(doc, block, *revision, self.block_bytes),
+            ));
+        }
+        out.push_str(r#"],"meta":{"words":1234,"locale":"en-US","status":"active"}}"#);
+        out
+    }
+}
+
+/// Deterministic prose-shaped filler. Word-like tokens keep zstd's literal and
+/// match distribution close to real text instead of a single long run.
+fn block_text(doc: usize, block: usize, revision: usize, bytes: usize) -> String {
+    const WORDS: [&str; 16] = [
+        "the", "quick", "brown", "fox", "jumps", "over", "lazy", "dog", "storage", "layout",
+        "commit", "payload", "version", "delta", "content", "address",
+    ];
+    let mut state = ((doc as u64) << 32 | (block as u64) << 16 | revision as u64)
+        .wrapping_mul(0x9E37_79B9_7F4A_7C15)
+        | 1;
+    let mut out = String::with_capacity(bytes + 16);
+    while out.len() < bytes {
+        state ^= state << 13;
+        state ^= state >> 7;
+        state ^= state << 17;
+        if !out.is_empty() {
+            out.push(' ');
+        }
+        out.push_str(WORDS[(state % WORDS.len() as u64) as usize]);
+    }
+    out.truncate(bytes);
+    out
+}
+
+async fn build(corpus: &str, dir: &Path, log_path: &Path) {
+    assert!(
+        !dir.exists(),
+        "refusing to seed into an existing directory: {}",
+        dir.display()
+    );
+    let storage = SlateDB::open(dir).expect("open SlateDB corpus");
+    Engine::initialize(storage.clone())
+        .await
+        .expect("initialize corpus repository");
+    let engine = Engine::new(storage.clone())
+        .await
+        .expect("open corpus engine");
+    let session = engine
+        .open_workspace_session()
+        .await
+        .expect("open corpus workspace");
+    let mut log = WriteLog::create(log_path);
+
+    match corpus {
+        // Many documents, each edited many times, one block per edit. This is
+        // the shape a delta encoder is supposed to win on.
+        "doc_edits" | "doc_small" | "doc_large" | "doc_scattered" | "doc_header_only" => {
+            let shape = match corpus {
+                "doc_small" => DocShape {
+                    blocks: env_usize("LIX_EXPU_BLOCKS", 6),
+                    block_bytes: env_usize("LIX_EXPU_BLOCK_BYTES", 180),
+                },
+                "doc_large" => DocShape {
+                    blocks: env_usize("LIX_EXPU_BLOCKS", 200),
+                    block_bytes: env_usize("LIX_EXPU_BLOCK_BYTES", 400),
+                },
+                _ => DocShape {
+                    blocks: env_usize("LIX_EXPU_BLOCKS", 40),
+                    block_bytes: env_usize("LIX_EXPU_BLOCK_BYTES", 220),
+                },
+            };
+            register_document_schema(&session).await;
+            let docs = env_usize("LIX_EXPU_DOCS", 400);
+            let rounds = env_usize("LIX_EXPU_ROUNDS", 25);
+            let commit_rows = env_usize("LIX_EXPU_COMMIT_ROWS", 200);
+            let mut revisions = vec![vec![0_usize; shape.blocks]; docs];
+            seed_documents(&session, &shape, &revisions, commit_rows, &mut log).await;
+            edit_documents(
+                &session,
+                &shape,
+                corpus,
+                &mut revisions,
+                rounds,
+                commit_rows,
+                &mut log,
+            )
+            .await;
+        }
+        // The built-in key/value plugin schema: a plugin-driven shape whose
+        // payloads straddle the 1 KiB inline threshold.
+        // `kv_rewrite` replaces the whole value body on every edit: the
+        // negative control that shows what the oracle reports when there is no
+        // delta to find.
+        "kv" | "kv_rewrite" => {
+            let keys = env_usize("LIX_EXPU_DOCS", 2_000);
+            let rounds = env_usize("LIX_EXPU_ROUNDS", 10);
+            let value_bytes = env_usize("LIX_EXPU_BLOCK_BYTES", 4_096);
+            let rewrite = corpus == "kv_rewrite";
+            seed_key_values(&session, keys, value_bytes, rewrite, &mut log).await;
+            edit_key_values(&session, keys, rounds, value_bytes, rewrite, &mut log).await;
+        }
+        other => panic!("unknown corpus '{other}'"),
+    }
+
+    log.finish();
+    drop(session);
+    drop(engine);
+    storage.flush().await.expect("flush SlateDB WAL");
+    storage
+        .flush_memtable_for_diagnostics()
+        .await
+        .expect("flush SlateDB memtable");
+    drop(storage);
+    println!("BUILT\tcorpus={corpus}\tdir={}", dir.display());
+}
+
+async fn register_document_schema<S>(session: &SessionContext<S>)
+where
+    S: Storage + Clone + Send + Sync + 'static,
+{
+    let schema = serde_json::json!({
+        "x-lix-key": "expu_document",
+        "x-lix-primary-key": ["/path"],
+        "type": "object",
+        "required": ["path", "doc"],
+        "properties": {
+            "path": { "type": "string" },
+            "doc": { "type": ["object", "array", "string", "number", "boolean", "null"] }
+        },
+        "additionalProperties": false
+    });
+    session
+        .execute(
+            "INSERT INTO lix_registered_schema (value, lixcol_global, lixcol_untracked) \
+             VALUES (lix_json($1), false, false)",
+            &[Value::Text(schema.to_string())],
+        )
+        .await
+        .expect("register expU document schema");
+}
+
+async fn seed_documents<S>(
+    session: &SessionContext<S>,
+    shape: &DocShape,
+    revisions: &[Vec<usize>],
+    commit_rows: usize,
+    log: &mut WriteLog,
+) where
+    S: Storage + Clone + Send + Sync + 'static,
+{
+    let docs = revisions.len();
+    let mut index = 0;
+    while index < docs {
+        let end = (index + commit_rows).min(docs);
+        let mut transaction = session.begin_transaction().await.expect("begin seed");
+        while index < end {
+            let path = format!("/doc/{index:06}");
+            let document = shape.document(index, 0, &revisions[index]);
+            transaction
+                .execute(
+                    "INSERT INTO expu_document (path, doc) VALUES ($1, lix_json($2))",
+                    &[Value::Text(path.clone()), Value::Text(document.clone())],
+                )
+                .await
+                .expect("stage seed document");
+            log.push(&path, &document);
+            index += 1;
+        }
+        transaction.commit().await.expect("commit seed batch");
+    }
+}
+
+async fn edit_documents<S>(
+    session: &SessionContext<S>,
+    shape: &DocShape,
+    corpus: &str,
+    revisions: &mut [Vec<usize>],
+    rounds: usize,
+    commit_rows: usize,
+    log: &mut WriteLog,
+) where
+    S: Storage + Clone + Send + Sync + 'static,
+{
+    let docs = revisions.len();
+    for round in 1..=rounds {
+        let mut index = 0;
+        while index < docs {
+            let end = (index + commit_rows).min(docs);
+            let mut transaction = session.begin_transaction().await.expect("begin edit");
+            while index < end {
+                // `doc_header_only` bumps only the header fields, the pure
+                // "leading bytes differ" case. Everything else also rewrites
+                // one body block, the realistic single-field edit.
+                if corpus != "doc_header_only" {
+                    let block = (round * 7 + index) % shape.blocks;
+                    revisions[index][block] = round;
+                }
+                let path = format!("/doc/{index:06}");
+                let document = shape.document(index, round, &revisions[index]);
+                transaction
+                    .execute(
+                        "UPDATE expu_document SET doc = lix_json($2) WHERE path = $1",
+                        &[Value::Text(path.clone()), Value::Text(document.clone())],
+                    )
+                    .await
+                    .expect("stage document edit");
+                log.push(&path, &document);
+                index += 1;
+            }
+            transaction.commit().await.expect("commit edit batch");
+        }
+    }
+}
+
+fn key_value_payload(key: usize, revision: usize, bytes: usize, rewrite: bool) -> String {
+    const STATUS: [&str; 4] = ["active", "paused", "draining", "retired"];
+    serde_json::json!({
+        "revision": revision,
+        "owner": format!("service-{:03}", key % 32),
+        "status": STATUS[revision % STATUS.len()],
+        "payload": block_text(key, 0, if rewrite { revision } else { 0 }, bytes),
+    })
+    .to_string()
+}
+
+async fn seed_key_values<S>(
+    session: &SessionContext<S>,
+    keys: usize,
+    value_bytes: usize,
+    rewrite: bool,
+    log: &mut WriteLog,
+) where
+    S: Storage + Clone + Send + Sync + 'static,
+{
+    let mut transaction = session.begin_transaction().await.expect("begin kv seed");
+    for key in 0..keys {
+        let name = format!("expu_key_{key:06}");
+        let payload = key_value_payload(key, 0, value_bytes, rewrite);
+        transaction
+            .execute(
+                "INSERT INTO lix_key_value (key, value) VALUES ($1, lix_json($2))",
+                &[Value::Text(name.clone()), Value::Text(payload.clone())],
+            )
+            .await
+            .expect("stage kv seed");
+        log.push(&name, &payload);
+        if key % 500 == 499 {
+            transaction.commit().await.expect("commit kv seed batch");
+            transaction = session.begin_transaction().await.expect("begin kv seed");
+        }
+    }
+    transaction.commit().await.expect("commit kv seed tail");
+}
+
+async fn edit_key_values<S>(
+    session: &SessionContext<S>,
+    keys: usize,
+    rounds: usize,
+    value_bytes: usize,
+    rewrite: bool,
+    log: &mut WriteLog,
+) where
+    S: Storage + Clone + Send + Sync + 'static,
+{
+    for round in 1..=rounds {
+        let mut transaction = session.begin_transaction().await.expect("begin kv edit");
+        for key in 0..keys {
+            let name = format!("expu_key_{key:06}");
+            let payload = key_value_payload(key, round, value_bytes, rewrite);
+            transaction
+                .execute(
+                    "UPDATE lix_key_value SET value = lix_json($2) WHERE key = $1",
+                    &[Value::Text(name.clone()), Value::Text(payload.clone())],
+                )
+                .await
+                .expect("stage kv edit");
+            log.push(&name, &payload);
+            if key % 500 == 499 {
+                transaction.commit().await.expect("commit kv edit batch");
+                transaction = session.begin_transaction().await.expect("begin kv edit");
+            }
+        }
+        transaction.commit().await.expect("commit kv edit tail");
+    }
+}
+
+// ---------------------------------------------------------------------------
+// The store's own encoder rule, replayed offline.
+// ---------------------------------------------------------------------------
+
+fn zstd_compress(level: i32, data: &[u8]) -> Vec<u8> {
+    zstd::bulk::compress(data, level).expect("zstd compress")
+}
+
+/// Exactly what `StoredJsonBatchEncoder::append_json_with_ref` produces today,
+/// parameterized by compression level so a "just raise the level" arm can be
+/// priced against a delta scheme without changing anything else.
+fn stored_len_at_level(raw: &[u8], level: i32) -> usize {
+    let selected = if raw.len() >= ZSTD_MIN_JSON_BYTES {
+        let compressed = zstd_compress(level, raw);
+        if raw.len().saturating_sub(compressed.len()) >= MIN_ZSTD_SAVINGS_BYTES {
+            compressed.len()
+        } else {
+            raw.len()
+        }
+    } else {
+        raw.len()
+    };
+    STORED_JSON_HEADER_LEN + selected
+}
+
+fn stored_len_today(raw: &[u8]) -> usize {
+    stored_len_at_level(raw, ZSTD_LEVEL)
+}
+
+/// Decodes one settled `json_store.json` row back to its JSON text.
+///
+/// The envelope is replayed here rather than reached for through the engine so
+/// this tool stays a pure observer of the format it is measuring, exactly like
+/// `stored_len_at_level` replays the encoder side.
+fn decode_stored_json(value: &[u8]) -> Vec<u8> {
+    assert!(
+        value.len() >= STORED_JSON_HEADER_LEN && value.starts_with(STORED_JSON_MAGIC),
+        "stored JSON payload has an unexpected envelope"
+    );
+    let codec = value[STORED_JSON_MAGIC.len()];
+    let length_start = STORED_JSON_MAGIC.len() + 1;
+    let uncompressed_len = u64::from_be_bytes(
+        value[length_start..length_start + 8]
+            .try_into()
+            .expect("stored JSON length header is fixed size"),
+    ) as usize;
+    let payload = &value[length_start + 8..];
+    match codec {
+        0 => payload.to_vec(),
+        1 => zstd::bulk::decompress(payload, uncompressed_len).expect("decompress stored json"),
+        other => panic!("stored JSON payload has unknown codec byte {other}"),
+    }
+}
+
+/// Delta-encoded length: the same envelope, plus a base content address, with
+/// the frame produced against the base payload as a raw zstd dictionary. This
+/// is the `zstd --patch-from` model at the store's own compression level.
+fn stored_len_delta(raw: &[u8], base: &[u8]) -> usize {
+    let mut compressor =
+        zstd::bulk::Compressor::with_dictionary(ZSTD_LEVEL, base).expect("dictionary compressor");
+    let frame = compressor.compress(raw).expect("delta compress");
+    STORED_JSON_HEADER_LEN + DELTA_BASE_REF_BYTES + frame.len()
+}
+
+fn common_prefix(left: &[u8], right: &[u8]) -> usize {
+    left.iter().zip(right).take_while(|(a, b)| a == b).count()
+}
+
+fn common_suffix(left: &[u8], right: &[u8], skip: usize) -> usize {
+    left.iter()
+        .rev()
+        .zip(right.iter().rev())
+        .take(left.len().min(right.len()).saturating_sub(skip))
+        .take_while(|(a, b)| a == b)
+        .count()
+}
+
+fn percentile(sorted: &[f64], fraction: f64) -> f64 {
+    if sorted.is_empty() {
+        return 0.0;
+    }
+    let index = ((sorted.len() - 1) as f64 * fraction).round() as usize;
+    sorted[index]
+}
+
+fn percentile_u64(sorted: &[u64], fraction: f64) -> u64 {
+    if sorted.is_empty() {
+        return 0;
+    }
+    let index = ((sorted.len() - 1) as f64 * fraction).round() as usize;
+    sorted[index]
+}
+
+fn percent(part: u64, whole: u64) -> f64 {
+    if whole == 0 {
+        return 0.0;
+    }
+    100.0 * part as f64 / whole as f64
+}
+
+// ---------------------------------------------------------------------------
+// Oracle
+// ---------------------------------------------------------------------------
+
+fn oracle(log_path: &Path) {
+    let entries = read_write_log(log_path);
+
+    // Per entity, the ordered stream of *distinct* payloads. A repeat write of
+    // identical content is already free (content addressing), so it neither
+    // costs bytes nor extends a chain.
+    let mut order: Vec<String> = Vec::new();
+    let mut by_entity: HashMap<String, Vec<Vec<u8>>> = HashMap::new();
+    let mut stored_digests: HashSet<[u8; 32]> = HashSet::new();
+    let mut inline_writes = 0_u64;
+    let mut out_of_band_writes = 0_u64;
+    let mut raw_lengths: Vec<u64> = Vec::new();
+
+    for (entity, json) in &entries {
+        raw_lengths.push(json.len() as u64);
+        if json.len() <= JSON_INLINE_MAX_BYTES {
+            inline_writes += 1;
+            continue;
+        }
+        out_of_band_writes += 1;
+        if !stored_digests.insert(*blake3::hash(json).as_bytes()) {
+            continue;
+        }
+        let versions = by_entity.entry(entity.clone()).or_insert_with(|| {
+            order.push(entity.clone());
+            Vec::new()
+        });
+        versions.push(json.clone());
+    }
+
+    raw_lengths.sort_unstable();
+    println!(
+        "PAYLOAD\twrites={}\tinline_writes={inline_writes}\tout_of_band_writes={out_of_band_writes}\tdistinct_out_of_band={}\tentities={}\traw_p10={}\traw_p50={}\traw_p90={}\traw_max={}",
+        entries.len(),
+        stored_digests.len(),
+        by_entity.len(),
+        percentile_u64(&raw_lengths, 0.10),
+        percentile_u64(&raw_lengths, 0.50),
+        percentile_u64(&raw_lengths, 0.90),
+        raw_lengths.last().copied().unwrap_or_default(),
+    );
+
+    // Bounded-chain arms. `1` is "no delta at all" and the largest value is an
+    // unbounded chain; everything between is a periodic full snapshot.
+    let depths = [1_usize, 2, 4, 8, 16, usize::MAX];
+    let levels = [ZSTD_LEVEL, 3, 9, 19];
+
+    let mut raw_bytes = 0_u64;
+    let mut level_bytes = [0_u64; 4];
+    let mut delta_chain_bytes = 0_u64;
+    let mut delta_anchor_bytes = 0_u64;
+    let mut bounded_bytes = [0_u64; 6];
+    let mut edit_ratios: Vec<f64> = Vec::new();
+    let mut edit_spans: Vec<u64> = Vec::new();
+    let mut chain_lengths: Vec<u64> = Vec::new();
+    // Byte savings attributable only to the *successors*, so a corpus with one
+    // version per entity cannot flatter the delta arm.
+    let mut successor_today_bytes = 0_u64;
+    let mut successor_delta_bytes = 0_u64;
+    let mut successor_anchor_bytes = 0_u64;
+
+    for entity in &order {
+        let versions = &by_entity[entity];
+        chain_lengths.push(versions.len() as u64);
+        for (index, raw) in versions.iter().enumerate() {
+            raw_bytes += raw.len() as u64;
+            for (slot, level) in levels.iter().enumerate() {
+                level_bytes[slot] += stored_len_at_level(raw, *level) as u64;
+            }
+            let today = stored_len_today(raw) as u64;
+            if index == 0 {
+                delta_chain_bytes += today;
+                delta_anchor_bytes += today;
+                for slot in 0..depths.len() {
+                    bounded_bytes[slot] += today;
+                }
+                continue;
+            }
+            let base = &versions[index - 1];
+            let delta = stored_len_delta(raw, base) as u64;
+            // The anchor arm always deltas against version 0, so every payload
+            // is reachable in exactly one extra read regardless of history
+            // depth. It trades some compression for a hard depth bound of 1.
+            let anchor = stored_len_delta(raw, &versions[0]) as u64;
+            delta_chain_bytes += delta;
+            delta_anchor_bytes += anchor;
+            successor_today_bytes += today;
+            successor_delta_bytes += delta;
+            successor_anchor_bytes += anchor;
+            for (slot, depth) in depths.iter().enumerate() {
+                bounded_bytes[slot] += if *depth == 1 || index % depth == 0 {
+                    today
+                } else {
+                    delta
+                };
+            }
+
+            let prefix = common_prefix(raw, base);
+            let suffix = common_suffix(raw, base, prefix);
+            let span = raw.len().saturating_sub(prefix + suffix) as u64;
+            edit_spans.push(span);
+            edit_ratios.push(span as f64 / raw.len() as f64);
+        }
+    }
+
+    edit_ratios.sort_by(|a, b| a.partial_cmp(b).expect("finite ratio"));
+    edit_spans.sort_unstable();
+    chain_lengths.sort_unstable();
+    let today_bytes = level_bytes[0];
+
+    println!(
+        "EDIT_SPAN\tpairs={}\tspan_p10={}\tspan_p50={}\tspan_p90={}\tspan_p99={}\tratio_p10={:.4}\tratio_p50={:.4}\tratio_p90={:.4}\tratio_p99={:.4}",
+        edit_spans.len(),
+        percentile_u64(&edit_spans, 0.10),
+        percentile_u64(&edit_spans, 0.50),
+        percentile_u64(&edit_spans, 0.90),
+        percentile_u64(&edit_spans, 0.99),
+        percentile(&edit_ratios, 0.10),
+        percentile(&edit_ratios, 0.50),
+        percentile(&edit_ratios, 0.90),
+        percentile(&edit_ratios, 0.99),
+    );
+    println!(
+        "CHAIN\tentities={}\tlen_p50={}\tlen_p90={}\tlen_max={}",
+        chain_lengths.len(),
+        percentile_u64(&chain_lengths, 0.50),
+        percentile_u64(&chain_lengths, 0.90),
+        chain_lengths.last().copied().unwrap_or_default(),
+    );
+
+    // A single shared dictionary trained on the corpus: the delta idea without
+    // per-payload bases, chains, or a base-liveness rule.
+    let samples = order
+        .iter()
+        .flat_map(|entity| by_entity[entity].iter())
+        .take(env_usize("LIX_EXPU_DICT_SAMPLES", 512))
+        .map(Vec::as_slice)
+        .collect::<Vec<_>>();
+    let dictionary_bytes = env_usize("LIX_EXPU_DICT_BYTES", 110 * 1024);
+    let dictionary = zstd::dict::from_samples(&samples, dictionary_bytes).ok();
+    let mut dictionary_total = 0_u64;
+    if let Some(dictionary) = dictionary.as_ref() {
+        let mut compressor = zstd::bulk::Compressor::with_dictionary(ZSTD_LEVEL, dictionary)
+            .expect("dictionary compressor");
+        for entity in &order {
+            for raw in &by_entity[entity] {
+                let frame = compressor.compress(raw).expect("dictionary compress");
+                dictionary_total += (STORED_JSON_HEADER_LEN + frame.len()) as u64;
+            }
+        }
+        dictionary_total += dictionary.len() as u64;
+    }
+
+    println!(
+        "BYTES\traw={raw_bytes}\ttoday={today_bytes}\tzstd_capture_pct={:.2}\tdelta_chain={delta_chain_bytes}\tdelta_chain_saving_pct={:.2}\tdelta_anchor={delta_anchor_bytes}\tdelta_anchor_saving_pct={:.2}\tshared_dictionary={dictionary_total}\tdictionary_saving_pct={:.2}",
+        percent(raw_bytes.saturating_sub(today_bytes), raw_bytes),
+        percent(today_bytes.saturating_sub(delta_chain_bytes), today_bytes),
+        percent(today_bytes.saturating_sub(delta_anchor_bytes), today_bytes),
+        percent(today_bytes.saturating_sub(dictionary_total), today_bytes),
+    );
+    // The cheap alternative: keep every payload independent and only raise the
+    // compression level. No base, no chain, no GC edge, no read amplification.
+    for (slot, level) in levels.iter().enumerate() {
+        println!(
+            "LEVEL\tzstd_level={level}\tbytes={}\tsaving_vs_today_pct={:.2}",
+            level_bytes[slot],
+            percent(today_bytes.saturating_sub(level_bytes[slot]), today_bytes),
+        );
+    }
+    for (slot, depth) in depths.iter().enumerate() {
+        let label = if *depth == usize::MAX {
+            "unbounded".to_owned()
+        } else {
+            depth.to_string()
+        };
+        println!(
+            "DEPTH\tsnapshot_every={label}\tbytes={}\tsaving_vs_today_pct={:.2}",
+            bounded_bytes[slot],
+            percent(
+                today_bytes.saturating_sub(bounded_bytes[slot]),
+                today_bytes
+            ),
+        );
+    }
+    println!(
+        "BYTES_SUCCESSORS\ttoday={successor_today_bytes}\tdelta_chain={successor_delta_bytes}\tdelta_anchor={successor_anchor_bytes}\tchain_saving_pct={:.2}\tanchor_saving_pct={:.2}",
+        percent(
+            successor_today_bytes.saturating_sub(successor_delta_bytes),
+            successor_today_bytes
+        ),
+        percent(
+            successor_today_bytes.saturating_sub(successor_anchor_bytes),
+            successor_today_bytes
+        ),
+    );
+
+    encode_cost(&order, &by_entity, &levels);
+    reconstruction_latency(&order, &by_entity);
+}
+
+/// Write-path CPU of each encoding arm, per payload.
+///
+/// A delta encoder must build a fresh zstd dictionary context per row (the
+/// base differs every time), which is where its write cost comes from; a
+/// higher level pays in the compressor's own search effort instead.
+fn encode_cost(order: &[String], by_entity: &HashMap<String, Vec<Vec<u8>>>, levels: &[i32]) {
+    let samples = order
+        .iter()
+        .flat_map(|entity| {
+            let versions = &by_entity[entity];
+            versions
+                .iter()
+                .enumerate()
+                .skip(1)
+                .map(move |(index, raw)| (raw, &versions[index - 1]))
+        })
+        .take(env_usize("LIX_EXPU_ENCODE_SAMPLES", 2_000))
+        .collect::<Vec<_>>();
+    if samples.is_empty() {
+        return;
+    }
+    // Interleave the arms across reps. Running each arm once back to back makes
+    // whichever went first pay every cold-cache and page-fault cost, which is
+    // how "level 3 is cheaper than level 1" appears out of nowhere.
+    let reps = env_usize("LIX_EXPU_ENCODE_REPS", 9);
+    let mut timings = vec![Vec::with_capacity(reps); levels.len() + 1];
+    let mut sinks = vec![0_usize; levels.len() + 1];
+    for _ in 0..reps {
+        for (slot, level) in levels.iter().enumerate() {
+            let start = std::time::Instant::now();
+            let mut sink = 0_usize;
+            for (raw, _) in &samples {
+                sink += zstd_compress(*level, raw).len();
+            }
+            timings[slot].push(start.elapsed().as_nanos() as f64 / samples.len() as f64);
+            sinks[slot] = sink;
+        }
+        let start = std::time::Instant::now();
+        let mut sink = 0_usize;
+        for (raw, base) in &samples {
+            let mut compressor = zstd::bulk::Compressor::with_dictionary(ZSTD_LEVEL, base)
+                .expect("dictionary compressor");
+            sink += compressor.compress(raw).expect("delta compress").len();
+        }
+        timings[levels.len()].push(start.elapsed().as_nanos() as f64 / samples.len() as f64);
+        sinks[levels.len()] = sink;
+    }
+    for (slot, timing) in timings.iter_mut().enumerate() {
+        timing.sort_by(|a, b| a.partial_cmp(b).expect("finite"));
+        let arm = if slot == levels.len() {
+            "delta_level1".to_owned()
+        } else {
+            format!("level{}", levels[slot])
+        };
+        println!(
+            "ENCODE\tarm={arm}\treps={reps}\tns_median={:.0}\tns_p95={:.0}\tframe_bytes={}\tframe_bytes_per_payload={}",
+            percentile(timing, 0.5),
+            percentile(timing, 0.95),
+            sinks[slot],
+            sinks[slot] / samples.len(),
+        );
+    }
+}
+
+/// Read cost of reconstructing one payload at chain depth `d`.
+///
+/// A delta row cannot be decoded without its base, so a depth-`d` payload
+/// costs `d` sequential point reads plus `d` zstd frames. Storage latency is
+/// not modelled here; this isolates the CPU term, which is the floor.
+fn reconstruction_latency(order: &[String], by_entity: &HashMap<String, Vec<Vec<u8>>>) {
+    let Some(entity) = order.iter().find(|entity| by_entity[*entity].len() >= 9) else {
+        println!("RECONSTRUCT\tskipped=no_chain_of_depth_9");
+        return;
+    };
+    let versions = &by_entity[entity];
+    let max_depth = versions.len().min(env_usize("LIX_EXPU_MAX_DEPTH", 16));
+
+    // Encode the chain the way a delta store would hold it.
+    let base_full = zstd_compress(ZSTD_LEVEL, &versions[0]);
+    let mut frames = Vec::new();
+    for index in 1..max_depth {
+        let mut compressor =
+            zstd::bulk::Compressor::with_dictionary(ZSTD_LEVEL, &versions[index - 1])
+                .expect("dictionary compressor");
+        frames.push(compressor.compress(&versions[index]).expect("delta compress"));
+    }
+
+    let iterations = env_usize("LIX_EXPU_RECONSTRUCT_ITERS", 2_000);
+    let mut rows = BTreeMap::new();
+    for depth in 0..max_depth {
+        let start = std::time::Instant::now();
+        let mut sink = 0_usize;
+        for _ in 0..iterations {
+            let mut current =
+                zstd::bulk::decompress(&base_full, versions[0].len()).expect("decompress base");
+            for frame in frames.iter().take(depth) {
+                let mut decompressor = zstd::bulk::Decompressor::with_dictionary(&current)
+                    .expect("dictionary decompressor");
+                current = decompressor
+                    .decompress(frame, versions[0].len() * 2)
+                    .expect("decompress delta");
+            }
+            sink += current.len();
+        }
+        let elapsed = start.elapsed().as_nanos() as f64 / iterations as f64;
+        rows.insert(depth, (elapsed, sink));
+    }
+    for (depth, (nanos, _)) in rows {
+        println!("RECONSTRUCT\tdepth={depth}\tns_per_payload={nanos:.0}");
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Settled-store report
+// ---------------------------------------------------------------------------
+
+async fn store_report(dir: &Path) {
+    let storage = StorageAdapter::new(SlateDB::open(dir).expect("open SlateDB for report"));
+    let read = storage
+        .begin_read(StorageReadOptions::default())
+        .await
+        .expect("open report snapshot");
+
+    let inventory = space_inventory(&read, "json_store.json").await;
+    let mut raw_bytes = 0_u64;
+    let mut stored_bytes = 0_u64;
+    let mut zstd_rows = 0_u64;
+    let mut raw_rows = 0_u64;
+    let mut raw_payloads = Vec::with_capacity(inventory.len());
+    for (_, value) in &inventory {
+        stored_bytes += value.len() as u64;
+        if value.len() > 11 && value[11] == 1 {
+            zstd_rows += 1;
+        } else {
+            raw_rows += 1;
+        }
+        let json = decode_stored_json(value);
+        raw_bytes += json.len() as u64;
+        raw_payloads.push(json);
+    }
+
+    println!(
+        "JSON_STORE\trows={}\tstored_bytes={stored_bytes}\traw_bytes={raw_bytes}\tzstd_rows={zstd_rows}\traw_rows={raw_rows}\tzstd_capture_pct={:.2}",
+        inventory.len(),
+        percent(raw_bytes.saturating_sub(stored_bytes), raw_bytes),
+    );
+
+    // The same near-duplicate probe the auditor runs, but on the *logical*
+    // JSON and with widths expressed as a fraction of payload length. A fixed
+    // 64-byte window against a 181-byte compressed row is a third of the row;
+    // against a 4.6 KiB document it is 1.4%. Only the second is a delta case.
+    for fraction in [0.01_f64, 0.05, 0.25] {
+        let mut prefix_buckets: HashMap<[u8; 32], HashSet<[u8; 32]>> = HashMap::new();
+        let mut suffix_buckets: HashMap<[u8; 32], HashSet<[u8; 32]>> = HashMap::new();
+        for json in &raw_payloads {
+            let width = ((json.len() as f64) * fraction) as usize;
+            if width == 0 || json.len() <= width {
+                continue;
+            }
+            let digest = *blake3::hash(json).as_bytes();
+            prefix_buckets
+                .entry(*blake3::hash(&json[width..]).as_bytes())
+                .or_default()
+                .insert(digest);
+            suffix_buckets
+                .entry(*blake3::hash(&json[..json.len() - width]).as_bytes())
+                .or_default()
+                .insert(digest);
+        }
+        let near = |buckets: &HashMap<[u8; 32], HashSet<[u8; 32]>>| -> u64 {
+            buckets
+                .values()
+                .map(|digests| digests.len().saturating_sub(1) as u64)
+                .sum()
+        };
+        println!(
+            "NEAR_RELATIVE\tfraction={fraction:.2}\tprefix={}\tsuffix={}\tdistinct={}",
+            near(&prefix_buckets),
+            near(&suffix_buckets),
+            raw_payloads.len(),
+        );
+    }
+
+    let total_dir = directory_bytes(dir);
+    println!("PHYSICAL\tdirectory_bytes={total_dir}");
+}
+
+/// What a delta chain costs the OLTP read path, measured on the real store.
+///
+/// A delta row cannot name its base until it has been read, so resolving a
+/// depth-`d` payload is a **pointer chase**: `d + 1` sequential batched point
+/// reads, each waiting on the previous. The alternative — storing the whole
+/// base list in every delta row — collapses it to one wider batched read. Both
+/// are measured; neither is free, and the JSON space is keyed by digest, so
+/// every base lands in a different block from its dependant.
+async fn read_cost(dir: &Path) {
+    let storage = StorageAdapter::new(SlateDB::open(dir).expect("open SlateDB for read cost"));
+    let read = storage
+        .begin_read(StorageReadOptions::default())
+        .await
+        .expect("open read-cost snapshot");
+    let space = storage_space_by_name("json_store.json");
+    let keys = space_inventory(&read, "json_store.json")
+        .await
+        .into_iter()
+        .map(|(key, _)| StorageKey(bytes::Bytes::from(key)))
+        .collect::<Vec<_>>();
+    assert!(!keys.is_empty(), "json_store.json is empty");
+
+    let batch = env_usize("LIX_EXPU_READ_BATCH", 1_000).min(keys.len());
+    let reps = env_usize("LIX_EXPU_READ_REPS", 9);
+    let max_depth = env_usize("LIX_EXPU_MAX_DEPTH", 8);
+    // Deterministic strided sampling: a digest-keyed space has no locality to
+    // preserve, so a stride simply avoids re-reading one hot block.
+    let pick = |round: usize, rep: usize| -> Vec<StorageKey> {
+        let stride = 7919;
+        (0..batch)
+            .map(|index| {
+                keys[(index * stride + round * 104_729 + rep * 15_485_863) % keys.len()].clone()
+            })
+            .collect()
+    };
+
+    // Warm the block cache over the whole key space first. Without it the arm
+    // that runs second inherits the other arm's cache and the comparison is an
+    // artefact of ordering rather than of chain depth.
+    for chunk in keys.chunks(4_096) {
+        PointReadPlan::new(space, chunk)
+            .materialize(&read, StorageGetOptions::default())
+            .await
+            .expect("warm point read");
+    }
+
+    for depth in 0..=max_depth {
+        let mut chased = Vec::with_capacity(reps);
+        let mut widened = Vec::with_capacity(reps);
+        for rep in 0..reps {
+            let rounds = (0..=depth).map(|round| pick(round, rep)).collect::<Vec<_>>();
+            let wide = rounds.concat();
+            // Alternate which arm goes first so neither one systematically
+            // warms the other.
+            if rep % 2 == 1 {
+                widened.push(time_wide_read(&read, space, &wide, batch).await);
+                chased.push(time_chased_read(&read, space, &rounds, batch).await);
+            } else {
+                chased.push(time_chased_read(&read, space, &rounds, batch).await);
+                widened.push(time_wide_read(&read, space, &wide, batch).await);
+            }
+        }
+        chased.sort_by(|a, b| a.partial_cmp(b).expect("finite"));
+        widened.sort_by(|a, b| a.partial_cmp(b).expect("finite"));
+        println!(
+            "READCOST\tdepth={depth}\treps={reps}\tbatch={batch}\tchased_ns_median={:.0}\tchased_ns_p95={:.0}\twide_ns_median={:.0}\twide_ns_p95={:.0}",
+            percentile(&chased, 0.5),
+            percentile(&chased, 0.95),
+            percentile(&widened, 0.5),
+            percentile(&widened, 0.95),
+        );
+    }
+}
+
+/// `d + 1` dependent batched point reads: the pointer chase a delta row forces
+/// because it cannot name its base before it has itself been read.
+async fn time_chased_read<R>(
+    read: &R,
+    space: lix::storage_adapter::StorageSpace,
+    rounds: &[Vec<StorageKey>],
+    batch: usize,
+) -> f64
+where
+    R: lix::storage_adapter::StorageAdapterRead,
+{
+    let start = std::time::Instant::now();
+    let mut found = 0_usize;
+    for round in rounds {
+        let result = PointReadPlan::new(space, round)
+            .materialize(read, StorageGetOptions::default())
+            .await
+            .expect("point read");
+        found += result.value.iter().filter(|value| value.is_some()).count();
+    }
+    let elapsed = start.elapsed().as_nanos() as f64 / batch as f64;
+    assert!(found >= batch, "point reads should hit");
+    elapsed
+}
+
+/// One batched read of every base at once: the best case, available only if a
+/// delta row carries its whole base list instead of a single parent link.
+async fn time_wide_read<R>(
+    read: &R,
+    space: lix::storage_adapter::StorageSpace,
+    wide: &[StorageKey],
+    batch: usize,
+) -> f64
+where
+    R: lix::storage_adapter::StorageAdapterRead,
+{
+    let start = std::time::Instant::now();
+    let result = PointReadPlan::new(space, wide)
+        .materialize(read, StorageGetOptions::default())
+        .await
+        .expect("wide point read");
+    let elapsed = start.elapsed().as_nanos() as f64 / batch as f64;
+    assert!(!result.value.is_empty());
+    elapsed
+}
+
+fn directory_bytes(path: &Path) -> u64 {
+    std::fs::read_dir(path).map_or(0, |entries| {
+        entries
+            .flatten()
+            .map(|entry| {
+                let path = entry.path();
+                entry.metadata().map_or(0, |metadata| {
+                    if metadata.is_dir() {
+                        directory_bytes(&path)
+                    } else {
+                        metadata.len()
+                    }
+                })
+            })
+            .sum()
+    })
+}

--- a/packages/lix/src/storage_bench.rs
+++ b/packages/lix/src/storage_bench.rs
@@ -2488,6 +2488,18 @@ fn collect_binary_cas_json_owners(
     }
 }
 
+/// One registered storage space, looked up by its registry name.
+///
+/// Tools that issue their own point reads need the physical space without
+/// re-declaring its id, which would be a second authority for the registry.
+#[must_use]
+pub fn storage_space_by_name(space_name: &str) -> crate::storage_adapter::StorageSpace {
+    *native_storage_spaces()
+        .iter()
+        .find(|space| space.name == space_name)
+        .expect("space name should exist")
+}
+
 /// Per-row (key, value bytes) inventory of one space.
 ///
 /// Equivalence tests compare these inventories byte-for-byte, so the scan
@@ -2496,10 +2508,7 @@ pub async fn space_inventory<R>(read: &R, space_name: &str) -> Vec<(Vec<u8>, Vec
 where
     R: StorageAdapterRead,
 {
-    let space = *native_storage_spaces()
-        .iter()
-        .find(|space| space.name == space_name)
-        .expect("space name should exist");
+    let space = storage_space_by_name(space_name);
     scan_layout_entries(read, space)
         .await
         .iter()


### PR DESCRIPTION
## Verdict: the byte opportunity is real and large; delta encoding is rejected on read cost

`duplicate_audit` (#1308) found that 9,793 of 10,003 distinct `json_store.json` payloads on the
`bigjson` corpus "differ from a neighbour only in their leading 64 bytes". This experiment set out
to decide whether that justifies delta-encoding the JSON store. It does not — but not for the reason
I expected, and the measurement produced a methodological correction to the auditor itself.

**Nothing in the engine's behaviour changes here.** This PR adds a measurement-only example plus one
`storage-benches`-gated helper.

---

## 1. The auditor's near-duplicate probe is not a delta detector

The probe hashes `value[width..]` for fixed widths 8/16/32/64 against the **stored** bytes, which are
already zstd-compressed. On `bigjson` the mean stored row is **181 bytes**, so a "64-byte prefix" is
**35% of the row**, not a rounding error. Re-running the same probe on the *decoded* JSON with widths
expressed as a fraction of payload length:

| corpus | mean raw payload | auditor `prefix64` (stored) | raw `prefix@1%` | raw `prefix@5%` | raw `suffix@1%` | raw `suffix@5%` |
|---|---|---|---|---|---|---|
| `bigjson` | 4,628 B | **9,793 / 10,003** | 0 | 9,996 | 0 | 0 |
| `doc_edits` | 10,931 B | **0** (probe silent) | 0 | 0 | 0 | 250 |
| `doc_header_only` | 10,931 B | — | 0 | 0 | 9,600 | 10,000 |
| `kv` | 4,163 B | — | 0 | 0 | 16,000 | 16,000 |
| `kv_rewrite` (control) | 4,163 B | — | 0 | 0 | 0 | 0 |

The probe **overstates** on `bigjson` (the real prefix difference is 1–5% of the document, not 64 B of
4.6 KiB) and **misses entirely** on `doc_edits`, where it reports no near-duplicates at all across
10,403 rows / 25.7 MB — yet a delta oracle recovers **87%** of those bytes. The redundancy there is
*interior*, and an edge-window probe cannot see it. Suggest widths become a fraction of payload length
and run against decoded payloads.

## 2. zstd already captures most of it

Every payload is individually zstd level-1 compressed today. Decoding the settled stores:

| corpus | raw JSON | stored | **zstd already captures** |
|---|---|---|---|
| `bigjson` | 46,296,942 | 1,810,890 | **96.09%** |
| `doc_large` (89 KiB docs) | 98,655,052 | 19,385,137 | 80.35% |
| `doc_edits` (10.9 KiB docs) | 113,988,052 | 25,898,562 | 77.28% |
| `kv` (4.1 KiB values) | 92,360,052 | 23,704,031 | 74.34% |
| `doc_small` (1.6 KiB docs) | 36,112,052 | 13,780,248 | 61.84% |

The headline "1,810,890 bytes of near-duplicate waste" is what remains after zstd already removed
**96%** of a 46 MB logical corpus.

## 3. Edit size relative to payload size

`span` is the prefix/suffix envelope, which overstates whenever a header field *and* a body field
change (the envelope then spans everything between them). The delta frame size is the ground truth.

| corpus | payload p50 | span ratio p10 / p50 / p90 | delta frame ÷ independent frame |
|---|---|---|---|
| `doc_header_only` | 10,931 B | 0.0029 / 0.0029 / 0.0029 | **1.4%** |
| `kv` | 4,163 B | 0.0043 / 0.0046 / 0.0048 | **3.0%** |
| `doc_edits` | 10,931 B | 0.134 / 0.525 / 0.892 | **7.6%** |
| `doc_deep` | 10,931 B | 0.134 / 0.525 / 0.892 | 7.5% |
| `doc_small` | 1,612 B | 0.223 / 0.637 / 0.927 | 20.9% |
| `doc_large` | 89,650 B | 0.211 / 0.445 / 0.680 | 29.7% |
| `kv_rewrite` (control) | 4,163 B | 0.991 | 88.2% |

The control behaves: when the edit *is* the document, the oracle reports no win (7.7%).

## 4. Share of settled bytes — bimodal on the 1 KiB inline threshold

`JSON_INLINE_MAX_BYTES = 1024`. Payloads at or under it never reach the store.

| corpus | payload | `json_store.json` value bytes | total value bytes | **share** | share of physical dir |
|---|---|---|---|---|---|
| `plain` (127 B rows) | inline | 3,233 | 3,350,314 | **0.10%** | 0.33% |
| `edits` (127 B rows, 20 edit rounds) | inline | 3,233 | 3,549,194 | **0.09%** | 0.26% |
| `bigjson` | 4.6 KiB | 1,810,890 | 3,681,779 | **49.2%** | 86.8% |
| `doc_edits` | 10.9 KiB | 25,898,562 | 26,502,325 | **97.7%** | 92.6% |

There is no middle. Row-shaped workspaces put ~0.1% of their bytes in this plane; document-shaped
workspaces put nearly all of them there. History depth does not change the share (`doc_edits` at 26
versions/entity and `doc_deep` at 101 both sit at ~97%) — it scales both numerator and denominator.

## 5. Delta savings, and what they cost on the read path

Savings are **on top of** today's per-payload zstd, as a share of stored `json_store.json` bytes.
`snapshot_every=d` means every d-th version is a full payload, bounding reconstruction depth at `d-1`.

| corpus | d=2 | d=4 | d=8 | d=16 | unbounded | anchor (depth ≤ 1) |
|---|---|---|---|---|---|---|
| `doc_edits` | 45.2% | 66.1% | 76.5% | 83.5% | 87.0% | 38.8% |
| `doc_deep` | 44.8% | 67.2% | 78.8% | 84.2% | 89.6% | 17.6% |
| `doc_header_only` | 48.2% | 70.5% | 81.6% | 89.1% | 92.8% | 92.7% |
| `kv` | 41.9% | 66.9% | 75.3% | 83.7% | 83.7% | 83.8% |
| `doc_small` | 32.4% | 51.8% | 58.3% | 64.8% | 64.8% | 39.6% |
| `doc_large` | 31.9% | 51.0% | 57.4% | 63.7% | 63.7% | 58.8% |
| `kv_rewrite` (control) | 3.9% | 6.2% | 6.9% | 7.7% | 7.7% | 7.8% |

**The read curve. `doc_edits`, 9 reps, medians, block cache warmed over the whole key space, arms
interleaved.** `chased` is the honest model — a delta row cannot name its base until it has itself
been read, so depth `d` is `d+1` *dependent* batched point reads. `wide` is the best case, available
only if every delta row carries its whole base list.

| depth | chased ns/payload | wide ns/payload | decode ns/payload | chased total | vs depth 0 |
|---|---|---|---|---|---|
| 0 (today) | 7,967 | 4,047 | 6,154 | 14,121 | — |
| 1 | 12,945 | 10,541 | 6,863 | 19,808 | **+40%** |
| 2 | 19,546 | 16,730 | 7,628 | 27,174 | **+92%** |
| 4 | 33,321 | 20,498 | 9,838 | 43,159 | **+206%** |
| 8 | 57,241 | 27,403 | 12,899 | 70,140 | **+397%** |

Batching does not rescue it: `wide` at depth 8 is still 6.8× depth 0, because you read `d+1` payloads
either way. The JSON space is keyed by digest, so a base never shares a block with its dependant.
`kv` (22,003 rows) reproduces the same slope.

Read the **slope within each arm**, not the gap between arms. Both arms read the identical key set in
a given rep, so whichever runs second inherits the other's cache; alternating start order splits that
advantage unevenly across 9 reps and leaves the two arms' absolute levels non-comparable. Both arms'
absolute costs are therefore optimistic, and the real regression is at least the slope shown.
`chased` 7,967 → 57,241 ns is **7.2×**; `wide` 4,047 → 27,403 ns is **6.8×**. `decode` is measured
separately in-process; "chased total" is the sum of two independently measured terms.

**The efficient frontier.** There is no operating point where the bytes come cheap:

| arm | bytes saved (`doc_edits`) | read cost | write cost |
|---|---|---|---|
| zstd level 3 instead of level 1 | **7.55%** | unchanged | 17,640 → **16,916 ns** (cheaper) |
| zstd level 9 | 16.31% | unchanged | 17,640 → 221,711 ns (**+1157%**) |
| zstd level 19 | 22.02% | unchanged | 17,640 → 1,657,767 ns |
| shared trained dictionary | 11.59% | +1 dictionary read | — |
| delta, depth ≤ 1 (anchor) | 38.81% | **+40%** | 9,513 ns + a base read |
| delta, snapshot every 8 | 76.53% | **+397%** | 9,513 ns + a base read |

Encode arms: 9 reps, interleaved. Level 3 being *cheaper* than level 1 is reproducible (p95 17,038 vs
17,838 ns; `kv` 8,362 vs 8,627) — level 3 is zstd's tuned default. It is a free ~7%, but that is below
the 10% acceptance gate, so it is reported as a follow-up candidate rather than claimed here.

Under the project ranking **OLTP > version control > physical bytes**, a 40% read regression for the
cheapest delta configuration is not a trade the gate allows. Rejected.

## 6. Delta-base reachability — the crux, answered from the code

For an ordinary `UPDATE <table> SET <json col> = … WHERE <pk> = …`:

- **The previous `JsonRef` is not in hand at staging time.** `stage_state_json_payloads`
  (`transaction/commit.rs:653`) reads `PreparedStateBatch`, whose `durable_predecessor` is `None` on
  the generic path — `RawWriteBatch::push_parts` pushes `None` (`transaction/types.rs:1151`). It is
  set only for `{path,value}`-shaped certified surfaces (`sql2/exec/bound_public_write.rs:1372`,
  `:2073`; gated by `certifies_path_value_replacement`, `sql2/catalog/entity_surface.rs:243-281`) and
  for immutable-mutation journals (`transaction/context.rs:8173`).
- **The previous head row *is* read on every commit, but too late.**
  `hot_load_primary_mutation_identity_refs` (`live_state/tracked_head/hot.rs:7163`, defined `:8415`)
  runs inside `stage_tracked_head` (`commit.rs:723`) — ~70 lines *after* the JSON batch is staged.
  Reordering is a data-flow change, not new I/O.
- **The previous *bytes* are never loaded in the commit path.** `commit.rs:256` builds a write-only
  `JsonStoreContext::new().writer()`; the only production payload load is
  `materialize_selected_change_payloads` (`commit.rs:2089`), for checkpoint-selected historical
  changes only.
- **But statement execution already loaded them and threw them away.** The generic UPDATE's candidate
  scan calls `load_bytes_many` in `materialize_live_entries` (`live_state/tracked_head.rs:2190-2199`)
  because it must merge the new column into the prior snapshot. Only the post-image survives into
  `PreparedStateBatch`.
- **The certified fast paths deliberately avoid that read.** `scan_entity_candidates_for_pks(…,
  metadata_only = direct_replacement.is_some())` (`bound_public_write.rs:703-710`, `:4126-4132`).
  A delta encoder would force those paths to fetch the old payload back — undoing that optimisation
  on exactly the `lix_key_value`-shaped surfaces where the delta win is largest (83.8%).

**Verdict: the base *ref* is cheap (already in memory, one phase late). The base *bytes* are cheap on
the generic UPDATE path and expensive on precisely the certified paths built to avoid reading them.**

## 7. Layout-invariants checklist

1. **Single authority** — *no new authority added by this PR* (measurement only). For the rejected
   delta design: a delta row is one authority per key, but the encoding would stop being a function
   of the content. Two writers staging identical JSON against different bases produce **different
   value bytes for the same content address**. `key == blake3(decode(value))` survives; `value`
   determined by `key` does not, and `stage_content_addressed_encoded_batch` coalescing
   (`json_store/context.rs:271`) relies on it. Counted against the design.
2. **Commit canonicality** — unaffected.
3. **Derived views are caches** — no cache added. A delta reconstruction cache would hold
   materialized payloads, i.e. a second materialization of content-addressed truth; it would have to
   be provably non-authoritative and rebuildable.
4. **Atomic publication** — unaffected. For the delta design, base and delta must publish in one
   write set when both are new in the same transaction.
5. **GC from refs** — **this is where the delta design breaks.** The reachability walk enumerates
   `JsonSlot::Ref` out of change records (`gc.rs:3517 collect_change_payload_hashes`), hot head rows,
   and `decode_current_state_data_part_refs` (`gc.rs:3110-3113`). It **never opens a
   `json_store.json` value**, and the store has no refcount by explicit design
   (`json_store/context.rs:20-23`). A payload→payload edge is completely invisible: a swept base
   would be deleted at `gc.rs:3373-3375` while a dependant delta still needs it. The hazard is
   currently *latent* — production `stage_repository_gc` hardcodes `json_payloads: Vec::new()`
   (`gc.rs:2403`, `:2618`) and `stage_delete_refs` is still `#[allow(dead_code)]` — so a delta scheme
   would appear safe today and break the moment experiment R lands a working sweep. **This PR assumes
   nothing about experiment R and touches no GC code.**
6. **SQL reads canonical records** — unaffected.

## What changed

- `packages/engine-benchmarks/examples/expu_json_delta.rs` (new): `build` seeds seven corpora through
  the real `SessionContext` SQL commit path while logging the exact `(entity, payload)` stream;
  `oracle` prices zstd levels, per-entity delta chains at bounded depths, an anchor delta, and a
  shared trained dictionary, and times encode and reconstruction; `store` decodes a settled
  `json_store.json` and re-runs the near-duplicate probe with payload-relative widths; `readcost`
  measures the point-read curve versus chain depth on the real store.
- `packages/lix/src/storage_bench.rs`: `storage_space_by_name`, so a tool can issue its own point
  reads without re-declaring a space id. `space_inventory` now uses it instead of its own inline
  lookup — one registry authority, not two.
- **Removed:** nothing. **No production code path changes**, so the guard benchmarks
  (`tracked_state_crud`, `untracked_state_crud`, `diff_commands`) cannot move and were not run.

## Reproduce

Machine `ryzen-9950x-II`, base `claude-3-optimizations` @ `6711231ae`.

```
cargo build -p lix_benchmarks --release --features storage-benches,slatedb --example expu_json_delta
B=target/release/examples/expu_json_delta
LIX_EXPU_DOCS=400 LIX_EXPU_ROUNDS=25 LIX_EXPU_BLOCKS=40 LIX_EXPU_BLOCK_BYTES=220 \
  $B build doc_edits ~/expU-corpus/doc_edits ~/expU-corpus/doc_edits.wlog
$B store    ~/expU-corpus/doc_edits
$B oracle   ~/expU-corpus/doc_edits.wlog
$B readcost ~/expU-corpus/doc_edits
```

Corpora: `doc_edits`, `doc_small`, `doc_large`, `doc_header_only`, `kv`, `kv_rewrite`.

Caveat: the delta arm compresses at zstd level 1 with the base as a raw content dictionary, matching
the store's own level. A tuned `--patch-from` at a higher level would save more, which only widens
the byte gap — and the rejection is on read cost, so a larger byte win does not change it.
