### PR TITLE
fix(qualification): run movie workspace actors as independent tasks; fix accounting-mode locator panic

### DIFF
--- a/packages/engine-benchmarks/MOVIE_WORKSPACE.md
+++ b/packages/engine-benchmarks/MOVIE_WORKSPACE.md
@@ -31,6 +31,61 @@ this workload, so the larger CAS unit did not improve ingest and slightly
 regressed save p95. The engine therefore retains 1 MiB chunks; remote
 object-store latency profiles may justify revisiting the choice.
 
+## Each actor runs as its own task
+
+Ingest, project saves and the two proxy streams are spawned as four separate
+tokio tasks. They were previously branches of a single `tokio::join!` future,
+which put all four on one task: a slow write in any branch could not overlap a
+playback read, and the resulting scheduling delay was charged to the playback
+deadline.
+
+That is not a hypothetical. On SlateDB one project save per run — the save at
+t = 1200 ms — takes ~110 ms while every other save takes under 8 ms. Joined on
+one task, that save delayed both playback wake-ups by 69-70 ms against an 80 ms
+budget, and `stream_N_late` flipped to 1 whenever concurrent ingest pushed the
+delay past 80 ms. The proxy reads themselves were never slow: p99 5.6 ms, max
+5.9 ms, against the same 80 ms budget.
+
+The null control (`slatedb_movie_workspace_playback_control`, identical
+schedule with the ingest removed) reproduced the same 69-70 ms delay in 6 of 6
+stream-runs, which is what identified the save rather than ingest interference
+as the cause. `LIX_MOVIE_PLAYBACK_TRACE=1` prints per-sample read latency, per
+save latency, upload-window completion times, and a spawned runtime watchdog
+whose worst gap stayed at 2.0-2.6 ms throughout — proving the executor was not
+starved and the stall was confined to the joined task.
+
+The ~110 ms SlateDB save and the ~200 ms fixed cost of every
+`resumable_initial_write` in `large_blob_updates` are unexplained write-path
+stalls, tracked separately. Neither is a read-path defect.
+
+## Diagnostic environment variables
+
+None of these are set by the qualification itself.
+
+| Variable | Effect |
+| --- | --- |
+| `LIX_MOVIE_PLAYBACK_TRACE=1` | per-sample playback/save traces, upload-window times, runtime watchdog |
+| `LIX_MOVIE_WORKER_THREADS=N` | runtime width; the qualification profile is 4 |
+| `LIX_MOVIE_STREAM_SAMPLES=N` | playback sample count, for looking past the 40-sample window |
+| `LIX_MOVIE_UPLOAD_CONCURRENCY=N` | upload parts in flight, 1-4 |
+
+## First-window upload contention
+
+`chunk_hash_bytes_including_retries` measures payload actually hashed,
+including optimistic retries, so re-hashed parts are visible directly. For the
+512 MiB timed ingest it is exactly `512 MiB + (concurrency - 1) x 16 MiB`:
+
+| Upload concurrency | Hashed bytes | Re-hashed | Ingest |
+| ---: | ---: | ---: | ---: |
+| 1 | 536,870,912 (512 MiB) | 0 | 153.1 MiB/s |
+| 2 | 553,648,128 (528 MiB) | 16 MiB | 152.8 MiB/s |
+| 4 | 587,202,560 (560 MiB) | 48 MiB | 153.1 MiB/s |
+
+Exactly one part per extra in-flight part is re-hashed, and only in the first
+window, where `UPLOAD_STATE_SPACE` is absent for every concurrent part and the
+losers retry. It is bounded wasted work, not a scaling term, and ingest on this
+local-filesystem profile does not move with concurrency at all.
+
 ## Artificial object-store latency
 
 The latency qualification wraps the local object store and delays every

--- a/packages/engine-benchmarks/benches/large_blob_updates.rs
+++ b/packages/engine-benchmarks/benches/large_blob_updates.rs
@@ -444,7 +444,7 @@ where
     }
 
     async fn space_accounting(&self, space: SpaceId) -> SpaceAccounting {
-        space_accounting(&self.storage, space).await
+        space_accounting(&self.storage, space, self.workload.operation).await
     }
 }
 
@@ -515,12 +515,25 @@ struct SpaceAccounting {
     value_bytes: u64,
 }
 
