### PR TITLE
fix(lix): repair stale live_state symbols in validation tests

### DIFF
--- a/packages/lix/src/transaction/validation.rs
+++ b/packages/lix/src/transaction/validation.rs
@@ -6612,7 +6612,7 @@ mod tests {
 
     async fn committed_delete_restriction_outcome(
         staged_rows: Vec<TestPreparedStateRow>,
-        committed_rows: Vec<MaterializedLiveStateRow>,
+        committed_rows: Vec<MaterializedHotStateRow>,
     ) -> Result<(), LixError> {
         let staged_writes = PreparedWriteSet {
             state_rows: PreparedStateBatch::from_test_rows(staged_rows),
@@ -6624,7 +6624,7 @@ mod tests {
             directory_descriptor_schema(),
         ])
         .expect("descriptor schemas should compile");
-        let live_state = StrictStaticLiveStateReader {
+        let hot_state = StrictStaticHotStateReader {
             rows: committed_rows,
         };
         let mut pending_constraints = PendingConstraintIndexes::default();
@@ -6633,7 +6633,7 @@ mod tests {
                 pending_constraints.remember_tombstone(row);
             }
         }
-        let input = TransactionValidationInput::new(&validation_set, &catalog, &live_state);
+        let input = TransactionValidationInput::new(&validation_set, &catalog, &hot_state);
         validate_committed_delete_restrictions(&input, &catalog, &pending_constraints).await
     }
 
@@ -6659,8 +6659,8 @@ mod tests {
         committed_delete_restriction_outcome(
             vec![directory_delete],
             vec![
-                MaterializedLiveStateRow::from(committed_directory),
-                MaterializedLiveStateRow::from(committed_file),
+                MaterializedHotStateRow::from(committed_directory),
+                MaterializedHotStateRow::from(committed_file),
             ],
         )
         .await
@@ -6685,8 +6685,8 @@ mod tests {
         let error = committed_delete_restriction_outcome(
             vec![directory_delete],
             vec![
-                MaterializedLiveStateRow::from(committed_directory),
-                MaterializedLiveStateRow::from(committed_child),
+                MaterializedHotStateRow::from(committed_directory),
+                MaterializedHotStateRow::from(committed_child),
             ],
         )
         .await
@@ -6729,21 +6729,21 @@ mod tests {
         let outcome = committed_delete_restriction_outcome(
             vec![directory_delete],
             vec![
-                MaterializedLiveStateRow::from(directory_descriptor_row(
+                MaterializedHotStateRow::from(directory_descriptor_row(
                     FK_SCOPE_DIRECTORY_ID,
                     None,
                     "docs",
                     FK_SCOPE_BRANCH_ID,
                 )),
                 // same branch, different parent directory
-                MaterializedLiveStateRow::from(file_descriptor_row_in_directory(
+                MaterializedHotStateRow::from(file_descriptor_row_in_directory(
                     FK_SCOPE_FILE_ID,
                     Some(other_directory),
                     "readme.md",
                     FK_SCOPE_BRANCH_ID,
                 )),
                 // same directory id, different branch
-                MaterializedLiveStateRow::from(file_descriptor_row_in_directory(
+                MaterializedHotStateRow::from(file_descriptor_row_in_directory(
                     "01920000-0000-7000-8000-0000000000f2",
                     Some(FK_SCOPE_DIRECTORY_ID),
                     "readme.md",
@@ -6778,13 +6778,13 @@ mod tests {
         let outcome = committed_delete_restriction_outcome(
             vec![directory_delete, file_delete],
             vec![
-                MaterializedLiveStateRow::from(directory_descriptor_row(
+                MaterializedHotStateRow::from(directory_descriptor_row(
                     FK_SCOPE_DIRECTORY_ID,
                     None,
                     "docs",
                     FK_SCOPE_BRANCH_ID,
                 )),
-                MaterializedLiveStateRow::from(file_descriptor_row_in_directory(
+                MaterializedHotStateRow::from(file_descriptor_row_in_directory(
                     FK_SCOPE_FILE_ID,
                     Some(FK_SCOPE_DIRECTORY_ID),
                     "readme.md",
@@ -6800,9 +6800,9 @@ mod tests {
         );
     }
 
-    fn fk_row_in_file(mut row: TestPreparedStateRow, file_id: &str) -> MaterializedLiveStateRow {
+    fn fk_row_in_file(mut row: TestPreparedStateRow, file_id: &str) -> MaterializedHotStateRow {
         row.file_id = Some(file_id.into());
-        MaterializedLiveStateRow::from(row)
+        MaterializedHotStateRow::from(row)
     }
 
     /// Simulates the "just widen the delete-side source domain" fix by running
@@ -6813,7 +6813,7 @@ mod tests {
         let file_f = "01920000-0000-7000-8000-0000000000f0";
         let file_g = "01920000-0000-7000-8000-0000000000f9";
 
-        let live_state = StrictStaticLiveStateReader {
+        let hot_state = StrictStaticHotStateReader {
             rows: vec![
                 fk_row_in_file(fk_parent_row("parent-1", branch_id), file_f),
                 fk_row_in_file(fk_parent_row("parent-1", branch_id), file_g),
@@ -6854,7 +6854,7 @@ mod tests {
         )]);
 
         validate_committed_normal_delete_restriction_batches(
-            &live_state,
+            &hot_state,
             &PendingConstraintIndexes::default(),
             batches,
         )


### PR DESCRIPTION
## What was broken

`256b22587` — the round-5 base, and also the current `origin/main` — **does not compile the `lix`
lib-test target**:

```
$ cargo build -p lix --features all-simulations --tests
error[E0433]: cannot find type `MaterializedLiveStateRow` in this scope
error[E0422]: cannot find struct, variant or union type `StrictStaticLiveStateReader`
error: could not compile `lix` (lib test) due to 14 previous errors
```

The `live_state` → `hot_state` rename (`60032d16e`, merged via #1360) updated the library but missed
the `#[cfg(test)]` module at the bottom of `packages/lix/src/transaction/validation.rs`. Fourteen
call sites there still name the pre-rename types.

## Why it survived

- `cargo check --workspace` **does not build test targets**, so the ordinary quick check is green.
- The library itself compiles, so every benchmark build is unaffected.
- Only `--all-targets` / `cargo test --no-run` / `clippy --all-targets` see it — i.e. exactly the
  CI-scope gate.

## Why it blocks the round

CI runs `cargo test --profile test --workspace --all-features`, and `all-simulations` is inside
`--all-features`. So the CI-scope correctness gate **cannot pass at the round-5 base**: every other
experiment this round hits this failure in its own gate and cannot distinguish it from its own
breakage. It also means the simulation suite behind `all-simulations` (the `tracked_state_rebuild`
variant of every `simulation_test!`) has not been able to build, let alone run.

## What changed

Mechanical rename inside the `#[cfg(test)] mod tests` block of
`packages/lix/src/transaction/validation.rs` only. No library code, no behaviour change, no
reformatting.

- `MaterializedLiveStateRow` → `MaterializedHotStateRow` (12 sites) — the type already lives at
  `packages/lix/src/hot_state/types.rs:26`.
- `StrictStaticLiveStateReader` → `StrictStaticHotStateReader` (2 sites) — the renamed test reader
  is already defined in this same test module at `validation.rs:4068` and used by ~7 other tests
  there; these two call sites were simply missed.
- The two local bindings `let live_state = …` → `let hot_state = …`, matching every other test in
  the file.

16 lines changed in one file. No new symbols, no deletions, no public API change.

## Verification (`ryzen-9950x-IV`, 32c/186G, branch head `adae3845f`)

The originally failing command:

```
cargo build -p lix --features all-simulations --tests     # Finished in 1m43s, 0 errors
```

### The simulation suite that had never been able to build: all green

`all-simulations` gates the `tracked_state_rebuild` variant of every `simulation_test!`
(`packages/lix/tests/integration/support/mod.rs:21`, `packages/lix/tests/integration/sql.rs:11`).
Because the lib-test target failed to compile, `cargo test -p lix --features all-simulations` could
not get as far as running them.

```
cargo test --profile test -p lix --features all-simulations --no-fail-fast
```

- 10 test targets, **0 failures**, 0 `error` lines.
- lib-test target (the one that was broken): 2101 passed, 0 failed, 8 ignored.
- integration target: 860 passed, 0 failed, 2 ignored.
- **391 `*_tracked_state_rebuild` simulation cases ran and passed**, including
  `constraint_fuzz::randomized_constraints_never_publish_partial_state_tracked_state_rebuild` and
  the `merge_fuzz` family. No corruption or partial-publication failures surfaced.

### Full CI-scope gate (from `git show origin/main:.github/workflows/ci.yml`)

| command | exit | result |
|---|---|---|
| `cargo check --workspace --all-targets --all-features` | 0 | clean |
| `cargo clippy --profile test --workspace --all-targets --all-features -- -D warnings` | 0 | 0 warnings |
| `cargo check -p lix --no-default-features` | 0 | clean |
| `cargo check -p lix_js_sdk --target wasm32-unknown-unknown` | 0 | clean |
| `cargo test --profile test --workspace --exclude lix_benchmarks --all-features --no-fail-fast` | 0 | 55 targets, **3469 passed / 0 failed** / 45 ignored |
| `cargo test --profile test -p lix_benchmarks --features storage-benches,slatedb,root-replay-trace --no-fail-fast` | 0 | 10 targets, **26 passed / 0 failed** / 7 ignored |

Full logs were captured to files and grepped for `failures:`, `panicked`, `test result: FAILED` and
`^error` — no hits in any log.

`rustfmt --edition 2024 --check` on the touched file reports the **identical 8 pre-existing
complaints** at `256b22587` and at this branch head (lines 1947, 4895, 4912, 4980, 4993, 5354, 5362,
7237 — all outside the edited region). Nothing was reformatted.

## This fix is also needed on `main`

`origin/main` carries the identical break. This PR targets `claude-5-optimizations` per the round's
process; the path onto `main` is left to the coordinator to arbitrate.

## Notes

- No changenote: `.changenotes/README.md` excludes test-only changes, and this touches nothing
  outside a `#[cfg(test)]` block.
- Not benchmarked: there is no runtime code in the diff to measure.
