### PR TITLE
perf(sql2): give foreign-key joins an indexed probe-key access path

### DIFF
--- a/packages/lix/Cargo.toml
+++ b/packages/lix/Cargo.toml
@@ -59,6 +59,15 @@ path = "tests/semantic_merge.rs"
 name = "send_futures"
 path = "tests/send_futures.rs"
 
+# `SqlReadProfile` and `execute_profiled` are the diagnostic surface this test
+# asserts on, and both live behind `storage-benches`. CI's
+# `cargo test --workspace --all-features` run builds it; a plain
+# `cargo test -p lix` skips the target rather than failing to compile it.
+[[test]]
+name = "point_join_scan_scaling"
+path = "tests/point_join_scan_scaling.rs"
+required-features = ["storage-benches"]
+
 [[bench]]
 name = "profile_sql_result_streaming"
 path = "benches/profile_sql_result_streaming.rs"

--- a/packages/lix/src/hot_state/context.rs
+++ b/packages/lix/src/hot_state/context.rs
@@ -835,7 +835,7 @@ where
                     control.tracked_generation,
                     &predicate.schema_key,
                     predicate.ordinal,
-                    &predicate.value,
+                    &predicate.values,
                 )
                 .await?
             else {

--- a/packages/lix/src/hot_state/tracked_head/hot.rs
+++ b/packages/lix/src/hot_state/tracked_head/hot.rs
@@ -4956,26 +4956,36 @@ where
         Ok(dependencies)
     }
 
-    /// Candidate entity primary keys whose indexed column equals `value`.
+    /// Candidate entity primary keys whose indexed column equals any of
+    /// `values`.
     ///
     /// Returns `None` when the caller must not use the index and must fall
-    /// back to its ordinary scan, which happens for two reasons: the
-    /// collection has no completeness witness for the generation, or the
-    /// witness says the plane has degraded far enough that resolving its
-    /// candidates would cost more than the scan (see
-    /// [`hot_index_candidate_budget`]). `Some` is a candidate set, not an
+    /// back to its ordinary scan, which happens for three reasons: the
+    /// collection has no completeness witness for the generation, the witness
+    /// says the plane has degraded far enough that resolving its candidates
+    /// would cost more than the scan (see [`hot_index_candidate_budget`]), or
+    /// the caller asked for more distinct values than
+    /// [`HOT_INDEX_PROBE_VALUE_LIMIT`]. `Some` is a candidate set, not an
     /// answer: entries are never deleted within a generation, so a candidate
     /// may name a row that has since changed value or been deleted. Callers
     /// resolve candidates through the exact-entity-pk read and re-apply their
     /// own predicate. The set never *omits* a live matching row.
