### PR TITLE
perf(slatedb): flush the WAL on a durable commit instead of parking on the 100 ms ticker

### DIFF
--- a/.changenotes/faster-durable-writes-on-slatedb.md
+++ b/.changenotes/faster-durable-writes-on-slatedb.md
@@ -1,0 +1,7 @@
+---
+type: patch
+---
+
+Resumable media uploads on the SlateDB backend are dramatically faster.
+
+Writes that must cross a durability boundary — every part of a resumable file upload, and any statement acknowledged from a durable idempotency receipt — used to wait for SlateDB's periodic write-ahead-log flush timer, costing up to 100 ms of idle latency per commit no matter how small the payload. Lix now asks SlateDB to flush immediately instead of waiting for the timer. The durability guarantee is unchanged, and media ingest on SlateDB is over ten times faster.

--- a/packages/slatedb-storage/src/slatedb.rs
+++ b/packages/slatedb-storage/src/slatedb.rs
@@ -3827,15 +3827,35 @@ async fn drain_write_queue(
                     }
                 }
             }
-            db.write_with_options(
-                batch,
-                &SlateDBWriteOptions {
-                    await_durable,
-                    ..SlateDBWriteOptions::default()
-                },
-            )
+            // SlateDB's own `await_durable` write option does not ask for a WAL
+            // flush; it only parks on the WAL buffer's durability watcher, which
+            // fires either when the buffer exceeds `l0_sst_size_bytes` (64 MiB)
+            // or when the periodic `flush_interval` ticker (100 ms) elapses.
+            // Every durable commit under that ceiling therefore paid up to a
+            // full 100 ms tick of pure idle latency for a WAL write that costs
+            // microseconds. Enqueue the batch without waiting, then ask the
+            // batch writer to flush now. The flush message is ordered behind
+            // this batch on the same writer channel, so it carries exactly the
+            // same durability guarantee — the WAL SST is in the object store
+            // before the commit is acknowledged — and one flush covers every
+            // durable write in the drained group, amortizing the barrier
+            // across a concurrent window instead of serializing on the ticker.
+            async {
+                let handle = db
+                    .write_with_options(
+                        batch,
+                        &SlateDBWriteOptions {
+                            await_durable: false,
+                            ..SlateDBWriteOptions::default()
+                        },
+                    )
+                    .await?;
+                if await_durable {
+                    db.flush().await?;
+                }
+                Ok::<_, slatedb::Error>(handle.seqnum())
+            }
             .await
-            .map(|handle| handle.seqnum())
             .map_err(slatedb_error)
             .map_err(commit_outcome_unknown)
         };


### PR DESCRIPTION
## What changed

`drain_write_queue` in `packages/slatedb-storage/src/slatedb.rs` no longer passes `await_durable: true`
down to SlateDB's write option. It enqueues the batch non-durably and then calls `Db::flush()`.

**Why that is not a weakened barrier.** SlateDB's `await_durable` write option never *asks* for a WAL
flush. It only parks on the WAL buffer's durability watcher, which fires when the buffer exceeds
`l0_sst_size_bytes` (64 MiB) or when the periodic `flush_interval` ticker elapses — and lix takes
`Settings::default()`, which sets `flush_interval = 100 ms`. Every durable commit under the 64 MiB
ceiling therefore paid up to a full 100 ms tick of *idle* latency for a WAL write that takes ~100 µs.
`Db::flush()` sends a Flush message on the same writer channel, strictly ordered behind our batch, and
returns only once the WAL SST is in the object store. Same guarantee, no timer wait — and one flush
covers every durable write in the drained group, so the barrier is amortized across a concurrent
upload window instead of serialized on the ticker.

Nothing else changes: `await_durable == false` writes take a byte-identical path.

## Attribution of the fixed ~202 ms (measured before any change)

`resumable_initial_write` cost the same ~203 ms at 1 MiB and at 10 MiB. Three independent measurements
pinned it:

1. **Durable-wait trace.** Instrumenting both `completion.wait()` sites in `SlateDBWrite::commit`:
   5 samples produced exactly **2 `await_durable` waits each, ~99.5 ms apiece**, 199.6 ms of the
   202.76 ms measured. Zero backpressure waits. Real work ≈ 3 ms.
   (Two waits because the path is one 16 MiB-aligned part write plus the CAS publication —
   `media_upload.rs:354` and `stage_atomic_cas_publication` → `await_durable_commit`.)
