### PR TITLE
fix(rocksdb): honour WriteOptions::await_durable — and the price of making SQL commits use it

### DIFF
--- a/packages/engine-benchmarks/tests/crash_consistency_qualification.rs
+++ b/packages/engine-benchmarks/tests/crash_consistency_qualification.rs
@@ -357,8 +357,11 @@ struct Workload {
     /// row write set — a materially different publication shape from a plain row
     /// commit, and one that widens the swept window.
     ///
-    /// Note it does **not** set `await_durable`; measured, not assumed. See
-    /// [`Workload::force_await_durable`].
+    /// Note it does **not** set `await_durable`; measured, not assumed. The
+    /// blob is written with `INSERT INTO lix_file`, and the engine raises that
+    /// flag only in the resumable media-upload session, which is exercised by
+    /// `await_durable_publication_round_trips_through_the_resumable_upload_path`
+    /// below. See also [`Workload::force_await_durable`].
     blob_bytes: usize,
     /// Force `WriteOptions::await_durable` on at the storage boundary.
     ///
@@ -1249,8 +1252,9 @@ fn slatedb_durable_acknowledgement_survives_sigkill() {
 
 /// `WriteOptions::await_durable` is documented as "do not acknowledge the commit
 /// until the backend has crossed its durable persistence boundary". The engine
-/// sets it for atomic content-addressed publications and media uploads; SlateDB
-/// waits for its WAL upload; RocksDB must fsync the WAL before acknowledging.
+/// raises it on the resumable media-upload path — the per-part commit and the
+/// finalizing CAS publication. SlateDB waits for its WAL upload; RocksDB must
+/// fsync the WAL before acknowledging.
 ///
 /// The adapter used to accept the flag and silently drop it — `commit()` never
 /// saw the options it was opened with, and `rocksdb::WriteOptions` was never
@@ -1259,9 +1263,16 @@ fn slatedb_durable_acknowledgement_survives_sigkill() {
 /// the guarantee is invisible from inside the process, so nothing else in the
 /// suite would notice it disappearing again.
 ///
-/// If this fails, re-run the fsync census in the PR body for #1388/#E35 before
-/// changing it — a green suite with a silently non-syncing adapter is exactly
-/// the state this is here to prevent.
+/// This is deliberately a source assertion. There is no in-process observation
+/// that distinguishes a synced commit from an unsynced one — the difference
+/// only appears if the machine loses power — so pinning the code that produces
+/// the syscall is the strongest check available without `dm-log-writes`. It is
+/// paired with an strace census (in the PR body) that measured the syscall
+/// itself: two WAL fsyncs per single-part upload on the candidate, zero on the
+/// base, and an unchanged sync count on ordinary commits.
+///
+/// If this fails, re-run that census before changing it — a green suite with a
+/// silently non-syncing adapter is exactly the state this is here to prevent.
 #[test]
 fn rocksdb_honours_await_durable_by_syncing_the_wal_before_acknowledging() {
     let source = include_str!("../../rocksdb-storage/src/rocksdb.rs");
@@ -1284,21 +1295,32 @@ fn rocksdb_honours_await_durable_by_syncing_the_wal_before_acknowledging() {
     );
 }
 
-/// A publication that requests durable acknowledgement must still be a correct
-/// publication: same rows, same content-addressed bytes, readable after reopen.
+/// Exercises the one path that actually requests durable acknowledgement, and
+/// proves that requesting it did not change what gets written.
 ///
-/// The fsync itself is not observable from inside the process (see the strace
-/// census in the PR body); what this pins is that turning it on did not change
-/// what gets written.
+/// This matters because the *set* of durable writers is narrower than the
+/// module docs above might suggest. `await_durable` is raised in exactly two
+/// places, both in the resumable media-upload session
+/// (`session/media_upload.rs`): the per-part commit, and the finalization,
+/// which reaches `Transaction::stage_atomic_cas_publication` — the only caller
+/// of that function. An ordinary `INSERT INTO lix_file` carrying blob content
+/// still chunks through the content-addressed path but does **not** raise the
+/// flag, so it neither syncs before nor after this fix. A test that wrote its
+/// blob with SQL would therefore assert nothing about durability while looking
+/// like it did.
+///
+/// The fsync itself is not observable from inside the process — it is verified
+/// by the strace census in the PR body, whose slope is exactly two WAL fsyncs
+/// per upload of this shape: one for the part, one for the finalization.
 #[test]
-fn await_durable_publications_round_trip_unchanged() {
+fn await_durable_publication_round_trips_through_the_resumable_upload_path() {
+    const UPLOAD_PATH: &str = "/durable-round-trip.bin";
     let temp = tempfile::tempdir().expect("create durable round-trip fixture");
     let path = temp.path().join("database");
-    let workload = Workload {
-        rows: 8,
-        commits: 2,
-        blob_bytes: 128 * 1024,
-    };
+    // One part: well under `lix::FILE_UPLOAD_PART_BYTES`, so this is a single
+    // part commit followed by the atomic CAS publication.
+    let content = blob_for(7, 256 * 1024);
+    let expected = content.clone();
 
     block_on(move || async move {
         {
@@ -1307,14 +1329,21 @@ fn await_durable_publications_round_trip_unchanged() {
                 .with_storage(storage.clone())
                 .await
                 .expect("open durable round-trip Lix");
-            register_schema(&lix).await;
-            // Every one of these publishes a binary file, so every one of them
-            // takes the `await_durable` path.
-            for generation in 0..=workload.commits as i64 {
-                upsert_generation(&lix, workload, generation, generation == 0)
-                    .await
-                    .expect("durable round-trip commit");
-            }
+            let total_size = content.len() as u64;
+            let progress = lix
+                .upsert_file_content_part(
+                    "e35-durable-round-trip".to_owned(),
+                    UPLOAD_PATH.to_owned(),
+                    0,
+                    total_size,
+                    content,
+                )
+                .await
+                .expect("publish durable round-trip upload");
+            assert_eq!(
+                progress.next_offset, total_size,
+                "the durable upload did not consume the whole part"
+            );
             lix.close().await.expect("close durable round-trip Lix");
         }
 
@@ -1323,21 +1352,24 @@ fn await_durable_publications_round_trip_unchanged() {
             .with_storage(storage)
             .await
             .expect("reopen durable round-trip Lix");
-        let observed = read_generations(&lix)
+        let result = lix
+            .execute(
+                "SELECT content FROM lix_file WHERE path = $1",
+                &[Value::Text(UPLOAD_PATH.to_owned())],
+            )
             .await
-            .expect("read durable round-trip rows");
-        assert_eq!(observed.len(), workload.rows);
-        assert!(
-            observed.iter().all(|value| *value == workload.commits as i64),
-            "durable publication did not land whole: {observed:?}"
-        );
-        let content = read_blob(&lix)
-            .await
-            .expect("read durable round-trip blob")
-            .expect("durable round-trip blob is present");
+            .expect("read durable round-trip file");
+        let rows = result.rows();
         assert_eq!(
-            content,
-            blob_for(workload.commits as i64, workload.blob_bytes),
+            rows.len(),
+            1,
+            "the durable upload did not publish exactly one file row"
+        );
+        let observed: Vec<u8> = rows[0]
+            .get("content")
+            .expect("durable round-trip content was not a blob");
+        assert_eq!(
+            observed, expected,
             "durable publication wrote the wrong content-addressed bytes"
         );
         lix.close().await.expect("close reopened durable Lix");

--- a/packages/engine-benchmarks/tests/crash_consistency_qualification.rs
+++ b/packages/engine-benchmarks/tests/crash_consistency_qualification.rs
@@ -32,9 +32,10 @@
 //! SIGKILL models *process* death: the kernel keeps the page cache, so anything
 //! the process had already handed to `write(2)` survives. It therefore proves
 //! that the engine does not publish in observable stages. It does **not** model
-//! power loss, which additionally requires the backend to have fsynced. See
-//! `rocksdb_ignores_await_durable_and_therefore_proves_only_process_crash_consistency`
-//! in this file for the separate, statically-decidable half of that question.
+//! power loss, which additionally requires the backend to have fsynced before
+//! acknowledging. See
+//! `rocksdb_honours_await_durable_by_syncing_the_wal_before_acknowledging` in
+//! this file for the separate, statically-decidable half of that question.
 //!
 //! There is a second, sharper distinction that only shows up once a second
 //! backend is swept: the two adapters do not acknowledge the same thing.
@@ -56,6 +57,10 @@
 //! and reruns the identical schedule — and reports consistency violations and
 //! lost acknowledgements in separate columns, so a durability contract
 //! difference is never collapsed into a corruption-shaped number.
+//!
+//! What that flag *does* on RocksDB is not observable from inside the process —
+//! it is an fsync, and only power loss can reveal whether it happened. It is
+//! therefore verified by an strace census (PR #1392) rather than by this sweep.
 //!
 //! ## Cost
 //!
@@ -1242,24 +1247,101 @@ fn slatedb_durable_acknowledgement_survives_sigkill() {
     sweep::<SlateDB>(workload);
 }
 
-/// The RocksDB adapter accepts [`WriteOptions::await_durable`] and never acts on
-/// it. The option is documented as "do not acknowledge the commit until the
-/// backend has crossed its durable persistence boundary", the engine sets it for
-/// atomic CAS publications, and the SlateDB adapter honours it.
+/// `WriteOptions::await_durable` is documented as "do not acknowledge the commit
+/// until the backend has crossed its durable persistence boundary". The engine
+/// sets it for atomic content-addressed publications and media uploads; SlateDB
+/// waits for its WAL upload; RocksDB must fsync the WAL before acknowledging.
 ///
-/// This test pins the gap rather than hiding it: it is the reason the sweep
-/// above proves process-crash consistency and *not* power-loss durability.
+/// The adapter used to accept the flag and silently drop it — `commit()` never
+/// saw the options it was opened with, and `rocksdb::WriteOptions` was never
+/// constructed at all, so every write took the C++ default `sync = false`. That
+/// was found by strace, not by reading the code, which is why this test exists:
+/// the guarantee is invisible from inside the process, so nothing else in the
+/// suite would notice it disappearing again.
+///
+/// If this fails, re-run the fsync census in the PR body for #1388/#E35 before
+/// changing it — a green suite with a silently non-syncing adapter is exactly
+/// the state this is here to prevent.
 #[test]
-fn rocksdb_ignores_await_durable_and_therefore_proves_only_process_crash_consistency() {
+fn rocksdb_honours_await_durable_by_syncing_the_wal_before_acknowledging() {
     let source = include_str!("../../rocksdb-storage/src/rocksdb.rs");
     assert!(
-        !source.contains("await_durable"),
-        "the RocksDB adapter now reads await_durable — update this qualification's scope note"
+        source.contains("await_durable: opts.await_durable"),
+        "the RocksDB adapter no longer carries await_durable from WriteOptions onto the write \
+         handle: an acknowledged content-addressed publication would again be lost on power loss"
     );
     assert!(
-        !source.contains("set_sync(true)") && !source.contains("flush_wal(true)\n"),
-        "the RocksDB adapter now syncs on commit — update this qualification's scope note"
+        source.contains("write_options.set_sync(self.await_durable)")
+            && source.contains("write_opt(self.batch, &write_options)"),
+        "the RocksDB adapter no longer syncs on an await_durable commit: `commit()` must apply the \
+         batch with `write_opt` and `set_sync(self.await_durable)`, or the durable-acknowledgement \
+         contract is silently unimplemented again"
     );
+    assert!(
+        !source.contains("write_options.set_sync(true)"),
+        "the sync must stay conditional on await_durable — an unconditional fsync makes every \
+         ordinary row commit pay for durability the caller never asked for"
+    );
+}
+
+/// A publication that requests durable acknowledgement must still be a correct
+/// publication: same rows, same content-addressed bytes, readable after reopen.
+///
+/// The fsync itself is not observable from inside the process (see the strace
+/// census in the PR body); what this pins is that turning it on did not change
+/// what gets written.
+#[test]
+fn await_durable_publications_round_trip_unchanged() {
+    let temp = tempfile::tempdir().expect("create durable round-trip fixture");
+    let path = temp.path().join("database");
+    let workload = Workload {
+        rows: 8,
+        commits: 2,
+        blob_bytes: 128 * 1024,
+    };
+
+    block_on(move || async move {
+        {
+            let storage = RocksDB::open(&path).expect("open durable round-trip store");
+            let lix = open_lix()
+                .with_storage(storage.clone())
+                .await
+                .expect("open durable round-trip Lix");
+            register_schema(&lix).await;
+            // Every one of these publishes a binary file, so every one of them
+            // takes the `await_durable` path.
+            for generation in 0..=workload.commits as i64 {
+                upsert_generation(&lix, workload, generation, generation == 0)
+                    .await
+                    .expect("durable round-trip commit");
+            }
+            lix.close().await.expect("close durable round-trip Lix");
+        }
+
+        let storage = RocksDB::open(&path).expect("reopen durable round-trip store");
+        let lix = open_lix()
+            .with_storage(storage)
+            .await
+            .expect("reopen durable round-trip Lix");
+        let observed = read_generations(&lix)
+            .await
+            .expect("read durable round-trip rows");
+        assert_eq!(observed.len(), workload.rows);
+        assert!(
+            observed.iter().all(|value| *value == workload.commits as i64),
+            "durable publication did not land whole: {observed:?}"
+        );
+        let content = read_blob(&lix)
+            .await
+            .expect("read durable round-trip blob")
+            .expect("durable round-trip blob is present");
+        assert_eq!(
+            content,
+            blob_for(workload.commits as i64, workload.blob_bytes),
+            "durable publication wrote the wrong content-addressed bytes"
+        );
+        lix.close().await.expect("close reopened durable Lix");
+    });
 }
 
 /// The SlateDB adapter's acknowledgement is the mirror image of RocksDB's, and

--- a/packages/rocksdb-storage/src/rocksdb.rs
+++ b/packages/rocksdb-storage/src/rocksdb.rs
@@ -24,7 +24,7 @@ use lix::storage::{
 };
 use rocksdb::{
     BlockBasedOptions, ColumnFamily, ColumnFamilyDescriptor, DB, Direction, IteratorMode, Options,
-    WriteBatch,
+    WriteBatch, WriteOptions as RocksDBWriteOptions,
 };
 use rocksdb::{DBRawIteratorWithThreadMode, Snapshot};
 use tempfile::TempDir;
@@ -78,6 +78,10 @@ pub struct RocksDBWrite {
     batch: WriteBatch,
     immutable_values: HashMap<Vec<u8>, Bytes>,
     stats: WriteStats,
+    /// Mirrors [`WriteOptions::await_durable`]. `commit()` does not otherwise
+    /// see the options it was opened with, which is how this adapter came to
+    /// accept the flag and silently drop it.
+    await_durable: bool,
 }
 
 static OPEN_DATABASES: OnceLock<Mutex<HashMap<PathBuf, Weak<RocksDBInner>>>> = OnceLock::new();
@@ -204,6 +208,7 @@ impl Storage for RocksDB {
                 },
                 immutable_values: HashMap::new(),
                 stats: WriteStats::default(),
+                await_durable: opts.await_durable,
             })
         }
     }
@@ -617,7 +622,23 @@ impl StorageWrite for RocksDBWrite {
 
     fn commit(self) -> impl Future<Output = Result<CommitResult, StorageError>> + Send {
         async move {
-            self.inner.db.write(self.batch).map_err(rocksdb_error)?;
+            // `await_durable` means "do not acknowledge until the backend has
+            // crossed its durable persistence boundary". For RocksDB that is
+            // `sync = true`: the WAL append is fsynced before `write` returns,
+            // so an acknowledged publication survives power loss, not merely
+            // process death.
+            //
+            // Deliberately conditional. Ordinary row commits do not request
+            // durability and must not pay an fsync for it; the engine sets the
+            // flag only for atomic content-addressed publications and media
+            // uploads, which is precisely where losing an acknowledged write
+            // would be visible as a missing file.
+            let mut write_options = RocksDBWriteOptions::default();
+            write_options.set_sync(self.await_durable);
+            self.inner
+                .db
+                .write_opt(self.batch, &write_options)
+                .map_err(rocksdb_error)?;
             Ok(CommitResult {
                 commit_id: None,
                 stats: self.stats,


### PR DESCRIPTION
> **Base note:** opened against `main`. The round-5 integration branch
> (`claude-5-optimizations`, PR #1364) was merged into `main` and deleted while this
> experiment was running, so there is no integration branch left to target. This branch is
> `b7961358` + two commits, and `b7961358` is an ancestor of `main`, so it applies cleanly.
> Draft, as instructed — **do not merge without the coordinator.**

Makes the RocksDB adapter honour the durability contract it already advertises, and prices what it
would cost to actually *use* that contract for SQL commits — which is now the live decision after
#1394.

## Read this first: what this PR does and does not change

**It makes the contract real. It changes nothing for SQL workloads today, because nothing sets the
flag.** `stage_atomic_cas_publication` has exactly one caller — the resumable media-upload session
API — so an ordinary `INSERT`/`UPDATE` on `lix_file` never requests durability on either adapter.
The measured behaviour change is confined to resumable media uploads.

The separate, larger decision — what a SQL `commit()` acknowledgement should *mean* — is priced
below, because after #1394 that decision is the one that matters and my fsync number is its price
tag.

## The defect

`lix::storage::WriteOptions::await_durable` is documented as *"Do not acknowledge the commit until
the backend has crossed its durable persistence boundary"*. SlateDB honours it. **The RocksDB
adapter accepted the flag and silently dropped it**: `commit()` never saw the options `begin_write`
was called with, and `rocksdb::WriteOptions` was never constructed anywhere in the package, so every
`db.write()` took the C++ default `sync = false`.

So on RocksDB, `commit()` returning `Ok` meant *"in the OS page cache"*, not *"on disk"*, even when
lix explicitly asked for durability. A process crash could not lose it; **a power loss or kernel
panic could lose an unbounded suffix of acknowledged commits.** Not corruption — the WAL truncates
at a record boundary, so what survives is a prefix of whole publications.

### How this sits next to #1394

The two adapters fail in opposite directions, and it is worth stating both in one place:

| | RocksDB (before this PR) | SlateDB (#1394) |
|---|---|---|
| honours `await_durable`? | **no** — flag dropped | **yes** |
| non-durable ack means | applied to the page cache | queued in-process |
| lost acks under SIGKILL | **0 / 1,008** | **846 / 1,008** |
| lost acks under power loss | **unbounded suffix** | bounded by the same flag |

RocksDB survived SIGKILL *because of* the bug's shape, not despite it: the `WriteBatch` is already
in the kernel before ack, so only power loss can take it back. Neither adapter is wrong about
consistency — both publish atomically — they simply acknowledge different things.

## The fix

`packages/rocksdb-storage/src/rocksdb.rs`: carry `opts.await_durable` onto the write handle, and
apply the batch with `write_opt` under `set_sync(self.await_durable)`. This is the adapter's only
write site.

**Conditional, deliberately.** The option exists so ordinary commits stay fast; an unconditional
fsync would make every row commit pay for a guarantee nobody requested. The pinning test asserts the
conditionality as well as the sync.

The fix follows the shape the other adapters already use: SlateDB waits for its WAL upload, and the
IndexedDB adapter carries `opts.await_durable` onto its write handle and forwards it as
`strict_durability` (`js-sdk/native/indexeddb.rs:317`, `:496`) — the identical carry-then-apply
pattern. RocksDB was the sole outlier.

## Verification: strace, not inspection

Same method that found the defect. RocksDB store on ext4 (`~/claude5/tmp`, never the tmpfs `/tmp` —
a durability experiment against RAM would be worthless), `strace -f -y -e trace=fsync,fdatasync`
over the `large_blob_updates` accounting harness. Run at **two sample counts so the per-commit cost
is a measured slope, not an inference** — that separates RocksDB's fixed open-time syncs from syncs
attributable to commits.

**Durable lane** — `resumable_initial_write`, the resumable media-upload API, 1 MiB:

| arm | samples | total syncs | WAL (`*.log`) syncs |
|---|---:|---:|---:|
| base | 5 | 36 | 2 |
| base | 10 | 36 | **2** |
| cand | 5 | 46 | 11 |
| cand | 10 | 56 | **21** |

Fitted as `fixed + slope × samples`: base is `2 + 0.0N`, candidate is `1 + 2.0N`.

Base slope: **0.0 WAL fsyncs per upload** — its 2 are open-time and do not move with the workload,
which is exactly how a doubled sample count separates them from commit syncs. Candidate slope:
**exactly 2.0 WAL fsyncs per upload**, which is precisely the number of commits that raise the flag
for a 1 MiB upload — one per-part commit plus the finalizing CAS publication
(`FILE_UPLOAD_PART_BYTES` is 16 MiB, so 1 MiB is a single part). Attribution is exact, not
statistical. Both arms sync `000004.log` at open; the one fixed sync the candidate does *not* pay is
RocksDB's own later WAL sync, which the commit-time fsyncs have already made redundant.

**Non-durable lane** — `initial_write`, an ordinary `INSERT INTO lix_file`, same sizes:

| arm | samples | total syncs | WAL syncs |
|---|---:|---:|---:|
| base | 5 / 10 | 36 / 36 | 2 / 2 |
| cand | 5 / 10 | 36 / 36 | 2 / 2 |

**Byte-identical**, including the per-file breakdown (14 `fsync database`, 9 `fdatasync MANIFEST-*`,
6 `*.sst`, 3 `*.dbtmp`, 2 `*.log`, 1 `OPTIONS-*.dbtmp`, 1 `*.blob`). Commits that do not request
durability are unaffected — measured, not argued from the source.

## Cost of this PR as scoped

Same-host A/B, 9 alternating repetitions per arm (base-first on odd reps, cand-first on even), 15
samples per repetition, one `CARGO_TARGET_DIR` per arm, stores on ext4. Median of the 9
per-repetition p50s.

| lane | size | base p50 | cand p50 | ratio | delta |
|---|---:|---:|---:|---:|---:|
| **resumable_initial_write** (durable) | 1 MiB | 3.44 ms | 9.90 ms | **2.88x** | **+6.46 ms** |
| **resumable_initial_write** (durable) | 10 MiB | 28.16 ms | 35.94 ms | **1.28x** | **+7.78 ms** |
| initial_write (null control) | 1 MiB | 2.93 ms | 2.99 ms | 1.02x | +0.07 ms |
| initial_write (null control) | 10 MiB | 23.52 ms | 23.50 ms | 1.00x | −0.02 ms |
| raw_backend_initial_write (null control) | 1 MiB | 2.95 ms | 3.44 ms | 1.17x | +0.49 ms |
| raw_backend_initial_write (null control) | 10 MiB | 20.25 ms | 19.47 ms | 0.96x | −0.78 ms |

**Read it as a fixed cost, not a ratio.** The delta is +6.46 ms at 1 MiB and +7.78 ms at 10 MiB —
flat, because it is two fsyncs, **~3.2–3.9 ms each on this host's ext4/NVMe**, not work proportional
to the payload. The ratio looks alarming at 1 MiB only because the denominator is small. At 10 MiB
the media path goes 355 MiB/s → 278 MiB/s.

The durable-lane distributions do not overlap at either size (1 MiB: base 3.33–3.86, cand
5.95–11.37; 10 MiB: base 26.89–28.49, cand 33.53–37.09). The null controls interleave completely —
`raw_backend_initial_write` at 1 MiB is bimodal (~1.9 / ~3.7 ms) in both arms, which is what produces
its 1.17x p50 while its p95 goes the other way (0.95x). That lane is noise, and the strace census
independently confirms it with identical syscall counts.

Measurement arms were `37139213e` vs `37139213e` + this fix — a base that predates the
hardware-CRC32C build change (#1389), which touches `.cargo/config.toml` and would otherwise have
rebuilt both arms mid-experiment. It changes checksum throughput, not fsync latency, so it cannot
move a delta that is two syscalls wide. The branch itself is rebased onto `b7961358` and gated there.

## Pricing option (a): what if SQL commits requested durability?

This is not in the PR. It is a **throwaway probe arm** — the same tree with
`set_sync(self.await_durable)` replaced by `set_sync(true)`, marked `NOT for merge` — built into its
own target directory purely to answer the coordinator's question. Control is this PR's own commit
(`712bb5aef`), which on SQL lanes is behaviourally identical to base. One variable: whether ordinary
commits sync.

Alternating order, medians of per-repetition medians, machine otherwise idle.

| lane | control | option (a) | ratio | delta |
|---|---:|---:|---:|---:|
| **`update_one`** — single-row SQL update | 0.690 ms | 2.106 ms | **3.05x** | **+1.42 ms** |
| `insert_all` — 1,000 rows, one transaction | 8.387 ms | 10.503 ms | 1.25x | +2.12 ms |
| `initial_write` — 1 MiB SQL file write | 2.196 ms | 6.170 ms | 2.81x | +3.97 ms |
| `initial_write` — 10 MiB SQL file write | 17.384 ms | 23.955 ms | 1.38x | +6.57 ms |
| `read_one` — null control, no commit | 1.193 ms | 1.261 ms | 1.06x | +0.07 ms |

`update_one` distributions are cleanly disjoint (control 0.686–0.729, probe 2.016–2.181 across 7
alternating repetitions); `read_one`, which commits nothing, overlaps as a control should. The
strace census on the same lane confirms the direction independently: **0 WAL fsyncs in the control
at both sample counts, non-zero and scaling linearly in the probe.**

**The headline for the decision: option (a) costs 3.05x on a single-row SQL update.** Claim 3 is
"SQL surface at most 1.2x slower than SQLite" — a blanket durable default does not fit inside that
budget, and no amount of tuning closes a 3x. The cost is worst exactly where lix is trying to look
like an OLTP database, and mildest on bulk transactions and large media, because an fsync amortizes
over whatever the commit already had to write.

That points at (c) — durability at checkpoint/batch boundaries with an explicit flush API, the
SQLite-`NORMAL` shape — as the only option that buys real durability without spending the OLTP
claim. (b) is free but obliges the release post to say plainly that an acked SQL commit is not
durable, and after #1394 that it can be *lost outright* on SlateDB under process death, which is a
much harder sentence to write than "not power-loss safe".

Two caveats on this number, both of which make it a floor rather than a ceiling:

1. **fsync cost is not a constant.** It scales with what the WAL has to flush: ~3.2 ms per sync on
   the 1 MiB media lane, well under a millisecond on small row commits. Quoting one "cost per
   fsync" figure would be wrong; each lane is priced separately above.
2. **This is a local ext4/NVMe number, and SlateDB's durable path is an object-store round-trip.**
   Per this round's own instrument traps, a local-filesystem profile is not a scaled-down object
   store. Option (a)'s true price on SlateDB is unmeasured and will be worse.



## Test

`rocksdb_ignores_await_durable_and_therefore_proves_only_process_crash_consistency` →
`rocksdb_honours_await_durable_by_syncing_the_wal_before_acknowledging`. It flips from documenting
the gap to asserting the guarantee, and asserts three things: the flag is carried onto the write
handle, `commit()` applies the batch via `write_opt` with `set_sync(self.await_durable)`, and the
sync is **not** unconditional.

It is a source assertion by necessity — no in-process observation distinguishes a synced commit from
an unsynced one; the difference only appears if the machine loses power. That is why it is paired
with the strace census above, and why its doc comment tells the next person to re-run that census
before editing it.

`await_durable_publication_round_trips_through_the_resumable_upload_path` (new) drives
`upsert_file_content_part`, so the durable path is actually executed, and proves the fsync did not
change what gets written. The first draft of this test wrote its blob with SQL — it would have
looked like it tested durability while asserting nothing about it, which is the same trap #1394
found in E20's fsync census.

## Gaps — named, not built

- **Power-loss testing via `dm-log-writes`.** This change makes the fsync happen; it does not prove
  the store survives losing power *between* two of them. `dm-log-writes` replays a block-level write
  log to every flush boundary and checks the store at each one. **Until that exists nobody should
  write "durable" unqualified** — the honest claim is "acknowledged media publications are fsynced
  before acknowledgement", which is a statement about a syscall, not about a recovered store.
- **SlateDB's durable path is not fsync-audited.** #1394 established behaviourally that SlateDB
  honours the flag; what its durable acknowledgement costs against an object store (rather than the
  local FS used here) is unmeasured, and per the round's own instrument traps a local-filesystem
  profile is not a scaled-down object store. Option (a) below cannot be fully priced without it.

## Gate

Full CI scope on hetzner-cpx62-III, `--no-fail-fast`, logs grepped rather than tailed. Printed from
inside the run, before and after:

```
=== git rev-parse HEAD ===
712bb5aefe200f556619872ad26748c1f80ac700
=== git status --porcelain ===
=== (end status) ===
...
=== git rev-parse HEAD (post) ===
712bb5aefe200f556619872ad26748c1f80ac700
=== git status --porcelain (post) ===
=== (end status) ===
```

Clean tree, same commit before and after — nothing was edited mid-run.

```
GATE_STEP_RESULT clippy           rc=0
GATE_STEP_RESULT compile_ws       rc=0
GATE_STEP_RESULT compile_bench    rc=0
GATE_STEP_RESULT run_ws           rc=0
GATE_STEP_RESULT run_bench        rc=0
GATE_STEP_RESULT check_nodefault  rc=0
GATE_STEP_RESULT check_wasm       rc=0
```

**3526 passed / 0 failed / 0 ignored**, summed across every `test result:` line in the log. Zero
matches for `^failures:`, `test result: FAILED` or `panicked at`. The four durability tests all ran:

```
test rocksdb_honours_await_durable_by_syncing_the_wal_before_acknowledging ... ok
test await_durable_publication_round_trips_through_the_resumable_upload_path ... ok
test slatedb_honours_await_durable_and_acknowledges_non_durable_writes_early ... ok
test slatedb::tests::await_durable_write_does_not_acknowledge_a_blocked_wal_upload ... ok
```
