### PR TITLE
perf(sql): prune lix_file_history on a path predicate

### DIFF
--- a/.changenotes/file-history-path-pruning.md
+++ b/.changenotes/file-history-path-pruning.md
@@ -1,0 +1,7 @@
+---
+type: patch
+---
+
+`lix_file_history()` filtered by `path` now costs what the answer costs instead of scanning every file at every commit.
+
+A `WHERE path = '...'` predicate is resolved to the files that could ever render that path and then routed like a `WHERE id = '...'` lookup, so the traversal no longer reconstructs the whole filesystem at each observed commit. Reading one file's history in a workspace with five thousand files drops from over a second to a few milliseconds, and the cost stops growing with the number of files in the repository. Results are unchanged, including for paths a file has since been renamed away from.

--- a/packages/lix/src/sql2/providers/file_history.rs
+++ b/packages/lix/src/sql2/providers/file_history.rs
@@ -417,6 +417,27 @@ impl FileHistoryPublicPredicate {
             _ => None,
         }
     }
+
+    /// The finite set of `path` literals every matching row must render, when
+    /// one exists.
+    ///
+    /// A conjunction narrows (either side alone is already a sound bound); a
+    /// disjunction only bounds the whole expression when both sides do.
+    fn exact_paths(&self) -> Option<BTreeSet<String>> {
+        match self {
+            Self::All | Self::Ids(_) => None,
+            Self::Paths(paths) => Some(paths.clone()),
+            Self::And(left, right) => match (left.exact_paths(), right.exact_paths()) {
+                (Some(left), Some(right)) => Some(left.intersection(&right).cloned().collect()),
+                (bound, None) | (None, bound) => bound,
+            },
+            Self::Or(left, right) => {
+                let mut left = left.exact_paths()?;
+                left.extend(right.exact_paths()?);
+                Some(left)
+            }
+        }
+    }
 }
 
 /// A conservative exact public `id` constraint that can be translated to the
@@ -614,6 +635,28 @@ where
 
     let event_route = route.traversal_only();
     let context_route = route.anchors_only();
+    // A `path` predicate prunes exactly like an `id` predicate once it is
+    // resolved to the file IDs that could render that path.
+    let resolved_lookup_ids = match lookup_ids {
+        Some(lookup_ids) => Some(lookup_ids.clone()),
+        None => {
+            resolve_file_history_path_lookup_ids(
+                Arc::clone(&commit_graph),
+                query_source.clone(),
+                &context_route,
+                public_predicate,
+            )
+            .await?
+        }
+    };
+    if resolved_lookup_ids
+        .as_ref()
+        .is_some_and(|lookup_ids| lookup_ids.0.is_empty())
+    {
+        return Ok(Vec::new());
+    }
+    let lookup_ids = resolved_lookup_ids.as_ref();
+
     let filesystem_context = load_file_history_filesystem_context(
         Arc::clone(&commit_graph),
         query_source.clone(),
@@ -950,6 +993,85 @@ fn validate_file_history_materialization(
             descriptor.id,
         )))
     }
