### PR TITLE
fix(test): identify storage spaces by id in two fault-injection gates

### DIFF
--- a/packages/lix/tests/integration/transaction.rs
+++ b/packages/lix/tests/integration/transaction.rs
@@ -688,7 +688,7 @@ async fn rebuild_tracked_state_does_not_commit_on_read_failure() {
         .await
         .expect("initialized storage should create an engine");
 
-    storage.fail_read_namespace("changelog.commit");
+    storage.fail_read_space(CHANGELOG_COMMIT_SPACE_ID);
     let before = storage.stats();
     let error = engine
         .rebuild_tracked_state_for_branch(&receipt.main_branch_id)
@@ -721,7 +721,7 @@ async fn write_changelog_commit_failure_does_not_commit_storage_write() {
         .await
         .expect("workspace session should open");
 
-    storage.fail_write_namespace("changelog.commit");
+    storage.fail_write_space(CHANGELOG_COMMIT_SPACE_ID);
     let before = storage.stats();
     let error = session
         .execute(
@@ -1373,12 +1373,29 @@ impl InterferenceGate {
     }
 }
 
+/// The changelog commit space, identified by space id.
+///
+/// This fault injector used to be armed with a space *name*, resolved through a
+/// hand-written `namespace_space()` match from name to `SpaceId`. That match was
+/// a second authority for the engine registry and it failed **open**: an
+/// unrecognised name returned `None`, the injector never fired, and the test
+/// went green having injected no fault at all. A space name carries its record
+/// encoding version and is expected to churn, so that was a live way to turn a
+/// fault-injection test into a no-op silently.
+///
+/// The id is the durable identity — the first four bytes of every physical key,
+/// which a routine encoding bump does not move. The declaration this pins to is
+/// `lix::registered_spaces::COMMIT_SPACE`, `pub` only under `storage-benches`;
+/// this test target has no `required-features`, so it builds without that
+/// feature and the id is restated here rather than imported.
+const CHANGELOG_COMMIT_SPACE_ID: SpaceId = SpaceId(0x0006_0001);
+
 #[derive(Clone, Default)]
 struct RecordingStorage {
     inner: Memory,
     stats: Arc<TransactionStats>,
-    fail_read_namespace: Arc<Mutex<Option<String>>>,
-    fail_write_namespace: Arc<Mutex<Option<String>>>,
+    fail_read_space: Arc<Mutex<Option<SpaceId>>>,
+    fail_write_space: Arc<Mutex<Option<SpaceId>>>,
 }
 
 #[derive(Clone)]
@@ -1640,18 +1657,18 @@ impl RecordingStorage {
         self.stats.snapshot()
     }
 
-    fn fail_read_namespace(&self, namespace: &str) {
+    fn fail_read_space(&self, space: SpaceId) {
         *self
-            .fail_read_namespace
+            .fail_read_space
             .lock()
-            .expect("fail namespace lock should not poison") = Some(namespace.to_string());
+            .expect("fail space lock should not poison") = Some(space);
     }
 
-    fn fail_write_namespace(&self, namespace: &str) {
+    fn fail_write_space(&self, space: SpaceId) {
         *self
-            .fail_write_namespace
+            .fail_write_space
             .lock()
-            .expect("fail namespace lock should not poison") = Some(namespace.to_string());
+            .expect("fail space lock should not poison") = Some(space);
     }
 }
 
@@ -1669,7 +1686,7 @@ impl Storage for RecordingStorage {
         self.stats.read_opened.fetch_add(1, Ordering::SeqCst);
         Ok(RecordingRead {
             inner: self.inner.begin_read(opts).await?,
-            fail_read_namespace: Arc::clone(&self.fail_read_namespace),
+            fail_read_space: Arc::clone(&self.fail_read_space),
         })
     }
 
@@ -1678,7 +1695,7 @@ impl Storage for RecordingStorage {
         Ok(RecordingWrite {
             inner: self.inner.begin_write(opts).await?,
             stats: Arc::clone(&self.stats),
-            fail_write_namespace: Arc::clone(&self.fail_write_namespace),
+            fail_write_space: Arc::clone(&self.fail_write_space),
         })
     }
 }
@@ -1686,13 +1703,13 @@ impl Storage for RecordingStorage {
 #[derive(Clone)]
 struct RecordingRead {
     inner: MemoryRead,
-    fail_read_namespace: Arc<Mutex<Option<String>>>,
+    fail_read_space: Arc<Mutex<Option<SpaceId>>>,
 }
 
 struct RecordingWrite {
     inner: MemoryWrite,
     stats: Arc<TransactionStats>,
-    fail_write_namespace: Arc<Mutex<Option<String>>>,
+    fail_write_space: Arc<Mutex<Option<SpaceId>>>,
 }
 
 impl StorageRead for RecordingRead {
@@ -1756,58 +1773,45 @@ impl StorageWrite for RecordingWrite {
 
 impl RecordingWrite {
     fn fail_if_space_matches(&self, space: lix::storage::StorageSpace) -> Result<(), StorageError> {
-        if let Some(namespace) = self.fail_write_namespace() {
-            if let Some(failing) = namespace_space(&namespace) {
-                if space.id == failing {
-                    return Err(forced_write_failure(&namespace));
-                }
-            }
+        if self.fail_write_space() == Some(space.id) {
+            return Err(forced_write_failure(space.name));
         }
         Ok(())
     }
 
-    fn fail_write_namespace(&self) -> Option<String> {
-        self.fail_write_namespace
+    fn fail_write_space(&self) -> Option<SpaceId> {
+        *self
+            .fail_write_space
             .lock()
-            .expect("fail namespace lock should not poison")
-            .clone()
+            .expect("fail space lock should not poison")
     }
 }
 
 impl RecordingRead {
     fn fail_if_space_matches(&self, space: lix::storage::StorageSpace) -> Result<(), StorageError> {
-        if let Some(namespace) = self.fail_read_namespace() {
-            if let Some(failing) = namespace_space(&namespace) {
-                if space.id == failing {
-                    return Err(forced_read_failure(&namespace));
-                }
-            }
+        if self.fail_read_space() == Some(space.id) {
+            return Err(forced_read_failure(space.name));
         }
         Ok(())
     }
 
-    fn fail_read_namespace(&self) -> Option<String> {
-        self.fail_read_namespace
+    fn fail_read_space(&self) -> Option<SpaceId> {
+        *self
+            .fail_read_space
             .lock()
-            .expect("fail namespace lock should not poison")
-            .clone()
+            .expect("fail space lock should not poison")
     }
 }
 
-fn namespace_space(namespace: &str) -> Option<SpaceId> {
-    match namespace {
-        "changelog.commit" => Some(SpaceId(0x0006_0001)),
-        "changelog.change" => Some(SpaceId(0x0006_0002)),
-        _ => None,
-    }
+/// The space name comes from the `StorageSpace` that actually matched, so the
+/// message names whatever the registry currently calls that space instead of
+/// whatever this file last believed it was called.
+fn forced_read_failure(space: &str) -> StorageError {
+    StorageError::Io(format!("forced read failure for namespace {space}"))
 }
 
-fn forced_read_failure(namespace: &str) -> StorageError {
-    StorageError::Io(format!("forced read failure for namespace {namespace}"))
-}
-
-fn forced_write_failure(namespace: &str) -> StorageError {
-    StorageError::Io(format!("forced write failure for namespace {namespace}"))
+fn forced_write_failure(space: &str) -> StorageError {
+    StorageError::Io(format!("forced write failure for namespace {space}"))
 }
 
 #[derive(Default)]

--- a/packages/server-protocol/src/lib.rs
+++ b/packages/server-protocol/src/lib.rs
@@ -3964,8 +3964,8 @@ mod tests {
     use http_body_util::BodyExt as _;
     use lix::storage::{
         BeginScanOptions, CommitResult, GetManyRequest, GetManyResult, Key, KeyRange, MemoryRead,
-        MemoryWrite, PutBatch, ReadOptions, ScanCursor, Storage, StorageError, StorageRead,
-        StorageSpace, StorageWrite, WriteOptions,
+        MemoryWrite, PutBatch, ReadOptions, ScanCursor, SpaceId, Storage, StorageError,
+        StorageRead, StorageSpace, StorageWrite, WriteOptions,
     };
     use lix::telemetry::TracingTelemetrySink;
     use lix::{Blob, Memory, RequestBlobSpliceProvenance, open_lix};
@@ -4322,6 +4322,30 @@ mod tests {
         }
     }
 
+    /// The branch-control space, identified the way the storage layer
+    /// identifies it: by space id.
+    ///
+    /// This gate has to recognise the authoritative branch-control read that
+    /// `switch_branch` issues. It used to recognise it by *name*, and a space
+    /// name carries the record encoding version, so it is expected to churn:
+    /// when `untracked_generation` left the packed record in `76834a1c9`,
+    /// `branch.head_control.v10` became `v11`. The gate then matched nothing,
+    /// never armed, and `wait_for_blocked_branch_control_read` sat until its
+    /// 1 s budget expired — which read as "the branch switch stopped issuing
+    /// its authoritative read" when the read was in fact happening the whole
+    /// time. A prefix match (`starts_with("branch.head_control.")`) survives a
+    /// version bump but still breaks on an actual rename, because it is still
+    /// a contract on the name.
+    ///
+    /// The id is the durable identity: it is the first four bytes of every
+    /// physical key, so changing it for a live space is a layout break rather
+    /// than a routine bump, and `0x0004_0020` came through `v10 -> v11`
+    /// untouched. The declaration this pins to is
+    /// `lix::registered_spaces::BRANCH_HEAD_CONTROL_SPACE`, which is `pub` only
+    /// under the `storage-benches` feature that this crate deliberately does
+    /// not enable; the id is therefore restated here rather than imported.
+    const BRANCH_HEAD_CONTROL_SPACE_ID: SpaceId = SpaceId(0x0004_0020);
+
     #[derive(Clone)]
     struct BlockingFencedBranchControlReadStorage {
         inner: Memory,
@@ -4411,16 +4435,9 @@ mod tests {
             &self,
             requests: &[GetManyRequest<'_>],
         ) -> Result<GetManyResult, StorageError> {
-            // Match the branch-control space by identity, not by its exact
-            // name. The trailing version is part of the *encoding* contract and
-            // is bumped whenever the record layout changes, so pinning the full
-            // name here silently disarms this gate the next time that happens:
-            // the switch still issues its authoritative branch-control read,
-            // the wrapper just stops recognising it, and the test then fails on
-            // its timeout as though the read had disappeared.
             let reads_branch_control = requests
                 .iter()
-                .any(|request| request.space.name.starts_with("branch.head_control."));
+                .any(|request| request.space.id == BRANCH_HEAD_CONTROL_SPACE_ID);
             if reads_branch_control
                 && self
                     .gate
@@ -10264,7 +10281,13 @@ mod tests {
             storage.wait_for_blocked_branch_control_read(),
         )
         .await
-        .expect("branch switch should begin its authoritative branch-control read");
+        .expect(
+            "branch switch should begin its authoritative branch-control read. \
+             If this timed out, check BRANCH_HEAD_CONTROL_SPACE_ID against \
+             lix::registered_spaces::BRANCH_HEAD_CONTROL_SPACE before concluding \
+             the read is gone: a gate that stops recognising the space presents \
+             exactly like a read that stopped happening",
+        );
 
         operation.abort();
         assert!(


### PR DESCRIPTION
Follow-up to #1343. Two fault-injection gates recognised a storage space by
**name**. A space name carries its record encoding version and is expected to
churn, so both were one bump away from matching nothing — and a gate that stops
matching does not announce itself, it just stops gating.

## What changed

**`server-protocol/src/lib.rs`** — the branch-control gate matched
`space.name.starts_with("branch.head_control.")`. #1336's prefix was right at
the time and survives a version bump, but it is still a contract on the name and
still breaks on a rename. Now:

```rust
requests.iter().any(|request| request.space.id == BRANCH_HEAD_CONTROL_SPACE_ID)
```

**`lix/tests/integration/transaction.rs`** — the fault injector was armed with a
space name and resolved it through a hand-written `namespace_space()` match from
name to `SpaceId`. That match was a literal second authority for the registry —
exactly what `registered_spaces.rs` now exists to replace — and it is **deleted**.
`RecordingStorage` now stores `Option<SpaceId>` directly.

One side benefit: the forced-failure message now takes its name from the
`StorageSpace` that actually matched, so it reports whatever the registry
currently calls that space rather than whatever this file last believed.

## Why id

The id is the first four bytes of every physical key, so moving it for a live
space is a layout break rather than a routine bump, and `0x0004_0020` came
through `branch.head_control.v10 -> v11` untouched. `RETIRED_STORAGE_SPACE_IDS`
plus `every_space_id_is_unique_and_not_retired` also stop an id being silently
reused by a different space.

## Proofs — `hetzner-cpx62-II`

Not "it is green" but "it still has teeth", since a silently-disarmed predicate
is the exact failure being designed out.

**1. The gate arms, well inside budget.** `0.05 s` against a 1 s timeout.

```
test tests::cancelled_branch_switch_reports_terminal_storage_after_caller_cancellation ... ok
test result: ok. 1 passed; 0 failed; finished in 0.05s
```

**2a. A stale id pin fails the test** — the regression this is guarding against.
Repointing the const at `0x0004_0021` makes it time out at 1.06 s, and the new
message says where to look instead of implying the read vanished:

```
branch switch should begin its authoritative branch-control read. If this timed
out, check BRANCH_HEAD_CONTROL_SPACE_ID against
lix::registered_spaces::BRANCH_HEAD_CONTROL_SPACE before concluding the read is
gone: a gate that stops recognising the space presents exactly like a read that
stopped happening: Elapsed(())
```

**2b. Removing the authoritative read fails the test.** Deleting the pinned-arm
`require_existing_commit_id` from `switch_branch.rs` — so the read genuinely does
not happen — fails at 1.05 s. The test is gated on the read occurring, not merely
on the gate compiling.

**3. The fault injector has teeth, both tests.** Pointing
`CHANGELOG_COMMIT_SPACE_ID` at an unused id fails both:

```
test transaction::rebuild_tracked_state_does_not_commit_on_read_failure ... FAILED
test transaction::write_changelog_commit_failure_does_not_commit_storage_write ... FAILED
```

Restored, both pass.

## Gate — all four feature configurations, `--no-fail-fast`

| lane | rc |
|---|---|
| `cargo check -p lix --no-default-features` | **0** |
| `cargo check -p lix` (default) | **0** |
| `cargo check -p lix --no-default-features --features storage-benches` | **0** |
| `cargo check --workspace --all-targets --all-features` | **0** |
| `cargo clippy --workspace --all-targets --all-features -- -D warnings` | **0** |
| `cargo test --workspace --exclude lix_benchmarks --all-features --no-fail-fast` | **0** |
| `cargo test -p lix_benchmarks --features storage-benches,slatedb --no-fail-fast` | **0** |
| `cargo test -p lix_benchmarks --all-features --no-fail-fast` | **0** |

## One correction to the brief

The `transaction.rs` injector was described as failing open — passing while
testing nothing. **It does not, in effect.** Both call sites are immediately
followed by `.expect_err(..)`, so an injector that never fired makes the
operation succeed and the test panics. Verified in proof 3: both tests *fail*
when the injector is disarmed.

The injector itself did fail open (`namespace_space()` returned `None` and
`fail_if_space_matches` quietly did nothing) — that part is accurate, and
deleting the map is still right. But the blast radius was a confusing failure,
not a silent pass. Worth stating precisely, because "test passes while testing
nothing" would have justified a much larger change than this.

## Residual, not fixed here

Both sites still pin an **id literal** rather than importing
`registered_spaces::BRANCH_HEAD_CONTROL_SPACE` / `::COMMIT_SPACE`. Neither crate
can see that module: `server-protocol` takes `lix` with
`default-features = false` and no `storage-benches`, and this `lix` test target
has no `required-features`, so it builds without the feature too.

Closing that needs one of: making the handles visible on the unconditional
surface (the public-API question, reserved for the owner), or adding
`lix = { features = ["storage-benches"] }` to `server-protocol`'s
**dev**-dependencies — test-only, so not a production dependency, but still a
feature-graph change to spell one constant. I did not pick either.

No timing run: this touches no hot path.