-async fn space_accounting<S>(storage: &S, space: SpaceId) -> SpaceAccounting
+/// A physical space id has exactly one value semantics per fixture, and the
+/// accounting scan must use the one the operation under test actually wrote
+/// with. `raw_backend_initial_write` deliberately bypasses the binary CAS and
+/// stores plain payload bytes in the payload space, so scanning that space as
+/// `immutable` would hand raw payload bytes to the immutable-locator decoder
+/// and fail with `Corruption("immutable segment locator is invalid")`.
+async fn space_accounting<S>(
+    storage: &S,
+    space: SpaceId,
+    operation: Operation,
+) -> SpaceAccounting
 where
     S: Storage,
 {
-    let space = if space == PAYLOAD_SPACE {
+    let payload_is_immutable = !matches!(operation, Operation::RawBackendInitialWrite);
+    let space = if space == PAYLOAD_SPACE && payload_is_immutable {
         StorageSpace::immutable(space, "benchmark.binary_cas_payload")
+    } else if space == PAYLOAD_SPACE {
+        StorageSpace::mutable(space, "bench.raw_payload")
     } else {
         StorageSpace::mutable(space, "benchmark.binary_cas_metadata")
     };

--- a/packages/engine-benchmarks/tests/movie_workspace_qualification.rs
+++ b/packages/engine-benchmarks/tests/movie_workspace_qualification.rs
@@ -62,22 +62,59 @@ async fn slatedb_resumes_media_upload_after_engine_restart() {
     finish_restart_upload(storage).await;
 }
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
-#[ignore = "release qualification benchmark"]
-async fn rocksdb_movie_workspace_interference() {
-    let _qualification_guard = QUALIFICATION_LOCK.lock().await;
-    let temp = tempfile::tempdir().expect("create RocksDB movie fixture");
-    let storage = RocksDB::open(temp.path().join("database")).expect("open RocksDB fixture");
-    qualify("rocksdb", storage).await;
+/// The qualification models a desktop editor: a small fixed worker pool that
+/// media ingest, project saves and playback all share. `LIX_MOVIE_WORKER_THREADS`
+/// exists only so an investigation can separate executor starvation from engine
+/// latency; the qualification itself always runs the four-thread profile.
+fn qualification_runtime() -> tokio::runtime::Runtime {
+    let worker_threads = std::env::var("LIX_MOVIE_WORKER_THREADS")
+        .ok()
+        .and_then(|value| value.parse::<usize>().ok())
+        .filter(|value| *value > 0)
+        .unwrap_or(4);
+    tokio::runtime::Builder::new_multi_thread()
+        .worker_threads(worker_threads)
+        .enable_all()
+        .build()
+        .expect("build movie qualification runtime")
 }
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+#[test]
 #[ignore = "release qualification benchmark"]
-async fn slatedb_movie_workspace_interference() {
-    let _qualification_guard = QUALIFICATION_LOCK.lock().await;
-    let temp = tempfile::tempdir().expect("create SlateDB movie fixture");
-    let storage = SlateDB::open(temp.path().join("database")).expect("open SlateDB fixture");
-    qualify("slatedb", storage).await;
+fn rocksdb_movie_workspace_interference() {
+    qualification_runtime().block_on(async {
+        let _qualification_guard = QUALIFICATION_LOCK.lock().await;
+        let temp = tempfile::tempdir().expect("create RocksDB movie fixture");
+        let storage = RocksDB::open(temp.path().join("database")).expect("open RocksDB fixture");
+        qualify("rocksdb", storage).await;
+    });
+}
+
+#[test]
+#[ignore = "release qualification benchmark"]
+fn slatedb_movie_workspace_interference() {
+    qualification_runtime().block_on(async {
+        let _qualification_guard = QUALIFICATION_LOCK.lock().await;
+        let temp = tempfile::tempdir().expect("create SlateDB movie fixture");
+        let storage = SlateDB::open(temp.path().join("database")).expect("open SlateDB fixture");
+        qualify("slatedb", storage).await;
+    });
+}
+
+/// Null control for the playback assertions: identical schedule, sessions and
+/// fixture, with the concurrent 512 MiB ingest removed. Whatever scheduling
+/// jitter this run shows is the floor below which a playback deadline cannot
+/// be attributed to ingest interference.
+#[test]
+#[ignore = "playback null control"]
+fn slatedb_movie_workspace_playback_control() {
+    qualification_runtime().block_on(async {
+        let _qualification_guard = QUALIFICATION_LOCK.lock().await;
+        let temp = tempfile::tempdir().expect("create SlateDB control fixture");
+        let storage = SlateDB::open(temp.path().join("database")).expect("open SlateDB fixture");
+        let part_concurrency = upload_concurrency();
+        qualify_case("slatedb-control", storage, part_concurrency, None, None, false).await;
+    });
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
@@ -187,20 +224,24 @@ async fn qualify_delayed_slatedb(latency_ms: u64, upload_concurrency: usize) -> 
         upload_concurrency,
         Some((delayed, Duration::from_millis(latency_ms))),
         Some(counters),
+        true,
     )
     .await
+}
+
+fn upload_concurrency() -> usize {
+    std::env::var("LIX_MOVIE_UPLOAD_CONCURRENCY")
+        .ok()
+        .and_then(|value| value.parse::<usize>().ok())
+        .filter(|value| (1..=4).contains(value))
+        .unwrap_or(4)
 }
 
 async fn qualify<S>(backend: &str, storage: S)
 where
     S: Storage + Clone + Send + Sync + 'static,
 {
-    let part_concurrency = std::env::var("LIX_MOVIE_UPLOAD_CONCURRENCY")
-        .ok()
-        .and_then(|value| value.parse::<usize>().ok())
-        .filter(|value| (1..=4).contains(value))
-        .unwrap_or(4);
-    qualify_case(backend, storage, part_concurrency, None, None).await;
+    qualify_case(backend, storage, upload_concurrency(), None, None, true).await;
 }
 
 #[derive(Clone, Copy, Debug)]
@@ -218,6 +259,7 @@ async fn qualify_case<S>(
     part_concurrency: usize,
     artificial_latency: Option<(LatencyObjectStore, Duration)>,
     io_counters: Option<SlateDBIoCounters>,
+    run_ingest: bool,
 ) -> Qualification
 where
     S: Storage + Clone + Send + Sync + 'static,
@@ -255,6 +297,7 @@ where
         PROXY_BYTES,
         1,
         part_concurrency,
+        None,
     )
     .await;
     if let Some((store, latency)) = &artificial_latency {
@@ -293,15 +336,18 @@ where
     let started = tokio::time::Instant::now();
     let ingest_started = Instant::now();
     let ingest_future = async {
-        upload(
-            &ingest,
-            "concurrent-ingest",
-            "/media/import.mov",
-            INGEST_BYTES,
-            2,
-            part_concurrency,
-        )
-        .await;
+        if run_ingest {
+            upload(
+                &ingest,
+                "concurrent-ingest",
+                "/media/import.mov",
+                INGEST_BYTES,
+                2,
+                part_concurrency,
+                std::env::var_os("LIX_MOVIE_PLAYBACK_TRACE").is_some().then_some(started),
+            )
+            .await;
+        }
         ingest_started.elapsed()
     };
     let save_future = project_saves(saver, started);
@@ -339,14 +385,16 @@ where
         io.cache_filesystem_removes,
         io.writer_gate_wait_nanos as f64 / 1_000_000.0,
     );
-    assert!(save_p95 < Duration::from_millis(500));
-    assert_eq!(first_late, 0, "first 100 Mbit/s stream fell behind");
-    assert_eq!(second_late, 0, "second 100 Mbit/s stream fell behind");
-    assert_eq!(structural.temporary_manifest_leaf_rows, 32);
-    assert_eq!(structural.legacy_equivalent_chunk_rows, 512);
-    assert_eq!(row_reduction, 16.0);
-    assert_eq!(projected_chunk_rows / projected_leaf_rows, 16);
-    assert!(structural.chunk_payload_hash_bytes >= INGEST_BYTES as u64);
+    if run_ingest {
+        assert!(save_p95 < Duration::from_millis(500));
+        assert_eq!(first_late, 0, "first 100 Mbit/s stream fell behind");
+        assert_eq!(second_late, 0, "second 100 Mbit/s stream fell behind");
+        assert_eq!(structural.temporary_manifest_leaf_rows, 32);
+        assert_eq!(structural.legacy_equivalent_chunk_rows, 512);
+        assert_eq!(row_reduction, 16.0);
+        assert_eq!(projected_chunk_rows / projected_leaf_rows, 16);
+        assert!(structural.chunk_payload_hash_bytes >= INGEST_BYTES as u64);
+    }
     Qualification {
         ingest_mib_s,
         save_p95,
@@ -421,6 +469,7 @@ async fn upload<S>(
     total_bytes: usize,
     seed: u64,
     part_concurrency: usize,
+    schedule_start: Option<tokio::time::Instant>,
 ) where
     S: Storage + Clone + Send + Sync + 'static,
 {
@@ -448,6 +497,12 @@ async fn upload<S>(
             .max()
             .expect("upload window contains a part");
         assert_eq!(acknowledged, window_end as u64);
+        if let Some(schedule_start) = schedule_start {
+            println!(
+                "movie_upload_window,upload_id={upload_id},window_end={window_end},at_ms={:.3}",
+                (tokio::time::Instant::now() - schedule_start).as_secs_f64() * 1000.0,
+            );
+        }
         window_start = window_end;
     }
 }

--- a/packages/engine-benchmarks/tests/movie_workspace_qualification.rs
+++ b/packages/engine-benchmarks/tests/movie_workspace_qualification.rs
@@ -334,6 +334,26 @@ where
     );
 
     let started = tokio::time::Instant::now();
+    // Independent runtime watchdog: an empty task that only sleeps. Any gap it
+    // records is executor-level, because it touches neither storage nor a lock.
+    let watchdog_worst = Arc::new(AtomicU64::new(0));
+    let watchdog = std::env::var_os("LIX_MOVIE_PLAYBACK_TRACE")
+        .is_some()
+        .then(|| {
+            let worst = watchdog_worst.clone();
+            tokio::spawn(async move {
+                let tick = Duration::from_millis(5);
+                let mut next = started + tick;
+                loop {
+                    tokio::time::sleep_until(next).await;
+                    let gap = (tokio::time::Instant::now() - next).as_micros() as u64;
+                    let elapsed_ms = (next - started).as_millis() as u64;
+                    let packed = (gap << 20) | elapsed_ms.min((1 << 20) - 1);
+                    worst.fetch_max(packed, Ordering::Relaxed);
+                    next += tick;
+                }
+            })
+        });
     let ingest_started = Instant::now();
     let ingest_future = async {
         if run_ingest {
@@ -356,6 +376,15 @@ where
     let (ingest_elapsed, mut save_latencies, first_late, second_late) =
         tokio::join!(ingest_future, save_future, first_playback, second_playback);
 
+    if let Some(watchdog) = watchdog {
+        watchdog.abort();
+        let packed = watchdog_worst.load(Ordering::Relaxed);
+        println!(
+            "movie_runtime_watchdog,worst_gap_ms={:.3},at_ms={}",
+            (packed >> 20) as f64 / 1000.0,
+            packed & ((1 << 20) - 1),
+        );
+    }
     save_latencies.sort_unstable();
     let save_p95 = save_latencies[save_latencies.len() * 95 / 100];
     let ingest_mib_s = INGEST_BYTES as f64 / (1024.0 * 1024.0) / ingest_elapsed.as_secs_f64();
@@ -517,9 +546,14 @@ where
     S: Storage + Clone + Send + Sync + 'static,
 {
     let trace = std::env::var_os("LIX_MOVIE_PLAYBACK_TRACE").is_some();
+    let samples = std::env::var("LIX_MOVIE_STREAM_SAMPLES")
+        .ok()
+        .and_then(|value| value.parse::<usize>().ok())
+        .filter(|value| *value > 0)
+        .unwrap_or(STREAM_SAMPLES);
     let mut late = 0;
-    let mut read_latencies = Vec::with_capacity(STREAM_SAMPLES);
-    for sample in 0..STREAM_SAMPLES {
+    let mut read_latencies = Vec::with_capacity(samples);
+    for sample in 0..samples {
         let deadline = schedule_start + PLAYBACK_READ_AHEAD + STREAM_PERIOD * (sample as u32 + 1);
         let offset = (initial_offset + sample as u64 * STREAM_READ_BYTES)
             % (PROXY_BYTES as u64 - STREAM_READ_BYTES);

--- a/packages/engine-benchmarks/tests/movie_workspace_qualification.rs
+++ b/packages/engine-benchmarks/tests/movie_workspace_qualification.rs
@@ -305,8 +305,8 @@ where
         ingest_started.elapsed()
     };
     let save_future = project_saves(saver, started);
-    let first_playback = playback(first_reader, started, 0);
-    let second_playback = playback(second_reader, started, PROXY_BYTES as u64 / 2);
+    let first_playback = playback(first_reader, started, 0, 1);
+    let second_playback = playback(second_reader, started, PROXY_BYTES as u64 / 2, 2);
     let (ingest_elapsed, mut save_latencies, first_late, second_late) =
         tokio::join!(ingest_future, save_future, first_playback, second_playback);
 
@@ -456,15 +456,19 @@ async fn playback<S>(
     session: Arc<SessionContext<S>>,
     schedule_start: tokio::time::Instant,
     initial_offset: u64,
+    stream: usize,
 ) -> usize
 where
     S: Storage + Clone + Send + Sync + 'static,
 {
+    let trace = std::env::var_os("LIX_MOVIE_PLAYBACK_TRACE").is_some();
     let mut late = 0;
+    let mut read_latencies = Vec::with_capacity(STREAM_SAMPLES);
     for sample in 0..STREAM_SAMPLES {
         let deadline = schedule_start + PLAYBACK_READ_AHEAD + STREAM_PERIOD * (sample as u32 + 1);
         let offset = (initial_offset + sample as u64 * STREAM_READ_BYTES)
             % (PROXY_BYTES as u64 - STREAM_READ_BYTES);
+        let read_started = tokio::time::Instant::now();
         let read = session
             .read_file_content(
                 "/media/proxy.mov".to_owned(),
@@ -473,13 +477,42 @@ where
             .await
             .expect("read proxy range")
             .expect("proxy exists");
+        let finished = tokio::time::Instant::now();
+        let read_elapsed = finished - read_started;
+        read_latencies.push(read_elapsed);
         assert_eq!(read.content().len(), STREAM_READ_BYTES as usize);
-        if tokio::time::Instant::now() > deadline {
+        let is_late = finished > deadline;
+        if trace {
+            println!(
+                "movie_playback_sample,stream={stream},sample={sample},offset={offset},read_ms={:.3},slack_ms={:.3},late={is_late}",
+                read_elapsed.as_secs_f64() * 1000.0,
+                if is_late {
+                    -((finished - deadline).as_secs_f64() * 1000.0)
+                } else {
+                    (deadline - finished).as_secs_f64() * 1000.0
+                },
+            );
+        }
+        if is_late {
             late += 1;
         } else {
             tokio::time::sleep_until(deadline).await;
         }
     }
+    let mut sorted = read_latencies.clone();
+    sorted.sort_unstable();
+    let pick = |num: usize| sorted[(sorted.len() * num / 100).min(sorted.len() - 1)];
+    println!(
+        "movie_playback_latency,stream={stream},samples={},late={late},read_min_ms={:.3},read_p50_ms={:.3},read_p90_ms={:.3},read_p95_ms={:.3},read_p99_ms={:.3},read_max_ms={:.3},budget_ms={:.3}",
+        sorted.len(),
+        sorted[0].as_secs_f64() * 1000.0,
+        pick(50).as_secs_f64() * 1000.0,
+        pick(90).as_secs_f64() * 1000.0,
+        pick(95).as_secs_f64() * 1000.0,
+        pick(99).as_secs_f64() * 1000.0,
+        sorted[sorted.len() - 1].as_secs_f64() * 1000.0,
+        STREAM_PERIOD.as_secs_f64() * 1000.0,
+    );
     late
 }
 

--- a/packages/engine-benchmarks/tests/movie_workspace_qualification.rs
+++ b/packages/engine-benchmarks/tests/movie_workspace_qualification.rs
@@ -354,8 +354,14 @@ where
                 }
             })
         });
+    // Ingest, project saves and the two proxy streams are four independent
+    // actors in the workload this qualification claims to model, so each one
+    // gets its own task. Driving them as branches of a single `tokio::join!`
+    // future put all four on one task: a slow write in any branch could not
+    // overlap a playback read, and the resulting delay was scored against the
+    // playback deadline even though the read itself had not started.
     let ingest_started = Instant::now();
-    let ingest_future = async {
+    let ingest_task = tokio::spawn(async move {
         if run_ingest {
             upload(
                 &ingest,
@@ -364,17 +370,28 @@ where
                 INGEST_BYTES,
                 2,
                 part_concurrency,
-                std::env::var_os("LIX_MOVIE_PLAYBACK_TRACE").is_some().then_some(started),
+                std::env::var_os("LIX_MOVIE_PLAYBACK_TRACE")
+                    .is_some()
+                    .then_some(started),
             )
             .await;
         }
         ingest_started.elapsed()
-    };
-    let save_future = project_saves(saver, started);
-    let first_playback = playback(first_reader, started, 0, 1);
-    let second_playback = playback(second_reader, started, PROXY_BYTES as u64 / 2, 2);
-    let (ingest_elapsed, mut save_latencies, first_late, second_late) =
-        tokio::join!(ingest_future, save_future, first_playback, second_playback);
+    });
+    let save_task = tokio::spawn(project_saves(saver, started));
+    let first_task = tokio::spawn(playback(first_reader, started, 0, 1));
+    let second_task = tokio::spawn(playback(
+        second_reader,
+        started,
+        PROXY_BYTES as u64 / 2,
+        2,
+    ));
+    let (ingest_elapsed, mut save_latencies, first_late, second_late) = tokio::join!(
+        async { ingest_task.await.expect("ingest task") },
+        async { save_task.await.expect("project save task") },
+        async { first_task.await.expect("first playback task") },
+        async { second_task.await.expect("second playback task") },
+    );
 
     if let Some(watchdog) = watchdog {
         watchdog.abort();

--- a/packages/engine-benchmarks/tests/movie_workspace_qualification.rs
+++ b/packages/engine-benchmarks/tests/movie_workspace_qualification.rs
@@ -86,7 +86,9 @@ fn rocksdb_movie_workspace_interference() {
         let _qualification_guard = QUALIFICATION_LOCK.lock().await;
         let temp = tempfile::tempdir().expect("create RocksDB movie fixture");
         let storage = RocksDB::open(temp.path().join("database")).expect("open RocksDB fixture");
-        qualify("rocksdb", storage).await;
+        qualify("rocksdb", storage.clone()).await;
+        storage.flush().expect("flush RocksDB fixture");
+        report_settled_bytes("rocksdb", temp.path());
     });
 }
 
@@ -97,8 +99,61 @@ fn slatedb_movie_workspace_interference() {
         let _qualification_guard = QUALIFICATION_LOCK.lock().await;
         let temp = tempfile::tempdir().expect("create SlateDB movie fixture");
         let storage = SlateDB::open(temp.path().join("database")).expect("open SlateDB fixture");
-        qualify("slatedb", storage).await;
+        qualify("slatedb", storage.clone()).await;
+        storage.flush().await.expect("flush SlateDB fixture");
+        report_settled_bytes("slatedb", temp.path());
     });
+}
+
+/// Bytes the workload leaves on disk once the writer has flushed. Reported
+/// per top-level directory so an arm comparison can separate LSM state from
+/// the immutable value segments that carry the media payload.
+fn report_settled_bytes(backend: &str, root: &std::path::Path) {
+    fn directory_bytes(path: &std::path::Path) -> u64 {
+        let Ok(metadata) = std::fs::symlink_metadata(path) else {
+            return 0;
+        };
+        if metadata.is_file() {
+            return metadata.len();
+        }
+        if !metadata.is_dir() {
+            return 0;
+        }
+        std::fs::read_dir(path)
+            .map(|entries| {
+                entries
+                    .map(|entry| match entry {
+                        Ok(entry) => directory_bytes(&entry.path()),
+                        Err(_) => 0,
+                    })
+                    .sum()
+            })
+            .unwrap_or(0)
+    }
+    let database = root.join("database");
+    let mut breakdown = Vec::new();
+    if let Ok(entries) = std::fs::read_dir(database.join("db")) {
+        let mut named = entries
+            .filter_map(Result::ok)
+            .map(|entry| {
+                (
+                    entry.file_name().to_string_lossy().into_owned(),
+                    directory_bytes(&entry.path()),
+                )
+            })
+            .collect::<Vec<_>>();
+        named.sort();
+        breakdown = named;
+    }
+    println!(
+        "movie_settled_bytes,backend={backend},total_bytes={},{}",
+        directory_bytes(&database),
+        breakdown
+            .iter()
+            .map(|(name, bytes)| format!("{name}_bytes={bytes}"))
+            .collect::<Vec<_>>()
+            .join(","),
+    );
 }
 
 /// Null control for the playback assertions: identical schedule, sessions and

