### PR TITLE
perf(gc): reclaim change locators on retirement, and measure what the sweep actually retires

### DIFF
--- a/packages/engine-benchmarks/examples/e29_locator_leak.rs
+++ b/packages/engine-benchmarks/examples/e29_locator_leak.rs
@@ -144,21 +144,59 @@ async fn main() {
             .await
             .expect("insert the first revision");
 
-        // Each rewrite is its own commit, so each one retires the previous
-        // commit's physical authority while the live collection stays at one
-        // row. New entity keys are deliberately not used here: this arm asks
-        // what an in-place rewrite stream leaves behind.
+        // Two churn shapes, because they produce different change-id
+        // populations: an in-place rewrite stream reuses one entity key, while
+        // distinct inserts mint a new entity (and a new change) every time.
+        //
+        // Checkpoints matter more than either. Without one the shipping sweep
+        // proves nothing retirable — every commit stays a physical authority of
+        // the live head — so a probe that never checkpoints measures a sweep
+        // with no work to do and cannot tell "this plane is not wired into GC"
+        // apart from "GC retired nothing at all".
+        let checkpoint_every = std::env::var("E29_CHECKPOINT_EVERY")
+            .ok()
+            .and_then(|raw| raw.parse::<usize>().ok())
+            .unwrap_or(10);
+        let insert_arm = std::env::var("E29_SHAPE").as_deref() == Ok("insert");
         for revision in 1..=rewrites {
+            if insert_arm {
+                session
+                    .execute(
+                        "INSERT INTO locator_row (path, value) VALUES ($1, lix_json($2))",
+                        &[
+                            Value::Text(format!("/agent/file-{revision}")),
+                            Value::Text(serde_json::json!({ "revision": revision }).to_string()),
+                        ],
+                    )
+                    .await
+                    .expect("insert a distinct row");
+            } else {
+                session
+                    .execute(
+                        "UPDATE locator_row SET value = lix_json($2) WHERE path = $1",
+                        &[
+                            Value::Text("/agent/file".to_owned()),
+                            Value::Text(serde_json::json!({ "revision": revision }).to_string()),
+                        ],
+                    )
+                    .await
+                    .expect("rewrite the same row");
+            }
+            if checkpoint_every > 0 && revision % checkpoint_every == 0 {
+                session
+                    .create_checkpoint()
+                    .await
+                    .expect("create a checkpoint");
+            }
+        }
+        if checkpoint_every > 0 {
+            // A checkpoint releases the *previous* checkpoint's pins, so the
+            // last one needs a successor before its predecessors are provably
+            // retirable.
             session
-                .execute(
-                    "UPDATE locator_row SET value = lix_json($2) WHERE path = $1",
-                    &[
-                        Value::Text("/agent/file".to_owned()),
-                        Value::Text(serde_json::json!({ "revision": revision }).to_string()),
-                    ],
-                )
+                .create_checkpoint()
                 .await
-                .expect("rewrite the same row");
+                .expect("create the releasing checkpoint");
         }
 
         let storage = StorageAdapter::new(memory.clone());
@@ -183,14 +221,16 @@ async fn main() {
         let (chg_after, _) = space_rows(&storage, CHANGE_SPACE.name).await;
 
         println!(
-            "E29LOC rewrites={rewrites} \
+            "E29LOC shape={} rewrites={rewrites} \
              locators_before={loc_before} locators_after={loc_after} \
              locator_bytes_before={loc_bytes_before} locator_bytes_after={loc_bytes_after} \
              manifests_before={man_before} manifests_after={man_after} \
              segments_before={seg_before} segments_after={seg_after} \
              changes_before={chg_before} changes_after={chg_after} \
-             reclaimed_locators={}",
-            loc_before.saturating_sub(loc_after)
+             reclaimed_locators={} retired_manifests={}",
+            if insert_arm { "insert" } else { "rewrite" },
+            loc_before.saturating_sub(loc_after),
+            man_before.saturating_sub(man_after)
         );
 
         // Which surviving locators name a change the public ledger no longer

--- a/packages/engine-benchmarks/examples/e29_locator_leak.rs
+++ b/packages/engine-benchmarks/examples/e29_locator_leak.rs
@@ -1,0 +1,238 @@
+//! Does the shipping sweep reclaim `TRACKED_STATE_CHANGE_LOCATOR_SPACE`?
+//!
+//! `stage_delete_change_locators` is `#[cfg(test)]`
+//! (`tracked_state/storage.rs:5521`) and its only caller is the `#[cfg(test)]`
+//! `plan_and_stage_authority_gc` (`gc.rs:1420`, delete at `gc.rs:1888`). The
+//! shipping sweep `stage_repository_gc_with_preconditions` retires a commit's
+//! physical state — manifest, delta segments, mutation-directory nodes — via
+//! `stage_retire_commit_physical_state` and never touches the locator plane.
+//!
+//! Two questions, one run:
+//!
+//! 1. **Leak.** How many locator rows survive a sweep that retired their owning
+//!    commits? Deterministic, so one rep.
+//! 2. **Correctness class.** A surviving locator names a commit whose manifest
+//!    and segments are gone. What does a read that follows it do — error,
+//!    wrong answer, or clean miss? Every consumer identity-checks the row it
+//!    lands on (`storage.rs:6648`, `:6830`, `:7958`), so the static answer is
+//!    "never a wrong answer"; this measures which of error/miss it actually is
+//!    through the public SQL surface.
+//!
+//! ```text
+//! e29_locator_leak <rewrites> [<rewrites> ...]
+//! ```
+
+#![allow(clippy::large_futures)]
+
+use lix::Value;
+use lix::integration::{Engine, SessionContext};
+use lix::registered_spaces::{
+    CHANGE_SPACE, TRACKED_STATE_CHANGE_LOCATOR_SPACE, TRACKED_STATE_COMMIT_DELTA_SEGMENT_SPACE,
+    TRACKED_STATE_COMMIT_STATE_MANIFEST_SPACE,
+};
+use lix::storage::Storage;
+use lix::storage_adapter::{Memory, StorageAdapter, StorageReadOptions};
+use lix::storage_bench::{collect_repository_gc_for_bench, space_inventory};
+
+/// Hyphenated lowercase UUID from 16 raw bytes, matching how the engine
+/// renders a `ChangeId` on the public surface.
+fn format_uuid(bytes: &[u8]) -> Option<String> {
+    if bytes.len() != 16 {
+        return None;
+    }
+    let hex = bytes
+        .iter()
+        .map(|byte| format!("{byte:02x}"))
+        .collect::<String>();
+    Some(format!(
+        "{}-{}-{}-{}-{}",
+        &hex[0..8],
+        &hex[8..12],
+        &hex[12..16],
+        &hex[16..20],
+        &hex[20..32]
+    ))
+}
+
+async fn register_schema<S>(session: &SessionContext<S>)
+where
+    S: Storage + Clone + Send + Sync + 'static,
+{
+    let schema = serde_json::json!({
+        "x-lix-key": "locator_row",
+        "x-lix-primary-key": ["/path"],
+        "type": "object",
+        "required": ["path", "value"],
+        "properties": {
+            "path": { "type": "string" },
+            "value": {
+                "type": ["object", "array", "string", "number", "integer", "boolean", "null"]
+            }
+        },
+        "additionalProperties": false
+    });
+    session
+        .execute(
+            "INSERT INTO lix_registered_schema (value, lixcol_global, lixcol_untracked) \
+             VALUES (lix_json($1), false, false)",
+            &[Value::Text(schema.to_string())],
+        )
+        .await
+        .expect("register locator schema");
+}
+
+/// `(rows, bytes)` in one space.
+async fn space_rows(storage: &StorageAdapter<Memory>, space: &str) -> (usize, usize) {
+    let read = storage
+        .begin_read(StorageReadOptions::default())
+        .await
+        .expect("open inventory read");
+    let entries = space_inventory(&read, space).await;
+    let bytes = entries
+        .iter()
+        .map(|(key, value)| key.len() + value.len())
+        .sum();
+    (entries.len(), bytes)
+}
+
+async fn locator_keys(storage: &StorageAdapter<Memory>) -> Vec<Vec<u8>> {
+    let read = storage
+        .begin_read(StorageReadOptions::default())
+        .await
+        .expect("open locator read");
+    space_inventory(&read, TRACKED_STATE_CHANGE_LOCATOR_SPACE.name)
+        .await
+        .into_iter()
+        .map(|(key, _)| key)
+        .collect()
+}
+
+#[tokio::main(flavor = "current_thread")]
+async fn main() {
+    let counts = std::env::args()
+        .skip(1)
+        .map(|arg| arg.parse::<usize>().expect("rewrite count"))
+        .collect::<Vec<_>>();
+    let counts = if counts.is_empty() {
+        vec![10, 100, 1_000]
+    } else {
+        counts
+    };
+
+    for rewrites in counts {
+        let memory = Memory::new();
+        Engine::initialize(memory.clone())
+            .await
+            .expect("initialize locator repository");
+        let engine = Engine::new(memory.clone())
+            .await
+            .expect("open locator engine");
+        let session = engine
+            .open_workspace_session()
+            .await
+            .expect("open locator workspace");
+        register_schema(&session).await;
+
+        session
+            .execute(
+                "INSERT INTO locator_row (path, value) VALUES ($1, lix_json($2))",
+                &[
+                    Value::Text("/agent/file".to_owned()),
+                    Value::Text(serde_json::json!({ "revision": 0 }).to_string()),
+                ],
+            )
+            .await
+            .expect("insert the first revision");
+
+        // Each rewrite is its own commit, so each one retires the previous
+        // commit's physical authority while the live collection stays at one
+        // row. New entity keys are deliberately not used here: this arm asks
+        // what an in-place rewrite stream leaves behind.
+        for revision in 1..=rewrites {
+            session
+                .execute(
+                    "UPDATE locator_row SET value = lix_json($2) WHERE path = $1",
+                    &[
+                        Value::Text("/agent/file".to_owned()),
+                        Value::Text(serde_json::json!({ "revision": revision }).to_string()),
+                    ],
+                )
+                .await
+                .expect("rewrite the same row");
+        }
+
+        let storage = StorageAdapter::new(memory.clone());
+        let (loc_before, loc_bytes_before) =
+            space_rows(&storage, TRACKED_STATE_CHANGE_LOCATOR_SPACE.name).await;
+        let (man_before, _) =
+            space_rows(&storage, TRACKED_STATE_COMMIT_STATE_MANIFEST_SPACE.name).await;
+        let (seg_before, _) =
+            space_rows(&storage, TRACKED_STATE_COMMIT_DELTA_SEGMENT_SPACE.name).await;
+        let (chg_before, _) = space_rows(&storage, CHANGE_SPACE.name).await;
+
+        collect_repository_gc_for_bench(&storage)
+            .await
+            .expect("run the shipping repository sweep");
+
+        let (loc_after, loc_bytes_after) =
+            space_rows(&storage, TRACKED_STATE_CHANGE_LOCATOR_SPACE.name).await;
+        let (man_after, _) =
+            space_rows(&storage, TRACKED_STATE_COMMIT_STATE_MANIFEST_SPACE.name).await;
+        let (seg_after, _) =
+            space_rows(&storage, TRACKED_STATE_COMMIT_DELTA_SEGMENT_SPACE.name).await;
+        let (chg_after, _) = space_rows(&storage, CHANGE_SPACE.name).await;
+
+        println!(
+            "E29LOC rewrites={rewrites} \
+             locators_before={loc_before} locators_after={loc_after} \
+             locator_bytes_before={loc_bytes_before} locator_bytes_after={loc_bytes_after} \
+             manifests_before={man_before} manifests_after={man_after} \
+             segments_before={seg_before} segments_after={seg_after} \
+             changes_before={chg_before} changes_after={chg_after} \
+             reclaimed_locators={}",
+            loc_before.saturating_sub(loc_after)
+        );
+
+        // Which surviving locators name a change the public ledger no longer
+        // carries? Those are the dangling ones.
+        let live_change_ids = session
+            .execute("SELECT id FROM lix_change", &[])
+            .await
+            .expect("read the public change ledger")
+            .rows()
+            .iter()
+            .filter_map(|row| match row.values().first() {
+                Some(Value::Text(id)) => Some(id.clone()),
+                _ => None,
+            })
+            .collect::<std::collections::HashSet<_>>();
+
+        let surviving = locator_keys(&storage).await;
+        let dangling = surviving
+            .iter()
+            .filter_map(|key| format_uuid(key))
+            .filter(|id| !live_change_ids.contains(id))
+            .collect::<Vec<_>>();
+        println!(
+            "E29LOC rewrites={rewrites} surviving_locators={} live_ledger_changes={} dangling_locators={}",
+            surviving.len(),
+            live_change_ids.len(),
+            dangling.len()
+        );
+
+        // What does a read that follows a dangling locator do?
+        for id in dangling.iter().take(3) {
+            let outcome = match session
+                .execute("SELECT id FROM lix_change WHERE id = $1", &[
+                    Value::Text(id.clone()),
+                ])
+                .await
+            {
+                Ok(rows) if rows.rows().is_empty() => "clean_miss".to_owned(),
+                Ok(rows) => format!("returned_{}_rows", rows.rows().len()),
+                Err(error) => format!("error:{error}"),
+            };
+            println!("E29LOC rewrites={rewrites} dangling_read change_id={id} outcome={outcome}");
+        }
+    }
+}

--- a/packages/lix/src/gc.rs
+++ b/packages/lix/src/gc.rs
@@ -2736,6 +2736,11 @@ mod tests {
         let owner_stage = stage_commit_deltas_for_commit_state(&mut writes, &owner_deltas)
             .expect("selected owner payload should stage");
         stage_change_locators(&mut writes, &owner_stage.locators);
+        let selected_locator_change_id = owner_stage
+            .locators
+            .first()
+            .expect("the owner stages one locator")
+            .change_id;
         let mut checkpoint_deltas =
             commit_delta_refs(checkpoint.commit_id, std::slice::from_ref(&selected_change));
         checkpoint_deltas[0].authored = false;
@@ -2810,6 +2815,13 @@ mod tests {
                 .is_some(),
             "the finite selected locator keeps its physical owner live"
         );
+        // Co-ownership guard for locator reclamation: the checkpoint also
+        // carries this change as a selected member, so a sweep that retired
+        // anything must not have taken the row out from under the live owner.
+        assert!(
+            locator_row_exists(&read, selected_locator_change_id).await,
+            "a locator whose owner is retained must survive the sweep"
+        );
         drop(read);
 
         publish_branch_head_release(&storage, "main", released_control, released_manifest).await;
@@ -2832,6 +2844,25 @@ mod tests {
                 .is_none(),
             "the owner is reclaimable after the final checkpoint releases the selection"
         );
+        assert!(
+            !locator_row_exists(&read, selected_locator_change_id).await,
+            "retiring the owning commit reclaims its change-locator row"
+        );
+    }
+
+    /// Is there still a row in the change-locator plane for `change_id`?
+    async fn locator_row_exists<R>(read: &R, change_id: ChangeId) -> bool
+    where
+        R: crate::storage_adapter::StorageAdapterRead,
+    {
+        let wanted = change_id.as_uuid().as_bytes().to_vec();
+        crate::storage_bench::space_inventory(
+            read,
+            crate::tracked_state::TRACKED_STATE_CHANGE_LOCATOR_SPACE.name,
+        )
+        .await
+        .into_iter()
+        .any(|(key, _)| key == wanted)
     }
 
     #[tokio::test]

--- a/packages/lix/src/tracked_state/storage.rs
+++ b/packages/lix/src/tracked_state/storage.rs
@@ -10556,6 +10556,61 @@ pub(crate) struct RetainedPhysicalState<'a> {
     pub(crate) native_parts: &'a BTreeSet<[u8; 32]>,
 }
 
+/// Reclaims the change-locator rows owned by one retired commit.
+///
+/// A locator row is neither content addressed nor deduped: it belongs to
+/// exactly one change, and an authored change belongs to exactly one physical
+/// commit. Its lifetime is therefore exactly the lifetime of the segments it
+/// addresses, which is why reclaiming it needs no fence of its own. Binary CAS
+/// needs `stage_cas_publication_fence` because a publisher may *reuse* a
+/// deduped payload row it never wrote, so a sweep planned from an older
+/// snapshot could delete a row a newer publication now depends on. No publisher
+/// can reuse another change's locator, so that hazard does not exist here, and
+/// the sweep's existing branch-head-control preconditions already void the
+/// whole write set if any publication lands after the reachability plan.
+///
+/// The delete is verified rather than assumed. Only a row that still names
+/// `commit_id` is removed, so a locator naming a different owner — a selected
+/// member this commit merely referenced, or a locator GC relocated onto a
+/// retained commit — survives even though it appears in this commit's
+/// inventory.
+async fn stage_reclaim_retired_change_locators(
+    store: &(impl StorageAdapterRead + ?Sized),
+    writes: &mut StorageWriteSet,
+    commit_id: CommitId,
+) -> Result<(), LixError> {
+    let change_ids = scan_commit_delta_members(store, commit_id)
+        .await?
+        .into_iter()
+        .map(|(_, value)| value.change_id)
+        .collect::<BTreeSet<_>>()
+        .into_iter()
+        .collect::<Vec<_>>();
+    if change_ids.is_empty() {
+        return Ok(());
+    }
+    let locator_keys = change_ids
+        .iter()
+        .map(|change_id| StorageKey(Bytes::copy_from_slice(change_id.as_uuid().as_bytes())))
+        .collect::<Vec<_>>();
+    let stored = PointReadPlan::new(TRACKED_STATE_CHANGE_LOCATOR_SPACE, &locator_keys)
+        .materialize(store, StorageGetOptions::default())
+        .await?;
+    let mut reclaimed = Vec::new();
+    for (change_id, value) in change_ids.iter().copied().zip(stored.value) {
+        let Some(bytes) = value.and_then(full_value_bytes) else {
+            continue;
+        };
+        if decode_change_locator(change_id, &bytes)?.commit_id == commit_id {
+            reclaimed.push(change_id.as_uuid().as_bytes().to_vec());
+        }
+    }
+    if !reclaimed.is_empty() {
+        writes.delete_batch(TRACKED_STATE_CHANGE_LOCATOR_SPACE, reclaimed);
+    }
+    Ok(())
+}
+
 /// Retires every physical tracked-state row owned by one unreachable commit.
 ///
 /// GC proves unreachability from refs and hands the proof here; the layout of
@@ -10576,6 +10631,7 @@ pub(crate) async fn stage_retire_commit_physical_state(
                 format!("retired GC root '{commit_id}' has no authenticated manifest"),
             )
         })?;
