### PR TITLE
refactor(lix): one authority for the order-preserving key byte format

### DIFF
--- a/packages/lix/src/hot_state/tracked_head.rs
+++ b/packages/lix/src/hot_state/tracked_head.rs
@@ -933,17 +933,12 @@ fn encode_working_diff_scope_prefix(
     out
 }
 
-const KEY_ESCAPE: u8 = 0xff;
-const KEY_PART_FINAL: u8 = 0x00;
-const KEY_PART_MORE: u8 = 0x01;
-const FILE_ID_NONE: u8 = 0x00;
-const FILE_ID_SOME: u8 = 0x01;
+// The key byte format is shared with the tracked-state tree and lives in one
+// place; see `crate::order_preserving_key`. Re-exported so this module's
+// children keep resolving these names through `use super::*`.
+pub(crate) use crate::order_preserving_key::*;
+
 const GENERATION_BYTES: usize = 16;
-const ENTITY_PK_CODEC_V1: u8 = 0x01;
-const ENTITY_PK_UUID: u8 = 0x00;
-const ENTITY_PK_INTEGER: u8 = 0x01;
-const ENTITY_PK_STRING: u8 = 0x02;
-const ENTITY_PK_BYTES: u8 = 0x03;
 
 /// Order-preserving tracked-head key encoding.
 ///
