### PR TITLE
perf(key-codec): unify the order-preserving key decoder behind one memchr scanner

### DIFF
--- a/packages/lix/src/hot_state/tracked_head.rs
+++ b/packages/lix/src/hot_state/tracked_head.rs
@@ -1121,60 +1121,30 @@ fn read_key_string(
     Ok((value, terminator))
 }
 
+/// Maps the shared scanner's structured error into this plane's vocabulary, so
+/// unifying the scanner did not unify the error text.
+fn head_key_part_error(error: KeyPartError, field: &str) -> LixError {
+    match error {
+        KeyPartError::Truncated => key_codec_error(&format!("is truncated in {field}")),
+        KeyPartError::EscapeTruncated => key_codec_error(&format!("is truncated after {field}")),
+        KeyPartError::UnknownEscape(_) => {
+            key_codec_error(&format!("{field} has an invalid terminator"))
+        }
+    }
+}
+
 fn read_key_bytes(
     bytes: &[u8],
     offset: &mut usize,
     field: &str,
 ) -> Result<(Vec<u8>, u8), LixError> {
-    let start = *offset;
-    let mut cursor = start;
-    // The normal generated IDs do not contain the escaped NUL byte. Decode
-    // that common case directly from the RocksDB key instead of first growing
-    // a temporary `Vec<u8>` one byte at a time.
-    loop {
-        let byte = *bytes
-            .get(cursor)
-            .ok_or_else(|| key_codec_error(&format!("is truncated in {field}")))?;
-        cursor += 1;
-        if byte != KEY_PART_FINAL {
-            continue;
-        }
-        let terminator = *bytes
-            .get(cursor)
-            .ok_or_else(|| key_codec_error(&format!("is truncated after {field}")))?;
-        cursor += 1;
-        if terminator != KEY_ESCAPE {
-            *offset = cursor;
-            return Ok((bytes[start..cursor - 2].to_vec(), terminator));
-        }
-        break;
-    }
-
-    // Escaped NUL bytes are rare but remain fully supported. Seed the owned
-    // buffer with the prefix before the first escape, then decode the rest.
-    let mut out = Vec::with_capacity(cursor.saturating_sub(start) + 16);
-    out.extend_from_slice(&bytes[start..cursor - 2]);
-    out.push(KEY_PART_FINAL);
-    loop {
-        let byte = *bytes
-            .get(cursor)
-            .ok_or_else(|| key_codec_error(&format!("is truncated in {field}")))?;
-        cursor += 1;
-        if byte != KEY_PART_FINAL {
-            out.push(byte);
-            continue;
-        }
-        let terminator = *bytes
-            .get(cursor)
-            .ok_or_else(|| key_codec_error(&format!("is truncated after {field}")))?;
-        cursor += 1;
-        if terminator == KEY_ESCAPE {
-            out.push(KEY_PART_FINAL);
-            continue;
-        }
-        *offset = cursor;
-        return Ok((out, terminator));
-    }
+    let part = scan_key_part(bytes, *offset).map_err(|error| head_key_part_error(error, field))?;
+    *offset = part.end;
+    let value = match part.value {
+        ScannedKeyValue::Verbatim(range) => bytes[range].to_vec(),
+        ScannedKeyValue::Unescaped(value) => value,
+    };
+    Ok((value, part.terminator))
 }
 
 fn key_codec_error(message: &str) -> LixError {

--- a/packages/lix/src/hot_state/tracked_head/hot.rs
+++ b/packages/lix/src/hot_state/tracked_head/hot.rs
@@ -11597,39 +11597,29 @@ fn read_hot_scan_key_string(
     offset: &mut usize,
     field: &str,
 ) -> Result<(HotScanString, u8), LixError> {
-    let start = *offset;
-    let mut cursor = start;
-    loop {
-        let byte = *bytes
-            .get(cursor)
-            .ok_or_else(|| key_codec_error(&format!("is truncated in {field}")))?;
-        cursor += 1;
-        if byte != KEY_PART_FINAL {
-            continue;
-        }
-        let terminator = *bytes
-            .get(cursor)
-            .ok_or_else(|| key_codec_error(&format!("is truncated after {field}")))?;
-        cursor += 1;
-        if terminator != KEY_ESCAPE {
-            let end = cursor - 2;
-            std::str::from_utf8(&bytes[start..end])
+    let part = scan_key_part(bytes.as_ref(), *offset)
+        .map_err(|error| head_key_part_error(error, field))?;
+    *offset = part.end;
+    match part.value {
+        // No escape: the part is a span of the key, so it stays shared rather
+        // than becoming an owned buffer for generated schema and file ids.
+        ScannedKeyValue::Verbatim(range) => {
+            std::str::from_utf8(&bytes[range.clone()])
                 .map_err(|error| key_codec_error(&format!("{field} is not UTF-8: {error}")))?;
-            let start = u32::try_from(start)
+            let start = u32::try_from(range.start)
                 .map_err(|_| key_codec_error(&format!("{field} offset exceeds u32")))?;
-            let end = u32::try_from(end)
+            let end = u32::try_from(range.end)
                 .map_err(|_| key_codec_error(&format!("{field} offset exceeds u32")))?;
-            *offset = cursor;
-            return Ok((HotScanString::Borrowed(start..end), terminator));
+            Ok((HotScanString::Borrowed(start..end), part.terminator))
         }
-        break;
+        // Embedded NULs require unescaping; that uncommon case owns its buffer.
+        ScannedKeyValue::Unescaped(value) => {
+            let value = String::from_utf8(value).map_err(|error| {
+                key_codec_error(&format!("{field} is not UTF-8: {}", error.utf8_error()))
+            })?;
+            Ok((HotScanString::Owned(value), part.terminator))
+        }
     }
-
-    // Embedded NULs require unescaping. Preserve that uncommon case without
-    // imposing an owned buffer on generated schema and file identifiers.
-    *offset = start;
-    read_key_string(bytes.as_ref(), offset, field)
-        .map(|(value, terminator)| (HotScanString::Owned(value), terminator))
 }
 
 fn read_hot_scan_shared_bytes(
@@ -11637,30 +11627,16 @@ fn read_hot_scan_shared_bytes(
     offset: &mut usize,
     field: &str,
 ) -> Result<(Bytes, u8), LixError> {
-    let start = *offset;
-    let mut cursor = start;
-    loop {
-        let byte = *bytes
-            .get(cursor)
-            .ok_or_else(|| key_codec_error(&format!("is truncated in {field}")))?;
-        cursor += 1;
-        if byte != KEY_PART_FINAL {
-            continue;
-        }
-        let terminator = *bytes
-            .get(cursor)
-            .ok_or_else(|| key_codec_error(&format!("is truncated after {field}")))?;
-        cursor += 1;
-        if terminator != KEY_ESCAPE {
-            *offset = cursor;
-            return Ok((bytes.slice(start..cursor - 2), terminator));
-        }
-        break;
-    }
-
-    *offset = start;
-    read_key_bytes(bytes.as_ref(), offset, field)
-        .map(|(value, terminator)| (Bytes::from(value), terminator))
+    let part = scan_key_part(bytes.as_ref(), *offset)
+        .map_err(|error| head_key_part_error(error, field))?;
+    *offset = part.end;
+    let value = match part.value {
+        // No escape: hand back a refcounted slice of the same allocation.
+        ScannedKeyValue::Verbatim(range) => bytes.slice(range),
+        // Embedded NULs had to be unescaped, so this case owns its buffer.
+        ScannedKeyValue::Unescaped(value) => Bytes::from(value),
+    };
+    Ok((value, part.terminator))
 }
 
 fn decode_hot_row_key_in_scope(bytes: &[u8], scope: &[u8]) -> Result<HeadRowIdentity, LixError> {

--- a/packages/lix/src/order_preserving_key.rs
+++ b/packages/lix/src/order_preserving_key.rs
@@ -14,29 +14,29 @@
 //! signed integers use sign-bit-flipped big endian, so lexical byte order is
 //! logical order.
 //!
-//! # The decoders are still duplicated
+//! # Decoding is unified here too
 //!
-//! Encoding is unified here. **Decoding is not** — there are three independent
-//! implementations of this same grammar, and this module owns only the
-//! primitives whose divergence would corrupt silently (the field widths, the
-//! terminator predicate, and the sign flip):
+//! Both encoding and decoding are owned by this module. Decoding used to be
+//! four hand-written scanners across three planes, differing in ownership model
+//! and in *where* the terminator was validated:
 //!
 //! | implementation | ownership | scanner | terminator validated |
 //! |---|---|---|---|
 //! | `hot_state::tracked_head` | `Vec<u8>` / `String` | byte loop | by callers |
-//! | `hot_state::tracked_head::hot` | `Bytes` / `SharedStr` | byte loop | by callers |
-//! | `tracked_state::codec` | `Vec` / `Cow` / `Bytes` | `memchr` | inside the scanner |
+//! | `hot_state::tracked_head::hot` (×2) | `Bytes` / `SharedStr` | byte loop | by callers |
+//! | `tracked_state::codec` (×2) | `Vec` / `Cow` / `Bytes` | `memchr` | inside the scanner |
 //!
-//! They agree today — [`tests::all_three_decoders_agree`] proves it over every
-//! truncation and every single-byte mutation of a seed corpus — but they agree
-//! by coincidence of maintenance, not by construction. Unifying them means
-//! standardising on one scanner (the `memchr` one) behind a borrowable span so
-//! all three ownership modes keep zero-copy, and mapping a structured error
-//! enum to each plane's own error code and prefix. That rewrites a hot inner
-//! loop, so it wants a benchmark rather than only a green gate.
+//! They agreed on accept/reject, but by coincidence of maintenance rather than
+//! by construction, and the duplication had already drifted twice. All of them
+//! now call [`scan_key_part`], which scans with `memchr` and returns either a
+//! **span of the input** or an unescaped buffer — so an owned, a borrowed and a
+//! refcounted decoder share one scanner without any of them losing zero-copy.
+//! Each plane maps the returned [`KeyPartError`] onto its own error code and
+//! prefix, so unifying the scanner did not unify the error text.
 //!
-//! Treat the differential test as the contract until then: it fails the moment
-//! a fourth divergence appears.
+//! [`tests::all_three_decoders_agree`] remains the contract, and now guards a
+//! single implementation against its callers rather than three against each
+//! other: it fails the moment a plane's decode path diverges again.
 
 pub(crate) const KEY_ESCAPE: u8 = 0xff;
 pub(crate) const KEY_PART_FINAL: u8 = 0x00;
@@ -48,6 +48,86 @@ pub(crate) const ENTITY_PK_UUID: u8 = 0x00;
 pub(crate) const ENTITY_PK_INTEGER: u8 = 0x01;
 pub(crate) const ENTITY_PK_STRING: u8 = 0x02;
 pub(crate) const ENTITY_PK_BYTES: u8 = 0x03;
+
+/// One scanned key part: where it ends, how it terminated, and how to get its
+/// bytes without copying when it contained no escape.
+pub(crate) struct ScannedKeyPart {
+    pub(crate) value: ScannedKeyValue,
+    pub(crate) terminator: u8,
+    /// Offset just past the terminator.
+    pub(crate) end: usize,
+}
+
+/// A part is either exactly a span of the input, or — when it contained an
+/// escaped NUL — a buffer that had to be unescaped. Keeping the span case
+/// separate is what lets an owned, a borrowed and a shared decoder share one
+/// scanner without any of them losing zero-copy.
+pub(crate) enum ScannedKeyValue {
+    Verbatim(core::ops::Range<usize>),
+    Unescaped(Vec<u8>),
+}
+
+/// Structured so each plane maps it to its own error code and message. The
+/// planes' wordings differ and this module deliberately does not unify them.
+pub(crate) enum KeyPartError {
+    /// Ran out of input before the part's terminating NUL.
+    Truncated,
+    /// The NUL was the last byte, so its escape-or-terminator byte is missing.
+    EscapeTruncated,
+    /// The byte after the NUL is neither `KEY_ESCAPE` nor a valid terminator.
+    UnknownEscape(u8),
+}
+
+/// Scans one escaped key part beginning at `start`.
+///
+/// This is the single implementation of the part grammar. It replaced four
+/// scanners across three planes: an owned byte loop in `hot_state::tracked_head`,
+/// two `Bytes` byte loops in `hot_state::tracked_head::hot`, and two copies of
+/// this `memchr` scan in `tracked_state::codec`. They agreed on accept/reject
+/// but validated the terminator at different layers, which is the kind of drift
+/// that eventually lands in the bytes rather than in a message.
+///
+/// Validation now happens here, in the scanner, for every plane. That is
+/// accept/reject-neutral because every call site already re-validated the
+/// terminator it was handed — what changes is only *where* a couple of
+/// malformed shapes are rejected, and hence which message they carry.
+pub(crate) fn scan_key_part(bytes: &[u8], start: usize) -> Result<ScannedKeyPart, KeyPartError> {
+    let mut segment_start = start;
+    let mut decoded: Option<Vec<u8>> = None;
+    loop {
+        let tail = bytes.get(segment_start..).ok_or(KeyPartError::Truncated)?;
+        let relative_zero =
+            memchr::memchr(KEY_PART_FINAL, tail).ok_or(KeyPartError::Truncated)?;
+        let zero = segment_start + relative_zero;
+        let escape = *bytes.get(zero + 1).ok_or(KeyPartError::EscapeTruncated)?;
+        let end = zero + 2;
+        match escape {
+            KEY_ESCAPE => {
+                let out = decoded.get_or_insert_with(|| {
+                    Vec::with_capacity(zero.saturating_sub(start).saturating_add(16))
+                });
+                out.extend_from_slice(&bytes[segment_start..zero]);
+                out.push(KEY_PART_FINAL);
+                segment_start = end;
+            }
+            terminator if is_key_part_terminator(terminator) => {
+                let value = match decoded {
+                    None => ScannedKeyValue::Verbatim(start..zero),
+                    Some(mut out) => {
+                        out.extend_from_slice(&bytes[segment_start..zero]);
+                        ScannedKeyValue::Unescaped(out)
+                    }
+                };
+                return Ok(ScannedKeyPart {
+                    value,
+                    terminator,
+                    end,
+                });
+            }
+            other => return Err(KeyPartError::UnknownEscape(other)),
+        }
+    }
+}
 
 /// Byte width of a UUID entity-primary-key component.
 pub(crate) const ENTITY_PK_UUID_BYTES: usize = 16;

--- a/packages/lix/src/order_preserving_key.rs
+++ b/packages/lix/src/order_preserving_key.rs
@@ -91,41 +91,64 @@ pub(crate) enum KeyPartError {
 /// accept/reject-neutral because every call site already re-validated the
 /// terminator it was handed — what changes is only *where* a couple of
 /// malformed shapes are rejected, and hence which message they carry.
+/// `#[inline]` is load-bearing, not decoration. This replaced byte loops that
+/// were inlined into their callers; measured on `tracked_state_crud`, letting
+/// it stay a real call cost **+5.3%** on `transaction/read_all_rows/10k` (the
+/// `hot_state` scan path) while the escape-free path is otherwise one `memchr`
+/// plus one compare. The unescaping tail is deliberately out of line so only
+/// the fast path is duplicated into each of the five call sites.
+#[inline]
 pub(crate) fn scan_key_part(bytes: &[u8], start: usize) -> Result<ScannedKeyPart, KeyPartError> {
-    let mut segment_start = start;
-    let mut decoded: Option<Vec<u8>> = None;
+    let tail = bytes.get(start..).ok_or(KeyPartError::Truncated)?;
+    let relative_zero = memchr::memchr(KEY_PART_FINAL, tail).ok_or(KeyPartError::Truncated)?;
+    let zero = start + relative_zero;
+    let escape = *bytes.get(zero + 1).ok_or(KeyPartError::EscapeTruncated)?;
+    if is_key_part_terminator(escape) {
+        // No escaped NUL: the part is exactly a span of the input, so no
+        // ownership mode has to copy.
+        return Ok(ScannedKeyPart {
+            value: ScannedKeyValue::Verbatim(start..zero),
+            terminator: escape,
+            end: zero + 2,
+        });
+    }
+    if escape != KEY_ESCAPE {
+        return Err(KeyPartError::UnknownEscape(escape));
+    }
+    scan_key_part_escaped(bytes, start, zero)
+}
+
+/// The rare tail: the part contains at least one escaped NUL, so it cannot be a
+/// span of the input and has to be unescaped into an owned buffer.
+#[cold]
+#[inline(never)]
+fn scan_key_part_escaped(
+    bytes: &[u8],
+    start: usize,
+    first_zero: usize,
+) -> Result<ScannedKeyPart, KeyPartError> {
+    let mut out = Vec::with_capacity(first_zero.saturating_sub(start).saturating_add(16));
+    out.extend_from_slice(&bytes[start..first_zero]);
+    out.push(KEY_PART_FINAL);
+    let mut segment_start = first_zero + 2;
     loop {
         let tail = bytes.get(segment_start..).ok_or(KeyPartError::Truncated)?;
-        let relative_zero =
-            memchr::memchr(KEY_PART_FINAL, tail).ok_or(KeyPartError::Truncated)?;
+        let relative_zero = memchr::memchr(KEY_PART_FINAL, tail).ok_or(KeyPartError::Truncated)?;
         let zero = segment_start + relative_zero;
         let escape = *bytes.get(zero + 1).ok_or(KeyPartError::EscapeTruncated)?;
-        let end = zero + 2;
-        match escape {
-            KEY_ESCAPE => {
-                let out = decoded.get_or_insert_with(|| {
-                    Vec::with_capacity(zero.saturating_sub(start).saturating_add(16))
-                });
-                out.extend_from_slice(&bytes[segment_start..zero]);
-                out.push(KEY_PART_FINAL);
-                segment_start = end;
-            }
-            terminator if is_key_part_terminator(terminator) => {
-                let value = match decoded {
-                    None => ScannedKeyValue::Verbatim(start..zero),
-                    Some(mut out) => {
-                        out.extend_from_slice(&bytes[segment_start..zero]);
-                        ScannedKeyValue::Unescaped(out)
-                    }
-                };
-                return Ok(ScannedKeyPart {
-                    value,
-                    terminator,
-                    end,
-                });
-            }
-            other => return Err(KeyPartError::UnknownEscape(other)),
+        out.extend_from_slice(&bytes[segment_start..zero]);
+        if is_key_part_terminator(escape) {
+            return Ok(ScannedKeyPart {
+                value: ScannedKeyValue::Unescaped(out),
+                terminator: escape,
+                end: zero + 2,
+            });
         }
+        if escape != KEY_ESCAPE {
+            return Err(KeyPartError::UnknownEscape(escape));
+        }
+        out.push(KEY_PART_FINAL);
+        segment_start = zero + 2;
     }
 }
 

--- a/packages/lix/src/tracked_state/codec.rs
+++ b/packages/lix/src/tracked_state/codec.rs
@@ -1027,51 +1027,29 @@ fn read_key_bytes(
         .map(|(value, terminator)| (value.into_owned(), terminator))
 }
 
+/// Maps the shared scanner's structured error into this plane's vocabulary.
+fn tree_key_part_error(error: KeyPartError, field: &str) -> LixError {
+    match error {
+        KeyPartError::Truncated => key_codec_error(format!("{field} is truncated")),
+        KeyPartError::EscapeTruncated => key_codec_error(format!("{field} escape is truncated")),
+        KeyPartError::UnknownEscape(other) => {
+            key_codec_error(format!("{field} has unknown escape {other}"))
+        }
+    }
+}
+
 fn read_key_bytes_cow<'a>(
     bytes: &'a [u8],
     offset: &mut usize,
     field: &str,
 ) -> Result<(Cow<'a, [u8]>, u8), LixError> {
-    let start = *offset;
-    let mut segment_start = start;
-    let mut decoded: Option<Vec<u8>> = None;
-    loop {
-        let tail = bytes
-            .get(segment_start..)
-            .ok_or_else(|| key_codec_error(format!("{field} is truncated")))?;
-        let relative_zero = memchr::memchr(0, tail)
-            .ok_or_else(|| key_codec_error(format!("{field} is truncated")))?;
-        let zero = segment_start + relative_zero;
-        let escape = *bytes
-            .get(zero + 1)
-            .ok_or_else(|| key_codec_error(format!("{field} escape is truncated")))?;
-        *offset = zero + 2;
-        match escape {
-            KEY_ESCAPE => {
-                let out = decoded.get_or_insert_with(|| {
-                    Vec::with_capacity(zero.saturating_sub(start).saturating_add(16))
-                });
-                out.extend_from_slice(&bytes[segment_start..zero]);
-                out.push(0);
-                segment_start = *offset;
-            }
-            KEY_PART_FINAL | KEY_PART_MORE => {
-                let value = decoded.map_or_else(
-                    || Cow::Borrowed(&bytes[start..zero]),
-                    |mut out| {
-                        out.extend_from_slice(&bytes[segment_start..zero]);
-                        Cow::Owned(out)
-                    },
-                );
-                return Ok((value, escape));
-            }
-            other => {
-                return Err(key_codec_error(format!(
-                    "{field} has unknown escape {other}"
-                )));
-            }
-        }
-    }
+    let part = scan_key_part(bytes, *offset).map_err(|error| tree_key_part_error(error, field))?;
+    *offset = part.end;
+    let value = match part.value {
+        ScannedKeyValue::Verbatim(range) => Cow::Borrowed(&bytes[range]),
+        ScannedKeyValue::Unescaped(value) => Cow::Owned(value),
+    };
+    Ok((value, part.terminator))
 }
 
 fn read_key_bytes_shared(
@@ -1079,46 +1057,14 @@ fn read_key_bytes_shared(
     offset: &mut usize,
     field: &str,
 ) -> Result<(Bytes, u8), LixError> {
-    let start = *offset;
-    let mut segment_start = start;
-    let mut decoded: Option<Vec<u8>> = None;
-    loop {
-        let tail = bytes
-            .get(segment_start..)
-            .ok_or_else(|| key_codec_error(format!("{field} is truncated")))?;
-        let relative_zero = memchr::memchr(0, tail)
-            .ok_or_else(|| key_codec_error(format!("{field} is truncated")))?;
-        let zero = segment_start + relative_zero;
-        let escape = *bytes
-            .get(zero + 1)
-            .ok_or_else(|| key_codec_error(format!("{field} escape is truncated")))?;
-        *offset = zero + 2;
-        match escape {
-            KEY_ESCAPE => {
-                let out = decoded.get_or_insert_with(|| {
-                    Vec::with_capacity(zero.saturating_sub(start).saturating_add(16))
-                });
-                out.extend_from_slice(&bytes[segment_start..zero]);
-                out.push(0);
-                segment_start = *offset;
-            }
-            KEY_PART_FINAL | KEY_PART_MORE => {
-                let value = decoded.map_or_else(
-                    || bytes.slice(start..zero),
-                    |mut out| {
-                        out.extend_from_slice(&bytes[segment_start..zero]);
-                        Bytes::from(out)
-                    },
-                );
-                return Ok((value, escape));
-            }
-            other => {
-                return Err(key_codec_error(format!(
-                    "{field} has unknown escape {other}"
-                )));
-            }
-        }
-    }
+    let part = scan_key_part(bytes.as_ref(), *offset)
+        .map_err(|error| tree_key_part_error(error, field))?;
+    *offset = part.end;
+    let value = match part.value {
+        ScannedKeyValue::Verbatim(range) => bytes.slice(range),
+        ScannedKeyValue::Unescaped(value) => Bytes::from(value),
+    };
+    Ok((value, part.terminator))
 }
 
 fn key_codec_error(message: impl Into<String>) -> LixError {

--- a/packages/lix/src/tracked_state/codec.rs
+++ b/packages/lix/src/tracked_state/codec.rs
@@ -752,7 +752,11 @@ fn read_entity_pk_shared(
         match terminator {
             KEY_PART_FINAL => break,
             KEY_PART_MORE => {}
-            _ => unreachable!("shared key decoder validates terminators"),
+            // Sound because every arm of `read_entity_pk_part_shared` gets its
+            // terminator past `is_key_part_terminator`: the string and bytes
+            // arms via `scan_key_part`, the fixed-width arms by checking it
+            // directly.
+            _ => unreachable!("scan_key_part validates terminators"),
         }
     }
     crate::entity_pk::EntityPk::from_components(components).map_err(|error| {
@@ -889,7 +893,9 @@ fn read_entity_pk(
         match terminator {
             KEY_PART_FINAL => break,
             KEY_PART_MORE => {}
-            _ => unreachable!("read_key_string validates terminators"),
+            // Same invariant as `read_entity_pk_shared` above: `scan_key_part`
+            // is now the single place the terminator set is enforced.
+            _ => unreachable!("scan_key_part validates terminators"),
         }
     }
     crate::entity_pk::EntityPk::from_components(components).map_err(|error| {


### PR DESCRIPTION
# perf(key-codec): unify the order-preserving key decoder behind one `memchr` scanner

Follow-on to #1387 and #1391, which unified the **encode** side (sign flip 6 copies → 1 pair,
terminator predicate 8 → 1, widths 8 → 2 constants) and landed `all_three_decoders_agree` to pin the
decoders against each other. This finishes the job on the **decode** side.

> **Note on the base branch.** This was developed against `claude-5-optimizations` at `d3f880ce`,
> which is where the gate and both benchmark arms ran. That branch was merged to `main` (#1364) and
> deleted while this work was in flight, so the PR targets `main` instead. It is **not** rebased:
> `d3f880ce` is an ancestor of `main`, so the diff is exactly the three commits below. The 28 commits
> that landed on `main` since `d3f880ce` touch **none** of these four files — zero conflict surface —
> but the gate below was run on the `d3f880ce` lineage, not on current `main`. Say the word and I
> will re-gate on the current head.

## What changed physically

`order_preserving_key::scan_key_part` is now the single implementation of the key-part grammar. It
scans with `memchr` and returns a `ScannedKeyPart`, whose value is either

- `ScannedKeyValue::Verbatim(Range<usize>)` — a **span of the input**, when the part contained no
  escaped NUL (the overwhelmingly common case for generated schema keys, file ids and entity pks), or
- `ScannedKeyValue::Unescaped(Vec<u8>)` — an owned buffer, only when a NUL had to be unescaped.

Returning a *span* rather than a value is what lets three different ownership models share one
scanner without any of them giving up zero-copy: the owned decoder does `bytes[range].to_vec()`, the
`Cow` decoder does `Cow::Borrowed(&bytes[range])`, and the two `Bytes` decoders do
`bytes.slice(range)` — a refcount bump on the same allocation, exactly as before.

Errors are a structured `KeyPartError { Truncated, EscapeTruncated, UnknownEscape(u8) }`, which each
plane maps through its own helper (`head_key_part_error`, `tree_key_part_error`) onto its own error
code and message prefix. **Unifying the scanner did not unify the error text.**

## What was removed

**Four hand-written scanners across three planes**, all replaced by calls to `scan_key_part`:

| removed | plane | ownership | previously |
|---|---|---|---|
| `read_key_bytes`'s two-phase byte loop | `hot_state::tracked_head` | `Vec<u8>` / `String` | byte loop, terminator validated by callers |
| `read_hot_scan_key_string`'s byte loop | `hot_state::tracked_head::hot` | `SharedStr` | byte loop, fell back to re-scanning via the owned decoder on escape |
| `read_hot_scan_shared_bytes`'s byte loop | `hot_state::tracked_head::hot` | `Bytes` | byte loop, fell back to an **owned copy** on escape |
| `read_key_bytes_cow` / `read_key_bytes_shared`'s duplicated `memchr` scans | `tracked_state::codec` | `Cow` / `Bytes` | two copies of the same `memchr` loop |

Four files, **+200 / −199**. The line count is a wash because the deleted loops are replaced by one
scanner plus doc comments — the win is *authority*, not size. The structural check is that
`KEY_ESCAPE` now appears in `packages/lix/src` only inside `order_preserving_key.rs`: its
definition, the two arms of the one scanner, the one writer, and a test. No other module in the
crate can even name the escape byte.

## Benchmark guard — and a real regression that had to be fixed first

Machine **ryzen-9950x-III** (32c/186G), base arm at `d3f880ce` (= `origin/claude-5-optimizations`,
verified clean before every run). Interleaved with **arm-order rotation** (base-first on odd reps,
cand-first on even). Command:

```
cargo bench -p lix_benchmarks --features storage-benches,slatedb --bench tracked_state_crud -- '<filter>'
```

**Null control:** the `kv_layout/*` lanes are an *in-binary* control — they build their own
length-prefixed keys (`push_component` writes a `u32` length) and read raw storage, so they never
call the order-preserving decoder. Their code is byte-identical in both arms, they run in the same
process and the same interleaved session, and they are already inside the `read_` filter. That is a
better calibration than borrowing a control from another bench binary.

The seeding path is also *not* the changed path — encode is untouched by this PR — so the two arms'
stores are identical before the first timed op. The control behaves consistently at 1k and 10k
(no small-N/large-N divergence), which is the tell for the arms' stores having drifted apart.

### The first attempt regressed the hot scan path — this is the load-bearing finding

The unified scanner replaced byte loops that were **inlined into their callers**. Left as a real
call returning a 40-byte `ScannedKeyPart` by value, it cost:

| lane (5 reps/arm) | base ms | cand ms | delta |
|---|---|---|---|
| `transaction/lix_rocksdb/real_workload/read_all_rows/10k` | 11.793 | 12.422 | **+5.33%** |
| `transaction/lix_rocksdb/smoke/read_all_rows/1k` | 1.2265 | 1.2619 | **+2.89%** |
| *null control* `kv_layout/.../read_all_rows/10k` | 1.3208 | 1.3400 | +1.45% |

Raw per-rep, 10k lane — the arms' ranges did **not overlap**, so this was real, not noise:

```
base: 11.7630 11.6430 11.7930 11.8800 11.9690      (11.643 – 11.969)
cand: 12.4430 12.4220 12.2970 12.5460 12.1660      (12.166 – 12.546)
```

The attribution is clean and worth recording: `transaction/read_all_rows` goes through
`hot_state.reader(..).scan_batch(..)` — the **`hot.rs` scan plane**, whose two byte loops were the
tightest of the four. `sql_session/read_all_rows`, which reads via the `codec` plane (already
`memchr` before this PR), was flat over the same runs (−0.21%). The regression landed exactly where
the theory says it should.

**Fix:** split the fast path. `scan_key_part` is `#[inline]` and handles the escape-free case in one
`memchr` plus one compare; the unescaping tail moved to a `#[cold] #[inline(never)]` helper so only
the small fast path is duplicated into the five call sites.

### After the fix — 9 reps on the lane that moved

| lane (9 reps/arm) | base ms | cand ms | delta |
|---|---|---|---|
| `transaction/lix_rocksdb/real_workload/read_all_rows/10k` | 11.836 | 11.828 | **−0.07%** |
| `transaction/lix_slatedb/real_workload/read_all_rows/10k` | 12.498 | 12.402 | −0.77% |
| `sql_session/lix_rocksdb/real_workload/read_all_rows/10k` | 2.5634 | 2.5932 | +1.16% |
| `sql_session/lix_slatedb/real_workload/read_all_rows/10k` | 2.6797 | 2.6851 | +0.20% |
| **null control** `kv_layout/.../read_all_rows/10k` | 1.3082 | 1.3133 | **+0.39%** |

Raw per-rep for the lane that had regressed:

```
base: 11.4790 11.9850 11.5810 11.9040 11.9170 11.5790 11.7670 11.8360 11.9800
cand: 11.6480 11.8530 11.9630 11.7670 11.9170 11.8280 11.9960 11.6120 11.6760
```

Full `read_all_rows` sweep at 5 reps/arm after the fix: 12 decoder lanes spanning **−2.81% ..
+2.01%, median +0.44%**, against a null control of **+0.97% .. +1.20%**. The decoder lanes' median
sits *below* the control's own bias.

**Null-control spread across all runs: −1.10% .. +1.45%.** This bench cannot resolve anything under
roughly ±1.5%, so every post-fix delta above is unresolvable.

**Conclusion: the cut is performance-neutral.** There is **no speed claim here** — `memchr` did not
turn out measurably faster than the byte loops on this path once both are inlined, and I am not
claiming a win the instrument cannot resolve. The requirement for a cut is that it is *not slower*,
and that is what the numbers show.

## Mutation test — the differential still has teeth

The concern with collapsing three implementations onto one is that `all_three_decoders_agree`
degrades into an assertion of coverage rather than coverage. It does not. Each mutation was applied
to the candidate tree, the test run, and the tree restored:

| mutation | expectation | result |
|---|---|---|
| M0 — unmutated control | pass | **passed** |
| M1 — `tracked_head` hardcodes the terminator to `KEY_PART_FINAL` | fail | **FAILED** — `tracked_head and hot disagree on case 5` |
| M2 — `hot.rs` off-by-one on the borrowed `Bytes` span | fail | **FAILED** — `tracked_head and hot disagree on case 6` |
| M3 — `codec` off-by-one on the borrowed `Cow` span | fail | **FAILED** — `tracked_head and tracked_state disagree on case 0` |
| M4 — the **shared** scanner accepts `0x02` as a terminator | ? | **FAILED** — `tracked_head and tracked_state disagree on case 471` |

M4 is the interesting one. A mutation inside the now-shared scanner still produces a genuine
cross-plane *disagreement*, because the planes' **callers** validate independently and differently:
`tracked_head`'s entity-pk loop has an explicit `_ => Err(..)` arm that still rejects `0x02`, while
`codec`'s treats any non-`FINAL` terminator as "more components" and accepts. The redundant
per-caller validation that made this cut safe is the same thing that keeps the differential
meaningful over a unified implementation. M4 is *also* caught independently by
`key_part_terminators_are_exactly_two`.

The corpus genuinely exercises the changed shapes: its seeds include an escaped-NUL string
(`"a\0b"`) and `Bytes([0x00, 0xff])` — so both the `Verbatim` and `Unescaped` paths are covered for
all three ownership modes — and its single-byte mutations over `{0x00,0x01,0x02,0x03,0x04,0x7f,0xfe,0xff}`
produce exactly the `00 X` invalid-terminator shapes this PR moves.


## The behavioural delta, in full

This is the entire list; it is short on purpose and is the thing to review.

**`tracked_state::codec` is behaviour-identical**, not merely equivalent. Its old scanner already
validated inside itself with `KEY_PART_FINAL | KEY_PART_MORE`, and `is_key_part_terminator` is
*exactly* `matches!(byte, KEY_PART_FINAL | KEY_PART_MORE)`; `KEY_PART_FINAL == 0x00`, which is the
byte the old `memchr(0, ..)` searched for. Same accept/reject, same messages, same order.

The whole delta is on the **`tracked_head` planes**, whose loops previously accepted *any*
non-`KEY_ESCAPE` byte as a terminator and handed it back. Validation now happens in the scanner.

**That is accept/reject-neutral**, because the new acceptance set is a strict subset of the old one
and **every call site already re-validated the terminator it was handed** — all ten of them:
`read_entity_pk`'s loop on both planes (`_ => Err(...)`), and eight explicit
`if terminator != KEY_PART_FINAL` checks on schema key, branch id and file id.

What changes is *where* a malformed key is rejected, and therefore which message it carries. Six
shapes, all rejected before and after. Let `X` be a byte with `X ∉ {0x00, 0x01, 0xff}` directly
after a part's terminating NUL:

| # | shape | old message | new message |
|---|---|---|---|
| 1 | schema key ends `00 X` | `hot row schema key has an invalid terminator` (+ the `hot diff row` / `hot diff` / `hot file marker` variants) | `schema key has an invalid terminator` |
| 2 | branch id ends `00 X` | `hot diff branch id has an invalid terminator` | `branch id has an invalid terminator` |
| 3 | file id ends `00 X` | `file id has an invalid terminator` | **identical** |
| 4 | entity-pk **String** component ends `00 X` | `entity primary key has an invalid terminator` | **identical** |
| 5 | entity-pk **Bytes** component ends `00 X` | `entity primary key has an invalid terminator` | `entity primary key bytes has an invalid terminator` |
| 6 | a string part that is **both** non-UTF-8 **and** ends `00 X` | `<field> is not UTF-8: …` | `<field> has an invalid terminator` (terminator now checked first) |

Truncation maps one-to-one: `Truncated → "is truncated in <field>"`,
`EscapeTruncated → "is truncated after <field>"`, matching both old loops' `bytes.get()` misses.

Every message keeps its plane's `LixError::CODE_INTERNAL_ERROR` and its plane's prefix
(`invalid tracked-head row key:` / `invalid tracked-state row key:`).

### Why this drift was worth removing

Both divergences that had already appeared between these copies were harmless only by accident: an
encode-side `debug_assert!(!components.is_empty())` present on one plane and not the other (same
input, debug panic on one, fine on the other), and `tracked_head`'s scanner accepting any non-escape
byte as a terminator where `codec`'s rejected it — safe *only* because every current caller
re-validates. A new caller that forgot would have silently accepted garbage keys. That failure mode
is now structurally impossible: there is one scanner and it validates.

### One non-behavioural difference, for completeness

The old `codec` scanner set `*offset = zero + 2` *before* matching the escape byte, so on the
unknown-escape error path it left `offset` advanced. `scan_key_part` leaves `offset` untouched on
error. Every caller propagates with `?` and none reads `offset` after an error, so this is
unobservable.

### Two `unreachable!`s that are load-bearing

`tracked_state::codec` has two `unreachable!`s in its entity-pk loops asserting the terminator was
already validated. They remain sound: the fixed-width arms check `is_key_part_terminator` directly
and the string/bytes arms get their terminator from `scan_key_part`. One of the two comments still
named `read_key_string` as the validator; both now name `scan_key_part`.



## Layout invariants

1. **Single authority.** Yes, and it *deletes* rather than relocates: four scanners become one, and
   the three planes' decoders become callers of it. No new authority for any fact — `scan_key_part`
   owns no state, it is a pure function over a byte slice.
2. **Commit canonicality.** Untouched. No commit, parent link or state root is read or written
   differently.
3. **Derived views are caches.** Untouched. The hot-head serving index remains a rebuildable cache;
   this changes only how its keys are parsed, and byte-identically.
4. **Atomic publication.** Untouched — decode only, no write path.
5. **GC from refs.** Untouched.
6. **SQL reads canonical records.** Untouched.

**Storage adapter API: no change.** No trait method added, changed or removed; the conformance suite
and `third_party_storage_adapter.rs` are untouched. **Public API: no change** — every item involved
is `pub(crate)` or private.

## Gate

Full CI-scope gate on **ryzen-9950x-III**, run against the exact SHA this PR carries. `HEAD` and
`git status --porcelain` were printed *inside* the run:

```
HEAD=23392ff51042d17a6a3ff566da7647c9f3dc1d28
--- git status --porcelain ---
--- end status ---            # empty
CARGO_TARGET_DIR=/root/claude5/target-cand
```

| step | result |
|---|---|
| `cargo check --workspace --all-targets --all-features` | exit 0 |
| `cargo clippy --profile test --workspace --all-targets --all-features -- -D warnings` | exit 0 |
| `cargo check -p lix --no-default-features` | exit 0 |
| `cargo check -p lix_js_sdk --target wasm32-unknown-unknown` | exit 0 |
| `cargo test --profile test --workspace --exclude lix_benchmarks --all-features --no-fail-fast` | exit 0 — **56 targets, 3490 passed, 0 failed**, 50 ignored |
| `cargo test --profile test -p lix_benchmarks --features storage-benches,slatedb,root-replay-trace --no-fail-fast` | exit 0 — **11 targets, 29 passed, 0 failed**, 7 ignored |

Logs were captured to files and grepped (`failures:`, `panicked`, `test result: FAILED`, `^error`) —
**0 matching lines in all six logs**. Not tailed.

The features-OFF pair (`-p lix --no-default-features`, `lix_js_sdk` on wasm32) is included because
this PR moves code between a `#[cfg]`-heavy module and its callers.

All six pinning tests in `order_preserving_key::tests` ran and passed, including
`all_three_decoders_agree`, `key_part_terminators_are_exactly_two` and the three byte-pinned
encoding tests.

`rustfmt --check` was run on the four touched files only, **not** repo-wide (the tree is
fmt-dirty on `main` and reformatting would bury the diff). Both arms were checked and report the
**identical** set of diffs — 5 in `order_preserving_key.rs` and 6 in `codec.rs` on `d3f880ce`, and
the same 11 on this branch, none of them inside the code this PR adds or moves. **This PR introduces
zero new formatting diffs.** No `rustfmt` was run on a module root, so nothing unrelated was
reformatted.

## Not done / limits

- **No speed claim.** The guard shows neutrality, not a win. `memchr` is not measurably faster than
  the byte loops on this path once both are inlined, and this bench cannot resolve under ~±1.5%.
- Guards were chosen to match the layer touched (read lanes; a decode-only change cannot move the
  write matrix or physical bytes, so those were not run — per the guard-selection table, a guard
  that cannot execute the changed code is not a guard).
- The `#[inline]` on `scan_key_part` is load-bearing and measured; if a future change moves the
  unescaping back inline, the `+5.3%` returns. That is recorded in a comment on the function.
