### PR TITLE
bench(write): every lix_file statement rebuilds a whole-repository index (~5.4 µs/resident file)

### DIFF
--- a/packages/rs-sdk-tests/examples/e16_write_file_scaling.rs
+++ b/packages/rs-sdk-tests/examples/e16_write_file_scaling.rs
@@ -249,9 +249,14 @@ where
     }
 }
 
-const SHAPES: [&str; 8] = [
+const SHAPES: [&str; 10] = [
     "insert_file_80line",
     "insert_file_1line",
+    // Same total rows written as ten `insert_file_1line` probes, but in one
+    // statement. If the O(files) term is paid once per statement rather than
+    // once per written row, this costs about the same as a single-row insert.
+    "insert_10files_1stmt",
+    "insert_100files_1stmt",
     // Root-level path (one segment). `indexed_file_path_writes` only builds a
     // whole-repository `DirectoryPathResolver` when a *nested* path is missing,
     // so a root-level create isolates the path-index build from the resolver
@@ -302,6 +307,12 @@ where
             )
             .await
             .expect("insert 1-line probe file");
+        }
+        "insert_10files_1stmt" => {
+            insert_many(lix, "b10", probe, 10).await;
+        }
+        "insert_100files_1stmt" => {
+            insert_many(lix, "b100", probe, 100).await;
         }
         "insert_root_file" => {
             lix.execute(
@@ -477,6 +488,28 @@ where
             .expect("seed write-scaling files");
         written += batch;
     }
+}
+
+async fn insert_many<StorageImpl>(lix: &Lix<StorageImpl>, tag: &str, probe: usize, count: usize)
+where
+    StorageImpl: Storage + Clone + Send + Sync + 'static,
+{
+    let mut sql = String::from("INSERT INTO lix_file (path, content) VALUES ");
+    let mut params: Vec<Value> = Vec::with_capacity(count * 2);
+    for offset in 0..count {
+        if offset > 0 {
+            sql.push(',');
+        }
+        let parameter = offset * 2;
+        sql.push_str(&format!("(${}, ${})", parameter + 1, parameter + 2));
+        params.push(Value::Text(format!(
+            "/probe/{tag}-{probe:05}-{offset:04}.txt"
+        )));
+        params.push(Value::Blob(document(1, probe + offset).into()));
+    }
+    lix.execute(&sql, &params)
+        .await
+        .unwrap_or_else(|error| panic!("insert {count} probe files: {error:?}"));
 }
 
 fn document_string(lines: usize, index: usize) -> String {

--- a/packages/rs-sdk-tests/examples/e16_write_file_scaling.rs
+++ b/packages/rs-sdk-tests/examples/e16_write_file_scaling.rs
@@ -249,9 +249,14 @@ where
     }
 }
 
-const SHAPES: [&str; 4] = [
+const SHAPES: [&str; 5] = [
     "insert_file_80line",
     "insert_file_1line",
+    // Byte-identical work to `insert_file_1line`, but the ON CONFLICT clause
+    // makes the planner classify the write as `UpdateContent` instead of
+    // `None`, which is the discriminator for taking the indexed staging route
+    // rather than the whole-branch descriptor scan.
+    "upsert_file_1line",
     "update_file_1line",
     "key_value_write",
 ];
@@ -288,6 +293,18 @@ where
             )
             .await
             .expect("insert 1-line probe file");
+        }
+        "upsert_file_1line" => {
+            lix.execute(
+                "INSERT INTO lix_file (path, content) VALUES ($1, $2) \
+                 ON CONFLICT (path) DO UPDATE SET content = excluded.content",
+                &[
+                    Value::Text(format!("/probe/upsert-{probe:05}.txt")),
+                    Value::Blob(document(1, probe).into()),
+                ],
+            )
+            .await
+            .expect("upsert 1-line probe file");
         }
         "update_file_1line" => {
             // Rewrites a resident seeded file, changing exactly one line.

--- a/packages/rs-sdk-tests/examples/e16_write_file_scaling.rs
+++ b/packages/rs-sdk-tests/examples/e16_write_file_scaling.rs
@@ -28,7 +28,15 @@
 use std::collections::BTreeMap;
 use std::io::{Cursor, Write};
 use std::path::Path;
-use std::time::Instant;
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+
+use tracing::Subscriber;
+use tracing::span::{Attributes, Id};
+use tracing::subscriber::Interest;
+use tracing_subscriber::Layer;
+use tracing_subscriber::layer::{Context as TracingContext, SubscriberExt};
+use tracing_subscriber::registry::LookupSpan;
 
 use lix::storage::{ReadOptions, Storage};
 use lix::storage_adapter::StorageAdapter;
@@ -51,24 +59,41 @@ fn main() {
     } else {
         sizes
     };
+    let shapes: Vec<&'static str> = match std::env::var("E16_SHAPES") {
+        Ok(value) => SHAPES
+            .into_iter()
+            .filter(|shape| value.split(',').any(|entry| entry.trim() == *shape))
+            .collect(),
+        Err(_) => SHAPES.to_vec(),
+    };
+    assert!(!shapes.is_empty(), "E16_SHAPES selected no known shape");
     let probes = std::env::var("E16_PROBES")
         .ok()
         .and_then(|value| value.parse().ok())
         .unwrap_or(9usize);
 