--- a/packages/engine-benchmarks/tests/movie_workspace_qualification.rs
+++ b/packages/engine-benchmarks/tests/movie_workspace_qualification.rs
@@ -612,9 +612,12 @@ async fn project_saves<S>(
 where
     S: Storage + Clone + Send + Sync + 'static,
 {
+    let trace = std::env::var_os("LIX_MOVIE_PLAYBACK_TRACE").is_some();
     let mut timings = Vec::with_capacity(SAVE_SAMPLES);
     for sample in 0..SAVE_SAMPLES {
-        tokio::time::sleep_until(schedule_start + STREAM_PERIOD * sample as u32).await;
+        let scheduled = schedule_start + STREAM_PERIOD * sample as u32;
+        tokio::time::sleep_until(scheduled).await;
+        let wake_delay = tokio::time::Instant::now() - scheduled;
         let payload = format!(
             "{{\"timelineRevision\":{sample},\"playhead\":{}}}",
             sample * 24
@@ -624,7 +627,16 @@ where
             .upsert_file_content("/project/edit.json".to_owned(), payload.into_bytes().into())
             .await
             .expect("save project file");
-        timings.push(started.elapsed());
+        let elapsed = started.elapsed();
+        if trace {
+            println!(
+                "movie_save_sample,sample={sample},at_ms={:.3},wake_delay_ms={:.3},save_ms={:.3}",
+                (scheduled - schedule_start).as_secs_f64() * 1000.0,
+                wake_delay.as_secs_f64() * 1000.0,
+                elapsed.as_secs_f64() * 1000.0,
+            );
+        }
+        timings.push(elapsed);
     }
     timings
 }

--- a/packages/engine-benchmarks/tests/movie_workspace_qualification.rs
+++ b/packages/engine-benchmarks/tests/movie_workspace_qualification.rs
@@ -4,9 +4,11 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::{Duration, Instant};
 
+use std::panic::AssertUnwindSafe;
+
 use async_trait::async_trait;
 use bytes::Bytes;
-use futures_util::StreamExt;
+use futures_util::{FutureExt, StreamExt};
 use futures_util::future::join_all;
 use futures_util::stream::{self, BoxStream};
 use lix::FILE_UPLOAD_PART_BYTES;
@@ -86,9 +88,17 @@ fn rocksdb_movie_workspace_interference() {
         let _qualification_guard = QUALIFICATION_LOCK.lock().await;
         let temp = tempfile::tempdir().expect("create RocksDB movie fixture");
         let storage = RocksDB::open(temp.path().join("database")).expect("open RocksDB fixture");
-        qualify("rocksdb", storage.clone()).await;
+        // Settled bytes are part of the measurement, so they are reported even
+        // when an assertion above them fails — otherwise an arm that trips a
+        // structural assertion silently contributes no byte number.
+        let outcome = AssertUnwindSafe(qualify("rocksdb", storage.clone()))
+            .catch_unwind()
+            .await;
         storage.flush().expect("flush RocksDB fixture");
         report_settled_bytes("rocksdb", temp.path());
+        if let Err(panic) = outcome {
+            std::panic::resume_unwind(panic);
+        }
     });
 }
 