+    ///
+    /// The witness read and the candidate budget are shared across `values`:
+    /// the budget bounds the *total* candidate count, so a multi-value probe
+    /// can never read more index entries than a single-value probe was already
+    /// allowed to.
     pub(crate) async fn scan_hot_index_candidates(
         &self,
         branch_id: &str,
         generation: CommitId,
         schema_key: &str,
         ordinal: u16,
-        value: &HotIndexValue,
+        values: &[HotIndexValue],
     ) -> Result<Option<Vec<EntityPk>>, LixError> {
+        if values.is_empty() || values.len() > HOT_INDEX_PROBE_VALUE_LIMIT {
+            return Ok(None);
+        }
         let witness = StorageKey(Bytes::from(encode_hot_index_witness_key(
             branch_id,
             generation,
@@ -4998,47 +5008,51 @@ where
             return Ok(None);
         };
         let budget = hot_index_candidate_budget(entries_published);
-        let range = StoragePrefix {
-            bytes: Bytes::from(hot_index_value_prefix(
-                branch_id,
-                generation,
-                schema_key,
-                ordinal,
-                value,
-            )),
-        }
-        .to_range()?;
-        let mut cursor = self
-            .store
-            .begin_scan(
-                INDEX_SPACE,
-                range,
-                StorageBeginScanOptions::default(),
-            )
-            .await?;
         let mut candidates = Vec::new();
-        loop {
-            // Never read more than one entry past the budget: the extra entry
-            // is what proves the bucket exceeds it, and everything beyond is
-            // work this route has already decided not to do.
-            let want = (budget + 1 - candidates.len()).min(HOT_INDEX_CANDIDATE_PAGE);
-            let (page, page_has_more) = cursor.next_page(want).await?.into_parts();
-            for entry in &page {
-                let StorageProjectedValue::FullValue(value) = &entry.value else {
-                    continue;
-                };
-                let text = std::str::from_utf8(value).map_err(|error| {
-                    head_value_error(format!("hot index entry is not utf-8: {error}"))
-                })?;
-                candidates.push(EntityPk::from_json_array_text(text).map_err(|error| {
-                    head_value_error(format!("hot index entry has an invalid entity pk: {error}"))
-                })?);
+        for value in values {
+            let range = StoragePrefix {
+                bytes: Bytes::from(hot_index_value_prefix(
+                    branch_id,
+                    generation,
+                    schema_key,
+                    ordinal,
+                    value,
+                )),
             }
-            if candidates.len() > budget {
-                return Ok(None);
-            }
-            if !page_has_more {
-                break;
+            .to_range()?;
+            let mut cursor = self
+                .store
+                .begin_scan(
+                    INDEX_SPACE,
+                    range,
+                    StorageBeginScanOptions::default(),
+                )
+                .await?;
+            loop {
+                // Never read more than one entry past the budget: the extra
+                // entry is what proves the bucket exceeds it, and everything
+                // beyond is work this route has already decided not to do.
+                let want = (budget + 1 - candidates.len()).min(HOT_INDEX_CANDIDATE_PAGE);
+                let (page, page_has_more) = cursor.next_page(want).await?.into_parts();
+                for entry in &page {
+                    let StorageProjectedValue::FullValue(value) = &entry.value else {
+                        continue;
+                    };
+                    let text = std::str::from_utf8(value).map_err(|error| {
+                        head_value_error(format!("hot index entry is not utf-8: {error}"))
+                    })?;
+                    candidates.push(EntityPk::from_json_array_text(text).map_err(|error| {
+                        head_value_error(format!(
+                            "hot index entry has an invalid entity pk: {error}"
+                        ))
+                    })?);
+                }
+                if candidates.len() > budget {
+                    return Ok(None);
+                }
+                if !page_has_more {
+                    break;
+                }
             }
         }
         Ok(Some(candidates))
@@ -11670,6 +11684,13 @@ fn decode_hot_row_key_in_scope(bytes: &[u8], scope: &[u8]) -> Result<HeadRowIden
 const HOT_INDEX_WITNESS_TAG: u8 = 0x00;
 const HOT_INDEX_ENTRY_TAG: u8 = 0x01;
 const HOT_INDEX_CANDIDATE_PAGE: usize = 256;
+/// Distinct values one indexed-column probe may resolve.
+///
+/// Each value costs its own range scan, so a very wide `IN` list — or a very
+/// wide join build side — is cheaper to answer with the ordinary collection
+/// scan. Declining above the limit keeps the probe route weakly better than
+/// the scan route it replaces.
+const HOT_INDEX_PROBE_VALUE_LIMIT: usize = 64;
 
 /// One index entry to publish: the row's indexed value and its identity.
 #[derive(Debug, Clone)]

--- a/packages/lix/src/hot_state/types.rs
+++ b/packages/lix/src/hot_state/types.rs
@@ -1246,13 +1246,17 @@ pub(crate) enum ScanOperator {
     },
 }
 
-/// An equality predicate on a column the schema declares as unique or as a
+/// A membership predicate on a column the schema declares as unique or as a
 /// foreign key, addressed by its stable ordinal in the schema's index.
+///
+/// `values` holds one value for an `=` predicate and several for an `IN` list.
+/// The set is a disjunction: a row qualifies when its indexed column equals
+/// any member.
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 pub(crate) struct DeclaredColumnEq {
     pub(crate) schema_key: String,
     pub(crate) ordinal: u16,
-    pub(crate) value: crate::hot_state::HotIndexValue,
+    pub(crate) values: Vec<crate::hot_state::HotIndexValue>,
 }
 
 /// Identity-centered filter for visible live entities.

--- a/packages/lix/src/sql2/providers/entity.rs
+++ b/packages/lix/src/sql2/providers/entity.rs
@@ -625,6 +625,49 @@ impl TableSpec for EntitySpec {
         }
     }
 
+    /// Columns the hot index plane can serve that this scan is not already
+    /// constrained on.
+    ///
+    /// A scan whose filters already resolve to an identity, or that already
+    /// mentions the indexed column, is either a point lookup or about to be
+    /// one. Offering such a column as a probe key would make a join collect
+    /// its build side and replan a scan that was already as narrow as the
+    /// index can make it — measurably slower for no rows saved.
+    ///
+    /// The two tests are ordered by cost. Collecting the filters' column names
+    /// is cheap and already rejects the common case — a scan the planner has
+    /// pushed an equality on this very column into — so the identity analysis,
+    /// which parses primary-key constraints, only runs for the scans that are
+    /// still candidates. This runs once per scan per execution, including on
+    /// the warm plan-cache path that replans leaves, so it is on the point-read
+    /// critical path.
+    fn probe_key_columns(&self, filters: &[Expr]) -> Vec<String> {
+        if self.spec.indexed_columns.is_empty() {
+            return Vec::new();
+        }
+        let constrained = filters
+            .iter()
+            .flat_map(|filter| filter.column_refs())
+            .map(|column| column.name.as_str())
+            .collect::<BTreeSet<_>>();
+        let columns = self
+            .spec
+            .indexed_columns
+            .iter()
+            .filter(|column| !constrained.contains(column.name.as_str()))
+            .map(|column| column.name.clone())
+            .collect::<Vec<_>>();
+        if columns.is_empty()
+            || entity_pks_from_primary_key_filters(&self.spec, filters)
+                .ok()
+                .flatten()
+                .is_some()
+        {
+            return Vec::new();
+        }
+        columns
+    }
+
     async fn plan_scan(
         &self,
         projection: Option<&Vec<usize>>,
@@ -1800,41 +1843,72 @@ pub(super) fn entity_pks_from_primary_key_filters(
         .map(|ids| ids.into_iter().collect()))
 }
 
-/// The first equality on a column this schema declares as unique or as a
-/// foreign key, which the hot index plane can serve as an access path.
+/// The first equality or `IN` list on a column this schema declares as unique
+/// or as a foreign key, which the hot index plane can serve as an access path.
 ///
 /// The matched filter is deliberately **left in `row_filters`**. Index entries
 /// are never deleted when a value is superseded, so a lookup returns
 /// candidates and this predicate is what rejects the stale ones. It is not a
 /// redundant re-check over a handful of rows — it is the correctness half of
 /// the access path, and removing it reintroduces rows that no longer match.
+///
+/// An `IN` list resolves the same way as an equality — one index bucket per
+/// member, union of the candidates — which is what lets a join's runtime probe
+/// keys reach the index at all: a probe carries the several build-side values
+/// of one key column, never a single literal.
 fn declared_column_eq(
     spec: &EntitySurfaceSpec,
     row_filters: &[EntityRowFilter],
 ) -> Option<crate::hot_state::DeclaredColumnEq> {
     row_filters.iter().find_map(|filter| {
-        let EntityRowFilter::ColumnEq { column, value, .. } = filter else {
-            return None;
-        };
+        let (column, values) = declared_column_membership(filter)?;
         let indexed = spec
             .indexed_columns
             .iter()
-            .find(|candidate| candidate.name == *column)?;
-        let value = match value {
-            EntityFilterValue::String(value) => {
-                crate::hot_state::HotIndexValue::String(value.clone())
-            }
-            EntityFilterValue::Integer(value) => {
-                crate::hot_state::HotIndexValue::Integer(*value)
-            }
-            _ => return None,
-        };
+            .find(|candidate| candidate.name == column)?;
+        let values = values
+            .into_iter()
+            .map(|value| match value {
+                EntityFilterValue::String(value) => {
+                    Some(crate::hot_state::HotIndexValue::String(value.clone()))
+                }
+                EntityFilterValue::Integer(value) => {
+                    Some(crate::hot_state::HotIndexValue::Integer(*value))
+                }
+                _ => None,
+            })
+            .collect::<Option<Vec<_>>>()?;
         Some(crate::hot_state::DeclaredColumnEq {
             schema_key: spec.schema_key.clone(),
             ordinal: indexed.ordinal,
-            value,
+            values,
         })
     })
+}
+
+/// The column and the value set one row filter constrains it to, when the
+/// filter is a membership test on a single column.
+///
+/// A disjunction counts: DataFusion's simplifier rewrites a short `IN` list
+/// into `col = a OR col = b`, so the two spellings must reach the index the
+/// same way. A conjunction does not, because either side alone would need to
+/// be re-checked against the other, which is a wider contract than "the value
+/// is one of these".
+fn declared_column_membership(filter: &EntityRowFilter) -> Option<(&str, Vec<&EntityFilterValue>)> {
+    match filter {
+        EntityRowFilter::ColumnEq { column, value, .. } => Some((column, vec![value])),
+        EntityRowFilter::ColumnIn { column, values, .. } => Some((column, values.iter().collect())),
+        EntityRowFilter::Or(left, right) => {
+            let (column, mut values) = declared_column_membership(left)?;
+            let (right_column, right_values) = declared_column_membership(right)?;
+            if column != right_column {
+                return None;
+            }
+            values.extend(right_values);
+            Some((column, values))
+        }
+        EntityRowFilter::And(..) => None,
+    }
 }
 
 fn apply_exact_entity_pk_filters(

--- a/packages/lix/src/sql2/providers/spec.rs
+++ b/packages/lix/src/sql2/providers/spec.rs
@@ -22,11 +22,14 @@ use datafusion::arrow::compute::{SortOptions, and, filter_record_batch, take};
 use datafusion::arrow::datatypes::{DataType, Field, Schema, SchemaRef};
 use datafusion::arrow::record_batch::RecordBatch;
 use datafusion::catalog::{Session, TableProvider};
-use datafusion::common::{DFSchema, DataFusionError, Result, SchemaExt};
+use datafusion::common::{
+    Column as DFColumn, DFSchema, DataFusionError, Result, ScalarValue, SchemaExt,
+};
 use datafusion::datasource::TableType;
 use datafusion::execution::TaskContext;
 use datafusion::execution::context::ExecutionProps;
-use datafusion::logical_expr::{Expr, Operator, TableProviderFilterPushDown};
+use datafusion::logical_expr::expr::InList;
+use datafusion::logical_expr::{Expr, Operator, TableProviderFilterPushDown, lit};
 use datafusion::physical_expr::expressions::Column;
 use datafusion::physical_expr::{
     AcrossPartitions, ConstExpr, EquivalenceProperties, PhysicalExpr, PhysicalSortExpr,
@@ -322,6 +325,32 @@ pub(super) struct PlannedScan {
     pub(super) ordering: Option<String>,
 }
 
+/// Replans this scan with an extra `IN` restriction on one probe key column.
+///
+/// The closure re-enters the spec's own [`TableSpec::plan_scan`] with the
+/// original projection, filters and limit plus one appended `IN` list, so the
+/// restricted scan is an ordinary scan of a narrower predicate — same route
+/// selection, same residual row filters, same rows.
+type ProbeRebind =
+    Arc<dyn Fn(String, Vec<ScalarValue>) -> BoxFuture<'static, Result<PlannedScan>> + Send + Sync>;
+
+/// The execution-time narrowing a scan will accept, if any.
+#[derive(Clone)]
+pub(super) struct ScanProbeBinding {
+    columns: Arc<[String]>,
+    /// The constant columns the unrestricted scan advertised. A probe adds a
+    /// multi-value `IN`, which pins nothing, so the restricted scan advertises
+    /// exactly the same set.
+    constant_columns: Arc<[String]>,
+    rebind: ProbeRebind,
+}
+
+impl ScanProbeBinding {
+    fn serves(&self, column: &str) -> bool {
+        self.columns.iter().any(|name| name == column)
+    }
+}
+
 /// A planned UPDATE/DELETE: the candidate-row source the filters run against,
 /// and the handler that stages writes for the rows that matched.
 ///
@@ -369,6 +398,19 @@ pub(super) trait TableSpec: Send + Sync + 'static {
 
     fn filter_pushdown(&self, _filter: &Expr) -> TableProviderFilterPushDown {
         TableProviderFilterPushDown::Unsupported
+    }
+
+    /// Columns for which this table has an access path keyed by value, so a
+    /// scan restricted to a known set of values is cheaper than the scan these
+    /// `filters` alone would produce.
+    ///
+    /// Naming a column here only permits [`SpecScanExec::rebind_probe`] to
+    /// replan the scan with an extra `IN` filter on it. The replan goes through
+    /// the spec's ordinary [`TableSpec::plan_scan`], so the answer is the same
+    /// rows either way and a spec that names a column it cannot actually seek
+    /// loses performance, never correctness.
+    fn probe_key_columns(&self, _filters: &[Expr]) -> Vec<String> {
+        Vec::new()
     }
 
     /// Rejects filters that would be unsafe to leave as residual expressions.
@@ -932,6 +974,8 @@ impl TableProvider for SpecTableProvider {
                 table: self.spec.table_name().into(),
                 projection: projection.cloned(),
             });
+        let probe_binding =
+            self.probe_binding(projection, filters, limit, state, &constant_columns);
         Ok(Arc::new(SpecScanExec::new(
             self.spec.table_name().into(),
             planned,
@@ -939,6 +983,7 @@ impl TableProvider for SpecTableProvider {
             statement_cache_key,
             physical_cache_key,
             &constant_columns,
+            probe_binding,
         )?))
     }
 }
@@ -994,6 +1039,53 @@ fn exact_filter_constant_columns(spec: &dyn TableSpec, filters: &[Expr]) -> Vec<
         collect(filter, &mut columns);
     }
     columns
+}
+
+impl SpecTableProvider {
+    /// Captures everything needed to replan this scan with one extra `IN`
+    /// restriction, so a join can narrow it once its probe keys are known.
+    fn probe_binding(
+        &self,
+        projection: Option<&Vec<usize>>,
+        filters: &[Expr],
+        limit: Option<usize>,
+        state: &dyn Session,
+        constant_columns: &[String],
+    ) -> Option<ScanProbeBinding> {
+        // A pushed-down limit picks *which* rows the scan returns. Narrowing
+        // the row set underneath it would change that choice, so a limited scan
+        // keeps the plan it was given.
+        if limit.is_some() {
+            return None;
+        }
+        let columns: Arc<[String]> = self.spec.probe_key_columns(filters).into();
+        if columns.is_empty() {
+            return None;
+        }
+        let spec = Arc::clone(&self.spec);
+        let projection = projection.cloned();
+        let filters = filters.to_vec();
+        let props = state.execution_props().clone();
+        Some(ScanProbeBinding {
+            columns,
+            constant_columns: constant_columns.into(),
+            rebind: Arc::new(move |column: String, values: Vec<ScalarValue>| {
+                let spec = Arc::clone(&spec);
+                let projection = projection.clone();
+                let mut filters = filters.clone();
+                let props = props.clone();
+                Box::pin(async move {
+                    filters.push(Expr::InList(InList::new(
+                        Box::new(Expr::Column(DFColumn::new_unqualified(column))),
+                        values.into_iter().map(lit).collect(),
+                        false,
+                    )));
+                    spec.plan_scan(projection.as_ref(), &filters, limit, &props)
+                        .await
+                })
+            }),
+        })
+    }
 }
 
 fn physical_filters(
@@ -1102,6 +1194,8 @@ pub(crate) struct SpecScanExec {
     properties: Arc<PlanProperties>,
     statement_cache_key: Option<StatementScanKey>,
     physical_cache_key: PhysicalScanKey,
+    target_partitions: usize,
+    probe_binding: Option<ScanProbeBinding>,
 }
 
 impl SpecScanExec {
@@ -1112,6 +1206,7 @@ impl SpecScanExec {
         statement_cache_key: Option<StatementScanKey>,
         physical_cache_key: PhysicalScanKey,
         constant_columns: &[String],
+        probe_binding: Option<ScanProbeBinding>,
     ) -> Result<Self> {
         // A declared ordering only proves that each source fragment is sorted,
         // not that adjacent fragments have non-overlapping value ranges.
@@ -1178,6 +1273,8 @@ impl SpecScanExec {
             properties: Arc::new(properties),
             statement_cache_key,
             physical_cache_key,
+            target_partitions,
+            probe_binding,
         })
     }
 
@@ -1201,6 +1298,7 @@ impl SpecScanExec {
             statement_cache_key,
             physical_cache_key,
             &[],
+            None,
         )
         .expect("test scan properties build")
     }
@@ -1211,6 +1309,61 @@ impl SpecScanExec {
 
     pub(crate) fn physical_cache_key(&self) -> &PhysicalScanKey {
         &self.physical_cache_key
+    }
+
+    /// Whether this scan can be replanned restricted to values of `column`.
+    pub(crate) fn serves_probe_column(&self, column: &str) -> bool {
+        self.probe_binding
+            .as_ref()
+            .is_some_and(|binding| binding.serves(column))
+    }
+
+    /// Replans this scan restricted to rows whose `column` is one of `values`.
+    ///
+    /// The restriction is an ordinary `IN` predicate handed back to the spec,
+    /// so the replanned scan returns exactly the subset of this scan's rows
+    /// that satisfy it — never a different row set, and never a wider one. A
+    /// spec free to ignore the hint still answers correctly; it only loses the
+    /// point lookup.
+    ///
+    /// Returns `None` unless the replanned scan is a drop-in replacement for
+    /// this one. The caller has already published this scan's schema and
+    /// partition count to the operator above it, so a replan that lands on a
+    /// different layout must be discarded rather than substituted — a scan with
+    /// more partitions than the plan advertises would have rows nobody reads.
+    pub(crate) async fn rebind_probe(
+        &self,
+        column: &str,
+        values: Vec<ScalarValue>,
+    ) -> Result<Option<Arc<dyn ExecutionPlan>>> {
+        let Some(binding) = self.probe_binding.as_ref() else {
+            return Ok(None);
+        };
+        let planned = (binding.rebind)(column.to_string(), values).await?;
+        if planned
+            .schema
+            .logically_equivalent_names_and_types(&self.schema)
+            .is_err()
+        {
+            return Ok(None);
+        }
+        let restricted = Self::new(
+            Arc::clone(&self.table),
+            planned,
+            self.target_partitions,
+            // A probe-restricted scan is built during execution from values
+            // that exist only in this execution. It must never be shared as a
+            // statement-level scan, and it is never a physical-plan template
+            // leaf, so it carries no reusable identity.
+            None,
+            self.physical_cache_key.clone(),
+            &binding.constant_columns,
+            None,
+        )?;
+        if restricted.fragment_ranges.len() != self.fragment_ranges.len() {
+            return Ok(None);
+        }
+        Ok(Some(Arc::new(restricted)))
     }
 }
 

--- a/packages/lix/src/sql2/runtime.rs
+++ b/packages/lix/src/sql2/runtime.rs
@@ -1,5 +1,5 @@
 use std::any::Any;
-use std::collections::{BTreeMap, BTreeSet, HashMap, VecDeque};
+use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet, VecDeque};
 use std::fmt::Debug;
 use std::sync::Arc;
 #[cfg(feature = "storage-benches")]
@@ -9,18 +9,19 @@ use datafusion::arrow::datatypes::SchemaRef;
 use datafusion::arrow::record_batch::RecordBatch;
 use datafusion::catalog::ScanArgs;
 use datafusion::common::tree_node::{Transformed, TreeNode, TreeNodeRecursion};
-use datafusion::common::{DataFusionError, internal_err};
+use datafusion::common::{DataFusionError, NullEquality, ScalarValue, internal_err};
 use datafusion::datasource::provider_as_source;
 use datafusion::error::Result;
 use datafusion::execution::SessionState;
 use datafusion::execution::TaskContext;
 use datafusion::execution::memory_pool::{MemoryConsumer, MemoryReservation};
-use datafusion::logical_expr::LogicalPlan;
 use datafusion::logical_expr::expr_rewriter::unnormalize_cols;
-use datafusion::physical_expr::{LexOrdering, Partitioning};
+use datafusion::logical_expr::{JoinType, LogicalPlan};
+use datafusion::physical_expr::expressions::Column as PhysicalColumn;
+use datafusion::physical_expr::{LexOrdering, Partitioning, PhysicalExpr};
 use datafusion::physical_plan::coalesce_partitions::CoalescePartitionsExec;
 use datafusion::physical_plan::execution_plan::{Boundedness, CardinalityEffect, EmissionType};
-use datafusion::physical_plan::joins::HashJoinExec;
+use datafusion::physical_plan::joins::{HashJoinExec, PartitionMode};
 use datafusion::physical_plan::limit::LimitStream;
 use datafusion::physical_plan::metrics::{BaselineMetrics, ExecutionPlanMetricsSet, MetricsSet};
 use datafusion::physical_plan::sorts::sort::SortExec;
@@ -634,6 +635,10 @@ fn adapt_runtime_plan_inner(
         return Ok(Arc::new(StatementScanCacheExec::new(state)));
     }
 
+    if let Some(probe_join) = probe_key_join(&plan)? {
+        return Ok(probe_join);
+    }
+
     let Some(coalesce) = plan.as_any().downcast_ref::<CoalescePartitionsExec>() else {
         return Ok(plan);
     };
@@ -641,6 +646,279 @@ fn adapt_runtime_plan_inner(
         Arc::clone(coalesce.input()),
         coalesce.fetch(),
     )))
