### PR TITLE
perf(tracked_state): bound the commit-path commit-root availability proof

### DIFF
--- a/.changenotes/bounded-commit-root-availability-proof.md
+++ b/.changenotes/bounded-commit-root-availability-proof.md
@@ -1,0 +1,7 @@
+---
+type: patch
+---
+
+Commit no longer re-reads the whole workspace state to decide where a commit-root replay may resume.
+
+Closing a rootless replay interval checked that the previous durable state root was readable by traversing every row of the tree it addresses. That check cost time proportional to total state size and ran once per replay interval, so commit still carried a quadratic term even after replay itself was bounded. The commit path now proves only that the resume point is addressable, which is what actually distinguishes a usable root from a damaged one; the completeness of the chunk closure is already guaranteed by atomic publication and by garbage collection reaching chunks from refs. Explicit repair (`rebuild_tracked_state_for_branch`) still proves the whole closure, so a damaged root is still never resumed from during repair and repair stays total.

--- a/.changenotes/bounded-commit-root-replay.md
+++ b/.changenotes/bounded-commit-root-replay.md
@@ -1,0 +1,7 @@
+---
+type: patch
+---
+
+Commit-root materialization now resumes from the last durable state root instead of replaying history from genesis.
+
+Closing a rootless replay interval used to prove root availability by re-deriving every ancestor root from the changelog back to the first commit, so the periodic root materialization replayed the entire history and its cost grew quadratically with commit count. Availability is now proven from the commit-state manifest that already owns the root, plus a readable-closure check on the tree it addresses. A damaged root is still never resumed from, so explicit repair stays total.

--- a/packages/engine-benchmarks/Cargo.toml
+++ b/packages/engine-benchmarks/Cargo.toml
@@ -17,6 +17,7 @@ default = ["rocksdb"]
 rocksdb = ["dep:lix_storage_rocksdb"]
 slatedb = ["dep:lix_storage_slatedb", "dep:object_store", "dep:slatedb", "dep:ulid"]
 storage-benches = ["lix/storage-benches", "rocksdb"]
+root-replay-trace = ["lix/root-replay-trace", "storage-benches"]
 tpch = ["dep:duckdb", "dep:tpchgen"]
 # Opt-in profiling build that routes Rust allocations through libc so tools
 # such as heaptrack can attribute transient allocation churn to call stacks.
