### PR TITLE
perf(hot_state): bound declared-column index candidate resolution

### DIFF
--- a/packages/lix/src/engine.rs
+++ b/packages/lix/src/engine.rs
@@ -2487,11 +2487,178 @@ mod tests {
         let witnesses = entries
             .iter()
             .filter(|entry| match &entry.value {
-                crate::storage::ProjectedValue::FullValue(bytes) => bytes.is_empty(),
+                crate::storage::ProjectedValue::FullValue(bytes) => !bytes.starts_with(b"["),
                 crate::storage::ProjectedValue::KeyOnly => true,
             })
             .count();
         (witnesses, entries.len() - witnesses)
+    }
+
+    /// The witness carries how many entries the plane has published, which is
+    /// what sizes the degradation budget. It must count every published entry
+    /// in the generation, not just this commit's.
+    async fn hot_index_published_count(storage: &Memory) -> u64 {
+        let storage_adapter = StorageAdapter::new(storage.clone());
+        let read = storage_adapter
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("read the index plane");
+        let entries = scan_test_space(&read, crate::hot_state::INDEX_SPACE).await;
+        let mut total = 0;
+        for entry in &entries {
+            let crate::storage::ProjectedValue::FullValue(bytes) = &entry.value else {
+                continue;
+            };
+            if bytes.starts_with(b"[") {
+                continue;
+            }
+            let count: [u8; 8] = bytes.as_ref().try_into().expect("witness carries a u64");
+            total += u64::from_be_bytes(count);
+        }
+        total
+    }
+
+    #[tokio::test]
+    async fn the_index_witness_accumulates_its_published_entry_count() {
+        let (storage, session) = open_index_probe_session().await;
+        for schema in index_probe_schemas("counted_parent", "counted_child") {
+            session
+                .execute(
+                    "INSERT INTO lix_registered_schema (value) VALUES (lix_json($1))",
+                    &[crate::Value::Text(schema.to_string())],
+                )
+                .await
+                .expect("schema should register");
+        }
+        session
+            .execute("INSERT INTO counted_parent (id) VALUES ('parent-0')", &[])
+            .await
+            .expect("parent should insert");
+        assert_eq!(hot_index_published_count(&storage).await, 0);
+        for index in 0..4 {
+            session
+                .execute(
+                    r#"INSERT INTO counted_child (id, "parentId", locale) VALUES ($1, 'parent-0', 'en')"#,
+                    &[crate::Value::Text(format!("child-{index}"))],
+                )
+                .await
+                .expect("child should insert");
+        }
+        assert_eq!(
+            hot_index_published_count(&storage).await,
+            4,
+            "the count must span commits, not restart at each one"
+        );
+        // A delete publishes no entry — the plane is put-only — so the count
+        // stands still while the collection shrinks. That divergence is
+        // exactly what the budget measures.
+        session
+            .execute("DELETE FROM counted_child WHERE id = 'child-0'", &[])
+            .await
+            .expect("child should delete");
+        assert_eq!(hot_index_published_count(&storage).await, 4);
+    }
+
+    /// Past the budget the lookup abandons the index and the caller's ordinary
+    /// scan serves instead. The route is deliberately invisible in the result,
+    /// so what this pins is that it stays invisible: the same rows, through a
+    /// bucket far past the budget, with live rows, superseded rows and deleted
+    /// rows all present.
+    #[tokio::test]
+    async fn a_bucket_past_the_budget_still_answers_exactly() {
+        let (storage, session) = open_index_probe_session().await;
+        for schema in index_probe_schemas("degraded_parent", "degraded_child") {
+            session
+                .execute(
+                    "INSERT INTO lix_registered_schema (value) VALUES (lix_json($1))",
+                    &[crate::Value::Text(schema.to_string())],
+                )
+                .await
+                .expect("schema should register");
+        }
+        for parent in ["parent-0", "parent-1"] {
+            session
+                .execute(
+                    "INSERT INTO degraded_parent (id) VALUES ($1)",
+                    &[crate::Value::Text(parent.into())],
+                )
+                .await
+                .expect("parent should insert");
+        }
+        const ROWS: usize = 200;
+        let values = (0..ROWS)
+            .map(|index| format!("('child-{index}', 'parent-0', 'en')"))
+            .collect::<Vec<_>>()
+            .join(",");
+        session
+            .execute(
+                &format!(
+                    r#"INSERT INTO degraded_child (id, "parentId", locale) VALUES {values}"#
+                ),
+                &[],
+            )
+            .await
+            .expect("children should insert");
+        // Move half off `parent-0` and delete a quarter, so the `parent-0`
+        // bucket holds every identity while only a quarter still match.
+        let moved = (0..ROWS / 2)
+            .map(|index| format!("'child-{index}'"))
+            .collect::<Vec<_>>()
+            .join(",");
+        session
+            .execute(
+                &format!(
+                    r#"UPDATE degraded_child SET "parentId" = 'parent-1' WHERE id IN ({moved})"#
+                ),
+                &[],
+            )
+            .await
+            .expect("children should move");
+        let deleted = (ROWS / 2..ROWS * 3 / 4)
+            .map(|index| format!("'child-{index}'"))
+            .collect::<Vec<_>>()
+            .join(",");
+        session
+            .execute(
+                &format!("DELETE FROM degraded_child WHERE id IN ({deleted})"),
+                &[],
+            )
+            .await
+            .expect("children should delete");
+
+        let published = hot_index_published_count(&storage).await;
+        assert!(
+            published > 64,
+            "the fixture must push the plane past the budget floor, published {published}"
+        );
+
+        async fn ids(session: &SessionContext<Memory>, parent: &str) -> Vec<String> {
+            let rows = session
+                .execute(
+                    r#"SELECT id FROM degraded_child WHERE "parentId" = $1 ORDER BY id"#,
+                    &[crate::Value::Text(parent.into())],
+                )
+                .await
+                .expect("declared-column read should succeed");
+            rows.rows()
+                .iter()
+                .map(|row| match &row.values()[0] {
+                    crate::Value::Text(id) => id.clone(),
+                    other => panic!("unexpected id value {other:?}"),
+                })
+                .collect()
+        }
+
+        let mut expected_zero = (ROWS * 3 / 4..ROWS)
+            .map(|index| format!("child-{index}"))
+            .collect::<Vec<_>>();
+        expected_zero.sort();
+        assert_eq!(ids(&session, "parent-0").await, expected_zero);
+        let mut expected_one = (0..ROWS / 2)
+            .map(|index| format!("child-{index}"))
+            .collect::<Vec<_>>();
+        expected_one.sort();
+        assert_eq!(ids(&session, "parent-1").await, expected_one);
     }
 
     /// Entries are candidates, never answers. A row whose indexed value moves

