### PR TITLE
test(history): make the scan-row half of the file-history guards assert something

### DIFF
--- a/packages/lix/tests/integration/sql/lix_file_history.rs
+++ b/packages/lix/tests/integration/sql/lix_file_history.rs
@@ -134,7 +134,6 @@ async fn lix_file_history_point_lookup_does_not_rescan_unrelated_observed_state(
     // or other unrelated file rows a second time.
     const MAX_REQUESTED_KEYS: u64 = 416;
     const MAX_SCAN_CALLS: u64 = 128;
-    const MAX_SCANNED_ROWS: u64 = 512;
 
     let storage = CountingStorage::default();
     Engine::initialize(storage.clone())
@@ -241,9 +240,19 @@ async fn lix_file_history_point_lookup_does_not_rescan_unrelated_observed_state(
          {UNRELATED_ADDITIONAL_FILE_COUNT} additional files; expected at most {MAX_REQUESTED_KEYS}"
     );
     assert!(
-        scan_calls <= MAX_SCAN_CALLS && scanned_rows <= MAX_SCANNED_ROWS,
-        "point-routed history performed {scan_calls} scans returning {scanned_rows} rows; \
-         expected at most {MAX_SCAN_CALLS} scans and {MAX_SCANNED_ROWS} rows"
+        scan_calls <= MAX_SCAN_CALLS,
+        "point-routed history performed {scan_calls} scans; \
+         expected at most {MAX_SCAN_CALLS}"
+    );
+    // Point-routed file history resolves entirely through `get_many`: it opens
+    // scan cursors but never draws a row from one. An upper bound on rows is
+    // therefore vacuous here — it cannot fail, so it reads as coverage without
+    // being any. Asserting the exact zero makes it a real guard that fails the
+    // moment this path starts serving rows out of a scan.
+    assert_eq!(
+        scanned_rows, 0,
+        "point-routed history drew {scanned_rows} rows from scan cursors; \
+         this path is expected to read exclusively through get_many"
     );
 
     session.close().await.expect("session should close");
@@ -259,7 +268,6 @@ async fn lix_file_history_path_lookup_does_not_rescan_unrelated_observed_state()
     // blobs must not be reconstructed once per observed commit.
     const MAX_REQUESTED_KEYS: u64 = 416;
     const MAX_SCAN_CALLS: u64 = 128;
-    const MAX_SCANNED_ROWS: u64 = 512;
 
     let storage = CountingStorage::default();
     Engine::initialize(storage.clone())
@@ -366,9 +374,16 @@ async fn lix_file_history_path_lookup_does_not_rescan_unrelated_observed_state()
          {UNRELATED_ADDITIONAL_FILE_COUNT} additional files; expected at most {MAX_REQUESTED_KEYS}"
     );
     assert!(
-        scan_calls <= MAX_SCAN_CALLS && scanned_rows <= MAX_SCANNED_ROWS,
-        "path-routed history performed {scan_calls} scans returning {scanned_rows} rows; \
-         expected at most {MAX_SCAN_CALLS} scans and {MAX_SCANNED_ROWS} rows"
+        scan_calls <= MAX_SCAN_CALLS,
+        "path-routed history performed {scan_calls} scans; \
+         expected at most {MAX_SCAN_CALLS}"
+    );
+    // See the point-routed guard: a row upper bound cannot fail on this path,
+    // so assert the exact zero instead.
+    assert_eq!(
+        scanned_rows, 0,
+        "path-routed history drew {scanned_rows} rows from scan cursors; \
+         this path is expected to read exclusively through get_many"
     );
 
     session.close().await.expect("session should close");
@@ -525,7 +540,6 @@ async fn lix_file_history_ancestor_point_lookup_keeps_parent_evidence_bounded() 
     const UNRELATED_DIRECTORY_COUNT: usize = 256;
     const MAX_REQUESTED_KEYS: u64 = 400;
     const MAX_SCAN_CALLS: u64 = 48;
-    const MAX_SCANNED_ROWS: u64 = 48;
 
     let storage = CountingStorage::default();
     Engine::initialize(storage.clone())
@@ -622,9 +636,16 @@ async fn lix_file_history_ancestor_point_lookup_keeps_parent_evidence_bounded() 
          {UNRELATED_DIRECTORY_COUNT} unrelated directories; expected at most {MAX_REQUESTED_KEYS}"
     );
     assert!(
-        scan_calls <= MAX_SCAN_CALLS && scanned_rows <= MAX_SCANNED_ROWS,
-        "ancestor point history performed {scan_calls} scans returning {scanned_rows} rows; \
-         expected at most {MAX_SCAN_CALLS} scans and {MAX_SCANNED_ROWS} rows"
+        scan_calls <= MAX_SCAN_CALLS,
+        "ancestor point history performed {scan_calls} scans; \
+         expected at most {MAX_SCAN_CALLS}"
+    );
+    // See the point-routed guard: a row upper bound cannot fail on this path,
+    // so assert the exact zero instead.
+    assert_eq!(
+        scanned_rows, 0,
+        "ancestor point history drew {scanned_rows} rows from scan cursors; \
+         this path is expected to read exclusively through get_many"
     );
 
     session.close().await.expect("session should close");


