### PR TITLE
fix(hot_state): certified-manifest scans silently truncated at 1024 rows

### DIFF
--- a/packages/engine-benchmarks/benches/changelog_history_append.rs
+++ b/packages/engine-benchmarks/benches/changelog_history_append.rs
@@ -387,9 +387,9 @@ impl StorageScanSource for CountingScanSource<'_> {
         limit_rows: usize,
     ) -> std::pin::Pin<Box<dyn Future<Output = Result<ScanChunk, StorageError>> + Send + '_>> {
         Box::pin(async move {
-            let chunk = self.inner.next_page(limit_rows).await?;
+            let (chunk, chunk_has_more) = self.inner.next_page(limit_rows).await?.into_parts();
             let mut stats = self.stats.lock().expect("io stats mutex");
-            stats.scan_rows += chunk.entries.len() as u64;
+            stats.scan_rows += chunk.len() as u64;
             stats.scan_value_bytes += chunk
                 .entries
                 .iter()

--- a/packages/engine-benchmarks/benches/changelog_history_append.rs
+++ b/packages/engine-benchmarks/benches/changelog_history_append.rs
@@ -391,7 +391,6 @@ impl StorageScanSource for CountingScanSource<'_> {
             let mut stats = self.stats.lock().expect("io stats mutex");
             stats.scan_rows += chunk.len() as u64;
             stats.scan_value_bytes += chunk
-                .entries
                 .iter()
                 .map(|entry| projected_value_bytes(&entry.value) as u64)
                 .sum::<u64>();

--- a/packages/engine-benchmarks/benches/changelog_history_append.rs
+++ b/packages/engine-benchmarks/benches/changelog_history_append.rs
@@ -395,7 +395,7 @@ impl StorageScanSource for CountingScanSource<'_> {
                 .map(|entry| projected_value_bytes(&entry.value) as u64)
                 .sum::<u64>();
             drop(stats);
-            Ok(chunk)
+            Ok(ScanChunk::new(chunk, chunk_has_more))
         })
     }
 }

--- a/packages/engine-benchmarks/benches/large_blob_updates.rs
+++ b/packages/engine-benchmarks/benches/large_blob_updates.rs
@@ -568,11 +568,11 @@ where
         .await
         .expect("begin accounting scan");
     loop {
-        let page = cursor
+        let (page, page_has_more) = cursor
             .next_page(MAX_SCAN_PAGE_ROWS)
             .await
-            .expect("scan accounting space");
-        accounting.rows += page.entries.len() as u64;
+            .expect("scan accounting space").into_parts();
+        accounting.rows += page.len() as u64;
         accounting.value_bytes += page
             .entries
             .iter()
@@ -581,7 +581,7 @@ where
                 ProjectedValue::FullValue(value) => value.len() as u64,
             })
             .sum::<u64>();
-        if !page.has_more {
+        if !page_has_more {
             break;
         }
     }

--- a/packages/engine-benchmarks/benches/large_blob_updates.rs
+++ b/packages/engine-benchmarks/benches/large_blob_updates.rs
@@ -574,7 +574,6 @@ where
             .expect("scan accounting space").into_parts();
         accounting.rows += page.len() as u64;
         accounting.value_bytes += page
-            .entries
             .iter()
             .map(|entry| match &entry.value {
                 ProjectedValue::KeyOnly => 0,

--- a/packages/engine-benchmarks/benches/merge_base_scale.rs
+++ b/packages/engine-benchmarks/benches/merge_base_scale.rs
@@ -211,7 +211,7 @@ impl StorageScanSource for CountingScanSource<'_> {
                 .map(|entry| projected_value_len(&entry.value) as u64)
                 .sum::<u64>();
             drop(stats);
-            Ok(chunk)
+            Ok(ScanChunk::new(chunk, chunk_has_more))
         })
     }
 }

--- a/packages/engine-benchmarks/benches/merge_base_scale.rs
+++ b/packages/engine-benchmarks/benches/merge_base_scale.rs
@@ -203,9 +203,9 @@ impl StorageScanSource for CountingScanSource<'_> {
         limit_rows: usize,
     ) -> std::pin::Pin<Box<dyn Future<Output = Result<ScanChunk, StorageError>> + Send + '_>> {
         Box::pin(async move {
-            let chunk = self.inner.next_page(limit_rows).await?;
+            let (chunk, chunk_has_more) = self.inner.next_page(limit_rows).await?.into_parts();
             let mut stats = self.stats.lock().expect("I/O stats mutex");
-            stats.scan_entries += chunk.entries.len() as u64;
+            stats.scan_entries += chunk.len() as u64;
             stats.scan_value_bytes += chunk
                 .entries
                 .iter()

--- a/packages/engine-benchmarks/benches/merge_base_scale.rs
+++ b/packages/engine-benchmarks/benches/merge_base_scale.rs
@@ -207,7 +207,6 @@ impl StorageScanSource for CountingScanSource<'_> {
             let mut stats = self.stats.lock().expect("I/O stats mutex");
             stats.scan_entries += chunk.len() as u64;
             stats.scan_value_bytes += chunk
-                .entries
                 .iter()
                 .map(|entry| projected_value_len(&entry.value) as u64)
                 .sum::<u64>();

--- a/packages/engine-benchmarks/benches/storage_v2.rs
+++ b/packages/engine-benchmarks/benches/storage_v2.rs
@@ -2008,15 +2008,11 @@ where
         .await?;
 
     loop {
-        let chunk = cursor.next_page(MAX_SCAN_PAGE_ROWS).await?;
-        let has_more = chunk.has_more;
-        entries.extend(chunk.entries);
+        let (page, has_more) = cursor.next_page(MAX_SCAN_PAGE_ROWS).await?.into_parts();
+        entries.extend(page);
 
         if !has_more {
-            return Ok(ScanChunk {
-                entries,
-                has_more: false,
-            });
+            return Ok(ScanChunk::new(entries, false));
         }
     }
 }

--- a/packages/engine-benchmarks/benches/storage_v2.rs
+++ b/packages/engine-benchmarks/benches/storage_v2.rs
@@ -1531,8 +1531,9 @@ where
                         rows as usize + 1,
                     ))
                     .expect("direct full-value scan");
-                    assert_eq!(chunk.entries.len(), rows as usize);
-                    assert!(!chunk.has_more);
+                    let (chunk_entries, chunk_has_more) = chunk.into_parts();
+                    assert_eq!(chunk_entries.len(), rows as usize);
+                    assert!(!chunk_has_more);
                     drop(read);
                     black_box(chunk_entries);
                 });
@@ -1555,8 +1556,9 @@ where
                     let chunk =
                         block_on(materialize_complete_storage_scan(&read, scan_range.clone()))
                             .expect("direct small-value full scan");
-                    assert_eq!(chunk.entries.len(), rows as usize);
-                    assert!(!chunk.has_more);
+                    let (chunk_entries, chunk_has_more) = chunk.into_parts();
+                    assert_eq!(chunk_entries.len(), rows as usize);
+                    assert!(!chunk_has_more);
                     drop(read);
                     black_box(chunk_entries);
                 });

--- a/packages/engine-benchmarks/benches/storage_v2.rs
+++ b/packages/engine-benchmarks/benches/storage_v2.rs
@@ -1499,10 +1499,11 @@ where
                         1_001,
                     ))
                     .expect("direct materialized scan");
-                    assert_eq!(chunk.entries.len(), 1_000);
-                    assert!(!chunk.has_more);
+                    let (chunk_entries, chunk_has_more) = chunk.into_parts();
+                    assert_eq!(chunk_entries.len(), 1_000);
+                    assert!(!chunk_has_more);
                     drop(read);
-                    black_box(chunk);
+                    black_box(chunk_entries);
                 });
             });
         }
@@ -1533,7 +1534,7 @@ where
                     assert_eq!(chunk.entries.len(), rows as usize);
                     assert!(!chunk.has_more);
                     drop(read);
-                    black_box(chunk);
+                    black_box(chunk_entries);
                 });
             });
         }
@@ -1557,7 +1558,7 @@ where
                     assert_eq!(chunk.entries.len(), rows as usize);
                     assert!(!chunk.has_more);
                     drop(read);
-                    black_box(chunk);
+                    black_box(chunk_entries);
                 });
             });
         }

--- a/packages/engine-benchmarks/benches/storage_v2.rs
+++ b/packages/engine-benchmarks/benches/storage_v2.rs
@@ -1810,16 +1810,16 @@ where
         .map_err(|error| error.to_string())?;
 
     loop {
-        let result = cursor
+        let (result, result_has_more) = cursor
             .next_page(chunk_size)
             .await
-            .map_err(|error| error.to_string())?;
+            .map_err(|error| error.to_string())?.into_parts();
 
-        scanned += result.entries.len();
-        chunks += usize::from(!result.entries.is_empty() || result.has_more);
-        keys.extend(result.entries.into_iter().map(|entry| entry.key));
+        scanned += result.len();
+        chunks += usize::from(!result.is_empty() || result_has_more);
+        keys.extend(result.into_iter().map(|entry| entry.key));
 
-        if !result.has_more {
+        if !result_has_more {
             break;
         }
     }
@@ -1882,15 +1882,15 @@ where
     }
 
     loop {
-        let chunk = cursor.next_page(chunk_size).await?;
+        let (chunk, chunk_has_more) = cursor.next_page(chunk_size).await?.into_parts();
 
-        let entries = &chunk.entries;
+        let entries = &chunk;
         stats.scanned += entries.len();
         stats.storage_calls += 1;
-        stats.chunks += usize::from(!entries.is_empty() || chunk.has_more);
+        stats.chunks += usize::from(!entries.is_empty() || chunk_has_more);
         stats.read_stats.storage_calls += 1;
         stats.read_stats.scan_rows += entries.len() as u64;
-        stats.read_stats.scan_has_more += u64::from(chunk.has_more);
+        stats.read_stats.scan_has_more += u64::from(chunk_has_more);
         stats.read_stats.scan_limit_rows_total += effective_chunk as u64;
         stats.read_stats.scan_limit_rows_max = stats
             .read_stats
@@ -1903,7 +1903,7 @@ where
             stats.read_stats.range_scan_chunks += 1;
         }
 
-        if !chunk.has_more {
+        if !chunk_has_more {
             break;
         }
     }

--- a/packages/engine-benchmarks/benches/tracked_state_crud/kv_layout.rs
+++ b/packages/engine-benchmarks/benches/tracked_state_crud/kv_layout.rs
@@ -444,12 +444,10 @@ where
 
         rows += page.len() as u64;
         key_bytes += page
-            .entries
             .iter()
             .map(|entry| entry.key.0.len() as u64 + 4)
             .sum::<u64>();
         value_bytes += page
-            .entries
             .iter()
             .map(|entry| match &entry.value {
                 ProjectedValue::KeyOnly => 0,

--- a/packages/engine-benchmarks/benches/tracked_state_crud/kv_layout.rs
+++ b/packages/engine-benchmarks/benches/tracked_state_crud/kv_layout.rs
@@ -374,12 +374,12 @@ where
         .expect("begin row scan");
     let mut rows = 0usize;
     loop {
-        let page = cursor
+        let (page, page_has_more) = cursor
             .next_page(MAX_SCAN_PAGE_ROWS)
             .await
-            .expect("scan rows");
-        rows += page.entries.len();
-        if !page.has_more {
+            .expect("scan rows").into_parts();
+        rows += page.len();
+        if !page_has_more {
             break;
         }
     }
@@ -437,12 +437,12 @@ where
     let mut key_bytes = 0u64;
     let mut value_bytes = 0u64;
     loop {
-        let page = cursor
+        let (page, page_has_more) = cursor
             .next_page(MAX_SCAN_PAGE_ROWS)
             .await
-            .expect("scan kv layout accounting");
+            .expect("scan kv layout accounting").into_parts();
 
-        rows += page.entries.len() as u64;
+        rows += page.len() as u64;
         key_bytes += page
             .entries
             .iter()
@@ -457,7 +457,7 @@ where
             })
             .sum::<u64>();
 
-        if !page.has_more {
+        if !page_has_more {
             break;
         }
     }

--- a/packages/engine-benchmarks/benches/undo_redo_storage.rs
+++ b/packages/engine-benchmarks/benches/undo_redo_storage.rs
@@ -251,9 +251,9 @@ impl StorageScanSource for CountingScanSource<'_> {
         limit_rows: usize,
     ) -> std::pin::Pin<Box<dyn Future<Output = Result<ScanChunk, StorageError>> + Send + '_>> {
         Box::pin(async move {
-            let chunk = self.inner.next_page(limit_rows).await?;
+            let (chunk, chunk_has_more) = self.inner.next_page(limit_rows).await?.into_parts();
             let mut stats = self.stats.lock().expect("I/O stats mutex");
-            stats.scan_rows += chunk.entries.len() as u64;
+            stats.scan_rows += chunk.len() as u64;
             stats.scan_value_bytes += chunk
                 .entries
                 .iter()

--- a/packages/engine-benchmarks/benches/undo_redo_storage.rs
+++ b/packages/engine-benchmarks/benches/undo_redo_storage.rs
@@ -255,7 +255,6 @@ impl StorageScanSource for CountingScanSource<'_> {
             let mut stats = self.stats.lock().expect("I/O stats mutex");
             stats.scan_rows += chunk.len() as u64;
             stats.scan_value_bytes += chunk
-                .entries
                 .iter()
                 .map(|entry| match &entry.value {
                     ProjectedValue::KeyOnly => 0,

--- a/packages/engine-benchmarks/benches/undo_redo_storage.rs
+++ b/packages/engine-benchmarks/benches/undo_redo_storage.rs
@@ -262,7 +262,7 @@ impl StorageScanSource for CountingScanSource<'_> {
                 })
                 .sum::<u64>();
             drop(stats);
-            Ok(chunk)
+            Ok(ScanChunk::new(chunk, chunk_has_more))
         })
     }
 }

--- a/packages/engine-benchmarks/benches/untracked_state_crud/main.rs
+++ b/packages/engine-benchmarks/benches/untracked_state_crud/main.rs
@@ -364,9 +364,9 @@ impl StorageScanSource for CountingScanSource<'_> {
         limit_rows: usize,
     ) -> std::pin::Pin<Box<dyn Future<Output = Result<ScanChunk, StorageError>> + Send + '_>> {
         Box::pin(async move {
-            let chunk = self.inner.next_page(limit_rows).await?;
+            let (chunk, chunk_has_more) = self.inner.next_page(limit_rows).await?.into_parts();
             let mut stats = self.stats.lock().expect("io stats mutex");
-            stats.scan_entries += chunk.entries.len();
+            stats.scan_entries += chunk.len();
             stats.scan_entry_key_bytes += chunk
                 .entries
                 .iter()
@@ -1001,11 +1001,11 @@ where
         )
         .await
         .expect("begin row scan");
-    let page = cursor
+    let (page, page_has_more) = cursor
         .next_page(expected_rows + 1)
         .await
-        .expect("scan rows");
-    assert_eq!(page.entries.len(), expected_rows);
+        .expect("scan rows").into_parts();
+    assert_eq!(page.len(), expected_rows);
     expected_rows
 }
 

--- a/packages/engine-benchmarks/benches/untracked_state_crud/main.rs
+++ b/packages/engine-benchmarks/benches/untracked_state_crud/main.rs
@@ -376,7 +376,7 @@ impl StorageScanSource for CountingScanSource<'_> {
                 .map(|entry| projected_value_len(&entry.value))
                 .sum::<usize>();
             drop(stats);
-            Ok(chunk)
+            Ok(ScanChunk::new(chunk, chunk_has_more))
         })
     }
 }

--- a/packages/engine-benchmarks/benches/untracked_state_crud/main.rs
+++ b/packages/engine-benchmarks/benches/untracked_state_crud/main.rs
@@ -999,7 +999,7 @@ where
         )
         .await
         .expect("begin row scan");
-    let (page, page_has_more) = cursor
+    let (page, _page_has_more) = cursor
         .next_page(expected_rows + 1)
         .await
         .expect("scan rows").into_parts();

--- a/packages/engine-benchmarks/benches/untracked_state_crud/main.rs
+++ b/packages/engine-benchmarks/benches/untracked_state_crud/main.rs
@@ -368,12 +368,10 @@ impl StorageScanSource for CountingScanSource<'_> {
             let mut stats = self.stats.lock().expect("io stats mutex");
             stats.scan_entries += chunk.len();
             stats.scan_entry_key_bytes += chunk
-                .entries
                 .iter()
                 .map(|entry| entry.key.0.len())
                 .sum::<usize>();
             stats.scan_entry_value_bytes += chunk
-                .entries
                 .iter()
                 .map(|entry| projected_value_len(&entry.value))
                 .sum::<usize>();

--- a/packages/engine-benchmarks/examples/cas_gc_qualification.rs
+++ b/packages/engine-benchmarks/examples/cas_gc_qualification.rs
@@ -797,11 +797,11 @@ async fn space_stats<S: Storage>(storage: &S, space_id: lix::storage::SpaceId) -
         .await
         .expect("begin CAS stats scan");
     loop {
-        let page = cursor
+        let (page, page_has_more) = cursor
             .next_page(MAX_SCAN_PAGE_ROWS)
             .await
-            .expect("scan CAS stats");
-        stats.rows += page.entries.len() as u64;
+            .expect("scan CAS stats").into_parts();
+        stats.rows += page.len() as u64;
         stats.value_bytes += page
             .entries
             .iter()
@@ -810,7 +810,7 @@ async fn space_stats<S: Storage>(storage: &S, space_id: lix::storage::SpaceId) -
                 lix::storage::ProjectedValue::KeyOnly => 0,
             })
             .sum::<u64>();
-        if !page.has_more {
+        if !page_has_more {
             break;
         }
     }

--- a/packages/engine-benchmarks/examples/cas_gc_qualification.rs
+++ b/packages/engine-benchmarks/examples/cas_gc_qualification.rs
@@ -803,7 +803,6 @@ async fn space_stats<S: Storage>(storage: &S, space_id: lix::storage::SpaceId) -
             .expect("scan CAS stats").into_parts();
         stats.rows += page.len() as u64;
         stats.value_bytes += page
