### PR TITLE
perf(sql): cut three per-statement incidental costs on the point-read path

### DIFF
--- a/packages/lix/src/sql2/exec/datafusion.rs
+++ b/packages/lix/src/sql2/exec/datafusion.rs
@@ -77,7 +77,7 @@ pub(crate) const LIX_INSERT_COLUMN_OMITTED_METADATA_KEY: &str = "lix_insert_colu
 
 pub(crate) struct DataFusionLogicalPlan {
     pub(super) state: std::sync::Arc<SessionState>,
-    pub(super) plan: LogicalPlan,
+    pub(super) plan: crate::sql2::runtime::RuntimeReadPlan,
     pub(super) notices: Vec<LixNotice>,
     pub(super) json_predicate_params: BTreeSet<usize>,
     pub(super) expected_parameter_count: usize,
@@ -425,15 +425,25 @@ async fn create_logical_plan_in_session_from_parsed(
         && let Some((cache, catalog)) = &session.planning_environment
         && let Some(cached) = cache.read_plan(sql, params, catalog)
     {
-        let plan = rebind_cached_read_plan(session.context(), cached.plan.clone()).await?;
+        let physical_planning_cache = PhysicalReadPlanCacheKey::new(sql, params, catalog.clone())
+            .map(|key| (std::sync::Arc::clone(cache), key));
+        // With a physical-cache key the runtime rebinds scan providers lazily:
+        // a warm template execution never touches the logical plan, so eagerly
+        // resolving providers into it here would be pure per-statement waste.
+        let plan = if physical_planning_cache.is_some() {
+            crate::sql2::runtime::RuntimeReadPlan::Detached(cached.plan.clone())
+        } else {
+            crate::sql2::runtime::RuntimeReadPlan::Bound(
+                rebind_cached_read_plan(session.context(), cached.plan.clone()).await?,
+            )
+        };
         return Ok(SqlLogicalPlan::DataFusion(SqlDataFusionLogicalPlan {
             state: std::sync::Arc::clone(session.state()),
             plan,
             notices: Vec::new(),
             json_predicate_params: cached.json_predicate_params.clone(),
             expected_parameter_count: cached.expected_parameter_count,
-            physical_planning_cache: PhysicalReadPlanCacheKey::new(sql, params, catalog.clone())
-                .map(|key| (std::sync::Arc::clone(cache), key)),
+            physical_planning_cache,
         }));
     }
     bind_table_function_parameters(&mut statement, params)?;
@@ -473,7 +483,7 @@ async fn create_logical_plan_in_session_from_parsed(
 
     Ok(SqlLogicalPlan::DataFusion(SqlDataFusionLogicalPlan {
         state: std::sync::Arc::clone(session.state()),
-        plan,
+        plan: crate::sql2::runtime::RuntimeReadPlan::Bound(plan),
         notices: Vec::new(),
         json_predicate_params,
         expected_parameter_count,
@@ -659,7 +669,7 @@ async fn create_transaction_read_logical_plan_from_parsed(
     Ok((
         SqlLogicalPlan::DataFusion(SqlDataFusionLogicalPlan {
             state: std::sync::Arc::clone(session.state()),
-            plan,
+            plan: crate::sql2::runtime::RuntimeReadPlan::Bound(plan),
             notices: Vec::new(),
             json_predicate_params,
             expected_parameter_count,
@@ -1346,6 +1356,21 @@ fn validate_history_anchor_predicates_in_logical_plan(plan: &LogicalPlan) -> Res
 ///
 /// Mirrors `DataFrame::with_param_values`, which is exactly
 /// `LogicalPlan::with_param_values` plus a `SessionState` it does not need.
+fn bind_runtime_plan_param_values(
+    plan: crate::sql2::runtime::RuntimeReadPlan,
+    params: &[Value],
+) -> Result<crate::sql2::runtime::RuntimeReadPlan, LixError> {
+    use crate::sql2::runtime::RuntimeReadPlan;
+    Ok(match plan {
+        RuntimeReadPlan::Bound(plan) => {
+            RuntimeReadPlan::Bound(bind_plan_param_values(plan, params)?)
+        }
+        RuntimeReadPlan::Detached(plan) => {
+            RuntimeReadPlan::Detached(bind_plan_param_values(plan, params)?)
+        }
+    })
+}
+
 fn bind_plan_param_values(plan: LogicalPlan, params: &[Value]) -> Result<LogicalPlan, LixError> {
     if params.is_empty() {
         return Ok(plan);
@@ -1382,9 +1407,10 @@ async fn execute_logical_plan(
     // rejects, and otherwise wraps the plan in a `DataFrame` whose only purpose
     // here is to carry a freshly deep-copied `SessionState`. Bind the
     // parameters on the plan directly against the statement's pooled state.
-    let plan = bind_plan_param_values(plan, params)?;
+    let plan = bind_runtime_plan_param_values(plan, params)?;
 
     let result_fields = plan
+        .inner()
         .schema()
         .fields()
         .iter()
@@ -1456,8 +1482,9 @@ async fn execute_logical_plan_stream<'session>(
     // rejects, and otherwise wraps the plan in a `DataFrame` whose only purpose
     // here is to carry a freshly deep-copied `SessionState`. Bind the
     // parameters on the plan directly against the statement's pooled state.
-    let plan = bind_plan_param_values(plan, params)?;
+    let plan = bind_runtime_plan_param_values(plan, params)?;
     let fields = plan
+        .inner()
         .schema()
         .fields()
         .iter()
@@ -1501,8 +1528,9 @@ async fn execute_logical_plan_collected_batches(
     // rejects, and otherwise wraps the plan in a `DataFrame` whose only purpose
     // here is to carry a freshly deep-copied `SessionState`. Bind the
     // parameters on the plan directly against the statement's pooled state.
-    let plan = bind_plan_param_values(plan, params)?;
+    let plan = bind_runtime_plan_param_values(plan, params)?;
     let fields = plan
+        .inner()
         .schema()
         .fields()
         .iter()

--- a/packages/lix/src/sql2/planning_cache.rs
+++ b/packages/lix/src/sql2/planning_cache.rs
@@ -1,15 +1,19 @@
+use std::any::Any;
 use std::borrow::Cow;
+use std::collections::HashMap;
 use std::hash::Hash;
 use std::num::NonZeroUsize;
-use std::sync::{Arc, Mutex, MutexGuard};
+use std::sync::{Arc, Mutex, MutexGuard, RwLock};
 
 use crate::sql2::catalog::PublicCatalog;
 use crate::sql2::plan::LogicalWritePlan;
 use crate::{LixError, Value};
+use async_trait::async_trait;
 use datafusion::catalog::{
     CatalogProvider, CatalogProviderList, MemoryCatalogProvider, MemoryCatalogProviderList,
-    MemorySchemaProvider,
+    SchemaProvider, TableProvider,
 };
+use datafusion::common::exec_err;
 use datafusion::execution::session_state::SessionState;
 use datafusion::logical_expr::LogicalPlan;
 use datafusion::physical_plan::ExecutionPlan;
@@ -102,6 +106,83 @@ pub(crate) struct CachedUpdateLiteralShape {
     middle_start: usize,
     middle_end: usize,
     suffix_start: usize,
+}
+
+/// Statement-scoped `public` schema for pooled read sessions.
+///
+/// Every snapshot-bound table provider a statement registers lands here and
+/// must be gone by the time the session returns to the pool. DataFusion's
+/// `MemorySchemaProvider` can only express that as `table_names()` — one owned
+/// `String` per table, per statement, walking every dashmap shard — followed by
+/// one `deregister_table` per name. This provider keeps the identical
+/// registration semantics (registering an existing name is an error, matching
+/// `MemorySchemaProvider`) while letting session recycling drop every provider
+/// in one map clear.
+#[derive(Debug, Default)]
+struct StatementSchemaProvider {
+    tables: RwLock<HashMap<String, Arc<dyn TableProvider>>>,
+}
+
+impl StatementSchemaProvider {
+    fn tables(&self) -> std::sync::RwLockReadGuard<'_, HashMap<String, Arc<dyn TableProvider>>> {
+        self.tables
+            .read()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+    }
+
+    fn tables_mut(
+        &self,
+    ) -> std::sync::RwLockWriteGuard<'_, HashMap<String, Arc<dyn TableProvider>>> {
+        self.tables
+            .write()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+    }
+
+    /// Drops every statement-registered provider at once.
+    fn clear(&self) {
+        self.tables_mut().clear();
+    }
+}
+
+#[async_trait]
+impl SchemaProvider for StatementSchemaProvider {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn table_names(&self) -> Vec<String> {
+        self.tables().keys().cloned().collect()
+    }
+
+    async fn table(
+        &self,
+        name: &str,
+    ) -> Result<Option<Arc<dyn TableProvider>>, datafusion::error::DataFusionError> {
+        Ok(self.tables().get(name).cloned())
+    }
+
+    fn register_table(
+        &self,
+        name: String,
+        table: Arc<dyn TableProvider>,
+    ) -> datafusion::common::Result<Option<Arc<dyn TableProvider>>> {
+        let mut tables = self.tables_mut();
+        if tables.contains_key(name.as_str()) {
+            return exec_err!("The table {name} already exists");
+        }
+        Ok(tables.insert(name, table))
+    }
+
+    fn deregister_table(
+        &self,
+        name: &str,
+    ) -> datafusion::common::Result<Option<Arc<dyn TableProvider>>> {
+        Ok(self.tables_mut().remove(name))
+    }
+
+    fn table_exist(&self, name: &str) -> bool {
+        self.tables().contains_key(name)
+    }
 }
 
 /// One DataFusion session borrowed from the engine's pool for the duration of
@@ -216,7 +297,7 @@ where
         let catalogs = Arc::new(MemoryCatalogProviderList::new());
         let catalog = Arc::new(MemoryCatalogProvider::new());
         catalog
-            .register_schema("public", Arc::new(MemorySchemaProvider::new()))
+            .register_schema("public", Arc::new(StatementSchemaProvider::default()))
             .expect("fresh DataFusion catalog accepts the public schema");
         catalogs.register_catalog("datafusion".to_string(), catalog);
         super::session::sql_session_from_template(self.datafusion_state.clone(), Some(catalogs))
@@ -234,14 +315,22 @@ where
         if let Some(catalog) = session.context.catalog("datafusion")
             && let Some(public) = catalog.schema("public")
         {
-            for table in public.table_names() {
-                let _ = session
-                    .context
-                    .deregister_table(datafusion::common::TableReference::full(
-                        "datafusion",
-                        "public",
-                        table,
-                    ));
+            match public.as_any().downcast_ref::<StatementSchemaProvider>() {
+                Some(statement_schema) => statement_schema.clear(),
+                None => {
+                    // Sessions built by `datafusion_session` always carry a
+                    // `StatementSchemaProvider`; this enumeration remains only
+                    // for a foreign schema provider reaching the pool.
+                    for table in public.table_names() {
+                        let _ = session.context.deregister_table(
+                            datafusion::common::TableReference::full(
+                                "datafusion",
+                                "public",
+                                table,
+                            ),
+                        );
+                    }
+                }
             }
         }
         // Only table-valued functions are registered per statement; the five

--- a/packages/lix/src/sql2/providers/spec.rs
+++ b/packages/lix/src/sql2/providers/spec.rs
@@ -26,10 +26,11 @@ use datafusion::common::{DFSchema, DataFusionError, Result, SchemaExt};
 use datafusion::datasource::TableType;
 use datafusion::execution::TaskContext;
 use datafusion::execution::context::ExecutionProps;
-use datafusion::logical_expr::{Expr, TableProviderFilterPushDown};
+use datafusion::logical_expr::{Expr, Operator, TableProviderFilterPushDown};
 use datafusion::physical_expr::expressions::Column;
 use datafusion::physical_expr::{
-    EquivalenceProperties, PhysicalExpr, PhysicalSortExpr, create_physical_expr,
+    AcrossPartitions, ConstExpr, EquivalenceProperties, PhysicalExpr, PhysicalSortExpr,
+    create_physical_expr,
 };
 use datafusion::physical_plan::execution_plan::{Boundedness, EmissionType, PlanProperties};
 use datafusion::physical_plan::stream::RecordBatchStreamAdapter;
@@ -917,6 +918,7 @@ impl TableProvider for SpecTableProvider {
             filters: filters.iter().map(ToString::to_string).collect(),
             limit,
         };
+        let constant_columns = exact_filter_constant_columns(self.spec.as_ref(), filters);
         let planned = self
             .spec
             .plan_scan(projection, filters, limit, state.execution_props())
@@ -936,8 +938,62 @@ impl TableProvider for SpecTableProvider {
             state.config().target_partitions(),
             statement_cache_key,
             physical_cache_key,
-        )))
+            &constant_columns,
+        )?))
     }
+}
+
+/// Output columns pinned to one literal value by a fully-applied (`Exact`)
+/// pushed-down filter.
+///
+/// `Exact` pushdown means the provider applies the predicate in full, so every
+/// row leaving the scan satisfies it. For predicates shaped `col = literal` or
+/// `col IN (single literal)` the column is therefore constant across the scan's
+/// output — the same fact `FilterExec` would have advertised through its
+/// equivalence properties had the filter stayed above the scan. Restoring it
+/// here lets DataFusion's own `EnforceSorting` rule elide sort operators whose
+/// sort keys are pinned; the canonical beneficiary is the point read
+/// `WHERE pk = … ORDER BY pk`, which otherwise streams its at-most-one row
+/// through a full `SortExec`. Conjunctions recurse — an exactly-applied
+/// `a = 'x' AND b = 'y'` pins both columns — while `OR`, negated `IN`, and
+/// multi-value `IN` pin nothing. Filters the spec reports as `Inexact` or
+/// `Unsupported` are skipped: their rows are only narrowed above the scan, so
+/// the scan itself proves nothing.
+fn exact_filter_constant_columns(spec: &dyn TableSpec, filters: &[Expr]) -> Vec<String> {
+    fn collect(filter: &Expr, columns: &mut Vec<String>) {
+        match filter {
+            Expr::BinaryExpr(binary) if binary.op == Operator::And => {
+                collect(&binary.left, columns);
+                collect(&binary.right, columns);
+            }
+            Expr::BinaryExpr(binary) if binary.op == Operator::Eq => {
+                match (binary.left.as_ref(), binary.right.as_ref()) {
+                    (Expr::Column(column), Expr::Literal(..))
+                    | (Expr::Literal(..), Expr::Column(column)) => {
+                        columns.push(column.name.clone());
+                    }
+                    _ => {}
+                }
+            }
+            Expr::InList(in_list) if !in_list.negated && in_list.list.len() == 1 => {
+                if let (Expr::Column(column), Expr::Literal(..)) =
+                    (in_list.expr.as_ref(), &in_list.list[0])
+                {
+                    columns.push(column.name.clone());
+                }
+            }
+            _ => {}
+        }
+    }
+
+    let mut columns = Vec::new();
+    for filter in filters {
+        if spec.filter_pushdown(filter) != TableProviderFilterPushDown::Exact {
+            continue;
+        }
+        collect(filter, &mut columns);
+    }
+    columns
 }
 
 fn physical_filters(
@@ -1055,13 +1111,14 @@ impl SpecScanExec {
         target_partitions: usize,
         statement_cache_key: Option<StatementScanKey>,
         physical_cache_key: PhysicalScanKey,
-    ) -> Self {
+        constant_columns: &[String],
+    ) -> Result<Self> {
         // A declared ordering only proves that each source fragment is sorted,
         // not that adjacent fragments have non-overlapping value ranges.
         // Keep ordered fragments separate unless the source can eventually
         // provide that stronger cross-fragment guarantee.
         let preserve_fragment_boundaries = planned.ordering.is_some();
-        let equivalence_properties = planned
+        let mut equivalence_properties = planned
             .ordering
             .as_deref()
             .and_then(|column_name| {
@@ -1083,6 +1140,23 @@ impl SpecScanExec {
                     })
             })
             .unwrap_or_else(|| EquivalenceProperties::new(Arc::clone(&planned.schema)));
+        // Exact-pushdown equalities pin these output columns to one literal
+        // value, uniformly across every partition. Columns pruned from the
+        // projected schema carry no ordering obligations and are skipped.
+        let constants = constant_columns
+            .iter()
+            .filter_map(|column_name| {
+                planned.schema.index_of(column_name).ok().map(|index| {
+                    ConstExpr::new(
+                        Arc::new(Column::new(column_name, index)) as Arc<dyn PhysicalExpr>,
+                        AcrossPartitions::Uniform(None),
+                    )
+                })
+            })
+            .collect::<Vec<_>>();
+        if !constants.is_empty() {
+            equivalence_properties.add_constants(constants)?;
+        }
         let grouped_target = if preserve_fragment_boundaries {
             planned.source.partition_count
         } else {
@@ -1096,7 +1170,7 @@ impl SpecScanExec {
             EmissionType::Incremental,
             Boundedness::Bounded,
         );
-        Self {
+        Ok(Self {
             table,
             schema: planned.schema,
             source: planned.source,
@@ -1104,7 +1178,7 @@ impl SpecScanExec {
             properties: Arc::new(properties),
             statement_cache_key,
             physical_cache_key,
-        }
+        })
     }
 
     #[cfg(test)]
@@ -1126,7 +1200,9 @@ impl SpecScanExec {
             target_partitions,
             statement_cache_key,
             physical_cache_key,
+            &[],
         )
+        .expect("test scan properties build")
     }
 
     pub(crate) fn statement_cache_key(&self) -> Option<&StatementScanKey> {

--- a/packages/lix/src/sql2/providers/spec.rs
+++ b/packages/lix/src/sql2/providers/spec.rs
@@ -1708,9 +1708,13 @@ mod scan_source_tests {
             )
             .await
             .expect("CTE should plan");
-        let batches = crate::sql2::runtime::collect_plan(&session.state(), plan, None)
-            .await
-            .expect("CTE should execute");
+        let batches = crate::sql2::runtime::collect_plan(
+            &session.state(),
+            crate::sql2::runtime::RuntimeReadPlan::Bound(plan),
+            None,
+        )
+        .await
+        .expect("CTE should execute");
         let values = batches
             .iter()
             .flat_map(|batch| {

--- a/packages/lix/src/sql2/providers/spec.rs
+++ b/packages/lix/src/sql2/providers/spec.rs
@@ -1148,7 +1148,7 @@ impl SpecScanExec {
             .filter_map(|column_name| {
                 planned.schema.index_of(column_name).ok().map(|index| {
                     ConstExpr::new(
-                        Arc::new(Column::new(column_name, index)) as Arc<dyn PhysicalExpr>,
+                        Arc::new(Column::new(column_name, index)),
                         AcrossPartitions::Uniform(None),
                     )
                 })

--- a/packages/lix/src/sql2/runtime.rs
+++ b/packages/lix/src/sql2/runtime.rs
@@ -1,5 +1,5 @@
 use std::any::Any;
-use std::collections::{HashMap, VecDeque};
+use std::collections::{BTreeMap, BTreeSet, HashMap, VecDeque};
 use std::fmt::Debug;
 use std::sync::Arc;
 #[cfg(feature = "storage-benches")]
@@ -8,7 +8,9 @@ use std::time::Instant;
 use datafusion::arrow::datatypes::SchemaRef;
 use datafusion::arrow::record_batch::RecordBatch;
 use datafusion::catalog::ScanArgs;
+use datafusion::common::tree_node::{Transformed, TreeNode, TreeNodeRecursion};
 use datafusion::common::{DataFusionError, internal_err};
+use datafusion::datasource::provider_as_source;
 use datafusion::error::Result;
 use datafusion::execution::SessionState;
 use datafusion::execution::TaskContext;
@@ -42,9 +44,83 @@ type PhysicalPlanningCache = (
     PhysicalReadPlanCacheKey<CatalogFingerprint>,
 );
 
+/// One read statement's logical plan as handed to the execution runtime.
+///
+/// A warm physical-template execution never reads the logical plan at all —
+/// the cached leaf-scan requests replan directly against the current session —
+/// so a statement that owns a physical-cache key hands over the planning
+/// cache's *detached* template (table scans holding `EmptyTable` placeholders)
+/// instead of eagerly rebinding every scan to live providers first. The
+/// rebinding then happens here, and only on the paths that actually plan the
+/// logical tree.
+pub(crate) enum RuntimeReadPlan {
+    /// Table scans carry live snapshot-bound providers; plannable as-is.
+    Bound(LogicalPlan),
+    /// Table scans carry detached `EmptyTable` placeholders and must be
+    /// rebound against the session state before DataFusion may plan them.
+    Detached(LogicalPlan),
+}
+
+impl RuntimeReadPlan {
+    pub(crate) fn inner(&self) -> &LogicalPlan {
+        match self {
+            Self::Bound(plan) | Self::Detached(plan) => plan,
+        }
+    }
+
+    async fn into_bound(self, state: &SessionState) -> Result<LogicalPlan> {
+        match self {
+            Self::Bound(plan) => Ok(plan),
+            Self::Detached(plan) => rebind_detached_read_plan(state, plan).await,
+        }
+    }
+}
+
+/// Replaces detached `EmptyTable` scan sources with the current session's
+/// providers. Mirrors the eager rebinding previously done during logical
+/// planning; provider resolution goes through the same shared catalog list.
+async fn rebind_detached_read_plan(
+    state: &SessionState,
+    plan: LogicalPlan,
+) -> Result<LogicalPlan> {
+    let mut tables = BTreeSet::new();
+    plan.apply(|node| {
+        if let LogicalPlan::TableScan(scan) = node {
+            tables.insert(scan.table_name.clone());
+        }
+        Ok(TreeNodeRecursion::Continue)
+    })?;
+    let mut providers = BTreeMap::new();
+    for table in tables {
+        let provider = state
+            .schema_for_ref(table.clone())?
+            .table(table.table())
+            .await?
+            .ok_or_else(|| {
+                DataFusionError::Plan(format!(
+                    "cached SQL plan provider '{table}' is unavailable"
+                ))
+            })?;
+        providers.insert(table, provider_as_source(provider));
+    }
+    plan.transform_up(|node| {
+        let LogicalPlan::TableScan(mut scan) = node else {
+            return Ok(Transformed::no(node));
+        };
+        scan.source = providers.get(&scan.table_name).cloned().ok_or_else(|| {
+            DataFusionError::Plan(format!(
+                "cached SQL plan provider '{}' is unavailable",
+                scan.table_name
+            ))
+        })?;
+        Ok(Transformed::yes(LogicalPlan::TableScan(scan)))
+    })
+    .map(|transformed| transformed.data)
+}
+
 pub(crate) async fn collect_plan(
     state: &SessionState,
-    logical_plan: LogicalPlan,
+    logical_plan: RuntimeReadPlan,
     physical_planning_cache: Option<PhysicalPlanningCache>,
 ) -> Result<Vec<RecordBatch>> {
     let task_ctx = execution_task_context(state);
@@ -79,7 +155,7 @@ pub(crate) async fn collect_plan(
 #[cfg(feature = "storage-benches")]
 pub(crate) async fn stream_plan(
     state: &SessionState,
-    logical_plan: LogicalPlan,
+    logical_plan: RuntimeReadPlan,
     physical_planning_cache: Option<PhysicalPlanningCache>,
 ) -> Result<SendableRecordBatchStream> {
     let task_ctx = execution_task_context(state);
@@ -118,13 +194,14 @@ fn execution_task_context(state: &SessionState) -> Arc<TaskContext> {
 
 async fn create_or_rebind_physical_plan(
     state: &SessionState,
-    logical_plan: LogicalPlan,
+    logical_plan: RuntimeReadPlan,
     physical_planning_cache: Option<PhysicalPlanningCache>,
 ) -> Result<Arc<dyn ExecutionPlan>> {
     let Some((cache, key)) = physical_planning_cache else {
-        return state.create_physical_plan(&logical_plan).await;
+        return state.create_physical_plan(&logical_plan.into_bound(state).await?).await;
     };
     let Some(cached) = cache.physical_read_plan(&key) else {
+        let logical_plan = logical_plan.into_bound(state).await?;
         let optimized = state.optimize(&logical_plan)?;
         let plan = state
             .query_planner()
@@ -145,7 +222,8 @@ async fn create_or_rebind_physical_plan(
     // Warm path. Neither DataFusion's analyzer, logical optimizer nor physical
     // planner runs again for this statement shape: each cached leaf scan is
     // replanned against the current snapshot's provider and grafted into the
-    // template.
+    // template. The logical plan is never consulted, which is why a detached
+    // one may arrive here without ever being rebound.
     if let Some(replacements) = plan_cached_spec_scans(&cached.scans, state).await?
         && let Some(plan) =
             rebind_physical_plan_template(Arc::clone(&cached.template), replacements)
@@ -157,6 +235,7 @@ async fn create_or_rebind_physical_plan(
     // invalidates the detached template before execution. Fall back to the
     // ordinary DataFusion planner for this statement and evict the stale entry.
     cache.forget_physical_read_plan(&key);
+    let logical_plan = logical_plan.into_bound(state).await?;
     let optimized = state.optimize(&logical_plan)?;
     state
         .query_planner()

--- a/packages/lix/tests/integration/sql/entity_view.rs
+++ b/packages/lix/tests/integration/sql/entity_view.rs
@@ -180,6 +180,120 @@ simulation_test!(
     }
 );
 
+simulation_test!(
+    entity_point_read_order_by_pk_elides_physical_sort,
+    |sim| async move {
+        let engine = sim.boot_engine().await;
+        let session = sim.wrap_session(
+            engine
+                .open_workspace_session()
+                .await
+                .expect("main session should open"),
+            &engine,
+        );
+
+        register_pushdown_note_schema(&session).await;
+        insert_pushdown_note(&session, "n1", "todo", "First", "1", "NULL").await;
+        insert_pushdown_note(&session, "n2", "done", "Second", "2", "NULL").await;
+
+        // A fully-applied primary-key equality pins the sort column to one
+        // literal, so the ORDER BY over the at-most-one matching row must not
+        // build a physical sort operator.
+        for point_sql in [
+            "SELECT id, title FROM pushdown_note WHERE id = 'n2' ORDER BY id",
+            "SELECT id, title FROM pushdown_note WHERE id IN ('n2') ORDER BY id",
+        ] {
+            let explain = session
+                .execute(&format!("EXPLAIN {point_sql}"), &[])
+                .await
+                .expect("EXPLAIN should succeed");
+            let plan = explain_plan_text(&explain);
+            assert!(
+                !plan.contains("SortExec"),
+                "point read with ORDER BY on the pinned pk must elide the sort:\n{plan}"
+            );
+
+            let result = session
+                .execute(point_sql, &[])
+                .await
+                .expect("point read should succeed");
+            assert_rows_eq(
+                result,
+                vec![vec![
+                    Value::Text("n2".to_string()),
+                    Value::Text("Second".to_string()),
+                ]],
+            );
+        }
+    }
+);
+
+simulation_test!(
+    entity_multi_key_and_unpinned_order_by_keep_physical_sort,
+    |sim| async move {
+        let engine = sim.boot_engine().await;
+        let session = sim.wrap_session(
+            engine
+                .open_workspace_session()
+                .await
+                .expect("main session should open"),
+            &engine,
+        );
+
+        register_pushdown_note_schema(&session).await;
+        insert_pushdown_note(&session, "n1", "todo", "First", "1", "NULL").await;
+        insert_pushdown_note(&session, "n2", "done", "Second", "2", "NULL").await;
+
+        // A multi-value IN pins nothing: ordering across the matched keys is
+        // real work and the sort must stay.
+        let multi_sql = "SELECT id FROM pushdown_note WHERE id IN ('n2', 'n1') ORDER BY id";
+        let explain = session
+            .execute(&format!("EXPLAIN {multi_sql}"), &[])
+            .await
+            .expect("EXPLAIN should succeed");
+        let plan = explain_plan_text(&explain);
+        assert!(
+            plan.contains("SortExec"),
+            "multi-key IN with ORDER BY must keep its physical sort:\n{plan}"
+        );
+        let result = session
+            .execute(multi_sql, &[])
+            .await
+            .expect("multi-key read should succeed");
+        assert_rows_eq(
+            result,
+            vec![
+                vec![Value::Text("n1".to_string())],
+                vec![Value::Text("n2".to_string())],
+            ],
+        );
+
+        // An inexact residual predicate proves nothing about the scan output;
+        // ordering by an unpinned column must keep its physical sort.
+        let range_sql = "SELECT id FROM pushdown_note WHERE score > 0 ORDER BY id";
+        let explain = session
+            .execute(&format!("EXPLAIN {range_sql}"), &[])
+            .await
+            .expect("EXPLAIN should succeed");
+        let plan = explain_plan_text(&explain);
+        assert!(
+            plan.contains("SortExec"),
+            "range-filtered ORDER BY must keep its physical sort:\n{plan}"
+        );
+        let result = session
+            .execute(range_sql, &[])
+            .await
+            .expect("range read should succeed");
+        assert_rows_eq(
+            result,
+            vec![
+                vec![Value::Text("n1".to_string())],
+                vec![Value::Text("n2".to_string())],
+            ],
+        );
+    }
+);
+
 async fn register_pushdown_note_schema(
     session: &crate::support::simulation_test::engine::SimSession,
 ) {


### PR DESCRIPTION
# perf(sql): cut three per-statement incidental costs on the point-read path

E38's differential budget itemized a 29.19 µs point read on this host (ryzen-9950x-I, RocksDB,
10k rows) of which ~18 µs is per-statement machinery above the store. This PR removes three of the
ranked incidental items, cheapest-per-risk first. Nothing about the public API, SQL semantics, or
result ordering changes.

## What changed

**1. Session recycle is O(1) instead of a catalog enumeration (E38 item: 2.6 µs).**
`ReadSqlSession::drop` recycled the pooled DataFusion session by calling
`MemorySchemaProvider::table_names()` — allocating one owned `String` per registered table by
walking every dashmap shard — then deregistering names one at a time through three-part
`TableReference`s. The enumeration is *not* pure waste: it exists so a later statement cannot
resolve stale snapshot-bound providers, and so storage read handles release at statement end. But
the mechanism is replaceable: the pooled session's `public` schema is now a lix-owned
`StatementSchemaProvider` (`RwLock<HashMap>`, identical registration semantics including
error-on-duplicate) whose recycle path is a single `clear()`. The enumeration fallback remains only
for a foreign schema provider reaching the pool.

**2. `SortExec` over a pinned point read is elided at plan construction (E38 item: part of 8.3 µs).**
A point read `WHERE pk = 'x' ORDER BY pk` (or single-value `IN`) streamed its at-most-one row
through a full `SortExec`. The scan now restores information the `Exact` filter pushdown had
removed from DataFusion's view: a fully-applied `col = literal` (or 1-element `IN`) pins that
output column to one value, so `SpecScanExec` declares it as a uniform constant in its equivalence
properties — exactly the fact `FilterExec` advertises when the same predicate stays above a scan.
DataFusion's own `EnforceSorting` rule then removes the sort during physical planning, so the
cached physical template never contains it and warm executions never sort. This is *not* a
runtime branch and not a ≤1-row cardinality claim: it is sound for any row count (a by-branch scan
returning N rows with the same pinned pk is still trivially ordered by it). Multi-value `IN`,
negated `IN`, `OR`, and `Inexact`/`Unsupported` filters pin nothing and keep their sort — covered
by tests in both directions.

**3. Warm cached reads skip the logical provider rebind (E38 item: 1.8 µs template rebind + part of session residue).**
On a physical-template cache hit, the statement's logical plan is provably never read — the cached
leaf-scan requests replan directly against the current snapshot and graft into the template. Yet
every warm statement still deep-walked the cached logical plan, resolved each table provider
async, and rebuilt the scan spine (`rebind_cached_read_plan`). Read plans now travel as
`RuntimeReadPlan::{Bound,Detached}`: statements owning a physical-cache key hand the detached
template over as-is, and rebinding happens inside the runtime only on the paths that actually plan
the logical tree (first execution per param set, template-fingerprint fallback). Provider
resolution goes through the same shared catalog list (`SessionState::schema_for_ref`), so the
rebound plan is identical when it is needed.

**Removed:** per-statement `table_names()` enumeration + per-name deregistration; the physical
`SortExec` on pinned point reads; the eager per-statement logical rebind on warm template hits.
**Not attempted (load-bearing):** per-statement provider *registration* (E38 item 4, 1.5 µs) is
what carries the statement's storage snapshot into the session — the warm template path consumes
those providers via `scan_with_args`, so hoisting them needs revision-keyed provider reuse, a
separate design. The sqlparser AST clone (0.85 µs) is also untouched.

## Layout invariants

1. **Single authority** — no new authority; a schema-provider implementation swap, an equivalence
   property, and a lazy rebind. No second writer or materialization.
2. **Commit canonicality** — untouched.
3. **Derived views are caches** — the planning caches remain revision/catalog-keyed caches;
   eviction/fallback paths preserved (template mismatch still falls back to the full planner).
4. **Atomic publication** — untouched.
5. **GC from refs** — untouched.
6. **SQL reads canonical records** — unchanged; providers still resolve per statement from the
   current snapshot.

## Verification

- New tests: `entity_point_read_order_by_pk_elides_physical_sort` (EXPLAIN has no `SortExec`,
  results identical) and `entity_multi_key_and_unpinned_order_by_keep_physical_sort` (multi-key IN
  and range-filtered ORDER BY keep their sort and correct order).
- Full CI-scope gate on ryzen-9950x-I (results below).
- A/B on ryzen-9950x-I, base = `claude-5-optimizations` head `d3f880ce`, cand = this branch.

### A/B — ryzen-9950x-I, RocksDB, warm sql_session hot lane, base SHA `d3f880ce`

Method: e38-run.sh's lane verbatim (TMPDIR on ext4, 5000 hot repeats per invocation, per-invocation
reseed, rotating arm order). SQLite arm is the byte-identical claim-3 binary, riding the headline
lane as reference + run-stability control (its 9-rep spread: 2.4%). Raw per-rep CSVs:
`~/claude5/e40-ab.csv`, `~/claude5/e40-upd9.csv`, `~/claude5/e40-null.csv` on the host.

| lane | rows | reps | base median | cand median | delta |
|---|---:|---:|---:|---:|---:|
| **read_one_by_pk** | 10k | 9 | **29.12 µs** | **19.77 µs** | **−32.1%** (ranges disjoint: 28.6–29.5 vs 19.2–20.3) |
| read_one_by_pk | 1k | 3 | 29.09 µs | 19.97 µs | −31.4% |
| read_one_by_pk | 100k | 3 | 29.10 µs | 19.61 µs | −32.6% |
| read_many_by_pk (10) | 10k | 3 | 115.8 µs | 112.2 µs | −3.1% |
| update_one_by_pk | 10k | 9 | 271.6 µs | 280.7 µs | +3.3% — see null control below |
| read_all (warm) | 10k | 3 | 553.6 µs | 549.4 µs | −0.7% |
| read_all (warm) | 1k | 3 | 87.1 µs | 84.7 µs | −2.7% |

- **The curve is flat and the floor drops uniformly**: −9.3 µs at 1k, −9.4 µs at 10k, −9.5 µs at
  100k. This is a fixed per-statement term removed, exactly as the differential budget predicted —
  no scaling term added or removed elsewhere (read_all flat at both sizes).
- **SQLite ratio (this host): 31.1x → 21.1x** on the point read (SQLite median 936 ns, spread 2.4%).
- `read_all` here is the hot-lane metric that stops at `len()`; nothing in this change defers work
  past result construction (the recycle and rebind savings land inside the timed statement), so the
  consumed variant cannot diverge in the other direction.

### update_one +3.3% is the instrument, not the change — measured null control

The 9-rep escalation showed cand +3.3% on update_one with disjoint ranges, which looked real. The
null control resolves it: the cand worktree was reset to **the identical base commit `d3f880ce`**
and rebuilt, and that byte-equivalent-code binary was interleaved against the base binary, 5 reps:

| lane | base (base tree) | identical code (cand tree) | artifact |
|---|---:|---:|---:|
| update_one | 273.2 µs | 281.4 µs | **+3.0%, ranges disjoint** |
| read_one | 29.1 µs | 29.3 µs | +0.7% |

Two builds of the *same commit* from different worktree paths differ by +3.0% on the write lane —
binary-layout artifact (cargo fingerprints embed the worktree path; the two target trees lay code
out differently). The candidate's write delta net of the artifact is ≈ +0.3%, unresolvable. The
read lane's artifact is +0.7%, so the −32.1% read result stands far outside instrument error.
Mechanistically this is consistent: the write path shares only the schema-provider swap (a
per-statement `HashMap` vs dashmap, nanoseconds), and none of the three changes execute on it.

### Gate — full CI scope on ryzen-9950x-I (branch head `3c175da68`)

| step | result |
|---|---|
| `cargo clippy --profile test --workspace --all-targets --all-features -- -D warnings` | exit 0 |
| `cargo test --profile test --workspace --exclude lix_benchmarks --all-features --no-fail-fast` | **3494 passed, 0 failed** |
| `cargo test --profile test -p lix_benchmarks --features storage-benches,slatedb,root-replay-trace --no-fail-fast` | **29 passed, 0 failed** |
| `cargo check -p lix --no-default-features` | exit 0 |
| `cargo check -p lix_js_sdk --target wasm32-unknown-unknown` | exit 0 |

Full logs: `~/claude5/e40-gate.log`, `~/claude5/e40-gate-tests.log`,
`~/claude5/e40-gate-bench-tests.log` on the host.

### Frame-pointer profile — the same instrument that found the items confirms their removal

Method identical to E38: dedicated `target-fp` build with
`RUSTFLAGS="-C force-frame-pointers=yes -C target-feature=+sse4.2,+pclmulqdq"` (env `RUSTFLAGS`
overrides the target rustflags, so the CRC32C features are re-added explicitly), `perf record
-F 2999 --call-graph fp` over 20 000 warm `read_one` repeats, samples bucketed by innermost owning
phase with type parameters stripped before matching (`~/claude5/e38-bucket2.awk`). FP arm measured
20.0 µs per operation (FP overhead vs the 19.8 µs A/B arm: 1.2%; E38's FP arm was 30.5 µs).

| E38 bucket (of 29.2 µs) | before | after (of 20.0 µs) |
|---|---:|---:|
| catalog `table_names()` at session recycle | 2.56 µs (8.8%) | **bucket absent (0 samples)** |
| `SortExec` (datafusion_sort) | inside the 8.33 µs stream-exec item | **bucket absent (0 samples)** |
| session recycle/drop residue | 1.14 µs (3.9%) | 0.33 µs (1.67%) |
| plan template rebind | 1.83 µs (6.3%) | 0.15 µs (0.73%) — the graft now rebuilds no sort node |
| DataFusion stream execution | 8.33 µs (28.5%) | ~4.2 µs (21.1% = df_execute 14.4% + collect 6.7%) |
| RocksDB | 4.10 µs (14.0%) | 3.53 µs (17.6%) — same absolute, larger share, as expected |

Profile artifact: `~/claude5/e40-lix-readone.perf`; full bucket table in `~/claude5/e40-fp.log`.

### What this means for claim 3

On this host the point read moves from **31.1x to 21.1x SQLite**. E38's remaining-incidentals
estimate said removing *everything* incidental lands near ~11x; what remains after this PR is the
read-session build (2.6 µs), provider registration (1.0 µs), the cooperative-stream execution
residue (~4.2 µs), statement plumbing incl. the sqlparser AST clone, and the architectural
versioning cost. Those are follow-up material (revision-keyed provider/session reuse; Arc-carried
parsed statements).
