### PR TITLE
test(hot_state): pin why a LIMIT cannot be pushed into the certified manifest scan

### DIFF
--- a/packages/lix/src/hot_state/tracked_head/hot.rs
+++ b/packages/lix/src/hot_state/tracked_head/hot.rs
@@ -14242,6 +14242,10 @@ mod tests {
     const PAGING_FILE_COUNT: usize = crate::storage_adapter::MAX_SCAN_PAGE_ROWS + 3;
 
     fn paging_certified_batch(index: usize) -> WasmCertifiedEntityBatch {
+        certified_batch_for_schema(PAGING_SCHEMA_KEY, index)
+    }
+
+    fn certified_batch_for_schema(schema_key: &str, index: usize) -> WasmCertifiedEntityBatch {
         let mut page = Vec::new();
         page.extend_from_slice(&0_u32.to_le_bytes());
         page.extend_from_slice(&1_u64.to_le_bytes());
@@ -14253,7 +14257,7 @@ mod tests {
         let page = crate::plugin_wire::encode_single_section(
             crate::plugin_wire::Representation::SchemaRows,
             crate::plugin_wire::Operation::Create,
-            PAGING_SCHEMA_KEY,
+            schema_key,
             br#"{"wire":["create_ref_u32","u64","u8","bytes_u32","list_utf8_u16"],"primary_key":[{"kind":"generated_id","slot":0}],"fields":[{"name":"cells","value":{"kind":"list_utf8","slot":4}},{"name":"id","value":{"kind":"generated_id","slot":0}},{"name":"layout","object":[{"name":"force_quote","value":{"kind":"base64_url","slot":3}},{"name":"terminator","value":{"kind":"enum","slot":2,"values":[null,"","\n","\r\n","\r"]}}]},{"name":"order_key","value":{"kind":"hex_u64","slot":1,"width":16}}]}"#,
             1,
             page,
@@ -14261,7 +14265,7 @@ mod tests {
         .expect("paged certified schema-row page");
         WasmCertifiedEntityBatch {
             format: 1,
-            schema_keys: vec![PAGING_SCHEMA_KEY.to_owned()],
+            schema_keys: vec![schema_key.to_owned()],
             row_count: 1,
             creates: WasmCreateContext {
                 high: 0x0192_0000_0000_7000,
@@ -14371,6 +14375,121 @@ mod tests {
                 return total;
             }
         }
+    }
+
+    /// Pins why a `LIMIT` cannot be pushed into the certified manifest scan.
+    ///
+    /// Manifest keys are `generation || file_id || format || commit_id`, so the
+    /// scan visits files in `file_id` order. Rows are returned in canonical
+    /// identity order, which is `(schema_key, entity_pk, file_id)` — `file_id`
+    /// is the *last* tiebreaker (`compare_materialized_live_identity_refs`).
+    /// The two orders are orthogonal, so the canonically first row can live in
+    /// the last file the scan reaches, and no prefix of the manifest scan is
+    /// enough to answer `LIMIT 1`.
+    ///
+    /// This fixture makes that concrete: the winning row sits in the
+    /// lexicographically *last* file. A limit pushed into the manifest scan
+    /// would stop at `early.csv` and return the wrong row, so this test fails
+    /// for any such pushdown that is not preceded by a physical layout change.
+    #[tokio::test]
+    async fn certified_limit_cannot_stop_at_the_first_manifest() {
+        const BRANCH_ID: &str = "01920000-0000-7000-8000-0000000001a3";
+        const EARLY_FILE: &str = "early.csv";
+        const LATE_FILE: &str = "late.csv";
+        // Canonical order is schema-major, so the row in the later file wins.
+        const LATE_FILE_SCHEMA: &str = "aaa_winning_schema";
+        const EARLY_FILE_SCHEMA: &str = "zzz_losing_schema";
+
+        let storage = StorageAdapter::new(Memory::new());
+        let head_commit_id = CommitId::for_test_label("limit-pushdown-head");
+        let generation = CommitId::for_test_label("limit-pushdown-generation");
+        let created_at = timestamp();
+        let control = BranchHeadControl {
+            head_commit_id,
+            tracked_generation: generation,
+            current_state_revision: 0,
+            schema_presence_bloom: [u64::MAX; 4],
+            working_diff_checkpoint_commit_id: None,
+            created_at,
+            updated_at: created_at,
+            ref_change_id: ChangeId::for_test_label("limit-pushdown-ref"),
+        };
+
+        let early = [certified_batch_for_schema(EARLY_FILE_SCHEMA, 0)];
+        let late = [certified_batch_for_schema(LATE_FILE_SCHEMA, 1)];
+        let files = [
+            CertifiedEntityBatchFileRef {
+                branch_id: BRANCH_ID,
+                file_id: EARLY_FILE,
+                batches: &early,
+            },
+            CertifiedEntityBatchFileRef {
+                branch_id: BRANCH_ID,
+                file_id: LATE_FILE,
+                batches: &late,
+            },
+        ];
+
+        let read = storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("limit pushdown seed read should open");
+        let mut writes = StorageWriteSet::new();
+        stage_branch_head_control(&mut writes, BRANCH_ID, control)
+            .expect("limit pushdown control should stage");
+        stage_certified_entity_batches(
+            &read,
+            &mut writes,
+            &files,
+            &BTreeMap::from([(BRANCH_ID.to_owned(), control)]),
+            &BTreeMap::from([(
+                BRANCH_ID.to_owned(),
+                crate::branch::BranchHeadControlObservation {
+                    control: Some(control),
+                    raw_token: None,
+                },
+            )]),
+            &BTreeMap::from([(head_commit_id, created_at)]),
+            &BTreeSet::new(),
+        )
+        .await
+        .expect("limit pushdown batches should stage");
+        drop(read);
+        storage
+            .commit_write_set(writes, StorageWriteOptions::default())
+            .await
+            .expect("limit pushdown batches should commit");
+
+        let read = storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("limit pushdown verification read should open");
+        let rows = scan_certified_entity_batch_rows(
+            &read,
+            BRANCH_ID,
+            generation,
+            &TrackedStateScanRequest {
+                filter: TrackedStateFilter::default(),
+                read_columns: TrackedStateReadColumns {
+                    columns: vec!["snapshot_content".to_owned()],
+                },
+                limit: Some(1),
+            },
+            Some(1),
+            None,
+        )
+        .await
+        .expect("limited certified scan should succeed");
+
+        assert_eq!(rows.len(), 1);
+        assert_eq!(
+            rows.row(0).file_id(),
+            Some(LATE_FILE),
+            "LIMIT 1 must return the canonically first row, which lives in the \
+             last file the manifest scan reaches; a limit pushed into that scan \
+             would return {EARLY_FILE} instead"
+        );
+        assert_eq!(rows.row(0).schema_key(), LATE_FILE_SCHEMA);
     }
 
     #[tokio::test]


### PR DESCRIPTION
# test(hot_state): pin why a LIMIT cannot be pushed into the certified manifest scan

**Negative result.** E14 set out to push the deferred `LIMIT` into the certified manifest scan, with
"move winner selection ahead of the limit" as the expected prerequisite. Winner selection *can* move
ahead of the limit. It does not help, because that is not the binding constraint. The read
amplification is **structural** under the current physical layout, and this PR lands the test that
says so rather than a pushdown.

## The obstruction

Two orderings, and they are orthogonal.

**Physical manifest key** (`hot.rs`, certified manifest write path):

```
generation(16) || len(u16) || file_id || format(u32) || head_commit_id(16)
```

so a prefix scan over the generation visits files in **`file_id` order**.

**Canonical row order**, which is what `LIMIT` is applied to
(`compare_materialized_live_identity_refs`, `hot.rs:4409`):

```
schema_key, then entity_pk, then file_id
```

`file_id` is the **last** tiebreaker. And every row's `file_id` is fixed by which manifest produced
it — a certified batch header carries exactly one `file_id` (`decode_certified_entity_batch_rows`,
`hot.rs:1510`), so all rows from one manifest share it.

Put together: the canonically first row can live in the **last** file the scan reaches. No prefix of
the manifest scan is sufficient to answer `LIMIT 1`, for any prefix shorter than all of it. Stopping
early does not lose a *tie* — it returns a row that is not the answer.

Winner selection is genuinely movable: contests are confined within one `file_id` (the dedup key is
`(schema_key, entity_pk, file_id)`), and manifests for a file are contiguous in scan order, so
winners could be resolved per file, streaming, without materializing every row first. That is a real
memory improvement and it is *still* not a limit pushdown, because the limit needs global order and
the scan does not produce it.

## What would actually be required

An early-terminating scan needs a manifest ordering whose leading component matches the output
order — i.e. keyed by `schema_key`/`entity_pk` rather than `file_id`. But manifests are per
`(file, format, commit)` by construction, and individual rows inside a batch are not separately
addressable. Getting order-aligned early termination therefore means **per-row keys for certified
plugin rows** — which is precisely what the certified plane exists to avoid. That compaction is the
reason plugin-mapped files do not pay a HOT row key each.

So the trade is not an oversight to fix. **You can have the compact per-file batch layout, or
order-aligned early termination, not both.** Anyone who wants the pushdown is really proposing to
delete the certified plane's reason for existing, and should argue it on those terms.

## Cost that is now permanent, stated exactly

Deterministic, so 1 rep and no benchmark needed — it is evident in the control flow, not a
measurement: `scan_certified_entity_batch_rows` reads **every** manifest under the generation, then
issues a `PointReadPlan` over **every** resulting content key, regardless of `limit`. For a branch
with N plugin files and a query with `LIMIT k`:

| quantity | before #1367 | now | with a pushdown (unavailable) |
|---|---|---|---|
| manifests read | min(N, 1024) | N | k-ish |
| content batches fetched | min(N, 1024) | N | k-ish |
| answer | **wrong above 1024** | correct | correct |

Wall-clock shape for the same scan work was measured in #1367: linear, ≈0.18 µs per manifest
(0.017 ms at 100 files, 0.159 ms at 1,024, 1.819 ms at 10,000 — ryzen-9950x-I, release, 5 reps,
median).

## The one adjacent win that *is* available

Not in this PR, and not a pushdown, but worth recording because it is the only real read-amplification
reduction I found: **schema membership is currently discoverable only by fetching the content batch
header.** The manifest value holds nothing but the content key. A schema-filtered query
(`filter.schema_keys` non-empty, which is the common shape) therefore fetches every content batch on
the branch just to discover most of them cannot match.

Widening the manifest value to carry the batch's schema-key set would let that query skip the content
fetch for non-matching files — a genuine N→matching-N reduction on the second table row above. It is a
physical layout change, in scope for this round, and it does **not** help unfiltered `LIMIT` queries.
That is a separate experiment with its own measurement, not a variant of this one.

## What this PR contains

One test, `certified_limit_cannot_stop_at_the_first_manifest`, plus a two-line refactor making the
existing `paging_certified_batch` helper take a schema key so the fixture can control canonical
order.

The fixture puts the winning row in the lexicographically **last** file: `early.csv` holds schema
`zzz_losing_schema`, `late.csv` holds `aaa_winning_schema`. `LIMIT 1` must return the row from
`late.csv`. Any limit pushed into the manifest scan stops at `early.csv` and returns the wrong row,
so this test fails for exactly the class of change that would reintroduce "returns fewer rows than
exist".

It passes on current code — it pins correct behaviour and documents the reason at the site, so the
next person to reach for this optimization finds the argument instead of re-deriving it from a
corruption report.

The two #1367 proof tests stay green alongside it, which was the constraint on this experiment:

```
test ...::certified_limit_cannot_stop_at_the_first_manifest ... ok
test ...::branch_creation_inherits_every_certified_manifest_past_one_scan_page ... ok
test ...::certified_scan_returns_every_file_past_one_scan_page ... ok
test result: ok. 3 passed; 0 failed
```

## Layout invariants

Test-only; no physical change. (1) no new authority, (2) commit canonicality untouched, (3) no new
derived view, (4) no publication path touched, (5) no retention metadata, (6) no query surface
change.

## Gate

Full CI-scope gate on **ryzen-9950x-I**, branch head rebased on integration head `e981e2c5`:

| command | result |
|---|---|
| `cargo check --workspace --all-targets --all-features` | clean |
| `cargo clippy --workspace --all-targets --all-features -- -D warnings` | clean |
| `cargo check -p lix --no-default-features` | clean |
| `cargo check -p lix_js_sdk --target wasm32-unknown-unknown` | clean |
| workspace tests `--no-fail-fast` | **3476 passed / 0 failed** |
| `lix_benchmarks` tests `--no-fail-fast` | **26 passed / 0 failed** |

Zero `error` and zero `warning` lines. 3476 = the merged head's 3475 plus this PR's one new test.
