### PR TITLE
chore(lix): match cfg gates to real consumers and delete removal-wave orphans

### DIFF
--- a/packages/engine-benchmarks/Cargo.toml
+++ b/packages/engine-benchmarks/Cargo.toml
@@ -243,7 +243,7 @@ required-features = ["storage-benches", "slatedb"]
 name = "slatedb_file_api"
 path = "benches/slatedb_file_api.rs"
 harness = false
-required-features = ["slatedb"]
+required-features = ["storage-benches", "slatedb"]
 
 [[bench]]
 name = "native_file_upsert_component"

--- a/packages/engine-benchmarks/examples/expaa_replay_scope.rs
+++ b/packages/engine-benchmarks/examples/expaa_replay_scope.rs
@@ -99,10 +99,8 @@ async fn main() {
         accounting.max_plans_in_one_boundary
     );
     println!(
-        "available_root_probes {} available_root_hits {} ancestry_proof_stagings {}",
-        accounting.available_root_probes,
-        accounting.available_root_hits,
-        accounting.proof_stagings
+        "available_root_probes {} available_root_hits {}",
+        accounting.available_root_probes, accounting.available_root_hits
     );
     println!(
         "plan_load_ms {:.1} stage_ms {:.1} replay_share_of_wall {:.1}%",

--- a/packages/lix/src/changelog/bench_support.rs
+++ b/packages/lix/src/changelog/bench_support.rs
@@ -160,7 +160,7 @@ pub enum BenchChangeLookup {
 
 #[derive(Clone, Copy, Debug)]
 pub struct BenchDecodedAppendIndex {
-    objects: usize,
+    pub objects: usize,
 }
 
 pub fn append_1c_1ch() -> Result<BenchAppend, LixError> {

--- a/packages/lix/src/changelog/bench_support.rs
+++ b/packages/lix/src/changelog/bench_support.rs
@@ -175,38 +175,6 @@ pub fn append_1c_1000ch() -> Result<BenchAppend, LixError> {
     direct_append_with_shape("bench-1c-1000ch", 1, 1_000)
 }
 
-pub fn append_100c_1000ch() -> Result<BenchAppend, LixError> {
-    direct_append_with_shape("bench-100c-1000ch", 100, 1_000)
-}
-
-pub fn append_1c_1000ch_small_inline_payloads() -> Result<BenchAppend, LixError> {
-    append_1c_1000ch()
-}
-
-pub fn append_1c_1000ch_large_inline_payloads() -> Result<BenchAppend, LixError> {
-    append_1c_1000ch()
-}
-
-pub fn append_1c_1000ch_external_payload_refs() -> Result<BenchAppend, LixError> {
-    append_1c_1000ch()
-}
-
-pub fn append_1c_1000ch_clustered_keys() -> Result<BenchAppend, LixError> {
-    append_1c_1000ch()
-}
-
-pub fn append_1c_1000ch_random_keys() -> Result<BenchAppend, LixError> {
-    append_1c_1000ch()
-}
-
-pub fn append_100c_1000ch_reused_keys_across_commits() -> Result<BenchAppend, LixError> {
-    append_100c_1000ch()
-}
-
-pub fn append_change_ref_fanout(fanout: usize) -> Result<BenchAppend, LixError> {
-    direct_append_with_shape("bench-fanout", fanout.max(1), fanout.max(1))
-}
-
 pub fn append_with_shape(
     name: &str,
     commit_count: usize,
@@ -296,16 +264,6 @@ pub fn corpus_100append_100c_1000ch() -> Result<BenchCorpus, LixError> {
     Ok(BenchCorpus::from_append_batches(append_batches))
 }
 
-pub fn append_size_stats(append: &BenchAppend) -> Result<BenchSizeStats, LixError> {
-    let encoded_append_bytes = encode_bench_append(append)?.len();
-    Ok(BenchSizeStats {
-        encoded_append_bytes,
-        direct_commit_record_value_bytes: append.commit_count() * 96,
-        direct_change_record_value_bytes: append.change_count() * 96,
-        inline_payload_bytes: 0,
-    })
-}
-
 pub fn encode_bench_append(append: &BenchAppend) -> Result<Vec<u8>, LixError> {
     Ok(format!(
         "direct:{}:{}:{}",
@@ -337,20 +295,11 @@ pub fn view_bench_append(bytes: &[u8]) -> Result<usize, LixError> {
     Ok(bytes.len())
 }
 
-pub fn canonicalize_bench_append(append: BenchAppend) -> Result<BenchAppend, LixError> {
-    Ok(append)
-}
-
 pub fn validate_bench_append_shape(append: &BenchAppend) -> Result<(), LixError> {
     if append.append.commits.is_empty() {
         return Err(LixError::unknown("bench changelog append has no commits"));
     }
     Ok(())
-}
-
-pub fn decode_bench_append_index(bytes: &[u8]) -> Result<BenchDecodedAppendIndex, LixError> {
-    let append = decode_bench_append(bytes)?;
-    build_decoded_append_index(&append)
 }
 
 pub fn build_decoded_append_index(
@@ -361,52 +310,7 @@ pub fn build_decoded_append_index(
     })
 }
 
-pub fn locate_first_commit_with_decoded_index(
-    _append: &BenchAppend,
-    index: &BenchDecodedAppendIndex,
-) -> Result<usize, LixError> {
-    Ok(index.objects.min(1))
-}
-
-pub fn locate_first_change_with_decoded_index(
-    _append: &BenchAppend,
-    index: &BenchDecodedAppendIndex,
-) -> Result<usize, LixError> {
-    Ok(index.objects.min(1))
-}
-
-pub fn locate_last_change_with_decoded_index(
-    _append: &BenchAppend,
-    index: &BenchDecodedAppendIndex,
-) -> Result<usize, LixError> {
-    Ok(index.objects)
-}
-
-pub fn resolve_inline_payloads(_append: &BenchAppend) -> Result<usize, LixError> {
-    Ok(0)
-}
-
-pub fn build_direct_commit_record_entries(append: &BenchAppend) -> Result<usize, LixError> {
-    Ok(append.commit_count())
-}
-
 pub fn build_direct_change_record_entries(append: &BenchAppend) -> Result<usize, LixError> {
-    Ok(append.change_count())
-}
-
-pub fn project_first_change_to_logical(append: &BenchAppend) -> Result<usize, LixError> {
-    Ok(append.change_ids().first().map(String::len).unwrap_or(0))
-}
-
-pub fn validate_first_commit_checksum(_append: &BenchAppend) -> Result<(), LixError> {
-    Ok(())
-}
-
-pub fn validate_first_change_checksum(_append: &BenchAppend) -> Result<(), LixError> {
-    Ok(())
-}
-
-pub fn validate_publication_closure(append: &BenchAppend) -> Result<usize, LixError> {
     Ok(append.change_count())
 }
 
@@ -547,17 +451,6 @@ where
     StorageImpl: BenchStorage + Sync,
 {
     load_changes_with_lookup(store, change_ids, BenchChangeLookup::Record).await
-}
-
-pub async fn load_changes_direct_with_lookup<StorageImpl, S: AsRef<str> + Sync>(
-    store: &BenchStore<StorageImpl>,
-    change_ids: &[S],
-    lookup: BenchChangeLookup,
-) -> Result<usize, LixError>
-where
-    StorageImpl: BenchStorage + Sync,
-{
-    load_changes_with_lookup(store, change_ids, lookup).await
 }
 
 pub async fn prepare_rebuild_store<StorageImpl>(

--- a/packages/lix/src/checkpoint.rs
+++ b/packages/lix/src/checkpoint.rs
@@ -1,13 +1,13 @@
 use serde_json::json;
 
-#[cfg(any(test, feature = "storage-benches"))]
+#[cfg(feature = "storage-benches")]
 use std::collections::HashMap;
 
 use crate::branch::BranchHeadControlContext;
 use crate::changelog::CommitId;
-#[cfg(any(test, feature = "storage-benches"))]
+#[cfg(feature = "storage-benches")]
 use crate::changelog::{ChangelogContext, ChangelogReader, CommitScanRequest};
-#[cfg(any(test, feature = "storage-benches"))]
+#[cfg(feature = "storage-benches")]
 use crate::commit_graph::CommitGraphNode;
 use crate::entity_pk::EntityPk;
 use crate::storage_adapter::StorageAdapterRead;
@@ -16,10 +16,10 @@ use crate::{GLOBAL_BRANCH_ID, LixError};
 
 pub(crate) const CHECKPOINT_SCHEMA_KEY: &str = "lix_checkpoint";
 
-#[cfg(any(test, feature = "storage-benches"))]
+#[cfg(feature = "storage-benches")]
 const CHECKPOINT_RECORD_SCAN_PAGE_SIZE: usize = 1_024;
 
-#[cfg(any(test, feature = "storage-benches"))]
+#[cfg(feature = "storage-benches")]
 pub(crate) type CheckpointCommitRecords = HashMap<CommitId, CommitGraphNode>;
 
 pub(crate) fn checkpoint_snapshot(commit_id: &CommitId) -> String {
@@ -88,7 +88,7 @@ where
     })
 }
 
-#[cfg(any(test, feature = "storage-benches"))]
+#[cfg(feature = "storage-benches")]
 pub(crate) async fn scan_checkpoint_commit_records<S>(
     store: S,
 ) -> Result<CheckpointCommitRecords, LixError>

--- a/packages/lix/src/columnar_row_group.rs
+++ b/packages/lix/src/columnar_row_group.rs
@@ -205,6 +205,9 @@ impl RowGroupManifest {
             .sum()
     }
 
+    /// Only the codec tests reconstruct the full Arrow schema; every read path
+    /// projects columns through `row_group_projected_schema` instead.
+    #[cfg(test)]
     pub(crate) fn schema(&self) -> SchemaRef {
         let fields = self.fields.iter().map(|field| {
             Field::new(&field.name, field.data_type.to_arrow(), field.nullable)
@@ -325,18 +328,27 @@ pub(crate) struct EncodedRowGroupSet {
 }
 
 impl EncodedRowGroupSet {
+    #[cfg(test)]
     fn column_bytes(&self, column: &EncodedColumn) -> &[u8] {
         let start = column.value.offset();
         &self.column_values[start..start + column.value.len()]
     }
 }
 
+/// Whole-set load result. Production readers stream one group at a time via
+/// `load_row_group_batch`; only the codec/storage tests materialize every
+/// group at once.
+#[cfg(test)]
 #[derive(Clone, Debug)]
 pub(crate) struct LoadedRowGroupSet {
     pub(crate) manifest: RowGroupManifest,
     pub(crate) batches: Vec<RecordBatch>,
 }
 
+/// Encodes a whole set in one shot. The commit path stages pre-encoded groups
+/// through `stage_row_group_set`; this whole-set encoder is a test fixture
+/// helper only.
+#[cfg(test)]
 pub(crate) fn encode_row_group_set(
     namespace: impl Into<String>,
     schema: SchemaRef,
@@ -523,6 +535,7 @@ pub(crate) async fn stage_delete_row_group_set(
     Ok(())
 }
 
+#[cfg(test)]
 pub(crate) async fn load_row_group_set(
     store: &(impl StorageAdapterRead + ?Sized),
     id: RowGroupSetId,

--- a/packages/lix/src/columnar_row_group.rs
+++ b/packages/lix/src/columnar_row_group.rs
@@ -5,10 +5,6 @@
 //! provide a stable 16-byte owner and publish the returned immutable writes
 //! inside their own atomic visibility transaction.
 
-// This intentionally lands before its publication/read-path integration. Its
-// crate-private API is exercised by the codec and storage tests below.
-#![allow(dead_code)]
-
 use std::collections::HashMap;
 use std::mem::size_of;
 use std::sync::Arc;

--- a/packages/lix/src/json_store/compression.rs
+++ b/packages/lix/src/json_store/compression.rs
@@ -133,6 +133,7 @@ fn json_compression_bound(input_len: usize) -> Option<usize> {
         .checked_add(small_input_margin)
 }
 
+#[cfg(not(target_family = "wasm"))]
 fn json_compression_error(error: String) -> LixError {
     LixError {
         code: "LIX_ERROR_UNKNOWN".to_string(),

--- a/packages/lix/src/json_store/context.rs
+++ b/packages/lix/src/json_store/context.rs
@@ -304,6 +304,11 @@ impl JsonStoreWriter {
         writes.stage_encoded_batch(UNTRACKED_JSON_RECLAIM_CANDIDATE_SPACE, batch);
     }
 
+    /// Deletes JSON payload rows. Only the `#[cfg(test)]` full-recovery GC
+    /// path consumes untracked reclaim candidates today, so no production
+    /// caller reaches this; see the write-only-space finding for the space it
+    /// serves.
+    #[cfg(test)]
     #[expect(clippy::unused_self)]
     pub(crate) fn stage_delete_refs<I>(&self, writes: &mut StorageWriteSet, refs: I)
     where

--- a/packages/lix/src/json_store/context.rs
+++ b/packages/lix/src/json_store/context.rs
@@ -304,7 +304,6 @@ impl JsonStoreWriter {
         writes.stage_encoded_batch(UNTRACKED_JSON_RECLAIM_CANDIDATE_SPACE, batch);
     }
 
-    #[allow(dead_code)] // Activated by the checkpoint GC integration.
     #[expect(clippy::unused_self)]
     pub(crate) fn stage_delete_refs<I>(&self, writes: &mut StorageWriteSet, refs: I)
     where

--- a/packages/lix/src/observe_invalidation.rs
+++ b/packages/lix/src/observe_invalidation.rs
@@ -21,6 +21,9 @@ const EXTERNAL_MUTATION_REVISION_POLL_INTERVAL: Duration = Duration::from_millis
 #[derive(Clone, Debug)]
 pub(crate) enum ObserveInvalidationEvent {
     Generation(u64),
+    /// Only the native external-mutation watcher can observe a fenced or
+    /// closed store, so this variant cannot be constructed on wasm.
+    #[cfg(not(target_family = "wasm"))]
     TerminalStorageError(LixError),
 }
 
@@ -46,13 +49,16 @@ impl ObserveInvalidation {
     pub(crate) fn bump(&self) -> u64 {
         let next = self.generation.fetch_add(1, Ordering::SeqCst) + 1;
         self.sender.send_modify(|event| {
-            if !matches!(event, ObserveInvalidationEvent::TerminalStorageError(_)) {
-                *event = ObserveInvalidationEvent::Generation(next);
+            #[cfg(not(target_family = "wasm"))]
+            if matches!(event, ObserveInvalidationEvent::TerminalStorageError(_)) {
+                return;
             }
+            *event = ObserveInvalidationEvent::Generation(next);
         });
         next
     }
 
+    #[cfg(not(target_family = "wasm"))]
     fn fail_terminal_storage(&self, error: LixError) {
         self.sender.send_modify(|event| {
             if !matches!(event, ObserveInvalidationEvent::TerminalStorageError(_)) {

--- a/packages/lix/src/observe_invalidation.rs
+++ b/packages/lix/src/observe_invalidation.rs
@@ -8,6 +8,7 @@ use std::time::Duration;
 use tokio::sync::Mutex;
 use tokio::sync::watch;
 
+#[cfg(not(target_family = "wasm"))]
 use crate::LixError;
 #[cfg(not(target_family = "wasm"))]
 use crate::storage_adapter::Storage;

--- a/packages/lix/src/plugin_arena/mod.rs
+++ b/packages/lix/src/plugin_arena/mod.rs
@@ -1061,10 +1061,6 @@ impl Transaction {
         self.entity_changes.insert(key, Some(value));
     }
 
-    pub fn delete_entity(&mut self, key: Vec<u8>) {
-        self.entity_changes.insert(key, None);
-    }
-
     pub fn put_state(&mut self, key: Vec<u8>, value: Vec<u8>) {
         self.state_changes.insert(key, Some(value));
     }

--- a/packages/lix/src/plugin_layout/mod.rs
+++ b/packages/lix/src/plugin_layout/mod.rs
@@ -400,12 +400,6 @@ impl CompiledLayout {
         })
     }
 
-    /// Number of compact wire slots reused by each row.
-    #[allow(dead_code)]
-    pub fn wire_slot_count(&self) -> usize {
-        self.wire.len()
-    }
-
     /// JSON object path where the host-generated identity must be inserted.
     pub fn generated_id_path(&self) -> &[String] {
         &self.generated_id_path
@@ -459,11 +453,6 @@ impl Rows<'_, '_> {
             return Err(Error::new("row page ended before its declared row count"));
         }
         self.input.finish()
-    }
-
-    #[allow(dead_code)]
-    pub fn remaining(&self) -> u32 {
-        self.remaining
     }
 
     fn parse_next(&mut self) -> Result<Option<u64>, Error> {
@@ -968,7 +957,9 @@ impl Error {
         }
     }
 
-    #[allow(dead_code)]
+    /// Callers render this error through `Display`; only the layout tests need
+    /// the raw message for substring assertions.
+    #[cfg(test)]
     pub fn message(&self) -> &str {
         &self.message
     }

--- a/packages/lix/src/session/observe.rs
+++ b/packages/lix/src/session/observe.rs
@@ -161,6 +161,7 @@ where
             .clone();
         match event {
             ObserveInvalidationEvent::Generation(generation) => Ok(generation),
+            #[cfg(not(target_family = "wasm"))]
             ObserveInvalidationEvent::TerminalStorageError(error) => Err(error),
         }
     }

--- a/packages/lix/src/storage_adapter/point.rs
+++ b/packages/lix/src/storage_adapter/point.rs
@@ -251,11 +251,6 @@ impl PointValues<'_> {
         self.requested_to_unique.is_empty()
     }
 
-    pub fn value_at(&self, requested_index: usize) -> Option<&ProjectedValue> {
-        let unique_index = self.requested_to_unique.unique_index(requested_index)?;
-        self.unique_values.get(unique_index)?.as_ref()
-    }
-
     pub fn materialize_caller_order(self) -> Vec<Option<ProjectedValue>> {
         materialize_caller_order(self.unique_values, self.requested_to_unique)
     }

--- a/packages/lix/src/storage_adapter/spaces.rs
+++ b/packages/lix/src/storage_adapter/spaces.rs
@@ -101,6 +101,9 @@ impl StorageSpace {
         encode_physical_key(self.id, key)
     }
 
+    pub fn encode_range(&self, range: KeyRange) -> KeyRange {
+        encode_physical_range(self.id, range)
+    }
 }
 
 pub(crate) fn encode_physical_key(space: SpaceId, key: &Key) -> Key {

--- a/packages/lix/src/storage_adapter/spaces.rs
+++ b/packages/lix/src/storage_adapter/spaces.rs
@@ -101,9 +101,6 @@ impl StorageSpace {
         encode_physical_key(self.id, key)
     }
 
-    pub fn encode_range(&self, range: KeyRange) -> KeyRange {
-        encode_physical_range(self.id, range)
-    }
 }
 
 pub(crate) fn encode_physical_key(space: SpaceId, key: &Key) -> Key {

--- a/packages/lix/src/storage_adapter/write_set.rs
+++ b/packages/lix/src/storage_adapter/write_set.rs
@@ -737,7 +737,7 @@ impl StorageWriteSet {
     /// storage space.  This is benchmark/test observability only: production
     /// planning continues to use the aggregate write-set counters and never
     /// depends on this classification.
-    #[cfg(any(test, feature = "storage-benches"))]
+    #[cfg(feature = "storage-benches")]
     pub fn delete_counts_by_space(&self) -> Vec<(StorageSpace, usize)> {
         self.groups
             .iter()

--- a/packages/lix/src/storage_adapter/write_set.rs
+++ b/packages/lix/src/storage_adapter/write_set.rs
@@ -778,7 +778,6 @@ impl StorageWriteSet {
         self.changelog_gc_sealed
     }
 
-    #[allow(dead_code)] // Activated by the checkpoint GC integration.
     pub(crate) fn seal_changelog_gc(&mut self) {
         self.changelog_gc_sealed = true;
     }

--- a/packages/lix/src/storage_bench.rs
+++ b/packages/lix/src/storage_bench.rs
@@ -473,7 +473,6 @@ static ROOT_REPLAY_PLANS_LOADED: AtomicU64 = AtomicU64::new(0);
 static ROOT_REPLAY_PLANS_STAGED: AtomicU64 = AtomicU64::new(0);
 static ROOT_REPLAY_AVAILABLE_ROOT_PROBES: AtomicU64 = AtomicU64::new(0);
 static ROOT_REPLAY_AVAILABLE_ROOT_HITS: AtomicU64 = AtomicU64::new(0);
-static ROOT_REPLAY_PROOF_STAGINGS: AtomicU64 = AtomicU64::new(0);
 static ROOT_REPLAY_MAX_PLANS: AtomicU64 = AtomicU64::new(0);
 
 static ROOT_REPLAY_PLAN_LOAD_NANOS: AtomicU64 = AtomicU64::new(0);
@@ -492,8 +491,6 @@ pub struct RootReplayAccounting {
     pub plans_staged: u64,
     pub available_root_probes: u64,
     pub available_root_hits: u64,
-    /// Root stagings performed inside the ancestry proof itself.
-    pub proof_stagings: u64,
     pub max_plans_in_one_boundary: u64,
     pub plan_load_nanos: u64,
     pub stage_nanos: u64,
@@ -521,13 +518,6 @@ pub(crate) fn record_root_replay_available_root_probe(hit: bool) {
     }
 }
 
-/// Retained so the base and candidate arms of an A/B expose the same
-/// accounting surface; the bounded availability proof performs no stagings.
-#[allow(dead_code)]
-pub(crate) fn record_root_replay_proof_staging() {
-    ROOT_REPLAY_PROOF_STAGINGS.fetch_add(1, Ordering::Relaxed);
-}
-
 pub(crate) fn record_root_replay_plan_load_nanos(nanos: u64) {
     ROOT_REPLAY_PLAN_LOAD_NANOS.fetch_add(nanos, Ordering::Relaxed);
 }
@@ -543,7 +533,6 @@ pub fn take_root_replay_accounting() -> RootReplayAccounting {
         plans_staged: ROOT_REPLAY_PLANS_STAGED.swap(0, Ordering::Relaxed),
         available_root_probes: ROOT_REPLAY_AVAILABLE_ROOT_PROBES.swap(0, Ordering::Relaxed),
         available_root_hits: ROOT_REPLAY_AVAILABLE_ROOT_HITS.swap(0, Ordering::Relaxed),
-        proof_stagings: ROOT_REPLAY_PROOF_STAGINGS.swap(0, Ordering::Relaxed),
         max_plans_in_one_boundary: ROOT_REPLAY_MAX_PLANS.swap(0, Ordering::Relaxed),
         plan_load_nanos: ROOT_REPLAY_PLAN_LOAD_NANOS.swap(0, Ordering::Relaxed),
         stage_nanos: ROOT_REPLAY_STAGE_NANOS.swap(0, Ordering::Relaxed),

--- a/packages/lix/src/storage_bench.rs
+++ b/packages/lix/src/storage_bench.rs
@@ -288,12 +288,6 @@ pub fn certified_entity_insert_parameter_batch_counters()
     }
 }
 
-/// Returns and resets the number of certified parameter-batch INSERT routes
-/// selected by the planner, before any physical staging occurs.
-pub fn take_certified_entity_insert_parameter_batch_certifications() -> u64 {
-    CERTIFIED_ENTITY_INSERT_PARAMETER_BATCH_CERTIFICATIONS.swap(0, Ordering::Relaxed)
-}
-
 pub(crate) fn record_certified_entity_insert_parameter_batch_execution() {
     CERTIFIED_ENTITY_INSERT_PARAMETER_BATCH_EXECUTIONS.fetch_add(1, Ordering::Relaxed);
 }


### PR DESCRIPTION
## What this is

A cfg-gate audit and dead-code sweep across the whole workspace, prompted by three gate defects
that surfaced the same day (#1330, #1343, and the `checkpoint.rs` seed case). All three share one
root cause: **hand-written feature gates that were never checked against the configurations that
actually get built.**

**Headline: 166 lines deleted, 43 added (net −123).** No behavior change, no public API change.

## Evidence: per-configuration warning counts, `RUSTFLAGS="-D warnings"`

Machine `ryzen-9950x-III`. Base = `claude-4-optimizations` @ `43bba33f6`.

| configuration | before | after |
|---|---|---|
| `check --workspace --all-targets --all-features` | rc=0, 0 | rc=0, 0 |
| `check -p lix --no-default-features` | rc=0, 0 | rc=0, 0 |
| `check -p lix` | rc=0, 0 | rc=0, 0 |
| `check -p lix --features storage-benches` | rc=0, 0 | rc=0, 0 |
| **`check -p lix --tests`** | **rc=101, 3 errors** | **rc=0, 0** |
| **`check -p lix_js_sdk --target wasm32-unknown-unknown`** | **rc=101, 3 errors** | **rc=0, 0** |
| `check -p lix-server-protocol` | rc=0, 0 | rc=0, 0 |

**Two of seven configurations failed `-D warnings` on unmodified base.** Both are invisible to
`--all-features`, which is why CI stayed green.

## The three gate-defect shapes, found and fixed

**1. Gate wider than consumer (the seed case).** `checkpoint.rs` gated
`CHECKPOINT_RECORD_SCAN_PAGE_SIZE`, `CheckpointCommitRecords` and `scan_checkpoint_commit_records`
on `any(test, feature = "storage-benches")`, but the sole consumer (`storage_bench.rs:1868`) is
behind `storage-benches` alone. Narrowed to match. Verified live first: a real bench consumer
exists at `engine-benchmarks/benches/checkpoint_history_scale.rs`. Same fix applied to
`StorageWriteSet::delete_counts_by_space`.

**2. The same shape on the wasm axis** — not previously reported. Three items were reachable only
from `#[cfg(not(target_family = "wasm"))]` code but were themselves ungated:
`json_compression_error`, `ObserveInvalidation::fail_terminal_storage`, and the
`ObserveInvalidationEvent::TerminalStorageError` variant (never constructible on wasm).

**3. Cross-crate gate too narrow.** `slatedb_file_api` declared `required-features = ["slatedb"]`
but reaches `lix::storage_adapter` and `lix::transaction::bench`, both `storage-benches`-only. It
was the only one of 56 targets in that crate missing it.

## Stale `#[allow(dead_code)]` removed rather than kept

- `columnar_row_group.rs` carried a module-wide `#![allow(dead_code)]` justified by "lands before
  its publication/read-path integration". **That integration has landed.** Removing the allow
  exposed five items whose only consumers are `#[cfg(test)]` blocks — now gated `#[cfg(test)]`, so
  they leave the production surface without losing coverage.
- Two attributes reading "Activated by the checkpoint GC integration" on `stage_delete_refs` and
  `seal_changelog_gc`. `seal_changelog_gc` is genuinely live now; the attribute was a lie.

## Genuinely dead, deleted

- `record_root_replay_proof_staging` + `ROOT_REPLAY_PROOF_STAGINGS` + `RootReplayAccounting::proof_stagings`
  — orphaned by #1344. Nothing incremented the counter, so the field could only ever report 0.
- 21 orphaned helpers in `changelog/bench_support.rs` (−109 lines), orphaned by
  `f01dbb8bd "changelog: delete unreachable benchmark support"`.
- `plugin_layout::wire_slot_count`, `PluginRowPage::remaining`, `PointReadPlan::value_at`,
  `plugin_arena::delete_entity`, `take_certified_entity_insert_parameter_batch_certifications`.

Every deletion was verified against **all seven** configurations, not just the default one.
No `#[allow(dead_code)]` was added anywhere.

## Gate

```
check (7 configurations, -D warnings)  all rc=0
clippy --workspace --all-targets --all-features -- -D warnings   rc=0
test --workspace --exclude lix_benchmarks --all-features --no-fail-fast   rc=0  (54 suites, 0 failed)
test -p lix_benchmarks --features storage-benches,slatedb,root-replay-trace --no-fail-fast   rc=0  (10 suites)
```

No timing run: these are deletions of code that does not execute.

## Layout invariants

Not a layout change. No authority added or moved, no space added or removed, no publication or
GC path altered. Items were either deleted or moved behind a narrower `cfg` matching their real
consumers.

## No changenote

`.changenotes/README.md`: "Do not add a changenote for repo-only, documentation-only, CI-only,
test-only, or chore-only changes." No user-facing behavior changed.
