### PR TITLE
perf(storage): let a content-addressed space skip the backend value checksum

### DIFF
--- a/packages/lix/src/binary_cas/kv.rs
+++ b/packages/lix/src/binary_cas/kv.rs
@@ -60,7 +60,27 @@ pub(crate) const BINARY_CAS_MANIFEST_CHUNK_SPACE: StorageSpace = StorageSpace::d
     BINARY_CAS_MANIFEST_CHUNK_NAMESPACE,
     ValueSemantics::Mutable,
 );
-pub(crate) const BINARY_CAS_CHUNK_SPACE: StorageSpace = StorageSpace::declare(
+/// The chunk payload plane, and the one space whose values authenticate
+/// themselves.
+///
+/// Every row's key **is** the BLAKE3-256 digest of its own payload, and every
+/// production full-value read of this space passes through
+/// [`decode_and_verify_payload`], which recomputes that digest and compares it
+/// before returning the bytes — unconditionally, in release builds too. The
+/// two read sites are [`load_chunk_rows`] (which serves [`load_bytes_many`])
+/// and [`verify_live_chunk_presence`]; the GC orphan scan projects
+/// `KeyOnly` and never materializes a payload.
+///
+/// So a backend checksum over these same bytes is a strictly weaker duplicate
+/// of a check the engine has already paid for, and the declaration below lets
+/// a backend skip it. Measured on a 640 MiB read where RocksDB was on its
+/// software CRC32C — the path aarch64 cannot leave — that duplicate was 33.8%
+/// of all cycles.
+///
+/// **If you ever add a full-value read of this space that does not verify the
+/// digest, this declaration becomes false** and must be reverted to
+/// `StorageSpace::declare` in the same commit.
+pub(crate) const BINARY_CAS_CHUNK_SPACE: StorageSpace = StorageSpace::declare_content_addressed(
     StorageSpaceId(0x0005_0003),
     BINARY_CAS_CHUNK_NAMESPACE,
     ValueSemantics::Immutable,

--- a/packages/lix/src/storage/conformance/baseline.rs
+++ b/packages/lix/src/storage/conformance/baseline.rs
@@ -5,6 +5,13 @@ use std::ops::Bound;
 /// the bottom of this file pin space isolation.
 const TEST_SPACE: StorageSpace = StorageSpace::mutable(SpaceId(7), "storage.conformance.test");
 const OTHER_SPACE: StorageSpace = StorageSpace::mutable(SpaceId(8), "storage.conformance.other");
+/// Same id and bytes as [`TEST_SPACE`] would hold, declared with the value
+/// integrity that permits a backend to skip its own value checksum.
+const CONTENT_ADDRESSED_SPACE: StorageSpace = StorageSpace::declare_content_addressed(
+    SpaceId(9),
+    "storage.conformance.content_addressed",
+    ValueSemantics::Mutable,
+);
 
 use bytes::Bytes;
 
@@ -16,7 +23,7 @@ use crate::storage::conformance::{
 use crate::storage::{
     BeginScanOptions, CoreProjection, GetOptions, Key, KeyRange, MAX_SCAN_PAGE_ROWS, Precondition,
     ProjectedValue, ReadEntry, ReadOptions, ScanChunk, ScanOrder, SpaceId, Storage, StorageError,
-    StorageRead, StorageSpace, StorageWrite, WriteOptions,
+    StorageRead, StorageSpace, StorageWrite, ValueSemantics, WriteOptions,
 };
 
 pub(crate) async fn register<F>(report: &mut ConformanceReport, factory: &F)
@@ -44,6 +51,10 @@ where
         get_many_returns_requested_slots
     );
     run!("baseline::get_many_empty_key_list", get_many_empty_key_list);
+    run!(
+        "baseline::content_addressed_space_returns_identical_bytes",
+        content_addressed_space_returns_identical_bytes
+    );
     run!(
         "baseline::delete_many_missing_keys_is_idempotent",
         delete_many_missing_keys_is_idempotent
@@ -347,6 +358,128 @@ where
             result.values
         ))
     }