+}
+
+/// Distinct probe keys one join may carry into its scan.
+///
+/// Each key becomes its own index bucket lookup, so a wide build side is
+/// cheaper to answer with the collection scan the join already had. The
+/// storage plane applies the same cap independently and declines above it, so
+/// exceeding this number costs a scan, never a wrong answer.
+const MAX_PROBE_KEYS: usize = 64;
+
+/// Wraps a hash join whose probe side is a scan that can seek on the join key.
+///
+/// Only the shapes where discarding a non-matching probe row is already the
+/// join's own behaviour qualify:
+///
+/// - `CollectLeft`, so the build side is the left input and is fully consumed
+///   before the probe side is read;
+/// - `Inner` or `Left`, whose output contains a right row only when it matched
+///   a left row — `Right` and `Full` null-extend unmatched probe rows and are
+///   therefore excluded;
+/// - `NullEqualsNothing`, so a null probe key cannot match and dropping null
+///   rows is not observable;
+/// - a single output partition, so the build side is consumed once.
+///
+/// With more than one equijoin key, restricting on any one of them is still
+/// conservative: a row that matches must match on every key, so it survives the
+/// restriction on each of them individually.
+fn probe_key_join(plan: &Arc<dyn ExecutionPlan>) -> Result<Option<Arc<dyn ExecutionPlan>>> {
+    let Some(join) = plan.as_any().downcast_ref::<HashJoinExec>() else {
+        return Ok(None);
+    };
+    if join.mode != PartitionMode::CollectLeft
+        || !matches!(join.join_type(), JoinType::Inner | JoinType::Left)
+        || join.null_equality() != NullEquality::NullEqualsNothing
+        || plan.output_partitioning().partition_count() != 1
+        || join.left().output_partitioning().partition_count() != 1
+    {
+        return Ok(None);
+    }
+    let Some(scan) = probe_scan(join.right()) else {
+        return Ok(None);
+    };
+    let left_schema = join.left().schema();
+    let right_schema = join.right().schema();
+    for (left_key, right_key) in join.on() {
+        let Some(column) = right_key.as_any().downcast_ref::<PhysicalColumn>() else {
+            continue;
+        };
+        if !scan.serves_probe_column(column.name()) {
+            continue;
+        }
+        // The restriction is handed to the provider as literals of the probe
+        // column's own type. A join key that had to be widened or cast is not
+        // that type, so leave those to the scan.
+        if left_key.data_type(&left_schema)? != right_key.data_type(&right_schema)? {
+            continue;
+        }
+        return Ok(Some(Arc::new(ProbeKeyJoinExec::new(
+            Arc::clone(plan),
+            Arc::clone(left_key),
+            column.name().to_string(),
+        ))));
+    }
+    Ok(None)
+}
+
+/// The scan a probe side reads its rows from, if the operators above it in
+/// that side neither rename its columns nor add rows to it.
+///
+/// DataFusion puts a cooperative-yielding wrapper over every leaf and may put
+/// batch coalescing or a residual filter between the join and the scan. All
+/// three pass their input's schema through unchanged, so a join key names the
+/// same scan column through any chain of them, and all three only ever emit a
+/// subset of what the scan produced — which is what makes restricting the scan
+/// beneath them observationally identical to restricting the probe side.
+fn probe_scan(plan: &Arc<dyn ExecutionPlan>) -> Option<&SpecScanExec> {
+    if let Some(scan) = plan.as_any().downcast_ref::<SpecScanExec>() {
+        return Some(scan);
+    }
+    if !probe_passthrough(plan.as_ref()) {
+        return None;
+    }
+    let children = plan.children();
+    let [child] = children.as_slice() else {
+        return None;
+    };
+    probe_scan(child)
+}
+
+fn probe_passthrough(plan: &dyn ExecutionPlan) -> bool {
+    matches!(
+        plan.name(),
+        "CooperativeExec" | "CoalesceBatchesExec" | "FilterExec"
+    )
+}
+
+/// Rebuilds a probe side around a replacement for the scan `probe_scan` found.
+fn replace_probe_scan(
+    plan: &Arc<dyn ExecutionPlan>,
+    replacement: Arc<dyn ExecutionPlan>,
+) -> Result<Arc<dyn ExecutionPlan>> {
+    if plan.as_any().downcast_ref::<SpecScanExec>().is_some() {
+        return Ok(replacement);
+    }
+    let children = plan.children();
+    let [child] = children.as_slice() else {
+        return internal_err!("probe side lost its scan");
+    };
+    let child = replace_probe_scan(child, replacement)?;
+    Arc::clone(plan).with_new_children(vec![child])
+}
+
+/// A hash join that reads its build side first and replans its probe scan
+/// restricted to the build side's key values.
+///
+/// The rewrite is an access-path choice, never a semantic one. The restricted
+/// scan is the same provider scan with one extra `IN` predicate on a key
+/// column, and the join that runs over it is the original join with its
+/// children swapped for a replay of the build side and that restricted scan.
+/// Every reason to decline — too many distinct keys, a provider that cannot
+/// seek the column, a build side whose keys are all null — falls back to the
+/// unrestricted scan and produces the same rows more slowly.
+#[derive(Debug)]
+struct ProbeKeyJoinExec {
+    join: Arc<dyn ExecutionPlan>,
+    left_key: Arc<dyn PhysicalExpr>,
+    probe_column: String,
+    properties: Arc<PlanProperties>,
+}
+
+impl ProbeKeyJoinExec {
+    fn new(
+        join: Arc<dyn ExecutionPlan>,
+        left_key: Arc<dyn PhysicalExpr>,
+        probe_column: String,
+    ) -> Self {
+        Self {
+            properties: Arc::clone(join.properties()),
+            join,
+            left_key,
+            probe_column,
+        }
+    }
+}
+
+impl DisplayAs for ProbeKeyJoinExec {
+    fn fmt_as(&self, _t: DisplayFormatType, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "ProbeKeyJoinExec: probe_key={}", self.probe_column)
+    }
+}
+
+impl ExecutionPlan for ProbeKeyJoinExec {
+    fn name(&self) -> &'static str {
+        "ProbeKeyJoinExec"
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn properties(&self) -> &Arc<PlanProperties> {
+        &self.properties
+    }
+
+    fn children(&self) -> Vec<&Arc<dyn ExecutionPlan>> {
+        self.join.children()
+    }
+
+    fn with_new_children(
+        self: Arc<Self>,
+        children: Vec<Arc<dyn ExecutionPlan>>,
+    ) -> Result<Arc<dyn ExecutionPlan>> {
+        let join = rebuild_hash_join(&self.join, children)?;
+        // Re-derive rather than reattach: a replacement probe child that can no
+        // longer seek this key must go back to the plain join.
+        Ok(probe_key_join(&join)?.unwrap_or(join))
+    }
+
+    fn execute(
+        &self,
+        partition: usize,
+        context: Arc<TaskContext>,
+    ) -> Result<SendableRecordBatchStream> {
+        let join = Arc::clone(&self.join);
+        let left_key = Arc::clone(&self.left_key);
+        let probe_column = self.probe_column.clone();
+        let schema = self.schema();
+        let restricted = stream::once(async move {
+            let children = join.children();
+            let (Some(build), Some(probe)) = (children.first(), children.get(1)) else {
+                return internal_err!("probe-key join lost a child");
+            };
+            // The build side is consumed once here to read the keys and replayed
+            // from memory by the join. `CollectLeft` already materializes it, so
+            // this is the same collection moved one operator earlier.
+            let build: Arc<dyn ExecutionPlan> = Arc::new(StatementScanCacheExec::new(Arc::new(
+                StatementScanCacheState::new(Arc::clone(build)),
+            )));
+            let batches =
+                collect_adapted_input_plan(Arc::clone(&build), Arc::clone(&context)).await?;
+            let restricted_scan = match probe_keys(&batches, &left_key)? {
+                Some(values) => match probe_scan(probe) {
+                    Some(scan) if scan.serves_probe_column(&probe_column) => {
+                        scan.rebind_probe(&probe_column, values).await?
+                    }
+                    _ => None,
+                },
+                None => None,
+            };
+            let probe = match restricted_scan {
+                Some(restricted_scan) => replace_probe_scan(probe, restricted_scan)?,
+                None => Arc::clone(probe),
+            };
+            rebuild_hash_join(&join, vec![build, probe])?.execute(partition, context)
+        })
+        .try_flatten();
+        Ok(Box::pin(RecordBatchStreamAdapter::new(schema, restricted)))
+    }
+
+    fn partition_statistics(&self, partition: Option<usize>) -> Result<Statistics> {
+        self.join.partition_statistics(partition)
+    }
+}
+
+/// Rebuilds a hash join over new children with no state carried over.
+///
+/// `HashJoinExec::with_new_children` deliberately preserves the build table and
+/// dynamic-filter state of the operator it clones, which a rebuilt join must
+/// not inherit.
+fn rebuild_hash_join(
+    join: &Arc<dyn ExecutionPlan>,
+    children: Vec<Arc<dyn ExecutionPlan>>,
+) -> Result<Arc<dyn ExecutionPlan>> {
+    let Some(hash_join) = join.as_any().downcast_ref::<HashJoinExec>() else {
+        return internal_err!("probe-key join wraps a non-hash join");
+    };
+    hash_join
+        .builder()
+        .with_new_children(children)?
+        .reset_state()
+        .build_exec()
+}
+
+/// The distinct non-null build-side key values, or `None` when the join must
+/// keep its unrestricted probe scan.
+///
+/// Null keys are dropped because the caller already established
+/// `NullEqualsNothing`, under which a null key matches nothing.
+fn probe_keys(
+    batches: &[RecordBatch],
+    key: &Arc<dyn PhysicalExpr>,
+) -> Result<Option<Vec<ScalarValue>>> {
+    let mut seen = HashSet::new();
+    let mut values = Vec::new();
+    for batch in batches {
+        if batch.num_rows() == 0 {
+            continue;
+        }
+        let array = key.evaluate(batch)?.into_array(batch.num_rows())?;
+        for index in 0..array.len() {
+            if array.is_null(index) {
+                continue;
+            }
+            let value = ScalarValue::try_from_array(&array, index)?;
+            if seen.insert(value.clone()) {
+                if values.len() == MAX_PROBE_KEYS {
+                    return Ok(None);
+                }
+                values.push(value);
+            }
+        }
+    }
+    Ok((!values.is_empty()).then_some(values))
 }
 
 #[derive(Debug)]

