### PR TITLE
perf(session): shrink the execute idempotency receipt encoding

### DIFF
--- a/.changenotes/smaller-idempotency-receipts.md
+++ b/.changenotes/smaller-idempotency-receipts.md
@@ -1,0 +1,14 @@
+---
+type: patch
+---
+
+Server SQL mutations now store much smaller retry receipts.
+
+Every `/execute` write records its response so a retry with the same
+`Idempotency-Key` returns the recorded result instead of mutating twice. That
+record previously encoded returned binary values as arrays of decimal numbers,
+costing about 3.6 stored bytes per payload byte, so a mutation using `RETURNING`
+over file content retained nearly four permanent copies of it. Receipts now use
+a compact encoding: about 1.33 bytes per payload byte and about a third less for
+mutations with no `RETURNING`. The 8 MiB replay limit consequently accepts
+roughly 6 MiB of returned content where it previously accepted about 2.2 MiB.

--- a/packages/engine-benchmarks/examples/expv_blind_space_growth.rs
+++ b/packages/engine-benchmarks/examples/expv_blind_space_growth.rs
@@ -400,7 +400,10 @@ async fn idempotency_payload_scenario(samples: &[usize], blob_bytes: usize, retu
                 format!("expv-key-{issued:012}"),
                 fingerprint,
             );
-            let content = vec![b'a' + (issued % 26) as u8; blob_bytes];
+            // Incompressible, per-request distinct content. A repeated byte
+            // would let the backend compress both the file and its receipt to
+            // almost nothing and would make the physical arm meaningless.
+            let content = pseudo_random_bytes(issued as u64, blob_bytes);
             Arc::clone(&fixture.session)
                 .execute_with_idempotency_and_options_and_metadata(
                     sql.to_owned(),
@@ -518,6 +521,23 @@ impl Fixture {
     fn flush(&self) {
         self.storage.flush().expect("flush RocksDB");
     }
+}
+
+/// splitmix64 fill. Deterministic per seed, and statistically incompressible,
+/// which is what a physical byte measurement of a payload plane requires.
+fn pseudo_random_bytes(seed: u64, len: usize) -> Vec<u8> {
+    let mut state = seed.wrapping_mul(0x9e37_79b9_7f4a_7c15).wrapping_add(1);
+    let mut out = Vec::with_capacity(len);
+    while out.len() < len {
+        state = state.wrapping_add(0x9e37_79b9_7f4a_7c15);
+        let mut z = state;
+        z = (z ^ (z >> 30)).wrapping_mul(0xbf58_476d_1ce4_e5b9);
+        z = (z ^ (z >> 27)).wrapping_mul(0x94d0_49bb_1331_11eb);
+        z ^= z >> 31;
+        let take = (len - out.len()).min(8);
+        out.extend_from_slice(&z.to_le_bytes()[..take]);
+    }
+    out
 }
 
 fn report(scenario: &str, phase: &str, axis: u64, usage: &Usage) {

--- a/packages/engine-benchmarks/examples/expv_blind_space_growth.rs
+++ b/packages/engine-benchmarks/examples/expv_blind_space_growth.rs
@@ -93,6 +93,12 @@ async fn main() {
             let samples = parse_samples(arguments.get(1));
             idempotency_scenario(&samples).await;
         }
+        "idempotency_payload" => {
+            let samples = parse_samples(arguments.get(1));
+            let bytes = parse_usize(arguments.get(2), 65536);
+            let returning = arguments.get(3).map(String::as_str) != Some("plain");
+            idempotency_payload_scenario(&samples, bytes, returning).await;
+        }
         "uploads" => {
             let samples = parse_samples(arguments.get(1));
             let bytes = parse_usize(arguments.get(2), 4096);
@@ -367,6 +373,60 @@ async fn idempotency_scenario(samples: &[usize]) {
         1,
         &usage(&fixture.storage).await,
     );
+}
+
+/// The same replay ledger, measured for the request shape its 8 MiB cap exists
+/// for: a mutation whose `RETURNING` clause projects blob content.
+///
+/// A receipt stores the complete `ExecuteResult` — columns, every returned row
+/// value, `rows_affected` and notices — as `serde_json`. `plain` runs the same
+/// file write without `RETURNING`, so the difference between the two arms is
+/// exactly the cost of retaining a second copy of the response payload.
+async fn idempotency_payload_scenario(samples: &[usize], blob_bytes: usize, returning: bool) {
+    let fixture = Fixture::open().await;
+    let sql = if returning {
+        "INSERT INTO lix_file (path, content) VALUES ($1, $2) RETURNING id, path, content"
+    } else {
+        "INSERT INTO lix_file (path, content) VALUES ($1, $2)"
+    };
+    let mut issued = 0usize;
+    for &target in samples {
+        while issued < target {
+            let mut fingerprint = [0u8; 32];
+            fingerprint[..8].copy_from_slice(&(issued as u64).to_be_bytes());
+            fingerprint[8] = u8::from(returning);
+            let identity = ExecuteIdempotency::new(
+                Some("expv-principal".to_owned()),
+                format!("expv-key-{issued:012}"),
+                fingerprint,
+            );
+            let content = vec![b'a' + (issued % 26) as u8; blob_bytes];
+            Arc::clone(&fixture.session)
+                .execute_with_idempotency_and_options_and_metadata(
+                    sql.to_owned(),
+                    vec![
+                        Value::Text(format!("/expv/payload-{issued:012}.bin")),
+                        Value::Blob(Blob::from(content)),
+                    ],
+                    ExecuteOptions::default(),
+                    ExecuteStatementMetadata::default(),
+                    Some(identity),
+                )
+                .await
+                .expect("idempotent execute");
+            issued += 1;
+        }
+        report(
+            if returning {
+                "idempotency_payload_returning"
+            } else {
+                "idempotency_payload_plain"
+            },
+            "live",
+            target as u64,
+            &usage(&fixture.storage).await,
+        );
+    }
 }
 
 /// Resumable-upload receipts. `keep` leaves every uploaded file live; `delete`

--- a/packages/engine-benchmarks/examples/expv_blind_space_growth.rs
+++ b/packages/engine-benchmarks/examples/expv_blind_space_growth.rs
@@ -427,6 +427,7 @@ async fn idempotency_payload_scenario(samples: &[usize], blob_bytes: usize, retu
             &usage(&fixture.storage).await,
         );
     }
+    fixture.flush();
 }
 
 /// Resumable-upload receipts. `keep` leaves every uploaded file live; `delete`