+}
+
+/// `ValueIntegrity::ContentAddressed` must not change what a read returns.
+///
+/// It is a licence to skip a *redundant* corruption check on bytes the engine
+/// authenticates itself, and nothing more. An adapter is free to ignore it
+/// entirely — SlateDB does, because `slatedb::config::ReadOptions` has no
+/// checksum control — but an adapter that acts on it must return byte-identical
+/// values, through both `get_many` and a full-value scan, and must still report
+/// a missing key as missing.
+///
+/// The same rows are written to a `BackendVerified` space and a
+/// `ContentAddressed` one and the two reads are compared to each other, so this
+/// fails if a backend's opted-out path diverges in any way — not merely if it
+/// returns something a hand-written expectation did not anticipate.
+async fn content_addressed_space_returns_identical_bytes<F>(factory: &F) -> ConformanceResult
+where
+    F: StorageFactory,
+{
+    let storage = open_storage(factory).await;
+    let rows: [(&str, &[u8]); 3] = [
+        ("a", b"A"),
+        ("b", b"a much longer value than the block would like"),
+        ("c", &[0u8; 512]),
+    ];
+
+    let mut write = storage
+        .begin_write(WriteOptions::default())
+        .await
+        .map_err(|error| format!("begin_write failed: {error}"))?;
+    for target in [TEST_SPACE, CONTENT_ADDRESSED_SPACE] {
+        write
+            .put_many(
+                target,
+                put_batch(
+                    rows.iter()
+                        .map(|(key_bytes, value_bytes)| full_put(key(key_bytes), *value_bytes)),
+                ),
+            )
+            .await
+            .map_err(|error| format!("put_many into {target} failed: {error}"))?;
+    }
+    write
+        .commit()
+        .await
+        .map_err(|error| format!("commit failed: {error}"))?;
+
+    let requested = [key("a"), key("b"), key("c"), key("missing")];
+    let read = storage
+        .begin_read(ReadOptions::default())
+        .await
+        .map_err(|error| format!("begin_read failed: {error}"))?;
+
+    let verified = read
+        .get_many_in_space(TEST_SPACE, &requested, GetOptions::default())
+        .await
+        .map_err(|error| format!("get_many on the verified space failed: {error}"))?;
+    let addressed = read
+        .get_many_in_space(CONTENT_ADDRESSED_SPACE, &requested, GetOptions::default())
+        .await
+        .map_err(|error| format!("get_many on the content-addressed space failed: {error}"))?;
+
+    if verified.values != addressed.values {
+        return Err(format!(
+            "content-addressed space returned different values than the verified space: \
+             {:?} vs {:?}",
+            verified.values, addressed.values
+        ));
+    }
+    if addressed.values.last() != Some(&None) {
+        return Err(format!(
+            "a missing key must stay missing on a content-addressed space, got {:?}",
+            addressed.values.last()
+        ));
+    }
+
+    let scanned = collect_full_values(&read, CONTENT_ADDRESSED_SPACE).await?;
+    let expected = rows
+        .iter()
+        .map(|(key_bytes, value_bytes)| (key(key_bytes), Bytes::copy_from_slice(value_bytes)))
+        .collect::<Vec<_>>();
+    if scanned != expected {
+        return Err(format!(
+            "full-value scan of a content-addressed space returned {scanned:?}, expected {expected:?}"
+        ));
+    }
+
+    Ok(())
+}
+
+/// Drains a full-value scan of `space` into `(key, value)` pairs in key order.
+async fn collect_full_values<R>(read: &R, space: StorageSpace) -> Result<Vec<(Key, Bytes)>, String>
+where
+    R: StorageRead,
+{
+    let mut cursor = read
+        .begin_scan(
+            space,
+            KeyRange {
+                lower: Bound::Unbounded,
+                upper: Bound::Unbounded,
+            },
+            BeginScanOptions::default(),
+        )
+        .await
+        .map_err(|error| format!("begin_scan failed: {error}"))?;
+    let entries = cursor
+        .collect_all()
+        .await
+        .map_err(|error| format!("scan collect_all failed: {error}"))?;
+    let mut out = Vec::with_capacity(entries.len());
+    for entry in entries {
+        let ReadEntry {
+            key: entry_key,
+            value: ProjectedValue::FullValue(bytes),
+        } = entry
+        else {
+            return Err("full-value scan yielded a key-only entry".to_string());
+        };
+        out.push((entry_key, bytes));
+    }
+    Ok(out)
 }
 
 async fn delete_many_missing_keys_is_idempotent<F>(factory: &F) -> ConformanceResult

--- a/packages/lix/src/storage/conformance/mod.rs
+++ b/packages/lix/src/storage/conformance/mod.rs
@@ -70,6 +70,7 @@ mod tests {
                 "baseline::empty_space_reads_are_empty",
                 "baseline::get_many_returns_requested_slots",
                 "baseline::get_many_empty_key_list",
+                "baseline::content_addressed_space_returns_identical_bytes",
                 "baseline::delete_many_missing_keys_is_idempotent",
                 "baseline::delete_many_removes_existing_keys",
                 "baseline::delete_range_removes_exact_range",

--- a/packages/lix/src/storage/mod.rs
+++ b/packages/lix/src/storage/mod.rs
@@ -27,5 +27,5 @@ pub use types::{
     EncodedMutationBatchError, EncodedPut, GetManyRequest, GetManyResult, GetOptions, Key,
     KeyRange, MAX_SCAN_PAGE_ROWS, Prefix, ProjectedValue, PutBatch, PutEntry, ReadConsistency,
     ReadDurability, ReadEntry, ReadOptions, ScanChunk, ScanOrder, SnapshotRef, SpaceId,
-    StorageSpace, StoredValue, ValueSemantics, WriteOptions, WriteStats,
+    StorageSpace, StoredValue, ValueIntegrity, ValueSemantics, WriteOptions, WriteStats,
 };

--- a/packages/lix/src/storage/types.rs
+++ b/packages/lix/src/storage/types.rs
@@ -21,12 +21,48 @@ pub enum ValueSemantics {
     Immutable,
 }
 
+/// Who is responsible for detecting corruption of a space's *value* bytes.
+///
+/// This exists because one space in the engine authenticates its own values
+/// more strongly than any backend checksum can, and paying for both is pure
+/// duplicated work over the same bytes.
+///
+/// The default is [`ValueIntegrity::BackendVerified`] and every constructor
+/// produces it. Opting out requires naming
+/// [`StorageSpace::declare_content_addressed`] deliberately, so a space added
+/// tomorrow is protected without anyone having to remember that it should be.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub enum ValueIntegrity {
+    /// The backend's own checksum is the only thing standing between a bit
+    /// flip on disk and the engine. Backends must verify it on every read.
+    #[default]
+    BackendVerified,
+    /// Every value in this space is a content-addressed blob whose **key is a
+    /// BLAKE3-256 digest of its own bytes**, and the engine recomputes that
+    /// digest and compares it before the bytes escape the read — in every
+    /// build, release included.
+    ///
+    /// A backend may therefore skip its own value checksum here: a corruption
+    /// it would have caught is caught by a strictly stronger check that has
+    /// already been paid for. Skipping is an optimisation, never an
+    /// obligation; a backend that cannot express it stays correct by doing
+    /// nothing.
+    ///
+    /// **This is a claim about the engine, not a hint.** Declaring a space
+    /// content-addressed without an unconditional digest check on every
+    /// full-value read of it removes real protection and replaces it with
+    /// nothing.
+    ContentAddressed,
+}
+
 /// A logical ordered-key space and the value semantics Lix guarantees for it.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct StorageSpace {
     pub id: SpaceId,
     pub name: &'static str,
     pub value_semantics: ValueSemantics,