--- a/packages/lix/src/hot_index_aging_probe.rs
+++ b/packages/lix/src/hot_index_aging_probe.rs
@@ -74,7 +74,7 @@ async fn index_record_counts(storage: &Memory) -> (usize, usize) {
     let witnesses = entries
         .iter()
         .filter(|entry| match &entry.value {
-            ProjectedValue::FullValue(bytes) => bytes.is_empty(),
+            ProjectedValue::FullValue(bytes) => !bytes.starts_with(b"["),
             ProjectedValue::KeyOnly => true,
         })
         .count();

--- a/packages/lix/src/hot_state/tracked_head/hot.rs
+++ b/packages/lix/src/hot_state/tracked_head/hot.rs
@@ -4958,13 +4958,16 @@ where
 
     /// Candidate entity primary keys whose indexed column equals `value`.
     ///
-    /// Returns `None` when this collection has no completeness witness for the
-    /// generation, which means the caller must not use the index and must fall
-    /// back to its ordinary scan. `Some` is a candidate set, not an answer:
-    /// entries are never deleted within a generation, so a candidate may name a
-    /// row that has since changed value or been deleted. Callers resolve
-    /// candidates through the exact-entity-pk read and re-apply their own
-    /// predicate. The set never *omits* a live matching row.
+    /// Returns `None` when the caller must not use the index and must fall
+    /// back to its ordinary scan, which happens for two reasons: the
+    /// collection has no completeness witness for the generation, or the
+    /// witness says the plane has degraded far enough that resolving its
+    /// candidates would cost more than the scan (see
+    /// [`hot_index_candidate_budget`]). `Some` is a candidate set, not an
+    /// answer: entries are never deleted within a generation, so a candidate
+    /// may name a row that has since changed value or been deleted. Callers
+    /// resolve candidates through the exact-entity-pk read and re-apply their
+    /// own predicate. The set never *omits* a live matching row.
     pub(crate) async fn scan_hot_index_candidates(
         &self,
         branch_id: &str,
@@ -4980,16 +4983,21 @@ where
             ordinal,
         )));
         let present = PointReadPlan::new(INDEX_SPACE, &[witness])
