### PR TITLE
perf(hot-state): stop reading the packed commit delta to locate a row a HOT row already answers

### DIFF
--- a/packages/lix/src/hot_state/tracked_head/hot.rs
+++ b/packages/lix/src/hot_state/tracked_head/hot.rs
@@ -4185,12 +4185,42 @@ async fn scan_packed_current_base_provenance_rows(
     Ok(rows.finish())
 }
 
+/// Aligns already-resolved HOT overlay rows to an exact key list so the packed
+/// current base is only consulted for keys it could still win.
+fn packed_current_base_shadow_from_rows(
+    keys: &[TrackedStateKeyRef<'_>],
+    rows: &MaterializedHotStateBatch,
+) -> Vec<Option<CommitId>> {
+    let mut resolved = BTreeMap::<(&str, Option<&str>, &EntityPk), Option<CommitId>>::new();
+    for row in rows.iter() {
+        let commit_id = row.commit_id();
+        let slot = resolved
+            .entry((row.schema_key(), row.file_id(), row.entity_pk()))
+            .or_insert(commit_id);
+        // Keep the newest resolved commit. A row without one proves nothing
+        // about the base, so it disables the skip for that key entirely.
+        *slot = match (*slot, commit_id) {
+            (Some(current), Some(candidate)) => Some(current.max(candidate)),
+            _ => None,
+        };
+    }
+    keys.iter()
+        .map(|key| {
+            resolved
+                .get(&(key.schema_key, key.file_id, key.entity_pk))
+                .copied()
+                .flatten()
+        })
+        .collect()
+}
+
 async fn load_packed_current_base_exact(
     store: &(impl StorageAdapterRead + ?Sized),
     branch_id: &str,
     generation: CommitId,
     active_checkpoint_commit_id: Option<CommitId>,
     keys: &[TrackedStateKeyRef<'_>],
+    shadow: PackedCurrentBaseShadow<'_>,
     projection: ChangeRecordProjection,
     transaction_cache: Option<&HotStateTransactionCache>,
 ) -> Result<MaterializedHotStateExactBatch, LixError> {
@@ -4205,6 +4235,7 @@ async fn load_packed_current_base_exact(
         branch_id,
         generation,
         keys,
+        shadow,
         transaction_cache,
     )
     .await?;
@@ -4306,11 +4337,24 @@ async fn load_packed_current_base_exact(
     MaterializedHotStateExactBatch::new(rows.finish(), slots)
 }
 
+/// Per-key commit id already resolved from a plane that shadows the packed
+/// current base — in practice a branch-local HOT row. Empty means "nothing is
+/// known", which reads every key from the base as before.
+///
+/// A packed current base published at commit `C` can only serve rows whose
+/// owning commit is an ancestor of `C`, so `C` is an upper bound on every
+/// `commit_id` it can produce. The caller's merge keeps a packed candidate
+/// only when it is *strictly newer* than what is already resolved; a key whose
+/// resolved commit id is at least the newest base ref therefore cannot change
+/// its winner, and its segment never has to be fetched or decoded.
+type PackedCurrentBaseShadow<'a> = &'a [Option<CommitId>];
+
 async fn load_packed_current_base_exact_entries(
     store: &(impl StorageAdapterRead + ?Sized),
     branch_id: &str,
     generation: CommitId,
     keys: &[TrackedStateKeyRef<'_>],
+    shadow: PackedCurrentBaseShadow<'_>,
     transaction_cache: Option<&HotStateTransactionCache>,
 ) -> Result<
     Vec<
@@ -4325,6 +4369,7 @@ async fn load_packed_current_base_exact_entries(
     if keys.is_empty() {
         return Ok(Vec::new());
     }
+    debug_assert!(shadow.is_empty() || shadow.len() == keys.len());
     let transaction_cache = match transaction_cache {
         Some(cache) if cache.should_reuse_packed_points(generation)? => Some(cache),
         Some(_) | None => None,
@@ -4345,6 +4390,36 @@ async fn load_packed_current_base_exact_entries(
     };
     if base_refs.is_empty() {
         return Ok((0..keys.len()).map(|_| None).collect());
+    }
+    if shadow.len() == keys.len()
+        && let Some(newest_base) = base_refs.iter().map(|base_ref| base_ref.commit_id).max()
+    {
+        let unresolved = keys
+            .iter()
+            .enumerate()
+            .filter(|(index, _)| shadow[*index].is_none_or(|resolved| resolved < newest_base))
+            .map(|(index, key)| (index, *key))
+            .collect::<Vec<_>>();
+        if unresolved.is_empty() {
+            return Ok((0..keys.len()).map(|_| None).collect());
+        }
+        if unresolved.len() != keys.len() {
+            let unresolved_keys = unresolved.iter().map(|(_, key)| *key).collect::<Vec<_>>();
+            let loaded = Box::pin(load_packed_current_base_exact_entries(
+                store,
+                branch_id,
+                generation,
+                &unresolved_keys,
+                &[],
+                transaction_cache,
+            ))
+            .await?;
+            let mut output = (0..keys.len()).map(|_| None).collect::<Vec<_>>();
+            for ((index, _), entry) in unresolved.into_iter().zip(loaded) {
+                output[index] = entry;
+            }
+            return Ok(output);
+        }
     }
     if let [base_ref] = base_refs.as_slice() {
         return Ok(
@@ -5627,12 +5702,14 @@ where
                     entity_pk: &key.entity_pk,
                 })
                 .collect::<Vec<_>>();
+            let shadow = packed_current_base_shadow_from_rows(&key_refs, &rows);
             load_packed_current_base_exact(
                 &self.store,
                 branch_id,
                 generation,
                 active_checkpoint_commit_id,
                 &key_refs,
+                &shadow,
                 projection,
                 self.transaction_cache.as_deref(),
             )
@@ -5914,12 +5991,20 @@ where
         // proving that a keyed update or foreign-key target already exists.
         // Decode the matching segment rows only when the ordinary point-read
         // index misses, then preserve the original request alignment.
+        let packed_shadow = slots
+            .iter()
+            .map(|slot| {
+                slot.and_then(|slot| rows.get(slot as usize))
+                    .and_then(|row| row.commit_id())
+            })
+            .collect::<Vec<_>>();
         let packed = load_packed_current_base_exact(
             &self.store,
             branch_id,
             generation,
             active_checkpoint_commit_id,
             keys,
+            &packed_shadow,
             *projection,
             self.transaction_cache.as_deref(),
         )
@@ -7521,11 +7606,25 @@ where
                 }
             })
             .collect::<Vec<_>>();
+        // The HOT overlay predecessor loaded just above already shadows the
+        // packed current base whenever it is at least as new as the newest
+        // base ref, so hand it over and let the base loader skip those keys.
+        let packed_previous_shadow = packed_previous_indices
+            .iter()
+            .map(|&index| {
+                Ok(previous_values[index]
+                    .as_ref()
+                    .map(CertifiedCurrentStatePredecessor::view)
+                    .transpose()?
+                    .and_then(|previous| previous.commit_id))
+            })
+            .collect::<Result<Vec<_>, LixError>>()?;
         let packed_previous = Box::pin(load_packed_current_base_exact_entries(
             self.store,
             branch_id,
             generation,
             &packed_previous_keys,
+            &packed_previous_shadow,
             None,
         ))
         .await?;
@@ -13406,6 +13505,7 @@ mod tests {
             crate::GLOBAL_BRANCH_ID,
             generation,
             &request_keys,
+            &[],
             Some(transaction_cache.as_ref()),
         )
         .await
@@ -13416,6 +13516,7 @@ mod tests {
                 crate::GLOBAL_BRANCH_ID,
                 generation,
                 &request_keys,
+                &[],
                 Some(transaction_cache.as_ref()),
             )
             .await
@@ -13427,6 +13528,7 @@ mod tests {
             crate::GLOBAL_BRANCH_ID,
             generation,
             &request_keys,
+            &[],
             Some(transaction_cache.as_ref()),
         )
         .await
@@ -13441,6 +13543,7 @@ mod tests {
             crate::GLOBAL_BRANCH_ID,
             generation,
             &request_keys,
+            &[],
             Some(transaction_cache.as_ref()),
         )
         .await

--- a/packages/lix/src/hot_state/tracked_head/hot.rs
+++ b/packages/lix/src/hot_state/tracked_head/hot.rs
@@ -4391,37 +4391,71 @@ async fn load_packed_current_base_exact_entries(
     if base_refs.is_empty() {
         return Ok((0..keys.len()).map(|_| None).collect());
     }
-    if shadow.len() == keys.len()
-        && let Some(newest_base) = base_refs.iter().map(|base_ref| base_ref.commit_id).max()
-    {
-        let unresolved = keys
-            .iter()
-            .enumerate()
-            .filter(|(index, _)| shadow[*index].is_none_or(|resolved| resolved < newest_base))
-            .map(|(index, key)| (index, *key))
-            .collect::<Vec<_>>();
-        if unresolved.is_empty() {
-            return Ok((0..keys.len()).map(|_| None).collect());
-        }
-        if unresolved.len() != keys.len() {
-            let unresolved_keys = unresolved.iter().map(|(_, key)| *key).collect::<Vec<_>>();
-            let loaded = Box::pin(load_packed_current_base_exact_entries(
-                store,
-                branch_id,
-                generation,
-                &unresolved_keys,
-                &[],
-                transaction_cache,
-            ))
-            .await?;
-            let mut output = (0..keys.len()).map(|_| None).collect::<Vec<_>>();
-            for ((index, _), entry) in unresolved.into_iter().zip(loaded) {
-                output[index] = entry;
+    let skipped = packed_current_base_unresolved_indices(keys, shadow, &base_refs);
+    let unresolved_keys;
+    let selected = match skipped.as_deref() {
+        Some(indices) => {
+            if indices.is_empty() {
+                return Ok((0..keys.len()).map(|_| None).collect());
             }
-            return Ok(output);
+            unresolved_keys = indices.iter().map(|&index| keys[index]).collect::<Vec<_>>();
+            unresolved_keys.as_slice()
         }
+        None => keys,
+    };
+    // The base loader is boxed rather than inlined: this wrapper sits deep in an
+    // already-tall async write stack, and holding the loader's state machine in
+    // this frame overflows libtest's 2 MiB worker stack.
+    let loaded = Box::pin(load_packed_current_base_exact_entries_from_refs(
+        store,
+        &base_refs,
+        selected,
+        transaction_cache,
+    ))
+    .await?;
+    let Some(indices) = skipped else {
+        return Ok(loaded);
+    };
+    let mut output = (0..keys.len()).map(|_| None).collect::<Vec<_>>();
+    for (index, entry) in indices.into_iter().zip(loaded) {
+        output[index] = entry;
     }
-    if let [base_ref] = base_refs.as_slice() {
+    Ok(output)
+}
+
+/// Indices of the keys the packed current base could still win, or `None` when
+/// nothing is known and every key must be read.
+fn packed_current_base_unresolved_indices(
+    keys: &[TrackedStateKeyRef<'_>],
+    shadow: PackedCurrentBaseShadow<'_>,
+    base_refs: &[PackedCurrentBaseRef],
+) -> Option<Vec<usize>> {
+    if shadow.len() != keys.len() {
+        return None;
+    }
+    let newest_base = base_refs.iter().map(|base_ref| base_ref.commit_id).max()?;
+    let unresolved = (0..keys.len())
+        .filter(|&index| shadow[index].is_none_or(|resolved| resolved < newest_base))
+        .collect::<Vec<_>>();
+    (unresolved.len() != keys.len()).then_some(unresolved)
+}
+
+async fn load_packed_current_base_exact_entries_from_refs(
+    store: &(impl StorageAdapterRead + ?Sized),
+    base_refs: &[PackedCurrentBaseRef],
+    keys: &[TrackedStateKeyRef<'_>],
+    transaction_cache: Option<&HotStateTransactionCache>,
+) -> Result<
+    Vec<
+        Option<(
+            crate::tracked_state::TrackedStateIndexValue,
+            crate::changelog::ChangeRecord,
+            Option<crate::tracked_state::TrackedStateBaseCoordinate>,
+        )>,
+    >,
+    LixError,
+> {
+    if let [base_ref] = base_refs {
         return Ok(
             crate::tracked_state::load_owned_commit_delta_entries_one_ordered_ref(
                 store,

--- a/packages/lix/src/sql2/exec/bound_public_write.rs
+++ b/packages/lix/src/sql2/exec/bound_public_write.rs
@@ -4046,6 +4046,9 @@ async fn scan_entity_conflict_candidates(
     spec: &EntitySurfaceSpec,
     insert_rows: &RawWriteBatch,
 ) -> Result<MaterializedHotStateBatch, LixError> {
+    #[cfg(feature = "storage-benches")]
+    let _phase =
+        crate::storage_bench::enter_crud_phase(crate::storage_bench::CRUD_PHASE_WRITE_READ);
     let mut branch_ids = std::collections::BTreeSet::new();
     let mut entity_pks = std::collections::BTreeSet::new();
     let mut file_ids = std::collections::BTreeSet::new();
@@ -4087,6 +4090,9 @@ async fn scan_entity_candidates(
     spec: &EntitySurfaceSpec,
     params: &[Value],
 ) -> Result<MaterializedHotStateBatch, LixError> {
+    #[cfg(feature = "storage-benches")]
+    let _phase =
+        crate::storage_bench::enter_crud_phase(crate::storage_bench::CRUD_PHASE_WRITE_READ);
     let branch_ids = scan_branch_ids(&plan.bound.branch_scope)?;
     let mut request = HotStateScanRequest {
         filter: HotStateFilter {
@@ -4115,6 +4121,9 @@ async fn scan_entity_candidates_for_pks(
     entity_pks: Vec<EntityPk>,
     metadata_only: bool,
 ) -> Result<MaterializedHotStateBatch, LixError> {
+    #[cfg(feature = "storage-benches")]
+    let _phase =
+        crate::storage_bench::enter_crud_phase(crate::storage_bench::CRUD_PHASE_WRITE_READ);
     ctx.scan_hot_state_batch(&HotStateScanRequest {
         filter: HotStateFilter {
             schema_keys: vec![spec.schema_key.clone()],

--- a/packages/lix/src/storage_bench.rs
+++ b/packages/lix/src/storage_bench.rs
@@ -1,4 +1,4 @@
-use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering};
 
 use bytes::Bytes;
 
@@ -3271,6 +3271,121 @@ where
         if !has_more {
             return entries;
         }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// E42 probe — commit-delta decode census, attributed by write-path phase.
+//
+// Answers, deterministically and in one rep: does a single-row UPDATE reach
+// through the packed commit-delta indirection to locate the row it is
+// updating, or does it read the hot row? The phase is a process-global
+// marker rather than a thread-local because the profile harness runs exactly
+// one statement at a time under `block_on`; guards nest and restore.
+// ---------------------------------------------------------------------------
+
+pub const CRUD_PHASE_OTHER: usize = 0;
+/// The write-side read: `scan_entity_candidates*` locating the target row.
+pub const CRUD_PHASE_WRITE_READ: usize = 1;
+/// `Transaction::commit_prepared` — publication of the new write set.
+pub const CRUD_PHASE_COMMIT: usize = 2;
+pub const CRUD_PHASE_COUNT: usize = 3;
+
+static CRUD_PHASE: AtomicUsize = AtomicUsize::new(CRUD_PHASE_OTHER);
+static DELTA_LEAF_DECODES: [AtomicU64; CRUD_PHASE_COUNT] =
+    [AtomicU64::new(0), AtomicU64::new(0), AtomicU64::new(0)];
+static DELTA_LEAF_DECODE_ROWS: [AtomicU64; CRUD_PHASE_COUNT] =
+    [AtomicU64::new(0), AtomicU64::new(0), AtomicU64::new(0)];
+static DELTA_LEAF_DECODE_BYTES: [AtomicU64; CRUD_PHASE_COUNT] =
+    [AtomicU64::new(0), AtomicU64::new(0), AtomicU64::new(0)];
+static DELTA_ZSTD_CALLS: [AtomicU64; CRUD_PHASE_COUNT] =
+    [AtomicU64::new(0), AtomicU64::new(0), AtomicU64::new(0)];
+static DELTA_ZSTD_IN_BYTES: [AtomicU64; CRUD_PHASE_COUNT] =
+    [AtomicU64::new(0), AtomicU64::new(0), AtomicU64::new(0)];
+static DELTA_ZSTD_OUT_BYTES: [AtomicU64; CRUD_PHASE_COUNT] =
+    [AtomicU64::new(0), AtomicU64::new(0), AtomicU64::new(0)];
+static DELTA_ORDERED_LOADS: [AtomicU64; CRUD_PHASE_COUNT] =
+    [AtomicU64::new(0), AtomicU64::new(0), AtomicU64::new(0)];
+static DELTA_ENCODES: [AtomicU64; CRUD_PHASE_COUNT] =
+    [AtomicU64::new(0), AtomicU64::new(0), AtomicU64::new(0)];
+
+/// Restores the enclosing phase when dropped.
+#[derive(Debug)]
+pub struct CrudPhaseGuard(usize);
+
+impl Drop for CrudPhaseGuard {
+    fn drop(&mut self) {
+        CRUD_PHASE.store(self.0, Ordering::Relaxed);
+    }
+}
+
+pub(crate) fn enter_crud_phase(phase: usize) -> CrudPhaseGuard {
+    CrudPhaseGuard(CRUD_PHASE.swap(phase, Ordering::Relaxed))
+}
+
+fn crud_phase() -> usize {
+    let phase = CRUD_PHASE.load(Ordering::Relaxed);
+    if phase < CRUD_PHASE_COUNT {
+        phase
+    } else {
+        CRUD_PHASE_OTHER
+    }
+}
+
+pub(crate) fn record_commit_delta_leaf_decode(rows: usize, segment_bytes: usize) {
+    let phase = crud_phase();
+    DELTA_LEAF_DECODES[phase].fetch_add(1, Ordering::Relaxed);
+    DELTA_LEAF_DECODE_ROWS[phase].fetch_add(rows as u64, Ordering::Relaxed);
+    DELTA_LEAF_DECODE_BYTES[phase].fetch_add(segment_bytes as u64, Ordering::Relaxed);
+}
+
+pub(crate) fn record_commit_delta_sidecar_zstd(compressed: usize, uncompressed: usize) {
+    let phase = crud_phase();
+    DELTA_ZSTD_CALLS[phase].fetch_add(1, Ordering::Relaxed);
+    DELTA_ZSTD_IN_BYTES[phase].fetch_add(compressed as u64, Ordering::Relaxed);
+    DELTA_ZSTD_OUT_BYTES[phase].fetch_add(uncompressed as u64, Ordering::Relaxed);
+}
+
+pub(crate) fn record_commit_delta_ordered_load(keys: usize) {
+    let phase = crud_phase();
+    DELTA_ORDERED_LOADS[phase].fetch_add(keys.max(1) as u64, Ordering::Relaxed);
+}
+
+pub(crate) fn record_commit_delta_encode() {
+    DELTA_ENCODES[crud_phase()].fetch_add(1, Ordering::Relaxed);
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct CommitDeltaPhaseCensus {
+    pub leaf_decodes: u64,
+    pub leaf_decode_rows: u64,
+    pub leaf_decode_bytes: u64,
+    pub zstd_calls: u64,
+    pub zstd_in_bytes: u64,
+    pub zstd_out_bytes: u64,
+    pub ordered_load_keys: u64,
+    pub encodes: u64,
+}
+
+/// Drains the census. Index with `CRUD_PHASE_*`.
+pub fn take_commit_delta_phase_census() -> [CommitDeltaPhaseCensus; CRUD_PHASE_COUNT] {
+    std::array::from_fn(|phase| CommitDeltaPhaseCensus {
+        leaf_decodes: DELTA_LEAF_DECODES[phase].swap(0, Ordering::Relaxed),
+        leaf_decode_rows: DELTA_LEAF_DECODE_ROWS[phase].swap(0, Ordering::Relaxed),
+        leaf_decode_bytes: DELTA_LEAF_DECODE_BYTES[phase].swap(0, Ordering::Relaxed),
+        zstd_calls: DELTA_ZSTD_CALLS[phase].swap(0, Ordering::Relaxed),
+        zstd_in_bytes: DELTA_ZSTD_IN_BYTES[phase].swap(0, Ordering::Relaxed),
+        zstd_out_bytes: DELTA_ZSTD_OUT_BYTES[phase].swap(0, Ordering::Relaxed),
+        ordered_load_keys: DELTA_ORDERED_LOADS[phase].swap(0, Ordering::Relaxed),
+        encodes: DELTA_ENCODES[phase].swap(0, Ordering::Relaxed),
+    })
+}
+
+pub fn crud_phase_name(phase: usize) -> &'static str {
+    match phase {
+        CRUD_PHASE_WRITE_READ => "write_read",
+        CRUD_PHASE_COMMIT => "commit_prepared",
+        _ => "other",
     }
 }
 

--- a/packages/lix/src/tracked_state/storage.rs
+++ b/packages/lix/src/tracked_state/storage.rs
@@ -8847,6 +8847,8 @@ async fn load_local_owned_commit_delta_entries_one_ordered(
     keys: &[TrackedStateKeyRef<'_>],
     point_cache: Option<&CommitDeltaPointReadCache>,
 ) -> Result<Vec<Option<LoadedCommitDeltaEntry>>, LixError> {
+    #[cfg(feature = "storage-benches")]
+    crate::storage_bench::record_commit_delta_ordered_load(keys.len());
     let cached_state = point_cache
         .map(|cache| cache.authority(commit_id))
         .transpose()?
@@ -11518,6 +11520,8 @@ fn encode_commit_delta_segment_layout(
     debug_assert_eq!(entries.len(), payloads.len());
     let leaf = encode_leaf_node_refs(entries);
     #[cfg(feature = "storage-benches")]
+    crate::storage_bench::record_commit_delta_encode();
+    #[cfg(feature = "storage-benches")]
     crate::storage_bench::record_commit_delta_leaf_layout(
         entries.len(),
         crate::tracked_state::codec::leaf_uses_direct_address_layout(&leaf),
@@ -11771,6 +11775,8 @@ fn decode_commit_delta_leaf(
             "tracked_state commit_delta segment does not match its manifest bounds",
         ));
     }
+    #[cfg(feature = "storage-benches")]
+    crate::storage_bench::record_commit_delta_leaf_decode(leaf.len(), bytes.len());
     Ok(leaf)
 }
 
@@ -11889,6 +11895,11 @@ fn decode_commit_delta_with_payloads<'a>(
                     "tracked_state compressed commit_delta sidecar length does not match its header",
                 ));
             }
+            #[cfg(feature = "storage-benches")]
+            crate::storage_bench::record_commit_delta_sidecar_zstd(
+                encoded_sidecar.len(),
+                decoded.len(),
+            );
             Cow::Owned(decoded)
         }
         _ => unreachable!("commit-delta sidecar encoding was classified above"),

--- a/packages/lix/src/transaction/context.rs
+++ b/packages/lix/src/transaction/context.rs
@@ -1702,6 +1702,9 @@ where
         runtime_functions: &FunctionContext,
         mut prepared_writes: PreparedWriteSet,
     ) -> Result<TransactionCommitOutcome, LixError> {
+        #[cfg(feature = "storage-benches")]
+        let _phase =
+            crate::storage_bench::enter_crud_phase(crate::storage_bench::CRUD_PHASE_COMMIT);
         let transaction = &mut self;
         let commit_boundary = transaction.commit_boundary.clone();
         transaction


### PR DESCRIPTION
## The single-row write read through the packed commit delta. It no longer does.

E38 decomposed `update_one_by_pk` and found **60.9 µs, 22% of the whole operation, in commit-delta
decode + zstd**. This PR answers *why a write consults the packed history plane at all* — with a
counter, not a timing — and removes it.

**`update_one_by_pk`: 289.8 µs → 182.0 µs (−37.2%), 254.4x → 159.8x SQLite.** First movement on
this lane in two rounds (E38 measured 249.1x → 246.9x, −0.9%, across 26 merged PRs).

### The measurement that answers it (deterministic counter, 1 rep)

This PR adds, under `storage-benches` only, a **commit-delta decode census attributed by write-path
phase**: a process-global phase marker set by RAII guards in `scan_entity_candidates*`
(*write_read*) and `Transaction::commit_prepared` (*commit_prepared*), with counters hooked into
`decode_commit_delta_leaf`, the commit-delta sidecar zstd branch,
`load_local_owned_commit_delta_entries_one_ordered`, and the segment encoder.

Measured on `origin/main` **plus this census only** (routing change not yet applied), RocksDB,
10 000 rows, 200 warm repeats, **per single-row UPDATE**:

| phase | ordered delta loads | leaf decodes | rows decoded | segment bytes | zstd calls | zstd in → out |
|---|---:|---:|---:|---:|---:|---:|
| write_read (locating the row) | **1** | **1** | **512** | 26 485 | **1** | 18 740 → **93 332 B** |
| commit_prepared (publication) | **1** | 4.06 | 565 | 29 826 | **1** | 18 740 → **93 332 B** |
| other | 0 | 0 | 0 | 0 | 0 | 0 |

Same lane, single-row **READ** — the control: **0 in every column, in every phase.**

> A single-row UPDATE decoded 512 packed commit-delta rows and zstd-inflated 93 KB **twice** — once
> to locate the row and once to publish it. A single-row READ of the same row decoded nothing.

The two decodes take **byte-identical input** (18 740 → 93 332 B in both phases) against the same
storage snapshot within one transaction: the same packed segment, decoded twice. A per-transaction
decoded-base cache would have made the second one free; this change makes **both** unnecessary.

The write was paying history-structure cost to answer a current-state question. The read was not.

### The cause: a gate that was specified in a comment and never implemented

`packages/lix/src/hot_state/tracked_head/hot.rs`, immediately above the offending call:

> *"Decode the matching segment rows **only when the ordinary point-read index misses**, then
> preserve the original request alignment."*

The code did not do that. It loaded the packed current base for **every** requested key
unconditionally, then merged the planes and kept the packed candidate only when it was *strictly
newer* than the HOT row already resolved. In the steady state of a single-row update the HOT row
always wins — the packed base is the seed commit, the HOT row is the previous update — so the
segment fetch, the zstd inflate and the 512-row decode happened and were then discarded. The same
shape repeated in the publication path (`stage_current_state_with_working_diff_inner`): every delta
without a caller-certified durable predecessor got a packed lookup regardless of whether the HOT
overlay had already answered.

This is the third instance this round of *"the fast path exists and nothing reaches it"* (#1372
point reads, #1382 path-index cache).

### What changed

Nothing physical. This is **routing inside the write path's execution only**: no key encoding, no
value layout, no storage space, no versioned identifier, no adapter API. A store written by either
build is byte-compatible with the other, and **no open-time migration is required**.

`load_packed_current_base_exact_entries` now takes a per-key `shadow: &[Option<CommitId>]` — the
commit id already resolved from a plane that shadows the packed base. A packed current base
published at commit `C` can only serve rows whose owning commit is an ancestor of `C`, so the newest
base ref is an upper bound on every `commit_id` the base can produce. A key whose shadow is at least
that bound cannot change its winner **under the existing comparison**, so its segment is never
fetched. Keys with no shadow, or a shadow older than the newest base ref, are loaded exactly as
before, and the base-ref control read itself is unchanged.

The gate short-circuits a comparison whose outcome is already determined. It introduces no new
ordering assumption — it reuses the commit-id total order the plane merge already uses to pick
winners. A resolved row that carries no commit id disables the skip for that key (conservative), and
a partially-skipped batch re-enters the loader with only the keys that still need it, preserving
strict key order.

Three call sites supply the shadow: the exact-key live batch, the generic HOT scan's exact-key
branch, and the publication's predecessor lookup.

**Nothing was removed** — no space, no writer, no code path. The packed current base remains the
authority for every identity that has no shadowing HOT row.

### Census after the change (re-confirmed at `ab4277d9c`)

| phase | ordered delta loads | leaf decodes | rows decoded | segment bytes | zstd calls | zstd out |
|---|---:|---:|---:|---:|---:|---:|
| write_read | **0** (was 1) | **0** (was 1) | **0** (was 512) | 0 | **0** (was 1) | **0** (was 93 332 B) |
| commit_prepared | **0** (was 1) | 3.06 (was 4.06) | 53 (was 565) | 3 341 (was 29 826) | **0** (was 1) | **0** (was 93 332 B) |

186 KB of zstd inflate and 1 024 decoded packed rows removed per single-row update. What remains in
`commit_prepared` is 3 small leaf decodes totalling 53 rows / 3.3 KB — the newly staged delta, not
the packed base.

---

## A/B

**Machine:** ryzen-9950x-IV (32c / 186 GB), RocksDB, `TMPDIR` on the ext4 root volume, load < 1.0 at
start.
**Base SHA:** `ab4277d9c` (`origin/main`, unmodified), built in `~/claude5/base` → `~/claude5/target-base`.
**Candidate:** this branch rebased onto `ab4277d9c`.

**Bench command** (both arms, one arm per invocation, rotating order):

```
LIX_TRACKED_STATE_CRUD_PROFILE=1 \
LIX_TRACKED_STATE_CRUD_PROFILE_LAYER=sql_session \
LIX_TRACKED_STATE_CRUD_PROFILE_OP=update_one \
LIX_TRACKED_STATE_CRUD_PROFILE_STORAGE=rocksdb \
LIX_TRACKED_STATE_CRUD_PROFILE_ROW_COUNT=10000 \
LIX_TRACKED_STATE_CRUD_PROFILE_HOT_REPEATS=5000 \
<tracked_state_crud bench binary> --bench
```

built with `cargo bench -p lix_benchmarks --features storage-benches,slatedb --bench tracked_state_crud --no-run`.

### `update_one_by_pk` — the claim

| rep | base (µs) | cand (µs) |
|---|---:|---:|
| 1 | 297.086 | 177.888 |
| 2 | 289.282 | 178.060 |
| 3 | 285.319 | 181.085 |
| 4 | 289.839 | 182.479 |
| 5 | 285.957 | 180.910 |
| 6 | 288.982 | 182.663 |
| 7 | 294.818 | 186.537 |
| 8 | 290.281 | 182.049 |
| 9 | 290.323 | 188.180 |
| **median** | **289.839** | **182.049** |
| p95 | 297.086 | 188.180 |
| range | 285.319-297.086 | 177.888-188.180 |

**-37.2%.** The arms' raw ranges do not overlap at all: base min 285.3 us vs cand max 188.2 us.

Reproduced three times, across two base commits and three full rebuilds of both arms:
**-37.7%** (`b77a5308f`), **-37.1%** (`ab4277d9c`, before the stack fix), **-37.2%** (`ab4277d9c`,
final). Every run had disjoint ranges. Three independent rebuilds agreeing to 0.6 percentage points
is a stronger control than an identical-code null run would have been.

### Guard / control - `read_one_by_pk`, same interleaved run, 5 reps per arm

| rep | base (µs) | cand (µs) |
|---|---:|---:|
| 1 | 20.179 | 20.791 |
| 2 | 20.249 | 20.468 |
| 3 | 20.348 | 20.264 |
| 4 | 20.359 | 20.522 |
| 5 | 19.820 | 20.537 |
| **median** | **20.249** | **20.522** |

**+1.35%.** The census proves this lane decodes zero commit-delta segments on **both** arms, so it
can only move by noise and codegen. Its within-arm spread is the resolution floor for this bench:
**2.66% (base), 2.57% (cand)**, so +1.35% is inside the floor. The write result is 14x that floor
with disjoint ranges.

### SQLite ratio, same host

Standalone SQLite arm byte-identical to E38's (`main.rs` md5 `350801db23f9bdd94fe78fb5d5437a7f`,
SQLite 3.46.0 bundled amalgamation, WAL, `synchronous=NORMAL`, 4 KiB pages, same
`pnpm-lock.fixture.json`, 10 000 rows, same key). Three independent invocations:
1 146.3 / 1 137.8 / 1 139.1 ns → median **1.139 µs**, 0.7% spread — its own null control.

| | lix | SQLite | ratio |
|---|---:|---:|---:|
| `update_one_by_pk`, base `ab4277d9c` | 289.8 µs | 1.139 µs | **254.4x** |
| `update_one_by_pk`, candidate | 182.0 µs | 1.139 µs | **159.8x** |

### Metrics that regressed

None measured. The change only ever *removes* a storage read — a key is skipped exactly when the
packed candidate could not have won. Physical bytes, staged puts and the write set are untouched (no
encoding or layout change), so byte metrics cannot move; that is why no byte guard was run.

### Scope of the win

The removed cost is bounded by the commit-delta segment cap (512 rows), so this is a large constant,
not an asymptotic term, and it is claimed as such. The remaining ~182 µs is the commit floor E38
measured, whose atomic single-write-set publication is a deliberate design property and was not
traded away.

---

## Layout invariants

1. **Single authority.** No new authority. The packed current base remains the sole authority for
   identities without a shadowing HOT row; the gate proves, from the base's *own* published ref
   list, that reading it cannot change the answer for the keys it skips. Nothing is relocated or
   duplicated.
2. **Commit canonicality.** Untouched. No commit record, parent link or state root is read or
   written differently.
3. **Derived views are caches.** Unchanged. HOT rows are not promoted to an authority — the skip is
   justified by the packed base's published ref set, not by trusting the HOT row alone, and a HOT
   row that cannot prove it is newer disables the skip.
4. **Atomic publication.** Untouched. The write set, its contents and its single-shot publication
   are byte-identical; only a read that preceded it is elided.
5. **GC from refs.** Untouched. No retention or reachability metadata is read or written.
6. **SQL reads canonical records.** Unchanged. The SQL write surface reads the same planes through
   the same merge; one plane is skipped only when its result is provably discarded.

**Adapter API:** unchanged — nothing added, changed or removed in `StorageAdapter`, so both shipping
adapters and the conformance suite are unaffected.

**Format / compatibility:** no format change. No key encoding, value layout, storage space or
versioned identifier was touched, so no migration is needed in either direction.

---

## Gate

Run on ryzen-9950x-IV in `~/claude5/cand`, scope re-derived from
`origin/main:.github/workflows/ci.yml`:

```
cargo check --workspace --all-targets --all-features
cargo clippy --profile test --workspace --all-targets --all-features -- -D warnings
cargo test --profile test --workspace --exclude lix_benchmarks --all-features --no-fail-fast
cargo test --profile test -p lix_benchmarks --features storage-benches,slatedb,root-replay-trace --no-fail-fast
cargo check -p lix --no-default-features
cargo check -p lix_js_sdk --target wasm32-unknown-unknown
```

**All six commands exit 0.** `git rev-parse HEAD` inside the gate run:
`a8730a8220495d6016fc01b346f89f52ef9d7c7f`; `git status --porcelain` inside the gate run: empty.

```
##### exit=0 : cargo check --workspace --all-targets --all-features #####
##### exit=0 : cargo clippy --profile test --workspace --all-targets --all-features -- -D warnings #####
##### exit=0 : cargo test --profile test --workspace --exclude lix_benchmarks --all-features --no-fail-fast #####
##### exit=0 : cargo test --profile test -p lix_benchmarks --features storage-benches,slatedb,root-replay-trace --no-fail-fast #####
##### exit=0 : cargo check -p lix --no-default-features #####
##### exit=0 : cargo check -p lix_js_sdk --target wasm32-unknown-unknown #####
```

**3533 tests passed, 0 failed.** The full log was grepped for `failures:`, `panicked`, `overflowed`,
`test result: FAILED` and `^error` — no hits.

### One real regression was caught by this gate and fixed

The first version of the gate added locals to `load_packed_current_base_exact_entries`, whose future
is inlined deep in an already-tall async write stack. That overflowed libtest's 2 MiB worker stack in
`cas_gc_history_retention::slatedb_history_blob_survives_until_final_root_release` — a test that
**passes on base**, so it was this change's fault, not a flake. The fix splits the loader body into
`load_packed_current_base_exact_entries_from_refs` and boxes it, moving the heavy state machine to
the heap; the gating frame is now smaller than it was before this change. Verified by re-running that
target green on the candidate and confirming it green on base.

`rustfmt --check` is clean on every line this branch adds (the tree is fmt-dirty repo-wide on
pristine `main`, so only the added lines were checked and fixed).

## Note on `packages/e2e`

The harness print that emits the census (~49 additive lines in
`packages/e2e/benches/tracked_state_crud/main.rs`, behind
`LIX_TRACKED_STATE_CRUD_PROFILE_DELTA_CENSUS=1`) is **deliberately not in this PR** — `packages/e2e`
is off-limits while a fold is in flight. The counters it prints are `pub` in
`lix::storage_bench` (`take_commit_delta_phase_census`, `crud_phase_name`) and ready to wire once
that lands. The engine code measured above is byte-identical to the engine code in this PR; the
harness print is inert without the env var.
