### PR TITLE
perf(bench): growth curves for the 14 storage spaces layout accounting could not see

### DIFF
--- a/packages/engine-benchmarks/Cargo.toml
+++ b/packages/engine-benchmarks/Cargo.toml
@@ -66,6 +66,11 @@ path = "examples/space_growth.rs"
 required-features = ["storage-benches"]
 
 [[example]]
+name = "expv_blind_space_growth"
+path = "examples/expv_blind_space_growth.rs"
+required-features = ["storage-benches"]
+
+[[example]]
 name = "storage_layout"
 path = "examples/storage_layout.rs"
 required-features = ["storage-benches", "slatedb"]

--- a/packages/engine-benchmarks/examples/expv_blind_space_growth.rs
+++ b/packages/engine-benchmarks/examples/expv_blind_space_growth.rs
@@ -78,6 +78,11 @@ async fn main() {
             let rows = parse_usize(arguments.get(2), 10);
             checkpoints_scenario(&samples, rows).await;
         }
+        "entity_commits" => {
+            let samples = parse_samples(arguments.get(1));
+            let rows = parse_usize(arguments.get(2), 10);
+            entity_commits_scenario(&samples, rows).await;
+        }
         "checkpoint_then_gc" => {
             let commits = parse_usize(arguments.get(1), 200);
             let rows = parse_usize(arguments.get(2), 10);
@@ -197,6 +202,66 @@ async fn checkpoints_scenario(samples: &[usize], rows_per_commit: usize) {
         }
         report(
             "checkpoints",
+            "live",
+            target as u64,
+            &usage(&fixture.storage).await,
+        );
+    }
+}
+
+/// A strictly typed flat entity surface, which is what
+/// `encode_registered_entity_row_groups` needs before it publishes anything
+/// into the two `entity.columnar_row_group_*` spaces. The JSON-valued schema
+/// the other scenarios use never reaches that encoder, so those two spaces stay
+/// empty there and would be misread as "bounded" without this workload.
+async fn entity_commits_scenario(samples: &[usize], rows_per_commit: usize) {
+    let fixture = Fixture::open().await;
+    let schema = serde_json::json!({
+        "x-lix-key": "expv_entity",
+        "x-lix-primary-key": ["/id"],
+        "type": "object",
+        "required": ["id", "name", "amount"],
+        "properties": {
+            "id": { "type": "string" },
+            "name": { "type": "string" },
+            "amount": { "type": "integer" }
+        },
+        "additionalProperties": false
+    });
+    fixture
+        .session
+        .execute(
+            "INSERT INTO lix_registered_schema (value, lixcol_global, lixcol_untracked) VALUES (lix_json($1), false, false)",
+            &[Value::Text(schema.to_string())],
+        )
+        .await
+        .expect("register entity schema");
+    let mut committed = 0usize;
+    for &target in samples {
+        while committed < target {
+            let mut transaction = fixture
+                .session
+                .begin_transaction()
+                .await
+                .expect("begin commit");
+            for index in 0..rows_per_commit {
+                transaction
+                    .execute(
+                        "INSERT INTO expv_entity (id, name, amount) VALUES ($1, $2, $3)",
+                        &[
+                            Value::Text(format!("{committed:08}-{index:08}")),
+                            Value::Text(format!("name-{committed}-{index}")),
+                            Value::Integer((committed * 1000 + index) as i64),
+                        ],
+                    )
+                    .await
+                    .expect("insert entity row");
+            }
+            transaction.commit().await.expect("commit entity batch");
+            committed += 1;
+        }
+        report(
+            "entity_commits",
             "live",
             target as u64,
             &usage(&fixture.storage).await,

--- a/packages/engine-benchmarks/examples/expv_blind_space_growth.rs
+++ b/packages/engine-benchmarks/examples/expv_blind_space_growth.rs
@@ -1,0 +1,431 @@
+//! Growth curves for the storage spaces layout accounting could not see.
+//!
+//! Before PR #1308 `native_storage_spaces()` enumerated 32 of 46 physical
+//! spaces, so `layout_accounting`, `layout_space_catalog` and every report
+//! built on them (`storage_layout`, `space_growth`, the `tracked_state_crud`
+//! layout table) were blind to 14 real planes. Every per-space byte number this
+//! optimization program published before that fix is therefore a lower bound.
+//!
+//! `space_growth` answers "which spaces grow per commit" for one axis only.
+//! This example sweeps the axes that can distinguish the three classifications
+//! that matter:
+//!
+//! * **bounded** — flat, or converging to a constant, in every axis.
+//! * **proportional** — grows with *live* state (rows, branches, files). Paying
+//!   bytes for data that is still reachable is what a store is for.
+//! * **unbounded** — grows with *history* and is never reclaimed. That is a
+//!   leak, and no amount of GC brings it back.
+//!
+//! Scenarios (each prints one `expv,` line per space per sample):
+//!
+//! ```text
+//! commits     <samples-csv> <rows_per_commit> [gc_rounds]
+//! rows        <commits> <rows-csv>
+//! branches    <samples-csv> <rows_per_commit>
+//! checkpoints <samples-csv> <rows_per_commit>
+//! idempotency <samples-csv>
+//! uploads     <samples-csv> <bytes_per_upload> <keep|delete>
+//! ```
+//!
+//! `samples-csv` is an ascending list of axis values; the axis is driven
+//! forward incrementally and layout accounting is sampled at each value, so one
+//! process produces a whole curve without rebuilding the fixture.
+
+use std::collections::BTreeMap;
+use std::sync::Arc;
+
+use lix::integration::{Engine, SessionContext};
+use lix::storage::Storage;
+use lix::storage_adapter::{StorageAdapter, StorageReadOptions};
+use lix::storage_bench::{collect_repository_gc_for_bench, layout_accounting};
+use lix::{
+    Blob, CreateBranchOptions, ExecuteIdempotency, ExecuteOptions, ExecuteStatementMetadata, Value,
+};
+use lix_storage_rocksdb::RocksDB;
+
+#[derive(Clone, Copy, Default)]
+struct SpaceUsage {
+    rows: u64,
+    key_bytes: u64,
+    value_bytes: u64,
+}
+
+type Usage = BTreeMap<(u32, &'static str), SpaceUsage>;
+
+#[tokio::main]
+async fn main() {
+    let arguments = std::env::args().skip(1).collect::<Vec<_>>();
+    let scenario = arguments.first().map(String::as_str).unwrap_or("commits");
+    match scenario {
+        "commits" => {
+            let samples = parse_samples(arguments.get(1));
+            let rows = parse_usize(arguments.get(2), 10);
+            let gc_rounds = parse_usize(arguments.get(3), 0);
+            commits_scenario(&samples, rows, gc_rounds).await;
+        }
+        "rows" => {
+            let commits = parse_usize(arguments.get(1), 20);
+            let samples = parse_samples(arguments.get(2));
+            rows_scenario(commits, &samples).await;
+        }
+        "branches" => {
+            let samples = parse_samples(arguments.get(1));
+            let rows = parse_usize(arguments.get(2), 10);
+            branches_scenario(&samples, rows).await;
+        }
+        "checkpoints" => {
+            let samples = parse_samples(arguments.get(1));
+            let rows = parse_usize(arguments.get(2), 10);
+            checkpoints_scenario(&samples, rows).await;
+        }
+        "idempotency" => {
+            let samples = parse_samples(arguments.get(1));
+            idempotency_scenario(&samples).await;
+        }
+        "uploads" => {
+            let samples = parse_samples(arguments.get(1));
+            let bytes = parse_usize(arguments.get(2), 4096);
+            let delete = arguments.get(3).map(String::as_str) == Some("delete");
+            uploads_scenario(&samples, bytes, delete).await;
+        }
+        other => panic!("unknown scenario '{other}'"),
+    }
+}
+
+// ---------------------------------------------------------------- scenarios
+
+/// Commit count is the axis that separates "proportional" from "unbounded":
+/// row count, branch count and file count are all held fixed, so any plane that
+/// keeps growing is growing with history alone.
+async fn commits_scenario(samples: &[usize], rows_per_commit: usize, gc_rounds: usize) {
+    let fixture = Fixture::open().await;
+    register_schema(&fixture.session).await;
+    let mut committed = 0usize;
+    for &target in samples {
+        while committed < target {
+            commit_batch(&fixture.session, committed, rows_per_commit).await;
+            committed += 1;
+        }
+        report(
+            "commits",
+            "live",
+            target as u64,
+            &usage(&fixture.storage).await,
+        );
+    }
+    for round in 1..=gc_rounds {
+        let result = collect_repository_gc_for_bench(&StorageAdapter::new(fixture.storage.clone()))
+            .await
+            .expect("commit repository GC");
+        println!(
+            "expv_gc,scenario=commits,round={round},commits={committed},staged_deletes={},swept_commits={}",
+            result.staged_deletes, result.swept_commits
+        );
+        report(
+            "commits",
+            "gc",
+            round as u64,
+            &usage(&fixture.storage).await,
+        );
+    }
+}
+
+/// Live-row count at a fixed commit count. A plane that moves here and not on
+/// the commit axis is proportional to live state, which is expected.
+async fn rows_scenario(commits: usize, samples: &[usize]) {
+    for &rows in samples {
+        let fixture = Fixture::open().await;
+        register_schema(&fixture.session).await;
+        for index in 0..commits {
+            commit_batch(&fixture.session, index, rows).await;
+        }
+        report(
+            "rows",
+            "live",
+            (rows * commits) as u64,
+            &usage(&fixture.storage).await,
+        );
+    }
+}
+
+async fn branches_scenario(samples: &[usize], rows_per_commit: usize) {
+    let fixture = Fixture::open().await;
+    register_schema(&fixture.session).await;
+    commit_batch(&fixture.session, 0, rows_per_commit).await;
+    let mut created = 0usize;
+    for &target in samples {
+        while created < target {
+            fixture
+                .session
+                .create_branch(CreateBranchOptions {
+                    id: None,
+                    name: format!("expv-branch-{created}"),
+                    from_commit_id: None,
+                })
+                .await
+                .expect("create branch");
+            created += 1;
+        }
+        report(
+            "branches",
+            "live",
+            target as u64,
+            &usage(&fixture.storage).await,
+        );
+    }
+}
+
+async fn checkpoints_scenario(samples: &[usize], rows_per_commit: usize) {
+    let fixture = Fixture::open().await;
+    register_schema(&fixture.session).await;
+    let mut created = 0usize;
+    for &target in samples {
+        while created < target {
+            commit_batch(&fixture.session, created, rows_per_commit).await;
+            fixture
+                .session
+                .create_checkpoint()
+                .await
+                .expect("create checkpoint");
+            created += 1;
+        }
+        report(
+            "checkpoints",
+            "live",
+            target as u64,
+            &usage(&fixture.storage).await,
+        );
+    }
+}
+
+/// Server `/execute` replay receipts. The write site is
+/// `transaction/context.rs:1879`; this scenario exists to find out what removes
+/// them again.
+async fn idempotency_scenario(samples: &[usize]) {
+    let fixture = Fixture::open().await;
+    register_schema(&fixture.session).await;
+    let mut issued = 0usize;
+    for &target in samples {
+        while issued < target {
+            let mut fingerprint = [0u8; 32];
+            fingerprint[..8].copy_from_slice(&(issued as u64).to_be_bytes());
+            let identity = ExecuteIdempotency::new(
+                Some("expv-principal".to_owned()),
+                format!("expv-key-{issued:012}"),
+                fingerprint,
+            );
+            Arc::clone(&fixture.session)
+                .execute_with_idempotency_and_options_and_metadata(
+                    "INSERT INTO space_growth (path, value) VALUES ($1, lix_json($2))".to_owned(),
+                    vec![
+                        Value::Text(format!("/idem/{issued:012}")),
+                        Value::Text(format!(r#"{{"n":{issued}}}"#)),
+                    ],
+                    ExecuteOptions::default(),
+                    ExecuteStatementMetadata::default(),
+                    Some(identity),
+                )
+                .await
+                .expect("idempotent execute");
+            issued += 1;
+        }
+        report(
+            "idempotency",
+            "live",
+            target as u64,
+            &usage(&fixture.storage).await,
+        );
+    }
+    let result = collect_repository_gc_for_bench(&StorageAdapter::new(fixture.storage.clone()))
+        .await
+        .expect("commit repository GC");
+    println!(
+        "expv_gc,scenario=idempotency,round=1,requests={issued},staged_deletes={},swept_commits={}",
+        result.staged_deletes, result.swept_commits
+    );
+    report(
+        "idempotency",
+        "gc",
+        1,
+        &usage(&fixture.storage).await,
+    );
+}
+
+/// Resumable-upload receipts. `keep` leaves every uploaded file live; `delete`
+/// removes each file again, which is the shape that tells retained-receipt
+/// bytes apart from live-file bytes.
+async fn uploads_scenario(samples: &[usize], bytes_per_upload: usize, delete: bool) {
+    let fixture = Fixture::open().await;
+    let mut uploaded = 0usize;
+    for &target in samples {
+        while uploaded < target {
+            let path = format!("/expv/upload-{uploaded:08}.bin");
+            let payload = vec![(uploaded % 251) as u8; bytes_per_upload];
+            fixture
+                .session
+                .upsert_file_content_part(
+                    format!("expv-upload-{uploaded:08}"),
+                    path.clone(),
+                    0,
+                    bytes_per_upload as u64,
+                    Blob::from(payload),
+                )
+                .await
+                .expect("upload part");
+            if delete {
+                fixture
+                    .session
+                    .execute("DELETE FROM lix_file WHERE path = $1", &[Value::Text(path)])
+                    .await
+                    .expect("delete uploaded file");
+            }
+            uploaded += 1;
+        }
+        report(
+            "uploads",
+            if delete { "live_deleted" } else { "live_kept" },
+            target as u64,
+            &usage(&fixture.storage).await,
+        );
+    }
+    let result = collect_repository_gc_for_bench(&StorageAdapter::new(fixture.storage.clone()))
+        .await
+        .expect("commit repository GC");
+    println!(
+        "expv_gc,scenario=uploads,round=1,uploads={uploaded},staged_deletes={},swept_commits={}",
+        result.staged_deletes, result.swept_commits
+    );
+    report("uploads", "gc", 1, &usage(&fixture.storage).await);
+}
+
+// ------------------------------------------------------------------ harness
+
+struct Fixture {
+    storage: RocksDB,
+    session: Arc<SessionContext<RocksDB>>,
+    _directory: tempfile::TempDir,
+}
+
+impl Fixture {
+    async fn open() -> Self {
+        let directory = tempfile::tempdir().expect("create RocksDB directory");
+        let storage = RocksDB::open(directory.path()).expect("open RocksDB");
+        Engine::initialize(storage.clone())
+            .await
+            .expect("initialize repository");
+        let engine = Engine::new(storage.clone()).await.expect("open engine");
+        let session = engine
+            .open_workspace_session()
+            .await
+            .expect("open workspace");
+        Self {
+            storage,
+            session: Arc::new(session),
+            _directory: directory,
+        }
+    }
+}
+
+fn report(scenario: &str, phase: &str, axis: u64, usage: &Usage) {
+    for ((id, name), value) in usage {
+        println!(
+            "expv,scenario={scenario},phase={phase},axis={axis},space_id=0x{id:08x},space={name},rows={},key_bytes={},value_bytes={}",
+            value.rows, value.key_bytes, value.value_bytes
+        );
+    }
+}
+
+async fn usage<S>(storage: &S) -> Usage
+where
+    S: Storage + Clone + Send + Sync + 'static,
+{
+    let adapter = StorageAdapter::new(storage.clone());
+    let read = adapter
+        .begin_read(StorageReadOptions::default())
+        .await
+        .expect("open storage snapshot");
+    let accounting = layout_accounting(&read)
+        .await
+        .into_iter()
+        .map(|entry| {
+            (
+                (entry.space_id, entry.space),
+                SpaceUsage {
+                    rows: entry.rows,
+                    key_bytes: entry.key_bytes,
+                    value_bytes: entry.value_bytes,
+                },
+            )
+        })
+        .collect();
+    drop(read);
+    accounting
+}
+
+async fn commit_batch<S>(session: &SessionContext<S>, batch: usize, rows: usize)
+where
+    S: Storage + Clone + Send + Sync + 'static,
+{
+    let mut transaction = session.begin_transaction().await.expect("begin commit");
+    for index in 0..rows {
+        transaction
+            .execute(
+                "INSERT INTO space_growth (path, value) VALUES ($1, lix_json($2))",
+                &[
+                    Value::Text(format!("/row/{batch:08}/{index:08}")),
+                    Value::Text(format!(r#"{{"batch":{batch},"index":{index}}}"#)),
+                ],
+            )
+            .await
+            .expect("insert row");
+    }
+    transaction.commit().await.expect("commit batch");
+}
+
+async fn register_schema<S>(session: &SessionContext<S>)
+where
+    S: Storage + Clone + Send + Sync + 'static,
+{
+    let schema = serde_json::json!({
+        "x-lix-key": "space_growth",
+        "x-lix-primary-key": ["/path"],
+        "type": "object",
+        "required": ["path", "value"],
+        "properties": {
+            "path": { "type": "string" },
+            "value": {
+                "type": ["object", "array", "string", "number", "integer", "boolean", "null"]
+            }
+        },
+        "additionalProperties": false
+    });
+    session
+        .execute(
+            "INSERT INTO lix_registered_schema (value, lixcol_global, lixcol_untracked) VALUES (lix_json($1), false, false)",
+            &[Value::Text(schema.to_string())],
+        )
+        .await
+        .expect("register schema");
+}
+
+fn parse_samples(argument: Option<&String>) -> Vec<usize> {
+    let samples = argument
+        .map(|value| {
+            value
+                .split(',')
+                .map(|entry| entry.trim().parse::<usize>().expect("sample must be usize"))
+                .collect::<Vec<_>>()
+        })
+        .unwrap_or_else(|| vec![1, 10, 100, 1000]);
+    assert!(!samples.is_empty(), "need at least one sample point");
+    for pair in samples.windows(2) {
+        assert!(pair[0] < pair[1], "sample points must ascend");
+    }
+    samples
+}
+
+fn parse_usize(argument: Option<&String>, fallback: usize) -> usize {
+    argument
+        .and_then(|value| value.parse::<usize>().ok())
+        .unwrap_or(fallback)
+}

--- a/packages/engine-benchmarks/examples/expv_blind_space_growth.rs
+++ b/packages/engine-benchmarks/examples/expv_blind_space_growth.rs
@@ -78,6 +78,12 @@ async fn main() {
             let rows = parse_usize(arguments.get(2), 10);
             checkpoints_scenario(&samples, rows).await;
         }
+        "checkpoint_then_gc" => {
+            let commits = parse_usize(arguments.get(1), 200);
+            let rows = parse_usize(arguments.get(2), 10);
+            let gc_rounds = parse_usize(arguments.get(3), 12);
+            checkpoint_then_gc_scenario(commits, rows, gc_rounds).await;
+        }
         "idempotency" => {
             let samples = parse_samples(arguments.get(1));
             idempotency_scenario(&samples).await;
@@ -193,6 +199,53 @@ async fn checkpoints_scenario(samples: &[usize], rows_per_commit: usize) {
             "checkpoints",
             "live",
             target as u64,
+            &usage(&fixture.storage).await,
+        );
+    }
+}
+
+/// Isolates the drain rate of the authenticated reachability queue.
+///
+/// Without a checkpoint the whole commit chain is the retained undo interval
+/// (`gc.rs:118-159` walks head → `serving_checkpoint_commit_id`), so no old
+/// root is retirable and no queue row is consumable. One checkpoint lowers that
+/// floor; the explicit GC rounds afterwards then measure how many queue rows
+/// one sweep actually consumes.
+async fn checkpoint_then_gc_scenario(commits: usize, rows_per_commit: usize, gc_rounds: usize) {
+    let fixture = Fixture::open().await;
+    register_schema(&fixture.session).await;
+    for index in 0..commits {
+        commit_batch(&fixture.session, index, rows_per_commit).await;
+    }
+    report(
+        "checkpoint_then_gc",
+        "before_checkpoint",
+        commits as u64,
+        &usage(&fixture.storage).await,
+    );
+    fixture
+        .session
+        .create_checkpoint()
+        .await
+        .expect("create checkpoint");
+    report(
+        "checkpoint_then_gc",
+        "after_checkpoint",
+        0,
+        &usage(&fixture.storage).await,
+    );
+    for round in 1..=gc_rounds {
+        let result = collect_repository_gc_for_bench(&StorageAdapter::new(fixture.storage.clone()))
+            .await
+            .expect("commit repository GC");
+        println!(
+            "expv_gc,scenario=checkpoint_then_gc,round={round},commits={commits},staged_deletes={},swept_commits={}",
+            result.staged_deletes, result.swept_commits
+        );
+        report(
+            "checkpoint_then_gc",
+            "gc",
+            round as u64,
             &usage(&fixture.storage).await,
         );
     }

--- a/packages/engine-benchmarks/examples/storage_layout.rs
+++ b/packages/engine-benchmarks/examples/storage_layout.rs
@@ -11,7 +11,20 @@ use lix_storage_slatedb::SlateDB;
 use object_store::local::LocalFileSystem;
 use slatedb::{SstReader, ValueDeletable};
 
-const HOT_SPACE: &str = "live_state.hot_row.v20";
+/// The hot-row space is versioned in its name, so a hard-coded literal goes
+/// stale the moment the plane is revised — and `space_inventory` panics on a
+/// name the registry does not know, which took the whole non-`--physical-only`
+/// mode down when `hot_row.v20` became `v21`. Resolve it from the registry by
+/// prefix instead so the tool tracks the rename.
+const HOT_SPACE_PREFIX: &str = "live_state.hot_row.";
+
+fn hot_space_name() -> &'static str {
+    layout_space_catalog()
+        .into_iter()
+        .map(|(_, name)| name)
+        .find(|name| name.starts_with(HOT_SPACE_PREFIX))
+        .expect("registry has exactly one hot-row space")
+}
 const IMMUTABLE_BINARY_CAS_CHUNK_DIR: &str = "db/lix-immutable-binary-cas-segment-v4";
 
 #[derive(Default)]
@@ -95,7 +108,7 @@ async fn main() {
     print_binary_cas_owners(&read).await;
     print_plugin_checkpoint_layout(&read).await;
 
-    let inventory = space_inventory(&read, HOT_SPACE).await;
+    let inventory = space_inventory(&read, hot_space_name()).await;
     let mut groups = BTreeMap::<Vec<u8>, HotGroup>::new();
     for (key, value) in inventory {
         let decoded = decode_hot_group(&key).expect("valid HOT V19 key");


### PR DESCRIPTION
## What this is

PR #1308 found that `storage_bench::native_storage_spaces()` enumerated **32 of 46** physical
spaces, so `layout_accounting`, `layout_space_catalog` and every report built on them were blind to
14 real planes. This PR adds the instrument that measures those 14 across the axes that separate
*proportional* from *unbounded*, repairs a second tool that has been panicking, and reports what the
instrument found.

**No engine code changes.** Two benchmark files only.

### Added — `packages/engine-benchmarks/examples/expv_blind_space_growth.rs`

Per-space rows and bytes as a function of workload, driven through the real `SessionContext` SQL
commit path, with six scenarios: `commits`, `rows`, `branches`, `checkpoints`, `entity_commits`
(≥512-row transactions, which is what the columnar row-group spaces need), `idempotency`, `uploads`,
and `checkpoint_then_gc` (isolates the GC drain rate). Every scenario samples `layout_accounting`
at a list of axis points and after each explicit GC sweep, so one process produces a whole curve.

### Fixed — `packages/engine-benchmarks/examples/storage_layout.rs`

`const HOT_SPACE = "live_state.hot_row.v20"` went stale when the plane became `v21`.
`space_inventory` panics on a name the registry does not know
(`storage_bench.rs:2253` `.expect("space name should exist")`), so **every non-`--physical-only` run
of `storage_layout` has been aborting** — the whole per-space table, commit-delta inventory, binary
manifest layout and hot-key-width analysis. Resolved from the registry by prefix so it cannot drift
again.

## Findings

### 1. `gc.reachability_delta.v1` is unbounded and is never reclaimed in any configuration

One row per branch-head publication, ~439 B, forever.

| commits | delta rows | delta bytes | B/commit |
|---|---|---|---|
| 1 | 2 | 857 | — |
| 10 | 11 | 4,781 | 436 |
| 100 | 101 | 44,021 | 439 |
| 1,000 | 1,001 | 439,042 | 439 |
| 10,000 | 10,001 | **4,390,042** | 439 |

At 10,000 commits that is **1.6× the entire live serving plane** (`live_state.hot_row.v21`,
2,741,364 B) in pure GC bookkeeping. In the same fixture `tracked_state.tree_chunk` — the plane
PR #1299 called "the only unbounded mutable plane" — grows at 400 B/commit. The invisible plane is
the **larger** of the two.

Reclamation, measured:

| workload | GC sweeps | delta bytes before → after |
|---|---|---|
| 10,000 commits, no checkpoint | 6 explicit | 4,390,042 → 4,390,042 |
| 200 commits + 1 checkpoint | 12 explicit | 86,260 → 86,260 |
| 1,000 commits + 1 checkpoint | 20 explicit | 427,860 → 427,860 |
| 400 checkpoints (production cadence) | ~3 automatic | 512,987, exactly `2C+1` rows throughout |

Zero rows consumed, ever. Independent of row count (flat at 21 rows over a 1,000× row sweep).

### 2. Repository GC is inert without a checkpoint, and stops permanently after one

* 10,000 commits, six sweeps: `staged_deletes=0` on all six. `changelog.commit` 10,002 rows,
  `commit_state_manifest` 10,002 rows, `tree_chunk` 4,002,936 B — nothing moved.
* 100 uploaded files then all 100 deleted, one sweep: `staged_deletes=0`. All 6,557,900 B of
  `binary_cas.chunk` for the deleted files retained.
* 200 commits + one checkpoint: sweep 1 stages 189 deletes and drops `changelog.commit` 204→141.
  Sweeps 2–12 stage **0**. Same at 1,000 commits over 20 sweeps.

Mechanism, from `gc.rs` (read only — not touched here):

* `authenticated_control_commit_reachability` (`gc.rs:118-159`) walks head →
  `serving_checkpoint_commit_id` and inserts every ancestor into `history_dependencies`. With no
  checkpoint the floor is `None`, so the whole chain is a dependency and `retirement_is_proven`
  (`gc.rs:3530-3538`) is false for every delta.
* Consumption is strictly head-of-line: `queue_open = false` at the first blocked sequence
  (`gc.rs:2434-2440`), and only `head..consumed_through` is deleted (`gc.rs:2575-2593`). One
  permanently pinned old root at the queue head wedges the queue forever.
* Even unwedged the drain is capped at `GC_REACHABILITY_BATCH_LIMIT = 64` rows per sweep, while
  `checkpoint_gc_due` (`session/checkpoint.rs:175-191`) with `CHECKPOINT_GC_MIN_AGE = 64` and
  `CHECKPOINT_GC_HISTORY_FRACTION = 1` yields `age_limit = max(64, last_gc_sequence)` — sweeps at
  checkpoints 64, 128, 256, 512… i.e. `O(log C)`. Drain capacity `64·O(log C)` against a fill of
  1/commit is asymptotically unbounded on its own.
* The wedge is not confined to the delta plane. GC has two sweep paths, and only one survives.
  `plan_and_stage_authority_gc` (`gc.rs:2807+`) runs unconditionally — that is what dropped
  `changelog.commit` 204→141 in the drain run. But the **physical retirement of a released root** —
  its `commit_state_manifest`, `commit_mutation_directory_node`, the scoped-range nodes and
  `current_state_data_part{,_refs}` it pins — happens inside the consumed-prefix loop
  (`gc.rs:2484-2545`) and therefore never runs. Measured over the same 12 sweeps:
  `commit_state_manifest` stayed at 204 rows / 59,467 B and `tracked_state.tree_chunk` at 70 rows /
  143,437 B — byte-identical from sweep 1 to sweep 12.
* Second-order cost: `collect_all_reachability_checkpoint_roots` (`gc.rs:787-805`) folds the whole
  queue with `limit = None` on every sweep, decoding and BLAKE3-verifying every row. GC planning is
  therefore Θ(total commits ever made). `resolve_pending_checkpoint_replacement` (`gc.rs:817+`) does
  the same full-queue fold on the commit path.

This is handed to experiment R (GC self-containment); `gc.rs` is deliberately untouched here.

### 3. `session.execute_idempotency_receipt.v1` is unbounded, outside `gc.rs`, with no delete site

1 / 10 / 100 / 1,000 idempotent `/execute` writes → 1 / 10 / 100 / 1,000 rows, 259 / 2,590 / 25,990 /
260,560 B. A repository GC sweep reclaims none. `EXECUTE_IDEMPOTENCY_RECEIPT_SPACE` has exactly one
writer (`transaction/context.rs:1879`) and **no `delete` anywhere in the workspace**. Each row holds
the request's full result set, bounded only by `MAX_RECEIPT_BYTES = 8 MiB`. Server deployments
require an Idempotency-Key for every SQL mutation (`session/execute.rs:1254`), so this is one
permanent row per server write.

Not fixed here on purpose: the only correct reclamation point is repository GC (`gc.rs`, reserved
for experiment R), and any retention window is a protocol-replay decision — reclaiming a receipt
makes a later client retry re-execute the mutation — not a layout choice this experiment may make
unilaterally.

### 4. The columnar row-group spaces hold the bulk of live state for bulk inserts

A transaction staging ≥512 rows of one schema (`PACKED_CURRENT_BASE_MIN_ROWS`,
`transaction/commit.rs:5373`) publishes columnar row groups instead of hot rows:

| rows/commit (20 commits) | `hot_row.v21` | `columnar_row_group_manifest` | `columnar_row_group_column` |
|---|---|---|---|
| 100 | 2,041 r / 563,274 B | 0 | 0 |
| 1,000 | 41 r / 22,474 B | 20 r / 12,140 B | 60 r / 214,013 B |

Both row-group spaces were invisible. Any earlier per-space attribution taken on a fixture seeded in
≥512-row batches was reading a table with most of the live bytes missing.

### Full classification of all 14

| space | id | commits | rows | branches | checkpoints | files | reclaimed by GC | class |
|---|---|---|---|---|---|---|---|---|
| `gc.reachability_delta.v1` | `0x00080003` | **+439 B/commit** | flat | +1 row/branch | +2 rows/cp | — | **never** | **unbounded** |
| `session.execute_idempotency_receipt.v1` | `0x00070005` | — | — | — | — | +260 B/request | **never (no delete site)** | **unbounded** |
| `live_state.hot_collection_control.v1` | `0x00040023` | flat 10 r | flat | flat | flat | +270 B/file | no production sweeper | proportional (flagged) |
| `entity.columnar_row_group_manifest.v1` | `0x00040029` | flat | +1 row/bulk commit | flat | flat | — | with owning commit | proportional |
| `entity.columnar_row_group_column.v1` | `0x0004002a` | flat | +3 rows/bulk commit | flat | flat | — | with owning commit | proportional |
| `session.file_upload.v2` | `0x00070006` | — | — | — | — | +360 B/upload | contract says when the blob root dies; **not observed** — see finding 2 | proportional (blocked) |
| `session.file_upload_manifest_leaf.v2` | `0x00070007` | 0 | 0 | 0 | 0 | 0 (folded at publication) | at GC | bounded |
| `checkpoint.recovery_ref.v3` | `0x00080001` | 0 | 0 | 0 | 1 r / 112 B at 1..400 cp | — | with branch | bounded (1/branch) |
| `checkpoint.gc_state.v1` | `0x00080002` | 0 | 0 | 0 | 1 r / 18-20 B | — | n/a | bounded (exactly 1) |
| `gc.reachability_queue.v1` | `0x00080004` | 1 r / 13-15 B | flat | flat | flat | flat | n/a | bounded (exactly 1) |
| `lix.revision.v1` | `0x00070000` | 4 r / 84 B | flat | flat | flat | 5 r / 105 B (CAS publish), 6 r / 126 B (after CAS sweep) | n/a | bounded (**6** fixed one-byte keys) |
| `tracked_state.scoped_range.v3` | `0x00040032` | 0 | 0 | 0 | 0 | 0 | — | **not exercised** |
| `tracked_state.current_state_data_part.v1` | `0x0004002f` | 0 | 0 | 0 | 0 | 0 | — | **not exercised** |
| `tracked_state.current_state_data_part_refs.v1` | `0x00040030` | 0 | 0 | 0 | 0 | 0 | — | **not exercised** |

The last three carry no rows in any of the nine workloads I could drive through the public SQL
commit path. They are content-addressed and swept inside the queue-consumption loop, so they inherit
its reclamation behaviour, but their growth is unmeasured.

## Which earlier byte measurements should be re-run

The blindness was confined to the **logical per-space** tools. Backend-level totals were never
catalog-derived: `inspect_ssts_fast` sums every data block and only *names* spaces from the catalog
(unknown ids printed `<unknown>`), and `backend_bytes` / `physical_bytes` / `object_write_bytes` /
`storage_amplification` come from the adapters. Every A/B headline built on those stands.

| measurement | tool | verdict |
|---|---|---|
| **PR #1299 (run K)** — "`tree_chunk` is the only unbounded mutable plane at 29 KB/commit" | `examples/space_growth.rs` → `layout_accounting` | **Wrong. Re-run.** `gc.reachability_delta.v1` grows at 439 B/commit, *above* `tree_chunk`'s 400 B/commit in the same fixture, and unlike `tree_chunk` it is never reclaimed. |
| **PR #1305 (run M)** — "all of the saving is in `live_state.hot_row.v21`; nothing else moves" | `benches/branch_storage_sharing.rs` → `layout_accounting`, `SEED_BATCH_ROWS = 5_000` | **Re-run, and it holds** — see below. Reported as a comment on #1305. |
| any per-space table from `storage_layout` (runs F, K, and bytes reports) | `examples/storage_layout.rs` | **Re-run**, and note the tool has additionally been aborting outright since `hot_row` became `v21` (fixed here). Its `PHYSICAL_TOTAL_FAST` / `SST_SUMMARY_FAST` totals were always correct. |
| any claim of the form "the per-space sum is the total" | `layout_accounting` | Those sums were lower bounds by up to 14 spaces. |
| PR #1308 duplicate audit | `examples/duplicate_audit.rs` | Already re-run post-fix — this is how the 14 were found. |
| `tracked_state_crud` layout table | `benches/tracked_state_crud/kv_layout.rs` | **Unaffected.** It scans its own KV `ROW_SPACE`, not `native_storage_spaces()`. |
| `tests/corruption_recovery_qualification.rs` | `layout_space_catalog()` | Not a wrong number — it simply could not target any of the 14. Coverage gap now closed by the registry. |

## Re-validated after merging `origin/claude-3-optimizations` @ `7e539a0ce`

PR #1314 split `REVISION_KEY_BINARY_CAS_EPOCH` into `REVISION_KEY_BINARY_CAS_RECLAMATION` (`b`) and
`REVISION_KEY_BINARY_CAS_PUBLICATION` (`p`), so `lix.revision.v1` is now **6** fixed one-byte keys,
not 5. Re-measured on the merged head rather than carried forward:

| workload | `lix.revision.v1` |
|---|---|
| pure SQL commits (1 / 100 / 1,000) | 4 rows / 84 B, flat |
| + binary-CAS publication (1 / 10 / 100 uploads) | 5 rows / 105 B, flat |
| + one CAS reclamation sweep | **6 rows / 126 B** — the ceiling |

Still **bounded by construction**; only the ceiling moved. Every other row in the table re-measured
byte-identical on the merged head — `gc.reachability_delta.v1` is still 439 B/commit
(439,042 B at 1,000 commits), `session.file_upload.v2` still 359 B/upload, and
`live_state.hot_collection_control.v1` still 1,711 B at one uploaded file.

### PR #1305's attribution, re-run with the repaired catalog

`LIX_BRANCH_SHARING_ROWS=500,5000`, rocksdb, scenarios `base,branch_1pct,merge_1pct,delete_gc_1pct`.
500 is below the 512-row columnar gate, 5,000 is what #1305 actually ran.

The base *fixture* composition differs enormously between the two regimes:

| base fixture | `hot_row.v21` | `columnar_row_group_column` | `columnar_row_group_manifest` | `commit_delta_segment.v6` |
|---|---|---|---|---|
| 500 rows (below gate) | 541 r / 192,868 B | — | — | — |
| 5,000 rows (above gate) | 41 r / 22,478 B | 9 r / 59,891 B | 1 r / 936 B | 10 r / 72,576 B |

At 5,000 rows only ~14% of the live bytes are in `hot_row`. **But both row-group spaces have
`d_rows = 0` in every scenario** — they never appear in a `branch_sharing_space` delta line at either
row count. So **#1305's "nothing else moves" is confirmed**: the invisible spaces were static.

One small correction: three previously-blind spaces *do* move, and were missing from #1305's table —
`gc.reachability_delta.v1` (+1,164 B branch, +1,611 B merge, +1,862 B delete+GC),
`lix.revision.v1` (+21 to +42 B) and `live_state.hot_collection_control.v1` (+68 B). Combined ≤1.9 KB
against `hot_row` deltas of 2.0–18.0 KB and a −98.7% headline of ~29.5 MB. The attribution and the
conclusion stand.

Third independent confirmation of finding 2 from that run: in `delete_gc_1pct` **every** space has a
*positive* delta at both row counts — `changelog.commit` +2 rows, `tree_chunk` +2 rows,
`gc.reachability_delta.v1` +3 rows, nothing negative. The program's own branch-sharing GC lane
reclaims nothing.

## Layout invariants

1. **Single authority** — no. Adds one measurement example and repairs one; no writers, no
   materializations, no indexes.
2. **Commit canonicality** — unaffected.
3. **Derived views are caches** — unaffected.
4. **Atomic publication** — unaffected.
5. **GC from refs** — unaffected by this PR, and the finding above is exactly a defect in that
   mechanism, reported for experiment R rather than patched here.
6. **SQL reads canonical records** — unaffected.

## Gate

`cargo check --workspace`, `cargo clippy --workspace --all-targets --all-features -- -D warnings`,
`cargo test -p lix --all-features` on `hetzner-cpx62`.

## Metrics

Byte and row counts only; no timing claim, so the 9-rep A/B protocol does not apply. Every number
above is an exact `layout_accounting` scan (deterministic, not sampled), reproducible with:

```
cargo run -p lix_benchmarks --release --features storage-benches,slatedb \
  --example expv_blind_space_growth -- commits 1,10,100,1000,10000 1 6
```
