### PR TITLE
perf(tracked_state): resume commit-root replay from the last durable root

### DIFF
--- a/.changenotes/bounded-commit-root-replay.md
+++ b/.changenotes/bounded-commit-root-replay.md
@@ -1,0 +1,7 @@
+---
+type: patch
+---
+
+Commit-root materialization now resumes from the last durable state root instead of replaying history from genesis.
+
+Closing a rootless replay interval used to prove root availability by re-deriving every ancestor root from the changelog back to the first commit, so the periodic root materialization replayed the entire history and its cost grew quadratically with commit count. Availability is now proven from the commit-state manifest that already owns the root, plus a readable-closure check on the tree it addresses. A damaged root is still never resumed from, so explicit repair stays total.

--- a/packages/engine-benchmarks/Cargo.toml
+++ b/packages/engine-benchmarks/Cargo.toml
@@ -17,6 +17,7 @@ default = ["rocksdb"]
 rocksdb = ["dep:lix_storage_rocksdb"]
 slatedb = ["dep:lix_storage_slatedb", "dep:object_store", "dep:slatedb", "dep:ulid"]
 storage-benches = ["lix/storage-benches", "rocksdb"]
+root-replay-trace = ["lix/root-replay-trace", "storage-benches"]
 tpch = ["dep:duckdb", "dep:tpchgen"]
 # Opt-in profiling build that routes Rust allocations through libc so tools
 # such as heaptrack can attribute transient allocation churn to call stacks.
