### PR TITLE
perf(hot_state): carry the schema-key set in the certified manifest value

### DIFF
--- a/packages/lix/src/hot_state/tracked_head/hot.rs
+++ b/packages/lix/src/hot_state/tracked_head/hot.rs
@@ -140,9 +140,18 @@ pub(crate) const CERTIFIED_ENTITY_BATCH_SPACE: StorageSpace = StorageSpace::decl
     "hot_state.certified_entity_batch.v1",
     ValueSemantics::Mutable,
 );
+/// Maps one branch generation to the certified batches published under it.
+///
+/// The value carries the batch's schema-key set ahead of the content key, so a
+/// schema-filtered scan can decide from the manifest alone whether a batch can
+/// contribute rows. Without it the only way to learn a batch's schemas was to
+/// fetch and parse its content header, which made every schema-filtered scan
+/// read every batch on the branch.
+///
+/// `.v2` because the value layout changed; `.v1` bytes must not parse.
 pub(crate) const CERTIFIED_ENTITY_BATCH_MANIFEST_SPACE: StorageSpace = StorageSpace::declare(
     StorageSpaceId(0x0004_0021),
-    "hot_state.certified_entity_batch_manifest.v1",
+    "hot_state.certified_entity_batch_manifest.v2",
     ValueSemantics::Mutable,
 );
 pub(crate) const CERTIFIED_ENTITY_BATCH_PAGE_SPACE: StorageSpace = StorageSpace::declare(
@@ -783,12 +792,81 @@ pub(crate) async fn stage_certified_entity_batches(
                 CERTIFIED_ENTITY_BATCH_MANIFEST_SPACE,
                 StorageKey(Bytes::from(manifest_key)),
                 StorageValue {
-                    bytes: Bytes::from(content_key),
+                    bytes: Bytes::from(encode_certified_manifest_value(
+                        &batch.schema_keys,
+                        &content_key,
+                    )?),
                 },
             );
         }
     }
     Ok(())
+}
+
+/// Encodes one certified manifest value: the batch's schema-key set, then the
+/// content key it points at.
+///
+/// The schema set is a covering column over the batch header's own list, not a
+/// second authority: both are written from `batch.schema_keys` in the same
+/// write set, and inheritance copies the whole value, so the two cannot drift.
+fn encode_certified_manifest_value(
+    schema_keys: &[String],
+    content_key: &[u8],
+) -> Result<Vec<u8>, LixError> {
+    let schema_bytes = schema_keys
+        .iter()
+        .try_fold(2usize, |total, schema| total.checked_add(2 + schema.len()))
+        .ok_or_else(|| head_value_error("certified manifest schema list size overflowed"))?;
+    let mut value = Vec::with_capacity(schema_bytes + content_key.len());
+    value.extend_from_slice(
+        &u16::try_from(schema_keys.len())
+            .map_err(|_| head_value_error("certified manifest has too many schemas"))?
+            .to_le_bytes(),
+    );
+    for schema_key in schema_keys {
+        append_batch_text(&mut value, schema_key)?;
+    }
+    value.extend_from_slice(content_key);
+    Ok(value)
+}
+
+/// Returns where the content key starts, or `None` when this manifest's schema
+/// set cannot satisfy `wanted` and the batch therefore need not be fetched.
+///
+/// A manifest with no declared schemas is never pruned: an empty set means the
+/// batch declared nothing, not that it matches nothing.
+fn certified_manifest_content_offset(
+    value: &[u8],
+    wanted: Option<&HashSet<String>>,
+) -> Result<Option<usize>, LixError> {
+    let count_bytes = value
+        .get(..2)
+        .ok_or_else(|| head_value_error("certified manifest value is truncated"))?;
+    let count = u16::from_le_bytes([count_bytes[0], count_bytes[1]]) as usize;
+    let mut offset = 2usize;
+    let mut matched = wanted.is_none() || count == 0;
+    for _ in 0..count {
+        let length_bytes = value
+            .get(offset..offset + 2)
+            .ok_or_else(|| head_value_error("certified manifest schema length is truncated"))?;
+        let length = u16::from_le_bytes([length_bytes[0], length_bytes[1]]) as usize;
+        offset += 2;
+        let schema_bytes = value
+            .get(offset..offset + length)
+            .ok_or_else(|| head_value_error("certified manifest schema key is truncated"))?;
+        offset += length;
+        if let Some(wanted) = wanted
+            && !matched
+        {
+            let schema_key = std::str::from_utf8(schema_bytes)
+                .map_err(|_| head_value_error("certified manifest schema key is not utf-8"))?;
+            matched = wanted.contains(schema_key);
+        }
+    }
+    if offset > value.len() {
+        return Err(head_value_error("certified manifest content key is truncated"));
+    }
+    Ok(matched.then_some(offset))
 }
 
 fn append_batch_text(output: &mut Vec<u8>, value: &str) -> Result<(), LixError> {
@@ -1092,10 +1170,24 @@ async fn scan_certified_entity_batch_rows(
         }
         return Ok(MaterializedHotStateBatch::default());
     }