+    stage_reclaim_retired_change_locators(store, writes, commit_id).await?;
     let retired_root = load_commit_mutation_directory_roots(store, &[commit_id])
         .await?
         .into_iter()


### PR DESCRIPTION
# perf(gc): reclaim change locators on retirement, and measure what the sweep actually retires

Machine: `hetzner-cpx62-IV` (16c/30G). Base SHA: `d3f880ce`. Branch built and gated in
`~/claude5/cand`, `CARGO_BUILD_JOBS=4`, `TMPDIR=$HOME/claude5/tmp`.

**Read the measurement section before the diff.** The code change here is small and correct, but it
reclaims **zero rows on every workload measured**. The finding that matters is why.

## The assessment that was asked for first: what does a dangling locator do on read?

**It errors. It can never return a wrong answer.** This is not a corruption-class defect.

Every consumer of a locator re-verifies the identity of the row it lands on before returning it:

| site | check |
|---|---|
| `tracked_state/storage.rs:6648` | `value.change_id != change_id \|\| value.commit_id != locator.commit_id` → `CODE_INTERNAL_ERROR` |
| `tracked_state/storage.rs:6830` | columnar: `locator.change_id != expected_change_id` → error |
| `tracked_state/storage.rs:7958` | `validate_selected_owner_record` compares the full `(change_id, schema_key, file_id, entity_pk)` tuple |

