### PR TITLE
perf(binary-cas): scan the chunk plane key-only during reclamation

### DIFF
--- a/packages/engine-benchmarks/Cargo.toml
+++ b/packages/engine-benchmarks/Cargo.toml
@@ -116,6 +116,11 @@ path = "examples/cas_sharing.rs"
 required-features = ["storage-benches", "slatedb"]
 
 [[example]]
+name = "e3_cas_reclaim_scan"
+path = "examples/e3_cas_reclaim_scan.rs"
+required-features = ["storage-benches", "slatedb"]
+
+[[example]]
 name = "cas_gc_qualification"
 path = "examples/cas_gc_qualification.rs"
 required-features = ["storage-benches", "slatedb"]

--- a/packages/engine-benchmarks/examples/e3_cas_reclaim_scan.rs
+++ b/packages/engine-benchmarks/examples/e3_cas_reclaim_scan.rs
@@ -1,0 +1,243 @@
+//! Measures what one binary-CAS reclamation sweep costs an object store as a
+//! function of the number of rows in the chunk plane.
+//!
+//! The chunk plane is `ValueSemantics::Immutable`, so on SlateDB its values do
+//! not live in the LSM at all: the LSM holds a locator and the payload lives in
+//! an object-store segment. A reclamation scan that projects `FullValue`
+//! therefore pays an object-store round trip per scan page, and the page is
+//! hydrated *before* the caller can decide a row is live — so the cost is paid
+//! for every chunk in the repository, not only for the reclaimed ones.
+//!
+//! Setup runs against the unwrapped local object store and the store is closed
+//! and reopened before the measured sweep, so an optional latency profile is
+//! charged to the sweep only. Request counts are deterministic; wall clock at a
+//! given profile is what those counts cost over a link.
+//!
+//! ```text
+//! e3_cas_reclaim_scan <dir> <file_count> <file_kib> <local|regional|wide-area|rtt:mbps> <keep|orphan>
+//! ```
+
+use std::ops::Bound;
+use std::path::Path;
+use std::sync::Arc;
+use std::time::Instant;
+
+use lix::Value;
+use lix::integration::Engine;
+use lix::storage::{
+    BeginScanOptions, CoreProjection, KeyRange, MAX_SCAN_PAGE_ROWS, ReadOptions, Storage,
+    StorageRead,
+};
+use lix::storage_adapter::StorageAdapter;
+use lix::storage_bench::collect_repository_gc_for_bench;
+use lix_storage_slatedb::{SlateDB, SlateDBIoCounters, SlateDBObjectStoreOptions};
+
+#[path = "support/remote_object_store.rs"]
+mod remote_object_store;
+
+use remote_object_store::{RemoteObjectStore, RemoteProfile};
+
+const MANIFEST_SPACE: lix::storage::SpaceId = lix::storage::SpaceId(0x0005_0001);
+const MANIFEST_CHUNK_SPACE: lix::storage::SpaceId = lix::storage::SpaceId(0x0005_0002);
+const PAYLOAD_SPACE: lix::storage::SpaceId = lix::storage::SpaceId(0x0005_0003);
+const PRESENCE_SPACE: lix::storage::SpaceId = lix::storage::SpaceId(0x0005_0004);
+
+fn open(dir: &Path, profile: Option<RemoteProfile>, counters: &SlateDBIoCounters) -> SlateDB {
+    std::fs::create_dir_all(dir).expect("create reclaim scan directory");
+    let local = object_store::local::LocalFileSystem::new_with_prefix(dir)
+        .expect("open reclaim scan local object store");
+    let store: Arc<dyn object_store::ObjectStore> = match profile {
+        None => Arc::new(local),
+        Some(profile) => Arc::new(RemoteObjectStore::new(Arc::new(local), profile)),
+    };
+    SlateDB::open_object_store_with_options_and_io_counters(
+        "db",
+        store,
+        SlateDBObjectStoreOptions::default(),
+        counters.clone(),
+    )
+    .expect("open reclaim scan SlateDB")
+}
+
+fn main() {
+    let args = std::env::args().collect::<Vec<_>>();
+    let dir = args
+        .get(1)
+        .map(String::as_str)
+        .unwrap_or("/tmp/lix-e3-cas-reclaim-scan");
+    let file_count = args
+        .get(2)
+        .map(|value| value.parse::<usize>().expect("file count"))
+        .unwrap_or(100);
+    let file_kib = args
+        .get(3)
+        .map(|value| value.parse::<usize>().expect("file KiB"))
+        .unwrap_or(16);
+    let profile = args
+        .get(4)
+        .map_or_else(RemoteProfile::from_env, |value| RemoteProfile::parse(value));
+    let orphan = args.get(5).map(String::as_str).unwrap_or("orphan") == "orphan";
+
+    let runtime = tokio::runtime::Builder::new_multi_thread()
+        .worker_threads(4)
+        .enable_all()
+        .build()
+        .expect("create reclaim scan runtime");
+
+    runtime.block_on(async move {
+        let dir = Path::new(dir);
+        let _ = std::fs::remove_dir_all(dir);
+
+        // Phase 1: build the fixture over the unwrapped local store so setup
+        // never pays the profile under test.
+        let setup_counters = SlateDBIoCounters::default();
+        let storage = open(dir, None, &setup_counters);
+        let initialized = Engine::initialize(storage.clone())
+            .await
+            .expect("initialize reclaim scan repository");
+        let engine = Engine::new(storage.clone())
+            .await
+            .expect("open reclaim scan repository");
+        let session = engine
+            .open_session(initialized.main_branch_id)
+            .await
+            .expect("open reclaim scan session");
+        let setup_started = Instant::now();
+        for index in 0..file_count {
+            session
+                .upsert_file_content(
+                    format!("/e3/payload-{index:07}.bin"),
+                    distinct_payload(index as u64, file_kib * 1024).into(),
+                )
+                .await
+                .expect("write reclaim scan payload");
+        }
+        if orphan {
+            session
+                .execute(
+                    "DELETE FROM lix_file WHERE path LIKE $1",
+                    &[Value::Text("/e3/%".to_owned())],
+                )
+                .await
+                .expect("delete reclaim scan payloads");
+            session
+                .create_checkpoint()
+                .await
+                .expect("checkpoint reclaim scan deletion");
+        }
+        let setup_ms = setup_started.elapsed().as_millis();
+        let before = cas_stats(&storage).await;
+        drop(session);
+        drop(engine);
+        storage.flush().await.expect("flush reclaim scan setup");
+        drop(storage);
+
+        // Phase 2: reopen, optionally behind the latency profile, and measure
+        // exactly one reclamation sweep.
+        let counters = SlateDBIoCounters::default();
+        let storage = open(dir, profile, &counters);
+        let adapter = StorageAdapter::new(storage.clone());
+        let opened = counters.snapshot();
+        let started = Instant::now();
+        let sweep = collect_repository_gc_for_bench(&adapter)
+            .await
+            .expect("reclaim scan GC should commit");
+        let sweep_ms = started.elapsed().as_millis();
+        let io = counters.snapshot().saturating_sub(opened);
+        drop(adapter);
+        let after = cas_stats(&storage).await;
+        storage.flush().await.expect("flush reclaim scan sweep");
+        drop(storage);
+
+        println!(
+            "e3_cas_reclaim_scan,files={file_count},file_kib={file_kib},orphan={orphan},\
+profile={},setup_ms={setup_ms},sweep_ms={sweep_ms},\
+chunk_rows_before={},chunk_rows_after={},presence_rows_before={},manifest_rows_before={},\
+reclaimed_chunk_rows={},reclaimed_manifest_rows={},staged_deletes={},plan_us={},commit_us={},\
+read_objects={},read_bytes={},write_objects={},write_bytes={},list_operations={},\
+immutable_locator_rows={}",
+            profile.map_or_else(|| "local".to_owned(), |profile| profile.label()),
+            before[2].rows,
+            after[2].rows,
+            before[3].rows,
+            before[0].rows,
+            sweep.reclaimed_chunk_rows,
+            sweep.reclaimed_manifest_rows,
+            sweep.staged_deletes,
+            sweep.plan_us,
+            sweep.commit_us,
+            io.read_objects,
+            io.read_bytes,
+            io.write_objects,
+            io.write_bytes,
+            io.list_operations,
+            io.immutable_locator_rows,
+        );
+        let _ = std::fs::remove_dir_all(dir);
+    });
+}
+
+fn distinct_payload(seed: u64, len: usize) -> Vec<u8> {
+    let mut output = vec![0_u8; len];
+    for (block, bytes) in output.chunks_mut(32).enumerate() {
+        let mut hasher = blake3::Hasher::new();
+        hasher.update(b"lix e3 cas reclaim scan payload v1");
+        hasher.update(&seed.to_le_bytes());
+        hasher.update(&(block as u64).to_le_bytes());
+        let digest = hasher.finalize();
+        let count = bytes.len();
+        bytes.copy_from_slice(&digest.as_bytes()[..count]);
+    }
+    output
+}
+
+#[derive(Clone, Copy, Debug)]
+struct SpaceStats {
+    rows: u64,
+}
+
+async fn cas_stats<S: Storage>(storage: &S) -> [SpaceStats; 4] {
+    [
+        space_stats(storage, MANIFEST_SPACE).await,
+        space_stats(storage, MANIFEST_CHUNK_SPACE).await,
+        space_stats(storage, PAYLOAD_SPACE).await,
+        space_stats(storage, PRESENCE_SPACE).await,
+    ]
+}
+
+async fn space_stats<S: Storage>(storage: &S, space_id: lix::storage::SpaceId) -> SpaceStats {
+    let space = lix::storage_bench::storage_space_by_id(space_id.0);
+    let read = storage
+        .begin_read(ReadOptions::default())
+        .await
+        .expect("open reclaim scan stats read");
+    let mut rows = 0;
+    let mut cursor = read
+        .begin_scan(
+            space,
+            KeyRange {
+                lower: Bound::Unbounded,
+                upper: Bound::Unbounded,
+            },
+            BeginScanOptions {
+                // Key-only: counting rows must not hydrate immutable segments,
+                // or the instrument would cost what it measures.
+                projection: CoreProjection::KeyOnly,
+                ..BeginScanOptions::default()
+            },
+        )
+        .await
+        .expect("begin reclaim scan stats scan");
+    loop {
+        let (entries, has_more) = cursor
+            .next_page(MAX_SCAN_PAGE_ROWS)
+            .await
+            .expect("scan reclaim scan stats")
+            .into_parts();
+        rows += entries.len() as u64;
+        if !has_more {
+            break;
+        }
+    }
+    SpaceStats { rows }
+}