### PR DESCRIPTION
## What changed

The three `lix_file_history` "does not rescan unrelated observed state" guards each asserted

```rust
scan_calls <= MAX_SCAN_CALLS && scanned_rows <= MAX_SCANNED_ROWS
```

Point-, path- and ancestor-routed file history all resolve **entirely through `get_many`**. They open
scan cursors but never draw a row from one, so `scanned_rows` is structurally `0` and the upper bound
on it **cannot fail**. Half of each guard was reading as coverage without being any.

This asserts the exact zero instead:

```rust
assert!(scan_calls <= MAX_SCAN_CALLS, …);
assert_eq!(scanned_rows, 0, "… expected to read exclusively through get_many");
```

That is strictly stronger than the old bound and it can fail: it trips the moment one of these paths
starts serving rows out of a scan cursor. The `scan_calls` half was already live (92 observed against
a bound of 128) and keeps its upper bound. The now-unused `MAX_SCANNED_ROWS` constants are removed.

**Removed:** two `MAX_SCANNED_ROWS` constants and the unfailable half of three assertions. No engine
code changes; test-only.

## How the vacuousness was established

Not by reading — by counting. While instrumenting an unrelated experiment (E19) on the same
`CountingStorage` harness, a per-storage-space attribution of every `get_many` key showed
point-routed file history reading exclusively through `get_many` across
`tracked_state.commit_state_manifest.v7`, `tracked_state.commit_mutation_catalog.v1`,
`changelog.commit` and `tracked_state.commit_delta_segment.v6`, with `scanned_rows = 0` on every
query shape and every corpus size tested (bulk commits of 50, 500 and 5000 entities), reproduced
across two runs.

## Layout invariants

Test-only change; no physical layout is touched. For completeness:

1. **Single authority** — no new authority; nothing added or relocated.
2. **Commit canonicality** — unchanged.
3. **Derived views are caches** — unchanged.
4. **Atomic publication** — unchanged.
5. **GC from refs** — unchanged.
6. **SQL reads canonical records** — unchanged.

## Adapter API

No `StorageAdapter` surface added, changed, or removed. No public API change.

## Measurements

No performance claim is made, so there is no A/B table and no null control to report — this changes
only what a test asserts. The relevant number is the one that establishes the defect:
`scanned_rows = 0` (deterministic, 1 rep per the runbook, reproduced twice) against a bound of 512.

## Regressions

None. The change only tightens assertions; no lane's behavior is affected.

## Gate

Full CI-scope gate on `ryzen-9950x-V`, scope re-read from `origin/main:.github/workflows/ci.yml`
rather than the runbook copy:

```
cargo clippy --profile test --workspace --all-targets --all-features -- -D warnings
cargo test --profile test --workspace --exclude lix_benchmarks --all-features --no-fail-fast
cargo test --profile test -p lix_benchmarks --features storage-benches,slatedb,root-replay-trace --no-fail-fast
cargo check -p lix --no-default-features
cargo check -p lix_js_sdk --target wasm32-unknown-unknown
```

| phase | exit | result |
|---|---|---|
| clippy `-D warnings` | 0 | **0 warnings** |
| workspace tests | 101 | 3475 passed / **1 failed** (pre-existing, see below) |
| `lix_benchmarks` tests | 0 | 26 passed / 0 failed |
| `-p lix --no-default-features` | 0 | clean |
| `lix_js_sdk` wasm32 | 0 | clean |

Combined: **3501 passed / 1 failed**.

### The one failure is pre-existing on the integration head, not from this PR

```
sql2::exec::datafusion::tests::datafusion_entity_primary_key_read_uses_registered_provider
packages/lix/src/sql2/exec/datafusion.rs:4841: assertion `left == right` failed
  left: 0, right: 1
```

Verified rather than assumed: checked out pristine `9e22c61a` (integration head, **zero** changes) in
a separate worktree and ran that test alone — `test result: FAILED. 0 passed; 1 failed`. It
reproduces identically without this PR.

It is also structurally unreachable from this change: the failing test is a unit test in the `lix`
**lib** target (`packages/lix/src/…`), while this PR touches only
`packages/lix/tests/integration/sql/lix_file_history.rs`, a separate integration test binary. The
lib target does not compile that file.

The likely origin is the entity-planner change merged as PR #1372 ("analyse entity row filters over
residual filters only"), which is the last merge into `claude-5-optimizations` and touches exactly
this area. **Flagging for the coordinator: the integration branch head is currently red.**

All three modified guards pass:
`test result: ok. 34 passed; 0 failed` for the `lix_file_history` filter.

Base SHA: `9e22c61a`.