+}
+
+/// Resolves an exact `path` predicate to the file IDs that can render it, so a
+/// path lookup prunes the traversal the same way an ID lookup already does.
+///
+/// A row's path is `<directory path>/<descriptor name>` and a path segment can
+/// never contain `/`, so a row renders `path` only when its descriptor name
+/// equals the final segment of `path` at that commit. Every name a file has
+/// ever carried was written by a descriptor change, and every commit a row can
+/// be observed at is reachable from the anchors — so descriptor changes read
+/// from the anchors are a superset of the matching file IDs. The residual
+/// [`FileHistoryPublicPredicate::matches`] still decides every row, so this
+/// only narrows the traversal; it never decides the answer.
+///
+/// Returns `None` when the predicate cannot be bounded to a finite set of
+/// paths, which keeps the complete traversal.
+async fn resolve_file_history_path_lookup_ids<S>(
+    commit_graph: Arc<Mutex<Box<dyn CommitGraphReader>>>,
+    query_source: SqlHistoryQuerySource<S>,
+    anchor_route: &HistoryRoute,
+    public_predicate: &FileHistoryPublicPredicate,
+) -> Result<Option<FileHistoryLookupIds>, LixError>
+where
+    S: StorageAdapterRead + Clone + Send + Sync + 'static,
+{
+    let Some(paths) = public_predicate.exact_paths() else {
+        return Ok(None);
+    };
+    let mut names = BTreeSet::new();
+    for path in &paths {
+        match path.rsplit_once('/') {
+            Some((_, name)) if !name.is_empty() => {
+                names.insert(name.to_string());
+            }
+            // Not a composable Lix path. Rather than reason about a literal no
+            // composed path can equal, leave the traversal unpruned.
+            _ => return Ok(None),
+        }
+    }
+
+    let entries = load_history_entries(
+        HistoryViewDescriptor {
+            view_name: "lix_file_history",
+            as_of_commit_column: HISTORY_COL_AS_OF_COMMIT_ID,
+        },
+        commit_graph,
+        query_source,
+        anchor_route,
+        vec![FILE_DESCRIPTOR_SCHEMA_KEY.to_string()],
+        HistoryMetadataProjection::default(),
+        None,
+    )
+    .await?;
+
+    let mut file_ids = BTreeSet::new();
+    for entry in &entries {
+        // A tombstone carries no name, and the name it retired was written by
+        // the live descriptor change this scan already saw.
+        let Some(snapshot_content) = entry.change.snapshot_content.as_deref() else {
+            continue;
+        };
+        let snapshot: FileDescriptorSnapshot =
+            serde_json::from_str(snapshot_content).map_err(|error| {
+                LixError::new(
+                    "LIX_ERROR_UNKNOWN",
+                    format!("invalid lix_file_descriptor history snapshot JSON: {error}"),
+                )
+            })?;
+        if !names.contains(&snapshot.name) {
+            continue;
+        }
+        if EntityPk::uuid_from_canonical(&snapshot.id).is_err() {
+            // The pruned readers key on a canonical UUID. A file ID that is not
+            // one cannot be routed, so keep the complete traversal.
+            return Ok(None);
+        }
+        file_ids.insert(snapshot.id);
+    }
+    Ok(Some(FileHistoryLookupIds(file_ids)))
 }
 
 async fn load_file_history_filesystem_context<S>(
@@ -2934,6 +3056,54 @@ mod tests {
             .is_none(),
             "mixed public predicates retain the existing complete traversal"
         );
+    }
+
+    #[test]
+    fn exact_public_paths_bound_conjunctions_and_complete_disjunctions() {
+        let single = FileHistoryPublicPredicate::from_filters(&[eq_filter("path", "/docs/a.md")]);
+        assert_eq!(
+            single.exact_paths(),
+            Some(BTreeSet::from(["/docs/a.md".to_string()]))
+        );
+
+        // Either side of a conjunction is already a sound bound.
+        let mixed_conjunction = Expr::BinaryExpr(BinaryExpr::new(
+            Box::new(eq_filter("id", "01920000-0000-7000-8000-0000000000a2")),
+            Operator::And,
+            Box::new(eq_filter("path", "/docs/a.md")),
+        ));
+        assert_eq!(
+            FileHistoryPublicPredicate::from_filters(&[mixed_conjunction]).exact_paths(),
+            Some(BTreeSet::from(["/docs/a.md".to_string()]))
+        );
+
+        let path_disjunction = Expr::BinaryExpr(BinaryExpr::new(
+            Box::new(eq_filter("path", "/docs/a.md")),
+            Operator::Or,
+            Box::new(eq_filter("path", "/docs/b.md")),
+        ));
+        assert_eq!(
+            FileHistoryPublicPredicate::from_filters(&[path_disjunction]).exact_paths(),
+            Some(BTreeSet::from([
+                "/docs/a.md".to_string(),
+                "/docs/b.md".to_string()
+            ]))
+        );
+
+        // One unbounded side leaves the whole disjunction unbounded.
+        let mixed_disjunction = Expr::BinaryExpr(BinaryExpr::new(
+            Box::new(eq_filter("path", "/docs/a.md")),
+            Operator::Or,
+            Box::new(eq_filter("id", "01920000-0000-7000-8000-0000000000a2")),
+        ));
+        assert!(
+            FileHistoryPublicPredicate::from_filters(&[mixed_disjunction])
+                .exact_paths()
+                .is_none(),
+            "an unbounded disjunct must retain the complete traversal"
+        );
+
+        assert!(FileHistoryPublicPredicate::All.exact_paths().is_none());
     }
 
     #[tokio::test]

