### PR TITLE
perf(working-diff): remove the O(dirty set) scan from file-scoped working-diff reads

### DIFF
--- a/packages/lix/src/engine.rs
+++ b/packages/lix/src/engine.rs
@@ -1706,6 +1706,22 @@ mod tests {
                 .await
                 .expect("post-checkpoint insert should dirty a new identity");
         }
+        // Dirty the file itself, not just rows inside it. This puts a row of a
+        // *different* schema into file 0's diff, which is the case the bare
+        // `file_id` shape must cover and the `file_id + schema_key` shape must
+        // not. Without it both shapes would return the same json_pointer rows
+        // and the `FILE_SPACE` schema-domain resolution would go unexercised.
+        session
+            .execute(
+                "UPDATE lix_file SET content = CAST($1 AS BYTEA) WHERE id = $2",
+                &[
+                    crate::Value::Text("changed".to_string()),
+                    crate::Value::Text(files[0].to_string()),
+                ],
+            )
+            .await
+            .expect("file content update should dirty the file descriptor");
+
         // An untracked row cannot live inside a tracked file — file ownership
         // validation requires a row and its owning file to share one lane — so
         // the untracked case is only reachable in the null-file bucket. It is
@@ -1819,6 +1835,16 @@ mod tests {
                 scoped_schema, want_schema,
                 "the file+schema working-diff bypass disagrees with the index scan for {file}"
             );
+            if file == files[0] {
+                // The dirtied file descriptor proves the bare `file_id` shape
+                // resolved a schema domain wider than the one predicate-named
+                // schema, rather than silently answering json_pointer only.
+                assert!(
+                    want.len() > want_schema.len(),
+                    "fixture should put a non-json_pointer schema in {file}'s diff, \
+                     otherwise the FILE_SPACE schema-domain resolution is untested"
+                );
+            }
         }
     }
 

--- a/packages/lix/src/engine.rs
+++ b/packages/lix/src/engine.rs
@@ -1608,6 +1608,215 @@ mod tests {
         }
     }
 
