### PR TITLE
fix(binary-cas): split the publication fence so concurrent writers stop conflicting

### DIFF
--- a/.changenotes/concurrent-writers-no-longer-conflict.md
+++ b/.changenotes/concurrent-writers-no-longer-conflict.md
@@ -1,0 +1,7 @@
+---
+type: patch
+---
+
+Fixed `LIX_TRANSACTION_CONFLICT` being raised for writers that do not actually conflict.
+
+Saving a file while a resumable media upload was in progress — or running the four parts of one upload's in-flight window — could fail with "transaction snapshot is stale", because every content-addressed publication shared a single compare-and-set row with every garbage-collection sweep. Publications now fence only against sweeps, so independent writers commit independently; a sweep still cannot commit across a concurrent publication, and a publication still cannot commit across a concurrent sweep.

--- a/packages/lix/src/binary_cas/kv.rs
+++ b/packages/lix/src/binary_cas/kv.rs
@@ -16,8 +16,9 @@ use crate::binary_cas::{
 #[cfg(test)]
 use crate::storage_adapter::StoragePrefix;
 use crate::storage_adapter::{
-    PointReadPlan, REVISION_KEY_BINARY_CAS_EPOCH, REVISION_SPACE, StorageAdapterRead, StorageSpace,
-    StorageWriteSet, load_revision, revision_key,
+    PointReadPlan, REVISION_KEY_BINARY_CAS_PUBLICATION, REVISION_KEY_BINARY_CAS_RECLAMATION,
+    REVISION_SPACE, StorageAdapterRead, StorageSpace, StorageWriteSet, load_revision,
+    load_revisions, revision_key,
 };
 use crate::storage_adapter::{
     StorageBeginScanOptions, StorageCoreProjection, StorageGetOptions, StorageKey, StorageKeyRange,
@@ -56,46 +57,18 @@ pub(crate) const BINARY_CAS_CHUNK_PRESENCE_SPACE: StorageSpace = StorageSpace::m
     StorageSpaceId(0x0005_0004),
     BINARY_CAS_CHUNK_PRESENCE_NAMESPACE,
 );
-pub(in crate::binary_cas) async fn load_mutation_epoch(
-    store: &(impl StorageAdapterRead + ?Sized),
-) -> Result<(u64, Option<Bytes>), LixError> {
-    let value = load_revision(store, REVISION_KEY_BINARY_CAS_EPOCH).await?;
-    let Some(value) = value else {
-        return Ok((0, None));
-    };
-    if value.len() != 8 {
-        return Err(LixError::new(
-            LixError::CODE_STORAGE_ERROR,
-            "binary CAS mutation epoch has an invalid width",
-        ));
+fn fresh_revision_token() -> StorageValue {
+    StorageValue {
+        bytes: Bytes::copy_from_slice(uuid::Uuid::now_v7().as_bytes()),
     }
-    Ok((
-        u64::from_be_bytes(value.as_ref().try_into().expect("checked epoch width")),
-        Some(value),
-    ))
 }
 
-pub(in crate::binary_cas) fn stage_mutation_epoch(
-    writes: &mut StorageWriteSet,
-    preconditions: &mut Vec<StoragePrecondition>,
-    current: u64,
+fn unchanged_revision_precondition(
+    key: &'static [u8],
     token: Option<Bytes>,
-) -> Result<(), LixError> {
-    let next = current.checked_add(1).ok_or_else(|| {
-        LixError::new(
-            LixError::CODE_STORAGE_ERROR,
-            "binary CAS mutation epoch exhausted",
-        )
-    })?;
-    let key = revision_key(REVISION_KEY_BINARY_CAS_EPOCH);
-    writes.put(
-        REVISION_SPACE,
-        key.clone(),
-        StorageValue {
-            bytes: Bytes::copy_from_slice(&next.to_be_bytes()),
-        },
-    );
-    preconditions.push(match token {
+) -> StoragePrecondition {
+    let key = revision_key(key);
+    match token {
         Some(expected) => StoragePrecondition::KeyValueEquals {
             space: REVISION_SPACE,
             key,
@@ -105,7 +78,58 @@ pub(in crate::binary_cas) fn stage_mutation_epoch(
             space: REVISION_SPACE,
             key,
         },
-    });
+    }
+}
+
+pub(in crate::binary_cas) async fn stage_publication_fence(
+    store: &(impl StorageAdapterRead + ?Sized),
+    writes: &mut StorageWriteSet,
+    preconditions: &mut Vec<StoragePrecondition>,
+) -> Result<(), LixError> {
+    let reclamation = load_revision(store, REVISION_KEY_BINARY_CAS_RECLAMATION).await?;
+    // A fresh token, not a counter increment: two publishers planned from the
+    // same snapshot must both be able to commit, so neither can hold a
+    // compare-and-set on this row. Uniqueness is what a sweep's equality
+    // precondition needs, and blind counter increments would let a second
+    // publisher restore the value a sweep already observed.
+    writes.put(
+        REVISION_SPACE,
+        revision_key(REVISION_KEY_BINARY_CAS_PUBLICATION),
+        fresh_revision_token(),
+    );
+    preconditions.push(unchanged_revision_precondition(
+        REVISION_KEY_BINARY_CAS_RECLAMATION,
+        reclamation,
+    ));
+    Ok(())
+}
+
+pub(in crate::binary_cas) async fn stage_reclamation_fence(
+    store: &(impl StorageAdapterRead + ?Sized),
+    writes: &mut StorageWriteSet,
+    preconditions: &mut Vec<StoragePrecondition>,
+) -> Result<(), LixError> {
+    let [publication, reclamation] = load_revisions(
+        store,
+        [
+            REVISION_KEY_BINARY_CAS_PUBLICATION,
+            REVISION_KEY_BINARY_CAS_RECLAMATION,
+        ],
+    )
+    .await?;
+    writes.put(
+        REVISION_SPACE,
+        revision_key(REVISION_KEY_BINARY_CAS_RECLAMATION),
+        fresh_revision_token(),
+    );
+    preconditions.push(unchanged_revision_precondition(
+        REVISION_KEY_BINARY_CAS_PUBLICATION,
+        publication,
+    ));
+    preconditions.push(unchanged_revision_precondition(
+        REVISION_KEY_BINARY_CAS_RECLAMATION,
+        reclamation,
+    ));
     Ok(())
 }
 
@@ -2862,34 +2886,132 @@ mod tests {
         StorageScanCursor, StorageWriteOptions, StorageWriteSet,
     };
 
-    #[tokio::test]
-    async fn corrupt_mutation_epoch_fails_publication_closed() {
-        let storage = StorageAdapter::new(Memory::new());
-        let mut corrupt = storage.new_write_set();
-        corrupt.put(
-            REVISION_SPACE,
-            revision_key(REVISION_KEY_BINARY_CAS_EPOCH),
-            StorageValue {
-                bytes: Bytes::from_static(b"bad"),
-            },
-        );
-        storage
-            .commit_write_set(corrupt, StorageWriteOptions::default())
-            .await
-            .expect("corrupt epoch fixture should commit");
+    async fn stage_publication_fence_only(
+        storage: &StorageAdapter<Memory>,
+    ) -> (StorageWriteSet, Vec<StoragePrecondition>) {
         let read = storage
             .begin_read(StorageReadOptions::default())
             .await
-            .expect("corrupt epoch read should open");
+            .expect("publication fence read should open");
         let mut writes = storage.new_write_set();
         let mut preconditions = Vec::new();
-        let error = crate::binary_cas::stage_mutation_epoch(&read, &mut writes, &mut preconditions)
+        crate::binary_cas::stage_cas_publication_fence(&read, &mut writes, &mut preconditions)
             .await
-            .expect_err("corrupt epoch must reject publication");
-        assert_eq!(error.code, LixError::CODE_STORAGE_ERROR);
-        assert!(error.message.contains("invalid width"));
-        assert!(writes.is_empty());
-        assert!(preconditions.is_empty());
+            .expect("publication fence should stage");
+        (writes, preconditions)
+    }
+
+    /// Publishers are independent of each other: content-addressed payload rows
+    /// have no read-modify-write aggregate, so two publications planned from one
+    /// snapshot must both commit. A compare-and-set here is what made unrelated
+    /// concurrent writers collide with `LIX_TRANSACTION_CONFLICT`.
+    #[tokio::test]
+    async fn concurrent_publication_fences_planned_from_one_snapshot_both_commit() {
+        let storage = StorageAdapter::new(Memory::new());
+        let (first_writes, first_preconditions) = stage_publication_fence_only(&storage).await;
+        let (second_writes, second_preconditions) = stage_publication_fence_only(&storage).await;
+        storage
+            .commit_write_set(
+                first_writes,
+                StorageWriteOptions {
+                    preconditions: first_preconditions,
+                    ..StorageWriteOptions::default()
+                },
+            )
+            .await
+            .expect("first publication fence should commit");
+        storage
+            .commit_write_set(
+                second_writes,
+                StorageWriteOptions {
+                    preconditions: second_preconditions,
+                    ..StorageWriteOptions::default()
+                },
+            )
+            .await
+            .expect("a concurrent publication must not invalidate another publication");
+    }
+
+    /// The publication token must change on every publication, or a sweep that
+    /// observed a value could see that same value restored and commit a plan
+    /// that predates the publication.
+    #[tokio::test]
+    async fn every_publication_rewrites_the_publication_token() {
+        let storage = StorageAdapter::new(Memory::new());
+        let mut seen = std::collections::HashSet::new();
+        for _ in 0..4 {
+            let (writes, preconditions) = stage_publication_fence_only(&storage).await;
+            storage
+                .commit_write_set(
+                    writes,
+                    StorageWriteOptions {
+                        preconditions,
+                        ..StorageWriteOptions::default()
+                    },
+                )
+                .await
+                .expect("publication fence should commit");
+            let read = storage
+                .begin_read(StorageReadOptions::default())
+                .await
+                .expect("publication token read should open");
+            let token = load_revision(&read, REVISION_KEY_BINARY_CAS_PUBLICATION)
+                .await
+                .expect("publication token should load")
+                .expect("publication token should be present");
+            assert!(
+                seen.insert(token),
+                "each publication must write a distinct publication token"
+            );
+        }
+    }
+
+    /// Two sweeps planned from one snapshot must still be mutually exclusive:
+    /// each deletes rows the other assumed present.
+    #[tokio::test]
+    async fn concurrent_reclamation_fences_planned_from_one_snapshot_conflict() {
+        let storage = StorageAdapter::new(Memory::new());
+        let mut staged = Vec::new();
+        for _ in 0..2 {
+            let read = storage
+                .begin_read(StorageReadOptions::default())
+                .await
+                .expect("reclamation fence read should open");
+            let mut writes = storage.new_write_set();
+            let mut preconditions = Vec::new();
+            crate::binary_cas::stage_cas_reclamation_fence(&read, &mut writes, &mut preconditions)
+                .await
+                .expect("reclamation fence should stage");
+            staged.push((writes, preconditions));
+        }
+        let (second_writes, second_preconditions) = staged.pop().expect("two sweeps were staged");
+        let (first_writes, first_preconditions) = staged.pop().expect("two sweeps were staged");
+        storage
+            .commit_write_set(
+                first_writes,
+                StorageWriteOptions {
+                    preconditions: first_preconditions,
+                    ..StorageWriteOptions::default()
+                },
+            )
+            .await
+            .expect("first sweep should win the reclamation fence");
+        let error = storage
+            .commit_write_set(
+                second_writes,
+                StorageWriteOptions {
+                    preconditions: second_preconditions,
+                    ..StorageWriteOptions::default()
+                },
+            )
+            .await
+            .expect_err("a stale sweep must lose the reclamation fence");
+        assert!(matches!(
+            error,
+            crate::storage_adapter::StorageWriteSetError::Storage(
+                StorageError::PreconditionFailed(_)
+            )
+        ));
     }
 
     struct DelayedManifestScanRead<R> {

--- a/packages/lix/src/binary_cas/kv.rs
+++ b/packages/lix/src/binary_cas/kv.rs
@@ -2938,7 +2938,7 @@ mod tests {
     #[tokio::test]
     async fn every_publication_rewrites_the_publication_token() {
         let storage = StorageAdapter::new(Memory::new());
-        let mut seen = std::collections::HashSet::new();
+        let mut seen = HashSet::new();
         for _ in 0..4 {
             let (writes, preconditions) = stage_publication_fence_only(&storage).await;
             storage

--- a/packages/lix/src/binary_cas/mod.rs
+++ b/packages/lix/src/binary_cas/mod.rs
@@ -54,16 +54,49 @@ pub(crate) async fn stage_gc_reclamation(
     kv::stage_reclaim_unreachable_binary_cas(store, writes, blob_roots, upload_chunks).await
 }
 
-/// Stages the single authenticated publication/reclamation epoch owned by the
-/// binary CAS. Every logical CAS publisher and every sweep rotates this row in
-/// the same atomic commit. A publisher and sweep planned from one snapshot can
-/// therefore never both commit, including when publication reuses every
-/// immutable payload row.
-pub(crate) async fn stage_mutation_epoch(
+/// Stages the publisher half of the binary-CAS publication fence.
+///
+/// Every logical CAS publisher — an ordinary commit's root publication, a
+/// resumable upload part, a completed-upload receipt — calls this in the same
+/// atomic write set that stages its payload rows.
+///
+/// The fence is deliberately asymmetric, because the two directions it has to
+/// stop are not symmetric:
+///
+/// * A publisher may reuse an immutable payload row instead of restaging it, so
+///   it must not commit if a sweep deleted that row after the publisher's
+///   planning snapshot. That is enforced here: the publisher asserts the
+///   reclamation token is unchanged.
+/// * A sweep computes reachability from a snapshot, so it must not commit if a
+///   publication rooted new bytes after that snapshot. That is enforced by
+///   [`stage_cas_reclamation_fence`]: the sweep asserts the publication token is
+///   unchanged, and every publisher rewrites it.
+///
+/// Publishers, by contrast, never invalidate each other. Payload rows are
+/// content-addressed puts with no read-modify-write aggregate, so two
+/// publications planned from one snapshot are independent and both may commit.
+/// A publisher therefore holds no compare-and-set on the row it writes; making
+/// it do so is what turned unrelated concurrent writers — a project-file save
+/// alongside media ingest, or two parts of one resumable upload — into
+/// `LIX_TRANSACTION_CONFLICT`.
+pub(crate) async fn stage_cas_publication_fence(
     store: &(impl crate::storage_adapter::StorageAdapterRead + ?Sized),
     writes: &mut crate::storage_adapter::StorageWriteSet,
     preconditions: &mut Vec<crate::storage_adapter::StoragePrecondition>,
 ) -> Result<(), crate::LixError> {
-    let (current, token) = kv::load_mutation_epoch(store).await?;
-    kv::stage_mutation_epoch(writes, preconditions, current, token)
+    kv::stage_publication_fence(store, writes, preconditions).await
+}
+
+/// Stages the sweep half of the binary-CAS publication fence.
+///
+/// A sweep rotates the reclamation token under a compare-and-set (so two sweeps
+/// planned from one snapshot cannot both commit) and asserts the publication
+/// token is unchanged (so no publication slipped in after its reachability
+/// plan). See [`stage_cas_publication_fence`] for the full argument.
+pub(crate) async fn stage_cas_reclamation_fence(
+    store: &(impl crate::storage_adapter::StorageAdapterRead + ?Sized),
+    writes: &mut crate::storage_adapter::StorageWriteSet,
+    preconditions: &mut Vec<crate::storage_adapter::StoragePrecondition>,
+) -> Result<(), crate::LixError> {
+    kv::stage_reclamation_fence(store, writes, preconditions).await
 }

--- a/packages/lix/src/gc.rs
+++ b/packages/lix/src/gc.rs
@@ -605,10 +605,10 @@ pub(crate) async fn stage_reachability_delta_batch(
     checkpoint_roots: &[CommitId],
     preconditions: &mut Vec<StoragePrecondition>,
 ) -> Result<(), LixError> {
-    // This is the central authenticated root-publication boundary. Rotate the
-    // binary-CAS epoch in this same atomic write even when the transition only
-    // revives an existing commit and stages no blob bytes.
-    crate::binary_cas::stage_mutation_epoch(read, writes, preconditions).await?;
+    // This is the central authenticated root-publication boundary. Stage the
+    // binary-CAS publication fence in this same atomic write even when the
+    // transition only revives an existing commit and stages no blob bytes.
+    crate::binary_cas::stage_cas_publication_fence(read, writes, preconditions).await?;
     if deltas.is_empty() && checkpoint_roots.is_empty() {
         return Ok(());
     }
@@ -2380,7 +2380,8 @@ where
     let binary_cas =
         crate::binary_cas::stage_gc_reclamation(&store, writes, &blob_roots, &upload_chunks)
             .await?;
-    crate::binary_cas::stage_mutation_epoch(&store, writes, &mut staged_preconditions).await?;
+    crate::binary_cas::stage_cas_reclamation_fence(&store, writes, &mut staged_preconditions)
+        .await?;
 
     if batches.is_empty() {
         preconditions.extend(staged_preconditions);

--- a/packages/lix/src/session/media_upload.rs
+++ b/packages/lix/src/session/media_upload.rs
@@ -334,7 +334,12 @@ where
                 }
                 Some(UploadState::Complete(_)) => unreachable!("complete state returned above"),
             }
-            crate::binary_cas::stage_mutation_epoch(&read, &mut writes, &mut preconditions).await?;
+            crate::binary_cas::stage_cas_publication_fence(
+                &read,
+                &mut writes,
+                &mut preconditions,
+            )
+            .await?;
             drop(read);
 
             let commit_boundary = self.transaction_commit_boundary();
@@ -960,9 +965,9 @@ mod tests {
                 key: state_key,
             },
         ];
-        crate::binary_cas::stage_mutation_epoch(read, &mut writes, &mut preconditions)
+        crate::binary_cas::stage_cas_publication_fence(read, &mut writes, &mut preconditions)
             .await
-            .expect("deduplicated receipt epoch should stage");
+            .expect("deduplicated receipt publication fence should stage");
         (writes, preconditions)
     }
 
@@ -984,9 +989,9 @@ mod tests {
         .await
         .expect("stale CAS sweep should stage");
         assert_eq!(swept.reclaimed_chunk_rows, 1);
-        crate::binary_cas::stage_mutation_epoch(read, &mut writes, &mut preconditions)
+        crate::binary_cas::stage_cas_reclamation_fence(read, &mut writes, &mut preconditions)
             .await
-            .expect("stale sweep epoch should stage");
+            .expect("stale sweep reclamation fence should stage");
         (writes, preconditions)
     }
 

--- a/packages/lix/src/session/media_upload.rs
+++ b/packages/lix/src/session/media_upload.rs
@@ -917,6 +917,58 @@ mod tests {
         receipts[0].hash
     }
 
+    /// A resumable upload keeps four parts in flight by design, and the engine —
+    /// not the caller — owns that window. Parts staged from one snapshot write
+    /// disjoint manifest leaves over content-addressed payloads, so they are
+    /// independent publications: every one of them must commit.
+    ///
+    /// Making publishers share a compare-and-set row broke exactly this. It was
+    /// invisible at the public surface because `upsert_file_content_part` retries
+    /// a bounded number of times — a full window plus any other concurrent writer
+    /// exhausts that budget, which is how the movie-workspace qualification fails
+    /// its upload acknowledgement.
+    #[tokio::test]
+    async fn concurrent_upload_part_publications_from_one_snapshot_all_commit() {
+        let storage = StorageAdapter::new(Memory::new());
+        let payload = b"windowed-upload-part-payload";
+        seed_orphan_upload_chunk(&storage, payload).await;
+        let read = storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("upload window read should open");
+        let mut window = Vec::new();
+        for part in 0..4 {
+            window.push(
+                stage_deduplicated_receipt_publication(
+                    &storage,
+                    &read,
+                    &format!("windowed-part-{part}"),
+                    payload,
+                    true,
+                )
+                .await,
+            );
+        }
+        drop(read);
+
+        for (part, (writes, preconditions)) in window.into_iter().enumerate() {
+            storage
+                .commit_write_set(
+                    writes,
+                    StorageWriteOptions {
+                        preconditions,
+                        ..StorageWriteOptions::default()
+                    },
+                )
+                .await
+                .unwrap_or_else(|error| {
+                    panic!(
+                        "every part of one upload window must commit; part {part} was rejected: {error:?}"
+                    )
+                });
+        }
+    }
+
     async fn stage_deduplicated_receipt_publication(
         storage: &StorageAdapter<Memory>,
         read: &impl StorageAdapterRead,

--- a/packages/lix/src/storage_adapter/mod.rs
+++ b/packages/lix/src/storage_adapter/mod.rs
@@ -46,8 +46,9 @@ pub use point::{PointReadPlan, PointValues, RequestedToUnique, RequestedToUnique
 pub(crate) use read_scope::SharedStorageAdapterRead;
 pub use read_scope::{StorageAdapterRead, StorageAdapterReadScope};
 pub(crate) use spaces::{
-    REVISION_KEY_BINARY_CAS_EPOCH, REVISION_KEY_CATALOG, REVISION_KEY_FILESYSTEM_PATH,
-    REVISION_KEY_TRACKED_MUTATION, REVISION_SPACE, load_revision, load_revisions, revision_key,
+    REVISION_KEY_BINARY_CAS_PUBLICATION, REVISION_KEY_BINARY_CAS_RECLAMATION, REVISION_KEY_CATALOG,
+    REVISION_KEY_FILESYSTEM_PATH, REVISION_KEY_TRACKED_MUTATION, REVISION_SPACE, load_revision,
+    load_revisions, revision_key,
 };
 pub use stats::{
     StorageReadResult, StorageReadStats, StorageReadStatsCollector, StorageWriteSetStats,

--- a/packages/lix/src/storage_adapter/spaces.rs
+++ b/packages/lix/src/storage_adapter/spaces.rs
@@ -16,14 +16,20 @@ use crate::storage_adapter::{StorageAdapterRead, exact_get_many};
 /// physical keys. That is one SST block, one hot-key write region, and one
 /// batched point read instead of five scattered ones.
 ///
-/// The value semantics stay per-key: the binary-CAS epoch is a CAS-guarded
-/// `u64` big-endian counter, the other four are opaque uuid-v7 tokens whose
-/// only meaningful operation is equality.
+/// Every key holds an opaque uuid-v7 token whose only meaningful operation is
+/// equality: "did this fact change since I read it".
 pub(crate) const REVISION_SPACE: StorageSpace =
     StorageSpace::mutable(SpaceId(0x0007_0000), "lix.revision.v1");
 
-/// Binary-CAS publication/reclamation epoch (`u64` BE, CAS-guarded).
-pub(crate) const REVISION_KEY_BINARY_CAS_EPOCH: &[u8] = b"b";
+/// Binary-CAS reclamation token. Rotated only by an authenticated CAS sweep,
+/// and asserted unchanged by every CAS publisher, so a publisher that planned
+/// against payload rows a sweep then deleted cannot commit.
+pub(crate) const REVISION_KEY_BINARY_CAS_RECLAMATION: &[u8] = b"b";
+/// Binary-CAS publication token. Rewritten by every CAS publisher without a
+/// precondition on itself — publishers are mutually independent — and asserted
+/// unchanged by every sweep, so a sweep whose reachability plan predates a
+/// concurrent publication cannot commit.
+pub(crate) const REVISION_KEY_BINARY_CAS_PUBLICATION: &[u8] = b"p";
 /// Registered-schema catalog visibility token.
 pub(crate) const REVISION_KEY_CATALOG: &[u8] = b"c";
 /// Filesystem path-index cache-freshness token.

--- a/packages/lix/src/storage_adapter/spaces.rs
+++ b/packages/lix/src/storage_adapter/spaces.rs
@@ -12,9 +12,9 @@ use crate::storage_adapter::{StorageAdapterRead, exact_get_many};
 /// singleton.
 ///
 /// Physical keys are `4-byte-BE space id ++ logical key`, so one space with
-/// one-byte logical keys puts all revision singletons in five adjacent
-/// physical keys. That is one SST block, one hot-key write region, and one
-/// batched point read instead of five scattered ones.
+/// one-byte logical keys puts all revision singletons in adjacent physical
+/// keys. That is one SST block, one hot-key write region, and one batched
+/// point read instead of one read per singleton.
 ///
 /// Every key holds an opaque uuid-v7 token whose only meaningful operation is
 /// equality: "did this fact change since I read it".

--- a/packages/lix/src/storage_bench.rs
+++ b/packages/lix/src/storage_bench.rs
@@ -2749,17 +2749,18 @@ mod tests {
             first.staged_deletes
         );
         assert_eq!(first.delete_descriptors, first.staged_deletes as usize);
-        // GC also stages the mandatory binary-CAS epoch key. Its put shares the
-        // key arena with the UUID-keyed delete descriptors. Since the revision
-        // singletons were consolidated into one space, the epoch's *logical* key
-        // is a single byte (`b"b"`) and the 4-byte space id is prepended at the
-        // physical layer, so derive the width from the constant rather than
-        // restating it.
-        const EPOCH_KEY_BYTES: usize = crate::storage_adapter::REVISION_KEY_BINARY_CAS_EPOCH.len();
+        // GC also stages the mandatory binary-CAS reclamation key. Its put
+        // shares the key arena with the UUID-keyed delete descriptors. Since the
+        // revision singletons were consolidated into one space, the reclamation
+        // token's *logical* key is a single byte (`b"b"`) and the 4-byte space
+        // id is prepended at the physical layer, so derive the width from the
+        // constant rather than restating it.
+        const FENCE_KEY_BYTES: usize =
+            crate::storage_adapter::REVISION_KEY_BINARY_CAS_RECLAMATION.len();
         assert_eq!(first.key_shared_buffers, first.staged_deletes as usize + 1);
         assert_eq!(
             first.key_shared_bytes,
-            first.staged_deletes as usize * 16 + EPOCH_KEY_BYTES
+            first.staged_deletes as usize * 16 + FENCE_KEY_BYTES
         );
         assert_eq!(second.swept_commits, first.swept_commits);
         assert_eq!(second.delete_counts_by_space, first.delete_counts_by_space);

--- a/packages/lix/src/transaction/commit.rs
+++ b/packages/lix/src/transaction/commit.rs
@@ -10608,9 +10608,9 @@ mod tests {
         .await
         .expect("ordinary race CAS sweep should stage");
         assert_eq!(swept.reclaimed_chunk_rows, 1);
-        crate::binary_cas::stage_mutation_epoch(read, &mut writes, &mut preconditions)
+        crate::binary_cas::stage_cas_reclamation_fence(read, &mut writes, &mut preconditions)
             .await
-            .expect("ordinary race sweep epoch should stage");
+            .expect("ordinary race sweep fence should stage");
         (writes, preconditions)
     }
 

--- a/packages/lix/tests/integration/transaction.rs
+++ b/packages/lix/tests/integration/transaction.rs
@@ -108,15 +108,17 @@ async fn stale_transaction_composes_disjoint_semantic_writes() {
 /// they touch disjoint files, disjoint payload rows, and disjoint branch state.
 /// Neither may be rejected because the other committed first.
 ///
-/// This is the shape that the ignored `slatedb_movie_workspace_interference`
-/// qualification exercises with a 1 TiB corpus. Resumable upload parts commit
-/// straight to storage rather than through the collaboration write gate, so
-/// they land inside an ordinary commit's precondition window — which is exactly
-/// where a shared compare-and-set turns into a false `LIX_TRANSACTION_CONFLICT`.
+/// This is the shape the ignored `slatedb_movie_workspace_interference`
+/// qualification exercises with a 1 TiB corpus, reduced to the one interleaving
+/// that matters. Resumable upload parts commit straight to storage instead of
+/// through the collaboration write gate, so an ingest part lands squarely inside
+/// an ordinary commit's precondition window: between the save's commit-time
+/// snapshot and the save's storage write. The gate below parks the save exactly
+/// there rather than leaving the interleaving to the scheduler.
 #[tokio::test]
-async fn concurrent_media_ingest_does_not_conflict_with_project_saves() {
-    const ROUNDS: usize = 12;
-    let storage = InterleavingStorage::default();
+async fn committed_media_ingest_part_does_not_invalidate_a_concurrent_project_save() {
+    let storage = InterferingStorage::new();
+    let gate = storage.gate();
     Engine::initialize(storage.clone())
         .await
         .expect("storage should initialize");
@@ -131,124 +133,58 @@ async fn concurrent_media_ingest_does_not_conflict_with_project_saves() {
         .open_workspace_session()
         .await
         .expect("project-save session should open");
+    saver
+        .upsert_file_content(
+            "/project/edit.json".to_owned(),
+            br#"{"timelineRevision":0}"#.to_vec().into(),
+        )
+        .await
+        .expect("seed project file should save");
 
-    let ingest_future = async {
-        for round in 0..ROUNDS {
-            let payload = vec![round as u8 | 0x40; 4096];
-            let progress = ingest
-                .upsert_file_content_part(
-                    format!("media-ingest-{round}"),
-                    format!("/media/clip-{round}.bin"),
-                    0,
-                    payload.len() as u64,
-                    payload.into(),
-                )
-                .await
-                .expect("media ingest must not conflict with an unrelated concurrent writer");
-            assert!(progress.finalized, "single-part upload should finalize");
-        }
-    };
+    gate.arm();
     let save_future = async {
-        for round in 0..ROUNDS {
-            saver
-                .upsert_file_content(
-                    "/project/edit.json".to_owned(),
-                    format!("{{\"timelineRevision\":{round}}}")
-                        .into_bytes()
-                        .into(),
-                )
-                .await
-                .expect("project-file save must not conflict with concurrent media ingest");
-        }
+        saver
+            .upsert_file_content(
+                "/project/edit.json".to_owned(),
+                br#"{"timelineRevision":1}"#.to_vec().into(),
+            )
+            .await
     };
-    tokio::join!(ingest_future, save_future);
+    let ingest_future = async {
+        // Only start once the save is parked on its storage write, so this
+        // publisher is guaranteed to commit inside the save's precondition
+        // window. One part of a two-part upload: the upload does not finalize,
+        // so this path never needs the collaboration write gate the save holds.
+        gate.wait_until_a_write_is_parked().await;
+        let progress = ingest
+            .upsert_file_content_part(
+                "concurrent-ingest".to_owned(),
+                "/media/import.mov".to_owned(),
+                0,
+                2 * lix::FILE_UPLOAD_PART_BYTES as u64,
+                vec![0x5a; lix::FILE_UPLOAD_PART_BYTES].into(),
+            )
+            .await;
+        gate.release_parked_write();
+        progress
+    };
+    let (save_result, ingest_result) =
+        tokio::time::timeout(TEST_WAIT_TIMEOUT * 15, async move {
+            tokio::join!(save_future, ingest_future)
+        })
+        .await
+        .expect("interfering writers should not deadlock");
+
+    ingest_result.expect("media ingest part should commit");
+    save_result
+        .expect("a committed media ingest part must not invalidate a concurrent project save");
 
     let saved = saver
         .read_file_content("/project/edit.json".to_owned(), None)
         .await
         .expect("saved project file should read")
         .expect("saved project file should exist");
-    assert_eq!(
-        saved.content().as_ref(),
-        format!("{{\"timelineRevision\":{}}}", ROUNDS - 1).as_bytes(),
-        "the last committed save must be the visible one"
-    );
-    let ingested = ingest
-        .read_file_content(format!("/media/clip-{}.bin", ROUNDS - 1), None)
-        .await
-        .expect("ingested media should read")
-        .expect("ingested media should exist");
-    assert_eq!(ingested.content().len(), 4096);
-}
-
-/// A resumable upload keeps four parts in flight by design, and the engine —
-/// not the caller — owns that window. Parts of one upload stage disjoint
-/// manifest leaves and content-addressed payloads, so all four must be able to
-/// commit even while an unrelated writer commits alongside them. Losing this is
-/// how the qualification's `upload()` window fails its acknowledgement assert.
-#[tokio::test]
-async fn concurrent_upload_window_parts_commit_alongside_a_project_save() {
-    let storage = InterleavingStorage::default();
-    Engine::initialize(storage.clone())
-        .await
-        .expect("storage should initialize");
-    let engine = Engine::new(storage)
-        .await
-        .expect("initialized storage should create an engine");
-    let ingest = engine
-        .open_workspace_session()
-        .await
-        .expect("media ingest session should open");
-    let saver = engine
-        .open_workspace_session()
-        .await
-        .expect("project-save session should open");
-
-    // The smallest four-part window the upload contract admits: non-final parts
-    // must be exactly one part size, so three full parts plus a one-byte tail.
-    let part_bytes = lix::FILE_UPLOAD_PART_BYTES;
-    let total_size = 3 * part_bytes as u64 + 1;
-    let part = |index: usize| {
-        let len = if index == 3 { 1 } else { part_bytes };
-        ingest.upsert_file_content_part(
-            "windowed-ingest".to_owned(),
-            "/media/window.mov".to_owned(),
-            index as u64 * part_bytes as u64,
-            total_size,
-            vec![0x70 | index as u8; len].into(),
-        )
-    };
-    let window = async {
-        let (first, second, third, fourth) =
-            tokio::join!(part(0), part(1), part(2), part(3));
-        for progress in [first, second, third, fourth] {
-            progress.expect("every part of one upload window must commit");
-        }
-    };
-    let save_future = async {
-        for round in 0..6 {
-            saver
-                .upsert_file_content(
-                    "/project/edit.json".to_owned(),
-                    format!("{{\"timelineRevision\":{round}}}")
-                        .into_bytes()
-                        .into(),
-                )
-                .await
-                .expect("project-file save must not conflict with a concurrent upload window");
-        }
-    };
-    tokio::join!(window, save_future);
-
-    let published = ingest
-        .read_file_content(
-            "/media/window.mov".to_owned(),
-            Some(total_size - 1..total_size),
-        )
-        .await
-        .expect("published upload should read")
-        .expect("published upload should exist");
-    assert_eq!(published.content().as_ref(), &[0x73]);
+    assert_eq!(saved.content().as_ref(), br#"{"timelineRevision":1}"#);
 }
 
 #[tokio::test]
@@ -1342,21 +1278,36 @@ async fn session_read_waits_for_automatic_write_instead_of_rejecting() {
     assert_eq!(result.len(), 1);
 }
 
-/// In-memory storage that yields to the executor at every storage boundary.
+/// In-memory storage that can park one storage write and hand control to
+/// another writer.
 ///
-/// Concurrency defects on the commit path live in the window between a
-/// transaction's commit-time snapshot and its storage write. On the current
-/// thread runtime these tests use, two futures joined together would otherwise
-/// each run to completion without ever being suspended inside that window, so
-/// the race the qualification hits would never be sampled. Yielding at
-/// `begin_read`/`begin_write` makes the interleaving deterministic instead of
-/// leaving it to the scheduler.
-#[derive(Clone, Default)]
-struct InterleavingStorage {
+/// Commit-path concurrency defects live in the window between a transaction's
+/// commit-time snapshot and its storage write. Sampling that window by racing
+/// two futures is unreliable — on a current-thread runtime the phase
+/// relationship between them is fixed, and the interleaving that matters may
+/// never occur. Parking the first write after [`InterferenceGate::arm`] and
+/// resuming it only after the other writer has committed makes the interleaving
+/// a property of the test rather than of the scheduler.
+#[derive(Clone)]
+struct InterferingStorage {
     inner: Memory,
+    gate: Arc<InterferenceGate>,
 }
 
-impl Storage for InterleavingStorage {
+impl InterferingStorage {
+    fn new() -> Self {
+        Self {
+            inner: Memory::new(),
+            gate: Arc::new(InterferenceGate::new()),
+        }
+    }
+
+    fn gate(&self) -> Arc<InterferenceGate> {
+        Arc::clone(&self.gate)
+    }
+}
+
+impl Storage for InterferingStorage {
     type Read<'a>
         = MemoryRead
     where
@@ -1368,13 +1319,57 @@ impl Storage for InterleavingStorage {
         Self: 'a;
 
     async fn begin_read(&self, opts: ReadOptions) -> Result<Self::Read<'_>, StorageError> {
-        tokio::task::yield_now().await;
         self.inner.begin_read(opts).await
     }
 
     async fn begin_write(&self, opts: WriteOptions) -> Result<Self::Write<'_>, StorageError> {
-        tokio::task::yield_now().await;
+        self.gate.park_if_armed().await;
         self.inner.begin_write(opts).await
+    }
+}
+
+struct InterferenceGate {
+    armed: std::sync::atomic::AtomicBool,
+    parked: tokio::sync::Semaphore,
+    release: tokio::sync::Semaphore,
+}
+
+impl InterferenceGate {
+    fn new() -> Self {
+        Self {
+            armed: std::sync::atomic::AtomicBool::new(false),
+            parked: tokio::sync::Semaphore::new(0),
+            release: tokio::sync::Semaphore::new(0),
+        }
+    }
+
+    fn arm(&self) {
+        self.armed.store(true, Ordering::SeqCst);
+    }
+
+    /// Parks the next storage write only. Disarming before announcing means the
+    /// writer woken by `wait_until_a_write_is_parked` is never itself parked.
+    async fn park_if_armed(&self) {
+        if self.armed.swap(false, Ordering::SeqCst) {
+            self.parked.add_permits(1);
+            self.release
+                .acquire()
+                .await
+                .expect("interference gate should stay open")
+                .forget();
+        }
+    }
+
+    async fn wait_until_a_write_is_parked(&self) {
+        self.parked
+            .acquire()
+            .await
+            .expect("interference gate should stay open")
+            .forget();
+    }
+
+    fn release_parked_write(&self) {
+        self.release.add_permits(1);
     }
 }
 

--- a/packages/lix/tests/integration/transaction.rs
+++ b/packages/lix/tests/integration/transaction.rs
@@ -104,6 +104,153 @@ async fn stale_transaction_composes_disjoint_semantic_writes() {
     assert_eq!(result.rows()[1].get::<String>("key").unwrap(), "winner-key");
 }
 
+/// Media ingest and an unrelated project-file save are independent writers:
+/// they touch disjoint files, disjoint payload rows, and disjoint branch state.
+/// Neither may be rejected because the other committed first.
+///
+/// This is the shape that the ignored `slatedb_movie_workspace_interference`
+/// qualification exercises with a 1 TiB corpus. Resumable upload parts commit
+/// straight to storage rather than through the collaboration write gate, so
+/// they land inside an ordinary commit's precondition window — which is exactly
+/// where a shared compare-and-set turns into a false `LIX_TRANSACTION_CONFLICT`.
+#[tokio::test]
+async fn concurrent_media_ingest_does_not_conflict_with_project_saves() {
+    const ROUNDS: usize = 12;
+    let storage = InterleavingStorage::default();
+    Engine::initialize(storage.clone())
+        .await
+        .expect("storage should initialize");
+    let engine = Engine::new(storage)
+        .await
+        .expect("initialized storage should create an engine");
+    let ingest = engine
+        .open_workspace_session()
+        .await
+        .expect("media ingest session should open");
+    let saver = engine
+        .open_workspace_session()
+        .await
+        .expect("project-save session should open");
+
+    let ingest_future = async {
+        for round in 0..ROUNDS {
+            let payload = vec![round as u8 | 0x40; 4096];
+            let progress = ingest
+                .upsert_file_content_part(
+                    format!("media-ingest-{round}"),
+                    format!("/media/clip-{round}.bin"),
+                    0,
+                    payload.len() as u64,
+                    payload.into(),
+                )
+                .await
+                .expect("media ingest must not conflict with an unrelated concurrent writer");
+            assert!(progress.finalized, "single-part upload should finalize");
+        }
+    };
+    let save_future = async {
+        for round in 0..ROUNDS {
+            saver
+                .upsert_file_content(
+                    "/project/edit.json".to_owned(),
+                    format!("{{\"timelineRevision\":{round}}}")
+                        .into_bytes()
+                        .into(),
+                )
+                .await
+                .expect("project-file save must not conflict with concurrent media ingest");
+        }
+    };
+    tokio::join!(ingest_future, save_future);
+
+    let saved = saver
+        .read_file_content("/project/edit.json".to_owned(), None)
+        .await
+        .expect("saved project file should read")
+        .expect("saved project file should exist");
+    assert_eq!(
+        saved.content().as_ref(),
+        format!("{{\"timelineRevision\":{}}}", ROUNDS - 1).as_bytes(),
+        "the last committed save must be the visible one"
+    );
+    let ingested = ingest
+        .read_file_content(format!("/media/clip-{}.bin", ROUNDS - 1), None)
+        .await
+        .expect("ingested media should read")
+        .expect("ingested media should exist");
+    assert_eq!(ingested.content().len(), 4096);
+}
+
+/// A resumable upload keeps four parts in flight by design, and the engine —
+/// not the caller — owns that window. Parts of one upload stage disjoint
+/// manifest leaves and content-addressed payloads, so all four must be able to
+/// commit even while an unrelated writer commits alongside them. Losing this is
+/// how the qualification's `upload()` window fails its acknowledgement assert.
+#[tokio::test]
+async fn concurrent_upload_window_parts_commit_alongside_a_project_save() {
+    let storage = InterleavingStorage::default();
+    Engine::initialize(storage.clone())
+        .await
+        .expect("storage should initialize");
+    let engine = Engine::new(storage)
+        .await
+        .expect("initialized storage should create an engine");
+    let ingest = engine
+        .open_workspace_session()
+        .await
+        .expect("media ingest session should open");
+    let saver = engine
+        .open_workspace_session()
+        .await
+        .expect("project-save session should open");
+
+    // The smallest four-part window the upload contract admits: non-final parts
+    // must be exactly one part size, so three full parts plus a one-byte tail.
+    let part_bytes = lix::FILE_UPLOAD_PART_BYTES;
+    let total_size = 3 * part_bytes as u64 + 1;
+    let part = |index: usize| {
+        let len = if index == 3 { 1 } else { part_bytes };
+        ingest.upsert_file_content_part(
+            "windowed-ingest".to_owned(),
+            "/media/window.mov".to_owned(),
+            index as u64 * part_bytes as u64,
+            total_size,
+            vec![0x70 | index as u8; len].into(),
+        )
+    };
+    let window = async {
+        let (first, second, third, fourth) =
+            tokio::join!(part(0), part(1), part(2), part(3));
+        for progress in [first, second, third, fourth] {
+            progress.expect("every part of one upload window must commit");
+        }
+    };
+    let save_future = async {
+        for round in 0..6 {
+            saver
+                .upsert_file_content(
+                    "/project/edit.json".to_owned(),
+                    format!("{{\"timelineRevision\":{round}}}")
+                        .into_bytes()
+                        .into(),
+                )
+                .await
+                .expect("project-file save must not conflict with a concurrent upload window");
+        }
+    };
+    tokio::join!(window, save_future);
+
+    let published = ingest
+        .read_file_content(
+            "/media/window.mov".to_owned(),
+            Some(total_size - 1..total_size),
+        )
+        .await
+        .expect("published upload should read")
+        .expect("published upload should exist");
+    assert_eq!(published.content().as_ref(), &[0x73]);
+}
+
 #[tokio::test]
 async fn stale_transaction_reports_overlapping_ordinary_insert_atomically() {
     let storage = Memory::new();
@@ -1193,6 +1340,42 @@ async fn session_read_waits_for_automatic_write_instead_of_rejecting() {
     let result = join_thread(reader, "reader waiting for automatic write")
         .expect("session read should wait behind automatic write");
     assert_eq!(result.len(), 1);
+}
+
+/// In-memory storage that yields to the executor at every storage boundary.
+///
+/// Concurrency defects on the commit path live in the window between a
+/// transaction's commit-time snapshot and its storage write. On the current
+/// thread runtime these tests use, two futures joined together would otherwise
+/// each run to completion without ever being suspended inside that window, so
+/// the race the qualification hits would never be sampled. Yielding at
+/// `begin_read`/`begin_write` makes the interleaving deterministic instead of
+/// leaving it to the scheduler.
+#[derive(Clone, Default)]
+struct InterleavingStorage {
+    inner: Memory,
+}
+
+impl Storage for InterleavingStorage {
+    type Read<'a>
+        = MemoryRead
+    where
+        Self: 'a;
+
+    type Write<'a>
+        = MemoryWrite
+    where
+        Self: 'a;
+
+    async fn begin_read(&self, opts: ReadOptions) -> Result<Self::Read<'_>, StorageError> {
+        tokio::task::yield_now().await;
+        self.inner.begin_read(opts).await
+    }
+
+    async fn begin_write(&self, opts: WriteOptions) -> Result<Self::Write<'_>, StorageError> {
+        tokio::task::yield_now().await;
+        self.inner.begin_write(opts).await
+    }
 }
 
 #[derive(Clone, Default)]


### PR DESCRIPTION
## The defect

`packages/engine-benchmarks/tests/movie_workspace_qualification.rs::slatedb_movie_workspace_interference`
fails reproducibly with

```
LIX_TRANSACTION_CONFLICT: transaction snapshot is stale because tracked state changed before commit
```

at the project-file save (`:504`), and — once that save is retried — again at the concurrent upload
window (`:450`). It is `#[ignore]`d, so no CI job has ever run it.

**Both failures are one defect, and it is neither the cohort-join predicate nor a caller-retry
problem.** The message is not raised by `reconcile_stale_disjoint_writes`; every conflict it raises
has different wording. This one comes from the `StorageError` conversion at
`packages/lix/src/common/error.rs:341-345`, i.e. a `StoragePrecondition` failed at the storage write.

The failing precondition is the **binary-CAS mutation epoch**, a single row in the shared revision
space (`REVISION_SPACE` / key `b`). Before this change, `binary_cas::stage_mutation_epoch`
(`packages/lix/src/binary_cas/kv.rs:78-110`) had *every* participant rotate that row **and** hold a
`KeyValueEquals` compare-and-set on it:

| caller | role | `file:line` |
|---|---|---|
| `gc::stage_reachability_delta_batch` — reached by every non-empty commit (`transaction/commit.rs:798`) | publisher | `packages/lix/src/gc.rs:611` |
| `SessionContext::upsert_file_content_part` — every 16 MiB upload part | publisher | `packages/lix/src/session/media_upload.rs:337` |
| `gc::stage_repository_gc_with_preconditions` — the CAS sweep | sweep | `packages/lix/src/gc.rs:2383` |

That makes **all publishers mutually exclusive**, which they never needed to be. It only shows up
across the collaboration write gate boundary: ordinary commits hold
`collaboration_write_gate` for their whole lifetime (`session/context.rs:422-434`), but a resumable
upload part writes straight to storage without it (`media_upload.rs:334-360`), so an ingest part
lands squarely inside a save's precondition window — between the save's commit-time snapshot
(`transaction/context.rs:1728`) and its storage write (`transaction/context.rs:1898`).

The two symptoms follow directly:

* **`:504`** — the save's epoch precondition is invalidated by an ingest part. `upsert_file_content`
  has no retry, so it surfaces.
* **`:450`** — the four parts of one upload window all plan from the same epoch, so only one commits
  per round. `upsert_file_content_part` retries `UPLOAD_PART_WINDOW` = 4 times, which is exactly the
  worst case for a four-part window with no other writer; any concurrent writer (the save loop)
  exhausts the budget.

So this is **explanation 1 in spirit — an exclusion predicate that is too broad** — but at the
storage-precondition layer, not the cohort-join predicate. The cohort path is never reached. The
engine is *not* correct-as-is, and callers should *not* have to retry: `upsert_file_content` on the
active branch, concurrent with unrelated media ingest, genuinely conflicts with nothing.

## What changed

The epoch row conflated two different facts — "a publication happened" and "a reclamation happened" —
which is why it could only express symmetric exclusion. Split into two tokens and make the fence
asymmetric, because the two directions it must stop are asymmetric:

* `REVISION_KEY_BINARY_CAS_RECLAMATION` (key `b`, unchanged key) — rewritten **only** by a sweep,
  under a compare-and-set. Every publisher asserts it is unchanged.
* `REVISION_KEY_BINARY_CAS_PUBLICATION` (key `p`, new) — rewritten by **every** publisher, with **no**
  precondition on itself. Every sweep asserts it is unchanged.

Safety, case by case:

| interleaving | outcome | why |
|---|---|---|
| publisher ∥ publisher | both commit | no shared precondition; payload rows are content-addressed puts with no read-modify-write aggregate, so two publications planned from one snapshot are independent |
| sweep commits, then a publisher planned before it | publisher rejected | reclamation token changed — this is the case that matters, because a publisher may *skip* staging a payload row it saw present (`kv.rs::stage_fixed_part_skipping_existing`) |
| publisher commits, then a sweep planned before it | sweep rejected | publication token changed |
| sweep ∥ sweep | one commits | reclamation compare-and-set |

The publication token is a fresh uuid-v7, not a counter increment. With a blind counter, two
publishers could both write `N+1` and restore a value a sweep had already observed, letting a stale
sweep commit. Uniqueness is exactly what the sweep's equality check needs.

Reclamation is the only path that deletes CAS payload rows —
`binary_cas::stage_gc_reclamation` has exactly one production caller (`gc.rs:2381`) — so the
publisher/sweep fence remains the complete safety story.

**Removed:** the `u64` big-endian epoch codec, its overflow check, and its width validation. Both
tokens are now opaque uuid-v7 like the other four revision singletons, so `lix.revision.v1` has one
value encoding instead of two.

Sweeps remain best-effort (`session/gc.rs::collect_checkpoint_garbage_best_effort`) and retry at the
next checkpoint. They were already invalidated by every publisher before this change, so their
starvation profile is unchanged.

## Regression coverage

The reason this stayed broken is that the only coverage was an `#[ignore]`d qualification nothing
runs. Three new tests, none ignored, all in `cargo test -p lix --all-features`:

1. `transaction::committed_media_ingest_part_does_not_invalidate_a_concurrent_project_save`
   (`packages/lix/tests/integration/transaction.rs`) — the public-API reproduction of `:504`. A new
   `InterferingStorage` parks the save on its storage write and resumes it only after an ingest part
   has committed, so the interleaving is a property of the test rather than of the scheduler.
2. `session::media_upload::tests::concurrent_upload_part_publications_from_one_snapshot_all_commit`
   — the `:450` invariant: four upload-part publications staged from one snapshot must all commit.
3. `binary_cas::kv::tests::{concurrent_publication_fences_planned_from_one_snapshot_both_commit,
   every_publication_rewrites_the_publication_token,
   concurrent_reclamation_fences_planned_from_one_snapshot_conflict}` — the fence contract itself,
   including the sweep-vs-sweep exclusion that must survive.

Verified as a controlled experiment: with the branch's tree and **only** the publisher's `writes.put`
target reverted to the shared row (one-line patch, restoring the old semantics), all three fail —
test 1 with the byte-identical qualification error:

```
a committed media ingest part must not invalidate a concurrent project save:
LixError { code: "LIX_TRANSACTION_CONFLICT",
           message: "transaction snapshot is stale because tracked state changed before commit", ... }
```

test 2 with `part 1 was rejected: PreconditionFailed([PreconditionFailure { index: 2 }])` — index 2
being the fence, after the leaf and state `KeyAbsent`. Restoring the fix turns all three green.

The pre-existing publisher/sweep race tests
(`receipt_first_rejects_stale_gc_deleting_a_deduplicated_chunk`,
`gc_first_rejects_stale_receipt_publication_after_payload_deletion`,
`ordinary_deduplicated_publication_first_rejects_stale_cas_gc`,
`cas_gc_first_rejects_stale_ordinary_publication_and_retry_restages`) pass unchanged — both
directions of the fence still hold.

## Results (`ryzen-9950x-IV`)

`cargo test -p lix --all-features` — green: 2076 lib + 825 integration + 18 across the remaining
targets, 0 failed.

Qualification, `cargo test --release -p lix_benchmarks --features storage-benches,slatedb --test movie_workspace_qualification -- --ignored`:

* `rocksdb_movie_workspace_interference` — **passes**. `save_p95_ms=1.387`, `stream_1_late=0`,
  `stream_2_late=0`, `ingest_mib_s=762.8`.
* `slatedb_movie_workspace_interference` — **both conflict sites are gone**. All 40 project saves and
  the full upload window now commit; `save_p95_ms` = 3.285 / 3.967 / 2.413 / 2.503 across four runs
  against a 500 ms budget. It now fails further on, at `:343`, on a playback assertion
  (`stream_1_late=1`, `stream_2_late=1` out of 40 samples per stream) that no run has previously been
  able to reach.

  That assertion is **not** caused by this change. It is identical (1 and 1, 3/3 runs) and the ingest
  rate is identical (149.2 vs 149.1 MiB/s) whether the upload window is 4-wide or serial
  (`LIX_MOVIE_UPLOAD_CONCURRENCY=1`), so it is not write-pressure-driven; and RocksDB, on the same
  code, reports 0. It is a SlateDB read-path property of this qualification and wants its own
  investigation.

Residual, minor and separate: at a 4-wide window `chunk_hash_bytes_including_retries` is 560 MiB for
512 MiB ingested — exactly three 16 MiB parts re-hashed. That is the *first* window's
`UPLOAD_STATE_SPACE` `KeyAbsent` contention (four parts of a brand-new upload all try to create the
state row), not the fence: at `LIX_MOVIE_UPLOAD_CONCURRENCY=1` it is exactly 512 MiB, i.e. zero
retries. Worth a follow-up; not fixed here.

## Performance

This is a correctness fix, so the A/B acceptance gate does not apply, and it is not slower:

* Publisher: one revision-key point read (as before) and one revision-key put (as before), 16-byte
  value instead of 8. No change in staged row count or storage round trips.
* Sweep: the second key rides the existing batched `load_revisions` read — no extra round trip — plus
  one more precondition.
* The qualification's own numbers improve where the fence was the bottleneck: retried chunk hashing
  drops from a full retry storm to the residual 48 MiB noted above, and `writer_gate_wait_ms` is 0.

## Layout invariants

1. **Single authority.** No new authority. The old row carried two facts under one name, which is
   why it could not express an asymmetric fence; each fact now has its own row with exactly one
   writer class (sweeps write reclamation, publishers write publication). Neither is derived from the
   other and neither duplicates the other. The old key is reused for one of the two roles.
2. **Commit canonicality.** Untouched — no change to commit records, parent links, or state roots.
3. **Derived views are caches.** Untouched. Both tokens are fence tokens in the existing
   `lix.revision.v1` singleton space; neither is read by any serving path.
4. **Atomic publication.** Preserved for both participants. The fence is staged into the *same* write
   set as the state root, commit record, derived head view and ref — one atomic storage write,
   unchanged. Only which preconditions guard that write changed; no commit is split into stages, and
   no reader can observe a half-published cohort.
5. **GC from refs.** Unchanged. Reachability still starts at branch-head controls and checkpoint
   recovery refs and walks commits → state nodes → blobs. One reachability implementation; the sweep
   is fenced exactly as strictly as before.
6. **SQL reads canonical records.** Untouched.

## Note on #1310

#1310 carries a bounded retry at the `:504` save site. If this lands, that retry should not — the
engine was wrong, not the caller. Nothing here asks any application to retry an ordinary concurrent
write.