@@ -958,67 +953,6 @@ fn encode_scope_prefix(branch_id: &str, generation: CommitId) -> Vec<u8> {
     write_key_string(&mut out, branch_id, KEY_PART_FINAL);
     out.extend_from_slice(generation.as_uuid().as_bytes());
     out
-}
-
-fn write_entity_pk(out: &mut Vec<u8>, entity_pk: &EntityPk) {
-    debug_assert!(
-        !entity_pk.components.is_empty(),
-        "tracked-head entity primary keys must be non-empty"
-    );
-    out.push(ENTITY_PK_CODEC_V1);
-    for (index, component) in entity_pk.components.iter().enumerate() {
-        let terminator = if index + 1 == entity_pk.components.len() {
-            KEY_PART_FINAL
-        } else {
-            KEY_PART_MORE
-        };
-        match component {
-            crate::entity_pk::EntityPkComponent::Uuid(bytes) => {
-                out.push(ENTITY_PK_UUID);
-                out.extend_from_slice(bytes);
-                out.push(terminator);
-            }
-            crate::entity_pk::EntityPkComponent::Integer(value) => {
-                out.push(ENTITY_PK_INTEGER);
-                let ordered = u64::from_be_bytes(value.to_be_bytes()) ^ (1_u64 << 63);
-                out.extend_from_slice(&ordered.to_be_bytes());
-                out.push(terminator);
-            }
-            crate::entity_pk::EntityPkComponent::String(value) => {
-                out.push(ENTITY_PK_STRING);
-                write_key_bytes(out, value.as_bytes(), terminator);
-            }
-            crate::entity_pk::EntityPkComponent::Bytes(value) => {
-                out.push(ENTITY_PK_BYTES);
-                write_key_bytes(out, value, terminator);
-            }
-        }
-    }
-}
-
-fn write_file_id(out: &mut Vec<u8>, file_id: Option<&str>) {
-    match file_id {
-        None => out.push(FILE_ID_NONE),
-        Some(file_id) => {
-            out.push(FILE_ID_SOME);
-            write_key_string(out, file_id, KEY_PART_FINAL);
-        }
-    }
-}
-
-fn write_key_string(out: &mut Vec<u8>, value: &str, terminator: u8) {
-    write_key_bytes(out, value.as_bytes(), terminator);
-}
-
-fn write_key_bytes(out: &mut Vec<u8>, value: &[u8], terminator: u8) {
-    for &byte in value {
-        if byte == KEY_PART_FINAL {
-            out.extend_from_slice(&[KEY_PART_FINAL, KEY_ESCAPE]);
-        } else {
-            out.push(byte);
-        }
-    }
-    out.extend_from_slice(&[KEY_PART_FINAL, terminator]);
 }
 
 fn read_generation(bytes: &[u8], offset: &mut usize) -> Result<CommitId, LixError> {

--- a/packages/lix/src/lib.rs
+++ b/packages/lix/src/lib.rs
@@ -66,6 +66,7 @@ pub(crate) mod hot_state;
 mod module_layers;
 pub(crate) mod observe_coordinator;
 pub(crate) mod observe_invalidation;
+pub(crate) mod order_preserving_key;
 pub(crate) mod plugin;
 mod plugin_arena;
 mod plugin_layout;

--- a/packages/lix/src/module_layers.rs
+++ b/packages/lix/src/module_layers.rs
@@ -36,6 +36,11 @@ const MODULE_LAYERS: &[&[&str]] = &[
     // Value types and generic containers layered directly on the key space.
     &["binary_cas", "columnar_row_group", "common", "json_store"],
     &["entity_pk"],
+    // The order-preserving key byte format. A pure encoding over `entity_pk`
+    // with no repository semantics, and the single authority for how a key
+    // encodes. Both state planes store rows in the order it defines, so it must
+    // sit below both and must never read either back.
+    &["order_preserving_key"],
     // The canonical facts: changes, commits, commit-change ids.
     &["changelog"],
     // The collection-replacement marker. Both state planes read it to decide

--- a/packages/lix/src/order_preserving_key.rs
+++ b/packages/lix/src/order_preserving_key.rs
@@ -1,0 +1,198 @@
+//! The order-preserving key byte format, shared by the two planes that address
+//! rows by identity.
+//!
+//! The hot-head serving index (`hot_state::tracked_head`) and the tracked-state
+//! tree (`tracked_state::codec`) must agree byte-for-byte about how a key
+//! encodes. The head table's storage ordering *is* the visible row ordering,
+//! and the tree's ordering is what makes prefix scans exact, so a divergence
+//! between the two is not a bug in either plane — it is two planes disagreeing
+//! about what a key means. This module is the single authority for that format;
+//! neither plane may declare its own tags or writers.
+//!
+//! NUL bytes are escaped as `00 ff`, so no encoded part can contain the
+//! terminator. Tags match `EntityPk`'s cross-type order. UUIDs use raw bytes and
+//! signed integers use sign-bit-flipped big endian, so lexical byte order is
+//! logical order.
+
+pub(crate) const KEY_ESCAPE: u8 = 0xff;
+pub(crate) const KEY_PART_FINAL: u8 = 0x00;
+pub(crate) const KEY_PART_MORE: u8 = 0x01;
+pub(crate) const FILE_ID_NONE: u8 = 0x00;
+pub(crate) const FILE_ID_SOME: u8 = 0x01;
+pub(crate) const ENTITY_PK_CODEC_V1: u8 = 0x01;
+pub(crate) const ENTITY_PK_UUID: u8 = 0x00;
+pub(crate) const ENTITY_PK_INTEGER: u8 = 0x01;
+pub(crate) const ENTITY_PK_STRING: u8 = 0x02;
+pub(crate) const ENTITY_PK_BYTES: u8 = 0x03;
+
+/// Encoding an empty primary key is deliberately not an assertion failure.
+/// Non-emptiness is enforced where it can produce a real error —
+/// `EntityPk::from_components` rejects it, and `decode_key` rejects the encoded
+/// form — and `tracked_state::codec` relies on being able to encode one so that
+/// the decoder is what reports it. (The two former copies of this writer
+/// disagreed on exactly this point: the hot-head copy carried a `debug_assert`
+/// the tracked-state copy did not, so they produced the same bytes under
+/// different contracts. That divergence is the reason this module exists.)
+pub(crate) fn write_entity_pk(out: &mut Vec<u8>, entity_pk: &crate::entity_pk::EntityPk) {
+    out.push(ENTITY_PK_CODEC_V1);
+    for (index, component) in entity_pk.components.iter().enumerate() {
+        let terminator = if index + 1 == entity_pk.components.len() {
+            KEY_PART_FINAL
+        } else {
+            KEY_PART_MORE
+        };
+        match component {
+            crate::entity_pk::EntityPkComponent::Uuid(bytes) => {
+                out.push(ENTITY_PK_UUID);
+                out.extend_from_slice(bytes);
+                out.push(terminator);
+            }
+            crate::entity_pk::EntityPkComponent::Integer(value) => {
+                out.push(ENTITY_PK_INTEGER);
+                let ordered = u64::from_be_bytes(value.to_be_bytes()) ^ (1_u64 << 63);
+                out.extend_from_slice(&ordered.to_be_bytes());
+                out.push(terminator);
+            }
+            crate::entity_pk::EntityPkComponent::String(value) => {
+                out.push(ENTITY_PK_STRING);
+                write_key_bytes(out, value.as_bytes(), terminator);
+            }
+            crate::entity_pk::EntityPkComponent::Bytes(value) => {
+                out.push(ENTITY_PK_BYTES);
+                write_key_bytes(out, value, terminator);
+            }
+        }
+    }
+}
+
+pub(crate) fn write_file_id(out: &mut Vec<u8>, file_id: Option<&str>) {
+    match file_id {
+        None => out.push(FILE_ID_NONE),
+        Some(file_id) => {
+            out.push(FILE_ID_SOME);
+            write_key_string(out, file_id, KEY_PART_FINAL);
+        }
+    }
+}
+
+pub(crate) fn write_key_string(out: &mut Vec<u8>, value: &str, terminator: u8) {
+    write_key_bytes(out, value.as_bytes(), terminator);
+}
+
+pub(crate) fn write_key_bytes(out: &mut Vec<u8>, value: &[u8], terminator: u8) {
+    for &byte in value {
+        if byte == KEY_PART_FINAL {
+            out.extend_from_slice(&[KEY_PART_FINAL, KEY_ESCAPE]);
+        } else {
+            out.push(byte);
+        }
+    }
+    out.extend_from_slice(&[KEY_PART_FINAL, terminator]);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::entity_pk::{EntityPk, EntityPkComponent};
+
+    fn encoded_entity_pk(components: Vec<EntityPkComponent>) -> Vec<u8> {
+        let entity_pk = EntityPk::from_components(components.into_iter().collect())
+            .expect("golden entity primary keys are non-empty");
+        let mut out = Vec::new();
+        write_entity_pk(&mut out, &entity_pk);
+        out
+    }
+
+    /// Golden bytes. Both planes now call these writers, so byte-identity
+    /// across the planes holds by construction — what still needs pinning is
+    /// the format itself, because a single edit here now moves both planes at
+    /// once. Every shape either plane emits is covered.
+    #[test]
+    fn key_part_encoding_is_byte_pinned() {
+        let mut out = Vec::new();
+        write_key_string(&mut out, "ab", KEY_PART_FINAL);
+        assert_eq!(out, vec![b'a', b'b', 0x00, 0x00]);
+
+        let mut out = Vec::new();
+        write_key_string(&mut out, "ab", KEY_PART_MORE);
+        assert_eq!(out, vec![b'a', b'b', 0x00, 0x01]);
+
+        // A NUL inside a part is escaped so it can never be read as the
+        // terminator that ends the part.
+        let mut out = Vec::new();
+        write_key_bytes(&mut out, b"a\0b", KEY_PART_FINAL);
+        assert_eq!(out, vec![b'a', 0x00, 0xff, b'b', 0x00, 0x00]);
+
+        let mut out = Vec::new();
+        write_key_bytes(&mut out, b"", KEY_PART_FINAL);
+        assert_eq!(out, vec![0x00, 0x00]);
+    }
+
+    #[test]
+    fn file_id_encoding_is_byte_pinned() {
+        let mut out = Vec::new();
+        write_file_id(&mut out, None);
+        assert_eq!(out, vec![0x00]);
+
+        let mut out = Vec::new();
+        write_file_id(&mut out, Some("f"));
+        assert_eq!(out, vec![0x01, b'f', 0x00, 0x00]);
+    }
+
+    #[test]
+    fn entity_pk_encoding_is_byte_pinned() {
+        assert_eq!(
+            encoded_entity_pk(vec![EntityPkComponent::String("x".into())]),
+            vec![0x01, 0x02, b'x', 0x00, 0x00]
+        );
+        assert_eq!(
+            encoded_entity_pk(vec![EntityPkComponent::Bytes(bytes::Bytes::from_static(&[0xaa]))]),
+            vec![0x01, 0x03, 0xaa, 0x00, 0x00]
+        );
+        assert_eq!(
+            encoded_entity_pk(vec![EntityPkComponent::Uuid([7; 16])]),
+            [vec![0x01, 0x00], vec![7; 16], vec![0x00]].concat()
+        );
+        assert_eq!(
+            encoded_entity_pk(vec![EntityPkComponent::Integer(1)]),
+            vec![0x01, 0x01, 0x80, 0, 0, 0, 0, 0, 0, 0x01, 0x00]
+        );
+
+        // Non-final components carry KEY_PART_MORE, the final one
+        // KEY_PART_FINAL, so a shorter key never prefixes a longer one at the
+        // same component boundary.
+        assert_eq!(
+            encoded_entity_pk(vec![
+                EntityPkComponent::String("a".into()),
+                EntityPkComponent::String("b".into()),
+            ]),
+            vec![0x01, 0x02, b'a', 0x00, 0x01, 0x02, b'b', 0x00, 0x00]
+        );
+    }
+
+    /// The reason the integer tag flips the sign bit: encoded order must be
+    /// logical order, because these bytes *are* the storage ordering.
+    #[test]
+    fn integer_components_encode_in_signed_order() {
+        let ordered = [i64::MIN, -2, -1, 0, 1, 2, i64::MAX]
+            .into_iter()
+            .map(|value| encoded_entity_pk(vec![EntityPkComponent::Integer(value)]))
+            .collect::<Vec<_>>();
+        let mut sorted = ordered.clone();
+        sorted.sort();
+        assert_eq!(ordered, sorted);
+    }
+
+    /// Escaping is what keeps lexical order faithful for strings that contain
+    /// the terminator byte.
+    #[test]
+    fn escaped_strings_keep_lexical_order() {
+        let ordered = ["a", "a\0", "a\0b", "ab", "b"]
+            .into_iter()
+            .map(|value| encoded_entity_pk(vec![EntityPkComponent::String(value.into())]))
+            .collect::<Vec<_>>();
+        let mut sorted = ordered.clone();
+        sorted.sort();
+        assert_eq!(ordered, sorted);
+    }
+}

--- a/packages/lix/src/tracked_state/codec.rs
+++ b/packages/lix/src/tracked_state/codec.rs
@@ -648,16 +648,9 @@ pub(crate) fn decode_key_with_trusted_prefix(
     })
 }
 
