### PR TITLE
perf(sql): stop reconstructing the plugin registry at every reachable commit

### DIFF
--- a/.changenotes/bounded-history-traversal.md
+++ b/.changenotes/bounded-history-traversal.md
@@ -2,6 +2,8 @@
 type: patch
 ---
 
-History queries that ask for a shallow depth or a small `LIMIT` no longer read the whole commit graph.
+Commit-graph history traversal applies depth ranges and row limits while walking instead of afterwards.
 
-Depth ranges and row limits are now applied while walking history instead of afterwards, so a query such as `WHERE lixcol_depth = 0` or `LIMIT 10` costs the same on a repository with fifty thousand commits as on one with a thousand. Reading a full history is also faster, because each generation of commits is now fetched in one batched read.
+A traversal that asks for a shallow depth or a small `LIMIT` no longer reads the whole commit graph, and reading a full history is faster because each generation of commits is fetched in one batched read.
+
+This bounds the traversal itself. It does **not** bound every surface built on top of it: a row-shaping surface such as `lix_file_history()` still walks the reachable graph in full, because it can collapse or discard entries after the walk and so cannot pass a row limit down, and because composing a file's path needs ancestor records that may be older than the requested depth window. On `lix_file_history()` a one-row `WHERE lixcol_depth = 0` query therefore still costs more on a larger repository — measured at 2.3 ms against 20 commits and 56.2 ms against 2000. Bounding that surface is separate work.

--- a/.changenotes/file-history-registry-scan.md
+++ b/.changenotes/file-history-registry-scan.md
@@ -1,0 +1,9 @@
+---
+type: patch
+---
+
+Reading file history no longer reconstructs the plugin registry at every reachable commit.
+
+`lix_file_history()` discovered which plugins existed by rebuilding the plugin registry once per commit in the repository's history, on every query, regardless of how few rows the query asked for. It now reads the registry's own change history once instead: the registry any commit sees was written by a registry change that history already contains, so one traversal yields the same answer as thousands of per-commit reconstructions. Registries are still rebuilt where they are actually compared — commits that changed the registry, and their direct parents.
+
+On a workspace with 2000 commits this cuts a file's history read from 59 ms to 34 ms, and a single-revision read from 56 ms to 39 ms. The saving grows with the number of commits in the repository.

--- a/packages/lix/src/sql2/providers/file_history.rs
+++ b/packages/lix/src/sql2/providers/file_history.rs
@@ -672,6 +672,7 @@ where
         Arc::clone(&commit_graph),
         query_source.clone(),
         &event_route,
+        &context_route,
         &parent_commit_ids_by_commit,
         metadata_projection,
     )
@@ -1371,7 +1372,18 @@ where
     let snapshot = (rows.len() != 0)
         .then(|| rows.row(rows.len() - 1))
         .and_then(|row| (!row.deleted()).then_some(row.snapshot_content()))