-    let content_keys = manifest_entries
-        .into_iter()
-        .map(|entry| full_value_bytes(entry.value).map(StorageKey))
-        .collect::<Result<Vec<_>, _>>()?;
+    let filter_index = CertifiedScanFilterIndex::new(request);
+    // Prune from the manifest alone. The manifest value carries the batch's
+    // schema-key set, so a batch that cannot match the requested schemas is
+    // never fetched; previously the only way to learn its schemas was to read
+    // and parse the content header, so every batch on the branch was fetched.
+    let mut content_keys = Vec::with_capacity(manifest_entries.len());
+    for entry in manifest_entries {
+        let value = full_value_bytes(entry.value)?;
+        let Some(offset) =
+            certified_manifest_content_offset(&value, filter_index.schema_keys.as_ref())?
+        else {
+            continue;
+        };
+        content_keys.push(StorageKey(value.slice(offset..)));
+    }
+    if content_keys.is_empty() {
+        return Ok(MaterializedHotStateBatch::default());
+    }
     let contents = PointReadPlan::new(CERTIFIED_ENTITY_BATCH_SPACE, &content_keys)
         .materialize(store, StorageGetOptions::default())
         .await?
@@ -1107,7 +1199,6 @@ async fn scan_certified_entity_batch_rows(
             .columns
             .iter()
             .any(|column| column == "snapshot_content");
-    let filter_index = CertifiedScanFilterIndex::new(request);
     let mut decode_inputs = Vec::with_capacity(content_keys.len());
     let mut page_routes = Vec::new();
     let mut page_keys = Vec::new();
@@ -13894,7 +13985,10 @@ mod tests {
             CERTIFIED_ENTITY_BATCH_MANIFEST_SPACE,
             StorageKey(Bytes::from(manifest_key)),
             StorageValue {
-                bytes: malformed_content_key.0.clone(),
+                bytes: Bytes::from(
+                    encode_certified_manifest_value(&[], &malformed_content_key.0)
+                        .expect("manifest value should encode"),
+                ),
             },
         );
         writes.put(
@@ -13975,7 +14069,10 @@ mod tests {
             CERTIFIED_ENTITY_BATCH_MANIFEST_SPACE,
             StorageKey(Bytes::from(manifest_key)),
             StorageValue {
-                bytes: malformed_content_key.0.clone(),
+                bytes: Bytes::from(
+                    encode_certified_manifest_value(&[], &malformed_content_key.0)
+                        .expect("manifest value should encode"),
+                ),
             },
         );
         writes.put(
@@ -14375,6 +14472,130 @@ mod tests {
                 return total;
             }
         }
+    }
+
+    /// A schema-filtered scan must not fetch a batch whose manifest already
+    /// says it cannot match.
+    ///
+    /// The non-matching file's content batch is deliberately malformed. Before
+    /// the manifest carried the schema set, the scan had to fetch and parse
+    /// every content header to learn its schemas, so it would reach these bytes
+    /// and fail. Passing proves the batch was never fetched.
+    #[tokio::test]
+    async fn schema_filtered_certified_scan_skips_non_matching_batches() {
+        const BRANCH_ID: &str = "01920000-0000-7000-8000-0000000001a4";
+        const WANTED_FILE: &str = "wanted.csv";
+        const WANTED_SCHEMA: &str = "wanted_schema";
+        const OTHER_FILE: &str = "other.csv";
+        const OTHER_SCHEMA: &str = "other_schema";
+
+        let storage = StorageAdapter::new(Memory::new());
+        let head_commit_id = CommitId::for_test_label("schema-prune-head");
+        let generation = CommitId::for_test_label("schema-prune-generation");
+        let created_at = timestamp();
+        let control = BranchHeadControl {
+            head_commit_id,
+            tracked_generation: generation,
+            current_state_revision: 0,
+            schema_presence_bloom: [u64::MAX; 4],
+            working_diff_checkpoint_commit_id: None,
+            created_at,
+            updated_at: created_at,
+            ref_change_id: ChangeId::for_test_label("schema-prune-ref"),
+        };
+
+        let wanted = [certified_batch_for_schema(WANTED_SCHEMA, 0)];
+        let files = [CertifiedEntityBatchFileRef {
+            branch_id: BRANCH_ID,
+            file_id: WANTED_FILE,
+            batches: &wanted,
+        }];
+
+        let read = storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("schema prune seed read should open");
+        let mut writes = StorageWriteSet::new();
+        stage_branch_head_control(&mut writes, BRANCH_ID, control)
+            .expect("schema prune control should stage");
+        stage_certified_entity_batches(
+            &read,
+            &mut writes,
+            &files,
+            &BTreeMap::from([(BRANCH_ID.to_owned(), control)]),
+            &BTreeMap::from([(
+                BRANCH_ID.to_owned(),
+                crate::branch::BranchHeadControlObservation {
+                    control: Some(control),
+                    raw_token: None,
+                },
+            )]),
+            &BTreeMap::from([(head_commit_id, created_at)]),
+            &BTreeSet::new(),
+        )
+        .await
+        .expect("schema prune batch should stage");
+
+        // A second file whose manifest declares only OTHER_SCHEMA, pointing at
+        // content that cannot be parsed.
+        let poison_content_key = StorageKey(Bytes::from_static(b"schema-prune-poison"));
+        let mut manifest_key = generation.as_uuid().as_bytes().to_vec();
+        append_batch_text(&mut manifest_key, OTHER_FILE).unwrap();
+        manifest_key.extend_from_slice(&1_u32.to_le_bytes());
+        manifest_key.extend_from_slice(head_commit_id.as_uuid().as_bytes());
+        writes.put(
+            CERTIFIED_ENTITY_BATCH_MANIFEST_SPACE,
+            StorageKey(Bytes::from(manifest_key)),
+            StorageValue {
+                bytes: Bytes::from(
+                    encode_certified_manifest_value(
+                        &[OTHER_SCHEMA.to_owned()],
+                        &poison_content_key.0,
+                    )
+                    .expect("poison manifest should encode"),
+                ),
+            },
+        );
+        writes.put(
+            CERTIFIED_ENTITY_BATCH_SPACE,
+            poison_content_key,
+            StorageValue {
+                bytes: Bytes::from_static(b"malformed"),
+            },
+        );
+        drop(read);
+        storage
+            .commit_write_set(writes, StorageWriteOptions::default())
+            .await
+            .expect("schema prune fixture should commit");
+
+        let read = storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("schema prune verification read should open");
+        let rows = scan_certified_entity_batch_rows(
+            &read,
+            BRANCH_ID,
+            generation,
+            &TrackedStateScanRequest {
+                filter: TrackedStateFilter {
+                    schema_keys: vec![WANTED_SCHEMA.to_owned()],
+                    ..TrackedStateFilter::default()
+                },
+                read_columns: TrackedStateReadColumns {
+                    columns: vec!["snapshot_content".to_owned()],
+                },
+                limit: None,
+            },
+            None,
+            None,
+        )
+        .await
+        .expect("a manifest that cannot match must never be fetched or decoded");
+
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows.row(0).file_id(), Some(WANTED_FILE));
+        assert_eq!(rows.row(0).schema_key(), WANTED_SCHEMA);
     }
 
     /// Pins why a `LIMIT` cannot be pushed into the certified manifest scan.


