### PR TITLE
perf(live_state): measure hot_row cross-branch sharing — reject, the fix already ships above 1 KiB

### DIFF
--- a/packages/engine-benchmarks/Cargo.toml
+++ b/packages/engine-benchmarks/Cargo.toml
@@ -104,6 +104,11 @@ name = "cas_publication_epoch_qualification"
 path = "examples/cas_publication_epoch_qualification.rs"
 required-features = ["storage-benches", "slatedb"]
 
+[[example]]
+name = "expW_hot_row_anatomy"
+path = "examples/expW_hot_row_anatomy.rs"
+required-features = ["storage-benches", "slatedb"]
+
 [[test]]
 name = "exact_file_read_benchmark"
 path = "tests/exact_file_read_benchmark.rs"

--- a/packages/engine-benchmarks/benches/branch_storage_sharing.rs
+++ b/packages/engine-benchmarks/benches/branch_storage_sharing.rs
@@ -45,6 +45,8 @@ const DEFAULT_SCENARIOS: &[&str] = &[
     "branches_10",
     "branches_100",
     "branches_10_1row",
+    "branches_2_disjoint_1pct",
+    "branches_2_identical_1pct",
     "merge_1pct",
     "delete_gc_1pct",
 ];

--- a/packages/engine-benchmarks/examples/expW_hot_row_anatomy.rs
+++ b/packages/engine-benchmarks/examples/expW_hot_row_anatomy.rs
@@ -35,7 +35,19 @@ use lix_storage_slatedb::SlateDB;
 
 const HOT_ROW_SPACE: &str = "live_state.hot_row.v21";
 const SEED_BATCH_ROWS: usize = 5_000;
-const PAD: &str = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+const PAD_UNIT: &str = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+
+/// Payload padding. The default 64 bytes reproduces `branch_storage_sharing`
+/// exactly. Raising it past `json_store`'s 1024-byte inline threshold moves
+/// the snapshot slot from `INLINE_FINGERPRINTED` to `REF`, which is the
+/// already-shipped content-addressed sharing path.
+fn pad() -> String {
+    let bytes: usize = std::env::var("LIX_EXPW_PAD_BYTES")
+        .ok()
+        .and_then(|value| value.parse().ok())
+        .unwrap_or(64);
+    PAD_UNIT.repeat(bytes.div_ceil(PAD_UNIT.len()))[..bytes].to_owned()
+}
 
 // Mirrors `live_state::tracked_head` value codec v8. Asserted against the
 // version byte of every scanned row, so a codec change fails loudly here.
@@ -339,6 +351,45 @@ content_only_distinct={},content_only_dup_classes={n2_classes},content_only_dup_
         content_only.len(),
     );
 
+    // Cost model for the candidate fix: replace the payload in every HOT value
+    // with a 32-byte content digest and store each distinct payload once in a
+    // content-addressed side space (32-byte digest key + 4 accounting bytes).
+    // Keys stay branch-scoped either way. This is the *optimistic* model: it
+    // charges nothing for the presence/refcount plane that manifest-driven GC
+    // would need, and nothing for the extra read hop.
+    let mut model_hot_value_bytes = 0u64;
+    let mut model_payloads: HashMap<blake3::Hash, u64> = HashMap::new();
+    for (_, value) in new_rows.iter() {
+        let p = parse_value(value);
+        let payload_len = p.snapshot_payload + p.metadata_payload;
+        model_hot_value_bytes += (value.len()
+            - p.snapshot_fingerprint
+            - p.snapshot_payload
+            - p.metadata_fingerprint
+            - p.metadata_payload
+            + JSON_REF_BYTES) as u64;
+        let digest = blake3::hash(
+            &value[p.snapshot_start + p.snapshot_fingerprint
+                ..p.snapshot_start + p.snapshot_fingerprint + p.snapshot_payload],
+        );
+        model_payloads.insert(digest, payload_len as u64);
+    }
+    let model_cas_bytes: u64 = model_payloads
+        .values()
+        .map(|len| len + JSON_REF_BYTES as u64 + 4)
+        .sum();
+    let today = a.key_total + a.value_total;
+    let modeled = a.key_total + model_hot_value_bytes + model_cas_bytes;
+    println!(
+        "expW_indirection_model,rows={rows},scenario={scenario},new_hot_rows={},\
+today_bytes={today},modeled_bytes={modeled},\
+modeled_hot_value_bytes={model_hot_value_bytes},modeled_cas_rows={},modeled_cas_bytes={model_cas_bytes},\
+delta_pct={:.2}",
+        a.rows,
+        model_payloads.len(),
+        (modeled as f64 - today as f64) / today as f64 * 100.0,
+    );
+
     // Cross-branch pairing: same logical identity in >1 branch scope.
     let mut paired_identities = 0u64;
     let mut paired_exact_equal = 0u64;
