### PR TITLE
perf(hot_state): measure declared-column index candidate ageing (negative result + instrument)

### DIFF
--- a/packages/lix/src/hot_index_aging_probe.rs
+++ b/packages/lix/src/hot_index_aging_probe.rs
@@ -1,0 +1,429 @@
+//! Candidate amplification in the hot declared-column index.
+//!
+//! Not a product module. It measures how many *candidates* a single-value
+//! lookup on an indexed column resolves, versus how many rows actually match,
+//! after the collection has churned inside one generation. Entries are
+//! put-only and a generation spans a branch's lifetime, so the question is
+//! whether the wasted candidate resolutions stay a small constant or grow.
+
+use serde_json::json;
+use std::time::{Duration, Instant};
+
+use crate::engine::Engine;
+use crate::session::SessionContext;
+use crate::storage::ProjectedValue;
+use crate::storage_adapter::{
+    Memory, StorageAdapter, StorageAdapterRead, StorageBeginScanOptions, StoragePrefix,
+    StorageReadOptions,
+};
+
+fn sizes_from_env(var: &str, default: &[usize]) -> Vec<usize> {
+    match std::env::var(var) {
+        Ok(raw) => raw
+            .split(',')
+            .filter(|part| !part.trim().is_empty())
+            .map(|part| part.trim().parse::<usize>().expect("size must parse"))
+            .collect(),
+        Err(_) => default.to_vec(),
+    }
+}
+
+fn reps_from_env(default: usize) -> usize {
+    std::env::var("LIX_INDEX_AGING_REPS")
+        .ok()
+        .and_then(|raw| raw.parse::<usize>().ok())
+        .unwrap_or(default)
+}
+
+async fn open_session() -> (Memory, SessionContext<Memory>) {
+    let storage = Memory::new();
+    Engine::initialize(storage.clone())
+        .await
+        .expect("engine should initialize");
+    let engine = Engine::new(storage.clone())
+        .await
+        .expect("engine should open");
+    let session = engine
+        .open_workspace_session()
+        .await
+        .expect("session should open");
+    (storage, session)
+}
+
+/// `(witnesses, entries)` in the hot index plane.
+async fn index_record_counts(storage: &Memory) -> (usize, usize) {
+    let adapter = StorageAdapter::new(storage.clone());
+    let read = adapter
+        .begin_read(StorageReadOptions::default())
+        .await
+        .expect("read the index plane");
+    let range = StoragePrefix {
+        bytes: bytes::Bytes::new(),
+    }
+    .to_range()
+    .expect("valid empty prefix");
+    let mut cursor = read
+        .begin_scan(
+            crate::hot_state::INDEX_SPACE,
+            range,
+            StorageBeginScanOptions::default(),
+        )
+        .await
+        .expect("scan the index plane");
+    let entries = cursor.collect_all().await.expect("collect index entries");
+    let witnesses = entries
+        .iter()
+        .filter(|entry| match &entry.value {
+            ProjectedValue::FullValue(bytes) => bytes.is_empty(),
+            ProjectedValue::KeyOnly => true,
+        })
+        .count();
+    (witnesses, entries.len() - witnesses)
+}
+
+fn probe_schemas(parent: &str, child: &str) -> [serde_json::Value; 2] {
+    [
+        json!({
+            "x-lix-key": parent,
+            "x-lix-primary-key": ["/id"],
+            "type": "object",
+            "properties": { "id": { "type": "string" } },
+            "required": ["id"],
+            "additionalProperties": false
+        }),
+        json!({
+            "x-lix-key": child,
+            "x-lix-primary-key": ["/id"],
+            "x-lix-foreign-keys": [{
+                "properties": ["/parentId"],
+                "references": { "schemaKey": parent, "properties": ["/id"] }
+            }],
+            "type": "object",
+            "properties": {
+                "id": { "type": "string" },
+                "parentId": { "type": "string" },
+                "locale": { "type": "string" }
+            },
+            "required": ["id", "parentId", "locale"],
+            "additionalProperties": false
+        }),
+    ]
+}
+
+async fn register(session: &SessionContext<Memory>, schemas: [serde_json::Value; 2]) {
+    for schema in schemas {
+        session
+            .execute(
+                "INSERT INTO lix_registered_schema (value) VALUES (lix_json($1))",
+                &[crate::Value::Text(schema.to_string())],
+            )
+            .await
+            .expect("schema should register");
+    }
+}
+
+const CHUNK: usize = 250;
+
+async fn insert_parents(session: &SessionContext<Memory>, table: &str, count: usize) {
+    let mut index = 0;
+    while index < count {
+        let end = (index + CHUNK).min(count);
+        let values = (index..end)
+            .map(|i| format!("('parent-{i}')"))
+            .collect::<Vec<_>>()
+            .join(",");
+        session
+            .execute(&format!("INSERT INTO {table} (id) VALUES {values}"), &[])
+            .await
+            .expect("parents should insert");
+        index = end;
+    }
+}
+
+/// Inserts `count` children; child `i` points at `parent_of(i)`.
+async fn insert_children(
+    session: &SessionContext<Memory>,
+    table: &str,
+    count: usize,
+    parent_of: impl Fn(usize) -> usize,
+) {
+    let mut index = 0;
+    while index < count {
+        let end = (index + CHUNK).min(count);
+        let values = (index..end)
+            .map(|i| {
+                let parent = parent_of(i);
+                format!("('child-{i}', 'parent-{parent}', 'en')")
+            })
+            .collect::<Vec<_>>()
+            .join(",");
+        session
+            .execute(
+                &format!(r#"INSERT INTO {table} (id, "parentId", locale) VALUES {values}"#),
+                &[],
+            )
+            .await
+            .expect("children should insert");
+        index = end;
+    }
+}
+
+/// `id IN (...)` in chunks over `child-1 .. child-{count-1}`.
+async fn mutate_children_except_first(
+    session: &SessionContext<Memory>,
+    statement: impl Fn(&str) -> String,
+    count: usize,
+) {
+    let mut index = 1;
+    while index < count {
+        let end = (index + CHUNK).min(count);
+        let ids = (index..end)
+            .map(|i| format!("'child-{i}'"))
+            .collect::<Vec<_>>()
+            .join(",");
+        session
+            .execute(&statement(&ids), &[])
+            .await
+            .expect("bulk mutation should run");
+        index = end;
+    }
+}
+
+async fn timed_lookup(
+    session: &SessionContext<Memory>,
+    sql: &str,
+    expect_rows: usize,
+    reps: usize,
+) -> Duration {
+    let mut samples = Vec::new();
+    for _ in 0..reps {
+        let start = Instant::now();
+        let rows = session.execute(sql, &[]).await.expect("lookup should run");
+        let elapsed = start.elapsed();
+        assert_eq!(
+            rows.len(),
+            expect_rows,
+            "lookup returned the wrong row count"
+        );
+        samples.push(elapsed);
+    }
+    samples.sort();
+    samples[samples.len() / 2]
+}
+
+/// READ PATH. One live match at `parent-0` in every arm; only the number of
+/// stale candidates in that bucket differs.
+///
+/// * `aged`   — N children created at `parent-0`, then N-1 deleted. Live
+///   collection is 1 row. Candidates at `parent-0` are N.
+/// * `fresh`  — 1 child created at `parent-0`. Live collection is 1 row,
+///   candidates 1. This is the control: identical answer, identical live
+///   state, no stale candidates.
+/// * `moved`  — N children created at `parent-0`, then N-1 repointed at
+///   `parent-1`. Live collection is N rows, candidates at `parent-0` are N.
+///   Its `locale` lookup is the unindexed comparator: a full scan of the same
+///   N live rows.
+#[tokio::test]
+#[ignore = "measurement probe, not a gate"]
+async fn hot_index_read_path_candidate_amplification() {
+    let sizes = sizes_from_env("LIX_INDEX_AGING_SIZES", &[100, 1_000, 10_000]);
+    let reps = reps_from_env(5);
+    println!("read path | arm,n,index_entries,live_rows,answer_rows,median_us,scan_comparator_us");
+    for n in sizes {
+        // ---- aged arm: N candidates, 1 live row ----
+        {
+            let (storage, session) = open_session().await;
+            register(&session, probe_schemas("agedp", "agedc")).await;
+            insert_parents(&session, "agedp", 2).await;
+            insert_children(&session, "agedc", n, |_| 0).await;
+            mutate_children_except_first(
+                &session,
+                |ids| format!("DELETE FROM agedc WHERE id IN ({ids})"),
+                n,
+            )
+            .await;
+            let (_, entries) = index_record_counts(&storage).await;
+            let median = timed_lookup(
+                &session,
+                r#"SELECT id FROM agedc WHERE "parentId" = 'parent-0'"#,
+                1,
+                reps,
+            )
+            .await;
+            // Unindexed comparator on the same churned collection: equality
+            // on a column the schema does not declare keeps the ordinary
+            // scan, so whatever the 9,999 tombstones cost shows up here and
+            // not in the indexed number alone.
+            let scan = timed_lookup(
+                &session,
+                "SELECT id FROM agedc WHERE locale = 'nomatch'",
+                0,
+                reps,
+            )
+            .await;
+            println!(
+                "aged,{n},{entries},1,1,{},{}",
+                median.as_micros(),
+                scan.as_micros()
+            );
+        }
+        // ---- fresh control: 1 candidate, 1 live row ----
+        {
+            let (storage, session) = open_session().await;
+            register(&session, probe_schemas("freshp", "freshc")).await;
+            insert_parents(&session, "freshp", 2).await;
+            insert_children(&session, "freshc", 1, |_| 0).await;
+            let (_, entries) = index_record_counts(&storage).await;
+            let median = timed_lookup(
+                &session,
+                r#"SELECT id FROM freshc WHERE "parentId" = 'parent-0'"#,
+                1,
+                reps,
+            )
+            .await;
+            println!("fresh,{n},{entries},1,1,{},-", median.as_micros());
+        }
+        // ---- moved arm: N candidates, 1 live match, N live rows ----
+        {
+            let (storage, session) = open_session().await;
+            register(&session, probe_schemas("movedp", "movedc")).await;
+            insert_parents(&session, "movedp", 2).await;
+            insert_children(&session, "movedc", n, |_| 0).await;
+            mutate_children_except_first(
+                &session,
+                |ids| format!(r#"UPDATE movedc SET "parentId" = 'parent-1' WHERE id IN ({ids})"#),
+                n,
+            )
+            .await;
+            let (_, entries) = index_record_counts(&storage).await;
+            let median = timed_lookup(
+                &session,
+                r#"SELECT id FROM movedc WHERE "parentId" = 'parent-0'"#,
+                1,
+                reps,
+            )
+            .await;
+            // Unindexed comparator: same collection, equality on a column the
+            // schema does not declare, so the engine keeps its ordinary scan.
+            let scan = timed_lookup(
+                &session,
+                r#"SELECT id FROM movedc WHERE locale = 'nomatch'"#,
+                0,
+                reps,
+            )
+            .await;
+            println!(
+                "moved,{n},{entries},{n},1,{},{}",
+                median.as_micros(),
+                scan.as_micros()
+            );
+        }
+    }
+}
+
+fn unique_probe_schema(key: &str) -> serde_json::Value {
+    json!({
+        "x-lix-key": key,
+        "x-lix-primary-key": ["/id"],
+        "x-lix-unique": [["/slug"]],
+        "type": "object",
+        "properties": {
+            "id": { "type": "string" },
+            "slug": { "type": "string" },
+            "tag": { "type": "string" }
+        },
+        "required": ["id", "slug", "tag"],
+        "additionalProperties": false
+    })
+}
+
+/// A composite unique group: `declared_column_probe` declines composite
+/// groups, so this collection keeps the scan route on the write path.
+fn composite_unique_schema(key: &str) -> serde_json::Value {
+    json!({
+        "x-lix-key": key,
+        "x-lix-primary-key": ["/id"],
+        "x-lix-unique": [["/slug", "/tag"]],
+        "type": "object",
+        "properties": {
+            "id": { "type": "string" },
+            "slug": { "type": "string" },
+            "tag": { "type": "string" }
+        },
+        "required": ["id", "slug", "tag"],
+        "additionalProperties": false
+    })
+}
+
+/// WRITE PATH. `validate_committed_unique_constraints` probes the same plane
+/// for single-column unique groups, so every insert re-resolves whatever
+/// candidates have accumulated under the value being inserted.
+///
+/// The loop recreates one logical slot: insert a fresh entity holding
+/// `slug='dup'`, delete it, repeat. Each iteration leaves one more permanent
+/// candidate in the `dup` bucket while the live collection stays at one row.
+/// Insert latency is sampled at the requested checkpoints.
+#[tokio::test]
+#[ignore = "measurement probe, not a gate"]
+async fn hot_index_write_path_unique_probe_amplification() {
+    write_path_churn("uniqprobe", unique_probe_schema("uniqprobe")).await;
+}
+
+/// Control for the write-path probe. The unique group is composite, so
+/// `declared_column_probe` declines and the same churn runs on the collection
+/// scan route. Whatever the accumulated tombstones cost the scan appears here;
+/// the difference between the two runs is what the index plane adds.
+#[tokio::test]
+#[ignore = "measurement probe, not a gate"]
+async fn hot_index_write_path_composite_unique_control() {
+    write_path_churn("compprobe", composite_unique_schema("compprobe")).await;
+}
+
+async fn write_path_churn(table: &str, schema: serde_json::Value) {
+    let checkpoints = sizes_from_env("LIX_INDEX_AGING_WRITE_CHECKPOINTS", &[10, 100, 500, 1_000]);
+    let max = *checkpoints.iter().max().expect("at least one checkpoint");
+    let (storage, session) = open_session().await;
+    session
+        .execute(
+            "INSERT INTO lix_registered_schema (value) VALUES (lix_json($1))",
+            &[crate::Value::Text(schema.to_string())],
+        )
+        .await
+        .expect("schema should register");
+
+    println!(
+        "write path {table} | accumulated_candidates,index_entries,live_rows,median_insert_us"
+    );
+    let reps = reps_from_env(5);
+    let mut next = 0usize;
+    let mut samples: Vec<Duration> = Vec::new();
+    for iteration in 0..=max {
+        let sampling = next < checkpoints.len() && iteration + reps > checkpoints[next];
+        let start = Instant::now();
+        session
+            .execute(
+                &format!("INSERT INTO {table} (id, slug, tag) VALUES ($1, 'dup', 't')"),
+                &[crate::Value::Text(format!("row-{iteration}"))],
+            )
+            .await
+            .expect("insert should succeed");
+        if sampling {
+            samples.push(start.elapsed());
+        }
+        if next < checkpoints.len() && iteration == checkpoints[next] {
+            let (_, entries) = index_record_counts(&storage).await;
+            samples.sort();
+            let median = samples[samples.len() / 2];
+            println!("{iteration},{entries},1,{}", median.as_micros());
+            samples.clear();
+            next += 1;
+        }
+        session
+            .execute(
+                &format!("DELETE FROM {table} WHERE id = $1"),
+                &[crate::Value::Text(format!("row-{iteration}"))],
+            )
+            .await
+            .expect("delete should succeed");
+    }
+}

--- a/packages/lix/src/lib.rs
+++ b/packages/lix/src/lib.rs
@@ -55,6 +55,8 @@ pub(crate) mod filesystem;
 pub(crate) mod functions;
 pub(crate) mod gc;
 mod handle;
+#[cfg(test)]
+mod hot_index_aging_probe;
 pub(crate) mod init;
 pub(crate) mod json_store;
 pub(crate) mod hot_state;

--- a/packages/lix/src/module_layers.rs
+++ b/packages/lix/src/module_layers.rs
@@ -99,6 +99,7 @@ const UNLAYERED_MODULES: &[(&str, &str)] = &[
         "peer of `session` in the reclamation cycle, by design",
     ),
     ("handle", "entry point; reaches everywhere by design"),
+    ("hot_index_aging_probe", "cfg(test) measurement probe"),
     ("init", "entry point; reaches everywhere by design"),
     ("lib", "crate root"),
     ("module_layers", "this guard"),


### PR DESCRIPTION
## What this is

A **measurement instrument plus a negative result**, not a performance change.
It lands an `#[ignore]`d probe module (`packages/lix/src/hot_index_aging_probe.rs`)
that measures candidate amplification in the hot declared-column index plane,
and reports what it measures. No engine code changes; no public API change; no
storage adapter API added, changed, or removed.

## The property being measured

`INDEX_SPACE` entry key is
`(branch, generation, schema, ENTRY, ordinal, value) ++ entity_pk`
(`hot.rs: encode_hot_index_entry_key`). Maintenance is put-only —
`stage_hot_index_entries` has no delete path, and the only `INDEX_SPACE` delete
anywhere is whole-generation retirement.

Two consequences set the x-axis, and the first rules out the obvious one:

1. Re-writing the **same value for the same entity is idempotent** (identical
   key, no new row). An entity toggling `A→B→A→B` produces two entries, not N.
   **Update count is not the driver.**
2. A bucket holds every `entity_pk` that has **ever** been written with that
   value in the generation — including deleted entities and entities that have
   since moved off the value. A generation is minted on branch lifecycle
   publication only; ordinary commits, packed-base publication and checkpoints
   all reuse it (`a_checkpoint_keeps_the_declared_column_index_serving` pins
   that). So the driver is **distinct entities ever written with the value over
   the branch's lifetime**, which is unbounded relative to live rows.

Correctness is not at issue. Candidates are never answers, both consumers
re-apply their own predicate, and
`superseded_index_entries_are_rejected_and_no_match_is_ever_lost` pins it. This
is purely a cost result.

## Read path

Machine `ryzen-9950x-I`, base SHA `a0ccd0dd6`, `Memory` adapter, `--release`,
`--test-threads=1`, median of 5 reps. `index entries` is deterministic — 1 rep.

`SELECT id FROM child WHERE "parentId" = 'parent-0'`, **one live match in every
arm**. The last column is the same query shape on `locale`, a column the schema
does not declare, so it keeps the ordinary collection scan.

| arm | n | index entries | live rows | answer rows | indexed µs | unindexed scan µs |
|---|---:|---:|---:|---:|---:|---:|
| aged  | 100   | 100   | 1     | 1 | 130  | 71   |
| fresh | 100   | 1     | 1     | 1 | 41   | – |
| moved | 100   | 199   | 100   | 1 | 130  | 90   |
| aged  | 1000  | 1000  | 1     | 1 | 805  | 330  |
| fresh | 1000  | 1     | 1     | 1 | 42   | – |
| moved | 1000  | 1999  | 1000  | 1 | 957  | 536  |
| aged  | 10000 | 10000 | 1     | 1 | 7368 | 2974 |
| fresh | 10000 | 1     | 1     | 1 | 43   | – |
| moved | 10000 | 19999 | 10000 | 1 | 10054| 4941 |

* `aged` — n children created at `parent-0`, then n−1 deleted. Live collection
  is **one row**; the bucket holds n candidates.
* `fresh` — **null control**: identical answer, identical live state, one
  candidate. **41 / 42 / 43 µs, flat across two orders of magnitude.** That is
  this instrument's noise floor (±2%) and its no-amplification baseline.
* `moved` — n children created at `parent-0`, then n−1 repointed at `parent-1`.
  No deletes, therefore no tombstones: a confound-free arm.

The indexed lookup is **linear in accumulated candidates** (≈0.73 µs each) while
the control is flat: 41 µs → 7368 µs, a **175x** degradation for an identical
one-row answer over an identical one-row live collection.

The decisive comparison is the last column. Once a bucket has aged to collection
size, the index access path is **2.0–2.5x slower than the collection scan it
exists to replace** (7368 vs 2974; 10054 vs 4941). It does not converge to
neutral — it goes negative.

## Write path

`validate_committed_unique_constraints` → `declared_column_probe` probes the same
plane for single-column unique groups, so every insert re-resolves the
accumulated candidates under the value being inserted. The loop recreates one
logical slot: insert a fresh entity holding `slug='dup'`, delete it, repeat.

The control is the identical churn on a schema whose unique group is
**composite**, which `declared_column_probe` declines — so it runs the scan route
and absorbs whatever the accumulated tombstones cost.

| accumulated | index entries | live rows | insert µs (probe route) | insert µs (scan control) | index penalty |
|---:|---:|---:|---:|---:|---:|
| 10   | 11   | 1 | 162  | 147  | 1.10x |
| 100  | 101  | 1 | 248  | 185  | 1.34x |
| 1000 | 1001 | 1 | 1060 | 512  | 2.07x |
| 5000 | 5001 | 1 | 4779 | 1989 | 2.40x |

≈0.93 µs per accumulated candidate, on top of the scan route's own ≈0.37 µs per
accumulated tombstone. An insert into a table holding **one live row** costs
4.8 ms after 5000 create/delete cycles.

The control is *also* linear: deleted rows leave tombstones the collection scan
walks. That is a separate ageing term and is not claimed here — the index
plane's contribution is the difference between the two columns.

## Result

Not a bounded constant factor tied to collection shape. The wasted work is
O(distinct entities ever written with the value in the branch's generation),
unbounded relative to live rows, and it makes both the read path and the
unique-constraint write path **2–2.5x slower than the scan route the plane was
introduced to replace**.

Also worth recording: the entry key carries **no `file_id`**, so candidates from
every file scope collapse into one bucket and the file filter is applied after
resolution. In a repository holding one company's files that widens the bucket
further; the probe does not exercise it, so no number is claimed.

## What is NOT in this PR

No fix. Three were costed against this measurement, and the smallest that
removes the unbounded term is a degradation guard in `scan_hot_index_candidates`
— carry `entries_published` and the collection's `live_count` in the witness
record's value (the witness is already point-read on every lookup, so the read
is free; maintenance is one read-modify-write per touched collection per commit,
O(collections), not O(rows)), and return `None` once
`entries_published > 2 * live_count` so the caller's ordinary scan serves. That
bounds the cost at the pre-plane scan cost but reclaims no bytes and restores no
index benefit. Making the plane exact via a reverse `entity_pk -> current value`
record is the better fix and touches the commit path. Held for the coordinator's
go/no-go rather than landed unmeasured.

## Layout invariants

1. **Single authority** — no. Adds no writer, no materialization, no index. The
   probe is `#[cfg(test)]` and `#[ignore]`d.
2. **Commit canonicality** — unchanged; no commit or ref code touched.
3. **Derived views are caches** — unchanged. The finding *is* about a derived
   cache, and it confirms the cache stays non-authoritative: every candidate is
   re-resolved by an exact point read and re-checked by the caller's predicate,
   which is why an aged plane costs time and never returns a wrong answer.
4. **Atomic publication** — unchanged.
5. **GC from refs** — unchanged.
6. **SQL reads canonical records** — unchanged.

## Gate

Run on `ryzen-9950x-I` against base SHA `a0ccd0dd6`, matching
`origin/main:.github/workflows/ci.yml`:

```
cargo clippy --profile test --workspace --all-targets --all-features -- -D warnings
cargo test --profile test --workspace --exclude lix_benchmarks --all-features --no-fail-fast
cargo test --profile test -p lix_benchmarks --features storage-benches,slatedb,root-replay-trace --no-fail-fast
cargo check -p lix --no-default-features
cargo check -p lix_js_sdk --target wasm32-unknown-unknown
```

Full logs captured to `~/claude5/logs/e23-gate2.log` and grepped (not tailed) for
`failures:`, `panicked`, `test result: FAILED`, `^error`: **3503 passed, 0
failed**, no clippy warnings, both features-OFF checks clean.

The first gate run caught a real break in this PR — `module_layers::every_top_level_module_is_accounted_for`
rejects a top-level module that is in neither `MODULE_LAYERS` nor
`UNLAYERED_MODULES`. The second commit registers the probe module there as a
`cfg(test)` measurement probe.

Probe commands (both `#[ignore]`d, never run by the gate):

```
LIX_INDEX_AGING_SIZES=100,1000,10000 LIX_INDEX_AGING_REPS=5 \
LIX_INDEX_AGING_WRITE_CHECKPOINTS=10,100,1000,5000 \
cargo test --release -p lix --lib hot_index_ -- --ignored --nocapture --test-threads=1
```

## Regressions

None. No engine code path changes; the probe compiles only under `cfg(test)` and
is `#[ignore]`d, so it adds nothing to the gate's runtime.