And a locator whose commit is gone fails earlier still: missing manifest at `storage.rs:6714`,
missing segment at `:6766`, absent segment value at `:6791`, absent ordinal at `:6638`. The only
behavioural change a dangling locator can cause is turning what would be a clean `Ok(None)` from
`load_change_record_by_id` (`storage.rs:5533-5560`) into a hard `CODE_INTERNAL_ERROR`.

So: **stale metadata, not stale data.** No stop-the-line finding.

## Does reclaiming a locator need a fence? No — and the reason is specific

Binary CAS needs `stage_cas_publication_fence` because a publisher may **reuse** a deduped payload
row it never wrote, so a sweep planned from an older snapshot can delete a row a newer publication
now depends on (`binary_cas/mod.rs:60-78`).

Locators have no such hazard:

- A locator is **not content addressed and not deduped**. Its key is the change id
  (`storage.rs:5505-5519`), and an authored change belongs to exactly one physical commit.
- No publisher can reuse another change's locator row; `stage_change_locators` always puts its own.
- The sweep-side direction is already covered: `stage_repository_gc_with_preconditions` stages a
  `branch_head_control_precondition` for **every** branch (`gc.rs:1198-1209`), so any publication
  landing after the reachability plan voids the entire write set, locator deletes included.

The delete added here is additionally **verified rather than assumed**: it point-reads each candidate
locator and removes it only if the stored row still names the commit being retired. A locator naming
a different owner — a selected member this commit merely referenced, or one GC relocated onto a
retained commit — survives even though it appears in this commit's inventory.