2. **Flush-interval sweep** — the decisive test. Cost tracks `2 × flush_interval` exactly:

   | `flush_interval` | 1 MiB p50 | 10 MiB p50 | predicted `2 × I` |
   |---|---:|---:|---:|
   | 100 ms (default) | 202.6 ms | 203.4 ms | 200 ms |
   | 25 ms | 52.4 ms | 53.3 ms | 50 ms |
   | 5 ms | 12.0 ms | 18.1 ms | 10 ms |

3. **Size independence** is explained: 1 MiB and 10 MiB are both a single 16 MiB part, and both are far
   under the 64 MiB WAL size trigger, so both wait for the timer and nothing else.

**Verdict: removable overhead, not load-bearing durability.** The durability is real and is kept; only
the wait on a periodic timer is removed.

## A/B — machine `ryzen-9950x-I`, 4 reps per arm, interleaved with rotated arm order

Base = `claude-3-optimizations` @ `bdd8d3467`, cand = base + this commit. Both worktrees prebuilt
(`--no-run`) before any timing window.

### Primary 1: `large_blob_updates` / `resumable_initial_write` (p50 ms, `LIX_LARGE_BLOB_SAMPLES=9`)

| lane | base per-rep | cand per-rep | med base | med cand | delta |
|---|---|---|---:|---:|---:|
| **slatedb 1 MiB** | 202.10, 202.45, 203.09, 203.25 | 1.12, 1.06, 1.03, 1.08 | **202.774** | **1.074** | **−99.5%** |
| **slatedb 10 MiB** | 203.25, 203.22, 202.37, 203.00 | 5.32, 5.20, 5.17, 5.12 | **203.106** | **5.184** | **−97.4%** |
| rocksdb 1 MiB | 1.37, 1.48, 1.48, 1.37 | 1.37, 1.48, 1.50, 1.49 | 1.425 | 1.488 | +4.3% |
| rocksdb 10 MiB | 11.27, 11.25, 12.46, 12.51 | 11.24, 12.28, 12.20, 12.79 | 11.863 | 12.239 | +3.2% |

SlateDB now beats RocksDB on this lane in both sizes (1.07 vs 1.49 ms; 5.18 vs 12.24 ms).

### Primary 2: media ingest, `slatedb_movie_workspace_interference`

| rep | base MiB/s | cand MiB/s |
|---|---:|---:|
| 1 | 153.5 | 1710.2 |
| 2 | 153.3 | 1573.5 |
| 3 | 153.2 | 1681.0 |
| 4 | 153.3 | 1730.4 |
| **median** | **153.3** | **1695.6** |

**+1006% (11.1×).** Ranges do not overlap by an order of magnitude.
For scale, the RocksDB arm of the same qualification medians ~721 MiB/s, so SlateDB ingest goes from
0.21× RocksDB to 2.35× RocksDB.

## Guards

| guard | reps | result |
|---|---|---|
| `slatedb_movie_workspace_interference` `save_p95` | 4 | base med 2.168 ms → cand med 1.952 ms (−10%) |
| `slatedb_movie_workspace_interference` `stream_N_late` | 4 | 0 / 0 in all 8 runs, both arms |
| settled bytes (SlateDB fixture) | 4 | base 679,826,942–679,842,515 vs cand 679,826,033–679,836,498 — overlapping; `lix-immutable-value-segment-v1` identical to 1 byte |
| structural row counts | 4 | `temporary_leaf_rows=32`, `legacy_chunk_rows=512`, `row_reduction_x=16.0` identical in every run |
| `rocksdb_movie_workspace_interference` (null control) | 3 | base 659.4 / 721.9 / 753.3 vs cand 696.4 / 768.3 MiB/s — overlapping; establishes ~±8% noise for this bench |
| `large_blob_updates` other lanes | 4 | all within ±6% |
| `small_blob_cas` (`4,64,256 KiB × 100 samples`) | 4 | 39 lanes, 3 beyond ±5%; largest is slatedb `unique_write/64K` at −12.9% with fully overlapping raw ranges |
| `tracked_state_crud` write/read ids + `slatedb_file_api` | 1 | 78 lanes, **zero** beyond ±10%, max +7.9% |