### PR DESCRIPTION
# perf(hot_state): carry the schema-key set in the certified manifest value

A schema-filtered certified scan fetched **every** content batch on the branch just to discover that
most of them declare schemas it does not want. Schema membership lived only in the batch header, so
learning it required the fetch the check was supposed to avoid.

This moves the batch's schema-key set into the manifest value, where the scan already is. Batches
that cannot match are now never fetched.

## Physical change

Manifest value, before: the content key.

Manifest value, now:

```
u16 schema_count || (u16 len || schema_key)* || content_key
```

The space is bumped `hot_state.certified_entity_batch_manifest.v1` → **`.v2`**: the value layout
changed, so old bytes must not parse. Hard cut, no fallback reader. `rg` over the whole repo for the
old literal finds exactly one occurrence — the constant itself. Nothing pins or reconstructs this
space name, so there is no second fixture to update. `SpaceId(0x0004_0021)` is unchanged.

Read path: `scan_certified_entity_batch_rows` now builds the filter index *before* touching content,
decodes each manifest value, and skips any batch whose declared schema set is disjoint from the
requested one. The `PointReadPlan` over `CERTIFIED_ENTITY_BATCH_SPACE` then covers only surviving
manifests.

## Result — batches fetched (deterministic, 1 rep)

Measured on **ryzen-9950x-I**, in-memory backend, one file per batch, **one file in ten** carrying the
requested schema. Fetch counts are exact, not sampled — a counting read wrapper summing keys
requested against `CERTIFIED_ENTITY_BATCH_SPACE`.

