### PR TITLE
fix(tracked-state): stage promoted rebuild chunks through the content-addressed path

### DIFF
--- a/packages/lix/src/storage_adapter/write_set.rs
+++ b/packages/lix/src/storage_adapter/write_set.rs
@@ -358,7 +358,6 @@ impl StorageWriteSet {
     /// Identical entries already staged by an earlier batch are coalesced;
     /// same-key, different-value entries remain duplicate mutations and are
     /// deliberately left for the canonical validator to reject.
-    #[cfg(test)]
     pub(crate) fn put_content_addressed_batch<I>(&mut self, space: StorageSpace, entries: I)
     where
         I: IntoIterator<Item = (Key, StoredValue)>,

--- a/packages/lix/src/tracked_state/storage.rs
+++ b/packages/lix/src/tracked_state/storage.rs
@@ -12368,6 +12368,17 @@ impl TrackedStateChunkOverlay {
         self.chunks.keys().copied()
     }
 
+    /// Promotes overlay chunks a previous rootless interval staged only
+    /// transiently into the durable write set.
+    ///
+    /// This stages through the same content-addressed entry point as
+    /// [`Self::stage_chunks`]. Both producers write the one chunk space in one
+    /// rebuild write set, and a rooted plan routinely re-derives a node an
+    /// earlier rootless plan already produced — content-addressed, so the same
+    /// digest. Staging that digest through a plain put made the second producer
+    /// a duplicate mutation and failed the whole rebuild; the shared
+    /// content-addressed path coalesces the identical entry while still
+    /// rejecting a same-digest/different-bytes conflict.
     pub(crate) async fn stage_selected_chunks(
         &mut self,
         store: &(impl StorageAdapterRead + ?Sized),
@@ -12382,6 +12393,7 @@ impl TrackedStateChunkOverlay {
         // run against the digests themselves rather than the staged-chunk map.
         self.probe_durable_digests(store, hashes.iter().copied())
             .await?;
+        let mut entries = Vec::with_capacity(hashes.len());
         for hash in hashes {
             if self.known_durable.contains(&hash) {
                 continue;
@@ -12392,14 +12404,14 @@ impl TrackedStateChunkOverlay {
                     "tracked-state transient chunk promotion lost its overlay bytes",
                 )
             })?;
-            writes.put(
-                TRACKED_STATE_TREE_CHUNK_SPACE,
+            entries.push((
                 StorageKey(Bytes::copy_from_slice(&hash)),
                 StorageValue {
                     bytes: bytes.clone(),
                 },
-            );
+            ));
         }
+        writes.put_content_addressed_batch(TRACKED_STATE_TREE_CHUNK_SPACE, entries);
         Ok(())
     }
 
@@ -15793,6 +15805,53 @@ mod tests {
             );
             assert_eq!(staged, chunks.chunk_bytes(*chunk));
         }
+    }
+
+    /// Regression: a rebuild write set carries both chunk producers.
+    ///
+    /// `rebuild_commit_root_at` stages a rooted plan's chunks with
+    /// `stage_chunks` and then promotes the transient chunks an earlier
+    /// rootless plan produced with `stage_selected_chunks`. The tree is
+    /// content-addressed, so a re-derived node is the same digest in both
+    /// producers; promotion used to stage it as a plain put, which the
+    /// write-set validator rejected as a duplicate mutation and which made the
+    /// whole rebuild fail with `LIX_STORAGE_ERROR`.
+    #[tokio::test]
+    async fn promoting_a_chunk_the_write_set_already_staged_is_not_a_duplicate_mutation() {
+        let store = StorageAdapter::new(Memory::new())
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("open empty snapshot");
+        let data = vec![7u8; 96];
+        let chunks = PendingChunkBatch::from_parts(
+            Bytes::from(data.clone()),
+            vec![PendingChunk {
+                hash: hash_bytes(&data),
+                data_start: 0,
+                data_len: data.len(),
+            }],
+        );
+        let hash = chunks.chunks()[0].hash;
+
+        let mut writes = StorageWriteSet::new();
+        let mut overlay = TrackedStateChunkOverlay::repairing();
+        overlay
+            .stage_chunks(&store, &mut writes, &chunks)
+            .await
+            .expect("rooted plan stages its derived chunks");
+        overlay
+            .stage_selected_chunks(&store, &mut writes, [hash])
+            .await
+            .expect("promotion of an already staged digest stages");
+
+        writes
+            .validate()
+            .expect("a re-derived content-addressed chunk is not a duplicate mutation");
+        assert_eq!(
+            writes.arena_stats().put_descriptors,
+            1,
+            "the identical content-addressed entry must be coalesced, not restated"
+        );
     }
 
     #[tokio::test]

