### PR TITLE
refactor(plugin): stamp file-scoped plugin rows with their file's lane

### DIFF
--- a/packages/lix/src/plugin/create_context.rs
+++ b/packages/lix/src/plugin/create_context.rs
@@ -301,8 +301,9 @@ pub(crate) fn reserve_create_row(
     bound: BoundCreateContext,
     file_id: &str,
     branch_id: &str,
+    untracked: bool,
 ) -> Result<Option<TransactionWriteRow>, LixError> {
-    validate_create_reservation(existing, bound, file_id, branch_id)?;
+    validate_create_reservation(existing, bound, file_id, branch_id, untracked)?;
     if existing.is_some() {
         return Ok(None);
     }
@@ -321,6 +322,7 @@ pub(crate) fn reserve_create_row(
         Some(snapshot),
         file_id,
         branch_id,
+        untracked,
     )?))
 }
 
@@ -336,12 +338,13 @@ pub(crate) fn validate_create_reservation(
     bound: BoundCreateContext,
     file_id: &str,
     branch_id: &str,
+    untracked: bool,
 ) -> Result<(), LixError> {
     let Some(row) = existing else {
         return Ok(());
     };
     let key = bound.reservation_key();
-    validate_reservation_identity(row, &key, file_id, branch_id)?;
+    validate_reservation_identity(row, &key, file_id, branch_id, untracked)?;
     let snapshot = row
         .snapshot_content
         .as_deref()
@@ -398,11 +401,12 @@ pub(crate) fn reservation_tombstone_row(
     key: &str,
     file_id: &str,
     branch_id: &str,
+    untracked: bool,
 ) -> Result<TransactionWriteRow, LixError> {
     if !is_reservation_key(key) {
         return Err(invalid_id("invalid create reservation key"));
     }
-    reservation_row(key.to_string(), None, file_id, branch_id)
+    reservation_row(key.to_string(), None, file_id, branch_id, untracked)
 }
 
 pub(crate) fn is_reservation_key(key: &str) -> bool {
@@ -415,6 +419,7 @@ fn reservation_row(
     snapshot: Option<JsonValue>,
     file_id: &str,
     branch_id: &str,
+    untracked: bool,
 ) -> Result<TransactionWriteRow, LixError> {
     if file_id.is_empty() || branch_id.is_empty() || branch_id == crate::GLOBAL_BRANCH_ID {
         return Err(invalid_id(
@@ -435,7 +440,7 @@ fn reservation_row(
         global: false,
         change_id: None,
         commit_id: None,
-        untracked: false,
+        untracked,
         branch_id: branch_id.into(),
     })
 }
@@ -445,17 +450,18 @@ fn validate_reservation_identity(
     key: &str,
     file_id: &str,
     branch_id: &str,
+    untracked: bool,
 ) -> Result<(), LixError> {
     if row.schema_key != KEY_VALUE_SCHEMA_KEY
         || row.entity_pk.as_single_string().ok() != Some(key)
         || row.file_id.as_deref() != Some(file_id)
         || row.branch_id.as_ref() != branch_id
         || row.global
-        || row.untracked
+        || row.untracked != untracked
         || row.deleted
     {
         return Err(invalid_id(format!(
-            "create reservation '{key}' has invalid tracked file scope"
+            "create reservation '{key}' has invalid file scope"
         )));
     }
     Ok(())
@@ -583,9 +589,15 @@ mod tests {
     }
 
     fn row_for(bound: BoundCreateContext) -> MaterializedLiveStateRow {
-        let write = reserve_create_row(None, bound, "01920000-0000-7000-8000-0000000000a2", "main")
-            .expect("reserve")
-            .expect("new row");
+        let write = reserve_create_row(
+            None,
+            bound,
+            "01920000-0000-7000-8000-0000000000a2",
+            "main",
+            false,
+        )
+        .expect("reserve")
+        .expect("new row");
         MaterializedLiveStateRow {
             entity_pk: write.entity_pk.expect("pk"),
             schema_key: write.schema_key.into(),
@@ -718,7 +730,8 @@ mod tests {
                 Some(&existing),
                 first,
                 "01920000-0000-7000-8000-0000000000a2",
-                "main"
+                "main",
+                false
             )
             .expect("same proof")
             .is_none()
@@ -732,6 +745,7 @@ mod tests {
             collision,
             "01920000-0000-7000-8000-0000000000a2",
             "main",
+            false,
         )
         .expect_err("different proof must fail");
         assert_eq!(error.code, LixError::CODE_CONSTRAINT_VIOLATION);
@@ -750,6 +764,7 @@ mod tests {
             collision,
             "01920000-0000-7000-8000-0000000000a2",
             "main",
+            false,
         )
         .expect_err("preflight must reject a reused seed before entering the guest");
         assert_eq!(error.code, LixError::CODE_CONSTRAINT_VIOLATION);
@@ -771,10 +786,16 @@ mod tests {
         assert!(validation.requires_reservation);
         assert!(validation.existing_authorities.is_empty());
         assert_eq!(
-            reserve_create_row(None, cold, "01920000-0000-7000-8000-0000000000a2", "main")
-                .expect("cold reservation")
-                .into_iter()
-                .count(),
+            reserve_create_row(
+                None,
+                cold,
+                "01920000-0000-7000-8000-0000000000a2",
+                "main",
+                false
+            )
+            .expect("cold reservation")
+            .into_iter()
+            .count(),
             1,
         );
 
@@ -796,10 +817,16 @@ mod tests {
         assert!(validation.requires_reservation);
         assert!(validation.existing_authorities.is_empty());
         assert_eq!(
-            reserve_create_row(None, edit, "01920000-0000-7000-8000-0000000000a2", "main")
-                .expect("insert reservation")
-                .into_iter()
-                .count(),
+            reserve_create_row(
+                None,
+                edit,
+                "01920000-0000-7000-8000-0000000000a2",
+                "main",
+                false
+            )
+            .expect("insert reservation")
+            .into_iter()
+            .count(),
             1,
         );
     }

--- a/packages/lix/src/plugin/registry.rs
+++ b/packages/lix/src/plugin/registry.rs
@@ -396,11 +396,12 @@ impl PluginRegistry {
     }
 
     pub(crate) fn write_row(&self, branch_id: &str) -> Result<TransactionWriteRow, LixError> {
-        tracked_key_value_write_row(
+        plugin_key_value_write_row(
             PLUGIN_REGISTRY_KEY,
             None,
             Some(self.to_snapshot()?),
             branch_id,
+            false,
         )
     }
 
@@ -728,24 +729,30 @@ impl PluginFileOwner {
         Self::new(file_id, owner_value.plugin_key, owner_value.schema_keys)
     }
 
-    pub(crate) fn write_row(&self, branch_id: &str) -> Result<TransactionWriteRow, LixError> {
-        tracked_key_value_write_row(
+    pub(crate) fn write_row(
+        &self,
+        branch_id: &str,
+        untracked: bool,
+    ) -> Result<TransactionWriteRow, LixError> {
+        plugin_key_value_write_row(
             PLUGIN_OWNER_KEY,
             Some(self.file_id.clone()),
             Some(self.to_snapshot()?),
             branch_id,
+            untracked,
         )
     }
 
     pub(crate) fn delete_row(
         file_id: impl Into<String>,
         branch_id: &str,
+        untracked: bool,
     ) -> Result<TransactionWriteRow, LixError> {
         let file_id = file_id.into();
         if file_id.is_empty() {
             return Err(invalid_registry("plugin owner file_id must not be empty"));
         }
-        tracked_key_value_write_row(PLUGIN_OWNER_KEY, Some(file_id), None, branch_id)
+        plugin_key_value_write_row(PLUGIN_OWNER_KEY, Some(file_id), None, branch_id, untracked)
     }
 
     fn validate(&self) -> Result<(), LixError> {
@@ -1164,11 +1171,17 @@ fn decode_key_value_snapshot<'a>(
     })
 }
 
-fn tracked_key_value_write_row(
+/// Builds a reserved `lix_key_value` row for plugin bookkeeping.
+///
+/// File-scoped plugin rows must be written in the same durability lane as the
+/// file they describe, so the lane is a parameter rather than a constant. Rows
+/// that are not file-scoped (the branch's plugin registry) are always tracked.
+fn plugin_key_value_write_row(
     key: &str,
     file_id: Option<String>,
     snapshot: Option<JsonValue>,
     branch_id: &str,
+    untracked: bool,
 ) -> Result<TransactionWriteRow, LixError> {
     validate_branch_local_scope(branch_id)?;
     let snapshot = snapshot
@@ -1186,7 +1199,7 @@ fn tracked_key_value_write_row(
         global: false,
         change_id: None,
         commit_id: None,
-        untracked: false,
+        untracked,
         branch_id: branch_id.into(),
     })
 }
@@ -1511,7 +1524,7 @@ mod tests {
             vec!["plugin_a_note".to_string(), "plugin_a_meta".to_string()],
         )
         .unwrap();
-        let row = owner.write_row("main").unwrap();
+        let row = owner.write_row("main", false).unwrap();
         assert_eq!(
             row.entity_pk.unwrap().as_single_string().unwrap(),
             PLUGIN_OWNER_KEY

--- a/packages/lix/src/transaction/context.rs
+++ b/packages/lix/src/transaction/context.rs
@@ -2998,6 +2998,7 @@ where
                 bound,
                 &file_key.file_id,
                 &file_key.branch_id,
+                file_key.untracked,
             )? {
                 rows.push(row);
             }
@@ -3034,6 +3035,13 @@ where
                     })
                     .collect(),
                 projection: plugin_state_live_state_projection(),
+                // Lane is a property of each requested file, but the exact-batch
+                // request carries one lane for the whole batch. Every file that
+                // reaches plugin reconciliation is tracked today, so this is
+                // exact. Unskipping untracked files requires either a per-row
+                // lane here or partitioning the batch by lane; leaving it as a
+                // constant would silently miss an existing untracked
+                // reservation and re-reserve over it.
                 untracked: Some(false),
                 include_tombstones: false,
             })
@@ -3046,6 +3054,7 @@ where
                 *bound,
                 &file_key.file_id,
                 &file_key.branch_id,
+                file_key.untracked,
             )?;
             existing_rows.push(existing);
         }
@@ -3062,7 +3071,7 @@ where
                     schema_keys: vec![KEY_VALUE_SCHEMA_KEY.to_string()],
                     branch_ids: vec![file_key.branch_id.clone()],
                     file_ids: vec![NullableKeyFilter::Value(file_key.file_id.clone())],
-                    untracked: Some(false),
+                    untracked: Some(file_key.untracked),
                     ..Default::default()
                 },
                 projection: plugin_registry_live_state_projection(),
@@ -3079,6 +3088,7 @@ where
                     key,
                     &file_key.file_id,
                     &file_key.branch_id,
+                    file_key.untracked,
                 )?);
             }
         }