## What changed

- `tracked_state/storage.rs`: new `stage_reclaim_retired_change_locators`, called from
  `stage_retire_commit_physical_state`. Enumerates the retired commit's members, point-reads their
  locator rows, deletes only rows that still name that commit.
- `gc.rs`: two assertions added to the existing
  `ordinary_gc_releases_finite_selected_owner_only_after_checkpoint_release` fixture — the
  co-ownership guard (a locator whose owner is retained **must survive** a sweep) and the
  reclamation assertion (retiring the owner **does** remove it). Plus a `locator_row_exists` helper.
- `engine-benchmarks/examples/e29_locator_leak.rs`: new probe.

Nothing was removed. No adapter API changed. No public API changed.

**Release-freeze compliance.** This change is sweep-only. It deletes rows inside the existing sweep
write set. It introduces no new storage space, changes no key or value encoding, retires no plane,
and adds no migration surface — so it is safe on either side of the freeze. The two follow-ups it
names (tombstone compaction in the serving layer, and dropping redundant locator rows for
direct-addressable change ids) both change what bytes mean and are therefore migration-gated
post-release work.

## Measurement — and the finding that outranks the patch

Deterministic row counts, **1 rep** per the runbook. Command:

```
E29_CHECKPOINT_EVERY=<n> E29_SHAPE=<rewrite|insert> \
  target-cand/release/examples/e29_locator_leak 10 100 1000
```

