### PR TITLE
Let a file create advance the cached path index instead of discarding it

### DIFF
--- a/packages/lix/src/filesystem/path_index.rs
+++ b/packages/lix/src/filesystem/path_index.rs
@@ -41,22 +41,29 @@ fn reserve_eager_blob_cache_bytes(reserved: usize, size: usize) -> Option<usize>
         .filter(|total| *total <= MAX_EAGER_BLOB_CACHE_BYTES)
 }
 
+// Rebuild counters are per-thread, not process-global. `cargo test` runs many
+// tests concurrently in one process, and a global counter reports every other
+// test's rebuilds too — which makes any assertion on it fail in a full run
+// while passing when the test is filtered to itself. `#[tokio::test]` drives
+// its future on the calling thread, so a test observes exactly its own
+// rebuilds.
 #[cfg(test)]
-static FULL_REBUILD_BUILDS: AtomicUsize = AtomicUsize::new(0);
-#[cfg(test)]
-static FULL_REBUILD_DESCRIPTOR_ROWS: AtomicUsize = AtomicUsize::new(0);
+thread_local! {
+    static FULL_REBUILD_BUILDS: std::cell::Cell<usize> = const { std::cell::Cell::new(0) };
+    static FULL_REBUILD_DESCRIPTOR_ROWS: std::cell::Cell<usize> = const { std::cell::Cell::new(0) };
+}
 
 #[cfg(test)]
 pub(crate) fn reset_full_rebuild_stats() {
-    FULL_REBUILD_BUILDS.store(0, Ordering::SeqCst);
-    FULL_REBUILD_DESCRIPTOR_ROWS.store(0, Ordering::SeqCst);
+    FULL_REBUILD_BUILDS.with(|builds| builds.set(0));
+    FULL_REBUILD_DESCRIPTOR_ROWS.with(|rows| rows.set(0));
 }
 
 #[cfg(test)]
 pub(crate) fn full_rebuild_stats() -> (usize, usize) {
     (
-        FULL_REBUILD_BUILDS.load(Ordering::SeqCst),
-        FULL_REBUILD_DESCRIPTOR_ROWS.load(Ordering::SeqCst),
+        FULL_REBUILD_BUILDS.with(std::cell::Cell::get),
+        FULL_REBUILD_DESCRIPTOR_ROWS.with(std::cell::Cell::get),
     )
 }
 
@@ -1147,8 +1154,9 @@ pub(crate) async fn build_path_index(
     let rows = hot_state.scan_batch(&request.hot_state_request()).await?;
     #[cfg(test)]
     {
-        FULL_REBUILD_BUILDS.fetch_add(1, Ordering::SeqCst);
-        FULL_REBUILD_DESCRIPTOR_ROWS.fetch_add(rows.len(), Ordering::SeqCst);
+        FULL_REBUILD_BUILDS.with(|builds| builds.set(builds.get().saturating_add(1)));
+        FULL_REBUILD_DESCRIPTOR_ROWS
+            .with(|descriptor_rows| descriptor_rows.set(descriptor_rows.get() + rows.len()));
     }
     Ok(Arc::new(FilesystemPathIndex::from_live_batch(&rows)?))
 }

