### PR TITLE
test(convergence): assert the same-base guarantee, not the cohort count

### DIFF
--- a/packages/rs-sdk-tests/tests/crdt_benchmarks_baseline.rs
+++ b/packages/rs-sdk-tests/tests/crdt_benchmarks_baseline.rs
@@ -1,6 +1,6 @@
 //! Transactional slices comparable to dmonad/crdt-benchmarks.
 //!
-//! These are deliberately ignored profiling workloads. The upstream suite
+//! The heavier workloads here are ignored profiling runs. The upstream suite
 //! measures synchronous in-memory CRDT update exchange; Lix measures durable
 //! commit-to-convergence across same-base clients. These workloads use only the
 //! existing `begin_transaction()` API and never create synthetic branches.
@@ -79,8 +79,14 @@ async fn crdt_benchmarks_b2_1_markdown_concurrent_prefix_inserts() {
     report("B2.1", "markdown", &mut samples);
 }
 
+/// dmonad/crdt-benchmarks B3.1 durable Lix baseline.
+///
+/// Runs in CI rather than as a manual profiling workload: it is the only
+/// coverage for a hundred-writer same-base wave, it completes in about a
+/// second, and its convergence assertions no longer depend on how the
+/// coordinator batched that wave. `LIX_CRDT_B3_CLIENTS` and `LIX_CRDT_SAMPLES`
+/// scale it up for profiling runs.
 #[tokio::test]