**Null controls / noise floor.** `raw_backend_initial_write` in `large_blob_updates` moved −29.9%
(1 MiB) and −14.7% (10 MiB) between arms on sub-millisecond timings — that is this bench's floor for
those lanes, and the −99.5% primary is three orders of magnitude outside it. The RocksDB lanes are a
second null control (the adapter is untouched): they move up to +5.8% in `small_blob_cas` and +5.4% in
`tracked_state_crud`, which is the floor for those benches. Every SlateDB guard delta sits inside its
own backend-matched noise floor.

`tracked_state_crud` and `slatedb_file_api` ran 1 rep rather than 3. Justification: neither bench sets
`StorageWriteOptions::await_durable` nor an idempotency key (verified by grep), so both take the
unchanged `await_durable == false` branch — they are structural null controls, and 78/78 lanes agreeing
within ±10% confirms it.

## Regressions

None resolved above the relevant noise floor. RocksDB `resumable_initial_write` shows +4.3% / +3.2%,
which is inside that bench's rocksdb-lane spread and cannot be caused by this diff — the RocksDB
adapter is not touched.

## Layout invariants

1. **Single authority** — no new authority. One durability barrier is *moved earlier in time*, not
   duplicated.
2. **Commit canonicality** — untouched.
3. **Derived views are caches** — untouched.
4. **Atomic publication** — preserved and strengthened in ordering terms: the flush is strictly ordered
   behind the batch on the same writer channel, so a commit is still acknowledged only after its whole
   write set is durable.
5. **GC from refs** — untouched.
6. **SQL reads canonical records** — untouched.

## Correctness gate (on `ryzen-9950x-I`)

- `cargo check --workspace` — clean
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` — clean
- `cargo test -p lix --all-features` — **2074 + 830 + 18 tests, 0 failed**

Note that `await_durable_write_does_not_acknowledge_a_blocked_wal_upload`
(`slatedb.rs`) is a direct guard on this change and still passes: with the WAL upload blocked, the
durable commit does not acknowledge. It is now a *stronger* test, since the ack no longer has a 100 ms
timer to hide behind.

## Bench commands

```sh
LIX_LARGE_BLOB_ACCOUNTING=1 LIX_LARGE_BLOB_SAMPLES=9 LIX_LARGE_BLOB_SIZES_MIB=1,10 \
  LIX_LARGE_BLOB_SKIP_SPACE_ACCOUNTING=1 \
  cargo bench -p lix_benchmarks --features storage-benches,slatedb --bench large_blob_updates

cargo test -p lix_benchmarks --features 'storage-benches slatedb' \
  --test movie_workspace_qualification slatedb_movie_workspace_interference \
  --release -- --ignored --nocapture

LIX_SMALL_BLOB_SIZES_KIB=4,64,256 LIX_SMALL_BLOB_SAMPLES=100 \
  cargo bench -p lix_benchmarks --features storage-benches,slatedb --bench small_blob_cas
```

## Separately: the ~110 ms project save is a *different* bug

The qualification's one-per-run ~110 ms project save was investigated in the same session and does
**not** share this root cause. `lix_perf` span tracing localizes it exactly:

```
lix.perf.materialization.tracked_roots: close time.busy=107ms time.idle=1.36µs
```

- **CPU-busy, not blocked** — 1.36 µs idle across the whole 107 ms.
- **Flat against `flush_interval`** — 108.7 ms at 5 ms, 107.7 ms at 500 ms.
- **Periodic every 33 commits**, exactly: over 5042 `tracked_roots` spans in one run, all 150 gaps
  between the >1 ms spans are 33. That is `COMMIT_STATE_MAX_REPLAY_DEPTH = 32` closing a rootless
  replay interval and forcing a durable root rebuild (`commit.rs:1405`, `durable_root_rebuild_parents`).
- **Cost grows with history**: 1.3 ms at the first rebuild → 107 ms after ~5000 commits.
- **It also reproduces on RocksDB** (44.06 ms save, 42.6 ms `tracked_roots` span, same sample index 14),
  contradicting the note in `MOVIE_WORKSPACE.md` that it is SlateDB-only — it was simply less
  conspicuous there because RocksDB's baseline `save_p95` is ~45 ms.

So: **two bugs, not one.** This PR fixes the SlateDB-only timer stall. The periodic O(live-state)
tracked-root rebuild is a backend-independent lix cost and is left for a separate change.
