### PR TITLE
Make client state reads async

### DIFF
--- a/.changenotes/async-client-state-reads.md
+++ b/.changenotes/async-client-state-reads.md
@@ -1,0 +1,7 @@
+---
+type: minor
+---
+
+Changed `lix.clientState.get()` to read asynchronously from the configured client storage.
+
+Client-state reads now use the authoritative Lix transaction path instead of an eagerly hydrated in-memory copy. Callers must await `get()`.

--- a/docs/js-api-reference.md
+++ b/docs/js-api-reference.md
@@ -422,7 +422,12 @@ Closes the Lix handle and its storage resources.
 
 ### clientState
 
-`lix.clientState` stores private client-local JSON state with `get`, `set`, `delete`, and `subscribe`; pass `IndexedDbStorage` in remote mode to persist it locally.
+`lix.clientState` stores private client-local JSON state with asynchronous `get`, `set`, and `delete` methods plus `subscribe`; pass `IndexedDbStorage` in remote mode to persist it locally.
+
+```ts
+const preference = await lix.clientState.get("preference");
+await lix.clientState.set("preference", { sidebar: "history" });
+```
 
 ## Transaction
 

--- a/packages/js-sdk/README.md
+++ b/packages/js-sdk/README.md
@@ -68,14 +68,14 @@ const lix = await openLix({
 	storage: new IndexedDbStorage({ name: "lixray-client" }),
 });
 