| shape | ckpt | n | locators before → after | manifests before → after | retired | reclaimed locators | dangling |
|---|---|---|---|---|---|---|---|
| rewrite | none | 10 | 20 → 20 | 13 → 13 | **0** | 0 | 0 |
| rewrite | none | 100 | 20 → 20 | 103 → 103 | **0** | 0 | 0 |
| rewrite | none | 1000 | 20 → 20 | 1003 → 1003 | **0** | 0 | 0 |
| rewrite | /10 | 10 | 22 → 22 | 17 → 7 | 10 | 0 | 0 |
| rewrite | /10 | 100 | 31 → 31 | 125 → 20 | 105 | 0 | 0 |
| rewrite | /10 | 1000 | 121 → 121 | 1205 → 110 | **1095** | 0 | 0 |
| insert | /10 | 1000 | 121 → 121 | 1205 → 1205 | 0 | 0 | 0 |

Three things fall out, in increasing order of importance.

**1. The locator leak does not reproduce.** `stage_delete_change_locators` really is `#[cfg(test)]`
(`storage.rs:5521`) with its only caller in the `#[cfg(test)]` `plan_and_stage_authority_gc`
(`gc.rs:1420`, delete at `:1888`) — but the population it would reclaim is empty. Locator rows do
not grow per change or per commit: they grow **per checkpoint** (20 → 22 → 31 → 121, i.e. ~1 per
lifecycle publication), and those commits are exactly the ones GC retains. `dangling_locators=0` in
every arm. The new reclamation ran 1095 times in the largest arm and correctly deleted nothing.