@@ -59,6 +60,11 @@ tokio = { version = "1", features = ["rt-multi-thread", "macros", "sync", "time"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 uuid = { version = "1", features = ["std"] }
 xxhash-rust = { version = "0.8", features = ["xxh3"] }
+
+[[example]]
+name = "expaa_replay_scope"
+path = "examples/expaa_replay_scope.rs"
+required-features = ["storage-benches"]
 
 [[example]]
 name = "space_growth"

--- a/packages/engine-benchmarks/Cargo.toml
+++ b/packages/engine-benchmarks/Cargo.toml
@@ -67,6 +67,11 @@ path = "examples/expaa_replay_scope.rs"
 required-features = ["storage-benches"]
 
 [[example]]
+name = "expab_plan_load"
+path = "examples/expab_plan_load.rs"
+required-features = ["storage-benches"]
+
+[[example]]
 name = "space_growth"
 path = "examples/space_growth.rs"
 required-features = ["storage-benches"]

--- a/packages/engine-benchmarks/Cargo.toml
+++ b/packages/engine-benchmarks/Cargo.toml
@@ -69,7 +69,7 @@ required-features = ["storage-benches"]
 [[example]]
 name = "expab_plan_load"
 path = "examples/expab_plan_load.rs"
-required-features = ["storage-benches"]
+required-features = ["storage-benches", "slatedb"]
 
 [[example]]
 name = "space_growth"

--- a/packages/engine-benchmarks/examples/expaa_replay_scope.rs
+++ b/packages/engine-benchmarks/examples/expaa_replay_scope.rs
@@ -1,0 +1,232 @@
+//! Commit-root replay scope and cost attribution (experiment AA).
+//!
+//! Tracked-state root materialization is bursty: ordinary commits are
+//! "rootless" bounded-replay layouts and only every
+//! `COMMIT_STATE_MAX_REPLAY_DEPTH`-th commit closes the interval by
+//! materializing a durable root. This example drives N ordinary SQL commits
+//! through the real `SessionContext` commit path and reports, per boundary,
+//! how many ancestor commits that root materialization replayed.
+//!
+//! If the replay resumed from the previous materialized root the per-boundary
+//! replay set is a constant (the interval depth). If it restarts from genesis
+//! the replay set grows linearly with commit count and total replay work is
+//! quadratic. The printed `plans_per_boundary` row is the distinguishing
+//! measurement.
+//!
+//! Build with `--features root-replay-trace` to additionally attribute the
+//! per-replayed-commit cost across storage read / decode / encode / hash.
+//!
+//! Usage: `expaa_replay_scope [commits] [rows_per_commit]`
+//! (defaults: 200 commits, 10 rows).
+
+use std::time::{Duration, Instant};
+
+use lix::Value;
+use lix::integration::{Engine, SessionContext};
+use lix::storage::Storage;
+use lix::storage_bench::{
+    RootReplayCostBucket, root_replay_trace_enabled, take_root_replay_accounting,
+    take_root_replay_cost_attribution,
+};
+use lix_storage_rocksdb::RocksDB;
+
+#[tokio::main(flavor = "current_thread")]
+async fn main() {
+    let mut args = std::env::args().skip(1);
+    let commits = args
+        .next()
+        .and_then(|value| value.parse::<usize>().ok())
+        .unwrap_or(200);
+    let rows_per_commit = args
+        .next()
+        .and_then(|value| value.parse::<usize>().ok())
+        .unwrap_or(10);
+    // Checkpoints re-home live rows onto one commit and parent the previous
+    // checkpoint directly, so they are a candidate natural resume point. Pass a
+    // non-zero interval to test whether they bound the replay set on their own.
+    let checkpoint_every = args
+        .next()
+        .and_then(|value| value.parse::<usize>().ok())
+        .unwrap_or(0);
+    assert!(commits >= 2, "need at least two commits to measure growth");
+
+    let directory = tempfile::tempdir().expect("create RocksDB directory");
+    let storage = RocksDB::open(directory.path()).expect("open RocksDB");
+    Engine::initialize(storage.clone())
+        .await
+        .expect("initialize repository");
+    let engine = Engine::new(storage.clone()).await.expect("open engine");
+    let session = engine
+        .open_workspace_session()
+        .await
+        .expect("open workspace");
+    register_schema(&session).await;
+
+    // Discard setup accounting so the reported numbers cover only the measured
+    // history.
+    let _ = take_root_replay_accounting();
+    let _ = take_root_replay_cost_attribution();
+
+    let mut latencies = Vec::with_capacity(commits);
+    let mut checkpoints = 0_usize;
+    let run_start = Instant::now();
+    for index in 0..commits {
+        let start = Instant::now();
+        commit_batch(&session, index, rows_per_commit).await;
+        latencies.push(start.elapsed());
+        if checkpoint_every > 0 && (index + 1) % checkpoint_every == 0 {
+            session
+                .create_checkpoint()
+                .await
+                .expect("checkpoint should publish");
+            checkpoints += 1;
+        }
+    }
+    let wall = run_start.elapsed();
+
+    let accounting = take_root_replay_accounting();
+    let attribution = take_root_replay_cost_attribution();
+
+    println!(
+        "expAA_replay_scope commits={commits} rows_per_commit={rows_per_commit} checkpoint_every={checkpoint_every} checkpoints={checkpoints}"
+    );
+    println!("wall_ms {:.1}", wall.as_secs_f64() * 1000.0);
+    println!(
+        "boundaries {} plans_loaded {} plans_staged {} max_plans_in_one_boundary {}",
+        accounting.boundaries,
+        accounting.plans_loaded,
+        accounting.plans_staged,
+        accounting.max_plans_in_one_boundary
+    );
+    println!(
+        "available_root_probes {} available_root_hits {} ancestry_proof_stagings {}",
+        accounting.available_root_probes,
+        accounting.available_root_hits,
+        accounting.proof_stagings
+    );
+    println!(
+        "plan_load_ms {:.1} stage_ms {:.1} replay_share_of_wall {:.1}%",
+        accounting.plan_load_nanos as f64 / 1e6,
+        accounting.stage_nanos as f64 / 1e6,
+        (accounting.plan_load_nanos + accounting.stage_nanos) as f64 / wall.as_nanos() as f64
+            * 100.0
+    );
+    println!(
+        "plans_per_boundary {}",
+        accounting
+            .plans_per_boundary
+            .iter()
+            .map(u64::to_string)
+            .collect::<Vec<_>>()
+            .join(",")
+    );
+
+    // Commit latency at the burst boundary versus everywhere else.
+    let boundary_indices = top_latency_indices(&latencies, accounting.boundaries as usize);
+    println!(
+        "slowest_commit_indices {}",
+        boundary_indices
+            .iter()
+            .map(|(index, duration)| format!("{index}:{:.1}ms", duration.as_secs_f64() * 1000.0))
+            .collect::<Vec<_>>()
+            .join(" ")
+    );
+    let mut sorted = latencies.clone();
+    sorted.sort_unstable();
+    println!(
+        "commit_latency_ms median {:.2} p95 {:.2} max {:.2}",
+        sorted[sorted.len() / 2].as_secs_f64() * 1000.0,
+        sorted[sorted.len() * 95 / 100].as_secs_f64() * 1000.0,
+        sorted[sorted.len() - 1].as_secs_f64() * 1000.0
+    );
+
+    if root_replay_trace_enabled() {
+        println!(
+            "{:<14} {:>14} {:>14} {:>10} {:>14} {:>14}",
+            "phase", "replay_ms", "total_ms", "replay_%", "replay_bytes", "replay_calls"
+        );
+        for (name, bucket) in [
+            ("storage_read", attribution.storage_read),
+            ("decode", attribution.decode),
+            ("encode", attribution.encode),
+            ("hash", attribution.hash),
+        ] {
+            print_bucket(name, bucket);
+        }
+    } else {
+        println!("cost_attribution unavailable: rebuild with --features root-replay-trace");
+    }
+}
+
+fn print_bucket(name: &str, bucket: RootReplayCostBucket) {
+    let share = if bucket.total_nanos == 0 {
+        0.0
+    } else {
+        bucket.replay_nanos as f64 / bucket.total_nanos as f64 * 100.0
+    };
+    println!(
+        "{name:<14} {:>14.1} {:>14.1} {share:>9.1}% {:>14} {:>14}",
+        bucket.replay_nanos as f64 / 1e6,
+        bucket.total_nanos as f64 / 1e6,
+        bucket.replay_bytes,
+        bucket.replay_count
+    );
+}
+
+fn top_latency_indices(latencies: &[Duration], count: usize) -> Vec<(usize, Duration)> {
+    let mut indexed = latencies
+        .iter()
+        .copied()
+        .enumerate()
+        .collect::<Vec<(usize, Duration)>>();
+    indexed.sort_by_key(|(_, duration)| std::cmp::Reverse(*duration));
+    indexed.truncate(count.max(1).min(12));
+    indexed.sort_by_key(|(index, _)| *index);
+    indexed
+}
+
+async fn commit_batch<S>(session: &SessionContext<S>, batch: usize, rows: usize)
+where
+    S: Storage + Clone + Send + Sync + 'static,
+{
+    let mut transaction = session.begin_transaction().await.expect("begin commit");
+    for index in 0..rows {
+        transaction
+            .execute(
+                "INSERT INTO replay_scope (path, value) VALUES ($1, lix_json($2))",
+                &[
+                    Value::Text(format!("/row/{batch:08}/{index:08}")),
+                    Value::Text(format!(r#"{{"batch":{batch},"index":{index}}}"#)),
+                ],
+            )
+            .await
+            .expect("insert row");
+    }
+    transaction.commit().await.expect("commit batch");
+}
+
+async fn register_schema<S>(session: &SessionContext<S>)
+where
+    S: Storage + Clone + Send + Sync + 'static,
+{
+    let schema = serde_json::json!({
+        "x-lix-key": "replay_scope",
+        "x-lix-primary-key": ["/path"],
+        "type": "object",
+        "required": ["path", "value"],
+        "properties": {
+            "path": { "type": "string" },
+            "value": {
+                "type": ["object", "array", "string", "number", "integer", "boolean", "null"]
+            }
+        },
+        "additionalProperties": false
+    });
+    session
+        .execute(
+            "INSERT INTO lix_registered_schema (value, lixcol_global, lixcol_untracked) VALUES (lix_json($1), false, false)",
+            &[Value::Text(schema.to_string())],
+        )
+        .await
+        .expect("register schema");
+}

--- a/packages/engine-benchmarks/examples/expab_plan_load.rs
+++ b/packages/engine-benchmarks/examples/expab_plan_load.rs
@@ -110,23 +110,27 @@ async fn main() {
     println!("op checkpoint wall_ms {:.1}", checkpoint_wall.as_secs_f64() * 1000.0);
     report("checkpoint", &checkpoint);
 
-    let history_start = Instant::now();
-    let history = session
-        .execute(
-            "SELECT lixcol_commit_id FROM replay_scope_history LIMIT 100",
-            &[],
-        )
-        .await;
-    let history_wall = history_start.elapsed();
-    match history {
-        Ok(result) => println!(
-            "op history wall_ms {:.1} rows {}",
-            history_wall.as_secs_f64() * 1000.0,
-            result.len()
-        ),
-        Err(error) => println!("op history unavailable: {error}"),
+    for (label, sql) in [
+        ("history_key_value", "SELECT * FROM lix_key_value_history"),
+        ("history_checkpoint", "SELECT * FROM lix_checkpoint_history"),
+        ("commit_graph", "SELECT * FROM lix_commit"),
+        ("change_scan", "SELECT * FROM lix_change"),
+        ("read_all", "SELECT * FROM replay_scope"),
+    ] {
+        let _ = take_plan_load_attribution();
+        let start = Instant::now();
+        let outcome = session.execute(sql, &[]).await;
+        let elapsed = start.elapsed();
+        match outcome {
+            Ok(result) => println!(
+                "op {label} wall_ms {:.1} rows {}",
+                elapsed.as_secs_f64() * 1000.0,
+                result.len()
+            ),
+            Err(error) => println!("op {label} unavailable: {error}"),
+        }
+        report(label, &take_plan_load_attribution());
     }
-    report("history", &take_plan_load_attribution());
 
     let undo_start = Instant::now();
     let undo = session.undo().await;
@@ -187,11 +191,27 @@ fn report(label: &str, attribution: &PlanLoadAttribution) {
         attribution.members_kept,
         attribution.member_payload_bytes
     );
-    // `delta_segments` encloses `replay_state`; report the exclusive wall too.
-    let replay_state_wall = attribution.phases[3].wall_nanos;
+    // `delta_segments` encloses `replay_state` and `avail_probe` encloses
+    // `avail_tree_scan`; report the exclusive wall alongside the guard wall.
+    let exclusive_of = |index: usize| -> u64 {
+        let wall = attribution.phases[index].wall_nanos;
+        match index {
+            1 => wall.saturating_sub(attribution.phases[6].wall_nanos),
+            4 => wall.saturating_sub(attribution.phases[3].wall_nanos),
+            _ => wall,
+        }
+    };
     println!(
-        "{label}: {:<15} {:>8} {:>12} {:>12} {:>12} {:>10} {:>8} {:>8} {:>12}",
-        "phase", "entries", "wall_ms", "excl_wall_ms", "io_ms", "non_io_ms", "batches", "keys",
+        "{label}: {:<16} {:>8} {:>10} {:>12} {:>10} {:>10} {:>7} {:>8} {:>8} {:>12}",
+        "phase",
+        "entries",
+        "wall_ms",
+        "excl_wall_ms",
+        "io_ms",
+        "non_io_ms",
+        "calls",
+        "reqs",
+        "keys",
         "bytes"
     );
     for (index, name) in PLAN_LOAD_PHASE_NAMES.iter().enumerate() {
@@ -199,18 +219,15 @@ fn report(label: &str, attribution: &PlanLoadAttribution) {
         if phase.entries == 0 && phase.read_batches == 0 {
             continue;
         }
-        let exclusive = if index == 4 {
-            phase.wall_nanos.saturating_sub(replay_state_wall)
-        } else {
-            phase.wall_nanos
-        };
+        let exclusive = exclusive_of(index);
         println!(
-            "{label}: {name:<15} {:>8} {:>12.2} {:>12.2} {:>12.2} {:>10.2} {:>8} {:>8} {:>12}",
+            "{label}: {name:<16} {:>8} {:>10.2} {:>12.2} {:>10.2} {:>10.2} {:>7} {:>8} {:>8} {:>12}",
             phase.entries,
             phase.wall_nanos as f64 / 1e6,
             exclusive as f64 / 1e6,
             phase.io_nanos as f64 / 1e6,
             exclusive.saturating_sub(phase.io_nanos) as f64 / 1e6,
+            phase.read_calls,
             phase.read_batches,
             phase.read_keys,
             phase.read_bytes
@@ -218,45 +235,41 @@ fn report(label: &str, attribution: &PlanLoadAttribution) {
     }
     if attribution.plans > 0 {
         let plans = attribution.plans as f64;
-        let plan_phases = [1usize, 2, 3, 4, 5];
-        let wall: u64 = plan_phases
-            .iter()
-            .map(|index| {
-                if *index == 4 {
-                    attribution.phases[4]
-                        .wall_nanos
-                        .saturating_sub(replay_state_wall)
-                } else {
-                    attribution.phases[*index].wall_nanos
-                }
-            })
-            .sum();
-        let io: u64 = plan_phases
-            .iter()
-            .map(|index| attribution.phases[*index].io_nanos)
-            .sum();
-        let batches: u64 = plan_phases
-            .iter()
-            .map(|index| attribution.phases[*index].read_batches)
-            .sum();
-        let keys: u64 = plan_phases
-            .iter()
-            .map(|index| attribution.phases[*index].read_keys)
-            .sum();
-        let bytes: u64 = plan_phases
-            .iter()
-            .map(|index| attribution.phases[*index].read_bytes)
-            .sum();
+        let plan_phases = [1usize, 2, 3, 4, 5, 6];
+        let sum = |field: fn(&lix::storage_bench::PlanLoadPhaseMetric) -> u64| -> u64 {
+            plan_phases
+                .iter()
+                .map(|index| field(&attribution.phases[*index]))
+                .sum()
+        };
+        let wall: u64 = plan_phases.iter().map(|index| exclusive_of(*index)).sum();
+        let io = sum(|phase| phase.io_nanos);
+        let calls = sum(|phase| phase.read_calls);
+        let keys = sum(|phase| phase.read_keys);
+        let bytes = sum(|phase| phase.read_bytes);
         println!(
-            "{label}: per_plan wall_us {:.2} io_us {:.2} non_io_us {:.2} batches {:.2} keys {:.2} bytes {:.1} members {:.2}",
+            "{label}: per_plan wall_us {:.2} io_us {:.2} non_io_us {:.2} calls {:.2} keys {:.2} bytes {:.1} members {:.2}",
             wall as f64 / plans / 1e3,
             io as f64 / plans / 1e3,
             wall.saturating_sub(io) as f64 / plans / 1e3,
-            batches as f64 / plans,
+            calls as f64 / plans,
             keys as f64 / plans,
             bytes as f64 / plans,
             attribution.members_decoded as f64 / plans
         );
+        let tree = attribution.phases[6];
+        if tree.entries > 0 {
+            println!(
+                "{label}: per_tree_scan entries {} wall_us {:.2} io_us {:.2} non_io_us {:.2} calls {:.2} keys {:.2} bytes {:.1}",
+                tree.entries,
+                tree.wall_nanos as f64 / tree.entries as f64 / 1e3,
+                tree.io_nanos as f64 / tree.entries as f64 / 1e3,
+                tree.wall_nanos.saturating_sub(tree.io_nanos) as f64 / tree.entries as f64 / 1e3,
+                tree.read_calls as f64 / tree.entries as f64,
+                tree.read_keys as f64 / tree.entries as f64,
+                tree.read_bytes as f64 / tree.entries as f64
+            );
+        }
     }
 }
 

--- a/packages/engine-benchmarks/examples/expab_plan_load.rs
+++ b/packages/engine-benchmarks/examples/expab_plan_load.rs
@@ -1,0 +1,307 @@
+//! Commit-root rebuild plan-load attribution (experiment AB).
+//!
+//! Experiment AA measured that 83% of commit-root replay time is spent inside
+//! `load_rebuild_plans_to_nearest_available_root`, at ~76 µs per replayed
+//! ancestor, and called that "plan loading". This example splits one plan load
+//! into its phases and, per phase, separates time spent inside the storage
+//! adapter's `get_many` boundary (I/O) from everything else (decode +
+//! allocation + setup). It also counts physical read batches and keys per
+//! phase, so read amplification is a counter rather than an inference.
+//!
+//! Phases (see `lix::storage_bench::PlanLoadPhase`):
+//!   avail_probe    `load_available_root` — bounded durable-root probe
+//!   commit_record  `ChangelogReader::load_commits` for the replayed commit
+//!   replay_state   `load_point_replay_commit_state` — header + inventory
+//!   delta_segments mutation-directory routing + packed segment reads + decode
+//!   collect        owned-key materialization of the decoded batch
+//!
+//! `delta_segments` nests `replay_state`, so the report prints an exclusive
+//! wall column as well as the raw guard wall.
+//!
+//! The second section answers "is plan loading hot outside replay" by running
+//! checkpoint / history / undo / merge / GC against the same repository and
+//! reporting the same counters for each.
+//!
+//! Build with `--features root-replay-trace`; without it the counters are
+//! compiled out and the example says so.
+//!
+//! Usage: `expab_plan_load [commits] [rows_per_commit]`
+//! (defaults: 200 commits, 10 rows).
+
+use std::time::Instant;
+
+use lix::integration::{Engine, SessionContext};
+use lix::storage::Storage;
+use lix::storage_adapter::StorageAdapter;
+use lix::storage_bench::{
+    PLAN_LOAD_PHASE_NAMES, PlanLoadAttribution, collect_repository_gc_for_bench,
+    plan_load_trace_enabled, take_plan_load_attribution, take_root_replay_accounting,
+};
+use lix::{CreateBranchOptions, MergeBranchOptions, Value};
+use lix_storage_rocksdb::RocksDB;
+
+#[tokio::main(flavor = "current_thread")]
+async fn main() {
+    let mut args = std::env::args().skip(1);
+    let commits = args
+        .next()
+        .and_then(|value| value.parse::<usize>().ok())
+        .unwrap_or(200);
+    let rows_per_commit = args
+        .next()
+        .and_then(|value| value.parse::<usize>().ok())
+        .unwrap_or(10);
+    assert!(commits >= 2, "need at least two commits to measure replay");
+
+    let directory = tempfile::tempdir().expect("create RocksDB directory");
+    let storage = RocksDB::open(directory.path()).expect("open RocksDB");
+    Engine::initialize(storage.clone())
+        .await
+        .expect("initialize repository");
+    let engine = Engine::new(storage.clone()).await.expect("open engine");
+    let session = engine
+        .open_workspace_session()
+        .await
+        .expect("open workspace");
+    register_schema(&session).await;
+
+    // Discard setup accounting so the reported numbers cover only the measured
+    // history.
+    let _ = take_root_replay_accounting();
+    let _ = take_plan_load_attribution();
+
+    println!(
+        "expAB_plan_load commits={commits} rows_per_commit={rows_per_commit} trace={}",
+        plan_load_trace_enabled()
+    );
+
+    let run_start = Instant::now();
+    for index in 0..commits {
+        commit_batch(&session, index, rows_per_commit).await;
+    }
+    let wall = run_start.elapsed();
+
+    let accounting = take_root_replay_accounting();
+    let attribution = take_plan_load_attribution();
+    println!(
+        "wall_ms {:.1} boundaries {} plans_loaded {} plans_staged {} max_plans_in_one_boundary {}",
+        wall.as_secs_f64() * 1000.0,
+        accounting.boundaries,
+        accounting.plans_loaded,
+        accounting.plans_staged,
+        accounting.max_plans_in_one_boundary
+    );
+    println!(
+        "plan_load_ms {:.1} stage_ms {:.1}",
+        accounting.plan_load_nanos as f64 / 1e6,
+        accounting.stage_nanos as f64 / 1e6
+    );
+    report("commit_loop", &attribution);
+
+    // ---- Is plan loading hot outside replay? -------------------------------
+    let _ = take_plan_load_attribution();
+    let checkpoint_start = Instant::now();
+    session
+        .create_checkpoint()
+        .await
+        .expect("checkpoint should publish");
+    let checkpoint_wall = checkpoint_start.elapsed();
+    let checkpoint = take_plan_load_attribution();
+    println!("op checkpoint wall_ms {:.1}", checkpoint_wall.as_secs_f64() * 1000.0);
+    report("checkpoint", &checkpoint);
+
+    let history_start = Instant::now();
+    let history = session
+        .execute(
+            "SELECT lixcol_commit_id FROM replay_scope_history LIMIT 100",
+            &[],
+        )
+        .await;
+    let history_wall = history_start.elapsed();
+    match history {
+        Ok(result) => println!(
+            "op history wall_ms {:.1} rows {}",
+            history_wall.as_secs_f64() * 1000.0,
+            result.len()
+        ),
+        Err(error) => println!("op history unavailable: {error}"),
+    }
+    report("history", &take_plan_load_attribution());
+
+    let undo_start = Instant::now();
+    let undo = session.undo().await;
+    let undo_wall = undo_start.elapsed();
+    match undo {
+        Ok(_) => println!("op undo wall_ms {:.1}", undo_wall.as_secs_f64() * 1000.0),
+        Err(error) => println!("op undo unavailable: {error}"),
+    }
+    report("undo", &take_plan_load_attribution());
+
+    let branch = session
+        .create_branch(CreateBranchOptions {
+            id: None,
+            name: "expab-branch".to_owned(),
+            from_commit_id: None,
+        })
+        .await
+        .expect("create branch")
+        .id;
+    let branch_session = engine
+        .open_session(branch.clone())
+        .await
+        .expect("open branch session");
+    for index in 0..8 {
+        commit_batch(&branch_session, commits + index, rows_per_commit).await;
+    }
+    let _ = take_plan_load_attribution();
+    let merge_start = Instant::now();
+    session
+        .merge_branch(MergeBranchOptions {
+            source_branch_id: branch.clone(),
+        })
+        .await
+        .expect("merge branch");
+    let merge_wall = merge_start.elapsed();
+    println!("op merge wall_ms {:.1}", merge_wall.as_secs_f64() * 1000.0);
+    report("merge", &take_plan_load_attribution());
+
+    let adapter = StorageAdapter::new(storage.clone());
+    let gc_start = Instant::now();
+    collect_repository_gc_for_bench(&adapter)
+        .await
+        .expect("collect repository GC");
+    let gc_wall = gc_start.elapsed();
+    println!("op gc wall_ms {:.1}", gc_wall.as_secs_f64() * 1000.0);
+    report("gc", &take_plan_load_attribution());
+}
+
+fn report(label: &str, attribution: &PlanLoadAttribution) {
+    if !plan_load_trace_enabled() {
+        println!("{label}: attribution unavailable, rebuild with --features root-replay-trace");
+        return;
+    }
+    println!(
+        "{label}: plans {} members_decoded {} members_kept {} member_key_bytes {}",
+        attribution.plans,
+        attribution.members_decoded,
+        attribution.members_kept,
+        attribution.member_payload_bytes
+    );
+    // `delta_segments` encloses `replay_state`; report the exclusive wall too.
+    let replay_state_wall = attribution.phases[3].wall_nanos;
+    println!(
+        "{label}: {:<15} {:>8} {:>12} {:>12} {:>12} {:>10} {:>8} {:>8} {:>12}",
+        "phase", "entries", "wall_ms", "excl_wall_ms", "io_ms", "non_io_ms", "batches", "keys",
+        "bytes"
+    );
+    for (index, name) in PLAN_LOAD_PHASE_NAMES.iter().enumerate() {
+        let phase = attribution.phases[index];
+        if phase.entries == 0 && phase.read_batches == 0 {
+            continue;
+        }
+        let exclusive = if index == 4 {
+            phase.wall_nanos.saturating_sub(replay_state_wall)
+        } else {
+            phase.wall_nanos
+        };
+        println!(
+            "{label}: {name:<15} {:>8} {:>12.2} {:>12.2} {:>12.2} {:>10.2} {:>8} {:>8} {:>12}",
+            phase.entries,
+            phase.wall_nanos as f64 / 1e6,
+            exclusive as f64 / 1e6,
+            phase.io_nanos as f64 / 1e6,
+            exclusive.saturating_sub(phase.io_nanos) as f64 / 1e6,
+            phase.read_batches,
+            phase.read_keys,
+            phase.read_bytes
+        );
+    }
+    if attribution.plans > 0 {
+        let plans = attribution.plans as f64;
+        let plan_phases = [1usize, 2, 3, 4, 5];
+        let wall: u64 = plan_phases
+            .iter()
+            .map(|index| {
+                if *index == 4 {
+                    attribution.phases[4]
+                        .wall_nanos
+                        .saturating_sub(replay_state_wall)
+                } else {
+                    attribution.phases[*index].wall_nanos
+                }
+            })
+            .sum();
+        let io: u64 = plan_phases
+            .iter()
+            .map(|index| attribution.phases[*index].io_nanos)
+            .sum();
+        let batches: u64 = plan_phases
+            .iter()
+            .map(|index| attribution.phases[*index].read_batches)
+            .sum();
+        let keys: u64 = plan_phases
+            .iter()
+            .map(|index| attribution.phases[*index].read_keys)
+            .sum();
+        let bytes: u64 = plan_phases
+            .iter()
+            .map(|index| attribution.phases[*index].read_bytes)
+            .sum();
+        println!(
+            "{label}: per_plan wall_us {:.2} io_us {:.2} non_io_us {:.2} batches {:.2} keys {:.2} bytes {:.1} members {:.2}",
+            wall as f64 / plans / 1e3,
+            io as f64 / plans / 1e3,
+            wall.saturating_sub(io) as f64 / plans / 1e3,
+            batches as f64 / plans,
+            keys as f64 / plans,
+            bytes as f64 / plans,
+            attribution.members_decoded as f64 / plans
+        );
+    }
+}
+
+async fn commit_batch<S>(session: &SessionContext<S>, batch: usize, rows: usize)
+where
+    S: Storage + Clone + Send + Sync + 'static,
+{
+    let mut transaction = session.begin_transaction().await.expect("begin commit");
+    for index in 0..rows {
+        transaction
+            .execute(
+                "INSERT INTO replay_scope (path, value) VALUES ($1, lix_json($2))",
+                &[
+                    Value::Text(format!("/row/{batch:08}/{index:08}")),
+                    Value::Text(format!(r#"{{"batch":{batch},"index":{index}}}"#)),
+                ],
+            )
+            .await
+            .expect("insert row");
+    }
+    transaction.commit().await.expect("commit batch");
+}
+
+async fn register_schema<S>(session: &SessionContext<S>)
+where
+    S: Storage + Clone + Send + Sync + 'static,
+{
+    let schema = serde_json::json!({
+        "x-lix-key": "replay_scope",
+        "x-lix-primary-key": ["/path"],
+        "type": "object",
+        "required": ["path", "value"],
+        "properties": {
+            "path": { "type": "string" },
+            "value": {
+                "type": ["object", "array", "string", "number", "integer", "boolean", "null"]
+            }
+        },
+        "additionalProperties": false
+    });
+    session
+        .execute(
+            "INSERT INTO lix_registered_schema (value, lixcol_global, lixcol_untracked) VALUES (lix_json($1), false, false)",
+            &[Value::Text(schema.to_string())],
+        )
+        .await
+        .expect("register schema");
+}

--- a/packages/engine-benchmarks/examples/expab_plan_load.rs
+++ b/packages/engine-benchmarks/examples/expab_plan_load.rs
@@ -28,7 +28,7 @@
 //! Usage: `expab_plan_load [commits] [rows_per_commit]`
 //! (defaults: 200 commits, 10 rows).
 
-use std::time::Instant;
+use std::time::{Duration, Instant};
 
 use lix::integration::{Engine, SessionContext};
 use lix::storage::Storage;
@@ -39,6 +39,7 @@ use lix::storage_bench::{
 };
 use lix::{CreateBranchOptions, MergeBranchOptions, Value};
 use lix_storage_rocksdb::RocksDB;
+use lix_storage_slatedb::SlateDB;
 
 #[tokio::main(flavor = "current_thread")]
 async fn main() {
@@ -51,10 +52,27 @@ async fn main() {
         .next()
         .and_then(|value| value.parse::<usize>().ok())
         .unwrap_or(10);
+    let backend = args.next().unwrap_or_else(|| "rocksdb".to_owned());
     assert!(commits >= 2, "need at least two commits to measure replay");
 
-    let directory = tempfile::tempdir().expect("create RocksDB directory");
-    let storage = RocksDB::open(directory.path()).expect("open RocksDB");
+    let directory = tempfile::tempdir().expect("create storage directory");
+    match backend.as_str() {
+        "rocksdb" => {
+            let storage = RocksDB::open(directory.path()).expect("open RocksDB");
+            run(storage, &backend, commits, rows_per_commit).await;
+        }
+        "slatedb" => {
+            let storage = SlateDB::open(directory.path()).expect("open SlateDB");
+            run(storage, &backend, commits, rows_per_commit).await;
+        }
+        other => panic!("unknown backend '{other}', expected rocksdb or slatedb"),
+    }
+}
+
+async fn run<S>(storage: S, backend: &str, commits: usize, rows_per_commit: usize)
+where
+    S: Storage + Clone + Send + Sync + 'static,
+{
     Engine::initialize(storage.clone())
         .await
         .expect("initialize repository");
@@ -71,13 +89,16 @@ async fn main() {
     let _ = take_plan_load_attribution();
 
     println!(
-        "expAB_plan_load commits={commits} rows_per_commit={rows_per_commit} trace={}",
+        "expAB_plan_load backend={backend} commits={commits} rows_per_commit={rows_per_commit} trace={}",
         plan_load_trace_enabled()
     );
 
+    let mut latencies = Vec::with_capacity(commits);
     let run_start = Instant::now();
     for index in 0..commits {
+        let start = Instant::now();
         commit_batch(&session, index, rows_per_commit).await;
+        latencies.push(start.elapsed());
     }
     let wall = run_start.elapsed();
 
@@ -96,7 +117,31 @@ async fn main() {
         accounting.plan_load_nanos as f64 / 1e6,
         accounting.stage_nanos as f64 / 1e6
     );
+    // Boundary commits carry the whole root materialization, so the tail of the
+    // latency distribution is where a per-boundary cost shows up.
+    let mut sorted = latencies.clone();
+    sorted.sort_unstable();
+    let boundary_count = (accounting.boundaries as usize).max(1).min(sorted.len());
+    let worst_mean = sorted[sorted.len() - boundary_count..]
+        .iter()
+        .sum::<Duration>()
+        .as_secs_f64()
+        * 1000.0
+        / boundary_count as f64;
+    println!(
+        "commit_latency_ms median {:.3} p95 {:.3} p99 {:.3} max {:.3} worst{}_mean {:.3}",
+        sorted[sorted.len() / 2].as_secs_f64() * 1000.0,
+        sorted[sorted.len() * 95 / 100].as_secs_f64() * 1000.0,
+        sorted[sorted.len() * 99 / 100].as_secs_f64() * 1000.0,
+        sorted[sorted.len() - 1].as_secs_f64() * 1000.0,
+        boundary_count,
+        worst_mean
+    );
     report("commit_loop", &attribution);
+
+    if std::env::var("LIX_EXPAB_OPS").is_err() {
+        return;
+    }
 
     // ---- Is plan loading hot outside replay? -------------------------------
     let _ = take_plan_load_attribution();

--- a/packages/lix/Cargo.toml
+++ b/packages/lix/Cargo.toml
@@ -22,6 +22,9 @@ workspace = true
 default = ["default_wasm_runtime"]
 all-simulations = []
 storage-benches = []
+# Per-node cost attribution for commit-root replay (experiment AA). Kept out of
+# `storage-benches` so timing A/B runs never pay for the inline `Instant::now()`.
+root-replay-trace = ["storage-benches"]
 default_wasm_runtime = ["dep:wasmtime", "dep:wasmtime-wasi"]
 
 [[test]]

--- a/packages/lix/src/storage_adapter/read_scope.rs
+++ b/packages/lix/src/storage_adapter/read_scope.rs
@@ -86,6 +86,42 @@ where
     }
 }
 
+/// Charges one adapter point-read batch to the active plan-load phase.
+///
+/// This is the single boundary every engine point read crosses, so counting
+/// here answers "how many physical reads does one plan load issue" without
+/// trusting a hand audit of the call tree.
+#[cfg(feature = "root-replay-trace")]
+async fn traced_get_many<F>(
+    requests: &[GetManyRequest<'_>],
+    future: F,
+) -> Result<GetManyResult, StorageError>
+where
+    F: Future<Output = Result<GetManyResult, StorageError>>,
+{
+    let keys = requests
+        .iter()
+        .map(|request| request.keys.len() as u64)
+        .sum::<u64>();
+    let start = std::time::Instant::now();
+    let result = future.await;
+    let nanos = start.elapsed().as_nanos() as u64;
+    let (hits, bytes) = match result.as_ref() {
+        Ok(result) => result.values.iter().flatten().fold(
+            (0u64, 0u64),
+            |(hits, bytes), value| match value {
+                crate::storage::ProjectedValue::KeyOnly => (hits + 1, bytes),
+                crate::storage::ProjectedValue::FullValue(payload) => {
+                    (hits + 1, bytes + payload.len() as u64)
+                }
+            },
+        ),
+        Err(_) => (0, 0),
+    };
+    crate::storage_bench::record_plan_load_io(nanos, requests.len() as u64, keys, hits, bytes);
+    result
+}
+
 impl<R> StorageAdapterRead for StorageAdapterReadScope<R>
 where
     R: StorageRead,
@@ -98,7 +134,14 @@ where
         &self,
         requests: &[GetManyRequest<'_>],
     ) -> impl Future<Output = Result<GetManyResult, StorageError>> + Send {
-        self.read.get_many(requests)
+        #[cfg(feature = "root-replay-trace")]
+        {
+            traced_get_many(requests, self.read.get_many(requests))
+        }
+        #[cfg(not(feature = "root-replay-trace"))]
+        {
+            self.read.get_many(requests)
+        }
     }
 
     fn begin_scan(
@@ -123,7 +166,14 @@ where
         &self,
         requests: &[GetManyRequest<'_>],
     ) -> impl Future<Output = Result<GetManyResult, StorageError>> + Send {
-        self.read.get_many(requests)
+        #[cfg(feature = "root-replay-trace")]
+        {
+            traced_get_many(requests, self.read.get_many(requests))
+        }
+        #[cfg(not(feature = "root-replay-trace"))]
+        {
+            self.read.get_many(requests)
+        }
     }
 
     fn begin_scan(

--- a/packages/lix/src/storage_bench.rs
+++ b/packages/lix/src/storage_bench.rs
@@ -458,6 +458,313 @@ pub fn take_crud_current_state_scoped_range_accounting() -> CrudCurrentStateScop
     }
 }
 
+// ---------------------------------------------------------------------------
+// Commit-root replay accounting (experiment AA).
+//
+// Answers "how many ancestor commits does one root-materialization boundary
+// replay, and where does the per-replayed-commit cost go". The coarse counters
+// tick once per boundary/plan and are always compiled under `storage-benches`.
+// The per-node cost attribution is behind `root-replay-trace` so no timing A/B
+// ever pays for an `Instant::now()` inside `hash_bytes`.
+// ---------------------------------------------------------------------------
+
+static ROOT_REPLAY_BOUNDARIES: AtomicU64 = AtomicU64::new(0);
+static ROOT_REPLAY_PLANS_LOADED: AtomicU64 = AtomicU64::new(0);
+static ROOT_REPLAY_PLANS_STAGED: AtomicU64 = AtomicU64::new(0);
+static ROOT_REPLAY_AVAILABLE_ROOT_PROBES: AtomicU64 = AtomicU64::new(0);
+static ROOT_REPLAY_AVAILABLE_ROOT_HITS: AtomicU64 = AtomicU64::new(0);
+static ROOT_REPLAY_PROOF_STAGINGS: AtomicU64 = AtomicU64::new(0);
+static ROOT_REPLAY_MAX_PLANS: AtomicU64 = AtomicU64::new(0);
+
+static ROOT_REPLAY_PLAN_LOAD_NANOS: AtomicU64 = AtomicU64::new(0);
+static ROOT_REPLAY_STAGE_NANOS: AtomicU64 = AtomicU64::new(0);
+
+/// Per-boundary replay-set sizes, in boundary order.
+static ROOT_REPLAY_PLAN_HISTOGRAM: std::sync::Mutex<Vec<u64>> = std::sync::Mutex::new(Vec::new());
+
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct RootReplayAccounting {
+    /// Distinct durable rootless parents that forced a replay.
+    pub boundaries: u64,
+    /// Total rebuild plans returned by the nearest-available-root walk.
+    pub plans_loaded: u64,
+    /// Plans actually replayed through the tracked-state root writer.
+    pub plans_staged: u64,
+    pub available_root_probes: u64,
+    pub available_root_hits: u64,
+    /// Root stagings performed inside the ancestry proof itself.
+    pub proof_stagings: u64,
+    pub max_plans_in_one_boundary: u64,
+    pub plan_load_nanos: u64,
+    pub stage_nanos: u64,
+    /// Replay-set size per boundary, in boundary order.
+    pub plans_per_boundary: Vec<u64>,
+}
+
+pub(crate) fn record_root_replay_boundary(plans: usize) {
+    ROOT_REPLAY_BOUNDARIES.fetch_add(1, Ordering::Relaxed);
+    ROOT_REPLAY_PLANS_LOADED.fetch_add(plans as u64, Ordering::Relaxed);
+    ROOT_REPLAY_MAX_PLANS.fetch_max(plans as u64, Ordering::Relaxed);
+    if let Ok(mut histogram) = ROOT_REPLAY_PLAN_HISTOGRAM.lock() {
+        histogram.push(plans as u64);
+    }
+}
+
+pub(crate) fn record_root_replay_plan_staged() {
+    ROOT_REPLAY_PLANS_STAGED.fetch_add(1, Ordering::Relaxed);
+}
+
+pub(crate) fn record_root_replay_available_root_probe(hit: bool) {
+    ROOT_REPLAY_AVAILABLE_ROOT_PROBES.fetch_add(1, Ordering::Relaxed);
+    if hit {
+        ROOT_REPLAY_AVAILABLE_ROOT_HITS.fetch_add(1, Ordering::Relaxed);
+    }
+}
+
+/// Retained so the base and candidate arms of an A/B expose the same
+/// accounting surface; the bounded availability proof performs no stagings.
+#[allow(dead_code)]
+pub(crate) fn record_root_replay_proof_staging() {
+    ROOT_REPLAY_PROOF_STAGINGS.fetch_add(1, Ordering::Relaxed);
+}
+
+pub(crate) fn record_root_replay_plan_load_nanos(nanos: u64) {
+    ROOT_REPLAY_PLAN_LOAD_NANOS.fetch_add(nanos, Ordering::Relaxed);
+}
+
+pub(crate) fn record_root_replay_stage_nanos(nanos: u64) {
+    ROOT_REPLAY_STAGE_NANOS.fetch_add(nanos, Ordering::Relaxed);
+}
+
+pub fn take_root_replay_accounting() -> RootReplayAccounting {
+    RootReplayAccounting {
+        boundaries: ROOT_REPLAY_BOUNDARIES.swap(0, Ordering::Relaxed),
+        plans_loaded: ROOT_REPLAY_PLANS_LOADED.swap(0, Ordering::Relaxed),
+        plans_staged: ROOT_REPLAY_PLANS_STAGED.swap(0, Ordering::Relaxed),
+        available_root_probes: ROOT_REPLAY_AVAILABLE_ROOT_PROBES.swap(0, Ordering::Relaxed),
+        available_root_hits: ROOT_REPLAY_AVAILABLE_ROOT_HITS.swap(0, Ordering::Relaxed),
+        proof_stagings: ROOT_REPLAY_PROOF_STAGINGS.swap(0, Ordering::Relaxed),
+        max_plans_in_one_boundary: ROOT_REPLAY_MAX_PLANS.swap(0, Ordering::Relaxed),
+        plan_load_nanos: ROOT_REPLAY_PLAN_LOAD_NANOS.swap(0, Ordering::Relaxed),
+        stage_nanos: ROOT_REPLAY_STAGE_NANOS.swap(0, Ordering::Relaxed),
+        plans_per_boundary: ROOT_REPLAY_PLAN_HISTOGRAM
+            .lock()
+            .map(|mut histogram| std::mem::take(&mut *histogram))
+            .unwrap_or_default(),
+    }
+}
+
+/// Per-node cost attribution for replayed commits.
+///
+/// Every bucket records `(in_replay, total)` so a run can say what fraction of
+/// all tracked-state tree CPU is spent inside commit-root replay rather than on
+/// the commit's own mutations.
+#[cfg(feature = "root-replay-trace")]
+mod replay_trace {
+    use std::cell::Cell;
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    macro_rules! bucket {
+        ($replay_ns:ident, $total_ns:ident, $replay_bytes:ident, $total_bytes:ident,
+         $replay_count:ident, $total_count:ident, $record:ident) => {
+            static $replay_ns: AtomicU64 = AtomicU64::new(0);
+            static $total_ns: AtomicU64 = AtomicU64::new(0);
+            static $replay_bytes: AtomicU64 = AtomicU64::new(0);
+            static $total_bytes: AtomicU64 = AtomicU64::new(0);
+            static $replay_count: AtomicU64 = AtomicU64::new(0);
+            static $total_count: AtomicU64 = AtomicU64::new(0);
+
+            pub(crate) fn $record(nanos: u64, bytes: u64) {
+                $total_ns.fetch_add(nanos, Ordering::Relaxed);
+                $total_bytes.fetch_add(bytes, Ordering::Relaxed);
+                $total_count.fetch_add(1, Ordering::Relaxed);
+                if in_replay() {
+                    $replay_ns.fetch_add(nanos, Ordering::Relaxed);
+                    $replay_bytes.fetch_add(bytes, Ordering::Relaxed);
+                    $replay_count.fetch_add(1, Ordering::Relaxed);
+                }
+            }
+        };
+    }
+
+    thread_local! {
+        static REPLAY_DEPTH: Cell<u32> = const { Cell::new(0) };
+    }
+
+    pub(crate) fn in_replay() -> bool {
+        REPLAY_DEPTH.with(|depth| depth.get() > 0)
+    }
+
+    pub(crate) fn enter() {
+        REPLAY_DEPTH.with(|depth| depth.set(depth.get().saturating_add(1)));
+    }
+
+    pub(crate) fn exit() {
+        REPLAY_DEPTH.with(|depth| depth.set(depth.get().saturating_sub(1)));
+    }
+
+    bucket!(
+        READ_NS,
+        READ_TOTAL_NS,
+        READ_BYTES,
+        READ_TOTAL_BYTES,
+        READ_COUNT,
+        READ_TOTAL_COUNT,
+        record_chunk_read
+    );
+    bucket!(
+        DECODE_NS,
+        DECODE_TOTAL_NS,
+        DECODE_BYTES,
+        DECODE_TOTAL_BYTES,
+        DECODE_COUNT,
+        DECODE_TOTAL_COUNT,
+        record_node_decode
+    );
+    bucket!(
+        ENCODE_NS,
+        ENCODE_TOTAL_NS,
+        ENCODE_BYTES,
+        ENCODE_TOTAL_BYTES,
+        ENCODE_COUNT,
+        ENCODE_TOTAL_COUNT,
+        record_node_encode
+    );
+    bucket!(
+        HASH_NS,
+        HASH_TOTAL_NS,
+        HASH_BYTES,
+        HASH_TOTAL_BYTES,
+        HASH_COUNT,
+        HASH_TOTAL_COUNT,
+        record_node_hash
+    );
+
+    pub(crate) fn take() -> super::RootReplayCostAttribution {
+        let bucket = |ns: &AtomicU64,
+                      total_ns: &AtomicU64,
+                      bytes: &AtomicU64,
+                      total_bytes: &AtomicU64,
+                      count: &AtomicU64,
+                      total_count: &AtomicU64| {
+            super::RootReplayCostBucket {
+                replay_nanos: ns.swap(0, Ordering::Relaxed),
+                total_nanos: total_ns.swap(0, Ordering::Relaxed),
+                replay_bytes: bytes.swap(0, Ordering::Relaxed),
+                total_bytes: total_bytes.swap(0, Ordering::Relaxed),
+                replay_count: count.swap(0, Ordering::Relaxed),
+                total_count: total_count.swap(0, Ordering::Relaxed),
+            }
+        };
+        super::RootReplayCostAttribution {
+            storage_read: bucket(
+                &READ_NS,
+                &READ_TOTAL_NS,
+                &READ_BYTES,
+                &READ_TOTAL_BYTES,
+                &READ_COUNT,
+                &READ_TOTAL_COUNT,
+            ),
+            decode: bucket(
+                &DECODE_NS,
+                &DECODE_TOTAL_NS,
+                &DECODE_BYTES,
+                &DECODE_TOTAL_BYTES,
+                &DECODE_COUNT,
+                &DECODE_TOTAL_COUNT,
+            ),
+            encode: bucket(
+                &ENCODE_NS,
+                &ENCODE_TOTAL_NS,
+                &ENCODE_BYTES,
+                &ENCODE_TOTAL_BYTES,
+                &ENCODE_COUNT,
+                &ENCODE_TOTAL_COUNT,
+            ),
+            hash: bucket(
+                &HASH_NS,
+                &HASH_TOTAL_NS,
+                &HASH_BYTES,
+                &HASH_TOTAL_BYTES,
+                &HASH_COUNT,
+                &HASH_TOTAL_COUNT,
+            ),
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct RootReplayCostBucket {
+    pub replay_nanos: u64,
+    pub total_nanos: u64,
+    pub replay_bytes: u64,
+    pub total_bytes: u64,
+    pub replay_count: u64,
+    pub total_count: u64,
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct RootReplayCostAttribution {
+    pub storage_read: RootReplayCostBucket,
+    pub decode: RootReplayCostBucket,
+    pub encode: RootReplayCostBucket,
+    pub hash: RootReplayCostBucket,
+}
+
+/// True when this build carries the per-node replay cost attribution.
+pub fn root_replay_trace_enabled() -> bool {
+    cfg!(feature = "root-replay-trace")
+}
+
+pub fn take_root_replay_cost_attribution() -> RootReplayCostAttribution {
+    #[cfg(feature = "root-replay-trace")]
+    {
+        replay_trace::take()
+    }
+    #[cfg(not(feature = "root-replay-trace"))]
+    {
+        RootReplayCostAttribution::default()
+    }
+}
+
+/// Marks the dynamic extent of one commit-root replay for cost attribution.
+pub(crate) struct RootReplayScope;
+
+impl RootReplayScope {
+    pub(crate) fn enter() -> Self {
+        #[cfg(feature = "root-replay-trace")]
+        replay_trace::enter();
+        Self
+    }
+}
+
+impl Drop for RootReplayScope {
+    fn drop(&mut self) {
+        #[cfg(feature = "root-replay-trace")]
+        replay_trace::exit();
+    }
+}
+
+#[cfg(feature = "root-replay-trace")]
+pub(crate) fn record_replay_chunk_read(nanos: u64, bytes: u64) {
+    replay_trace::record_chunk_read(nanos, bytes);
+}
+
+#[cfg(feature = "root-replay-trace")]
+pub(crate) fn record_replay_node_decode(nanos: u64, bytes: u64) {
+    replay_trace::record_node_decode(nanos, bytes);
+}
+
+#[cfg(feature = "root-replay-trace")]
+pub(crate) fn record_replay_node_encode(nanos: u64, bytes: u64) {
+    replay_trace::record_node_encode(nanos, bytes);
+}
+
+#[cfg(feature = "root-replay-trace")]
+pub(crate) fn record_replay_node_hash(nanos: u64, bytes: u64) {
+    replay_trace::record_node_hash(nanos, bytes);
+}
+
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub struct BinaryCasWriteAccounting {
     pub chunk_lookup_count: u64,

--- a/packages/lix/src/storage_bench.rs
+++ b/packages/lix/src/storage_bench.rs
@@ -794,9 +794,13 @@ pub enum PlanLoadPhase {
     DeltaSegments = 4,
     /// Owned-key materialization of the decoded batch into plan deltas.
     Collect = 5,
+    /// `commit_root_tree_is_readable` — the full tracked-state tree scan the
+    /// availability probe runs to prove the addressed chunk closure is
+    /// physically readable. Nested inside `AvailProbe`.
+    AvailTreeScan = 6,
 }
 
-pub const PLAN_LOAD_PHASE_COUNT: usize = 6;
+pub const PLAN_LOAD_PHASE_COUNT: usize = 7;
 
 pub const PLAN_LOAD_PHASE_NAMES: [&str; PLAN_LOAD_PHASE_COUNT] = [
     "other",
@@ -805,6 +809,7 @@ pub const PLAN_LOAD_PHASE_NAMES: [&str; PLAN_LOAD_PHASE_COUNT] = [
     "replay_state",
     "delta_segments",
     "collect",
+    "avail_tree_scan",
 ];
 
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
@@ -813,7 +818,9 @@ pub struct PlanLoadPhaseMetric {
     pub wall_nanos: u64,
     /// Wall time inside `StorageAdapterRead::get_many` while in this phase.
     pub io_nanos: u64,
-    /// `get_many` batches issued while in this phase.
+    /// `StorageAdapterRead::get_many` invocations issued while in this phase.
+    pub read_calls: u64,
+    /// Logical per-space requests inside those invocations.
     pub read_batches: u64,
     /// Keys requested across those batches.
     pub read_keys: u64,
@@ -850,7 +857,7 @@ mod plan_load_trace {
 
     use super::{PLAN_LOAD_PHASE_COUNT, PlanLoadAttribution, PlanLoadPhase, PlanLoadPhaseMetric};
 
-    const FIELDS: usize = 7;
+    const FIELDS: usize = 8;
 
     #[allow(clippy::declare_interior_mutable_const)]
     const ZERO: AtomicU64 = AtomicU64::new(0);
@@ -889,6 +896,7 @@ mod plan_load_trace {
         add(phase, 3, keys);
         add(phase, 4, hits);
         add(phase, 5, bytes);
+        add(phase, 7, 1);
     }
 
     pub(super) fn record_plan(members_decoded: u64, members_kept: u64, payload_bytes: u64) {
@@ -910,6 +918,7 @@ mod plan_load_trace {
                 read_hits: get(4),
                 read_bytes: get(5),
                 entries: get(6),
+                read_calls: get(7),
             };
         }
         PlanLoadAttribution {

--- a/packages/lix/src/storage_bench.rs
+++ b/packages/lix/src/storage_bench.rs
@@ -765,6 +765,232 @@ pub(crate) fn record_replay_node_hash(nanos: u64, bytes: u64) {
     replay_trace::record_node_hash(nanos, bytes);
 }
 
+// ---------------------------------------------------------------------------
+// Plan-load phase attribution (experiment AB).
+//
+// Splits one commit-root rebuild plan load into named phases and, for every
+// phase, separates the time spent inside the storage adapter's `get_many`
+// boundary (I/O) from everything else (decode + allocation + setup). Also
+// counts physical read batches and keys per phase, so "how many physical reads
+// does one plan load issue" is answered by a counter rather than a guess.
+//
+// Gated behind `root-replay-trace` exactly like the AA attribution, so no A/B
+// timing build pays for an `Instant::now()` inside `get_many`.
+// ---------------------------------------------------------------------------
+
+/// Named phases of one commit-root rebuild plan load.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum PlanLoadPhase {
+    /// Everything outside a plan load.
+    Other = 0,
+    /// `load_available_root` — the bounded durable-root availability probe.
+    AvailProbe = 1,
+    /// `ChangelogReader::load_commits` for the one replayed commit.
+    CommitRecord = 2,
+    /// `load_point_replay_commit_state` — commit-state header + inventory.
+    ReplayState = 3,
+    /// Mutation-directory routing plus packed commit-delta segment reads and
+    /// leaf decode.
+    DeltaSegments = 4,
+    /// Owned-key materialization of the decoded batch into plan deltas.
+    Collect = 5,
+}
+
+pub const PLAN_LOAD_PHASE_COUNT: usize = 6;
+
+pub const PLAN_LOAD_PHASE_NAMES: [&str; PLAN_LOAD_PHASE_COUNT] = [
+    "other",
+    "avail_probe",
+    "commit_record",
+    "replay_state",
+    "delta_segments",
+    "collect",
+];
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct PlanLoadPhaseMetric {
+    /// Wall time inside the phase guard.
+    pub wall_nanos: u64,
+    /// Wall time inside `StorageAdapterRead::get_many` while in this phase.
+    pub io_nanos: u64,
+    /// `get_many` batches issued while in this phase.
+    pub read_batches: u64,
+    /// Keys requested across those batches.
+    pub read_keys: u64,
+    /// Keys that returned a value.
+    pub read_hits: u64,
+    /// Bytes returned by those batches.
+    pub read_bytes: u64,
+    /// Times the phase guard was entered.
+    pub entries: u64,
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct PlanLoadAttribution {
+    pub phases: [PlanLoadPhaseMetric; PLAN_LOAD_PHASE_COUNT],
+    /// Plan loads completed (one per replayed ancestor).
+    pub plans: u64,
+    /// Commit-delta members decoded across those plan loads.
+    pub members_decoded: u64,
+    /// Members kept in the returned plan.
+    pub members_kept: u64,
+    /// Bytes of packed commit-delta segment payload decoded.
+    pub member_payload_bytes: u64,
+}
+
+/// True when this build carries the plan-load phase attribution.
+pub fn plan_load_trace_enabled() -> bool {
+    cfg!(feature = "root-replay-trace")
+}
+
+#[cfg(feature = "root-replay-trace")]
+mod plan_load_trace {
+    use std::cell::Cell;
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    use super::{PLAN_LOAD_PHASE_COUNT, PlanLoadAttribution, PlanLoadPhase, PlanLoadPhaseMetric};
+
+    const FIELDS: usize = 7;
+
+    #[allow(clippy::declare_interior_mutable_const)]
+    const ZERO: AtomicU64 = AtomicU64::new(0);
+    static COUNTERS: [AtomicU64; PLAN_LOAD_PHASE_COUNT * FIELDS] =
+        [ZERO; PLAN_LOAD_PHASE_COUNT * FIELDS];
+    static PLANS: AtomicU64 = AtomicU64::new(0);
+    static MEMBERS_DECODED: AtomicU64 = AtomicU64::new(0);
+    static MEMBERS_KEPT: AtomicU64 = AtomicU64::new(0);
+    static MEMBER_PAYLOAD_BYTES: AtomicU64 = AtomicU64::new(0);
+
+    thread_local! {
+        static PHASE: Cell<usize> = const { Cell::new(0) };
+    }
+
+    fn add(phase: usize, field: usize, value: u64) {
+        COUNTERS[phase * FIELDS + field].fetch_add(value, Ordering::Relaxed);
+    }
+
+    pub(super) fn current_phase() -> usize {
+        PHASE.with(Cell::get)
+    }
+
+    pub(super) fn set_phase(phase: usize) -> usize {
+        PHASE.with(|slot| slot.replace(phase))
+    }
+
+    pub(super) fn record_phase_wall(phase: usize, nanos: u64) {
+        add(phase, 0, nanos);
+        add(phase, 6, 1);
+    }
+
+    pub(super) fn record_io(nanos: u64, batches: u64, keys: u64, hits: u64, bytes: u64) {
+        let phase = current_phase();
+        add(phase, 1, nanos);
+        add(phase, 2, batches);
+        add(phase, 3, keys);
+        add(phase, 4, hits);
+        add(phase, 5, bytes);
+    }
+
+    pub(super) fn record_plan(members_decoded: u64, members_kept: u64, payload_bytes: u64) {
+        PLANS.fetch_add(1, Ordering::Relaxed);
+        MEMBERS_DECODED.fetch_add(members_decoded, Ordering::Relaxed);
+        MEMBERS_KEPT.fetch_add(members_kept, Ordering::Relaxed);
+        MEMBER_PAYLOAD_BYTES.fetch_add(payload_bytes, Ordering::Relaxed);
+    }
+
+    pub(super) fn take() -> PlanLoadAttribution {
+        let mut phases = [PlanLoadPhaseMetric::default(); PLAN_LOAD_PHASE_COUNT];
+        for (index, phase) in phases.iter_mut().enumerate() {
+            let get = |field: usize| COUNTERS[index * FIELDS + field].swap(0, Ordering::Relaxed);
+            *phase = PlanLoadPhaseMetric {
+                wall_nanos: get(0),
+                io_nanos: get(1),
+                read_batches: get(2),
+                read_keys: get(3),
+                read_hits: get(4),
+                read_bytes: get(5),
+                entries: get(6),
+            };
+        }
+        PlanLoadAttribution {
+            phases,
+            plans: PLANS.swap(0, Ordering::Relaxed),
+            members_decoded: MEMBERS_DECODED.swap(0, Ordering::Relaxed),
+            members_kept: MEMBERS_KEPT.swap(0, Ordering::Relaxed),
+            member_payload_bytes: MEMBER_PAYLOAD_BYTES.swap(0, Ordering::Relaxed),
+        }
+    }
+
+    pub(super) fn phase_index(phase: PlanLoadPhase) -> usize {
+        phase as usize
+    }
+}
+
+pub fn take_plan_load_attribution() -> PlanLoadAttribution {
+    #[cfg(feature = "root-replay-trace")]
+    {
+        plan_load_trace::take()
+    }
+    #[cfg(not(feature = "root-replay-trace"))]
+    {
+        PlanLoadAttribution::default()
+    }
+}
+
+/// RAII guard marking the dynamic extent of one plan-load phase.
+///
+/// Phases nest: the guard restores the enclosing phase on drop, and wall time
+/// is charged to the phase named by the guard (so an inner phase's time is
+/// counted in both, exactly like a call-tree self/total split at one level).
+pub(crate) struct PlanLoadPhaseScope {
+    #[cfg(feature = "root-replay-trace")]
+    phase: usize,
+    #[cfg(feature = "root-replay-trace")]
+    previous: usize,
+    #[cfg(feature = "root-replay-trace")]
+    start: std::time::Instant,
+}
+
+impl PlanLoadPhaseScope {
+    #[allow(unused_variables)]
+    pub(crate) fn enter(phase: PlanLoadPhase) -> Self {
+        #[cfg(feature = "root-replay-trace")]
+        {
+            let phase = plan_load_trace::phase_index(phase);
+            let previous = plan_load_trace::set_phase(phase);
+            Self {
+                phase,
+                previous,
+                start: std::time::Instant::now(),
+            }
+        }
+        #[cfg(not(feature = "root-replay-trace"))]
+        {
+            Self {}
+        }
+    }
+}
+
+impl Drop for PlanLoadPhaseScope {
+    fn drop(&mut self) {
+        #[cfg(feature = "root-replay-trace")]
+        {
+            plan_load_trace::record_phase_wall(self.phase, self.start.elapsed().as_nanos() as u64);
+            plan_load_trace::set_phase(self.previous);
+        }
+    }
+}
+
+#[cfg(feature = "root-replay-trace")]
+pub(crate) fn record_plan_load_io(nanos: u64, batches: u64, keys: u64, hits: u64, bytes: u64) {
+    plan_load_trace::record_io(nanos, batches, keys, hits, bytes);
+}
+
+#[cfg(feature = "root-replay-trace")]
+pub(crate) fn record_plan_load_plan(members_decoded: u64, members_kept: u64, payload_bytes: u64) {
+    plan_load_trace::record_plan(members_decoded, members_kept, payload_bytes);
+}
+
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub struct BinaryCasWriteAccounting {
     pub chunk_lookup_count: u64,

--- a/packages/lix/src/tracked_state/codec.rs
+++ b/packages/lix/src/tracked_state/codec.rs
@@ -479,6 +479,17 @@ impl TrackedStateMutationBatchBuilder {
 }
 
 pub(crate) fn hash_bytes(bytes: &[u8]) -> [u8; TRACKED_STATE_HASH_BYTES] {
+    #[cfg(feature = "root-replay-trace")]
+    {
+        let start = std::time::Instant::now();
+        let digest = *blake3::hash(bytes).as_bytes();
+        crate::storage_bench::record_replay_node_hash(
+            start.elapsed().as_nanos() as u64,
+            bytes.len() as u64,
+        );
+        return digest;
+    }
+    #[cfg(not(feature = "root-replay-trace"))]
     *blake3::hash(bytes).as_bytes()
 }
 
@@ -1451,6 +1462,21 @@ const VALUE_TAIL_DISTINCT_MAX: u8 =
 /// produces sorted entries); it is asserted in debug builds but not
 /// revalidated on every release-mode read.
 pub(crate) fn encode_leaf_node_refs(entries: &[EncodedLeafEntryRef<'_>]) -> Vec<u8> {
+    #[cfg(feature = "root-replay-trace")]
+    {
+        let start = std::time::Instant::now();
+        let encoded = encode_leaf_node_refs_inner(entries);
+        crate::storage_bench::record_replay_node_encode(
+            start.elapsed().as_nanos() as u64,
+            encoded.len() as u64,
+        );
+        return encoded;
+    }
+    #[cfg(not(feature = "root-replay-trace"))]
+    encode_leaf_node_refs_inner(entries)
+}
+
+fn encode_leaf_node_refs_inner(entries: &[EncodedLeafEntryRef<'_>]) -> Vec<u8> {
     debug_assert!(
         entries.windows(2).all(|pair| pair[0].key < pair[1].key),
         "leaf entries must be strictly sorted by key"
@@ -2002,6 +2028,21 @@ pub(crate) fn encode_internal_node(children: &[ChildSummary]) -> Vec<u8> {
 }
 
 pub(crate) fn encode_internal_node_refs(children: &[ChildSummaryRef<'_>]) -> Vec<u8> {
+    #[cfg(feature = "root-replay-trace")]
+    {
+        let start = std::time::Instant::now();
+        let encoded = encode_internal_node_refs_inner(children);
+        crate::storage_bench::record_replay_node_encode(
+            start.elapsed().as_nanos() as u64,
+            encoded.len() as u64,
+        );
+        return encoded;
+    }
+    #[cfg(not(feature = "root-replay-trace"))]
+    encode_internal_node_refs_inner(children)
+}
+
+fn encode_internal_node_refs_inner(children: &[ChildSummaryRef<'_>]) -> Vec<u8> {
     assert!(
         !children.is_empty(),
         "tracked-state internal nodes must contain at least one child"
@@ -2176,6 +2217,21 @@ pub(crate) fn decode_node(bytes: &[u8]) -> Result<DecodedNode, LixError> {
 }
 
 pub(crate) fn decode_node_ref(bytes: &[u8]) -> Result<DecodedNodeRef, LixError> {
+    #[cfg(feature = "root-replay-trace")]
+    {
+        let start = std::time::Instant::now();
+        let decoded = decode_node_ref_inner(bytes);
+        crate::storage_bench::record_replay_node_decode(
+            start.elapsed().as_nanos() as u64,
+            bytes.len() as u64,
+        );
+        return decoded;
+    }
+    #[cfg(not(feature = "root-replay-trace"))]
+    decode_node_ref_inner(bytes)
+}
+
+fn decode_node_ref_inner(bytes: &[u8]) -> Result<DecodedNodeRef, LixError> {
     let (&kind, body) = bytes
         .split_first()
         .ok_or_else(|| LixError::new("LIX_ERROR_UNKNOWN", "tracked-state tree node is empty"))?;

--- a/packages/lix/src/tracked_state/commit_root_rebuild.rs
+++ b/packages/lix/src/tracked_state/commit_root_rebuild.rs
@@ -175,12 +175,13 @@ where
                 ),
             ));
         }
-        if !force_current
-            && load_available_root(store, &current_commit_id)
-                .await?
-                .is_some()
-        {
-            break;
+        if !force_current {
+            let available = load_available_root(store, &current_commit_id).await?;
+            #[cfg(feature = "storage-benches")]
+            crate::storage_bench::record_root_replay_available_root_probe(available.is_some());
+            if available.is_some() {
+                break;
+            }
         }
         let plan = load_commit_root_rebuild_plan(store, &current_commit_id).await?;
         let parent_commit_id = plan.parent_commit_id;
@@ -194,6 +195,26 @@ where
     Ok(plans)
 }
 
+/// Resolves the durable root a replay may resume from.
+///
+/// The commit-state manifest is the single immutable authority for a commit's
+/// tracked-state root: it is sealed atomically with the commit, keyed by that
+/// commit id, and never rewritten. `rebuild_commit_root_at_inner` already
+/// treats a rebuild that disagrees with it as a hard error rather than a
+/// repair, so the manifest — not a replay of the changelog — is what makes a
+/// root canonical. Availability therefore has exactly two obligations:
+///
+/// 1. the root pointer is live (`load_snapshot_commit_root` also proves the
+///    commit itself exists in the changelog, so an orphaned manifest cannot
+///    authorize a resume), and
+/// 2. the content-addressed chunk closure it names is physically readable, so
+///    a damaged root is never resumed from and explicit repair stays total.
+///
+/// This proof is bounded by the size of the addressed tree. It deliberately
+/// does **not** recurse through the ancestry: ordinary commits are rootless
+/// bounded-replay layouts by design, so an ancestry-wide proof can only ever
+/// succeed by reaching genesis, which makes every interval closure replay the
+/// entire history.
 async fn load_available_root<S>(
     store: &S,
     commit_id: &str,
@@ -201,60 +222,13 @@ async fn load_available_root<S>(
 where
     S: StorageAdapterRead + ?Sized,
 {
-    // Build the ancestry proof iteratively. The former boxed async recursion
-    // retained one large future frame per ancestor and could overflow the test
-    // worker stack even for otherwise valid publication paths.
-    let mut chain = Vec::new();
-    let mut current_commit_id = commit_id.to_string();
-    let mut seen = HashSet::new();
-    loop {
-        if !seen.insert(current_commit_id.clone()) {
-            return Ok(None);
-        }
-        let Some(metadata) = storage::load_snapshot_commit_root(store, &current_commit_id).await?
-        else {
-            return Ok(None);
-        };
-        if !commit_root_tree_is_readable(store, &metadata).await? {
-            return Ok(None);
-        }
-        let plan = load_commit_root_rebuild_plan(store, &current_commit_id).await?;
-        let parent_commit_id = plan.parent_commit_id;
-        chain.push((metadata, plan));
-        let Some(parent_commit_id) = parent_commit_id else {
-            break;
-        };
-        current_commit_id = parent_commit_id.to_string();
+    let Some(metadata) = storage::load_snapshot_commit_root(store, commit_id).await? else {
+        return Ok(None);
+    };
+    if !commit_root_tree_is_readable(store, &metadata).await? {
+        return Ok(None);
     }
-
-    let target_root_id = chain
-        .first()
-        .expect("available-root proof contains its requested commit")
-        .0
-        .root_id
-        .clone();
-    let mut canonical_parent = None;
-    for (metadata, plan) in chain.iter().rev() {
-        match (plan.parent_commit_id, canonical_parent.as_ref()) {
-            (Some(parent_commit_id), Some(parent_root_id)) => match metadata.parent_roots.first() {
-                Some(parent)
-                    if parent.commit_id == parent_commit_id
-                        && &parent.root_id == parent_root_id => {}
-                _ => return Ok(None),
-            },
-            (None, None) if metadata.parent_roots.is_empty() => {}
-            _ => return Ok(None),
-        }
-        let mut scratch_writes = StorageWriteSet::new();
-        let context = TrackedStateContext::new();
-        let mut writer = context.writer(store, &mut scratch_writes);
-        let report = stage_rebuild_plan_with_writer(&mut writer, plan).await?;
-        if report.root_id != metadata.root_id {
-            return Ok(None);
-        }
-        canonical_parent = Some(metadata.root_id.clone());
-    }
-    Ok(Some(target_root_id))
+    Ok(Some(metadata.root_id))
 }
 
 async fn commit_root_tree_is_readable<S>(

--- a/packages/lix/src/tracked_state/commit_root_rebuild.rs
+++ b/packages/lix/src/tracked_state/commit_root_rebuild.rs
@@ -176,6 +176,10 @@ where
             ));
         }
         if !force_current {
+            #[cfg(feature = "storage-benches")]
+            let _phase = crate::storage_bench::PlanLoadPhaseScope::enter(
+                crate::storage_bench::PlanLoadPhase::AvailProbe,
+            );
             let available = load_available_root(store, &current_commit_id).await?;
             #[cfg(feature = "storage-benches")]
             crate::storage_bench::record_root_replay_available_root_probe(available.is_some());
@@ -265,34 +269,54 @@ async fn load_commit_root_rebuild_plan<S>(
 where
     S: StorageAdapterRead + ?Sized,
 {
-    let mut reader = ChangelogContext::new().reader(store);
-    let commit_ids = [CommitId::parse_lix(
-        commit_id,
-        "commit-root rebuild commit_id",
-    )?];
-    let batch = reader
-        .load_commits(CommitLoadRequest {
-            commit_ids: &commit_ids,
-        })
-        .await?;
-    let entry = batch
-        .into_iter()
-        .next()
-        .and_then(|(_, value)| value)
-        .ok_or_else(|| {
-            LixError::new(
-                LixError::CODE_INTERNAL_ERROR,
-                format!(
-                    "cannot rebuild tracked_state commit_root for unknown commit '{commit_id}'"
-                ),
-            )
-        })?;
-    let commit = entry;
+    let commit = {
+        #[cfg(feature = "storage-benches")]
+        let _phase = crate::storage_bench::PlanLoadPhaseScope::enter(
+            crate::storage_bench::PlanLoadPhase::CommitRecord,
+        );
+        let mut reader = ChangelogContext::new().reader(store);
+        let commit_ids = [CommitId::parse_lix(
+            commit_id,
+            "commit-root rebuild commit_id",
+        )?];
+        let batch = reader
+            .load_commits(CommitLoadRequest {
+                commit_ids: &commit_ids,
+            })
+            .await?;
+        batch
+            .into_iter()
+            .next()
+            .and_then(|(_, value)| value)
+            .ok_or_else(|| {
+                LixError::new(
+                    LixError::CODE_INTERNAL_ERROR,
+                    format!(
+                        "cannot rebuild tracked_state commit_root for unknown commit '{commit_id}'"
+                    ),
+                )
+            })?
+    };
     // Commit roots contain only identity/index facts. Avoid hydrating JSON
     // sidecars while rebuilding them; the packed delta index already carries
     // deletion, owner ids, and original timestamps.
-    let deltas = storage::scan_commit_delta_members(store, commit.commit_id)
-        .await?
+    let members = storage::scan_commit_delta_members(store, commit.commit_id).await?;
+    #[cfg(feature = "root-replay-trace")]
+    let member_bytes = members
+        .iter()
+        .map(|(key, _)| {
+            (key.schema_key.len()
+                + key.file_id.as_ref().map(String::len).unwrap_or(0)
+                + key.entity_pk.estimated_heap_bytes()) as u64
+        })
+        .sum::<u64>();
+    #[cfg(feature = "root-replay-trace")]
+    crate::storage_bench::record_plan_load_plan(
+        members.len() as u64,
+        members.len() as u64,
+        member_bytes,
+    );
+    let deltas = members
         .into_iter()
         .map(|(key, value)| CommitRootRebuildDelta {
             schema_key: key.schema_key,

--- a/packages/lix/src/tracked_state/commit_root_rebuild.rs
+++ b/packages/lix/src/tracked_state/commit_root_rebuild.rs
@@ -211,14 +211,24 @@ where
 /// 1. the root pointer is live (`load_snapshot_commit_root` also proves the
 ///    commit itself exists in the changelog, so an orphaned manifest cannot
 ///    authorize a resume), and
-/// 2. the content-addressed chunk closure it names is physically readable, so
-///    a damaged root is never resumed from and explicit repair stays total.
+/// 2. the content-addressed chunk closure it names is physically addressable,
+///    so a damaged root is never resumed from and explicit repair stays total.
 ///
-/// This proof is bounded by the size of the addressed tree. It deliberately
-/// does **not** recurse through the ancestry: ordinary commits are rootless
-/// bounded-replay layouts by design, so an ancestry-wide proof can only ever
-/// succeed by reaching genesis, which makes every interval closure replay the
-/// entire history.
+/// It deliberately does **not** recurse through the ancestry: ordinary commits
+/// are rootless bounded-replay layouts by design, so an ancestry-wide proof can
+/// only ever succeed by reaching genesis, which makes every interval closure
+/// replay the entire history.
+///
+/// Obligation (2) is also bounded, to one root-to-leaf path. Chunk-closure
+/// completeness is not a fact this probe owns: chunks are staged in the same
+/// atomic write set that publishes the root and the manifest, and GC reaches
+/// them from refs, so the write path and GC are the single authority for it.
+/// Re-deriving it here by full traversal made a commit-path probe cost
+/// `O(total state)` and, at one boundary per `COMMIT_STATE_MAX_REPLAY_DEPTH`
+/// commits, put an `O(N^2)` term back into commit. What the probe must still
+/// catch is a resume point that is *not addressable at all* — the damage shape
+/// the root-chunk delete/corrupt paths produce — and that is decided by the
+/// root node and the first path below it.
 async fn load_available_root<S>(
     store: &S,
     commit_id: &str,
@@ -249,12 +259,15 @@ async fn commit_root_tree_is_readable<S>(
 where
     S: StorageAdapterRead + ?Sized,
 {
+    // One row is enough: the scan walks root -> leftmost overlapping child ->
+    // leaf and stops, so a missing or corrupt root chunk still fails while the
+    // probe stays `O(tree depth)` instead of `O(tree rows)`.
+    let request = TrackedStateTreeScanRequest {
+        limit: Some(1),
+        ..TrackedStateTreeScanRequest::default()
+    };
     match TrackedStateTree::new()
-        .scan(
-            store,
-            &metadata.root_id,
-            &TrackedStateTreeScanRequest::default(),
-        )
+        .scan(store, &metadata.root_id, &request)
         .await
     {
         Ok(_) => Ok(true),

--- a/packages/lix/src/tracked_state/commit_root_rebuild.rs
+++ b/packages/lix/src/tracked_state/commit_root_rebuild.rs
@@ -229,7 +229,14 @@ where
     let Some(metadata) = storage::load_snapshot_commit_root(store, commit_id).await? else {
         return Ok(None);
     };
-    if !commit_root_tree_is_readable(store, &metadata).await? {
+    let readable = {
+        #[cfg(feature = "storage-benches")]
+        let _phase = crate::storage_bench::PlanLoadPhaseScope::enter(
+            crate::storage_bench::PlanLoadPhase::AvailTreeScan,
+        );
+        commit_root_tree_is_readable(store, &metadata).await?
+    };
+    if !readable {
         return Ok(None);
     }
     Ok(Some(metadata.root_id))

--- a/packages/lix/src/tracked_state/commit_root_rebuild.rs
+++ b/packages/lix/src/tracked_state/commit_root_rebuild.rs
@@ -72,8 +72,15 @@ async fn rebuild_commit_root_at_inner<S>(
 where
     S: StorageAdapterRead + ?Sized,
 {
-    let plans =
-        load_rebuild_plans_to_nearest_available_root(rebuilder.store, commit_id, true).await?;
+    // Explicit repair is the caller whose job is to distrust the chunk plane,
+    // so it — and only it — pays for the total closure proof.
+    let plans = load_rebuild_plans_to_nearest_available_root_with_proof(
+        rebuilder.store,
+        commit_id,
+        true,
+        RootAvailabilityProof::Complete,
+    )
+    .await?;
     let mut report = None;
     let context = TrackedStateContext::new();
     let mut state = TrackedStateTransientRebuildState::default();
@@ -154,10 +161,48 @@ where
     Ok(report)
 }
 
+/// How much of a candidate resume point's chunk closure a caller demands to be
+/// proved readable before it may resume from it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum RootAvailabilityProof {
+    /// Prove the root is *addressable*: the root chunk and one root-to-leaf
+    /// path load and decode. `O(tree depth)`.
+    ///
+    /// Closure completeness is not re-derived. Chunks are staged in the same
+    /// atomic write set that publishes the root and the manifest, and GC
+    /// reaches them from refs, so the write path and GC are already its single
+    /// authority. This is what the commit path uses.
+    Addressable,
+    /// Prove the whole addressed closure loads and decodes. `O(tree rows)`.
+    ///
+    /// Used only by explicit repair (`rebuild_commit_root_at`), whose contract
+    /// is to distrust the chunk plane: rejecting a damaged resume point is what
+    /// makes it walk back and re-stage every chunk, so repair stays total.
+    Complete,
+}
+
 pub(crate) async fn load_rebuild_plans_to_nearest_available_root<S>(
     store: &S,
     commit_id: &str,
     force_head: bool,
+) -> Result<Vec<CommitRootRebuildPlan>, LixError>
+where
+    S: StorageAdapterRead + ?Sized,
+{
+    load_rebuild_plans_to_nearest_available_root_with_proof(
+        store,
+        commit_id,
+        force_head,
+        RootAvailabilityProof::Addressable,
+    )
+    .await
+}
+
+pub(crate) async fn load_rebuild_plans_to_nearest_available_root_with_proof<S>(
+    store: &S,
+    commit_id: &str,
+    force_head: bool,
+    proof: RootAvailabilityProof,
 ) -> Result<Vec<CommitRootRebuildPlan>, LixError>
 where
     S: StorageAdapterRead + ?Sized,
@@ -180,7 +225,7 @@ where
             let _phase = crate::storage_bench::PlanLoadPhaseScope::enter(
                 crate::storage_bench::PlanLoadPhase::AvailProbe,
             );
-            let available = load_available_root(store, &current_commit_id).await?;
+            let available = load_available_root(store, &current_commit_id, proof).await?;
             #[cfg(feature = "storage-benches")]
             crate::storage_bench::record_root_replay_available_root_probe(available.is_some());
             if available.is_some() {
@@ -219,19 +264,16 @@ where
 /// only ever succeed by reaching genesis, which makes every interval closure
 /// replay the entire history.
 ///
-/// Obligation (2) is also bounded, to one root-to-leaf path. Chunk-closure
-/// completeness is not a fact this probe owns: chunks are staged in the same
-/// atomic write set that publishes the root and the manifest, and GC reaches
-/// them from refs, so the write path and GC are the single authority for it.
-/// Re-deriving it here by full traversal made a commit-path probe cost
-/// `O(total state)` and, at one boundary per `COMMIT_STATE_MAX_REPLAY_DEPTH`
-/// commits, put an `O(N^2)` term back into commit. What the probe must still
-/// catch is a resume point that is *not addressable at all* — the damage shape
-/// the root-chunk delete/corrupt paths produce — and that is decided by the
-/// root node and the first path below it.
+/// How much of obligation (2) is proved is the caller's choice — see
+/// [`RootAvailabilityProof`]. The commit path proves addressability only:
+/// re-deriving closure completeness there cost `O(total state)` per boundary
+/// and, at one boundary per `COMMIT_STATE_MAX_REPLAY_DEPTH` commits, put an
+/// `O(N^2)` term back into commit for a fact atomic publication and GC already
+/// own. Explicit repair still proves the whole closure.
 async fn load_available_root<S>(
     store: &S,
     commit_id: &str,
+    proof: RootAvailabilityProof,
 ) -> Result<Option<TrackedStateRootId>, LixError>
 where
     S: StorageAdapterRead + ?Sized,
@@ -244,7 +286,7 @@ where
         let _phase = crate::storage_bench::PlanLoadPhaseScope::enter(
             crate::storage_bench::PlanLoadPhase::AvailTreeScan,
         );
-        commit_root_tree_is_readable(store, &metadata).await?
+        commit_root_tree_is_readable(store, &metadata, proof).await?
     };
     if !readable {
         return Ok(None);
@@ -255,15 +297,19 @@ where
 async fn commit_root_tree_is_readable<S>(
     store: &S,
     metadata: &TrackedStateCommitRoot,
+    proof: RootAvailabilityProof,
 ) -> Result<bool, LixError>
 where
     S: StorageAdapterRead + ?Sized,
 {
-    // One row is enough: the scan walks root -> leftmost overlapping child ->
-    // leaf and stops, so a missing or corrupt root chunk still fails while the
-    // probe stays `O(tree depth)` instead of `O(tree rows)`.
+    // One row is enough for addressability: the scan walks root -> leftmost
+    // overlapping child -> leaf and stops, so a missing or corrupt root chunk
+    // still fails while the probe stays `O(tree depth)`.
     let request = TrackedStateTreeScanRequest {
-        limit: Some(1),
+        limit: match proof {
+            RootAvailabilityProof::Addressable => Some(1),
+            RootAvailabilityProof::Complete => None,
+        },
         ..TrackedStateTreeScanRequest::default()
     };
     match TrackedStateTree::new()

--- a/packages/lix/src/tracked_state/context.rs
+++ b/packages/lix/src/tracked_state/context.rs
@@ -8648,6 +8648,110 @@ mod tests {
         );
     }
 
+    /// The commit-path availability probe proves the resume point is
+    /// *addressable*, not that its whole chunk closure is intact; explicit
+    /// repair still proves the whole closure. Pins both halves, because the
+    /// difference between them is the entire cost argument: the commit path
+    /// walks one root-to-leaf path, repair walks every row.
+    #[tokio::test]
+    async fn availability_proof_is_bounded_on_commit_and_total_on_repair() {
+        use crate::tracked_state::commit_root_rebuild::RootAvailabilityProof;
+
+        let tracked_state = TrackedStateContext::new();
+        let storage = StorageAdapter::new(Memory::new());
+        // Wide enough that the tree is more than one chunk, so "the root chunk"
+        // and "the closure" are actually different sets.
+        let rows = (0..4000)
+            .map(|index| {
+                row_with_value(
+                    &format!("entity-{index:06}"),
+                    &format!("gen-change-{index}"),
+                    "gen",
+                    "gen",
+                )
+            })
+            .collect::<Vec<_>>();
+        write_root_for_test(&storage, &tracked_state, "gen", None, &rows)
+            .await
+            .expect("wide genesis root should write");
+        write_rootless_commit_for_test(
+            &storage,
+            "a1",
+            "gen",
+            &[row_with_value("entity-a1", "a1-change", "a1", "a1")],
+        )
+        .await;
+
+        let read = storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("root read should open");
+        let root_id = storage::load_root(&read, "gen")
+            .await
+            .expect("genesis root should load")
+            .expect("genesis root should exist");
+        drop(read);
+        let chunks = stored_tree_chunk_hashes_for_test(&storage).await;
+        assert!(
+            chunks.len() > 2,
+            "fixture must build a multi-chunk tree, got {} chunks",
+            chunks.len()
+        );
+
+        // Damage a chunk that is not the root and not on the leftmost path, so
+        // only a total traversal can notice it.
+        let mut damaged_chunk = None;
+        for chunk in chunks.iter() {
+            if chunk != root_id.as_bytes() {
+                damaged_chunk = Some(*chunk);
+            }
+        }
+        let damaged_chunk = damaged_chunk.expect("a non-root chunk exists");
+        let mut writes = storage.new_write_set();
+        writes.delete(
+            storage::TRACKED_STATE_TREE_CHUNK_SPACE,
+            crate::storage_adapter::StorageKey(Bytes::copy_from_slice(&damaged_chunk)),
+        );
+        storage
+            .commit_write_set(writes, StorageWriteOptions::default())
+            .await
+            .expect("chunk delete should commit");
+
+        let read = storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("probe read should open");
+        let bounded = crate::tracked_state::commit_root_rebuild::
+            load_rebuild_plans_to_nearest_available_root_with_proof(
+                &read,
+                "a1",
+                true,
+                RootAvailabilityProof::Addressable,
+            )
+            .await
+            .expect("bounded probe should load plans");
+        assert_eq!(
+            bounded.len(),
+            1,
+            "the commit path resumes from an addressable root and does not re-derive closure completeness"
+        );
+
+        let total = crate::tracked_state::commit_root_rebuild::
+            load_rebuild_plans_to_nearest_available_root_with_proof(
+                &read,
+                "a1",
+                true,
+                RootAvailabilityProof::Complete,
+            )
+            .await
+            .expect("total probe should load plans");
+        assert_eq!(
+            total.len(),
+            2,
+            "explicit repair must reject a resume point with a damaged closure and replay past it"
+        );
+    }
+
     async fn stored_tree_chunk_hashes_for_test(
         storage: &StorageAdapter,
     ) -> HashSet<[u8; crate::tracked_state::types::TRACKED_STATE_HASH_BYTES]> {

--- a/packages/lix/src/tracked_state/context.rs
+++ b/packages/lix/src/tracked_state/context.rs
@@ -7054,8 +7054,18 @@ mod tests {
             .expect_err("first-parent cycle should not rebuild forever");
 
         assert_eq!(error.code, LixError::CODE_INTERNAL_ERROR);
+        // Availability is proven from immutable commit-state authority instead
+        // of by walking the ancestry, so a cycle whose members are all rooted
+        // is no longer reported by the walk's cycle detector: the walk resumes
+        // at the first rooted member. It still fails closed, because replaying
+        // the cycle against that root cannot reproduce the root immutable
+        // authority names for this commit. The walk's `seen_commit_ids` guard
+        // remains the termination proof for cycles with no rooted member.
         assert!(
-            error.message.contains("first-parent cycle"),
+            error.message.contains("first-parent cycle")
+                || error
+                    .message
+                    .contains("disagrees with immutable commit authority"),
             "unexpected error message: {}",
             error.message
         );
@@ -8379,6 +8389,262 @@ mod tests {
                 .and_then(|row| row.snapshot_content())
                 .map(AsRef::as_ref),
             Some("{\"value\":\"child\"}")
+        );
+    }
+
+    /// Builds `gen -> a1 -> a2 -> a3 -> b1 -> b2 -> b3` where every commit
+    /// after `gen` is a rootless bounded-replay layout, then optionally seals
+    /// `a3` as a durable interval root so a replay of the `b` interval has a
+    /// resume point.
+    async fn write_two_interval_history_for_test(
+        storage: &StorageAdapter,
+        tracked_state: &TrackedStateContext,
+        seal_midpoint: bool,
+    ) {
+        write_root_for_test(
+            storage,
+            tracked_state,
+            "gen",
+            None,
+            &[row_with_value("entity-gen", "gen-change", "gen", "gen")],
+        )
+        .await
+        .expect("genesis root should write");
+        let mut parent = "gen".to_owned();
+        for commit in ["a1", "a2", "a3"] {
+            write_rootless_commit_for_test(
+                storage,
+                commit,
+                &parent,
+                &[
+                    row_with_value(
+                        &format!("entity-{commit}"),
+                        &format!("{commit}-change"),
+                        commit,
+                        commit,
+                    ),
+                    // Rewrite a shared key in every commit so the interval is
+                    // order sensitive rather than a disjoint insert stream.
+                    row_with_value("entity-shared", &format!("{commit}-shared"), commit, commit),
+                ],
+            )
+            .await;
+            parent = commit.to_owned();
+        }
+        if seal_midpoint {
+            seal_rooted_commit_for_test(storage, tracked_state, "a3").await;
+        }
+        for commit in ["b1", "b2", "b3"] {
+            write_rootless_commit_for_test(
+                storage,
+                commit,
+                &parent,
+                &[
+                    row_with_value(
+                        &format!("entity-{commit}"),
+                        &format!("{commit}-change"),
+                        commit,
+                        commit,
+                    ),
+                    row_with_value("entity-shared", &format!("{commit}-shared"), commit, commit),
+                ],
+            )
+            .await;
+            parent = commit.to_owned();
+        }
+    }
+
+    /// Publishes the canonical root for `commit_id` into its immutable
+    /// commit-state authority, turning a rootless commit into an interval root.
+    async fn seal_rooted_commit_for_test(
+        storage: &StorageAdapter,
+        tracked_state: &TrackedStateContext,
+        commit_id: &str,
+    ) {
+        let read = storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("seal read should open");
+        let plans = crate::tracked_state::commit_root_rebuild::load_rebuild_plans_to_nearest_available_root(
+            &read,
+            commit_id,
+            true,
+        )
+        .await
+        .expect("seal plans should load");
+        let mut writes = storage.new_write_set();
+        let mut writer = tracked_state.writer(&read, &mut writes);
+        for plan in plans.iter().rev() {
+            crate::tracked_state::commit_root_rebuild::stage_rebuild_plan_with_writer(
+                &mut writer, plan,
+            )
+            .await
+            .expect("seal root should stage");
+        }
+        let typed_commit_id = CommitId::for_test_label(commit_id);
+        let snapshot_root = writer
+            .staged_commit_roots()
+            .find(|root| root.commit_id == typed_commit_id)
+            .cloned()
+            .expect("sealed root should be staged");
+        drop(writer);
+        let mut manifest = storage::load_commit_state_manifest(&read, typed_commit_id)
+            .await
+            .expect("sealed manifest should load")
+            .expect("sealed manifest should exist");
+        manifest.replay_debt = crate::tracked_state::CommitStateReplayDebt::default();
+        manifest.snapshot_root = Some(Box::new(snapshot_root));
+        storage::stage_resealed_commit_state_manifest_for_test(&mut writes, &manifest)
+            .expect("sealed authority should reseal");
+        drop(read);
+        storage
+            .commit_write_set(writes, StorageWriteOptions::default())
+            .await
+            .expect("sealed root should commit");
+    }
+
+    /// Replays `commit_id` the way the commit path closes a rootless interval
+    /// and returns `(replay-set size, resulting root)`.
+    async fn replay_root_for_test(
+        storage: &StorageAdapter,
+        tracked_state: &TrackedStateContext,
+        commit_id: &str,
+    ) -> (usize, TrackedStateRootId) {
+        let read = storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("replay read should open");
+        let plans = crate::tracked_state::commit_root_rebuild::load_rebuild_plans_to_nearest_available_root(
+            &read,
+            commit_id,
+            true,
+        )
+        .await
+        .expect("replay plans should load");
+        let mut writes = storage.new_write_set();
+        let mut writer = tracked_state.writer(&read, &mut writes);
+        let mut report = None;
+        for plan in plans.iter().rev() {
+            report = Some(
+                crate::tracked_state::commit_root_rebuild::stage_rebuild_plan_with_writer(
+                    &mut writer,
+                    plan,
+                )
+                .await
+                .expect("replay root should stage"),
+            );
+        }
+        (
+            plans.len(),
+            report.expect("replay stages at least one root").root_id,
+        )
+    }
+
+    /// The resume point is the previous interval root named by immutable
+    /// commit-state authority. Resuming from it must produce exactly the root
+    /// a from-genesis replay of the same history produces.
+    #[tokio::test]
+    async fn resumed_interval_root_is_identical_to_from_genesis_root() {
+        let tracked_state = TrackedStateContext::new();
+
+        let from_genesis = StorageAdapter::new(Memory::new());
+        write_two_interval_history_for_test(&from_genesis, &tracked_state, false).await;
+        let (genesis_plans, genesis_root) =
+            replay_root_for_test(&from_genesis, &tracked_state, "b3").await;
+
+        let resumed = StorageAdapter::new(Memory::new());
+        write_two_interval_history_for_test(&resumed, &tracked_state, true).await;
+        let (resumed_plans, resumed_root) = replay_root_for_test(&resumed, &tracked_state, "b3").await;
+
+        assert_eq!(
+            genesis_plans, 6,
+            "without a sealed interval root the replay set is the whole history"
+        );
+        assert_eq!(
+            resumed_plans, 3,
+            "a sealed interval root bounds the replay set to its own interval"
+        );
+        assert_eq!(
+            resumed_root, genesis_root,
+            "resumed replay must produce a byte-identical state root"
+        );
+    }
+
+    /// Teeth for the assertion above: pointing the resume point at a readable
+    /// but wrong root must change the resulting state root, so a silently bad
+    /// resume point cannot pass the byte-identity check.
+    #[tokio::test]
+    async fn byte_identical_root_check_rejects_a_broken_resume_point() {
+        let tracked_state = TrackedStateContext::new();
+
+        let from_genesis = StorageAdapter::new(Memory::new());
+        write_two_interval_history_for_test(&from_genesis, &tracked_state, false).await;
+        let (_, genesis_root) = replay_root_for_test(&from_genesis, &tracked_state, "b3").await;
+
+        let broken = StorageAdapter::new(Memory::new());
+        write_two_interval_history_for_test(&broken, &tracked_state, true).await;
+        // Repoint `a3`'s immutable root pointer at `gen`'s root: present,
+        // readable, content-addressed — and wrong.
+        let read = broken
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("broken resume read should open");
+        let genesis_metadata = storage::load_snapshot_commit_root(&read, "gen")
+            .await
+            .expect("genesis root metadata should load")
+            .expect("genesis root metadata should exist");
+        let mut manifest =
+            storage::load_commit_state_manifest(&read, CommitId::for_test_label("a3"))
+                .await
+                .expect("midpoint manifest should load")
+                .expect("midpoint manifest should exist");
+        let mut broken_root = *manifest
+            .snapshot_root
+            .clone()
+            .expect("midpoint is sealed by the fixture");
+        broken_root.root_id = genesis_metadata.root_id.clone();
+        manifest.snapshot_root = Some(Box::new(broken_root));
+        let mut writes = broken.new_write_set();
+        storage::stage_resealed_commit_state_manifest_for_test(&mut writes, &manifest)
+            .expect("broken authority should reseal");
+        drop(read);
+        broken
+            .commit_write_set(writes, StorageWriteOptions::default())
+            .await
+            .expect("broken resume point should commit");
+
+        let (broken_plans, broken_root_id) = replay_root_for_test(&broken, &tracked_state, "b3").await;
+        assert_eq!(broken_plans, 3, "the broken pointer is still readable");
+        assert_ne!(
+            broken_root_id, genesis_root,
+            "a wrong resume point must not reproduce the canonical state root"
+        );
+    }
+
+    /// A resume point whose chunk closure is damaged must not be resumed from.
+    /// Repair stays total: the walk continues past it and the replay rebuilds
+    /// the canonical root from the changelog.
+    #[tokio::test]
+    async fn damaged_resume_point_falls_back_to_total_replay() {
+        let tracked_state = TrackedStateContext::new();
+
+        let from_genesis = StorageAdapter::new(Memory::new());
+        write_two_interval_history_for_test(&from_genesis, &tracked_state, false).await;
+        let (_, genesis_root) = replay_root_for_test(&from_genesis, &tracked_state, "b3").await;
+
+        let damaged = StorageAdapter::new(Memory::new());
+        write_two_interval_history_for_test(&damaged, &tracked_state, true).await;
+        delete_root_chunk_for_test(&damaged, "a3").await;
+
+        let (damaged_plans, damaged_root) =
+            replay_root_for_test(&damaged, &tracked_state, "b3").await;
+        assert_eq!(
+            damaged_plans, 6,
+            "a damaged interval root must not bound the replay set"
+        );
+        assert_eq!(
+            damaged_root, genesis_root,
+            "total replay must still produce the canonical state root"
         );
     }
 

--- a/packages/lix/src/tracked_state/storage.rs
+++ b/packages/lix/src/tracked_state/storage.rs
@@ -8427,7 +8427,17 @@ pub(crate) async fn scan_commit_delta_members(
     store: &(impl StorageAdapterRead + ?Sized),
     commit_id: CommitId,
 ) -> Result<Vec<(TrackedStateKey, TrackedStateIndexValue)>, LixError> {
-    let batch = scan_commit_delta_values(store, commit_id, &[]).await?;
+    let batch = {
+        #[cfg(feature = "storage-benches")]
+        let _phase = crate::storage_bench::PlanLoadPhaseScope::enter(
+            crate::storage_bench::PlanLoadPhase::DeltaSegments,
+        );
+        scan_commit_delta_values(store, commit_id, &[]).await?
+    };
+    #[cfg(feature = "storage-benches")]
+    let _phase = crate::storage_bench::PlanLoadPhaseScope::enter(
+        crate::storage_bench::PlanLoadPhase::Collect,
+    );
     let mut members = Vec::with_capacity(batch.len());
     for row in batch.iter() {
         let key = row.key_ref();
@@ -9204,7 +9214,14 @@ pub(crate) async fn scan_commit_delta_values(
     commit_id: CommitId,
     schema_keys: &[String],
 ) -> Result<DecodedCommitDeltaBatch, LixError> {
-    let Some(state) = load_point_replay_commit_state(store, commit_id).await? else {
+    let state = {
+        #[cfg(feature = "storage-benches")]
+        let _phase = crate::storage_bench::PlanLoadPhaseScope::enter(
+            crate::storage_bench::PlanLoadPhase::ReplayState,
+        );
+        load_point_replay_commit_state(store, commit_id).await?
+    };
+    let Some(state) = state else {
         return Ok(DecodedCommitDeltaBatch::default());
     };
     let source = match state.mutations.selected_source_commit_id() {

--- a/packages/lix/src/tracked_state/storage.rs
+++ b/packages/lix/src/tracked_state/storage.rs
@@ -12181,6 +12181,22 @@ pub(crate) async fn read_chunk(
     store: &(impl StorageAdapterRead + ?Sized),
     hash: &[u8; TRACKED_STATE_HASH_BYTES],
 ) -> Result<Option<Bytes>, LixError> {
+    #[cfg(feature = "root-replay-trace")]
+    {
+        let start = std::time::Instant::now();
+        let bytes = get_one(store, TRACKED_STATE_TREE_CHUNK_SPACE, hash.to_vec()).await;
+        let read_bytes = bytes
+            .as_ref()
+            .ok()
+            .and_then(|value| value.as_ref())
+            .map_or(0, |value| value.len() as u64);
+        crate::storage_bench::record_replay_chunk_read(
+            start.elapsed().as_nanos() as u64,
+            read_bytes,
+        );
+        return bytes;
+    }
+    #[cfg(not(feature = "root-replay-trace"))]
     get_one(store, TRACKED_STATE_TREE_CHUNK_SPACE, hash.to_vec()).await
 }
 

--- a/packages/lix/src/transaction/commit.rs
+++ b/packages/lix/src/transaction/commit.rs
@@ -5548,16 +5548,30 @@ async fn stage_tracked_roots(
     }
     let mut tracked_writer = tracked_state.writer(read, writes);
     let mut staged_rebuild_plan_ids = BTreeSet::new();
+    #[cfg(feature = "storage-benches")]
+    let _replay_scope = (!durable_root_rebuild_parents.is_empty())
+        .then(crate::storage_bench::RootReplayScope::enter);
     for parent_commit_id in durable_root_rebuild_parents {
+        #[cfg(feature = "storage-benches")]
+        let plan_load_start = std::time::Instant::now();
         let plans = crate::tracked_state::load_rebuild_plans_to_nearest_available_root(
             read,
             &parent_commit_id.to_string(),
             true,
         )
         .await?;
+        #[cfg(feature = "storage-benches")]
+        {
+            crate::storage_bench::record_root_replay_plan_load_nanos(
+                plan_load_start.elapsed().as_nanos() as u64,
+            );
+            crate::storage_bench::record_root_replay_boundary(plans.len());
+        }
         let all_new = plans
             .iter()
             .all(|plan| !staged_rebuild_plan_ids.contains(&plan.commit_id));
+        #[cfg(feature = "storage-benches")]
+        let stage_start = std::time::Instant::now();
         if all_new
             && crate::tracked_state::try_stage_collapsed_rebuild_plans_with_writer(
                 &mut tracked_writer,
@@ -5566,6 +5580,13 @@ async fn stage_tracked_roots(
             .await?
             .is_some()
         {
+            #[cfg(feature = "storage-benches")]
+            {
+                crate::storage_bench::record_root_replay_plan_staged();
+                crate::storage_bench::record_root_replay_stage_nanos(
+                    stage_start.elapsed().as_nanos() as u64,
+                );
+            }
             // A collapsed replay stages only its terminal root. Intermediate
             // plan IDs remain unstaged so another rebuild parent sharing this
             // suffix can independently collapse against immutable authority.
@@ -5574,10 +5595,16 @@ async fn stage_tracked_roots(
         }
         for plan in plans.iter().rev() {
             if staged_rebuild_plan_ids.insert(plan.commit_id) {
+                #[cfg(feature = "storage-benches")]
+                crate::storage_bench::record_root_replay_plan_staged();
                 crate::tracked_state::stage_rebuild_plan_with_writer(&mut tracked_writer, plan)
                     .await?;
             }
         }
+        #[cfg(feature = "storage-benches")]
+        crate::storage_bench::record_root_replay_stage_nanos(
+            stage_start.elapsed().as_nanos() as u64
+        );
     }
     let empty_certified_replacement_markers = BTreeSet::new();
     for root in tracked_roots_parent_first(tracked_roots)? {


### PR DESCRIPTION
## What changed

Closing a rootless commit-root replay interval used to prove the resume point was usable by **traversing every row of the tracked-state tree it addresses** and throwing the result away to produce one bool (`commit_root_tree_is_readable`, `TrackedStateTreeScanRequest::default()` — unfiltered, no limit). At 10k rows that is 58 point reads, 132 KB and 1.3 ms of CPU **for one bit**; at 40k rows it is 247 reads, 549 KB and 5.6 ms. It runs once per replay boundary, i.e. once per `COMMIT_STATE_MAX_REPLAY_DEPTH` (32) commits, so total cost is `O(N_commits x state) = O(N^2/32)` — an asymptotic term still on the commit path after #1331 bounded the replay set itself.

The commit path now proves only that the resume point is **addressable** (`limit: Some(1)`: root chunk plus one root-to-leaf path, `O(tree depth)`). Explicit repair (`rebuild_commit_root_at`, reached from `Engine::rebuild_tracked_state_for_branch`) keeps the **total** closure proof, selected by a new `RootAvailabilityProof` enum.

**Removed:** the commit path's re-derivation of chunk-closure completeness.

### Why this is a dual-authority cut, not a tuning knob

Chunk-closure completeness already has a single authority and it is not this probe:

- Chunks are staged in the **same atomic write set** that publishes the state root, the commit record and the manifest (invariant 4).
- GC reaches chunks from refs -> commits -> state nodes -> blobs (invariant 5), so nothing reachable is collected.
- #1331 established that the **manifest** is the single authority for which root is canonical, and `rebuild_commit_root_at_inner` already treats a rebuild that disagrees with the manifest as a hard error, not a repair.

So the full traversal was a second, commit-path authority for a fact the write path and GC already own, reconciled at `O(state)` every 32 commits. What a resume probe must still decide is whether the named root is *addressable at all* — the damage shape the root-chunk delete/corrupt paths produce — and that is decided by the root node and the first path below it.

Explicit repair is the one caller whose contract *is* to distrust the chunk plane, so it keeps paying for the total proof. #1331's `damaged_resume_point_falls_back_to_total_replay` is unchanged and still passes.

## Layout invariants checklist

1. **Single authority.** Yes — it *removes* one. The commit path no longer maintains a second, re-derived opinion about chunk-closure completeness. Nothing was relocated; the code path is deleted from the commit arm and retained only in explicit repair.
2. **Commit canonicality.** Unchanged. The manifest still names one canonical root per commit; traversal reads commit records; no parallel graph.
3. **Derived views are caches.** Unaffected — no derived view added or changed.
4. **Atomic publication.** Unchanged, and now *relied on* rather than re-proved. Publication of root + manifest + chunks stays one write set.
5. **GC from refs.** Unchanged, and now relied on for chunk retention. One reachability implementation.
6. **SQL reads canonical records.** Unaffected — no query-side change.

## A/B — machine `ryzen-9950x-IV`, 9 interleaved reps per arm, rotated 3-way order

Arms per rep are run back to back in a rotating order (`base1, cand, base2` / `cand, base2, base1` / `base2, base1, cand`), so each arm takes each position equally. `base1` and `base2` are **the same binary**: their spread is the null control.

Base = `exp/plan-loading-layout-base` (instrument only), cand = same tree plus the cut. Driver: `packages/engine-benchmarks/examples/expab_plan_load.rs`, real `SessionContext` commit path, 10 rows/commit, `N` ordinary commits.

### Boundary commit latency — the metric that carries this cost

`worst_mean_ms` = mean latency of the slowest `boundaries` commits (the root-materialization commits).

| backend | N | base | cand | delta | null control |
|---|---:|---:|---:|---:|---:|
| rocksdb | 500 | 2.06 ms | 1.52 ms | **-26.6%** | 1.2% |
| rocksdb | 1000 | 3.03 ms | 1.73 ms | **-42.8%** | 9.1% |
| rocksdb | 2000 | 5.02 ms | 2.57 ms | **-48.8%** | 1.2% |
| rocksdb | 4000 | 9.20 ms | 3.92 ms | **-57.4%** | 2.6% |
| slatedb | 500 | 2.41 ms | 1.85 ms | **-23.4%** | 0.0% |
| slatedb | 1000 | 3.16 ms | 1.84 ms | **-41.5%** | 0.1% |
| slatedb | 2000 | 4.65 ms | 1.84 ms | **-60.4%** | 0.7% |
| slatedb | 4000 | 7.78 ms | 1.86 ms | **-76.1%** | 0.3% |

p99 commit latency, slatedb: 2.65 / 3.61 / 5.71 / 9.91 ms -> **1.82 / 1.84 / 1.85 / 1.87 ms** (-31.4% / -49.0% / -67.6% / -81.2%, null 0.0-2.5%).

### The slope change (the actual claim)

Growth factor per doubling of `N`:

| metric (slatedb) | base x per 2x N | cand x per 2x N |
|---|---|---|
| plan_load_ms | 3.02, 3.41, 3.72 | **2.00, 2.03, 2.03** |
| boundary latency | 1.31, 1.47, 1.67 | **1.00, 1.00, 1.01** |
| p99 latency | 1.36, 1.58, 1.74 | **1.01, 1.00, 1.01** |
| end-to-end wall | 2.06, 2.15, 2.28 | **1.99, 2.02, 2.00** |

Base grows superlinearly on every one; cand is exactly linear in total work and **constant** in per-boundary latency. That is the `N^2` term leaving.

`plan_load_ms` (total time in `load_rebuild_plans_to_nearest_available_root`):

| backend | N=500 | N=1000 | N=2000 | N=4000 |
|---|---:|---:|---:|---:|
| rocksdb base | 15.9 | 56.1 | 213.8 | 835.6 |
| rocksdb cand | 7.5 | 17.3 | 43.7 | **114.2** (-86.3%, null 2.3%) |
| slatedb base | 21.2 | 64.0 | 217.8 | 810.8 |
| slatedb cand | 11.9 | 23.8 | 48.2 | **98.0** (-87.9%, null 0.3%) |

### Deterministic counters — 1 rep, exactly reproducible

Reads and bytes per availability probe (`root-replay-trace` build, rocksdb):

| N | rows in state | base reads | cand reads | base bytes | cand bytes | base us | cand us |
|---:|---:|---:|---:|---:|---:|---:|---:|
| 500 | 5k | 26.9 | **1.93** | 63.6 KB | 4.2 KB | 633 | 20.5 |
| 1000 | 10k | 58.6 | **1.97** | 132.2 KB | 6.0 KB | 1313 | 24.6 |
| 2000 | 20k | 121.3 | **2.45** | 268.7 KB | 8.0 KB | 2674 | 26.7 |
| 4000 | 40k | 246.9 | **2.73** | 548.8 KB | 9.1 KB | 5574 | 30.3 |

Base doubles with state (`O(rows)`). Cand goes 1.93 -> 2.73 reads across an 8x increase in state (`O(depth)`). Per replayed ancestor, total plan-load wall is now flat: 15.24 / 15.31 / 15.39 us at N=500/1000/2000 (28.13 us at N=4000, from an unrelated `COMMIT_SPACE` point-read cost — see "not measured").

`boundaries`, `plans_loaded`, `plans_staged` and `max_plans_in_one_boundary` (32) are **identical in both arms at every N**, so the replay set and therefore everything written is unchanged.

### End-to-end wall — reported honestly

| backend | N | base | cand | delta | null | verdict |
|---|---:|---:|---:|---:|---:|---|
| slatedb | 1000 | 676.9 ms | 638.6 ms | -5.7% | 0.0% | result |
| slatedb | 2000 | 1455.1 ms | 1287.1 ms | **-11.5%** | 0.4% | result |
| slatedb | 4000 | 3316.4 ms | 2579.6 ms | **-22.2%** | 0.3% | result |
| rocksdb | 1000 | 730.8 ms | 772.6 ms | +5.7% | 20.0% | unresolvable |
| rocksdb | 2000 | 2088.1 ms | 2209.5 ms | +5.8% | 6.5% | unresolvable |
| rocksdb | 4000 | 7185.0 ms | 6769.9 ms | -5.8% | 12.7% | unresolvable |

**RocksDB end-to-end wall does not resolve.** Its wall is dominated by something with a 6.5-20% run-to-run spread, and the saving (0.7 s out of ~7 s at N=4000) sits inside that band. The claim on RocksDB rests on the latency metrics (null 1.2-2.6%) and the counters, not on wall. On SlateDB, whose wall null control is 0.0-0.4%, the saving shows through cleanly.

This also settles the concern that the removed scan might have been warming the block cache for the staging that follows: it was not. Wall improves or is flat; it never regresses outside the null band.

Median (non-boundary) commit latency is flat, as designed — only boundary commits ever ran the probe. SlateDB (null 0.0-0.5%): +0.5%, +0.5%, +0.7%, +0.6%. RocksDB median has a 1.8-23.8% null and cannot resolve anything.

## Guards

Layer touched: commit / staging path -> write ids and settled bytes.

- **`tracked_state_crud`, 50 write ids** (insert_all / update_all / update_one_by_pk / delete_all / delete_one_by_pk x kv_layout, transaction, sql_session x rocksdb, slatedb x smoke/1k, real_workload/10k), 3 interleaved reps, rotated: **max |delta| 2.6%**, every id inside its own base spread. Largest movers: `transaction/lix_slatedb/smoke/delete_one_by_pk` -2.6%, `kv_layout/lix_rocksdb/smoke/delete_one_by_pk` +2.6%.
- **`diff_commands`**, 3 interleaved reps: `working_diff_1000` +0.8%, `revert_100_of_1000` +0.1%, `apply_100_of_1000` -0.2%, `partial_checkpoint_500_of_1000` +0.3%. Max |delta| 0.8%.
- **Bytes**: no write path is touched. The A/B shows identical `boundaries`, `plans_loaded`, `plans_staged` and `max_plans_in_one_boundary` in both arms at all four scales, so the staged write set is unchanged by construction.

Honest caveat: none of these guard lanes makes 32+ commits, so none of them reaches a replay boundary and none executes the changed code. They are guards against unintended side effects (nothing else regressed), not evidence about the changed path. The changed path is covered by the A/B above.

## Correctness

- `cargo clippy --profile test --workspace --all-targets --all-features -- -D warnings` — **clean**.
- `cargo test --profile test --workspace --all-features --no-fail-fast` — 3432 tests pass. **Three targets fail, and the identical three fail on the base arm**, so all are inherited, none is caused by this change:

| failing target | test | inherited |
|---|---|---|
| `-p lix-server-protocol --lib` | `cancelled_branch_switch_reports_terminal_storage_after_caller_cancellation` | yes — this is #1331's known red CI |
| `-p lix_benchmarks --test corruption_recovery_qualification` | `rocksdb_cold_reopen_corruption_qualification`, `slatedb_cold_reopen_corruption_qualification` | yes |
| `-p lix_benchmarks --test tracked_state_crud_public_result` | — | yes |

Base arm (`exp/plan-loading-layout-base`, same tree minus the cut) produces byte-identical failing-target and failing-test lists.
- New test `availability_proof_is_bounded_on_commit_and_total_on_repair` pins both halves: on a multi-chunk tree with a non-root chunk deleted, the commit-path proof still resumes (1 plan) and the repair proof rejects the resume point and replays past it (2 plans).
- #1331's `damaged_resume_point_falls_back_to_total_replay` and `byte_identical_root_check_rejects_a_broken_resume_point` are unchanged and still pass.

## Behaviour change, stated plainly

Before, an ordinary commit that closed a replay interval would *incidentally repair* a resume point with a missing deep chunk, by rejecting it and replaying from genesis. It no longer does: the commit path resumes from an addressable root and leaves such damage in place until explicit repair runs. This is deliberate. Silent, unbounded, `O(state)` self-repair on the commit path is exactly the second authority being removed, and `Engine::rebuild_tracked_state_for_branch` still performs total repair. If a deep chunk really is missing, the failure surfaces the next time a read needs it, loudly, rather than being papered over at 5.6 ms per boundary commit.

## Not measured / gaps

- History SQL surfaces. `lix_key_value_history` and `lix_checkpoint_history` are in the fixed catalog but returned `LIX_TABLE_NOT_FOUND` from a workspace session, so the history read path is untested by the counters. The claim that plan loading is commit-path-only rests on static reachability there (`load_available_root` has exactly one caller, `load_rebuild_plans_to_nearest_available_root`, whose non-test callers are `transaction/commit.rs` and `rebuild_commit_root_at`), plus measured zeroes for checkpoint, merge, GC, `lix_commit`, `lix_change` and a 10k-row table scan.
- RocksDB end-to-end wall, as above.
- Trees deeper than what 40k rows produces; the probe is `O(depth)`, not `O(1)`.
- An unverified secondary observation carried over from attribution: the single `COMMIT_SPACE` point read per replayed ancestor went 2.4 -> 23.5 us across N = 250..4000. One rep, plausibly compaction interference. It survives in both arms of this A/B (cand `per_plan io_us` jumps 8.6 -> 21.0 at N=4000) and is unaffected by this change. Not chased.

## Machine note

`~/claude3/cand` on `ryzen-9950x-IV` was checked out to `fix/branch-control-space-name-hook` by another session at 00:33 UTC and compiled there for ~20 minutes, overlapping the first A/B matrix. That run's RocksDB null control degraded to 8-19%. Every number above is from a **second, clean matrix** run against binaries copied out to `~/claude3/expab-bin/`, on an idle box (load average < 1.0), after that session's build finished.

## Stacking

This branch is `origin/main` merged with `exp/root-replay-scope-2` (#1331), then the cut. **Merge #1331 first.** #1331 is currently red on `lix-server-protocol`; that failure is reproduced above on both of my arms and is not mine to fix. If #1331's diff changes, this branch needs a re-merge.

Files that are mine (everything else in the diff comes from #1331):
- `packages/lix/src/tracked_state/commit_root_rebuild.rs` — the cut
- `packages/lix/src/tracked_state/context.rs` — the new test
- `packages/lix/src/storage_bench.rs`, `packages/lix/src/storage_adapter/read_scope.rs`, `packages/lix/src/tracked_state/storage.rs`, `packages/lix/Cargo.toml` — plan-load phase attribution instrument (all behind `root-replay-trace`, compiled out of every default and `storage-benches` build; verified by building all three feature configs)
- `packages/engine-benchmarks/examples/expab_plan_load.rs`, `packages/engine-benchmarks/Cargo.toml` — the A/B driver
- `.changenotes/bounded-commit-root-availability-proof.md`