-#[ignore = "dmonad/crdt-benchmarks B3.1 durable Lix baseline"]
 async fn crdt_benchmarks_b3_1_json_concurrent_map_sets() {
     let clients = std::env::var("LIX_CRDT_B3_CLIENTS")
         .ok()
@@ -134,7 +140,6 @@ async fn crdt_benchmarks_b3_1_json_concurrent_map_sets() {
             transactions.push(transaction);
         }
 
-        let commits_before = commit_count(&lix).await;
         lix.reset_plugin_transition_counters();
         let batch_started = Instant::now();
         let commit_results = tokio::task::LocalSet::new()
@@ -160,16 +165,21 @@ async fn crdt_benchmarks_b3_1_json_concurrent_map_sets() {
             all_latencies.push(elapsed);
         }
 
+        // Cohort cardinality is an admission batching artifact and is deliberately
+        // not asserted; the durable guarantee is that every contender resolves once
+        // into a single converged value on a history that never forks.
         let counters = lix.plugin_transition_counters();
-        assert_eq!(
-            commit_count(&lix).await - commits_before,
-            1,
-            "one admitted same-base cohort must publish one durable commit",
-        );
         assert!(counters.conflict_resolution_calls > 0);
+        // Resolution must batch: one plugin transition carries many contenders.
+        // The exact call count tracks how the wave happened to be admitted into
+        // cohorts, so only the batching itself is assertable. Measured at 100
+        // clients: 9-13 calls for 99 records.
         assert!(
-            counters.conflict_resolution_calls <= clients.ilog2() as u64 + 1,
-            "balanced reduction should cross the plugin boundary logarithmically",
+            counters.conflict_resolution_calls < (clients - 1) as u64,
+            "resolution must batch contenders instead of crossing the plugin \
+             boundary once per contender: {} calls for {} records",
+            counters.conflict_resolution_calls,
+            counters.conflict_resolution_records,
         );
         assert_eq!(
             counters.conflict_resolution_records,
@@ -183,6 +193,7 @@ async fn crdt_benchmarks_b3_1_json_concurrent_map_sets() {
         for peer in &peers {
             assert_eq!(read_file(peer, &path).await, converged);
         }
+        assert_linear_history(&lix).await;
         for peer in peers {
             peer.close().await.expect("peer should close");
         }
@@ -284,7 +295,6 @@ fn same_base_three_writer_cohort_converges_and_reuses_follower_session() {
                         transactions.push(transaction);
                     }
 
-                    let commits_before = commit_count(&lix).await;
                     lix.reset_plugin_transition_counters();
                     let results = tokio::task::LocalSet::new()
                         .run_until(async move {
@@ -310,7 +320,11 @@ fn same_base_three_writer_cohort_converges_and_reuses_follower_session() {
                     for result in results {
                         result.unwrap();
                     }
-                    assert_eq!(commit_count(&lix).await - commits_before, 1);
+                    // How many commits the coordinator published is an admission
+                    // batching artifact, not a guarantee: whether the wave lands in
+                    // one cohort or several depends only on arrival timing. Assert
+                    // the guarantee instead — every contender resolved once, one
+                    // converged value, and a history that never forked.
                     let counters = lix.plugin_transition_counters();
                     assert_eq!(counters.conflict_resolution_calls, 2);
                     assert_eq!(counters.conflict_resolution_records, 2);
@@ -330,6 +344,98 @@ fn same_base_three_writer_cohort_converges_and_reuses_follower_session() {
                     for peer in &peers {
                         assert_eq!(read_file(peer, path).await, converged);
                     }
+                    assert_linear_history(&lix).await;
+                    for peer in peers {
+                        peer.close().await.unwrap();
+                    }
+                    lix.close().await.unwrap();
+                });
+        })
+        .unwrap()
+        .join()
+        .unwrap();
+}
+
+/// Deterministic coverage for the multi-cohort path.
+///
+/// The racy same-base tests reach a split only by arrival timing, so they cannot
+/// be relied on to exercise it. Committing the first writer to completion before
+/// the others start forces the followers to open on a stale head and reconcile
+/// against a commit that did not exist when they staged. Disjoint edits make a
+/// lost update visible: every key must survive the split.
+#[test]
+fn serialized_leader_forces_stale_followers_to_reconcile_without_losing_writes() {
+    std::thread::Builder::new()
+        .name("stale-follower-reconcile".to_owned())
+        .stack_size(16 * 1024 * 1024)
+        .spawn(|| {
+            tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .unwrap()
+                .block_on(async {
+                    let lix = open_lix().await.unwrap();
+                    install_plugin(&lix, "plugin_json", &build_json_plugin_archive()).await;
+                    let path = "/stale-follower-reconcile.json";
+                    write_file(&lix, path, br#"{"a":0,"b":0,"c":0}"#).await;
+                    let file_id = file_id(&lix, path).await;
+                    let mut peers = Vec::new();
+                    let mut transactions = Vec::new();
+                    for (key, value) in [("a", "1"), ("b", "2"), ("c", "3")] {
+                        let peer = lix.open_workspace_session().await.unwrap();
+                        let mut transaction = peer.begin_transaction().await.unwrap();
+                        transaction
+                            .execute(
+                                "UPDATE json_object_member SET scalar_json = $1 \
+                                 WHERE parent_id = 'root' AND key = $2 AND lixcol_file_id = $3",
+                                &[
+                                    Value::Text(value.to_owned()),
+                                    Value::Text(key.to_owned()),
+                                    Value::Text(file_id.clone()),
+                                ],
+                            )
+                            .await
+                            .unwrap();
+                        peers.push(peer);
+                        transactions.push(transaction);
+                    }
+
+                    let results = tokio::task::LocalSet::new()
+                        .run_until(async move {
+                            let mut transactions = transactions.into_iter();
+                            let leader = transactions.next().unwrap();
+                            // Publish the leader before the followers enqueue, so
+                            // they cannot share its cohort.
+                            let mut results = vec![leader.commit().await];
+                            let mut commits = tokio::task::JoinSet::new();
+                            for transaction in transactions {
+                                commits.spawn_local(async move { transaction.commit().await });
+                            }
+                            while let Some(result) = commits.join_next().await {
+                                results.push(result.unwrap());
+                            }
+                            results
+                        })
+                        .await;
+                    for result in results {
+                        result.expect("a stale follower must reconcile, not fail");
+                    }
+
+                    let converged = read_file(&lix, path).await;
+                    let merged: serde_json::Value =
+                        serde_json::from_slice(&converged).expect("merged JSON should parse");
+                    for (key, value) in [("a", 1), ("b", 2), ("c", 3)] {
+                        assert_eq!(
+                            merged[key].as_i64(),
+                            Some(value),
+                            "disjoint write {key}={value} was lost reconciling against a \
+                             commit published after it staged: {merged}"
+                        );
+                    }
+                    for peer in &peers {
+                        assert_eq!(read_file(peer, path).await, converged);
+                    }
+                    assert_linear_history(&lix).await;
                     for peer in peers {
                         peer.close().await.unwrap();
                     }
@@ -465,6 +571,41 @@ where
         .rows()[0]
         .get::<i64>("count")
         .expect("benchmark commit count should be an integer")
+}
+
+/// Asserts the commit history never forked.
+///
+/// Two commits sharing a parent is what a genuine convergence defect would look
+/// like: concurrent writers publishing divergent successors of the same base.
+/// The number of commits a same-base wave publishes is timing-dependent and is
+/// deliberately not asserted anywhere; this is the property that is not.
+async fn assert_linear_history<StorageImpl>(lix: &Lix<StorageImpl>)
+where
+    StorageImpl: Storage + Clone + Send + Sync + 'static,
+{
+    let forks = lix
+        .execute(
+            "SELECT parent_id, COUNT(*) AS children FROM lix_commit_edge \
+             GROUP BY parent_id HAVING COUNT(*) > 1",
+            &[],
+        )
+        .await
+        .expect("commit edge fork query should run");
+    let forks = forks
+        .rows()
+        .iter()
+        .map(|row| {
+            format!(
+                "{} has {} children",
+                row.get::<String>("parent_id").unwrap_or_default(),
+                row.get::<i64>("children").unwrap_or_default(),
+            )
+        })
+        .collect::<Vec<_>>();
+    assert!(
+        forks.is_empty(),
+        "same-base writers must not fork the commit history: {forks:?}"
+    );
 }
 
 fn build_markdown_plugin_archive() -> Vec<u8> {

--- a/packages/rs-sdk-tests/tests/crdt_benchmarks_baseline.rs
+++ b/packages/rs-sdk-tests/tests/crdt_benchmarks_baseline.rs
@@ -323,7 +323,7 @@ fn same_base_three_writer_cohort_converges_and_reuses_follower_session() {
                     // How many commits the coordinator published is an admission
                     // batching artifact, not a guarantee: whether the wave lands in
                     // one cohort or several depends only on arrival timing. Assert
-                    // the guarantee instead — every contender resolved once, one
+                    // the guarantee instead: every contender resolved once, one
                     // converged value, and a history that never forked.
                     let counters = lix.plugin_transition_counters();
                     assert_eq!(counters.conflict_resolution_calls, 2);

--- a/packages/server-protocol/src/lib.rs
+++ b/packages/server-protocol/src/lib.rs
@@ -7600,7 +7600,7 @@ mod tests {
         // admission batching artifact of the commit coordinator and depends only
         // on arrival timing. The durable guarantee is that every contender is
         // resolved once, all sessions converge on one value, and the history
-        // never forks — assert those, not the commit count.
+        // never forks: assert those, not the commit count.
         let forks = root
             .execute(
                 "SELECT parent_id, COUNT(*) AS children FROM lix_commit_edge \

--- a/packages/server-protocol/src/lib.rs
+++ b/packages/server-protocol/src/lib.rs
@@ -7573,13 +7573,6 @@ mod tests {
             assert_eq!(staged.status(), StatusCode::OK);
         }
 
-        let commits_before = root
-            .execute("SELECT COUNT(*) AS count FROM lix_commit", &[])
-            .await
-            .unwrap()
-            .rows()[0]
-            .get::<i64>("count")
-            .unwrap();
         root.reset_plugin_transition_counters();
         let mut commits = tokio::task::JoinSet::new();
         for (session_id, transaction_id) in [
@@ -7603,14 +7596,24 @@ mod tests {
         while let Some(committed) = commits.join_next().await {
             assert_eq!(committed.unwrap().status(), StatusCode::NO_CONTENT);
         }
-        let commits_after = root
-            .execute("SELECT COUNT(*) AS count FROM lix_commit", &[])
+        // Whether the three remote commits land in one cohort or several is an
+        // admission batching artifact of the commit coordinator and depends only
+        // on arrival timing. The durable guarantee is that every contender is
+        // resolved once, all sessions converge on one value, and the history
+        // never forks — assert those, not the commit count.
+        let forks = root
+            .execute(
+                "SELECT parent_id, COUNT(*) AS children FROM lix_commit_edge \
+                 GROUP BY parent_id HAVING COUNT(*) > 1",
+                &[],
+            )
             .await
-            .unwrap()
-            .rows()[0]
-            .get::<i64>("count")
             .unwrap();
-        assert_eq!(commits_after - commits_before, 1);
+        assert_eq!(
+            forks.rows().len(),
+            0,
+            "same-base remote writers must not fork the commit history"
+        );
         let counters = root.plugin_transition_counters();
         assert_eq!(counters.conflict_resolution_calls, 2);
         assert_eq!(counters.conflict_resolution_records, 2);
@@ -7630,7 +7633,9 @@ mod tests {
             assert_eq!(visible.status(), StatusCode::OK);
             converged_rows.push(response_json(visible).await["rows"].clone());
         }
+        // Every session, not just the first two, must observe the same value.
         assert_eq!(converged_rows[0], converged_rows[1]);
+        assert_eq!(converged_rows[0], converged_rows[2]);
     }
 
     struct RemoteCapacityBackend {


### PR DESCRIPTION
## Summary

Three tests asserted that a wave of concurrent same-base writers publishes exactly **one** commit. That is an artifact of admission batching in `CommitCoordinator`, not a durable guarantee, and it has been unreliable since PR #1275. This replaces those assertions with the guarantee itself, adds deterministic coverage for the path the racy tests only reach by luck, and restores an ignored test to CI.

No engine change. Test-only, so no changenote (`.changenotes/README.md`: "Do not add a changenote for ... test-only ... changes"). No layout change, so the layout-invariant checklist does not apply.

## Root cause

`CommitCoordinator::commit` makes the first writer to `enqueue()` the cohort leader; it spawns a driver thread that drains the whole queue into one cohort, which publishes one commit. Writers that arrive after the drain form a second cohort and a second commit.

`b0c8d0874` (PR #1275, `perf(lix): remove fixed commit gather delay`, merged 2026-08-11) deleted the 2 ms sleep that gave later writers a window to join:

```rust
-const COMMIT_GATHER_WINDOW: Duration = Duration::from_millis(2);
     .spawn(move || {
-        std::thread::sleep(COMMIT_GATHER_WINDOW);
         runtime.block_on(coordinator.drive());
     })
```

The coalescing window is now OS thread-spawn latency, tens of microseconds. **#1275 knowingly accepted this** — from its own body:

> Zero-delay traces still formed cohorts; occasional larger waves split, but total wall time remained lower.

Its validation was `cargo fmt --check`, `cargo test -p lix`, and `cargo test -p lix --features all-simulations`. **`-p lix` builds neither `lix_tests` nor `lix-server-protocol`**, so none of the three affected tests could run — the change could not have been caught by the gate it was given. The runbook already records #1331 going red in CI the same way; this is another instance of the same blind spot, and the CI-scope gate is the only one that sees cross-package tests.

The removal is on `main`, not just on this branch: `commit_coordinator.rs`, `context/cohort.rs` and both racy test bodies are byte-identical between `origin/main` and `origin/claude-4-optimizations`. Merging the integration branch does not introduce this.

## What the tests asserted, and what they assert now

| site | was | now |
| --- | --- | --- |
| `server-protocol/src/lib.rs` `same_base_remote_plugin_writes_resolve_and_converge` | `commits_after - commits_before == 1` | history never forks; all **three** sessions converge (it previously compared only the first two) |
| `crdt_benchmarks_baseline.rs` `same_base_three_writer_cohort_converges_and_reuses_follower_session` | `commit_count - commits_before == 1` | history never forks (convergence and resolver counts were already asserted) |
| `crdt_benchmarks_baseline.rs` `crdt_benchmarks_b3_1_json_concurrent_map_sets` | `commit_count - commits_before == 1` **and** `conflict_resolution_calls <= log2(clients) + 1` | history never forks; resolution still batches (`calls < clients - 1`) |

No commit count is asserted in either direction. A bound on cohort count is the same mistake with a looser constant.

`invalid_aggregate_member_does_not_poison_valid_transaction` keeps its `== 1`: only one of its two writers can succeed, so its count does not depend on batching.

### B3.1 was already dead, and is now back in CI

B3.1 was `#[ignore]`d and **failed deterministically in both profiles** — 3/3 in release — not on the commit count but on `conflict_resolution_calls <= clients.ilog2() + 1`. At 100 clients that bound is 7; measured **13 calls / 99 records** in release and **9-10 / 99** in debug. That is the same defect one assertion deeper: the log2 bound describes a single cohort's balanced reduction tree, and the wave no longer lands in a single cohort.

`conflict_resolution_records == clients - 1` is the invariant that survives any split, and it holds exactly: a cohort of *k* contributes *k-1* internal resolutions, and a stale follower cohort contributes one more against the commit that landed ahead of it.

Un-ignored, because it now passes and it is the only coverage for a hundred-writer wave:

| | p95 | gate | runtime |
| --- | ---: | ---: | ---: |
| release | 5.66 ms | 100 ms | 0.33 s |
| debug, idle | 14.7-19.0 ms | 100 ms | 1.3 s |
| debug, 8-way self-contention | 20.0-22.9 ms, 0/8 failures | 100 ms | - |

CI runs `blacksmith-32vcpu-ubuntu-2404`, comparable to the measurement box, so the 100 ms gate keeps roughly 4.5x headroom under load.

### New deterministic coverage

`serialized_leader_forces_stale_followers_to_reconcile_without_losing_writes` commits the first writer to completion before the others start, so the followers are *forced* to open on a stale head and reconcile against a commit that did not exist when they staged. Three **disjoint** keys make a lost update visible. The racy tests reach this path only by arrival timing; this one reaches it every run.

## Measurements

Machine `ryzen-9950x-IV`. Failure counts, so lower is better; "full binary" means the whole test binary as CI runs it, which is the load that matters.

### The bug is contention-driven

| condition | `same_base_remote_plugin_writes_resolve_and_converge` |
| --- | ---: |
| test run alone | **0/60** |
| inside its full binary (95 tests in parallel) | **22/100** |

### Causation: three arms, interleaved, 5 rotated blocks, base `e1aedddc8`

`base` = unmodified `claude-4-optimizations`; `c0` = diagnostic build with the gather window off (behavioural null control); `c2` = same binary with the 2 ms window restored.

| arm | server-protocol, seq | crdt, seq | crdt, 8-way parallel |
| --- | ---: | ---: | ---: |
| base | 31/250 (12.4%) | 0/250 | 1/320 |
| c0 (null control) | 39/250 (15.6%) | 0/250 | 17/320 |
| c2 (2 ms restored) | **0/250** | **0/250** | **0/320** |

`base` vs `c0`: z = 1.03, p = 0.30 — the instrument is neutral. `c2` vs `base`: p < 1e-8.

The parallel-crdt column is **not** comparable between `base` and `c0`: the diagnostic branch adds two always-run tests to that binary, raising its own contention. The valid same-binary comparison there is `c0` 17/320 vs `c2` 0/320, p < 1e-4.

### Mechanism, isolated

Racy three-writer wave, 300 iterations in-process, commit-delta histogram:

| gather window | histogram |
| --- | --- |
| removed (today) | `{1: 34, 2: 266}` |
| 2 ms (pre-#1275) | `{1: 300}` |

### Blast radius: the split is semantically inert

Across all 300 racy iterations and both forced-split probes: **0 peer divergences, 0 forked histories**, `conflict_resolution_calls == 2` every time.

| probe | result |
| --- | --- |
| forced split, same scalar | `commit_delta=2`, one converged value, `forks=[]`, `calls=2` |
| forced split, disjoint keys | `{"a":1,"b":2,"c":3}` — **no write lost** |

A follower cohort funnels into the same `commit_prepared`, which runs `reconcile_stale_disjoint_writes` and resolves parents against the *current* head, so a stale cohort is merged rather than clobbered. This matches the engine's own framing in `TRANSACTION_CONFLICT_PERFORMANCE.md`: "this is admission batching, not a change to atomicity or durability."

### Before and after, same tree, interleaved

Both arms rebuilt at `bdb0a4587` and run back to back with rotated arm order. `before` is `~/claude3/base` on unmodified `claude-4-optimizations`; `after` is this branch.

| arm | server-protocol, seq | crdt, seq | crdt, 8-way parallel |
| --- | ---: | ---: | ---: |
| before (unmodified `bdb0a4587`) | 31/250 (12.4%) | 1/250 | 1/320 |
| after (this branch) | **0/250** | **0/250** | **0/320** |

Fisher exact on the server-protocol lane, 31/250 vs 0/250: p < 1e-9. Zero failures in 820 runs across the three lanes puts the 95% upper bound on the residual rate at 0.37% (rule of three).

The before-arm rate reproduced at **31/250 on both `e1aedddc8` and `bdb0a4587`**, which is the expected result given the coordinator is untouched between them, and it is the check that the baseline was not stale.

The parallel-crdt column is again not comparable across arms, and this time it is *harder* on `after`: the fixed binary runs six tests including the newly un-ignored hundred-writer B3.1, against four with B3.1 ignored on `before`. The server-protocol column runs the same 95 tests on both sides and is the like-for-like comparison.

## Residual cost, stated plainly

A split wave costs one extra commit row and one extra observe-invalidation bump. That is history and bytes churn, ranked below OLTP, and it is the deliberate price of #1275's **6.6x faster singleton commit** (p50 2.358 ms to 0.355 ms; 32-writer cohort 4.681 to 2.705 ms). Restoring the window to make these tests green would hand that back in the top-ranked category to satisfy an assertion that was never a guarantee.

Signpost, not work: if commit-row churn ever shows up as a measured cost in the history or GC benchmarks, an adaptive gather window becomes worth revisiting.

## Gate

Run on `ryzen-9950x-IV` against this branch's merged head, after merging `bdb0a4587`. All six stages exit 0.

```
cargo check  --workspace --all-targets --all-features                                            exit 0
cargo clippy --workspace --all-targets --all-features -- -D warnings                             exit 0
cargo test   --profile test --workspace --exclude lix_benchmarks --all-features --no-fail-fast   exit 0
cargo test   --profile test -p lix_benchmarks --features storage-benches,slatedb,root-replay-trace --no-fail-fast   exit 0
cargo check  -p lix --no-default-features                                                        exit 0
cargo check  -p lix_js_sdk --target wasm32-unknown-unknown                                       exit 0
```

All four affected tests ran inside the real gate rather than only in isolation:

```
test tests::same_base_remote_plugin_writes_resolve_and_converge ... ok
test same_base_three_writer_cohort_converges_and_reuses_follower_session ... ok
test serialized_leader_forces_stale_followers_to_reconcile_without_losing_writes ... ok
test crdt_benchmarks_b3_1_json_concurrent_map_sets ... ok
```

`rustfmt --edition 2024 --check` is clean on both touched files. `cargo fmt --all --check` is dirty repo-wide on pristine base and was deliberately not run.
