### PR TITLE
perf(filesystem): connect the path index cache — 44.7x on one-file edits, flat in repository size

### DIFF
--- a/packages/lix/src/hot_state/context.rs
+++ b/packages/lix/src/hot_state/context.rs
@@ -383,9 +383,22 @@ impl HotStateContext {
         }
     }
 
-    /// Creates a reader whose derived indexes are private to one retained
-    /// storage snapshot. Process-wide caches intentionally advance with live
-    /// commits and therefore cannot serve an older explicit transaction.
+    /// Creates a reader whose entity-level derived indexes are private to one
+    /// retained storage snapshot. Those caches are not revision-tagged, so they
+    /// cannot serve an older explicit transaction and stay per-snapshot.
+    ///
+    /// The filesystem path index is deliberately **not** among them. It is
+    /// keyed by the `filesystem.path` revision, which
+    /// [`stage_path_index_revision`](crate::filesystem::stage_path_index_revision)
+    /// rewrites with a fresh UUIDv7 on every commit that changes the filesystem
+    /// view. Equal revision therefore means equal view, and a reader pinned to
+    /// an older snapshot loads the older revision from its own store and misses
+    /// rather than being served a newer view. Correctness comes from the
+    /// revision in the cache key, not from owning a private cache — and giving
+    /// each snapshot reader its own empty cache guaranteed a full
+    /// whole-repository rebuild for the first statement of every write
+    /// transaction, which is the epoch-0 path in
+    /// `TransactionSqlWriteExecutionContext::filesystem_path_index`.
     pub(crate) fn snapshot_reader<S>(&self, store: S) -> HotStateContextReader<S>
     where
         S: StorageAdapterRead,