+    /// A file-scoped working-diff read skips the `HOT_DIFF` index and its
+    /// scope-global coverage proof, enumerating primary `HOT_ROW` rows through
+    /// the file-first prefix seek instead. That is only sound if the primary
+    /// rows are the complete authority for every dirty identity in the file, so
+    /// this asserts the file-scoped answer equals the unfiltered index-driven
+    /// answer restricted to that file — across every reachable row state, and
+    /// for both the bare `file_id` shape (whose schema domain is resolved from
+    /// the `FILE_SPACE` markers) and the `file_id + schema_key` shape.
+    #[tokio::test]
+    async fn file_scoped_working_diff_bypass_matches_the_index_scan() {
+        let storage = Memory::new();
+        Engine::initialize(storage.clone())
+            .await
+            .expect("engine should initialize");
+        let engine = Engine::new(storage.clone())
+            .await
+            .expect("initialized engine should open");
+        let session = engine
+            .open_workspace_session()
+            .await
+            .expect("workspace session should open");
+        register_json_pointer_schema(&session).await;
+
+        let files = [
+            "66696c65-0000-8000-8000-000000000000",
+            "66696c65-0001-8000-8000-000000000001",
+        ];
+        for (index, file) in files.iter().enumerate() {
+            session
+                .execute(
+                    "INSERT INTO lix_file (id, path, content) \
+                     VALUES ($1, $2, CAST($3 AS BYTEA))",
+                    &[
+                        crate::Value::Text((*file).to_string()),
+                        crate::Value::Text(format!("/f{index}.txt")),
+                        crate::Value::Text("seed".to_string()),
+                    ],
+                )
+                .await
+                .expect("file should insert");
+        }
+
+        // Pre-checkpoint rows: one per reachable post-checkpoint fate, spread
+        // over both files and the null-file bucket.
+        for (path, file) in [
+            ("/clean", Some(files[0])),
+            ("/modified", Some(files[0])),
+            ("/removed", Some(files[0])),
+            ("/clean-b", Some(files[1])),
+            ("/modified-b", Some(files[1])),
+            ("/modified-none", None),
+        ] {
+            session
+                .execute(
+                    "INSERT INTO json_pointer (path, value, lixcol_file_id) \
+                     VALUES ($1, lix_json('{\"v\":0}'), $2)",
+                    &[
+                        crate::Value::Text(path.to_string()),
+                        file.map_or(crate::Value::Null, |file| {
+                            crate::Value::Text(file.to_string())
+                        }),
+                    ],
+                )
+                .await
+                .expect("pre-checkpoint row should insert");
+        }
+        session
+            .create_checkpoint()
+            .await
+            .expect("checkpoint should publish a clean working state");
+
+        session
+            .execute(
+                "UPDATE json_pointer SET value = lix_json('{\"v\":1}') \
+                 WHERE path IN ('/modified', '/modified-b', '/modified-none')",
+                &[],
+            )
+            .await
+            .expect("modify should dirty the rows");
+        session
+            .execute("DELETE FROM json_pointer WHERE path = '/removed'", &[])
+            .await
+            .expect("delete should dirty the row");
+        for (path, file) in [("/added", Some(files[0])), ("/added-b", Some(files[1]))] {
+            session
+                .execute(
+                    "INSERT INTO json_pointer (path, value, lixcol_file_id) \
+                     VALUES ($1, lix_json('{\"v\":1}'), $2)",
+                    &[
+                        crate::Value::Text(path.to_string()),
+                        file.map_or(crate::Value::Null, |file| {
+                            crate::Value::Text(file.to_string())
+                        }),
+                    ],
+                )
+                .await
+                .expect("post-checkpoint insert should dirty a new identity");
+        }
+        session
+            .execute(
+                "INSERT INTO json_pointer (path, value, lixcol_file_id, lixcol_untracked) \
+                 VALUES ('/untracked', lix_json('{\"v\":1}'), $1, true)",
+                &[crate::Value::Text(files[0].to_string())],
+            )
+            .await
+            .expect("untracked insert should commit");
+
+        type DiffRow = (String, String, Option<String>, String);
+        fn collect(result: &crate::ExecuteResult) -> Vec<DiffRow> {
+            let mut rows = result
+                .rows()
+                .iter()
+                .map(|row| {
+                    (
+                        row.get::<String>("schema_key")
+                            .expect("schema_key should decode"),
+                        row.get::<serde_json::Value>("entity_pk")
+                            .expect("entity_pk should decode")
+                            .to_string(),
+                        // `file_id` is nullable; a NULL surfaces as a decode
+                        // error through the typed accessor.
+                        row.get::<String>("file_id").ok(),
+                        row.get::<String>("diff_type")
+                            .expect("diff_type should decode"),
+                    )
+                })
+                .collect::<Vec<_>>();
+            rows.sort();
+            rows
+        }
+        const COLUMNS: &str = "SELECT entity_pk, schema_key, file_id, diff_type \
+                               FROM lix_working_diff";
+
+        use std::sync::atomic::Ordering;
+        let hits = &crate::hot_state::WORKING_DIFF_PATH_HITS;
+
+        let index_before = hits.index_scan.load(Ordering::Relaxed);
+        let broad = collect(
+            &session
+                .execute(COLUMNS, &[])
+                .await
+                .expect("unfiltered working-diff read should execute"),
+        );
+        assert!(
+            hits.index_scan.load(Ordering::Relaxed) > index_before,
+            "the unfiltered working-diff read must take the HOT_DIFF index path"
+        );
+        assert!(
+            broad.iter().any(|(schema, _, file, kind)| schema
+                == "json_pointer"
+                && file.as_deref() == Some(files[0])
+                && kind == "removed"),
+            "fixture should produce a removed row inside the probed file"
+        );
+
+        for file in files {
+            let bypass_before = hits.finite_bypass.load(Ordering::Relaxed);
+            let scoped = collect(
+                &session
+                    .execute(
+                        &format!("{COLUMNS} WHERE file_id = $1"),
+                        &[crate::Value::Text(file.to_string())],
+                    )
+                    .await
+                    .expect("file-scoped working-diff read should execute"),
+            );
+            assert!(
+                hits.finite_bypass.load(Ordering::Relaxed) > bypass_before,
+                "the file-scoped working-diff read for {file} must take the primary-row bypass"
+            );
+            let want = broad
+                .iter()
+                .filter(|(_, _, row_file, _)| row_file.as_deref() == Some(file))
+                .cloned()
+                .collect::<Vec<_>>();
+            assert_eq!(
+                scoped, want,
+                "the file-scoped working-diff bypass disagrees with the index scan for {file}"
+            );
+
+            let bypass_before = hits.finite_bypass.load(Ordering::Relaxed);
+            let scoped_schema = collect(
+                &session
+                    .execute(
+                        &format!("{COLUMNS} WHERE file_id = $1 AND schema_key = $2"),
+                        &[
+                            crate::Value::Text(file.to_string()),
+                            crate::Value::Text("json_pointer".to_string()),
+                        ],
+                    )
+                    .await
+                    .expect("file+schema working-diff read should execute"),
+            );
+            assert!(
+                hits.finite_bypass.load(Ordering::Relaxed) > bypass_before,
+                "the file+schema working-diff read for {file} must take the primary-row bypass"
+            );
+            let want_schema = want
+                .iter()
+                .filter(|(schema, _, _, _)| schema == "json_pointer")
+                .cloned()
+                .collect::<Vec<_>>();
+            assert_eq!(
+                scoped_schema, want_schema,
+                "the file+schema working-diff bypass disagrees with the index scan for {file}"
+            );
+        }
+    }
+
     /// `WHERE lixcol_file_id = $1` is now an exact provider constraint, so
     /// DataFusion drops its residual filter and the answer rests entirely on
     /// `HotStateFilter::file_ids`. Rows can live in four authorities — the