**2. Therefore this patch does not meet the acceptance gate on its own.** It closes a real
`cfg(test)`-only gap and the added test proves the mechanism works, but it reclaims nothing
measurable and costs one member scan per retired commit. I am opening it as a draft for the
coordinator to judge; **my own recommendation is that it should not land as a performance change.**
If it lands, it should land as the correctness/authority cleanup it is, and the cost line should be
stated honestly.

**3. The real finding: the shipping sweep retires nothing without a checkpoint.**
With no checkpoint, `retired_manifests = 0` at 10, 100, and 1000 edits — one commit-state manifest
accumulates per commit and GC proves nothing retirable. Insert a checkpoint every 10 edits and the
same 1000-edit stream retires **1095** manifests, 1205 → 110.

This recontextualises the `json_store` leak note that `gc.rs:1147-1155` cites as settled. That note's
evidence is `engine-benchmarks/examples/e1_json_leak.rs`, "measured at 0 rows reclaimed for 10, 100,
and 1000 rewrites" — and that probe **never checkpoints**. Its zero is therefore consistent with two
different worlds: "`json_store` is not wired into the sweep" (which the `cfg(test)` code does support
independently) and "the sweep retired nothing at all in this fixture" (which the table above shows is
also true). The cited measurement cannot separate them. Any `json_store` work should re-measure with
checkpoints before assuming the size of the leak.