-const KEY_ESCAPE: u8 = 0xff;
-const KEY_PART_FINAL: u8 = 0x00;
-const KEY_PART_MORE: u8 = 0x01;
-const FILE_ID_NONE: u8 = 0x00;
-const FILE_ID_SOME: u8 = 0x01;
-const ENTITY_PK_CODEC_V1: u8 = 0x01;
-const ENTITY_PK_UUID: u8 = 0x00;
-const ENTITY_PK_INTEGER: u8 = 0x01;
-const ENTITY_PK_STRING: u8 = 0x02;
-const ENTITY_PK_BYTES: u8 = 0x03;
+// The key byte format is shared with the hot-head serving index and lives in
+// one place; see `crate::order_preserving_key`.
+use crate::order_preserving_key::*;
 
 /// Order-preserving tracked-state key encoding.
 ///
@@ -684,60 +677,7 @@ fn encode_key_parts_into(
 ) {
     write_key_string(out, schema_key, KEY_PART_FINAL);
     write_file_id(out, file_id);
-    out.push(ENTITY_PK_CODEC_V1);
-    for (index, component) in entity_pk.components.iter().enumerate() {
-        let terminator = if index + 1 == entity_pk.components.len() {
-            KEY_PART_FINAL
-        } else {
-            KEY_PART_MORE
-        };
-        match component {
-            crate::entity_pk::EntityPkComponent::Uuid(bytes) => {
-                out.push(ENTITY_PK_UUID);
-                out.extend_from_slice(bytes);
-                out.push(terminator);
-            }
-            crate::entity_pk::EntityPkComponent::Integer(value) => {
-                out.push(ENTITY_PK_INTEGER);
-                let ordered = u64::from_be_bytes(value.to_be_bytes()) ^ (1_u64 << 63);
-                out.extend_from_slice(&ordered.to_be_bytes());
-                out.push(terminator);
-            }
-            crate::entity_pk::EntityPkComponent::String(value) => {
-                out.push(ENTITY_PK_STRING);
-                write_key_bytes(out, value.as_bytes(), terminator);
-            }
-            crate::entity_pk::EntityPkComponent::Bytes(value) => {
-                out.push(ENTITY_PK_BYTES);
-                write_key_bytes(out, value, terminator);
-            }
-        }
-    }
-}
-
-fn write_file_id(out: &mut Vec<u8>, file_id: Option<&str>) {
-    match file_id {
-        None => out.push(FILE_ID_NONE),
-        Some(file_id) => {
-            out.push(FILE_ID_SOME);
-            write_key_string(out, file_id, KEY_PART_FINAL);
-        }
-    }
-}
-
-fn write_key_string(out: &mut Vec<u8>, value: &str, terminator: u8) {
-    write_key_bytes(out, value.as_bytes(), terminator);
-}
-
-fn write_key_bytes(out: &mut Vec<u8>, value: &[u8], terminator: u8) {
-    for &byte in value {
-        if byte == 0 {
-            out.extend_from_slice(&[0, KEY_ESCAPE]);
-        } else {
-            out.push(byte);
-        }
-    }
-    out.extend_from_slice(&[0, terminator]);
+    write_entity_pk(out, entity_pk);
 }
 
 fn read_file_id_cow<'a>(


