### PR TITLE
test(storage): qualify crash consistency by SIGKILLing the writer mid-publication

### DIFF
--- a/packages/engine-benchmarks/Cargo.toml
+++ b/packages/engine-benchmarks/Cargo.toml
@@ -156,6 +156,11 @@ path = "tests/large_payload_read_qualification.rs"
 required-features = ["storage-benches", "slatedb"]
 
 [[test]]
+name = "crash_consistency_qualification"
+path = "tests/crash_consistency_qualification.rs"
+required-features = ["rocksdb"]
+
+[[test]]
 name = "certified_replacement_delete_reopen"
 path = "tests/certified_replacement_delete_reopen.rs"
 required-features = ["rocksdb", "slatedb"]

--- a/packages/engine-benchmarks/tests/crash_consistency_qualification.rs
+++ b/packages/engine-benchmarks/tests/crash_consistency_qualification.rs
@@ -238,6 +238,14 @@ impl StorageWrite for CrashWrite {
 struct Workload {
     rows: usize,
     commits: u64,
+    /// Bytes of binary file content rewritten in the same transaction.
+    ///
+    /// A non-zero size routes each publication through the atomic
+    /// content-addressed path (`stage_atomic_cas_publication`), which stages
+    /// blob chunks, a prepared manifest and a publication fence alongside the
+    /// row write set — a materially different publication shape from a plain
+    /// row commit, and the one the engine marks `await_durable`.
+    blob_bytes: usize,
 }
 
 impl Workload {
@@ -246,8 +254,21 @@ impl Workload {
         Self {
             rows: env_usize("LIX_CRASH_CONSISTENCY_ROWS", if deep { 64 } else { 8 }),
             commits: env_u64("LIX_CRASH_CONSISTENCY_COMMITS", if deep { 12 } else { 3 }),
+            blob_bytes: env_usize(
+                "LIX_CRASH_CONSISTENCY_BLOB_BYTES",
+                if deep { 128 * 1024 } else { 64 * 1024 },
+            ),
         }
     }
+}
+
+const BLOB_PATH: &str = "/crash-consistency.bin";
+
+/// Deterministic content whose every byte depends on the generation, so a blob
+/// left over from a different generation cannot masquerade as the current one.
+fn blob_for(generation: i64, size: usize) -> Vec<u8> {
+    let mut rng = SplitMix64::new(0xb10b_0000_0000_0000 ^ generation as u64);
+    (0..size).map(|_| (rng.next() >> 24) as u8).collect()
 }
 
 fn env_flag(name: &str) -> bool {
@@ -318,7 +339,7 @@ async fn child_main(db: PathBuf, ack: PathBuf, killer: Arc<Killer>, workload: Wo
     // --- setup, deliberately not armed -------------------------------------
     let setup_started = Instant::now();
     register_schema(&lix).await;
-    write_generation(&lix, workload.rows, 0).await;
+    write_generation(&lix, workload, 0).await;
     // A fsynced marker so the verifier knows whether a crash landed in setup
     // (where the row invariant does not hold yet) or in the measured window.
     let marker = db.parent().expect("trial directory").join("setup.done");
@@ -333,7 +354,7 @@ async fn child_main(db: PathBuf, ack: PathBuf, killer: Arc<Killer>, workload: Wo
     // --- measured publication window ---------------------------------------
     killer.arm();
     for generation in 1..=workload.commits {
-        write_generation(&lix, workload.rows, generation as i64).await;
+        write_generation(&lix, workload, generation as i64).await;
         // Acknowledge only after `commit()` returned Ok. Whatever is in this
         // file must be visible after the crash; that is the durability half of
         // the invariant set.
@@ -371,9 +392,10 @@ async fn verify_after_crash(
     path: PathBuf,
     acked: Option<i64>,
     attempted: i64,
-    rows: usize,
+    workload: Workload,
     setup_complete: bool,
 ) -> Result<Recovered, String> {
+    let rows = workload.rows;
     // 1. Does the store open at all?
     let storage = RocksDB::open(&path).map_err(|error| format!("store did not open: {error}"))?;
     let lix = open_lix()
@@ -489,6 +511,35 @@ async fn verify_after_crash(
         }
     }
 
+    // The binary file is published through the content-addressed path in the
+    // same transaction as the rows. Its bytes must belong to the same
+    // generation the rows report, or the write set reached the store in pieces.
+    if workload.blob_bytes > 0
+        && let Some(visible) = generation
+    {
+        let content = read_blob(&lix)
+            .await
+            .map_err(|error| format!("binary file unreadable after crash: {error}"))?;
+        match content {
+            Some(bytes) if bytes == blob_for(visible, workload.blob_bytes) => {}
+            Some(bytes) => {
+                let matching = (0..=attempted)
+                    .chain(std::iter::once(visible))
+                    .find(|candidate| bytes == blob_for(*candidate, workload.blob_bytes));
+                return Err(format!(
+                    "TORN WRITE SET: rows report generation {visible} but the CAS-published file \
+                     holds generation {matching:?} ({} bytes)",
+                    bytes.len()
+                ));
+            }
+            None => {
+                return Err(format!(
+                    "TORN WRITE SET: rows report generation {visible} but the CAS-published file is absent"
+                ));
+            }
+        }
+    }
+
     // 5. Does the next commit after recovery succeed?
     if observed.is_empty() {
         // The crash landed before the schema or the seed published; recovering
@@ -498,7 +549,7 @@ async fn verify_after_crash(
         }
     }
     let recovery_generation = generation.unwrap_or(0) + RECOVERY_MARK;
-    upsert_generation(&lix, rows, recovery_generation, observed.is_empty())
+    upsert_generation(&lix, workload, recovery_generation, observed.is_empty())
         .await
         .map_err(|error| format!("first commit after recovery failed: {error}"))?;
     lix.close()
@@ -579,28 +630,24 @@ async fn register_schema<S: Storage + Clone + Send + Sync + 'static>(lix: &Lix<S
 /// write set reached the store in stages.
 async fn write_generation<S: Storage + Clone + Send + Sync + 'static>(
     lix: &Lix<S>,
-    rows: usize,
+    workload: Workload,
     generation: i64,
 ) {
-    write_generation_checked(lix, rows, generation)
+    upsert_generation(lix, workload, generation, generation == 0)
         .await
         .expect("crash-consistency generation commit");
 }
 
-async fn write_generation_checked<S: Storage + Clone + Send + Sync + 'static>(
-    lix: &Lix<S>,
-    rows: usize,
-    generation: i64,
-) -> Result<(), lix::LixError> {
-    upsert_generation(lix, rows, generation, generation == 0).await
-}
-
+/// One publication that rewrites every row *and* the binary file to the same
+/// generation, so a torn write set is visible either as mixed row generations or
+/// as a blob that disagrees with the rows.
 async fn upsert_generation<S: Storage + Clone + Send + Sync + 'static>(
     lix: &Lix<S>,
-    rows: usize,
+    workload: Workload,
     generation: i64,
     insert: bool,
 ) -> Result<(), lix::LixError> {
+    let rows = workload.rows;
     let mut transaction = lix.begin_transaction().await?;
     for index in 0..rows {
         let payload = format!("gen-{generation}-row-{index}");
@@ -628,6 +675,24 @@ async fn upsert_generation<S: Storage + Clone + Send + Sync + 'static>(
                         Value::Text(payload),
                         Value::Text(format!("row-{index}")),
                     ],
+                )
+                .await?;
+        }
+    }
+    if workload.blob_bytes > 0 {
+        let content = Value::Blob(blob_for(generation, workload.blob_bytes).into());
+        if insert {
+            transaction
+                .execute(
+                    "INSERT INTO lix_file (path, content) VALUES ($1, $2)",
+                    &[Value::Text(BLOB_PATH.to_owned()), content],
+                )
+                .await?;
+        } else {
+            transaction
+                .execute(
+                    "UPDATE lix_file SET content = $1 WHERE path = $2",
+                    &[content, Value::Text(BLOB_PATH.to_owned())],
                 )
                 .await?;
         }
@@ -666,6 +731,26 @@ async fn read_generations<S: Storage + Clone + Send + Sync + 'static>(
         .iter()
         .map(|row| row.get::<i64>("generation").expect("generation is an integer"))
         .collect())
+}
+
+async fn read_blob<S: Storage + Clone + Send + Sync + 'static>(
+    lix: &Lix<S>,
+) -> Result<Option<Vec<u8>>, String> {
+    let result = lix
+        .execute(
+            "SELECT content FROM lix_file WHERE path = $1",
+            &[Value::Text(BLOB_PATH.to_owned())],
+        )
+        .await
+        .map_err(|error| error.to_string())?;
+    let rows = result.rows();
+    if rows.is_empty() {
+        return Ok(None);
+    }
+    rows[0]
+        .get::<Vec<u8>>("content")
+        .map(Some)
+        .map_err(|error| format!("content was not a blob: {error}"))
 }
 
 async fn scalar_text<S: Storage + Clone + Send + Sync + 'static>(
@@ -758,7 +843,7 @@ fn rocksdb_publication_window_survives_sigkill_at_every_storage_event() {
             control_database,
             control_acked,
             workload.commits as i64,
-            workload.rows,
+            workload,
             true,
         )
     });