@@ -99,9 +109,14 @@ fn slatedb_movie_workspace_interference() {
         let _qualification_guard = QUALIFICATION_LOCK.lock().await;
         let temp = tempfile::tempdir().expect("create SlateDB movie fixture");
         let storage = SlateDB::open(temp.path().join("database")).expect("open SlateDB fixture");
-        qualify("slatedb", storage.clone()).await;
+        let outcome = AssertUnwindSafe(qualify("slatedb", storage.clone()))
+            .catch_unwind()
+            .await;
         storage.flush().await.expect("flush SlateDB fixture");
         report_settled_bytes("slatedb", temp.path());
+        if let Err(panic) = outcome {
+            std::panic::resume_unwind(panic);
+        }
     });
 }
 


### PR DESCRIPTION
Clears the two blockers that kept `slatedb_movie_workspace_interference` from
running to completion. Both were harness defects; neither the SlateDB read path
nor the immutable segment format is at fault.

## Blocker 1 — playback assertion at `movie_workspace_qualification.rs:343`

**Verdict: harness artifact, triggered by a real SlateDB write stall. Not a
read-path latency defect, and the 80 ms threshold is not wrong.**

The qualification drove ingest, project saves and both proxy streams as four
branches of a single `tokio::join!` future — one task. A slow write in any
branch could not overlap a playback read, and the resulting scheduling delay
was charged to the playback deadline.