-        .flatten()
+        .flatten();
+    parse_plugin_registry_snapshot(snapshot, observed_commit_id.as_str())
+}
+
+/// Builds the plugin registry a snapshot describes.
+///
+/// A `None` snapshot is an absent or tombstoned registry, i.e. no plugins.
+fn parse_plugin_registry_snapshot(
+    snapshot_content: Option<&str>,
+    observed_commit_id: &str,
+) -> Result<PluginRegistry, LixError> {
+    let snapshot = snapshot_content
         .map(|snapshot| {
             serde_json::from_str::<serde_json::Value>(snapshot).map_err(|error| {
                 LixError::new(
@@ -1697,53 +1709,99 @@ async fn discover_file_history_plugins<S>(
     commit_graph: Arc<Mutex<Box<dyn CommitGraphReader>>>,
     query_source: SqlHistoryQuerySource<S>,
     event_route: &HistoryRoute,
+    context_route: &HistoryRoute,
     parent_commit_ids_by_commit: &BTreeMap<String, Vec<String>>,
     metadata_projection: HistoryMetadataProjection,
 ) -> Result<FileHistoryPluginDiscovery, LixError>
 where
     S: StorageAdapterRead + Clone + Send + Sync + 'static,
 {
-    // The durable registry snapshot is already the complete plugin set at its
-    // observed commit. Read that exact root identity for every reachable commit
-    // instead of inventing a filesystem state from `(anchor, depth)`, which
-    // conflates equal-depth siblings in a DAG.
-    let observed_commit_ids = parent_commit_ids_by_commit
-        .keys()
-        .cloned()
-        .collect::<BTreeSet<_>>();
-    let mut reader = TrackedStateContext::new().reader(query_source.store.clone());
-    let mut schema_keys = BTreeSet::new();
-    let mut registries_by_commit = BTreeMap::new();
-    for observed_commit_id in observed_commit_ids {
-        let shared_observed_commit: SharedStr = observed_commit_id.as_str().into();
-        let registry =
-            load_plugin_registry_at_observed_commit(&mut reader, &shared_observed_commit).await?;
-        schema_keys.extend(
-            registry
-                .plugins()
-                .iter()
-                .flat_map(|plugin| plugin.schema_keys().iter().cloned()),
-        );
-        registries_by_commit.insert(observed_commit_id, registry);
-    }
+    let registry_pk = EntityPk::single(PLUGIN_REGISTRY_KEY);
+    let registry_pk_text = registry_pk.as_json_array_text()?;
 
     let mut registry_route = event_route.clone();
-    let registry_pk = EntityPk::single(PLUGIN_REGISTRY_KEY);
-    registry_route.entity_pks = vec![registry_pk.as_json_array_text()?];
-    registry_route.resolved_entity_pks = vec![registry_pk];
+    registry_route.entity_pks = vec![registry_pk_text.clone()];
+    registry_route.resolved_entity_pks = vec![registry_pk.clone()];
     let registry_events = load_history_entries(
         HistoryViewDescriptor {
             view_name: "lix_file_history",
             as_of_commit_column: HISTORY_COL_AS_OF_COMMIT_ID,
         },
-        commit_graph,
-        query_source,
+        Arc::clone(&commit_graph),
+        query_source.clone(),
         &registry_route,
         vec![KEY_VALUE_SCHEMA_KEY.to_string()],
         metadata_projection,
         None,
     )
     .await?;
+
+    // Schema-key discovery reads the registry's change history once instead of
+    // reconstructing the registry at every reachable commit.
+    //
+    // The registry at a reachable commit is whatever the nearest reachable
+    // registry change wrote, so the reachable registry changes carry every
+    // registry value any reachable commit can observe. Taking the union over
+    // those changes is therefore the same schema-key set the per-commit
+    // reconstruction produced, for one traversal instead of one tracked-state
+    // scan per commit. The anchors-only route keeps this independent of a depth
+    // bound, which restricts the rows that are emitted, not which plugins
+    // existed.
+    let mut schema_key_route = context_route.clone();
+    schema_key_route.entity_pks = vec![registry_pk_text];
+    schema_key_route.resolved_entity_pks = vec![registry_pk];
+    let schema_key_entries = if schema_key_route == registry_route {
+        registry_events.clone()
+    } else {
+        load_history_entries(
+            HistoryViewDescriptor {
+                view_name: "lix_file_history",
+                as_of_commit_column: HISTORY_COL_AS_OF_COMMIT_ID,
+            },
+            Arc::clone(&commit_graph),
+            query_source.clone(),
+            &schema_key_route,
+            vec![KEY_VALUE_SCHEMA_KEY.to_string()],
+            HistoryMetadataProjection::default(),
+            None,
+        )
+        .await?
+    };
+    let mut schema_keys = BTreeSet::new();
+    for entry in &schema_key_entries {
+        let registry = parse_plugin_registry_snapshot(
+            entry.change.snapshot_content.as_deref(),
+            &entry.observed_commit_id,
+        )?;
+        schema_keys.extend(
+            registry
+                .plugins()
+                .iter()
+                .flat_map(|plugin| plugin.schema_keys().iter().cloned()),
+        );
+    }
+
+    // A registry is only ever compared at a commit whose registry changed and
+    // at that commit's direct parents, so reconstruct exactly those.
+    let mut registry_commit_ids = BTreeSet::new();
+    for entry in &registry_events {
+        registry_commit_ids.insert(entry.observed_commit_id.clone());
+        registry_commit_ids.extend(
+            parent_commit_ids_by_commit
+                .get(&entry.observed_commit_id)
+                .into_iter()
+                .flatten()
+                .cloned(),
+        );
+    }
+    let mut reader = TrackedStateContext::new().reader(query_source.store.clone());
+    let mut registries_by_commit = BTreeMap::new();
+    for observed_commit_id in registry_commit_ids {
+        let shared_observed_commit: SharedStr = observed_commit_id.as_str().into();
+        let registry =
+            load_plugin_registry_at_observed_commit(&mut reader, &shared_observed_commit).await?;
+        registries_by_commit.insert(observed_commit_id, registry);
+    }
 
     Ok(FileHistoryPluginDiscovery {
         schema_keys: schema_keys.into_iter().collect(),

--- a/packages/lix/src/sql2/providers/file_history.rs
+++ b/packages/lix/src/sql2/providers/file_history.rs
@@ -1373,7 +1373,7 @@ where
         .then(|| rows.row(rows.len() - 1))
         .and_then(|row| (!row.deleted()).then_some(row.snapshot_content()))
         .flatten();
-    parse_plugin_registry_snapshot(snapshot, observed_commit_id.as_str())
+    parse_plugin_registry_snapshot(snapshot.map(|snapshot| snapshot.as_str()), observed_commit_id.as_str())
 }
 
 /// Builds the plugin registry a snapshot describes.

--- a/packages/rs-sdk-tests/tests/history_scaling_probe.rs
+++ b/packages/rs-sdk-tests/tests/history_scaling_probe.rs
@@ -1,0 +1,353 @@
+//! The standard scaling instrument for `lix_file_history()`.
+//!
+//! **Use this rather than writing a fresh history probe, and keep the two
+//! sweeps separate.** History cost has two independent terms - the number of
+//! files in the workspace and the number of commits the query traverses - and
+//! the obvious way to seed a probe couples them. A probe that inserts files in
+//! fixed-size batches makes `commits = files / batch + edits`, so "cost grew
+//! 9x when I added 100x the files" silently also means "and 5.7x the commits".
+//! That conflation sent one optimization round at the wrong variable; the
+//! measurement that corrected it is exactly the pair of tests below.
+//!
+//! * [`history_files_at_fixed_commits`] varies file count with the commit count
+//!   pinned, by seeding every file in a single statement. Growth here is a real
+//!   `O(files)` term.
+//! * [`history_commits_at_fixed_files`] varies commit count with both the file
+//!   count and the answer size pinned, by committing edits to a file the query
+//!   never asks about. Growth here is a real `O(commits traversed)` term. Its
+//!   `depth0` lane asks for a single row via `lixcol_depth = 0`, so any growth
+//!   there is work that a depth bound failed to prune.
+//!
+//! Both are `#[ignore]`d; run them by name with `--release`. Every knob is an
+//! environment variable so a curve can be widened without editing this file.
+//!
+//! MEASUREMENT ONLY - this file drives the public SQL surface and
+//! changes no engine code.
+
+use lix::storage::Storage;
+use lix::{Lix, Row, Value, open_lix};
+use lix_storage_rocksdb::RocksDB;
+use std::collections::BTreeSet;
+use std::path::Path;
+use std::time::{Duration, Instant};
+
+fn env_usize(name: &str, default: usize) -> usize {
+    std::env::var(name)
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(default)
+}
+
+fn env_list(name: &str, default: &str) -> Vec<usize> {
+    std::env::var(name)
+        .unwrap_or_else(|_| default.to_string())
+        .split(',')
+        .filter_map(|v| v.trim().parse().ok())
+        .collect()
+}
+
+fn emit(label: &str, samples: &[Duration]) {
+    let mut sorted = samples.to_vec();
+    sorted.sort_unstable();
+    let raw: Vec<String> = samples
+        .iter()
+        .map(|d| format!("{:.3}", d.as_secs_f64() * 1000.0))
+        .collect();
+    let idx = (sorted.len() / 2).min(sorted.len().saturating_sub(1));
+    eprintln!(
+        "history_scale {label} samples={} p50_ms={:.3} raw_ms=[{}]",
+        sorted.len(),
+        sorted[idx].as_secs_f64() * 1000.0,
+        raw.join(","),
+    );
+}
+
+async fn open_at(dir: &Path) -> Lix<RocksDB> {
+    let storage = RocksDB::open(dir.join(".lix")).expect("open RocksDB");
+    open_lix()
+        .with_storage(storage)
+        .await
+        .expect("open lix workspace")
+}
+
+async fn active_commit<S>(lix: &Lix<S>) -> String
+where
+    S: Storage + Clone + Send + Sync + 'static,
+{
+    let r = lix
+        .execute("SELECT lix_active_branch_commit_id()", &[])
+        .await
+        .expect("active commit");
+    match &r.rows()[0].values()[0] {
+        Value::Text(t) => t.clone(),
+        other => panic!("expected text, got {other:?}"),
+    }
+}
+
+fn payload_for(index: usize, bytes: usize) -> Vec<u8> {
+    let mut v = vec![0u8; bytes];
+    for (j, b) in v.iter_mut().enumerate() {
+        *b = ((index * 31 + j * 17) % 251) as u8;
+    }
+    v
+}
+
+/// Seeds `files` files using `rows_per_stmt` rows per statement (one statement
+/// is one commit), then applies `edits` further commits to `edit_path`.
+async fn seed(
+    lix: &Lix<RocksDB>,
+    files: usize,
+    file_bytes: usize,
+    rows_per_stmt: usize,
+    edits: usize,
+    edit_path: &str,
+) {
+    let mut i = 0;
+    while i < files {
+        let n = rows_per_stmt.min(files - i);
+        let mut sql = String::from("INSERT INTO lix_file (path, content) VALUES ");
+        let mut params: Vec<Value> = Vec::new();
+        for k in 0..n {
+            if k > 0 {
+                sql.push(',');
+            }
+            sql.push_str(&format!("(${}, ${})", 2 * k + 1, 2 * k + 2));
+            params.push(Value::Text(format!("/probe/f{:05}.bin", i + k)));
+            params.push(Value::Blob(payload_for(i + k, file_bytes).into()));
+        }
+        sql.push_str(" ON CONFLICT (path) DO UPDATE SET content = excluded.content");
+        lix.execute(&sql, &params).await.expect("probe insert");
+        i += n;
+    }
+
+    let mut body = payload_for(0, file_bytes);
+    for r in 0..edits {
+        let slot = r % body.len();
+        body[slot] = body[slot].wrapping_add(1);
+        lix.execute(
+            "INSERT INTO lix_file (path, content) VALUES ($1, $2) \
+             ON CONFLICT (path) DO UPDATE SET content = excluded.content",
+            &[
+                Value::Text(edit_path.to_string()),
+                Value::Blob(body.clone().into()),
+            ],
+        )
+        .await
+        .expect("probe edit");
+    }
+}
+
+fn row_path(row: &Row) -> Option<String> {
+    match row.value("path").expect("path column") {
+        Value::Text(value) => Some(value.clone()),
+        _ => None,
+    }
+}
+
+fn row_key(row: &Row) -> String {
+    let id: String = row.get("id").expect("id");
+    let depth: i64 = row.get("lixcol_depth").expect("depth");
+    let observed: String = row
+        .get("lixcol_observed_commit_id")
+        .expect("observed commit");
+    format!(
+        "{id}|{depth}|{observed}|{}",
+        row_path(row).unwrap_or_default()
+    )
+}
+
+async fn timed(
+    lix: &Lix<RocksDB>,
+    sql: &str,
+    params: &[Value],
+    samples: usize,
+) -> (Vec<Duration>, usize) {
+    let mut d = Vec::new();
+    let mut rows = 0;
+    for _ in 0..samples {
+        let t = Instant::now();
+        let result = lix.execute(sql, params).await.expect("probe query");
+        d.push(t.elapsed());
+        rows = result.rows().len();
+    }
+    (d, rows)
+}
+
+/// Vary file count with the commit count held constant.
+///
+/// All files land in ONE statement, i.e. one commit, so reachable commits stay
+/// at `1 + edits` regardless of how many files exist. Growth here is a genuine
+/// `O(files)` term.
+#[tokio::test]
+#[ignore = "manual history-scaling probe"]
+async fn history_files_at_fixed_commits() {
+    let file_bytes = env_usize("LIX_HISTORY_SCALE_FILE_BYTES", 4 * 1024);
+    let edits = env_usize("LIX_HISTORY_SCALE_EDITS", 20);
+    let samples = env_usize("LIX_HISTORY_SCALE_SAMPLES", 3);
+    let depth = env_usize("LIX_HISTORY_SCALE_DEPTH", 20);
+
+    for files in env_list("LIX_HISTORY_SCALE_FILES", "50,500,5000") {
+        let dir = tempfile::tempdir().expect("probe tempdir");
+        let lix = open_at(dir.path()).await;
+        let probe_path = "/probe/f00000.bin".to_string();
+        // rows_per_stmt = files => the whole corpus is a single commit.
+        seed(&lix, files, file_bytes, files, edits, &probe_path).await;
+
+        let head = active_commit(&lix).await;
+        let file_id: String = lix
+            .execute(
+                "SELECT id FROM lix_file WHERE path = $1",
+                &[Value::Text(probe_path.clone())],
+            )
+            .await
+            .expect("probe file id")
+            .rows()[0]
+            .get("id")
+            .expect("id text");
+
+        let by_path = format!(
+            "SELECT lixcol_depth FROM lix_file_history($1) WHERE path = $2 \
+             ORDER BY lixcol_depth LIMIT {depth}"
+        );
+        let by_id = format!(
+            "SELECT lixcol_depth FROM lix_file_history($1) WHERE id = $2 \
+             ORDER BY lixcol_depth LIMIT {depth}"
+        );
+
+        for (label, sql, arg) in [
+            ("by_path", &by_path, probe_path.clone()),
+            ("by_id", &by_id, file_id.clone()),
+        ] {
+            let (d, rows) = timed(
+                &lix,
+                sql,
+                &[Value::Text(head.clone()), Value::Text(arg)],
+                samples,
+            )
+            .await;
+            emit(
+                &format!("fixed_commits {label} files={files} commits={} rows={rows}", edits + 1),
+                &d,
+            );
+        }
+        lix.close().await.expect("close probe");
+    }
+}
+
+/// Vary the number of reachable commits with file count AND answer size held
+/// constant.
+///
+/// The extra commits touch a file the query never asks about, so the answer
+/// stays at `edits + 1` rows. Growth here is an `O(commits traversed)` term.
+#[tokio::test]
+#[ignore = "manual history-scaling probe"]
+async fn history_commits_at_fixed_files() {
+    let files = env_usize("LIX_HISTORY_SCALE_FIXED_FILES", 200);
+    let file_bytes = env_usize("LIX_HISTORY_SCALE_FILE_BYTES", 4 * 1024);
+    let edits = env_usize("LIX_HISTORY_SCALE_EDITS", 20);
+    let samples = env_usize("LIX_HISTORY_SCALE_SAMPLES", 3);
+    let depth = env_usize("LIX_HISTORY_SCALE_DEPTH", 20);
+
+    for noise_commits in env_list("LIX_HISTORY_SCALE_COMMITS", "20,200,2000") {
+        let dir = tempfile::tempdir().expect("probe tempdir");
+        let lix = open_at(dir.path()).await;
+        let probe_path = "/probe/f00000.bin".to_string();
+        seed(&lix, files, file_bytes, files, edits, &probe_path).await;
+
+        // Commits that never touch the queried file.
+        let noise_path = format!("/probe/f{:05}.bin", files - 1);
+        let mut noise = payload_for(files - 1, file_bytes);
+        for r in 0..noise_commits {
+            let slot = r % noise.len();
+            noise[slot] = noise[slot].wrapping_add(1);
+            lix.execute(
+                "INSERT INTO lix_file (path, content) VALUES ($1, $2) \
+                 ON CONFLICT (path) DO UPDATE SET content = excluded.content",
+                &[
+                    Value::Text(noise_path.clone()),
+                    Value::Blob(noise.clone().into()),
+                ],
+            )
+            .await
+            .expect("noise commit");
+        }
+
+        let head = active_commit(&lix).await;
+        let file_id: String = lix
+            .execute(
+                "SELECT id FROM lix_file WHERE path = $1",
+                &[Value::Text(probe_path.clone())],
+            )
+            .await
+            .expect("probe file id")
+            .rows()[0]
+            .get("id")
+            .expect("id text");
+
+        let by_path = format!(
+            "SELECT lixcol_depth FROM lix_file_history($1) WHERE path = $2 \
+             ORDER BY lixcol_depth LIMIT {depth}"
+        );
+        let by_id = format!(
+            "SELECT lixcol_depth FROM lix_file_history($1) WHERE id = $2 \
+             ORDER BY lixcol_depth LIMIT {depth}"
+        );
+        // A depth-bounded shape: the bounded-history-traversal work should make
+        // this cheap regardless of how many commits exist.
+        let by_path_depth0 = "SELECT lixcol_depth FROM lix_file_history($1) \
+                              WHERE path = $2 AND lixcol_depth = 0"
+            .to_string();
+
+        for (label, sql, arg) in [
+            ("by_path", &by_path, probe_path.clone()),
+            ("by_id", &by_id, file_id.clone()),
+            ("by_path_depth0", &by_path_depth0, noise_path.clone()),
+        ] {
+            let (d, rows) = timed(
+                &lix,
+                sql,
+                &[Value::Text(head.clone()), Value::Text(arg)],
+                samples,
+            )
+            .await;
+            emit(
+                &format!(
+                    "fixed_files {label} files={files} noise_commits={noise_commits} rows={rows}"
+                ),
+                &d,
+            );
+        }
+
+        if std::env::var("LIX_HISTORY_SCALE_VERIFY").is_ok() {
+            let projection = "SELECT id, path, lixcol_depth, lixcol_observed_commit_id \
+                              FROM lix_file_history($1)";
+            let all = lix
+                .execute(projection, &[Value::Text(head.clone())])
+                .await
+                .expect("unfiltered history");
+            for target in [&probe_path, &noise_path] {
+                let expected: BTreeSet<String> = all
+                    .rows()
+                    .iter()
+                    .filter(|row| row_path(row).as_deref() == Some(target.as_str()))
+                    .map(row_key)
+                    .collect();
+                let actual: BTreeSet<String> = lix
+                    .execute(
+                        &format!("{projection} WHERE path = $2"),
+                        &[Value::Text(head.clone()), Value::Text(target.clone())],
+                    )
+                    .await
+                    .expect("filtered history")
+                    .rows()
+                    .iter()
+                    .map(row_key)
+                    .collect();
+                assert_eq!(expected, actual, "path pushdown changed the answer for {target}");
+            }
+            eprintln!("history_scale verify noise_commits={noise_commits} ok");
+        }
+
+        lix.close().await.expect("close probe");
+    }
+}


### PR DESCRIPTION
> ✅ **Full CI-scope gate green on `ryzen-9950x-V`** at `c45644bab` (scope re-read from
> `git show origin/main:.github/workflows/ci.yml`). Every step exit 0; all six logs grepped for
> `^error` / `panicked` / `test result: FAILED` / `failures:` — **0 hits in all six**.
>
> | step | result |
> |---|---|
> | `cargo check --workspace --all-targets --all-features` | 0 |
> | `cargo clippy --profile test --workspace --all-targets --all-features -- -D warnings` | 0 — **0 warnings** |
> | `cargo test --profile test --workspace --exclude lix_benchmarks --all-features --no-fail-fast` | 0 — 56 targets, **3473 passed / 0 failed** / 47 ignored |
> | `cargo test --profile test -p lix_benchmarks --features storage-benches,slatedb,root-replay-trace --no-fail-fast` | 0 — 10 targets, **26 passed / 0 failed** / 7 ignored |
> | `cargo check -p lix --no-default-features` | 0 |
> | `cargo check -p lix_js_sdk --target wasm32-unknown-unknown` | 0 |

## Problem

`lix_file_history()` rebuilt the plugin registry **once per reachable commit**, on every query,
regardless of how few rows the query asked for:

```rust
// discover_file_history_plugins, before
let observed_commit_ids = parent_commit_ids_by_commit.keys().cloned().collect::<BTreeSet<_>>();
for observed_commit_id in observed_commit_ids {
    let registry = load_plugin_registry_at_observed_commit(&mut reader, &shared).await?;
    schema_keys.extend(...);
    registries_by_commit.insert(observed_commit_id, registry);
}
```

`load_plugin_registry_at_observed_commit` is a `scan_batch_at_commit`, so that loop is one
tracked-state scan per commit in the repository's reachable history — ignoring the depth bound,
the `LIMIT`, and the file predicate. `parent_commit_ids_by_commit` comes from
`load_history_commit_parents`, which walks every reachable node.

Flat `perf -F 2999` on the merged head attributes the cost to exactly that shape:
`tracked_state::storage::collect_strict_commit_delta_members` **5.45%**, blake3 **6.70%**, ZSTD
**~3.6%**, `tracked_state::codec::*` **~11%** — commit-delta decoding, per commit traversed.

## The measurement that found it, and the prior result it invalidates

The probe used in the previous round seeded files in fixed batches of 50, so
`commits = files / 50 + edits`. **File count and commit count moved together**, and the headline
"9.2x across a 100x file increase" was really "9.2x across 100x files *and* 5.7x commits". The
term being chased was misidentified as `O(files)`.

Decoupling them on the merged head (`5bc46723`) settles it:

| sweep | what is pinned | 100x increase → `WHERE id` growth |
|---|---|---|
| file count | commits pinned at 21 (all files in one statement) | **3.6x** |
| commit count | files pinned at 200 **and answer pinned at 20 rows** | **15.4x** |

The residual term is **commits traversed, not files**. Sharpest form: a **one-row** answer via
`WHERE path = ... AND lixcol_depth = 0` costs **2.3 ms against 20 commits and 56.2 ms against
2000** — 24x for a constant answer.

## What changed

The registry a commit observes was written by a registry change that history already contains, so
the reachable registry changes carry every registry value any reachable commit can observe.
Schema-key discovery therefore reads **the registry's own change history once** — on the
anchors-only route, so a depth bound cannot hide an older registry — instead of N per-commit
reconstructions.

Registries are still reconstructed exactly where they are *compared*:
`file_history_plugin_registry_events` only inspects commits whose registry changed and those
commits' direct parents. That set is independent of repository size.

Also factored `parse_plugin_registry_snapshot` out of `load_plugin_registry_at_observed_commit` so
both paths share one parse.

**One engine file.** No public API change, no storage-adapter API added/changed/removed, no new
storage space, no new persisted index.

### Two documentation changes in this PR

1. **`.changenotes/bounded-history-traversal.md` is corrected.** It claimed `WHERE lixcol_depth = 0`
   "costs the same on a repository with fifty thousand commits as on one with a thousand". That is
   true of the commit-graph traversal that note fixed and **false for `lix_file_history()`**
   (2.3 ms → 56.2 ms for a one-row answer). The note now states precisely which layer is bounded
   and which is not.
2. **`packages/rs-sdk-tests/tests/history_scaling_probe.rs` is added as the standard history
   instrument**, replacing ad-hoc probes. Its module docs explain the coupling trap above, and its
   two `#[ignore]`d tests are the file sweep and the commit sweep, so the next person cannot
   accidentally repeat the conflation.

## Layout invariants

1. **Single authority — no.** Nothing is written; nothing is cached across queries. The schema-key
   set is derived per query from canonical registry changes and discarded.
2. **Commit canonicality — unaffected.** Registry changes are read through the same
   `load_history_entries` walk every other history surface uses. No parallel graph.
3. **Derived views are caches — n/a.** No derived view is created or consulted.
4. **Atomic publication — unaffected.** Read-only path, no write set.
5. **GC from refs — unaffected.** No retention metadata.
6. **SQL reads canonical records — yes.** Schema keys now come from canonical `lix_key_value`
   registry *changes* rather than from N reconstructions of the same records.

## A/B

`ryzen-9950x-V` (32c/186G). Base `~/claude5/base` @ **`5bc46723`** (integration head), cand
`~/claude5/cand` @ `01de998fc`. RocksDB, release, `TMPDIR=$HOME/claude5/tmp` (note `/tmp` on this
host is on `/dev/md0`, not tmpfs). 3 interleaved runs per arm, rotated order
(`base cand` / `cand base` / `base cand`), 3 samples inside each run. Medians of the per-run p50s.

The A/B was measured at `01de998fc`; the gate ran at `c45644bab`. `git diff 01de998fc c45644bab --
packages/lix/src` is **empty** — the later commit adds only the two changenotes and the probe test
file, so the benched and gated engine are the same code.

### Commit sweep — files pinned at 200, answer pinned

| lane | commits | base | cand | speedup |
|---|---|---|---|---|
| `WHERE id` (20 rows) | 20 | 3.850 ms | 3.332 ms | 1.16x |
| | 200 | 8.698 ms | 6.043 ms | **1.44x** |
| | 2000 | 59.233 ms | 33.715 ms | **1.76x** |
| `WHERE path` (20 rows) | 20 | 4.411 ms | 3.850 ms | 1.15x |
| | 200 | 9.950 ms | 7.211 ms | **1.38x** |
| | 2000 | 67.742 ms | 42.699 ms | **1.59x** |
| `WHERE path AND depth=0` (**1 row**) | 20 | 2.320 ms | 1.984 ms | 1.17x |
| | 200 | 7.175 ms | 5.395 ms | **1.33x** |
| | 2000 | 56.151 ms | 39.304 ms | **1.43x** |

Raw per-run p50s at 2000 commits, `WHERE id`: base `[59.23, 61.40, 56.80]`, cand
`[34.00, 33.35, 33.72]` — **non-overlapping**.

### File sweep — commits pinned at 21 (this change should be ~neutral here, and is)

| lane | files | base | cand | speedup |
|---|---|---|---|---|
| `WHERE id` | 50 | 3.056 ms | 2.766 ms | 1.10x |
| | 500 | 3.878 ms | 3.555 ms | 1.09x |
| | 5000 | 10.894 ms | 10.322 ms | 1.06x |
| `WHERE path` | 5000 | 17.098 ms | 16.457 ms | 1.04x |

**Noise-floor disclosure:** this run has **no byte-identical null control** — the change touches
every `lix_file_history()` query, so no lane executes identical code. The file sweep is the closest
substitute: at 21 commits the removed loop was only ~21 scans, so its 1.04–1.12x is mostly the
small real saving, and anything under ~1.15x here should be treated as unresolved. The headline
lanes are 1.33–1.76x and are not close calls.

Bench commands:

```
LIX_HISTORY_SCALE_FIXED_FILES=200 LIX_HISTORY_SCALE_COMMITS=20,200,2000 \
LIX_HISTORY_SCALE_EDITS=20 LIX_HISTORY_SCALE_SAMPLES=3 \
  <target>/release/deps/history_scaling_probe-* --ignored --nocapture --test-threads=1 \
  history_commits_at_fixed_files

LIX_HISTORY_SCALE_FILES=50,500,5000 LIX_HISTORY_SCALE_EDITS=20 LIX_HISTORY_SCALE_SAMPLES=3 \
  <target>/release/deps/history_scaling_probe-* --ignored --nocapture --test-threads=1 \
  history_files_at_fixed_commits
```

## Correctness

- The probe's `LIX_HISTORY_SCALE_VERIFY=1` mode asserts that `WHERE path = $p` returns exactly the
  unfiltered scan filtered afterwards; green on the candidate at 20 and 200 commits, for both the
  queried file and the noise file.
- Schema-key derivation is a **superset argument, not a heuristic**: the registry at reachable
  commit `C` was written by a change reachable from the anchors, so the union over reachable
  registry changes contains every registry value any reachable commit observes. A superset is safe
  because schema keys only widen which plugin state is loaded; every row is still decided
  downstream.
- Full CI-scope gate on `ryzen-9950x-V` — see the block at the top.

## What regressed, and the honest residual

- **Nothing measured regressed.** Every lane is neutral or faster.
- **The target was flat, and this is not flat.** Slope across 20 → 2000 commits (100x):

  | lane | base | cand |
  |---|---|---|
  | `WHERE id` | 15.4x | **10.1x** |
  | `WHERE path` | 15.4x | 11.1x |
  | `WHERE path AND depth=0` | 24.2x | 19.8x |

  One of two `O(commits)` terms is removed. The other remains.
- **What remains, named:** `load_history_commit_parents` walks the whole graph via
  `reachable_nodes()`, and `load_history_entries` is called with `limit: None` by deliberate design
  ("a row-shaping provider must pass `None` because it can collapse or discard entries
  afterwards"), while the context route drops depth bounds on purpose (`anchors_only()`) because
  composing a path needs ancestor descriptors that may be older than the depth window. So a depth-0
  query still visits every reachable commit *by design*. Making that cheap changes the
  `load_history_entries` contract shared by every history surface, so it is a separate experiment
  rather than something to smuggle in here.