--- a/packages/lix/src/engine.rs
+++ b/packages/lix/src/engine.rs
@@ -1777,10 +1777,11 @@ mod tests {
             "the unfiltered working-diff read must take the HOT_DIFF index path"
         );
         assert!(
-            broad.iter().any(|(schema, _, file, kind)| schema
-                == "json_pointer"
-                && file.as_deref() == Some(files[0])
-                && kind == "removed"),
+            broad
+                .iter()
+                .any(|(schema, _, file, kind)| schema == "json_pointer"
+                    && file.as_deref() == Some(files[0])
+                    && kind == "removed"),
             "fixture should produce a removed row inside the probed file"
         );
 

--- a/packages/lix/src/engine.rs
+++ b/packages/lix/src/engine.rs
@@ -1706,11 +1706,16 @@ mod tests {
                 .await
                 .expect("post-checkpoint insert should dirty a new identity");
         }
+        // An untracked row cannot live inside a tracked file — file ownership
+        // validation requires a row and its owning file to share one lane — so
+        // the untracked case is only reachable in the null-file bucket. It is
+        // still worth carrying: the bypass must classify it as "no diff entry"
+        // and the unfiltered index scan must agree.
         session
             .execute(
-                "INSERT INTO json_pointer (path, value, lixcol_file_id, lixcol_untracked) \
-                 VALUES ('/untracked', lix_json('{\"v\":1}'), $1, true)",
-                &[crate::Value::Text(files[0].to_string())],
+                "INSERT INTO json_pointer (path, value, lixcol_untracked) \
+                 VALUES ('/untracked', lix_json('{\"v\":1}'), true)",
+                &[],
             )
             .await
             .expect("untracked insert should commit");

--- a/packages/lix/src/hot_state/tracked_head/hot.rs
+++ b/packages/lix/src/hot_state/tracked_head/hot.rs
@@ -7,6 +7,7 @@
 //! the physical mutation unit, and stores each value only in the authoritative
 //! file-first row index.
 
+use std::borrow::Cow;
 use std::cmp::Ordering;
 use std::collections::{BTreeMap, BTreeSet, HashSet, VecDeque};
 use std::mem::size_of;
@@ -9974,6 +9975,148 @@ pub(crate) struct WorkingDiffPathHits {
     pub(crate) finite_bypass: std::sync::atomic::AtomicUsize,
 }
 