Measured on `ryzen-9950x-I`, `LIX_MOVIE_PLAYBACK_TRACE=1`:

| | value |
| --- | --- |
| proxy read latency, all arms | p50 0.3-3.8 ms, p95 5.5 ms, p99 5.6 ms, **max 5.9 ms** |
| playback budget | 80 ms |
| delay between timer deadline and the read starting, at sample 3 | **69.0-101.6 ms** |
| spawned runtime watchdog, worst gap | **2.0-2.6 ms** |

The read never came close to the budget. The lateness was entirely wake-up
delay, and the watchdog — a spawned task that only sleeps — was scheduled
normally throughout, so the executor was not starved.

The cause is one project save. On SlateDB the save at t = 1200 ms takes
**109-110 ms** while every other save takes under 8 ms:

```
movie_save_sample,sample=15,at_ms=1200.000,wake_delay_ms=1.305,save_ms=110.291
movie_save_sample,sample=15,at_ms=1200.000,wake_delay_ms=1.773,save_ms=109.113
```

Joined on one task, that save blocked both playback branches for ~69 ms.
The **null control** added here (`slatedb_movie_workspace_playback_control`,
identical schedule with the 512 MiB ingest removed) reproduced 68.0-70.6 ms
stalls at the same sample in **6 of 6** stream-runs — with no ingest at all.
Ingest interference only added jitter on top (69-102 ms), which is why the
assertion failed about a third of the time rather than always.