### PR DESCRIPTION
# refactor(lix): one authority for the order-preserving key byte format

**Machine:** `ryzen-9950x-III`. **Base SHA:** `d0de4e869`. No behaviour change, no public API change,
no SQL surface change, **no adapter API change**, no bytes on disk.

## What was duplicated

`hot_state/tracked_head.rs` and `tracked_state/codec.rs` each declared, independently:

- the same **ten** tag constants — `KEY_ESCAPE`, `KEY_PART_FINAL`, `KEY_PART_MORE`, `FILE_ID_NONE`,
  `FILE_ID_SOME`, `ENTITY_PK_CODEC_V1`, `ENTITY_PK_UUID`, `ENTITY_PK_INTEGER`, `ENTITY_PK_STRING`,
  `ENTITY_PK_BYTES`;
- `write_key_bytes`, `write_key_string`, `write_file_id`, and the entity-pk component loop
  (a `write_entity_pk` function in one plane, inlined into `encode_key_parts_into` in the other).

This is two authorities for one fact, and the fact is a **wire format**. The head table's storage
ordering *is* the visible row ordering, and the tree's ordering is what makes prefix scans exact, so
a divergence between the two copies is not a bug in either plane — it is two planes disagreeing about
what a key means. That is cross-plane corruption, and nothing in the build would have caught it.

