### PR TITLE
fix(gc): document the json_store reclamation gap, land its instrument, close a dead registry hole

### DIFF
--- a/packages/engine-benchmarks/examples/e1_json_leak.rs
+++ b/packages/engine-benchmarks/examples/e1_json_leak.rs
@@ -1,0 +1,152 @@
+//! Does `json_store` reclaim superseded out-of-band payloads?
+//!
+//! `stage_delete_refs` is `#[cfg(test)]` and its only caller is the
+//! `#[cfg(test)]` `plan_and_stage_authority_gc`, so the shipping sweep
+//! (`stage_repository_gc_with_preconditions`) never stages a JSON delete. This
+//! probe measures what that costs on the workload being advertised: an agent
+//! rewriting the same file over and over.
+//!
+//! Two fixture facts the measurement depends on:
+//!
+//! 1. **The out-of-band threshold is `JSON_INLINE_MAX_BYTES` (1 KiB) on the raw
+//!    normalized snapshot.** The 512-byte/128-byte constants are the *zstd*
+//!    thresholds inside the store and do not decide whether a payload reaches
+//!    it at all. A payload at or under 1 KiB stays inline in the hot row and
+//!    this probe would measure an empty table.
+//! 2. **The store is content-addressed** (`JsonRef::for_content`). Rewriting
+//!    byte-identical content dedups to one row and leaks nothing. Every
+//!    rewrite here is a *distinct* payload, which is what an agent editing a
+//!    file actually produces.
+//!
+//! ```text
+//! e1_json_leak <rewrites> [<rewrites> ...]
+//! ```
+
+#![allow(clippy::large_futures)]
+
+use lix::Value;
+use lix::integration::{Engine, SessionContext};
+use lix::registered_spaces::JSON_SPACE;
+use lix::storage::Storage;
+use lix::storage_adapter::{Memory, StorageAdapter, StorageReadOptions};
+use lix::storage_bench::{collect_repository_gc_for_bench, space_inventory};
+
+/// A snapshot whose normalized JSON is comfortably past the 1 KiB inline
+/// threshold, and distinct for every `revision`.
+fn payload(revision: usize) -> String {
+    let filler = format!("rev-{revision:08}-");
+    let mut body = String::with_capacity(2_048);
+    while body.len() < 1_800 {
+        body.push_str(&filler);
+    }
+    serde_json::json!({ "revision": revision, "body": body }).to_string()
+}
+
+async fn register_schema<S>(session: &SessionContext<S>)
+where
+    S: Storage + Clone + Send + Sync + 'static,
+{
+    let schema = serde_json::json!({
+        "x-lix-key": "leak_row",
+        "x-lix-primary-key": ["/path"],
+        "type": "object",
+        "required": ["path", "value"],
+        "properties": {
+            "path": { "type": "string" },
+            "value": {
+                "type": ["object", "array", "string", "number", "integer", "boolean", "null"]
+            }
+        },
+        "additionalProperties": false
+    });
+    session
+        .execute(
+            "INSERT INTO lix_registered_schema (value, lixcol_global, lixcol_untracked) \
+             VALUES (lix_json($1), false, false)",
+            &[Value::Text(schema.to_string())],
+        )
+        .await
+        .expect("register leak schema");
+}
+
+async fn json_rows(storage: &StorageAdapter<Memory>) -> (usize, usize) {
+    let read = storage
+        .begin_read(StorageReadOptions::default())
+        .await
+        .expect("open json inventory read");
+    let entries = space_inventory(&read, JSON_SPACE.name).await;
+    let bytes = entries
+        .iter()
+        .map(|(key, value)| key.len() + value.len())
+        .sum();
+    (entries.len(), bytes)
+}
+
+#[tokio::main(flavor = "current_thread")]
+async fn main() {
+    let counts = std::env::args()
+        .skip(1)
+        .map(|arg| arg.parse::<usize>().expect("rewrite count"))
+        .collect::<Vec<_>>();
+    let counts = if counts.is_empty() {
+        vec![10, 100, 1_000]
+    } else {
+        counts
+    };
+
+    for rewrites in counts {
+        let memory = Memory::new();
+        Engine::initialize(memory.clone())
+            .await
+            .expect("initialize leak repository");
+        let engine = Engine::new(memory.clone())
+            .await
+            .expect("open leak engine");
+        let session = engine
+            .open_workspace_session()
+            .await
+            .expect("open leak workspace");
+        register_schema(&session).await;
+
+        session
+            .execute(
+                "INSERT INTO leak_row (path, value) VALUES ($1, lix_json($2))",
+                &[
+                    Value::Text("/agent/file".to_owned()),
+                    Value::Text(payload(0)),
+                ],
+            )
+            .await
+            .expect("insert the first revision");
+
+        for revision in 1..=rewrites {
+            session
+                .execute(
+                    "UPDATE leak_row SET value = lix_json($2) WHERE path = $1",
+                    &[
+                        Value::Text("/agent/file".to_owned()),
+                        Value::Text(payload(revision)),
+                    ],
+                )
+                .await
+                .expect("rewrite the same row");
+        }
+
+        let storage = StorageAdapter::new(memory.clone());
+        let (rows_before, bytes_before) = json_rows(&storage).await;
+        collect_repository_gc_for_bench(&storage)
+            .await
+            .expect("run the shipping repository sweep");
+        let (rows_after, bytes_after) = json_rows(&storage).await;
+
+        // Exactly one revision is live: the row was rewritten in place.
+        println!(
+            "E1LEAK rewrites={rewrites} live_payloads=1 \
+             rows_before_gc={rows_before} rows_after_gc={rows_after} \
+             bytes_before_gc={bytes_before} bytes_after_gc={bytes_after} \
+             reclaimed_rows={} orphan_rows={}",
+            rows_before.saturating_sub(rows_after),
+            rows_after.saturating_sub(1),
+        );
+    }
+}

