### PR TITLE
perf(tracked_state): stop inlining a full commit-delta segment (6.3x read cliff at 512-row commits)

### DIFF
--- a/.changenotes/no-inline-full-commit-delta-segment.md
+++ b/.changenotes/no-inline-full-commit-delta-segment.md
@@ -1,0 +1,10 @@
+---
+type: patch
+---
+
+Fixed a 6.3x current-value read penalty on commits of exactly 512 rows.
+
+A commit that filled one whole commit-delta segment inlined that segment into
+its commit-state manifest, so every later point read of those rows fetched the
+manifest and decoded all 512 rows to return one. A full segment is now written
+as its own segment row; smaller single-segment commits still inline.

--- a/packages/engine-benchmarks/examples/write_amplification.rs
+++ b/packages/engine-benchmarks/examples/write_amplification.rs
@@ -13,13 +13,20 @@
 //! Modes:
 //!
 //! ```text
-//! write_amplification seed   <dir> <rows>
+//! write_amplification seed   <dir> <rows> [seed_width]
 //! write_amplification update <dir> <updates> <width> <distinct>
+//! write_amplification read   <dir> <reads> <distinct>
 //! write_amplification census <dir>
 //! ```
 //!
 //! `seed` inserts `rows` tracked rows through the real SQL commit path in
-//! batches of 1000 (one commit each). `update` applies `updates` single-row
+//! commits of `seed_width` rows (default 1000). Varying `seed_width` while
+//! holding `rows` fixed changes how wide the commit that *wrote* a row was,
+//! which is what `read` exists to probe: a current-value read locates a row
+//! through its owning commit's packed delta, so if read cost tracks
+//! `seed_width` the current-value path is paying for history it does not need.
+//!
+//! `update` applies `updates` single-row
 //! `UPDATE`s committed in groups of `width`, cycling over `distinct` distinct
 //! rows, so repeated edits to one row can be told apart from edits spread over
 //! many. `census` walks every registered space and prints per-space rows, key