@@ -394,7 +407,7 @@ impl HotStateContext {
             store,
             tracked_head: self.tracked_head,
             commit_graph: self.commit_graph.clone(),
-            filesystem_path_index_cache: std::sync::Arc::new(FilesystemPathIndexCache::default()),
+            filesystem_path_index_cache: std::sync::Arc::clone(&self.filesystem_path_index_cache),
             entity_point_snapshot_cache: std::sync::Arc::new(EntityPointSnapshotCache::default()),
             entity_columnar_layout_cache: std::sync::Arc::new(EntityColumnarLayoutCache::default()),
             branch_head_control_cache: None,


### PR DESCRIPTION
## Summary

Editing one file in a 10,000-file repository cost **80 ms**. It now costs **1.8 ms** — a **44.7x**
speedup — and the cost is **flat** in repository size instead of growing 44x across it.

This lands directly on the release claim. The post is about **agent workloads**, and an agent editing
one file at a time in a company-sized repository was paying a full whole-repository index rebuild on
*every single edit*. That is the difference between lix scaling to a company repository and not.

E16 measured that every SQL statement touching `lix_file` pays ~5.4 µs per *resident* file
regardless of what it writes. This PR removes that term for the shapes that go through the
filesystem path index, by **connecting an incremental cache that already existed and was simply
never read**.

**One line of behaviour changes**: `HotStateContext::snapshot_reader` now shares the process-wide,
revision-keyed `FilesystemPathIndexCache` instead of allocating a fresh empty one per statement.

## The defect, established by tracing rather than by reading

`filesystem/path_index.rs` ships a full incremental cache: `advance_committed` applies a committed
descriptor delta to a cached index, and `advance_revisions` does the same intra-transaction. Neither
saved anything. I instrumented the code paths and printed the `Arc` identity of every cache touched:

```
E21 advance target        cache=0x6467f0d745c0     <- long-lived, constant
E21 advance ENTER delta_rows=1 cached=0            <- ...and always empty
E21 snapshot_reader() -> FRESH EMPTY path index cache
E21 base path_index CACHE MISS  cache=0x6467f15c7cc0   <- different pointer
E21 build_path_index FULL REBUILD rows=204
E21 snapshot_reader() -> FRESH EMPTY path index cache
E21 base path_index CACHE MISS  cache=0x6467f16953a0   <- different again
E21 build_path_index FULL REBUILD rows=204
```

`TransactionSqlWriteExecutionContext::filesystem_path_index` takes the `descriptor_epoch == 0`
branch whenever nothing has been staged yet — the normal case for the first (and usually only)
statement of a write. That branch calls `snapshot_reader`, which allocated a **private empty**
cache. So every statement missed into a fresh cache and rebuilt the whole repository index, while
the incremental machinery faithfully maintained a different instance that no write ever read.

**It was never unsound — it was unconnected.** After the change the same trace reads:

```
E21 base path_index MISS  rev=Some("7641f3f8")
E21 build_path_index FULL REBUILD rows=204     <- exactly once
E21 advance ENTER delta=1 cached=1 global_or_untracked=false
E21 advance APPLIED
E21 base path_index CACHE HIT                  <- and every statement after
```

One rebuild, then hits forever. The raw per-probe series shows it directly: at 10,000 files the
first probe is 59.4 ms and all 249 after it are ~1.8 ms.

## Why sharing the cache is correct

Correctness comes from the cache key, not from cache isolation:

- The key includes the `filesystem.path` **revision**.
- `transaction/commit.rs` calls `stage_path_index_revision` **only** `if filesystem_view_changed`,
  and it writes a fresh UUIDv7. Equal revision therefore means equal committed filesystem view.
- A reader pinned to an older retained snapshot loads the **older** revision from its own store and
  misses, rebuilding from its own snapshot. It cannot be served a newer view.
- Staged-but-uncommitted rows are handled by the pre-existing `descriptor_epoch` mechanism; epoch 0
  means nothing is staged, so the committed view at that revision is exactly right.

`EntityPointSnapshotCache` and `EntityColumnarLayoutCache` **stay private, precisely because they are
not revision-tagged**: `EntityPointSnapshotCache` is keyed only by `(branch_id, schema_key,
entity_pk)` with nothing identifying which commit the snapshot came from, so sharing it across
commits would serve stale rows. Only the filesystem path index — the one cache that *is* tagged with
its source revision — moves, and the doc comment on `snapshot_reader` now records the distinction.

One honest interaction: `FilesystemPathIndexCache::insert` keeps at most one entry per
`(branch_ids, include_blob_refs, cache_small_blob_data)` shape regardless of revision. With a shared
cache, a long-lived older-snapshot reader and the live write path can therefore evict each other's
entry and both re-miss. That is a **performance** interaction in concurrent mixed-snapshot
workloads, not a correctness one — every miss rebuilds from the reader's own snapshot — and it
replaces a state where the write path missed unconditionally, every statement.

## A/B — ryzen-9950x-IV, base `a0ccd0dd`, candidate `eb856e12c`, RocksDB, release

Base worktree was moved to the **current integration head** and rebuilt before measuring; a retired
baseline produces a flattering wrong number. Verified in the run output:
`BASE_HEAD=a0ccd0dd6  CAND_HEAD=eb856e12c`.

Each shape is run **in isolation** — a mixed-shape stream interleaves other commits between probes
and masks the effect — 50 probes per run, arm order rotated `base, cand, cand, base` so each arm
takes each position. Both raw p50s per arm are shown; the speedup uses their median.

**`update_file_1line` — one-line edit of an existing file, the canonical agent operation**

| resident files | base p50 (2 runs) | cand p50 (2 runs) | speedup |
|---|---|---|---|
| 100 | 1.835 / 1.800 | 1.307 / 1.346 | 1.37x |
| 1,000 | 5.445 / 5.439 | 1.432 / 1.435 | 3.79x |
| 10,000 | 78.713 / 82.037 | **1.729 / 1.867** | **44.7x** |

**`upsert_existing_file` — `INSERT … ON CONFLICT (path) DO UPDATE`**

| resident files | base p50 (2 runs) | cand p50 (2 runs) | speedup |
|---|---|---|---|
| 100 | 1.840 / 2.078 | 1.473 / 1.483 | 1.33x |
| 1,000 | 4.502 / 4.482 | 1.654 / 1.663 | 2.71x |
| 10,000 | 59.477 / 62.118 | **1.899 / 2.344** | **28.7x** |

**The slope is the result.** Base grows **44x** across a 100x increase in resident files
(1.82 → 80.4 ms). The candidate is **flat**: 1.33 → 1.43 → 1.80 ms, a 1.35x change over the same
100x. The asymptotic term is removed, not shaved — which is the success signature this was aimed at:
flat in *resident* files while still linear in files *written*.

## Null control

`key_value_write` — same transaction open/stage/commit machinery, touches no file, byte-identical
code in both arms:

| resident files | base p50 | cand p50 | delta |
|---|---|---|---|
| 100 | 0.217 / 0.214 | 0.216 / 0.215 | +0.2% |
| 1,000 | 0.218 / 0.220 | 0.228 / 0.220 | +2.3% |
| 10,000 | 0.300 / 0.290 | 0.301 / 0.273 | −2.7% |

Control spread between arms is **≤2.7%** at every size. The 28–45x wins are three orders of
magnitude outside it.

## What regressed: nothing measurable

Creating a *new* file takes a different route and this PR does not change it. On the first A/B (base
`3b28dacc`, arm order giving the candidate both warmer middle slots) that lane read **+5–6%** at
10,000 files and I reported it rather than dismissing it. **Against the correct base with rotated arm
order it does not reproduce** — the candidate is now marginally *faster*:

| resident files | base p50 | cand p50 | delta |
|---|---|---|---|
| 100 | 1.358 / 1.346 | 1.433 / 1.338 | +2.5% |
| 1,000 | 4.648 / 3.880 | 3.800 / 4.287 | −5.2% |
| 10,000 | 54.179 / 54.264 | 50.334 / 51.945 | −5.7% |

The lane straddles zero across sizes and its own base spread at 1,000 files (3.880–4.648) exceeds the
inter-arm delta. The honest statement is **no measurable change on the new-file path**, which is what
the code predicts: that route provably never consults the path index, and the changed line strictly
*removes* an allocation (`Arc::clone` instead of `FilesystemPathIndexCache::default()`).

## The term that remains — measured, scoped, not fixed here

**Creating a new file is still O(resident files)** and this PR does not change that. The reason is
specific and measured: `lix_file` has **two** whole-repository derived views, and this PR fixes only
one of them.

- `filesystem::path_index::FilesystemPathIndex` — has the incremental cache, now connected. Used by
  the indexed write route (`upsert`/`update`).
- `filesystem::read::FilesystemIndex` — a **second** whole-repository index built by
  `sql2/providers/file.rs:2687` from its own fresh whole-branch scan, with **no cache of any kind**.
  A plain `INSERT` is classified `FastLixFilePathWriteConflict::None`, takes neither indexed route,
  and lands here. Tracing confirms the new-file path builds this and never touches the path index;
  `upsert_root_file` builds **both** in one statement.

`FilesystemIndex` has exactly one consumer. The principled follow-up is to route the `None` /
`DoNothing` conflict classes through the indexed path as well and **delete `FilesystemIndex`**,
collapsing two parallel derived views of the same facts into one. `indexed_file_path_writes` itself
is already conflict-agnostic — it takes no `conflict` argument and the gate is entirely in its
caller — but `stage_indexed_file_path_writes` currently asserts
`conflict.updates_existing() || conflict == IdDoNothing` and would need the "row already exists but
the statement declared no conflict clause" case (error for `None`, skip for `DoNothing`). That is
provider surgery in a 10k-line file and wants its own PR and its own gate, so I have scoped it rather
than bundled it.

## Layout invariants

1. **Single authority** — no new authority. The change *reduces* the number of live derived-view
   instances from one-per-statement to one shared, revision-tagged instance. It does not consolidate
   the two competing filesystem indexes; that is named above as the follow-up.
2. **Commit canonicality** — unchanged; no commit, ref, or graph code touched.
3. **Derived views are caches** — this is the invariant the PR enforces. The path index is a
   disposable cache tagged with its source revision; the change makes the tag do the work it was
   designed for instead of relying on per-statement isolation.
4. **Atomic publication** — unchanged.
5. **GC from refs** — unchanged.
6. **SQL reads canonical records** — unchanged; the cache is rebuildable from canonical descriptor
   rows and a miss simply rebuilds.

## What was removed / adapter API

**No storage adapter API added, changed, or removed.** No space, no versioned identifier, no key
encoding, no writer touched. Public API unchanged. Diff is 1 file, +17/−4, all in
`hot_state/context.rs` (mostly the doc comment explaining the revision-key argument).

## Gate — ryzen-9950x-IV, at `a0ccd0dd` + this diff (commit `eb856e12c`)

```
cargo clippy --profile test --workspace --all-targets --all-features -- -D warnings
cargo test   --profile test --workspace --exclude lix_benchmarks --all-features --no-fail-fast
cargo test   --profile test -p lix_benchmarks --features storage-benches,slatedb,root-replay-trace --no-fail-fast
cargo check  -p lix --no-default-features
cargo check  -p lix_js_sdk --target wasm32-unknown-unknown
```

**Result: 3503 passed / 0 failed / 54 ignored, 0 clippy warnings.** All five commands exited 0
(`CLIPPY_EXIT=0 TEST_EXIT=0 TESTBENCH_EXIT=0 NODEFAULT_EXIT=0 WASM_EXIT=0`).

Provenance was captured **inside** the gate run, before and after, so this result is attributable to
a commit rather than to a working tree:

```
=== GATE PROVENANCE ===
eb856e12cd4049a7e5062352dce3a96fcc93de8e
--- git status --porcelain (must be empty) ---
--- end status ---                                  <- empty, nothing staged or modified
eb856e12c perf(filesystem): share the revision-keyed path index cache with snapshot readers
a0ccd0dd6 Merge PR #1378: restore entity point-read routing assertions lost from #1372
=== GATE PROVENANCE (post-run, must be unchanged) ===
eb856e12cd4049a7e5062352dce3a96fcc93de8e            <- unchanged
```

## Bench commands

```
E16_SHAPES=update_file_1line E16_PROBES=50 \
  cargo run --release -p lix_tests --example e16_write_file_scaling -- 100 1000 10000
```