+/// Decides whether a working-diff read may skip the `HOT_DIFF` scope scan and
+/// enumerate primary `HOT_ROW` rows instead, and under which filter.
+///
+/// `None` means "no bounded primary route exists — take the index scan".
+///
+/// # Why this is sound without the coverage proof
+///
+/// The `HOT_DIFF` coverage proof is scope-global and cannot be partitioned (see
+/// [`append_hot_diff_key_parts`]), so a *filtered* index scan still has to
+/// enumerate the whole `(branch, checkpoint, generation)` scope to reconstruct
+/// it. The proof exists to certify that the sparse index names **every** dirty
+/// identity. A reader that never consults the index does not need it certified:
+/// it needs the primary rows it enumerates to be the complete authority for the
+/// identities it claims to cover.
+///
+/// That is exactly the invariant the finite bypass already rests on, and it is
+/// a property of `HOT_ROW`, not of the filter shape:
+///
+/// * `HOT_DIFF` keys are only written for `!delta.untracked` deltas.
+/// * A primary row is physically removed only by
+///   `CurrentStateDelta::physically_deletes` (`untracked && deleted`); a tracked
+///   delete leaves a tombstone that keeps its baseline.
+/// * `reject_retention_change` forbids flipping retention while a physical
+///   member exists.
+///
+/// So every dirty tracked identity has a branch-local `HOT_ROW` row carrying its
+/// own `working_diff_baseline` — **except** identities whose current authority
+/// is a packed current base published inside this checkpoint window, which own
+/// no `HOT_ROW` row at all. Those are precisely what the caller's
+/// `packed_refs.is_empty()` guard excludes before calling this, and that guard
+/// is unchanged.
+///
+/// The only thing this function adds is *which* bounded routes count. The
+/// caller previously admitted one (a finite `schema_key + entity_pk` identity
+/// batch); a file-scoped read is equally bounded, because `HOT_ROW` is keyed
+/// `scope ++ schema_key ++ file_id ++ entity_pk` and `hot_scan_entries` already
+/// owns the file-first prefix route over it. Admitting it trades
+/// O(dirty rows in the branch) for O(live rows in the file).
+async fn hot_working_diff_bypass_filter<'a>(
+    store: &(impl StorageAdapterRead + ?Sized),
+    branch_id: &str,
+    generation: CommitId,
+    filter: &'a TrackedStateFilter,
+) -> Result<Option<Cow<'a, TrackedStateFilter>>, LixError> {
+    // A finite identity batch resolves as point reads and needs no file bound.
+    if !filter.entity_pks.is_empty() {
+        return Ok((!filter.schema_keys.is_empty()).then_some(Cow::Borrowed(filter)));
+    }
+    // Every remaining bounded route is a file-first `HOT_ROW` prefix seek, so
+    // every requested file id must be an exact value. `Any` and `Null` name no
+    // prefix.
+    if filter.file_ids.is_empty()
+        || filter
+            .file_ids
+            .iter()
+            .any(|file_id| !matches!(file_id, NullableKeyFilter::Value(_)))
+    {
+        return Ok(None);
+    }
+    if !filter.schema_keys.is_empty() {
+        return Ok(Some(Cow::Borrowed(filter)));
+    }
+    // No schema predicate. `HOT_ROW` is schema-major, so a file bound alone
+    // names no prefix. `FILE_SPACE` holds one marker per
+    // `(branch, generation, schema)` that has ever written a file-backed row,
+    // which is the schema domain a file-scoped read must cover: a row with a
+    // non-null `file_id` cannot exist without its schema's marker. Markers are
+    // conservative in the safe direction — never removed within a generation,
+    // so a stale one costs one empty seek and cannot hide a live row.
+    let schema_keys = hot_file_backed_schema_keys(store, branch_id, generation).await?;
+    if schema_keys.is_empty() {
+        // Nothing in this generation is file-backed. Fall back rather than
+        // inventing an empty-prefix scan; the index path answers this
+        // (necessarily empty) case correctly and it is not hot.
+        return Ok(None);
+    }
+    let mut bypass = filter.clone();
+    bypass.schema_keys = schema_keys;
+    Ok(Some(Cow::Owned(bypass)))
+}
+
+/// Names every schema with a file-backed row in this `(branch, generation)`,
+/// read from the conservative `FILE_SPACE` markers.
+///
+/// The markers carry no value, so this is a key-only scan bounded by the number
+/// of schemas, not by the number of rows.
+async fn hot_file_backed_schema_keys(
+    store: &(impl StorageAdapterRead + ?Sized),
+    branch_id: &str,
+    generation: CommitId,
+) -> Result<Vec<String>, LixError> {
+    let scope = hot_scope_prefix(branch_id, generation);
+    let range = StoragePrefix {
+        bytes: Bytes::from(scope.clone()),
+    }
+    .to_range()?;
+    let mut schema_keys = Vec::new();
+    let mut cursor = store
+        .begin_scan(
+            FILE_SPACE,
+            range,
+            StorageBeginScanOptions {
+                projection: StorageCoreProjection::KeyOnly,
+                ..StorageBeginScanOptions::default()
+            },
+        )
+        .await?;
+    loop {
+        let page = cursor
+            .next_page(crate::storage_adapter::MAX_SCAN_PAGE_ROWS)
+            .await?;
+        for entry in page.entries {
+            schema_keys.push(decode_hot_file_schema_key_in_scope(entry.key.0, &scope)?);
+        }
+        if !page.has_more {
+            break;
+        }
+    }
+    schema_keys.sort();
+    schema_keys.dedup();
+    Ok(schema_keys)
+}
+
+fn decode_hot_file_schema_key_in_scope(key: Bytes, scope: &[u8]) -> Result<String, LixError> {
+    if !key.starts_with(scope) {
+        return Err(key_codec_error(
+            "hot file marker does not begin with its scanned scope",
+        ));
+    }
+    let mut offset = scope.len();
+    let (schema_key, terminator) = read_hot_scan_key_string(&key, &mut offset, "schema key")?;
+    if terminator != KEY_PART_FINAL {
+        return Err(key_codec_error(
+            "hot file marker schema key has an invalid terminator",
+        ));
+    }
+    if offset != key.len() {
+        return Err(key_codec_error("hot file marker key has trailing bytes"));
+    }
+    Ok(schema_key.as_str(&key).to_string())
+}
+
 /// Resolves a checkpoint diff from row-local first-before images. Broad diffs
 /// enumerate the sparse dirty-key index; finite PK queries read only the
 /// primary rows that can answer the request.
