### PR TITLE
perf(storage): delete the write-only untracked JSON reclaim candidate space

### DIFF
--- a/.changenotes/no-write-only-json-reclaim-hints.md
+++ b/.changenotes/no-write-only-json-reclaim-hints.md
@@ -1,0 +1,7 @@
+---
+type: patch
+---
+
+Removed a storage plane that recorded reclamation hints nothing ever read.
+
+Every commit that superseded or deleted a large untracked JSON payload wrote a durable hint row into a dedicated storage space. No maintenance path ever consumed those rows, so they accumulated for the life of a repository. The hints and the space are gone; repositories now spend nothing on them.

--- a/packages/lix/src/gc.rs
+++ b/packages/lix/src/gc.rs
@@ -23,9 +23,7 @@ use crate::commit_graph::CommitGraphContext;
 #[cfg(test)]
 use crate::json_store::JsonRef;
 #[cfg(test)]
-use crate::json_store::{
-    JsonSlot, JsonStoreContext, JsonStoreWriter, UntrackedJsonReclaimCandidate,
-};
+use crate::json_store::{JsonSlot, JsonStoreContext};
 use crate::live_state::TrackedHeadContext;
 #[cfg(test)]
 use crate::live_state::stage_collect_stale_working_diff_indexes;
@@ -1387,57 +1385,6 @@ where
     // maintenance work, but delta rows have no shared ownership and must be
     // reclaimed in the same logical GC pass.
     let phase_started = Instant::now();
-    // The changelog plan contains every payload reachable from tracked
-    // history plus the active untracked roots supplied above. A retired
-    // untracked JSON ref is only a deletion candidate: content-addressed
-    // payloads can be shared with another current row or reachable history,
-    // so absence from this complete live set is the required proof.
-    let live_payloads = changelog_plan
-        .live
-        .payloads
-        .iter()
-        .map(|json_ref| *json_ref.as_hash_array())
-        .collect::<BTreeSet<_>>();
-    // `collect_garbage` already staged deletes for dead changelog payloads.
-    // Avoid emitting a second mutation for a content hash shared with a stale
-    // untracked generation; `StorageWriteSet` deliberately rejects duplicate
-    // final mutations, even when both are deletes.
-    let changelog_swept_payloads = changelog_plan
-        .sweep
-        .json_payloads
-        .iter()
-        .map(|json_ref| *json_ref.as_hash_array())
-        .collect::<BTreeSet<_>>();
-    let mut reclaimable_untracked_refs = BTreeSet::new();
-    let mut consumed_candidate_keys = Vec::new();
-    for candidate in JsonStoreContext::new()
-        .scan_untracked_reclaim_candidates(&store)
-        .await?
-    {
-        let UntrackedJsonReclaimCandidate { key, json_ref } = candidate;
-        let Some(json_ref) = json_ref else {
-            // Candidate records are derived hints. A malformed one cannot
-            // safely name a JSON payload, but it must not become permanent
-            // maintenance debt.
-            consumed_candidate_keys.push(key);
-            continue;
-        };
-        if !live_payloads.contains(json_ref.as_hash_array()) {
-            reclaimable_untracked_refs.insert(*json_ref.as_hash_array());
-            consumed_candidate_keys.push(key);
-        }
-        // Keep a live candidate. If a shared owner later disappears through a
-        // different lifecycle path, the next GC can still prove reclamation
-        // without relying on that path to recreate this hint.
-    }
-    let reclaimable_untracked_refs = reclaimable_untracked_refs
-        .into_iter()
-        .filter(|hash| !live_payloads.contains(hash) && !changelog_swept_payloads.contains(hash))
-        .map(JsonRef::from_hash_bytes)
-        .collect::<Vec<_>>();
-    let json_writer = JsonStoreContext::new().writer();
-    json_writer.stage_delete_refs(writes, reclaimable_untracked_refs);
-    JsonStoreWriter::stage_delete_untracked_reclaim_candidates(writes, consumed_candidate_keys);
     // Checkpoint publication leaves prior dirty-index generations unreachable
     // in O(1). Reclaim those auxiliary records only in the asynchronous GC
     // pass so a foreground checkpoint never pays a history-sized delete cost.
