### PR TITLE
docs(storage): document the durability contract each adapter actually implements

### DIFF
--- a/packages/lix/src/storage/conformance/persistence.rs
+++ b/packages/lix/src/storage/conformance/persistence.rs
@@ -33,6 +33,12 @@ where
             overwrite_and_delete_final_state_survives_reopen(factory),
         )
         .await;
+    report
+        .run(
+            "persistence::await_durable_commit_is_accepted_and_survives_reopen",
+            await_durable_commit_is_accepted_and_survives_reopen(factory),
+        )
+        .await;
 }
 
 async fn committed_data_survives_reopen<F>(factory: &F) -> ConformanceResult
@@ -76,6 +82,58 @@ where
         ],
     )
     .await
+}
+
+/// An adapter must accept `WriteOptions::await_durable` and apply the write
+/// set unchanged under it.
+///
+/// # Read the name literally
+///
+/// This proves **acceptance and round-trip, not durability.** A durable
+/// acknowledgement is invisible from inside the process — on RocksDB it is an
+/// `fdatasync` on the WAL, and no in-process observation distinguishes a synced
+/// commit from an unsynced one. An adapter that ignores the flag entirely
+/// passes this case, and for four rounds one did.
+///
+/// It is here for the failure it *can* catch cheaply: an adapter that rejects
+/// the flag, or that takes a different and buggy code path under it. Verifying
+/// that the sync actually happens requires an external syscall census, and
+/// verifying that the store survives losing power requires block-level fault
+/// injection; see `WriteOptions::await_durable`. **Do not extend this case to
+/// claim more than its name says** — a test that looks like it checks
+/// durability while checking acceptance is worse than no test.
+async fn await_durable_commit_is_accepted_and_survives_reopen<F>(factory: &F) -> ConformanceResult
+where
+    F: StorageFactory,
+{
+    let fixture = factory.create_fixture();
+    let test_space = space(71);
+    let durable = key("durable");
+
+    {
+        let storage = fixture.open().await;
+        let mut write = storage
+            .begin_write(WriteOptions {
+                await_durable: true,
+                ..WriteOptions::default()
+            })
+            .await
+            .map_err(|error| format!("begin_write with await_durable failed: {error}"))?;
+        write
+            .put_many(
+                TEST_SPACE,
+                put_batch([full_put(durable.clone(), "durable-value")]),
+            )
+            .await
+            .map_err(|error| format!("put_many under await_durable failed: {error}"))?;
+        write
+            .commit()
+            .await
+            .map_err(|error| format!("await_durable commit failed: {error}"))?;
+    }
+
+    let reopened = fixture.open().await;
+    assert_full_values(&reopened, test_space, &[(durable, Some("durable-value"))]).await
 }
 
 async fn rolled_back_data_does_not_survive_reopen<F>(factory: &F) -> ConformanceResult

--- a/packages/lix/src/storage/traits.rs
+++ b/packages/lix/src/storage/traits.rs
@@ -113,6 +113,16 @@ pub trait StorageWrite: Send {
         range: KeyRange,
     ) -> impl Future<Output = Result<(), StorageError>> + Send;
 
+    /// Applies the write transaction atomically and acknowledges it.
+    ///
+    /// Atomicity is required: either every staged mutation becomes visible or
+    /// none does, and no reader may observe a partial write set.
+    ///
+    /// **What the acknowledgement means on disk is the adapter's choice**, and
+    /// it differs between shipping adapters — see `WriteOptions::await_durable`
+    /// for the measured behaviour of each with and without the flag. Returning
+    /// `Ok` does not by itself imply the write survives a crash, and which
+    /// crash it survives is exactly what varies.
     fn commit(self) -> impl Future<Output = Result<CommitResult, StorageError>> + Send;
 
     fn rollback(self) -> impl Future<Output = Result<(), StorageError>> + Send;

