### PR TITLE
perf(build): compile RocksDB hardware CRC32C — binary CAS reads +40-48% throughput

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -21,7 +21,7 @@ lclippy = "b NPROC=$(nproc 2>/dev/null || getconf _NPROCESSORS_ONLN 2>/dev/null 
 # for the Linux host. Cargo's host-config isolates those flags from the Wasm
 # target while keeping host linking on mold.
 [host.x86_64-unknown-linux-gnu]
-rustflags = "-C link-arg=-fuse-ld=mold"
+rustflags = ["-C", "link-arg=-fuse-ld=mold", "-C", "target-feature=+sse4.2,+pclmulqdq"]
 
 [host.aarch64-unknown-linux-gnu]
 rustflags = "-C link-arg=-fuse-ld=mold"
@@ -37,6 +37,18 @@ rustflags = "-C link-arg=-fuse-ld=mold"
 # proc macros. WebAssembly targets remain linker-neutral.
 [target.'cfg(all(target_os = "linux", not(target_family = "wasm")))']
 rustflags = "-C link-arg=-fuse-ld=mold"
+
+# RocksDB picks its CRC32C implementation at C++ *compile* time
+# (`rocksdb/util/crc32c.cc`: `#elif defined(__SSE4_2__) && defined(__PCLMUL__)`
+# -> `crc32c_3way`). `librocksdb-sys/build.rs` only forwards `-msse4.2
+# -mpclmul` to that compile when `CARGO_CFG_TARGET_FEATURE` already lists them,
+# and the default `x86-64` baseline does not — so without this line every
+# build gets `ExtendImpl<DefaultCRC32>`, the table-driven software fallback.
+# A flat profile of a 640 MiB binary-CAS read spent 33.1% of its cycles there.
+# SSE4.2 and PCLMULQDQ are Nehalem (2008) / Bulldozer (2011) and later; this
+# raises lix's x86_64 floor to that, roughly `x86-64-v2`.
+[target.'cfg(all(target_arch = "x86_64", not(target_family = "wasm")))']
+rustflags = ["-C", "target-feature=+sse4.2,+pclmulqdq"]
 
 [target.wasm32-unknown-unknown]
 # rustflags = [

--- a/packages/engine-benchmarks/examples/e24_cas_read_probe.rs
+++ b/packages/engine-benchmarks/examples/e24_cas_read_probe.rs
@@ -21,7 +21,6 @@ use std::hint::black_box;
 use std::path::{Path, PathBuf};
 use std::time::{Duration, Instant};
 
-use lix::storage::Storage;
 use lix::{Lix, Value, open_lix};
 use lix_storage_rocksdb::RocksDB;
 