@@ -800,13 +885,7 @@ fn rocksdb_publication_window_survives_sigkill_at_every_storage_event() {
         let acked = child.acked;
         let setup_complete = child.setup_complete;
         let outcome = block_on(move || {
-            verify_after_crash(
-                database,
-                acked,
-                workload.commits as i64,
-                workload.rows,
-                setup_complete,
-            )
+            verify_after_crash(database, acked, workload.commits as i64, workload, setup_complete)
         });
         match &outcome {
             Ok(recovered) => recovered_generations.push(recovered.generation),
@@ -847,13 +926,7 @@ fn rocksdb_publication_window_survives_sigkill_at_every_storage_event() {
         let acked = child.acked;
         let setup_complete = child.setup_complete;
         let outcome = block_on(move || {
-            verify_after_crash(
-                database,
-                acked,
-                workload.commits as i64,
-                workload.rows,
-                setup_complete,
-            )
+            verify_after_crash(database, acked, workload.commits as i64, workload, setup_complete)
         });
         match &outcome {
             Ok(recovered) => recovered_generations.push(recovered.generation),

--- a/packages/engine-benchmarks/tests/crash_consistency_qualification.rs
+++ b/packages/engine-benchmarks/tests/crash_consistency_qualification.rs
@@ -746,7 +746,34 @@ fn rocksdb_publication_window_survives_sigkill_at_every_storage_event() {
         .events
         .expect("calibration child must report its storage event count");
     assert!(events > 0, "publication window contained no storage events");
-    let labels = calibration.labels;
+    let labels = calibration.labels.clone();
+
+    // Null control: the same invariant battery against a store that was closed
+    // cleanly and never killed. If this does not pass, nothing the sweep reports
+    // afterwards is attributable to the crash.
+    let control_database = root.path().join("calibration").join("database");
+    let control_acked = calibration.acked;
+    let control = block_on(move || {
+        verify_after_crash(
+            control_database,
+            control_acked,
+            workload.commits as i64,
+            workload.rows,
+            true,
+        )
+    });
+    let control = control.unwrap_or_else(|error| {
+        panic!(
+            "clean-close control failed before any kill was issued — the harness, not the crash, \
+             is the problem: {error}"
+        )
+    });
+    assert_eq!(
+        control.generation,
+        Some(workload.commits as i64),
+        "clean-close control did not reach the last attempted generation"
+    );
+    let _ = fs::remove_dir_all(root.path().join("calibration"));
 
     let max_points = env_usize("LIX_CRASH_CONSISTENCY_MAX_POINTS", 512);
     let swept: Vec<u64> = if events as usize <= max_points {

--- a/packages/engine-benchmarks/tests/crash_consistency_qualification.rs
+++ b/packages/engine-benchmarks/tests/crash_consistency_qualification.rs
@@ -316,8 +316,19 @@ async fn child_main(db: PathBuf, ack: PathBuf, killer: Arc<Killer>, workload: Wo
         .expect("child opens crash-consistency Lix");
 
     // --- setup, deliberately not armed -------------------------------------
+    let setup_started = Instant::now();
     register_schema(&lix).await;
     write_generation(&lix, workload.rows, 0).await;
+    // A fsynced marker so the verifier knows whether a crash landed in setup
+    // (where the row invariant does not hold yet) or in the measured window.
+    let marker = db.parent().expect("trial directory").join("setup.done");
+    fs::write(&marker, b"1").expect("write crash-consistency setup marker");
+    fs::File::open(&marker)
+        .expect("reopen crash-consistency setup marker")
+        .sync_all()
+        .expect("fsync crash-consistency setup marker");
+    println!("E20_SETUP_NANOS {}", setup_started.elapsed().as_nanos());
+    let _ = std::io::stdout().flush();
 
     // --- measured publication window ---------------------------------------
     killer.arm();
@@ -350,7 +361,9 @@ fn append_ack(path: &Path, generation: u64) {
 
 #[derive(Debug)]
 struct Recovered {
-    generation: i64,
+    /// Highest generation visible after the crash, or `None` when the crash
+    /// landed before the seed commit published.
+    generation: Option<i64>,
 }
 
 /// Everything the brief asks of a store that has just survived a crash.
@@ -359,6 +372,7 @@ async fn verify_after_crash(
     acked: Option<i64>,
     attempted: i64,
     rows: usize,
+    setup_complete: bool,
 ) -> Result<Recovered, String> {
     // 1. Does the store open at all?
     let storage = RocksDB::open(&path).map_err(|error| format!("store did not open: {error}"))?;
@@ -401,43 +415,90 @@ async fn verify_after_crash(
     }
 
     // 3./4. Does a plain SELECT return one whole committed write set?
-    let observed = read_generations(&lix, rows)
-        .await
-        .map_err(|error| format!("plain SELECT failed after crash: {error}"))?;
-    let generation = single_generation(&observed)?;
-
-    // Durability: a commit whose `commit()` returned Ok must still be there.
-    if let Some(acked) = acked
-        && generation < acked
-    {
+    //
+    // A kill that landed before the seed commit published leaves the table
+    // absent or empty. Both are legal *pre-publication* states; what would not
+    // be legal is a partially applied seed, so the row count is still pinned to
+    // 0 or `rows` and the generations must still be uniform.
+    let observed = match read_generations(&lix).await {
+        Ok(observed) => observed,
+        Err(ReadFailure::TableAbsent) if !setup_complete => Vec::new(),
+        Err(ReadFailure::TableAbsent) => {
+            return Err(
+                "plain SELECT failed after crash: the table is gone even though setup completed"
+                    .to_owned(),
+            );
+        }
+        Err(ReadFailure::Other(error)) => {
+            return Err(format!("plain SELECT failed after crash: {error}"));
+        }
+    };
+    if !observed.is_empty() && observed.len() != rows {
         return Err(format!(
-            "acknowledged commit lost: ack log reached generation {acked}, store shows {generation}"
+            "TORN WRITE SET: {} rows visible, expected 0 or {rows} — a publication was observed half-applied",
+            observed.len()
         ));
     }
-    if generation > attempted {
+    let generation = if observed.is_empty() {
+        if setup_complete {
+            return Err(
+                "no rows visible even though the seed commit was acknowledged before the crash"
+                    .to_owned(),
+            );
+        }
+        None
+    } else {
+        Some(single_generation(&observed)?)
+    };
+
+    // Durability: a commit whose `commit()` returned Ok must still be there.
+    if let Some(acked) = acked {
+        let visible = generation.ok_or_else(|| {
+            format!("acknowledged commit lost: ack log reached generation {acked}, store is empty")
+        })?;
+        if visible < acked {
+            return Err(format!(
+                "acknowledged commit lost: ack log reached generation {acked}, store shows {visible}"
+            ));
+        }
+    }
+    if let Some(visible) = generation
+        && visible > attempted
+    {
         return Err(format!(
-            "store shows generation {generation}, which the writer never attempted (max {attempted})"
+            "store shows generation {visible}, which the writer never attempted (max {attempted})"
         ));
     }
 
     // Derived views must not be stale-but-authoritative: the history view is
     // rebuilt from canonical records and must agree with the serving read.
-    let history_rows = scalar_i64(
-        &lix,
-        &format!("SELECT COUNT(*) AS n FROM {SCHEMA_KEY}_history() WHERE generation = $1"),
-        &[Value::Integer(generation)],
-    )
-    .await
-    .map_err(|error| format!("history view unreadable after crash: {error}"))?;
-    if history_rows == 0 && generation > 0 {
-        return Err(format!(
-            "serving read reports generation {generation}, but the canonical history view has no such rows"
-        ));
+    if let Some(visible) = generation
+        && visible > 0
+    {
+        let history_rows = scalar_i64(
+            &lix,
+            &format!("SELECT COUNT(*) AS n FROM {SCHEMA_KEY}_history() WHERE generation = $1"),
+            &[Value::Integer(visible)],
+        )
+        .await
+        .map_err(|error| format!("history view unreadable after crash: {error}"))?;
+        if history_rows == 0 {
+            return Err(format!(
+                "serving read reports generation {visible}, but the canonical history view has no such rows"
+            ));
+        }
     }
 
     // 5. Does the next commit after recovery succeed?
-    let recovery_generation = generation + RECOVERY_MARK;
-    write_generation_checked(&lix, rows, recovery_generation)
+    if observed.is_empty() {
+        // The crash landed before the schema or the seed published; recovering
+        // means the store accepts the setup it never finished.
+        if matches!(read_generations(&lix).await, Err(ReadFailure::TableAbsent)) {
+            register_schema(&lix).await;
+        }
+    }
+    let recovery_generation = generation.unwrap_or(0) + RECOVERY_MARK;
+    upsert_generation(&lix, rows, recovery_generation, observed.is_empty())
         .await
         .map_err(|error| format!("first commit after recovery failed: {error}"))?;
     lix.close()
@@ -452,9 +513,15 @@ async fn verify_after_crash(
         .with_storage(storage.clone())
         .await
         .map_err(|error| format!("second engine open failed: {error}"))?;
-    let observed = read_generations(&lix, rows)
+    let observed = read_generations(&lix)
         .await
-        .map_err(|error| format!("SELECT after recovery reopen failed: {error}"))?;
+        .map_err(|error| format!("SELECT after recovery reopen failed: {error:?}"))?;
+    if observed.len() != rows {
+        return Err(format!(
+            "post-recovery commit left {} rows, expected {rows}",
+            observed.len()
+        ));
+    }
     let confirmed = single_generation(&observed)?;
     if confirmed != recovery_generation {
         return Err(format!(
@@ -525,10 +592,19 @@ async fn write_generation_checked<S: Storage + Clone + Send + Sync + 'static>(
     rows: usize,
     generation: i64,
 ) -> Result<(), lix::LixError> {
+    upsert_generation(lix, rows, generation, generation == 0).await
+}
+
+async fn upsert_generation<S: Storage + Clone + Send + Sync + 'static>(
+    lix: &Lix<S>,
+    rows: usize,
+    generation: i64,
+    insert: bool,
+) -> Result<(), lix::LixError> {
     let mut transaction = lix.begin_transaction().await?;
     for index in 0..rows {
         let payload = format!("gen-{generation}-row-{index}");
-        if generation == 0 {
+        if insert {
             transaction
                 .execute(
                     &format!(
@@ -560,29 +636,36 @@ async fn write_generation_checked<S: Storage + Clone + Send + Sync + 'static>(
     Ok(())
 }
 
+/// Why a post-crash read failed. A missing table is a legal pre-publication
+/// state; anything else is a defect.
+#[derive(Debug)]
+enum ReadFailure {
+    TableAbsent,
+    Other(String),
+}
+
 async fn read_generations<S: Storage + Clone + Send + Sync + 'static>(
     lix: &Lix<S>,
-    rows: usize,
-) -> Result<Vec<i64>, String> {
+) -> Result<Vec<i64>, ReadFailure> {
     let result = lix
         .execute(
             &format!("SELECT id, generation FROM {SCHEMA_KEY} ORDER BY id"),
             &[],
         )
         .await
-        .map_err(|error| error.to_string())?;
-    let observed: Vec<i64> = result
+        .map_err(|error| {
+            let text = error.to_string();
+            if text.contains("LIX_TABLE_NOT_FOUND") {
+                ReadFailure::TableAbsent
+            } else {
+                ReadFailure::Other(text)
+            }
+        })?;
+    Ok(result
         .rows()
         .iter()
         .map(|row| row.get::<i64>("generation").expect("generation is an integer"))
-        .collect();
-    if observed.len() != rows {
-        return Err(format!(
-            "row count is {} after recovery, expected {rows} — a publication was observed half-applied",
-            observed.len()
-        ));
-    }
-    Ok(observed)
+        .collect())
 }
 
 async fn scalar_text<S: Storage + Clone + Send + Sync + 'static>(
@@ -640,6 +723,7 @@ fn rocksdb_publication_window_survives_sigkill_at_every_storage_event() {
     let workload = Workload::from_env();
     let root = tempfile::tempdir().expect("create crash-consistency sweep root");
     let mut failures: Vec<String> = Vec::new();
+    let mut recovered_generations: Vec<Option<i64>> = Vec::new();
     let mut trials = 0usize;
     let mut killed_trials = 0usize;
 
@@ -687,14 +771,22 @@ fn rocksdb_publication_window_survives_sigkill_at_every_storage_event() {
             .unwrap_or_else(|| "?".to_owned());
         let database = dir.join("database");
         let acked = child.acked;
+        let setup_complete = child.setup_complete;
         let outcome = block_on(move || {
-            verify_after_crash(database, acked, workload.commits as i64, workload.rows)
+            verify_after_crash(
+                database,
+                acked,
+                workload.commits as i64,
+                workload.rows,
+                setup_complete,
+            )
         });
-        if let Err(error) = &outcome {
-            failures.push(format!(
+        match &outcome {
+            Ok(recovered) => recovered_generations.push(recovered.generation),
+            Err(error) => failures.push(format!(
                 "kill_at={kill_at} ({label}, killed={}): {error}",
                 child.killed_by_signal
-            ));
+            )),
         }
         let _ = fs::remove_dir_all(&dir);
     }
@@ -709,11 +801,15 @@ fn rocksdb_publication_window_survives_sigkill_at_every_storage_event() {
         },
     );
     let window_nanos = window_duration.as_nanos().max(1) as u64;
+    // Setup is not part of the measured window, so aim the timed kills at what
+    // follows it. A 10% undershoot deliberately keeps a few kills in late setup:
+    // a crash during repository initialization must also leave a usable store.
+    let setup_nanos = calibration.setup_nanos.unwrap_or(0);
+    let aim_from = setup_nanos - setup_nanos / 10;
+    let aim_span = window_nanos.saturating_sub(aim_from).max(1);
     let mut rng = SplitMix64::new(env_u64("LIX_CRASH_CONSISTENCY_SEED", 0x5eed_c0de_1234_5678));
     for trial in 0..timed_trials {
-        // Sweep the whole observed window, biased to the second half where the
-        // measured publications live (setup occupies the first part).
-        let delay = window_nanos / 4 + rng.next() % window_nanos;
+        let delay = aim_from + rng.next() % aim_span;
         let dir = root.path().join(format!("t{trial}"));
         let child = run_child(&dir, workload, KillPlan::AfterNanos(delay), false);
         trials += 1;
@@ -722,23 +818,36 @@ fn rocksdb_publication_window_survives_sigkill_at_every_storage_event() {
         }
         let database = dir.join("database");
         let acked = child.acked;
+        let setup_complete = child.setup_complete;
         let outcome = block_on(move || {
-            verify_after_crash(database, acked, workload.commits as i64, workload.rows)
+            verify_after_crash(
+                database,
+                acked,
+                workload.commits as i64,
+                workload.rows,
+                setup_complete,
+            )
         });
-        if let Err(error) = &outcome {
-            failures.push(format!(
+        match &outcome {
+            Ok(recovered) => recovered_generations.push(recovered.generation),
+            Err(error) => failures.push(format!(
                 "timed delay={delay}ns (killed={}): {error}",
                 child.killed_by_signal
-            ));
+            )),
         }
         let _ = fs::remove_dir_all(&dir);
     }
 
+    let mut distinct: Vec<Option<i64>> = recovered_generations.clone();
+    distinct.sort_unstable();
+    distinct.dedup();
     println!(
         "crash-consistency sweep: {trials} trials ({} storage-event points over a {events}-event \
-         publication window, {timed_trials} seeded wall-clock kills), {killed_trials} confirmed \
-         SIGKILLed, {} inconsistencies",
+         publication window, {timed_trials} seeded wall-clock kills spanning \
+         {aim_from}..{}ns), {killed_trials} confirmed SIGKILLed, {} inconsistencies; \
+         recovered generations observed: {distinct:?}",
         swept.len(),
+        aim_from + aim_span,
         failures.len()
     );
 
@@ -791,6 +900,8 @@ struct ChildRun {
     killed_by_signal: bool,
     acked: Option<i64>,
     events: Option<u64>,
+    setup_nanos: Option<u64>,
+    setup_complete: bool,
     labels: Vec<String>,
     output: String,
 }
@@ -849,11 +960,18 @@ fn run_child(dir: &Path, workload: Workload, plan: KillPlan, trace: bool) -> Chi
         .filter_map(|rest| rest.split_once(' ').map(|(_, label)| label.to_owned()))
         .collect();
 
+    let setup_nanos = stdout
+        .lines()
+        .find_map(|line| line.strip_prefix("E20_SETUP_NANOS "))
+        .and_then(|value| value.trim().parse().ok());
+
     ChildRun {
         status_success: output.status.success(),
         killed_by_signal: signal_of(&output.status) == Some(libc::SIGKILL),
         acked: read_ack(&ack),
         events,
+        setup_nanos,
+        setup_complete: dir.join("setup.done").exists(),
         labels,
         output: format!("stdout:\n{stdout}\nstderr:\n{stderr}"),
     }

--- a/packages/engine-benchmarks/tests/crash_consistency_qualification.rs
+++ b/packages/engine-benchmarks/tests/crash_consistency_qualification.rs
@@ -1,0 +1,938 @@
+//! Crash-consistency qualification: kill a real writer process with SIGKILL at
+//! every point of the publication window, then reopen the store in a fresh
+//! process and prove the invariants still hold.
+//!
+//! Every other "reopen" test in this repository performs an orderly
+//! `flush -> close -> drop -> reopen`. That verifies clean rollback, not crash
+//! consistency: it never observes the store in a state a cooperative shutdown
+//! cannot produce. This qualification closes that gap for the layout invariant
+//! that "state root, commit record, derived-view update and ref move publish in
+//! one atomic write set, never in stages another reader can observe half-done".
+//!
+//! ## How the window is swept
+//!
+//! [`CrashStorage`] wraps [`RocksDB`] and counts every mutation the engine
+//! issues at the storage boundary — `begin_write`, each `put_many`,
+//! `delete_many` and `delete_range`, the moment before `commit()` is delegated,
+//! and the moment after it returns. A child process is launched once per kill
+//! point with `LIX_CRASH_KILL_AT=k`; the wrapper raises `SIGKILL` on itself when
+//! the counter reaches `k`, so the process dies *inside* the publication with no
+//! unwinding, no destructor, and no flush. The sweep is exhaustive over `k`, and
+//! the event index is deterministic for a fixed workload, so a failing point
+//! reproduces by rerunning the same `k`.
+//!
+//! A second phase kills on a seeded wall-clock delay instead. That is the only
+//! way to land inside RocksDB's own write path (WAL append, memtable insert),
+//! which the storage-boundary sweep steps over atomically.
+//!
+//! ## What SIGKILL can and cannot prove
+//!
+//! SIGKILL models *process* death: the kernel keeps the page cache, so anything
+//! the process had already handed to `write(2)` survives. It therefore proves
+//! that the engine does not publish in observable stages. It does **not** model
+//! power loss, which additionally requires the backend to have fsynced. See
+//! `rocksdb_ignores_await_durable_write_option` in this file for the separate,
+//! statically-decidable half of that question.
+//!
+//! ## Cost
+//!
+//! The default sweep is deliberately small enough for CI. Set
+//! `LIX_CRASH_CONSISTENCY_DEEP=1` for a wider workload and a longer timed
+//! phase, or set the individual knobs:
+//!
+//! * `LIX_CRASH_CONSISTENCY_ROWS` — rows rewritten per commit (default 8)
+//! * `LIX_CRASH_CONSISTENCY_COMMITS` — commits attempted per trial (default 3)
+//! * `LIX_CRASH_CONSISTENCY_TIMED_TRIALS` — seeded wall-clock kills (default 12)
+//! * `LIX_CRASH_CONSISTENCY_MAX_POINTS` — cap on swept kill points (default 512)
+
+use std::fs;
+use std::io::Write as _;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::time::{Duration, Instant};
+
+use lix::storage::{
+    CommitResult, Key, KeyRange, PutBatch, ReadOptions, Storage, StorageError, StorageSpace,
+    StorageWrite, WriteOptions,
+};
+use lix::{Lix, Value, open_lix};
+use lix_storage_rocksdb::{RocksDB, RocksDBRead, RocksDBWrite};
+
+const SCHEMA_KEY: &str = "crash_consistency_row";
+const CHILD_ENV: &str = "LIX_CRASH_CONSISTENCY_CHILD";
+const CHILD_TEST: &str = "crash_consistency_child_worker";
+
+/// Marker added by the post-recovery write so a second reopen can prove the
+/// recovered store is stable, not merely readable once.
+const RECOVERY_MARK: i64 = 1_000_000;
+
+// ---------------------------------------------------------------------------
+// Kill scheduling
+// ---------------------------------------------------------------------------
+
+/// Counts storage-boundary events and kills the process at a chosen one.
+///
+/// Counting is disarmed during setup so that kill point `k` always refers to
+/// the same position inside the *measured* publication window regardless of how
+/// many writes schema registration and seeding happen to take.
+struct Killer {
+    counter: AtomicU64,
+    armed: AtomicBool,
+    kill_at: u64,
+    trace: bool,
+}
+
+impl Killer {
+    fn new(kill_at: u64, trace: bool) -> Self {
+        Self {
+            counter: AtomicU64::new(0),
+            armed: AtomicBool::new(false),
+            kill_at,
+            trace,
+        }
+    }
+
+    fn arm(&self) {
+        self.armed.store(true, Ordering::SeqCst);
+    }
+
+    fn events(&self) -> u64 {
+        self.counter.load(Ordering::SeqCst)
+    }
+
+    fn tick(&self, label: &str) {
+        if !self.armed.load(Ordering::SeqCst) {
+            return;
+        }
+        let index = self.counter.fetch_add(1, Ordering::SeqCst) + 1;
+        if self.trace {
+            println!("E20_EVENT {index} {label}");
+        }
+        if self.kill_at != 0 && index == self.kill_at {
+            // Flush whatever the harness itself has buffered; the point is to
+            // kill lix mid-publication, not to lose the trial's own bookkeeping.
+            let _ = std::io::stdout().flush();
+            // SIGKILL cannot be caught, blocked or ignored: no unwinding, no
+            // Drop, no RocksDB shutdown hook, no WAL flush.
+            unsafe {
+                libc::kill(libc::getpid(), libc::SIGKILL);
+            }
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Storage wrapper
+// ---------------------------------------------------------------------------
+
+#[derive(Clone)]
+struct CrashStorage {
+    inner: RocksDB,
+    killer: Arc<Killer>,
+}
+
+impl CrashStorage {
+    fn open(path: &Path, killer: Arc<Killer>) -> Self {
+        Self {
+            inner: RocksDB::open(path).expect("open crash-consistency RocksDB fixture"),
+            killer,
+        }
+    }
+}
+
+impl Storage for CrashStorage {
+    type Read<'a>
+        = RocksDBRead<'a>
+    where
+        Self: 'a;
+
+    type Write<'a>
+        = CrashWrite
+    where
+        Self: 'a;
+
+    fn begin_read(
+        &self,
+        opts: ReadOptions,
+    ) -> impl Future<Output = Result<Self::Read<'_>, StorageError>> + Send {
+        self.inner.begin_read(opts)
+    }
+
+    fn begin_write(
+        &self,
+        opts: WriteOptions,
+    ) -> impl Future<Output = Result<Self::Write<'_>, StorageError>> + Send {
+        let killer = self.killer.clone();
+        async move {
+            killer.tick("begin_write");
+            let inner = self.inner.begin_write(opts).await?;
+            Ok(CrashWrite { inner, killer })
+        }
+    }
+}
+
+struct CrashWrite {
+    inner: RocksDBWrite,
+    killer: Arc<Killer>,
+}
+
+impl StorageWrite for CrashWrite {
+    fn put_many(
+        &mut self,
+        space: StorageSpace,
+        entries: PutBatch,
+    ) -> impl Future<Output = Result<(), StorageError>> + Send {
+        self.killer.tick("put_many");
+        self.inner.put_many(space, entries)
+    }
+
+    fn delete_many(
+        &mut self,
+        space: StorageSpace,
+        keys: &[Key],
+    ) -> impl Future<Output = Result<(), StorageError>> + Send {
+        self.killer.tick("delete_many");
+        self.inner.delete_many(space, keys)
+    }
+
+    fn delete_range(
+        &mut self,
+        space: StorageSpace,
+        range: KeyRange,
+    ) -> impl Future<Output = Result<(), StorageError>> + Send {
+        self.killer.tick("delete_range");
+        self.inner.delete_range(space, range)
+    }
+
+    fn commit(self) -> impl Future<Output = Result<CommitResult, StorageError>> + Send {
+        let killer = self.killer;
+        let inner = self.inner;
+        async move {
+            killer.tick("pre_commit");
+            let result = inner.commit().await;
+            killer.tick("post_commit");
+            result
+        }
+    }
+
+    fn rollback(self) -> impl Future<Output = Result<(), StorageError>> + Send {
+        let killer = self.killer;
+        let inner = self.inner;
+        async move {
+            killer.tick("rollback");
+            inner.rollback().await
+        }
+    }
+}
+
+// The read side is pass-through: `RocksDBRead` already satisfies `StorageRead`,
+// and a read cannot publish, so reads are not kill points.
+
+// ---------------------------------------------------------------------------
+// Workload shape
+// ---------------------------------------------------------------------------
+
+#[derive(Clone, Copy)]
+struct Workload {
+    rows: usize,
+    commits: u64,
+}
+
+impl Workload {
+    fn from_env() -> Self {
+        let deep = env_flag("LIX_CRASH_CONSISTENCY_DEEP");
+        Self {
+            rows: env_usize("LIX_CRASH_CONSISTENCY_ROWS", if deep { 64 } else { 8 }),
+            commits: env_u64("LIX_CRASH_CONSISTENCY_COMMITS", if deep { 12 } else { 3 }),
+        }
+    }
+}
+
+fn env_flag(name: &str) -> bool {
+    std::env::var(name).map(|v| v != "0" && !v.is_empty()).unwrap_or(false)
+}
+
+fn env_usize(name: &str, default: usize) -> usize {
+    std::env::var(name)
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(default)
+}
+
+fn env_u64(name: &str, default: u64) -> u64 {
+    std::env::var(name)
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(default)
+}
+
+// ---------------------------------------------------------------------------
+// Child process: the writer that gets killed
+// ---------------------------------------------------------------------------
+
+/// Re-entry point for the child processes the sweep spawns.
+///
+/// A plain test run executes this as a no-op; it only does work when the parent
+/// has set [`CHILD_ENV`], which it does when re-invoking this same binary.
+#[test]
+fn crash_consistency_child_worker() {
+    if std::env::var(CHILD_ENV).is_err() {
+        return;
+    }
+    let db = PathBuf::from(std::env::var("LIX_CRASH_DB").expect("child needs LIX_CRASH_DB"));
+    let ack = PathBuf::from(std::env::var("LIX_CRASH_ACK").expect("child needs LIX_CRASH_ACK"));
+    let kill_at = env_u64("LIX_CRASH_KILL_AT", 0);
+    let kill_after_nanos = env_u64("LIX_CRASH_KILL_AFTER_NANOS", 0);
+    let trace = env_flag("LIX_CRASH_TRACE");
+    let workload = Workload::from_env();
+
+    let killer = Arc::new(Killer::new(kill_at, trace));
+
+    if kill_after_nanos != 0 {
+        // Timed phase: a watchdog thread lands the kill wherever the writer
+        // happens to be, including inside RocksDB's own WAL append.
+        std::thread::Builder::new()
+            .name("crash-consistency-watchdog".to_owned())
+            .spawn(move || {
+                std::thread::sleep(Duration::from_nanos(kill_after_nanos));
+                let _ = std::io::stdout().flush();
+                unsafe {
+                    libc::kill(libc::getpid(), libc::SIGKILL);
+                }
+            })
+            .expect("spawn crash-consistency watchdog");
+    }
+
+    run_on_large_stack(move || child_main(db, ack, killer, workload));
+}
+
+async fn child_main(db: PathBuf, ack: PathBuf, killer: Arc<Killer>, workload: Workload) {
+    let storage = CrashStorage::open(&db, killer.clone());
+    let lix = open_lix()
+        .with_storage(storage.clone())
+        .await
+        .expect("child opens crash-consistency Lix");
+
+    // --- setup, deliberately not armed -------------------------------------
+    register_schema(&lix).await;
+    write_generation(&lix, workload.rows, 0).await;
+
+    // --- measured publication window ---------------------------------------
+    killer.arm();
+    for generation in 1..=workload.commits {
+        write_generation(&lix, workload.rows, generation as i64).await;
+        // Acknowledge only after `commit()` returned Ok. Whatever is in this
+        // file must be visible after the crash; that is the durability half of
+        // the invariant set.
+        append_ack(&ack, generation);
+    }
+
+    println!("E20_EVENTS {}", killer.events());
+    let _ = std::io::stdout().flush();
+    lix.close().await.expect("child closes crash-consistency Lix");
+}
+
+fn append_ack(path: &Path, generation: u64) {
+    let mut file = fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(path)
+        .expect("open crash-consistency ack log");
+    writeln!(file, "{generation}").expect("append crash-consistency ack");
+    file.sync_all().expect("fsync crash-consistency ack log");
+}
+
+// ---------------------------------------------------------------------------
+// Invariants checked in a fresh process after the kill
+// ---------------------------------------------------------------------------
+
+#[derive(Debug)]
+struct Recovered {
+    generation: i64,
+}
+
+/// Everything the brief asks of a store that has just survived a crash.
+async fn verify_after_crash(
+    path: &Path,
+    acked: Option<i64>,
+    attempted: i64,
+    rows: usize,
+) -> Result<Recovered, String> {
+    // 1. Does the store open at all?
+    let storage = RocksDB::open(path).map_err(|error| format!("store did not open: {error}"))?;
+    let lix = open_lix()
+        .with_storage(storage.clone())
+        .await
+        .map_err(|error| format!("engine did not open: {error}"))?;
+
+    // 2. Is the branch ref pointing at a commit whose record exists?
+    let head = scalar_text(&lix, "SELECT lix_active_branch_commit_id() AS commit_id", &[])
+        .await
+        .map_err(|error| format!("active branch ref unreadable: {error}"))?;
+    let head_records = scalar_i64(
+        &lix,
+        "SELECT COUNT(*) AS n FROM lix_commit WHERE id = $1",
+        &[Value::Text(head.clone())],
+    )
+    .await
+    .map_err(|error| format!("commit record lookup failed for head {head}: {error}"))?;
+    if head_records != 1 {
+        return Err(format!(
+            "branch ref points at commit {head}, but lix_commit holds {head_records} record(s)"
+        ));
+    }
+    let branch_ref = scalar_text(
+        &lix,
+        "SELECT commit_id FROM lix_branch WHERE id = $1",
+        &[Value::Text(lix.active_branch_id().to_string())],
+    )
+    .await
+    .map_err(|error| format!("branch table unreadable: {error}"))?;
+    if branch_ref != head {
+        return Err(format!(
+            "branch ref disagrees with active head: lix_branch={branch_ref} head={head}"
+        ));
+    }
+
+    // 3./4. Does a plain SELECT return one whole committed write set?
+    let observed = read_generations(&lix, rows)
+        .await
+        .map_err(|error| format!("plain SELECT failed after crash: {error}"))?;
+    let generation = single_generation(&observed)?;
+
+    // Durability: a commit whose `commit()` returned Ok must still be there.
+    if let Some(acked) = acked
+        && generation < acked
+    {
+        return Err(format!(
+            "acknowledged commit lost: ack log reached generation {acked}, store shows {generation}"
+        ));
+    }
+    if generation > attempted {
+        return Err(format!(
+            "store shows generation {generation}, which the writer never attempted (max {attempted})"
+        ));
+    }
+
+    // Derived views must not be stale-but-authoritative: the history view is
+    // rebuilt from canonical records and must agree with the serving read.
+    let history_rows = scalar_i64(
+        &lix,
+        &format!("SELECT COUNT(*) AS n FROM {SCHEMA_KEY}_history() WHERE generation = $1"),
+        &[Value::Integer(generation)],
+    )
+    .await
+    .map_err(|error| format!("history view unreadable after crash: {error}"))?;
+    if history_rows == 0 && generation > 0 {
+        return Err(format!(
+            "serving read reports generation {generation}, but the canonical history view has no such rows"
+        ));
+    }
+
+    // 5. Does the next commit after recovery succeed?
+    let recovery_generation = generation + RECOVERY_MARK;
+    write_generation_checked(&lix, rows, recovery_generation)
+        .await
+        .map_err(|error| format!("first commit after recovery failed: {error}"))?;
+    lix.close()
+        .await
+        .map_err(|error| format!("close after recovery failed: {error}"))?;
+    drop(lix);
+    drop(storage);
+
+    // And the recovered store must stay recovered across another clean reopen.
+    let storage = RocksDB::open(path).map_err(|error| format!("second open failed: {error}"))?;
+    let lix = open_lix()
+        .with_storage(storage.clone())
+        .await
+        .map_err(|error| format!("second engine open failed: {error}"))?;
+    let observed = read_generations(&lix, rows)
+        .await
+        .map_err(|error| format!("SELECT after recovery reopen failed: {error}"))?;
+    let confirmed = single_generation(&observed)?;
+    if confirmed != recovery_generation {
+        return Err(format!(
+            "post-recovery commit did not survive reopen: expected {recovery_generation}, saw {confirmed}"
+        ));
+    }
+    lix.close()
+        .await
+        .map_err(|error| format!("final close failed: {error}"))?;
+
+    Ok(Recovered { generation })
+}
+
+fn single_generation(rows: &[i64]) -> Result<i64, String> {
+    let first = rows[0];
+    if rows.iter().any(|value| *value != first) {
+        let mut distinct: Vec<i64> = rows.to_vec();
+        distinct.sort_unstable();
+        distinct.dedup();
+        return Err(format!(
+            "TORN WRITE SET: rows carry mixed generations {distinct:?} — a publication was observed half-applied"
+        ));
+    }
+    Ok(first)
+}
+
+// ---------------------------------------------------------------------------
+// SQL helpers
+// ---------------------------------------------------------------------------
+
+async fn register_schema<S: Storage + Clone + Send + Sync + 'static>(lix: &Lix<S>) {
+    let schema = serde_json::json!({
+        "x-lix-key": SCHEMA_KEY,
+        "x-lix-primary-key": ["/id"],
+        "type": "object",
+        "required": ["id", "generation", "payload"],
+        "properties": {
+            "id": { "type": "string" },
+            "generation": { "type": "integer" },
+            "payload": { "type": "string" }
+        },
+        "additionalProperties": false
+    });
+    lix.execute(
+        "INSERT INTO lix_registered_schema (value, lixcol_global, lixcol_untracked) VALUES (lix_json($1), false, false)",
+        &[Value::Text(schema.to_string())],
+    )
+    .await
+    .expect("register crash-consistency schema");
+}
+
+/// One publication that rewrites *every* row to the same generation.
+///
+/// This is the oracle: any kill that leaves two rows disagreeing proves the
+/// write set reached the store in stages.
+async fn write_generation<S: Storage + Clone + Send + Sync + 'static>(
+    lix: &Lix<S>,
+    rows: usize,
+    generation: i64,
+) {
+    write_generation_checked(lix, rows, generation)
+        .await
+        .expect("crash-consistency generation commit");
+}
+
+async fn write_generation_checked<S: Storage + Clone + Send + Sync + 'static>(
+    lix: &Lix<S>,
+    rows: usize,
+    generation: i64,
+) -> Result<(), lix::LixError> {
+    let mut transaction = lix.begin_transaction().await?;
+    for index in 0..rows {
+        let payload = format!("gen-{generation}-row-{index}");
+        if generation == 0 {
+            transaction
+                .execute(
+                    &format!(
+                        "INSERT INTO {SCHEMA_KEY} (id, generation, payload) VALUES ($1, $2, $3)"
+                    ),
+                    &[
+                        Value::Text(format!("row-{index}")),
+                        Value::Integer(generation),
+                        Value::Text(payload),
+                    ],
+                )
+                .await?;
+        } else {
+            transaction
+                .execute(
+                    &format!(
+                        "UPDATE {SCHEMA_KEY} SET generation = $1, payload = $2 WHERE id = $3"
+                    ),
+                    &[
+                        Value::Integer(generation),
+                        Value::Text(payload),
+                        Value::Text(format!("row-{index}")),
+                    ],
+                )
+                .await?;
+        }
+    }
+    transaction.commit().await?;
+    Ok(())
+}
+
+async fn read_generations<S: Storage + Clone + Send + Sync + 'static>(
+    lix: &Lix<S>,
+    rows: usize,
+) -> Result<Vec<i64>, String> {
+    let result = lix
+        .execute(
+            &format!("SELECT id, generation FROM {SCHEMA_KEY} ORDER BY id"),
+            &[],
+        )
+        .await
+        .map_err(|error| error.to_string())?;
+    let observed: Vec<i64> = result
+        .rows()
+        .iter()
+        .map(|row| row.get::<i64>("generation").expect("generation is an integer"))
+        .collect();
+    if observed.len() != rows {
+        return Err(format!(
+            "row count is {} after recovery, expected {rows} — a publication was observed half-applied",
+            observed.len()
+        ));
+    }
+    Ok(observed)
+}
+
+async fn scalar_text<S: Storage + Clone + Send + Sync + 'static>(
+    lix: &Lix<S>,
+    sql: &str,
+    params: &[Value],
+) -> Result<String, String> {
+    let result = lix
+        .execute(sql, params)
+        .await
+        .map_err(|error| error.to_string())?;
+    let rows = result.rows();
+    if rows.is_empty() {
+        return Err("query returned no rows".to_owned());
+    }
+    rows[0]
+        .get::<String>(result_column(sql))
+        .ok_or_else(|| "column was not text".to_owned())
+}
+
+async fn scalar_i64<S: Storage + Clone + Send + Sync + 'static>(
+    lix: &Lix<S>,
+    sql: &str,
+    params: &[Value],
+) -> Result<i64, String> {
+    let result = lix
+        .execute(sql, params)
+        .await
+        .map_err(|error| error.to_string())?;
+    let rows = result.rows();
+    if rows.is_empty() {
+        return Err("query returned no rows".to_owned());
+    }
+    rows[0]
+        .get::<i64>(result_column(sql))
+        .ok_or_else(|| "column was not an integer".to_owned())
+}
+
+fn result_column(sql: &str) -> &'static str {
+    if sql.contains(" AS commit_id") {
+        "commit_id"
+    } else if sql.contains("SELECT commit_id") {
+        "commit_id"
+    } else {
+        "n"
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Parent process: the sweep
+// ---------------------------------------------------------------------------
+
+#[test]
+fn rocksdb_publication_window_survives_sigkill_at_every_storage_event() {
+    let workload = Workload::from_env();
+    let root = tempfile::tempdir().expect("create crash-consistency sweep root");
+    let mut failures: Vec<String> = Vec::new();
+    let mut trials = 0usize;
+    let mut killed_trials = 0usize;
+
+    // Calibrate: one unkilled run establishes how many storage events the
+    // measured window contains, and how long it takes.
+    let started = Instant::now();
+    let calibration = run_child(
+        &root.path().join("calibration"),
+        workload,
+        KillPlan::None,
+        true,
+    );
+    let window_duration = started.elapsed();
+    assert!(
+        calibration.status_success,
+        "calibration child failed: {}",
+        calibration.output
+    );
+    let events = calibration
+        .events
+        .expect("calibration child must report its storage event count");
+    assert!(events > 0, "publication window contained no storage events");
+    let labels = calibration.labels;
+
+    let max_points = env_usize("LIX_CRASH_CONSISTENCY_MAX_POINTS", 512);
+    let swept: Vec<u64> = if events as usize <= max_points {
+        (1..=events).collect()
+    } else {
+        // Even coverage of the window when it is larger than the cap.
+        (0..max_points)
+            .map(|i| 1 + (i as u64 * (events - 1)) / (max_points as u64 - 1))
+            .collect()
+    };
+
+    for kill_at in &swept {
+        let dir = root.path().join(format!("k{kill_at}"));
+        let child = run_child(&dir, workload, KillPlan::AtEvent(*kill_at), false);
+        trials += 1;
+        if child.killed_by_signal {
+            killed_trials += 1;
+        }
+        let label = labels
+            .get((*kill_at as usize).saturating_sub(1))
+            .cloned()
+            .unwrap_or_else(|| "?".to_owned());
+        let outcome = block_on(verify_after_crash(
+            &dir.join("database"),
+            child.acked,
+            workload.commits as i64,
+            workload.rows,
+        ));
+        if let Err(error) = &outcome {
+            failures.push(format!(
+                "kill_at={kill_at} ({label}, killed={}): {error}",
+                child.killed_by_signal
+            ));
+        }
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    // Timed phase: land the kill inside RocksDB's own write path.
+    let timed_trials = env_usize(
+        "LIX_CRASH_CONSISTENCY_TIMED_TRIALS",
+        if env_flag("LIX_CRASH_CONSISTENCY_DEEP") {
+            200
+        } else {
+            12
+        },
+    );
+    let window_nanos = window_duration.as_nanos().max(1) as u64;
+    let mut rng = SplitMix64::new(env_u64("LIX_CRASH_CONSISTENCY_SEED", 0x5eed_c0de_1234_5678));
+    for trial in 0..timed_trials {
+        // Sweep the whole observed window, biased to the second half where the
+        // measured publications live (setup occupies the first part).
+        let delay = window_nanos / 4 + rng.next() % window_nanos;
+        let dir = root.path().join(format!("t{trial}"));
+        let child = run_child(&dir, workload, KillPlan::AfterNanos(delay), false);
+        trials += 1;
+        if child.killed_by_signal {
+            killed_trials += 1;
+        }
+        let outcome = block_on(verify_after_crash(
+            &dir.join("database"),
+            child.acked,
+            workload.commits as i64,
+            workload.rows,
+        ));
+        if let Err(error) = &outcome {
+            failures.push(format!(
+                "timed delay={delay}ns (killed={}): {error}",
+                child.killed_by_signal
+            ));
+        }
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    println!(
+        "crash-consistency sweep: {trials} trials ({} storage-event points over a {events}-event \
+         publication window, {timed_trials} seeded wall-clock kills), {killed_trials} confirmed \
+         SIGKILLed, {} inconsistencies",
+        swept.len(),
+        failures.len()
+    );
+
+    assert!(
+        failures.is_empty(),
+        "crash consistency violated in {} of {trials} trials:\n  - {}",
+        failures.len(),
+        failures.join("\n  - ")
+    );
+    // A sweep in which nothing ever died would be vacuously green.
+    assert!(
+        killed_trials * 2 >= swept.len(),
+        "only {killed_trials} of {trials} trials actually died; the harness is not exercising crashes"
+    );
+}
+
+/// The RocksDB adapter accepts [`WriteOptions::await_durable`] and never acts on
+/// it. The option is documented as "do not acknowledge the commit until the
+/// backend has crossed its durable persistence boundary", the engine sets it for
+/// atomic CAS publications, and the SlateDB adapter honours it.
+///
+/// This test pins the gap rather than hiding it: it is the reason the sweep
+/// above proves process-crash consistency and *not* power-loss durability.
+#[test]
+fn rocksdb_ignores_await_durable_and_therefore_proves_only_process_crash_consistency() {
+    let source = include_str!("../../rocksdb-storage/src/rocksdb.rs");
+    assert!(
+        !source.contains("await_durable"),
+        "the RocksDB adapter now reads await_durable — update this qualification's scope note"
+    );
+    assert!(
+        !source.contains("set_sync(true)") && !source.contains("flush_wal(true)\n"),
+        "the RocksDB adapter now syncs on commit — update this qualification's scope note"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Child process plumbing
+// ---------------------------------------------------------------------------
+
+#[derive(Clone, Copy)]
+enum KillPlan {
+    None,
+    AtEvent(u64),
+    AfterNanos(u64),
+}
+
+struct ChildRun {
+    status_success: bool,
+    killed_by_signal: bool,
+    acked: Option<i64>,
+    events: Option<u64>,
+    labels: Vec<String>,
+    output: String,
+}
+
+fn run_child(dir: &Path, workload: Workload, plan: KillPlan, trace: bool) -> ChildRun {
+    fs::create_dir_all(dir).expect("create crash-consistency trial directory");
+    let ack = dir.join("ack.log");
+    let exe = std::env::current_exe().expect("locate crash-consistency test binary");
+
+    let mut command = Command::new(exe);
+    command
+        .args([
+            "--exact",
+            CHILD_TEST,
+            "--nocapture",
+            "--test-threads=1",
+            "--quiet",
+        ])
+        .env(CHILD_ENV, "1")
+        .env("LIX_CRASH_DB", dir.join("database"))
+        .env("LIX_CRASH_ACK", &ack)
+        .env(
+            "LIX_CRASH_CONSISTENCY_ROWS",
+            workload.rows.to_string(),
+        )
+        .env(
+            "LIX_CRASH_CONSISTENCY_COMMITS",
+            workload.commits.to_string(),
+        )
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+    if trace {
+        command.env("LIX_CRASH_TRACE", "1");
+    }
+    match plan {
+        KillPlan::None => {}
+        KillPlan::AtEvent(k) => {
+            command.env("LIX_CRASH_KILL_AT", k.to_string());
+        }
+        KillPlan::AfterNanos(n) => {
+            command.env("LIX_CRASH_KILL_AFTER_NANOS", n.to_string());
+        }
+    }
+
+    let output = command.output().expect("run crash-consistency child");
+    let stdout = String::from_utf8_lossy(&output.stdout).into_owned();
+    let stderr = String::from_utf8_lossy(&output.stderr).into_owned();
+
+    let events = stdout
+        .lines()
+        .find_map(|line| line.strip_prefix("E20_EVENTS "))
+        .and_then(|value| value.trim().parse().ok());
+    let labels = stdout
+        .lines()
+        .filter_map(|line| line.strip_prefix("E20_EVENT "))
+        .filter_map(|rest| rest.split_once(' ').map(|(_, label)| label.to_owned()))
+        .collect();
+
+    ChildRun {
+        status_success: output.status.success(),
+        killed_by_signal: signal_of(&output.status) == Some(libc::SIGKILL),
+        acked: read_ack(&ack),
+        events,
+        labels,
+        output: format!("stdout:\n{stdout}\nstderr:\n{stderr}"),
+    }
+}
+
+fn signal_of(status: &std::process::ExitStatus) -> Option<i32> {
+    use std::os::unix::process::ExitStatusExt;
+    status.signal()
+}
+
+/// Highest generation whose `commit()` returned Ok, reading only whole lines —
+/// a partially written final line is by definition not acknowledged.
+fn read_ack(path: &Path) -> Option<i64> {
+    let contents = fs::read_to_string(path).ok()?;
+    contents
+        .lines()
+        .filter(|line| contents.ends_with('\n') || Some(*line) != contents.lines().last())
+        .filter_map(|line| line.trim().parse::<i64>().ok())
+        .max()
+}
+
+// ---------------------------------------------------------------------------
+// Runtime plumbing
+// ---------------------------------------------------------------------------
+
+fn run_on_large_stack<F, Fut>(make_future: F)
+where
+    F: FnOnce() -> Fut + Send + 'static,
+    Fut: Future<Output = ()> + 'static,
+{
+    std::thread::Builder::new()
+        .name("crash-consistency".to_owned())
+        .stack_size(16 * 1024 * 1024)
+        .spawn(move || {
+            tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .expect("build crash-consistency runtime")
+                .block_on(make_future());
+        })
+        .expect("spawn crash-consistency thread")
+        .join()
+        .expect("crash-consistency thread should not panic");
+}
+
+fn block_on<T, Fut>(future: Fut) -> T
+where
+    Fut: Future<Output = T> + 'static,
+    T: Send + 'static,
+{
+    let (sender, receiver) = std::sync::mpsc::channel();
+    std::thread::Builder::new()
+        .name("crash-consistency-verify".to_owned())
+        .stack_size(16 * 1024 * 1024)
+        .spawn(move || {
+            let value = tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .expect("build crash-consistency verify runtime")
+                .block_on(future);
+            let _ = sender.send(value);
+        })
+        .expect("spawn crash-consistency verify thread")
+        .join()
+        .expect("crash-consistency verify thread should not panic");
+    receiver.recv().expect("verify thread returned a value")
+}
+
+/// Deterministic, seedable, dependency-free.
+struct SplitMix64(u64);
+
+impl SplitMix64 {
+    fn new(seed: u64) -> Self {
+        Self(seed)
+    }
+
+    fn next(&mut self) -> u64 {
+        self.0 = self.0.wrapping_add(0x9e37_79b9_7f4a_7c15);
+        let mut z = self.0;
+        z = (z ^ (z >> 30)).wrapping_mul(0xbf58_476d_1ce4_e5b9);
+        z = (z ^ (z >> 27)).wrapping_mul(0x94d0_49bb_1331_11eb);
+        z ^ (z >> 31)
+    }
+}

--- a/packages/engine-benchmarks/tests/crash_consistency_qualification.rs
+++ b/packages/engine-benchmarks/tests/crash_consistency_qualification.rs
@@ -355,13 +355,13 @@ struct Recovered {
 
 /// Everything the brief asks of a store that has just survived a crash.
 async fn verify_after_crash(
-    path: &Path,
+    path: PathBuf,
     acked: Option<i64>,
     attempted: i64,
     rows: usize,
 ) -> Result<Recovered, String> {
     // 1. Does the store open at all?
-    let storage = RocksDB::open(path).map_err(|error| format!("store did not open: {error}"))?;
+    let storage = RocksDB::open(&path).map_err(|error| format!("store did not open: {error}"))?;
     let lix = open_lix()
         .with_storage(storage.clone())
         .await
@@ -383,10 +383,14 @@ async fn verify_after_crash(
             "branch ref points at commit {head}, but lix_commit holds {head_records} record(s)"
         ));
     }
+    let branch_id = lix
+        .active_branch_id()
+        .await
+        .map_err(|error| format!("active branch id unreadable: {error}"))?;
     let branch_ref = scalar_text(
         &lix,
         "SELECT commit_id FROM lix_branch WHERE id = $1",
-        &[Value::Text(lix.active_branch_id().to_string())],
+        &[Value::Text(branch_id)],
     )
     .await
     .map_err(|error| format!("branch table unreadable: {error}"))?;
@@ -443,7 +447,7 @@ async fn verify_after_crash(
     drop(storage);
 
     // And the recovered store must stay recovered across another clean reopen.
-    let storage = RocksDB::open(path).map_err(|error| format!("second open failed: {error}"))?;
+    let storage = RocksDB::open(&path).map_err(|error| format!("second open failed: {error}"))?;
     let lix = open_lix()
         .with_storage(storage.clone())
         .await
@@ -596,7 +600,7 @@ async fn scalar_text<S: Storage + Clone + Send + Sync + 'static>(
     }
     rows[0]
         .get::<String>(result_column(sql))
-        .ok_or_else(|| "column was not text".to_owned())
+        .map_err(|error| format!("column was not text: {error}"))
 }
 
 async fn scalar_i64<S: Storage + Clone + Send + Sync + 'static>(
@@ -614,7 +618,7 @@ async fn scalar_i64<S: Storage + Clone + Send + Sync + 'static>(
     }
     rows[0]
         .get::<i64>(result_column(sql))
-        .ok_or_else(|| "column was not an integer".to_owned())
+        .map_err(|error| format!("column was not an integer: {error}"))
 }
 
 fn result_column(sql: &str) -> &'static str {
@@ -681,12 +685,11 @@ fn rocksdb_publication_window_survives_sigkill_at_every_storage_event() {
             .get((*kill_at as usize).saturating_sub(1))
             .cloned()
             .unwrap_or_else(|| "?".to_owned());
-        let outcome = block_on(verify_after_crash(
-            &dir.join("database"),
-            child.acked,
-            workload.commits as i64,
-            workload.rows,
-        ));
+        let database = dir.join("database");
+        let acked = child.acked;
+        let outcome = block_on(move || {
+            verify_after_crash(database, acked, workload.commits as i64, workload.rows)
+        });
         if let Err(error) = &outcome {
             failures.push(format!(
                 "kill_at={kill_at} ({label}, killed={}): {error}",
@@ -717,12 +720,11 @@ fn rocksdb_publication_window_survives_sigkill_at_every_storage_event() {
         if child.killed_by_signal {
             killed_trials += 1;
         }
-        let outcome = block_on(verify_after_crash(
-            &dir.join("database"),
-            child.acked,
-            workload.commits as i64,
-            workload.rows,
-        ));
+        let database = dir.join("database");
+        let acked = child.acked;
+        let outcome = block_on(move || {
+            verify_after_crash(database, acked, workload.commits as i64, workload.rows)
+        });
         if let Err(error) = &outcome {
             failures.push(format!(
                 "timed delay={delay}ns (killed={}): {error}",
@@ -897,9 +899,10 @@ where
         .expect("crash-consistency thread should not panic");
 }
 
-fn block_on<T, Fut>(future: Fut) -> T
+fn block_on<T, F, Fut>(make_future: F) -> T
 where
-    Fut: Future<Output = T> + 'static,
+    F: FnOnce() -> Fut + Send + 'static,
+    Fut: Future<Output = T>,
     T: Send + 'static,
 {
     let (sender, receiver) = std::sync::mpsc::channel();
@@ -911,7 +914,7 @@ where
                 .enable_all()
                 .build()
                 .expect("build crash-consistency verify runtime")
-                .block_on(future);
+                .block_on(make_future());
             let _ = sender.send(value);
         })
         .expect("spawn crash-consistency verify thread")


### PR DESCRIPTION
## What this is

Crash consistency was the largest untested dimension behind the "you can use lix as a backend"
claim. Every "reopen" test in the repository does an orderly `flush → close → drop → reopen`; there
was no kill-9, no partial-publication test, nothing anywhere in the workspace that observed a store
in a state a cooperative shutdown cannot produce. Layout invariant 4 — *"state root, commit record,
derived-view update and ref move publish in one atomic write set, never in stages another reader can
observe half-done"* — was asserted only against clean rollback.

This PR adds `packages/engine-benchmarks/tests/crash_consistency_qualification.rs`, which kills a
real writer process with **SIGKILL** at every point of the publication window against a real RocksDB
store on a real filesystem, then reopens in a **fresh process** and checks the invariants.

**Result: 3,072 trials, 0 inconsistencies.** Plus one real defect found, which is a *durability*
defect rather than a corruption defect and is documented rather than fixed here (see below).

This is a **measurement/verification** PR. It changes no engine code and no adapter code.

## What changed physically

- **Added**: one test target, `crash_consistency_qualification` (`required-features = ["rocksdb"]`),
  registered in `packages/engine-benchmarks/Cargo.toml`.
- **Removed**: nothing.
- **Adapter API added / changed / removed**: **none**. The harness's `CrashStorage` is a decorator
  that lives entirely in the test crate and implements the existing `Storage` / `StorageWrite`
  traits over `RocksDB`. No production code was touched.

## How the window is swept

`CrashStorage` wraps `RocksDB` and counts every mutation the engine issues at the storage boundary —
`begin_write`, each `put_many` / `delete_many` / `delete_range`, the instant **before** `commit()` is
delegated, and the instant **after** it returns. `LIX_CRASH_KILL_AT=k` makes the wrapper
`kill(getpid(), SIGKILL)` at event *k*: uncatchable, no unwinding, no `Drop`, no RocksDB shutdown
hook, no WAL flush. The sweep is **exhaustive over every k**, and *k* is deterministic for a fixed
workload, so a failure reproduces by rerunning the same *k*.

A second, seeded wall-clock phase kills after a pseudorandom delay aimed at the measured window.
That is the only schedule that can land *inside* RocksDB's own write path (mid WAL append, mid
memtable insert), which the storage-boundary sweep steps over atomically.

The workload commits, in **one transaction**, a rewrite of every row to the same generation number
*and* a binary file whose bytes are derived from that same generation. The oracle is therefore
total: a publication that reached the store in stages shows up as mixed row generations, a wrong row
count, or a blob that disagrees with the rows.

### Invariants checked on reopen

1. The store opens (`RocksDB::open`, then `open_lix`).
2. The branch ref resolves, `lix_commit` holds exactly one record for it, and `lix_branch.commit_id`
   agrees with `lix_active_branch_commit_id()`.
3. A plain `SELECT` returns exactly the seeded row width (or exactly zero, pre-seed) with a single
   uniform generation — mixed generations are reported as `TORN WRITE SET`.
4. The content-addressed file decodes to the generation the rows report.
5. The serving read agrees with `<schema>_history()`, which is rebuilt from canonical records — a
   derived view may be absent, never stale-and-authoritative.
6. **Durability of acknowledgement**: the child appends to an **fsynced** ack log only after
   `commit()` returned `Ok`; anything in that log must be visible after the crash.
7. The visible generation never exceeds what the writer attempted (no phantom state).
8. The next commit after recovery succeeds — and survives a further clean reopen.

**Null control.** Before any kill is issued, the identical battery runs against the calibration
store, which was closed cleanly. If it fails, the harness panics saying so, so a harness defect can
never be misread as a crash finding. It passed on every run below.

## Results — hetzner-cpx62-III, base `d8d5131b`

Stores rooted on the ext4 volume (`TMPDIR=$HOME/claude5/tmp`). `/tmp` on this host is a 16 GB
tmpfs; a durability experiment run there would have been measuring RAM.

| phase | workload | kill points (exhaustive) | timed kills | trials | confirmed SIGKILLed | inconsistencies |
|---|---|---|---|---|---|---|
| rows, default | 8 rows × 3 commits | 42 of 42 | 12 | 54 | 53 | **0** |
| rows, deep seed 1 | 64 rows × 12 commits | 168 of 168 | 300 | 468 | 400 | **0** |
| rows, deep seed 2 | 64 rows × 12 commits | 168 of 168 | 300 | 468 | 407 | **0** |
| rows, deep seed 3 | 64 rows × 12 commits | 168 of 168 | 300 | 468 | 467 | **0** |
| rows + CAS file, default | 8 rows + 64 KiB file × 3 | 54 of 54 | 12 | 66 | 62 | **0** |
| rows + CAS file, deep seed 1 | 64 rows + 128 KiB file × 12 | 216 of 216 | 300 | 516 | 468 | **0** |
| rows + CAS file, deep seed 2 | 64 rows + 128 KiB file × 12 | 216 of 216 | 300 | 516 | 500 | **0** |
| rows + CAS file, deep seed 3 | 64 rows + 128 KiB file × 12 | 216 of 216 | 300 | 516 | 514 | **0** |
| **total** | | **1248** | **1824** | **3072** | **2871** | **0** |

"Confirmed SIGKILLed" means the child's exit status carried `WTERMSIG == 9` — 2,871 of 3,072 trials
provably died mid-flight rather than finishing.

Adding the content-addressed file widens the deep publication window from 168 to 216 storage events:
the CAS blob chunks, the prepared manifest and the publication fence are all additional staged
mutations, and every one of them was used as a kill point.

**Coverage is demonstrated, not assumed.** The recovered generations observed across each deep sweep
were `None, 0, 1, 2, …, 12` — kills landed before the seed published, after every intermediate
commit, and after the last one. A sweep that only ever killed after everything was written would
have reported a single generation.

Commands:

```
cargo test -p lix_benchmarks --release --features storage-benches \
  --test crash_consistency_qualification
LIX_CRASH_CONSISTENCY_DEEP=1 LIX_CRASH_CONSISTENCY_TIMED_TRIALS=300 \
LIX_CRASH_CONSISTENCY_SEED=<n> <binary> --exact \
  rocksdb_publication_window_survives_sigkill_at_every_storage_event
```

### Cost, and the CI/deep split

The default configuration is 8 rows × 3 commits + a 64 KiB CAS file: **66 trials in ~9 s**, which is
what CI runs. `LIX_CRASH_CONSISTENCY_DEEP=1` widens it to 64 rows × 12 commits + a 128 KiB file
(~516 trials, ~2 min), and the individual knobs (`_ROWS`, `_COMMITS`, `_BLOB_BYTES`, `_TIMED_TRIALS`,
`_MAX_POINTS`, `_SEED`) are all overridable. Same shape as the seed-budget override E11 is applying
to the fuzz suites.

## The one defect found: `await_durable` is silently ignored on RocksDB

Not a corruption bug, and not fixed in this PR — but it bounds what the result above may be quoted
as, so it must not be lost.

1. `lix::storage::WriteOptions::await_durable` is documented as *"Do not acknowledge the commit until
   the backend has crossed its durable persistence boundary"* (`packages/lix/src/storage/types.rs:461-463`).
2. **lix sets it.** `packages/lix/src/transaction/context.rs:1867` propagates
   `transaction.await_durable_commit`, which `stage_atomic_cas_publication` sets to `true`
   (`context.rs:830`) — the **binary content-addressed publication path**, i.e. file and media
   writes. `session/media_upload.rs:358` sets it too. The SlateDB adapter honours it
   (`packages/slatedb-storage/src/slatedb.rs:3800`, `:3839-3871`).
3. **The RocksDB adapter never reads it.** `begin_write` consumes only `opts.preconditions` and
   `opts.batch_capacity_hint_bytes` (`packages/rocksdb-storage/src/rocksdb.rs:191`, `:195-199`);
   `commit()` never sees `opts`. `rocksdb::WriteOptions` is never constructed in the package, so
   `db.write()` takes the C++ defaults — **`sync = false`**. The package's only WAL-sync entry point,
   `flush_wal_for_diagnostics` (`rocksdb.rs:150-157`), is `#[doc(hidden)]` and has **zero callers**.

Measured with `strace -f -y -e trace=fsync,fdatasync,sync_file_range` over 20 commits, each
publishing a 128 KiB CAS file (so all 20 requested a durable acknowledgement):

| syncs | target | attributable to |
|---:|---|---|
| 20 | `ack.log` | the **harness's own** bookkeeping |
| 1 | `setup.done` | the **harness's own** bookkeeping |
| 11 | `database/` dir, `MANIFEST-*`, `OPTIONS-*.dbtmp`, `*.dbtmp` | RocksDB, at **open** |
| **0** | **the WAL (`*.log`)** | — |

53 sync syscalls, none of them attributable to a commit. **On RocksDB, `commit()` returning `Ok`
means "in the OS page cache", not "on disk"** — even when lix explicitly asked otherwise.

Consequences, stated precisely:

- A **process crash** cannot lose an acknowledged commit (the WAL is in the page cache and the kernel
  survives) — which is why the 3,072-trial sweep is clean.
- A **power loss or kernel panic** can lose an unbounded suffix of acknowledged commits. It cannot
  corrupt them: the WAL truncates at a record boundary under `kPointInTimeRecovery`, so what survives
  is a *prefix of whole publications*. No torn write set.
- `set_atomic_flush` is also off (`rocksdb.rs:725-753`). That is harmless **only because** every
  write goes through the WAL; the two column families are flushed by two independent `flush_cf` calls
  (`rocksdb.rs:138-148`), so the moment anything writes WAL-disabled, `atomic_flush(true)` becomes
  mandatory.

`rocksdb_ignores_await_durable_and_therefore_proves_only_process_crash_consistency` in the new file
pins this: it fails the moment the adapter starts reading `await_durable` or syncing on commit,
forcing the scope note to be updated rather than silently going stale.

### Suggested wording for the release post

> Every lix commit — state root, commit record, derived views, and the branch ref move — is applied
> as one atomic write set. We qualify that by SIGKILLing the writing process at every storage
> operation in the publication window and reopening in a fresh process: 3,072 trials, zero
> inconsistencies, including crashes inside the content-addressed file publication path.
>
> Scope: this establishes consistency under **process** crash. On the RocksDB backend commits are not
> fsynced before acknowledgement, so a power loss or kernel panic can lose recently acknowledged
> commits — each publication is lost whole, and the store stays consistent.

Please do not drop the second paragraph.

## Is this *lix* being durable, or *RocksDB* being durable?

**The atomicity is lix's, and it is structural.** The engine materializes an entire publication — CAS
blob chunks, changelog commits and changes, tracked state roots, certified commit-state manifests,
hot rows and hot heads, columnar caches, checkpoint working-diff epochs, the **branch head control
(the ref move)**, the CAS publication fence, and the catalog / mutation revision tokens — into **one**
`StorageWriteSet` (`packages/lix/src/transaction/commit.rs:247`, staged through `commit.rs:830`),
lowers it into **one** storage write transaction, and calls `commit()` **once**
(`packages/lix/src/storage_adapter/context.rs:93-241`). No separate flush, no separate blob
transaction, no separate ref update. Preconditions (branch-head CAS, CAS fence, tracked-mutation
fence) ride in `WriteOptions.preconditions` and are evaluated with the same write.

That is why invariant 4 holds under SIGKILL, and it is lix's property, not a borrowed one: an adapter
can only be atomic about what it is handed in one piece.

**The adapter contributes the atomic apply and nothing more.** `RocksDBWrite` stages into a single
`rocksdb::WriteBatch` spanning both column families and applies it with one `db.write()`
(`rocksdb.rs:70-76`, `:508-566`, `:575-583`).

## Layout invariants

1. **Single authority** — no. Test-only addition; no new writer, no new materialization, no index.
2. **Commit canonicality** — unchanged, and now *verified*: every trial asserts the branch ref
   resolves to exactly one `lix_commit` record and that `lix_branch` agrees with it.
3. **Derived views are caches** — unchanged, and now *verified*: every trial cross-checks the serving
   read against the canonical history view, so a stale-but-authoritative derived view fails the test.
4. **Atomic publication** — unchanged, and this PR exists to test it. 3,072 crash trials, 0 torn
   write sets. Previously asserted only against clean rollback.
5. **GC from refs** — untouched.
6. **SQL reads canonical records** — untouched.

## What is still not covered

- **Power loss.** Needs fsync (above) plus a fault-injecting block layer (`dm-log-writes`) to test
  honestly. Not attempted; do not claim it.
- **SlateDB.** Structurally different in the direction that matters: it *does* honour `await_durable`
  and waits for the WAL upload, so its acknowledgement is strictly stronger than RocksDB's. Its
  publication is also a single write set, so the atomicity argument carries over — but it was not
  measured. The harness is generic over `Storage`; adding a SlateDB arm is a small follow-up.
- **Concurrent writers.** Unchanged: no loom/shuttle/madsim in the workspace, conformance still
  defaults `supports_concurrent_writers: false`. The RocksDB adapter serializes writers with an
  **in-process** `WriteGate` (`rocksdb.rs:59-61`, `:185-204`); cross-process exclusion rests on
  RocksDB's own LOCK file.

## What regressed

Nothing. No engine or adapter code is touched; the only cost is ~9 s added to the
`lix_benchmarks` test job.

## Gate

Full CI-scope gate on **hetzner-cpx62-III**, transcribed from `origin/main:.github/workflows/ci.yml`
(re-read before running, per the runbook), at `3a8ebb8e` = this branch merged with integration head
`f54e5fce`. Every step exit code 0:

| step | command | rc |
|---|---|---|
| clippy | `cargo clippy --profile test --workspace --all-targets --all-features -- -D warnings` | **0** |
| compile workspace | `cargo test --profile test --workspace --exclude lix_benchmarks --all-features --no-run` | **0** |
| compile benches | `cargo test --profile test -p lix_benchmarks --features storage-benches,slatedb,root-replay-trace --no-run` | **0** |
| run workspace | `cargo test --profile test --workspace --exclude lix_benchmarks --all-features --no-fail-fast` | **0** |
| run benches | `cargo test --profile test -p lix_benchmarks --features storage-benches,slatedb,root-replay-trace --no-fail-fast` | **0** |
| features-off | `cargo check -p lix --no-default-features` | **0** |
| wasm | `cargo check -p lix_js_sdk --target wasm32-unknown-unknown` | **0** |

**3,505 passed / 0 failed**, 0 clippy warnings. The full log was captured to a file and grepped for
`failures:`, `panicked`, `test result: FAILED` and `^error` — zero hits; not tailed.

The new target inside that run: `crash_consistency_qualification` — 3 passed / 0 failed, **15.61 s**
in the debug test profile under CI-like parallel execution (~9 s in release). That is the whole CI
cost of this PR.

No versioned identifier was bumped, so no repo-wide literal grep was required.