| files on branch | manifests read | batches fetched — before | batches fetched — now | rows returned |
|---|---|---|---|---|
| 100 | 100 | 100 | **10** | 10 |
| 1,000 | 1,000 | 1,000 | **100** | 100 |
| 10,000 | 10,000 | 10,000 | **1,000** | 1,000 |

**Exactly N → matching-N**, a 10x reduction at this selectivity and a 1/selectivity reduction in
general. The "before" column is not an estimate: the previous code mapped every manifest entry to a
content key and materialized all of them unconditionally, which is the code this PR replaces.

Manifests read is unchanged at N — this PR does not touch the manifest scan itself, which #1371
established cannot terminate early for structural reasons. What changes is the far more expensive
half: the content batch fetch and header parse behind each manifest.

## Cost — manifest value growth (deterministic, 1 rep)

| files | manifest value bytes | of which content key | schema-set overhead |
|---|---|---|---|
| 100 | 5,210 | 3,600 | 1,610 |
| 1,000 | 52,100 | 36,000 | 16,100 |
| 10,000 | 521,000 | 360,000 | 161,000 |

Per manifest: **36 bytes → 52.1 bytes, +16.1 bytes (+44.7%)** for this fixture, whose batches carry
one schema key each with 12–13 character names. Overhead is exactly `2 + Σ(2 + len(schema_key))`.

