### PR TITLE
fix: unpin the branch-control space version in two test fixtures

### DIFF
--- a/packages/engine-benchmarks/tests/corruption_recovery_qualification.rs
+++ b/packages/engine-benchmarks/tests/corruption_recovery_qualification.rs
@@ -17,7 +17,12 @@ use std::path::Path;
 
 const BRANCH_ID: &str = "01920000-0000-7000-8000-000000000001";
 const CHECKPOINT_FILE_ID: &str = "01920000-0000-7000-8000-000010000000";
-const BRANCH_CONTROL_SPACE: &str = "branch.head_control.v10";
+// Must track `BRANCH_HEAD_CONTROL_NAMESPACE` in `lix::branch::control`, which
+// is bumped whenever the branch-control record layout changes. Unlike the
+// predicate in the server-protocol gate this cannot match on a prefix: it names
+// the space it reconstructs. A stale value here does not fail loudly at the
+// mismatch, it makes the inventory come back empty.
+const BRANCH_CONTROL_SPACE: &str = "branch.head_control.v11";
 const PLUGIN_CHECKPOINT_SPACE: &str = "plugin.current_checkpoint.v2";
 const COMMIT_MANIFEST_SPACE: &str = "tracked_state.commit_state_manifest.v7";
 const TREE_CHUNK_SPACE: &str = "tracked_state.tree_chunk";

--- a/packages/server-protocol/src/lib.rs
+++ b/packages/server-protocol/src/lib.rs
@@ -4411,9 +4411,16 @@ mod tests {
             &self,
             requests: &[GetManyRequest<'_>],
         ) -> Result<GetManyResult, StorageError> {
+            // Match the branch-control space by identity, not by its exact
+            // name. The trailing version is part of the *encoding* contract and
+            // is bumped whenever the record layout changes, so pinning the full
+            // name here silently disarms this gate the next time that happens:
+            // the switch still issues its authoritative branch-control read,
+            // the wrapper just stops recognising it, and the test then fails on
+            // its timeout as though the read had disappeared.
             let reads_branch_control = requests
                 .iter()
-                .any(|request| request.space.name == "branch.head_control.v10");
+                .any(|request| request.space.name.starts_with("branch.head_control."));
             if reads_branch_control
                 && self
                     .gate


### PR DESCRIPTION
Fixes `main`, red since #1329. **Outcome 2: the authoritative read still happens; the test's wrapper stopped recognising it.** This is not a single-authority or commit-canonicality violation.

## Root cause

#1329 removed `untracked_generation` from the musli-packed `BranchHeadControl`. That changes the record encoding, so the space namespace had to move `branch.head_control.v10` → `v11`.

Two test fixtures pinned the **full name including the version**:

1. `packages/server-protocol/src/lib.rs` — the gate predicate `request.space.name == "branch.head_control.v10"`. With the name bumped, the gate never armed, `wait_for_blocked_branch_control_read` never returned, and the 1 s timeout fired — presenting exactly as "the switch never issued a branch-control read".
2. `packages/engine-benchmarks/tests/corruption_recovery_qualification.rs` — `const BRANCH_CONTROL_SPACE`. Its inventory came back empty and tripped `assert!(!entries.is_empty())`, failing `rocksdb_cold_reopen_corruption_qualification` and `slatedb_cold_reopen_corruption_qualification`. This one is in the `lix_benchmarks` CI job, so it was a second, separate breakage from the same bump.

The space **id** `0x0004_0020` never changed. Only the name, which carries the encoding version and is *expected* to churn.

## The authoritative read is intact — named and proven

`switch_branch` reads branch control authoritatively on both arms, via
`BranchLifecycle::new(&reader).require_existing_commit_id(..)` → `BranchRefReader` → `BranchHeadControlReader` → `PointReadPlan::new(BRANCH_HEAD_CONTROL_SPACE, ..)`
(`packages/lix/src/session/switch_branch.rs`: pinned arm through `self.branch_ctx.ref_reader(&read)`, workspace arm through `transaction.branch_ref_reader()`).

Proven, not asserted:

- With the hook fixed, the test passes in **0.02 s** against its 1 s budget — the gate observes a real branch-control read ~50× inside the window.
- Deleting **both** `require_existing_commit_id` calls makes the corrected test fail again with the identical 1.02 s timeout. The corrected test still has teeth; it is genuinely gated on that read occurring.
- Deleting only the *workspace* arm leaves it passing, which identifies the pinned arm as the one this test exercises. Both call sites were confirmed live by renaming the method and observing exactly two `E0599`s.

## The fix

- Server-protocol gate now matches `space.name.starts_with("branch.head_control.")` — a predicate needs identity, not the encoding version, so this cannot drift again.
- The corruption fixture must name the space it reconstructs, so it tracks `v11` with a comment pointing at the constant it must follow. `native_storage_spaces()` is private, so a prefix lookup is not available there; making it resolvable is the obvious follow-up that would remove this trap class entirely.

The timeout is untouched and nothing is `#[ignore]`d.

## Gate — CI scope

- `cargo test --profile test --workspace --exclude lix_benchmarks --all-features` → **rc=0**
- `cargo test --profile test -p lix_benchmarks --features storage-benches,slatedb` → **rc=0** (10 binaries ok)

Two things seen while gating that are **not** from #1329 and are not fixed here:

- `tracked_state_crud_public_result::typed_olap_shapes_validate_above_columnar_publication_threshold` overflows the stack under the debug test profile on this machine. It reproduces **identically on `3523a82f3`, the last green commit**, and passes 10/10 with `RUST_MIN_STACK=16777216`. Local stack-size artifact, pre-existing.
- `same_base_remote_plugin_writes_resolve_and_converge` failed once inside a loaded parallel workspace run (`commits_after - commits_before` was 2, expected 1) and then passed 8/8 in isolation and on the full re-run. A concurrency flake, distinct in character from the deterministic failure this PR fixes.