Nothing was relaxed. Each actor now gets its own task, which is the workload
the qualification claims to model. The assertion now measures playback.

Discriminators run before the fix (3 reps each, rotated order, wake delay =
`80 ms - slack - read_ms`):

| arm | mean | max | >40 ms | read max | late |
| --- | ---: | ---: | ---: | ---: | ---: |
| slatedb w4 | 6.11 | 95.6 | 6 | 5.73 | 2 |
| slatedb w8 | 5.69 | 101.7 | 6 | 5.71 | 1 |
| slatedb w16 | 6.16 | 99.0 | 6 | 5.92 | 2 |
| slatedb w4, upload concurrency 1 | 5.31 | 76.4 | 6 | 5.56 | 0 |
| **slatedb null control (no ingest)** | **5.16** | **70.4** | **6** | **5.56** | **0** |
| rocksdb w4 | 2.57 | **6.3** | **0** | 2.05 | 0 |

Six stalls per arm = 3 reps x 2 streams: exactly one per stream per run, in
every SlateDB arm including the no-ingest control, and never on RocksDB. Extra
worker threads did not help because it was one task, not a thread shortage.

After the fix, 5 reps per backend, all passing:

| backend | late reads | save p95 | read max | ingest |
| --- | ---: | ---: | ---: | ---: |
| slatedb | 0/0 x5 | 2.0-2.6 ms | 5.8 ms | 153.2-153.5 MiB/s |
| rocksdb | 0/0 x5 | 36.4-44.4 ms | 1.8 ms | 733-744 MiB/s |

