### PR TITLE
perf(tracked_state): skip staging tree chunks already durable

### DIFF
--- a/.changenotes/skip-rewriting-durable-tree-chunks.md
+++ b/.changenotes/skip-rewriting-durable-tree-chunks.md
@@ -1,0 +1,7 @@
+---
+type: patch
+---
+
+Commits no longer rewrite tracked-state tree nodes that are already stored.
+
+The tracked-state tree is content-addressed, so a node's identity is its content. Rebuilding a commit root could still re-write nodes that were byte-for-byte already on disk, and neither storage backend filtered those out. Writers now check first and stage only genuinely new nodes, cutting redundant write traffic in long histories by roughly three quarters without changing on-disk size or query results.

--- a/packages/lix/src/tracked_state/context.rs
+++ b/packages/lix/src/tracked_state/context.rs
@@ -3773,11 +3773,23 @@ pub(crate) struct TrackedStateWriter<'a, S: ?Sized> {
     writes: &'a mut StorageWriteSet,
 }
 
-#[derive(Debug, Default)]
+#[derive(Debug)]
 pub(crate) struct TrackedStateTransientRebuildState {
     chunk_overlay: storage::TrackedStateChunkOverlay,
     staged_roots: BTreeMap<String, TrackedStateCommitRoot>,
     transient_chunk_hashes: HashSet<[u8; crate::tracked_state::types::TRACKED_STATE_HASH_BYTES]>,
+}
+
+impl Default for TrackedStateTransientRebuildState {
+    /// Rebuild state exists only for the explicit repair path, so its overlay
+    /// rewrites durable chunks instead of trusting an addressed digest.
+    fn default() -> Self {
+        Self {
+            chunk_overlay: storage::TrackedStateChunkOverlay::repairing(),
+            staged_roots: BTreeMap::new(),
+            transient_chunk_hashes: HashSet::new(),
+        }
+    }
 }
 
 impl TrackedStateTransientRebuildState {
@@ -3846,7 +3858,8 @@ where
             .copied()
             .collect::<Vec<_>>();
         self.chunk_overlay
-            .stage_selected_chunks(self.writes, promoted.iter().copied())?;
+            .stage_selected_chunks(self.store, self.writes, promoted.iter().copied())
+            .await?;
         for hash in promoted {
             self.transient_chunk_hashes.remove(&hash);
         }

--- a/packages/lix/src/tracked_state/storage.rs
+++ b/packages/lix/src/tracked_state/storage.rs
@@ -5,7 +5,7 @@
 )]
 
 use std::borrow::Cow;
-use std::collections::{BTreeMap, BTreeSet, HashMap, VecDeque};
+use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet, VecDeque};
 use std::ops::{Bound, Deref, Range};
 use std::sync::{Arc, Mutex, OnceLock};
 
