### PR TITLE
bench(branch): branch creation is O(1) — measured, hypothesis rejected

### DIFF
--- a/packages/rs-sdk-tests/examples/e10_branch_file_cost.rs
+++ b/packages/rs-sdk-tests/examples/e10_branch_file_cost.rs
@@ -9,10 +9,16 @@
 //! `hot_state/tracked_head/hot.rs`. Those rows only exist for files a WASM
 //! plugin materialized, so no row-shaped fixture can see them.
 //!
-//! This example seeds `N` JSON files through the real plugin path, snapshots
-//! exact logical layout accounting, creates one branch, and snapshots again.
-//! The delta is the price of the branch. Byte and row counts are
-//! deterministic, so one repetition per size is the whole measurement.
+//! This example seeds `N` plugin-backed files, snapshots exact logical layout
+//! accounting, creates one branch, and snapshots again. The delta is the price
+//! of the branch. Byte and row counts are deterministic, so one repetition per
+//! size is the whole measurement.
+//!
+//! Files are plain-text documents handled by the `text` plugin, with a line
+//! count above `HOST_CERTIFIED_PACKET_MIN_ROWS` (64) so that every seeded file
+//! produces a real certified entity batch and therefore a certified manifest
+//! row. A fixture whose files materialize into fewer rows leaves the manifest
+//! plane empty and cannot see the inheritance path at all.
 //!
 //! ```text
 //! cargo run --release -p lix_tests --example e10_branch_file_cost -- 100 1000 10000
@@ -30,6 +36,8 @@ use lix::{CreateBranchOptions, Lix, Value, open_lix};
 use lix_storage_rocksdb::RocksDB;
 
 const INSERT_BATCH: usize = 100;
+/// Above `HOST_CERTIFIED_PACKET_MIN_ROWS` so each file certifies a dense batch.
+const LINES_PER_FILE: usize = 80;
 
 fn main() {
     let sizes: Vec<usize> = std::env::args()
@@ -66,7 +74,7 @@ async fn run_case(files: usize) {
         .await
         .expect("open branch-file-cost Lix");
 
-    install_json_plugin(&lix).await;
+    install_text_plugin(&lix).await;
     let seed_started = Instant::now();
     seed_files(&lix, files).await;
     let seed_ms = seed_started.elapsed().as_secs_f64() * 1_000.0;
@@ -183,19 +191,19 @@ async fn snapshot(storage: &RocksDB, directory: &Path) -> Snapshot {
     }
 }
 
-async fn install_json_plugin<StorageImpl>(lix: &Lix<StorageImpl>)
+async fn install_text_plugin<StorageImpl>(lix: &Lix<StorageImpl>)
 where
     StorageImpl: Storage + Clone + Send + Sync + 'static,
 {
     lix.execute(
         "INSERT INTO lix_file (path, content) VALUES ($1, $2)",
         &[
-            Value::Text("/.lix/plugins/plugin_json.lixplugin".to_owned()),
-            Value::Blob(build_json_plugin_archive().into()),
+            Value::Text("/.lix/plugins/plugin_text.lixplugin".to_owned()),
+            Value::Blob(build_text_plugin_archive().into()),
         ],
     )
     .await
-    .expect("install branch-file-cost JSON plugin");
+    .expect("install branch-file-cost text plugin");
 }
 
 async fn seed_files<StorageImpl>(lix: &Lix<StorageImpl>, files: usize)
@@ -214,15 +222,14 @@ where
             let parameter = offset * 2;
             sql.push_str(&format!("(${}, ${})", parameter + 1, parameter + 2));
             let index = written + offset;
-            params.push(Value::Text(format!("/docs/file-{index:07}.json")));
-            params.push(Value::Blob(
-                format!(
-                    r#"{{"index":{index},"title":"document {index}","body":"{}"}}"#,
-                    "content padding for a realistic small document"
-                )
-                .into_bytes()
-                .into(),
-            ));
+            params.push(Value::Text(format!("/docs/file-{index:07}.txt")));
+            let mut body = String::with_capacity(LINES_PER_FILE * 48);
+            for line in 0..LINES_PER_FILE {
+                body.push_str(&format!(
+                    "document {index} line {line}: content padding text\n"
+                ));
+            }
+            params.push(Value::Blob(body.into_bytes().into()));
         }
         lix.execute(&sql, &params)
             .await
@@ -231,11 +238,11 @@ where
     }
 }
 