+    /// Who detects value corruption in this space. See [`ValueIntegrity`].
+    pub value_integrity: ValueIntegrity,
 }
 
 impl StorageSpace {
@@ -47,6 +83,38 @@ impl StorageSpace {
             id,
             name,
             value_semantics,
+            value_integrity: ValueIntegrity::BackendVerified,
+        }
+    }
+
+    /// Declares a space whose values are BLAKE3-256 content-addressed by their
+    /// own key and verified by the engine on every full-value read.
+    ///
+    /// Deliberately a **separate constructor** rather than a parameter on
+    /// [`StorageSpace::declare`] or a builder method: the safe answer is what
+    /// you get by default and by omission, and opting out is something you
+    /// have to type. `storage_spaces::tests::exactly_one_space_declares_
+    /// content_addressed_values` pins the opt-in set to the single space that
+    /// has earned it, reading it back out of `ALL_STORAGE_SPACES` rather than
+    /// from a second hand-written list.
+    ///
+    /// Do not reach for this because a space "holds hashes" or "is immutable".
+    /// The requirement is exact: the key must be the digest of the value, and
+    /// the engine must recompute and compare it on every read in release
+    /// builds. `binary_cas.manifest` fails that test — its rows *contain*
+    /// chunk hashes but are not themselves addressed by their content, and the
+    /// whole-blob guard that would catch a corrupted manifest
+    /// (`assemble_blob_bytes`) is `cfg!(debug_assertions)` only.
+    pub(crate) const fn declare_content_addressed(
+        id: SpaceId,
+        name: &'static str,
+        value_semantics: ValueSemantics,
+    ) -> Self {
+        Self {
+            id,
+            name,
+            value_semantics,
+            value_integrity: ValueIntegrity::ContentAddressed,
         }
     }
 
@@ -118,6 +186,10 @@ impl StorageSpace {
             id: self.id,
             name: self.name,
             value_semantics: ValueSemantics::Mutable,
+            // A corruption test writes bytes that deliberately do not match
+            // the key's digest, so this view must not claim the engine will
+            // authenticate them.
+            value_integrity: ValueIntegrity::BackendVerified,
         }
     }
 }

--- a/packages/lix/src/storage_adapter/mod.rs
+++ b/packages/lix/src/storage_adapter/mod.rs
@@ -35,8 +35,8 @@ pub use crate::storage::{
     ReadDurability as StorageReadDurability, ReadEntry as StorageReadEntry,
     ReadOptions as StorageReadOptions, ScanChunk as StorageScanChunk,
     ScanCursor as StorageScanCursor, ScanOrder as StorageScanOrder, SpaceId as StorageSpaceId,
-    Storage, StorageError, StorageRead, StorageSpace, StoredValue as StorageValue, ValueSemantics,
-    WriteOptions as StorageWriteOptions,
+    Storage, StorageError, StorageRead, StorageSpace, StoredValue as StorageValue, ValueIntegrity,
+    ValueSemantics, WriteOptions as StorageWriteOptions,
 };
 pub(crate) use crate::storage::{PutBatch, PutEntry};
 

--- a/packages/lix/src/storage_spaces.rs
+++ b/packages/lix/src/storage_spaces.rs
@@ -195,6 +195,58 @@ mod tests {
         }
     }
 
+    /// Opting a space out of the backend's value checksum is only sound when
+    /// the engine authenticates that space's values itself, and exactly one
+    /// space does: `binary_cas.chunk`, whose key *is* the BLAKE3-256 digest of
+    /// its value and which `decode_and_verify_payload` re-checks on every
+    /// full-value read in every build.
+    ///
+    /// This reads the opt-in set **back out of the registry** rather than
+    /// comparing two hand-written lists, so a space that opts in tomorrow
+    /// fails here rather than silently losing its corruption detection. That
+    /// is the whole point: the guard has to be able to observe the thing it
+    /// guards.
+    #[test]
+    fn exactly_one_space_declares_content_addressed_values() {
+        let opted_out: Vec<&str> = ALL_STORAGE_SPACES
+            .iter()
+            .filter(|space| space.value_integrity == ValueIntegrity::ContentAddressed)
+            .map(|space| space.name)
+            .collect();
+
+        assert_eq!(
+            opted_out,
+            vec![crate::binary_cas::BINARY_CAS_CHUNK_SPACE.name],
+            "a space declared ValueIntegrity::ContentAddressed. That tells every backend it may \
+             skip its own value checksum, which is only true if the engine recomputes the value's \
+             BLAKE3-256 digest from its key on EVERY full-value read, in release builds too. If \
+             the new space really does that, add it here deliberately; otherwise use \
+             StorageSpace::declare and keep the backend's checksum."
+        );
+    }
+
+    /// The manifest planes name chunk hashes but are not addressed by their
+    /// own content, and the whole-blob digest check that would catch a
+    /// corrupted manifest (`assemble_blob_bytes`) is `cfg!(debug_assertions)`
+    /// only. They are the most tempting spaces to opt out by analogy and the
+    /// ones where it would be silently wrong, so they are pinned explicitly.
+    #[test]
+    fn binary_cas_manifest_planes_keep_the_backend_checksum() {
+        for space in [
+            crate::binary_cas::BINARY_CAS_MANIFEST_SPACE,
+            crate::binary_cas::BINARY_CAS_MANIFEST_CHUNK_SPACE,
+            crate::binary_cas::BINARY_CAS_CHUNK_PRESENCE_SPACE,
+        ] {
+            assert_eq!(
+                space.value_integrity,
+                ValueIntegrity::BackendVerified,
+                "{} is not content-addressed: a corrupted row yields wrong chunk hashes and the \
+                 whole-blob guard in assemble_blob_bytes is debug-only",
+                space.name
+            );
+        }
+    }
+
     /// Two spaces sharing an id interleave their keys in one physical range,
     /// so each would scan and range-delete the other's rows.
     #[test]