--- a/packages/lix/src/binary_cas/kv.rs
+++ b/packages/lix/src/binary_cas/kv.rs
@@ -38,8 +38,13 @@ const MANIFEST_SCAN_CONCURRENCY: usize = 8;
 const MAX_DELTA_SEGMENTS: usize = 32;
 const MAX_DELTA_INSERT_BYTES: usize = 64 * 1024;
 const MAX_DELTA_INSERT_FRACTION_DIVISOR: usize = 8;
-const CAS_RECLAIM_MANIFEST_PAGE_ROWS: usize = 256;
-const CAS_RECLAIM_CHUNK_PAGE_ROWS: usize = 1;
+// Every reclamation scan is bounded by rows because every reclamation scan now
+// carries bounded per-row payloads: three of the four planes are scanned
+// key-only (32- or 40-byte keys), and the manifest plane's values are a fixed
+// header. The chunk plane deliberately does *not* project its value: chunk
+// payloads are 256 KiB-4 MiB, so a row-bounded window over them would be
+// unbounded in bytes, which is why this used to be paged one row at a time.
+const CAS_RECLAIM_PAGE_ROWS: usize = 256;
 
 pub(crate) const BINARY_CAS_MANIFEST_NAMESPACE: &str = "binary_cas.manifest";
 pub(crate) const BINARY_CAS_MANIFEST_CHUNK_NAMESPACE: &str = "binary_cas.manifest_chunk";
