### PR TITLE
probe(hot-state): quantify hot row tombstone ageing, and show nothing reclaims it

### DIFF
--- a/packages/lix/src/hot_row_tombstone_probe.rs
+++ b/packages/lix/src/hot_row_tombstone_probe.rs
@@ -19,7 +19,8 @@ use crate::session::SessionContext;
 use crate::storage::ProjectedValue;
 use crate::storage_adapter::{
     Memory, SharedStorageAdapterRead, StorageAdapter, StorageAdapterRead,
-    StorageBeginScanOptions, StoragePrefix, StorageReadOptions, StorageWriteOptions,
+    StorageBeginScanOptions, StoragePrefix, StorageReadOptions, StorageSpace,
+    StorageWriteOptions,
 };
 
 fn sizes_from_env(var: &str, default: &[usize]) -> Vec<usize> {
@@ -77,7 +78,10 @@ impl RowCensus {
 /// this probe out of the private value codec.
 const HEAD_VALUE_DELETED_BIT: u8 = 0b0000_0001;
 
-async fn count_space(read: &(impl StorageAdapterRead + ?Sized), space: crate::storage::StorageSpace) -> Vec<(bytes::Bytes, bytes::Bytes)> {
+async fn space_values(
+    read: &(impl StorageAdapterRead + ?Sized),
+    space: StorageSpace,
+) -> Vec<bytes::Bytes> {
     let range = StoragePrefix {
         bytes: bytes::Bytes::new(),
     }
@@ -92,12 +96,9 @@ async fn count_space(read: &(impl StorageAdapterRead + ?Sized), space: crate::st
         .await
         .expect("collect serving entries")
         .into_iter()
-        .map(|entry| {
-            let value = match entry.value {
-                ProjectedValue::FullValue(bytes) => bytes,
-                ProjectedValue::KeyOnly => bytes::Bytes::new(),
-            };
-            (entry.key, value)
+        .map(|entry| match entry.value {
+            ProjectedValue::FullValue(bytes) => bytes,
+            ProjectedValue::KeyOnly => bytes::Bytes::new(),
         })
         .collect()
 }
@@ -108,12 +109,12 @@ async fn row_census(storage: &Memory) -> RowCensus {
         .begin_read(StorageReadOptions::default())
         .await
         .expect("read the hot row plane");
-    let rows = count_space(&read, crate::hot_state::ROW_SPACE).await;
+    let rows = space_values(&read, crate::hot_state::ROW_SPACE).await;
     let tombstones = rows
         .iter()
-        .filter(|(_, value)| value.len() > 1 && value[1] & HEAD_VALUE_DELETED_BIT != 0)
+        .filter(|value| value.len() > 1 && value[1] & HEAD_VALUE_DELETED_BIT != 0)
         .count();
-    let packed_bases = count_space(&read, crate::hot_state::PACKED_CURRENT_BASE_SPACE)
+    let packed_bases = space_values(&read, crate::hot_state::PACKED_CURRENT_BASE_SPACE)
         .await
         .len();
     RowCensus {
@@ -121,6 +122,26 @@ async fn row_census(storage: &Memory) -> RowCensus {
         tombstones,
         packed_bases,
     }
+}
+
+/// Plans and commits a repository GC sweep against the same physical store the
+/// session writes through.
+async fn run_repository_gc(storage: &Memory) {
+    let adapter = StorageAdapter::new(storage.clone());
+    let read = SharedStorageAdapterRead::new(
+        adapter
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("gc read"),
+    );
+    let mut gc_writes = adapter.new_write_set();
+    crate::gc::stage_repository_gc(read, &mut gc_writes)
+        .await
+        .expect("repository gc should plan");
+    adapter
+        .commit_write_set(gc_writes, StorageWriteOptions::default())
+        .await
+        .expect("gc write set should commit");
 }
 
 fn probe_schema(key: &str) -> serde_json::Value {
@@ -324,22 +345,7 @@ async fn hot_row_tombstone_reclamation_events() {
     report("after_checkpoint", census, scan);
 
     // (c) repository GC.
-    let read = SharedStorageAdapterRead::new(
-        session
-            .storage
-            .begin_read(StorageReadOptions::default())
-            .await
-            .expect("gc read"),
-    );
-    let mut gc_writes = session.storage.new_write_set();
-    crate::gc::stage_repository_gc(read, &mut gc_writes)
-        .await
-        .expect("repository gc should plan");
-    session
-        .storage
-        .commit_write_set(gc_writes, StorageWriteOptions::default())
-        .await
-        .expect("gc write set should commit");
+    run_repository_gc(&storage).await;
     let census = row_census(&storage).await;
     let scan = timed_scan(&session, &scan_sql("evtrow"), 1, reps).await;
     report("after_gc", census, scan);
@@ -357,22 +363,7 @@ async fn hot_row_tombstone_reclamation_events() {
         .create_checkpoint()
         .await
         .expect("second checkpoint should publish");
-    let read = SharedStorageAdapterRead::new(
-        session
-            .storage
-            .begin_read(StorageReadOptions::default())
-            .await
-            .expect("gc read"),
-    );
-    let mut gc_writes = session.storage.new_write_set();
-    crate::gc::stage_repository_gc(read, &mut gc_writes)
-        .await
-        .expect("second repository gc should plan");
-    session
-        .storage
-        .commit_write_set(gc_writes, StorageWriteOptions::default())
-        .await
-        .expect("second gc write set should commit");
+    run_repository_gc(&storage).await;
     let census = row_census(&storage).await;
     let scan = timed_scan(&session, &scan_sql("evtrow"), 1, reps).await;
     report("after_ckpt2_gc", census, scan);

--- a/packages/lix/src/hot_row_tombstone_probe.rs
+++ b/packages/lix/src/hot_row_tombstone_probe.rs
@@ -1,0 +1,379 @@
+//! Tombstone accumulation in the hot row serving view.
+//!
+//! Not a product module. `ROW_SPACE` is a derived, generation-keyed serving
+//! view. A delete publishes a *tombstone* row there rather than removing the
+//! key, because the hot row plane is a sparse overlay over packed/root
+//! current-state bases and the tombstone is what shadows the base row.
+//!
+//! The question these probes answer is what happens to those tombstones over a
+//! branch's life: how many accumulate per delete, what they cost a collection
+//! scan that returns an unchanged answer, and whether anything in the engine
+//! (ordinary commits, checkpoints, generation retirement, repository GC) ever
+//! removes them.
+
+use serde_json::json;
+use std::time::{Duration, Instant};
+
+use crate::engine::Engine;
+use crate::session::SessionContext;
+use crate::storage::ProjectedValue;
+use crate::storage_adapter::{
+    Memory, SharedStorageAdapterRead, StorageAdapter, StorageAdapterRead,
+    StorageBeginScanOptions, StoragePrefix, StorageReadOptions, StorageWriteOptions,
+};
+
+fn sizes_from_env(var: &str, default: &[usize]) -> Vec<usize> {
+    match std::env::var(var) {
+        Ok(raw) => raw
+            .split(',')
+            .filter(|part| !part.trim().is_empty())
+            .map(|part| part.trim().parse::<usize>().expect("size must parse"))
+            .collect(),
+        Err(_) => default.to_vec(),
+    }
+}
+
+fn reps_from_env(default: usize) -> usize {
+    std::env::var("LIX_TOMBSTONE_REPS")
+        .ok()
+        .and_then(|raw| raw.parse::<usize>().ok())
+        .unwrap_or(default)
+}
+
+async fn open_session() -> (Memory, SessionContext<Memory>) {
+    let storage = Memory::new();
+    Engine::initialize(storage.clone())
+        .await
+        .expect("engine should initialize");
+    let engine = Engine::new(storage.clone())
+        .await
+        .expect("engine should open");
+    let session = engine
+        .open_workspace_session()
+        .await
+        .expect("session should open");
+    (storage, session)
+}
+
+/// Census of the hot row serving view.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+struct RowCensus {
+    /// Every key in `ROW_SPACE`, across every branch and generation.
+    entries: usize,
+    /// Entries whose fixed header carries the deleted flag.
+    tombstones: usize,
+    /// Records in the packed current-state base plane.
+    packed_bases: usize,
+}
+
+impl RowCensus {
+    fn live(self) -> usize {
+        self.entries - self.tombstones
+    }
+}
+
+/// `HEAD_VALUE_DELETED` is bit 0 of the flags byte at offset 1 of the fixed
+/// row header (`hot_state/tracked_head.rs`). Reading the byte directly keeps
+/// this probe out of the private value codec.
+const HEAD_VALUE_DELETED_BIT: u8 = 0b0000_0001;
+
+async fn count_space(read: &(impl StorageAdapterRead + ?Sized), space: crate::storage::StorageSpace) -> Vec<(bytes::Bytes, bytes::Bytes)> {
+    let range = StoragePrefix {
+        bytes: bytes::Bytes::new(),
+    }
+    .to_range()
+    .expect("valid empty prefix");
+    let mut cursor = read
+        .begin_scan(space, range, StorageBeginScanOptions::default())
+        .await
+        .expect("scan the serving space");
+    cursor
+        .collect_all()
+        .await
+        .expect("collect serving entries")
+        .into_iter()
+        .map(|entry| {
+            let value = match entry.value {
+                ProjectedValue::FullValue(bytes) => bytes,
+                ProjectedValue::KeyOnly => bytes::Bytes::new(),
+            };
+            (entry.key, value)
+        })
+        .collect()
+}
+
+async fn row_census(storage: &Memory) -> RowCensus {
+    let adapter = StorageAdapter::new(storage.clone());
+    let read = adapter
+        .begin_read(StorageReadOptions::default())
+        .await
+        .expect("read the hot row plane");
+    let rows = count_space(&read, crate::hot_state::ROW_SPACE).await;
+    let tombstones = rows
+        .iter()
+        .filter(|(_, value)| value.len() > 1 && value[1] & HEAD_VALUE_DELETED_BIT != 0)
+        .count();
+    let packed_bases = count_space(&read, crate::hot_state::PACKED_CURRENT_BASE_SPACE)
+        .await
+        .len();
+    RowCensus {
+        entries: rows.len(),
+        tombstones,
+        packed_bases,
+    }
+}
+
+fn probe_schema(key: &str) -> serde_json::Value {
+    json!({
+        "x-lix-key": key,
+        "x-lix-primary-key": ["/id"],
+        "type": "object",
+        "properties": {
+            "id": { "type": "string" },
+            "locale": { "type": "string" }
+        },
+        "required": ["id", "locale"],
+        "additionalProperties": false
+    })
+}
+
+async fn register(session: &SessionContext<Memory>, schema: serde_json::Value) {
+    session
+        .execute(
+            "INSERT INTO lix_registered_schema (value) VALUES (lix_json($1))",
+            &[crate::Value::Text(schema.to_string())],
+        )
+        .await
+        .expect("schema should register");
+}
+
+const CHUNK: usize = 250;
+
+/// Row 0 carries `locale = 'keep'`; every other row carries `'drop'`.
+async fn insert_rows(session: &SessionContext<Memory>, table: &str, count: usize) {
+    let mut index = 0;
+    while index < count {
+        let end = (index + CHUNK).min(count);
+        let values = (index..end)
+            .map(|i| {
+                let locale = if i == 0 { "keep" } else { "drop" };
+                format!("('row-{i}', '{locale}')")
+            })
+            .collect::<Vec<_>>()
+            .join(",");
+        session
+            .execute(
+                &format!("INSERT INTO {table} (id, locale) VALUES {values}"),
+                &[],
+            )
+            .await
+            .expect("rows should insert");
+        index = end;
+    }
+}
+
+/// Deletes `row-1 .. row-{count-1}`, leaving exactly one live row.
+async fn delete_all_but_first(session: &SessionContext<Memory>, table: &str, count: usize) {
+    let mut index = 1;
+    while index < count {
+        let end = (index + CHUNK).min(count);
+        let ids = (index..end)
+            .map(|i| format!("'row-{i}'"))
+            .collect::<Vec<_>>()
+            .join(",");
+        session
+            .execute(&format!("DELETE FROM {table} WHERE id IN ({ids})"), &[])
+            .await
+            .expect("bulk delete should run");
+        index = end;
+    }
+}
+
+async fn timed_scan(
+    session: &SessionContext<Memory>,
+    sql: &str,
+    expect_rows: usize,
+    reps: usize,
+) -> Duration {
+    for _ in 0..2 {
+        let rows = session.execute(sql, &[]).await.expect("warmup should run");
+        assert_eq!(rows.len(), expect_rows, "warmup returned the wrong count");
+    }
+    let mut samples = Vec::new();
+    for _ in 0..reps {
+        let start = Instant::now();
+        let rows = session.execute(sql, &[]).await.expect("scan should run");
+        let elapsed = start.elapsed();
+        assert_eq!(rows.len(), expect_rows, "scan returned the wrong row count");
+        samples.push(elapsed);
+    }
+    samples.sort();
+    samples[samples.len() / 2]
+}
+
+fn scan_sql(table: &str) -> String {
+    // Equality on a column the schema neither keys nor declares, so the engine
+    // keeps its ordinary collection scan instead of any point or index route.
+    format!("SELECT id FROM {table} WHERE locale = 'keep'")
+}
+
+/// PHASE 1 — the rate.
+///
+/// `churn` inserts N rows and deletes N-1, so the live collection is one row
+/// at every size and the answer is one row at every size. `fresh` inserts the
+/// single surviving row and nothing else: same live state, same answer, no
+/// tombstones. The difference between the two columns is what the tombstones
+/// cost, and the census says how many there are per delete.
+#[tokio::test]
+#[ignore = "measurement probe, not a gate"]
+async fn hot_row_tombstone_accumulation_and_scan_cost() {
+    let sizes = sizes_from_env("LIX_TOMBSTONE_SIZES", &[100, 1_000, 10_000]);
+    let reps = reps_from_env(5);
+    println!(
+        "phase1 | arm,n,deletes,row_entries,tombstones,live_entries,packed_bases,answer_rows,scan_us"
+    );
+    for n in sizes {
+        {
+            let (storage, session) = open_session().await;
+            register(&session, probe_schema("churnrow")).await;
+            insert_rows(&session, "churnrow", n).await;
+            delete_all_but_first(&session, "churnrow", n).await;
+            let census = row_census(&storage).await;
+            let scan = timed_scan(&session, &scan_sql("churnrow"), 1, reps).await;
+            println!(
+                "churn,{n},{},{},{},{},{},1,{}",
+                n - 1,
+                census.entries,
+                census.tombstones,
+                census.live(),
+                census.packed_bases,
+                scan.as_micros()
+            );
+        }
+        {
+            let (storage, session) = open_session().await;
+            register(&session, probe_schema("freshrow")).await;
+            insert_rows(&session, "freshrow", 1).await;
+            let census = row_census(&storage).await;
+            let scan = timed_scan(&session, &scan_sql("freshrow"), 1, reps).await;
+            println!(
+                "fresh,{n},0,{},{},{},{},1,{}",
+                census.entries,
+                census.tombstones,
+                census.live(),
+                census.packed_bases,
+                scan.as_micros()
+            );
+        }
+    }
+}
+
+/// PHASE 2 — what, if anything, reclaims a tombstone.
+///
+/// One churned collection, then each candidate reclamation event in turn, with
+/// a census after each. Every census also re-runs the scan so a reclamation
+/// that fires shows up as both a lower count and a cheaper scan.
+#[tokio::test]
+#[ignore = "measurement probe, not a gate"]
+async fn hot_row_tombstone_reclamation_events() {
+    let n = sizes_from_env("LIX_TOMBSTONE_SIZES", &[1_000])[0];
+    let reps = reps_from_env(5);
+    let (storage, session) = open_session().await;
+    register(&session, probe_schema("evtrow")).await;
+    register(&session, probe_schema("otherrow")).await;
+    insert_rows(&session, "evtrow", n).await;
+    delete_all_but_first(&session, "evtrow", n).await;
+
+    println!("phase2 | event,row_entries,tombstones,live_entries,packed_bases,scan_us");
+    let mut report = |label: &str, census: RowCensus, scan: Duration| {
+        println!(
+            "{label},{},{},{},{},{}",
+            census.entries,
+            census.tombstones,
+            census.live(),
+            census.packed_bases,
+            scan.as_micros()
+        );
+    };
+
+    let census = row_census(&storage).await;
+    let scan = timed_scan(&session, &scan_sql("evtrow"), 1, reps).await;
+    report("after_churn", census, scan);
+
+    // (a) ordinary commits inside the same generation, on an unrelated table.
+    for index in 0..20 {
+        session
+            .execute(
+                "INSERT INTO otherrow (id, locale) VALUES ($1, 'x')",
+                &[crate::Value::Text(format!("o-{index}"))],
+            )
+            .await
+            .expect("unrelated insert should commit");
+    }
+    let census = row_census(&storage).await;
+    let scan = timed_scan(&session, &scan_sql("evtrow"), 1, reps).await;
+    report("after_20_commits", census, scan);
+
+    // (b) checkpoint.
+    session
+        .create_checkpoint()
+        .await
+        .expect("checkpoint should publish");
+    let census = row_census(&storage).await;
+    let scan = timed_scan(&session, &scan_sql("evtrow"), 1, reps).await;
+    report("after_checkpoint", census, scan);
+
+    // (c) repository GC.
+    let read = SharedStorageAdapterRead::new(
+        session
+            .storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("gc read"),
+    );
+    let mut gc_writes = session.storage.new_write_set();
+    crate::gc::stage_repository_gc(read, &mut gc_writes)
+        .await
+        .expect("repository gc should plan");
+    session
+        .storage
+        .commit_write_set(gc_writes, StorageWriteOptions::default())
+        .await
+        .expect("gc write set should commit");
+    let census = row_census(&storage).await;
+    let scan = timed_scan(&session, &scan_sql("evtrow"), 1, reps).await;
+    report("after_gc", census, scan);
+
+    // (d) a second checkpoint plus GC, in case the first checkpoint's debt had
+    //     not yet come due.
+    session
+        .execute(
+            "INSERT INTO otherrow (id, locale) VALUES ('post-ckpt', 'x')",
+            &[],
+        )
+        .await
+        .expect("post-checkpoint insert should commit");
+    session
+        .create_checkpoint()
+        .await
+        .expect("second checkpoint should publish");
+    let read = SharedStorageAdapterRead::new(
+        session
+            .storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("gc read"),
+    );
+    let mut gc_writes = session.storage.new_write_set();
+    crate::gc::stage_repository_gc(read, &mut gc_writes)
+        .await
+        .expect("second repository gc should plan");
+    session
+        .storage
+        .commit_write_set(gc_writes, StorageWriteOptions::default())
+        .await
+        .expect("second gc write set should commit");
+    let census = row_census(&storage).await;
+    let scan = timed_scan(&session, &scan_sql("evtrow"), 1, reps).await;
+    report("after_ckpt2_gc", census, scan);
+}

--- a/packages/lix/src/hot_row_tombstone_probe.rs
+++ b/packages/lix/src/hot_row_tombstone_probe.rs
@@ -65,6 +65,8 @@ struct RowCensus {
     tombstones: usize,
     /// Records in the packed current-state base plane.
     packed_bases: usize,
+    /// Records in the sparse-generation root base plane.
+    root_bases: usize,
 }
 
 impl RowCensus {
@@ -117,10 +119,14 @@ async fn row_census(storage: &Memory) -> RowCensus {
     let packed_bases = space_values(&read, crate::hot_state::PACKED_CURRENT_BASE_SPACE)
         .await
         .len();
+    let root_bases = space_values(&read, crate::hot_state::ROOT_CURRENT_BASE_SPACE)
+        .await
+        .len();
     RowCensus {
         entries: rows.len(),
         tombstones,
         packed_bases,
+        root_bases,
     }
 }
 
@@ -251,7 +257,7 @@ async fn hot_row_tombstone_accumulation_and_scan_cost() {
     let sizes = sizes_from_env("LIX_TOMBSTONE_SIZES", &[100, 1_000, 10_000]);
     let reps = reps_from_env(5);
     println!(
-        "phase1 | arm,n,deletes,row_entries,tombstones,live_entries,packed_bases,answer_rows,scan_us"
+        "phase1 | arm,n,deletes,row_entries,tombstones,live_entries,packed_bases,root_bases,answer_rows,scan_us"
     );
     for n in sizes {
         {
@@ -262,12 +268,13 @@ async fn hot_row_tombstone_accumulation_and_scan_cost() {
             let census = row_census(&storage).await;
             let scan = timed_scan(&session, &scan_sql("churnrow"), 1, reps).await;
             println!(
-                "churn,{n},{},{},{},{},{},1,{}",
+                "churn,{n},{},{},{},{},{},{},1,{}",
                 n - 1,
                 census.entries,
                 census.tombstones,
                 census.live(),
                 census.packed_bases,
+                census.root_bases,
                 scan.as_micros()
             );
         }
@@ -278,11 +285,12 @@ async fn hot_row_tombstone_accumulation_and_scan_cost() {
             let census = row_census(&storage).await;
             let scan = timed_scan(&session, &scan_sql("freshrow"), 1, reps).await;
             println!(
-                "fresh,{n},0,{},{},{},{},1,{}",
+                "fresh,{n},0,{},{},{},{},{},1,{}",
                 census.entries,
                 census.tombstones,
                 census.live(),
                 census.packed_bases,
+                census.root_bases,
                 scan.as_micros()
             );
         }
@@ -305,14 +313,15 @@ async fn hot_row_tombstone_reclamation_events() {
     insert_rows(&session, "evtrow", n).await;
     delete_all_but_first(&session, "evtrow", n).await;
 
-    println!("phase2 | event,row_entries,tombstones,live_entries,packed_bases,scan_us");
-    let mut report = |label: &str, census: RowCensus, scan: Duration| {
+    println!("phase2 | event,row_entries,tombstones,live_entries,packed_bases,root_bases,scan_us");
+    let report = |label: &str, census: RowCensus, scan: Duration| {
         println!(
-            "{label},{},{},{},{},{}",
+            "{label},{},{},{},{},{},{}",
             census.entries,
             census.tombstones,
             census.live(),
             census.packed_bases,
+            census.root_bases,
             scan.as_micros()
         );
     };
@@ -367,4 +376,89 @@ async fn hot_row_tombstone_reclamation_events() {
     let census = row_census(&storage).await;
     let scan = timed_scan(&session, &scan_sql("evtrow"), 1, reps).await;
     report("after_ckpt2_gc", census, scan);
+}
+
+/// PHASE 3 — generation rotation.
+///
+/// The claim under test is that a branch lifecycle publication mints a fresh
+/// serving generation and *re-encodes* the retired generation's tombstones into
+/// it, so the retirement sweep reclaims nothing on net. The census is taken on
+/// the whole `ROW_SPACE`, across every branch and generation, so a carry-forward
+/// shows up as a count that does not fall.
+#[tokio::test]
+#[ignore = "measurement probe, not a gate"]
+async fn hot_row_tombstone_generation_rotation() {
+    let n = sizes_from_env("LIX_TOMBSTONE_SIZES", &[1_000])[0];
+    let reps = reps_from_env(5);
+    let (storage, session) = open_session().await;
+    register(&session, probe_schema("rotrow")).await;
+    insert_rows(&session, "rotrow", n).await;
+    delete_all_but_first(&session, "rotrow", n).await;
+
+    println!("phase3 | event,row_entries,tombstones,live_entries,packed_bases,root_bases,scan_us");
+    let report = |label: &str, census: RowCensus, scan: Duration| {
+        println!(
+            "{label},{},{},{},{},{},{}",
+            census.entries,
+            census.tombstones,
+            census.live(),
+            census.packed_bases,
+            census.root_bases,
+            scan.as_micros()
+        );
+    };
+
+    let main_branch_id = session
+        .active_branch_id()
+        .await
+        .expect("active branch should resolve");
+    let census = row_census(&storage).await;
+    let scan = timed_scan(&session, &scan_sql("rotrow"), 1, reps).await;
+    report("after_churn", census, scan);
+
+    let branch = session
+        .create_branch(crate::CreateBranchOptions {
+            id: None,
+            name: "e45-rotation".to_string(),
+            from_commit_id: None,
+        })
+        .await
+        .expect("branch should create");
+    let census = row_census(&storage).await;
+    let scan = timed_scan(&session, &scan_sql("rotrow"), 1, reps).await;
+    report("after_create_branch", census, scan);
+
+    session
+        .switch_branch(crate::SwitchBranchOptions {
+            branch_id: branch.id.clone(),
+        })
+        .await
+        .expect("branch should switch");
+    let census = row_census(&storage).await;
+    let scan = timed_scan(&session, &scan_sql("rotrow"), 1, reps).await;
+    report("after_switch_to_branch", census, scan);
+
+    // A commit on the new branch, then back to main: exercises both branches'
+    // serving generations.
+    session
+        .execute(
+            "INSERT INTO rotrow (id, locale) VALUES ('branch-row', 'x')",
+            &[],
+        )
+        .await
+        .expect("branch insert should commit");
+    session
+        .switch_branch(crate::SwitchBranchOptions {
+            branch_id: main_branch_id,
+        })
+        .await
+        .expect("branch should switch back");
+    let census = row_census(&storage).await;
+    let scan = timed_scan(&session, &scan_sql("rotrow"), 1, reps).await;
+    report("after_switch_back_to_main", census, scan);
+
+    run_repository_gc(&storage).await;
+    let census = row_census(&storage).await;
+    let scan = timed_scan(&session, &scan_sql("rotrow"), 1, reps).await;
+    report("after_gc", census, scan);
 }

--- a/packages/lix/src/lib.rs
+++ b/packages/lix/src/lib.rs
@@ -57,6 +57,8 @@ pub(crate) mod gc;
 mod handle;
 #[cfg(test)]
 mod hot_index_aging_probe;
+#[cfg(test)]
+mod hot_row_tombstone_probe;
 pub(crate) mod init;
 pub(crate) mod json_store;
 pub(crate) mod hot_state;

--- a/packages/lix/src/module_layers.rs
+++ b/packages/lix/src/module_layers.rs
@@ -105,6 +105,7 @@ const UNLAYERED_MODULES: &[(&str, &str)] = &[
     ),
     ("handle", "entry point; reaches everywhere by design"),
     ("hot_index_aging_probe", "cfg(test) measurement probe"),
+    ("hot_row_tombstone_probe", "cfg(test) measurement probe"),
     ("init", "entry point; reaches everywhere by design"),
     ("lib", "crate root"),
     ("module_layers", "this guard"),


### PR DESCRIPTION
# probe(hot-state): quantify hot row tombstone ageing, and show nothing reclaims it

**No engine code changes.** This adds one `#[cfg(test)]` measurement module and its two registry
entries. It is the instrument plus the finding; the fix it argues for is scoped at the bottom and is
deliberately not in this diff.

Machine `hetzner-cpx62-III` (16c/30G). Base SHA `ab4277d9c` (`origin/main`). Probe HEAD `2e45f96c4`.

---

## The finding in one line

A collection holding **one live row** costs **4 978 µs** to scan after 10 000 deletes and **117 µs**
with the same one-row live set and no deletes — a **43x** degradation for an identical answer,
growing at **exactly one tombstone per delete** and **≈0.49 µs of scan per tombstone**, and **not one
of them is ever reclaimed** by an ordinary commit, a checkpoint, a repository GC sweep, or a
generation rotation.

## What changed physically

- `packages/lix/src/hot_row_tombstone_probe.rs` (new, `#[cfg(test)]`) — three `#[ignore]`d probes.
- `packages/lix/src/lib.rs` — one `#[cfg(test)] mod` line.
- `packages/lix/src/module_layers.rs` — one `UNLAYERED_MODULES` entry, mirroring the existing
  `hot_index_aging_probe` entry.

Nothing was removed. No adapter API, no storage space, no key or value encoding, no public API.
Because the probes are `#[ignore]`d, the CI test run compiles them and executes none of them, so
this adds no CI time.

## Measurement

Deterministic counts are **1 rep** (runbook rule); scans are the **median of 5** after 2 warmups,
in-process `Memory` adapter, `--release`, `--test-threads=1`.

```
LIX_TOMBSTONE_SIZES=100,1000,10000 LIX_TOMBSTONE_REPS=5 \
  cargo test -p lix --release --features storage-benches --lib \
  hot_row_tombstone_accumulation_and_scan_cost -- --ignored --nocapture --test-threads=1
```

### Phase 1 — the rate, across two orders of magnitude, live set pinned at one row

`churn` inserts N rows and deletes N−1. `fresh` inserts only the row that would have survived. Both
arms end with the same one-row live collection and both queries return one row. The predicate is
equality on `locale`, a column the schema neither keys nor declares, so the engine keeps its ordinary
collection scan.

| arm | n | deletes | row entries | tombstones | live entries | packed bases | root bases | answer rows | scan µs |
|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| churn | 100 | 99 | 141 | **99** | 42 | 0 | 0 | 1 | **142** |
| fresh | 100 | 0 | 42 | 0 | 42 | 0 | 0 | 1 | 93 |
| churn | 1 000 | 999 | 1 041 | **999** | 42 | 0 | 0 | 1 | **572** |
| fresh | 1 000 | 0 | 42 | 0 | 42 | 0 | 0 | 1 | 104 |
| churn | 10 000 | 9 999 | 10 041 | **9 999** | 42 | 0 | 0 | 1 | **4 978** |
| fresh | 10 000 | 0 | 42 | 0 | 42 | 0 | 0 | 1 | 117 |

A second independent run gave 140 / 579 / 5 071 and 85 / 98 / 90 — the same curve; the counts were
byte-identical.

**Rate — 1.000 tombstone per delete**, exactly, at every size. **Cost — ≈0.49 µs per tombstone:**

| n | (churn − fresh) µs | tombstones | µs/tombstone |
|---:|---:|---:|---:|
| 100 | 49 | 99 | 0.49 |
| 1 000 | 468 | 999 | 0.47 |
| 10 000 | 4 861 | 9 999 | 0.49 |

**`fresh` is the null control and it is flat** — 93 → 104 → 117 µs over a 100x span of the churn the
other arm did. That is this instrument's noise floor, and the churn arm is 43x outside it at the top
size. `live_entries` is 42 in all six arms, which is the control that the live set really is held
constant.

### Phase 2 — what reclaims them (n = 1 000: 999 tombstones, 1 live row)

| event | row entries | tombstones | live entries | scan µs |
|---|---:|---:|---:|---:|
| after churn | 1 042 | 999 | 43 | 631 |
| after 20 ordinary commits | 1 062 | **999** | 63 | 657 |
| after `create_checkpoint()` | 1 063 | **999** | 64 | 585 |
| after a `stage_repository_gc` sweep | 1 063 | **999** | 64 | 594 |
| after a 2nd checkpoint + 2nd sweep | 1 065 | **999** | 66 | 578 |

**Nothing reclaims a single one.** This was previously an inherited claim; it is now measured.

### Phase 3 — generation rotation (n = 1 000)

| event | row entries | tombstones | root bases | scan µs |
|---|---:|---:|---:|---:|
| after churn | 1 041 | 999 | 0 | 556 |
| after `create_branch` | 1 042 | **999** | 1 | 566 |
| after `switch_branch` to the new branch | 1 042 | **999** | 1 | **2 198** |
| after `switch_branch` back to main | 1 043 | **999** | 1 | 596 |
| after GC | 1 043 | **999** | 1 | 569 |

Rotation does not reclaim, and it makes the read **worse** on the rotated side: the root-backed
sparse generation serves the same one-row answer at **2 198 µs against main's 556 µs, 3.9x** (3.3x at
n = 100). A branch created over a churned head inherits the churn through its root base and pays the
base/overlay merge on top of it. **That is a second, separate defect** and none of the fixes below
address it.

## Mechanism (code, not inference)

- **Key layout.** `encode_hot_row_key_parts` builds `scope | schema_key | file_id | entity_pk`. A
  tombstone is the *same key* with `HEAD_VALUE_DELETED` set in the value, so tombstones interleave
  with live rows and a scan cannot seek past them.
- **The scan does not filter early.** `hot_scan_entries` enters `ROW_SPACE` at `scope|schema_key`,
  decodes every key, materialises the **full value** for filter-matching entries and pushes it; the
  deleted filter runs downstream. That is where the 0.49 µs goes.
- **Why the tombstone is load-bearing.** `merge_ordered_live_batches` resolves overlay-vs-base by
  `commit_id` on equal identity and **never inspects `deleted`**. A tombstone shadows a packed/root
  base row purely by being newer. Second reason: it carries the `WorkingDiffBaseline` that makes the
  delete visible in `lix_working_diff`.
- **Why rotation carries them.** `load_persisted_lifecycle_tracked_snapshot` scans canonical state
  with `include_tombstones: true`; `HotTrackedSnapshot::from_materialized_rows` copies
  `deleted: row.deleted`; `stage_complete_hot_rows` writes every row of that map as explicit keys in
  the successor generation.

## Why this is worth its own fix, and what the fix is

`packed_bases = 0` and `root_bases = 0` in **every** phase-1 arm. The 10 000 inserted rows became
explicit `ROW_SPACE` keys and the deletes rewrote them in place, so **not one of the 9 999
tombstones shadows anything**. Their only remaining obligation is the working diff, and that expires
at the next checkpoint — which phase 2 shows comes and goes with all 999 still there.

So this is not conservative retention the engine cannot prove away. **Nothing ever asks the
question.**

The correctness rule is: a tombstone is load-bearing **iff** (a) a base visible to its generation
still contains its identity, or (b) its working-diff baseline still makes the delete observable.
Proposed, in order of value:

1. **Compact at the checkpoint boundary.** The checkpoint is exactly the publication at which (b) is
   discharged for the whole branch, and `ROW_SPACE` serves the **head only** — history reads go to
   the canonical plane and a concurrent reader is on a storage snapshot, so it observes a compaction
   write set all-or-nothing. Add a `tombstone_count` to the existing per-`(schema_key, file_id)`
   `HotCollectionControl` (whose `live_count` already excludes tombstones), and compact a collection
   when `tombstone_count > max(K, live_count)`. The ratio trigger makes the O(collection) pass
   amortised O(1) per delete and leaves untripped checkpoints doing **zero** extra work, which
   preserves the explicit decision recorded at `engine.rs` that a checkpoint must not be
   O(collection).
2. **Stop re-encoding tombstones into a complete generation republication.**
   `stage_complete_current_state_with_working_diff` writes a dense map and its call site stages no
   root base, so (a) cannot hold; it also forces the baselines to `Clean`/`Disabled`, so (b) cannot
   hold. Dropping `deleted` rows there is strictly less work and strictly fewer keys. It only fires
   at lifecycle events, so it is not the fix — but it removes the "immortal across the branch's
   entire history" property.
3. **Rejected: key segregation.** A liveness discriminator between `file_id` and `entity_pk` makes
   the live scan O(live) with no reclamation and therefore **no resurrection hazard at all** — the
   easiest design to argue. It is rejected because `hot_exact_identity_batches` would need two keys
   instead of one to tell "deleted here" from "absent, fall through to base", doubling the key count
   of the engine's hottest OLTP lane to fix a scan lane, and it reclaims no bytes.

**On the format-change window: none of this needs it.** (1) widens the value of
`COLLECTION_CONTROL_SPACE`, a derived generation-scoped record that `stage_retire_hot_generation`
already sweeps and that is rebuildable from canonical records — rebuildable-cache churn under
invariant 3, not a migration. (2) is a filter on an in-memory map. The only option that would need
the window is (3), and (3) is the one being rejected. This work does not have to be rushed to beat
the freeze.

**To check before implementing:** that `undo_redo` replays canonical changes rather than reading a
`ROW_SPACE` tombstone, and that every site distinguishing "identity is a tombstone" from "identity is
absent" (`tracked_head_absence_guards`, `validate_exact_collection_member`) treats absence as at
least as strong.

## Layout invariants

1. **Single authority** — no. Adds no writer and no materialization; the probe only reads.
2. **Commit canonicality** — unaffected.
3. **Derived views are caches** — unaffected by this diff, and this is the invariant the argument
   above rests on: `ROW_SPACE` is a generation-keyed serving view, which is why compaction is the
   right frame and forcing tombstones into the GC walk (invariant 5) would not be.
4. **Atomic publication** — unaffected. The proposed compaction is explicitly a single write set.
5. **GC from refs** — unaffected. Tombstones are not reachability metadata and this does not make
   them so.
6. **SQL reads canonical records** — unaffected.

## Regressions

None measured and none possible from this diff: the added module is `#[cfg(test)]` and every test in
it is `#[ignore]`d, so no shipped code path and no CI-executed test is touched. No timing guard is
reported because **a guard that cannot execute changed code is not a guard** — there is no changed
engine code here.

## Gate

Full CI-scope suite on `hetzner-cpx62-III`, provenance printed inside the run
(`git rev-parse HEAD`, `git status --porcelain`, before and after), `--no-fail-fast`, full log
captured to a file and grepped rather than tailed:

```
cargo check --workspace --all-targets --all-features
cargo clippy --profile test --workspace --all-targets --all-features -- -D warnings
cargo test --profile test --workspace --exclude lix_benchmarks --all-features --no-fail-fast
cargo test --profile test -p lix_benchmarks --features storage-benches,slatedb,root-replay-trace --no-fail-fast
cargo check -p lix --no-default-features
cargo check -p lix_js_sdk --target wasm32-unknown-unknown
node scripts/validate-changes.mjs
```

Provenance printed inside the run:

```
worktree: /root/claude5/cand
HEAD: 2e45f96c4c9875d400ccd9b0496aa27bea6c6e17
status.porcelain: []
merge-base with origin/main: ab4277d9c69f325c56e480e28d44b856ccd087fe
```

`git diff --stat ab4277d9c origin/claude-6/e45-hot-row-tombstone` inside the run reports exactly the
three files listed above and nothing else.

**Result: green except one target, and that target is red on base too.**

| step | result |
|---|---|
| `cargo check --workspace --all-targets --all-features` | pass |
| `cargo clippy --profile test --workspace --all-targets --all-features -- -D warnings` | pass |
| `cargo test --profile test --workspace --exclude lix_benchmarks --all-features --no-fail-fast` | **56 targets ok, 0 failed** |
| `cargo test --profile test -p lix_benchmarks --features storage-benches,slatedb,root-replay-trace --no-fail-fast` | 66 targets ok, **1 target aborted** (below) |
| `cargo check -p lix --no-default-features` | pass |
| `cargo check -p lix_js_sdk --target wasm32-unknown-unknown` | pass |
| `node scripts/validate-changes.mjs` | pass — 42 fragments |

### The one failure is pre-existing on `ab4277d9c`

```
Running tests/cas_gc_history_retention.rs
thread 'slatedb_history_blob_survives_until_final_root_release' has overflowed its stack
fatal runtime error: stack overflow, aborting
```

Re-checked out `ab4277d9c` in the same worktree and ran the same target: **identical abort, same
test, same message.** Two independent proofs that this diff is not the cause:

1. **The test binary is byte-identical on both arms** — cargo produced
   `cas_gc_history_retention-ea7c50d0f4d1c66d` on the branch *and* on base. Same fingerprint, so the
   diff contributes nothing to it.
2. **It structurally cannot**: `hot_row_tombstone_probe` is behind `#[cfg(test)]` in `packages/lix`,
   and `lix_benchmarks` links `lix` as an ordinary dependency, where `cfg(test)` is off.

It is the failure mode `ci.yml` already warns about in its "Run Rust workspace tests" comment —
a `--profile test` (unoptimized) target exceeding libtest's 2 MiB worker-stack default. It needs its
own sized thread, the way `run_on_sized_stack` does elsewhere. **Filed as a separate issue; not
worked around here, and nothing was weakened, shortened or deleted to get green.**