@@ -59,6 +60,11 @@ tokio = { version = "1", features = ["rt-multi-thread", "macros", "sync", "time"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 uuid = { version = "1", features = ["std"] }
 xxhash-rust = { version = "0.8", features = ["xxh3"] }
+
+[[example]]
+name = "expaa_replay_scope"
+path = "examples/expaa_replay_scope.rs"
+required-features = ["storage-benches"]
 
 [[example]]
 name = "space_growth"

--- a/packages/engine-benchmarks/examples/expaa_replay_scope.rs
+++ b/packages/engine-benchmarks/examples/expaa_replay_scope.rs
@@ -1,0 +1,215 @@
+//! Commit-root replay scope and cost attribution (experiment AA).
+//!
+//! Tracked-state root materialization is bursty: ordinary commits are
+//! "rootless" bounded-replay layouts and only every
+//! `COMMIT_STATE_MAX_REPLAY_DEPTH`-th commit closes the interval by
+//! materializing a durable root. This example drives N ordinary SQL commits
+//! through the real `SessionContext` commit path and reports, per boundary,
+//! how many ancestor commits that root materialization replayed.
+//!
+//! If the replay resumed from the previous materialized root the per-boundary
+//! replay set is a constant (the interval depth). If it restarts from genesis
+//! the replay set grows linearly with commit count and total replay work is
+//! quadratic. The printed `plans_per_boundary` row is the distinguishing
+//! measurement.
+//!
+//! Build with `--features root-replay-trace` to additionally attribute the
+//! per-replayed-commit cost across storage read / decode / encode / hash.
+//!
+//! Usage: `expaa_replay_scope [commits] [rows_per_commit]`
+//! (defaults: 200 commits, 10 rows).
+
+use std::time::{Duration, Instant};
+
+use lix::Value;
+use lix::integration::{Engine, SessionContext};
+use lix::storage::Storage;
+use lix::storage_bench::{
+    RootReplayCostBucket, root_replay_trace_enabled, take_root_replay_accounting,
+    take_root_replay_cost_attribution,
+};
+use lix_storage_rocksdb::RocksDB;
+
+#[tokio::main(flavor = "current_thread")]
+async fn main() {
+    let mut args = std::env::args().skip(1);
+    let commits = args
+        .next()
+        .and_then(|value| value.parse::<usize>().ok())
+        .unwrap_or(200);
+    let rows_per_commit = args
+        .next()
+        .and_then(|value| value.parse::<usize>().ok())
+        .unwrap_or(10);
+    assert!(commits >= 2, "need at least two commits to measure growth");
+
+    let directory = tempfile::tempdir().expect("create RocksDB directory");
+    let storage = RocksDB::open(directory.path()).expect("open RocksDB");
+    Engine::initialize(storage.clone())
+        .await
+        .expect("initialize repository");
+    let engine = Engine::new(storage.clone()).await.expect("open engine");
+    let session = engine
+        .open_workspace_session()
+        .await
+        .expect("open workspace");
+    register_schema(&session).await;
+
+    // Discard setup accounting so the reported numbers cover only the measured
+    // history.
+    let _ = take_root_replay_accounting();
+    let _ = take_root_replay_cost_attribution();
+
+    let mut latencies = Vec::with_capacity(commits);
+    let run_start = Instant::now();
+    for index in 0..commits {
+        let start = Instant::now();
+        commit_batch(&session, index, rows_per_commit).await;
+        latencies.push(start.elapsed());
+    }
+    let wall = run_start.elapsed();
+
+    let accounting = take_root_replay_accounting();
+    let attribution = take_root_replay_cost_attribution();
+
+    println!("expAA_replay_scope commits={commits} rows_per_commit={rows_per_commit}");
+    println!("wall_ms {:.1}", wall.as_secs_f64() * 1000.0);
+    println!(
+        "boundaries {} plans_loaded {} plans_staged {} max_plans_in_one_boundary {}",
+        accounting.boundaries,
+        accounting.plans_loaded,
+        accounting.plans_staged,
+        accounting.max_plans_in_one_boundary
+    );
+    println!(
+        "available_root_probes {} available_root_hits {} ancestry_proof_stagings {}",
+        accounting.available_root_probes,
+        accounting.available_root_hits,
+        accounting.proof_stagings
+    );
+    println!(
+        "plan_load_ms {:.1} stage_ms {:.1} replay_share_of_wall {:.1}%",
+        accounting.plan_load_nanos as f64 / 1e6,
+        accounting.stage_nanos as f64 / 1e6,
+        (accounting.plan_load_nanos + accounting.stage_nanos) as f64 / wall.as_nanos() as f64
+            * 100.0
+    );
+    println!(
+        "plans_per_boundary {}",
+        accounting
+            .plans_per_boundary
+            .iter()
+            .map(u64::to_string)
+            .collect::<Vec<_>>()
+            .join(",")
+    );
+
+    // Commit latency at the burst boundary versus everywhere else.
+    let boundary_indices = top_latency_indices(&latencies, accounting.boundaries as usize);
+    println!(
+        "slowest_commit_indices {}",
+        boundary_indices
+            .iter()
+            .map(|(index, duration)| format!("{index}:{:.1}ms", duration.as_secs_f64() * 1000.0))
+            .collect::<Vec<_>>()
+            .join(" ")
+    );
+    let mut sorted = latencies.clone();
+    sorted.sort_unstable();
+    println!(
+        "commit_latency_ms median {:.2} p95 {:.2} max {:.2}",
+        sorted[sorted.len() / 2].as_secs_f64() * 1000.0,
+        sorted[sorted.len() * 95 / 100].as_secs_f64() * 1000.0,
+        sorted[sorted.len() - 1].as_secs_f64() * 1000.0
+    );
+
+    if root_replay_trace_enabled() {
+        println!(
+            "{:<14} {:>14} {:>14} {:>10} {:>14} {:>14}",
+            "phase", "replay_ms", "total_ms", "replay_%", "replay_bytes", "replay_calls"
+        );
+        for (name, bucket) in [
+            ("storage_read", attribution.storage_read),
+            ("decode", attribution.decode),
+            ("encode", attribution.encode),
+            ("hash", attribution.hash),
+        ] {
+            print_bucket(name, bucket);
+        }
+    } else {
+        println!("cost_attribution unavailable: rebuild with --features root-replay-trace");
+    }
+}
+
+fn print_bucket(name: &str, bucket: RootReplayCostBucket) {
+    let share = if bucket.total_nanos == 0 {
+        0.0
+    } else {
+        bucket.replay_nanos as f64 / bucket.total_nanos as f64 * 100.0
+    };
+    println!(
+        "{name:<14} {:>14.1} {:>14.1} {share:>9.1}% {:>14} {:>14}",
+        bucket.replay_nanos as f64 / 1e6,
+        bucket.total_nanos as f64 / 1e6,
+        bucket.replay_bytes,
+        bucket.replay_count
+    );
+}
+
+fn top_latency_indices(latencies: &[Duration], count: usize) -> Vec<(usize, Duration)> {
+    let mut indexed = latencies
+        .iter()
+        .copied()
+        .enumerate()
+        .collect::<Vec<(usize, Duration)>>();
+    indexed.sort_by_key(|(_, duration)| std::cmp::Reverse(*duration));
+    indexed.truncate(count.max(1).min(12));
+    indexed.sort_by_key(|(index, _)| *index);
+    indexed
+}
+
+async fn commit_batch<S>(session: &SessionContext<S>, batch: usize, rows: usize)
+where
+    S: Storage + Clone + Send + Sync + 'static,
+{
+    let mut transaction = session.begin_transaction().await.expect("begin commit");
+    for index in 0..rows {
+        transaction
+            .execute(
+                "INSERT INTO replay_scope (path, value) VALUES ($1, lix_json($2))",
+                &[
+                    Value::Text(format!("/row/{batch:08}/{index:08}")),
+                    Value::Text(format!(r#"{{"batch":{batch},"index":{index}}}"#)),
+                ],
+            )
+            .await
+            .expect("insert row");
+    }
+    transaction.commit().await.expect("commit batch");
+}
+
+async fn register_schema<S>(session: &SessionContext<S>)
+where
+    S: Storage + Clone + Send + Sync + 'static,
+{
+    let schema = serde_json::json!({
+        "x-lix-key": "replay_scope",
+        "x-lix-primary-key": ["/path"],
+        "type": "object",
+        "required": ["path", "value"],
+        "properties": {
+            "path": { "type": "string" },
+            "value": {
+                "type": ["object", "array", "string", "number", "integer", "boolean", "null"]
+            }
+        },
+        "additionalProperties": false
+    });
+    session
+        .execute(
+            "INSERT INTO lix_registered_schema (value, lixcol_global, lixcol_untracked) VALUES (lix_json($1), false, false)",
+            &[Value::Text(schema.to_string())],
+        )
+        .await
+        .expect("register schema");
+}

--- a/packages/engine-benchmarks/examples/expaa_replay_scope.rs
+++ b/packages/engine-benchmarks/examples/expaa_replay_scope.rs
@@ -41,6 +41,13 @@ async fn main() {
         .next()
         .and_then(|value| value.parse::<usize>().ok())
         .unwrap_or(10);
+    // Checkpoints re-home live rows onto one commit and parent the previous
+    // checkpoint directly, so they are a candidate natural resume point. Pass a
+    // non-zero interval to test whether they bound the replay set on their own.
+    let checkpoint_every = args
+        .next()
+        .and_then(|value| value.parse::<usize>().ok())
+        .unwrap_or(0);
     assert!(commits >= 2, "need at least two commits to measure growth");
 
     let directory = tempfile::tempdir().expect("create RocksDB directory");
@@ -61,18 +68,28 @@ async fn main() {
     let _ = take_root_replay_cost_attribution();
 
     let mut latencies = Vec::with_capacity(commits);
+    let mut checkpoints = 0_usize;
     let run_start = Instant::now();
     for index in 0..commits {
         let start = Instant::now();
         commit_batch(&session, index, rows_per_commit).await;
         latencies.push(start.elapsed());
+        if checkpoint_every > 0 && (index + 1) % checkpoint_every == 0 {
+            session
+                .create_checkpoint()
+                .await
+                .expect("checkpoint should publish");
+            checkpoints += 1;
+        }
     }
     let wall = run_start.elapsed();
 
     let accounting = take_root_replay_accounting();
     let attribution = take_root_replay_cost_attribution();
 
-    println!("expAA_replay_scope commits={commits} rows_per_commit={rows_per_commit}");
+    println!(
+        "expAA_replay_scope commits={commits} rows_per_commit={rows_per_commit} checkpoint_every={checkpoint_every} checkpoints={checkpoints}"
+    );
     println!("wall_ms {:.1}", wall.as_secs_f64() * 1000.0);
     println!(
         "boundaries {} plans_loaded {} plans_staged {} max_plans_in_one_boundary {}",

--- a/packages/lix/Cargo.toml
+++ b/packages/lix/Cargo.toml
@@ -22,6 +22,9 @@ workspace = true
 default = ["default_wasm_runtime"]
 all-simulations = []
 storage-benches = []
+# Per-node cost attribution for commit-root replay (experiment AA). Kept out of
+# `storage-benches` so timing A/B runs never pay for the inline `Instant::now()`.
+root-replay-trace = ["storage-benches"]
 default_wasm_runtime = ["dep:wasmtime", "dep:wasmtime-wasi"]
 
 [[test]]

--- a/packages/lix/src/storage_bench.rs
+++ b/packages/lix/src/storage_bench.rs
@@ -458,6 +458,310 @@ pub fn take_crud_current_state_scoped_range_accounting() -> CrudCurrentStateScop
     }
 }
 
+// ---------------------------------------------------------------------------
+// Commit-root replay accounting (experiment AA).
+//
+// Answers "how many ancestor commits does one root-materialization boundary
+// replay, and where does the per-replayed-commit cost go". The coarse counters
+// tick once per boundary/plan and are always compiled under `storage-benches`.
+// The per-node cost attribution is behind `root-replay-trace` so no timing A/B
+// ever pays for an `Instant::now()` inside `hash_bytes`.
+// ---------------------------------------------------------------------------
+
+static ROOT_REPLAY_BOUNDARIES: AtomicU64 = AtomicU64::new(0);
+static ROOT_REPLAY_PLANS_LOADED: AtomicU64 = AtomicU64::new(0);
+static ROOT_REPLAY_PLANS_STAGED: AtomicU64 = AtomicU64::new(0);
+static ROOT_REPLAY_AVAILABLE_ROOT_PROBES: AtomicU64 = AtomicU64::new(0);
+static ROOT_REPLAY_AVAILABLE_ROOT_HITS: AtomicU64 = AtomicU64::new(0);
+static ROOT_REPLAY_PROOF_STAGINGS: AtomicU64 = AtomicU64::new(0);
+static ROOT_REPLAY_MAX_PLANS: AtomicU64 = AtomicU64::new(0);
+
+static ROOT_REPLAY_PLAN_LOAD_NANOS: AtomicU64 = AtomicU64::new(0);
+static ROOT_REPLAY_STAGE_NANOS: AtomicU64 = AtomicU64::new(0);
+
+/// Per-boundary replay-set sizes, in boundary order.
+static ROOT_REPLAY_PLAN_HISTOGRAM: std::sync::Mutex<Vec<u64>> = std::sync::Mutex::new(Vec::new());
+
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct RootReplayAccounting {
+    /// Distinct durable rootless parents that forced a replay.
+    pub boundaries: u64,
+    /// Total rebuild plans returned by the nearest-available-root walk.
+    pub plans_loaded: u64,
+    /// Plans actually replayed through the tracked-state root writer.
+    pub plans_staged: u64,
+    pub available_root_probes: u64,
+    pub available_root_hits: u64,
+    /// Root stagings performed inside the ancestry proof itself.
+    pub proof_stagings: u64,
+    pub max_plans_in_one_boundary: u64,
+    pub plan_load_nanos: u64,
+    pub stage_nanos: u64,
+    /// Replay-set size per boundary, in boundary order.
+    pub plans_per_boundary: Vec<u64>,
+}
+
+pub(crate) fn record_root_replay_boundary(plans: usize) {
+    ROOT_REPLAY_BOUNDARIES.fetch_add(1, Ordering::Relaxed);
+    ROOT_REPLAY_PLANS_LOADED.fetch_add(plans as u64, Ordering::Relaxed);
+    ROOT_REPLAY_MAX_PLANS.fetch_max(plans as u64, Ordering::Relaxed);
+    if let Ok(mut histogram) = ROOT_REPLAY_PLAN_HISTOGRAM.lock() {
+        histogram.push(plans as u64);
+    }
+}
+
+pub(crate) fn record_root_replay_plan_staged() {
+    ROOT_REPLAY_PLANS_STAGED.fetch_add(1, Ordering::Relaxed);
+}
+
+pub(crate) fn record_root_replay_available_root_probe(hit: bool) {
+    ROOT_REPLAY_AVAILABLE_ROOT_PROBES.fetch_add(1, Ordering::Relaxed);
+    if hit {
+        ROOT_REPLAY_AVAILABLE_ROOT_HITS.fetch_add(1, Ordering::Relaxed);
+    }
+}
+
+pub(crate) fn record_root_replay_proof_staging() {
+    ROOT_REPLAY_PROOF_STAGINGS.fetch_add(1, Ordering::Relaxed);
+}
+
+pub(crate) fn record_root_replay_plan_load_nanos(nanos: u64) {
+    ROOT_REPLAY_PLAN_LOAD_NANOS.fetch_add(nanos, Ordering::Relaxed);
+}
+
+pub(crate) fn record_root_replay_stage_nanos(nanos: u64) {
+    ROOT_REPLAY_STAGE_NANOS.fetch_add(nanos, Ordering::Relaxed);
+}
+
+pub fn take_root_replay_accounting() -> RootReplayAccounting {
+    RootReplayAccounting {
+        boundaries: ROOT_REPLAY_BOUNDARIES.swap(0, Ordering::Relaxed),
+        plans_loaded: ROOT_REPLAY_PLANS_LOADED.swap(0, Ordering::Relaxed),
+        plans_staged: ROOT_REPLAY_PLANS_STAGED.swap(0, Ordering::Relaxed),
+        available_root_probes: ROOT_REPLAY_AVAILABLE_ROOT_PROBES.swap(0, Ordering::Relaxed),
+        available_root_hits: ROOT_REPLAY_AVAILABLE_ROOT_HITS.swap(0, Ordering::Relaxed),
+        proof_stagings: ROOT_REPLAY_PROOF_STAGINGS.swap(0, Ordering::Relaxed),
+        max_plans_in_one_boundary: ROOT_REPLAY_MAX_PLANS.swap(0, Ordering::Relaxed),
+        plan_load_nanos: ROOT_REPLAY_PLAN_LOAD_NANOS.swap(0, Ordering::Relaxed),
+        stage_nanos: ROOT_REPLAY_STAGE_NANOS.swap(0, Ordering::Relaxed),
+        plans_per_boundary: ROOT_REPLAY_PLAN_HISTOGRAM
+            .lock()
+            .map(|mut histogram| std::mem::take(&mut *histogram))
+            .unwrap_or_default(),
+    }
+}
+
+/// Per-node cost attribution for replayed commits.
+///
+/// Every bucket records `(in_replay, total)` so a run can say what fraction of
+/// all tracked-state tree CPU is spent inside commit-root replay rather than on
+/// the commit's own mutations.
+#[cfg(feature = "root-replay-trace")]
+mod replay_trace {
+    use std::cell::Cell;
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    macro_rules! bucket {
+        ($replay_ns:ident, $total_ns:ident, $replay_bytes:ident, $total_bytes:ident,
+         $replay_count:ident, $total_count:ident, $record:ident) => {
+            static $replay_ns: AtomicU64 = AtomicU64::new(0);
+            static $total_ns: AtomicU64 = AtomicU64::new(0);
+            static $replay_bytes: AtomicU64 = AtomicU64::new(0);
+            static $total_bytes: AtomicU64 = AtomicU64::new(0);
+            static $replay_count: AtomicU64 = AtomicU64::new(0);
+            static $total_count: AtomicU64 = AtomicU64::new(0);
+
+            pub(crate) fn $record(nanos: u64, bytes: u64) {
+                $total_ns.fetch_add(nanos, Ordering::Relaxed);
+                $total_bytes.fetch_add(bytes, Ordering::Relaxed);
+                $total_count.fetch_add(1, Ordering::Relaxed);
+                if in_replay() {
+                    $replay_ns.fetch_add(nanos, Ordering::Relaxed);
+                    $replay_bytes.fetch_add(bytes, Ordering::Relaxed);
+                    $replay_count.fetch_add(1, Ordering::Relaxed);
+                }
+            }
+        };
+    }
+
+    thread_local! {
+        static REPLAY_DEPTH: Cell<u32> = const { Cell::new(0) };
+    }
+
+    pub(crate) fn in_replay() -> bool {
+        REPLAY_DEPTH.with(|depth| depth.get() > 0)
+    }
+
+    pub(crate) fn enter() {
+        REPLAY_DEPTH.with(|depth| depth.set(depth.get().saturating_add(1)));
+    }
+
+    pub(crate) fn exit() {
+        REPLAY_DEPTH.with(|depth| depth.set(depth.get().saturating_sub(1)));
+    }
+
+    bucket!(
+        READ_NS,
+        READ_TOTAL_NS,
+        READ_BYTES,
+        READ_TOTAL_BYTES,
+        READ_COUNT,
+        READ_TOTAL_COUNT,
+        record_chunk_read
+    );
+    bucket!(
+        DECODE_NS,
+        DECODE_TOTAL_NS,
+        DECODE_BYTES,
+        DECODE_TOTAL_BYTES,
+        DECODE_COUNT,
+        DECODE_TOTAL_COUNT,
+        record_node_decode
+    );
+    bucket!(
+        ENCODE_NS,
+        ENCODE_TOTAL_NS,
+        ENCODE_BYTES,
+        ENCODE_TOTAL_BYTES,
+        ENCODE_COUNT,
+        ENCODE_TOTAL_COUNT,
+        record_node_encode
+    );
+    bucket!(
+        HASH_NS,
+        HASH_TOTAL_NS,
+        HASH_BYTES,
+        HASH_TOTAL_BYTES,
+        HASH_COUNT,
+        HASH_TOTAL_COUNT,
+        record_node_hash
+    );
+
+    pub(crate) fn take() -> super::RootReplayCostAttribution {
+        let bucket = |ns: &AtomicU64,
+                      total_ns: &AtomicU64,
+                      bytes: &AtomicU64,
+                      total_bytes: &AtomicU64,
+                      count: &AtomicU64,
+                      total_count: &AtomicU64| {
+            super::RootReplayCostBucket {
+                replay_nanos: ns.swap(0, Ordering::Relaxed),
+                total_nanos: total_ns.swap(0, Ordering::Relaxed),
+                replay_bytes: bytes.swap(0, Ordering::Relaxed),
+                total_bytes: total_bytes.swap(0, Ordering::Relaxed),
+                replay_count: count.swap(0, Ordering::Relaxed),
+                total_count: total_count.swap(0, Ordering::Relaxed),
+            }
+        };
+        super::RootReplayCostAttribution {
+            storage_read: bucket(
+                &READ_NS,
+                &READ_TOTAL_NS,
+                &READ_BYTES,
+                &READ_TOTAL_BYTES,
+                &READ_COUNT,
+                &READ_TOTAL_COUNT,
+            ),
+            decode: bucket(
+                &DECODE_NS,
+                &DECODE_TOTAL_NS,
+                &DECODE_BYTES,
+                &DECODE_TOTAL_BYTES,
+                &DECODE_COUNT,
+                &DECODE_TOTAL_COUNT,
+            ),
+            encode: bucket(
+                &ENCODE_NS,
+                &ENCODE_TOTAL_NS,
+                &ENCODE_BYTES,
+                &ENCODE_TOTAL_BYTES,
+                &ENCODE_COUNT,
+                &ENCODE_TOTAL_COUNT,
+            ),
+            hash: bucket(
+                &HASH_NS,
+                &HASH_TOTAL_NS,
+                &HASH_BYTES,
+                &HASH_TOTAL_BYTES,
+                &HASH_COUNT,
+                &HASH_TOTAL_COUNT,
+            ),
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct RootReplayCostBucket {
+    pub replay_nanos: u64,
+    pub total_nanos: u64,
+    pub replay_bytes: u64,
+    pub total_bytes: u64,
+    pub replay_count: u64,
+    pub total_count: u64,
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct RootReplayCostAttribution {
+    pub storage_read: RootReplayCostBucket,
+    pub decode: RootReplayCostBucket,
+    pub encode: RootReplayCostBucket,
+    pub hash: RootReplayCostBucket,
+}
+
+/// True when this build carries the per-node replay cost attribution.
+pub fn root_replay_trace_enabled() -> bool {
+    cfg!(feature = "root-replay-trace")
+}
+
+pub fn take_root_replay_cost_attribution() -> RootReplayCostAttribution {
+    #[cfg(feature = "root-replay-trace")]
+    {
+        replay_trace::take()
+    }
+    #[cfg(not(feature = "root-replay-trace"))]
+    {
+        RootReplayCostAttribution::default()
+    }
+}
+
+/// Marks the dynamic extent of one commit-root replay for cost attribution.
+pub(crate) struct RootReplayScope;
+
+impl RootReplayScope {
+    pub(crate) fn enter() -> Self {
+        #[cfg(feature = "root-replay-trace")]
+        replay_trace::enter();
+        Self
+    }
+}
+
+impl Drop for RootReplayScope {
+    fn drop(&mut self) {
+        #[cfg(feature = "root-replay-trace")]
+        replay_trace::exit();
+    }
+}
+
+#[cfg(feature = "root-replay-trace")]
+pub(crate) fn record_replay_chunk_read(nanos: u64, bytes: u64) {
+    replay_trace::record_chunk_read(nanos, bytes);
+}
+
+#[cfg(feature = "root-replay-trace")]
+pub(crate) fn record_replay_node_decode(nanos: u64, bytes: u64) {
+    replay_trace::record_node_decode(nanos, bytes);
+}
+
+#[cfg(feature = "root-replay-trace")]
+pub(crate) fn record_replay_node_encode(nanos: u64, bytes: u64) {
+    replay_trace::record_node_encode(nanos, bytes);
+}
+
+#[cfg(feature = "root-replay-trace")]
+pub(crate) fn record_replay_node_hash(nanos: u64, bytes: u64) {
+    replay_trace::record_node_hash(nanos, bytes);
+}
+
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub struct BinaryCasWriteAccounting {
     pub chunk_lookup_count: u64,

--- a/packages/lix/src/storage_bench.rs
+++ b/packages/lix/src/storage_bench.rs
@@ -521,6 +521,9 @@ pub(crate) fn record_root_replay_available_root_probe(hit: bool) {
     }
 }
 
+/// Retained so the base and candidate arms of an A/B expose the same
+/// accounting surface; the bounded availability proof performs no stagings.
+#[allow(dead_code)]
 pub(crate) fn record_root_replay_proof_staging() {
     ROOT_REPLAY_PROOF_STAGINGS.fetch_add(1, Ordering::Relaxed);
 }

--- a/packages/lix/src/tracked_state/codec.rs
+++ b/packages/lix/src/tracked_state/codec.rs
@@ -479,6 +479,17 @@ impl TrackedStateMutationBatchBuilder {
 }
 
 pub(crate) fn hash_bytes(bytes: &[u8]) -> [u8; TRACKED_STATE_HASH_BYTES] {
+    #[cfg(feature = "root-replay-trace")]
+    {
+        let start = std::time::Instant::now();
+        let digest = *blake3::hash(bytes).as_bytes();
+        crate::storage_bench::record_replay_node_hash(
+            start.elapsed().as_nanos() as u64,
+            bytes.len() as u64,
+        );
+        return digest;
+    }
+    #[cfg(not(feature = "root-replay-trace"))]
     *blake3::hash(bytes).as_bytes()
 }
 
@@ -1451,6 +1462,21 @@ const VALUE_TAIL_DISTINCT_MAX: u8 =
 /// produces sorted entries); it is asserted in debug builds but not
 /// revalidated on every release-mode read.
 pub(crate) fn encode_leaf_node_refs(entries: &[EncodedLeafEntryRef<'_>]) -> Vec<u8> {
+    #[cfg(feature = "root-replay-trace")]
+    {
+        let start = std::time::Instant::now();
+        let encoded = encode_leaf_node_refs_inner(entries);
+        crate::storage_bench::record_replay_node_encode(
+            start.elapsed().as_nanos() as u64,
+            encoded.len() as u64,
+        );
+        return encoded;
+    }
+    #[cfg(not(feature = "root-replay-trace"))]
+    encode_leaf_node_refs_inner(entries)
+}
+
+fn encode_leaf_node_refs_inner(entries: &[EncodedLeafEntryRef<'_>]) -> Vec<u8> {
     debug_assert!(
         entries.windows(2).all(|pair| pair[0].key < pair[1].key),
         "leaf entries must be strictly sorted by key"
@@ -2002,6 +2028,21 @@ pub(crate) fn encode_internal_node(children: &[ChildSummary]) -> Vec<u8> {
 }
 
 pub(crate) fn encode_internal_node_refs(children: &[ChildSummaryRef<'_>]) -> Vec<u8> {
+    #[cfg(feature = "root-replay-trace")]
+    {
+        let start = std::time::Instant::now();
+        let encoded = encode_internal_node_refs_inner(children);
+        crate::storage_bench::record_replay_node_encode(
+            start.elapsed().as_nanos() as u64,
+            encoded.len() as u64,
+        );
+        return encoded;
+    }
+    #[cfg(not(feature = "root-replay-trace"))]
+    encode_internal_node_refs_inner(children)
+}
+
+fn encode_internal_node_refs_inner(children: &[ChildSummaryRef<'_>]) -> Vec<u8> {
     assert!(
         !children.is_empty(),
         "tracked-state internal nodes must contain at least one child"
@@ -2176,6 +2217,21 @@ pub(crate) fn decode_node(bytes: &[u8]) -> Result<DecodedNode, LixError> {
 }
 
 pub(crate) fn decode_node_ref(bytes: &[u8]) -> Result<DecodedNodeRef, LixError> {
+    #[cfg(feature = "root-replay-trace")]
+    {
+        let start = std::time::Instant::now();
+        let decoded = decode_node_ref_inner(bytes);
+        crate::storage_bench::record_replay_node_decode(
+            start.elapsed().as_nanos() as u64,
+            bytes.len() as u64,
+        );
+        return decoded;
+    }
+    #[cfg(not(feature = "root-replay-trace"))]
+    decode_node_ref_inner(bytes)
+}
+
+fn decode_node_ref_inner(bytes: &[u8]) -> Result<DecodedNodeRef, LixError> {
     let (&kind, body) = bytes
         .split_first()
         .ok_or_else(|| LixError::new("LIX_ERROR_UNKNOWN", "tracked-state tree node is empty"))?;

--- a/packages/lix/src/tracked_state/commit_root_rebuild.rs
+++ b/packages/lix/src/tracked_state/commit_root_rebuild.rs
@@ -195,6 +195,26 @@ where
     Ok(plans)
 }
 
+/// Resolves the durable root a replay may resume from.
+///
+/// The commit-state manifest is the single immutable authority for a commit's
+/// tracked-state root: it is sealed atomically with the commit, keyed by that
+/// commit id, and never rewritten. `rebuild_commit_root_at_inner` already
+/// treats a rebuild that disagrees with it as a hard error rather than a
+/// repair, so the manifest — not a replay of the changelog — is what makes a
+/// root canonical. Availability therefore has exactly two obligations:
+///
+/// 1. the root pointer is live (`load_snapshot_commit_root` also proves the
+///    commit itself exists in the changelog, so an orphaned manifest cannot
+///    authorize a resume), and
+/// 2. the content-addressed chunk closure it names is physically readable, so
+///    a damaged root is never resumed from and explicit repair stays total.
+///
+/// This proof is bounded by the size of the addressed tree. It deliberately
+/// does **not** recurse through the ancestry: ordinary commits are rootless
+/// bounded-replay layouts by design, so an ancestry-wide proof can only ever
+/// succeed by reaching genesis, which makes every interval closure replay the
+/// entire history.
 async fn load_available_root<S>(
     store: &S,
     commit_id: &str,
@@ -202,62 +222,13 @@ async fn load_available_root<S>(
 where
     S: StorageAdapterRead + ?Sized,
 {
-    // Build the ancestry proof iteratively. The former boxed async recursion
-    // retained one large future frame per ancestor and could overflow the test
-    // worker stack even for otherwise valid publication paths.
-    let mut chain = Vec::new();
-    let mut current_commit_id = commit_id.to_string();
-    let mut seen = HashSet::new();
-    loop {
-        if !seen.insert(current_commit_id.clone()) {
-            return Ok(None);
-        }
-        let Some(metadata) = storage::load_snapshot_commit_root(store, &current_commit_id).await?
-        else {
-            return Ok(None);
-        };
-        if !commit_root_tree_is_readable(store, &metadata).await? {
-            return Ok(None);
-        }
-        let plan = load_commit_root_rebuild_plan(store, &current_commit_id).await?;
-        let parent_commit_id = plan.parent_commit_id;
-        chain.push((metadata, plan));
-        let Some(parent_commit_id) = parent_commit_id else {
-            break;
-        };
-        current_commit_id = parent_commit_id.to_string();
+    let Some(metadata) = storage::load_snapshot_commit_root(store, commit_id).await? else {
+        return Ok(None);
+    };
+    if !commit_root_tree_is_readable(store, &metadata).await? {
+        return Ok(None);
     }
-
-    let target_root_id = chain
-        .first()
-        .expect("available-root proof contains its requested commit")
-        .0
-        .root_id
-        .clone();
-    let mut canonical_parent = None;
-    for (metadata, plan) in chain.iter().rev() {
-        match (plan.parent_commit_id, canonical_parent.as_ref()) {
-            (Some(parent_commit_id), Some(parent_root_id)) => match metadata.parent_roots.first() {
-                Some(parent)
-                    if parent.commit_id == parent_commit_id
-                        && &parent.root_id == parent_root_id => {}
-                _ => return Ok(None),
-            },
-            (None, None) if metadata.parent_roots.is_empty() => {}
-            _ => return Ok(None),
-        }
-        let mut scratch_writes = StorageWriteSet::new();
-        let context = TrackedStateContext::new();
-        let mut writer = context.writer(store, &mut scratch_writes);
-        #[cfg(feature = "storage-benches")]
-        crate::storage_bench::record_root_replay_proof_staging();
-        let report = stage_rebuild_plan_with_writer(&mut writer, plan).await?;
-        if report.root_id != metadata.root_id {
-            return Ok(None);
-        }
-        canonical_parent = Some(metadata.root_id.clone());
-    }
-    Ok(Some(target_root_id))
+    Ok(Some(metadata.root_id))
 }
 
 async fn commit_root_tree_is_readable<S>(

--- a/packages/lix/src/tracked_state/commit_root_rebuild.rs
+++ b/packages/lix/src/tracked_state/commit_root_rebuild.rs
@@ -175,12 +175,13 @@ where
                 ),
             ));
         }
-        if !force_current
-            && load_available_root(store, &current_commit_id)
-                .await?
-                .is_some()
-        {
-            break;
+        if !force_current {
+            let available = load_available_root(store, &current_commit_id).await?;
+            #[cfg(feature = "storage-benches")]
+            crate::storage_bench::record_root_replay_available_root_probe(available.is_some());
+            if available.is_some() {
+                break;
+            }
         }
         let plan = load_commit_root_rebuild_plan(store, &current_commit_id).await?;
         let parent_commit_id = plan.parent_commit_id;
@@ -248,6 +249,8 @@ where
         let mut scratch_writes = StorageWriteSet::new();
         let context = TrackedStateContext::new();
         let mut writer = context.writer(store, &mut scratch_writes);
+        #[cfg(feature = "storage-benches")]
+        crate::storage_bench::record_root_replay_proof_staging();
         let report = stage_rebuild_plan_with_writer(&mut writer, plan).await?;
         if report.root_id != metadata.root_id {
             return Ok(None);

--- a/packages/lix/src/tracked_state/context.rs
+++ b/packages/lix/src/tracked_state/context.rs
@@ -7054,8 +7054,18 @@ mod tests {
             .expect_err("first-parent cycle should not rebuild forever");
 
         assert_eq!(error.code, LixError::CODE_INTERNAL_ERROR);
+        // Availability is proven from immutable commit-state authority instead
+        // of by walking the ancestry, so a cycle whose members are all rooted
+        // is no longer reported by the walk's cycle detector: the walk resumes
+        // at the first rooted member. It still fails closed, because replaying
+        // the cycle against that root cannot reproduce the root immutable
+        // authority names for this commit. The walk's `seen_commit_ids` guard
+        // remains the termination proof for cycles with no rooted member.
         assert!(
-            error.message.contains("first-parent cycle"),
+            error.message.contains("first-parent cycle")
+                || error
+                    .message
+                    .contains("disagrees with immutable commit authority"),
             "unexpected error message: {}",
             error.message
         );

--- a/packages/lix/src/tracked_state/context.rs
+++ b/packages/lix/src/tracked_state/context.rs
@@ -8382,6 +8382,262 @@ mod tests {
         );
     }
 
+    /// Builds `gen -> a1 -> a2 -> a3 -> b1 -> b2 -> b3` where every commit
+    /// after `gen` is a rootless bounded-replay layout, then optionally seals
+    /// `a3` as a durable interval root so a replay of the `b` interval has a
+    /// resume point.
+    async fn write_two_interval_history_for_test(
+        storage: &StorageAdapter,
+        tracked_state: &TrackedStateContext,
+        seal_midpoint: bool,
+    ) {
+        write_root_for_test(
+            storage,
+            tracked_state,
+            "gen",
+            None,
+            &[row_with_value("entity-gen", "gen-change", "gen", "gen")],
+        )
+        .await
+        .expect("genesis root should write");
+        let mut parent = "gen".to_owned();
+        for commit in ["a1", "a2", "a3"] {
+            write_rootless_commit_for_test(
+                storage,
+                commit,
+                &parent,
+                &[
+                    row_with_value(
+                        &format!("entity-{commit}"),
+                        &format!("{commit}-change"),
+                        commit,
+                        commit,
+                    ),
+                    // Rewrite a shared key in every commit so the interval is
+                    // order sensitive rather than a disjoint insert stream.
+                    row_with_value("entity-shared", &format!("{commit}-shared"), commit, commit),
+                ],
+            )
+            .await;
+            parent = commit.to_owned();
+        }
+        if seal_midpoint {
+            seal_rooted_commit_for_test(storage, tracked_state, "a3").await;
+        }
+        for commit in ["b1", "b2", "b3"] {
+            write_rootless_commit_for_test(
+                storage,
+                commit,
+                &parent,
+                &[
+                    row_with_value(
+                        &format!("entity-{commit}"),
+                        &format!("{commit}-change"),
+                        commit,
+                        commit,
+                    ),
+                    row_with_value("entity-shared", &format!("{commit}-shared"), commit, commit),
+                ],
+            )
+            .await;
+            parent = commit.to_owned();
+        }
+    }
+
+    /// Publishes the canonical root for `commit_id` into its immutable
+    /// commit-state authority, turning a rootless commit into an interval root.
+    async fn seal_rooted_commit_for_test(
+        storage: &StorageAdapter,
+        tracked_state: &TrackedStateContext,
+        commit_id: &str,
+    ) {
+        let read = storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("seal read should open");
+        let plans = crate::tracked_state::commit_root_rebuild::load_rebuild_plans_to_nearest_available_root(
+            &read,
+            commit_id,
+            true,
+        )
+        .await
+        .expect("seal plans should load");
+        let mut writes = storage.new_write_set();
+        let mut writer = tracked_state.writer(&read, &mut writes);
+        for plan in plans.iter().rev() {
+            crate::tracked_state::commit_root_rebuild::stage_rebuild_plan_with_writer(
+                &mut writer, plan,
+            )
+            .await
+            .expect("seal root should stage");
+        }
+        let typed_commit_id = CommitId::for_test_label(commit_id);
+        let snapshot_root = writer
+            .staged_commit_roots()
+            .find(|root| root.commit_id == typed_commit_id)
+            .cloned()
+            .expect("sealed root should be staged");
+        drop(writer);
+        let mut manifest = storage::load_commit_state_manifest(&read, typed_commit_id)
+            .await
+            .expect("sealed manifest should load")
+            .expect("sealed manifest should exist");
+        manifest.replay_debt = crate::tracked_state::CommitStateReplayDebt::default();
+        manifest.snapshot_root = Some(Box::new(snapshot_root));
+        storage::stage_resealed_commit_state_manifest_for_test(&mut writes, &manifest)
+            .expect("sealed authority should reseal");
+        drop(read);
+        storage
+            .commit_write_set(writes, StorageWriteOptions::default())
+            .await
+            .expect("sealed root should commit");
+    }
+
+    /// Replays `commit_id` the way the commit path closes a rootless interval
+    /// and returns `(replay-set size, resulting root)`.
+    async fn replay_root_for_test(
+        storage: &StorageAdapter,
+        tracked_state: &TrackedStateContext,
+        commit_id: &str,
+    ) -> (usize, TrackedStateRootId) {
+        let read = storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("replay read should open");
+        let plans = crate::tracked_state::commit_root_rebuild::load_rebuild_plans_to_nearest_available_root(
+            &read,
+            commit_id,
+            true,
+        )
+        .await
+        .expect("replay plans should load");
+        let mut writes = storage.new_write_set();
+        let mut writer = tracked_state.writer(&read, &mut writes);
+        let mut report = None;
+        for plan in plans.iter().rev() {
+            report = Some(
+                crate::tracked_state::commit_root_rebuild::stage_rebuild_plan_with_writer(
+                    &mut writer,
+                    plan,
+                )
+                .await
+                .expect("replay root should stage"),
+            );
+        }
+        (
+            plans.len(),
+            report.expect("replay stages at least one root").root_id,
+        )
+    }
+
+    /// The resume point is the previous interval root named by immutable
+    /// commit-state authority. Resuming from it must produce exactly the root
+    /// a from-genesis replay of the same history produces.
+    #[tokio::test]
+    async fn resumed_interval_root_is_identical_to_from_genesis_root() {
+        let tracked_state = TrackedStateContext::new();
+
+        let from_genesis = StorageAdapter::new(Memory::new());
+        write_two_interval_history_for_test(&from_genesis, &tracked_state, false).await;
+        let (genesis_plans, genesis_root) =
+            replay_root_for_test(&from_genesis, &tracked_state, "b3").await;
+
+        let resumed = StorageAdapter::new(Memory::new());
+        write_two_interval_history_for_test(&resumed, &tracked_state, true).await;
+        let (resumed_plans, resumed_root) = replay_root_for_test(&resumed, &tracked_state, "b3").await;
+
+        assert_eq!(
+            genesis_plans, 6,
+            "without a sealed interval root the replay set is the whole history"
+        );
+        assert_eq!(
+            resumed_plans, 3,
+            "a sealed interval root bounds the replay set to its own interval"
+        );
+        assert_eq!(
+            resumed_root, genesis_root,
+            "resumed replay must produce a byte-identical state root"
+        );
+    }
+
+    /// Teeth for the assertion above: pointing the resume point at a readable
+    /// but wrong root must change the resulting state root, so a silently bad
+    /// resume point cannot pass the byte-identity check.
+    #[tokio::test]
+    async fn byte_identical_root_check_rejects_a_broken_resume_point() {
+        let tracked_state = TrackedStateContext::new();
+
+        let from_genesis = StorageAdapter::new(Memory::new());
+        write_two_interval_history_for_test(&from_genesis, &tracked_state, false).await;
+        let (_, genesis_root) = replay_root_for_test(&from_genesis, &tracked_state, "b3").await;
+
+        let broken = StorageAdapter::new(Memory::new());
+        write_two_interval_history_for_test(&broken, &tracked_state, true).await;
+        // Repoint `a3`'s immutable root pointer at `gen`'s root: present,
+        // readable, content-addressed — and wrong.
+        let read = broken
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("broken resume read should open");
+        let genesis_metadata = storage::load_snapshot_commit_root(&read, "gen")
+            .await
+            .expect("genesis root metadata should load")
+            .expect("genesis root metadata should exist");
+        let mut manifest =
+            storage::load_commit_state_manifest(&read, CommitId::for_test_label("a3"))
+                .await
+                .expect("midpoint manifest should load")
+                .expect("midpoint manifest should exist");
+        let mut broken_root = *manifest
+            .snapshot_root
+            .clone()
+            .expect("midpoint is sealed by the fixture");
+        broken_root.root_id = genesis_metadata.root_id.clone();
+        manifest.snapshot_root = Some(Box::new(broken_root));
+        let mut writes = broken.new_write_set();
+        storage::stage_resealed_commit_state_manifest_for_test(&mut writes, &manifest)
+            .expect("broken authority should reseal");
+        drop(read);
+        broken
+            .commit_write_set(writes, StorageWriteOptions::default())
+            .await
+            .expect("broken resume point should commit");
+
+        let (broken_plans, broken_root_id) = replay_root_for_test(&broken, &tracked_state, "b3").await;
+        assert_eq!(broken_plans, 3, "the broken pointer is still readable");
+        assert_ne!(
+            broken_root_id, genesis_root,
+            "a wrong resume point must not reproduce the canonical state root"
+        );
+    }
+
+    /// A resume point whose chunk closure is damaged must not be resumed from.
+    /// Repair stays total: the walk continues past it and the replay rebuilds
+    /// the canonical root from the changelog.
+    #[tokio::test]
+    async fn damaged_resume_point_falls_back_to_total_replay() {
+        let tracked_state = TrackedStateContext::new();
+
+        let from_genesis = StorageAdapter::new(Memory::new());
+        write_two_interval_history_for_test(&from_genesis, &tracked_state, false).await;
+        let (_, genesis_root) = replay_root_for_test(&from_genesis, &tracked_state, "b3").await;
+
+        let damaged = StorageAdapter::new(Memory::new());
+        write_two_interval_history_for_test(&damaged, &tracked_state, true).await;
+        delete_root_chunk_for_test(&damaged, "a3").await;
+
+        let (damaged_plans, damaged_root) =
+            replay_root_for_test(&damaged, &tracked_state, "b3").await;
+        assert_eq!(
+            damaged_plans, 6,
+            "a damaged interval root must not bound the replay set"
+        );
+        assert_eq!(
+            damaged_root, genesis_root,
+            "total replay must still produce the canonical state root"
+        );
+    }
+
     async fn stored_tree_chunk_hashes_for_test(
         storage: &StorageAdapter,
     ) -> HashSet<[u8; crate::tracked_state::types::TRACKED_STATE_HASH_BYTES]> {

--- a/packages/lix/src/tracked_state/storage.rs
+++ b/packages/lix/src/tracked_state/storage.rs
@@ -12181,6 +12181,22 @@ pub(crate) async fn read_chunk(
     store: &(impl StorageAdapterRead + ?Sized),
     hash: &[u8; TRACKED_STATE_HASH_BYTES],
 ) -> Result<Option<Bytes>, LixError> {
+    #[cfg(feature = "root-replay-trace")]
+    {
+        let start = std::time::Instant::now();
+        let bytes = get_one(store, TRACKED_STATE_TREE_CHUNK_SPACE, hash.to_vec()).await;
+        let read_bytes = bytes
+            .as_ref()
+            .ok()
+            .and_then(|value| value.as_ref())
+            .map_or(0, |value| value.len() as u64);
+        crate::storage_bench::record_replay_chunk_read(
+            start.elapsed().as_nanos() as u64,
+            read_bytes,
+        );
+        return bytes;
+    }
+    #[cfg(not(feature = "root-replay-trace"))]
     get_one(store, TRACKED_STATE_TREE_CHUNK_SPACE, hash.to_vec()).await
 }
 

--- a/packages/lix/src/transaction/commit.rs
+++ b/packages/lix/src/transaction/commit.rs
@@ -5717,16 +5717,30 @@ async fn stage_tracked_roots(
     }
     let mut tracked_writer = tracked_state.writer(read, writes);
     let mut staged_rebuild_plan_ids = BTreeSet::new();
+    #[cfg(feature = "storage-benches")]
+    let _replay_scope = (!durable_root_rebuild_parents.is_empty())
+        .then(crate::storage_bench::RootReplayScope::enter);
     for parent_commit_id in durable_root_rebuild_parents {
+        #[cfg(feature = "storage-benches")]
+        let plan_load_start = std::time::Instant::now();
         let plans = crate::tracked_state::load_rebuild_plans_to_nearest_available_root(
             read,
             &parent_commit_id.to_string(),
             true,
         )
         .await?;
+        #[cfg(feature = "storage-benches")]
+        {
+            crate::storage_bench::record_root_replay_plan_load_nanos(
+                plan_load_start.elapsed().as_nanos() as u64,
+            );
+            crate::storage_bench::record_root_replay_boundary(plans.len());
+        }
         let all_new = plans
             .iter()
             .all(|plan| !staged_rebuild_plan_ids.contains(&plan.commit_id));
+        #[cfg(feature = "storage-benches")]
+        let stage_start = std::time::Instant::now();
         if all_new
             && crate::tracked_state::try_stage_collapsed_rebuild_plans_with_writer(
                 &mut tracked_writer,
@@ -5735,6 +5749,13 @@ async fn stage_tracked_roots(
             .await?
             .is_some()
         {
+            #[cfg(feature = "storage-benches")]
+            {
+                crate::storage_bench::record_root_replay_plan_staged();
+                crate::storage_bench::record_root_replay_stage_nanos(
+                    stage_start.elapsed().as_nanos() as u64,
+                );
+            }
             // A collapsed replay stages only its terminal root. Intermediate
             // plan IDs remain unstaged so another rebuild parent sharing this
             // suffix can independently collapse against immutable authority.
@@ -5743,10 +5764,16 @@ async fn stage_tracked_roots(
         }
         for plan in plans.iter().rev() {
             if staged_rebuild_plan_ids.insert(plan.commit_id) {
+                #[cfg(feature = "storage-benches")]
+                crate::storage_bench::record_root_replay_plan_staged();
                 crate::tracked_state::stage_rebuild_plan_with_writer(&mut tracked_writer, plan)
                     .await?;
             }
         }
+        #[cfg(feature = "storage-benches")]
+        crate::storage_bench::record_root_replay_stage_nanos(
+            stage_start.elapsed().as_nanos() as u64
+        );
     }
     let empty_certified_replacement_markers = BTreeSet::new();
     for root in tracked_roots_parent_first(tracked_roots)? {


### PR DESCRIPTION
## What changed

Closing a rootless replay interval walked first-parent ancestors until it found a commit whose tracked-state root was "available". Availability was proven by `load_available_root`, which walked the **entire ancestry to genesis**, required every ancestor to carry a durable root, and **re-derived each ancestor's root from the changelog** to compare it against stored metadata.

Ordinary commits are rootless bounded-replay layouts by design (`COMMIT_STATE_MAX_REPLAY_DEPTH = 32`). To re-derive commit *K*'s root you need commit *K-1*'s root, which by construction does not exist. **The two designs are mutually incompatible: the proof can only ever succeed by reaching genesis, so every interval closure replayed the whole history.** Measured: the replay set at each boundary is 32, 65, 98, 131, … — one plan per commit since genesis.

Availability is now proven from the **commit-state manifest**, which is already the single immutable authority for a commit's tracked-state root: sealed atomically with the commit, keyed by that commit id, never rewritten, and already treated as ground truth by `rebuild_commit_root_at_inner` (a rebuild that disagrees with it is a hard error, not a repair). The proof is:

1. `load_snapshot_commit_root` — the root pointer is present **and** the commit exists in the changelog, so an orphaned manifest cannot authorize a resume; and
2. `commit_root_tree_is_readable` — a full scan of the addressed tree, so every chunk under the resume point is present and hash-verified.

**Removed:** the recursive ancestry walk, its per-ancestor root re-derivation, and its parent-root linkage walk (`commit_root_rebuild.rs`, −45 lines net).

### Why this is a cut, not a shortcut

The engine had **two authorities** for one fact — a commit's tracked-state root — the manifest and a from-genesis changelog replay, reconciled on every 33rd commit at O(n²) cost. This deletes one of them. Layout invariant 1 says consolidations must *delete* one authority, not relocate code; that is exactly what this is.

## Growth curve — deterministic counters, 1 rep, `expaa_replay_scope`, RocksDB, 10 rows/commit

| commits | boundaries | replay set at last boundary | total plans replayed (base) | total (cand) |
|---:|---:|---:|---:|---:|
| 200 | 6 | 197 | 687 | 192 |
| 500 | 15 | 494 | 3,945 | 480 |
| 1,000 | 30 | 989 | 15,315 | 960 |
| 2,000 | 60 | 1,979 | 60,330 | 1,920 |
| 5,000 | 151 | 4,982 | 378,557 | 4,832 |

Base total plans scale as N² exactly (×6.25 for ×2.5 in N, ×3.94 for ×2). Candidate replay set is **flat at 32** — the interval depth — at every scale, so total plans become linear.

## Per-replayed-commit cost attribution (N=1,000, `--features root-replay-trace`)

| phase | replay ms | share of replay | % of *all* tracked-state tree CPU spent inside replay | replay bytes |
|---|---:|---:|---:|---:|
| plan load (commit record + packed commit-delta members) | 1,167.0 | 83.1% | — | — |
| decode | 98.7 | 7.0% | 95.2% | 45.4 MB |
| hash | 74.8 | 5.3% | 100.0% | 46.2 MB |
| storage read (tree chunks) | 51.0 | 3.6% | 100.0% | 41.7 MB |
| encode | 13.7 | 1.0% | 81.3% | 4.5 MB |

**Plan loading dominates at 83%** — 76 µs of storage read + decode per replayed ancestor. Re-encode is only 1.0% of replay cost: the collapse path issues one `stage_commit_root` over unique keys, so the tree is mostly re-*read* and re-*hashed*, not re-encoded. Essentially all tracked-state tree CPU in the whole run (95–100% of decode/hash/read) sits inside root replay.

## Is from-genesis replay load-bearing?

**No — but it was doing a second job.** It is not needed to *derive* the root: the manifest owns that, and `stage_commit_root` already resolves a durable parent root from it. It was, however, acting as a continuous from-genesis integrity audit of every historical root, and as an implicit self-heal (a missing chunk got re-staged at the next boundary).

A previous attempt at this optimization (`30f7c786f`) was rolled back (`b4961583a`, *"can publish roots that explicit changelog replay cannot reproduce"*) because it validated only the **left spine** of the resume root. This change keeps the **full** readable-closure scan, so a damaged root is refused and repair stays total.

**What proves the resume point current:**
- the commit-state manifest is immutable per-commit authority, sealed in the same write set as the commit (invariant 4), so a root pointer cannot be stale — commits are never rewritten;
- `load_snapshot_commit_root` additionally requires the commit to be live in the changelog;
- every chunk read is content-addressed and hash-verified, and the full-tree scan forces all of them before the root is accepted;
- the rebuild still validates its result against the manifest.

**What is no longer caught at interval closure (explicit regression):** a manifest whose `snapshot_root` is present, readable, and internally consistent but *semantically wrong*. That state is unreachable through any engine write path; it requires corruption of the manifest itself. `byte_identical_root_check_rejects_a_broken_resume_point` constructs exactly that state and shows it yields a different root — i.e. it is detected by the test, not by production code.

**Behaviour change:** a first-parent cycle whose members are all rooted now fails closed with *"disagrees with immutable commit authority"* instead of *"first-parent cycle"* (the walk resumes at the first rooted member rather than revisiting). `seen_commit_ids` remains the termination proof for cycles with no rooted member. `explicit_rebuild_errors_on_first_parent_cycle` updated to accept either diagnostic.

## Do checkpoints already bound this?

Measured explicitly, since `create_checkpoint` re-homes live rows and parents the previous checkpoint directly. **Partly — they bound the replay set, not the proof.**

| checkpoint interval | result |
|---|---|
| every 10 commits (< depth 32) | **0 boundaries** at N=500/1,000/2,000 — the interval never closes, both arms identical. This lane is the null control below. |
| every 50 commits (> depth 32) | boundaries occur, and the replay set is **32 in both arms** — checkpoints do bound it. But base's ancestry proof still re-derives every rooted ancestor back to genesis. |

`ancestry_proof_stagings` at checkpoint-every-50 (base): **55 / 210 / 820** for 10 / 20 / 40 boundaries — triangular, i.e. quadratic in checkpoint count. Candidate: **0**.

| N (ckpt every 50) | plan_load ms base → cand | replay share of wall base → cand | worst commit ms base → cand |
|---:|---|---|---|
| 500 | 139.9 → 26.6 | 9.7% → 2.5% | 38.95 → 10.41 (−73%) |
| 1,000 | 636.4 → 122.7 | 18.0% → 5.0% | 72.28 → 15.82 (−78%) |
| 2,000 | 2,990.9 → 441.1 | 32.4% → 8.0% | 182.08 → 27.59 (−85%) |

So the prize survives checkpointing: with checkpoints the O(n²) term simply moves from the replay set into the availability proof.

## A/B — primary metric, worst commit latency at the burst boundary

Machine `hetzner-cpx62-IV`, RocksDB, 3 interleaved reps with rotated arm order, `expaa_replay_scope <N> 10`.

| N | base raw (ms) | base median | cand raw (ms) | cand median | delta |
|---:|---|---:|---|---:|---:|
| 1,000 | 115.06 / 133.78 / 117.76 | 117.76 | 22.65 / 23.36 / 21.03 | 22.65 | **−80.8%** |
| 2,000 | 319.04 / 411.31 / 310.54 | 319.04 | 37.72 / 40.65 / 66.55 | 40.65 | **−87.3%** |
| 5,000 | 1778.77 / 2738.24 / 2390.77 | 2390.77 | 60.80 / 63.51 / 63.69 | 63.51 | **−97.3%** |

Arm ranges are disjoint at every scale, which is the runbook's condition for accepting 3 reps.

Whole-run wall time (medians): 5,425 → 4,076 ms (−24.9%) at N=1,000; 15,199 → 13,725 ms (−9.7%) at N=2,000; 194,409 → 40,977 ms (**−78.9%**) at N=5,000.

**Null control.** The `checkpoint_every=10` lane executes zero boundaries, so the changed code never runs; whatever spread it shows is the floor. Wall time base → cand: 1,494.9 → 1,396.4 (−6.6%), 3,064.5 → 2,956.9 (−3.5%), 8,331.2 → 6,291.3 (−24.5%) at N=500/1,000/2,000. **Wall-time deltas under roughly ±25% at N=2,000 are not resolvable by this harness**; the −81%…−97% latency deltas and the deterministic counter reductions are far outside it.

## Guards

`tracked_state_crud`, RocksDB `sql_session` write ids (3 interleaved reps, rotated, medians in ms):

| id | base | cand | delta |
|---|---:|---:|---:|
| smoke/insert_all_rows/1k | 10.347 | 8.347 | −19.3% |
| smoke/update_all_rows/1k | 2.826 | 2.565 | −9.2% |
| smoke/update_one_by_pk/1k | 0.870 | 0.885 | +1.7% |
| smoke/delete_all_rows/1k | 0.570 | 0.719 | +26.1% ⚠ |
| real_workload/insert_all_rows/10k | 42.680 | 41.334 | −3.2% |
| real_workload/update_all_rows/10k | 12.853 | 12.312 | −4.2% |
| real_workload/update_one_by_pk/10k | 1.1615 | 1.1795 | +1.5% |
| real_workload/delete_all_rows/10k | 0.8072 | 0.8603 | +6.6% |

`delete_all_rows/1k` raw ranges are base 0.541–0.969 ms vs cand 0.451–0.760 ms — fully overlapping, and the fixture executes no boundary closure. Not resolvable, not a regression signal.

`diff_commands` — `revert_100_of_1000` looked like it moved at 3 reps (+8.7%), so it was escalated to **9 reps** and collapsed:

| id | reps | base median | cand median | delta |
|---|---:|---:|---:|---:|
| revert_100_of_1000 | 9 | 9.3689 | 9.3364 | −0.3% |
| apply_100_of_1000 | 9 | 9.3147 | 8.7552 | −6.0% |
| working_diff_1000 | 3 | 3.5265 | 3.5077 | −0.5% |
| partial_checkpoint_500_of_1000 | 3 | 20.376 | 20.295 | −0.4% |

`undo_redo` (3 reps, all named lanes): every lane within the null-control band, no directional pattern (ordinary_update/1000 −13.9%, undo/1000 −9.5%, redo/1000 +7.4%, all /10 lanes within ±1.3%).

**Settled bytes** — `space_growth` (200 commits, deterministic, 1 rep). Every space byte-identical except: `tracked_state.tree_chunk` 88,570 → 88,490 B (−0.09%), `tracked_state.commit_mutation_catalog` 196,779 → 197,105 B (+0.17%), `tracked_state.change_locator` 560 → 674 B (+114 B, one-time; `bytes_per_commit` 0.0 in both arms). This is expected: PR #1318 already removed the redundant *writes* this replay caused, so what is left to remove is the redundant *work*.

`gc.rs` was not touched.

## Regressions and trade-offs

- Nothing measurable regressed. The two positive guard deltas (`delete_all_rows` lanes) sit inside overlapping raw ranges on fixtures that never close an interval.
- The integrity trade-off is stated above and is the substantive cost of this change: the periodic from-genesis audit of historical roots is gone. Fail-closed behaviour on *damaged* roots is preserved by the full-closure scan, and is regression-tested.
- One O(state) term remains per boundary — the readable-closure scan of the resume point (visible as candidate `plan_load_ms` still growing: 122.7 → 441.1 ms from N=1,000 → 2,000 with checkpoints). It is deliberate: it is what keeps repair total. It replaces an O(history × state) term.

## Layout invariants checklist

1. **Single authority.** Improved. This *deletes* an authority: the changelog re-derivation of a fact the commit-state manifest owns. No new writer, no new materialization, no new index.
2. **Commit canonicality.** Unchanged. One canonical state root per commit, carried by that commit's own sealed manifest; traversal still reads commit records and stores no parallel graph.
3. **Derived views are caches.** Unchanged. No derived view added or promoted; tracked-state chunks remain content-addressed state, not a cache.
4. **Atomic publication.** Unchanged. State root, commit record, derived-view update and ref move still publish in one write set; this only changes how far back the write set's replay reaches.
5. **GC from refs.** Unchanged. `gc.rs` untouched (#1319); reachability still starts at refs.
6. **SQL reads canonical records.** Unchanged.

## Correctness gate

Re-run at **CI scope** (not `-p lix`) on `01f423668`, this branch merged with `main` @ `d89ab8681`, machine `hetzner-cpx62-IV`:

```
cargo test --profile test --workspace --exclude lix_benchmarks --all-features --no-fail-fast
cargo test --profile test -p lix_benchmarks --features storage-benches,slatedb --no-fail-fast
```

Every target passes except three, **all three of which reproduce identically on unmodified `main` @ `d89ab8681`**:

| target | failure | on `main`? |
|---|---|---|
| `lix-server-protocol` (lib) | `cancelled_branch_switch_reports_terminal_storage_after_caller_cancellation` | yes |
| `lix_benchmarks` `corruption_recovery_qualification` | `rocksdb_/slatedb_cold_reopen_corruption_qualification` | yes |
| `lix_benchmarks` `tracked_state_crud_public_result` | stack overflow in `typed_olap_shapes_*` (debug profile) | yes |

Highlights of what *does* pass at this scope, none of which the original `-p lix` gate exercised: `lix-storage-filesystem` 19, `lix-storage-rocksdb` 3 + 15, `lix-storage-slatedb` 65 + 11, `lix_cli` 67, `lix_tests` e2e 75 + `rust_sdk_api` 39, all five plugins, all doc-tests, plus `lix` 2,084 + 854 as before.

### Root cause of the first two (belongs to #1329, not this PR)

`76834a1c9` (#1329) renamed the branch-control space `branch.head_control.v10` → `v11` in `packages/lix/src/branch/control.rs:22` and left two **test-side string literals** behind:

- `packages/server-protocol/src/lib.rs:4416` — the cancellation test's storage wrapper intercepts on `request.space.name == "branch.head_control.v10"`, which now matches nothing, so the gate never trips and the 1s wait expires deterministically at ~1.06s.
- `packages/engine-benchmarks/tests/corruption_recovery_qualification.rs:20` — `BRANCH_CONTROL_SPACE = "branch.head_control.v10"`, so `storage_space_by_name` panics `space name should exist`.

Neither file is touched by this PR (`git diff origin/main...HEAD -- packages/server-protocol packages/engine-benchmarks/tests` is empty). Verified by experiment on unmodified `main`: flipping only those two literals to `v11` turns all three of those failures green (`cancelled_branch_switch… ok`; `rocksdb_/slatedb_cold_reopen_corruption_qualification … ok`), and the scratch edit was reverted.

**`switch_branch` did not lose its authoritative branch-control read.** The read still happens; the test harness stopped matching it. The stack overflow in `typed_olap_shapes_*` is a separate pre-existing debug-profile issue on `main`.

### Original gate (unchanged, still green)

On `ee484039e` (merged with `main`), machine `hetzner-cpx62-IV`:

- `cargo check --workspace` — clean
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` — clean
- `cargo test -p lix --all-features` — **2,084 + 848 + 18 passed, 0 failed**
- `cargo check -p lix_js_sdk --target wasm32-unknown-unknown` — clean (3 pre-existing dead-code warnings, unrelated)

New tests in `tracked_state::context::tests`:
- `resumed_interval_root_is_identical_to_from_genesis_root` — same history built twice, once with a sealed interval root and once without; asserts replay set 3 vs 6 **and** that the resulting roots are identical.
- `byte_identical_root_check_rejects_a_broken_resume_point` — repoints the resume marker at a readable-but-wrong root; asserts the resulting root differs, so the identity check above is not vacuous.
- `damaged_resume_point_falls_back_to_total_replay` — deletes the resume root's chunk; asserts the replay set widens back to the full history and still produces the canonical root.

## Bench commands

```
cargo build -p lix_benchmarks --release --features storage-benches,slatedb --example expaa_replay_scope
./target/release/examples/expaa_replay_scope <commits> 10 [checkpoint_every]
cargo build -p lix_benchmarks --release --features root-replay-trace,slatedb --example expaa_replay_scope   # cost attribution
tracked_state_crud --bench 'sql_session/lix_rocksdb/.*(insert_all_rows|update_all_rows|update_one_by_pk|delete_all_rows)'
diff_commands --bench '(revert_100_of_1000|apply_100_of_1000)'
undo_redo --bench
cargo run -p lix_benchmarks --release --features storage-benches,slatedb --example space_growth
```