@@ -593,7 +644,10 @@ async fn modify_rows(engine: &Engine<SlateDB>, branch: &str, start: usize, count
                 .execute(
                     "UPDATE branch_fixture SET value = lix_json($1) WHERE path = $2",
                     &[
-                        Value::Text(format!(r#"{{"seed":{index},"edited":true,"pad":"{PAD}"}}"#)),
+                        Value::Text(format!(
+                            r#"{{"seed":{index},"edited":true,"pad":"{}"}}"#,
+                            pad()
+                        )),
                         Value::Text(row_path(index)),
                     ],
                 )
@@ -651,7 +705,7 @@ async fn seed_rows(session: &SessionContext<SlateDB>, rows: usize) {
                     "INSERT INTO branch_fixture (path, value) VALUES ($1, lix_json($2))",
                     &[
                         Value::Text(row_path(index)),
-                        Value::Text(format!(r#"{{"seed":{index},"pad":"{PAD}"}}"#)),
+                        Value::Text(format!(r#"{{"seed":{index},"pad":"{}"}}"#, pad())),
                     ],
                 )
                 .await

--- a/packages/engine-benchmarks/examples/expW_hot_row_anatomy.rs
+++ b/packages/engine-benchmarks/examples/expW_hot_row_anatomy.rs
@@ -27,7 +27,7 @@ use std::collections::{BTreeMap, HashMap};
 use std::path::{Path, PathBuf};
 
 use lix::integration::{Engine, SessionContext};
-use lix::storage::{ReadOptions, Storage};
+use lix::storage::ReadOptions;
 use lix::storage_adapter::StorageAdapter;
 use lix::storage_bench::{layout_accounting, space_inventory};
 use lix::{CreateBranchOptions, Value};
@@ -209,6 +209,10 @@ struct Anatomy {
     slot_ref: u64,
     slot_inline: u64,
     slot_inline_fingerprinted: u64,
+    meta_slot_none: u64,
+    meta_slot_ref: u64,
+    meta_slot_inline: u64,
+    meta_slot_inline_fingerprinted: u64,
 }
 
 fn analyze(rows: usize, scenario: &str, new_rows: &[(Vec<u8>, Vec<u8>)], changed_rows: usize) {
@@ -261,6 +265,13 @@ fn analyze(rows: usize, scenario: &str, new_rows: &[(Vec<u8>, Vec<u8>)], changed
             HEAD_SLOT_INLINE_FINGERPRINTED => a.slot_inline_fingerprinted += 1,
             _ => {}
         }
+        match parsed.metadata_kind {
+            HEAD_SLOT_NONE => a.meta_slot_none += 1,
+            HEAD_SLOT_REF => a.meta_slot_ref += 1,
+            HEAD_SLOT_INLINE => a.meta_slot_inline += 1,
+            HEAD_SLOT_INLINE_FINGERPRINTED => a.meta_slot_inline_fingerprinted += 1,
+            _ => {}
+        }
 
         *exact_values.entry(blake3::hash(value)).or_insert(0) += 1;
         let n1 = normalize_identity(value, &parsed);
@@ -304,7 +315,8 @@ v_working_diff_per_row={:.2},v_columnar_per_row={:.2}",
     println!(
         "expW_anatomy_tags,rows={rows},scenario={scenario},\
 wd_disabled={},wd_clean={},wd_before_absent={},wd_before_present={},\
-snapshot_none={},snapshot_ref={},snapshot_inline={},snapshot_inline_fingerprinted={}",
+snapshot_none={},snapshot_ref={},snapshot_inline={},snapshot_inline_fingerprinted={},\
+metadata_none={},metadata_ref={},metadata_inline={},metadata_inline_fingerprinted={}",
         a.wd_disabled,
         a.wd_clean,
         a.wd_before_absent,
@@ -313,6 +325,10 @@ snapshot_none={},snapshot_ref={},snapshot_inline={},snapshot_inline_fingerprinte
         a.slot_ref,
         a.slot_inline,
         a.slot_inline_fingerprinted,
+        a.meta_slot_none,
+        a.meta_slot_ref,
+        a.meta_slot_inline,
+        a.meta_slot_inline_fingerprinted,
     );
 
     // Sharing oracles over the new HOT rows.

--- a/packages/engine-benchmarks/examples/expW_hot_row_anatomy.rs
+++ b/packages/engine-benchmarks/examples/expW_hot_row_anatomy.rs
@@ -1,0 +1,666 @@
+//! Anatomy of a `live_state.hot_row.v21` row, and what two branches share.
+//!
+//! Experiment T attributed 95.4% of the two-branch storage delta to
+//! `live_state.hot_row.v21` and showed that two branches making *identical*
+//! edits pay the same as two branches making *disjoint* edits. This tool
+//! answers the follow-up questions directly on the bytes:
+//!
+//! 1. Where do the ~390 bytes of a branch-local HOT row go — key vs value, and
+//!    inside the value, payload vs per-row identity vs working-diff baseline?
+//! 2. Are the HOT values for byte-identical content byte-identical apart from
+//!    the branch-scoped key? Reported byte-exact and under two normalizations.
+//! 3. What does the base (unedited) row cost in its packed plane, so the
+//!    amplification factor is measured rather than assumed?
+//!
+//! Usage:
+//! ```text
+//! expW_hot_row_anatomy <rows> <scenario> <dir>
+//! ```
+//! Scenarios: `identical`, `disjoint`, `single`, `base`.
+//!
+//! Every write goes through the real `SessionContext` SQL commit path, so the
+//! inventory observes exactly what an ordinary commit stages.
+
+#![allow(clippy::large_futures)]
+
+use std::collections::{BTreeMap, HashMap};
+use std::path::{Path, PathBuf};
+
+use lix::integration::{Engine, SessionContext};
+use lix::storage::{ReadOptions, Storage};
+use lix::storage_adapter::StorageAdapter;
+use lix::storage_bench::{layout_accounting, space_inventory};
+use lix::{CreateBranchOptions, Value};
+use lix_storage_slatedb::SlateDB;
+
+const HOT_ROW_SPACE: &str = "live_state.hot_row.v21";
+const SEED_BATCH_ROWS: usize = 5_000;
+const PAD: &str = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+
+// Mirrors `live_state::tracked_head` value codec v8. Asserted against the
+// version byte of every scanned row, so a codec change fails loudly here.
+const HEAD_VALUE_VERSION: u8 = 8;
+const HEAD_VALUE_HEADER_BYTES: usize = 59;
+const HEAD_VALUE_SNAPSHOT_SHIFT: u8 = 1;
+const HEAD_VALUE_METADATA_SHIFT: u8 = 3;
+const HEAD_VALUE_WORKING_DIFF_SHIFT: u8 = 6;
+const HEAD_VALUE_SLOT_MASK: u8 = 0b11;
+const HEAD_VALUE_WORKING_DIFF_MASK: u8 = 0b11;
+const HEAD_SLOT_NONE: u8 = 0;
+const HEAD_SLOT_REF: u8 = 1;
+const HEAD_SLOT_INLINE: u8 = 2;
+const HEAD_SLOT_INLINE_FINGERPRINTED: u8 = 3;
+const HEAD_WORKING_DIFF_DISABLED: u8 = 0;
+const HEAD_WORKING_DIFF_CLEAN: u8 = 1;
+const HEAD_WORKING_DIFF_BEFORE_ABSENT: u8 = 2;
+const HEAD_WORKING_DIFF_BEFORE_PRESENT: u8 = 3;
+const JSON_REF_BYTES: usize = 32;
+const WORKING_DIFF_CHECKPOINT_BYTES: usize = 16;
+const WORKING_DIFF_VERSION_BYTES: usize = 16 + 16 + 1 + 8 + 8 + 1 + 32 + 1 + 32;
+const COLUMNAR_BASE_COORDINATE_BYTES: usize = 16 + 4 + 4;
+const GENERATION_BYTES: usize = 16;
+
+fn main() {
+    let args = std::env::args().collect::<Vec<_>>();
+    let usage = "usage: expW_hot_row_anatomy <rows> <identical|disjoint|single|base> <dir>";
+    let rows: usize = args.get(1).expect(usage).parse().expect(usage);
+    let scenario = args.get(2).map(String::as_str).expect(usage).to_owned();
+    let dir = PathBuf::from(args.get(3).expect(usage));
+    let runtime = tokio::runtime::Builder::new_multi_thread()
+        .worker_threads(4)
+        .enable_all()
+        .build()
+        .expect("build anatomy runtime");
+    runtime.block_on(run(rows, &scenario, &dir));
+}
+
+async fn run(rows: usize, scenario: &str, dir: &Path) {
+    std::fs::create_dir_all(dir).expect("create anatomy directory");
+    let storage = SlateDB::open(dir).expect("open anatomy SlateDB");
+    Engine::initialize(storage.clone())
+        .await
+        .expect("initialize anatomy repository");
+    let engine = Engine::new(storage.clone())
+        .await
+        .expect("open anatomy engine");
+    let main = engine
+        .open_workspace_session()
+        .await
+        .expect("open anatomy workspace session");
+    register_schema(&main).await;
+    seed_rows(&main, rows).await;
+
+    settle(&storage).await;
+    let base_spaces = space_totals(&storage).await;
+    let base_hot: HashMap<Vec<u8>, Vec<u8>> = hot_inventory(&storage).await.into_iter().collect();
+    println!(
+        "expW_base,rows={rows},scenario={scenario},base_hot_rows={},base_logical_bytes={}",
+        base_hot.len(),
+        base_spaces.values().map(|c| c.0 + c.1).sum::<u64>(),
+    );
+    for (space, counts) in &base_spaces {
+        if counts.2 == 0 {
+            continue;
+        }
+        println!(
+            "expW_base_space,rows={rows},space={space},rows_in_space={},key_bytes={},value_bytes={},bytes_per_row={:.2}",
+            counts.2,
+            counts.0,
+            counts.1,
+            (counts.0 + counts.1) as f64 / counts.2 as f64
+        );
+    }
+
+    let one_percent = (rows / 100).max(1);
+    let branch_ids = match scenario {
+        "base" => Vec::new(),
+        "single" => {
+            let branch = create_branch(&main, "branch-0").await;
+            modify_rows(&engine, &branch, 0, one_percent).await;
+            vec![branch]
+        }
+        "identical" => {
+            let first = create_branch(&main, "branch-0").await;
+            modify_rows(&engine, &first, 0, one_percent).await;
+            let second = create_branch(&main, "branch-1").await;
+            modify_rows(&engine, &second, 0, one_percent).await;
+            vec![first, second]
+        }
+        "disjoint" => {
+            let first = create_branch(&main, "branch-0").await;
+            modify_rows(&engine, &first, 0, one_percent).await;
+            let second = create_branch(&main, "branch-1").await;
+            modify_rows(&engine, &second, one_percent, one_percent).await;
+            vec![first, second]
+        }
+        other => panic!("unknown scenario '{other}'"),
+    };
+
+    settle(&storage).await;
+    let after_spaces = space_totals(&storage).await;
+    let after_hot = hot_inventory(&storage).await;
+
+    let mut names: Vec<String> = base_spaces.keys().cloned().collect();
+    for name in after_spaces.keys() {
+        if !names.contains(name) {
+            names.push(name.clone());
+        }
+    }
+    names.sort();
+    let changed_rows = branch_ids.len() * one_percent;
+    for name in &names {
+        let before = base_spaces.get(name).copied().unwrap_or_default();
+        let now = after_spaces.get(name).copied().unwrap_or_default();
+        let d_bytes = (now.0 + now.1) as i64 - (before.0 + before.1) as i64;
+        let d_rows = now.2 as i64 - before.2 as i64;
+        if d_bytes == 0 && d_rows == 0 {
+            continue;
+        }
+        println!(
+            "expW_space_delta,rows={rows},scenario={scenario},space={name},d_rows={d_rows},d_bytes={d_bytes},d_bytes_per_changed_row={:.2}",
+            if changed_rows == 0 {
+                0.0
+            } else {
+                d_bytes as f64 / changed_rows as f64
+            }
+        );
+    }
+
+    // Only the rows this scenario added to HOT.
+    let new_rows: Vec<(Vec<u8>, Vec<u8>)> = after_hot
+        .into_iter()
+        .filter(|(key, _)| !base_hot.contains_key(key))
+        .collect();
+    analyze(rows, scenario, &new_rows, changed_rows);
+}
+
+#[derive(Clone, Copy, Default)]
+struct Anatomy {
+    rows: u64,
+    key_total: u64,
+    key_scope: u64,
+    key_identity: u64,
+    value_total: u64,
+    v_fixed: u64,
+    v_identity: u64,
+    v_snapshot_fingerprint: u64,
+    v_snapshot_payload: u64,
+    v_metadata_fingerprint: u64,
+    v_metadata_payload: u64,
+    v_working_diff: u64,
+    v_columnar: u64,
+    wd_disabled: u64,
+    wd_clean: u64,
+    wd_before_absent: u64,
+    wd_before_present: u64,
+    slot_none: u64,
+    slot_ref: u64,
+    slot_inline: u64,
+    slot_inline_fingerprinted: u64,
+}
+
+fn analyze(rows: usize, scenario: &str, new_rows: &[(Vec<u8>, Vec<u8>)], changed_rows: usize) {
+    if new_rows.is_empty() {
+        println!("expW_anatomy,rows={rows},scenario={scenario},new_hot_rows=0");
+        return;
+    }
+    let mut a = Anatomy::default();
+    // key with the (branch_id, generation) scope stripped -> logical identity
+    let mut by_identity: HashMap<Vec<u8>, Vec<usize>> = HashMap::new();
+    let mut exact_values: HashMap<blake3::Hash, u64> = HashMap::new();
+    let mut ident_norm: HashMap<blake3::Hash, u64> = HashMap::new();
+    let mut content_only: HashMap<blake3::Hash, u64> = HashMap::new();
+    let mut ident_norm_bytes: HashMap<blake3::Hash, u64> = HashMap::new();
+    let mut content_only_bytes: HashMap<blake3::Hash, u64> = HashMap::new();
+
+    for (index, (key, value)) in new_rows.iter().enumerate() {
+        a.rows += 1;
+        // `+ 4` matches layout_accounting's per-row key accounting.
+        a.key_total += key.len() as u64 + 4;
+        let scope_len = scope_prefix_len(key);
+        a.key_scope += scope_len as u64;
+        a.key_identity += (key.len() - scope_len) as u64;
+        by_identity
+            .entry(key[scope_len..].to_vec())
+            .or_default()
+            .push(index);
+
+        let parsed = parse_value(value);
+        a.value_total += value.len() as u64;
+        a.v_fixed += 11; // version + flags + 2 lengths + columnar tag
+        a.v_identity += 48; // change_id + commit_id + created_at + updated_at
+        a.v_snapshot_fingerprint += parsed.snapshot_fingerprint as u64;
+        a.v_snapshot_payload += parsed.snapshot_payload as u64;
+        a.v_metadata_fingerprint += parsed.metadata_fingerprint as u64;
+        a.v_metadata_payload += parsed.metadata_payload as u64;
+        a.v_working_diff += parsed.working_diff as u64;
+        a.v_columnar += parsed.columnar as u64;
+        match parsed.working_diff_tag {
+            HEAD_WORKING_DIFF_DISABLED => a.wd_disabled += 1,
+            HEAD_WORKING_DIFF_CLEAN => a.wd_clean += 1,
+            HEAD_WORKING_DIFF_BEFORE_ABSENT => a.wd_before_absent += 1,
+            HEAD_WORKING_DIFF_BEFORE_PRESENT => a.wd_before_present += 1,
+            _ => {}
+        }
+        match parsed.snapshot_kind {
+            HEAD_SLOT_NONE => a.slot_none += 1,
+            HEAD_SLOT_REF => a.slot_ref += 1,
+            HEAD_SLOT_INLINE => a.slot_inline += 1,
+            HEAD_SLOT_INLINE_FINGERPRINTED => a.slot_inline_fingerprinted += 1,
+            _ => {}
+        }
+
+        *exact_values.entry(blake3::hash(value)).or_insert(0) += 1;
+        let n1 = normalize_identity(value, &parsed);
+        let h1 = blake3::hash(&n1);
+        *ident_norm.entry(h1).or_insert(0) += 1;
+        ident_norm_bytes.insert(h1, n1.len() as u64);
+        let n2 = content_only_bytes_of(value, &parsed);
+        let h2 = blake3::hash(&n2);
+        *content_only.entry(h2).or_insert(0) += 1;
+        content_only_bytes.insert(h2, n2.len() as u64);
+    }
+
+    let per_row = |v: u64| v as f64 / a.rows as f64;
+    println!(
+        "expW_anatomy,rows={rows},scenario={scenario},new_hot_rows={},changed_rows={changed_rows},\
+total_bytes={},bytes_per_row={:.2},\
+key_bytes={},key_per_row={:.2},key_scope_per_row={:.2},key_identity_per_row={:.2},\
+value_bytes={},value_per_row={:.2},\
+v_fixed_per_row={:.2},v_identity_per_row={:.2},\
+v_snapshot_fingerprint_per_row={:.2},v_snapshot_payload_per_row={:.2},\
+v_metadata_fingerprint_per_row={:.2},v_metadata_payload_per_row={:.2},\
+v_working_diff_per_row={:.2},v_columnar_per_row={:.2}",
+        a.rows,
+        a.key_total + a.value_total,
+        per_row(a.key_total + a.value_total),
+        a.key_total,
+        per_row(a.key_total),
+        per_row(a.key_scope),
+        per_row(a.key_identity),
+        a.value_total,
+        per_row(a.value_total),
+        per_row(a.v_fixed),
+        per_row(a.v_identity),
+        per_row(a.v_snapshot_fingerprint),
+        per_row(a.v_snapshot_payload),
+        per_row(a.v_metadata_fingerprint),
+        per_row(a.v_metadata_payload),
+        per_row(a.v_working_diff),
+        per_row(a.v_columnar),
+    );
+    println!(
+        "expW_anatomy_tags,rows={rows},scenario={scenario},\
+wd_disabled={},wd_clean={},wd_before_absent={},wd_before_present={},\
+snapshot_none={},snapshot_ref={},snapshot_inline={},snapshot_inline_fingerprinted={}",
+        a.wd_disabled,
+        a.wd_clean,
+        a.wd_before_absent,
+        a.wd_before_present,
+        a.slot_none,
+        a.slot_ref,
+        a.slot_inline,
+        a.slot_inline_fingerprinted,
+    );
+
+    // Sharing oracles over the new HOT rows.
+    let dup = |map: &HashMap<blake3::Hash, u64>| -> (u64, u64) {
+        let mut classes_gt1 = 0u64;
+        let mut dup_rows = 0u64;
+        for count in map.values() {
+            if *count > 1 {
+                classes_gt1 += 1;
+                dup_rows += count - 1;
+            }
+        }
+        (classes_gt1, dup_rows)
+    };
+    let (exact_classes, exact_dup) = dup(&exact_values);
+    let (n1_classes, n1_dup) = dup(&ident_norm);
+    let (n2_classes, n2_dup) = dup(&content_only);
+    let n1_saved: u64 = ident_norm
+        .iter()
+        .filter(|(_, c)| **c > 1)
+        .map(|(h, c)| (c - 1) * ident_norm_bytes[h])
+        .sum();
+    let n2_saved: u64 = content_only
+        .iter()
+        .filter(|(_, c)| **c > 1)
+        .map(|(h, c)| (c - 1) * content_only_bytes[h])
+        .sum();
+    println!(
+        "expW_sharing,rows={rows},scenario={scenario},new_hot_rows={},\
+exact_distinct={},exact_dup_classes={exact_classes},exact_dup_rows={exact_dup},\
+identity_normalized_distinct={},identity_normalized_dup_classes={n1_classes},identity_normalized_dup_rows={n1_dup},identity_normalized_saved_bytes={n1_saved},\
+content_only_distinct={},content_only_dup_classes={n2_classes},content_only_dup_rows={n2_dup},content_only_saved_bytes={n2_saved}",
+        a.rows,
+        exact_values.len(),
+        ident_norm.len(),
+        content_only.len(),
+    );
+
+    // Cross-branch pairing: same logical identity in >1 branch scope.
+    let mut paired_identities = 0u64;
+    let mut paired_exact_equal = 0u64;
+    let mut paired_ident_norm_equal = 0u64;
+    let mut paired_content_equal = 0u64;
+    let mut first_diff_report: Option<String> = None;
+    for indices in by_identity.values() {
+        if indices.len() < 2 {
+            continue;
+        }
+        paired_identities += 1;
+        let (_, v0) = &new_rows[indices[0]];
+        let p0 = parse_value(v0);
+        let mut exact = true;
+        let mut n1eq = true;
+        let mut n2eq = true;
+        for &other in &indices[1..] {
+            let (_, v1) = &new_rows[other];
+            let p1 = parse_value(v1);
+            if v0 != v1 {
+                exact = false;
+            }
+            if normalize_identity(v0, &p0) != normalize_identity(v1, &p1) {
+                n1eq = false;
+            }
+            if content_only_bytes_of(v0, &p0) != content_only_bytes_of(v1, &p1) {
+                n2eq = false;
+            }
+            if first_diff_report.is_none() && v0 != v1 {
+                first_diff_report = Some(describe_diff(v0, v1));
+            }
+        }
+        paired_exact_equal += u64::from(exact);
+        paired_ident_norm_equal += u64::from(n1eq);
+        paired_content_equal += u64::from(n2eq);
+    }
+    println!(
+        "expW_crossbranch,rows={rows},scenario={scenario},\
+paired_identities={paired_identities},paired_exact_equal={paired_exact_equal},\
+paired_identity_normalized_equal={paired_ident_norm_equal},paired_content_equal={paired_content_equal}"
+    );
+    if let Some(report) = first_diff_report {
+        println!("expW_crossbranch_diff,rows={rows},scenario={scenario},{report}");
+    }
+}
+
+fn describe_diff(a: &[u8], b: &[u8]) -> String {
+    let common_prefix = a
+        .iter()
+        .zip(b.iter())
+        .take_while(|(x, y)| x == y)
+        .count();
+    let common_suffix = a
+        .iter()
+        .rev()
+        .zip(b.iter().rev())
+        .take_while(|(x, y)| x == y)
+        .count();
+    let differing = if a.len() == b.len() {
+        a.iter().zip(b.iter()).filter(|(x, y)| x != y).count()
+    } else {
+        usize::MAX
+    };
+    format!(
+        "len_a={},len_b={},common_prefix={common_prefix},common_suffix={common_suffix},differing_bytes={}",
+        a.len(),
+        b.len(),
+        if differing == usize::MAX {
+            -1
+        } else {
+            differing as i64
+        }
+    )
+}
+
+#[derive(Clone, Copy, Default)]
+struct Parsed {
+    snapshot_kind: u8,
+    metadata_kind: u8,
+    working_diff_tag: u8,
+    snapshot_fingerprint: usize,
+    snapshot_payload: usize,
+    metadata_fingerprint: usize,
+    metadata_payload: usize,
+    working_diff: usize,
+    columnar: usize,
+    snapshot_start: usize,
+    metadata_end: usize,
+}
+
+fn parse_value(value: &[u8]) -> Parsed {
+    assert!(
+        value.len() >= HEAD_VALUE_HEADER_BYTES,
+        "hot row shorter than v8 header"
+    );
+    assert_eq!(
+        value[0], HEAD_VALUE_VERSION,
+        "hot row codec version changed; update expW_hot_row_anatomy"
+    );
+    let flags = value[1];
+    let snapshot_kind = (flags >> HEAD_VALUE_SNAPSHOT_SHIFT) & HEAD_VALUE_SLOT_MASK;
+    let metadata_kind = (flags >> HEAD_VALUE_METADATA_SHIFT) & HEAD_VALUE_SLOT_MASK;
+    let working_diff_tag = (flags >> HEAD_VALUE_WORKING_DIFF_SHIFT) & HEAD_VALUE_WORKING_DIFF_MASK;
+    let snapshot_len =
+        u32::from_be_bytes(value[50..54].try_into().expect("snapshot len")) as usize;
+    let metadata_len = u32::from_be_bytes(value[54..58].try_into().expect("metadata len")) as usize;
+    let has_columnar = value[58] == 1;
+    let snapshot_fingerprint = match snapshot_kind {
+        HEAD_SLOT_REF => JSON_REF_BYTES,
+        HEAD_SLOT_INLINE_FINGERPRINTED => JSON_REF_BYTES,
+        _ => 0,
+    };
+    let metadata_fingerprint = match metadata_kind {
+        HEAD_SLOT_REF => JSON_REF_BYTES,
+        HEAD_SLOT_INLINE_FINGERPRINTED => JSON_REF_BYTES,
+        _ => 0,
+    };
+    let working_diff = match working_diff_tag {
+        HEAD_WORKING_DIFF_BEFORE_ABSENT => WORKING_DIFF_CHECKPOINT_BYTES,
+        HEAD_WORKING_DIFF_BEFORE_PRESENT => {
+            WORKING_DIFF_CHECKPOINT_BYTES + WORKING_DIFF_VERSION_BYTES
+        }
+        _ => 0,
+    };
+    Parsed {
+        snapshot_kind,
+        metadata_kind,
+        working_diff_tag,
+        snapshot_fingerprint,
+        snapshot_payload: snapshot_len - snapshot_fingerprint,
+        metadata_fingerprint,
+        metadata_payload: metadata_len - metadata_fingerprint,
+        working_diff,
+        columnar: if has_columnar {
+            COLUMNAR_BASE_COORDINATE_BYTES
+        } else {
+            0
+        },
+        snapshot_start: HEAD_VALUE_HEADER_BYTES,
+        metadata_end: HEAD_VALUE_HEADER_BYTES + snapshot_len + metadata_len,
+    }
+}
+
+/// Zeroes the fields whose only job is to name *this* change: change id, commit
+/// id and both timestamps. Everything else, including the working-diff
+/// baseline and columnar coordinate, is preserved.
+fn normalize_identity(value: &[u8], _parsed: &Parsed) -> Vec<u8> {
+    let mut out = value.to_vec();
+    out[2..50].fill(0);
+    out
+}
+
+/// Keeps only the parts that describe the row's *content*: flags, slot kinds
+/// and both JSON payloads. Per-row identity, the working-diff baseline and the
+/// columnar coordinate are dropped entirely. This is the upper bound on what a
+/// cross-branch content-addressed HOT plane could ever share.
+fn content_only_bytes_of(value: &[u8], parsed: &Parsed) -> Vec<u8> {
+    let mut out = Vec::with_capacity(parsed.metadata_end - parsed.snapshot_start + 4);
+    out.push(value[1] & 0b0011_1111); // flags without the working-diff tag
+    out.extend_from_slice(&value[parsed.snapshot_start..parsed.metadata_end]);
+    out
+}
+
+/// Length of the `branch_id ++ generation` scope prefix of a HOT row key.
+///
+/// `branch_id` is written by `write_key_string` (0x00 escaped as 0x00 0xFF,
+/// terminated by 0x00 0x00), then a fixed 16-byte generation.
+fn scope_prefix_len(key: &[u8]) -> usize {
+    let mut index = 0usize;
+    while index + 1 < key.len() {
+        if key[index] == 0x00 {
+            if key[index + 1] == 0xff {
+                index += 2;
+                continue;
+            }
+            assert_eq!(key[index + 1], 0x00, "unexpected branch-id terminator");
+            return index + 2 + GENERATION_BYTES;
+        }
+        index += 1;
+    }
+    panic!("hot row key has no branch-id terminator");
+}
+
+// ---------------------------------------------------------------------------
+// Fixture — identical to `benches/branch_storage_sharing.rs`.
+// ---------------------------------------------------------------------------
+
+async fn settle(storage: &SlateDB) {
+    storage
+        .flush_memtable_for_diagnostics()
+        .await
+        .expect("flush anatomy memtable");
+    tokio::time::sleep(std::time::Duration::from_millis(250)).await;
+}
+
+async fn space_totals(storage: &SlateDB) -> BTreeMap<String, (u64, u64, u64)> {
+    let adapter = StorageAdapter::new(storage.clone());
+    let read = adapter
+        .begin_read(ReadOptions::default())
+        .await
+        .expect("open anatomy layout read");
+    let accounting = layout_accounting(&read).await;
+    drop(read);
+    accounting
+        .into_iter()
+        .map(|entry| {
+            (
+                entry.space.to_owned(),
+                (entry.key_bytes, entry.value_bytes, entry.rows),
+            )
+        })
+        .collect()
+}
+
+async fn hot_inventory(storage: &SlateDB) -> Vec<(Vec<u8>, Vec<u8>)> {
+    let adapter = StorageAdapter::new(storage.clone());
+    let read = adapter
+        .begin_read(ReadOptions::default())
+        .await
+        .expect("open anatomy inventory read");
+    let inventory = space_inventory(&read, HOT_ROW_SPACE).await;
+    drop(read);
+    inventory
+}
+
+async fn create_branch(main: &SessionContext<SlateDB>, name: &str) -> String {
+    main.create_branch(CreateBranchOptions {
+        id: None,
+        name: name.to_owned(),
+        from_commit_id: None,
+    })
+    .await
+    .expect("create anatomy branch")
+    .id
+}
+
+async fn modify_rows(engine: &Engine<SlateDB>, branch: &str, start: usize, count: usize) {
+    let session = engine
+        .open_session(branch.to_owned())
+        .await
+        .expect("open anatomy branch session");
+    let mut written = 0usize;
+    while written < count {
+        let batch = (count - written).min(SEED_BATCH_ROWS);
+        let mut transaction = session
+            .begin_transaction()
+            .await
+            .expect("begin anatomy modification");
+        for offset in 0..batch {
+            let index = start + written + offset;
+            transaction
+                .execute(
+                    "UPDATE branch_fixture SET value = lix_json($1) WHERE path = $2",
+                    &[
+                        Value::Text(format!(r#"{{"seed":{index},"edited":true,"pad":"{PAD}"}}"#)),
+                        Value::Text(row_path(index)),
+                    ],
+                )
+                .await
+                .expect("stage anatomy modification");
+        }
+        transaction
+            .commit()
+            .await
+            .expect("commit anatomy modification");
+        written += batch;
+    }
+}
+
+fn row_path(index: usize) -> String {
+    format!("/branch/fixture/{index:09}")
+}
+
+async fn register_schema(session: &SessionContext<SlateDB>) {
+    let schema = serde_json::json!({
+        "x-lix-key": "branch_fixture",
+        "x-lix-primary-key": ["/path"],
+        "type": "object",
+        "required": ["path", "value"],
+        "properties": {
+            "path": { "type": "string" },
+            "value": {
+                "type": ["object", "array", "string", "number", "integer", "boolean", "null"]
+            }
+        },
+        "additionalProperties": false
+    });
+    session
+        .execute(
+            "INSERT INTO lix_registered_schema (value, lixcol_global, lixcol_untracked) \
+             VALUES (lix_json($1), false, false)",
+            &[Value::Text(schema.to_string())],
+        )
+        .await
+        .expect("register anatomy schema");
+}
+
+async fn seed_rows(session: &SessionContext<SlateDB>, rows: usize) {
+    let mut written = 0usize;
+    while written < rows {
+        let batch = (rows - written).min(SEED_BATCH_ROWS);
+        let mut transaction = session
+            .begin_transaction()
+            .await
+            .expect("begin anatomy seed");
+        for offset in 0..batch {
+            let index = written + offset;
+            transaction
+                .execute(
+                    "INSERT INTO branch_fixture (path, value) VALUES ($1, lix_json($2))",
+                    &[
+                        Value::Text(row_path(index)),
+                        Value::Text(format!(r#"{{"seed":{index},"pad":"{PAD}"}}"#)),
+                    ],
+                )
+                .await
+                .expect("stage anatomy seed row");
+        }
+        transaction
+            .commit()
+            .await
+            .expect("commit anatomy seed");
+        written += batch;
+    }
+}


### PR DESCRIPTION
Experiment W asked why a row materialized into the HOT serving plane on branch A shares
nothing with the identical row on branch B, and whether it could.

**Answer: it already does — above 1024 bytes — and extending it below that threshold is a
measured 10% physical-bytes regression on the realistic workload.** HOT rows must stay
branch-scoped. The 12x is the price of the serving plane. Negative result, full numbers below.

## What changed

Bench and measurement only. **Zero engine files touched** — `git diff --name-only
origin/claude-3-optimizations...HEAD | grep '^packages/lix/src'` is empty.

- `packages/engine-benchmarks/benches/branch_storage_sharing.rs`: adds
  `branches_2_disjoint_1pct` and `branches_2_identical_1pct` to `DEFAULT_SCENARIOS`.
  Both scenarios already existed in `apply_scenario` and `scenario_changed_rows` but were
  absent from the default list, so the *only* pair of scenarios that can expose cross-branch
  sharing never ran unless you named them by hand. Instrument fix.
- `packages/engine-benchmarks/examples/expW_hot_row_anatomy.rs`: new. Breaks a HOT row into
  key vs value and, inside the value, into payload / per-row identity / working-diff baseline;
  runs byte-exact and two normalized cross-branch sharing oracles; models the cost of the
  candidate content-digest indirection; and sweeps payload size across the `json_store`
  inline threshold via `LIX_EXPW_PAD_BYTES`.

Nothing was removed. No storage space, writer or code path changed.

## 1. Where the ~390 bytes go

`expW_hot_row_anatomy 100000 identical`, slatedb, 2002 new HOT rows, **354.82 B/row**:

| component | B/row | share | why the base plane does not pay it |
|---|---:|---:|---|
| key — branch scope (`branch_id` string + 16B generation) | 54.00 | 15.2% | packed base writes one key per *commit*, not per row |
| key — identity (`schema_key` + file tag + `entity_pk`) | 46.00 | 13.0% | columnar row group stores identities as one shared column |
| key — accounting (`+4`, matches `layout_accounting`) | 4.00 | 1.1% | — |
| value — fixed header (version, flags, 2 lengths, columnar tag) | 11.00 | 3.1% | one per segment |
| value — identity (`change_id` 16 + `commit_id` 16 + `created_at` 8 + `updated_at` 8) | 48.00 | 13.5% | segment carries one commit id; timestamps dictionary-encoded |
| value — snapshot fingerprint (32B `JsonRef`, present because the row is dirty) | 32.00 | 9.0% | base rows are clean and carry no fingerprint |
| value — snapshot payload (**raw, uncompressed inline JSON**) | 143.82 | 40.5% | columnar row group compresses and dictionary-encodes it |
| value — working-diff baseline (`BeforeAbsent` checkpoint id) | 16.00 | 4.5% | base rows carry no baseline |
| **total** | **354.82** | | vs **27.71** B/row in the base plane |

Base plane at 100k: 2,770,631 logical bytes across all spaces for 100,000 seeded rows =
**27.71 B/row**. Amplification = 354.82 / 27.71 = **12.8x**, reproducing experiment M's ~12x.

**The 12x is not duplication.** It is three separate amortization failures against a plane
that packs 500+ rows per segment: a full uncompressed key per row (29.3%), an uncompressed
inline payload (40.5%), and per-row change/commit identity (13.5%). The remaining 13.5% is
the fixed header, the dirty-row fingerprint and the working-diff baseline — all of which
exist only while the row is a branch-local overlay.

Same numbers at 10k (353.23 B/row over 202 rows) and for the single-branch scenario
(353.23 B/row over 101 rows), so this is flat in N and flat in branch count, as experiment M
reported.

## 2. Are HOT values for identical content byte-identical?

**Byte-exact: no. Identity-normalized: yes, exactly.**

100k, `branches_2_identical_1pct`, both branches applying byte-identical edits to the same
1% window:

| oracle | distinct | duplicate rows | saved bytes |
|---|---:|---:|---:|
| byte-exact (`space_value_duplication` equivalent) | 2002 / 2002 | **0** | 0 |
| identity-normalized (bytes 2..50 zeroed) | 1002 | **1000** | 250,890 |
| content-only (payload + slot kinds, identity/baseline dropped) | 1002 | **1000** | 176,890 |

Cross-branch pairing by logical identity (key with the `branch_id ++ generation` scope stripped):

```
paired_identities=1000  paired_exact_equal=0
paired_identity_normalized_equal=1000  paired_content_equal=1000
```

**1000 of 1000** cross-branch pairs are byte-identical once the 48-byte identity block is
zeroed. A representative pair: `len_a=251 len_b=251 common_prefix=6 common_suffix=202
differing_bytes=19` — every differing byte lies in `bytes[6..49]`, entirely inside the
`change_id ++ commit_id ++ created_at ++ updated_at` block at `bytes[2..50]`.

So the HOT value embeds **change/commit identity, not branch identity**, exactly as delta
segments embed commit identity. The content portion (32-byte fingerprint + 143.8-byte
payload) is bit-for-bit identical across branches. Sharing is representable.

## 3. The materialization rule

A commit publishes an O(1) **reference** instead of materializing rows into HOT only when
every one of these holds (`packages/lix/src/transaction/commit.rs:3601-3644`, `:4158-4180`):

- at least `PACKED_CURRENT_BASE_MIN_ROWS` = 512 tracked deltas (`commit.rs:67`)
- **every delta is an insert** — `!delta.deleted`, with absence guards proving the identities
  were absent; or `try_stage_exact_collection_replacement_current_base` proves the commit
  replaces *every* live member of one schema
- every delta is unfiled (`file_id.is_none()`), tracked, same-commit, not the
  collection-generation schema
- not a checkpoint publication, no certified fresh plugin file, no host-certified live
  increments, no selected change batches, no untracked/engine rows

Branch **creation** is separately O(1): `stage_root_current_base`
(`commit.rs:5052`, `hot.rs:5894-5907`) writes one 16-byte commit id under the branch scope key
into `live_state.root_current_base.v1`. Measured at 74 B/branch (`d_rows=2, d_bytes=148`).

**Everything else materializes a HOT row.** In particular, a partial UPDATE of an existing
collection can never take the reference route: it is not an insert, so no absence guard can
hold, and it is not a complete replacement. A branch-local 1% edit is therefore forced onto
the HOT overlay *by construction* — the overlay is the mechanism that expresses "this identity
differs from the base I reference" without rewriting the base. The alternative would make a
one-row branch edit cost O(state), which is precisely what #1305 removed for merge.

That is the boundary, and it is in the right place.

## 4. Can it be shared? It already is — above 1024 bytes

`JsonSlot::from_json` (`packages/lix/src/json_store/types.rs:206-217`) routes payloads longer
than `JSON_INLINE_MAX_BYTES` = 1024 into the content-addressed `json_store.json` and stores
only a 32-byte `JsonRef` in the HOT value (`HEAD_SLOT_REF`). This is exactly the "branch-scoped
key -> shared content digest" indirection the experiment proposed, already shipped.

Measured, 10k rows, two branches, 1% edits, `LIX_EXPW_PAD_BYTES=1200`:

| scenario | snapshot slot | hot_row Δ | json_store Δrows | json_store Δbytes | **total** |
|---|---|---:|---:|---:|---:|
| identical | `REF` x200 | 42,772 | **100** | 15,601 | **58,373** |
| disjoint | `REF` x200 | 42,772 | **200** | 31,473 | **74,245** |

Exactly 2.00x on rows and 2.02x on bytes. **Cross-branch content sharing is real, exact, and
in production.** It simply does not fire at 143-byte payloads. The HOT row also drops from
353.77 to 211.74 B/row once the payload moves behind the ref.

### Extending it below the threshold is a regression

`expW_indirection_model` prices the optimistic version of the change: replace the payload in
every HOT value with a 32-byte digest, store each distinct payload once at `32B key + 4B
accounting + payload`. It charges **nothing** for the presence/refcount plane that
manifest-driven, refcount-free GC would need (experiment T), and **nothing** for the extra
read hop.

| scale | scenario | today | modeled | delta |
|---|---|---:|---:|---:|
| 10k | identical | 71,352 | 60,734 | **-14.88%** |
| 10k | disjoint | 71,462 | 78,734 | **+10.18%** |

The win exists only when two branches edit the same rows to the same values. Experiment T
measured byte-exact duplication of **0** in all 27 real repositories, so the disjoint column
is the real workload — and there the change is a **10% regression on physical bytes**, the
very axis it was meant to improve, before any OLTP cost is counted. Since it loses on its own
axis, the read hop never needed measuring; had it won, it would have.

The threshold's own comment (`json_store/types.rs:192-198`) records the measurement that set
it: "99.8% of payloads at 65-128 bytes with ~0.2% content dedup, so the json_store
indirection (two 32-byte refs, a store key, a store row, and a point read per
materialization) cost more than the payloads themselves." This experiment independently
reproduces that conclusion on the branch-sharing workload.

**Verdict: reject.** No engine change proposed.

## A/B table — primary metric

`branch_storage_sharing`, slatedb, ryzen-9950x-I, **9 reps per scenario**, arm order rotated
every rep (even reps identical-first, odd reps disjoint-first).

```
BIN=~/claude3/cand/target/release/deps/branch_storage_sharing-*
LIX_BRANCH_SHARING_ROWS=$ROWS LIX_BRANCH_SHARING_BACKENDS=slatedb \
LIX_BRANCH_SHARING_SCENARIOS=$SC LIX_BRANCH_SHARING_REP=$REP "$BIN" --bench
```

### `live_state.hot_row.v21` delta bytes

| scale | scenario | n | median | p95 | min | max | spread |
|---|---|---:|---:|---:|---:|---:|---:|
| 10k | disjoint | 9 | 71,462 | 71,462 | 71,462 | 71,462 | **0.000%** |
| 10k | identical | 9 | 71,352 | 71,352 | 71,352 | 71,352 | **0.000%** |
| 100k | disjoint | 9 | 711,462 | 711,462 | 711,462 | 711,462 | **0.000%** |
| 100k | identical | 9 | 710,352 | 710,352 | 710,352 | 710,352 | **0.000%** |

identical vs disjoint: **-0.154%** at 10k, **-0.156%** at 100k.

### Scenario `delta_logical_bytes` (all spaces)

| scale | scenario | n | median | p95 | min | max | spread |
|---|---|---:|---:|---:|---:|---:|---:|
| 10k | disjoint | 9 | 83,595 | 83,610 | 83,594 | 83,610 | 0.019% |
| 10k | identical | 9 | 83,533 | 83,533 | 83,503 | 83,533 | 0.036% |
| 100k | disjoint | 9 | 745,643 | 745,688 | 745,642 | 745,688 | 0.006% |
| 100k | identical | 9 | 744,328 | 744,329 | 744,298 | 744,329 | 0.004% |

identical vs disjoint: -0.074% at 10k, **-0.176%** at 100k.

`hot_row` is 710,352 / 744,328 = **95.4%** of the 100k two-branch scenario delta, reproducing
experiment T to the byte.

### `delta_physical_bytes` (filesystem walk)

| scale | scenario | n | median | min | max | spread |
|---|---|---:|---:|---:|---:|---:|
| 10k | disjoint | 9 | 57,051 | 56,959 | 57,098 | 0.244% |
| 10k | identical | 9 | 57,100 | 57,049 | 57,158 | 0.191% |
| 100k | disjoint | 9 | 313,142 | 312,485 | 313,991 | 0.481% |
| 100k | identical | 9 | 312,693 | 312,084 | 313,422 | 0.428% |

### Null control / resolution limit

The layout-accounting instrument is exactly deterministic: **0.000% spread across 9 reps in
all four `hot_row` cells**, and 0.004-0.036% on the all-spaces logical total. The measured
identical-vs-disjoint gap of 0.15% therefore sits roughly two orders of magnitude above the
instrument's resolution limit — it is a real, fully resolved 0.15%, not noise.

The filesystem measure is a different story: its own spread is 0.19-0.48%, i.e. **larger than
the effect**, so `delta_physical_bytes` cannot resolve this question at all. Anyone repeating
this must use `layout_accounting`, not the directory walk.

Raw per-rep numbers for every cell are in the analysis output; every `hot_row` cell repeated
its median exactly 9 times.

## Regressions

None. No engine code changed, so `tracked_state_crud` (including
`read_all_rows_consumed`, `read_one_by_pk`, `read_many_by_pk`), the write ids, `diff_commands`
and `repository_gc_scale` are all bit-identical by construction — the diff touches only
`packages/engine-benchmarks/`. Adding two scenarios to `DEFAULT_SCENARIOS` makes a default
`branch_storage_sharing` run longer; it changes no measurement of an existing scenario.

## Layout invariants checklist

1. **Single authority.** No. No new writer, no new materialization, no new index. The change
   adds one read-only example and two entries to a bench's default scenario list. The
   rejected candidate *would* have added a second authority for row payloads plus a
   presence/refcount plane, which is part of why it is rejected.
2. **Commit canonicality.** Unaffected. Nothing here reads or writes commit records; the
   example reads storage spaces through `layout_accounting` / `space_inventory`.
3. **Derived views are caches.** Unaffected, and the experiment confirms the existing
   property: `live_state.hot_row.v21` is a branch- and generation-scoped serving overlay over
   a canonical root/packed base reference, rebuildable from those records, and never the
   correctness authority.
4. **Atomic publication.** Unaffected — no publication path changed.
5. **GC from refs.** Unaffected, and reinforced: the rejected candidate would have required
   a presence/refcount plane disconnected from ref-rooted reachability, which experiment T
   showed this GC does not have. That is a design defect the numbers let us avoid paying for.
6. **SQL reads canonical records.** Unaffected. No query surface changed.

## Reproduce

```
cargo bench -p lix_benchmarks --features storage-benches,slatedb --bench branch_storage_sharing
cargo build -p lix_benchmarks --release --features storage-benches,slatedb --example expW_hot_row_anatomy
./target/release/examples/expW_hot_row_anatomy 100000 identical /tmp/w
LIX_EXPW_PAD_BYTES=1200 ./target/release/examples/expW_hot_row_anatomy 10000 identical /tmp/w2
```
