### PR TITLE
test(lix): restore the dropped entity-routing assertion and de-flake the availability proof

### DIFF
--- a/packages/lix/src/sql2/exec/datafusion.rs
+++ b/packages/lix/src/sql2/exec/datafusion.rs
@@ -4838,12 +4838,16 @@ mod tests {
                 ],
             ]
         );
-        assert_eq!(scans.load(Ordering::SeqCst), 1);
+        // An `IN` list over the whole primary key is an exact identity set, so
+        // the provider routes it through the registered entity-snapshot reader
+        // and never needs the generic visibility scan. The reader is handed the
+        // deduplicated identities and no residual predicate, because the
+        // identity access path applies that predicate in full.
+        assert_eq!(scans.load(Ordering::SeqCst), 0);
         let requests = requests.lock().expect("captured snapshot requests lock");
-        assert!(
-            requests.is_empty(),
-            "DataFusion reads must not invoke the deleted native snapshot route"
-        );
+        assert_eq!(requests.len(), 1);
+        assert_eq!(requests[0].filter.entity_pks.len(), 2);
+        assert!(requests[0].filter.constraints.is_empty());
     }
 
     #[tokio::test]

--- a/packages/lix/src/tracked_state/context.rs
+++ b/packages/lix/src/tracked_state/context.rs
@@ -8594,12 +8594,20 @@ mod tests {
     /// repair still proves the whole closure. Pins both halves, because the
     /// difference between them is the entire cost argument: the commit path
     /// walks one root-to-leaf path, repair walks every row.
+    ///
+    /// This sweeps every non-root chunk rather than damaging one of them.
+    /// Picking a single chunk cannot express the property: `Addressable` walks
+    /// root -> leftmost child -> leaf, so damaging a chunk *on* that path
+    /// legitimately defeats the bounded probe too, and only damage *off* it
+    /// separates the two proofs. An earlier version selected the target by
+    /// iterating a `HashSet`, whose order varies with the thread-local
+    /// `RandomState` seed, and so damaged an on-path chunk in roughly 5% of
+    /// runs — a flake that reproduced only under parallel test execution.
+    /// Sweeping pins the whole partition instead of guessing a member of it.
     #[tokio::test]
     async fn availability_proof_is_bounded_on_commit_and_total_on_repair() {
         use crate::tracked_state::commit_root_rebuild::RootAvailabilityProof;
 
-        let tracked_state = TrackedStateContext::new();
-        let storage = StorageAdapter::new(Memory::new());
         // Wide enough that the tree is more than one chunk, so "the root chunk"
         // and "the closure" are actually different sets.
         let rows = (0..4000)
@@ -8612,17 +8620,26 @@ mod tests {
                 )
             })
             .collect::<Vec<_>>();
-        write_root_for_test(&storage, &tracked_state, "gen", None, &rows)
-            .await
-            .expect("wide genesis root should write");
-        write_rootless_commit_for_test(
-            &storage,
-            "a1",
-            "gen",
-            &[row_with_value("entity-a1", "a1-change", "a1", "a1")],
-        )
-        .await;
 
+        // Rebuilt per damaged chunk: the damage is a delete, so each candidate
+        // needs an undamaged fixture of its own.
+        async fn seeded_fixture(rows: &[MaterializedTrackedStateRow]) -> StorageAdapter {
+            let tracked_state = TrackedStateContext::new();
+            let storage = StorageAdapter::new(Memory::new());
+            write_root_for_test(&storage, &tracked_state, "gen", None, rows)
+                .await
+                .expect("wide genesis root should write");
+            write_rootless_commit_for_test(
+                &storage,
+                "a1",
+                "gen",
+                &[row_with_value("entity-a1", "a1-change", "a1", "a1")],
+            )
+            .await;
+            storage
+        }
+
+        let storage = seeded_fixture(&rows).await;
         let read = storage
             .begin_read(StorageReadOptions::default())
             .await