SlateDB ingest also improved 148.3-148.7 -> 153.2-153.5 MiB/s (+3.3%) and save
p95 fell from 2.8-26.9 ms to 2.0-2.6 ms, because the ingest and save tasks no
longer wait behind playback sleeps.

## Blocker 2 — `raw_backend_initial_write` accounting-mode panic

**Verdict: not corruption. An accounting-mode-only read that declared the wrong
value semantics for a space it did not write.**

`raw_backend_initial_write` is the null control: it deliberately bypasses the
binary CAS and writes plain payload bytes with
`StorageSpace::mutable(SpaceId(0x0005_0003), "bench.raw_payload")`. But
`0x0005_0003` is `BINARY_CAS_CHUNK_NAMESPACE`, which the engine declares
**immutable** (`binary_cas/kv.rs:55`), and `space_accounting` hardcoded
`StorageSpace::immutable` for that id regardless of the operation under test.

Scanning it as immutable sends every row through
`hydrate_immutable_value_scan` (`slatedb.rs:3345`), which hands the raw 1 MiB
payload to `decode_immutable_locator` — magic check fails —
`Corruption("immutable segment locator is invalid")` (`immutable.rs:145`).
It only fires in accounting mode because that is the only mode that scans.

The fix makes the scan use the semantics the operation actually wrote with.
Verified: the full accounting matrix now completes on both backends at 1 MiB
and 10 MiB, with `payload_rows=1`/`10` and `payload_value_bytes` exactly
1,048,576 / 10,485,760 — raw uncompressed rows, as a bypass control should be.