@@ -4441,7 +4451,7 @@ where
                 let desired_owner =
                     PluginFileOwner::from_registry_entry(write.file_id.clone(), &selected)?;
                 let owner_change_id = self.functions.call_uuid_v7().to_string();
-                let mut owner_row = desired_owner.write_row(&write.branch_id)?;
+                let mut owner_row = desired_owner.write_row(&write.branch_id, write.untracked)?;
                 owner_row.change_id = Some(owner_change_id.clone());
                 let actor_key = PluginActorKey {
                     branch_id: write.branch_id.clone(),
@@ -4699,7 +4709,7 @@ where
                 let context = FilesystemRowContext {
                     branch_id: write.branch_id.clone(),
                     global: false,
-                    untracked: false,
+                    untracked: write.untracked,
                     file_id: None,
                     metadata: None,
                 };
@@ -4754,7 +4764,7 @@ where
             let context = FilesystemRowContext {
                 branch_id: write.branch_id.clone(),
                 global: false,
-                untracked: false,
+                untracked: write.untracked,
                 file_id: None,
                 metadata: None,
             };
@@ -4795,6 +4805,7 @@ where
                     rows.push(PluginFileOwner::delete_row(
                         write.file_id.clone(),
                         &write.branch_id,
+                        write.untracked,
                     )?);
                 }
                 reconciled_file_keys.insert(file_key);