**The trade depends on how many schemas a batch holds, and it should be stated rather than assumed.**
For the common case — a plugin file whose rows are one schema — the set is one short string and the
cost is ~16 bytes against one avoided batch fetch plus header parse, which is not close. A batch
holding many schemas pays proportionally more and prunes less often, because a larger set is more
likely to intersect the filter. The degenerate case is a batch declaring every schema on the branch:
it can never be pruned and pays full overhead. Nothing in the layout prevents that; it is simply a
bad batch, and it costs bytes rather than correctness.

At 10,000 files the manifest space grows 360 KB → 521 KB. Physical bytes on disk is the **lowest**
priority in this round's ordering, below OLTP, and the thing bought is a 10x cut in read
amplification on a hot read path.

## Correctness — this is the "returns fewer rows than exist" class, so it is guarded

A pruning decision made from the wrong metadata drops rows silently. That is exactly the bug class
#1367 was about, so the safety argument is structural rather than hopeful:

- The manifest's schema set and the batch header's list are written from the same
  `batch.schema_keys`, in the same function, into the same write set. There is no path that writes
  one without the other.
- Manifest inheritance on a generation change copies the whole value verbatim, so the schema set
  travels with the content key it describes and cannot be re-derived incorrectly.
- The header remains the authority for what a batch actually contains. The manifest copy is only ever
  used to *skip* work, never to produce row data.
- **Fail-open on an empty set.** A manifest declaring zero schemas is never pruned — an empty set
  means "declared nothing", not "matches nothing".

New test `schema_filtered_certified_scan_skips_non_matching_batches` uses the file's existing
malformed-content idiom: the non-matching file's content batch is deliberately unparseable, so the
scan can only pass if it never fetched it. Before this change the scan had to parse every header and
would fail on those bytes.

The certified plane's regression suite stays green:

```
test ...::schema_filtered_certified_scan_skips_non_matching_batches ... ok
test ...::certified_limit_cannot_stop_at_the_first_manifest ... ok        (#1371)
test ...::certified_scan_returns_every_file_past_one_scan_page ... ok     (#1367)
test ...::branch_creation_inherits_every_certified_manifest_past_one_scan_page ... ok  (#1367)
test ...::exact_file_certified_scan_does_not_read_unrelated_manifest ... ok
test ...::exact_hot_hit_skips_matching_certified_fallback ... ok
test result: ok. 6 passed; 0 failed
```

## Layout invariants

1. **Single authority — no new authority.** The schema set is a covering column over a fact the batch
   header already states, not a second writer of it. Both come from one source in one write set;
   inheritance copies the value whole. The header stays authoritative and the copy is used only to
   skip work. This is the one invariant this PR could plausibly have violated, which is why the
   drift argument above is structural and why the fail-open default exists.
2. **Commit canonicality — unaffected.** No commit record, parent link, or state root touched.
3. **Derived views are caches — held.** The manifest was already a derived index over certified
   batches; it gains a column and stays derived.
4. **Atomic publication — held.** Manifest and batch publish in the same write set, as before.
5. **GC from refs — unaffected.** No retention metadata; the manifest still points at exactly one
   content key.
6. **SQL reads canonical records — held.** The scan still reads canonical batches; it just stops
   reading ones it can prove cannot match.

## Gate

Full CI-scope gate on **ryzen-9950x-I**, branch based on integration head `cb257285`:

| command | result |
|---|---|
| `cargo check --workspace --all-targets --all-features` | clean |
| `cargo clippy --workspace --all-targets --all-features -- -D warnings` | clean |
| `cargo check -p lix --no-default-features` | clean |
| `cargo check -p lix_js_sdk --target wasm32-unknown-unknown` | clean |
| workspace tests `--no-fail-fast` | **3477 passed / 0 failed** |
| `lix_benchmarks` tests `--no-fail-fast` | **26 passed / 0 failed** |

Zero `error` and zero `warning` lines. 3477 = `cb257285`'s 3476 plus this PR's one new test. Log
captured to a file and grepped for `failures:`, `panicked at`, `test result: FAILED`, `^error`.