@@ -165,11 +170,11 @@ pub(crate) struct KvBlobManifestChunk {
 /// Stages deletion of binary-CAS rows not reachable from authenticated blob
 /// roots and active upload receipts.
 ///
-/// This is intentionally an explicit maintenance operation. It scans in
-/// single-row payload windows, retains only hashes and bounded manifest
-/// metadata in memory, and never reconstructs a full blob. Any malformed live
-/// manifest or missing live chunk fails closed before the caller can commit
-/// the write set.
+/// This is intentionally an explicit maintenance operation. Reachability is
+/// decided entirely from keys and bounded manifest metadata, so no scan here
+/// projects a chunk payload and no blob is ever reconstructed. Any malformed
+/// live manifest or missing live chunk fails closed before the caller can
+/// commit the write set.
 pub(in crate::binary_cas) async fn stage_reclaim_unreachable_binary_cas(
     store: &(impl StorageAdapterRead + ?Sized),
     writes: &mut StorageWriteSet,
@@ -226,7 +231,7 @@ pub(in crate::binary_cas) async fn stage_reclaim_unreachable_binary_cas(
         .await?;
     loop {
         let (page, page_has_more) = manifest_cursor
-            .next_page(CAS_RECLAIM_MANIFEST_PAGE_ROWS)
+            .next_page(CAS_RECLAIM_PAGE_ROWS)
             .await?.into_parts();
         for entry in page {
             let blob_id = BlobId::from_bytes(entry.key.0.as_ref().try_into().map_err(|_| {
@@ -272,7 +277,7 @@ pub(in crate::binary_cas) async fn stage_reclaim_unreachable_binary_cas(
         .await?;
     loop {
         let (page, page_has_more) = manifest_chunk_cursor
-            .next_page(CAS_RECLAIM_MANIFEST_PAGE_ROWS)
+            .next_page(CAS_RECLAIM_PAGE_ROWS)
             .await?.into_parts();
         for entry in page {
             let (blob_id, offset) = decode_manifest_chunk_key(&entry.key)?;
@@ -289,6 +294,13 @@ pub(in crate::binary_cas) async fn stage_reclaim_unreachable_binary_cas(
         }
     }
 
+    // Orphan selection is a key-set difference, so this scan must never
+    // project chunk payloads. On SlateDB the chunk plane is
+    // `ValueSemantics::Immutable`: its values live in object-store segments and
+    // a full-value page pays one segment fetch round trip. The page is
+    // hydrated before this loop can decide a row is live, so that round trip
+    // was charged for every chunk in the repository, not only the reclaimed
+    // ones. Key-only keeps the whole plane inside the LSM index.
     let mut chunk_cursor = store
         .begin_scan(
             BINARY_CAS_CHUNK_SPACE,
@@ -297,13 +309,15 @@ pub(in crate::binary_cas) async fn stage_reclaim_unreachable_binary_cas(
                 upper: Bound::Unbounded,
             },
             StorageBeginScanOptions {
-                projection: StorageCoreProjection::FullValue,
+                projection: StorageCoreProjection::KeyOnly,
                 ..StorageBeginScanOptions::default()
             },
         )
         .await?;
     loop {
-        let (page, page_has_more) = chunk_cursor.next_page(CAS_RECLAIM_CHUNK_PAGE_ROWS).await?.into_parts();
+        let (page, page_has_more) = chunk_cursor
+            .next_page(CAS_RECLAIM_PAGE_ROWS)
+            .await?.into_parts();
         for entry in page {
             let chunk_hash =
                 ChunkHash::from_bytes(entry.key.0.as_ref().try_into().map_err(|_| {
@@ -315,29 +329,8 @@ pub(in crate::binary_cas) async fn stage_reclaim_unreachable_binary_cas(
             if live_chunks.contains_key(&chunk_hash) {
                 continue;
             }
-            let StorageProjectedValue::FullValue(bytes) = entry.value else {
-                return Err(LixError::new(
-                    LixError::CODE_STORAGE_ERROR,
-                    "binary CAS chunk scan omitted its value",
-                ));
-            };
-            let byte_count = u64::try_from(bytes.len()).map_err(|_| {
-                LixError::new(
-                    LixError::CODE_INTERNAL_ERROR,
-                    "binary CAS orphan chunk size exceeds u64",
-                )
-            })?;
-            writes.delete(BINARY_CAS_CHUNK_SPACE, entry.key.clone());
+            writes.delete(BINARY_CAS_CHUNK_SPACE, entry.key);
             result.reclaimed_chunk_rows += 1;
-            result.reclaimed_chunk_bytes = result
-                .reclaimed_chunk_bytes
-                .checked_add(byte_count)
-                .ok_or_else(|| {
-                    LixError::new(
-                        LixError::CODE_INTERNAL_ERROR,
-                        "binary CAS reclaimed byte count overflowed",
-                    )
-                })?;
         }
         if !page_has_more {
             break;
@@ -359,7 +352,7 @@ pub(in crate::binary_cas) async fn stage_reclaim_unreachable_binary_cas(
         .await?;
     loop {
         let (page, page_has_more) = presence_cursor
-            .next_page(CAS_RECLAIM_MANIFEST_PAGE_ROWS)
+            .next_page(CAS_RECLAIM_PAGE_ROWS)
             .await?.into_parts();
         for entry in page {
             let chunk_hash =

--- a/packages/lix/src/binary_cas/mod.rs
+++ b/packages/lix/src/binary_cas/mod.rs
@@ -39,7 +39,6 @@ pub(crate) struct BinaryCasGcSweep {
     pub(crate) reclaimed_manifest_rows: usize,
     pub(crate) reclaimed_manifest_chunk_rows: usize,
     pub(crate) reclaimed_chunk_rows: usize,
-    pub(crate) reclaimed_chunk_bytes: u64,
 }
 
 /// Stages the owner's authenticated binary-CAS reclamation operation.

--- a/packages/lix/src/storage_bench.rs
+++ b/packages/lix/src/storage_bench.rs
@@ -1741,7 +1741,6 @@ pub struct RepositoryGcCommitBenchResult {
     pub reclaimed_manifest_rows: usize,
     pub reclaimed_manifest_chunk_rows: usize,
     pub reclaimed_chunk_rows: usize,
-    pub reclaimed_chunk_bytes: u64,
     pub plan_us: u64,
     pub commit_us: u64,
 }
@@ -1800,7 +1799,6 @@ where
                     reclaimed_manifest_rows: binary_cas.reclaimed_manifest_rows,
                     reclaimed_manifest_chunk_rows: binary_cas.reclaimed_manifest_chunk_rows,
                     reclaimed_chunk_rows: binary_cas.reclaimed_chunk_rows,
-                    reclaimed_chunk_bytes: binary_cas.reclaimed_chunk_bytes,
                     plan_us,
                     commit_us: commit_started.elapsed().as_micros() as u64,
                 });


### PR DESCRIPTION
## Summary

Binary-CAS reclamation scanned the chunk plane with a **full-value projection** it never
needed. On SlateDB that plane is `ValueSemantics::Immutable`, so its values live in
object-store segments rather than the LSM — one full-value scan page costs one object-store
round trip, and the page is hydrated *before* the caller can decide a row is live. The scan
was paged **one row at a time**, so a reclamation sweep spent **one object-store GET per
chunk in the repository**, live or orphan, on every GC pass.

Scanning key-only removes that GET entirely: **exactly one object-store request per chunk
eliminated, flat while chunk count grew 100x**, sweep read bytes down **89.7-92.3%**, and
sweep wall clock **-31.7%** at a 15 ms regional profile / **-27.1%** at 80 ms wide-area.

## Root cause — the constant was correct; the projection was the defect

This is the part worth reading, because the obvious diagnosis is wrong.

`CAS_RECLAIM_CHUNK_PAGE_ROWS = 1` sat next to `CAS_RECLAIM_MANIFEST_PAGE_ROWS = 256` and
looked like an oversight. It was not. Chunk payloads are 256 KiB-4 MiB
(`binary_cas/chunking.rs`: FastCDC min 256 KiB / avg 1 MiB / max 4 MiB), so with a full-value
projection a 256-row page really would have put **up to a gigabyte in flight**. Given the
code as written, `1` was the only safe value, and the doc comment said so
(*"scans in single-row payload windows"*). Raising it would have been a memory bug.

The defect was one level up: **`stage_reclaim_unreachable_binary_cas` never needed the
value.** Orphan selection is a key-set difference — it hashes the scanned key and asks
whether that hash is in `live_chunks`. The only consumer of the projected bytes was
`bytes.len()`, summed into `BinaryCasGcSweep::reclaimed_chunk_bytes` — **a field no caller in
the workspace reads.** It is plumbed into `storage_bench::RepositoryGcCommitBenchResult` and
dead-ends there; `rg` finds zero consumers.

So a dead statistic forced a full-value projection, the projection forced a one-row page, and
the one-row page forced one object-store round trip per chunk.

### Storage adapter API: offered, and not needed

The round directive offered a byte-bounded scan primitive on `StorageAdapter` if paging by
rows was the wrong knob. It was the wrong knob **only while the page carried 256 KiB-4 MiB
values**. Once the projection is key-only the rows are 32-byte keys, so 256 rows is **8 KiB**
and the existing row bound *is* a byte bound. **No adapter API was added, changed, or
removed** — `packages/lix/src/storage/conformance`,
`packages/lix/tests/third_party_storage_adapter.rs`, `packages/rocksdb-storage` and
`packages/slatedb-storage` are all untouched.

## What changed

* `BINARY_CAS_CHUNK_SPACE` is scanned with `StorageCoreProjection::KeyOnly`, so
  `hydrate_immutable_value_scan` returns early and the sweep never touches the object store
  for chunk payloads.
* **Deleted** `CAS_RECLAIM_CHUNK_PAGE_ROWS`. All four reclamation scans now share one
  `CAS_RECLAIM_PAGE_ROWS = 256`; the surviving constant is renamed from
  `CAS_RECLAIM_MANIFEST_PAGE_ROWS` because it is no longer manifest-specific.
* **Deleted** `BinaryCasGcSweep::reclaimed_chunk_bytes` and its
  `storage_bench::RepositoryGcCommitBenchResult` mirror — the sole reason the projection
  existed.
* Adds one instrument, `packages/engine-benchmarks/examples/e3_cas_reclaim_scan.rs`.

Engine diff is 27 insertions / 37 deletions across three files. `packages/lix/src/gc.rs` is
untouched.

## Measurement

Machine `hetzner-cpx62-IV` (16c/30G, `CARGO_BUILD_JOBS=4`).

**Arms.** Both arms carry the identical instrument and differ by exactly this engine diff.
Baseline was verified equal to the `claude-5-optimizations` head at build time
(**base SHA `256b22587`**); the branch was subsequently rebased, ending on `d8d5131b`.
Separate target dirs (`target-base` / `target-cand`) confirmed via `CLAUDE5_ROLE`.

**Storage location.** `/tmp` on this host is tmpfs. Every run rooted its SlateDB directory at
`$HOME/claude5/e3-scratch/...` on `/dev/sda1`, with `TMPDIR` redirected to
`$HOME/claude5/tmp`. **No number below was taken against RAM.**

**Fixture.** `N` distinct 16 KiB files written through the public file surface (one chunk row
each), deleted and checkpointed so every chunk is unreachable. Setup runs against the
**unwrapped** local object store; the store is then closed and reopened, optionally behind
`RemoteObjectStore`, so a latency profile is charged to the measured sweep only.

**Both arms reclaim identically at every point** — `reclaimed_chunk_rows`,
`reclaimed_manifest_rows` and `staged_deletes` agree exactly, and the chunk plane ends empty
in both.

### Primary claim — object-store requests per sweep (deterministic, 1 rep)

`e3_cas_reclaim_scan <dir> N 16 local orphan`

| chunk rows | base `read_objects` | cand `read_objects` | delta | delta % | **removed per chunk** |
|---|---|---|---|---|---|
| 100 | 529 | 429 | -100 | -18.9% | 1.00 |
| 1,000 | 4,210 | 3,206 | -1,004 | -23.8% | 1.00 |
| 10,000 | 41,026 | 31,033 | -9,993 | -24.4% | 1.00 |

**Exactly one object-store GET per chunk removed, and flat while chunk count grew 100x.** The
chunk plane's contribution falls from `N` requests to `ceil(N/256)`; the residual is the rest
of repository GC (manifest, manifest-chunk and presence scans over ~5N rows), which this PR
does not touch.

**Re-validated on the current head.** Because the branch was rebased across a dozen merged
PRs (including the `ScanChunk` refactor), both arms were rebuilt at `d8d5131b` and the
1,000-chunk point re-run, 2 reps per arm, interleaved:

| arm | rep 1 `read_objects` | rep 2 `read_objects` | `read_bytes` |
|---|---|---|---|
| base | 4,204 | 4,208 | 17,812,432 / 17,812,294 |
| cand | 3,209 | 3,234 | 1,406,750 / 1,405,906 |

Medians 4,206 -> 3,222, **-984 requests for 1,000 chunks (0.98/chunk)** and **-92.1% bytes** —
matching the `256b22587` measurement (4,210 -> 3,206) within noise. `reclaimed_chunk_rows`
(1,000) and `staged_deletes` (4,996) are identical across arms on the new base too.

| chunk rows | base `read_bytes` | cand `read_bytes` | delta % |
|---|---|---|---|
| 100 | 1,830,046 | 189,394 | -89.7% |
| 1,000 | 17,813,670 | 1,406,804 | -92.1% |
| 10,000 | 177,655,669 | 13,588,001 | -92.3% |

The fixture's 16 KiB chunks make this a **conservative lower bound**. At real media chunk
sizes the same 10,000-chunk repository would have had every GC pass pull on the order of
**10 GB** of chunk payload out of object storage — to compute a number nobody reads.

### Wall clock — and why local timing is the wrong instrument here

Local object store (`LocalFileSystem`), `sweep_ms`:

| chunk rows | base | cand | delta % |
|---|---|---|---|
| 100 | 43 | 48 | +11.6% |
| 1,000 | 376 | 345 | -8.2% |
| 10,000 | 3,443 | 3,046 | -11.5% |

**Only -8% to -11%, and it inverts at the smallest size.** On a local filesystem an
object-store request is a `read(2)` out of page cache and costs approximately nothing, so
this lane cannot price the thing being removed. **Anyone re-measuring this change on a local
FS will conclude it does not matter, and will be wrong.** The metric that predicts
object-store behaviour is the request count above, which is deterministic and reproduces
exactly.

Simulated remote object store (`RemoteObjectStore`,
`examples/support/remote_object_store.rs`) — the profile SlateDB actually ships against. Arm
order rotated across reps; setup is outside the wrapper, so `sweep_ms` is the sweep alone.

**1,000 chunk rows, `regional` = 15 ms RTT / 600 Mbps**

| rep | base | cand |
|---|---|---|
| 1 | 52,280 | 35,696 |
| 2 | 52,298 | 35,557 |
| 3 | 52,471 | 35,849 |
| **median** | **52,298** | **35,696** |
| max | 52,471 | 35,849 |

**-31.7%.** Raw ranges are disjoint (52.28-52.47 s vs 35.56-35.85 s), which is the runbook's
condition for accepting 3 reps.

**100 chunk rows, `wide-area` = 80 ms RTT / 100 Mbps**

| rep | base | cand |
|---|---|---|
| 1 | 30,309 | 22,021 |
| 2 | 30,140 | 22,009 |
| 3 | 30,205 | 21,925 |
| **median** | **30,205** | **22,009** |
| max | 30,309 | 22,021 |

**-27.1%**, ranges again disjoint (30.14-30.31 s vs 21.93-22.02 s).

**Null control.** This instrument's byte-identical lane is its **setup phase**: reclamation
never runs there, so both arms execute the same code. Its spread across all runs is
**-3.1% to +7.9%** (local 1k 4,991 -> 4,740; local 10k 456,881 -> 442,861; regional 1k medians
4,682 -> 5,051 — it moves in both directions). Both sweep results are **3-4x that floor** with
non-overlapping per-rep ranges.

**The per-request model checks out**, so the 10k remote point is projected rather than paid
for:

| point | requests removed | measured reduction | per removed request | profile RTT |
|---|---|---|---|---|
| 1,000 @ 15 ms | 1,026 | 16,602 ms | 16.2 ms | 15 ms |
| 100 @ 80 ms | 113 | 8,196 ms | 72.5 ms | 80 ms |

Pages are consumed one at a time, so the removed requests were fully serialized. Projecting
the deterministic 10,000-chunk delta of **9,993 requests**: **~50 s** removed at 5 ms (the
`tracked_state_crud` remote default), **~150 s** at 15 ms, **~800 s** at 80 ms — per GC pass,
on a repository holding 10,000 chunks, which at real chunk sizes is a ~10 GB media working
set.

## Layout invariants

1. **Single authority — no new authority.** Nothing gains a second writer or a second truth.
   The chunk plane remains the payload authority and is still enumerated directly; the
   sibling `binary_cas.chunk_presence` plane was deliberately **not** substituted for it, so
   a payload row that ever existed without a presence row is still reclaimable. One derived
   counter is deleted.
2. **Commit canonicality — unaffected.** No commit, parent link or state root is touched.
3. **Derived views are caches — yes.** `BinaryCasGcSweep` is maintenance accounting, never
   consulted by serving reads; one of its fields is removed.
4. **Atomic publication — unchanged.** Same single write set, same publication/reclamation
   fences and preconditions. Only the projection of one read changed.
5. **GC from refs — unchanged.** Reachability still starts at refs -> blob roots -> manifests
   -> chunks, one implementation. Only orphan *enumeration* changed projection.
6. **SQL reads canonical records — unaffected.** No query surface is touched.

## What regressed

* `BinaryCasGcSweep::reclaimed_chunk_bytes` and its `storage_bench` mirror are gone. Nothing
  in the workspace read either; `cas_gc_qualification` only `Debug`-printed the struct. The
  same quantity remains observable as the chunk plane's `value_bytes` delta across a sweep,
  which `cas_gc_qualification` already reports before and after.
* Local-filesystem wall clock at 100 chunks moved **+11.6%** (43 -> 48 ms). That is 5 ms on a
  43 ms run, it inverts at 1k and 10k, and it is inside the null control's spread. Accepted:
  the local FS prices an object request at ~0, which is the whole reason this lane has no
  signal.
* **Not addressed here, unchanged in both arms:** `verify_live_chunk_presence` still does a
  full-value point read per **live** chunk to authenticate it before staging any mutation.
  That is a deliberate fail-closed check and this PR leaves it alone. It means the win above
  is realised on repositories with orphans to collect — which is what a GC pass is for.

## Gate

Full CI-scope gate on `hetzner-cpx62-IV`, run on this branch rebased onto **`d8d5131b`**
(the `ScanChunk` change privatised `entries`/`has_more`; all four reclamation scans and the
instrument were moved to `into_parts()`).

**Result: clean, with one known pre-existing failure that is not from this diff.**

5/5 stages ran. **65 `test result: ok`**, **1 `test result: FAILED`**, clippy clean under
`-D warnings`, no compile errors, both features-OFF checks pass.

The single failure is:

```
sql2::exec::datafusion::tests::datafusion_entity_primary_key_read_uses_registered_provider
packages/lix/src/sql2/exec/datafusion.rs:4841 — assertion `left == right` failed
  left: 0
 right: 1
```

**This reproduces on a pristine `d8d5131b` checkout with zero changes.** I ran that exact
test on the unmodified integration head in a separate worktree and it fails identically, so
it is a red parent, not a regression here. It is a DataFusion entity-provider assertion with
no path to the binary CAS; this PR touches only `binary_cas/` and deletes a maintenance
counter. Independently reproduced by other agents; the window is pinned to
`cb257285..96ebabb6` and a fix is assigned elsewhere.

Everything else in the suite passes on this branch.

Commands, per `git show origin/main:.github/workflows/ci.yml`:

```
cargo clippy --profile test --workspace --all-targets --all-features -- -D warnings
cargo test --profile test --workspace --exclude lix_benchmarks --all-features --no-fail-fast
cargo test --profile test -p lix_benchmarks --features storage-benches,slatedb,root-replay-trace --no-fail-fast
cargo check -p lix --no-default-features
cargo check -p lix_js_sdk --target wasm32-unknown-unknown
```

The log was captured in full and grepped for `^error`, `error[E`, `panicked`,
`test result: FAILED` and `^failures:` rather than tailed.