--- a/packages/lix/src/transaction/validation.rs
+++ b/packages/lix/src/transaction/validation.rs
@@ -3162,7 +3162,7 @@ fn declared_column_probe(
     Some(crate::hot_state::DeclaredColumnEq {
         schema_key: scope.schema_key.clone(),
         ordinal,
-        value: value.exact_hot_index_value()?,
+        values: vec![value.exact_hot_index_value()?],
     })
 }
 

--- a/packages/lix/tests/point_join_scan_scaling.rs
+++ b/packages/lix/tests/point_join_scan_scaling.rs
@@ -1,0 +1,300 @@
+//! A point lookup through two foreign-key joins must read a number of stored
+//! rows set by its answer, not by the size of the collections it joins.
+//!
+//! The shape is the inlang `selectBundleNested(...).where("bundle.id","=",id)`
+//! query from issue #1337: `bundle -> message -> variant`, two rows out. The
+//! first join's equality reaches `message` by ordinary constant propagation,
+//! but `variant."messageId"` can only be known once the message rows exist, so
+//! before the probe-key access path the `variant` scan was unfiltered and the
+//! query read `2N+3` rows at N bundles.
+//!
+//! `provider_rows_examined` is the metric under test because it counts stored
+//! rows a provider *looked at*, before its own row filters. `scan_rows` alone
+//! cannot falsify this claim: moving a filter earlier in the plan changes
+//! `scan_rows` while the collection is still being read end to end.
+
+use std::future::Future;
+
+use lix::integration::{Engine, SessionContext};
+use lix::{Memory, Value};
+
+/// See the identical note in `e2e`'s `tracked_state_crud_public_result`:
+/// building and optimizing real DataFusion plans recurses per plan node and
+/// overflows libtest's 2 MiB worker stack in the `test` profile.
+const POINT_JOIN_TEST_STACK_SIZE: usize = 32 * 1024 * 1024;
+
+const NESTED_BUNDLE_SQL: &str = r#"SELECT bundle.id AS "bundleId", bundle.declarations AS "bundleDeclarations", message.id AS "messageId", message.locale AS "messageLocale", variant.id AS "variantId", variant.pattern AS "variantPattern" FROM bundle LEFT JOIN message ON message."bundleId" = bundle.id LEFT JOIN variant ON variant."messageId" = message.id WHERE bundle.id = $1"#;
+
+/// Rows the three scans must examine for a bundle with two messages and one
+/// variant each: one bundle row, two message rows, two variant rows.
+const ANSWER_SIZED_ROWS: u64 = 5;
+
+fn run_on_sized_stack<Body, Fut>(name: &str, body: Body)
+where
+    Body: FnOnce() -> Fut + Send + 'static,
+    Fut: Future<Output = ()>,
+{
+    std::thread::Builder::new()
+        .name(name.to_string())
+        .stack_size(POINT_JOIN_TEST_STACK_SIZE)
+        .spawn(move || {
+            tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .expect("build point-join test runtime")
+                .block_on(body());
+        })
+        .expect("spawn point-join test thread")
+        .join()
+        .expect("point-join test body panicked");
+}
+
+#[test]
+fn nested_bundle_point_lookup_reads_rows_proportional_to_its_answer() {
+    run_on_sized_stack("point_join_scan_scaling", || async {
+        let mut examined_by_size = Vec::new();
+        for bundles in [10_usize, 500] {
+            let session = seeded_session(bundles).await;
+            let target = Value::Text(format!("bundle-{}", bundles / 2));
+            // Warm the statement and physical plan caches so the measured
+            // execution takes the same route a repeated application query does.
+            let (rows, _) = session
+                .execute_profiled(NESTED_BUNDLE_SQL, std::slice::from_ref(&target))
+                .await
+                .expect("nested bundle query");
+            assert_eq!(rows.len(), 2, "{bundles} bundles: two flat rows");
+            let (rows, profile) = session
+                .execute_profiled(NESTED_BUNDLE_SQL, std::slice::from_ref(&target))
+                .await
+                .expect("nested bundle query");
+            assert_eq!(rows.len(), 2, "{bundles} bundles: two flat rows");
+            examined_by_size.push((bundles, profile.provider_rows_examined));
+        }
+
+        for (bundles, examined) in &examined_by_size {
+            assert_eq!(
+                *examined, ANSWER_SIZED_ROWS,
+                "at {bundles} bundles the point lookup examined {examined} stored rows; \
+                 it must examine {ANSWER_SIZED_ROWS} — one per row its answer is built from. \
+                 A count that grows with the fixture means a join key never reached an \
+                 indexed access path and a collection was scanned in full."
+            );
+        }
+        let [(_, small), (_, large)] = examined_by_size.as_slice() else {
+            panic!("two fixture sizes");
+        };
+        assert_eq!(
+            small, large,
+            "rows examined must not grow with the collections being joined"
+        );
+    });
+}
+
+#[test]
+fn nested_bundle_point_lookup_preserves_left_join_null_extension() {
+    run_on_sized_stack("point_join_null_extension", || async {
+        let session = seeded_session(4).await;
+        // A bundle with no message at all, and a message with no variant. Both
+        // are rows the probe-key restriction must not be able to remove.
+        session
+            .execute(
+                "INSERT INTO bundle (id, declarations) VALUES ('bundle-lonely', lix_json('[]'))",
+                &[],
+            )
+            .await
+            .expect("insert childless bundle");
+        session
+            .execute(
+                "INSERT INTO bundle (id, declarations) VALUES ('bundle-variantless', lix_json('[]'))",
+                &[],
+            )
+            .await
+            .expect("insert variantless bundle");
+        session
+            .execute(
+                r#"INSERT INTO message (id, "bundleId", locale, selectors) VALUES ('message-variantless', 'bundle-variantless', 'en', lix_json('[]'))"#,
+                &[],
+            )
+            .await
+            .expect("insert variantless message");
+
+        let lonely = select_ids(&session, "bundle-lonely").await;
+        assert_eq!(
+            lonely,
+            vec![("bundle-lonely".to_string(), None, None)],
+            "a bundle with no message must still produce one null-extended row"
+        );
+
+        let variantless = select_ids(&session, "bundle-variantless").await;
+        assert_eq!(
+            variantless,
+            vec![(
+                "bundle-variantless".to_string(),
+                Some("message-variantless".to_string()),
+                None,
+            )],
+            "a message with no variant must still produce one null-extended row"
+        );
+
+        let missing = select_ids(&session, "bundle-does-not-exist").await;
+        assert!(
+            missing.is_empty(),
+            "an unmatched bundle id must produce no rows, got {missing:?}"
+        );
+
+        let present = select_ids(&session, "bundle-2").await;
+        assert_eq!(
+            present,
+            vec![
+                (
+                    "bundle-2".to_string(),
+                    Some("message-2-de".to_string()),
+                    Some("variant-2-de".to_string()),
+                ),
+                (
+                    "bundle-2".to_string(),
+                    Some("message-2-en".to_string()),
+                    Some("variant-2-en".to_string()),
+                ),
+            ],
+            "a fully populated bundle must produce both of its rows"
+        );
+    });
+}
+
+type NestedRow = (String, Option<String>, Option<String>);
+
+async fn select_ids(session: &SessionContext<Memory>, bundle_id: &str) -> Vec<NestedRow> {
+    let result = session
+        .execute(NESTED_BUNDLE_SQL, &[Value::Text(bundle_id.to_string())])
+        .await
+        .expect("nested bundle query");
+    let mut rows = result
+        .rows()
+        .iter()
+        .map(|row| {
+            (
+                text(row.value("bundleId").expect("bundleId column"))
+                    .expect("bundle id is never null"),
+                text(row.value("messageId").expect("messageId column")),
+                text(row.value("variantId").expect("variantId column")),
+            )
+        })
+        .collect::<Vec<_>>();
+    rows.sort();
+    rows
+}
+
+fn text(value: &Value) -> Option<String> {
+    match value {
+        Value::Text(text) => Some(text.clone()),
+        Value::Null => None,
+        other => panic!("expected a text or null id, got {other:?}"),
+    }
+}
+
+async fn seeded_session(bundles: usize) -> SessionContext<Memory> {
+    let storage = Memory::default();
+    Engine::initialize(storage.clone())
+        .await
+        .expect("initialize fixture");
+    let engine = Engine::new(storage).await.expect("open engine");
+    let session = engine
+        .open_workspace_session()
+        .await
+        .expect("open workspace session");
+    for schema in schemas() {
+        session
+            .execute(
+                "INSERT INTO lix_registered_schema (value) VALUES (lix_json($1))",
+                &[Value::Text(schema.to_string())],
+            )
+            .await
+            .expect("register schema");
+    }
+    for index in 0..bundles {
+        let bundle = format!("bundle-{index}");
+        session
+            .execute(
+                "INSERT INTO bundle (id, declarations) VALUES ($1, lix_json('[]'))",
+                &[Value::Text(bundle.clone())],
+            )
+            .await
+            .expect("insert bundle");
+        for locale in ["en", "de"] {
+            let message = format!("message-{index}-{locale}");
+            session
+                .execute(
+                    r#"INSERT INTO message (id, "bundleId", locale, selectors) VALUES ($1, $2, $3, lix_json('[]'))"#,
+                    &[
+                        Value::Text(message.clone()),
+                        Value::Text(bundle.clone()),
+                        Value::Text(locale.into()),
+                    ],
+                )
+                .await
+                .expect("insert message");
+            session
+                .execute(
+                    r#"INSERT INTO variant (id, "messageId", matches, pattern) VALUES ($1, $2, lix_json('[]'), lix_json('[{"type":"text","value":"fixture"}]'))"#,
+                    &[
+                        Value::Text(format!("variant-{index}-{locale}")),
+                        Value::Text(message),
+                    ],
+                )
+                .await
+                .expect("insert variant");
+        }
+    }
+    session
+}
+
+fn schemas() -> [serde_json::Value; 3] {
+    [
+        serde_json::json!({
+            "x-lix-key": "bundle",
+            "x-lix-primary-key": ["/id"],
+            "type": "object",
+            "properties": {
+                "id": { "type": "string" },
+                "declarations": { "type": "array", "items": { "type": "object" }, "default": [] }
+            },
+            "required": ["id", "declarations"],
+            "additionalProperties": false
+        }),
+        serde_json::json!({
+            "x-lix-key": "message",
+            "x-lix-primary-key": ["/id"],
+            "x-lix-foreign-keys": [{
+                "properties": ["/bundleId"],
+                "references": { "schemaKey": "bundle", "properties": ["/id"] }
+            }],
+            "type": "object",
+            "properties": {
+                "id": { "type": "string" },
+                "bundleId": { "type": "string" },
+                "locale": { "type": "string" },
+                "selectors": { "type": "array", "items": { "type": "object" }, "default": [] }
+            },
+            "required": ["id", "bundleId", "locale", "selectors"],
+            "additionalProperties": false
+        }),
+        serde_json::json!({
+            "x-lix-key": "variant",
+            "x-lix-primary-key": ["/id"],
+            "x-lix-foreign-keys": [{
+                "properties": ["/messageId"],
+                "references": { "schemaKey": "message", "properties": ["/id"] }
+            }],
+            "type": "object",
+            "properties": {
+                "id": { "type": "string" },
+                "messageId": { "type": "string" },
+                "matches": { "type": "array", "items": { "type": "object" }, "default": [] },
+                "pattern": { "type": "array", "items": { "type": "object" }, "default": [] }
+            },
+            "required": ["id", "messageId", "matches", "pattern"],
+            "additionalProperties": false
+        }),
+    ]
+}