## What changed

New `packages/lix/src/order_preserving_key.rs` holds the constants and the four writers. Both former
copies are **deleted**; `tracked_head.rs` re-exports the module (`pub(crate) use`) so its child
`tracked_head/hot.rs`, which calls `write_entity_pk` in eight places, keeps resolving the names
through `use super::*`. `codec.rs`'s inlined loop becomes a call to the shared `write_entity_pk`.

Removed: **20 constant declarations** (10 per plane) and **7 duplicated function bodies**.

```
 packages/lix/src/hot_state/tracked_head.rs | 76 ++-----------------
 packages/lix/src/tracked_state/codec.rs    | 68 ++----------------
 packages/lix/src/lib.rs                    |  1 +
 packages/lix/src/module_layers.rs          |  6 ++
 packages/lix/src/order_preserving_key.rs   | (new)
```

Placed directly above `entity_pk` in `MODULE_LAYERS`: a pure encoding whose only dependency is
`entity_pk`, sitting below both state planes and reading neither back. The layering guard
(`every_top_level_module_is_accounted_for`) required this declaration and is what makes the position
reviewable rather than incidental.

## The copies had already diverged — the gate caught it

They emitted identical bytes but did **not** have identical contracts. `tracked_head`'s copy carried

```rust
debug_assert!(!entity_pk.components.is_empty(), "tracked-head entity primary keys must be non-empty");
```

and `tracked_state`'s copy did not. `tracked_state::codec::tests::key_codec_rejects_empty_entity_pk`
encodes an empty primary key **on purpose** and asserts that `decode_key` is what reports it:

```rust
let encoded = encode_key(&TrackedStateKey { …, entity_pk: EntityPk::from_parts_unchecked(Vec::new()) });
let error = decode_key(&encoded).expect_err("empty entity pk should reject");
assert!(error.message.contains("entity primary key is empty"));
```

So the same input was a debug panic on one plane and a well-defined encoding on the other. The shared
writer takes the tracked-state contract — the only one with a test behind it — and the reasoning is
recorded at the call site. Non-emptiness is still enforced where it can produce a real error:
`EntityPk::from_components` rejects it, and `decode_key` rejects the encoded form.

