### PR TITLE
perf: skip redundant native result JSON clones

### DIFF
--- a/.changenotes/skip-native-result-clone.md
+++ b/.changenotes/skip-native-result-clone.md
@@ -1,0 +1,7 @@
+---
+type: patch
+---
+
+Faster JSON-heavy SQL reads by removing a redundant native-result copy.
+
+Native query results are already materialized for the result set, so the SDK no longer deep-clones structured values while wrapping them. Public `toJS()` and row accessors still return defensive copies.

--- a/packages/js-sdk/scripts/benchmark-native-result-clone.mjs
+++ b/packages/js-sdk/scripts/benchmark-native-result-clone.mjs
@@ -1,0 +1,72 @@
+import { performance } from "node:perf_hooks";
+import { wrapExecuteResult } from "../dist/result.js";
+
+const rowCount = Number(process.env.ROWS ?? 20_000);
+const iterations = Number(process.env.ITERATIONS ?? 5);
+const mode = process.env.MODE ?? "optimized";
+const payload = {
+	declarations: [
+		{ type: "input-variable", name: "username" },
+		{ type: "local-variable", name: "greeting", value: "Hello" },
+	],
+	selectors: [{ type: "variable-reference", name: "username" }],
+	matches: [{ type: "select", key: "username", value: "samuel" }],
+	pattern: [
+		{ type: "text", value: "Hello " },
+		{ type: "expression", arg: { type: "variable-reference", name: "username" } },
+	],
+};
+
+const columns = ["declarations", "selectors", "matches", "pattern"];
+const rows = Array.from({ length: rowCount }, () => [
+	{ kind: "json", value: payload.declarations },
+	{ kind: "json", value: payload.selectors },
+	{ kind: "json", value: payload.matches },
+	{ kind: "json", value: payload.pattern },
+]);
+
+function cloneJsonValue(value) {
+	if (Array.isArray(value)) return value.map(cloneJsonValue);
+	if (value && typeof value === "object") {
+		return Object.fromEntries(
+			Object.entries(value).map(([key, entry]) => [key, cloneJsonValue(entry)])
+		);
+	}
+	return value;
+}
+
+function nativeRows() {
+	if (mode !== "legacy") return rows;
+	return rows.map((row) =>
+		row.map((value) =>
+			value.kind === "json"
+				? { kind: "json", value: cloneJsonValue(value.value) }
+				: value
+		)
+	);
+}
+
+function run() {
+	const started = performance.now();
+	let checksum = 0;
+	for (let iteration = 0; iteration < iterations; iteration += 1) {
+		const result = wrapExecuteResult({
+			columns,
+			rows: nativeRows(),
+			rowsAffected: 0,
+			notices: [],
+		});
+		for (const row of result.rows) {
+			checksum += row.toObject().pattern.length;
+		}
+	}
+	return {
+		mode,
+		rowCount,
+		iterations,
+		meanMs: (performance.now() - started) / iterations,
+		checksum,
+	};
+}
+
+console.log(JSON.stringify(run()));

--- a/packages/js-sdk/src/value.ts
+++ b/packages/js-sdk/src/value.ts
@@ -5,9 +5,9 @@ export class Value {
 	readonly kind: LixValue["kind"];
 	readonly #raw: LixValue;
 
-	private constructor(raw: LixValue) {
+	private constructor(raw: LixValue, clone = true) {
 		validateExplicitValue(raw);
-		this.#raw = cloneValue(raw);
+		this.#raw = clone ? cloneValue(raw) : raw;
 		this.kind = this.#raw.kind;
 	}
 
@@ -44,7 +44,11 @@ export class Value {
 	}
 
 	static _fromNative(value: LixValue) {
-		return new Value(value);
+		// Native execute results are newly materialized for this result set. Keep
+		// the native value as-is and defer the defensive copy until toJS(). This
+		// avoids cloning every structured result once during row wrapping and
+		// again when callers read it.
+		return new Value(value, false);
 	}
 
 	_toNative() {


### PR DESCRIPTION
## What changed

Native SQL results are already materialized for each result set. `Value._fromNative()` now retains those values and defers the defensive JSON copy until `toJS()` / row access, removing the redundant clone during row wrapping.

Public structured-value safety is preserved: callers still receive copies and cannot mutate SDK-owned result data.

## Why

The Paraglide/Inlang profile showed `cloneJsonValue` as a significant hot path in JSON-heavy nested reads. The previous path cloned structured values while constructing `Value`, then cloned them again when Kysely materialized rows.

## Measurement

Using `packages/js-sdk/scripts/benchmark-native-result-clone.mjs` with 20,000 JSON-heavy rows × 5 iterations:

- legacy path: ~100–107 ms mean
- optimized path: ~55–61 ms mean

At 50,000 rows × 10 iterations: ~264 ms → ~144 ms.

## Validation

- `pnpm exec tsc -p tsconfig.test.json --noEmit`
- `pnpm exec vitest run` (8 files, 140 tests)
- existing structured-value immutability tests pass

Browser Vitest was not runnable in the sandbox because its local listener was denied; CI should cover browser bindings.