@@ -540,17 +592,87 @@ mod tests {
 
     /// Every `StorageSpace` constructor call in one source file.
     ///
-    /// `declare` states a pairing and carries its semantics as a third
-    /// argument; `mutable` and `immutable` carry it in the name. All three are
-    /// collected, so the scan can both find the registry's own declarations
-    /// and check every use against them.
+    /// `declare` and `declare_content_addressed` state a pairing and carry
+    /// their semantics as a third argument; `mutable` and `immutable` carry it
+    /// in the name. All four are collected, so the scan can both find the
+    /// registry's own declarations and check every use against them.
+    ///
+    /// **Every constructor must be listed here.** These names are matched as
+    /// literal substrings ending in `(`, so a constructor that is added to
+    /// `StorageSpace` and not added to this list does not fail anything — its
+    /// call sites simply stop being scanned, and both
+    /// [`tests::every_declared_space_is_registered`] and
+    /// [`tests::no_registered_space_id_is_declared_with_two_value_semantics`]
+    /// go quiet about the space it declares. That is the failure mode this
+    /// module exists to prevent, reintroduced one level up. Note also that
+    /// `StorageSpace::declare(` does **not** match
+    /// `StorageSpace::declare_content_addressed(`, which is why the latter is
+    /// its own row rather than covered by a prefix.
+    const SPACE_CONSTRUCTORS: &[(&str, Option<ValueSemantics>)] = &[
+        ("StorageSpace::mutable(", Some(ValueSemantics::Mutable)),
+        ("StorageSpace::immutable(", Some(ValueSemantics::Immutable)),
+        ("StorageSpace::declare(", None),
+        ("StorageSpace::declare_content_addressed(", None),
+    ];
+
+    /// [`SPACE_CONSTRUCTORS`] must name every constructor that takes a space id.
+    ///
+    /// Read back out of `storage/types.rs` rather than compared to a second
+    /// hand-written list, because a list checked against another list is what
+    /// `UNCHECKED_SPACE_IDS` above already learned the hard way. A constructor
+    /// added to `StorageSpace` and not added to the scanner does not fail
+    /// anything by itself — it silently removes its own call sites from both
+    /// registry guards — so the scanner's completeness has to be an assertion
+    /// against the type, and this is it.
+    #[test]
+    fn the_scanner_knows_every_space_constructor() {
+        let (_, types_source) = engine_sources()
+            .into_iter()
+            .find(|(path, _)| path.replace('\\', "/").ends_with("storage/types.rs"))
+            .expect("storage/types.rs should be readable");
+        let implementation = types_source
+            .split_once("impl StorageSpace {")
+            .expect("StorageSpace should have an inherent impl block")
+            .1;
+        let mut declared = Vec::new();
+        for line in implementation.lines() {
+            if line.starts_with('}') {
+                break;
+            }
+            let Some((_, tail)) = line.trim_start().split_once("const fn ") else {
+                continue;
+            };
+            let Some((name, _)) = tail.split_once('(') else {
+                continue;
+            };
+            // `mutable_view_for_corruption_test` takes `self`, not an id, so
+            // it can neither introduce a space nor pick a value integrity.
+            if implementation
+                .split_once(&format!("const fn {name}("))
+                .is_some_and(|(_, arguments)| !arguments.trim_start().starts_with("id: SpaceId"))
+            {
+                continue;
+            }
+            declared.push(format!("StorageSpace::{name}("));
+        }
+        declared.sort();
+        let mut scanned = SPACE_CONSTRUCTORS
+            .iter()
+            .map(|(constructor, _)| (*constructor).to_string())
+            .collect::<Vec<_>>();
+        scanned.sort();
+        assert_eq!(
+            scanned, declared,
+            "storage/types.rs declares a StorageSpace constructor the registry scanner does not \
+             look for. Add it to SPACE_CONSTRUCTORS, or every space declared through it becomes \
+             invisible to every_declared_space_is_registered and to \
+             no_registered_space_id_is_declared_with_two_value_semantics."
+        );
+    }
+
     fn construction_sites(source: &str) -> Vec<ConstructionSite> {
         let mut sites = Vec::new();
-        for (constructor, declared) in [
-            ("StorageSpace::mutable(", Some(ValueSemantics::Mutable)),
-            ("StorageSpace::immutable(", Some(ValueSemantics::Immutable)),
-            ("StorageSpace::declare(", None),
-        ] {
+        for (constructor, declared) in SPACE_CONSTRUCTORS.iter().copied() {
             let mut cursor = 0;
             while let Some(offset) = source[cursor..].find(constructor) {
                 let start = cursor + offset;

--- a/packages/lix/src/storage_spaces.rs
+++ b/packages/lix/src/storage_spaces.rs
@@ -175,7 +175,7 @@ pub(crate) const FIRST_LIVE_ROW_SPACE_ID: StorageSpaceId = StorageSpaceId(0x0004
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::storage_adapter::ValueSemantics;
+    use crate::storage_adapter::{ValueIntegrity, ValueSemantics};
     use std::collections::BTreeMap;
 
     /// The registry must list spaces in ascending id order, because that order

--- a/packages/rocksdb-storage/src/rocksdb.rs
+++ b/packages/rocksdb-storage/src/rocksdb.rs
@@ -19,8 +19,8 @@ use lix::storage::{
     BeginScanOptions, Capability, CommitResult, CoreProjection, GetManyRequest, GetManyResult, Key,
     KeyRange, Precondition, PreconditionFailure, ProjectedValue, PutBatch, ReadDurability,
     ReadEntry, ReadOptions, ScanChunk, ScanCursor, ScanOrder, SpaceId, Storage, StorageError,
-    StorageRead, StorageScanSource, StorageSpace, StorageWrite, StoredValue, ValueSemantics,
-    WriteOptions, WriteStats,
+    StorageRead, StorageScanSource, StorageSpace, StorageWrite, StoredValue, ValueIntegrity,
+    ValueSemantics, WriteOptions, WriteStats,
 };
 use rocksdb::{
     BlockBasedOptions, ColumnFamily, ColumnFamilyDescriptor, DB, Direction, IteratorMode, Options,
@@ -255,6 +255,34 @@ fn check_preconditions(db: &DB, preconditions: &[Precondition]) -> Result<(), St
     }
 }
 
+/// Read options for a full-value read of `space`.
+///
+/// RocksDB verifies a CRC32C over every block and every blob-file record it
+/// reads. For a [`ValueIntegrity::ContentAddressed`] space that is a strictly
+/// weaker duplicate of a check the engine has already made unconditional: the
+/// key *is* the BLAKE3-256 digest of the value, and the engine recomputes and
+/// compares it before the bytes escape the read. Corruption that RocksDB's
+/// CRC32C would have caught is caught by the digest instead — including the
+/// cases CRC32C cannot distinguish — so the second pass buys nothing and costs
+/// a full sweep over every payload byte.
+///
+/// It is worth stating what is *not* claimed. Skipping verification means a
+/// corrupt block reaches the engine before it is rejected, so the failure mode
+/// moves from RocksDB's error to the engine's content-address error. The bytes
+/// never escape either way. `verify_checksums` also covers this column
+/// family's index and filter blocks; a corrupt index can only send the read to
+/// the wrong key, and the wrong payload fails the digest check for the key that
+/// was actually asked for.
+///
+/// Every other space gets RocksDB's default, which verifies.
+fn value_read_options(space: StorageSpace) -> rocksdb::ReadOptions {
+    let mut options = rocksdb::ReadOptions::default();
+    if space.value_integrity == ValueIntegrity::ContentAddressed {
+        options.set_verify_checksums(false);
+    }
+    options
+}
+
 fn column_family(db: &DB, space: StorageSpace) -> &ColumnFamily {
     match space.value_semantics {
         ValueSemantics::Mutable => mutable_column_family(db),
@@ -352,9 +380,10 @@ impl StorageRead for RocksDBRead<'_> {
                         }
                     }
                     CoreProjection::FullValue => {
-                        let values = self
-                            .snapshot
-                            .multi_get_cf(physical_keys.iter().map(|key| (cf, key.0.as_ref())));
+                        let values = self.snapshot.multi_get_cf_opt(
+                            physical_keys.iter().map(|key| (cf, key.0.as_ref())),
+                            value_read_options(request.space),
+                        );
                         results.extend(
                             values
                                 .into_iter()
@@ -384,7 +413,16 @@ impl StorageRead for RocksDBRead<'_> {
                 return Err(StorageError::Unsupported(Capability::ReverseScan));
             }
             let bounds = EncodedBounds::new(physical_range(space.id, range.clone()));
-            let mut iterator = self.snapshot.raw_iterator_cf(column_family(self.db, space));
+            let mut iterator = match opts.projection {
+                // A key-only scan never materializes a value, so there is no
+                // value checksum to skip and the default options are right.
+                CoreProjection::KeyOnly => {
+                    self.snapshot.raw_iterator_cf(column_family(self.db, space))
+                }
+                CoreProjection::FullValue => self
+                    .snapshot
+                    .raw_iterator_cf_opt(column_family(self.db, space), value_read_options(space)),
+            };
             iterator.seek(&bounds.lower_seek);
             iterator.status().map_err(rocksdb_error)?;
             ScanCursor::from_source(

--- a/packages/slatedb-storage/src/slatedb.rs
+++ b/packages/slatedb-storage/src/slatedb.rs
@@ -2847,6 +2847,20 @@ fn point_precondition_matches(precondition: &Precondition, value: Option<&Bytes>
     }
 }
 
+/// `ValueIntegrity::ContentAddressed` is a no-op on this adapter, deliberately.
+///
+/// The declaration tells a backend it *may* skip its own value checksum,
+/// because the engine recomputes the value's BLAKE3-256 digest from its key on
+/// every full-value read. Acting on it is an optimisation, never an
+/// obligation, and SlateDB has nothing to act with: `slatedb::config::ReadOptions`
+/// exposes `durability_filter`, `dirty`, `cache_blocks` and `filter_context`
+/// and no checksum control at any level. Immutable values also leave the LSM
+/// entirely for `db/lix-immutable-value-segment-v1`, where integrity is the
+/// object store's rather than a per-read setting.
+///
+/// So SlateDB keeps verifying exactly as before and stays correct by doing
+/// nothing. This comment exists so the asymmetry with `packages/rocksdb-storage`
+/// reads as a decision rather than as a missed call site.
 impl StorageRead for SlateDBRead {
     fn snapshot_cache_key(&self) -> Option<u128> {
         let publication_id = self


### PR DESCRIPTION
# perf(storage): let a content-addressed space skip the backend's value checksum

**Read the headline carefully: this is an aarch64 fix. On x86_64 as it ships today it is worth
0%.** PR #1389 already took that win by turning on hardware CRC32C, and the two changes are
*alternatives, not additives*. The reason to land this is that aarch64 — Apple Silicon — cannot
reach #1389's fix from this repository, and this is the only path to the same ceiling there.

Machine **ryzen-9950x-V** (32c/186G). Base SHA **`d3f880ced`** (integration head).
Branch head **`ae0abba7b`**.

---

## The duplication being removed

`binary_cas.chunk` (`0x0005_0003`) is the CAS chunk payload plane. Every row's key **is** the
BLAKE3-256 digest of its own payload, and `binary_cas/kv.rs::decode_and_verify_payload` recomputes
that digest and compares it before the bytes escape any read:

```rust
if ChunkHash::from_content(&decoded) != chunk_hash {
    return Err(/* failed content-address verification */);
}
```

That check has no `cfg`. It runs in release. RocksDB then verifies a **CRC32C over the same
bytes** — a strictly weaker duplicate of a check the engine has already paid for, and a second
full sweep over every payload byte on the hottest read path in the product.

## What changed physically

A **space-level `ValueIntegrity` property** on `StorageSpace`:

```rust
pub enum ValueIntegrity {
    #[default]
    BackendVerified,   // the backend's checksum is the only protection; verify it
    ContentAddressed,  // the key is the BLAKE3-256 digest of the value and the engine
                       // re-checks it on every full-value read, in every build
}
```

`declare` / `mutable` / `immutable` all produce `BackendVerified`. Opting out requires naming a
separate const constructor, `declare_content_addressed`, so a space added tomorrow is protected by
default and by omission. **Exactly one space opts in.**

- **RocksDB** acts on it: `value_read_options(space)` sets `verify_checksums(false)` for a
  `ContentAddressed` space and returns RocksDB's verifying default for every other space. Applied
  to full-value point reads (`multi_get_cf_opt`) and full-value scans
  (`raw_iterator_cf_opt`). Key-only scans keep the default — they materialize no value, so there
  is no value checksum to skip. Both calls go through the **snapshot**, which calls
  `readopts.set_snapshot(self)`, so snapshot isolation is unchanged.
- **SlateDB** is a **deliberate no-op**, documented at `impl StorageRead for SlateDBRead`.
  `slatedb::config::ReadOptions` (0.14.1) has exactly four fields — `durability_filter`, `dirty`,
  `cache_blocks`, `filter_context` — and no checksum control at any level. Immutable values also
  leave the LSM for `db/lix-immutable-value-segment-v1`, where integrity belongs to the object
  store rather than a per-read setting. Acting on the declaration is an optimisation, never an
  obligation; SlateDB stays correct by doing nothing.
- **In-memory** has no checksum at all; nothing to do.

Nothing was deleted from the adapter trait. Nothing moved between spaces. No on-disk bytes change:
this is purely which verification passes run on read.

## Why it is safe here and nowhere else

**Only the chunk payload space is authenticated end to end.** Every production full-value read of
`0x0005_0003` was enumerated at this head:

| site | projection | independently verified? |
|---|---|---|
| `kv.rs:1792` `load_chunk_rows` → `load_bytes_many` | FullValue | **yes** — funnels through `kv.rs:1952-1962` → `decode_and_verify_chunk` |
| `kv.rs:653` `verify_live_chunk_presence` | FullValue | **yes** — `decode_and_verify_chunk` |
| `stats.rs:67` `count_space` | KeyOnly | n/a, no payload read |
| `media_upload.rs:1061/1554` | KeyOnly, `#[cfg(test)]` | n/a |
| `kv.rs:827` `load_chunk` | FullValue | `#[cfg(test)]` only |
| `storage_bench.rs:2646/2944` layout accounting | FullValue scan | `feature = "storage-benches"`, byte accounting only |

There is **no production full-value scan** of this space today; the scan opt-out exists so the
property stays uniform if one is added.

**The manifest spaces must keep their checksum, and a test pins that.** A corrupted manifest row
yields wrong chunk hashes, and the whole-blob guard that would catch it —
`BlobId::from_content(&out) != metadata.hash` in `assemble_blob_bytes` — is
`cfg!(debug_assertions)` only. In release a corrupt manifest would **not** be caught. Manifest rows
*contain* chunk hashes but are not themselves addressed by their content. The boundary is exactly
the chunk payload plane, and it is narrower than "the immutable column family".

## Guards that can observe what they guard

This round produced four guards that could not see the thing they guarded. These three can.

1. **`exactly_one_space_declares_content_addressed_values`** — filters `ALL_STORAGE_SPACES` by
   `value_integrity` and asserts the result is exactly `[binary_cas.chunk]`. It reads the opt-in
   set **back out of the registry**, not from a second hand-written list, so a space that opts in
   tomorrow fails here rather than silently losing its corruption detection.
2. **`binary_cas_manifest_planes_keep_the_backend_checksum`** — pins the three manifest/presence
   planes to `BackendVerified`. They are the spaces most tempting to opt out by analogy and the
   ones where it would be silently wrong.
3. **`the_scanner_knows_every_space_constructor`** — the one that nearly got away. The registry's
   source scanner matches constructor names as **literal substrings ending in `(`**, and
   `"StorageSpace::declare("` does **not** match `StorageSpace::declare_content_addressed(`.
   Adding a fourth constructor without telling the scanner would not have failed anything — it
   would have quietly removed `binary_cas.chunk` from *both*
   `every_declared_space_is_registered` and
   `no_registered_space_id_is_declared_with_two_value_semantics`, which is precisely the failure
   mode `storage_spaces.rs` exists to prevent, reintroduced one level up. The new test reads the
   constructor list back out of `storage/types.rs` (every `const fn` whose first parameter is
   `id: SpaceId`) and asserts it equals the scanner's list.

Beyond the new guards, the **existing corruption qualification already observes the precondition**
and passes unchanged on both backends:
`engine-benchmarks/tests/corruption_recovery_qualification.rs::qualify_binary_payload_chunk`
corrupts a `binary_cas.chunk` row and asserts the read fails closed. Note *how* it corrupts:
`replace_immutable_value_with_corruption` writes through the normal write path, so RocksDB's
CRC32C is recomputed over the corrupt bytes and **never caught this case in the first place** —
the BLAKE3 digest check is what fails it closed, before and after this change.

## Conformance

`baseline::content_addressed_space_returns_identical_bytes` (new) writes the same three rows to a
`BackendVerified` space and a `ContentAddressed` one and compares the two reads **to each other**,
through `get_many` and through a full-value scan, and asserts a missing key stays missing. It
fails if an adapter's opted-out path diverges in any way, rather than only if it returns something
a hand-written expectation did not anticipate. An adapter is free to ignore the declaration
entirely (SlateDB does) and still pass.

The suite's own case list is pinned in `conformance/mod.rs`, so the new case had to be registered
there as well — the first gate run caught exactly that and nothing else, which is the pin working
as intended. The `assert_no_failures()` entry points used by
`packages/rocksdb-storage/tests/storage/main.rs` and `packages/slatedb-storage/tests/storage.rs`
pick the case up automatically, so **the new case ran against the real RocksDB adapter with
`verify_checksums(false)` actually in effect**, and against SlateDB, and passed on both.

`packages/lix/tests/third_party_storage_adapter.rs` **needs no change** and was checked: it
delegates wholesale to `Memory` and never inspects a `StorageSpace`, so the new field is invisible
to it. `ValueIntegrity` is exported from `lix::storage`, so a third-party adapter that *does* want
to branch on it can.

## Adapter API surface: added, changed, removed

Per the round-5 directive that the adapter API is in scope, stated explicitly:

- **Added**: `lix::storage::ValueIntegrity` (public enum, `Default = BackendVerified`);
  `StorageSpace::value_integrity` (public field);
  `StorageSpace::declare_content_addressed` (`pub(crate)`).
- **Changed**: `StorageSpace` gained a field. No call site constructs it with struct-literal
  syntax, so nothing outside the constructors is affected.
- **Removed**: nothing.
- **Both shipping adapters** were updated and behave identically from the caller's side: RocksDB
  acts on the declaration, SlateDB documents why it does not. The in-memory adapter and the
  conformance suite were checked.

`packages/lix/src/lib.rs` exports, the SQL surface and the JS SDK surface are unchanged.

## Measurements

### Symbol-level proof the checksum is actually skipped

**This is a profile of the shipped implementation, not of a scaffold, and not a timing.** Both
arms are the stock x86_64 build — `nm` confirms `crc32c_3way` × 2 and
`ExtendImpl<DefaultCRC32>` × 0 in *both* binaries, so the two arms are linked against the same
CRC32C implementation and differ only in whether the space declaration tells RocksDB to run it.

`e24_cas_read_probe 10240 64`, 640 MiB in 64 assets, read path only
(`E24_SKIP_SEED=1 E24_SKIP_WRITE=1`), `perf record -F 2999`. base = integration head
`d3f880ced`, cand = `ae0abba7b`.

| symbol | base (6353 samples) | cand (6524 samples) |
|---|---|---|
| `rocksdb::crc32c::crc32c_3way` | **3.55%** | **absent — 0 rows at `--percent-limit 0`** |
| `blake3_hash_many_avx512` | 12.04% | 12.10% |
| `clear_page_erms` (kernel) | 8.32% | 8.61% |
| `zap_present_ptes` (kernel) | 6.07% | 7.05% |
| `_copy_to_iter` (kernel) | 5.42% | 4.76% |

The CRC32C symbol does not merely shrink — `perf report --percent-limit 0 | grep -ci crc32`
returns **1 row on base and 0 on cand**, i.e. not a single sample landed in any CRC32C symbol
across the candidate's entire profile. Meanwhile **BLAKE3 is unchanged at ~12%**, which is the
other half of the proof: the engine's own content-address verification is still running on every
byte. Exactly one of the two passes was removed, and it was the weaker one.

The probe asserts `seen == total_bytes` on every rep of both arms, so the full 640 MiB corpus read
back byte-complete with the backend checksum disabled — every chunk passing
`decode_and_verify_chunk`, which is what would fail first if any byte were wrong.

**Timings from this same run, reported for honesty rather than as a claim** (a `perf record` run
is not a timing harness): `select` p50 574.1 ms base vs 595.9 ms cand, 1114.8 vs 1074.1 MiB/s.
The candidate is nominally *slower* here. That is the x86 non-result restating itself — with
hardware CRC32C the removed work is ~3.5% of a path dominated by page faults and memcpy, well
inside the noise of a 3-rep profiled run. **Do not read a portable speedup into this PR.**

### The prize, both CRC configurations

Measured by E37's predecessor on the same machine at `d35dc8429` with a scaffold that made the
identical RocksDB call this PR now makes from the space declaration
(`multi_get_cf_opt` + `verify_checksums(false)`, chunk payload space only). One binary per CRC
configuration, so the two arms compared cannot differ in codegen. `e24_cas_read_probe`, RocksDB,
store on ext4. 3 interleaved blocks, arm order rotated, 5 reps each; per-block p50s in parentheses.

- `hw` = today's shipped x86_64 build. Verified `crc32c_3way` × 2 in the symbol table.
- `sw` = **same commit** compiled `-mno-sse4.2 -mno-pclmul`. Verified `crc32c_3way` × 0 and
  `ExtendImpl<DefaultCRC32>` × 1. This is literally the code path aarch64 takes.

| CRC | asset | keep p50 ms | keep MiB/s | cut p50 ms | cut MiB/s | delta |
|---|---|---|---|---|---|---|
| **hw** | 256 KiB | 246.6 (247, 244, 247) | 1038 | 251.9 (247, 252, 258) | 1016 | **+2.2% / −2.1%** |
| **hw** | 10240 KiB | 655.4 (655, 678, 649) | 976 | 632.7 (643, 633, 628) | 1012 | **−3.5% / +3.6%** |
| **sw** | 256 KiB | 360.4 (361, 360, 359) | 710 | **252.0** (254, 250, 252) | **1016** | **−30.1% / +43.0%** |
| **sw** | 10240 KiB | 925.6 (926, 923, 928) | 691 | **631.1** (631, 630, 654) | **1014** | **−31.8% / +46.7%** |

**Null control, same run**: the `write` lane (`fs::write`, executes no lix code) moved
**−1.7% / −0.3%**. The two `hw` deltas are the same size as the control's own spread and are
**non-results**. The `sw` deltas are roughly 20x it.

### The convergence check — two mechanisms, one ceiling

| configuration | 256 KiB | 10240 KiB |
|---|---|---|
| hw-keep (x86 today) | 1038 | 976 |
| hw-cut | 1016 | 1012 |
| **sw-cut** | **1016** | **1014** |
| sw-keep (aarch64 today) | 710 | 691 |

Making the checksum fast and deleting the checksum land on the **same** number, ~1010–1040 MiB/s,
from completely different directions. That is the read path's real ceiling, now set by BLAKE3 +
memcpy + page faults rather than by RocksDB. It is also the proof that the two fixes are
alternatives: having taken #1389, there is nothing left on x86 for this PR to take.

### Which metrics regressed

None measurably. On x86 the result is a non-result in both directions (+2.2% / −3.5%, inside the
±5% the control licenses) and no byte counts, row counts or write paths are touched — this change
only removes a read-time verification pass. Guards that could not execute the changed code (write
matrix, plan-cache lanes, `packed_history_scale`, which writes zero CAS chunks) were deliberately
not run, per the guard-selection rule.

## Why land it despite 0% on x86

Under the acceptance gate this qualifies on **(1) >10% on a target metric** for the aarch64
configuration and on **(2) a cut**, shown not to be slower anywhere.

The alternative aarch64 fix is **not reachable from this repository**. `librocksdb-sys/build.rs`
never defines `HAVE_ARM64_CRC` and never inspects ARM target features, so no rustflag or
`.cargo/config.toml` entry can turn hardware CRC32C on there. It would need a forked or vendored
`librocksdb-sys`, i.e. carrying the whole RocksDB C++ source tree. The choice is: fork
`librocksdb-sys`, take this cut, or accept that Apple Silicon checkout runs at ~690 MiB/s where
x86 now runs at ~1010.

**This also gets more valuable, not less, once chunk compression lands.** Decompression is
currently **0%** of the per-chunk read loop because `Raw` is the only `BinaryChunkCodec` variant.
When a real codec arrives, decode joins BLAKE3 in that loop — and the redundant CRC32C is then
competing for the same cycles as work that actually buys something.

## Layout invariants

1. **Single authority.** No. Nothing gains a second writer or a second materialization. The
   change *removes* one of two redundant verification passes over the same bytes and leaves the
   stronger one. The declaration itself has a single authority: `ALL_STORAGE_SPACES`, which the
   opt-in guard reads rather than duplicating.
2. **Commit canonicality.** Unaffected — no commit, ref or parent-link structure is touched.
3. **Derived views are caches.** Unaffected. No view is added, removed or re-tagged.
4. **Atomic publication.** Unaffected. This is a read-path property only; no write set changes.
5. **GC from refs.** Unaffected. The GC orphan scan over this space projects `KeyOnly` and is
   untouched.
6. **SQL reads canonical records.** Unaffected. No query-side index or plan changes.

## Sequencing

E37 lands **before** E34's chunk-payload compression — both touch the per-chunk read loop. This
change is deliberately narrow and does **not** restructure the assembly buffer, which is E34's.

## Gate

Full CI scope on ryzen-9950x-V, `--no-fail-fast`, every log captured in full and grepped rather
than tailed. `git rev-parse HEAD` and `git status --porcelain` were printed **inside** the run:

```
=== E37 GATE PROVENANCE ===
host: ryzen-9950x-V
HEAD: ae0abba7b84bb82d73bf2740391bb6c508db3b7b
git status --porcelain:
(end status)
base/integration head: d3f880ced413a01b807cbed5c3009144683ac0b4
diff --stat vs integration head:
 packages/lix/src/binary_cas/kv.rs                |  22 +++-
 packages/lix/src/storage/conformance/baseline.rs | 135 ++++++++++++++++++++-
 packages/lix/src/storage/conformance/mod.rs      |   1 +
 packages/lix/src/storage/mod.rs                  |   2 +-
 packages/lix/src/storage/types.rs                |  72 ++++++++++++
 packages/lix/src/storage_adapter/mod.rs          |   4 +-
 packages/lix/src/storage_spaces.rs               | 142 +++++++++++++++++++++--
 packages/rocksdb-storage/src/rocksdb.rs          |  50 +++++++-
 packages/slatedb-storage/src/slatedb.rs          |  14 +++
 9 files changed, 421 insertions(+), 21 deletions(-)
=== END PROVENANCE ===
--- 1/6 check --workspace --all-targets --all-features      exit=0
--- 2/6 clippy --profile test -D warnings                   exit=0
--- 3/6 test workspace (excluding lix_benchmarks)           exit=0
--- 4/6 test lix_benchmarks                                 exit=0
--- 5/6 check -p lix --no-default-features                  exit=0
--- 6/6 check -p lix_js_sdk --target wasm32-unknown-unknown  exit=0
=== GREP SUMMARY (never tailed) ===
### check      (no error/panic/FAILED lines)
### clippy     (no error/panic/FAILED lines)
### test       totals: 3493 passed, 0 failed, across 56 targets
### benchtest  totals: 29 passed, 0 failed, across 11 targets
### nodefault  (no error/panic/FAILED lines)
### wasm       (no error/panic/FAILED lines)
=== E37 GATE DONE ===
HEAD at end: ae0abba7b84bb82d73bf2740391bb6c508db3b7b
```

**3522 tests passed, 0 failed.** Every log was captured in full and grepped for
`^error`, `panicked`, `test result: FAILED`, `^failures:`; nothing was tailed. `--no-fail-fast`
throughout, so all 67 targets ran.

Two results in that run are worth naming explicitly:

- `engine-benchmarks/tests/corruption_recovery_qualification.rs` —
  `rocksdb_cold_reopen_corruption_qualification ... ok` and
  `slatedb_cold_reopen_corruption_qualification ... ok`. Byte-level corruption detection on
  `binary_cas.chunk` still fails closed on both backends.
- `storage_spaces::tests::{exactly_one_space_declares_content_addressed_values,
  binary_cas_manifest_planes_keep_the_backend_checksum, the_scanner_knows_every_space_constructor}
  ... ok`.

The first gate run (at `269334139`) had exactly one failure, the pinned conformance case list, and
it is included here as evidence the pin works: 3492 passed / 1 failed / 56 targets, the failure
being `storage::conformance::tests::memory_passes_baseline_conformance` reporting that the actual
case list contained `baseline::content_addressed_space_returns_identical_bytes` and the expected
one did not. Registering the case is commit `ae0abba7b`.

`rustfmt --edition 2024 --check` was run on the touched **leaf** files only, never on a module root
(that walks the tree and reports unrelated files), and `git status --porcelain` was empty
afterwards. `cargo fmt --all --check` is dirty repo-wide on pristine `main` and was deliberately
not used. Diff counts are **identical between base and this branch** for every file, i.e. this
change adds zero formatting drift:

| file | base | this branch |
|---|---|---|
| `binary_cas/kv.rs` | 10 | 10 |
| `storage/conformance/baseline.rs` | 17 | 17 |
| `slatedb-storage/src/slatedb.rs` | 2 | 2 |
| `storage/types.rs` | 0 | **0** |
| `storage_spaces.rs` | 0 | **0** |
| `rocksdb-storage/src/rocksdb.rs` | 0 | **0** |

The three files carrying most of the new code were clean before and are clean after. The
pre-existing diffs in the other three are all `.into_parts()` chains and an import block from the
streaming-cursor work, at line numbers outside anything this PR touches.
