### PR TITLE
fix(gc): re-measure the JSON leak with checkpoints — it is real, at 1 payload per edit

### DIFF
--- a/packages/engine-benchmarks/examples/e1_json_leak.rs
+++ b/packages/engine-benchmarks/examples/e1_json_leak.rs
@@ -6,7 +6,17 @@
 //! probe measures what that costs on the workload being advertised: an agent
 //! rewriting the same file over and over.
 //!
-//! Two fixture facts the measurement depends on:
+//! **This probe's original form produced misleading evidence and was corrected.**
+//! It never created a checkpoint, and the shipping sweep retires nothing
+//! without one: a 1000-edit stream with no checkpoint retires 0 commit-state
+//! manifests, while the same stream with a checkpoint every 10 edits retires
+//! 1095 (measured by `e29_locator_leak`). The original "0 rows reclaimed at
+//! 10/100/1000 rewrites" was therefore consistent with two different worlds —
+//! "`json_store` is not wired into the sweep" and "the sweep had no work to do
+//! in this fixture" — and could not separate them. The checkpoint cadence below
+//! exists to separate them, so **do not remove it**.
+//!
+//! Three fixture facts the measurement depends on:
 //!
 //! 1. **The out-of-band threshold is `JSON_INLINE_MAX_BYTES` (1 KiB) on the raw
 //!    normalized snapshot.** The 512-byte/128-byte constants are the *zstd*
@@ -17,16 +27,29 @@
 //!    byte-identical content dedups to one row and leaks nothing. Every
 //!    rewrite here is a *distinct* payload, which is what an agent editing a
 //!    file actually produces.
+//! 3. **A checkpoint is what makes a commit retirable.** Without one every
+//!    commit remains a physical authority of the live head, so no retirement is
+//!    proven and no plane — JSON or otherwise — can be observed being swept.
+//!
+//! Two churn shapes, because they bound the answer from both sides:
+//!
+//! * `rewrite` — one entity, rewritten `n` times. Exactly **one** payload is
+//!   live at the end and the other `n` are superseded. This is the leak arm.
+//! * `insert` — `n` distinct entities, each written once. **All** payloads are
+//!   live. This is the control: a sweep that reclaims anything here is wrong,
+//!   so it separates "reclaims dead payloads" from "reclaims payloads".
 //!
 //! ```text
-//! e1_json_leak <rewrites> [<rewrites> ...]
+//! e1_json_leak [<edits> ...]              # default 10 100 1000
+//! E1_SHAPES=rewrite,insert
+//! E1_CHECKPOINT_CADENCES=0,10,100         # 0 means "never checkpoint"
 //! ```
 
 #![allow(clippy::large_futures)]
 
 use lix::Value;
 use lix::integration::{Engine, SessionContext};
-use lix::registered_spaces::JSON_SPACE;
+use lix::registered_spaces::{JSON_SPACE, TRACKED_STATE_COMMIT_STATE_MANIFEST_SPACE};
 use lix::storage::Storage;
 use lix::storage_adapter::{Memory, StorageAdapter, StorageReadOptions};
 use lix::storage_bench::{collect_repository_gc_for_bench, space_inventory};
@@ -69,12 +92,13 @@ where
         .expect("register leak schema");
 }
 