-fn build_json_plugin_archive() -> Vec<u8> {
-    let wasm_path = Path::new(env!("CARGO_CDYLIB_FILE_PLUGIN_JSON_plugin_json"));
+fn build_text_plugin_archive() -> Vec<u8> {
+    let wasm_path = Path::new(env!("CARGO_CDYLIB_FILE_PLUGIN_TEXT_plugin_text"));
     let wasm = std::fs::read(wasm_path).unwrap_or_else(|error| {
         panic!(
-            "failed to read bindep-built JSON wasm at {}: {error}",
+            "failed to read bindep-built text wasm at {}: {error}",
             wasm_path.display()
         )
     });
@@ -245,19 +252,11 @@ fn build_json_plugin_archive() -> Vec<u8> {
     for (path, bytes) in [
         (
             "manifest.json",
-            include_str!("../../../plugins/json/manifest.json").as_bytes(),
+            include_str!("../../../plugins/text/manifest.json").as_bytes(),
         ),
         (
-            "schema/json_root.json",
-            include_str!("../../../plugins/json/schema/json_root.json").as_bytes(),
-        ),
-        (
-            "schema/json_object_member.json",
-            include_str!("../../../plugins/json/schema/json_object_member.json").as_bytes(),
-        ),
-        (
-            "schema/json_array_item.json",
-            include_str!("../../../plugins/json/schema/json_array_item.json").as_bytes(),
+            "schema/text_line.json",
+            include_str!("../../../plugins/text/schema/text_line.json").as_bytes(),
         ),
         ("plugin.wasm", wasm.as_slice()),
     ] {

--- a/packages/rs-sdk-tests/examples/e10_branch_file_cost.rs
+++ b/packages/rs-sdk-tests/examples/e10_branch_file_cost.rs
@@ -141,6 +141,18 @@ async fn run_case(files: usize) {
     let after_switch = snapshot(&storage, &db_path).await;
     report(files, "switch_branch", &after, &after_switch, switch_ms);
 
+    // The branch inherited zero per-file rows. Confirm it nevertheless serves
+    // the full plugin-materialized state, i.e. the planes are shared and not
+    // silently missing.
+    let branch_plugin_rows = lix
+        .execute("SELECT COUNT(*) AS n FROM text_line", &[])
+        .await
+        .map(|result| result.rows()[0].get::<i64>("n").unwrap_or(-1))
+        .unwrap_or(-1);
+    println!(
+        "branch_file_cost_branch_rows,files={files},text_line_rows_on_branch={branch_plugin_rows}"
+    );
+
     let write_started = Instant::now();
     write_probe(&lix, "/docs/branch-probe-1.txt").await;
     let write_ms = write_started.elapsed().as_secs_f64() * 1_000.0;

--- a/packages/rs-sdk-tests/examples/e10_branch_file_cost.rs
+++ b/packages/rs-sdk-tests/examples/e10_branch_file_cost.rs
@@ -79,7 +79,26 @@ async fn run_case(files: usize) {
     seed_files(&lix, files).await;
     let seed_ms = seed_started.elapsed().as_secs_f64() * 1_000.0;
 
+    let plugin_rows = lix
+        .execute("SELECT COUNT(*) AS n FROM text_line", &[])
+        .await
+        .map(|result| result.rows()[0].get::<i64>("n").unwrap_or(-1))
+        .unwrap_or(-1);
+    println!("branch_file_cost_plugin_rows,files={files},text_line_rows={plugin_rows}");
+
     let before = snapshot(&storage, &db_path).await;
+    if std::env::var_os("E10_INVENTORY").is_some() {
+        for (name, counts) in &before.spaces {
+            if counts.rows == 0 {
+                continue;
+            }
+            println!(
+                "branch_file_cost_inventory,files={files},space={name},rows={},bytes={}",
+                counts.rows,
+                counts.key_bytes + counts.value_bytes
+            );
+        }
+    }
 
     let branch_started = Instant::now();
     lix.create_branch(CreateBranchOptions {

--- a/packages/rs-sdk-tests/examples/e10_branch_file_cost.rs
+++ b/packages/rs-sdk-tests/examples/e10_branch_file_cost.rs
@@ -87,6 +87,16 @@ async fn run_case(files: usize) {
         .unwrap_or(-1);
     println!("branch_file_cost_plugin_rows,files={files},text_line_rows={plugin_rows}");
 
+    // Control: the same single-file write on the *established* branch, so the
+    // first-write-on-a-fresh-branch number can be read as a branch cost rather
+    // than as "a commit in a big repository".
+    let control_before = snapshot(&storage, &db_path).await;
+    let control_started = Instant::now();
+    write_probe(&lix, "/docs/main-probe.txt").await;
+    let control_ms = control_started.elapsed().as_secs_f64() * 1_000.0;
+    let control_after = snapshot(&storage, &db_path).await;
+    report(files, "control_write_on_main", &control_before, &control_after, control_ms);
+
     let before = snapshot(&storage, &db_path).await;
     if std::env::var_os("E10_INVENTORY").is_some() {
         for (name, counts) in &before.spaces {
@@ -132,18 +142,16 @@ async fn run_case(files: usize) {
     report(files, "switch_branch", &after, &after_switch, switch_ms);
 
     let write_started = Instant::now();
-    lix.execute(
-        "INSERT INTO lix_file (path, content) VALUES ($1, $2)",
-        &[
-            Value::Text("/docs/branch-probe.txt".to_owned()),
-            Value::Blob(one_document(usize::MAX).into()),
-        ],
-    )
-    .await
-    .expect("write first file on branch-file-cost branch");
+    write_probe(&lix, "/docs/branch-probe-1.txt").await;
     let write_ms = write_started.elapsed().as_secs_f64() * 1_000.0;
     let after_write = snapshot(&storage, &db_path).await;
     report(files, "first_write_on_branch", &after_switch, &after_write, write_ms);
+
+    let second_started = Instant::now();
+    write_probe(&lix, "/docs/branch-probe-2.txt").await;
+    let second_ms = second_started.elapsed().as_secs_f64() * 1_000.0;
+    let after_second = snapshot(&storage, &db_path).await;
+    report(files, "second_write_on_branch", &after_write, &after_second, second_ms);
 
     lix.close().await.expect("close branch-file-cost Lix");
 }
@@ -284,6 +292,21 @@ where
             .expect("seed branch-file-cost files");
         written += batch;
     }
+}
+
+async fn write_probe<StorageImpl>(lix: &Lix<StorageImpl>, path: &str)
+where
+    StorageImpl: Storage + Clone + Send + Sync + 'static,
+{
+    lix.execute(
+        "INSERT INTO lix_file (path, content) VALUES ($1, $2)",
+        &[
+            Value::Text(path.to_owned()),
+            Value::Blob(one_document(path.len()).into()),
+        ],
+    )
+    .await
+    .unwrap_or_else(|error| panic!("write branch-file-cost probe {path}: {error:?}"));
 }
 
 fn one_document(index: usize) -> Vec<u8> {

--- a/packages/rs-sdk-tests/examples/e10_branch_file_cost.rs
+++ b/packages/rs-sdk-tests/examples/e10_branch_file_cost.rs
@@ -32,7 +32,7 @@ use std::time::Instant;
 use lix::storage::{ReadOptions, Storage};
 use lix::storage_adapter::StorageAdapter;
 use lix::storage_bench::layout_accounting;
-use lix::{CreateBranchOptions, Lix, Value, open_lix};
+use lix::{CreateBranchOptions, Lix, SwitchBranchOptions, Value, open_lix};
 use lix_storage_rocksdb::RocksDB;
 
 const INSERT_BATCH: usize = 100;
@@ -78,6 +78,7 @@ async fn run_case(files: usize) {
     let seed_started = Instant::now();
     seed_files(&lix, files).await;
     let seed_ms = seed_started.elapsed().as_secs_f64() * 1_000.0;
+    println!("branch_file_cost_seed,files={files},seed_ms={seed_ms:.3}");
 
     let plugin_rows = lix
         .execute("SELECT COUNT(*) AS n FROM text_line", &[])
@@ -101,23 +102,59 @@ async fn run_case(files: usize) {
     }
 
     let branch_started = Instant::now();
-    lix.create_branch(CreateBranchOptions {
-        id: None,
-        name: "e10-branch".to_owned(),
-        from_commit_id: None,
-    })
-    .await
-    .expect("create branch-file-cost branch");
+    let branch_id = lix
+        .create_branch(CreateBranchOptions {
+            id: None,
+            name: "e10-branch".to_owned(),
+            from_commit_id: None,
+        })
+        .await
+        .expect("create branch-file-cost branch")
+        .id;
     let branch_ms = branch_started.elapsed().as_secs_f64() * 1_000.0;
 
     let after = snapshot(&storage, &db_path).await;
 
+    report(files, "create_branch", &before, &after, branch_ms);
+
+    // A root-backed branch publication is cheap by construction. The question
+    // that decides whether the cost was removed or merely deferred is what the
+    // *first write on the new branch* costs: if the per-file planes are copied
+    // lazily, they are copied here.
+    let switch_started = Instant::now();
+    lix.switch_branch(SwitchBranchOptions {
+        branch_id: branch_id.clone(),
+    })
+    .await
+    .expect("switch to branch-file-cost branch");
+    let switch_ms = switch_started.elapsed().as_secs_f64() * 1_000.0;
+    let after_switch = snapshot(&storage, &db_path).await;
+    report(files, "switch_branch", &after, &after_switch, switch_ms);
+
+    let write_started = Instant::now();
+    lix.execute(
+        "INSERT INTO lix_file (path, content) VALUES ($1, $2)",
+        &[
+            Value::Text("/docs/branch-probe.txt".to_owned()),
+            Value::Blob(one_document(usize::MAX).into()),
+        ],
+    )
+    .await
+    .expect("write first file on branch-file-cost branch");
+    let write_ms = write_started.elapsed().as_secs_f64() * 1_000.0;
+    let after_write = snapshot(&storage, &db_path).await;
+    report(files, "first_write_on_branch", &after_switch, &after_write, write_ms);
+
+    lix.close().await.expect("close branch-file-cost Lix");
+}
+
+fn report(files: usize, phase: &str, before: &Snapshot, after: &Snapshot, elapsed_ms: f64) {
     println!(
-        "branch_file_cost,files={files},\
+        "branch_file_cost,files={files},phase={phase},\
 before_rows={},after_rows={},d_rows={},\
 before_bytes={},after_bytes={},d_bytes={},\
 before_physical_bytes={},after_physical_bytes={},d_physical_bytes={},\
-seed_ms={seed_ms:.3},create_branch_ms={branch_ms:.3}",
+elapsed_ms={elapsed_ms:.3}",
         before.rows(),
         after.rows(),
         after.rows() as i64 - before.rows() as i64,
@@ -145,7 +182,7 @@ seed_ms={seed_ms:.3},create_branch_ms={branch_ms:.3}",
             continue;
         }
         println!(
-            "branch_file_cost_space,files={files},space={name},\
+            "branch_file_cost_space,files={files},phase={phase},space={name},\
 before_rows={},after_rows={},d_rows={d_rows},\
 before_bytes={},after_bytes={},d_bytes={d_bytes}",
             a.rows,
@@ -154,8 +191,6 @@ before_bytes={},after_bytes={},d_bytes={d_bytes}",
             b.key_bytes + b.value_bytes,
         );
     }
-
-    lix.close().await.expect("close branch-file-cost Lix");
 }
 
 #[derive(Clone, Default)]
@@ -242,19 +277,23 @@ where
             sql.push_str(&format!("(${}, ${})", parameter + 1, parameter + 2));
             let index = written + offset;
             params.push(Value::Text(format!("/docs/file-{index:07}.txt")));
-            let mut body = String::with_capacity(LINES_PER_FILE * 48);
-            for line in 0..LINES_PER_FILE {
-                body.push_str(&format!(
-                    "document {index} line {line}: content padding text\n"
-                ));
-            }
-            params.push(Value::Blob(body.into_bytes().into()));
+            params.push(Value::Blob(one_document(index).into()));
         }
         lix.execute(&sql, &params)
             .await
             .expect("seed branch-file-cost files");
         written += batch;
     }
+}
+
+fn one_document(index: usize) -> Vec<u8> {
+    let mut body = String::with_capacity(LINES_PER_FILE * 48);
+    for line in 0..LINES_PER_FILE {
+        body.push_str(&format!(
+            "document {index} line {line}: content padding text\n"
+        ));
+    }
+    body.into_bytes()
 }
 
 fn build_text_plugin_archive() -> Vec<u8> {

--- a/packages/rs-sdk-tests/examples/e10_branch_file_cost.rs
+++ b/packages/rs-sdk-tests/examples/e10_branch_file_cost.rs
@@ -1,0 +1,286 @@
+//! What does creating a branch cost, as a function of the number of
+//! **plugin-backed files** already on the branch?
+//!
+//! `branch_storage_sharing` answers the same question for entity *rows* and
+//! shows a flat curve: `hot_state.root_current_base.v1` publishes one 16-byte
+//! reference instead of copying hot rows. That plane does not cover the
+//! certified-entity-batch manifests, which are re-keyed from the source
+//! generation to the new branch generation one row per (file, format) in
+//! `hot_state/tracked_head/hot.rs`. Those rows only exist for files a WASM
+//! plugin materialized, so no row-shaped fixture can see them.
+//!
+//! This example seeds `N` JSON files through the real plugin path, snapshots
+//! exact logical layout accounting, creates one branch, and snapshots again.
+//! The delta is the price of the branch. Byte and row counts are
+//! deterministic, so one repetition per size is the whole measurement.
+//!
+//! ```text
+//! cargo run --release -p lix_tests --example e10_branch_file_cost -- 100 1000 10000
+//! ```
+
+use std::collections::BTreeMap;
+use std::io::{Cursor, Write};
+use std::path::Path;
+use std::time::Instant;
+
+use lix::storage::{ReadOptions, Storage};
+use lix::storage_adapter::StorageAdapter;
+use lix::storage_bench::layout_accounting;
+use lix::{CreateBranchOptions, Lix, Value, open_lix};
+use lix_storage_rocksdb::RocksDB;
+
+const INSERT_BATCH: usize = 100;
+
+fn main() {
+    let sizes: Vec<usize> = std::env::args()
+        .skip(1)
+        .filter_map(|value| value.parse().ok())
+        .collect();
+    let sizes = if sizes.is_empty() {
+        vec![100, 1_000, 10_000]
+    } else {
+        sizes
+    };
+
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("create branch-file-cost runtime");
+
+    runtime.block_on(async {
+        for files in sizes {
+            run_case(files).await;
+        }
+    });
+}
+
+async fn run_case(files: usize) {
+    let root = tempfile::Builder::new()
+        .prefix("e10-branch-file-cost-")
+        .tempdir()
+        .expect("create branch-file-cost directory");
+    let db_path = root.path().join("db");
+    let storage = RocksDB::open(&db_path).expect("open branch-file-cost RocksDB");
+    let lix = open_lix()
+        .with_storage(storage.clone())
+        .await
+        .expect("open branch-file-cost Lix");
+
+    install_json_plugin(&lix).await;
+    let seed_started = Instant::now();
+    seed_files(&lix, files).await;
+    let seed_ms = seed_started.elapsed().as_secs_f64() * 1_000.0;
+
+    let before = snapshot(&storage, &db_path).await;
+
+    let branch_started = Instant::now();
+    lix.create_branch(CreateBranchOptions {
+        id: None,
+        name: "e10-branch".to_owned(),
+        from_commit_id: None,
+    })
+    .await
+    .expect("create branch-file-cost branch");
+    let branch_ms = branch_started.elapsed().as_secs_f64() * 1_000.0;
+
+    let after = snapshot(&storage, &db_path).await;
+
+    println!(
+        "branch_file_cost,files={files},\
+before_rows={},after_rows={},d_rows={},\
+before_bytes={},after_bytes={},d_bytes={},\
+before_physical_bytes={},after_physical_bytes={},d_physical_bytes={},\
+seed_ms={seed_ms:.3},create_branch_ms={branch_ms:.3}",
+        before.rows(),
+        after.rows(),
+        after.rows() as i64 - before.rows() as i64,
+        before.bytes(),
+        after.bytes(),
+        after.bytes() as i64 - before.bytes() as i64,
+        before.physical_bytes,
+        after.physical_bytes,
+        after.physical_bytes as i64 - before.physical_bytes as i64,
+    );
+
+    let mut names: Vec<&'static str> = before.spaces.keys().copied().collect();
+    for name in after.spaces.keys() {
+        if !names.contains(name) {
+            names.push(name);
+        }
+    }
+    names.sort_unstable();
+    for name in names {
+        let a = before.spaces.get(name).copied().unwrap_or_default();
+        let b = after.spaces.get(name).copied().unwrap_or_default();
+        let d_rows = b.rows as i64 - a.rows as i64;
+        let d_bytes = (b.key_bytes + b.value_bytes) as i64 - (a.key_bytes + a.value_bytes) as i64;
+        if d_rows == 0 && d_bytes == 0 {
+            continue;
+        }
+        println!(
+            "branch_file_cost_space,files={files},space={name},\
+before_rows={},after_rows={},d_rows={d_rows},\
+before_bytes={},after_bytes={},d_bytes={d_bytes}",
+            a.rows,
+            b.rows,
+            a.key_bytes + a.value_bytes,
+            b.key_bytes + b.value_bytes,
+        );
+    }
+
+    lix.close().await.expect("close branch-file-cost Lix");
+}
+
+#[derive(Clone, Default)]
+struct Snapshot {
+    physical_bytes: u64,
+    spaces: BTreeMap<&'static str, SpaceCounts>,
+}
+
+#[derive(Clone, Copy, Default)]
+struct SpaceCounts {
+    rows: u64,
+    key_bytes: u64,
+    value_bytes: u64,
+}
+
+impl Snapshot {
+    fn rows(&self) -> u64 {
+        self.spaces.values().map(|counts| counts.rows).sum()
+    }
+
+    fn bytes(&self) -> u64 {
+        self.spaces
+            .values()
+            .map(|counts| counts.key_bytes + counts.value_bytes)
+            .sum()
+    }
+}
+
+async fn snapshot(storage: &RocksDB, directory: &Path) -> Snapshot {
+    storage.flush().expect("flush branch-file-cost RocksDB");
+    let adapter = StorageAdapter::new(storage.clone());
+    let read = adapter
+        .begin_read(ReadOptions::default())
+        .await
+        .expect("open branch-file-cost layout read");
+    let accounting = layout_accounting(&read).await;
+    drop(read);
+    let mut spaces = BTreeMap::new();
+    for entry in accounting {
+        spaces.insert(
+            entry.space,
+            SpaceCounts {
+                rows: entry.rows,
+                key_bytes: entry.key_bytes,
+                value_bytes: entry.value_bytes,
+            },
+        );
+    }
+    Snapshot {
+        physical_bytes: directory_bytes(directory),
+        spaces,
+    }
+}
+
+async fn install_json_plugin<StorageImpl>(lix: &Lix<StorageImpl>)
+where
+    StorageImpl: Storage + Clone + Send + Sync + 'static,
+{
+    lix.execute(
+        "INSERT INTO lix_file (path, content) VALUES ($1, $2)",
+        &[
+            Value::Text("/.lix/plugins/plugin_json.lixplugin".to_owned()),
+            Value::Blob(build_json_plugin_archive().into()),
+        ],
+    )
+    .await
+    .expect("install branch-file-cost JSON plugin");
+}
+
+async fn seed_files<StorageImpl>(lix: &Lix<StorageImpl>, files: usize)
+where
+    StorageImpl: Storage + Clone + Send + Sync + 'static,
+{
+    let mut written = 0usize;
+    while written < files {
+        let batch = (files - written).min(INSERT_BATCH);
+        let mut sql = String::from("INSERT INTO lix_file (path, content) VALUES ");
+        let mut params: Vec<Value> = Vec::with_capacity(batch * 2);
+        for offset in 0..batch {
+            if offset > 0 {
+                sql.push(',');
+            }
+            let parameter = offset * 2;
+            sql.push_str(&format!("(${}, ${})", parameter + 1, parameter + 2));
+            let index = written + offset;
+            params.push(Value::Text(format!("/docs/file-{index:07}.json")));
+            params.push(Value::Blob(
+                format!(
+                    r#"{{"index":{index},"title":"document {index}","body":"{}"}}"#,
+                    "content padding for a realistic small document"
+                )
+                .into_bytes()
+                .into(),
+            ));
+        }
+        lix.execute(&sql, &params)
+            .await
+            .expect("seed branch-file-cost files");
+        written += batch;
+    }
+}
+
+fn build_json_plugin_archive() -> Vec<u8> {
+    let wasm_path = Path::new(env!("CARGO_CDYLIB_FILE_PLUGIN_JSON_plugin_json"));
+    let wasm = std::fs::read(wasm_path).unwrap_or_else(|error| {
+        panic!(
+            "failed to read bindep-built JSON wasm at {}: {error}",
+            wasm_path.display()
+        )
+    });
+    let mut writer = zip::ZipWriter::new(Cursor::new(Vec::new()));
+    let options =
+        zip::write::SimpleFileOptions::default().compression_method(zip::CompressionMethod::Stored);
+    for (path, bytes) in [
+        (
+            "manifest.json",
+            include_str!("../../../plugins/json/manifest.json").as_bytes(),
+        ),
+        (
+            "schema/json_root.json",
+            include_str!("../../../plugins/json/schema/json_root.json").as_bytes(),
+        ),
+        (
+            "schema/json_object_member.json",
+            include_str!("../../../plugins/json/schema/json_object_member.json").as_bytes(),
+        ),
+        (
+            "schema/json_array_item.json",
+            include_str!("../../../plugins/json/schema/json_array_item.json").as_bytes(),
+        ),
+        ("plugin.wasm", wasm.as_slice()),
+    ] {
+        writer.start_file(path, options).expect("start archive file");
+        writer.write_all(bytes).expect("write archive file");
+    }
+    writer.finish().expect("finish archive").into_inner()
+}
+
+fn directory_bytes(path: &Path) -> u64 {
+    std::fs::read_dir(path).map_or(0, |entries| {
+        entries
+            .flatten()
+            .map(|entry| {
+                let path = entry.path();
+                entry.metadata().map_or(0, |metadata| {
+                    if metadata.is_dir() {
+                        directory_bytes(&path)
+                    } else {
+                        metadata.len()
+                    }
+                })
+            })
+            .sum()
+    })
+}


### PR DESCRIPTION
## Summary

**Measurement only — no engine change.** This PR adds one benchmark example and reports a
**negative result**: branch creation is already O(1), and the hypothesis that it copies per-file
state does not reproduce through the public branch-creation path.

Machine **ryzen-9950x-IV**, base SHA **`5bc46723`**, RocksDB + SlateDB, release profile.
Byte and row counts are deterministic, so every point is **1 rep** (verified reproducing across
three independent runs of the files curve).

## The hypothesis, and why it fails

The suspicion was that certified-manifest inheritance re-copies every manifest row under the new
generation on a generation change (`hot_state/tracked_head/hot.rs:610-655`), making branch creation
O(files on the branch).

That loop is unreachable from branch creation. `create_branch` stages a branch descriptor and a
branch ref (`session/create_branch.rs:80-82`); that ref move is an **explicit branch head target**,
and every explicit head move publishes a root-backed reference and registers the branch in
`root_backed_branch_publications` (`transaction/commit.rs:5093-5111`). The inheritance loop is
guarded by exactly that set (`hot.rs:586-589`) and skips.

Consequence for sequencing: **E1's fix does not make branch creation more expensive.** E1's
0.017 / 0.159 / 1.819 ms curve measures the inheritance call itself, which on this head is only
reached by a non-root-backed generation change on an already-established branch.

## Curve 1 — rows axis (existing `branch_storage_sharing`, scenario `branch_noop`)

| rows | Δrows | Δlogical bytes | Δphysical rocks | Δphysical slate | ms |
|---|---|---|---|---|---|
| 1,000 | 15 | 3,095 | 21,456 | 20,428 | 3.81 |
| 10,000 | 15 | 3,095 | 21,447 | 20,413 | 3.68 |
| 100,000 | 15 | 3,095 | 21,025 | 20,400 | 3.17 |

100x rows, identical row count and identical byte count on both backends. Flat latency.
`hot_state.root_current_base.v1` gains exactly 1 row / 74 bytes — the 16-byte-reference design
documented at `hot.rs:118-125` doing exactly what it claims.

## Curve 2 — files axis (new `e10_branch_file_cost`)

`branch_storage_sharing` structurally cannot see the plane under suspicion: its registered-schema
fixture leaves all three `hot_state.certified_entity_batch*` spaces at **zero rows**.

The new example seeds N files through the real `text` plugin at **80 lines each**, above
`HOST_CERTIFIED_PACKET_MIN_ROWS = 64` (`plugin/incremental.rs:1903`) — the threshold that makes a
fresh file certify a dense batch. Verified populated: at 100 files,
`hot_state.certified_entity_batch_manifest.v1` = 100 rows / 13,200 bytes (one per file),
`certified_entity_batch.v1` = 100 rows, `certified_entity_batch_page.v1` = 100 rows / 1.36 MB.

**A fixture below that threshold measures nothing while looking healthy** — a JSON fixture at
~3 rows/file leaves the planes empty and the delta table looks identical. That is why the example
prints the plugin row count and an optional full space inventory (`E10_INVENTORY=1`).

| files | phase | Δrows | Δlogical bytes | elapsed |
|---|---|---|---|---|
| 100 | create_branch | **14** | **3,079** | 2.30 ms |
| 1,000 | create_branch | **14** | **3,080** | 2.77 ms |
| 10,000 | create_branch | **14** | **3,080** | 3.66 ms |
| 100 | switch_branch | 0 | 0 | 0.65 ms |
| 1,000 | switch_branch | 0 | 0 | 0.87 ms |
| 10,000 | switch_branch | 0 | 0 | 1.16 ms |

`hot_state.certified_entity_batch_manifest.v1` has **Δ = 0 at every file count**. The same 12 spaces
move by one row each at every size.

Sharing is real rather than a missing copy: after switching, the branch serves the full `text_line`
population (8,080 / 80,080 rows) having inherited zero per-file rows.

## Sharing side — where content-addressing does not pay

`branches_2_identical_1pct` (two branches writing **byte-identical** payloads to the same paths) vs
`branches_2_disjoint_1pct`:

| rows | disjoint Δbytes | identical Δbytes | saving |
|---|---|---|---|
| 1,000 | 19,950 | 19,937 | 0.07% |
| 10,000 | 114,384 | 114,322 | 0.05% |

No cross-branch value dedup on the edit path; the dominant term is `hot_state.row.v21`
(94,462 vs 94,352 at 10k), which carries the value inline rather than a content hash. This is *edit*
cost, not *branch* cost, and it overlaps E8's write-amplification lane, so it is reported and not
pursued here.

## Adjacent findings (reported, not fixed)

**Steady-state branch write premium.** A write on a non-default branch costs ~1.6-1.9x a write on
main at constant rows written. The 2nd write equals the 1st at 10k files (133.6 vs 135.0 ms), so it
is not one-time deferred materialization.

| files | write on main | 1st write on branch | 2nd write on branch |
|---|---|---|---|
| 100 | 2.41 ms | 4.97 ms | 2.66 ms |
| 1,000 | 8.45 ms | 13.27 ms | 10.64 ms |
| 10,000 | 72.04 ms | 134.97 ms | 133.60 ms |

The write path is also O(files) **on main** (2.4 → 8.4 → 72 ms while writing ~33 rows).

**Independent end-to-end reproduction of E1's read truncation.** `SELECT COUNT(*) FROM text_line`
on main, through the plain SQL surface, on `5bc46723`:

| files | expected | returned |
|---|---|---|
| 100 | 8,000 | 8,000 |
| 1,000 | 80,000 | 80,000 |
| 10,000 | 800,000 | **81,920** |

81,920 = 80 x **1,024**. Corroborates E1 at file granularity; E1 owns the fix.

## Layout invariants

1. **Single authority** — no. Adds no writer, no materialization, no index. One new example file.
2. **Commit canonicality** — unchanged; nothing here touches commits or refs.
3. **Derived views are caches** — unchanged. The measurement confirms `root_current_base.v1` behaves
   as a shared reference rather than a per-branch copy.
4. **Atomic publication** — unchanged.
5. **GC from refs** — unchanged.
6. **SQL reads canonical records** — unchanged.

## What was removed / adapter API

Nothing removed. **No storage adapter API added, changed, or removed.** No space added, no versioned
identifier bumped, no key encoding changed, no writer touched. Public API untouched.

## Regressions

None — no engine code changes.

## Null control

Not applicable to the primary claim. Every number in the two curves is a deterministic logical
row/byte count from `layout_accounting`, reproducing exactly across three independent runs of the
files curve and both backends of the rows curve. `Δphysical_bytes` is *not* deterministic (LSM
compaction timing; one 10k sample read −19 MB) and is reported for context only, never as the claim.

## Gate

On ryzen-9950x-IV at `5bc46723` + this diff:

```
cargo check   --workspace --all-targets --all-features   # clean
cargo clippy  --workspace --all-targets --all-features -- -D warnings   # 0 warnings
cargo build --release -p lix_tests --example e10_branch_file_cost       # clean
```

The full workspace test job was not re-run: this diff adds a single `examples/` file to `lix_tests`
and changes no library code, so no test target's behaviour can move. `--all-targets` covers that the
example compiles.

## Bench commands

```
LIX_BRANCH_SHARING_ROWS=1000,10000,100000 LIX_BRANCH_SHARING_BACKENDS=rocksdb,slatedb \
  cargo bench -p lix_benchmarks --features storage-benches,slatedb --bench branch_storage_sharing

cargo run --release -p lix_tests --example e10_branch_file_cost -- 100 1000 10000
```