Worth noting as a design gap, not fixed here: nothing in the engine enforces
that a physical `SpaceId` has exactly one `ValueSemantics`, so two conflicting
declarations for one id are accepted and only fail at decode.

## Blocker 3 — first-window upload contention (quantified, not fixed)

`chunk_hash_bytes_including_retries` for the 512 MiB ingest is exactly
`512 MiB + (concurrency - 1) x 16 MiB`, deterministic across reps:

| concurrency | hashed bytes | re-hashed | ingest |
| ---: | ---: | ---: | ---: |
| 1 | 536,870,912 | 0 | 153.0-153.1 MiB/s |
| 2 | 553,648,128 | 16 MiB | 152.8 MiB/s |
| 4 | 587,202,560 | 48 MiB | 153.0-153.2 MiB/s |

One re-hashed part per extra in-flight part, first window only, where
`UPLOAD_STATE_SPACE` is absent for every concurrent part and the losers retry.
Bounded, not a scaling term, and ingest does not move with concurrency on this
local-filesystem profile — so it is left as a follow-up rather than fixed here.

## Follow-ups this surfaced

- SlateDB takes **~110 ms** on one project save per run (t = 1200 ms) while all
  others are under 8 ms. `save_p95` over 40 samples cannot see it.
- SlateDB `resumable_initial_write` costs a **fixed ~202 ms** at both 1 MiB and
  10 MiB, versus 0.66 / 3.5 ms for `initial_write` and 1.5 / 12.3 ms for
  RocksDB. Size-independent, so it is a per-upload stall, and it is the path
  media ingest uses.

## Gate

`cargo check --workspace`, `cargo clippy --workspace --all-targets
--all-features -- -D warnings` and `cargo test -p lix --all-features` all clean
on `ryzen-9950x-I`. No engine code changed — the diff is one benchmark, one
qualification test and its doc.