### PR TITLE
test(engine-benchmarks): stop the public-result parity test from aborting the run in debug

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,11 +113,11 @@ jobs:
         run: cargo test --profile test --workspace --all-features --no-run
 
       - name: Run Rust workspace tests
+        # Deliberately no RUST_MIN_STACK here. Tests that need more than
+        # libtest's 2 MiB worker-stack default must size their own thread
+        # (see `run_on_sized_stack` in the CRUD public-result parity test), so
+        # that the command a developer runs by hand behaves like CI's.
         if: matrix.task == 'test'
-        env:
-          # The CRUD public-result parity test exercises every adapter in one
-          # libtest worker and can exceed Rust's 2 MiB worker-stack default.
-          RUST_MIN_STACK: 8388608
         run: cargo test --profile test --workspace --all-features
 
       - name: Verify the packaged plugin API contract

--- a/packages/engine-benchmarks/tests/tracked_state_crud_public_result.rs
+++ b/packages/engine-benchmarks/tests/tracked_state_crud_public_result.rs
@@ -40,7 +40,7 @@ const PUBLIC_RESULT_TEST_STACK_SIZE: usize = 32 * 1024 * 1024;
 fn run_on_sized_stack<Body, Fut>(name: &str, body: Body)
 where
     Body: FnOnce() -> Fut + Send + 'static,
-    Fut: std::future::Future<Output = ()>,
+    Fut: Future<Output = ()>,
 {
     std::thread::Builder::new()
         .name(name.to_string())

--- a/packages/engine-benchmarks/tests/tracked_state_crud_public_result.rs
+++ b/packages/engine-benchmarks/tests/tracked_state_crud_public_result.rs
@@ -20,6 +20,43 @@ async fn serialized_public_result_test() -> tokio::sync::MutexGuard<'static, ()>
     PUBLIC_RESULT_TEST_LOCK.lock().await
 }
 
+/// Stack budget for the OLAP parity bodies below.
+///
+/// These tests build and optimize real DataFusion plans over a seeded fixture.
+/// Plan construction and the optimizer recurse per plan node, and an
+/// unoptimized build needs several times the stack that an optimized one does,
+/// so the bodies overflow libtest's 2 MiB worker-stack default in the `test`
+/// profile while passing in `--release`. Running them on an explicitly sized
+/// thread makes the suite independent of the build profile and of whether
+/// `RUST_MIN_STACK` happens to be exported by the caller.
+const PUBLIC_RESULT_TEST_STACK_SIZE: usize = 32 * 1024 * 1024;
+
+/// Runs an async test body on a thread with [`PUBLIC_RESULT_TEST_STACK_SIZE`]
+/// of stack, driven by a current-thread runtime so the concurrency semantics
+/// match the `#[tokio::test]` default these bodies were written against.
+///
+/// Panics (including assertion failures) propagate to the libtest worker
+/// through the join handle, so a failing assertion still fails the test.
+fn run_on_sized_stack<Body, Fut>(name: &str, body: Body)
+where
+    Body: FnOnce() -> Fut + Send + 'static,
+    Fut: std::future::Future<Output = ()>,
+{
+    std::thread::Builder::new()
+        .name(name.to_string())
+        .stack_size(PUBLIC_RESULT_TEST_STACK_SIZE)
+        .spawn(move || {
+            tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .expect("build public-result test runtime")
+                .block_on(body());
+        })
+        .expect("spawn public-result test thread")
+        .join()
+        .expect("public-result test body panicked");
+}
+
 #[test]
 fn typed_olap_queries_are_plain_datafusion_selects() {
     use datafusion::sql::parser::DFParser;
@@ -49,8 +86,14 @@ fn typed_olap_queries_are_plain_datafusion_selects() {
     }
 }
 