@@ -8632,64 +8649,97 @@ mod tests {
             .expect("genesis root should load")
             .expect("genesis root should exist");
         drop(read);
-        let chunks = stored_tree_chunk_hashes_for_test(&storage).await;
+        let root_bytes = *root_id.as_bytes();
+        let mut candidates = stored_tree_chunk_hashes_for_test(&storage)
+            .await
+            .into_iter()
+            .filter(|chunk| chunk != &root_bytes)
+            .collect::<Vec<_>>();
+        // Sorted so the sweep, and any failure message, is reproducible.
+        candidates.sort_unstable();
         assert!(
-            chunks.len() > 2,
-            "fixture must build a multi-chunk tree, got {} chunks",
-            chunks.len()
+            candidates.len() > 1,
+            "fixture must build a multi-chunk tree, got {} non-root chunks",
+            candidates.len()
         );
+        drop(storage);
 
-        // Damage a chunk that is not the root and not on the leftmost path, so
-        // only a total traversal can notice it.
-        let mut damaged_chunk = None;
-        for chunk in chunks.iter() {
-            if chunk != root_id.as_bytes() {
-                damaged_chunk = Some(*chunk);
+        let mut resumed_from_damaged_root = 0usize;
+        let mut rejected_damaged_root = 0usize;
+        for candidate in &candidates {
+            let storage = seeded_fixture(&rows).await;
+            let mut writes = storage.new_write_set();
+            writes.delete(
+                storage::TRACKED_STATE_TREE_CHUNK_SPACE,
+                crate::storage_adapter::StorageKey(Bytes::copy_from_slice(candidate)),
+            );
+            storage
+                .commit_write_set(writes, StorageWriteOptions::default())
+                .await
+                .expect("chunk delete should commit");
+
+            let read = storage
+                .begin_read(StorageReadOptions::default())
+                .await
+                .expect("probe read should open");
+            let bounded = crate::tracked_state::commit_root_rebuild::
+                load_rebuild_plans_to_nearest_available_root_with_proof(
+                    &read,
+                    "a1",
+                    true,
+                    RootAvailabilityProof::Addressable,
+                )
+                .await
+                .expect("bounded probe should load plans");
+            let total = crate::tracked_state::commit_root_rebuild::
+                load_rebuild_plans_to_nearest_available_root_with_proof(
+                    &read,
+                    "a1",
+                    true,
+                    RootAvailabilityProof::Complete,
+                )
+                .await
+                .expect("total probe should load plans");
+
+            // Repair distrusts the chunk plane, so *every* damaged closure
+            // makes it walk back past the resume point. This half holds for
+            // every chunk, on the addressable path or not.
+            assert_eq!(
+                total.len(),
+                2,
+                "explicit repair must reject a resume point with a damaged closure \
+                 and replay past it (chunk {candidate:02x?})"
+            );
+            match bounded.len() {
+                1 => resumed_from_damaged_root += 1,
+                2 => rejected_damaged_root += 1,
+                other => panic!(
+                    "bounded probe returned {other} plans for chunk {candidate:02x?}; \
+                     expected 1 (resumed) or 2 (walked back)"
+                ),
             }
         }
-        let damaged_chunk = damaged_chunk.expect("a non-root chunk exists");
-        let mut writes = storage.new_write_set();
-        writes.delete(
-            storage::TRACKED_STATE_TREE_CHUNK_SPACE,
-            crate::storage_adapter::StorageKey(Bytes::copy_from_slice(&damaged_chunk)),
-        );
-        storage
-            .commit_write_set(writes, StorageWriteOptions::default())
-            .await
-            .expect("chunk delete should commit");
 
-        let read = storage
-            .begin_read(StorageReadOptions::default())
-            .await
-            .expect("probe read should open");
-        let bounded = crate::tracked_state::commit_root_rebuild::
-            load_rebuild_plans_to_nearest_available_root_with_proof(
-                &read,
-                "a1",
-                true,
-                RootAvailabilityProof::Addressable,
-            )
-            .await
-            .expect("bounded probe should load plans");
-        assert_eq!(
-            bounded.len(),
-            1,
-            "the commit path resumes from an addressable root and does not re-derive closure completeness"
+        // The commit path does not re-derive closure completeness: damage that
+        // its one root-to-leaf walk never touches leaves the root resumable.
+        assert!(
+            resumed_from_damaged_root > 0,
+            "the commit path must resume from a root whose closure is damaged off \
+             the addressable path"
         );
-
-        let total = crate::tracked_state::commit_root_rebuild::
-            load_rebuild_plans_to_nearest_available_root_with_proof(
-                &read,
-                "a1",
-                true,
-                RootAvailabilityProof::Complete,
-            )
-            .await
-            .expect("total probe should load plans");
-        assert_eq!(
-            total.len(),
-            2,
-            "explicit repair must reject a resume point with a damaged closure and replay past it"
+        // ...and the bounded probe is not vacuous: damage *on* that walk still
+        // rejects the root.
+        assert!(
+            rejected_damaged_root > 0,
+            "the bounded probe must still reject a root whose addressable path is damaged"
+        );
+        // The whole cost argument: the bounded probe reads one root-to-leaf
+        // path, not the closure. If it read everything, every chunk would
+        // reject.
+        assert!(
+            rejected_damaged_root < candidates.len(),
+            "the bounded probe walks one root-to-leaf path, so it cannot notice \
+             every chunk in the closure"
         );
     }
 


### PR DESCRIPTION
# test(lix): restore the dropped entity-routing assertion and de-flake the availability proof

**Machine:** `ryzen-9950x-III`. **Base SHA:** `d8d5131bc` (integration head).
Test-only change: no engine code, no public API, no SQL surface, no adapter API, no bytes on disk.

Two fixes, deliberately in **one commit** so a merge cannot apply one without the other — which is
exactly what went wrong with the first of them.

---

## 1. The integration head is red, and this restores it

### It is a dropped commit, not a semantic merge conflict

PR #1372 contained two commits: `3e3e16305` (the provider change) and `0ccd27ec1` (the test that
records the resulting routing). **The merge took the first and dropped the second.**

```
$ git merge-base --is-ancestor 3e3e16305 origin/claude-5-optimizations   -> present
$ git merge-base --is-ancestor 0ccd27ec1 origin/claude-5-optimizations   -> ABSENT

$ git show --stat 9e22c61a1
  Merge PR #1372: analyse entity row filters over residual filters only
   packages/lix/src/sql2/providers/entity.rs | 27 ++++++++++++++++++++++---
   1 file changed, 25 insertions(+), 2 deletions(-)
```

The merge commit touches **one file**. `datafusion.rs` was never carried over, so the head has the new
routing and the old assertion about it. Nothing about the combination with any other PR is involved —
no other change needs to be examined, and a bisect of `cb257285..96ebabb6` will land on #1372 for this
reason rather than an interaction one.

Verified on a **clean, unmodified `base` worktree**:

```
thread '…datafusion_entity_primary_key_read_uses_registered_provider' panicked at
packages/lix/src/sql2/exec/datafusion.rs:4841:9
  left: 0
 right: 1
test result: FAILED. 0 passed; 1 failed
```

This is **deterministic, not flaky** — it failed 53/53 full-suite runs. The head has been red since
that merge.

### The performance win is intact — `left: 0` is the win, not its loss

`scans` is the counter for the **generic visibility scan**. `left: 0` means the generic scan did not
run, i.e. the direct entity-snapshot route **was** taken. The old assertion demanded `1`, which is the
pre-change routing. So the failure is the test reporting the optimization working, not failing.

Measured directly on the integration head `d8d5131b`, warm SQL session, RocksDB, 5 000 hot repeats:

| rows | before #1372 | **at `d8d5131b`** | point cache |
|---:|---:|---:|---|
| 1 000 | 76.2 µs | 36.5 µs † | `hits=4999 misses=1` |
| 10 000 | 79.6 µs | **29.8 µs** | `hits=4999 misses=1` |
| 100 000 | 78.9 µs | **29.5 µs** | `hits=4999 misses=1` |

† first invocation of the sweep, a warm-up outlier; it measured 29.7 µs on my branch.

The point-snapshot cache is being consulted and hit at every size, and the floor is the same ~29 µs
my branch measured. **None of the 2.7x is lost in integration.** The only thing wrong at the head is
the stale assertion, which this commit re-applies.

This commit re-applies the dropped assertion verbatim: `scans == 0`, and one recorded snapshot
request carrying the two deduplicated identities and no residual constraint. The justification is
unchanged from #1372 and was reviewed there: `scan_direct_entity_snapshots` builds an
`EntityPointSnapshotCacheKey` only for the single-entity-pk shape, so a route that exists solely to
serve a point read by primary key cannot also be contractually forbidden from serving it. The test's
public-behaviour assertions (returned columns and rows) were never touched.

---

## 2. `availability_proof_is_bounded_on_commit_and_total_on_repair` — diagnosis

**Verdict: a test-harness artifact. Not an ordering or visibility bug.** No engine concurrency is
involved, and nothing about this needs to change in the correctness story.

### Root cause

The test damages one tree chunk and asserts the bounded (`Addressable`) probe still resumes from the
root while the total (`Complete`) probe walks past it. It chose the chunk like this:

```rust
let chunks = stored_tree_chunk_hashes_for_test(&storage).await;   // -> HashSet
let mut damaged_chunk = None;
for chunk in chunks.iter() {
    if chunk != root_id.as_bytes() {
        damaged_chunk = Some(*chunk);          // keeps the LAST in iteration order
    }
}
```

Two things collide:

- `RootAvailabilityProof::Addressable` is `limit: Some(1)`, and its own doc says the scan "walks
  root -> leftmost overlapping child -> leaf and stops". So damage **on that path** legitimately
  defeats the bounded probe. The test's comment claims it damages a chunk "not on the leftmost path",
  but **the code only excludes the root chunk** — the leftmost-path condition was never implemented.
- `chunks` is a `HashSet`. Its iteration order depends on the `RandomState` seed, which is drawn from
  a thread-local counter that advances per `HashSet` constructed on that thread. Run the test alone
  and the order is stable; run it inside the full suite and it depends on how many hash maps that
  worker thread built first. That is precisely why it reproduced only under parallel execution.

### Measurement

I swept every candidate: rebuild the fixture, damage exactly one chunk, record both probes.

```
E18: total chunks = 41
E18: SUMMARY bounded==1 for 38 chunks, bounded!=1 for 2 chunks
```

- 41 chunks: 1 root + 40 candidates.
- **2 of 40 candidates (5.0%)** are on the addressable path and make the bounded probe return 2 plans.
- The other 38 return 1 plan.
- `total` is **2 for every single candidate** — the repair half of the test was never at risk.

5.0% matches the observed failure rate (1 in 23 full-suite runs on the unmodified base worktree at
`f3c37056`) within sampling error. The engine behaved correctly in **both** outcomes; the test simply
did not control which one it asked for.

### Fix

Sweep every non-root chunk in sorted order and pin the *partition* rather than guessing a member of
it. The assertions become:

- `total == 2` for **every** candidate — repair distrusts the chunk plane unconditionally.
- at least one candidate leaves the root resumable (`bounded == 1`) — the commit path does not
  re-derive closure completeness;
- at least one candidate rejects it (`bounded == 2`) — the bounded probe is not vacuous;
- the rejecting set is strictly smaller than the candidate set — the probe reads one root-to-leaf
  path, not the closure. **This is the cost argument in the doc comment, now actually asserted.**

Any bounded value other than 1 or 2 panics with the offending chunk hash. There is no `HashSet`
ordering dependence left, and the test no longer depends on tree fanout: if the layout changes, the
partition sizes change but every assertion still holds.

Cost: the test goes from ~0.04 s to **1.55 s** (41 fixture builds on in-memory storage). The suite is
wall-clock unchanged at ~11.8 s because it runs in parallel.

I checked for the same pattern elsewhere: `stored_tree_chunk_hashes_for_test` has three other callers
(`context.rs:8280/8292/8309`) and all use the result for order-independent set comparison. The other
`for chunk in chunks.iter()` sites in `binary_cas/kv.rs` iterate `Vec`s. This was the only instance.

---

## Evidence that the flake is gone

| tree | full-suite runs (`cargo test -p lix --lib --all-features`) | `availability_proof` failures |
|---|---:|---:|
| base @ `f3c37056`, unmodified | 23 | **1** |
| this branch | 53+ | **0** |

At the measured 4.3% rate, 53 clean runs put the probability of seeing zero failures by luck at ~9%,
so the soak alone would be suggestive rather than conclusive. The **mechanistic** result is what
settles it: the sweep enumerated the poisoned set exactly (2 of 40), and the new test cannot select a
member of that set because it selects every member and asserts the partition. The nondeterministic
input — `HashSet` iteration order — is gone from the test entirely.

(Those 53 runs were taken before fix 1 was applied, so they failed on the *datafusion* test while
passing `availability_proof` in every single run.)

## Layout invariants

Not applicable in substance — this is a test-only change. No authority, commit record, derived view,
publication path, GC root, or query surface is touched. For completeness: (1) no new authority,
(2) commit canonicality untouched, (3) no derived view changed, (4) no publication path changed,
(5) no retention metadata touched, (6) no query surface changed.

## Gate

`ryzen-9950x-III`, against `ci.yml` from `origin/main`, `--no-fail-fast`, full log captured and
grepped (never tailed):

```
cargo check --workspace --all-targets --all-features
cargo clippy --profile test --workspace --all-targets --all-features -- -D warnings
cargo test --profile test --workspace --exclude lix_benchmarks --all-features --no-fail-fast
cargo test --profile test -p lix_benchmarks --features storage-benches,slatedb,root-replay-trace --no-fail-fast
cargo check -p lix --no-default-features
cargo check -p lix_js_sdk --target wasm32-unknown-unknown
```

**Green: 3503 passed / 0 failed across 66 test targets, 0 clippy warnings**, both feature-variant
checks clean. (Baseline 3470/0/0; the head was red before this branch.)

## What regressed

Nothing. One test's runtime rises 0.04 s → 1.55 s, absorbed by parallelism. No timing, bytes, or
version-control metric can move: no non-test code is touched.