-            .entries
             .iter()
             .map(|entry| match &entry.value {
                 lix::storage::ProjectedValue::FullValue(bytes) => bytes.len() as u64,

--- a/packages/engine-benchmarks/examples/cas_sharing.rs
+++ b/packages/engine-benchmarks/examples/cas_sharing.rs
@@ -581,7 +581,6 @@ where
             .expect("scan accounting space").into_parts();
         rows += page.len() as u64;
         value_bytes += page
-            .entries
             .iter()
             .map(|entry| match &entry.value {
                 ProjectedValue::KeyOnly => 0,

--- a/packages/engine-benchmarks/examples/cas_sharing.rs
+++ b/packages/engine-benchmarks/examples/cas_sharing.rs
@@ -575,11 +575,11 @@ where
         .await
         .expect("begin accounting scan");
     loop {
-        let page = cursor
+        let (page, page_has_more) = cursor
             .next_page(MAX_SCAN_PAGE_ROWS)
             .await
-            .expect("scan accounting space");
-        rows += page.entries.len() as u64;
+            .expect("scan accounting space").into_parts();
+        rows += page.len() as u64;
         value_bytes += page
             .entries
             .iter()
@@ -588,7 +588,7 @@ where
                 ProjectedValue::FullValue(value) => value.len() as u64,
             })
             .sum::<u64>();
-        if !page.has_more {
+        if !page_has_more {
             break;
         }
     }

--- a/packages/engine-benchmarks/tests/large_payload_read_qualification.rs
+++ b/packages/engine-benchmarks/tests/large_payload_read_qualification.rs
@@ -220,9 +220,9 @@ impl StorageScanSource for CountingScanSource<'_> {
         limit_rows: usize,
     ) -> std::pin::Pin<Box<dyn Future<Output = Result<ScanChunk, StorageError>> + Send + '_>> {
         Box::pin(async move {
-            let chunk = self.inner.next_page(limit_rows).await?;
+            let (chunk, chunk_has_more) = self.inner.next_page(limit_rows).await?.into_parts();
             let mut stats = self.stats.lock().expect("I/O stats mutex");
-            stats.scan_rows += chunk.entries.len() as u64;
+            stats.scan_rows += chunk.len() as u64;
             stats.scan_value_bytes += chunk
                 .entries
                 .iter()
@@ -1113,11 +1113,11 @@ where
         .await
         .expect("begin CAS accounting scan");
     loop {
-        let page = cursor
+        let (page, page_has_more) = cursor
             .next_page(MAX_SCAN_PAGE_ROWS)
             .await
-            .expect("scan CAS accounting space");
-        accounting.rows += page.entries.len() as u64;
+            .expect("scan CAS accounting space").into_parts();
+        accounting.rows += page.len() as u64;
         accounting.key_bytes += page
             .entries
             .iter()
@@ -1131,7 +1131,7 @@ where
                 ProjectedValue::FullValue(value) => value.len() as u64,
             })
             .sum::<u64>();
-        if !page.has_more {
+        if !page_has_more {
             break;
         }
     }

--- a/packages/engine-benchmarks/tests/large_payload_read_qualification.rs
+++ b/packages/engine-benchmarks/tests/large_payload_read_qualification.rs
@@ -224,7 +224,6 @@ impl StorageScanSource for CountingScanSource<'_> {
             let mut stats = self.stats.lock().expect("I/O stats mutex");
             stats.scan_rows += chunk.len() as u64;
             stats.scan_value_bytes += chunk
-                .entries
                 .iter()
                 .map(|entry| match &entry.value {
                     ProjectedValue::KeyOnly => 0,
@@ -1119,12 +1118,10 @@ where
             .expect("scan CAS accounting space").into_parts();
         accounting.rows += page.len() as u64;
         accounting.key_bytes += page
-            .entries
             .iter()
             .map(|entry| entry.key.0.len() as u64)
             .sum::<u64>();
         accounting.value_bytes += page
-            .entries
             .iter()
             .map(|entry| match &entry.value {
                 ProjectedValue::KeyOnly => 0,

--- a/packages/engine-benchmarks/tests/large_payload_read_qualification.rs
+++ b/packages/engine-benchmarks/tests/large_payload_read_qualification.rs
@@ -231,7 +231,7 @@ impl StorageScanSource for CountingScanSource<'_> {
                 })
                 .sum::<u64>();
             drop(stats);
-            Ok(chunk)
+            Ok(ScanChunk::new(chunk, chunk_has_more))
         })
     }
 }

--- a/packages/js-sdk/native/indexeddb.rs
+++ b/packages/js-sdk/native/indexeddb.rs
@@ -394,10 +394,7 @@ impl StorageScanSource for IndexedDbScanSource {
                 })
                 .collect::<Result<Vec<_>, StorageError>>()?;
             self.offset = end;
-            Ok(ScanChunk {
-                entries,
-                has_more: self.offset < self.entries.len(),
-            })
+            Ok(ScanChunk::new(entries, self.offset < self.entries.len()))
         })
     }
 }