### PR DESCRIPTION
Fixes #1337. A three-table point lookup that returns 2 rows read `2N+3` stored
rows, so it grew with the collections it joined while SQLite stayed flat on
three indexes. It is now flat:

| bundles | `main` rows examined | this PR |
|---:|---:|---:|
| 10 | 23 | **5** |
| 100 | 203 | **5** |
| 500 | 1,003 | **5** |
| 2,000 | 4,003 | **5** |

Those `main` numbers are the issue's own `2*N+3` column, reproduced exactly. 5
is one bundle row, two message rows and two variant rows — one per row the
two-row answer is built from. The `2N` term is gone, not shrunk.

## Why it was slow — two separate gaps, and the first one is not a pushdown bug

lix already has the index this query needs. `hot_state.index.v1` indexes every
single-property `x-lix-unique` group **and every single-property
`x-lix-foreign-keys` local property**, and `message.bundleId` /
`variant.messageId` are exactly that. The obvious diagnosis — "the join never
consults the index, so push the predicate down" — is half right, and the wrong
half matters.

Controls measured on `main` (`provider_rows_examined`: stored rows a provider
looked at *before* its own row filters):

| control | what it isolates | `main` |
|---|---|---:|
| `message_fk_only` — `WHERE "bundleId" = $1` | single-table FK equality | 2, flat in N |
| `two_table` — `bundle LEFT JOIN message` | one FK join | 3, flat in N |
| `real` — the issue's query | two FK joins | **2N+3** |
| `real_manual_predicates` — `real` with `variant."messageId" IN ($2,$3)` written out | the values supplied as literals | **2N+3** |

