### PR TITLE
test(tracked_state): sweep the availability proof over every chunk

### DIFF
--- a/packages/lix/src/tracked_state/context.rs
+++ b/packages/lix/src/tracked_state/context.rs
@@ -8593,12 +8593,23 @@ mod tests {
     /// repair still proves the whole closure. Pins both halves, because the
     /// difference between them is the entire cost argument: the commit path
     /// walks one root-to-leaf path, repair walks every row.
+    ///
+    /// This sweeps every non-root chunk rather than damaging one of them.
+    /// A single representative cannot express the property: `Addressable`
+    /// walks root -> leftmost child -> leaf, so damage *on* that path
+    /// legitimately defeats the bounded probe too, and only damage *off* it
+    /// separates the two proofs. Measured on this fixture, 2 of the 40
+    /// candidates sit on the bounded path. Selecting one of them by content
+    /// hash therefore leaves a ~1-in-20 chance that any future change to the
+    /// tree's contents flips this test to a permanent failure that reads like
+    /// a commit-root-rebuild regression rather than fixture drift. (An earlier
+    /// version selected by `HashSet` iteration order, which made the same
+    /// mistake nondeterministically and flaked in roughly 5% of runs.)
+    /// Sweeping pins the whole partition instead of guessing a member of it.
     #[tokio::test]
     async fn availability_proof_is_bounded_on_commit_and_total_on_repair() {
         use crate::tracked_state::commit_root_rebuild::RootAvailabilityProof;
 
-        let tracked_state = TrackedStateContext::new();
-        let storage = StorageAdapter::new(Memory::new());
         // Wide enough that the tree is more than one chunk, so "the root chunk"
         // and "the closure" are actually different sets.
         let rows = (0..4000)
@@ -8611,17 +8622,26 @@ mod tests {
                 )
             })
             .collect::<Vec<_>>();
-        write_root_for_test(&storage, &tracked_state, "gen", None, &rows)
-            .await
-            .expect("wide genesis root should write");
-        write_rootless_commit_for_test(
-            &storage,
-            "a1",
-            "gen",
-            &[row_with_value("entity-a1", "a1-change", "a1", "a1")],
-        )
-        .await;
 
+        // The damage is a delete, so every candidate needs an undamaged fixture
+        // of its own.
+        async fn seeded_fixture(rows: &[MaterializedTrackedStateRow]) -> StorageAdapter {
+            let tracked_state = TrackedStateContext::new();
+            let storage = StorageAdapter::new(Memory::new());
+            write_root_for_test(&storage, &tracked_state, "gen", None, rows)
+                .await
+                .expect("wide genesis root should write");
+            write_rootless_commit_for_test(
+                &storage,
+                "a1",
+                "gen",
+                &[row_with_value("entity-a1", "a1-change", "a1", "a1")],
+            )
+            .await;
+            storage
+        }
+
+        let storage = seeded_fixture(&rows).await;
         let read = storage
             .begin_read(StorageReadOptions::default())
             .await
