### PR TITLE
perf(gc): make garbage collection self-contained

### DIFF
--- a/.changenotes/reclaim-deleted-branch-storage.md
+++ b/.changenotes/reclaim-deleted-branch-storage.md
@@ -1,0 +1,7 @@
+---
+type: patch
+---
+
+Garbage collection now reclaims the storage a deleted or superseded branch leaves behind.
+
+Every branch serves its current state from a generation of derived rows. When a branch was deleted, or when a lifecycle publication replaced its generation, those rows were never reclaimed and stayed on disk forever. Repository GC now retires them as part of its ordinary pass, so deleting a branch and collecting frees the space it actually used — measured at roughly 85% less residual storage after deleting a branch in a 10,000-row workspace.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3438,6 +3438,7 @@ dependencies = [
  "codspeed-criterion-compat",
  "datafusion",
  "duckdb",
+ "fastcdc",
  "futures-util",
  "libc",
  "lix",

--- a/packages/lix/src/changelog/gc.rs
+++ b/packages/lix/src/changelog/gc.rs
@@ -1,0 +1,133 @@
+//! Changelog-owned retirement of canonical records.
+//!
+//! Garbage collection proves unreachability from refs; it does not know which
+//! physical rows a commit projection or a standalone change occupies. These
+//! entry points keep that knowledge inside the module that writes those rows,
+//! so `changelog` remains the sole writer of its own storage spaces.
+
+use bytes::Bytes;
+
+use super::context::ChangelogContext;
+use super::store::{
+    CHANGE_SPACE, COMMIT_CHANGE_ID_SPACE, COMMIT_SPACE, ChangelogReader, change_key,
+    commit_change_id_key, commit_key,
+};
+use super::types::{ChangeId, CommitId, CommitLoadRequest};
+use crate::LixError;
+use crate::storage_adapter::{
+    PointReadPlan, StorageAdapterRead, StorageGetOptions, StorageKey, StorageWriteSet,
+};
+
+/// Removes the semantic commit projection once its root interval is no longer
+/// reachable. Physical tracked-state authority may remain alive as a selected
+/// source or serving dependency, so this decision is intentionally separate
+/// from manifest/CAS retirement.
+pub(crate) async fn stage_delete_commit_projection<S>(
+    store: &S,
+    writes: &mut StorageWriteSet,
+    commit_id: CommitId,
+) -> Result<(), LixError>
+where
+    S: StorageAdapterRead + ?Sized,
+{
+    let commit_ids = [commit_id];
+    let record = ChangelogContext::new()
+        .reader(store)
+        .load_commits(CommitLoadRequest {
+            commit_ids: &commit_ids,
+        })
+        .await?
+        .into_iter()
+        .next()
+        .and_then(|(_, record)| record);
+    let Some(record) = record else {
+        // A prior GC pass may already have removed the semantic projection
+        // while its physical authority remained pinned.
+        return Ok(());
+    };
+    if record.commit_id != commit_id {
+        return Err(LixError::new(
+            LixError::CODE_INTERNAL_ERROR,
+            format!(
+                "commit projection key for '{commit_id}' contains '{}'",
+                record.commit_id
+            ),
+        ));
+    }
+    writes.delete(COMMIT_SPACE, StorageKey(Bytes::from(commit_key(commit_id))));
+    writes.delete(
+        COMMIT_CHANGE_ID_SPACE,
+        StorageKey(Bytes::from(commit_change_id_key(record.change_id))),
+    );
+    writes.delete(
+        CHANGE_SPACE,
+        StorageKey(Bytes::from(change_key(record.change_id))),
+    );
+    Ok(())
+}
+
+/// Removes one standalone change record whose last owning branch control has
+/// been retired.
+///
+/// The record must still exist: a retired control naming an absent standalone
+/// fact means the ledger and the control plane already disagree, and deleting
+/// nothing would hide that.
+pub(crate) async fn stage_delete_standalone_change<S>(
+    store: &S,
+    writes: &mut StorageWriteSet,
+    change_id: ChangeId,
+) -> Result<(), LixError>
+where
+    S: StorageAdapterRead + ?Sized,
+{
+    let key = StorageKey(Bytes::from(change_key(change_id)));
+    let existing = PointReadPlan::new(CHANGE_SPACE, std::slice::from_ref(&key))
+        .materialize(store, StorageGetOptions::default())
+        .await?
+        .value
+        .into_iter()
+        .next()
+        .flatten();
+    if existing.is_none() {
+        return Err(LixError::new(
+            LixError::CODE_INTERNAL_ERROR,
+            format!("retired branch control references missing standalone change '{change_id}'"),
+        ));
+    }
+    writes.delete(CHANGE_SPACE, key);
+    Ok(())
+}
+
+/// Removes canonical commit projections in bulk.
+///
+/// Only the whole-repository oracle collector reaches this: ordinary GC
+/// retires one proven-unreachable projection at a time through
+/// [`stage_delete_commit_projection`].
+#[cfg(test)]
+pub(crate) fn stage_delete_commits(
+    writes: &mut StorageWriteSet,
+    commit_ids: impl IntoIterator<Item = CommitId>,
+) {
+    writes.delete_batch(COMMIT_SPACE, commit_ids.into_iter().map(commit_key));
+}
+
+/// Removes commit-derived reverse-index rows in bulk.
+#[cfg(test)]
+pub(crate) fn stage_delete_commit_change_ids(
+    writes: &mut StorageWriteSet,
+    change_ids: impl IntoIterator<Item = ChangeId>,
+) {
+    writes.delete_batch(
+        COMMIT_CHANGE_ID_SPACE,
+        change_ids.into_iter().map(commit_change_id_key),
+    );
+}
+
+/// Removes change records in bulk.
+#[cfg(test)]
+pub(crate) fn stage_delete_changes(
+    writes: &mut StorageWriteSet,
+    change_ids: impl IntoIterator<Item = ChangeId>,
+) {
+    writes.delete_batch(CHANGE_SPACE, change_ids.into_iter().map(change_key));
+}

--- a/packages/lix/src/changelog/mod.rs
+++ b/packages/lix/src/changelog/mod.rs
@@ -6,6 +6,7 @@ pub mod bench {
 }
 mod codec;
 mod context;
+mod gc;
 mod materialization;
 mod store;
 #[cfg(test)]
@@ -17,15 +18,15 @@ pub(crate) use codec::decode_change_record;
 pub(crate) use codec::encode_commit_record;
 pub(crate) use context::ChangelogContext;
 #[cfg(test)]
+pub(crate) use gc::{stage_delete_changes, stage_delete_commit_change_ids, stage_delete_commits};
+pub(crate) use gc::{stage_delete_commit_projection, stage_delete_standalone_change};
+#[cfg(test)]
 pub(crate) use materialization::MaterializedChangeIdentity;
 pub(crate) use materialization::{
     ChangeRecordProjection, MaterializedChangePayload, load_change_records,
     materialize_known_change_payloads, materialize_known_change_payloads_in_order,
 };
-pub(crate) use store::{
-    CHANGE_SPACE, COMMIT_CHANGE_ID_SPACE, COMMIT_SPACE, change_key, commit_change_id_key,
-    commit_key,
-};
+pub(crate) use store::{CHANGE_SPACE, COMMIT_CHANGE_ID_SPACE, COMMIT_SPACE, commit_key};
 pub(crate) use store::{ChangelogReader, ChangelogWriter};
 pub(crate) use types::{
     ChangeId, ChangeLoadBatch, ChangeLoadRequest, ChangeRecord, ChangeScanBatch, ChangeScanRequest,

--- a/packages/lix/src/gc.rs
+++ b/packages/lix/src/gc.rs
@@ -6,7 +6,6 @@
 //! the same storage write set that publishes the compacted checkpoint.
 
 use std::collections::{BTreeMap, BTreeSet};
-use std::ops::Bound;
 use std::time::Instant;
 
 use bytes::Bytes;
@@ -15,15 +14,11 @@ use crate::branch::{
     BranchHeadControl, BranchHeadControlContext, BranchHeadTrackedReachability,
     branch_head_control_precondition,
 };
-#[cfg(any(test, feature = "storage-benches"))]
-use crate::changelog::ChangeScanRequest;
-use crate::changelog::{
-    CHANGE_SPACE, COMMIT_CHANGE_ID_SPACE, COMMIT_SPACE, ChangeId, ChangelogContext,
-    ChangelogReader, CommitId, CommitLoadRequest, GcLiveSet, GcPlan, GcRepairSet, GcRoot,
-    GcSweepSet, change_key, commit_change_id_key, commit_key,
-};
+use crate::changelog::{ChangeId, CommitId, GcLiveSet, GcPlan, GcRepairSet, GcRoot, GcSweepSet};
 #[cfg(test)]
 use crate::changelog::{ChangeRecord, CommitScanRequest};
+#[cfg(any(test, feature = "storage-benches"))]
+use crate::changelog::{ChangeScanRequest, ChangelogContext, ChangelogReader};
 use crate::commit_graph::CommitGraphContext;
 #[cfg(test)]
 use crate::json_store::JsonRef;
@@ -34,11 +29,14 @@ use crate::json_store::{
 use crate::live_state::TrackedHeadContext;
 #[cfg(test)]
 use crate::live_state::stage_collect_stale_working_diff_indexes;
+#[cfg(test)]
+use crate::storage_adapter::StorageCoreProjection;
 use crate::storage_adapter::{
-    PointReadPlan, StorageAdapterRead, StorageBeginScanOptions, StorageCoreProjection,
-    StorageGetOptions, StorageKey, StorageKeyRange, StoragePrecondition, StoragePrefix,
-    StorageProjectedValue, StorageSpace, StorageSpaceId, StorageValue, StorageWriteSet,
+    PointReadPlan, StorageAdapterRead, StorageBeginScanOptions, StorageGetOptions, StorageKey,
+    StoragePrecondition, StoragePrefix, StorageProjectedValue, StorageSpace, StorageSpaceId,
+    StorageValue, StorageWriteSet,
 };
+use crate::tracked_state::RetainedPhysicalState;
 use crate::{LixError, storage_codec};
 
 pub(crate) const CHECKPOINT_RECOVERY_REF_NAMESPACE: &str = "checkpoint.recovery_ref.v3";
@@ -58,36 +56,12 @@ pub(crate) const GC_REACHABILITY_DELTA_SPACE: StorageSpace =
 pub(crate) const GC_REACHABILITY_QUEUE_NAMESPACE: &str = "gc.reachability_queue.v1";
 pub(crate) const GC_REACHABILITY_QUEUE_SPACE: StorageSpace =
     StorageSpace::mutable(StorageSpaceId(0x0008_0004), GC_REACHABILITY_QUEUE_NAMESPACE);
-/// Rebuildable metadata for an explicit tree-chunk sweep epoch. It is never
-/// consulted as a serving root; the active root closure is re-derived from
-/// branch/recovery controls and authenticated commit manifests.
-pub(crate) const GC_TREE_SWEEP_EPOCH_NAMESPACE: &str = "gc.tree_sweep_epoch.v1";
-pub(crate) const GC_TREE_SWEEP_EPOCH_SPACE: StorageSpace =
-    StorageSpace::mutable(StorageSpaceId(0x0008_0005), GC_TREE_SWEEP_EPOCH_NAMESPACE);
-/// One rebuildable live-chunk mark per content hash for the current epoch.
-pub(crate) const GC_TREE_SWEEP_MARK_NAMESPACE: &str = "gc.tree_sweep_mark.v1";
-pub(crate) const GC_TREE_SWEEP_MARK_SPACE: StorageSpace =
-    StorageSpace::mutable(StorageSpaceId(0x0008_0006), GC_TREE_SWEEP_MARK_NAMESPACE);
-/// CAS-protected bounded cursor for an in-progress tree-chunk enumeration.
-pub(crate) const GC_TREE_SWEEP_CURSOR_NAMESPACE: &str = "gc.tree_sweep_cursor.v1";
-pub(crate) const GC_TREE_SWEEP_CURSOR_SPACE: StorageSpace =
-    StorageSpace::mutable(StorageSpaceId(0x0008_0007), GC_TREE_SWEEP_CURSOR_NAMESPACE);
-
 const CHECKPOINT_RECOVERY_REF_FORMAT_VERSION: u32 = 3;
 const CHECKPOINT_GC_STATE_FORMAT_VERSION: u32 = 1;
 const CHECKPOINT_GC_STATE_KEY: &[u8] = b"repository";
 const GC_REACHABILITY_FORMAT_VERSION: u32 = 2;
 const GC_REACHABILITY_QUEUE_KEY: &[u8] = b"queue";
 const GC_REACHABILITY_BATCH_LIMIT: usize = 64;
-#[allow(dead_code)]
-const GC_TREE_SWEEP_EPOCH_KEY: &[u8] = b"epoch";
-#[allow(dead_code)]
-const GC_TREE_SWEEP_CURSOR_KEY: &[u8] = b"cursor";
-#[allow(dead_code)]
-const GC_TREE_SWEEP_FORMAT_VERSION: u32 = 1;
-#[allow(dead_code)]
-const GC_TREE_SWEEP_PAGE_ROWS: usize = 64;
-
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct AuthenticatedControlCommitReachability {
     chronology_roots: BTreeSet<CommitId>,
@@ -279,61 +253,6 @@ struct StoredReachabilityQueue {
     head_sequence: u64,
     tail_sequence: u64,
     next_sequence: u64,
-}
-
-/// Authenticated metadata for one explicit tree-chunk sweep epoch. The root
-/// and closure digests are evidence for resumption only; immutable manifests
-/// and branch/recovery controls remain the sole logical root authority.
-#[derive(Clone, Debug, Eq, PartialEq, musli::Encode, musli::Decode)]
-#[musli(packed)]
-#[allow(dead_code)]
-struct StoredTreeSweepEpoch {
-    format_version: u32,
-    epoch_id: u64,
-    queue_digest: [u8; 32],
-    root_set_digest: [u8; 32],
-    live_chunk_digest: [u8; 32],
-    live_chunk_count: u64,
-}
-
-/// CAS-protected bounded enumeration cursor. A completed cursor is retained
-/// until the next epoch so an interrupted/reopened maintenance pass can
-/// distinguish a resumable epoch from a fresh one.
-#[derive(Clone, Debug, Eq, PartialEq, musli::Encode, musli::Decode)]
-#[musli(packed)]
-#[allow(dead_code)]
-struct StoredTreeSweepCursor {
-    format_version: u32,
-    epoch_id: u64,
-    #[musli(with = storage_codec::option)]
-    last_key: Option<Vec<u8>>,
-    scanned_rows: u64,
-    deleted_rows: u64,
-    complete: bool,
-}
-
-/// A mark is rebuildable inventory, not payload truth. The hash in the key,
-/// value, and epoch are all checked before a sweep can delete an unmarked
-/// tree chunk.
-#[derive(Clone, Debug, Eq, PartialEq, musli::Encode, musli::Decode)]
-#[musli(packed)]
-#[allow(dead_code)]
-struct StoredTreeSweepMark {
-    format_version: u32,
-    epoch_id: u64,
-    chunk_hash: [u8; 32],
-}
-
-/// In-memory state for one authenticated sweep epoch. The live set is loaded
-/// and verified once when the session starts or reopens; ordinary queue-prefix
-/// GC never consults it.
-#[derive(Clone, Debug)]
-#[allow(dead_code)]
-pub(crate) struct TreeSweepEpochSession {
-    epoch: StoredTreeSweepEpoch,
-    cursor: StoredTreeSweepCursor,
-    raw_cursor: Bytes,
-    live_chunks: BTreeSet<[u8; 32]>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -770,20 +689,6 @@ fn decode_reachability_batch(
     Ok(batch)
 }
 
-#[allow(dead_code)]
-fn tree_sweep_error(message: impl Into<String>) -> LixError {
-    LixError::new(LixError::CODE_INTERNAL_ERROR, message)
-}
-
-#[allow(dead_code)]
-fn tree_sweep_digest(hashes: &BTreeSet<[u8; 32]>) -> [u8; 32] {
-    let mut hasher = blake3::Hasher::new();
-    for hash in hashes {
-        hasher.update(hash);
-    }
-    *hasher.finalize().as_bytes()
-}
-
 async fn collect_all_reachability_checkpoint_roots<S>(
     store: &S,
     queue: &StoredReachabilityQueue,
@@ -902,562 +807,6 @@ where
     .with_hint(
         "The commit is no longer an authenticated branchable root after checkpoint compaction.",
     ))
-}
-
-#[allow(dead_code)]
-async fn load_tree_sweep_root_closure<S>(
-    store: &S,
-) -> Result<([u8; 32], [u8; 32], Bytes, BTreeSet<[u8; 32]>), LixError>
-where
-    S: StorageAdapterRead + Clone + Send + Sync,
-{
-    let controls = BranchHeadControlContext::new()
-        .reader(store.clone())
-        .scan()
-        .await?;
-    let (queue, raw_queue) = load_reachability_queue(store).await?;
-    let closure = load_authenticated_repository_retention(store, &controls, &queue).await?;
-    let mut roots = BTreeSet::new();
-    for manifest in closure.manifests.values() {
-        if let Some(snapshot_root) = manifest.snapshot_root.as_ref() {
-            roots.insert(*snapshot_root.root_id.as_bytes());
-            for parent in &snapshot_root.parent_roots {
-                roots.insert(*parent.root_id.as_bytes());
-            }
-        }
-    }
-    if roots.is_empty() {
-        return Err(tree_sweep_error(
-            "tree sweep authenticated root set has no tracked tree roots",
-        ));
-    }
-    let root_set_digest = tree_sweep_digest(&roots);
-    let typed_roots = roots
-        .iter()
-        .copied()
-        .map(crate::tracked_state::TrackedStateRootId::new)
-        .collect::<Vec<_>>();
-    let live_chunks =
-        crate::tracked_state::collect_reachable_tree_chunk_hashes(store, &typed_roots).await?;
-    if live_chunks.is_empty() {
-        return Err(tree_sweep_error(
-            "tree sweep authenticated root closure is empty",
-        ));
-    }
-    Ok((
-        root_set_digest,
-        tree_sweep_digest(&live_chunks),
-        raw_queue,
-        live_chunks,
-    ))
-}
-
-#[allow(dead_code)]
-async fn scan_tree_sweep_marks<S>(
-    store: &S,
-    expected_epoch: Option<u64>,
-) -> Result<(BTreeSet<[u8; 32]>, BTreeSet<[u8; 32]>), LixError>
-where
-    S: StorageAdapterRead + ?Sized,
-{
-    let range = StoragePrefix {
-        bytes: Bytes::new(),
-    }
-    .to_range()?;
-    let mut previous_key = None;
-    let mut current = BTreeSet::new();
-    let mut all = BTreeSet::new();
-    let mut cursor = store
-        .begin_scan(
-            GC_TREE_SWEEP_MARK_SPACE,
-            range,
-            StorageBeginScanOptions {
-                projection: StorageCoreProjection::FullValue,
-                ..StorageBeginScanOptions::default()
-            },
-        )
-        .await?;
-    loop {
-        let page = cursor.next_page(GC_TREE_SWEEP_PAGE_ROWS).await?;
-        if page.has_more && page.entries.is_empty() {
-            return Err(tree_sweep_error(
-                "tree sweep mark scan reported has_more with an empty page",
-            ));
-        }
-        for entry in &page.entries {
-            if entry.key.0.len() != 32
-                || previous_key
-                    .as_ref()
-                    .is_some_and(|previous: &StorageKey| entry.key <= *previous)
-            {
-                return Err(tree_sweep_error(
-                    "tree sweep mark scan keys are malformed or non-increasing",
-                ));
-            }
-            let key_hash: [u8; 32] = entry
-                .key
-                .0
-                .as_ref()
-                .try_into()
-                .map_err(|_| tree_sweep_error("tree sweep mark key is not 32 bytes"))?;
-            let StorageProjectedValue::FullValue(bytes) = &entry.value else {
-                return Err(tree_sweep_error(
-                    "tree sweep mark scan returned a key-only value",
-                ));
-            };
-            let mark: StoredTreeSweepMark = storage_codec::decode("tree sweep mark", bytes)
-                .map_err(|error| {
-                    tree_sweep_error(format!("tree sweep mark is malformed: {error}"))
-                })?;
-            if mark.format_version != GC_TREE_SWEEP_FORMAT_VERSION || mark.chunk_hash != key_hash {
-                return Err(tree_sweep_error(
-                    "tree sweep mark identity or format is invalid",
-                ));
-            }
-            all.insert(key_hash);
-            if expected_epoch.is_none_or(|epoch| mark.epoch_id == epoch) {
-                current.insert(key_hash);
-            }
-            previous_key = Some(entry.key.clone());
-        }
-        if page.entries.is_empty() {
-            if page.has_more {
-                return Err(tree_sweep_error(
-                    "tree sweep mark scan has_more without a resume key",
-                ));
-            }
-            break;
-        }
-        if !page.has_more {
-            break;
-        }
-    }
-    Ok((current, all))
-}
-
-#[allow(dead_code)]
-async fn load_optional_tree_sweep_row<S, T>(
-    store: &S,
-    space: StorageSpace,
-    key: &'static [u8],
-    label: &'static str,
-) -> Result<Option<(T, Bytes)>, LixError>
-where
-    S: StorageAdapterRead + ?Sized,
-    T: for<'de> musli::Decode<'de, musli::mode::Binary, musli::alloc::Global>,
-{
-    let key = StorageKey(Bytes::from_static(key));
-    let value = PointReadPlan::new(space, std::slice::from_ref(&key))
-        .materialize(store, StorageGetOptions::default())
-        .await?
-        .value
-        .into_iter()
-        .next()
-        .flatten();
-    let Some(StorageProjectedValue::FullValue(bytes)) = value else {
-        return Ok(None);
-    };
-    let decoded = storage_codec::decode(label, &bytes)?;
-    Ok(Some((decoded, bytes)))
-}
-
-/// Starts a new authenticated tree sweep epoch. The expensive root closure
-/// and mark inventory are built once here; ordinary queue-prefix GC never
-/// calls this function.
-#[allow(dead_code)]
-pub(crate) async fn begin_tree_sweep_epoch<S>(
-    store: &S,
-    writes: &mut StorageWriteSet,
-    preconditions: &mut Vec<StoragePrecondition>,
-) -> Result<TreeSweepEpochSession, LixError>
-where
-    S: StorageAdapterRead + Clone + Send + Sync,
-{
-    let old_epoch = load_optional_tree_sweep_row::<S, StoredTreeSweepEpoch>(
-        store,
-        GC_TREE_SWEEP_EPOCH_SPACE,
-        GC_TREE_SWEEP_EPOCH_KEY,
-        "tree sweep epoch",
-    )
-    .await?;
-    let old_cursor = load_optional_tree_sweep_row::<S, StoredTreeSweepCursor>(
-        store,
-        GC_TREE_SWEEP_CURSOR_SPACE,
-        GC_TREE_SWEEP_CURSOR_KEY,
-        "tree sweep cursor",
-    )
-    .await?;
-    if old_epoch.is_some() != old_cursor.is_some() {
-        return Err(tree_sweep_error(
-            "tree sweep epoch and cursor lifecycle rows disagree",
-        ));
-    }
-    if old_cursor
-        .as_ref()
-        .is_some_and(|(cursor, _)| !cursor.complete)
-    {
-        return Err(tree_sweep_error(
-            "tree sweep epoch is already active; reopen it instead of creating a second epoch",
-        ));
-    }
-    let (root_set_digest, live_chunk_digest, raw_queue, live_chunks) =
-        load_tree_sweep_root_closure(store).await?;
-    let epoch_id = old_epoch
-        .as_ref()
-        .map_or(1, |(epoch, _)| epoch.epoch_id.saturating_add(1));
-    let epoch = StoredTreeSweepEpoch {
-        format_version: GC_TREE_SWEEP_FORMAT_VERSION,
-        epoch_id,
-        queue_digest: *blake3::hash(&raw_queue).as_bytes(),
-        root_set_digest,
-        live_chunk_digest,
-        live_chunk_count: live_chunks.len() as u64,
-    };
-    let cursor = StoredTreeSweepCursor {
-        format_version: GC_TREE_SWEEP_FORMAT_VERSION,
-        epoch_id,
-        last_key: None,
-        scanned_rows: 0,
-        deleted_rows: 0,
-        complete: false,
-    };
-    let (current_marks, all_marks) = scan_tree_sweep_marks(store, None).await?;
-    let _ = current_marks;
-    for hash in all_marks.difference(&live_chunks) {
-        writes.delete(
-            GC_TREE_SWEEP_MARK_SPACE,
-            StorageKey(Bytes::copy_from_slice(hash)),
-        );
-    }
-    for hash in &live_chunks {
-        let mark = StoredTreeSweepMark {
-            format_version: GC_TREE_SWEEP_FORMAT_VERSION,
-            epoch_id,
-            chunk_hash: *hash,
-        };
-        writes.put(
-            GC_TREE_SWEEP_MARK_SPACE,
-            StorageKey(Bytes::copy_from_slice(hash)),
-            StorageValue {
-                bytes: Bytes::from(storage_codec::encode("tree sweep mark", &mark)?),
-            },
-        );
-    }
-    let epoch_bytes = Bytes::from(storage_codec::encode("tree sweep epoch", &epoch)?);
-    let cursor_bytes = Bytes::from(storage_codec::encode("tree sweep cursor", &cursor)?);
-    writes.put(
-        GC_TREE_SWEEP_EPOCH_SPACE,
-        StorageKey(Bytes::from_static(GC_TREE_SWEEP_EPOCH_KEY)),
-        StorageValue { bytes: epoch_bytes },
-    );
-    writes.put(
-        GC_TREE_SWEEP_CURSOR_SPACE,
-        StorageKey(Bytes::from_static(GC_TREE_SWEEP_CURSOR_KEY)),
-        StorageValue {
-            bytes: cursor_bytes.clone(),
-        },
-    );
-    preconditions.push(StoragePrecondition::KeyValueEquals {
-        space: GC_REACHABILITY_QUEUE_SPACE,
-        key: StorageKey(Bytes::from_static(GC_REACHABILITY_QUEUE_KEY)),
-        expected: raw_queue,
-    });
-    if let Some((_, raw)) = old_epoch {
-        preconditions.push(StoragePrecondition::KeyValueEquals {
-            space: GC_TREE_SWEEP_EPOCH_SPACE,
-            key: StorageKey(Bytes::from_static(GC_TREE_SWEEP_EPOCH_KEY)),
-            expected: raw,
-        });
-    } else {
-        preconditions.push(StoragePrecondition::KeyAbsent {
-            space: GC_TREE_SWEEP_EPOCH_SPACE,
-            key: StorageKey(Bytes::from_static(GC_TREE_SWEEP_EPOCH_KEY)),
-        });
-    }
-    if let Some((_, raw)) = old_cursor {
-        preconditions.push(StoragePrecondition::KeyValueEquals {
-            space: GC_TREE_SWEEP_CURSOR_SPACE,
-            key: StorageKey(Bytes::from_static(GC_TREE_SWEEP_CURSOR_KEY)),
-            expected: raw,
-        });
-    } else {
-        preconditions.push(StoragePrecondition::KeyAbsent {
-            space: GC_TREE_SWEEP_CURSOR_SPACE,
-            key: StorageKey(Bytes::from_static(GC_TREE_SWEEP_CURSOR_KEY)),
-        });
-    }
-    Ok(TreeSweepEpochSession {
-        epoch,
-        cursor,
-        raw_cursor: cursor_bytes,
-        live_chunks,
-    })
-}
-
-/// Reopens an active or completed epoch. Mark rows are fully authenticated
-/// against the persisted count/digest before any page may stage a delete.
-#[allow(dead_code)]
-pub(crate) async fn open_tree_sweep_epoch<S>(
-    store: &S,
-) -> Result<Option<TreeSweepEpochSession>, LixError>
-where
-    S: StorageAdapterRead + ?Sized,
-{
-    let Some((epoch, _)) = load_optional_tree_sweep_row::<S, StoredTreeSweepEpoch>(
-        store,
-        GC_TREE_SWEEP_EPOCH_SPACE,
-        GC_TREE_SWEEP_EPOCH_KEY,
-        "tree sweep epoch",
-    )
-    .await?
-    else {
-        return Ok(None);
-    };
-    if epoch.format_version != GC_TREE_SWEEP_FORMAT_VERSION {
-        return Err(tree_sweep_error("tree sweep epoch format is unsupported"));
-    }
-    let Some((cursor, raw_cursor)) = load_optional_tree_sweep_row::<S, StoredTreeSweepCursor>(
-        store,
-        GC_TREE_SWEEP_CURSOR_SPACE,
-        GC_TREE_SWEEP_CURSOR_KEY,
-        "tree sweep cursor",
-    )
-    .await?
-    else {
-        return Err(tree_sweep_error("tree sweep cursor is missing"));
-    };
-    if cursor.format_version != GC_TREE_SWEEP_FORMAT_VERSION || cursor.epoch_id != epoch.epoch_id {
-        return Err(tree_sweep_error("tree sweep cursor identity is invalid"));
-    }
-    let (live_chunks, all_marks) = scan_tree_sweep_marks(store, Some(epoch.epoch_id)).await?;
-    if live_chunks != all_marks
-        || live_chunks.len() as u64 != epoch.live_chunk_count
-        || tree_sweep_digest(&live_chunks) != epoch.live_chunk_digest
-    {
-        return Err(tree_sweep_error(
-            "tree sweep mark inventory disagrees with epoch closure or contains stale rows",
-        ));
-    }
-    Ok(Some(TreeSweepEpochSession {
-        epoch,
-        cursor,
-        raw_cursor,
-        live_chunks,
-    }))
-}
-
-/// Enumerates one bounded tree-chunk page and stages only chunks absent from
-/// the authenticated epoch mark set. Every key/value and cursor transition is
-/// validated before staging; the queue and cursor CAS fences make interruption
-/// and root publication races fail closed.
-#[allow(dead_code)]
-pub(crate) async fn stage_tree_sweep_epoch_page<S>(
-    store: &S,
-    session: &mut TreeSweepEpochSession,
-    writes: &mut StorageWriteSet,
-    preconditions: &mut Vec<StoragePrecondition>,
-) -> Result<bool, LixError>
-where
-    S: StorageAdapterRead + ?Sized,
-{
-    if session.cursor.complete {
-        return Ok(true);
-    }
-    let (queue, raw_queue) = load_reachability_queue(store).await?;
-    if *blake3::hash(&raw_queue).as_bytes() != session.epoch.queue_digest {
-        return Err(tree_sweep_error(
-            "tree sweep root publication advanced during an active epoch",
-        ));
-    }
-    let range = StorageKeyRange {
-        lower: session
-            .cursor
-            .last_key
-            .as_ref()
-            .map_or(Bound::Unbounded, |key| {
-                Bound::Excluded(StorageKey(Bytes::copy_from_slice(key)))
-            }),
-        upper: Bound::Unbounded,
-    };
-    let mut cursor = store
-        .begin_scan(
-            crate::tracked_state::TRACKED_STATE_TREE_CHUNK_SPACE,
-            range,
-            StorageBeginScanOptions {
-                projection: StorageCoreProjection::FullValue,
-                ..StorageBeginScanOptions::default()
-            },
-        )
-        .await?;
-    let page = cursor.next_page(GC_TREE_SWEEP_PAGE_ROWS).await?;
-    if page.has_more && page.entries.is_empty() {
-        return Err(tree_sweep_error(
-            "tree sweep tree-chunk scan reported has_more with an empty page",
-        ));
-    }
-    let previous = session.cursor.last_key.as_deref();
-    let mut hashes = Vec::with_capacity(page.entries.len());
-    for entry in &page.entries {
-        if entry.key.0.len() != 32
-            || previous.is_some_and(|previous| entry.key.0.as_ref() <= previous)
-            || hashes
-                .last()
-                .is_some_and(|last: &[u8; 32]| entry.key.0.as_ref() <= last.as_slice())
-        {
-            return Err(tree_sweep_error(
-                "tree sweep tree-chunk keys are malformed or non-increasing",
-            ));
-        }
-        let hash: [u8; 32] = entry
-            .key
-            .0
-            .as_ref()
-            .try_into()
-            .map_err(|_| tree_sweep_error("tree sweep tree-chunk key is not 32 bytes"))?;
-        let StorageProjectedValue::FullValue(bytes) = &entry.value else {
-            return Err(tree_sweep_error(
-                "tree sweep tree-chunk scan returned a key-only value",
-            ));
-        };
-        if *blake3::hash(bytes).as_bytes() != hash {
-            return Err(tree_sweep_error(
-                "tree sweep tree-chunk value hash disagrees with its key",
-            ));
-        }
-        hashes.push(hash);
-    }
-    let mark_keys = hashes
-        .iter()
-        .map(|hash| StorageKey(Bytes::copy_from_slice(hash)))
-        .collect::<Vec<_>>();
-    let marks = if mark_keys.is_empty() {
-        Vec::new()
-    } else {
-        PointReadPlan::new(GC_TREE_SWEEP_MARK_SPACE, &mark_keys)
-            .materialize(store, StorageGetOptions::default())
-            .await?
-            .value
-    };
-    if marks.len() != hashes.len() {
-        return Err(tree_sweep_error(
-            "tree sweep mark point read returned the wrong cardinality",
-        ));
-    }
-    let mut deletes = Vec::new();
-    for (hash, mark) in hashes.iter().zip(marks) {
-        let marked = match mark {
-            None => false,
-            Some(StorageProjectedValue::KeyOnly) => {
-                return Err(tree_sweep_error(
-                    "tree sweep mark point read returned a key-only value",
-                ));
-            }
-            Some(StorageProjectedValue::FullValue(bytes)) => {
-                let mark: StoredTreeSweepMark = storage_codec::decode("tree sweep mark", &bytes)
-                    .map_err(|error| {
-                        tree_sweep_error(format!("tree sweep mark is malformed: {error}"))
-                    })?;
-                if mark.format_version != GC_TREE_SWEEP_FORMAT_VERSION
-                    || mark.epoch_id != session.epoch.epoch_id
-                    || mark.chunk_hash != *hash
-                {
-                    return Err(tree_sweep_error(
-                        "tree sweep mark does not authenticate the current epoch chunk",
-                    ));
-                }
-                true
-            }
-        };
-        if marked != session.live_chunks.contains(hash) {
-            return Err(tree_sweep_error(
-                "tree sweep mark completeness disagrees with authenticated closure",
-            ));
-        }
-        if !marked {
-            deletes.push(*hash);
-        }
-    }
-
-    // A complete keyspace scan must prove that every authenticated live mark
-    // still has its physical chunk before any delete is staged.  This catches
-    // a live chunk deleted between epoch creation and the final page (the
-    // mark inventory alone cannot distinguish that from a clean sweep).
-    if !page.has_more {
-        let live_keys = session
-            .live_chunks
-            .iter()
-            .map(|hash| StorageKey(Bytes::copy_from_slice(hash)))
-            .collect::<Vec<_>>();
-        for chunk_keys in live_keys.chunks(GC_TREE_SWEEP_PAGE_ROWS) {
-            let values = PointReadPlan::new(
-                crate::tracked_state::TRACKED_STATE_TREE_CHUNK_SPACE,
-                chunk_keys,
-            )
-            .materialize(store, StorageGetOptions::default())
-            .await?
-            .value;
-            if values.len() != chunk_keys.len() {
-                return Err(tree_sweep_error(
-                    "tree sweep final live-chunk validation returned the wrong cardinality",
-                ));
-            }
-            for (key, value) in chunk_keys.iter().zip(values) {
-                let Some(StorageProjectedValue::FullValue(bytes)) = value else {
-                    return Err(tree_sweep_error(
-                        "tree sweep final live-chunk validation found a missing or key-only chunk",
-                    ));
-                };
-                if blake3::hash(&bytes).as_bytes().as_slice() != key.0.as_ref() {
-                    return Err(tree_sweep_error(
-                        "tree sweep final live-chunk validation found a corrupt chunk",
-                    ));
-                }
-            }
-        }
-    }
-
-    for hash in &deletes {
-        writes.delete(
-            crate::tracked_state::TRACKED_STATE_TREE_CHUNK_SPACE,
-            StorageKey(Bytes::copy_from_slice(hash)),
-        );
-    }
-    let next_cursor = StoredTreeSweepCursor {
-        format_version: GC_TREE_SWEEP_FORMAT_VERSION,
-        epoch_id: session.epoch.epoch_id,
-        last_key: page.entries.last().map(|entry| entry.key.0.to_vec()),
-        scanned_rows: session
-            .cursor
-            .scanned_rows
-            .saturating_add(hashes.len() as u64),
-        deleted_rows: session
-            .cursor
-            .deleted_rows
-            .saturating_add(deletes.len() as u64),
-        complete: !page.has_more,
-    };
-    let next_raw = Bytes::from(storage_codec::encode("tree sweep cursor", &next_cursor)?);
-    writes.put(
-        GC_TREE_SWEEP_CURSOR_SPACE,
-        StorageKey(Bytes::from_static(GC_TREE_SWEEP_CURSOR_KEY)),
-        StorageValue {
-            bytes: next_raw.clone(),
-        },
-    );
-    preconditions.push(StoragePrecondition::KeyValueEquals {
-        space: GC_REACHABILITY_QUEUE_SPACE,
-        key: StorageKey(Bytes::from_static(GC_REACHABILITY_QUEUE_KEY)),
-        expected: raw_queue,
-    });
-    preconditions.push(StoragePrecondition::KeyValueEquals {
-        space: GC_TREE_SWEEP_CURSOR_SPACE,
-        key: StorageKey(Bytes::from_static(GC_TREE_SWEEP_CURSOR_KEY)),
-        expected: session.raw_cursor.clone(),
-    });
-    session.cursor = next_cursor;
-    session.raw_cursor = next_raw;
-    let _ = queue;
-    Ok(session.cursor.complete)
 }
 
 /// Returns the exact standalone semantic facts and the authenticated reason
@@ -1612,52 +961,6 @@ pub(crate) async fn load_recovery_refs(
     Ok(refs.into_values().collect())
 }
 
-#[cfg(test)]
-async fn stage_sweep_unreachable_content_nodes(
-    store: &(impl StorageAdapterRead + ?Sized),
-    writes: &mut StorageWriteSet,
-    space: StorageSpace,
-    live: &BTreeSet<[u8; 32]>,
-) -> Result<(), LixError> {
-    let range = StoragePrefix {
-        bytes: Bytes::new(),
-    }
-    .to_range()?;
-    let mut cursor = store
-        .begin_scan(
-            space,
-            range,
-            StorageBeginScanOptions {
-                projection: StorageCoreProjection::KeyOnly,
-                ..StorageBeginScanOptions::default()
-            },
-        )
-        .await?;
-    loop {
-        let page = cursor
-            .next_page(crate::storage_adapter::MAX_SCAN_PAGE_ROWS)
-            .await?;
-        for entry in page.entries {
-            let node_id = <[u8; 32]>::try_from(entry.key.0.as_ref()).map_err(|_| {
-                LixError::new(
-                    LixError::CODE_INTERNAL_ERROR,
-                    format!(
-                        "content-addressed space '{}' contains a malformed key",
-                        space.name
-                    ),
-                )
-            })?;
-            if !live.contains(&node_id) {
-                writes.delete(space, entry.key);
-            }
-        }
-        if !page.has_more {
-            break;
-        }
-    }
-    Ok(())
-}
-
 pub(crate) async fn load_recovery_ref(
     store: &(impl StorageAdapterRead + ?Sized),
     branch_id: &str,
@@ -1799,6 +1102,9 @@ fn validate_stored_recovery_ref(
 pub(crate) struct RepositoryGcSweep {
     pub(crate) tracked_commit_roots: Vec<CommitId>,
     pub(crate) standalone_changes: Vec<ChangeId>,
+    /// Derived serving rows reclaimed from branch generations that no live
+    /// branch control selects any more.
+    pub(crate) reclaimed_generation_rows: u64,
     pub(crate) binary_cas: crate::binary_cas::BinaryCasGcSweep,
 }
 
@@ -1991,7 +1297,6 @@ struct AuthenticatedServingDependencyClosure {
     physical_dependencies: BTreeSet<CommitId>,
     semantic_dependencies: BTreeSet<CommitId>,
     cas_logical_dependencies: BTreeSet<CommitId>,
-    manifests: BTreeMap<CommitId, crate::tracked_state::CommitStateManifest>,
     mutation_nodes: BTreeSet<[u8; 32]>,
     scoped_nodes: BTreeSet<[u8; 32]>,
     native_parts: BTreeSet<[u8; 32]>,
@@ -2097,7 +1402,8 @@ where
             }
         }
     }
-    let native_commit_dependencies = validate_live_native_parts(store, &native_parts).await?;
+    let native_commit_dependencies =
+        crate::tracked_state::load_native_current_state_part_owners(store, &native_parts).await?;
     physical_dependencies.extend(native_commit_dependencies.iter().copied());
     semantic_dependencies.extend(native_commit_dependencies);
 
@@ -2200,7 +1506,6 @@ where
         physical_dependencies,
         semantic_dependencies,
         cas_logical_dependencies,
-        manifests,
         mutation_nodes,
         scoped_nodes,
         native_parts,
@@ -2312,7 +1617,6 @@ where
         physical_dependencies: active_dependency_ids,
         semantic_dependencies: active_semantic_dependency_ids,
         cas_logical_dependencies: active_cas_dependency_ids,
-        manifests: _,
         mutation_nodes: active_mutation_nodes,
         scoped_nodes: active_scoped_nodes,
         native_parts: active_current_parts,
@@ -2408,6 +1712,7 @@ where
             sweep: RepositoryGcSweep {
                 tracked_commit_roots: Vec::new(),
                 standalone_changes: Vec::new(),
+                reclaimed_generation_rows: 0,
                 binary_cas,
             },
             profile: RepositoryGcProfile {
@@ -2433,6 +1738,21 @@ where
     let mut reclaimed_semantic_commits = BTreeSet::new();
     let mut reclaimed_standalone_changes = BTreeSet::new();
     let mut reclaimed_checkpoint_branches = BTreeSet::new();
+    // Derived serving generations are reachable from exactly one place: the
+    // live branch controls this pass already read for root discovery. Reusing
+    // that root set is what keeps generation reclamation inside the single
+    // reachability walk instead of needing a second retention ledger.
+    let live_generations = controls
+        .iter()
+        .flat_map(|(branch_id, control)| {
+            [
+                (branch_id.as_str(), control.tracked_generation),
+                (branch_id.as_str(), control.untracked_generation),
+            ]
+        })
+        .collect::<BTreeSet<_>>();
+    let mut retired_generations = BTreeSet::new();
+    let mut reclaimed_generation_rows = 0_u64;
     for (sequence, batch) in batches {
         if queue_open && blocked_sequences.contains(&sequence) {
             queue_open = false;
@@ -2461,6 +1781,41 @@ where
                 )
                 .await?;
             }
+            // A branch generation is a disposable serving cache reachable from
+            // exactly one place: a branch control. Once no live control selects
+            // it, nothing can ever read it again, so retire it.
+            //
+            // This deliberately does not wait for the batch to be consumable.
+            // A blocked batch means a *commit root* is still pinned by history,
+            // undo, or replay — all of which read tracked-state records, never
+            // these derived rows. Coupling the two would strand a whole
+            // generation behind an unrelated pin, exactly like the retired
+            // branch-checkpoint prefix immediately above.
+            if let Some(old_control) = delta.old_control.as_ref() {
+                for generation in [
+                    old_control.tracked_generation,
+                    old_control.untracked_generation,
+                ] {
+                    if delta.new_control.is_some_and(|new_control| {
+                        new_control.tracked_generation == generation
+                            || new_control.untracked_generation == generation
+                    }) || live_generations.contains(&(delta.branch_id.as_str(), generation))
+                    {
+                        continue;
+                    }
+                    if retired_generations.insert((delta.branch_id.clone(), generation)) {
+                        reclaimed_generation_rows = reclaimed_generation_rows.saturating_add(
+                            crate::live_state::stage_retire_hot_generation(
+                                &store,
+                                writes,
+                                &delta.branch_id,
+                                generation,
+                            )
+                            .await?,
+                        );
+                    }
+                }
+            }
             let Some(old_root) = delta.old_root else {
                 continue;
             };
@@ -2477,98 +1832,36 @@ where
                 &active_semantic_dependency_ids,
             );
             if semantic_retirement && reclaimed_semantic_commits.insert(old_root) {
-                stage_delete_semantic_commit_projection(&store, writes, old_root).await?;
+                crate::changelog::stage_delete_commit_projection(&store, writes, old_root).await?;
             }
             if !physical_retirement {
                 continue;
             }
             if reclaimed_commits.insert(old_root) {
-                let manifest = crate::tracked_state::load_commit_state_manifest(&store, old_root)
-                    .await?
-                    .ok_or_else(|| {
-                        LixError::new(
-                            LixError::CODE_INTERNAL_ERROR,
-                            format!("retired GC root '{old_root}' has no authenticated manifest"),
-                        )
-                    })?;
-                let retired_root =
-                    crate::tracked_state::load_commit_mutation_directory_roots(&store, &[old_root])
-                        .await?
-                        .into_iter()
-                        .next()
-                        .flatten();
-                if let Some(root) = retired_root {
-                    let nodes =
-                        crate::tracked_state::collect_mutation_directory_node_ids(&store, &root)
-                            .await?;
-                    for node_id in nodes.difference(&active_mutation_nodes) {
-                        writes.delete(
-                            crate::tracked_state::MUTATION_DIRECTORY_NODE_SPACE,
-                            StorageKey(Bytes::copy_from_slice(node_id)),
-                        );
-                    }
-                }
-                if let Some(root) = manifest.current_state_scoped_ranges.as_ref() {
-                    let reachable = crate::tracked_state::validate_scoped_range_trees(
-                        &store,
-                        std::slice::from_ref(&root.tree),
-                    )
-                    .await?;
-                    for node_id in reachable.node_ids.difference(&active_scoped_nodes) {
-                        writes.delete(
-                            crate::tracked_state::SCOPED_RANGE_NODE_SPACE,
-                            StorageKey(Bytes::copy_from_slice(node_id)),
-                        );
-                    }
-                    for part in reachable.parts {
-                        let descriptor =
-                            crate::tracked_state::current_state_descriptor_from_scoped_range_part(
-                                &part,
-                            )?;
-                        if descriptor.source_kind == 1
-                            && !active_current_parts.contains(&descriptor.content_digest)
-                        {
-                            writes.delete(
-                                crate::tracked_state::CURRENT_STATE_DATA_PART_SPACE,
-                                StorageKey(Bytes::copy_from_slice(&descriptor.content_digest)),
-                            );
-                            writes.delete(
-                                crate::tracked_state::CURRENT_STATE_DATA_PART_REFS_SPACE,
-                                StorageKey(Bytes::copy_from_slice(&descriptor.payload_refs_digest)),
-                            );
-                        }
-                    }
-                }
-                crate::tracked_state::stage_delete_commit_state_manifest_for_gc(
-                    &store, writes, old_root, &manifest,
+                crate::tracked_state::stage_retire_commit_physical_state(
+                    &store,
+                    writes,
+                    old_root,
+                    RetainedPhysicalState {
+                        mutation_nodes: &active_mutation_nodes,
+                        scoped_nodes: &active_scoped_nodes,
+                        native_parts: &active_current_parts,
+                    },
                 )
                 .await?;
             }
-            if let Some(control) = delta.old_control.as_ref() {
-                if !controls
+            if let Some(control) = delta.old_control.as_ref()
+                && !controls
                     .iter()
                     .any(|(_, active)| active.ref_change_id == control.ref_change_id)
-                {
-                    let key = StorageKey(Bytes::from(change_key(control.ref_change_id)));
-                    let existing = PointReadPlan::new(CHANGE_SPACE, std::slice::from_ref(&key))
-                        .materialize(&store, StorageGetOptions::default())
-                        .await?
-                        .value
-                        .into_iter()
-                        .next()
-                        .flatten();
-                    if existing.is_none() {
-                        return Err(LixError::new(
-                            LixError::CODE_INTERNAL_ERROR,
-                            format!(
-                                "retired branch control references missing standalone change '{}'",
-                                control.ref_change_id
-                            ),
-                        ));
-                    }
-                    writes.delete(CHANGE_SPACE, key);
-                    reclaimed_standalone_changes.insert(control.ref_change_id);
-                }
+            {
+                crate::changelog::stage_delete_standalone_change(
+                    &store,
+                    writes,
+                    control.ref_change_id,
+                )
+                .await?;
+                reclaimed_standalone_changes.insert(control.ref_change_id);
             }
         }
     }
@@ -2623,6 +1916,7 @@ where
         sweep: RepositoryGcSweep {
             tracked_commit_roots: reclaimed_commits.into_iter().collect(),
             standalone_changes: reclaimed_standalone_changes.into_iter().collect(),
+            reclaimed_generation_rows,
             binary_cas,
         },
         profile: RepositoryGcProfile {
@@ -2632,43 +1926,6 @@ where
             total_us: elapsed_micros(started),
         },
     })
-}
-
-/// Every authenticated active scoped-range descriptor must have its native
-/// payload present before ordinary GC is allowed to stage any sweep.  The
-/// descriptor is authority for the digest, but not proof that the immutable
-/// payload still exists; treating a missing payload as an empty live set would
-/// silently turn corruption into deletion.
-async fn validate_live_native_parts<S>(
-    store: &S,
-    digests: &BTreeSet<[u8; 32]>,
-) -> Result<BTreeSet<CommitId>, LixError>
-where
-    S: StorageAdapterRead + ?Sized,
-{
-    if digests.is_empty() {
-        return Ok(BTreeSet::new());
-    }
-    let keys = digests
-        .iter()
-        .map(|digest| StorageKey(Bytes::copy_from_slice(digest)))
-        .collect::<Vec<_>>();
-    let loaded = PointReadPlan::new(crate::tracked_state::CURRENT_STATE_DATA_PART_SPACE, &keys)
-        .materialize(store, StorageGetOptions::default())
-        .await?;
-    let mut commit_ids = BTreeSet::new();
-    for (digest, value) in digests.iter().zip(loaded.value) {
-        let Some(StorageProjectedValue::FullValue(bytes)) = value else {
-            return Err(LixError::new(
-                LixError::CODE_INTERNAL_ERROR,
-                "live current-state directory references a missing native data part",
-            ));
-        };
-        commit_ids.extend(
-            crate::tracked_state::decode_current_state_data_part_commit_ids(digest, &bytes)?,
-        );
-    }
-    Ok(commit_ids)
 }
 
 /// Recovery-only verifier retained for explicit rebuild tooling and tests.
@@ -2793,6 +2050,7 @@ where
         sweep: RepositoryGcSweep {
             tracked_commit_roots: swept_snapshot_authorities,
             standalone_changes: Vec::new(),
+            reclaimed_generation_rows: 0,
             binary_cas: Default::default(),
         },
         profile: RepositoryGcProfile {
@@ -3309,36 +2567,15 @@ where
         .collect::<Vec<_>>();
     crate::tracked_state::stage_change_locators(writes, &relocated_locators);
 
-    writes.delete_batch(
-        COMMIT_SPACE,
-        sweep_commits.iter().map(|commit_id| commit_key(*commit_id)),
-    );
-    stage_sweep_unreachable_content_nodes(
+    crate::changelog::stage_delete_commits(writes, sweep_commits.iter().copied());
+    crate::tracked_state::stage_sweep_unreachable_content_nodes(
         store,
         writes,
-        crate::tracked_state::SCOPED_RANGE_NODE_SPACE,
-        &live_scoped_range_nodes,
-    )
-    .await?;
-    stage_sweep_unreachable_content_nodes(
-        store,
-        writes,
-        crate::tracked_state::MUTATION_DIRECTORY_NODE_SPACE,
-        &live_mutation_directory_nodes,
-    )
-    .await?;
-    stage_sweep_unreachable_content_nodes(
-        store,
-        writes,
-        crate::tracked_state::CURRENT_STATE_DATA_PART_REFS_SPACE,
-        &live_current_state_data_parts,
-    )
-    .await?;
-    stage_sweep_unreachable_content_nodes(
-        store,
-        writes,
-        crate::tracked_state::CURRENT_STATE_DATA_PART_SPACE,
-        &live_current_state_data_parts,
+        RetainedPhysicalState {
+            mutation_nodes: &live_mutation_directory_nodes,
+            scoped_nodes: &live_scoped_range_nodes,
+            native_parts: &live_current_state_data_parts,
+        },
     )
     .await?;
     for commit_id in &sweep_authority_commits {
@@ -3361,16 +2598,11 @@ where
             )?;
         }
     }
-    writes.delete_batch(
-        COMMIT_CHANGE_ID_SPACE,
-        sweep_commit_change_ids
-            .iter()
-            .map(|change_id| commit_change_id_key(*change_id)),
+    crate::changelog::stage_delete_commit_change_ids(
+        writes,
+        sweep_commit_change_ids.iter().copied(),
     );
-    writes.delete_batch(
-        CHANGE_SPACE,
-        sweep_changes.iter().map(|change_id| change_key(*change_id)),
-    );
+    crate::changelog::stage_delete_changes(writes, sweep_changes.iter().copied());
     JsonStoreContext::new()
         .writer()
         .stage_delete_refs(writes, sweep_json_payloads.iter().copied());
@@ -3539,54 +2771,6 @@ fn retirement_is_proven(
         && !active_dependency_ids.contains(&old_root)
 }
 
-/// Removes the semantic commit projection once its root interval is no longer
-/// reachable. Physical tracked-state authority may remain alive as a selected
-/// source or serving dependency, so this decision is intentionally separate
-/// from manifest/CAS retirement.
-async fn stage_delete_semantic_commit_projection<S>(
-    store: &S,
-    writes: &mut StorageWriteSet,
-    commit_id: CommitId,
-) -> Result<(), LixError>
-where
-    S: StorageAdapterRead + ?Sized,
-{
-    let commit_ids = [commit_id];
-    let record = ChangelogContext::new()
-        .reader(store)
-        .load_commits(CommitLoadRequest {
-            commit_ids: &commit_ids,
-        })
-        .await?
-        .into_iter()
-        .next()
-        .and_then(|(_, record)| record);
-    let Some(record) = record else {
-        // A prior GC pass may already have removed the semantic projection
-        // while its physical authority remained pinned.
-        return Ok(());
-    };
-    if record.commit_id != commit_id {
-        return Err(LixError::new(
-            LixError::CODE_INTERNAL_ERROR,
-            format!(
-                "commit projection key for '{commit_id}' contains '{}'",
-                record.commit_id
-            ),
-        ));
-    }
-    writes.delete(COMMIT_SPACE, StorageKey(Bytes::from(commit_key(commit_id))));
-    writes.delete(
-        COMMIT_CHANGE_ID_SPACE,
-        StorageKey(Bytes::from(commit_change_id_key(record.change_id))),
-    );
-    writes.delete(
-        CHANGE_SPACE,
-        StorageKey(Bytes::from(change_key(record.change_id))),
-    );
-    Ok(())
-}
-
 #[cfg(test)]
 mod tests {
     use std::collections::{BTreeMap, BTreeSet};
@@ -3616,7 +2800,6 @@ mod tests {
         StorageKey, StoragePrecondition, StorageReadOptions, StorageSpace, StorageValue,
         StorageWriteOptions, StorageWriteSet,
     };
-    use crate::storage_codec;
     use crate::tracked_state::{
         CommitDeltaLifecycleSummary, CommitDeltaReplacementGeneration, CommitDeltaReplacementScope,
         CommitStateManifest, CommitStateMutationInventory, CommitStateReplayDebt,
@@ -3636,15 +2819,13 @@ mod tests {
 
     use super::{
         CheckpointGcState, CheckpointRecoveryRef, GC_REACHABILITY_DELTA_SPACE,
-        GC_REACHABILITY_QUEUE_SPACE, GC_TREE_SWEEP_FORMAT_VERSION, GC_TREE_SWEEP_MARK_SPACE,
-        RootReachabilityDelta, StoredTreeSweepMark, authenticated_control_commit_reachability,
-        begin_tree_sweep_epoch, collect_all_reachability_checkpoint_roots,
+        GC_REACHABILITY_QUEUE_SPACE, RootReachabilityDelta,
+        authenticated_control_commit_reachability, collect_all_reachability_checkpoint_roots,
         load_checkpoint_gc_state, load_reachability_batches, load_reachability_queue,
-        load_recovery_ref, load_recovery_refs, open_tree_sweep_epoch,
-        resolve_pending_checkpoint_replacement, retirement_is_proven,
-        root_control_digest_for_control, stage_checkpoint_gc_state, stage_delete_recovery_ref,
-        stage_reachability_delta_batch, stage_reachability_queue_seed, stage_recovery_ref_rotation,
-        stage_tree_sweep_epoch_page,
+        load_recovery_ref, load_recovery_refs, resolve_pending_checkpoint_replacement,
+        retirement_is_proven, root_control_digest_for_control, stage_checkpoint_gc_state,
+        stage_delete_recovery_ref, stage_reachability_delta_batch, stage_reachability_queue_seed,
+        stage_recovery_ref_rotation,
     };
 
     async fn append_checkpoint_batch(
@@ -4752,9 +3933,12 @@ mod tests {
             .await
             .expect("native dependency read should open");
         assert_eq!(
-            super::validate_live_native_parts(&read, &BTreeSet::from([encoded.digest]))
-                .await
-                .expect("native owner should decode"),
+            crate::tracked_state::load_native_current_state_part_owners(
+                &read,
+                &BTreeSet::from([encoded.digest]),
+            )
+            .await
+            .expect("native owner should decode"),
             BTreeSet::from([owner.commit_id])
         );
         drop(read);
@@ -4903,7 +4087,7 @@ mod tests {
         );
     }
 
-    async fn tree_sweep_fixture() -> (
+    async fn gc_sweep_fixture() -> (
         StorageAdapter<Memory>,
         CommitId,
         [u8; 32],
@@ -4973,8 +4157,7 @@ mod tests {
 
     #[tokio::test]
     async fn gc_sweep_branch_guard_rejects_concurrent_publication() {
-        let (storage, commit_id, _root_hash, _dead_hash, _dead_hash_two) =
-            tree_sweep_fixture().await;
+        let (storage, commit_id, _root_hash, _dead_hash, _dead_hash_two) = gc_sweep_fixture().await;
         let read = storage
             .begin_read(StorageReadOptions::default())
             .await
@@ -5026,7 +4209,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn offline_sweep_and_audit_share_retained_physical_owner_closure() {
+    async fn retention_closure_and_audit_share_retained_physical_owner() {
         let storage = StorageAdapter::new(Memory::new());
         let timestamp =
             LixTimestamp::expect_parse("shared offline owner timestamp", "2026-01-01T00:00:00Z");
@@ -5144,10 +4327,34 @@ mod tests {
             .await
             .expect("shared offline owner closure should authenticate");
         assert!(closure.physical_dependencies.contains(&owner));
-        let (_, _, _, live_chunks) = super::load_tree_sweep_root_closure(&read)
-            .await
-            .expect("offline sweep should retain the physical owner tree");
-        assert_eq!(live_chunks, BTreeSet::from([owner_hash, active_hash]));
+        // The one retention closure is also what keeps the retired owner's
+        // tracked tree root alive; there is no second root walk to consult.
+        let retained_ids = closure
+            .physical_authorities
+            .union(&closure.physical_dependencies)
+            .copied()
+            .collect::<Vec<_>>();
+        assert_eq!(retained_ids, vec![owner.min(active), owner.max(active)]);
+        let closure_tree_roots =
+            crate::tracked_state::load_commit_state_manifests(&read, &retained_ids)
+                .await
+                .expect("retained manifests should load")
+                .into_iter()
+                .flatten()
+                .filter_map(|manifest| manifest.snapshot_root)
+                .flat_map(|root| {
+                    std::iter::once(*root.root_id.as_bytes()).chain(
+                        root.parent_roots
+                            .iter()
+                            .map(|parent| *parent.root_id.as_bytes())
+                            .collect::<Vec<_>>(),
+                    )
+                })
+                .collect::<BTreeSet<_>>();
+        assert_eq!(
+            closure_tree_roots,
+            BTreeSet::from([owner_hash, active_hash])
+        );
         let audit = super::audit_repository_gc_standalone_refs(&read)
             .await
             .expect("standalone audit should consume the same closure");
@@ -5157,269 +4364,6 @@ mod tests {
                 "{}:retired_delta_old_control:history_dependency_pin:old_root={owner}",
                 retired_ref
             )]
-        );
-    }
-
-    #[tokio::test]
-    async fn tree_sweep_epoch_closes_roots_once_and_reclaims_only_unmarked_chunks() {
-        let (storage, _commit_id, _root_hash, dead_hash, dead_hash_two) =
-            tree_sweep_fixture().await;
-        let read = storage
-            .begin_read(StorageReadOptions::default())
-            .await
-            .expect("fixture read should open");
-        let mut writes = storage.new_write_set();
-        let mut preconditions = Vec::<StoragePrecondition>::new();
-        let _session = begin_tree_sweep_epoch(&&read, &mut writes, &mut preconditions)
-            .await
-            .expect("epoch closure should build once");
-        storage
-            .commit_write_set(
-                writes,
-                StorageWriteOptions {
-                    preconditions,
-                    ..StorageWriteOptions::default()
-                },
-            )
-            .await
-            .expect("epoch metadata should publish atomically");
-        drop(read);
-
-        let read = storage
-            .begin_read(StorageReadOptions::default())
-            .await
-            .expect("reopened epoch read should open");
-        let mut reopened = open_tree_sweep_epoch(&read)
-            .await
-            .expect("epoch should reopen")
-            .expect("epoch should exist");
-        assert_eq!(reopened.epoch.live_chunk_count, 1);
-        assert_eq!(reopened.live_chunks.len(), 1);
-        let mut page_writes = storage.new_write_set();
-        let mut page_preconditions = Vec::new();
-        assert!(
-            stage_tree_sweep_epoch_page(
-                &read,
-                &mut reopened,
-                &mut page_writes,
-                &mut page_preconditions,
-            )
-            .await
-            .expect("tree page should stage")
-        );
-        storage
-            .commit_write_set(
-                page_writes,
-                StorageWriteOptions {
-                    preconditions: page_preconditions,
-                    ..StorageWriteOptions::default()
-                },
-            )
-            .await
-            .expect("tree page should commit");
-        drop(read);
-
-        let read = storage
-            .begin_read(StorageReadOptions::default())
-            .await
-            .expect("post-sweep read should open");
-        let keys = [
-            StorageKey(Bytes::copy_from_slice(&dead_hash)),
-            StorageKey(Bytes::copy_from_slice(&dead_hash_two)),
-        ];
-        let result =
-            PointReadPlan::new(crate::tracked_state::TRACKED_STATE_TREE_CHUNK_SPACE, &keys)
-                .materialize(&read, StorageGetOptions::default())
-                .await
-                .expect("post-sweep chunks should read");
-        assert!(result.value.into_iter().all(|value| value.is_none()));
-        assert!(
-            open_tree_sweep_epoch(&read)
-                .await
-                .expect("completed epoch should reopen")
-                .expect("completed epoch should remain")
-                .cursor
-                .complete
-        );
-    }
-
-    #[tokio::test]
-    async fn tree_sweep_epoch_fails_closed_on_missing_mark_or_corrupt_chunk() {
-        let (storage, _commit_id, _root_hash, dead_hash, _dead_hash_two) =
-            tree_sweep_fixture().await;
-        let read = storage
-            .begin_read(StorageReadOptions::default())
-            .await
-            .expect("fixture read should open");
-        let mut writes = storage.new_write_set();
-        let mut preconditions = Vec::new();
-        begin_tree_sweep_epoch(&&read, &mut writes, &mut preconditions)
-            .await
-            .expect("epoch should begin");
-        storage
-            .commit_write_set(
-                writes,
-                StorageWriteOptions {
-                    preconditions,
-                    ..StorageWriteOptions::default()
-                },
-            )
-            .await
-            .expect("epoch should publish");
-        drop(read);
-
-        let read = storage
-            .begin_read(StorageReadOptions::default())
-            .await
-            .expect("reopened epoch read should open");
-        let session = open_tree_sweep_epoch(&read)
-            .await
-            .expect("epoch should load")
-            .expect("epoch should exist");
-        let live_hash = *session.live_chunks.iter().next().expect("root mark");
-        let epoch_id = session.epoch.epoch_id;
-        drop(read);
-        let mut remove_mark = storage.new_write_set();
-        remove_mark.delete(
-            GC_TREE_SWEEP_MARK_SPACE,
-            StorageKey(Bytes::copy_from_slice(&live_hash)),
-        );
-        storage
-            .commit_write_set(remove_mark, StorageWriteOptions::default())
-            .await
-            .expect("test mark deletion should commit");
-        let read = storage
-            .begin_read(StorageReadOptions::default())
-            .await
-            .expect("missing-mark read should open");
-        assert!(
-            open_tree_sweep_epoch(&read)
-                .await
-                .expect_err("missing live mark must fail closed")
-                .to_string()
-                .contains("mark inventory")
-        );
-        drop(read);
-
-        // Restore the mark and corrupt an unmarked chunk. The page validates
-        // every key/value before it stages any delete, so the failed page has
-        // an empty write set and cannot partially reclaim its siblings.
-        let mut restore = storage.new_write_set();
-        restore.put(
-            GC_TREE_SWEEP_MARK_SPACE,
-            StorageKey(Bytes::copy_from_slice(&live_hash)),
-            StorageValue {
-                bytes: Bytes::from(
-                    storage_codec::encode(
-                        "tree sweep mark",
-                        &StoredTreeSweepMark {
-                            format_version: GC_TREE_SWEEP_FORMAT_VERSION,
-                            epoch_id,
-                            chunk_hash: live_hash,
-                        },
-                    )
-                    .expect("mark should encode"),
-                ),
-            },
-        );
-        storage
-            .commit_write_set(restore, StorageWriteOptions::default())
-            .await
-            .expect("mark restoration should commit");
-        let mut corrupt = storage.new_write_set();
-        corrupt.put(
-            crate::tracked_state::TRACKED_STATE_TREE_CHUNK_SPACE,
-            StorageKey(Bytes::copy_from_slice(&dead_hash)),
-            StorageValue {
-                bytes: Bytes::from_static(b"corrupt-tree-chunk"),
-            },
-        );
-        storage
-            .commit_write_set(corrupt, StorageWriteOptions::default())
-            .await
-            .expect("test corruption should commit");
-        let read = storage
-            .begin_read(StorageReadOptions::default())
-            .await
-            .expect("corruption read should open");
-        let mut session = open_tree_sweep_epoch(&read)
-            .await
-            .expect("restored epoch should load")
-            .expect("restored epoch should exist");
-        let mut page_writes = storage.new_write_set();
-        let mut page_preconditions = Vec::new();
-        assert!(
-            stage_tree_sweep_epoch_page(
-                &read,
-                &mut session,
-                &mut page_writes,
-                &mut page_preconditions,
-            )
-            .await
-            .is_err()
-        );
-        assert!(page_writes.is_empty(), "failed page must stage zero writes");
-    }
-
-    #[tokio::test]
-    async fn tree_sweep_epoch_fails_closed_when_live_chunk_disappears() {
-        let (storage, _commit_id, root_hash, _dead_hash, _dead_hash_two) =
-            tree_sweep_fixture().await;
-        let read = storage
-            .begin_read(StorageReadOptions::default())
-            .await
-            .expect("fixture read should open");
-        let mut writes = storage.new_write_set();
-        let mut preconditions = Vec::new();
-        begin_tree_sweep_epoch(&&read, &mut writes, &mut preconditions)
-            .await
-            .expect("epoch should begin");
-        storage
-            .commit_write_set(
-                writes,
-                StorageWriteOptions {
-                    preconditions,
-                    ..StorageWriteOptions::default()
-                },
-            )
-            .await
-            .expect("epoch should publish");
-        drop(read);
-
-        let mut remove_root = storage.new_write_set();
-        remove_root.delete(
-            crate::tracked_state::TRACKED_STATE_TREE_CHUNK_SPACE,
-            StorageKey(Bytes::copy_from_slice(&root_hash)),
-        );
-        storage
-            .commit_write_set(remove_root, StorageWriteOptions::default())
-            .await
-            .expect("test root deletion should commit");
-
-        let read = storage
-            .begin_read(StorageReadOptions::default())
-            .await
-            .expect("missing-root read should open");
-        let mut session = open_tree_sweep_epoch(&read)
-            .await
-            .expect("epoch should load")
-            .expect("epoch should exist");
-        let mut page_writes = storage.new_write_set();
-        let mut page_preconditions = Vec::new();
-        assert!(
-            stage_tree_sweep_epoch_page(
-                &read,
-                &mut session,
-                &mut page_writes,
-                &mut page_preconditions,
-            )
-            .await
-            .is_err(),
-            "missing live chunk must fail closed"
-        );
-        assert!(
-            page_writes.is_empty(),
-            "missing live chunk must stage zero deletes"
         );
     }
 
@@ -6730,16 +5674,17 @@ mod tests {
             .expect("shared-node read should open");
         let mut sweep = storage.new_write_set();
         let live = BTreeSet::from([live_id]);
-        for space in [
-            crate::tracked_state::SCOPED_RANGE_NODE_SPACE,
-            crate::tracked_state::MUTATION_DIRECTORY_NODE_SPACE,
-            crate::tracked_state::CURRENT_STATE_DATA_PART_SPACE,
-            crate::tracked_state::CURRENT_STATE_DATA_PART_REFS_SPACE,
-        ] {
-            super::stage_sweep_unreachable_content_nodes(&read, &mut sweep, space, &live)
-                .await
-                .expect("content-addressed sweep should stage");
-        }
+        crate::tracked_state::stage_sweep_unreachable_content_nodes(
+            &read,
+            &mut sweep,
+            crate::tracked_state::RetainedPhysicalState {
+                mutation_nodes: &live,
+                scoped_nodes: &live,
+                native_parts: &live,
+            },
+        )
+        .await
+        .expect("content-addressed sweep should stage");
         drop(read);
         storage
             .commit_write_set(sweep, StorageWriteOptions::default())
@@ -7311,7 +6256,10 @@ mod tests {
             )
             .await
             .expect("tracked owner should remain readable");
-        assert_eq!(tracked.rows()[0].values(), &[Value::Json(shared_value.into())]);
+        assert_eq!(
+            tracked.rows()[0].values(),
+            &[Value::Json(shared_value.into())]
+        );
     }
 
     #[tokio::test]
@@ -8289,6 +7237,103 @@ mod tests {
             .expect("replay release should publish");
     }
 
+    /// Reproduction of a known, unfixed defect: the retirement ledger never
+    /// drains, so `gc.reachability_delta.v1` grows one ~439 B row per branch
+    /// publication forever.
+    ///
+    /// Measured cause (this test, plus `expv_blind_space_growth commits`): it
+    /// is *not* head-of-line blocking and not the 64-row consumption cap. Every
+    /// delta is blocked on its own merits, because every commit that still owns
+    /// a live current-state scoped-range part is inserted into
+    /// `physical_authorities` (see the `source_kind` 0 | 2 arm of
+    /// `load_authenticated_serving_dependency_closure`). In an append-only
+    /// workload that is every commit, so `retirement_is_proven` is false for
+    /// every `old_root` even after a checkpoint releases the undo interval.
+    ///
+    /// Fixing it therefore requires either compacting live current state so old
+    /// commits stop owning live parts, or deriving retirement candidates from
+    /// the manifests instead of storing a per-publication ledger. Both are
+    /// larger than this change, so the reproduction is kept and ignored rather
+    /// than deleted.
+    #[tokio::test]
+    #[ignore = "reproduces the unfixed retirement-ledger leak; see the doc comment"]
+    async fn ordinary_gc_drains_the_reachability_queue_past_a_pinned_head() {
+        let backend = Memory::new();
+        Engine::initialize(backend.clone())
+            .await
+            .expect("queue drain fixture should initialize");
+        let engine = Engine::new(backend.clone())
+            .await
+            .expect("queue drain fixture should open");
+        let session = engine
+            .open_workspace_session()
+            .await
+            .expect("queue drain session should open");
+        let schema = serde_json::json!({
+            "x-lix-key": "gc_queue_drain_fixture",
+            "x-lix-primary-key": ["/path"],
+            "type": "object",
+            "required": ["path", "value"],
+            "properties": {
+                "path": { "type": "string" },
+                "value": { "type": ["object", "array", "string", "number", "integer", "boolean", "null"] }
+            },
+            "additionalProperties": false
+        });
+        session
+            .execute(
+                "INSERT INTO lix_registered_schema (value, lixcol_global, lixcol_untracked) VALUES (lix_json($1), false, false)",
+                &[Value::Text(schema.to_string())],
+            )
+            .await
+            .expect("queue drain schema should register");
+        for row in 0..24 {
+            session
+                .execute(
+                    "INSERT INTO gc_queue_drain_fixture (path, value) VALUES ($1, lix_json($2))",
+                    &[
+                        Value::Text(format!("/row/{row}")),
+                        Value::Text(format!(r#"{{"v":{row}}}"#)),
+                    ],
+                )
+                .await
+                .expect("queue drain row should publish");
+        }
+        // A checkpoint releases the undo interval, so every commit below it is
+        // provably retirable and its delta is consumable.
+        session
+            .create_checkpoint()
+            .await
+            .expect("queue drain checkpoint should publish");
+
+        let storage = StorageAdapter::new(backend.clone());
+        let queue_depth = async |storage: &StorageAdapter<Memory>| {
+            let read = SharedStorageAdapterRead::new(
+                storage
+                    .begin_read(StorageReadOptions::default())
+                    .await
+                    .expect("queue depth read should open"),
+            );
+            let (queue, _) = load_reachability_queue(&read)
+                .await
+                .expect("queue depth should load");
+            queue.tail_sequence.saturating_sub(queue.head_sequence)
+        };
+        let before = queue_depth(&storage).await;
+        assert!(before > 0, "the fixture must leave a non-empty queue");
+
+        // Repeated sweeps must converge, not plateau.
+        let mut after = before;
+        for _ in 0..8 {
+            run_ordinary_repository_gc(&storage).await;
+            after = queue_depth(&storage).await;
+        }
+        assert!(
+            after < before,
+            "repeated GC left the retirement ledger at {after} of {before} deltas"
+        );
+    }
+
     async fn run_ordinary_repository_gc(
         storage: &StorageAdapter<Memory>,
     ) -> super::RepositoryGcPlan {
@@ -8315,6 +7360,169 @@ mod tests {
             .await
             .expect("ordinary GC should commit");
         plan
+    }
+
+    /// Counts serving rows still addressed by one branch generation.
+    async fn hot_generation_rows(
+        storage: &StorageAdapter<Memory>,
+        branch_id: &str,
+        generation: CommitId,
+    ) -> usize {
+        let read = storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("generation census read should open");
+        let prefix = crate::storage_adapter::StoragePrefix {
+            bytes: Bytes::from(crate::live_state::hot_generation_scope_prefix(
+                branch_id, generation,
+            )),
+        };
+        let mut rows = 0;
+        let mut cursor = crate::storage_adapter::StorageAdapterRead::begin_scan(
+            &read,
+            crate::live_state::HOT_ROW_SPACE,
+            prefix.to_range().expect("generation prefix should range"),
+            crate::storage_adapter::StorageBeginScanOptions::default(),
+        )
+        .await
+        .expect("generation census scan should open");
+        loop {
+            let page = cursor
+                .next_page(crate::storage_adapter::MAX_SCAN_PAGE_ROWS)
+                .await
+                .expect("generation census page should load");
+            rows += page.entries.len();
+            if !page.has_more {
+                break;
+            }
+        }
+        rows
+    }
+
+    /// A deleted branch strands its whole serving generation. The one
+    /// reachability walk already knows which generations the live controls
+    /// select, so the ordinary pass must reclaim it — no second sweeper, no
+    /// retention ledger.
+    #[tokio::test]
+    async fn ordinary_gc_reclaims_the_serving_generation_of_a_deleted_branch() {
+        let backend = Memory::new();
+        Engine::initialize(backend.clone())
+            .await
+            .expect("generation fixture should initialize");
+        let engine = Engine::new(backend.clone())
+            .await
+            .expect("generation fixture should open");
+        let session = engine
+            .open_workspace_session()
+            .await
+            .expect("generation fixture session should open");
+        let schema = serde_json::json!({
+            "x-lix-key": "gc_generation_fixture",
+            "x-lix-primary-key": ["/path"],
+            "type": "object",
+            "required": ["path", "value"],
+            "properties": {
+                "path": { "type": "string" },
+                "value": { "type": ["object", "array", "string", "number", "integer", "boolean", "null"] }
+            },
+            "additionalProperties": false
+        });
+        session
+            .execute(
+                "INSERT INTO lix_registered_schema (value, lixcol_global, lixcol_untracked) VALUES (lix_json($1), false, false)",
+                &[Value::Text(schema.to_string())],
+            )
+            .await
+            .expect("generation fixture schema should register");
+        for row in 0..16 {
+            session
+                .execute(
+                    "INSERT INTO gc_generation_fixture (path, value) VALUES ($1, lix_json($2))",
+                    &[
+                        Value::Text(format!("/row/{row}")),
+                        Value::Text(format!(r#"{{"v":{row}}}"#)),
+                    ],
+                )
+                .await
+                .expect("generation fixture row should publish");
+        }
+        let branch = session
+            .create_branch(crate::CreateBranchOptions {
+                id: Some("01990000-0000-7000-8000-0000000000a1".to_owned()),
+                name: "gc-generation-dead".to_owned(),
+                from_commit_id: None,
+            })
+            .await
+            .expect("generation fixture branch should create");
+        let branch_session = engine
+            .open_session(branch.id.clone())
+            .await
+            .expect("generation fixture branch session should open");
+        for row in 0..16 {
+            branch_session
+                .execute(
+                    "UPDATE gc_generation_fixture SET value = lix_json($2) WHERE path = $1",
+                    &[
+                        Value::Text(format!("/row/{row}")),
+                        Value::Text(format!(r#"{{"v":{}}}"#, row + 100)),
+                    ],
+                )
+                .await
+                .expect("generation fixture branch row should publish");
+        }
+        let storage = StorageAdapter::new(backend.clone());
+        let generation = {
+            let read = storage
+                .begin_read(StorageReadOptions::default())
+                .await
+                .expect("generation control read should open");
+            BranchHeadControlContext::new()
+                .reader(&read)
+                .scan()
+                .await
+                .expect("generation controls should load")
+                .into_iter()
+                .find(|(branch_id, _)| branch_id == &branch.id)
+                .expect("the disposable branch must have a control")
+                .1
+                .tracked_generation
+        };
+        let seeded = hot_generation_rows(&storage, &branch.id, generation).await;
+        assert!(
+            seeded > 0,
+            "the disposable branch must materialize its own serving generation"
+        );
+
+        drop(branch_session);
+        session
+            .execute(
+                "DELETE FROM lix_branch WHERE id = $1",
+                &[Value::Text(branch.id.clone())],
+            )
+            .await
+            .expect("generation fixture branch should delete");
+        let plan = run_ordinary_repository_gc(&storage).await;
+
+        assert!(
+            plan.sweep.reclaimed_generation_rows >= seeded as u64,
+            "ordinary GC reclaimed {} of {seeded} stranded serving rows",
+            plan.sweep.reclaimed_generation_rows
+        );
+        assert_eq!(
+            hot_generation_rows(&storage, &branch.id, generation).await,
+            0,
+            "no serving row of a deleted branch generation may survive GC"
+        );
+
+        // The surviving branch must still read exactly what it wrote.
+        let survivors = session
+            .execute("SELECT COUNT(*) AS rows FROM gc_generation_fixture", &[])
+            .await
+            .expect("surviving branch should still read")
+            .rows()[0]
+            .get::<i64>("rows")
+            .expect("row count should decode");
+        assert_eq!(survivors, 16);
     }
 
     async fn load_audited_repository_retention(
@@ -8406,7 +7614,10 @@ mod tests {
         }
     }
 
-    async fn assert_offline_sweep_and_audit_fail_closed(
+    /// The retention closure is the single reachability implementation, and the
+    /// standalone audit reads it. Both must reject the same malformed authority
+    /// with the same reason.
+    async fn assert_retention_closure_and_audit_fail_closed(
         storage: &StorageAdapter<Memory>,
         expected_message: &str,
     ) {
@@ -8416,28 +7627,37 @@ mod tests {
                 .await
                 .expect("offline authority read should open"),
         );
-        let sweep_error = super::load_tree_sweep_root_closure(&read)
+        let controls = BranchHeadControlContext::new()
+            .reader(read.clone())
+            .scan()
             .await
-            .expect_err("offline tree sweep must fail closed");
+            .expect("offline authority controls should load");
+        let (queue, _) = load_reachability_queue(&read)
+            .await
+            .expect("offline authority queue should load");
+        let closure_error =
+            super::load_authenticated_repository_retention(&read, &controls, &queue)
+                .await
+                .expect_err("the retention closure must fail closed");
         let audit_error = super::audit_repository_gc_standalone_refs(&read)
             .await
             .expect_err("standalone audit must fail closed");
-        assert_eq!(sweep_error.message, audit_error.message);
+        assert_eq!(closure_error.message, audit_error.message);
         assert!(
-            sweep_error.message.contains(expected_message),
+            closure_error.message.contains(expected_message),
             "unexpected shared authority error: {}",
-            sweep_error.message
+            closure_error.message
         );
     }
 
     #[tokio::test]
-    async fn offline_sweep_and_audit_reject_missing_and_malformed_required_authority() {
+    async fn retention_closure_and_audit_reject_missing_and_malformed_required_authority() {
         const MUTABLE_MANIFEST_SPACE: StorageSpace = StorageSpace::mutable(
             crate::tracked_state::TRACKED_STATE_COMMIT_STATE_MANIFEST_SPACE.id,
             "tracked_state.commit_state_manifest.v7",
         );
 
-        let (storage, commit_id, _, _, _) = tree_sweep_fixture().await;
+        let (storage, commit_id, _, _, _) = gc_sweep_fixture().await;
         let mut writes = storage.new_write_set();
         writes.delete(
             MUTABLE_MANIFEST_SPACE,
@@ -8447,10 +7667,13 @@ mod tests {
             .commit_write_set(writes, StorageWriteOptions::default())
             .await
             .expect("required manifest removal should commit");
-        assert_offline_sweep_and_audit_fail_closed(&storage, "incomplete split physical authority")
-            .await;
+        assert_retention_closure_and_audit_fail_closed(
+            &storage,
+            "incomplete split physical authority",
+        )
+        .await;
 
-        let (storage, commit_id, _, _, _) = tree_sweep_fixture().await;
+        let (storage, commit_id, _, _, _) = gc_sweep_fixture().await;
         let mut writes = storage.new_write_set();
         writes.put(
             MUTABLE_MANIFEST_SPACE,
@@ -8463,11 +7686,11 @@ mod tests {
             .commit_write_set(writes, StorageWriteOptions::default())
             .await
             .expect("malformed manifest should commit");
-        assert_offline_sweep_and_audit_fail_closed(&storage, "unsupported format").await;
+        assert_retention_closure_and_audit_fail_closed(&storage, "unsupported format").await;
     }
 
     #[tokio::test]
-    async fn offline_sweep_and_audit_reject_non_decreasing_and_cyclic_replay_authority() {
+    async fn retention_closure_and_audit_reject_non_decreasing_and_cyclic_replay_authority() {
         let timestamp = LixTimestamp::expect_parse(
             "offline replay authority timestamp",
             "2026-01-01T00:00:00Z",
@@ -8506,7 +7729,7 @@ mod tests {
             &[root_manifest, child_manifest],
         )
         .await;
-        assert_offline_sweep_and_audit_fail_closed(&storage, "replay debt disagrees").await;
+        assert_retention_closure_and_audit_fail_closed(&storage, "replay debt disagrees").await;
 
         let storage = StorageAdapter::new(Memory::new());
         let root = replay_commit_record("offline-replay-cycle-root", 0, None, timestamp);
@@ -8559,7 +7782,7 @@ mod tests {
             ],
         )
         .await;
-        assert_offline_sweep_and_audit_fail_closed(&storage, "dependency cycle").await;
+        assert_retention_closure_and_audit_fail_closed(&storage, "dependency cycle").await;
     }
 
     async fn json_ref_exists(storage: &Memory, space: StorageSpace, json_ref: JsonRef) -> bool {

--- a/packages/lix/src/live_state/mod.rs
+++ b/packages/lix/src/live_state/mod.rs
@@ -25,7 +25,10 @@ pub(crate) use reader::{LiveStateReadDomain, LiveStateReader};
 #[cfg(test)]
 pub(crate) use tracked_head::TrackedHeadDeltaRef;
 #[cfg(test)]
+pub(crate) use tracked_head::hot_generation_scope_prefix;
+#[cfg(test)]
 pub(crate) use tracked_head::stage_collect_stale_working_diff_indexes;
+pub(crate) use tracked_head::stage_retire_hot_generation;
 #[allow(unused_imports)]
 pub(crate) use tracked_head::{
     CERTIFIED_ENTITY_BATCH_MANIFEST_SPACE, CERTIFIED_ENTITY_BATCH_PAGE_SPACE,
@@ -33,12 +36,11 @@ pub(crate) use tracked_head::{
     CertifiedCurrentStatePredecessorRef, CertifiedEntityBatchFileRef, ColumnarBaseCoordinate,
     CurrentStateDeltaRef, DeferredFreshHotPlan, DeferredFreshHotRowRef, DeferredFreshHotRows,
     EntityColumnarOverlayRow, HOT_COLLECTION_CONTROL_SPACE, HOT_DIFF_SPACE, HOT_FILE_SPACE,
-    HOT_ROW_SPACE, HotTrackedSnapshot,
-    PACKED_CURRENT_BASE_CONTROL_SPACE, PACKED_CURRENT_BASE_SPACE,
-    PACKED_CURRENT_EXCLUSIVE_SCHEMA_BASE_SPACE, PackedIdentityMembership, ROOT_CURRENT_BASE_SPACE,
-    TRACKED_WORKING_DIFF_MARKER_SPACE, TrackedHeadContext, TrackedWorkingDiff,
-    TrackedWorkingDiffEpoch, WorkingDiffIndexCoverage, materialize_certified_root_rows,
-    scan_certified_history_rows, stage_certified_entity_batches,
+    HOT_ROW_SPACE, HotTrackedSnapshot, PACKED_CURRENT_BASE_CONTROL_SPACE,
+    PACKED_CURRENT_BASE_SPACE, PACKED_CURRENT_EXCLUSIVE_SCHEMA_BASE_SPACE,
+    PackedIdentityMembership, ROOT_CURRENT_BASE_SPACE, TRACKED_WORKING_DIFF_MARKER_SPACE,
+    TrackedHeadContext, TrackedWorkingDiff, TrackedWorkingDiffEpoch, WorkingDiffIndexCoverage,
+    materialize_certified_root_rows, scan_certified_history_rows, stage_certified_entity_batches,
     stage_delete_tracked_working_diff_epoch, stage_tracked_working_diff_epoch,
 };
 #[allow(unused_imports)]

--- a/packages/lix/src/live_state/tracked_head.rs
+++ b/packages/lix/src/live_state/tracked_head.rs
@@ -10,15 +10,17 @@
 mod hot;
 
 pub(crate) use crate::live_state::LiveStateReadDomain;
+#[cfg(test)]
+pub(crate) use hot::hot_generation_scope_prefix;
 pub(crate) use hot::{
     CERTIFIED_ENTITY_BATCH_MANIFEST_SPACE, CERTIFIED_ENTITY_BATCH_PAGE_SPACE,
     CERTIFIED_ENTITY_BATCH_SPACE, CertifiedEntityBatchFileRef, DeferredFreshHotPlan,
-    DeferredFreshHotRowRef, DeferredFreshHotRows, EntityColumnarOverlayRow, HOT_DIFF_SPACE,
-    HOT_COLLECTION_CONTROL_SPACE, HOT_FILE_SPACE, HOT_ROW_SPACE, HotStateTransactionCache,
-    HotTrackedSnapshot,
-    PACKED_CURRENT_BASE_CONTROL_SPACE, PACKED_CURRENT_BASE_SPACE,
-    PACKED_CURRENT_EXCLUSIVE_SCHEMA_BASE_SPACE, PackedIdentityMembership, ROOT_CURRENT_BASE_SPACE,
-    materialize_certified_root_rows, scan_certified_history_rows, stage_certified_entity_batches,
+    DeferredFreshHotRowRef, DeferredFreshHotRows, EntityColumnarOverlayRow,
+    HOT_COLLECTION_CONTROL_SPACE, HOT_DIFF_SPACE, HOT_FILE_SPACE, HOT_ROW_SPACE,
+    HotStateTransactionCache, HotTrackedSnapshot, PACKED_CURRENT_BASE_CONTROL_SPACE,
+    PACKED_CURRENT_BASE_SPACE, PACKED_CURRENT_EXCLUSIVE_SCHEMA_BASE_SPACE,
+    PackedIdentityMembership, ROOT_CURRENT_BASE_SPACE, materialize_certified_root_rows,
+    scan_certified_history_rows, stage_certified_entity_batches, stage_retire_hot_generation,
 };
 
 /// Stable physical address of a row in an immutable columnar base.

--- a/packages/lix/src/live_state/tracked_head/hot.rs
+++ b/packages/lix/src/live_state/tracked_head/hot.rs
@@ -11236,6 +11236,76 @@ fn collect_hot_untracked_refs(value: HeadValueView<'_>, refs: &mut BTreeSet<[u8;
     }
 }
 
+/// Every serving plane whose key begins with `(branch_id, generation)`.
+///
+/// These are derived caches of one branch generation, so a generation that no
+/// live branch control selects is exactly one contiguous key range per space.
+/// Content-addressed planes (the certified entity batches) are deliberately
+/// absent: their rows are shared across generations and are reclaimed by
+/// content reachability, not by scope.
+const GENERATION_SCOPED_SPACES: &[StorageSpace] = &[
+    HOT_ROW_SPACE,
+    HOT_FILE_SPACE,
+    HOT_COLLECTION_CONTROL_SPACE,
+    PACKED_CURRENT_BASE_SPACE,
+    PACKED_CURRENT_BASE_CONTROL_SPACE,
+    PACKED_CURRENT_EXCLUSIVE_SCHEMA_BASE_SPACE,
+    ROOT_CURRENT_BASE_SPACE,
+];
+
+/// The `(branch_id, generation)` key prefix that scopes every derived serving
+/// plane. Exposed for GC census assertions.
+#[cfg(test)]
+pub(crate) fn hot_generation_scope_prefix(branch_id: &str, generation: CommitId) -> Vec<u8> {
+    encode_scope_prefix(branch_id, generation)
+}
+
+/// Retires every derived serving row of one branch generation.
+///
+/// The caller proves the generation is unreachable from the live branch
+/// controls; this stages the deletes. Work is bounded by the rows actually
+/// reclaimed — each space is entered at the generation's key prefix, never
+/// scanned whole — so a repository sweep costs what its garbage costs.
+pub(crate) async fn stage_retire_hot_generation<S>(
+    store: &S,
+    writes: &mut StorageWriteSet,
+    branch_id: &str,
+    generation: CommitId,
+) -> Result<u64, LixError>
+where
+    S: StorageAdapterRead + ?Sized,
+{
+    let prefix = StoragePrefix {
+        bytes: Bytes::from(encode_scope_prefix(branch_id, generation)),
+    };
+    let mut deleted = 0_u64;
+    for space in GENERATION_SCOPED_SPACES {
+        let mut cursor = store
+            .begin_scan(
+                *space,
+                prefix.to_range()?,
+                StorageBeginScanOptions {
+                    projection: StorageCoreProjection::KeyOnly,
+                    ..StorageBeginScanOptions::default()
+                },
+            )
+            .await?;
+        loop {
+            let page = cursor
+                .next_page(crate::storage_adapter::MAX_SCAN_PAGE_ROWS)
+                .await?;
+            for entry in page.entries {
+                writes.delete(*space, entry.key);
+                deleted = deleted.saturating_add(1);
+            }
+            if !page.has_more {
+                break;
+            }
+        }
+    }
+    Ok(deleted)
+}
+
 #[cfg(test)]
 pub(crate) async fn stage_collect_stale_hot_generations<S>(
     store: &S,

--- a/packages/lix/src/storage_bench.rs
+++ b/packages/lix/src/storage_bench.rs
@@ -948,6 +948,7 @@ pub struct RepositoryGcBenchResult {
     pub key_shared_buffers: usize,
     pub key_shared_bytes: usize,
     pub key_shared_capacity: usize,
+    pub reclaimed_generation_rows: u64,
     pub root_discovery_us: u64,
     pub changelog_us: u64,
     pub tracked_root_stage_us: u64,
@@ -1199,6 +1200,7 @@ where
         key_shared_buffers: arena.key_shared_buffers,
         key_shared_bytes: arena.key_shared_bytes,
         key_shared_capacity: arena.key_shared_capacity,
+        reclaimed_generation_rows: plan.sweep.reclaimed_generation_rows,
         root_discovery_us: plan.profile.root_discovery_us,
         changelog_us: plan.profile.changelog_us,
         tracked_root_stage_us: plan.profile.tracked_root_stage_us,
@@ -1210,6 +1212,7 @@ where
 pub struct RepositoryGcCommitBenchResult {
     pub staged_deletes: u64,
     pub swept_commits: usize,
+    pub reclaimed_generation_rows: u64,
     pub reclaimed_manifest_rows: usize,
     pub reclaimed_manifest_chunk_rows: usize,
     pub reclaimed_chunk_rows: usize,
@@ -1262,6 +1265,7 @@ where
             Ok(_) => {
                 return Ok(RepositoryGcCommitBenchResult {
                     staged_deletes: stats.staged_deletes,
+                    reclaimed_generation_rows: plan.sweep.reclaimed_generation_rows,
                     swept_commits: plan
                         .changelog
                         .sweep
@@ -2975,9 +2979,17 @@ mod tests {
         // row; the other ten change deletes are retired branch-ref facts.
         assert_eq!(first.deleted_semantic_change_rows, 20);
         assert_eq!(first.deleted_semantic_reverse_index_rows, 10);
+        // The deleted branch also strands the whole serving generation it was
+        // reading from. No live branch control can select it again, so the
+        // same pass retires it: ten commits of ten rows, plus the generation's
+        // collection control and root current base.
+        assert_eq!(first.reclaimed_generation_rows, 102);
         assert_eq!(
             first.delete_counts_by_space,
             vec![
+                (crate::live_state::HOT_ROW_SPACE.id.0, 100), // stranded serving rows
+                (crate::live_state::HOT_COLLECTION_CONTROL_SPACE.id.0, 1), // its collection control
+                (crate::live_state::ROOT_CURRENT_BASE_SPACE.id.0, 1), // its root current base
                 (
                     crate::tracked_state::TRACKED_STATE_COMMIT_STATE_MANIFEST_SPACE
                         .id
@@ -2990,8 +3002,8 @@ mod tests {
                         .0,
                     10,
                 ), // mutation inventory authority
-                (crate::changelog::COMMIT_SPACE.id.0, 10), // branch-only commit projections
-                (crate::changelog::CHANGE_SPACE.id.0, 20), // projection and branch-ref changes
+                (crate::changelog::COMMIT_SPACE.id.0, 10),    // branch-only commit projections
+                (crate::changelog::CHANGE_SPACE.id.0, 20),    // projection and branch-ref changes
                 (crate::changelog::COMMIT_CHANGE_ID_SPACE.id.0, 10), // commit -> change reverse index
             ]
         );
@@ -3013,9 +3025,35 @@ mod tests {
         const FENCE_KEY_BYTES: usize =
             crate::storage_adapter::REVISION_KEY_BINARY_CAS_RECLAMATION.len();
         assert_eq!(first.key_shared_buffers, first.staged_deletes as usize + 1);
-        assert_eq!(
-            first.key_shared_bytes,
-            first.staged_deletes as usize * 16 + FENCE_KEY_BYTES
+        // Canonical-record deletes are UUID keyed, so each descriptor is
+        // exactly 16 bytes. Generation-scoped serving rows are keyed by
+        // `(branch, generation, schema, entity, file)` and are wider, so assert
+        // the UUID-keyed floor instead of restating that key layout here.
+        let uuid_keyed_deletes = first
+            .delete_counts_by_space
+            .iter()
+            .filter(|(space, _)| {
+                [
+                    crate::tracked_state::TRACKED_STATE_COMMIT_STATE_MANIFEST_SPACE
+                        .id
+                        .0,
+                    crate::tracked_state::TRACKED_STATE_COMMIT_MUTATION_INVENTORY_SPACE
+                        .id
+                        .0,
+                    crate::changelog::COMMIT_SPACE.id.0,
+                    crate::changelog::CHANGE_SPACE.id.0,
+                    crate::changelog::COMMIT_CHANGE_ID_SPACE.id.0,
+                ]
+                .contains(space)
+            })
+            .map(|(_, count)| *count)
+            .sum::<usize>();
+        let generation_keyed_deletes = first.staged_deletes as usize - uuid_keyed_deletes;
+        assert_eq!(generation_keyed_deletes, 102);
+        assert!(
+            first.key_shared_bytes
+                > uuid_keyed_deletes * 16 + generation_keyed_deletes * 16 + FENCE_KEY_BYTES,
+            "generation-scoped delete keys must be wider than a bare UUID"
         );
         assert_eq!(second.swept_commits, first.swept_commits);
         assert_eq!(second.delete_counts_by_space, first.delete_counts_by_space);

--- a/packages/lix/src/storage_spaces.rs
+++ b/packages/lix/src/storage_spaces.rs
@@ -65,9 +65,6 @@ pub(crate) const ALL_STORAGE_SPACES: &[StorageSpace] = &[
     crate::gc::CHECKPOINT_GC_STATE_SPACE,
     crate::gc::GC_REACHABILITY_DELTA_SPACE,
     crate::gc::GC_REACHABILITY_QUEUE_SPACE,
-    crate::gc::GC_TREE_SWEEP_EPOCH_SPACE,
-    crate::gc::GC_TREE_SWEEP_MARK_SPACE,
-    crate::gc::GC_TREE_SWEEP_CURSOR_SPACE,
 ];
 
 /// Space ids that belonged to spaces this protocol has cut.
@@ -81,6 +78,12 @@ pub(crate) const RETIRED_STORAGE_SPACE_IDS: &[StorageSpaceId] = &[
     StorageSpaceId(0x0001_0002),
     // live_state.index.branch_root.v1
     StorageSpaceId(0x0004_0005),
+    // gc.tree_sweep_epoch.v1
+    StorageSpaceId(0x0008_0005),
+    // gc.tree_sweep_mark.v1
+    StorageSpaceId(0x0008_0006),
+    // gc.tree_sweep_cursor.v1
+    StorageSpaceId(0x0008_0007),
 ];
 
 /// The first live-row space id.

--- a/packages/lix/src/tracked_state/mod.rs
+++ b/packages/lix/src/tracked_state/mod.rs
@@ -70,6 +70,8 @@ pub(crate) use storage::TRACKED_STATE_COMMIT_STATE_MANIFEST_SPACE;
 pub(crate) use storage::TRACKED_STATE_TREE_CHUNK_SPACE;
 #[cfg(any(test, feature = "storage-benches"))]
 pub(crate) use storage::stage_commit_state_manifest;
+#[cfg(test)]
+pub(crate) use storage::stage_sweep_unreachable_content_nodes;
 pub(crate) use storage::{
     CertifiedCommitStateTopologyParent, CommitDeltaChangeLocator, CommitDeltaLiveMembershipCursor,
     CommitDeltaMember, CommitDeltaPointReadCache, CommitDeltaReplacementGeneration,
@@ -89,21 +91,25 @@ pub(crate) use storage::{
     stage_current_state_scoped_ranges_from_published_parent,
     stage_current_state_scoped_ranges_from_published_topology_parent,
     stage_current_state_scoped_ranges_from_staged_parent,
-    stage_current_state_scoped_ranges_from_topology, stage_delete_commit_state_manifest_for_gc,
-    stage_ordered_addressable_commit_deltas, stage_ordered_addressable_replacement_parts,
-    stage_ordered_columnar_mutations, stage_preencoded_ordered_addressable_replacement_parts,
+    stage_current_state_scoped_ranges_from_topology, stage_ordered_addressable_commit_deltas,
+    stage_ordered_addressable_replacement_parts, stage_ordered_columnar_mutations,
+    stage_preencoded_ordered_addressable_replacement_parts,
     stage_prefixed_ordered_addressable_replacement_parts,
+};
+pub(crate) use storage::{
+    RetainedPhysicalState, load_native_current_state_part_owners,
+    stage_retire_commit_physical_state,
 };
 // The storage-space constants are what the space registry
 // (`crate::storage_spaces`) and its layout invariants are built from, so they
 // must be reachable whenever tests compile, not only under `storage-benches`.
+#[cfg(feature = "storage-benches")]
+pub(crate) use storage::decode_change_locator;
 #[cfg(any(test, feature = "storage-benches"))]
 pub(crate) use storage::{
     TRACKED_STATE_CHANGE_LOCATOR_SPACE, TRACKED_STATE_COMMIT_DELTA_SEGMENT_SPACE,
     TRACKED_STATE_COMMIT_MUTATION_INVENTORY_SPACE, TRACKED_STATE_COMMIT_STATE_MANIFEST_SPACE,
 };
-#[cfg(feature = "storage-benches")]
-pub(crate) use storage::decode_change_locator;
 #[cfg(test)]
 pub(crate) use storage::{
     change_id_from_packed_address, commit_state_authority_key, load_commit_delta_change_ids,

--- a/packages/lix/src/tracked_state/storage.rs
+++ b/packages/lix/src/tracked_state/storage.rs
@@ -10444,6 +10444,191 @@ pub(crate) async fn stage_delete_commit_state_manifest_for_gc(
     Ok(())
 }
 
+/// The content-addressed nodes and parts that are still reachable from the
+/// repository's live root closure.
+///
+/// Every tracked-state plane below is content addressed and therefore shared
+/// between commits, so a retired commit may only drop a node the live closure
+/// does not also name.
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct RetainedPhysicalState<'a> {
+    pub(crate) mutation_nodes: &'a BTreeSet<[u8; 32]>,
+    pub(crate) scoped_nodes: &'a BTreeSet<[u8; 32]>,
+    pub(crate) native_parts: &'a BTreeSet<[u8; 32]>,
+}
+
+/// Retires every physical tracked-state row owned by one unreachable commit.
+///
+/// GC proves unreachability from refs and hands the proof here; the layout of
+/// mutation directories, scoped-range trees, and native current-state parts —
+/// and therefore which keys a retirement touches — stays inside the module
+/// that writes them.
+pub(crate) async fn stage_retire_commit_physical_state(
+    store: &(impl StorageAdapterRead + ?Sized),
+    writes: &mut StorageWriteSet,
+    commit_id: CommitId,
+    retained: RetainedPhysicalState<'_>,
+) -> Result<(), LixError> {
+    let manifest = load_commit_state_manifest(store, commit_id)
+        .await?
+        .ok_or_else(|| {
+            LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                format!("retired GC root '{commit_id}' has no authenticated manifest"),
+            )
+        })?;
+    let retired_root = load_commit_mutation_directory_roots(store, &[commit_id])
+        .await?
+        .into_iter()
+        .next()
+        .flatten();
+    if let Some(root) = retired_root {
+        let nodes = crate::tracked_state::collect_mutation_directory_node_ids(store, &root).await?;
+        for node_id in nodes.difference(retained.mutation_nodes) {
+            writes.delete(
+                crate::tracked_state::MUTATION_DIRECTORY_NODE_SPACE,
+                key(node_id.to_vec()),
+            );
+        }
+    }
+    if let Some(root) = manifest.current_state_scoped_ranges.as_ref() {
+        let reachable = crate::tracked_state::validate_scoped_range_trees(
+            store,
+            std::slice::from_ref(&root.tree),
+        )
+        .await?;
+        for node_id in reachable.node_ids.difference(retained.scoped_nodes) {
+            writes.delete(
+                crate::tracked_state::SCOPED_RANGE_NODE_SPACE,
+                key(node_id.to_vec()),
+            );
+        }
+        for part in reachable.parts {
+            let descriptor =
+                crate::tracked_state::current_state_descriptor_from_scoped_range_part(&part)?;
+            if descriptor.source_kind == 1
+                && !retained.native_parts.contains(&descriptor.content_digest)
+            {
+                writes.delete(
+                    crate::tracked_state::CURRENT_STATE_DATA_PART_SPACE,
+                    key(descriptor.content_digest.to_vec()),
+                );
+                writes.delete(
+                    crate::tracked_state::CURRENT_STATE_DATA_PART_REFS_SPACE,
+                    key(descriptor.payload_refs_digest.to_vec()),
+                );
+            }
+        }
+    }
+    stage_delete_commit_state_manifest_for_gc(store, writes, commit_id, &manifest).await
+}
+
+/// Loads the owning commit ids of every native current-state data part named by
+/// `digests`, proving each payload is still physically present.
+///
+/// A scoped-range descriptor is authority for the digest, but not proof that
+/// the immutable payload still exists; treating a missing payload as an empty
+/// live set would silently turn corruption into deletion, so this fails closed.
+pub(crate) async fn load_native_current_state_part_owners(
+    store: &(impl StorageAdapterRead + ?Sized),
+    digests: &BTreeSet<[u8; 32]>,
+) -> Result<BTreeSet<CommitId>, LixError> {
+    if digests.is_empty() {
+        return Ok(BTreeSet::new());
+    }
+    let keys = digests
+        .iter()
+        .map(|digest| StorageKey(Bytes::copy_from_slice(digest)))
+        .collect::<Vec<_>>();
+    let loaded = PointReadPlan::new(crate::tracked_state::CURRENT_STATE_DATA_PART_SPACE, &keys)
+        .materialize(store, StorageGetOptions::default())
+        .await?;
+    let mut commit_ids = BTreeSet::new();
+    for (digest, value) in digests.iter().zip(loaded.value) {
+        let Some(StorageProjectedValue::FullValue(bytes)) = value else {
+            return Err(LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                "live current-state directory references a missing native data part",
+            ));
+        };
+        commit_ids.extend(
+            crate::tracked_state::decode_current_state_data_part_commit_ids(digest, &bytes)?,
+        );
+    }
+    Ok(commit_ids)
+}
+
+/// Sweeps every content-addressed tracked-state plane down to a repository-wide
+/// live closure.
+///
+/// This is the whole-repository counterpart to
+/// [`stage_retire_commit_physical_state`]: it discovers rows by scanning rather
+/// than from a retirement proof, so it is reserved for the offline oracle that
+/// cross-checks incremental GC.
+#[cfg(test)]
+pub(crate) async fn stage_sweep_unreachable_content_nodes(
+    store: &(impl StorageAdapterRead + ?Sized),
+    writes: &mut StorageWriteSet,
+    retained: RetainedPhysicalState<'_>,
+) -> Result<(), LixError> {
+    for (space, live) in [
+        (
+            crate::tracked_state::SCOPED_RANGE_NODE_SPACE,
+            retained.scoped_nodes,
+        ),
+        (
+            crate::tracked_state::MUTATION_DIRECTORY_NODE_SPACE,
+            retained.mutation_nodes,
+        ),
+        (
+            crate::tracked_state::CURRENT_STATE_DATA_PART_REFS_SPACE,
+            retained.native_parts,
+        ),
+        (
+            crate::tracked_state::CURRENT_STATE_DATA_PART_SPACE,
+            retained.native_parts,
+        ),
+    ] {
+        let range = StorageKeyRange {
+            lower: Bound::Unbounded,
+            upper: Bound::Unbounded,
+        };
+        let mut cursor = store
+            .begin_scan(
+                space,
+                range,
+                StorageBeginScanOptions {
+                    projection: StorageCoreProjection::KeyOnly,
+                    ..StorageBeginScanOptions::default()
+                },
+            )
+            .await?;
+        loop {
+            let page = cursor
+                .next_page(crate::storage_adapter::MAX_SCAN_PAGE_ROWS)
+                .await?;
+            for entry in page.entries {
+                let node_id = <[u8; 32]>::try_from(entry.key.0.as_ref()).map_err(|_| {
+                    LixError::new(
+                        LixError::CODE_INTERNAL_ERROR,
+                        format!(
+                            "content-addressed space '{}' contains a malformed key",
+                            space.name
+                        ),
+                    )
+                })?;
+                if !live.contains(&node_id) {
+                    writes.delete(space, entry.key);
+                }
+            }
+            if !page.has_more {
+                break;
+            }
+        }
+    }
+    Ok(())
+}
+
 async fn scan_full_space(
     store: &(impl StorageAdapterRead + ?Sized),
     space: StorageSpace,


### PR DESCRIPTION
Machine: `ryzen-9950x-V` (32 cores, 186 GB). Base commit for both arms: `3ff58c484`.

## The three claims

**1. Deleting a branch now reclaims 355,065 logical bytes that were previously retained forever.**
At 100k rows, the residual footprint after *branch delete + GC* falls from 361,410 B to 6,345 B. The
baseline for "bytes reclaimed" was **0** — not "less than we wanted", zero. And the residual is now
**constant at ~6,345 B regardless of workspace size** (1k, 10k and 100k rows all land on the same
number), so this removes an asymptotic term rather than a constant factor.

**2. Three entire storage spaces are retired, and foreign-space writes go 12 → 0.**
`gc.tree_sweep_epoch.v1` (`0x0008_0005`), `gc.tree_sweep_mark.v1` (`0x0008_0006`) and
`gc.tree_sweep_cursor.v1` (`0x0008_0007`) are deleted and their ids moved to
`RETIRED_STORAGE_SPACE_IDS`. `gc.rs` production code now stages mutations into **only** the four
spaces it owns.

**3. The sweeper did not fail — a refactor deleted it, and nothing put it back.**
`stage_collect_stale_hot_generations` was `#[cfg(test)]`-gated by `8b3a95a4d` ("queue authenticated
branch generation reclamation") *because a queue-driven replacement was being written*. That
replacement was then removed by `63d46f8fe` ("consume authenticated root deltas incrementally")
without restoring the original. Net result: from that commit until this one, lix shipped with **no
production sweeper for stale live-state generations at all**, and no test failed. This is the
clearest instance this program has produced of a refactor silently removing a production capability.

## What changed

### 1. One reachability implementation

Three retention walks existed. Only one ever ran in a repository:

| # | walk | entry point | before | after |
|---|---|---|---|---|
| 1 | authenticated queue-delta closure | `stage_repository_gc_with_preconditions` | the production collector | **the only collector** |
| 2 | tree-sweep epoch collector | `begin_tree_sweep_epoch` → `load_tree_sweep_root_closure` → `scan_tree_sweep_marks` | **no production caller**; all 16 items `#[allow(dead_code)]` | **deleted** |
| 3 | whole-repository full-scan oracle | `stage_repository_gc_full_recovery` → `plan_and_stage_authority_gc` | `#[cfg(test)]` | kept as a test oracle, now reaching every foreign space through its owner |

Walk 2 is gone: 912 lines, 4 constants, 4 stored types, 6 functions, and **three entire storage spaces** — `gc.tree_sweep_epoch.v1` (`0x0008_0005`), `gc.tree_sweep_mark.v1` (`0x0008_0006`), `gc.tree_sweep_cursor.v1` (`0x0008_0007`) — whose ids are now in `RETIRED_STORAGE_SPACE_IDS`.

Walk 3 is `#[cfg(test)]` and never runs in a repository. It is a slow, obviously-correct oracle for the fast incremental collector, not a second authority. It is **not** redundant with walk 1: it computes a complete live-JSON-payload set, which requires a full scan of `COMMIT_SPACE`, `CHANGE_SPACE` and the commit-delta inventory plus every member change of every retained commit — Θ(repository) per pass. See "JSON payloads" below.

### 2. No foreign-space writes

Verified post-merge inventory of staged mutations in `gc.rs` above the test module.

**Before** — 12 foreign write sites across 7 spaces:

| site | space | owner | reachable in production? |
|---|---|---|---|
| `gc.rs:2504` | `MUTATION_DIRECTORY_NODE_SPACE` | `tracked_state` | yes |
| `gc.rs:2517` | `SCOPED_RANGE_NODE_SPACE` | `tracked_state` | yes |
| `gc.rs:2530` | `CURRENT_STATE_DATA_PART_SPACE` | `tracked_state` | yes |
| `gc.rs:2534` | `CURRENT_STATE_DATA_PART_REFS_SPACE` | `tracked_state` | yes |
| `gc.rs:2568` | `CHANGE_SPACE` | `changelog` | yes |
| `gc.rs:3577` | `COMMIT_SPACE` | `changelog` | yes |
| `gc.rs:3578` | `COMMIT_CHANGE_ID_SPACE` | `changelog` | yes |
| `gc.rs:3582` | `CHANGE_SPACE` | `changelog` | yes |
| `gc.rs:1420` | `TRACKED_STATE_TREE_CHUNK_SPACE` | `tracked_state` | no — dead tree-sweep |
| `gc.rs:1651` | 4 `tracked_state` spaces (generic param) | `tracked_state` | no — `#[cfg(test)]` |
| `gc.rs:3311/3363/3369` | `COMMIT_SPACE` / `COMMIT_CHANGE_ID_SPACE` / `CHANGE_SPACE` | `changelog` | no — `#[cfg(test)]` |

**After** — zero. Every staged mutation in `gc.rs` production code targets one of the four gc-owned spaces (`CHECKPOINT_RECOVERY_REF`, `CHECKPOINT_GC_STATE`, `GC_REACHABILITY_DELTA`, `GC_REACHABILITY_QUEUE`). The work moved to owner-module entry points: `changelog::stage_delete_commit_projection`, `changelog::stage_delete_standalone_change`, `tracked_state::stage_retire_commit_physical_state`, `tracked_state::load_native_current_state_part_owners`, and (for the test oracle) `changelog::stage_delete_commits` / `stage_delete_commit_change_ids` / `stage_delete_changes` and `tracked_state::stage_sweep_unreachable_content_nodes`.

Note: the original brief's "ownership inversion — `gc.rs` is the only production writer of `CURRENT_STATE_DATA_PART_SPACE` puts" is **stale post-merge**. The codex-1+2 merge moved that put into `tracked_state::stage_scoped_native_current_state_rows` (`tracked_state/storage.rs:3083-3105`). What remained was foreign *deletes*, which this change removes.

### 3. The branch-generation sweeper, reconnected

See claim 3 above for how the sweeper died. A generation is reachable from exactly one place — a live branch control — and the GC pass already reads all of them for root discovery. Retiring one is therefore a bounded prefix sweep of the seven generation-scoped serving planes, owned by `live_state::stage_retire_hot_generation`. Work is proportional to rows reclaimed; no plane is ever scanned whole.

This is deliberately **not** gated on queue consumption. A blocked batch means a *commit root* is pinned by history/undo/replay, all of which read tracked-state records, never these derived rows. That decoupling is why this reclamation works despite the separate retirement-ledger wedge described below.

## Reclaim evidence (absolute, not parity)

`branch_storage_sharing delete_gc_1pct`: seed a workspace, branch, modify 1% of rows, delete the branch, run repository GC. `delta_*` is the residual footprint after the whole cycle. rocksdb, 3 interleaved reps, **zero variance, non-overlapping ranges**:

| rows | metric | base | cand | delta |
|---|---|---|---|---|
| 100,000 | residual logical bytes | 361,410 | 6,345 | **−98.2%** |
| 100,000 | residual logical rows | 1,024 | 22 | −97.9% |
| 100,000 | residual physical bytes | 91,732 (med) | 28,394 (med) | **−69.1%** |

**Absolute bytes newly reclaimed per deleted branch at 100k rows: 355,065 logical / 63,338 physical.**
Before this change that number was **0** — every one of those bytes was retained forever. Re-confirmed
on the merged branch at `3ff58c484` with identical values.

The residual is now **constant at 6,345 bytes independent of workspace size**, so this removes an asymptotic term, not a constant factor. Earlier 9-rep matrix on the previous base (both backends, three row tiers) agreed exactly:

| rows | base | cand | delta |
|---|---|---|---|
| 1,000 | 10,029 | 6,324 | −36.9% |
| 10,000 | 41,889 | 6,324 | −84.9% |
| 100,000 | 361,389 | 6,324 | −98.3% |

Per space at 100k (median `d_bytes`): `live_state.hot_row.v21` 355,066 → 176; `live_state.root_current_base.v1` 74 → 0; `live_state.hot_collection_control.v1` 68 → −33.

Guard scenarios in the same 9-rep matrix, both backends: `base` and `merge_1pct` are **+0.0%** on every logical metric and within ±1% on `scenario_ms`.

## Performance

`repository_gc_scale` (10,000 history changes, width 10, 11 samples + 2 warmups, **9 reps, rotated arm order, with a null control** = the base binary run a second time under a different label):

| backend | metric | base | null | cand | null Δ | cand Δ |
|---|---|---|---|---|---|---|
| rocksdb | GC plan p50 | 2.4 ms | 2.4 ms | 2.4 ms | +0.1% | +0.1% |
| rocksdb | GC plan p95 | 2.5 ms | 2.5 ms | 2.5 ms | +0.1% | +0.3% |
| rocksdb | setup seed_ms | 1522 | 1420 | 1543 | −6.7% | +1.4% |
| rocksdb | settled backend bytes | 2,511,890 | 2,510,141 | 2,510,549 | −0.1% | −0.1% |
| slatedb | GC plan p50 | 8.8 ms | 8.9 ms | 8.9 ms | +0.3% | +1.1% |
| slatedb | GC plan p95 | 8.9 ms | 8.9 ms | 9.0 ms | +0.2% | +1.0% |
| slatedb | settled backend bytes | 2,568,464 | 2,568,357 | 2,567,655 | −0.0% | −0.0% |

The null control moved +0.3% on slatedb, so the ~0.8pp residual on cand is at the edge of the noise band and far inside the 5% threshold. Reclaim on this fixture is **identical** across all three arms: `swept_commits` 61, `live_commits` 4, `swept_standalone_changes` 61, `staged_deletes` 366, `staged_puts` 1.

Caveat, stated plainly: on this fixture the generation sweep contributes **zero** extra deletes, because the branch-deletion delta sits past the 64-row consumption window. `repository_gc_scale` therefore does not exercise the new path — it is a pure no-regression guard. The new path's cost is measured by `delete_gc_1pct`, where reclaiming 1,002 extra rows leaves `scenario_ms` flat at −0.3% (rocksdb) / +0.1% (slatedb) across 9 reps.

`delta_physical_bytes` on slatedb at 100k rose +5.4% in the 9-rep matrix while logical bytes fell 98.3%. That is LSM tombstone accounting: `storage.flush()` runs before the sample, so deletes are counted before compaction can reclaim them. rocksdb, which compacts differently, shows −68.9% on the same corpus.

## What this change does NOT fix

**`gc.reachability_delta.v1` never drains.** Reproduced independently here with `expv_blind_space_growth` (PR #1317): 1,000 commits → 1,001 rows / 427,030 value bytes, byte-identical after 3 GC rounds, with `commit_state_manifest` stuck at 1,002 rows and `tree_chunk` at 283 the whole time.

The mechanism is **not** head-of-line blocking and **not** the 64-row consumption cap. A new ignored test, `ordinary_gc_drains_the_reachability_queue_past_a_pinned_head`, reproduces it in 0.09 s: 24 commits plus a checkpoint, then 8 consecutive ordinary sweeps drain **0 of 25** deltas. Instrumenting `retirement_is_proven` shows `active_authority_ids.contains(old_root)` is true for **every** delta, so each is blocked on its own merits and there is nothing behind the block to unblock.

The cause is in `load_authenticated_serving_dependency_closure`: every live current-state scoped-range part with `source_kind` 0 or 2 inserts its **owner commit** into `physical_authorities`. In an append-only workload that is every commit, so no `old_root` is ever retirable — even after a checkpoint releases the undo interval. This is *correct* retention (the commit's delta is where the live row's bytes are); the defect is that the ledger stores 439 B per publication to record a fact that is derivable from the manifests.

Fixing it therefore requires either compacting live current state so old commits stop owning live parts (a `tracked_state` change), or deriving retirement candidates from the manifests instead of keeping a per-publication ledger (a GC redesign). Both are larger than this change. The reproduction is kept and `#[ignore]`d rather than deleted.

Two related Θ(total commits) terms on the GC path, also unfixed here: `authenticated_control_commit_reachability` walks the entire first-parent chain when a branch has no checkpoint (`floor = None`), and `collect_all_reachability_checkpoint_roots` folds the whole queue with `limit = None`, BLAKE3-verifying every row on every sweep.

**JSON payloads are never reclaimed in production.** `stage_delete_refs` is called only from the `#[cfg(test)]` oracle; production returns `json_payloads: Vec::new()`. This is *not* dead wiring that can simply be reconnected, because the JSON store has no refcount by design (`json_store/context.rs:20-23`) and a sweep needs the **complete** live-payload set — the Θ(repository) walk the incremental collector exists to avoid. Payloads ≤ `JSON_INLINE_MAX_BYTES` (1024) are inlined, so the leak is confined to workspaces with >1 KiB values; `space_growth` shows `json_store.json` flat at 3 rows / 0.0 bytes per commit for small-value tracked workloads. Recommend queueing separately.

Safety note for whoever picks that up: **the reachability walk sees only ref→payload edges.** Every live reference is discoverable from change records and current-state data parts. It would not be sound for any scheme introducing payload→payload edges (delta encoding, evaluated and rejected) — a swept base would be deleted while its dependant lived. Extending the walk is a precondition for any such edge.

## Layout invariants checklist

1. **Single authority.** No new authority. One is *deleted*: the tree-sweep collector and its three spaces. The generation sweeper adds no retention metadata — it derives liveness from the branch controls the pass already reads.
2. **Commit canonicality.** Untouched. No parallel graph added. (The pre-existing reachability-delta ledger arguably *is* one; documented above, not changed here.)
3. **Derived views are caches.** Strengthened. Branch generations are derived serving caches that previously could never be evicted; they now are.
4. **Atomic publication.** Unchanged. Generation retirement is staged into the same GC write set, under the same branch-control preconditions and queue CAS.
5. **GC from refs.** Improved: 3 reachability implementations → 2, one of which is `#[cfg(test)]`-only. Generation reclamation now starts from refs (branch controls) instead of a dead scan-based sweeper. Three spaces of disconnected retention metadata deleted. Not fully satisfied: the retirement ledger remains.
6. **SQL reads canonical records.** Unaffected.

## Gate

`cargo check --workspace`, `cargo clippy --workspace --all-targets --all-features -- -D warnings`, and `cargo test -p lix --all-features` (2074 lib + 830 integration, 0 failures) all green on `ryzen-9950x-V`.

The stricter `--all-features` gate caught a real assertion that plain `cargo test -p lix` misses: `repository_gc_benchmark_plans_unreachable_nodes_without_mutating` now sees the 102 generation rows the pass reclaims, and its `delete_counts_by_space` and key-arena assertions are updated accordingly.