**Gap 1 — there is no constant to propagate.** `message.bundleId` already
reaches the index on `main`: DataFusion's constant propagation rewrites
`bundle.id = $1` into `message."bundleId" = $1`, and that is why `two_table`
sits at 3 rows at every N. It does not generalise to the second join.
`variant."messageId" = message.id` has a constant on neither side — the message
ids are **data**, produced only once the message rows have been read.

This is worth stating plainly because the neighbouring machinery invites the
opposite conclusion: #1399's sort elision works by pinning a column against a
**literal** carried by an `Exact` pushdown. There is no literal here at plan
time, so no amount of planner-side pushdown can reach `variant`. The
distinction is between *constant propagation reaching the index* (already
works) and *a join probe needing the index at execution time* (did not exist).
DataFusion's own join dynamic filter does not close it either: `HashJoinExec`
gates it on `JoinType::Inner`, and what it publishes is a min/max bound, not the
exact key set an index bucket lookup needs.

**Gap 2 — even with literals, the index declined.** `declared_column_eq`
matched `EntityRowFilter::ColumnEq` and nothing else — one value. A join probe
never carries one value, and DataFusion's simplifier rewrites a short `IN` list
into `col = a OR col = b`, so both spellings missed. The
`real_manual_predicates` control is the proof: at N=2000 it examines **4,003**
rows to produce a scan output of **5**, i.e. the predicate ran after the whole
collection had already been read. An application cannot work around gap 1 by
splitting the query, because gap 2 catches it too.