@@ -8631,69 +8651,96 @@ mod tests {
             .expect("genesis root should load")
             .expect("genesis root should exist");
         drop(read);
-        let chunks = stored_tree_chunk_hashes_for_test(&storage).await;
-        assert!(
-            chunks.len() > 2,
-            "fixture must build a multi-chunk tree, got {} chunks",
-            chunks.len()
-        );
-
-        // Damage a chunk that is not the root and not on the bounded path, so
-        // only a total traversal can notice it.
-        //
-        // `chunks` is a HashSet, so picking "the last non-root chunk" made the
-        // choice depend on hash iteration order — the fixture silently relied
-        // on that pick landing off the bounded path. Sort first so the chunk
-        // this test damages is a property of the tree, not of the allocator.
-        let mut candidates = chunks
-            .iter()
-            .copied()
-            .filter(|chunk| chunk != root_id.as_bytes())
+        let root_bytes = *root_id.as_bytes();
+        let mut candidates = stored_tree_chunk_hashes_for_test(&storage)
+            .await
+            .into_iter()
+            .filter(|chunk| chunk != &root_bytes)
             .collect::<Vec<_>>();
+        // Sorted so the sweep order, and any failure message, is reproducible.
         candidates.sort_unstable();
-        let damaged_chunk = *candidates.last().expect("a non-root chunk exists");
-        let mut writes = storage.new_write_set();
-        writes.delete(
-            storage::TRACKED_STATE_TREE_CHUNK_SPACE,
-            crate::storage_adapter::StorageKey(Bytes::copy_from_slice(&damaged_chunk)),
+        assert!(
+            candidates.len() > 1,
+            "fixture must build a multi-chunk tree, got {} non-root chunks",
+            candidates.len()
         );
-        storage
-            .commit_write_set(writes, StorageWriteOptions::default())
-            .await
-            .expect("chunk delete should commit");
+        drop(storage);
 
-        let read = storage
-            .begin_read(StorageReadOptions::default())
-            .await
-            .expect("probe read should open");
-        let bounded = crate::tracked_state::commit_root_rebuild::
-            load_rebuild_plans_to_nearest_available_root_with_proof(
-                &read,
-                "a1",
-                true,
-                RootAvailabilityProof::Addressable,
-            )
-            .await
-            .expect("bounded probe should load plans");
-        assert_eq!(
-            bounded.len(),
-            1,
-            "the commit path resumes from an addressable root and does not re-derive closure completeness"
+        let mut resumed_from_damaged_root = 0usize;
+        let mut rejected_damaged_root = 0usize;
+        for candidate in &candidates {
+            let storage = seeded_fixture(&rows).await;
+            let mut writes = storage.new_write_set();
+            writes.delete(
+                storage::TRACKED_STATE_TREE_CHUNK_SPACE,
+                crate::storage_adapter::StorageKey(Bytes::copy_from_slice(candidate)),
+            );
+            storage
+                .commit_write_set(writes, StorageWriteOptions::default())
+                .await
+                .expect("chunk delete should commit");
+
+            let read = storage
+                .begin_read(StorageReadOptions::default())
+                .await
+                .expect("probe read should open");
+            let bounded = crate::tracked_state::commit_root_rebuild::
+                load_rebuild_plans_to_nearest_available_root_with_proof(
+                    &read,
+                    "a1",
+                    true,
+                    RootAvailabilityProof::Addressable,
+                )
+                .await
+                .expect("bounded probe should load plans");
+            let total = crate::tracked_state::commit_root_rebuild::
+                load_rebuild_plans_to_nearest_available_root_with_proof(
+                    &read,
+                    "a1",
+                    true,
+                    RootAvailabilityProof::Complete,
+                )
+                .await
+                .expect("total probe should load plans");
+
+            // Repair distrusts the chunk plane, so every damaged closure makes
+            // it walk back past the resume point — on the bounded path or not.
+            assert_eq!(
+                total.len(),
+                2,
+                "explicit repair must reject a resume point with a damaged closure \
+                 and replay past it (chunk {candidate:02x?})"
+            );
+            match bounded.len() {
+                1 => resumed_from_damaged_root += 1,
+                2 => rejected_damaged_root += 1,
+                other => panic!(
+                    "bounded probe returned {other} plans for chunk {candidate:02x?}; \
+                     expected 1 (resumed) or 2 (walked back)"
+                ),
+            }
+        }
+
+        // The commit path does not re-derive closure completeness: damage its
+        // one root-to-leaf walk never touches leaves the root resumable.
+        assert!(
+            resumed_from_damaged_root > 0,
+            "the commit path must resume from a root whose closure is damaged off \
+             the bounded path"
         );
-
-        let total = crate::tracked_state::commit_root_rebuild::
-            load_rebuild_plans_to_nearest_available_root_with_proof(
-                &read,
-                "a1",
-                true,
-                RootAvailabilityProof::Complete,
-            )
-            .await
-            .expect("total probe should load plans");
-        assert_eq!(
-            total.len(),
-            2,
-            "explicit repair must reject a resume point with a damaged closure and replay past it"
+        // ...and the bounded probe is not vacuous: damage *on* that walk still
+        // rejects the root.
+        assert!(
+            rejected_damaged_root > 0,
+            "the bounded probe must still reject a root whose bounded path is damaged"
+        );
+        // The whole cost argument: the bounded probe reads one root-to-leaf
+        // path, not the closure. If it read the closure, every chunk would
+        // reject.
+        assert!(
+            rejected_damaged_root < candidates.len(),
+            "the bounded probe walks one root-to-leaf path, so it cannot notice \
+             every chunk in the closure"
         );
     }
 


### PR DESCRIPTION
# test(tracked_state): sweep the availability proof over every chunk

**Machine:** `ryzen-9950x-III`. **Base SHA:** `8119553d3`. Test-only: no engine code, no public API,
no adapter API, no bytes on disk. Follow-up to the `HashSet`-ordering fix in `957b0d3a`.

## Why the sorted pick is not yet safe

`957b0d3a` fixed the flake by sorting the candidates before choosing one, which was the right
immediate call — the choice is now a property of the tree rather than of the allocator. But it is
still a **content-hash** choice, and the property under test is not a property of an arbitrary chunk.

`RootAvailabilityProof::Addressable` is `limit: Some(1)`, and its own doc says the scan walks
root → leftmost child → leaf and stops. So damage **on that path** legitimately defeats the bounded
probe too. Only damage **off** it separates the two proofs, and the test's comment has always claimed
that condition without any code implementing it.

I measured the partition — rebuild the fixture, damage exactly one chunk, record both probes, for
every candidate:

```
total chunks = 41            (1 root + 40 candidates)
bounded == 1 for 38 chunks   (off the bounded path — the case the test wants)
bounded == 2 for  2 chunks   (on the bounded path — a legitimate rejection)
total   == 2 for all 40      (the repair half was never at risk)
```

**2 of 40 (5.0%)** are poisoned. `candidates.last()` happens to miss both today. But chunk hashes move
whenever row content, fanout, or the commit address space moves — the commit-address-space UUID
change is what perturbed this fixture in the first place — so any future tree has roughly a 1-in-20
chance of selecting an on-path chunk. At that point the test fails **deterministically and always**,
and it reads as a commit-root-rebuild regression rather than fixture drift.

That is strictly better than a flake, because it is loud. It is still a trap: this round has twice
lost hours to a test failing for a reason nobody could see from the failure.

## What changed

Sweep every non-root chunk in sorted order and assert the **partition** instead of damaging one
representative:

- `total == 2` for **every** candidate — repair distrusts the chunk plane unconditionally. This is
  the assertion the old test made about one chunk, now made about all 40.
- at least one candidate leaves the root resumable (`bounded == 1`) — the commit path does not
  re-derive closure completeness;
- at least one candidate rejects it (`bounded == 2`) — the bounded probe is not vacuous;
- the rejecting set is strictly smaller than the candidate set — the probe reads one root-to-leaf
  path, not the closure.

That last pair is the cost argument in the doc comment, asserted for the first time. Any bounded
value other than 1 or 2 panics with the offending chunk hash. There is no chunk selection left to get
wrong, and the assertions hold for any fanout.

The doc comment now records the measured partition and both failure modes, so the next person to
touch this fixture does not have to rediscover them.

## Cost

The test goes from ~0.04 s to **1.56 s** (41 in-memory fixture builds). Suite wall-clock is unchanged
at ~11.8 s because it runs in parallel. That is the whole price.

## Evidence

| tree | full-suite runs | `availability_proof` failures |
|---|---:|---:|
| pre-fix base @ `f3c37056` | 23 | 1 |
| sweep (this branch) | 45 | **0** |

The soak is corroboration; the argument is mechanistic. The nondeterministic input is gone from the
test — it no longer selects a chunk at all — so there is nothing left to be lucky about.

## Layout invariants

Test-only; none engaged. (1) no new authority, (2) commit canonicality untouched, (3) no derived view
changed, (4) no publication path changed, (5) no retention metadata touched, (6) no query surface
changed.

## Gate

`ryzen-9950x-III`, `ci.yml` scope from `origin/main`, `--no-fail-fast`, full log captured and grepped:
**3502 passed / 0 failed across 66 test targets, 0 clippy warnings**, plus
`cargo check -p lix --no-default-features` and
`cargo check -p lix_js_sdk --target wasm32-unknown-unknown` clean.

## What regressed

Nothing. One test's runtime rises 1.5 s, absorbed by parallelism.
