### PR TITLE
fix(slatedb): stale read after a concurrent commit on the cached snapshot path

### DIFF
--- a/.changenotes/fix-slatedb-cached-snapshot-coherence.md
+++ b/.changenotes/fix-slatedb-cached-snapshot-coherence.md
@@ -1,0 +1,7 @@
+---
+type: patch
+---
+
+Fixed a rare stale read on SlateDB storage after a concurrent commit.
+
+A reader that picked up a cached storage snapshot could miss a write that had already been committed, returning the previous value from either a point read or a range scan. It required a commit to land at the same moment another reader acquired its snapshot, and it cleared on reopen, but while it lasted a live session could observe out-of-date data.

--- a/packages/slatedb-storage/src/slatedb.rs
+++ b/packages/slatedb-storage/src/slatedb.rs
@@ -7350,10 +7350,16 @@ mod tests {
         );
     }
 
-    /// D1. `commit` clears `latest_snapshot` so the next reader refetches. That
-    /// invalidation must not be undone by an install that was decided before
-    /// the commit landed: the freshness test and the install share one lock
-    /// acquisition, and the install re-validates `next_publication_id`.
+    /// D1. `commit` clears `latest_snapshot` and bumps `next_publication_id`
+    /// so the next reader refetches. That invalidation must not be undone by an
+    /// install decided before the commit landed.
+    ///
+    /// The state below is arranged so that **only** the publication-id term can
+    /// reject the install: the racing publication has already persisted and
+    /// been retired from `visible`, so `snapshot_covers_persisted_publications`
+    /// holds, the tail is complete, and `latest_snapshot` is empty, so the
+    /// monotonic guard passes vacuously. That is precisely the state the old
+    /// two-phase structure reached by the time it called `install_snapshot`.
     #[tokio::test]
     async fn commit_is_not_undone_by_an_install_decided_before_it() {
         let storage = cached_snapshot_test_storage("test-cached-snapshot-install-race");
@@ -7373,18 +7379,28 @@ mod tests {
             .next_publication_id;
         drop(fetch);
 
-        // The commit that races the in-flight install.
+        // The commit that races the in-flight install, then fully settles:
+        // its publication persists and retires, leaving only the publication
+        // id to witness that the snapshot is stale.
         cached_snapshot_commit(&storage, space, "B").await;
-        assert!(
-            storage
+        {
+            let mut state = storage
                 .write_pipeline
                 .state
                 .lock()
-                .expect("lock publication state")
-                .latest_snapshot
-                .is_none(),
-            "commit invalidates the cached snapshot"
-        );
+                .expect("lock publication state");
+            state.visible.clear();
+            state.tail = None;
+            state.latest_snapshot = None;
+            assert_ne!(
+                state.next_publication_id, publication_id,
+                "the racing commit must advance the publication id"
+            );
+            assert!(
+                snapshot_covers_persisted_publications(&state, stale_snapshot.seq()),
+                "every other cacheability term must hold, isolating the publication-id check"
+            );
+        }
 
         assert!(
             !storage

--- a/packages/slatedb-storage/src/slatedb.rs
+++ b/packages/slatedb-storage/src/slatedb.rs
@@ -1883,29 +1883,42 @@ impl WritePipeline {
         error.map_or(Ok(()), Err)
     }
 
+    /// Obtains a snapshot together with the retirement guard its reader must
+    /// hold until it captures a publication view.
+    ///
+    /// Both paths — cached and freshly fetched — return a `SnapshotFetch`, so
+    /// the guard cannot be omitted by construction. `cleanup_publications`
+    /// retires a publication only while `snapshot_fetches == 0`, and a reader
+    /// holding a snapshot it has not yet captured a view against still depends
+    /// on every publication newer than that snapshot. The cached fast path
+    /// used to return no guard, which let cleanup retire a publication in
+    /// exactly that gap; the reader then observed neither the snapshot value
+    /// nor the overlay value, i.e. a stale point read or scan.
     async fn snapshot(
         &self,
         worker: &SlateDBWorker,
-    ) -> Result<(Arc<DbSnapshot>, Option<SnapshotFetch>), StorageError> {
-        let publication_id = {
+    ) -> Result<(Arc<DbSnapshot>, SnapshotFetch), StorageError> {
+        let (cached, publication_id) = {
             let mut state = self
                 .state
                 .lock()
                 .unwrap_or_else(std::sync::PoisonError::into_inner);
-            if let Some(snapshot) = state.latest_snapshot.clone() {
-                worker.check_open_fast()?;
-                return Ok((snapshot, None));
-            }
             state.snapshot_fetches = state
                 .snapshot_fetches
                 .checked_add(1)
                 .expect("SlateDB snapshot fetch overflow");
-            state.next_publication_id
+            (state.latest_snapshot.clone(), state.next_publication_id)
         };
+        // Constructed immediately after the increment so that every early
+        // return below balances the counter through `SnapshotFetch::drop`.
         let fetch = SnapshotFetch {
             pipeline: self.clone(),
             worker: worker.clone(),
         };
+        if let Some(snapshot) = cached {
+            worker.check_open_fast()?;
+            return Ok((snapshot, fetch));
+        }
         let snapshot = worker
             .call_read(|db| async move { db.snapshot().await.map_err(slatedb_error) })
             .await?;
@@ -1926,7 +1939,7 @@ impl WritePipeline {
         } else {
             worker.check_open_fast()?;
         }
-        Ok((snapshot, Some(fetch)))
+        Ok((snapshot, fetch))
     }
 
     fn install_snapshot(&self, snapshot: Arc<DbSnapshot>) {
@@ -7239,6 +7252,96 @@ mod tests {
                 &key,
             ),
             Some(Some(value))
+        );
+    }
+
+    fn cached_snapshot_test_storage(name: &'static str) -> SlateDB {
+        SlateDB::open_object_store_with_options(
+            name,
+            Arc::new(InMemory::new()),
+            SlateDBObjectStoreOptions::default(),
+        )
+        .expect("open cached-snapshot coherence storage")
+    }
+
+    async fn cached_snapshot_commit(storage: &SlateDB, space: StorageSpace, value: &'static str) {
+        let mut write = storage
+            .begin_write(WriteOptions::default())
+            .await
+            .expect("begin cached-snapshot write");
+        write
+            .put_many(
+                space,
+                PutBatch {
+                    entries: vec![PutEntry {
+                        key: Key(Bytes::from_static(b"a")),
+                        value: StoredValue {
+                            bytes: Bytes::from_static(value.as_bytes()),
+                        },
+                    }],
+                },
+            )
+            .await
+            .expect("stage cached-snapshot write");
+        write.commit().await.expect("commit cached-snapshot write");
+    }
+
+    fn snapshot_fetches_of(storage: &SlateDB) -> usize {
+        storage
+            .write_pipeline
+            .state
+            .lock()
+            .expect("lock publication state")
+            .snapshot_fetches
+    }
+
+    /// D2. Companion to
+    /// `dropping_unrelated_view_does_not_reclaim_publication_a_stale_fetch_needs`,
+    /// which proves the `snapshot_fetches` guard protects a reader in the gap
+    /// between obtaining a snapshot and capturing its publication view — but
+    /// only ever exercises the fetch path, pinning `snapshot_fetches = 1`.
+    ///
+    /// The cached fast path used to return no guard, so a cached reader sat in
+    /// the identical gap with the protection switched off and
+    /// `cleanup_publications` could retire the publication its older snapshot
+    /// still needed. Both paths must register the guard.
+    #[tokio::test]
+    async fn cached_snapshot_path_registers_a_retirement_guard() {
+        let storage = cached_snapshot_test_storage("test-cached-snapshot-guard");
+        let space = StorageSpace::mutable(SpaceId(0x91), "test.cached-snapshot-guard");
+        cached_snapshot_commit(&storage, space, "A").await;
+
+        let (snapshot, fetch) = storage
+            .write_pipeline
+            .snapshot(&storage.worker)
+            .await
+            .expect("fetch a snapshot");
+        drop(fetch);
+        assert_eq!(snapshot_fetches_of(&storage), 0);
+
+        // Force the cached fast path deterministically.
+        storage
+            .write_pipeline
+            .state
+            .lock()
+            .expect("lock publication state")
+            .latest_snapshot = Some(Arc::clone(&snapshot));
+
+        let (_cached, cached_fetch) = storage
+            .write_pipeline
+            .snapshot(&storage.worker)
+            .await
+            .expect("take the cached snapshot path");
+        assert_eq!(
+            snapshot_fetches_of(&storage),
+            1,
+            "the cached snapshot path must register the same retirement guard as the fetch path"
+        );
+        drop(cached_fetch);
+        assert_eq!(
+            snapshot_fetches_of(&storage),
+            0,
+            "dropping the guard must balance the counter"
         );
     }
 

--- a/packages/slatedb-storage/src/slatedb.rs
+++ b/packages/slatedb-storage/src/slatedb.rs
@@ -1922,38 +1922,43 @@ impl WritePipeline {
         let snapshot = worker
             .call_read(|db| async move { db.snapshot().await.map_err(slatedb_error) })
             .await?;
-        let cacheable = {
-            let state = self
-                .state
-                .lock()
-                .unwrap_or_else(std::sync::PoisonError::into_inner);
-            state.next_publication_id == publication_id
-                && state
-                    .tail
-                    .as_ref()
-                    .is_none_or(|tail| tail.done.load(Ordering::Acquire))
-                && snapshot_covers_persisted_publications(&state, snapshot.seq())
-        };
-        if cacheable {
-            self.install_snapshot(Arc::clone(&snapshot));
-        } else {
+        if !self.try_install_snapshot(publication_id, &snapshot) {
             worker.check_open_fast()?;
         }
         Ok((snapshot, fetch))
     }
 
-    fn install_snapshot(&self, snapshot: Arc<DbSnapshot>) {
+    /// Publishes `snapshot` as the cached snapshot when it is still current,
+    /// reporting whether it was installed.
+    ///
+    /// The freshness test and the install happen under **one** acquisition of
+    /// the pipeline lock. They used to be two, and a commit landing in the gap
+    /// was silently undone: `commit` clears `latest_snapshot` and bumps
+    /// `next_publication_id`, then the later install found `latest_snapshot`
+    /// empty, passed its monotonic guard vacuously, and reinstated a snapshot
+    /// that predated the write that commit had just published.
+    fn try_install_snapshot(&self, publication_id: u64, snapshot: &Arc<DbSnapshot>) -> bool {
         let mut state = self
             .state
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let cacheable = state.next_publication_id == publication_id
+            && state
+                .tail
+                .as_ref()
+                .is_none_or(|tail| tail.done.load(Ordering::Acquire))
+            && snapshot_covers_persisted_publications(&state, snapshot.seq());
+        if !cacheable {
+            return false;
+        }
         if state
             .latest_snapshot
             .as_ref()
             .is_none_or(|current| current.seq() <= snapshot.seq())
         {
-            state.latest_snapshot = Some(snapshot);
+            state.latest_snapshot = Some(Arc::clone(snapshot));
         }
+        true
     }
 
     fn capture_with_worker(
@@ -7342,6 +7347,60 @@ mod tests {
             snapshot_fetches_of(&storage),
             0,
             "dropping the guard must balance the counter"
+        );
+    }
+
+    /// D1. `commit` clears `latest_snapshot` so the next reader refetches. That
+    /// invalidation must not be undone by an install that was decided before
+    /// the commit landed: the freshness test and the install share one lock
+    /// acquisition, and the install re-validates `next_publication_id`.
+    #[tokio::test]
+    async fn commit_is_not_undone_by_an_install_decided_before_it() {
+        let storage = cached_snapshot_test_storage("test-cached-snapshot-install-race");
+        let space = StorageSpace::mutable(SpaceId(0x92), "test.cached-snapshot-install-race");
+        cached_snapshot_commit(&storage, space, "A").await;
+
+        let (stale_snapshot, fetch) = storage
+            .write_pipeline
+            .snapshot(&storage.worker)
+            .await
+            .expect("fetch the pre-commit snapshot");
+        let publication_id = storage
+            .write_pipeline
+            .state
+            .lock()
+            .expect("lock publication state")
+            .next_publication_id;
+        drop(fetch);
+
+        // The commit that races the in-flight install.
+        cached_snapshot_commit(&storage, space, "B").await;
+        assert!(
+            storage
+                .write_pipeline
+                .state
+                .lock()
+                .expect("lock publication state")
+                .latest_snapshot
+                .is_none(),
+            "commit invalidates the cached snapshot"
+        );
+
+        assert!(
+            !storage
+                .write_pipeline
+                .try_install_snapshot(publication_id, &stale_snapshot),
+            "an install decided before the commit must be rejected"
+        );
+        assert!(
+            storage
+                .write_pipeline
+                .state
+                .lock()
+                .expect("lock publication state")
+                .latest_snapshot
+                .is_none(),
+            "the commit's cache invalidation must not be undone by a stale install"
         );
     }
 


### PR DESCRIPTION
# Severity

A cached-snapshot reader could observe **neither the snapshot value nor the overlay value** for a committed write — a **stale read returnable to a live engine session**, on both the point-read and scan paths. It is transient and heals on reopen, but that is the mitigation, not the headline.

This is the defect behind the intermittent conformance failure

```
baseline::scan_range_sees_overwritten_existing_value:
  expected [(Key(b"a"), b"B")], got [(Key(b"a"), b"A")]
```

which had been dismissed as environmental. It is not environmental.

## Three findings worth stating plainly

**1. Point reads are affected identically — the scan was sampling, not scope.** `get_many` applies the overlay via `write_pipeline.point_value(view.snapshot_sequence, view.publication_id, &key)`, and `point_value` filters through `publication_visible_to_view` — the *same predicate*, over the *same* `visible` deque, that `begin_scan`'s `visible_writes` uses. There is no second mechanism protecting gets. The conformance suite catching `scan_range` first was which case ran, not the limit of the blast radius. The stale point read is the serious case and it is in scope.

**2. The disk cache is not implicated — my earlier diagnosis was wrong.** I originally pointed at `SplitCache`, the moka block/meta caches and the 16 MiB disk cache. That was incorrect and would have sent the next reader to the wrong file. Those caches key immutable SST blocks by object path and byte range and cannot serve a value that contradicts a snapshot. The incoherence lives entirely in per-instance, in-memory `WritePipelineState` (`latest_snapshot`, `visible`, `newest_snapshot_sequence`). The cached fixture is merely what makes the timing window reachable.

**3. It is reachable through the engine — a data-correctness bug, not a conformance-contract artifact.** `WriteOptions::default()` has `await_durable: false`, and `commit()` returns **without awaiting the drainer**. Ordinary engine commits therefore publish into this pipeline and return, and ordinary engine reads take `begin_read`. The window needs a commit concurrent with another reader's snapshot acquisition — the normal multi-session shape. Nothing about it requires the raw adapter API.

**Why it is rare rather than constant:** the overlay normally masks the stale snapshot, because a write committed after that snapshot has `persisted > snapshot_sequence` and so stays visible. Staleness additionally requires the publication to have been **retired** from `visible` first, which requires `newest_snapshot_sequence` to have advanced past it. That conjunction is narrow, which is why it presents as roughly one-in-many-hundreds rather than always.

# The two defects

Both in `packages/slatedb-storage/src/slatedb.rs`. They are independent and land as two commits.

## D2 — the cached fast path registered no retirement guard (the correctness fix)

`cleanup_publications` retires a publication only while `snapshot_fetches == 0`. The fetch path increments that counter and returns a `SnapshotFetch` which `begin_read` holds across the reader's `capture`. The cached fast path returned `(snapshot, None)` — no guard — so a reader on the cached path occupied the identical obtain→capture gap with the protection switched off. Cleanup in that window retires the publication the older cached snapshot still needs, and the reader falls through both layers.

The codebase already agrees this guard matters: `dropping_unrelated_view_does_not_reclaim_publication_a_stale_fetch_needs` exists specifically to prove it protects this gap — but it only ever exercises the fetch path, pinning `snapshot_fetches = 1`. The cached path produces `0`, and nothing tested that.

`snapshot()` now returns `SnapshotFetch` rather than `Option<SnapshotFetch>`, so the guard cannot be omitted by construction. All three call sites drop it immediately after `capture`, so publication retention is unchanged in steady state.

## D1 — the cacheability decision and the install were two critical sections

`snapshot()` computed `cacheable` under one lock acquisition and called `install_snapshot` under another. `commit()` invalidates the cache with `state.latest_snapshot = None` and bumps `next_publication_id`. A commit landing in that gap had its invalidation **undone**: the later install found `latest_snapshot` empty, so its monotonic `current.seq() <= snapshot.seq()` guard passed vacuously, and a snapshot predating the just-committed write was installed as the cache for every subsequent reader.

`try_install_snapshot` now re-validates `next_publication_id` under the same lock that performs the install.

# Tests — each proven against its own defect

Found by construction, not by volume: both tests are deterministic, with no timing or sleeps.

| test | defect | negative control |
|---|---|---|
| `cached_snapshot_path_registers_a_retirement_guard` | D2 | with the cached path's guard removed: **FAILED**, `left: 0, right: 1` |
| `commit_is_not_undone_by_an_install_decided_before_it` | D1 | with the publication-id re-check removed: **FAILED** at the rejection assertion |

The D1 test needed a second pass. My first version passed its own negative control, because the racing commit left `tail.done` false and `snapshot_covers_persisted_publications` false, so those terms rejected the install regardless of the publication-id check — the test was not specific to D1. The committed version arranges the state so the racing publication has already persisted and retired, making **only** the publication-id term capable of rejecting the install. It now fails when that term is removed.

The conformance test is untouched. It caught a real defect and it is the storage layer's correctness contract.

# Gate

Machine `ryzen-9950x-I`, verified uncontended. Final run on `0715d13cd`, merged with `claude-4-optimizations` @ `bdb0a4587`.

| line | result |
|---|---|
| `cargo check --workspace --all-targets --all-features` | clean |
| `cargo clippy --workspace --all-targets --all-features -- -D warnings` | clean, no warnings |
| `cargo test --profile test --workspace --all-features --no-fail-fast` | **zero failing targets** |
| `cargo check -p lix --no-default-features` | clean |

Both new tests re-confirmed on this base. An earlier gate on `43bba33f6` also ran the full test line 4/4 clean.

## Conformance suite, run hard — counts, not "passes"

| shape | base | this branch |
|---|---|---|
| `-p lix-storage-slatedb --test storage`, full binary, solo | 0/40 failed | 0/40 failed |
| `cached_slatedb_passes_storage_conformance` under `taskset -c 0,1` + 8-way oversubscription | 0/96 failed | 0/96 failed |

**Read that honestly:** the conformance suite did not reproduce the bug before the fix either — 272 runs per arm, zero failures, consistent with the original one-in-many-hundreds rate. A green conformance suite is therefore *not* the evidence that these fixes work. The evidence is the two deterministic tests plus their negative controls, each of which fails when its own fix is removed.

## One pre-existing flake, now attributed empirically

`lix-server-protocol` `same_base_remote_plugin_writes_resolve_and_converge` (`lib.rs:7613`, `assert_eq!(commits_after - commits_before, 1)` over three racing commits) failed twice during this work. It is **not** from this PR, and this time that is measured rather than argued: it also failed **1 in 6** full-workspace runs on **unmodified `claude-4-optimizations`**.

Tally across both arms in the full `--workspace --all-features` shape: base 1 failure / 13 runs, this branch 2 / 11. One of the branch failures occurred on an unrelated branch whose only change was filesystem-planner code, which cannot reach commit convergence. Pre-existing intermittent, worth its own ticket.
