### PR TITLE
test(storage): qualify crash consistency on SlateDB, and measure the await_durable gap both adapters leave open

### DIFF
--- a/packages/engine-benchmarks/tests/crash_consistency_qualification.rs
+++ b/packages/engine-benchmarks/tests/crash_consistency_qualification.rs
@@ -67,10 +67,14 @@
 //! * `LIX_CRASH_CONSISTENCY_COMMITS` — commits attempted per trial (default 3)
 //! * `LIX_CRASH_CONSISTENCY_TIMED_TRIALS` — seeded wall-clock kills (default 12)
 //! * `LIX_CRASH_CONSISTENCY_MAX_POINTS` — cap on swept kill points (default 512)
+//! * `LIX_CRASH_CONSISTENCY_SEED` — seed for the wall-clock kill delays
+//! * `LIX_CRASH_AWAIT_DURABLE=1` — force `WriteOptions::await_durable` on every
+//!   write transaction, in every arm (the durability A/B)
 //! * `LIX_CRASH_CONSISTENCY_BLOB_BYTES` — binary file bytes republished in the
 //!   same transaction, `0` to publish rows only (default 64 KiB, 128 KiB deep).
-//!   A non-zero value is what routes the publication through the atomic CAS path
-//!   and therefore what sets `await_durable`.
+//!   A non-zero value routes the publication through the content-addressed blob
+//!   path, which widens the swept window. It does **not** set `await_durable`;
+//!   measured, not assumed — the sweep prints the durable/total write census.
 
 use std::fs;
 use std::io::Write as _;
