### PR TITLE
perf(sql2): stop double-applying exact identity predicates on entity scans

### DIFF
--- a/packages/lix/src/sql2/providers/entity.rs
+++ b/packages/lix/src/sql2/providers/entity.rs
@@ -288,7 +288,18 @@ impl EntitySpec {
         limit: Option<usize>,
     ) -> Result<(SchemaRef, HotStateScanRequest, Vec<EntityRowFilter>)> {
         let projected_schema = projected_schema(&self.schema, projection);
-        let row_filters = EntityRowFilterAnalyzer::new(&self.spec).analyze_filters(filters)?;
+        // A predicate that resolves to a complete identity set is applied in
+        // full by the `entity_pks` access path below, and `filter_pushdown`
+        // already reports it as `Exact` for exactly that reason. Re-deriving a
+        // residual row filter for it makes the provider evaluate the same
+        // predicate twice and — because a non-empty `row_filters` disqualifies
+        // every direct route — forces the point read onto the generic
+        // visibility scan.
+        let row_filters =
+            EntityRowFilterAnalyzer::new(&self.spec).analyze_filters(&exact_identity_residual(
+                &EntityPrimaryKeyFilterAnalyzer::new(&self.spec),
+                filters,
+            ))?;
         let mut request = entity_hot_state_scan_request(
             &self.spec.schema_key,
             self.branch_binding.active_branch_id(),
@@ -2238,7 +2249,7 @@ impl<'a> EntityRowFilterAnalyzer<'a> {
     }
 
     #[expect(clippy::unnecessary_wraps)]
-    fn analyze_filters(&self, filters: &[Expr]) -> Result<Vec<EntityRowFilter>> {
+    fn analyze_filters(&self, filters: &[&Expr]) -> Result<Vec<EntityRowFilter>> {
         Ok(filters
             .iter()
             .filter_map(|filter| self.analyze(filter))
@@ -2902,6 +2913,18 @@ fn projection_column_names(schema: &Schema) -> Vec<String> {
         .iter()
         .filter_map(|field| field.name().strip_prefix("lixcol_"))
         .map(str::to_string)
+        .collect()
+}
+
+/// The filters that still need a row-shaped predicate after the exact
+/// identity access path has consumed the ones it applies in full.
+fn exact_identity_residual<'a>(
+    analyzer: &EntityPrimaryKeyFilterAnalyzer<'_>,
+    filters: &'a [Expr],
+) -> Vec<&'a Expr> {
+    filters
+        .iter()
+        .filter(|filter| !analyzer.supports(filter))
         .collect()
 }
 


### PR DESCRIPTION
# perf(sql2): stop double-applying exact identity predicates on entity scans

**Machine:** `ryzen-9950x-III` (32c / 186 GB). **Base SHA:** `f3c37056c7ed3223f00ebed458d469af19dd49cf`
(integration head at the time of measurement). **Backend:** RocksDB.
`/tmp` on this host is **not** a tmpfs — it resolves to the ext4 RAID root (`/dev/md0`), and every
run additionally forced `TMPDIR=$HOME/claude5/e7-scratch` on that same volume. The two arms use
separate target dirs (`~/claude5/target-base`, `~/claude5/target-cand`).

## What this fixes

`EntitySpec::plan_scan_parts` derived its residual `row_filters` from **every** pushed-down filter,
including the ones that resolve to a complete entity identity set. Those predicates are already
applied in full by the `entity_pks` access path, and `filter_pushdown` reports them to DataFusion as
`Exact` for precisely that reason — so the provider was evaluating the same predicate twice.

The second, larger cost is that a non-empty `row_filters` **disqualifies every direct route**:
`direct_entity_batch_eligible` requires `row_filters.is_empty()`. So a plain point read
(`SELECT path, value FROM json_pointer WHERE path IN ('…')`) could never reach
`scan_direct_entity_snapshots`, and therefore never reached the entity point-snapshot cache either.

This was visible in the round-5 claim-3 measurement as `point cache accounting: hits=0 misses=0` —
not "misses", *never consulted*. Instrumenting the gate on this host confirmed the cause exactly:

```
E7-TRACE: plan_scan: eligible=false reader_present=true fields=[path,value] rows_all=true
          row_filters=1 file_ids=0 constraints=0 pks=1 limit=None branch_ids=1 schema_keys=1
```

Every precondition was satisfied except `row_filters=1`, and that one entry was the redundant copy
of the `path IN (…)` predicate that `entity_pks` had already consumed.

## What changed physically

- `plan_scan_parts` now analyses row filters over the **residual** filters only — those for which
  `EntityPrimaryKeyFilterAnalyzer::supports()` is false. `supports()` is the same predicate that
  already drives the `Exact` pushdown answer, and it is true only when `into_entity_pks` binds every
  primary-key component, i.e. only when the whole expression is expressible as an identity set.
- `EntityRowFilterAnalyzer::analyze_filters` takes `&[&Expr]` so the residual is borrowed, not cloned.
- New 8-line helper `exact_identity_residual`.

**Removed:** the duplicate evaluation of an exact-identity predicate on every entity scan. No storage
space, writer, or code path was added. **No adapter API was added, changed, or removed**, and no
public API or SQL surface changed — the same statements return the same rows.

## Results — the floor drops and stays flat

Warm SQL session (`LIX_TRACKED_STATE_CRUD_PROFILE_LAYER=sql_session`), 5 000 hot repeats,
3 interleaved reps per point with **rotating arm order**. This is the same lane the round-5 claim-3
baseline used. µs/operation.

### `read_one_by_pk` — the primary claim

| rows | base raw | base median | cand raw | cand median | delta |
|---:|---|---:|---|---:|---:|
| 1 000 | 80.038, 75.928, 76.205 | **76.205** | 30.407, 29.608, 29.739 | **29.739** | **−61.0%** |
| 10 000 | 79.753, 79.612, 79.133 | **79.612** | 29.196, 29.415, 29.726 | **29.415** | **−63.1%** |
| 100 000 | 80.016, 78.930, 78.283 | **78.930** | 29.656, 28.679, 29.932 | **29.656** | **−62.4%** |

The arms' raw ranges do not overlap at any size (base min 75.9, cand max 30.4), which is the
runbook's condition for accepting 3 reps on a timing claim; the effect is also 36x this bench's
measured noise floor (below).

**The shape is the point.** The cost was already flat in table size — a fixed per-statement floor,
not an asymptotic term. It is still flat, and the whole curve moved down by ~2.7x. p95 (max of 3):
base 80.0 / 79.8 / 80.0 µs, cand 30.4 / 29.7 / 29.9 µs.

Point-cache accounting on the same runs: base `hits=0 misses=0` (never consulted) →
cand `hits=4999 misses=1`.

### In claim-3 terms

The round-5 claim-3 baseline was taken on `hetzner-cpx62-III`. To make this comparable I rebuilt that
report's SQLite arm (`claim3-sqlite-arm`, SQLite 3.46.0 bundled, WAL, `synchronous=NORMAL`, same
fixture, same statement shape, same fold-every-cell consumption) on **this** host and ran it against
the same 10k-row workload, 3 reps:

| op | SQLite (this host) | lix base | ratio | lix cand | **ratio** |
|---|---:|---:|---:|---:|---:|
| `read_one_by_pk` | 0.942 µs | 79.612 µs | 84.5x | 29.415 µs | **31.2x** |
| `read_many_by_pk` (10) | 12.90 µs | 126.508 µs | 9.8x | 116.950 µs | **9.1x** |
| `update_one_by_pk` | 1.124 µs | 280.776 µs | 250x | 276.467 µs | 246x |

SQLite raw: `read_one` 0.938 / 0.959 / 0.942 µs · `read_many` 12.83 / 12.90 / 12.91 µs ·
`update_one` 1.111 / 1.127 / 1.124 µs.

The base ratio of **84.5x** here reproduces the claim-3 report's **86.4x** on a machine 2.8x faster in
absolute terms, so the ratio is host-independent and this change moves the published point-read gap
from ~86x to ~31x. It does not rescue claim 3 as written ("at most 1.2x slower than SQLite") — nothing
in this diff could — but it is the largest single step toward it measured this round.

### Decomposing the win

`read_many_by_pk` (10 keys, 10k rows) enters the direct route but **cannot** use the point-snapshot
cache — `point_key` is only formed for a single entity pk. It therefore isolates the part of the win
that is not cache warmth:

| id | base raw | base median | cand raw | cand median | delta |
|---|---|---:|---|---:|---:|
| `read_many_by_pk` (10) | 126.552, 124.510, 126.508 | 126.508 | 115.208, 117.719, 116.950 | 116.950 | **−7.6%** |

So ~7.6% comes from taking the direct route at all, and the rest of the 62% comes from the point
cache the direct route unlocks. Ranges do not overlap here either (base min 124.5 > cand max 117.7).

**Honest framing of the point-read number:** the hot lane reads the *same* key 5 000 times, so the
point cache hits 4999/5000. That is the steady-state shape of an application reusing a connection on
a hot row — and it is the same shape the SQLite comparison arm was given (a reused prepared
statement) — but it is not the number for a scan of 5 000 *distinct* keys. For that population the
`read_many_by_pk` figure (−7.6%) is the applicable one.

### Null control

`read_all_rows` at 10k has no `WHERE` clause, so `filters` is empty and the changed code is
byte-equivalent in both arms. It is the null control:

| id | base raw | base median | cand raw | cand median | delta |
|---|---|---:|---|---:|---:|
| `read_all` (10k) | 547.488, 545.757, 551.903 | 547.488 | 547.214, 543.296, 552.474 | 547.214 | **−0.05%** |

Within-arm spread: base 1.1%, cand 1.7%. **This bench's noise floor is ~±1.7%.**

## Guards

**Write path** (`update_one_by_pk`, 10k rows, 1 000 repeats, 3 interleaved reps). The write path
shares the same per-statement floor, so it is a guard that can genuinely move:

| arm | raw | median |
|---|---|---:|
| base | 318.936, 280.776, 276.347 | 280.776 |
| cand | 274.143, 276.467, 286.722 | 276.467 |

−1.5%, ranges overlap → **neutral, no regression**. (The 318.9 first-rep base sample is a warm-up
outlier.)

**Criterion read lanes** (`sql_session/lix_rocksdb/.*/read_`, `--sample-size 10`, 2 interleaved reps
per arm). This lane builds a **fresh engine, plan cache and block cache per timed operation**, so
~1.19 ms of its 1.22 ms `read_one_by_pk` is fixture construction and the point cache can never be
warm. It cannot resolve this change; it is here only to prove nothing regressed.

| id | base | cand | delta |
|---|---:|---:|---:|
| `smoke/read_all_rows/1k` | 820.0 µs | 834.6 µs | +1.8% |
| `smoke/read_all_rows_consumed/1k` | 1074.8 µs | 1095.5 µs | +1.9% |
| `smoke/read_one_by_pk/1k` | 701.4 µs | 730.9 µs | +4.2% → see below |
| `smoke/read_many_by_pk/10` | 793.6 µs | 755.2 µs | −4.8% |
| `real_workload/read_all_rows/10k` | 2555.5 µs | 2507.6 µs | −1.9% |
| `real_workload/read_all_rows_consumed/10k` | 3702.5 µs | 3691.7 µs | −0.3% |
| `real_workload/read_one_by_pk/10k` | 1217.6 µs | 1232.0 µs | +1.2% |
| `real_workload/read_many_by_pk/10` | 1313.4 µs | 1285.0 µs | −2.2% |

`smoke/read_one_by_pk/1k` moved past 4% on 2 reps, so it was **escalated to 5 interleaved reps**
(the runbook names the 1k ids as the worst offenders for fake results at low rep counts):

| arm | raw (µs) | median |
|---|---|---:|
| base | 708.79, 710.03, 727.95, 710.13, 728.39 | 710.13 |
| cand | 719.78, 707.00, 721.64, 726.07, 714.94 | 719.78 |

+1.4% with the arms' ranges **fully overlapping** (base 708.8–728.4, cand 707.0–726.1). The +4.2%
was a 2-rep artefact. No lane regresses beyond this bench's own noise.

Guards deliberately **not** run: the bytes/space benches (`packed_history_scale`, `small_blob_cas`,
`large_blob_updates`) and the VC benches. This change is confined to SQL provider planning, writes no
bytes, and alters no encoding — a guard that cannot execute the changed code is not a guard.

## Layout invariants

1. **Single authority.** No new authority. The change *deletes* a second, redundant application of a
   predicate that the `entity_pks` access path already applies in full. No new writer, no new
   materialization, no new index.
2. **Commit canonicality.** Untouched — this is read-side query planning only. No commit record, ref,
   or parent link is read or written differently.
3. **Derived views are caches.** The entity point-snapshot cache is pre-existing and unchanged; this
   change only makes it reachable from the lane it was written for. It stays a cache: keyed by
   `(branch_id, tracked_generation, current_state_revision, schema_key, entity_pk)`, bounded at
   8 MiB / 4 096 entries, rebuilt from the tracked-head serving plane on a miss, never authoritative.
4. **Atomic publication.** Unaffected; no publication path is touched.
5. **GC from refs.** Unaffected; no retention metadata is read or written.
6. **SQL reads canonical records.** Yes. The direct route resolves rows through the same tracked-head
   serving plane the generic visibility scan reads. Because the cache key carries both
   `tracked_generation` and `current_state_revision`, a commit invalidates it by construction rather
   than by explicit eviction, so it cannot serve a superseded row.

### Why this is safe

`filter_pushdown` already answers `Exact` for exactly the filters this change stops re-deriving,
which is the provider telling DataFusion it applies them in full and DataFusion must not re-check
them. `EntityPrimaryKeyFilterAnalyzer::analyze` returns `Some` only when `into_entity_pks` binds
every primary-key component — for an `AND` it requires *both* sides to be identity constraints, so a
partially-routable expression (`path = 'x' AND value > 5`) keeps its residual row filter. Predicates
that only bind part of a composite key, or that are not identity-shaped at all, are untouched.
`HotStateFilter::entity_pks` is a real row-level predicate in the generic path too
(`hot_state/visibility.rs:1291`), so the `plan_delete` path that shares `plan_scan_parts` is equally
covered.

## What regressed

Nothing outside the measured noise floor. The largest adverse median in the whole run is
`smoke/read_all_rows_consumed/1k` at +1.9%, in a cold-fixture lane whose own null-equivalent spread
is the same size, and the lane that looked worst on 2 reps collapsed to +1.4% with overlapping ranges
at 5. The write path is −1.5% (neutral). No metric regressed by more than ~5%, and no bytes-on-disk
or version-control metric can move.

## Reproduction

```bash
# both arms, warm session, per-operation medians
TMPDIR=$HOME/claude5/e7-scratch \
LIX_TRACKED_STATE_CRUD_PROFILE=1 \
LIX_TRACKED_STATE_CRUD_PROFILE_LAYER=sql_session \
LIX_TRACKED_STATE_CRUD_PROFILE_OP=read_one \
LIX_TRACKED_STATE_CRUD_PROFILE_STORAGE=rocksdb \
LIX_TRACKED_STATE_CRUD_PROFILE_ROW_COUNT=10000 \
LIX_TRACKED_STATE_CRUD_PROFILE_HOT_REPEATS=5000 \
  <target>/release/deps/tracked_state_crud-<hash> --bench

# criterion guard
<bin> --bench 'sql_session/lix_rocksdb/.*/read_' --sample-size 10 --warm-up-time 1 --measurement-time 3
```

Interleaving/rotation scripts on the host: `~/claude5/e7-ab.sh`, `~/claude5/e7-ab2.sh`,
`~/claude5/e7-crit.sh`, `~/claude5/e7-crit2.sh`.

## Gate

Run on `ryzen-9950x-III` against `ci.yml` from `origin/main`, `--no-fail-fast`, full log captured and
grepped (never tailed), plus the features-OFF pair that `--all-features` structurally cannot catch:

```
cargo check --workspace --all-targets --all-features
cargo clippy --profile test --workspace --all-targets --all-features -- -D warnings
cargo test --profile test --workspace --exclude lix_benchmarks --all-features --no-fail-fast
cargo test --profile test -p lix_benchmarks --features storage-benches,slatedb,root-replay-trace --no-fail-fast
cargo check -p lix --no-default-features
cargo check -p lix_js_sdk --target wasm32-unknown-unknown
```

**Result: green.** `cargo check --workspace --all-targets --all-features` clean;
`cargo clippy … -- -D warnings` **0 warnings**; both `cargo check` feature-variant commands clean;
`cargo test` **3496 passed / 0 failed** across **65** test targets (baseline to beat: 3470 / 0 / 0).

### One test was retargeted, and why the old assertion was incidental

`sql2::exec::datafusion::tests::datafusion_entity_primary_key_read_uses_registered_provider` asserted
`scans == 1` and `requests.is_empty()` — i.e. that a point read by primary key goes through the
**generic** visibility scan and never touches the registered `EntitySnapshotReader`. It is the only
test in `datafusion.rs` that wires a non-`None` `entity_snapshot_reader`, and it was written to assert
the reader is not called.

That was a record of the mis-gating, not a contract. `scan_direct_entity_snapshots` builds an
`EntityPointSnapshotCacheKey` for exactly the `([entity_pk], None | Some(1..))` shape — a fast path
whose only purpose is to serve a point read by primary key. A route that exists solely for this query
shape, wired into every entity surface by `CurrentEntitySnapshotReader::new`, cannot also be
contractually forbidden from serving it. The test's actual public-behaviour assertions — the returned
columns and rows — are **unchanged and still pass**; only the two routing assertions were flipped to
the intended direction (`scans == 0`, one recorded request carrying the two deduplicated identities
and no residual constraint).

### Pre-existing flake observed (not caused by this PR)

The first full gate run on this branch also failed
`tracked_state::context::tests::availability_proof_is_bounded_on_commit_and_total_on_repair`
(`packages/lix/src/tracked_state/context.rs:8674`, "bounded probe" returned 2 plans, expected 1).
That test lives in the commit-root-rebuild layer, which this diff does not touch.

Per the runbook I reproduced it on both arms rather than calling it flaky: running
`cargo test --profile test -p lix --lib --all-features` repeatedly, it failed **1 time in 23 runs on
the unmodified `base` worktree at `f3c37056`** and passed in every other run on both arms. It is a
pre-existing intermittent failure on the integration head, at roughly a 4% rate, and it is worth its
own investigation.

No versioned identifier (space name, encoding version) was changed, so no repo-wide literal grep was
required.
