### PR TITLE
fix(working-diff): branch-local edits lost their before image, making revert delete the row

### DIFF
--- a/.changenotes/fix-branch-working-diff-baseline.md
+++ b/.changenotes/fix-branch-working-diff-baseline.md
@@ -1,0 +1,7 @@
+---
+type: patch
+---
+
+Fixed branch-local edits being reported as additions in the working diff, which made reverting one delete the row instead of restoring its previous value.
+
+On a newly created branch, editing a row that already existed at the checkpoint was recorded as if the row had just been created. `lix_working_diff` reported it as `added` with no before value, deleting such a row did not appear in the working diff at all, and reverting the edit removed the row rather than restoring the checkpointed value. Branch-local edits now carry their correct before image, so working diffs classify them as modifications and reverts restore the previous value. Merges, merge previews and the main branch were never affected.

--- a/packages/lix/src/live_state/tracked_head.rs
+++ b/packages/lix/src/live_state/tracked_head.rs
@@ -182,6 +182,15 @@ struct WorkingDiffSlotFingerprint {
 const WORKING_DIFF_SLOT_NONE: u8 = 0;
 const WORKING_DIFF_SLOT_REF: u8 = 1;
 const WORKING_DIFF_SLOT_INLINE: u8 = 2;
+/// The before image is identified by its change id, but its payload slot was
+/// not materialized where the baseline was captured.
+///
+/// Root current bases are read under `ChangeRecordProjection::identity_only()`
+/// so the write path pays no payload I/O to capture a baseline. The reader
+/// hydrates the referenced change record only for the one question the change
+/// id cannot answer on its own: whether two distinct changes carry the same
+/// payload.
+const WORKING_DIFF_SLOT_UNRESOLVED: u8 = 3;
 const WORKING_DIFF_VERSION_BYTES: usize =
     16 + 16 + 1 + 8 + 8 + 1 + JSON_REF_BYTES + 1 + JSON_REF_BYTES;
 const WORKING_DIFF_CHECKPOINT_BYTES: usize = 16;
@@ -1300,16 +1309,21 @@ fn decode_working_diff_slot(
         .ok_or_else(|| working_diff_error(&format!("{field} kind is missing")))?;
     if !matches!(
         kind,
-        WORKING_DIFF_SLOT_NONE | WORKING_DIFF_SLOT_REF | WORKING_DIFF_SLOT_INLINE
+        WORKING_DIFF_SLOT_NONE
+            | WORKING_DIFF_SLOT_REF
+            | WORKING_DIFF_SLOT_INLINE
+            | WORKING_DIFF_SLOT_UNRESOLVED
     ) {
         return Err(working_diff_error(&format!("{field} slot kind is invalid")));
     }
     let hash: [u8; JSON_REF_BYTES] = take_working_diff_bytes(bytes, offset, JSON_REF_BYTES)?
         .try_into()
         .map_err(|_| working_diff_error(&format!("{field} hash is invalid")))?;
-    if kind == WORKING_DIFF_SLOT_NONE && hash != [0; JSON_REF_BYTES] {
+    if matches!(kind, WORKING_DIFF_SLOT_NONE | WORKING_DIFF_SLOT_UNRESOLVED)
+        && hash != [0; JSON_REF_BYTES]
+    {
         return Err(working_diff_error(&format!(
-            "{field} none slot must have a zero hash"
+            "{field} slot kind must have a zero hash"
         )));
     }
     Ok(WorkingDiffSlotFingerprint { kind, hash })
@@ -1409,6 +1423,11 @@ struct HeadValueView<'a> {
     metadata: HeadSlotView<'a>,
     columnar_base_coordinate: Option<ColumnarBaseCoordinate>,
     working_diff_baseline: WorkingDiffBaseline,
+    /// False when the JSON slots above are placeholders because this view was
+    /// synthesized from a current-state base that was read without payload
+    /// projection. Baselines captured from such a view record their payload
+    /// slots as unresolved and are hydrated by the reader on demand.
+    payload_slots_materialized: bool,
 }
 
 impl CertifiedCurrentStatePredecessor {
@@ -1426,15 +1445,12 @@ impl CertifiedCurrentStatePredecessor {
                 deleted: value.deleted,
                 created_at: value.created_at,
                 updated_at: value.updated_at,
-                // Neither base materializes its JSON slots here. A packed base
-                // has no active-epoch before image at all, and a root base
-                // relies on `WorkingDiffVersion::payload_eq` short-circuiting
-                // on change id: a genuine mutation always mints a new change
-                // record. The residual cost is that restoring the checkpoint
-                // payload on a root-backed generation reports `modified`
-                // rather than a net no-op.
+                // Current-state bases are read without payload projection, so
+                // these slots are placeholders. The change id above is the
+                // reference the reader hydrates from when it needs the payload.
                 snapshot: HeadSlotView::None,
                 metadata: HeadSlotView::None,
+                payload_slots_materialized: false,
                 columnar_base_coordinate: value.columnar_base_coordinate,
                 working_diff_baseline: match value.working_diff_baseline {
                     PackedWorkingDiffBaseline::Disabled => WorkingDiffBaseline::Disabled,
@@ -1458,9 +1474,26 @@ impl HeadValueView<'_> {
             deleted: self.deleted,
             created_at: self.created_at,
             updated_at: self.updated_at,
-            snapshot: working_diff_slot_fingerprint(self.snapshot),
-            metadata: working_diff_slot_fingerprint(self.metadata),
+            snapshot: self.working_diff_slot(self.snapshot),
+            metadata: self.working_diff_slot(self.metadata),
         })
+    }
+
+    fn working_diff_slot(self, slot: HeadSlotView<'_>) -> WorkingDiffSlotFingerprint {
+        if self.payload_slots_materialized {
+            working_diff_slot_fingerprint(slot)
+        } else {
+            WorkingDiffSlotFingerprint::unresolved()
+        }
+    }
+}
+
+impl WorkingDiffSlotFingerprint {
+    fn unresolved() -> Self {
+        Self {
+            kind: WORKING_DIFF_SLOT_UNRESOLVED,
+            hash: [0; JSON_REF_BYTES],
+        }
     }
 }
 
@@ -1491,13 +1524,53 @@ fn effective_hot_commit_id(
     }
 }
 
+/// Whether two working-diff versions carry the same payload.
+///
+/// `Unresolved` is deliberately a distinct answer rather than a default. An
+/// accelerator over the canonical diff may answer correctly or decline, but it
+/// must never answer confidently and wrongly, so a caller that has not
+/// hydrated an unresolved before image cannot accidentally read it as
+/// "different".
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum WorkingDiffPayloadEquality {
+    Equal,
+    Different,
+    Unresolved,
+}
+
 impl WorkingDiffVersion {
-    fn payload_eq(self, other: Self) -> bool {
+    /// True when this version's payload slots were never materialized, so only
+    /// its change id is known. Resolve with `resolve_payload_slots` before
+    /// classifying.
+    fn payload_is_unresolved(self) -> bool {
+        self.snapshot.kind == WORKING_DIFF_SLOT_UNRESOLVED
+            || self.metadata.kind == WORKING_DIFF_SLOT_UNRESOLVED
+    }
+
+    fn resolve_payload_slots(
+        &mut self,
+        snapshot: WorkingDiffSlotFingerprint,
+        metadata: WorkingDiffSlotFingerprint,
+    ) {
+        self.snapshot = snapshot;
+        self.metadata = metadata;
+    }
+
+    fn payload_equality(self, other: Self) -> WorkingDiffPayloadEquality {
         // Keep the accelerator's net-change classification identical to the
         // canonical tracked diff: a shared change record is intrinsically the
         // same payload, otherwise compare the two stored payload slots.
-        self.change_id == other.change_id
-            || (self.snapshot == other.snapshot && self.metadata == other.metadata)
+        if self.change_id == other.change_id {
+            return WorkingDiffPayloadEquality::Equal;
+        }
+        if self.payload_is_unresolved() || other.payload_is_unresolved() {
+            return WorkingDiffPayloadEquality::Unresolved;
+        }
+        if self.snapshot == other.snapshot && self.metadata == other.metadata {
+            WorkingDiffPayloadEquality::Equal
+        } else {
+            WorkingDiffPayloadEquality::Different
+        }
     }
 
     fn into_diff_row(self, identity: TrackedStateDiffIdentity) -> TrackedStateDiffRow {
@@ -1961,6 +2034,7 @@ fn decode_head_value(bytes: &[u8]) -> Result<HeadValueView<'_>, LixError> {
         updated_at,
         snapshot,
         metadata,
+        payload_slots_materialized: true,
         columnar_base_coordinate,
         working_diff_baseline,
     })
@@ -2630,9 +2704,38 @@ mod tests {
             ..baseline
         };
 
-        assert!(baseline.payload_eq(same_change));
-        assert!(baseline.payload_eq(same_payload));
-        assert!(!baseline.payload_eq(different_payload));
+        assert_eq!(
+            baseline.payload_equality(same_change),
+            WorkingDiffPayloadEquality::Equal
+        );
+        assert_eq!(
+            baseline.payload_equality(same_payload),
+            WorkingDiffPayloadEquality::Equal
+        );
+        assert_eq!(
+            baseline.payload_equality(different_payload),
+            WorkingDiffPayloadEquality::Different
+        );
+
+        // A baseline captured by reference must never be read as "different".
+        let unresolved = WorkingDiffVersion {
+            change_id: ChangeId::for_test_label("root-change"),
+            snapshot: WorkingDiffSlotFingerprint::unresolved(),
+            metadata: WorkingDiffSlotFingerprint::unresolved(),
+            ..baseline
+        };
+        assert_eq!(
+            unresolved.payload_equality(different_payload),
+            WorkingDiffPayloadEquality::Unresolved
+        );
+        assert_eq!(
+            unresolved.payload_equality(WorkingDiffVersion {
+                change_id: ChangeId::for_test_label("root-change"),
+                ..different_payload
+            }),
+            WorkingDiffPayloadEquality::Equal,
+            "a shared change record resolves without hydration"
+        );
     }
 
     #[tokio::test]