@@ -67,6 +74,7 @@ impl BenchStorage for RocksDB {
 
 const SEED_SQL: &str = "INSERT INTO json_pointer (path, value) VALUES ($1, lix_json($2))";
 const UPDATE_SQL: &str = "UPDATE json_pointer SET value = lix_json($1) WHERE path = $2";
+const READ_SQL: &str = "SELECT value FROM json_pointer WHERE path = $1";
 const SEED_COMMIT_ROWS: usize = 1_000;
 const MIN_RUN: usize = 6;
 
@@ -89,10 +97,13 @@ async fn main() {
     match mode.as_str() {
         "seed" => {
             let rows = next("rows");
+            let seed_width = args
+                .next()
+                .map_or(SEED_COMMIT_ROWS, |v| v.parse().expect("seed_width"));
             if rocksdb {
-                seed(RocksDB::open(&dir).expect("open RocksDB"), rows).await;
+                seed(RocksDB::open(&dir).expect("open RocksDB"), rows, seed_width).await;
             } else {
-                seed(SlateDB::open(&dir).expect("open SlateDB"), rows).await;
+                seed(SlateDB::open(&dir).expect("open SlateDB"), rows, seed_width).await;
             }
         }
         "update" => {
@@ -117,6 +128,15 @@ async fn main() {
                 .await;
             }
         }
+        "read" => {
+            let reads = next("reads");
+            let distinct = next("distinct");
+            if rocksdb {
+                read_rows(RocksDB::open(&dir).expect("open RocksDB"), reads, distinct).await;
+            } else {
+                read_rows(SlateDB::open(&dir).expect("open SlateDB"), reads, distinct).await;
+            }
+        }
         "census" => {
             if rocksdb {
                 census(RocksDB::open(&dir).expect("open RocksDB")).await;
@@ -128,7 +148,7 @@ async fn main() {
     }
 }
 
-async fn seed<S: BenchStorage>(storage: S, rows: usize) {
+async fn seed<S: BenchStorage>(storage: S, rows: usize, seed_width: usize) {
     Engine::initialize(storage.clone())
         .await
         .expect("initialize repository");
@@ -164,7 +184,7 @@ async fn seed<S: BenchStorage>(storage: S, rows: usize) {
 
     let mut inserted = 0_usize;
     while inserted < rows {
-        let chunk = SEED_COMMIT_ROWS.min(rows - inserted);
+        let chunk = seed_width.max(1).min(rows - inserted);
         let parameter_rows = (inserted..inserted + chunk).map(|index| {
             vec![
                 Value::Text(format!("/fixture/path/{index:08}")),
@@ -191,7 +211,7 @@ async fn seed<S: BenchStorage>(storage: S, rows: usize) {
     drop(session);
     drop(engine);
     storage.settle().await;
-    println!("SEEDED\trows={rows}");
+    println!("SEEDED\trows={rows}\tseed_width={seed_width}");
 }
 
 /// Applies `updates` row updates in `updates / width` commits.
@@ -239,6 +259,52 @@ async fn update<S: BenchStorage>(storage: S, updates: usize, width: usize, disti
     println!(
         "UPDATED\tupdates={updates}\twidth={width}\tdistinct={distinct}\tcommits={}",
         updates / width
+    );
+}
+
+/// Times `reads` current-value point reads over `distinct` rows.
+///
+/// This is the read half of a single-row `UPDATE` in isolation: no transaction,
+/// no commit, just "find the current value of this row".
+async fn read_rows<S: BenchStorage>(storage: S, reads: usize, distinct: usize) {
+    let engine = Engine::new(storage.clone())
+        .await
+        .expect("open engine over initialized repository");
+    let session = engine
+        .open_workspace_session()
+        .await
+        .expect("open workspace session");
+
+    // Warm the plan cache so the measurement is the read, not planning.
+    for index in 0..distinct.min(16) {
+        session
+            .execute(
+                READ_SQL,
+                &[Value::Text(format!("/fixture/path/{index:08}"))],
+            )
+            .await
+            .expect("warm read");
+    }
+
+    let start = std::time::Instant::now();
+    let mut rows_seen = 0_u64;
+    for index in 0..reads {
+        let target = index % distinct;
+        let result = session
+            .execute(
+                READ_SQL,
+                &[Value::Text(format!("/fixture/path/{target:08}"))],
+            )
+            .await
+            .expect("point read");
+        rows_seen += result.len() as u64;
+    }
+    let elapsed = start.elapsed();
+    assert_eq!(rows_seen as usize, reads, "every point read must find its row");
+    println!(
+        "READ\treads={reads}\tdistinct={distinct}\ttotal_us={}\tus_per_read={:.2}",
+        elapsed.as_micros(),
+        elapsed.as_micros() as f64 / reads as f64,
     );
 }
 

--- a/packages/lix/src/tracked_state/storage.rs
+++ b/packages/lix/src/tracked_state/storage.rs
@@ -4408,10 +4408,38 @@ where
         single_partition_from_bounds(&first.first_key, &last.last_key)?
     };
     if segment_row_counts.len() == 1 {
-        let (_, inline_segment) = first_segment
+        let (bounds, encoded) = first_segment
             .take()
-            .expect("one ordered segment remains inline in its manifest");
-        manifest.inline_segment = inline_segment;
+            .expect("one ordered segment remains available for its manifest");
+        // Inlining a lone segment into the manifest saves a small commit one
+        // storage row and one point read, and costs nothing while no reader
+        // touches the payload — a small commit leaves its rows on the hot
+        // plane, which is where current-value reads find them.
+        //
+        // A segment that fills to `COMMIT_DELTA_SEGMENT_MAX_ROWS` is the one
+        // case where that stops being true. Filling a whole segment is also
+        // what takes the commit over the packing threshold, so its rows leave
+        // the hot plane and every current-value read has to fetch the manifest
+        // and decode the entire inlined segment to reach one row.
+        //
+        // Measured (rocksdb, 10 240 rows, 2 000 point reads, ryzen-9950x-II):
+        // a 512-row commit read at 887 us against 140 us at 511 rows and
+        // 314 us at 513 — 6.3x — because 512 is the only width that both packs
+        // and produces exactly one segment. Decode dominates that cost
+        // (`decode_commit_delta_with_payloads` 41%, zstd 23%, manifest fetch
+        // under 2.5%), so the fix is to stop inlining a full segment rather
+        // than to make the fetch cheaper.
+        if usize::from(segment_row_counts[0]) < COMMIT_DELTA_SEGMENT_MAX_ROWS {
+            manifest.inline_segment = encoded;
+        } else {
+            manifest.segments.push(bounds);
+            writes.reserve_space(TRACKED_STATE_COMMIT_DELTA_SEGMENT_SPACE, 1, 0);
+            writes.put(
+                TRACKED_STATE_COMMIT_DELTA_SEGMENT_SPACE,
+                key(commit_delta_segment_key(commit_id, 0)?),
+                value(encoded),
+            );
+        }
     }
     let dense_addresses = segment_row_counts
         .iter()


### PR DESCRIPTION
## Summary

**A commit of exactly 512 rows made every later current-value read of those rows 6.3x slower.**
Point reads cost **895 µs** against **140 µs** at a 511-row commit and **314 µs** at 513 — a
non-monotonic cliff at one exact width, invisible to anyone benchmarking at 500 or 1000. This fixes
it: **895 µs → 319 µs, −64.3%**, with writes also **19% faster**, for **+1.8% logical bytes** on the
affected commits and **zero change** to every other width.

512 is not an exotic number. It is `COMMIT_DELTA_SEGMENT_MAX_ROWS`, and it is an ordinary bulk-import
batch size — and lix imports files as rows.

## Why exactly 512

Two thresholds collide at one value:

- A commit that fills a whole segment crosses the **packing** threshold, so its rows leave the hot
  plane and current-value reads must go through the packed commit-delta path.
- A commit of ≤512 rows produces exactly **one** segment, and `segment_row_counts.len() == 1`
  inlined that segment into the commit-state manifest value instead of writing it as a
  `commit_delta_segment` row.

512 is the only width that satisfies both. Below it the rows stay on the hot plane, so the inlined
payload is written but never read. Above it there are two segments, so nothing is inlined. At
exactly 512 the rows are packed *and* the whole 512-row payload is inlined, so every point read
fetches the manifest and decodes all 512 rows to return one.

The census proves it: width 512 was the **only** width with zero `commit_delta_segment` rows while
being fully packed (`hot_state.row` = 41, i.e. bootstrap rows only).

## What changed

`packages/lix/src/tracked_state/storage.rs` — one predicate. A lone segment is still inlined, but
**not when it filled to `COMMIT_DELTA_SEGMENT_MAX_ROWS`**; that one case is written as segment 0 and
its bounds pushed into `manifest.segments`, exactly as the multi-segment path already does.

Nothing was removed and no adapter API changed. The non-inline single-segment manifest is not a new
state — it is the same shape the two-segment path already produces, and the reader already falls
back from `manifest.inline_segment()` to `manifest.segments` (`storage.rs`, and
`commit_delta_segment_for_key` binary-searches that list).

The inline optimization is **kept** for every case where it currently pays. Bounding it lower would
have cost a storage row per commit for widths 1–511, where the inlined payload is never read.

## Which of fetch / decompress / decode dominates — measured, not assumed

Frame-pointer call-graph profile of the read phase (`-F 2999 --call-graph fp`, 6086 samples at
width 512, 2569 at 513), inclusive:

| | width 512 | width 513 |
|---|---:|---:|
| `load_local_owned_commit_delta_entries_one_ordered` | 75.4% | 39.2% |
| `decode_commit_delta_with_payloads` | **41.3%** | below 2.5% |
| ` └ decode_commit_delta_leaf` | 34.0% | — |
| `decompress_zstd` | **22.6%** | — |
| manifest/segment fetch (`MultiGet`) | **below 2.5%** | ~19% |

Self time at 512: `decode_node_ref` **19.1%**, `ZSTD_decompressSequences` 17.1%, `read_varint` 6.0%.

**The fetch is not the problem — it is cheaper at 512 than at 513**, which is exactly what inlining
buys. The cost is decoding the entire inlined segment: ~41% decode plus ~23% decompress. That is why
the fix is a bound on *what may be inlined* rather than a faster fetch, a smaller segment size, or a
lazy decode.

## A/B — interleaved, rotated, 6 reps per arm

`base` = `e12/harness-only` (integration head + the harness commit, no engine change).
Order rotated `base, cand, cand, base` × 3 so each arm takes each position equally.
RocksDB, 10 240 rows seeded at the stated commit width, 2 000 point reads over all rows.

**Width 512 — the affected lane (µs/read):**

| arm | per-rep | median | delta |
|---|---|---:|---:|
| base | 891.9 · 895.2 · 895.5 · 895.5 · 896.5 · 899.4 | **895.5** | |
| cand | 318.0 · 319.1 · 319.5 · 319.5 · 319.7 · 320.1 | **319.5** | **−64.3%** |

Ranges do not overlap at all (891.9–899.4 vs 318.0–320.1).

**Width 1000 — null control (µs/read).** My change cannot reach it: a 1000-row commit makes two
segments, so nothing was ever inlined. Byte-identical rows and key bytes in both arms.

| arm | per-rep | median | delta |
|---|---|---:|---:|
| base | 257.2 · 257.5 · 258.0 · 259.2 · 261.9 · 262.2 | **258.6** | |
| cand | 257.4 · 257.7 · 258.3 · 259.3 · 259.5 · 260.8 | **258.8** | **+0.08%** |

**The control's own spread is ±1.9%, so this bench cannot resolve anything under ~2%.** The 64.3%
win is two orders of magnitude outside that floor; the control's +0.08% is inside it.

**Write path (seed wall time, same runs):**

| width | base | cand | delta |
|---|---|---|---:|
| 512 | 119 · 120 · 120 · 121 · 122 · 149 ms | 97 · 97 · 97 · 98 · 98 · 99 ms | **−19.1%** |
| 1000 | 79 · 79 · 79 · 80 · 80 · 80 ms | 79 · 79 · 79 · 80 · 80 · 80 ms | 0% |

Writes got *faster*: the manifest value no longer carries a 512-row payload that must be encoded and
hashed on the commit path.

**Bytes and rows (deterministic, 1 rep — these reproduce exactly):**

| width | metric | base | cand | delta |
|---|---|---:|---:|---:|
| 512 | storage rows | 274 | 314 | **+40 (+14.6%)** |
| 512 | key bytes | 12 468 | 13 668 | +1 200 |
| 512 | logical bytes | 338 413 | 344 513 | **+6 100 (+1.8%)** |
| 1000 | rows / key bytes | 458 / 33 974 | 458 / 33 974 | **identical** |

Exact per-space row delta at width 512, everything else unchanged:
`tracked_state.commit_delta_segment.v6` **+20** and
`tracked_state.commit_mutation_directory_node.v1` **+20** — one segment row and one directory node
per affected commit.

## What regressed

**+1.8% logical bytes and +2 storage rows per 512-row commit.** Accepted under the round's priority
order: this trades the round's fourth priority (bytes on disk) for its third (OLTP), at a ratio of
+1.8% bytes for −64.3% read latency and −19.1% write latency, and only on commits that fill a
segment exactly. No other commit width changes on any axis.

## Layout invariants

1. **Single authority.** Unchanged — this moves one payload between two encodings of the same
   authority (inline in the manifest vs its own segment row). No second writer, no second copy: the
   inline field is left empty precisely when the segment row exists.
2. **Commit canonicality.** Unchanged.
3. **Derived views are caches.** Unchanged.
4. **Atomic publication.** Unchanged — the segment put joins the same write set as the manifest.
5. **GC from refs.** Unchanged; commit-delta segments are already swept with their commit.
6. **SQL reads canonical records.** Improved for the affected width: the read reaches the same
   canonical delta through a targeted segment fetch instead of decoding an inlined payload.

## Gate

Machine `ryzen-9950x-II`, run against `origin/main`'s `ci.yml` scope. Tree identity printed **inside**
the gate run, before and after:

```
GATE-TREE     rev=28c7b76aadb6ed5cf0efc3278641c0c83fd97bd1 status=[]
GATE-TREE-END rev=28c7b76aadb6ed5cf0efc3278641c0c83fd97bd1 status=[]
```

```
cargo clippy --profile test --workspace --all-targets --all-features -- -D warnings
cargo test --profile test --workspace --exclude lix_benchmarks --all-features --no-fail-fast
cargo test --profile test -p lix_benchmarks --features storage-benches,slatedb,root-replay-trace --no-fail-fast
cargo check -p lix --no-default-features
cargo check -p lix_js_sdk --target wasm32-unknown-unknown
```

**66 test targets ok, 0 failures, 0 panics.** Full log captured and grepped for `failures:`,
`panicked`, `test result: FAILED`, `^error` — not tailed.

## Harness

`write_amplification` gains `seed <dir> <rows> [seed_width]` and `read <dir> <reads> <distinct>`, so
the relationship between *how a row was written* and *what it costs to read* is measurable. That is
what surfaced this cliff, and it is what would catch a regression of it.
