### PR TITLE
docs(changenotes): cover round-5 user-facing changes

### DIFF
--- a/.changenotes/fix-truncated-scans-and-rebuild-failure.md
+++ b/.changenotes/fix-truncated-scans-and-rebuild-failure.md
@@ -1,0 +1,7 @@
+---
+type: patch
+---
+
+Fixed two data-loss bugs: silent row loss on repositories with more than 1024 plugin-backed files, and a rebuild that could fail part-way and leave a branch unreadable.
+
+On a repository with more than 1024 plugin-backed files, reads could return fewer rows than exist, and creating a branch could permanently drop the certified manifests of files past the 1024th — the new branch was missing those files with no error and no warning. Separately, rebuilding a branch's tracked state across a deep history could fail with a duplicate-mutation error, leaving the repository unreadable in that mode; that failure was fail-closed, so it never returned incorrect data.

--- a/.changenotes/no-stall-on-first-commit-after-import.md
+++ b/.changenotes/no-stall-on-first-commit-after-import.md
@@ -1,0 +1,7 @@
+---
+type: patch
+---
+
+The first commit after a bulk import no longer stalls for several hundred milliseconds.
+
+A bulk import could fill the storage engine's write buffers, so the next commit waited on a flush — around 350 ms, against a typical commit of about 20 ms. That commit now takes about 22 ms, in line with every other commit.

--- a/.changenotes/x86-64-v2-baseline-for-x86-64-builds.md
+++ b/.changenotes/x86-64-v2-baseline-for-x86-64-builds.md
@@ -1,0 +1,7 @@
+---
+type: patch
+---
+
+x86_64 builds now require SSE4.2 and PCLMULQDQ, raising the baseline to roughly `x86-64-v2`.
+
+These instructions let the storage engine compile its hardware CRC32C implementation instead of the software fallback, which speeds up reads of large binary files. Every x86_64 CPU since roughly 2009 (Intel Nehalem, AMD Bulldozer) provides them, but a build targeting an older baseline will no longer run. ARM builds are unaffected.


### PR DESCRIPTION
Doc-only. Adds three `.changenotes/` fragments covering the round-5 changes a user would act on, so the release changelog does not ship with them missing.

Branched off `550aebf8` (head after #1395).

## The three fragments

| file | covers | why it passes the "would a user act on it" test |
|---|---|---|
| `fix-truncated-scans-and-rebuild-failure.md` | #1367, #1381 | Data loss. Both triggers are stated concretely so a reader can tell whether they were affected: more than 1024 plugin-backed files, and a tracked-state rebuild over a deep history. |
| `no-stall-on-first-commit-after-import.md` | #1383 | ~350 ms → ~22 ms on the first commit after a bulk import. Observable in a real workload. |
| `x86-64-v2-baseline-for-x86-64-builds.md` | #1389 | A build requirement, not a perf note. This is the only round-5 change that can stop lix building or running where it used to. |

## What was deliberately left out

The round merged 29 PRs. Most are internal cuts, instruments, or lane-level wins that a user will not observe end to end, and listing them would promise something the round does not deliver. Specifically excluded: the path-index cache (#1382), the 512-row commit-delta cliff (#1386), the CRC32C *read gain* as a headline (#1389 appears here only as the build requirement), the declared-column index guard (#1390), the CAS reclaim projection (#1375), the manifest schema-key sets (#1374), the working-diff routes (#1366), and `ValueIntegrity` (#1393).

**The path-filtered history win is not restated here because it is already covered** by the existing `.changenotes/file-history-path-pruning.md` and `.changenotes/bounded-history-traversal.md`. A second fragment would have duplicated it in the generated changelog.

## Validation

```
node scripts/validate-changes.mjs
Validated 42 change fragment(s).
```

39 existing + 3 added. **Node v22.22.3 (major 22)**; CI runs Node 24, so this is evidence rather than proof for the JS toolchain, though this script uses no version-sensitive API.

There is no `--dry-run` flag on `scripts/prepare-release.mjs` — it mutates in place. The rendered entry was previewed instead by calling the exported pure functions `loadChanges` / `changelogEntry` from `scripts/release.mjs` and printing the result, writing nothing. All three fragments render in the `### Patch` section as intended.

No full CI-scope gate: the diff is three Markdown files, touches no Rust, and changes no build input. The separate CI-scope gate on `b7961358` (the head before #1395) passed 3525/0 with 0 clippy warnings.

Wording is the owner's to revise — these are drafted to be replaced if they read wrong.