--- a/packages/engine-benchmarks/examples/e24_cas_read_probe.rs
+++ b/packages/engine-benchmarks/examples/e24_cas_read_probe.rs
@@ -1,0 +1,176 @@
+//! E24 — binary CAS read-path throughput probe.
+//!
+//! Reproduces the claim-2 `checkout` shape in isolation so the per-byte cost of
+//! the binary CAS read path can be attributed and profiled:
+//!
+//!   phase `open`   — cold `open_lix` against an already-populated store
+//!   phase `select` — `SELECT path, content FROM lix_file`, every payload
+//!                    materialized (this is where the CAS read lives)
+//!   phase `write`  — `fs::write` of every payload to a fresh directory
+//!
+//! `checkout` in the claim-2 harness is exactly `open + select + write`.
+//!
+//! Usage:
+//!   e24_cas_read_probe <asset_kib> <asset_count> <reps> <dir> [import_batch]
+//!
+//! The payload is incompressible pseudo-random data, matching the `bigmedia`
+//! corpus (gif/mp4) rather than text.
+
+use std::fs;
+use std::hint::black_box;
+use std::path::{Path, PathBuf};
+use std::time::{Duration, Instant};
+
+use lix::storage::Storage;
+use lix::{Lix, Value, open_lix};
+use lix_storage_rocksdb::RocksDB;
+
+fn incompressible(len: usize, seed: u64) -> Vec<u8> {
+    // xorshift64* — fast, and its output does not compress.
+    let mut state = seed.wrapping_mul(0x9E37_79B9_7F4A_7C15) | 1;
+    let mut out = Vec::with_capacity(len);
+    while out.len() < len {
+        state ^= state >> 12;
+        state ^= state << 25;
+        state ^= state >> 27;
+        let word = state.wrapping_mul(0x2545_F491_4F6C_DD1D);
+        out.extend_from_slice(&word.to_le_bytes());
+    }
+    out.truncate(len);
+    out
+}
+
+async fn open_at(dir: &Path) -> Lix<RocksDB> {
+    let storage = RocksDB::open(dir.join(".lix")).expect("open RocksDB storage");
+    open_lix()
+        .with_storage(storage)
+        .await
+        .expect("open lix workspace")
+}
+
+fn stats(label: &str, size_bytes: u64, samples: &[Duration]) {
+    let mut sorted = samples.to_vec();
+    sorted.sort();
+    let median = sorted[sorted.len() / 2];
+    let p95 = sorted[(sorted.len() * 95 / 100).min(sorted.len() - 1)];
+    let raw = samples
+        .iter()
+        .map(|d| format!("{:.3}", d.as_secs_f64() * 1000.0))
+        .collect::<Vec<_>>()
+        .join(",");
+    let mib = size_bytes as f64 / (1024.0 * 1024.0);
+    println!(
+        "e24 phase={label} p50_ms={:.3} p95_ms={:.3} mib={mib:.1} \
+         p50_mibs={:.1} raw_ms=[{raw}]",
+        median.as_secs_f64() * 1000.0,
+        p95.as_secs_f64() * 1000.0,
+        mib / median.as_secs_f64(),
+    );
+}
+
+#[tokio::main(flavor = "multi_thread")]
+async fn main() {
+    let mut args = std::env::args().skip(1);
+    let asset_kib: usize = args
+        .next()
+        .and_then(|v| v.parse().ok())
+        .expect("usage: e24_cas_read_probe <asset_kib> <asset_count> <reps> <dir> [batch]");
+    let asset_count: usize = args.next().and_then(|v| v.parse().ok()).expect("asset_count");
+    let reps: usize = args.next().and_then(|v| v.parse().ok()).expect("reps");
+    let dir = PathBuf::from(args.next().expect("dir"));
+    let import_batch: usize = args.next().and_then(|v| v.parse().ok()).unwrap_or(50).max(1);
+    let skip_write = std::env::var("E24_SKIP_WRITE").is_ok();
+
+    fs::create_dir_all(&dir).expect("create probe dir");
+    let asset_bytes = asset_kib * 1024;
+    let total_bytes = (asset_bytes * asset_count) as u64;
+    println!(
+        "e24 corpus asset_kib={asset_kib} assets={asset_count} total_mib={:.1} reps={reps} \
+         batch={import_batch} threads={}",
+        total_bytes as f64 / (1024.0 * 1024.0),
+        std::thread::available_parallelism().map_or(0, |n| n.get()),
+    );
+
+    // ---- seed (untimed) -------------------------------------------------
+    {
+        let lix = open_at(&dir).await;
+        let seed_started = Instant::now();
+        let mut cursor = 0usize;
+        while cursor < asset_count {
+            let n = import_batch.min(asset_count - cursor);
+            let mut sql = String::from("INSERT INTO lix_file (path, content) VALUES ");
+            let mut params: Vec<Value> = Vec::with_capacity(n * 2);
+            for k in 0..n {
+                if k > 0 {
+                    sql.push(',');
+                }
+                sql.push_str(&format!("(${}, ${})", 2 * k + 1, 2 * k + 2));
+                params.push(Value::Text(format!("/assets/a{:06}.bin", cursor + k)));
+                params.push(Value::Blob(
+                    incompressible(asset_bytes, (cursor + k) as u64 + 1).into(),
+                ));
+            }
+            sql.push_str(" ON CONFLICT (path) DO UPDATE SET content = excluded.content");
+            lix.execute(&sql, &params).await.expect("seed import");
+            cursor += n;
+        }
+        println!("e24 seed_ms={:.1}", seed_started.elapsed().as_secs_f64() * 1000.0);
+        lix.close().await.expect("close seed lix");
+    }
+
+    // ---- measured phases ------------------------------------------------
+    let mut opens = Vec::new();
+    let mut selects = Vec::new();
+    let mut writes = Vec::new();
+    let mut checkouts = Vec::new();
+
+    for rep in 0..reps {
+        let dest = dir.join(format!("co-{rep}"));
+        let checkout_started = Instant::now();
+
+        let t = Instant::now();
+        let lix = open_at(&dir).await;
+        opens.push(t.elapsed());
+
+        let t = Instant::now();
+        let rows = lix
+            .execute("SELECT path, content FROM lix_file", &[])
+            .await
+            .expect("full-tree read");
+        let mut payloads: Vec<(String, Vec<u8>)> = Vec::with_capacity(asset_count);
+        let mut seen = 0u64;
+        for row in rows.rows() {
+            let p: String = row.get("path").expect("path text");
+            let c: Vec<u8> = row.get("content").expect("content bytes");
+            seen += c.len() as u64;
+            payloads.push((p, c));
+        }
+        selects.push(t.elapsed());
+        assert_eq!(seen, total_bytes, "read back the whole corpus");
+        black_box(&payloads);
+
+        if !skip_write {
+            let t = Instant::now();
+            for (p, c) in &payloads {
+                let out = dest.join(p.trim_start_matches('/'));
+                if let Some(parent) = out.parent() {
+                    fs::create_dir_all(parent).expect("checkout parent");
+                }
+                fs::write(&out, c).expect("checkout write");
+            }
+            writes.push(t.elapsed());
+        }
+
+        drop(payloads);
+        checkouts.push(checkout_started.elapsed());
+        lix.close().await.expect("close probe lix");
+        fs::remove_dir_all(&dest).ok();
+    }
+
+    stats("open", total_bytes, &opens);
+    stats("select", total_bytes, &selects);
+    if !skip_write {
+        stats("write", total_bytes, &writes);
+    }
+    stats("checkout", total_bytes, &checkouts);
+}