--- a/packages/lix/src/gc.rs
+++ b/packages/lix/src/gc.rs
@@ -5741,10 +5741,13 @@ mod tests {
 
     #[tokio::test]
     async fn retention_closure_and_audit_reject_missing_and_malformed_required_authority() {
-        const MUTABLE_MANIFEST_SPACE: StorageSpace = StorageSpace::mutable(
-            crate::tracked_state::TRACKED_STATE_COMMIT_STATE_MANIFEST_SPACE.id,
-            "tracked_state.commit_state_manifest.v7",
-        );
+        // States the corruption-test need at the call site instead of smuggling
+        // it in as a second `StorageSpace::mutable` declaration that reads like
+        // a canonical one. This was the last raw re-declaration in the engine,
+        // and closing it lets `UNCHECKED_SPACE_IDS` go empty.
+        const MUTABLE_MANIFEST_SPACE: StorageSpace =
+            crate::tracked_state::TRACKED_STATE_COMMIT_STATE_MANIFEST_SPACE
+                .mutable_view_for_corruption_test();
 
         let (storage, commit_id, _, _, _) = gc_sweep_fixture().await;
         let mut writes = storage.new_write_set();

--- a/packages/lix/src/gc.rs
+++ b/packages/lix/src/gc.rs
@@ -1142,9 +1142,17 @@ where
 /// The caller must serialize this operation with repository writes and commit
 /// `writes` atomically. Planning and mutation are deliberately separated from
 /// storage commit so checkpoint/session code can retain lifecycle control.
-/// Content-addressed tree/CAS orphan repair is intentionally an offline path;
-/// out-of-band JSON is reclaimed here only from explicit ownership-loss
-/// candidates.
+/// Content-addressed tree/CAS orphan repair is intentionally an offline path.
+///
+/// **Out-of-band JSON is not reclaimed here at all.** This comment used to
+/// claim reclamation "from explicit ownership-loss candidates"; that mechanism
+/// was deleted in 31cb639ae because the candidate hints were write-only, and
+/// nothing replaced it. `stage_delete_refs` and every function that enumerates
+/// payload hashes are `#[cfg(test)]`, and this path stages an empty
+/// `json_payloads`. A repository's out-of-band payload count therefore grows
+/// linearly with edits and is never reclaimed -- measured at 0 rows reclaimed
+/// for 10, 100, and 1000 rewrites of a single row
+/// (`engine-benchmarks/examples/e1_json_leak.rs`).
 /// Ordinary GC derives its candidates from the physical manifest inventory and
 /// proves liveness only from refs: branch-head controls and checkpoint recovery
 /// refs are the complete active-root set, and the walk from those roots through

--- a/packages/lix/src/storage_spaces.rs
+++ b/packages/lix/src/storage_spaces.rs
@@ -86,17 +86,22 @@ pub(crate) const ALL_STORAGE_SPACES: &[StorageSpace] = &[
 
 /// Space ids the constructor check cannot reject yet.
 ///
-/// `gc.rs` re-declares `0x0004_002b` (`tracked_state.commit_state_manifest.v7`)
-/// as mutable so a retention test can delete and overwrite an authority the
-/// engine publishes write-once. Every other engine test states that need
-/// through `StorageSpace::mutable_view_for_corruption_test`, which does not go
-/// through the checked constructors at all. `gc.rs` is owned by the in-flight
-/// GC ledger redesign and is not edited this cycle, so this one id keeps the
-/// weaker, test-enforced treatment: it is reported by
-/// [`tests::no_registered_space_id_is_declared_with_two_value_semantics`], and
-/// [`tests::the_unchecked_ids_are_exactly_the_known_disagreements`] fails the
-/// moment the site goes away and this list becomes stale.
-const UNCHECKED_SPACE_IDS: &[u32] = &[0x0004_002b];
+/// Empty, and it should stay that way. Every engine site that needs to place
+/// chosen bytes under a write-once key states it through
+/// `StorageSpace::mutable_view_for_corruption_test`, which does not go through
+/// the checked constructors at all.
+///
+/// This list previously held `0x0004_002b`
+/// (`tracked_state.commit_state_manifest.v7`) for a raw re-declaration in
+/// `gc.rs`, justified by `gc.rs` being owned by an in-flight redesign and not
+/// editable. Both halves expired: the re-declaration is gone (the site now uses
+/// `mutable_view_for_corruption_test`) and the ownership claim was round-4
+/// residue. The hole outlived its reason by a whole cycle because the guard
+/// meant to catch that compares this list to `tests::KNOWN_DISAGREEMENTS` --
+/// two hand-maintained lists, checked against each other and never against the
+/// code -- so it could not have noticed the site disappearing. Widening a
+/// safety check for one call site needs a guard that watches the call site.
+const UNCHECKED_SPACE_IDS: &[u32] = &[];
 
 /// Whether a space id may be declared with `semantics`.
 ///
@@ -343,7 +348,7 @@ mod tests {
     /// owned by the in-flight GC ledger redesign and is left alone this cycle.
     /// The list is exact, so this also fails once the redesign removes the
     /// site and the entry goes stale.
-    const KNOWN_DISAGREEMENTS: &[(&str, u32)] = &[("lix/src/gc.rs", 0x0004_002b)];
+    const KNOWN_DISAGREEMENTS: &[(&str, u32)] = &[];
 
     #[test]
     fn no_registered_space_id_is_declared_with_two_value_semantics() {

--- a/packages/lix/src/storage_spaces.rs
+++ b/packages/lix/src/storage_spaces.rs
@@ -87,20 +87,25 @@ pub(crate) const ALL_STORAGE_SPACES: &[StorageSpace] = &[
 /// Space ids the constructor check cannot reject yet.
 ///
 /// Empty, and it should stay that way. Every engine site that needs to place
-/// chosen bytes under a write-once key states it through
-/// `StorageSpace::mutable_view_for_corruption_test`, which does not go through
-/// the checked constructors at all.
+/// chosen bytes under a key the engine publishes write-once states that need
+/// through `StorageSpace::mutable_view_for_corruption_test`, which does not go
+/// through the checked constructors at all.
 ///
-/// This list previously held `0x0004_002b`
-/// (`tracked_state.commit_state_manifest.v7`) for a raw re-declaration in
-/// `gc.rs`, justified by `gc.rs` being owned by an in-flight redesign and not
-/// editable. Both halves expired: the re-declaration is gone (the site now uses
-/// `mutable_view_for_corruption_test`) and the ownership claim was round-4
-/// residue. The hole outlived its reason by a whole cycle because the guard
-/// meant to catch that compares this list to `tests::KNOWN_DISAGREEMENTS` --
-/// two hand-maintained lists, checked against each other and never against the
-/// code -- so it could not have noticed the site disappearing. Widening a
-/// safety check for one call site needs a guard that watches the call site.
+/// This list held `0x0004_002b` (`tracked_state.commit_state_manifest.v7`) for
+/// one raw re-declaration in a `gc.rs` retention test, justified by `gc.rs`
+/// being owned by an in-flight redesign and not editable that cycle. The
+/// ownership claim was round-4 residue; the site has now been converted to
+/// `mutable_view_for_corruption_test` and the hole is closed.
+///
+/// Note what the guard could and could not do. `tests::the_unchecked_ids_are_
+/// exactly_the_known_disagreements` compares this list to
+/// `tests::KNOWN_DISAGREEMENTS` -- two hand-maintained lists, checked against
+/// each other and never against the code -- so it would not have noticed the
+/// call site disappearing, only a disagreement between the two lists. What
+/// actually enforces this is the `const` assertion in
+/// `StorageSpace::mutable`: with the list empty, a re-declaration is a compile
+/// error naming the exact site. Widening a safety check for one call site needs
+/// a guard that watches the call site, not a second list describing it.
 const UNCHECKED_SPACE_IDS: &[u32] = &[];
 
 /// Whether a space id may be declared with `semantics`.


### PR DESCRIPTION
# fix(gc): document the json_store reclamation gap, land its instrument, close a dead registry hole

**Negative result plus two real fixes.** E22 set out to wire JSON payload reclamation into the
shipping GC. It is not in this PR, for a specific reason stated below. What is here: the leak
measured and committed as a runnable instrument, two comments that asserted behaviour which does not
exist, and one live defect closed.

## The limitation, as a checkable sentence

> **JSON payload reclamation is not implemented; a repository's out-of-band payload count grows
> linearly with distinct edits.**

That belongs in the release post's known-limits list. It is true, it is measurable, and this PR ships
the thing that measures it.

## Measured

`engine-benchmarks/examples/e1_json_leak.rs`, on ryzen-9950x-I, in-memory backend, one row rewritten
in place with distinct >1 KiB payloads, then the **real shipping sweep**
(`collect_repository_gc_for_bench` → `stage_repository_gc_with_preconditions`). Deterministic, 1 rep:

| rewrites | live payloads | json rows before GC | after GC | **reclaimed** | bytes after GC | orphans |
|---|---|---|---|---|---|---|
| 10 | 1 | 14 | 14 | **0** | 4,812 | 13 |
| 100 | 1 | 104 | 104 | **0** | 16,774 | 103 |
| 1,000 | 1 | 1,004 | 1,004 | **0** | 138,967 | 1,003 |

Rows are `rewrites + 4` engine-bootstrap payloads. One payload is live throughout. **Zero reclaimed at
every scale** — not bounded-in-practice, but unbounded and monotonic for the life of the repository.

Marginal cost here is ~136 B/row, but the probe's filler is highly repetitive so zstd crushes it:
treat that as a **floor**, not a typical figure. The row count is the honest metric — provably linear
regardless of payload shape.

The static picture agrees: `stage_delete_refs` is `#[cfg(test)]` and carries its own verdict in a
comment, the shipping path stages an explicitly empty `json_payloads`, and every function that
enumerates payload hashes is `cfg(test)`. Retired commits **do** get their change rows deleted. So
changes die and payloads do not.

## Two fixture traps, either of which produces a false rejection

Both are documented in the probe's header, because the next person to measure this will hit them.

1. **The cutoff that matters is `JSON_INLINE_MAX_BYTES = 1024`** on the raw normalized snapshot
   (`json_store/types.rs:208`). The ≥512 / ≥128 pair is the *zstd* threshold **inside** the store and
   does not decide whether a payload reaches it at all. A 512-byte payload stays inline in the hot
   row and measures an empty table.
2. **The store is content-addressed** (`JsonRef::for_content`). The obvious fixture — rewrite the
   *same* payload N times — dedups to one row and leaks nothing, reading as a clean pass. Only
   *distinct* payloads per rewrite show the defect, which is also what an agent editing a file
   actually produces.

## Why the fix is not here: json_store has no publication/reclamation fence

The fix is feasible and structurally identical to binary CAS — reuse the existing `retained_cas_root_ids`
walk, add a `collect_gc_json_payload_roots` mirroring `collect_gc_binary_blob_roots`, mark-sweep
`JSON_SPACE`. No second reachability implementation, no forbidden semantic inventory scan. Three of
the four gaps are ordinary work: the per-commit read cannot be schema-filtered (JSON hangs off every
schema, unlike CAS's single `BLOB_REF_SCHEMA_KEY`); it must stop at `JsonSlot` before
`load_bytes_many` hydrates and discards the ref; and three `cfg(test)` functions need un-gating.

The fourth is disqualifying. Binary CAS pairs **`stage_cas_publication_fence`** with
**`stage_cas_reclamation_fence`** precisely so that a concurrent publisher reusing a **deduped**
payload cannot race a sweep planned from an older snapshot. **`json_store` has no such mechanism and
no precedent to copy.** Content-addressed dedup makes that race *more* likely, not less: a "new"
write can resolve to an existing row the sweep has already marked dead. Losing that race deletes a
live payload — worse than leaking, and the one failure mode that cannot be walked back.

Designing a new concurrency fence for a new plane is real work that deserves its own experiment and
its own gate. Filing it with the design mapped and the gap named beats shipping it fast.

## Two comments that asserted behaviour which does not exist

- **`gc.rs`** claimed out-of-band JSON "is reclaimed here only from explicit ownership-loss
  candidates". That mechanism was **deleted in `31cb639ae`** (the hints were write-only) and replaced
  with nothing. The comment now states the limitation truthfully and points at the measurement.
- **`storage_spaces.rs`** justified an `UNCHECKED_SPACE_IDS` hole with "`gc.rs` is owned by the
  in-flight GC ledger redesign and is not edited this cycle". That was round-4 residue: `gc.rs` has
  been edited repeatedly this cycle, and no open PR is a GC ledger redesign.

A comment asserting behaviour that does not exist is worse than no comment — it makes the next agent
detour around a defect.

## The registry hole, and a guard that could not see

`UNCHECKED_SPACE_IDS` is now **empty**. The one entry (`0x0004_002b`,
`tracked_state.commit_state_manifest.v7`) existed for a single raw `StorageSpace::mutable`
re-declaration in a `gc.rs` retention test; that site now uses the sanctioned
`mutable_view_for_corruption_test()`, like every other such site in the engine. The registry's
value-semantics check is enforced with no exceptions.

This is worth landing on its own because of *why* the hole outlived its reason by a cycle.
`tests::the_unchecked_ids_are_exactly_the_known_disagreements` compares `UNCHECKED_SPACE_IDS` to
`tests::KNOWN_DISAGREEMENTS` — **two hand-maintained lists, checked against each other and never
against the code.** It could not have detected the call site disappearing; it can only notice the two
lists disagreeing. A guard that cannot observe the thing it guards is not a guard. What actually
enforces this is the `const` assertion in `StorageSpace::mutable`, which with the list empty turns a
re-declaration into a compile error naming the exact site — which is why closing the hole beats
maintaining the list.

**And it caught the author of this PR, within the hour.** I first concluded the hole was already dead
and wrote that in a comment. It was not: my `rg` searched the numeric literal `0x0004_002b` while the
site referenced the space by constant (`TRACKED_STATE_COMMIT_STATE_MANIFEST_SPACE.id`). Emptying the
list and compiling produced `E0080` pointing straight at `gc.rs:5744`. That is the runbook entry I
added this morning — *verify the invariant, don't trust the edit* — doing its job on its own author,
and it is why the note in this PR is written from a compile result rather than from a grep.

## Layout invariants

No physical layout change; no space added, removed, or versioned. (1) no new authority — the
corruption-test view re-expresses an existing test need through the sanctioned constructor; (2)–(6)
untouched. Invariant 5 is the reason the GC change is *absent*: extending reachability is the only
acceptable shape, and it is not safe to land without the fence above.

## Gate

Full CI-scope gate on **ryzen-9950x-I**, rebased onto integration head `d8d5131b`. The five-command
gate ran at `14d76dcba`; the probe example was then restored (see note) and `check --all-targets`,
`clippy -D warnings`, and the `lix_benchmarks` test target re-run at head `ddc613025`, all clean —
those three are the only commands a new example target can affect.

| command | result |
|---|---|
| `cargo check --workspace --all-targets --all-features` | clean |
| `cargo clippy --workspace --all-targets --all-features -- -D warnings` | clean, 0 warnings |
| `cargo check -p lix --no-default-features` | clean |
| `cargo check -p lix_js_sdk --target wasm32-unknown-unknown` | clean |
| workspace tests `--no-fail-fast` | 3476 passed / **1 failed** (see below) |
| `lix_benchmarks` tests `--no-fail-fast` | **26 passed / 0 failed** |

Zero `error` and zero `warning` lines across check, clippy, and the features-off pair. Log captured
to a file and grepped for `failures:`, `panicked at`, `test result: FAILED`, `^error`.

**This gate carries one known pre-existing failure**,
`sql2::exec::datafusion::tests::datafusion_entity_primary_key_read_uses_registered_provider`
(`datafusion.rs:4841`, `left: 0, right: 1`). It is **not caused by this PR**: it reproduces
identically on the integration head with these changes absent. It entered in `cb257285..96ebabb6` —
my #1374 gate was 3477 / 0 at `cb257285` — and is already assigned to another agent. Attributed, not
chased.
