### PR TITLE
bench(working-diff): measure the file-scoped over-scan and rule out partitioning the coverage proof

### DIFF
--- a/packages/engine-benchmarks/Cargo.toml
+++ b/packages/engine-benchmarks/Cargo.toml
@@ -198,6 +198,12 @@ harness = false
 required-features = ["storage-benches", "slatedb"]
 
 [[bench]]
+name = "working_diff_file_scope"
+path = "benches/working_diff_file_scope.rs"
+harness = false
+required-features = ["storage-benches", "slatedb"]
+
+[[bench]]
 name = "slatedb_file_api"
 path = "benches/slatedb_file_api.rs"
 harness = false

--- a/packages/engine-benchmarks/benches/working_diff_file_scope.rs
+++ b/packages/engine-benchmarks/benches/working_diff_file_scope.rs
@@ -1,0 +1,461 @@
+#![allow(clippy::large_futures)]
+
+//! Scaling harness for **file-scoped** working-diff reads.
+//!
+//! `docs/diff-commands.md` documents `SELECT ... FROM lix_working_diff WHERE
+//! file_id = $1` as the headline shape, but no benchmark covered it. This
+//! harness holds the *returned* row count fixed and grows the *total* dirty
+//! set since the checkpoint, so the slope answers one question: does a
+//! narrow file-scoped working-diff read cost O(rows returned) or O(all dirty
+//! rows in the branch)?
+//!
+//! Three query shapes are timed against the same fixture:
+//!   * `full`   — unfiltered `lix_working_diff` (the existing bench shape)
+//!   * `file`   — `WHERE file_id = $1` on one lightly dirtied file
+//!   * `finite` — `WHERE schema_key = $1 AND entity_pk = lix_json($2)`, which
+//!                takes the existing finite-filter bypass in
+//!                `hot_working_diff_entries` and therefore never touches the
+//!                HOT_DIFF index or its coverage proof.
+//!
+//! ```text
+//! cargo bench -p lix_benchmarks --features storage-benches,slatedb \
+//!   --bench working_diff_file_scope -- rocksdb 64 40 100 9
+//! ```
+//! Positionals: `<rocksdb|slatedb> <files> <rows-per-file> <changes-per-commit> <reps>`
+//! then a list of total dirty-row targets, e.g. `1000 10000 100000`.
+
+use std::fmt::Write as _;
+use std::time::{Duration, Instant};
+
+#[cfg(not(target_family = "wasm"))]
+#[global_allocator]
+static GLOBAL_ALLOCATOR: mimalloc::MiMalloc = mimalloc::MiMalloc;
+
+use lix::integration::{Engine, SessionContext};
+use lix::storage::Storage;
+use lix::{ExecuteBatchStatement, Value};
+use lix_storage_rocksdb::RocksDB;
+use lix_storage_slatedb::SlateDB;
+
+const SCHEMA_KEY: &str = "wd_file_row";
+const INSERT_BATCH_SIZE: usize = 500;
+/// Rows dirtied inside the probe file. Held constant across every dirty-set
+/// size so the file-scoped query always returns the same number of rows.
+const PROBE_DIRTY_ROWS: usize = 4;
+
+fn main() {
+    let args = std::env::args().collect::<Vec<_>>();
+    let backend = args.get(1).map(String::as_str).unwrap_or("rocksdb");
+    let files = parse_usize(args.get(2), 64);
+    let rows_per_file = parse_usize(args.get(3), 40);
+    let changes_per_commit = parse_usize(args.get(4), 100);
+    let reps = parse_usize(args.get(5), 9);
+    let targets = args
+        .get(6..)
+        .map(|rest| {
+            rest.iter()
+                .filter(|value| value.parse::<usize>().is_ok())
+                .map(|value| value.parse::<usize>().expect("checked"))
+                .collect::<Vec<_>>()
+        })
+        .filter(|targets: &Vec<usize>| !targets.is_empty())
+        .unwrap_or_else(|| vec![1_000, 10_000, 100_000]);
+
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("create working-diff file-scope runtime");
+
+    for target in targets {
+        let dir = tempdir(backend, target);
+        runtime.block_on(async {
+            match backend {
+                "rocksdb" => {
+                    let storage = RocksDB::open(&dir).expect("open working-diff file-scope RocksDB");
+                    run(
+                        storage.clone(),
+                        backend,
+                        files,
+                        rows_per_file,
+                        changes_per_commit,
+                        target,
+                        reps,
+                    )
+                    .await;
+                    storage.flush().expect("flush RocksDB");
+                }
+                "slatedb" => {
+                    let storage = SlateDB::open(&dir).expect("open working-diff file-scope SlateDB");
+                    run(
+                        storage.clone(),
+                        backend,
+                        files,
+                        rows_per_file,
+                        changes_per_commit,
+                        target,
+                        reps,
+                    )
+                    .await;
+                    storage.flush().await.expect("flush SlateDB");
+                }
+                other => panic!("backend must be 'rocksdb' or 'slatedb', got '{other}'"),
+            }
+        });
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+}
+
+fn tempdir(backend: &str, target: usize) -> String {
+    let nanos = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .expect("clock")
+        .as_nanos();
+    format!("/tmp/lix-expS-wdfs-{backend}-{target}-{nanos}")
+}
+
+fn parse_usize(value: Option<&String>, default: usize) -> usize {
+    value.map_or(default, |value| {
+        value.parse::<usize>().unwrap_or_else(|_| default)
+    })
+}
+
+async fn run<StorageImpl>(
+    storage: StorageImpl,
+    backend: &str,
+    files: usize,
+    rows_per_file: usize,
+    changes_per_commit: usize,
+    dirty_target: usize,
+    reps: usize,
+) where
+    StorageImpl: Storage + Clone + Send + Sync + 'static,
+{
+    Engine::initialize(storage.clone())
+        .await
+        .expect("initialize working-diff file-scope storage");
+    let engine = Engine::new(storage.clone())
+        .await
+        .expect("open working-diff file-scope engine");
+    let session = engine
+        .open_workspace_session()
+        .await
+        .expect("open working-diff file-scope session");
+
+    register_schema(&session).await;
+    let file_ids = (0..files).map(file_id).collect::<Vec<_>>();
+    seed_files(&session, &file_ids).await;
+    // Every dirty row must exist before the checkpoint so the working diff is
+    // a pure "modified" set with a stable returned-row count.
+    let bulk_files = files.saturating_sub(1);
+    let bulk_rows_needed = dirty_target.saturating_sub(PROBE_DIRTY_ROWS);
+    let bulk_rows_per_file = bulk_rows_needed.div_ceil(bulk_files.max(1)).max(rows_per_file);
+    seed_rows(&session, &file_ids, bulk_rows_per_file).await;
+
+    session
+        .create_checkpoint()
+        .await
+        .expect("create working-diff file-scope checkpoint");
+
+    // Dirty exactly PROBE_DIRTY_ROWS rows inside file 0 …
+    dirty_rows(
+        &session,
+        &[(0usize, PROBE_DIRTY_ROWS)],
+        changes_per_commit,
+        bulk_rows_per_file,
+    )
+    .await;
+    // … and spread the remainder over files 1..files, never touching file 0.
+    let mut plan = Vec::new();
+    let mut remaining = bulk_rows_needed;
+    let mut file_index = 1usize;
+    while remaining > 0 && file_index < files.max(2) {
+        let take = remaining.min(bulk_rows_per_file);
+        plan.push((file_index, take));
+        remaining -= take;
+        file_index += 1;
+        if file_index >= files {
+            break;
+        }
+    }
+    assert_eq!(
+        remaining, 0,
+        "fixture cannot hold {dirty_target} dirty rows in {files} files \
+         at {bulk_rows_per_file} rows/file"
+    );
+    dirty_rows(&session, &plan, changes_per_commit, bulk_rows_per_file).await;
+
+    let total_dirty = count(&session, "SELECT COUNT(*) FROM lix_working_diff", &[]).await;
+    let probe_file = file_ids[0].clone();
+    let file_sql = "SELECT diff_id, entity_pk, schema_key, file_id, diff_type \
+                    FROM lix_working_diff WHERE file_id = $1";
+    let full_sql = "SELECT diff_id, entity_pk, schema_key, file_id, diff_type \
+                    FROM lix_working_diff";
+    let finite_sql = "SELECT diff_id, entity_pk, schema_key, file_id, diff_type \
+                      FROM lix_working_diff \
+                      WHERE schema_key = $1 AND entity_pk = lix_json($2)";
+    let file_params = vec![Value::Text(probe_file.clone())];
+    let finite_params = vec![
+        Value::Text(SCHEMA_KEY.to_string()),
+        Value::Text(format!("[\"{}\"]", row_id(0, 0))),
+    ];
+
+    // Warm provider construction and the block cache outside the samples.
+    let file_rows = rows(&session, file_sql, &file_params).await;
+    let full_rows = rows(&session, full_sql, &[]).await;
+    let finite_rows = rows(&session, finite_sql, &finite_params).await;
+
+    let file = sample(&session, file_sql, &file_params, reps).await;
+    let full = sample(&session, full_sql, &[], reps).await;
+    let finite = sample(&session, finite_sql, &finite_params, reps).await;
+
+    println!(
+        "working_diff_file_scope backend={backend} files={files} total_dirty={total_dirty} \
+         file_rows={file_rows} full_rows={full_rows} finite_rows={finite_rows} reps={reps} \
+         file_p50_ms={:.3} file_min_ms={:.3} file_max_ms={:.3} \
+         full_p50_ms={:.3} full_min_ms={:.3} full_max_ms={:.3} \
+         finite_p50_ms={:.3} finite_min_ms={:.3} finite_max_ms={:.3}",
+        millis(file.0),
+        millis(file.1),
+        millis(file.2),
+        millis(full.0),
+        millis(full.1),
+        millis(full.2),
+        millis(finite.0),
+        millis(finite.1),
+        millis(finite.2),
+    );
+    drop(session);
+    drop(engine);
+}
+
+async fn sample<StorageImpl>(
+    session: &SessionContext<StorageImpl>,
+    sql: &str,
+    params: &[Value],
+    reps: usize,
+) -> (Duration, Duration, Duration)
+where
+    StorageImpl: Storage + Clone + Send + Sync + 'static,
+{
+    let mut latencies = Vec::with_capacity(reps);
+    for _ in 0..reps {
+        let start = Instant::now();
+        let _ = rows(session, sql, params).await;
+        latencies.push(start.elapsed());
+    }
+    latencies.sort_unstable();
+    (
+        latencies[latencies.len() / 2],
+        latencies[0],
+        *latencies.last().expect("samples are non-empty"),
+    )
+}
+
+async fn rows<StorageImpl>(
+    session: &SessionContext<StorageImpl>,
+    sql: &str,
+    params: &[Value],
+) -> usize
+where
+    StorageImpl: Storage + Clone + Send + Sync + 'static,
+{
+    session
+        .execute(sql, params)
+        .await
+        .expect("working-diff query should succeed")
+        .len()
+}
+
+async fn count<StorageImpl>(
+    session: &SessionContext<StorageImpl>,
+    sql: &str,
+    params: &[Value],
+) -> i64
+where
+    StorageImpl: Storage + Clone + Send + Sync + 'static,
+{
+    let result = session
+        .execute(sql, params)
+        .await
+        .expect("working-diff count should succeed");
+    match result.rows().first().and_then(|row| row.get(0)) {
+        Some(Value::Integer(value)) => *value,
+        other => panic!("unexpected count row {other:?}"),
+    }
+}
+
+async fn register_schema<StorageImpl>(session: &SessionContext<StorageImpl>)
+where
+    StorageImpl: Storage + Clone + Send + Sync + 'static,
+{
+    let schema = serde_json::json!({
+        "x-lix-key": SCHEMA_KEY,
+        "x-lix-primary-key": ["/id"],
+        "type": "object",
+        "required": ["id", "value"],
+        "properties": {
+            "id": { "type": "string" },
+            "value": { "type": "string" }
+        },
+        "additionalProperties": false
+    });
+    session
+        .execute(
+            "INSERT INTO lix_registered_schema (value, lixcol_global, lixcol_untracked) \
+             VALUES (lix_json($1), false, false)",
+            &[Value::Text(schema.to_string())],
+        )
+        .await
+        .expect("register working-diff file-scope schema");
+}
+
+async fn seed_files<StorageImpl>(session: &SessionContext<StorageImpl>, file_ids: &[String])
+where
+    StorageImpl: Storage + Clone + Send + Sync + 'static,
+{
+    let mut transaction = session
+        .begin_transaction()
+        .await
+        .expect("begin file seed transaction");
+    for chunk in file_ids.chunks(100) {
+        let mut sql = String::from("INSERT INTO lix_file (id, path, content) VALUES ");
+        let mut params = Vec::with_capacity(chunk.len() * 3);
+        for (offset, id) in chunk.iter().enumerate() {
+            if offset > 0 {
+                sql.push(',');
+            }
+            let parameter = offset * 3;
+            write!(
+                sql,
+                "(${}, ${}, CAST(${} AS BYTEA))",
+                parameter + 1,
+                parameter + 2,
+                parameter + 3
+            )
+            .expect("write file insert parameters");
+            params.push(Value::Text(id.clone()));
+            params.push(Value::Text(format!("/f-{id}.txt")));
+            params.push(Value::Text("seed".to_string()));
+        }
+        transaction
+            .execute(&sql, &params)
+            .await
+            .expect("seed working-diff file-scope files");
+    }
+    transaction
+        .commit()
+        .await
+        .expect("commit file seed transaction");
+}
+
+async fn seed_rows<StorageImpl>(
+    session: &SessionContext<StorageImpl>,
+    file_ids: &[String],
+    rows_per_file: usize,
+) where
+    StorageImpl: Storage + Clone + Send + Sync + 'static,
+{
+    for (file_index, file) in file_ids.iter().enumerate() {
+        let mut transaction = session
+            .begin_transaction()
+            .await
+            .expect("begin row seed transaction");
+        for start in (0..rows_per_file).step_by(INSERT_BATCH_SIZE) {
+            let end = (start + INSERT_BATCH_SIZE).min(rows_per_file);
+            let mut sql =
+                format!("INSERT INTO {SCHEMA_KEY} (id, value, lixcol_file_id) VALUES ");
+            let mut params = Vec::with_capacity((end - start) * 3);
+            for (offset, row_index) in (start..end).enumerate() {
+                if offset > 0 {
+                    sql.push(',');
+                }
+                let parameter = offset * 3;
+                write!(
+                    sql,
+                    "(${}, ${}, ${})",
+                    parameter + 1,
+                    parameter + 2,
+                    parameter + 3
+                )
+                .expect("write row insert parameters");
+                params.push(Value::Text(row_id(file_index, row_index)));
+                params.push(Value::Text("baseline".to_string()));
+                params.push(Value::Text(file.clone()));
+            }
+            transaction
+                .execute(&sql, &params)
+                .await
+                .expect("seed working-diff file-scope rows");
+        }
+        transaction
+            .commit()
+            .await
+            .expect("commit row seed transaction");
+    }
+}
+
+/// Applies `count` updates inside each listed file, batching `changes_per_commit`
+/// statements into one commit so the HOT_DIFF packing threshold is exercised
+/// the same way an ordinary bulk edit would exercise it.
+async fn dirty_rows<StorageImpl>(
+    session: &SessionContext<StorageImpl>,
+    plan: &[(usize, usize)],
+    changes_per_commit: usize,
+    rows_per_file: usize,
+) where
+    StorageImpl: Storage + Clone + Send + Sync + 'static,
+{
+    let mut pending: Vec<ExecuteBatchStatement> = Vec::with_capacity(changes_per_commit);
+    for (file_index, count) in plan {
+        assert!(
+            *count <= rows_per_file,
+            "cannot dirty {count} rows in a file seeded with {rows_per_file}"
+        );
+        for row_index in 0..*count {
+            pending.push(ExecuteBatchStatement {
+                label: None,
+                sql: format!("UPDATE {SCHEMA_KEY} SET value = $1 WHERE id = $2"),
+                params: vec![
+                    Value::Text("dirty".to_string()),
+                    Value::Text(row_id(*file_index, row_index)),
+                ],
+            });
+            if pending.len() >= changes_per_commit {
+                flush(session, &mut pending).await;
+            }
+        }
+    }
+    flush(session, &mut pending).await;
+}
+
+async fn flush<StorageImpl>(
+    session: &SessionContext<StorageImpl>,
+    pending: &mut Vec<ExecuteBatchStatement>,
+) where
+    StorageImpl: Storage + Clone + Send + Sync + 'static,
+{
+    if pending.is_empty() {
+        return;
+    }
+    let results = session
+        .execute_batch(pending)
+        .await
+        .expect("dirty working-diff rows");
+    assert!(
+        results.iter().all(|result| result.rows_affected() == 1),
+        "every dirtying update must affect exactly one row"
+    );
+    pending.clear();
+}
+
+fn file_id(index: usize) -> String {
+    format!("66696c65-{:04x}-8000-8000-{:012x}", index & 0xffff, index)
+}
+
+fn row_id(file_index: usize, row_index: usize) -> String {
+    format!("f{file_index:04}-r{row_index:06}")
+}
+
+fn millis(duration: Duration) -> f64 {
+    duration.as_secs_f64() * 1_000.0
+}

--- a/packages/engine-benchmarks/benches/working_diff_file_scope.rs
+++ b/packages/engine-benchmarks/benches/working_diff_file_scope.rs
@@ -184,7 +184,6 @@ async fn run<StorageImpl>(
     );
     dirty_rows(&session, &plan, changes_per_commit, bulk_rows_per_file).await;
 
-    let total_dirty = count(&session, "SELECT COUNT(*) FROM lix_working_diff", &[]).await;
     let probe_file = file_ids[0].clone();
     let file_sql = "SELECT diff_id, entity_pk, schema_key, file_id, diff_type \
                     FROM lix_working_diff WHERE file_id = $1";
@@ -209,7 +208,7 @@ async fn run<StorageImpl>(
     let finite = sample(&session, finite_sql, &finite_params, reps).await;
 
     println!(
-        "working_diff_file_scope backend={backend} files={files} total_dirty={total_dirty} \
+        "working_diff_file_scope backend={backend} files={files} total_dirty={full_rows} \
          file_rows={file_rows} full_rows={full_rows} finite_rows={finite_rows} reps={reps} \
          file_p50_ms={:.3} file_min_ms={:.3} file_max_ms={:.3} \
          full_p50_ms={:.3} full_min_ms={:.3} full_max_ms={:.3} \
@@ -264,24 +263,6 @@ where
         .await
         .expect("working-diff query should succeed")
         .len()
-}
-
-async fn count<StorageImpl>(
-    session: &SessionContext<StorageImpl>,
-    sql: &str,
-    params: &[Value],
-) -> i64
-where
-    StorageImpl: Storage + Clone + Send + Sync + 'static,
-{
-    let result = session
-        .execute(sql, params)
-        .await
-        .expect("working-diff count should succeed");
-    match result.rows().first().and_then(|row| row.get(0)) {
-        Some(Value::Integer(value)) => *value,
-        other => panic!("unexpected count row {other:?}"),
-    }
 }
 
 async fn register_schema<StorageImpl>(session: &SessionContext<StorageImpl>)

--- a/packages/engine-benchmarks/benches/working_diff_file_scope.rs
+++ b/packages/engine-benchmarks/benches/working_diff_file_scope.rs
@@ -151,8 +151,7 @@ async fn run<StorageImpl>(
     seed_files(&session, &file_ids).await;
     // Every dirty row must exist before the checkpoint so the working diff is
     // a pure "modified" set with a stable returned-row count.
-    let bulk_rows_per_file = rows_per_file;
-    seed_rows(&session, &file_ids, bulk_rows_per_file).await;
+    seed_rows(&session, &file_ids, rows_per_file).await;
 
     session
         .create_checkpoint()
@@ -164,7 +163,7 @@ async fn run<StorageImpl>(
         &session,
         &[(0usize, PROBE_DIRTY_ROWS)],
         changes_per_commit,
-        bulk_rows_per_file,
+        rows_per_file,
     )
     .await;
     // … and spread the remainder over files 1..files, never touching file 0.
@@ -172,7 +171,7 @@ async fn run<StorageImpl>(
     let mut remaining = bulk_rows_needed;
     let mut file_index = 1usize;
     while remaining > 0 && file_index < files.max(2) {
-        let take = remaining.min(bulk_rows_per_file);
+        let take = remaining.min(rows_per_file);
         plan.push((file_index, take));
         remaining -= take;
         file_index += 1;
@@ -183,9 +182,9 @@ async fn run<StorageImpl>(
     assert_eq!(
         remaining, 0,
         "fixture cannot hold {dirty_target} dirty rows in {files} files \
-         at {bulk_rows_per_file} rows/file"
+         at {rows_per_file} rows/file"
     );
-    dirty_rows(&session, &plan, changes_per_commit, bulk_rows_per_file).await;
+    dirty_rows(&session, &plan, changes_per_commit, rows_per_file).await;
 
     let probe_file = file_ids[0].clone();
     let file_sql = "SELECT diff_id, entity_pk, schema_key, file_id, diff_type \

--- a/packages/engine-benchmarks/benches/working_diff_file_scope.rs
+++ b/packages/engine-benchmarks/benches/working_diff_file_scope.rs
@@ -213,9 +213,9 @@ async fn run<StorageImpl>(
     // `lixcol_file_id` into `TrackedStateFilter::file_ids` (its
     // `filter_pushdown` only recognizes branch-id and primary-key analyzers),
     // so this measures a full schema scan with a residual filter. Reported to
-    // keep that gap visible: `entity_rows` stays fixed at `rows_per_file`
+    // keep that gap visible: `entity_scan_rows` stays fixed at `rows_per_file`
     // while the latency tracks the whole schema.
-    let proxy_sql = format!("SELECT id FROM {SCHEMA_KEY} WHERE lixcol_file_id = $1");
+    let entity_scan_sql = format!("SELECT id FROM {SCHEMA_KEY} WHERE lixcol_file_id = $1");
     let file_params = vec![Value::Text(probe_file.clone())];
     let file_schema_params = vec![
         Value::Text(probe_file.clone()),
@@ -232,18 +232,18 @@ async fn run<StorageImpl>(
     let full_rows = rows(&session, full_sql, &[]).await;
     let file_schema_rows = rows(&session, file_schema_sql, &file_schema_params).await;
     let point_rows = rows(&session, point_sql, &point_params).await;
-    let proxy_rows = rows(&session, &proxy_sql, &file_params).await;
+    let entity_scan_rows_count = rows(&session, &entity_scan_sql, &file_params).await;
 
     let file = sample(&session, file_sql, &file_params, reps).await;
     let full = sample(&session, full_sql, &[], reps).await;
     let file_schema = sample(&session, file_schema_sql, &file_schema_params, reps).await;
     let point = sample(&session, point_sql, &point_params, reps).await;
-    let proxy = sample(&session, &proxy_sql, &file_params, reps).await;
+    let entity_scan = sample(&session, &entity_scan_sql, &file_params, reps).await;
 
     println!(
         "working_diff_file_scope backend={backend} files={files} total_dirty={full_rows} \
          file_rows={file_rows} full_rows={full_rows} file_schema_rows={file_schema_rows} \
-         point_rows={point_rows} entity_scan_rows={proxy_rows} reps={reps} \
+         point_rows={point_rows} entity_scan_rows={entity_scan_rows_count} reps={reps} \
          file_p50_ms={:.3} file_min_ms={:.3} file_max_ms={:.3} \
          full_p50_ms={:.3} full_min_ms={:.3} full_max_ms={:.3} \
          file_schema_p50_ms={:.3} file_schema_min_ms={:.3} file_schema_max_ms={:.3} \
@@ -261,9 +261,9 @@ async fn run<StorageImpl>(
         millis(point.0),
         millis(point.1),
         millis(point.2),
-        millis(proxy.0),
-        millis(proxy.1),
-        millis(proxy.2),
+        millis(entity_scan.0),
+        millis(entity_scan.1),
+        millis(entity_scan.2),
     );
     drop(session);
     drop(engine);

--- a/packages/engine-benchmarks/benches/working_diff_file_scope.rs
+++ b/packages/engine-benchmarks/benches/working_diff_file_scope.rs
@@ -189,39 +189,67 @@ async fn run<StorageImpl>(
                     FROM lix_working_diff WHERE file_id = $1";
     let full_sql = "SELECT diff_id, entity_pk, schema_key, file_id, diff_type \
                     FROM lix_working_diff";
-    let finite_sql = "SELECT diff_id, entity_pk, schema_key, file_id, diff_type \
-                      FROM lix_working_diff \
-                      WHERE schema_key = $1 AND entity_pk = lix_json($2)";
+    // `schema_key + file_id`, the shape of the only file-scoped working-diff
+    // test in the tree. Still a full HOT_DIFF scan today.
+    let file_schema_sql = "SELECT diff_id, entity_pk, schema_key, file_id, diff_type \
+                           FROM lix_working_diff WHERE file_id = $1 AND schema_key = $2";
+    // Finite identity + file id: takes the existing bypass and resolves as a
+    // point read. This is the floor a seekable file-scoped read aims at.
+    let point_sql = "SELECT diff_id, entity_pk, schema_key, file_id, diff_type \
+                     FROM lix_working_diff \
+                     WHERE schema_key = $1 AND entity_pk = lix_json($2) AND file_id = $3";
+    // Live-state read of the same file through HOT_ROW's existing file-first
+    // prefix seek. Proxy for what a HOT_ROW-seeking working-diff read would
+    // cost: O(live rows in the file) instead of O(all dirty rows).
+    let proxy_sql = format!("SELECT id FROM {SCHEMA_KEY} WHERE lixcol_file_id = $1");
     let file_params = vec![Value::Text(probe_file.clone())];
-    let finite_params = vec![
+    let file_schema_params = vec![
+        Value::Text(probe_file.clone()),
+        Value::Text(SCHEMA_KEY.to_string()),
+    ];
+    let point_params = vec![
         Value::Text(SCHEMA_KEY.to_string()),
         Value::Text(format!("[\"{}\"]", row_id(0, 0))),
+        Value::Text(probe_file.clone()),
     ];
 
     // Warm provider construction and the block cache outside the samples.
     let file_rows = rows(&session, file_sql, &file_params).await;
     let full_rows = rows(&session, full_sql, &[]).await;
-    let finite_rows = rows(&session, finite_sql, &finite_params).await;
+    let file_schema_rows = rows(&session, file_schema_sql, &file_schema_params).await;
+    let point_rows = rows(&session, point_sql, &point_params).await;
+    let proxy_rows = rows(&session, &proxy_sql, &file_params).await;
 
     let file = sample(&session, file_sql, &file_params, reps).await;
     let full = sample(&session, full_sql, &[], reps).await;
-    let finite = sample(&session, finite_sql, &finite_params, reps).await;
+    let file_schema = sample(&session, file_schema_sql, &file_schema_params, reps).await;
+    let point = sample(&session, point_sql, &point_params, reps).await;
+    let proxy = sample(&session, &proxy_sql, &file_params, reps).await;
 
     println!(
         "working_diff_file_scope backend={backend} files={files} total_dirty={full_rows} \
-         file_rows={file_rows} full_rows={full_rows} finite_rows={finite_rows} reps={reps} \
+         file_rows={file_rows} full_rows={full_rows} file_schema_rows={file_schema_rows} \
+         point_rows={point_rows} proxy_rows={proxy_rows} reps={reps} \
          file_p50_ms={:.3} file_min_ms={:.3} file_max_ms={:.3} \
          full_p50_ms={:.3} full_min_ms={:.3} full_max_ms={:.3} \
-         finite_p50_ms={:.3} finite_min_ms={:.3} finite_max_ms={:.3}",
+         file_schema_p50_ms={:.3} file_schema_min_ms={:.3} file_schema_max_ms={:.3} \
+         point_p50_ms={:.3} point_min_ms={:.3} point_max_ms={:.3} \
+         proxy_p50_ms={:.3} proxy_min_ms={:.3} proxy_max_ms={:.3}",
         millis(file.0),
         millis(file.1),
         millis(file.2),
         millis(full.0),
         millis(full.1),
         millis(full.2),
-        millis(finite.0),
-        millis(finite.1),
-        millis(finite.2),
+        millis(file_schema.0),
+        millis(file_schema.1),
+        millis(file_schema.2),
+        millis(point.0),
+        millis(point.1),
+        millis(point.2),
+        millis(proxy.0),
+        millis(proxy.1),
+        millis(proxy.2),
     );
     drop(session);
     drop(engine);

--- a/packages/engine-benchmarks/benches/working_diff_file_scope.rs
+++ b/packages/engine-benchmarks/benches/working_diff_file_scope.rs
@@ -142,13 +142,16 @@ async fn run<StorageImpl>(
         .expect("open working-diff file-scope session");
 
     register_schema(&session).await;
+    // Rows per file stays FIXED and the file count grows with the dirty
+    // target. Holding the file width constant is what makes the probe file's
+    // cost independent of the dirty-set size, which is the whole question.
+    let bulk_rows_needed = dirty_target.saturating_sub(PROBE_DIRTY_ROWS);
+    let files = files.max(1 + bulk_rows_needed.div_ceil(rows_per_file));
     let file_ids = (0..files).map(file_id).collect::<Vec<_>>();
     seed_files(&session, &file_ids).await;
     // Every dirty row must exist before the checkpoint so the working diff is
     // a pure "modified" set with a stable returned-row count.
-    let bulk_files = files.saturating_sub(1);
-    let bulk_rows_needed = dirty_target.saturating_sub(PROBE_DIRTY_ROWS);
-    let bulk_rows_per_file = bulk_rows_needed.div_ceil(bulk_files.max(1)).max(rows_per_file);
+    let bulk_rows_per_file = rows_per_file;
     seed_rows(&session, &file_ids, bulk_rows_per_file).await;
 
     session

--- a/packages/engine-benchmarks/benches/working_diff_file_scope.rs
+++ b/packages/engine-benchmarks/benches/working_diff_file_scope.rs
@@ -9,20 +9,27 @@
 //! narrow file-scoped working-diff read cost O(rows returned) or O(all dirty
 //! rows in the branch)?
 //!
-//! Three query shapes are timed against the same fixture:
-//!   * `full`   — unfiltered `lix_working_diff` (the existing bench shape)
-//!   * `file`   — `WHERE file_id = $1` on one lightly dirtied file
-//!   * `finite` — `WHERE schema_key = $1 AND entity_pk = lix_json($2)`, which
-//!                takes the existing finite-filter bypass in
-//!                `hot_working_diff_entries` and therefore never touches the
-//!                HOT_DIFF index or its coverage proof.
+//! Five query shapes are timed against the same fixture:
+//!   * `full`        — unfiltered `lix_working_diff` (the existing bench shape)
+//!   * `file`        — `WHERE file_id = $1`, the shape `docs/diff-commands.md`
+//!                     shows first
+//!   * `file_schema` — `WHERE file_id = $1 AND schema_key = $2`, the shape of
+//!                     the one file-scoped working-diff test in the tree
+//!   * `point`       — `WHERE schema_key = $1 AND entity_pk = lix_json($2) AND
+//!                     file_id = $3`, which takes the finite-filter bypass in
+//!                     `hot_working_diff_entries` and therefore never reads the
+//!                     HOT_DIFF index or verifies its coverage proof. This is
+//!                     the control: it isolates the proof as the cost.
+//!   * `entity_scan` — the same file read through the ordinary entity surface,
+//!                     which does not push `lixcol_file_id` down at all.
 //!
 //! ```text
 //! cargo bench -p lix_benchmarks --features storage-benches,slatedb \
-//!   --bench working_diff_file_scope -- rocksdb 64 40 100 9
+//!   --bench working_diff_file_scope -- rocksdb 8 40 100 9 1000 20000 100000
 //! ```
-//! Positionals: `<rocksdb|slatedb> <files> <rows-per-file> <changes-per-commit> <reps>`
-//! then a list of total dirty-row targets, e.g. `1000 10000 100000`.
+//! Positionals: `<rocksdb|slatedb> <min-files> <rows-per-file> <changes-per-commit> <reps>`
+//! then a list of total dirty-row targets, e.g. `1000 10000 100000`. Rows per
+//! file is fixed; the file count grows to hold the requested dirty set.
 
 use std::fmt::Write as _;
 use std::time::{Duration, Instant};
@@ -200,9 +207,14 @@ async fn run<StorageImpl>(
     let point_sql = "SELECT diff_id, entity_pk, schema_key, file_id, diff_type \
                      FROM lix_working_diff \
                      WHERE schema_key = $1 AND entity_pk = lix_json($2) AND file_id = $3";
-    // Live-state read of the same file through HOT_ROW's existing file-first
-    // prefix seek. Proxy for what a HOT_ROW-seeking working-diff read would
-    // cost: O(live rows in the file) instead of O(all dirty rows).
+    // Live-state read of the same file. HOT_ROW is keyed
+    // `schema_key ++ file_id ++ entity_pk` and `hot_scan_entries` owns a
+    // file-first prefix route, but the entity surface never pushes
+    // `lixcol_file_id` into `TrackedStateFilter::file_ids` (its
+    // `filter_pushdown` only recognizes branch-id and primary-key analyzers),
+    // so this measures a full schema scan with a residual filter. Reported to
+    // keep that gap visible: `entity_rows` stays fixed at `rows_per_file`
+    // while the latency tracks the whole schema.
     let proxy_sql = format!("SELECT id FROM {SCHEMA_KEY} WHERE lixcol_file_id = $1");
     let file_params = vec![Value::Text(probe_file.clone())];
     let file_schema_params = vec![
@@ -231,12 +243,12 @@ async fn run<StorageImpl>(
     println!(
         "working_diff_file_scope backend={backend} files={files} total_dirty={full_rows} \
          file_rows={file_rows} full_rows={full_rows} file_schema_rows={file_schema_rows} \
-         point_rows={point_rows} proxy_rows={proxy_rows} reps={reps} \
+         point_rows={point_rows} entity_scan_rows={proxy_rows} reps={reps} \
          file_p50_ms={:.3} file_min_ms={:.3} file_max_ms={:.3} \
          full_p50_ms={:.3} full_min_ms={:.3} full_max_ms={:.3} \
          file_schema_p50_ms={:.3} file_schema_min_ms={:.3} file_schema_max_ms={:.3} \
          point_p50_ms={:.3} point_min_ms={:.3} point_max_ms={:.3} \
-         proxy_p50_ms={:.3} proxy_min_ms={:.3} proxy_max_ms={:.3}",
+         entity_scan_p50_ms={:.3} entity_scan_min_ms={:.3} entity_scan_max_ms={:.3}",
         millis(file.0),
         millis(file.1),
         millis(file.2),

--- a/packages/lix/src/live_state/tracked_head/hot.rs
+++ b/packages/lix/src/live_state/tracked_head/hot.rs
@@ -10653,10 +10653,53 @@ fn encode_hot_diff_key_parts(
 ///   into segments keyed by `scope ++ digest`; the identity components leave
 ///   the key for the segment value altogether.
 ///
-/// The order is therefore an arbitrary but load-bearing input to the
-/// coverage hash: every writer, the segment visitor, and the stored epoch
-/// coverage must produce these bytes identically. Change it only for a
-/// reason, and only everywhere at once.
+/// The order is not arbitrary in one respect: it is exactly
+/// `compare_hot_deltas`, the order a publication's deltas are already sorted
+/// in, so the segment packer can append identity suffixes without a second
+/// sort. It is otherwise a load-bearing input to the coverage hash: every
+/// writer, the segment visitor, and the stored epoch coverage must produce
+/// these bytes identically. Change it only for a reason, and only everywhere
+/// at once.
+///
+/// # Why the proof is not partitioned
+///
+/// [`WorkingDiffIndexCoverage`] is a monoid — `group_count` is additive and
+/// `group_key_xor` is commutative — so it looks like it could be maintained
+/// per `file_id`, composed back into the scope proof, and a
+/// `scope ++ file_id` seek made legal. Two independent facts block that:
+///
+/// - **Not every coverage group is an identity.** A packed current base
+///   contributes exactly one group key naming a *commit*
+///   (`hot_scope_prefix ++ new_head`, see the collection-replacement writer),
+///   standing for a whole schema collection whose members span every file and
+///   are only recoverable through `load_commit_delta_members_with_payloads`
+///   at read time. Attributing it to file partitions means expanding it per
+///   member on the write path — reinstating the per-identity coverage cost
+///   the manifest exists to remove.
+/// - **A partition-keyed segment is not a packed segment.** A segment batches
+///   whatever identities one publication produced, in `compare_hot_deltas`
+///   order — which is this key's `schema_key ++ entity_pk ++ file_id`, so
+///   `file_id` is the *last* discriminator and identities of one file are
+///   scattered through the batch. Moving the partition ahead of the digest
+///   forces the packer to re-sort and split each publication by `file_id`, so
+///   a bulk edit spread over many files emits one segment per file — each
+///   re-paying the scope and a 32-byte digest — and most publications stop
+///   reaching `HOT_DIFF_PACK_MIN_IDENTITIES` per partition at all.
+///
+/// Measured consequence of leaving the proof scope-global (rocksdb,
+/// hetzner-cpx62-II, `working_diff_file_scope`, 9 reps, four dirty rows in the
+/// probed file): `WHERE file_id = ?` costs 0.61 ms at 1k total dirty rows and
+/// 51.6 ms at 100k — linear in the dirty set, flat in the answer — while the
+/// finite `schema_key + entity_pk + file_id` shape that bypasses this space
+/// stays at ~0.5 ms across the same range.
+///
+/// The route that would remove that scan does not need this space at all:
+/// `HOT_ROW` is already keyed `schema_key ++ file_id ++ entity_pk` and
+/// `hot_scan_entries` already owns a file-first prefix route, so a
+/// `schema_key + file_id` working-diff read could enumerate primary rows the
+/// way the finite bypass does. That trades O(dirty rows in the branch) for
+/// O(live rows in the file) and still owes a soundness argument for rows that
+/// leave `HOT_ROW` entirely (untracked deletes), so it is not implemented.
 fn append_hot_diff_key_parts(
     key_bytes: &mut Vec<u8>,
     scope: &[u8],


### PR DESCRIPTION
## Summary

**Negative result.** Experiment S asked whether the working-diff coverage proof forces an unnecessary
full scan, and whether the proof's monoid structure (`group_count` adds, `group_key_xor` XORs) lets it
be maintained per `file_id` so a `scope ++ file_id` seek becomes legal.

The over-scan is real and asymptotic — measured below, **84× at 100k dirty rows for a 4-row answer**.
The proposed fix does not work: partitioning the proof is blocked by two independent packing facts.
This PR lands the missing benchmark that records the cliff and a doc comment that records why the
obvious fix is not available, so the next attempt starts from facts rather than re-deriving them.

**No engine behaviour changes.** The only `packages/lix` edit is a rustdoc comment.

## What changed

- **New** `packages/engine-benchmarks/benches/working_diff_file_scope.rs` — a scaling harness that
  holds the *returned* row count fixed at 4 and grows the *total* dirty set since the checkpoint.
  `docs/diff-commands.md` documents `SELECT ... FROM lix_working_diff WHERE file_id = $1` as its
  headline example ("Revert every working change in one file") and **no benchmark covered it**:
  `tracked_working_diff` runs unfiltered, `diff_commands` filters on `schema_key` only,
  `profile_checkpoint_scale` runs unfiltered counts.
- **Doc comment** on `append_hot_diff_key_parts` (`packages/lix/src/live_state/tracked_head/hot.rs`),
  extending the note shipped in #1306 with the measured cost of the scope-global proof, the two
  blockers against partitioning it, and one correction: the component order is *not* arbitrary — it is
  exactly `compare_hot_deltas`, the order a publication's deltas already arrive in, which is what lets
  the segment packer append identity suffixes without a second sort.

Nothing removed. No changenote: documentation-only + benchmark-only per `.changenotes/README.md`.

## Is file-scoped working diff a real query shape?

Advertised, barely exercised.

| Where | Shape | Count |
|---|---|---|
| `docs/diff-commands.md:23,34,72` | `WHERE file_id = $1` (no `schema_key`, no `entity_pk`) | headline example of the page |
| `packages/lix/tests/integration/sql/lix_file.rs:249` | `WHERE file_id = ? AND schema_key = ?` | 1 test |
| JS SDK (`packages/js-sdk`) | — | 0 (raw `lix.execute` passthrough only; no working-diff API) |
| CLI, website, plugins, rs-sdk-tests | — | 0 |
| Benchmarks | — | 0 before this PR |

`lix_file_working_diff` / `lix_directory_working_diff` do **not** count: `filesystem_working_diff.rs:237`
deliberately runs a fully unfiltered `diff_commits` because it must answer "which files changed", then
post-filters by `id` in memory.

So this is a documented API with a latent asymptotic cliff, not a hot path in any profile.

## The over-scan, measured

`working_diff_file_scope`, rocksdb, `hetzner-cpx62-II`, 9 reps/arm, 40 rows per file (fixed), 4 dirty
rows in the probed file at every size, 100 changes per commit. Command:

```
./target/release/deps/working_diff_file_scope-<hash> rocksdb 8 40 100 9 1000 5000 20000 50000 100000
```

| total dirty | files | `WHERE file_id=?` p50 (min–max) | `file_id + schema_key` p50 | `schema_key + entity_pk + file_id` p50 | unfiltered p50 |
|---:|---:|---|---|---|---|
| 1,000 | 26 | **0.611** (0.600–0.725) | 0.628 | 0.456 | 2.492 |
| 5,000 | 126 | **2.659** (2.624–2.993) | 2.732 | 0.470 | 13.657 |
| 20,000 | 501 | **10.310** (10.066–10.998) | 10.886 | 0.505 | 69.604 |
| 50,000 | 1,251 | **26.311** (25.979–26.832) | 26.731 | 0.581 | 170.147 |
| 100,000 | 2,501 | **52.299** (51.788–63.416) | 51.973 | 0.619 | 392.547 |

- The file-scoped read grows **85.6× for a 100× dirty set while returning the same 4 rows** — a clean
  linear slope of **0.52 µs per dirty row**, entirely independent of the answer size.
- The `schema_key + entity_pk + file_id` shape is **flat** (0.456 → 0.619 ms, 1.36× over the same
  range). That shape takes the existing finite-filter bypass at `hot.rs:9764`, which never reads
  HOT_DIFF and **verifies no coverage at all** — it reads `working_diff_baseline` inline on the
  primary HOT_ROW row. It is the control that isolates the proof as the cost.
- Over-scan factor at 100k dirty: **52.3 / 0.62 = 84×**.
- Adding `schema_key` to the file filter changes nothing (10.310 vs 10.886 at 20k), confirming both
  predicates land in the in-memory `matches_filter` (`hot.rs:9309`) and neither becomes a seek.

Secondary finding, reported by the bench's `entity_scan` column: `SELECT ... FROM <schema> WHERE
lixcol_file_id = ?` is **also** a full schema scan (1.174 → 126.881 ms over the same range, for a fixed
40-row answer — 1.27 µs/row). HOT_ROW is keyed `schema_key ++ file_id ++ entity_pk` and
`hot_scan_entries` has a file-first prefix route for exactly this, but the entity surface's
`filter_pushdown` (`entity.rs:526`) only recognizes branch-id and primary-key analyzers, so
`lixcol_file_id` never reaches `TrackedStateFilter::file_ids` (only the null-file case sets it,
`entity.rs:3328`). That is a separate, simpler optimization opportunity than anything in this
experiment.

## Packing interaction — hard blocker

Packing is engaged in the fixture and the cliff is present on every HOT_DIFF layout (20k dirty):

| changes/commit | HOT_DIFF layout | `WHERE file_id=?` p50 (min–max) |
|---:|---|---|
| 10 | all sparse identity keys (below `HOT_DIFF_PACK_MIN_IDENTITIES` = 64) | 12.408 (12.365–13.091) |
| 100 | packed segments | 10.473 (10.369–10.761) |
| 4,000 | packed segments at max width | 9.512 (9.286–10.137) |

(Packing is worth ~23% on the read; the linear cliff is present on every layout, so it is not an
artifact of one HOT_DIFF shape.)

Two independent reasons the proof cannot be partitioned per file:

1. **Not every coverage group is an identity.** A packed current base contributes exactly *one* group
   key naming a **commit** — `hot_scope_prefix(branch, generation) ++ new_head` (`hot.rs:6133-6135`,
   added at `:6141`/`:6187`, predecessors removed at `:6173`). It stands for a whole schema
   collection whose members span every file and are only recoverable through
   `load_commit_delta_members_with_payloads` at read time (`hot.rs:9854`). Attributing it to file
   partitions means expanding it per member on the write path — reinstating exactly the per-identity
   coverage cost the manifest exists to remove. The alternative, a "spans-all-partitions" bucket every
   partition read must expand in full, restores O(all dirty) and defeats the purpose.
2. **A partition-keyed segment is not a packed segment.** `stage_hot_diff_batch` (`hot.rs:8663`) keys
   segments `scope ++ blake3(value)` and appends identity suffixes in `compare_hot_deltas` order —
   `schema_key ++ entity_pk ++ file_id`, so `file_id` is the **last** discriminator and one file's
   identities are scattered through the batch. Moving a partition ahead of the digest forces the packer
   to re-sort and split every publication by `file_id`: a bulk edit spread over many files emits one
   segment per file, each re-paying the scope and a 32-byte digest, and most publications stop reaching
   the 64-identity packing threshold per partition at all. That is a write-path and physical-bytes
   regression aimed squarely at the workload the partitioning was meant to help — and writes outrank
   version-control reads in the trade-off ranking.

Storing the partition proofs is separately awkward: inline in `TrackedWorkingDiffEpoch` makes a
per-commit record O(#dirty files); as sibling records a partition read cannot distinguish "file is
clean" from "partition was lost", so it does not fail closed.

## Recommended follow-up (not implemented here)

The route that removes the scan does not need the proof at all. HOT_ROW is already keyed
`schema_key ++ file_id ++ entity_pk`, and `hot_scan_entries` already owns a file-first prefix route
(`hot_file_scan_prefixes`, `hot.rs:10405`) that fires for exactly `schema_key + file_id` with no
`entity_pk` — the shape of the one file-scoped test in the tree. Tracked deletes keep a HOT_ROW
tombstone (`physically_deletes = untracked && deleted`, `tracked_head.rs:418`), so that enumeration is
complete for tracked rows. Widening the bypass gate at `hot.rs:9764` would trade O(dirty rows in the
branch) for O(live rows in the file).

It is not in this PR because it still owes a soundness argument for rows that leave HOT_ROW entirely,
and because the two paths already disagree there today: the scan path fails closed to canonical replay
on an untracked or missing primary row (`hot.rs:9901`, `:9916`), while the finite bypass silently skips
it (`hot.rs:9978`, `:10001`). That asymmetry should be resolved on its own before any path relies on it
more heavily.

## Metrics that regressed

None. No engine code path changed; the only `packages/lix` edit is a rustdoc comment. Guard metrics
(`tracked_state_crud` write ids, `read_all_rows_consumed`, `space_growth`) were not run because there
is no code change that could move them.

## Layout invariants

1. **Single authority.** No. Adds no writer, no materialization, no index. The doc comment reinforces
   that HOT_DIFF is a sparse enumeration aid and the primary HOT_ROW value owns the before-image.
2. **Commit canonicality.** Unchanged.
3. **Derived views are caches.** Unchanged; the note documents why HOT_DIFF must stay disposable and
   why the epoch coverage is what makes trusting it safe.
4. **Atomic publication.** Unchanged.
5. **GC from refs.** Unchanged.
6. **SQL reads canonical records.** Unchanged. The benchmark reads only through the public SQL surface.

## Gate

Run on `hetzner-cpx62-II` at `dccf9ef17`, never locally. Exit codes captured directly (not through a
pipeline):

| Command | Exit | Result |
|---|---:|---|
| `cargo check --workspace` | 0 | clean |
| `cargo clippy --workspace --all-targets --all-features -- -D warnings` | 0 | 0 warnings |
| `cargo test -p lix` | 0 | 2522 passed, 0 failed |
