### PR TITLE
Switch Lix SQL parsing to PostgreSQL grammar

### DIFF
--- a/.changenotes/postgresql-sql-grammar.md
+++ b/.changenotes/postgresql-sql-grammar.md
@@ -1,0 +1,9 @@
+---
+type: minor
+---
+
+Lix SQL now uses PostgreSQL grammar.
+
+Queries use PostgreSQL-style numbered parameters such as `$1` and `$2`.
+Anonymous `?` parameters are no longer accepted, and `VALUES` relations use
+the PostgreSQL form `FROM (VALUES (...)) AS alias(column)`.

--- a/docs/diff-commands.md
+++ b/docs/diff-commands.md
@@ -90,7 +90,7 @@ a parameterized `VALUES` relation:
 
 ```sql
 INSERT INTO lix_revert (diff_id)
-SELECT diff_id FROM VALUES ($1) AS selected(diff_id);
+SELECT diff_id FROM (VALUES ($1)) AS selected(diff_id);
 ```
 
 Direct `INSERT ... VALUES` is intentionally rejected. Every command must be

--- a/docs/js-api-reference.md
+++ b/docs/js-api-reference.md
@@ -109,13 +109,13 @@ await storage.syncDiskToLix();
 const result = await lix.execute(sql, params?, options?);
 ```
 
-Executes one DataFusion SQL statement against the active Lix session.
+Executes one PostgreSQL-dialect SQL statement against the active Lix session.
 
 Parameters:
 
 | Parameter | Type                     | Description                                                        |
 | --------- | ------------------------ | ------------------------------------------------------------------ |
-| `sql`     | `string`                 | One SQL statement. Use DataFusion SQL, not SQLite SQL.             |
+| `sql`     | `string`                 | One statement from Lix's PostgreSQL-dialect subset.                |
 | `params`  | `SqlParam[]`             | Optional positional parameters addressed as `$1`, `$2`, and so on. |
 | `options` | `ExecuteOptions`         | Optional execution options. See below.                             |
 

--- a/docs/sql-functions.md
+++ b/docs/sql-functions.md
@@ -4,7 +4,7 @@ description: Built-in scalar SQL functions provided by the Lix engine. Covers JS
 
 # SQL Functions
 
-Lix's DataFusion-backed engine registers a small set of scalar functions for use inside `lix.execute()`. They cover the gaps between standard SQL and Lix's own conventions: parsing JSON parameters, producing IDs and timestamps, and resolving the active branch and its commit id.
+Lix accepts a PostgreSQL-dialect SQL subset executed by its DataFusion-backed engine. It registers a small set of scalar functions for use inside `lix.execute()`. They cover the gaps between PostgreSQL grammar and Lix's own conventions: parsing JSON parameters, producing IDs and timestamps, and resolving the active branch and its commit id.
 
 ## At a glance
 
@@ -111,5 +111,5 @@ For the column types Lix accepts in `CAST` expressions (for example `TEXT` and `
 ## Notes
 
 - Functions are pure scalars; they do not consume rows or take aggregates.
-- Bound parameters can use `?` or `$1`, `$2`, …
+- Bound parameters use PostgreSQL-style `$1`, `$2`, … placeholders.
 - `lix_active_branch_id()`, `lix_active_branch_commit_id()`, `lix_uuid_v7()`, and `lix_timestamp()` reflect the engine's current view at planning/execution time and are stable across the rows of a single statement.

