### PR TITLE
perf: claude-3 optimization program, wave 2

### DIFF
--- a/.changenotes/concurrent-writers-no-longer-conflict.md
+++ b/.changenotes/concurrent-writers-no-longer-conflict.md
@@ -1,0 +1,7 @@
+---
+type: patch
+---
+
+Fixed `LIX_TRANSACTION_CONFLICT` being raised for writers that do not actually conflict.
+
+Saving a file while a resumable media upload was in progress — or running the four parts of one upload's in-flight window — could fail with "transaction snapshot is stale", because every content-addressed publication shared a single compare-and-set row with every garbage-collection sweep. Publications now fence only against sweeps, so independent writers commit independently; a sweep still cannot commit across a concurrent publication, and a publication still cannot commit across a concurrent sweep.

--- a/.changenotes/faster-durable-writes-on-slatedb.md
+++ b/.changenotes/faster-durable-writes-on-slatedb.md
@@ -1,0 +1,7 @@
+---
+type: patch
+---
+
+Resumable media uploads on the SlateDB backend are dramatically faster.
+
+Writes that must cross a durability boundary — every part of a resumable file upload, and any statement acknowledged from a durable idempotency receipt — used to wait for SlateDB's periodic write-ahead-log flush timer, costing up to 100 ms of idle latency per commit no matter how small the payload. Lix now asks SlateDB to flush immediately instead of waiting for the timer. The durability guarantee is unchanged, and media ingest on SlateDB is over ten times faster.

--- a/.changenotes/file-scoped-entity-reads.md
+++ b/.changenotes/file-scoped-entity-reads.md
@@ -1,0 +1,7 @@
+---
+type: patch
+---
+
+Reading entity rows by `lixcol_file_id` now seeks straight to that file instead of scanning the whole schema.
+
+`SELECT ... WHERE lixcol_file_id = ?` previously matched the file only after every row of the schema had been read, so a narrow read of one file grew with the size of the branch. The file scope is now part of the scan itself, and the cost tracks the number of rows in the file.

--- a/.changenotes/reclaim-deleted-branch-storage.md
+++ b/.changenotes/reclaim-deleted-branch-storage.md
@@ -1,0 +1,7 @@
+---
+type: patch
+---
+
+Garbage collection now reclaims the storage a deleted or superseded branch leaves behind.
+
+Every branch serves its current state from a generation of derived rows. When a branch was deleted, or when a lifecycle publication replaced its generation, those rows were never reclaimed and stayed on disk forever. Repository GC now retires them as part of its ordinary pass, so deleting a branch and collecting frees the space it actually used — measured at roughly 85% less residual storage after deleting a branch in a 10,000-row workspace.

--- a/.changenotes/reuse-sql-sessions-across-statements.md
+++ b/.changenotes/reuse-sql-sessions-across-statements.md
@@ -1,0 +1,7 @@
+---
+type: patch
+---
+
+Faster repeated SQL reads: a pooled query session is now reused across statements instead of being rebuilt for each one.
+
+The engine used to re-register its per-statement SQL functions, re-install the `information_schema` views and deep-copy its function registries on every statement. Those are now installed once per session, and repeated statement shapes reuse the prepared scan plan directly. Point and multi-key reads get noticeably cheaper; results are unchanged.

--- a/.changenotes/skip-rewriting-durable-tree-chunks.md
+++ b/.changenotes/skip-rewriting-durable-tree-chunks.md
@@ -1,0 +1,7 @@
+---
+type: patch
+---
+
+Commits no longer rewrite tracked-state tree nodes that are already stored.
+
+The tracked-state tree is content-addressed, so a node's identity is its content. Rebuilding a commit root could still re-write nodes that were byte-for-byte already on disk, and neither storage backend filtered those out. Writers now check first and stage only genuinely new nodes, cutting redundant write traffic in long histories by roughly three quarters without changing on-disk size or query results.

--- a/.changenotes/smaller-idempotency-receipts.md
+++ b/.changenotes/smaller-idempotency-receipts.md
@@ -1,0 +1,14 @@
+---
+type: patch
+---
+
+Server SQL mutations now store much smaller retry receipts.
+
+Every `/execute` write records its response so a retry with the same
+`Idempotency-Key` returns the recorded result instead of mutating twice. That
+record previously encoded returned binary values as arrays of decimal numbers,
+costing about 3.6 stored bytes per payload byte, so a mutation using `RETURNING`
+over file content retained nearly four permanent copies of it. Receipts now use
+a compact encoding: about 1.33 bytes per payload byte and about a third less for
+mutations with no `RETURNING`. The 8 MiB replay limit consequently accepts
+roughly 6 MiB of returned content where it previously accepted about 2.2 MiB.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3438,6 +3438,7 @@ dependencies = [
  "codspeed-criterion-compat",
  "datafusion",
  "duckdb",
+ "fastcdc",
  "futures-util",
  "libc",
  "lix",

--- a/packages/engine-benchmarks/Cargo.toml
+++ b/packages/engine-benchmarks/Cargo.toml
@@ -66,6 +66,11 @@ path = "examples/space_growth.rs"
 required-features = ["storage-benches"]
 
 [[example]]
+name = "expv_blind_space_growth"
+path = "examples/expv_blind_space_growth.rs"
+required-features = ["storage-benches"]
+
+[[example]]
 name = "storage_layout"
 path = "examples/storage_layout.rs"
 required-features = ["storage-benches", "slatedb"]

--- a/packages/engine-benchmarks/Cargo.toml
+++ b/packages/engine-benchmarks/Cargo.toml
@@ -198,6 +198,12 @@ harness = false
 required-features = ["storage-benches", "slatedb"]
 
 [[bench]]
+name = "working_diff_file_scope"
+path = "benches/working_diff_file_scope.rs"
+harness = false
+required-features = ["storage-benches", "slatedb"]
+
+[[bench]]
 name = "slatedb_file_api"
 path = "benches/slatedb_file_api.rs"
 harness = false

--- a/packages/engine-benchmarks/Cargo.toml
+++ b/packages/engine-benchmarks/Cargo.toml
@@ -104,6 +104,11 @@ name = "cas_publication_epoch_qualification"
 path = "examples/cas_publication_epoch_qualification.rs"
 required-features = ["storage-benches", "slatedb"]
 
+[[example]]
+name = "expW_hot_row_anatomy"
+path = "examples/expW_hot_row_anatomy.rs"
+required-features = ["storage-benches", "slatedb"]
+
 [[test]]
 name = "exact_file_read_benchmark"
 path = "tests/exact_file_read_benchmark.rs"

--- a/packages/engine-benchmarks/Cargo.toml
+++ b/packages/engine-benchmarks/Cargo.toml
@@ -81,6 +81,11 @@ path = "examples/duplicate_audit.rs"
 required-features = ["storage-benches", "slatedb"]
 
 [[example]]
+name = "expu_json_delta"
+path = "examples/expu_json_delta.rs"
+required-features = ["storage-benches", "slatedb"]
+
+[[example]]
 name = "revision_pack_oracle"
 path = "examples/revision_pack_oracle.rs"
 required-features = ["storage-benches", "slatedb"]

--- a/packages/engine-benchmarks/Cargo.toml
+++ b/packages/engine-benchmarks/Cargo.toml
@@ -66,6 +66,11 @@ path = "examples/space_growth.rs"
 required-features = ["storage-benches"]
 
 [[example]]
+name = "delta_segment_duplication"
+path = "examples/delta_segment_duplication.rs"
+required-features = ["storage-benches"]
+
+[[example]]
 name = "storage_layout"
 path = "examples/storage_layout.rs"
 required-features = ["storage-benches", "slatedb"]

--- a/packages/engine-benchmarks/MOVIE_WORKSPACE.md
+++ b/packages/engine-benchmarks/MOVIE_WORKSPACE.md
@@ -31,6 +31,61 @@ this workload, so the larger CAS unit did not improve ingest and slightly
 regressed save p95. The engine therefore retains 1 MiB chunks; remote
 object-store latency profiles may justify revisiting the choice.
 
+## Each actor runs as its own task
+
+Ingest, project saves and the two proxy streams are spawned as four separate
+tokio tasks. They were previously branches of a single `tokio::join!` future,
+which put all four on one task: a slow write in any branch could not overlap a
+playback read, and the resulting scheduling delay was charged to the playback
+deadline.
+
+That is not a hypothetical. On SlateDB one project save per run — the save at
+t = 1200 ms — takes ~110 ms while every other save takes under 8 ms. Joined on
+one task, that save delayed both playback wake-ups by 69-70 ms against an 80 ms
+budget, and `stream_N_late` flipped to 1 whenever concurrent ingest pushed the
+delay past 80 ms. The proxy reads themselves were never slow: p99 5.6 ms, max
+5.9 ms, against the same 80 ms budget.
+
+The null control (`slatedb_movie_workspace_playback_control`, identical
+schedule with the ingest removed) reproduced the same 69-70 ms delay in 6 of 6
+stream-runs, which is what identified the save rather than ingest interference
+as the cause. `LIX_MOVIE_PLAYBACK_TRACE=1` prints per-sample read latency, per
+save latency, upload-window completion times, and a spawned runtime watchdog
+whose worst gap stayed at 2.0-2.6 ms throughout — proving the executor was not
+starved and the stall was confined to the joined task.
+
+The ~110 ms SlateDB save and the ~200 ms fixed cost of every
+`resumable_initial_write` in `large_blob_updates` are unexplained write-path
+stalls, tracked separately. Neither is a read-path defect.
+
+## Diagnostic environment variables
+
+None of these are set by the qualification itself.
+
+| Variable | Effect |
+| --- | --- |
+| `LIX_MOVIE_PLAYBACK_TRACE=1` | per-sample playback/save traces, upload-window times, runtime watchdog |
+| `LIX_MOVIE_WORKER_THREADS=N` | runtime width; the qualification profile is 4 |
+| `LIX_MOVIE_STREAM_SAMPLES=N` | playback sample count, for looking past the 40-sample window |
+| `LIX_MOVIE_UPLOAD_CONCURRENCY=N` | upload parts in flight, 1-4 |
+
+## First-window upload contention
+
+`chunk_hash_bytes_including_retries` measures payload actually hashed,
+including optimistic retries, so re-hashed parts are visible directly. For the
+512 MiB timed ingest it is exactly `512 MiB + (concurrency - 1) x 16 MiB`:
+
+| Upload concurrency | Hashed bytes | Re-hashed | Ingest |
+| ---: | ---: | ---: | ---: |
+| 1 | 536,870,912 (512 MiB) | 0 | 153.1 MiB/s |
+| 2 | 553,648,128 (528 MiB) | 16 MiB | 152.8 MiB/s |
+| 4 | 587,202,560 (560 MiB) | 48 MiB | 153.1 MiB/s |
+
+Exactly one part per extra in-flight part is re-hashed, and only in the first
+window, where `UPLOAD_STATE_SPACE` is absent for every concurrent part and the
+losers retry. It is bounded wasted work, not a scaling term, and ingest on this
+local-filesystem profile does not move with concurrency at all.
+
 ## Artificial object-store latency
 
 The latency qualification wraps the local object store and delays every

--- a/packages/engine-benchmarks/benches/branch_storage_sharing.rs
+++ b/packages/engine-benchmarks/benches/branch_storage_sharing.rs
@@ -45,6 +45,8 @@ const DEFAULT_SCENARIOS: &[&str] = &[
     "branches_10",
     "branches_100",
     "branches_10_1row",
+    "branches_2_disjoint_1pct",
+    "branches_2_identical_1pct",
     "merge_1pct",
     "delete_gc_1pct",
 ];

--- a/packages/engine-benchmarks/benches/large_blob_updates.rs
+++ b/packages/engine-benchmarks/benches/large_blob_updates.rs
@@ -444,7 +444,7 @@ where
     }
 
     async fn space_accounting(&self, space: SpaceId) -> SpaceAccounting {
-        space_accounting(&self.storage, space).await
+        space_accounting(&self.storage, space, self.workload.operation).await
     }
 }
 
@@ -515,12 +515,25 @@ struct SpaceAccounting {
     value_bytes: u64,
 }
 
-async fn space_accounting<S>(storage: &S, space: SpaceId) -> SpaceAccounting
+/// A physical space id has exactly one value semantics per fixture, and the
+/// accounting scan must use the one the operation under test actually wrote
+/// with. `raw_backend_initial_write` deliberately bypasses the binary CAS and
+/// stores plain payload bytes in the payload space, so scanning that space as
+/// `immutable` would hand raw payload bytes to the immutable-locator decoder
+/// and fail with `Corruption("immutable segment locator is invalid")`.
+async fn space_accounting<S>(
+    storage: &S,
+    space: SpaceId,
+    operation: Operation,
+) -> SpaceAccounting
 where
     S: Storage,
 {
-    let space = if space == PAYLOAD_SPACE {
+    let payload_is_immutable = !matches!(operation, Operation::RawBackendInitialWrite);
+    let space = if space == PAYLOAD_SPACE && payload_is_immutable {
         StorageSpace::immutable(space, "benchmark.binary_cas_payload")
+    } else if space == PAYLOAD_SPACE {
+        StorageSpace::mutable(space, "bench.raw_payload")
     } else {
         StorageSpace::mutable(space, "benchmark.binary_cas_metadata")
     };

--- a/packages/engine-benchmarks/benches/packed_history_scale.rs
+++ b/packages/engine-benchmarks/benches/packed_history_scale.rs
@@ -310,9 +310,9 @@ async fn run_case<S, Flush, FlushFuture>(
     );
     let lifecycle_write_amplification = ratio(lifecycle_io.write_bytes, logical_written_bytes);
     let storage_amplification = ratio(backend_bytes, logical_written_bytes);
-    let manifest = find_layout(&layout, "tracked_state.commit_delta_manifest.v2");
-    let segments = find_layout(&layout, "tracked_state.commit_delta_segment.v2");
-    let locators = find_layout(&layout, "tracked_state.change_locator.v1");
+    let manifest = find_layout(&layout, "tracked_state.commit_state_manifest.v7");
+    let segments = find_layout(&layout, "tracked_state.commit_delta_segment.v6");
+    let locators = find_layout(&layout, "tracked_state.change_locator.v2");
     let json_payloads = find_layout(&layout, "json_store.json");
 
     println!(
@@ -385,17 +385,22 @@ async fn run_case<S, Flush, FlushFuture>(
     );
 }
 
+/// `layout_accounting` enumerates every registered space, so a name that is not
+/// present is a stale namespace in this bench, not an empty space. Failing loudly
+/// is the only way the columns cannot silently rot into zeros the next time a
+/// namespace version is bumped.
 fn find_layout(layout: &[BenchLayoutAccounting], name: &str) -> BenchLayoutAccounting {
     layout
         .iter()
         .find(|space| space.space == name)
         .copied()
-        .unwrap_or(BenchLayoutAccounting {
-            space_id: 0,
-            space: "missing",
-            rows: 0,
-            key_bytes: 0,
-            value_bytes: 0,
+        .unwrap_or_else(|| {
+            let known = layout
+                .iter()
+                .map(|space| space.space)
+                .collect::<Vec<_>>()
+                .join(", ");
+            panic!("packed_history_scale asked for unregistered storage space '{name}'; registered: {known}")
         })
 }
 

--- a/packages/engine-benchmarks/benches/working_diff_file_scope.rs
+++ b/packages/engine-benchmarks/benches/working_diff_file_scope.rs
@@ -1,0 +1,461 @@
+#![allow(clippy::large_futures)]
+
+//! Scaling harness for **file-scoped** working-diff reads.
+//!
+//! `docs/diff-commands.md` documents `SELECT ... FROM lix_working_diff WHERE
+//! file_id = $1` as the headline shape, but no benchmark covered it. This
+//! harness holds the *returned* row count fixed and grows the *total* dirty
+//! set since the checkpoint, so the slope answers one question: does a
+//! narrow file-scoped working-diff read cost O(rows returned) or O(all dirty
+//! rows in the branch)?
+//!
+//! Three query shapes are timed against the same fixture:
+//!   * `full`   — unfiltered `lix_working_diff` (the existing bench shape)
+//!   * `file`   — `WHERE file_id = $1` on one lightly dirtied file
+//!   * `finite` — `WHERE schema_key = $1 AND entity_pk = lix_json($2)`, which
+//!                takes the existing finite-filter bypass in
+//!                `hot_working_diff_entries` and therefore never touches the
+//!                HOT_DIFF index or its coverage proof.
+//!
+//! ```text
+//! cargo bench -p lix_benchmarks --features storage-benches,slatedb \
+//!   --bench working_diff_file_scope -- rocksdb 64 40 100 9
+//! ```
+//! Positionals: `<rocksdb|slatedb> <files> <rows-per-file> <changes-per-commit> <reps>`
+//! then a list of total dirty-row targets, e.g. `1000 10000 100000`.
+
+use std::fmt::Write as _;
+use std::time::{Duration, Instant};
+
+#[cfg(not(target_family = "wasm"))]
+#[global_allocator]
+static GLOBAL_ALLOCATOR: mimalloc::MiMalloc = mimalloc::MiMalloc;
+
+use lix::integration::{Engine, SessionContext};
+use lix::storage::Storage;
+use lix::{ExecuteBatchStatement, Value};
+use lix_storage_rocksdb::RocksDB;
+use lix_storage_slatedb::SlateDB;
+
+const SCHEMA_KEY: &str = "wd_file_row";
+const INSERT_BATCH_SIZE: usize = 500;
+/// Rows dirtied inside the probe file. Held constant across every dirty-set
+/// size so the file-scoped query always returns the same number of rows.
+const PROBE_DIRTY_ROWS: usize = 4;
+
+fn main() {
+    let args = std::env::args().collect::<Vec<_>>();
+    let backend = args.get(1).map(String::as_str).unwrap_or("rocksdb");
+    let files = parse_usize(args.get(2), 64);
+    let rows_per_file = parse_usize(args.get(3), 40);
+    let changes_per_commit = parse_usize(args.get(4), 100);
+    let reps = parse_usize(args.get(5), 9);
+    let targets = args
+        .get(6..)
+        .map(|rest| {
+            rest.iter()
+                .filter(|value| value.parse::<usize>().is_ok())
+                .map(|value| value.parse::<usize>().expect("checked"))
+                .collect::<Vec<_>>()
+        })
+        .filter(|targets: &Vec<usize>| !targets.is_empty())
+        .unwrap_or_else(|| vec![1_000, 10_000, 100_000]);
+
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("create working-diff file-scope runtime");
+
+    for target in targets {
+        let dir = tempdir(backend, target);
+        runtime.block_on(async {
+            match backend {
+                "rocksdb" => {
+                    let storage = RocksDB::open(&dir).expect("open working-diff file-scope RocksDB");
+                    run(
+                        storage.clone(),
+                        backend,
+                        files,
+                        rows_per_file,
+                        changes_per_commit,
+                        target,
+                        reps,
+                    )
+                    .await;
+                    storage.flush().expect("flush RocksDB");
+                }
+                "slatedb" => {
+                    let storage = SlateDB::open(&dir).expect("open working-diff file-scope SlateDB");
+                    run(
+                        storage.clone(),
+                        backend,
+                        files,
+                        rows_per_file,
+                        changes_per_commit,
+                        target,
+                        reps,
+                    )
+                    .await;
+                    storage.flush().await.expect("flush SlateDB");
+                }
+                other => panic!("backend must be 'rocksdb' or 'slatedb', got '{other}'"),
+            }
+        });
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+}
+
+fn tempdir(backend: &str, target: usize) -> String {
+    let nanos = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .expect("clock")
+        .as_nanos();
+    format!("/tmp/lix-expS-wdfs-{backend}-{target}-{nanos}")
+}
+
+fn parse_usize(value: Option<&String>, default: usize) -> usize {
+    value.map_or(default, |value| {
+        value.parse::<usize>().unwrap_or_else(|_| default)
+    })
+}
+
+async fn run<StorageImpl>(
+    storage: StorageImpl,
+    backend: &str,
+    files: usize,
+    rows_per_file: usize,
+    changes_per_commit: usize,
+    dirty_target: usize,
+    reps: usize,
+) where
+    StorageImpl: Storage + Clone + Send + Sync + 'static,
+{
+    Engine::initialize(storage.clone())
+        .await
+        .expect("initialize working-diff file-scope storage");
+    let engine = Engine::new(storage.clone())
+        .await
+        .expect("open working-diff file-scope engine");
+    let session = engine
+        .open_workspace_session()
+        .await
+        .expect("open working-diff file-scope session");
+
+    register_schema(&session).await;
+    let file_ids = (0..files).map(file_id).collect::<Vec<_>>();
+    seed_files(&session, &file_ids).await;
+    // Every dirty row must exist before the checkpoint so the working diff is
+    // a pure "modified" set with a stable returned-row count.
+    let bulk_files = files.saturating_sub(1);
+    let bulk_rows_needed = dirty_target.saturating_sub(PROBE_DIRTY_ROWS);
+    let bulk_rows_per_file = bulk_rows_needed.div_ceil(bulk_files.max(1)).max(rows_per_file);
+    seed_rows(&session, &file_ids, bulk_rows_per_file).await;
+
+    session
+        .create_checkpoint()
+        .await
+        .expect("create working-diff file-scope checkpoint");
+
+    // Dirty exactly PROBE_DIRTY_ROWS rows inside file 0 …
+    dirty_rows(
+        &session,
+        &[(0usize, PROBE_DIRTY_ROWS)],
+        changes_per_commit,
+        bulk_rows_per_file,
+    )
+    .await;
+    // … and spread the remainder over files 1..files, never touching file 0.
+    let mut plan = Vec::new();
+    let mut remaining = bulk_rows_needed;
+    let mut file_index = 1usize;
+    while remaining > 0 && file_index < files.max(2) {
+        let take = remaining.min(bulk_rows_per_file);
+        plan.push((file_index, take));
+        remaining -= take;
+        file_index += 1;
+        if file_index >= files {
+            break;
+        }
+    }
+    assert_eq!(
+        remaining, 0,
+        "fixture cannot hold {dirty_target} dirty rows in {files} files \
+         at {bulk_rows_per_file} rows/file"
+    );
+    dirty_rows(&session, &plan, changes_per_commit, bulk_rows_per_file).await;
+
+    let total_dirty = count(&session, "SELECT COUNT(*) FROM lix_working_diff", &[]).await;
+    let probe_file = file_ids[0].clone();
+    let file_sql = "SELECT diff_id, entity_pk, schema_key, file_id, diff_type \
+                    FROM lix_working_diff WHERE file_id = $1";
+    let full_sql = "SELECT diff_id, entity_pk, schema_key, file_id, diff_type \
+                    FROM lix_working_diff";
+    let finite_sql = "SELECT diff_id, entity_pk, schema_key, file_id, diff_type \
+                      FROM lix_working_diff \
+                      WHERE schema_key = $1 AND entity_pk = lix_json($2)";
+    let file_params = vec![Value::Text(probe_file.clone())];
+    let finite_params = vec![
+        Value::Text(SCHEMA_KEY.to_string()),
+        Value::Text(format!("[\"{}\"]", row_id(0, 0))),
+    ];
+
+    // Warm provider construction and the block cache outside the samples.
+    let file_rows = rows(&session, file_sql, &file_params).await;
+    let full_rows = rows(&session, full_sql, &[]).await;
+    let finite_rows = rows(&session, finite_sql, &finite_params).await;
+
+    let file = sample(&session, file_sql, &file_params, reps).await;
+    let full = sample(&session, full_sql, &[], reps).await;
+    let finite = sample(&session, finite_sql, &finite_params, reps).await;
+
+    println!(
+        "working_diff_file_scope backend={backend} files={files} total_dirty={total_dirty} \
+         file_rows={file_rows} full_rows={full_rows} finite_rows={finite_rows} reps={reps} \
+         file_p50_ms={:.3} file_min_ms={:.3} file_max_ms={:.3} \
+         full_p50_ms={:.3} full_min_ms={:.3} full_max_ms={:.3} \
+         finite_p50_ms={:.3} finite_min_ms={:.3} finite_max_ms={:.3}",
+        millis(file.0),
+        millis(file.1),
+        millis(file.2),
+        millis(full.0),
+        millis(full.1),
+        millis(full.2),
+        millis(finite.0),
+        millis(finite.1),
+        millis(finite.2),
+    );
+    drop(session);
+    drop(engine);
+}
+
+async fn sample<StorageImpl>(
+    session: &SessionContext<StorageImpl>,
+    sql: &str,
+    params: &[Value],
+    reps: usize,
+) -> (Duration, Duration, Duration)
+where
+    StorageImpl: Storage + Clone + Send + Sync + 'static,
+{
+    let mut latencies = Vec::with_capacity(reps);
+    for _ in 0..reps {
+        let start = Instant::now();
+        let _ = rows(session, sql, params).await;
+        latencies.push(start.elapsed());
+    }
+    latencies.sort_unstable();
+    (
+        latencies[latencies.len() / 2],
+        latencies[0],
+        *latencies.last().expect("samples are non-empty"),
+    )
+}
+
+async fn rows<StorageImpl>(
+    session: &SessionContext<StorageImpl>,
+    sql: &str,
+    params: &[Value],
+) -> usize
+where
+    StorageImpl: Storage + Clone + Send + Sync + 'static,
+{
+    session
+        .execute(sql, params)
+        .await
+        .expect("working-diff query should succeed")
+        .len()
+}
+
+async fn count<StorageImpl>(
+    session: &SessionContext<StorageImpl>,
+    sql: &str,
+    params: &[Value],
+) -> i64
+where
+    StorageImpl: Storage + Clone + Send + Sync + 'static,
+{
+    let result = session
+        .execute(sql, params)
+        .await
+        .expect("working-diff count should succeed");
+    match result.rows().first().and_then(|row| row.get(0)) {
+        Some(Value::Integer(value)) => *value,
+        other => panic!("unexpected count row {other:?}"),
+    }
+}
+
+async fn register_schema<StorageImpl>(session: &SessionContext<StorageImpl>)
+where
+    StorageImpl: Storage + Clone + Send + Sync + 'static,
+{
+    let schema = serde_json::json!({
+        "x-lix-key": SCHEMA_KEY,
+        "x-lix-primary-key": ["/id"],
+        "type": "object",
+        "required": ["id", "value"],
+        "properties": {
+            "id": { "type": "string" },
+            "value": { "type": "string" }
+        },
+        "additionalProperties": false
+    });
+    session
+        .execute(
+            "INSERT INTO lix_registered_schema (value, lixcol_global, lixcol_untracked) \
+             VALUES (lix_json($1), false, false)",
+            &[Value::Text(schema.to_string())],
+        )
+        .await
+        .expect("register working-diff file-scope schema");
+}
+
+async fn seed_files<StorageImpl>(session: &SessionContext<StorageImpl>, file_ids: &[String])
+where
+    StorageImpl: Storage + Clone + Send + Sync + 'static,
+{
+    let mut transaction = session
+        .begin_transaction()
+        .await
+        .expect("begin file seed transaction");
+    for chunk in file_ids.chunks(100) {
+        let mut sql = String::from("INSERT INTO lix_file (id, path, content) VALUES ");
+        let mut params = Vec::with_capacity(chunk.len() * 3);
+        for (offset, id) in chunk.iter().enumerate() {
+            if offset > 0 {
+                sql.push(',');
+            }
+            let parameter = offset * 3;
+            write!(
+                sql,
+                "(${}, ${}, CAST(${} AS BYTEA))",
+                parameter + 1,
+                parameter + 2,
+                parameter + 3
+            )
+            .expect("write file insert parameters");
+            params.push(Value::Text(id.clone()));
+            params.push(Value::Text(format!("/f-{id}.txt")));
+            params.push(Value::Text("seed".to_string()));
+        }
+        transaction
+            .execute(&sql, &params)
+            .await
+            .expect("seed working-diff file-scope files");
+    }
+    transaction
+        .commit()
+        .await
+        .expect("commit file seed transaction");
+}
+
+async fn seed_rows<StorageImpl>(
+    session: &SessionContext<StorageImpl>,
+    file_ids: &[String],
+    rows_per_file: usize,
+) where
+    StorageImpl: Storage + Clone + Send + Sync + 'static,
+{
+    for (file_index, file) in file_ids.iter().enumerate() {
+        let mut transaction = session
+            .begin_transaction()
+            .await
+            .expect("begin row seed transaction");
+        for start in (0..rows_per_file).step_by(INSERT_BATCH_SIZE) {
+            let end = (start + INSERT_BATCH_SIZE).min(rows_per_file);
+            let mut sql =
+                format!("INSERT INTO {SCHEMA_KEY} (id, value, lixcol_file_id) VALUES ");
+            let mut params = Vec::with_capacity((end - start) * 3);
+            for (offset, row_index) in (start..end).enumerate() {
+                if offset > 0 {
+                    sql.push(',');
+                }
+                let parameter = offset * 3;
+                write!(
+                    sql,
+                    "(${}, ${}, ${})",
+                    parameter + 1,
+                    parameter + 2,
+                    parameter + 3
+                )
+                .expect("write row insert parameters");
+                params.push(Value::Text(row_id(file_index, row_index)));
+                params.push(Value::Text("baseline".to_string()));
+                params.push(Value::Text(file.clone()));
+            }
+            transaction
+                .execute(&sql, &params)
+                .await
+                .expect("seed working-diff file-scope rows");
+        }
+        transaction
+            .commit()
+            .await
+            .expect("commit row seed transaction");
+    }
+}
+
+/// Applies `count` updates inside each listed file, batching `changes_per_commit`
+/// statements into one commit so the HOT_DIFF packing threshold is exercised
+/// the same way an ordinary bulk edit would exercise it.
+async fn dirty_rows<StorageImpl>(
+    session: &SessionContext<StorageImpl>,
+    plan: &[(usize, usize)],
+    changes_per_commit: usize,
+    rows_per_file: usize,
+) where
+    StorageImpl: Storage + Clone + Send + Sync + 'static,
+{
+    let mut pending: Vec<ExecuteBatchStatement> = Vec::with_capacity(changes_per_commit);
+    for (file_index, count) in plan {
+        assert!(
+            *count <= rows_per_file,
+            "cannot dirty {count} rows in a file seeded with {rows_per_file}"
+        );
+        for row_index in 0..*count {
+            pending.push(ExecuteBatchStatement {
+                label: None,
+                sql: format!("UPDATE {SCHEMA_KEY} SET value = $1 WHERE id = $2"),
+                params: vec![
+                    Value::Text("dirty".to_string()),
+                    Value::Text(row_id(*file_index, row_index)),
+                ],
+            });
+            if pending.len() >= changes_per_commit {
+                flush(session, &mut pending).await;
+            }
+        }
+    }
+    flush(session, &mut pending).await;
+}
+
+async fn flush<StorageImpl>(
+    session: &SessionContext<StorageImpl>,
+    pending: &mut Vec<ExecuteBatchStatement>,
+) where
+    StorageImpl: Storage + Clone + Send + Sync + 'static,
+{
+    if pending.is_empty() {
+        return;
+    }
+    let results = session
+        .execute_batch(pending)
+        .await
+        .expect("dirty working-diff rows");
+    assert!(
+        results.iter().all(|result| result.rows_affected() == 1),
+        "every dirtying update must affect exactly one row"
+    );
+    pending.clear();
+}
+
+fn file_id(index: usize) -> String {
+    format!("66696c65-{:04x}-8000-8000-{:012x}", index & 0xffff, index)
+}
+
+fn row_id(file_index: usize, row_index: usize) -> String {
+    format!("f{file_index:04}-r{row_index:06}")
+}
+
+fn millis(duration: Duration) -> f64 {
+    duration.as_secs_f64() * 1_000.0
+}

--- a/packages/engine-benchmarks/benches/working_diff_file_scope.rs
+++ b/packages/engine-benchmarks/benches/working_diff_file_scope.rs
@@ -184,7 +184,6 @@ async fn run<StorageImpl>(
     );
     dirty_rows(&session, &plan, changes_per_commit, bulk_rows_per_file).await;
 
-    let total_dirty = count(&session, "SELECT COUNT(*) FROM lix_working_diff", &[]).await;
     let probe_file = file_ids[0].clone();
     let file_sql = "SELECT diff_id, entity_pk, schema_key, file_id, diff_type \
                     FROM lix_working_diff WHERE file_id = $1";
@@ -209,7 +208,7 @@ async fn run<StorageImpl>(
     let finite = sample(&session, finite_sql, &finite_params, reps).await;
 
     println!(
-        "working_diff_file_scope backend={backend} files={files} total_dirty={total_dirty} \
+        "working_diff_file_scope backend={backend} files={files} total_dirty={full_rows} \
          file_rows={file_rows} full_rows={full_rows} finite_rows={finite_rows} reps={reps} \
          file_p50_ms={:.3} file_min_ms={:.3} file_max_ms={:.3} \
          full_p50_ms={:.3} full_min_ms={:.3} full_max_ms={:.3} \
@@ -264,24 +263,6 @@ where
         .await
         .expect("working-diff query should succeed")
         .len()
-}
-
-async fn count<StorageImpl>(
-    session: &SessionContext<StorageImpl>,
-    sql: &str,
-    params: &[Value],
-) -> i64
-where
-    StorageImpl: Storage + Clone + Send + Sync + 'static,
-{
-    let result = session
-        .execute(sql, params)
-        .await
-        .expect("working-diff count should succeed");
-    match result.rows().first().and_then(|row| row.get(0)) {
-        Some(Value::Integer(value)) => *value,
-        other => panic!("unexpected count row {other:?}"),
-    }
 }
 
 async fn register_schema<StorageImpl>(session: &SessionContext<StorageImpl>)

--- a/packages/engine-benchmarks/benches/working_diff_file_scope.rs
+++ b/packages/engine-benchmarks/benches/working_diff_file_scope.rs
@@ -151,8 +151,7 @@ async fn run<StorageImpl>(
     seed_files(&session, &file_ids).await;
     // Every dirty row must exist before the checkpoint so the working diff is
     // a pure "modified" set with a stable returned-row count.
-    let bulk_rows_per_file = rows_per_file;
-    seed_rows(&session, &file_ids, bulk_rows_per_file).await;
+    seed_rows(&session, &file_ids, rows_per_file).await;
 
     session
         .create_checkpoint()
@@ -164,7 +163,7 @@ async fn run<StorageImpl>(
         &session,
         &[(0usize, PROBE_DIRTY_ROWS)],
         changes_per_commit,
-        bulk_rows_per_file,
+        rows_per_file,
     )
     .await;
     // … and spread the remainder over files 1..files, never touching file 0.
@@ -172,7 +171,7 @@ async fn run<StorageImpl>(
     let mut remaining = bulk_rows_needed;
     let mut file_index = 1usize;
     while remaining > 0 && file_index < files.max(2) {
-        let take = remaining.min(bulk_rows_per_file);
+        let take = remaining.min(rows_per_file);
         plan.push((file_index, take));
         remaining -= take;
         file_index += 1;
@@ -183,9 +182,9 @@ async fn run<StorageImpl>(
     assert_eq!(
         remaining, 0,
         "fixture cannot hold {dirty_target} dirty rows in {files} files \
-         at {bulk_rows_per_file} rows/file"
+         at {rows_per_file} rows/file"
     );
-    dirty_rows(&session, &plan, changes_per_commit, bulk_rows_per_file).await;
+    dirty_rows(&session, &plan, changes_per_commit, rows_per_file).await;
 
     let probe_file = file_ids[0].clone();
     let file_sql = "SELECT diff_id, entity_pk, schema_key, file_id, diff_type \

--- a/packages/engine-benchmarks/benches/working_diff_file_scope.rs
+++ b/packages/engine-benchmarks/benches/working_diff_file_scope.rs
@@ -213,9 +213,9 @@ async fn run<StorageImpl>(
     // `lixcol_file_id` into `TrackedStateFilter::file_ids` (its
     // `filter_pushdown` only recognizes branch-id and primary-key analyzers),
     // so this measures a full schema scan with a residual filter. Reported to
-    // keep that gap visible: `entity_rows` stays fixed at `rows_per_file`
+    // keep that gap visible: `entity_scan_rows` stays fixed at `rows_per_file`
     // while the latency tracks the whole schema.
-    let proxy_sql = format!("SELECT id FROM {SCHEMA_KEY} WHERE lixcol_file_id = $1");
+    let entity_scan_sql = format!("SELECT id FROM {SCHEMA_KEY} WHERE lixcol_file_id = $1");
     let file_params = vec![Value::Text(probe_file.clone())];
     let file_schema_params = vec![
         Value::Text(probe_file.clone()),
@@ -232,18 +232,18 @@ async fn run<StorageImpl>(
     let full_rows = rows(&session, full_sql, &[]).await;
     let file_schema_rows = rows(&session, file_schema_sql, &file_schema_params).await;
     let point_rows = rows(&session, point_sql, &point_params).await;
-    let proxy_rows = rows(&session, &proxy_sql, &file_params).await;
+    let entity_scan_rows_count = rows(&session, &entity_scan_sql, &file_params).await;
 
     let file = sample(&session, file_sql, &file_params, reps).await;
     let full = sample(&session, full_sql, &[], reps).await;
     let file_schema = sample(&session, file_schema_sql, &file_schema_params, reps).await;
     let point = sample(&session, point_sql, &point_params, reps).await;
-    let proxy = sample(&session, &proxy_sql, &file_params, reps).await;
+    let entity_scan = sample(&session, &entity_scan_sql, &file_params, reps).await;
 
     println!(
         "working_diff_file_scope backend={backend} files={files} total_dirty={full_rows} \
          file_rows={file_rows} full_rows={full_rows} file_schema_rows={file_schema_rows} \
-         point_rows={point_rows} entity_scan_rows={proxy_rows} reps={reps} \
+         point_rows={point_rows} entity_scan_rows={entity_scan_rows_count} reps={reps} \
          file_p50_ms={:.3} file_min_ms={:.3} file_max_ms={:.3} \
          full_p50_ms={:.3} full_min_ms={:.3} full_max_ms={:.3} \
          file_schema_p50_ms={:.3} file_schema_min_ms={:.3} file_schema_max_ms={:.3} \
@@ -261,9 +261,9 @@ async fn run<StorageImpl>(
         millis(point.0),
         millis(point.1),
         millis(point.2),
-        millis(proxy.0),
-        millis(proxy.1),
-        millis(proxy.2),
+        millis(entity_scan.0),
+        millis(entity_scan.1),
+        millis(entity_scan.2),
     );
     drop(session);
     drop(engine);

--- a/packages/engine-benchmarks/benches/working_diff_file_scope.rs
+++ b/packages/engine-benchmarks/benches/working_diff_file_scope.rs
@@ -189,39 +189,67 @@ async fn run<StorageImpl>(
                     FROM lix_working_diff WHERE file_id = $1";
     let full_sql = "SELECT diff_id, entity_pk, schema_key, file_id, diff_type \
                     FROM lix_working_diff";
-    let finite_sql = "SELECT diff_id, entity_pk, schema_key, file_id, diff_type \
-                      FROM lix_working_diff \
-                      WHERE schema_key = $1 AND entity_pk = lix_json($2)";
+    // `schema_key + file_id`, the shape of the only file-scoped working-diff
+    // test in the tree. Still a full HOT_DIFF scan today.
+    let file_schema_sql = "SELECT diff_id, entity_pk, schema_key, file_id, diff_type \
+                           FROM lix_working_diff WHERE file_id = $1 AND schema_key = $2";
+    // Finite identity + file id: takes the existing bypass and resolves as a
+    // point read. This is the floor a seekable file-scoped read aims at.
+    let point_sql = "SELECT diff_id, entity_pk, schema_key, file_id, diff_type \
+                     FROM lix_working_diff \
+                     WHERE schema_key = $1 AND entity_pk = lix_json($2) AND file_id = $3";
+    // Live-state read of the same file through HOT_ROW's existing file-first
+    // prefix seek. Proxy for what a HOT_ROW-seeking working-diff read would
+    // cost: O(live rows in the file) instead of O(all dirty rows).
+    let proxy_sql = format!("SELECT id FROM {SCHEMA_KEY} WHERE lixcol_file_id = $1");
     let file_params = vec![Value::Text(probe_file.clone())];
-    let finite_params = vec![
+    let file_schema_params = vec![
+        Value::Text(probe_file.clone()),
+        Value::Text(SCHEMA_KEY.to_string()),
+    ];
+    let point_params = vec![
         Value::Text(SCHEMA_KEY.to_string()),
         Value::Text(format!("[\"{}\"]", row_id(0, 0))),
+        Value::Text(probe_file.clone()),
     ];
 
     // Warm provider construction and the block cache outside the samples.
     let file_rows = rows(&session, file_sql, &file_params).await;
     let full_rows = rows(&session, full_sql, &[]).await;
-    let finite_rows = rows(&session, finite_sql, &finite_params).await;
+    let file_schema_rows = rows(&session, file_schema_sql, &file_schema_params).await;
+    let point_rows = rows(&session, point_sql, &point_params).await;
+    let proxy_rows = rows(&session, &proxy_sql, &file_params).await;
 
     let file = sample(&session, file_sql, &file_params, reps).await;
     let full = sample(&session, full_sql, &[], reps).await;
-    let finite = sample(&session, finite_sql, &finite_params, reps).await;
+    let file_schema = sample(&session, file_schema_sql, &file_schema_params, reps).await;
+    let point = sample(&session, point_sql, &point_params, reps).await;
+    let proxy = sample(&session, &proxy_sql, &file_params, reps).await;
 
     println!(
         "working_diff_file_scope backend={backend} files={files} total_dirty={full_rows} \
-         file_rows={file_rows} full_rows={full_rows} finite_rows={finite_rows} reps={reps} \
+         file_rows={file_rows} full_rows={full_rows} file_schema_rows={file_schema_rows} \
+         point_rows={point_rows} proxy_rows={proxy_rows} reps={reps} \
          file_p50_ms={:.3} file_min_ms={:.3} file_max_ms={:.3} \
          full_p50_ms={:.3} full_min_ms={:.3} full_max_ms={:.3} \
-         finite_p50_ms={:.3} finite_min_ms={:.3} finite_max_ms={:.3}",
+         file_schema_p50_ms={:.3} file_schema_min_ms={:.3} file_schema_max_ms={:.3} \
+         point_p50_ms={:.3} point_min_ms={:.3} point_max_ms={:.3} \
+         proxy_p50_ms={:.3} proxy_min_ms={:.3} proxy_max_ms={:.3}",
         millis(file.0),
         millis(file.1),
         millis(file.2),
         millis(full.0),
         millis(full.1),
         millis(full.2),
-        millis(finite.0),
-        millis(finite.1),
-        millis(finite.2),
+        millis(file_schema.0),
+        millis(file_schema.1),
+        millis(file_schema.2),
+        millis(point.0),
+        millis(point.1),
+        millis(point.2),
+        millis(proxy.0),
+        millis(proxy.1),
+        millis(proxy.2),
     );
     drop(session);
     drop(engine);

--- a/packages/engine-benchmarks/benches/working_diff_file_scope.rs
+++ b/packages/engine-benchmarks/benches/working_diff_file_scope.rs
@@ -142,13 +142,16 @@ async fn run<StorageImpl>(
         .expect("open working-diff file-scope session");
 
     register_schema(&session).await;
+    // Rows per file stays FIXED and the file count grows with the dirty
+    // target. Holding the file width constant is what makes the probe file's
+    // cost independent of the dirty-set size, which is the whole question.
+    let bulk_rows_needed = dirty_target.saturating_sub(PROBE_DIRTY_ROWS);
+    let files = files.max(1 + bulk_rows_needed.div_ceil(rows_per_file));
     let file_ids = (0..files).map(file_id).collect::<Vec<_>>();
     seed_files(&session, &file_ids).await;
     // Every dirty row must exist before the checkpoint so the working diff is
     // a pure "modified" set with a stable returned-row count.
-    let bulk_files = files.saturating_sub(1);
-    let bulk_rows_needed = dirty_target.saturating_sub(PROBE_DIRTY_ROWS);
-    let bulk_rows_per_file = bulk_rows_needed.div_ceil(bulk_files.max(1)).max(rows_per_file);
+    let bulk_rows_per_file = rows_per_file;
     seed_rows(&session, &file_ids, bulk_rows_per_file).await;
 
     session

--- a/packages/engine-benchmarks/benches/working_diff_file_scope.rs
+++ b/packages/engine-benchmarks/benches/working_diff_file_scope.rs
@@ -209,12 +209,11 @@ async fn run<StorageImpl>(
                      WHERE schema_key = $1 AND entity_pk = lix_json($2) AND file_id = $3";
     // Live-state read of the same file. HOT_ROW is keyed
     // `schema_key ++ file_id ++ entity_pk` and `hot_scan_entries` owns a
-    // file-first prefix route, but the entity surface never pushes
-    // `lixcol_file_id` into `TrackedStateFilter::file_ids` (its
-    // `filter_pushdown` only recognizes branch-id and primary-key analyzers),
-    // so this measures a full schema scan with a residual filter. Reported to
-    // keep that gap visible: `entity_scan_rows` stays fixed at `rows_per_file`
-    // while the latency tracks the whole schema.
+    // file-first prefix route; the entity surface pushes `lixcol_file_id` into
+    // `LiveStateFilter::file_ids`, so this reaches that prefix seek and costs
+    // O(rows in the file). `entity_scan_rows` is fixed at `rows_per_file`, so
+    // a flat latency across dirty-set sizes is the pass condition and a rising
+    // one means the pushdown stopped reaching the seek.
     let entity_scan_sql = format!("SELECT id FROM {SCHEMA_KEY} WHERE lixcol_file_id = $1");
     let file_params = vec![Value::Text(probe_file.clone())];
     let file_schema_params = vec![

--- a/packages/engine-benchmarks/benches/working_diff_file_scope.rs
+++ b/packages/engine-benchmarks/benches/working_diff_file_scope.rs
@@ -9,20 +9,27 @@
 //! narrow file-scoped working-diff read cost O(rows returned) or O(all dirty
 //! rows in the branch)?
 //!
-//! Three query shapes are timed against the same fixture:
-//!   * `full`   — unfiltered `lix_working_diff` (the existing bench shape)
-//!   * `file`   — `WHERE file_id = $1` on one lightly dirtied file
-//!   * `finite` — `WHERE schema_key = $1 AND entity_pk = lix_json($2)`, which
-//!                takes the existing finite-filter bypass in
-//!                `hot_working_diff_entries` and therefore never touches the
-//!                HOT_DIFF index or its coverage proof.
+//! Five query shapes are timed against the same fixture:
+//!   * `full`        — unfiltered `lix_working_diff` (the existing bench shape)
+//!   * `file`        — `WHERE file_id = $1`, the shape `docs/diff-commands.md`
+//!                     shows first
+//!   * `file_schema` — `WHERE file_id = $1 AND schema_key = $2`, the shape of
+//!                     the one file-scoped working-diff test in the tree
+//!   * `point`       — `WHERE schema_key = $1 AND entity_pk = lix_json($2) AND
+//!                     file_id = $3`, which takes the finite-filter bypass in
+//!                     `hot_working_diff_entries` and therefore never reads the
+//!                     HOT_DIFF index or verifies its coverage proof. This is
+//!                     the control: it isolates the proof as the cost.
+//!   * `entity_scan` — the same file read through the ordinary entity surface,
+//!                     which does not push `lixcol_file_id` down at all.
 //!
 //! ```text
 //! cargo bench -p lix_benchmarks --features storage-benches,slatedb \
-//!   --bench working_diff_file_scope -- rocksdb 64 40 100 9
+//!   --bench working_diff_file_scope -- rocksdb 8 40 100 9 1000 20000 100000
 //! ```
-//! Positionals: `<rocksdb|slatedb> <files> <rows-per-file> <changes-per-commit> <reps>`
-//! then a list of total dirty-row targets, e.g. `1000 10000 100000`.
+//! Positionals: `<rocksdb|slatedb> <min-files> <rows-per-file> <changes-per-commit> <reps>`
+//! then a list of total dirty-row targets, e.g. `1000 10000 100000`. Rows per
+//! file is fixed; the file count grows to hold the requested dirty set.
 
 use std::fmt::Write as _;
 use std::time::{Duration, Instant};
@@ -200,9 +207,14 @@ async fn run<StorageImpl>(
     let point_sql = "SELECT diff_id, entity_pk, schema_key, file_id, diff_type \
                      FROM lix_working_diff \
                      WHERE schema_key = $1 AND entity_pk = lix_json($2) AND file_id = $3";
-    // Live-state read of the same file through HOT_ROW's existing file-first
-    // prefix seek. Proxy for what a HOT_ROW-seeking working-diff read would
-    // cost: O(live rows in the file) instead of O(all dirty rows).
+    // Live-state read of the same file. HOT_ROW is keyed
+    // `schema_key ++ file_id ++ entity_pk` and `hot_scan_entries` owns a
+    // file-first prefix route, but the entity surface never pushes
+    // `lixcol_file_id` into `TrackedStateFilter::file_ids` (its
+    // `filter_pushdown` only recognizes branch-id and primary-key analyzers),
+    // so this measures a full schema scan with a residual filter. Reported to
+    // keep that gap visible: `entity_rows` stays fixed at `rows_per_file`
+    // while the latency tracks the whole schema.
     let proxy_sql = format!("SELECT id FROM {SCHEMA_KEY} WHERE lixcol_file_id = $1");
     let file_params = vec![Value::Text(probe_file.clone())];
     let file_schema_params = vec![
@@ -231,12 +243,12 @@ async fn run<StorageImpl>(
     println!(
         "working_diff_file_scope backend={backend} files={files} total_dirty={full_rows} \
          file_rows={file_rows} full_rows={full_rows} file_schema_rows={file_schema_rows} \
-         point_rows={point_rows} proxy_rows={proxy_rows} reps={reps} \
+         point_rows={point_rows} entity_scan_rows={proxy_rows} reps={reps} \
          file_p50_ms={:.3} file_min_ms={:.3} file_max_ms={:.3} \
          full_p50_ms={:.3} full_min_ms={:.3} full_max_ms={:.3} \
          file_schema_p50_ms={:.3} file_schema_min_ms={:.3} file_schema_max_ms={:.3} \
          point_p50_ms={:.3} point_min_ms={:.3} point_max_ms={:.3} \
-         proxy_p50_ms={:.3} proxy_min_ms={:.3} proxy_max_ms={:.3}",
+         entity_scan_p50_ms={:.3} entity_scan_min_ms={:.3} entity_scan_max_ms={:.3}",
         millis(file.0),
         millis(file.1),
         millis(file.2),

--- a/packages/engine-benchmarks/examples/chunking_oracle.rs
+++ b/packages/engine-benchmarks/examples/chunking_oracle.rs
@@ -30,6 +30,10 @@ enum Policy {
     Cdc {
         avg_bytes: usize,
         anchor_bytes: Option<usize>,
+        /// Divisor for the minimum chunk size. FastCDC skips `min` bytes
+        /// without hashing at the start of every chunk, so a larger minimum is
+        /// directly less CPU per written byte.
+        min_divisor: usize,
     },
 }
 
@@ -40,11 +44,18 @@ impl Policy {
             Self::Cdc {
                 avg_bytes,
                 anchor_bytes: None,
-            } => format!("cdc/{}", human(*avg_bytes)),
+                min_divisor,
+            } => format!("cdc/{}/min{}", human(*avg_bytes), min_divisor),
             Self::Cdc {
                 avg_bytes,
                 anchor_bytes: Some(anchor),
-            } => format!("cdc/{}@{}", human(*avg_bytes), human(*anchor)),
+                min_divisor,
+            } => format!(
+                "cdc/{}@{}/min{}",
+                human(*avg_bytes),
+                human(*anchor),
+                min_divisor
+            ),
         }
     }
 
@@ -57,15 +68,20 @@ impl Policy {
             Self::Cdc {
                 avg_bytes,
                 anchor_bytes,
+                min_divisor,
             } => {
                 let span = anchor_bytes.unwrap_or(usize::MAX);
                 let mut out = Vec::new();
                 let mut base = 0usize;
                 while base < data.len() {
                     let end = base.saturating_add(span).min(data.len());
-                    out.extend(cdc_ranges(&data[base..end], *avg_bytes).into_iter().map(
-                        |(start, stop)| (base.saturating_add(start), base.saturating_add(stop)),
-                    ));
+                    out.extend(
+                        cdc_ranges(&data[base..end], *avg_bytes, *min_divisor)
+                            .into_iter()
+                            .map(|(start, stop)| {
+                                (base.saturating_add(start), base.saturating_add(stop))
+                            }),
+                    );
                     base = end;
                 }
                 out
@@ -74,11 +90,11 @@ impl Policy {
     }
 }
 
-fn cdc_ranges(data: &[u8], avg_bytes: usize) -> Vec<(usize, usize)> {
+fn cdc_ranges(data: &[u8], avg_bytes: usize, min_divisor: usize) -> Vec<(usize, usize)> {
     if data.is_empty() {
         return Vec::new();
     }
-    let min = (avg_bytes / 4).max(64) as u32;
+    let min = (avg_bytes * 1 / min_divisor).max(64) as u32;
     let avg = avg_bytes as u32;
     let max = (avg_bytes * 4) as u32;
     fastcdc::v2020::FastCDC::new(data, min, avg, max)
@@ -94,37 +110,64 @@ fn human(bytes: usize) -> String {
     }
 }
 
-const POLICIES: &[Policy] = &[
-    Policy::Fixed {
-        chunk_bytes: 1 << 20,
+/// A scenario names the policy that chunked v1 and the policy that chunks v2.
+/// They differ only for `mixed/*`, which models gating the chunker on write
+/// context: v1 arrives as an initial write, v2 as a rewrite.
+struct Scenario {
+    label: &'static str,
+    v1: Policy,
+    v2: Policy,
+}
+
+const FIXED_1M: Policy = Policy::Fixed {
+    chunk_bytes: 1 << 20,
+};
+const CDC_1M: Policy = Policy::Cdc {
+    avg_bytes: 1 << 20,
+    anchor_bytes: Some(16 << 20),
+    min_divisor: 4,
+};
+const CDC_1M_MIN2: Policy = Policy::Cdc {
+    avg_bytes: 1 << 20,
+    anchor_bytes: Some(16 << 20),
+    min_divisor: 2,
+};
+const CDC_1M_MIN1_33: Policy = Policy::Cdc {
+    avg_bytes: 1 << 20,
+    anchor_bytes: Some(16 << 20),
+    min_divisor: 1,
+};
+
+const SCENARIOS: &[Scenario] = &[
+    Scenario {
+        label: "fixed/1m",
+        v1: FIXED_1M,
+        v2: FIXED_1M,
     },
-    Policy::Fixed {
-        chunk_bytes: 256 << 10,
+    Scenario {
+        label: "cdc/1m@16m/min4",
+        v1: CDC_1M,
+        v2: CDC_1M,
     },
-    Policy::Fixed {
-        chunk_bytes: 64 << 10,
+    Scenario {
+        label: "cdc/1m@16m/min2",
+        v1: CDC_1M_MIN2,
+        v2: CDC_1M_MIN2,
     },
-    Policy::Cdc {
-        avg_bytes: 1 << 20,
-        anchor_bytes: None,
+    Scenario {
+        label: "cdc/1m@16m/min1",
+        v1: CDC_1M_MIN1_33,
+        v2: CDC_1M_MIN1_33,
     },
-    Policy::Cdc {
-        avg_bytes: 256 << 10,
-        anchor_bytes: None,
-    },
-    Policy::Cdc {
-        avg_bytes: 64 << 10,
-        anchor_bytes: None,
-    },
-    Policy::Cdc {
-        avg_bytes: 1 << 20,
-        anchor_bytes: Some(16 << 20),
-    },
-    Policy::Cdc {
-        avg_bytes: 256 << 10,
-        anchor_bytes: Some(16 << 20),
+    // The proposed gate: fixed chunking on the initial write, CDC on rewrites.
+    Scenario {
+        label: "mixed/fixed-v1_cdc-v2",
+        v1: FIXED_1M,
+        v2: CDC_1M,
     },
 ];
+
+const THROUGHPUT_POLICIES: &[Policy] = &[FIXED_1M, CDC_1M, CDC_1M_MIN2, CDC_1M_MIN1_33];
 
 const EDIT_BYTES: usize = 4 << 10;
 
@@ -149,8 +192,8 @@ fn main() {
             .into_owned();
         let base = fs::read(case.join("base.bin")).expect("read case base.bin");
         for (shape, v2) in shapes(&case, &base) {
-            for policy in POLICIES {
-                report(&name, &shape, *policy, &base, &v2);
+            for scenario in SCENARIOS {
+                report(&name, &shape, scenario, &base, &v2);
             }
         }
     }
@@ -168,7 +211,7 @@ fn main() {
             largest = data;
         }
     }
-    for policy in POLICIES {
+    for policy in THROUGHPUT_POLICIES {
         let mut best = f64::MAX;
         for _ in 0..9 {
             let started = Instant::now();
@@ -245,9 +288,9 @@ fn shapes(case: &Path, base: &[u8]) -> Vec<(String, Vec<u8>)> {
     shapes
 }
 
-fn report(case: &str, shape: &str, policy: Policy, base: &[u8], v2: &[u8]) {
-    let base_ranges = policy.ranges(base);
-    let v2_ranges = policy.ranges(v2);
+fn report(case: &str, shape: &str, scenario: &Scenario, base: &[u8], v2: &[u8]) {
+    let base_ranges = scenario.v1.ranges(base);
+    let v2_ranges = scenario.v2.ranges(v2);
     let known = base_ranges
         .iter()
         .map(|&(start, end)| *blake3::hash(&base[start..end]).as_bytes())
@@ -269,7 +312,7 @@ fn report(case: &str, shape: &str, policy: Policy, base: &[u8], v2: &[u8]) {
          v1_bytes={},v2_bytes={},v1_chunks={},v2_chunks={},\
          new_chunks={new_chunks},new_bytes={new_bytes},shared_bytes={shared},\
          sharing_ratio={:.4},mean_chunk_bytes={}",
-        policy.label(),
+        scenario.label,
         base.len(),
         v2.len(),
         base_ranges.len(),

--- a/packages/engine-benchmarks/examples/delta_segment_duplication.rs
+++ b/packages/engine-benchmarks/examples/delta_segment_duplication.rs
@@ -247,7 +247,9 @@ segment_dup_bytes={},segment_dup_pct={:.3},segment_max_occurrences={},\
 segment_share_of_settled_pct={:.2},\
 sim_distinct={},sim_same_length={},sim_pairs={},sim_near_identical={},\
 sim_min_differing_bytes={},sim_min_pair_len={},sim_min_pair_common_prefix={},\
-sim_min_pair_common_suffix={}",
+sim_min_pair_common_suffix={},\
+norm_dup_segments={},norm_dup_bytes={},norm_dup_pct_of_segment={:.2},\
+norm_dup_pct_of_settled={:.2},norm_shared_classes={}",
         directory_bytes(directory),
         percent(duplicate_bytes, settled_value_bytes),
         segment.rows,
@@ -266,6 +268,17 @@ sim_min_pair_common_suffix={}",
         similarity.min_differing_pair_len,
         similarity.min_differing_pair_common_prefix,
         similarity.min_differing_pair_common_suffix,
+        similarity.identity_normalized_duplicate_segments,
+        similarity.identity_normalized_duplicate_bytes,
+        percent(
+            similarity.identity_normalized_duplicate_bytes,
+            segment.value_bytes,
+        ),
+        percent(
+            similarity.identity_normalized_duplicate_bytes,
+            settled_value_bytes,
+        ),
+        similarity.identity_normalized_shared_classes,
     );
 
     let mut by_bytes: Vec<&StorageValueDuplication> = duplication

--- a/packages/engine-benchmarks/examples/delta_segment_duplication.rs
+++ b/packages/engine-benchmarks/examples/delta_segment_duplication.rs
@@ -70,6 +70,13 @@ async fn main() {
         .next()
         .and_then(|value| value.parse::<usize>().ok())
         .unwrap_or(10_000);
+    // Rows touched by one workload commit. The segment plane only receives a
+    // commit whose mutation count clears the ordered-part geometry, so the edit
+    // width is the variable that decides whether this plane is exercised at all.
+    let window = arguments
+        .next()
+        .and_then(|value| value.parse::<usize>().ok())
+        .unwrap_or_else(|| (rows / 100).max(1));
     let selected = arguments.next().map(|value| {
         value
             .split(',')
@@ -84,11 +91,11 @@ async fn main() {
         {
             continue;
         }
-        run_workload(workload, rows).await;
+        run_workload(workload, rows, window).await;
     }
 }
 
-async fn run_workload(workload: &str, rows: usize) {
+async fn run_workload(workload: &str, rows: usize, window: usize) {
     let directory = tempfile::tempdir().expect("create duplication-audit directory");
     let storage = RocksDB::open(directory.path()).expect("open duplication-audit RocksDB");
     Engine::initialize(storage.clone())
@@ -104,7 +111,6 @@ async fn run_workload(workload: &str, rows: usize) {
     register_schema(&main).await;
     seed_rows(&main, rows).await;
 
-    let window = (rows / 100).max(1);
     apply_workload(&engine, &main, workload, window).await;
 
     storage.flush().expect("flush duplication-audit RocksDB");

--- a/packages/engine-benchmarks/examples/delta_segment_duplication.rs
+++ b/packages/engine-benchmarks/examples/delta_segment_duplication.rs
@@ -240,7 +240,8 @@ segment_rows={},segment_value_bytes={},segment_distinct={},segment_dup_rows={},\
 segment_dup_bytes={},segment_dup_pct={:.3},segment_max_occurrences={},\
 segment_share_of_settled_pct={:.2},\
 sim_distinct={},sim_same_length={},sim_pairs={},sim_near_identical={},\
-sim_min_differing_bytes={},sim_min_pair_len={}",
+sim_min_differing_bytes={},sim_min_pair_len={},sim_min_pair_common_prefix={},\
+sim_min_pair_common_suffix={}",
         directory_bytes(directory),
         percent(duplicate_bytes, settled_value_bytes),
         segment.rows,
@@ -257,6 +258,8 @@ sim_min_differing_bytes={},sim_min_pair_len={}",
         similarity.near_identical_pairs,
         similarity.min_differing_bytes,
         similarity.min_differing_pair_len,
+        similarity.min_differing_pair_common_prefix,
+        similarity.min_differing_pair_common_suffix,
     );
 
     let mut by_bytes: Vec<&StorageValueDuplication> = duplication

--- a/packages/engine-benchmarks/examples/delta_segment_duplication.rs
+++ b/packages/engine-benchmarks/examples/delta_segment_duplication.rs
@@ -1,0 +1,470 @@
+//! How much of the settled repository is byte-identical duplicate content?
+//!
+//! The commit-delta segment plane is keyed `commit_id ++ segment_index`, not by
+//! a content digest, so nothing in the engine can notice that two commits wrote
+//! the same segment bytes. Every other high-volume immutable plane in the engine
+//! *is* content-addressed. The obvious question is whether that difference costs
+//! anything in practice.
+//!
+//! This example answers it by measurement rather than by assumption. Each
+//! workload builds a repository through the real `SessionContext` SQL commit
+//! path, then reads every storage space back and reports, per space:
+//!
+//! * `rows` / `value_bytes` — what settled.
+//! * `distinct` — distinct value byte strings.
+//! * `dup_bytes` — what a perfect content-addressed store would never have
+//!   written: `(occurrences - 1) * len` summed over distinct values. This is an
+//!   upper bound on the win, since it charges nothing for the indirection a real
+//!   content-addressed layout would need.
+//!
+//! For the delta-segment plane it additionally reports a nearest-neighbour
+//! analysis over equal-length segments: if two segments that "should" be
+//! identical differ in a handful of bytes, the payload carries per-commit
+//! identity that a naive CAS key would not have caught anyway.
+//!
+//! Usage:
+//! ```sh
+//! cargo run -p lix_benchmarks --release --features storage-benches \
+//!   --example delta_segment_duplication -- [rows] [workloads]
+//! ```
+//! `workloads` is a comma-separated subset of the names in `WORKLOADS`.
+
+use std::path::Path;
+
+use lix::integration::{Engine, SessionContext};
+use lix::storage::Storage;
+use lix::storage_adapter::{StorageAdapter, StorageReadOptions};
+use lix::storage_bench::{
+    CommitDeltaSegmentSimilarity, StorageValueDuplication, commit_delta_segment_similarity,
+    space_value_duplication,
+};
+use lix::{CreateBranchOptions, MergeBranchOptions, Value};
+use lix_storage_rocksdb::RocksDB;
+
+const WORKLOADS: &[&str] = &[
+    // Ordinary forward development: every commit writes new content.
+    "linear_disjoint",
+    "linear_hot_window",
+    // Real workloads that plausibly re-create content already stored.
+    "repeat_identical_write",
+    "revert_roundtrip",
+    "undo_roundtrip",
+    "merge_replay",
+    // Synthetic upper bound: N branches making byte-identical edits.
+    "branches_2_identical",
+    "branches_2_disjoint",
+    "branches_10_identical",
+    "branches_10_disjoint",
+];
+
+const PAD: &str = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+const SEED_BATCH_ROWS: usize = 5_000;
+/// Commits applied by every multi-commit workload, so their per-commit costs
+/// are directly comparable.
+const WORKLOAD_COMMITS: usize = 10;
+
+#[tokio::main(flavor = "current_thread")]
+async fn main() {
+    let mut arguments = std::env::args().skip(1);
+    let rows = arguments
+        .next()
+        .and_then(|value| value.parse::<usize>().ok())
+        .unwrap_or(10_000);
+    let selected = arguments.next().map(|value| {
+        value
+            .split(',')
+            .map(str::trim)
+            .map(str::to_owned)
+            .collect::<Vec<_>>()
+    });
+
+    for workload in WORKLOADS {
+        if let Some(selected) = selected.as_ref()
+            && !selected.iter().any(|value| value == workload)
+        {
+            continue;
+        }
+        run_workload(workload, rows).await;
+    }
+}
+
+async fn run_workload(workload: &str, rows: usize) {
+    let directory = tempfile::tempdir().expect("create duplication-audit directory");
+    let storage = RocksDB::open(directory.path()).expect("open duplication-audit RocksDB");
+    Engine::initialize(storage.clone())
+        .await
+        .expect("initialize duplication-audit repository");
+    let engine = Engine::new(storage.clone())
+        .await
+        .expect("open duplication-audit engine");
+    let main = engine
+        .open_workspace_session()
+        .await
+        .expect("open duplication-audit workspace");
+    register_schema(&main).await;
+    seed_rows(&main, rows).await;
+
+    let window = (rows / 100).max(1);
+    apply_workload(&engine, &main, workload, window).await;
+
+    storage.flush().expect("flush duplication-audit RocksDB");
+    let adapter = StorageAdapter::new(storage.clone());
+    let read = adapter
+        .begin_read(StorageReadOptions::default())
+        .await
+        .expect("open duplication-audit snapshot");
+    let duplication = space_value_duplication(&read).await;
+    let similarity = commit_delta_segment_similarity(&read).await;
+    drop(read);
+
+    report(
+        workload,
+        rows,
+        window,
+        directory.path(),
+        &duplication,
+        similarity,
+    );
+}
+
+async fn apply_workload<S>(
+    engine: &Engine<S>,
+    main: &SessionContext<S>,
+    workload: &str,
+    window: usize,
+) where
+    S: Storage + Clone + Send + Sync + 'static,
+{
+    match workload {
+        // Each commit edits a different window: no commit can repeat another.
+        "linear_disjoint" => {
+            for index in 0..WORKLOAD_COMMITS {
+                edit_rows(main, index * window, window, index + 1).await;
+            }
+        }
+        // Every commit rewrites the same rows with fresh content.
+        "linear_hot_window" => {
+            for index in 0..WORKLOAD_COMMITS {
+                edit_rows(main, 0, window, index + 1).await;
+            }
+        }
+        // The same statement, committed repeatedly. Every commit after the
+        // first re-states content the repository already holds.
+        "repeat_identical_write" => {
+            for _ in 0..WORKLOAD_COMMITS {
+                edit_rows(main, 0, window, 1).await;
+            }
+        }
+        // Edit away and back again. Every even commit restores content that the
+        // repository stored one commit earlier.
+        "revert_roundtrip" => {
+            for index in 0..WORKLOAD_COMMITS / 2 {
+                edit_rows(main, 0, window, index + 1).await;
+                restore_rows(main, 0, window).await;
+            }
+        }
+        // Same shape, driven through the engine's own undo path.
+        "undo_roundtrip" => {
+            for index in 0..WORKLOAD_COMMITS / 2 {
+                edit_rows(main, 0, window, index + 1).await;
+                main.undo().await.expect("undo duplication-audit commit");
+            }
+        }
+        // Two branches off the same base make the same edit; both are merged
+        // into main. The merge commits replay content already stored.
+        "merge_replay" => {
+            let first = create_branch(main, "replay-0").await;
+            edit_on_branch(engine, &first, 0, window, 1).await;
+            let second = create_branch(main, "replay-1").await;
+            edit_on_branch(engine, &second, 0, window, 1).await;
+            main.merge_branch(MergeBranchOptions {
+                source_branch_id: first,
+            })
+            .await
+            .expect("merge duplication-audit branch");
+            let _ = main
+                .merge_branch(MergeBranchOptions {
+                    source_branch_id: second,
+                })
+                .await;
+        }
+        "branches_2_identical" => branch_fanout(engine, main, 2, window, false).await,
+        "branches_2_disjoint" => branch_fanout(engine, main, 2, window, true).await,
+        "branches_10_identical" => branch_fanout(engine, main, 10, window, false).await,
+        "branches_10_disjoint" => branch_fanout(engine, main, 10, window, true).await,
+        other => panic!("unknown duplication-audit workload '{other}'"),
+    }
+}
+
+async fn branch_fanout<S>(
+    engine: &Engine<S>,
+    main: &SessionContext<S>,
+    branches: usize,
+    window: usize,
+    disjoint: bool,
+) where
+    S: Storage + Clone + Send + Sync + 'static,
+{
+    for index in 0..branches {
+        let branch = create_branch(main, &format!("fanout-{index}")).await;
+        let start = if disjoint { index * window } else { 0 };
+        edit_on_branch(engine, &branch, start, window, 1).await;
+    }
+}
+
+fn report(
+    workload: &str,
+    rows: usize,
+    window: usize,
+    directory: &Path,
+    duplication: &[StorageValueDuplication],
+    similarity: CommitDeltaSegmentSimilarity,
+) {
+    let settled_value_bytes: u64 = duplication.iter().map(|entry| entry.value_bytes).sum();
+    let settled_key_bytes: u64 = duplication.iter().map(|entry| entry.key_bytes).sum();
+    let duplicate_bytes: u64 = duplication
+        .iter()
+        .map(|entry| entry.duplicate_value_bytes)
+        .sum();
+    let segment = duplication
+        .iter()
+        .find(|entry| entry.space_id == 0x0004_001a)
+        .copied()
+        .unwrap_or_default();
+
+    println!(
+        "delta_dup,workload={workload},rows={rows},window={window},\
+physical_bytes={},settled_key_bytes={settled_key_bytes},settled_value_bytes={settled_value_bytes},\
+settled_dup_bytes={duplicate_bytes},settled_dup_pct={:.3},\
+segment_rows={},segment_value_bytes={},segment_distinct={},segment_dup_rows={},\
+segment_dup_bytes={},segment_dup_pct={:.3},segment_max_occurrences={},\
+segment_share_of_settled_pct={:.2},\
+sim_distinct={},sim_same_length={},sim_pairs={},sim_near_identical={},\
+sim_min_differing_bytes={},sim_min_pair_len={}",
+        directory_bytes(directory),
+        percent(duplicate_bytes, settled_value_bytes),
+        segment.rows,
+        segment.value_bytes,
+        segment.distinct_values,
+        segment.duplicate_rows,
+        segment.duplicate_value_bytes,
+        segment.duplicate_fraction() * 100.0,
+        segment.max_occurrences,
+        percent(segment.value_bytes, settled_value_bytes),
+        similarity.distinct_values,
+        similarity.same_length_distinct_values,
+        similarity.compared_pairs,
+        similarity.near_identical_pairs,
+        similarity.min_differing_bytes,
+        similarity.min_differing_pair_len,
+    );
+
+    let mut by_bytes: Vec<&StorageValueDuplication> = duplication
+        .iter()
+        .filter(|entry| entry.value_bytes > 0)
+        .collect();
+    by_bytes.sort_unstable_by_key(|entry| std::cmp::Reverse(entry.value_bytes));
+    for entry in by_bytes.iter().take(12) {
+        println!(
+            "  delta_dup_space,workload={workload},rows={rows},space=0x{:08x}/{},\
+rows={},key_bytes={},value_bytes={},distinct={},dup_rows={},dup_bytes={},dup_pct={:.3},\
+max_occurrences={}",
+            entry.space_id,
+            entry.space,
+            entry.rows,
+            entry.key_bytes,
+            entry.value_bytes,
+            entry.distinct_values,
+            entry.duplicate_rows,
+            entry.duplicate_value_bytes,
+            entry.duplicate_fraction() * 100.0,
+            entry.max_occurrences,
+        );
+    }
+}
+
+fn percent(part: u64, whole: u64) -> f64 {
+    if whole == 0 {
+        0.0
+    } else {
+        part as f64 * 100.0 / whole as f64
+    }
+}
+
+async fn create_branch<S>(main: &SessionContext<S>, name: &str) -> String
+where
+    S: Storage + Clone + Send + Sync + 'static,
+{
+    main.create_branch(CreateBranchOptions {
+        id: None,
+        name: name.to_owned(),
+        from_commit_id: None,
+    })
+    .await
+    .expect("create duplication-audit branch")
+    .id
+}
+
+async fn edit_on_branch<S>(
+    engine: &Engine<S>,
+    branch: &str,
+    start: usize,
+    count: usize,
+    generation: usize,
+) where
+    S: Storage + Clone + Send + Sync + 'static,
+{
+    let session = engine
+        .open_session(branch.to_owned())
+        .await
+        .expect("open duplication-audit branch session");
+    edit_rows(&session, start, count, generation).await;
+}
+
+/// The written value depends only on the row index and the generation, so two
+/// commits given the same `(start, count, generation)` produce byte-identical
+/// content whatever branch or order they run in.
+async fn edit_rows<S>(session: &SessionContext<S>, start: usize, count: usize, generation: usize)
+where
+    S: Storage + Clone + Send + Sync + 'static,
+{
+    let mut written = 0usize;
+    while written < count {
+        let batch = (count - written).min(SEED_BATCH_ROWS);
+        let mut transaction = session
+            .begin_transaction()
+            .await
+            .expect("begin duplication-audit edit");
+        for offset in 0..batch {
+            let index = start + written + offset;
+            transaction
+                .execute(
+                    "UPDATE dup_fixture SET value = lix_json($1) WHERE path = $2",
+                    &[
+                        Value::Text(format!(
+                            r#"{{"seed":{index},"generation":{generation},"pad":"{PAD}"}}"#
+                        )),
+                        Value::Text(row_path(index)),
+                    ],
+                )
+                .await
+                .expect("stage duplication-audit edit");
+        }
+        transaction
+            .commit()
+            .await
+            .expect("commit duplication-audit edit");
+        written += batch;
+    }
+}
+
+/// Restores the exact bytes `seed_rows` wrote, so the resulting commit's payload
+/// is content the repository already stored.
+async fn restore_rows<S>(session: &SessionContext<S>, start: usize, count: usize)
+where
+    S: Storage + Clone + Send + Sync + 'static,
+{
+    let mut transaction = session
+        .begin_transaction()
+        .await
+        .expect("begin duplication-audit restore");
+    for offset in 0..count {
+        let index = start + offset;
+        transaction
+            .execute(
+                "UPDATE dup_fixture SET value = lix_json($1) WHERE path = $2",
+                &[
+                    Value::Text(seed_value(index)),
+                    Value::Text(row_path(index)),
+                ],
+            )
+            .await
+            .expect("stage duplication-audit restore");
+    }
+    transaction
+        .commit()
+        .await
+        .expect("commit duplication-audit restore");
+}
+
+fn row_path(index: usize) -> String {
+    format!("/dup/fixture/{index:09}")
+}
+
+fn seed_value(index: usize) -> String {
+    format!(r#"{{"seed":{index},"pad":"{PAD}"}}"#)
+}
+
+async fn register_schema<S>(session: &SessionContext<S>)
+where
+    S: Storage + Clone + Send + Sync + 'static,
+{
+    let schema = serde_json::json!({
+        "x-lix-key": "dup_fixture",
+        "x-lix-primary-key": ["/path"],
+        "type": "object",
+        "required": ["path", "value"],
+        "properties": {
+            "path": { "type": "string" },
+            "value": {
+                "type": ["object", "array", "string", "number", "integer", "boolean", "null"]
+            }
+        },
+        "additionalProperties": false
+    });
+    session
+        .execute(
+            "INSERT INTO lix_registered_schema (value, lixcol_global, lixcol_untracked) \
+             VALUES (lix_json($1), false, false)",
+            &[Value::Text(schema.to_string())],
+        )
+        .await
+        .expect("register duplication-audit schema");
+}
+
+async fn seed_rows<S>(session: &SessionContext<S>, rows: usize)
+where
+    S: Storage + Clone + Send + Sync + 'static,
+{
+    let mut written = 0usize;
+    while written < rows {
+        let batch = (rows - written).min(SEED_BATCH_ROWS);
+        let mut transaction = session
+            .begin_transaction()
+            .await
+            .expect("begin duplication-audit seed");
+        for offset in 0..batch {
+            let index = written + offset;
+            transaction
+                .execute(
+                    "INSERT INTO dup_fixture (path, value) VALUES ($1, lix_json($2))",
+                    &[Value::Text(row_path(index)), Value::Text(seed_value(index))],
+                )
+                .await
+                .expect("stage duplication-audit seed row");
+        }
+        transaction
+            .commit()
+            .await
+            .expect("commit duplication-audit seed");
+        written += batch;
+    }
+}
+
+fn directory_bytes(path: &Path) -> u64 {
+    std::fs::read_dir(path).map_or(0, |entries| {
+        entries
+            .flatten()
+            .map(|entry| {
+                let path = entry.path();
+                entry.metadata().map_or(0, |metadata| {
+                    if metadata.is_dir() {
+                        directory_bytes(&path)
+                    } else {
+                        metadata.len()
+                    }
+                })
+            })
+            .sum()
+    })
+}

--- a/packages/engine-benchmarks/examples/expW_hot_row_anatomy.rs
+++ b/packages/engine-benchmarks/examples/expW_hot_row_anatomy.rs
@@ -35,7 +35,19 @@ use lix_storage_slatedb::SlateDB;
 
 const HOT_ROW_SPACE: &str = "live_state.hot_row.v21";
 const SEED_BATCH_ROWS: usize = 5_000;
-const PAD: &str = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+const PAD_UNIT: &str = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+
+/// Payload padding. The default 64 bytes reproduces `branch_storage_sharing`
+/// exactly. Raising it past `json_store`'s 1024-byte inline threshold moves
+/// the snapshot slot from `INLINE_FINGERPRINTED` to `REF`, which is the
+/// already-shipped content-addressed sharing path.
+fn pad() -> String {
+    let bytes: usize = std::env::var("LIX_EXPW_PAD_BYTES")
+        .ok()
+        .and_then(|value| value.parse().ok())
+        .unwrap_or(64);
+    PAD_UNIT.repeat(bytes.div_ceil(PAD_UNIT.len()))[..bytes].to_owned()
+}
 
 // Mirrors `live_state::tracked_head` value codec v8. Asserted against the
 // version byte of every scanned row, so a codec change fails loudly here.
@@ -339,6 +351,45 @@ content_only_distinct={},content_only_dup_classes={n2_classes},content_only_dup_
         content_only.len(),
     );
 
+    // Cost model for the candidate fix: replace the payload in every HOT value
+    // with a 32-byte content digest and store each distinct payload once in a
+    // content-addressed side space (32-byte digest key + 4 accounting bytes).
+    // Keys stay branch-scoped either way. This is the *optimistic* model: it
+    // charges nothing for the presence/refcount plane that manifest-driven GC
+    // would need, and nothing for the extra read hop.
+    let mut model_hot_value_bytes = 0u64;
+    let mut model_payloads: HashMap<blake3::Hash, u64> = HashMap::new();
+    for (_, value) in new_rows.iter() {
+        let p = parse_value(value);
+        let payload_len = p.snapshot_payload + p.metadata_payload;
+        model_hot_value_bytes += (value.len()
+            - p.snapshot_fingerprint
+            - p.snapshot_payload
+            - p.metadata_fingerprint
+            - p.metadata_payload
+            + JSON_REF_BYTES) as u64;
+        let digest = blake3::hash(
+            &value[p.snapshot_start + p.snapshot_fingerprint
+                ..p.snapshot_start + p.snapshot_fingerprint + p.snapshot_payload],
+        );
+        model_payloads.insert(digest, payload_len as u64);
+    }
+    let model_cas_bytes: u64 = model_payloads
+        .values()
+        .map(|len| len + JSON_REF_BYTES as u64 + 4)
+        .sum();
+    let today = a.key_total + a.value_total;
+    let modeled = a.key_total + model_hot_value_bytes + model_cas_bytes;
+    println!(
+        "expW_indirection_model,rows={rows},scenario={scenario},new_hot_rows={},\
+today_bytes={today},modeled_bytes={modeled},\
+modeled_hot_value_bytes={model_hot_value_bytes},modeled_cas_rows={},modeled_cas_bytes={model_cas_bytes},\
+delta_pct={:.2}",
+        a.rows,
+        model_payloads.len(),
+        (modeled as f64 - today as f64) / today as f64 * 100.0,
+    );
+
     // Cross-branch pairing: same logical identity in >1 branch scope.
     let mut paired_identities = 0u64;
     let mut paired_exact_equal = 0u64;
@@ -593,7 +644,10 @@ async fn modify_rows(engine: &Engine<SlateDB>, branch: &str, start: usize, count
                 .execute(
                     "UPDATE branch_fixture SET value = lix_json($1) WHERE path = $2",
                     &[
-                        Value::Text(format!(r#"{{"seed":{index},"edited":true,"pad":"{PAD}"}}"#)),
+                        Value::Text(format!(
+                            r#"{{"seed":{index},"edited":true,"pad":"{}"}}"#,
+                            pad()
+                        )),
                         Value::Text(row_path(index)),
                     ],
                 )
@@ -651,7 +705,7 @@ async fn seed_rows(session: &SessionContext<SlateDB>, rows: usize) {
                     "INSERT INTO branch_fixture (path, value) VALUES ($1, lix_json($2))",
                     &[
                         Value::Text(row_path(index)),
-                        Value::Text(format!(r#"{{"seed":{index},"pad":"{PAD}"}}"#)),
+                        Value::Text(format!(r#"{{"seed":{index},"pad":"{}"}}"#, pad())),
                     ],
                 )
                 .await

--- a/packages/engine-benchmarks/examples/expW_hot_row_anatomy.rs
+++ b/packages/engine-benchmarks/examples/expW_hot_row_anatomy.rs
@@ -27,7 +27,7 @@ use std::collections::{BTreeMap, HashMap};
 use std::path::{Path, PathBuf};
 
 use lix::integration::{Engine, SessionContext};
-use lix::storage::{ReadOptions, Storage};
+use lix::storage::ReadOptions;
 use lix::storage_adapter::StorageAdapter;
 use lix::storage_bench::{layout_accounting, space_inventory};
 use lix::{CreateBranchOptions, Value};
@@ -209,6 +209,10 @@ struct Anatomy {
     slot_ref: u64,
     slot_inline: u64,
     slot_inline_fingerprinted: u64,
+    meta_slot_none: u64,
+    meta_slot_ref: u64,
+    meta_slot_inline: u64,
+    meta_slot_inline_fingerprinted: u64,
 }
 
 fn analyze(rows: usize, scenario: &str, new_rows: &[(Vec<u8>, Vec<u8>)], changed_rows: usize) {
@@ -261,6 +265,13 @@ fn analyze(rows: usize, scenario: &str, new_rows: &[(Vec<u8>, Vec<u8>)], changed
             HEAD_SLOT_INLINE_FINGERPRINTED => a.slot_inline_fingerprinted += 1,
             _ => {}
         }
+        match parsed.metadata_kind {
+            HEAD_SLOT_NONE => a.meta_slot_none += 1,
+            HEAD_SLOT_REF => a.meta_slot_ref += 1,
+            HEAD_SLOT_INLINE => a.meta_slot_inline += 1,
+            HEAD_SLOT_INLINE_FINGERPRINTED => a.meta_slot_inline_fingerprinted += 1,
+            _ => {}
+        }
 
         *exact_values.entry(blake3::hash(value)).or_insert(0) += 1;
         let n1 = normalize_identity(value, &parsed);
@@ -304,7 +315,8 @@ v_working_diff_per_row={:.2},v_columnar_per_row={:.2}",
     println!(
         "expW_anatomy_tags,rows={rows},scenario={scenario},\
 wd_disabled={},wd_clean={},wd_before_absent={},wd_before_present={},\
-snapshot_none={},snapshot_ref={},snapshot_inline={},snapshot_inline_fingerprinted={}",
+snapshot_none={},snapshot_ref={},snapshot_inline={},snapshot_inline_fingerprinted={},\
+metadata_none={},metadata_ref={},metadata_inline={},metadata_inline_fingerprinted={}",
         a.wd_disabled,
         a.wd_clean,
         a.wd_before_absent,
@@ -313,6 +325,10 @@ snapshot_none={},snapshot_ref={},snapshot_inline={},snapshot_inline_fingerprinte
         a.slot_ref,
         a.slot_inline,
         a.slot_inline_fingerprinted,
+        a.meta_slot_none,
+        a.meta_slot_ref,
+        a.meta_slot_inline,
+        a.meta_slot_inline_fingerprinted,
     );
 
     // Sharing oracles over the new HOT rows.

--- a/packages/engine-benchmarks/examples/expW_hot_row_anatomy.rs
+++ b/packages/engine-benchmarks/examples/expW_hot_row_anatomy.rs
@@ -1,0 +1,666 @@
+//! Anatomy of a `live_state.hot_row.v21` row, and what two branches share.
+//!
+//! Experiment T attributed 95.4% of the two-branch storage delta to
+//! `live_state.hot_row.v21` and showed that two branches making *identical*
+//! edits pay the same as two branches making *disjoint* edits. This tool
+//! answers the follow-up questions directly on the bytes:
+//!
+//! 1. Where do the ~390 bytes of a branch-local HOT row go — key vs value, and
+//!    inside the value, payload vs per-row identity vs working-diff baseline?
+//! 2. Are the HOT values for byte-identical content byte-identical apart from
+//!    the branch-scoped key? Reported byte-exact and under two normalizations.
+//! 3. What does the base (unedited) row cost in its packed plane, so the
+//!    amplification factor is measured rather than assumed?
+//!
+//! Usage:
+//! ```text
+//! expW_hot_row_anatomy <rows> <scenario> <dir>
+//! ```
+//! Scenarios: `identical`, `disjoint`, `single`, `base`.
+//!
+//! Every write goes through the real `SessionContext` SQL commit path, so the
+//! inventory observes exactly what an ordinary commit stages.
+
+#![allow(clippy::large_futures)]
+
+use std::collections::{BTreeMap, HashMap};
+use std::path::{Path, PathBuf};
+
+use lix::integration::{Engine, SessionContext};
+use lix::storage::{ReadOptions, Storage};
+use lix::storage_adapter::StorageAdapter;
+use lix::storage_bench::{layout_accounting, space_inventory};
+use lix::{CreateBranchOptions, Value};
+use lix_storage_slatedb::SlateDB;
+
+const HOT_ROW_SPACE: &str = "live_state.hot_row.v21";
+const SEED_BATCH_ROWS: usize = 5_000;
+const PAD: &str = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+
+// Mirrors `live_state::tracked_head` value codec v8. Asserted against the
+// version byte of every scanned row, so a codec change fails loudly here.
+const HEAD_VALUE_VERSION: u8 = 8;
+const HEAD_VALUE_HEADER_BYTES: usize = 59;
+const HEAD_VALUE_SNAPSHOT_SHIFT: u8 = 1;
+const HEAD_VALUE_METADATA_SHIFT: u8 = 3;
+const HEAD_VALUE_WORKING_DIFF_SHIFT: u8 = 6;
+const HEAD_VALUE_SLOT_MASK: u8 = 0b11;
+const HEAD_VALUE_WORKING_DIFF_MASK: u8 = 0b11;
+const HEAD_SLOT_NONE: u8 = 0;
+const HEAD_SLOT_REF: u8 = 1;
+const HEAD_SLOT_INLINE: u8 = 2;
+const HEAD_SLOT_INLINE_FINGERPRINTED: u8 = 3;
+const HEAD_WORKING_DIFF_DISABLED: u8 = 0;
+const HEAD_WORKING_DIFF_CLEAN: u8 = 1;
+const HEAD_WORKING_DIFF_BEFORE_ABSENT: u8 = 2;
+const HEAD_WORKING_DIFF_BEFORE_PRESENT: u8 = 3;
+const JSON_REF_BYTES: usize = 32;
+const WORKING_DIFF_CHECKPOINT_BYTES: usize = 16;
+const WORKING_DIFF_VERSION_BYTES: usize = 16 + 16 + 1 + 8 + 8 + 1 + 32 + 1 + 32;
+const COLUMNAR_BASE_COORDINATE_BYTES: usize = 16 + 4 + 4;
+const GENERATION_BYTES: usize = 16;
+
+fn main() {
+    let args = std::env::args().collect::<Vec<_>>();
+    let usage = "usage: expW_hot_row_anatomy <rows> <identical|disjoint|single|base> <dir>";
+    let rows: usize = args.get(1).expect(usage).parse().expect(usage);
+    let scenario = args.get(2).map(String::as_str).expect(usage).to_owned();
+    let dir = PathBuf::from(args.get(3).expect(usage));
+    let runtime = tokio::runtime::Builder::new_multi_thread()
+        .worker_threads(4)
+        .enable_all()
+        .build()
+        .expect("build anatomy runtime");
+    runtime.block_on(run(rows, &scenario, &dir));
+}
+
+async fn run(rows: usize, scenario: &str, dir: &Path) {
+    std::fs::create_dir_all(dir).expect("create anatomy directory");
+    let storage = SlateDB::open(dir).expect("open anatomy SlateDB");
+    Engine::initialize(storage.clone())
+        .await
+        .expect("initialize anatomy repository");
+    let engine = Engine::new(storage.clone())
+        .await
+        .expect("open anatomy engine");
+    let main = engine
+        .open_workspace_session()
+        .await
+        .expect("open anatomy workspace session");
+    register_schema(&main).await;
+    seed_rows(&main, rows).await;
+
+    settle(&storage).await;
+    let base_spaces = space_totals(&storage).await;
+    let base_hot: HashMap<Vec<u8>, Vec<u8>> = hot_inventory(&storage).await.into_iter().collect();
+    println!(
+        "expW_base,rows={rows},scenario={scenario},base_hot_rows={},base_logical_bytes={}",
+        base_hot.len(),
+        base_spaces.values().map(|c| c.0 + c.1).sum::<u64>(),
+    );
+    for (space, counts) in &base_spaces {
+        if counts.2 == 0 {
+            continue;
+        }
+        println!(
+            "expW_base_space,rows={rows},space={space},rows_in_space={},key_bytes={},value_bytes={},bytes_per_row={:.2}",
+            counts.2,
+            counts.0,
+            counts.1,
+            (counts.0 + counts.1) as f64 / counts.2 as f64
+        );
+    }
+
+    let one_percent = (rows / 100).max(1);
+    let branch_ids = match scenario {
+        "base" => Vec::new(),
+        "single" => {
+            let branch = create_branch(&main, "branch-0").await;
+            modify_rows(&engine, &branch, 0, one_percent).await;
+            vec![branch]
+        }
+        "identical" => {
+            let first = create_branch(&main, "branch-0").await;
+            modify_rows(&engine, &first, 0, one_percent).await;
+            let second = create_branch(&main, "branch-1").await;
+            modify_rows(&engine, &second, 0, one_percent).await;
+            vec![first, second]
+        }
+        "disjoint" => {
+            let first = create_branch(&main, "branch-0").await;
+            modify_rows(&engine, &first, 0, one_percent).await;
+            let second = create_branch(&main, "branch-1").await;
+            modify_rows(&engine, &second, one_percent, one_percent).await;
+            vec![first, second]
+        }
+        other => panic!("unknown scenario '{other}'"),
+    };
+
+    settle(&storage).await;
+    let after_spaces = space_totals(&storage).await;
+    let after_hot = hot_inventory(&storage).await;
+
+    let mut names: Vec<String> = base_spaces.keys().cloned().collect();
+    for name in after_spaces.keys() {
+        if !names.contains(name) {
+            names.push(name.clone());
+        }
+    }
+    names.sort();
+    let changed_rows = branch_ids.len() * one_percent;
+    for name in &names {
+        let before = base_spaces.get(name).copied().unwrap_or_default();
+        let now = after_spaces.get(name).copied().unwrap_or_default();
+        let d_bytes = (now.0 + now.1) as i64 - (before.0 + before.1) as i64;
+        let d_rows = now.2 as i64 - before.2 as i64;
+        if d_bytes == 0 && d_rows == 0 {
+            continue;
+        }
+        println!(
+            "expW_space_delta,rows={rows},scenario={scenario},space={name},d_rows={d_rows},d_bytes={d_bytes},d_bytes_per_changed_row={:.2}",
+            if changed_rows == 0 {
+                0.0
+            } else {
+                d_bytes as f64 / changed_rows as f64
+            }
+        );
+    }
+
+    // Only the rows this scenario added to HOT.
+    let new_rows: Vec<(Vec<u8>, Vec<u8>)> = after_hot
+        .into_iter()
+        .filter(|(key, _)| !base_hot.contains_key(key))
+        .collect();
+    analyze(rows, scenario, &new_rows, changed_rows);
+}
+
+#[derive(Clone, Copy, Default)]
+struct Anatomy {
+    rows: u64,
+    key_total: u64,
+    key_scope: u64,
+    key_identity: u64,
+    value_total: u64,
+    v_fixed: u64,
+    v_identity: u64,
+    v_snapshot_fingerprint: u64,
+    v_snapshot_payload: u64,
+    v_metadata_fingerprint: u64,
+    v_metadata_payload: u64,
+    v_working_diff: u64,
+    v_columnar: u64,
+    wd_disabled: u64,
+    wd_clean: u64,
+    wd_before_absent: u64,
+    wd_before_present: u64,
+    slot_none: u64,
+    slot_ref: u64,
+    slot_inline: u64,
+    slot_inline_fingerprinted: u64,
+}
+
+fn analyze(rows: usize, scenario: &str, new_rows: &[(Vec<u8>, Vec<u8>)], changed_rows: usize) {
+    if new_rows.is_empty() {
+        println!("expW_anatomy,rows={rows},scenario={scenario},new_hot_rows=0");
+        return;
+    }
+    let mut a = Anatomy::default();
+    // key with the (branch_id, generation) scope stripped -> logical identity
+    let mut by_identity: HashMap<Vec<u8>, Vec<usize>> = HashMap::new();
+    let mut exact_values: HashMap<blake3::Hash, u64> = HashMap::new();
+    let mut ident_norm: HashMap<blake3::Hash, u64> = HashMap::new();
+    let mut content_only: HashMap<blake3::Hash, u64> = HashMap::new();
+    let mut ident_norm_bytes: HashMap<blake3::Hash, u64> = HashMap::new();
+    let mut content_only_bytes: HashMap<blake3::Hash, u64> = HashMap::new();
+
+    for (index, (key, value)) in new_rows.iter().enumerate() {
+        a.rows += 1;
+        // `+ 4` matches layout_accounting's per-row key accounting.
+        a.key_total += key.len() as u64 + 4;
+        let scope_len = scope_prefix_len(key);
+        a.key_scope += scope_len as u64;
+        a.key_identity += (key.len() - scope_len) as u64;
+        by_identity
+            .entry(key[scope_len..].to_vec())
+            .or_default()
+            .push(index);
+
+        let parsed = parse_value(value);
+        a.value_total += value.len() as u64;
+        a.v_fixed += 11; // version + flags + 2 lengths + columnar tag
+        a.v_identity += 48; // change_id + commit_id + created_at + updated_at
+        a.v_snapshot_fingerprint += parsed.snapshot_fingerprint as u64;
+        a.v_snapshot_payload += parsed.snapshot_payload as u64;
+        a.v_metadata_fingerprint += parsed.metadata_fingerprint as u64;
+        a.v_metadata_payload += parsed.metadata_payload as u64;
+        a.v_working_diff += parsed.working_diff as u64;
+        a.v_columnar += parsed.columnar as u64;
+        match parsed.working_diff_tag {
+            HEAD_WORKING_DIFF_DISABLED => a.wd_disabled += 1,
+            HEAD_WORKING_DIFF_CLEAN => a.wd_clean += 1,
+            HEAD_WORKING_DIFF_BEFORE_ABSENT => a.wd_before_absent += 1,
+            HEAD_WORKING_DIFF_BEFORE_PRESENT => a.wd_before_present += 1,
+            _ => {}
+        }
+        match parsed.snapshot_kind {
+            HEAD_SLOT_NONE => a.slot_none += 1,
+            HEAD_SLOT_REF => a.slot_ref += 1,
+            HEAD_SLOT_INLINE => a.slot_inline += 1,
+            HEAD_SLOT_INLINE_FINGERPRINTED => a.slot_inline_fingerprinted += 1,
+            _ => {}
+        }
+
+        *exact_values.entry(blake3::hash(value)).or_insert(0) += 1;
+        let n1 = normalize_identity(value, &parsed);
+        let h1 = blake3::hash(&n1);
+        *ident_norm.entry(h1).or_insert(0) += 1;
+        ident_norm_bytes.insert(h1, n1.len() as u64);
+        let n2 = content_only_bytes_of(value, &parsed);
+        let h2 = blake3::hash(&n2);
+        *content_only.entry(h2).or_insert(0) += 1;
+        content_only_bytes.insert(h2, n2.len() as u64);
+    }
+
+    let per_row = |v: u64| v as f64 / a.rows as f64;
+    println!(
+        "expW_anatomy,rows={rows},scenario={scenario},new_hot_rows={},changed_rows={changed_rows},\
+total_bytes={},bytes_per_row={:.2},\
+key_bytes={},key_per_row={:.2},key_scope_per_row={:.2},key_identity_per_row={:.2},\
+value_bytes={},value_per_row={:.2},\
+v_fixed_per_row={:.2},v_identity_per_row={:.2},\
+v_snapshot_fingerprint_per_row={:.2},v_snapshot_payload_per_row={:.2},\
+v_metadata_fingerprint_per_row={:.2},v_metadata_payload_per_row={:.2},\
+v_working_diff_per_row={:.2},v_columnar_per_row={:.2}",
+        a.rows,
+        a.key_total + a.value_total,
+        per_row(a.key_total + a.value_total),
+        a.key_total,
+        per_row(a.key_total),
+        per_row(a.key_scope),
+        per_row(a.key_identity),
+        a.value_total,
+        per_row(a.value_total),
+        per_row(a.v_fixed),
+        per_row(a.v_identity),
+        per_row(a.v_snapshot_fingerprint),
+        per_row(a.v_snapshot_payload),
+        per_row(a.v_metadata_fingerprint),
+        per_row(a.v_metadata_payload),
+        per_row(a.v_working_diff),
+        per_row(a.v_columnar),
+    );
+    println!(
+        "expW_anatomy_tags,rows={rows},scenario={scenario},\
+wd_disabled={},wd_clean={},wd_before_absent={},wd_before_present={},\
+snapshot_none={},snapshot_ref={},snapshot_inline={},snapshot_inline_fingerprinted={}",
+        a.wd_disabled,
+        a.wd_clean,
+        a.wd_before_absent,
+        a.wd_before_present,
+        a.slot_none,
+        a.slot_ref,
+        a.slot_inline,
+        a.slot_inline_fingerprinted,
+    );
+
+    // Sharing oracles over the new HOT rows.
+    let dup = |map: &HashMap<blake3::Hash, u64>| -> (u64, u64) {
+        let mut classes_gt1 = 0u64;
+        let mut dup_rows = 0u64;
+        for count in map.values() {
+            if *count > 1 {
+                classes_gt1 += 1;
+                dup_rows += count - 1;
+            }
+        }
+        (classes_gt1, dup_rows)
+    };
+    let (exact_classes, exact_dup) = dup(&exact_values);
+    let (n1_classes, n1_dup) = dup(&ident_norm);
+    let (n2_classes, n2_dup) = dup(&content_only);
+    let n1_saved: u64 = ident_norm
+        .iter()
+        .filter(|(_, c)| **c > 1)
+        .map(|(h, c)| (c - 1) * ident_norm_bytes[h])
+        .sum();
+    let n2_saved: u64 = content_only
+        .iter()
+        .filter(|(_, c)| **c > 1)
+        .map(|(h, c)| (c - 1) * content_only_bytes[h])
+        .sum();
+    println!(
+        "expW_sharing,rows={rows},scenario={scenario},new_hot_rows={},\
+exact_distinct={},exact_dup_classes={exact_classes},exact_dup_rows={exact_dup},\
+identity_normalized_distinct={},identity_normalized_dup_classes={n1_classes},identity_normalized_dup_rows={n1_dup},identity_normalized_saved_bytes={n1_saved},\
+content_only_distinct={},content_only_dup_classes={n2_classes},content_only_dup_rows={n2_dup},content_only_saved_bytes={n2_saved}",
+        a.rows,
+        exact_values.len(),
+        ident_norm.len(),
+        content_only.len(),
+    );
+
+    // Cross-branch pairing: same logical identity in >1 branch scope.
+    let mut paired_identities = 0u64;
+    let mut paired_exact_equal = 0u64;
+    let mut paired_ident_norm_equal = 0u64;
+    let mut paired_content_equal = 0u64;
+    let mut first_diff_report: Option<String> = None;
+    for indices in by_identity.values() {
+        if indices.len() < 2 {
+            continue;
+        }
+        paired_identities += 1;
+        let (_, v0) = &new_rows[indices[0]];
+        let p0 = parse_value(v0);
+        let mut exact = true;
+        let mut n1eq = true;
+        let mut n2eq = true;
+        for &other in &indices[1..] {
+            let (_, v1) = &new_rows[other];
+            let p1 = parse_value(v1);
+            if v0 != v1 {
+                exact = false;
+            }
+            if normalize_identity(v0, &p0) != normalize_identity(v1, &p1) {
+                n1eq = false;
+            }
+            if content_only_bytes_of(v0, &p0) != content_only_bytes_of(v1, &p1) {
+                n2eq = false;
+            }
+            if first_diff_report.is_none() && v0 != v1 {
+                first_diff_report = Some(describe_diff(v0, v1));
+            }
+        }
+        paired_exact_equal += u64::from(exact);
+        paired_ident_norm_equal += u64::from(n1eq);
+        paired_content_equal += u64::from(n2eq);
+    }
+    println!(
+        "expW_crossbranch,rows={rows},scenario={scenario},\
+paired_identities={paired_identities},paired_exact_equal={paired_exact_equal},\
+paired_identity_normalized_equal={paired_ident_norm_equal},paired_content_equal={paired_content_equal}"
+    );
+    if let Some(report) = first_diff_report {
+        println!("expW_crossbranch_diff,rows={rows},scenario={scenario},{report}");
+    }
+}
+
+fn describe_diff(a: &[u8], b: &[u8]) -> String {
+    let common_prefix = a
+        .iter()
+        .zip(b.iter())
+        .take_while(|(x, y)| x == y)
+        .count();
+    let common_suffix = a
+        .iter()
+        .rev()
+        .zip(b.iter().rev())
+        .take_while(|(x, y)| x == y)
+        .count();
+    let differing = if a.len() == b.len() {
+        a.iter().zip(b.iter()).filter(|(x, y)| x != y).count()
+    } else {
+        usize::MAX
+    };
+    format!(
+        "len_a={},len_b={},common_prefix={common_prefix},common_suffix={common_suffix},differing_bytes={}",
+        a.len(),
+        b.len(),
+        if differing == usize::MAX {
+            -1
+        } else {
+            differing as i64
+        }
+    )
+}
+
+#[derive(Clone, Copy, Default)]
+struct Parsed {
+    snapshot_kind: u8,
+    metadata_kind: u8,
+    working_diff_tag: u8,
+    snapshot_fingerprint: usize,
+    snapshot_payload: usize,
+    metadata_fingerprint: usize,
+    metadata_payload: usize,
+    working_diff: usize,
+    columnar: usize,
+    snapshot_start: usize,
+    metadata_end: usize,
+}
+
+fn parse_value(value: &[u8]) -> Parsed {
+    assert!(
+        value.len() >= HEAD_VALUE_HEADER_BYTES,
+        "hot row shorter than v8 header"
+    );
+    assert_eq!(
+        value[0], HEAD_VALUE_VERSION,
+        "hot row codec version changed; update expW_hot_row_anatomy"
+    );
+    let flags = value[1];
+    let snapshot_kind = (flags >> HEAD_VALUE_SNAPSHOT_SHIFT) & HEAD_VALUE_SLOT_MASK;
+    let metadata_kind = (flags >> HEAD_VALUE_METADATA_SHIFT) & HEAD_VALUE_SLOT_MASK;
+    let working_diff_tag = (flags >> HEAD_VALUE_WORKING_DIFF_SHIFT) & HEAD_VALUE_WORKING_DIFF_MASK;
+    let snapshot_len =
+        u32::from_be_bytes(value[50..54].try_into().expect("snapshot len")) as usize;
+    let metadata_len = u32::from_be_bytes(value[54..58].try_into().expect("metadata len")) as usize;
+    let has_columnar = value[58] == 1;
+    let snapshot_fingerprint = match snapshot_kind {
+        HEAD_SLOT_REF => JSON_REF_BYTES,
+        HEAD_SLOT_INLINE_FINGERPRINTED => JSON_REF_BYTES,
+        _ => 0,
+    };
+    let metadata_fingerprint = match metadata_kind {
+        HEAD_SLOT_REF => JSON_REF_BYTES,
+        HEAD_SLOT_INLINE_FINGERPRINTED => JSON_REF_BYTES,
+        _ => 0,
+    };
+    let working_diff = match working_diff_tag {
+        HEAD_WORKING_DIFF_BEFORE_ABSENT => WORKING_DIFF_CHECKPOINT_BYTES,
+        HEAD_WORKING_DIFF_BEFORE_PRESENT => {
+            WORKING_DIFF_CHECKPOINT_BYTES + WORKING_DIFF_VERSION_BYTES
+        }
+        _ => 0,
+    };
+    Parsed {
+        snapshot_kind,
+        metadata_kind,
+        working_diff_tag,
+        snapshot_fingerprint,
+        snapshot_payload: snapshot_len - snapshot_fingerprint,
+        metadata_fingerprint,
+        metadata_payload: metadata_len - metadata_fingerprint,
+        working_diff,
+        columnar: if has_columnar {
+            COLUMNAR_BASE_COORDINATE_BYTES
+        } else {
+            0
+        },
+        snapshot_start: HEAD_VALUE_HEADER_BYTES,
+        metadata_end: HEAD_VALUE_HEADER_BYTES + snapshot_len + metadata_len,
+    }
+}
+
+/// Zeroes the fields whose only job is to name *this* change: change id, commit
+/// id and both timestamps. Everything else, including the working-diff
+/// baseline and columnar coordinate, is preserved.
+fn normalize_identity(value: &[u8], _parsed: &Parsed) -> Vec<u8> {
+    let mut out = value.to_vec();
+    out[2..50].fill(0);
+    out
+}
+
+/// Keeps only the parts that describe the row's *content*: flags, slot kinds
+/// and both JSON payloads. Per-row identity, the working-diff baseline and the
+/// columnar coordinate are dropped entirely. This is the upper bound on what a
+/// cross-branch content-addressed HOT plane could ever share.
+fn content_only_bytes_of(value: &[u8], parsed: &Parsed) -> Vec<u8> {
+    let mut out = Vec::with_capacity(parsed.metadata_end - parsed.snapshot_start + 4);
+    out.push(value[1] & 0b0011_1111); // flags without the working-diff tag
+    out.extend_from_slice(&value[parsed.snapshot_start..parsed.metadata_end]);
+    out
+}
+
+/// Length of the `branch_id ++ generation` scope prefix of a HOT row key.
+///
+/// `branch_id` is written by `write_key_string` (0x00 escaped as 0x00 0xFF,
+/// terminated by 0x00 0x00), then a fixed 16-byte generation.
+fn scope_prefix_len(key: &[u8]) -> usize {
+    let mut index = 0usize;
+    while index + 1 < key.len() {
+        if key[index] == 0x00 {
+            if key[index + 1] == 0xff {
+                index += 2;
+                continue;
+            }
+            assert_eq!(key[index + 1], 0x00, "unexpected branch-id terminator");
+            return index + 2 + GENERATION_BYTES;
+        }
+        index += 1;
+    }
+    panic!("hot row key has no branch-id terminator");
+}
+
+// ---------------------------------------------------------------------------
+// Fixture — identical to `benches/branch_storage_sharing.rs`.
+// ---------------------------------------------------------------------------
+
+async fn settle(storage: &SlateDB) {
+    storage
+        .flush_memtable_for_diagnostics()
+        .await
+        .expect("flush anatomy memtable");
+    tokio::time::sleep(std::time::Duration::from_millis(250)).await;
+}
+
+async fn space_totals(storage: &SlateDB) -> BTreeMap<String, (u64, u64, u64)> {
+    let adapter = StorageAdapter::new(storage.clone());
+    let read = adapter
+        .begin_read(ReadOptions::default())
+        .await
+        .expect("open anatomy layout read");
+    let accounting = layout_accounting(&read).await;
+    drop(read);
+    accounting
+        .into_iter()
+        .map(|entry| {
+            (
+                entry.space.to_owned(),
+                (entry.key_bytes, entry.value_bytes, entry.rows),
+            )
+        })
+        .collect()
+}
+
+async fn hot_inventory(storage: &SlateDB) -> Vec<(Vec<u8>, Vec<u8>)> {
+    let adapter = StorageAdapter::new(storage.clone());
+    let read = adapter
+        .begin_read(ReadOptions::default())
+        .await
+        .expect("open anatomy inventory read");
+    let inventory = space_inventory(&read, HOT_ROW_SPACE).await;
+    drop(read);
+    inventory
+}
+
+async fn create_branch(main: &SessionContext<SlateDB>, name: &str) -> String {
+    main.create_branch(CreateBranchOptions {
+        id: None,
+        name: name.to_owned(),
+        from_commit_id: None,
+    })
+    .await
+    .expect("create anatomy branch")
+    .id
+}
+
+async fn modify_rows(engine: &Engine<SlateDB>, branch: &str, start: usize, count: usize) {
+    let session = engine
+        .open_session(branch.to_owned())
+        .await
+        .expect("open anatomy branch session");
+    let mut written = 0usize;
+    while written < count {
+        let batch = (count - written).min(SEED_BATCH_ROWS);
+        let mut transaction = session
+            .begin_transaction()
+            .await
+            .expect("begin anatomy modification");
+        for offset in 0..batch {
+            let index = start + written + offset;
+            transaction
+                .execute(
+                    "UPDATE branch_fixture SET value = lix_json($1) WHERE path = $2",
+                    &[
+                        Value::Text(format!(r#"{{"seed":{index},"edited":true,"pad":"{PAD}"}}"#)),
+                        Value::Text(row_path(index)),
+                    ],
+                )
+                .await
+                .expect("stage anatomy modification");
+        }
+        transaction
+            .commit()
+            .await
+            .expect("commit anatomy modification");
+        written += batch;
+    }
+}
+
+fn row_path(index: usize) -> String {
+    format!("/branch/fixture/{index:09}")
+}
+
+async fn register_schema(session: &SessionContext<SlateDB>) {
+    let schema = serde_json::json!({
+        "x-lix-key": "branch_fixture",
+        "x-lix-primary-key": ["/path"],
+        "type": "object",
+        "required": ["path", "value"],
+        "properties": {
+            "path": { "type": "string" },
+            "value": {
+                "type": ["object", "array", "string", "number", "integer", "boolean", "null"]
+            }
+        },
+        "additionalProperties": false
+    });
+    session
+        .execute(
+            "INSERT INTO lix_registered_schema (value, lixcol_global, lixcol_untracked) \
+             VALUES (lix_json($1), false, false)",
+            &[Value::Text(schema.to_string())],
+        )
+        .await
+        .expect("register anatomy schema");
+}
+
+async fn seed_rows(session: &SessionContext<SlateDB>, rows: usize) {
+    let mut written = 0usize;
+    while written < rows {
+        let batch = (rows - written).min(SEED_BATCH_ROWS);
+        let mut transaction = session
+            .begin_transaction()
+            .await
+            .expect("begin anatomy seed");
+        for offset in 0..batch {
+            let index = written + offset;
+            transaction
+                .execute(
+                    "INSERT INTO branch_fixture (path, value) VALUES ($1, lix_json($2))",
+                    &[
+                        Value::Text(row_path(index)),
+                        Value::Text(format!(r#"{{"seed":{index},"pad":"{PAD}"}}"#)),
+                    ],
+                )
+                .await
+                .expect("stage anatomy seed row");
+        }
+        transaction
+            .commit()
+            .await
+            .expect("commit anatomy seed");
+        written += batch;
+    }
+}

--- a/packages/engine-benchmarks/examples/expu_json_delta.rs
+++ b/packages/engine-benchmarks/examples/expu_json_delta.rs
@@ -1,0 +1,1114 @@
+//! Does delta encoding pay for the content-addressed JSON store?
+//!
+//! `duplicate_audit` established that `json_store.json` is full of *near*
+//! duplicates: distinct payloads that agree with a neighbour outside a narrow
+//! byte window. Near-duplication is a suggestive shape, not a case. The case
+//! needs three numbers the auditor cannot produce:
+//!
+//! 1. **Edit size relative to payload size.** A delta only pays when the
+//!    changed span is a small fraction of the document. The auditor probes
+//!    fixed 8/16/32/64-byte windows against the *stored* (already compressed)
+//!    bytes, so a "64-byte prefix" on a 181-byte compressed row is a third of
+//!    the row, not a rounding error.
+//! 2. **How much of that near-duplication zstd already captured.** Every
+//!    payload is individually zstd-compressed at level 1 today. A delta only
+//!    earns the bytes zstd left on the table.
+//! 3. **What a delta base costs to reach.** A payload's natural base is the
+//!    previous version of the same entity, which is a different content
+//!    address in the same space.
+//!
+//! Modes:
+//! ```text
+//! expu_json_delta build  <corpus> <dir> <writelog>  # seed via the real SQL commit path
+//! expu_json_delta oracle <writelog>                 # delta/dictionary/zstd accounting
+//! expu_json_delta store  <dir>                      # decode the settled JSON space
+//! expu_json_delta readcost <dir>                    # point-read cost versus chain depth
+//! ```
+//!
+//! Every corpus is seeded through `SessionContext` SQL, so the write log is
+//! exactly the payload stream an ordinary commit stages. The oracle never
+//! touches engine internals: it replays the store's own encoder rule
+//! (`>= 512` bytes, zstd level 1, keep raw unless it saves `>= 128` bytes,
+//! plus a 20-byte envelope) so "bytes today" is the real stored size.
+
+#![allow(clippy::large_futures)]
+
+use std::collections::{BTreeMap, HashMap, HashSet};
+use std::io::{Read, Write};
+use std::path::{Path, PathBuf};
+
+use lix::integration::{Engine, SessionContext};
+use lix::storage::Storage;
+use lix::storage_adapter::{
+    PointReadPlan, StorageAdapter, StorageGetOptions, StorageKey, StorageReadOptions,
+};
+use lix::storage_bench::{space_inventory, storage_space_by_name};
+use lix::Value;
+use lix_storage_slatedb::SlateDB;
+
+/// Mirrors `json_store::store`: magic + codec byte + u64 uncompressed length.
+const STORED_JSON_MAGIC: &[u8] = b"lix-json:v1";
+const STORED_JSON_HEADER_LEN: usize = STORED_JSON_MAGIC.len() + 1 + 8;
+/// Mirrors `json_store::store::ZSTD_MIN_JSON_BYTES`.
+const ZSTD_MIN_JSON_BYTES: usize = 512;
+/// Mirrors `json_store::store::MIN_ZSTD_SAVINGS_BYTES`.
+const MIN_ZSTD_SAVINGS_BYTES: usize = 128;
+/// Mirrors `json_store::types::JSON_INLINE_MAX_BYTES`.
+const JSON_INLINE_MAX_BYTES: usize = 1024;
+/// Mirrors the store's compression level.
+const ZSTD_LEVEL: i32 = 1;
+/// A delta row must name its base. One content address, 32 bytes.
+const DELTA_BASE_REF_BYTES: usize = 32;
+
+fn main() {
+    let args = std::env::args().collect::<Vec<_>>();
+    let usage =
+        "usage: expu_json_delta (build <corpus> <dir> <writelog> | oracle <writelog> | store <dir>)";
+    let mode = args.get(1).map(String::as_str).expect(usage);
+    match mode {
+        "build" => {
+            let corpus = args.get(2).map(String::as_str).expect(usage);
+            let dir = PathBuf::from(args.get(3).expect(usage));
+            let log = PathBuf::from(args.get(4).expect(usage));
+            let runtime = tokio::runtime::Builder::new_multi_thread()
+                .worker_threads(4)
+                .enable_all()
+                .build()
+                .expect("build runtime");
+            runtime.block_on(build(corpus, &dir, &log));
+        }
+        "oracle" => oracle(&PathBuf::from(args.get(2).expect(usage))),
+        "store" => {
+            let runtime = tokio::runtime::Builder::new_multi_thread()
+                .worker_threads(4)
+                .enable_all()
+                .build()
+                .expect("build runtime");
+            runtime.block_on(store_report(&PathBuf::from(args.get(2).expect(usage))));
+        }
+        "readcost" => {
+            let runtime = tokio::runtime::Builder::new_multi_thread()
+                .worker_threads(4)
+                .enable_all()
+                .build()
+                .expect("build runtime");
+            runtime.block_on(read_cost(&PathBuf::from(args.get(2).expect(usage))));
+        }
+        other => panic!("unknown mode '{other}'; {usage}"),
+    }
+}
+
+fn env_usize(name: &str, default: usize) -> usize {
+    std::env::var(name)
+        .ok()
+        .and_then(|value| value.parse().ok())
+        .filter(|value| *value > 0)
+        .unwrap_or(default)
+}
+
+// ---------------------------------------------------------------------------
+// Write log: the exact (entity, payload) stream the commit path staged.
+// ---------------------------------------------------------------------------
+
+struct WriteLog {
+    file: std::io::BufWriter<std::fs::File>,
+}
+
+impl WriteLog {
+    fn create(path: &Path) -> Self {
+        Self {
+            file: std::io::BufWriter::new(
+                std::fs::File::create(path).expect("create expU write log"),
+            ),
+        }
+    }
+
+    fn push(&mut self, entity: &str, json: &str) {
+        let entity = entity.as_bytes();
+        let json = json.as_bytes();
+        self.file
+            .write_all(&(entity.len() as u32).to_le_bytes())
+            .expect("write entity length");
+        self.file.write_all(entity).expect("write entity");
+        self.file
+            .write_all(&(json.len() as u32).to_le_bytes())
+            .expect("write payload length");
+        self.file.write_all(json).expect("write payload");
+    }
+
+    fn finish(mut self) {
+        self.file.flush().expect("flush expU write log");
+    }
+}
+
+fn read_write_log(path: &Path) -> Vec<(String, Vec<u8>)> {
+    let mut file =
+        std::io::BufReader::new(std::fs::File::open(path).expect("open expU write log"));
+    let mut entries = Vec::new();
+    let mut length = [0_u8; 4];
+    loop {
+        match file.read_exact(&mut length) {
+            Ok(()) => {}
+            Err(error) if error.kind() == std::io::ErrorKind::UnexpectedEof => break,
+            Err(error) => panic!("read expU write log: {error}"),
+        }
+        let mut entity = vec![0_u8; u32::from_le_bytes(length) as usize];
+        file.read_exact(&mut entity).expect("read entity");
+        file.read_exact(&mut length).expect("read payload length");
+        let mut json = vec![0_u8; u32::from_le_bytes(length) as usize];
+        file.read_exact(&mut json).expect("read payload");
+        entries.push((String::from_utf8(entity).expect("utf8 entity"), json));
+    }
+    entries
+}
+
+// ---------------------------------------------------------------------------
+// Corpora
+// ---------------------------------------------------------------------------
+
+/// A structured document with a realistic edit surface.
+///
+/// `blocks` dominates the byte count, so a one-block edit is the JSON analogue
+/// of "the user typed a sentence". `version`/`updated_at` sit in the header,
+/// which is what makes the *leading* bytes differ on every single edit even
+/// when the body is untouched — exactly the prefix-64 shape the auditor saw.
+struct DocShape {
+    blocks: usize,
+    block_bytes: usize,
+}
+
+impl DocShape {
+    /// Renders a document from its per-block revision vector.
+    ///
+    /// Edits *accumulate*: a block keeps the text it was last given. Two
+    /// consecutive versions therefore differ in exactly the block that was
+    /// edited plus the header, which is what makes the measured edit span an
+    /// honest number rather than the envelope of two unrelated changes.
+    fn document(&self, doc: usize, version: usize, block_revisions: &[usize]) -> String {
+        let mut out = String::with_capacity(self.blocks * (self.block_bytes + 64) + 256);
+        out.push_str(&format!(
+            r#"{{"id":"doc-{doc:06}","schema":"expu/document/v1","version":{version},"updated_at":"2026-08-{:02}T{:02}:{:02}:00Z","author":{{"id":"user-{:04}","name":"Contributor {:04}"}},"tags":["draft","review","expu"],"blocks":["#,
+            (version % 28) + 1,
+            version % 24,
+            version % 60,
+            doc % 64,
+            doc % 64,
+        ));
+        for (block, revision) in block_revisions.iter().enumerate() {
+            if block > 0 {
+                out.push(',');
+            }
+            out.push_str(&format!(
+                r#"{{"id":"blk-{block:04}","type":"paragraph","text":"{}"}}"#,
+                block_text(doc, block, *revision, self.block_bytes),
+            ));
+        }
+        out.push_str(r#"],"meta":{"words":1234,"locale":"en-US","status":"active"}}"#);
+        out
+    }
+}
+
+/// Deterministic prose-shaped filler. Word-like tokens keep zstd's literal and
+/// match distribution close to real text instead of a single long run.
+fn block_text(doc: usize, block: usize, revision: usize, bytes: usize) -> String {
+    const WORDS: [&str; 16] = [
+        "the", "quick", "brown", "fox", "jumps", "over", "lazy", "dog", "storage", "layout",
+        "commit", "payload", "version", "delta", "content", "address",
+    ];
+    let mut state = ((doc as u64) << 32 | (block as u64) << 16 | revision as u64)
+        .wrapping_mul(0x9E37_79B9_7F4A_7C15)
+        | 1;
+    let mut out = String::with_capacity(bytes + 16);
+    while out.len() < bytes {
+        state ^= state << 13;
+        state ^= state >> 7;
+        state ^= state << 17;
+        if !out.is_empty() {
+            out.push(' ');
+        }
+        out.push_str(WORDS[(state % WORDS.len() as u64) as usize]);
+    }
+    out.truncate(bytes);
+    out
+}
+
+async fn build(corpus: &str, dir: &Path, log_path: &Path) {
+    assert!(
+        !dir.exists(),
+        "refusing to seed into an existing directory: {}",
+        dir.display()
+    );
+    let storage = SlateDB::open(dir).expect("open SlateDB corpus");
+    Engine::initialize(storage.clone())
+        .await
+        .expect("initialize corpus repository");
+    let engine = Engine::new(storage.clone())
+        .await
+        .expect("open corpus engine");
+    let session = engine
+        .open_workspace_session()
+        .await
+        .expect("open corpus workspace");
+    let mut log = WriteLog::create(log_path);
+
+    match corpus {
+        // Many documents, each edited many times, one block per edit. This is
+        // the shape a delta encoder is supposed to win on.
+        "doc_edits" | "doc_small" | "doc_large" | "doc_scattered" | "doc_header_only" => {
+            let shape = match corpus {
+                "doc_small" => DocShape {
+                    blocks: env_usize("LIX_EXPU_BLOCKS", 6),
+                    block_bytes: env_usize("LIX_EXPU_BLOCK_BYTES", 180),
+                },
+                "doc_large" => DocShape {
+                    blocks: env_usize("LIX_EXPU_BLOCKS", 200),
+                    block_bytes: env_usize("LIX_EXPU_BLOCK_BYTES", 400),
+                },
+                _ => DocShape {
+                    blocks: env_usize("LIX_EXPU_BLOCKS", 40),
+                    block_bytes: env_usize("LIX_EXPU_BLOCK_BYTES", 220),
+                },
+            };
+            register_document_schema(&session).await;
+            let docs = env_usize("LIX_EXPU_DOCS", 400);
+            let rounds = env_usize("LIX_EXPU_ROUNDS", 25);
+            let commit_rows = env_usize("LIX_EXPU_COMMIT_ROWS", 200);
+            let mut revisions = vec![vec![0_usize; shape.blocks]; docs];
+            seed_documents(&session, &shape, &revisions, commit_rows, &mut log).await;
+            edit_documents(
+                &session,
+                &shape,
+                corpus,
+                &mut revisions,
+                rounds,
+                commit_rows,
+                &mut log,
+            )
+            .await;
+        }
+        // The built-in key/value plugin schema: a plugin-driven shape whose
+        // payloads straddle the 1 KiB inline threshold.
+        // `kv_rewrite` replaces the whole value body on every edit: the
+        // negative control that shows what the oracle reports when there is no
+        // delta to find.
+        "kv" | "kv_rewrite" => {
+            let keys = env_usize("LIX_EXPU_DOCS", 2_000);
+            let rounds = env_usize("LIX_EXPU_ROUNDS", 10);
+            let value_bytes = env_usize("LIX_EXPU_BLOCK_BYTES", 4_096);
+            let rewrite = corpus == "kv_rewrite";
+            seed_key_values(&session, keys, value_bytes, rewrite, &mut log).await;
+            edit_key_values(&session, keys, rounds, value_bytes, rewrite, &mut log).await;
+        }
+        other => panic!("unknown corpus '{other}'"),
+    }
+
+    log.finish();
+    drop(session);
+    drop(engine);
+    storage.flush().await.expect("flush SlateDB WAL");
+    storage
+        .flush_memtable_for_diagnostics()
+        .await
+        .expect("flush SlateDB memtable");
+    drop(storage);
+    println!("BUILT\tcorpus={corpus}\tdir={}", dir.display());
+}
+
+async fn register_document_schema<S>(session: &SessionContext<S>)
+where
+    S: Storage + Clone + Send + Sync + 'static,
+{
+    let schema = serde_json::json!({
+        "x-lix-key": "expu_document",
+        "x-lix-primary-key": ["/path"],
+        "type": "object",
+        "required": ["path", "doc"],
+        "properties": {
+            "path": { "type": "string" },
+            "doc": { "type": ["object", "array", "string", "number", "boolean", "null"] }
+        },
+        "additionalProperties": false
+    });
+    session
+        .execute(
+            "INSERT INTO lix_registered_schema (value, lixcol_global, lixcol_untracked) \
+             VALUES (lix_json($1), false, false)",
+            &[Value::Text(schema.to_string())],
+        )
+        .await
+        .expect("register expU document schema");
+}
+
+async fn seed_documents<S>(
+    session: &SessionContext<S>,
+    shape: &DocShape,
+    revisions: &[Vec<usize>],
+    commit_rows: usize,
+    log: &mut WriteLog,
+) where
+    S: Storage + Clone + Send + Sync + 'static,
+{
+    let docs = revisions.len();
+    let mut index = 0;
+    while index < docs {
+        let end = (index + commit_rows).min(docs);
+        let mut transaction = session.begin_transaction().await.expect("begin seed");
+        while index < end {
+            let path = format!("/doc/{index:06}");
+            let document = shape.document(index, 0, &revisions[index]);
+            transaction
+                .execute(
+                    "INSERT INTO expu_document (path, doc) VALUES ($1, lix_json($2))",
+                    &[Value::Text(path.clone()), Value::Text(document.clone())],
+                )
+                .await
+                .expect("stage seed document");
+            log.push(&path, &document);
+            index += 1;
+        }
+        transaction.commit().await.expect("commit seed batch");
+    }
+}
+
+async fn edit_documents<S>(
+    session: &SessionContext<S>,
+    shape: &DocShape,
+    corpus: &str,
+    revisions: &mut [Vec<usize>],
+    rounds: usize,
+    commit_rows: usize,
+    log: &mut WriteLog,
+) where
+    S: Storage + Clone + Send + Sync + 'static,
+{
+    let docs = revisions.len();
+    for round in 1..=rounds {
+        let mut index = 0;
+        while index < docs {
+            let end = (index + commit_rows).min(docs);
+            let mut transaction = session.begin_transaction().await.expect("begin edit");
+            while index < end {
+                // `doc_header_only` bumps only the header fields, the pure
+                // "leading bytes differ" case. Everything else also rewrites
+                // one body block, the realistic single-field edit.
+                if corpus != "doc_header_only" {
+                    let block = (round * 7 + index) % shape.blocks;
+                    revisions[index][block] = round;
+                }
+                let path = format!("/doc/{index:06}");
+                let document = shape.document(index, round, &revisions[index]);
+                transaction
+                    .execute(
+                        "UPDATE expu_document SET doc = lix_json($2) WHERE path = $1",
+                        &[Value::Text(path.clone()), Value::Text(document.clone())],
+                    )
+                    .await
+                    .expect("stage document edit");
+                log.push(&path, &document);
+                index += 1;
+            }
+            transaction.commit().await.expect("commit edit batch");
+        }
+    }
+}
+
+fn key_value_payload(key: usize, revision: usize, bytes: usize, rewrite: bool) -> String {
+    const STATUS: [&str; 4] = ["active", "paused", "draining", "retired"];
+    serde_json::json!({
+        "revision": revision,
+        "owner": format!("service-{:03}", key % 32),
+        "status": STATUS[revision % STATUS.len()],
+        "payload": block_text(key, 0, if rewrite { revision } else { 0 }, bytes),
+    })
+    .to_string()
+}
+
+async fn seed_key_values<S>(
+    session: &SessionContext<S>,
+    keys: usize,
+    value_bytes: usize,
+    rewrite: bool,
+    log: &mut WriteLog,
+) where
+    S: Storage + Clone + Send + Sync + 'static,
+{
+    let mut transaction = session.begin_transaction().await.expect("begin kv seed");
+    for key in 0..keys {
+        let name = format!("expu_key_{key:06}");
+        let payload = key_value_payload(key, 0, value_bytes, rewrite);
+        transaction
+            .execute(
+                "INSERT INTO lix_key_value (key, value) VALUES ($1, lix_json($2))",
+                &[Value::Text(name.clone()), Value::Text(payload.clone())],
+            )
+            .await
+            .expect("stage kv seed");
+        log.push(&name, &payload);
+        if key % 500 == 499 {
+            transaction.commit().await.expect("commit kv seed batch");
+            transaction = session.begin_transaction().await.expect("begin kv seed");
+        }
+    }
+    transaction.commit().await.expect("commit kv seed tail");
+}
+
+async fn edit_key_values<S>(
+    session: &SessionContext<S>,
+    keys: usize,
+    rounds: usize,
+    value_bytes: usize,
+    rewrite: bool,
+    log: &mut WriteLog,
+) where
+    S: Storage + Clone + Send + Sync + 'static,
+{
+    for round in 1..=rounds {
+        let mut transaction = session.begin_transaction().await.expect("begin kv edit");
+        for key in 0..keys {
+            let name = format!("expu_key_{key:06}");
+            let payload = key_value_payload(key, round, value_bytes, rewrite);
+            transaction
+                .execute(
+                    "UPDATE lix_key_value SET value = lix_json($2) WHERE key = $1",
+                    &[Value::Text(name.clone()), Value::Text(payload.clone())],
+                )
+                .await
+                .expect("stage kv edit");
+            log.push(&name, &payload);
+            if key % 500 == 499 {
+                transaction.commit().await.expect("commit kv edit batch");
+                transaction = session.begin_transaction().await.expect("begin kv edit");
+            }
+        }
+        transaction.commit().await.expect("commit kv edit tail");
+    }
+}
+
+// ---------------------------------------------------------------------------
+// The store's own encoder rule, replayed offline.
+// ---------------------------------------------------------------------------
+
+fn zstd_compress(level: i32, data: &[u8]) -> Vec<u8> {
+    zstd::bulk::compress(data, level).expect("zstd compress")
+}
+
+/// Exactly what `StoredJsonBatchEncoder::append_json_with_ref` produces today,
+/// parameterized by compression level so a "just raise the level" arm can be
+/// priced against a delta scheme without changing anything else.
+fn stored_len_at_level(raw: &[u8], level: i32) -> usize {
+    let selected = if raw.len() >= ZSTD_MIN_JSON_BYTES {
+        let compressed = zstd_compress(level, raw);
+        if raw.len().saturating_sub(compressed.len()) >= MIN_ZSTD_SAVINGS_BYTES {
+            compressed.len()
+        } else {
+            raw.len()
+        }
+    } else {
+        raw.len()
+    };
+    STORED_JSON_HEADER_LEN + selected
+}
+
+fn stored_len_today(raw: &[u8]) -> usize {
+    stored_len_at_level(raw, ZSTD_LEVEL)
+}
+
+/// Decodes one settled `json_store.json` row back to its JSON text.
+///
+/// The envelope is replayed here rather than reached for through the engine so
+/// this tool stays a pure observer of the format it is measuring, exactly like
+/// `stored_len_at_level` replays the encoder side.
+fn decode_stored_json(value: &[u8]) -> Vec<u8> {
+    assert!(
+        value.len() >= STORED_JSON_HEADER_LEN && value.starts_with(STORED_JSON_MAGIC),
+        "stored JSON payload has an unexpected envelope"
+    );
+    let codec = value[STORED_JSON_MAGIC.len()];
+    let length_start = STORED_JSON_MAGIC.len() + 1;
+    let uncompressed_len = u64::from_be_bytes(
+        value[length_start..length_start + 8]
+            .try_into()
+            .expect("stored JSON length header is fixed size"),
+    ) as usize;
+    let payload = &value[length_start + 8..];
+    match codec {
+        0 => payload.to_vec(),
+        1 => zstd::bulk::decompress(payload, uncompressed_len).expect("decompress stored json"),
+        other => panic!("stored JSON payload has unknown codec byte {other}"),
+    }
+}
+
+/// Delta-encoded length: the same envelope, plus a base content address, with
+/// the frame produced against the base payload as a raw zstd dictionary. This
+/// is the `zstd --patch-from` model at the store's own compression level.
+fn stored_len_delta(raw: &[u8], base: &[u8]) -> usize {
+    let mut compressor =
+        zstd::bulk::Compressor::with_dictionary(ZSTD_LEVEL, base).expect("dictionary compressor");
+    let frame = compressor.compress(raw).expect("delta compress");
+    STORED_JSON_HEADER_LEN + DELTA_BASE_REF_BYTES + frame.len()
+}
+
+fn common_prefix(left: &[u8], right: &[u8]) -> usize {
+    left.iter().zip(right).take_while(|(a, b)| a == b).count()
+}
+
+fn common_suffix(left: &[u8], right: &[u8], skip: usize) -> usize {
+    left.iter()
+        .rev()
+        .zip(right.iter().rev())
+        .take(left.len().min(right.len()).saturating_sub(skip))
+        .take_while(|(a, b)| a == b)
+        .count()
+}
+
+fn percentile(sorted: &[f64], fraction: f64) -> f64 {
+    if sorted.is_empty() {
+        return 0.0;
+    }
+    let index = ((sorted.len() - 1) as f64 * fraction).round() as usize;
+    sorted[index]
+}
+
+fn percentile_u64(sorted: &[u64], fraction: f64) -> u64 {
+    if sorted.is_empty() {
+        return 0;
+    }
+    let index = ((sorted.len() - 1) as f64 * fraction).round() as usize;
+    sorted[index]
+}
+
+fn percent(part: u64, whole: u64) -> f64 {
+    if whole == 0 {
+        return 0.0;
+    }
+    100.0 * part as f64 / whole as f64
+}
+
+// ---------------------------------------------------------------------------
+// Oracle
+// ---------------------------------------------------------------------------
+
+fn oracle(log_path: &Path) {
+    let entries = read_write_log(log_path);
+
+    // Per entity, the ordered stream of *distinct* payloads. A repeat write of
+    // identical content is already free (content addressing), so it neither
+    // costs bytes nor extends a chain.
+    let mut order: Vec<String> = Vec::new();
+    let mut by_entity: HashMap<String, Vec<Vec<u8>>> = HashMap::new();
+    let mut stored_digests: HashSet<[u8; 32]> = HashSet::new();
+    let mut inline_writes = 0_u64;
+    let mut out_of_band_writes = 0_u64;
+    let mut raw_lengths: Vec<u64> = Vec::new();
+
+    for (entity, json) in &entries {
+        raw_lengths.push(json.len() as u64);
+        if json.len() <= JSON_INLINE_MAX_BYTES {
+            inline_writes += 1;
+            continue;
+        }
+        out_of_band_writes += 1;
+        if !stored_digests.insert(*blake3::hash(json).as_bytes()) {
+            continue;
+        }
+        let versions = by_entity.entry(entity.clone()).or_insert_with(|| {
+            order.push(entity.clone());
+            Vec::new()
+        });
+        versions.push(json.clone());
+    }
+
+    raw_lengths.sort_unstable();
+    println!(
+        "PAYLOAD\twrites={}\tinline_writes={inline_writes}\tout_of_band_writes={out_of_band_writes}\tdistinct_out_of_band={}\tentities={}\traw_p10={}\traw_p50={}\traw_p90={}\traw_max={}",
+        entries.len(),
+        stored_digests.len(),
+        by_entity.len(),
+        percentile_u64(&raw_lengths, 0.10),
+        percentile_u64(&raw_lengths, 0.50),
+        percentile_u64(&raw_lengths, 0.90),
+        raw_lengths.last().copied().unwrap_or_default(),
+    );
+
+    // Bounded-chain arms. `1` is "no delta at all" and the largest value is an
+    // unbounded chain; everything between is a periodic full snapshot.
+    let depths = [1_usize, 2, 4, 8, 16, usize::MAX];
+    let levels = [ZSTD_LEVEL, 3, 9, 19];
+
+    let mut raw_bytes = 0_u64;
+    let mut level_bytes = [0_u64; 4];
+    let mut delta_chain_bytes = 0_u64;
+    let mut delta_anchor_bytes = 0_u64;
+    let mut bounded_bytes = [0_u64; 6];
+    let mut edit_ratios: Vec<f64> = Vec::new();
+    let mut edit_spans: Vec<u64> = Vec::new();
+    let mut chain_lengths: Vec<u64> = Vec::new();
+    // Byte savings attributable only to the *successors*, so a corpus with one
+    // version per entity cannot flatter the delta arm.
+    let mut successor_today_bytes = 0_u64;
+    let mut successor_delta_bytes = 0_u64;
+    let mut successor_anchor_bytes = 0_u64;
+
+    for entity in &order {
+        let versions = &by_entity[entity];
+        chain_lengths.push(versions.len() as u64);
+        for (index, raw) in versions.iter().enumerate() {
+            raw_bytes += raw.len() as u64;
+            for (slot, level) in levels.iter().enumerate() {
+                level_bytes[slot] += stored_len_at_level(raw, *level) as u64;
+            }
+            let today = stored_len_today(raw) as u64;
+            if index == 0 {
+                delta_chain_bytes += today;
+                delta_anchor_bytes += today;
+                for slot in 0..depths.len() {
+                    bounded_bytes[slot] += today;
+                }
+                continue;
+            }
+            let base = &versions[index - 1];
+            let delta = stored_len_delta(raw, base) as u64;
+            // The anchor arm always deltas against version 0, so every payload
+            // is reachable in exactly one extra read regardless of history
+            // depth. It trades some compression for a hard depth bound of 1.
+            let anchor = stored_len_delta(raw, &versions[0]) as u64;
+            delta_chain_bytes += delta;
+            delta_anchor_bytes += anchor;
+            successor_today_bytes += today;
+            successor_delta_bytes += delta;
+            successor_anchor_bytes += anchor;
+            for (slot, depth) in depths.iter().enumerate() {
+                bounded_bytes[slot] += if *depth == 1 || index % depth == 0 {
+                    today
+                } else {
+                    delta
+                };
+            }
+
+            let prefix = common_prefix(raw, base);
+            let suffix = common_suffix(raw, base, prefix);
+            let span = raw.len().saturating_sub(prefix + suffix) as u64;
+            edit_spans.push(span);
+            edit_ratios.push(span as f64 / raw.len() as f64);
+        }
+    }
+
+    edit_ratios.sort_by(|a, b| a.partial_cmp(b).expect("finite ratio"));
+    edit_spans.sort_unstable();
+    chain_lengths.sort_unstable();
+    let today_bytes = level_bytes[0];
+
+    println!(
+        "EDIT_SPAN\tpairs={}\tspan_p10={}\tspan_p50={}\tspan_p90={}\tspan_p99={}\tratio_p10={:.4}\tratio_p50={:.4}\tratio_p90={:.4}\tratio_p99={:.4}",
+        edit_spans.len(),
+        percentile_u64(&edit_spans, 0.10),
+        percentile_u64(&edit_spans, 0.50),
+        percentile_u64(&edit_spans, 0.90),
+        percentile_u64(&edit_spans, 0.99),
+        percentile(&edit_ratios, 0.10),
+        percentile(&edit_ratios, 0.50),
+        percentile(&edit_ratios, 0.90),
+        percentile(&edit_ratios, 0.99),
+    );
+    println!(
+        "CHAIN\tentities={}\tlen_p50={}\tlen_p90={}\tlen_max={}",
+        chain_lengths.len(),
+        percentile_u64(&chain_lengths, 0.50),
+        percentile_u64(&chain_lengths, 0.90),
+        chain_lengths.last().copied().unwrap_or_default(),
+    );
+
+    // A single shared dictionary trained on the corpus: the delta idea without
+    // per-payload bases, chains, or a base-liveness rule.
+    let samples = order
+        .iter()
+        .flat_map(|entity| by_entity[entity].iter())
+        .take(env_usize("LIX_EXPU_DICT_SAMPLES", 512))
+        .map(Vec::as_slice)
+        .collect::<Vec<_>>();
+    let dictionary_bytes = env_usize("LIX_EXPU_DICT_BYTES", 110 * 1024);
+    let dictionary = zstd::dict::from_samples(&samples, dictionary_bytes).ok();
+    let mut dictionary_total = 0_u64;
+    if let Some(dictionary) = dictionary.as_ref() {
+        let mut compressor = zstd::bulk::Compressor::with_dictionary(ZSTD_LEVEL, dictionary)
+            .expect("dictionary compressor");
+        for entity in &order {
+            for raw in &by_entity[entity] {
+                let frame = compressor.compress(raw).expect("dictionary compress");
+                dictionary_total += (STORED_JSON_HEADER_LEN + frame.len()) as u64;
+            }
+        }
+        dictionary_total += dictionary.len() as u64;
+    }
+
+    println!(
+        "BYTES\traw={raw_bytes}\ttoday={today_bytes}\tzstd_capture_pct={:.2}\tdelta_chain={delta_chain_bytes}\tdelta_chain_saving_pct={:.2}\tdelta_anchor={delta_anchor_bytes}\tdelta_anchor_saving_pct={:.2}\tshared_dictionary={dictionary_total}\tdictionary_saving_pct={:.2}",
+        percent(raw_bytes.saturating_sub(today_bytes), raw_bytes),
+        percent(today_bytes.saturating_sub(delta_chain_bytes), today_bytes),
+        percent(today_bytes.saturating_sub(delta_anchor_bytes), today_bytes),
+        percent(today_bytes.saturating_sub(dictionary_total), today_bytes),
+    );
+    // The cheap alternative: keep every payload independent and only raise the
+    // compression level. No base, no chain, no GC edge, no read amplification.
+    for (slot, level) in levels.iter().enumerate() {
+        println!(
+            "LEVEL\tzstd_level={level}\tbytes={}\tsaving_vs_today_pct={:.2}",
+            level_bytes[slot],
+            percent(today_bytes.saturating_sub(level_bytes[slot]), today_bytes),
+        );
+    }
+    for (slot, depth) in depths.iter().enumerate() {
+        let label = if *depth == usize::MAX {
+            "unbounded".to_owned()
+        } else {
+            depth.to_string()
+        };
+        println!(
+            "DEPTH\tsnapshot_every={label}\tbytes={}\tsaving_vs_today_pct={:.2}",
+            bounded_bytes[slot],
+            percent(
+                today_bytes.saturating_sub(bounded_bytes[slot]),
+                today_bytes
+            ),
+        );
+    }
+    println!(
+        "BYTES_SUCCESSORS\ttoday={successor_today_bytes}\tdelta_chain={successor_delta_bytes}\tdelta_anchor={successor_anchor_bytes}\tchain_saving_pct={:.2}\tanchor_saving_pct={:.2}",
+        percent(
+            successor_today_bytes.saturating_sub(successor_delta_bytes),
+            successor_today_bytes
+        ),
+        percent(
+            successor_today_bytes.saturating_sub(successor_anchor_bytes),
+            successor_today_bytes
+        ),
+    );
+
+    encode_cost(&order, &by_entity, &levels);
+    reconstruction_latency(&order, &by_entity);
+}
+
+/// Write-path CPU of each encoding arm, per payload.
+///
+/// A delta encoder must build a fresh zstd dictionary context per row (the
+/// base differs every time), which is where its write cost comes from; a
+/// higher level pays in the compressor's own search effort instead.
+fn encode_cost(order: &[String], by_entity: &HashMap<String, Vec<Vec<u8>>>, levels: &[i32]) {
+    let samples = order
+        .iter()
+        .flat_map(|entity| {
+            let versions = &by_entity[entity];
+            versions
+                .iter()
+                .enumerate()
+                .skip(1)
+                .map(move |(index, raw)| (raw, &versions[index - 1]))
+        })
+        .take(env_usize("LIX_EXPU_ENCODE_SAMPLES", 2_000))
+        .collect::<Vec<_>>();
+    if samples.is_empty() {
+        return;
+    }
+    // Interleave the arms across reps. Running each arm once back to back makes
+    // whichever went first pay every cold-cache and page-fault cost, which is
+    // how "level 3 is cheaper than level 1" appears out of nowhere.
+    let reps = env_usize("LIX_EXPU_ENCODE_REPS", 9);
+    let mut timings = vec![Vec::with_capacity(reps); levels.len() + 1];
+    let mut sinks = vec![0_usize; levels.len() + 1];
+    for _ in 0..reps {
+        for (slot, level) in levels.iter().enumerate() {
+            let start = std::time::Instant::now();
+            let mut sink = 0_usize;
+            for (raw, _) in &samples {
+                sink += zstd_compress(*level, raw).len();
+            }
+            timings[slot].push(start.elapsed().as_nanos() as f64 / samples.len() as f64);
+            sinks[slot] = sink;
+        }
+        let start = std::time::Instant::now();
+        let mut sink = 0_usize;
+        for (raw, base) in &samples {
+            let mut compressor = zstd::bulk::Compressor::with_dictionary(ZSTD_LEVEL, base)
+                .expect("dictionary compressor");
+            sink += compressor.compress(raw).expect("delta compress").len();
+        }
+        timings[levels.len()].push(start.elapsed().as_nanos() as f64 / samples.len() as f64);
+        sinks[levels.len()] = sink;
+    }
+    for (slot, timing) in timings.iter_mut().enumerate() {
+        timing.sort_by(|a, b| a.partial_cmp(b).expect("finite"));
+        let arm = if slot == levels.len() {
+            "delta_level1".to_owned()
+        } else {
+            format!("level{}", levels[slot])
+        };
+        println!(
+            "ENCODE\tarm={arm}\treps={reps}\tns_median={:.0}\tns_p95={:.0}\tframe_bytes={}\tframe_bytes_per_payload={}",
+            percentile(timing, 0.5),
+            percentile(timing, 0.95),
+            sinks[slot],
+            sinks[slot] / samples.len(),
+        );
+    }
+}
+
+/// Read cost of reconstructing one payload at chain depth `d`.
+///
+/// A delta row cannot be decoded without its base, so a depth-`d` payload
+/// costs `d` sequential point reads plus `d` zstd frames. Storage latency is
+/// not modelled here; this isolates the CPU term, which is the floor.
+fn reconstruction_latency(order: &[String], by_entity: &HashMap<String, Vec<Vec<u8>>>) {
+    let Some(entity) = order.iter().find(|entity| by_entity[*entity].len() >= 9) else {
+        println!("RECONSTRUCT\tskipped=no_chain_of_depth_9");
+        return;
+    };
+    let versions = &by_entity[entity];
+    let max_depth = versions.len().min(env_usize("LIX_EXPU_MAX_DEPTH", 16));
+
+    // Encode the chain the way a delta store would hold it.
+    let base_full = zstd_compress(ZSTD_LEVEL, &versions[0]);
+    let mut frames = Vec::new();
+    for index in 1..max_depth {
+        let mut compressor =
+            zstd::bulk::Compressor::with_dictionary(ZSTD_LEVEL, &versions[index - 1])
+                .expect("dictionary compressor");
+        frames.push(compressor.compress(&versions[index]).expect("delta compress"));
+    }
+
+    let iterations = env_usize("LIX_EXPU_RECONSTRUCT_ITERS", 2_000);
+    let mut rows = BTreeMap::new();
+    for depth in 0..max_depth {
+        let start = std::time::Instant::now();
+        let mut sink = 0_usize;
+        for _ in 0..iterations {
+            let mut current =
+                zstd::bulk::decompress(&base_full, versions[0].len()).expect("decompress base");
+            for frame in frames.iter().take(depth) {
+                let mut decompressor = zstd::bulk::Decompressor::with_dictionary(&current)
+                    .expect("dictionary decompressor");
+                current = decompressor
+                    .decompress(frame, versions[0].len() * 2)
+                    .expect("decompress delta");
+            }
+            sink += current.len();
+        }
+        let elapsed = start.elapsed().as_nanos() as f64 / iterations as f64;
+        rows.insert(depth, (elapsed, sink));
+    }
+    for (depth, (nanos, _)) in rows {
+        println!("RECONSTRUCT\tdepth={depth}\tns_per_payload={nanos:.0}");
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Settled-store report
+// ---------------------------------------------------------------------------
+
+async fn store_report(dir: &Path) {
+    let storage = StorageAdapter::new(SlateDB::open(dir).expect("open SlateDB for report"));
+    let read = storage
+        .begin_read(StorageReadOptions::default())
+        .await
+        .expect("open report snapshot");
+
+    let inventory = space_inventory(&read, "json_store.json").await;
+    let mut raw_bytes = 0_u64;
+    let mut stored_bytes = 0_u64;
+    let mut zstd_rows = 0_u64;
+    let mut raw_rows = 0_u64;
+    let mut raw_payloads = Vec::with_capacity(inventory.len());
+    for (_, value) in &inventory {
+        stored_bytes += value.len() as u64;
+        if value.len() > 11 && value[11] == 1 {
+            zstd_rows += 1;
+        } else {
+            raw_rows += 1;
+        }
+        let json = decode_stored_json(value);
+        raw_bytes += json.len() as u64;
+        raw_payloads.push(json);
+    }
+
+    println!(
+        "JSON_STORE\trows={}\tstored_bytes={stored_bytes}\traw_bytes={raw_bytes}\tzstd_rows={zstd_rows}\traw_rows={raw_rows}\tzstd_capture_pct={:.2}",
+        inventory.len(),
+        percent(raw_bytes.saturating_sub(stored_bytes), raw_bytes),
+    );
+
+    // The same near-duplicate probe the auditor runs, but on the *logical*
+    // JSON and with widths expressed as a fraction of payload length. A fixed
+    // 64-byte window against a 181-byte compressed row is a third of the row;
+    // against a 4.6 KiB document it is 1.4%. Only the second is a delta case.
+    for fraction in [0.01_f64, 0.05, 0.25] {
+        let mut prefix_buckets: HashMap<[u8; 32], HashSet<[u8; 32]>> = HashMap::new();
+        let mut suffix_buckets: HashMap<[u8; 32], HashSet<[u8; 32]>> = HashMap::new();
+        for json in &raw_payloads {
+            let width = ((json.len() as f64) * fraction) as usize;
+            if width == 0 || json.len() <= width {
+                continue;
+            }
+            let digest = *blake3::hash(json).as_bytes();
+            prefix_buckets
+                .entry(*blake3::hash(&json[width..]).as_bytes())
+                .or_default()
+                .insert(digest);
+            suffix_buckets
+                .entry(*blake3::hash(&json[..json.len() - width]).as_bytes())
+                .or_default()
+                .insert(digest);
+        }
+        let near = |buckets: &HashMap<[u8; 32], HashSet<[u8; 32]>>| -> u64 {
+            buckets
+                .values()
+                .map(|digests| digests.len().saturating_sub(1) as u64)
+                .sum()
+        };
+        println!(
+            "NEAR_RELATIVE\tfraction={fraction:.2}\tprefix={}\tsuffix={}\tdistinct={}",
+            near(&prefix_buckets),
+            near(&suffix_buckets),
+            raw_payloads.len(),
+        );
+    }
+
+    let total_dir = directory_bytes(dir);
+    println!("PHYSICAL\tdirectory_bytes={total_dir}");
+}
+
+/// What a delta chain costs the OLTP read path, measured on the real store.
+///
+/// A delta row cannot name its base until it has been read, so resolving a
+/// depth-`d` payload is a **pointer chase**: `d + 1` sequential batched point
+/// reads, each waiting on the previous. The alternative — storing the whole
+/// base list in every delta row — collapses it to one wider batched read. Both
+/// are measured; neither is free, and the JSON space is keyed by digest, so
+/// every base lands in a different block from its dependant.
+async fn read_cost(dir: &Path) {
+    let storage = StorageAdapter::new(SlateDB::open(dir).expect("open SlateDB for read cost"));
+    let read = storage
+        .begin_read(StorageReadOptions::default())
+        .await
+        .expect("open read-cost snapshot");
+    let space = storage_space_by_name("json_store.json");
+    let keys = space_inventory(&read, "json_store.json")
+        .await
+        .into_iter()
+        .map(|(key, _)| StorageKey(bytes::Bytes::from(key)))
+        .collect::<Vec<_>>();
+    assert!(!keys.is_empty(), "json_store.json is empty");
+
+    let batch = env_usize("LIX_EXPU_READ_BATCH", 1_000).min(keys.len());
+    let reps = env_usize("LIX_EXPU_READ_REPS", 9);
+    let max_depth = env_usize("LIX_EXPU_MAX_DEPTH", 8);
+    // Deterministic strided sampling: a digest-keyed space has no locality to
+    // preserve, so a stride simply avoids re-reading one hot block.
+    let pick = |round: usize, rep: usize| -> Vec<StorageKey> {
+        let stride = 7919;
+        (0..batch)
+            .map(|index| {
+                keys[(index * stride + round * 104_729 + rep * 15_485_863) % keys.len()].clone()
+            })
+            .collect()
+    };
+
+    // Warm the block cache over the whole key space first. Without it the arm
+    // that runs second inherits the other arm's cache and the comparison is an
+    // artefact of ordering rather than of chain depth.
+    for chunk in keys.chunks(4_096) {
+        PointReadPlan::new(space, chunk)
+            .materialize(&read, StorageGetOptions::default())
+            .await
+            .expect("warm point read");
+    }
+
+    for depth in 0..=max_depth {
+        let mut chased = Vec::with_capacity(reps);
+        let mut widened = Vec::with_capacity(reps);
+        for rep in 0..reps {
+            let rounds = (0..=depth).map(|round| pick(round, rep)).collect::<Vec<_>>();
+            let wide = rounds.concat();
+            // Alternate which arm goes first so neither one systematically
+            // warms the other.
+            if rep % 2 == 1 {
+                widened.push(time_wide_read(&read, space, &wide, batch).await);
+                chased.push(time_chased_read(&read, space, &rounds, batch).await);
+            } else {
+                chased.push(time_chased_read(&read, space, &rounds, batch).await);
+                widened.push(time_wide_read(&read, space, &wide, batch).await);
+            }
+        }
+        chased.sort_by(|a, b| a.partial_cmp(b).expect("finite"));
+        widened.sort_by(|a, b| a.partial_cmp(b).expect("finite"));
+        println!(
+            "READCOST\tdepth={depth}\treps={reps}\tbatch={batch}\tchased_ns_median={:.0}\tchased_ns_p95={:.0}\twide_ns_median={:.0}\twide_ns_p95={:.0}",
+            percentile(&chased, 0.5),
+            percentile(&chased, 0.95),
+            percentile(&widened, 0.5),
+            percentile(&widened, 0.95),
+        );
+    }
+}
+
+/// `d + 1` dependent batched point reads: the pointer chase a delta row forces
+/// because it cannot name its base before it has itself been read.
+async fn time_chased_read<R>(
+    read: &R,
+    space: lix::storage_adapter::StorageSpace,
+    rounds: &[Vec<StorageKey>],
+    batch: usize,
+) -> f64
+where
+    R: lix::storage_adapter::StorageAdapterRead,
+{
+    let start = std::time::Instant::now();
+    let mut found = 0_usize;
+    for round in rounds {
+        let result = PointReadPlan::new(space, round)
+            .materialize(read, StorageGetOptions::default())
+            .await
+            .expect("point read");
+        found += result.value.iter().filter(|value| value.is_some()).count();
+    }
+    let elapsed = start.elapsed().as_nanos() as f64 / batch as f64;
+    assert!(found >= batch, "point reads should hit");
+    elapsed
+}
+
+/// One batched read of every base at once: the best case, available only if a
+/// delta row carries its whole base list instead of a single parent link.
+async fn time_wide_read<R>(
+    read: &R,
+    space: lix::storage_adapter::StorageSpace,
+    wide: &[StorageKey],
+    batch: usize,
+) -> f64
+where
+    R: lix::storage_adapter::StorageAdapterRead,
+{
+    let start = std::time::Instant::now();
+    let result = PointReadPlan::new(space, wide)
+        .materialize(read, StorageGetOptions::default())
+        .await
+        .expect("wide point read");
+    let elapsed = start.elapsed().as_nanos() as f64 / batch as f64;
+    assert!(!result.value.is_empty());
+    elapsed
+}
+
+fn directory_bytes(path: &Path) -> u64 {
+    std::fs::read_dir(path).map_or(0, |entries| {
+        entries
+            .flatten()
+            .map(|entry| {
+                let path = entry.path();
+                entry.metadata().map_or(0, |metadata| {
+                    if metadata.is_dir() {
+                        directory_bytes(&path)
+                    } else {
+                        metadata.len()
+                    }
+                })
+            })
+            .sum()
+    })
+}

--- a/packages/engine-benchmarks/examples/expv_blind_space_growth.rs
+++ b/packages/engine-benchmarks/examples/expv_blind_space_growth.rs
@@ -400,7 +400,10 @@ async fn idempotency_payload_scenario(samples: &[usize], blob_bytes: usize, retu
                 format!("expv-key-{issued:012}"),
                 fingerprint,
             );
-            let content = vec![b'a' + (issued % 26) as u8; blob_bytes];
+            // Incompressible, per-request distinct content. A repeated byte
+            // would let the backend compress both the file and its receipt to
+            // almost nothing and would make the physical arm meaningless.
+            let content = pseudo_random_bytes(issued as u64, blob_bytes);
             Arc::clone(&fixture.session)
                 .execute_with_idempotency_and_options_and_metadata(
                     sql.to_owned(),
@@ -518,6 +521,23 @@ impl Fixture {
     fn flush(&self) {
         self.storage.flush().expect("flush RocksDB");
     }
+}
+
+/// splitmix64 fill. Deterministic per seed, and statistically incompressible,
+/// which is what a physical byte measurement of a payload plane requires.
+fn pseudo_random_bytes(seed: u64, len: usize) -> Vec<u8> {
+    let mut state = seed.wrapping_mul(0x9e37_79b9_7f4a_7c15).wrapping_add(1);
+    let mut out = Vec::with_capacity(len);
+    while out.len() < len {
+        state = state.wrapping_add(0x9e37_79b9_7f4a_7c15);
+        let mut z = state;
+        z = (z ^ (z >> 30)).wrapping_mul(0xbf58_476d_1ce4_e5b9);
+        z = (z ^ (z >> 27)).wrapping_mul(0x94d0_49bb_1331_11eb);
+        z ^= z >> 31;
+        let take = (len - out.len()).min(8);
+        out.extend_from_slice(&z.to_le_bytes()[..take]);
+    }
+    out
 }
 
 fn report(scenario: &str, phase: &str, axis: u64, usage: &Usage) {

--- a/packages/engine-benchmarks/examples/expv_blind_space_growth.rs
+++ b/packages/engine-benchmarks/examples/expv_blind_space_growth.rs
@@ -93,6 +93,12 @@ async fn main() {
             let samples = parse_samples(arguments.get(1));
             idempotency_scenario(&samples).await;
         }
+        "idempotency_payload" => {
+            let samples = parse_samples(arguments.get(1));
+            let bytes = parse_usize(arguments.get(2), 65536);
+            let returning = arguments.get(3).map(String::as_str) != Some("plain");
+            idempotency_payload_scenario(&samples, bytes, returning).await;
+        }
         "uploads" => {
             let samples = parse_samples(arguments.get(1));
             let bytes = parse_usize(arguments.get(2), 4096);
@@ -367,6 +373,60 @@ async fn idempotency_scenario(samples: &[usize]) {
         1,
         &usage(&fixture.storage).await,
     );
+}
+
+/// The same replay ledger, measured for the request shape its 8 MiB cap exists
+/// for: a mutation whose `RETURNING` clause projects blob content.
+///
+/// A receipt stores the complete `ExecuteResult` — columns, every returned row
+/// value, `rows_affected` and notices — as `serde_json`. `plain` runs the same
+/// file write without `RETURNING`, so the difference between the two arms is
+/// exactly the cost of retaining a second copy of the response payload.
+async fn idempotency_payload_scenario(samples: &[usize], blob_bytes: usize, returning: bool) {
+    let fixture = Fixture::open().await;
+    let sql = if returning {
+        "INSERT INTO lix_file (path, content) VALUES ($1, $2) RETURNING id, path, content"
+    } else {
+        "INSERT INTO lix_file (path, content) VALUES ($1, $2)"
+    };
+    let mut issued = 0usize;
+    for &target in samples {
+        while issued < target {
+            let mut fingerprint = [0u8; 32];
+            fingerprint[..8].copy_from_slice(&(issued as u64).to_be_bytes());
+            fingerprint[8] = u8::from(returning);
+            let identity = ExecuteIdempotency::new(
+                Some("expv-principal".to_owned()),
+                format!("expv-key-{issued:012}"),
+                fingerprint,
+            );
+            let content = vec![b'a' + (issued % 26) as u8; blob_bytes];
+            Arc::clone(&fixture.session)
+                .execute_with_idempotency_and_options_and_metadata(
+                    sql.to_owned(),
+                    vec![
+                        Value::Text(format!("/expv/payload-{issued:012}.bin")),
+                        Value::Blob(Blob::from(content)),
+                    ],
+                    ExecuteOptions::default(),
+                    ExecuteStatementMetadata::default(),
+                    Some(identity),
+                )
+                .await
+                .expect("idempotent execute");
+            issued += 1;
+        }
+        report(
+            if returning {
+                "idempotency_payload_returning"
+            } else {
+                "idempotency_payload_plain"
+            },
+            "live",
+            target as u64,
+            &usage(&fixture.storage).await,
+        );
+    }
 }
 
 /// Resumable-upload receipts. `keep` leaves every uploaded file live; `delete`

--- a/packages/engine-benchmarks/examples/expv_blind_space_growth.rs
+++ b/packages/engine-benchmarks/examples/expv_blind_space_growth.rs
@@ -427,6 +427,7 @@ async fn idempotency_payload_scenario(samples: &[usize], blob_bytes: usize, retu
             &usage(&fixture.storage).await,
         );
     }
+    fixture.flush();
 }
 
 /// Resumable-upload receipts. `keep` leaves every uploaded file live; `delete`
@@ -481,13 +482,24 @@ async fn uploads_scenario(samples: &[usize], bytes_per_upload: usize, delete: bo
 struct Fixture {
     storage: RocksDB,
     session: Arc<SessionContext<RocksDB>>,
-    _directory: tempfile::TempDir,
+    _directory: Option<tempfile::TempDir>,
 }
 
 impl Fixture {
+    /// Logical accounting is the default answer, so the fixture normally lives
+    /// in a temporary directory. Setting `LIX_EXPV_DIR` keeps the backend files
+    /// at a fixed path instead, which is what turns a logical byte curve into a
+    /// physical one (`flush`, then measure the directory).
     async fn open() -> Self {
-        let directory = tempfile::tempdir().expect("create RocksDB directory");
-        let storage = RocksDB::open(directory.path()).expect("open RocksDB");
+        let (directory, path) = match std::env::var_os("LIX_EXPV_DIR") {
+            Some(path) => (None, std::path::PathBuf::from(path)),
+            None => {
+                let directory = tempfile::tempdir().expect("create RocksDB directory");
+                let path = directory.path().to_path_buf();
+                (Some(directory), path)
+            }
+        };
+        let storage = RocksDB::open(&path).expect("open RocksDB");
         Engine::initialize(storage.clone())
             .await
             .expect("initialize repository");
@@ -501,6 +513,10 @@ impl Fixture {
             session: Arc::new(session),
             _directory: directory,
         }
+    }
+
+    fn flush(&self) {
+        self.storage.flush().expect("flush RocksDB");
     }
 }
 

--- a/packages/engine-benchmarks/examples/expv_blind_space_growth.rs
+++ b/packages/engine-benchmarks/examples/expv_blind_space_growth.rs
@@ -78,6 +78,11 @@ async fn main() {
             let rows = parse_usize(arguments.get(2), 10);
             checkpoints_scenario(&samples, rows).await;
         }
+        "entity_commits" => {
+            let samples = parse_samples(arguments.get(1));
+            let rows = parse_usize(arguments.get(2), 10);
+            entity_commits_scenario(&samples, rows).await;
+        }
         "checkpoint_then_gc" => {
             let commits = parse_usize(arguments.get(1), 200);
             let rows = parse_usize(arguments.get(2), 10);
@@ -197,6 +202,66 @@ async fn checkpoints_scenario(samples: &[usize], rows_per_commit: usize) {
         }
         report(
             "checkpoints",
+            "live",
+            target as u64,
+            &usage(&fixture.storage).await,
+        );
+    }
+}
+
+/// A strictly typed flat entity surface, which is what
+/// `encode_registered_entity_row_groups` needs before it publishes anything
+/// into the two `entity.columnar_row_group_*` spaces. The JSON-valued schema
+/// the other scenarios use never reaches that encoder, so those two spaces stay
+/// empty there and would be misread as "bounded" without this workload.
+async fn entity_commits_scenario(samples: &[usize], rows_per_commit: usize) {
+    let fixture = Fixture::open().await;
+    let schema = serde_json::json!({
+        "x-lix-key": "expv_entity",
+        "x-lix-primary-key": ["/id"],
+        "type": "object",
+        "required": ["id", "name", "amount"],
+        "properties": {
+            "id": { "type": "string" },
+            "name": { "type": "string" },
+            "amount": { "type": "integer" }
+        },
+        "additionalProperties": false
+    });
+    fixture
+        .session
+        .execute(
+            "INSERT INTO lix_registered_schema (value, lixcol_global, lixcol_untracked) VALUES (lix_json($1), false, false)",
+            &[Value::Text(schema.to_string())],
+        )
+        .await
+        .expect("register entity schema");
+    let mut committed = 0usize;
+    for &target in samples {
+        while committed < target {
+            let mut transaction = fixture
+                .session
+                .begin_transaction()
+                .await
+                .expect("begin commit");
+            for index in 0..rows_per_commit {
+                transaction
+                    .execute(
+                        "INSERT INTO expv_entity (id, name, amount) VALUES ($1, $2, $3)",
+                        &[
+                            Value::Text(format!("{committed:08}-{index:08}")),
+                            Value::Text(format!("name-{committed}-{index}")),
+                            Value::Integer((committed * 1000 + index) as i64),
+                        ],
+                    )
+                    .await
+                    .expect("insert entity row");
+            }
+            transaction.commit().await.expect("commit entity batch");
+            committed += 1;
+        }
+        report(
+            "entity_commits",
             "live",
             target as u64,
             &usage(&fixture.storage).await,

--- a/packages/engine-benchmarks/examples/expv_blind_space_growth.rs
+++ b/packages/engine-benchmarks/examples/expv_blind_space_growth.rs
@@ -1,0 +1,431 @@
+//! Growth curves for the storage spaces layout accounting could not see.
+//!
+//! Before PR #1308 `native_storage_spaces()` enumerated 32 of 46 physical
+//! spaces, so `layout_accounting`, `layout_space_catalog` and every report
+//! built on them (`storage_layout`, `space_growth`, the `tracked_state_crud`
+//! layout table) were blind to 14 real planes. Every per-space byte number this
+//! optimization program published before that fix is therefore a lower bound.
+//!
+//! `space_growth` answers "which spaces grow per commit" for one axis only.
+//! This example sweeps the axes that can distinguish the three classifications
+//! that matter:
+//!
+//! * **bounded** — flat, or converging to a constant, in every axis.
+//! * **proportional** — grows with *live* state (rows, branches, files). Paying
+//!   bytes for data that is still reachable is what a store is for.
+//! * **unbounded** — grows with *history* and is never reclaimed. That is a
+//!   leak, and no amount of GC brings it back.
+//!
+//! Scenarios (each prints one `expv,` line per space per sample):
+//!
+//! ```text
+//! commits     <samples-csv> <rows_per_commit> [gc_rounds]
+//! rows        <commits> <rows-csv>
+//! branches    <samples-csv> <rows_per_commit>
+//! checkpoints <samples-csv> <rows_per_commit>
+//! idempotency <samples-csv>
+//! uploads     <samples-csv> <bytes_per_upload> <keep|delete>
+//! ```
+//!
+//! `samples-csv` is an ascending list of axis values; the axis is driven
+//! forward incrementally and layout accounting is sampled at each value, so one
+//! process produces a whole curve without rebuilding the fixture.
+
+use std::collections::BTreeMap;
+use std::sync::Arc;
+
+use lix::integration::{Engine, SessionContext};
+use lix::storage::Storage;
+use lix::storage_adapter::{StorageAdapter, StorageReadOptions};
+use lix::storage_bench::{collect_repository_gc_for_bench, layout_accounting};
+use lix::{
+    Blob, CreateBranchOptions, ExecuteIdempotency, ExecuteOptions, ExecuteStatementMetadata, Value,
+};
+use lix_storage_rocksdb::RocksDB;
+
+#[derive(Clone, Copy, Default)]
+struct SpaceUsage {
+    rows: u64,
+    key_bytes: u64,
+    value_bytes: u64,
+}
+
+type Usage = BTreeMap<(u32, &'static str), SpaceUsage>;
+
+#[tokio::main]
+async fn main() {
+    let arguments = std::env::args().skip(1).collect::<Vec<_>>();
+    let scenario = arguments.first().map(String::as_str).unwrap_or("commits");
+    match scenario {
+        "commits" => {
+            let samples = parse_samples(arguments.get(1));
+            let rows = parse_usize(arguments.get(2), 10);
+            let gc_rounds = parse_usize(arguments.get(3), 0);
+            commits_scenario(&samples, rows, gc_rounds).await;
+        }
+        "rows" => {
+            let commits = parse_usize(arguments.get(1), 20);
+            let samples = parse_samples(arguments.get(2));
+            rows_scenario(commits, &samples).await;
+        }
+        "branches" => {
+            let samples = parse_samples(arguments.get(1));
+            let rows = parse_usize(arguments.get(2), 10);
+            branches_scenario(&samples, rows).await;
+        }
+        "checkpoints" => {
+            let samples = parse_samples(arguments.get(1));
+            let rows = parse_usize(arguments.get(2), 10);
+            checkpoints_scenario(&samples, rows).await;
+        }
+        "idempotency" => {
+            let samples = parse_samples(arguments.get(1));
+            idempotency_scenario(&samples).await;
+        }
+        "uploads" => {
+            let samples = parse_samples(arguments.get(1));
+            let bytes = parse_usize(arguments.get(2), 4096);
+            let delete = arguments.get(3).map(String::as_str) == Some("delete");
+            uploads_scenario(&samples, bytes, delete).await;
+        }
+        other => panic!("unknown scenario '{other}'"),
+    }
+}
+
+// ---------------------------------------------------------------- scenarios
+
+/// Commit count is the axis that separates "proportional" from "unbounded":
+/// row count, branch count and file count are all held fixed, so any plane that
+/// keeps growing is growing with history alone.
+async fn commits_scenario(samples: &[usize], rows_per_commit: usize, gc_rounds: usize) {
+    let fixture = Fixture::open().await;
+    register_schema(&fixture.session).await;
+    let mut committed = 0usize;
+    for &target in samples {
+        while committed < target {
+            commit_batch(&fixture.session, committed, rows_per_commit).await;
+            committed += 1;
+        }
+        report(
+            "commits",
+            "live",
+            target as u64,
+            &usage(&fixture.storage).await,
+        );
+    }
+    for round in 1..=gc_rounds {
+        let result = collect_repository_gc_for_bench(&StorageAdapter::new(fixture.storage.clone()))
+            .await
+            .expect("commit repository GC");
+        println!(
+            "expv_gc,scenario=commits,round={round},commits={committed},staged_deletes={},swept_commits={}",
+            result.staged_deletes, result.swept_commits
+        );
+        report(
+            "commits",
+            "gc",
+            round as u64,
+            &usage(&fixture.storage).await,
+        );
+    }
+}
+
+/// Live-row count at a fixed commit count. A plane that moves here and not on
+/// the commit axis is proportional to live state, which is expected.
+async fn rows_scenario(commits: usize, samples: &[usize]) {
+    for &rows in samples {
+        let fixture = Fixture::open().await;
+        register_schema(&fixture.session).await;
+        for index in 0..commits {
+            commit_batch(&fixture.session, index, rows).await;
+        }
+        report(
+            "rows",
+            "live",
+            (rows * commits) as u64,
+            &usage(&fixture.storage).await,
+        );
+    }
+}
+
+async fn branches_scenario(samples: &[usize], rows_per_commit: usize) {
+    let fixture = Fixture::open().await;
+    register_schema(&fixture.session).await;
+    commit_batch(&fixture.session, 0, rows_per_commit).await;
+    let mut created = 0usize;
+    for &target in samples {
+        while created < target {
+            fixture
+                .session
+                .create_branch(CreateBranchOptions {
+                    id: None,
+                    name: format!("expv-branch-{created}"),
+                    from_commit_id: None,
+                })
+                .await
+                .expect("create branch");
+            created += 1;
+        }
+        report(
+            "branches",
+            "live",
+            target as u64,
+            &usage(&fixture.storage).await,
+        );
+    }
+}
+
+async fn checkpoints_scenario(samples: &[usize], rows_per_commit: usize) {
+    let fixture = Fixture::open().await;
+    register_schema(&fixture.session).await;
+    let mut created = 0usize;
+    for &target in samples {
+        while created < target {
+            commit_batch(&fixture.session, created, rows_per_commit).await;
+            fixture
+                .session
+                .create_checkpoint()
+                .await
+                .expect("create checkpoint");
+            created += 1;
+        }
+        report(
+            "checkpoints",
+            "live",
+            target as u64,
+            &usage(&fixture.storage).await,
+        );
+    }
+}
+
+/// Server `/execute` replay receipts. The write site is
+/// `transaction/context.rs:1879`; this scenario exists to find out what removes
+/// them again.
+async fn idempotency_scenario(samples: &[usize]) {
+    let fixture = Fixture::open().await;
+    register_schema(&fixture.session).await;
+    let mut issued = 0usize;
+    for &target in samples {
+        while issued < target {
+            let mut fingerprint = [0u8; 32];
+            fingerprint[..8].copy_from_slice(&(issued as u64).to_be_bytes());
+            let identity = ExecuteIdempotency::new(
+                Some("expv-principal".to_owned()),
+                format!("expv-key-{issued:012}"),
+                fingerprint,
+            );
+            Arc::clone(&fixture.session)
+                .execute_with_idempotency_and_options_and_metadata(
+                    "INSERT INTO space_growth (path, value) VALUES ($1, lix_json($2))".to_owned(),
+                    vec![
+                        Value::Text(format!("/idem/{issued:012}")),
+                        Value::Text(format!(r#"{{"n":{issued}}}"#)),
+                    ],
+                    ExecuteOptions::default(),
+                    ExecuteStatementMetadata::default(),
+                    Some(identity),
+                )
+                .await
+                .expect("idempotent execute");
+            issued += 1;
+        }
+        report(
+            "idempotency",
+            "live",
+            target as u64,
+            &usage(&fixture.storage).await,
+        );
+    }
+    let result = collect_repository_gc_for_bench(&StorageAdapter::new(fixture.storage.clone()))
+        .await
+        .expect("commit repository GC");
+    println!(
+        "expv_gc,scenario=idempotency,round=1,requests={issued},staged_deletes={},swept_commits={}",
+        result.staged_deletes, result.swept_commits
+    );
+    report(
+        "idempotency",
+        "gc",
+        1,
+        &usage(&fixture.storage).await,
+    );
+}
+
+/// Resumable-upload receipts. `keep` leaves every uploaded file live; `delete`
+/// removes each file again, which is the shape that tells retained-receipt
+/// bytes apart from live-file bytes.
+async fn uploads_scenario(samples: &[usize], bytes_per_upload: usize, delete: bool) {
+    let fixture = Fixture::open().await;
+    let mut uploaded = 0usize;
+    for &target in samples {
+        while uploaded < target {
+            let path = format!("/expv/upload-{uploaded:08}.bin");
+            let payload = vec![(uploaded % 251) as u8; bytes_per_upload];
+            fixture
+                .session
+                .upsert_file_content_part(
+                    format!("expv-upload-{uploaded:08}"),
+                    path.clone(),
+                    0,
+                    bytes_per_upload as u64,
+                    Blob::from(payload),
+                )
+                .await
+                .expect("upload part");
+            if delete {
+                fixture
+                    .session
+                    .execute("DELETE FROM lix_file WHERE path = $1", &[Value::Text(path)])
+                    .await
+                    .expect("delete uploaded file");
+            }
+            uploaded += 1;
+        }
+        report(
+            "uploads",
+            if delete { "live_deleted" } else { "live_kept" },
+            target as u64,
+            &usage(&fixture.storage).await,
+        );
+    }
+    let result = collect_repository_gc_for_bench(&StorageAdapter::new(fixture.storage.clone()))
+        .await
+        .expect("commit repository GC");
+    println!(
+        "expv_gc,scenario=uploads,round=1,uploads={uploaded},staged_deletes={},swept_commits={}",
+        result.staged_deletes, result.swept_commits
+    );
+    report("uploads", "gc", 1, &usage(&fixture.storage).await);
+}
+
+// ------------------------------------------------------------------ harness
+
+struct Fixture {
+    storage: RocksDB,
+    session: Arc<SessionContext<RocksDB>>,
+    _directory: tempfile::TempDir,
+}
+
+impl Fixture {
+    async fn open() -> Self {
+        let directory = tempfile::tempdir().expect("create RocksDB directory");
+        let storage = RocksDB::open(directory.path()).expect("open RocksDB");
+        Engine::initialize(storage.clone())
+            .await
+            .expect("initialize repository");
+        let engine = Engine::new(storage.clone()).await.expect("open engine");
+        let session = engine
+            .open_workspace_session()
+            .await
+            .expect("open workspace");
+        Self {
+            storage,
+            session: Arc::new(session),
+            _directory: directory,
+        }
+    }
+}
+
+fn report(scenario: &str, phase: &str, axis: u64, usage: &Usage) {
+    for ((id, name), value) in usage {
+        println!(
+            "expv,scenario={scenario},phase={phase},axis={axis},space_id=0x{id:08x},space={name},rows={},key_bytes={},value_bytes={}",
+            value.rows, value.key_bytes, value.value_bytes
+        );
+    }
+}
+
+async fn usage<S>(storage: &S) -> Usage
+where
+    S: Storage + Clone + Send + Sync + 'static,
+{
+    let adapter = StorageAdapter::new(storage.clone());
+    let read = adapter
+        .begin_read(StorageReadOptions::default())
+        .await
+        .expect("open storage snapshot");
+    let accounting = layout_accounting(&read)
+        .await
+        .into_iter()
+        .map(|entry| {
+            (
+                (entry.space_id, entry.space),
+                SpaceUsage {
+                    rows: entry.rows,
+                    key_bytes: entry.key_bytes,
+                    value_bytes: entry.value_bytes,
+                },
+            )
+        })
+        .collect();
+    drop(read);
+    accounting
+}
+
+async fn commit_batch<S>(session: &SessionContext<S>, batch: usize, rows: usize)
+where
+    S: Storage + Clone + Send + Sync + 'static,
+{
+    let mut transaction = session.begin_transaction().await.expect("begin commit");
+    for index in 0..rows {
+        transaction
+            .execute(
+                "INSERT INTO space_growth (path, value) VALUES ($1, lix_json($2))",
+                &[
+                    Value::Text(format!("/row/{batch:08}/{index:08}")),
+                    Value::Text(format!(r#"{{"batch":{batch},"index":{index}}}"#)),
+                ],
+            )
+            .await
+            .expect("insert row");
+    }
+    transaction.commit().await.expect("commit batch");
+}
+
+async fn register_schema<S>(session: &SessionContext<S>)
+where
+    S: Storage + Clone + Send + Sync + 'static,
+{
+    let schema = serde_json::json!({
+        "x-lix-key": "space_growth",
+        "x-lix-primary-key": ["/path"],
+        "type": "object",
+        "required": ["path", "value"],
+        "properties": {
+            "path": { "type": "string" },
+            "value": {
+                "type": ["object", "array", "string", "number", "integer", "boolean", "null"]
+            }
+        },
+        "additionalProperties": false
+    });
+    session
+        .execute(
+            "INSERT INTO lix_registered_schema (value, lixcol_global, lixcol_untracked) VALUES (lix_json($1), false, false)",
+            &[Value::Text(schema.to_string())],
+        )
+        .await
+        .expect("register schema");
+}
+
+fn parse_samples(argument: Option<&String>) -> Vec<usize> {
+    let samples = argument
+        .map(|value| {
+            value
+                .split(',')
+                .map(|entry| entry.trim().parse::<usize>().expect("sample must be usize"))
+                .collect::<Vec<_>>()
+        })
+        .unwrap_or_else(|| vec![1, 10, 100, 1000]);
+    assert!(!samples.is_empty(), "need at least one sample point");
+    for pair in samples.windows(2) {
+        assert!(pair[0] < pair[1], "sample points must ascend");
+    }
+    samples
+}
+
+fn parse_usize(argument: Option<&String>, fallback: usize) -> usize {
+    argument
+        .and_then(|value| value.parse::<usize>().ok())
+        .unwrap_or(fallback)
+}

--- a/packages/engine-benchmarks/examples/expv_blind_space_growth.rs
+++ b/packages/engine-benchmarks/examples/expv_blind_space_growth.rs
@@ -78,6 +78,12 @@ async fn main() {
             let rows = parse_usize(arguments.get(2), 10);
             checkpoints_scenario(&samples, rows).await;
         }
+        "checkpoint_then_gc" => {
+            let commits = parse_usize(arguments.get(1), 200);
+            let rows = parse_usize(arguments.get(2), 10);
+            let gc_rounds = parse_usize(arguments.get(3), 12);
+            checkpoint_then_gc_scenario(commits, rows, gc_rounds).await;
+        }
         "idempotency" => {
             let samples = parse_samples(arguments.get(1));
             idempotency_scenario(&samples).await;
@@ -193,6 +199,53 @@ async fn checkpoints_scenario(samples: &[usize], rows_per_commit: usize) {
             "checkpoints",
             "live",
             target as u64,
+            &usage(&fixture.storage).await,
+        );
+    }
+}
+
+/// Isolates the drain rate of the authenticated reachability queue.
+///
+/// Without a checkpoint the whole commit chain is the retained undo interval
+/// (`gc.rs:118-159` walks head → `serving_checkpoint_commit_id`), so no old
+/// root is retirable and no queue row is consumable. One checkpoint lowers that
+/// floor; the explicit GC rounds afterwards then measure how many queue rows
+/// one sweep actually consumes.
+async fn checkpoint_then_gc_scenario(commits: usize, rows_per_commit: usize, gc_rounds: usize) {
+    let fixture = Fixture::open().await;
+    register_schema(&fixture.session).await;
+    for index in 0..commits {
+        commit_batch(&fixture.session, index, rows_per_commit).await;
+    }
+    report(
+        "checkpoint_then_gc",
+        "before_checkpoint",
+        commits as u64,
+        &usage(&fixture.storage).await,
+    );
+    fixture
+        .session
+        .create_checkpoint()
+        .await
+        .expect("create checkpoint");
+    report(
+        "checkpoint_then_gc",
+        "after_checkpoint",
+        0,
+        &usage(&fixture.storage).await,
+    );
+    for round in 1..=gc_rounds {
+        let result = collect_repository_gc_for_bench(&StorageAdapter::new(fixture.storage.clone()))
+            .await
+            .expect("commit repository GC");
+        println!(
+            "expv_gc,scenario=checkpoint_then_gc,round={round},commits={commits},staged_deletes={},swept_commits={}",
+            result.staged_deletes, result.swept_commits
+        );
+        report(
+            "checkpoint_then_gc",
+            "gc",
+            round as u64,
             &usage(&fixture.storage).await,
         );
     }

--- a/packages/engine-benchmarks/examples/storage_layout.rs
+++ b/packages/engine-benchmarks/examples/storage_layout.rs
@@ -11,7 +11,20 @@ use lix_storage_slatedb::SlateDB;
 use object_store::local::LocalFileSystem;
 use slatedb::{SstReader, ValueDeletable};
 
-const HOT_SPACE: &str = "live_state.hot_row.v20";
+/// The hot-row space is versioned in its name, so a hard-coded literal goes
+/// stale the moment the plane is revised — and `space_inventory` panics on a
+/// name the registry does not know, which took the whole non-`--physical-only`
+/// mode down when `hot_row.v20` became `v21`. Resolve it from the registry by
+/// prefix instead so the tool tracks the rename.
+const HOT_SPACE_PREFIX: &str = "live_state.hot_row.";
+
+fn hot_space_name() -> &'static str {
+    layout_space_catalog()
+        .into_iter()
+        .map(|(_, name)| name)
+        .find(|name| name.starts_with(HOT_SPACE_PREFIX))
+        .expect("registry has exactly one hot-row space")
+}
 const IMMUTABLE_BINARY_CAS_CHUNK_DIR: &str = "db/lix-immutable-binary-cas-segment-v4";
 
 #[derive(Default)]
@@ -95,7 +108,7 @@ async fn main() {
     print_binary_cas_owners(&read).await;
     print_plugin_checkpoint_layout(&read).await;
 
-    let inventory = space_inventory(&read, HOT_SPACE).await;
+    let inventory = space_inventory(&read, hot_space_name()).await;
     let mut groups = BTreeMap::<Vec<u8>, HotGroup>::new();
     for (key, value) in inventory {
         let decoded = decode_hot_group(&key).expect("valid HOT V19 key");

--- a/packages/engine-benchmarks/tests/movie_workspace_qualification.rs
+++ b/packages/engine-benchmarks/tests/movie_workspace_qualification.rs
@@ -62,22 +62,59 @@ async fn slatedb_resumes_media_upload_after_engine_restart() {
     finish_restart_upload(storage).await;
 }
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
-#[ignore = "release qualification benchmark"]
-async fn rocksdb_movie_workspace_interference() {
-    let _qualification_guard = QUALIFICATION_LOCK.lock().await;
-    let temp = tempfile::tempdir().expect("create RocksDB movie fixture");
-    let storage = RocksDB::open(temp.path().join("database")).expect("open RocksDB fixture");
-    qualify("rocksdb", storage).await;
+/// The qualification models a desktop editor: a small fixed worker pool that
+/// media ingest, project saves and playback all share. `LIX_MOVIE_WORKER_THREADS`
+/// exists only so an investigation can separate executor starvation from engine
+/// latency; the qualification itself always runs the four-thread profile.
+fn qualification_runtime() -> tokio::runtime::Runtime {
+    let worker_threads = std::env::var("LIX_MOVIE_WORKER_THREADS")
+        .ok()
+        .and_then(|value| value.parse::<usize>().ok())
+        .filter(|value| *value > 0)
+        .unwrap_or(4);
+    tokio::runtime::Builder::new_multi_thread()
+        .worker_threads(worker_threads)
+        .enable_all()
+        .build()
+        .expect("build movie qualification runtime")
 }
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+#[test]
 #[ignore = "release qualification benchmark"]
-async fn slatedb_movie_workspace_interference() {
-    let _qualification_guard = QUALIFICATION_LOCK.lock().await;
-    let temp = tempfile::tempdir().expect("create SlateDB movie fixture");
-    let storage = SlateDB::open(temp.path().join("database")).expect("open SlateDB fixture");
-    qualify("slatedb", storage).await;
+fn rocksdb_movie_workspace_interference() {
+    qualification_runtime().block_on(async {
+        let _qualification_guard = QUALIFICATION_LOCK.lock().await;
+        let temp = tempfile::tempdir().expect("create RocksDB movie fixture");
+        let storage = RocksDB::open(temp.path().join("database")).expect("open RocksDB fixture");
+        qualify("rocksdb", storage).await;
+    });
+}
+
+#[test]
+#[ignore = "release qualification benchmark"]
+fn slatedb_movie_workspace_interference() {
+    qualification_runtime().block_on(async {
+        let _qualification_guard = QUALIFICATION_LOCK.lock().await;
+        let temp = tempfile::tempdir().expect("create SlateDB movie fixture");
+        let storage = SlateDB::open(temp.path().join("database")).expect("open SlateDB fixture");
+        qualify("slatedb", storage).await;
+    });
+}
+
+/// Null control for the playback assertions: identical schedule, sessions and
+/// fixture, with the concurrent 512 MiB ingest removed. Whatever scheduling
+/// jitter this run shows is the floor below which a playback deadline cannot
+/// be attributed to ingest interference.
+#[test]
+#[ignore = "playback null control"]
+fn slatedb_movie_workspace_playback_control() {
+    qualification_runtime().block_on(async {
+        let _qualification_guard = QUALIFICATION_LOCK.lock().await;
+        let temp = tempfile::tempdir().expect("create SlateDB control fixture");
+        let storage = SlateDB::open(temp.path().join("database")).expect("open SlateDB fixture");
+        let part_concurrency = upload_concurrency();
+        qualify_case("slatedb-control", storage, part_concurrency, None, None, false).await;
+    });
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
@@ -187,20 +224,24 @@ async fn qualify_delayed_slatedb(latency_ms: u64, upload_concurrency: usize) -> 
         upload_concurrency,
         Some((delayed, Duration::from_millis(latency_ms))),
         Some(counters),
+        true,
     )
     .await
+}
+
+fn upload_concurrency() -> usize {
+    std::env::var("LIX_MOVIE_UPLOAD_CONCURRENCY")
+        .ok()
+        .and_then(|value| value.parse::<usize>().ok())
+        .filter(|value| (1..=4).contains(value))
+        .unwrap_or(4)
 }
 
 async fn qualify<S>(backend: &str, storage: S)
 where
     S: Storage + Clone + Send + Sync + 'static,
 {
-    let part_concurrency = std::env::var("LIX_MOVIE_UPLOAD_CONCURRENCY")
-        .ok()
-        .and_then(|value| value.parse::<usize>().ok())
-        .filter(|value| (1..=4).contains(value))
-        .unwrap_or(4);
-    qualify_case(backend, storage, part_concurrency, None, None).await;
+    qualify_case(backend, storage, upload_concurrency(), None, None, true).await;
 }
 
 #[derive(Clone, Copy, Debug)]
@@ -218,6 +259,7 @@ async fn qualify_case<S>(
     part_concurrency: usize,
     artificial_latency: Option<(LatencyObjectStore, Duration)>,
     io_counters: Option<SlateDBIoCounters>,
+    run_ingest: bool,
 ) -> Qualification
 where
     S: Storage + Clone + Send + Sync + 'static,
@@ -255,6 +297,7 @@ where
         PROXY_BYTES,
         1,
         part_concurrency,
+        None,
     )
     .await;
     if let Some((store, latency)) = &artificial_latency {
@@ -293,15 +336,18 @@ where
     let started = tokio::time::Instant::now();
     let ingest_started = Instant::now();
     let ingest_future = async {
-        upload(
-            &ingest,
-            "concurrent-ingest",
-            "/media/import.mov",
-            INGEST_BYTES,
-            2,
-            part_concurrency,
-        )
-        .await;
+        if run_ingest {
+            upload(
+                &ingest,
+                "concurrent-ingest",
+                "/media/import.mov",
+                INGEST_BYTES,
+                2,
+                part_concurrency,
+                std::env::var_os("LIX_MOVIE_PLAYBACK_TRACE").is_some().then_some(started),
+            )
+            .await;
+        }
         ingest_started.elapsed()
     };
     let save_future = project_saves(saver, started);
@@ -339,14 +385,16 @@ where
         io.cache_filesystem_removes,
         io.writer_gate_wait_nanos as f64 / 1_000_000.0,
     );
-    assert!(save_p95 < Duration::from_millis(500));
-    assert_eq!(first_late, 0, "first 100 Mbit/s stream fell behind");
-    assert_eq!(second_late, 0, "second 100 Mbit/s stream fell behind");
-    assert_eq!(structural.temporary_manifest_leaf_rows, 32);
-    assert_eq!(structural.legacy_equivalent_chunk_rows, 512);
-    assert_eq!(row_reduction, 16.0);
-    assert_eq!(projected_chunk_rows / projected_leaf_rows, 16);
-    assert!(structural.chunk_payload_hash_bytes >= INGEST_BYTES as u64);
+    if run_ingest {
+        assert!(save_p95 < Duration::from_millis(500));
+        assert_eq!(first_late, 0, "first 100 Mbit/s stream fell behind");
+        assert_eq!(second_late, 0, "second 100 Mbit/s stream fell behind");
+        assert_eq!(structural.temporary_manifest_leaf_rows, 32);
+        assert_eq!(structural.legacy_equivalent_chunk_rows, 512);
+        assert_eq!(row_reduction, 16.0);
+        assert_eq!(projected_chunk_rows / projected_leaf_rows, 16);
+        assert!(structural.chunk_payload_hash_bytes >= INGEST_BYTES as u64);
+    }
     Qualification {
         ingest_mib_s,
         save_p95,
@@ -421,6 +469,7 @@ async fn upload<S>(
     total_bytes: usize,
     seed: u64,
     part_concurrency: usize,
+    schedule_start: Option<tokio::time::Instant>,
 ) where
     S: Storage + Clone + Send + Sync + 'static,
 {
@@ -448,6 +497,12 @@ async fn upload<S>(
             .max()
             .expect("upload window contains a part");
         assert_eq!(acknowledged, window_end as u64);
+        if let Some(schedule_start) = schedule_start {
+            println!(
+                "movie_upload_window,upload_id={upload_id},window_end={window_end},at_ms={:.3}",
+                (tokio::time::Instant::now() - schedule_start).as_secs_f64() * 1000.0,
+            );
+        }
         window_start = window_end;
     }
 }

--- a/packages/engine-benchmarks/tests/movie_workspace_qualification.rs
+++ b/packages/engine-benchmarks/tests/movie_workspace_qualification.rs
@@ -334,6 +334,26 @@ where
     );
 
     let started = tokio::time::Instant::now();
+    // Independent runtime watchdog: an empty task that only sleeps. Any gap it
+    // records is executor-level, because it touches neither storage nor a lock.
+    let watchdog_worst = Arc::new(AtomicU64::new(0));
+    let watchdog = std::env::var_os("LIX_MOVIE_PLAYBACK_TRACE")
+        .is_some()
+        .then(|| {
+            let worst = watchdog_worst.clone();
+            tokio::spawn(async move {
+                let tick = Duration::from_millis(5);
+                let mut next = started + tick;
+                loop {
+                    tokio::time::sleep_until(next).await;
+                    let gap = (tokio::time::Instant::now() - next).as_micros() as u64;
+                    let elapsed_ms = (next - started).as_millis() as u64;
+                    let packed = (gap << 20) | elapsed_ms.min((1 << 20) - 1);
+                    worst.fetch_max(packed, Ordering::Relaxed);
+                    next += tick;
+                }
+            })
+        });
     let ingest_started = Instant::now();
     let ingest_future = async {
         if run_ingest {
@@ -356,6 +376,15 @@ where
     let (ingest_elapsed, mut save_latencies, first_late, second_late) =
         tokio::join!(ingest_future, save_future, first_playback, second_playback);
 
+    if let Some(watchdog) = watchdog {
+        watchdog.abort();
+        let packed = watchdog_worst.load(Ordering::Relaxed);
+        println!(
+            "movie_runtime_watchdog,worst_gap_ms={:.3},at_ms={}",
+            (packed >> 20) as f64 / 1000.0,
+            packed & ((1 << 20) - 1),
+        );
+    }
     save_latencies.sort_unstable();
     let save_p95 = save_latencies[save_latencies.len() * 95 / 100];
     let ingest_mib_s = INGEST_BYTES as f64 / (1024.0 * 1024.0) / ingest_elapsed.as_secs_f64();
@@ -517,9 +546,14 @@ where
     S: Storage + Clone + Send + Sync + 'static,
 {
     let trace = std::env::var_os("LIX_MOVIE_PLAYBACK_TRACE").is_some();
+    let samples = std::env::var("LIX_MOVIE_STREAM_SAMPLES")
+        .ok()
+        .and_then(|value| value.parse::<usize>().ok())
+        .filter(|value| *value > 0)
+        .unwrap_or(STREAM_SAMPLES);
     let mut late = 0;
-    let mut read_latencies = Vec::with_capacity(STREAM_SAMPLES);
-    for sample in 0..STREAM_SAMPLES {
+    let mut read_latencies = Vec::with_capacity(samples);
+    for sample in 0..samples {
         let deadline = schedule_start + PLAYBACK_READ_AHEAD + STREAM_PERIOD * (sample as u32 + 1);
         let offset = (initial_offset + sample as u64 * STREAM_READ_BYTES)
             % (PROXY_BYTES as u64 - STREAM_READ_BYTES);

--- a/packages/engine-benchmarks/tests/movie_workspace_qualification.rs
+++ b/packages/engine-benchmarks/tests/movie_workspace_qualification.rs
@@ -305,8 +305,8 @@ where
         ingest_started.elapsed()
     };
     let save_future = project_saves(saver, started);
-    let first_playback = playback(first_reader, started, 0);
-    let second_playback = playback(second_reader, started, PROXY_BYTES as u64 / 2);
+    let first_playback = playback(first_reader, started, 0, 1);
+    let second_playback = playback(second_reader, started, PROXY_BYTES as u64 / 2, 2);
     let (ingest_elapsed, mut save_latencies, first_late, second_late) =
         tokio::join!(ingest_future, save_future, first_playback, second_playback);
 
@@ -456,15 +456,19 @@ async fn playback<S>(
     session: Arc<SessionContext<S>>,
     schedule_start: tokio::time::Instant,
     initial_offset: u64,
+    stream: usize,
 ) -> usize
 where
     S: Storage + Clone + Send + Sync + 'static,
 {
+    let trace = std::env::var_os("LIX_MOVIE_PLAYBACK_TRACE").is_some();
     let mut late = 0;
+    let mut read_latencies = Vec::with_capacity(STREAM_SAMPLES);
     for sample in 0..STREAM_SAMPLES {
         let deadline = schedule_start + PLAYBACK_READ_AHEAD + STREAM_PERIOD * (sample as u32 + 1);
         let offset = (initial_offset + sample as u64 * STREAM_READ_BYTES)
             % (PROXY_BYTES as u64 - STREAM_READ_BYTES);
+        let read_started = tokio::time::Instant::now();
         let read = session
             .read_file_content(
                 "/media/proxy.mov".to_owned(),
@@ -473,13 +477,42 @@ where
             .await
             .expect("read proxy range")
             .expect("proxy exists");
+        let finished = tokio::time::Instant::now();
+        let read_elapsed = finished - read_started;
+        read_latencies.push(read_elapsed);
         assert_eq!(read.content().len(), STREAM_READ_BYTES as usize);
-        if tokio::time::Instant::now() > deadline {
+        let is_late = finished > deadline;
+        if trace {
+            println!(
+                "movie_playback_sample,stream={stream},sample={sample},offset={offset},read_ms={:.3},slack_ms={:.3},late={is_late}",
+                read_elapsed.as_secs_f64() * 1000.0,
+                if is_late {
+                    -((finished - deadline).as_secs_f64() * 1000.0)
+                } else {
+                    (deadline - finished).as_secs_f64() * 1000.0
+                },
+            );
+        }
+        if is_late {
             late += 1;
         } else {
             tokio::time::sleep_until(deadline).await;
         }
     }
+    let mut sorted = read_latencies.clone();
+    sorted.sort_unstable();
+    let pick = |num: usize| sorted[(sorted.len() * num / 100).min(sorted.len() - 1)];
+    println!(
+        "movie_playback_latency,stream={stream},samples={},late={late},read_min_ms={:.3},read_p50_ms={:.3},read_p90_ms={:.3},read_p95_ms={:.3},read_p99_ms={:.3},read_max_ms={:.3},budget_ms={:.3}",
+        sorted.len(),
+        sorted[0].as_secs_f64() * 1000.0,
+        pick(50).as_secs_f64() * 1000.0,
+        pick(90).as_secs_f64() * 1000.0,
+        pick(95).as_secs_f64() * 1000.0,
+        pick(99).as_secs_f64() * 1000.0,
+        sorted[sorted.len() - 1].as_secs_f64() * 1000.0,
+        STREAM_PERIOD.as_secs_f64() * 1000.0,
+    );
     late
 }
 

--- a/packages/engine-benchmarks/tests/movie_workspace_qualification.rs
+++ b/packages/engine-benchmarks/tests/movie_workspace_qualification.rs
@@ -354,8 +354,14 @@ where
                 }
             })
         });
+    // Ingest, project saves and the two proxy streams are four independent
+    // actors in the workload this qualification claims to model, so each one
+    // gets its own task. Driving them as branches of a single `tokio::join!`
+    // future put all four on one task: a slow write in any branch could not
+    // overlap a playback read, and the resulting delay was scored against the
+    // playback deadline even though the read itself had not started.
     let ingest_started = Instant::now();
-    let ingest_future = async {
+    let ingest_task = tokio::spawn(async move {
         if run_ingest {
             upload(
                 &ingest,
@@ -364,17 +370,28 @@ where
                 INGEST_BYTES,
                 2,
                 part_concurrency,
-                std::env::var_os("LIX_MOVIE_PLAYBACK_TRACE").is_some().then_some(started),
+                std::env::var_os("LIX_MOVIE_PLAYBACK_TRACE")
+                    .is_some()
+                    .then_some(started),
             )
             .await;
         }
         ingest_started.elapsed()
-    };
-    let save_future = project_saves(saver, started);
-    let first_playback = playback(first_reader, started, 0, 1);
-    let second_playback = playback(second_reader, started, PROXY_BYTES as u64 / 2, 2);
-    let (ingest_elapsed, mut save_latencies, first_late, second_late) =
-        tokio::join!(ingest_future, save_future, first_playback, second_playback);
+    });
+    let save_task = tokio::spawn(project_saves(saver, started));
+    let first_task = tokio::spawn(playback(first_reader, started, 0, 1));
+    let second_task = tokio::spawn(playback(
+        second_reader,
+        started,
+        PROXY_BYTES as u64 / 2,
+        2,
+    ));
+    let (ingest_elapsed, mut save_latencies, first_late, second_late) = tokio::join!(
+        async { ingest_task.await.expect("ingest task") },
+        async { save_task.await.expect("project save task") },
+        async { first_task.await.expect("first playback task") },
+        async { second_task.await.expect("second playback task") },
+    );
 
     if let Some(watchdog) = watchdog {
         watchdog.abort();

--- a/packages/engine-benchmarks/tests/movie_workspace_qualification.rs
+++ b/packages/engine-benchmarks/tests/movie_workspace_qualification.rs
@@ -86,7 +86,9 @@ fn rocksdb_movie_workspace_interference() {
         let _qualification_guard = QUALIFICATION_LOCK.lock().await;
         let temp = tempfile::tempdir().expect("create RocksDB movie fixture");
         let storage = RocksDB::open(temp.path().join("database")).expect("open RocksDB fixture");
-        qualify("rocksdb", storage).await;
+        qualify("rocksdb", storage.clone()).await;
+        storage.flush().expect("flush RocksDB fixture");
+        report_settled_bytes("rocksdb", temp.path());
     });
 }
 
@@ -97,8 +99,61 @@ fn slatedb_movie_workspace_interference() {
         let _qualification_guard = QUALIFICATION_LOCK.lock().await;
         let temp = tempfile::tempdir().expect("create SlateDB movie fixture");
         let storage = SlateDB::open(temp.path().join("database")).expect("open SlateDB fixture");
-        qualify("slatedb", storage).await;
+        qualify("slatedb", storage.clone()).await;
+        storage.flush().await.expect("flush SlateDB fixture");
+        report_settled_bytes("slatedb", temp.path());
     });
+}
+
+/// Bytes the workload leaves on disk once the writer has flushed. Reported
+/// per top-level directory so an arm comparison can separate LSM state from
+/// the immutable value segments that carry the media payload.
+fn report_settled_bytes(backend: &str, root: &std::path::Path) {
+    fn directory_bytes(path: &std::path::Path) -> u64 {
+        let Ok(metadata) = std::fs::symlink_metadata(path) else {
+            return 0;
+        };
+        if metadata.is_file() {
+            return metadata.len();
+        }
+        if !metadata.is_dir() {
+            return 0;
+        }
+        std::fs::read_dir(path)
+            .map(|entries| {
+                entries
+                    .map(|entry| match entry {
+                        Ok(entry) => directory_bytes(&entry.path()),
+                        Err(_) => 0,
+                    })
+                    .sum()
+            })
+            .unwrap_or(0)
+    }
+    let database = root.join("database");
+    let mut breakdown = Vec::new();
+    if let Ok(entries) = std::fs::read_dir(database.join("db")) {
+        let mut named = entries
+            .filter_map(Result::ok)
+            .map(|entry| {
+                (
+                    entry.file_name().to_string_lossy().into_owned(),
+                    directory_bytes(&entry.path()),
+                )
+            })
+            .collect::<Vec<_>>();
+        named.sort();
+        breakdown = named;
+    }
+    println!(
+        "movie_settled_bytes,backend={backend},total_bytes={},{}",
+        directory_bytes(&database),
+        breakdown
+            .iter()
+            .map(|(name, bytes)| format!("{name}_bytes={bytes}"))
+            .collect::<Vec<_>>()
+            .join(","),
+    );
 }
 
 /// Null control for the playback assertions: identical schedule, sessions and

--- a/packages/engine-benchmarks/tests/movie_workspace_qualification.rs
+++ b/packages/engine-benchmarks/tests/movie_workspace_qualification.rs
@@ -612,9 +612,12 @@ async fn project_saves<S>(
 where
     S: Storage + Clone + Send + Sync + 'static,
 {
+    let trace = std::env::var_os("LIX_MOVIE_PLAYBACK_TRACE").is_some();
     let mut timings = Vec::with_capacity(SAVE_SAMPLES);
     for sample in 0..SAVE_SAMPLES {
-        tokio::time::sleep_until(schedule_start + STREAM_PERIOD * sample as u32).await;
+        let scheduled = schedule_start + STREAM_PERIOD * sample as u32;
+        tokio::time::sleep_until(scheduled).await;
+        let wake_delay = tokio::time::Instant::now() - scheduled;
         let payload = format!(
             "{{\"timelineRevision\":{sample},\"playhead\":{}}}",
             sample * 24
@@ -624,7 +627,16 @@ where
             .upsert_file_content("/project/edit.json".to_owned(), payload.into_bytes().into())
             .await
             .expect("save project file");
-        timings.push(started.elapsed());
+        let elapsed = started.elapsed();
+        if trace {
+            println!(
+                "movie_save_sample,sample={sample},at_ms={:.3},wake_delay_ms={:.3},save_ms={:.3}",
+                (scheduled - schedule_start).as_secs_f64() * 1000.0,
+                wake_delay.as_secs_f64() * 1000.0,
+                elapsed.as_secs_f64() * 1000.0,
+            );
+        }
+        timings.push(elapsed);
     }
     timings
 }

--- a/packages/engine-benchmarks/tests/movie_workspace_qualification.rs
+++ b/packages/engine-benchmarks/tests/movie_workspace_qualification.rs
@@ -4,9 +4,11 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::{Duration, Instant};
 
+use std::panic::AssertUnwindSafe;
+
 use async_trait::async_trait;
 use bytes::Bytes;
-use futures_util::StreamExt;
+use futures_util::{FutureExt, StreamExt};
 use futures_util::future::join_all;
 use futures_util::stream::{self, BoxStream};
 use lix::FILE_UPLOAD_PART_BYTES;
@@ -86,9 +88,17 @@ fn rocksdb_movie_workspace_interference() {
         let _qualification_guard = QUALIFICATION_LOCK.lock().await;
         let temp = tempfile::tempdir().expect("create RocksDB movie fixture");
         let storage = RocksDB::open(temp.path().join("database")).expect("open RocksDB fixture");
-        qualify("rocksdb", storage.clone()).await;
+        // Settled bytes are part of the measurement, so they are reported even
+        // when an assertion above them fails — otherwise an arm that trips a
+        // structural assertion silently contributes no byte number.
+        let outcome = AssertUnwindSafe(qualify("rocksdb", storage.clone()))
+            .catch_unwind()
+            .await;
         storage.flush().expect("flush RocksDB fixture");
         report_settled_bytes("rocksdb", temp.path());
+        if let Err(panic) = outcome {
+            std::panic::resume_unwind(panic);
+        }
     });
 }
 
@@ -99,9 +109,14 @@ fn slatedb_movie_workspace_interference() {
         let _qualification_guard = QUALIFICATION_LOCK.lock().await;
         let temp = tempfile::tempdir().expect("create SlateDB movie fixture");
         let storage = SlateDB::open(temp.path().join("database")).expect("open SlateDB fixture");
-        qualify("slatedb", storage.clone()).await;
+        let outcome = AssertUnwindSafe(qualify("slatedb", storage.clone()))
+            .catch_unwind()
+            .await;
         storage.flush().await.expect("flush SlateDB fixture");
         report_settled_bytes("slatedb", temp.path());
+        if let Err(panic) = outcome {
+            std::panic::resume_unwind(panic);
+        }
     });
 }
 

--- a/packages/lix/src/binary_cas/chunking.rs
+++ b/packages/lix/src/binary_cas/chunking.rs
@@ -1,19 +1,29 @@
+//! The single authority for binary-CAS chunk boundaries.
+//!
+//! Boundaries are decided exactly once per payload, in
+//! [`crate::binary_cas::BlobPayload::from_bytes`], and travel with the payload
+//! as chunk receipts. Staging reconstructs the ranges from those receipt sizes
+//! rather than asking this module again, so a write never searches for the same
+//! boundaries twice.
+
 pub(super) const SINGLE_CHUNK_FAST_PATH_MAX_BYTES: usize = 64 * 1024;
 pub(super) const MAX_BINARY_CAS_CHUNK_BYTES: usize = 4096 * 1024;
 // SlateDB packs sequential immutable payloads into 64 MiB sidecar segments.
-// The local mixed movie profile in engine-benchmarks/MOVIE_WORKSPACE.md was
+// The local mixed movie profile in engine-benchmarks/MOVIE_WORKSPACE.md
 // showed no ingest gain at 4 MiB and a slightly worse save p95; retain the
 // smaller seek unit until a remote profile demonstrates a material win.
 pub(crate) const MEDIA_CHUNK_BYTES: usize = 1024 * 1024;
 
+/// Chunk boundaries are cut at fixed offsets. Nothing here inspects content,
+/// so a payload that shifts by one byte renames every chunk after the shift.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub(crate) struct BinaryCasChunking {
+pub(super) struct BinaryCasChunking {
     chunk_bytes: usize,
     single_chunk_fast_path_max_bytes: usize,
 }
 
 impl BinaryCasChunking {
-    pub(crate) const fn fixed_1m_v3() -> Self {
+    pub(super) const fn fixed_1m_v3() -> Self {
         Self {
             chunk_bytes: MEDIA_CHUNK_BYTES,
             single_chunk_fast_path_max_bytes: SINGLE_CHUNK_FAST_PATH_MAX_BYTES,
@@ -27,12 +37,11 @@ impl Default for BinaryCasChunking {
     }
 }
 
-#[cfg(test)]
-pub(crate) fn fastcdc_chunk_ranges(data: &[u8]) -> Vec<(usize, usize)> {
-    fastcdc_chunk_ranges_with_chunking(data, BinaryCasChunking::default())
+pub(crate) fn chunk_ranges(data: &[u8]) -> Vec<(usize, usize)> {
+    chunk_ranges_with_chunking(data, BinaryCasChunking::default())
 }
 
-pub(crate) fn fastcdc_chunk_ranges_with_chunking(
+pub(super) fn chunk_ranges_with_chunking(
     data: &[u8],
     chunking: BinaryCasChunking,
 ) -> Vec<(usize, usize)> {
@@ -69,10 +78,7 @@ mod tests {
     #[test]
     fn single_chunk_fast_path_applies_through_64kib() {
         let at_boundary = vec![0; 64 * 1024];
-        assert_eq!(
-            fastcdc_chunk_ranges(&at_boundary),
-            vec![(0, at_boundary.len())]
-        );
+        assert_eq!(chunk_ranges(&at_boundary), vec![(0, at_boundary.len())]);
     }
 
     #[test]
@@ -84,7 +90,7 @@ mod tests {
         };
 
         assert_ne!(
-            fastcdc_chunk_ranges_with_chunking(&above_boundary, chunking),
+            chunk_ranges_with_chunking(&above_boundary, chunking),
             vec![(0, above_boundary.len())]
         );
     }
@@ -92,7 +98,7 @@ mod tests {
     #[test]
     fn multi_megabyte_payloads_cannot_collapse_to_one_rewritten_chunk() {
         let payload = vec![b'a'; 3_500_000];
-        let ranges = fastcdc_chunk_ranges(&payload);
+        let ranges = chunk_ranges(&payload);
 
         assert!(ranges.len() >= 4);
         assert!(
@@ -106,7 +112,7 @@ mod tests {
     fn media_chunks_have_stable_offsets() {
         let data = vec![0; MEDIA_CHUNK_BYTES * 2 + 7];
         assert_eq!(
-            fastcdc_chunk_ranges(&data),
+            chunk_ranges(&data),
             vec![
                 (0, MEDIA_CHUNK_BYTES),
                 (MEDIA_CHUNK_BYTES, MEDIA_CHUNK_BYTES * 2),

--- a/packages/lix/src/binary_cas/context.rs
+++ b/packages/lix/src/binary_cas/context.rs
@@ -1,7 +1,6 @@
 use async_trait::async_trait;
 
 use crate::LixError;
-use crate::binary_cas::BinaryCasChunking;
 use crate::binary_cas::{
     BlobBytesBatch, BlobChunkReceipt, BlobEditSplice, BlobId, BlobPayload, BlobRangeBytes,
     BlobRangeBytesBatch, BlobSameLengthSplice, BlobWriteReceipt,
@@ -73,15 +72,11 @@ fn materialize_blob_range(
 /// The context does not own storage. Callers explicitly provide a KV store via
 /// `reader(...)` or `writer_skipping_existing_chunks(...)`, keeping storage and
 /// transaction ownership at the execution layer.
-pub(crate) struct BinaryCasContext {
-    chunking: BinaryCasChunking,
-}
+pub(crate) struct BinaryCasContext;
 
 impl BinaryCasContext {
     pub(crate) fn new() -> Self {
-        Self {
-            chunking: BinaryCasChunking::default(),
-        }
+        Self
     }
 
     pub(crate) fn prepared_manifest_is_staged(
@@ -112,7 +107,7 @@ impl BinaryCasContext {
     where
         S: StorageAdapterRead + ?Sized,
     {
-        ExistingChunkAwareBinaryCasWriter::new(store, writes, self.chunking)
+        ExistingChunkAwareBinaryCasWriter::new(store, writes)
     }
 }
 
@@ -162,7 +157,6 @@ where
 {
     store: &'a S,
     writes: &'a mut StorageWriteSet,
-    chunking: BinaryCasChunking,
     blob_hashes: HashSet<[u8; 32]>,
     chunk_keys: HashSet<Vec<u8>>,
 }
@@ -171,11 +165,10 @@ impl<'a, S> ExistingChunkAwareBinaryCasWriter<'a, S>
 where
     S: StorageAdapterRead + ?Sized,
 {
-    fn new(store: &'a S, writes: &'a mut StorageWriteSet, chunking: BinaryCasChunking) -> Self {
+    fn new(store: &'a S, writes: &'a mut StorageWriteSet) -> Self {
         Self {
             store,
             writes,
-            chunking,
             blob_hashes: HashSet::new(),
             chunk_keys: HashSet::new(),
         }
@@ -186,7 +179,6 @@ where
         payload: &BlobPayload,
     ) -> Result<BlobWriteReceipt, LixError> {
         crate::binary_cas::kv::stage_blob_write_skipping_existing_chunks(
-            self.chunking,
             self.store,
             self.writes,
             &mut self.blob_hashes,

--- a/packages/lix/src/binary_cas/kv.rs
+++ b/packages/lix/src/binary_cas/kv.rs
@@ -1,7 +1,7 @@
 #![allow(clippy::cast_sign_loss)]
 
 use crate::LixError;
-use crate::binary_cas::chunking::{MAX_BINARY_CAS_CHUNK_BYTES, fastcdc_chunk_ranges_with_chunking};
+use crate::binary_cas::chunking::MAX_BINARY_CAS_CHUNK_BYTES;
 use crate::binary_cas::codec::{
     BinaryCasManifest, BinaryChunkCodec, StorageBinaryCasDeltaBaseLayout,
     StorageBinaryCasDeltaSegment, decode_binary_cas_chunk, decode_binary_cas_manifest,
@@ -9,7 +9,7 @@ use crate::binary_cas::codec::{
     encode_binary_cas_manifest_chunk,
 };
 use crate::binary_cas::{
-    BinaryCasChunking, BinaryCasGcSweep, BlobBytesBatch, BlobDeltaBaseLayout, BlobDeltaSegment,
+    BinaryCasGcSweep, BlobBytesBatch, BlobDeltaBaseLayout, BlobDeltaSegment,
     BlobEditSplice, BlobId, BlobLayout, BlobMetadata, BlobMetadataBatch, BlobRangeBytes,
     BlobRangeBytesBatch, BlobSameLengthSplice, BlobWriteReceipt, ChunkHash,
 };
@@ -2025,7 +2025,6 @@ fn decode_and_verify_payload(
 }
 
 pub(in crate::binary_cas) async fn stage_blob_write_skipping_existing_chunks<S>(
-    chunking: BinaryCasChunking,
     store: &S,
     writes: &mut StorageWriteSet,
     blob_hashes: &mut HashSet<[u8; 32]>,
@@ -2060,7 +2059,7 @@ where
             layout: metadata.layout,
         });
     }
-    let plan = prepare_blob_write(chunking, payload)?;
+    let plan = prepare_blob_write(payload)?;
     let receipt = plan.receipt.clone();
     if !blob_hashes.insert(plan.blob_hash.into_bytes()) {
         return Ok(receipt);
@@ -2080,9 +2079,9 @@ where
 /// This is deliberately opportunistic. The caller still owns complete
 /// replacement bytes and falls back to [`stage_blob_write_skipping_existing_chunks`]
 /// for every missing, malformed, non-chunked, length-changing, or otherwise
-/// ineligible base. A manifest is an ordered content-addressed chunk list;
-/// readers do not require its boundaries to have been freshly produced by
-/// FastCDC, so keeping valid existing boundaries is format-compatible.
+/// ineligible base. A manifest is an ordered content-addressed chunk list and a
+/// same-length splice cannot move a boundary, so reusing the base's existing
+/// boundaries produces the layout the chunker would have produced anyway.
 pub(in crate::binary_cas) async fn try_stage_blob_write_reusing_same_length_splice<S>(
     store: &S,
     writes: &mut StorageWriteSet,
@@ -2422,8 +2421,51 @@ fn normalize_delta_segments(segments: Vec<BlobDeltaSegment>) -> Vec<BlobDeltaSeg
     out
 }
 
+/// Rebuilds the payload's chunk layout from the receipt sizes that
+/// [`crate::binary_cas::BlobPayload::from_bytes`] already produced.
+///
+/// The receipts are the boundary decision, so staging never runs the boundary
+/// search a second time over bytes it is about to write. The tiling check below
+/// is what makes that safe: receipts that do not cover the payload exactly are
+/// rejected rather than trusted.
+fn chunk_ranges_from_receipts(
+    receipts: &[crate::binary_cas::BlobChunkReceipt],
+    len: usize,
+) -> Result<Vec<(usize, usize)>, LixError> {
+    let mut ranges = Vec::with_capacity(receipts.len());
+    let mut cursor = 0usize;
+    for receipt in receipts {
+        let size = usize::try_from(receipt.size_bytes)
+            .ok()
+            .filter(|size| *size > 0 && *size <= MAX_BINARY_CAS_CHUNK_BYTES)
+            .ok_or_else(|| {
+                LixError::new(
+                    "LIX_ERROR_UNKNOWN",
+                    "binary CAS payload chunk receipt has an unusable size".to_string(),
+                )
+            })?;
+        let end = cursor
+            .checked_add(size)
+            .filter(|end| *end <= len)
+            .ok_or_else(|| {
+                LixError::new(
+                    "LIX_ERROR_UNKNOWN",
+                    "binary CAS payload chunk receipts overrun the payload".to_string(),
+                )
+            })?;
+        ranges.push((cursor, end));
+        cursor = end;
+    }
+    if cursor != len {
+        return Err(LixError::new(
+            "LIX_ERROR_UNKNOWN",
+            "binary CAS payload chunk receipts do not tile the payload".to_string(),
+        ));
+    }
+    Ok(ranges)
+}
+
 fn prepare_blob_write(
-    chunking: BinaryCasChunking,
     payload: &crate::binary_cas::BlobPayload,
 ) -> Result<BlobWritePlan, LixError> {
     let bytes = payload.bytes();
@@ -2439,13 +2481,7 @@ fn prepare_blob_write(
         }
         (Vec::new(), BlobLayout::Empty)
     } else {
-        let chunk_ranges = fastcdc_chunk_ranges_with_chunking(bytes, chunking);
-        if chunk_ranges.len() != payload.chunks().len() {
-            return Err(LixError::new(
-                "LIX_ERROR_UNKNOWN",
-                "binary CAS payload chunk receipts disagree with canonical chunking".to_string(),
-            ));
-        }
+        let chunk_ranges = chunk_ranges_from_receipts(payload.chunks(), bytes.len())?;
         let layout = match chunk_ranges.as_slice() {
             [] => unreachable!("non-empty blobs always have at least one chunk"),
             [_] => BlobLayout::SingleChunk {
@@ -4001,7 +4037,7 @@ mod tests {
     fn every_non_empty_blob_is_out_of_line() {
         for size in [1, 32 * 1024, 128 * 1024] {
             let payload = BlobPayload::from_bytes(vec![b'a'; size]);
-            let plan = prepare_blob_write(BinaryCasChunking::default(), &payload)
+            let plan = prepare_blob_write(&payload)
                 .expect("non-empty blob should plan");
             assert!(!plan.chunk_ranges.is_empty());
             assert!(matches!(
@@ -4128,7 +4164,7 @@ mod tests {
         let data = definitely_multi_chunk_blob_bytes();
         let payload = BlobPayload::from_bytes(data.clone());
         let blob_hash = payload.hash().expect("payload should have a hash");
-        let chunk_ranges = crate::binary_cas::chunking::fastcdc_chunk_ranges(&data);
+        let chunk_ranges = crate::binary_cas::chunking::chunk_ranges(&data);
         assert!(chunk_ranges.len() > 1);
         let chunk_hashes = chunk_ranges
             .iter()
@@ -4160,7 +4196,6 @@ mod tests {
             .expect("read should open");
         let mut writes = storage.new_write_set();
         stage_blob_write_skipping_existing_chunks(
-            BinaryCasChunking::default(),
             &store,
             &mut writes,
             &mut HashSet::new(),
@@ -4557,7 +4592,7 @@ mod tests {
             .begin_read(StorageReadOptions::default())
             .await
             .expect("result read should open");
-        let expected_hashes = crate::binary_cas::chunking::fastcdc_chunk_ranges(&after)
+        let expected_hashes = crate::binary_cas::chunking::chunk_ranges(&after)
             .into_iter()
             .map(|(start, end)| BlobId::from_content(&after[start..end]).into_bytes())
             .collect::<Vec<_>>();
@@ -4569,7 +4604,7 @@ mod tests {
             .collect::<Vec<_>>();
         assert_eq!(
             actual_hashes, expected_hashes,
-            "fallback must retain FastCDC layout"
+            "fallback must retain the canonical chunk layout"
         );
         assert_eq!(
             load_bytes_many(&store, &[after_blob_hash])

--- a/packages/lix/src/binary_cas/kv.rs
+++ b/packages/lix/src/binary_cas/kv.rs
@@ -16,8 +16,9 @@ use crate::binary_cas::{
 #[cfg(test)]
 use crate::storage_adapter::StoragePrefix;
 use crate::storage_adapter::{
-    PointReadPlan, REVISION_KEY_BINARY_CAS_EPOCH, REVISION_SPACE, StorageAdapterRead, StorageSpace,
-    StorageWriteSet, load_revision, revision_key,
+    PointReadPlan, REVISION_KEY_BINARY_CAS_PUBLICATION, REVISION_KEY_BINARY_CAS_RECLAMATION,
+    REVISION_SPACE, StorageAdapterRead, StorageSpace, StorageWriteSet, load_revision,
+    load_revisions, revision_key,
 };
 use crate::storage_adapter::{
     StorageBeginScanOptions, StorageCoreProjection, StorageGetOptions, StorageKey, StorageKeyRange,
@@ -56,46 +57,18 @@ pub(crate) const BINARY_CAS_CHUNK_PRESENCE_SPACE: StorageSpace = StorageSpace::m
     StorageSpaceId(0x0005_0004),
     BINARY_CAS_CHUNK_PRESENCE_NAMESPACE,
 );
-pub(in crate::binary_cas) async fn load_mutation_epoch(
-    store: &(impl StorageAdapterRead + ?Sized),
-) -> Result<(u64, Option<Bytes>), LixError> {
-    let value = load_revision(store, REVISION_KEY_BINARY_CAS_EPOCH).await?;
-    let Some(value) = value else {
-        return Ok((0, None));
-    };
-    if value.len() != 8 {
-        return Err(LixError::new(
-            LixError::CODE_STORAGE_ERROR,
-            "binary CAS mutation epoch has an invalid width",
-        ));
+fn fresh_revision_token() -> StorageValue {
+    StorageValue {
+        bytes: Bytes::copy_from_slice(uuid::Uuid::now_v7().as_bytes()),
     }
-    Ok((
-        u64::from_be_bytes(value.as_ref().try_into().expect("checked epoch width")),
-        Some(value),
-    ))
 }
 
-pub(in crate::binary_cas) fn stage_mutation_epoch(
-    writes: &mut StorageWriteSet,
-    preconditions: &mut Vec<StoragePrecondition>,
-    current: u64,
+fn unchanged_revision_precondition(
+    key: &'static [u8],
     token: Option<Bytes>,
-) -> Result<(), LixError> {
-    let next = current.checked_add(1).ok_or_else(|| {
-        LixError::new(
-            LixError::CODE_STORAGE_ERROR,
-            "binary CAS mutation epoch exhausted",
-        )
-    })?;
-    let key = revision_key(REVISION_KEY_BINARY_CAS_EPOCH);
-    writes.put(
-        REVISION_SPACE,
-        key.clone(),
-        StorageValue {
-            bytes: Bytes::copy_from_slice(&next.to_be_bytes()),
-        },
-    );
-    preconditions.push(match token {
+) -> StoragePrecondition {
+    let key = revision_key(key);
+    match token {
         Some(expected) => StoragePrecondition::KeyValueEquals {
             space: REVISION_SPACE,
             key,
@@ -105,7 +78,58 @@ pub(in crate::binary_cas) fn stage_mutation_epoch(
             space: REVISION_SPACE,
             key,
         },
-    });
+    }
+}
+
+pub(in crate::binary_cas) async fn stage_publication_fence(
+    store: &(impl StorageAdapterRead + ?Sized),
+    writes: &mut StorageWriteSet,
+    preconditions: &mut Vec<StoragePrecondition>,
+) -> Result<(), LixError> {
+    let reclamation = load_revision(store, REVISION_KEY_BINARY_CAS_RECLAMATION).await?;
+    // A fresh token, not a counter increment: two publishers planned from the
+    // same snapshot must both be able to commit, so neither can hold a
+    // compare-and-set on this row. Uniqueness is what a sweep's equality
+    // precondition needs, and blind counter increments would let a second
+    // publisher restore the value a sweep already observed.
+    writes.put(
+        REVISION_SPACE,
+        revision_key(REVISION_KEY_BINARY_CAS_PUBLICATION),
+        fresh_revision_token(),
+    );
+    preconditions.push(unchanged_revision_precondition(
+        REVISION_KEY_BINARY_CAS_RECLAMATION,
+        reclamation,
+    ));
+    Ok(())
+}
+
+pub(in crate::binary_cas) async fn stage_reclamation_fence(
+    store: &(impl StorageAdapterRead + ?Sized),
+    writes: &mut StorageWriteSet,
+    preconditions: &mut Vec<StoragePrecondition>,
+) -> Result<(), LixError> {
+    let [publication, reclamation] = load_revisions(
+        store,
+        [
+            REVISION_KEY_BINARY_CAS_PUBLICATION,
+            REVISION_KEY_BINARY_CAS_RECLAMATION,
+        ],
+    )
+    .await?;
+    writes.put(
+        REVISION_SPACE,
+        revision_key(REVISION_KEY_BINARY_CAS_RECLAMATION),
+        fresh_revision_token(),
+    );
+    preconditions.push(unchanged_revision_precondition(
+        REVISION_KEY_BINARY_CAS_PUBLICATION,
+        publication,
+    ));
+    preconditions.push(unchanged_revision_precondition(
+        REVISION_KEY_BINARY_CAS_RECLAMATION,
+        reclamation,
+    ));
     Ok(())
 }
 
@@ -2862,34 +2886,132 @@ mod tests {
         StorageScanCursor, StorageWriteOptions, StorageWriteSet,
     };
 
-    #[tokio::test]
-    async fn corrupt_mutation_epoch_fails_publication_closed() {
-        let storage = StorageAdapter::new(Memory::new());
-        let mut corrupt = storage.new_write_set();
-        corrupt.put(
-            REVISION_SPACE,
-            revision_key(REVISION_KEY_BINARY_CAS_EPOCH),
-            StorageValue {
-                bytes: Bytes::from_static(b"bad"),
-            },
-        );
-        storage
-            .commit_write_set(corrupt, StorageWriteOptions::default())
-            .await
-            .expect("corrupt epoch fixture should commit");
+    async fn stage_publication_fence_only(
+        storage: &StorageAdapter<Memory>,
+    ) -> (StorageWriteSet, Vec<StoragePrecondition>) {
         let read = storage
             .begin_read(StorageReadOptions::default())
             .await
-            .expect("corrupt epoch read should open");
+            .expect("publication fence read should open");
         let mut writes = storage.new_write_set();
         let mut preconditions = Vec::new();
-        let error = crate::binary_cas::stage_mutation_epoch(&read, &mut writes, &mut preconditions)
+        crate::binary_cas::stage_cas_publication_fence(&read, &mut writes, &mut preconditions)
             .await
-            .expect_err("corrupt epoch must reject publication");
-        assert_eq!(error.code, LixError::CODE_STORAGE_ERROR);
-        assert!(error.message.contains("invalid width"));
-        assert!(writes.is_empty());
-        assert!(preconditions.is_empty());
+            .expect("publication fence should stage");
+        (writes, preconditions)
+    }
+
+    /// Publishers are independent of each other: content-addressed payload rows
+    /// have no read-modify-write aggregate, so two publications planned from one
+    /// snapshot must both commit. A compare-and-set here is what made unrelated
+    /// concurrent writers collide with `LIX_TRANSACTION_CONFLICT`.
+    #[tokio::test]
+    async fn concurrent_publication_fences_planned_from_one_snapshot_both_commit() {
+        let storage = StorageAdapter::new(Memory::new());
+        let (first_writes, first_preconditions) = stage_publication_fence_only(&storage).await;
+        let (second_writes, second_preconditions) = stage_publication_fence_only(&storage).await;
+        storage
+            .commit_write_set(
+                first_writes,
+                StorageWriteOptions {
+                    preconditions: first_preconditions,
+                    ..StorageWriteOptions::default()
+                },
+            )
+            .await
+            .expect("first publication fence should commit");
+        storage
+            .commit_write_set(
+                second_writes,
+                StorageWriteOptions {
+                    preconditions: second_preconditions,
+                    ..StorageWriteOptions::default()
+                },
+            )
+            .await
+            .expect("a concurrent publication must not invalidate another publication");
+    }
+
+    /// The publication token must change on every publication, or a sweep that
+    /// observed a value could see that same value restored and commit a plan
+    /// that predates the publication.
+    #[tokio::test]
+    async fn every_publication_rewrites_the_publication_token() {
+        let storage = StorageAdapter::new(Memory::new());
+        let mut seen = std::collections::HashSet::new();
+        for _ in 0..4 {
+            let (writes, preconditions) = stage_publication_fence_only(&storage).await;
+            storage
+                .commit_write_set(
+                    writes,
+                    StorageWriteOptions {
+                        preconditions,
+                        ..StorageWriteOptions::default()
+                    },
+                )
+                .await
+                .expect("publication fence should commit");
+            let read = storage
+                .begin_read(StorageReadOptions::default())
+                .await
+                .expect("publication token read should open");
+            let token = load_revision(&read, REVISION_KEY_BINARY_CAS_PUBLICATION)
+                .await
+                .expect("publication token should load")
+                .expect("publication token should be present");
+            assert!(
+                seen.insert(token),
+                "each publication must write a distinct publication token"
+            );
+        }
+    }
+
+    /// Two sweeps planned from one snapshot must still be mutually exclusive:
+    /// each deletes rows the other assumed present.
+    #[tokio::test]
+    async fn concurrent_reclamation_fences_planned_from_one_snapshot_conflict() {
+        let storage = StorageAdapter::new(Memory::new());
+        let mut staged = Vec::new();
+        for _ in 0..2 {
+            let read = storage
+                .begin_read(StorageReadOptions::default())
+                .await
+                .expect("reclamation fence read should open");
+            let mut writes = storage.new_write_set();
+            let mut preconditions = Vec::new();
+            crate::binary_cas::stage_cas_reclamation_fence(&read, &mut writes, &mut preconditions)
+                .await
+                .expect("reclamation fence should stage");
+            staged.push((writes, preconditions));
+        }
+        let (second_writes, second_preconditions) = staged.pop().expect("two sweeps were staged");
+        let (first_writes, first_preconditions) = staged.pop().expect("two sweeps were staged");
+        storage
+            .commit_write_set(
+                first_writes,
+                StorageWriteOptions {
+                    preconditions: first_preconditions,
+                    ..StorageWriteOptions::default()
+                },
+            )
+            .await
+            .expect("first sweep should win the reclamation fence");
+        let error = storage
+            .commit_write_set(
+                second_writes,
+                StorageWriteOptions {
+                    preconditions: second_preconditions,
+                    ..StorageWriteOptions::default()
+                },
+            )
+            .await
+            .expect_err("a stale sweep must lose the reclamation fence");
+        assert!(matches!(
+            error,
+            crate::storage_adapter::StorageWriteSetError::Storage(
+                StorageError::PreconditionFailed(_)
+            )
+        ));
     }
 
     struct DelayedManifestScanRead<R> {

--- a/packages/lix/src/binary_cas/kv.rs
+++ b/packages/lix/src/binary_cas/kv.rs
@@ -2938,7 +2938,7 @@ mod tests {
     #[tokio::test]
     async fn every_publication_rewrites_the_publication_token() {
         let storage = StorageAdapter::new(Memory::new());
-        let mut seen = std::collections::HashSet::new();
+        let mut seen = HashSet::new();
         for _ in 0..4 {
             let (writes, preconditions) = stage_publication_fence_only(&storage).await;
             storage

--- a/packages/lix/src/binary_cas/mod.rs
+++ b/packages/lix/src/binary_cas/mod.rs
@@ -54,16 +54,49 @@ pub(crate) async fn stage_gc_reclamation(
     kv::stage_reclaim_unreachable_binary_cas(store, writes, blob_roots, upload_chunks).await
 }
 
-/// Stages the single authenticated publication/reclamation epoch owned by the
-/// binary CAS. Every logical CAS publisher and every sweep rotates this row in
-/// the same atomic commit. A publisher and sweep planned from one snapshot can
-/// therefore never both commit, including when publication reuses every
-/// immutable payload row.
-pub(crate) async fn stage_mutation_epoch(
+/// Stages the publisher half of the binary-CAS publication fence.
+///
+/// Every logical CAS publisher — an ordinary commit's root publication, a
+/// resumable upload part, a completed-upload receipt — calls this in the same
+/// atomic write set that stages its payload rows.
+///
+/// The fence is deliberately asymmetric, because the two directions it has to
+/// stop are not symmetric:
+///
+/// * A publisher may reuse an immutable payload row instead of restaging it, so
+///   it must not commit if a sweep deleted that row after the publisher's
+///   planning snapshot. That is enforced here: the publisher asserts the
+///   reclamation token is unchanged.
+/// * A sweep computes reachability from a snapshot, so it must not commit if a
+///   publication rooted new bytes after that snapshot. That is enforced by
+///   [`stage_cas_reclamation_fence`]: the sweep asserts the publication token is
+///   unchanged, and every publisher rewrites it.
+///
+/// Publishers, by contrast, never invalidate each other. Payload rows are
+/// content-addressed puts with no read-modify-write aggregate, so two
+/// publications planned from one snapshot are independent and both may commit.
+/// A publisher therefore holds no compare-and-set on the row it writes; making
+/// it do so is what turned unrelated concurrent writers — a project-file save
+/// alongside media ingest, or two parts of one resumable upload — into
+/// `LIX_TRANSACTION_CONFLICT`.
+pub(crate) async fn stage_cas_publication_fence(
     store: &(impl crate::storage_adapter::StorageAdapterRead + ?Sized),
     writes: &mut crate::storage_adapter::StorageWriteSet,
     preconditions: &mut Vec<crate::storage_adapter::StoragePrecondition>,
 ) -> Result<(), crate::LixError> {
-    let (current, token) = kv::load_mutation_epoch(store).await?;
-    kv::stage_mutation_epoch(writes, preconditions, current, token)
+    kv::stage_publication_fence(store, writes, preconditions).await
+}
+
+/// Stages the sweep half of the binary-CAS publication fence.
+///
+/// A sweep rotates the reclamation token under a compare-and-set (so two sweeps
+/// planned from one snapshot cannot both commit) and asserts the publication
+/// token is unchanged (so no publication slipped in after its reachability
+/// plan). See [`stage_cas_publication_fence`] for the full argument.
+pub(crate) async fn stage_cas_reclamation_fence(
+    store: &(impl crate::storage_adapter::StorageAdapterRead + ?Sized),
+    writes: &mut crate::storage_adapter::StorageWriteSet,
+    preconditions: &mut Vec<crate::storage_adapter::StoragePrecondition>,
+) -> Result<(), crate::LixError> {
+    kv::stage_reclamation_fence(store, writes, preconditions).await
 }

--- a/packages/lix/src/binary_cas/mod.rs
+++ b/packages/lix/src/binary_cas/mod.rs
@@ -9,7 +9,6 @@ mod types;
 
 use std::collections::{BTreeMap, BTreeSet};
 
-pub(crate) use chunking::BinaryCasChunking;
 #[cfg(all(feature = "storage-benches", test))]
 pub(crate) use codec::encode_binary_cas_manifest;
 #[cfg(feature = "storage-benches")]

--- a/packages/lix/src/binary_cas/types.rs
+++ b/packages/lix/src/binary_cas/types.rs
@@ -1,5 +1,5 @@
 use crate::LixError;
-use crate::binary_cas::chunking::{MEDIA_CHUNK_BYTES, chunk_ranges};
+use crate::binary_cas::chunking::chunk_ranges;
 use crate::binary_cas::codec::BinaryChunkCodec;
 use crate::binary_cas::codec::{binary_blob_hash_bytes, hash_bytes_to_hex, hash_hex_to_bytes};
 use std::ops::Range;
@@ -308,6 +308,7 @@ pub(crate) struct BinaryCasChunkView<'a> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::binary_cas::chunking::MEDIA_CHUNK_BYTES;
 
     #[test]
     fn payload_carries_exact_canonical_chunk_receipts() {

--- a/packages/lix/src/binary_cas/types.rs
+++ b/packages/lix/src/binary_cas/types.rs
@@ -1,5 +1,5 @@
 use crate::LixError;
-use crate::binary_cas::chunking::MEDIA_CHUNK_BYTES;
+use crate::binary_cas::chunking::{MEDIA_CHUNK_BYTES, chunk_ranges};
 use crate::binary_cas::codec::BinaryChunkCodec;
 use crate::binary_cas::codec::{binary_blob_hash_bytes, hash_bytes_to_hex, hash_hex_to_bytes};
 use std::ops::Range;
@@ -14,13 +14,19 @@ impl BlobId {
     }
 
     pub(crate) fn from_content(content: &[u8]) -> Self {
-        if content.len() <= MEDIA_CHUNK_BYTES {
-            return Self::from_single_chunk(ChunkHash::from_content(content));
+        let ranges = chunk_ranges(content);
+        match ranges.as_slice() {
+            [] | [_] => Self::from_single_chunk(ChunkHash::from_content(content)),
+            ranges => Self::from_chunks(
+                content.len() as u64,
+                ranges.iter().map(|&(start, end)| {
+                    (
+                        ChunkHash::from_content(&content[start..end]),
+                        (end - start) as u64,
+                    )
+                }),
+            ),
         }
-        let chunks = content
-            .chunks(MEDIA_CHUNK_BYTES)
-            .map(|chunk| (ChunkHash::from_content(chunk), chunk.len() as u64));
-        Self::from_chunks(content.len() as u64, chunks)
     }
 
     pub(crate) fn from_single_chunk(chunk_hash: ChunkHash) -> Self {
@@ -135,11 +141,13 @@ pub(crate) struct BlobPayload {
 impl BlobPayload {
     pub(crate) fn from_bytes(bytes: impl Into<crate::Blob>) -> Self {
         let bytes = bytes.into();
-        let chunks = bytes
-            .chunks(MEDIA_CHUNK_BYTES)
-            .map(|chunk| BlobChunkReceipt {
-                hash: ChunkHash::from_content(chunk),
-                size_bytes: chunk.len() as u64,
+        // The one and only boundary search for these bytes. Staging rebuilds
+        // the ranges from the receipt sizes below.
+        let chunks = chunk_ranges(&bytes)
+            .into_iter()
+            .map(|(start, end)| BlobChunkReceipt {
+                hash: ChunkHash::from_content(&bytes[start..end]),
+                size_bytes: (end - start) as u64,
             })
             .collect::<Arc<[_]>>();
         let hash = match chunks.as_ref() {
@@ -169,9 +177,9 @@ impl BlobPayload {
         self.hash
     }
 
-    /// Canonical fixed-chunk identities derived from these exact immutable
-    /// bytes. Keeping the receipts inside the payload prevents CAS staging
-    /// from hashing every large-file chunk a second time.
+    /// Canonical chunk identities derived from these exact immutable bytes,
+    /// in order. Their sizes are also the payload's chunk layout, so staging
+    /// neither hashes nor re-searches for boundaries a second time.
     pub(crate) fn chunks(&self) -> &[BlobChunkReceipt] {
         &self.chunks
     }

--- a/packages/lix/src/changelog/gc.rs
+++ b/packages/lix/src/changelog/gc.rs
@@ -1,0 +1,133 @@
+//! Changelog-owned retirement of canonical records.
+//!
+//! Garbage collection proves unreachability from refs; it does not know which
+//! physical rows a commit projection or a standalone change occupies. These
+//! entry points keep that knowledge inside the module that writes those rows,
+//! so `changelog` remains the sole writer of its own storage spaces.
+
+use bytes::Bytes;
+
+use super::context::ChangelogContext;
+use super::store::{
+    CHANGE_SPACE, COMMIT_CHANGE_ID_SPACE, COMMIT_SPACE, ChangelogReader, change_key,
+    commit_change_id_key, commit_key,
+};
+use super::types::{ChangeId, CommitId, CommitLoadRequest};
+use crate::LixError;
+use crate::storage_adapter::{
+    PointReadPlan, StorageAdapterRead, StorageGetOptions, StorageKey, StorageWriteSet,
+};
+
+/// Removes the semantic commit projection once its root interval is no longer
+/// reachable. Physical tracked-state authority may remain alive as a selected
+/// source or serving dependency, so this decision is intentionally separate
+/// from manifest/CAS retirement.
+pub(crate) async fn stage_delete_commit_projection<S>(
+    store: &S,
+    writes: &mut StorageWriteSet,
+    commit_id: CommitId,
+) -> Result<(), LixError>
+where
+    S: StorageAdapterRead + ?Sized,
+{
+    let commit_ids = [commit_id];
+    let record = ChangelogContext::new()
+        .reader(store)
+        .load_commits(CommitLoadRequest {
+            commit_ids: &commit_ids,
+        })
+        .await?
+        .into_iter()
+        .next()
+        .and_then(|(_, record)| record);
+    let Some(record) = record else {
+        // A prior GC pass may already have removed the semantic projection
+        // while its physical authority remained pinned.
+        return Ok(());
+    };
+    if record.commit_id != commit_id {
+        return Err(LixError::new(
+            LixError::CODE_INTERNAL_ERROR,
+            format!(
+                "commit projection key for '{commit_id}' contains '{}'",
+                record.commit_id
+            ),
+        ));
+    }
+    writes.delete(COMMIT_SPACE, StorageKey(Bytes::from(commit_key(commit_id))));
+    writes.delete(
+        COMMIT_CHANGE_ID_SPACE,
+        StorageKey(Bytes::from(commit_change_id_key(record.change_id))),
+    );
+    writes.delete(
+        CHANGE_SPACE,
+        StorageKey(Bytes::from(change_key(record.change_id))),
+    );
+    Ok(())
+}
+
+/// Removes one standalone change record whose last owning branch control has
+/// been retired.
+///
+/// The record must still exist: a retired control naming an absent standalone
+/// fact means the ledger and the control plane already disagree, and deleting
+/// nothing would hide that.
+pub(crate) async fn stage_delete_standalone_change<S>(
+    store: &S,
+    writes: &mut StorageWriteSet,
+    change_id: ChangeId,
+) -> Result<(), LixError>
+where
+    S: StorageAdapterRead + ?Sized,
+{
+    let key = StorageKey(Bytes::from(change_key(change_id)));
+    let existing = PointReadPlan::new(CHANGE_SPACE, std::slice::from_ref(&key))
+        .materialize(store, StorageGetOptions::default())
+        .await?
+        .value
+        .into_iter()
+        .next()
+        .flatten();
+    if existing.is_none() {
+        return Err(LixError::new(
+            LixError::CODE_INTERNAL_ERROR,
+            format!("retired branch control references missing standalone change '{change_id}'"),
+        ));
+    }
+    writes.delete(CHANGE_SPACE, key);
+    Ok(())
+}
+
+/// Removes canonical commit projections in bulk.
+///
+/// Only the whole-repository oracle collector reaches this: ordinary GC
+/// retires one proven-unreachable projection at a time through
+/// [`stage_delete_commit_projection`].
+#[cfg(test)]
+pub(crate) fn stage_delete_commits(
+    writes: &mut StorageWriteSet,
+    commit_ids: impl IntoIterator<Item = CommitId>,
+) {
+    writes.delete_batch(COMMIT_SPACE, commit_ids.into_iter().map(commit_key));
+}
+
+/// Removes commit-derived reverse-index rows in bulk.
+#[cfg(test)]
+pub(crate) fn stage_delete_commit_change_ids(
+    writes: &mut StorageWriteSet,
+    change_ids: impl IntoIterator<Item = ChangeId>,
+) {
+    writes.delete_batch(
+        COMMIT_CHANGE_ID_SPACE,
+        change_ids.into_iter().map(commit_change_id_key),
+    );
+}
+
+/// Removes change records in bulk.
+#[cfg(test)]
+pub(crate) fn stage_delete_changes(
+    writes: &mut StorageWriteSet,
+    change_ids: impl IntoIterator<Item = ChangeId>,
+) {
+    writes.delete_batch(CHANGE_SPACE, change_ids.into_iter().map(change_key));
+}

--- a/packages/lix/src/changelog/mod.rs
+++ b/packages/lix/src/changelog/mod.rs
@@ -6,6 +6,7 @@ pub mod bench {
 }
 mod codec;
 mod context;
+mod gc;
 mod materialization;
 mod store;
 #[cfg(test)]
@@ -17,15 +18,15 @@ pub(crate) use codec::decode_change_record;
 pub(crate) use codec::encode_commit_record;
 pub(crate) use context::ChangelogContext;
 #[cfg(test)]
+pub(crate) use gc::{stage_delete_changes, stage_delete_commit_change_ids, stage_delete_commits};
+pub(crate) use gc::{stage_delete_commit_projection, stage_delete_standalone_change};
+#[cfg(test)]
 pub(crate) use materialization::MaterializedChangeIdentity;
 pub(crate) use materialization::{
     ChangeRecordProjection, MaterializedChangePayload, load_change_records,
     materialize_known_change_payloads, materialize_known_change_payloads_in_order,
 };
-pub(crate) use store::{
-    CHANGE_SPACE, COMMIT_CHANGE_ID_SPACE, COMMIT_SPACE, change_key, commit_change_id_key,
-    commit_key,
-};
+pub(crate) use store::{CHANGE_SPACE, COMMIT_CHANGE_ID_SPACE, COMMIT_SPACE, commit_key};
 pub(crate) use store::{ChangelogReader, ChangelogWriter};
 pub(crate) use types::{
     ChangeId, ChangeLoadBatch, ChangeLoadRequest, ChangeRecord, ChangeScanBatch, ChangeScanRequest,

--- a/packages/lix/src/engine.rs
+++ b/packages/lix/src/engine.rs
@@ -1707,8 +1707,9 @@ mod tests {
             .map(|row| {
                 (
                     row.get::<String>("path").expect("path should decode"),
-                    row.get::<Option<String>>("lixcol_file_id")
-                        .expect("file id should decode"),
+                    // `lixcol_file_id` is nullable; the typed accessor has no
+                    // Option impl, so a NULL surfaces as a decode error here.
+                    row.get::<String>("lixcol_file_id").ok(),
                 )
             })
             .collect::<Vec<_>>();

--- a/packages/lix/src/engine.rs
+++ b/packages/lix/src/engine.rs
@@ -1387,6 +1387,215 @@ mod tests {
         );
     }
 
+    /// The two working-diff read paths in `hot_working_diff_entries` must
+    /// answer identically for every row state a branch can actually reach.
+    ///
+    /// The broad path enumerates the sparse `HOT_DIFF` index and then loads
+    /// each dirty identity's primary row; the finite `schema_key + entity_pk`
+    /// path skips that index entirely and reads the primary rows directly.
+    /// They treat an untracked or absent primary row differently — the broad
+    /// path fails closed to canonical replay, the finite path skips the row —
+    /// so this walks every reachable shape (clean, modified, removed,
+    /// added, added-then-removed, untracked, untracked-recycled-as-tracked,
+    /// never-existed) and asserts the finite answer equals the broad answer
+    /// restricted to that identity.
+    #[tokio::test]
+    async fn working_diff_finite_bypass_and_index_scan_agree_on_every_row_state() {
+        let storage = Memory::new();
+        Engine::initialize(storage.clone())
+            .await
+            .expect("engine should initialize");
+        let engine = Engine::new(storage.clone())
+            .await
+            .expect("initialized engine should open");
+        let session = engine
+            .open_workspace_session()
+            .await
+            .expect("workspace session should open");
+        register_json_pointer_schema(&session).await;
+
+        for path in ["/clean", "/modified", "/removed", "/recycled-source"] {
+            session
+                .execute(
+                    "INSERT INTO json_pointer (path, value) VALUES ($1, lix_json('{\"v\":0}'))",
+                    &[crate::Value::Text(path.to_string())],
+                )
+                .await
+                .expect("pre-checkpoint tracked row should commit");
+        }
+        session
+            .execute(
+                "DELETE FROM json_pointer WHERE path = '/recycled-source'",
+                &[],
+            )
+            .await
+            .expect("pre-checkpoint delete should commit");
+        session
+            .create_checkpoint()
+            .await
+            .expect("checkpoint should publish a clean working state");
+
+        session
+            .execute(
+                "UPDATE json_pointer SET value = lix_json('{\"v\":1}') WHERE path = '/modified'",
+                &[],
+            )
+            .await
+            .expect("modify should dirty the row");
+        session
+            .execute("DELETE FROM json_pointer WHERE path = '/removed'", &[])
+            .await
+            .expect("delete should dirty the row");
+        session
+            .execute(
+                "INSERT INTO json_pointer (path, value) VALUES ('/added', lix_json('{\"v\":1}'))",
+                &[],
+            )
+            .await
+            .expect("insert should dirty a new identity");
+        session
+            .execute(
+                "INSERT INTO json_pointer (path, value) \
+                 VALUES ('/added-then-removed', lix_json('{\"v\":1}'))",
+                &[],
+            )
+            .await
+            .expect("insert should dirty a new identity");
+        session
+            .execute(
+                "DELETE FROM json_pointer WHERE path = '/added-then-removed'",
+                &[],
+            )
+            .await
+            .expect("delete of a post-checkpoint insert should commit");
+        session
+            .execute(
+                "INSERT INTO json_pointer (path, value, lixcol_untracked) \
+                 VALUES ('/untracked', lix_json('{\"v\":1}'), true)",
+                &[],
+            )
+            .await
+            .expect("untracked insert should commit");
+
+        // Physically removing a HOT primary row is only reachable through an
+        // untracked delete (`CurrentStateDelta::physically_deletes` is
+        // `untracked && deleted`). Exercise that, then re-insert the identity
+        // as tracked so a dirty row exists whose HOT slot was previously
+        // vacated.
+        session
+            .execute(
+                "INSERT INTO json_pointer (path, value, lixcol_untracked) \
+                 VALUES ('/recycled', lix_json('{\"v\":1}'), true)",
+                &[],
+            )
+            .await
+            .expect("untracked insert should commit");
+        session
+            .execute("DELETE FROM json_pointer WHERE path = '/recycled'", &[])
+            .await
+            .expect("untracked delete should physically remove the hot row");
+        session
+            .execute(
+                "INSERT INTO json_pointer (path, value) \
+                 VALUES ('/recycled', lix_json('{\"v\":2}'))",
+                &[],
+            )
+            .await
+            .expect("tracked insert should reuse the vacated identity");
+
+        // The invariant that makes the two paths equivalent: retention is
+        // immutable while a physical member exists, so a dirty tracked row can
+        // never become untracked or vanish under its own `HOT_DIFF` entry.
+        let retention_flip = session
+            .execute(
+                "INSERT INTO json_pointer (path, value, lixcol_untracked) \
+                 VALUES ('/modified', lix_json('{\"v\":9}'), true)",
+                &[],
+            )
+            .await;
+        assert!(
+            retention_flip.is_err(),
+            "an untracked write must not take over a dirty tracked identity"
+        );
+
+        let broad = session
+            .execute(
+                "SELECT entity_pk, diff_type FROM lix_working_diff \
+                 WHERE schema_key = 'json_pointer' ORDER BY entity_pk",
+                &[],
+            )
+            .await
+            .expect("broad working-diff read should execute");
+        let broad_rows = broad
+            .rows()
+            .iter()
+            .map(|row| {
+                (
+                    row.get::<serde_json::Value>("entity_pk")
+                        .expect("entity_pk should decode")
+                        .to_string(),
+                    row.get::<String>("diff_type")
+                        .expect("diff_type should decode"),
+                )
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(
+            broad_rows,
+            vec![
+                ("[\"/added\"]".to_string(), "added".to_string()),
+                ("[\"/modified\"]".to_string(), "modified".to_string()),
+                ("[\"/recycled\"]".to_string(), "added".to_string()),
+                ("[\"/removed\"]".to_string(), "removed".to_string()),
+            ],
+            "the index-driven working diff must classify every reachable shape"
+        );
+
+        for path in [
+            "/clean",
+            "/modified",
+            "/removed",
+            "/added",
+            "/added-then-removed",
+            "/untracked",
+            "/recycled",
+            "/recycled-source",
+            "/never-existed",
+        ] {
+            let entity_pk = format!("[\"{path}\"]");
+            let finite = session
+                .execute(
+                    "SELECT entity_pk, diff_type FROM lix_working_diff \
+                     WHERE schema_key = 'json_pointer' AND entity_pk = lix_json($1) \
+                     ORDER BY entity_pk",
+                    &[crate::Value::Text(entity_pk.clone())],
+                )
+                .await
+                .expect("finite working-diff read should execute");
+            let finite_rows = finite
+                .rows()
+                .iter()
+                .map(|row| {
+                    (
+                        row.get::<serde_json::Value>("entity_pk")
+                            .expect("entity_pk should decode")
+                            .to_string(),
+                        row.get::<String>("diff_type")
+                            .expect("diff_type should decode"),
+                    )
+                })
+                .collect::<Vec<_>>();
+            let expected = broad_rows
+                .iter()
+                .filter(|(row_pk, _)| row_pk == &entity_pk)
+                .cloned()
+                .collect::<Vec<_>>();
+            assert_eq!(
+                finite_rows, expected,
+                "the finite working-diff bypass disagrees with the index scan for {path}"
+            );
+        }
+    }
+
     #[tokio::test]
     async fn untracked_state_survives_checkpoint_and_next_tracked_write() {
         let storage = Memory::new();

--- a/packages/lix/src/engine.rs
+++ b/packages/lix/src/engine.rs
@@ -1518,6 +1518,9 @@ mod tests {
             "an untracked write must not take over a dirty tracked identity"
         );
 
+        use std::sync::atomic::Ordering;
+        let hits = &crate::live_state::WORKING_DIFF_PATH_HITS;
+        let index_before = hits.index_scan.load(Ordering::Relaxed);
         let broad = session
             .execute(
                 "SELECT entity_pk, diff_type FROM lix_working_diff \
@@ -1526,6 +1529,10 @@ mod tests {
             )
             .await
             .expect("broad working-diff read should execute");
+        assert!(
+            hits.index_scan.load(Ordering::Relaxed) > index_before,
+            "the schema-only working-diff read must take the HOT_DIFF index path"
+        );
         let broad_rows = broad
             .rows()
             .iter()
@@ -1562,6 +1569,7 @@ mod tests {
             "/never-existed",
         ] {
             let entity_pk = format!("[\"{path}\"]");
+            let bypass_before = hits.finite_bypass.load(Ordering::Relaxed);
             let finite = session
                 .execute(
                     "SELECT entity_pk, diff_type FROM lix_working_diff \
@@ -1571,6 +1579,10 @@ mod tests {
                 )
                 .await
                 .expect("finite working-diff read should execute");
+            assert!(
+                hits.finite_bypass.load(Ordering::Relaxed) > bypass_before,
+                "the finite working-diff read for {path} must take the primary-row bypass"
+            );
             let finite_rows = finite
                 .rows()
                 .iter()
@@ -1594,6 +1606,186 @@ mod tests {
                 "the finite working-diff bypass disagrees with the index scan for {path}"
             );
         }
+    }
+
+    /// `WHERE lixcol_file_id = ?` is now an exact provider constraint, so
+    /// DataFusion drops its residual filter and the answer rests entirely on
+    /// `LiveStateFilter::file_ids`. Rows can live in four authorities — the
+    /// branch-local `HOT_ROW` overlay, a packed current base, a certified
+    /// entity batch, and the root current base — and a file-scoped seek is
+    /// only sound if every one of them applies the same filter. The checkpoint
+    /// in the middle republishes the generation, so rows written before and
+    /// after it reach the read through different authorities.
+    #[tokio::test]
+    async fn file_scoped_entity_read_matches_the_unfiltered_scan() {
+        let storage = Memory::new();
+        Engine::initialize(storage.clone())
+            .await
+            .expect("engine should initialize");
+        let engine = Engine::new(storage.clone())
+            .await
+            .expect("initialized engine should open");
+        let session = engine
+            .open_workspace_session()
+            .await
+            .expect("workspace session should open");
+        register_json_pointer_schema(&session).await;
+
+        let files = ["66696c65-0000-8000-8000-000000000000", "66696c65-0001-8000-8000-000000000001"];
+        for (index, file) in files.iter().enumerate() {
+            session
+                .execute(
+                    "INSERT INTO lix_file (id, path, content) \
+                     VALUES ($1, $2, CAST($3 AS BYTEA))",
+                    &[
+                        crate::Value::Text((*file).to_string()),
+                        crate::Value::Text(format!("/f{index}.txt")),
+                        crate::Value::Text("seed".to_string()),
+                    ],
+                )
+                .await
+                .expect("file should insert");
+        }
+
+        let mut expected: Vec<(String, Option<String>)> = Vec::new();
+        for (path, file) in [
+            ("/a0", Some(files[0])),
+            ("/a1", Some(files[0])),
+            ("/b0", Some(files[1])),
+            ("/none", None),
+        ] {
+            session
+                .execute(
+                    "INSERT INTO json_pointer (path, value, lixcol_file_id) \
+                     VALUES ($1, lix_json('{\"v\":0}'), $2)",
+                    &[
+                        crate::Value::Text(path.to_string()),
+                        file.map_or(crate::Value::Null, |file| {
+                            crate::Value::Text(file.to_string())
+                        }),
+                    ],
+                )
+                .await
+                .expect("pre-checkpoint row should insert");
+            expected.push((path.to_string(), file.map(str::to_string)));
+        }
+
+        session
+            .create_checkpoint()
+            .await
+            .expect("checkpoint should republish the generation");
+
+        for (path, file) in [
+            ("/a2", Some(files[0])),
+            ("/b1", Some(files[1])),
+            ("/none2", None),
+        ] {
+            session
+                .execute(
+                    "INSERT INTO json_pointer (path, value, lixcol_file_id) \
+                     VALUES ($1, lix_json('{\"v\":1}'), $2)",
+                    &[
+                        crate::Value::Text(path.to_string()),
+                        file.map_or(crate::Value::Null, |file| {
+                            crate::Value::Text(file.to_string())
+                        }),
+                    ],
+                )
+                .await
+                .expect("post-checkpoint row should insert");
+            expected.push((path.to_string(), file.map(str::to_string)));
+        }
+        expected.sort();
+
+        let all = session
+            .execute("SELECT path, lixcol_file_id FROM json_pointer", &[])
+            .await
+            .expect("unfiltered scan should execute");
+        let mut all_rows = all
+            .rows()
+            .iter()
+            .map(|row| {
+                (
+                    row.get::<String>("path").expect("path should decode"),
+                    row.get::<Option<String>>("lixcol_file_id")
+                        .expect("file id should decode"),
+                )
+            })
+            .collect::<Vec<_>>();
+        all_rows.sort();
+        assert_eq!(all_rows, expected, "fixture should read back unfiltered");
+
+        for file in files {
+            let filtered = session
+                .execute(
+                    "SELECT path FROM json_pointer WHERE lixcol_file_id = $1 ORDER BY path",
+                    &[crate::Value::Text(file.to_string())],
+                )
+                .await
+                .expect("file-scoped read should execute");
+            let filtered_rows = filtered
+                .rows()
+                .iter()
+                .map(|row| row.get::<String>("path").expect("path should decode"))
+                .collect::<Vec<_>>();
+            let mut want = expected
+                .iter()
+                .filter(|(_, row_file)| row_file.as_deref() == Some(file))
+                .map(|(path, _)| path.clone())
+                .collect::<Vec<_>>();
+            want.sort();
+            assert_eq!(
+                filtered_rows, want,
+                "file-scoped entity read must return exactly the rows in {file}"
+            );
+        }
+
+        let in_list = session
+            .execute(
+                "SELECT path FROM json_pointer \
+                 WHERE lixcol_file_id IN ($1, $2) ORDER BY path",
+                &[
+                    crate::Value::Text(files[0].to_string()),
+                    crate::Value::Text(files[1].to_string()),
+                ],
+            )
+            .await
+            .expect("file-scoped IN read should execute");
+        let mut want_in = expected
+            .iter()
+            .filter(|(_, row_file)| row_file.is_some())
+            .map(|(path, _)| path.clone())
+            .collect::<Vec<_>>();
+        want_in.sort();
+        assert_eq!(
+            in_list
+                .rows()
+                .iter()
+                .map(|row| row.get::<String>("path").expect("path should decode"))
+                .collect::<Vec<_>>(),
+            want_in
+        );
+
+        let point = session
+            .execute(
+                "SELECT path FROM json_pointer WHERE lixcol_file_id = $1 AND path = '/a2'",
+                &[crate::Value::Text(files[0].to_string())],
+            )
+            .await
+            .expect("file + primary key read should execute");
+        assert_eq!(point.rows().len(), 1);
+
+        let contradiction = session
+            .execute(
+                "SELECT path FROM json_pointer WHERE lixcol_file_id = $1 AND path = '/b0'",
+                &[crate::Value::Text(files[0].to_string())],
+            )
+            .await
+            .expect("contradictory file + primary key read should execute");
+        assert!(
+            contradiction.rows().is_empty(),
+            "a row must not be visible through another file's scope"
+        );
     }
 
     #[tokio::test]

--- a/packages/lix/src/gc.rs
+++ b/packages/lix/src/gc.rs
@@ -6,7 +6,6 @@
 //! the same storage write set that publishes the compacted checkpoint.
 
 use std::collections::{BTreeMap, BTreeSet};
-use std::ops::Bound;
 use std::time::Instant;
 
 use bytes::Bytes;
@@ -15,15 +14,11 @@ use crate::branch::{
     BranchHeadControl, BranchHeadControlContext, BranchHeadTrackedReachability,
     branch_head_control_precondition,
 };
-#[cfg(any(test, feature = "storage-benches"))]
-use crate::changelog::ChangeScanRequest;
-use crate::changelog::{
-    CHANGE_SPACE, COMMIT_CHANGE_ID_SPACE, COMMIT_SPACE, ChangeId, ChangelogContext,
-    ChangelogReader, CommitId, CommitLoadRequest, GcLiveSet, GcPlan, GcRepairSet, GcRoot,
-    GcSweepSet, change_key, commit_change_id_key, commit_key,
-};
+use crate::changelog::{ChangeId, CommitId, GcLiveSet, GcPlan, GcRepairSet, GcRoot, GcSweepSet};
 #[cfg(test)]
 use crate::changelog::{ChangeRecord, CommitScanRequest};
+#[cfg(any(test, feature = "storage-benches"))]
+use crate::changelog::{ChangeScanRequest, ChangelogContext, ChangelogReader};
 use crate::commit_graph::CommitGraphContext;
 #[cfg(test)]
 use crate::json_store::JsonRef;
@@ -34,11 +29,14 @@ use crate::json_store::{
 use crate::live_state::TrackedHeadContext;
 #[cfg(test)]
 use crate::live_state::stage_collect_stale_working_diff_indexes;
+#[cfg(test)]
+use crate::storage_adapter::StorageCoreProjection;
 use crate::storage_adapter::{
-    PointReadPlan, StorageAdapterRead, StorageBeginScanOptions, StorageCoreProjection,
-    StorageGetOptions, StorageKey, StorageKeyRange, StoragePrecondition, StoragePrefix,
-    StorageProjectedValue, StorageSpace, StorageSpaceId, StorageValue, StorageWriteSet,
+    PointReadPlan, StorageAdapterRead, StorageBeginScanOptions, StorageGetOptions, StorageKey,
+    StoragePrecondition, StoragePrefix, StorageProjectedValue, StorageSpace, StorageSpaceId,
+    StorageValue, StorageWriteSet,
 };
+use crate::tracked_state::RetainedPhysicalState;
 use crate::{LixError, storage_codec};
 
 pub(crate) const CHECKPOINT_RECOVERY_REF_NAMESPACE: &str = "checkpoint.recovery_ref.v3";
@@ -58,36 +56,12 @@ pub(crate) const GC_REACHABILITY_DELTA_SPACE: StorageSpace =
 pub(crate) const GC_REACHABILITY_QUEUE_NAMESPACE: &str = "gc.reachability_queue.v1";
 pub(crate) const GC_REACHABILITY_QUEUE_SPACE: StorageSpace =
     StorageSpace::mutable(StorageSpaceId(0x0008_0004), GC_REACHABILITY_QUEUE_NAMESPACE);
-/// Rebuildable metadata for an explicit tree-chunk sweep epoch. It is never
-/// consulted as a serving root; the active root closure is re-derived from
-/// branch/recovery controls and authenticated commit manifests.
-pub(crate) const GC_TREE_SWEEP_EPOCH_NAMESPACE: &str = "gc.tree_sweep_epoch.v1";
-pub(crate) const GC_TREE_SWEEP_EPOCH_SPACE: StorageSpace =
-    StorageSpace::mutable(StorageSpaceId(0x0008_0005), GC_TREE_SWEEP_EPOCH_NAMESPACE);
-/// One rebuildable live-chunk mark per content hash for the current epoch.
-pub(crate) const GC_TREE_SWEEP_MARK_NAMESPACE: &str = "gc.tree_sweep_mark.v1";
-pub(crate) const GC_TREE_SWEEP_MARK_SPACE: StorageSpace =
-    StorageSpace::mutable(StorageSpaceId(0x0008_0006), GC_TREE_SWEEP_MARK_NAMESPACE);
-/// CAS-protected bounded cursor for an in-progress tree-chunk enumeration.
-pub(crate) const GC_TREE_SWEEP_CURSOR_NAMESPACE: &str = "gc.tree_sweep_cursor.v1";
-pub(crate) const GC_TREE_SWEEP_CURSOR_SPACE: StorageSpace =
-    StorageSpace::mutable(StorageSpaceId(0x0008_0007), GC_TREE_SWEEP_CURSOR_NAMESPACE);
-
 const CHECKPOINT_RECOVERY_REF_FORMAT_VERSION: u32 = 3;
 const CHECKPOINT_GC_STATE_FORMAT_VERSION: u32 = 1;
 const CHECKPOINT_GC_STATE_KEY: &[u8] = b"repository";
 const GC_REACHABILITY_FORMAT_VERSION: u32 = 2;
 const GC_REACHABILITY_QUEUE_KEY: &[u8] = b"queue";
 const GC_REACHABILITY_BATCH_LIMIT: usize = 64;
-#[allow(dead_code)]
-const GC_TREE_SWEEP_EPOCH_KEY: &[u8] = b"epoch";
-#[allow(dead_code)]
-const GC_TREE_SWEEP_CURSOR_KEY: &[u8] = b"cursor";
-#[allow(dead_code)]
-const GC_TREE_SWEEP_FORMAT_VERSION: u32 = 1;
-#[allow(dead_code)]
-const GC_TREE_SWEEP_PAGE_ROWS: usize = 64;
-
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct AuthenticatedControlCommitReachability {
     chronology_roots: BTreeSet<CommitId>,
@@ -279,61 +253,6 @@ struct StoredReachabilityQueue {
     head_sequence: u64,
     tail_sequence: u64,
     next_sequence: u64,
-}
-
-/// Authenticated metadata for one explicit tree-chunk sweep epoch. The root
-/// and closure digests are evidence for resumption only; immutable manifests
-/// and branch/recovery controls remain the sole logical root authority.
-#[derive(Clone, Debug, Eq, PartialEq, musli::Encode, musli::Decode)]
-#[musli(packed)]
-#[allow(dead_code)]
-struct StoredTreeSweepEpoch {
-    format_version: u32,
-    epoch_id: u64,
-    queue_digest: [u8; 32],
-    root_set_digest: [u8; 32],
-    live_chunk_digest: [u8; 32],
-    live_chunk_count: u64,
-}
-
-/// CAS-protected bounded enumeration cursor. A completed cursor is retained
-/// until the next epoch so an interrupted/reopened maintenance pass can
-/// distinguish a resumable epoch from a fresh one.
-#[derive(Clone, Debug, Eq, PartialEq, musli::Encode, musli::Decode)]
-#[musli(packed)]
-#[allow(dead_code)]
-struct StoredTreeSweepCursor {
-    format_version: u32,
-    epoch_id: u64,
-    #[musli(with = storage_codec::option)]
-    last_key: Option<Vec<u8>>,
-    scanned_rows: u64,
-    deleted_rows: u64,
-    complete: bool,
-}
-
-/// A mark is rebuildable inventory, not payload truth. The hash in the key,
-/// value, and epoch are all checked before a sweep can delete an unmarked
-/// tree chunk.
-#[derive(Clone, Debug, Eq, PartialEq, musli::Encode, musli::Decode)]
-#[musli(packed)]
-#[allow(dead_code)]
-struct StoredTreeSweepMark {
-    format_version: u32,
-    epoch_id: u64,
-    chunk_hash: [u8; 32],
-}
-
-/// In-memory state for one authenticated sweep epoch. The live set is loaded
-/// and verified once when the session starts or reopens; ordinary queue-prefix
-/// GC never consults it.
-#[derive(Clone, Debug)]
-#[allow(dead_code)]
-pub(crate) struct TreeSweepEpochSession {
-    epoch: StoredTreeSweepEpoch,
-    cursor: StoredTreeSweepCursor,
-    raw_cursor: Bytes,
-    live_chunks: BTreeSet<[u8; 32]>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -770,20 +689,6 @@ fn decode_reachability_batch(
     Ok(batch)
 }
 
-#[allow(dead_code)]
-fn tree_sweep_error(message: impl Into<String>) -> LixError {
-    LixError::new(LixError::CODE_INTERNAL_ERROR, message)
-}
-
-#[allow(dead_code)]
-fn tree_sweep_digest(hashes: &BTreeSet<[u8; 32]>) -> [u8; 32] {
-    let mut hasher = blake3::Hasher::new();
-    for hash in hashes {
-        hasher.update(hash);
-    }
-    *hasher.finalize().as_bytes()
-}
-
 async fn collect_all_reachability_checkpoint_roots<S>(
     store: &S,
     queue: &StoredReachabilityQueue,
@@ -902,562 +807,6 @@ where
     .with_hint(
         "The commit is no longer an authenticated branchable root after checkpoint compaction.",
     ))
-}
-
-#[allow(dead_code)]
-async fn load_tree_sweep_root_closure<S>(
-    store: &S,
-) -> Result<([u8; 32], [u8; 32], Bytes, BTreeSet<[u8; 32]>), LixError>
-where
-    S: StorageAdapterRead + Clone + Send + Sync,
-{
-    let controls = BranchHeadControlContext::new()
-        .reader(store.clone())
-        .scan()
-        .await?;
-    let (queue, raw_queue) = load_reachability_queue(store).await?;
-    let closure = load_authenticated_repository_retention(store, &controls, &queue).await?;
-    let mut roots = BTreeSet::new();
-    for manifest in closure.manifests.values() {
-        if let Some(snapshot_root) = manifest.snapshot_root.as_ref() {
-            roots.insert(*snapshot_root.root_id.as_bytes());
-            for parent in &snapshot_root.parent_roots {
-                roots.insert(*parent.root_id.as_bytes());
-            }
-        }
-    }
-    if roots.is_empty() {
-        return Err(tree_sweep_error(
-            "tree sweep authenticated root set has no tracked tree roots",
-        ));
-    }
-    let root_set_digest = tree_sweep_digest(&roots);
-    let typed_roots = roots
-        .iter()
-        .copied()
-        .map(crate::tracked_state::TrackedStateRootId::new)
-        .collect::<Vec<_>>();
-    let live_chunks =
-        crate::tracked_state::collect_reachable_tree_chunk_hashes(store, &typed_roots).await?;
-    if live_chunks.is_empty() {
-        return Err(tree_sweep_error(
-            "tree sweep authenticated root closure is empty",
-        ));
-    }
-    Ok((
-        root_set_digest,
-        tree_sweep_digest(&live_chunks),
-        raw_queue,
-        live_chunks,
-    ))
-}
-
-#[allow(dead_code)]
-async fn scan_tree_sweep_marks<S>(
-    store: &S,
-    expected_epoch: Option<u64>,
-) -> Result<(BTreeSet<[u8; 32]>, BTreeSet<[u8; 32]>), LixError>
-where
-    S: StorageAdapterRead + ?Sized,
-{
-    let range = StoragePrefix {
-        bytes: Bytes::new(),
-    }
-    .to_range()?;
-    let mut previous_key = None;
-    let mut current = BTreeSet::new();
-    let mut all = BTreeSet::new();
-    let mut cursor = store
-        .begin_scan(
-            GC_TREE_SWEEP_MARK_SPACE,
-            range,
-            StorageBeginScanOptions {
-                projection: StorageCoreProjection::FullValue,
-                ..StorageBeginScanOptions::default()
-            },
-        )
-        .await?;
-    loop {
-        let page = cursor.next_page(GC_TREE_SWEEP_PAGE_ROWS).await?;
-        if page.has_more && page.entries.is_empty() {
-            return Err(tree_sweep_error(
-                "tree sweep mark scan reported has_more with an empty page",
-            ));
-        }
-        for entry in &page.entries {
-            if entry.key.0.len() != 32
-                || previous_key
-                    .as_ref()
-                    .is_some_and(|previous: &StorageKey| entry.key <= *previous)
-            {
-                return Err(tree_sweep_error(
-                    "tree sweep mark scan keys are malformed or non-increasing",
-                ));
-            }
-            let key_hash: [u8; 32] = entry
-                .key
-                .0
-                .as_ref()
-                .try_into()
-                .map_err(|_| tree_sweep_error("tree sweep mark key is not 32 bytes"))?;
-            let StorageProjectedValue::FullValue(bytes) = &entry.value else {
-                return Err(tree_sweep_error(
-                    "tree sweep mark scan returned a key-only value",
-                ));
-            };
-            let mark: StoredTreeSweepMark = storage_codec::decode("tree sweep mark", bytes)
-                .map_err(|error| {
-                    tree_sweep_error(format!("tree sweep mark is malformed: {error}"))
-                })?;
-            if mark.format_version != GC_TREE_SWEEP_FORMAT_VERSION || mark.chunk_hash != key_hash {
-                return Err(tree_sweep_error(
-                    "tree sweep mark identity or format is invalid",
-                ));
-            }
-            all.insert(key_hash);
-            if expected_epoch.is_none_or(|epoch| mark.epoch_id == epoch) {
-                current.insert(key_hash);
-            }
-            previous_key = Some(entry.key.clone());
-        }
-        if page.entries.is_empty() {
-            if page.has_more {
-                return Err(tree_sweep_error(
-                    "tree sweep mark scan has_more without a resume key",
-                ));
-            }
-            break;
-        }
-        if !page.has_more {
-            break;
-        }
-    }
-    Ok((current, all))
-}
-
-#[allow(dead_code)]
-async fn load_optional_tree_sweep_row<S, T>(
-    store: &S,
-    space: StorageSpace,
-    key: &'static [u8],
-    label: &'static str,
-) -> Result<Option<(T, Bytes)>, LixError>
-where
-    S: StorageAdapterRead + ?Sized,
-    T: for<'de> musli::Decode<'de, musli::mode::Binary, musli::alloc::Global>,
-{
-    let key = StorageKey(Bytes::from_static(key));
-    let value = PointReadPlan::new(space, std::slice::from_ref(&key))
-        .materialize(store, StorageGetOptions::default())
-        .await?
-        .value
-        .into_iter()
-        .next()
-        .flatten();
-    let Some(StorageProjectedValue::FullValue(bytes)) = value else {
-        return Ok(None);
-    };
-    let decoded = storage_codec::decode(label, &bytes)?;
-    Ok(Some((decoded, bytes)))
-}
-
-/// Starts a new authenticated tree sweep epoch. The expensive root closure
-/// and mark inventory are built once here; ordinary queue-prefix GC never
-/// calls this function.
-#[allow(dead_code)]
-pub(crate) async fn begin_tree_sweep_epoch<S>(
-    store: &S,
-    writes: &mut StorageWriteSet,
-    preconditions: &mut Vec<StoragePrecondition>,
-) -> Result<TreeSweepEpochSession, LixError>
-where
-    S: StorageAdapterRead + Clone + Send + Sync,
-{
-    let old_epoch = load_optional_tree_sweep_row::<S, StoredTreeSweepEpoch>(
-        store,
-        GC_TREE_SWEEP_EPOCH_SPACE,
-        GC_TREE_SWEEP_EPOCH_KEY,
-        "tree sweep epoch",
-    )
-    .await?;
-    let old_cursor = load_optional_tree_sweep_row::<S, StoredTreeSweepCursor>(
-        store,
-        GC_TREE_SWEEP_CURSOR_SPACE,
-        GC_TREE_SWEEP_CURSOR_KEY,
-        "tree sweep cursor",
-    )
-    .await?;
-    if old_epoch.is_some() != old_cursor.is_some() {
-        return Err(tree_sweep_error(
-            "tree sweep epoch and cursor lifecycle rows disagree",
-        ));
-    }
-    if old_cursor
-        .as_ref()
-        .is_some_and(|(cursor, _)| !cursor.complete)
-    {
-        return Err(tree_sweep_error(
-            "tree sweep epoch is already active; reopen it instead of creating a second epoch",
-        ));
-    }
-    let (root_set_digest, live_chunk_digest, raw_queue, live_chunks) =
-        load_tree_sweep_root_closure(store).await?;
-    let epoch_id = old_epoch
-        .as_ref()
-        .map_or(1, |(epoch, _)| epoch.epoch_id.saturating_add(1));
-    let epoch = StoredTreeSweepEpoch {
-        format_version: GC_TREE_SWEEP_FORMAT_VERSION,
-        epoch_id,
-        queue_digest: *blake3::hash(&raw_queue).as_bytes(),
-        root_set_digest,
-        live_chunk_digest,
-        live_chunk_count: live_chunks.len() as u64,
-    };
-    let cursor = StoredTreeSweepCursor {
-        format_version: GC_TREE_SWEEP_FORMAT_VERSION,
-        epoch_id,
-        last_key: None,
-        scanned_rows: 0,
-        deleted_rows: 0,
-        complete: false,
-    };
-    let (current_marks, all_marks) = scan_tree_sweep_marks(store, None).await?;
-    let _ = current_marks;
-    for hash in all_marks.difference(&live_chunks) {
-        writes.delete(
-            GC_TREE_SWEEP_MARK_SPACE,
-            StorageKey(Bytes::copy_from_slice(hash)),
-        );
-    }
-    for hash in &live_chunks {
-        let mark = StoredTreeSweepMark {
-            format_version: GC_TREE_SWEEP_FORMAT_VERSION,
-            epoch_id,
-            chunk_hash: *hash,
-        };
-        writes.put(
-            GC_TREE_SWEEP_MARK_SPACE,
-            StorageKey(Bytes::copy_from_slice(hash)),
-            StorageValue {
-                bytes: Bytes::from(storage_codec::encode("tree sweep mark", &mark)?),
-            },
-        );
-    }
-    let epoch_bytes = Bytes::from(storage_codec::encode("tree sweep epoch", &epoch)?);
-    let cursor_bytes = Bytes::from(storage_codec::encode("tree sweep cursor", &cursor)?);
-    writes.put(
-        GC_TREE_SWEEP_EPOCH_SPACE,
-        StorageKey(Bytes::from_static(GC_TREE_SWEEP_EPOCH_KEY)),
-        StorageValue { bytes: epoch_bytes },
-    );
-    writes.put(
-        GC_TREE_SWEEP_CURSOR_SPACE,
-        StorageKey(Bytes::from_static(GC_TREE_SWEEP_CURSOR_KEY)),
-        StorageValue {
-            bytes: cursor_bytes.clone(),
-        },
-    );
-    preconditions.push(StoragePrecondition::KeyValueEquals {
-        space: GC_REACHABILITY_QUEUE_SPACE,
-        key: StorageKey(Bytes::from_static(GC_REACHABILITY_QUEUE_KEY)),
-        expected: raw_queue,
-    });
-    if let Some((_, raw)) = old_epoch {
-        preconditions.push(StoragePrecondition::KeyValueEquals {
-            space: GC_TREE_SWEEP_EPOCH_SPACE,
-            key: StorageKey(Bytes::from_static(GC_TREE_SWEEP_EPOCH_KEY)),
-            expected: raw,
-        });
-    } else {
-        preconditions.push(StoragePrecondition::KeyAbsent {
-            space: GC_TREE_SWEEP_EPOCH_SPACE,
-            key: StorageKey(Bytes::from_static(GC_TREE_SWEEP_EPOCH_KEY)),
-        });
-    }
-    if let Some((_, raw)) = old_cursor {
-        preconditions.push(StoragePrecondition::KeyValueEquals {
-            space: GC_TREE_SWEEP_CURSOR_SPACE,
-            key: StorageKey(Bytes::from_static(GC_TREE_SWEEP_CURSOR_KEY)),
-            expected: raw,
-        });
-    } else {
-        preconditions.push(StoragePrecondition::KeyAbsent {
-            space: GC_TREE_SWEEP_CURSOR_SPACE,
-            key: StorageKey(Bytes::from_static(GC_TREE_SWEEP_CURSOR_KEY)),
-        });
-    }
-    Ok(TreeSweepEpochSession {
-        epoch,
-        cursor,
-        raw_cursor: cursor_bytes,
-        live_chunks,
-    })
-}
-
-/// Reopens an active or completed epoch. Mark rows are fully authenticated
-/// against the persisted count/digest before any page may stage a delete.
-#[allow(dead_code)]
-pub(crate) async fn open_tree_sweep_epoch<S>(
-    store: &S,
-) -> Result<Option<TreeSweepEpochSession>, LixError>
-where
-    S: StorageAdapterRead + ?Sized,
-{
-    let Some((epoch, _)) = load_optional_tree_sweep_row::<S, StoredTreeSweepEpoch>(
-        store,
-        GC_TREE_SWEEP_EPOCH_SPACE,
-        GC_TREE_SWEEP_EPOCH_KEY,
-        "tree sweep epoch",
-    )
-    .await?
-    else {
-        return Ok(None);
-    };
-    if epoch.format_version != GC_TREE_SWEEP_FORMAT_VERSION {
-        return Err(tree_sweep_error("tree sweep epoch format is unsupported"));
-    }
-    let Some((cursor, raw_cursor)) = load_optional_tree_sweep_row::<S, StoredTreeSweepCursor>(
-        store,
-        GC_TREE_SWEEP_CURSOR_SPACE,
-        GC_TREE_SWEEP_CURSOR_KEY,
-        "tree sweep cursor",
-    )
-    .await?
-    else {
-        return Err(tree_sweep_error("tree sweep cursor is missing"));
-    };
-    if cursor.format_version != GC_TREE_SWEEP_FORMAT_VERSION || cursor.epoch_id != epoch.epoch_id {
-        return Err(tree_sweep_error("tree sweep cursor identity is invalid"));
-    }
-    let (live_chunks, all_marks) = scan_tree_sweep_marks(store, Some(epoch.epoch_id)).await?;
-    if live_chunks != all_marks
-        || live_chunks.len() as u64 != epoch.live_chunk_count
-        || tree_sweep_digest(&live_chunks) != epoch.live_chunk_digest
-    {
-        return Err(tree_sweep_error(
-            "tree sweep mark inventory disagrees with epoch closure or contains stale rows",
-        ));
-    }
-    Ok(Some(TreeSweepEpochSession {
-        epoch,
-        cursor,
-        raw_cursor,
-        live_chunks,
-    }))
-}
-
-/// Enumerates one bounded tree-chunk page and stages only chunks absent from
-/// the authenticated epoch mark set. Every key/value and cursor transition is
-/// validated before staging; the queue and cursor CAS fences make interruption
-/// and root publication races fail closed.
-#[allow(dead_code)]
-pub(crate) async fn stage_tree_sweep_epoch_page<S>(
-    store: &S,
-    session: &mut TreeSweepEpochSession,
-    writes: &mut StorageWriteSet,
-    preconditions: &mut Vec<StoragePrecondition>,
-) -> Result<bool, LixError>
-where
-    S: StorageAdapterRead + ?Sized,
-{
-    if session.cursor.complete {
-        return Ok(true);
-    }
-    let (queue, raw_queue) = load_reachability_queue(store).await?;
-    if *blake3::hash(&raw_queue).as_bytes() != session.epoch.queue_digest {
-        return Err(tree_sweep_error(
-            "tree sweep root publication advanced during an active epoch",
-        ));
-    }
-    let range = StorageKeyRange {
-        lower: session
-            .cursor
-            .last_key
-            .as_ref()
-            .map_or(Bound::Unbounded, |key| {
-                Bound::Excluded(StorageKey(Bytes::copy_from_slice(key)))
-            }),
-        upper: Bound::Unbounded,
-    };
-    let mut cursor = store
-        .begin_scan(
-            crate::tracked_state::TRACKED_STATE_TREE_CHUNK_SPACE,
-            range,
-            StorageBeginScanOptions {
-                projection: StorageCoreProjection::FullValue,
-                ..StorageBeginScanOptions::default()
-            },
-        )
-        .await?;
-    let page = cursor.next_page(GC_TREE_SWEEP_PAGE_ROWS).await?;
-    if page.has_more && page.entries.is_empty() {
-        return Err(tree_sweep_error(
-            "tree sweep tree-chunk scan reported has_more with an empty page",
-        ));
-    }
-    let previous = session.cursor.last_key.as_deref();
-    let mut hashes = Vec::with_capacity(page.entries.len());
-    for entry in &page.entries {
-        if entry.key.0.len() != 32
-            || previous.is_some_and(|previous| entry.key.0.as_ref() <= previous)
-            || hashes
-                .last()
-                .is_some_and(|last: &[u8; 32]| entry.key.0.as_ref() <= last.as_slice())
-        {
-            return Err(tree_sweep_error(
-                "tree sweep tree-chunk keys are malformed or non-increasing",
-            ));
-        }
-        let hash: [u8; 32] = entry
-            .key
-            .0
-            .as_ref()
-            .try_into()
-            .map_err(|_| tree_sweep_error("tree sweep tree-chunk key is not 32 bytes"))?;
-        let StorageProjectedValue::FullValue(bytes) = &entry.value else {
-            return Err(tree_sweep_error(
-                "tree sweep tree-chunk scan returned a key-only value",
-            ));
-        };
-        if *blake3::hash(bytes).as_bytes() != hash {
-            return Err(tree_sweep_error(
-                "tree sweep tree-chunk value hash disagrees with its key",
-            ));
-        }
-        hashes.push(hash);
-    }
-    let mark_keys = hashes
-        .iter()
-        .map(|hash| StorageKey(Bytes::copy_from_slice(hash)))
-        .collect::<Vec<_>>();
-    let marks = if mark_keys.is_empty() {
-        Vec::new()
-    } else {
-        PointReadPlan::new(GC_TREE_SWEEP_MARK_SPACE, &mark_keys)
-            .materialize(store, StorageGetOptions::default())
-            .await?
-            .value
-    };
-    if marks.len() != hashes.len() {
-        return Err(tree_sweep_error(
-            "tree sweep mark point read returned the wrong cardinality",
-        ));
-    }
-    let mut deletes = Vec::new();
-    for (hash, mark) in hashes.iter().zip(marks) {
-        let marked = match mark {
-            None => false,
-            Some(StorageProjectedValue::KeyOnly) => {
-                return Err(tree_sweep_error(
-                    "tree sweep mark point read returned a key-only value",
-                ));
-            }
-            Some(StorageProjectedValue::FullValue(bytes)) => {
-                let mark: StoredTreeSweepMark = storage_codec::decode("tree sweep mark", &bytes)
-                    .map_err(|error| {
-                        tree_sweep_error(format!("tree sweep mark is malformed: {error}"))
-                    })?;
-                if mark.format_version != GC_TREE_SWEEP_FORMAT_VERSION
-                    || mark.epoch_id != session.epoch.epoch_id
-                    || mark.chunk_hash != *hash
-                {
-                    return Err(tree_sweep_error(
-                        "tree sweep mark does not authenticate the current epoch chunk",
-                    ));
-                }
-                true
-            }
-        };
-        if marked != session.live_chunks.contains(hash) {
-            return Err(tree_sweep_error(
-                "tree sweep mark completeness disagrees with authenticated closure",
-            ));
-        }
-        if !marked {
-            deletes.push(*hash);
-        }
-    }
-
-    // A complete keyspace scan must prove that every authenticated live mark
-    // still has its physical chunk before any delete is staged.  This catches
-    // a live chunk deleted between epoch creation and the final page (the
-    // mark inventory alone cannot distinguish that from a clean sweep).
-    if !page.has_more {
-        let live_keys = session
-            .live_chunks
-            .iter()
-            .map(|hash| StorageKey(Bytes::copy_from_slice(hash)))
-            .collect::<Vec<_>>();
-        for chunk_keys in live_keys.chunks(GC_TREE_SWEEP_PAGE_ROWS) {
-            let values = PointReadPlan::new(
-                crate::tracked_state::TRACKED_STATE_TREE_CHUNK_SPACE,
-                chunk_keys,
-            )
-            .materialize(store, StorageGetOptions::default())
-            .await?
-            .value;
-            if values.len() != chunk_keys.len() {
-                return Err(tree_sweep_error(
-                    "tree sweep final live-chunk validation returned the wrong cardinality",
-                ));
-            }
-            for (key, value) in chunk_keys.iter().zip(values) {
-                let Some(StorageProjectedValue::FullValue(bytes)) = value else {
-                    return Err(tree_sweep_error(
-                        "tree sweep final live-chunk validation found a missing or key-only chunk",
-                    ));
-                };
-                if blake3::hash(&bytes).as_bytes().as_slice() != key.0.as_ref() {
-                    return Err(tree_sweep_error(
-                        "tree sweep final live-chunk validation found a corrupt chunk",
-                    ));
-                }
-            }
-        }
-    }
-
-    for hash in &deletes {
-        writes.delete(
-            crate::tracked_state::TRACKED_STATE_TREE_CHUNK_SPACE,
-            StorageKey(Bytes::copy_from_slice(hash)),
-        );
-    }
-    let next_cursor = StoredTreeSweepCursor {
-        format_version: GC_TREE_SWEEP_FORMAT_VERSION,
-        epoch_id: session.epoch.epoch_id,
-        last_key: page.entries.last().map(|entry| entry.key.0.to_vec()),
-        scanned_rows: session
-            .cursor
-            .scanned_rows
-            .saturating_add(hashes.len() as u64),
-        deleted_rows: session
-            .cursor
-            .deleted_rows
-            .saturating_add(deletes.len() as u64),
-        complete: !page.has_more,
-    };
-    let next_raw = Bytes::from(storage_codec::encode("tree sweep cursor", &next_cursor)?);
-    writes.put(
-        GC_TREE_SWEEP_CURSOR_SPACE,
-        StorageKey(Bytes::from_static(GC_TREE_SWEEP_CURSOR_KEY)),
-        StorageValue {
-            bytes: next_raw.clone(),
-        },
-    );
-    preconditions.push(StoragePrecondition::KeyValueEquals {
-        space: GC_REACHABILITY_QUEUE_SPACE,
-        key: StorageKey(Bytes::from_static(GC_REACHABILITY_QUEUE_KEY)),
-        expected: raw_queue,
-    });
-    preconditions.push(StoragePrecondition::KeyValueEquals {
-        space: GC_TREE_SWEEP_CURSOR_SPACE,
-        key: StorageKey(Bytes::from_static(GC_TREE_SWEEP_CURSOR_KEY)),
-        expected: session.raw_cursor.clone(),
-    });
-    session.cursor = next_cursor;
-    session.raw_cursor = next_raw;
-    let _ = queue;
-    Ok(session.cursor.complete)
 }
 
 /// Returns the exact standalone semantic facts and the authenticated reason
@@ -1612,52 +961,6 @@ pub(crate) async fn load_recovery_refs(
     Ok(refs.into_values().collect())
 }
 
-#[cfg(test)]
-async fn stage_sweep_unreachable_content_nodes(
-    store: &(impl StorageAdapterRead + ?Sized),
-    writes: &mut StorageWriteSet,
-    space: StorageSpace,
-    live: &BTreeSet<[u8; 32]>,
-) -> Result<(), LixError> {
-    let range = StoragePrefix {
-        bytes: Bytes::new(),
-    }
-    .to_range()?;
-    let mut cursor = store
-        .begin_scan(
-            space,
-            range,
-            StorageBeginScanOptions {
-                projection: StorageCoreProjection::KeyOnly,
-                ..StorageBeginScanOptions::default()
-            },
-        )
-        .await?;
-    loop {
-        let page = cursor
-            .next_page(crate::storage_adapter::MAX_SCAN_PAGE_ROWS)
-            .await?;
-        for entry in page.entries {
-            let node_id = <[u8; 32]>::try_from(entry.key.0.as_ref()).map_err(|_| {
-                LixError::new(
-                    LixError::CODE_INTERNAL_ERROR,
-                    format!(
-                        "content-addressed space '{}' contains a malformed key",
-                        space.name
-                    ),
-                )
-            })?;
-            if !live.contains(&node_id) {
-                writes.delete(space, entry.key);
-            }
-        }
-        if !page.has_more {
-            break;
-        }
-    }
-    Ok(())
-}
-
 pub(crate) async fn load_recovery_ref(
     store: &(impl StorageAdapterRead + ?Sized),
     branch_id: &str,
@@ -1799,6 +1102,9 @@ fn validate_stored_recovery_ref(
 pub(crate) struct RepositoryGcSweep {
     pub(crate) tracked_commit_roots: Vec<CommitId>,
     pub(crate) standalone_changes: Vec<ChangeId>,
+    /// Derived serving rows reclaimed from branch generations that no live
+    /// branch control selects any more.
+    pub(crate) reclaimed_generation_rows: u64,
     pub(crate) binary_cas: crate::binary_cas::BinaryCasGcSweep,
 }
 
@@ -1991,7 +1297,6 @@ struct AuthenticatedServingDependencyClosure {
     physical_dependencies: BTreeSet<CommitId>,
     semantic_dependencies: BTreeSet<CommitId>,
     cas_logical_dependencies: BTreeSet<CommitId>,
-    manifests: BTreeMap<CommitId, crate::tracked_state::CommitStateManifest>,
     mutation_nodes: BTreeSet<[u8; 32]>,
     scoped_nodes: BTreeSet<[u8; 32]>,
     native_parts: BTreeSet<[u8; 32]>,
@@ -2097,7 +1402,8 @@ where
             }
         }
     }
-    let native_commit_dependencies = validate_live_native_parts(store, &native_parts).await?;
+    let native_commit_dependencies =
+        crate::tracked_state::load_native_current_state_part_owners(store, &native_parts).await?;
     physical_dependencies.extend(native_commit_dependencies.iter().copied());
     semantic_dependencies.extend(native_commit_dependencies);
 
@@ -2200,7 +1506,6 @@ where
         physical_dependencies,
         semantic_dependencies,
         cas_logical_dependencies,
-        manifests,
         mutation_nodes,
         scoped_nodes,
         native_parts,
@@ -2312,7 +1617,6 @@ where
         physical_dependencies: active_dependency_ids,
         semantic_dependencies: active_semantic_dependency_ids,
         cas_logical_dependencies: active_cas_dependency_ids,
-        manifests: _,
         mutation_nodes: active_mutation_nodes,
         scoped_nodes: active_scoped_nodes,
         native_parts: active_current_parts,
@@ -2408,6 +1712,7 @@ where
             sweep: RepositoryGcSweep {
                 tracked_commit_roots: Vec::new(),
                 standalone_changes: Vec::new(),
+                reclaimed_generation_rows: 0,
                 binary_cas,
             },
             profile: RepositoryGcProfile {
@@ -2433,6 +1738,21 @@ where
     let mut reclaimed_semantic_commits = BTreeSet::new();
     let mut reclaimed_standalone_changes = BTreeSet::new();
     let mut reclaimed_checkpoint_branches = BTreeSet::new();
+    // Derived serving generations are reachable from exactly one place: the
+    // live branch controls this pass already read for root discovery. Reusing
+    // that root set is what keeps generation reclamation inside the single
+    // reachability walk instead of needing a second retention ledger.
+    let live_generations = controls
+        .iter()
+        .flat_map(|(branch_id, control)| {
+            [
+                (branch_id.as_str(), control.tracked_generation),
+                (branch_id.as_str(), control.untracked_generation),
+            ]
+        })
+        .collect::<BTreeSet<_>>();
+    let mut retired_generations = BTreeSet::new();
+    let mut reclaimed_generation_rows = 0_u64;
     for (sequence, batch) in batches {
         if queue_open && blocked_sequences.contains(&sequence) {
             queue_open = false;
@@ -2461,6 +1781,41 @@ where
                 )
                 .await?;
             }
+            // A branch generation is a disposable serving cache reachable from
+            // exactly one place: a branch control. Once no live control selects
+            // it, nothing can ever read it again, so retire it.
+            //
+            // This deliberately does not wait for the batch to be consumable.
+            // A blocked batch means a *commit root* is still pinned by history,
+            // undo, or replay — all of which read tracked-state records, never
+            // these derived rows. Coupling the two would strand a whole
+            // generation behind an unrelated pin, exactly like the retired
+            // branch-checkpoint prefix immediately above.
+            if let Some(old_control) = delta.old_control.as_ref() {
+                for generation in [
+                    old_control.tracked_generation,
+                    old_control.untracked_generation,
+                ] {
+                    if delta.new_control.is_some_and(|new_control| {
+                        new_control.tracked_generation == generation
+                            || new_control.untracked_generation == generation
+                    }) || live_generations.contains(&(delta.branch_id.as_str(), generation))
+                    {
+                        continue;
+                    }
+                    if retired_generations.insert((delta.branch_id.clone(), generation)) {
+                        reclaimed_generation_rows = reclaimed_generation_rows.saturating_add(
+                            crate::live_state::stage_retire_hot_generation(
+                                &store,
+                                writes,
+                                &delta.branch_id,
+                                generation,
+                            )
+                            .await?,
+                        );
+                    }
+                }
+            }
             let Some(old_root) = delta.old_root else {
                 continue;
             };
@@ -2477,98 +1832,36 @@ where
                 &active_semantic_dependency_ids,
             );
             if semantic_retirement && reclaimed_semantic_commits.insert(old_root) {
-                stage_delete_semantic_commit_projection(&store, writes, old_root).await?;
+                crate::changelog::stage_delete_commit_projection(&store, writes, old_root).await?;
             }
             if !physical_retirement {
                 continue;
             }
             if reclaimed_commits.insert(old_root) {
-                let manifest = crate::tracked_state::load_commit_state_manifest(&store, old_root)
-                    .await?
-                    .ok_or_else(|| {
-                        LixError::new(
-                            LixError::CODE_INTERNAL_ERROR,
-                            format!("retired GC root '{old_root}' has no authenticated manifest"),
-                        )
-                    })?;
-                let retired_root =
-                    crate::tracked_state::load_commit_mutation_directory_roots(&store, &[old_root])
-                        .await?
-                        .into_iter()
-                        .next()
-                        .flatten();
-                if let Some(root) = retired_root {
-                    let nodes =
-                        crate::tracked_state::collect_mutation_directory_node_ids(&store, &root)
-                            .await?;
-                    for node_id in nodes.difference(&active_mutation_nodes) {
-                        writes.delete(
-                            crate::tracked_state::MUTATION_DIRECTORY_NODE_SPACE,
-                            StorageKey(Bytes::copy_from_slice(node_id)),
-                        );
-                    }
-                }
-                if let Some(root) = manifest.current_state_scoped_ranges.as_ref() {
-                    let reachable = crate::tracked_state::validate_scoped_range_trees(
-                        &store,
-                        std::slice::from_ref(&root.tree),
-                    )
-                    .await?;
-                    for node_id in reachable.node_ids.difference(&active_scoped_nodes) {
-                        writes.delete(
-                            crate::tracked_state::SCOPED_RANGE_NODE_SPACE,
-                            StorageKey(Bytes::copy_from_slice(node_id)),
-                        );
-                    }
-                    for part in reachable.parts {
-                        let descriptor =
-                            crate::tracked_state::current_state_descriptor_from_scoped_range_part(
-                                &part,
-                            )?;
-                        if descriptor.source_kind == 1
-                            && !active_current_parts.contains(&descriptor.content_digest)
-                        {
-                            writes.delete(
-                                crate::tracked_state::CURRENT_STATE_DATA_PART_SPACE,
-                                StorageKey(Bytes::copy_from_slice(&descriptor.content_digest)),
-                            );
-                            writes.delete(
-                                crate::tracked_state::CURRENT_STATE_DATA_PART_REFS_SPACE,
-                                StorageKey(Bytes::copy_from_slice(&descriptor.payload_refs_digest)),
-                            );
-                        }
-                    }
-                }
-                crate::tracked_state::stage_delete_commit_state_manifest_for_gc(
-                    &store, writes, old_root, &manifest,
+                crate::tracked_state::stage_retire_commit_physical_state(
+                    &store,
+                    writes,
+                    old_root,
+                    RetainedPhysicalState {
+                        mutation_nodes: &active_mutation_nodes,
+                        scoped_nodes: &active_scoped_nodes,
+                        native_parts: &active_current_parts,
+                    },
                 )
                 .await?;
             }
-            if let Some(control) = delta.old_control.as_ref() {
-                if !controls
+            if let Some(control) = delta.old_control.as_ref()
+                && !controls
                     .iter()
                     .any(|(_, active)| active.ref_change_id == control.ref_change_id)
-                {
-                    let key = StorageKey(Bytes::from(change_key(control.ref_change_id)));
-                    let existing = PointReadPlan::new(CHANGE_SPACE, std::slice::from_ref(&key))
-                        .materialize(&store, StorageGetOptions::default())
-                        .await?
-                        .value
-                        .into_iter()
-                        .next()
-                        .flatten();
-                    if existing.is_none() {
-                        return Err(LixError::new(
-                            LixError::CODE_INTERNAL_ERROR,
-                            format!(
-                                "retired branch control references missing standalone change '{}'",
-                                control.ref_change_id
-                            ),
-                        ));
-                    }
-                    writes.delete(CHANGE_SPACE, key);
-                    reclaimed_standalone_changes.insert(control.ref_change_id);
-                }
+            {
+                crate::changelog::stage_delete_standalone_change(
+                    &store,
+                    writes,
+                    control.ref_change_id,
+                )
+                .await?;
+                reclaimed_standalone_changes.insert(control.ref_change_id);
             }
         }
     }
@@ -2623,6 +1916,7 @@ where
         sweep: RepositoryGcSweep {
             tracked_commit_roots: reclaimed_commits.into_iter().collect(),
             standalone_changes: reclaimed_standalone_changes.into_iter().collect(),
+            reclaimed_generation_rows,
             binary_cas,
         },
         profile: RepositoryGcProfile {
@@ -2632,43 +1926,6 @@ where
             total_us: elapsed_micros(started),
         },
     })
-}
-
-/// Every authenticated active scoped-range descriptor must have its native
-/// payload present before ordinary GC is allowed to stage any sweep.  The
-/// descriptor is authority for the digest, but not proof that the immutable
-/// payload still exists; treating a missing payload as an empty live set would
-/// silently turn corruption into deletion.
-async fn validate_live_native_parts<S>(
-    store: &S,
-    digests: &BTreeSet<[u8; 32]>,
-) -> Result<BTreeSet<CommitId>, LixError>
-where
-    S: StorageAdapterRead + ?Sized,
-{
-    if digests.is_empty() {
-        return Ok(BTreeSet::new());
-    }
-    let keys = digests
-        .iter()
-        .map(|digest| StorageKey(Bytes::copy_from_slice(digest)))
-        .collect::<Vec<_>>();
-    let loaded = PointReadPlan::new(crate::tracked_state::CURRENT_STATE_DATA_PART_SPACE, &keys)
-        .materialize(store, StorageGetOptions::default())
-        .await?;
-    let mut commit_ids = BTreeSet::new();
-    for (digest, value) in digests.iter().zip(loaded.value) {
-        let Some(StorageProjectedValue::FullValue(bytes)) = value else {
-            return Err(LixError::new(
-                LixError::CODE_INTERNAL_ERROR,
-                "live current-state directory references a missing native data part",
-            ));
-        };
-        commit_ids.extend(
-            crate::tracked_state::decode_current_state_data_part_commit_ids(digest, &bytes)?,
-        );
-    }
-    Ok(commit_ids)
 }
 
 /// Recovery-only verifier retained for explicit rebuild tooling and tests.
@@ -2793,6 +2050,7 @@ where
         sweep: RepositoryGcSweep {
             tracked_commit_roots: swept_snapshot_authorities,
             standalone_changes: Vec::new(),
+            reclaimed_generation_rows: 0,
             binary_cas: Default::default(),
         },
         profile: RepositoryGcProfile {
@@ -3309,36 +2567,15 @@ where
         .collect::<Vec<_>>();
     crate::tracked_state::stage_change_locators(writes, &relocated_locators);
 
-    writes.delete_batch(
-        COMMIT_SPACE,
-        sweep_commits.iter().map(|commit_id| commit_key(*commit_id)),
-    );
-    stage_sweep_unreachable_content_nodes(
+    crate::changelog::stage_delete_commits(writes, sweep_commits.iter().copied());
+    crate::tracked_state::stage_sweep_unreachable_content_nodes(
         store,
         writes,
-        crate::tracked_state::SCOPED_RANGE_NODE_SPACE,
-        &live_scoped_range_nodes,
-    )
-    .await?;
-    stage_sweep_unreachable_content_nodes(
-        store,
-        writes,
-        crate::tracked_state::MUTATION_DIRECTORY_NODE_SPACE,
-        &live_mutation_directory_nodes,
-    )
-    .await?;
-    stage_sweep_unreachable_content_nodes(
-        store,
-        writes,
-        crate::tracked_state::CURRENT_STATE_DATA_PART_REFS_SPACE,
-        &live_current_state_data_parts,
-    )
-    .await?;
-    stage_sweep_unreachable_content_nodes(
-        store,
-        writes,
-        crate::tracked_state::CURRENT_STATE_DATA_PART_SPACE,
-        &live_current_state_data_parts,
+        RetainedPhysicalState {
+            mutation_nodes: &live_mutation_directory_nodes,
+            scoped_nodes: &live_scoped_range_nodes,
+            native_parts: &live_current_state_data_parts,
+        },
     )
     .await?;
     for commit_id in &sweep_authority_commits {
@@ -3361,16 +2598,11 @@ where
             )?;
         }
     }
-    writes.delete_batch(
-        COMMIT_CHANGE_ID_SPACE,
-        sweep_commit_change_ids
-            .iter()
-            .map(|change_id| commit_change_id_key(*change_id)),
+    crate::changelog::stage_delete_commit_change_ids(
+        writes,
+        sweep_commit_change_ids.iter().copied(),
     );
-    writes.delete_batch(
-        CHANGE_SPACE,
-        sweep_changes.iter().map(|change_id| change_key(*change_id)),
-    );
+    crate::changelog::stage_delete_changes(writes, sweep_changes.iter().copied());
     JsonStoreContext::new()
         .writer()
         .stage_delete_refs(writes, sweep_json_payloads.iter().copied());
@@ -3539,54 +2771,6 @@ fn retirement_is_proven(
         && !active_dependency_ids.contains(&old_root)
 }
 
-/// Removes the semantic commit projection once its root interval is no longer
-/// reachable. Physical tracked-state authority may remain alive as a selected
-/// source or serving dependency, so this decision is intentionally separate
-/// from manifest/CAS retirement.
-async fn stage_delete_semantic_commit_projection<S>(
-    store: &S,
-    writes: &mut StorageWriteSet,
-    commit_id: CommitId,
-) -> Result<(), LixError>
-where
-    S: StorageAdapterRead + ?Sized,
-{
-    let commit_ids = [commit_id];
-    let record = ChangelogContext::new()
-        .reader(store)
-        .load_commits(CommitLoadRequest {
-            commit_ids: &commit_ids,
-        })
-        .await?
-        .into_iter()
-        .next()
-        .and_then(|(_, record)| record);
-    let Some(record) = record else {
-        // A prior GC pass may already have removed the semantic projection
-        // while its physical authority remained pinned.
-        return Ok(());
-    };
-    if record.commit_id != commit_id {
-        return Err(LixError::new(
-            LixError::CODE_INTERNAL_ERROR,
-            format!(
-                "commit projection key for '{commit_id}' contains '{}'",
-                record.commit_id
-            ),
-        ));
-    }
-    writes.delete(COMMIT_SPACE, StorageKey(Bytes::from(commit_key(commit_id))));
-    writes.delete(
-        COMMIT_CHANGE_ID_SPACE,
-        StorageKey(Bytes::from(commit_change_id_key(record.change_id))),
-    );
-    writes.delete(
-        CHANGE_SPACE,
-        StorageKey(Bytes::from(change_key(record.change_id))),
-    );
-    Ok(())
-}
-
 #[cfg(test)]
 mod tests {
     use std::collections::{BTreeMap, BTreeSet};
@@ -3616,7 +2800,6 @@ mod tests {
         StorageKey, StoragePrecondition, StorageReadOptions, StorageSpace, StorageValue,
         StorageWriteOptions, StorageWriteSet,
     };
-    use crate::storage_codec;
     use crate::tracked_state::{
         CommitDeltaLifecycleSummary, CommitDeltaReplacementGeneration, CommitDeltaReplacementScope,
         CommitStateManifest, CommitStateMutationInventory, CommitStateReplayDebt,
@@ -3636,15 +2819,13 @@ mod tests {
 
     use super::{
         CheckpointGcState, CheckpointRecoveryRef, GC_REACHABILITY_DELTA_SPACE,
-        GC_REACHABILITY_QUEUE_SPACE, GC_TREE_SWEEP_FORMAT_VERSION, GC_TREE_SWEEP_MARK_SPACE,
-        RootReachabilityDelta, StoredTreeSweepMark, authenticated_control_commit_reachability,
-        begin_tree_sweep_epoch, collect_all_reachability_checkpoint_roots,
+        GC_REACHABILITY_QUEUE_SPACE, RootReachabilityDelta,
+        authenticated_control_commit_reachability, collect_all_reachability_checkpoint_roots,
         load_checkpoint_gc_state, load_reachability_batches, load_reachability_queue,
-        load_recovery_ref, load_recovery_refs, open_tree_sweep_epoch,
-        resolve_pending_checkpoint_replacement, retirement_is_proven,
-        root_control_digest_for_control, stage_checkpoint_gc_state, stage_delete_recovery_ref,
-        stage_reachability_delta_batch, stage_reachability_queue_seed, stage_recovery_ref_rotation,
-        stage_tree_sweep_epoch_page,
+        load_recovery_ref, load_recovery_refs, resolve_pending_checkpoint_replacement,
+        retirement_is_proven, root_control_digest_for_control, stage_checkpoint_gc_state,
+        stage_delete_recovery_ref, stage_reachability_delta_batch, stage_reachability_queue_seed,
+        stage_recovery_ref_rotation,
     };
 
     async fn append_checkpoint_batch(
@@ -4752,9 +3933,12 @@ mod tests {
             .await
             .expect("native dependency read should open");
         assert_eq!(
-            super::validate_live_native_parts(&read, &BTreeSet::from([encoded.digest]))
-                .await
-                .expect("native owner should decode"),
+            crate::tracked_state::load_native_current_state_part_owners(
+                &read,
+                &BTreeSet::from([encoded.digest]),
+            )
+            .await
+            .expect("native owner should decode"),
             BTreeSet::from([owner.commit_id])
         );
         drop(read);
@@ -4903,7 +4087,7 @@ mod tests {
         );
     }
 
-    async fn tree_sweep_fixture() -> (
+    async fn gc_sweep_fixture() -> (
         StorageAdapter<Memory>,
         CommitId,
         [u8; 32],
@@ -4973,8 +4157,7 @@ mod tests {
 
     #[tokio::test]
     async fn gc_sweep_branch_guard_rejects_concurrent_publication() {
-        let (storage, commit_id, _root_hash, _dead_hash, _dead_hash_two) =
-            tree_sweep_fixture().await;
+        let (storage, commit_id, _root_hash, _dead_hash, _dead_hash_two) = gc_sweep_fixture().await;
         let read = storage
             .begin_read(StorageReadOptions::default())
             .await
@@ -5026,7 +4209,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn offline_sweep_and_audit_share_retained_physical_owner_closure() {
+    async fn retention_closure_and_audit_share_retained_physical_owner() {
         let storage = StorageAdapter::new(Memory::new());
         let timestamp =
             LixTimestamp::expect_parse("shared offline owner timestamp", "2026-01-01T00:00:00Z");
@@ -5144,10 +4327,34 @@ mod tests {
             .await
             .expect("shared offline owner closure should authenticate");
         assert!(closure.physical_dependencies.contains(&owner));
-        let (_, _, _, live_chunks) = super::load_tree_sweep_root_closure(&read)
-            .await
-            .expect("offline sweep should retain the physical owner tree");
-        assert_eq!(live_chunks, BTreeSet::from([owner_hash, active_hash]));
+        // The one retention closure is also what keeps the retired owner's
+        // tracked tree root alive; there is no second root walk to consult.
+        let retained_ids = closure
+            .physical_authorities
+            .union(&closure.physical_dependencies)
+            .copied()
+            .collect::<Vec<_>>();
+        assert_eq!(retained_ids, vec![owner.min(active), owner.max(active)]);
+        let closure_tree_roots =
+            crate::tracked_state::load_commit_state_manifests(&read, &retained_ids)
+                .await
+                .expect("retained manifests should load")
+                .into_iter()
+                .flatten()
+                .filter_map(|manifest| manifest.snapshot_root)
+                .flat_map(|root| {
+                    std::iter::once(*root.root_id.as_bytes()).chain(
+                        root.parent_roots
+                            .iter()
+                            .map(|parent| *parent.root_id.as_bytes())
+                            .collect::<Vec<_>>(),
+                    )
+                })
+                .collect::<BTreeSet<_>>();
+        assert_eq!(
+            closure_tree_roots,
+            BTreeSet::from([owner_hash, active_hash])
+        );
         let audit = super::audit_repository_gc_standalone_refs(&read)
             .await
             .expect("standalone audit should consume the same closure");
@@ -5157,269 +4364,6 @@ mod tests {
                 "{}:retired_delta_old_control:history_dependency_pin:old_root={owner}",
                 retired_ref
             )]
-        );
-    }
-
-    #[tokio::test]
-    async fn tree_sweep_epoch_closes_roots_once_and_reclaims_only_unmarked_chunks() {
-        let (storage, _commit_id, _root_hash, dead_hash, dead_hash_two) =
-            tree_sweep_fixture().await;
-        let read = storage
-            .begin_read(StorageReadOptions::default())
-            .await
-            .expect("fixture read should open");
-        let mut writes = storage.new_write_set();
-        let mut preconditions = Vec::<StoragePrecondition>::new();
-        let _session = begin_tree_sweep_epoch(&&read, &mut writes, &mut preconditions)
-            .await
-            .expect("epoch closure should build once");
-        storage
-            .commit_write_set(
-                writes,
-                StorageWriteOptions {
-                    preconditions,
-                    ..StorageWriteOptions::default()
-                },
-            )
-            .await
-            .expect("epoch metadata should publish atomically");
-        drop(read);
-
-        let read = storage
-            .begin_read(StorageReadOptions::default())
-            .await
-            .expect("reopened epoch read should open");
-        let mut reopened = open_tree_sweep_epoch(&read)
-            .await
-            .expect("epoch should reopen")
-            .expect("epoch should exist");
-        assert_eq!(reopened.epoch.live_chunk_count, 1);
-        assert_eq!(reopened.live_chunks.len(), 1);
-        let mut page_writes = storage.new_write_set();
-        let mut page_preconditions = Vec::new();
-        assert!(
-            stage_tree_sweep_epoch_page(
-                &read,
-                &mut reopened,
-                &mut page_writes,
-                &mut page_preconditions,
-            )
-            .await
-            .expect("tree page should stage")
-        );
-        storage
-            .commit_write_set(
-                page_writes,
-                StorageWriteOptions {
-                    preconditions: page_preconditions,
-                    ..StorageWriteOptions::default()
-                },
-            )
-            .await
-            .expect("tree page should commit");
-        drop(read);
-
-        let read = storage
-            .begin_read(StorageReadOptions::default())
-            .await
-            .expect("post-sweep read should open");
-        let keys = [
-            StorageKey(Bytes::copy_from_slice(&dead_hash)),
-            StorageKey(Bytes::copy_from_slice(&dead_hash_two)),
-        ];
-        let result =
-            PointReadPlan::new(crate::tracked_state::TRACKED_STATE_TREE_CHUNK_SPACE, &keys)
-                .materialize(&read, StorageGetOptions::default())
-                .await
-                .expect("post-sweep chunks should read");
-        assert!(result.value.into_iter().all(|value| value.is_none()));
-        assert!(
-            open_tree_sweep_epoch(&read)
-                .await
-                .expect("completed epoch should reopen")
-                .expect("completed epoch should remain")
-                .cursor
-                .complete
-        );
-    }
-
-    #[tokio::test]
-    async fn tree_sweep_epoch_fails_closed_on_missing_mark_or_corrupt_chunk() {
-        let (storage, _commit_id, _root_hash, dead_hash, _dead_hash_two) =
-            tree_sweep_fixture().await;
-        let read = storage
-            .begin_read(StorageReadOptions::default())
-            .await
-            .expect("fixture read should open");
-        let mut writes = storage.new_write_set();
-        let mut preconditions = Vec::new();
-        begin_tree_sweep_epoch(&&read, &mut writes, &mut preconditions)
-            .await
-            .expect("epoch should begin");
-        storage
-            .commit_write_set(
-                writes,
-                StorageWriteOptions {
-                    preconditions,
-                    ..StorageWriteOptions::default()
-                },
-            )
-            .await
-            .expect("epoch should publish");
-        drop(read);
-
-        let read = storage
-            .begin_read(StorageReadOptions::default())
-            .await
-            .expect("reopened epoch read should open");
-        let session = open_tree_sweep_epoch(&read)
-            .await
-            .expect("epoch should load")
-            .expect("epoch should exist");
-        let live_hash = *session.live_chunks.iter().next().expect("root mark");
-        let epoch_id = session.epoch.epoch_id;
-        drop(read);
-        let mut remove_mark = storage.new_write_set();
-        remove_mark.delete(
-            GC_TREE_SWEEP_MARK_SPACE,
-            StorageKey(Bytes::copy_from_slice(&live_hash)),
-        );
-        storage
-            .commit_write_set(remove_mark, StorageWriteOptions::default())
-            .await
-            .expect("test mark deletion should commit");
-        let read = storage
-            .begin_read(StorageReadOptions::default())
-            .await
-            .expect("missing-mark read should open");
-        assert!(
-            open_tree_sweep_epoch(&read)
-                .await
-                .expect_err("missing live mark must fail closed")
-                .to_string()
-                .contains("mark inventory")
-        );
-        drop(read);
-
-        // Restore the mark and corrupt an unmarked chunk. The page validates
-        // every key/value before it stages any delete, so the failed page has
-        // an empty write set and cannot partially reclaim its siblings.
-        let mut restore = storage.new_write_set();
-        restore.put(
-            GC_TREE_SWEEP_MARK_SPACE,
-            StorageKey(Bytes::copy_from_slice(&live_hash)),
-            StorageValue {
-                bytes: Bytes::from(
-                    storage_codec::encode(
-                        "tree sweep mark",
-                        &StoredTreeSweepMark {
-                            format_version: GC_TREE_SWEEP_FORMAT_VERSION,
-                            epoch_id,
-                            chunk_hash: live_hash,
-                        },
-                    )
-                    .expect("mark should encode"),
-                ),
-            },
-        );
-        storage
-            .commit_write_set(restore, StorageWriteOptions::default())
-            .await
-            .expect("mark restoration should commit");
-        let mut corrupt = storage.new_write_set();
-        corrupt.put(
-            crate::tracked_state::TRACKED_STATE_TREE_CHUNK_SPACE,
-            StorageKey(Bytes::copy_from_slice(&dead_hash)),
-            StorageValue {
-                bytes: Bytes::from_static(b"corrupt-tree-chunk"),
-            },
-        );
-        storage
-            .commit_write_set(corrupt, StorageWriteOptions::default())
-            .await
-            .expect("test corruption should commit");
-        let read = storage
-            .begin_read(StorageReadOptions::default())
-            .await
-            .expect("corruption read should open");
-        let mut session = open_tree_sweep_epoch(&read)
-            .await
-            .expect("restored epoch should load")
-            .expect("restored epoch should exist");
-        let mut page_writes = storage.new_write_set();
-        let mut page_preconditions = Vec::new();
-        assert!(
-            stage_tree_sweep_epoch_page(
-                &read,
-                &mut session,
-                &mut page_writes,
-                &mut page_preconditions,
-            )
-            .await
-            .is_err()
-        );
-        assert!(page_writes.is_empty(), "failed page must stage zero writes");
-    }
-
-    #[tokio::test]
-    async fn tree_sweep_epoch_fails_closed_when_live_chunk_disappears() {
-        let (storage, _commit_id, root_hash, _dead_hash, _dead_hash_two) =
-            tree_sweep_fixture().await;
-        let read = storage
-            .begin_read(StorageReadOptions::default())
-            .await
-            .expect("fixture read should open");
-        let mut writes = storage.new_write_set();
-        let mut preconditions = Vec::new();
-        begin_tree_sweep_epoch(&&read, &mut writes, &mut preconditions)
-            .await
-            .expect("epoch should begin");
-        storage
-            .commit_write_set(
-                writes,
-                StorageWriteOptions {
-                    preconditions,
-                    ..StorageWriteOptions::default()
-                },
-            )
-            .await
-            .expect("epoch should publish");
-        drop(read);
-
-        let mut remove_root = storage.new_write_set();
-        remove_root.delete(
-            crate::tracked_state::TRACKED_STATE_TREE_CHUNK_SPACE,
-            StorageKey(Bytes::copy_from_slice(&root_hash)),
-        );
-        storage
-            .commit_write_set(remove_root, StorageWriteOptions::default())
-            .await
-            .expect("test root deletion should commit");
-
-        let read = storage
-            .begin_read(StorageReadOptions::default())
-            .await
-            .expect("missing-root read should open");
-        let mut session = open_tree_sweep_epoch(&read)
-            .await
-            .expect("epoch should load")
-            .expect("epoch should exist");
-        let mut page_writes = storage.new_write_set();
-        let mut page_preconditions = Vec::new();
-        assert!(
-            stage_tree_sweep_epoch_page(
-                &read,
-                &mut session,
-                &mut page_writes,
-                &mut page_preconditions,
-            )
-            .await
-            .is_err(),
-            "missing live chunk must fail closed"
-        );
-        assert!(
-            page_writes.is_empty(),
-            "missing live chunk must stage zero deletes"
         );
     }
 
@@ -6730,16 +5674,17 @@ mod tests {
             .expect("shared-node read should open");
         let mut sweep = storage.new_write_set();
         let live = BTreeSet::from([live_id]);
-        for space in [
-            crate::tracked_state::SCOPED_RANGE_NODE_SPACE,
-            crate::tracked_state::MUTATION_DIRECTORY_NODE_SPACE,
-            crate::tracked_state::CURRENT_STATE_DATA_PART_SPACE,
-            crate::tracked_state::CURRENT_STATE_DATA_PART_REFS_SPACE,
-        ] {
-            super::stage_sweep_unreachable_content_nodes(&read, &mut sweep, space, &live)
-                .await
-                .expect("content-addressed sweep should stage");
-        }
+        crate::tracked_state::stage_sweep_unreachable_content_nodes(
+            &read,
+            &mut sweep,
+            crate::tracked_state::RetainedPhysicalState {
+                mutation_nodes: &live,
+                scoped_nodes: &live,
+                native_parts: &live,
+            },
+        )
+        .await
+        .expect("content-addressed sweep should stage");
         drop(read);
         storage
             .commit_write_set(sweep, StorageWriteOptions::default())
@@ -7311,7 +6256,10 @@ mod tests {
             )
             .await
             .expect("tracked owner should remain readable");
-        assert_eq!(tracked.rows()[0].values(), &[Value::Json(shared_value.into())]);
+        assert_eq!(
+            tracked.rows()[0].values(),
+            &[Value::Json(shared_value.into())]
+        );
     }
 
     #[tokio::test]
@@ -8289,6 +7237,103 @@ mod tests {
             .expect("replay release should publish");
     }
 
+    /// Reproduction of a known, unfixed defect: the retirement ledger never
+    /// drains, so `gc.reachability_delta.v1` grows one ~439 B row per branch
+    /// publication forever.
+    ///
+    /// Measured cause (this test, plus `expv_blind_space_growth commits`): it
+    /// is *not* head-of-line blocking and not the 64-row consumption cap. Every
+    /// delta is blocked on its own merits, because every commit that still owns
+    /// a live current-state scoped-range part is inserted into
+    /// `physical_authorities` (see the `source_kind` 0 | 2 arm of
+    /// `load_authenticated_serving_dependency_closure`). In an append-only
+    /// workload that is every commit, so `retirement_is_proven` is false for
+    /// every `old_root` even after a checkpoint releases the undo interval.
+    ///
+    /// Fixing it therefore requires either compacting live current state so old
+    /// commits stop owning live parts, or deriving retirement candidates from
+    /// the manifests instead of storing a per-publication ledger. Both are
+    /// larger than this change, so the reproduction is kept and ignored rather
+    /// than deleted.
+    #[tokio::test]
+    #[ignore = "reproduces the unfixed retirement-ledger leak; see the doc comment"]
+    async fn ordinary_gc_drains_the_reachability_queue_past_a_pinned_head() {
+        let backend = Memory::new();
+        Engine::initialize(backend.clone())
+            .await
+            .expect("queue drain fixture should initialize");
+        let engine = Engine::new(backend.clone())
+            .await
+            .expect("queue drain fixture should open");
+        let session = engine
+            .open_workspace_session()
+            .await
+            .expect("queue drain session should open");
+        let schema = serde_json::json!({
+            "x-lix-key": "gc_queue_drain_fixture",
+            "x-lix-primary-key": ["/path"],
+            "type": "object",
+            "required": ["path", "value"],
+            "properties": {
+                "path": { "type": "string" },
+                "value": { "type": ["object", "array", "string", "number", "integer", "boolean", "null"] }
+            },
+            "additionalProperties": false
+        });
+        session
+            .execute(
+                "INSERT INTO lix_registered_schema (value, lixcol_global, lixcol_untracked) VALUES (lix_json($1), false, false)",
+                &[Value::Text(schema.to_string())],
+            )
+            .await
+            .expect("queue drain schema should register");
+        for row in 0..24 {
+            session
+                .execute(
+                    "INSERT INTO gc_queue_drain_fixture (path, value) VALUES ($1, lix_json($2))",
+                    &[
+                        Value::Text(format!("/row/{row}")),
+                        Value::Text(format!(r#"{{"v":{row}}}"#)),
+                    ],
+                )
+                .await
+                .expect("queue drain row should publish");
+        }
+        // A checkpoint releases the undo interval, so every commit below it is
+        // provably retirable and its delta is consumable.
+        session
+            .create_checkpoint()
+            .await
+            .expect("queue drain checkpoint should publish");
+
+        let storage = StorageAdapter::new(backend.clone());
+        let queue_depth = async |storage: &StorageAdapter<Memory>| {
+            let read = SharedStorageAdapterRead::new(
+                storage
+                    .begin_read(StorageReadOptions::default())
+                    .await
+                    .expect("queue depth read should open"),
+            );
+            let (queue, _) = load_reachability_queue(&read)
+                .await
+                .expect("queue depth should load");
+            queue.tail_sequence.saturating_sub(queue.head_sequence)
+        };
+        let before = queue_depth(&storage).await;
+        assert!(before > 0, "the fixture must leave a non-empty queue");
+
+        // Repeated sweeps must converge, not plateau.
+        let mut after = before;
+        for _ in 0..8 {
+            run_ordinary_repository_gc(&storage).await;
+            after = queue_depth(&storage).await;
+        }
+        assert!(
+            after < before,
+            "repeated GC left the retirement ledger at {after} of {before} deltas"
+        );
+    }
+
     async fn run_ordinary_repository_gc(
         storage: &StorageAdapter<Memory>,
     ) -> super::RepositoryGcPlan {
@@ -8315,6 +7360,169 @@ mod tests {
             .await
             .expect("ordinary GC should commit");
         plan
+    }
+
+    /// Counts serving rows still addressed by one branch generation.
+    async fn hot_generation_rows(
+        storage: &StorageAdapter<Memory>,
+        branch_id: &str,
+        generation: CommitId,
+    ) -> usize {
+        let read = storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("generation census read should open");
+        let prefix = crate::storage_adapter::StoragePrefix {
+            bytes: Bytes::from(crate::live_state::hot_generation_scope_prefix(
+                branch_id, generation,
+            )),
+        };
+        let mut rows = 0;
+        let mut cursor = crate::storage_adapter::StorageAdapterRead::begin_scan(
+            &read,
+            crate::live_state::HOT_ROW_SPACE,
+            prefix.to_range().expect("generation prefix should range"),
+            crate::storage_adapter::StorageBeginScanOptions::default(),
+        )
+        .await
+        .expect("generation census scan should open");
+        loop {
+            let page = cursor
+                .next_page(crate::storage_adapter::MAX_SCAN_PAGE_ROWS)
+                .await
+                .expect("generation census page should load");
+            rows += page.entries.len();
+            if !page.has_more {
+                break;
+            }
+        }
+        rows
+    }
+
+    /// A deleted branch strands its whole serving generation. The one
+    /// reachability walk already knows which generations the live controls
+    /// select, so the ordinary pass must reclaim it — no second sweeper, no
+    /// retention ledger.
+    #[tokio::test]
+    async fn ordinary_gc_reclaims_the_serving_generation_of_a_deleted_branch() {
+        let backend = Memory::new();
+        Engine::initialize(backend.clone())
+            .await
+            .expect("generation fixture should initialize");
+        let engine = Engine::new(backend.clone())
+            .await
+            .expect("generation fixture should open");
+        let session = engine
+            .open_workspace_session()
+            .await
+            .expect("generation fixture session should open");
+        let schema = serde_json::json!({
+            "x-lix-key": "gc_generation_fixture",
+            "x-lix-primary-key": ["/path"],
+            "type": "object",
+            "required": ["path", "value"],
+            "properties": {
+                "path": { "type": "string" },
+                "value": { "type": ["object", "array", "string", "number", "integer", "boolean", "null"] }
+            },
+            "additionalProperties": false
+        });
+        session
+            .execute(
+                "INSERT INTO lix_registered_schema (value, lixcol_global, lixcol_untracked) VALUES (lix_json($1), false, false)",
+                &[Value::Text(schema.to_string())],
+            )
+            .await
+            .expect("generation fixture schema should register");
+        for row in 0..16 {
+            session
+                .execute(
+                    "INSERT INTO gc_generation_fixture (path, value) VALUES ($1, lix_json($2))",
+                    &[
+                        Value::Text(format!("/row/{row}")),
+                        Value::Text(format!(r#"{{"v":{row}}}"#)),
+                    ],
+                )
+                .await
+                .expect("generation fixture row should publish");
+        }
+        let branch = session
+            .create_branch(crate::CreateBranchOptions {
+                id: Some("01990000-0000-7000-8000-0000000000a1".to_owned()),
+                name: "gc-generation-dead".to_owned(),
+                from_commit_id: None,
+            })
+            .await
+            .expect("generation fixture branch should create");
+        let branch_session = engine
+            .open_session(branch.id.clone())
+            .await
+            .expect("generation fixture branch session should open");
+        for row in 0..16 {
+            branch_session
+                .execute(
+                    "UPDATE gc_generation_fixture SET value = lix_json($2) WHERE path = $1",
+                    &[
+                        Value::Text(format!("/row/{row}")),
+                        Value::Text(format!(r#"{{"v":{}}}"#, row + 100)),
+                    ],
+                )
+                .await
+                .expect("generation fixture branch row should publish");
+        }
+        let storage = StorageAdapter::new(backend.clone());
+        let generation = {
+            let read = storage
+                .begin_read(StorageReadOptions::default())
+                .await
+                .expect("generation control read should open");
+            BranchHeadControlContext::new()
+                .reader(&read)
+                .scan()
+                .await
+                .expect("generation controls should load")
+                .into_iter()
+                .find(|(branch_id, _)| branch_id == &branch.id)
+                .expect("the disposable branch must have a control")
+                .1
+                .tracked_generation
+        };
+        let seeded = hot_generation_rows(&storage, &branch.id, generation).await;
+        assert!(
+            seeded > 0,
+            "the disposable branch must materialize its own serving generation"
+        );
+
+        drop(branch_session);
+        session
+            .execute(
+                "DELETE FROM lix_branch WHERE id = $1",
+                &[Value::Text(branch.id.clone())],
+            )
+            .await
+            .expect("generation fixture branch should delete");
+        let plan = run_ordinary_repository_gc(&storage).await;
+
+        assert!(
+            plan.sweep.reclaimed_generation_rows >= seeded as u64,
+            "ordinary GC reclaimed {} of {seeded} stranded serving rows",
+            plan.sweep.reclaimed_generation_rows
+        );
+        assert_eq!(
+            hot_generation_rows(&storage, &branch.id, generation).await,
+            0,
+            "no serving row of a deleted branch generation may survive GC"
+        );
+
+        // The surviving branch must still read exactly what it wrote.
+        let survivors = session
+            .execute("SELECT COUNT(*) AS rows FROM gc_generation_fixture", &[])
+            .await
+            .expect("surviving branch should still read")
+            .rows()[0]
+            .get::<i64>("rows")
+            .expect("row count should decode");
+        assert_eq!(survivors, 16);
     }
 
     async fn load_audited_repository_retention(
@@ -8406,7 +7614,10 @@ mod tests {
         }
     }
 
-    async fn assert_offline_sweep_and_audit_fail_closed(
+    /// The retention closure is the single reachability implementation, and the
+    /// standalone audit reads it. Both must reject the same malformed authority
+    /// with the same reason.
+    async fn assert_retention_closure_and_audit_fail_closed(
         storage: &StorageAdapter<Memory>,
         expected_message: &str,
     ) {
@@ -8416,28 +7627,37 @@ mod tests {
                 .await
                 .expect("offline authority read should open"),
         );
-        let sweep_error = super::load_tree_sweep_root_closure(&read)
+        let controls = BranchHeadControlContext::new()
+            .reader(read.clone())
+            .scan()
             .await
-            .expect_err("offline tree sweep must fail closed");
+            .expect("offline authority controls should load");
+        let (queue, _) = load_reachability_queue(&read)
+            .await
+            .expect("offline authority queue should load");
+        let closure_error =
+            super::load_authenticated_repository_retention(&read, &controls, &queue)
+                .await
+                .expect_err("the retention closure must fail closed");
         let audit_error = super::audit_repository_gc_standalone_refs(&read)
             .await
             .expect_err("standalone audit must fail closed");
-        assert_eq!(sweep_error.message, audit_error.message);
+        assert_eq!(closure_error.message, audit_error.message);
         assert!(
-            sweep_error.message.contains(expected_message),
+            closure_error.message.contains(expected_message),
             "unexpected shared authority error: {}",
-            sweep_error.message
+            closure_error.message
         );
     }
 
     #[tokio::test]
-    async fn offline_sweep_and_audit_reject_missing_and_malformed_required_authority() {
+    async fn retention_closure_and_audit_reject_missing_and_malformed_required_authority() {
         const MUTABLE_MANIFEST_SPACE: StorageSpace = StorageSpace::mutable(
             crate::tracked_state::TRACKED_STATE_COMMIT_STATE_MANIFEST_SPACE.id,
             "tracked_state.commit_state_manifest.v7",
         );
 
-        let (storage, commit_id, _, _, _) = tree_sweep_fixture().await;
+        let (storage, commit_id, _, _, _) = gc_sweep_fixture().await;
         let mut writes = storage.new_write_set();
         writes.delete(
             MUTABLE_MANIFEST_SPACE,
@@ -8447,10 +7667,13 @@ mod tests {
             .commit_write_set(writes, StorageWriteOptions::default())
             .await
             .expect("required manifest removal should commit");
-        assert_offline_sweep_and_audit_fail_closed(&storage, "incomplete split physical authority")
-            .await;
+        assert_retention_closure_and_audit_fail_closed(
+            &storage,
+            "incomplete split physical authority",
+        )
+        .await;
 
-        let (storage, commit_id, _, _, _) = tree_sweep_fixture().await;
+        let (storage, commit_id, _, _, _) = gc_sweep_fixture().await;
         let mut writes = storage.new_write_set();
         writes.put(
             MUTABLE_MANIFEST_SPACE,
@@ -8463,11 +7686,11 @@ mod tests {
             .commit_write_set(writes, StorageWriteOptions::default())
             .await
             .expect("malformed manifest should commit");
-        assert_offline_sweep_and_audit_fail_closed(&storage, "unsupported format").await;
+        assert_retention_closure_and_audit_fail_closed(&storage, "unsupported format").await;
     }
 
     #[tokio::test]
-    async fn offline_sweep_and_audit_reject_non_decreasing_and_cyclic_replay_authority() {
+    async fn retention_closure_and_audit_reject_non_decreasing_and_cyclic_replay_authority() {
         let timestamp = LixTimestamp::expect_parse(
             "offline replay authority timestamp",
             "2026-01-01T00:00:00Z",
@@ -8506,7 +7729,7 @@ mod tests {
             &[root_manifest, child_manifest],
         )
         .await;
-        assert_offline_sweep_and_audit_fail_closed(&storage, "replay debt disagrees").await;
+        assert_retention_closure_and_audit_fail_closed(&storage, "replay debt disagrees").await;
 
         let storage = StorageAdapter::new(Memory::new());
         let root = replay_commit_record("offline-replay-cycle-root", 0, None, timestamp);
@@ -8559,7 +7782,7 @@ mod tests {
             ],
         )
         .await;
-        assert_offline_sweep_and_audit_fail_closed(&storage, "dependency cycle").await;
+        assert_retention_closure_and_audit_fail_closed(&storage, "dependency cycle").await;
     }
 
     async fn json_ref_exists(storage: &Memory, space: StorageSpace, json_ref: JsonRef) -> bool {

--- a/packages/lix/src/gc.rs
+++ b/packages/lix/src/gc.rs
@@ -605,10 +605,10 @@ pub(crate) async fn stage_reachability_delta_batch(
     checkpoint_roots: &[CommitId],
     preconditions: &mut Vec<StoragePrecondition>,
 ) -> Result<(), LixError> {
-    // This is the central authenticated root-publication boundary. Rotate the
-    // binary-CAS epoch in this same atomic write even when the transition only
-    // revives an existing commit and stages no blob bytes.
-    crate::binary_cas::stage_mutation_epoch(read, writes, preconditions).await?;
+    // This is the central authenticated root-publication boundary. Stage the
+    // binary-CAS publication fence in this same atomic write even when the
+    // transition only revives an existing commit and stages no blob bytes.
+    crate::binary_cas::stage_cas_publication_fence(read, writes, preconditions).await?;
     if deltas.is_empty() && checkpoint_roots.is_empty() {
         return Ok(());
     }
@@ -2380,7 +2380,8 @@ where
     let binary_cas =
         crate::binary_cas::stage_gc_reclamation(&store, writes, &blob_roots, &upload_chunks)
             .await?;
-    crate::binary_cas::stage_mutation_epoch(&store, writes, &mut staged_preconditions).await?;
+    crate::binary_cas::stage_cas_reclamation_fence(&store, writes, &mut staged_preconditions)
+        .await?;
 
     if batches.is_empty() {
         preconditions.extend(staged_preconditions);

--- a/packages/lix/src/live_state/mod.rs
+++ b/packages/lix/src/live_state/mod.rs
@@ -25,7 +25,10 @@ pub(crate) use reader::{LiveStateReadDomain, LiveStateReader};
 #[cfg(test)]
 pub(crate) use tracked_head::TrackedHeadDeltaRef;
 #[cfg(test)]
+pub(crate) use tracked_head::hot_generation_scope_prefix;
+#[cfg(test)]
 pub(crate) use tracked_head::stage_collect_stale_working_diff_indexes;
+pub(crate) use tracked_head::stage_retire_hot_generation;
 #[allow(unused_imports)]
 pub(crate) use tracked_head::{
     CERTIFIED_ENTITY_BATCH_MANIFEST_SPACE, CERTIFIED_ENTITY_BATCH_PAGE_SPACE,
@@ -33,12 +36,11 @@ pub(crate) use tracked_head::{
     CertifiedCurrentStatePredecessorRef, CertifiedEntityBatchFileRef, ColumnarBaseCoordinate,
     CurrentStateDeltaRef, DeferredFreshHotPlan, DeferredFreshHotRowRef, DeferredFreshHotRows,
     EntityColumnarOverlayRow, HOT_COLLECTION_CONTROL_SPACE, HOT_DIFF_SPACE, HOT_FILE_SPACE,
-    HOT_ROW_SPACE, HotTrackedSnapshot,
-    PACKED_CURRENT_BASE_CONTROL_SPACE, PACKED_CURRENT_BASE_SPACE,
-    PACKED_CURRENT_EXCLUSIVE_SCHEMA_BASE_SPACE, PackedIdentityMembership, ROOT_CURRENT_BASE_SPACE,
-    TRACKED_WORKING_DIFF_MARKER_SPACE, TrackedHeadContext, TrackedWorkingDiff,
-    TrackedWorkingDiffEpoch, WorkingDiffIndexCoverage, materialize_certified_root_rows,
-    scan_certified_history_rows, stage_certified_entity_batches,
+    HOT_ROW_SPACE, HotTrackedSnapshot, PACKED_CURRENT_BASE_CONTROL_SPACE,
+    PACKED_CURRENT_BASE_SPACE, PACKED_CURRENT_EXCLUSIVE_SCHEMA_BASE_SPACE,
+    PackedIdentityMembership, ROOT_CURRENT_BASE_SPACE, TRACKED_WORKING_DIFF_MARKER_SPACE,
+    TrackedHeadContext, TrackedWorkingDiff, TrackedWorkingDiffEpoch, WorkingDiffIndexCoverage,
+    materialize_certified_root_rows, scan_certified_history_rows, stage_certified_entity_batches,
     stage_delete_tracked_working_diff_epoch, stage_tracked_working_diff_epoch,
 };
 #[allow(unused_imports)]

--- a/packages/lix/src/live_state/mod.rs
+++ b/packages/lix/src/live_state/mod.rs
@@ -25,6 +25,8 @@ pub(crate) use reader::{LiveStateReadDomain, LiveStateReader};
 #[cfg(test)]
 pub(crate) use tracked_head::TrackedHeadDeltaRef;
 #[cfg(test)]
+pub(crate) use tracked_head::WORKING_DIFF_PATH_HITS;
+#[cfg(test)]
 pub(crate) use tracked_head::stage_collect_stale_working_diff_indexes;
 #[allow(unused_imports)]
 pub(crate) use tracked_head::{

--- a/packages/lix/src/live_state/tracked_head.rs
+++ b/packages/lix/src/live_state/tracked_head.rs
@@ -10,15 +10,17 @@
 mod hot;
 
 pub(crate) use crate::live_state::LiveStateReadDomain;
+#[cfg(test)]
+pub(crate) use hot::hot_generation_scope_prefix;
 pub(crate) use hot::{
     CERTIFIED_ENTITY_BATCH_MANIFEST_SPACE, CERTIFIED_ENTITY_BATCH_PAGE_SPACE,
     CERTIFIED_ENTITY_BATCH_SPACE, CertifiedEntityBatchFileRef, DeferredFreshHotPlan,
-    DeferredFreshHotRowRef, DeferredFreshHotRows, EntityColumnarOverlayRow, HOT_DIFF_SPACE,
-    HOT_COLLECTION_CONTROL_SPACE, HOT_FILE_SPACE, HOT_ROW_SPACE, HotStateTransactionCache,
-    HotTrackedSnapshot,
-    PACKED_CURRENT_BASE_CONTROL_SPACE, PACKED_CURRENT_BASE_SPACE,
-    PACKED_CURRENT_EXCLUSIVE_SCHEMA_BASE_SPACE, PackedIdentityMembership, ROOT_CURRENT_BASE_SPACE,
-    materialize_certified_root_rows, scan_certified_history_rows, stage_certified_entity_batches,
+    DeferredFreshHotRowRef, DeferredFreshHotRows, EntityColumnarOverlayRow,
+    HOT_COLLECTION_CONTROL_SPACE, HOT_DIFF_SPACE, HOT_FILE_SPACE, HOT_ROW_SPACE,
+    HotStateTransactionCache, HotTrackedSnapshot, PACKED_CURRENT_BASE_CONTROL_SPACE,
+    PACKED_CURRENT_BASE_SPACE, PACKED_CURRENT_EXCLUSIVE_SCHEMA_BASE_SPACE,
+    PackedIdentityMembership, ROOT_CURRENT_BASE_SPACE, materialize_certified_root_rows,
+    scan_certified_history_rows, stage_certified_entity_batches, stage_retire_hot_generation,
 };
 
 /// Stable physical address of a row in an immutable columnar base.

--- a/packages/lix/src/live_state/tracked_head.rs
+++ b/packages/lix/src/live_state/tracked_head.rs
@@ -10,6 +10,8 @@
 mod hot;
 
 pub(crate) use crate::live_state::LiveStateReadDomain;
+#[cfg(test)]
+pub(crate) use hot::WORKING_DIFF_PATH_HITS;
 pub(crate) use hot::{
     CERTIFIED_ENTITY_BATCH_MANIFEST_SPACE, CERTIFIED_ENTITY_BATCH_PAGE_SPACE,
     CERTIFIED_ENTITY_BATCH_SPACE, CertifiedEntityBatchFileRef, DeferredFreshHotPlan,

--- a/packages/lix/src/live_state/tracked_head/hot.rs
+++ b/packages/lix/src/live_state/tracked_head/hot.rs
@@ -11236,6 +11236,76 @@ fn collect_hot_untracked_refs(value: HeadValueView<'_>, refs: &mut BTreeSet<[u8;
     }
 }
 
+/// Every serving plane whose key begins with `(branch_id, generation)`.
+///
+/// These are derived caches of one branch generation, so a generation that no
+/// live branch control selects is exactly one contiguous key range per space.
+/// Content-addressed planes (the certified entity batches) are deliberately
+/// absent: their rows are shared across generations and are reclaimed by
+/// content reachability, not by scope.
+const GENERATION_SCOPED_SPACES: &[StorageSpace] = &[
+    HOT_ROW_SPACE,
+    HOT_FILE_SPACE,
+    HOT_COLLECTION_CONTROL_SPACE,
+    PACKED_CURRENT_BASE_SPACE,
+    PACKED_CURRENT_BASE_CONTROL_SPACE,
+    PACKED_CURRENT_EXCLUSIVE_SCHEMA_BASE_SPACE,
+    ROOT_CURRENT_BASE_SPACE,
+];
+
+/// The `(branch_id, generation)` key prefix that scopes every derived serving
+/// plane. Exposed for GC census assertions.
+#[cfg(test)]
+pub(crate) fn hot_generation_scope_prefix(branch_id: &str, generation: CommitId) -> Vec<u8> {
+    encode_scope_prefix(branch_id, generation)
+}
+
+/// Retires every derived serving row of one branch generation.
+///
+/// The caller proves the generation is unreachable from the live branch
+/// controls; this stages the deletes. Work is bounded by the rows actually
+/// reclaimed — each space is entered at the generation's key prefix, never
+/// scanned whole — so a repository sweep costs what its garbage costs.
+pub(crate) async fn stage_retire_hot_generation<S>(
+    store: &S,
+    writes: &mut StorageWriteSet,
+    branch_id: &str,
+    generation: CommitId,
+) -> Result<u64, LixError>
+where
+    S: StorageAdapterRead + ?Sized,
+{
+    let prefix = StoragePrefix {
+        bytes: Bytes::from(encode_scope_prefix(branch_id, generation)),
+    };
+    let mut deleted = 0_u64;
+    for space in GENERATION_SCOPED_SPACES {
+        let mut cursor = store
+            .begin_scan(
+                *space,
+                prefix.to_range()?,
+                StorageBeginScanOptions {
+                    projection: StorageCoreProjection::KeyOnly,
+                    ..StorageBeginScanOptions::default()
+                },
+            )
+            .await?;
+        loop {
+            let page = cursor
+                .next_page(crate::storage_adapter::MAX_SCAN_PAGE_ROWS)
+                .await?;
+            for entry in page.entries {
+                writes.delete(*space, entry.key);
+                deleted = deleted.saturating_add(1);
+            }
+            if !page.has_more {
+                break;
+            }
+        }
+    }
+    Ok(deleted)
+}
+
 #[cfg(test)]
 pub(crate) async fn stage_collect_stale_hot_generations<S>(
     store: &S,

--- a/packages/lix/src/live_state/tracked_head/hot.rs
+++ b/packages/lix/src/live_state/tracked_head/hot.rs
@@ -9745,6 +9745,21 @@ fn packed_working_diff_version(
     }
 }
 
+/// Counts which of the two working-diff read paths served a request, so the
+/// public-surface equivalence test can prove it exercised both instead of
+/// silently comparing one path against itself.
+#[cfg(test)]
+pub(crate) static WORKING_DIFF_PATH_HITS: WorkingDiffPathHits = WorkingDiffPathHits {
+    index_scan: std::sync::atomic::AtomicUsize::new(0),
+    finite_bypass: std::sync::atomic::AtomicUsize::new(0),
+};
+
+#[cfg(test)]
+pub(crate) struct WorkingDiffPathHits {
+    pub(crate) index_scan: std::sync::atomic::AtomicUsize,
+    pub(crate) finite_bypass: std::sync::atomic::AtomicUsize,
+}
+
 /// Resolves a checkpoint diff from row-local first-before images. Broad diffs
 /// enumerate the sparse dirty-key index; finite PK queries read only the
 /// primary rows that can answer the request.
@@ -9772,6 +9787,10 @@ async fn hot_working_diff_entries(
         .await;
     }
 
+    #[cfg(test)]
+    WORKING_DIFF_PATH_HITS
+        .index_scan
+        .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
     let scope = encode_working_diff_scope_prefix(branch_id, checkpoint_commit_id, generation);
     let range = StoragePrefix {
         bytes: Bytes::from(scope.clone()),
@@ -9976,6 +9995,10 @@ async fn hot_working_diff_entries_for_finite_filter(
     generation: CommitId,
     filter: &TrackedStateFilter,
 ) -> Result<Option<Vec<TrackedStateDiffEntry>>, LixError> {
+    #[cfg(test)]
+    WORKING_DIFF_PATH_HITS
+        .finite_bypass
+        .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
     let rows = hot_scan_entries(store, branch_id, generation, filter, None, None)
         .await?
         .expect("unbounded HOT scan cannot exhaust a byte budget");

--- a/packages/lix/src/live_state/tracked_head/hot.rs
+++ b/packages/lix/src/live_state/tracked_head/hot.rs
@@ -9898,6 +9898,33 @@ async fn hot_working_diff_entries(
             let Ok(after) = decode_head_value(&after) else {
                 return Ok(None);
             };
+            // Not a classification, an inconsistency guard — and deliberately
+            // stricter than the finite bypass, which merely skips an untracked
+            // or absent primary row (`finite_working_diff_versions`).
+            //
+            // The two are equivalent because the populations differ. This loop
+            // only visits identities the sparse `HOT_DIFF` index already
+            // asserts are dirty against this checkpoint, and a dirty identity
+            // always has a tracked primary row in this generation:
+            //
+            // * `HOT_DIFF` keys are only written for `!delta.untracked`
+            //   deltas, both incrementally and from the file cascade.
+            // * A primary row is physically removed only by
+            //   `CurrentStateDelta::physically_deletes` — `untracked &&
+            //   deleted`. A tracked delete writes a tombstone that keeps its
+            //   baseline, so a dirty row cannot vanish.
+            // * `reject_retention_change` forbids flipping retention while any
+            //   physical member exists, so a dirty tracked row cannot be
+            //   overwritten by an untracked one.
+            // * The scope prefix contains the checkpoint and the generation, so
+            //   a `Clean` baseline or a foreign checkpoint owner cannot appear
+            //   under the scope the epoch names.
+            //
+            // The finite bypass instead reads *all* primary rows matching a
+            // finite identity filter, where clean, untracked, and absent rows
+            // are the normal case and skipping them is the classification. It
+            // never sees this population, so keep the strict guard here rather
+            // than relaxing it to match.
             if after.untracked {
                 return Ok(None);
             }
@@ -9993,6 +10020,21 @@ async fn hot_working_diff_entries_for_finite_filter(
     }
 }
 
+/// Classifies one primary `HOT_ROW` value for the finite bypass.
+///
+/// `None` means "this scope cannot answer, replay canonically"; `Some(None)`
+/// means "this row contributes no diff entry".
+///
+/// Skipping an untracked, clean, or foreign-checkpoint row here is not the
+/// same decision the index-driven path makes for the same predicates — that
+/// path fails closed. Both are correct because they classify different
+/// populations: this one sees every primary row matching a finite identity
+/// filter, where untracked/clean/absent rows are ordinary and not dirty, while
+/// the index-driven path only ever sees identities `HOT_DIFF` already asserts
+/// are dirty, where those same states would be corruption. See the equivalence
+/// argument in `hot_working_diff_entries`; the reachable-state proof is
+/// exercised end to end by
+/// `working_diff_finite_bypass_and_index_scan_agree_on_every_row_state`.
 fn finite_working_diff_versions(
     bytes: &Bytes,
     checkpoint_commit_id: CommitId,

--- a/packages/lix/src/live_state/tracked_head/hot.rs
+++ b/packages/lix/src/live_state/tracked_head/hot.rs
@@ -10653,10 +10653,53 @@ fn encode_hot_diff_key_parts(
 ///   into segments keyed by `scope ++ digest`; the identity components leave
 ///   the key for the segment value altogether.
 ///
-/// The order is therefore an arbitrary but load-bearing input to the
-/// coverage hash: every writer, the segment visitor, and the stored epoch
-/// coverage must produce these bytes identically. Change it only for a
-/// reason, and only everywhere at once.
+/// The order is not arbitrary in one respect: it is exactly
+/// `compare_hot_deltas`, the order a publication's deltas are already sorted
+/// in, so the segment packer can append identity suffixes without a second
+/// sort. It is otherwise a load-bearing input to the coverage hash: every
+/// writer, the segment visitor, and the stored epoch coverage must produce
+/// these bytes identically. Change it only for a reason, and only everywhere
+/// at once.
+///
+/// # Why the proof is not partitioned
+///
+/// [`WorkingDiffIndexCoverage`] is a monoid — `group_count` is additive and
+/// `group_key_xor` is commutative — so it looks like it could be maintained
+/// per `file_id`, composed back into the scope proof, and a
+/// `scope ++ file_id` seek made legal. Two independent facts block that:
+///
+/// - **Not every coverage group is an identity.** A packed current base
+///   contributes exactly one group key naming a *commit*
+///   (`hot_scope_prefix ++ new_head`, see the collection-replacement writer),
+///   standing for a whole schema collection whose members span every file and
+///   are only recoverable through `load_commit_delta_members_with_payloads`
+///   at read time. Attributing it to file partitions means expanding it per
+///   member on the write path — reinstating the per-identity coverage cost
+///   the manifest exists to remove.
+/// - **A partition-keyed segment is not a packed segment.** A segment batches
+///   whatever identities one publication produced, in `compare_hot_deltas`
+///   order — which is this key's `schema_key ++ entity_pk ++ file_id`, so
+///   `file_id` is the *last* discriminator and identities of one file are
+///   scattered through the batch. Moving the partition ahead of the digest
+///   forces the packer to re-sort and split each publication by `file_id`, so
+///   a bulk edit spread over many files emits one segment per file — each
+///   re-paying the scope and a 32-byte digest — and most publications stop
+///   reaching `HOT_DIFF_PACK_MIN_IDENTITIES` per partition at all.
+///
+/// Measured consequence of leaving the proof scope-global (rocksdb,
+/// hetzner-cpx62-II, `working_diff_file_scope`, 9 reps, four dirty rows in the
+/// probed file): `WHERE file_id = ?` costs 0.61 ms at 1k total dirty rows and
+/// 51.6 ms at 100k — linear in the dirty set, flat in the answer — while the
+/// finite `schema_key + entity_pk + file_id` shape that bypasses this space
+/// stays at ~0.5 ms across the same range.
+///
+/// The route that would remove that scan does not need this space at all:
+/// `HOT_ROW` is already keyed `schema_key ++ file_id ++ entity_pk` and
+/// `hot_scan_entries` already owns a file-first prefix route, so a
+/// `schema_key + file_id` working-diff read could enumerate primary rows the
+/// way the finite bypass does. That trades O(dirty rows in the branch) for
+/// O(live rows in the file) and still owes a soundness argument for rows that
+/// leave `HOT_ROW` entirely (untracked deletes), so it is not implemented.
 fn append_hot_diff_key_parts(
     key_bytes: &mut Vec<u8>,
     scope: &[u8],

--- a/packages/lix/src/live_state/tracked_head/hot.rs
+++ b/packages/lix/src/live_state/tracked_head/hot.rs
@@ -10763,8 +10763,18 @@ fn encode_hot_diff_key_parts(
 /// `hot_scan_entries` already owns a file-first prefix route, so a
 /// `schema_key + file_id` working-diff read could enumerate primary rows the
 /// way the finite bypass does. That trades O(dirty rows in the branch) for
-/// O(live rows in the file) and still owes a soundness argument for rows that
-/// leave `HOT_ROW` entirely (untracked deletes), so it is not implemented.
+/// O(live rows in the file). It is still not implemented *for the working
+/// diff*, because a diff must also see identities whose current authority is a
+/// packed current base published inside this checkpoint window, and those
+/// contribute exactly the whole-commit coverage groups described above.
+///
+/// The ordinary **entity** surface has no such obligation and does take that
+/// route: `lixcol_file_id` is an exact provider constraint that lands in
+/// `LiveStateFilter::file_ids`, and every authority the live-state merge reads
+/// — `HOT_ROW`, the packed current base, the certified entity batches, and the
+/// root current base — filters on it, two of them with their own file-scoped
+/// seek. Rows that never had a branch-local `HOT_ROW` are therefore still
+/// returned by the other three legs.
 fn append_hot_diff_key_parts(
     key_bytes: &mut Vec<u8>,
     scope: &[u8],

--- a/packages/lix/src/session/context.rs
+++ b/packages/lix/src/session/context.rs
@@ -682,7 +682,7 @@ where
         self.sql_planning_cache.datafusion_session()
     }
 
-    fn datafusion_read_session(&self) -> datafusion::prelude::SessionContext {
+    fn datafusion_read_session(&self) -> crate::sql2::PooledReadSession {
         self.sql_planning_cache.datafusion_read_session()
     }
 

--- a/packages/lix/src/session/execute.rs
+++ b/packages/lix/src/session/execute.rs
@@ -1779,7 +1779,7 @@ where
                 if let IdempotencyReceiptResolution::Replay(receipt) =
                     self.resolve_idempotency_receipt(&idempotency).await?
                 {
-                    return Ok(receipt.into_results());
+                    return receipt.into_results();
                 }
                 let result = self
                     .execute_transaction_batch(
@@ -1807,7 +1807,7 @@ where
                                 // callback was bypassed by an ambiguous error.
                                 self.observe_invalidation.bump();
                                 self.file_views.clear();
-                                Ok(receipt.into_results())
+                                receipt.into_results()
                             }
                             Ok(IdempotencyReceiptResolution::Absent) => Err(error),
                             Err(recovery_error) => Err(recovery_error),

--- a/packages/lix/src/session/idempotency.rs
+++ b/packages/lix/src/session/idempotency.rs
@@ -2,9 +2,6 @@ use base64::Engine as _;
 use bytes::Bytes;
 use serde::{Deserialize, Serialize};
 
-const BASE64: base64::engine::general_purpose::GeneralPurpose =
-    base64::engine::general_purpose::STANDARD;
-
 use crate::storage_adapter::StorageSpaceId;
 use crate::storage_adapter::{
     StorageAdapterRead, StorageCoreProjection, StorageGetManyRequest, StorageGetOptions,
@@ -79,6 +76,9 @@ pub(crate) const EXECUTE_IDEMPOTENCY_RECEIPT_SPACE: StorageSpace = StorageSpace:
     StorageSpaceId(0x0007_0005),
     "session.execute_idempotency_receipt.v1",
 );
+
+const BASE64: base64::engine::general_purpose::GeneralPurpose =
+    base64::engine::general_purpose::STANDARD;
 
 const RECEIPT_VERSION: u8 = 3;
 /// Keep the retry ledger bounded even when a mutation uses `RETURNING` with a

--- a/packages/lix/src/session/idempotency.rs
+++ b/packages/lix/src/session/idempotency.rs
@@ -1,5 +1,9 @@
+use base64::Engine as _;
 use bytes::Bytes;
 use serde::{Deserialize, Serialize};
+
+const BASE64: base64::engine::general_purpose::GeneralPurpose =
+    base64::engine::general_purpose::STANDARD;
 
 use crate::storage_adapter::StorageSpaceId;
 use crate::storage_adapter::{
@@ -76,7 +80,7 @@ pub(crate) const EXECUTE_IDEMPOTENCY_RECEIPT_SPACE: StorageSpace = StorageSpace:
     "session.execute_idempotency_receipt.v1",
 );
 
-const RECEIPT_VERSION: u8 = 2;
+const RECEIPT_VERSION: u8 = 3;
 /// Keep the retry ledger bounded even when a mutation uses `RETURNING` with a
 /// large blob. The request is rejected before its transaction commits, so a
 /// successful mutation always has a replayable response.
@@ -85,18 +89,83 @@ const MAX_RECEIPT_BYTES: usize = 8 * 1024 * 1024;
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub(crate) struct ExecuteIdempotencyReceipt {
     version: u8,
-    scope: Option<String>,
     branch_id: Option<String>,
-    request_fingerprint: [u8; 32],
+    /// Base64 rather than `[u8; 32]`: `serde_json` renders a byte array as 32
+    /// decimal numbers plus separators, which costs ~115 bytes for 32 bytes of
+    /// information and dominates a receipt for a mutation with no `RETURNING`.
+    request_fingerprint: String,
     results: Vec<StoredExecuteResult>,
 }
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 struct StoredExecuteResult {
     columns: Vec<String>,
-    rows: Vec<Vec<Value>>,
+    rows: Vec<Vec<StoredValue>>,
     rows_affected: u64,
     notices: Vec<LixNotice>,
+}
+
+/// Replay-storage form of a SQL value.
+///
+/// This exists for one variant. `Value`'s own `serde` representation renders
+/// `Blob` as an array of decimal numbers, which costs 3.57 stored bytes per
+/// payload byte, so a mutation that projects file content through `RETURNING`
+/// writes almost four permanent copies of that content into the retry ledger.
+/// The match below is exhaustive, so a new `Value` variant is a compile error
+/// here rather than a silently unreplayable receipt.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+enum StoredValue {
+    Null,
+    Boolean(bool),
+    Integer(i64),
+    Real(f64),
+    Text(String),
+    Json(crate::Json),
+    Blob(String),
+}
+
+impl StoredValue {
+    fn from_value(value: &Value) -> Result<Self, LixError> {
+        Ok(match value {
+            Value::Null => Self::Null,
+            Value::Boolean(value) => Self::Boolean(*value),
+            Value::Integer(value) => Self::Integer(*value),
+            Value::Real(value) => {
+                if !value.is_finite() {
+                    return Err(LixError::new(
+                        LixError::CODE_INTERNAL_ERROR,
+                        "execute result contains a non-finite value that cannot be replayed over the protocol",
+                    ));
+                }
+                Self::Real(*value)
+            }
+            Value::Text(value) => Self::Text(value.clone()),
+            Value::Json(value) => Self::Json(value.clone()),
+            Value::Blob(value) => Self::Blob(BASE64.encode(value.as_ref())),
+        })
+    }
+
+    fn into_value(self) -> Result<Value, LixError> {
+        Ok(match self {
+            Self::Null => Value::Null,
+            Self::Boolean(value) => Value::Boolean(value),
+            Self::Integer(value) => Value::Integer(value),
+            Self::Real(value) => Value::Real(value),
+            Self::Text(value) => Value::Text(value),
+            Self::Json(value) => Value::Json(value),
+            Self::Blob(value) => Value::Blob(
+                BASE64
+                    .decode(value.as_bytes())
+                    .map_err(|error| {
+                        LixError::new(
+                            LixError::CODE_STORAGE_ERROR,
+                            format!("decode execute idempotency receipt blob: {error}"),
+                        )
+                    })?
+                    .into(),
+            ),
+        })
+    }
 }
 
 impl ExecuteIdempotencyReceipt {
@@ -113,9 +182,8 @@ impl ExecuteIdempotencyReceipt {
     ) -> Result<Self, LixError> {
         Ok(Self {
             version: RECEIPT_VERSION,
-            scope: idempotency.scope.clone(),
             branch_id: idempotency.branch_id.clone(),
-            request_fingerprint: *idempotency.request_fingerprint(),
+            request_fingerprint: BASE64.encode(idempotency.request_fingerprint()),
             results: results
                 .iter()
                 .map(StoredExecuteResult::from_execute_result)
@@ -123,15 +191,19 @@ impl ExecuteIdempotencyReceipt {
         })
     }
 
+    /// `scope` is deliberately not a stored field. [`receipt_key`] is injective
+    /// over `(scope, key)` — it length-prefixes both components and carries the
+    /// scope's presence bit — so a receipt read at a key *is* a receipt for that
+    /// key's scope. Storing it again would make the value a second authority for
+    /// a fact the key already decides.
     pub(crate) fn matches(&self, idempotency: &ExecuteIdempotency) -> bool {
         self.version == RECEIPT_VERSION
-            && self.scope.as_deref() == idempotency.scope()
             && self.branch_id.as_deref() == idempotency.branch_id()
-            && self.request_fingerprint == *idempotency.request_fingerprint()
+            && self.request_fingerprint == BASE64.encode(idempotency.request_fingerprint())
     }
 
     pub(crate) fn into_single_result(self) -> Result<ExecuteResult, LixError> {
-        let mut results = self.into_results();
+        let mut results = self.into_results()?;
         if results.len() != 1 {
             return Err(LixError::new(
                 LixError::CODE_INTERNAL_ERROR,
@@ -141,8 +213,11 @@ impl ExecuteIdempotencyReceipt {
         Ok(results.remove(0))
     }
 
-    pub(crate) fn into_results(self) -> Vec<ExecuteResult> {
-        self.results.into_iter().map(ExecuteResult::from).collect()
+    pub(crate) fn into_results(self) -> Result<Vec<ExecuteResult>, LixError> {
+        self.results
+            .into_iter()
+            .map(StoredExecuteResult::into_execute_result)
+            .collect()
     }
 }
 
@@ -154,7 +229,7 @@ impl StoredExecuteResult {
             .map(|row| {
                 row.values()
                     .iter()
-                    .map(replayable_value)
+                    .map(StoredValue::from_value)
                     .collect::<Result<Vec<_>, _>>()
             })
             .collect::<Result<Vec<_>, _>>()?;
@@ -165,16 +240,23 @@ impl StoredExecuteResult {
             notices: result.notices().to_vec(),
         })
     }
-}
 
-impl From<StoredExecuteResult> for ExecuteResult {
-    fn from(result: StoredExecuteResult) -> Self {
-        Self::from_idempotency_parts(
-            result.columns,
-            result.rows,
-            result.rows_affected,
-            result.notices,
-        )
+    fn into_execute_result(self) -> Result<ExecuteResult, LixError> {
+        let rows = self
+            .rows
+            .into_iter()
+            .map(|row| {
+                row.into_iter()
+                    .map(StoredValue::into_value)
+                    .collect::<Result<Vec<_>, _>>()
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+        Ok(ExecuteResult::from_idempotency_parts(
+            self.columns,
+            rows,
+            self.rows_affected,
+            self.notices,
+        ))
     }
 }
 
@@ -262,14 +344,112 @@ fn receipt_key(idempotency: &ExecuteIdempotency) -> Result<StorageKey, LixError>
     Ok(StorageKey(Bytes::from(bytes)))
 }
 
-fn replayable_value(value: &Value) -> Result<Value, LixError> {
-    if let Value::Real(value) = value
-        && !value.is_finite()
-    {
-        return Err(LixError::new(
-            LixError::CODE_INTERNAL_ERROR,
-            "execute result contains a non-finite value that cannot be replayed over the protocol",
-        ));
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::Blob;
+
+    fn identity() -> ExecuteIdempotency {
+        ExecuteIdempotency::new(
+            Some("usr_expIR".to_owned()),
+            "key-expIR".to_owned(),
+            [7u8; 32],
+        )
+        .with_branch("0199aaaa-bbbb-cccc-dddd-eeeeeeeeeeee".to_owned())
     }
-    Ok(value.clone())
+
+    fn roundtrip(values: Vec<Value>) -> Vec<Value> {
+        let identity = identity();
+        let result = ExecuteResult::from_rows(vec!["c".to_owned()], vec![values]);
+        let receipt = ExecuteIdempotencyReceipt::single(&identity, &result).expect("build receipt");
+        let (_, encoded) = encode_receipt(&identity, &receipt).expect("encode receipt");
+        let decoded: ExecuteIdempotencyReceipt =
+            serde_json::from_slice(&encoded).expect("decode receipt");
+        assert!(decoded.matches(&identity), "decoded receipt must replay");
+        decoded
+            .into_single_result()
+            .expect("replay result")
+            .rows()
+            .first()
+            .expect("one row")
+            .values()
+            .to_vec()
+    }
+
+    /// Every SQL value shape must survive the storage form byte for byte; the
+    /// replay contract is that a retry sees the recorded response.
+    #[test]
+    fn every_value_variant_replays_unchanged() {
+        let values = vec![
+            Value::Null,
+            Value::Boolean(true),
+            Value::Integer(-42),
+            Value::Real(1.5),
+            Value::Text("text".to_owned()),
+            Value::Blob(Blob::from(vec![0u8, 255, 1, 128, 7])),
+        ];
+        assert_eq!(roundtrip(values.clone()), values);
+    }
+
+    /// Blob payloads are the reason this encoding exists: `Value`'s own serde
+    /// form spends 3.57 stored bytes per payload byte.
+    #[test]
+    fn blob_payloads_cost_roughly_their_own_size() {
+        let payload = (0..4096u32).map(|byte| byte as u8).collect::<Vec<_>>();
+        let identity = identity();
+        let result = ExecuteResult::from_rows(
+            vec!["content".to_owned()],
+            vec![vec![Value::Blob(Blob::from(payload.clone()))]],
+        );
+        let receipt = ExecuteIdempotencyReceipt::single(&identity, &result).expect("build receipt");
+        let (_, encoded) = encode_receipt(&identity, &receipt).expect("encode receipt");
+        assert!(
+            encoded.len() < payload.len() * 2,
+            "a {}-byte payload must not cost {} receipt bytes",
+            payload.len(),
+            encoded.len()
+        );
+    }
+
+    /// A non-finite float cannot cross the protocol, so it must be refused
+    /// while the mutation can still be rejected rather than at replay time.
+    #[test]
+    fn non_finite_reals_are_refused_before_commit() {
+        let identity = identity();
+        let result = ExecuteResult::from_rows(
+            vec!["c".to_owned()],
+            vec![vec![Value::Real(f64::INFINITY)]],
+        );
+        let error =
+            ExecuteIdempotencyReceipt::single(&identity, &result).expect_err("must be refused");
+        assert_eq!(error.code, LixError::CODE_INTERNAL_ERROR);
+    }
+
+    /// The storage key already decides the scope, so the value must not carry
+    /// it — but a differing scope must still never replay, because it lands on
+    /// a different key.
+    #[test]
+    fn scope_is_decided_by_the_key_alone() {
+        let scoped = ExecuteIdempotency::new(
+            Some("usr_a".to_owned()),
+            "shared-key".to_owned(),
+            [7u8; 32],
+        );
+        let other = ExecuteIdempotency::new(
+            Some("usr_b".to_owned()),
+            "shared-key".to_owned(),
+            [7u8; 32],
+        );
+        let unscoped =
+            ExecuteIdempotency::new(None, "shared-key".to_owned(), [7u8; 32]);
+        let empty_scope =
+            ExecuteIdempotency::new(Some(String::new()), "shared-key".to_owned(), [7u8; 32]);
+        let keys = [&scoped, &other, &unscoped, &empty_scope]
+            .map(|identity| receipt_key(identity).expect("build key"));
+        for left in 0..keys.len() {
+            for right in (left + 1)..keys.len() {
+                assert_ne!(keys[left], keys[right], "receipt keys must not alias");
+            }
+        }
+    }
 }

--- a/packages/lix/src/session/media_upload.rs
+++ b/packages/lix/src/session/media_upload.rs
@@ -334,7 +334,12 @@ where
                 }
                 Some(UploadState::Complete(_)) => unreachable!("complete state returned above"),
             }
-            crate::binary_cas::stage_mutation_epoch(&read, &mut writes, &mut preconditions).await?;
+            crate::binary_cas::stage_cas_publication_fence(
+                &read,
+                &mut writes,
+                &mut preconditions,
+            )
+            .await?;
             drop(read);
 
             let commit_boundary = self.transaction_commit_boundary();
@@ -960,9 +965,9 @@ mod tests {
                 key: state_key,
             },
         ];
-        crate::binary_cas::stage_mutation_epoch(read, &mut writes, &mut preconditions)
+        crate::binary_cas::stage_cas_publication_fence(read, &mut writes, &mut preconditions)
             .await
-            .expect("deduplicated receipt epoch should stage");
+            .expect("deduplicated receipt publication fence should stage");
         (writes, preconditions)
     }
 
@@ -984,9 +989,9 @@ mod tests {
         .await
         .expect("stale CAS sweep should stage");
         assert_eq!(swept.reclaimed_chunk_rows, 1);
-        crate::binary_cas::stage_mutation_epoch(read, &mut writes, &mut preconditions)
+        crate::binary_cas::stage_cas_reclamation_fence(read, &mut writes, &mut preconditions)
             .await
-            .expect("stale sweep epoch should stage");
+            .expect("stale sweep reclamation fence should stage");
         (writes, preconditions)
     }
 

--- a/packages/lix/src/session/media_upload.rs
+++ b/packages/lix/src/session/media_upload.rs
@@ -917,6 +917,58 @@ mod tests {
         receipts[0].hash
     }
 
+    /// A resumable upload keeps four parts in flight by design, and the engine —
+    /// not the caller — owns that window. Parts staged from one snapshot write
+    /// disjoint manifest leaves over content-addressed payloads, so they are
+    /// independent publications: every one of them must commit.
+    ///
+    /// Making publishers share a compare-and-set row broke exactly this. It was
+    /// invisible at the public surface because `upsert_file_content_part` retries
+    /// a bounded number of times — a full window plus any other concurrent writer
+    /// exhausts that budget, which is how the movie-workspace qualification fails
+    /// its upload acknowledgement.
+    #[tokio::test]
+    async fn concurrent_upload_part_publications_from_one_snapshot_all_commit() {
+        let storage = StorageAdapter::new(Memory::new());
+        let payload = b"windowed-upload-part-payload";
+        seed_orphan_upload_chunk(&storage, payload).await;
+        let read = storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("upload window read should open");
+        let mut window = Vec::new();
+        for part in 0..4 {
+            window.push(
+                stage_deduplicated_receipt_publication(
+                    &storage,
+                    &read,
+                    &format!("windowed-part-{part}"),
+                    payload,
+                    true,
+                )
+                .await,
+            );
+        }
+        drop(read);
+
+        for (part, (writes, preconditions)) in window.into_iter().enumerate() {
+            storage
+                .commit_write_set(
+                    writes,
+                    StorageWriteOptions {
+                        preconditions,
+                        ..StorageWriteOptions::default()
+                    },
+                )
+                .await
+                .unwrap_or_else(|error| {
+                    panic!(
+                        "every part of one upload window must commit; part {part} was rejected: {error:?}"
+                    )
+                });
+        }
+    }
+
     async fn stage_deduplicated_receipt_publication(
         storage: &StorageAdapter<Memory>,
         read: &impl StorageAdapterRead,

--- a/packages/lix/src/sql2/catalog/registry.rs
+++ b/packages/lix/src/sql2/catalog/registry.rs
@@ -47,14 +47,22 @@ impl PublicCatalog {
     /// complete `lix_*` namespace, so only trusted bootstrap schemas can add
     /// Lix-owned surfaces to this catalog.
     pub(crate) fn fixed_system() -> &'static Self {
-        static FIXED_SYSTEM_CATALOG: OnceLock<PublicCatalog> = OnceLock::new();
+        Self::fixed_system_shared()
+    }
+
+    /// The same immutable catalog behind an `Arc` so per-statement provider
+    /// registration can share it instead of deep-copying two `BTreeMap`s.
+    pub(crate) fn fixed_system_shared() -> &'static Arc<Self> {
+        static FIXED_SYSTEM_CATALOG: OnceLock<Arc<PublicCatalog>> = OnceLock::new();
         FIXED_SYSTEM_CATALOG.get_or_init(|| {
             let schemas = crate::schema::seed_schema_definitions()
                 .into_iter()
                 .cloned()
                 .collect::<Vec<_>>();
-            Self::from_visible_schemas(&schemas)
-                .expect("compile-time Lix schemas must form a valid SQL catalog")
+            Arc::new(
+                Self::from_visible_schemas(&schemas)
+                    .expect("compile-time Lix schemas must form a valid SQL catalog"),
+            )
         })
     }
 

--- a/packages/lix/src/sql2/context.rs
+++ b/packages/lix/src/sql2/context.rs
@@ -99,8 +99,8 @@ pub(crate) trait SqlExecutionContext: Sync {
     fn datafusion_session(&self) -> datafusion::prelude::SessionContext {
         super::session::new_sql_session_context()
     }
-    fn datafusion_read_session(&self) -> datafusion::prelude::SessionContext {
-        self.datafusion_session()
+    fn datafusion_read_session(&self) -> super::planning_cache::PooledReadSession {
+        super::planning_cache::PooledReadSession::standalone(self.datafusion_session())
     }
     async fn sql_planning_environment(
         &self,

--- a/packages/lix/src/sql2/exec/datafusion.rs
+++ b/packages/lix/src/sql2/exec/datafusion.rs
@@ -70,11 +70,13 @@ use crate::sql2::{
 };
 
 use super::{SqlDataFusionLogicalPlan, SqlLogicalPlan, SqlWriteResult};
+use crate::sql2::PooledReadSession;
+use datafusion::execution::SessionState;
 
 pub(crate) const LIX_INSERT_COLUMN_OMITTED_METADATA_KEY: &str = "lix_insert_column_omitted";
 
 pub(crate) struct DataFusionLogicalPlan {
-    pub(super) session: SessionContext,
+    pub(super) state: std::sync::Arc<SessionState>,
     pub(super) plan: LogicalPlan,
     pub(super) notices: Vec<LixNotice>,
     pub(super) json_predicate_params: BTreeSet<usize>,
@@ -240,7 +242,7 @@ impl SessionReadResult {
 
 /// DataFusion catalog and providers scoped to one immutable storage read.
 pub(crate) struct ReadSqlSession<'ctx> {
-    session: SessionContext,
+    session: Option<PooledReadSession>,
     planning_environment: Option<(
         std::sync::Arc<SqlPlanningCache<CatalogFingerprint>>,
         CatalogFingerprint,
@@ -248,10 +250,27 @@ pub(crate) struct ReadSqlSession<'ctx> {
     _context: PhantomData<&'ctx ()>,
 }
 
+impl ReadSqlSession<'_> {
+    fn pooled(&self) -> &PooledReadSession {
+        self.session
+            .as_ref()
+            .expect("read session is only taken back when the statement ends")
+    }
+
+    fn context(&self) -> &SessionContext {
+        self.pooled().context()
+    }
+
+    fn state(&self) -> &std::sync::Arc<SessionState> {
+        self.pooled().state()
+    }
+}
+
 impl Drop for ReadSqlSession<'_> {
     fn drop(&mut self) {
-        if let Some((cache, _)) = &self.planning_environment {
-            cache.recycle_datafusion_read_session(self.session.clone());
+        if let (Some((cache, _)), Some(session)) = (&self.planning_environment, self.session.take())
+        {
+            cache.recycle_datafusion_read_session(session);
         }
     }
 }
@@ -288,7 +307,7 @@ where
 {
     let planning_environment = ctx.sql_planning_environment().await?;
     Ok(ReadSqlSession {
-        session: build_read_session(ctx, statements).await?,
+        session: Some(build_read_session(ctx, statements).await?),
         planning_environment,
         _context: PhantomData,
     })
@@ -304,7 +323,7 @@ where
 {
     let planning_environment = ctx.sql_planning_environment().await?;
     Ok(ReadSqlSession {
-        session: build_read_session_at_head(ctx, active_head, statements).await?,
+        session: Some(build_read_session_at_head(ctx, active_head, statements).await?),
         planning_environment,
         _context: PhantomData,
     })
@@ -406,9 +425,9 @@ async fn create_logical_plan_in_session_from_parsed(
         && let Some((cache, catalog)) = &session.planning_environment
         && let Some(cached) = cache.read_plan(sql, params, catalog)
     {
-        let plan = rebind_cached_read_plan(&session.session, cached.plan.clone()).await?;
+        let plan = rebind_cached_read_plan(session.context(), cached.plan.clone()).await?;
         return Ok(SqlLogicalPlan::DataFusion(SqlDataFusionLogicalPlan {
-            session: session.session.clone(),
+            state: std::sync::Arc::clone(session.state()),
             plan,
             notices: Vec::new(),
             json_predicate_params: cached.json_predicate_params.clone(),
@@ -418,7 +437,7 @@ async fn create_logical_plan_in_session_from_parsed(
         }));
     }
     bind_table_function_parameters(&mut statement, params)?;
-    let plan = create_logical_plan_from_statement(&session.session, statement).await?;
+    let plan = create_logical_plan_from_statement(session.context(), statement).await?;
     validate_supported_logical_plan(&plan)?;
     validate_json_predicates_in_logical_plan(&plan)?;
     validate_history_anchor_predicates_in_logical_plan(&plan)?;
@@ -451,7 +470,7 @@ async fn create_logical_plan_in_session_from_parsed(
     };
 
     Ok(SqlLogicalPlan::DataFusion(SqlDataFusionLogicalPlan {
-        session: session.session.clone(),
+        state: std::sync::Arc::clone(session.state()),
         plan,
         notices: Vec::new(),
         json_predicate_params,
@@ -530,7 +549,7 @@ fn logical_plan_has_scalar_function(plan: &LogicalPlan) -> bool {
     found
 }
 
-fn statement_has_table_function(statement: &DataFusionStatement) -> bool {
+pub(crate) fn statement_has_table_function(statement: &DataFusionStatement) -> bool {
     struct TableFunctionVisitor(bool);
 
     impl Visitor for TableFunctionVisitor {
@@ -566,14 +585,10 @@ pub(crate) async fn execute_transaction_read_statement_from_parsed(
     // Same fence as session reads, with the transaction overlay available
     // during planning/execution but not returned to the caller.
     let planning_environment = read_ctx.sql_planning_environment().await?;
-    let plan = create_transaction_read_logical_plan_from_parsed(
+    let (plan, session) = create_transaction_read_logical_plan_from_parsed(
         read_ctx, write_ctx, sql, statement, params,
     )
     .await?;
-    let session = match &plan {
-        SqlLogicalPlan::DataFusion(plan) => plan.session.clone(),
-        _ => unreachable!("transaction reads are planned by DataFusion"),
-    };
     let result = execute_logical_plan(plan, params)
         .await
         .and_then(SessionReadResult::into_sql_query_result);
@@ -589,27 +604,30 @@ async fn create_transaction_read_logical_plan_from_parsed(
     sql: &str,
     mut statement: DataFusionStatement,
     params: &[Value],
-) -> Result<SqlLogicalPlan, LixError> {
+) -> Result<(SqlLogicalPlan, PooledReadSession), LixError> {
     crate::sql2::bind_read_statement(sql, &statement)?;
     let parameter_names = statement_parameter_names(&statement)?;
     let expected_parameter_count = expected_positional_parameter_count(&parameter_names)?;
     validate_parameter_count_values(expected_parameter_count, &parameter_names, params.len())?;
     bind_table_function_parameters(&mut statement, params)?;
     let session = build_transaction_read_session(read_ctx, write_ctx, &statement).await?;
-    let plan = create_logical_plan_from_statement(&session, statement).await?;
+    let plan = create_logical_plan_from_statement(session.context(), statement).await?;
     validate_supported_logical_plan(&plan)?;
     validate_json_predicates_in_logical_plan(&plan)?;
     validate_history_anchor_predicates_in_logical_plan(&plan)?;
     let json_predicate_params = json_predicate_params_in_logical_plan(&plan);
 
-    Ok(SqlLogicalPlan::DataFusion(SqlDataFusionLogicalPlan {
+    Ok((
+        SqlLogicalPlan::DataFusion(SqlDataFusionLogicalPlan {
+            state: std::sync::Arc::clone(session.state()),
+            plan,
+            notices: Vec::new(),
+            json_predicate_params,
+            expected_parameter_count,
+            physical_planning_cache: None,
+        }),
         session,
-        plan,
-        notices: Vec::new(),
-        json_predicate_params,
-        expected_parameter_count,
-        physical_planning_cache: None,
-    }))
+    ))
 }
 
 async fn create_logical_plan_from_statement(
@@ -1285,6 +1303,20 @@ fn validate_history_anchor_predicates_in_logical_plan(plan: &LogicalPlan) -> Res
     visit_history_anchor_plan(plan, &[]).map(|_| ())
 }
 
+/// Substitutes positional parameters into a bound read plan.
+///
+/// Mirrors `DataFrame::with_param_values`, which is exactly
+/// `LogicalPlan::with_param_values` plus a `SessionState` it does not need.
+fn bind_plan_param_values(plan: LogicalPlan, params: &[Value]) -> Result<LogicalPlan, LixError> {
+    if params.is_empty() {
+        return Ok(plan);
+    }
+    plan.with_param_values(ParamValues::List(
+        params.iter().map(scalar_value_from_lix_value).collect(),
+    ))
+    .map_err(datafusion_error_to_lix_error)
+}
+
 async fn execute_logical_plan(
     plan: SqlLogicalPlan,
     params: &[Value],
@@ -1296,7 +1328,7 @@ async fn execute_logical_plan(
         ));
     };
     let SqlDataFusionLogicalPlan {
-        session,
+        state,
         plan,
         notices,
         json_predicate_params,
@@ -1306,25 +1338,20 @@ async fn execute_logical_plan(
     debug_assert_eq!(expected_parameter_count, params.len());
     validate_json_predicate_params(&json_predicate_params, params)?;
 
-    let mut dataframe = session
-        .execute_logical_plan(plan)
-        .await
-        .map_err(datafusion_error_to_lix_error)?;
-    if !params.is_empty() {
-        dataframe = dataframe
-            .with_param_values(ParamValues::List(
-                params.iter().map(scalar_value_from_lix_value).collect(),
-            ))
-            .map_err(datafusion_error_to_lix_error)?;
-    }
+    // `SessionContext::execute_logical_plan` only branches for DDL and utility
+    // statements, both of which `validate_supported_logical_plan` already
+    // rejects, and otherwise wraps the plan in a `DataFrame` whose only purpose
+    // here is to carry a freshly deep-copied `SessionState`. Bind the
+    // parameters on the plan directly against the statement's pooled state.
+    let plan = bind_plan_param_values(plan, params)?;
 
-    let result_fields = dataframe
+    let result_fields = plan
         .schema()
         .fields()
         .iter()
         .map(|field| field.as_ref().clone())
         .collect::<Vec<_>>();
-    let batches = crate::sql2::runtime::collect_dataframe(dataframe, physical_planning_cache)
+    let batches = crate::sql2::runtime::collect_plan(&state, plan, physical_planning_cache)
         .await
         .map_err(datafusion_error_to_lix_error)?;
     // This is a benchmark-only causal ceiling probe. It keeps DataFusion's
@@ -1375,7 +1402,7 @@ async fn execute_logical_plan_stream<'session>(
         ));
     };
     let SqlDataFusionLogicalPlan {
-        session,
+        state,
         plan,
         notices,
         json_predicate_params,
@@ -1385,24 +1412,19 @@ async fn execute_logical_plan_stream<'session>(
     debug_assert_eq!(expected_parameter_count, params.len());
     validate_json_predicate_params(&json_predicate_params, params)?;
 
-    let mut dataframe = session
-        .execute_logical_plan(plan)
-        .await
-        .map_err(datafusion_error_to_lix_error)?;
-    if !params.is_empty() {
-        dataframe = dataframe
-            .with_param_values(ParamValues::List(
-                params.iter().map(scalar_value_from_lix_value).collect(),
-            ))
-            .map_err(datafusion_error_to_lix_error)?;
-    }
-    let fields = dataframe
+    // `SessionContext::execute_logical_plan` only branches for DDL and utility
+    // statements, both of which `validate_supported_logical_plan` already
+    // rejects, and otherwise wraps the plan in a `DataFrame` whose only purpose
+    // here is to carry a freshly deep-copied `SessionState`. Bind the
+    // parameters on the plan directly against the statement's pooled state.
+    let plan = bind_plan_param_values(plan, params)?;
+    let fields = plan
         .schema()
         .fields()
         .iter()
         .map(|field| field.as_ref().clone())
         .collect::<Vec<_>>();
-    let stream = crate::sql2::runtime::stream_dataframe(dataframe, physical_planning_cache)
+    let stream = crate::sql2::runtime::stream_plan(&state, plan, physical_planning_cache)
         .await
         .map_err(datafusion_error_to_lix_error)?;
     Ok(SessionReadBatchStreamResult {
@@ -1425,7 +1447,7 @@ async fn execute_logical_plan_collected_batches(
         ));
     };
     let SqlDataFusionLogicalPlan {
-        session,
+        state,
         plan,
         notices,
         json_predicate_params,
@@ -1435,24 +1457,19 @@ async fn execute_logical_plan_collected_batches(
     debug_assert_eq!(expected_parameter_count, params.len());
     validate_json_predicate_params(&json_predicate_params, params)?;
 
-    let mut dataframe = session
-        .execute_logical_plan(plan)
-        .await
-        .map_err(datafusion_error_to_lix_error)?;
-    if !params.is_empty() {
-        dataframe = dataframe
-            .with_param_values(ParamValues::List(
-                params.iter().map(scalar_value_from_lix_value).collect(),
-            ))
-            .map_err(datafusion_error_to_lix_error)?;
-    }
-    let fields = dataframe
+    // `SessionContext::execute_logical_plan` only branches for DDL and utility
+    // statements, both of which `validate_supported_logical_plan` already
+    // rejects, and otherwise wraps the plan in a `DataFrame` whose only purpose
+    // here is to carry a freshly deep-copied `SessionState`. Bind the
+    // parameters on the plan directly against the statement's pooled state.
+    let plan = bind_plan_param_values(plan, params)?;
+    let fields = plan
         .schema()
         .fields()
         .iter()
         .map(|field| field.as_ref().clone())
         .collect::<Vec<_>>();
-    let batches = crate::sql2::runtime::collect_dataframe(dataframe, physical_planning_cache)
+    let batches = crate::sql2::runtime::collect_plan(&state, plan, physical_planning_cache)
         .await
         .map_err(datafusion_error_to_lix_error)?;
     Ok(SessionReadCollectedBatchResult {

--- a/packages/lix/src/sql2/exec/mod.rs
+++ b/packages/lix/src/sql2/exec/mod.rs
@@ -77,7 +77,7 @@ pub(crate) use datafusion::{
     DataFusionLogicalPlan as SqlDataFusionLogicalPlan, SessionReadResult, SessionReadSqlResult,
     execute_read_statement_in_session_from_parsed, execute_read_statement_in_session_with_result,
     execute_transaction_read_statement_from_parsed, prepare_read_session,
-    prepare_read_session_at_head, query_result_from_batches,
+    prepare_read_session_at_head, query_result_from_batches, statement_has_table_function,
 };
 #[cfg(test)]
 pub(crate) use write::{

--- a/packages/lix/src/sql2/information_schema.rs
+++ b/packages/lix/src/sql2/information_schema.rs
@@ -30,12 +30,18 @@ const TABLE_FUNCTIONS: &str = "table_functions";
 /// between read nullability and insert-time omission/default behavior.
 pub(crate) fn register(
     session: &SessionContext,
-    public_catalog: &PublicCatalog,
+    public_catalog: Arc<PublicCatalog>,
 ) -> Result<(), LixError> {
-    let state = session.state();
+    // Borrow the live session state. `SessionState::clone` deep-copies the
+    // `String`-keyed registries for every built-in scalar, aggregate and window
+    // function; this call site only needs two config strings and the catalog
+    // list `Arc`.
+    let state_ref = session.state_ref();
+    let state = state_ref.read();
     let catalog_name = state.config_options().catalog.default_catalog.clone();
     let schema_name = state.config_options().catalog.default_schema.clone();
     let catalog_list = Arc::clone(state.catalog_list());
+    drop(state);
     let catalog = catalog_list.catalog(&catalog_name).ok_or_else(|| {
         LixError::new(
             LixError::CODE_INTERNAL_ERROR,
@@ -44,7 +50,7 @@ pub(crate) fn register(
     })?;
     let provider: Arc<dyn SchemaProvider> = Arc::new(LixInformationSchemaProvider::new(
         catalog_list,
-        public_catalog.clone(),
+        public_catalog,
         catalog_name.clone(),
         schema_name,
     ));
@@ -60,7 +66,7 @@ struct LixInformationSchemaProvider {
     // reference here would create a cycle that retains every session table
     // provider and its storage read handles.
     catalog_list: Weak<dyn CatalogProviderList>,
-    public_catalog: PublicCatalog,
+    public_catalog: Arc<PublicCatalog>,
     public_catalog_name: String,
     public_schema_name: String,
 }
@@ -68,7 +74,7 @@ struct LixInformationSchemaProvider {
 impl LixInformationSchemaProvider {
     fn new(
         catalog_list: Arc<dyn CatalogProviderList>,
-        public_catalog: PublicCatalog,
+        public_catalog: Arc<PublicCatalog>,
         public_catalog_name: String,
         public_schema_name: String,
     ) -> Self {

--- a/packages/lix/src/sql2/mod.rs
+++ b/packages/lix/src/sql2/mod.rs
@@ -96,8 +96,8 @@ pub(crate) use file_view::{
 pub(crate) use parse::parse_statement;
 pub(crate) use plan::plan_write;
 pub(crate) use planning_cache::{
-    CachedPhysicalRead, CachedReadPlan, CachedUpdateLiteralShape, PhysicalReadPlanCacheKey,
-    PooledReadSession, SqlPlanningCache,
+    CachedPhysicalRead, CachedReadPlan, CachedScanRequest, CachedUpdateLiteralShape,
+    PhysicalReadPlanCacheKey, PooledReadSession, SqlPlanningCache,
 };
 pub(crate) use providers::{
     ExactLixFileReadColumn, ExactLixFileReadSelector, FastLixFilePathWriteConflict,

--- a/packages/lix/src/sql2/mod.rs
+++ b/packages/lix/src/sql2/mod.rs
@@ -97,7 +97,7 @@ pub(crate) use parse::parse_statement;
 pub(crate) use plan::plan_write;
 pub(crate) use planning_cache::{
     CachedPhysicalRead, CachedReadPlan, CachedUpdateLiteralShape, PhysicalReadPlanCacheKey,
-    SqlPlanningCache,
+    PooledReadSession, SqlPlanningCache,
 };
 pub(crate) use providers::{
     ExactLixFileReadColumn, ExactLixFileReadSelector, FastLixFilePathWriteConflict,

--- a/packages/lix/src/sql2/planning_cache.rs
+++ b/packages/lix/src/sql2/planning_cache.rs
@@ -33,16 +33,27 @@ pub(crate) struct CachedReadPlan {
     pub(crate) expected_parameter_count: usize,
 }
 
-/// One reusable physical read template plus the optimized logical plan it was
+/// One reusable physical read template plus the leaf scan requests it was
 /// planned from.
 ///
-/// Both are stripped of snapshot-bound table providers. Keeping the optimized
-/// plan with the template is what makes a warm execution skip DataFusion's
-/// analyzer and logical optimizer entirely: the only work left is grafting the
-/// current snapshot's providers back on and re-planning the leaf scans.
+/// The template is stripped of snapshot-bound table providers, and the scan
+/// requests carry no provider at all — only the table name, projection,
+/// unnormalized filters and fetch that the optimizer settled on for this exact
+/// cache key. A warm execution therefore skips DataFusion's analyzer, logical
+/// optimizer and physical planner entirely: it resolves each table against the
+/// current session, replans just that leaf, and grafts it into the template.
 pub(crate) struct CachedPhysicalRead {
-    pub(crate) optimized: LogicalPlan,
+    pub(crate) scans: Vec<CachedScanRequest>,
     pub(crate) template: Arc<dyn ExecutionPlan>,
+}
+
+/// One leaf `TableScan` of a cached optimized plan, reduced to the arguments
+/// `TableProvider::scan_with_args` needs.
+pub(crate) struct CachedScanRequest {
+    pub(crate) table: datafusion::common::TableReference,
+    pub(crate) projection: Option<Vec<usize>>,
+    pub(crate) filters: Vec<datafusion::logical_expr::Expr>,
+    pub(crate) fetch: Option<usize>,
 }
 
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
@@ -94,13 +105,6 @@ pub(crate) struct CachedUpdateLiteralShape {
     suffix_start: usize,
 }
 
-/// Bounded, engine-owned cache for snapshot-independent SQL planning templates.
-///
-/// Parsed statements depend only on the exact SQL text. Bound write plans also
-/// depend on the visible catalog and active branch because binding resolves
-/// public surfaces and injects branch scope. Cached DataFusion read plans are
-/// stripped of snapshot-bound providers and rebound to the current read
-/// session before execution.
 /// One DataFusion session borrowed from the engine's pool for the duration of
 /// one statement.
 ///
@@ -156,6 +160,13 @@ impl PooledReadSession {
     }
 }
 
+/// Bounded, engine-owned cache for snapshot-independent SQL planning templates.
+///
+/// Parsed statements depend only on the exact SQL text. Bound write plans also
+/// depend on the visible catalog and active branch because binding resolves
+/// public surfaces and injects branch scope. Cached DataFusion read plans are
+/// stripped of snapshot-bound providers and rebound to the current read
+/// session before execution.
 pub(crate) struct SqlPlanningCache<CatalogKey> {
     datafusion_state: SessionState,
     read_sessions: Mutex<Vec<PooledReadSession>>,

--- a/packages/lix/src/sql2/planning_cache.rs
+++ b/packages/lix/src/sql2/planning_cache.rs
@@ -11,7 +11,6 @@ use datafusion::catalog::{
     MemorySchemaProvider,
 };
 use datafusion::execution::session_state::SessionState;
-use datafusion::execution::session_state::SessionStateBuilder;
 use datafusion::logical_expr::LogicalPlan;
 use datafusion::physical_plan::ExecutionPlan;
 use datafusion::prelude::SessionContext;
@@ -220,10 +219,7 @@ where
             .register_schema("public", Arc::new(MemorySchemaProvider::new()))
             .expect("fresh DataFusion catalog accepts the public schema");
         catalogs.register_catalog("datafusion".to_string(), catalog);
-        let state = SessionStateBuilder::new_from_existing(self.datafusion_state.clone())
-            .with_catalog_list(catalogs)
-            .build();
-        super::session::attach_execution_slots(SessionContext::new_with_state(state))
+        super::session::sql_session_from_template(self.datafusion_state.clone(), Some(catalogs))
     }
 
     pub(crate) fn datafusion_read_session(&self) -> PooledReadSession {

--- a/packages/lix/src/sql2/planning_cache.rs
+++ b/packages/lix/src/sql2/planning_cache.rs
@@ -101,9 +101,64 @@ pub(crate) struct CachedUpdateLiteralShape {
 /// public surfaces and injects branch scope. Cached DataFusion read plans are
 /// stripped of snapshot-bound providers and rebound to the current read
 /// session before execution.
+/// One DataFusion session borrowed from the engine's pool for the duration of
+/// one statement.
+///
+/// The `SessionState` travels with the session instead of being cloned out of
+/// it per statement. `SessionState::clone` deep-copies the `String`-keyed
+/// registries for every built-in scalar, aggregate, window and table function;
+/// with the execution UDFs registered once at session construction those
+/// registries no longer change, so the pooled copy stays authoritative for the
+/// lifetime of the session.
+pub(crate) struct PooledReadSession {
+    context: SessionContext,
+    state: Arc<SessionState>,
+}
+
+impl PooledReadSession {
+    fn new(context: SessionContext) -> Self {
+        let state = Arc::new(context.state());
+        Self { context, state }
+    }
+
+    /// A session that is not owned by any pool, used by lightweight contexts
+    /// that build one DataFusion session per statement.
+    pub(crate) fn standalone(context: SessionContext) -> Self {
+        Self::new(context)
+    }
+
+    pub(crate) fn context(&self) -> &SessionContext {
+        &self.context
+    }
+
+    /// The session state for this statement.
+    ///
+    /// Table registration flows through the shared catalog list, so this stays
+    /// current for provider resolution. Per-statement table-valued functions
+    /// are registered on the live session and are resolved there during logical
+    /// planning; this copy is used for physical planning and execution, which
+    /// never resolves a function by name.
+    pub(crate) fn state(&self) -> &Arc<SessionState> {
+        &self.state
+    }
+
+    /// Restamps `query_execution_start_time` so `now()` and friends observe the
+    /// statement's own start rather than the session's construction time.
+    fn begin_statement(&mut self) {
+        match Arc::get_mut(&mut self.state) {
+            Some(state) => state.mark_start_execution(),
+            None => {
+                let mut state = self.state.as_ref().clone();
+                state.mark_start_execution();
+                self.state = Arc::new(state);
+            }
+        }
+    }
+}
+
 pub(crate) struct SqlPlanningCache<CatalogKey> {
     datafusion_state: SessionState,
-    read_sessions: Mutex<Vec<SessionContext>>,
+    read_sessions: Mutex<Vec<PooledReadSession>>,
     parsed_statements: Mutex<LruCache<Arc<str>, Arc<DataFusionStatement>>>,
     public_catalogs: Mutex<LruCache<CatalogKey, Arc<PublicCatalog>>>,
     write_plans: Mutex<LruCache<WritePlanCacheKey<CatalogKey>, Arc<LogicalWritePlan>>>,
@@ -157,39 +212,38 @@ where
         let state = SessionStateBuilder::new_from_existing(self.datafusion_state.clone())
             .with_catalog_list(catalogs)
             .build();
-        SessionContext::new_with_state(state)
+        super::session::attach_execution_slots(SessionContext::new_with_state(state))
     }
 
-    pub(crate) fn datafusion_read_session(&self) -> SessionContext {
-        lock_or_recover(&self.read_sessions)
+    pub(crate) fn datafusion_read_session(&self) -> PooledReadSession {
+        let mut session = lock_or_recover(&self.read_sessions)
             .pop()
-            .unwrap_or_else(|| self.datafusion_session())
+            .unwrap_or_else(|| PooledReadSession::new(self.datafusion_session()));
+        session.begin_statement();
+        session
     }
 
-    pub(crate) fn recycle_datafusion_read_session(&self, session: SessionContext) {
-        if let Some(catalog) = session.catalog("datafusion")
+    pub(crate) fn recycle_datafusion_read_session(&self, session: PooledReadSession) {
+        if let Some(catalog) = session.context.catalog("datafusion")
             && let Some(public) = catalog.schema("public")
         {
             for table in public.table_names() {
-                let _ = session.deregister_table(datafusion::common::TableReference::full(
-                    "datafusion",
-                    "public",
-                    table,
-                ));
+                let _ = session
+                    .context
+                    .deregister_table(datafusion::common::TableReference::full(
+                        "datafusion",
+                        "public",
+                        table,
+                    ));
             }
         }
-        // Borrow the live session state instead of cloning it. `SessionState`
-        // owns `String`-keyed registries for every built-in scalar, aggregate
-        // and window function, so a clone here would deep-copy hundreds of
-        // keys just to diff two name sets.
-        let state_ref = session.state_ref();
+        // Only table-valued functions are registered per statement; the five
+        // execution scalar functions are installed once at session construction
+        // and read their per-statement values from the session's slots. Borrow
+        // the live state rather than cloning it — a clone would deep-copy the
+        // registries for every built-in function just to diff two name sets.
+        let state_ref = session.context.state_ref();
         let state = state_ref.read();
-        let execution_scalar_functions = state
-            .scalar_functions()
-            .keys()
-            .filter(|name| !self.datafusion_state.scalar_functions().contains_key(*name))
-            .cloned()
-            .collect::<Vec<_>>();
         let execution_table_functions = state
             .table_functions()
             .keys()
@@ -198,11 +252,8 @@ where
             .collect::<Vec<_>>();
         drop(state);
         drop(state_ref);
-        for name in execution_scalar_functions {
-            session.deregister_udf(&name);
-        }
         for name in execution_table_functions {
-            session.deregister_udtf(&name);
+            session.context.deregister_udtf(&name);
         }
 
         let mut sessions = lock_or_recover(&self.read_sessions);
@@ -1106,8 +1157,9 @@ mod tests {
     fn recycled_read_sessions_drop_snapshot_bound_tables() {
         let cache = test_cache(2);
         let session = cache.datafusion_read_session();
-        let session_id = session.session_id();
+        let session_id = session.context().session_id();
         session
+            .context()
             .register_table(
                 "snapshot_table",
                 Arc::new(EmptyTable::new(Arc::new(Schema::empty()))),
@@ -1116,8 +1168,8 @@ mod tests {
 
         cache.recycle_datafusion_read_session(session);
         let recycled = cache.datafusion_read_session();
-        assert_eq!(recycled.session_id(), session_id);
-        assert!(!recycled.table_exist("snapshot_table").unwrap());
+        assert_eq!(recycled.context().session_id(), session_id);
+        assert!(!recycled.context().table_exist("snapshot_table").unwrap());
     }
 
     #[test]

--- a/packages/lix/src/sql2/providers/entity.rs
+++ b/packages/lix/src/sql2/providers/entity.rs
@@ -4299,7 +4299,7 @@ mod tests {
         );
 
         // An IN list is still one contiguous set of file prefixes.
-        let in_list = Expr::InList(datafusion::logical_expr::expr::InList::new(
+        let in_list = Expr::InList(InList::new(
             Box::new(column("lixcol_file_id")),
             vec![
                 Expr::Literal(ScalarValue::Utf8(Some("file-a".to_string())), None),
@@ -4332,7 +4332,7 @@ mod tests {
             .await
             .expect("contradictory file scopes should plan");
         assert!(request.filter.file_ids.is_empty());
-        assert_eq!(request.filter.rows, crate::live_state::LiveStateRowFilter::None);
+        assert_eq!(request.filter.rows, LiveStateRowFilter::None);
 
         // Shapes the seek cannot represent stay unsupported so DataFusion keeps
         // its residual instead of silently widening the scan.

--- a/packages/lix/src/sql2/providers/entity.rs
+++ b/packages/lix/src/sql2/providers/entity.rs
@@ -314,6 +314,7 @@ impl EntitySpec {
         .map_err(lix_error_to_datafusion_error)?;
         apply_exact_branch_id_filter(&mut request, exact_branch_ids);
         apply_exact_entity_pk_filters(&mut request, &self.spec, filters)?;
+        apply_exact_file_id_filter(&mut request, exact_file_ids_from_filters(filters)?);
         Ok((projected_schema, request, row_filters))
     }
 
@@ -526,7 +527,10 @@ impl TableSpec for EntitySpec {
     fn filter_pushdown(&self, filter: &Expr) -> TableProviderFilterPushDown {
         let primary_key_analyzer = EntityPrimaryKeyFilterAnalyzer::new(&self.spec);
         let row_filter_analyzer = EntityRowFilterAnalyzer::new(&self.spec);
-        if ExactBranchIdFilterAnalyzer.supports(filter) || primary_key_analyzer.supports(filter) {
+        if ExactBranchIdFilterAnalyzer.supports(filter)
+            || ExactFileIdFilterAnalyzer.supports(filter)
+            || primary_key_analyzer.supports(filter)
+        {
             TableProviderFilterPushDown::Exact
         } else if row_filter_analyzer.supports(filter) {
             // Retain a DataFusion residual even when the row-shaped fallback
@@ -1701,6 +1705,125 @@ fn apply_exact_branch_id_filter(
         }
         request.filter.branch_ids = branch_ids;
     }
+}
+
+/// Extracts the exact `lixcol_file_id` selector so a file-scoped entity read
+/// becomes a physical seek instead of a schema-wide scan.
+///
+/// `HOT_ROW` is keyed `schema_key ++ file_id ++ entity_pk`, so a
+/// `schema_key + file_id` filter is a contiguous prefix
+/// (`hot_file_scan_prefixes`). The other three live-state authorities that can
+/// hold rows with no branch-local `HOT_ROW` — the packed current base, the
+/// certified entity batches, and the root current base — each already apply
+/// `LiveStateFilter::file_ids` (two of them with their own file-scoped seek),
+/// so the merged answer stays complete. Without this analyzer the predicate
+/// only ever survived as a DataFusion residual and every file-scoped read paid
+/// O(rows in the branch).
+fn exact_file_ids_from_filters(filters: &[Expr]) -> Result<Option<Vec<String>>> {
+    let analyzer = ExactFileIdFilterAnalyzer;
+    let mut file_ids: Option<BTreeSet<String>> = None;
+    for filter in filters {
+        let Some(filter_ids) = analyzer.analyze(filter)? else {
+            continue;
+        };
+        file_ids = Some(match file_ids {
+            Some(existing_ids) => existing_ids.intersection(&filter_ids).cloned().collect(),
+            None => filter_ids,
+        });
+    }
+    Ok(file_ids.map(|ids| ids.into_iter().collect()))
+}
+
+fn apply_exact_file_id_filter(request: &mut LiveStateScanRequest, file_ids: Option<Vec<String>>) {
+    if let Some(file_ids) = file_ids {
+        if file_ids.is_empty() {
+            request.filter.rows = LiveStateRowFilter::None;
+        }
+        request.filter.file_ids = file_ids
+            .into_iter()
+            .map(crate::NullableKeyFilter::Value)
+            .collect();
+    }
+}
+
+struct ExactFileIdFilterAnalyzer;
+
+impl ExactFileIdFilterAnalyzer {
+    fn supports(&self, expr: &Expr) -> bool {
+        self.analyze(expr)
+            .is_ok_and(|constraint| constraint.is_some())
+    }
+
+    #[expect(clippy::self_only_used_in_recursion)]
+    fn analyze(&self, expr: &Expr) -> Result<Option<BTreeSet<String>>> {
+        match expr {
+            Expr::BinaryExpr(binary_expr) if binary_expr.op == Operator::And => {
+                let Some(left) = self.analyze(&binary_expr.left)? else {
+                    return Ok(None);
+                };
+                let Some(right) = self.analyze(&binary_expr.right)? else {
+                    return Ok(None);
+                };
+                Ok(Some(left.intersection(&right).cloned().collect()))
+            }
+            Expr::BinaryExpr(binary_expr) if binary_expr.op == Operator::Or => {
+                let Some(mut left) = self.analyze(&binary_expr.left)? else {
+                    return Ok(None);
+                };
+                let Some(right) = self.analyze(&binary_expr.right)? else {
+                    return Ok(None);
+                };
+                left.extend(right);
+                Ok(Some(left))
+            }
+            Expr::BinaryExpr(binary_expr) => {
+                Ok(file_id_from_binary_filter(binary_expr).map(|value| BTreeSet::from([value])))
+            }
+            Expr::InList(in_list) => {
+                Ok(file_ids_from_in_list_filter(in_list).map(|values| values.into_iter().collect()))
+            }
+            _ => Ok(None),
+        }
+    }
+}
+
+fn file_id_from_binary_filter(binary_expr: &BinaryExpr) -> Option<String> {
+    if binary_expr.op != Operator::Eq {
+        return None;
+    }
+    file_id_from_column_literal_filter(&binary_expr.left, &binary_expr.right)
+        .or_else(|| file_id_from_column_literal_filter(&binary_expr.right, &binary_expr.left))
+}
+
+fn file_ids_from_in_list_filter(in_list: &InList) -> Option<Vec<String>> {
+    if in_list.negated {
+        return None;
+    }
+    let Expr::Column(column) = in_list.expr.as_ref() else {
+        return None;
+    };
+    if column.name != "lixcol_file_id" {
+        return None;
+    }
+    let values = in_list
+        .list
+        .iter()
+        .map(string_expr_literal)
+        .collect::<Option<Vec<_>>>()?;
+    if values.is_empty() {
+        return None;
+    }
+    Some(values)
+}
+
+fn file_id_from_column_literal_filter(column_expr: &Expr, literal_expr: &Expr) -> Option<String> {
+    let Expr::Column(column) = column_expr else {
+        return None;
+    };
+    if column.name != "lixcol_file_id" {
+        return None;
+    }
+    string_expr_literal(literal_expr)
 }
 
 pub(super) struct EntityPrimaryKeyFilterAnalyzer<'a> {

--- a/packages/lix/src/sql2/providers/entity.rs
+++ b/packages/lix/src/sql2/providers/entity.rs
@@ -4256,6 +4256,110 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn file_id_filter_pushes_an_exact_file_scope_into_scan() {
+        let spec = Arc::new(
+            derive_entity_surface_spec_from_schema(&json!({
+                "x-lix-key": "file_note",
+                "x-lix-primary-key": ["/id"],
+                "type": "object",
+                "properties": {
+                    "id": { "type": "string" },
+                    "body": { "type": "string" }
+                },
+                "required": ["id", "body"]
+            }))
+            .expect("file-scoped schema should derive"),
+        );
+        let provider = super::EntitySpec::by_branch(
+            Arc::clone(&spec),
+            Arc::new(EmptyLiveStateReader) as Arc<dyn LiveStateReader>,
+            empty_branch_ref(),
+            None,
+        );
+
+        let filter = eq_filter("lixcol_file_id", "file-a");
+        assert_eq!(
+            <super::EntitySpec as super::super::spec::TableSpec>::filter_pushdown(
+                &provider, &filter
+            ),
+            datafusion::logical_expr::TableProviderFilterPushDown::Exact,
+            "an exact file scope must not be left as a DataFusion residual"
+        );
+        let (_schema, request, row_filters) = provider
+            .plan_scan_parts(None, &[filter], None)
+            .await
+            .expect("file-scoped scan should plan");
+        assert_eq!(
+            request.filter.file_ids,
+            vec![crate::NullableKeyFilter::Value("file-a".to_string())]
+        );
+        assert!(
+            row_filters.is_empty(),
+            "lixcol_file_id is an identity column, not a payload row filter"
+        );
+
+        // An IN list is still one contiguous set of file prefixes.
+        let in_list = Expr::InList(datafusion::logical_expr::expr::InList::new(
+            Box::new(column("lixcol_file_id")),
+            vec![
+                Expr::Literal(ScalarValue::Utf8(Some("file-a".to_string())), None),
+                Expr::Literal(ScalarValue::Utf8(Some("file-b".to_string())), None),
+            ],
+            false,
+        ));
+        let (_schema, request, _row_filters) = provider
+            .plan_scan_parts(None, &[in_list], None)
+            .await
+            .expect("file-scoped IN scan should plan");
+        assert_eq!(
+            request.filter.file_ids,
+            vec![
+                crate::NullableKeyFilter::Value("file-a".to_string()),
+                crate::NullableKeyFilter::Value("file-b".to_string()),
+            ]
+        );
+
+        // Contradictory scopes select nothing rather than every file.
+        let (_schema, request, _row_filters) = provider
+            .plan_scan_parts(
+                None,
+                &[
+                    eq_filter("lixcol_file_id", "file-a"),
+                    eq_filter("lixcol_file_id", "file-b"),
+                ],
+                None,
+            )
+            .await
+            .expect("contradictory file scopes should plan");
+        assert!(request.filter.file_ids.is_empty());
+        assert_eq!(request.filter.rows, crate::live_state::LiveStateRowFilter::None);
+
+        // Shapes the seek cannot represent stay unsupported so DataFusion keeps
+        // its residual instead of silently widening the scan.
+        assert_eq!(
+            <super::EntitySpec as super::super::spec::TableSpec>::filter_pushdown(
+                &provider,
+                &Expr::IsNull(Box::new(column("lixcol_file_id")))
+            ),
+            datafusion::logical_expr::TableProviderFilterPushDown::Unsupported
+        );
+        assert_eq!(
+            <super::EntitySpec as super::super::spec::TableSpec>::filter_pushdown(
+                &provider,
+                &Expr::BinaryExpr(BinaryExpr::new(
+                    Box::new(column("lixcol_file_id")),
+                    Operator::NotEq,
+                    Box::new(Expr::Literal(
+                        ScalarValue::Utf8(Some("file-a".to_string())),
+                        None
+                    )),
+                ))
+            ),
+            datafusion::logical_expr::TableProviderFilterPushDown::Unsupported
+        );
+    }
+
+    #[tokio::test]
     async fn integer_primary_key_filter_pushes_exact_identity_into_scan() {
         let spec = Arc::new(
             derive_entity_surface_spec_from_schema(&json!({

--- a/packages/lix/src/sql2/providers/mod.rs
+++ b/packages/lix/src/sql2/providers/mod.rs
@@ -74,23 +74,40 @@ where
     if selection.is_empty() {
         return Ok(());
     }
-    let dynamic_catalog;
     let catalog = if selection.requires_visible_schemas() {
-        dynamic_catalog = ctx.public_catalog().await?;
-        dynamic_catalog.as_ref()
+        ctx.public_catalog().await?
     } else {
-        PublicCatalog::fixed_system()
+        Arc::clone(PublicCatalog::fixed_system_shared())
     };
     register_read_from_catalog(
         session,
         ctx,
         branch_ref,
         active_branch_commit_id,
-        catalog,
+        catalog.as_ref(),
         ReadProviderScope::All,
         selection,
     )
     .await?;
+    register_information_schema(session, selection, catalog)
+}
+
+/// Installs the `information_schema` views only for statements that can reach
+/// them.
+///
+/// `read_provider_selection` widens to [`ProviderSelection::All`] for every
+/// `information_schema`-qualified reference and every `SHOW` form, so a narrowed
+/// selection provably never resolves an information-schema table. Registering
+/// the schema anyway cost one catalog write lock and one `SchemaProvider`
+/// allocation on every ordinary statement.
+fn register_information_schema(
+    session: &SessionContext,
+    selection: &ProviderSelection,
+    catalog: Arc<PublicCatalog>,
+) -> Result<(), LixError> {
+    if !matches!(selection, ProviderSelection::All) {
+        return Ok(());
+    }
     crate::sql2::information_schema::register(session, catalog)
 }
 
@@ -144,15 +161,13 @@ impl ProviderSelection {
 }
 
 pub(crate) fn read_provider_selection(
-    session: &SessionContext,
+    state: &datafusion::execution::session_state::SessionState,
     statements: &[datafusion::sql::parser::Statement],
 ) -> ProviderSelection {
     let mut names = BTreeSet::new();
-    // Resolving references only reads the SQL parser configuration. Borrowing
-    // the session state avoids deep-copying its `String`-keyed function
-    // registries once per statement.
-    let state_ref = session.state_ref();
-    let state = state_ref.read();
+    // Resolving references only reads the SQL parser configuration, so the
+    // statement's pooled session state is used directly instead of cloning the
+    // live one.
     for statement in statements {
         if statement_requires_all_providers(statement) {
             return ProviderSelection::All;
@@ -490,7 +505,7 @@ pub(crate) async fn register_write(
     let catalog = write_ctx.public_catalog()?;
     register_write_from_catalog(session, write_ctx, branch_ref, options, &catalog, selection)
         .await?;
-    crate::sql2::information_schema::register(session, &catalog)
+    register_information_schema(session, selection, catalog)
 }
 
 pub(crate) async fn register_transaction<C>(
@@ -529,7 +544,7 @@ where
         selection,
     )
     .await?;
-    crate::sql2::information_schema::register(session, &catalog)
+    register_information_schema(session, selection, catalog)
 }
 
 async fn register_write_from_catalog(
@@ -677,7 +692,7 @@ mod tests {
             .iter()
             .map(|sql| crate::sql2::parse_statement(sql).expect("SQL should parse"))
             .collect::<Vec<_>>();
-        read_provider_selection(&SessionContext::new(), &statements)
+        read_provider_selection(&SessionContext::new().state(), &statements)
     }
 
     fn selected_names(names: &[&str]) -> ProviderSelection {

--- a/packages/lix/src/sql2/providers/spec.rs
+++ b/packages/lix/src/sql2/providers/spec.rs
@@ -1624,14 +1624,15 @@ mod scan_source_tests {
         session
             .register_table("counted", Arc::new(SpecTableProvider::new(spec)))
             .expect("counted test table should register");
-        let dataframe = session
-            .sql(
+        let plan = session
+            .state()
+            .create_logical_plan(
                 "WITH reused AS (SELECT value FROM counted) \
                  SELECT value FROM reused UNION ALL SELECT value FROM reused",
             )
             .await
             .expect("CTE should plan");
-        let batches = crate::sql2::runtime::collect_dataframe(dataframe, None)
+        let batches = crate::sql2::runtime::collect_plan(&session.state(), plan, None)
             .await
             .expect("CTE should execute");
         let values = batches

--- a/packages/lix/src/sql2/runtime.rs
+++ b/packages/lix/src/sql2/runtime.rs
@@ -5,11 +5,11 @@ use std::sync::Arc;
 #[cfg(feature = "storage-benches")]
 use std::time::Instant;
 
+use datafusion::arrow::datatypes::SchemaRef;
 use datafusion::arrow::record_batch::RecordBatch;
 use datafusion::catalog::ScanArgs;
 use datafusion::common::tree_node::{Transformed, TreeNode};
 use datafusion::common::{DataFusionError, TableReference, internal_err};
-use datafusion::dataframe::DataFrame;
 use datafusion::datasource::empty::EmptyTable;
 use datafusion::datasource::{provider_as_source, source_as_provider};
 use datafusion::error::Result;
@@ -19,7 +19,8 @@ use datafusion::execution::memory_pool::{MemoryConsumer, MemoryReservation};
 use datafusion::logical_expr::{LogicalPlan, TableSource};
 use datafusion::logical_expr::expr_rewriter::unnormalize_cols;
 use datafusion::physical_plan::coalesce_partitions::CoalescePartitionsExec;
-use datafusion::physical_plan::execution_plan::{CardinalityEffect, EmissionType};
+use datafusion::physical_expr::{LexOrdering, Partitioning};
+use datafusion::physical_plan::execution_plan::{Boundedness, CardinalityEffect, EmissionType};
 use datafusion::physical_plan::joins::HashJoinExec;
 use datafusion::physical_plan::limit::LimitStream;
 use datafusion::physical_plan::sorts::sort::SortExec;
@@ -42,16 +43,15 @@ type PhysicalPlanningCache = (
     PhysicalReadPlanCacheKey<CatalogFingerprint>,
 );
 
-pub(crate) async fn collect_dataframe(
-    dataframe: DataFrame,
+pub(crate) async fn collect_plan(
+    state: &SessionState,
+    logical_plan: LogicalPlan,
     physical_planning_cache: Option<PhysicalPlanningCache>,
 ) -> Result<Vec<RecordBatch>> {
-    let (state, logical_plan) = dataframe.into_parts();
-    let task_ctx = execution_task_context(&state);
+    let task_ctx = execution_task_context(state);
     #[cfg(feature = "storage-benches")]
     let started = crate::sql_profile::is_active().then(Instant::now);
-    let plan =
-        create_or_rebind_physical_plan(&state, logical_plan, physical_planning_cache).await?;
+    let plan = create_or_rebind_physical_plan(state, logical_plan, physical_planning_cache).await?;
     let plan = adapt_runtime_plan(plan)?;
     #[cfg(feature = "storage-benches")]
     if let Some(started) = started {
@@ -78,16 +78,15 @@ pub(crate) async fn collect_dataframe(
 /// stop polling it early; dropping the stream then drops the underlying scan
 /// futures as well.
 #[cfg(feature = "storage-benches")]
-pub(crate) async fn stream_dataframe(
-    dataframe: DataFrame,
+pub(crate) async fn stream_plan(
+    state: &SessionState,
+    logical_plan: LogicalPlan,
     physical_planning_cache: Option<PhysicalPlanningCache>,
 ) -> Result<SendableRecordBatchStream> {
-    let (state, logical_plan) = dataframe.into_parts();
-    let task_ctx = execution_task_context(&state);
+    let task_ctx = execution_task_context(state);
     #[cfg(feature = "storage-benches")]
     let started = crate::sql_profile::is_active().then(Instant::now);
-    let plan =
-        create_or_rebind_physical_plan(&state, logical_plan, physical_planning_cache).await?;
+    let plan = create_or_rebind_physical_plan(state, logical_plan, physical_planning_cache).await?;
     let plan = adapt_runtime_plan(plan)?;
     #[cfg(feature = "storage-benches")]
     if let Some(started) = started {
@@ -311,7 +310,9 @@ fn rebind_physical_plan_template_inner(
 ) -> Option<Arc<dyn ExecutionPlan>> {
     if let Some(detached) = plan.as_any().downcast_ref::<DetachedSpecScanExec>() {
         let replacement = replacements.get_mut(&detached.key)?.pop_front()?;
-        return (physical_plan_fingerprint(replacement.as_ref()) == detached.fingerprint)
+        return detached
+            .fingerprint
+            .matches(replacement.as_ref())
             .then_some(replacement);
     }
     let children = plan
@@ -356,17 +357,53 @@ fn rebuild_template_node(
     plan.with_new_children(children).ok()
 }
 
-fn physical_plan_fingerprint(plan: &dyn ExecutionPlan) -> Arc<str> {
-    Arc::from(format!(
-        "schema={:?};properties={:?}",
-        plan.schema(),
-        plan.properties()
-    ))
+/// The structural identity a replacement scan must reproduce before a detached
+/// template leaf accepts it.
+///
+/// This is compared once per leaf on every warm execution, so it is kept as
+/// direct field equality. Formatting `Debug` for the schema and the full
+/// `PlanProperties` — including `EquivalenceProperties` — allocated several
+/// kilobytes of string per scan per query for the same decision.
+///
+/// `Partitioning` deliberately compares by discriminant and partition count:
+/// its `PartialEq` returns `false` for two identical `UnknownPartitioning`
+/// values, which is the variant every `SpecScanExec` reports.
+struct ScanFingerprint {
+    schema: SchemaRef,
+    partitioning: std::mem::Discriminant<Partitioning>,
+    partition_count: usize,
+    output_ordering: Option<LexOrdering>,
+    emission_type: EmissionType,
+    boundedness: Boundedness,
+}
+
+impl ScanFingerprint {
+    fn new(plan: &dyn ExecutionPlan) -> Self {
+        let properties = plan.properties();
+        Self {
+            schema: plan.schema(),
+            partitioning: std::mem::discriminant(&properties.partitioning),
+            partition_count: properties.partitioning.partition_count(),
+            output_ordering: properties.output_ordering().cloned(),
+            emission_type: properties.emission_type,
+            boundedness: properties.boundedness,
+        }
+    }
+
+    fn matches(&self, plan: &dyn ExecutionPlan) -> bool {
+        let properties = plan.properties();
+        self.partition_count == properties.partitioning.partition_count()
+            && self.partitioning == std::mem::discriminant(&properties.partitioning)
+            && self.emission_type == properties.emission_type
+            && self.boundedness == properties.boundedness
+            && self.output_ordering.as_ref() == properties.output_ordering()
+            && self.schema == plan.schema()
+    }
 }
 
 struct DetachedSpecScanExec {
     key: PhysicalScanKey,
-    fingerprint: Arc<str>,
+    fingerprint: ScanFingerprint,
     properties: Arc<PlanProperties>,
 }
 
@@ -374,7 +411,7 @@ impl DetachedSpecScanExec {
     fn new(scan: &SpecScanExec) -> Self {
         Self {
             key: scan.physical_cache_key().clone(),
-            fingerprint: physical_plan_fingerprint(scan),
+            fingerprint: ScanFingerprint::new(scan),
             properties: Arc::clone(scan.properties()),
         }
     }

--- a/packages/lix/src/sql2/runtime.rs
+++ b/packages/lix/src/sql2/runtime.rs
@@ -8,23 +8,20 @@ use std::time::Instant;
 use datafusion::arrow::datatypes::SchemaRef;
 use datafusion::arrow::record_batch::RecordBatch;
 use datafusion::catalog::ScanArgs;
-use datafusion::common::tree_node::{Transformed, TreeNode};
-use datafusion::common::{DataFusionError, TableReference, internal_err};
-use datafusion::datasource::empty::EmptyTable;
-use datafusion::datasource::{provider_as_source, source_as_provider};
+use datafusion::common::{DataFusionError, internal_err};
 use datafusion::error::Result;
 use datafusion::execution::SessionState;
 use datafusion::execution::TaskContext;
 use datafusion::execution::memory_pool::{MemoryConsumer, MemoryReservation};
-use datafusion::logical_expr::{LogicalPlan, TableSource};
+use datafusion::logical_expr::LogicalPlan;
 use datafusion::logical_expr::expr_rewriter::unnormalize_cols;
-use datafusion::physical_plan::coalesce_partitions::CoalescePartitionsExec;
 use datafusion::physical_expr::{LexOrdering, Partitioning};
+use datafusion::physical_plan::coalesce_partitions::CoalescePartitionsExec;
 use datafusion::physical_plan::execution_plan::{Boundedness, CardinalityEffect, EmissionType};
 use datafusion::physical_plan::joins::HashJoinExec;
 use datafusion::physical_plan::limit::LimitStream;
-use datafusion::physical_plan::sorts::sort::SortExec;
 use datafusion::physical_plan::metrics::{BaselineMetrics, ExecutionPlanMetricsSet, MetricsSet};
+use datafusion::physical_plan::sorts::sort::SortExec;
 use datafusion::physical_plan::stream::RecordBatchStreamAdapter;
 use datafusion::physical_plan::{
     DisplayAs, DisplayFormatType, ExecutionPlan, ExecutionPlanProperties, PlanProperties,
@@ -34,7 +31,9 @@ use futures_util::{StreamExt, TryStreamExt, stream};
 use tokio::sync::OnceCell;
 
 use crate::catalog::CatalogFingerprint;
-use crate::sql2::{CachedPhysicalRead, PhysicalReadPlanCacheKey, SqlPlanningCache};
+use crate::sql2::{
+    CachedPhysicalRead, CachedScanRequest, PhysicalReadPlanCacheKey, SqlPlanningCache,
+};
 
 use super::providers::{PhysicalScanKey, SpecScanExec, StatementScanKey};
 
@@ -131,19 +130,23 @@ async fn create_or_rebind_physical_plan(
             .query_planner()
             .create_physical_plan(&optimized, state)
             .await?;
-        if let Some(template) = detach_physical_plan_template(Arc::clone(&plan))
-            && let Some(optimized) = detach_logical_plan_sources(optimized)
-        {
-            cache.remember_physical_read_plan(key, CachedPhysicalRead { optimized, template });
+        if let Some(template) = detach_physical_plan_template(Arc::clone(&plan)) {
+            cache.remember_physical_read_plan(
+                key,
+                CachedPhysicalRead {
+                    scans: cached_scan_requests(&optimized),
+                    template,
+                },
+            );
         }
         return Ok(plan);
     };
 
-    // Warm path. The optimized plan is reused verbatim, so DataFusion's
-    // analyzer and logical optimizer never run again for this statement shape;
-    // only the snapshot-bound table sources are grafted back on.
-    if let Some(optimized) = rebind_logical_plan_sources(&cached.optimized, &logical_plan)
-        && let Some(replacements) = plan_current_spec_scans(&optimized, state).await?
+    // Warm path. Neither DataFusion's analyzer, logical optimizer nor physical
+    // planner runs again for this statement shape: each cached leaf scan is
+    // replanned against the current snapshot's provider and grafted into the
+    // template.
+    if let Some(replacements) = plan_cached_spec_scans(&cached.scans, state).await?
         && let Some(plan) =
             rebind_physical_plan_template(Arc::clone(&cached.template), replacements)
     {
@@ -161,91 +164,53 @@ async fn create_or_rebind_physical_plan(
         .await
 }
 
-/// Replaces every table source with an empty stand-in of the same schema.
+/// Reduces an optimized plan's leaf scans to provider-free scan requests.
 ///
-/// Cached plans must not retain a provider bound to the storage snapshot that
-/// planned them.
-fn detach_logical_plan_sources(plan: LogicalPlan) -> Option<LogicalPlan> {
-    plan.transform_up(|node| {
-        let LogicalPlan::TableScan(mut scan) = node else {
-            return Ok(Transformed::no(node));
-        };
-        scan.source = provider_as_source(Arc::new(EmptyTable::new(scan.source.schema())));
-        Ok(Transformed::yes(LogicalPlan::TableScan(scan)))
-    })
-    .map(|transformed| transformed.data)
-    .ok()
+/// A cache entry must never retain a table provider bound to the storage
+/// snapshot that planned it. Keeping only the resolved table name, projection,
+/// filters and fetch makes that structural rather than a discipline: there is
+/// no provider in the entry to go stale, and no logical plan to clone on the
+/// warm path.
+fn cached_scan_requests(plan: &LogicalPlan) -> Vec<CachedScanRequest> {
+    fn collect(plan: &LogicalPlan, scans: &mut Vec<CachedScanRequest>) {
+        if let LogicalPlan::TableScan(scan) = plan {
+            scans.push(CachedScanRequest {
+                table: scan.table_name.clone(),
+                projection: scan.projection.clone(),
+                filters: unnormalize_cols(scan.filters.clone()),
+                fetch: scan.fetch,
+            });
+        }
+        for input in plan.inputs() {
+            collect(input, scans);
+        }
+    }
+
+    let mut scans = Vec::new();
+    collect(plan, &mut scans);
+    scans
 }
 
-/// Grafts the current snapshot's table sources onto a cached optimized plan.
+/// Replans each cached leaf scan against the current snapshot's provider.
 ///
-/// Sources are taken from the freshly bound plan for the same statement, which
-/// already resolved them against the live read session. A cached plan that
-/// references a table the current plan does not provide is treated as stale.
-fn rebind_logical_plan_sources(
-    cached: &LogicalPlan,
-    current: &LogicalPlan,
-) -> Option<LogicalPlan> {
-    let mut sources: HashMap<TableReference, Arc<dyn TableSource>> = HashMap::new();
-    collect_logical_table_sources(current, &mut sources);
-    cached
-        .clone()
-        .transform_up(|node| {
-            let LogicalPlan::TableScan(mut scan) = node else {
-                return Ok(Transformed::no(node));
-            };
-            let Some(source) = sources.get(&scan.table_name) else {
-                return internal_err!("cached SQL plan provider is unavailable");
-            };
-            scan.source = Arc::clone(source);
-            Ok(Transformed::yes(LogicalPlan::TableScan(scan)))
-        })
-        .map(|transformed| transformed.data)
-        .ok()
-}
-
-fn collect_logical_table_sources(
-    plan: &LogicalPlan,
-    sources: &mut HashMap<TableReference, Arc<dyn TableSource>>,
-) {
-    if let LogicalPlan::TableScan(scan) = plan {
-        sources
-            .entry(scan.table_name.clone())
-            .or_insert_with(|| Arc::clone(&scan.source));
-    }
-    for input in plan.inputs() {
-        collect_logical_table_sources(input, sources);
-    }
-}
-
-fn collect_logical_table_scans(
-    plan: &LogicalPlan,
-    scans: &mut Vec<datafusion::logical_expr::TableScan>,
-) {
-    if let LogicalPlan::TableScan(scan) = plan {
-        scans.push(scan.clone());
-    }
-    for input in plan.inputs() {
-        collect_logical_table_scans(input, scans);
-    }
-}
-
-async fn plan_current_spec_scans(
-    logical_plan: &LogicalPlan,
+/// Declining (returning `None`) is always safe: the caller evicts the entry and
+/// falls back to the ordinary DataFusion planner.
+async fn plan_cached_spec_scans(
+    scans: &[CachedScanRequest],
     state: &SessionState,
 ) -> Result<Option<HashMap<PhysicalScanKey, VecDeque<Arc<dyn ExecutionPlan>>>>> {
-    let mut logical_scans = Vec::new();
-    collect_logical_table_scans(logical_plan, &mut logical_scans);
     let mut replacements: HashMap<PhysicalScanKey, VecDeque<Arc<dyn ExecutionPlan>>> =
         HashMap::new();
-    for scan in logical_scans {
-        let Ok(provider) = source_as_provider(&scan.source) else {
+    for scan in scans {
+        let Ok(schema) = state.schema_for_ref(scan.table.clone()) else {
             return Ok(None);
         };
-        let filters = unnormalize_cols(scan.filters);
+        let Some(provider) = schema.table(scan.table.table()).await? else {
+            return Ok(None);
+        };
         let args = ScanArgs::default()
             .with_projection(scan.projection.as_deref())
-            .with_filters(Some(&filters))
+            .with_filters(Some(&scan.filters))
             .with_limit(scan.fetch);
         let result = provider.scan_with_args(state, args).await?;
         let plan = Arc::clone(result.plan());
@@ -268,8 +233,13 @@ async fn plan_current_spec_scans(
 /// alive, so it is rejected rather than rebuilt.
 fn template_operator_is_reusable(plan: &dyn ExecutionPlan) -> bool {
     match plan.name() {
-        "ProjectionExec" | "HashJoinExec" | "FilterExec" | "CooperativeExec"
-        | "CoalesceBatchesExec" | "CoalescePartitionsExec" | "SortPreservingMergeExec" => true,
+        "ProjectionExec"
+        | "HashJoinExec"
+        | "FilterExec"
+        | "CooperativeExec"
+        | "CoalesceBatchesExec"
+        | "CoalescePartitionsExec"
+        | "SortPreservingMergeExec" => true,
         "SortExec" => plan
             .as_any()
             .downcast_ref::<SortExec>()

--- a/packages/lix/src/sql2/session.rs
+++ b/packages/lix/src/sql2/session.rs
@@ -1,4 +1,5 @@
-use datafusion::execution::session_state::SessionStateBuilder;
+use datafusion::catalog::CatalogProviderList;
+use datafusion::execution::session_state::{SessionState, SessionStateBuilder};
 use datafusion::prelude::{SessionConfig, SessionContext};
 use datafusion::sql::parser::Statement as DataFusionStatement;
 use std::collections::BTreeSet;
@@ -237,28 +238,32 @@ pub(crate) fn new_sql_session_context() -> SessionContext {
         .build();
     let session = SessionContext::new_with_state(state);
     register_static_sql2_functions(&session);
-    attach_execution_slots(session)
+    sql_session_from_template(session.state(), None)
 }
 
-/// Gives a session its own execution-function slots and registers the five
-/// execution UDFs against them.
+/// Builds a Lix SQL session from a template state, gives it its own
+/// execution-function slots, and registers the five execution UDFs against them.
 ///
 /// Every Lix SQL session goes through here exactly once. Doing it at session
 /// construction rather than per statement is what lets a pooled session keep a
 /// stable function registry: nothing mutates `SessionState`'s scalar-function
 /// map after this point.
-pub(crate) fn attach_execution_slots(session: SessionContext) -> SessionContext {
+///
+/// The slots are installed into the config *before* the state is built, so this
+/// costs one `SessionState` construction rather than one per configuration step.
+/// Write sessions are not pooled — they are built per statement — so an extra
+/// registry deep copy here would land on every write.
+pub(crate) fn sql_session_from_template(
+    template: SessionState,
+    catalog_list: Option<Arc<dyn CatalogProviderList>>,
+) -> SessionContext {
     let slots = Arc::new(ExecutionSlots::default());
-    let config = session
-        .state_ref()
-        .read()
-        .config()
-        .clone()
-        .with_extension(Arc::clone(&slots));
-    let state = SessionStateBuilder::new_from_existing(session.state())
-        .with_config(config)
-        .build();
-    let session = SessionContext::new_with_state(state);
+    let config = template.config().clone().with_extension(Arc::clone(&slots));
+    let mut builder = SessionStateBuilder::new_from_existing(template).with_config(config);
+    if let Some(catalog_list) = catalog_list {
+        builder = builder.with_catalog_list(catalog_list);
+    }
+    let session = SessionContext::new_with_state(builder.build());
     register_execution_sql2_functions(&session, slots);
     session
 }

--- a/packages/lix/src/sql2/session.rs
+++ b/packages/lix/src/sql2/session.rs
@@ -9,14 +9,19 @@ use crate::LixError;
 use crate::branch::{BranchHead, BranchRefReader};
 
 use super::branch_ref::CachingBranchRefReader;
+use super::planning_cache::PooledReadSession;
 use super::providers;
-use super::udfs::{register_execution_sql2_functions, register_static_sql2_functions};
+use super::udfs::{
+    ExecutionSlots, bind_execution_sql2_functions, register_execution_sql2_functions,
+    register_static_sql2_functions,
+};
+use super::exec::statement_has_table_function;
 use super::{SqlExecutionContext, SqlWriteContext, SqlWriteExecutionContext};
 
 pub(crate) async fn build_read_session<C>(
     ctx: &C,
     statements: &[DataFusionStatement],
-) -> Result<SessionContext, LixError>
+) -> Result<PooledReadSession, LixError>
 where
     C: SqlExecutionContext + ?Sized,
 {
@@ -27,7 +32,7 @@ pub(crate) async fn build_read_session_at_head<C>(
     ctx: &C,
     active_head: BranchHead,
     statements: &[DataFusionStatement],
-) -> Result<SessionContext, LixError>
+) -> Result<PooledReadSession, LixError>
 where
     C: SqlExecutionContext + ?Sized,
 {
@@ -38,11 +43,12 @@ async fn build_read_session_with_active_head<C>(
     ctx: &C,
     active_head: Option<BranchHead>,
     statements: &[DataFusionStatement],
-) -> Result<SessionContext, LixError>
+) -> Result<PooledReadSession, LixError>
 where
     C: SqlExecutionContext + ?Sized,
 {
-    let session = ctx.datafusion_read_session();
+    let pooled = ctx.datafusion_read_session();
+    let session = pooled.context();
     let branch_ref: Arc<dyn BranchRefReader> = match active_head.as_ref() {
         Some(head) => {
             if head.branch_id != ctx.active_branch_id() {
@@ -65,17 +71,22 @@ where
             .await?
             .map(|head| head.commit_id.to_string()),
     };
-    register_execution_sql2_functions(
-        &session,
+    bind_execution_sql2_functions(
+        session,
         ctx.functions(),
-        ctx.active_account_id().to_string(),
-        Some(ctx.active_branch_id().to_string()),
-        active_branch_commit_id.clone(),
+        ctx.active_account_id(),
+        Some(ctx.active_branch_id()),
+        active_branch_commit_id.as_deref(),
     );
-    providers::register_diff_function(&session, ctx.changelog_query_source());
-    let provider_selection = providers::read_provider_selection(&session, statements);
+    // `lix_diff` is a table-valued function, so only a statement that actually
+    // calls one can reach it. Registering it unconditionally took the session
+    // write lock on every read.
+    if statements.iter().any(statement_has_table_function) {
+        providers::register_diff_function(session, ctx.changelog_query_source());
+    }
+    let provider_selection = providers::read_provider_selection(pooled.state(), statements);
     providers::register_read(
-        &session,
+        session,
         ctx,
         branch_ref,
         active_branch_commit_id,
@@ -83,40 +94,43 @@ where
     )
     .await?;
 
-    Ok(session)
+    Ok(pooled)
 }
 
 pub(crate) async fn build_transaction_read_session<C>(
     read_ctx: &C,
     write_ctx: &mut dyn SqlWriteExecutionContext,
     statement: &DataFusionStatement,
-) -> Result<SessionContext, LixError>
+) -> Result<PooledReadSession, LixError>
 where
     C: SqlExecutionContext + ?Sized,
 {
-    let session = read_ctx.datafusion_read_session();
+    let pooled = read_ctx.datafusion_read_session();
+    let session = pooled.context();
     let read_branch_ref: Arc<dyn BranchRefReader> =
         Arc::new(CachingBranchRefReader::new(read_ctx.branch_ref()));
     let active_branch_commit_id = read_branch_ref
         .load_head(read_ctx.active_branch_id())
         .await?
         .map(|head| head.commit_id.to_string());
-    register_execution_sql2_functions(
-        &session,
+    bind_execution_sql2_functions(
+        session,
         read_ctx.functions(),
-        read_ctx.active_account_id().to_string(),
-        Some(read_ctx.active_branch_id().to_string()),
-        active_branch_commit_id.clone(),
+        read_ctx.active_account_id(),
+        Some(read_ctx.active_branch_id()),
+        active_branch_commit_id.as_deref(),
     );
-    providers::register_diff_function(&session, read_ctx.changelog_query_source());
+    if statement_has_table_function(statement) {
+        providers::register_diff_function(session, read_ctx.changelog_query_source());
+    }
     let write_ctx = SqlWriteContext::new(write_ctx);
     let write_branch_ref: Arc<dyn BranchRefReader> = Arc::new(CachingBranchRefReader::new(
         Arc::new(super::WriteContextBranchRefReader::new(write_ctx.clone())),
     ));
     let provider_selection =
-        providers::read_provider_selection(&session, std::slice::from_ref(statement));
+        providers::read_provider_selection(pooled.state(), std::slice::from_ref(statement));
     providers::register_transaction(
-        &session,
+        session,
         read_ctx,
         read_branch_ref,
         active_branch_commit_id,
@@ -126,7 +140,7 @@ where
         &provider_selection,
     )
     .await?;
-    Ok(session)
+    Ok(pooled)
 }
 
 #[derive(Clone, Debug, Default)]
@@ -181,12 +195,12 @@ pub(crate) async fn build_write_session_with_options(
                     "active branch",
                 )
             })?;
-    register_execution_sql2_functions(
+    bind_execution_sql2_functions(
         &session,
         write_ctx.functions(),
-        write_ctx.active_account_id().to_string(),
-        Some(active_branch_id),
-        Some(active_branch_commit_id.commit_id.to_string()),
+        &write_ctx.active_account_id(),
+        Some(&active_branch_id),
+        Some(&active_branch_commit_id.commit_id.to_string()),
     );
     providers::register_write(&session, write_ctx, branch_ref, options, provider_selection).await?;
 
@@ -223,5 +237,28 @@ pub(crate) fn new_sql_session_context() -> SessionContext {
         .build();
     let session = SessionContext::new_with_state(state);
     register_static_sql2_functions(&session);
+    attach_execution_slots(session)
+}
+
+/// Gives a session its own execution-function slots and registers the five
+/// execution UDFs against them.
+///
+/// Every Lix SQL session goes through here exactly once. Doing it at session
+/// construction rather than per statement is what lets a pooled session keep a
+/// stable function registry: nothing mutates `SessionState`'s scalar-function
+/// map after this point.
+pub(crate) fn attach_execution_slots(session: SessionContext) -> SessionContext {
+    let slots = Arc::new(ExecutionSlots::default());
+    let config = session
+        .state_ref()
+        .read()
+        .config()
+        .clone()
+        .with_extension(Arc::clone(&slots));
+    let state = SessionStateBuilder::new_from_existing(session.state())
+        .with_config(config)
+        .build();
+    let session = SessionContext::new_with_state(state);
+    register_execution_sql2_functions(&session, slots);
     session
 }

--- a/packages/lix/src/sql2/session.rs
+++ b/packages/lix/src/sql2/session.rs
@@ -9,13 +9,13 @@ use crate::LixError;
 use crate::branch::{BranchHead, BranchRefReader};
 
 use super::branch_ref::CachingBranchRefReader;
+use super::exec::statement_has_table_function;
 use super::planning_cache::PooledReadSession;
 use super::providers;
 use super::udfs::{
     ExecutionSlots, bind_execution_sql2_functions, register_execution_sql2_functions,
     register_static_sql2_functions,
 };
-use super::exec::statement_has_table_function;
 use super::{SqlExecutionContext, SqlWriteContext, SqlWriteExecutionContext};
 
 pub(crate) async fn build_read_session<C>(

--- a/packages/lix/src/sql2/udfs/execution_slots.rs
+++ b/packages/lix/src/sql2/udfs/execution_slots.rs
@@ -32,7 +32,9 @@ struct ExecutionSlotValues {
 
 impl std::fmt::Debug for ExecutionSlots {
     fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        formatter.debug_struct("ExecutionSlots").finish_non_exhaustive()
+        formatter
+            .debug_struct("ExecutionSlots")
+            .finish_non_exhaustive()
     }
 }
 
@@ -53,10 +55,7 @@ impl ExecutionSlots {
         let mut values = self.lock();
         assign(&mut values.active_account_id, Some(active_account_id));
         assign(&mut values.active_branch_id, active_branch_id);
-        assign(
-            &mut values.active_branch_commit_id,
-            active_branch_commit_id,
-        );
+        assign(&mut values.active_branch_commit_id, active_branch_commit_id);
         values.functions = Some(functions);
     }
 

--- a/packages/lix/src/sql2/udfs/execution_slots.rs
+++ b/packages/lix/src/sql2/udfs/execution_slots.rs
@@ -1,0 +1,120 @@
+use std::sync::{Arc, Mutex, MutexGuard, PoisonError};
+
+use datafusion::common::{DataFusionError, Result};
+use datafusion::prelude::SessionContext;
+
+use crate::functions::FunctionProviderHandle;
+
+/// Per-session storage for the per-statement facts the execution UDFs report.
+///
+/// The five execution functions (`lix_active_account_id`,
+/// `lix_active_branch_id`, `lix_active_branch_commit_id`, `lix_uuid_v7`,
+/// `lix_timestamp`) used to be registered and deregistered on every statement so
+/// each one could capture that statement's values in its own fields. They are
+/// now registered once, when the session is created, and read this slot at
+/// invocation time instead.
+///
+/// The slot is what makes that safe: a pooled session never carries a value from
+/// an earlier statement, because [`Self::bind`] overwrites every field before
+/// planning starts and the UDFs never hold a copy of their own.
+#[derive(Default)]
+pub(crate) struct ExecutionSlots {
+    values: Mutex<ExecutionSlotValues>,
+}
+
+#[derive(Default)]
+struct ExecutionSlotValues {
+    active_account_id: Option<String>,
+    active_branch_id: Option<String>,
+    active_branch_commit_id: Option<String>,
+    functions: Option<FunctionProviderHandle>,
+}
+
+impl std::fmt::Debug for ExecutionSlots {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.debug_struct("ExecutionSlots").finish_non_exhaustive()
+    }
+}
+
+impl ExecutionSlots {
+    /// Installs the current statement's execution facts.
+    ///
+    /// Every field is written unconditionally: leaving a field untouched would
+    /// be exactly the staleness this type exists to prevent. Existing
+    /// allocations are reused when the text is unchanged, which is the steady
+    /// state for a session that keeps serving the same branch and account.
+    pub(crate) fn bind(
+        &self,
+        functions: FunctionProviderHandle,
+        active_account_id: &str,
+        active_branch_id: Option<&str>,
+        active_branch_commit_id: Option<&str>,
+    ) {
+        let mut values = self.lock();
+        assign(&mut values.active_account_id, Some(active_account_id));
+        assign(&mut values.active_branch_id, active_branch_id);
+        assign(
+            &mut values.active_branch_commit_id,
+            active_branch_commit_id,
+        );
+        values.functions = Some(functions);
+    }
+
+    pub(crate) fn active_account_id(&self) -> Option<String> {
+        self.lock().active_account_id.clone()
+    }
+
+    pub(crate) fn active_branch_id(&self) -> Option<String> {
+        self.lock().active_branch_id.clone()
+    }
+
+    pub(crate) fn active_branch_commit_id(&self) -> Option<String> {
+        self.lock().active_branch_commit_id.clone()
+    }
+
+    /// The statement's function provider.
+    ///
+    /// An unbound slot is an engine bug rather than a user error, so it fails
+    /// the statement instead of silently falling back to the system provider —
+    /// a deterministic-uuid test harness must never be replaced by wall-clock
+    /// randomness without saying so.
+    pub(crate) fn functions(&self) -> Result<FunctionProviderHandle> {
+        self.lock().functions.clone().ok_or_else(|| {
+            DataFusionError::Internal(
+                "Lix SQL execution functions were invoked on an unbound session".to_string(),
+            )
+        })
+    }
+
+    fn lock(&self) -> MutexGuard<'_, ExecutionSlotValues> {
+        self.values.lock().unwrap_or_else(PoisonError::into_inner)
+    }
+}
+
+fn assign(slot: &mut Option<String>, value: Option<&str>) {
+    match (slot.as_mut(), value) {
+        (Some(existing), Some(value)) => {
+            if existing != value {
+                existing.clear();
+                existing.push_str(value);
+            }
+        }
+        (_, Some(value)) => *slot = Some(value.to_string()),
+        (_, None) => *slot = None,
+    }
+}
+
+/// Recovers the slots a Lix SQL session was created with.
+///
+/// The slots travel in the session's `SessionConfig` extensions so that every
+/// holder of a `SessionContext` — read sessions, write sessions and transaction
+/// sessions alike — reaches the same instance the session's UDFs were
+/// registered against.
+pub(crate) fn execution_slots(session: &SessionContext) -> Arc<ExecutionSlots> {
+    session
+        .state_ref()
+        .read()
+        .config()
+        .get_extension::<ExecutionSlots>()
+        .expect("Lix SQL sessions are created with execution-function slots")
+}

--- a/packages/lix/src/sql2/udfs/lix_active_account_id.rs
+++ b/packages/lix/src/sql2/udfs/lix_active_account_id.rs
@@ -1,4 +1,5 @@
 use std::any::Any;
+use std::sync::Arc;
 
 use datafusion::arrow::datatypes::DataType;
 use datafusion::common::{Result, ScalarValue, plan_err};
@@ -6,14 +7,35 @@ use datafusion::logical_expr::{
     ColumnarValue, ScalarFunctionArgs, ScalarUDFImpl, Signature, Volatility,
 };
 
-#[derive(Clone, PartialEq, Eq, Hash)]
+use super::execution_slots::ExecutionSlots;
+
+#[derive(Clone)]
 pub(super) struct LixActiveAccountId {
-    account_id: String,
+    slots: Arc<ExecutionSlots>,
 }
 
 impl LixActiveAccountId {
-    pub(super) fn new(account_id: String) -> Self {
-        Self { account_id }
+    pub(super) fn new(slots: Arc<ExecutionSlots>) -> Self {
+        Self { slots }
+    }
+}
+
+// Every session owns exactly one instance of this function, and plans that call
+// it are never shared between sessions: `logical_plan_has_scalar_function`
+// excludes any plan containing a scalar function from the read-plan and
+// physical-plan caches. Identity therefore carries no information, exactly as
+// for the volatile execution functions.
+impl PartialEq for LixActiveAccountId {
+    fn eq(&self, _other: &Self) -> bool {
+        true
+    }
+}
+
+impl Eq for LixActiveAccountId {}
+
+impl std::hash::Hash for LixActiveAccountId {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.name().hash(state);
     }
 }
 
@@ -46,8 +68,8 @@ impl ScalarUDFImpl for LixActiveAccountId {
         if !args.args.is_empty() {
             return plan_err!("lix_active_account_id requires no arguments");
         }
-        Ok(ColumnarValue::Scalar(ScalarValue::Utf8(Some(
-            self.account_id.clone(),
-        ))))
+        Ok(ColumnarValue::Scalar(ScalarValue::Utf8(
+            self.slots.active_account_id(),
+        )))
     }
 }

--- a/packages/lix/src/sql2/udfs/lix_active_branch_commit_id.rs
+++ b/packages/lix/src/sql2/udfs/lix_active_branch_commit_id.rs
@@ -1,4 +1,5 @@
 use std::any::Any;
+use std::sync::Arc;
 
 use datafusion::arrow::datatypes::DataType;
 use datafusion::common::{Result, ScalarValue, plan_err};
@@ -6,14 +7,30 @@ use datafusion::logical_expr::{
     ColumnarValue, ScalarFunctionArgs, ScalarUDFImpl, Signature, Volatility,
 };
 
-#[derive(Clone, PartialEq, Eq, Hash)]
+use super::execution_slots::ExecutionSlots;
+
+#[derive(Clone)]
 pub(super) struct LixActiveBranchCommitId {
-    commit_id: Option<String>,
+    slots: Arc<ExecutionSlots>,
 }
 
 impl LixActiveBranchCommitId {
-    pub(super) fn new(commit_id: Option<String>) -> Self {
-        Self { commit_id }
+    pub(super) fn new(slots: Arc<ExecutionSlots>) -> Self {
+        Self { slots }
+    }
+}
+
+impl PartialEq for LixActiveBranchCommitId {
+    fn eq(&self, _other: &Self) -> bool {
+        true
+    }
+}
+
+impl Eq for LixActiveBranchCommitId {}
+
+impl std::hash::Hash for LixActiveBranchCommitId {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.name().hash(state);
     }
 }
 
@@ -47,7 +64,7 @@ impl ScalarUDFImpl for LixActiveBranchCommitId {
             return plan_err!("lix_active_branch_commit_id requires no arguments");
         }
         Ok(ColumnarValue::Scalar(ScalarValue::Utf8(
-            self.commit_id.clone(),
+            self.slots.active_branch_commit_id(),
         )))
     }
 }

--- a/packages/lix/src/sql2/udfs/lix_active_branch_id.rs
+++ b/packages/lix/src/sql2/udfs/lix_active_branch_id.rs
@@ -1,4 +1,5 @@
 use std::any::Any;
+use std::sync::Arc;
 
 use datafusion::arrow::datatypes::DataType;
 use datafusion::common::{Result, ScalarValue, plan_err};
@@ -6,14 +7,30 @@ use datafusion::logical_expr::{
     ColumnarValue, ScalarFunctionArgs, ScalarUDFImpl, Signature, Volatility,
 };
 
-#[derive(Clone, PartialEq, Eq, Hash)]
+use super::execution_slots::ExecutionSlots;
+
+#[derive(Clone)]
 pub(super) struct LixActiveBranchId {
-    branch_id: Option<String>,
+    slots: Arc<ExecutionSlots>,
 }
 
 impl LixActiveBranchId {
-    pub(super) fn new(branch_id: Option<String>) -> Self {
-        Self { branch_id }
+    pub(super) fn new(slots: Arc<ExecutionSlots>) -> Self {
+        Self { slots }
+    }
+}
+
+impl PartialEq for LixActiveBranchId {
+    fn eq(&self, _other: &Self) -> bool {
+        true
+    }
+}
+
+impl Eq for LixActiveBranchId {}
+
+impl std::hash::Hash for LixActiveBranchId {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.name().hash(state);
     }
 }
 
@@ -47,7 +64,7 @@ impl ScalarUDFImpl for LixActiveBranchId {
             return plan_err!("lix_active_branch_id requires no arguments");
         }
         Ok(ColumnarValue::Scalar(ScalarValue::Utf8(
-            self.branch_id.clone(),
+            self.slots.active_branch_id(),
         )))
     }
 }

--- a/packages/lix/src/sql2/udfs/lix_timestamp.rs
+++ b/packages/lix/src/sql2/udfs/lix_timestamp.rs
@@ -1,4 +1,5 @@
 use std::any::Any;
+use std::sync::Arc;
 
 use datafusion::arrow::datatypes::DataType;
 use datafusion::common::{Result, ScalarValue, plan_err};
@@ -6,11 +7,11 @@ use datafusion::logical_expr::{
     ColumnarValue, ScalarFunctionArgs, ScalarUDFImpl, Signature, Volatility,
 };
 
-use crate::functions::FunctionProviderHandle;
+use super::execution_slots::ExecutionSlots;
 
 #[derive(Clone)]
 pub(super) struct LixTimestamp {
-    pub(super) functions: FunctionProviderHandle,
+    pub(super) slots: Arc<ExecutionSlots>,
 }
 
 impl PartialEq for LixTimestamp {
@@ -57,7 +58,7 @@ impl ScalarUDFImpl for LixTimestamp {
             return plan_err!("lix_timestamp requires no arguments");
         }
         Ok(ColumnarValue::Scalar(ScalarValue::Utf8(Some(
-            self.functions.call_timestamp().to_string(),
+            self.slots.functions()?.call_timestamp().to_string(),
         ))))
     }
 }

--- a/packages/lix/src/sql2/udfs/lix_uuid_v7.rs
+++ b/packages/lix/src/sql2/udfs/lix_uuid_v7.rs
@@ -1,4 +1,5 @@
 use std::any::Any;
+use std::sync::Arc;
 
 use datafusion::arrow::datatypes::DataType;
 use datafusion::common::{Result, ScalarValue, plan_err};
@@ -6,11 +7,11 @@ use datafusion::logical_expr::{
     ColumnarValue, ScalarFunctionArgs, ScalarUDFImpl, Signature, Volatility,
 };
 
-use crate::functions::FunctionProviderHandle;
+use super::execution_slots::ExecutionSlots;
 
 #[derive(Clone)]
 pub(super) struct LixUuidV7 {
-    pub(super) functions: FunctionProviderHandle,
+    pub(super) slots: Arc<ExecutionSlots>,
 }
 
 impl PartialEq for LixUuidV7 {
@@ -57,7 +58,7 @@ impl ScalarUDFImpl for LixUuidV7 {
             return plan_err!("lix_uuid_v7 requires no arguments");
         }
         Ok(ColumnarValue::Scalar(ScalarValue::Utf8(Some(
-            self.functions.call_uuid_v7().to_string(),
+            self.slots.functions()?.call_uuid_v7().to_string(),
         ))))
     }
 }

--- a/packages/lix/src/sql2/udfs/mod.rs
+++ b/packages/lix/src/sql2/udfs/mod.rs
@@ -43,9 +43,9 @@ pub(crate) fn register_execution_sql2_functions(ctx: &SessionContext, slots: Arc
     ctx.register_udf(ScalarUDF::from(
         lix_active_account_id::LixActiveAccountId::new(Arc::clone(&slots)),
     ));
-    ctx.register_udf(ScalarUDF::from(lix_active_branch_id::LixActiveBranchId::new(
-        Arc::clone(&slots),
-    )));
+    ctx.register_udf(ScalarUDF::from(
+        lix_active_branch_id::LixActiveBranchId::new(Arc::clone(&slots)),
+    ));
     ctx.register_udf(ScalarUDF::from(
         lix_active_branch_commit_id::LixActiveBranchCommitId::new(Arc::clone(&slots)),
     ));

--- a/packages/lix/src/sql2/udfs/mod.rs
+++ b/packages/lix/src/sql2/udfs/mod.rs
@@ -1,4 +1,5 @@
 mod common;
+pub(crate) mod execution_slots;
 mod lix_active_account_id;
 mod lix_active_branch_commit_id;
 mod lix_active_branch_id;
@@ -9,32 +10,18 @@ mod lix_octet_length;
 mod lix_timestamp;
 mod lix_uuid_v7;
 
+use std::sync::Arc;
+
 use datafusion::execution::context::SessionContext;
 use datafusion::logical_expr::ScalarUDF;
 
 use crate::functions::FunctionProviderHandle;
 
+pub(crate) use execution_slots::{ExecutionSlots, execution_slots};
+
 #[cfg(test)]
 pub(crate) fn system_sql2_function_provider() -> FunctionProviderHandle {
     FunctionProviderHandle::system()
-}
-
-#[cfg(test)]
-pub(crate) fn register_sql2_functions(
-    ctx: &SessionContext,
-    functions: FunctionProviderHandle,
-    active_account_id: String,
-    active_branch_id: Option<String>,
-    active_branch_commit_id: Option<String>,
-) {
-    register_static_sql2_functions(ctx);
-    register_execution_sql2_functions(
-        ctx,
-        functions,
-        active_account_id,
-        active_branch_id,
-        active_branch_commit_id,
-    );
 }
 
 pub(crate) fn register_static_sql2_functions(ctx: &SessionContext) {
@@ -44,41 +31,58 @@ pub(crate) fn register_static_sql2_functions(ctx: &SessionContext) {
     ctx.register_udf(ScalarUDF::from(lix_octet_length::LixOctetLength::new()));
 }
 
-pub(crate) fn register_execution_sql2_functions(
-    ctx: &SessionContext,
-    functions: FunctionProviderHandle,
-    active_account_id: String,
-    active_branch_id: Option<String>,
-    active_branch_commit_id: Option<String>,
-) {
+/// Installs the five per-statement execution functions once, for the lifetime
+/// of the session.
+///
+/// Each one holds only the session's [`ExecutionSlots`] and reads the current
+/// statement's value at invocation time, so a session can be pooled and reused
+/// without a function ever reporting an earlier statement's account, branch or
+/// commit. Call [`bind_execution_sql2_functions`] before planning each
+/// statement.
+pub(crate) fn register_execution_sql2_functions(ctx: &SessionContext, slots: Arc<ExecutionSlots>) {
     ctx.register_udf(ScalarUDF::from(
-        lix_active_account_id::LixActiveAccountId::new(active_account_id),
+        lix_active_account_id::LixActiveAccountId::new(Arc::clone(&slots)),
     ));
+    ctx.register_udf(ScalarUDF::from(lix_active_branch_id::LixActiveBranchId::new(
+        Arc::clone(&slots),
+    )));
     ctx.register_udf(ScalarUDF::from(
-        lix_active_branch_id::LixActiveBranchId::new(active_branch_id),
-    ));
-    ctx.register_udf(ScalarUDF::from(
-        lix_active_branch_commit_id::LixActiveBranchCommitId::new(active_branch_commit_id),
+        lix_active_branch_commit_id::LixActiveBranchCommitId::new(Arc::clone(&slots)),
     ));
     ctx.register_udf(ScalarUDF::from(lix_uuid_v7::LixUuidV7 {
-        functions: functions.clone(),
+        slots: Arc::clone(&slots),
     }));
-    ctx.register_udf(ScalarUDF::from(lix_timestamp::LixTimestamp { functions }));
+    ctx.register_udf(ScalarUDF::from(lix_timestamp::LixTimestamp { slots }));
+}
+
+/// Points the session's execution functions at this statement's facts.
+pub(crate) fn bind_execution_sql2_functions(
+    ctx: &SessionContext,
+    functions: FunctionProviderHandle,
+    active_account_id: &str,
+    active_branch_id: Option<&str>,
+    active_branch_commit_id: Option<&str>,
+) {
+    execution_slots(ctx).bind(
+        functions,
+        active_account_id,
+        active_branch_id,
+        active_branch_commit_id,
+    );
 }
 
 #[cfg(test)]
 pub(super) mod test_support {
     use datafusion::arrow::array::{Array, StringArray};
-    use datafusion::prelude::SessionContext;
 
-    use super::{register_sql2_functions, system_sql2_function_provider};
+    use super::{bind_execution_sql2_functions, system_sql2_function_provider};
 
     pub(super) async fn single_text(sql: &str) -> Option<String> {
-        let ctx = SessionContext::new();
-        register_sql2_functions(
+        let ctx = crate::sql2::session::new_sql_session_context();
+        bind_execution_sql2_functions(
             &ctx,
             system_sql2_function_provider(),
-            crate::ANONYMOUS_ACCOUNT_ID.to_string(),
+            crate::ANONYMOUS_ACCOUNT_ID,
             None,
             None,
         );

--- a/packages/lix/src/storage_adapter/mod.rs
+++ b/packages/lix/src/storage_adapter/mod.rs
@@ -46,8 +46,9 @@ pub use point::{PointReadPlan, PointValues, RequestedToUnique, RequestedToUnique
 pub(crate) use read_scope::SharedStorageAdapterRead;
 pub use read_scope::{StorageAdapterRead, StorageAdapterReadScope};
 pub(crate) use spaces::{
-    REVISION_KEY_BINARY_CAS_EPOCH, REVISION_KEY_CATALOG, REVISION_KEY_FILESYSTEM_PATH,
-    REVISION_KEY_TRACKED_MUTATION, REVISION_SPACE, load_revision, load_revisions, revision_key,
+    REVISION_KEY_BINARY_CAS_PUBLICATION, REVISION_KEY_BINARY_CAS_RECLAMATION, REVISION_KEY_CATALOG,
+    REVISION_KEY_FILESYSTEM_PATH, REVISION_KEY_TRACKED_MUTATION, REVISION_SPACE, load_revision,
+    load_revisions, revision_key,
 };
 pub use stats::{
     StorageReadResult, StorageReadStats, StorageReadStatsCollector, StorageWriteSetStats,

--- a/packages/lix/src/storage_adapter/spaces.rs
+++ b/packages/lix/src/storage_adapter/spaces.rs
@@ -16,14 +16,20 @@ use crate::storage_adapter::{StorageAdapterRead, exact_get_many};
 /// physical keys. That is one SST block, one hot-key write region, and one
 /// batched point read instead of five scattered ones.
 ///
-/// The value semantics stay per-key: the binary-CAS epoch is a CAS-guarded
-/// `u64` big-endian counter, the other four are opaque uuid-v7 tokens whose
-/// only meaningful operation is equality.
+/// Every key holds an opaque uuid-v7 token whose only meaningful operation is
+/// equality: "did this fact change since I read it".
 pub(crate) const REVISION_SPACE: StorageSpace =
     StorageSpace::mutable(SpaceId(0x0007_0000), "lix.revision.v1");
 
-/// Binary-CAS publication/reclamation epoch (`u64` BE, CAS-guarded).
-pub(crate) const REVISION_KEY_BINARY_CAS_EPOCH: &[u8] = b"b";
+/// Binary-CAS reclamation token. Rotated only by an authenticated CAS sweep,
+/// and asserted unchanged by every CAS publisher, so a publisher that planned
+/// against payload rows a sweep then deleted cannot commit.
+pub(crate) const REVISION_KEY_BINARY_CAS_RECLAMATION: &[u8] = b"b";
+/// Binary-CAS publication token. Rewritten by every CAS publisher without a
+/// precondition on itself — publishers are mutually independent — and asserted
+/// unchanged by every sweep, so a sweep whose reachability plan predates a
+/// concurrent publication cannot commit.
+pub(crate) const REVISION_KEY_BINARY_CAS_PUBLICATION: &[u8] = b"p";
 /// Registered-schema catalog visibility token.
 pub(crate) const REVISION_KEY_CATALOG: &[u8] = b"c";
 /// Filesystem path-index cache-freshness token.

--- a/packages/lix/src/storage_adapter/spaces.rs
+++ b/packages/lix/src/storage_adapter/spaces.rs
@@ -12,9 +12,9 @@ use crate::storage_adapter::{StorageAdapterRead, exact_get_many};
 /// singleton.
 ///
 /// Physical keys are `4-byte-BE space id ++ logical key`, so one space with
-/// one-byte logical keys puts all revision singletons in five adjacent
-/// physical keys. That is one SST block, one hot-key write region, and one
-/// batched point read instead of five scattered ones.
+/// one-byte logical keys puts all revision singletons in adjacent physical
+/// keys. That is one SST block, one hot-key write region, and one batched
+/// point read instead of one read per singleton.
 ///
 /// Every key holds an opaque uuid-v7 token whose only meaningful operation is
 /// equality: "did this fact change since I read it".

--- a/packages/lix/src/storage_bench.rs
+++ b/packages/lix/src/storage_bench.rs
@@ -2749,17 +2749,18 @@ mod tests {
             first.staged_deletes
         );
         assert_eq!(first.delete_descriptors, first.staged_deletes as usize);
-        // GC also stages the mandatory binary-CAS epoch key. Its put shares the
-        // key arena with the UUID-keyed delete descriptors. Since the revision
-        // singletons were consolidated into one space, the epoch's *logical* key
-        // is a single byte (`b"b"`) and the 4-byte space id is prepended at the
-        // physical layer, so derive the width from the constant rather than
-        // restating it.
-        const EPOCH_KEY_BYTES: usize = crate::storage_adapter::REVISION_KEY_BINARY_CAS_EPOCH.len();
+        // GC also stages the mandatory binary-CAS reclamation key. Its put
+        // shares the key arena with the UUID-keyed delete descriptors. Since the
+        // revision singletons were consolidated into one space, the reclamation
+        // token's *logical* key is a single byte (`b"b"`) and the 4-byte space
+        // id is prepended at the physical layer, so derive the width from the
+        // constant rather than restating it.
+        const FENCE_KEY_BYTES: usize =
+            crate::storage_adapter::REVISION_KEY_BINARY_CAS_RECLAMATION.len();
         assert_eq!(first.key_shared_buffers, first.staged_deletes as usize + 1);
         assert_eq!(
             first.key_shared_bytes,
-            first.staged_deletes as usize * 16 + EPOCH_KEY_BYTES
+            first.staged_deletes as usize * 16 + FENCE_KEY_BYTES
         );
         assert_eq!(second.swept_commits, first.swept_commits);
         assert_eq!(second.delete_counts_by_space, first.delete_counts_by_space);

--- a/packages/lix/src/storage_bench.rs
+++ b/packages/lix/src/storage_bench.rs
@@ -1840,16 +1840,30 @@ pub struct CommitDeltaSegmentSimilarity {
     pub min_differing_pair_common_suffix: u64,
     /// Whether any pair was compared at all.
     pub compared_any: bool,
+    /// Segments that a content-addressed plane could have elided *if* the
+    /// format also hoisted per-commit identity out of the payload. Two segments
+    /// count as content-equal when they share a byte length and their differing
+    /// bytes all fall inside one window of at most
+    /// `SEGMENT_IDENTITY_WINDOW_BYTES`.
+    pub identity_normalized_duplicate_segments: u64,
+    pub identity_normalized_duplicate_bytes: u64,
+    /// Content-equivalence classes with more than one member.
+    pub identity_normalized_shared_classes: u64,
 }
 
 /// Cap on distinct same-length values compared pairwise per length bucket.
 const SEGMENT_SIMILARITY_BUCKET_CAP: usize = 128;
+/// How much per-segment identity a redesigned payload is allowed to hoist out.
+/// The LXCD16 direct leaf carries a 16-byte commit id, a 4-byte packed base and
+/// a small timestamp-tail dictionary; 128 bytes is a generous allowance for all
+/// of it, so this over-counts rather than under-counts the achievable win.
+const SEGMENT_IDENTITY_WINDOW_BYTES: usize = 128;
 
 pub async fn commit_delta_segment_similarity<R>(read: &R) -> CommitDeltaSegmentSimilarity
 where
     R: StorageAdapterRead,
 {
-    let mut distinct = std::collections::HashMap::<[u8; 32], Bytes>::new();
+    let mut distinct = std::collections::HashMap::<[u8; 32], (Bytes, u64)>::new();
     let mut segments = 0u64;
     for entry in scan_layout_entries(
         read,
@@ -1861,14 +1875,18 @@ where
         let StorageProjectedValue::FullValue(value) = entry.value else {
             continue;
         };
-        distinct
+        let slot = distinct
             .entry(*blake3::hash(&value).as_bytes())
-            .or_insert(value);
+            .or_insert((value, 0));
+        slot.1 += 1;
     }
 
-    let mut buckets = std::collections::BTreeMap::<usize, Vec<Bytes>>::new();
-    for value in distinct.into_values() {
-        buckets.entry(value.len()).or_default().push(value);
+    let mut buckets = std::collections::BTreeMap::<usize, Vec<(Bytes, u64)>>::new();
+    for (value, occurrences) in distinct.into_values() {
+        buckets
+            .entry(value.len())
+            .or_default()
+            .push((value, occurrences));
     }
 
     let mut similarity = CommitDeltaSegmentSimilarity {
@@ -1883,8 +1901,10 @@ where
         }
         similarity.same_length_distinct_values += values.len() as u64;
         let window = &values[..values.len().min(SEGMENT_SIMILARITY_BUCKET_CAP)];
-        for (index, left) in window.iter().enumerate() {
-            for right in &window[index + 1..] {
+        // Union-find over "content-equal once identity is hoisted out".
+        let mut class = (0..window.len()).collect::<Vec<_>>();
+        for (index, (left, _)) in window.iter().enumerate() {
+            for (offset, (right, _)) in window[index + 1..].iter().enumerate() {
                 let differing = left
                     .iter()
                     .zip(right.iter())
@@ -1895,21 +1915,41 @@ where
                 if differing * 100 <= left.len() as u64 {
                     similarity.near_identical_pairs += 1;
                 }
+                let common_prefix = left
+                    .iter()
+                    .zip(right.iter())
+                    .take_while(|(left, right)| left == right)
+                    .count();
+                let common_suffix = left
+                    .iter()
+                    .rev()
+                    .zip(right.iter().rev())
+                    .take_while(|(left, right)| left == right)
+                    .count();
+                if differing > 0
+                    && common_prefix + common_suffix + SEGMENT_IDENTITY_WINDOW_BYTES >= left.len()
+                {
+                    union(&mut class, index, index + 1 + offset);
+                }
                 if differing < similarity.min_differing_bytes {
                     similarity.min_differing_bytes = differing;
                     similarity.min_differing_pair_len = left.len() as u64;
-                    similarity.min_differing_pair_common_prefix = left
-                        .iter()
-                        .zip(right.iter())
-                        .take_while(|(left, right)| left == right)
-                        .count() as u64;
-                    similarity.min_differing_pair_common_suffix = left
-                        .iter()
-                        .rev()
-                        .zip(right.iter().rev())
-                        .take_while(|(left, right)| left == right)
-                        .count() as u64;
+                    similarity.min_differing_pair_common_prefix = common_prefix as u64;
+                    similarity.min_differing_pair_common_suffix = common_suffix as u64;
                 }
+            }
+        }
+        let mut members = std::collections::BTreeMap::<usize, (u64, u64)>::new();
+        for (index, (value, occurrences)) in window.iter().enumerate() {
+            let root = find(&mut class, index);
+            let slot = members.entry(root).or_insert((0, value.len() as u64));
+            slot.0 += occurrences;
+        }
+        for (occurrences, len) in members.into_values() {
+            if occurrences > 1 {
+                similarity.identity_normalized_shared_classes += 1;
+                similarity.identity_normalized_duplicate_segments += occurrences - 1;
+                similarity.identity_normalized_duplicate_bytes += (occurrences - 1) * len;
             }
         }
     }
@@ -1917,6 +1957,22 @@ where
         similarity.min_differing_bytes = 0;
     }
     similarity
+}
+
+fn find(class: &mut [usize], mut index: usize) -> usize {
+    while class[index] != index {
+        class[index] = class[class[index]];
+        index = class[index];
+    }
+    index
+}
+
+fn union(class: &mut [usize], left: usize, right: usize) {
+    let left = find(class, left);
+    let right = find(class, right);
+    if left != right {
+        class[right] = left;
+    }
 }
 
 pub async fn binary_manifest_layout_accounting<R>(

--- a/packages/lix/src/storage_bench.rs
+++ b/packages/lix/src/storage_bench.rs
@@ -1729,6 +1729,179 @@ where
     accounting
 }
 
+/// Exact value-level duplication for one storage space.
+///
+/// `duplicate_value_bytes` is what a perfect content-addressed store would not
+/// have had to write: for every distinct value byte string that occurs `n`
+/// times, `(n - 1) * len`. It is an upper bound on the win from content
+/// addressing that plane, because it ignores whatever indirection a real
+/// content-addressed layout would have to add.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct StorageValueDuplication {
+    pub space_id: u32,
+    pub space: &'static str,
+    pub rows: u64,
+    pub key_bytes: u64,
+    pub value_bytes: u64,
+    /// Distinct value byte strings in the space.
+    pub distinct_values: u64,
+    /// Rows whose value byte string also occurs on at least one other row.
+    pub duplicate_rows: u64,
+    pub duplicate_value_bytes: u64,
+    /// Largest number of rows sharing one value byte string.
+    pub max_occurrences: u64,
+}
+
+impl StorageValueDuplication {
+    /// Share of the space's value bytes a perfect CAS would have elided.
+    pub fn duplicate_fraction(&self) -> f64 {
+        if self.value_bytes == 0 {
+            0.0
+        } else {
+            self.duplicate_value_bytes as f64 / self.value_bytes as f64
+        }
+    }
+}
+
+/// Byte-exact duplication for every native storage space.
+pub async fn space_value_duplication<R>(read: &R) -> Vec<StorageValueDuplication>
+where
+    R: StorageAdapterRead,
+{
+    let mut accounting = Vec::with_capacity(native_storage_spaces().len());
+    for space in native_storage_spaces() {
+        accounting.push(scan_space_value_duplication(read, *space).await);
+    }
+    accounting
+}
+
+async fn scan_space_value_duplication<R>(
+    read: &R,
+    space: crate::storage_adapter::StorageSpace,
+) -> StorageValueDuplication
+where
+    R: StorageAdapterRead,
+{
+    let mut accounting = StorageValueDuplication {
+        space_id: space.id.0,
+        space: space.name,
+        ..StorageValueDuplication::default()
+    };
+    let mut occurrences = std::collections::HashMap::<[u8; 32], (u64, u64)>::new();
+    for entry in scan_layout_entries(read, space).await {
+        accounting.rows += 1;
+        accounting.key_bytes += entry.key.0.len() as u64 + 4;
+        let StorageProjectedValue::FullValue(value) = entry.value else {
+            continue;
+        };
+        accounting.value_bytes += value.len() as u64;
+        let digest = *blake3::hash(&value).as_bytes();
+        let slot = occurrences.entry(digest).or_insert((0, value.len() as u64));
+        slot.0 += 1;
+    }
+    accounting.distinct_values = occurrences.len() as u64;
+    for (count, len) in occurrences.into_values() {
+        accounting.max_occurrences = accounting.max_occurrences.max(count);
+        if count > 1 {
+            accounting.duplicate_rows += count - 1;
+            accounting.duplicate_value_bytes += (count - 1) * len;
+        }
+    }
+    accounting
+}
+
+/// Nearest-neighbour analysis of the commit-delta segment plane.
+///
+/// Byte-exact duplication answers "would a naive CAS dedup this". This answers
+/// the follow-up: when two segments are *not* byte-identical, how far apart are
+/// they? Two equal-length segments differing in a handful of bytes mean the
+/// payload carries per-commit identity (commit id, timestamps) that a redesign
+/// could hoist out; two segments differing in most of their bytes mean the
+/// content genuinely differs and no format change would help.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct CommitDeltaSegmentSimilarity {
+    pub segments: u64,
+    pub distinct_values: u64,
+    /// Distinct values that share their byte length with another distinct value.
+    pub same_length_distinct_values: u64,
+    /// Compared pairs of equal-length distinct values.
+    pub compared_pairs: u64,
+    /// Pairs differing in at most 1% of their bytes.
+    pub near_identical_pairs: u64,
+    /// Smallest positive byte-difference count over all compared pairs.
+    pub min_differing_bytes: u64,
+    /// Byte length of the pair that produced `min_differing_bytes`.
+    pub min_differing_pair_len: u64,
+    /// Whether any pair was compared at all.
+    pub compared_any: bool,
+}
+
+/// Cap on distinct same-length values compared pairwise per length bucket.
+const SEGMENT_SIMILARITY_BUCKET_CAP: usize = 128;
+
+pub async fn commit_delta_segment_similarity<R>(read: &R) -> CommitDeltaSegmentSimilarity
+where
+    R: StorageAdapterRead,
+{
+    let mut distinct = std::collections::HashMap::<[u8; 32], Bytes>::new();
+    let mut segments = 0u64;
+    for entry in scan_layout_entries(
+        read,
+        crate::tracked_state::TRACKED_STATE_COMMIT_DELTA_SEGMENT_SPACE,
+    )
+    .await
+    {
+        segments += 1;
+        let StorageProjectedValue::FullValue(value) = entry.value else {
+            continue;
+        };
+        distinct
+            .entry(*blake3::hash(&value).as_bytes())
+            .or_insert(value);
+    }
+
+    let mut buckets = std::collections::BTreeMap::<usize, Vec<Bytes>>::new();
+    for value in distinct.into_values() {
+        buckets.entry(value.len()).or_default().push(value);
+    }
+
+    let mut similarity = CommitDeltaSegmentSimilarity {
+        segments,
+        min_differing_bytes: u64::MAX,
+        ..CommitDeltaSegmentSimilarity::default()
+    };
+    for values in buckets.values() {
+        similarity.distinct_values += values.len() as u64;
+        if values.len() < 2 {
+            continue;
+        }
+        similarity.same_length_distinct_values += values.len() as u64;
+        let window = &values[..values.len().min(SEGMENT_SIMILARITY_BUCKET_CAP)];
+        for (index, left) in window.iter().enumerate() {
+            for right in &window[index + 1..] {
+                let differing = left
+                    .iter()
+                    .zip(right.iter())
+                    .filter(|(left, right)| left != right)
+                    .count() as u64;
+                similarity.compared_pairs += 1;
+                similarity.compared_any = true;
+                if differing * 100 <= left.len() as u64 {
+                    similarity.near_identical_pairs += 1;
+                }
+                if differing < similarity.min_differing_bytes {
+                    similarity.min_differing_bytes = differing;
+                    similarity.min_differing_pair_len = left.len() as u64;
+                }
+            }
+        }
+    }
+    if !similarity.compared_any {
+        similarity.min_differing_bytes = 0;
+    }
+    similarity
+}
+
 pub async fn binary_manifest_layout_accounting<R>(
     read: &R,
 ) -> Result<BinaryManifestLayoutAccounting, crate::LixError>

--- a/packages/lix/src/storage_bench.rs
+++ b/packages/lix/src/storage_bench.rs
@@ -948,6 +948,7 @@ pub struct RepositoryGcBenchResult {
     pub key_shared_buffers: usize,
     pub key_shared_bytes: usize,
     pub key_shared_capacity: usize,
+    pub reclaimed_generation_rows: u64,
     pub root_discovery_us: u64,
     pub changelog_us: u64,
     pub tracked_root_stage_us: u64,
@@ -1199,6 +1200,7 @@ where
         key_shared_buffers: arena.key_shared_buffers,
         key_shared_bytes: arena.key_shared_bytes,
         key_shared_capacity: arena.key_shared_capacity,
+        reclaimed_generation_rows: plan.sweep.reclaimed_generation_rows,
         root_discovery_us: plan.profile.root_discovery_us,
         changelog_us: plan.profile.changelog_us,
         tracked_root_stage_us: plan.profile.tracked_root_stage_us,
@@ -1210,6 +1212,7 @@ where
 pub struct RepositoryGcCommitBenchResult {
     pub staged_deletes: u64,
     pub swept_commits: usize,
+    pub reclaimed_generation_rows: u64,
     pub reclaimed_manifest_rows: usize,
     pub reclaimed_manifest_chunk_rows: usize,
     pub reclaimed_chunk_rows: usize,
@@ -1262,6 +1265,7 @@ where
             Ok(_) => {
                 return Ok(RepositoryGcCommitBenchResult {
                     staged_deletes: stats.staged_deletes,
+                    reclaimed_generation_rows: plan.sweep.reclaimed_generation_rows,
                     swept_commits: plan
                         .changelog
                         .sweep
@@ -2975,9 +2979,17 @@ mod tests {
         // row; the other ten change deletes are retired branch-ref facts.
         assert_eq!(first.deleted_semantic_change_rows, 20);
         assert_eq!(first.deleted_semantic_reverse_index_rows, 10);
+        // The deleted branch also strands the whole serving generation it was
+        // reading from. No live branch control can select it again, so the
+        // same pass retires it: ten commits of ten rows, plus the generation's
+        // collection control and root current base.
+        assert_eq!(first.reclaimed_generation_rows, 102);
         assert_eq!(
             first.delete_counts_by_space,
             vec![
+                (crate::live_state::HOT_ROW_SPACE.id.0, 100), // stranded serving rows
+                (crate::live_state::HOT_COLLECTION_CONTROL_SPACE.id.0, 1), // its collection control
+                (crate::live_state::ROOT_CURRENT_BASE_SPACE.id.0, 1), // its root current base
                 (
                     crate::tracked_state::TRACKED_STATE_COMMIT_STATE_MANIFEST_SPACE
                         .id
@@ -2990,8 +3002,8 @@ mod tests {
                         .0,
                     10,
                 ), // mutation inventory authority
-                (crate::changelog::COMMIT_SPACE.id.0, 10), // branch-only commit projections
-                (crate::changelog::CHANGE_SPACE.id.0, 20), // projection and branch-ref changes
+                (crate::changelog::COMMIT_SPACE.id.0, 10),    // branch-only commit projections
+                (crate::changelog::CHANGE_SPACE.id.0, 20),    // projection and branch-ref changes
                 (crate::changelog::COMMIT_CHANGE_ID_SPACE.id.0, 10), // commit -> change reverse index
             ]
         );
@@ -3013,9 +3025,35 @@ mod tests {
         const FENCE_KEY_BYTES: usize =
             crate::storage_adapter::REVISION_KEY_BINARY_CAS_RECLAMATION.len();
         assert_eq!(first.key_shared_buffers, first.staged_deletes as usize + 1);
-        assert_eq!(
-            first.key_shared_bytes,
-            first.staged_deletes as usize * 16 + FENCE_KEY_BYTES
+        // Canonical-record deletes are UUID keyed, so each descriptor is
+        // exactly 16 bytes. Generation-scoped serving rows are keyed by
+        // `(branch, generation, schema, entity, file)` and are wider, so assert
+        // the UUID-keyed floor instead of restating that key layout here.
+        let uuid_keyed_deletes = first
+            .delete_counts_by_space
+            .iter()
+            .filter(|(space, _)| {
+                [
+                    crate::tracked_state::TRACKED_STATE_COMMIT_STATE_MANIFEST_SPACE
+                        .id
+                        .0,
+                    crate::tracked_state::TRACKED_STATE_COMMIT_MUTATION_INVENTORY_SPACE
+                        .id
+                        .0,
+                    crate::changelog::COMMIT_SPACE.id.0,
+                    crate::changelog::CHANGE_SPACE.id.0,
+                    crate::changelog::COMMIT_CHANGE_ID_SPACE.id.0,
+                ]
+                .contains(space)
+            })
+            .map(|(_, count)| *count)
+            .sum::<usize>();
+        let generation_keyed_deletes = first.staged_deletes as usize - uuid_keyed_deletes;
+        assert_eq!(generation_keyed_deletes, 102);
+        assert!(
+            first.key_shared_bytes
+                > uuid_keyed_deletes * 16 + generation_keyed_deletes * 16 + FENCE_KEY_BYTES,
+            "generation-scoped delete keys must be wider than a bare UUID"
         );
         assert_eq!(second.swept_commits, first.swept_commits);
         assert_eq!(second.delete_counts_by_space, first.delete_counts_by_space);

--- a/packages/lix/src/storage_bench.rs
+++ b/packages/lix/src/storage_bench.rs
@@ -1832,6 +1832,12 @@ pub struct CommitDeltaSegmentSimilarity {
     pub min_differing_bytes: u64,
     /// Byte length of the pair that produced `min_differing_bytes`.
     pub min_differing_pair_len: u64,
+    /// Shared leading bytes of the pair that produced `min_differing_bytes`.
+    pub min_differing_pair_common_prefix: u64,
+    /// Shared trailing bytes of the same pair. A long shared suffix next to a
+    /// short shared prefix is the signature of a small identity header in front
+    /// of otherwise identical content.
+    pub min_differing_pair_common_suffix: u64,
     /// Whether any pair was compared at all.
     pub compared_any: bool,
 }
@@ -1892,6 +1898,17 @@ where
                 if differing < similarity.min_differing_bytes {
                     similarity.min_differing_bytes = differing;
                     similarity.min_differing_pair_len = left.len() as u64;
+                    similarity.min_differing_pair_common_prefix = left
+                        .iter()
+                        .zip(right.iter())
+                        .take_while(|(left, right)| left == right)
+                        .count() as u64;
+                    similarity.min_differing_pair_common_suffix = left
+                        .iter()
+                        .rev()
+                        .zip(right.iter().rev())
+                        .take_while(|(left, right)| left == right)
+                        .count() as u64;
                 }
             }
         }

--- a/packages/lix/src/storage_bench.rs
+++ b/packages/lix/src/storage_bench.rs
@@ -2488,6 +2488,18 @@ fn collect_binary_cas_json_owners(
     }
 }
 
+/// One registered storage space, looked up by its registry name.
+///
+/// Tools that issue their own point reads need the physical space without
+/// re-declaring its id, which would be a second authority for the registry.
+#[must_use]
+pub fn storage_space_by_name(space_name: &str) -> crate::storage_adapter::StorageSpace {
+    *native_storage_spaces()
+        .iter()
+        .find(|space| space.name == space_name)
+        .expect("space name should exist")
+}
+
 /// Per-row (key, value bytes) inventory of one space.
 ///
 /// Equivalence tests compare these inventories byte-for-byte, so the scan
@@ -2496,10 +2508,7 @@ pub async fn space_inventory<R>(read: &R, space_name: &str) -> Vec<(Vec<u8>, Vec
 where
     R: StorageAdapterRead,
 {
-    let space = *native_storage_spaces()
-        .iter()
-        .find(|space| space.name == space_name)
-        .expect("space name should exist");
+    let space = storage_space_by_name(space_name);
     scan_layout_entries(read, space)
         .await
         .iter()

--- a/packages/lix/src/storage_spaces.rs
+++ b/packages/lix/src/storage_spaces.rs
@@ -65,9 +65,6 @@ pub(crate) const ALL_STORAGE_SPACES: &[StorageSpace] = &[
     crate::gc::CHECKPOINT_GC_STATE_SPACE,
     crate::gc::GC_REACHABILITY_DELTA_SPACE,
     crate::gc::GC_REACHABILITY_QUEUE_SPACE,
-    crate::gc::GC_TREE_SWEEP_EPOCH_SPACE,
-    crate::gc::GC_TREE_SWEEP_MARK_SPACE,
-    crate::gc::GC_TREE_SWEEP_CURSOR_SPACE,
 ];
 
 /// Space ids that belonged to spaces this protocol has cut.
@@ -81,6 +78,12 @@ pub(crate) const RETIRED_STORAGE_SPACE_IDS: &[StorageSpaceId] = &[
     StorageSpaceId(0x0001_0002),
     // live_state.index.branch_root.v1
     StorageSpaceId(0x0004_0005),
+    // gc.tree_sweep_epoch.v1
+    StorageSpaceId(0x0008_0005),
+    // gc.tree_sweep_mark.v1
+    StorageSpaceId(0x0008_0006),
+    // gc.tree_sweep_cursor.v1
+    StorageSpaceId(0x0008_0007),
 ];
 
 /// The first live-row space id.

--- a/packages/lix/src/tracked_state/context.rs
+++ b/packages/lix/src/tracked_state/context.rs
@@ -3773,11 +3773,23 @@ pub(crate) struct TrackedStateWriter<'a, S: ?Sized> {
     writes: &'a mut StorageWriteSet,
 }
 
-#[derive(Debug, Default)]
+#[derive(Debug)]
 pub(crate) struct TrackedStateTransientRebuildState {
     chunk_overlay: storage::TrackedStateChunkOverlay,
     staged_roots: BTreeMap<String, TrackedStateCommitRoot>,
     transient_chunk_hashes: HashSet<[u8; crate::tracked_state::types::TRACKED_STATE_HASH_BYTES]>,
+}
+
+impl Default for TrackedStateTransientRebuildState {
+    /// Rebuild state exists only for the explicit repair path, so its overlay
+    /// rewrites durable chunks instead of trusting an addressed digest.
+    fn default() -> Self {
+        Self {
+            chunk_overlay: storage::TrackedStateChunkOverlay::repairing(),
+            staged_roots: BTreeMap::new(),
+            transient_chunk_hashes: HashSet::new(),
+        }
+    }
 }
 
 impl TrackedStateTransientRebuildState {
@@ -3846,7 +3858,8 @@ where
             .copied()
             .collect::<Vec<_>>();
         self.chunk_overlay
-            .stage_selected_chunks(self.writes, promoted.iter().copied())?;
+            .stage_selected_chunks(self.store, self.writes, promoted.iter().copied())
+            .await?;
         for hash in promoted {
             self.transient_chunk_hashes.remove(&hash);
         }

--- a/packages/lix/src/tracked_state/mod.rs
+++ b/packages/lix/src/tracked_state/mod.rs
@@ -70,6 +70,8 @@ pub(crate) use storage::TRACKED_STATE_COMMIT_STATE_MANIFEST_SPACE;
 pub(crate) use storage::TRACKED_STATE_TREE_CHUNK_SPACE;
 #[cfg(any(test, feature = "storage-benches"))]
 pub(crate) use storage::stage_commit_state_manifest;
+#[cfg(test)]
+pub(crate) use storage::stage_sweep_unreachable_content_nodes;
 pub(crate) use storage::{
     CertifiedCommitStateTopologyParent, CommitDeltaChangeLocator, CommitDeltaLiveMembershipCursor,
     CommitDeltaMember, CommitDeltaPointReadCache, CommitDeltaReplacementGeneration,
@@ -89,21 +91,25 @@ pub(crate) use storage::{
     stage_current_state_scoped_ranges_from_published_parent,
     stage_current_state_scoped_ranges_from_published_topology_parent,
     stage_current_state_scoped_ranges_from_staged_parent,
-    stage_current_state_scoped_ranges_from_topology, stage_delete_commit_state_manifest_for_gc,
-    stage_ordered_addressable_commit_deltas, stage_ordered_addressable_replacement_parts,
-    stage_ordered_columnar_mutations, stage_preencoded_ordered_addressable_replacement_parts,
+    stage_current_state_scoped_ranges_from_topology, stage_ordered_addressable_commit_deltas,
+    stage_ordered_addressable_replacement_parts, stage_ordered_columnar_mutations,
+    stage_preencoded_ordered_addressable_replacement_parts,
     stage_prefixed_ordered_addressable_replacement_parts,
+};
+pub(crate) use storage::{
+    RetainedPhysicalState, load_native_current_state_part_owners,
+    stage_retire_commit_physical_state,
 };
 // The storage-space constants are what the space registry
 // (`crate::storage_spaces`) and its layout invariants are built from, so they
 // must be reachable whenever tests compile, not only under `storage-benches`.
+#[cfg(feature = "storage-benches")]
+pub(crate) use storage::decode_change_locator;
 #[cfg(any(test, feature = "storage-benches"))]
 pub(crate) use storage::{
     TRACKED_STATE_CHANGE_LOCATOR_SPACE, TRACKED_STATE_COMMIT_DELTA_SEGMENT_SPACE,
     TRACKED_STATE_COMMIT_MUTATION_INVENTORY_SPACE, TRACKED_STATE_COMMIT_STATE_MANIFEST_SPACE,
 };
-#[cfg(feature = "storage-benches")]
-pub(crate) use storage::decode_change_locator;
 #[cfg(test)]
 pub(crate) use storage::{
     change_id_from_packed_address, commit_state_authority_key, load_commit_delta_change_ids,

--- a/packages/lix/src/tracked_state/storage.rs
+++ b/packages/lix/src/tracked_state/storage.rs
@@ -10444,6 +10444,191 @@ pub(crate) async fn stage_delete_commit_state_manifest_for_gc(
     Ok(())
 }
 
+/// The content-addressed nodes and parts that are still reachable from the
+/// repository's live root closure.
+///
+/// Every tracked-state plane below is content addressed and therefore shared
+/// between commits, so a retired commit may only drop a node the live closure
+/// does not also name.
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct RetainedPhysicalState<'a> {
+    pub(crate) mutation_nodes: &'a BTreeSet<[u8; 32]>,
+    pub(crate) scoped_nodes: &'a BTreeSet<[u8; 32]>,
+    pub(crate) native_parts: &'a BTreeSet<[u8; 32]>,
+}
+
+/// Retires every physical tracked-state row owned by one unreachable commit.
+///
+/// GC proves unreachability from refs and hands the proof here; the layout of
+/// mutation directories, scoped-range trees, and native current-state parts —
+/// and therefore which keys a retirement touches — stays inside the module
+/// that writes them.
+pub(crate) async fn stage_retire_commit_physical_state(
+    store: &(impl StorageAdapterRead + ?Sized),
+    writes: &mut StorageWriteSet,
+    commit_id: CommitId,
+    retained: RetainedPhysicalState<'_>,
+) -> Result<(), LixError> {
+    let manifest = load_commit_state_manifest(store, commit_id)
+        .await?
+        .ok_or_else(|| {
+            LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                format!("retired GC root '{commit_id}' has no authenticated manifest"),
+            )
+        })?;
+    let retired_root = load_commit_mutation_directory_roots(store, &[commit_id])
+        .await?
+        .into_iter()
+        .next()
+        .flatten();
+    if let Some(root) = retired_root {
+        let nodes = crate::tracked_state::collect_mutation_directory_node_ids(store, &root).await?;
+        for node_id in nodes.difference(retained.mutation_nodes) {
+            writes.delete(
+                crate::tracked_state::MUTATION_DIRECTORY_NODE_SPACE,
+                key(node_id.to_vec()),
+            );
+        }
+    }
+    if let Some(root) = manifest.current_state_scoped_ranges.as_ref() {
+        let reachable = crate::tracked_state::validate_scoped_range_trees(
+            store,
+            std::slice::from_ref(&root.tree),
+        )
+        .await?;
+        for node_id in reachable.node_ids.difference(retained.scoped_nodes) {
+            writes.delete(
+                crate::tracked_state::SCOPED_RANGE_NODE_SPACE,
+                key(node_id.to_vec()),
+            );
+        }
+        for part in reachable.parts {
+            let descriptor =
+                crate::tracked_state::current_state_descriptor_from_scoped_range_part(&part)?;
+            if descriptor.source_kind == 1
+                && !retained.native_parts.contains(&descriptor.content_digest)
+            {
+                writes.delete(
+                    crate::tracked_state::CURRENT_STATE_DATA_PART_SPACE,
+                    key(descriptor.content_digest.to_vec()),
+                );
+                writes.delete(
+                    crate::tracked_state::CURRENT_STATE_DATA_PART_REFS_SPACE,
+                    key(descriptor.payload_refs_digest.to_vec()),
+                );
+            }
+        }
+    }
+    stage_delete_commit_state_manifest_for_gc(store, writes, commit_id, &manifest).await
+}
+
+/// Loads the owning commit ids of every native current-state data part named by
+/// `digests`, proving each payload is still physically present.
+///
+/// A scoped-range descriptor is authority for the digest, but not proof that
+/// the immutable payload still exists; treating a missing payload as an empty
+/// live set would silently turn corruption into deletion, so this fails closed.
+pub(crate) async fn load_native_current_state_part_owners(
+    store: &(impl StorageAdapterRead + ?Sized),
+    digests: &BTreeSet<[u8; 32]>,
+) -> Result<BTreeSet<CommitId>, LixError> {
+    if digests.is_empty() {
+        return Ok(BTreeSet::new());
+    }
+    let keys = digests
+        .iter()
+        .map(|digest| StorageKey(Bytes::copy_from_slice(digest)))
+        .collect::<Vec<_>>();
+    let loaded = PointReadPlan::new(crate::tracked_state::CURRENT_STATE_DATA_PART_SPACE, &keys)
+        .materialize(store, StorageGetOptions::default())
+        .await?;
+    let mut commit_ids = BTreeSet::new();
+    for (digest, value) in digests.iter().zip(loaded.value) {
+        let Some(StorageProjectedValue::FullValue(bytes)) = value else {
+            return Err(LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                "live current-state directory references a missing native data part",
+            ));
+        };
+        commit_ids.extend(
+            crate::tracked_state::decode_current_state_data_part_commit_ids(digest, &bytes)?,
+        );
+    }
+    Ok(commit_ids)
+}
+
+/// Sweeps every content-addressed tracked-state plane down to a repository-wide
+/// live closure.
+///
+/// This is the whole-repository counterpart to
+/// [`stage_retire_commit_physical_state`]: it discovers rows by scanning rather
+/// than from a retirement proof, so it is reserved for the offline oracle that
+/// cross-checks incremental GC.
+#[cfg(test)]
+pub(crate) async fn stage_sweep_unreachable_content_nodes(
+    store: &(impl StorageAdapterRead + ?Sized),
+    writes: &mut StorageWriteSet,
+    retained: RetainedPhysicalState<'_>,
+) -> Result<(), LixError> {
+    for (space, live) in [
+        (
+            crate::tracked_state::SCOPED_RANGE_NODE_SPACE,
+            retained.scoped_nodes,
+        ),
+        (
+            crate::tracked_state::MUTATION_DIRECTORY_NODE_SPACE,
+            retained.mutation_nodes,
+        ),
+        (
+            crate::tracked_state::CURRENT_STATE_DATA_PART_REFS_SPACE,
+            retained.native_parts,
+        ),
+        (
+            crate::tracked_state::CURRENT_STATE_DATA_PART_SPACE,
+            retained.native_parts,
+        ),
+    ] {
+        let range = StorageKeyRange {
+            lower: Bound::Unbounded,
+            upper: Bound::Unbounded,
+        };
+        let mut cursor = store
+            .begin_scan(
+                space,
+                range,
+                StorageBeginScanOptions {
+                    projection: StorageCoreProjection::KeyOnly,
+                    ..StorageBeginScanOptions::default()
+                },
+            )
+            .await?;
+        loop {
+            let page = cursor
+                .next_page(crate::storage_adapter::MAX_SCAN_PAGE_ROWS)
+                .await?;
+            for entry in page.entries {
+                let node_id = <[u8; 32]>::try_from(entry.key.0.as_ref()).map_err(|_| {
+                    LixError::new(
+                        LixError::CODE_INTERNAL_ERROR,
+                        format!(
+                            "content-addressed space '{}' contains a malformed key",
+                            space.name
+                        ),
+                    )
+                })?;
+                if !live.contains(&node_id) {
+                    writes.delete(space, entry.key);
+                }
+            }
+            if !page.has_more {
+                break;
+            }
+        }
+    }
+    Ok(())
+}
+
 async fn scan_full_space(
     store: &(impl StorageAdapterRead + ?Sized),
     space: StorageSpace,

--- a/packages/lix/src/tracked_state/storage.rs
+++ b/packages/lix/src/tracked_state/storage.rs
@@ -5,7 +5,7 @@
 )]
 
 use std::borrow::Cow;
-use std::collections::{BTreeMap, BTreeSet, HashMap, VecDeque};
+use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet, VecDeque};
 use std::ops::{Bound, Deref, Range};
 use std::sync::{Arc, Mutex, OnceLock};
 
@@ -12026,11 +12026,66 @@ pub(crate) fn debug_verify_chunk_hash(
 #[derive(Debug, Default)]
 pub(crate) struct TrackedStateChunkOverlay {
     chunks: HashMap<[u8; TRACKED_STATE_HASH_BYTES], Bytes>,
+    /// Chunk digests this writer has proven are already durable at its read
+    /// snapshot. The space is content-addressed, so a present key is the same
+    /// bytes by construction and re-writing it is a no-op the backend cannot
+    /// elide for a mutable space.
+    known_durable: HashSet<[u8; TRACKED_STATE_HASH_BYTES]>,
+    /// Explicit commit-root rebuild is the repair path for a damaged chunk, so
+    /// it must rewrite every node it derives. A present key proves the digest
+    /// is addressed, not that the stored bytes still hash to it.
+    rewrite_durable: bool,
 }
 
 impl TrackedStateChunkOverlay {
     pub(crate) fn new() -> Self {
         Self::default()
+    }
+
+    /// Overlay for the explicit rebuild path, which repairs corrupt chunks by
+    /// rewriting them and therefore never skips a durable digest.
+    pub(crate) fn repairing() -> Self {
+        Self {
+            rewrite_durable: true,
+            ..Self::default()
+        }
+    }
+
+    /// Records which of `hashes` are already durable, using one presence-only
+    /// batched point read. Digests already proven durable are not probed again.
+    async fn probe_durable_digests(
+        &mut self,
+        store: &(impl StorageAdapterRead + ?Sized),
+        hashes: impl IntoIterator<Item = [u8; TRACKED_STATE_HASH_BYTES]>,
+    ) -> Result<(), LixError> {
+        if self.rewrite_durable {
+            return Ok(());
+        }
+        let candidates = hashes
+            .into_iter()
+            .filter(|hash| !self.known_durable.contains(hash))
+            .collect::<Vec<_>>();
+        if candidates.is_empty() {
+            return Ok(());
+        }
+        let keys = candidates
+            .iter()
+            .map(|hash| StorageKey(Bytes::copy_from_slice(hash)))
+            .collect::<Vec<_>>();
+        let requests = [StorageGetManyRequest {
+            space: TRACKED_STATE_TREE_CHUNK_SPACE,
+            keys: &keys,
+            opts: StorageGetOptions {
+                projection: StorageCoreProjection::KeyOnly,
+            },
+        }];
+        let result = exact_get_many(store, &requests).await?;
+        for (hash, value) in candidates.into_iter().zip(result.values) {
+            if value.is_some() {
+                self.known_durable.insert(hash);
+            }
+        }
+        Ok(())
     }
 
     pub(crate) fn staged_chunk(&self, hash: &[u8; TRACKED_STATE_HASH_BYTES]) -> Option<&[u8]> {
@@ -12041,12 +12096,24 @@ impl TrackedStateChunkOverlay {
         self.chunks.keys().copied()
     }
 
-    pub(crate) fn stage_selected_chunks(
-        &self,
+    pub(crate) async fn stage_selected_chunks(
+        &mut self,
+        store: &(impl StorageAdapterRead + ?Sized),
         writes: &mut StorageWriteSet,
         hashes: impl IntoIterator<Item = [u8; TRACKED_STATE_HASH_BYTES]>,
     ) -> Result<(), LixError> {
+        let hashes = hashes.into_iter().collect::<Vec<_>>();
+        if hashes.is_empty() {
+            return Ok(());
+        }
+        // Transient chunks live only in the overlay, so the durable probe must
+        // run against the digests themselves rather than the staged-chunk map.
+        self.probe_durable_digests(store, hashes.iter().copied())
+            .await?;
         for hash in hashes {
+            if self.known_durable.contains(&hash) {
+                continue;
+            }
             let bytes = self.chunks.get(&hash).ok_or_else(|| {
                 LixError::new(
                     LixError::CODE_INTERNAL_ERROR,
@@ -12068,25 +12135,46 @@ impl TrackedStateChunkOverlay {
         self.chunks.get(hash).cloned()
     }
 
-    pub(crate) fn stage_chunks(
+    /// Stages the chunks this rewrite produced, skipping any digest already
+    /// durable at the writer's read snapshot.
+    ///
+    /// The tracked-state tree is content-addressed, so an existing key is
+    /// necessarily the same bytes. A mutable storage space has no
+    /// already-present skip of its own (RocksDB's lives behind
+    /// `ValueSemantics::Immutable`; SlateDB's mutable path writes straight into
+    /// its overlay), so without this filter a root rewrite that re-derives an
+    /// ancestor's nodes pays the full write-set, WAL, memtable and compaction
+    /// cost for bytes that are already on disk.
+    pub(crate) async fn stage_chunks(
         &mut self,
+        store: &(impl StorageAdapterRead + ?Sized),
         writes: &mut StorageWriteSet,
         chunks: &PendingChunkBatch,
-    ) {
+    ) -> Result<(), LixError> {
         if chunks.is_empty() {
-            return;
+            return Ok(());
         }
+        self.probe_durable_digests(store, chunks.chunks().iter().map(|chunk| chunk.hash))
+            .await?;
         let mut key_arena =
             Vec::with_capacity(chunks.len().saturating_mul(TRACKED_STATE_HASH_BYTES));
         let mut puts = Vec::with_capacity(chunks.len());
         for chunk in chunks.chunks() {
+            // Overlay residency is independent of staging: an in-flight rewrite
+            // still reads a durable-skipped node through the overlay.
+            self.chunks.insert(chunk.hash, chunks.chunk_data(*chunk));
+            if self.known_durable.contains(&chunk.hash) {
+                continue;
+            }
             let key_start = key_arena.len();
             key_arena.extend_from_slice(&chunk.hash);
             puts.push(EncodedPut {
                 key: BufferRange::new(key_start, TRACKED_STATE_HASH_BYTES),
                 value: BufferRange::new(chunk.data_start, chunk.data_len),
             });
-            self.chunks.insert(chunk.hash, chunks.chunk_data(*chunk));
+        }
+        if puts.is_empty() {
+            return Ok(());
         }
         let batch = EncodedMutationBatch::try_new(
             Bytes::from(key_arena),
@@ -12096,6 +12184,7 @@ impl TrackedStateChunkOverlay {
         )
         .expect("tracked-state chunk batch descriptors must match their arenas");
         writes.stage_content_addressed_encoded_batch(TRACKED_STATE_TREE_CHUNK_SPACE, batch);
+        Ok(())
     }
 }
 
@@ -15383,8 +15472,12 @@ mod tests {
             .collect()
     }
 
-    #[test]
-    fn large_chunk_batch_stages_two_shared_arenas() {
+    #[tokio::test]
+    async fn large_chunk_batch_stages_two_shared_arenas() {
+        let store = StorageAdapter::new(Memory::new())
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("open empty snapshot");
         let chunk_count = 4_096;
         let mut data_arena = Vec::with_capacity(chunk_count * 64);
         let mut descriptors = Vec::with_capacity(chunk_count);
@@ -15401,7 +15494,10 @@ mod tests {
         let chunks = PendingChunkBatch::from_parts(Bytes::from(data_arena), descriptors);
         let mut writes = StorageWriteSet::new();
         let mut overlay = TrackedStateChunkOverlay::new();
-        overlay.stage_chunks(&mut writes, &chunks);
+        overlay
+            .stage_chunks(&store, &mut writes, &chunks)
+            .await
+            .expect("stage chunks against an empty durable store");
 
         let arena = writes.arena_stats();
         assert_eq!(arena.put_descriptors, chunk_count);

--- a/packages/lix/src/tracked_state/tree.rs
+++ b/packages/lix/src/tracked_state/tree.rs
@@ -388,7 +388,7 @@ impl TrackedStateTree {
                     })?;
                 let chunk_bytes = chunks.data.len();
                 let chunks = chunks.finish();
-                overlay.stage_chunks(writes, &chunks);
+                overlay.stage_chunks(store, writes, &chunks).await?;
                 return Ok(TrackedStateApplyResult {
                     root_id: TrackedStateRootId::new(root.child_hash),
                     row_count: 0,
@@ -489,7 +489,7 @@ impl TrackedStateTree {
         };
         let chunk_bytes = chunks.data.len();
         let chunks = chunks.finish();
-        overlay.stage_chunks(writes, &chunks);
+        overlay.stage_chunks(store, writes, &chunks).await?;
         Ok(TrackedStateApplyResult {
             root_id,
             row_count,
@@ -934,7 +934,7 @@ impl TrackedStateTree {
 
         let built = assembler.finish(self)?;
         let result = self
-            .persist_built_tree(writes, overlay, built, commit_id)
+            .persist_built_tree(store, writes, overlay, built, commit_id)
             .await?;
         Ok((result, cascaded_rows))
     }
@@ -1241,12 +1241,13 @@ impl TrackedStateTree {
 
     async fn persist_built_tree(
         &self,
+        store: &(impl StorageAdapterRead + ?Sized),
         writes: &mut StorageWriteSet,
         overlay: &mut storage::TrackedStateChunkOverlay,
         built: BuiltTree,
         _commit_id: Option<&str>,
     ) -> Result<TrackedStateApplyResult, LixError> {
-        overlay.stage_chunks(writes, &built.chunks);
+        overlay.stage_chunks(store, writes, &built.chunks).await?;
         Ok(TrackedStateApplyResult {
             root_id: built.root_id,
             row_count: built.row_count,

--- a/packages/lix/src/transaction/commit.rs
+++ b/packages/lix/src/transaction/commit.rs
@@ -10608,9 +10608,9 @@ mod tests {
         .await
         .expect("ordinary race CAS sweep should stage");
         assert_eq!(swept.reclaimed_chunk_rows, 1);
-        crate::binary_cas::stage_mutation_epoch(read, &mut writes, &mut preconditions)
+        crate::binary_cas::stage_cas_reclamation_fence(read, &mut writes, &mut preconditions)
             .await
-            .expect("ordinary race sweep epoch should stage");
+            .expect("ordinary race sweep fence should stage");
         (writes, preconditions)
     }
 

--- a/packages/lix/src/transaction/context.rs
+++ b/packages/lix/src/transaction/context.rs
@@ -8430,7 +8430,7 @@ where
         self.sql_planning_cache.datafusion_session()
     }
 
-    fn datafusion_read_session(&self) -> datafusion::prelude::SessionContext {
+    fn datafusion_read_session(&self) -> crate::sql2::PooledReadSession {
         self.sql_planning_cache.datafusion_read_session()
     }
 

--- a/packages/lix/tests/integration/main.rs
+++ b/packages/lix/tests/integration/main.rs
@@ -20,6 +20,7 @@ mod merge_fuzz;
 mod observe;
 mod observe_mutation_revision;
 mod physical_plan_cache;
+mod pooled_session_reuse;
 mod sql;
 mod storage_accounting;
 mod transaction;

--- a/packages/lix/tests/integration/pooled_session_reuse.rs
+++ b/packages/lix/tests/integration/pooled_session_reuse.rs
@@ -97,10 +97,7 @@ async fn execution_functions_follow_a_branch_switch_on_a_reused_session() {
         .execute(ACTIVE_FACTS_SQL, &[])
         .await
         .expect("active facts should read after switching back");
-    assert_eq!(
-        text(&restored, "branch_id"),
-        Some(main_branch_id)
-    );
+    assert_eq!(text(&restored, "branch_id"), Some(main_branch_id));
     assert_eq!(text(&restored, "commit_id"), Some(before_commit));
 }
 
@@ -185,7 +182,10 @@ async fn a_reused_session_reads_rows_committed_after_its_plan_was_cached() {
 
     let sql = "SELECT key FROM lix_key_value WHERE key LIKE 'pooled-visibility-%' ORDER BY key";
     for round in 0..4 {
-        let rows = session.execute(sql, &[]).await.expect("read should execute");
+        let rows = session
+            .execute(sql, &[])
+            .await
+            .expect("read should execute");
         assert_eq!(
             rows.len(),
             round,

--- a/packages/lix/tests/integration/pooled_session_reuse.rs
+++ b/packages/lix/tests/integration/pooled_session_reuse.rs
@@ -1,0 +1,269 @@
+//! A pooled DataFusion session outlives the statement that borrowed it, and its
+//! execution functions are registered once for the life of the session rather
+//! than per statement. These tests pin the resulting hazard: a second execution
+//! of the same statement shape must never observe the first execution's account,
+//! branch, commit or snapshot.
+
+use lix::integration::Engine;
+use lix::storage::Memory;
+use lix::{CreateBranchOptions, SwitchBranchOptions, Value};
+
+const DRAFT_BRANCH_ID: &str = "01930000-0000-7000-8000-0000000000d1";
+
+const ACTIVE_FACTS_SQL: &str = "SELECT lix_active_branch_id() AS branch_id, \
+    lix_active_branch_commit_id() AS commit_id, \
+    lix_active_account_id() AS account_id";
+
+async fn open_engine() -> Engine {
+    let storage = Memory::new();
+    Engine::initialize(storage.clone())
+        .await
+        .expect("storage should initialize");
+    Engine::new(storage)
+        .await
+        .expect("initialized storage should open")
+}
+
+fn text(rows: &lix::ExecuteResult, column: &str) -> Option<String> {
+    match rows.rows()[0].value(column).expect("column is present") {
+        Value::Text(value) => Some(value.clone()),
+        Value::Null => None,
+        other => panic!("unexpected {column} value: {other:?}"),
+    }
+}
+
+/// Switching branches between two executions of the same statement shape must
+/// change what `lix_active_branch_id()` reports.
+///
+/// Before the execution functions moved into a per-session slot they were
+/// deregistered and re-registered per statement, so a stale registration was
+/// impossible by construction. The slot is what preserves that property now.
+#[tokio::test(flavor = "current_thread")]
+async fn execution_functions_follow_a_branch_switch_on_a_reused_session() {
+    let engine = open_engine().await;
+    let session = engine
+        .open_workspace_session()
+        .await
+        .expect("workspace session should open");
+
+    session
+        .create_branch(CreateBranchOptions {
+            id: Some(DRAFT_BRANCH_ID.to_string()),
+            name: "Draft".to_string(),
+            from_commit_id: None,
+        })
+        .await
+        .expect("branch should be created");
+
+    // Warm the pooled session and every planning cache on this exact shape.
+    let before = session
+        .execute(ACTIVE_FACTS_SQL, &[])
+        .await
+        .expect("active facts should read");
+    let main_branch_id = text(&before, "branch_id").expect("branch id is present");
+    let before_commit = text(&before, "commit_id").expect("commit id is present");
+    let account = text(&before, "account_id").expect("account id is present");
+
+    session
+        .switch_branch(SwitchBranchOptions {
+            branch_id: DRAFT_BRANCH_ID.to_string(),
+        })
+        .await
+        .expect("switch should succeed");
+
+    let after = session
+        .execute(ACTIVE_FACTS_SQL, &[])
+        .await
+        .expect("active facts should read after the switch");
+    assert_eq!(
+        text(&after, "branch_id").as_deref(),
+        Some(DRAFT_BRANCH_ID),
+        "the reused session reported the previous statement's branch"
+    );
+    assert_ne!(text(&after, "branch_id"), Some(main_branch_id.clone()));
+    assert_eq!(text(&after, "account_id"), Some(account));
+    // The draft branch was created from main's head, so the commit id is only
+    // required to still be present and to track the branch that is now active.
+    assert!(text(&after, "commit_id").is_some());
+
+    // Switching back must not leave the draft's identity behind either.
+    session
+        .switch_branch(SwitchBranchOptions {
+            branch_id: main_branch_id.clone(),
+        })
+        .await
+        .expect("switch back should succeed");
+    let restored = session
+        .execute(ACTIVE_FACTS_SQL, &[])
+        .await
+        .expect("active facts should read after switching back");
+    assert_eq!(
+        text(&restored, "branch_id"),
+        Some(main_branch_id)
+    );
+    assert_eq!(text(&restored, "commit_id"), Some(before_commit));
+}
+
+/// `lix_active_branch_commit_id()` must advance when the active branch commits,
+/// even though the SQL text and parameter bytes are unchanged.
+#[tokio::test(flavor = "current_thread")]
+async fn active_commit_id_advances_between_executions_of_one_shape() {
+    let engine = open_engine().await;
+    let session = engine
+        .open_workspace_session()
+        .await
+        .expect("workspace session should open");
+
+    let sql = "SELECT lix_active_branch_commit_id() AS commit_id";
+    let first = text(
+        &session.execute(sql, &[]).await.expect("first read"),
+        "commit_id",
+    )
+    .expect("commit id is present");
+
+    session
+        .execute(
+            "INSERT INTO lix_key_value (key, value) VALUES ('pooled-session-probe', 'v1')",
+            &[],
+        )
+        .await
+        .expect("write should commit");
+
+    let second = text(
+        &session.execute(sql, &[]).await.expect("second read"),
+        "commit_id",
+    )
+    .expect("commit id is present");
+    assert_ne!(
+        first, second,
+        "a reused session reported the commit id captured by an earlier statement"
+    );
+}
+
+/// The volatile execution functions must produce a fresh value per invocation,
+/// per row and per statement — never one frozen into the session.
+#[tokio::test(flavor = "current_thread")]
+async fn volatile_execution_functions_stay_fresh_on_a_reused_session() {
+    let engine = open_engine().await;
+    let session = engine
+        .open_workspace_session()
+        .await
+        .expect("workspace session should open");
+
+    let sql = "SELECT lix_uuid_v7() AS first, lix_uuid_v7() AS second, \
+        lix_timestamp() AS stamp";
+    let mut uuids = Vec::new();
+    for _ in 0..3 {
+        let rows = session.execute(sql, &[]).await.expect("volatile read");
+        let first = text(&rows, "first").expect("uuid is present");
+        let second = text(&rows, "second").expect("uuid is present");
+        assert_ne!(
+            first, second,
+            "two calls in one statement returned the same uuid"
+        );
+        assert!(text(&rows, "stamp").is_some());
+        uuids.push(first);
+        uuids.push(second);
+    }
+    let unique = uuids.iter().collect::<std::collections::BTreeSet<_>>();
+    assert_eq!(
+        unique.len(),
+        uuids.len(),
+        "a reused session replayed uuids from an earlier statement"
+    );
+}
+
+/// A row committed between two executions of one statement shape must be
+/// visible to the second, on the same pooled session and the same cached plan.
+#[tokio::test(flavor = "current_thread")]
+async fn a_reused_session_reads_rows_committed_after_its_plan_was_cached() {
+    let engine = open_engine().await;
+    let session = engine
+        .open_workspace_session()
+        .await
+        .expect("workspace session should open");
+
+    let sql = "SELECT key FROM lix_key_value WHERE key LIKE 'pooled-visibility-%' ORDER BY key";
+    for round in 0..4 {
+        let rows = session.execute(sql, &[]).await.expect("read should execute");
+        assert_eq!(
+            rows.len(),
+            round,
+            "the reused session served a stale snapshot"
+        );
+        session
+            .execute(
+                "INSERT INTO lix_key_value (key, value) VALUES ($1, 'v')",
+                &[Value::Text(format!("pooled-visibility-{round}"))],
+            )
+            .await
+            .expect("write should commit");
+    }
+    assert_eq!(
+        session
+            .execute(sql, &[])
+            .await
+            .expect("final read should execute")
+            .len(),
+        4
+    );
+}
+
+/// `information_schema` is registered only for statements that can reach it.
+/// Interleaving it with ordinary statements on a pooled session must not make
+/// its rows go missing or go stale.
+#[tokio::test(flavor = "current_thread")]
+async fn information_schema_stays_available_across_pooled_statements() {
+    let engine = open_engine().await;
+    let session = engine
+        .open_workspace_session()
+        .await
+        .expect("workspace session should open");
+
+    let information_schema_sql =
+        "SELECT table_name FROM information_schema.tables WHERE table_name = 'lix_key_value'";
+    for _ in 0..3 {
+        assert_eq!(
+            session
+                .execute(information_schema_sql, &[])
+                .await
+                .expect("information_schema should read")
+                .len(),
+            1
+        );
+        session
+            .execute("SELECT key FROM lix_key_value LIMIT 1", &[])
+            .await
+            .expect("ordinary read should execute");
+    }
+
+    session
+        .execute(
+            "INSERT INTO lix_registered_schema (value) VALUES (lix_json($1))",
+            &[Value::Text(
+                serde_json::json!({
+                    "x-lix-key": "pooled_probe",
+                    "x-lix-primary-key": ["/id"],
+                    "type": "object",
+                    "properties": { "id": { "type": "string" } },
+                    "required": ["id"],
+                    "additionalProperties": false
+                })
+                .to_string(),
+            )],
+        )
+        .await
+        .expect("schema should register");
+
+    assert_eq!(
+        session
+            .execute(
+                "SELECT table_name FROM information_schema.tables WHERE table_name = 'pooled_probe'",
+                &[],
+            )
+            .await
+            .expect("information_schema should see the new surface")
+            .len(),
+        1
+    );
+}

--- a/packages/lix/tests/integration/transaction.rs
+++ b/packages/lix/tests/integration/transaction.rs
@@ -108,15 +108,17 @@ async fn stale_transaction_composes_disjoint_semantic_writes() {
 /// they touch disjoint files, disjoint payload rows, and disjoint branch state.
 /// Neither may be rejected because the other committed first.
 ///
-/// This is the shape that the ignored `slatedb_movie_workspace_interference`
-/// qualification exercises with a 1 TiB corpus. Resumable upload parts commit
-/// straight to storage rather than through the collaboration write gate, so
-/// they land inside an ordinary commit's precondition window — which is exactly
-/// where a shared compare-and-set turns into a false `LIX_TRANSACTION_CONFLICT`.
+/// This is the shape the ignored `slatedb_movie_workspace_interference`
+/// qualification exercises with a 1 TiB corpus, reduced to the one interleaving
+/// that matters. Resumable upload parts commit straight to storage instead of
+/// through the collaboration write gate, so an ingest part lands squarely inside
+/// an ordinary commit's precondition window: between the save's commit-time
+/// snapshot and the save's storage write. The gate below parks the save exactly
+/// there rather than leaving the interleaving to the scheduler.
 #[tokio::test]
-async fn concurrent_media_ingest_does_not_conflict_with_project_saves() {
-    const ROUNDS: usize = 12;
-    let storage = InterleavingStorage::default();
+async fn committed_media_ingest_part_does_not_invalidate_a_concurrent_project_save() {
+    let storage = InterferingStorage::new();
+    let gate = storage.gate();
     Engine::initialize(storage.clone())
         .await
         .expect("storage should initialize");
@@ -131,124 +133,58 @@ async fn concurrent_media_ingest_does_not_conflict_with_project_saves() {
         .open_workspace_session()
         .await
         .expect("project-save session should open");
+    saver
+        .upsert_file_content(
+            "/project/edit.json".to_owned(),
+            br#"{"timelineRevision":0}"#.to_vec().into(),
+        )
+        .await
+        .expect("seed project file should save");
 
-    let ingest_future = async {
-        for round in 0..ROUNDS {
-            let payload = vec![round as u8 | 0x40; 4096];
-            let progress = ingest
-                .upsert_file_content_part(
-                    format!("media-ingest-{round}"),
-                    format!("/media/clip-{round}.bin"),
-                    0,
-                    payload.len() as u64,
-                    payload.into(),
-                )
-                .await
-                .expect("media ingest must not conflict with an unrelated concurrent writer");
-            assert!(progress.finalized, "single-part upload should finalize");
-        }
-    };
+    gate.arm();
     let save_future = async {
-        for round in 0..ROUNDS {
-            saver
-                .upsert_file_content(
-                    "/project/edit.json".to_owned(),
-                    format!("{{\"timelineRevision\":{round}}}")
-                        .into_bytes()
-                        .into(),
-                )
-                .await
-                .expect("project-file save must not conflict with concurrent media ingest");
-        }
+        saver
+            .upsert_file_content(
+                "/project/edit.json".to_owned(),
+                br#"{"timelineRevision":1}"#.to_vec().into(),
+            )
+            .await
     };
-    tokio::join!(ingest_future, save_future);
+    let ingest_future = async {
+        // Only start once the save is parked on its storage write, so this
+        // publisher is guaranteed to commit inside the save's precondition
+        // window. One part of a two-part upload: the upload does not finalize,
+        // so this path never needs the collaboration write gate the save holds.
+        gate.wait_until_a_write_is_parked().await;
+        let progress = ingest
+            .upsert_file_content_part(
+                "concurrent-ingest".to_owned(),
+                "/media/import.mov".to_owned(),
+                0,
+                2 * lix::FILE_UPLOAD_PART_BYTES as u64,
+                vec![0x5a; lix::FILE_UPLOAD_PART_BYTES].into(),
+            )
+            .await;
+        gate.release_parked_write();
+        progress
+    };
+    let (save_result, ingest_result) =
+        tokio::time::timeout(TEST_WAIT_TIMEOUT * 15, async move {
+            tokio::join!(save_future, ingest_future)
+        })
+        .await
+        .expect("interfering writers should not deadlock");
+
+    ingest_result.expect("media ingest part should commit");
+    save_result
+        .expect("a committed media ingest part must not invalidate a concurrent project save");
 
     let saved = saver
         .read_file_content("/project/edit.json".to_owned(), None)
         .await
         .expect("saved project file should read")
         .expect("saved project file should exist");
-    assert_eq!(
-        saved.content().as_ref(),
-        format!("{{\"timelineRevision\":{}}}", ROUNDS - 1).as_bytes(),
-        "the last committed save must be the visible one"
-    );
-    let ingested = ingest
-        .read_file_content(format!("/media/clip-{}.bin", ROUNDS - 1), None)
-        .await
-        .expect("ingested media should read")
-        .expect("ingested media should exist");
-    assert_eq!(ingested.content().len(), 4096);
-}
-
-/// A resumable upload keeps four parts in flight by design, and the engine —
-/// not the caller — owns that window. Parts of one upload stage disjoint
-/// manifest leaves and content-addressed payloads, so all four must be able to
-/// commit even while an unrelated writer commits alongside them. Losing this is
-/// how the qualification's `upload()` window fails its acknowledgement assert.
-#[tokio::test]
-async fn concurrent_upload_window_parts_commit_alongside_a_project_save() {
-    let storage = InterleavingStorage::default();
-    Engine::initialize(storage.clone())
-        .await
-        .expect("storage should initialize");
-    let engine = Engine::new(storage)
-        .await
-        .expect("initialized storage should create an engine");
-    let ingest = engine
-        .open_workspace_session()
-        .await
-        .expect("media ingest session should open");
-    let saver = engine
-        .open_workspace_session()
-        .await
-        .expect("project-save session should open");
-
-    // The smallest four-part window the upload contract admits: non-final parts
-    // must be exactly one part size, so three full parts plus a one-byte tail.
-    let part_bytes = lix::FILE_UPLOAD_PART_BYTES;
-    let total_size = 3 * part_bytes as u64 + 1;
-    let part = |index: usize| {
-        let len = if index == 3 { 1 } else { part_bytes };
-        ingest.upsert_file_content_part(
-            "windowed-ingest".to_owned(),
-            "/media/window.mov".to_owned(),
-            index as u64 * part_bytes as u64,
-            total_size,
-            vec![0x70 | index as u8; len].into(),
-        )
-    };
-    let window = async {
-        let (first, second, third, fourth) =
-            tokio::join!(part(0), part(1), part(2), part(3));
-        for progress in [first, second, third, fourth] {
-            progress.expect("every part of one upload window must commit");
-        }
-    };
-    let save_future = async {
-        for round in 0..6 {
-            saver
-                .upsert_file_content(
-                    "/project/edit.json".to_owned(),
-                    format!("{{\"timelineRevision\":{round}}}")
-                        .into_bytes()
-                        .into(),
-                )
-                .await
-                .expect("project-file save must not conflict with a concurrent upload window");
-        }
-    };
-    tokio::join!(window, save_future);
-
-    let published = ingest
-        .read_file_content(
-            "/media/window.mov".to_owned(),
-            Some(total_size - 1..total_size),
-        )
-        .await
-        .expect("published upload should read")
-        .expect("published upload should exist");
-    assert_eq!(published.content().as_ref(), &[0x73]);
+    assert_eq!(saved.content().as_ref(), br#"{"timelineRevision":1}"#);
 }
 
 #[tokio::test]
@@ -1342,21 +1278,36 @@ async fn session_read_waits_for_automatic_write_instead_of_rejecting() {
     assert_eq!(result.len(), 1);
 }
 
-/// In-memory storage that yields to the executor at every storage boundary.
+/// In-memory storage that can park one storage write and hand control to
+/// another writer.
 ///
-/// Concurrency defects on the commit path live in the window between a
-/// transaction's commit-time snapshot and its storage write. On the current
-/// thread runtime these tests use, two futures joined together would otherwise
-/// each run to completion without ever being suspended inside that window, so
-/// the race the qualification hits would never be sampled. Yielding at
-/// `begin_read`/`begin_write` makes the interleaving deterministic instead of
-/// leaving it to the scheduler.
-#[derive(Clone, Default)]
-struct InterleavingStorage {
+/// Commit-path concurrency defects live in the window between a transaction's
+/// commit-time snapshot and its storage write. Sampling that window by racing
+/// two futures is unreliable — on a current-thread runtime the phase
+/// relationship between them is fixed, and the interleaving that matters may
+/// never occur. Parking the first write after [`InterferenceGate::arm`] and
+/// resuming it only after the other writer has committed makes the interleaving
+/// a property of the test rather than of the scheduler.
+#[derive(Clone)]
+struct InterferingStorage {
     inner: Memory,
+    gate: Arc<InterferenceGate>,
 }
 
-impl Storage for InterleavingStorage {
+impl InterferingStorage {
+    fn new() -> Self {
+        Self {
+            inner: Memory::new(),
+            gate: Arc::new(InterferenceGate::new()),
+        }
+    }
+
+    fn gate(&self) -> Arc<InterferenceGate> {
+        Arc::clone(&self.gate)
+    }
+}
+
+impl Storage for InterferingStorage {
     type Read<'a>
         = MemoryRead
     where
@@ -1368,13 +1319,57 @@ impl Storage for InterleavingStorage {
         Self: 'a;
 
     async fn begin_read(&self, opts: ReadOptions) -> Result<Self::Read<'_>, StorageError> {
-        tokio::task::yield_now().await;
         self.inner.begin_read(opts).await
     }
 
     async fn begin_write(&self, opts: WriteOptions) -> Result<Self::Write<'_>, StorageError> {
-        tokio::task::yield_now().await;
+        self.gate.park_if_armed().await;
         self.inner.begin_write(opts).await
+    }
+}
+
+struct InterferenceGate {
+    armed: std::sync::atomic::AtomicBool,
+    parked: tokio::sync::Semaphore,
+    release: tokio::sync::Semaphore,
+}
+
+impl InterferenceGate {
+    fn new() -> Self {
+        Self {
+            armed: std::sync::atomic::AtomicBool::new(false),
+            parked: tokio::sync::Semaphore::new(0),
+            release: tokio::sync::Semaphore::new(0),
+        }
+    }
+
+    fn arm(&self) {
+        self.armed.store(true, Ordering::SeqCst);
+    }
+
+    /// Parks the next storage write only. Disarming before announcing means the
+    /// writer woken by `wait_until_a_write_is_parked` is never itself parked.
+    async fn park_if_armed(&self) {
+        if self.armed.swap(false, Ordering::SeqCst) {
+            self.parked.add_permits(1);
+            self.release
+                .acquire()
+                .await
+                .expect("interference gate should stay open")
+                .forget();
+        }
+    }
+
+    async fn wait_until_a_write_is_parked(&self) {
+        self.parked
+            .acquire()
+            .await
+            .expect("interference gate should stay open")
+            .forget();
+    }
+
+    fn release_parked_write(&self) {
+        self.release.add_permits(1);
     }
 }
 

--- a/packages/lix/tests/integration/transaction.rs
+++ b/packages/lix/tests/integration/transaction.rs
@@ -104,6 +104,153 @@ async fn stale_transaction_composes_disjoint_semantic_writes() {
     assert_eq!(result.rows()[1].get::<String>("key").unwrap(), "winner-key");
 }
 
+/// Media ingest and an unrelated project-file save are independent writers:
+/// they touch disjoint files, disjoint payload rows, and disjoint branch state.
+/// Neither may be rejected because the other committed first.
+///
+/// This is the shape that the ignored `slatedb_movie_workspace_interference`
+/// qualification exercises with a 1 TiB corpus. Resumable upload parts commit
+/// straight to storage rather than through the collaboration write gate, so
+/// they land inside an ordinary commit's precondition window — which is exactly
+/// where a shared compare-and-set turns into a false `LIX_TRANSACTION_CONFLICT`.
+#[tokio::test]
+async fn concurrent_media_ingest_does_not_conflict_with_project_saves() {
+    const ROUNDS: usize = 12;
+    let storage = InterleavingStorage::default();
+    Engine::initialize(storage.clone())
+        .await
+        .expect("storage should initialize");
+    let engine = Engine::new(storage)
+        .await
+        .expect("initialized storage should create an engine");
+    let ingest = engine
+        .open_workspace_session()
+        .await
+        .expect("media ingest session should open");
+    let saver = engine
+        .open_workspace_session()
+        .await
+        .expect("project-save session should open");
+
+    let ingest_future = async {
+        for round in 0..ROUNDS {
+            let payload = vec![round as u8 | 0x40; 4096];
+            let progress = ingest
+                .upsert_file_content_part(
+                    format!("media-ingest-{round}"),
+                    format!("/media/clip-{round}.bin"),
+                    0,
+                    payload.len() as u64,
+                    payload.into(),
+                )
+                .await
+                .expect("media ingest must not conflict with an unrelated concurrent writer");
+            assert!(progress.finalized, "single-part upload should finalize");
+        }
+    };
+    let save_future = async {
+        for round in 0..ROUNDS {
+            saver
+                .upsert_file_content(
+                    "/project/edit.json".to_owned(),
+                    format!("{{\"timelineRevision\":{round}}}")
+                        .into_bytes()
+                        .into(),
+                )
+                .await
+                .expect("project-file save must not conflict with concurrent media ingest");
+        }
+    };
+    tokio::join!(ingest_future, save_future);
+
+    let saved = saver
+        .read_file_content("/project/edit.json".to_owned(), None)
+        .await
+        .expect("saved project file should read")
+        .expect("saved project file should exist");
+    assert_eq!(
+        saved.content().as_ref(),
+        format!("{{\"timelineRevision\":{}}}", ROUNDS - 1).as_bytes(),
+        "the last committed save must be the visible one"
+    );
+    let ingested = ingest
+        .read_file_content(format!("/media/clip-{}.bin", ROUNDS - 1), None)
+        .await
+        .expect("ingested media should read")
+        .expect("ingested media should exist");
+    assert_eq!(ingested.content().len(), 4096);
+}
+
+/// A resumable upload keeps four parts in flight by design, and the engine —
+/// not the caller — owns that window. Parts of one upload stage disjoint
+/// manifest leaves and content-addressed payloads, so all four must be able to
+/// commit even while an unrelated writer commits alongside them. Losing this is
+/// how the qualification's `upload()` window fails its acknowledgement assert.
+#[tokio::test]
+async fn concurrent_upload_window_parts_commit_alongside_a_project_save() {
+    let storage = InterleavingStorage::default();
+    Engine::initialize(storage.clone())
+        .await
+        .expect("storage should initialize");
+    let engine = Engine::new(storage)
+        .await
+        .expect("initialized storage should create an engine");
+    let ingest = engine
+        .open_workspace_session()
+        .await
+        .expect("media ingest session should open");
+    let saver = engine
+        .open_workspace_session()
+        .await
+        .expect("project-save session should open");
+
+    // The smallest four-part window the upload contract admits: non-final parts
+    // must be exactly one part size, so three full parts plus a one-byte tail.
+    let part_bytes = lix::FILE_UPLOAD_PART_BYTES;
+    let total_size = 3 * part_bytes as u64 + 1;
+    let part = |index: usize| {
+        let len = if index == 3 { 1 } else { part_bytes };
+        ingest.upsert_file_content_part(
+            "windowed-ingest".to_owned(),
+            "/media/window.mov".to_owned(),
+            index as u64 * part_bytes as u64,
+            total_size,
+            vec![0x70 | index as u8; len].into(),
+        )
+    };
+    let window = async {
+        let (first, second, third, fourth) =
+            tokio::join!(part(0), part(1), part(2), part(3));
+        for progress in [first, second, third, fourth] {
+            progress.expect("every part of one upload window must commit");
+        }
+    };
+    let save_future = async {
+        for round in 0..6 {
+            saver
+                .upsert_file_content(
+                    "/project/edit.json".to_owned(),
+                    format!("{{\"timelineRevision\":{round}}}")
+                        .into_bytes()
+                        .into(),
+                )
+                .await
+                .expect("project-file save must not conflict with a concurrent upload window");
+        }
+    };
+    tokio::join!(window, save_future);
+
+    let published = ingest
+        .read_file_content(
+            "/media/window.mov".to_owned(),
+            Some(total_size - 1..total_size),
+        )
+        .await
+        .expect("published upload should read")
+        .expect("published upload should exist");
+    assert_eq!(published.content().as_ref(), &[0x73]);
+}
+
 #[tokio::test]
 async fn stale_transaction_reports_overlapping_ordinary_insert_atomically() {
     let storage = Memory::new();
@@ -1193,6 +1340,42 @@ async fn session_read_waits_for_automatic_write_instead_of_rejecting() {
     let result = join_thread(reader, "reader waiting for automatic write")
         .expect("session read should wait behind automatic write");
     assert_eq!(result.len(), 1);
+}
+
+/// In-memory storage that yields to the executor at every storage boundary.
+///
+/// Concurrency defects on the commit path live in the window between a
+/// transaction's commit-time snapshot and its storage write. On the current
+/// thread runtime these tests use, two futures joined together would otherwise
+/// each run to completion without ever being suspended inside that window, so
+/// the race the qualification hits would never be sampled. Yielding at
+/// `begin_read`/`begin_write` makes the interleaving deterministic instead of
+/// leaving it to the scheduler.
+#[derive(Clone, Default)]
+struct InterleavingStorage {
+    inner: Memory,
+}
+
+impl Storage for InterleavingStorage {
+    type Read<'a>
+        = MemoryRead
+    where
+        Self: 'a;
+
+    type Write<'a>
+        = MemoryWrite
+    where
+        Self: 'a;
+
+    async fn begin_read(&self, opts: ReadOptions) -> Result<Self::Read<'_>, StorageError> {
+        tokio::task::yield_now().await;
+        self.inner.begin_read(opts).await
+    }
+
+    async fn begin_write(&self, opts: WriteOptions) -> Result<Self::Write<'_>, StorageError> {
+        tokio::task::yield_now().await;
+        self.inner.begin_write(opts).await
+    }
 }
 
 #[derive(Clone, Default)]

--- a/packages/slatedb-storage/src/slatedb.rs
+++ b/packages/slatedb-storage/src/slatedb.rs
@@ -3827,15 +3827,35 @@ async fn drain_write_queue(
                     }
                 }
             }
-            db.write_with_options(
-                batch,
-                &SlateDBWriteOptions {
-                    await_durable,
-                    ..SlateDBWriteOptions::default()
-                },
-            )
+            // SlateDB's own `await_durable` write option does not ask for a WAL
+            // flush; it only parks on the WAL buffer's durability watcher, which
+            // fires either when the buffer exceeds `l0_sst_size_bytes` (64 MiB)
+            // or when the periodic `flush_interval` ticker (100 ms) elapses.
+            // Every durable commit under that ceiling therefore paid up to a
+            // full 100 ms tick of pure idle latency for a WAL write that costs
+            // microseconds. Enqueue the batch without waiting, then ask the
+            // batch writer to flush now. The flush message is ordered behind
+            // this batch on the same writer channel, so it carries exactly the
+            // same durability guarantee — the WAL SST is in the object store
+            // before the commit is acknowledged — and one flush covers every
+            // durable write in the drained group, amortizing the barrier
+            // across a concurrent window instead of serializing on the ticker.
+            async {
+                let handle = db
+                    .write_with_options(
+                        batch,
+                        &SlateDBWriteOptions {
+                            await_durable: false,
+                            ..SlateDBWriteOptions::default()
+                        },
+                    )
+                    .await?;
+                if await_durable {
+                    db.flush().await?;
+                }
+                Ok::<_, slatedb::Error>(handle.seqnum())
+            }
             .await
-            .map(|handle| handle.seqnum())
             .map_err(slatedb_error)
             .map_err(commit_outcome_unknown)
         };


### PR DESCRIPTION
Second wave from `claude-3-optimizations`. 72 commits, 0 behind `main`.

## Headline results

| area | result |
|---|---|
| **File-scoped entity reads** | **1,046×** at 100k dirty rows (126.6 ms → 0.121 ms); slope 1.2665 µs/row → 0.222 ns/row |
| **SlateDB media ingest** | **153.3 → 1,695.6 MiB/s (+1006%)** — now 2.35× RocksDB, was 0.21× |
| **SlateDB durable write** | `resumable_initial_write` 202.8 ms → **1.07 ms** |
| **Branch merge storage** | **−98.7%** (29.9 MB → 388 KB at 100k rows); residual now constant, not O(state) |
| **GC reclamation** | **355,065 bytes per deleted branch, against a baseline of 0**; residual constant regardless of workspace size |
| **Tree-chunk writes** | −73.3% (removed an O(n²/period) write-amplification term) |
| **Idempotency receipts** | −35% per receipt, −62.5% per returned payload byte |

## Correctness fixes

- **Data loss in `lix_revert`** — a branch-local edit of a checkpointed row was classified as an *addition*, so reverting it **deleted the row** instead of restoring the checkpoint value. Branch-local deletes were also invisible in the working diff. Root cause: one struct field conflated "absent at checkpoint" with "is the checkpoint state".
- **Concurrent-writer conflict** — a single conflated binary-CAS epoch row made ordinary commits, upload parts and the CAS sweep **all mutually exclusive**. Split into an asymmetric fence; publisher↔sweep exclusion preserved, publisher↔publisher removed.
- **GC generation sweeper reconnected** — `stage_collect_stale_hot_generations` had been `#[cfg(test)]`-gated by a refactor that removed its replacement and never restored it, so **no production sweeper for stale live-state generations existed**.

## Structural cuts

Three reachability walks → one. Twelve foreign-space writes from `gc.rs` → zero. Three storage spaces retired (`gc.tree_sweep_epoch/mark/cursor`). Five revision authorities → one space. One authoritative `ALL_STORAGE_SPACES` registry with a drift guard, replacing three hand-maintained lists that had drifted to 21/2/31 of 46 coverage.

## Measurement infrastructure

**Five broken instruments were found and repaired** — this was the recurring theme:
- `storage_layout` was blind to **14 of 46 spaces** and had been aborting outright since `hot_row` reached v21
- `packed_history_scale` printed `manifest_*`/`segment_*`/`locator_*` as **zeros** across three namespace bumps
- `storage_v2` had two assertion bugs, the second masked by the first
- `read_all` never exercised per-cell consumer cost — **~40% of read cost sat past `len()`**, invisible to every read benchmark
- the near-duplicate probe measured *compressed* bytes, inventing an opportunity that did not exist

New durable instruments: duplicate auditor, blind-space growth curves, branch-sharing bench, chunking oracle, CAS sharing bench, `space_growth`.

## Rejected with evidence

Tree-chunk `immutable` (SlateDB +145% bytes, +13,427% write amp) · space-id reordering (flagged spaces are 0.6% of churn) · delta-segment content addressing (byte-exact duplication is **0** across 27 repositories) · JSON delta encoding (+40% read for 38.8% bytes; zstd already captures 96%) · content-defined chunking (saves 1.9 KB of 675 MB on ingest, costs +55% CPU) · `BINARY_CAS_CHUNK_PRESENCE` removal (~180× penalty on RocksDB — the mirror earns its keep) · hot-key interning (10% logical, 1% physical — block compression already captured it).

## Breaking changes

Carried forward from wave 1: `Value::Json` is `lix::Json`; protocol v64. New in this wave: uncastable Arrow result types now error rather than returning `ScalarValue` debug text.

## Duplicates confirmed absent

A content-addressed audit across six corpora found byte-exact duplication **under 1% everywhere** (0.008% on 295 MB of media), **zero** key≠digest violations, and binary-CAS chunk reuse at the **theoretical optimum**.