@@ -12026,11 +12026,66 @@ pub(crate) fn debug_verify_chunk_hash(
 #[derive(Debug, Default)]
 pub(crate) struct TrackedStateChunkOverlay {
     chunks: HashMap<[u8; TRACKED_STATE_HASH_BYTES], Bytes>,
+    /// Chunk digests this writer has proven are already durable at its read
+    /// snapshot. The space is content-addressed, so a present key is the same
+    /// bytes by construction and re-writing it is a no-op the backend cannot
+    /// elide for a mutable space.
+    known_durable: HashSet<[u8; TRACKED_STATE_HASH_BYTES]>,
+    /// Explicit commit-root rebuild is the repair path for a damaged chunk, so
+    /// it must rewrite every node it derives. A present key proves the digest
+    /// is addressed, not that the stored bytes still hash to it.
+    rewrite_durable: bool,
 }
 
 impl TrackedStateChunkOverlay {
     pub(crate) fn new() -> Self {
         Self::default()
+    }
+
+    /// Overlay for the explicit rebuild path, which repairs corrupt chunks by
+    /// rewriting them and therefore never skips a durable digest.
+    pub(crate) fn repairing() -> Self {
+        Self {
+            rewrite_durable: true,
+            ..Self::default()
+        }
+    }
+
+    /// Records which of `hashes` are already durable, using one presence-only
+    /// batched point read. Digests already proven durable are not probed again.
+    async fn probe_durable_digests(
+        &mut self,
+        store: &(impl StorageAdapterRead + ?Sized),
+        hashes: impl IntoIterator<Item = [u8; TRACKED_STATE_HASH_BYTES]>,
+    ) -> Result<(), LixError> {
+        if self.rewrite_durable {
+            return Ok(());
+        }
+        let candidates = hashes
+            .into_iter()
+            .filter(|hash| !self.known_durable.contains(hash))
+            .collect::<Vec<_>>();
+        if candidates.is_empty() {
+            return Ok(());
+        }
+        let keys = candidates
+            .iter()
+            .map(|hash| StorageKey(Bytes::copy_from_slice(hash)))
+            .collect::<Vec<_>>();
+        let requests = [StorageGetManyRequest {
+            space: TRACKED_STATE_TREE_CHUNK_SPACE,
+            keys: &keys,
+            opts: StorageGetOptions {
+                projection: StorageCoreProjection::KeyOnly,
+            },
+        }];
+        let result = exact_get_many(store, &requests).await?;
+        for (hash, value) in candidates.into_iter().zip(result.values) {
+            if value.is_some() {
+                self.known_durable.insert(hash);
+            }
+        }
+        Ok(())
     }
 
     pub(crate) fn staged_chunk(&self, hash: &[u8; TRACKED_STATE_HASH_BYTES]) -> Option<&[u8]> {
@@ -12041,12 +12096,24 @@ impl TrackedStateChunkOverlay {
         self.chunks.keys().copied()
     }
 
-    pub(crate) fn stage_selected_chunks(
-        &self,
+    pub(crate) async fn stage_selected_chunks(
+        &mut self,
+        store: &(impl StorageAdapterRead + ?Sized),
         writes: &mut StorageWriteSet,
         hashes: impl IntoIterator<Item = [u8; TRACKED_STATE_HASH_BYTES]>,
     ) -> Result<(), LixError> {
+        let hashes = hashes.into_iter().collect::<Vec<_>>();
+        if hashes.is_empty() {
+            return Ok(());
+        }
+        // Transient chunks live only in the overlay, so the durable probe must
+        // run against the digests themselves rather than the staged-chunk map.
+        self.probe_durable_digests(store, hashes.iter().copied())
+            .await?;
         for hash in hashes {
+            if self.known_durable.contains(&hash) {
+                continue;
+            }
             let bytes = self.chunks.get(&hash).ok_or_else(|| {
                 LixError::new(
                     LixError::CODE_INTERNAL_ERROR,
@@ -12068,25 +12135,46 @@ impl TrackedStateChunkOverlay {
         self.chunks.get(hash).cloned()
     }
 
-    pub(crate) fn stage_chunks(
+    /// Stages the chunks this rewrite produced, skipping any digest already
+    /// durable at the writer's read snapshot.
+    ///
+    /// The tracked-state tree is content-addressed, so an existing key is
+    /// necessarily the same bytes. A mutable storage space has no
+    /// already-present skip of its own (RocksDB's lives behind
+    /// `ValueSemantics::Immutable`; SlateDB's mutable path writes straight into
+    /// its overlay), so without this filter a root rewrite that re-derives an
+    /// ancestor's nodes pays the full write-set, WAL, memtable and compaction
+    /// cost for bytes that are already on disk.
+    pub(crate) async fn stage_chunks(
         &mut self,
+        store: &(impl StorageAdapterRead + ?Sized),
         writes: &mut StorageWriteSet,
         chunks: &PendingChunkBatch,
-    ) {
+    ) -> Result<(), LixError> {
         if chunks.is_empty() {
-            return;
+            return Ok(());
         }
+        self.probe_durable_digests(store, chunks.chunks().iter().map(|chunk| chunk.hash))
+            .await?;
         let mut key_arena =
             Vec::with_capacity(chunks.len().saturating_mul(TRACKED_STATE_HASH_BYTES));
         let mut puts = Vec::with_capacity(chunks.len());
         for chunk in chunks.chunks() {
+            // Overlay residency is independent of staging: an in-flight rewrite
+            // still reads a durable-skipped node through the overlay.
+            self.chunks.insert(chunk.hash, chunks.chunk_data(*chunk));
+            if self.known_durable.contains(&chunk.hash) {
+                continue;
+            }
             let key_start = key_arena.len();
             key_arena.extend_from_slice(&chunk.hash);
             puts.push(EncodedPut {
                 key: BufferRange::new(key_start, TRACKED_STATE_HASH_BYTES),
                 value: BufferRange::new(chunk.data_start, chunk.data_len),
             });
-            self.chunks.insert(chunk.hash, chunks.chunk_data(*chunk));
+        }
+        if puts.is_empty() {
+            return Ok(());
         }
         let batch = EncodedMutationBatch::try_new(
             Bytes::from(key_arena),
@@ -12096,6 +12184,7 @@ impl TrackedStateChunkOverlay {
         )
         .expect("tracked-state chunk batch descriptors must match their arenas");
         writes.stage_content_addressed_encoded_batch(TRACKED_STATE_TREE_CHUNK_SPACE, batch);
+        Ok(())
     }
 }
 
@@ -15383,8 +15472,12 @@ mod tests {
             .collect()
     }
 
-    #[test]
-    fn large_chunk_batch_stages_two_shared_arenas() {
+    #[tokio::test]
+    async fn large_chunk_batch_stages_two_shared_arenas() {
+        let store = StorageAdapter::new(Memory::new())
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("open empty snapshot");
         let chunk_count = 4_096;
         let mut data_arena = Vec::with_capacity(chunk_count * 64);
         let mut descriptors = Vec::with_capacity(chunk_count);
@@ -15401,7 +15494,10 @@ mod tests {
         let chunks = PendingChunkBatch::from_parts(Bytes::from(data_arena), descriptors);
         let mut writes = StorageWriteSet::new();
         let mut overlay = TrackedStateChunkOverlay::new();
-        overlay.stage_chunks(&mut writes, &chunks);
+        overlay
+            .stage_chunks(&store, &mut writes, &chunks)
+            .await
+            .expect("stage chunks against an empty durable store");
 
         let arena = writes.arena_stats();
         assert_eq!(arena.put_descriptors, chunk_count);

--- a/packages/lix/src/tracked_state/tree.rs
+++ b/packages/lix/src/tracked_state/tree.rs
@@ -388,7 +388,7 @@ impl TrackedStateTree {
                     })?;
                 let chunk_bytes = chunks.data.len();
                 let chunks = chunks.finish();
-                overlay.stage_chunks(writes, &chunks);
+                overlay.stage_chunks(store, writes, &chunks).await?;
                 return Ok(TrackedStateApplyResult {
                     root_id: TrackedStateRootId::new(root.child_hash),
                     row_count: 0,
@@ -489,7 +489,7 @@ impl TrackedStateTree {
         };
         let chunk_bytes = chunks.data.len();
         let chunks = chunks.finish();
-        overlay.stage_chunks(writes, &chunks);
+        overlay.stage_chunks(store, writes, &chunks).await?;
         Ok(TrackedStateApplyResult {
             root_id,
             row_count,
@@ -934,7 +934,7 @@ impl TrackedStateTree {
 
         let built = assembler.finish(self)?;
         let result = self
-            .persist_built_tree(writes, overlay, built, commit_id)
+            .persist_built_tree(store, writes, overlay, built, commit_id)
             .await?;
         Ok((result, cascaded_rows))
     }
@@ -1241,12 +1241,13 @@ impl TrackedStateTree {
 
     async fn persist_built_tree(
         &self,
+        store: &(impl StorageAdapterRead + ?Sized),
         writes: &mut StorageWriteSet,
         overlay: &mut storage::TrackedStateChunkOverlay,
         built: BuiltTree,
         _commit_id: Option<&str>,
     ) -> Result<TrackedStateApplyResult, LixError> {
-        overlay.stage_chunks(writes, &built.chunks);
+        overlay.stage_chunks(store, writes, &built.chunks).await?;
         Ok(TrackedStateApplyResult {
             root_id: built.root_id,
             row_count: built.row_count,


### PR DESCRIPTION
Experiment Q: attribute the 29 KB/commit `tracked_state.tree_chunk` growth, then cut what the attribution indicts.

Machine: `hetzner-cpx62-IV` (16 cores, 30 GB). Measurement base commit: `2091dc36a`. Code rebased onto `7e539a0ce`.

## TL;DR

The 29 KB/commit headline is **not** redundancy — in a fresh 60x2000 insert history every one of those bytes is new unique content, and this PR does not shrink it. What the attribution *did* find is that **73.3% of all bytes written to the tree-chunk space are byte-identical to chunks already durable**, and that share grows with history length. That is write amplification, not footprint. This PR removes it.

**This is an acceptance-criterion-2 landing (asymptotic cut, shown not slower), not a criterion-1 speed win.** Settled bytes are unchanged (0.02%) and OLTP latency is flat within noise. If the orchestrator's bar is a >10% metric move, this should be rejected — the numbers below are the honest case either way.

## Phase 1 — attribution

Instrumented chunk staging (tree writer) and the RocksDB mutable put path with an env-gated
per-chunk trace, and drove ordinary SQL commits through the real `SessionContext` commit path.
Instrumentation commit for reproduction: `f51ef0ec7` on branch `exp/tree-chunk-footprint`
(deliberately **not** in this PR — it is measurement scaffolding, and the RocksDB hook sits in a
per-put loop).

### Finding 0 — tree chunks are not written per commit

Staging is **bursty**. In a 200-commit history, chunks are staged only at commits 31, 64, 97, 130,
163, 196 — a root-materialization boundary every ~33 commits. "29 KB/commit" is a burst amortized
over the interval. A 2000-row update batch against a 20k-row parent (T4) staged **zero** chunks
across 20 commits.

Each burst issues one staging call per commit since genesis (34, 67, 100, 133, 166, 199 calls) —
the replay restarts from the beginning rather than from the previous materialized root.

### Finding 1 — nodes, depths, sizes per burst

`T3` = 50 single-row update commits against a 2000-row tree; `T2` = 60x2000-row insert commits.

| workload | burst | leaf nodes / bytes | h1 nodes / bytes | h2 nodes / bytes | total |
|---|---|---|---|---|---|
| T3 (1-row updates) | commit 30 | 66 / 115,816 B | 33 / 39,353 B | 32 / 5,056 B | 131 / 160,225 B |
| T2 (2000-row inserts) | commit 31 | 762 / 1,588,282 B | 53 / 77,654 B | 32 / 19,210 B | 847 / 1,685,146 B |

32 distinct roots per burst — one materialized root per replayed commit. The rewrite is **not**
larger than the root-to-leaf path the edit touches; it is one path per replayed commit, and the
replay set is what is oversized.

### Finding 2 — re-staged durable-identical chunks (the indictment)

`T1` = 200 commits x 10 rows, six bursts. `durable_same` is measured in the RocksDB adapter by
comparing each staged value against the value already in the column family.

| burst at commit | puts | bytes | durable-identical puts | durable-identical bytes | share |
|---|---|---|---|---|---|
| 31 | 44 | 110,964 | 0 | 0 | 0.0% |
| 64 | 111 | 201,813 | 44 | 110,964 | 55.0% |
| 97 | 181 | 282,271 | 111 | 201,813 | 71.5% |
| 130 | 249 | 390,079 | 181 | 282,271 | 72.4% |
| 163 | 349 | 446,069 | 249 | 390,079 | 87.4% |
| 196 | 453 | 521,837 | 349 | 446,069 | 85.5% |
| **total** | **1,388** | **1,953,821** | **934** | **1,431,196** | **73.3%** |

Burst *k* re-writes burst *k-1*'s entire output verbatim, plus the interval's new nodes. Total write
bytes over *n* commits is therefore **O(n^2 / period)** where the content is O(n).

Neither adapter elides this. RocksDB's already-present skip (`rocksdb.rs:481-503`) is gated on
`ValueSemantics::Immutable`; `tracked_state.tree_chunk` is `mutable`. SlateDB's mutable path
(`slatedb.rs:3544-3572`) writes straight into its overlay with no comparison at all. Experiment F's
lead is confirmed, and it is worse on SlateDB than the hint suggested.

### Finding 3 — structural vs payload bytes (no win available here)

| workload | encoded leaf bytes | raw key+value bytes | ratio |
|---|---|---|---|
| T2 | 1,589,070 | 5,233,680 | **0.30x** |
| T3 | 116,604 | 371,695 | **0.31x** |
| T1 | 1,741,288 | 4,971,179 | **0.35x** |

Leaf encoding (front-coding + commit-id/state-tail dictionaries) is **3.0-3.3x denser than raw**
key+value. Structural overhead is negative — there is nothing to reclaim.

Internal nodes carry the 32-byte child pointers, but they are a small minority of bytes:

| workload | internal bytes | share of total | children | child-hash bytes | share of internal |
|---|---|---|---|---|---|
| T2 | 96,864 | 5.7% | 2,005 | 64,160 | 66.2% |
| T1 | 217,261 | 11.1% | 3,386 | 108,352 | 49.9% |

A denser child table could at best address ~66% of ~6-11% of the bytes. **Structural-share encoding
was evaluated and rejected on this evidence.** Node-geometry changes were likewise not pursued: the
path rewrite is already minimal per replayed commit.

### Finding 4 — dead-chunk share between GC sweeps

Superseded path nodes are **never reclaimed in these workloads**. A checkpoint plus one repository
GC pass:

| workload | tree_chunk before GC | after checkpoint+GC | swept commits |
|---|---|---|---|
| 50 single-row update commits | 131 rows / 164,925 B | 168 rows / 218,557 B | 0 |
| 200x10 insert commits | 454 rows / 538,497 B | 480 rows / 593,613 B | 0 |

GC swept zero commits and the space **grew** (+32% and +10%) because `create_checkpoint()` is itself
a commit that materializes more roots. Dead-chunk share at steady state is therefore effectively
100% of everything superseded — nothing was collected. **This is a separate defect from the one this
PR fixes and is not addressed here**; it lives in the GC reachability/retention path.

## Phase 2 — what changed

`TrackedStateChunkOverlay` now proves durability before staging. Because the space is
content-addressed (chunk key = blake3 of node bytes), a present key is the same bytes by
construction, so one **presence-only** (`CoreProjection::KeyOnly`) batched point read per staging
call is sufficient — no value bytes are read. Proven digests are memoized for the writer's lifetime.
Chunks are still inserted into the overlay whether staged or skipped, so an in-flight rewrite still
resolves a skipped node.

Explicit commit-root rebuild is the **repair** path for a damaged chunk: a present key proves the
digest is addressed, not that the stored bytes still hash to it. Rebuild overlays are constructed via
`TrackedStateChunkOverlay::repairing()` and never skip. This was caught by
`explicit_rebuild_repairs_corrupt_head_root_chunk`, which failed on the first version of this patch.

Removed: nothing (no space, writer, or code path deleted). Net diff is 126 lines across 3 files.

## A/B

### Write volume (the target metric) — 200 commits x 10 rows, RocksDB

| arm | tree-chunk puts | tree-chunk write bytes |
|---|---|---|
| base | 1,388 | 1,953,821 |
| cand | 454 | 522,137 |
| **delta** | **-67.3%** | **-73.3%** |

The redundant share grows with history, so this removes an asymptotic term, not a constant.

### Settled bytes — `space_growth`, 3 interleaved reps (negative result)

| workload | base bytes | cand bytes | delta |
|---|---|---|---|
| 200 x 10 | 629,354 / 628,826 / 628,298 | 629,218 / 627,714 / 628,642 | -0.02% |
| 60 x 2000 | 1,717,103 / 1,717,399 / 1,716,527 | 1,716,951 / 1,716,455 / 1,716,775 | -0.01% |

**Unchanged, as expected.** The redundant puts were same-key overwrites, so they never occupied
settled bytes. The 29,089 B/commit figure is untouched — in that workload it is genuinely new
content. Anyone hoping this PR shrinks the tree's footprint should read this row and stop.

### OLTP — `tracked_state_crud`, sql_session, 1k, 9 interleaved reps

| id | base med (ms) | cand med (ms) | delta | p95 delta |
|---|---|---|---|---|
| rocksdb/insert_all_rows | 8.5762 | 8.3729 | -2.4% | +12.1% |
| rocksdb/update_all_rows | 2.9732 | 2.9316 | -1.4% | -16.4% |
| rocksdb/update_one_by_pk | 0.9741 | 0.8990 | -7.7% | -23.0% |
| rocksdb/read_all_rows_consumed | 2.3205 | 2.2644 | -2.4% | +14.2% |
| slatedb/insert_all_rows | 9.8447 | 9.3058 | -5.5% | -15.4% |
| slatedb/update_all_rows | 3.5220 | 3.6374 | **+3.3%** | +4.8% |
| slatedb/update_one_by_pk | 1.4439 | 1.5318 | **+6.1%** | -3.8% |
| slatedb/read_all_rows_consumed | 2.5547 | 2.5321 | -0.9% | -8.3% |

Raw per-rep numbers (ms):

```
rocksdb/insert_all_rows      base [9.5312, 8.4143, 8.5762, 8.482, 8.2483, 8.658, 9.2399, 8.3834, 8.6154]
                             cand [8.8357, 8.7156, 8.2201, 10.68, 8.3499, 8.4924, 8.3729, 8.3557, 8.2354]
rocksdb/update_all_rows      base [2.7067, 2.8272, 2.9732, 2.9742, 3.8072, 3.0404, 3.62, 2.6758, 2.9375]
                             cand [2.9964, 2.921, 2.9316, 2.7972, 2.8199, 3.184, 3.0801, 2.9779, 2.9088]
rocksdb/update_one_by_pk     base [0.9741, 0.9808, 0.9311, 1.0125, 0.9223, 0.954, 0.9998, 1.3827, 0.9193]
                             cand [0.8309, 1.0649, 0.8929, 0.905, 0.85, 0.8622, 0.899, 0.9842, 0.9576]
rocksdb/read_all_consumed    base [2.3205, 2.1936, 2.3392, 2.3515, 2.2798, 2.4535, 2.312, 2.1719, 2.5278]
                             cand [2.2778, 2.3413, 2.1802, 2.456, 2.2017, 2.8857, 2.2254, 2.2005, 2.2644]
slatedb/insert_all_rows      base [9.7224, 9.0352, 10.116, 10.0, 10.572, 8.9254, 9.8447, 9.4335, 11.465]
                             cand [9.4267, 9.6943, 9.101, 9.5941, 8.7957, 9.4621, 9.3058, 9.0921, 8.9962]
slatedb/update_all_rows      base [3.9228, 3.522, 3.4834, 3.154, 3.5621, 3.4855, 3.5257, 3.3947, 3.5407]
                             cand [3.7423, 3.486, 4.0628, 3.7095, 3.4464, 3.4164, 3.286, 3.6374, 4.1105]
slatedb/update_one_by_pk     base [1.579, 1.4439, 1.385, 1.4079, 1.3654, 1.679, 1.4167, 1.4881, 1.5274]
                             cand [1.2613, 1.5856, 1.3514, 1.5318, 1.4946, 1.604, 1.2078, 1.5882, 1.6159]
slatedb/read_all_consumed    base [2.736, 2.6766, 2.428, 2.4534, 2.3838, 2.5547, 2.5156, 2.7554, 3.0064]
                             cand [2.4636, 2.667, 2.6757, 2.5151, 2.5028, 2.7556, 2.4575, 2.5482, 2.5321]
```

Every arm's raw range overlaps its counterpart's completely. **Both regressions (slatedb
update_all +3.3%, update_one_by_pk +6.1%) are inside the spread and inside the runbook's stated
noise band for these ids**; slatedb/update_one_by_pk's base range is 1.365-1.679 and cand's is
1.208-1.616. `update_one_by_pk` (the PR #1280 win) is not regressed on RocksDB (-7.7%) and is
noise-bound on SlateDB. Candidate binaries here still carried the env-gated trace hooks, which can
only have disadvantaged the candidate; the shipped diff has them removed.

### Guards — `diff_commands` + `undo_redo`, 9 interleaved reps

| id | base med (ms) | cand med (ms) | delta |
|---|---|---|---|
| diff_commands/apply_100_of_1000 | 9.2938 | 9.4264 | +1.4% |
| diff_commands/partial_checkpoint_500_of_1000 | 21.3450 | 20.5750 | -3.6% |
| diff_commands/revert_100_of_1000 | 9.6795 | 9.5446 | -1.4% |
| diff_commands/working_diff_1000 | 3.7436 | 3.7722 | +0.8% |
| undo_descriptor_unrelated_repository_width/undo_file_delete/10000 | 2.8608 | 2.7019 | -5.6% |
| undo_redo_repeated_identity_depth/ordinary_update/1000 | 2.6421 | 2.5677 | -2.8% |
| undo_redo_repeated_identity_depth/redo/1000 | 2.6013 | 2.5336 | -2.6% |
| undo_redo_repeated_identity_depth/undo/1000 | 2.5807 | 2.4025 | -6.9% |
| undo_sparse_identity_gap/undo/1000 | 2.6059 | 2.4111 | -7.5% |
| undo_transition_width/undo/1000 | 12.4290 | 12.1080 | -2.6% |
| undo_wide_parent_delta/undo/1000 | 2.2657 | 2.2892 | +1.0% |

(20 guard ids measured; all within +-7.5%, medians mostly favourable. Full table in the run log.)

### End-to-end wall clock — `space_growth 300 10`, 9 interleaved reps

base median 1.7768 s, cand median 1.8074 s (**+1.7%**, p95 +4.2%); raw ranges 1.689-1.919 vs
1.699-1.999, fully overlapping. The presence probe's cost roughly offsets the write saving at
RocksDB's memtable level, where a same-key overwrite is cheap. The saving is real on WAL bytes and
compaction input, which this short workload does not exercise.

## Regressions and trade-offs

- **No settled-byte win.** Explicitly measured and reported above as a negative result.
- **No latency win.** Flat within noise on every id at 9 reps; end-to-end +1.7% (noise-bound).
- **One extra batched read per staging call.** Presence-only, and memoized per writer.
- The win is confined to the **physical bytes** axis (write amplification), which the trade-off
  ranking places below OLTP and version control. OLTP and VC are both flat, so nothing is traded.

## Bench commands

```
cargo run -p lix_benchmarks --release --features storage-benches,slatedb --example space_growth -- 200 10
cargo run -p lix_benchmarks --release --features storage-benches,slatedb --example space_growth -- 60 2000
<tracked_state_crud bin> --bench 'sql_session/lix_(rocksdb|slatedb)/smoke/(insert_all_rows|update_all_rows|update_one_by_pk|read_all_rows_consumed)/1k' \
    --warm-up-time 1 --measurement-time 3 --sample-size 10
<diff_commands bin> --bench --warm-up-time 1 --measurement-time 3 --sample-size 10
<undo_redo bin> --bench --warm-up-time 1 --measurement-time 3 --sample-size 10
```

Bench binaries were exec'd directly (built with `--no-run`) per the harness manual, so cargo's
appended `--bench` could not swallow positionals.

## Correctness gate

On `hetzner-cpx62-IV`, on the rebased branch:

- `cargo check --workspace` — clean
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` — clean
- `cargo test -p lix --all-features` — **all passing**, including doctests

Note for the record: at measurement base `2091dc36a`,
`storage_bench::tests::repository_gc_benchmark_plans_unreachable_nodes_without_mutating` failed
(`961 != 965`) on **both** arms — verified pre-existing by running it on an unmodified base
worktree. It is fixed on the current head, and this branch is green there.

## Layout invariants checklist

1. **Single authority.** No. No second writer, materialization, or index is added. `known_durable`
   is a per-writer memo of facts read from the one canonical chunk store; it is discarded with the
   writer and never consulted as truth about content, only about presence at the read snapshot.
2. **Commit canonicality.** Unaffected. Branch refs, commit parent links, and canonical state roots
   are untouched; this changes only whether a chunk whose digest is already addressed is written
   again. The root a commit records is byte-identical either way.
3. **Derived views are caches.** Unaffected. No derived or serving view is added or changed.
4. **Atomic publication.** Preserved. The skip removes puts from the *same* write set that publishes
   the state root, commit record and ref move; it does not split or reorder publication. A skipped
   chunk was durable before the write set opened, so no reader can observe a half-written tree.
5. **GC from refs.** Preserved, and this is the sharpest question. Reachability still starts at refs
   and walks commits -> state nodes -> blobs; no retention metadata is added. The skip is safe
   because a skipped chunk is reachable from the parent root the writer is reading, which is
   reachable from a branch ref, so a concurrent GC computing reachability at its own snapshot cannot
   have collected it; and the write set commits under preconditions, so a racing sweep loses the
   fence rather than silently orphaning a reference. Finding 4 above documents a *separate*
   pre-existing GC defect (zero commits swept) that this PR does not touch and does not depend on.
6. **SQL reads canonical records.** Unaffected. Read paths are unchanged and still resolve chunks
   from the canonical content-addressed store (through the overlay while a write set is in flight).

## Not pursued, and why

- **Node geometry (fanout / node size).** Attribution shows the per-commit rewrite is already the
  minimal path per replayed commit; the cost is the size of the replay set, not the path. Bigger
  nodes would enlarge each rewrite without shortening the replay.
- **Structural-share encoding.** Leaf encoding is already 3.0-3.3x denser than raw payload and
  internal nodes are 6-11% of bytes. Nothing material to reclaim.
- **The replay-from-genesis policy itself.** This is the real O(n^2) generator and the larger prize:
  each burst re-derives every root since genesis, paying read, decode, re-encode and re-hash on top
  of the write cost this PR removes. It lives in `transaction/` and `commit_root_rebuild.rs`, in the
  path of the `merge/codex-1-2` merge, and warrants its own experiment.
- **The GC defect in Finding 4.** Separate subsystem, separate change.