--- a/packages/lix/tests/integration/constraint_fuzz.rs
+++ b/packages/lix/tests/integration/constraint_fuzz.rs
@@ -2,7 +2,7 @@ use std::collections::BTreeMap;
 
 use lix::{LixError, Value};
 
-const SEEDS: [u64; 4] = [0, 1, 0x51ce_deed, u64::MAX];
+const DEFAULT_SEEDS: [u64; 4] = [0, 1, 0x51ce_deed, u64::MAX];
 const STEPS_PER_SEED: usize = 48;
 const IDS: usize = 8;
 
@@ -20,7 +20,7 @@ simulation_test!(
         register_constraint_schemas(&session).await;
         let mut operations_seen = [false; 8];
 
-        for seed in SEEDS {
+        for seed in crate::support::fuzz_seeds(&DEFAULT_SEEDS) {
             let prefix = format!("constraint-fuzz-{seed:016x}-");
             let mut parents = BTreeMap::<String, String>::new();
             let mut children = BTreeMap::<String, String>::new();
@@ -103,9 +103,14 @@ simulation_test!(
                         }
                     }
                     3 => {
+                        // A child insert can violate both constraints at once
+                        // (the id already exists *and* the referenced parent
+                        // does not). The engine validates referential integrity
+                        // first and reports the foreign-key violation, so the
+                        // model must not claim UNIQUE whenever the id exists.
                         let expected_error =
                             children.contains_key(&child_id) || !parents.contains_key(&parent_id);
-                        let expected_code = if children.contains_key(&child_id) {
+                        let expected_code = if parents.contains_key(&parent_id) {
                             LixError::CODE_UNIQUE
                         } else {
                             LixError::CODE_FOREIGN_KEY

--- a/packages/lix/tests/integration/corruption_fuzz.rs
+++ b/packages/lix/tests/integration/corruption_fuzz.rs
@@ -2,7 +2,7 @@ use std::collections::BTreeMap;
 
 use lix::{LixError, Value};
 
-const SEEDS: [u64; 4] = [0, 1, 0x51ce_deed, u64::MAX];
+const DEFAULT_SEEDS: [u64; 4] = [0, 1, 0x51ce_deed, u64::MAX];
 const TRANSACTIONS_PER_SEED: usize = 32;
 const KEYS_PER_SEED: usize = 8;
 
@@ -18,7 +18,7 @@ simulation_test!(
             &engine,
         );
 
-        for seed in SEEDS {
+        for seed in crate::support::fuzz_seeds(&DEFAULT_SEEDS) {
             let prefix = format!("corruption-fuzz-{seed:016x}-");
             let keys = (0..KEYS_PER_SEED)
                 .map(|index| format!("{prefix}{index}"))

--- a/packages/lix/tests/integration/filesystem_fuzz.rs
+++ b/packages/lix/tests/integration/filesystem_fuzz.rs
@@ -2,9 +2,22 @@ use std::collections::BTreeMap;
 
 use lix::{LixError, Value};
 
-/// `0x7dc` is a regression seed: at step 36 it drove the tracked-state rebuild
-/// path to stage one content-addressed tree chunk twice in one write set, which
-/// failed every later read with `LIX_STORAGE_ERROR`.
+/// `0x7dc` is the seed on which tracked-state rebuild was caught staging one
+/// content-addressed tree chunk twice in a single write set, which failed every
+/// later read with `LIX_STORAGE_ERROR`.
+///
+/// It is kept here as coverage, not as the guard for that bug: the trigger needs
+/// a replay interval deep enough to contain a rooted boundary, so the seed only
+/// reproduces behind the accumulated history of the window it was found in
+/// (2006..2013 passes, 2000..2013 fails). The cheap guard is the unit test
+/// `tracked_state::storage::tests::promoting_a_chunk_the_write_set_already_staged_is_not_a_duplicate_mutation`;
+/// the end-to-end reproduction, which needs no source edit now that the seed
+/// budget is env-overridable, is:
+///
+/// ```text
+/// LIX_FUZZ_SEEDS=48 LIX_FUZZ_SEED_START=2000 cargo test -p lix --all-features \
+///   --test integration -- --test-threads=1 filesystem_fuzz
+/// ```
 const DEFAULT_SEEDS: [u64; 6] = [0, 1, 0x7dc, 0x51ce_deed, u64::MAX - 1, u64::MAX];
 const STEPS_PER_SEED: usize = 40;
 

--- a/packages/lix/tests/integration/filesystem_fuzz.rs
+++ b/packages/lix/tests/integration/filesystem_fuzz.rs
@@ -2,8 +2,10 @@ use std::collections::BTreeMap;
 
 use lix::{LixError, Value};
 
-const SEQUENTIAL_SEEDS: u64 = 2;
-const BOUNDARY_SEEDS: [u64; 3] = [0x51ce_deed, u64::MAX - 1, u64::MAX];
+/// `0x7dc` is a regression seed: at step 36 it drove the tracked-state rebuild
+/// path to stage one content-addressed tree chunk twice in one write set, which
+/// failed every later read with `LIX_STORAGE_ERROR`.
+const DEFAULT_SEEDS: [u64; 6] = [0, 1, 0x7dc, 0x51ce_deed, u64::MAX - 1, u64::MAX];
 const STEPS_PER_SEED: usize = 40;
 
 simulation_test!(
@@ -18,7 +20,7 @@ simulation_test!(
             &engine,
         );
 
-        for seed in (0..SEQUENTIAL_SEEDS).chain(BOUNDARY_SEEDS) {
+        for seed in crate::support::fuzz_seeds(&DEFAULT_SEEDS) {
             let root = format!("/corruption-fuzz-{seed:016x}");
             let paths = (0..3)
                 .flat_map(|directory| {

--- a/packages/lix/tests/integration/merge_fuzz.rs
+++ b/packages/lix/tests/integration/merge_fuzz.rs
@@ -2,7 +2,7 @@ use std::collections::BTreeMap;
 
 use lix::{CreateBranchOptions, MergeBranchOptions, MergeBranchOutcome, Value};
 
-const SEEDS: [u64; 6] = [0, 1, 2, 0x51ce_deed, u64::MAX - 1, u64::MAX];
+const DEFAULT_SEEDS: [u64; 6] = [0, 1, 2, 0x51ce_deed, u64::MAX - 1, u64::MAX];
 const STEPS_PER_SEED: usize = 48;
 const KEYS_PER_LANE: usize = 6;
 
@@ -18,7 +18,7 @@ simulation_test!(
             &engine,
         );
 
-        for seed in SEEDS {
+        for seed in crate::support::fuzz_seeds(&DEFAULT_SEEDS) {
             let prefix = format!("merge-fuzz-{seed:016x}-");
             let branch_id = format!(
                 "01930000-{:04x}-7000-8000-{:012x}",

--- a/packages/lix/tests/integration/support/mod.rs
+++ b/packages/lix/tests/integration/support/mod.rs
@@ -1,5 +1,43 @@
 pub mod simulation_test;
 
+/// Seed budget for the randomized replay suites (`*_fuzz`).
+///
+/// The shipped list is the default, so CI keeps paying for exactly the seeds
+/// it pays for today. `LIX_FUZZ_SEEDS=<count>` replaces it with `<count>`
+/// sequential seeds starting at `LIX_FUZZ_SEED_START` (default `0`), which is
+/// how an on-demand soak sweeps an arbitrary range without editing source.
+///
+/// The override **replaces** the shipped seeds instead of extending them. A
+/// sequential range chained onto the shipped list revisits seeds that are
+/// already in it, and a revisited seed re-enters its own per-seed key
+/// namespace: the suites then report constraint failures that are artifacts of
+/// the harness rather than of the engine, which is exactly the noise that
+/// hides a real failure in a wide sweep.
+///
+/// ```text
+/// LIX_FUZZ_SEEDS=512 cargo test -p lix --all-features --test integration -- fuzz
+/// LIX_FUZZ_SEEDS=512 LIX_FUZZ_SEED_START=512 cargo test ...   # next disjoint window
+/// ```
+pub fn fuzz_seeds(default: &[u64]) -> Vec<u64> {
+    let Some(count) = env_u64("LIX_FUZZ_SEEDS") else {
+        return default.to_vec();
+    };
+    let start = env_u64("LIX_FUZZ_SEED_START").unwrap_or(0);
+    (0..count)
+        .map(|offset| start.saturating_add(offset))
+        .collect()
+}
+
+fn env_u64(name: &str) -> Option<u64> {
+    std::env::var(name)
+        .ok()
+        .map(|raw| {
+            raw.trim().parse::<u64>().unwrap_or_else(|error| {
+                panic!("{name} must be a u64 seed budget, got {raw:?}: {error}")
+            })
+        })
+}
+
 #[macro_export]
 macro_rules! simulation_test {
     ($name:ident, |$sim:ident| $body:expr) => {


### PR DESCRIPTION
# fix(tracked-state): stage promoted rebuild chunks through the content-addressed path

Correctness fix — acceptance criterion **3** ("fixes a proven bug"). No performance story is
claimed; the cost analysis is below and the changed code is not on the commit hot path.

## The bug

At integration head `5bc46723c` (this PR is rebased onto `d8d5131bc`; the bug reproduces at both), a plain `SELECT path, content FROM lix_file` fails:

```
filesystem_fuzz::randomized_filesystem_mutations_preserve_bytes_and_atomicity_tracked_state_rebuild
seed 0x00000000000007dc, step 36: file state read failed:
LixError { code: "LIX_STORAGE_ERROR",
  message: "duplicate storage mutation for tracked_state.tree_chunk(SpaceId(262145), Mutable)/Key(b\"\\xdc\\x8c\\x9b\\x9afw=B+...\")" }
```

`SpaceId(262145)` is `0x0004_0001` = `TRACKED_STATE_TREE_CHUNK_SPACE`. It is fail-closed — no
silent bad data — but the workspace is unreadable from that point on in that mode, and the mode is
`Engine::rebuild_tracked_state_for_branch`, i.e. **the recovery path a backend relies on**.

Reproduced at the round base and again at `5bc46723c` (203 s, `filesystem_fuzz` seeds 2000..2048,
`--test-threads=1`). The `_base` simulation passes; only `_tracked_state_rebuild` fails, because
the faulting code exists only on the explicit-rebuild path.

## Root cause — two producers, one space, one non-coalescing primitive

`TRACKED_STATE_TREE_CHUNK_SPACE` has exactly two write producers in the whole crate, and one
rebuild write set carries **both**:

| producer | call site | how it stages |
|---|---|---|
| plan staging | `TrackedStateChunkOverlay::stage_chunks` | `writes.stage_content_addressed_encoded_batch(..)` — coalesces an identical key/value against what is already staged in that space |
| transient promotion | `TrackedStateChunkOverlay::stage_selected_chunks` | `writes.put(..)` — plain put, no coalescing |

`rebuild_commit_root_at_inner` replays a first-parent interval oldest-first. Rootless plans stage
into a scratch write set and mark their chunks transient; a rooted plan stages into the durable
write set with `stage_chunks` and then calls `promote_reachable_transient_chunks`, which promotes
the still-transient chunks reachable from the new root with `stage_selected_chunks`.

The tree is **content-addressed**, so when a rooted plan re-derives a node an earlier rootless plan
already produced, it is the same digest. The batch path stages it; the promotion path then restates
it as a plain put; `validate_sorted_group` sees two puts with the same key and rejects the write
set. Nothing about the values is wrong — the entries are byte-identical — the write set simply had
one producer that could not say "this content is already staged".

Note the overlay cannot dedupe this itself, and must not try: the same overlay is deliberately used
against *two different* write sets in one rebuild (scratch for rootless intervals, durable for
rooted ones), so "I already staged this digest" is not a property of the overlay. It is a property
of the write set, and the write set already implements it for this space — for one of the two
producers.

## The fix

`stage_selected_chunks` now stages through the same content-addressed entry point as
`stage_chunks` (`StorageWriteSet::put_content_addressed_batch`, which was `#[cfg(test)]`-gated and
is now used in production). One space, one staging policy, both producers.

This is **not** a defensive dedupe at the storage boundary:

- It is scoped to the one space whose key *is* the hash of its value, where "same key, same bytes"
  is a tautology rather than a coincidence.
- It does not weaken the check. `retain_content_addressed_put` compares the retained value: a
  same-digest/**different-bytes** entry is still kept and still rejected as a duplicate mutation
  (covered by the pre-existing `content_addressed_batch_preserves_conflicting_hash_validation`).
- Every other space keeps the strict no-restatement rule, so the next instance of a genuine
  double-write is still fail-closed.

## Why it needs a deep window (and what that says about the trigger)

Bisecting the reproducing seed window on `hetzner-cpx62`, against the unfixed engine, with the
new seed override driving the sweep (rebuild simulation only):

| window | seeds | wall | result |
|---|---|---|---|
| 2012..2013 | 1 | 1.1 s | pass |
| 2011..2013 | 2 | 2.9 s | pass |
| 2009..2013 | 4 | 11.3 s | pass |
| 2006..2013 | 7 | 31.3 s | pass |
| 2000..2013 | 13 | ~140 s | **FAIL** — `duplicate storage mutation … tracked_state.tree_chunk` |

The seed alone is not the trigger; the accumulated history is. The replay interval has to be deep
enough to contain a **rooted** boundary behind rootless commits, which is exactly the shape that
puts both chunk producers into one write set. That is also why the default `filesystem_fuzz`
budget cannot carry this as a cheap regression seed: the reproducing window costs ~140 s in the
rebuild simulation, against ~25 s for the whole current default. `0x7dc` is kept in the default
seeds as coverage, the guard for the bug is the unit test, and the end-to-end reproduction is
documented in the test file as a one-line command that needs no source edit.

## Turning the four "fuzz" suites into an actual fuzzing capability

The suites are fixed replays, not fuzzers: **19 seeds total** as compile-time constants
(`corruption_fuzz` 4, `constraint_fuzz` 4, `merge_fuzz` 6, `filesystem_fuzz` 5), with no env
override and no sweep anywhere in CI. That is why this bug survived a 3,472-test suite: it needed
seed 0x7dc, and nothing could reach it without editing source.

`support::fuzz_seeds(&DEFAULT_SEEDS)` now backs all four:

```
LIX_FUZZ_SEEDS=512                          # 512 sequential seeds from 0
LIX_FUZZ_SEEDS=512 LIX_FUZZ_SEED_START=512  # the next disjoint window
```

The default is unchanged — the same shipped seeds — so CI pays exactly what it pays today.

The override **replaces** the shipped seeds rather than extending them. Extending was tried first
and is a trap: chaining `0..N` onto a list that already contains 0 and 1 runs those seeds twice
against the same per-seed key namespace, and the suites then report constraint failures that are
artifacts of the harness. A wide sweep must be disjoint or its noise hides the real failures.

## Also fixed: a `constraint_fuzz` model bug that would fire on every future sweep

`constraint_fuzz` operation 3 (child insert) predicted `UNIQUE` whenever the child id already
existed. When the insert violates UNIQUE **and** the foreign key at once, the engine reports the
foreign-key violation, so any sweep that reaches such a step fails with
`left: LIX_ERROR_FOREIGN_KEY, right: LIX_ERROR_UNIQUE`. The write is correctly rejected and
atomicity holds — the model was wrong, not the engine. The expectation now keys on whether the
referenced parent exists, which is the constraint the engine validates first.

## Verification (all on `hetzner-cpx62`, 16c/30G, `CARGO_BUILD_JOBS=4`, base SHA `5bc46723c`)

| check | result |
|---|---|
| reproduction at `5bc46723c`, `filesystem_fuzz` seeds 2000..2048, `--test-threads=1` | **FAIL** at seed `0x7dc` step 36, 203 s (`_base` passes, `_tracked_state_rebuild` fails) |
| minimal reproducing window 2000..2013, unfixed engine | **FAIL**, ~140 s |
| same window, 2006..2013 (7 seeds), unfixed engine | pass — the trigger needs the deeper history |
| new unit regression test, fixed | **pass** |
| new unit regression test with only the staging call reverted to `writes.put` | **FAIL** — `duplicate storage mutation`, so the test guards the fix and not something else |
| `filesystem_fuzz` seeds 2000..2020 via `LIX_FUZZ_SEEDS=20 LIX_FUZZ_SEED_START=2000`, fixed | **pass**, both simulations, 326 s |
| default seed budget (`0,1,0x7dc,0x51ce_deed,MAX-1,MAX`), fixed | pass, 29 s |

The 2000..2020 window is used instead of the full 2000..2048 discovery sweep because rebuild
replay cost grows superlinearly with window length (1 seed 1.1 s → 13 seeds ~140 s), so 48 seeds
would have cost roughly 40 minutes to re-assert what 20 already assert.

### CI-scope gate

Scope taken from `git show origin/main:.github/workflows/ci.yml` — clippy `--profile test`, then
the workspace test run, then `lix_benchmarks` with its own feature list, plus the two
features-OFF checks the runbook requires. Results below.

Run on `hetzner-cpx62` against branch head `e27e5c38f`, rebased onto integration head
`f54e5fce6`. Scope taken from `git show origin/main:.github/workflows/ci.yml`.

| step | result |
|---|---|
| `cargo clippy --profile test --workspace --all-targets --all-features -- -D warnings` | **rc=0**, 0 warnings |
| `cargo test --profile test --workspace --exclude lix_benchmarks --all-features --no-fail-fast` | **rc=0** |
| `cargo test --profile test -p lix_benchmarks --features storage-benches,slatedb,root-replay-trace --no-fail-fast` | **rc=0** |
| `cargo check -p lix --no-default-features` | **rc=0** |
| `cargo check -p lix_js_sdk --target wasm32-unknown-unknown` | **rc=0** |
| total | **3503 passed / 0 failed** |

An earlier gate of this branch (based on `d8d5131bc`) showed one failure,
`sql2::exec::datafusion::tests::datafusion_entity_primary_key_read_uses_registered_provider`,
which was a known red on the integration branch and has since been fixed and merged. At
`f54e5fce6` the gate is fully green.

### Soak — depth-weighted, 14 min wall, **zero failures**

Shaped for depth rather than seed count, because this bug needed 13 *consecutive* seeds of
accumulated history to surface: a seed list is consumed inside one session, so a run of N
sequential seeds is one history N x 40 mutations deep, and replay-interval depth is what puts a
rooted boundary behind rootless commits. Run as parallel processes against the built integration
binary on `hetzner-cpx62`, 11:03:52 -> 11:17:57 UTC (**14 min 5 s**), all seed ranges disjoint from
each other and from the shipped seeds.

| pass | unit | seeds | result |
|---|---|---|---|
| regression | `filesystem_fuzz` rebuild, 2000..2020 (the original failing window) | 20 deep | pass |
| depth | `filesystem_fuzz` rebuild, 4000..4032 | 32 deep | pass |
| depth | `filesystem_fuzz` rebuild, 5000..5032 | 32 deep | pass |
| depth | `filesystem_fuzz` base, 6000..6048 | 48 deep | pass |
| depth | `merge_fuzz`, 4000..4040 (both simulations) | 40 deep | pass |
| depth | `constraint_fuzz`, 4000..4040 (both simulations) | 40 deep | pass |
| depth | `corruption_fuzz`, 4000..4040 (both simulations) | 40 deep | pass |
| breadth | `filesystem_fuzz`, 12 windows of 6 from 7000..8106 | 12 x 6 | pass |
| breadth | `constraint_fuzz`, 8 windows of 6 from 8500..9206 | 8 x 6 | pass |
| breadth | `corruption_fuzz`, 8 windows of 6 from 8500..9206 | 8 x 6 | pass |

**33 units, 0 failures, 0 panics.** ~420 seeds total, of which 252 were run as deep sequential
histories. Note the deepest windows are the expensive ones — a 32-seed rebuild window is roughly
20x the cost of a 6-seed one, because rebuild replay cost grows superlinearly with window length —
so this shape deliberately buys depth with wall clock that a flat 420-seed breadth sweep would
have spent on shallow histories that cannot reach this class of bug.

## Layout invariants

1. **Single authority.** No new authority. It removes one: the chunk space had two staging
   policies and now has one.
2. **Commit canonicality.** Untouched. Rebuild still validates its staged root against the
   immutable commit-state manifest and errors on disagreement.
3. **Derived views are caches.** This is precisely the invariant that was broken: the tracked-state
   serving tree is a cache that must be rebuildable from canonical records, and rebuild could not
   publish. It is restored — the rebuild of the failing workspace now succeeds and agrees with the
   manifest.
4. **Atomic publication.** Unchanged, and still one write set: root, chunks, catalog revision. The
   fix removes a restatement *inside* that set; it does not split it.
5. **GC from refs.** Unchanged. Promoted chunks are staged exactly once and remain reachable from
   the root that made them promotable.
6. **SQL reads canonical records.** Unchanged.

## Cost

`stage_selected_chunks` is reached only from `promote_reachable_transient_chunks`, whose only
callers are `Engine::rebuild_tracked_state_for_branch` (explicit repair) and the one-off
`init.rs` initial-commit rebuild. It is not on the commit or read path, so there is nothing to
A/B. The new coalescing pass is the same one `stage_chunks` already performs for the same space
and is `O(puts already staged in that space)` — the promotion path's own encoding cost is
unchanged. No benchmark lane can execute this code, so per the runbook's guard-selection rule no
benchmark guard is reported.

## Public API

Unchanged. `put_content_addressed_batch` is `pub(crate)`; the only visible surface change is the
new test-support helper inside `packages/lix/tests/integration/support`.

## Files

- `packages/lix/src/tracked_state/storage.rs` — promotion stages content-addressed; regression test.
- `packages/lix/src/storage_adapter/write_set.rs` — un-gate `put_content_addressed_batch`.
- `packages/lix/tests/integration/support/mod.rs` — `fuzz_seeds` env override.
- `packages/lix/tests/integration/{corruption,constraint,merge,filesystem}_fuzz.rs` — use it;
  `constraint_fuzz` model fix.