--- a/packages/lix/src/binary_cas/kv.rs
+++ b/packages/lix/src/binary_cas/kv.rs
@@ -225,10 +225,10 @@ pub(in crate::binary_cas) async fn stage_reclaim_unreachable_binary_cas(
         )
         .await?;
     loop {
-        let page = manifest_cursor
+        let (page, page_has_more) = manifest_cursor
             .next_page(CAS_RECLAIM_MANIFEST_PAGE_ROWS)
-            .await?;
-        for entry in page.entries {
+            .await?.into_parts();
+        for entry in page {
             let blob_id = BlobId::from_bytes(entry.key.0.as_ref().try_into().map_err(|_| {
                 LixError::new(
                     LixError::CODE_STORAGE_ERROR,
@@ -252,7 +252,7 @@ pub(in crate::binary_cas) async fn stage_reclaim_unreachable_binary_cas(
                 validate_live_manifest_identity(blob_id, &manifest)?;
             }
         }
-        if !page.has_more {
+        if !page_has_more {
             break;
         }
     }
@@ -271,10 +271,10 @@ pub(in crate::binary_cas) async fn stage_reclaim_unreachable_binary_cas(
         )
         .await?;
     loop {
-        let page = manifest_chunk_cursor
+        let (page, page_has_more) = manifest_chunk_cursor
             .next_page(CAS_RECLAIM_MANIFEST_PAGE_ROWS)
-            .await?;
-        for entry in page.entries {
+            .await?.into_parts();
+        for entry in page {
             let (blob_id, offset) = decode_manifest_chunk_key(&entry.key)?;
             let keep = live_manifest_sizes
                 .get(&blob_id)
@@ -284,7 +284,7 @@ pub(in crate::binary_cas) async fn stage_reclaim_unreachable_binary_cas(
                 result.reclaimed_manifest_chunk_rows += 1;
             }
         }
-        if !page.has_more {
+        if !page_has_more {
             break;
         }
     }
@@ -303,8 +303,8 @@ pub(in crate::binary_cas) async fn stage_reclaim_unreachable_binary_cas(
         )
         .await?;
     loop {
-        let page = chunk_cursor.next_page(CAS_RECLAIM_CHUNK_PAGE_ROWS).await?;
-        for entry in page.entries {
+        let (page, page_has_more) = chunk_cursor.next_page(CAS_RECLAIM_CHUNK_PAGE_ROWS).await?.into_parts();
+        for entry in page {
             let chunk_hash =
                 ChunkHash::from_bytes(entry.key.0.as_ref().try_into().map_err(|_| {
                     LixError::new(
@@ -339,7 +339,7 @@ pub(in crate::binary_cas) async fn stage_reclaim_unreachable_binary_cas(
                     )
                 })?;
         }
-        if !page.has_more {
+        if !page_has_more {
             break;
         }
     }
@@ -358,10 +358,10 @@ pub(in crate::binary_cas) async fn stage_reclaim_unreachable_binary_cas(
         )
         .await?;
     loop {
-        let page = presence_cursor
+        let (page, page_has_more) = presence_cursor
             .next_page(CAS_RECLAIM_MANIFEST_PAGE_ROWS)
-            .await?;
-        for entry in page.entries {
+            .await?.into_parts();
+        for entry in page {
             let chunk_hash =
                 ChunkHash::from_bytes(entry.key.0.as_ref().try_into().map_err(|_| {
                     LixError::new(
@@ -373,7 +373,7 @@ pub(in crate::binary_cas) async fn stage_reclaim_unreachable_binary_cas(
                 writes.delete(BINARY_CAS_CHUNK_PRESENCE_SPACE, entry.key);
             }
         }
-        if !page.has_more {
+        if !page_has_more {
             break;
         }
     }
@@ -1037,16 +1037,16 @@ async fn scan_all_values_for_range(
         .begin_scan(space, range, StorageBeginScanOptions::default())
         .await?;
     loop {
-        let page = cursor
+        let (page, page_has_more) = cursor
             .next_page(crate::storage_adapter::MAX_SCAN_PAGE_ROWS)
-            .await?;
+            .await?.into_parts();
         values.extend(
-            page.entries
+            page
                 .into_iter()
                 .filter_map(|entry| full_value(entry.value))
                 .map(|bytes| bytes.to_vec()),
         );
-        if !page.has_more {
+        if !page_has_more {
             break;
         }
     }

--- a/packages/lix/src/binary_cas/stats.rs
+++ b/packages/lix/src/binary_cas/stats.rs
@@ -102,12 +102,12 @@ where
         .await?;
 
     loop {
-        let result = cursor.next_page(4096).await?;
-        row_count += result.entries.len() as u64;
-        for entry in result.entries {
+        let (result, result_has_more) = cursor.next_page(4096).await?.into_parts();
+        row_count += result.len() as u64;
+        for entry in result {
             visit(entry.value)?;
         }
-        if !result.has_more {
+        if !result_has_more {
             break;
         }
     }

--- a/packages/lix/src/branch/control.rs
+++ b/packages/lix/src/branch/control.rs
@@ -259,10 +259,10 @@ where
             )
             .await?;
         loop {
-            let page = cursor
+            let (page, page_has_more) = cursor
                 .next_page(crate::storage_adapter::MAX_SCAN_PAGE_ROWS)
-                .await?;
-            for entry in page.entries {
+                .await?.into_parts();
+            for entry in page {
                 let key = storage_codec::decode::<BranchHeadControlKey>(
                     "branch-head control key",
                     entry.key.0.as_ref(),
@@ -270,7 +270,7 @@ where
                 let control = decode_projected_value(&key.branch_id, entry.value)?;
                 rows.push((key.branch_id, control));
             }
-            if !page.has_more {
+            if !page_has_more {
                 break;
             }
         }

--- a/packages/lix/src/changelog/context.rs
+++ b/packages/lix/src/changelog/context.rs
@@ -1060,8 +1060,7 @@ where
             },
         )
         .await?;
-    let (chunk, chunk_has_more) = cursor.next_page(limit).await?.into_parts();
-    let has_more = chunk_has_more;
+    let (chunk, has_more) = cursor.next_page(limit).await?.into_parts();
     let mut keys = Vec::with_capacity(chunk.len());
     let mut values = Vec::with_capacity(chunk.len());
     for entry in chunk {

--- a/packages/lix/src/changelog/context.rs
+++ b/packages/lix/src/changelog/context.rs
@@ -1060,11 +1060,11 @@ where
             },
         )
         .await?;
-    let chunk = cursor.next_page(limit).await?;
-    let has_more = chunk.has_more;
-    let mut keys = Vec::with_capacity(chunk.entries.len());
-    let mut values = Vec::with_capacity(chunk.entries.len());
-    for entry in chunk.entries {
+    let (chunk, chunk_has_more) = cursor.next_page(limit).await?.into_parts();
+    let has_more = chunk_has_more;
+    let mut keys = Vec::with_capacity(chunk.len());
+    let mut values = Vec::with_capacity(chunk.len());
+    for entry in chunk {
         keys.push(entry.key.0.to_vec());
         if let StorageProjectedValue::FullValue(bytes) = entry.value {
             values.push(bytes.to_vec());

--- a/packages/lix/src/engine.rs
+++ b/packages/lix/src/engine.rs
@@ -480,7 +480,7 @@ async fn repository_has_changelog_commit(
             },
         )
         .await?;
-    Ok(!cursor.next_page(1).await?.entries.is_empty())
+    Ok(!cursor.next_page(1).await?.is_empty())
 }
 
 fn not_initialized_error() -> LixError {

--- a/packages/lix/src/engine.rs
+++ b/packages/lix/src/engine.rs
@@ -2152,7 +2152,7 @@ mod tests {
         let before_packed =
             scan_test_space(&read, crate::hot_state::PACKED_CURRENT_BASE_SPACE).await;
         assert!(
-            !before_sparse.entries.is_empty() || !before_packed.entries.is_empty(),
+            !before_sparse.is_empty() || !before_packed.is_empty(),
             "tracked mutation must persist a sparse or packed physical dirty epoch"
         );
         drop(read);
@@ -2168,7 +2168,7 @@ mod tests {
             .expect("post-checkpoint inventory read should open");
         let after = scan_test_space(&read, crate::hot_state::DIFF_SPACE).await;
         assert_eq!(
-            after.entries.len(),
+            after.len(),
             1,
             "the superseded branch epoch must be reclaimed; only the repository-global checkpoint entity may remain dirty"
         );
@@ -2183,7 +2183,7 @@ mod tests {
             .expect("second checkpoint inventory read should open");
         let after_second = scan_test_space(&read, crate::hot_state::DIFF_SPACE).await;
         assert_eq!(
-            after_second.entries.len(),
+            after_second.len(),
             2,
             "the second immutable checkpoint entity remains while the superseded branch epoch is reclaimed"
         );

--- a/packages/lix/src/engine.rs
+++ b/packages/lix/src/engine.rs
@@ -504,7 +504,7 @@ mod tests {
     async fn scan_test_space(
         read: &(impl crate::storage_adapter::StorageAdapterRead + ?Sized),
         space: StorageSpace,
-    ) -> crate::storage_adapter::StorageScanChunk {
+    ) -> Vec<crate::storage_adapter::StorageReadEntry> {
         let range = StoragePrefix {
             bytes: Bytes::new(),
         }
@@ -515,7 +515,7 @@ mod tests {
             .await
             .expect("begin test scan");
         cursor
-            .next_page(crate::storage_adapter::MAX_SCAN_PAGE_ROWS)
+            .collect_all()
             .await
             .expect("read test scan page")
     }
@@ -2283,8 +2283,7 @@ mod tests {
             .await
             .expect("read initialized hot rows");
         let hot_rows = scan_test_space(&read, crate::hot_state::ROW_SPACE)
-            .await
-            .entries;
+            .await;
         assert!(
             !hot_rows.is_empty(),
             "initialized repository must have hot rows"
@@ -2484,8 +2483,7 @@ mod tests {
             .await
             .expect("read the index plane");
         let entries = scan_test_space(&read, crate::hot_state::INDEX_SPACE)
-            .await
-            .entries;
+            .await;
         let witnesses = entries
             .iter()
             .filter(|entry| match &entry.value {

--- a/packages/lix/src/functions/state.rs
+++ b/packages/lix/src/functions/state.rs
@@ -388,10 +388,9 @@ mod tests {
             .await
             .expect("selected HOT member scan should begin");
         let mut rows = cursor
-            .next_page(crate::storage_adapter::MAX_SCAN_PAGE_ROWS)
+            .collect_all()
             .await
-            .expect("selected HOT members should scan")
-            .entries;
+            .expect("selected HOT members should scan");
         assert_eq!(
             rows.len(),
             1,

--- a/packages/lix/src/gc.rs
+++ b/packages/lix/src/gc.rs
@@ -440,10 +440,10 @@ pub(crate) async fn load_recovery_refs(
         )
         .await?;
     loop {
-        let page = cursor
+        let (page, page_has_more) = cursor
             .next_page(crate::storage_adapter::MAX_SCAN_PAGE_ROWS)
-            .await?;
-        for entry in page.entries {
+            .await?.into_parts();
+        for entry in page {
             let StorageProjectedValue::FullValue(bytes) = entry.value else {
                 return Err(LixError::new(
                     LixError::CODE_INTERNAL_ERROR,
@@ -481,7 +481,7 @@ pub(crate) async fn load_recovery_refs(
                 },
             );
         }
-        if !page.has_more {
+        if !page_has_more {
             break;
         }
     }
@@ -5467,12 +5467,12 @@ mod tests {
         .await
         .expect("generation census scan should open");
         loop {
-            let page = cursor
+            let (page, page_has_more) = cursor
                 .next_page(crate::storage_adapter::MAX_SCAN_PAGE_ROWS)
                 .await
-                .expect("generation census page should load");
-            rows += page.entries.len();
-            if !page.has_more {
+                .expect("generation census page should load").into_parts();
+            rows += page.len();
+            if !page_has_more {
                 break;
             }
         }

--- a/packages/lix/src/hot_state/tracked_head.rs
+++ b/packages/lix/src/hot_state/tracked_head.rs
@@ -2393,7 +2393,7 @@ mod tests {
     async fn scan_test_space(
         read: &(impl StorageAdapterRead + ?Sized),
         space: StorageSpace,
-    ) -> crate::storage_adapter::StorageScanChunk {
+    ) -> Vec<crate::storage_adapter::StorageReadEntry> {
         let range = StoragePrefix {
             bytes: Bytes::new(),
         }
@@ -2404,7 +2404,7 @@ mod tests {
             .await
             .expect("begin test scan");
         cursor
-            .next_page(crate::storage_adapter::MAX_SCAN_PAGE_ROWS)
+            .collect_all()
             .await
             .expect("read test scan page")
     }
@@ -4040,8 +4040,7 @@ mod tests {
             .await
             .expect("open file schema marker verification read");
         let projection_rows = scan_test_space(&projection_read, FILE_SPACE)
-            .await
-            .entries;
+            .await;
         assert_eq!(
             projection_rows.len(),
             1,
@@ -4681,7 +4680,6 @@ mod tests {
             .expect("open corruption fixture read");
         let unrelated_key = scan_test_space(&read, ROW_SPACE)
             .await
-            .entries
             .into_iter()
             .find_map(|entry| {
                 let value = full_value_bytes(entry.value).ok()?;

--- a/packages/lix/src/hot_state/tracked_head.rs
+++ b/packages/lix/src/hot_state/tracked_head.rs
@@ -4623,7 +4623,7 @@ mod tests {
             .begin_read(StorageReadOptions::default())
             .await
             .expect("open file-schema marker verification read");
-        let projections = scan_test_space(&read, FILE_SPACE).await.entries;
+        let projections = scan_test_space(&read, FILE_SPACE).await;
         assert_eq!(projections.len(), 1);
         assert!(
             projections.into_iter().all(|projection| {

--- a/packages/lix/src/hot_state/tracked_head.rs
+++ b/packages/lix/src/hot_state/tracked_head.rs
@@ -857,10 +857,10 @@ where
         )
         .await?;
     loop {
-        let page = cursor
+        let (page, page_has_more) = cursor
             .next_page(crate::storage_adapter::MAX_SCAN_PAGE_ROWS)
-            .await?;
-        for entry in page.entries {
+            .await?.into_parts();
+        for entry in page {
             let key: BranchRefKey = match storage_codec::decode(
                 "tracked working-diff marker key",
                 entry.key.0.as_ref(),
@@ -901,7 +901,7 @@ where
                 },
             );
         }
-        if !page.has_more {
+        if !page_has_more {
             break;
         }
     }

--- a/packages/lix/src/hot_state/tracked_head/hot.rs
+++ b/packages/lix/src/hot_state/tracked_head/hot.rs
@@ -14248,6 +14248,235 @@ mod tests {
         );
     }
 
+    const PAGING_SCHEMA_KEY: &str = "paged_certified_row";
+    const PAGING_FILE_COUNT: usize = crate::storage_adapter::MAX_SCAN_PAGE_ROWS + 3;
+
+    fn paging_certified_batch(index: usize) -> WasmCertifiedEntityBatch {
+        let mut page = Vec::new();
+        page.extend_from_slice(&0_u32.to_le_bytes());
+        page.extend_from_slice(&1_u64.to_le_bytes());
+        page.push(0);
+        page.extend_from_slice(&0_u32.to_le_bytes());
+        page.extend_from_slice(&1_u16.to_le_bytes());
+        page.extend_from_slice(&5_u32.to_le_bytes());
+        page.extend_from_slice(b"value");
+        let page = crate::plugin_wire::encode_single_section(
+            crate::plugin_wire::Representation::SchemaRows,
+            crate::plugin_wire::Operation::Create,
+            PAGING_SCHEMA_KEY,
+            br#"{"wire":["create_ref_u32","u64","u8","bytes_u32","list_utf8_u16"],"primary_key":[{"kind":"generated_id","slot":0}],"fields":[{"name":"cells","value":{"kind":"list_utf8","slot":4}},{"name":"id","value":{"kind":"generated_id","slot":0}},{"name":"layout","object":[{"name":"force_quote","value":{"kind":"base64_url","slot":3}},{"name":"terminator","value":{"kind":"enum","slot":2,"values":[null,"","\n","\r\n","\r"]}}]},{"name":"order_key","value":{"kind":"hex_u64","slot":1,"width":16}}]}"#,
+            1,
+            page,
+        )
+        .expect("paged certified schema-row page");
+        WasmCertifiedEntityBatch {
+            format: 1,
+            schema_keys: vec![PAGING_SCHEMA_KEY.to_owned()],
+            row_count: 1,
+            creates: WasmCreateContext {
+                high: 0x0192_0000_0000_7000,
+                low: 0x8000_0000 + index as u32,
+            },
+            create_ranges: Vec::new(),
+            complete_file_state: true,
+            pages: vec![Bytes::from(page)],
+        }
+    }
+
+    /// Publishes `PAGING_FILE_COUNT` single-row certified files on one branch
+    /// generation, so every certified manifest scan for that generation has to
+    /// cross the storage scan page boundary.
+    async fn seed_paged_certified_generation(
+        branch_id: &str,
+        generation_label: &str,
+    ) -> (StorageAdapter, BranchHeadControl) {
+        let storage = StorageAdapter::new(Memory::new());
+        let head_commit_id = CommitId::for_test_label("paged-certified-head");
+        let created_at = timestamp();
+        let control = BranchHeadControl {
+            head_commit_id,
+            tracked_generation: CommitId::for_test_label(generation_label),
+            current_state_revision: 0,
+            schema_presence_bloom: [u64::MAX; 4],
+            working_diff_checkpoint_commit_id: None,
+            created_at,
+            updated_at: created_at,
+            ref_change_id: ChangeId::for_test_label("paged-certified-ref"),
+        };
+
+        let file_ids = (0..PAGING_FILE_COUNT)
+            .map(|index| format!("paged-{index:05}.csv"))
+            .collect::<Vec<_>>();
+        let batches = (0..PAGING_FILE_COUNT)
+            .map(|index| [paging_certified_batch(index)])
+            .collect::<Vec<_>>();
+        let files = file_ids
+            .iter()
+            .zip(batches.iter())
+            .map(|(file_id, batches)| CertifiedEntityBatchFileRef {
+                branch_id,
+                file_id,
+                batches,
+            })
+            .collect::<Vec<_>>();
+
+        let read = storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("paged certified seed read should open");
+        let mut writes = StorageWriteSet::new();
+        stage_branch_head_control(&mut writes, branch_id, control)
+            .expect("paged certified control should stage");
+        stage_certified_entity_batches(
+            &read,
+            &mut writes,
+            &files,
+            &BTreeMap::from([(branch_id.to_owned(), control)]),
+            &BTreeMap::from([(
+                branch_id.to_owned(),
+                crate::branch::BranchHeadControlObservation {
+                    control: Some(control),
+                    raw_token: None,
+                },
+            )]),
+            &BTreeMap::from([(head_commit_id, created_at)]),
+            &BTreeSet::new(),
+        )
+        .await
+        .expect("paged certified batches should stage");
+        drop(read);
+        storage
+            .commit_write_set(writes, StorageWriteOptions::default())
+            .await
+            .expect("paged certified batches should commit");
+        (storage, control)
+    }
+
+    async fn count_certified_manifests(
+        read: &impl StorageAdapterRead,
+        generation: CommitId,
+    ) -> usize {
+        let range = StoragePrefix {
+            bytes: Bytes::copy_from_slice(generation.as_uuid().as_bytes()),
+        }
+        .to_range()
+        .expect("manifest prefix range");
+        let mut cursor = read
+            .begin_scan(
+                CERTIFIED_ENTITY_BATCH_MANIFEST_SPACE,
+                range,
+                StorageBeginScanOptions::default(),
+            )
+            .await
+            .expect("manifest scan should open");
+        let mut total = 0;
+        loop {
+            let page = cursor
+                .next_page(crate::storage_adapter::MAX_SCAN_PAGE_ROWS)
+                .await
+                .expect("manifest page should read");
+            let has_more = page.has_more;
+            total += page.entries.len();
+            if !has_more {
+                return total;
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn certified_scan_returns_every_file_past_one_scan_page() {
+        const BRANCH_ID: &str = "01920000-0000-7000-8000-0000000001a0";
+        let (storage, control) =
+            seed_paged_certified_generation(BRANCH_ID, "paged-certified-generation").await;
+
+        let read = storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("paged certified verification read should open");
+        assert_eq!(
+            count_certified_manifests(&read, control.tracked_generation).await,
+            PAGING_FILE_COUNT,
+            "every published file must have a durable certified manifest"
+        );
+
+        let rows = scan_certified_entity_batch_rows(
+            &read,
+            BRANCH_ID,
+            control.tracked_generation,
+            &TrackedStateScanRequest {
+                filter: TrackedStateFilter {
+                    schema_keys: vec![PAGING_SCHEMA_KEY.to_owned()],
+                    ..TrackedStateFilter::default()
+                },
+                read_columns: TrackedStateReadColumns {
+                    columns: vec!["snapshot_content".to_owned()],
+                },
+                limit: None,
+            },
+            None,
+            None,
+        )
+        .await
+        .expect("paged certified rows should scan");
+
+        assert_eq!(
+            rows.len(),
+            PAGING_FILE_COUNT,
+            "an unfiltered certified scan must not stop at the first storage scan page"
+        );
+    }
+
+    #[tokio::test]
+    async fn branch_creation_inherits_every_certified_manifest_past_one_scan_page() {
+        const DONOR_BRANCH: &str = "01920000-0000-7000-8000-0000000001a1";
+        const CREATED_BRANCH: &str = "01920000-0000-7000-8000-0000000001a2";
+        let (storage, donor_control) =
+            seed_paged_certified_generation(DONOR_BRANCH, "paged-inherit-donor").await;
+        let created_control = BranchHeadControl {
+            tracked_generation: CommitId::for_test_label("paged-inherit-created"),
+            ref_change_id: ChangeId::for_test_label("paged-inherit-created-ref"),
+            ..donor_control
+        };
+
+        let read = storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("paged inherit read should open");
+        let mut writes = StorageWriteSet::new();
+        stage_certified_entity_batches(
+            &read,
+            &mut writes,
+            &[],
+            &BTreeMap::from([(CREATED_BRANCH.to_owned(), created_control)]),
+            &BTreeMap::from([(
+                CREATED_BRANCH.to_owned(),
+                crate::branch::BranchHeadControlObservation {
+                    control: None,
+                    raw_token: None,
+                },
+            )]),
+            &BTreeMap::new(),
+            &BTreeSet::new(),
+        )
+        .await
+        .expect("created branch should inherit certified manifests");
+        drop(read);
+        storage
+            .commit_write_set(writes, StorageWriteOptions::default())
+            .await
+            .expect("inherited certified manifests should commit");
+
+        let read = storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("paged inherit verification read should open");
+        assert_eq!(
+            count_certified_manifests(&read, created_control.tracked_generation).await,
+            PAGING_FILE_COUNT,
+            "branch creation must inherit every certified manifest, not one scan page of them"
+        );
+    }
+
     fn diff_identity(branch_id: &str, generation: CommitId, entity: &str) -> HeadIdentity {
         HeadIdentity {
             branch_id: branch_id.to_string(),

--- a/packages/lix/src/hot_state/tracked_head/hot.rs
+++ b/packages/lix/src/hot_state/tracked_head/hot.rs
@@ -615,10 +615,11 @@ pub(crate) async fn stage_certified_entity_batches(
                     StorageBeginScanOptions::default(),
                 )
                 .await?;
-            let manifests = cursor
-                .next_page(crate::storage_adapter::MAX_SCAN_PAGE_ROWS)
-                .await?;
-            for entry in manifests.entries {
+            // The prefix is only the 16-byte generation, so this range covers
+            // every file on the branch. Reading one page dropped every file
+            // past row 1024 out of the new generation permanently.
+            let manifests = cursor.collect_all().await?;
+            for entry in manifests {
                 let suffix = entry
                     .key
                     .0
@@ -685,10 +686,10 @@ pub(crate) async fn stage_certified_entity_batches(
                         StorageBeginScanOptions::default(),
                     )
                     .await?;
-                let prior_manifests = cursor
-                    .next_page(crate::storage_adapter::MAX_SCAN_PAGE_ROWS)
-                    .await?;
-                for entry in prior_manifests.entries {
+                // Every prior manifest for this file must be deleted, or a
+                // superseded batch survives its replacement.
+                let prior_manifests = cursor.collect_all().await?;
+                for entry in prior_manifests {
                     writes.delete(CERTIFIED_ENTITY_BATCH_MANIFEST_SPACE, entry.key);
                 }
             }
@@ -1066,12 +1067,7 @@ async fn scan_certified_entity_batch_rows(
                     StorageBeginScanOptions::default(),
                 )
                 .await?;
-            manifest_entries.extend(
-                cursor
-                    .next_page(crate::storage_adapter::MAX_SCAN_PAGE_ROWS)
-                    .await?
-                    .entries,
-            );
+            manifest_entries.extend(cursor.collect_all().await?);
         }
     } else {
         let range = StoragePrefix {
@@ -1085,10 +1081,10 @@ async fn scan_certified_entity_batch_rows(
                 StorageBeginScanOptions::default(),
             )
             .await?;
-        manifest_entries = cursor
-            .next_page(crate::storage_adapter::MAX_SCAN_PAGE_ROWS)
-            .await?
-            .entries;
+        // Prefixed by the generation alone, so this covers every file on the
+        // branch. One page silently hid every file past row 1024 from the
+        // merged scan result.
+        manifest_entries = cursor.collect_all().await?;
     }
     if exact_file_ids.is_none() && manifest_entries.is_empty() {
         if let Some(cache) = transaction_cache {
@@ -3509,10 +3505,11 @@ async fn scan_root_current_base_rows_for_merge(
                     StorageBeginScanOptions::default(),
                 )
                 .await?;
-            control_entries = cursor
-                .next_page(crate::storage_adapter::MAX_SCAN_PAGE_ROWS)
-                .await?
-                .entries;
+            // A replacement control anywhere in the generation decides whether
+            // the root scan may keep a pushed-down LIMIT. Missing one past row
+            // 1024 reads as "no replacement" and can select a retired row while
+            // a live row still exists further along.
+            control_entries = cursor.collect_all().await?;
         } else {
             for schema_key in &request.filter.schema_keys {
                 let mut prefix = hot_scope_prefix(branch_id, generation);
@@ -3528,12 +3525,7 @@ async fn scan_root_current_base_rows_for_merge(
                         StorageBeginScanOptions::default(),
                     )
                     .await?;
-                control_entries.extend(
-                    cursor
-                        .next_page(crate::storage_adapter::MAX_SCAN_PAGE_ROWS)
-                        .await?
-                        .entries,
-                );
+                control_entries.extend(cursor.collect_all().await?);
             }
         }
         control_entries

--- a/packages/lix/src/hot_state/tracked_head/hot.rs
+++ b/packages/lix/src/hot_state/tracked_head/hot.rs
@@ -4962,7 +4962,7 @@ where
                 },
             )
             .await?;
-        let (page, page_has_more) = cursor.next_page(1).await?.into_parts();
+        let (page, _page_has_more) = cursor.next_page(1).await?.into_parts();
         if !page.is_empty() {
             return Ok(true);
         }

--- a/packages/lix/src/hot_state/tracked_head/hot.rs
+++ b/packages/lix/src/hot_state/tracked_head/hot.rs
@@ -10719,10 +10719,12 @@ async fn hot_scan_entries<'a>(
                 };
                 return Ok(Some(HotScanEntries::Decoded(rows)));
             }
-            let page = cursor
+            // Deliberately bounded: this reader stops at the caller's LIMIT.
+            let (page, page_has_more) = cursor
                 .next_page(remaining.unwrap_or(crate::storage_adapter::MAX_SCAN_PAGE_ROWS))
-                .await?;
-            for entry in page.entries {
+                .await?
+                .into_parts();
+            for entry in page {
                 let encoded_key_bytes = entry.key.0.len();
                 let identity = decode_hot_scan_row_key_in_scope(entry.key.0, &scope)?;
                 if identity.matches_filter(filter) {
@@ -10747,7 +10749,7 @@ async fn hot_scan_entries<'a>(
                     }
                 }
             }
-            if !page.has_more {
+            if !page_has_more {
                 break;
             }
         }
@@ -10911,11 +10913,14 @@ async fn hot_scan_dense_encoded_key_range<'a>(
         if remaining_budget == 0 {
             return Ok(None);
         }
-        let page = cursor
+        // Deliberately bounded: this reader gives up once it has burned its
+        // scan budget rather than reading an unbounded range.
+        let (page, page_has_more) = cursor
             .next_page(remaining_budget.min(crate::storage_adapter::MAX_SCAN_PAGE_ROWS))
-            .await?;
-        scanned += page.entries.len();
-        for entry in page.entries {
+            .await?
+            .into_parts();
+        scanned += page.len();
+        for entry in page {
             while requested_index < key_count && key_at(requested_index) < entry.key.0.as_ref() {
                 requested_index += 1;
             }
@@ -10924,7 +10929,7 @@ async fn hot_scan_dense_encoded_key_range<'a>(
                 requested_index += 1;
             }
         }
-        if requested_index == key_count || !page.has_more {
+        if requested_index == key_count || !page_has_more {
             return Ok(Some(values));
         }
     }

--- a/packages/lix/src/hot_state/tracked_head/hot.rs
+++ b/packages/lix/src/hot_state/tracked_head/hot.rs
@@ -10074,15 +10074,9 @@ async fn hot_file_backed_schema_keys(
             },
         )
         .await?;
-    loop {
-        let page = cursor
-            .next_page(crate::storage_adapter::MAX_SCAN_PAGE_ROWS)
-            .await?;
-        for entry in page.entries {
+    while let Some(entries) = cursor.next_chunk().await? {
+        for entry in entries {
             schema_keys.push(decode_hot_file_schema_key_in_scope(entry.key.0, &scope)?);
-        }
-        if !page.has_more {
-            break;
         }
     }
     schema_keys.sort();

--- a/packages/lix/src/hot_state/tracked_head/hot.rs
+++ b/packages/lix/src/hot_state/tracked_head/hot.rs
@@ -1212,11 +1212,11 @@ pub(crate) async fn scan_certified_history_rows(
             )
             .await?;
         loop {
-            let page = cursor
+            let (page, page_has_more) = cursor
                 .next_page(crate::storage_adapter::MAX_SCAN_PAGE_ROWS)
-                .await?;
-            let has_more = page.has_more;
-            for entry in page.entries {
+                .await?.into_parts();
+            let has_more = page_has_more;
+            for entry in page {
                 let value = full_value_bytes(entry.value)?;
                 if certified_batch_commit_id(&value)? != *commit_id {
                     continue;
@@ -3089,10 +3089,10 @@ async fn packed_exclusive_schema_base_refs(
         )
         .await?;
     loop {
-        let page = cursor
+        let (page, page_has_more) = cursor
             .next_page(crate::storage_adapter::MAX_SCAN_PAGE_ROWS)
-            .await?;
-        for entry in page.entries {
+            .await?.into_parts();
+        for entry in page {
             let bytes = entry.key.0.as_ref();
             if bytes.len() != prefix.len() + 16 || bytes[..prefix.len()] != prefix {
                 return Err(head_value_error(
@@ -3107,7 +3107,7 @@ async fn packed_exclusive_schema_base_refs(
                 index_key: entry.key.0,
             });
         }
-        if !page.has_more {
+        if !page_has_more {
             break;
         }
     }
@@ -3164,10 +3164,10 @@ async fn packed_current_base_refs(
         )
         .await?;
     loop {
-        let page = cursor
+        let (page, page_has_more) = cursor
             .next_page(crate::storage_adapter::MAX_SCAN_PAGE_ROWS)
-            .await?;
-        for entry in page.entries {
+            .await?.into_parts();
+        for entry in page {
             let bytes = entry.key.0.as_ref();
             if bytes.len() != prefix.len() + 16 || bytes[..prefix.len()] != prefix {
                 return Err(head_value_error(
@@ -3193,7 +3193,7 @@ async fn packed_current_base_refs(
                 coverage_key: entry.key.0,
             });
         }
-        if !page.has_more {
+        if !page_has_more {
             break;
         }
     }
@@ -3235,13 +3235,13 @@ async fn stage_retire_packed_current_bases(
         )
         .await?;
     loop {
-        let page = cursor
+        let (page, page_has_more) = cursor
             .next_page(crate::storage_adapter::MAX_SCAN_PAGE_ROWS)
-            .await?;
-        for entry in page.entries {
+            .await?.into_parts();
+        for entry in page {
             writes.delete(PACKED_CURRENT_EXCLUSIVE_SCHEMA_BASE_SPACE, entry.key);
         }
-        if !page.has_more {
+        if !page_has_more {
             break;
         }
     }
@@ -4728,10 +4728,10 @@ where
             .begin_scan(ROW_SPACE, range, StorageBeginScanOptions::default())
             .await?;
         loop {
-            let page = cursor
+            let (page, page_has_more) = cursor
                 .next_page(crate::storage_adapter::MAX_SCAN_PAGE_ROWS)
-                .await?;
-            for entry in page.entries {
+                .await?.into_parts();
+            for entry in page {
                 let raw_key = entry.key.0;
                 let raw_value = full_value_bytes(entry.value)?;
                 let identity = validate_exact_collection_member(
@@ -4751,7 +4751,7 @@ where
                         .ok_or_else(|| head_value_error("hot collection live count exceeds u64"))?;
                 }
             }
-            if !page.has_more {
+            if !page_has_more {
                 break;
             }
         }
@@ -4920,8 +4920,8 @@ where
             .await?;
         let mut candidates = Vec::new();
         loop {
-            let page = cursor.next_page(HOT_INDEX_CANDIDATE_PAGE).await?;
-            for entry in &page.entries {
+            let (page, page_has_more) = cursor.next_page(HOT_INDEX_CANDIDATE_PAGE).await?.into_parts();
+            for entry in &page {
                 let StorageProjectedValue::FullValue(value) = &entry.value else {
                     continue;
                 };
@@ -4932,7 +4932,7 @@ where
                     head_value_error(format!("hot index entry has an invalid entity pk: {error}"))
                 })?);
             }
-            if !page.has_more {
+            if !page_has_more {
                 break;
             }
         }
@@ -4962,8 +4962,8 @@ where
                 },
             )
             .await?;
-        let page = cursor.next_page(1).await?;
-        if !page.entries.is_empty() {
+        let (page, page_has_more) = cursor.next_page(1).await?.into_parts();
+        if !page.is_empty() {
             return Ok(true);
         }
         if packed_current_base_has_schema(
@@ -5996,15 +5996,15 @@ where
                 .begin_scan(ROW_SPACE, range, StorageBeginScanOptions::default())
                 .await?;
             loop {
-                let page = cursor
+                let (page, page_has_more) = cursor
                     .next_page(crate::storage_adapter::MAX_SCAN_PAGE_ROWS)
-                    .await?;
-                for entry in page.entries {
+                    .await?.into_parts();
+                for entry in page {
                     let bytes = full_value_bytes(entry.value)?;
                     let value = decode_head_value(&bytes)?;
                     collect_hot_untracked_refs(value, &mut refs);
                 }
-                if !page.has_more {
+                if !page_has_more {
                     break;
                 }
             }
@@ -9875,10 +9875,10 @@ async fn hot_load_file_scope_identities(
         )
         .await?;
     loop {
-        let page = cursor
+        let (page, page_has_more) = cursor
             .next_page(crate::storage_adapter::MAX_SCAN_PAGE_ROWS)
-            .await?;
-        for entry in page.entries {
+            .await?.into_parts();
+        for entry in page {
             let row = decode_hot_row_key_in_scope(entry.key.0.as_ref(), &scope)?;
             if !row
                 .file_id
@@ -9895,7 +9895,7 @@ async fn hot_load_file_scope_identities(
                 file_id: row.file_id,
             });
         }
-        if !page.has_more {
+        if !page_has_more {
             break;
         }
     }
@@ -10155,10 +10155,10 @@ async fn hot_working_diff_entries(
         .begin_scan(DIFF_SPACE, range, StorageBeginScanOptions::default())
         .await?;
     loop {
-        let page = cursor
+        let (page, page_has_more) = cursor
             .next_page(crate::storage_adapter::MAX_SCAN_PAGE_ROWS)
-            .await?;
-        for entry in page.entries {
+            .await?.into_parts();
+        for entry in page {
             let Ok(bytes) = full_value_bytes(entry.value) else {
                 return Ok(None);
             };
@@ -10212,7 +10212,7 @@ async fn hot_working_diff_entries(
                 return Ok(None);
             }
         }
-        if !page.has_more {
+        if !page_has_more {
             break;
         }
     }
@@ -10996,16 +10996,16 @@ async fn scan_hot_file_entries(
             .begin_scan(ROW_SPACE, range, StorageBeginScanOptions::default())
             .await?;
         loop {
-            let page = cursor
+            let (page, page_has_more) = cursor
                 .next_page(crate::storage_adapter::MAX_SCAN_PAGE_ROWS)
-                .await?;
-            for entry in page.entries {
+                .await?.into_parts();
+            for entry in page {
                 let identity = decode_hot_scan_row_key_in_scope(entry.key.0, &scope)?;
                 if identity.matches_filter(filter) {
                     rows.push((identity, full_value_bytes(entry.value)?));
                 }
             }
-            if !page.has_more {
+            if !page_has_more {
                 break;
             }
         }
@@ -11959,17 +11959,17 @@ where
             )
             .await?;
         loop {
-            let page = cursor
+            let (page, page_has_more) = cursor
                 .next_page(crate::storage_adapter::MAX_SCAN_PAGE_ROWS)
-                .await?;
-            for entry in page.entries {
+                .await?.into_parts();
+            for entry in page {
                 if declared.contains(entry.key.0.as_ref()) {
                     continue;
                 }
                 writes.delete(*space, entry.key);
                 deleted = deleted.saturating_add(1);
             }
-            if !page.has_more {
+            if !page_has_more {
                 break;
             }
         }
@@ -11994,10 +11994,10 @@ where
         .begin_scan(DIFF_SPACE, range, StorageBeginScanOptions::default())
         .await?;
     loop {
-        let page = cursor
+        let (page, page_has_more) = cursor
             .next_page(crate::storage_adapter::MAX_SCAN_PAGE_ROWS)
-            .await?;
-        for entry in page.entries {
+            .await?.into_parts();
+        for entry in page {
             let keep = match full_value_bytes(entry.value) {
                 Ok(bytes) if bytes.is_empty() => decode_hot_diff_key(entry.key.0.as_ref())
                     .is_ok_and(|(checkpoint_commit_id, identity)| {
@@ -12030,7 +12030,7 @@ where
                 writes.delete(DIFF_SPACE, entry.key);
             }
         }
-        if !page.has_more {
+        if !page_has_more {
             break;
         }
     }
@@ -12070,14 +12070,14 @@ where
         )
         .await?;
     loop {
-        let page = cursor
+        let (page, page_has_more) = cursor
             .next_page(crate::storage_adapter::MAX_SCAN_PAGE_ROWS)
-            .await?;
+            .await?.into_parts();
         writes.delete_batch(
             DIFF_SPACE,
-            page.entries.into_iter().map(|entry| entry.key),
+            page.into_iter().map(|entry| entry.key),
         );
-        if !page.has_more {
+        if !page_has_more {
             break;
         }
     }
@@ -14363,12 +14363,12 @@ mod tests {
             .expect("manifest scan should open");
         let mut total = 0;
         loop {
-            let page = cursor
+            let (page, page_has_more) = cursor
                 .next_page(crate::storage_adapter::MAX_SCAN_PAGE_ROWS)
                 .await
-                .expect("manifest page should read");
-            let has_more = page.has_more;
-            total += page.entries.len();
+                .expect("manifest page should read").into_parts();
+            let has_more = page_has_more;
+            total += page.len();
             if !has_more {
                 return total;
             }
@@ -15090,15 +15090,15 @@ mod tests {
             .begin_scan(DIFF_SPACE, range, StorageBeginScanOptions::default())
             .await
             .expect("begin segmented hot diff scan");
-        let page = cursor
+        let (page, page_has_more) = cursor
             .next_page(crate::storage_adapter::MAX_SCAN_PAGE_ROWS)
             .await
-            .expect("scan segmented hot diff");
-        assert!(!page.has_more);
+            .expect("scan segmented hot diff").into_parts();
+        assert!(!page_has_more);
 
         let mut actual_coverage = WorkingDiffIndexCoverage::default();
         let mut decoded = 0_usize;
-        for entry in page.entries {
+        for entry in page {
             let bytes = full_value_bytes(entry.value).expect("full segment value");
             let segment_scope =
                 decode_hot_diff_segment_key(entry.key.0.as_ref()).expect("segment key");

--- a/packages/lix/src/hot_state/tracked_head/hot.rs
+++ b/packages/lix/src/hot_state/tracked_head/hot.rs
@@ -1212,10 +1212,9 @@ pub(crate) async fn scan_certified_history_rows(
             )
             .await?;
         loop {
-            let (page, page_has_more) = cursor
+            let (page, has_more) = cursor
                 .next_page(crate::storage_adapter::MAX_SCAN_PAGE_ROWS)
                 .await?.into_parts();
-            let has_more = page_has_more;
             for entry in page {
                 let value = full_value_bytes(entry.value)?;
                 if certified_batch_commit_id(&value)? != *commit_id {
@@ -3089,7 +3088,7 @@ async fn packed_exclusive_schema_base_refs(
         )
         .await?;
     loop {
-        let (page, page_has_more) = cursor
+        let (page, has_more) = cursor
             .next_page(crate::storage_adapter::MAX_SCAN_PAGE_ROWS)
             .await?.into_parts();
         for entry in page {
@@ -3107,7 +3106,7 @@ async fn packed_exclusive_schema_base_refs(
                 index_key: entry.key.0,
             });
         }
-        if !page_has_more {
+        if !has_more {
             break;
         }
     }
@@ -14362,11 +14361,11 @@ mod tests {
             .expect("manifest scan should open");
         let mut total = 0;
         loop {
-            let (page, page_has_more) = cursor
+            let (page, has_more) = cursor
                 .next_page(crate::storage_adapter::MAX_SCAN_PAGE_ROWS)
                 .await
-                .expect("manifest page should read").into_parts();
-            let has_more = page_has_more;
+                .expect("manifest page should read")
+                .into_parts();
             total += page.len();
             if !has_more {
                 return total;

--- a/packages/lix/src/session/media_upload.rs
+++ b/packages/lix/src/session/media_upload.rs
@@ -1070,7 +1070,7 @@ mod tests {
             )
             .await
             .expect("chunk verification scan should succeed");
-        let (page, page_has_more) = cursor
+        let (page, _page_has_more) = cursor
             .next_page(1)
             .await
             .expect("chunk verification page should succeed").into_parts();
@@ -1470,7 +1470,7 @@ mod tests {
             )
             .await
             .expect("begin temporary upload receipt scan");
-        let (temporary_receipts, temporary_receipts_has_more) = cursor
+        let (temporary_receipts, _temporary_receipts_has_more) = cursor
             .next_page(MAX_SCAN_PAGE_ROWS)
             .await
             .expect("scan temporary upload receipts").into_parts();
@@ -1629,7 +1629,7 @@ mod tests {
             )
             .await
             .expect("begin upload leaf scan");
-        let (leaves, leaves_has_more) = cursor
+        let (leaves, _leaves_has_more) = cursor
             .next_page(MAX_SCAN_PAGE_ROWS)
             .await
             .expect("scan upload leaves").into_parts();

--- a/packages/lix/src/session/media_upload.rs
+++ b/packages/lix/src/session/media_upload.rs
@@ -55,8 +55,8 @@ pub(crate) async fn stage_reclaimable_upload_receipts(
         )
         .await?;
     loop {
-        let page = state_cursor.next_page(MAX_SCAN_PAGE_ROWS).await?;
-        for entry in page.entries {
+        let (page, page_has_more) = state_cursor.next_page(MAX_SCAN_PAGE_ROWS).await?.into_parts();
+        for entry in page {
             let upload_id = std::str::from_utf8(&entry.key.0)
                 .map_err(|_| invalid_upload_storage("upload state key is not UTF-8"))?
                 .to_owned();
@@ -70,7 +70,7 @@ pub(crate) async fn stage_reclaimable_upload_receipts(
                 .map_err(|_| invalid_upload_storage("upload state value is invalid JSON"))?;
             states.push((upload_id, state));
         }
-        if !page.has_more {
+        if !page_has_more {
             break;
         }
     }
@@ -104,8 +104,8 @@ pub(crate) async fn stage_reclaimable_upload_receipts(
         )
         .await?;
     loop {
-        let page = leaf_cursor.next_page(MAX_SCAN_PAGE_ROWS).await?;
-        for entry in page.entries {
+        let (page, page_has_more) = leaf_cursor.next_page(MAX_SCAN_PAGE_ROWS).await?.into_parts();
+        for entry in page {
             let upload_id = decode_upload_manifest_leaf_upload_id(&entry.key)?;
             if !open_ids.contains(&upload_id) {
                 // Finalized or state-less receipts are not active roots; the
@@ -138,7 +138,7 @@ pub(crate) async fn stage_reclaimable_upload_receipts(
                 }
             }
         }
-        if !page.has_more {
+        if !page_has_more {
             break;
         }
     }
@@ -745,8 +745,8 @@ async fn load_upload_progress(
         )
         .await?;
     'pages: loop {
-        let page = cursor.next_page(MAX_SCAN_PAGE_ROWS).await?;
-        for entry in &page.entries {
+        let (page, page_has_more) = cursor.next_page(MAX_SCAN_PAGE_ROWS).await?.into_parts();
+        for entry in &page {
             let part_number = decode_upload_manifest_leaf_part_number(upload_id, &entry.key)?;
             if part_number != expected_part {
                 break 'pages;
@@ -755,7 +755,7 @@ async fn load_upload_progress(
                 .checked_add(1)
                 .ok_or_else(|| invalid_upload("upload part count exceeds u32"))?;
         }
-        if !page.has_more {
+        if !page_has_more {
             break;
         }
     }
@@ -790,8 +790,8 @@ async fn load_upload_manifest_leaves(
         )
         .await?;
     loop {
-        let page = cursor.next_page(MAX_SCAN_PAGE_ROWS).await?;
-        for entry in &page.entries {
+        let (page, page_has_more) = cursor.next_page(MAX_SCAN_PAGE_ROWS).await?.into_parts();
+        for entry in &page {
             let part_number = decode_upload_manifest_leaf_part_number(upload_id, &entry.key)?;
             if part_number != next_part {
                 return Err(LixError::new(
@@ -819,7 +819,7 @@ async fn load_upload_manifest_leaves(
                 .checked_add(1)
                 .ok_or_else(|| invalid_upload("upload part count exceeds u32"))?;
         }
-        if !page.has_more {
+        if !page_has_more {
             break;
         }
     }
@@ -1070,11 +1070,11 @@ mod tests {
             )
             .await
             .expect("chunk verification scan should succeed");
-        let page = cursor
+        let (page, page_has_more) = cursor
             .next_page(1)
             .await
-            .expect("chunk verification page should succeed");
-        !page.entries.is_empty()
+            .expect("chunk verification page should succeed").into_parts();
+        !page.is_empty()
     }
 
     #[tokio::test]
@@ -1470,12 +1470,12 @@ mod tests {
             )
             .await
             .expect("begin temporary upload receipt scan");
-        let temporary_receipts = cursor
+        let (temporary_receipts, temporary_receipts_has_more) = cursor
             .next_page(MAX_SCAN_PAGE_ROWS)
             .await
-            .expect("scan temporary upload receipts");
+            .expect("scan temporary upload receipts").into_parts();
         assert!(
-            temporary_receipts.entries.is_empty(),
+            temporary_receipts.is_empty(),
             "publication must atomically remove temporary chunk receipts",
         );
         drop(cursor);
@@ -1563,13 +1563,13 @@ mod tests {
             )
             .await
             .expect("begin CAS chunk scan");
-        let chunks = cursor
+        let (chunks, chunks_has_more) = cursor
             .next_page(MAX_SCAN_PAGE_ROWS)
             .await
-            .expect("scan CAS chunks");
-        assert!(!chunks.has_more);
+            .expect("scan CAS chunks").into_parts();
+        assert!(!chunks_has_more);
         assert_eq!(
-            chunks.entries.len(),
+            chunks.len(),
             2,
             "identical media must reuse payloads"
         );
@@ -1629,12 +1629,12 @@ mod tests {
             )
             .await
             .expect("begin upload leaf scan");
-        let leaves = cursor
+        let (leaves, leaves_has_more) = cursor
             .next_page(MAX_SCAN_PAGE_ROWS)
             .await
-            .expect("scan upload leaves");
-        assert_eq!(leaves.entries.len(), 3);
-        for entry in leaves.entries {
+            .expect("scan upload leaves").into_parts();
+        assert_eq!(leaves.len(), 3);
+        for entry in leaves {
             let StorageProjectedValue::FullValue(value) = entry.value else {
                 panic!("manifest leaf scan must return values");
             };

--- a/packages/lix/src/storage/conformance/baseline.rs
+++ b/packages/lix/src/storage/conformance/baseline.rs
@@ -576,12 +576,12 @@ where
         .begin_scan(TEST_SPACE, range, BeginScanOptions::default())
         .await
         .map_err(|error| format!("begin scan_range failed: {error}"))?;
-    let first = cursor
+    let (first, first_has_more) = cursor
         .next_page(2)
         .await
-        .map_err(|error| format!("first scan_range failed: {error}"))?;
-    assert_read_entries(&first.entries, &[("b", "B"), ("c", "C")])?;
-    if !first.has_more {
+        .map_err(|error| format!("first scan_range failed: {error}"))?.into_parts();
+    assert_read_entries(&first, &[("b", "B"), ("c", "C")])?;
+    if !first_has_more {
         return Err("first scan chunk did not report has_more".to_string());
     }
 
@@ -635,15 +635,15 @@ where
         )
         .await
         .map_err(|error| format!("begin capped scan failed: {error}"))?;
-    let first = cursor
+    let (first, first_has_more) = cursor
         .next_page(usize::MAX)
         .await
-        .map_err(|error| format!("first capped scan failed: {error}"))?;
-    if first.entries.len() != MAX_SCAN_PAGE_ROWS || !first.has_more {
+        .map_err(|error| format!("first capped scan failed: {error}"))?.into_parts();
+    if first.len() != MAX_SCAN_PAGE_ROWS || !first_has_more {
         return Err(format!(
             "oversized scan returned {} rows with has_more={} (expected {} and true)",
-            first.entries.len(),
-            first.has_more,
+            first.len(),
+            first_has_more,
             MAX_SCAN_PAGE_ROWS
         ));
     }
@@ -864,12 +864,12 @@ where
             .await
             .map_err(|error| format!("begin scan limit {limit} failed: {error}"))?;
         loop {
-            let chunk = cursor
+            let (chunk, chunk_has_more) = cursor
                 .next_page(limit)
                 .await
-                .map_err(|error| format!("scan_range limit {limit} failed: {error}"))?;
-            actual.extend(entries_to_key_values(&chunk.entries));
-            if !chunk.has_more {
+                .map_err(|error| format!("scan_range limit {limit} failed: {error}"))?.into_parts();
+            actual.extend(entries_to_key_values(&chunk));
+            if !chunk_has_more {
                 break;
             }
             if actual.len() > expected.len() {
@@ -930,12 +930,12 @@ where
             .await
             .map_err(|error| format!("begin paged scan limit {limit} failed: {error}"))?;
         loop {
-            let result = cursor
+            let (result, result_has_more) = cursor
                 .next_page(limit)
                 .await
-                .map_err(|error| format!("paged scan limit {limit} failed: {error}"))?;
-            actual.extend(entries_to_key_values(&result.entries));
-            if !result.has_more {
+                .map_err(|error| format!("paged scan limit {limit} failed: {error}"))?.into_parts();
+            actual.extend(entries_to_key_values(&result));
+            if !result_has_more {
                 break;
             }
             if actual.len() > expected.len() {
@@ -1147,12 +1147,12 @@ where
         .begin_scan(TEST_SPACE, full_range.clone(), BeginScanOptions::default())
         .await
         .map_err(|error| format!("begin old cursor failed: {error}"))?;
-    let first = old_cursor
+    let (first, first_has_more) = old_cursor
         .next_page(2)
         .await
-        .map_err(|error| format!("old cursor first page failed: {error}"))?;
-    assert_read_entries(&first.entries, &[("a", "A"), ("b", "B")])?;
-    if !first.has_more {
+        .map_err(|error| format!("old cursor first page failed: {error}"))?.into_parts();
+    assert_read_entries(&first, &[("a", "A"), ("b", "B")])?;
+    if !first_has_more {
         return Err("old cursor ended before its second page".to_string());
     }
 
@@ -1179,12 +1179,12 @@ where
         .await
         .map_err(|error| format!("commit concurrent mutation failed: {error}"))?;
 
-    let second = old_cursor
+    let (second, second_has_more) = old_cursor
         .next_page(2)
         .await
-        .map_err(|error| format!("old cursor second page failed: {error}"))?;
-    assert_read_entries(&second.entries, &[("c", "C"), ("d", "D")])?;
-    if second.has_more {
+        .map_err(|error| format!("old cursor second page failed: {error}"))?.into_parts();
+    assert_read_entries(&second, &[("c", "C"), ("d", "D")])?;
+    if second_has_more {
         return Err("old cursor exposed unexpected rows after its snapshot tail".to_string());
     }
     drop(old_cursor);
@@ -1205,11 +1205,11 @@ where
         )
         .await
         .map_err(|error| format!("begin exclusive restart failed: {error}"))?;
-    let restarted_page = restarted
+    let (restarted_page, restarted_page_has_more) = restarted
         .next_page(usize::MAX)
         .await
-        .map_err(|error| format!("exclusive restart failed: {error}"))?;
-    assert_read_entries(&restarted_page.entries, &[("c", "C2"), ("e", "E")])
+        .map_err(|error| format!("exclusive restart failed: {error}"))?.into_parts();
+    assert_read_entries(&restarted_page, &[("c", "C2"), ("e", "E")])
 }
 
 async fn descending_scan_is_explicitly_unsupported<F>(factory: &F) -> ConformanceResult
@@ -1264,11 +1264,11 @@ where
         .map_err(|error| format!("begin cursor failed: {error}"))?;
     let unpolled = cursor.next_page(1);
     drop(unpolled);
-    let page = cursor
+    let (page, page_has_more) = cursor
         .next_page(1)
         .await
-        .map_err(|error| format!("cursor failed after unpolled cancellation: {error}"))?;
-    assert_read_entries(&page.entries, &[("a", "A")])
+        .map_err(|error| format!("cursor failed after unpolled cancellation: {error}"))?.into_parts();
+    assert_read_entries(&page, &[("a", "A")])
 }
 
 async fn invalid_scan_range_fails_closed<F>(factory: &F) -> ConformanceResult

--- a/packages/lix/src/storage/conformance/baseline.rs
+++ b/packages/lix/src/storage/conformance/baseline.rs
@@ -536,7 +536,7 @@ where
         .begin_read(ReadOptions::default())
         .await
         .map_err(|error| format!("begin_read failed: {error}"))?;
-    let chunk = scan_range(
+    let (chunk, chunk_has_more) = scan_range(
         &read,
         test_space,
         KeyRange {
@@ -546,9 +546,9 @@ where
         BeginScanOptions::default(),
     )
     .await
-    .map_err(|error| format!("scan_range failed: {error}"))?;
+    .map_err(|error| format!("scan_range failed: {error}"))?.into_parts();
 
-    assert_read_entries(&chunk.entries, &[("a", "B")])
+    assert_read_entries(&chunk, &[("a", "B")])
 }
 
 async fn scan_range_returns_forward_row_bounded_chunks<F>(factory: &F) -> ConformanceResult
@@ -585,12 +585,13 @@ where
         return Err("first scan chunk did not report has_more".to_string());
     }
 
-    let second = cursor
+    let (second, second_has_more) = cursor
         .next_page(2)
         .await
-        .map_err(|error| format!("second scan_range failed: {error}"))?;
-    assert_read_entries(&second.entries, &[("d", "D")])?;
-    if second.has_more {
+        .map_err(|error| format!("second scan_range failed: {error}"))?
+        .into_parts();
+    assert_read_entries(&second, &[("d", "D")])?;
+    if second_has_more {
         return Err("last scan chunk unexpectedly reported has_more".to_string());
     }
     Ok(())
@@ -648,24 +649,25 @@ where
         ));
     }
 
-    let tail = cursor
+    let (tail, tail_has_more) = cursor
         .next_page(usize::MAX)
         .await
-        .map_err(|error| format!("tail scan failed: {error}"))?;
-    if tail.entries.len() != 1 || tail.has_more {
+        .map_err(|error| format!("tail scan failed: {error}"))?
+        .into_parts();
+    if tail.len() != 1 || tail_has_more {
         return Err(format!(
             "tail scan returned {} rows with has_more={} (expected 1 and false)",
-            tail.entries.len(),
-            tail.has_more
+            tail.len(),
+            tail_has_more
         ));
     }
     let expected_tail = key(u32::try_from(MAX_SCAN_PAGE_ROWS)
         .expect("maximum scan page rows fits u32")
         .to_be_bytes());
-    if tail.entries[0].key != expected_tail {
+    if tail[0].key != expected_tail {
         return Err(format!(
             "tail scan returned key {:?}, expected {:?}",
-            tail.entries[0].key, expected_tail
+            tail[0].key, expected_tail
         ));
     }
     Ok(())
@@ -688,7 +690,7 @@ where
         .await
         .map_err(|error| format!("begin_read failed: {error}"))?;
 
-    let included = scan_range(
+    let (included, included_has_more) = scan_range(
         &read,
         test_space,
         KeyRange {
@@ -698,10 +700,10 @@ where
         BeginScanOptions::default(),
     )
     .await
-    .map_err(|error| format!("included range scan failed: {error}"))?;
-    assert_read_entries(&included.entries, &[("b", "B"), ("c", "C")])?;
+    .map_err(|error| format!("included range scan failed: {error}"))?.into_parts();
+    assert_read_entries(&included, &[("b", "B"), ("c", "C")])?;
 
-    let excluded = scan_range(
+    let (excluded, excluded_has_more) = scan_range(
         &read,
         test_space,
         KeyRange {
@@ -711,8 +713,8 @@ where
         BeginScanOptions::default(),
     )
     .await
-    .map_err(|error| format!("excluded range scan failed: {error}"))?;
-    assert_read_entries(&excluded.entries, &[("c", "C")])
+    .map_err(|error| format!("excluded range scan failed: {error}"))?.into_parts();
+    assert_read_entries(&excluded, &[("c", "C")])
 }
 
 async fn scan_range_resume_before_lower_does_not_widen_range<F>(factory: &F) -> ConformanceResult
@@ -731,7 +733,7 @@ where
         .begin_read(ReadOptions::default())
         .await
         .map_err(|error| format!("begin_read failed: {error}"))?;
-    let chunk = scan_range(
+    let (chunk, chunk_has_more) = scan_range(
         &read,
         test_space,
         KeyRange {
@@ -741,9 +743,9 @@ where
         BeginScanOptions::default(),
     )
     .await
-    .map_err(|error| format!("scan_range failed: {error}"))?;
+    .map_err(|error| format!("scan_range failed: {error}"))?.into_parts();
 
-    assert_read_entries(&chunk.entries, &[("c", "C"), ("d", "D")])
+    assert_read_entries(&chunk, &[("c", "C"), ("d", "D")])
 }
 
 async fn scan_range_orders_raw_byte_keys<F>(factory: &F) -> ConformanceResult
@@ -782,7 +784,7 @@ where
         .begin_read(ReadOptions::default())
         .await
         .map_err(|error| format!("begin_read failed: {error}"))?;
-    let chunk = scan_range(
+    let (chunk, chunk_has_more) = scan_range(
         &read,
         test_space,
         KeyRange {
@@ -792,10 +794,10 @@ where
         BeginScanOptions::default(),
     )
     .await
-    .map_err(|error| format!("scan_range failed: {error}"))?;
+    .map_err(|error| format!("scan_range failed: {error}"))?.into_parts();
 
     assert_read_entries_bytes(
-        &chunk.entries,
+        &chunk,
         &[
             (Bytes::new(), Bytes::from_static(b"empty")),
             (Bytes::from_static(&[0x00]), Bytes::from_static(b"00")),
@@ -964,7 +966,7 @@ where
         .begin_read(ReadOptions::default())
         .await
         .map_err(|error| format!("begin_read failed: {error}"))?;
-    let chunk = scan_range(
+    let (chunk, chunk_has_more) = scan_range(
         &read,
         test_space,
         KeyRange {
@@ -974,11 +976,11 @@ where
         BeginScanOptions::default(),
     )
     .await
-    .map_err(|error| format!("scan_range failed: {error}"))?;
-    if chunk.entries.is_empty() {
+    .map_err(|error| format!("scan_range failed: {error}"))?.into_parts();
+    if chunk.is_empty() {
         Ok(())
     } else {
-        Err(format!("empty range returned entries: {:?}", chunk.entries))
+        Err(format!("empty range returned entries: {:?}", chunk))
     }
 }
 
@@ -1105,7 +1107,7 @@ where
         &[("a", "A")],
     )?;
 
-    let old_scan = scan_range(
+    let (old_scan, old_scan_has_more) = scan_range(
         &old_read,
         test_space,
         KeyRange {
@@ -1115,8 +1117,8 @@ where
         BeginScanOptions::default(),
     )
     .await
-    .map_err(|error| format!("old read scan_range failed: {error}"))?;
-    assert_read_entries(&old_scan.entries, &[("a", "A")])?;
+    .map_err(|error| format!("old read scan_range failed: {error}"))?.into_parts();
+    assert_read_entries(&old_scan, &[("a", "A")])?;
 
     assert_get_entries(&storage, test_space, &[("a", Some("C"))]).await
 }
@@ -1338,7 +1340,7 @@ where
         &[key("a")],
     )?;
 
-    let key_only_scan = scan_range(
+    let (key_only_scan, key_only_scan_has_more) = scan_range(
         &read,
         test_space,
         KeyRange {
@@ -1351,8 +1353,8 @@ where
         },
     )
     .await
-    .map_err(|error| format!("KeyOnly scan_range failed: {error}"))?;
-    assert_key_only_entries(&key_only_scan.entries, &[key("a")])
+    .map_err(|error| format!("KeyOnly scan_range failed: {error}"))?.into_parts();
+    assert_key_only_entries(&key_only_scan, &[key("a")])
 }
 
 fn assert_key_only_entries(entries: &[ReadEntry], expected_keys: &[Key]) -> ConformanceResult {
@@ -1523,7 +1525,7 @@ where
         .begin_read(ReadOptions::default())
         .await
         .map_err(|error| format!("begin read failed: {error}"))?;
-    let result = scan_range_in_space(
+    let (result, result_has_more) = scan_range_in_space(
         &read,
         OTHER_SPACE,
         full_key_range(),
@@ -1531,19 +1533,18 @@ where
         MAX_SCAN_PAGE_ROWS,
     )
     .await
-    .map_err(|error| format!("scan failed: {error}"))?;
+    .map_err(|error| format!("scan failed: {error}"))?.into_parts();
     let rows = result
-        .entries
         .iter()
         .map(|entry| entry.key.clone())
         .collect::<Vec<_>>();
-    if rows != vec![key("a"), key("b"), key("c")] || result.has_more {
+    if rows != vec![key("a"), key("b"), key("c")] || result_has_more {
         return Err(format!("scan must observe only its space, got {rows:?}"));
     }
 
     // Resume past the last row: must report exhaustion, never the
     // neighbouring space's rows.
-    let result = scan_range_in_space(
+    let (result, result_has_more) = scan_range_in_space(
         &read,
         OTHER_SPACE,
         KeyRange {
@@ -1554,13 +1555,13 @@ where
         MAX_SCAN_PAGE_ROWS,
     )
     .await
-    .map_err(|error| format!("resume scan failed: {error}"))?;
+    .map_err(|error| format!("resume scan failed: {error}"))?
+    .into_parts();
     let tail = result
-        .entries
         .iter()
         .map(|entry| entry.key.clone())
         .collect::<Vec<_>>();
-    if !tail.is_empty() || result.has_more {
+    if !tail.is_empty() || result_has_more {
         return Err(format!(
             "resume past the space's last key must be empty, got {tail:?}"
         ));
@@ -1623,7 +1624,8 @@ where
         )
         .await
         .map_err(|error| format!("scan failed: {error}"))?
-        .entries
+        .into_parts()
+        .0
         .len();
         if rows != expected {
             return Err(format!(
@@ -1670,7 +1672,7 @@ where
     if result.values[0].as_ref().is_some() {
         return Err("never-written space must miss".to_string());
     }
-    let scan = scan_range_in_space(
+    let (scan, scan_has_more) = scan_range_in_space(
         &read,
         empty,
         full_key_range(),
@@ -1678,8 +1680,9 @@ where
         MAX_SCAN_PAGE_ROWS,
     )
     .await
-    .map_err(|error| format!("scan failed: {error}"))?;
-    if !scan.entries.is_empty() || scan.has_more {
+    .map_err(|error| format!("scan failed: {error}"))?
+    .into_parts();
+    if !scan.is_empty() || scan_has_more {
         return Err("never-written space must scan empty".to_string());
     }
     drop(read);

--- a/packages/lix/src/storage/conformance/baseline.rs
+++ b/packages/lix/src/storage/conformance/baseline.rs
@@ -536,7 +536,7 @@ where
         .begin_read(ReadOptions::default())
         .await
         .map_err(|error| format!("begin_read failed: {error}"))?;
-    let (chunk, chunk_has_more) = scan_range(
+    let (chunk, _chunk_has_more) = scan_range(
         &read,
         test_space,
         KeyRange {
@@ -690,7 +690,7 @@ where
         .await
         .map_err(|error| format!("begin_read failed: {error}"))?;
 
-    let (included, included_has_more) = scan_range(
+    let (included, _included_has_more) = scan_range(
         &read,
         test_space,
         KeyRange {
@@ -703,7 +703,7 @@ where
     .map_err(|error| format!("included range scan failed: {error}"))?.into_parts();
     assert_read_entries(&included, &[("b", "B"), ("c", "C")])?;
 
-    let (excluded, excluded_has_more) = scan_range(
+    let (excluded, _excluded_has_more) = scan_range(
         &read,
         test_space,
         KeyRange {
@@ -733,7 +733,7 @@ where
         .begin_read(ReadOptions::default())
         .await
         .map_err(|error| format!("begin_read failed: {error}"))?;
-    let (chunk, chunk_has_more) = scan_range(
+    let (chunk, _chunk_has_more) = scan_range(
         &read,
         test_space,
         KeyRange {
@@ -784,7 +784,7 @@ where
         .begin_read(ReadOptions::default())
         .await
         .map_err(|error| format!("begin_read failed: {error}"))?;
-    let (chunk, chunk_has_more) = scan_range(
+    let (chunk, _chunk_has_more) = scan_range(
         &read,
         test_space,
         KeyRange {
@@ -966,7 +966,7 @@ where
         .begin_read(ReadOptions::default())
         .await
         .map_err(|error| format!("begin_read failed: {error}"))?;
-    let (chunk, chunk_has_more) = scan_range(
+    let (chunk, _chunk_has_more) = scan_range(
         &read,
         test_space,
         KeyRange {
@@ -1107,7 +1107,7 @@ where
         &[("a", "A")],
     )?;
 
-    let (old_scan, old_scan_has_more) = scan_range(
+    let (old_scan, _old_scan_has_more) = scan_range(
         &old_read,
         test_space,
         KeyRange {
@@ -1207,7 +1207,7 @@ where
         )
         .await
         .map_err(|error| format!("begin exclusive restart failed: {error}"))?;
-    let (restarted_page, restarted_page_has_more) = restarted
+    let (restarted_page, _restarted_page_has_more) = restarted
         .next_page(usize::MAX)
         .await
         .map_err(|error| format!("exclusive restart failed: {error}"))?.into_parts();
@@ -1266,7 +1266,7 @@ where
         .map_err(|error| format!("begin cursor failed: {error}"))?;
     let unpolled = cursor.next_page(1);
     drop(unpolled);
-    let (page, page_has_more) = cursor
+    let (page, _page_has_more) = cursor
         .next_page(1)
         .await
         .map_err(|error| format!("cursor failed after unpolled cancellation: {error}"))?.into_parts();
@@ -1340,7 +1340,7 @@ where
         &[key("a")],
     )?;
 
-    let (key_only_scan, key_only_scan_has_more) = scan_range(
+    let (key_only_scan, _key_only_scan_has_more) = scan_range(
         &read,
         test_space,
         KeyRange {

--- a/packages/lix/src/storage/conformance/failure_tests.rs
+++ b/packages/lix/src/storage/conformance/failure_tests.rs
@@ -429,10 +429,7 @@ impl StorageScanSource for BrokenScanSource {
                 self.last = Some(entry.clone());
                 entries.push(entry);
             }
-            Ok(ScanChunk {
-                entries,
-                has_more: !self.rows.is_empty(),
-            })
+            Ok(ScanChunk::new(entries, !self.rows.is_empty()))
         })
     }
 }

--- a/packages/lix/src/storage/conformance/model_based.rs
+++ b/packages/lix/src/storage/conformance/model_based.rs
@@ -200,20 +200,20 @@ where
             )
             .await
             .map_err(|error| format!("{label}: begin full scan in {space:?} failed: {error}"))?;
-        let chunk = cursor
+        let (chunk, chunk_has_more) = cursor
             .next_page(usize::MAX)
             .await
-            .map_err(|error| format!("{label}: full scan in {space:?} failed: {error}"))?;
-        let actual = chunk_entries(&chunk.entries);
+            .map_err(|error| format!("{label}: full scan in {space:?} failed: {error}"))?.into_parts();
+        let actual = chunk_entries(&chunk);
         let expected = model
             .iter()
             .map(|(key, value)| (key.clone(), value.clone()))
             .collect::<Vec<_>>();
-        if actual != expected || chunk.has_more {
+        if actual != expected || chunk_has_more {
             return Err(format!(
                 "{label}: full scan in {space:?} mismatch: expected {expected:?} with \
                  has_more=false, got {actual:?} with has_more={}",
-                chunk.has_more
+                chunk_has_more
             ));
         }
     }
@@ -280,10 +280,10 @@ where
         )
         .await
         .map_err(|error| format!("{label}: begin randomized scan failed: {error}"))?;
-    let chunk = cursor
+    let (chunk, chunk_has_more) = cursor
         .next_page(limit_rows)
         .await
-        .map_err(|error| format!("{label}: randomized scan failed: {error}"))?;
+        .map_err(|error| format!("{label}: randomized scan failed: {error}"))?.into_parts();
     let eligible = scan_model
         .iter()
         .filter(|(key, _)| {
@@ -299,13 +299,13 @@ where
         .collect::<Vec<_>>();
     let expected_has_more = limit_rows != 0 && eligible.len() > limit_rows;
     let expected_scan = eligible.into_iter().take(limit_rows).collect::<Vec<_>>();
-    if chunk.entries != expected_scan || chunk.has_more != expected_has_more {
+    if chunk != expected_scan || chunk_has_more != expected_has_more {
         return Err(format!(
             "{label}: randomized scan in {scan_space:?} mismatch for range {range:?}, \
              resume_after {resume_after:?}, limit {limit_rows}, projection {projection:?}: \
              expected {expected_scan:?} with has_more={expected_has_more}, got {:?} with \
              has_more={}",
-            chunk.entries, chunk.has_more
+            chunk, chunk_has_more
         ));
     }
 

--- a/packages/lix/src/storage/cursor.rs
+++ b/packages/lix/src/storage/cursor.rs
@@ -2,7 +2,7 @@ use std::future::Future;
 use std::ops::Bound;
 use std::pin::Pin;
 
-use crate::storage::{Key, KeyRange, ScanChunk, ScanOrder, StorageError};
+use crate::storage::{Key, KeyRange, ReadEntry, ScanChunk, ScanOrder, StorageError};
 
 /// Ephemeral iterator state owned by a coherent storage read view.
 ///
@@ -60,6 +60,17 @@ impl<'a> ScanCursor<'a> {
 
     /// Advances the live native iterator by at most `limit_rows` entries.
     ///
+    /// **This is the deliberately bounded read.** It stops at the page boundary
+    /// even when the range holds more rows, and the returned [`ScanChunk`] only
+    /// yields its entries through
+    /// [`into_parts`](ScanChunk::into_parts) so that the `has_more` flag is
+    /// bound at the call site. Reach for it only when a bound is the intent —
+    /// an existence probe, a `LIMIT` pushed down from SQL, or a byte budget.
+    ///
+    /// **To read every row in the range, use [`Self::collect_all`] or
+    /// [`Self::next_chunk`] instead.** Those cannot truncate, and they are
+    /// shorter to write than a hand-rolled page loop.
+    ///
     /// The requested limit is capped by [`crate::storage::MAX_SCAN_PAGE_ROWS`].
     /// A zero limit ends the cursor without touching the backend.
     ///
@@ -74,29 +85,65 @@ impl<'a> ScanCursor<'a> {
         }
         if self.finished || limit_rows == 0 {
             self.finished = true;
-            return Ok(ScanChunk {
-                entries: Vec::new(),
-                has_more: false,
-            });
+            return Ok(ScanChunk::new(Vec::new(), false));
         }
         let page_size = limit_rows.min(crate::storage::MAX_SCAN_PAGE_ROWS);
         self.poisoned = true;
-        let chunk = self.source.next_page(page_size).await?;
-        if chunk.entries.len() > page_size
-            || (chunk.has_more && chunk.entries.is_empty())
-            || !self.valid_entries(&chunk)
+        let (entries, has_more) = self.source.next_page(page_size).await?.into_parts();
+        if entries.len() > page_size
+            || (has_more && entries.is_empty())
+            || !self.valid_entries(&entries)
         {
             return Err(StorageError::InvalidCursor);
         }
-        self.last_key = chunk.entries.last().map(|entry| entry.key.clone());
-        self.finished = !chunk.has_more;
+        self.last_key = entries.last().map(|entry| entry.key.clone());
+        self.finished = !has_more;
         self.poisoned = false;
-        Ok(chunk)
+        Ok(ScanChunk::new(entries, has_more))
     }
 
-    fn valid_entries(&self, chunk: &ScanChunk) -> bool {
+    /// Yields the next chunk of rows, or `None` once the range is drained.
+    ///
+    /// This is the streaming drain:
+    /// `while let Some(entries) = cursor.next_chunk().await? { … }` visits
+    /// every row in the range without materializing all of them at once, and
+    /// there is no continuation flag for a caller to forget. Prefer it over a
+    /// hand-written `next_page` loop — a hand-written loop is exactly the shape
+    /// that truncated certified-manifest scans at one page.
+    pub async fn next_chunk(&mut self) -> Result<Option<Vec<ReadEntry>>, StorageError> {
+        if self.finished {
+            return Ok(None);
+        }
+        let (entries, has_more) = self
+            .next_page(crate::storage::MAX_SCAN_PAGE_ROWS)
+            .await?
+            .into_parts();
+        if entries.is_empty() && !has_more {
+            return Ok(None);
+        }
+        Ok(Some(entries))
+    }
+
+    /// Reads every remaining row in the range into one vector.
+    ///
+    /// This is the ordinary read. It cannot truncate, and it is shorter than
+    /// the bounded form, which is the intended asymmetry: a call site that
+    /// wants everything says so in one call, and a call site that wants a bound
+    /// has to reach for [`Self::next_page`] and bind `has_more` explicitly.
+    ///
+    /// The cost is O(rows in range) memory. A caller scanning an unbounded
+    /// range over a large space should stream with [`Self::next_chunk`].
+    pub async fn collect_all(&mut self) -> Result<Vec<ReadEntry>, StorageError> {
+        let mut all = Vec::new();
+        while let Some(entries) = self.next_chunk().await? {
+            all.extend(entries);
+        }
+        Ok(all)
+    }
+
+    fn valid_entries(&self, entries: &[ReadEntry]) -> bool {
         let mut previous = self.last_key.as_ref();
-        for entry in &chunk.entries {
+        for entry in entries {
             if !range_contains(&self.range, &entry.key) {
                 return false;
             }
@@ -141,7 +188,7 @@ fn range_contains(range: &KeyRange, key: &Key) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::storage::{ProjectedValue, ReadEntry};
+    use crate::storage::ProjectedValue;
     use bytes::Bytes;
     use std::task::{Context, Poll};
 
@@ -153,13 +200,13 @@ mod tests {
             _limit_rows: usize,
         ) -> Pin<Box<dyn Future<Output = Result<ScanChunk, StorageError>> + Send + '_>> {
             Box::pin(async {
-                Ok(ScanChunk {
-                    entries: vec![ReadEntry {
+                Ok(ScanChunk::new(
+                    vec![ReadEntry {
                         key: Key(Bytes::from_static(b"a")),
                         value: ProjectedValue::KeyOnly,
                     }],
-                    has_more: false,
-                })
+                    false,
+                ))
             })
         }
     }
@@ -198,10 +245,7 @@ mod tests {
                     key: Key(Bytes::from_static(b"a")),
                     value: ProjectedValue::KeyOnly,
                 };
-                Ok(ScanChunk {
-                    entries: vec![entry.clone(), entry],
-                    has_more: false,
-                })
+                Ok(ScanChunk::new(vec![entry.clone(), entry], false))
             })
         }
     }
@@ -220,8 +264,12 @@ mod tests {
         let future = cursor.next_page(1);
         drop(future);
 
-        let page = cursor.next_page(1).await.expect("cursor remains usable");
-        assert_eq!(page.entries[0].key.0.as_ref(), b"a");
+        let (entries, _has_more) = cursor
+            .next_page(1)
+            .await
+            .expect("cursor remains usable")
+            .into_parts();
+        assert_eq!(entries[0].key.0.as_ref(), b"a");
     }
 
     #[tokio::test]

--- a/packages/lix/src/storage/in_memory.rs
+++ b/packages/lix/src/storage/in_memory.rs
@@ -668,12 +668,12 @@ mod tests {
             )
             .await
             .expect("begin scan after range delete");
-        let chunk = cursor
+        let (chunk, chunk_has_more) = cursor
             .next_page(MAX_SCAN_PAGE_ROWS)
             .await
-            .expect("scan after range delete");
-        assert!(chunk.entries.is_empty());
-        assert!(!chunk.has_more);
+            .expect("scan after range delete").into_parts();
+        assert!(chunk.is_empty());
+        assert!(!chunk_has_more);
     }
 
     #[tokio::test]

--- a/packages/lix/src/storage/in_memory.rs
+++ b/packages/lix/src/storage/in_memory.rs
@@ -360,10 +360,7 @@ impl StorageScanSource for MemoryScanSource<'_> {
                 });
             }
             self.pending = self.cursor.next();
-            Ok(ScanChunk {
-                entries,
-                has_more: self.pending.is_some(),
-            })
+            Ok(ScanChunk::new(entries, self.pending.is_some()))
         })
     }
 }

--- a/packages/lix/src/storage/types.rs
+++ b/packages/lix/src/storage/types.rs
@@ -381,10 +381,51 @@ impl Default for BeginScanOptions {
     }
 }
 
+/// One page of a storage scan, together with whether the range has more rows.
+///
+/// Both fields are private on purpose. The only way to reach the rows is
+/// [`ScanChunk::into_parts`], which hands back `has_more` in the same
+/// expression, so a caller that stops after one page does so visibly at the
+/// call site. The previous public `entries` field let
+/// `cursor.next_page(MAX_SCAN_PAGE_ROWS).await?.entries` read as a complete
+/// scan while silently dropping every row past the page boundary; nothing in
+/// the type system, the linter, or CI could see that.
+///
+/// Callers that want every row in the range must not assemble pages by hand.
+/// Use [`crate::storage::ScanCursor::collect_all`] for a materialized vector or
+/// [`crate::storage::ScanCursor::next_chunk`] to stream page by page — neither
+/// exposes a flag that can be forgotten.
 #[derive(Clone, Debug, PartialEq, Eq)]
+#[must_use = "a scan page carries `has_more`; dropping it silently truncates the scan"]
 pub struct ScanChunk {
-    pub entries: Vec<ReadEntry>,
-    pub has_more: bool,
+    entries: Vec<ReadEntry>,
+    has_more: bool,
+}
+
+impl ScanChunk {
+    /// Builds one scan page. Storage adapters are the intended callers.
+    pub fn new(entries: Vec<ReadEntry>, has_more: bool) -> Self {
+        Self { entries, has_more }
+    }
+
+    /// Splits the page into its rows and whether the range continues past them.
+    ///
+    /// Binding both halves is the point: a caller that discards the flag has
+    /// written that decision down where a reviewer can see it.
+    pub fn into_parts(self) -> (Vec<ReadEntry>, bool) {
+        (self.entries, self.has_more)
+    }
+
+    /// Rows in this page, not counting anything the range may hold after it.
+    pub fn len(&self) -> usize {
+        self.entries.len()
+    }
+
+    /// Whether this page has no rows. A page can be empty while the range
+    /// itself is not yet drained only if the backend says so.
+    pub fn is_empty(&self) -> bool {
+        self.entries.is_empty()
+    }
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]

--- a/packages/lix/src/storage_adapter/conformance.rs
+++ b/packages/lix/src/storage_adapter/conformance.rs
@@ -181,7 +181,7 @@ async fn prefix_scan_lowers_to_storage_range() -> StorageConformanceResult {
         .begin_scan(space_one(), range, BeginScanOptions::default())
         .await
         .map_err(|error| format!("begin prefix scan failed: {error}"))?;
-    let (chunk, chunk_has_more) = cursor
+    let (chunk, _chunk_has_more) = cursor
         .next_page(crate::storage::MAX_SCAN_PAGE_ROWS)
         .await
         .map_err(|error| format!("scan_prefix failed: {error}"))?.into_parts();
@@ -289,7 +289,7 @@ async fn read_scope_pins_snapshot() -> StorageConformanceResult {
         )
         .await
         .map_err(|error| format!("begin scan_range failed: {error}"))?;
-    let (chunk, chunk_has_more) = cursor
+    let (chunk, _chunk_has_more) = cursor
         .next_page(crate::storage::MAX_SCAN_PAGE_ROWS)
         .await
         .map_err(|error| format!("scan_range failed: {error}"))?.into_parts();

--- a/packages/lix/src/storage_adapter/conformance.rs
+++ b/packages/lix/src/storage_adapter/conformance.rs
@@ -181,10 +181,10 @@ async fn prefix_scan_lowers_to_storage_range() -> StorageConformanceResult {
         .begin_scan(space_one(), range, BeginScanOptions::default())
         .await
         .map_err(|error| format!("begin prefix scan failed: {error}"))?;
-    let chunk = cursor
+    let (chunk, chunk_has_more) = cursor
         .next_page(crate::storage::MAX_SCAN_PAGE_ROWS)
         .await
-        .map_err(|error| format!("scan_prefix failed: {error}"))?;
+        .map_err(|error| format!("scan_prefix failed: {error}"))?.into_parts();
 
     assert_eq!(
         chunk
@@ -236,10 +236,10 @@ async fn cursor_drains_chunked_pages() -> StorageConformanceResult {
         .map_err(|error| format!("begin scan plan failed: {error}"))?;
 
     loop {
-        let result = cursor
+        let (result, result_has_more) = cursor
             .next_page(2)
             .await
-            .map_err(|error| format!("scan cursor page failed: {error}"))?;
+            .map_err(|error| format!("scan cursor page failed: {error}"))?.into_parts();
 
         if result
             .entries
@@ -248,8 +248,8 @@ async fn cursor_drains_chunked_pages() -> StorageConformanceResult {
         {
             return Err("expected key-only scan value".to_string());
         }
-        emitted += result.entries.len();
-        if !result.has_more {
+        emitted += result.len();
+        if !result_has_more {
             break;
         }
     }
@@ -291,10 +291,10 @@ async fn read_scope_pins_snapshot() -> StorageConformanceResult {
         )
         .await
         .map_err(|error| format!("begin scan_range failed: {error}"))?;
-    let chunk = cursor
+    let (chunk, chunk_has_more) = cursor
         .next_page(crate::storage::MAX_SCAN_PAGE_ROWS)
         .await
-        .map_err(|error| format!("scan_range failed: {error}"))?;
+        .map_err(|error| format!("scan_range failed: {error}"))?.into_parts();
 
     assert_eq!(
         chunk

--- a/packages/lix/src/storage_adapter/conformance.rs
+++ b/packages/lix/src/storage_adapter/conformance.rs
@@ -188,7 +188,6 @@ async fn prefix_scan_lowers_to_storage_range() -> StorageConformanceResult {
 
     assert_eq!(
         chunk
-            .entries
             .into_iter()
             .map(|entry| entry.key)
             .collect::<Vec<_>>(),
@@ -242,7 +241,6 @@ async fn cursor_drains_chunked_pages() -> StorageConformanceResult {
             .map_err(|error| format!("scan cursor page failed: {error}"))?.into_parts();
 
         if result
-            .entries
             .iter()
             .any(|entry| !matches!(entry.value, ProjectedValue::KeyOnly))
         {
@@ -298,7 +296,6 @@ async fn read_scope_pins_snapshot() -> StorageConformanceResult {
 
     assert_eq!(
         chunk
-            .entries
             .into_iter()
             .map(|entry| entry.value)
             .collect::<Vec<_>>(),

--- a/packages/lix/src/storage_adapter/reader.rs
+++ b/packages/lix/src/storage_adapter/reader.rs
@@ -345,10 +345,10 @@ mod tests {
             )
             .await
             .expect("begin zero-limit prefix scan");
-        let result = cursor.next_page(0).await.expect("zero-limit prefix scan");
+        let (result, result_has_more) = cursor.next_page(0).await.expect("zero-limit prefix scan").into_parts();
 
-        assert!(result.entries.is_empty());
-        assert!(!result.has_more);
+        assert!(result.is_empty());
+        assert!(!result_has_more);
         assert_eq!(scan_calls.load(Ordering::Relaxed), 1);
     }
 
@@ -378,16 +378,16 @@ mod tests {
             )
             .await
             .expect("begin cursor");
-        let page = cursor.next_page(1).await.expect("first page");
-        assert_eq!(page.entries[0].key, key("a"));
-        assert!(page.has_more);
+        let (page, page_has_more) = cursor.next_page(1).await.expect("first page").into_parts();
+        assert_eq!(page[0].key, key("a"));
+        assert!(page_has_more);
 
-        let next = cursor
+        let (next, next_has_more) = cursor
             .next_page(crate::storage::MAX_SCAN_PAGE_ROWS)
             .await
-            .expect("second page");
+            .expect("second page").into_parts();
         assert_eq!(
-            next.entries
+            next
                 .into_iter()
                 .map(|entry| entry.key)
                 .collect::<Vec<_>>(),

--- a/packages/lix/src/storage_adapter/reader.rs
+++ b/packages/lix/src/storage_adapter/reader.rs
@@ -92,10 +92,7 @@ mod tests {
         ) -> std::pin::Pin<Box<dyn Future<Output = Result<ScanChunk, StorageError>> + Send + '_>>
         {
             Box::pin(async {
-                Ok(ScanChunk {
-                    entries: Vec::new(),
-                    has_more: false,
-                })
+                Ok(ScanChunk::new(Vec::new(), false))
             })
         }
     }

--- a/packages/lix/src/storage_adapter/reader.rs
+++ b/packages/lix/src/storage_adapter/reader.rs
@@ -302,7 +302,7 @@ mod tests {
                 .begin_scan(space(), range, BeginScanOptions::default())
                 .await
                 .expect("begin prefix scan");
-            cursor.next_page(1).await.expect("prefix scan");
+            let _ = cursor.next_page(1).await.expect("prefix scan");
         }
 
         assert_eq!(
@@ -382,7 +382,7 @@ mod tests {
         assert_eq!(page[0].key, key("a"));
         assert!(page_has_more);
 
-        let (next, next_has_more) = cursor
+        let (next, _next_has_more) = cursor
             .next_page(crate::storage::MAX_SCAN_PAGE_ROWS)
             .await
             .expect("second page").into_parts();

--- a/packages/lix/src/storage_bench.rs
+++ b/packages/lix/src/storage_bench.rs
@@ -3218,11 +3218,10 @@ where
         .await
         .expect("begin storage bench layout scan");
     loop {
-        let (result, result_has_more) = cursor
+        let (result, has_more) = cursor
             .next_page(crate::storage_adapter::MAX_SCAN_PAGE_ROWS)
             .await
             .expect("scan complete storage bench layout space").into_parts();
-        let has_more = result_has_more;
         for entry in result {
             accounting.rows = accounting
                 .rows
@@ -3271,11 +3270,10 @@ where
         .await
         .expect("begin storage bench layout scan");
     loop {
-        let (result, result_has_more) = cursor
+        let (result, has_more) = cursor
             .next_page(crate::storage_adapter::MAX_SCAN_PAGE_ROWS)
             .await
             .expect("scan complete storage bench layout space").into_parts();
-        let has_more = result_has_more;
         entries.extend(result);
         if !has_more {
             return entries;

--- a/packages/lix/src/storage_bench.rs
+++ b/packages/lix/src/storage_bench.rs
@@ -3218,12 +3218,12 @@ where
         .await
         .expect("begin storage bench layout scan");
     loop {
-        let result = cursor
+        let (result, result_has_more) = cursor
             .next_page(crate::storage_adapter::MAX_SCAN_PAGE_ROWS)
             .await
-            .expect("scan complete storage bench layout space");
-        let has_more = result.has_more;
-        for entry in result.entries {
+            .expect("scan complete storage bench layout space").into_parts();
+        let has_more = result_has_more;
+        for entry in result {
             accounting.rows = accounting
                 .rows
                 .checked_add(1)
@@ -3271,12 +3271,12 @@ where
         .await
         .expect("begin storage bench layout scan");
     loop {
-        let result = cursor
+        let (result, result_has_more) = cursor
             .next_page(crate::storage_adapter::MAX_SCAN_PAGE_ROWS)
             .await
-            .expect("scan complete storage bench layout space");
-        let has_more = result.has_more;
-        entries.extend(result.entries);
+            .expect("scan complete storage bench layout space").into_parts();
+        let has_more = result_has_more;
+        entries.extend(result);
         if !has_more {
             return entries;
         }

--- a/packages/lix/src/tracked_state/context.rs
+++ b/packages/lix/src/tracked_state/context.rs
@@ -8720,7 +8720,6 @@ mod tests {
             .expect("chunk inventory should scan").into_parts();
         assert!(!chunk_has_more, "test chunk inventory must fit one page");
         chunk
-            .entries
             .into_iter()
             .map(|entry| {
                 entry

--- a/packages/lix/src/tracked_state/context.rs
+++ b/packages/lix/src/tracked_state/context.rs
@@ -8714,11 +8714,11 @@ mod tests {
             )
             .await
             .expect("chunk inventory scan should begin");
-        let chunk = cursor
+        let (chunk, chunk_has_more) = cursor
             .next_page(crate::storage_adapter::MAX_SCAN_PAGE_ROWS)
             .await
-            .expect("chunk inventory should scan");
-        assert!(!chunk.has_more, "test chunk inventory must fit one page");
+            .expect("chunk inventory should scan").into_parts();
+        assert!(!chunk_has_more, "test chunk inventory must fit one page");
         chunk
             .entries
             .into_iter()

--- a/packages/lix/src/tracked_state/storage.rs
+++ b/packages/lix/src/tracked_state/storage.rs
@@ -3824,10 +3824,10 @@ pub(crate) async fn scan_commit_state_manifest_commit_ids(
         .await?;
     let mut commit_ids = Vec::new();
     loop {
-        let page = cursor
+        let (page, page_has_more) = cursor
             .next_page(crate::storage_adapter::MAX_SCAN_PAGE_ROWS)
-            .await?;
-        for entry in &page.entries {
+            .await?.into_parts();
+        for entry in &page {
             let bytes: [u8; 16] = entry.key.0.as_ref().try_into().map_err(|_| {
                 LixError::new(
                     LixError::CODE_INTERNAL_ERROR,
@@ -3836,7 +3836,7 @@ pub(crate) async fn scan_commit_state_manifest_commit_ids(
             })?;
             commit_ids.push(CommitId::new(uuid::Uuid::from_bytes(bytes)));
         }
-        if !page.has_more {
+        if !page_has_more {
             break;
         }
     }
@@ -9835,10 +9835,10 @@ pub(crate) async fn visit_change_records_from_commit_deltas(
         )
         .await?;
     loop {
-        let page = cursor
+        let (page, page_has_more) = cursor
             .next_page(crate::storage_adapter::MAX_SCAN_PAGE_ROWS)
-            .await?;
-        for entry_batch in page.entries.chunks(COMMIT_STATE_SCAN_AUTHORITY_BATCH_ROWS) {
+            .await?.into_parts();
+        for entry_batch in page.chunks(COMMIT_STATE_SCAN_AUTHORITY_BATCH_ROWS) {
             let commit_ids = entry_batch
                 .iter()
                 .map(|entry| commit_id_from_delta_key(&entry.key))
@@ -9925,7 +9925,7 @@ pub(crate) async fn visit_change_records_from_commit_deltas(
                 }
             }
         }
-        if !page.has_more {
+        if !page_has_more {
             break;
         }
     }
@@ -10003,14 +10003,14 @@ async fn validate_no_orphan_commit_delta_segments(
         )
         .await?;
     loop {
-        let page = cursor
+        let (page, page_has_more) = cursor
             .next_page(crate::storage_adapter::MAX_SCAN_PAGE_ROWS)
-            .await?;
-        if page.entries.is_empty() {
+            .await?.into_parts();
+        if page.is_empty() {
             break;
         }
         let mut commit_ids = Vec::new();
-        for entry in &page.entries {
+        for entry in &page {
             if entry.key.0.len() != 20 && entry.key.0.len() != 52 {
                 return Err(LixError::new(
                     LixError::CODE_INTERNAL_ERROR,
@@ -10027,7 +10027,7 @@ async fn validate_no_orphan_commit_delta_segments(
             .into_iter()
             .zip(manifests)
             .collect::<BTreeMap<_, _>>();
-        for entry in &page.entries {
+        for entry in &page {
             let commit_id = commit_id_from_delta_key(&entry.key)?;
             let segment_index = usize::try_from(u32::from_be_bytes(
                 entry.key.0[16..20]
@@ -10065,7 +10065,7 @@ async fn validate_no_orphan_commit_delta_segments(
                 ));
             }
         }
-        if !page.has_more {
+        if !page_has_more {
             break;
         }
     }
@@ -10675,10 +10675,10 @@ pub(crate) async fn stage_sweep_unreachable_content_nodes(
             )
             .await?;
         loop {
-            let page = cursor
+            let (page, page_has_more) = cursor
                 .next_page(crate::storage_adapter::MAX_SCAN_PAGE_ROWS)
-                .await?;
-            for entry in page.entries {
+                .await?.into_parts();
+            for entry in page {
                 let node_id = <[u8; 32]>::try_from(entry.key.0.as_ref()).map_err(|_| {
                     LixError::new(
                         LixError::CODE_INTERNAL_ERROR,
@@ -10692,7 +10692,7 @@ pub(crate) async fn stage_sweep_unreachable_content_nodes(
                     writes.delete(space, entry.key);
                 }
             }
-            if !page.has_more {
+            if !page_has_more {
                 break;
             }
         }
@@ -10720,16 +10720,16 @@ async fn scan_full_space(
         )
         .await?;
     loop {
-        let page = cursor
+        let (page, page_has_more) = cursor
             .next_page(crate::storage_adapter::MAX_SCAN_PAGE_ROWS)
-            .await?;
-        for entry in &page.entries {
+            .await?.into_parts();
+        for entry in &page {
             let StorageProjectedValue::FullValue(bytes) = &entry.value else {
                 unreachable!("full commit-delta scan returned a key-only row");
             };
             rows.push((entry.key.clone(), bytes.clone()));
         }
-        if !page.has_more {
+        if !page_has_more {
             break;
         }
     }

--- a/packages/lix/src/transaction/plugin_checkpoint.rs
+++ b/packages/lix/src/transaction/plugin_checkpoint.rs
@@ -125,17 +125,17 @@ pub(crate) async fn stage_delete_branch_plugin_checkpoints(
         )
         .await?;
     loop {
-        let chunk = cursor
+        let (chunk, chunk_has_more) = cursor
             .next_page(crate::storage_adapter::MAX_SCAN_PAGE_ROWS)
-            .await?;
-        if chunk.entries.is_empty() {
+            .await?.into_parts();
+        if chunk.is_empty() {
             break;
         }
         writes.delete_batch(
             PLUGIN_CHECKPOINT_SPACE,
-            chunk.entries.into_iter().map(|entry| entry.key),
+            chunk.into_iter().map(|entry| entry.key),
         );
-        if !chunk.has_more {
+        if !chunk_has_more {
             break;
         }
     }

--- a/packages/lix/tests/adapter_deterministic_sequence_corruption.rs
+++ b/packages/lix/tests/adapter_deterministic_sequence_corruption.rs
@@ -79,16 +79,16 @@ where
         .await
         .expect("HOT member scan should begin");
     loop {
-        let page = cursor
+        let (page, page_has_more) = cursor
             .next_page(lix::storage::MAX_SCAN_PAGE_ROWS)
             .await
-            .expect("HOT members should scan");
+            .expect("HOT members should scan").into_parts();
         sequence_entries.extend(
-            page.entries
+            page
                 .into_iter()
                 .filter(|entry| contains_subslice(entry.key.0.as_ref(), SEQUENCE_IDENTITY)),
         );
-        if !page.has_more {
+        if !page_has_more {
             break;
         }
     }

--- a/packages/lix/tests/integration/sql/lix_file_history.rs
+++ b/packages/lix/tests/integration/sql/lix_file_history.rs
@@ -119,7 +119,7 @@ impl StorageScanSource for CountingScanSource<'_> {
             let (chunk, chunk_has_more) = self.inner.next_page(limit_rows).await?.into_parts();
             self.scanned_rows
                 .fetch_add(chunk.len() as u64, Ordering::Relaxed);
-            Ok(chunk)
+            Ok(ScanChunk::new(chunk, chunk_has_more))
         })
     }
 }

--- a/packages/lix/tests/integration/sql/lix_file_history.rs
+++ b/packages/lix/tests/integration/sql/lix_file_history.rs
@@ -116,9 +116,9 @@ impl StorageScanSource for CountingScanSource<'_> {
         limit_rows: usize,
     ) -> std::pin::Pin<Box<dyn Future<Output = Result<ScanChunk, StorageError>> + Send + '_>> {
         Box::pin(async move {
-            let chunk = self.inner.next_page(limit_rows).await?;
+            let (chunk, chunk_has_more) = self.inner.next_page(limit_rows).await?.into_parts();
             self.scanned_rows
-                .fetch_add(chunk.entries.len() as u64, Ordering::Relaxed);
+                .fetch_add(chunk.len() as u64, Ordering::Relaxed);
             Ok(chunk)
         })
     }

--- a/packages/rocksdb-storage/src/rocksdb.rs
+++ b/packages/rocksdb-storage/src/rocksdb.rs
@@ -440,7 +440,7 @@ impl StorageScanSource for RocksDBScanSource<'_> {
                 .iterator
                 .key()
                 .is_some_and(|key| self.bounds.before_upper(key));
-            Ok(ScanChunk { entries, has_more })
+            Ok(ScanChunk::new(entries, has_more))
         })
     }
 }

--- a/packages/rs-sdk-tests/tests/e2e.rs
+++ b/packages/rs-sdk-tests/tests/e2e.rs
@@ -7940,22 +7940,20 @@ where
         )
         .await
         .expect("begin raw certified storage scan");
-    loop {
-        let page = cursor
-            .next_page(usize::MAX)
+    entries.extend(
+        cursor
+            .collect_all()
             .await
-            .expect("scan raw certified storage space");
-        let has_more = page.has_more;
-        entries.extend(page.entries.into_iter().map(|entry| {
-            let ProjectedValue::FullValue(bytes) = entry.value else {
-                panic!("full certified storage projection must return bytes");
-            };
-            (entry.key, bytes)
-        }));
-        if !has_more {
-            return entries;
-        }
-    }
+            .expect("scan raw certified storage space")
+            .into_iter()
+            .map(|entry| {
+                let ProjectedValue::FullValue(bytes) = entry.value else {
+                    panic!("full certified storage projection must return bytes");
+                };
+                (entry.key, bytes)
+            }),
+    );
+    entries
 }
 
 async fn write_and_verify_ceb2_fixture<StorageImpl>(storage: &StorageImpl)

--- a/packages/slatedb-storage/src/slatedb.rs
+++ b/packages/slatedb-storage/src/slatedb.rs
@@ -3070,7 +3070,7 @@ impl StorageScanSource for SlateDBScanSource {
             let space_id = self.space.id;
             #[cfg(test)]
             let worker_gate = self.worker_gate.clone();
-            let (state, mut chunk) = self
+            let (state, chunk) = self
                 .worker
                 .call_read(move |_db| async move {
                     #[cfg(test)]
@@ -3089,14 +3089,15 @@ impl StorageScanSource for SlateDBScanSource {
                 gate.entered_notify.notify_waiters();
                 gate.release.notified().await;
             }
+            let (mut entries, has_more) = chunk.into_parts();
             hydrate_immutable_value_scan(
                 &self.immutable_value_store,
                 self.space,
                 self.projection,
-                &mut chunk,
+                &mut entries,
             )
             .await?;
-            Ok(chunk)
+            Ok(ScanChunk::new(entries, has_more))
         })
     }
 }
@@ -3284,7 +3285,7 @@ async fn streaming_scan_page(
             })
         })
         .collect::<Result<Vec<_>, _>>()?;
-    Ok((state, ScanChunk { entries, has_more }))
+    Ok((state, ScanChunk::new(entries, has_more)))
 }
 
 async fn next_streaming_visible_row(
@@ -3364,7 +3365,7 @@ async fn hydrate_immutable_value_scan(
     immutable_value_store: &ImmutableValueStore,
     space: StorageSpace,
     projection: CoreProjection,
-    chunk: &mut ScanChunk,
+    entries: &mut [ReadEntry],
 ) -> Result<(), StorageError> {
     if space.value_semantics != ValueSemantics::Immutable || projection != CoreProjection::FullValue
     {
@@ -3372,8 +3373,7 @@ async fn hydrate_immutable_value_scan(
     }
     let values = immutable_value_store
         .get_many(
-            chunk
-                .entries
+            entries
                 .iter()
                 .map(|entry| match &entry.value {
                     ProjectedValue::FullValue(marker) => Ok(marker.clone()),
@@ -3384,7 +3384,7 @@ async fn hydrate_immutable_value_scan(
                 .collect::<Result<Vec<_>, _>>()?,
         )
         .await?;
-    for (entry, value) in chunk.entries.iter_mut().zip(values) {
+    for (entry, value) in entries.iter_mut().zip(values) {
         entry.value = ProjectedValue::FullValue(value);
     }
     Ok(())

--- a/packages/slatedb-storage/src/slatedb.rs
+++ b/packages/slatedb-storage/src/slatedb.rs
@@ -5788,10 +5788,12 @@ mod tests {
             },
         ))
         .expect("begin immutable chunk scan");
-        let scan = block_on(cursor.next_page(16)).expect("scan immutable chunk");
-        assert_eq!(scan.entries.len(), 1);
-        assert_eq!(scan.entries[0].key, key);
-        assert_eq!(scan.entries[0].value, ProjectedValue::FullValue(value));
+        let (scan, scan_has_more) = block_on(cursor.next_page(16))
+            .expect("scan immutable chunk")
+            .into_parts();
+        assert_eq!(scan.len(), 1);
+        assert_eq!(scan[0].key, key);
+        assert_eq!(scan[0].value, ProjectedValue::FullValue(value));
 
         let matching = block_on(storage.begin_write(WriteOptions {
             preconditions: vec![Precondition::KeyValueHashEquals {
@@ -6551,12 +6553,16 @@ mod tests {
             },
         ))
         .expect("begin cursor-test scan");
-        let first = block_on(cursor.next_page(1)).expect("scan first cursor-test page");
-        assert_eq!(first.entries[0].key, keys[0]);
-        assert!(first.has_more);
-        let second = block_on(cursor.next_page(1)).expect("scan second cursor-test page");
-        assert_eq!(second.entries[0].key, keys[1]);
-        assert!(second.has_more);
+        let (first, first_has_more) = block_on(cursor.next_page(1))
+            .expect("scan first cursor-test page")
+            .into_parts();
+        assert_eq!(first[0].key, keys[0]);
+        assert!(first_has_more);
+        let (second, second_has_more) = block_on(cursor.next_page(1))
+            .expect("scan second cursor-test page")
+            .into_parts();
+        assert_eq!(second[0].key, keys[1]);
+        assert!(second_has_more);
 
         // A changed projection requires a new cursor with an explicit exclusive
         // authenticated restart boundary.
@@ -6572,10 +6578,12 @@ mod tests {
             },
         ))
         .expect("begin projected restart scan");
-        let third = block_on(key_cursor.next_page(1)).expect("scan projected restart page");
-        assert_eq!(third.entries[0].key, keys[2]);
-        assert_eq!(third.entries[0].value, ProjectedValue::KeyOnly);
-        assert!(!third.has_more);
+        let (third, third_has_more) = block_on(key_cursor.next_page(1))
+            .expect("scan projected restart page")
+            .into_parts();
+        assert_eq!(third[0].key, keys[2]);
+        assert_eq!(third[0].value, ProjectedValue::KeyOnly);
+        assert!(!third_has_more);
 
         let mut restarted_cursor = block_on(read.begin_scan(
             space,
@@ -6586,11 +6594,13 @@ mod tests {
             },
         ))
         .expect("begin restarted cursor-test scan");
-        let restarted = block_on(restarted_cursor.next_page(1)).expect("scan restarted first page");
-        assert_eq!(restarted.entries[0].key, keys[0]);
+        let (restarted, restarted_has_more) = block_on(restarted_cursor.next_page(1))
+            .expect("scan restarted first page")
+            .into_parts();
+        assert_eq!(restarted[0].key, keys[0]);
         let restarted_second =
             block_on(restarted_cursor.next_page(1)).expect("scan restarted second page");
-        assert_eq!(restarted_second.entries[0].key, keys[1]);
+        assert_eq!(restarted_second[0].key, keys[1]);
     }
 
     #[test]

--- a/packages/slatedb-storage/src/slatedb.rs
+++ b/packages/slatedb-storage/src/slatedb.rs
@@ -5788,7 +5788,7 @@ mod tests {
             },
         ))
         .expect("begin immutable chunk scan");
-        let (scan, scan_has_more) = block_on(cursor.next_page(16))
+        let (scan, _scan_has_more) = block_on(cursor.next_page(16))
             .expect("scan immutable chunk")
             .into_parts();
         assert_eq!(scan.len(), 1);
@@ -5917,7 +5917,7 @@ mod tests {
             )
             .await
             .expect("begin fresh worker-cancellation cursor");
-        let (restarted, restarted_has_more) = restart
+        let (restarted, _restarted_has_more) = restart
             .next_page(2)
             .await
             .expect("drain fresh worker-cancellation cursor").into_parts();
@@ -6009,7 +6009,7 @@ mod tests {
             )
             .await
             .expect("begin explicit exclusive restart");
-        let (restarted, restarted_has_more) = restart
+        let (restarted, _restarted_has_more) = restart
             .next_page(1)
             .await
             .expect("read explicit exclusive restart page").into_parts();
@@ -6594,11 +6594,11 @@ mod tests {
             },
         ))
         .expect("begin restarted cursor-test scan");
-        let (restarted, restarted_has_more) = block_on(restarted_cursor.next_page(1))
+        let (restarted, _restarted_has_more) = block_on(restarted_cursor.next_page(1))
             .expect("scan restarted first page")
             .into_parts();
         assert_eq!(restarted[0].key, keys[0]);
-        let (restarted_second, _restarted_second_has_more) =
+        let (restarted_second, __restarted_second_has_more) =
             block_on(restarted_cursor.next_page(1))
                 .expect("scan restarted second page")
                 .into_parts();

--- a/packages/slatedb-storage/src/slatedb.rs
+++ b/packages/slatedb-storage/src/slatedb.rs
@@ -5915,10 +5915,10 @@ mod tests {
             )
             .await
             .expect("begin fresh worker-cancellation cursor");
-        let restarted = restart
+        let (restarted, restarted_has_more) = restart
             .next_page(2)
             .await
-            .expect("drain fresh worker-cancellation cursor");
+            .expect("drain fresh worker-cancellation cursor").into_parts();
         assert_eq!(
             restarted
                 .entries
@@ -6008,14 +6008,14 @@ mod tests {
             )
             .await
             .expect("begin explicit exclusive restart");
-        let restarted = restart
+        let (restarted, restarted_has_more) = restart
             .next_page(1)
             .await
-            .expect("read explicit exclusive restart page");
-        assert_eq!(restarted.entries.len(), 1);
-        assert_eq!(restarted.entries[0].key, second_key);
+            .expect("read explicit exclusive restart page").into_parts();
+        assert_eq!(restarted.len(), 1);
+        assert_eq!(restarted[0].key, second_key);
         assert_eq!(
-            restarted.entries[0].value,
+            restarted[0].value,
             ProjectedValue::FullValue(Bytes::from_static(b"second-value"))
         );
     }

--- a/packages/slatedb-storage/src/slatedb.rs
+++ b/packages/slatedb-storage/src/slatedb.rs
@@ -5921,7 +5921,6 @@ mod tests {
             .expect("drain fresh worker-cancellation cursor").into_parts();
         assert_eq!(
             restarted
-                .entries
                 .iter()
                 .map(|entry| entry.key.0.as_ref())
                 .collect::<Vec<_>>(),

--- a/packages/slatedb-storage/src/slatedb.rs
+++ b/packages/slatedb-storage/src/slatedb.rs
@@ -6598,8 +6598,10 @@ mod tests {
             .expect("scan restarted first page")
             .into_parts();
         assert_eq!(restarted[0].key, keys[0]);
-        let restarted_second =
-            block_on(restarted_cursor.next_page(1)).expect("scan restarted second page");
+        let (restarted_second, _restarted_second_has_more) =
+            block_on(restarted_cursor.next_page(1))
+                .expect("scan restarted second page")
+                .into_parts();
         assert_eq!(restarted_second[0].key, keys[1]);
     }
 
@@ -6768,7 +6770,8 @@ mod tests {
         assert_eq!(
             block_on(cursor.next_page(usize::MAX))
                 .expect("scan pending point")
-                .entries,
+                .into_parts()
+                .0,
             vec![ReadEntry {
                 key: key.clone(),
                 value: ProjectedValue::FullValue(value.clone()),
@@ -7203,7 +7206,8 @@ mod tests {
         assert_eq!(
             block_on(cursor.next_page(usize::MAX))
                 .expect("read publication through older scan view")
-                .entries,
+                .into_parts()
+                .0,
             vec![ReadEntry {
                 key,
                 value: ProjectedValue::FullValue(value),

--- a/packages/slatedb-storage/tests/storage.rs
+++ b/packages/slatedb-storage/tests/storage.rs
@@ -308,7 +308,6 @@ async fn slatedb_streams_unbounded_scan_limits() {
     assert_eq!(result.len(), 10);
     assert!(
         result
-            .entries
             .iter()
             .all(|entry| entry.value == ProjectedValue::KeyOnly)
     );
@@ -531,7 +530,6 @@ async fn assert_cached_rows(
 
     assert_eq!(result.len(), 3);
     let rows = result
-        .entries
         .into_iter()
         .map(|entry| {
             let ProjectedValue::FullValue(value) = entry.value else {

--- a/packages/slatedb-storage/tests/storage.rs
+++ b/packages/slatedb-storage/tests/storage.rs
@@ -523,7 +523,7 @@ async fn assert_cached_rows(
         )
         .await
         .expect("begin cached scan");
-    let (result, result_has_more) = cursor
+    let (result, _result_has_more) = cursor
         .next_page(usize::MAX)
         .await
         .expect("scan cached rows").into_parts();

--- a/packages/slatedb-storage/tests/storage.rs
+++ b/packages/slatedb-storage/tests/storage.rs
@@ -300,19 +300,19 @@ async fn slatedb_streams_unbounded_scan_limits() {
         )
         .await
         .expect("begin scan slatedb rows");
-    let result = cursor
+    let (result, result_has_more) = cursor
         .next_page(usize::MAX)
         .await
-        .expect("scan slatedb rows");
+        .expect("scan slatedb rows").into_parts();
 
-    assert_eq!(result.entries.len(), 10);
+    assert_eq!(result.len(), 10);
     assert!(
         result
             .entries
             .iter()
             .all(|entry| entry.value == ProjectedValue::KeyOnly)
     );
-    assert!(!result.has_more);
+    assert!(!result_has_more);
 }
 
 #[tokio::test]
@@ -524,12 +524,12 @@ async fn assert_cached_rows(
         )
         .await
         .expect("begin cached scan");
-    let result = cursor
+    let (result, result_has_more) = cursor
         .next_page(usize::MAX)
         .await
-        .expect("scan cached rows");
+        .expect("scan cached rows").into_parts();
 
-    assert_eq!(result.entries.len(), 3);
+    assert_eq!(result.len(), 3);
     let rows = result
         .entries
         .into_iter()


### PR DESCRIPTION
# fix(hot_state): certified-manifest scans silently truncated at 1024 rows

**This is a proven data-loss bug, not a performance change.** Two tests fail on the base commit and pass on this branch.

## The defect

`MAX_SCAN_PAGE_ROWS = 1024` (`packages/lix/src/storage/types.rs`). Six scan sites in
`packages/lix/src/hot_state/tracked_head/hot.rs` read **one page** and never looked at `has_more`,
so every row past 1024 in the range was dropped with no error, no log, and no failing test.

Two of the six had directly observable consequences:

| site | what the range covers | consequence |
|---|---|---|
| `hot.rs:610-619` — certified-manifest inheritance on a generation change | prefix is the bare 16-byte generation, so **every file on the branch** | **Durable loss.** Creating a branch re-keys the previous generation's manifests under the new one. Above 1024 files the remainder was never written. The new branch is permanently missing those files' certified rows. |
| `hot.rs:1080-1090` — unfiltered certified-manifest scan | same bare-generation prefix | **Missing query rows.** `scan_certified_entity_batch_rows` feeds the authoritative HOT + packed + certified + root merge (`hot.rs:5560`). There is no re-derivation fallback, so a `SELECT` returned fewer rows than exist. |

**Plainly: creating a branch on a repository with more than 1024 plugin-mapped files silently loses
manifests.** `vscode-docs` — this round's own file→row corpus — is past that threshold.

The other four were the same root cause with narrower blast radius, and are fixed here rather than
left for someone to rediscover from a stranger symptom:

- `hot.rs:688`, `hot.rs:1069` — prefix is generation+file(+format); one row per commit since the
  last complete-file-state write. Truncation let a superseded manifest survive the delete that was
  meant to replace it, so a stale batch stayed reachable.
- `hot.rs:3511`, `hot.rs:3527` — collection controls, folded into the boolean
  `has_local_collection_replacement`. A missed replacement past row 1024 reads as "no replacement",
  which leaves `root_request.limit` pushed down instead of cleared — the exact hazard the comment at
  `hot.rs:5004-5006` warns about, where an early LIMIT can select a retired row while a live row
  still exists further along.

This was not an intentional bound. Every other scan in the file already drains, including
`scan_certified_history_rows`, which has a test named
`certified_history_scan_paginates_past_1024_batches`. These six were missed by the #1261
streaming-cursor migration.

### Why the fix is a type change and not six one-line fixes

Because fixing the six sites does not stop the seventh.

While this branch was in flight, PR #1366 landed a **new** single-page scan into this same file, at
what is now `hot.rs:10078` — a file schema-key scan, written with a correct `loop { … if
!page.has_more { break } }` drain. It was not buggy. But it appeared, in the same file, within hours
of this investigation starting, written by someone who had every reason to get it right and did.
That is the whole argument: the hazard is not that people are careless, it is that the correct and
the truncating spelling looked identical and nothing distinguished them. Site number seven arrived
before the fix for sites one through six could merge.

So this PR removes the spelling instead of the six instances of it. `hot.rs:10078` is migrated to
`next_chunk()` here as part of the rebase.

## What changed physically

**Removed: the ability to write the bug.** `ScanChunk`'s `entries` and `has_more` fields are now
private. The only way to reach the rows is `into_parts() -> (Vec<ReadEntry>, bool)`, which hands
back the continuation flag in the same expression, and the struct is `#[must_use]`. The shape that
caused this — `cursor.next_page(MAX_SCAN_PAGE_ROWS).await?.entries`, which reads as a complete scan
— no longer compiles anywhere in the workspace. That is what forced this diff to touch 39 files:
every scan site had to state whether it drains or is bounded on purpose.

**Added: draining is now the short path.** Two new primitives on `ScanCursor`
(`packages/lix/src/storage/cursor.rs`):

- `collect_all()` — every remaining row, one call, cannot truncate.
- `next_chunk()` — `while let Some(entries) = cursor.next_chunk().await? { … }`, streams page by
  page with no flag to forget, for callers that must not materialize the whole range.

The asymmetry is deliberate: wanting everything is one call; wanting a bound requires reaching for
`next_page(limit)` and binding `has_more`, which reads as intentional at the call site. Where the
flag is genuinely discarded it is now spelled `_..._has_more`, so "bounded on purpose" is greppable
and distinguishable from "forgot to drain".

Neither primitive adds a backend round trip: `next_page` already records exhaustion from `has_more`,
so `next_chunk` returns `None` from cursor state without touching the adapter. Call counts against
storage are unchanged for every previously-correct site.

Also updated, since they construct or consume the type: `storage/in_memory.rs`, the RocksDB and
SlateDB adapters, `js-sdk/native/indexeddb.rs`, `storage/conformance/{baseline,model_based,failure_tests}.rs`,
`storage_adapter/conformance.rs`, and the `lix_benchmarks` scan-source wrappers. SlateDB's
`hydrate_immutable_value_scan` now takes `&mut [ReadEntry]` instead of `&mut ScanChunk`; no
behavior change.

## Proof

`packages/lix/src/hot_state/tracked_head/hot.rs`, two new tests, 1027 files (`MAX_SCAN_PAGE_ROWS + 3`)
each publishing one certified single-row batch on one generation.

On base `2deccf091`:

```
certified_scan_returns_every_file_past_one_scan_page          left: 1024  right: 1027  FAILED
branch_creation_inherits_every_certified_manifest_past_...    left: 1024  right: 1027  FAILED
test result: FAILED. 0 passed; 2 failed
```

On this branch:

```
test ...::branch_creation_inherits_every_certified_manifest_past_one_scan_page ... ok
test ...::certified_scan_returns_every_file_past_one_scan_page ... ok
test result: ok. 2 passed; 0 failed
```

The first test isolates the two defects: it asserts the manifest count in storage is 1027 (the write
path was always correct) **and** that the scan returns 1027 rows (the read dropped 3). The second
asserts that after a branch creation all 1027 manifests exist under the new generation.

## Cost: branch-creation inheritance is now genuinely O(files)

This is the honest trade. Before the fix, inheritance did at most 1024 manifests regardless of
repository size — because it was wrong. It is now linear in the file count.

Measured on **ryzen-9950x-I** (32c/186G), release profile, in-memory backend, 5 reps per point,
median reported; this is the `stage_certified_entity_batches` inheritance call that runs on a
generation change:

| files on branch | median | raw (ms) |
|---|---|---|
| 100 | 0.017 ms | 0.016, 0.017, 0.017, 0.019, 0.036 |
| 1,024 | 0.159 ms | 0.154, 0.155, 0.159, 0.160, 0.199 |
| 10,000 | 1.819 ms | 1.703, 1.738, 1.819, 1.911, 2.219 |

**Slope: linear, ≈0.18 µs per inherited manifest.** 10.24x the files costs 9.4x the time
(100→1,024); 9.77x the files costs 11.4x the time (1,024→10,000).

**What this costs versus base.** At or below 1,024 files the two arms perform identical work — the
pre-fix code only truncated above the page boundary — so the 100 and 1,024 rows are also the base
numbers, and they double as the null control for this measurement: identical code path, identical
inputs. At 10,000 files the pre-fix code processed exactly 1,024 manifests, so its cost is the
1,024 row: **0.159 ms**. The fix therefore adds **~1.66 ms to one branch creation on a
10,000-file repository**, and would add ~18 ms at 100,000 files. Branch creation is not a
per-operation hot path and has no 2 ms budget, so this is not a follow-up concern; the number is
here so it is not a surprise later.

The read-side site (`hot.rs:1080`) is on the OLTP scan path. Below 1,024 files per generation it
does byte-identical work. Above it, it now reads the manifests it was previously skipping — which is
the fix, not a regression: the old cost was low because the answer was wrong.

### An accepted regression, stated plainly

That manifest scan was never bounded by the caller's `LIMIT` — the limit is applied after decoding,
in `canonicalize_single_certified_batch`. So `SELECT … LIMIT 10` against a branch with 5,000 plugin
files previously read 1,024 manifests and now reads 5,000. **This is a real read regression and it is
accepted deliberately.** Correctness outranks OLTP performance in this round's priority order, and
the pre-fix behaviour was only cheaper because it was returning an incomplete answer.

The obvious optimization — push the `LIMIT` down into the manifest scan — is **deliberately not in
this PR**, and not merely for scope. A limit pushdown on a scan whose winners are selected *after*
decoding is precisely the shape of the bug this PR spent the day proving: stop reading early, and
the row that would have won is the one you never read. Doing it safely requires moving winner
selection ahead of the limit so the scan can know when it is allowed to stop. That is a real piece of
work and a legitimate follow-up; it is not a line change, and folding it in here would make a pure
correctness fix un-reviewable.

I did not run a `tracked_state_crud` timing guard. The primitive change is field privacy plus a
move, with identical control flow and identical adapter call counts; no lane can move except the six
sites, whose cost shape is the table above. Correctness outranks performance this round and the
change lands either way, so a guard result could not have changed the decision — per the round's
speed rule I did not spend the machine time.

## Layout invariants

1. **Single authority — no.** No authority added or moved. `ScanChunk` gains no state; the six sites
   read the same records from the same space, just all of them.
2. **Commit canonicality — unaffected.** No commit, parent link, or state root is touched.
3. **Derived views are caches — unaffected, and this is the point.** The certified manifest index is
   a derived serving structure, but it is *not* rebuilt on miss: a truncated inheritance was
   permanent, which is why this was corruption rather than a cold cache.
4. **Atomic publication — unaffected.** Inheritance still stages into the same write set that
   publishes the generation change; it now stages the complete set.
5. **GC from refs — unaffected.** No retention metadata changed. Fixing `hot.rs:688` *removes* a
   drift source: superseded manifests that survived their own delete previously kept content
   reachable.
6. **SQL reads canonical records — improved.** The certified scan that feeds the SQL merge path now
   returns every matching row instead of the first page.

## Gate

Run on **ryzen-9950x-I** against `.github/workflows/ci.yml` from `origin/main`, base
`2deccf0913fcc322987bcd7c550f66927a51146b`:

```
cargo check --workspace --all-targets --all-features
cargo clippy --workspace --all-targets --all-features -- -D warnings
cargo test --profile test --workspace --exclude lix_benchmarks --all-features --no-fail-fast
cargo test --profile test -p lix_benchmarks --features storage-benches,slatedb,root-replay-trace --no-fail-fast
cargo check -p lix --no-default-features
cargo check -p lix_js_sdk --target wasm32-unknown-unknown
```

Run on **ryzen-9950x-I**. The full six-command gate ran on `044298b9c` (rebased onto integration
head `5bc46723c`). Integration then advanced to `0c6cfd859` (PR #1369), so the branch was rebased
again to `2757050c7` and re-verified.

That #1369 delta touches `sql2/providers/file_history.rs` and a new test file only, and contains
**zero** additions of `next_page`, `begin_scan`, `.entries` or `.has_more` — verified by diffing the
range — so it cannot interact with this PR's type change. On the current head `2757050c7`:
`cargo check --workspace --all-targets --all-features` clean, `cargo clippy … -D warnings` clean,
and both proof tests `ok`. The full suite result below is from `044298b9c`, one rebase behind, with
the intervening delta shown above to be scan-API-free.

| command | result |
|---|---|
| `cargo check --workspace --all-targets --all-features` | clean |
| `cargo clippy --workspace --all-targets --all-features -- -D warnings` | clean |
| `cargo check -p lix --no-default-features` | clean |
| `cargo check -p lix_js_sdk --target wasm32-unknown-unknown` | clean |
| `cargo test --profile test --workspace --exclude lix_benchmarks --all-features --no-fail-fast` | **3475 passed / 0 failed** |
| `cargo test --profile test -p lix_benchmarks --features storage-benches,slatedb,root-replay-trace --no-fail-fast` | **26 passed / 0 failed** |

**Zero `error` or `warning` lines across the entire run.** The log was captured to a file and
grepped for `failures:`, `panicked at`, `test result: FAILED` and `^error` — not tailed, which would
have hidden early failures behind later passes. Both proof tests appear as `ok` in the workspace run.

No versioned identifier was bumped: no space name, encoding version, or magic constant changed, so
there is no cross-crate literal to grep for.

## Why this survived an otherwise-green suite

Two things that looked like they were watching structurally could not see this. `cargo check
--workspace` does not build test targets, so it cannot see a broken one. And a public, ignorable
`has_more` field cannot be seen by any check at all — not the compiler, not clippy, not a test that
does not happen to cross 1024 rows. The 3469-test suite is green and stays green; nothing in it
built a scope wider than one scan page.
