### PR TITLE
perf(rocksdb-storage): give every column family four write buffers

### DIFF
--- a/packages/engine-benchmarks/Cargo.toml
+++ b/packages/engine-benchmarks/Cargo.toml
@@ -107,6 +107,11 @@ path = "examples/revision_pack_oracle.rs"
 required-features = ["storage-benches", "slatedb"]
 
 [[example]]
+name = "e5_media_probe"
+path = "examples/e5_media_probe.rs"
+required-features = ["storage-benches"]
+
+[[example]]
 name = "chunking_oracle"
 path = "examples/chunking_oracle.rs"
 

--- a/packages/engine-benchmarks/examples/e5_media_probe.rs
+++ b/packages/engine-benchmarks/examples/e5_media_probe.rs
@@ -1,0 +1,429 @@
+//! E5 probe: large-binary read (checkout) throughput and commit-latency tail.
+//!
+//! Two questions, one binary so a single build serves both:
+//!
+//! * `read` — how does whole-corpus materialization
+//!   (`SELECT path, content FROM lix_file`, the checkout shape) scale with mean
+//!   asset size at a fixed total byte count? A flat MB/s curve means the cost is
+//!   a per-byte constant; a falling curve means a per-chunk or per-file term.
+//! * `commit` — the per-commit latency *distribution* for a 3-file agent edit on
+//!   a large-asset corpus. Medians hide the LSM flush/compaction tail, so every
+//!   round's wall time and start timestamp are printed for correlation against
+//!   the RocksDB `LOG`.
+//!
+//! Usage:
+//!   e5_media_probe read   <asset_kib> <files> <reps> [db_dir]
+//!   e5_media_probe commit <asset_kib> <files> <rounds> [db_dir]
+//!
+//! Payload bytes are deterministic xorshift output, which is incompressible and
+//! therefore behaves like the compressed media (gif/mp4/png) the claim-2 corpora
+//! are made of.
+
+use std::path::{Path, PathBuf};
+use std::time::{Instant, SystemTime, UNIX_EPOCH};
+
+use lix::integration::{Engine, SessionContext};
+use lix::{Lix, Value, open_lix};
+use lix_storage_rocksdb::RocksDB;
+
+fn fill_pseudo_random(buffer: &mut [u8], seed: u64) {
+    let mut state = seed | 1;
+    for chunk in buffer.chunks_mut(8) {
+        state ^= state << 13;
+        state ^= state >> 7;
+        state ^= state << 17;
+        let bytes = state.to_le_bytes();
+        chunk.copy_from_slice(&bytes[..chunk.len()]);
+    }
+}
+
+fn asset(index: usize, bytes: usize) -> Vec<u8> {
+    let mut buffer = vec![0_u8; bytes];
+    fill_pseudo_random(&mut buffer, 0x9E37_79B9_7F4A_7C15 ^ (index as u64 + 1));
+    buffer
+}
+
+fn path_of(index: usize) -> String {
+    format!("/assets/{index:05}.bin")
+}
+
+fn now_millis() -> u128 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("clock after epoch")
+        .as_millis()
+}
+
+fn percentile(sorted: &[f64], p: f64) -> f64 {
+    if sorted.is_empty() {
+        return 0.0;
+    }
+    let rank = (p / 100.0 * (sorted.len() - 1) as f64).round() as usize;
+    sorted[rank.min(sorted.len() - 1)]
+}
+
+async fn open_session(dir: &Path, initialize: bool) -> (RocksDB, SessionContext<RocksDB>) {
+    let storage = RocksDB::open(dir).expect("open RocksDB storage");
+    if initialize {
+        Engine::initialize(storage.clone())
+            .await
+            .expect("initialize repository");
+    }
+    let engine = Engine::new(storage.clone()).await.expect("open engine");
+    let session = engine
+        .open_workspace_session()
+        .await
+        .expect("open workspace session");
+    (storage, session)
+}
+
+/// Seeds `files` assets of `asset_bytes` each, batching statements so a batch
+/// carries at most `MAX_BATCH_BYTES` of payload. One transaction, one commit —
+/// the claim-2 harness's corrected import granularity.
+const MAX_BATCH_BYTES: usize = 64 * 1024 * 1024;
+
+async fn seed(session: &SessionContext<RocksDB>, files: usize, asset_bytes: usize) -> f64 {
+    let started = Instant::now();
+    let mut transaction = session
+        .begin_transaction()
+        .await
+        .expect("begin seed transaction");
+    let mut batch_bytes = 0_usize;
+    let mut sql = String::new();
+    let mut params: Vec<Value> = Vec::new();
+    let mut flush_at: Vec<usize> = Vec::new();
+    let mut pending = 0_usize;
+
+    for index in 0..files {
+        if pending > 0 && batch_bytes + asset_bytes > MAX_BATCH_BYTES {
+            flush_at.push(index);
+            batch_bytes = 0;
+            pending = 0;
+        }
+        batch_bytes += asset_bytes;
+        pending += 1;
+    }
+    flush_at.push(files);
+
+    let mut start = 0_usize;
+    for end in flush_at {
+        sql.clear();
+        params.clear();
+        sql.push_str("INSERT INTO lix_file (path, content) VALUES ");
+        for index in start..end {
+            if index != start {
+                sql.push(',');
+            }
+            let slot = (index - start) * 2;
+            sql.push_str(&format!("(${},${})", slot + 1, slot + 2));
+            params.push(Value::Text(path_of(index)));
+            params.push(Value::Blob(asset(index, asset_bytes).into()));
+        }
+        transaction
+            .execute(&sql, &params)
+            .await
+            .expect("seed asset batch");
+        start = end;
+    }
+    transaction.commit().await.expect("commit seed");
+    started.elapsed().as_secs_f64() * 1000.0
+}
+
+/// Whole-corpus materialization: the checkout shape.
+async fn read_all(session: &SessionContext<RocksDB>) -> (f64, u64, u64) {
+    let started = Instant::now();
+    let result = session
+        .execute("SELECT path, content FROM lix_file", &[])
+        .await
+        .expect("read every file");
+    let mut bytes = 0_u64;
+    let mut rows = 0_u64;
+    for row in result.rows() {
+        rows += 1;
+        match &row.values()[1] {
+            Value::Blob(blob) => bytes += blob.len() as u64,
+            other => panic!("content should be a blob, got {other:?}"),
+        }
+    }
+    (started.elapsed().as_secs_f64() * 1000.0, rows, bytes)
+}
+
+async fn mode_read(dir: PathBuf, asset_bytes: usize, files: usize, reps: usize) {
+    let total = (asset_bytes * files) as f64;
+    let seed_ms = {
+        let (_storage, session) = open_session(&dir, true).await;
+        let ms = seed(&session, files, asset_bytes).await;
+        drop(session);
+        ms
+    };
+    println!(
+        "e5_read setup asset_bytes={asset_bytes} files={files} total_bytes={} seed_ms={seed_ms:.2}",
+        asset_bytes * files
+    );
+
+    // Cold arm: a fresh process-level open of the same store, exactly like a
+    // checkout into a new directory.
+    let mut samples = Vec::new();
+    for rep in 0..reps {
+        let (_storage, session) = open_session(&dir, false).await;
+        let (ms, rows, bytes) = read_all(&session).await;
+        let mb_per_s = (bytes as f64 / (1024.0 * 1024.0)) / (ms / 1000.0);
+        println!(
+            "e5_read cold rep={rep} asset_bytes={asset_bytes} files={files} \
+             ms={ms:.3} rows={rows} bytes={bytes} mib_per_s={mb_per_s:.1}"
+        );
+        samples.push(ms);
+        // Warm arm: same open, second read — separates backend I/O from
+        // per-byte engine work.
+        let (warm_ms, _, warm_bytes) = read_all(&session).await;
+        let warm_mb = (warm_bytes as f64 / (1024.0 * 1024.0)) / (warm_ms / 1000.0);
+        println!(
+            "e5_read warm rep={rep} asset_bytes={asset_bytes} files={files} \
+             ms={warm_ms:.3} mib_per_s={warm_mb:.1}"
+        );
+        drop(session);
+    }
+    samples.sort_by(|a, b| a.partial_cmp(b).expect("finite"));
+    let median = percentile(&samples, 50.0);
+    println!(
+        "e5_read summary asset_bytes={asset_bytes} files={files} total_bytes={} \
+         cold_median_ms={median:.3} cold_median_mib_per_s={:.1}",
+        asset_bytes * files,
+        (total / (1024.0 * 1024.0)) / (median / 1000.0)
+    );
+}
+
+async fn mode_commit(dir: PathBuf, asset_bytes: usize, files: usize, rounds: usize) {
+    let (_storage, session) = open_session(&dir, true).await;
+    let seed_ms = seed(&session, files, asset_bytes).await;
+    println!(
+        "e5_commit setup asset_bytes={asset_bytes} files={files} total_bytes={} \
+         seed_ms={seed_ms:.2} rounds={rounds}",
+        asset_bytes * files
+    );
+
+    let mut samples = Vec::new();
+    for round in 0..rounds {
+        // The claim-2 agent edit: three files, one byte flipped near the middle
+        // of each, published as a single commit.
+        let mut payloads = Vec::with_capacity(3);
+        for slot in 0..3 {
+            let index = (round * 3 + slot) % files;
+            let mut bytes = asset(index, asset_bytes);
+            let middle = bytes.len() / 2;
+            bytes[middle] = bytes[middle].wrapping_add(round as u8 + 1);
+            payloads.push((path_of(index), bytes));
+        }
+
+        let started_at = now_millis();
+        let started = Instant::now();
+        let mut transaction = session
+            .begin_transaction()
+            .await
+            .expect("begin agent commit");
+        let mut sql = String::from("INSERT INTO lix_file (path, content) VALUES ");
+        let mut params: Vec<Value> = Vec::new();
+        for (slot, (path, bytes)) in payloads.into_iter().enumerate() {
+            if slot != 0 {
+                sql.push(',');
+            }
+            sql.push_str(&format!("(${},${})", slot * 2 + 1, slot * 2 + 2));
+            params.push(Value::Text(path));
+            params.push(Value::Blob(bytes.into()));
+        }
+        sql.push_str(" ON CONFLICT (path) DO UPDATE SET content = excluded.content");
+        transaction
+            .execute(&sql, &params)
+            .await
+            .expect("agent edit");
+        transaction.commit().await.expect("commit agent edit");
+        let ms = started.elapsed().as_secs_f64() * 1000.0;
+        println!("e5_commit round={round} ms={ms:.3} start_unix_ms={started_at}");
+        samples.push(ms);
+    }
+
+    let mut sorted = samples.clone();
+    sorted.sort_by(|a, b| a.partial_cmp(b).expect("finite"));
+    println!(
+        "e5_commit summary asset_bytes={asset_bytes} files={files} rounds={rounds} \
+         p50={:.3} p90={:.3} p95={:.3} p99={:.3} max={:.3} mean={:.3}",
+        percentile(&sorted, 50.0),
+        percentile(&sorted, 90.0),
+        percentile(&sorted, 95.0),
+        percentile(&sorted, 99.0),
+        sorted.last().copied().unwrap_or(0.0),
+        samples.iter().sum::<f64>() / samples.len() as f64,
+    );
+    let p50 = percentile(&sorted, 50.0);
+    let over = samples
+        .iter()
+        .enumerate()
+        .filter(|(_, ms)| **ms > p50 * 5.0)
+        .map(|(round, ms)| format!("{round}:{ms:.1}"))
+        .collect::<Vec<_>>();
+    println!("e5_commit stalls_over_5x_median count={} {}", over.len(), over.join(" "));
+}
+
+/// Replicates the claim-2 agent harness shape exactly, because the 565.9 ms
+/// outlier it reported has to be reproduced under *its* conditions before it
+/// can be attributed to anything: the public `Lix` handle rather than a raw
+/// `SessionContext`, an import split into `batch`-row commits rather than one,
+/// and an `lix_active_branch_commit_id()` read plus a `lix_diff` count between
+/// every pair of commits.
+async fn mode_agent(dir: PathBuf, asset_bytes: usize, files: usize, rounds: usize, batch: usize) {
+    let storage = RocksDB::open(&dir).expect("open RocksDB storage");
+    let lix: Lix<RocksDB> = open_lix()
+        .with_storage(storage)
+        .await
+        .expect("open lix workspace");
+
+    let import_started = Instant::now();
+    let mut cursor = 0_usize;
+    while cursor < files {
+        let n = batch.min(files - cursor);
+        let mut sql = String::from("INSERT INTO lix_file (path, content) VALUES ");
+        let mut params: Vec<Value> = Vec::with_capacity(n * 2);
+        for k in 0..n {
+            if k > 0 {
+                sql.push(',');
+            }
+            sql.push_str(&format!("(${},${})", 2 * k + 1, 2 * k + 2));
+            params.push(Value::Text(path_of(cursor + k)));
+            params.push(Value::Blob(asset(cursor + k, asset_bytes).into()));
+        }
+        sql.push_str(" ON CONFLICT (path) DO UPDATE SET content = excluded.content");
+        lix.execute(&sql, &params).await.expect("import batch");
+        cursor += n;
+    }
+    let import_ms = import_started.elapsed().as_secs_f64() * 1000.0;
+    println!(
+        "e5_agent setup asset_bytes={asset_bytes} files={files} import_batch={batch} \
+         import_ms={import_ms:.2} rounds={rounds}"
+    );
+
+    let mut samples = Vec::new();
+    for round in 0..rounds {
+        let before = active_commit(&lix).await;
+        let mut sql = String::from("INSERT INTO lix_file (path, content) VALUES ");
+        let mut params: Vec<Value> = Vec::new();
+        for slot in 0..3 {
+            let index = (round * 3 + slot) % files;
+            let mut bytes = asset(index, asset_bytes);
+            // The claim-2 mutation: one byte near the middle, walked by round.
+            let at = (bytes.len() / 2 + round * 7) % bytes.len();
+            bytes[at] = bytes[at].wrapping_add(1 + (round as u8 % 7));
+            if slot != 0 {
+                sql.push(',');
+            }
+            sql.push_str(&format!("(${},${})", slot * 2 + 1, slot * 2 + 2));
+            params.push(Value::Text(path_of(index)));
+            params.push(Value::Blob(bytes.into()));
+        }
+        sql.push_str(" ON CONFLICT (path) DO UPDATE SET content = excluded.content");
+
+        let started_at = now_millis();
+        let started = Instant::now();
+        lix.execute(&sql, &params).await.expect("agent commit");
+        let ms = started.elapsed().as_secs_f64() * 1000.0;
+        println!("e5_agent round={round} ms={ms:.3} start_unix_ms={started_at}");
+        samples.push(ms);
+
+        let after = active_commit(&lix).await;
+        lix.execute(
+            &format!("SELECT COUNT(*) FROM lix_diff('{before}', '{after}')"),
+            &[],
+        )
+        .await
+        .expect("diff versus parent");
+    }
+
+    let mut sorted = samples.clone();
+    sorted.sort_by(|a, b| a.partial_cmp(b).expect("finite"));
+    let p50 = percentile(&sorted, 50.0);
+    println!(
+        "e5_agent summary asset_bytes={asset_bytes} files={files} rounds={rounds} \
+         p50={p50:.3} p90={:.3} p95={:.3} p99={:.3} max={:.3} mean={:.3}",
+        percentile(&sorted, 90.0),
+        percentile(&sorted, 95.0),
+        percentile(&sorted, 99.0),
+        sorted.last().copied().unwrap_or(0.0),
+        samples.iter().sum::<f64>() / samples.len() as f64,
+    );
+    let over = samples
+        .iter()
+        .enumerate()
+        .filter(|(_, ms)| **ms > p50 * 5.0)
+        .map(|(round, ms)| format!("{round}:{ms:.1}"))
+        .collect::<Vec<_>>();
+    println!(
+        "e5_agent stalls_over_5x_median count={} {}",
+        over.len(),
+        over.join(" ")
+    );
+}
+
+async fn active_commit(lix: &Lix<RocksDB>) -> String {
+    let result = lix
+        .execute("SELECT lix_active_branch_commit_id()", &[])
+        .await
+        .expect("read active commit id");
+    match &result.rows()[0].values()[0] {
+        Value::Text(id) => id.clone(),
+        other => panic!("active commit id should be text, got {other:?}"),
+    }
+}
+
+/// `E5_PERF_SPANS=1` turns on the engine's own `lix_perf` spans and prints one
+/// line per span close, so a single outlier commit can be attributed to a
+/// materialization stage instead of guessed at.
+fn install_perf_spans() {
+    if std::env::var("E5_PERF_SPANS").ok().as_deref() != Some("1") {
+        return;
+    }
+    use tracing_subscriber::fmt::format::FmtSpan;
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("lix_perf=debug")),
+        )
+        .with_span_events(FmtSpan::CLOSE)
+        .with_target(true)
+        .init();
+}
+
+#[tokio::main]
+async fn main() {
+    install_perf_spans();
+    let mut args = std::env::args().skip(1);
+    let mode = args.next().unwrap_or_else(|| "read".to_string());
+    let asset_kib = args
+        .next()
+        .and_then(|value| value.parse::<usize>().ok())
+        .unwrap_or(1024);
+    let files = args
+        .next()
+        .and_then(|value| value.parse::<usize>().ok())
+        .unwrap_or(64);
+    let count = args
+        .next()
+        .and_then(|value| value.parse::<usize>().ok())
+        .unwrap_or(3);
+    let explicit_dir = args.next().map(PathBuf::from);
+    let import_batch = args
+        .next()
+        .and_then(|value| value.parse::<usize>().ok())
+        .unwrap_or(50)
+        .max(1);
+
+    let temp = tempfile::tempdir().expect("create probe directory");
+    let dir = explicit_dir.unwrap_or_else(|| temp.path().join("rocksdb"));
+    std::fs::create_dir_all(&dir).expect("create store directory");
+    println!("e5_probe mode={mode} dir={}", dir.display());
+
+    match mode.as_str() {
+        "read" => mode_read(dir, asset_kib * 1024, files, count).await,
+        "commit" => mode_commit(dir, asset_kib * 1024, files, count).await,
+        "agent" => mode_agent(dir, asset_kib * 1024, files, count, import_batch).await,
+        other => panic!("unknown mode {other}; expected read|commit|agent"),
+    }
+}