--- a/packages/cli/src/commands/exp/git_replay.rs
+++ b/packages/cli/src/commands/exp/git_replay.rs
@@ -699,7 +699,7 @@ fn is_prepared_replay_shape(sql: &str) -> bool {
 
 fn git_replay_marker_statement(commit: &ReplayCommit) -> SqlStatement {
     SqlStatement {
-        sql: "INSERT INTO lix_key_value (key, value) VALUES (?, ?) \
+        sql: "INSERT INTO lix_key_value (key, value) VALUES ($1, $2) \
               ON CONFLICT(key) DO UPDATE SET value = excluded.value"
             .to_string(),
         params: vec![
@@ -1895,7 +1895,10 @@ fn build_replay_commit_statements(
             continue;
         }
 
-        let placeholders = vec!["?"; delete_chunk.len()].join(", ");
+        let placeholders = (1..=delete_chunk.len())
+            .map(|index| format!("${index}"))
+            .collect::<Vec<_>>()
+            .join(", ");
         let sql = format!("DELETE FROM lix_file WHERE id IN ({placeholders})");
         let params = delete_chunk
             .iter()
@@ -1907,8 +1910,9 @@ fn build_replay_commit_statements(
 
     for row in &batch.inserts {
         statements.push(SqlStatement {
-            sql: "INSERT INTO lix_file (id, path, content, lixcol_metadata) VALUES (?, ?, ?, ?)"
-                .to_string(),
+            sql:
+                "INSERT INTO lix_file (id, path, content, lixcol_metadata) VALUES ($1, $2, $3, $4)"
+                    .to_string(),
             params: vec![
                 Value::Text(row.id.clone()),
                 Value::Text(row.path.clone()),
@@ -1920,10 +1924,11 @@ fn build_replay_commit_statements(
 
     for row in &batch.updates {
         statements.push(SqlStatement {
-            sql: "INSERT INTO lix_file (id, path, content, lixcol_metadata) VALUES (?, ?, ?, ?) \
+            sql:
+                "INSERT INTO lix_file (id, path, content, lixcol_metadata) VALUES ($1, $2, $3, $4) \
                  ON CONFLICT(id) DO UPDATE SET content = excluded.content, \
                  lixcol_metadata = excluded.lixcol_metadata"
-                .to_string(),
+                    .to_string(),
             params: vec![
                 Value::Text(row.id.clone()),
                 Value::Text(row.path.clone()),
@@ -2030,7 +2035,10 @@ where
             end += 1;
         }
         let batch = &expected[offset..end];
-        let placeholders = vec!["?"; batch.len()].join(", ");
+        let placeholders = (1..=batch.len())
+            .map(|index| format!("${index}"))
+            .collect::<Vec<_>>()
+            .join(", ");
         let sql = format!(
             "SELECT path, content, lixcol_metadata FROM lix_file WHERE path IN ({placeholders})"
         );
@@ -2336,7 +2344,7 @@ where
     ];
     for (key, archive) in plugins {
         db::block_on(lix.execute(
-            "INSERT INTO lix_file (path, content) VALUES (?, ?)",
+            "INSERT INTO lix_file (path, content) VALUES ($1, $2)",
             &[
                 Value::Text(format!("/.lix/plugins/{key}.lixplugin")),
                 Value::Blob(archive.into()),
@@ -2575,7 +2583,7 @@ mod tests {
         let statements =
             vec![
             SqlStatement {
-                sql: "INSERT INTO lix_file (id, path, content, lixcol_metadata) VALUES (?, ?, ?, ?)"
+                sql: "INSERT INTO lix_file (id, path, content, lixcol_metadata) VALUES ($1, $2, $3, $4)"
                     .to_string(),
                 params: vec![
                     Value::Text(stable_file_id(&git_path(b"one"))),
@@ -2585,7 +2593,7 @@ mod tests {
                 ],
             },
             SqlStatement {
-                sql: "INSERT INTO lix_file (id, path, content, lixcol_metadata) VALUES (?, ?, ?, ?)"
+                sql: "INSERT INTO lix_file (id, path, content, lixcol_metadata) VALUES ($1, $2, $3, $4)"
                     .to_string(),
                 params: vec![
                     Value::Text(stable_file_id(&git_path(b"two"))),
@@ -2610,7 +2618,7 @@ mod tests {
             "two contiguous file rows must enter one prepared production page"
         );
         let marker = db::block_on(lix.execute(
-            "SELECT value FROM lix_key_value WHERE key = ?",
+            "SELECT value FROM lix_key_value WHERE key = $1",
             &[Value::Text(GIT_REPLAY_MARKER_KEY.to_string())],
         ))
         .expect("marker should be visible after atomic replay");
@@ -2731,7 +2739,7 @@ mod tests {
         let marker_rows = db::block_on(lix.execute(
             "SELECT value, lixcol_observed_commit_id \
              FROM lix_key_value_history() \
-             WHERE key = ? AND NOT lixcol_is_deleted",
+             WHERE key = $1 AND NOT lixcol_is_deleted",
             &[Value::Text(GIT_REPLAY_MARKER_KEY.to_string())],
         ))
         .expect("replay markers should be queryable without Git");
@@ -2763,7 +2771,7 @@ mod tests {
                 .get(git_sha)
                 .unwrap_or_else(|| panic!("missing Lix commit for Git version {version_index}"));
             let historical = db::block_on(lix.execute(
-                "SELECT content FROM lix_file_history(?) \
+                "SELECT content FROM lix_file_history($1) \
                  WHERE path = '/asset.bin' AND lixcol_depth = 0 AND NOT lixcol_is_deleted",
                 &[Value::Text(lix_commit.clone())],
             ))
@@ -3100,7 +3108,7 @@ mod tests {
 
         assert_eq!(
             statement.sql,
-            "INSERT INTO lix_key_value (key, value) VALUES (?, ?) ON CONFLICT(key) DO UPDATE SET value = excluded.value"
+            "INSERT INTO lix_key_value (key, value) VALUES ($1, $2) ON CONFLICT(key) DO UPDATE SET value = excluded.value"
         );
         assert_eq!(
             statement.params[0],
@@ -3131,7 +3139,7 @@ mod tests {
         assert_eq!(statements.len(), 1);
         assert_eq!(
             statements[0].sql,
-            "INSERT INTO lix_file (id, path, content, lixcol_metadata) VALUES (?, ?, ?, ?) ON CONFLICT(id) DO UPDATE SET content = excluded.content, lixcol_metadata = excluded.lixcol_metadata"
+            "INSERT INTO lix_file (id, path, content, lixcol_metadata) VALUES ($1, $2, $3, $4) ON CONFLICT(id) DO UPDATE SET content = excluded.content, lixcol_metadata = excluded.lixcol_metadata"
         );
         assert_eq!(
             statements[0].params,
@@ -3161,14 +3169,14 @@ mod tests {
         let statements = build_replay_commit_statements(&batch, DEFAULT_INSERT_BATCH_ROWS);
 
         assert_eq!(statements.len(), 2);
-        assert_eq!(statements[0].sql, "DELETE FROM lix_file WHERE id IN (?)");
+        assert_eq!(statements[0].sql, "DELETE FROM lix_file WHERE id IN ($1)");
         assert_eq!(
             statements[0].params,
             vec![Value::Text("/src/old.ts".to_string())]
         );
         assert_eq!(
             statements[1].sql,
-            "INSERT INTO lix_file (id, path, content, lixcol_metadata) VALUES (?, ?, ?, ?)"
+            "INSERT INTO lix_file (id, path, content, lixcol_metadata) VALUES ($1, $2, $3, $4)"
         );
         assert_eq!(
             statements[1].params,
@@ -3424,7 +3432,7 @@ mod tests {
             "initialization plus four replayed commits should publish five checkpoints"
         );
         let text_rows = db::block_on(lix.execute(
-            "SELECT lixcol_entity_pk FROM text_line WHERE lixcol_file_id = ?",
+            "SELECT lixcol_entity_pk FROM text_line WHERE lixcol_file_id = $1",
             &[Value::Text(stable_file_id(&git_path(b"docs/renamed.txt")))],
         ))
         .expect("Git text rows should be queryable after replay");
@@ -3433,7 +3441,7 @@ mod tests {
             "renamed text file must derive Git-text semantic rows at its new path"
         );
         let csv_rows = db::block_on(lix.execute(
-            "SELECT lixcol_entity_pk FROM csv_row WHERE lixcol_file_id = ?",
+            "SELECT lixcol_entity_pk FROM csv_row WHERE lixcol_file_id = $1",
             &[Value::Text(stable_file_id(&git_path(b"table.csv")))],
         ))
         .expect("CSV rows should be queryable after replay");
@@ -3443,7 +3451,7 @@ mod tests {
             "CSV replay must eagerly materialize both records"
         );
         let binary_rows = db::block_on(lix.execute(
-            "SELECT lixcol_entity_pk FROM text_line WHERE lixcol_file_id = ?",
+            "SELECT lixcol_entity_pk FROM text_line WHERE lixcol_file_id = $1",
             &[Value::Text(stable_file_id(&git_path(b"binary.bin")))],
         ))
         .expect("Git text rows should query for binary fixture");
@@ -3532,7 +3540,7 @@ mod tests {
         let lix = db::block_on(open_lix().with_storage(storage))
             .expect("replay Lix should reopen cleanly");
         let rows = db::block_on(lix.execute(
-            "SELECT lixcol_entity_pk FROM csv_row WHERE lixcol_file_id = ?",
+            "SELECT lixcol_entity_pk FROM csv_row WHERE lixcol_file_id = $1",
             &[Value::Text(stable_file_id(&git_path(b"table.csv")))],
         ))
         .expect("CSV rows should be queryable after replay");
@@ -3692,7 +3700,7 @@ mod tests {
         for (index, expected) in expected_final.iter().enumerate() {
             let path = format!("/bulk-{index:02}.txt");
             let file_rows = db::block_on(lix.execute(
-                "SELECT content FROM lix_file WHERE path = ?",
+                "SELECT content FROM lix_file WHERE path = $1",
                 &[Value::Text(path.clone())],
             ))
             .expect("reopened rendered text file should query");
@@ -3711,7 +3719,7 @@ mod tests {
             );
 
             let semantic_rows = db::block_on(lix.execute(
-                "SELECT lixcol_entity_pk FROM text_line WHERE lixcol_file_id = ?",
+                "SELECT lixcol_entity_pk FROM text_line WHERE lixcol_file_id = $1",
                 &[Value::Text(stable_file_id(&git_path(
                     path.trim_start_matches('/').as_bytes(),
                 )))],
@@ -3793,7 +3801,7 @@ mod tests {
         let lix = db::block_on(open_lix().with_storage(storage))
             .expect("replay Lix should reopen with installed plugin");
         let file_rows = db::block_on(lix.execute(
-            "SELECT content FROM lix_file WHERE path = ?",
+            "SELECT content FROM lix_file WHERE path = $1",
             &[Value::Text("/src/index.ts".to_string())],
         ))
         .expect("replayed text file should query");
@@ -3808,7 +3816,7 @@ mod tests {
         assert_eq!(rendered, Some(b"a\na\n".as_slice()));
 
         let semantic_rows = db::block_on(lix.execute(
-            "SELECT lixcol_entity_pk FROM text_line WHERE lixcol_file_id = ?",
+            "SELECT lixcol_entity_pk FROM text_line WHERE lixcol_file_id = $1",
             &[Value::Text(stable_file_id(&git_path(b"src/index.ts")))],
         ))
         .expect("replayed Git-text rows should query");

--- a/packages/engine-benchmarks/tests/tracked_state_crud_public_result.rs
+++ b/packages/engine-benchmarks/tests/tracked_state_crud_public_result.rs
@@ -61,10 +61,10 @@ where
 fn typed_olap_queries_are_plain_datafusion_selects() {
     use datafusion::sql::parser::DFParser;
     use datafusion::sql::sqlparser::ast::{SetExpr, Statement as SqlStatement};
-    use datafusion::sql::sqlparser::dialect::GenericDialect;
+    use datafusion::sql::sqlparser::dialect::PostgreSqlDialect;
 
     for shape in sql_session::OlapReadShape::ALL {
-        let mut statements = DFParser::parse_sql_with_dialect(shape.sql(), &GenericDialect {})
+        let mut statements = DFParser::parse_sql_with_dialect(shape.sql(), &PostgreSqlDialect {})
             .expect("typed OLAP benchmark SQL should parse");
         let statement = statements.pop_front().expect("one OLAP statement");
         let datafusion::sql::parser::Statement::Statement(statement) = statement else {

--- a/packages/lix/src/engine.rs
+++ b/packages/lix/src/engine.rs
@@ -1608,7 +1608,7 @@ mod tests {
         }
     }
 
-    /// `WHERE lixcol_file_id = ?` is now an exact provider constraint, so
+    /// `WHERE lixcol_file_id = $1` is now an exact provider constraint, so
     /// DataFusion drops its residual filter and the answer rests entirely on
     /// `LiveStateFilter::file_ids`. Rows can live in four authorities — the
     /// branch-local `HOT_ROW` overlay, a packed current base, a certified

--- a/packages/lix/src/handle.rs
+++ b/packages/lix/src/handle.rs
@@ -211,13 +211,13 @@ where
         })
     }
 
-    /// Executes one DataFusion SQL statement against this Lix session.
+    /// Executes one PostgreSQL-dialect SQL statement against this Lix session.
     ///
-    /// The SQL dialect is DataFusion SQL, not SQLite SQL. Positional
-    /// placeholders use `?` or `$1`, `$2`, and so on. SQLite-specific catalog tables
-    /// and transaction statements such as `sqlite_master`, `BEGIN`, and
-    /// `COMMIT` are not part of this contract; use `information_schema` for
-    /// catalog inspection. Lix owns transaction boundaries for each statement.
+    /// Lix supports a PostgreSQL-dialect subset executed by DataFusion.
+    /// Positional placeholders use `$1`, `$2`, and so on. Parsing PostgreSQL
+    /// syntax does not imply support for every PostgreSQL statement or runtime
+    /// feature. Use `information_schema` for catalog inspection. Lix owns
+    /// transaction boundaries for each statement.
     /// While a transaction is active, call `execute()` on the transaction
     /// handle instead.
     pub async fn execute(&self, sql: &str, params: &[Value]) -> Result<ExecuteResult, LixError> {

--- a/packages/lix/src/live_state/tracked_head.rs
+++ b/packages/lix/src/live_state/tracked_head.rs
@@ -4122,7 +4122,7 @@ mod tests {
             Some("01920000-0000-7000-8000-0000000000b2")
         );
 
-        // A schema-scoped `file_id = ?` query reads the hydrated file-first
+        // A schema-scoped `file_id = $1` query reads the hydrated file-first
         // primary range directly. This is the access pattern used by
         // filesystem-backed entity scans, where the entity PK is not known
         // before the query.

--- a/packages/lix/src/live_state/tracked_head/hot.rs
+++ b/packages/lix/src/live_state/tracked_head/hot.rs
@@ -10391,7 +10391,7 @@ async fn hot_scan_entries<'a>(
     }
 
     // The authoritative hot index is file-first, so filesystem queries such as
-    // `WHERE file_id = ?` read one contiguous hydrated range without a second
+    // `WHERE file_id = $1` read one contiguous hydrated range without a second
     // value projection or random point-read hydration.
     if let Some(prefixes) = hot_file_scan_prefixes(branch_id, generation, filter) {
         let entries = HotScanEntries::Decoded(
@@ -10941,7 +10941,7 @@ fn encode_hot_diff_key_parts(
 ///
 /// Measured consequence of leaving the proof scope-global (rocksdb,
 /// hetzner-cpx62-II, `working_diff_file_scope`, 9 reps, four dirty rows in the
-/// probed file): `WHERE file_id = ?` costs 0.61 ms at 1k total dirty rows and
+/// probed file): `WHERE file_id = $1` costs 0.61 ms at 1k total dirty rows and
 /// 51.6 ms at 100k — linear in the dirty set, flat in the answer — while the
 /// finite `schema_key + entity_pk + file_id` shape that bypasses this space
 /// stays at ~0.5 ms across the same range.

--- a/packages/lix/src/session/execute.rs
+++ b/packages/lix/src/session/execute.rs
@@ -792,13 +792,13 @@ where
         Ok(ExecutionDisposition::CancellableRead)
     }
 
-    /// Executes one DataFusion SQL statement against this Lix session.
+    /// Executes one PostgreSQL-dialect SQL statement against this Lix session.
     ///
-    /// The SQL dialect is DataFusion SQL, not SQLite SQL. Positional
-    /// placeholders use `?` or `$1`, `$2`, and so on. SQLite-specific catalog tables
-    /// and transaction statements such as `sqlite_master`, `BEGIN`, and
-    /// `COMMIT` are not part of this contract; use `information_schema` for
-    /// catalog inspection. Lix owns transaction boundaries for each statement.
+    /// Lix supports a PostgreSQL-dialect subset executed by DataFusion.
+    /// Positional placeholders use `$1`, `$2`, and so on. Parsing PostgreSQL
+    /// syntax does not imply support for every PostgreSQL statement or runtime
+    /// feature. Use `information_schema` for catalog inspection. Lix owns
+    /// transaction boundaries for each statement.
     pub async fn execute(&self, sql: &str, params: &[Value]) -> Result<ExecuteResult, LixError> {
         Box::pin(self.execute_with_options(sql, params, ExecuteOptions::default())).await
     }
@@ -3479,21 +3479,7 @@ fn is_acknowledgeable_file_content_read(statement: &DataFusionStatement, params:
         .as_ref()
         .expect("simple point read requires a predicate");
     let mut equality_columns = BTreeSet::new();
-    // Anonymous placeholders are bound in textual order. Atelier's point read
-    // projects the active branch as `? AS active_branch_id` before filtering
-    // by `file.id = ?`, so start the WHERE binder after projection params.
-    let mut anonymous_placeholder_index = point_read
-        .select
-        .projection
-        .iter()
-        .map(anonymous_placeholders_in_select_item)
-        .sum();
-    if !collect_literal_equalities(
-        selection,
-        &mut equality_columns,
-        params,
-        &mut anonymous_placeholder_index,
-    ) {
+    if !collect_literal_equalities(selection, &mut equality_columns, params) {
         return false;
     }
     match point_read.table_name.as_str() {
@@ -4097,9 +4083,7 @@ fn exact_point_text_param(expression: &Expr, params: &[Value]) -> Option<String>
         return None;
     };
     match &value.value {
-        SqlValue::Placeholder(placeholder)
-            if params.len() == 1 && (placeholder == "?" || placeholder == "$1") =>
-        {
+        SqlValue::Placeholder(placeholder) if params.len() == 1 && placeholder == "$1" => {
             let Value::Text(value) = &params[0] else {
                 return None;
             };
@@ -4134,38 +4118,6 @@ fn point_read_limit_is_safe(limit_clause: Option<&LimitClause>) -> bool {
     matches!(&value.value, SqlValue::Number(number, _) if number.parse::<u64>().is_ok_and(|number| number > 0))
 }
 
-fn anonymous_placeholders_in_select_item(item: &SelectItem) -> usize {
-    let expression = match item {
-        SelectItem::UnnamedExpr(expression)
-        | SelectItem::ExprWithAlias {
-            expr: expression, ..
-        } => expression,
-        SelectItem::QualifiedWildcard(..) | SelectItem::Wildcard(..) => return 0,
-    };
-    let mut visitor = AnonymousPlaceholderCounter::default();
-    let _ = expression.visit(&mut visitor);
-    visitor.count
-}
-
-#[derive(Default)]
-struct AnonymousPlaceholderCounter {
-    count: usize,
-}
-
-impl Visitor for AnonymousPlaceholderCounter {
-    type Break = ();
-
-    fn pre_visit_expr(&mut self, expression: &Expr) -> ControlFlow<Self::Break> {
-        if matches!(
-            expression,
-            Expr::Value(value) if matches!(&value.value, SqlValue::Placeholder(placeholder) if placeholder == "?")
-        ) {
-            self.count = self.count.saturating_add(1);
-        }
-        ControlFlow::Continue(())
-    }
-}
-
 fn group_by_is_empty(group_by: &GroupByExpr) -> bool {
     matches!(group_by, GroupByExpr::Expressions(expressions, modifiers)
         if expressions.is_empty() && modifiers.is_empty())
@@ -4185,19 +4137,16 @@ fn collect_literal_equalities(
     expression: &Expr,
     columns: &mut BTreeSet<String>,
     params: &[Value],
-    anonymous_placeholder_index: &mut usize,
 ) -> bool {
     match expression {
-        Expr::Nested(expression) => {
-            collect_literal_equalities(expression, columns, params, anonymous_placeholder_index)
-        }
+        Expr::Nested(expression) => collect_literal_equalities(expression, columns, params),
         Expr::BinaryOp {
             left,
             op: BinaryOperator::And,
             right,
         } => {
-            collect_literal_equalities(left, columns, params, anonymous_placeholder_index)
-                && collect_literal_equalities(right, columns, params, anonymous_placeholder_index)
+            collect_literal_equalities(left, columns, params)
+                && collect_literal_equalities(right, columns, params)
         }
         Expr::BinaryOp {
             left,
@@ -4205,16 +4154,8 @@ fn collect_literal_equalities(
             right,
         } => {
             let column = match (direct_column_name(left), direct_column_name(right)) {
-                (Some(column), None)
-                    if point_identity_value_is_text(right, params, anonymous_placeholder_index) =>
-                {
-                    column
-                }
-                (None, Some(column))
-                    if point_identity_value_is_text(left, params, anonymous_placeholder_index) =>
-                {
-                    column
-                }
+                (Some(column), None) if point_identity_value_is_text(right, params) => column,
+                (None, Some(column)) if point_identity_value_is_text(left, params) => column,
                 _ => return false,
             };
             columns.insert(column)
@@ -4223,26 +4164,16 @@ fn collect_literal_equalities(
     }
 }
 
-fn point_identity_value_is_text(
-    expression: &Expr,
-    params: &[Value],
-    anonymous_placeholder_index: &mut usize,
-) -> bool {
+fn point_identity_value_is_text(expression: &Expr, params: &[Value]) -> bool {
     let Expr::Value(value) = expression else {
         return false;
     };
     match &value.value {
         SqlValue::Placeholder(placeholder) => {
-            let index = if placeholder == "?" {
-                let index = *anonymous_placeholder_index;
-                *anonymous_placeholder_index += 1;
-                Some(index)
-            } else {
-                placeholder
-                    .strip_prefix('$')
-                    .and_then(|index| index.parse::<usize>().ok())
-                    .and_then(|index| index.checked_sub(1))
-            };
+            let index = placeholder
+                .strip_prefix('$')
+                .and_then(|index| index.parse::<usize>().ok())
+                .and_then(|index| index.checked_sub(1));
             index
                 .and_then(|index| params.get(index))
                 .is_some_and(|value| matches!(value, Value::Text(_)))
@@ -4716,7 +4647,7 @@ mod tests {
         );
 
         let change_by_path =
-            sql2::parse_statement("SELECT lixcol_change_id FROM lix_file WHERE path = ?").unwrap();
+            sql2::parse_statement("SELECT lixcol_change_id FROM lix_file WHERE path = $1").unwrap();
         assert_eq!(
             exact_filesystem_read_route(&change_by_path, &[Value::Text("/a.txt".to_string())]),
             Some(ExactFilesystemRead::Point(

--- a/packages/lix/src/sql2/bind/public_udf.rs
+++ b/packages/lix/src/sql2/bind/public_udf.rs
@@ -5,20 +5,19 @@ use datafusion::sql::sqlparser::ast::{
     Expr, Function, FunctionArguments, ObjectNamePart, Statement, Visit, Visitor,
 };
 #[cfg(test)]
-use datafusion::sql::sqlparser::dialect::GenericDialect;
-#[cfg(test)]
 use datafusion::sql::sqlparser::parser::Parser;
 
 use crate::LixError;
 
 #[cfg(test)]
 pub(crate) fn validate_public_udf_calls(sql: &str) -> Result<(), LixError> {
-    let statements = Parser::parse_sql(&GenericDialect {}, sql).map_err(|error| {
-        LixError::new(
-            LixError::CODE_PARSE_ERROR,
-            format!("sql2 SQL parse error: {error}"),
-        )
-    })?;
+    let statements =
+        Parser::parse_sql(&super::super::dialect::lix_sql_dialect(), sql).map_err(|error| {
+            LixError::new(
+                LixError::CODE_PARSE_ERROR,
+                format!("sql2 SQL parse error: {error}"),
+            )
+        })?;
 
     let mut visitor = PublicUdfCallVisitor;
     match statements.visit(&mut visitor) {

--- a/packages/lix/src/sql2/bind/statement.rs
+++ b/packages/lix/src/sql2/bind/statement.rs
@@ -1648,56 +1648,25 @@ fn active_branch_scope(active_branch_id: &str) -> BranchScope {
 
 #[derive(Default)]
 struct ParamBinder {
-    next_implicit_index: usize,
-    mode: Option<ParamMode>,
     params: BTreeMap<usize, BoundParamRef>,
-}
-
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-enum ParamMode {
-    Implicit,
-    Numbered,
 }
 
 impl ParamBinder {
     fn bind(&mut self, name: &str) -> Result<BoundParamRef, LixError> {
-        let index = if name == "?" {
-            self.require_mode(ParamMode::Implicit, name)?;
-            self.next_implicit_index += 1;
-            self.next_implicit_index
-        } else {
-            self.require_mode(ParamMode::Numbered, name)?;
-            name.strip_prefix('$')
-                .and_then(|raw| raw.parse::<usize>().ok())
-                .filter(|index| *index > 0)
-                .ok_or_else(|| {
-                    LixError::new(
-                        LixError::CODE_PARSE_ERROR,
-                        format!("unsupported SQL parameter placeholder '{name}'"),
-                    )
-                    .with_hint(
-                        "Use placeholders like ?, ? or numbered placeholders like $1, $2, ...",
-                    )
-                })?
-        };
+        let index = name
+            .strip_prefix('$')
+            .and_then(|raw| raw.parse::<usize>().ok())
+            .filter(|index| *index > 0)
+            .ok_or_else(|| {
+                LixError::new(
+                    LixError::CODE_PARSE_ERROR,
+                    format!("unsupported SQL parameter placeholder '{name}'"),
+                )
+                .with_hint("Use PostgreSQL-style numbered placeholders like $1, $2, ...")
+            })?;
         let param = BoundParamRef { index };
         self.params.entry(index).or_insert(param);
         Ok(param)
-    }
-
-    fn require_mode(&mut self, mode: ParamMode, name: &str) -> Result<(), LixError> {
-        match self.mode {
-            Some(existing) if existing != mode => Err(LixError::new(
-                LixError::CODE_PARSE_ERROR,
-                format!("cannot mix SQL parameter placeholder styles near '{name}'"),
-            )
-            .with_hint("Use either positional ? placeholders or numbered $1 placeholders.")),
-            Some(_) => Ok(()),
-            None => {
-                self.mode = Some(mode);
-                Ok(())
-            }
-        }
     }
 
     fn into_map(self) -> BoundParamMap {
@@ -2403,18 +2372,17 @@ mod tests {
     }
 
     #[test]
-    fn bind_statement_rejects_mixed_placeholder_styles() {
+    fn bind_statement_rejects_anonymous_placeholders() {
         let mut params = ParamBinder::default();
-        params.bind("?").expect("implicit placeholder should bind");
         let error = params
-            .bind("$1")
-            .expect_err("mixed placeholder styles should be rejected");
+            .bind("?")
+            .expect_err("anonymous placeholders are unsupported");
 
         assert_eq!(error.code, LixError::CODE_PARSE_ERROR);
         assert!(
             error
                 .message
-                .contains("cannot mix SQL parameter placeholder styles")
+                .contains("unsupported SQL parameter placeholder")
         );
     }
 

--- a/packages/lix/src/sql2/bind/table.rs
+++ b/packages/lix/src/sql2/bind/table.rs
@@ -115,7 +115,6 @@ pub(crate) fn bind_public_column_ref(
 #[cfg(test)]
 mod tests {
     use datafusion::sql::sqlparser::ast::{SetExpr, Statement, TableFactor};
-    use datafusion::sql::sqlparser::dialect::GenericDialect;
     use datafusion::sql::sqlparser::parser::Parser;
     use serde_json::json;
 
@@ -388,7 +387,8 @@ mod tests {
     }
 
     fn table_name(sql: &str) -> ObjectName {
-        let mut statements = Parser::parse_sql(&GenericDialect {}, sql).expect("parse SQL");
+        let mut statements =
+            Parser::parse_sql(&crate::sql2::dialect::lix_sql_dialect(), sql).expect("parse SQL");
         let Some(Statement::Query(query)) = statements.pop() else {
             panic!("expected query");
         };

--- a/packages/lix/src/sql2/dialect.rs
+++ b/packages/lix/src/sql2/dialect.rs
@@ -1,0 +1,7 @@
+use datafusion::sql::sqlparser::dialect::PostgreSqlDialect;
+
+pub(crate) const DATAFUSION_SQL_DIALECT: &str = "postgresql";
+
+pub(crate) fn lix_sql_dialect() -> PostgreSqlDialect {
+    PostgreSqlDialect {}
+}

--- a/packages/lix/src/sql2/error.rs
+++ b/packages/lix/src/sql2/error.rs
@@ -58,7 +58,7 @@ fn classify_datafusion_error(error: &DataFusionError) -> LixError {
 
     if looks_like_unsupported_dialect(&lower) {
         return LixError::new(LixError::CODE_DIALECT_UNSUPPORTED, message)
-            .with_hint("Lix SQL uses DataFusion syntax. Use lix_json_get(...) or lix_json_get_text(...) for JSON access, and placeholders like ?, ? or $1, $2, ...");
+            .with_hint("Lix SQL uses a PostgreSQL-dialect subset. Use lix_json_get(...) or lix_json_get_text(...) for JSON access, and numbered placeholders like $1, $2, ...");
     }
 
     if looks_like_unsupported_runtime_plan(&lower) {
@@ -76,7 +76,7 @@ fn classify_datafusion_error(error: &DataFusionError) -> LixError {
         || lower.contains("bind")
     {
         return LixError::new(LixError::CODE_PARSE_ERROR, message)
-            .with_hint("Use placeholders like ?, ? or numbered placeholders like $1, $2, ...");
+            .with_hint("Use PostgreSQL-style numbered placeholders like $1, $2, ...");
     }
 
     if lower.contains("table not found")

--- a/packages/lix/src/sql2/exec/datafusion.rs
+++ b/packages/lix/src/sql2/exec/datafusion.rs
@@ -2907,7 +2907,7 @@ fn expected_positional_parameter_count(
                 LixError::CODE_PARSE_ERROR,
                 format!("unsupported SQL parameter placeholder '{name}'"),
             )
-            .with_hint("Use placeholders like ?, ? or numbered placeholders like $1, $2, ...")
+            .with_hint("Use PostgreSQL-style numbered placeholders like $1, $2, ...")
             .with_details(json!({
                 "operation": "execute",
                 "placeholder": name,
@@ -2918,7 +2918,7 @@ fn expected_positional_parameter_count(
                 LixError::CODE_PARSE_ERROR,
                 "SQL parameter placeholders are 1-indexed",
             )
-            .with_hint("Use placeholders like ?, ? or numbered placeholders like $1, $2, ...")
+            .with_hint("Use PostgreSQL-style numbered placeholders like $1, $2, ...")
             .with_details(json!({
                 "operation": "execute",
                 "placeholder": name,
@@ -4195,7 +4195,7 @@ mod tests {
         let plan = create_write_logical_plan(
             &mut ctx,
             "INSERT INTO lix_revert (diff_id) \
-             SELECT diff_id FROM VALUES ('d1.test') AS selected(diff_id) \
+             SELECT diff_id FROM (VALUES ('d1.test')) AS selected(diff_id) \
              RETURNING commit_id",
         )
         .await

--- a/packages/lix/src/sql2/mod.rs
+++ b/packages/lix/src/sql2/mod.rs
@@ -4,6 +4,7 @@ mod branch_scope;
 mod catalog;
 mod change_materialization;
 mod context;
+mod dialect;
 mod dml;
 mod entity_batch;
 mod entity_columnar_layout;

--- a/packages/lix/src/sql2/parse/mod.rs
+++ b/packages/lix/src/sql2/parse/mod.rs
@@ -1,30 +1,12 @@
 use datafusion::sql::parser::{DFParserBuilder, Statement as DataFusionStatement};
-use datafusion::sql::sqlparser::dialect::GenericDialect;
 use datafusion::sql::sqlparser::tokenizer::{Token, TokenWithSpan, Tokenizer};
-use serde_json::json;
 
 use crate::LixError;
 
 pub(crate) fn parse_statement(sql: &str) -> Result<DataFusionStatement, LixError> {
-    let dialect = GenericDialect {};
-    let mut next_index = 1usize;
-    let mut has_anonymous = false;
-    let mut explicit_placeholders = Vec::new();
-
-    let mut tokens = Vec::new();
-    Tokenizer::new(&dialect, sql)
-        .tokenize_with_location_into_buf_with_mapper(&mut tokens, |mut token_span| {
-            if let Token::Placeholder(placeholder) = &token_span.token {
-                if placeholder == "?" {
-                    has_anonymous = true;
-                    token_span.token = Token::Placeholder(format!("${next_index}"));
-                    next_index += 1;
-                } else {
-                    explicit_placeholders.push(placeholder.clone());
-                }
-            }
-            token_span
-        })
+    let dialect = super::dialect::lix_sql_dialect();
+    let tokens = Tokenizer::new(&dialect, sql)
+        .tokenize_with_location()
         .map_err(|error| {
             LixError::new(
                 LixError::CODE_PARSE_ERROR,
@@ -33,18 +15,6 @@ pub(crate) fn parse_statement(sql: &str) -> Result<DataFusionStatement, LixError
         })?;
 
     reject_sql_hex_literals(&tokens)?;
-
-    if has_anonymous && !explicit_placeholders.is_empty() {
-        return Err(LixError::new(
-            LixError::CODE_PARSE_ERROR,
-            "SQL mixes anonymous and explicit parameter placeholders",
-        )
-        .with_hint("Use either anonymous placeholders like ?, ? or numbered placeholders like $1, $2, but not both.")
-        .with_details(json!({
-            "operation": "execute",
-            "explicit_placeholders": explicit_placeholders,
-        })));
-    }
 
     let mut statements = DFParserBuilder::new(tokens)
         .with_dialect(&dialect)
@@ -78,7 +48,7 @@ pub(super) fn reject_sql_hex_literals(tokens: &[TokenWithSpan]) -> Result<(), Li
             "SQL hex literals are not supported",
         )
         .with_hint(
-            "Bind binary data directly, or use CAST(? AS BYTEA) with a text parameter for UTF-8 content.",
+            "Bind binary data directly, or use CAST($1 AS BYTEA) with a text parameter for UTF-8 content.",
         ));
     }
 
@@ -89,6 +59,24 @@ pub(super) fn reject_sql_hex_literals(tokens: &[TokenWithSpan]) -> Result<(), Li
 mod tests {
     use super::parse_statement;
     use crate::LixError;
+
+    #[test]
+    fn parses_postgresql_numbered_parameters() {
+        parse_statement("SELECT $1::TEXT, $2")
+            .expect("PostgreSQL parameters and casts should parse");
+    }
+
+    #[test]
+    fn parses_postgresql_values_table_expression() {
+        parse_statement("SELECT value FROM (VALUES ($1)) AS selected(value)")
+            .expect("PostgreSQL VALUES table expression should parse");
+    }
+
+    #[test]
+    fn rejects_anonymous_parameters() {
+        let error = parse_statement("SELECT ?").expect_err("anonymous parameters are unsupported");
+        assert_eq!(error.code, LixError::CODE_PARSE_ERROR);
+    }
 
     #[test]
     fn rejects_hex_literals_before_read_or_write_planning() {

--- a/packages/lix/src/sql2/script.rs
+++ b/packages/lix/src/sql2/script.rs
@@ -1,6 +1,5 @@
 use datafusion::sql::parser::{DFParserBuilder, Statement as DataFusionStatement};
 use datafusion::sql::sqlparser::ast::{BeginTransactionKind, Statement as SqlStatement};
-use datafusion::sql::sqlparser::dialect::GenericDialect;
 use datafusion::sql::sqlparser::tokenizer::{Token, TokenWithSpan, Tokenizer};
 use serde_json::json;
 use std::ops::Range;
@@ -33,9 +32,7 @@ enum TransactionControl {
 
 #[derive(Debug, Clone, Copy, Default)]
 struct PlaceholderUsage {
-    anonymous: usize,
     explicit_max: usize,
-    has_explicit: bool,
 }
 
 #[derive(Debug, Clone)]
@@ -49,8 +46,8 @@ struct ParsedStatement {
 /// Multi-statement scripts may be unwrapped, or wrapped by `BEGIN` (optionally
 /// followed by `TRANSACTION`) and a final `COMMIT`. Transaction aliases,
 /// modes, savepoints, rollback, nested controls, and empty transactions are
-/// rejected. Anonymous placeholders consume request parameters sequentially;
-/// numbered placeholders retain their request-wide positions.
+/// rejected. PostgreSQL-style numbered placeholders retain their request-wide
+/// positions.
 pub fn parse_sql_script(sql: &str, provided_param_count: usize) -> Result<SqlScriptPlan, LixError> {
     let statements = parse_statements(sql)?;
     if statements.is_empty() {
@@ -94,7 +91,7 @@ pub fn parse_sql_script(sql: &str, provided_param_count: usize) -> Result<SqlScr
 }
 
 fn parse_statements(sql: &str) -> Result<Vec<ParsedStatement>, LixError> {
-    let dialect = GenericDialect {};
+    let dialect = super::dialect::lix_sql_dialect();
     let tokens = Tokenizer::new(&dialect, sql)
         .tokenize_with_location()
         .map_err(tokenizer_error)?;
@@ -157,33 +154,11 @@ fn build_atomic_plan(
             (sql, placeholders)
         })
         .collect::<Vec<_>>();
-    let anonymous_count = statements
+    let expected_param_count = statements
         .iter()
-        .map(|(_, placeholders)| placeholders.anonymous)
-        .sum::<usize>();
-    let has_explicit = statements
-        .iter()
-        .any(|(_, placeholders)| placeholders.has_explicit);
-    if anonymous_count > 0 && has_explicit {
-        return Err(LixError::new(
-            LixError::CODE_PARSE_ERROR,
-            "SQL mixes anonymous and explicit parameter placeholders",
-        )
-        .with_hint(
-            "Use either anonymous placeholders like ?, ? or numbered placeholders like $1, $2, but not both.",
-        )
-        .with_details(json!({ "operation": "execute" })));
-    }
-
-    let expected_param_count = if anonymous_count > 0 {
-        anonymous_count
-    } else {
-        statements
-            .iter()
-            .map(|(_, placeholders)| placeholders.explicit_max)
-            .max()
-            .unwrap_or(0)
-    };
+        .map(|(_, placeholders)| placeholders.explicit_max)
+        .max()
+        .unwrap_or(0);
     if provided_param_count != expected_param_count {
         return Err(LixError::new(
             LixError::CODE_INVALID_PARAM,
@@ -198,17 +173,10 @@ fn build_atomic_plan(
         })));
     }
 
-    let mut anonymous_offset = 0usize;
     let statements = statements
         .into_iter()
         .map(|(sql, placeholders)| {
-            let params = if anonymous_count > 0 {
-                let start = anonymous_offset;
-                anonymous_offset += placeholders.anonymous;
-                start..anonymous_offset
-            } else {
-                0..placeholders.explicit_max
-            };
+            let params = 0..placeholders.explicit_max;
             SqlScriptStatement { sql, params }
         })
         .collect();
@@ -221,17 +189,12 @@ fn placeholder_usage(tokens: &[Token]) -> PlaceholderUsage {
         let Token::Placeholder(placeholder) = token else {
             continue;
         };
-        if placeholder == "?" {
-            usage.anonymous += 1;
-            continue;
-        }
         let Some(index) = placeholder
             .strip_prefix('$')
             .and_then(|value| value.parse::<usize>().ok())
         else {
             continue;
         };
-        usage.has_explicit = true;
         usage.explicit_max = usage.explicit_max.max(index);
     }
     usage
@@ -349,19 +312,12 @@ mod tests {
     }
 
     #[test]
-    fn plans_sequential_anonymous_parameters() {
-        let statements = atomic("SELECT ?, ?; SELECT ?", 3);
-        assert_eq!(statements[0].params, 0..2);
-        assert_eq!(statements[1].params, 2..3);
-    }
-
-    #[test]
     fn parser_ignores_delimiters_and_placeholders_in_sql_literals_and_comments() {
         let statements = atomic(
             r#"
                 SELECT '; ? $9' AS value, 1 AS "semi;?;$8", $tag$?; $7$tag$ AS tagged;
                 -- ; ? $6
-                SELECT ? /* ; ? $5 */ AS bound
+                SELECT $1 /* ; ? $5 */ AS bound
             "#,
             1,
         );
@@ -374,7 +330,6 @@ mod tests {
     fn rejects_unsupported_transaction_boundaries() {
         for sql in [
             "BEGIN; COMMIT",
-            "BEGIN IMMEDIATE; SELECT 1; COMMIT",
             "BEGIN WORK; SELECT 1; COMMIT",
             "START TRANSACTION; SELECT 1; COMMIT",
             "BEGIN; SELECT 1; END",
@@ -397,24 +352,28 @@ mod tests {
     }
 
     #[test]
-    fn rejects_mixed_or_mismatched_parameters() {
-        assert_eq!(
-            parse_sql_script("SELECT ?; SELECT $2", 2)
-                .expect_err("mixed placeholders are invalid")
-                .code,
-            LixError::CODE_PARSE_ERROR
-        );
+    fn rejects_non_postgresql_transaction_syntax() {
+        parse_sql_script("BEGIN IMMEDIATE; SELECT 1; COMMIT", 0)
+            .expect_err("SQLite transaction syntax is unsupported");
+    }
+
+    #[test]
+    fn rejects_mismatched_parameters() {
         assert_eq!(
             parse_sql_script("SELECT $1; SELECT $2", 1)
                 .expect_err("parameter count is invalid")
                 .code,
             LixError::CODE_INVALID_PARAM
         );
+    }
+
+    #[test]
+    fn rejects_anonymous_parameters() {
         assert_eq!(
-            parse_sql_script("SELECT ?; SELECT ?", 1)
-                .expect_err("parameter count is invalid")
+            parse_sql_script("SELECT ?", 1)
+                .expect_err("anonymous parameters are unsupported")
                 .code,
-            LixError::CODE_INVALID_PARAM
+            LixError::CODE_PARSE_ERROR
         );
     }
 

--- a/packages/lix/src/sql2/session.rs
+++ b/packages/lix/src/sql2/session.rs
@@ -213,6 +213,10 @@ pub(crate) async fn build_write_session_with_options(
 
 pub(crate) fn new_sql_session_context() -> SessionContext {
     let config = SessionConfig::new()
+        .set_str(
+            "datafusion.sql_parser.dialect",
+            super::dialect::DATAFUSION_SQL_DIALECT,
+        )
         .with_information_schema(false)
         .with_target_partitions(1)
         .set_bool("datafusion.optimizer.repartition_aggregations", false)
@@ -239,6 +243,22 @@ pub(crate) fn new_sql_session_context() -> SessionContext {
     let session = SessionContext::new_with_state(state);
     register_static_sql2_functions(&session);
     sql_session_from_template(session.state(), None)
+}
+
+#[cfg(test)]
+mod tests {
+    use datafusion::common::config::Dialect;
+
+    use super::new_sql_session_context;
+
+    #[test]
+    fn datafusion_session_uses_postgresql_dialect() {
+        let session = new_sql_session_context();
+        assert_eq!(
+            session.copied_config().options().sql_parser.dialect,
+            Dialect::PostgreSQL
+        );
+    }
 }
 
 /// Builds a Lix SQL session from a template state, gives it its own

--- a/packages/lix/src/sql2/write_normalization.rs
+++ b/packages/lix/src/sql2/write_normalization.rs
@@ -251,7 +251,7 @@ pub(crate) fn scalar_is_binary_or_null(value: &ScalarValue) -> bool {
 }
 
 pub(crate) const LIX_FILE_CONTENT_CAST_HINT: &str =
-    "Use CAST(? AS BYTEA) with a text parameter for file contents.";
+    "Use CAST($1 AS BYTEA) with a text parameter for file contents.";
 
 pub(crate) fn lix_file_content_type_lix_error() -> LixError {
     LixError::new(

--- a/packages/lix/tests/integration/branching.rs
+++ b/packages/lix/tests/integration/branching.rs
@@ -1019,7 +1019,7 @@ simulation_test!(
             .expect("draft checkpoint should succeed");
         assert_eq!(
             main.execute(
-                "SELECT commit_id FROM lix_checkpoint WHERE commit_id = ?",
+                "SELECT commit_id FROM lix_checkpoint WHERE commit_id = $1",
                 &[Value::Text(checkpoint.commit_id.clone())],
             )
             .await
@@ -1050,7 +1050,7 @@ simulation_test!(
 
         let checkpoints = main
             .execute(
-                "SELECT commit_id FROM lix_checkpoint WHERE commit_id = ?",
+                "SELECT commit_id FROM lix_checkpoint WHERE commit_id = $1",
                 &[Value::Text(checkpoint.commit_id.clone())],
             )
             .await

--- a/packages/lix/tests/integration/sql/diff_commands.rs
+++ b/packages/lix/tests/integration/sql/diff_commands.rs
@@ -60,7 +60,7 @@ simulation_test!(
             .execute(
                 "INSERT INTO lix_revert (diff_id) \
                  SELECT diff_id \
-                 FROM VALUES ($1) AS selected(diff_id) \
+                 FROM (VALUES ($1)) AS selected(diff_id) \
                  RETURNING commit_id",
                 &[selected_diff_id],
             )

--- a/packages/lix/tests/integration/sql/errors.rs
+++ b/packages/lix/tests/integration/sql/errors.rs
@@ -60,7 +60,7 @@ simulation_test!(
 );
 
 simulation_test!(
-    sql_question_mark_placeholders_bind_positionally,
+    sql_postgresql_numbered_placeholders_bind_positionally,
     |sim| async move {
         let engine = sim.boot_engine().await;
         let session = engine
@@ -70,22 +70,22 @@ simulation_test!(
 
         let result = session
             .execute(
-                "SELECT * FROM lix_file WHERE id = ?",
+                "SELECT * FROM lix_file WHERE id = $1",
                 &[Value::Text(
                     "6d697373-696e-872d-8669-6c6500000000".to_string(),
                 )],
             )
             .await
-            .expect("anonymous placeholder should still bind when no rows match");
+            .expect("numbered placeholder should bind when no rows match");
         assert_eq!(result.len(), 0);
 
         let result = session
             .execute(
-                "SELECT '?' AS literal, ? AS first, ? AS second",
+                "SELECT '?' AS literal, $1 AS first, $2 AS second",
                 &[Value::Integer(10), Value::Text("second".to_string())],
             )
             .await
-            .expect("anonymous placeholders should bind left to right");
+            .expect("numbered placeholders should bind by index");
         let row = result.rows().first().expect("query should return one row");
         assert_eq!(
             row.values(),
@@ -98,7 +98,7 @@ simulation_test!(
 
         let result = session
             .execute(
-                "SELECT 'it''s ?' AS escaped_literal, ? AS bound_value -- ? in comment\n",
+                "SELECT 'it''s ?' AS escaped_literal, $1 AS bound_value -- ? in comment\n",
                 &[Value::Integer(42)],
             )
             .await
@@ -110,43 +110,33 @@ simulation_test!(
         );
 
         let error = session
-            .execute("SELECT ? AS missing_param", &[])
+            .execute("SELECT $1 AS missing_param", &[])
             .await
-            .expect_err("anonymous placeholder without a value should fail");
+            .expect_err("numbered placeholder without a value should fail");
         assert_eq!(error.code, LixError::CODE_INVALID_PARAM);
     }
 );
 
-simulation_test!(
-    sql_mixed_anonymous_and_explicit_placeholders_are_rejected,
-    |sim| async move {
-        let engine = sim.boot_engine().await;
-        let session = sim.wrap_session(
-            engine
-                .open_workspace_session()
-                .await
-                .expect("main session should open"),
-            &engine,
-        );
-
-        let error = session
-            .execute(
-                "SELECT ? AS anonymous_value, $2 AS numbered_value",
-                &[Value::Integer(1), Value::Integer(2)],
-            )
+simulation_test!(sql_anonymous_placeholders_are_rejected, |sim| async move {
+    let engine = sim.boot_engine().await;
+    let session = sim.wrap_session(
+        engine
+            .open_workspace_session()
             .await
-            .expect_err("mixed placeholder styles should fail");
+            .expect("main session should open"),
+        &engine,
+    );
 
-        assert_eq!(error.code, LixError::CODE_PARSE_ERROR);
-        assert!(
-            error.hint().is_some_and(|hint| hint.contains("not both")),
-            "expected mixed-placeholder hint: {error}"
-        );
-    }
-);
+    let error = session
+        .execute("SELECT ? AS anonymous_value", &[Value::Integer(1)])
+        .await
+        .expect_err("anonymous placeholders should fail");
+
+    assert_eq!(error.code, LixError::CODE_PARSE_ERROR);
+});
 
 simulation_test!(
-    sql_transaction_execute_accepts_anonymous_placeholders,
+    sql_transaction_execute_accepts_numbered_placeholders,
     |sim| async move {
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
@@ -163,11 +153,11 @@ simulation_test!(
 
         let result = transaction
             .execute(
-                "SELECT ? AS first, ? AS second",
+                "SELECT $1 AS first, $2 AS second",
                 &[Value::Integer(1), Value::Text("two".to_string())],
             )
             .await
-            .expect("anonymous parameter read in transaction should succeed");
+            .expect("numbered parameter read in transaction should succeed");
         assert_eq!(
             result.rows()[0].values(),
             &[Value::Integer(1), Value::Text("two".to_string())]
@@ -175,14 +165,14 @@ simulation_test!(
 
         transaction
             .execute(
-                "INSERT INTO lix_file (id, path) VALUES (?, ?)",
+                "INSERT INTO lix_file (id, path) VALUES ($1, $2)",
                 &[
                     Value::Text("616e6f6e-796d-8f75-832d-7472616e7300".to_string()),
-                    Value::Text("/anonymous-transaction.txt".to_string()),
+                    Value::Text("/numbered-transaction.txt".to_string()),
                 ],
             )
             .await
-            .expect("anonymous parameter write in transaction should succeed");
+            .expect("numbered parameter write in transaction should succeed");
 
         transaction
             .commit()
@@ -191,16 +181,16 @@ simulation_test!(
 
         let result = session
             .execute(
-                "SELECT path FROM lix_file WHERE id = ?",
+                "SELECT path FROM lix_file WHERE id = $1",
                 &[Value::Text(
                     "616e6f6e-796d-8f75-832d-7472616e7300".to_string(),
                 )],
             )
             .await
-            .expect("committed anonymous parameter write should be visible");
+            .expect("committed numbered parameter write should be visible");
         assert_eq!(
             result.rows()[0].values(),
-            &[Value::Text("/anonymous-transaction.txt".to_string())]
+            &[Value::Text("/numbered-transaction.txt".to_string())]
         );
     }
 );
@@ -216,7 +206,7 @@ simulation_test!(sql_explain_is_read_shaped, |sim| async move {
     );
 
     let result = session
-        .execute("EXPLAIN SELECT ? AS explained_value", &[Value::Integer(1)])
+        .execute("EXPLAIN SELECT $1 AS explained_value", &[Value::Integer(1)])
         .await
         .expect("EXPLAIN SELECT should return explain rows");
     assert!(!result.columns().is_empty());
@@ -224,7 +214,7 @@ simulation_test!(sql_explain_is_read_shaped, |sim| async move {
 
     let error = session
         .execute(
-            "EXPLAIN INSERT INTO lix_file (id, path) VALUES (?, ?)",
+            "EXPLAIN INSERT INTO lix_file (id, path) VALUES ($1, $2)",
             &[
                 Value::Text("explained-write".to_string()),
                 Value::Text("/explained-write.txt".to_string()),

--- a/packages/lix/tests/integration/sql/lix_branch.rs
+++ b/packages/lix/tests/integration/sql/lix_branch.rs
@@ -57,7 +57,7 @@ simulation_test!(
 
         let exact = session
             .execute(
-                "SELECT id, name FROM lix_branch WHERE id = ?",
+                "SELECT id, name FROM lix_branch WHERE id = $1",
                 &[Value::Text(main_id.clone())],
             )
             .await
@@ -73,7 +73,7 @@ simulation_test!(
 
         let in_list = session
             .execute(
-                "SELECT id FROM lix_branch WHERE id IN (?, ?) ORDER BY id",
+                "SELECT id FROM lix_branch WHERE id IN ($1, $2) ORDER BY id",
                 &[
                     Value::Text(global_id.to_string()),
                     Value::Text(main_id.clone()),
@@ -97,7 +97,7 @@ simulation_test!(
 
         let invalid = session
             .execute(
-                "SELECT id FROM lix_branch WHERE id = ?",
+                "SELECT id FROM lix_branch WHERE id = $1",
                 &[Value::Text("not-a-branch-id".to_string())],
             )
             .await

--- a/packages/lix/tests/integration/sql/lix_file.rs
+++ b/packages/lix/tests/integration/sql/lix_file.rs
@@ -1360,7 +1360,7 @@ simulation_test!(
             assert_eq!(error.code, LixError::CODE_TYPE_MISMATCH, "{id}");
             assert_eq!(
                 error.hint(),
-                Some("Use CAST(? AS BYTEA) with a text parameter for file contents."),
+                Some("Use CAST($1 AS BYTEA) with a text parameter for file contents."),
                 "{id}"
             );
         }
@@ -1406,7 +1406,7 @@ simulation_test!(
         assert_eq!(error.code, LixError::CODE_TYPE_MISMATCH);
         assert_eq!(
             error.hint(),
-            Some("Use CAST(? AS BYTEA) with a text parameter for file contents.")
+            Some("Use CAST($1 AS BYTEA) with a text parameter for file contents.")
         );
 
         let result = session
@@ -1455,7 +1455,7 @@ simulation_test!(
             assert_eq!(error.code, LixError::CODE_TYPE_MISMATCH, "{id}");
             assert_eq!(
                 error.hint(),
-                Some("Use CAST(? AS BYTEA) with a text parameter for file contents."),
+                Some("Use CAST($1 AS BYTEA) with a text parameter for file contents."),
                 "{id}"
             );
         }
@@ -1552,7 +1552,7 @@ simulation_test!(
 );
 
 simulation_test!(
-    lix_file_insert_accepts_anonymous_path_and_content_parameters,
+    lix_file_insert_accepts_numbered_path_and_content_parameters,
     |sim| async move {
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
@@ -1565,38 +1565,38 @@ simulation_test!(
 
         let insert_result = session
             .execute(
-                "INSERT INTO lix_file (id, path, content) VALUES (?, ?, ?)",
+                "INSERT INTO lix_file (id, path, content) VALUES ($1, $2, $3)",
                 &[
                     Value::Text("616e6f6e-796d-8f75-832d-706172616d00".to_string()),
-                    Value::Text("/anonymous-param.bin".to_string()),
-                    Value::Blob(b"anonymous".to_vec().into()),
+                    Value::Text("/numbered-param.bin".to_string()),
+                    Value::Blob(b"numbered".to_vec().into()),
                 ],
             )
             .await
-            .expect("anonymous parameter insert should succeed");
+            .expect("numbered parameter insert should succeed");
         assert_eq!(insert_result.rows_affected(), 1);
 
         let result = session
             .execute(
-                "SELECT path, content FROM lix_file WHERE id = ?",
+                "SELECT path, content FROM lix_file WHERE id = $1",
                 &[Value::Text(
                     "616e6f6e-796d-8f75-832d-706172616d00".to_string(),
                 )],
             )
             .await
-            .expect("anonymous parameter read should succeed");
+            .expect("numbered parameter read should succeed");
         assert_rows_eq(
             result,
             vec![vec![
-                Value::Text("/anonymous-param.bin".to_string()),
-                Value::Blob(b"anonymous".to_vec().into()),
+                Value::Text("/numbered-param.bin".to_string()),
+                Value::Blob(b"numbered".to_vec().into()),
             ]],
         );
     }
 );
 
 simulation_test!(
-    lix_file_anonymous_content_parameter_keeps_strict_blob_validation,
+    lix_file_numbered_content_parameter_keeps_strict_blob_validation,
     |sim| async move {
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
@@ -1609,15 +1609,15 @@ simulation_test!(
 
         let error = session
             .execute(
-                "INSERT INTO lix_file (id, path, content) VALUES (?, ?, ?)",
+                "INSERT INTO lix_file (id, path, content) VALUES ($1, $2, $3)",
                 &[
                     Value::Text("616e6f6e-796d-8f75-832d-746578742d00".to_string()),
-                    Value::Text("/anonymous-text-data.bin".to_string()),
+                    Value::Text("/numbered-text-data.bin".to_string()),
                     Value::Text("not binary".to_string()),
                 ],
             )
             .await
-            .expect_err("anonymous non-binary data parameter should be rejected");
+            .expect_err("numbered non-binary data parameter should be rejected");
         assert_eq!(error.code, LixError::CODE_TYPE_MISMATCH);
     }
 );

--- a/packages/lix/tests/integration/sql/subquery_reads.rs
+++ b/packages/lix/tests/integration/sql/subquery_reads.rs
@@ -25,7 +25,7 @@ simulation_test!(subquery_reads_do_not_leak_storage_read_handles, |sim| async mo
     for (index, key) in ["sq-a", "sq-b", "sq-c"].into_iter().enumerate() {
         session
             .execute(
-                "INSERT INTO lix_key_value (key, value) VALUES (?, ?)",
+                "INSERT INTO lix_key_value (key, value) VALUES ($1, $2)",
                 &[
                     Value::Text(key.to_string()),
                     Value::Text(format!("value-{index}")),

--- a/packages/lix/tests/integration/sql/subquery_writes.rs
+++ b/packages/lix/tests/integration/sql/subquery_writes.rs
@@ -30,7 +30,7 @@ simulation_test!(subquery_writes_do_not_leak_storage_read_handles, |sim| async m
     for (index, key) in ["sqw-a", "sqw-b", "sqw-c"].into_iter().enumerate() {
         session
             .execute(
-                "INSERT INTO lix_key_value (key, value) VALUES (?, ?)",
+                "INSERT INTO lix_key_value (key, value) VALUES ($1, $2)",
                 &[
                     Value::Text(key.to_string()),
                     Value::Text(format!("value-{index}")),
@@ -90,7 +90,7 @@ simulation_test!(subquery_writes_do_not_leak_storage_read_handles, |sim| async m
         let result = session
             .execute(
                 "INSERT INTO lix_file (id, path) \
-                 SELECT ?, ? WHERE EXISTS (SELECT 1 FROM lix_key_value WHERE key = 'sqw-a')",
+                 SELECT $1, $2 WHERE EXISTS (SELECT 1 FROM lix_key_value WHERE key = 'sqw-a')",
                 &[
                     Value::Text(id.to_string()),
                     Value::Text(format!("/subquery-{index}.txt")),


### PR DESCRIPTION
## Summary

- centralize PostgreSQL grammar for Lix parsing and configure every DataFusion SQL session to use it
- hard-cut anonymous `?` parameters in favor of PostgreSQL-style `$1`, `$2`, and so on
- migrate Lix-owned SQL, generated CLI queries, `VALUES` relations, diagnostics, docs, tests, and the release note
- remove the remaining anonymous-placeholder binding and point-read compatibility paths

## Scope

This selects PostgreSQL grammar; execution is still the Lix/DataFusion PostgreSQL-dialect subset. Lix history table functions, diff functions, command sinks, branch semantics, and custom UDFs remain Lix runtime features rather than PostgreSQL-provided behavior.

## Breaking change

Anonymous `?` placeholders are no longer accepted. Downstream Atelier currently uses a Kysely SQLite compiler that emits `?`; it must switch to PostgreSQL compilation or otherwise emit numbered parameters before consuming this Lix revision. Lixray must update its pinned Lix and Atelier revisions together.

## Verification

- `cargo clippy --profile test --workspace --all-targets --all-features -- -D warnings`
- `cargo test --profile test --workspace --exclude lix_benchmarks --all-features --no-run`
- `cargo test --profile test -p lix_benchmarks --features storage-benches,slatedb,root-replay-trace --no-run`
- `cargo test -p lix --lib session::execute::tests` (71 passed)
- `cargo test -p lix --lib sql2::` (465 passed, 1 ignored)
- `cargo test -p lix --test integration sql::` (296 passed)
- `cargo test -p lix_cli git_replay` (31 passed)
- `cargo test -p lix_benchmarks --features storage-benches,slatedb --test tracked_state_crud_public_result` (10 passed)