--- a/packages/lix/tests/integration/sql/lix_file_history.rs
+++ b/packages/lix/tests/integration/sql/lix_file_history.rs
@@ -250,6 +250,277 @@ async fn lix_file_history_point_lookup_does_not_rescan_unrelated_observed_state(
 }
 
 #[tokio::test]
+async fn lix_file_history_path_lookup_does_not_rescan_unrelated_observed_state() {
+    const UNRELATED_FILE_COUNT: usize = 64;
+    const UNRELATED_DIRECTORY_COUNT: usize = 32;
+    const UNRELATED_ADDITIONAL_FILE_COUNT: usize = 16;
+    // A `path` predicate identifies one file exactly as an `id` predicate does,
+    // so it must cost the same: the unrelated descriptors, directories and
+    // blobs must not be reconstructed once per observed commit.
+    const MAX_REQUESTED_KEYS: u64 = 416;
+    const MAX_SCAN_CALLS: u64 = 128;
+    const MAX_SCANNED_ROWS: u64 = 512;
+
+    let storage = CountingStorage::default();
+    Engine::initialize(storage.clone())
+        .await
+        .expect("storage should initialize");
+    let engine = Engine::new(storage.clone())
+        .await
+        .expect("engine should open");
+    let session = engine
+        .open_workspace_session()
+        .await
+        .expect("workspace session should open");
+
+    let unrelated_values = (0..UNRELATED_FILE_COUNT)
+        .map(|index| {
+            format!(
+                "('01940000-0000-7000-8000-{index:012x}', '/unrelated-history-{index:03}.txt', CAST('x' AS BYTEA))"
+            )
+        })
+        .collect::<Vec<_>>()
+        .join(",");
+    session
+        .execute(
+            &format!("INSERT INTO lix_file (id, path, content) VALUES {unrelated_values}"),
+            &[],
+        )
+        .await
+        .expect("unrelated files should insert in one commit");
+    let unrelated_directories = (0..UNRELATED_DIRECTORY_COUNT)
+        .map(|index| {
+            format!("('01940001-0000-7000-8000-{index:012x}', '/unrelated-directory-{index:03}')")
+        })
+        .collect::<Vec<_>>()
+        .join(",");
+    session
+        .execute(
+            &format!("INSERT INTO lix_directory (id, path) VALUES {unrelated_directories}"),
+            &[],
+        )
+        .await
+        .expect("unrelated directories should insert in one commit");
+    let unrelated_additional_files = (0..UNRELATED_ADDITIONAL_FILE_COUNT)
+        .map(|index| {
+            format!(
+                "('01940002-0000-7000-8000-{index:012x}', '/unrelated-additional-{index:03}.bin', CAST('x' AS BYTEA))"
+            )
+        })
+        .collect::<Vec<_>>()
+        .join(",");
+    session
+        .execute(
+            &format!(
+                "INSERT INTO lix_file (id, path, content) VALUES {unrelated_additional_files}"
+            ),
+            &[],
+        )
+        .await
+        .expect("unrelated additional files should insert in one commit");
+    session
+        .execute(
+            "INSERT INTO lix_file (id, path, content) \
+             VALUES ('3faa577b-02e3-7c30-8b7d-30a9698cba93', '/target-by-path.txt', CAST('target' AS BYTEA))",
+            &[],
+        )
+        .await
+        .expect("target file should insert in its own commit");
+    let commit_id_rows = session
+        .execute("SELECT lix_active_branch_commit_id() AS commit_id", &[])
+        .await
+        .expect("target commit head should load");
+    let [Value::Text(commit_id)] = commit_id_rows.rows()[0].values() else {
+        panic!(
+            "expected active branch commit id row, got {:?}",
+            commit_id_rows.rows()[0].values()
+        );
+    };
+
+    storage.reset_counters();
+    let result = session
+        .execute(
+            &format!(
+                "SELECT id, path \
+                 FROM lix_file_history('{commit_id}') \
+                   WHERE lixcol_depth = 0 \
+                   AND path = '/target-by-path.txt'"
+            ),
+            &[],
+        )
+        .await
+        .expect("path-routed file history should load");
+
+    assert_rows_eq(
+        result,
+        vec![vec![
+            Value::Text("3faa577b-02e3-7c30-8b7d-30a9698cba93".to_string()),
+            Value::Text("/target-by-path.txt".to_string()),
+        ]],
+    );
+    let (requested_keys, scan_calls, scanned_rows) = storage.counters();
+    assert!(
+        requested_keys <= MAX_REQUESTED_KEYS,
+        "path-routed history requested {requested_keys} storage keys with \
+         {UNRELATED_FILE_COUNT} unrelated files, {UNRELATED_DIRECTORY_COUNT} directories, and \
+         {UNRELATED_ADDITIONAL_FILE_COUNT} additional files; expected at most {MAX_REQUESTED_KEYS}"
+    );
+    assert!(
+        scan_calls <= MAX_SCAN_CALLS && scanned_rows <= MAX_SCANNED_ROWS,
+        "path-routed history performed {scan_calls} scans returning {scanned_rows} rows; \
+         expected at most {MAX_SCAN_CALLS} scans and {MAX_SCANNED_ROWS} rows"
+    );
+
+    session.close().await.expect("session should close");
+}
+
+#[tokio::test]
+async fn lix_file_history_path_filter_equals_unfiltered_scan_over_many_files() {
+    const BULK_FILE_COUNT: usize = 40;
+
+    let storage = Memory::default();
+    Engine::initialize(storage.clone())
+        .await
+        .expect("storage should initialize");
+    let engine = Engine::new(storage.clone())
+        .await
+        .expect("engine should open");
+    let session = engine
+        .open_workspace_session()
+        .await
+        .expect("workspace session should open");
+
+    let bulk_values = (0..BULK_FILE_COUNT)
+        .map(|index| format!("('/bulk/f{index:03}.txt', CAST('bulk' AS BYTEA))"))
+        .collect::<Vec<_>>()
+        .join(",");
+    session
+        .execute(
+            &format!("INSERT INTO lix_file (path, content) VALUES {bulk_values}"),
+            &[],
+        )
+        .await
+        .expect("bulk files should insert");
+    // Same basename in two directories: the name-derived candidate set must not
+    // be mistaken for the answer.
+    for path in ["/bulk/target.txt", "/other/target.txt"] {
+        session
+            .execute(
+                "INSERT INTO lix_file (path, content) VALUES ($1, CAST('v0' AS BYTEA))",
+                &[Value::Text(path.to_string())],
+            )
+            .await
+            .expect("target file should insert");
+    }
+    for revision in 1..4u32 {
+        session
+            .execute(
+                "UPDATE lix_file SET content = $1 WHERE path = '/bulk/target.txt'",
+                &[Value::Blob(format!("v{revision}").into_bytes().into())],
+            )
+            .await
+            .expect("target revision should commit");
+    }
+    session
+        .execute(
+            "UPDATE lix_file SET name = 'renamed.txt' WHERE path = '/bulk/target.txt'",
+            &[],
+        )
+        .await
+        .expect("target rename should commit");
+    session
+        .execute("DELETE FROM lix_file WHERE path = '/bulk/f005.txt'", &[])
+        .await
+        .expect("bulk delete should commit");
+    let directory_id: String = session
+        .execute("SELECT id FROM lix_directory WHERE path = '/bulk'", &[])
+        .await
+        .expect("bulk directory should load")
+        .rows()[0]
+        .get("id")
+        .expect("directory id should be text");
+    session
+        .execute(
+            "UPDATE lix_directory SET name = 'bulk-renamed' WHERE id = $1",
+            &[Value::Text(directory_id)],
+        )
+        .await
+        .expect("directory rename should commit");
+
+    let head: String = session
+        .execute("SELECT lix_active_branch_commit_id() AS commit_id", &[])
+        .await
+        .expect("head should load")
+        .rows()[0]
+        .get("commit_id")
+        .expect("head should be text");
+
+    let projection = "SELECT id, path, lixcol_depth, lixcol_observed_commit_id \
+                      FROM lix_file_history($1)";
+    let unfiltered = session
+        .execute(projection, &[Value::Text(head.clone())])
+        .await
+        .expect("unfiltered history should load");
+    let row_key = |row: &lix::Row| {
+        let id: String = row.get("id").expect("id");
+        let depth: i64 = row.get("lixcol_depth").expect("depth");
+        let observed: String = row
+            .get("lixcol_observed_commit_id")
+            .expect("observed commit");
+        let path = match row.value("path").expect("path column") {
+            Value::Text(path) => path.clone(),
+            _ => String::new(),
+        };
+        format!("{id}|{depth}|{observed}|{path}")
+    };
+
+    let probes = [
+        "/bulk/target.txt",
+        "/bulk/renamed.txt",
+        "/bulk-renamed/renamed.txt",
+        "/other/target.txt",
+        "/bulk/f005.txt",
+        "/bulk/f012.txt",
+        "/bulk-renamed/f012.txt",
+        "/never/existed.txt",
+    ];
+    let mut matched_any = false;
+    for probe in probes {
+        let expected = unfiltered
+            .rows()
+            .iter()
+            .filter(|row| match row.value("path").expect("path column") {
+                Value::Text(path) => path == probe,
+                _ => false,
+            })
+            .map(row_key)
+            .collect::<BTreeSet<_>>();
+        let actual = session
+            .execute(
+                &format!("{projection} WHERE path = $2"),
+                &[Value::Text(head.clone()), Value::Text(probe.to_string())],
+            )
+            .await
+            .expect("path-filtered history should load")
+            .rows()
+            .iter()
+            .map(row_key)
+            .collect::<BTreeSet<_>>();
+        assert_eq!(
+            expected, actual,
+            "path pushdown changed the result set for '{probe}'"
+        );
+        matched_any |= !expected.is_empty();
+    }
+    assert!(
+        matched_any,
+        "the probe corpus must produce at least one matching history row"
+    );
+
+    session.close().await.expect("session should close");
+}
+
+#[tokio::test]
 async fn lix_file_history_ancestor_point_lookup_keeps_parent_evidence_bounded() {
     const UNRELATED_DIRECTORY_COUNT: usize = 256;
     const MAX_REQUESTED_KEYS: u64 = 400;


### PR DESCRIPTION
> ✅ **Full CI-scope gate green on `ryzen-9950x-V`** (scope re-read from
> `git show origin/main:.github/workflows/ci.yml`, not from the runbook copy). Every step
> exit 0; full logs captured and grepped for `^error` / `panicked` / `test result: FAILED` /
> `failures:` — **0 hits in all six logs**.
>
> | step | result |
> |---|---|
> | `cargo check --workspace --all-targets --all-features` | 0 |
> | `cargo clippy --profile test --workspace --all-targets --all-features -- -D warnings` | 0 — **0 warnings** |
> | `cargo test --profile test --workspace --exclude lix_benchmarks --all-features --no-fail-fast` | 0 — 55 targets, **3472 passed / 0 failed** / 45 ignored |
> | `cargo test --profile test -p lix_benchmarks --features storage-benches,slatedb,root-replay-trace --no-fail-fast` | 0 — 10 targets, **26 passed / 0 failed** / 7 ignored |
> | `cargo check -p lix --no-default-features` | 0 |
> | `cargo check -p lix_js_sdk --target wasm32-unknown-unknown` | 0 |

## Problem

`lix_file_history()` filtered by `path` does not prune. It is a full scan of the composed
filesystem projection: **160.8 ms for a file with 20 revisions and 159.9 ms for a file with
exactly one revision** in the same store (round-5 claim-2 probe). Filtering by `id` was
17.6x faster because an `id` predicate already routes into pruned descriptor/blob history
and pruned per-commit observed-state reads (`FileHistoryLookupIds`); `path` had no such
route and fell through to the complete traversal.

Measured on `ryzen-9950x-V` at the round base, `WHERE path = ...` was **203x slower than
`git log -- <path>`** on vscode-docs and **221x** on wesnoth, and the loss grew with file
count — the wrong direction for the company-wide repository lix targets.

Flat `perf -F 2999` of the 5000-file lane on the base arm attributes the cost to
re-materialising the whole filesystem state once per observed commit
(`BTreeMap<String,SetValZST>::insert` 8.6% from `FileHistoryDirectoryIndex::from_state`,
`scan_batch_at_commit` 3.0%, plus ~12% across `tracked_state` codec/scan symbols). No
DataFusion planning symbol appears in the top 50.

## What changed

A row's `path` is `<directory path>/<descriptor name>`, and a Lix path segment can never
contain `/`. So a row can render `path` only when its descriptor `name` equals the final
segment of `path` at that commit. Every name a file has ever carried was written by a
descriptor change, and every commit a row can be observed at is reachable from the query
anchors — therefore a **descriptor-only walk from the anchors** yields a *superset* of the
file IDs that can render the path.

`lix_file_history` now resolves an exact `path` predicate to that superset and feeds it into
the **existing** `FileHistoryLookupIds` route. Nothing new decides rows: the residual
`FileHistoryPublicPredicate::matches(id, path)` still filters every candidate, so results are
byte-identical, including for a path a file has since been renamed away from.

The traversal term changes from `O(files x commits)` to `O(files) + O(revisions of the
requested file)`.

Physically: 3 files, +448 lines, no deletions of behaviour. This is **wiring**, not a new
plane — it reuses the pruning the `id` path already had.

- `FileHistoryPublicPredicate::exact_paths()` — the dual of the existing `exact_ids()`.
  A conjunction narrows; a disjunction only bounds when both sides do.
- `resolve_file_history_path_lookup_ids()` — one descriptor-only history walk from the
  anchors, name-matched to candidate file IDs. Declines (keeping the complete traversal)
  for a path with no `/`, an empty final segment, or a non-UUID file ID.
- An empty candidate set short-circuits to zero rows instead of degenerating into an
  unconstrained scan.

**No storage-adapter API was added, changed, or removed.** No new storage space, no
persisted index.

## Layout invariants

1. **Single authority — no.** Nothing is written. The candidate ID set is derived per query
   from canonical descriptor changes, used only to narrow a traversal, and discarded.
   No second authority for any fact.
2. **Commit canonicality — unaffected.** The pre-pass reads commit records through the same
   `load_history_entries` walk every other history surface uses. No parallel graph.
3. **Derived views are caches — n/a and satisfied.** Nothing is cached across queries.
4. **Atomic publication — unaffected.** Read-only path; no write set.
5. **GC from refs — unaffected.** No retention metadata.
6. **SQL reads canonical records — yes.** The pre-pass reads `lix_file_descriptor` changes
   from the commit graph, i.e. the canonical records, not a serving projection.

## A/B

Machine `ryzen-9950x-V` (32c/186G). Base arm `~/claude5/base` @ `2deccf091`
(= `origin/claude-5-optimizations` after E0), cand arm @ `57bf14ea1`. RocksDB, release.
3 interleaved runs per arm with rotated order (`base cand` / `cand base` / `base cand`),
3 samples inside each run. `/tmp` on this host is on `/dev/md0`, **not** tmpfs.

Probe: `e4-history-probe.rs` (measurement-only, dropped identically on both arms), derived
from the round's `claim2-history-probe.rs`.

```
SELECT lixcol_depth FROM lix_file_history($head) WHERE path = $p ORDER BY lixcol_depth LIMIT 20
```

### Null control

`WHERE id = ...` executes byte-identical code in both arms (the new code takes the
`Some(lookup_ids)` arm immediately).

| files | base p50 | cand p50 | delta |
|---|---|---|---|
| 50 | 3.01 ms | 2.97 ms | −1.3% |
| 500 | 5.04 ms | 4.96 ms | −1.6% |
| 5000 | 23.29 ms | 22.32 ms | −4.2% |

**The control moves up to 4.2%, so nothing under ~5% is resolvable here.** It runs third in
each process, after two `path` queries whose cost differs 40x between arms, so its cache
state genuinely differs. Every headline number below is 2–43x.

### `WHERE path = ...`, file with 20 revisions (p50 ms; raw per-run p50s)

| files | base | cand | speedup |
|---|---|---|---|
| 50 | 7.201 / 5.721 / 5.738 → **5.74** | 3.364 / 3.391 / 3.349 → **3.36** | **1.7x** |
| 500 | 44.127 / 45.022 / 45.227 → **45.02** | 5.991 / 5.821 / 5.964 → **5.96** | **7.6x** |
| 5000 | 1254.2 / 1252.5 / 1248.9 → **1252.5** | 30.90 / 31.06 / 31.12 → **31.06** | **40.3x** |

Raw sample ranges do not overlap at any size (50 files: base 5.646–7.703, cand 3.253–3.772).

### `WHERE path = ...`, file with exactly 1 revision (p50 ms)

| files | base | cand | speedup |
|---|---|---|---|
| 50 | 5.63 | 1.64 | **3.4x** |
| 500 | 44.80 | 4.21 | **10.6x** |
| 5000 | 1243.9 | 28.88 | **43.1x** |

### Revisions-per-file sweep at a fixed 500 files (p50 ms)

| revisions | answer rows | base | cand | speedup |
|---|---|---|---|---|
| 1 | 2 | 13.497 | 3.585 | 3.8x |
| 20 | 21 | 45.017 | 6.030 | 7.5x |
| 200 | 200 | 389.974 | 27.975 | 13.9x |

Marginal cost per answer row: base **1.90 ms/row**, cand **0.123 ms/row**.

### The slope

| | 50 → 5000 files (100x) | 1 → 200 revisions (200x) |
|---|---|---|
| base `WHERE path` | **218x** | 28.9x |
| cand `WHERE path` | **9.2x** | 7.8x |

Cand's residual file-count growth tracks the null control (`id`: 2.97 → 22.32, 7.5x): it is
the *pre-existing* unpruned directory-history walk that the `id` route also pays, plus the
new `O(files)` descriptor pre-pass. Neither is `O(files x commits)`.

Bench commands:

```
E4_FILES=50,500,5000 E4_ROUNDS=20 E4_SAMPLES=3 \
  <target>/release/deps/e4_history_probe-* --ignored --nocapture --test-threads=1 \
  e4_history_path_pruning_probe
E4_REV_FILES=500 E4_ROUND_SWEEP=1,20,200 E4_SAMPLES=3 \
  <target>/release/deps/e4_history_probe-* --ignored --nocapture --test-threads=1 \
  e4_history_revision_sweep
```

## Correctness

Public API is unchanged — `lix_file_history()` keeps the same columns, the same pushdown
classification, and the same rows.

- New `lix_file_history_path_filter_equals_unfiltered_scan_over_many_files`: 40 bulk files
  plus a rename, a delete, a directory rename, and **two files sharing one basename in
  different directories**; asserts that `WHERE path = $p` returns exactly the unfiltered
  scan filtered afterwards, for eight probe paths including a historical path, a
  post-rename path, a deleted file's path, and a path that never existed.
- New `lix_file_history_path_lookup_does_not_rescan_unrelated_observed_state`: the storage
  regression guard, mirroring the existing `id` test — a `path` lookup with 64 unrelated
  files, 32 directories and 16 more files must stay inside the same storage-key,
  scan-call and scanned-row budgets as the `id` lookup.
- New unit test for `exact_paths()` covering conjunction narrowing, complete disjunctions,
  and declining a mixed disjunction.
- The pre-existing `lix_file_history_reads_path_and_content_from_commit_graph` already
  asserts that `WHERE path = '/docs/guides/readme.md'` still returns the depth-1 row after
  the file was renamed to `/docs/readme-renamed.md`; it now exercises the new route.

Full CI-scope gate run on `ryzen-9950x-V` (see comment below).

## What regressed, and the honest remaining gap

- **Nothing measured regressed.** Unfiltered history and `WHERE id = ...` take an identical
  code path (`exact_paths()` returns `None` immediately for `All`/`Ids`), confirmed by the
  null control.
- The pre-pass adds one descriptor-only walk on the `path` route. At 5000 files it costs
  ~6.6 ms (`path`-cold 28.88 ms vs `id` 22.32 ms) — `O(files)`, the same order as the
  directory walk already there, and it buys a 43x reduction.
- **lix still loses history reads to git.** `git log --pretty=%H -n 20 -- <path>` is
  0.88–1.00 ms p50 (including ~0.5 ms process spawn lix does not pay). At the claim-2
  corpus scale (1200 files) this change is expected to land near **10–15x slower than
  `git log`, down from 203–221x**. That is a defensible sentence; parity is not.
- The next `O(files)` term is the complete directory-history walk that both the `id` and
  `path` routes still pay. Out of scope here.