@@ -2188,7 +2135,7 @@ mod tests {
     use crate::entity_pk::EntityPk;
     use crate::json_store::{
         JsonRef, JsonSlot, JsonSlotRef, JsonStoreContext, JsonWritePlacementRef, NormalizedJson,
-        NormalizedJsonRef, UNTRACKED_JSON_RECLAIM_CANDIDATE_SPACE,
+        NormalizedJsonRef,
     };
     use crate::live_state::{CurrentStateDeltaRef, TrackedHeadContext, WorkingDiffIndexCoverage};
     use crate::storage_adapter::{
@@ -4367,85 +4314,6 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn repository_gc_reclaims_retired_untracked_update_without_inventory_sweep() {
-        let storage = Memory::new();
-        Engine::initialize(storage.clone())
-            .await
-            .expect("repository should initialize");
-        let engine = Engine::new(storage.clone())
-            .await
-            .expect("repository should open");
-        let session = engine
-            .open_workspace_session()
-            .await
-            .expect("workspace session should open");
-        let old_value = serde_json::json!({
-            "payload": "old-".repeat(crate::json_store::JSON_INLINE_MAX_BYTES),
-        });
-        let old_json = old_value.to_string();
-        let old_ref = key_value_snapshot_ref("gc-update-untracked", &old_value);
-        let new_value = serde_json::json!({
-            "payload": "new-".repeat(crate::json_store::JSON_INLINE_MAX_BYTES),
-        });
-        let new_json = new_value.to_string();
-        let new_ref = key_value_snapshot_ref("gc-update-untracked", &new_value);
-        session
-            .execute(
-                "INSERT INTO lix_key_value (key, value, lixcol_untracked) \
-                 VALUES ('gc-update-untracked', lix_json($1), true)",
-                &[Value::Text(old_json)],
-            )
-            .await
-            .expect("old untracked value should write");
-        session
-            .execute(
-                "UPDATE lix_key_value SET value = lix_json($1) \
-                 WHERE key = 'gc-update-untracked'",
-                &[Value::Text(new_json)],
-            )
-            .await
-            .expect("untracked value should update in the same generation");
-
-        // A bare JSON object has no reclaim candidate. It proves this GC is
-        // deliberately targeted rather than a full JSON-store inventory scan.
-        let bare_orphan_ref =
-            stage_bare_json(&storage, &format!("\"{}\"", "bare-".repeat(1024))).await;
-
-        run_repository_gc(&storage).await;
-
-        assert!(
-            !json_ref_exists(&storage, crate::json_store::store::JSON_SPACE, old_ref).await,
-            "the superseded untracked payload should be reclaimed"
-        );
-        assert!(
-            json_ref_exists(&storage, crate::json_store::store::JSON_SPACE, new_ref).await,
-            "the current untracked payload must remain stored"
-        );
-        assert!(
-            json_ref_exists(
-                &storage,
-                crate::json_store::store::JSON_SPACE,
-                bare_orphan_ref,
-            )
-            .await,
-            "candidate GC must not scan and sweep unrelated JSON"
-        );
-        assert!(
-            !json_ref_exists(&storage, UNTRACKED_JSON_RECLAIM_CANDIDATE_SPACE, old_ref,).await,
-            "a dead payload should consume its reclamation candidate"
-        );
-
-        let visible = session
-            .execute(
-                "SELECT value FROM lix_key_value WHERE key = 'gc-update-untracked'",
-                &[],
-            )
-            .await
-            .expect("live untracked value should remain readable after GC");
-        assert_eq!(visible.rows()[0].values(), &[Value::Json(new_value.into())]);
-    }
-
-    #[tokio::test]
     async fn repository_gc_retains_active_history_diff_undo_redo_and_reclaims_deleted_branch_refs()
     {
         let storage = Memory::new();
@@ -4754,111 +4622,6 @@ mod tests {
         assert_eq!(branches.rows()[0].get::<i64>("entries").unwrap(), 0);
     }
 
-    #[tokio::test]
-    async fn repository_gc_reclaims_retired_untracked_delete() {
-        let storage = Memory::new();
-        Engine::initialize(storage.clone())
-            .await
-            .expect("repository should initialize");
-        let engine = Engine::new(storage.clone())
-            .await
-            .expect("repository should open");
-        let session = engine
-            .open_workspace_session()
-            .await
-            .expect("workspace session should open");
-        let deleted_value = serde_json::json!({
-            "payload": "delete-".repeat(crate::json_store::JSON_INLINE_MAX_BYTES),
-        });
-        let deleted_json = deleted_value.to_string();
-        let deleted_ref = key_value_snapshot_ref("gc-delete-untracked", &deleted_value);
-        session
-            .execute(
-                "INSERT INTO lix_key_value (key, value, lixcol_untracked) \
-                 VALUES ('gc-delete-untracked', lix_json($1), true)",
-                &[Value::Text(deleted_json)],
-            )
-            .await
-            .expect("untracked value should write");
-        session
-            .execute(
-                "DELETE FROM lix_key_value WHERE key = 'gc-delete-untracked'",
-                &[],
-            )
-            .await
-            .expect("untracked value should delete physically");
-
-        run_repository_gc(&storage).await;
-
-        assert!(
-            !json_ref_exists(&storage, crate::json_store::store::JSON_SPACE, deleted_ref,).await,
-            "a deleted untracked payload should be reclaimed"
-        );
-        assert!(
-            !json_ref_exists(
-                &storage,
-                UNTRACKED_JSON_RECLAIM_CANDIDATE_SPACE,
-                deleted_ref,
-            )
-            .await,
-            "a reclaimed deletion should consume its candidate"
-        );
-    }
-
-    #[tokio::test]
-    async fn repository_gc_keeps_candidate_reachable_from_tracked_history() {
-        let storage = Memory::new();
-        Engine::initialize(storage.clone())
-            .await
-            .expect("repository should initialize");
-        let engine = Engine::new(storage.clone())
-            .await
-            .expect("repository should open");
-        let session = engine
-            .open_workspace_session()
-            .await
-            .expect("workspace session should open");
-        let shared_value = serde_json::json!({
-            "payload": "shared-".repeat(crate::json_store::JSON_INLINE_MAX_BYTES),
-        });
-        let shared_json = shared_value.to_string();
-        let shared_ref = key_value_snapshot_ref("gc-tracked-candidate", &shared_value);
-        session
-            .execute(
-                "INSERT INTO lix_key_value (key, value) \
-                 VALUES ('gc-tracked-candidate', lix_json($1))",
-                &[Value::Text(shared_json)],
-            )
-            .await
-            .expect("tracked owner should write");
-
-        // Candidate records are merely ownership-loss hints. Injecting one
-        // for a tracked payload exercises the exact same liveness proof that
-        // protects a hash shared with retained history.
-        stage_untracked_reclaim_candidate(&storage, shared_ref).await;
-
-        run_repository_gc(&storage).await;
-
-        assert!(
-            json_ref_exists(&storage, crate::json_store::store::JSON_SPACE, shared_ref).await,
-            "reachable tracked history must retain a candidate payload"
-        );
-        assert!(
-            json_ref_exists(&storage, UNTRACKED_JSON_RECLAIM_CANDIDATE_SPACE, shared_ref,).await,
-            "a candidate rooted by history must survive for later re-evaluation"
-        );
-        let tracked = session
-            .execute(
-                "SELECT value FROM lix_key_value WHERE key = 'gc-tracked-candidate'",
-                &[],
-            )
-            .await
-            .expect("tracked owner should remain readable");
-        assert_eq!(
-            tracked.rows()[0].values(),
-            &[Value::Json(shared_value.into())]
-        );
-    }
 
     #[tokio::test]
     async fn authority_gc_rejects_missing_live_commit_state_before_staging_deletes() {
@@ -5438,126 +5201,6 @@ mod tests {
         );
     }
 
-    #[tokio::test]
-    async fn repository_gc_reclaims_candidate_after_last_live_untracked_owner_disappears() {
-        let storage = Memory::new();
-        Engine::initialize(storage.clone())
-            .await
-            .expect("repository should initialize");
-        let shared_ref = stage_bare_json(
-            &storage,
-            &serde_json::json!({
-                "payload": "shared-untracked-"
-                    .repeat(crate::json_store::JSON_INLINE_MAX_BYTES),
-            })
-            .to_string(),
-        )
-        .await;
-        stage_untracked_current_owner(&storage, "gc-untracked-owner-a", Some(shared_ref)).await;
-        stage_untracked_current_owner(&storage, "gc-untracked-owner-b", Some(shared_ref)).await;
-        stage_untracked_current_owner(&storage, "gc-untracked-owner-a", None).await;
-
-        run_repository_gc(&storage).await;
-
-        assert!(
-            json_ref_exists(&storage, crate::json_store::store::JSON_SPACE, shared_ref).await,
-            "the second live untracked owner must retain its payload"
-        );
-        assert!(
-            json_ref_exists(&storage, UNTRACKED_JSON_RECLAIM_CANDIDATE_SPACE, shared_ref,).await,
-            "the candidate must survive until the last untracked owner disappears"
-        );
-
-        stage_untracked_current_owner(&storage, "gc-untracked-owner-b", None).await;
-
-        run_repository_gc(&storage).await;
-
-        assert!(
-            !json_ref_exists(&storage, crate::json_store::store::JSON_SPACE, shared_ref).await,
-            "the final owner's payload should be reclaimed after its deletion"
-        );
-        assert!(
-            !json_ref_exists(&storage, UNTRACKED_JSON_RECLAIM_CANDIDATE_SPACE, shared_ref,).await,
-            "reclaiming the payload should consume the durable candidate"
-        );
-    }
-
-    async fn stage_untracked_current_owner(
-        storage: &Memory,
-        entity_pk_value: &str,
-        snapshot: Option<JsonRef>,
-    ) {
-        let storage_adapter = StorageAdapter::new(storage.clone());
-        let read = storage_adapter
-            .begin_read(StorageReadOptions::default())
-            .await
-            .expect("current-state owner read should open");
-        let control = BranchHeadControlContext::new()
-            .reader(&read)
-            .load(GLOBAL_BRANCH_ID)
-            .await
-            .expect("global control should load")
-            .expect("global control should exist");
-        let entity_pk = EntityPk::single(entity_pk_value);
-        let snapshot_slot = snapshot.map_or(JsonSlot::None, JsonSlot::Ref);
-        let timestamp =
-            LixTimestamp::expect_parse("untracked GC owner timestamp", "2026-01-01T00:00:00Z");
-        let mut writes = storage_adapter.new_write_set();
-        let mut coverage = WorkingDiffIndexCoverage::default();
-        TrackedHeadContext::new()
-            .writer(&read, &mut writes)
-            .stage_current_state_with_working_diff(
-                GLOBAL_BRANCH_ID,
-                Some(control.tracked_generation),
-                control.head_commit_id,
-                &[CurrentStateDeltaRef {
-                    schema_key: "gc_untracked_owner",
-                    file_id: None,
-                    entity_pk: &entity_pk,
-                    change_id: Some(ChangeId::for_test_label("gc-untracked-owner")),
-                    commit_id: None,
-                    untracked: true,
-                    deleted: snapshot.is_none(),
-                    created_at: timestamp,
-                    updated_at: timestamp,
-                    snapshot: snapshot_slot.as_ref_slot(),
-                    metadata: JsonSlotRef::None,
-                    columnar_base_coordinate: None,
-                }],
-                &BTreeSet::new(),
-                None,
-                None,
-                None,
-                &mut coverage,
-            )
-            .await
-            .expect("untracked current-state owner should stage");
-        stage_branch_head_control(
-            &mut writes,
-            GLOBAL_BRANCH_ID,
-            control
-                .next_current_state_revision()
-                .expect("current-state revision should advance"),
-        )
-        .expect("current-state control should stage");
-        storage_adapter
-            .commit_write_set(writes, StorageWriteOptions::default())
-            .await
-            .expect("untracked current-state owner should commit");
-    }
-
-    async fn stage_untracked_reclaim_candidate(storage: &Memory, json_ref: JsonRef) {
-        let storage_adapter = StorageAdapter::new(storage.clone());
-        let mut writes = storage_adapter.new_write_set();
-        crate::json_store::JsonStoreWriter::stage_untracked_reclaim_candidates(
-            &mut writes,
-            [json_ref],
-        );
-        storage_adapter
-            .commit_write_set(writes, StorageWriteOptions::default())
-            .await
-            .expect("reclaim candidate should commit");
-    }
 
     async fn run_repository_gc(storage: &Memory) {
         let storage_adapter = StorageAdapter::new(storage.clone());
@@ -6239,15 +5882,6 @@ mod tests {
         .next()
         .flatten()
         .is_some()
-    }
-
-    fn key_value_snapshot_ref(key: &str, value: &serde_json::Value) -> JsonRef {
-        let snapshot = serde_json::json!({
-            "key": key,
-            "value": value,
-        })
-        .to_string();
-        JsonRef::for_content(snapshot.as_bytes())
     }
 
     fn recovery(branch_id: &str, recovered_head: &str, checkpoint: &str) -> CheckpointRecoveryRef {

--- a/packages/lix/src/json_store/context.rs
+++ b/packages/lix/src/json_store/context.rs
@@ -4,44 +4,12 @@ use crate::json_store::types::{
     JsonLoadBatch, JsonLoadRequestRef, JsonRef, JsonWritePlacementRef, NormalizedJsonRef,
 };
 use crate::storage_adapter::{
-    BufferRange, EncodedMutationBatch, EncodedPut, StorageAdapterRead, StorageSpace,
-    StorageSpaceId, StorageWriteSet,
-};
-#[cfg(test)]
-use crate::storage_adapter::{
-    StorageBeginScanOptions, StorageCoreProjection, StorageKey, StoragePrefix,
+    BufferRange, EncodedMutationBatch, EncodedPut, StorageAdapterRead, StorageWriteSet,
 };
 use bytes::Bytes;
 use std::collections::HashSet;
 
-/// A durable deletion hint for a large JSON payload retired from the
-/// untracked current-state plane.
-///
-/// The content-addressed JSON store intentionally has no refcount: the same
-/// payload can be owned by tracked history and by multiple untracked rows.
-/// This key is therefore not an ownership edge. Repository GC compares it
-/// with the complete live-payload set before it deletes the JSON value.
-pub(crate) const UNTRACKED_JSON_RECLAIM_CANDIDATE_NAMESPACE: &str =
-    "json_store.untracked_reclaim_candidate.v1";
-pub(crate) const UNTRACKED_JSON_RECLAIM_CANDIDATE_SPACE: StorageSpace = StorageSpace::mutable(
-    StorageSpaceId(0x0002_0002),
-    UNTRACKED_JSON_RECLAIM_CANDIDATE_NAMESPACE,
-);
-
-const UNTRACKED_JSON_RECLAIM_CANDIDATE_VALUE: &[u8] = b"\x01";
 const JSON_REF_BYTES: usize = 32;
-
-/// One candidate record discovered from the pinned repository-GC view.
-///
-/// Malformed keys are retained as `None` so GC can reclaim the derived record
-/// without treating a corrupt hint as a reason to touch an arbitrary JSON
-/// payload.
-#[cfg(test)]
-#[derive(Clone, Debug)]
-pub(crate) struct UntrackedJsonReclaimCandidate {
-    pub(crate) key: StorageKey,
-    pub(crate) json_ref: Option<JsonRef>,
-}
 
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct JsonStoreContext;
@@ -72,50 +40,6 @@ impl JsonStoreContext {
         store::load_json_bytes_many_in_scope(store, request.refs, request.scope)
             .await
             .map(JsonLoadBatch::new)
-    }
-
-    /// Lists the durable hints for out-of-band untracked payloads that may no
-    /// longer have an owner. This is deliberately a key-only, paged scan: the
-    /// hint value carries no data and the caller already holds the complete
-    /// logical root set from the same pinned read.
-    #[cfg(test)]
-    pub(crate) async fn scan_untracked_reclaim_candidates(
-        &self,
-        store: &(impl StorageAdapterRead + ?Sized),
-    ) -> Result<Vec<UntrackedJsonReclaimCandidate>, LixError> {
-        let range = StoragePrefix {
-            bytes: Bytes::new(),
-        }
-        .to_range()?;
-        let mut candidates = Vec::new();
-        let mut cursor = store
-            .begin_scan(
-                UNTRACKED_JSON_RECLAIM_CANDIDATE_SPACE,
-                range,
-                StorageBeginScanOptions {
-                    projection: StorageCoreProjection::KeyOnly,
-                    ..StorageBeginScanOptions::default()
-                },
-            )
-            .await?;
-        loop {
-            let page = cursor
-                .next_page(crate::storage_adapter::MAX_SCAN_PAGE_ROWS)
-                .await?;
-            candidates.extend(page.entries.into_iter().map(|entry| {
-                let json_ref = <[u8; 32]>::try_from(entry.key.0.as_ref())
-                    .ok()
-                    .map(JsonRef::from_hash_bytes);
-                UntrackedJsonReclaimCandidate {
-                    key: entry.key,
-                    json_ref,
-                }
-            }));
-            if !page.has_more {
-                break;
-            }
-        }
-        Ok(candidates)
     }
 }
 
@@ -234,80 +158,9 @@ impl JsonStoreWriter {
         Ok(order)
     }
 
-    /// Records exactly the out-of-band untracked JSON payloads that lost one
-    /// current-state owner in this atomic write. Repeated content hashes are
-    /// idempotent: they remain one durable GC hint until a sweep proves them
-    /// dead.
-    pub(crate) fn stage_untracked_reclaim_candidates<I>(writes: &mut StorageWriteSet, refs: I)
-    where
-        I: IntoIterator<Item = JsonRef>,
-        I::IntoIter: ExactSizeIterator,
-    {
-        let refs = refs.into_iter();
-        let row_capacity = refs.len();
-        let mut key_bytes =
-            Vec::with_capacity(row_capacity.checked_mul(JSON_REF_BYTES).unwrap_or_default());
-        let mut puts = Vec::with_capacity(row_capacity);
-        for json_ref in refs {
-            let offset = key_bytes.len();
-            key_bytes.extend_from_slice(json_ref.as_hash_bytes());
-            puts.push(EncodedPut {
-                key: BufferRange::new(offset, JSON_REF_BYTES),
-                value: BufferRange::new(0, UNTRACKED_JSON_RECLAIM_CANDIDATE_VALUE.len()),
-            });
-        }
-        if puts.is_empty() {
-            return;
-        }
-        let batch = EncodedMutationBatch::try_new(
-            Bytes::from(key_bytes),
-            Bytes::from_static(UNTRACKED_JSON_RECLAIM_CANDIDATE_VALUE),
-            puts,
-            Vec::new(),
-        )
-        .expect("JSON reclaim candidate descriptors are built from arena offsets");
-        // The write-set helper coalesces an identical hint emitted by an
-        // earlier current-state staging call in the same atomic commit.
-        writes.stage_content_addressed_encoded_batch(UNTRACKED_JSON_RECLAIM_CANDIDATE_SPACE, batch);
-    }
-
-    /// Removes only candidate hints whose payload was proved dead (or whose
-    /// key was malformed) from the same pinned GC view.
-    #[cfg(test)]
-    pub(crate) fn stage_delete_untracked_reclaim_candidates<I>(
-        writes: &mut StorageWriteSet,
-        keys: I,
-    ) where
-        I: IntoIterator<Item = StorageKey>,
-        I::IntoIter: ExactSizeIterator,
-    {
-        let keys = keys.into_iter();
-        let row_capacity = keys.len();
-        let mut key_bytes =
-            Vec::with_capacity(row_capacity.checked_mul(JSON_REF_BYTES).unwrap_or_default());
-        let mut deletes = Vec::with_capacity(row_capacity);
-        for key in keys {
-            let offset = key_bytes.len();
-            key_bytes.extend_from_slice(&key.0);
-            deletes.push(BufferRange::new(offset, key.0.len()));
-        }
-        if deletes.is_empty() {
-            return;
-        }
-        let batch = EncodedMutationBatch::try_new(
-            Bytes::from(key_bytes),
-            Bytes::new(),
-            Vec::new(),
-            deletes,
-        )
-        .expect("JSON reclaim candidate delete descriptors are built from arena offsets");
-        writes.stage_encoded_batch(UNTRACKED_JSON_RECLAIM_CANDIDATE_SPACE, batch);
-    }
-
-    /// Deletes JSON payload rows. Only the `#[cfg(test)]` full-recovery GC
-    /// path consumes untracked reclaim candidates today, so no production
-    /// caller reaches this; see the write-only-space finding for the space it
-    /// serves.
+    /// Deletes JSON payload rows. The only caller is the `#[cfg(test)]`
+    /// changelog sweep in `gc.rs`; no production path reclaims JSON payloads
+    /// today.
     #[cfg(test)]
     #[expect(clippy::unused_self)]
     pub(crate) fn stage_delete_refs<I>(&self, writes: &mut StorageWriteSet, refs: I)
@@ -411,50 +264,12 @@ mod tests {
     }
 
     #[test]
-    fn reclaim_and_delete_batches_use_one_key_arena_for_ten_thousand_rows() {
+    fn delete_batches_use_one_key_arena_for_ten_thousand_rows() {
         const ROW_COUNT: usize = 10_000;
 
         let refs = (0_u32..ROW_COUNT as u32)
             .map(|index| JsonRef::for_content(&index.to_be_bytes()))
             .collect::<Vec<_>>();
-
-        let mut candidate_puts = StorageWriteSet::new();
-        JsonStoreWriter::stage_untracked_reclaim_candidates(
-            &mut candidate_puts,
-            refs.iter().copied(),
-        );
-        // A later domain stage of the same content-addressed hints must discard
-        // descriptors without retaining another pair of arenas.
-        JsonStoreWriter::stage_untracked_reclaim_candidates(
-            &mut candidate_puts,
-            refs.iter().copied(),
-        );
-        let arenas = candidate_puts.arena_stats();
-        assert_eq!(arenas.put_descriptors, ROW_COUNT);
-        assert_eq!(arenas.delete_descriptors, 0);
-        assert_eq!(arenas.key_shared_buffers, 1);
-        assert_eq!(arenas.key_shared_bytes, ROW_COUNT * JSON_REF_BYTES);
-        assert_eq!(arenas.value_shared_buffers, 1);
-        assert_eq!(
-            arenas.value_shared_bytes,
-            UNTRACKED_JSON_RECLAIM_CANDIDATE_VALUE.len()
-        );
-
-        let candidate_keys = refs
-            .iter()
-            .map(|json_ref| StorageKey(Bytes::copy_from_slice(json_ref.as_hash_bytes())))
-            .collect::<Vec<_>>();
-        let mut candidate_deletes = StorageWriteSet::new();
-        JsonStoreWriter::stage_delete_untracked_reclaim_candidates(
-            &mut candidate_deletes,
-            candidate_keys,
-        );
-        let arenas = candidate_deletes.arena_stats();
-        assert_eq!(arenas.put_descriptors, 0);
-        assert_eq!(arenas.delete_descriptors, ROW_COUNT);
-        assert_eq!(arenas.key_shared_buffers, 1);
-        assert_eq!(arenas.key_shared_bytes, ROW_COUNT * JSON_REF_BYTES);
-        assert_eq!(arenas.value_shared_buffers, 0);
 
         let mut payload_deletes = StorageWriteSet::new();
         JsonStoreContext::new()

--- a/packages/lix/src/json_store/context.rs
+++ b/packages/lix/src/json_store/context.rs
@@ -9,6 +9,7 @@ use crate::storage_adapter::{
 use bytes::Bytes;
 use std::collections::HashSet;
 
+#[cfg(test)]
 const JSON_REF_BYTES: usize = 32;
 
 #[derive(Debug, Clone, Copy)]

--- a/packages/lix/src/json_store/mod.rs
+++ b/packages/lix/src/json_store/mod.rs
@@ -4,12 +4,8 @@ mod encoded;
 pub(crate) mod store;
 pub(crate) mod types;
 
-#[cfg(test)]
-pub(crate) use context::UntrackedJsonReclaimCandidate;
 #[allow(unused_imports)]
-pub(crate) use context::{
-    JsonStoreContext, JsonStoreReader, JsonStoreWriter, UNTRACKED_JSON_RECLAIM_CANDIDATE_SPACE,
-};
+pub(crate) use context::{JsonStoreContext, JsonStoreReader, JsonStoreWriter};
 // Owner facade for the storage-space registry (`crate::storage_spaces`).
 #[cfg(any(test, feature = "storage-benches"))]
 pub(crate) use store::JSON_SPACE;

--- a/packages/lix/src/live_state/tracked_head.rs
+++ b/packages/lix/src/live_state/tracked_head.rs
@@ -55,7 +55,6 @@ use crate::common::{LixTimestamp, SharedStr};
 use crate::entity_pk::EntityPk;
 use crate::json_store::{
     JsonLoadRequestRef, JsonReadScopeRef, JsonRef, JsonSlot, JsonSlotRef, JsonStoreContext,
-    JsonStoreWriter,
 };
 use crate::live_state::{
     MaterializedLiveStateBatch, MaterializedLiveStateBatchBuilder, MaterializedLiveStateExactBatch,
@@ -584,29 +583,6 @@ fn current_state_duplicate_delta_error(delta: &CurrentStateDeltaRef<'_>) -> LixE
             delta.schema_key, delta.entity_pk, delta.file_id
         ),
     )
-}
-
-fn collect_retired_untracked_json_refs(
-    existing: HeadValueView<'_>,
-    delta: &CurrentStateDeltaRef<'_>,
-    retired: &mut BTreeSet<[u8; JSON_REF_BYTES]>,
-) {
-    debug_assert!(existing.untracked);
-    if !delta.untracked {
-        return;
-    }
-    for old_slot in [existing.snapshot, existing.metadata] {
-        let HeadSlotView::Ref(old_ref) = old_slot else {
-            continue;
-        };
-        let retained_by_successor = !delta.physically_deletes()
-            && [delta.snapshot, delta.metadata].into_iter().any(
-                |new_slot| matches!(new_slot, JsonSlotRef::Ref(new_ref) if new_ref == &old_ref),
-            );
-        if !retained_by_successor {
-            retired.insert(*old_ref.as_hash_array());
-        }
-    }
 }
 
 fn reject_guarded_live_member(

--- a/packages/lix/src/live_state/tracked_head/hot.rs
+++ b/packages/lix/src/live_state/tracked_head/hot.rs
@@ -7455,7 +7455,6 @@ where
             }
         }
         let mut created_ats = Vec::with_capacity(sorted.len());
-        let mut retired_untracked_json_refs = BTreeSet::new();
         for (delta, previous) in sorted.iter().zip(&previous_values) {
             let Some(previous) = previous else {
                 created_ats.push(delta.created_at);
@@ -7468,13 +7467,6 @@ where
                 reject_guarded_live_member(absence_guards, delta, existing)?;
             }
             reject_retention_change(delta, existing)?;
-            if existing.untracked {
-                collect_retired_untracked_json_refs(
-                    existing,
-                    delta,
-                    &mut retired_untracked_json_refs,
-                );
-            }
             created_ats.push(if reset_working_diff_baselines && !delta.untracked {
                 // Checkpoint selection canonicalizes newly added rows to the
                 // changelog timestamp and preserves the original timestamp
@@ -7724,7 +7716,6 @@ where
                 working_diff_capture_checkpoint_commit_id,
                 reset_working_diff_baselines,
                 &mut next_coverage,
-                &mut retired_untracked_json_refs,
             )
             .await
         }
@@ -7733,12 +7724,6 @@ where
             "lix.perf.materialization.hot.stage"
         ))
         .await?;
-        JsonStoreWriter::stage_untracked_reclaim_candidates(
-            self.writes,
-            retired_untracked_json_refs
-                .into_iter()
-                .map(JsonRef::from_hash_bytes),
-        );
         *coverage = next_coverage;
         Ok(generation)
     }
@@ -7777,23 +7762,12 @@ where
         let sorted_tracked = sorted_lifecycle_hot_deltas(tracked_deltas, false)?;
         reject_lifecycle_retention_collisions(&sorted_untracked, &sorted_tracked)?;
 
-        let mut retired_untracked_json_refs = BTreeSet::new();
         for delta in &sorted_untracked {
-            apply_complete_hot_snapshot_delta(
-                &mut untracked_rows,
-                delta,
-                absence_guards,
-                &mut retired_untracked_json_refs,
-            )?;
+            apply_complete_hot_snapshot_delta(&mut untracked_rows, delta, absence_guards)?;
         }
         merge_final_untracked_rows(&mut rows, untracked_rows)?;
         for delta in &sorted_tracked {
-            apply_complete_hot_snapshot_delta(
-                &mut rows,
-                delta,
-                absence_guards,
-                &mut retired_untracked_json_refs,
-            )?;
+            apply_complete_hot_snapshot_delta(&mut rows, delta, absence_guards)?;
         }
 
         // A replacement generation cannot inherit a checkpoint baseline from
@@ -7818,12 +7792,6 @@ where
 
         stage_complete_collection_controls(self.writes, branch_id, generation, &rows)?;
         stage_complete_hot_rows(self.writes, branch_id, generation, rows);
-        JsonStoreWriter::stage_untracked_reclaim_candidates(
-            self.writes,
-            retired_untracked_json_refs
-                .into_iter()
-                .map(JsonRef::from_hash_bytes),
-        );
         *coverage = WorkingDiffIndexCoverage::default();
         Ok((
             HotTrackedSnapshot {
@@ -7844,7 +7812,6 @@ async fn stage_incremental_file_delete_cascades(
     working_diff_capture_checkpoint_commit_id: Option<CommitId>,
     reset_working_diff_baselines: bool,
     coverage: &mut WorkingDiffIndexCoverage,
-    retired_untracked_json_refs: &mut BTreeSet<[u8; JSON_REF_BYTES]>,
 ) -> Result<(), LixError> {
     let mut cascades = BTreeMap::<String, &CurrentStateDeltaRef<'_>>::new();
     for cascade in deltas {
@@ -7940,7 +7907,6 @@ async fn stage_incremental_file_delete_cascades(
         write_entity_pk(&mut mutations.key_bytes, &identity.entity_pk);
         let row_key = BufferRange::new(row_start, mutations.key_bytes.len() - row_start);
         if existing.untracked {
-            collect_hot_untracked_refs(existing, retired_untracked_json_refs);
             mutations.row_deletes.push(row_key);
             continue;
         }
@@ -8314,14 +8280,12 @@ fn reject_lifecycle_retention_collisions(
     Ok(())
 }
 
-#[allow(clippy::too_many_arguments)]
 fn apply_complete_hot_snapshot_delta(
     rows: &mut HotRowMap,
     delta: &CurrentStateDeltaRef<'_>,
     absence_guards: &BTreeSet<TrackedStateKey>,
-    retired_untracked_json_refs: &mut BTreeSet<[u8; JSON_REF_BYTES]>,
 ) -> Result<(), LixError> {
-    apply_complete_file_delete_cascade(rows, delta, retired_untracked_json_refs)?;
+    apply_complete_file_delete_cascade(rows, delta)?;
     let identity = HeadRowIdentity {
         schema_key: delta.schema_key.to_string(),
         entity_pk: delta.entity_pk.clone(),
@@ -8332,9 +8296,6 @@ fn apply_complete_hot_snapshot_delta(
         let existing = decode_head_value(previous)?;
         reject_guarded_live_member(absence_guards, delta, existing)?;
         reject_retention_change(delta, existing)?;
-        if existing.untracked {
-            collect_retired_untracked_json_refs(existing, delta, retired_untracked_json_refs);
-        }
     }
     if delta.physically_deletes() {
         rows.remove(&identity);
@@ -8358,7 +8319,6 @@ fn apply_complete_hot_snapshot_delta(
 fn apply_complete_file_delete_cascade(
     rows: &mut HotRowMap,
     delta: &CurrentStateDeltaRef<'_>,
-    retired_untracked_json_refs: &mut BTreeSet<[u8; JSON_REF_BYTES]>,
 ) -> Result<(), LixError> {
     let Some(file_id) = file_delete_cascade_id(delta)? else {
         return Ok(());
@@ -8377,7 +8337,6 @@ fn apply_complete_file_delete_cascade(
             continue;
         }
         if existing.untracked {
-            collect_hot_untracked_refs(existing, retired_untracked_json_refs);
             rows.remove(&identity);
             continue;
         }
@@ -9119,9 +9078,8 @@ fn stage_hot_bootstrap(
             ));
         }
     }
-    let mut retired_untracked_json_refs = BTreeSet::new();
     for delta in deltas {
-        apply_complete_file_delete_cascade(&mut rows, delta, &mut retired_untracked_json_refs)?;
+        apply_complete_file_delete_cascade(&mut rows, delta)?;
         let identity = HeadRowIdentity {
             schema_key: delta.schema_key.to_string(),
             entity_pk: delta.entity_pk.clone(),
@@ -9132,13 +9090,6 @@ fn stage_hot_bootstrap(
             let existing = decode_head_value(previous)?;
             reject_guarded_live_member(absence_guards, delta, existing)?;
             reject_retention_change(delta, existing)?;
-            if existing.untracked {
-                collect_retired_untracked_json_refs(
-                    existing,
-                    delta,
-                    &mut retired_untracked_json_refs,
-                );
-            }
         }
         if delta.physically_deletes() {
             rows.remove(&identity);
@@ -9166,12 +9117,6 @@ fn stage_hot_bootstrap(
     }
     stage_complete_collection_controls(writes, branch_id, generation, &rows)?;
     stage_complete_hot_rows(writes, branch_id, generation, rows);
-    JsonStoreWriter::stage_untracked_reclaim_candidates(
-        writes,
-        retired_untracked_json_refs
-            .into_iter()
-            .map(JsonRef::from_hash_bytes),
-    );
     *coverage = WorkingDiffIndexCoverage::default();
     Ok(())
 }
@@ -14923,7 +14868,6 @@ mod tests {
         let generation = CommitId::for_test_label("ordinary-import-generation");
         let mut writes = StorageWriteSet::new();
         let mut coverage = WorkingDiffIndexCoverage::default();
-        let mut retired_untracked_json_refs = BTreeSet::new();
         let explicit_index_builds = incremental_cascade_explicit_index_builds();
 
         stage_incremental_file_delete_cascades(
@@ -14935,7 +14879,6 @@ mod tests {
             None,
             false,
             &mut coverage,
-            &mut retired_untracked_json_refs,
         )
         .await
         .expect("ordinary imports do not need file-delete cascade staging");

--- a/packages/lix/src/live_state/tracked_head/hot.rs
+++ b/packages/lix/src/live_state/tracked_head/hot.rs
@@ -11456,6 +11456,7 @@ fn decode_hot_diff_key(bytes: &[u8]) -> Result<(CommitId, HeadIdentity), LixErro
     ))
 }
 
+#[cfg(test)]
 fn collect_hot_untracked_refs(value: HeadValueView<'_>, refs: &mut BTreeSet<[u8; JSON_REF_BYTES]>) {
     if !value.untracked {
         return;

--- a/packages/lix/src/registered_spaces.rs
+++ b/packages/lix/src/registered_spaces.rs
@@ -38,8 +38,6 @@
 use crate::storage_adapter::StorageSpace;
 
 pub const JSON_SPACE: StorageSpace = crate::json_store::JSON_SPACE;
-pub const UNTRACKED_JSON_RECLAIM_CANDIDATE_SPACE: StorageSpace =
-    crate::json_store::UNTRACKED_JSON_RECLAIM_CANDIDATE_SPACE;
 pub const TRACKED_STATE_TREE_CHUNK_SPACE: StorageSpace =
     crate::tracked_state::TRACKED_STATE_TREE_CHUNK_SPACE;
 pub const REPOSITORY_PROTOCOL_SPACE: StorageSpace = crate::init::REPOSITORY_PROTOCOL_SPACE;
@@ -110,7 +108,6 @@ mod tests {
     /// publishes the whole registry" a checked claim rather than a comment.
     const PUBLISHED: &[StorageSpace] = &[
         JSON_SPACE,
-        UNTRACKED_JSON_RECLAIM_CANDIDATE_SPACE,
         TRACKED_STATE_TREE_CHUNK_SPACE,
         REPOSITORY_PROTOCOL_SPACE,
         TRACKED_STATE_CHANGE_LOCATOR_SPACE,

--- a/packages/lix/src/storage_bench.rs
+++ b/packages/lix/src/storage_bench.rs
@@ -3124,8 +3124,6 @@ pub fn content_address_rule(space_id: u32) -> ContentAddressRule {
         0x0005_0003 => ContentAddressRule::BinaryCasChunkPayload,
         // json_store.json
         0x0002_0001 => ContentAddressRule::JsonStorePayload,
-        // json_store.untracked_reclaim_candidate.v1
-        0x0002_0002 => ContentAddressRule::ContentAddressedKeyOnlyMirror,
         // binary_cas.chunk_presence
         0x0005_0004 => ContentAddressRule::ContentAddressedKeyOnlyMirror,
         _ => ContentAddressRule::NotContentAddressed,

--- a/packages/lix/src/storage_spaces.rs
+++ b/packages/lix/src/storage_spaces.rs
@@ -23,7 +23,6 @@ use crate::storage_adapter::StorageSpaceId;
 /// checked against.
 pub(crate) const ALL_STORAGE_SPACES: &[StorageSpace] = &[
     crate::json_store::JSON_SPACE,
-    crate::json_store::UNTRACKED_JSON_RECLAIM_CANDIDATE_SPACE,
     crate::tracked_state::TRACKED_STATE_TREE_CHUNK_SPACE,
     crate::init::REPOSITORY_PROTOCOL_SPACE,
     crate::tracked_state::TRACKED_STATE_CHANGE_LOCATOR_SPACE,
@@ -74,6 +73,8 @@ pub(crate) const ALL_STORAGE_SPACES: &[StorageSpace] = &[
 pub(crate) const RETIRED_STORAGE_SPACE_IDS: &[StorageSpaceId] = &[
     // untracked_state.row.v1
     StorageSpaceId(0x0001_0002),
+    // json_store.untracked_reclaim_candidate.v1
+    StorageSpaceId(0x0002_0002),
     // live_state.index.branch_root.v1
     StorageSpaceId(0x0004_0005),
     // gc.reachability_delta.v1


### PR DESCRIPTION
Deletes `json_store.untracked_reclaim_candidate.v1` (`0x0002_0002`) — a storage space production **wrote on every qualifying commit and never once read**.

## The finding, re-verified on `claude-4-optimizations` (635890375)

| role | site | reachable in production? |
|---|---|---|
| writer | `live_state/tracked_head/hot.rs:7736` (incremental current-state staging) | **yes** |
| writer | `live_state/tracked_head/hot.rs:7821` (complete replacement generation) | **yes** |
| writer | `live_state/tracked_head/hot.rs:9169` (complete current-state staging) | **yes** |
| reader | `gc.rs:1414` `scan_untracked_reclaim_candidates` | no — inside `#[cfg(test)] stage_repository_gc_full_recovery` (`gc.rs:1342`) |
| deleter | `gc.rs:1440` `stage_delete_untracked_reclaim_candidates` | no — same test-only function |

`stage_repository_gc` and `stage_repository_gc_with_preconditions`, the two entry points ordinary maintenance
uses, never touch the space. So a repository accumulated a 32-byte key + 1-byte value hint for every distinct
out-of-band (>1 KiB) untracked JSON payload it ever retired, and nothing in a shipped build could ever read
that hint or reclaim the row. Monotonic, unbounded, and inert.

That also means the hints were **not** buying deferred reclamation of the JSON payloads themselves: the payload
delete they were supposed to authorize (`JsonStoreWriter::stage_delete_refs`) is likewise only reachable from
`#[cfg(test)]` code. The plane was pure write amplification.

## What is removed

- The space `UNTRACKED_JSON_RECLAIM_CANDIDATE_SPACE` / `..._NAMESPACE` / `..._VALUE` and its id from the registry.
- All three production writers, plus the whole `retired_untracked_json_refs` accumulator threaded through the
  hot-row staging paths — a `BTreeSet` allocation and a hash-collect pass on **every** current-state staging
  call, empty or not. `collect_retired_untracked_json_refs` (`live_state/tracked_head.rs`) is deleted outright.
- `scan_untracked_reclaim_candidates`, `stage_untracked_reclaim_candidates`,
  `stage_delete_untracked_reclaim_candidates`, and the `UntrackedJsonReclaimCandidate` type.
- The candidate-consumption block in `stage_repository_gc_full_recovery` and the four tests that only asserted
  candidate behaviour, plus their now-orphaned fixtures.
- The space's `ContentAddressRule` row in `storage_bench.rs`.

654 deletions, 16 insertions, no `#[allow(dead_code)]`.

`json_store::stage_delete_refs` (the corroborating finding) does **not** become fully dead — `gc.rs`'s
changelog sweep still calls it inside `#[cfg(test)] plan_and_stage_authority_gc` — so it stays, with its stale
comment about the write-only space corrected. Two items became test-only as a consequence and are now
`#[cfg(test)]` rather than deleted or allowed: `collect_hot_untracked_refs` and `context.rs`'s `JSON_REF_BYTES`.

## Retiring the id

Following the precedent #1333 set, `0x0002_0002` goes into `RETIRED_STORAGE_SPACE_IDS` rather than back into the
free pool, so no future space can be handed an id whose bytes still sit on disk in an existing repository.
`registered_spaces.rs`'s published handle is removed with it; the element-for-element mirror test
`the_published_handles_are_exactly_the_registry` and `every_declared_space_is_registered` both pass.

## Layout invariants

1. **Single authority** — removes a writer, adds none. The JSON store's content-addressed rows remain the one
   authority for payloads; this plane was a second, disconnected retention record with no reader.
2. **Commit canonicality** — untouched.
3. **Derived views are caches** — the space was disconnected retention metadata, exactly the shape (5) forbids.
4. **Atomic publication** — untouched; the removed writes were part of the same write set and simply stop.
5. **GC from refs** — improved. Repository GC now has no retention metadata outside the ref walk to drift from.
6. **SQL reads canonical records** — untouched; nothing queried this space.

## Numbers

Machine `hetzner-cpx62-II`. Base `claude-4-optimizations` @ `635890375`, candidate @ `26cce4e82`.

**No timing run.** Deleting writes that nothing reads cannot make anything slower; if a benchmark had moved, the
writes would have been load-bearing and this PR would be wrong.

Per-space physical growth, `cargo run -p lix_benchmarks --release --features storage-benches,slatedb --example
space_growth` (200 commits × 10 rows, RocksDB), 2 reps per arm. Byte counts are deterministic per the runbook,
so this is a 1-rep-class measurement; the second rep is there to separate signal from fixture noise.

| space | base bytes/commit | cand bytes/commit |
|---|---|---|
| `json_store.untracked_reclaim_candidate.v1` | **absent (0)** | **absent (0)** |
| `json_store.json` | 0.0 | 0.0 |
| `tracked_state.tree_chunk` | 440.7 / 441.2 | 440.5 / 441.1 |
| `repository.protocol.v1` | 0.0 | 0.0 |
| `tracked_state.change_locator.v2` | 0.0 | 0.0 |
| `live_state.hot_row.v21` | 2704.6 | 2704.6 |
| `live_state.hot_diff.v17` | 1150.0 | 1150.0 |
| `live_state.hot_diff_marker.v16` | 0.0 | 0.0 |
| `branch.head_control.v11` | 0.0 | 0.0 |
| `live_state.hot_collection_control.v1` | 0.0 | 0.0 |
| `tracked_state.commit_state_manifest.v7` | 290.6 | 290.6 |
| `tracked_state.commit_mutation_catalog.v1` | 963.2 / 961.3 | 964.8 / 962.2 |
| `changelog.commit` | 133.4 | 133.4 |
| `changelog.change` | 0.0 | 0.0 |
| `changelog.commit_change_id` | 36.0 | 36.0 |
| `lix.revision.v1` | 0.0 | 0.0 |

Every space is byte-identical across arms except `tree_chunk` and `commit_mutation_catalog`, which **also vary
rep-to-rep within each arm** (base `tree_chunk` 88522 → 88618 total bytes; cand 88490 → 88610) because the
fixture's ids are per-run. Their spread across reps exceeds the spread across arms, so that is the noise floor,
not a change.

### What the space actually cost — honest answer

**`space_growth` reports zero for it, and so would every other existing instrument.** The hint is only staged
when a retired untracked slot is *out-of-band*, i.e. a JSON payload above `JSON_INLINE_MAX_BYTES` (1024).
`space_growth` commits tracked rows; `expY_untracked_mutation_scaling` mutates untracked rows whose values are a
handful of bytes and therefore inline; `expv_blind_space_growth` sweeps commits/rows/branches/checkpoints/
idempotency/uploads and none of those axes retires a large untracked payload. No harness in the tree exercises
the write, so **there is no measured bytes-per-commit figure to report, and I did not build an instrument for
one.** The per-row cost is structural rather than measured: 4-byte space prefix + 32-byte BLAKE3 key + 1-byte
value = 37 physical bytes per distinct retired >1 KiB untracked payload, never reclaimed for the life of the
repository.

The cut therefore stands on category (2) of the acceptance gate — it removes an entire storage space and a
disconnected retention authority — with the numbers above showing it is not slower and costs no other plane a
byte.

## Gate

Full CI-scope on `hetzner-cpx62-II`, run twice: once at `086784850` before the PR, and again at `b82dd9f25`
after merging `origin/claude-4-optimizations` (`860123b2d`). Counts below are the **post-merge** run.

| command | result |
|---|---|
| `cargo check --workspace --all-targets --all-features` | ok, 0 warnings |
| `cargo clippy --workspace --all-targets --all-features -- -D warnings` | ok, 0 warnings |
| `cargo test --profile test --workspace --exclude lix_benchmarks --all-features --no-fail-fast` | ok — 40 target results retained in the log, **0 not-ok**. My own log filter truncated the head of the run, so the largest target was re-run on its own: `-p lix --all-features --lib` = **2089 passed, 0 failed, 8 ignored** |
| `cargo test --profile test -p lix_benchmarks --features storage-benches,slatedb,root-replay-trace --no-fail-fast` | ok — 10 targets, **26 passed, 0 failed, 7 ignored** |
| `cargo check -p lix --no-default-features` | ok |

No `error`, `FAILED`, `panicked` or `failures:` line appears anywhere in either gate log. The merge brought in
`transaction/types.rs` and `transaction/context.rs` changes from `860123b2d`; this PR does not touch either
file, and the merge was clean.

`rustfmt --check --config skip_children=true` on the eight touched files reports the same pre-existing diffs
that `635890375` already has (and two fewer, in regions this PR deleted) — no new formatting drift, and the
repo-wide fmt dirt was deliberately left alone.

`module_layers.rs`'s `ALLOWED_UPWARD_EDGES` is still empty; a deletion adds no edge and the guard agrees.
`transaction/types.rs` is untouched.