## What changed

**Storage — the index answers a value set, not one value.**
`DeclaredColumnEq.value` becomes `values: Vec<HotIndexValue>` and
`scan_hot_index_candidates` takes a slice. The witness read and the candidate
budget are **shared across the values**, so a multi-value probe can never read
more index entries than a single-value probe was already allowed to. Above
`HOT_INDEX_PROBE_VALUE_LIMIT` (64) distinct values it declines and the caller
keeps its ordinary scan: each value costs its own range scan, so a wide `IN`
list or a wide join build side is genuinely cheaper to answer by scanning, and
declining keeps the probe route weakly better than the route it replaces in
every case. `declared_column_eq` now also recognises `ColumnIn` and a
disjunction of equalities on one column, so both spellings of a membership test
reach the index the same way.

**SQL — a join hands its probe keys to the scan.** `adapt_runtime_plan` (the
existing runtime adaptation pass in `sql2/runtime.rs`, which already inserts
`StatementScanCacheExec`) wraps a qualifying `HashJoinExec` in a new
`ProbeKeyJoinExec`. At execution it reads the build side once, takes the
distinct non-null values of the join key, replans the probe scan with one extra
`IN` predicate on that column, and runs the original join over a replay of the
build side and the restricted scan.

The restriction is an access-path choice, never a semantic one:

- the replanned scan is the *same* provider scan with one more predicate, so it
  returns exactly the subset of rows the unrestricted scan would have returned;
- the index lookup returns *candidates* — entries are not deleted when a value
  is superseded — and the appended `IN` stays in the provider's row filters,
  which is what rejects stale candidates;
- every reason to decline (more than 64 distinct keys, a provider that cannot
  seek the column, an all-null build key, a cast between the key types, a
  replanned scan whose schema or partition count is not a drop-in replacement)
  falls back to the unrestricted scan and produces the same rows, more slowly.

Only shapes where dropping a non-matching probe row is already the join's own
behaviour qualify: `CollectLeft` (build side is the left input and is fully
consumed before the probe side is read), `Inner` or `Left` (`Right`/`Full`
null-extend unmatched probe rows and are excluded), `NullEqualsNothing`, a
single output partition, and a probe side that reaches its `SpecScanExec`
through schema-preserving operators only (`CooperativeExec`,
`CoalesceBatchesExec`, `FilterExec`).

A scan that is *already* constrained on the key gets no probe binding
(`probe_key_columns` now takes the pushed-down filters): without that gate the
two-table control paid for a build-side collection and a replan that could not
narrow anything.

`ProbeKeyJoinExec` is built during `adapt_runtime_plan`, which runs *after* the
physical-plan template is detached, so it never enters the plan cache and needs
no entry in `template_operator_is_reusable`. It holds no state across
executions: the build side is collected inside one `execute` call and the
restricted scan is constructed from values that exist only in that call.

**No format change and no migration.** No key encoding, value layout or storage
space changed. `DeclaredColumnEq` is an in-process request type, never
persisted. The index plane this reads is the one `main` already writes.

**Public API:** unchanged. No `lib.rs` export, SQL surface or JS SDK surface
moves.

## Measurements