--- a/packages/lix/src/live_state/tracked_head.rs
+++ b/packages/lix/src/live_state/tracked_head.rs
@@ -371,8 +371,29 @@ pub(crate) struct PackedHeadValue {
     deleted: bool,
     created_at: LixTimestamp,
     updated_at: LixTimestamp,
-    checkpoint_commit_id: Option<CommitId>,
+    working_diff_baseline: PackedWorkingDiffBaseline,
     columnar_base_coordinate: Option<ColumnarBaseCoordinate>,
+}
+
+/// Checkpoint-relative position of a current-state base row that is served
+/// without a branch-local hot row.
+///
+/// The two bases are not interchangeable and must not share one encoding. A
+/// *packed* current base is a collection published **inside** the active
+/// working interval, so its rows were absent at the checkpoint. A *root*
+/// current base is the referenced head itself, so its rows **are** the
+/// checkpoint state. Collapsing both onto "has an active checkpoint id" made
+/// the first branch-local mutation of a checkpointed identity look like a
+/// creation.
+#[derive(Debug, Clone, Copy)]
+pub(crate) enum PackedWorkingDiffBaseline {
+    /// No active checkpoint owns this generation.
+    Disabled,
+    /// Published inside the active working interval: absent at the checkpoint.
+    AbsentAtCheckpoint { checkpoint_commit_id: CommitId },
+    /// Served from the referenced root current base: present at the active
+    /// checkpoint and unchanged since.
+    CleanAtCheckpoint,
 }
 
 impl<'a> CurrentStateDeltaRef<'a> {
@@ -1405,18 +1426,25 @@ impl CertifiedCurrentStatePredecessor {
                 deleted: value.deleted,
                 created_at: value.created_at,
                 updated_at: value.updated_at,
-                // Packed current bases are immutable post-checkpoint inserts.
-                // Their active-epoch before image is therefore absent; no
-                // payload fingerprint is needed to preserve that baseline.
+                // Neither base materializes its JSON slots here. A packed base
+                // has no active-epoch before image at all, and a root base
+                // relies on `WorkingDiffVersion::payload_eq` short-circuiting
+                // on change id: a genuine mutation always mints a new change
+                // record. The residual cost is that restoring the checkpoint
+                // payload on a root-backed generation reports `modified`
+                // rather than a net no-op.
                 snapshot: HeadSlotView::None,
                 metadata: HeadSlotView::None,
                 columnar_base_coordinate: value.columnar_base_coordinate,
-                working_diff_baseline: value.checkpoint_commit_id.map_or(
-                    WorkingDiffBaseline::Disabled,
-                    |checkpoint_commit_id| WorkingDiffBaseline::BeforeAbsent {
+                working_diff_baseline: match value.working_diff_baseline {
+                    PackedWorkingDiffBaseline::Disabled => WorkingDiffBaseline::Disabled,
+                    PackedWorkingDiffBaseline::AbsentAtCheckpoint {
+                        checkpoint_commit_id,
+                    } => WorkingDiffBaseline::BeforeAbsent {
                         checkpoint_commit_id,
                     },
-                ),
+                    PackedWorkingDiffBaseline::CleanAtCheckpoint => WorkingDiffBaseline::Clean,
+                },
             }),
         }
     }

--- a/packages/lix/src/live_state/tracked_head.rs
+++ b/packages/lix/src/live_state/tracked_head.rs
@@ -1495,6 +1495,13 @@ impl WorkingDiffSlotFingerprint {
             hash: [0; JSON_REF_BYTES],
         }
     }
