### PR TITLE
refactor(lix): share the silently-corrupting key primitives, and pin the three decoders against each other

### DIFF
--- a/packages/lix/src/hot_state/mod.rs
+++ b/packages/lix/src/hot_state/mod.rs
@@ -4,6 +4,8 @@ mod entity_columnar_cache;
 mod entity_decoded_column_cache;
 mod reader;
 mod tracked_head;
+#[cfg(test)]
+pub(crate) use tracked_head::{head_decode_entity_pk_probe, hot_decode_entity_pk_probe};
 mod types;
 pub(crate) mod visibility;
 

--- a/packages/lix/src/hot_state/tracked_head.rs
+++ b/packages/lix/src/hot_state/tracked_head.rs
@@ -8,6 +8,8 @@
 //! untracked overlay.
 
 mod hot;
+#[cfg(test)]
+pub(crate) use hot::hot_decode_entity_pk_probe;
 
 pub(crate) use crate::hot_state::HotStateReadDomain;
 #[cfg(test)]
@@ -968,6 +970,17 @@ fn read_generation(bytes: &[u8], offset: &mut usize) -> Result<CommitId, LixErro
     Ok(CommitId::new(uuid::Uuid::from_bytes(uuid)))
 }
 
+
+/// Test-only shim so the shared codec's three-way differential can drive this
+/// plane's decoder. See `crate::order_preserving_key::tests`.
+#[cfg(test)]
+pub(crate) fn head_decode_entity_pk_probe(bytes: &[u8]) -> Option<(EntityPk, usize)> {
+    let mut offset = 0usize;
+    read_entity_pk(bytes, &mut offset)
+        .ok()
+        .map(|entity_pk| (entity_pk, offset))
+}
+
 fn read_entity_pk(bytes: &[u8], offset: &mut usize) -> Result<EntityPk, LixError> {
     let version = bytes
         .get(*offset)
@@ -1024,7 +1037,7 @@ fn read_entity_pk_part(
         }
         ENTITY_PK_UUID => {
             let uuid_end = offset
-                .checked_add(16)
+                .checked_add(ENTITY_PK_UUID_BYTES)
                 .ok_or_else(|| key_codec_error("UUIDv7 entity primary key offset overflow"))?;
             let uuid_bytes: [u8; 16] = bytes
                 .get(*offset..uuid_end)
@@ -1035,7 +1048,7 @@ fn read_entity_pk_part(
                 .get(uuid_end)
                 .copied()
                 .ok_or_else(|| key_codec_error("is truncated after UUIDv7 entity primary key"))?;
-            if !matches!(terminator, KEY_PART_FINAL | KEY_PART_MORE) {
+            if !is_key_part_terminator(terminator) {
                 return Err(key_codec_error(
                     "UUIDv7 entity primary key has an invalid terminator",
                 ));
@@ -1048,7 +1061,7 @@ fn read_entity_pk_part(
         }
         ENTITY_PK_INTEGER => {
             let integer_end = offset
-                .checked_add(8)
+                .checked_add(ENTITY_PK_INTEGER_BYTES)
                 .ok_or_else(|| key_codec_error("integer entity primary key offset overflow"))?;
             let ordered = u64::from_be_bytes(
                 bytes
@@ -1061,16 +1074,14 @@ fn read_entity_pk_part(
                 .get(integer_end)
                 .copied()
                 .ok_or_else(|| key_codec_error("is truncated after integer entity primary key"))?;
-            if !matches!(terminator, KEY_PART_FINAL | KEY_PART_MORE) {
+            if !is_key_part_terminator(terminator) {
                 return Err(key_codec_error(
                     "integer entity primary key has an invalid terminator",
                 ));
             }
             *offset = integer_end + 1;
             Ok((
-                crate::entity_pk::EntityPkComponent::Integer(i64::from_be_bytes(
-                    (ordered ^ (1_u64 << 63)).to_be_bytes(),
-                )),
+                crate::entity_pk::EntityPkComponent::Integer(i64_from_ordered_integer(ordered)),
                 terminator,
             ))
         }

--- a/packages/lix/src/hot_state/tracked_head/hot.rs
+++ b/packages/lix/src/hot_state/tracked_head/hot.rs
@@ -11434,6 +11434,16 @@ fn decode_hot_scan_row_key_in_scope(key: Bytes, scope: &[u8]) -> Result<HotScanI
     })
 }
 
+
+/// Test-only shim; see `crate::order_preserving_key::tests`.
+#[cfg(test)]
+pub(crate) fn hot_decode_entity_pk_probe(bytes: &[u8]) -> Option<(EntityPk, usize)> {
+    let mut offset = 0usize;
+    read_hot_scan_entity_pk(&Bytes::copy_from_slice(bytes), &mut offset)
+        .ok()
+        .map(|entity_pk| (entity_pk, offset))
+}
+
 fn read_hot_scan_entity_pk(bytes: &Bytes, offset: &mut usize) -> Result<EntityPk, LixError> {
     let version = bytes
         .get(*offset)
@@ -11492,7 +11502,7 @@ fn read_hot_scan_entity_pk_part(
         }
         ENTITY_PK_UUID => {
             let uuid_end = offset
-                .checked_add(16)
+                .checked_add(ENTITY_PK_UUID_BYTES)
                 .ok_or_else(|| key_codec_error("UUIDv7 entity primary key offset overflow"))?;
             let uuid_bytes: [u8; 16] = bytes
                 .get(*offset..uuid_end)
@@ -11503,7 +11513,7 @@ fn read_hot_scan_entity_pk_part(
                 .get(uuid_end)
                 .copied()
                 .ok_or_else(|| key_codec_error("is truncated after UUIDv7 entity primary key"))?;
-            if !matches!(terminator, KEY_PART_FINAL | KEY_PART_MORE) {
+            if !is_key_part_terminator(terminator) {
                 return Err(key_codec_error(
                     "UUIDv7 entity primary key has an invalid terminator",
                 ));
@@ -11516,7 +11526,7 @@ fn read_hot_scan_entity_pk_part(
         }
         ENTITY_PK_INTEGER => {
             let integer_end = offset
-                .checked_add(8)
+                .checked_add(ENTITY_PK_INTEGER_BYTES)
                 .ok_or_else(|| key_codec_error("integer entity primary key offset overflow"))?;
             let ordered = u64::from_be_bytes(
                 bytes
@@ -11529,16 +11539,14 @@ fn read_hot_scan_entity_pk_part(
                 .get(integer_end)
                 .copied()
                 .ok_or_else(|| key_codec_error("is truncated after integer entity primary key"))?;
-            if !matches!(terminator, KEY_PART_FINAL | KEY_PART_MORE) {
+            if !is_key_part_terminator(terminator) {
                 return Err(key_codec_error(
                     "integer entity primary key has an invalid terminator",
                 ));
             }
             *offset = integer_end + 1;
             Ok((
-                crate::entity_pk::EntityPkComponent::Integer(i64::from_be_bytes(
-                    (ordered ^ (1_u64 << 63)).to_be_bytes(),
-                )),
+                crate::entity_pk::EntityPkComponent::Integer(i64_from_ordered_integer(ordered)),
                 terminator,
             ))
         }
@@ -11754,8 +11762,7 @@ impl HotIndexValue {
             }
             Self::Integer(value) => {
                 out.push(ENTITY_PK_INTEGER);
-                let ordered = u64::from_be_bytes(value.to_be_bytes()) ^ (1_u64 << 63);
-                out.extend_from_slice(&ordered.to_be_bytes());
+                out.extend_from_slice(&ordered_integer_from_i64(*value).to_be_bytes());
                 out.push(KEY_PART_FINAL);
             }
         }

--- a/packages/lix/src/order_preserving_key.rs
+++ b/packages/lix/src/order_preserving_key.rs
@@ -13,6 +13,30 @@
 //! terminator. Tags match `EntityPk`'s cross-type order. UUIDs use raw bytes and
 //! signed integers use sign-bit-flipped big endian, so lexical byte order is
 //! logical order.
+//!
+//! # The decoders are still duplicated
+//!
+//! Encoding is unified here. **Decoding is not** — there are three independent
+//! implementations of this same grammar, and this module owns only the
+//! primitives whose divergence would corrupt silently (the field widths, the
+//! terminator predicate, and the sign flip):
+//!
+//! | implementation | ownership | scanner | terminator validated |
+//! |---|---|---|---|
+//! | `hot_state::tracked_head` | `Vec<u8>` / `String` | byte loop | by callers |
+//! | `hot_state::tracked_head::hot` | `Bytes` / `SharedStr` | byte loop | by callers |
+//! | `tracked_state::codec` | `Vec` / `Cow` / `Bytes` | `memchr` | inside the scanner |
+//!
+//! They agree today — [`tests::all_three_decoders_agree`] proves it over every
+//! truncation and every single-byte mutation of a seed corpus — but they agree
+//! by coincidence of maintenance, not by construction. Unifying them means
+//! standardising on one scanner (the `memchr` one) behind a borrowable span so
+//! all three ownership modes keep zero-copy, and mapping a structured error
+//! enum to each plane's own error code and prefix. That rewrites a hot inner
+//! loop, so it wants a benchmark rather than only a green gate.
+//!
+//! Treat the differential test as the contract until then: it fails the moment
+//! a fourth divergence appears.
 
 pub(crate) const KEY_ESCAPE: u8 = 0xff;
 pub(crate) const KEY_PART_FINAL: u8 = 0x00;
@@ -24,6 +48,29 @@ pub(crate) const ENTITY_PK_UUID: u8 = 0x00;
 pub(crate) const ENTITY_PK_INTEGER: u8 = 0x01;
 pub(crate) const ENTITY_PK_STRING: u8 = 0x02;
 pub(crate) const ENTITY_PK_BYTES: u8 = 0x03;
+
+/// Byte width of a UUID entity-primary-key component.
+pub(crate) const ENTITY_PK_UUID_BYTES: usize = 16;
+/// Byte width of an integer entity-primary-key component.
+pub(crate) const ENTITY_PK_INTEGER_BYTES: usize = 8;
+
+/// A part terminator is either "more components follow" or "this was the last".
+/// Any other byte in that position is a malformed key.
+pub(crate) fn is_key_part_terminator(byte: u8) -> bool {
+    matches!(byte, KEY_PART_FINAL | KEY_PART_MORE)
+}
+
+/// Signed integers are stored sign-bit-flipped big endian so that lexical byte
+/// order is numeric order. These two are exact inverses and must only ever be
+/// changed together, which is why they live next to each other rather than at
+/// each of the six sites that used to open-code the flip.
+pub(crate) fn ordered_integer_from_i64(value: i64) -> u64 {
+    u64::from_be_bytes(value.to_be_bytes()) ^ (1_u64 << 63)
+}
+
+pub(crate) fn i64_from_ordered_integer(ordered: u64) -> i64 {
+    i64::from_be_bytes((ordered ^ (1_u64 << 63)).to_be_bytes())
+}
 
 /// Encoding an empty primary key is deliberately not an assertion failure.
 /// Non-emptiness is enforced where it can produce a real error —
@@ -49,8 +96,7 @@ pub(crate) fn write_entity_pk(out: &mut Vec<u8>, entity_pk: &crate::entity_pk::E
             }
             crate::entity_pk::EntityPkComponent::Integer(value) => {
                 out.push(ENTITY_PK_INTEGER);
-                let ordered = u64::from_be_bytes(value.to_be_bytes()) ^ (1_u64 << 63);
-                out.extend_from_slice(&ordered.to_be_bytes());
+                out.extend_from_slice(&ordered_integer_from_i64(*value).to_be_bytes());
                 out.push(terminator);
             }
             crate::entity_pk::EntityPkComponent::String(value) => {
@@ -101,6 +147,140 @@ mod tests {
         let mut out = Vec::new();
         write_entity_pk(&mut out, &entity_pk);
         out
+    }
+
+
+    /// The corpus the three-way differential runs over: valid encodings, every
+    /// truncation of them, every single-byte mutation to a grammar-significant
+    /// value, and shapes the generators cannot reach. Decode is where a
+    /// divergence between the planes becomes a wrong row rather than a wrong
+    /// message, so malformed input is the interesting part.
+    fn differential_corpus() -> Vec<Vec<u8>> {
+        let seeds = vec![
+            encoded_entity_pk(vec![EntityPkComponent::String("x".into())]),
+            encoded_entity_pk(vec![EntityPkComponent::String("a\0b".into())]),
+            encoded_entity_pk(vec![EntityPkComponent::Integer(-1)]),
+            encoded_entity_pk(vec![EntityPkComponent::Uuid([7; 16])]),
+            encoded_entity_pk(vec![EntityPkComponent::Bytes(
+                bytes::Bytes::from_static(&[0, 0xff]),
+            )]),
+            encoded_entity_pk(vec![
+                EntityPkComponent::String("a".into()),
+                EntityPkComponent::Integer(7),
+            ]),
+            encoded_entity_pk(vec![
+                EntityPkComponent::Uuid([0; 16]),
+                EntityPkComponent::Bytes(bytes::Bytes::from_static(&[9])),
+                EntityPkComponent::String("z".into()),
+            ]),
+        ];
+
+        let mut corpus = seeds.clone();
+        for seed in &seeds {
+            for len in 0..seed.len() {
+                corpus.push(seed[..len].to_vec());
+            }
+            for index in 0..seed.len() {
+                for replacement in [0x00u8, 0x01, 0x02, 0x03, 0x04, 0x7f, 0xfe, 0xff] {
+                    if seed[index] == replacement {
+                        continue;
+                    }
+                    let mut mutated = seed.clone();
+                    mutated[index] = replacement;
+                    corpus.push(mutated);
+                }
+            }
+        }
+        corpus.extend([
+            vec![],
+            vec![ENTITY_PK_CODEC_V1],
+            vec![0x00],
+            vec![ENTITY_PK_CODEC_V1, ENTITY_PK_STRING, 0x00, 0x02],
+            vec![ENTITY_PK_CODEC_V1, ENTITY_PK_STRING, 0xff, 0x00, 0x00],
+            vec![ENTITY_PK_CODEC_V1, ENTITY_PK_STRING, 0x00, 0xff, 0x00, 0x00],
+            vec![ENTITY_PK_CODEC_V1, 0x05, 0x00, 0x00],
+        ]);
+        corpus
+    }
+
+    /// A rendering that compares accept/reject *and* the decoded value, without
+    /// depending on any plane's error strings — which deliberately differ, since
+    /// each plane keeps its own error code and prefix. Decoding and re-encoding
+    /// canonicalises the value.
+    fn render(decoded: Option<(EntityPk, usize)>) -> String {
+        match decoded {
+            None => "rejected".to_string(),
+            Some((entity_pk, offset)) => {
+                let mut out = Vec::new();
+                write_entity_pk(&mut out, &entity_pk);
+                format!(
+                    "accepted off={offset} {}",
+                    out.iter().map(|b| format!("{b:02x}")).collect::<String>()
+                )
+            }
+        }
+    }
+
+    /// Three implementations of one grammar, held to each other byte for byte.
+    ///
+    /// This is the contract that keeps them from drifting apart. The duplication
+    /// has already drifted twice — an encode-side `debug_assert` present on one
+    /// plane and not the other, and `tracked_head`'s scanner accepting any
+    /// non-escape byte as a terminator where `codec`'s rejects it — and both
+    /// times it was harmless only by luck. A divergence in *decode* is not
+    /// harmless: it is two planes reading different rows out of the same bytes.
+    #[test]
+    fn all_three_decoders_agree() {
+        let corpus = differential_corpus();
+        assert!(
+            corpus.len() > 700,
+            "differential corpus collapsed to {} cases",
+            corpus.len()
+        );
+        let mut accepted = 0usize;
+        for (index, input) in corpus.iter().enumerate() {
+            let head = render(crate::hot_state::head_decode_entity_pk_probe(input));
+            let hot = render(crate::hot_state::hot_decode_entity_pk_probe(input));
+            let tree = render(crate::tracked_state::tree_decode_entity_pk_probe(input));
+            assert_eq!(
+                head, hot,
+                "tracked_head and hot disagree on case {index}: {input:02x?}"
+            );
+            assert_eq!(
+                head, tree,
+                "tracked_head and tracked_state disagree on case {index}: {input:02x?}"
+            );
+            if head != "rejected" {
+                accepted += 1;
+            }
+        }
+        // Guards the corpus itself: a mutation that made every case invalid
+        // would leave the test asserting three agreeing rejections forever.
+        assert!(
+            accepted >= 7,
+            "differential corpus accepted only {accepted} cases; it is no longer exercising decode"
+        );
+    }
+
+    /// The sign flip and its inverse must stay exact inverses; they are used by
+    /// the encoder here and by all three decoders.
+    #[test]
+    fn ordered_integer_round_trips() {
+        for value in [i64::MIN, i64::MIN + 1, -2, -1, 0, 1, 2, i64::MAX - 1, i64::MAX] {
+            assert_eq!(i64_from_ordered_integer(ordered_integer_from_i64(value)), value);
+        }
+        assert_eq!(ordered_integer_from_i64(i64::MIN), 0);
+        assert_eq!(ordered_integer_from_i64(0), 1_u64 << 63);
+        assert_eq!(ordered_integer_from_i64(i64::MAX), u64::MAX);
+    }
+
+    #[test]
+    fn key_part_terminators_are_exactly_two() {
+        assert!(is_key_part_terminator(KEY_PART_FINAL));
+        assert!(is_key_part_terminator(KEY_PART_MORE));
+        for byte in [0x02u8, 0x03, 0x7f, KEY_ESCAPE] {
+            assert!(!is_key_part_terminator(byte), "{byte:#04x} is not a terminator");
+        }
     }
 
     /// Golden bytes. Both planes now call these writers, so byte-identity

--- a/packages/lix/src/tracked_state/codec.rs
+++ b/packages/lix/src/tracked_state/codec.rs
@@ -790,7 +790,7 @@ fn read_entity_pk_part_shared(
         }
         ENTITY_PK_UUID => {
             let uuid_end = offset
-                .checked_add(16)
+                .checked_add(ENTITY_PK_UUID_BYTES)
                 .ok_or_else(|| key_codec_error("UUIDv7 entity primary-key part is truncated"))?;
             let uuid_bytes: [u8; 16] = bytes
                 .get(*offset..uuid_end)
@@ -801,7 +801,7 @@ fn read_entity_pk_part_shared(
                 .get(uuid_end)
                 .copied()
                 .ok_or_else(|| key_codec_error("UUIDv7 entity primary-key ending is truncated"))?;
-            if !matches!(terminator, KEY_PART_FINAL | KEY_PART_MORE) {
+            if !is_key_part_terminator(terminator) {
                 return Err(key_codec_error(format!(
                     "UUIDv7 entity primary-key part has invalid terminator {terminator}"
                 )));
@@ -814,7 +814,7 @@ fn read_entity_pk_part_shared(
         }
         ENTITY_PK_INTEGER => {
             let integer_end = offset
-                .checked_add(8)
+                .checked_add(ENTITY_PK_INTEGER_BYTES)
                 .ok_or_else(|| key_codec_error("integer entity primary-key part is truncated"))?;
             let ordered = u64::from_be_bytes(
                 bytes
@@ -827,16 +827,14 @@ fn read_entity_pk_part_shared(
                 .get(integer_end)
                 .copied()
                 .ok_or_else(|| key_codec_error("integer entity primary-key ending is truncated"))?;
-            if !matches!(terminator, KEY_PART_FINAL | KEY_PART_MORE) {
+            if !is_key_part_terminator(terminator) {
                 return Err(key_codec_error(format!(
                     "integer entity primary-key part has invalid terminator {terminator}"
                 )));
             }
             *offset = integer_end + 1;
             Ok((
-                crate::entity_pk::EntityPkComponent::Integer(i64::from_be_bytes(
-                    (ordered ^ (1_u64 << 63)).to_be_bytes(),
-                )),
+                crate::entity_pk::EntityPkComponent::Integer(i64_from_ordered_integer(ordered)),
                 terminator,
             ))
         }
@@ -844,6 +842,18 @@ fn read_entity_pk_part_shared(
             "entity primary-key part has unknown tag {other}"
         ))),
     }
+}
+
+
+/// Test-only shim; see `crate::order_preserving_key::tests`.
+#[cfg(test)]
+pub(crate) fn tree_decode_entity_pk_probe(
+    bytes: &[u8],
+) -> Option<(crate::entity_pk::EntityPk, usize)> {
+    let mut offset = 0usize;
+    read_entity_pk(bytes, &mut offset)
+        .ok()
+        .map(|entity_pk| (entity_pk, offset))
 }
 
 fn read_entity_pk(
@@ -915,7 +925,7 @@ fn read_entity_pk_part(
         }
         ENTITY_PK_UUID => {
             let uuid_end = offset
-                .checked_add(16)
+                .checked_add(ENTITY_PK_UUID_BYTES)
                 .ok_or_else(|| key_codec_error("UUIDv7 entity primary-key part is truncated"))?;
             let uuid_bytes: [u8; 16] = bytes
                 .get(*offset..uuid_end)
@@ -926,7 +936,7 @@ fn read_entity_pk_part(
                 .get(uuid_end)
                 .copied()
                 .ok_or_else(|| key_codec_error("UUIDv7 entity primary-key ending is truncated"))?;
-            if !matches!(terminator, KEY_PART_FINAL | KEY_PART_MORE) {
+            if !is_key_part_terminator(terminator) {
                 return Err(key_codec_error(format!(
                     "UUIDv7 entity primary-key part has invalid terminator {terminator}"
                 )));
@@ -939,7 +949,7 @@ fn read_entity_pk_part(
         }
         ENTITY_PK_INTEGER => {
             let integer_end = offset
-                .checked_add(8)
+                .checked_add(ENTITY_PK_INTEGER_BYTES)
                 .ok_or_else(|| key_codec_error("integer entity primary-key part is truncated"))?;
             let ordered = u64::from_be_bytes(
                 bytes
@@ -952,16 +962,14 @@ fn read_entity_pk_part(
                 .get(integer_end)
                 .copied()
                 .ok_or_else(|| key_codec_error("integer entity primary-key ending is truncated"))?;
-            if !matches!(terminator, KEY_PART_FINAL | KEY_PART_MORE) {
+            if !is_key_part_terminator(terminator) {
                 return Err(key_codec_error(format!(
                     "integer entity primary-key part has invalid terminator {terminator}"
                 )));
             }
             *offset = integer_end + 1;
             Ok((
-                crate::entity_pk::EntityPkComponent::Integer(i64::from_be_bytes(
-                    (ordered ^ (1_u64 << 63)).to_be_bytes(),
-                )),
+                crate::entity_pk::EntityPkComponent::Integer(i64_from_ordered_integer(ordered)),
                 terminator,
             ))
         }

--- a/packages/lix/src/tracked_state/mod.rs
+++ b/packages/lix/src/tracked_state/mod.rs
@@ -7,6 +7,8 @@ use crate::LixError;
 #[cfg(feature = "storage-benches")]
 mod bench_support;
 mod codec;
+#[cfg(test)]
+pub(crate) use codec::tree_decode_entity_pk_probe;
 mod commit_root_rebuild;
 mod context;
 mod current_state_data_part;


### PR DESCRIPTION
# refactor(lix): share the silently-corrupting key primitives, and pin the three decoders against each other

**Machine:** `ryzen-9950x-III`. **Base SHA:** `37139213`. **Gate HEAD:** `57665b03`, worktree clean.
No behaviour change, no public API change, no SQL surface change, **no adapter API change**, no bytes
on disk.

## This is deliberately partial. Say so first.

Encoding was unified in #1387. **Decoding is not unified here, and the scanners remain duplicated.**
There are three independent implementations of the same grammar:

| implementation | ownership | scanner | terminator validated |
|---|---|---|---|
| `hot_state::tracked_head` | `Vec<u8>` / `String` | byte loop | by callers |
| `hot_state::tracked_head::hot` | `Bytes` / `SharedStr` | byte loop | by callers |
| `tracked_state::codec` | `Vec` / `Cow` / `Bytes` | `memchr` | **inside the scanner** |

That table is now in the shared module's doc comment, because it is the map the next person needs.
`tracked_head::hot` was a third copy neither of us had counted.

This PR shares only the primitives whose divergence **corrupts silently**, and leaves the scanners
alone. The follow-up is described at the bottom.

## The drift is a demonstrated pattern, not a hypothesis

Two divergences found in this codec pair, in two directions, both currently harmless:

1. **Encode** (fixed in #1387): `tracked_head`'s writer carried
   `debug_assert!(!components.is_empty())` and `tracked_state`'s did not, so the same input
   debug-panicked on one plane and encoded fine on the other.
2. **Decode** (found here, *not* changed by this PR): `tracked_head`'s `read_key_bytes` accepts **any**
   non-`KEY_ESCAPE` byte as a terminator and returns it, where `codec`'s scanner rejects it as an
   unknown escape. It is safe today *only* because every current caller re-validates the terminator
   afterwards. A new caller that forgot would silently accept garbage keys.

Neither has caused damage. Nothing structural was stopping the next one from landing in the bytes.

## What is shared

Into `crate::order_preserving_key`, next to the encoder that already lives there:

| primitive | copies before | after |
|---|---:|---:|
| sign flip (`^ 1<<63`), encode and decode | **6** | 1 pair |
| terminator predicate `matches!(t, FINAL \| MORE)` | **8** | 1 |
| UUID / integer component widths (`16` / `8`, open-coded) | **8** | 2 constants |

The sign flip is now `ordered_integer_from_i64` / `i64_from_ordered_integer`, documented as exact
inverses that may only change together, with a round-trip test across `i64::MIN … i64::MAX`.

**Why these and not the scanners.** A divergence in a field width or the sign flip writes or reads the
wrong bytes for a *well-formed* key — silent corruption, no error, wrong row. A divergence in the
scanners changes accept/reject on *malformed* input, which is exactly what both found divergences are,
and both were harmless. The higher-risk duplication is the one with no benchmark risk attached, so it
goes first.

The sixth sign-flip copy was `HotIndexValue::write` in `hot.rs` — an index-value encoder, not a key
encoder, using the same ordered representation. It is now on the shared helper too.

## The differential harness, landed as a permanent test

`order_preserving_key::tests::all_three_decoders_agree` drives all three decoders over the same corpus
and asserts they agree:

- 7 seed keys covering every component type, an embedded NUL, and a three-component composite;
- **every truncation** of each seed;
- **every single-byte mutation** to each grammar-significant value (`00 01 02 03 04 7f fe ff`);
- 7 hand-written malformed shapes the generators cannot reach — bad version, unknown tag, unknown
  terminator, non-UTF-8 string part, escaped-NUL-then-end.

**774 cases, 437 of which decode successfully.** Each result is rendered by decoding and then
**re-encoding**, so the comparison covers accept/reject *and* the decoded value, and does not depend
on any plane's error strings — those deliberately differ, since each plane keeps its own error code
and message prefix. Nothing in this PR changes error text.

Two guards on the harness itself, so it cannot rot into a test that asserts three agreeing rejections
forever: it fails if the corpus drops below 700 cases, and fails if fewer than 7 cases are accepted.

Each plane exposes a five-line `#[cfg(test)]` shim so the shared module can reach its private decoder;
those are the only additions to `hot.rs` beyond the primitive call sites.

### It has teeth — verified by mutation

I changed `tracked_head`'s UUID width from `ENTITY_PK_UUID_BYTES` to `15` on one plane only:

```
test result: FAILED. 0 passed; 1 failed
```

A one-byte divergence in a single plane fails it. Mutation reverted.

## Byte identity — measured, not asserted

A temporary probe ran the same 774-case corpus through all three decoders on the **parent commit** and
on **this branch**, reducing each plane's 774 renderings to one FNV digest (774 printed lines per plane
interleave across test threads and lose output; a digest cannot):

```
parent      E33-DIGEST head total=774 accepted=437 digest=dbc25a4aa4c08c82
            E33-DIGEST hot  total=774 accepted=437 digest=dbc25a4aa4c08c82
            E33-DIGEST tree total=774 accepted=437 digest=dbc25a4aa4c08c82
this branch E33-DIGEST head total=774 accepted=437 digest=dbc25a4aa4c08c82
            E33-DIGEST hot  total=774 accepted=437 digest=dbc25a4aa4c08c82
            E33-DIGEST tree total=774 accepted=437 digest=dbc25a4aa4c08c82
```

Identical across all three planes *and* across both commits. Probe removed before commit. The encode
side is covered by the existing golden byte tests from #1387, which still pass unchanged.

## Layout invariants

1. **Single authority.** Partially advanced, honestly. Six sign-flip copies, eight terminator
   predicates and eight magic-number widths become one each, and every original is **deleted**. The
   scanners remain three copies — stated in the doc comment and above, not papered over.
2. **Commit canonicality.** Untouched.
3. **Derived views are caches.** Unchanged; the hot plane and the canonical tree now share more of the
   key format explicitly, and the module still sits below both.
4. **Atomic publication.** Unaffected.
5. **GC from refs.** Unaffected.
6. **SQL reads canonical records.** Unaffected.

## Follow-up, filed with the design intact

Unify the three decoders: standardise on the `memchr` scanner behind a **borrowable span** so all
three ownership modes keep zero-copy (`Vec` / `Cow` / `Bytes`), and map a structured error enum to
each plane's own error code and prefix so no message changes. That rewrites a hot inner loop that
appears in the claim-3 profile, so it wants a **benchmark guard**, not only a green gate — and it must
do all three copies at once, because doing two of three would claim an authority that does not exist.
Whoever picks it up inherits `all_three_decoders_agree` as a ready-made proof harness.

## Gate

`ryzen-9950x-III`, `ci.yml` scope from `origin/main`, `--no-fail-fast`, full log captured and grepped
(never tailed). `git rev-parse HEAD` = `57665b03cc835977f22c59513b4dbd6453b5a82b`,
`git status --porcelain` empty at gate time.

**3514 passed / 0 failed across 67 test targets, 0 clippy warnings**, plus
`cargo check -p lix --no-default-features` and `cargo check -p lix_js_sdk --target wasm32-unknown-unknown`
clean.

No versioned identifier changed.

## What regressed

Nothing. The emitted and accepted bytes are identical on all three planes across 774 cases; the
changed code is the same arithmetic reached through one path instead of six. No timing lane can move —
the shared helpers are `#[inline]`-eligible free functions in the same crate, and no scanner loop was
touched.