`packages/e2e/examples/exppq_point_query`, ryzen-9950x-V (32c/186G), `Memory`
storage. Base = `main` `8111941b8231a330ff80f26697df72f2c643c434`; candidate =
this branch at that base. (`main` has since taken the `packages/e2e` rename,
`ab4277d9c`; this branch is rebased onto it and nothing in the measured code
path changed between the two.)

```
~/claude5/target-{base,cand}/release/examples/exppq_point_query 10,100,500,2000 200
```

3 interleaved reps per arm, arm order rotated (base-first, cand-first,
base-first), 200 measured rounds per point after 50 warm-up rounds, nothing else
running on the host.

`provider_rows_examined` is the primary metric rather than `scan_rows`, because
it counts rows read *before* the provider's own filters: a change that merely
moves filtering earlier in the plan moves `scan_rows` and cannot move this. It
is deterministic and was identical in all three reps — the table at the top of
this description is the whole result.

### Timings (median of 3 reps, µs per query)

| scenario | N | base | cand | delta |
|---|---:|---:|---:|---:|
| **real** — the issue's query | 10 | 192.9 | 209.3 | **+8.5%** |
| **real** | 100 | 337.5 | 210.0 | **−37.8%** |
| **real** | 500 | 1,054.0 | 211.8 | **−79.9%** (5.0x) |
| **real** | 2,000 | 3,613.7 | 213.5 | **−94.1%** (16.9x) |
| real_manual_predicates | 10 | 178.2 | 155.7 | −12.6% |
| real_manual_predicates | 2,000 | 3,170.7 | 160.2 | −94.9% |
| two_table (guard) | 2,000 | 100.1 | 103.5 | +3.4% |
| message_fk_only (guard) | 2,000 | 40.7 | 41.7 | +2.4% |
| bundle_pk (null control) | 2,000 | 24.3 | 23.8 | −2.1% |
| constant (null control) | 2,000 | 27.7 | 27.8 | +0.4% |

Raw per-rep `real` (µs) — base 194.6 / 192.9 / 189.8 @ N=10,
341.2 / 337.5 / 334.6 @ N=100, 1061.6 / 1047.0 / 1054.0 @ N=500,
3671.5 / 3613.7 / 3613.7 @ N=2000; cand 209.3 / 208.3 / 209.3 @ N=10,
210.6 / 210.0 / 208.3 @ N=100, 211.2 / 211.8 / 212.1 @ N=500,
211.8 / 213.5 / 213.5 @ N=2000.

**Null-control spread.** `constant` (`SELECT 1`) and `bundle_pk` execute
byte-identical code in both arms. Across the three reps `constant` spans
27.0–27.9 µs on base and 27.5–28.3 on cand; `bundle_pk` 24.1–24.7 vs 23.5–24.3.
**Read anything under roughly ±3% as unresolvable on this bench.** The
`two_table` and `message_fk_only` guards sit at that line. The `real` rows at
N≥100 are far outside it — the arms' raw ranges do not overlap at all
(334.6–341.2 vs 208.3–210.6; 3613.7–3671.5 vs 211.8–213.5).

### What regressed, stated up front

**The three-table lookup is ~8.5% slower at N=10** (192.9 → 209.3 µs). That is
the mechanism's fixed cost, not noise: collecting the build side and issuing two
index bucket lookups is more work than reading the 20 variant rows that exist at
that size. It is a constant, so it is already repaid at N=100 (−37.8%) and is
17x by N=2000. Anyone who runs a small fixture will see it, so it is better read
here first. Under the priority ranking, removing an asymptotic term outranks a
constant at the smallest size.

`two_table` at +3.4% is the plan-time cost of asking each entity scan whether it
has an unconstrained indexed column; that runs on the warm plan-cache path too.
The two tests in `probe_key_columns` are therefore ordered so the cheap one
(column names referenced by the filters) rejects the common case before the
identity analysis runs — **that ordering landed after this measurement**, so
+3.4% is an upper bound on the shipped code, and it already sits at the bench's
resolution limit.

## Regression test

`packages/lix/tests/point_join_scan_scaling.rs`, gated on `storage-benches`
(the feature `SqlReadProfile` / `execute_profiled` live behind); CI's
`cargo test --workspace --all-features` run builds it.

- `nested_bundle_point_lookup_reads_rows_proportional_to_its_answer` asserts
  `provider_rows_examined == 5` at both 10 and 500 bundles, and that the two
  counts are equal — the shape the issue asked for.
- `nested_bundle_point_lookup_preserves_left_join_null_extension` covers the
  cases an over-eager pushdown breaks: a bundle with no message, a message with
  no variant, an id that matches nothing, and a fully populated bundle.

**It fails on `main`.** Branch `e41-main-plus-test` is `main` plus this test and
its `[[test]]` entry, nothing else:

```
$ cargo test --profile test -p lix --features storage-benches --test point_join_scan_scaling
HEAD: d9e13188c959b3ddb64e22c444701ac4d6aeb27a   (main ab4277d9c + this test)

thread 'point_join_scan_scaling' panicked at packages/lix/tests/point_join_scan_scaling.rs:75:13:
assertion `left == right` failed: at 10 bundles the point lookup examined 23 stored
rows; it must examine 5 — one per row its answer is built from. A count that grows
with the fixture means a join key never reached an indexed access path and a
collection was scanned in full.

test result: FAILED. 1 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out
```

The null-extension test passes there, as it must — it is a correctness guard,
not a performance one.

## Layout invariants

1. **Single authority.** No new authority; nothing is written. The hot index
   plane already existed and is already a disposable derived cache. This PR
   only reads it with a value set instead of a single value.
2. **Commit canonicality.** Untouched — no commit, ref or parent link is read or
   written differently.
3. **Derived views are caches.** Yes, and unchanged: the index returns
   *candidates* and the provider's own predicate rejects stale ones. Deleting
   the whole index plane would still produce identical rows, only slower.
4. **Atomic publication.** Untouched — read path only.
5. **GC from refs.** Untouched.
6. **SQL reads canonical records.** Yes. The restricted scan is the ordinary
   entity scan; the index only chooses which identities it reads.

## Adapter API

No change. `StorageAdapter` and the conformance suite are untouched — the new
work is one extra `begin_scan` per probe value on the existing `INDEX_SPACE`.

## Gate

Run on ryzen-9950x-V, from inside the gate run:

```
=== GATE HEAD ===
b76dc4880a852deb34d119fd12e72cb597c11099
=== git status --porcelain ===
=== END ===
```

(`git status --porcelain` is empty — no uncommitted changes.)

Scope taken from `origin/main:.github/workflows/ci.yml`; the package is still
named `lix_benchmarks` after the `packages/e2e` directory rename.

| command | result |
|---|---|
| `cargo clippy --profile test --workspace --all-targets --all-features -- -D warnings` | **0 warnings, 0 errors** |
| `cargo test --profile test --workspace --exclude lix_benchmarks --all-features --no-fail-fast` | **3502 passed, 0 failed** |
| `cargo test --profile test -p lix_benchmarks --features storage-benches,slatedb,root-replay-trace --no-fail-fast` | **33 passed, 0 failed** |
| `cargo check -p lix --no-default-features` | clean |
| `cargo check -p lix_js_sdk --target wasm32-unknown-unknown` | clean |

3,535 passed / 0 failed in total. The new target reports
`test result: ok. 2 passed; 0 failed`. Logs were captured to files and grepped
for `test result: FAILED`, `panicked`, `^error` — not tailed. The clippy run was
re-run with the touched sources invalidated so the log is a real compile, not a
cache hit.

`rustfmt --check` was run on every touched file: the new test file is clean, and
the remaining diffs in the edited files are identical to the ones already
present on `main` (the repo is fmt-dirty repo-wide). One pre-existing diff in
`entity.rs` was incidentally removed by the rewrite of `declared_column_eq`.