The same caution applies to this round's three-planes-retained-but-never-reclaimed narrative. Two of
the three data points were taken on a fixture where GC had no work to do.

## Tombstones (the other half of my brief): compaction-shaped, not reachability-shaped

Reported here rather than fixed, because folding them into the reachability walk would be the wrong
unification.

- Tracked deletes leave a `deleted: true` row in `hot_state` `ROW_SPACE`
  (`hot_state/tracked_head.rs:482`: `physically_deletes = untracked && deleted`), and the scan cannot
  short-circuit on them (`hot.rs:5578-5580`) — a `LIMIT` applied to the raw scan would let one
  tombstone hide a later live row.
- `ROW_SPACE` is a **derived serving view** keyed by `(branch_id, generation)`, rebuildable from
  canonical records — invariant 3, not invariant 5. A refs→commits→blobs walk has no reason to
  descend into it. Forcing it in would make a cache a GC participant.
- The reclaimer that does exist, `stage_retire_hot_generation` (`hot.rs:12143`, sole non-test caller
  `commit.rs:5193`), only frees the **old** generation's copies — and the new generation's snapshot
  **carries the tombstones forward**: `commit.rs:3288` scans with `include_tombstones: true` and
  `hot.rs:6219` re-emits `deleted: row.deleted`. So generation retirement does not reclaim them
  either, which contradicts the `HOT_INDEX_SPACE` doc claim at `registered_spaces.rs:84-85`
  ("reclaimed with its generation") for the row plane it sits beside.

The fix therefore belongs in the storage/serving layer — stop carrying tombstones across a complete
snapshot republication, or compact them — not in the GC walk. I did not build it and did not measure
the tombstone counts; that measurement is the natural next step and needs a fixture that stays inside
one generation while producing genuinely new keys.

## Layout invariants

1. **Single authority** — no new authority. The locator plane keeps exactly one writer.
2. **Commit canonicality** — untouched.
3. **Derived views are caches** — untouched; the tombstone section above argues `ROW_SPACE` should be
   treated as one.
4. **Atomic publication** — the locator delete rides in the same write set and under the same
   branch-head-control preconditions as the retirement that motivates it.
5. **GC from refs** — this moves one more plane behind the existing refs-rooted proof instead of a
   `cfg(test)` path. It does not add a second reachability notion.
6. **SQL reads canonical records** — untouched.

## Regressions

None measured. No timing claim is made — the change runs only inside the async GC sweep, and it adds
one member scan plus one batched point read per retired commit. On the largest arm that was 1095
extra scans for zero reclaimed rows, which is the honest argument against landing it as-is.

## Gate

Full CI-scope gate on `hetzner-cpx62-IV`, provenance printed inside the run:

```
=== GATE PROVENANCE ===
worktree: /root/claude5/cand
HEAD: 2816c3814156915e85e2ef0369c360e61448ac9c
describe: 2816c3814 bench(gc): checkpoint the locator probe so the sweep has work to prove
status.porcelain: []
=== END PROVENANCE ===
...
=== GATE PROVENANCE (post-run) ===
HEAD: 2816c3814156915e85e2ef0369c360e61448ac9c
status.porcelain: []
E29-GATE2-COMPLETE
```

`clippy --profile test --workspace --all-targets --all-features -- -D warnings`, then
`test --profile test --workspace --exclude lix_benchmarks --all-features --no-fail-fast`, then
`test --profile test -p lix_benchmarks --features storage-benches,slatedb,root-replay-trace --no-fail-fast`,
then `check -p lix --no-default-features` and `check -p lix_js_sdk --target wasm32-unknown-unknown`.

**67 `test result: ok` lines, 3519 passed, 0 failed**, no `error[E…]`, no `panicked at`, no
`test result: FAILED`. Log grepped, not tailed.