-#[tokio::test]
-async fn typed_olap_shapes_validate_exact_results_on_every_adapter() {
+#[test]
+fn typed_olap_shapes_validate_exact_results_on_every_adapter() {
+    run_on_sized_stack("olap-exact-results", || async {
+        validate_exact_olap_shapes().await;
+    });
+}
+
+async fn validate_exact_olap_shapes() {
     let _test_guard = serialized_public_result_test().await;
     let rows = workload::fixture_rows(128);
     for &profile in storage::STORAGE_PROFILES {
@@ -74,8 +117,14 @@ async fn typed_olap_shapes_validate_exact_results_on_every_adapter() {
     }
 }
 
-#[tokio::test]
-async fn typed_olap_shapes_validate_above_columnar_publication_threshold() {
+#[test]
+fn typed_olap_shapes_validate_above_columnar_publication_threshold() {
+    run_on_sized_stack("olap-above-columnar-threshold", || async {
+        validate_above_columnar_publication_threshold().await;
+    });
+}
+
+async fn validate_above_columnar_publication_threshold() {
     let _test_guard = serialized_public_result_test().await;
     let rows = workload::fixture_rows(2_048);
     for &profile in storage::STORAGE_PROFILES {
@@ -101,22 +150,10 @@ async fn typed_olap_shapes_validate_above_columnar_publication_threshold() {
 
 #[test]
 fn typed_olap_shapes_validate_exact_results_after_sparse_and_moderate_mutations() {
-    std::thread::Builder::new()
-        .name("post-update-olap-validation".to_string())
-        .stack_size(16 * 1024 * 1024)
-        .spawn(|| {
-            tokio::runtime::Builder::new_current_thread()
-                .enable_all()
-                .build()
-                .expect("build post-update OLAP runtime")
-                .block_on(async {
-                    let _test_guard = serialized_public_result_test().await;
-                    validate_post_update_olap_shapes().await;
-                });
-        })
-        .expect("spawn post-update OLAP validation thread")
-        .join()
-        .expect("join post-update OLAP validation thread");
+    run_on_sized_stack("post-update-olap-validation", || async {
+        let _test_guard = serialized_public_result_test().await;
+        validate_post_update_olap_shapes().await;
+    });
 }
 
 async fn validate_post_update_olap_shapes() {
@@ -136,8 +173,14 @@ async fn validate_post_update_olap_shapes() {
     }
 }
 
-#[tokio::test]
-async fn insert_benchmark_hits_certified_parameter_batch_on_every_adapter() {
+#[test]
+fn insert_benchmark_hits_certified_parameter_batch_on_every_adapter() {
+    run_on_sized_stack("certified-parameter-batch", || async {
+        validate_certified_parameter_batch().await;
+    });
+}
+
+async fn validate_certified_parameter_batch() {
     let _test_guard = serialized_public_result_test().await;
     let rows = [
         WorkloadRow {
@@ -159,8 +202,14 @@ async fn insert_benchmark_hits_certified_parameter_batch_on_every_adapter() {
     }
 }
 
-#[tokio::test]
-async fn certified_insert_counter_deltas_are_isolated_across_sequential_fixtures() {
+#[test]
+fn certified_insert_counter_deltas_are_isolated_across_sequential_fixtures() {
+    run_on_sized_stack("sequential-counter-isolation", || async {
+        validate_sequential_counter_isolation().await;
+    });
+}
+
+async fn validate_sequential_counter_isolation() {
     let _test_guard = serialized_public_result_test().await;
     let rows = [WorkloadRow {
         path: "/sequential".to_string(),
@@ -185,8 +234,14 @@ async fn certified_insert_counter_deltas_are_isolated_across_sequential_fixtures
     assert_eq!(slatedb.insert_all().await, 1);
 }
 
-#[tokio::test]
-async fn certified_insert_counter_deltas_are_isolated_for_concurrent_fixtures() {
+#[test]
+fn certified_insert_counter_deltas_are_isolated_for_concurrent_fixtures() {
+    run_on_sized_stack("concurrent-counter-isolation", || async {
+        validate_concurrent_counter_isolation().await;
+    });
+}
+
+async fn validate_concurrent_counter_isolation() {
     let rows = [WorkloadRow {
         path: "/concurrent".to_string(),
         value_json: r#"{"enabled":true}"#.to_string(),
@@ -216,6 +271,10 @@ async fn insert_one_counter_fixture(
 
 /// Regression for the automatic-write future retaining SlateDB's large
 /// adapter-specific open and commit futures on Tokio's default test stack.
+///
+/// Deliberately NOT wrapped in [`run_on_sized_stack`]: asserting that this
+/// path still fits the default worker stack is the entire point of the test.
+/// It must keep running on whatever stack libtest hands it.
 #[cfg(feature = "slatedb")]
 #[tokio::test]
 async fn slatedb_automatic_write_runs_on_default_stack() {


### PR DESCRIPTION
## The defect: CI was green while the documented command aborted

`cargo test -p lix_benchmarks --features storage-benches,slatedb --test tracked_state_crud_public_result`
overflowed its stack in the default (debug) profile and **aborted the whole process with SIGABRT**,
so libtest never reported the remaining tests at all. CI did not see it because
`.github/workflows/ci.yml` exported `RUST_MIN_STACK: 8388608` on the test step, with a comment naming
this exact test. That asymmetry — green in CI, `signal: 6` by hand — is what this PR fixes.

Pre-existing on `main`; not introduced by any recent branch.

### Baseline, reproduced on `hetzner-cpx62-II` at `origin/main` (608508c5c), `RUST_MIN_STACK` unset

```
test result: 7 ok, then
test typed_olap_shapes_validate_above_columnar_publication_threshold ...
thread '...' has overflowed its stack
fatal runtime error: stack overflow, aborting
```

**It was worse than a single test.** With `--test-threads=1` the abort hid the last two tests. Running
them individually against the same baseline binary shows a *second* test also overflows:

| test | baseline (debug, no `RUST_MIN_STACK`) |
|---|---|
| `typed_olap_shapes_validate_above_columnar_publication_threshold` (2 048 rows) | **stack overflow, SIGABRT** |
| `typed_olap_shapes_validate_exact_results_on_every_adapter` (128 rows) | **stack overflow, SIGABRT** |
| `typed_olap_shapes_validate_exact_results_after_sparse_and_moderate_mutations` | ok — already had a 16 MiB thread |
| the other 7 | ok |

So the reported "8th test" was two broken tests plus one already-fixed test that had never been
reached, all masked by the abort.

## Fix — option 1 from the brief: run the bodies on an explicitly sized thread

Fixture-size reduction (option 2) was rejected: the 2 048-row fixture is exactly what puts the test
above the columnar publication threshold it exists to gate, so shrinking it would delete the coverage.

Added a `run_on_sized_stack` helper in the test file: a `std::thread::Builder` with a 32 MiB stack
driving a `tokio::runtime::Builder::new_current_thread()`. Current-thread is deliberate — it matches
the `#[tokio::test]` default these bodies were written against, so the concurrency semantics of
`certified_insert_counter_deltas_are_isolated_for_concurrent_fixtures` (which uses `tokio::join!`) are
unchanged. Panics propagate through the join handle, so assertion failures still fail the test.

The file already contained a hand-rolled 16 MiB version of this pattern for one test; that is now
folded into the shared helper, and every fixture-building `#[tokio::test]` in the file uses it. This
is the established pattern in this repo — `packages/lix/tests/integration/support/mod.rs`,
`packages/rs-sdk-tests/tests/e2e.rs`, `packages/cli/src/commands/sql/execute.rs` and
`packages/lix/src/sql2/exec/datafusion.rs` all size their own stacks for the same reason.

### Siblings: yes, they shared the exposure — with one deliberate exception

All six fixture-building async tests now run on the sized stack.
`slatedb_automatic_write_runs_on_default_stack` is **deliberately left on `#[tokio::test]`**: asserting
that the SlateDB automatic-write future still fits libtest's default worker stack is the entire point
of that test, and wrapping it would silently delete the guard. It passes on the default stack on
baseline and on this branch, so the guard is real and still holding. A comment on the test says so.

## Root cause

The bodies build and optimize real DataFusion plans. Plan construction and the optimizer recurse per
plan node, and an unoptimized build needs several times the stack frame size of an optimized one — so
the same plan fits comfortably in `--release` and blows the 2 MiB libtest worker default in `test`.
Nothing in the engine is at fault; the test was simply relying on an environment variable it never
set itself.

## CI workaround removed

`RUST_MIN_STACK: 8388608` is **deleted** from the workflow. Evidence: the full CI test command ran on
`hetzner-cpx62-II` with `RUST_MIN_STACK` explicitly unset —

```
cargo test --profile test --workspace --all-features
```

**64 test binaries, 3 417 tests passed, 0 failed, 0 aborts.** No other test needed the workaround.
The step now carries a comment explaining that a test needing more than 2 MiB must size its own
thread, so this cannot quietly come back.

## Verification (all on `hetzner-cpx62-II`, `RUST_MIN_STACK` unset in every run)

| run | result |
|---|---|
| debug, `--test-threads=1` | `ok. 10 passed; 0 failed` — **all 10 report by name** |
| debug, default parallelism (the exact documented command) | `ok. 10 passed; 0 failed` |
| `--release` | `ok. 10 passed; 0 failed` |
| `cargo check --workspace` | ok |
| `cargo clippy --profile test --workspace --all-targets --all-features -- -D warnings` | ok (exit 0) |
| `cargo test --profile test --workspace --all-features` | 3 417 passed, 0 failed |

Not "the process survived" — the per-test lines for all ten are in the log, including the two that
previously never printed.

## No timing

The diff is two files: one integration test and one CI workflow. No engine code, no hot path, nothing
a benchmark could observe. Per the runbook's guard-selection rule, benchmarks are skipped as they
could not answer a question anyone asked.

## Layout invariants

Not applicable — this is a test-harness fix. No authority, canonicality, derived view, publication
atomicity, GC reachability, or SQL read path is touched.