@@ -4818,7 +4829,7 @@ where
             let owner_needs_write = plugin_owner_needs_write(owner, &desired_owner);
             let owner_change_id = if owner_needs_write {
                 let owner_change_id = self.functions.call_uuid_v7().to_string();
-                let mut owner_row = desired_owner.write_row(&write.branch_id)?;
+                let mut owner_row = desired_owner.write_row(&write.branch_id, write.untracked)?;
                 owner_row.change_id = Some(owner_change_id.clone());
                 rows.push(owner_row);
                 owner_change_id
@@ -6120,8 +6131,11 @@ where
                 &file_key.branch_id,
                 &file_key.file_id,
             ));
-            let owner_tombstone =
-                PluginFileOwner::delete_row(file_key.file_id, &file_key.branch_id)?;
+            let owner_tombstone = PluginFileOwner::delete_row(
+                file_key.file_id,
+                &file_key.branch_id,
+                file_key.untracked,
+            )?;
             if let Some(rows) = &mut reconciled_rows {
                 rows.push_raw(owner_tombstone);
             } else {


### PR DESCRIPTION
## What this changes

Every plugin-written row that carries a `file_id` must live in the same durability lane as the file it describes. Today all of them hardcode the tracked lane. That is correct *only* because plugin reconciliation skips untracked file writes entirely (`transaction/context.rs:3820, 4099, 4405, 4742`), so no untracked file ever reaches these builders.

This PR threads the owning file's lane through those builders instead of hardcoding it. **It is a behavioural no-op on `main`** — every file that reaches these sites is tracked, so every new argument is `false` today.

Threaded:

- `PluginFileOwner::write_row` / `delete_row`, and the shared helper, renamed `tracked_key_value_write_row` → `plugin_key_value_write_row` because the name is no longer accurate. The branch plugin **registry** row is not file-scoped and stays unconditionally tracked.
- `append_plugin_change_rows` and `plugin_state_tombstone_batch`, whose `FilesystemRowContext` hardcoded `untracked: false` at both call sites (`context.rs:4702`, `:4757`) even though the field was already a parameter.
- Create reservations, which are also file-scoped: `reservation_row`, `reservation_tombstone_row`, `reserve_create_row`, `validate_create_reservation`, `validate_reservation_identity`, plus the `v2_id_reservation_tombstones` scan filter (`untracked: Some(false)` → `Some(file_key.untracked)`).

The blob-ref materialization row already propagated `file_key.untracked`; this brings the rest of the plugin row surface in line with the precedent that was already there.

## Why now

This is step 1 of 3 toward letting plugin reconciliation run on untracked files, so an untracked JSON file parses into queryable untracked entity rows the same way a tracked one does.

The ordering matters and is not cosmetic. **Unskipping reconciliation before this lands breaks on its own, independently of any new validation.** `PluginFileOwner::write_row` produced a *tracked* owner row scoped to the file (`plugin/registry.rs:731`, helper hardcoding `untracked: false` at `:1189`, `file_id: Some(...)` at `:1180`). For an untracked file that is a tracked row inside an untracked file — which the engine already rejects today via `Domain::file_owner_domains`, surfacing as `CODE_FILE_NOT_FOUND`. So propagation has to come first, as its own reviewable no-op.

## Deliberately not fixed here, and why

`preflight_creates` (`transaction/context.rs:~3025`) loads existing reservations with a **batch-level** `untracked: Some(false)`, but lane is a per-file property and `LiveStateExactBatchRequest` carries one lane for the whole batch. That is exact today and I left it as a constant with a comment explaining the constraint. Resolving it needs either a per-row lane on the request or partitioning the batch by lane — that belongs in the unskip PR, where it can be tested, not smuggled in here. Left unfixed it would silently miss an existing untracked reservation and re-reserve over it.

## One finding worth flagging for the follow-up

The owner row is assigned an explicit `change_id` (`context.rs:4444`, `:4821`) and `PluginActorKey` is keyed on that `owner_change_id`; owner incarnation is detected by comparing change ids (`context.rs:1121`). Untracked rows today read back with `change_id = None` (`transaction/commit.rs:9703`; `tests/integration/sql/untracked_current_state.rs:504`). So an untracked owner row would lose its incarnation identity and hit the "durable component plugin owner is missing its incarnation" internal error.

That means the unskip work depends on untracked rows carrying a `change_id` — it is not orthogonal to that change, as it first appears. Nothing to do in this PR; recording it so the dependency is not discovered mid-implementation.

## Layout invariants

1. **Single authority** — no new authority; a hardcoded constant becomes a value read from the row's owning file.
2. **Commit canonicality** — untouched.
3. **Derived views are caches** — untouched.
4. **Atomic publication** — untouched; same rows in the same write set.
5. **GC from refs** — untouched.
6. **SQL reads canonical records** — untouched.

## Gate

`ryzen-9950x-V`, on the exact commit in this PR (`e9339aff4`), after merging `main` (`d89ab8681`, already up to date):

- `cargo check --workspace` — clean
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` — clean
- `cargo test -p lix --all-features` — **2081 lib + 854 integration + 18 across the remaining suites, 0 failed**
- `rustfmt --check` on every file this PR touches — clean. (`cargo fmt --all --check` is dirty repo-wide on pristine `main` too, ~85 files, identical list; I verified against `~/claude3/base` and fixed the 4 violations this PR introduced rather than reformatting unrelated files.)

No timing run: this changes no hot-path logic, only where a boolean is read from. Every value is identical to the previous constant at runtime, so there is nothing for a bench to resolve.

No changenote: internal refactor, no user-facing behaviour change, per `.changenotes/README.md`.