-const previousUiState = lix.clientState.get("atelier-ui");
+const previousUiState = await lix.clientState.get("atelier-ui");
 await lix.clientState.set("atelier-ui", { sidebar: "history" });
 ```
 
-`lix.clientState` is hydrated before `openLix()` resolves, so reads are
-synchronous. Its JSON values and the client's active branch are stored in a
-the local IndexedDB database; workspace SQL continues to execute only on the
-server. Reopening the same remote URL with the same storage name restores both. Each
+`lix.clientState` reads and writes through the local Lix transaction path. Its
+JSON values and the client's active branch are stored in the local IndexedDB
+database; workspace SQL continues to execute only on the server. Reopening the
+same remote URL with the same storage name restores both. Each
 remote server session is branch-pinned, so switching one client does not switch
 another client.
 

--- a/packages/js-sdk/native/wasm.rs
+++ b/packages/js-sdk/native/wasm.rs
@@ -209,20 +209,6 @@ impl WasmLix {
         Ok(self.inner.active_account_id().to_string())
     }
 
-    #[wasm_bindgen(js_name = clientStateEntries)]
-    pub async fn client_state_entries(&self) -> Result<JsValue, JsValue> {
-        let entries = self
-            .inner
-            .client_state()
-            .entries()
-            .await
-            .map_err(lix_error_to_js)?
-            .into_iter()
-            .map(|(key, value)| ClientStateEntryDto { key, value })
-            .collect::<Vec<_>>();
-        to_js(&entries)
-    }
-
     #[wasm_bindgen(js_name = clientStateGet)]
     pub async fn client_state_get(&self, key: String) -> Result<JsValue, JsValue> {
         match self
@@ -441,13 +427,6 @@ impl WasmObserveEvents {
 #[serde(rename_all = "camelCase")]
 struct ExecuteOptionsDto {
     origin_key: Option<String>,
-}
-
-#[derive(Serialize)]
-#[serde(rename_all = "camelCase")]
-struct ClientStateEntryDto {
-    key: String,
-    value: serde_json::Value,
 }
 
 #[derive(Serialize)]

--- a/packages/js-sdk/src/binding-types.ts
+++ b/packages/js-sdk/src/binding-types.ts
@@ -57,7 +57,6 @@ export type LixBinding = {
 	beginTransaction(): Promise<LixTransactionBinding>;
 	activeBranchId(): Promise<string>;
 	activeAccountId(): Promise<string>;
-	clientStateEntries?(): Promise<Array<{ key: string; value: JsonValue }>>;
 	clientStateGet?(key: string): Promise<JsonValue | undefined>;
 	clientStateSet?(key: string, value: JsonValue): Promise<void>;
 	clientStateDelete?(key: string): Promise<void>;

--- a/packages/js-sdk/src/client-state.ts
+++ b/packages/js-sdk/src/client-state.ts
@@ -6,8 +6,8 @@ export const ACTIVE_BRANCH_CLIENT_STATE_KEY = "lix_active_branch_id";
 export const ACTIVE_ACCOUNT_CLIENT_STATE_KEY = "lix_active_account_id";
 
 export type LixClientState = {
-	/** Returns the hydrated client-local value without a network round trip. */
-	get<T extends JsonValue = JsonValue>(key: string): T | undefined;
+	/** Reads a client-local value through the configured client storage. */
+	get<T extends JsonValue = JsonValue>(key: string): Promise<T | undefined>;
 	/** Persists a client-local value in the configured client storage. */
 	set(key: string, value: JsonValue): Promise<void>;
 	/** Deletes a client-local value from the configured client storage. */
@@ -30,7 +30,7 @@ export function unavailableClientState(): LixClientState {
 		return error;
 	};
 	return {
-		get: () => undefined,
+		get: async () => undefined,
 		set: async () => {
 			throw unavailable();
 		},
@@ -55,46 +55,45 @@ export type OpenClientStateOptions = {
  * prefix is intentionally private so built-in Lix key/value rows never leak
  * through this small API.
  */
-export async function openClientState(
+export function openClientState(
 	options: OpenClientStateOptions,
-): Promise<ManagedLixClientState> {
-	const entries = options.binding.clientStateEntries;
-	if (!entries) {
+): ManagedLixClientState {
+	if (
+		!options.binding.clientStateGet ||
+		!options.binding.clientStateSet ||
+		!options.binding.clientStateDelete
+	) {
 		throw new Error(
 			"The selected Lix binding does not support typed client state",
 		);
 	}
-	const initial = new Map<string, JsonValue>();
-	for (const entry of await entries.call(options.binding)) {
-		assertClientStateKey(entry.key);
-		assertJsonValue(entry.value);
-		initial.set(entry.key, cloneJsonValue(entry.value));
-	}
-	return new ManagedLixClientState(options, initial);
+	return new ManagedLixClientState(options);
 }
 
 export class ManagedLixClientState implements LixClientState {
 	readonly #binding: ClientStateBinding;
 	readonly #closeBinding: boolean;
-	readonly #values: Map<string, JsonValue>;
 	readonly #listeners = new Set<() => void>();
 	#operationQueue: Promise<void> = Promise.resolve();
 	#closePromise: Promise<void> | undefined;
 	#acceptingOperations = true;
 
-	constructor(
-		options: OpenClientStateOptions,
-		initial: Map<string, JsonValue>,
-	) {
+	constructor(options: OpenClientStateOptions) {
 		this.#binding = options.binding;
 		this.#closeBinding = options.closeBinding ?? false;
-		this.#values = initial;
 	}
 
-	get<T extends JsonValue = JsonValue>(key: string): T | undefined {
+	get<T extends JsonValue = JsonValue>(key: string): Promise<T | undefined> {
 		assertClientStateKey(key);
-		const value = this.#values.get(key);
-		return value === undefined ? undefined : (cloneJsonValue(value) as T);
+		this.#assertOpen();
+		return this.#enqueue(async () => {
+			const get = this.#binding.clientStateGet;
+			if (!get) throw new Error("Typed Lix client state is unavailable");
+			const value = await get.call(this.#binding, key);
+			if (value === undefined) return undefined;
+			assertJsonValue(value);
+			return cloneJsonValue(value) as T;
+		});
 	}
 
 	set(key: string, value: JsonValue): Promise<void> {
@@ -106,7 +105,7 @@ export class ManagedLixClientState implements LixClientState {
 			const set = this.#binding.clientStateSet;
 			if (!set) throw new Error("Typed Lix client state is unavailable");
 			await set.call(this.#binding, key, nextValue);
-			this.#commitSet(key, nextValue);
+			this.#publish();
 		});
 	}
 
@@ -118,7 +117,7 @@ export class ManagedLixClientState implements LixClientState {
 			if (!deleteValue)
 				throw new Error("Typed Lix client state is unavailable");
 			await deleteValue.call(this.#binding, key);
-			this.#commitDelete(key);
+			this.#publish();
 		});
 	}
 
@@ -142,22 +141,13 @@ export class ManagedLixClientState implements LixClientState {
 		return this.#closePromise;
 	}
 
-	#enqueue(operation: () => Promise<void>): Promise<void> {
+	#enqueue<T>(operation: () => Promise<T>): Promise<T> {
 		const result = this.#operationQueue.then(operation, operation);
 		this.#operationQueue = result.then(
 			() => undefined,
 			() => undefined,
 		);
 		return result;
-	}
-
-	#commitSet(key: string, value: JsonValue): void {
-		this.#values.set(key, value);
-		this.#publish();
-	}
-
-	#commitDelete(key: string): void {
-		if (this.#values.delete(key)) this.#publish();
 	}
 
 	#publish(): void {

--- a/packages/js-sdk/src/lix-lifecycle.test.ts
+++ b/packages/js-sdk/src/lix-lifecycle.test.ts
@@ -33,10 +33,10 @@ test("managed Lix close rejects new work and drains an in-flight branch switch",
 			order.push("client binding closed");
 		},
 	} as unknown as LixBinding;
-	const clientState = new ManagedLixClientState(
-		{ binding: clientBinding, closeBinding: true },
-		new Map(),
-	);
+	const clientState = new ManagedLixClientState({
+		binding: clientBinding,
+		closeBinding: true,
+	});
 	const lix = new Lix(binding, clientState);
 	const branchListener = vi.fn();
 	lix.subscribeActiveBranch(branchListener);
@@ -44,12 +44,16 @@ test("managed Lix close rejects new work and drains an in-flight branch switch",
 	const switching = lix.switchBranch({ branchId: "draft" });
 	const closing = lix.close();
 	const readAfterClose = lix.execute("SELECT 1");
+	const stateReadAfterClose = lix.clientState.get("late");
 	const stateWriteAfterClose = lix.clientState.set("late", true);
 
 	await expect(readAfterClose).rejects.toMatchObject({
 		code: "LIX_ERROR_CLOSED",
 	});
 	expect(execute).not.toHaveBeenCalled();
+	await expect(stateReadAfterClose).rejects.toMatchObject({
+		code: "LIX_ERROR_CLOSED",
+	});
 	await expect(stateWriteAfterClose).rejects.toMatchObject({
 		code: "LIX_ERROR_CLOSED",
 	});
@@ -91,14 +95,18 @@ test("an active-transaction close preflight preserves client state and observati
 		})),
 		close: vi.fn(async () => undefined),
 	} as unknown as LixBinding;
+	const storedClientState = new Map<string, unknown>();
 	const clientBinding = {
-		clientStateSet: vi.fn(async () => undefined),
+		clientStateGet: vi.fn(async (key: string) => storedClientState.get(key)),
+		clientStateSet: vi.fn(async (key: string, value: unknown) => {
+			storedClientState.set(key, value);
+		}),
 		close: vi.fn(async () => undefined),
 	} as unknown as LixBinding;
-	const clientState = new ManagedLixClientState(
-		{ binding: clientBinding, closeBinding: true },
-		new Map(),
-	);
+	const clientState = new ManagedLixClientState({
+		binding: clientBinding,
+		closeBinding: true,
+	});
 	const lix = new Lix(binding, clientState);
 	const observation = lix.observe("SELECT 1");
 	await observation.next();
@@ -111,7 +119,7 @@ test("an active-transaction close preflight preserves client state and observati
 	expect(clientBinding.close).not.toHaveBeenCalled();
 	expect(observationClose).not.toHaveBeenCalled();
 	await expect(lix.clientState.set("still-open", true)).resolves.toBeUndefined();
-	expect(lix.clientState.get("still-open")).toBe(true);
+	await expect(lix.clientState.get("still-open")).resolves.toBe(true);
 
 	await transaction.rollback();
 	await expect(lix.close()).resolves.toBeUndefined();
@@ -143,6 +151,33 @@ test("a terminal commit failure releases the transaction from its parent Lix", a
 	expect(transactionBinding.rollback).not.toHaveBeenCalled();
 });
 
+test("client state get reads the binding and preserves operation order", async () => {
+	const pendingSet = deferred<void>();
+	let stored: unknown = "before";
+	const clientBinding = {
+		clientStateGet: vi.fn(async () => stored),
+		clientStateSet: vi.fn(async (_key: string, value: unknown) => {
+			await pendingSet.promise;
+			stored = value;
+		}),
+	} as unknown as LixBinding;
+	const clientState = new ManagedLixClientState({ binding: clientBinding });
+
+	await expect(clientState.get("preference")).resolves.toBe("before");
+	stored = "changed-outside-facade";
+	await expect(clientState.get("preference")).resolves.toBe(
+		"changed-outside-facade",
+	);
+
+	const setting = clientState.set("preference", "after");
+	const reading = clientState.get("preference");
+	expect(clientBinding.clientStateGet).toHaveBeenCalledTimes(2);
+	pendingSet.resolve();
+	await expect(setting).resolves.toBeUndefined();
+	await expect(reading).resolves.toBe("after");
+	expect(clientBinding.clientStateGet).toHaveBeenCalledTimes(3);
+});
+
 test("a remote close failure still closes managed local client state", async () => {
 	const binding = {
 		close: vi.fn(async () => {
@@ -152,10 +187,10 @@ test("a remote close failure still closes managed local client state", async () 
 	const clientBinding = {
 		close: vi.fn(async () => undefined),
 	} as unknown as LixBinding;
-	const clientState = new ManagedLixClientState(
-		{ binding: clientBinding, closeBinding: true },
-		new Map(),
-	);
+	const clientState = new ManagedLixClientState({
+		binding: clientBinding,
+		closeBinding: true,
+	});
 	const lix = new Lix(binding, clientState);
 
 	await expect(lix.close()).rejects.toThrow("remote close failed");

--- a/packages/js-sdk/src/lix.ts
+++ b/packages/js-sdk/src/lix.ts
@@ -75,7 +75,7 @@ export class Lix {
 		this.clientState = managedClientState
 			? {
 					get: <T extends JsonValue = JsonValue>(key: string) =>
-						managedClientState.get<T>(key),
+						this.#runOperation(() => managedClientState.get<T>(key)),
 					set: (key, value) =>
 						this.#runOperation(() => managedClientState.set(key, value)),
 					delete: (key) =>

--- a/packages/js-sdk/src/open-lix-client-state.test.ts
+++ b/packages/js-sdk/src/open-lix-client-state.test.ts
@@ -1,0 +1,54 @@
+import { expect, test, vi } from "vitest";
+import type { LixBinding, LixStorageConfig } from "./binding-types.js";
+import { IndexedDbStorage, openLix } from "./open-lix.js";
+
+const workerMocks = vi.hoisted(() => ({
+	clientStateGet: vi.fn(),
+	close: vi.fn(),
+	openLixWorkerBinding: vi.fn(),
+}));
+
+vi.mock("./worker/client.js", () => ({
+	openLixWorkerBinding: workerMocks.openLixWorkerBinding,
+}));
+
+vi.mock("./remote/client.js", () => ({
+	openRemoteLixBinding: vi.fn(),
+}));
+
+test("remote client storage closes when restoration reads fail", async () => {
+	workerMocks.clientStateGet.mockRejectedValue(
+		new Error("client state restoration failed"),
+	);
+	workerMocks.openLixWorkerBinding.mockImplementation(
+		async (
+			_storage: LixStorageConfig,
+			onDisposed?: () => void,
+		): Promise<LixBinding> => ({
+			clientStateGet: workerMocks.clientStateGet,
+			clientStateSet: vi.fn(),
+			clientStateDelete: vi.fn(),
+			close: async () => {
+				workerMocks.close();
+				onDisposed?.();
+			},
+		}) as LixBinding,
+	);
+	const options = {
+		server: {
+			mode: "remote" as const,
+			url: "https://lixray.test/@acme/restoration-failure",
+		},
+		storage: new IndexedDbStorage({ name: "restoration-failure" }),
+	};
+
+	await expect(openLix(options)).rejects.toThrow(
+		"client state restoration failed",
+	);
+	await expect(openLix(options)).rejects.toThrow(
+		"client state restoration failed",
+	);
+
+	expect(workerMocks.openLixWorkerBinding).toHaveBeenCalledTimes(2);
+	expect(workerMocks.close).toHaveBeenCalledTimes(2);
+});

--- a/packages/js-sdk/src/open-lix.browser.test.ts
+++ b/packages/js-sdk/src/open-lix.browser.test.ts
@@ -215,7 +215,7 @@ test("remote client state and active branch survive reopen without reaching the 
 	const second = await openLix(options);
 	try {
 		expect(await second.activeBranchId()).toBe("draft");
-		expect(second.clientState.get("atelier")).toEqual({
+		await expect(second.clientState.get("atelier")).resolves.toEqual({
 			focusedPanel: "right",
 		});
 		expect(requestBodies).toEqual([JSON.stringify({ branchId: "draft" })]);
@@ -337,12 +337,16 @@ test("remote IndexedDbStorage isolates client state by server URL", async () => 
 	await workspaceA.close();
 
 	const workspaceB = await openRemote("https://lixray.test/@acme/b");
-	expect(workspaceB.clientState.get("selected-panel")).toBeUndefined();
+	await expect(
+		workspaceB.clientState.get("selected-panel"),
+	).resolves.toBeUndefined();
 	await workspaceB.clientState.set("selected-panel", "files");
 	await workspaceB.close();
 
 	const reopenedA = await openRemote("https://lixray.test/@acme/a/");
-	expect(reopenedA.clientState.get("selected-panel")).toBe("history");
+	await expect(reopenedA.clientState.get("selected-panel")).resolves.toBe(
+		"history",
+	);
 	await reopenedA.close();
 });
 
@@ -362,7 +366,9 @@ test("IndexedDbStorage close can retry after an active transaction", async () =>
 	await lix.close();
 
 	const reopened = await openLix({ storage });
-	expect(reopened.clientState.get("after-failed-close")).toBe(true);
+	await expect(reopened.clientState.get("after-failed-close")).resolves.toBe(
+		true,
+	);
 	await reopened.close();
 });
 

--- a/packages/js-sdk/src/open-lix.ts
+++ b/packages/js-sdk/src/open-lix.ts
@@ -120,13 +120,13 @@ export async function openLix(options: OpenLixOptions = {}): Promise<Lix> {
 		}
 		openIndexedDbStorageNames.add(databaseName);
 		let clientBinding: LixBinding | undefined;
-		let clientState: Awaited<ReturnType<typeof openClientState>> | undefined;
+		let clientState: ReturnType<typeof openClientState> | undefined;
 		try {
 			clientBinding = await openLixWorkerBinding(
 				{ kind: "indexedDb", name: databaseName },
 				() => openIndexedDbStorageNames.delete(databaseName),
 			);
-			clientState = await openClientState({
+			clientState = openClientState({
 				binding: clientBinding,
 				closeBinding: true,
 			});
@@ -136,10 +136,10 @@ export async function openLix(options: OpenLixOptions = {}): Promise<Lix> {
 			throw error;
 		}
 
-		const restoredBranchId = clientState.get<string>(
+		const restoredBranchId = await clientState.get<string>(
 			ACTIVE_BRANCH_CLIENT_STATE_KEY,
 		);
-		const restoredAccountId = clientState.get<string>(
+		const restoredAccountId = await clientState.get<string>(
 			ACTIVE_ACCOUNT_CLIENT_STATE_KEY,
 		);
 		let remoteBinding: LixBinding | undefined;
@@ -218,7 +218,7 @@ export async function openLix(options: OpenLixOptions = {}): Promise<Lix> {
 				() => openIndexedDbStorageNames.delete(databaseName),
 				options.telemetry,
 			);
-			const clientState = await openClientState({ binding });
+			const clientState = openClientState({ binding });
 			return new Lix(binding, clientState);
 		} catch (error) {
 			openIndexedDbStorageNames.delete(databaseName);

--- a/packages/js-sdk/src/open-lix.ts
+++ b/packages/js-sdk/src/open-lix.ts
@@ -136,14 +136,14 @@ export async function openLix(options: OpenLixOptions = {}): Promise<Lix> {
 			throw error;
 		}
 
-		const restoredBranchId = await clientState.get<string>(
-			ACTIVE_BRANCH_CLIENT_STATE_KEY,
-		);
-		const restoredAccountId = await clientState.get<string>(
-			ACTIVE_ACCOUNT_CLIENT_STATE_KEY,
-		);
 		let remoteBinding: LixBinding | undefined;
 		try {
+			const restoredBranchId = await clientState.get<string>(
+				ACTIVE_BRANCH_CLIENT_STATE_KEY,
+			);
+			const restoredAccountId = await clientState.get<string>(
+				ACTIVE_ACCOUNT_CLIENT_STATE_KEY,
+			);
 			try {
 				remoteBinding = await openRemoteLixBinding(options.server, {
 					initialActiveBranchId: restoredBranchId,

--- a/packages/js-sdk/src/worker/client.ts
+++ b/packages/js-sdk/src/worker/client.ts
@@ -122,7 +122,6 @@ function workerBinding(client: LixWorkerClient): LixBinding {
 		},
 		activeBranchId: () => request({ kind: "activeBranchId" }),
 		activeAccountId: () => request({ kind: "activeAccountId" }),
-		clientStateEntries: () => request({ kind: "clientState.entries" }),
 		clientStateGet: (key) => request({ kind: "clientState.get", key }),
 		clientStateSet: (key, value) =>
 			request({ kind: "clientState.set", key, value }),

--- a/packages/js-sdk/src/worker/host.ts
+++ b/packages/js-sdk/src/worker/host.ts
@@ -125,8 +125,6 @@ export function startWorkerHost(endpoint: WorkerHostEndpoint): void {
 				return requiredLix().activeBranchId();
 			case "activeAccountId":
 				return requiredLix().activeAccountId();
-			case "clientState.entries":
-				return requiredClientStateMethod("clientStateEntries")();
 			case "clientState.get":
 				return requiredClientStateMethod("clientStateGet")(operation.key);
 			case "clientState.set":
@@ -190,7 +188,6 @@ export function startWorkerHost(endpoint: WorkerHostEndpoint): void {
 
 	function requiredClientStateMethod<
 		Key extends
-			| "clientStateEntries"
 			| "clientStateGet"
 			| "clientStateSet"
 			| "clientStateDelete",

--- a/packages/js-sdk/src/worker/protocol.ts
+++ b/packages/js-sdk/src/worker/protocol.ts
@@ -43,7 +43,6 @@ export type WorkerOperation =
 	| { kind: "transaction.rollback"; transactionId: number }
 	| { kind: "activeBranchId" }
 	| { kind: "activeAccountId" }
-	| { kind: "clientState.entries" }
 	| { kind: "clientState.get"; key: string }
 	| { kind: "clientState.set"; key: string; value: JsonValue }
 	| { kind: "clientState.delete"; key: string }


### PR DESCRIPTION
## Summary

- hard-cut `lix.clientState.get()` from a synchronous hydrated lookup to an asynchronous storage read
- route every read through the authoritative Lix transaction path and serialize reads with client-state writes
- remove the WASM/worker bulk hydration transport and update remote restoration, tests, docs, and release notes

## Validation

- `npm run build:ts`
- `npm run typecheck`
- `npm exec -- vitest run src/lix-lifecycle.test.ts`
- `cargo check --locked -p lix_js_sdk --target wasm32-unknown-unknown`
- `npm run build:wasm:dev`
- `npm run test:browser:built` (29 passed, 2 skipped)
- `cargo test -p lix --features all-simulations`