@@ -171,7 +175,8 @@ impl Killer {
             // kill lix mid-publication, not to lose the trial's own bookkeeping.
             let _ = std::io::stdout().flush();
             // SIGKILL cannot be caught, blocked or ignored: no unwinding, no
-            // Drop, no RocksDB shutdown hook, no WAL flush.
+            // Drop, no backend shutdown hook, no WAL flush, and for SlateDB no
+            // chance for the background write pipeline to drain.
             unsafe {
                 libc::kill(libc::getpid(), libc::SIGKILL);
             }
@@ -509,8 +514,10 @@ fn append_ack(path: &Path, generation: u64) {
 
 #[derive(Debug)]
 struct Recovered {
-    /// Highest generation visible after the crash, or `None` when the crash
-    /// landed before the seed commit published.
+    /// Highest generation visible after the crash, or `None` when the store has
+    /// no rows — either because the crash landed before the seed commit
+    /// published, or because the backend had not yet persisted it (see
+    /// `lost_acknowledgement`).
     generation: Option<i64>,
     /// Set when every state the store presented was internally consistent, but
     /// a commit whose `commit()` had already returned `Ok` is not in it.
@@ -968,8 +975,7 @@ fn result_column(sql: &str) -> &'static str {
 /// backend: the only thing that varies is which adapter the engine was handed.
 /// That is what makes the two arms comparable — a second harness would only
 /// prove that two harnesses agree.
-fn sweep<B: CrashBackend>() {
-    let workload = Workload::from_env();
+fn sweep<B: CrashBackend>(workload: Workload) {
     let root = tempfile::tempdir().expect("create crash-consistency sweep root");
     let mut failures: Vec<String> = Vec::new();
     let mut lost_acks: Vec<String> = Vec::new();
@@ -1195,7 +1201,7 @@ fn sweep<B: CrashBackend>() {
 
 #[test]
 fn rocksdb_publication_window_survives_sigkill_at_every_storage_event() {
-    sweep::<RocksDB>();
+    sweep::<RocksDB>(Workload::from_env());
 }
 
 /// The same sweep, the same invariants and the same null control against the
@@ -1214,7 +1220,26 @@ fn rocksdb_publication_window_survives_sigkill_at_every_storage_event() {
 #[cfg(feature = "slatedb")]
 #[test]
 fn slatedb_publication_window_survives_sigkill_at_every_storage_event() {
-    sweep::<SlateDB>();
+    sweep::<SlateDB>(Workload::from_env());
+}
+
+/// The durable half of the SlateDB arm, and the reason the sweep above reports
+/// lost acknowledgements instead of failing on them.
+///
+/// Identical backend, identical workload, identical kill schedule; the only
+/// difference is that every write transaction sets
+/// `WriteOptions::await_durable`. The sweep above measures what a SQL commit
+/// gets today (acknowledged off an in-process queue, so SIGKILL takes it back);
+/// this one measures what the flag buys (acknowledged only after the WAL SST is
+/// in the object store, so SIGKILL cannot). Keeping both in the default run
+/// means the durable contract is a standing assertion rather than a one-off
+/// measurement in a PR body.
+#[cfg(feature = "slatedb")]
+#[test]
+fn slatedb_durable_acknowledgement_survives_sigkill() {
+    let mut workload = Workload::from_env();
+    workload.force_await_durable = true;
+    sweep::<SlateDB>(workload);
 }
 
 /// The RocksDB adapter accepts [`WriteOptions::await_durable`] and never acts on
@@ -1259,8 +1284,9 @@ fn slatedb_honours_await_durable_and_acknowledges_non_durable_writes_early() {
          re-measure this qualification's durability arm"
     );
     assert!(
-        source.contains("if await_durable {\n                    db.flush().await?;"),
-        "the SlateDB adapter no longer flushes the WAL for a durable write — \
+        source.contains("let await_durable = writes.iter().any(|write| write.await_durable);")
+            && source.contains("db.flush().await?"),
+        "the SlateDB adapter's write drainer no longer flushes the WAL for a durable write — \
          re-measure this qualification's durability arm"
     );
     assert!(

--- a/packages/engine-benchmarks/tests/crash_consistency_qualification.rs
+++ b/packages/engine-benchmarks/tests/crash_consistency_qualification.rs
@@ -11,8 +11,9 @@
 //!
 //! ## How the window is swept
 //!
-//! [`CrashStorage`] wraps [`RocksDB`] and counts every mutation the engine
-//! issues at the storage boundary — `begin_write`, each `put_many`,
+//! [`CrashStorage`] wraps a real backend — [`RocksDB`] or `SlateDB`, selected by
+//! the [`CrashBackend`] type parameter — and counts every mutation the engine
+//! issues at the storage boundary: `begin_write`, each `put_many`,
 //! `delete_many` and `delete_range`, the moment before `commit()` is delegated,
 //! and the moment after it returns. A child process is launched once per kill
 //! point with `LIX_CRASH_KILL_AT=k`; the wrapper raises `SIGKILL` on itself when
@@ -22,8 +23,9 @@
 //! reproduces by rerunning the same `k`.
 //!
 //! A second phase kills on a seeded wall-clock delay instead. That is the only
-//! way to land inside RocksDB's own write path (WAL append, memtable insert),
-//! which the storage-boundary sweep steps over atomically.
+//! way to land inside the backend's own write path (RocksDB's WAL append and
+//! memtable insert; SlateDB's write pipeline, WAL buffer and object-store
+//! upload), which the storage-boundary sweep steps over atomically.
 //!
 //! ## What SIGKILL can and cannot prove
 //!
@@ -31,8 +33,21 @@
 //! the process had already handed to `write(2)` survives. It therefore proves
 //! that the engine does not publish in observable stages. It does **not** model
 //! power loss, which additionally requires the backend to have fsynced. See
-//! `rocksdb_ignores_await_durable_write_option` in this file for the separate,
-//! statically-decidable half of that question.
+//! `rocksdb_ignores_await_durable_and_therefore_proves_only_process_crash_consistency`
+//! in this file for the separate, statically-decidable half of that question.
+//!
+//! There is a second, sharper distinction that only shows up once a second
+//! backend is swept. `WriteOptions::await_durable` asks the adapter not to
+//! acknowledge until it has crossed its durable persistence boundary, and lix
+//! sets it for atomic content-addressed publications. RocksDB ignores the flag
+//! but writes its WAL synchronously inside `db.write()`, so an acknowledged
+//! commit is already in the kernel and survives process death regardless.
+//! SlateDB honours the flag, but its adapter acknowledges a *non*-durable commit
+//! as soon as the write set is queued on an in-process pipeline
+//! (`slatedb.rs:3784-3806`), which SIGKILL discards. The two arms therefore
+//! measure genuinely different acknowledgement contracts, and the sweep reports
+//! consistency violations and lost acknowledgements separately so the difference
+//! is visible rather than averaged away.
 //!
 //! ## Cost
 //!
@@ -44,6 +59,10 @@
 //! * `LIX_CRASH_CONSISTENCY_COMMITS` — commits attempted per trial (default 3)
 //! * `LIX_CRASH_CONSISTENCY_TIMED_TRIALS` — seeded wall-clock kills (default 12)
 //! * `LIX_CRASH_CONSISTENCY_MAX_POINTS` — cap on swept kill points (default 512)
+//! * `LIX_CRASH_CONSISTENCY_BLOB_BYTES` — binary file bytes republished in the
+//!   same transaction, `0` to publish rows only (default 64 KiB, 128 KiB deep).
+//!   A non-zero value is what routes the publication through the atomic CAS path
+//!   and therefore what sets `await_durable`.
 
 use std::fs;
 use std::io::Write as _;
@@ -58,11 +77,14 @@ use lix::storage::{
     StorageWrite, WriteOptions,
 };
 use lix::{Lix, Value, open_lix};
-use lix_storage_rocksdb::{RocksDB, RocksDBRead, RocksDBWrite};
+use lix_storage_rocksdb::RocksDB;
+#[cfg(feature = "slatedb")]
+use lix_storage_slatedb::SlateDB;
 
 const SCHEMA_KEY: &str = "crash_consistency_row";
 const CHILD_ENV: &str = "LIX_CRASH_CONSISTENCY_CHILD";
 const CHILD_TEST: &str = "crash_consistency_child_worker";
+const BACKEND_ENV: &str = "LIX_CRASH_BACKEND";
 
 /// Marker added by the post-recovery write so a second reopen can prove the
 /// recovered store is stable, not merely readable once.
@@ -82,6 +104,13 @@ struct Killer {
     armed: AtomicBool,
     kill_at: u64,
     trace: bool,
+    /// Write transactions opened inside the measured window, and how many of
+    /// them asked for a durable acknowledgement. Recorded rather than assumed:
+    /// whether the workload exercises `await_durable` is the thing that
+    /// separates the two backends' acknowledgement contracts, so the harness
+    /// reports it from the storage boundary instead of inferring it.
+    writes: AtomicU64,
+    durable_writes: AtomicU64,
 }
 
 impl Killer {
@@ -91,6 +120,8 @@ impl Killer {
             armed: AtomicBool::new(false),
             kill_at,
             trace,
+            writes: AtomicU64::new(0),
+            durable_writes: AtomicU64::new(0),
         }
     }
 
@@ -100,6 +131,23 @@ impl Killer {
 
     fn events(&self) -> u64 {
         self.counter.load(Ordering::SeqCst)
+    }
+
+    fn record_write(&self, await_durable: bool) {
+        if !self.armed.load(Ordering::SeqCst) {
+            return;
+        }
+        self.writes.fetch_add(1, Ordering::SeqCst);
+        if await_durable {
+            self.durable_writes.fetch_add(1, Ordering::SeqCst);
+        }
+    }
+
+    fn durability_census(&self) -> (u64, u64) {
+        (
+            self.durable_writes.load(Ordering::SeqCst),
+            self.writes.load(Ordering::SeqCst),
+        )
     }
 
     fn tick(&self, label: &str) {
@@ -127,29 +175,58 @@ impl Killer {
 // Storage wrapper
 // ---------------------------------------------------------------------------
 
+/// A shipping storage adapter this qualification can sweep.
+///
+/// The only thing the harness needs beyond [`Storage`] is "open me at this
+/// path", which is deliberately the same call a user makes. Both shipping
+/// adapters implement it identically; nothing here is adapter-specific.
+trait CrashBackend: Storage + Clone + Send + Sync + Sized + 'static {
+    /// Value of [`BACKEND_ENV`] that selects this backend in the child process.
+    const NAME: &'static str;
+
+    fn open_at(path: &Path) -> Result<Self, StorageError>;
+}
+
+impl CrashBackend for RocksDB {
+    const NAME: &'static str = "rocksdb";
+
+    fn open_at(path: &Path) -> Result<Self, StorageError> {
+        RocksDB::open(path)
+    }
+}
+
+#[cfg(feature = "slatedb")]
+impl CrashBackend for SlateDB {
+    const NAME: &'static str = "slatedb";
+
+    fn open_at(path: &Path) -> Result<Self, StorageError> {
+        SlateDB::open(path)
+    }
+}
+
 #[derive(Clone)]
-struct CrashStorage {
-    inner: RocksDB,
+struct CrashStorage<B> {
+    inner: B,
     killer: Arc<Killer>,
 }
 
-impl CrashStorage {
+impl<B: CrashBackend> CrashStorage<B> {
     fn open(path: &Path, killer: Arc<Killer>) -> Self {
         Self {
-            inner: RocksDB::open(path).expect("open crash-consistency RocksDB fixture"),
+            inner: B::open_at(path).expect("open crash-consistency backend fixture"),
             killer,
         }
     }
 }
 
-impl Storage for CrashStorage {
+impl<B: CrashBackend> Storage for CrashStorage<B> {
     type Read<'a>
-        = RocksDBRead<'a>
+        = B::Read<'a>
     where
         Self: 'a;
 
     type Write<'a>
-        = CrashWrite
+        = CrashWrite<B::Write<'a>>
     where
         Self: 'a;
 
@@ -166,6 +243,7 @@ impl Storage for CrashStorage {
     ) -> impl Future<Output = Result<Self::Write<'_>, StorageError>> + Send {
         let killer = self.killer.clone();
         async move {
+            killer.record_write(opts.await_durable);
             killer.tick("begin_write");
             let inner = self.inner.begin_write(opts).await?;
             Ok(CrashWrite { inner, killer })
@@ -173,12 +251,12 @@ impl Storage for CrashStorage {
     }
 }
 
-struct CrashWrite {
-    inner: RocksDBWrite,
+struct CrashWrite<W> {
+    inner: W,
     killer: Arc<Killer>,
 }
 
-impl StorageWrite for CrashWrite {
+impl<W: StorageWrite> StorageWrite for CrashWrite<W> {
     fn put_many(
         &mut self,
         space: StorageSpace,
@@ -227,8 +305,9 @@ impl StorageWrite for CrashWrite {
     }
 }
 
-// The read side is pass-through: `RocksDBRead` already satisfies `StorageRead`,
-// and a read cannot publish, so reads are not kill points.
+// The read side is pass-through: the backend's own read handle already
+// satisfies `StorageRead`, and a read cannot publish, so reads are not kill
+// points.
 
 // ---------------------------------------------------------------------------
 // Workload shape
@@ -308,6 +387,7 @@ fn crash_consistency_child_worker() {
     let kill_after_nanos = env_u64("LIX_CRASH_KILL_AFTER_NANOS", 0);
     let trace = env_flag("LIX_CRASH_TRACE");
     let workload = Workload::from_env();
+    let backend = std::env::var(BACKEND_ENV).unwrap_or_else(|_| RocksDB::NAME.to_owned());
 
     let killer = Arc::new(Killer::new(kill_at, trace));
 
@@ -326,11 +406,25 @@ fn crash_consistency_child_worker() {
             .expect("spawn crash-consistency watchdog");
     }
 
-    run_on_large_stack(move || child_main(db, ack, killer, workload));
+    match backend.as_str() {
+        name if name == RocksDB::NAME => {
+            run_on_large_stack(move || child_main::<RocksDB>(db, ack, killer, workload));
+        }
+        #[cfg(feature = "slatedb")]
+        name if name == SlateDB::NAME => {
+            run_on_large_stack(move || child_main::<SlateDB>(db, ack, killer, workload));
+        }
+        other => panic!("unknown crash-consistency backend {other:?}"),
+    }
 }
 
-async fn child_main(db: PathBuf, ack: PathBuf, killer: Arc<Killer>, workload: Workload) {
-    let storage = CrashStorage::open(&db, killer.clone());
+async fn child_main<B: CrashBackend>(
+    db: PathBuf,
+    ack: PathBuf,
+    killer: Arc<Killer>,
+    workload: Workload,
+) {
+    let storage = CrashStorage::<B>::open(&db, killer.clone());
     let lix = open_lix()
         .with_storage(storage.clone())
         .await
@@ -361,7 +455,9 @@ async fn child_main(db: PathBuf, ack: PathBuf, killer: Arc<Killer>, workload: Wo
         append_ack(&ack, generation);
     }
 
+    let (durable, total) = killer.durability_census();
     println!("E20_EVENTS {}", killer.events());
+    println!("E36_DURABLE_WRITES {durable} {total}");
     let _ = std::io::stdout().flush();
     lix.close().await.expect("child closes crash-consistency Lix");
 }
@@ -385,10 +481,20 @@ struct Recovered {
     /// Highest generation visible after the crash, or `None` when the crash
     /// landed before the seed commit published.
     generation: Option<i64>,
+    /// Set when every state the store presented was internally consistent, but
+    /// a commit whose `commit()` had already returned `Ok` is not in it.
+    ///
+    /// This is deliberately *not* an `Err`. Losing an acknowledged commit is a
+    /// durability outcome, not a consistency one — the store is whole, it is
+    /// merely older than the writer was told — and the two backends differ
+    /// exactly here. Keeping them in separate columns is what lets the sweep
+    /// report "0 inconsistencies, N lost acknowledgements" instead of collapsing
+    /// a durability contract difference into a corruption-shaped number.
+    lost_acknowledgement: Option<String>,
 }
 
 /// Everything the brief asks of a store that has just survived a crash.
-async fn verify_after_crash(
+async fn verify_after_crash<B: CrashBackend>(
     path: PathBuf,
     acked: Option<i64>,
     attempted: i64,
@@ -396,8 +502,9 @@ async fn verify_after_crash(
     setup_complete: bool,
 ) -> Result<Recovered, String> {
     let rows = workload.rows;
+    let mut lost_acknowledgement: Option<String> = None;
     // 1. Does the store open at all?
-    let storage = RocksDB::open(&path).map_err(|error| format!("store did not open: {error}"))?;
+    let storage = B::open_at(&path).map_err(|error| format!("store did not open: {error}"))?;
     let lix = open_lix()
         .with_storage(storage.clone())
         .await
@@ -463,8 +570,13 @@ async fn verify_after_crash(
     }
     let generation = if observed.is_empty() {
         if setup_complete {
-            return Err(
-                "no rows visible even though the seed commit was acknowledged before the crash"
+            // `setup.done` is fsynced only after the seed commit returned `Ok`,
+            // so an empty store here means an acknowledged commit is gone. The
+            // store is still whole — it is simply older than the writer was
+            // told — so this is a durability observation, not a torn write.
+            lost_acknowledgement = Some(
+                "acknowledged commit lost: the seed commit returned Ok (setup.done is fsynced) \
+                 but the store has no rows"
                     .to_owned(),
             );
         }
@@ -475,13 +587,18 @@ async fn verify_after_crash(
 
     // Durability: a commit whose `commit()` returned Ok must still be there.
     if let Some(acked) = acked {
-        let visible = generation.ok_or_else(|| {
-            format!("acknowledged commit lost: ack log reached generation {acked}, store is empty")
-        })?;
-        if visible < acked {
-            return Err(format!(
-                "acknowledged commit lost: ack log reached generation {acked}, store shows {visible}"
-            ));
+        match generation {
+            None => {
+                lost_acknowledgement = Some(format!(
+                    "acknowledged commit lost: ack log reached generation {acked}, store is empty"
+                ));
+            }
+            Some(visible) if visible < acked => {
+                lost_acknowledgement = Some(format!(
+                    "acknowledged commit lost: ack log reached generation {acked}, store shows {visible}"
+                ));
+            }
+            Some(_) => {}
         }
     }
     if let Some(visible) = generation
@@ -559,7 +676,7 @@ async fn verify_after_crash(
     drop(storage);
 
     // And the recovered store must stay recovered across another clean reopen.
-    let storage = RocksDB::open(&path).map_err(|error| format!("second open failed: {error}"))?;
+    let storage = B::open_at(&path).map_err(|error| format!("second open failed: {error}"))?;
     let lix = open_lix()
         .with_storage(storage.clone())
         .await
@@ -583,7 +700,10 @@ async fn verify_after_crash(
         .await
         .map_err(|error| format!("final close failed: {error}"))?;
 
-    Ok(Recovered { generation })
+    Ok(Recovered {
+        generation,
+        lost_acknowledgement,
+    })
 }
 
 fn single_generation(rows: &[i64]) -> Result<i64, String> {
@@ -803,11 +923,17 @@ fn result_column(sql: &str) -> &'static str {
 // Parent process: the sweep
 // ---------------------------------------------------------------------------
 
-#[test]
-fn rocksdb_publication_window_survives_sigkill_at_every_storage_event() {
+/// Sweep every kill point in the publication window of one shipping adapter.
+///
+/// Identical code, identical invariants and an identical null control for every
+/// backend: the only thing that varies is which adapter the engine was handed.
+/// That is what makes the two arms comparable — a second harness would only
+/// prove that two harnesses agree.
+fn sweep<B: CrashBackend>() {
     let workload = Workload::from_env();
     let root = tempfile::tempdir().expect("create crash-consistency sweep root");
     let mut failures: Vec<String> = Vec::new();
+    let mut lost_acks: Vec<String> = Vec::new();
     let mut recovered_generations: Vec<Option<i64>> = Vec::new();
     let mut trials = 0usize;
     let mut killed_trials = 0usize;
@@ -815,7 +941,7 @@ fn rocksdb_publication_window_survives_sigkill_at_every_storage_event() {
     // Calibrate: one unkilled run establishes how many storage events the
     // measured window contains, and how long it takes.
     let started = Instant::now();
-    let calibration = run_child(
+    let calibration = run_child::<B>(
         &root.path().join("calibration"),
         workload,
         KillPlan::None,
@@ -839,7 +965,7 @@ fn rocksdb_publication_window_survives_sigkill_at_every_storage_event() {
     let control_database = root.path().join("calibration").join("database");
     let control_acked = calibration.acked;
     let control = block_on(move || {
-        verify_after_crash(
+        verify_after_crash::<B>(
             control_database,
             control_acked,
             workload.commits as i64,
@@ -858,6 +984,19 @@ fn rocksdb_publication_window_survives_sigkill_at_every_storage_event() {
         Some(workload.commits as i64),
         "clean-close control did not reach the last attempted generation"
     );
+    assert!(
+        control.lost_acknowledgement.is_none(),
+        "clean-close control lost an acknowledged commit without any kill — the harness, not the \
+         crash, is the problem: {:?}",
+        control.lost_acknowledgement
+    );
+
+    // How many of the window's write transactions actually asked for a durable
+    // acknowledgement, read off the storage boundary rather than assumed. This
+    // is what decides whether "acknowledged commit lost" below is a contract
+    // violation or a documented property of a non-durable write.
+    let (durable_writes, total_writes) = calibration.durability.unwrap_or((0, 0));
+    let durability_requested = durable_writes > 0;
     let _ = fs::remove_dir_all(root.path().join("calibration"));
 
     let max_points = env_usize("LIX_CRASH_CONSISTENCY_MAX_POINTS", 512);
@@ -872,7 +1011,7 @@ fn rocksdb_publication_window_survives_sigkill_at_every_storage_event() {
 
     for kill_at in &swept {
         let dir = root.path().join(format!("k{kill_at}"));
-        let child = run_child(&dir, workload, KillPlan::AtEvent(*kill_at), false);
+        let child = run_child::<B>(&dir, workload, KillPlan::AtEvent(*kill_at), false);
         trials += 1;
         if child.killed_by_signal {
             killed_trials += 1;
@@ -885,10 +1024,21 @@ fn rocksdb_publication_window_survives_sigkill_at_every_storage_event() {
         let acked = child.acked;
         let setup_complete = child.setup_complete;
         let outcome = block_on(move || {
-            verify_after_crash(database, acked, workload.commits as i64, workload, setup_complete)
+            verify_after_crash::<B>(
+                database,
+                acked,
+                workload.commits as i64,
+                workload,
+                setup_complete,
+            )
         });
         match &outcome {
-            Ok(recovered) => recovered_generations.push(recovered.generation),
+            Ok(recovered) => {
+                recovered_generations.push(recovered.generation);
+                if let Some(loss) = &recovered.lost_acknowledgement {
+                    lost_acks.push(format!("kill_at={kill_at} ({label}): {loss}"));
+                }
+            }
             Err(error) => failures.push(format!(
                 "kill_at={kill_at} ({label}, killed={}): {error}",
                 child.killed_by_signal
@@ -897,7 +1047,7 @@ fn rocksdb_publication_window_survives_sigkill_at_every_storage_event() {
         let _ = fs::remove_dir_all(&dir);
     }
 
-    // Timed phase: land the kill inside RocksDB's own write path.
+    // Timed phase: land the kill inside the backend's own write path.
     let timed_trials = env_usize(
         "LIX_CRASH_CONSISTENCY_TIMED_TRIALS",
         if env_flag("LIX_CRASH_CONSISTENCY_DEEP") {
@@ -917,7 +1067,7 @@ fn rocksdb_publication_window_survives_sigkill_at_every_storage_event() {
     for trial in 0..timed_trials {
         let delay = aim_from + rng.next() % aim_span;
         let dir = root.path().join(format!("t{trial}"));
-        let child = run_child(&dir, workload, KillPlan::AfterNanos(delay), false);
+        let child = run_child::<B>(&dir, workload, KillPlan::AfterNanos(delay), false);
         trials += 1;
         if child.killed_by_signal {
             killed_trials += 1;
@@ -926,10 +1076,21 @@ fn rocksdb_publication_window_survives_sigkill_at_every_storage_event() {
         let acked = child.acked;
         let setup_complete = child.setup_complete;
         let outcome = block_on(move || {
-            verify_after_crash(database, acked, workload.commits as i64, workload, setup_complete)
+            verify_after_crash::<B>(
+                database,
+                acked,
+                workload.commits as i64,
+                workload,
+                setup_complete,
+            )
         });
         match &outcome {
-            Ok(recovered) => recovered_generations.push(recovered.generation),
+            Ok(recovered) => {
+                recovered_generations.push(recovered.generation);
+                if let Some(loss) = &recovered.lost_acknowledgement {
+                    lost_acks.push(format!("timed delay={delay}ns: {loss}"));
+                }
+            }
             Err(error) => failures.push(format!(
                 "timed delay={delay}ns (killed={}): {error}",
                 child.killed_by_signal
@@ -942,26 +1103,79 @@ fn rocksdb_publication_window_survives_sigkill_at_every_storage_event() {
     distinct.sort_unstable();
     distinct.dedup();
     println!(
-        "crash-consistency sweep: {trials} trials ({} storage-event points over a {events}-event \
-         publication window, {timed_trials} seeded wall-clock kills spanning \
-         {aim_from}..{}ns), {killed_trials} confirmed SIGKILLed, {} inconsistencies; \
-         recovered generations observed: {distinct:?}",
+        "crash-consistency sweep [{backend}]: {trials} trials ({} storage-event points over a \
+         {events}-event publication window, {timed_trials} seeded wall-clock kills spanning \
+         {aim_from}..{}ns), {killed_trials} confirmed SIGKILLed, {} inconsistencies, \
+         {} lost acknowledgements ({durable_writes}/{total_writes} window write transactions \
+         requested await_durable); recovered generations observed: {distinct:?}",
         swept.len(),
         aim_from + aim_span,
-        failures.len()
+        failures.len(),
+        lost_acks.len(),
+        backend = B::NAME,
     );
 
     assert!(
         failures.is_empty(),
-        "crash consistency violated in {} of {trials} trials:\n  - {}",
+        "crash consistency violated on {} in {} of {trials} trials:\n  - {}",
+        B::NAME,
         failures.len(),
         failures.join("\n  - ")
     );
+    // Losing an acknowledged commit is only a contract violation when the
+    // acknowledgement was asked to be durable. `WriteOptions::await_durable` is
+    // opt-in and `Storage::begin_write` explicitly documents that "a storage may
+    // publish a commit before its background durability boundary", so a
+    // non-durable write that vanishes with the process is within contract — it
+    // is reported above and analysed in the qualification write-up, not failed.
+    if durability_requested {
+        assert!(
+            lost_acks.is_empty(),
+            "{} lost {} acknowledged commits out of {trials} trials even though \
+             {durable_writes} of {total_writes} write transactions in the window set \
+             await_durable:\n  - {}",
+            B::NAME,
+            lost_acks.len(),
+            lost_acks.join("\n  - ")
+        );
+    }
     // A sweep in which nothing ever died would be vacuously green.
     assert!(
         killed_trials * 2 >= swept.len(),
         "only {killed_trials} of {trials} trials actually died; the harness is not exercising crashes"
     );
+    // Coverage has to be demonstrated, not asserted. A sweep whose kills all
+    // landed after the last commit had already published would report exactly
+    // one recovered generation and pass every invariant vacuously.
+    assert!(
+        distinct.len() >= 2,
+        "the sweep only ever recovered {distinct:?}; every kill landed in the same state, so the \
+         window was not actually swept"
+    );
+}
+
+#[test]
+fn rocksdb_publication_window_survives_sigkill_at_every_storage_event() {
+    sweep::<RocksDB>();
+}
+
+/// The same sweep, the same invariants and the same null control against the
+/// other shipping adapter.
+///
+/// Scope note, stated rather than implied: this runs SlateDB over a
+/// **local-filesystem** object store (`SlateDB::open`, which is
+/// `LocalFileSystem` under the hood — `slatedb.rs:2366-2402`). For *performance*
+/// that configuration is misleading and the round's rules forbid quoting it as
+/// "the SlateDB result". For *crash consistency* it is the legitimate
+/// configuration and the only one this qualification can express: the kill has
+/// to interrupt a real writer process with real bytes crossing a real process
+/// boundary, and the object-store simulation used by the benches
+/// (`ThrottledStore` over `InMemory`) keeps every byte inside the dying
+/// process's heap, so "killed mid-upload" is not even representable there.
+#[cfg(feature = "slatedb")]
+#[test]
+fn slatedb_publication_window_survives_sigkill_at_every_storage_event() {
+    sweep::<SlateDB>();
 }
 
 /// The RocksDB adapter accepts [`WriteOptions::await_durable`] and never acts on
@@ -984,6 +1198,39 @@ fn rocksdb_ignores_await_durable_and_therefore_proves_only_process_crash_consist
     );
 }
 
+/// The SlateDB adapter's acknowledgement is the mirror image of RocksDB's, and
+/// the sweep above is what turns that from a code reading into a measurement.
+///
+/// `SlateDBWrite::commit` publishes the write set onto an in-process pipeline
+/// and returns; the bytes only reach the object store when the background
+/// drainer runs. A commit that did **not** set `await_durable` is therefore
+/// acknowledged while its write set is still in the dying process's heap. A
+/// commit that **did** set it parks on `completion.wait()`, which resolves only
+/// after `drain_write_queue` has run `db.write_with_options` *and* `db.flush()`,
+/// i.e. after the WAL SST is in the object store.
+///
+/// This test pins both halves so the scope note cannot go stale silently.
+#[cfg(feature = "slatedb")]
+#[test]
+fn slatedb_honours_await_durable_and_acknowledges_non_durable_writes_early() {
+    let source = include_str!("../../slatedb-storage/src/slatedb.rs");
+    assert!(
+        source.contains("if await_durable && !apply_backpressure {"),
+        "the SlateDB adapter no longer waits for write completion on await_durable — \
+         re-measure this qualification's durability arm"
+    );
+    assert!(
+        source.contains("if await_durable {\n                    db.flush().await?;"),
+        "the SlateDB adapter no longer flushes the WAL for a durable write — \
+         re-measure this qualification's durability arm"
+    );
+    assert!(
+        source.contains("await_durable: false,"),
+        "the SlateDB adapter no longer enqueues batches with SlateDB's own await_durable off — \
+         re-measure this qualification's durability arm"
+    );
+}
+
 // ---------------------------------------------------------------------------
 // Child process plumbing
 // ---------------------------------------------------------------------------
@@ -1003,10 +1250,18 @@ struct ChildRun {
     setup_nanos: Option<u64>,
     setup_complete: bool,
     labels: Vec<String>,
+    /// `(write transactions that set await_durable, write transactions)` in the
+    /// measured window. Only a child that ran to completion reports it.
+    durability: Option<(u64, u64)>,
     output: String,
 }
 
-fn run_child(dir: &Path, workload: Workload, plan: KillPlan, trace: bool) -> ChildRun {
+fn run_child<B: CrashBackend>(
+    dir: &Path,
+    workload: Workload,
+    plan: KillPlan,
+    trace: bool,
+) -> ChildRun {
     fs::create_dir_all(dir).expect("create crash-consistency trial directory");
     let ack = dir.join("ack.log");
     let exe = std::env::current_exe().expect("locate crash-consistency test binary");
@@ -1021,6 +1276,7 @@ fn run_child(dir: &Path, workload: Workload, plan: KillPlan, trace: bool) -> Chi
             "--quiet",
         ])
         .env(CHILD_ENV, "1")
+        .env(BACKEND_ENV, B::NAME)
         .env("LIX_CRASH_DB", dir.join("database"))
         .env("LIX_CRASH_ACK", &ack)
         .env(
@@ -1030,6 +1286,10 @@ fn run_child(dir: &Path, workload: Workload, plan: KillPlan, trace: bool) -> Chi
         .env(
             "LIX_CRASH_CONSISTENCY_COMMITS",
             workload.commits.to_string(),
+        )
+        .env(
+            "LIX_CRASH_CONSISTENCY_BLOB_BYTES",
+            workload.blob_bytes.to_string(),
         )
         .stdout(Stdio::piped())
         .stderr(Stdio::piped());
@@ -1065,6 +1325,12 @@ fn run_child(dir: &Path, workload: Workload, plan: KillPlan, trace: bool) -> Chi
         .find_map(|line| line.strip_prefix("E20_SETUP_NANOS "))
         .and_then(|value| value.trim().parse().ok());
 
+    let durability = stdout
+        .lines()
+        .find_map(|line| line.strip_prefix("E36_DURABLE_WRITES "))
+        .and_then(|rest| rest.trim().split_once(' '))
+        .and_then(|(durable, total)| Some((durable.parse().ok()?, total.parse().ok()?)));
+
     ChildRun {
         status_success: output.status.success(),
         killed_by_signal: signal_of(&output.status) == Some(libc::SIGKILL),
@@ -1073,6 +1339,7 @@ fn run_child(dir: &Path, workload: Workload, plan: KillPlan, trace: bool) -> Chi
         setup_nanos,
         setup_complete: dir.join("setup.done").exists(),
         labels,
+        durability,
         output: format!("stdout:\n{stdout}\nstderr:\n{stderr}"),
     }
 }

--- a/packages/engine-benchmarks/tests/crash_consistency_qualification.rs
+++ b/packages/engine-benchmarks/tests/crash_consistency_qualification.rs
@@ -37,17 +37,25 @@
 //! in this file for the separate, statically-decidable half of that question.
 //!
 //! There is a second, sharper distinction that only shows up once a second
-//! backend is swept. `WriteOptions::await_durable` asks the adapter not to
-//! acknowledge until it has crossed its durable persistence boundary, and lix
-//! sets it for atomic content-addressed publications. RocksDB ignores the flag
-//! but writes its WAL synchronously inside `db.write()`, so an acknowledged
-//! commit is already in the kernel and survives process death regardless.
-//! SlateDB honours the flag, but its adapter acknowledges a *non*-durable commit
-//! as soon as the write set is queued on an in-process pipeline
-//! (`slatedb.rs:3784-3806`), which SIGKILL discards. The two arms therefore
-//! measure genuinely different acknowledgement contracts, and the sweep reports
-//! consistency violations and lost acknowledgements separately so the difference
-//! is visible rather than averaged away.
+//! backend is swept: the two adapters do not acknowledge the same thing.
+//!
+//! * RocksDB stages into one `WriteBatch` and applies it inside `db.write()`
+//!   before `commit()` returns, so an acknowledged commit is already in the
+//!   kernel's page cache. SIGKILL cannot take it back; only power loss can,
+//!   because the WAL is never fsynced.
+//! * SlateDB's adapter publishes the write set onto an in-process pipeline and
+//!   returns (`slatedb.rs:3784-3806`). Unless `WriteOptions::await_durable` is
+//!   set, the bytes are still in the dying process's heap when `commit()`
+//!   returns `Ok`, and SIGKILL discards them.
+//!
+//! `WriteOptions::await_durable` is the flag that closes that gap, and **no SQL
+//! path sets it**: `stage_atomic_cas_publication`, the only writer that does, is
+//! reachable solely from the resumable media-upload session API
+//! (`session/media_upload.rs:441`). The sweep therefore measures the flag
+//! directly — `LIX_CRASH_AWAIT_DURABLE=1` forces it on at the storage boundary
+//! and reruns the identical schedule — and reports consistency violations and
+//! lost acknowledgements in separate columns, so a durability contract
+//! difference is never collapsed into a corruption-shaped number.
 //!
 //! ## Cost
 //!
@@ -208,13 +216,25 @@ impl CrashBackend for SlateDB {
 struct CrashStorage<B> {
     inner: B,
     killer: Arc<Killer>,
+    /// Overrides [`WriteOptions::await_durable`] to `true` on every write
+    /// transaction the engine opens.
+    ///
+    /// No SQL path sets the flag on its own — `stage_atomic_cas_publication`,
+    /// the only writer that does, is reachable only from the resumable
+    /// media-upload session API (`session/media_upload.rs:441`), never from
+    /// `INSERT INTO lix_file`. Forcing it at the storage boundary is therefore
+    /// the only way to run the same workload, the same kill schedule and the
+    /// same invariants with the one bit changed, which is what "does
+    /// `await_durable` change the outcome" actually asks.
+    force_await_durable: bool,
 }
 
 impl<B: CrashBackend> CrashStorage<B> {
-    fn open(path: &Path, killer: Arc<Killer>) -> Self {
+    fn open(path: &Path, killer: Arc<Killer>, force_await_durable: bool) -> Self {
         Self {
             inner: B::open_at(path).expect("open crash-consistency backend fixture"),
             killer,
+            force_await_durable,
         }
     }
 }
@@ -242,7 +262,10 @@ impl<B: CrashBackend> Storage for CrashStorage<B> {
         opts: WriteOptions,
     ) -> impl Future<Output = Result<Self::Write<'_>, StorageError>> + Send {
         let killer = self.killer.clone();
+        let force_await_durable = self.force_await_durable;
         async move {
+            let mut opts = opts;
+            opts.await_durable |= force_await_durable;
             killer.record_write(opts.await_durable);
             killer.tick("begin_write");
             let inner = self.inner.begin_write(opts).await?;
@@ -319,12 +342,19 @@ struct Workload {
     commits: u64,
     /// Bytes of binary file content rewritten in the same transaction.
     ///
-    /// A non-zero size routes each publication through the atomic
-    /// content-addressed path (`stage_atomic_cas_publication`), which stages
-    /// blob chunks, a prepared manifest and a publication fence alongside the
-    /// row write set — a materially different publication shape from a plain
-    /// row commit, and the one the engine marks `await_durable`.
+    /// A non-zero size routes each publication through the content-addressed
+    /// blob path, which stages blob chunks and a publication fence alongside the
+    /// row write set — a materially different publication shape from a plain row
+    /// commit, and one that widens the swept window.
+    ///
+    /// Note it does **not** set `await_durable`; measured, not assumed. See
+    /// [`Workload::force_await_durable`].
     blob_bytes: usize,
+    /// Force `WriteOptions::await_durable` on at the storage boundary.
+    ///
+    /// The A/B for "what does the durability flag buy" — same workload, same
+    /// kill schedule, same invariants, one bit changed.
+    force_await_durable: bool,
 }
 
 impl Workload {
@@ -337,6 +367,7 @@ impl Workload {
                 "LIX_CRASH_CONSISTENCY_BLOB_BYTES",
                 if deep { 128 * 1024 } else { 64 * 1024 },
             ),
+            force_await_durable: env_flag("LIX_CRASH_AWAIT_DURABLE"),
         }
     }
 }
@@ -424,7 +455,7 @@ async fn child_main<B: CrashBackend>(
     killer: Arc<Killer>,
     workload: Workload,
 ) {
-    let storage = CrashStorage::<B>::open(&db, killer.clone());
+    let storage = CrashStorage::<B>::open(&db, killer.clone(), workload.force_await_durable);
     let lix = open_lix()
         .with_storage(storage.clone())
         .await
@@ -551,12 +582,20 @@ async fn verify_after_crash<B: CrashBackend>(
     // 0 or `rows` and the generations must still be uniform.
     let observed = match read_generations(&lix).await {
         Ok(observed) => observed,
-        Err(ReadFailure::TableAbsent) if !setup_complete => Vec::new(),
         Err(ReadFailure::TableAbsent) => {
-            return Err(
-                "plain SELECT failed after crash: the table is gone even though setup completed"
-                    .to_owned(),
-            );
+            if setup_complete {
+                // Schema registration and the seed commit both returned `Ok`
+                // before `setup.done` was fsynced, so the table's absence means
+                // acknowledged commits are gone. The store is not damaged — it
+                // is empty, which is a legal state a fresh store also has — so
+                // this is a durability outcome, not a consistency one.
+                lost_acknowledgement = Some(
+                    "acknowledged commit lost: schema registration and the seed commit both \
+                     returned Ok (setup.done is fsynced) but the table is gone"
+                        .to_owned(),
+                );
+            }
+            Vec::new()
         }
         Err(ReadFailure::Other(error)) => {
             return Err(format!("plain SELECT failed after crash: {error}"));
@@ -569,7 +608,7 @@ async fn verify_after_crash<B: CrashBackend>(
         ));
     }
     let generation = if observed.is_empty() {
-        if setup_complete {
+        if setup_complete && lost_acknowledgement.is_none() {
             // `setup.done` is fsynced only after the seed commit returned `Ok`,
             // so an empty store here means an acknowledged commit is gone. The
             // store is still whole — it is simply older than the writer was
@@ -1290,6 +1329,10 @@ fn run_child<B: CrashBackend>(
         .env(
             "LIX_CRASH_CONSISTENCY_BLOB_BYTES",
             workload.blob_bytes.to_string(),
+        )
+        .env(
+            "LIX_CRASH_AWAIT_DURABLE",
+            if workload.force_await_durable { "1" } else { "0" },
         )
         .stdout(Stdio::piped())
         .stderr(Stdio::piped());


### PR DESCRIPTION
## What this is

Extends the crash-consistency qualification (#1388) from one storage backend to both.
Same harness, same invariants, same null control, same exhaustive-plus-timed kill
schedule — the backend became a type parameter instead of a hard-wired `RocksDB`.

**Test-only.** One file: `packages/engine-benchmarks/tests/crash_consistency_qualification.rs`.
No engine code, no adapter code, no `Cargo.toml` change.

## Headline

**SlateDB: 0 consistency violations in 2,520 deep trials.** Publication is atomic under
process death on both shipping adapters.

**And the durability expectation was wrong, in the direction that matters.** The premise
going in was that SlateDB is *structurally stronger* than RocksDB, because SlateDB honours
`WriteOptions::await_durable` and the RocksDB adapter ignores it. SlateDB does honour it.
The measurement still comes out the other way round:

**As shipped, a SQL commit on SlateDB is acknowledged before its bytes leave the process,
and SIGKILL takes it back. On RocksDB it is not.** SlateDB lost an acknowledged commit in
**846 of 1,008** non-durable deep trials; RocksDB lost **0 of 1,008** in the same schedule.

* SlateDB's adapter is honest and *asynchronous*: `commit()` publishes the write set onto
  an in-process pipeline and returns (`slatedb.rs:3796-3806`). Without `await_durable` the
  bytes are in the dying process's heap when the caller is told `Ok`.
* RocksDB's adapter is dishonest and *synchronous*: it never reads `await_durable` (zero
  occurrences of the identifier in `packages/rocksdb-storage/src`), but it has already
  applied its `WriteBatch` inside `db.write()` before `commit()` returns, so the commit is
  in the kernel page cache. SIGKILL cannot take it back; only power loss can.

The two adapters fail in opposite directions, and **no SQL path sets the flag that would
close the gap** (see the correction below). `await_durable` closes it completely:
**846 lost acknowledgements → 0**, over three seeds and 1,512 durable trials.

## Numbers

Deep sweep: 64 rows + a 128 KiB content-addressed file per commit, 12 commits/trial. Every
storage-boundary event in the publication window is a kill point, **exhaustively — 204 of
204, not a sample** — plus 300 seeded wall-clock kills that can land inside the backend's
own write path.

| arm | kill points | timed | trials | confirmed SIGKILLed | durable/total | inconsistencies | lost acks | recovered generations |
|---|---|---|---|---|---|---|---|---|
| rocksdb, durable off | 204 of 204 | 300 | 504 | 439 | 0/12 | **0** | **0** | `None, 0, 1, …, 12` |
| rocksdb, durable **on** | 204 of 204 | 300 | 504 | 501 | 12/12 | **0** | **0** | `None, 0, 1, …, 12` |
| slatedb, durable off, seed A | 204 of 204 | 300 | 504 | 492 | 0/12 | **0** | 416 | `None, 3, 8, 9, 12` |
| slatedb, durable **on**, seed A | 204 of 204 | 300 | 504 | 500 | 12/12 | **0** | **0** | `None, 0, 1, …, 12` |
| slatedb, durable off, seed B | 204 of 204 | 300 | 504 | 488 | 0/12 | **0** | 430 | `None, 3, 8, 9, 12` |
| slatedb, durable **on**, seed B | 204 of 204 | 300 | 504 | 497 | 12/12 | **0** | **0** | `None, 0, 1, …, 12` |
| slatedb, durable **on**, seed C | 204 of 204 | 300 | 504 | 502 | 12/12 | **0** | **0** | `None, 0, 1, …, 12` |
| **total** | **1428** | **2100** | **3528** | **3419** | | **0** | 846 | |

Plus the default (CI-sized) run — three sweeps, 63 trials each, **15.4 s total**:

| test | trials | SIGKILLed | durable/total | inconsistencies | lost acks | generations |
|---|---|---|---|---|---|---|
| `rocksdb_publication_window_survives_sigkill_at_every_storage_event` | 63 | 58 | 0/3 | **0** | **0** | `None, 0, 1, 2, 3` |
| `slatedb_publication_window_survives_sigkill_at_every_storage_event` | 63 | 63 | 0/3 | **0** | 58 | `None, 3` |
| `slatedb_durable_acknowledgement_survives_sigkill` | 63 | 60 | 3/3 | **0** | **0** | `None, 0, 1, 2, 3` |

**3,717 trials, 0 inconsistencies.**

### Coverage is demonstrated, not asserted

* 204 of 204 storage-boundary events swept in every deep arm — exhaustive, not sampled.
* **The recovered-generation column is the evidence.** A sweep that only killed after
  everything had been written would report exactly one generation. Both RocksDB arms and
  all three durable SlateDB arms report the whole ladder `None, 0, 1, …, 12`. The harness
  now **asserts** `distinct.len() >= 2`, so a degenerate schedule fails instead of passing
  vacuously.
* 3,419 of 3,528 deep trials confirmed dead by `WTERMSIG == 9`; the sweep asserts at least
  half the swept points really died.
* The **null control** — the identical battery against a cleanly-closed store before any
  kill — passed on every arm, and now also asserts it lost no acknowledgement.

### Where the SlateDB atomicity evidence actually lives

Stated plainly rather than glossed: the non-durable SlateDB arms recover only
`None, 3, 8, 9, 12` because almost nothing survives, so in 846 of 1,008 trials the store
comes back empty and the torn-write/history/blob checks are vacuous. Those trials still
exercise a real recovery path (reopen, re-register, commit, close, reopen, verify), but
**the atomicity claim rests on the three durable arms: 1,512 trials, 1,499 confirmed
killed, full generation ladder, every invariant non-vacuous, 0 violations.**

This is SIGKILL, not power loss — unchanged from #1388.

## Correction to #1388

#1388 said lix "sets `await_durable` … that is the binary content-addressed publication
path, i.e. exactly the file/media writes a backend user cares most about."

**The flag-setting code is real but no SQL statement reaches it.**
`stage_atomic_cas_publication` (`transaction/context.rs:807`, sets the flag at `:830`) has
exactly one caller: `session/media_upload.rs:441`, the resumable media-upload session API.
The only other `await_durable: true` in the engine is `media_upload.rs:358`. `INSERT INTO
lix_file` / `UPDATE lix_file` reach neither; the default is `await_durable_commit: false`
(`context.rs:1662`), propagated at `:1867`.

This PR measures the flag at the storage boundary instead of inferring it from call sites:
every sweep prints a `durable/total` census, and the workload that publishes a 128 KiB
content-addressed file in **every one of its 12 commits** reports **`0/12`**.

## Scope note, stated rather than implied

`SlateDB::open` runs SlateDB over `LocalFileSystem` (`slatedb.rs:2377`). For
**performance** that configuration is misleading and must not be quoted as "the SlateDB
result". For **crash consistency** it is legitimate, and it is the only configuration this
qualification can express: the object-store simulation the benches use (`ThrottledStore`
over `InMemory`) keeps every byte in the writing process's heap, so SIGKILL destroys the
"object store" along with the writer and *killed mid-upload is not a representable state*.
A crash test against an object store needs one that outlives the process.

Atomicity is latency-independent (one write set, one `commit()`, one `WriteBatch`), so it
carries over. The durability finding gets *stronger* with round-trip latency, not weaker:
846/1,008 over a local filesystem is a lower bound.

## Layout invariants

1. **Single authority.** Not affected — test-only; no new writer, materialization or index.
   It *checks* single authority rather than adding to it.
2. **Commit canonicality.** Unchanged, now verified on a second backend: after every kill
   the branch ref must resolve to exactly one `lix_commit` record and `lix_branch.commit_id`
   must agree with it.
3. **Derived views are caches.** Unchanged, now verified on a second backend: any generation
   visible through the serving read must exist in `<schema>_history()`, which is rebuilt
   from canonical records.
4. **Atomic publication.** The invariant this PR exists to qualify. On SlateDB it holds at
   every swept kill point: no torn write set, no mixed row generations, no CAS blob
   disagreeing with its rows.
5. **GC from refs.** Untouched.
6. **SQL reads canonical records.** Untouched.

## Public / adapter API

Public API unchanged. **No storage adapter API was added, changed, or removed.** The
harness's `CrashBackend` trait is test-local and its whole surface is `open_at(&Path)` plus
the existing `Storage` bounds; both shipping adapters already satisfy it with their
existing `open`.

## One behavioural change worth flagging in review

Losing an acknowledged commit was previously reported as a **consistency failure**. It is
now a **separate column**, and only fails the test when the write actually requested
durability.

That is deliberate, and it is the difference between two very different claims: an
empty-but-whole store after a crash is a state a fresh store is also in — the store is
*older* than the writer was told, not *damaged*. Collapsing the two would have reported
SlateDB as corrupting data when what it does is lose acknowledged data while staying whole.

It does not weaken the RocksDB arm in practice: RocksDB measures **0** lost
acknowledgements with the flag off and on. And the strict assertion is still there and now
runs in CI — `slatedb_durable_acknowledgement_survives_sigkill` hard-fails if a durable
acknowledgement is ever lost.

## Cost

The whole `crash_consistency_qualification` binary — all 6 tests, three 63-trial sweeps —
runs in **5.90 s** inside the gate (15.4 s at `--test-threads=1`). Adding the second
backend and the durable arm roughly doubled a ~3 s test. The deep sweep stays behind
`LIX_CRASH_CONSISTENCY_DEEP=1`, and the timed-trial count, row count, commit count, blob
size, seed and durability flag are all env-overridable.

## Gate

Full CI scope on ryzen-9950x-II (32c/186 GB), `--no-fail-fast`. Scope taken from
`.github/workflows/ci.yml` (the `clippy` and `test` matrix tasks), plus the features-OFF
pair `--all-features` structurally cannot catch. `16:07:00Z → 16:21:19Z`.

Printed inside the run, at the start and again at the end:

```
$ git rev-parse HEAD
b8f3fca58fba958e0f60748dfa9d353cfd5cd727
$ git status --porcelain
(empty)
```

| step | rc |
|---|---|
| `cargo clippy --profile test --workspace --all-targets --all-features -- -D warnings` | **0** |
| `cargo test --profile test --workspace --exclude lix_benchmarks --all-features --no-run` | **0** |
| `cargo test --profile test -p lix_benchmarks --features storage-benches,slatedb,root-replay-trace --no-run` | **0** |
| `cargo test --profile test --workspace --exclude lix_benchmarks --all-features --no-fail-fast` | **0** |
| `cargo test --profile test -p lix_benchmarks --features storage-benches,slatedb,root-replay-trace --no-fail-fast` | **0** |
| `cargo check -p lix --no-default-features` | **0** |
| `cargo check -p lix_js_sdk --target wasm32-unknown-unknown` | **0** |

**3522 passed, 0 failed, 57 ignored** across both test steps. Grepped for
`^test result: FAILED`, `^error`, and `panicked` — **0 matches**; the logs were not tailed.

The qualification binary inside that run:

```
running 6 tests
test crash_consistency_child_worker ... ok
test rocksdb_ignores_await_durable_and_therefore_proves_only_process_crash_consistency ... ok
test slatedb_honours_await_durable_and_acknowledges_non_durable_writes_early ... ok
test rocksdb_publication_window_survives_sigkill_at_every_storage_event ... ok
test slatedb_durable_acknowledgement_survives_sigkill ... ok
test slatedb_publication_window_survives_sigkill_at_every_storage_event ... ok

test result: ok. 6 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 5.90s
```