--- a/packages/lix/src/storage/types.rs
+++ b/packages/lix/src/storage/types.rs
@@ -573,6 +573,71 @@ pub struct WriteOptions {
     pub idempotency_key: Option<Bytes>,
     /// Do not acknowledge the commit until the backend has crossed its
     /// durable persistence boundary.
+    ///
+    /// # Where the boundary sits
+    ///
+    /// **lix guarantees atomicity. The adapter guarantees durability.**
+    ///
+    /// A publication — blob chunks, commit records, derived views and the
+    /// branch ref move — is lowered into one write set and committed exactly
+    /// once, so no reader observes it in stages. That is lix's property and it
+    /// holds on every backend. What "committed" means *on the physical device*
+    /// is the adapter's decision, and this flag is the whole of the engine's
+    /// influence over it. lix deliberately implements no durability policy on
+    /// top of a backend: there is no checkpoint-boundary flush, and no flush
+    /// API. If you need a stronger acknowledgement than your adapter gives,
+    /// that is a question for the adapter, not for lix.
+    ///
+    /// # What each shipping adapter actually does
+    ///
+    /// Measured behaviour, not declared intent. Sources are named so the
+    /// claims can be re-run rather than trusted.
+    ///
+    /// | adapter | flag clear | flag set |
+    /// |---|---|---|
+    /// | **RocksDB** | the batch is applied into the OS page cache before ack: a process crash cannot lose it, a power loss can | the WAL is fsynced before ack |
+    /// | **SlateDB** | `commit()` acks once the write set is queued in-process: a SIGKILL discards it | waits for the WAL upload |
+    /// | **IndexedDB** | the browser's normal transaction durability | forwarded as `strict_durability` |
+    ///
+    /// RocksDB syncs **one WAL fsync per commit that raises the flag** —
+    /// measured by strace as exactly `2.0` per single-part resumable upload,
+    /// which is two such commits (the part commit and the finalizing
+    /// publication), against a slope of `0.0` before the adapter honoured it.
+    /// Commits that leave the flag clear produce a byte-identical syscall
+    /// census, so the cost is confined to callers that ask for it.
+    ///
+    /// SlateDB lost **846 of 1,008** acknowledged writes to SIGKILL with the
+    /// flag clear, and **0 of 1,512** with it set. Across both adapters the
+    /// atomicity result is 6,789 SIGKILL trials with zero torn write sets.
+    ///
+    /// # The asymmetry, which is the opposite of what you would guess
+    ///
+    /// Until recently RocksDB **ignored** this flag and SlateDB **honoured**
+    /// it — and RocksDB was nevertheless the safer of the two under process
+    /// death, losing nothing where SlateDB lost five acknowledged writes in
+    /// six.
+    ///
+    /// That has nothing to do with the flag. It follows from where each
+    /// adapter's acknowledgement sits: RocksDB's `WriteBatch` is already inside
+    /// the kernel when `commit()` returns, so only a power loss can take it
+    /// back, while SlateDB's is still in the dying process's own heap, so a
+    /// SIGKILL is enough. **"Honours `await_durable`" is not a ranking of
+    /// backends,** and a non-durable acknowledgement does not fail the same way
+    /// everywhere: on RocksDB it survives a crashing process, on SlateDB it
+    /// does not. Read the table, not the flag.
+    ///
+    /// # What is not proven
+    ///
+    /// On RocksDB this flag is verified by observing the `fdatasync` syscall,
+    /// because the effect is invisible from inside the process — no in-process
+    /// test can distinguish a synced commit from an unsynced one. **That is a
+    /// statement about a syscall, not about a recovered store.** Nothing here
+    /// establishes that the store survives a power cut *between* two syncs;
+    /// proving that needs block-level fault injection (`dm-log-writes`, which
+    /// replays the write log to each flush boundary and checks the store at
+    /// every one), and no such harness exists. Until it does, do not describe
+    /// any backend as "durable" without saying which of these two things is
+    /// meant.
     pub await_durable: bool,
     /// Conditions evaluated atomically against the state immediately before
     /// this write becomes visible.


### PR DESCRIPTION
Documents the durability contract that #1398 finished making true. **No new mechanism, no
optimization, no behaviour change** — three doc comments and one conformance case, all additive.

Follows the owner's decision closing the durability workstream: **durability is the storage
adapter's concern.** lix will not build checkpoint-boundary durability and will not add a flush API.
`WriteOptions::await_durable` is the interface; each backend decides what it does with and without
the flag. This PR writes that down where the next person will actually find it.

## The line

> **lix guarantees atomicity. The adapter guarantees durability.**

Atomicity is lix's and it is structural — one write set, one transaction, 6,789 SIGKILL trials
across both adapters with zero torn write sets. What "committed" means on the physical device is the
adapter's, and this flag is the whole of the engine's influence over it.

## What changed

**1. `WriteOptions::await_durable` (`storage/types.rs`)** — the contract itself. Four sections:
where the boundary sits, a per-adapter table of measured behaviour with and without the flag, the
asymmetry, and what is not proven.

| adapter | flag clear | flag set |
|---|---|---|
| **RocksDB** | batch applied into the OS page cache before ack — a process crash cannot lose it, a power loss can | WAL fsynced before ack |
| **SlateDB** | `commit()` acks once the write set is queued in-process — a SIGKILL discards it | waits for the WAL upload |
| **IndexedDB** | the browser's normal transaction durability | forwarded as `strict_durability` |

With the measurements attached: RocksDB syncs **one WAL fsync per raising commit** (strace slope of
exactly 2.0 per single-part upload, which is two such commits, against 0.0 before #1398, and a
byte-identical census on commits that leave the flag clear). SlateDB lost **846 of 1,008**
acknowledged writes to SIGKILL with the flag clear and **0 of 1,512** with it set.

One correction to the framing in passing: the "2.0 fsyncs per raising commit" figure is 2.0 per
*upload*. An upload raises the flag twice — the part commit and the finalizing publication — so the
per-commit rate is one. The doc states it that way.

**2. `StorageWrite::commit` (`storage/traits.rs`)** — previously undocumented. States that atomicity
is required and that the meaning of the acknowledgement is the adapter's choice, pointing at the
table rather than restating it.

**3. `persistence::await_durable_commit_is_accepted_and_survives_reopen`** — a conformance case
asserting an adapter accepts the flag and round-trips the write set under it.

## The asymmetry, called out because it inverts the obvious reading

Until #1398, RocksDB **ignored** this flag and SlateDB **honoured** it — and RocksDB was
nevertheless the safer of the two under process death, losing nothing where SlateDB lost five
acknowledged writes in six.

That has nothing to do with the flag. It follows from where each adapter's acknowledgement sits:
RocksDB's `WriteBatch` is already inside the kernel when `commit()` returns, so only power loss can
take it back; SlateDB's is still in the dying process's heap, so a SIGKILL is enough. **"Honours
`await_durable`" is not a ranking of backends.** Without that sentence written down, the next reader
of #1394 draws precisely the wrong conclusion.

## On the conformance case — what it does not do

It is named `await_durable_commit_is_accepted_and_survives_reopen`, and the name is the whole claim.
**It proves acceptance and round-trip, not durability.** A durable acknowledgement is invisible from
inside the process; an adapter that ignores the flag entirely passes this case, and for four rounds
one did.

It earns its place on the failure it *can* catch for free — an adapter that rejects the flag, or
takes a different and buggy path under it. Its doc comment says all of this and tells the next
person not to extend it into a durability claim, because a test that looks like it checks durability
while checking acceptance is worse than no test. That failure mode already appeared once in this
workstream and was caught only by accident.

Per the instruction, **no mechanism was added to force adapters to comply.** Documenting the
contract is the deliverable; an adapter that wants to ignore the flag still can, and the table now
says what that costs its users.

### Proof that it runs at all

Conformance cases print nothing when they pass — only failures are reported — so a green gate is not
evidence the case executed. Given that this whole workstream turned on a test that silently asserted
nothing, I ran the negative control rather than assuming: inverted the expected value, reran, and
confirmed it fails **by name**, then reverted.

```
storage conformance problems:
persistence::await_durable_commit_is_accepted_and_survives_reopen: key Key(b"durable") \
  value mismatch: expected Some("WRONG-VALUE-PROBE"), got Some("durable-value")
test result: FAILED. 9 passed; 2 failed; 0 ignored
```

Two failures because SlateDB registers two conformance fixtures; both reached the case. The working
tree was clean afterwards (`git status --porcelain` empty), so nothing from the probe is in this
branch.

## What is still not proven, stated in the doc rather than implied

The RocksDB guarantee is verified by observing the `fdatasync` syscall, because no in-process test
can distinguish a synced commit from an unsynced one. **That is a statement about a syscall, not
about a recovered store.** Nothing establishes that the store survives a power cut *between* two
syncs; that needs block-level fault injection (`dm-log-writes`), which does not exist here. The doc
says so, and says not to call any backend "durable" without specifying which of the two is meant.

## Compatibility

Additive doc comments plus one conformance case. No signature, field, default, or behaviour changes
— backwards-compatible by construction. The new case runs against every adapter that already runs
the persistence suite and passes on all of them.

## Gate

Full CI scope on hetzner-cpx62-III, `--no-fail-fast`, logs grepped rather than tailed, with
`cargo doc --workspace --no-deps --all-features` added as a step since this is a documentation
change. Printed from inside the run, before and after:

```
=== git rev-parse HEAD ===
96344a8faef3b3c9b1077bc824e00f9e0c0c4ff2
=== git status --porcelain ===
=== (end status) ===
...
=== git rev-parse HEAD (post) ===
96344a8faef3b3c9b1077bc824e00f9e0c0c4ff2
=== git status --porcelain (post) ===
=== (end status) ===
```

```
GATE_STEP_RESULT clippy           rc=0
GATE_STEP_RESULT doc              rc=0
GATE_STEP_RESULT compile_ws       rc=0
GATE_STEP_RESULT compile_bench    rc=0
GATE_STEP_RESULT run_ws           rc=0
GATE_STEP_RESULT run_bench        rc=0
GATE_STEP_RESULT check_nodefault  rc=0
GATE_STEP_RESULT check_wasm       rc=0
```

**3529 passed / 0 failed / 0 ignored**, summed across every `test result:` line. Zero matches for
`^failures:`, `test result: FAILED`, or `panicked at`. `cargo doc` is clean, so the new rustdoc has
no broken intra-doc links.