-async fn json_rows(storage: &StorageAdapter<Memory>) -> (usize, usize) {
+/// `(rows, bytes)` in one space.
+async fn space_rows(storage: &StorageAdapter<Memory>, space: &str) -> (usize, usize) {
     let read = storage
         .begin_read(StorageReadOptions::default())
         .await
-        .expect("open json inventory read");
-    let entries = space_inventory(&read, JSON_SPACE.name).await;
+        .expect("open space inventory read");
+    let entries = space_inventory(&read, space).await;
     let bytes = entries
         .iter()
         .map(|(key, value)| key.len() + value.len())
@@ -82,44 +106,58 @@ async fn json_rows(storage: &StorageAdapter<Memory>) -> (usize, usize) {
     (entries.len(), bytes)
 }
 
-#[tokio::main(flavor = "current_thread")]
-async fn main() {
-    let counts = std::env::args()
-        .skip(1)
-        .map(|arg| arg.parse::<usize>().expect("rewrite count"))
-        .collect::<Vec<_>>();
-    let counts = if counts.is_empty() {
-        vec![10, 100, 1_000]
-    } else {
-        counts
-    };
+fn list_from_env(var: &str, default: &[usize]) -> Vec<usize> {
+    std::env::var(var).map_or_else(
+        |_| default.to_vec(),
+        |raw| {
+            raw.split(',')
+                .filter(|part| !part.trim().is_empty())
+                .map(|part| part.trim().parse::<usize>().expect("numeric list entry"))
+                .collect()
+        },
+    )
+}
 
-    for rewrites in counts {
-        let memory = Memory::new();
-        Engine::initialize(memory.clone())
-            .await
-            .expect("initialize leak repository");
-        let engine = Engine::new(memory.clone())
-            .await
-            .expect("open leak engine");
-        let session = engine
-            .open_workspace_session()
-            .await
-            .expect("open leak workspace");
-        register_schema(&session).await;
+/// One matrix cell: `edits` mutations of `shape`, checkpointing every
+/// `cadence` edits, then one shipping sweep.
+async fn run_cell(shape: &str, cadence: usize, edits: usize) {
+    let memory = Memory::new();
+    Engine::initialize(memory.clone())
+        .await
+        .expect("initialize leak repository");
+    let engine = Engine::new(memory.clone())
+        .await
+        .expect("open leak engine");
+    let session = engine
+        .open_workspace_session()
+        .await
+        .expect("open leak workspace");
+    register_schema(&session).await;
 
-        session
-            .execute(
-                "INSERT INTO leak_row (path, value) VALUES ($1, lix_json($2))",
-                &[
-                    Value::Text("/agent/file".to_owned()),
-                    Value::Text(payload(0)),
-                ],
-            )
-            .await
-            .expect("insert the first revision");
+    session
+        .execute(
+            "INSERT INTO leak_row (path, value) VALUES ($1, lix_json($2))",
+            &[
+                Value::Text("/agent/file".to_owned()),
+                Value::Text(payload(0)),
+            ],
+        )
+        .await
+        .expect("insert the first revision");
 
-        for revision in 1..=rewrites {
+    for revision in 1..=edits {
+        if shape == "insert" {
+            session
+                .execute(
+                    "INSERT INTO leak_row (path, value) VALUES ($1, lix_json($2))",
+                    &[
+                        Value::Text(format!("/agent/file-{revision}")),
+                        Value::Text(payload(revision)),
+                    ],
+                )
+                .await
+                .expect("insert a distinct row");
+        } else {
             session
                 .execute(
                     "UPDATE leak_row SET value = lix_json($2) WHERE path = $1",
@@ -131,22 +169,78 @@ async fn main() {
                 .await
                 .expect("rewrite the same row");
         }
-
-        let storage = StorageAdapter::new(memory.clone());
-        let (rows_before, bytes_before) = json_rows(&storage).await;
-        collect_repository_gc_for_bench(&storage)
+        if cadence > 0 && revision % cadence == 0 {
+            session
+                .create_checkpoint()
+                .await
+                .expect("create a checkpoint");
+        }
+    }
+    let mut checkpoints = 0;
+    if cadence > 0 {
+        // A checkpoint releases the *previous* checkpoint's pins, so the last
+        // one needs a successor before its predecessors are provably retirable.
+        checkpoints = edits / cadence + 1;
+        session
+            .create_checkpoint()
             .await
-            .expect("run the shipping repository sweep");
-        let (rows_after, bytes_after) = json_rows(&storage).await;
+            .expect("create the releasing checkpoint");
+    }
 
-        // Exactly one revision is live: the row was rewritten in place.
-        println!(
-            "E1LEAK rewrites={rewrites} live_payloads=1 \
-             rows_before_gc={rows_before} rows_after_gc={rows_after} \
-             bytes_before_gc={bytes_before} bytes_after_gc={bytes_after} \
-             reclaimed_rows={} orphan_rows={}",
-            rows_before.saturating_sub(rows_after),
-            rows_after.saturating_sub(1),
-        );
+    let storage = StorageAdapter::new(memory.clone());
+    let (json_before, json_bytes_before) = space_rows(&storage, JSON_SPACE.name).await;
+    let (manifests_before, _) =
+        space_rows(&storage, TRACKED_STATE_COMMIT_STATE_MANIFEST_SPACE.name).await;
+
+    collect_repository_gc_for_bench(&storage)
+        .await
+        .expect("run the shipping repository sweep");
+
+    let (json_after, json_bytes_after) = space_rows(&storage, JSON_SPACE.name).await;
+    let (manifests_after, _) =
+        space_rows(&storage, TRACKED_STATE_COMMIT_STATE_MANIFEST_SPACE.name).await;
+
+    // `rewrite` leaves one live payload; `insert` leaves one per entity.
+    let live_payloads = if shape == "insert" { edits + 1 } else { 1 };
+    let leaked = json_after.saturating_sub(live_payloads);
+
+    println!(
+        "E1LEAK shape={shape} cadence={cadence} edits={edits} checkpoints={checkpoints} \
+         live_payloads={live_payloads} \
+         json_before={json_before} json_after={json_after} \
+         json_bytes_before={json_bytes_before} json_bytes_after={json_bytes_after} \
+         manifests_before={manifests_before} manifests_after={manifests_after} \
+         retired_manifests={} reclaimed_json={} leaked_payloads={leaked} \
+         leaked_per_edit={:.3}",
+        manifests_before.saturating_sub(manifests_after),
+        json_before.saturating_sub(json_after),
+        leaked as f64 / edits as f64
+    );
+}
+
+#[tokio::main(flavor = "current_thread")]
+async fn main() {
+    let counts = std::env::args()
+        .skip(1)
+        .map(|arg| arg.parse::<usize>().expect("edit count"))
+        .collect::<Vec<_>>();
+    let counts = if counts.is_empty() {
+        vec![10, 100, 1_000]
+    } else {
+        counts
+    };
+    let cadences = list_from_env("E1_CHECKPOINT_CADENCES", &[0, 10, 100]);
+    let shapes = std::env::var("E1_SHAPES")
+        .unwrap_or_else(|_| "rewrite,insert".to_owned())
+        .split(',')
+        .map(str::to_owned)
+        .collect::<Vec<_>>();
+
+    for shape in &shapes {
+        for &cadence in &cadences {
+            for &edits in &counts {
+                run_cell(shape, cadence, edits).await;
+            }
+        }
     }
 }

--- a/packages/lix/src/gc.rs
+++ b/packages/lix/src/gc.rs
@@ -1150,9 +1150,27 @@ where
 /// nothing replaced it. `stage_delete_refs` and every function that enumerates
 /// payload hashes are `#[cfg(test)]`, and this path stages an empty
 /// `json_payloads`. A repository's out-of-band payload count therefore grows
-/// linearly with edits and is never reclaimed -- measured at 0 rows reclaimed
-/// for 10, 100, and 1000 rewrites of a single row
-/// (`engine-benchmarks/examples/e1_json_leak.rs`).
+/// linearly with edits and is never reclaimed.
+///
+/// The rate is **one leaked payload per superseded edit**, and it is
+/// independent of checkpoint cadence. Measured by
+/// `engine-benchmarks/examples/e1_json_leak.rs` over a
+/// shape x cadence x edits matrix: rewriting one row 1000 times leaves 1004
+/// payload rows where 1 is live, at every cadence (never / every 10 / every
+/// 100), i.e. `leaked_per_edit` 1.300 -> 1.030 -> 1.003 at 10 -> 100 -> 1000
+/// edits, converging on 1.0 over a fixed ~3-row bootstrap. The `insert` control
+/// arm, where every payload stays live, leaks exactly those 3 rows at every
+/// size -- so the rewrite arm's growth is the superseded payloads and nothing
+/// else.
+///
+/// **That measurement is only meaningful because the probe checkpoints.** An
+/// earlier version of this comment cited the same probe before it did, and that
+/// evidence could not support the claim: without a checkpoint the sweep proves
+/// *nothing* retirable -- 0 commit-state manifests retired across 1000 edits --
+/// so "0 payloads reclaimed" was equally consistent with "the sweep had no work
+/// to do". With a checkpoint every 10 edits the same stream retires 1095
+/// manifests and *still* reclaims 0 payloads. That is what establishes the
+/// leak: the owning commits really are being retired underneath the payloads.
 /// Ordinary GC derives its candidates from the physical manifest inventory and
 /// proves liveness only from refs: branch-head controls and checkpoint recovery
 /// refs are the complete active-root set, and the walk from those roots through

--- a/packages/lix/src/registered_spaces.rs
+++ b/packages/lix/src/registered_spaces.rs
@@ -79,8 +79,22 @@ pub const CURRENT_STATE_DATA_PART_SPACE: StorageSpace =
 pub const CURRENT_STATE_DATA_PART_REFS_SPACE: StorageSpace =
     crate::tracked_state::CURRENT_STATE_DATA_PART_REFS_SPACE;
 pub const SCOPED_RANGE_NODE_SPACE: StorageSpace = crate::tracked_state::SCOPED_RANGE_NODE_SPACE;
-/// Declared-column access path over the hot rows. Disposable: derived from the
-/// hot rows and reclaimed with its generation.
+/// Declared-column access path over the hot rows. Disposable, and genuinely
+/// reclaimed with its generation: `INDEX_SPACE` is the first entry in
+/// `GENERATION_SCOPED_SPACES` (`hot_state/tracked_head/hot.rs`), so
+/// `stage_retire_hot_generation` deletes every entry *and* witness under the
+/// retired `(branch_id, generation)` prefix, and the sole writer of this plane
+/// (`stage_hot_index_entries`, called from `transaction/commit.rs`) is not
+/// reached on any lifecycle republication route. Tombstones do not change this:
+/// a deleted row never mints an index entry at all, because the extractor runs
+/// only in the live-snapshot arm of transaction validation.
+///
+/// "Derived from the hot rows" is the one imprecise part, so do not rely on it:
+/// nothing reconstructs this plane *from* `ROW_SPACE`. Entries are extracted
+/// from snapshot JSON during transaction validation and carried on the prepared
+/// batch, so the plane is rebuildable from canonical records but not from the
+/// hot rows it indexes. Once a generation is retired, the surviving hot rows
+/// cannot rebuild it.
 pub const HOT_INDEX_SPACE: StorageSpace = crate::hot_state::INDEX_SPACE;
 pub const BINARY_CAS_MANIFEST_SPACE: StorageSpace = crate::binary_cas::BINARY_CAS_MANIFEST_SPACE;
 pub const BINARY_CAS_MANIFEST_CHUNK_SPACE: StorageSpace =


### PR DESCRIPTION
# fix(gc): re-measure the JSON leak with checkpoints — it is real, and the rate is 1 payload per edit

Machine: `hetzner-cpx62-IV` (16c/30G). Base: `main` @ `838c8ba3`. `CARGO_BUILD_JOBS=4`,
`TMPDIR=$HOME/claude5/tmp`.

Follow-up to #1397, which showed that `e1_json_leak.rs` never checkpointed and that the shipping
sweep retires nothing without a checkpoint — so its "0 payloads reclaimed" could not distinguish
*"`json_store` is not wired into the sweep"* from *"the sweep had no work to do."*

**Answer: the leak is real.** With checkpoints the sweep retires the owning commits — up to 1095
manifests on a 1000-edit stream — and **reclaims zero JSON payloads anyway**.

## The matrix

`E1_SHAPES=rewrite,insert E1_CHECKPOINT_CADENCES=0,10,100 e1_json_leak 10 100 1000`.
Deterministic row counts, **1 rep**, 18 cells.

### `rewrite` — one entity rewritten `n` times, so exactly 1 payload is live

| cadence | edits | ckpts | json before → after | manifests before → after | **retired** | **reclaimed json** | **leaked** | leaked/edit |
|---|---|---|---|---|---|---|---|---|
| never | 10 | 0 | 14 → 14 | 13 → 13 | 0 | 0 | 13 | 1.300 |
| never | 100 | 0 | 104 → 104 | 103 → 103 | 0 | 0 | 103 | 1.030 |
| never | 1000 | 0 | 1004 → 1004 | 1003 → 1003 | 0 | 0 | 1003 | 1.003 |
| /10 | 10 | 2 | 14 → 14 | 17 → 7 | 10 | 0 | 13 | 1.300 |
| /10 | 100 | 11 | 104 → 104 | 125 → 20 | 105 | 0 | 103 | 1.030 |
| /10 | 1000 | 101 | 1004 → 1004 | 1205 → 110 | **1095** | **0** | 1003 | 1.003 |
| /100 | 10 | 1 | 14 → 14 | 15 → 15 | 0 | 0 | 13 | 1.300 |
| /100 | 100 | 2 | 104 → 104 | 107 → 7 | 100 | 0 | 103 | 1.030 |
| /100 | 1000 | 11 | 1004 → 1004 | 1025 → 20 | **1005** | **0** | 1003 | 1.003 |

### `insert` — `n` distinct entities, every payload live (control)

| cadence | edits | live | json before → after | retired | reclaimed | leaked |
|---|---|---|---|---|---|---|
| never | 1000 | 1001 | 1004 → 1004 | 0 | 0 | **3** |
| /10 | 1000 | 1001 | 1004 → 1004 | 0 | 0 | **3** |
| /100 | 1000 | 1001 | 1004 → 1004 | 0 | 0 | **3** |

(All nine `insert` cells leak exactly 3 at every size and cadence.)

## What the numbers establish

1. **The leak is real, and it is not a retirement problem.** In the two cells that retire the most
   (1095 and 1005 manifests), `json_before == json_after` exactly. The owning commits are being
   swept out from underneath the payloads and the payloads stay. This is the evidence the previous
   measurement could not supply.

2. **The rate is one payload per superseded edit.** `leaked_per_edit` converges 1.300 → 1.030 →
   1.003 at 10 → 100 → 1000 edits. The `insert` control leaks exactly **3** rows at every size, so
   that 3 is a fixed bootstrap constant and the rewrite arm's growth is the superseded payloads and
   nothing else. The clean form is **leaked = edits + 3**.

3. **Checkpoint cadence does not matter.** `json_after` is byte-identical across never / every 10 /
   every 100 (1004 rows, 138,967 bytes at 1000 edits). Nothing about checkpoint frequency, commit
   retirement, or GC pressure changes it — consistent with `stage_repository_gc_with_preconditions`
   staging a literally empty `json_payloads` (`gc.rs`), i.e. the plane is not wired in at all rather
   than wired in and losing a race.

4. **Per branch lifetime**, since that was the open unit: an agent doing 10k edits to a repository
   retains ~10k out-of-band payloads where the live set may be 1. At the measured
   ~138 bytes/row settled that is ~1.4 MB per 10k edits of pure garbage, growing without bound and
   never reclaimed by any shipping path.

## Implication for the fence

The leak is real, so a fix is warranted — but note point 3 before designing one. Nothing here is a
concurrency symptom. The sweep never proposes a JSON delete, so there is no window in which a
publisher and a sweep disagree about a payload. **A publication/reclamation fence of the binary-CAS
shape is not what makes this correct; it is what makes a reclamation that already exists safe.** The
missing piece is the reclamation. I would build the payload-reachability side first and measure it
against this matrix (every cell must go to `leaked = 3`, and the `insert` control must stay at 3),
then decide whether it needs a fence — and unlike locators, JSON payloads **are** content-addressed
and deduped (`JsonRef::for_content`), so the CAS reuse hazard does apply and it probably will.

## Also in this PR: a correction I owe, against my own earlier claim

I reported that `registered_spaces.rs`'s "reclaimed with its generation" note on `HOT_INDEX_SPACE`
was false. **It is true. I was wrong, and I verified it before writing anything into the tree.**

- `INDEX_SPACE` is the first entry of `GENERATION_SCOPED_SPACES`, and
  `stage_retire_hot_generation` deletes every entry *and* witness under the retired
  `(branch_id, generation)` prefix.
- Tombstones never mint index entries in the first place — the extractor runs only in the
  live-snapshot arm of transaction validation, and the deleted arm goes to `remember_tombstone`.
  My inference "tombstones carry forward, therefore the index carries forward" was a non sequitur:
  the row plane carries them, the index plane never held them.
- The sole writer of the plane is not reached on any lifecycle republication route, so the new
  generation starts empty.

The one genuinely imprecise phrase is **"derived from the hot rows"** — nothing reconstructs
`INDEX_SPACE` from `ROW_SPACE`; entries are extracted from snapshot JSON during validation. The
plane is rebuildable from canonical records (invariant 3 holds) but not from the rows it indexes.
The comment now says that, and says what *is* verified so the next reader does not re-derive it.

The tombstone finding itself is unchanged and unaffected: tombstones do accumulate in `ROW_SPACE`,
lifecycle republication carries them forward, and that is a serving-layer compaction question. Only
my claim about the *index* plane's comment was wrong.

## Layout invariants

1. **Single authority** — unchanged; no code path added or removed.
2. **Commit canonicality** — unchanged.
3. **Derived views are caches** — the `HOT_INDEX_SPACE` note is now precise about what the plane is
   rebuildable *from*, which is exactly this invariant's claim.
4. **Atomic publication** — unchanged.
5. **GC from refs** — unchanged. This PR measures the sweep, it does not alter it.
6. **SQL reads canonical records** — unchanged.

## Scope and risk

Instrumentation and comments only. No engine behaviour changes: the diff is the `e1_json_leak`
example plus two doc comments. **Freeze-safe** — no key or value encoding, no new space, no
migration surface.

## Gate

Full CI-scope gate on `hetzner-cpx62-IV`, provenance printed inside the run:

```
=== GATE PROVENANCE ===
worktree: /root/claude5/cand
HEAD: d341f940f12bcf084de86130edbcd358f0668899
describe: d341f940f docs(gc): record the checkpointed json-leak rate and correct the hot-index reclamation note
status.porcelain: []
=== END PROVENANCE ===
...
=== GATE PROVENANCE (post-run) ===
HEAD: d341f940f12bcf084de86130edbcd358f0668899
status.porcelain: []
E29-GATE3-COMPLETE
```

`clippy --profile test --workspace --all-targets --all-features -- -D warnings`, then
`test --profile test --workspace --exclude lix_benchmarks --all-features --no-fail-fast`, then
`test --profile test -p lix_benchmarks --features storage-benches,slatedb,root-replay-trace --no-fail-fast`,
then `check -p lix --no-default-features` and `check -p lix_js_sdk --target wasm32-unknown-unknown`.

**67 `test result: ok` lines, 3528 passed, 0 failed**, no `error[E…]`, no `panicked at`, no
`test result: FAILED`. Log grepped, not tailed.