This is worth stating plainly because it is the argument for the change: the duplication had *already*
drifted. It drifted in an assertion rather than in emitted bytes, so it was harmless this time. There
was nothing structural preventing the next drift from being in the bytes.

## Byte identity — measured, not asserted

A temporary probe dumped the encoded bytes from **both** planes over a 14-shape corpus, on the parent
commit and on this branch, and the outputs were diffed. The probe was removed before commit.

Corpus: plain string pk; pk with a file id; embedded NUL in schema key, file id **and** pk (the
escape path); `i64::MIN`, `-1`, `0`, `i64::MAX`; all-zero and all-ones UUIDs; a bytes component
containing `00` and `ff`; a four-component composite (string + integer + uuid + bytes) exercising
`KEY_PART_MORE`; empty schema key with empty file id; a pk that is a single NUL; an empty bytes
component. Each shape is emitted through the head plane's writers and the tree plane's
`encode_key_parts`, plus a `KEY_PART_MORE` terminator variant.

```
$ diff e27-base.txt e27-cand.txt
(no output — 42 lines, byte-for-byte identical)
```

Re-run after the contract fix above: still identical.

Sample (head plane, cases 0–2 — note the `00 ff` escapes in case 2):

```
E27 HEAD case00 736368656d610000000102780000
E27 HEAD case01 736368656d6100000166696c652d3100000102780000
E27 HEAD case02 6100ff620000016600ff67000001027000ff710000
```

## Explicit format tests

The shared module carries golden byte vectors, because a single edit there now moves **both** planes
at once — the refactor concentrates the blast radius, so the format needs pinning where it lives:

- `key_part_encoding_is_byte_pinned` — terminators, and `a\0b` → `61 00 ff 62 00 00`;
- `file_id_encoding_is_byte_pinned` — `None` → `00`, `Some("f")` → `01 66 00 00`;
- `entity_pk_encoding_is_byte_pinned` — all four component tags plus the `KEY_PART_MORE` /
  `KEY_PART_FINAL` split across a two-component key;
- `integer_components_encode_in_signed_order` — `i64::MIN … i64::MAX` encode in ascending byte order,
  which is *why* the integer tag flips the sign bit;
- `escaped_strings_keep_lexical_order` — `"a" < "a\0" < "a\0b" < "ab" < "b"` survives escaping.

The byte vectors were derived by hand from the original code and passed first try, which is
independent evidence the moved bodies match the originals.

## Layout invariants

1. **Single authority.** This is the point. Two declarations of one wire format are consolidated into
   one, and both originals are **deleted** — not relocated, not wrapped. Verified: `const KEY_ESCAPE`
   and `const ENTITY_PK_CODEC_V1` now have exactly one declaring site each, repo-wide.
2. **Commit canonicality.** Untouched. No commit record, ref, or parent link is read or written
   differently.
3. **Derived views are caches.** Unchanged, and reinforced: the hot plane and the canonical tree now
   share the key format explicitly instead of each asserting its own, and the module sits below both.
4. **Atomic publication.** Unaffected; no publication path is touched.
5. **GC from refs.** Unaffected; no retention metadata is read or written.
6. **SQL reads canonical records.** Unaffected; no query surface is touched.

## Adapter API

None added, changed, or removed. This is entirely inside `packages/lix`.

## Why it matters beyond tidiness

It is a precondition for changing key width — or any tag, escape rule, or component encoding — at one
point rather than two. E6 is working on physical key width; that change is materially safer against
this module than against two copies that must be edited in lockstep and whose agreement nothing
verifies.

## Gate

`ryzen-9950x-III`, `ci.yml` scope from `origin/main`, `--no-fail-fast`, full log captured and grepped:

**3507 passed / 0 failed across 66 test targets, 0 clippy warnings**, plus
`cargo check -p lix --no-default-features` and `cargo check -p lix_js_sdk --target wasm32-unknown-unknown`
clean.

No versioned identifier was changed — `ENTITY_PK_CODEC_V1` keeps its name and its value `0x01` — so
no repo-wide literal grep was required. I confirmed anyway that the constant now has a single
declaring site.

## What regressed

Nothing. No timing lane can move: the emitted bytes are identical and the writers are the same code
in the same crate, now reached through one path instead of two. No bytes-on-disk or version-control
metric can move for the same reason.

## Scope note

`tracked_head.rs` edits are confined to the codec block: the constant block and the four writer
definitions. Nothing else in that file was touched.