@@ -481,13 +482,24 @@ async fn uploads_scenario(samples: &[usize], bytes_per_upload: usize, delete: bo
 struct Fixture {
     storage: RocksDB,
     session: Arc<SessionContext<RocksDB>>,
-    _directory: tempfile::TempDir,
+    _directory: Option<tempfile::TempDir>,
 }
 
 impl Fixture {
+    /// Logical accounting is the default answer, so the fixture normally lives
+    /// in a temporary directory. Setting `LIX_EXPV_DIR` keeps the backend files
+    /// at a fixed path instead, which is what turns a logical byte curve into a
+    /// physical one (`flush`, then measure the directory).
     async fn open() -> Self {
-        let directory = tempfile::tempdir().expect("create RocksDB directory");
-        let storage = RocksDB::open(directory.path()).expect("open RocksDB");
+        let (directory, path) = match std::env::var_os("LIX_EXPV_DIR") {
+            Some(path) => (None, std::path::PathBuf::from(path)),
+            None => {
+                let directory = tempfile::tempdir().expect("create RocksDB directory");
+                let path = directory.path().to_path_buf();
+                (Some(directory), path)
+            }
+        };
+        let storage = RocksDB::open(&path).expect("open RocksDB");
         Engine::initialize(storage.clone())
             .await
             .expect("initialize repository");
@@ -501,6 +513,10 @@ impl Fixture {
             session: Arc::new(session),
             _directory: directory,
         }
+    }
+
+    fn flush(&self) {
+        self.storage.flush().expect("flush RocksDB");
     }
 }
 

--- a/packages/lix/src/session/execute.rs
+++ b/packages/lix/src/session/execute.rs
@@ -1779,7 +1779,7 @@ where
                 if let IdempotencyReceiptResolution::Replay(receipt) =
                     self.resolve_idempotency_receipt(&idempotency).await?
                 {
-                    return Ok(receipt.into_results());
+                    return receipt.into_results();
                 }
                 let result = self
                     .execute_transaction_batch(
@@ -1807,7 +1807,7 @@ where
                                 // callback was bypassed by an ambiguous error.
                                 self.observe_invalidation.bump();
                                 self.file_views.clear();
-                                Ok(receipt.into_results())
+                                receipt.into_results()
                             }
                             Ok(IdempotencyReceiptResolution::Absent) => Err(error),
                             Err(recovery_error) => Err(recovery_error),

--- a/packages/lix/src/session/idempotency.rs
+++ b/packages/lix/src/session/idempotency.rs
@@ -2,9 +2,6 @@ use base64::Engine as _;
 use bytes::Bytes;
 use serde::{Deserialize, Serialize};
 
-const BASE64: base64::engine::general_purpose::GeneralPurpose =
-    base64::engine::general_purpose::STANDARD;
-
 use crate::storage_adapter::StorageSpaceId;
 use crate::storage_adapter::{
     StorageAdapterRead, StorageCoreProjection, StorageGetManyRequest, StorageGetOptions,
@@ -79,6 +76,9 @@ pub(crate) const EXECUTE_IDEMPOTENCY_RECEIPT_SPACE: StorageSpace = StorageSpace:
     StorageSpaceId(0x0007_0005),
     "session.execute_idempotency_receipt.v1",
 );
+
+const BASE64: base64::engine::general_purpose::GeneralPurpose =
+    base64::engine::general_purpose::STANDARD;
 
 const RECEIPT_VERSION: u8 = 3;
 /// Keep the retry ledger bounded even when a mutation uses `RETURNING` with a

--- a/packages/lix/src/session/idempotency.rs
+++ b/packages/lix/src/session/idempotency.rs
@@ -1,5 +1,9 @@
+use base64::Engine as _;
 use bytes::Bytes;
 use serde::{Deserialize, Serialize};
+
+const BASE64: base64::engine::general_purpose::GeneralPurpose =
+    base64::engine::general_purpose::STANDARD;
 
 use crate::storage_adapter::StorageSpaceId;
 use crate::storage_adapter::{
@@ -76,7 +80,7 @@ pub(crate) const EXECUTE_IDEMPOTENCY_RECEIPT_SPACE: StorageSpace = StorageSpace:
     "session.execute_idempotency_receipt.v1",
 );
 
-const RECEIPT_VERSION: u8 = 2;
+const RECEIPT_VERSION: u8 = 3;
 /// Keep the retry ledger bounded even when a mutation uses `RETURNING` with a
 /// large blob. The request is rejected before its transaction commits, so a
 /// successful mutation always has a replayable response.
@@ -85,18 +89,83 @@ const MAX_RECEIPT_BYTES: usize = 8 * 1024 * 1024;
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub(crate) struct ExecuteIdempotencyReceipt {
     version: u8,
-    scope: Option<String>,
     branch_id: Option<String>,
-    request_fingerprint: [u8; 32],
+    /// Base64 rather than `[u8; 32]`: `serde_json` renders a byte array as 32
+    /// decimal numbers plus separators, which costs ~115 bytes for 32 bytes of
+    /// information and dominates a receipt for a mutation with no `RETURNING`.
+    request_fingerprint: String,
     results: Vec<StoredExecuteResult>,
 }
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 struct StoredExecuteResult {
     columns: Vec<String>,
-    rows: Vec<Vec<Value>>,
+    rows: Vec<Vec<StoredValue>>,
     rows_affected: u64,
     notices: Vec<LixNotice>,
+}
+
+/// Replay-storage form of a SQL value.
+///
+/// This exists for one variant. `Value`'s own `serde` representation renders
+/// `Blob` as an array of decimal numbers, which costs 3.57 stored bytes per
+/// payload byte, so a mutation that projects file content through `RETURNING`
+/// writes almost four permanent copies of that content into the retry ledger.
+/// The match below is exhaustive, so a new `Value` variant is a compile error
+/// here rather than a silently unreplayable receipt.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+enum StoredValue {
+    Null,
+    Boolean(bool),
+    Integer(i64),
+    Real(f64),
+    Text(String),
+    Json(crate::Json),
+    Blob(String),
+}
+
+impl StoredValue {
+    fn from_value(value: &Value) -> Result<Self, LixError> {
+        Ok(match value {
+            Value::Null => Self::Null,
+            Value::Boolean(value) => Self::Boolean(*value),
+            Value::Integer(value) => Self::Integer(*value),
+            Value::Real(value) => {
+                if !value.is_finite() {
+                    return Err(LixError::new(
+                        LixError::CODE_INTERNAL_ERROR,
+                        "execute result contains a non-finite value that cannot be replayed over the protocol",
+                    ));
+                }
+                Self::Real(*value)
+            }
+            Value::Text(value) => Self::Text(value.clone()),
+            Value::Json(value) => Self::Json(value.clone()),
+            Value::Blob(value) => Self::Blob(BASE64.encode(value.as_ref())),
+        })
+    }
+
+    fn into_value(self) -> Result<Value, LixError> {
+        Ok(match self {
+            Self::Null => Value::Null,
+            Self::Boolean(value) => Value::Boolean(value),
+            Self::Integer(value) => Value::Integer(value),
+            Self::Real(value) => Value::Real(value),
+            Self::Text(value) => Value::Text(value),
+            Self::Json(value) => Value::Json(value),
+            Self::Blob(value) => Value::Blob(
+                BASE64
+                    .decode(value.as_bytes())
+                    .map_err(|error| {
+                        LixError::new(
+                            LixError::CODE_STORAGE_ERROR,
+                            format!("decode execute idempotency receipt blob: {error}"),
+                        )
+                    })?
+                    .into(),
+            ),
+        })
+    }
 }
 
 impl ExecuteIdempotencyReceipt {
@@ -113,9 +182,8 @@ impl ExecuteIdempotencyReceipt {
     ) -> Result<Self, LixError> {
         Ok(Self {
             version: RECEIPT_VERSION,
-            scope: idempotency.scope.clone(),
             branch_id: idempotency.branch_id.clone(),
-            request_fingerprint: *idempotency.request_fingerprint(),
+            request_fingerprint: BASE64.encode(idempotency.request_fingerprint()),
             results: results
                 .iter()
                 .map(StoredExecuteResult::from_execute_result)
@@ -123,15 +191,19 @@ impl ExecuteIdempotencyReceipt {
         })
     }
 
+    /// `scope` is deliberately not a stored field. [`receipt_key`] is injective
+    /// over `(scope, key)` — it length-prefixes both components and carries the
+    /// scope's presence bit — so a receipt read at a key *is* a receipt for that
+    /// key's scope. Storing it again would make the value a second authority for
+    /// a fact the key already decides.
     pub(crate) fn matches(&self, idempotency: &ExecuteIdempotency) -> bool {
         self.version == RECEIPT_VERSION
-            && self.scope.as_deref() == idempotency.scope()
             && self.branch_id.as_deref() == idempotency.branch_id()
-            && self.request_fingerprint == *idempotency.request_fingerprint()
+            && self.request_fingerprint == BASE64.encode(idempotency.request_fingerprint())
     }
 
     pub(crate) fn into_single_result(self) -> Result<ExecuteResult, LixError> {
-        let mut results = self.into_results();
+        let mut results = self.into_results()?;
         if results.len() != 1 {
             return Err(LixError::new(
                 LixError::CODE_INTERNAL_ERROR,
@@ -141,8 +213,11 @@ impl ExecuteIdempotencyReceipt {
         Ok(results.remove(0))
     }
 
-    pub(crate) fn into_results(self) -> Vec<ExecuteResult> {
-        self.results.into_iter().map(ExecuteResult::from).collect()
+    pub(crate) fn into_results(self) -> Result<Vec<ExecuteResult>, LixError> {
+        self.results
+            .into_iter()
+            .map(StoredExecuteResult::into_execute_result)
+            .collect()
     }
 }
 
@@ -154,7 +229,7 @@ impl StoredExecuteResult {
             .map(|row| {
                 row.values()
                     .iter()
-                    .map(replayable_value)
+                    .map(StoredValue::from_value)
                     .collect::<Result<Vec<_>, _>>()
             })
             .collect::<Result<Vec<_>, _>>()?;
@@ -165,16 +240,23 @@ impl StoredExecuteResult {
             notices: result.notices().to_vec(),
         })
     }
-}
 
-impl From<StoredExecuteResult> for ExecuteResult {
-    fn from(result: StoredExecuteResult) -> Self {
-        Self::from_idempotency_parts(
-            result.columns,
-            result.rows,
-            result.rows_affected,
-            result.notices,
-        )
+    fn into_execute_result(self) -> Result<ExecuteResult, LixError> {
+        let rows = self
+            .rows
+            .into_iter()
+            .map(|row| {
+                row.into_iter()
+                    .map(StoredValue::into_value)
+                    .collect::<Result<Vec<_>, _>>()
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+        Ok(ExecuteResult::from_idempotency_parts(
+            self.columns,
+            rows,
+            self.rows_affected,
+            self.notices,
+        ))
     }
 }
 
@@ -262,14 +344,112 @@ fn receipt_key(idempotency: &ExecuteIdempotency) -> Result<StorageKey, LixError>
     Ok(StorageKey(Bytes::from(bytes)))
 }
 
-fn replayable_value(value: &Value) -> Result<Value, LixError> {
-    if let Value::Real(value) = value
-        && !value.is_finite()
-    {
-        return Err(LixError::new(
-            LixError::CODE_INTERNAL_ERROR,
-            "execute result contains a non-finite value that cannot be replayed over the protocol",
-        ));
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::Blob;
+
+    fn identity() -> ExecuteIdempotency {
+        ExecuteIdempotency::new(
+            Some("usr_expIR".to_owned()),
+            "key-expIR".to_owned(),
+            [7u8; 32],
+        )
+        .with_branch("0199aaaa-bbbb-cccc-dddd-eeeeeeeeeeee".to_owned())
     }
-    Ok(value.clone())
+
+    fn roundtrip(values: Vec<Value>) -> Vec<Value> {
+        let identity = identity();
+        let result = ExecuteResult::from_rows(vec!["c".to_owned()], vec![values]);
+        let receipt = ExecuteIdempotencyReceipt::single(&identity, &result).expect("build receipt");
+        let (_, encoded) = encode_receipt(&identity, &receipt).expect("encode receipt");
+        let decoded: ExecuteIdempotencyReceipt =
+            serde_json::from_slice(&encoded).expect("decode receipt");
+        assert!(decoded.matches(&identity), "decoded receipt must replay");
+        decoded
+            .into_single_result()
+            .expect("replay result")
+            .rows()
+            .first()
+            .expect("one row")
+            .values()
+            .to_vec()
+    }
+
+    /// Every SQL value shape must survive the storage form byte for byte; the
+    /// replay contract is that a retry sees the recorded response.
+    #[test]
+    fn every_value_variant_replays_unchanged() {
+        let values = vec![
+            Value::Null,
+            Value::Boolean(true),
+            Value::Integer(-42),
+            Value::Real(1.5),
+            Value::Text("text".to_owned()),
+            Value::Blob(Blob::from(vec![0u8, 255, 1, 128, 7])),
+        ];
+        assert_eq!(roundtrip(values.clone()), values);
+    }
+
+    /// Blob payloads are the reason this encoding exists: `Value`'s own serde
+    /// form spends 3.57 stored bytes per payload byte.
+    #[test]
+    fn blob_payloads_cost_roughly_their_own_size() {
+        let payload = (0..4096u32).map(|byte| byte as u8).collect::<Vec<_>>();
+        let identity = identity();
+        let result = ExecuteResult::from_rows(
+            vec!["content".to_owned()],
+            vec![vec![Value::Blob(Blob::from(payload.clone()))]],
+        );
+        let receipt = ExecuteIdempotencyReceipt::single(&identity, &result).expect("build receipt");
+        let (_, encoded) = encode_receipt(&identity, &receipt).expect("encode receipt");
+        assert!(
+            encoded.len() < payload.len() * 2,
+            "a {}-byte payload must not cost {} receipt bytes",
+            payload.len(),
+            encoded.len()
+        );
+    }
+
+    /// A non-finite float cannot cross the protocol, so it must be refused
+    /// while the mutation can still be rejected rather than at replay time.
+    #[test]
+    fn non_finite_reals_are_refused_before_commit() {
+        let identity = identity();
+        let result = ExecuteResult::from_rows(
+            vec!["c".to_owned()],
+            vec![vec![Value::Real(f64::INFINITY)]],
+        );
+        let error =
+            ExecuteIdempotencyReceipt::single(&identity, &result).expect_err("must be refused");
+        assert_eq!(error.code, LixError::CODE_INTERNAL_ERROR);
+    }
+
+    /// The storage key already decides the scope, so the value must not carry
+    /// it — but a differing scope must still never replay, because it lands on
+    /// a different key.
+    #[test]
+    fn scope_is_decided_by_the_key_alone() {
+        let scoped = ExecuteIdempotency::new(
+            Some("usr_a".to_owned()),
+            "shared-key".to_owned(),
+            [7u8; 32],
+        );
+        let other = ExecuteIdempotency::new(
+            Some("usr_b".to_owned()),
+            "shared-key".to_owned(),
+            [7u8; 32],
+        );
+        let unscoped =
+            ExecuteIdempotency::new(None, "shared-key".to_owned(), [7u8; 32]);
+        let empty_scope =
+            ExecuteIdempotency::new(Some(String::new()), "shared-key".to_owned(), [7u8; 32]);
+        let keys = [&scoped, &other, &unscoped, &empty_scope]
+            .map(|identity| receipt_key(identity).expect("build key"));
+        for left in 0..keys.len() {
+            for right in (left + 1)..keys.len() {
+                assert_ne!(keys[left], keys[right], "receipt keys must not alias");
+            }
+        }
+    }
 }


### PR DESCRIPTION
## The leak

`session.execute_idempotency_receipt.v1` grows **one row per server write, forever**. `expv_blind_space_growth`, RocksDB: 100 → 1,000 → 4,000 writes gives 100 → 1,000 → 4,000 rows, and **a full GC round reclaims nothing** (`staged_deletes=0`). At 4,000 tiny writes it is the 5th largest of 18 populated spaces and the **largest `key_bytes` consumer of all**.

Computed for the production shape (random SHA-256 fingerprint, bound branch UUID, UUID key): **~374 bytes per server write** → **32 MB/day at 1 write/s, ~11.9 GB/year per repository**, never reclaimed.

Nothing noticed because the only reader is an **exact-key point get** (`session/idempotency.rs:206`), never a scan — and `space_growth` contains zero occurrences of `idempot`, so that instrument is structurally blind to this plane.

## Why it is so large: it stores the full result payload

`StoredExecuteResult` holds `columns`, **every returned row value**, `rows_affected` and `notices` via `serde_json` — which renders `Value::Blob` as an array of decimal numbers. Measured, 200 × `INSERT INTO lix_file … RETURNING id, path, content` at 64 KiB each:

- **3.572 stored bytes per payload byte** — 234,062 B of receipt per 65,536 B file
- **1,100×** the receipt of the same write without `RETURNING`
- receipts were **55% of the on-disk repository**, storing ~1.4 permanent copies of a file the CAS stores once, deduped

## What this PR does — store less, commit to nothing

`RECEIPT_VERSION` 2→3, hard cut. Dropped the redundant `scope` field (`receipt_key` is injective over `(scope, key)`, so the value was a second authority for a fact the key already decides), base64 fingerprint instead of a 32-number array, and a `StoredValue` form whose `Blob` arm is base64.

| metric | base | cand | delta |
|---|---:|---:|---:|
| receipt bytes/write, no RETURNING (bench) | 212.92 | 167.00 | **−21.6%** |
| same, production shape (computed) | 311.2 | 201.0 | **−35.4%** |
| stored bytes per returned payload byte | 3.572 | 1.338 | **−62.5%** |
| receipt physical bytes, 200×64 KiB RETURNING | 17,812,384 | 13,003,735 | **−27.0%** |
| whole repository on disk, same workload | 32,388,425 | 27,704,263 | **−14.5%** |

Null control: two spaces the change cannot touch moved +0.0001% and −0.14%; the other 15 populated spaces are byte-identical.

**Retries still work**: `cargo test -p lix --all-features` (2,078 + 830, 0 failed), `cargo test -p lix-server-protocol` (95, 0 failed — including the acknowledgement-loss replay tests), clippy `-D warnings` clean. Four new unit tests: every `Value` variant replays byte-identically, a 4 KiB blob costs <2× itself, non-finite floats are refused pre-commit, four scope shapes give four distinct keys.

**One accepted side effect**: the 8 MiB cap now admits ~6 MiB of returned blob instead of ~2.24 MiB. Strictly more requests succeed; none that succeeded now fail.

## What this PR deliberately does NOT do

**It does not reclaim anything.** The correct retention window is a **product decision** — reclaiming a receipt makes a client retry re-execute its mutation. Nothing in the code, docs or client establishes a window.

Three findings for whoever makes that call:

1. **Bound by commit distance, not wall clock** *(recommended)*. Needs no clock authority (matters for deterministic mode), and N is an easier product statement than seconds. Reclamation would go through a `session`-owned `stage_reclaimable_execute_receipts` called from `gc.rs` — the shape `stage_reclaimable_upload_receipts` already establishes, satisfying #1319's no-foreign-writes rule.
2. **TTL** needs a timestamp field *and* a number no current code or doc justifies. There is no timestamp field at all today.
3. **Session/lease lifetime — do not.** Receipts bind to the **branch, never the session id**, so a client retrying after a dropped connection is on a *new* session — which is the primary case receipts exist for. This option looks obvious and is wrong.

Cheapest correct first move may be neither: the shipped JS client mints `crypto.randomUUID()` per call and has **no retry**, so ~100% of receipts are dead on delivery. Documenting a retry window in `docs/js-api-reference.md` (which currently promises unbounded replay by omission) would come before reclaiming to it.

## Layout invariants

No new authority; one is removed (the redundant `scope` field). No plane, view, publication or GC behaviour changes.