--- a/packages/rocksdb-storage/src/rocksdb.rs
+++ b/packages/rocksdb-storage/src/rocksdb.rs
@@ -30,6 +30,11 @@ use rocksdb::{DBRawIteratorWithThreadMode, Snapshot};
 use tempfile::TempDir;
 use tokio::sync::{Mutex as AsyncMutex, OwnedMutexGuard};
 
+const WRITE_BUFFER_BYTES: usize = 64 * 1024 * 1024;
+/// Spare memtables per column family. Four buffers cap resident memtable memory
+/// at `WRITE_BUFFER_BYTES * WRITE_BUFFER_COUNT` per family (512 MiB across the
+/// two families) and are what keeps a flush off the next writer's latency.
+const WRITE_BUFFER_COUNT: i32 = 4;
 const DEFAULT_BLOB_MIN_SIZE: u64 = 32 * 1024;
 const DEFAULT_BLOB_FILE_SIZE: u64 = 256 * 1024 * 1024;
 const BLOB_GC_FORCE_THRESHOLD: f64 = 0.5;
@@ -754,7 +759,17 @@ fn open_rocksdb(path: &Path) -> Result<DB, StorageError> {
 
 fn column_family_options() -> Options {
     let mut options = Options::default();
-    options.set_write_buffer_size(64 * 1024 * 1024);
+    options.set_write_buffer_size(WRITE_BUFFER_BYTES);
+    // RocksDB's default of two write buffers gives a writer exactly one spare
+    // memtable: the moment the active one fills, the next `db.write` blocks
+    // until the previous flush has finished. A media commit stages megabytes at
+    // a time, so a bulk import fills both buffers and the *next* ordinary agent
+    // commit pays the whole flush inside its own latency. Measured on a 64 file
+    // / 10 MiB corpus, that one commit cost 337-369 ms against a 21 ms median;
+    // with four buffers it costs 22 ms and the median does not move. Raising
+    // `max_background_jobs` instead changes nothing (measured 339/369 ms), so
+    // the spare-memtable count is the whole effect.
+    options.set_max_write_buffer_number(WRITE_BUFFER_COUNT);
     let mut table_options = BlockBasedOptions::default();
     // Full whole-key filters let missing point reads skip unrelated SST data.
     table_options.set_bloom_filter(8.0, false);


### PR DESCRIPTION
# perf(rocksdb-storage): give every column family four write buffers

## The finding first, because it corrects a release claim

`claim2-results.md` reports that on the large-binary corpus one lix commit in nine took
**565.9 ms against a 10.1 ms median**, and concludes:

> At p95 lix (565.9 ms) is *worse* than git+LFS (238.4 ms). … the honest form is "~14x faster at
> the median, with a periodic multi-hundred-ms stall git+LFS does not have".

**That stall is not periodic.** It is the *first agent commit after a bulk import*, it happens
exactly once, and it is caused by a RocksDB option this repository never set. Reproduced here at
337–375 ms, diagnosed to the adapter before anything was changed, then removed by one line.

The p95 conclusion was an artifact of computing p95 over **nine samples in which a single one-time
event was 11% of the population**. At 200 rounds the real distribution before the fix is
p50 20.730 / p95 23.366 / p99 26.797, with one stall at index 0. **The ~14x median commit win
holds at p95 and p99.** After the fix, 200 rounds x 3 reps: p50 20.3–21.2, p95 22.8–23.8,
p99 24.1–24.7, **max 24.8–26.4 ms, zero stalls** — a max/median ratio of 1.2.

The release post should still disclose the one-time import-adjacent cost. This PR reduces it from
~350 ms to ~22 ms; it does not make it free.

## Why two competent measurements disagreed

The stall is **import-batch-shape dependent**, and claim-2's `LIX_CLAIM2_IMPORT_BATCH=50` sits
exactly on the bad point. 2 reps each, 30 rounds:

| import batch | commits in import | round-0 (ms) |
|---|---|---|
| 1 | 64 | 22.4 / 22.4 |
| 8 | 8 | 22.4 / 22.9 |
| **50 (claim-2's)** | **2** | **366.0 / 371.3** |
| 64 | 1 | 28.7 / 28.0 |

This is why the tail looked periodic and unreproducible: a probe that seeds in one transaction
never sees it, and a probe that seeds one file per commit never sees it either.

## What changed physically

`packages/rocksdb-storage/src/rocksdb.rs`, `column_family_options()`:

```rust
options.set_max_write_buffer_number(WRITE_BUFFER_COUNT);   // 4, was RocksDB's default 2
```

RocksDB's default `max_write_buffer_number = 2` gives a writer exactly one spare memtable. When
the active memtable fills, the next `db.write` blocks until the pending flush completes. A media
commit stages megabytes at a time, so a bulk import fills both buffers and the **next** ordinary
agent commit pays the entire flush inside its own latency.

`write_buffer_size` (64 MiB) is unchanged and is now a named constant beside the new one. Also
adds `packages/engine-benchmarks/examples/e5_media_probe.rs`, the instrument that measures the
per-commit latency *distribution* rather than its median.

**Nothing was removed.** This is not a cut; it is a one-line configuration fix backed by a 15x
measurement on a metric the round is about to publish.

## Adapter API

**Unchanged.** No `StorageAdapter` trait method was added, changed, or removed. The diff touches
only `packages/rocksdb-storage`'s private `column_family_options()`. `packages/slatedb-storage`,
the in-memory adapter, `packages/lix/src/storage/conformance`, and
`packages/lix/tests/third_party_storage_adapter.rs` are untouched and needed no change:
`max_write_buffer_number` is a RocksDB memtable-count option with no SlateDB analogue, and it
changes *when* a flush blocks a writer, never what any adapter returns.

## Layout invariants

1. **Single authority.** No second authority. No writer, materialization, or index is added or
   relocated; only how many memtables RocksDB keeps resident before it blocks a writer.
2. **Commit canonicality.** Unaffected. No commit record, parent link, or state root is touched.
3. **Derived views are caches.** Unaffected. No derived view appears in this diff.
4. **Atomic publication.** Preserved. The write set is still one `WriteBatch` handed to
   `db.write`; buffering more memtables does not split it, and RocksDB's atomicity guarantee for a
   single batch is independent of `max_write_buffer_number`.
5. **GC from refs.** Unaffected. No retention metadata, no reachability change.
6. **SQL reads canonical records.** Unaffected. Reads see the same rows. A point read could in
   principle search up to four memtables instead of two before reaching an SST; that is the one
   place a regression could hide, and it is guarded below.

## A/B — the commit tail

Machine **hetzner-cpx62-II** (16 core / 30 GB). RocksDB only.

**The store directory is on ext4, not tmpfs.** `/tmp` on this host is a 16 GB tmpfs, so any
benchmark defaulting to `TMPDIR` measures RAM. Every number here used an explicit
`~/claude5/e5/...` path on `/dev/sda1` (ext4) with `TMPDIR=$HOME/claude5/tmp`. Measured both ways
as a control — the medium moves nothing (below).

### Workload

`e5_media_probe agent 10240 64 <rounds> <dir> 50` — 64 synthetic incompressible assets of 10 MiB
(640 MiB total), imported in 50-row batches, then N rounds of the claim-2 agent edit (3 files, one
byte flipped near the middle, one commit), with an `lix_active_branch_commit_id()` read and a
`lix_diff` count between rounds. This replicates the claim-2 harness shape including its
`LIX_CLAIM2_IMPORT_BATCH=50`.

### Primary: interleaved A/B, one binary, arms switched at open

Both arms are the *same* build; `max_write_buffer_number` was switched by env var so no compile
lands between arms and the arms cannot differ in codegen. The env default is 2, so the base arm is
byte-identical to today's behaviour. Order rotated base, cand, base, cand, base, cand.

| rep | base round-0 (ms) | cand round-0 (ms) | base p50 (ms) | cand p50 (ms) |
|---|---|---|---|---|
| 1 | 337.566 | 22.047 | 20.880 | 20.986 |
| 2 | 365.636 | 28.759 | 21.100 | 20.527 |
| 3 | 342.569 | 22.380 | 21.172 | 20.987 |
| **median** | **342.569** | **22.380** | **21.100** | **20.986** |

**Stalling commit −93.5% (15.3x). Steady-state median −0.5%, i.e. nothing.** The arms' raw round-0
ranges (`337.6–365.6` vs `22.0–28.8`) do not overlap, which is the runbook's condition for
accepting 3 reps on a timing claim.

### Knob isolation — `max_background_jobs` does nothing

2 reps each, same binary, same corpus, 30 rounds.

| `max_write_buffer_number` | `max_background_jobs` | round-0 (ms) | store MB |
|---|---|---|---|
| 2 (default) | 2 (default) | 337.6 / 342.6 / 365.6 / 374.7 | 827 |
| 2 | 6 | **339.2 / 369.3 — stall remains** | 827 |
| 4 | 4 | 22.3 / 22.4 | 827 |
| 6 | 2 | 22.4 / 22.8 | 827 |
| 6 | 6 | 22.0 / 22.4 / 28.8 | 827 |

The spare-memtable count is the entire effect; background-job concurrency is irrelevant. 4 ships
rather than 6 because it already removes the stall completely at half the extra memory.

### Shipped code, 200 rounds x 3 reps

| rep | round-0 | p50 | p95 | p99 | max | stalls >5x median | store MB |
|---|---|---|---|---|---|---|---|
| 1 | 21.866 | 20.284 | 22.765 | 24.102 | 24.768 | 0 | 1878 |
| 2 | 24.672 | 21.233 | 23.813 | 24.672 | 24.789 | 0 | 1878 |
| 3 | 23.406 | 20.846 | 23.637 | 24.429 | 26.432 | 0 | 1878 |

Base, same shape, 200 rounds: p50 20.730, p95 23.366, p99 **26.797**, **max 374.669**, 1 stall.
**p99 −8.4%, max −93.4%, p50 and p95 unchanged.**

### Deterministic byte counts — 1 rep, verified reproducible

Store bytes after the run are **identical across every configuration**: 827 MB at 30 rounds across
6 configurations, 1878 MB at 200 rounds across 3 reps. The change buffers writes differently; it
writes the same bytes.

### Null control and bench resolution

`e5_media_probe commit` — the same corpus driven through `SessionContext::begin_transaction` with a
single-transaction seed — **never triggers the stall in either arm**, which is exactly why the
harness shape mattered. Its spread is this bench's noise floor and it doubles as the
tmpfs-versus-ext4 control:

| medium | rounds | p50 | p95 | p99 | max | stalls |
|---|---|---|---|---|---|---|
| ext4 | 500 | 20.765 | 31.369 | 35.145 | 43.225 | 0 |
| tmpfs | 500 | 21.034 | 33.460 | 36.245 | 38.392 | 0 |

Medium moves p50 by 1.3% and p95 by 6.7% — inside noise. **The tail is not a storage-medium
artifact.** Anything under roughly 7% on this bench is unresolvable; the claim here is 93%.

### Attribution — `lix_perf` spans on the stalling commit

One stalling commit (380.672 ms total) decomposed by the engine's own spans:

| span | time.busy |
|---|---|
| `lix.perf.transaction_open` | 176 µs |
| `lix.perf.transaction_plan_and_stage` | 15.8 ms |
| `lix.perf.transaction_validation` | 248 µs |
| `lix.perf.transaction_materialization` | 811 µs |
| `lix.perf.transaction_storage_prepare` | 279 µs |
| **`lix.perf.transaction_storage_commit`** | **363 ms** |
| └ `lix.perf.storage_commit_accepted_visible` | 363 ms |

**95% of the outlier is inside `RocksDB::commit()` → `db.write`.** Engine materialization —
including the tracked-state root rebuild that was the competing hypothesis — costs 811 µs. This
ruled the engine out and the adapter in *before* any option was changed.

## Read guard

The stated risk is a point read searching up to four memtables instead of two. Guarded with
`tracked_state_crud --bench read_`, **both arms built from `9e22c61a1` ± this commit**, so the
guard runs against the post-#1372 entity planner, not the old one. Interleaved, arm order rotated,
5 reps per arm across all 20 read lanes; medians in ms.

| lane | base | cand | delta | base self-spread |
|---|---|---|---|---|
| sql_session/real_workload/read_one_by_pk/10k | 1.7466 | 1.7319 | **−0.84%** | 9.1% |
| sql_session/real_workload/read_many_by_pk/10 | 1.8789 | 1.8838 | +0.26% | 6.7% |
| sql_session/real_workload/read_all_rows_consumed/10k | 6.1653 | 6.2467 | +1.32% | 11.7% |
| sql_session/real_workload/read_all_rows/10k | 4.3872 | 4.4631 | +1.73% | 5.7% |
| sql_session/smoke/read_one_by_pk/1k | 1.6011 | 1.5742 | −1.68% | 9.7% |
| sql_session/smoke/read_all_rows_consumed/1k | 2.1936 | 2.1610 | −1.49% | 3.8% |
| sql_session/smoke/read_many_by_pk/10 | 1.6504 | 1.7424 | +5.57% | 7.2% |
| transaction/real_workload/read_all_rows/10k | 18.5210 | 18.6180 | +0.52% | 5.9% |
| transaction/real_workload/read_many_by_pk/10 | 1.0769 | 1.0948 | +1.66% | 5.5% |
| transaction/real_workload/read_one_by_pk/10k | 0.2613 | 0.2675 | +2.35% | 9.3% |
| transaction/smoke/read_all_rows/1k | 2.2373 | 2.1940 | −1.94% | 12.7% |
| transaction/smoke/read_one_by_pk/1k | 0.2235 | 0.2301 | +2.93% | 22.1% |
| transaction/smoke/read_many_by_pk/10 | 0.9467 | 0.9776 | +3.26% | 116.2% |
| kv_layout/real_workload/read_all_rows/10k | 2.5382 | 2.5787 | +1.60% | 5.9% |
| kv_layout/real_workload/read_many_by_pk/10 | 0.0610 | 0.0580 | −4.87% | 17.2% |
| kv_layout/smoke/read_one_by_pk/1k | 0.0277 | 0.0250 | −9.88% | 21.1% |
| kv_layout/smoke/read_many_by_pk/10 | 0.0490 | 0.0429 | −12.43% | 32.8% |
| kv_layout/smoke/read_all_rows/1k | 0.3518 | 0.3773 | +7.26% | 46.1% |
| sql_session/smoke/read_all_rows/1k | 1.7073 | 1.8868 | +10.51% | 7.7% |
| kv_layout/real_workload/read_one_by_pk/10k | 0.0369 | 0.0410 | +11.32% | 32.4% |

Two lanes exceeded 10%, both in the 1k/µs class the runbook names as this harness's worst
offenders, so **both were escalated to 9 reps per arm**, interleaved and rotated:

| lane | base | cand | 5-rep delta | **9-rep delta** | base self-spread |
|---|---|---|---|---|---|
| sql_session/smoke/read_all_rows/1k | 1.7935 | 1.7985 | +10.51% | **+0.28%** | 15.5% |
| kv_layout/real_workload/read_one_by_pk/10k | 0.0359 | 0.0395 | +11.32% | **+9.96%** | 22.7% |
| sql_session/real_workload/read_one_by_pk/10k | 1.7501 | 1.8213 | −0.84% | +4.07% | 8.8% |
| kv_layout/smoke/read_all_rows/1k | 0.3649 | 0.3916 | +7.26% | +7.32% | 22.6% |
| transaction/real_workload/read_one_by_pk/10k | 0.2742 | 0.2784 | +2.35% | +1.54% | 12.9% |
| transaction/smoke/read_all_rows/1k | 2.1685 | 2.2649 | −1.94% | +4.45% | 10.4% |

**Verdict: no regression.** The `sql_session` 1k lane collapsed from +10.51% to +0.28%, exactly as
the runbook predicts for 1k ids. The one lane still elevated,
`kv_layout/real_workload/read_one_by_pk/10k`, is a **3.6 µs** absolute delta (35.9 → 39.5 µs)
inside a **22.7%** within-arm spread, and the signs across the sweep are incoherent — the public
point read moves −0.84%/+4.07%, the kv smoke point read −9.88%, the kv smoke many-by-pk −12.43%.

There is also a physical reason none of these lanes can move: **no read lane in
`tracked_state_crud` generates enough write volume to fill even one 64 MiB memtable.** 10k small
rows is single-digit MB, so both arms hold exactly one active memtable during every timed read and
`max_write_buffer_number` is never reached. Per the runbook, a guard that cannot execute the
changed code is not a guard; these lanes are reported for completeness and read as noise, which is
what they are.

**Guards deliberately skipped as unable to execute the change**: `diff_commands` (no RocksDB
adapter), `packed_history_scale` (seeds via `seed_packed_history`, bypasses the commit path), and
every SlateDB lane (this option is RocksDB-only).

## What regressed

**Resident memtable memory.** The ceiling per column family goes from `64 MiB x 2 = 128 MiB` to
`64 MiB x 4 = 256 MiB`, so **256 MiB → 512 MiB across the two families**. This is a *ceiling*, not
a steady-state cost: the extra buffers are only allocated when flushes are actually lagging, which
is precisely the situation this PR fixes. It is memory, not bytes on disk — disk is unchanged and
measured identical across all six configurations.

Under the round's priority ranking (correctness > file/VC performance > OLTP > physical bytes on
disk), trading a 256 MiB memory ceiling for a 15x cut in a file-path commit outlier is the intended
direction. Steady-state commit median moved **−0.5%**, i.e. nothing.

## Correctness gate

Full CI-scope gate on hetzner-cpx62-II, run against `origin/main`'s `ci.yml` rather than the
runbook's copy. All five stages **exit 0**; logs grepped for `^error`, `panicked`,
`test result: FAILED`, `^failures:` — **zero matches in any stage**.

| stage | result |
|---|---|
| `cargo clippy --profile test --workspace --all-targets --all-features -- -D warnings` | exit 0, 0 warnings |
| `cargo check -p lix --no-default-features` | exit 0 |
| `cargo check -p lix_js_sdk --target wasm32-unknown-unknown` | exit 0 |
| `cargo test --profile test --workspace --exclude lix_benchmarks --all-features --no-fail-fast` | exit 0 |
| `cargo test --profile test -p lix_benchmarks --features storage-benches,slatedb,root-replay-trace --no-fail-fast` | exit 0 |

**3,499 tests passed, 0 failed, 52 ignored.**

### SHAs, stated precisely

- **Gate** ran at `863f56308` = `5bc46723c` (PR #1368) + this commit. That base **predates
  PR #1372**, so the gate is fully green and does not carry the known-red
  `datafusion_entity_primary_key_read_uses_registered_provider` failure currently on the
  integration branch.
- **Read guard** ran at `9e22c61a1` (PR #1372 merged) ± this commit, deliberately, so it measures
  against the new entity planner.
- **Commit-tail A/B** ran at `5bc46723c` ± this commit.

The diff is three files and touches no code any of those merges touched, so it was rebased forward
to the current integration head without re-gating. If a gate on the current head is wanted, note it
will carry that one known pre-existing failure.

## Host note (not part of the diff)

`/tmp` and `/dev/shm` on hetzner-cpx62-II are 16 GB tmpfs mounts, so a benchmark that defaults to
`TMPDIR` measures RAM, not disk. 9.5 GB of stale round-3/4 fixtures were reclaimed from them before
measuring (`/dev/shm` 5.5 GB → 0; `/tmp` 6.7 → 3.7 GB), taking available memory from 13 GB to
24 GB on a box with no swap.

## Reproduce

```sh
export TMPDIR=$HOME/claude5/tmp                 # /tmp is tmpfs on the cpx62 hosts
cargo build --release -p lix_benchmarks --features storage-benches --example e5_media_probe
./e5_media_probe agent 10240 64 200 <ext4-dir>/db 50     # the tail
./e5_media_probe commit 10240 64 500 <ext4-dir>/db       # the null control
```
