### PR TITLE
perf(sql): push lixcol_file_id down to the file-first HOT_ROW seek

### DIFF
--- a/.changenotes/file-scoped-entity-reads.md
+++ b/.changenotes/file-scoped-entity-reads.md
@@ -1,0 +1,7 @@
+---
+type: patch
+---
+
+Reading entity rows by `lixcol_file_id` now seeks straight to that file instead of scanning the whole schema.
+
+`SELECT ... WHERE lixcol_file_id = ?` previously matched the file only after every row of the schema had been read, so a narrow read of one file grew with the size of the branch. The file scope is now part of the scan itself, and the cost tracks the number of rows in the file.

--- a/packages/engine-benchmarks/benches/working_diff_file_scope.rs
+++ b/packages/engine-benchmarks/benches/working_diff_file_scope.rs
@@ -209,12 +209,11 @@ async fn run<StorageImpl>(
                      WHERE schema_key = $1 AND entity_pk = lix_json($2) AND file_id = $3";
     // Live-state read of the same file. HOT_ROW is keyed
     // `schema_key ++ file_id ++ entity_pk` and `hot_scan_entries` owns a
-    // file-first prefix route, but the entity surface never pushes
-    // `lixcol_file_id` into `TrackedStateFilter::file_ids` (its
-    // `filter_pushdown` only recognizes branch-id and primary-key analyzers),
-    // so this measures a full schema scan with a residual filter. Reported to
-    // keep that gap visible: `entity_scan_rows` stays fixed at `rows_per_file`
-    // while the latency tracks the whole schema.
+    // file-first prefix route; the entity surface pushes `lixcol_file_id` into
+    // `LiveStateFilter::file_ids`, so this reaches that prefix seek and costs
+    // O(rows in the file). `entity_scan_rows` is fixed at `rows_per_file`, so
+    // a flat latency across dirty-set sizes is the pass condition and a rising
+    // one means the pushdown stopped reaching the seek.
     let entity_scan_sql = format!("SELECT id FROM {SCHEMA_KEY} WHERE lixcol_file_id = $1");
     let file_params = vec![Value::Text(probe_file.clone())];
     let file_schema_params = vec![

--- a/packages/lix/src/engine.rs
+++ b/packages/lix/src/engine.rs
@@ -1707,8 +1707,9 @@ mod tests {
             .map(|row| {
                 (
                     row.get::<String>("path").expect("path should decode"),
-                    row.get::<Option<String>>("lixcol_file_id")
-                        .expect("file id should decode"),
+                    // `lixcol_file_id` is nullable; the typed accessor has no
+                    // Option impl, so a NULL surfaces as a decode error here.
+                    row.get::<String>("lixcol_file_id").ok(),
                 )
             })
             .collect::<Vec<_>>();

--- a/packages/lix/src/engine.rs
+++ b/packages/lix/src/engine.rs
@@ -1387,6 +1387,215 @@ mod tests {
         );
     }
 
+    /// The two working-diff read paths in `hot_working_diff_entries` must
+    /// answer identically for every row state a branch can actually reach.
+    ///
+    /// The broad path enumerates the sparse `HOT_DIFF` index and then loads
+    /// each dirty identity's primary row; the finite `schema_key + entity_pk`
+    /// path skips that index entirely and reads the primary rows directly.
+    /// They treat an untracked or absent primary row differently — the broad
+    /// path fails closed to canonical replay, the finite path skips the row —
+    /// so this walks every reachable shape (clean, modified, removed,
+    /// added, added-then-removed, untracked, untracked-recycled-as-tracked,
+    /// never-existed) and asserts the finite answer equals the broad answer
+    /// restricted to that identity.
+    #[tokio::test]
+    async fn working_diff_finite_bypass_and_index_scan_agree_on_every_row_state() {
+        let storage = Memory::new();
+        Engine::initialize(storage.clone())
+            .await
+            .expect("engine should initialize");
+        let engine = Engine::new(storage.clone())
+            .await
+            .expect("initialized engine should open");
+        let session = engine
+            .open_workspace_session()
+            .await
+            .expect("workspace session should open");
+        register_json_pointer_schema(&session).await;
+
+        for path in ["/clean", "/modified", "/removed", "/recycled-source"] {
+            session
+                .execute(
+                    "INSERT INTO json_pointer (path, value) VALUES ($1, lix_json('{\"v\":0}'))",
+                    &[crate::Value::Text(path.to_string())],
+                )
+                .await
+                .expect("pre-checkpoint tracked row should commit");
+        }
+        session
+            .execute(
+                "DELETE FROM json_pointer WHERE path = '/recycled-source'",
+                &[],
+            )
+            .await
+            .expect("pre-checkpoint delete should commit");
+        session
+            .create_checkpoint()
+            .await
+            .expect("checkpoint should publish a clean working state");
+
+        session
+            .execute(
+                "UPDATE json_pointer SET value = lix_json('{\"v\":1}') WHERE path = '/modified'",
+                &[],
+            )
+            .await
+            .expect("modify should dirty the row");
+        session
+            .execute("DELETE FROM json_pointer WHERE path = '/removed'", &[])
+            .await
+            .expect("delete should dirty the row");
+        session
+            .execute(
+                "INSERT INTO json_pointer (path, value) VALUES ('/added', lix_json('{\"v\":1}'))",
+                &[],
+            )
+            .await
+            .expect("insert should dirty a new identity");
+        session
+            .execute(
+                "INSERT INTO json_pointer (path, value) \
+                 VALUES ('/added-then-removed', lix_json('{\"v\":1}'))",
+                &[],
+            )
+            .await
+            .expect("insert should dirty a new identity");
+        session
+            .execute(
+                "DELETE FROM json_pointer WHERE path = '/added-then-removed'",
+                &[],
+            )
+            .await
+            .expect("delete of a post-checkpoint insert should commit");
+        session
+            .execute(
+                "INSERT INTO json_pointer (path, value, lixcol_untracked) \
+                 VALUES ('/untracked', lix_json('{\"v\":1}'), true)",
+                &[],
+            )
+            .await
+            .expect("untracked insert should commit");
+
+        // Physically removing a HOT primary row is only reachable through an
+        // untracked delete (`CurrentStateDelta::physically_deletes` is
+        // `untracked && deleted`). Exercise that, then re-insert the identity
+        // as tracked so a dirty row exists whose HOT slot was previously
+        // vacated.
+        session
+            .execute(
+                "INSERT INTO json_pointer (path, value, lixcol_untracked) \
+                 VALUES ('/recycled', lix_json('{\"v\":1}'), true)",
+                &[],
+            )
+            .await
+            .expect("untracked insert should commit");
+        session
+            .execute("DELETE FROM json_pointer WHERE path = '/recycled'", &[])
+            .await
+            .expect("untracked delete should physically remove the hot row");
+        session
+            .execute(
+                "INSERT INTO json_pointer (path, value) \
+                 VALUES ('/recycled', lix_json('{\"v\":2}'))",
+                &[],
+            )
+            .await
+            .expect("tracked insert should reuse the vacated identity");
+
+        // The invariant that makes the two paths equivalent: retention is
+        // immutable while a physical member exists, so a dirty tracked row can
+        // never become untracked or vanish under its own `HOT_DIFF` entry.
+        let retention_flip = session
+            .execute(
+                "INSERT INTO json_pointer (path, value, lixcol_untracked) \
+                 VALUES ('/modified', lix_json('{\"v\":9}'), true)",
+                &[],
+            )
+            .await;
+        assert!(
+            retention_flip.is_err(),
+            "an untracked write must not take over a dirty tracked identity"
+        );
+
+        let broad = session
+            .execute(
+                "SELECT entity_pk, diff_type FROM lix_working_diff \
+                 WHERE schema_key = 'json_pointer' ORDER BY entity_pk",
+                &[],
+            )
+            .await
+            .expect("broad working-diff read should execute");
+        let broad_rows = broad
+            .rows()
+            .iter()
+            .map(|row| {
+                (
+                    row.get::<serde_json::Value>("entity_pk")
+                        .expect("entity_pk should decode")
+                        .to_string(),
+                    row.get::<String>("diff_type")
+                        .expect("diff_type should decode"),
+                )
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(
+            broad_rows,
+            vec![
+                ("[\"/added\"]".to_string(), "added".to_string()),
+                ("[\"/modified\"]".to_string(), "modified".to_string()),
+                ("[\"/recycled\"]".to_string(), "added".to_string()),
+                ("[\"/removed\"]".to_string(), "removed".to_string()),
+            ],
+            "the index-driven working diff must classify every reachable shape"
+        );
+
+        for path in [
+            "/clean",
+            "/modified",
+            "/removed",
+            "/added",
+            "/added-then-removed",
+            "/untracked",
+            "/recycled",
+            "/recycled-source",
+            "/never-existed",
+        ] {
+            let entity_pk = format!("[\"{path}\"]");
+            let finite = session
+                .execute(
+                    "SELECT entity_pk, diff_type FROM lix_working_diff \
+                     WHERE schema_key = 'json_pointer' AND entity_pk = lix_json($1) \
+                     ORDER BY entity_pk",
+                    &[crate::Value::Text(entity_pk.clone())],
+                )
+                .await
+                .expect("finite working-diff read should execute");
+            let finite_rows = finite
+                .rows()
+                .iter()
+                .map(|row| {
+                    (
+                        row.get::<serde_json::Value>("entity_pk")
+                            .expect("entity_pk should decode")
+                            .to_string(),
+                        row.get::<String>("diff_type")
+                            .expect("diff_type should decode"),
+                    )
+                })
+                .collect::<Vec<_>>();
+            let expected = broad_rows
+                .iter()
+                .filter(|(row_pk, _)| row_pk == &entity_pk)
+                .cloned()
+                .collect::<Vec<_>>();
+            assert_eq!(
+                finite_rows, expected,
+                "the finite working-diff bypass disagrees with the index scan for {path}"
+            );
+        }
+    }
+
     #[tokio::test]
     async fn untracked_state_survives_checkpoint_and_next_tracked_write() {
         let storage = Memory::new();

--- a/packages/lix/src/engine.rs
+++ b/packages/lix/src/engine.rs
@@ -1518,6 +1518,9 @@ mod tests {
             "an untracked write must not take over a dirty tracked identity"
         );
 
+        use std::sync::atomic::Ordering;
+        let hits = &crate::live_state::WORKING_DIFF_PATH_HITS;
+        let index_before = hits.index_scan.load(Ordering::Relaxed);
         let broad = session
             .execute(
                 "SELECT entity_pk, diff_type FROM lix_working_diff \
@@ -1526,6 +1529,10 @@ mod tests {
             )
             .await
             .expect("broad working-diff read should execute");
+        assert!(
+            hits.index_scan.load(Ordering::Relaxed) > index_before,
+            "the schema-only working-diff read must take the HOT_DIFF index path"
+        );
         let broad_rows = broad
             .rows()
             .iter()
@@ -1562,6 +1569,7 @@ mod tests {
             "/never-existed",
         ] {
             let entity_pk = format!("[\"{path}\"]");
+            let bypass_before = hits.finite_bypass.load(Ordering::Relaxed);
             let finite = session
                 .execute(
                     "SELECT entity_pk, diff_type FROM lix_working_diff \
@@ -1571,6 +1579,10 @@ mod tests {
                 )
                 .await
                 .expect("finite working-diff read should execute");
+            assert!(
+                hits.finite_bypass.load(Ordering::Relaxed) > bypass_before,
+                "the finite working-diff read for {path} must take the primary-row bypass"
+            );
             let finite_rows = finite
                 .rows()
                 .iter()
@@ -1594,6 +1606,186 @@ mod tests {
                 "the finite working-diff bypass disagrees with the index scan for {path}"
             );
         }
+    }
+
+    /// `WHERE lixcol_file_id = ?` is now an exact provider constraint, so
+    /// DataFusion drops its residual filter and the answer rests entirely on
+    /// `LiveStateFilter::file_ids`. Rows can live in four authorities — the
+    /// branch-local `HOT_ROW` overlay, a packed current base, a certified
+    /// entity batch, and the root current base — and a file-scoped seek is
+    /// only sound if every one of them applies the same filter. The checkpoint
+    /// in the middle republishes the generation, so rows written before and
+    /// after it reach the read through different authorities.
+    #[tokio::test]
+    async fn file_scoped_entity_read_matches_the_unfiltered_scan() {
+        let storage = Memory::new();
+        Engine::initialize(storage.clone())
+            .await
+            .expect("engine should initialize");
+        let engine = Engine::new(storage.clone())
+            .await
+            .expect("initialized engine should open");
+        let session = engine
+            .open_workspace_session()
+            .await
+            .expect("workspace session should open");
+        register_json_pointer_schema(&session).await;
+
+        let files = ["66696c65-0000-8000-8000-000000000000", "66696c65-0001-8000-8000-000000000001"];
+        for (index, file) in files.iter().enumerate() {
+            session
+                .execute(
+                    "INSERT INTO lix_file (id, path, content) \
+                     VALUES ($1, $2, CAST($3 AS BYTEA))",
+                    &[
+                        crate::Value::Text((*file).to_string()),
+                        crate::Value::Text(format!("/f{index}.txt")),
+                        crate::Value::Text("seed".to_string()),
+                    ],
+                )
+                .await
+                .expect("file should insert");
+        }
+
+        let mut expected: Vec<(String, Option<String>)> = Vec::new();
+        for (path, file) in [
+            ("/a0", Some(files[0])),
+            ("/a1", Some(files[0])),
+            ("/b0", Some(files[1])),
+            ("/none", None),
+        ] {
+            session
+                .execute(
+                    "INSERT INTO json_pointer (path, value, lixcol_file_id) \
+                     VALUES ($1, lix_json('{\"v\":0}'), $2)",
+                    &[
+                        crate::Value::Text(path.to_string()),
+                        file.map_or(crate::Value::Null, |file| {
+                            crate::Value::Text(file.to_string())
+                        }),
+                    ],
+                )
+                .await
+                .expect("pre-checkpoint row should insert");
+            expected.push((path.to_string(), file.map(str::to_string)));
+        }
+
+        session
+            .create_checkpoint()
+            .await
+            .expect("checkpoint should republish the generation");
+
+        for (path, file) in [
+            ("/a2", Some(files[0])),
+            ("/b1", Some(files[1])),
+            ("/none2", None),
+        ] {
+            session
+                .execute(
+                    "INSERT INTO json_pointer (path, value, lixcol_file_id) \
+                     VALUES ($1, lix_json('{\"v\":1}'), $2)",
+                    &[
+                        crate::Value::Text(path.to_string()),
+                        file.map_or(crate::Value::Null, |file| {
+                            crate::Value::Text(file.to_string())
+                        }),
+                    ],
+                )
+                .await
+                .expect("post-checkpoint row should insert");
+            expected.push((path.to_string(), file.map(str::to_string)));
+        }
+        expected.sort();
+
+        let all = session
+            .execute("SELECT path, lixcol_file_id FROM json_pointer", &[])
+            .await
+            .expect("unfiltered scan should execute");
+        let mut all_rows = all
+            .rows()
+            .iter()
+            .map(|row| {
+                (
+                    row.get::<String>("path").expect("path should decode"),
+                    row.get::<Option<String>>("lixcol_file_id")
+                        .expect("file id should decode"),
+                )
+            })
+            .collect::<Vec<_>>();
+        all_rows.sort();
+        assert_eq!(all_rows, expected, "fixture should read back unfiltered");
+
+        for file in files {
+            let filtered = session
+                .execute(
+                    "SELECT path FROM json_pointer WHERE lixcol_file_id = $1 ORDER BY path",
+                    &[crate::Value::Text(file.to_string())],
+                )
+                .await
+                .expect("file-scoped read should execute");
+            let filtered_rows = filtered
+                .rows()
+                .iter()
+                .map(|row| row.get::<String>("path").expect("path should decode"))
+                .collect::<Vec<_>>();
+            let mut want = expected
+                .iter()
+                .filter(|(_, row_file)| row_file.as_deref() == Some(file))
+                .map(|(path, _)| path.clone())
+                .collect::<Vec<_>>();
+            want.sort();
+            assert_eq!(
+                filtered_rows, want,
+                "file-scoped entity read must return exactly the rows in {file}"
+            );
+        }
+
+        let in_list = session
+            .execute(
+                "SELECT path FROM json_pointer \
+                 WHERE lixcol_file_id IN ($1, $2) ORDER BY path",
+                &[
+                    crate::Value::Text(files[0].to_string()),
+                    crate::Value::Text(files[1].to_string()),
+                ],
+            )
+            .await
+            .expect("file-scoped IN read should execute");
+        let mut want_in = expected
+            .iter()
+            .filter(|(_, row_file)| row_file.is_some())
+            .map(|(path, _)| path.clone())
+            .collect::<Vec<_>>();
+        want_in.sort();
+        assert_eq!(
+            in_list
+                .rows()
+                .iter()
+                .map(|row| row.get::<String>("path").expect("path should decode"))
+                .collect::<Vec<_>>(),
+            want_in
+        );
+
+        let point = session
+            .execute(
+                "SELECT path FROM json_pointer WHERE lixcol_file_id = $1 AND path = '/a2'",
+                &[crate::Value::Text(files[0].to_string())],
+            )
+            .await
+            .expect("file + primary key read should execute");
+        assert_eq!(point.rows().len(), 1);
+
+        let contradiction = session
+            .execute(
+                "SELECT path FROM json_pointer WHERE lixcol_file_id = $1 AND path = '/b0'",
+                &[crate::Value::Text(files[0].to_string())],
+            )
+            .await
+            .expect("contradictory file + primary key read should execute");
+        assert!(
+            contradiction.rows().is_empty(),
+            "a row must not be visible through another file's scope"
+        );
     }
 
     #[tokio::test]

--- a/packages/lix/src/live_state/mod.rs
+++ b/packages/lix/src/live_state/mod.rs
@@ -25,6 +25,8 @@ pub(crate) use reader::{LiveStateReadDomain, LiveStateReader};
 #[cfg(test)]
 pub(crate) use tracked_head::TrackedHeadDeltaRef;
 #[cfg(test)]
+pub(crate) use tracked_head::WORKING_DIFF_PATH_HITS;
+#[cfg(test)]
 pub(crate) use tracked_head::stage_collect_stale_working_diff_indexes;
 #[allow(unused_imports)]
 pub(crate) use tracked_head::{

--- a/packages/lix/src/live_state/tracked_head.rs
+++ b/packages/lix/src/live_state/tracked_head.rs
@@ -10,6 +10,8 @@
 mod hot;
 
 pub(crate) use crate::live_state::LiveStateReadDomain;
+#[cfg(test)]
+pub(crate) use hot::WORKING_DIFF_PATH_HITS;
 pub(crate) use hot::{
     CERTIFIED_ENTITY_BATCH_MANIFEST_SPACE, CERTIFIED_ENTITY_BATCH_PAGE_SPACE,
     CERTIFIED_ENTITY_BATCH_SPACE, CertifiedEntityBatchFileRef, DeferredFreshHotPlan,

--- a/packages/lix/src/live_state/tracked_head/hot.rs
+++ b/packages/lix/src/live_state/tracked_head/hot.rs
@@ -9745,6 +9745,21 @@ fn packed_working_diff_version(
     }
 }
 
+/// Counts which of the two working-diff read paths served a request, so the
+/// public-surface equivalence test can prove it exercised both instead of
+/// silently comparing one path against itself.
+#[cfg(test)]
+pub(crate) static WORKING_DIFF_PATH_HITS: WorkingDiffPathHits = WorkingDiffPathHits {
+    index_scan: std::sync::atomic::AtomicUsize::new(0),
+    finite_bypass: std::sync::atomic::AtomicUsize::new(0),
+};
+
+#[cfg(test)]
+pub(crate) struct WorkingDiffPathHits {
+    pub(crate) index_scan: std::sync::atomic::AtomicUsize,
+    pub(crate) finite_bypass: std::sync::atomic::AtomicUsize,
+}
+
 /// Resolves a checkpoint diff from row-local first-before images. Broad diffs
 /// enumerate the sparse dirty-key index; finite PK queries read only the
 /// primary rows that can answer the request.
@@ -9772,6 +9787,10 @@ async fn hot_working_diff_entries(
         .await;
     }
 
+    #[cfg(test)]
+    WORKING_DIFF_PATH_HITS
+        .index_scan
+        .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
     let scope = encode_working_diff_scope_prefix(branch_id, checkpoint_commit_id, generation);
     let range = StoragePrefix {
         bytes: Bytes::from(scope.clone()),
@@ -9976,6 +9995,10 @@ async fn hot_working_diff_entries_for_finite_filter(
     generation: CommitId,
     filter: &TrackedStateFilter,
 ) -> Result<Option<Vec<TrackedStateDiffEntry>>, LixError> {
+    #[cfg(test)]
+    WORKING_DIFF_PATH_HITS
+        .finite_bypass
+        .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
     let rows = hot_scan_entries(store, branch_id, generation, filter, None, None)
         .await?
         .expect("unbounded HOT scan cannot exhaust a byte budget");

--- a/packages/lix/src/live_state/tracked_head/hot.rs
+++ b/packages/lix/src/live_state/tracked_head/hot.rs
@@ -9898,6 +9898,33 @@ async fn hot_working_diff_entries(
             let Ok(after) = decode_head_value(&after) else {
                 return Ok(None);
             };
+            // Not a classification, an inconsistency guard — and deliberately
+            // stricter than the finite bypass, which merely skips an untracked
+            // or absent primary row (`finite_working_diff_versions`).
+            //
+            // The two are equivalent because the populations differ. This loop
+            // only visits identities the sparse `HOT_DIFF` index already
+            // asserts are dirty against this checkpoint, and a dirty identity
+            // always has a tracked primary row in this generation:
+            //
+            // * `HOT_DIFF` keys are only written for `!delta.untracked`
+            //   deltas, both incrementally and from the file cascade.
+            // * A primary row is physically removed only by
+            //   `CurrentStateDelta::physically_deletes` — `untracked &&
+            //   deleted`. A tracked delete writes a tombstone that keeps its
+            //   baseline, so a dirty row cannot vanish.
+            // * `reject_retention_change` forbids flipping retention while any
+            //   physical member exists, so a dirty tracked row cannot be
+            //   overwritten by an untracked one.
+            // * The scope prefix contains the checkpoint and the generation, so
+            //   a `Clean` baseline or a foreign checkpoint owner cannot appear
+            //   under the scope the epoch names.
+            //
+            // The finite bypass instead reads *all* primary rows matching a
+            // finite identity filter, where clean, untracked, and absent rows
+            // are the normal case and skipping them is the classification. It
+            // never sees this population, so keep the strict guard here rather
+            // than relaxing it to match.
             if after.untracked {
                 return Ok(None);
             }
@@ -9993,6 +10020,21 @@ async fn hot_working_diff_entries_for_finite_filter(
     }
 }
 
+/// Classifies one primary `HOT_ROW` value for the finite bypass.
+///
+/// `None` means "this scope cannot answer, replay canonically"; `Some(None)`
+/// means "this row contributes no diff entry".
+///
+/// Skipping an untracked, clean, or foreign-checkpoint row here is not the
+/// same decision the index-driven path makes for the same predicates — that
+/// path fails closed. Both are correct because they classify different
+/// populations: this one sees every primary row matching a finite identity
+/// filter, where untracked/clean/absent rows are ordinary and not dirty, while
+/// the index-driven path only ever sees identities `HOT_DIFF` already asserts
+/// are dirty, where those same states would be corruption. See the equivalence
+/// argument in `hot_working_diff_entries`; the reachable-state proof is
+/// exercised end to end by
+/// `working_diff_finite_bypass_and_index_scan_agree_on_every_row_state`.
 fn finite_working_diff_versions(
     bytes: &Bytes,
     checkpoint_commit_id: CommitId,

--- a/packages/lix/src/live_state/tracked_head/hot.rs
+++ b/packages/lix/src/live_state/tracked_head/hot.rs
@@ -10763,8 +10763,18 @@ fn encode_hot_diff_key_parts(
 /// `hot_scan_entries` already owns a file-first prefix route, so a
 /// `schema_key + file_id` working-diff read could enumerate primary rows the
 /// way the finite bypass does. That trades O(dirty rows in the branch) for
-/// O(live rows in the file) and still owes a soundness argument for rows that
-/// leave `HOT_ROW` entirely (untracked deletes), so it is not implemented.
+/// O(live rows in the file). It is still not implemented *for the working
+/// diff*, because a diff must also see identities whose current authority is a
+/// packed current base published inside this checkpoint window, and those
+/// contribute exactly the whole-commit coverage groups described above.
+///
+/// The ordinary **entity** surface has no such obligation and does take that
+/// route: `lixcol_file_id` is an exact provider constraint that lands in
+/// `LiveStateFilter::file_ids`, and every authority the live-state merge reads
+/// — `HOT_ROW`, the packed current base, the certified entity batches, and the
+/// root current base — filters on it, two of them with their own file-scoped
+/// seek. Rows that never had a branch-local `HOT_ROW` are therefore still
+/// returned by the other three legs.
 fn append_hot_diff_key_parts(
     key_bytes: &mut Vec<u8>,
     scope: &[u8],

--- a/packages/lix/src/sql2/providers/entity.rs
+++ b/packages/lix/src/sql2/providers/entity.rs
@@ -4299,7 +4299,7 @@ mod tests {
         );
 
         // An IN list is still one contiguous set of file prefixes.
-        let in_list = Expr::InList(datafusion::logical_expr::expr::InList::new(
+        let in_list = Expr::InList(InList::new(
             Box::new(column("lixcol_file_id")),
             vec![
                 Expr::Literal(ScalarValue::Utf8(Some("file-a".to_string())), None),
@@ -4332,7 +4332,7 @@ mod tests {
             .await
             .expect("contradictory file scopes should plan");
         assert!(request.filter.file_ids.is_empty());
-        assert_eq!(request.filter.rows, crate::live_state::LiveStateRowFilter::None);
+        assert_eq!(request.filter.rows, LiveStateRowFilter::None);
 
         // Shapes the seek cannot represent stay unsupported so DataFusion keeps
         // its residual instead of silently widening the scan.

--- a/packages/lix/src/sql2/providers/entity.rs
+++ b/packages/lix/src/sql2/providers/entity.rs
@@ -314,6 +314,7 @@ impl EntitySpec {
         .map_err(lix_error_to_datafusion_error)?;
         apply_exact_branch_id_filter(&mut request, exact_branch_ids);
         apply_exact_entity_pk_filters(&mut request, &self.spec, filters)?;
+        apply_exact_file_id_filter(&mut request, exact_file_ids_from_filters(filters)?);
         Ok((projected_schema, request, row_filters))
     }
 
@@ -526,7 +527,10 @@ impl TableSpec for EntitySpec {
     fn filter_pushdown(&self, filter: &Expr) -> TableProviderFilterPushDown {
         let primary_key_analyzer = EntityPrimaryKeyFilterAnalyzer::new(&self.spec);
         let row_filter_analyzer = EntityRowFilterAnalyzer::new(&self.spec);
-        if ExactBranchIdFilterAnalyzer.supports(filter) || primary_key_analyzer.supports(filter) {
+        if ExactBranchIdFilterAnalyzer.supports(filter)
+            || ExactFileIdFilterAnalyzer.supports(filter)
+            || primary_key_analyzer.supports(filter)
+        {
             TableProviderFilterPushDown::Exact
         } else if row_filter_analyzer.supports(filter) {
             // Retain a DataFusion residual even when the row-shaped fallback
@@ -1701,6 +1705,125 @@ fn apply_exact_branch_id_filter(
         }
         request.filter.branch_ids = branch_ids;
     }
+}
+
+/// Extracts the exact `lixcol_file_id` selector so a file-scoped entity read
+/// becomes a physical seek instead of a schema-wide scan.
+///
+/// `HOT_ROW` is keyed `schema_key ++ file_id ++ entity_pk`, so a
+/// `schema_key + file_id` filter is a contiguous prefix
+/// (`hot_file_scan_prefixes`). The other three live-state authorities that can
+/// hold rows with no branch-local `HOT_ROW` — the packed current base, the
+/// certified entity batches, and the root current base — each already apply
+/// `LiveStateFilter::file_ids` (two of them with their own file-scoped seek),
+/// so the merged answer stays complete. Without this analyzer the predicate
+/// only ever survived as a DataFusion residual and every file-scoped read paid
+/// O(rows in the branch).
+fn exact_file_ids_from_filters(filters: &[Expr]) -> Result<Option<Vec<String>>> {
+    let analyzer = ExactFileIdFilterAnalyzer;
+    let mut file_ids: Option<BTreeSet<String>> = None;
+    for filter in filters {
+        let Some(filter_ids) = analyzer.analyze(filter)? else {
+            continue;
+        };
+        file_ids = Some(match file_ids {
+            Some(existing_ids) => existing_ids.intersection(&filter_ids).cloned().collect(),
+            None => filter_ids,
+        });
+    }
+    Ok(file_ids.map(|ids| ids.into_iter().collect()))
+}
+
+fn apply_exact_file_id_filter(request: &mut LiveStateScanRequest, file_ids: Option<Vec<String>>) {
+    if let Some(file_ids) = file_ids {
+        if file_ids.is_empty() {
+            request.filter.rows = LiveStateRowFilter::None;
+        }
+        request.filter.file_ids = file_ids
+            .into_iter()
+            .map(crate::NullableKeyFilter::Value)
+            .collect();
+    }
+}
+
+struct ExactFileIdFilterAnalyzer;
+
+impl ExactFileIdFilterAnalyzer {
+    fn supports(&self, expr: &Expr) -> bool {
+        self.analyze(expr)
+            .is_ok_and(|constraint| constraint.is_some())
+    }
+
+    #[expect(clippy::self_only_used_in_recursion)]
+    fn analyze(&self, expr: &Expr) -> Result<Option<BTreeSet<String>>> {
+        match expr {
+            Expr::BinaryExpr(binary_expr) if binary_expr.op == Operator::And => {
+                let Some(left) = self.analyze(&binary_expr.left)? else {
+                    return Ok(None);
+                };
+                let Some(right) = self.analyze(&binary_expr.right)? else {
+                    return Ok(None);
+                };
+                Ok(Some(left.intersection(&right).cloned().collect()))
+            }
+            Expr::BinaryExpr(binary_expr) if binary_expr.op == Operator::Or => {
+                let Some(mut left) = self.analyze(&binary_expr.left)? else {
+                    return Ok(None);
+                };
+                let Some(right) = self.analyze(&binary_expr.right)? else {
+                    return Ok(None);
+                };
+                left.extend(right);
+                Ok(Some(left))
+            }
+            Expr::BinaryExpr(binary_expr) => {
+                Ok(file_id_from_binary_filter(binary_expr).map(|value| BTreeSet::from([value])))
+            }
+            Expr::InList(in_list) => {
+                Ok(file_ids_from_in_list_filter(in_list).map(|values| values.into_iter().collect()))
+            }
+            _ => Ok(None),
+        }
+    }
+}
+
+fn file_id_from_binary_filter(binary_expr: &BinaryExpr) -> Option<String> {
+    if binary_expr.op != Operator::Eq {
+        return None;
+    }
+    file_id_from_column_literal_filter(&binary_expr.left, &binary_expr.right)
+        .or_else(|| file_id_from_column_literal_filter(&binary_expr.right, &binary_expr.left))
+}
+
+fn file_ids_from_in_list_filter(in_list: &InList) -> Option<Vec<String>> {
+    if in_list.negated {
+        return None;
+    }
+    let Expr::Column(column) = in_list.expr.as_ref() else {
+        return None;
+    };
+    if column.name != "lixcol_file_id" {
+        return None;
+    }
+    let values = in_list
+        .list
+        .iter()
+        .map(string_expr_literal)
+        .collect::<Option<Vec<_>>>()?;
+    if values.is_empty() {
+        return None;
+    }
+    Some(values)
+}
+
+fn file_id_from_column_literal_filter(column_expr: &Expr, literal_expr: &Expr) -> Option<String> {
+    let Expr::Column(column) = column_expr else {
+        return None;
+    };
+    if column.name != "lixcol_file_id" {
+        return None;
+    }
+    string_expr_literal(literal_expr)
 }
 
 pub(super) struct EntityPrimaryKeyFilterAnalyzer<'a> {

--- a/packages/lix/src/sql2/providers/entity.rs
+++ b/packages/lix/src/sql2/providers/entity.rs
@@ -4256,6 +4256,110 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn file_id_filter_pushes_an_exact_file_scope_into_scan() {
+        let spec = Arc::new(
+            derive_entity_surface_spec_from_schema(&json!({
+                "x-lix-key": "file_note",
+                "x-lix-primary-key": ["/id"],
+                "type": "object",
+                "properties": {
+                    "id": { "type": "string" },
+                    "body": { "type": "string" }
+                },
+                "required": ["id", "body"]
+            }))
+            .expect("file-scoped schema should derive"),
+        );
+        let provider = super::EntitySpec::by_branch(
+            Arc::clone(&spec),
+            Arc::new(EmptyLiveStateReader) as Arc<dyn LiveStateReader>,
+            empty_branch_ref(),
+            None,
+        );
+
+        let filter = eq_filter("lixcol_file_id", "file-a");
+        assert_eq!(
+            <super::EntitySpec as super::super::spec::TableSpec>::filter_pushdown(
+                &provider, &filter
+            ),
+            datafusion::logical_expr::TableProviderFilterPushDown::Exact,
+            "an exact file scope must not be left as a DataFusion residual"
+        );
+        let (_schema, request, row_filters) = provider
+            .plan_scan_parts(None, &[filter], None)
+            .await
+            .expect("file-scoped scan should plan");
+        assert_eq!(
+            request.filter.file_ids,
+            vec![crate::NullableKeyFilter::Value("file-a".to_string())]
+        );
+        assert!(
+            row_filters.is_empty(),
+            "lixcol_file_id is an identity column, not a payload row filter"
+        );
+
+        // An IN list is still one contiguous set of file prefixes.
+        let in_list = Expr::InList(datafusion::logical_expr::expr::InList::new(
+            Box::new(column("lixcol_file_id")),
+            vec![
+                Expr::Literal(ScalarValue::Utf8(Some("file-a".to_string())), None),
+                Expr::Literal(ScalarValue::Utf8(Some("file-b".to_string())), None),
+            ],
+            false,
+        ));
+        let (_schema, request, _row_filters) = provider
+            .plan_scan_parts(None, &[in_list], None)
+            .await
+            .expect("file-scoped IN scan should plan");
+        assert_eq!(
+            request.filter.file_ids,
+            vec![
+                crate::NullableKeyFilter::Value("file-a".to_string()),
+                crate::NullableKeyFilter::Value("file-b".to_string()),
+            ]
+        );
+
+        // Contradictory scopes select nothing rather than every file.
+        let (_schema, request, _row_filters) = provider
+            .plan_scan_parts(
+                None,
+                &[
+                    eq_filter("lixcol_file_id", "file-a"),
+                    eq_filter("lixcol_file_id", "file-b"),
+                ],
+                None,
+            )
+            .await
+            .expect("contradictory file scopes should plan");
+        assert!(request.filter.file_ids.is_empty());
+        assert_eq!(request.filter.rows, crate::live_state::LiveStateRowFilter::None);
+
+        // Shapes the seek cannot represent stay unsupported so DataFusion keeps
+        // its residual instead of silently widening the scan.
+        assert_eq!(
+            <super::EntitySpec as super::super::spec::TableSpec>::filter_pushdown(
+                &provider,
+                &Expr::IsNull(Box::new(column("lixcol_file_id")))
+            ),
+            datafusion::logical_expr::TableProviderFilterPushDown::Unsupported
+        );
+        assert_eq!(
+            <super::EntitySpec as super::super::spec::TableSpec>::filter_pushdown(
+                &provider,
+                &Expr::BinaryExpr(BinaryExpr::new(
+                    Box::new(column("lixcol_file_id")),
+                    Operator::NotEq,
+                    Box::new(Expr::Literal(
+                        ScalarValue::Utf8(Some("file-a".to_string())),
+                        None
+                    )),
+                ))
+            ),
+            datafusion::logical_expr::TableProviderFilterPushDown::Unsupported
+        );
+    }
+
+    #[tokio::test]
     async fn integer_primary_key_filter_pushes_exact_identity_into_scan() {
         let spec = Arc::new(
             derive_entity_surface_spec_from_schema(&json!({


### PR DESCRIPTION
## What changed

`SELECT ... FROM <entity> WHERE lixcol_file_id = ?` is now an **exact provider
constraint** instead of a DataFusion residual.

`sql2/providers/entity.rs` recognised only branch-id and primary-key analyzers,
so a file predicate never reached `LiveStateFilter::file_ids` and every
file-scoped entity read scanned the whole schema and then threw most rows away.
This adds `ExactFileIdFilterAnalyzer` (`=`, `IN (...)`, both operand orders,
intersected across conjuncts) and applies it in `plan_scan_parts`.

Nothing physical was invented. The route already existed and was simply
unreachable from SQL: `HOT_ROW` is keyed `schema_key ++ file_id ++ entity_pk`
and `hot_scan_entries` already owns `hot_file_scan_prefixes`
(`hot.rs:10405`), which fires for exactly `schema_key + file_id`. The change is
one analyzer wiring an existing physical capability to the planner.

**Removed:** the residual `FilterExec` above every file-scoped entity scan, and
with it the O(rows in branch) term. No new writer, space, index, or code path;
no dual route is kept — a shape the seek cannot represent (`IS NULL`, `!=`, a
disjunction mixing in a payload column) stays `Unsupported` and falls back to
the existing scan plus residual.

Also updated the now-stale `append_hot_diff_key_parts` doc block, which said
this route "is not implemented", and the `working_diff_file_scope` bench comment
that described the gap.

## Primary metric — the `entity_scan` over-scan curve

`working_diff_file_scope`, rocksdb, `hetzner-cpx62-II`, **4 rotated passes per
arm** (`base cand` / `cand base` / `cand base` / `base cand`), 9 internal reps
each = 36 samples per arm per scale. The answer is fixed at 40 rows
(`entity_scan_rows=40`) at every scale; only the branch grows.

`SELECT id FROM wd_file_row WHERE lixcol_file_id = $1`

| total dirty rows | base p50 (ms) | cand p50 (ms) | speedup |
|---|---|---|---|
| 1 000   | **1.220**   | **0.099** | 12.3× |
| 20 000  | **23.528**  | **0.112** | 210×  |
| 100 000 | **126.598** | **0.121** | 1046× |

Raw per-pass p50 (ms):

| scale | base | cand |
|---|---|---|
| 1k   | 1.063, 1.365, 1.158, 1.281      | 0.105, 0.109, 0.091, 0.093 |
| 20k  | 21.989, 24.480, 23.321, 23.735  | 0.113, 0.110, 0.111, 0.119 |
| 100k | 126.157, 127.038, 123.416, 128.689 | 0.121, 0.133, 0.121, 0.121 |

The ranges do not come close to overlapping: at 100k the base arm's *minimum*
over all passes is 121.902 ms and the cand arm's *maximum* is 0.460 ms.

**Slope, not intercept** — this is the point of the change:

* base: 1.2665 µs of latency per additional dirty row in the branch
  (`(126.598 − 1.220) / 99 000`). 100× the data, 103.8× the time — linear in
  the branch, flat in the answer.
* cand: 0.222 ns per row (`(0.121 − 0.099) / 99 000`). 100× the data, 1.22× the
  time. **The slope drops by ~5 700×**; what remains is cache/level effects, not
  a scan term.

### Null control

The same bench process times four other shapes whose code is **byte-identical in
both arms** (`full`, `file`, `file_schema`, `point` are all `lix_working_diff`
queries; this PR does not touch that provider). Same fixture, same reps, same
process — a better control than a separate benchmark.

| control column | 1k | 20k | 100k |
|---|---|---|---|
| `full`        | −5.7% | +0.2% | +4.8% |
| `file`        | −3.0% | −2.1% | +1.4% |
| `file_schema` | −10.0% | +0.3% | +1.4% |
| `point`       | −13.2% | +3.2% | +14.4% |

**Noise floor: ±5% on the multi-millisecond columns, ±14% on the
sub-millisecond `point` and `file_schema`-at-1k columns.** The measured effect (12×–1046×) is three orders of magnitude
outside it.

## Guards

Two rotated passes per arm (`base cand`, then `cand base`), each an unfiltered
criterion run — 109 comparable ids across `tracked_state_crud`,
`untracked_state_crud` and `diff_commands`. **I stopped at two passes
deliberately**: this is a plan-time predicate analyzer, the question is "did any
lane move beyond the noise band", and the guard matrix had grown to hours of
machine time for a question the read ids answer in minutes. Guard cost was cut
on purpose; I am not implying more measurement than I did.

Whole-distribution view over all 109 ids: **mean −0.86%, median −1.8%,
p10 −8.5%, p90 +6.0%, min −21.9%, max +20.5%.** Symmetric around zero, with the
extremes on 13–24 µs `kv_layout` ids where two criterion runs cannot resolve
anything. No directional movement.

Read ids called out in the brief (p50 ms, base → cand):

| id | base | cand | Δ |
|---|---|---|---|
| `sql_session/rocksdb/smoke/read_all_rows_consumed/1k`        | 2.2208 | 2.0741 | −6.6% |
| `sql_session/rocksdb/real_workload/read_all_rows_consumed/10k` | 5.9481 | 6.1435 | +3.3% |
| `sql_session/slatedb/smoke/read_all_rows_consumed/1k`        | 2.5219 | 2.4751 | −1.9% |
| `sql_session/slatedb/real_workload/read_all_rows_consumed/10k` | 6.6888 | 6.5688 | −1.8% |
| `sql_session/rocksdb/smoke/read_one_by_pk/1k`                | 1.5200 | 1.6046 | +5.6% |
| `sql_session/rocksdb/real_workload/read_one_by_pk/10k`       | 1.7367 | 1.7559 | +1.1% |
| `sql_session/slatedb/smoke/read_one_by_pk/1k`                | 1.7634 | 1.6698 | −5.3% |
| `sql_session/rocksdb/smoke/read_many_by_pk/10`               | 1.6284 | 1.6946 | +4.1% |
| `sql_session/slatedb/real_workload/read_many_by_pk/10`       | 2.2037 | 2.0791 | −5.7% |

Write ids (`sql_session`, both backends, insert/update/delete × smoke and
real_workload, 20 ids): every one within −12.5%…+3.3%, **17 of 20 negative**
(nominally faster). A plan-time analyzer cannot make writes faster; that skew is
the two-sample noise band, and it is the direction that matters — nothing shows
a write regression.

`diff_commands`: `apply_100_of_1000` −2.6%, `partial_checkpoint_500_of_1000`
−2.0%, `revert_100_of_1000` +4.8%, `working_diff_1000` +3.8%.

**Not run: `space_growth` (settled bytes).** The guard loop was stopped before
that stage. Stating it plainly rather than inferring a number: this change adds
no writer and touches no staging code — it is entirely plan-time predicate
analysis on the read path — so settled bytes cannot move. If you want the
measurement anyway it is one `space_growth` run per arm and I will do it.

## Correctness: the scan-vs-bypass asymmetry

**Verdict: provably equivalent, not a live bug.** The two sites classify
*different populations*, and the difference is unreachable rather than merely
unobserved.

`hot_working_diff_entries` has two paths. The index path (`hot.rs:9901`, `:9916`)
enumerates the sparse `HOT_DIFF` scope and then loads each dirty identity's
primary row; on an untracked or absent primary row it returns `Ok(None)`, which
makes the caller fall back to canonical replay. The finite bypass
(`finite_working_diff_versions`, `hot.rs:9978`, `:10001`) reads primary rows
directly for a finite `schema_key + entity_pk` filter and *skips* untracked,
absent, clean, and foreign-checkpoint rows.

That looks like a disagreement, but the two never see the same population:

* The index path only ever visits identities that `HOT_DIFF` already asserts are
  **dirty against this checkpoint**. For such an identity, untracked/absent/clean
  is corruption, so failing closed is right.
* The bypass visits **every primary row matching a finite identity filter**,
  where clean, untracked and absent rows are the ordinary majority. Skipping them
  is the classification, not a bail-out.

A dirty identity always has a tracked primary row in its generation, for four
independent reasons:

1. `HOT_DIFF` keys are only written for `!delta.untracked` deltas — both in
   `stage_*_current_state_with_working_diff` and in
   `stage_incremental_file_delete_cascades`.
2. A primary row is physically removed only when
   `CurrentStateDelta::physically_deletes` holds, which is
   `untracked && deleted` (`tracked_head.rs:418`). A **tracked** delete writes a
   tombstone that keeps its baseline. The file-delete cascade obeys the same rule
   (`hot.rs:7815` deletes only `existing.untracked`; tracked members get a
   tombstone plus a baseline). So a dirty row cannot vanish.
3. `reject_retention_change` (`tracked_head.rs:602`) makes retention immutable
   while any physical member exists — with a comment saying exactly why: letting
   an untracked member overwrite a tracked tombstone "would erase the tracked
   checkpoint baseline and make a later diff silently miss the removal". So a
   dirty tracked row cannot be replaced by an untracked one.
4. The `HOT_DIFF` scope prefix contains the checkpoint **and** the generation, so
   a `Clean` baseline or a foreign checkpoint owner cannot appear under the scope
   the epoch names. Lifecycle republication builds a new generation and resets
   coverage.

### Evidence, not just argument

`engine::tests::working_diff_finite_bypass_and_index_scan_agree_on_every_row_state`
builds every reachable row shape through the public SQL surface — clean,
modified, removed, added, added-then-removed, untracked, untracked-recycled-as-
tracked (an untracked delete *does* physically vacate the `HOT_ROW` slot, then a
tracked insert reuses it), and never-existed — then compares
`WHERE schema_key = ?` against `WHERE schema_key = ? AND entity_pk = ?` for each
identity. It also asserts that writing an untracked row over a dirty tracked
identity **errors**, which is the invariant the equivalence rests on.

The test is **not vacuous**: a test-only counter
(`live_state::WORKING_DIFF_PATH_HITS`) is incremented at the head of each path,
and the test asserts the broad query took the index path and every finite query
took the bypass. Without it the test could have compared one path against itself.

Both sites now carry the equivalence argument as a comment, so the next audit
does not re-flag it. I deliberately did **not** relax the index path's guards to
match the bypass — over its population those states are corruption and should
keep failing closed.

## Soundness: which rows can be absent from `HOT_ROW`

This was the crux, and it resolves in favour of the fast path — because
`hot_scan_entries` is only **one of four legs** of the live-state merge in
`scan_live_batch_for_generation_with_visibility` (`hot.rs:5182`–`5292`):

| authority | rows with no branch-local `HOT_ROW` | honours `file_ids`? |
|---|---|---|
| `HOT_ROW` overlay | — | yes — **`hot_file_scan_prefixes`**, the seek this PR reaches |
| packed current base | rows published through the collection-replacement / packed-insert lanes | yes — `packed_identity_matches_filter` (`hot.rs:3038`) |
| certified entity batches | plugin-certified batches | yes — and it has its **own** file-scoped manifest seek (`hot.rs:983`) |
| root current base | rows inherited from a referenced root, never rewritten locally | yes — and it also builds **exact file scopes** (`hot.rs:3195`) |

So the answer is not "the fast path covers those rows" and not "they cannot
occur" — it is that **the other three legs still run, and each already applies
the same file filter**, two of them with their own file-scoped seek. A row living
only in a referenced root base is returned by the root leg exactly as before;
only the `HOT_ROW` leg got faster. That is also why the risk direction here is
*extra* rows, never missing ones: if a leg ignored `file_ids` the merge would
over-return, and internal callers that already set `file_ids`
(`context.rs:2500`, `tracked_head.rs:3039`) would have been broken long before
this PR.

`engine::tests::file_scoped_entity_read_matches_the_unfiltered_scan` pins this at
the public surface: rows are written **before and after a checkpoint** (so they
reach the read through different authorities), and the file-scoped read is
compared against the unfiltered scan filtered in Rust, including `NULL` file ids,
an `IN` list, a `file_id + primary key` point read, and a contradictory
`file_id + primary key` pair that must return nothing.

`sql2::providers::entity::tests::file_id_filter_pushes_an_exact_file_scope_into_scan`
proves the predicate actually lands in `LiveStateFilter::file_ids` rather than
quietly staying a residual — a passing end-to-end test alone could not tell the
two apart, since a residual also returns the right rows.

## Layout invariants

1. **Single authority — no.** No second writer, no second materialization, no
   parallel index. The change adds a plan-time predicate analyzer and populates
   an existing filter field; nothing new is persisted and nothing is duplicated.
2. **Commit canonicality — unaffected.** No commit record, parent link, ref, or
   state root is read or written differently.
3. **Derived views are caches — preserved.** `HOT_ROW`, the packed and root
   current bases, and the certified batches remain disposable caches; this only
   narrows *which part* of them is read. No new derived view.
4. **Atomic publication — unaffected.** Read-path only; no staging or write-set
   code is touched.
5. **GC from refs — unaffected.** No retention metadata is added or read.
6. **SQL reads canonical records — yes.** The entity surface still reads the
   same four-authority live-state merge; only the physical access method for the
   `HOT_ROW` leg changes, from full scan + residual to prefix seek.

## Gate

Merged `origin/claude-3-optimizations` (`c7def1582`) into this branch. Two
conflicts, both trivial: adjacent `#[cfg(test)]` re-export lines in
`live_state/mod.rs` and `live_state/tracked_head.rs`, where upstream added
`hot_generation_scope_prefix` next to this PR's `WORKING_DIFF_PATH_HITS`. Both
sides kept; `hot.rs` auto-merged and both path counters plus the equivalence
comments survived intact.

Re-run on the merged head (`a41d0f26d`):

* `cargo test -p lix --all-features` — pass (2 081 lib + 830 integration). All
  three new tests green: `working_diff_finite_bypass_and_index_scan_agree_on_every_row_state`,
  `file_scoped_entity_read_matches_the_unfiltered_scan`,
  `file_id_filter_pushes_an_exact_file_scope_into_scan`.
* `cargo clippy --workspace --all-targets --all-features -- -D warnings` — clean.
* No `packages/js-sdk/` changes, so the wasm target is unaffected.

Benchmarks were **not** re-run after the merge. The numbers above were measured
at `07d680b30`; the merged-in work is idempotency-receipt encoding and hot
generation retirement, neither of which can interact with a plan-time predicate
analyzer. Recording that the measurements predate the merge rather than implying
they were repeated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