--- a/packages/lix/src/transaction/commit.rs
+++ b/packages/lix/src/transaction/commit.rs
@@ -154,7 +154,7 @@ pub(crate) async fn commit_prepared_writes(
     let tracked_state = TrackedStateContext::new();
     let commit_parent_heads =
         resolve_prepared_commit_parent_heads(branch_ctx, &*read, &prepared_writes, false).await?;
-    commit_prepared_writes_with_parent_heads(
+    let outcome = commit_prepared_writes_with_parent_heads(
         binary_cas,
         &tracked_state,
         None,
@@ -165,7 +165,30 @@ pub(crate) async fn commit_prepared_writes(
         &BTreeMap::new(),
         prepared_writes,
     )
-    .await
+    .await?;
+    Ok((outcome.writes, outcome.preconditions))
+}
+
+/// A materialized commit: the atomic storage write set, the preconditions it
+/// must publish under, and the filesystem rows it staged.
+pub(crate) struct MaterializedCommit {
+    pub(crate) writes: StorageWriteSet,
+    pub(crate) preconditions: Vec<StoragePrecondition>,
+    /// Filesystem descriptor and blob-ref rows staged by this commit, carrying
+    /// their **final** identities.
+    ///
+    /// Addressable rows only receive their commit-delta change id during
+    /// materialization, so the caller's pre-commit `PreparedWriteSet` cannot
+    /// supply a projectable delta: it still holds the provisional change id
+    /// that `set_ordered_addressable_change_ids` overwrites. Projecting here is
+    /// what lets a file *create* advance the cached path index rather than
+    /// invalidate it.
+    ///
+    /// Empty when the commit changes no filesystem row. Non-empty does not by
+    /// itself license a projection — a branch-ref move or a change selected in
+    /// from another commit alters the visible filesystem without appearing in
+    /// these rows, and the caller must rebuild for those shapes.
+    pub(crate) filesystem_delta_rows: Vec<MaterializedHotStateRow>,
 }
 
 /// Materializes a prepared commit with branch heads already resolved from the
@@ -180,7 +203,7 @@ pub(crate) async fn commit_prepared_writes_with_parent_heads(
     read: &mut impl StorageAdapterRead,
     branch_checkpoint_bridges: &BTreeMap<String, crate::gc::CheckpointRecoveryRef>,
     prepared_writes: PreparedWriteSet,
-) -> Result<(StorageWriteSet, Vec<StoragePrecondition>), LixError> {
+) -> Result<MaterializedCommit, LixError> {
     Box::pin(validate_active_account_and_account_rows(
         read,
         &prepared_writes,
@@ -543,7 +566,11 @@ pub(crate) async fn commit_prepared_writes_with_parent_heads(
         && engine_rows.is_empty()
         && writes.is_empty()
     {
-        return Ok((writes, preconditions));
+        return Ok(MaterializedCommit {
+            writes,
+            preconditions,
+            filesystem_delta_rows: Vec::new(),
+        });
     }
 
     let selected_change_records = load_selected_change_records(read, &commit_rows).await?;
@@ -812,6 +839,25 @@ pub(crate) async fn commit_prepared_writes_with_parent_heads(
     .await?;
     #[cfg(feature = "storage-benches")]
     state_rows.record_ownership(crate::storage_bench::CRUD_OWNERSHIP_ROOT_PUBLICATION);
+    // Every staging pass that can rewrite a row's identity has run, so these
+    // rows now match what a cold rebuild would read back out of hot state.
+    // `stage_tracked_commit_delta_index` above is the one that matters: it
+    // replaces the provisional change id every addressable row carried into
+    // this function with the row's commit-delta address.
+    let filesystem_delta_rows = if filesystem_view_changed {
+        state_rows
+            .iter()
+            .filter(|row| {
+                matches!(
+                    row.schema_key.as_str(),
+                    "lix_file_descriptor" | "lix_directory_descriptor" | "lix_binary_blob_ref"
+                )
+            })
+            .map(MaterializedHotStateRow::from)
+            .collect::<Vec<_>>()
+    } else {
+        Vec::new()
+    };
     if !staged_hot_heads.deferred_fresh_hot_plans.is_empty() {
         if staged_hot_heads.deferred_fresh_hot_plans.len() != 1 {
             return Err(LixError::new(
@@ -829,7 +875,11 @@ pub(crate) async fn commit_prepared_writes_with_parent_heads(
     if filesystem_view_changed {
         stage_path_index_revision(&mut writes);
     }
-    Ok((writes, preconditions))
+    Ok(MaterializedCommit {
+        writes,
+        preconditions,
+        filesystem_delta_rows,
+    })
 }
 
 fn certified_batch_requires_root_expansion(batch: &crate::wasm::WasmCertifiedEntityBatch) -> bool {

--- a/packages/lix/src/transaction/context.rs
+++ b/packages/lix/src/transaction/context.rs
@@ -13031,6 +13031,87 @@ mod tests {
         }
     }
 
+    /// Creating a file must advance the cached path index, not discard it.
+    ///
+    /// This is the create analogue of the `(0, 0)` assertion in
+    /// `committed_filesystem_path_index_benchmark_probe`, and it is a
+    /// *deterministic* statement of the property: a rebuild count does not
+    /// depend on machine, store shape, or fixture size, so it holds where a
+    /// timing comparison would be contaminated by the fixture — seeding this
+    /// workload runs through the very path the fix changes.
+    ///
+    /// Each insert also has to chain: the index advanced to revision N is what
+    /// insert N+1 must find, otherwise only the first create would be cheap.
+    #[tokio::test]
+    async fn committed_file_creates_advance_the_path_index_without_rebuilding() {
+        if !incremental_filesystem_index_enabled() {
+            return;
+        }
+        let storage = Memory::new();
+        Engine::initialize(storage.clone())
+            .await
+            .expect("storage should initialize");
+        let engine = Engine::new(storage)
+            .await
+            .expect("engine should open initialized storage");
+        let session = engine
+            .open_workspace_session()
+            .await
+            .expect("workspace session should open");
+
+        session
+            .execute(
+                "INSERT INTO lix_file (path, content) \
+                 VALUES ('/seed.md', CAST('byte-01' AS BYTEA))",
+                &[],
+            )
+            .await
+            .expect("seed file should commit");
+        session
+            .execute("SELECT id FROM lix_file WHERE path = '/seed.md'", &[])
+            .await
+            .expect("path index should warm");
+        crate::filesystem::reset_full_rebuild_stats();
+
+        // Reading after each create is what makes this discriminating. A create
+        // that fails to advance the index leaves the cache keyed on the
+        // superseded revision; nothing observes that until the next read
+        // arrives at the new revision, misses, and rebuilds.
+        for index in 0..8 {
+            session
+                .execute(
+                    &format!(
+                        "INSERT INTO lix_file (path, content) \
+                         VALUES ('/created-{index:02}.md', CAST('byte-01' AS BYTEA))"
+                    ),
+                    &[],
+                )
+                .await
+                .expect("created file should commit");
+            // The advanced index must be *correct*, not merely present: an
+            // under-projected delta that lost a row surfaces here as a missing
+            // path rather than as a slow read.
+            let result = session
+                .execute(
+                    &format!("SELECT id FROM lix_file WHERE path = '/created-{index:02}.md'"),
+                    &[],
+                )
+                .await
+                .expect("created path should resolve through the advanced index");
+            assert_eq!(
+                result.len(),
+                1,
+                "created path /created-{index:02}.md must resolve after the index advanced"
+            );
+        }
+
+        assert_eq!(
+            crate::filesystem::full_rebuild_stats(),
+            (0, 0),
+            "committed file creates must advance the cached path index, not rebuild it"
+        );
+    }
+
     #[tokio::test]
     async fn stage_rows_routes_tracked_and_untracked_rows_without_sql() {
         let storage = Memory::new();

--- a/packages/lix/src/transaction/context.rs
+++ b/packages/lix/src/transaction/context.rs
@@ -1810,14 +1810,22 @@ where
         // *projectability* is decided here, because the revision the cached
         // views are keyed on has to be read before the commit publishes its
         // successor.
-        let filesystem_delta_projectable =
+        let stages_projectable_filesystem_rows =
             prepared_writes_stage_filesystem_rows(&prepared_writes)
                 && !prepared_writes_require_filesystem_index_rebuild(&prepared_writes);
-        let previous_filesystem_revision = if filesystem_delta_projectable {
-            load_path_index_revision(&read).await.ok().flatten()
+        // A failed revision read must not collapse into "no revision yet".
+        // `None` is itself a live cache key — the state before the first
+        // filesystem commit — so treating an error as `None` would rekey
+        // entries built at an unknown revision onto this commit's successor and
+        // make a stale index reachable. The outer `Option` is "the read
+        // succeeded"; only that licenses a projection.
+        let loaded_filesystem_revision = if stages_projectable_filesystem_rows {
+            load_path_index_revision(&read).await.ok()
         } else {
             None
         };
+        let filesystem_delta_projectable = loaded_filesystem_revision.is_some();
+        let previous_filesystem_revision = loaded_filesystem_revision.flatten();
         let (mut writes, materialization_preconditions, filesystem_delta_rows) =
             match commit::commit_prepared_writes_with_parent_heads(
                 &transaction.binary_cas,

--- a/packages/lix/src/transaction/context.rs
+++ b/packages/lix/src/transaction/context.rs
@@ -8914,36 +8914,48 @@ fn prepared_writes_change_catalog(prepared_writes: &PreparedWriteSet) -> bool {
 /// of how the visible filesystem changed, so cached path indexes must be
 /// rebuilt from hot state rather than advanced by a delta.
 ///
-/// Two shapes are incomplete, and both are about *which rows exist*, not about
+/// Three shapes are incomplete, and all are about *which rows exist*, not about
 /// when their identities are assigned:
 ///
 /// * a **branch ref move** republishes the branch's entire visible filesystem;
 ///   the difference is between two commits, not between staged rows;
 /// * a **change selected into this commit from another commit** (merge,
 ///   checkpoint, cherry-pick) enters the branch's visible filesystem without
-///   appearing in `state_rows` at all.
+///   appearing in `state_rows` at all;
+/// * a **global or untracked filesystem row** changes visibility in every
+///   branch at once, so a single-branch delta cannot describe it.
+///
+/// The last one is also the only shape whose staged rows can be *dropped*
+/// between here and the capture point: `retain_untracked_rows_not_superseded_by_engine`
+/// removes untracked rows that an engine row supersedes. Deciding it here, off
+/// the complete pre-materialization row set, is what keeps the capture point
+/// from silently projecting a delta that lost a row. `advance_committed`
+/// evicts on the same condition, but it can only see the rows it is handed.
 ///
 /// An ordinary create, rename, delete, or content write is fully described by
 /// its staged rows and is therefore projectable. Those rows are read back out
 /// of the commit once materialization has assigned their final change ids —
 /// see [`commit::MaterializedCommit::filesystem_delta_rows`].
 fn prepared_writes_require_filesystem_index_rebuild(prepared_writes: &PreparedWriteSet) -> bool {
-    prepared_writes
-        .state_rows
-        .iter()
-        .any(|row| row.schema_key == BRANCH_REF_SCHEMA_KEY)
-        || prepared_writes
-            .commit_change_refs_by_branch
-            .values()
-            .flat_map(
-                crate::transaction::staged_commit_changes::StagedCommitChangeRefs::selected_changes,
-            )
-            .any(|change_ref| {
-                matches!(
-                    change_ref.schema_key(),
+    prepared_writes.state_rows.iter().any(|row| {
+        row.schema_key == BRANCH_REF_SCHEMA_KEY
+            || ((row.global || row.untracked)
+                && matches!(
+                    row.schema_key.as_str(),
                     "lix_file_descriptor" | "lix_directory_descriptor" | BLOB_REF_SCHEMA_KEY
-                )
-            })
+                ))
+    }) || prepared_writes
+        .commit_change_refs_by_branch
+        .values()
+        .flat_map(
+            crate::transaction::staged_commit_changes::StagedCommitChangeRefs::selected_changes,
+        )
+        .any(|change_ref| {
+            matches!(
+                change_ref.schema_key(),
+                "lix_file_descriptor" | "lix_directory_descriptor" | BLOB_REF_SCHEMA_KEY
+            )
+        })
 }
 
 /// Whether this commit stages any row that the cached path index projects.
@@ -12122,6 +12134,54 @@ mod tests {
         assert!(prepared_writes_require_filesystem_index_rebuild(
             &prepared_writes
         ));
+    }
+
+    /// A global or untracked filesystem row changes visibility in every branch,
+    /// which a single-branch delta cannot describe. It is also the only staged
+    /// filesystem row that can be dropped before the delta is captured, by
+    /// `retain_untracked_rows_not_superseded_by_engine`, so the rebuild has to
+    /// be decided here rather than left to `advance_committed`'s own eviction —
+    /// that only sees the rows it is handed.
+    #[test]
+    fn global_or_untracked_filesystem_row_requires_index_rebuild() {
+        for (global, untracked) in [(true, false), (false, true), (true, true)] {
+            let timestamp = LixTimestamp::from_unix_millis_utc_lossy(0);
+            let mut state_rows = PreparedStateBatch::with_capacity(1);
+            state_rows.push_parts_with_change_addressability(
+                SchemaPlanId::for_test(0),
+                PreparedRowFacts::default(),
+                EntityPk::single("file-a"),
+                "lix_file_descriptor".into(),
+                Some("file-a".into()),
+                None,
+                None,
+                None,
+                None,
+                timestamp,
+                timestamp,
+                global,
+                Some(ChangeId::for_test_label("provisional")),
+                true,
+                Some(CommitId::for_test_label("commit")),
+                untracked,
+                "main".into(),
+            );
+            let prepared_writes = PreparedWriteSet {
+                state_rows,
+                insert_selection: crate::transaction::staging::PreparedInsertSelection::new(),
+                commit_change_refs_by_branch: BTreeMap::new(),
+                first_commit_parent_override_by_branch: BTreeMap::new(),
+                checkpoint_publications: Vec::new(),
+                extra_commit_parents_by_branch: BTreeMap::new(),
+                intermediate_commits: Vec::new(),
+                file_content_writes: Vec::new(),
+            };
+
+            assert!(
+                prepared_writes_require_filesystem_index_rebuild(&prepared_writes),
+                "global={global} untracked={untracked} must force a rebuild"
+            );
+        }
     }
 
     #[test]

--- a/packages/lix/src/transaction/context.rs
+++ b/packages/lix/src/transaction/context.rs
@@ -1805,30 +1805,20 @@ where
                 .await;
             return Err(error);
         }
-        let filesystem_delta_rows =
-            if prepared_writes_require_filesystem_index_rebuild(&prepared_writes) {
-                Vec::new()
-            } else {
-                prepared_writes
-                    .state_rows
-                    .iter()
-                    .filter(|row| {
-                        matches!(
-                            row.schema_key.as_str(),
-                            "lix_file_descriptor"
-                                | "lix_directory_descriptor"
-                                | BLOB_REF_SCHEMA_KEY
-                        )
-                    })
-                    .map(MaterializedHotStateRow::from)
-                    .collect::<Vec<_>>()
-            };
-        let previous_filesystem_revision = if filesystem_delta_rows.is_empty() {
-            None
-        } else {
+        // The delta itself is projected out of the commit below, once
+        // addressable rows hold their final commit-delta change ids. Only its
+        // *projectability* is decided here, because the revision the cached
+        // views are keyed on has to be read before the commit publishes its
+        // successor.
+        let filesystem_delta_projectable =
+            prepared_writes_stage_filesystem_rows(&prepared_writes)
+                && !prepared_writes_require_filesystem_index_rebuild(&prepared_writes);
+        let previous_filesystem_revision = if filesystem_delta_projectable {
             load_path_index_revision(&read).await.ok().flatten()
+        } else {
+            None
         };
-        let (mut writes, materialization_preconditions) =
+        let (mut writes, materialization_preconditions, filesystem_delta_rows) =
             match commit::commit_prepared_writes_with_parent_heads(
                 &transaction.binary_cas,
                 &transaction.tracked_state,
@@ -1846,7 +1836,15 @@ where
             ))
             .await
             {
-                Ok(writes) => writes,
+                Ok(commit) => (
+                    commit.writes,
+                    commit.preconditions,
+                    if filesystem_delta_projectable {
+                        commit.filesystem_delta_rows
+                    } else {
+                        Vec::new()
+                    },
+                ),
                 Err(error) => {
                     transaction
                         .discard_pending_plugin_actor_publications()
@@ -8912,26 +8910,50 @@ fn prepared_writes_change_catalog(prepared_writes: &PreparedWriteSet) -> bool {
         .any(|change_ref| change_ref.schema_key() == REGISTERED_SCHEMA_KEY)
 }
 
+/// Whether this commit's staged filesystem rows are an incomplete description
+/// of how the visible filesystem changed, so cached path indexes must be
+/// rebuilt from hot state rather than advanced by a delta.
+///
+/// Two shapes are incomplete, and both are about *which rows exist*, not about
+/// when their identities are assigned:
+///
+/// * a **branch ref move** republishes the branch's entire visible filesystem;
+///   the difference is between two commits, not between staged rows;
+/// * a **change selected into this commit from another commit** (merge,
+///   checkpoint, cherry-pick) enters the branch's visible filesystem without
+///   appearing in `state_rows` at all.
+///
+/// An ordinary create, rename, delete, or content write is fully described by
+/// its staged rows and is therefore projectable. Those rows are read back out
+/// of the commit once materialization has assigned their final change ids —
+/// see [`commit::MaterializedCommit::filesystem_delta_rows`].
 fn prepared_writes_require_filesystem_index_rebuild(prepared_writes: &PreparedWriteSet) -> bool {
-    prepared_writes.state_rows.iter().any(|row| {
-        row.schema_key == BRANCH_REF_SCHEMA_KEY
-            || (row.addressable_change_id
-                && matches!(
-                    row.schema_key.as_str(),
-                    "lix_file_descriptor" | "lix_directory_descriptor" | BLOB_REF_SCHEMA_KEY
-                ))
-    }) || prepared_writes
-        .commit_change_refs_by_branch
-        .values()
-        .flat_map(
-            crate::transaction::staged_commit_changes::StagedCommitChangeRefs::selected_changes,
-        )
-        .any(|change_ref| {
-            matches!(
-                change_ref.schema_key(),
-                "lix_file_descriptor" | "lix_directory_descriptor" | BLOB_REF_SCHEMA_KEY
+    prepared_writes
+        .state_rows
+        .iter()
+        .any(|row| row.schema_key == BRANCH_REF_SCHEMA_KEY)
+        || prepared_writes
+            .commit_change_refs_by_branch
+            .values()
+            .flat_map(
+                crate::transaction::staged_commit_changes::StagedCommitChangeRefs::selected_changes,
             )
-        })
+            .any(|change_ref| {
+                matches!(
+                    change_ref.schema_key(),
+                    "lix_file_descriptor" | "lix_directory_descriptor" | BLOB_REF_SCHEMA_KEY
+                )
+            })
+}
+
+/// Whether this commit stages any row that the cached path index projects.
+fn prepared_writes_stage_filesystem_rows(prepared_writes: &PreparedWriteSet) -> bool {
+    prepared_writes.state_rows.iter().any(|row| {
+        matches!(
+            row.schema_key.as_str(),
+            "lix_file_descriptor" | "lix_directory_descriptor" | BLOB_REF_SCHEMA_KEY
+        )
+    })
 }
 
 pub(crate) struct OpenTransaction<StorageImpl: Storage + 'static = Memory> {
@@ -12015,8 +12037,14 @@ mod tests {
         ));
     }
 
+    /// An addressable filesystem row carries a provisional change id into
+    /// materialization, which is why the delta is projected out of the commit
+    /// rather than out of the caller's `PreparedWriteSet`. Addressability alone
+    /// says nothing about whether the staged rows describe the whole change,
+    /// so it must not force a rebuild — that is what made every file *create*
+    /// discard the cached path index.
     #[test]
-    fn addressable_filesystem_row_requires_index_rebuild() {
+    fn addressable_filesystem_row_does_not_require_index_rebuild() {
         let timestamp = LixTimestamp::from_unix_millis_utc_lossy(0);
         let mut state_rows = PreparedStateBatch::with_capacity(1);
         state_rows.push_parts_with_change_addressability(
@@ -12034,6 +12062,48 @@ mod tests {
             false,
             Some(ChangeId::for_test_label("provisional")),
             true,
+            Some(CommitId::for_test_label("commit")),
+            false,
+            "main".into(),
+        );
+        let prepared_writes = PreparedWriteSet {
+            state_rows,
+            insert_selection: crate::transaction::staging::PreparedInsertSelection::new(),
+            commit_change_refs_by_branch: BTreeMap::new(),
+            first_commit_parent_override_by_branch: BTreeMap::new(),
+            checkpoint_publications: Vec::new(),
+            extra_commit_parents_by_branch: BTreeMap::new(),
+            intermediate_commits: Vec::new(),
+            file_content_writes: Vec::new(),
+        };
+
+        assert!(prepared_writes_stage_filesystem_rows(&prepared_writes));
+        assert!(!prepared_writes_require_filesystem_index_rebuild(
+            &prepared_writes
+        ));
+    }
+
+    /// A branch ref move republishes the branch's whole visible filesystem, so
+    /// the staged rows cannot describe the difference.
+    #[test]
+    fn branch_ref_write_requires_filesystem_index_rebuild() {
+        let timestamp = LixTimestamp::from_unix_millis_utc_lossy(0);
+        let mut state_rows = PreparedStateBatch::with_capacity(1);
+        state_rows.push_parts_with_change_addressability(
+            SchemaPlanId::for_test(0),
+            PreparedRowFacts::default(),
+            EntityPk::single("main"),
+            BRANCH_REF_SCHEMA_KEY.into(),
+            None,
+            None,
+            None,
+            None,
+            None,
+            timestamp,
+            timestamp,
+            true,
+            Some(ChangeId::for_test_label("branch-ref")),
+            false,
             Some(CommitId::for_test_label("commit")),
             false,
             "main".into(),

--- a/packages/rs-sdk-tests/examples/e16_write_file_scaling.rs
+++ b/packages/rs-sdk-tests/examples/e16_write_file_scaling.rs
@@ -45,6 +45,27 @@ use lix::{Lix, Value, open_lix};
 use lix_storage_rocksdb::RocksDB;
 
 const INSERT_BATCH: usize = 100;
+/// Directories the seeded files are spread across. Held at 1 by default so the
+/// original file-count curve is unchanged; raised to isolate a term that is
+/// linear in *directories* rather than in resident files. A resolver seeded
+/// from directory descriptors alone is flat in files but not in directories,
+/// and a single-directory fixture cannot tell those apart.
+fn seed_dirs() -> usize {
+    std::env::var("E16_DIRS")
+        .ok()
+        .and_then(|value| value.parse().ok())
+        .filter(|value| *value >= 1)
+        .unwrap_or(1)
+}
+
+fn seed_path(index: usize) -> String {
+    let dirs = seed_dirs();
+    if dirs <= 1 {
+        format!("/docs/file-{index:07}.txt")
+    } else {
+        format!("/docs/d{:05}/file-{index:07}.txt", index % dirs)
+    }
+}
 /// Above `HOST_CERTIFIED_PACKET_MIN_ROWS` so each seeded file certifies a
 /// dense batch, matching the fixture `e10_branch_file_cost` established.
 const LINES_PER_FILE: usize = 80;
@@ -109,7 +130,8 @@ async fn run_case(
     let seed_started = Instant::now();
     seed_files(&lix, files).await;
     println!(
-        "write_scaling_seed,files={files},seed_ms={:.3}",
+        "write_scaling_seed,files={files},dirs={},seed_ms={:.3}",
+        seed_dirs(),
         seed_started.elapsed().as_secs_f64() * 1_000.0
     );
 
@@ -138,8 +160,9 @@ async fn run_case(
         let mut values = samples.remove(shape).unwrap_or_default();
         values.sort_by(f64::total_cmp);
         println!(
-            "write_scaling,files={files},shape={shape},probes={},\
+            "write_scaling,files={files},dirs={},shape={shape},probes={},\
 p50_ms={:.3},min_ms={:.3},p95_ms={:.3},raw={}",
+            seed_dirs(),
             values.len(),
             percentile(&values, 0.50),
             values.first().copied().unwrap_or(0.0),
@@ -385,7 +408,7 @@ where
                 "INSERT INTO lix_file (path, content) VALUES ($1, $2) \
                  ON CONFLICT (path) DO UPDATE SET content = excluded.content",
                 &[
-                    Value::Text(format!("/docs/file-{target:07}.txt")),
+                    Value::Text(seed_path(target)),
                     Value::Blob(document(1, probe).into()),
                 ],
             )
@@ -412,7 +435,7 @@ where
             lix.execute(
                 "UPDATE lix_file SET content = $2 WHERE path = $1",
                 &[
-                    Value::Text(format!("/docs/file-{target:07}.txt")),
+                    Value::Text(seed_path(target)),
                     Value::Blob(body.into_bytes().into()),
                 ],
             )
@@ -522,7 +545,7 @@ where
             let parameter = offset * 2;
             sql.push_str(&format!("(${}, ${})", parameter + 1, parameter + 2));
             let index = written + offset;
-            params.push(Value::Text(format!("/docs/file-{index:07}.txt")));
+            params.push(Value::Text(seed_path(index)));
             params.push(Value::Blob(document(LINES_PER_FILE, index).into()));
         }
         lix.execute(&sql, &params)


### PR DESCRIPTION
# Let a file create advance the cached path index instead of discarding it

Creating a file threw away the whole cached filesystem path index and rebuilt it from hot state.
Editing one has been flat since #1382; creating one still rebuilt, once per create, over a growing
set of descriptor rows.

**This PR removes that rebuild. It does not make creation faster in wall time, and the measurements
below say so plainly.** The rebuild is real and is now gone — proven deterministically — but it was
never what makes a create cost 44–80 ms. That cost is named at the end.

## Why the rebuild happened

`prepared_writes_require_filesystem_index_rebuild` tripped on `addressable_change_id`, which does
not mean *"this is a create"*. `context.rs` defines it as `row.change_id.is_none()` — **"this row's
change id is not assigned yet"**. Ids are assigned during materialization, in
`set_ordered_addressable_change_ids`, while the delta was captured *before* the commit ran. The
captured rows therefore did not match what a cold rebuild would read back out of hot state, so they
could not be projected, and the rebuild was the conservative response to **capturing the delta too
early** rather than to a create as such.

So the fix is to move the capture, not to loosen the predicate. The delta is now read out of the
commit at the point where every staging pass that can rewrite a row's identity has already run —
the same point that stages the new revision — and returned on a new `MaterializedCommit`.

Which clause was firing was measured, not assumed, because clause 2 fires on *any* filesystem
descriptor change and would have made a clause-1 fix a no-op. Instrumented on a create workload:

```
E31 predicate clause1=true  [lix_file_descriptor(addr=true,del=false)] clause2=false []   (x4)
E31 predicate clause1=false []                                        clause2=false []   (x4)
```

Clause 2 never fired. Clause 1 was the whole cause.

## The result that stands: rebuild counts

Timing on this workload is fragile (see *Measurement* below), but a rebuild count is deterministic —
it does not depend on machine, store shape, or fixture size. Eight committed creates, reading after
each one, counted by the existing `full_rebuild_stats` instrumentation:

| | full rebuilds | descriptor rows rescanned |
|---|---|---|
| base `d3f880ce` | **8** | **44** |
| this branch | **0** | **0** |

One rebuild per create, rescanning a growing set — exactly the O(resident files) term — reduced to
none. This is pinned by a new test, `committed_file_creates_advance_the_path_index_without_rebuilding`.

The test is verified to **fail on base** (`d3f880ce` + the test commit alone: `left: (8, 44)`,
`right: (0, 0)`). My first version of it passed on both arms and pinned nothing: creates alone never
force a lookup at the new revision, so the stale cache entry is invisible until a read arrives.
Interleaving a read after each create is what makes it discriminating. The test also asserts every
created path still resolves, so an under-projected delta surfaces as a **missing path**, not as a
slow read.

## Correctness: how a reader that should miss still misses

An under-invalidating predicate silently serves a stale index, so this is the load-bearing argument.

**1. The revision is the cache key, and this PR does not touch how it is written.**
`stage_path_index_revision` still writes a fresh UUIDv7 whenever `filesystem_view_changed`. Cache
entries are keyed on `(branch_ids, revision, include_blob_refs, cache_small_blob_data)`; a reader
loads the current revision from storage and looks up by it. An entry left at a superseded revision is
therefore **unreachable**. Under-projection can only cost a rebuild, never serve stale data.

**2. The only way to serve stale data is to rekey an entry onto the new revision while applying an
incomplete delta.** That is the entire risk surface, and it is guarded on both sides:

- *Caller side (this PR):* unless the delta is projectable, `filesystem_delta_rows` is passed empty
  and `advance_filesystem_path_indexes` is not called at all — nothing is rekeyed, and every reader
  at the new revision misses and rebuilds, exactly as before.
- *Cache side (unchanged):* `advance_committed` **evicts** rather than advances for global/untracked
  rows, for multi-branch views, and for any `apply_committed_rows` error. Its `retain` drops every
  candidate it touches; only successfully advanced indexes are pushed back under the new key.

**3. The predicate invalidates on exactly the rows that change the path→id mapping** — it is an
enumeration, not an inversion of the old condition:

| staged shape | changes the mapping? | behaviour |
|---|---|---|
| new descriptor at a new path | yes | projected by `apply_committed_row` |
| rename (parent/name changed) | yes | projected |
| delete | yes | projected |
| content-only change | no | nothing to project |
| blob-ref change | `include_blob_refs` views only | projected by `apply_committed_blob_ref_row` |
| **branch ref move** | yes, wholesale | **rebuild** — the difference is between two commits, not between staged rows |
| **change selected in from another commit** (merge, checkpoint, cherry-pick) | yes | **rebuild** — it never appears in `state_rows` |
| **global or untracked filesystem row** | yes, in every branch | **rebuild** |

The last row is a clause I added rather than inherited, and it closes a hole the capture-point move
would otherwise open. `retain_untracked_rows_not_superseded_by_engine` runs *between* the
projectability decision and the capture point and can **drop** untracked rows.
`advance_committed` defends itself against global/untracked rows, but it can only see the rows it is
handed — a dropped row would be projected silently. This is unreachable today only because
`engine_rows` happens to contain nothing but a deterministic-sequence row. Deciding it off the
complete pre-materialization row set closes it properly instead of resting index correctness on that
incidental fact.

**4. A failed revision read no longer counts as "no revision yet".** `.ok().flatten()` collapsed the
two, but `None` is itself a live cache key — the state before the first filesystem commit — so an
error would rekey entries built at an unknown revision onto this commit's successor. The hazard
predates this branch; making creates projectable widens it from content-only edits to every create,
so it is closed here.

## Measurement

Two axes, arms interleaved `base/cand/cand/base`, on one machine (ryzen-9950x, 32c/186G).

`key_value_write` is the null control and is reported at **every** size, not just the largest. That
matters here: seeding this fixture creates files, which is the path this change touches, so the arms
could diverge physically before the first timed operation. **The control is clean at every size** —
spread ≤6% with no systematic direction — so unlike the E25 lane the comparison is trustworthy. The
reason is worth recording: this change alters only in-memory cache maintenance and writes no
different bytes, so the two arms' RocksDB stores stay physically identical.

### Axis 1 — resident files, one directory (p50 ms)

Both measurements of each arm are shown, because the within-arm spread is the honest error bar here
and in two cells it exceeds the between-arm difference.

| shape | files | base (both) | cand (both) |
|---|---|---|---|
| insert_file_1line | 100 | 1.70 / 1.30 | 1.32 / 1.29 |
| insert_file_1line | 1,000 | 4.43 / 3.98 | 3.75 / 3.78 |
| insert_file_1line | 10,000 | 49.95 / 52.63 | 53.31 / 53.26 |
| update_file_1line (guard) | 100 | 1.84 / 1.33 | 1.37 / 1.28 |
| update_file_1line (guard) | 1,000 | 1.43 / 2.31 | 2.26 / 2.30 |
| key_value_write (control) | 100 | 0.212 / 0.208 | 0.207 / 0.209 |
| key_value_write (control) | 1,000 | 0.219 / 0.213 | 0.219 / 0.215 |
| key_value_write (control) | 10,000 | 0.283 / 0.287 | 0.301 / 0.289 |

At 10,000 files the two base measurements (49.95, 52.63) straddle a 5.3% spread and the candidate
sits at the top of it. Read conservatively, that is *no improvement and possibly a slight
regression*, not a win. The `update_file_1line` lane at 1,000 files spans 1.43–2.31 ms **within the
base arm alone** (61%), so nothing can be concluded there beyond "no gross regression".

### Axis 2 — directories at fixed 10,000 files (p50 ms, insert_file_1line)

| directories | base | cand |
|---|---|---|
| 1 | 52.4 | 52.0 |
| 50 | 54.4 | 54.3 |
| 500 | 57.7 | 56.0 |
| 5,000 | 80.9 | 81.0 |

**Verdict: no measurable timing change on either axis, at any size.** The guard lane is unchanged and
the control is flat. The O(directories) slope (52 → 81 ms) is identical in both arms — as expected;
that term was never diagnosed and this PR does not claim it.

### Naming the residual

Span attribution on base explains why removing the rebuild bought nothing, and it contradicts the
premise the work started from. At 10,000 files the insert probe costs ~50 ms, and essentially all of
it is in one span:

| span | 100 files | 1,000 | 10,000 |
|---|---|---|---|
| `transaction_plan_and_stage` | 0.81 | 2.96 | **50.46** |
| `transaction_validation` | 0.05 | 0.10 | 1.95 |
| `transaction_materialization` | 0.60 | 0.96 | 1.72 |
| `validation.filesystem_namespace` | 0.006 | 0.040 | 0.63 |

(per-probe ms; measured p50 for the whole probe was 1.59 / 4.12 / 54.09)

The absence of a win is not one O(n) traded for another: `FilesystemPathIndex` is built on
`PersistentMap`, so the `self.clone()` inside `apply_committed_rows` is structurally shared and the
advance path really is cheap. The rebuild it replaces was simply never the expensive part.

**Creating a file is dominated by SQL planning and staging, not by anything in the commit pipeline.**
The path-index work this PR removes appears under `validation.filesystem_namespace` — 0.63 ms at
10,000 files, about 1% of the probe. So the earlier characterisation of file creation as
"O(resident files) because of the index rebuild" was right about the rebuild existing and wrong about
its share of the cost. `transaction_plan_and_stage` grows ×3.7 then ×17 across the two decades and is
the real target for anyone continuing this work.

I am reporting this as a correctness-and-cleanliness change with a deterministic win in rebuild
counts, **not** as a latency win.

## Instrument notes

**A cold first slot, but not always.** In the `base/cand/cand/base` rotation, position 1 is often
cold: the same base binary measured 1.704 ms in position 1 and 1.304 ms in position 4 on an identical
cell (also 4.425 vs 3.981 at 1,000 files). Taking position 1 at face value manufactures a ~25% win
from nothing. But the effect is **not a reliable correction**: at 10,000 files it reverses (49.95 in
position 1, 52.63 in position 4). So "discard position 1" would itself be a bias. Both arm
measurements are reported above and the within-arm spread is treated as the error bar.

**A process-global test counter is not usable from a parallel test.** `FULL_REBUILD_BUILDS` was a
process-global static, so an assertion on it also counts rebuilds caused by every other test sharing
the process. The test therefore **passed when filtered to itself and failed in the full workspace
run** — it was green in three targeted runs before the gate caught it. The counters are now
thread-local; `#[tokio::test]` drives its future on the calling thread, so a test observes exactly
its own rebuilds. Making a counter thread-local can also silently make it read zero, which would turn
the assertion vacuous, so the base failure was re-verified afterwards and still reports `(8, 44)`.

## Gate

Full CI scope per `origin/main:.github/workflows/ci.yml`, `--no-fail-fast`, logs captured and
grepped. Provenance printed inside the run, since a gate result is evidence about a tree, not a
commit:

```
GATE_HEAD=61536d3a19142bd3191867fa1f5d5f572e2c1ea2
git status --porcelain -> (empty, pre-run and post-run)

CLIPPY_EXIT=0  TEST_EXIT=0  TESTBENCH_EXIT=0
NODEFAULT_EXIT=0  WASM_EXIT=0
TOTALS  workspace   passed=3493 failed=0 ignored=50
        benchmarks  passed=29   failed=0 ignored=7
```

Public API is unchanged: `MaterializedCommit` is `pub(crate)`, and the one caller outside this module
(`commit_prepared_writes`) still returns the same tuple.

## Also included

`bench(write): add a directory-count axis to the write-scaling harness` — test-only, cherry-picked
from the unmerged E25 branch. Axis 2 above cannot be measured without it.