--- a/packages/engine-benchmarks/examples/e24_cas_read_probe.rs
+++ b/packages/engine-benchmarks/examples/e24_cas_read_probe.rs
@@ -91,7 +91,9 @@ async fn main() {
     );
 
     // ---- seed (untimed) -------------------------------------------------
-    {
+    // `E24_SKIP_SEED=1` reuses an already-populated directory so a profile can
+    // be taken over the read path alone, with no write-path samples in it.
+    if !std::env::var("E24_SKIP_SEED").is_ok_and(|v| v == "1") {
         let lix = open_at(&dir).await;
         let seed_started = Instant::now();
         let mut cursor = 0usize;

--- a/packages/rocksdb-storage/src/rocksdb.rs
+++ b/packages/rocksdb-storage/src/rocksdb.rs
@@ -23,8 +23,8 @@ use lix::storage::{
     WriteOptions, WriteStats,
 };
 use rocksdb::{
-    BlockBasedOptions, ChecksumType, ColumnFamily, ColumnFamilyDescriptor, DB, Direction,
-    IteratorMode, Options, WriteBatch,
+    BlockBasedOptions, ColumnFamily, ColumnFamilyDescriptor, DB, Direction, IteratorMode, Options,
+    WriteBatch,
 };
 use rocksdb::{DBRawIteratorWithThreadMode, Snapshot};
 use tempfile::TempDir;
@@ -757,18 +757,6 @@ fn open_rocksdb(path: &Path) -> Result<DB, StorageError> {
         .map_err(|error| rocksdb_open_error(error, path))
 }
 
-/// MEASUREMENT SCAFFOLD (E24) — remove before shipping.
-///
-/// Lets one binary produce both A/B arms so the arms cannot differ in codegen.
-/// `LIX_ROCKSDB_CHECKSUM=crc32c` reproduces today's behaviour exactly.
-fn measurement_checksum_type() -> ChecksumType {
-    match std::env::var("LIX_ROCKSDB_CHECKSUM").as_deref() {
-        Ok("crc32c") => ChecksumType::CRC32c,
-        Ok("none") => ChecksumType::NoChecksum,
-        _ => ChecksumType::XXH3,
-    }
-}
-
 fn column_family_options() -> Options {
     let mut options = Options::default();
     options.set_write_buffer_size(WRITE_BUFFER_BYTES);
@@ -786,20 +774,6 @@ fn column_family_options() -> Options {
     // Full whole-key filters let missing point reads skip unrelated SST data.
     table_options.set_bloom_filter(8.0, false);
     table_options.set_optimize_filters_for_memory(true);
-    // RocksDB's default block checksum is CRC32c, and its hardware
-    // (SSE4.2 + PCLMULQDQ) implementation is selected at C++ *compile* time.
-    // `librocksdb-sys` only passes `-msse4.2 -mpclmul` when the Rust target
-    // already enables those features, and the default `x86-64` baseline does
-    // not — so every shipped build gets `ExtendImpl<DefaultCRC32>`, the
-    // table-driven software fallback. A flat profile of a 640 MiB binary-CAS
-    // read spends 34.6% of its cycles in exactly that symbol.
-    //
-    // XXH3 is a checksum of the same strength class whose speed does not
-    // depend on a compile-time ISA gate, so it is fast on every target lix
-    // ships to instead of only on hosts built with a raised baseline.
-    // Checksum type is recorded per table file: existing CRC32c files stay
-    // readable, and nothing about the key or value encoding changes.
-    table_options.set_checksum_type(measurement_checksum_type());
     options.set_block_based_table_factory(&table_options);
     options
 }

--- a/packages/rocksdb-storage/src/rocksdb.rs
+++ b/packages/rocksdb-storage/src/rocksdb.rs
@@ -23,8 +23,8 @@ use lix::storage::{
     WriteOptions, WriteStats,
 };
 use rocksdb::{
-    BlockBasedOptions, ColumnFamily, ColumnFamilyDescriptor, DB, Direction, IteratorMode, Options,
-    WriteBatch,
+    BlockBasedOptions, ChecksumType, ColumnFamily, ColumnFamilyDescriptor, DB, Direction,
+    IteratorMode, Options, WriteBatch,
 };
 use rocksdb::{DBRawIteratorWithThreadMode, Snapshot};
 use tempfile::TempDir;
@@ -757,6 +757,18 @@ fn open_rocksdb(path: &Path) -> Result<DB, StorageError> {
         .map_err(|error| rocksdb_open_error(error, path))
 }
 
+/// MEASUREMENT SCAFFOLD (E24) — remove before shipping.
+///
+/// Lets one binary produce both A/B arms so the arms cannot differ in codegen.
+/// `LIX_ROCKSDB_CHECKSUM=crc32c` reproduces today's behaviour exactly.
+fn measurement_checksum_type() -> ChecksumType {
+    match std::env::var("LIX_ROCKSDB_CHECKSUM").as_deref() {
+        Ok("crc32c") => ChecksumType::CRC32c,
+        Ok("none") => ChecksumType::NoChecksum,
+        _ => ChecksumType::XXH3,
+    }
+}
+
 fn column_family_options() -> Options {
     let mut options = Options::default();
     options.set_write_buffer_size(WRITE_BUFFER_BYTES);
@@ -774,6 +786,20 @@ fn column_family_options() -> Options {
     // Full whole-key filters let missing point reads skip unrelated SST data.
     table_options.set_bloom_filter(8.0, false);
     table_options.set_optimize_filters_for_memory(true);
+    // RocksDB's default block checksum is CRC32c, and its hardware
+    // (SSE4.2 + PCLMULQDQ) implementation is selected at C++ *compile* time.
+    // `librocksdb-sys` only passes `-msse4.2 -mpclmul` when the Rust target
+    // already enables those features, and the default `x86-64` baseline does
+    // not — so every shipped build gets `ExtendImpl<DefaultCRC32>`, the
+    // table-driven software fallback. A flat profile of a 640 MiB binary-CAS
+    // read spends 34.6% of its cycles in exactly that symbol.
+    //
+    // XXH3 is a checksum of the same strength class whose speed does not
+    // depend on a compile-time ISA gate, so it is fast on every target lix
+    // ships to instead of only on hosts built with a raised baseline.
+    // Checksum type is recorded per table file: existing CRC32c files stay
+    // readable, and nothing about the key or value encoding changes.
+    table_options.set_checksum_type(measurement_checksum_type());
     options.set_block_based_table_factory(&table_options);
     options
 }


### PR DESCRIPTION
# perf(build): compile RocksDB's hardware CRC32C — binary CAS reads +40–48% throughput

## The finding first

This experiment was commissioned to test whether the binary CAS read path is bottlenecked on a
**single-threaded BLAKE3 pass** (`binary_cas/kv.rs:2020`) and whether parallel hashing would
raise the checkout ceiling.

**It is not, and it would not.** A flat profile of the read path alone puts BLAKE3 at **8.0%**
of cycles. Amdahl caps a perfect, free, 32-way parallel hash at an 8% win — under the round's
gate — for the price of a `cfg`-gated `rayon` dependency in a crate that compiles to wasm.
**The hypothesis is rejected on measurement.**

What the profile found instead, at the top of the same read path:

| symbol | share |
|---|---|
| **`rocksdb::crc32c::ExtendImpl<&rocksdb::crc32c::DefaultCRC32>`** | **33.1%** |
| `blake3_hash_many_avx512` | 8.0% |
| kernel page-fault / page-zeroing / free for the output buffers | ~18% |
| libc `memmove` (the two full memcpys) | ~14% |
| `_copy_to_iter` (kernel copy out of page cache) | 3.4% |
| decompression | **0%** — `BinaryChunkCodec::Raw` is the only variant |

`DefaultCRC32` is RocksDB's **table-driven software fallback**. lix has been running it in every
build.

That profile is the read path in isolation — a pre-seeded store read six times with
`E24_SKIP_SEED=1 E24_SKIP_WRITE=1`, so it contains no write-path samples (18,133 samples). An
independent profile of an **unmodified tree** (probe-only commit, no adapter change, 33,981
samples) puts the same symbol at 32.3%, so it is not an artifact of the measurement scaffold.

**Consistency check:** if CRC32C is ~33% of read cycles and the hardware path makes it
effectively free, the predicted wall-time reduction is ~31%. Measured: **−28.7%** at 10 MiB and
**−32.6%** at 256 KiB. The profile and the A/B agree, which is the reason to believe both.

## Why, precisely

RocksDB picks its hardware CRC32C at C++ **compile** time:

```c
// rocksdb/util/crc32c.cc:1116
#elif defined(__SSE4_2__) && defined(__PCLMUL__) && !defined NO_THREEWAY_CRC32C
  return crc32c_3way;
```

`librocksdb-sys-0.17.3+10.4.2/build.rs:117-147` forwards `-msse4.2 -mpclmul` **only if
`CARGO_CFG_TARGET_FEATURE` already contains them**, and Rust's default `x86-64` baseline does
not. So the fast path was never compiled in.

The payload is affected even though block checksums are fine: RocksDB's default
`BlockBasedTableOptions::checksum` is already `kXXH3` (`include/rocksdb/table.h:283`), but the
immutable CF sets `min_blob_size = 32 KiB`, so every asset at or above 32 KiB lives in a **blob
file** — and blob-file records are checksummed with **CRC32C**, which `BlockBasedOptions` cannot
configure. That is exactly why the win below starts at 32 KiB and not below it.

## What changed physically

`.cargo/config.toml` only. Fourteen lines, twelve of them the comment explaining the above.

```toml
[target.'cfg(all(target_arch = "x86_64", not(target_family = "wasm")))']
rustflags = ["-C", "target-feature=+sse4.2,+pclmulqdq"]
```

plus the same feature added to `[host.x86_64-unknown-linux-gnu]`, per that file's own
"keep host and generic-target rustflags in sync" comment.

**Nothing is removed**, and this is not a cut. No Rust source, no adapter code, no SQL, no
storage layout, and no on-disk format changes. `git diff --stat` against the base is
`.cargo/config.toml | 14 +-` plus the measurement probe.

**`RUSTFLAGS` as an env var does not work here** and this cost a build cycle: the repo sets
`target-applies-to-host = false`, so in a non-cross build cargo treats these units as *host*
units and honours `[host.<triple>]` rather than `RUSTFLAGS`/`[target.*]`. The binary came out
identical and the timings read as "no effect", which is indistinguishable from a refuted
hypothesis. It was caught only by checking the symbol table. **Both entries are required.**

Verification is a symbol check, not an inference:

```
nm -C <binary> | grep -c crc32c_3way     # base: 0     candidate: 2
```

## Adapter API

**Unchanged.** No `StorageAdapter` trait method added, changed or removed. `packages/rocksdb-storage`,
`packages/slatedb-storage`, the in-memory adapter, `packages/lix/src/storage/conformance` and
`packages/lix/tests/third_party_storage_adapter.rs` are all untouched. The change is a compiler
flag; it alters which machine instructions RocksDB's checksum routine uses and nothing else.

## Layout invariants

1. **Single authority.** No. No writer, materialization or index is added, relocated or
   duplicated. Zero lines of engine code change.
2. **Commit canonicality.** Unaffected. No commit record, parent link or state root is touched.
3. **Derived views are caches.** Unaffected; no derived view appears in this diff.
4. **Atomic publication.** Preserved. The write set is unchanged; a faster checksum routine
   cannot split a batch.
5. **GC from refs.** Unaffected. No retention metadata, no reachability change.
6. **SQL reads canonical records.** Unaffected. The same bytes are returned, still checksum-verified
   — CRC32C is still computed and still compared, just with PCLMULQDQ instead of a byte table.
   **The integrity check is not weakened, disabled or replaced.**

## A/B

Machine **ryzen-9950x-V** (32c / 186 GB). Base SHA **`8119553d`**. RocksDB.
`TMPDIR=$HOME/claude5/tmp`; store on `/dev/md0` ext4 — `/tmp` is **not** tmpfs on this host.

`base` = `claude-5/e24-probe-base` (= `8119553d` + the measurement-only probe), default build
config. `cand` = this branch. No env vars set on either arm. Three interleaved blocks with arm
order rotated, 5 reps per block; per-block p50s in parentheses.

Bench: `packages/engine-benchmarks/examples/e24_cas_read_probe.rs` (added here).
`select` = `SELECT path, content FROM lix_file` with every payload materialized — the binary CAS
read. `checkout` = `open + select + write`, the claim-2 operation. Three asset sizes spanning
640x, chosen to match the claim-2 corpora's mean asset sizes.

### `select` — the binary CAS read

| corpus analogue | asset | base p50 ms | base MiB/s | cand p50 ms | cand MiB/s | delta |
|---|---|---|---|---|---|---|
| wesnoth (18 KB mean) | 16 KiB × 4096 | 138.7 (136, 139, 139) | 461 | 135.1 (139, 135, 135) | 474 | −2.6% / +2.7% |
| vscode-docs (341 KB mean) | 256 KiB × 1024 | 364.7 (366, 365, 363) | 702 | **245.9** (246, 253, 239) | **1041** | **−32.6% / +48.3%** |
| bigmedia (10.7 MB mean) | 10240 KiB × 64 | 929.0 (937, 929, 910) | 689 | **662.0** (666, 659, 662) | **967** | **−28.7% / +40.3%** |

### `checkout` — `open + select + write`

| asset | base p50 ms | base MiB/s | cand p50 ms | cand MiB/s | delta |
|---|---|---|---|---|---|
| 16 KiB | 181.7 (179, 182, 182) | 352 | 178.6 (181, 178, 179) | 358 | −1.7% / +1.8% |
| 256 KiB | 409.7 (410, 410, 408) | 625 | **290.8** (291, 302, 283) | **880** | **−29.0% / +40.9%** |
| 10240 KiB | 1020.1 (1025, 1020, 999) | 627 | **751.0** (755, 747, 751) | **852** | **−26.4% / +35.8%** |

### Null control — same run, same reps, same process

`write` is `fs::write` of the identical payloads. It executes no lix code and cannot be affected
by this change, so its spread is this bench's resolution:

| asset | base p50 ms | cand p50 ms | delta |
|---|---|---|---|
| 16 KiB | 39.1 (39, 39, 39) | 39.1 (39, 39, 39) | **−0.0%** |
| 256 KiB | 41.3 (41, 41, 41) | 41.4 (41, 41, 42) | **+0.2%** |
| 10240 KiB | 85.7 (86, 86, 86) | 85.6 (86, 86, 86) | **−0.2%** |

**Noise floor ±0.2%** — two orders of magnitude below the effect. (For contrast, the runbook
records `large_blob_updates`' `raw_backend_initial_write` control at ±5%; this probe resolves
far better because it re-uses one seeded store across reps instead of rebuilding it.)

### Write-path guard — from the same interleaved run

RocksDB checksums on write as well as on read, so the write path is a lane that could plausibly
move. The probe's untimed seed is a real `INSERT INTO lix_file` import of the whole corpus in
50-row batches — the same shape as claim-2's `import`. Three reps per arm, interleaved with
everything above:

| asset | base seed ms | cand seed ms | delta |
|---|---|---|---|
| 16 KiB | 828 (849, 823, 828) | 792 (788, 795, 792) | **−4.3%** |
| 256 KiB | 425 (435, 419, 425) | 316 (314, 316, 318) | **−25.6%** |
| 10240 KiB | 1235 (1222, 1235, 1255) | 993 (1000, 973, 993) | **−19.6%** |

**The write path improves too**, and `import` is one of the operations claim-2 records lix
losing on (1.18–1.35x slower than git+LFS on large binaries). Nothing regressed in either
direction.

### Guards deliberately skipped

Per the runbook's rule that a guard which cannot execute the changed code is not a guard: this
is a compiler flag, so every lane in the binary is "touched" and no lane can be isolated as
unaffected. The two lanes that matter — the CAS read and the real commit/import path — are both
measured above, in the same interleaved run, against a null control that executes no lix code at
all. A `tracked_state_crud` sweep would re-measure the same RocksDB checksum with more noise and
would not change whether this PR opens.

### Mechanism attribution

With **both** arms forced to `ChecksumType::CRC32c` from a single binary (arm selected by env at
open, so codegen is bit-identical), software vs hardware CRC32C alone gives **−18.6% / −32.8% /
−28.9%** on `select`. That isolates the effect to the CRC32C implementation and rules out the
general auto-vectorization that `+sse4.2` also enables for Rust code.

### Scaling

The claim is a constant-factor throughput ceiling, not an asymptotic term, and it is reported as
a curve across three sizes spanning 640x. The ceiling rises from ~630 to ~850–880 MiB/s on
checkout for the two large-asset regimes; the 16 KiB regime is unmoved because those payloads sit
below `min_blob_size` and were already on XXH3.

## What regressed

**Nothing measured regressed.** The null control is flat at ±0.2% and the 16 KiB lane moves
+1.8%, inside its own block spread.

The real cost is not a metric, it is a **distribution constraint**: lix's x86_64 builds now
require SSE4.2 and PCLMULQDQ, i.e. roughly `x86-64-v2`. Those are Intel Nehalem (2008) and AMD
Bulldozer (2011) and later. Every GitHub Actions runner, every current cloud instance type and
every consumer CPU of the last fifteen years has them. **This is a judgement call about the
supported CPU floor and should be confirmed by the owner rather than assumed by me.** If the
answer is no, the alternative is in the follow-up section below.

Scope limits, stated plainly:

1. **aarch64 is not fixed and cannot be fixed this way.** `librocksdb-sys/build.rs` never
   inspects ARM target features and never defines `HAVE_ARM64_CRC`, so `crc32c.cc:1109` can never
   select `ExtendARMImpl`. **Apple Silicon and ARM servers keep the software fallback.** Fixing
   them needs a patched or forked `librocksdb-sys`.
2. **Downstream consumers of the published crates are unaffected**, since `.cargo/config.toml`
   applies only to builds run from inside this repository. It does cover lix's own CI, CLI,
   server and release builds.

## Follow-up this measurement identifies (not in this PR)

The portable fix for both gaps is to stop paying RocksDB's checksum on the binary-CAS chunk
space at all. `binary_cas/kv.rs:2020` already verifies **every** chunk against its BLAKE3-256
content address, unconditionally, in release builds — so RocksDB's CRC32C over those same bytes
is a strictly weaker duplicate of an integrity check lix already pays for. Deleting it is a
"two authorities for one fact, remove the weaker" cut in this round's language, it is portable to
aarch64, and it needs no ISA baseline change.

It is not in this PR because the immutable column family also holds `columnar_row_group` and four
`tracked_state` spaces which are **not** content-addressed, so it cannot be a per-CF switch. It
needs a per-read flag on `StorageGetOptions` plumbed through both shipping adapters, the
in-memory adapter and the conformance suite — a real adapter-API change, correctly scoped as its
own experiment.

## Also added

`packages/engine-benchmarks/examples/e24_cas_read_probe.rs` — measurement only, changes no engine
code. It seeds N incompressible assets through the real `INSERT INTO lix_file` path and then
times `open` / `select` / `write` separately, reporting MiB/s. It is the reproducer for every
number above and the tool that showed 91% of checkout is `select` (922 ms of 1011 ms at 640 MiB,
with `open` at 3.0 ms warm and `fs::write` at 86 ms).

## Correctness gate

Full CI-scope gate on **ryzen-9950x-V**, run from `~/claude5/cand`. `git rev-parse HEAD` and
`git status --porcelain` are printed **inside the gate run**, before and after, so this is
evidence about this commit and not merely about some tree:

```
=== TREE UNDER TEST ===
HEAD: 94e1d039f1c02c1fbce5a07997b34dc98495efe4
status --porcelain:
(end status)                                   <- empty, i.e. clean
=== 1 check --workspace --all-targets --all-features (not a CI step; local)
check exit=0
=== 2 clippy --profile test --workspace --all-targets --all-features -D warnings
clippy exit=0
=== 3 check -p lix --no-default-features
nodefault exit=0
=== 4 check -p lix_js_sdk --target wasm32-unknown-unknown
wasm exit=0
=== 5 test --workspace --exclude lix_benchmarks --all-features --no-fail-fast
test-ws exit=0
=== 6 test -p lix_benchmarks --features storage-benches,slatedb,root-replay-trace --no-fail-fast
test-bench exit=0
=== TREE AFTER GATE ===
HEAD: 94e1d039f1c02c1fbce5a07997b34dc98495efe4
(end status)                                   <- still clean
```

Logs were captured to files and **grepped**, never tailed:
`test result: ok` × 56 / × 10, **3476 + 26 = 3502 passed, 0 failed**, and zero matches for
`test result: FAILED`, `^failures:`, `panicked at` or `^error` in either log.

The features-OFF pair (stages 3 and 4) matters here specifically: raising the x86_64 target
features must not leak into the wasm build. `cfg(all(target_arch = "x86_64", ...))` does not
match `wasm32`, and `[host.x86_64-unknown-linux-gnu]` correctly applies only to the native build
scripts and proc macros of a wasm cross-build. Stage 4 is the thing that confirms it.

## Reproduce

```sh
cargo build --release -p lix_benchmarks --features storage-benches --example e24_cas_read_probe
nm -C target/release/examples/e24_cas_read_probe | grep -c crc32c_3way   # 2 = hardware, 0 = software
./e24_cas_read_probe 10240 64 5 <ext4-dir> 50
# E24_SKIP_SEED=1 reuses a populated dir so perf sees only the read path
# E24_SKIP_WRITE=1 drops the fs::write phase
```
