### PR TITLE
fix(sql2): repair the red integration head — retarget the entity point-read routing test

### DIFF
--- a/packages/lix/src/sql2/exec/datafusion.rs
+++ b/packages/lix/src/sql2/exec/datafusion.rs
@@ -4838,11 +4838,44 @@ mod tests {
                 ],
             ]
         );
-        assert_eq!(scans.load(Ordering::SeqCst), 1);
+        // A `WHERE` clause that resolves to a complete entity identity set is
+        // applied in full by the `entity_pks` access path, so this read must
+        // take the direct point-snapshot route rather than the generic
+        // visibility scan.
+        //
+        // This assertion pair previously read `scans == 1` and
+        // `requests.is_empty()` — the exact opposite — and its message called
+        // the snapshot reader "the deleted native snapshot route". That wording
+        // predates the current `EntitySnapshotReader`, which is a live route
+        // registered from `SqlExecutionContext::entity_snapshot_reader` and
+        // backed by the entity point-snapshot cache. The old expectation froze
+        // a mis-gate in `plan_scan_parts`: it re-derived a residual row filter
+        // for a predicate the access path already applied, and a non-empty
+        // `row_filters` disqualifies every direct route.
+        assert_eq!(
+            scans.load(Ordering::SeqCst),
+            0,
+            "an exact identity point read must not fall back to the generic visibility scan"
+        );
         let requests = requests.lock().expect("captured snapshot requests lock");
-        assert!(
-            requests.is_empty(),
-            "DataFusion reads must not invoke the deleted native snapshot route"
+        assert_eq!(
+            requests.len(),
+            1,
+            "an exact identity point read must consult the entity point-snapshot route exactly once"
+        );
+        assert_eq!(
+            requests[0].filter.schema_keys,
+            vec!["test_state_schema".to_string()],
+            "the point-snapshot request must be scoped to the queried schema"
+        );
+        assert_eq!(
+            requests[0].filter.entity_pks,
+            vec![
+                crate::entity_pk::EntityPk::single("entity-a"),
+                crate::entity_pk::EntityPk::single("entity-b"),
+            ],
+            "the repeated 'entity-b' in the IN list must collapse into a deduplicated, \
+             ordered identity set rather than being pushed down three times"
         );
     }
 


### PR DESCRIPTION
Fixes the red integration head.

`sql2::exec::datafusion::tests::datafusion_entity_primary_key_read_uses_registered_provider` has been
failing at `datafusion.rs:4841` with `left: 0, right: 1` since PR #1372.

## What actually happened — it is not a semantic merge conflict

Bisected, one test per revision, `cargo test --profile test -p lix --lib --all-features`:

| revision | what it is | result |
|---|---|---|
| `cb257285e` | integration head **before** #1372 | **ok. 1 passed; 0 failed** |
| `3e3e16305` | **#1372's own branch tip** | **FAILED** — `left: 0, right: 1` |
| `9e22c61a1` | #1372's merge | FAILED — `left: 0, right: 1` |
| `d8d5131bc` | current integration head | FAILED — `left: 0, right: 1` |

**#1372's branch was already red on its own tip**, on its own base, before any merge. So no
interaction with #1367/#1370/#1371 is involved, and nothing was lost or re-introduced by merging.

The reason is narrower and more mundane than an interaction: **#1372's test edit was never committed.**
Its branch is a single commit (`3e3e16305`) whose entire diff is
`packages/lix/src/sql2/providers/entity.rs | 27 +++++--`. The assertions at `datafusion.rs:4841` are
byte-identical at `cb257285e` and at every head since — the engine change shipped, the test change
did not.

This is visible in #1372's own PR body, which describes the edit in detail:

> only the two routing assertions were flipped to the intended direction (`scans == 0`, one recorded
> request carrying the two deduplicated identities and no residual constraint)

That text describes a change the pushed branch does not contain, and the reported gate result
(`3496 passed / 0 failed`) is not reproducible from it — the branch tip fails. The edit was presumably
present in the working tree that was gated and lost in a later amend, reset or rebase.

## The engine is fine — #1372's win is intact at the head

No revert is warranted. Measured at the current head `d8d5131bc` by instrumenting the test's
recording reader:

```
scans=0 requests=1 shapes=[(["test_state_schema"],
                            [Single(String("entity-a")), Single(String("entity-b"))],
                            limit=None)]
```

The direct point-snapshot route **is** taken at the merged head: zero generic visibility scans, one
point-snapshot request, correctly scoped, with the `IN ('entity-b','entity-a','entity-b')` list
collapsed to a deduplicated, ordered two-element identity set. That is exactly the routing #1372
measured its 2.7x `read_one_by_pk` win from, so the win is present at the integration head and no
release claim is affected.

## What changed here

The test now asserts the behaviour we want, derived from the measured routing facts above rather than
edited into agreement with whatever the code happened to do:

```rust
assert_eq!(scans.load(Ordering::SeqCst), 0,
    "an exact identity point read must not fall back to the generic visibility scan");
assert_eq!(requests.len(), 1,
    "an exact identity point read must consult the entity point-snapshot route exactly once");
assert_eq!(requests[0].filter.schema_keys, vec!["test_state_schema".to_string()], …);
assert_eq!(requests[0].filter.entity_pks,
    vec![EntityPk::single("entity-a"), EntityPk::single("entity-b")],
    "the repeated 'entity-b' in the IN list must collapse into a deduplicated, ordered identity set …");
```

This is strictly stronger than what #1372 said it was going to land: besides the two routing
assertions it also pins the request's schema scoping and the deduplication of the `IN` list, so a
future regression that took the direct route but pushed the duplicate down three times, or leaked
across schemas, would now fail.

The old assertion's message — "DataFusion reads must not invoke the deleted native snapshot route" —
was stale and actively misleading. It predates the current `EntitySnapshotReader`, which is **not**
deleted: it is a live route registered from `SqlExecutionContext::entity_snapshot_reader`
(`sql2/providers/mod.rs:484`), implemented by `CurrentEntitySnapshotReader`, and backed by the entity
point-snapshot cache. The comment now records why the old expectation was incidental — it froze the
`plan_scan_parts` mis-gate, where a residual row filter was re-derived for a predicate the
`entity_pks` access path already applies in full, and a non-empty `row_filters` disqualifies every
direct route.

**Removed:** the two inverted routing assertions and the stale "deleted native snapshot route"
message. Test-only; no engine code is touched.

## Layout invariants

Test-only change; no physical layout is touched.

1. **Single authority** — unchanged; nothing added or relocated.
2. **Commit canonicality** — unchanged.
3. **Derived views are caches** — unchanged. The entity point-snapshot cache is pre-existing; this
   only asserts that the lane it was written for reaches it.
4. **Atomic publication** — unchanged.
5. **GC from refs** — unchanged.
6. **SQL reads canonical records** — unchanged.

## Adapter API

None added, changed, or removed. No public API or SQL surface change.

## Gate

Full CI-scope gate on `ryzen-9950x-V`, scope re-read from `origin/main:.github/workflows/ci.yml`:

```
cargo clippy --profile test --workspace --all-targets --all-features -- -D warnings
cargo test --profile test --workspace --exclude lix_benchmarks --all-features --no-fail-fast
cargo test --profile test -p lix_benchmarks --features storage-benches,slatedb,root-replay-trace --no-fail-fast
cargo check -p lix --no-default-features
cargo check -p lix_js_sdk --target wasm32-unknown-unknown
```

**Gated SHA: `a3edcb7ef9798f1ac7b16cfcf96bd5858de962a9`** — identical to this branch's pushed tip
(`git rev-parse origin/claude-5-fix-entity-pk-route-test`). The gate ran from a clean
`git checkout --detach origin/<branch>` on the build machine, so the tree that was gated is the tree
that is published. See the closing section for why this is now worth stating explicitly.

| phase | exit | result |
|---|---|---|
| `clippy --profile test --workspace --all-targets --all-features -- -D warnings` | 0 | **0 warnings** |
| workspace tests (`--no-fail-fast`) | 0 | 3477 passed / 0 failed |
| `lix_benchmarks` tests (`--no-fail-fast`) | 0 | 26 passed / 0 failed |
| `cargo check -p lix --no-default-features` | 0 | clean |
| `cargo check -p lix_js_sdk --target wasm32-unknown-unknown` | 0 | clean |

**Combined: 3503 passed / 0 failed. Zero failures, zero clippy warnings.**

Reconciliation against the expected 3502: my previous gate measured 3501/1 on top of `9e22c61a`.
The head has since taken #1373, #1374 and #1376, which add tests; 3503 is that count plus the
formerly-failing test now passing. Full logs captured to files and grepped for `failures:`,
`panicked`, `test result: FAILED` and `^error` — not tailed.

`tracked_state::context::tests::availability_proof_is_bounded_on_commit_and_total_on_repair`, the
1-in-23 flake #1372 reported, did **not** fire in this run.

## A green branch gate does not imply a green integration head

The coordinator asked for this lesson in the PR body, and this incident sharpens it into two distinct
failure modes that need different defences:

1. **The one people expect:** a branch gates green, and the *merge* breaks it. Defence: gate the
   merged head, not the pre-merge branch.
2. **The one that actually happened here, which no amount of merged-head gating on someone else's
   part would have prevented at the source:** the gate was green on a **working tree** that was never
   pushed. The branch as published was red at its own tip. A reported gate result is evidence about a
   tree, not about a commit, unless the tree and the commit are known to be the same thing.

The cheap defence for (2) is to run the gate **after** the final `git push -f`, from a clean checkout
of the pushed SHA — which is what the runbook's `git reset --hard origin/<branch>` step on the build
machine already does, provided nothing is edited afterwards. The trap is editing, gating, and *then*
amending or squashing. Worth stating explicitly in the runbook: **the SHA you gated must be the SHA
you pushed — print `git rev-parse HEAD` inside the gate run and quote it in the PR body**, so the
claim is falsifiable rather than merely asserted. This PR's gate log does that.