-            .materialize(
-                &self.store,
-                StorageGetOptions {
-                    projection: StorageCoreProjection::KeyOnly,
-                },
-            )
+            .materialize(&self.store, StorageGetOptions::default())
             .await?;
-        if present.value.into_iter().next().flatten().is_none() {
+        let Some(StorageProjectedValue::FullValue(witness_value)) =
+            present.value.into_iter().next().flatten()
+        else {
             return Ok(None);
-        }
+        };
+        // A witness that carries no readable count cannot size the plane, and
+        // an unsized plane is exactly the case this guard exists to refuse.
+        // The next commit that touches the collection republishes the witness
+        // with a count, so this is self-healing rather than permanent.
+        let Some(entries_published) = decode_hot_index_witness(&witness_value) else {
+            return Ok(None);
+        };
+        let budget = hot_index_candidate_budget(entries_published);
         let range = StoragePrefix {
             bytes: Bytes::from(hot_index_value_prefix(
                 branch_id,
@@ -5010,7 +5018,11 @@ where
             .await?;
         let mut candidates = Vec::new();
         loop {
-            let (page, page_has_more) = cursor.next_page(HOT_INDEX_CANDIDATE_PAGE).await?.into_parts();
+            // Never read more than one entry past the budget: the extra entry
+            // is what proves the bucket exceeds it, and everything beyond is
+            // work this route has already decided not to do.
+            let want = (budget + 1 - candidates.len()).min(HOT_INDEX_CANDIDATE_PAGE);
+            let (page, page_has_more) = cursor.next_page(want).await?.into_parts();
             for entry in &page {
                 let StorageProjectedValue::FullValue(value) = &entry.value else {
                     continue;
@@ -5021,6 +5033,9 @@ where
                 candidates.push(EntityPk::from_json_array_text(text).map_err(|error| {
                     head_value_error(format!("hot index entry has an invalid entity pk: {error}"))
                 })?);
+            }
+            if candidates.len() > budget {
+                return Ok(None);
             }
             if !page_has_more {
                 break;
@@ -11688,7 +11703,8 @@ pub(crate) struct HotIndexEntry {
 /// O(changed rows) with no reads. Duplicate `(space, key)` mutations are
 /// rejected by the write set, so identical entries staged twice in one commit
 /// are collapsed here rather than at lowering time.
-pub(crate) fn stage_hot_index_entries(
+pub(crate) async fn stage_hot_index_entries(
+    read: &(impl StorageAdapterRead + ?Sized),
     writes: &mut StorageWriteSet,
     branch_id: &str,
     generation: CommitId,
@@ -11696,6 +11712,7 @@ pub(crate) fn stage_hot_index_entries(
     witnessed_collections: &BTreeSet<(String, u16)>,
 ) -> Result<(), LixError> {
     let mut staged = BTreeSet::new();
+    let mut published_by_collection: BTreeMap<(String, u16), u64> = BTreeMap::new();
     for entry in entries {
         let key = encode_hot_index_entry_key(
             branch_id,
@@ -11718,21 +11735,118 @@ pub(crate) fn stage_hot_index_entries(
                 bytes: Bytes::from(identity.into_bytes()),
             },
         );
+        *published_by_collection
+            .entry((entry.schema_key.clone(), entry.ordinal))
+            .or_default() += 1;
     }
-    for (schema_key, ordinal) in witnessed_collections {
-        let key = encode_hot_index_witness_key(branch_id, generation, schema_key, *ordinal);
-        if !staged.insert(key.clone()) {
+    for collection in witnessed_collections {
+        published_by_collection.entry(collection.clone()).or_default();
+    }
+    if published_by_collection.is_empty() {
+        return Ok(());
+    }
+    // One multi-get and one put per *collection* touched by this commit, not
+    // per row, so maintaining the count is O(collections) and independent of
+    // how many rows the commit carries.
+    let witness_keys = published_by_collection
+        .keys()
+        .map(|(schema_key, ordinal)| {
+            StorageKey(Bytes::from(encode_hot_index_witness_key(
+                branch_id,
+                generation,
+                schema_key,
+                *ordinal,
+            )))
+        })
+        .collect::<Vec<_>>();
+    let previous = PointReadPlan::new(INDEX_SPACE, &witness_keys)
+        .materialize(read, StorageGetOptions::default())
+        .await?
+        .value;
+    for ((collection, published), (key, previous)) in published_by_collection
+        .into_iter()
+        .zip(witness_keys.into_iter().zip(previous.into_iter()))
+    {
+        let existing = match previous {
+            Some(StorageProjectedValue::FullValue(bytes)) => Some(decode_hot_index_witness(&bytes)),
+            Some(StorageProjectedValue::KeyOnly) | None => None,
+        };
+        // Never *create* a witness for a collection that has not asserted
+        // completeness. A witness is the claim that this plane holds every row
+        // of the collection, and inventing one here would turn a partial index
+        // into an authoritative-looking one.
+        if existing.is_none() && !witnessed_collections.contains(&collection) {
+            continue;
+        }
+        // A witness whose previous value could not be decoded restarts the
+        // count from this commit. That undercounts history, which shrinks the
+        // budget and makes the guard fire *earlier* — the safe direction.
+        let total = existing.flatten().unwrap_or(0).saturating_add(published);
+        if !staged.insert(key.0.to_vec()) {
             continue;
         }
         writes.put(
             INDEX_SPACE,
-            StorageKey(Bytes::from(key)),
+            key,
             StorageValue {
-                bytes: Bytes::new(),
+                bytes: Bytes::from(encode_hot_index_witness(total).to_vec()),
             },
         );
     }
     Ok(())
+}
+
+/// Entries published into one `(collection, column)` plane since the
+/// generation began, as carried by the witness record.
+///
+/// This is a monotone upper bound on the plane's size, not an exact count: it
+/// counts staged puts, and a commit that rewrites an unchanged value restages
+/// an identical key. Over-counting only widens the budget, so the bound is
+/// safe in the direction that matters.
+fn encode_hot_index_witness(entries_published: u64) -> [u8; 8] {
+    entries_published.to_be_bytes()
+}
+
+fn decode_hot_index_witness(value: &[u8]) -> Option<u64> {
+    value.try_into().ok().map(u64::from_be_bytes)
+}
+
+/// How many candidates one value lookup may collect before the collection scan
+/// becomes the cheaper route.
+///
+/// **This is a graceful-degradation bound, not a repair.** Entries still
+/// accumulate; past the budget the plane simply stops being consulted, so the
+/// index can never cost more than not having it. Nothing is pruned and no
+/// bytes are reclaimed.
+///
+/// The constant is measured, not chosen. On `ryzen-9950x-I` at base
+/// `a0ccd0dd6`, resolving one candidate costs ≈0.73 µs (point read plus
+/// snapshot parse) while the collection scan costs ≈0.30–0.49 µs per row, so
+/// the index route loses once a bucket exceeds roughly two thirds of the rows
+/// the scan would walk. `entries_published` is an upper bound on the plane's
+/// size and grows with the same entity churn that grows the scan's row count
+/// (deleted rows leave tombstones the scan still walks), which makes it the
+/// available proxy for that row count. Halving it keeps the budget below the
+/// measured crossover.
+///
+/// Checked against every point of the measurement that motivated it: the aged
+/// 100/1000/10000 buckets, the moved 100/1000/10000 buckets and the 100/1000/5000
+/// write-path buckets all exceed their budget, and all were slower than the
+/// scan; the fresh one-candidate arm and the 10-candidate write-path arm stay
+/// under it, and both were faster.
+///
+/// At the boundary the route flips: a bucket of exactly `budget` is served by
+/// the index; one entry more abandons the route after reading that one extra
+/// entry and pays the scan, so the worst case is the scan plus a bounded
+/// key-only prefix read.
+///
+/// The floor exists because below it the absolute cost is smaller than the
+/// measurement's own noise floor — a 64-candidate bucket resolves in ≈47 µs —
+/// so flipping tiny collections to a scan would trade a real access path for
+/// no measurable gain.
+fn hot_index_candidate_budget(entries_published: u64) -> usize {
+    const MIN_CANDIDATE_BUDGET: u64 = 64;
+    usize::try_from((entries_published / 2).max(MIN_CANDIDATE_BUDGET)).unwrap_or(usize::MAX)
 }
 
 /// One indexed value, encoded so that equality is a key prefix.
@@ -15835,6 +15949,68 @@ mod tests {
         assert_eq!(buffers.row_deletes.as_ptr(), row_delete_allocation);
         assert!(buffers.row_puts.capacity() >= ROW_COUNT);
         assert!(buffers.row_deletes.capacity() >= ROW_COUNT);
+    }
+
+    /// The budget is the whole guard, so its shape is pinned here rather than
+    /// inferred from a timing test. Every constant is justified in
+    /// [`hot_index_candidate_budget`]'s own documentation against the
+    /// measurement that produced it.
+    #[test]
+    fn the_candidate_budget_floors_small_planes_and_halves_large_ones() {
+        // Below the floor the absolute cost of resolving a bucket is smaller
+        // than the measurement's noise floor, so tiny planes keep the index.
+        assert_eq!(hot_index_candidate_budget(0), 64);
+        assert_eq!(hot_index_candidate_budget(1), 64);
+        assert_eq!(hot_index_candidate_budget(128), 64);
+        // Above it the budget is half the plane, which sits below the measured
+        // crossover of roughly two thirds.
+        assert_eq!(hot_index_candidate_budget(129), 64);
+        assert_eq!(hot_index_candidate_budget(200), 100);
+        assert_eq!(hot_index_candidate_budget(20_000), 10_000);
+        // The guard must not overflow into a permissive budget on a plane
+        // whose count is nonsense.
+        assert_eq!(hot_index_candidate_budget(u64::MAX), (u64::MAX / 2) as usize);
+    }
+
+    /// Every arm of the measurement that motivated the guard, classified by the
+    /// budget. The aged, moved and large write-path buckets were all slower
+    /// than the collection scan and must be refused; the fresh and small
+    /// write-path buckets were faster and must be kept.
+    #[test]
+    fn the_budget_refuses_exactly_the_buckets_that_lost_to_the_scan() {
+        for (entries_published, bucket, expected_served) in [
+            // arm            plane    bucket  index route beat the scan?
+            /* fresh      */ (1_u64, 1_usize, true),
+            /* write 10   */ (11, 10, true),
+            /* write 100  */ (101, 100, false),
+            /* write 1000 */ (1_001, 1_000, false),
+            /* write 5000 */ (5_001, 5_000, false),
+            /* aged 100   */ (100, 100, false),
+            /* aged 1000  */ (1_000, 1_000, false),
+            /* aged 10000 */ (10_000, 10_000, false),
+            /* moved 100  */ (199, 100, false),
+            /* moved 1000 */ (1_999, 1_000, false),
+            /* moved 10k  */ (19_999, 10_000, false),
+        ] {
+            let served = bucket <= hot_index_candidate_budget(entries_published);
+            assert_eq!(
+                served, expected_served,
+                "plane of {entries_published} entries, bucket of {bucket}",
+            );
+        }
+    }
+
+    #[test]
+    fn a_witness_round_trips_its_published_count() {
+        assert_eq!(decode_hot_index_witness(&encode_hot_index_witness(0)), Some(0));
+        assert_eq!(
+            decode_hot_index_witness(&encode_hot_index_witness(7_919)),
+            Some(7_919)
+        );
+        // An unreadable witness cannot size the plane, and the lookup refuses
+        // the index rather than guessing a budget.
+        assert_eq!(decode_hot_index_witness(&[]), None);
+        assert_eq!(decode_hot_index_witness(&[0, 1, 2]), None);
     }
 
     #[tokio::test]

--- a/packages/lix/src/transaction/commit.rs
+++ b/packages/lix/src/transaction/commit.rs
@@ -4377,12 +4377,14 @@ async fn stage_tracked_head(
             hot_index_writes_for_commit(state_rows, &root.branch_id, parent_control.as_ref());
         if !index_entries.is_empty() || !index_witnesses.is_empty() {
             crate::hot_state::stage_hot_index_entries(
+                read,
                 writes,
                 &root.branch_id,
                 generation,
                 &index_entries,
                 &index_witnesses,
-            )?;
+            )
+            .await?;
         }
         if let Some(epoch) = working_diff_epoch {
             let next_epoch = TrackedWorkingDiffEpoch {


### PR DESCRIPTION
Follow-up to #1384, which measured the defect. This bounds it.

## What this is — and what it is not

**A graceful-degradation bound, not a repair.** Entries still accumulate exactly
as before; nothing is pruned and no bytes are reclaimed. What changes is that a
lookup now knows how large the plane has grown and **stops consulting the index
once doing so would cost more than not having it**. Anyone reading this should
not come away thinking the plane was made exact — it was not. The exact fix is
filed at the bottom.

## The defect, from #1384

`INDEX_SPACE` maintenance is put-only within a generation, so a bucket holds
every `entity_pk` that has **ever** been written with that value — including
deleted entities and entities that have moved off it. A generation spans a
branch's lifetime. Measured on the probe #1384 landed: once a bucket ages to
collection size, the indexed access path is **2.0–2.5x slower than the
collection scan it exists to replace**, growing without bound in entity churn.
An insert into a table holding one live row cost 5.0 ms after 5000
create/delete cycles.

## What changed physically

1. **The witness record's value stops being empty.** It now carries
   `entries_published: u64` — a monotone upper bound on the plane's size for one
   `(collection, column)`, big-endian.
2. **`stage_hot_index_entries` is now `async` and takes the read handle.** It
   multi-gets the witness keys for the collections this commit touches, adds the
   entries it staged, and writes them back — **one multi-get and one put per
   touched collection per commit, O(collections), never O(rows)**. It still
   never *creates* a witness for a collection that has not asserted
   completeness; a collection with no witness is skipped entirely, so a partial
   index can never acquire an authoritative-looking one.
3. **`scan_hot_index_candidates` reads the witness value** (projection changed
   from `KeyOnly` to full), sizes a budget from it, and returns `None` — the
   existing "caller must use its ordinary scan" signal — as soon as the bucket
   exceeds the budget. It reads at most one entry past the budget, so the
   abandoned route pays a bounded prefix read and nothing else.

Nothing was removed. No storage adapter API was added, changed, or removed. No
public API change. No new storage space, no new writer, no versioned identifier
bumped (`hot_state.index.v1` is unchanged; `rg` confirms no pinned literal).

A witness whose value does not decode cannot size the plane, and the lookup
refuses the index rather than guessing — self-healing, because the next commit
touching the collection republishes the witness with a count, and undercounting
history only shrinks the budget, which makes the guard fire *earlier*.

## Why `entries_published / 2`, on evidence

The constant is derived from #1384's own table, not chosen.

Resolving one candidate costs **≈0.73 µs** (point read plus snapshot parse);
the collection scan costs **≈0.30–0.49 µs per row**. So the index route loses
once a bucket exceeds roughly **two thirds** of the rows the scan would walk —
that is the crossover, and it sits between the aged 1k and 10k points where the
indexed path went from 2.3x to 2.5x the scan.

`entries_published` is the available proxy for that row count: it is an upper
bound on the plane's size, and it grows with the same entity churn that grows
the scan's row count, because deleted rows leave tombstones the scan still
walks. **Halving it keeps the budget below the measured crossover** rather than
straddling it.

Checked against every arm of the measurement — this is a test
(`the_budget_refuses_exactly_the_buckets_that_lost_to_the_scan`), not a claim:

| arm | plane | bucket | budget | served? | was it faster than the scan? |
|---|---:|---:|---:|:--:|:--:|
| fresh | 1 | 1 | 64 | yes | yes |
| write 10 | 11 | 10 | 64 | yes | yes |
| write 100 | 101 | 100 | 64 | no | no |
| write 1000 | 1001 | 1000 | 500 | no | no |
| write 5000 | 5001 | 5000 | 2500 | no | no |
| aged 100 / 1k / 10k | 100 / 1000 / 10000 | same | 64 / 500 / 5000 | no | no |
| moved 100 / 1k / 10k | 199 / 1999 / 19999 | 100 / 1000 / 10000 | 99 / 999 / 9999 | no | no |

Every bucket that lost to the scan is refused; every bucket that beat it is
kept. No arm distinguishes `/2` from a tighter divisor, so the measured
crossover is the only evidence available and `/2` is the nearest simple constant
below it.

**At the boundary**: a bucket of exactly `budget` is served by the index. One
entry more abandons the route *after reading that one extra entry*, and the
caller pays the ordinary scan. So the worst case is the scan plus a bounded
key-prefix read — which is what the residual in the table below is.

**The floor of 64** exists because below it the absolute cost is under the
instrument's own noise floor (a 64-candidate bucket resolves in ≈47 µs against a
41–45 µs baseline), so flipping tiny collections to a scan would trade a real
access path for nothing measurable.

## A/B

Machine `ryzen-9950x-I`. Base SHA **`d0de4e869`** (`~/claude5/base`, verified at
`origin/claude-5-optimizations`, clean). Candidate `be90ee807`. Both arms built
`--release` from separate target dirs, **no compile inside any timing window**.
Arm order rotated `base, cand, cand, base, base, cand`; median of 3 per arm.
Each test run **in its own process** — see the confound note below.

Probe (`--ignored`, landed in #1384):

```
LIX_INDEX_AGING_SIZES=100,1000,10000 LIX_INDEX_AGING_REPS=5 \
LIX_INDEX_AGING_WRITE_CHECKPOINTS=10,100,1000,5000 \
<target>/release/deps/lix-<hash> hot_index_<test> --ignored --nocapture --test-threads=1
```

### Null control

The `fresh` arm — one candidate, one live row, identical answer — is byte-identical
work in both arms: **base 44 / 44 / 43 µs, cand 41 / 43 / 42 µs** at n = 100 /
1000 / 10000. Spread across both arms is 41–56 µs, so this instrument resolves
roughly **±5%**. Every delta claimed below is 15–53%.

### Read path (one live match in every arm; last columns are the unindexed scan)

| arm | n | base µs | cand µs | Δ | scan base | scan cand | index vs scan: base → cand |
|---|---:|---:|---:|---:|---:|---:|---|
| aged | 100 | 122 | 99 | **−19%** | 72 | 68 | 1.69x → 1.46x |
| aged | 1000 | 753 | 405 | **−46%** | 317 | 322 | 2.38x → 1.26x |
| aged | 10000 | 7660 | 3604 | **−53%** | 2886 | 2850 | **2.65x → 1.26x** |
| moved | 100 | 131 | 111 | −15% | 89 | 88 | 1.47x → 1.26x |
| moved | 1000 | 948 | 691 | −27% | 533 | 515 | 1.78x → 1.34x |
| moved | 10000 | 10040 | 6373 | **−36%** | 4950 | 4810 | **2.03x → 1.33x** |
| fresh | 100/1k/10k | 44/44/43 | 41/43/42 | – (control) | – | – | – |

Raw per-rep, aged 10000: base 7660 / 7275 / 7721, cand 3592 / 3604 / 3623.
Raw per-rep, moved 10000: base 9911 / 10040 / 10065, cand 6373 / 6358 / 6418.

### Write path — `validate_committed_unique_constraints` probe route

| accumulated | base µs | cand µs | Δ |
|---:|---:|---:|---:|
| 10 | 171 | 173 | +1.2% (within the ±5% floor) |
| 100 | 244 | 199 | −18% |
| 1000 | 1057 | 586 | **−45%** |
| 5000 | 5028 | 2660 | **−47%** |

Raw per-rep at 5000: base 5017 / 5028 / 5509, cand 2644 / 2673 / 2660.

The `accumulated = 10` row is the **maintenance-cost guard**: a collection with
an indexed column, healthy plane, paying one extra multi-get and one extra put
per commit for no benefit yet. It does not move.

### Guards

**Composite-unique control** (same churn, scan route, no indexed column — the
lane the guard must not touch), run in isolation:

| accumulated | base µs | cand µs | Δ |
|---:|---:|---:|---:|
| 1000 | 565 | 570 | +0.9% |
| 5000 | 2276 | 2293 | +0.7% |

**`tracked_state_crud … insert_all_rows/10k`**, 3 reps per arm, medians:

| lane | base ms | cand ms | Δ |
|---|---:|---:|---:|
| kv_layout / rocksdb | 5.007 | 5.030 | +0.5% |
| transaction / rocksdb | 21.762 | 21.608 | −0.7% |
| sql_session / rocksdb | 25.080 | 25.081 | 0.0% |
| transaction / slatedb | 23.267 | 23.298 | +0.1% |
| sql_session / slatedb | 25.598 | 25.648 | +0.2% |

**Honest caveat on that guard**: the `tracked_state_crud` fixture schema
(`json_pointer.schema.json`) declares no `x-lix-unique` and no
`x-lix-foreign-keys`, so it has **no indexed columns and never calls
`stage_hot_index_entries`**. It therefore guards only against collateral damage
from making `stage_tracked_head` carry another `await` — it does **not** measure
the maintenance cost. The `accumulated = 10` probe row above is what measures
that, and the per-commit cost is structurally one multi-get plus one put per
touched collection regardless.

### Confound worth recording

Running all three probe tests in one process makes the composite control look
**20% slower in the candidate arm** (1910 → 2295 µs), which is an artifact, not a
regression: the preceding read-path test allocates a 10 000-entry candidate
vector in the base arm and aborts at 5001 in the candidate arm, leaving different
heap state for the test that follows. In isolation the two arms are within 0.7%.
**Every number above was measured with one test per process.**

## What did not improve, and why

The guard leaves a **residual 1.26–1.33x over the scan**, down from 2.03–2.65x.
That residual is the budget prefix read: abandoning the route still costs
reading `budget + 1` entries, and in the `moved` arm the plane is twice the
bucket so the budget is nearly the bucket itself. Bounded, and it does not grow
relative to the scan.

**Bytes regress, marginally and deliberately**: one 8-byte witness value per
touched collection is rewritten each commit instead of being written once.
Physical bytes are this round's lowest priority, and the plane's real space
problem — unbounded entry accumulation — is untouched by this PR either way.

## Follow-up: make the plane exact

Add a reverse record `(…, REVERSE, ordinal, entity_pk) -> current value`. On
commit, batch multi-get the reverse records for changed indexed rows; when the
value moved or the row was deleted, stage a delete of the stale entry alongside
the new put — same write set, so publication stays atomic and no false negative
is possible. Candidates then equal live matches, plane size becomes O(live rows
× indexed columns), and both paths stay flat forever. It costs one extra point
read **per changed indexed row** per commit rather than per collection, so it
needs a real write-lane guard on a fixture that actually has indexed columns.
The reason it is the larger change is that `hot_index_writes_for_commit` is
currently sync with no store access. Not a change to make the night before a
release claim.

Separately and independently: **the collection scan is itself ageing.** The
composite-unique control grows 147 → 1989 µs over the same 5000 create/delete
cycles with one live row, because deleted rows leave tombstones the scan walks.
That is a second ageing term in the same generation, it is not addressed here,
and it means this guard's fallback is bounded relative to the index but is not
constant.

## Layout invariants

1. **Single authority** — no second authority. The witness value is a size hint
   for an access-path choice; both routes return the same rows, and the rows
   remain the only authority for content. Nothing reads the count for a semantic
   decision.
2. **Commit canonicality** — unchanged. No commit record, parent link, state
   root or ref handling touched.
3. **Derived views are caches** — strengthened. The plane was already a cache;
   this makes it a cache the engine is willing to *ignore*. The guard's only
   effect is to fall back to the canonical scan, which is why an inaccurate
   count can cost time and can never produce a wrong answer.
4. **Atomic publication** — preserved. The witness put lands in the same
   `StorageWriteSet` as the entries it counts, so no reader observes a count
   that disagrees with the entries beside it.
5. **GC from refs** — unchanged. Generation retirement still removes the whole
   plane; no new retention metadata.
6. **SQL reads canonical records** — unchanged, and the fallback route *is* the
   canonical scan.

The count is read at commit time and written in the same write set, so two
concurrent publications could lose one increment. That undercounts, which
shrinks the budget and fires the guard earlier — safe in the only direction that
matters, and it is documented at the call site.

## Gate

Run on `ryzen-9950x-I`, matching `origin/main:.github/workflows/ci.yml`
(clippy → `--no-run` compile → test run; CI has no `cargo check --workspace`
step). Log `~/claude5/logs/e23-gate3.log`, captured in full and **grepped**, not
tailed, for `failures:`, `panicked`, `test result: FAILED`, `^error`.

```
+ git rev-parse HEAD
be90ee807714352ddb9d4142bcfd3f8e855c7f68
+ git status --porcelain
+ cargo clippy --profile test --workspace --all-targets --all-features -- -D warnings
+ cargo test --profile test --workspace --exclude lix_benchmarks --all-features --no-fail-fast
+ cargo test --profile test -p lix_benchmarks --features storage-benches,slatedb,root-replay-trace --no-fail-fast
+ cargo check -p lix --no-default-features
+ cargo check -p lix_js_sdk --target wasm32-unknown-unknown
```

**3507 passed, 0 failed**, zero clippy warnings, both features-OFF checks clean,
working tree clean at the gated SHA.

New tests: `the_candidate_budget_floors_small_planes_and_halves_large_ones`,
`the_budget_refuses_exactly_the_buckets_that_lost_to_the_scan`,
`a_witness_round_trips_its_published_count`,
`the_index_witness_accumulates_its_published_entry_count`,
`a_bucket_past_the_budget_still_answers_exactly`. The last one is the one that
matters: the route is invisible in the result by design, so it pins that it
*stays* invisible — the same rows through a bucket far past the budget, with
live, superseded and deleted identities all present.