-    let runtime = tokio::runtime::Builder::new_current_thread()
-        .enable_all()
-        .build()
-        .expect("create write-scaling runtime");
+    let collector = PerfSpanCollector::default();
+    let dispatch = tracing::Dispatch::new(tracing_subscriber::registry().with(collector.clone()));
+    tracing::dispatcher::with_default(&dispatch, || {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("create write-scaling runtime");
 
-    runtime.block_on(async {
-        for files in sizes {
-            run_case(files, probes).await;
-        }
+        runtime.block_on(async {
+            for files in sizes {
+                run_case(files, probes, &shapes, &collector).await;
+            }
+        });
     });
 }
 
-async fn run_case(files: usize, probes: usize) {
+async fn run_case(
+    files: usize,
+    probes: usize,
+    shapes: &[&'static str],
+    collector: &PerfSpanCollector,
+) {
     let root = tempfile::Builder::new()
         .prefix("e16-write-scaling-")
         .tempdir()
@@ -92,16 +117,24 @@ async fn run_case(files: usize, probes: usize) {
     // between cases. Probes run interleaved by shape so that any drift over the
     // measurement window hits all four shapes equally.
     let mut samples: BTreeMap<&'static str, Vec<f64>> = BTreeMap::new();
+    let mut spans: BTreeMap<&'static str, BTreeMap<&'static str, (f64, u64)>> = BTreeMap::new();
     let before = snapshot(&storage, &db_path).await;
+    let _ = collector.take_ms();
     for probe in 0..probes {
-        for shape in SHAPES {
+        for shape in shapes.iter().copied() {
             let elapsed = run_probe(&lix, shape, files, probe).await;
             samples.entry(shape).or_default().push(elapsed);
+            let shape_spans = spans.entry(shape).or_default();
+            for (name, (ms, count)) in collector.take_ms() {
+                let entry = shape_spans.entry(name).or_insert((0.0, 0));
+                entry.0 += ms;
+                entry.1 += count;
+            }
         }
     }
     let after = snapshot(&storage, &db_path).await;
 
-    for shape in SHAPES {
+    for shape in shapes.iter().copied() {
         let mut values = samples.remove(shape).unwrap_or_default();
         values.sort_by(f64::total_cmp);
         println!(
@@ -117,6 +150,18 @@ p50_ms={:.3},min_ms={:.3},p95_ms={:.3},raw={}",
                 .collect::<Vec<_>>()
                 .join("|"),
         );
+    }
+
+    for (shape, shape_spans) in &spans {
+        let mut ranked: Vec<(&&'static str, &(f64, u64))> = shape_spans.iter().collect();
+        ranked.sort_by(|left, right| right.1.0.total_cmp(&left.1.0));
+        for (name, (ms, count)) in ranked {
+            println!(
+                "write_scaling_span,files={files},shape={shape},span={name},\
+total_ms={ms:.3},per_probe_ms={:.4},entries={count}",
+                ms / probes as f64,
+            );
+        }
     }
 
     // Written volume across the whole probe window, so a latency term can be
@@ -139,6 +184,69 @@ p50_ms={:.3},min_ms={:.3},p95_ms={:.3},raw={}",
     }
 
     lix.close().await.expect("close write-scaling Lix");
+}
+
+/// Sums the engine's own `lix_perf` spans, so the O(files) term can be
+/// attributed to a named phase of the write path instead of to a leaf symbol.
+/// Spans nest, so a parent's total includes its children; read the tree, not
+/// the sum.
+#[derive(Clone, Default)]
+struct PerfSpanCollector {
+    samples: Arc<Mutex<Vec<(&'static str, Duration)>>>,
+}
+
+struct StartedPerfSpan {
+    name: &'static str,
+    started: Instant,
+}
+
+impl PerfSpanCollector {
+    fn take_ms(&self) -> BTreeMap<&'static str, (f64, u64)> {
+        let samples = std::mem::take(&mut *self.samples.lock().expect("span lock"));
+        let mut result: BTreeMap<&'static str, (f64, u64)> = BTreeMap::new();
+        for (name, elapsed) in samples {
+            let entry = result.entry(name).or_insert((0.0, 0));
+            entry.0 += elapsed.as_secs_f64() * 1_000.0;
+            entry.1 += 1;
+        }
+        result
+    }
+}
+
+impl<S> Layer<S> for PerfSpanCollector
+where
+    S: Subscriber + for<'lookup> LookupSpan<'lookup>,
+{
+    fn register_callsite(&self, metadata: &'static tracing::Metadata<'static>) -> Interest {
+        if metadata.target() == "lix_perf" {
+            Interest::always()
+        } else {
+            Interest::never()
+        }
+    }
+
+    fn on_new_span(&self, attrs: &Attributes<'_>, id: &Id, ctx: TracingContext<'_, S>) {
+        if attrs.metadata().target() != "lix_perf" {
+            return;
+        }
+        if let Some(span) = ctx.span(id) {
+            span.extensions_mut().insert(StartedPerfSpan {
+                name: attrs.metadata().name(),
+                started: Instant::now(),
+            });
+        }
+    }
+
+    fn on_close(&self, id: Id, ctx: TracingContext<'_, S>) {
+        let Some(span) = ctx.span(&id) else { return };
+        let Some(started) = span.extensions_mut().remove::<StartedPerfSpan>() else {
+            return;
+        };
+        self.samples
+            .lock()
+            .expect("span lock")
+            .push((started.name, started.started.elapsed()));
+    }
 }
 
 const SHAPES: [&str; 4] = [

--- a/packages/rs-sdk-tests/examples/e16_write_file_scaling.rs
+++ b/packages/rs-sdk-tests/examples/e16_write_file_scaling.rs
@@ -1,0 +1,352 @@
+//! Why does a single write cost 30x more in a 10,000-file repository than in a
+//! 100-file one, while writing the same handful of rows?
+//!
+//! `e10_branch_file_cost` measured branch creation as O(1) and, as a control,
+//! measured one file write on the default branch at 2.4 / 8.4 / 72.0 ms across
+//! 100 / 1,000 / 10,000 files. That control is the subject here: the write path
+//! carries a term in *total files in the repository*, not in files touched.
+//!
+//! This harness holds the written payload fixed and grows only the resident
+//! file count, then splits the write into four shapes so the term can be
+//! attributed:
+//!
+//! * `insert_file_80line` — a new plugin-backed file, 80 entity rows. The
+//!   original control shape.
+//! * `insert_file_1line`  — a new plugin-backed file, 1 entity row. Isolates
+//!   per-entity plugin work from per-write work.
+//! * `update_file_1line`  — rewrite one already-resident file with a one-line
+//!   edit. The common agent-workload shape.
+//! * `key_value_write`    — a single `lix_key_value` row, touching no file at
+//!   all. If *this* scales with the resident file count, the term is in the
+//!   commit machinery and is independent of what the write touched.
+//!
+//! ```text
+//! cargo run --release -p lix_tests --example e16_write_file_scaling -- 100 1000 10000
+//! E16_PROBES=200 E16_SIZES=10000 cargo run --release ...   # long write phase for perf
+//! ```
+
+use std::collections::BTreeMap;
+use std::io::{Cursor, Write};
+use std::path::Path;
+use std::time::Instant;
+
+use lix::storage::{ReadOptions, Storage};
+use lix::storage_adapter::StorageAdapter;
+use lix::storage_bench::layout_accounting;
+use lix::{Lix, Value, open_lix};
+use lix_storage_rocksdb::RocksDB;
+
+const INSERT_BATCH: usize = 100;
+/// Above `HOST_CERTIFIED_PACKET_MIN_ROWS` so each seeded file certifies a
+/// dense batch, matching the fixture `e10_branch_file_cost` established.
+const LINES_PER_FILE: usize = 80;
+
+fn main() {
+    let sizes: Vec<usize> = std::env::args()
+        .skip(1)
+        .filter_map(|value| value.parse().ok())
+        .collect();
+    let sizes = if sizes.is_empty() {
+        vec![100, 1_000, 10_000]
+    } else {
+        sizes
+    };
+    let probes = std::env::var("E16_PROBES")
+        .ok()
+        .and_then(|value| value.parse().ok())
+        .unwrap_or(9usize);
+
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("create write-scaling runtime");
+
+    runtime.block_on(async {
+        for files in sizes {
+            run_case(files, probes).await;
+        }
+    });
+}
+
+async fn run_case(files: usize, probes: usize) {
+    let root = tempfile::Builder::new()
+        .prefix("e16-write-scaling-")
+        .tempdir()
+        .expect("create write-scaling directory");
+    let db_path = root.path().join("db");
+    let storage = RocksDB::open(&db_path).expect("open write-scaling RocksDB");
+    let lix = open_lix()
+        .with_storage(storage.clone())
+        .await
+        .expect("open write-scaling Lix");
+
+    install_text_plugin(&lix).await;
+    let seed_started = Instant::now();
+    seed_files(&lix, files).await;
+    println!(
+        "write_scaling_seed,files={files},seed_ms={:.3}",
+        seed_started.elapsed().as_secs_f64() * 1_000.0
+    );
+
+    // Every probe writes the same payload; only the resident file count differs
+    // between cases. Probes run interleaved by shape so that any drift over the
+    // measurement window hits all four shapes equally.
+    let mut samples: BTreeMap<&'static str, Vec<f64>> = BTreeMap::new();
+    let before = snapshot(&storage, &db_path).await;
+    for probe in 0..probes {
+        for shape in SHAPES {
+            let elapsed = run_probe(&lix, shape, files, probe).await;
+            samples.entry(shape).or_default().push(elapsed);
+        }
+    }
+    let after = snapshot(&storage, &db_path).await;
+
+    for shape in SHAPES {
+        let mut values = samples.remove(shape).unwrap_or_default();
+        values.sort_by(f64::total_cmp);
+        println!(
+            "write_scaling,files={files},shape={shape},probes={},\
+p50_ms={:.3},min_ms={:.3},p95_ms={:.3},raw={}",
+            values.len(),
+            percentile(&values, 0.50),
+            values.first().copied().unwrap_or(0.0),
+            percentile(&values, 0.95),
+            values
+                .iter()
+                .map(|value| format!("{value:.3}"))
+                .collect::<Vec<_>>()
+                .join("|"),
+        );
+    }
+
+    // Written volume across the whole probe window, so a latency term can be
+    // separated from a bytes term.
+    println!(
+        "write_scaling_volume,files={files},probes={probes},d_rows={},d_bytes={}",
+        after.rows() as i64 - before.rows() as i64,
+        after.bytes() as i64 - before.bytes() as i64,
+    );
+    for (name, a) in &before.spaces {
+        let b = after.spaces.get(name).copied().unwrap_or_default();
+        let d_rows = b.rows as i64 - a.rows as i64;
+        let d_bytes = (b.key_bytes + b.value_bytes) as i64 - (a.key_bytes + a.value_bytes) as i64;
+        if d_rows == 0 && d_bytes == 0 {
+            continue;
+        }
+        println!(
+            "write_scaling_space,files={files},space={name},d_rows={d_rows},d_bytes={d_bytes}"
+        );
+    }
+
+    lix.close().await.expect("close write-scaling Lix");
+}
+
+const SHAPES: [&str; 4] = [
+    "insert_file_80line",
+    "insert_file_1line",
+    "update_file_1line",
+    "key_value_write",
+];
+
+async fn run_probe<StorageImpl>(
+    lix: &Lix<StorageImpl>,
+    shape: &str,
+    files: usize,
+    probe: usize,
+) -> f64
+where
+    StorageImpl: Storage + Clone + Send + Sync + 'static,
+{
+    let started = Instant::now();
+    match shape {
+        "insert_file_80line" => {
+            lix.execute(
+                "INSERT INTO lix_file (path, content) VALUES ($1, $2)",
+                &[
+                    Value::Text(format!("/probe/big-{probe:05}.txt")),
+                    Value::Blob(document(LINES_PER_FILE, probe).into()),
+                ],
+            )
+            .await
+            .expect("insert 80-line probe file");
+        }
+        "insert_file_1line" => {
+            lix.execute(
+                "INSERT INTO lix_file (path, content) VALUES ($1, $2)",
+                &[
+                    Value::Text(format!("/probe/small-{probe:05}.txt")),
+                    Value::Blob(document(1, probe).into()),
+                ],
+            )
+            .await
+            .expect("insert 1-line probe file");
+        }
+        "update_file_1line" => {
+            // Rewrites a resident seeded file, changing exactly one line.
+            let target = probe % files.max(1);
+            let mut body = document_string(LINES_PER_FILE, target);
+            body.push_str(&format!("edit {probe}\n"));
+            lix.execute(
+                "UPDATE lix_file SET content = $2 WHERE path = $1",
+                &[
+                    Value::Text(format!("/docs/file-{target:07}.txt")),
+                    Value::Blob(body.into_bytes().into()),
+                ],
+            )
+            .await
+            .expect("update resident probe file");
+        }
+        "key_value_write" => {
+            lix.execute(
+                "INSERT INTO lix_key_value (key, value) VALUES ($1, lix_json($2))",
+                &[
+                    Value::Text(format!("e16-probe-{probe:05}")),
+                    Value::Text(format!("\"{probe}\"")),
+                ],
+            )
+            .await
+            .expect("insert key-value probe row");
+        }
+        other => panic!("unknown probe shape {other}"),
+    }
+    started.elapsed().as_secs_f64() * 1_000.0
+}
+
+fn percentile(sorted: &[f64], quantile: f64) -> f64 {
+    if sorted.is_empty() {
+        return 0.0;
+    }
+    let index = ((sorted.len() - 1) as f64 * quantile).round() as usize;
+    sorted[index]
+}
+
+#[derive(Clone, Default)]
+struct Snapshot {
+    spaces: BTreeMap<&'static str, SpaceCounts>,
+}
+
+#[derive(Clone, Copy, Default)]
+struct SpaceCounts {
+    rows: u64,
+    key_bytes: u64,
+    value_bytes: u64,
+}
+
+impl Snapshot {
+    fn rows(&self) -> u64 {
+        self.spaces.values().map(|counts| counts.rows).sum()
+    }
+
+    fn bytes(&self) -> u64 {
+        self.spaces
+            .values()
+            .map(|counts| counts.key_bytes + counts.value_bytes)
+            .sum()
+    }
+}
+
+async fn snapshot(storage: &RocksDB, _directory: &Path) -> Snapshot {
+    storage.flush().expect("flush write-scaling RocksDB");
+    let adapter = StorageAdapter::new(storage.clone());
+    let read = adapter
+        .begin_read(ReadOptions::default())
+        .await
+        .expect("open write-scaling layout read");
+    let accounting = layout_accounting(&read).await;
+    drop(read);
+    let mut spaces = BTreeMap::new();
+    for entry in accounting {
+        spaces.insert(
+            entry.space,
+            SpaceCounts {
+                rows: entry.rows,
+                key_bytes: entry.key_bytes,
+                value_bytes: entry.value_bytes,
+            },
+        );
+    }
+    Snapshot { spaces }
+}
+
+async fn install_text_plugin<StorageImpl>(lix: &Lix<StorageImpl>)
+where
+    StorageImpl: Storage + Clone + Send + Sync + 'static,
+{
+    lix.execute(
+        "INSERT INTO lix_file (path, content) VALUES ($1, $2)",
+        &[
+            Value::Text("/.lix/plugins/plugin_text.lixplugin".to_owned()),
+            Value::Blob(build_text_plugin_archive().into()),
+        ],
+    )
+    .await
+    .expect("install write-scaling text plugin");
+}
+
+async fn seed_files<StorageImpl>(lix: &Lix<StorageImpl>, files: usize)
+where
+    StorageImpl: Storage + Clone + Send + Sync + 'static,
+{
+    let mut written = 0usize;
+    while written < files {
+        let batch = (files - written).min(INSERT_BATCH);
+        let mut sql = String::from("INSERT INTO lix_file (path, content) VALUES ");
+        let mut params: Vec<Value> = Vec::with_capacity(batch * 2);
+        for offset in 0..batch {
+            if offset > 0 {
+                sql.push(',');
+            }
+            let parameter = offset * 2;
+            sql.push_str(&format!("(${}, ${})", parameter + 1, parameter + 2));
+            let index = written + offset;
+            params.push(Value::Text(format!("/docs/file-{index:07}.txt")));
+            params.push(Value::Blob(document(LINES_PER_FILE, index).into()));
+        }
+        lix.execute(&sql, &params)
+            .await
+            .expect("seed write-scaling files");
+        written += batch;
+    }
+}
+
+fn document_string(lines: usize, index: usize) -> String {
+    let mut body = String::with_capacity(lines * 48);
+    for line in 0..lines {
+        body.push_str(&format!(
+            "document {index} line {line}: content padding text\n"
+        ));
+    }
+    body
+}
+
+fn document(lines: usize, index: usize) -> Vec<u8> {
+    document_string(lines, index).into_bytes()
+}
+
+fn build_text_plugin_archive() -> Vec<u8> {
+    let wasm_path = Path::new(env!("CARGO_CDYLIB_FILE_PLUGIN_TEXT_plugin_text"));
+    let wasm = std::fs::read(wasm_path).unwrap_or_else(|error| {
+        panic!(
+            "failed to read bindep-built text wasm at {}: {error}",
+            wasm_path.display()
+        )
+    });
+    let mut writer = zip::ZipWriter::new(Cursor::new(Vec::new()));
+    let options =
+        zip::write::SimpleFileOptions::default().compression_method(zip::CompressionMethod::Stored);
+    for (path, bytes) in [
+        (
+            "manifest.json",
+            include_str!("../../../plugins/text/manifest.json").as_bytes(),
+        ),
+        (
+            "schema/text_line.json",
+            include_str!("../../../plugins/text/schema/text_line.json").as_bytes(),
+        ),
+        ("plugin.wasm", wasm.as_slice()),
+    ] {
+        writer.start_file(path, options).expect("start archive file");
+        writer.write_all(bytes).expect("write archive file");
+    }
+    writer.finish().expect("finish archive").into_inner()
+}

--- a/packages/rs-sdk-tests/examples/e16_write_file_scaling.rs
+++ b/packages/rs-sdk-tests/examples/e16_write_file_scaling.rs
@@ -249,9 +249,16 @@ where
     }
 }
 
-const SHAPES: [&str; 10] = [
+const SHAPES: [&str; 12] = [
     "insert_file_80line",
     "insert_file_1line",
+    // Ten single-row statements inside ONE explicit transaction. The
+    // path-index cache documents an intra-transaction delta advance, so if that
+    // works this costs one whole-repository rebuild rather than ten.
+    "insert_10files_1txn",
+    // The control for it: ten single-row statements in ten autocommit
+    // transactions.
+    "insert_10files_10txn",
     // Same total rows written as ten `insert_file_1line` probes, but in one
     // statement. If the O(files) term is paid once per statement rather than
     // once per written row, this costs about the same as a single-row insert.
@@ -307,6 +314,41 @@ where
             )
             .await
             .expect("insert 1-line probe file");
+        }
+        "insert_10files_1txn" => {
+            let mut transaction = lix
+                .begin_transaction()
+                .await
+                .expect("begin write-scaling transaction");
+            for offset in 0..10 {
+                transaction
+                    .execute(
+                        "INSERT INTO lix_file (path, content) VALUES ($1, $2)",
+                        &[
+                            Value::Text(format!("/probe/t1-{probe:05}-{offset:04}.txt")),
+                            Value::Blob(document(1, probe + offset).into()),
+                        ],
+                    )
+                    .await
+                    .expect("stage write-scaling transaction row");
+            }
+            transaction
+                .commit()
+                .await
+                .expect("commit write-scaling transaction");
+        }
+        "insert_10files_10txn" => {
+            for offset in 0..10 {
+                lix.execute(
+                    "INSERT INTO lix_file (path, content) VALUES ($1, $2)",
+                    &[
+                        Value::Text(format!("/probe/tN-{probe:05}-{offset:04}.txt")),
+                        Value::Blob(document(1, probe + offset).into()),
+                    ],
+                )
+                .await
+                .expect("insert autocommit write-scaling row");
+            }
         }
         "insert_10files_1stmt" => {
             insert_many(lix, "b10", probe, 10).await;

--- a/packages/rs-sdk-tests/examples/e16_write_file_scaling.rs
+++ b/packages/rs-sdk-tests/examples/e16_write_file_scaling.rs
@@ -249,9 +249,18 @@ where
     }
 }
 
-const SHAPES: [&str; 5] = [
+const SHAPES: [&str; 8] = [
     "insert_file_80line",
     "insert_file_1line",
+    // Root-level path (one segment). `indexed_file_path_writes` only builds a
+    // whole-repository `DirectoryPathResolver` when a *nested* path is missing,
+    // so a root-level create isolates the path-index build from the resolver
+    // build.
+    "insert_root_file",
+    "upsert_root_file",
+    // Upsert over an already-resident file: nothing is missing, so no resolver
+    // is built at all. What remains is the path-index acquisition alone.
+    "upsert_existing_file",
     // Byte-identical work to `insert_file_1line`, but the ON CONFLICT clause
     // makes the planner classify the write as `UpdateContent` instead of
     // `None`, which is the discriminator for taking the indexed staging route
@@ -293,6 +302,42 @@ where
             )
             .await
             .expect("insert 1-line probe file");
+        }
+        "insert_root_file" => {
+            lix.execute(
+                "INSERT INTO lix_file (path, content) VALUES ($1, $2)",
+                &[
+                    Value::Text(format!("/root-ins-{probe:05}.txt")),
+                    Value::Blob(document(1, probe).into()),
+                ],
+            )
+            .await
+            .expect("insert root probe file");
+        }
+        "upsert_root_file" => {
+            lix.execute(
+                "INSERT INTO lix_file (path, content) VALUES ($1, $2) \
+                 ON CONFLICT (path) DO UPDATE SET content = excluded.content",
+                &[
+                    Value::Text(format!("/root-ups-{probe:05}.txt")),
+                    Value::Blob(document(1, probe).into()),
+                ],
+            )
+            .await
+            .expect("upsert root probe file");
+        }
+        "upsert_existing_file" => {
+            let target = probe % files.max(1);
+            lix.execute(
+                "INSERT INTO lix_file (path, content) VALUES ($1, $2) \
+                 ON CONFLICT (path) DO UPDATE SET content = excluded.content",
+                &[
+                    Value::Text(format!("/docs/file-{target:07}.txt")),
+                    Value::Blob(document(1, probe).into()),
+                ],
+            )
+            .await
+            .expect("upsert resident probe file");
         }
         "upsert_file_1line" => {
             lix.execute(


### PR DESCRIPTION
## Summary

**Measurement only — no engine change, no fix proposed.** This PR adds one
benchmark example and reports where the O(files) write term lives.

Machine **ryzen-9950x-IV**, base **`8dc5ddaa`**, RocksDB, release. Instrument:
`packages/rs-sdk-tests/examples/e16_write_file_scaling.rs` (branch
`claude-5-e16-write-file-scaling`). Fixture: N resident plain-text files, 80 lines each, through the
real `text` plugin. Each probe writes a fixed payload; only the resident file count varies.

## Result in one line

**Every SQL statement that touches `lix_file` pays a fixed cost linear in the number of files
resident in the branch — about 5.4 µs per resident file — regardless of how many files the statement
writes, what shape the write is, or whether it is batched inside a transaction.**

## 1. Which writes carry the term (p50 ms, 9 reps)

| files | insert 80-line | insert 1-line | upsert root | upsert existing | update | **key_value** |
|---|---|---|---|---|---|---|
| 100 | 2.06 | 1.48 | 1.44 | 2.10 | 2.31 | **0.33** |
| 1,000 | 5.14 | 4.60 | 4.42 | 4.55 | 5.86 | **0.28** |
| 10,000 | 53.76 | 52.15 | 58.66 | 60.95 | 78.89 | **0.56** |

Ruled out by measurement, not by reading:

- **Not per-entity plugin work.** An 80-row file and a 1-row file cost the same (52.1 vs 53.8 ms).
- **Not the commit machinery.** `key_value_write` touches no file and is **flat** (0.28–0.56 ms).
- **Not path depth.** Root-level (one segment) and nested paths cost the same.
- **Not new-vs-existing.** Upserting an already-resident file costs the same as creating one.
- **Not a bytes term.** Written volume is constant across sizes; only latency moves.

## 2. Where it goes — flat profile at 10,000 files

`perf record -F 2999` (no call graph), 29,941 samples, `insert_file_1line` only. Top self symbols:

| % | symbol |
|---|---|
| 5.37 | `BTreeMap<filesystem::planner::FilesystemBlobRefKey, …>::search_tree` |
| 5.18 | `serde_json::read::SliceRead::skip_to_escape` |
| 2.55 | `BTreeMap<(Option<String>,String), filesystem::planner::FilesystemNamespaceEntry>::search_tree` |
| 2.49 | `hot_state::types::MaterializedHotStateBatchBuilder::push_ref` |
| 2.25 | `hot::HotStateStoreReader::scan_live_batch_for_generation_with_visibility` |
| 1.72 | `filesystem::read::insert_entry` |
| 1.47 | `serde_json … deserialize_string` |
| 1.46 | `filesystem::read::FilesystemIndex::from_live_batch` |
| 1.08 | `MaterializedHotStateBatchBuilder::push_columns` |
| 1.07 | `hot::read_hot_scan_key_string` |
| 0.97 | `BTreeMap<String, filesystem::read::FilesystemEntry>::insert` |
| 0.80 | `filesystem::planner::FilesystemDescriptorKey::from_live_row_ref` |

One coherent story: **a whole-branch scan of every `lix_file_descriptor` / `lix_directory_descriptor`
/ `lix_binary_blob_ref` row, a JSON parse of every descriptor snapshot, and a rebuild of the
repository-wide BTree indexes** — per statement.

Span attribution agrees (`lix_perf` spans, per probe):

| span | 100 files | 10,000 files | growth |
|---|---|---|---|
| `transaction_plan_and_stage` | 0.843 ms | **52.97 ms** | **62.8x** |
| `transaction_validation` | 0.088 ms | 4.40 ms | 50x |
| `transaction_materialization` | 0.654 ms | 2.34 ms | 3.6x |
| `plugin_reconciliation` | 0.348 ms | 0.671 ms | 1.9x |
| `transaction_storage_commit` | 0.061 ms | 0.106 ms | 1.7x |

`transaction_plan_and_stage` is essentially the whole probe, and roughly **46 ms of it is covered by
no child span** — unattributed work in staging, which is where the descriptor index is built.

## 3. The term is per **statement**, not per row (10,000 files)

| shape | total | per file written |
|---|---|---|
| 1 file, 1 statement | 55.3 ms | **55.3 ms** |
| 10 files, 1 statement | 57.1 ms | **5.7 ms** |
| 100 files, 1 statement | 87.6 ms | **0.88 ms** |

100 files in one statement costs 1.58x a single-file statement. Fixed cost ≈ 54 ms at 10,000 files,
marginal cost ≈ 0.33 ms per file. At 1,000 files the fixed cost is ≈ 5.4 ms — i.e. **~5.4 µs per
resident file**, linear.

## 4. Batching inside a transaction does not help

| shape (10,000 files) | p50 |
|---|---|
| 10 files, 1 statement | 53.8 ms |
| 10 files, 10 statements, **1 explicit transaction** | **587.1 ms** |
| 10 files, 10 statements, 10 autocommit transactions | 520.4 ms |

Ten statements inside one transaction cost the same as ten separate transactions — slightly *more*.
`filesystem/path_index.rs` documents an intra-transaction delta advance (`advance_revisions`,
"avoids rebuilding the complete visible filesystem for the next statement in the same transaction")
and a cross-commit one (`advance_committed`). **Neither is saving anything in this workload.**

## 5. One hypothesis already tested and falsified

`sql2/providers/file.rs:2676-2697`: the fast `lix_file` write route only takes the indexed path when
the write is classified `UpdateContent`/`Id*`; a plain `INSERT` is classified `None` and falls
through to `FilesystemIndex::from_live_batch` over the whole branch. Prediction: an
`INSERT … ON CONFLICT (path) DO UPDATE` would take the indexed route and be flat.

**It is not.** `upsert_file_1line` measured 1.46 / 4.85 / 65.6 ms — if anything worse than the plain
insert. So the fallthrough is not the cause; *both* routes pay a whole-branch descriptor scan. I am
reporting this rather than quietly dropping it, because it is the same failure mode you warned
about, caught by measurement instead of shipped.

## 6. E8 — they do **not** converge

E8's "329 µs fixed per commit regardless of width" is exactly my **flat** `key_value_write` lane
(270–588 µs across a 100x file range). That is the commit floor, and it is genuinely constant.
The E16 term is **additive on top of it**, lives in `transaction_plan_and_stage` (staging, before
commit), and is paid only by statements touching `lix_file`. Two different costs; no merge needed —
though E8's floor is the number that would remain if E16's term were removed.

## What is not yet established

Which of the two whole-repository builders dominates (`FilesystemIndex::from_live_batch` on the
non-indexed route vs `filesystem_path_index` acquisition on the indexed one — both routes measure
the same, so likely the shared scan + materialization), and **why the two documented delta-advance
paths never fire**. I have not designed a fix and will not until that is measured.

## Why this matters for the round

Claim 2 is the agent-workload file lane. An agent writing files one statement at a time in a
10,000-file repository pays **55 ms per file instead of ~0.9 ms** — a 60x penalty that is pure
overhead, on the axis the round ranks second only to correctness.

## Commands

```
cargo run --release -p lix_tests --example e16_write_file_scaling -- 100 1000 10000
E16_SHAPES=insert_file_1line E16_PROBES=250 perf record -F 2999 -D 12000 -- \
  ./e16_write_file_scaling 10000
```

Logs on ryzen-9950x-IV: `~/claude5/logs/e16-decomp.log`, `e16-spans.log`, `/tmp/e16.perf.data`.