+
+    fn none() -> Self {
+        Self {
+            kind: WORKING_DIFF_SLOT_NONE,
+            hash: [0; JSON_REF_BYTES],
+        }
+    }
 }
 
 fn working_diff_checkpoint_owner(baseline: WorkingDiffBaseline) -> Option<CommitId> {

--- a/packages/lix/src/live_state/tracked_head/hot.rs
+++ b/packages/lix/src/live_state/tracked_head/hot.rs
@@ -13916,7 +13916,11 @@ mod tests {
 
     #[tokio::test]
     async fn hot_working_diff_entries_share_one_identity_batch() {
-        let store = StorageAdapter::new(Memory::new());
+        let storage = StorageAdapter::new(Memory::new());
+        let store = storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("classification read should open");
         let candidates = ["first", "second"]
             .into_iter()
             .map(|entity| {
@@ -13949,7 +13953,11 @@ mod tests {
 
     #[tokio::test]
     async fn finite_hot_working_diff_borrows_keys_into_one_identity_batch() {
-        let store = StorageAdapter::new(Memory::new());
+        let storage = StorageAdapter::new(Memory::new());
+        let store = storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("classification read should open");
         let schema_key = String::from("schema");
         let file_id = String::from("file");
         let entity_pks = [EntityPk::single("first"), EntityPk::single("second")];

--- a/packages/lix/src/live_state/tracked_head/hot.rs
+++ b/packages/lix/src/live_state/tracked_head/hot.rs
@@ -10052,9 +10052,9 @@ async fn classify_hot_working_diff_entries(
 ) -> Result<Vec<TrackedStateDiffEntry>, LixError> {
     resolve_working_diff_before_payloads(
         store,
-        candidates
-            .iter_mut()
-            .map(|(key, before, _)| (key.clone(), before)),
+        &mut candidates,
+        |(key, _, _)| key.clone(),
+        |(_, before, _)| before,
     )
     .await?;
     let row_count = candidates.len();
@@ -10084,16 +10084,13 @@ async fn classify_hot_working_diff_entry_refs(
 ) -> Result<Vec<TrackedStateDiffEntry>, LixError> {
     resolve_working_diff_before_payloads(
         store,
-        candidates.iter_mut().map(|(key, before, _)| {
-            (
-                TrackedStateKey {
-                    schema_key: key.schema_key.to_owned(),
-                    file_id: key.file_id.map(str::to_owned),
-                    entity_pk: key.entity_pk.clone(),
-                },
-                before,
-            )
-        }),
+        &mut candidates,
+        |(key, _, _)| TrackedStateKey {
+            schema_key: key.schema_key.to_owned(),
+            file_id: key.file_id.map(str::to_owned),
+            entity_pk: key.entity_pk.clone(),
+        },
+        |(_, before, _)| before,
     )
     .await?;
     let row_count = candidates.len();
@@ -10118,16 +10115,13 @@ async fn classify_hot_working_diff_scan_entries(
 ) -> Result<Vec<TrackedStateDiffEntry>, LixError> {
     resolve_working_diff_before_payloads(
         store,
-        candidates.iter_mut().map(|(identity, before, _)| {
-            (
-                TrackedStateKey {
-                    schema_key: identity.schema_key().to_owned(),
-                    file_id: identity.file_id().map(str::to_owned),
-                    entity_pk: identity.entity_pk.clone(),
-                },
-                before,
-            )
-        }),
+        &mut candidates,
+        |(identity, _, _)| TrackedStateKey {
+            schema_key: identity.schema_key().to_owned(),
+            file_id: identity.file_id().map(str::to_owned),
+            entity_pk: identity.entity_pk.clone(),
+        },
+        |(_, before, _)| before,
     )
     .await?;
     let row_count = candidates.len();
@@ -10155,65 +10149,71 @@ async fn classify_hot_working_diff_scan_entries(
 /// I/O to capture it. Classification needs the payload itself for exactly one
 /// question the change id cannot answer alone: whether two distinct change
 /// records carry the same payload. Change records are addressed by owning
-/// commit, so the pending rows are grouped by commit and fetched one batch per
-/// commit, and only for the rows that are actually unresolved.
-async fn resolve_working_diff_before_payloads<'a>(
+/// commit, so pending rows are grouped by commit and fetched one batch per
+/// commit. Identity keys are materialized only for rows that are actually
+/// unresolved, so a diff with no root-backed baselines pays nothing.
+async fn resolve_working_diff_before_payloads<T>(
     store: &(impl StorageAdapterRead + ?Sized),
-    rows: impl Iterator<Item = (TrackedStateKey, &'a mut Option<WorkingDiffVersion>)>,
+    candidates: &mut [T],
+    key_of: impl Fn(&T) -> TrackedStateKey,
+    before_of: impl Fn(&mut T) -> &mut Option<WorkingDiffVersion>,
 ) -> Result<(), LixError> {
     let mut pending = Vec::new();
-    for (key, before) in rows {
-        let Some(version) = before.as_mut() else {
+    for index in 0..candidates.len() {
+        let Some(version) = before_of(&mut candidates[index]).as_mut() else {
             continue;
         };
         if !version.payload_is_unresolved() {
             continue;
         }
         if version.deleted {
-            // A tombstone before image has no payload to hydrate, and its
-            // classification never consults one.
+            // A tombstone before image has no payload to hydrate, and
+            // classification never consults one for a deleted row.
             version.resolve_payload_slots(
                 WorkingDiffSlotFingerprint::none(),
                 WorkingDiffSlotFingerprint::none(),
             );
             continue;
         }
-        pending.push((version.commit_id, key, version));
+        pending.push(index);
     }
     if pending.is_empty() {
         return Ok(());
     }
     let mut by_commit = BTreeMap::<CommitId, Vec<usize>>::new();
-    for (index, (commit_id, _, _)) in pending.iter().enumerate() {
-        by_commit.entry(*commit_id).or_default().push(index);
+    for index in pending {
+        let commit_id = before_of(&mut candidates[index])
+            .as_ref()
+            .expect("pending before images are present")
+            .commit_id;
+        by_commit.entry(commit_id).or_default().push(index);
     }
-    let mut resolved = vec![None; pending.len()];
     for (commit_id, indexes) in by_commit {
         let keys = indexes
             .iter()
-            .map(|index| pending[*index].1.clone())
+            .map(|index| key_of(&candidates[*index]))
             .collect::<Vec<_>>();
         let records =
             crate::tracked_state::load_commit_delta_change_records(store, commit_id, &keys).await?;
         for (index, record) in indexes.into_iter().zip(records) {
-            resolved[index] = record;
+            let record = record.ok_or_else(|| {
+                head_value_error(
+                    "working-diff baseline references a before image that is missing from its commit",
+                )
+            })?;
+            let version = before_of(&mut candidates[index])
+                .as_mut()
+                .expect("pending before images are present the second time");
+            if record.change_id != version.change_id {
+                return Err(head_value_error(
+                    "working-diff baseline before image does not match its referenced change record",
+                ));
+            }
+            version.resolve_payload_slots(
+                packed_working_diff_slot(&record.snapshot),
+                packed_working_diff_slot(&record.metadata),
+            );
         }
-    }
-    for ((_, _, version), record) in pending.into_iter().zip(resolved) {
-        let record = record.ok_or_else(|| {
-            head_value_error(
-                "working-diff baseline references a before image that is missing from its commit",
-            )
-        })?;
-        if record.change_id != version.change_id {
-            return Err(head_value_error(
-                "working-diff baseline before image does not match its referenced change record",
-            ));
-        }
-        version.resolve_payload_slots(
-            packed_working_diff_slot(&record.snapshot),
-            packed_working_diff_slot(&record.metadata),
-        );
     }
     Ok(())
 }

--- a/packages/lix/src/live_state/tracked_head/hot.rs
+++ b/packages/lix/src/live_state/tracked_head/hot.rs
@@ -9952,7 +9952,9 @@ async fn hot_working_diff_entries(
             after,
         ));
     }
-    Ok(Some(classify_hot_working_diff_entries(candidates)?))
+    Ok(Some(
+        classify_hot_working_diff_entries(store, candidates).await?,
+    ))
 }
 
 fn choose_hot_or_packed_working_diff(
@@ -9990,7 +9992,9 @@ async fn hot_working_diff_entries_for_finite_filter(
                 };
                 candidates.push((identity, before, after));
             }
-            Ok(Some(classify_hot_working_diff_scan_entries(candidates)?))
+            Ok(Some(
+                classify_hot_working_diff_scan_entries(store, candidates).await?,
+            ))
         }
         HotScanEntries::Finite(batches) => {
             let row_count = batches
@@ -10013,7 +10017,9 @@ async fn hot_working_diff_entries_for_finite_filter(
                     candidates.push((batch.identities.key_ref(index), before, after));
                 }
             }
-            Ok(Some(classify_hot_working_diff_entry_refs(candidates)?))
+            Ok(Some(
+                classify_hot_working_diff_entry_refs(store, candidates).await?,
+            ))
         }
     }
 }
@@ -10036,13 +10042,19 @@ fn finite_working_diff_versions(
     Some(Some((before, after)))
 }
 
-fn classify_hot_working_diff_entries(
-    candidates: Vec<(
+async fn classify_hot_working_diff_entries(
+    store: &(impl StorageAdapterRead + ?Sized),
+    mut candidates: Vec<(
         TrackedStateKey,
         Option<WorkingDiffVersion>,
         WorkingDiffVersion,
     )>,
 ) -> Result<Vec<TrackedStateDiffEntry>, LixError> {
+    resolve_working_diff_before_payloads(
+        store,
+        candidates.iter_mut().map(|(_, before, _)| before),
+    )
+    .await?;
     let row_count = candidates.len();
     let mut keys = Vec::with_capacity(row_count);
     let mut versions = Vec::with_capacity(row_count);
@@ -10053,39 +10065,51 @@ fn classify_hot_working_diff_entries(
     let identities = TrackedStateDiffIdentity::from_key_batch(keys)?;
     let mut entries = Vec::with_capacity(row_count);
     for (identity, (before, after)) in identities.into_iter().zip(versions) {
-        if let Some(entry) = classify_hot_working_diff_entry(identity, before, after) {
+        if let Some(entry) = classify_hot_working_diff_entry(identity, before, after)? {
             entries.push(entry);
         }
     }
     Ok(entries)
 }
 
-fn classify_hot_working_diff_entry_refs(
-    candidates: Vec<(
+async fn classify_hot_working_diff_entry_refs(
+    store: &(impl StorageAdapterRead + ?Sized),
+    mut candidates: Vec<(
         TrackedStateKeyRef<'_>,
         Option<WorkingDiffVersion>,
         WorkingDiffVersion,
     )>,
 ) -> Result<Vec<TrackedStateDiffEntry>, LixError> {
+    resolve_working_diff_before_payloads(
+        store,
+        candidates.iter_mut().map(|(_, before, _)| before),
+    )
+    .await?;
     let row_count = candidates.len();
     let identities =
         TrackedStateDiffIdentity::from_key_refs(row_count, |index| candidates[index].0)?;
     let mut entries = Vec::with_capacity(row_count);
     for (identity, (_, before, after)) in identities.into_iter().zip(candidates) {
-        if let Some(entry) = classify_hot_working_diff_entry(identity, before, after) {
+        if let Some(entry) = classify_hot_working_diff_entry(identity, before, after)? {
             entries.push(entry);
         }
     }
     Ok(entries)
 }
 
-fn classify_hot_working_diff_scan_entries(
-    candidates: Vec<(
+async fn classify_hot_working_diff_scan_entries(
+    store: &(impl StorageAdapterRead + ?Sized),
+    mut candidates: Vec<(
         HotScanIdentity,
         Option<WorkingDiffVersion>,
         WorkingDiffVersion,
     )>,
 ) -> Result<Vec<TrackedStateDiffEntry>, LixError> {
+    resolve_working_diff_before_payloads(
+        store,
+        candidates.iter_mut().map(|(_, before, _)| before),
+    )
+    .await?;
     let row_count = candidates.len();
     let identities = TrackedStateDiffIdentity::from_key_refs(row_count, |index| {
         let identity = &candidates[index].0;
@@ -10097,44 +10121,103 @@ fn classify_hot_working_diff_scan_entries(
     })?;
     let mut entries = Vec::with_capacity(row_count);
     for (identity, (_, before, after)) in identities.into_iter().zip(candidates) {
-        if let Some(entry) = classify_hot_working_diff_entry(identity, before, after) {
+        if let Some(entry) = classify_hot_working_diff_entry(identity, before, after)? {
             entries.push(entry);
         }
     }
     Ok(entries)
 }
 
+/// Hydrates the payload slots of before images that were captured by reference.
+///
+/// A root-backed baseline stores only the change id of its before image, so the
+/// write path pays no payload I/O. Classification needs the payload itself only
+/// to separate "different change, same payload" from a real modification, so
+/// the change records are fetched here, in one batch, and only for the rows
+/// that are actually unresolved.
+async fn resolve_working_diff_before_payloads<'a>(
+    store: &(impl StorageAdapterRead + ?Sized),
+    befores: impl Iterator<Item = &'a mut Option<WorkingDiffVersion>>,
+) -> Result<(), LixError> {
+    let mut pending = befores
+        .filter(|before| {
+            before
+                .as_ref()
+                .is_some_and(|version| version.payload_is_unresolved())
+        })
+        .collect::<Vec<_>>();
+    if pending.is_empty() {
+        return Ok(());
+    }
+    let records = crate::changelog::load_change_records(
+        store,
+        pending.iter().map(|before| {
+            before
+                .as_ref()
+                .expect("pending before images are present")
+                .change_id
+        }),
+    )
+    .await?;
+    for before in &mut pending {
+        let version = before
+            .as_mut()
+            .expect("pending before images are present the second time");
+        let record = records.get(&version.change_id).ok_or_else(|| {
+            head_value_error(
+                "working-diff baseline references a change record that is no longer readable",
+            )
+        })?;
+        version.resolve_payload_slots(
+            packed_working_diff_slot(&record.snapshot),
+            packed_working_diff_slot(&record.metadata),
+        );
+    }
+    Ok(())
+}
+
 fn classify_hot_working_diff_entry(
     diff_identity: TrackedStateDiffIdentity,
     before: Option<WorkingDiffVersion>,
     after: WorkingDiffVersion,
-) -> Option<TrackedStateDiffEntry> {
+) -> Result<Option<TrackedStateDiffEntry>, LixError> {
     let before_row = before.map(|version| version.into_diff_row(diff_identity.clone()));
     let after_row = after.into_diff_row(diff_identity.clone());
     match (
         before_row.as_ref().filter(|row| !row.deleted),
         (!after_row.deleted).then_some(&after_row),
     ) {
-        (None, None) => None,
-        (None, Some(_)) => Some(TrackedStateDiffEntry {
+        (None, None) => Ok(None),
+        (None, Some(_)) => Ok(Some(TrackedStateDiffEntry {
             identity: diff_identity,
             kind: TrackedStateDiffKind::Added,
             before: before_row,
             after: Some(after_row),
-        }),
-        (Some(_), None) => Some(TrackedStateDiffEntry {
+        })),
+        (Some(_), None) => Ok(Some(TrackedStateDiffEntry {
             identity: diff_identity,
             kind: TrackedStateDiffKind::Removed,
             before: before_row,
             after: Some(after_row),
-        }),
-        (Some(_), Some(_)) if before.is_some_and(|version| version.payload_eq(after)) => None,
-        (Some(_), Some(_)) => Some(TrackedStateDiffEntry {
-            identity: diff_identity,
-            kind: TrackedStateDiffKind::Modified,
-            before: before_row,
-            after: Some(after_row),
-        }),
+        })),
+        (Some(_), Some(_)) => {
+            let before = before.expect("a present before row implies a before version");
+            match before.payload_equality(after) {
+                WorkingDiffPayloadEquality::Equal => Ok(None),
+                WorkingDiffPayloadEquality::Different => Ok(Some(TrackedStateDiffEntry {
+                    identity: diff_identity,
+                    kind: TrackedStateDiffKind::Modified,
+                    before: before_row,
+                    after: Some(after_row),
+                })),
+                // Never guess. Every caller hydrates unresolved before images
+                // before classifying, so reaching this arm means a new baseline
+                // source skipped that step.
+                WorkingDiffPayloadEquality::Unresolved => Err(head_value_error(
+                    "working-diff classification reached an unresolved before image",
+                )),
+            }
+        }
     }
 }
 
@@ -13831,8 +13914,9 @@ mod tests {
         (key, value)
     }
 
-    #[test]
-    fn hot_working_diff_entries_share_one_identity_batch() {
+    #[tokio::test]
+    async fn hot_working_diff_entries_share_one_identity_batch() {
+        let store = StorageAdapter::new(Memory::new());
         let candidates = ["first", "second"]
             .into_iter()
             .map(|entity| {
@@ -13848,8 +13932,9 @@ mod tests {
             })
             .collect();
 
-        let entries =
-            classify_hot_working_diff_entries(candidates).expect("valid working diff batch");
+        let entries = classify_hot_working_diff_entries(&store, candidates)
+            .await
+            .expect("valid working diff batch");
 
         assert_eq!(entries.len(), 2);
         assert!(entries[0].identity.shares_batch_with(&entries[1].identity));
@@ -13862,8 +13947,9 @@ mod tests {
         }
     }
 
-    #[test]
-    fn finite_hot_working_diff_borrows_keys_into_one_identity_batch() {
+    #[tokio::test]
+    async fn finite_hot_working_diff_borrows_keys_into_one_identity_batch() {
+        let store = StorageAdapter::new(Memory::new());
         let schema_key = String::from("schema");
         let file_id = String::from("file");
         let entity_pks = [EntityPk::single("first"), EntityPk::single("second")];
@@ -13883,8 +13969,9 @@ mod tests {
             })
             .collect();
 
-        let entries =
-            classify_hot_working_diff_entry_refs(candidates).expect("valid borrowed diff batch");
+        let entries = classify_hot_working_diff_entry_refs(&store, candidates)
+            .await
+            .expect("valid borrowed diff batch");
 
         assert_eq!(entries.len(), 2);
         assert!(entries[0].identity.shares_batch_with(&entries[1].identity));

--- a/packages/lix/src/live_state/tracked_head/hot.rs
+++ b/packages/lix/src/live_state/tracked_head/hot.rs
@@ -10149,6 +10149,7 @@ async fn resolve_working_diff_before_payloads<'a>(
     if pending.is_empty() {
         return Ok(());
     }
+    let pending_len = pending.len();
     let records = crate::changelog::load_change_records(
         store,
         pending.iter().map(|before| {
@@ -10164,9 +10165,12 @@ async fn resolve_working_diff_before_payloads<'a>(
             .as_mut()
             .expect("pending before images are present the second time");
         let record = records.get(&version.change_id).ok_or_else(|| {
-            head_value_error(
-                "working-diff baseline references a change record that is no longer readable",
-            )
+            head_value_error(&format!(
+                "working-diff baseline references change record '{}' that is no longer readable (loaded {} of {})",
+                version.change_id,
+                records.len(),
+                pending_len,
+            ))
         })?;
         version.resolve_payload_slots(
             packed_working_diff_slot(&record.snapshot),

--- a/packages/lix/src/live_state/tracked_head/hot.rs
+++ b/packages/lix/src/live_state/tracked_head/hot.rs
@@ -10052,7 +10052,9 @@ async fn classify_hot_working_diff_entries(
 ) -> Result<Vec<TrackedStateDiffEntry>, LixError> {
     resolve_working_diff_before_payloads(
         store,
-        candidates.iter_mut().map(|(_, before, _)| before),
+        candidates
+            .iter_mut()
+            .map(|(key, before, _)| (key.clone(), before)),
     )
     .await?;
     let row_count = candidates.len();
@@ -10082,7 +10084,16 @@ async fn classify_hot_working_diff_entry_refs(
 ) -> Result<Vec<TrackedStateDiffEntry>, LixError> {
     resolve_working_diff_before_payloads(
         store,
-        candidates.iter_mut().map(|(_, before, _)| before),
+        candidates.iter_mut().map(|(key, before, _)| {
+            (
+                TrackedStateKey {
+                    schema_key: key.schema_key.to_owned(),
+                    file_id: key.file_id.map(str::to_owned),
+                    entity_pk: key.entity_pk.clone(),
+                },
+                before,
+            )
+        }),
     )
     .await?;
     let row_count = candidates.len();
@@ -10107,7 +10118,16 @@ async fn classify_hot_working_diff_scan_entries(
 ) -> Result<Vec<TrackedStateDiffEntry>, LixError> {
     resolve_working_diff_before_payloads(
         store,
-        candidates.iter_mut().map(|(_, before, _)| before),
+        candidates.iter_mut().map(|(identity, before, _)| {
+            (
+                TrackedStateKey {
+                    schema_key: identity.schema_key().to_owned(),
+                    file_id: identity.file_id().map(str::to_owned),
+                    entity_pk: identity.entity_pk.clone(),
+                },
+                before,
+            )
+        }),
     )
     .await?;
     let row_count = candidates.len();
@@ -10130,48 +10150,66 @@ async fn classify_hot_working_diff_scan_entries(
 
 /// Hydrates the payload slots of before images that were captured by reference.
 ///
-/// A root-backed baseline stores only the change id of its before image, so the
-/// write path pays no payload I/O. Classification needs the payload itself only
-/// to separate "different change, same payload" from a real modification, so
-/// the change records are fetched here, in one batch, and only for the rows
-/// that are actually unresolved.
+/// A root-backed baseline stores only the reference to its before image — the
+/// change id plus the commit that owns it — so the write path pays no payload
+/// I/O to capture it. Classification needs the payload itself for exactly one
+/// question the change id cannot answer alone: whether two distinct change
+/// records carry the same payload. Change records are addressed by owning
+/// commit, so the pending rows are grouped by commit and fetched one batch per
+/// commit, and only for the rows that are actually unresolved.
 async fn resolve_working_diff_before_payloads<'a>(
     store: &(impl StorageAdapterRead + ?Sized),
-    befores: impl Iterator<Item = &'a mut Option<WorkingDiffVersion>>,
+    rows: impl Iterator<Item = (TrackedStateKey, &'a mut Option<WorkingDiffVersion>)>,
 ) -> Result<(), LixError> {
-    let mut pending = befores
-        .filter(|before| {
-            before
-                .as_ref()
-                .is_some_and(|version| version.payload_is_unresolved())
-        })
-        .collect::<Vec<_>>();
+    let mut pending = Vec::new();
+    for (key, before) in rows {
+        let Some(version) = before.as_mut() else {
+            continue;
+        };
+        if !version.payload_is_unresolved() {
+            continue;
+        }
+        if version.deleted {
+            // A tombstone before image has no payload to hydrate, and its
+            // classification never consults one.
+            version.resolve_payload_slots(
+                WorkingDiffSlotFingerprint::none(),
+                WorkingDiffSlotFingerprint::none(),
+            );
+            continue;
+        }
+        pending.push((version.commit_id, key, version));
+    }
     if pending.is_empty() {
         return Ok(());
     }
-    let pending_len = pending.len();
-    let records = crate::changelog::load_change_records(
-        store,
-        pending.iter().map(|before| {
-            before
-                .as_ref()
-                .expect("pending before images are present")
-                .change_id
-        }),
-    )
-    .await?;
-    for before in &mut pending {
-        let version = before
-            .as_mut()
-            .expect("pending before images are present the second time");
-        let record = records.get(&version.change_id).ok_or_else(|| {
-            head_value_error(&format!(
-                "working-diff baseline references change record '{}' that is no longer readable (loaded {} of {})",
-                version.change_id,
-                records.len(),
-                pending_len,
-            ))
+    let mut by_commit = BTreeMap::<CommitId, Vec<usize>>::new();
+    for (index, (commit_id, _, _)) in pending.iter().enumerate() {
+        by_commit.entry(*commit_id).or_default().push(index);
+    }
+    let mut resolved = vec![None; pending.len()];
+    for (commit_id, indexes) in by_commit {
+        let keys = indexes
+            .iter()
+            .map(|index| pending[*index].1.clone())
+            .collect::<Vec<_>>();
+        let records =
+            crate::tracked_state::load_commit_delta_change_records(store, commit_id, &keys).await?;
+        for (index, record) in indexes.into_iter().zip(records) {
+            resolved[index] = record;
+        }
+    }
+    for ((_, _, version), record) in pending.into_iter().zip(resolved) {
+        let record = record.ok_or_else(|| {
+            head_value_error(
+                "working-diff baseline references a before image that is missing from its commit",
+            )
         })?;
+        if record.change_id != version.change_id {
+            return Err(head_value_error(
+                "working-diff baseline before image does not match its referenced change record",
+            ));
+        }
         version.resolve_payload_slots(
             packed_working_diff_slot(&record.snapshot),
             packed_working_diff_slot(&record.metadata),

--- a/packages/lix/src/live_state/tracked_head/hot.rs
+++ b/packages/lix/src/live_state/tracked_head/hot.rs
@@ -3087,6 +3087,19 @@ fn packed_exact_keys_for_filter(filter: &TrackedStateFilter) -> Option<Vec<Track
     Some(keys)
 }
 
+/// A packed current base is a collection published inside the active working
+/// interval, so its rows were absent when that checkpoint was taken.
+fn packed_current_base_working_diff_baseline(
+    active_checkpoint_commit_id: Option<CommitId>,
+) -> PackedWorkingDiffBaseline {
+    match active_checkpoint_commit_id {
+        Some(checkpoint_commit_id) => PackedWorkingDiffBaseline::AbsentAtCheckpoint {
+            checkpoint_commit_id,
+        },
+        None => PackedWorkingDiffBaseline::Disabled,
+    }
+}
+
 fn push_root_current_base_row(
     rows: &mut MaterializedLiveStateBatchBuilder,
     row: crate::tracked_state::MaterializedTrackedStateRowRef<'_>,
@@ -3116,7 +3129,15 @@ fn push_root_current_base_row(
             deleted: row.deleted(),
             created_at: row.created_at(),
             updated_at: row.updated_at(),
-            checkpoint_commit_id: active_checkpoint_commit_id,
+            // The root current base *is* the branch's checkpoint state, so
+            // these rows are clean at the active checkpoint. Reporting them as
+            // absent made the first branch-local mutation of a checkpointed
+            // identity look like a creation and gave `lix_revert` an empty
+            // before image.
+            working_diff_baseline: match active_checkpoint_commit_id {
+                Some(_) => PackedWorkingDiffBaseline::CleanAtCheckpoint,
+                None => PackedWorkingDiffBaseline::Disabled,
+            },
             columnar_base_coordinate: None,
         }),
     );
@@ -3887,7 +3908,9 @@ async fn load_packed_current_base_exact(
             deleted: false,
             created_at: value.created_at,
             updated_at: value.updated_at,
-            checkpoint_commit_id: active_checkpoint_commit_id,
+            working_diff_baseline: packed_current_base_working_diff_baseline(
+                active_checkpoint_commit_id,
+            ),
             columnar_base_coordinate,
         });
         let snapshot = materialize_packed_slot(
@@ -7248,7 +7271,9 @@ where
                 deleted: packed_value.deleted,
                 created_at: packed_value.created_at,
                 updated_at: packed_value.updated_at,
-                checkpoint_commit_id: working_diff_capture_checkpoint_commit_id,
+                working_diff_baseline: packed_current_base_working_diff_baseline(
+                    working_diff_capture_checkpoint_commit_id,
+                ),
                 columnar_base_coordinate: base_coordinate.map(|coordinate| {
                     ColumnarBaseCoordinate {
                         base_commit_id: coordinate.base_commit_id,

--- a/packages/lix/tests/integration/branching.rs
+++ b/packages/lix/tests/integration/branching.rs
@@ -2534,6 +2534,10 @@ simulation_test!(
             )
             .await
             .expect("working diff should load");
+        // The branch-local baseline stores only the before image's change id,
+        // so this net-empty answer is exactly the case that forces the reader
+        // to hydrate the referenced change record. A regression to change-id
+        // equality alone would report `modified` here.
         assert_eq!(
             rows.len(),
             0,

--- a/packages/lix/tests/integration/branching.rs
+++ b/packages/lix/tests/integration/branching.rs
@@ -2326,3 +2326,321 @@ simulation_test!(
         );
     }
 );
+
+simulation_test!(
+    working_diff_first_branch_delete_of_existing_row_is_removed,
+    |sim| async move {
+        let engine = sim.boot_engine().await;
+        let main = sim.wrap_session(
+            engine
+                .open_session(sim.main_branch_id())
+                .await
+                .expect("main session should open"),
+            &engine,
+        );
+        main.execute(
+            "INSERT INTO lix_key_value (key, value) VALUES ('branch-delete', 'before')",
+            &[],
+        )
+        .await
+        .expect("seed write should succeed");
+        main.create_checkpoint()
+            .await
+            .expect("checkpoint should succeed");
+
+        let draft = create_draft(&engine, &main).await;
+        delete_key_value(&draft, "branch-delete").await;
+
+        let narrow = draft
+            .execute(
+                "SELECT diff_type, before_change_id FROM lix_working_diff \
+                 WHERE schema_key = 'lix_key_value' \
+                   AND entity_pk = lix_json('[\"branch-delete\"]')",
+                &[],
+            )
+            .await
+            .expect("narrow working diff should load");
+        assert_eq!(
+            narrow.len(),
+            1,
+            "the deleted row must appear in the narrow working diff"
+        );
+        assert_eq!(
+            narrow.rows()[0].values()[0],
+            Value::Text("removed".to_string()),
+            "deleting a checkpointed row on a fresh branch must classify as removed, got {:?}",
+            narrow.rows()[0].values()
+        );
+
+        let broad = draft
+            .execute(
+                "SELECT entity_pk, diff_type FROM lix_working_diff \
+                 WHERE schema_key = 'lix_key_value' ORDER BY entity_pk",
+                &[],
+            )
+            .await
+            .expect("broad working diff should load");
+        assert_eq!(
+            broad.len(),
+            1,
+            "the deleted row must also appear in the unfiltered working diff, got {:?}",
+            broad.rows().iter().map(|row| row.values().to_vec()).collect::<Vec<_>>()
+        );
+    }
+);
+
+simulation_test!(
+    working_diff_branch_edit_is_modified_for_broad_and_repeated_edits,
+    |sim| async move {
+        let engine = sim.boot_engine().await;
+        let main = sim.wrap_session(
+            engine
+                .open_session(sim.main_branch_id())
+                .await
+                .expect("main session should open"),
+            &engine,
+        );
+        main.execute(
+            "INSERT INTO lix_key_value (key, value) VALUES ('branch-broad-a', 'before')",
+            &[],
+        )
+        .await
+        .expect("seed write should succeed");
+        main.execute(
+            "INSERT INTO lix_key_value (key, value) VALUES ('branch-broad-b', 'before')",
+            &[],
+        )
+        .await
+        .expect("seed write should succeed");
+        main.create_checkpoint()
+            .await
+            .expect("checkpoint should succeed");
+
+        let draft = create_draft(&engine, &main).await;
+        draft
+            .execute(
+                "INSERT INTO lix_key_value (key, value) VALUES ('branch-broad-new', 'new')",
+                &[],
+            )
+            .await
+            .expect("unrelated branch insert should succeed");
+        draft
+            .execute(
+                "UPDATE lix_key_value SET value = 'after' WHERE key = 'branch-broad-a'",
+                &[],
+            )
+            .await
+            .expect("first edit should succeed");
+        draft
+            .execute(
+                "UPDATE lix_key_value SET value = 'after-2' WHERE key = 'branch-broad-a'",
+                &[],
+            )
+            .await
+            .expect("second edit of the same row should succeed");
+        draft
+            .execute(
+                "UPDATE lix_key_value SET value = 'after' WHERE key = 'branch-broad-b'",
+                &[],
+            )
+            .await
+            .expect("edit of a second pre-existing row should succeed");
+
+        let rows = draft
+            .execute(
+                "SELECT entity_pk, diff_type FROM lix_working_diff \
+                 WHERE schema_key = 'lix_key_value' ORDER BY entity_pk",
+                &[],
+            )
+            .await
+            .expect("broad working diff should load");
+        let actual = rows
+            .rows()
+            .iter()
+            .map(|row| row.values().to_vec())
+            .collect::<Vec<_>>();
+        assert_eq!(
+            actual,
+            vec![
+                vec![
+                    Value::Json(JsonValue::Array(vec![JsonValue::String(
+                        "branch-broad-a".to_string()
+                    )])
+                    .into()),
+                    Value::Text("modified".to_string()),
+                ],
+                vec![
+                    Value::Json(JsonValue::Array(vec![JsonValue::String(
+                        "branch-broad-b".to_string()
+                    )])
+                    .into()),
+                    Value::Text("modified".to_string()),
+                ],
+                vec![
+                    Value::Json(JsonValue::Array(vec![JsonValue::String(
+                        "branch-broad-new".to_string()
+                    )])
+                    .into()),
+                    Value::Text("added".to_string()),
+                ],
+            ],
+            "every branch-local edit of a checkpointed row must classify as modified"
+        );
+    }
+);
+
+simulation_test!(
+    working_diff_restoring_the_checkpoint_payload_on_a_branch_is_net_empty,
+    |sim| async move {
+        let engine = sim.boot_engine().await;
+        let main = sim.wrap_session(
+            engine
+                .open_session(sim.main_branch_id())
+                .await
+                .expect("main session should open"),
+            &engine,
+        );
+        main.execute(
+            "INSERT INTO lix_key_value (key, value) VALUES ('branch-restore', 'before')",
+            &[],
+        )
+        .await
+        .expect("seed write should succeed");
+        main.create_checkpoint()
+            .await
+            .expect("checkpoint should succeed");
+
+        let draft = create_draft(&engine, &main).await;
+        draft
+            .execute(
+                "UPDATE lix_key_value SET value = 'after' WHERE key = 'branch-restore'",
+                &[],
+            )
+            .await
+            .expect("first branch edit should succeed");
+        draft
+            .execute(
+                "UPDATE lix_key_value SET value = 'before' WHERE key = 'branch-restore'",
+                &[],
+            )
+            .await
+            .expect("restoring the checkpoint payload should succeed");
+
+        let rows = draft
+            .execute(
+                "SELECT entity_pk, diff_type FROM lix_working_diff \
+                 WHERE schema_key = 'lix_key_value' ORDER BY entity_pk",
+                &[],
+            )
+            .await
+            .expect("working diff should load");
+        assert_eq!(
+            rows.len(),
+            0,
+            "restoring the checkpoint payload must be net empty, got {:?}",
+            rows.rows().iter().map(|row| row.values().to_vec()).collect::<Vec<_>>()
+        );
+    }
+);
+
+simulation_test!(
+    working_diff_first_edit_after_switch_branch_of_existing_row_is_modified,
+    |sim| async move {
+        let engine = sim.boot_engine().await;
+        let main = sim.wrap_session(
+            engine
+                .open_session(sim.main_branch_id())
+                .await
+                .expect("main session should open"),
+            &engine,
+        );
+        main.execute(
+            "INSERT INTO lix_key_value (key, value) VALUES ('switch-baseline', 'before')",
+            &[],
+        )
+        .await
+        .expect("seed write should succeed");
+        main.create_checkpoint()
+            .await
+            .expect("checkpoint should succeed");
+        let draft = create_draft(&engine, &main).await;
+        drop(draft);
+
+        main.switch_branch(SwitchBranchOptions {
+            branch_id: "01930000-0000-7000-8000-000000000001".to_string(),
+            pinned_commit_id: None,
+        })
+        .await
+        .expect("switch should succeed");
+
+        main.execute(
+            "UPDATE lix_key_value SET value = 'after' WHERE key = 'switch-baseline'",
+            &[],
+        )
+        .await
+        .expect("first edit after switch should succeed");
+
+        let rows = main
+            .execute(
+                "SELECT diff_type, before_change_id FROM lix_working_diff \
+                 WHERE schema_key = 'lix_key_value' \
+                   AND entity_pk = lix_json('[\"switch-baseline\"]')",
+                &[],
+            )
+            .await
+            .expect("working diff should load");
+        assert_eq!(rows.len(), 1);
+        assert_eq!(
+            rows.rows()[0].values()[0],
+            Value::Text("modified".to_string()),
+            "the first edit after a branch switch must classify as modified, got {:?}",
+            rows.rows()[0].values()
+        );
+    }
+);
+
+simulation_test!(
+    checkpoint_after_first_branch_edit_keeps_the_edited_value,
+    |sim| async move {
+        let engine = sim.boot_engine().await;
+        let main = sim.wrap_session(
+            engine
+                .open_session(sim.main_branch_id())
+                .await
+                .expect("main session should open"),
+            &engine,
+        );
+        main.execute(
+            "INSERT INTO lix_key_value (key, value) VALUES ('branch-checkpoint', 'before')",
+            &[],
+        )
+        .await
+        .expect("seed write should succeed");
+        main.create_checkpoint()
+            .await
+            .expect("checkpoint should succeed");
+
+        let draft = create_draft(&engine, &main).await;
+        draft
+            .execute(
+                "UPDATE lix_key_value SET value = 'after' WHERE key = 'branch-checkpoint'",
+                &[],
+            )
+            .await
+            .expect("first branch edit should succeed");
+        draft
+            .create_checkpoint()
+            .await
+            .expect("branch checkpoint should succeed");
+
+        assert_key_value(&draft, "branch-checkpoint", Some("\"after\"")).await;
+        let rows = draft
+            .execute(
+                "SELECT entity_pk FROM lix_working_diff WHERE schema_key = 'lix_key_value'",
+                &[],
+            )
+            .await
+            .expect("working diff should load");
+        assert_eq!(rows.len(), 0, "a fresh checkpoint has an empty working diff");
+    }
+);

--- a/packages/lix/tests/integration/branching.rs
+++ b/packages/lix/tests/integration/branching.rs
@@ -2568,7 +2568,6 @@ simulation_test!(
 
         main.switch_branch(SwitchBranchOptions {
             branch_id: "01930000-0000-7000-8000-000000000001".to_string(),
-            pinned_commit_id: None,
         })
         .await
         .expect("switch should succeed");

--- a/packages/lix/tests/integration/branching.rs
+++ b/packages/lix/tests/integration/branching.rs
@@ -2155,3 +2155,174 @@ async fn assert_empty_merge_commit(
         "empty merge commit should preserve target/source ancestry"
     );
 }
+
+// ---------------------------------------------------------------------------
+// Regression: root-backed generations must not lose the working-diff baseline.
+// ---------------------------------------------------------------------------
+
+simulation_test!(
+    working_diff_first_branch_edit_of_existing_row_is_modified,
+    |sim| async move {
+        let engine = sim.boot_engine().await;
+        let main = sim.wrap_session(
+            engine
+                .open_session(sim.main_branch_id())
+                .await
+                .expect("main session should open"),
+            &engine,
+        );
+        main.execute(
+            "INSERT INTO lix_key_value (key, value) VALUES ('branch-baseline', 'before')",
+            &[],
+        )
+        .await
+        .expect("seed write should succeed");
+        main.create_checkpoint()
+            .await
+            .expect("checkpoint should succeed");
+
+        let draft = create_draft(&engine, &main).await;
+
+        draft
+            .execute(
+                "UPDATE lix_key_value SET value = 'after' WHERE key = 'branch-baseline'",
+                &[],
+            )
+            .await
+            .expect("first branch edit should succeed");
+
+        let rows = draft
+            .execute(
+                "SELECT diff_type, before_change_id, after_change_id \
+                 FROM lix_working_diff \
+                 WHERE schema_key = 'lix_key_value' \
+                   AND entity_pk = lix_json('[\"branch-baseline\"]')",
+                &[],
+            )
+            .await
+            .expect("working diff should load");
+        assert_eq!(rows.len(), 1, "the edited row must appear in the working diff");
+        let values = rows.rows()[0].values().to_vec();
+        assert!(
+            matches!(&values[1], Value::Text(_)),
+            "the first branch-local edit of a checkpointed row must carry a before image, got {values:?}"
+        );
+        assert_eq!(
+            values[0],
+            Value::Text("modified".to_string()),
+            "the first branch-local edit of a checkpointed row must classify as modified, got {values:?}"
+        );
+    }
+);
+
+simulation_test!(
+    revert_of_first_branch_edit_restores_the_checkpoint_value,
+    |sim| async move {
+        let engine = sim.boot_engine().await;
+        let main = sim.wrap_session(
+            engine
+                .open_session(sim.main_branch_id())
+                .await
+                .expect("main session should open"),
+            &engine,
+        );
+        main.execute(
+            "INSERT INTO lix_key_value (key, value) VALUES ('branch-revert', 'before')",
+            &[],
+        )
+        .await
+        .expect("seed write should succeed");
+        main.create_checkpoint()
+            .await
+            .expect("checkpoint should succeed");
+
+        let draft = create_draft(&engine, &main).await;
+        draft
+            .execute(
+                "UPDATE lix_key_value SET value = 'after' WHERE key = 'branch-revert'",
+                &[],
+            )
+            .await
+            .expect("first branch edit should succeed");
+
+        draft
+            .execute(
+                "INSERT INTO lix_revert (diff_id) \
+                 SELECT diff_id FROM lix_working_diff \
+                 WHERE schema_key = 'lix_key_value' \
+                   AND entity_pk = lix_json('[\"branch-revert\"]')",
+                &[],
+            )
+            .await
+            .expect("revert should succeed");
+
+        assert_key_value(&draft, "branch-revert", Some("\"before\"")).await;
+    }
+);
+
+simulation_test!(
+    working_diff_first_edit_after_merge_of_existing_row_is_modified,
+    |sim| async move {
+        let engine = sim.boot_engine().await;
+        let main = sim.wrap_session(
+            engine
+                .open_session(sim.main_branch_id())
+                .await
+                .expect("main session should open"),
+            &engine,
+        );
+        main.execute(
+            "INSERT INTO lix_key_value (key, value) VALUES ('merge-baseline', 'before')",
+            &[],
+        )
+        .await
+        .expect("seed write should succeed");
+
+        let draft = create_draft(&engine, &main).await;
+        draft
+            .execute(
+                "INSERT INTO lix_key_value (key, value) VALUES ('merge-unrelated', 'draft')",
+                &[],
+            )
+            .await
+            .expect("draft write should succeed");
+
+        main.create_checkpoint()
+            .await
+            .expect("target checkpoint should succeed");
+        main.merge_branch(MergeBranchOptions {
+            source_branch_id: "01930000-0000-7000-8000-000000000001".to_string(),
+        })
+        .await
+        .expect("merge should succeed");
+
+        main.execute(
+            "UPDATE lix_key_value SET value = 'after' WHERE key = 'merge-baseline'",
+            &[],
+        )
+        .await
+        .expect("first post-merge edit should succeed");
+
+        let rows = main
+            .execute(
+                "SELECT diff_type, before_change_id \
+                 FROM lix_working_diff \
+                 WHERE schema_key = 'lix_key_value' \
+                   AND entity_pk = lix_json('[\"merge-baseline\"]')",
+                &[],
+            )
+            .await
+            .expect("working diff should load");
+        assert_eq!(rows.len(), 1, "the edited row must appear in the working diff");
+        let values = rows.rows()[0].values().to_vec();
+        assert!(
+            matches!(&values[1], Value::Text(_)),
+            "the first post-merge edit of a checkpointed row must carry a before image, got {values:?}"
+        );
+        assert_eq!(
+            values[0],
+            Value::Text("modified".to_string()),
+            "the first post-merge edit of a checkpointed row must classify as modified, got {values:?}"
+        );
+    }
+);

--- a/packages/lix/tests/integration/branching.rs
+++ b/packages/lix/tests/integration/branching.rs
@@ -2643,3 +2643,70 @@ simulation_test!(
         assert_eq!(rows.len(), 0, "a fresh checkpoint has an empty working diff");
     }
 );
+
+simulation_test!(
+    merging_a_first_branch_edit_reports_modified_and_lands_the_value,
+    |sim| async move {
+        let engine = sim.boot_engine().await;
+        let main = sim.wrap_session(
+            engine
+                .open_session(sim.main_branch_id())
+                .await
+                .expect("main session should open"),
+            &engine,
+        );
+        main.execute(
+            "INSERT INTO lix_key_value (key, value) VALUES ('merge-first-edit', 'before')",
+            &[],
+        )
+        .await
+        .expect("seed write should succeed");
+        main.create_checkpoint()
+            .await
+            .expect("checkpoint should succeed");
+
+        let draft = create_draft(&engine, &main).await;
+        draft
+            .execute(
+                "UPDATE lix_key_value SET value = 'after' WHERE key = 'merge-first-edit'",
+                &[],
+            )
+            .await
+            .expect("first branch edit should succeed");
+
+        let preview = main
+            .merge_branch_preview(MergeBranchPreviewOptions {
+                source_branch_id: "01930000-0000-7000-8000-000000000001".to_string(),
+            })
+            .await
+            .expect("preview should succeed");
+        assert_eq!(
+            preview.change_stats,
+            MergeChangeStats {
+                total: 1,
+                added: 0,
+                modified: 1,
+                removed: 0,
+            },
+            "merge preview must see the branch-local edit as a modification"
+        );
+
+        let receipt = main
+            .merge_branch(MergeBranchOptions {
+                source_branch_id: "01930000-0000-7000-8000-000000000001".to_string(),
+            })
+            .await
+            .expect("merge should succeed");
+        assert_eq!(
+            receipt.change_stats,
+            MergeChangeStats {
+                total: 1,
+                added: 0,
+                modified: 1,
+                removed: 0,
+            },
+            "merge must record the branch-local edit as a modification"
+        );
+        assert_key_value(&main, "merge-first-edit", Some("\"after\"")).await;
+    }
+);


### PR DESCRIPTION
## Data loss: reverting a branch-local edit deleted the row

On a branch created by `create_branch`, the **first** mutation of a row that already existed at the checkpoint was recorded as if that row had just been *created*. The consequences at the public SQL surface:

- **`lix_revert` deleted the user's checkpointed value instead of restoring it.** The diff said `added`, so revert correctly undid an "add" — by removing the row. The prior value is gone.
- **Branch-local deletes were invisible.** Deleting a checkpointed row on a branch produced *no* `lix_working_diff` row at all, narrow or broad.
- **Edited rows were missing from broad `lix_working_diff` queries entirely.** An unfiltered `SELECT … FROM lix_working_diff` returned only newly inserted keys; every edited pre-existing row was absent.
- Narrow (`entity_pk`-filtered) queries did return the row, but as `diff_type = 'added'` with `before_change_id = NULL`.

### Scope — read this part

- **The trigger is `create_branch`, not merge.** It also reproduces through `switch_branch` into such a branch (same root cause, not an independent one). `main` is unaffected because it is not root-backed.
- **The wrong baseline is sticky.** A second `UPDATE` of the same row does not repair it.
- **It affects every identity without a branch-local HOT row**, not just the literally-first edit. In the regression test, two separate pre-existing rows edited after an unrelated insert are *both* missing from the working diff.
- **PR #1305's root-backed head moves did not widen this.** An explicit head move on an *existing* branch stages no new working-diff epoch, so the stored epoch's generation goes stale, `commit.rs` yields `working_diff_epoch = None`, the branch control drops its `working_diff_checkpoint_commit_id`, and `working_diff_for_control` bails to the canonical diff. Post-merge working diffs are correct (unaccelerated). Our own recent work is not implicated.
- **Merge and merge preview were never affected** — they use the canonical commit diff, not the HOT working-diff accelerator. Two tests in this PR prove it and are expected to pass both before and after the fix.

## Root cause

One struct field conflated two different facts. `PackedHeadValue.checkpoint_commit_id: Option<CommitId>` was used for both current-state bases, and `CertifiedCurrentStatePredecessor::view()` mapped any `Some(..)` to `WorkingDiffBaseline::BeforeAbsent`:

```rust
// before
working_diff_baseline: value.checkpoint_commit_id.map_or(
    WorkingDiffBaseline::Disabled,
    |checkpoint_commit_id| WorkingDiffBaseline::BeforeAbsent { checkpoint_commit_id },
),
```

That is right for the **packed** current base — a collection published *inside* the working interval, therefore absent at the checkpoint. It is wrong for the **root** current base, which *is* the checkpoint state. `next_hot_working_diff_baseline` then returned `(BeforeAbsent, newly_dirty = false)`, which is both halves of the bug: the wrong classification, and no sparse dirty-key index entry — which is why broad queries omitted the row while coverage stayed self-consistent and nothing tripped the canonical fallback.

This is the third defect in this family: a type that can represent "unknown" or "not applicable" collapses onto the dangerous answer by default. The fix makes the unclassified state **unrepresentable as an answer** rather than defaulting.

## The fix

**Split the type.** `checkpoint_commit_id: Option<CommitId>` becomes:

```rust
enum PackedWorkingDiffBaseline {
    Disabled,
    AbsentAtCheckpoint { checkpoint_commit_id: CommitId },  // packed base
    CleanAtCheckpoint,                                       // root base
}
```

`view()` matches this exhaustively by name. There is no `_ =>` arm and no `map_or` anywhere on the path, so a new base kind is a compile error rather than a silent `BeforeAbsent`.

**Capture the before image by reference; resolve it lazily.** A baseline taken from a base that was read without payload projection records its payload slots as `WORKING_DIFF_SLOT_UNRESOLVED` (new kind `3`, zero hash, validated on decode). The write path stores only the reference it already had — change id plus owning commit — and does **no** new I/O.

**Make "unclassified" a distinct answer.** `payload_eq -> bool` becomes `payload_equality -> WorkingDiffPayloadEquality {Equal, Different, Unresolved}`. `Equal` still short-circuits on change id, so ordinary modifications never hydrate anything. `Unresolved` reaching classification is a hard error, not a guess.

**Hydrate on the read path.** `resolve_working_diff_before_payloads` runs before each classifier, groups unresolved rows by owning commit, and issues one `load_commit_delta_change_records` batch per commit. Identity keys are materialized only for rows that are actually unresolved, so a diff with no root-backed baselines allocates nothing extra and returns immediately.

> **Note for whoever touches this next.** My first implementation resolved via `load_change_records` against `CHANGE_SPACE` and failed with `loaded 0 of 1`. Change records are addressed **by owning commit**, not by raw change id. `WorkingDiffVersion` already carries `commit_id`, so the stored reference was complete — the lookup was wrong. That is why hydration batches per commit rather than per change.

## Layout invariants

1. **Single authority** — no new authority. One field replaced by one better-typed field; the root base remains the only source of its own baseline.
2. **Commit canonicality** — unchanged.
3. **Derived views are caches** — this restores the property. The HOT working-diff index is an accelerator over the canonical diff; it was answering *confidently and wrongly* where it should have answered correctly. It now either answers correctly or errors.
4. **Atomic publication** — unchanged; the baseline publishes in the same write set as the row.
5. **GC from refs** — unchanged. Before images are referenced through commits already reachable from the checkpoint.
6. **SQL reads canonical records** — strengthened: the accelerator now hydrates from the canonical change record when the reference alone is insufficient.

## Correctness

`cargo test -p lix --all-features` green (2073 + 847 + 12 across targets, 0 failed). `cargo clippy --workspace --all-targets --all-features -- -D warnings` clean. `cargo check --workspace` clean.

Ten regression assertions, all **verified failing against the unfixed tree**, in both simulation variants (`_base`, `_tracked_state_rebuild`):

| test | pre-fix |
|---|---|
| `working_diff_first_branch_edit_of_existing_row_is_modified` | FAIL — `added`, before `NULL` |
| `revert_of_first_branch_edit_restores_the_checkpoint_value` | FAIL — **row deleted** |
| `working_diff_first_branch_delete_of_existing_row_is_removed` | FAIL — 0 rows, narrow **and** broad |
| `working_diff_branch_edit_is_modified_for_broad_and_repeated_edits` | FAIL — both edited rows missing |
| `working_diff_first_edit_after_switch_branch_of_existing_row_is_modified` | FAIL — `added` |
| `working_diff_first_edit_after_merge_of_existing_row_is_modified` | pass (guard: merge unaffected) |
| `merging_a_first_branch_edit_reports_modified_and_lands_the_value` | pass (guard: merge unaffected) |
| `checkpoint_after_first_branch_edit_keeps_the_edited_value` | pass (guard) |
| `working_diff_restoring_the_checkpoint_payload_on_a_branch_is_net_empty` | passed **vacuously** pre-fix (row was invisible); now a real assertion that exercises hydration |

That last one is the test that fails if anyone regresses hydration back to change-id-only equality.

## Cost — measured

The fix makes a branch-local first mutation stage a dirty-key index entry that `newly_dirty = false` wrongly skipped, and store `BeforePresent` (checkpoint id + 115-byte version) instead of the smaller `BeforeAbsent`. **That is the write that makes the row visible in the working diff at all**, and it is what a non-root-backed branch already pays.

`branch_storage_sharing`, `LIX_BRANCH_SHARING_ROWS=10000`, byte-exact and deterministic (no rep noise). Logical bytes per changed row, rocksdb — slatedb agrees to within 0.1%:

| scenario | changed rows | base | cand | delta |
|---|---:|---:|---:|---:|
| `branch_1row` | 1 | 5525.00 | 5760.00 | +235 (+4.3%) |
| `branch_1pct` | 100 | 417.32 | 583.58 | **+166.3 (+39.8%)** |
| `branch_10pct` | 1000 | 372.31 | 537.47 | **+165.2 (+44.4%)** |
| `merge_1pct` | 100 | 424.74 | 591.00 | **+166.3 (+39.1%)** |

**+166 logical bytes per branch-local changed row, flat across scale.** That decomposes cleanly: `WORKING_DIFF_VERSION_BYTES` = 115, plus ~50 bytes of dirty-key segment entry. Physical bytes move less: `branch_1pct` +5.8% rocksdb / +7.4% slatedb, `branch_10pct` +15.0% / +15.2%, `branch_1row` +0.3%.

Compounding note for the HOT-plane work: this moves the branch-local edit cost from ~390 B/row to **~556 B/row** against ~32 B in the packed plane. The fix is not the cause of that gap, but it widens it, and that argues for the HOT-plane layout work rather than against this fix.

Write latency (`scenario_ms`, single rep, noisy): `branch_1pct` +3.5%, `branch_10pct` −3.7%, `merge_1pct` −4.9%, `branch_1row` −17%. Straddles zero; no systematic write regression.

## Guards — honest status

`tracked_state_crud` (read + write ids), `untracked_state_crud` as the null control, and `tracked_working_diff`, interleaved with rotated arm order. At n=3 the run is **not resolvable**:

| | n | median | min | max |
|---|---:|---:|---:|---:|
| **null control** (`untracked_state_crud`, byte-identical code both arms) | 21 ids | −0.59% | −11.3% | **+25.5%** |
| `tracked_state_crud` | 84 ids | −0.85% | −21.0% | +21.5% |

The null control's own spread is ±25%, so every per-id delta in the guard set sits inside the noise floor. The two medians (−0.85% vs −0.59%) are indistinguishable. The defensible statement is: **no systematic shift, and this harness at n=3 cannot resolve anything smaller than roughly ±25%.**

This is expected rather than lucky. The change is provably inert off the branch path: with no root current base, `CleanAtCheckpoint` is never constructed, `payload_is_unresolved()` is always false, and the resolver returns at `pending.is_empty()` before touching storage. The benches above all run on `main`.

A longer 5-rep run was still in flight when this was opened; the deterministic byte accounting above is the load-bearing cost number and is not subject to rep noise. I will post the completed timing table as a comment.