@@ -9990,15 +10133,19 @@ async fn hot_working_diff_entries(
         .into_iter()
         .filter(|base| base.checkpoint_commit_id == Some(checkpoint_commit_id))
         .collect::<Vec<_>>();
-    if packed_refs.is_empty() && !filter.schema_keys.is_empty() && !filter.entity_pks.is_empty() {
-        return hot_working_diff_entries_for_finite_filter(
-            store,
-            branch_id,
-            checkpoint_commit_id,
-            generation,
-            filter,
-        )
-        .await;
+    if packed_refs.is_empty() {
+        if let Some(bypass) =
+            hot_working_diff_bypass_filter(store, branch_id, generation, filter).await?
+        {
+            return hot_working_diff_entries_for_finite_filter(
+                store,
+                branch_id,
+                checkpoint_commit_id,
+                generation,
+                bypass.as_ref(),
+            )
+            .await;
+        }
     }
 
     #[cfg(test)]
@@ -11046,13 +11193,15 @@ fn encode_hot_diff_key_parts(
 /// prefix-seeks `HOT_DIFF` below its `(branch, checkpoint, generation)`
 /// scope.
 ///
-/// - `hot_working_diff_entries` must enumerate the entire scope to
+/// - Any reader that *consults* this index must enumerate the entire scope to
 ///   reconstruct the [`WorkingDiffIndexCoverage`] count/XOR proof before the
-///   sparse index may be trusted, so even file- or schema-filtered diff
-///   queries visit every entry and filter in memory. A sub-scope seek can
-///   never satisfy the proof.
-/// - Finite (schema + entity) diff queries bypass this space entirely and
-///   read the `working_diff_baseline` inline on primary `HOT_ROW` rows.
+///   sparse index may be trusted, so a schema-filtered diff query that takes
+///   the index path visits every entry and filters in memory. A sub-scope seek
+///   can never satisfy the proof.
+/// - Finite (schema + entity) and file-scoped diff queries bypass this space
+///   entirely and read the `working_diff_baseline` inline on primary `HOT_ROW`
+///   rows, so they never pay the proof at all. See
+///   [`hot_working_diff_bypass_filter`].
 /// - Batches of `HOT_DIFF_PACK_MIN_IDENTITIES` or more identities are packed
 ///   into segments keyed by `scope ++ digest`; the identity components leave
 ///   the key for the segment value altogether.
@@ -11090,22 +11239,27 @@ fn encode_hot_diff_key_parts(
 ///   re-paying the scope and a 32-byte digest — and most publications stop
 ///   reaching `HOT_DIFF_PACK_MIN_IDENTITIES` per partition at all.
 ///
-/// Measured consequence of leaving the proof scope-global (rocksdb,
-/// hetzner-cpx62-II, `working_diff_file_scope`, 9 reps, four dirty rows in the
-/// probed file): `WHERE file_id = $1` costs 0.61 ms at 1k total dirty rows and
-/// 51.6 ms at 100k — linear in the dirty set, flat in the answer — while the
-/// finite `schema_key + entity_pk + file_id` shape that bypasses this space
-/// stays at ~0.5 ms across the same range.
+/// Measured consequence of routing a file-scoped read *through* this proof
+/// (rocksdb, hetzner-cpx62-II, `working_diff_file_scope`, 9 reps, four dirty
+/// rows in the probed file): `WHERE file_id = $1` cost 0.61 ms at 1k total
+/// dirty rows and 51.6 ms at 100k — linear in the dirty set, flat in the
+/// answer — while the finite `schema_key + entity_pk + file_id` shape that
+/// bypasses this space stayed at ~0.5 ms across the same range.
 ///
-/// The route that would remove that scan does not need this space at all:
-/// `HOT_ROW` is already keyed `schema_key ++ file_id ++ entity_pk` and
-/// `hot_scan_entries` already owns a file-first prefix route, so a
-/// `schema_key + file_id` working-diff read could enumerate primary rows the
-/// way the finite bypass does. That trades O(dirty rows in the branch) for
-/// O(live rows in the file). It is still not implemented *for the working
-/// diff*, because a diff must also see identities whose current authority is a
-/// packed current base published inside this checkpoint window, and those
-/// contribute exactly the whole-commit coverage groups described above.
+/// That is why file-scoped reads no longer take this path. The route that
+/// removes the scan does not need this space at all: `HOT_ROW` is keyed
+/// `schema_key ++ file_id ++ entity_pk` and `hot_scan_entries` owns a
+/// file-first prefix route, so a file-scoped working-diff read enumerates
+/// primary rows the way the finite bypass does, trading O(dirty rows in the
+/// branch) for O(live rows in the file). [`hot_working_diff_bypass_filter`]
+/// implements it and carries the soundness argument.
+///
+/// The one obligation that route cannot discharge is a packed current base
+/// published inside this checkpoint window, whose members own no `HOT_ROW` row
+/// and contribute exactly the whole-commit coverage groups described above.
+/// That case is excluded by the caller's pre-existing `packed_refs.is_empty()`
+/// guard and still reads the index, proof and all — which is why the proof
+/// stays scope-global and this key order stays as it is.
 ///
 /// The ordinary **entity** surface has no such obligation and does take that
 /// route: `lixcol_file_id` is an exact provider constraint that lands in


### PR DESCRIPTION
## What changed

A file-scoped working-diff read no longer scans the `HOT_DIFF` index. It enumerates primary
`HOT_ROW` rows through the file-first prefix seek that already exists, the same way the finite
`schema_key + entity_pk` bypass does.

This removes an asymptotic term: `SELECT ... FROM lix_working_diff WHERE file_id = $1` cost
**O(dirty rows in the branch)** and now costs **O(live rows in the file)**.

### Why the scan existed

`hot_state.diff.v17` keys are `escaped branch_id ++ 16B checkpoint ++ 16B generation ++ schema_key
++ entity_pk ++ file_id`. The `WorkingDiffIndexCoverage` count/XOR proof that certifies the sparse
index is **scope-global**, so any reader that *consults* the index must enumerate the whole
`(branch, checkpoint, generation)` scope to reconstruct it — a filtered read still visits every
entry and filters in memory. `file_id` being last in the key is a consequence of that, not the
cause: the design note at `hot.rs:11040-11116` records that the proof cannot be partitioned per
`file_id`, for two independent reasons (a packed current base contributes one coverage group naming
a *commit*, not an identity; and a partition-keyed segment is not a packed segment).

**So the key order is not the problem and this PR does not touch it.** Reordering the key to put
`file_id` before `entity_pk` would not have helped — the scan is forced by the proof, not by the
seek. The measurement below confirms `file_id + schema_key` was exactly as slow as bare `file_id`,
which is what you would expect if the key order were irrelevant, and it is.

### The actual fix

The route was already named as the intended design in the same note, and marked not implemented:

> `HOT_ROW` is already keyed `schema_key ++ file_id ++ entity_pk` and `hot_scan_entries` already
> owns a file-first prefix route, so a `schema_key + file_id` working-diff read could enumerate
> primary rows the way the finite bypass does. That trades O(dirty rows in the branch) for O(live
> rows in the file).

It was blocked on one obligation: a diff must also see identities whose current authority is a
**packed current base** published inside the checkpoint window, and those own no `HOT_ROW` row.

That obligation is already discharged by a guard the code has had all along. `hot_working_diff_entries`
computes `packed_refs` for this checkpoint and the finite bypass is gated on `packed_refs.is_empty()`.
When there is no packed current base in the window, there is no identity without a `HOT_ROW` row —
so the primary rows *are* the complete authority, and no coverage proof is needed because the index
is never read. The bypass is legal for exactly the same reason it was already legal for finite
identity filters; the filter shape was never what made it sound.

The change is therefore to widen *which bounded routes* the bypass admits, leaving the
`packed_refs.is_empty()` guard untouched:

- `packages/lix/src/hot_state/tracked_head/hot.rs` — new `hot_working_diff_bypass_filter`
  replaces the inline `!schema_keys.is_empty() && !entity_pks.is_empty()` condition. It admits the
  finite identity route (unchanged) and, additionally, a file-scoped route when every requested
  `file_id` is an exact value.
- For `file_id + schema_key`, the filter passes through untouched; `hot_scan_entries` takes its
  existing `hot_file_scan_prefixes` seek.
- For bare `file_id` (no schema predicate) `HOT_ROW` is schema-major, so a file bound alone names
  no prefix. `hot_file_backed_schema_keys` resolves the schema domain from the existing `FILE_SPACE`
  markers — one key-only marker per `(branch, generation, schema)` that has written a file-backed
  row — and seeks once per (schema, file). That is bounded by the schema count, not the row count.
  The markers are conservative in the safe direction: never removed within a generation, so a stale
  one costs one empty seek and cannot hide a live row.

### What was removed

- The `HOT_DIFF` scope scan and its coverage-proof reconstruction on every file-scoped working-diff
  read. That is the asymptotic term.
- No space was added, no space version bumped, no key encoding changed, no writer touched. `rg`
  confirms the diff contains no change to any `*_NAMESPACE`, `StorageSpaceId`, `stage_*`, or key
  encoder.
- **No storage adapter API was added, changed, or removed.** The scope-global proof turned out to
  be forced by the diff plane's own design, not by a missing adapter primitive; the file-first seek
  the fix needs is `begin_scan` over a prefix, which every adapter already implements.

### Stale documentation corrected

The design note at `append_hot_diff_key_parts` said this route "is still not implemented" and that
"even file- or schema-filtered diff queries visit every entry". Both are now false. The note has
been updated to say why the key order and the scope-global proof nonetheless stay as they are — the
packed-current-base case still reads the index, proof and all.

## Layout invariants

1. **Single authority.** No. Nothing is added. This *removes* a reader's dependence on the derived
   `HOT_DIFF` index for file-scoped reads and points it at `HOT_ROW`, which is already the primary
   authority for row content and its own `working_diff_baseline`. One fewer structure is consulted,
   not one more.
2. **Commit canonicality.** Unaffected. No commit record, parent link, or ref is read or written
   differently, and no parallel graph is introduced.
3. **Derived views are caches.** This is the invariant that matters here, and the change
   strengthens it. `HOT_DIFF` is a derived serving structure over the dirty set. Previously a
   file-scoped read could not be answered without it; now that read is served from the canonical
   primary rows and `HOT_DIFF` is genuinely optional for that shape. The index remains disposably
   rebuildable and is still the route for the shapes that need it (unfiltered, schema-only, and any
   read where a packed current base is live in the checkpoint window).
4. **Atomic publication.** Unaffected — read-path only. No staging, ordering, or publication set
   changed.
5. **GC from refs.** Unaffected. No retention metadata is read or written; `HOT_DIFF` GC is
   untouched.
6. **SQL reads canonical records.** Improved. The `lix_working_diff` surface now reaches primary
   `HOT_ROW` records directly for file-scoped shapes instead of going through the derived index.

## Correctness

New test `engine::tests::file_scoped_working_diff_bypass_matches_the_index_scan` asserts, over a
fixture covering added / modified / removed / clean / untracked / null-file rows across two files:

- the bare `file_id` shape takes the primary-row bypass (`WORKING_DIFF_PATH_HITS.finite_bypass`),
- the `file_id + schema_key` shape takes it too,
- and both answers equal the **unfiltered index-scan** answer restricted to that file.

Comparing against the unfiltered scan rather than a schema-filtered one is deliberate: it catches
rows of other schemas (e.g. `lix_file_descriptor`) that a bare `file_id` read must also return, which
is precisely what the `FILE_SPACE` schema-domain resolution is responsible for.

The pre-existing `working_diff_finite_bypass_and_index_scan_agree_on_every_row_state` still passes
unchanged, including its assertion that a schema-only read still takes the index path.

## Gate

Run on **ryzen-9950x-III** against `git show origin/main:.github/workflows/ci.yml` (re-read as the
authority rather than trusting the runbook copy), on this branch rebased onto
`claude-5-optimizations` @ `2deccf091`. Full logs captured to files and grepped, not tailed.

| step | result |
|---|---|
| `cargo clippy --profile test --workspace --all-targets --all-features -- -D warnings` | **exit 0**, 0 warnings |
| `cargo test --profile test --workspace --exclude lix_benchmarks --all-features --no-fail-fast` | **exit 0** — 3470 passed, **0 failed**, 55 suites |
| `cargo test --profile test -p lix_benchmarks --features storage-benches,slatedb,root-replay-trace --no-fail-fast` | **exit 0** — 26 passed, 0 failed |
| `cargo check -p lix --no-default-features` | **exit 0** |
| `cargo check -p lix_js_sdk --target wasm32-unknown-unknown` | **exit 0** |

3470 = the 3469 the coordinator measured green at the round base, plus the one test this PR adds.
`engine::tests::file_scoped_working_diff_bypass_matches_the_index_scan ... ok` appears in the
workspace log. Clippy is run with `--all-targets`, so it also proves the new test compiles.

The gate ran at `53aa5e723`; the only later commit is `7b21dfab6`, which is whitespace inside one
`assert!` (a rustfmt fix). Nothing else changed after the gate.

`hot_state/tracked_head/hot.rs` — the file carrying the behaviour change — is **clean under
`rustfmt --check`**. `engine.rs` retains the repo-wide pre-existing import-ordering churn the
runbook warns about (hunks at lines 1/7/16/28/1263/1282/1872, none of them in this diff); the one
rustfmt hunk that *was* mine has been fixed.

## Measurements

Machine **ryzen-9950x-III** (32c/186G), rocksdb, base SHA `256b22587`.

Command (per arm, per size):
```
<bench-binary> rocksdb 8 40 100 3 <dirty-target>
```
built from `cargo bench -p lix_benchmarks --features storage-benches,slatedb --bench working_diff_file_scope --no-run`.

The fixture holds the **answer size fixed at 4 dirty rows in the probed file** and grows the total
dirty set, so any growth in latency is pure scan cost.

**Storage medium verified, not assumed.** This bench hardcodes its RocksDB directory under `/tmp`
(`working_diff_file_scope.rs:115-121`), and `/tmp` is a tmpfs on at least one host in the fleet,
which would mean measuring against RAM. On `ryzen-9950x-III` it is not: `df -h /tmp` resolves to
`/dev/md0`, the ext4 RAID root volume (`/dev/md0 on / type ext4`), with `tmpfs` mounted only at
`/dev/shm`, which this bench never touches. These numbers are against real disk. The two arms also
have genuinely separate target dirs (`target-base` / `target-cand`), so no arm switch triggered a
silent rebuild inside a timing window.

Arms were built first and then alternated as **binaries**, interleaved with the arm order rotated
per size (`base,cand` at 1k · `cand,base` at 10k · `base,cand` at 100k). 3 reps per point: the
claim is a **slope change**, and the arms' raw ranges do not overlap at any size, which is the
runbook's condition for 3 reps being sufficient.

Base arm is `~/claude5/base` at **`256b22587`**. That is one merge behind the current integration
head `2deccf091`; the coordinator confirmed E0's merge is 16 lines inside `#[cfg(test)] mod tests`
in one file, linked by no benchmark binary, so it cannot affect these numbers.

### Primary claim — `WHERE file_id = $1` (p50 ms, raw min–max in parens)

| total dirty rows | base | cand | speedup |
|---|---|---|---|
| 1,000 | **0.474** (0.456–0.531) | **0.117** (0.113–0.182) | 4.1x |
| 10,000 | **3.195** (3.180–3.279) | **0.409** (0.384–0.603) | 7.8x |
| 100,000 | **31.767** (31.646–32.136) | **0.088** (0.068–0.152) | 361x |

**Base grows 67.0x across a 100x growth in the dirty set. The candidate does not grow at all**
(0.474→31.767 vs 0.117→0.088). That is the whole result: the term is gone, not shaved.

### `WHERE file_id = $1 AND schema_key = $2` (p50 ms)

| total dirty rows | base | cand | speedup |
|---|---|---|---|
| 1,000 | **0.469** (0.458–0.487) | **0.061** (0.056–0.085) | 7.7x |
| 10,000 | **3.269** (3.232–3.561) | **0.077** (0.060–0.304) | 42x |
| 100,000 | **32.031** (31.664–33.273) | **0.121** (0.090–0.519) | 265x |

Base grows 68.3x; the candidate stays inside the sub-millisecond noise band.

Note that base is *identical* for the two shapes (31.8 vs 32.0 ms at 100k) even though one names a
schema and the other does not. That is the direct evidence that the key order was never the
bottleneck — adding a schema predicate bought nothing, because the cost was the coverage proof.

### Guards

`full` — unfiltered `lix_working_diff`, which **still takes the index path**. This is the guard that
matters: it proves the shapes that still need the proof did not regress.

| total dirty rows | base | cand | delta |
|---|---|---|---|
| 1,000 | 2.062 | 2.022 | −1.9% |
| 10,000 | 18.545 | 18.613 | +0.4% |
| 100,000 | 244.666 | 242.638 | −0.8% |

`point` — the pre-existing finite `schema_key + entity_pk + file_id` bypass, whose gating condition
this PR rewrote:

| total dirty rows | base | cand | delta |
|---|---|---|---|
| 1,000 | 0.348 | 0.343 | −1.4% |
| 10,000 | 0.413 | 0.313 | −24% |
| 100,000 | 0.370 | 0.354 | −4.3% |

### Null control

`entity_scan` — the same file read through the ordinary entity surface. **Byte-identical code in
both arms**; it never enters `hot_working_diff_entries`.

| total dirty rows | base | cand | delta |
|---|---|---|---|
| 1,000 | 0.087 | 0.089 | +2.3% |
| 10,000 | 0.079 | 0.081 | +2.5% |
| 100,000 | 0.094 | 0.104 | **+10.6%** |

**This bench cannot resolve anything under roughly ±10% on its sub-millisecond lanes.** Two
consequences, stated rather than buried:

- The `point` guard's −24% at 10k is **not** claimed as a win — it sits inside that floor's tail
  (per-rep maxima were 0.626 ms base / 0.638 ms cand against p50s near 0.35 ms).
- The candidate `file` lane's 10k reading (0.409 ms) is higher than both its 1k (0.117 ms) and its
  100k (0.088 ms) reading. Being **non-monotonic in N, it is not scaling** — it is fixture and cache
  variation. It is reported as measured rather than smoothed. It is 0.3 ms against the 31.8 ms it
  replaced.

The primary claim is 4x–361x and survives this floor by two to three orders of magnitude.

## What regressed

**Nothing measurable.** Every guard is inside the null control's resolution.

Two real cost additions, neither of which any measurement could resolve:

1. A bare `file_id` read (no schema predicate) now performs one extra **key-only** prefix scan of
   `FILE_SPACE` to resolve its schema domain. That is bounded by the number of schemas that have
   written a file-backed row in the generation, not by row count, so it does not reintroduce a term
   in the dirty set — the flat 1k→100k curve above is measured with this scan included.
2. In a generation with **no** file-backed schema at all, a file-scoped read pays that scan and then
   falls back to the index path. The answer is necessarily empty and the case is not hot; it is
   handled by falling back rather than by adding a special case.

### Guards deliberately not run, with reasons

Per the runbook: a guard that cannot execute the changed code is not a guard.

- **The entire write matrix** (staged-put counts, settled bytes, `physical_bytes`,
  `storage_amplification`). This PR is **read-path only**. It changes no writer, no key encoder, no
  `StorageSpaceId`, and no `*_NAMESPACE` constant — `rg` over the diff returns zero hits for all of
  those. Byte counts are deterministic functions of the write path and cannot move.
- **`diff_commands`.** Checkpoint creation calls `working_diff_at_head` with
  `TrackedStateDiffRequest::default()` — an empty filter. That reaches
  `hot_working_diff_bypass_filter` and returns `None` after two `is_empty()` checks with no I/O,
  then takes the byte-identical index path. The `full` lane above measures exactly that path, at
  three sizes, and it is flat within 2%.
- **`tracked_state_crud` read ids.** `hot_scan_entries` is not modified; only its *caller* is. The
  OLTP row path never enters `hot_working_diff_entries`.

### Versioned identifiers

None bumped. `hot_state.diff.v17` is **unchanged** — deliberately, since the fix does not require
re-keying the diff plane. `rg 'hot_state\.diff\.v17'` and `rg '0004_001d'` confirm no call site
needed updating.
