### PR TITLE
Make primary session restoration Rust-owned

### DIFF
--- a/.changenotes/primary-session-hard-cut.md
+++ b/.changenotes/primary-session-hard-cut.md
@@ -1,0 +1,10 @@
+---
+type: minor
+---
+
+Replace workspace sessions with client-owned primary sessions. New repositories
+track `lix_default_branch_id` in their initial commit, while `open_lix()` restores
+the primary session from untracked client state at
+`lix_primary_session_branch_id`. Additional sessions are independent and branch
+switches no longer mutate repository state. This is a storage and API hard cut;
+older repositories and the removed workspace-session methods are unsupported.

--- a/packages/cli/src/commands/redo.rs
+++ b/packages/cli/src/commands/redo.rs
@@ -8,7 +8,7 @@ pub fn run(context: &AppContext, command: RedoCommand) -> Result<CommandOutput, 
     let path = resolve_db_path(context)?;
     let lix = open_lix_at(&path)?;
     let receipt = if let Some(branch_id) = command.branch {
-        let branch = crate::db::block_on(lix.open_session(branch_id))
+        let branch = crate::db::block_on(lix.open_session_at(branch_id))
             .map_err(|error| CliError::msg(error.to_string()))?;
         crate::db::block_on(branch.redo())
     } else {

--- a/packages/cli/src/commands/undo.rs
+++ b/packages/cli/src/commands/undo.rs
@@ -8,7 +8,7 @@ pub fn run(context: &AppContext, command: UndoCommand) -> Result<CommandOutput, 
     let path = resolve_db_path(context)?;
     let lix = open_lix_at(&path)?;
     let receipt = if let Some(branch_id) = command.branch {
-        let branch = crate::db::block_on(lix.open_session(branch_id))
+        let branch = crate::db::block_on(lix.open_session_at(branch_id))
             .map_err(|error| CliError::msg(error.to_string()))?;
         crate::db::block_on(branch.undo())
     } else {

--- a/packages/e2e/benches/branch_checkpoint_retirement.rs
+++ b/packages/e2e/benches/branch_checkpoint_retirement.rs
@@ -265,7 +265,7 @@ where
         .await
         .expect("open branch-delete benchmark engine");
     let session = engine
-        .open_workspace_session()
+        .open_session()
         .await
         .expect("open branch-delete benchmark workspace");
     session
@@ -286,7 +286,7 @@ where
         .await
         .expect("open branch-delete benchmark engine");
     let session = engine
-        .open_workspace_session()
+        .open_session()
         .await
         .expect("open branch-delete benchmark workspace");
     session

--- a/packages/e2e/benches/branch_storage_sharing.rs
+++ b/packages/e2e/benches/branch_storage_sharing.rs
@@ -210,9 +210,9 @@ async fn run_case<S>(
         .await
         .expect("open branch-sharing engine");
     let main = engine
-        .open_workspace_session()
+        .open_session()
         .await
-        .expect("open branch-sharing workspace session");
+        .expect("open branch-sharing session");
     register_schema(&main).await;
     let seed_started = Instant::now();
     seed_rows(&main, rows).await;
@@ -431,7 +431,7 @@ where
     S: Storage + Clone + Send + Sync + 'static,
 {
     let session = engine
-        .open_session(branch.to_owned())
+        .open_session_at(branch.to_owned())
         .await
         .expect("open branch-sharing branch session");
     let mut written = 0usize;

--- a/packages/e2e/benches/checkpoint_history_scale.rs
+++ b/packages/e2e/benches/checkpoint_history_scale.rs
@@ -359,7 +359,7 @@ where
         .await
         .expect("open checkpoint-query setup engine");
     let session = engine
-        .open_workspace_session()
+        .open_session()
         .await
         .expect("open checkpoint-query setup session");
     for _ in 0..additional_checkpoints {
@@ -450,7 +450,7 @@ async fn measure_query<StorageImpl>(
         .await
         .expect("open checkpoint-query engine");
     let session = engine
-        .open_workspace_session()
+        .open_session()
         .await
         .expect("open checkpoint-query session");
     for _ in 0..warmups {

--- a/packages/e2e/benches/fixed_live_history_scale.rs
+++ b/packages/e2e/benches/fixed_live_history_scale.rs
@@ -183,7 +183,7 @@ where
             .expect("initialize repository");
         let engine = Engine::new(storage.clone()).await.expect("open engine");
         let session = engine
-            .open_workspace_session()
+            .open_session()
             .await
             .expect("open workspace");
         register_schema(&session).await;

--- a/packages/e2e/benches/large_blob_updates.rs
+++ b/packages/e2e/benches/large_blob_updates.rs
@@ -360,7 +360,7 @@ where
             .await
             .expect("open large blob benchmark engine");
         let session = engine
-            .open_session(receipt.main_branch_id)
+            .open_session_at(receipt.main_branch_id)
             .await
             .expect("open large blob benchmark session");
         let workload = WorkloadState::new(size, operation);

--- a/packages/e2e/benches/native_file_read_component.rs
+++ b/packages/e2e/benches/native_file_read_component.rs
@@ -755,7 +755,7 @@ where
         .await
         .expect("open native read component source engine");
     let session = engine
-        .open_session(init.main_branch_id.clone())
+        .open_session_at(init.main_branch_id.clone())
         .await
         .expect("open native read component source session");
 
@@ -817,7 +817,7 @@ where
         .await
         .expect("open native read component clone engine");
     let session = engine
-        .open_session(main_branch_id)
+        .open_session_at(main_branch_id)
         .await
         .expect("open native read component clone session");
     ComponentFixture {

--- a/packages/e2e/benches/native_file_upsert_component.rs
+++ b/packages/e2e/benches/native_file_upsert_component.rs
@@ -730,7 +730,7 @@ where
         .await
         .expect("open native component source engine");
     let session = engine
-        .open_session(init.main_branch_id.clone())
+        .open_session_at(init.main_branch_id.clone())
         .await
         .expect("open native component source session");
 
@@ -809,7 +809,7 @@ where
         .await
         .expect("open native component clone engine");
     let session = engine
-        .open_session(main_branch_id)
+        .open_session_at(main_branch_id)
         .await
         .expect("open native component clone session");
     ComponentFixture {

--- a/packages/e2e/benches/repository_gc_scale.rs
+++ b/packages/e2e/benches/repository_gc_scale.rs
@@ -227,7 +227,7 @@ where
         .await
         .expect("open repository-GC engine");
     let main = engine
-        .open_workspace_session()
+        .open_session()
         .await
         .expect("open repository-GC main session");
     let schema = serde_json::json!({
@@ -256,7 +256,7 @@ where
         .await
         .expect("create repository-GC disposable branch");
     let branch_session = engine
-        .open_session(branch.id.clone())
+        .open_session_at(branch.id.clone())
         .await
         .expect("open repository-GC disposable branch");
     for commit_index in 0..commit_count {

--- a/packages/e2e/benches/slatedb_file_api.rs
+++ b/packages/e2e/benches/slatedb_file_api.rs
@@ -684,7 +684,7 @@ impl SeededStore {
             .await
             .expect("open SlateDB file benchmark engine");
         let session = engine
-            .open_session(init_receipt.main_branch_id.clone())
+            .open_session_at(init_receipt.main_branch_id.clone())
             .await
             .expect("open SlateDB file benchmark session");
 
@@ -718,7 +718,7 @@ impl SeededStore {
             .await
             .expect("reopen SlateDB file benchmark engine");
         let session = engine
-            .open_session(self.main_branch_id.clone())
+            .open_session_at(self.main_branch_id.clone())
             .await
             .expect("reopen SlateDB file benchmark session");
         (session, cache_dir)
@@ -752,7 +752,7 @@ impl UploadBenchFixture {
             .await
             .expect("open SlateDB upload benchmark engine");
         let session = engine
-            .open_session(seeded.main_branch_id)
+            .open_session_at(seeded.main_branch_id)
             .await
             .expect("open SlateDB upload benchmark session");
         seeded.object_store.set_delay(delay);
@@ -1184,7 +1184,7 @@ impl FreshEngineSelectBenchFixture {
             .await
             .expect("open fresh-engine SlateDB benchmark engine");
         engine
-            .open_session(self.main_branch_id.clone())
+            .open_session_at(self.main_branch_id.clone())
             .await
             .expect("open fresh-engine SlateDB benchmark session")
     }
@@ -1219,7 +1219,7 @@ async fn lixray_download_file(engine: &Engine<SlateDB>, branch_id: &str, file_id
         "seeded lifecycle branch should exist"
     );
     let session = engine
-        .open_session(branch_id.to_string())
+        .open_session_at(branch_id.to_string())
         .await
         .expect("open lifecycle session");
     download_file(&session, file_id).await

--- a/packages/e2e/benches/tpch/lix.rs
+++ b/packages/e2e/benches/tpch/lix.rs
@@ -320,7 +320,7 @@ where
         .expect("initialize Lix TPC-H storage");
     let engine = Engine::new(storage).await.expect("open Lix TPC-H engine");
     let session = engine
-        .open_workspace_session()
+        .open_session()
         .await
         .expect("open Lix TPC-H session");
     for schema in [

--- a/packages/e2e/benches/tracked_state_crud/sql_session.rs
+++ b/packages/e2e/benches/tracked_state_crud/sql_session.rs
@@ -1803,7 +1803,7 @@ where
         .await
         .expect("open tracked-state crud engine");
     let session = engine
-        .open_workspace_session()
+        .open_session()
         .await
         .expect("open tracked-state crud session");
     register_json_pointer_schema(&session).await;

--- a/packages/e2e/benches/tracked_working_diff.rs
+++ b/packages/e2e/benches/tracked_working_diff.rs
@@ -404,7 +404,7 @@ async fn setup<StorageImpl>(
         .await
         .expect("open tracked-working-diff engine");
     let session = engine
-        .open_workspace_session()
+        .open_session()
         .await
         .expect("open tracked-working-diff session");
     register_schema(&session).await;
@@ -468,7 +468,7 @@ async fn measure<StorageImpl>(
         .await
         .expect("open tracked-working-diff engine");
     let session = engine
-        .open_workspace_session()
+        .open_session()
         .await
         .expect("open tracked-working-diff session");
 
@@ -520,7 +520,7 @@ async fn measure_history<StorageImpl>(
         .await
         .expect("open tracked-working-diff engine");
     let session = engine
-        .open_workspace_session()
+        .open_session()
         .await
         .expect("open tracked-working-diff session");
     let expected_changes = working_diff_count(&session).await;
@@ -573,7 +573,7 @@ where
         .await
         .expect("open tracked-working-diff engine");
     let session = engine
-        .open_workspace_session()
+        .open_session()
         .await
         .expect("open tracked-working-diff session");
     let before = working_diff_count(&session).await;
@@ -617,7 +617,7 @@ async fn measure_merge_preview<StorageImpl>(
         .await
         .expect("open merge-preview engine");
     let target = engine
-        .open_workspace_session()
+        .open_session()
         .await
         .expect("open merge-preview target session");
     register_schema(&target).await;
@@ -635,7 +635,7 @@ async fn measure_merge_preview<StorageImpl>(
         .await
         .expect("create merge-preview source branch");
     let source = engine
-        .open_session(MERGE_PREVIEW_SOURCE_BRANCH_ID)
+        .open_session_at(MERGE_PREVIEW_SOURCE_BRANCH_ID)
         .await
         .expect("open merge-preview source session");
 
@@ -709,7 +709,7 @@ async fn measure_merge_commit<StorageImpl>(
         .await
         .expect("open merge-commit engine");
     let target = engine
-        .open_workspace_session()
+        .open_session()
         .await
         .expect("open merge-commit target session");
     register_schema(&target).await;
@@ -731,7 +731,7 @@ async fn measure_merge_commit<StorageImpl>(
             .await
             .expect("create merge-commit source branch");
         let source = engine
-            .open_session(&source_branch_id)
+            .open_session_at(&source_branch_id)
             .await
             .expect("open merge-commit source session");
         update_commit_range(

--- a/packages/e2e/benches/undo_redo_storage.rs
+++ b/packages/e2e/benches/undo_redo_storage.rs
@@ -438,7 +438,7 @@ where
         .await
         .expect("open undo/redo setup engine");
     let session = engine
-        .open_workspace_session()
+        .open_session()
         .await
         .expect("open undo/redo setup session");
     register_schema(&session).await;
@@ -576,7 +576,7 @@ async fn measure<S>(
         .await
         .expect("open measured undo/redo engine");
     let session = engine
-        .open_workspace_session()
+        .open_session()
         .await
         .expect("open measured undo/redo session");
     let rows = count_rows(&session).await;

--- a/packages/e2e/benches/untracked_state_crud/main.rs
+++ b/packages/e2e/benches/untracked_state_crud/main.rs
@@ -1075,12 +1075,12 @@ where
         .expect("initialize benchmark engine");
     let engine = Engine::new(storage).await.expect("open in-memory engine");
     let setup = engine
-        .open_workspace_session()
+        .open_session()
         .await
         .expect("open benchmark setup session");
     register_json_pointer_schema(&setup).await;
     engine
-        .open_workspace_session()
+        .open_session()
         .await
         .expect("open benchmark session")
 }

--- a/packages/e2e/benches/working_diff_file_scope.rs
+++ b/packages/e2e/benches/working_diff_file_scope.rs
@@ -144,7 +144,7 @@ async fn run<StorageImpl>(
         .await
         .expect("open working-diff file-scope engine");
     let session = engine
-        .open_workspace_session()
+        .open_session()
         .await
         .expect("open working-diff file-scope session");
 

--- a/packages/e2e/examples/branch_merge_benchmark.rs
+++ b/packages/e2e/examples/branch_merge_benchmark.rs
@@ -454,7 +454,7 @@ where
     .await
     .expect("switch workspace to plugin target");
     let mut source = lix
-        .open_session(&source_receipt.id)
+        .open_session_at(&source_receipt.id)
         .await
         .expect("open plugin source session");
     if cold_reopen {
@@ -469,7 +469,7 @@ where
         drop(lix);
         lix = open_benchmark::<StorageImpl>(&db_path).await;
         source = lix
-            .open_session(SOURCE_BRANCH_ID)
+            .open_session_at(SOURCE_BRANCH_ID)
             .await
             .expect("cold-open plugin source");
     }
@@ -729,7 +729,7 @@ where
     let branch_max_ms = sorted_branch_ms[sorted_branch_ms.len() - 1];
     let create_branches_ms = branch_measure.wall_ms;
     let source = lix
-        .open_session(&source_receipt.id)
+        .open_session_at(&source_receipt.id)
         .await
         .expect("open source session");
 

--- a/packages/e2e/examples/cas_gc_qualification.rs
+++ b/packages/e2e/examples/cas_gc_qualification.rs
@@ -396,7 +396,7 @@ where
         .await
         .expect("open retained repository");
     let session = engine
-        .open_session(initialized.main_branch_id)
+        .open_session_at(initialized.main_branch_id)
         .await
         .expect("open retained preparation session");
     let total_size = size_mib
@@ -524,7 +524,7 @@ where
         .await
         .expect("cold reopen retained repository");
     let session = engine
-        .open_session(fixture.branch_id.clone())
+        .open_session_at(fixture.branch_id.clone())
         .await
         .expect("cold reopen retained owner branch");
     let diff = session
@@ -575,7 +575,7 @@ where
 
     let release_started = PhaseStart::begin(slate_io);
     let workspace = engine
-        .open_workspace_session()
+        .open_session()
         .await
         .expect("open workspace for final owner release");
     workspace
@@ -620,9 +620,9 @@ where
         .await
         .expect("final repository should reopen");
     let workspace = engine
-        .open_workspace_session()
+        .open_session()
         .await
-        .expect("final workspace session should open");
+        .expect("final session should open");
     let branches = workspace
         .execute(
             "SELECT COUNT(*) AS entries FROM lix_branch WHERE id = $1",

--- a/packages/e2e/examples/cas_publication_epoch_qualification.rs
+++ b/packages/e2e/examples/cas_publication_epoch_qualification.rs
@@ -218,7 +218,7 @@ async fn run<S>(
         .await
         .expect("open publication repository");
     let session = engine
-        .open_session(initialized.main_branch_id)
+        .open_session_at(initialized.main_branch_id)
         .await
         .expect("open publication session");
     let stable_1k = deterministic_bytes(KIB, 1);

--- a/packages/e2e/examples/cas_sharing.rs
+++ b/packages/e2e/examples/cas_sharing.rs
@@ -378,7 +378,7 @@ where
             .await
             .expect("open cas sharing engine");
         let session = engine
-            .open_session(receipt.main_branch_id)
+            .open_session_at(receipt.main_branch_id)
             .await
             .expect("open cas sharing session");
         Self {
@@ -420,7 +420,7 @@ where
             .expect("create cas sharing branch");
         let session = self
             .engine
-            .open_session(branch.id)
+            .open_session_at(branch.id)
             .await
             .expect("open cas sharing branch session");
         let result = session

--- a/packages/e2e/examples/delta_segment_duplication.rs
+++ b/packages/e2e/examples/delta_segment_duplication.rs
@@ -105,7 +105,7 @@ async fn run_workload(workload: &str, rows: usize, window: usize) {
         .await
         .expect("open duplication-audit engine");
     let main = engine
-        .open_workspace_session()
+        .open_session()
         .await
         .expect("open duplication-audit workspace");
     register_schema(&main).await;
@@ -337,7 +337,7 @@ async fn edit_on_branch<S>(
     S: Storage + Clone + Send + Sync + 'static,
 {
     let session = engine
-        .open_session(branch.to_owned())
+        .open_session_at(branch.to_owned())
         .await
         .expect("open duplication-audit branch session");
     edit_rows(&session, start, count, generation).await;

--- a/packages/e2e/examples/duplicate_audit.rs
+++ b/packages/e2e/examples/duplicate_audit.rs
@@ -90,7 +90,7 @@ async fn build(corpus: &str, dir: &Path) {
         .await
         .expect("open corpus engine");
     let session = engine
-        .open_workspace_session()
+        .open_session()
         .await
         .expect("open corpus workspace");
     register_schema(&session).await;
@@ -132,7 +132,7 @@ async fn build(corpus: &str, dir: &Path) {
                     .await
                     .expect("create audit branch");
                 let branch_session = engine
-                    .open_session(branch.id.clone())
+                    .open_session_at(branch.id.clone())
                     .await
                     .expect("open audit branch session");
                 edit_rows(&branch_session, shape, 3, 100, base).await;
@@ -158,7 +158,7 @@ async fn build(corpus: &str, dir: &Path) {
                 .await
                 .expect("create GC-disposable branch");
             let branch_session = engine
-                .open_session(branch.id.clone())
+                .open_session_at(branch.id.clone())
                 .await
                 .expect("open GC-disposable branch");
             edit_rows(&branch_session, shape, 10, 200, rows / 2).await;

--- a/packages/e2e/examples/e1_json_leak.rs
+++ b/packages/e2e/examples/e1_json_leak.rs
@@ -129,7 +129,7 @@ async fn run_cell(shape: &str, cadence: usize, edits: usize) {
         .await
         .expect("open leak engine");
     let session = engine
-        .open_workspace_session()
+        .open_session()
         .await
         .expect("open leak workspace");
     register_schema(&session).await;

--- a/packages/e2e/examples/e29_locator_leak.rs
+++ b/packages/e2e/examples/e29_locator_leak.rs
@@ -128,7 +128,7 @@ async fn main() {
             .await
             .expect("open locator engine");
         let session = engine
-            .open_workspace_session()
+            .open_session()
             .await
             .expect("open locator workspace");
         register_schema(&session).await;

--- a/packages/e2e/examples/e3_cas_reclaim_scan.rs
+++ b/packages/e2e/examples/e3_cas_reclaim_scan.rs
@@ -99,7 +99,7 @@ fn main() {
             .await
             .expect("open reclaim scan repository");
         let session = engine
-            .open_session(initialized.main_branch_id)
+            .open_session_at(initialized.main_branch_id)
             .await
             .expect("open reclaim scan session");
         let setup_started = Instant::now();

--- a/packages/e2e/examples/e5_media_probe.rs
+++ b/packages/e2e/examples/e5_media_probe.rs
@@ -71,9 +71,9 @@ async fn open_session(dir: &Path, initialize: bool) -> (RocksDB, SessionContext<
     }
     let engine = Engine::new(storage.clone()).await.expect("open engine");
     let session = engine
-        .open_workspace_session()
+        .open_session()
         .await
-        .expect("open workspace session");
+        .expect("open session");
     (storage, session)
 }
 

--- a/packages/e2e/examples/expW_hot_row_anatomy.rs
+++ b/packages/e2e/examples/expW_hot_row_anatomy.rs
@@ -96,9 +96,9 @@ async fn run(rows: usize, scenario: &str, dir: &Path) {
         .await
         .expect("open anatomy engine");
     let main = engine
-        .open_workspace_session()
+        .open_session()
         .await
-        .expect("open anatomy workspace session");
+        .expect("open anatomy session");
     register_schema(&main).await;
     seed_rows(&main, rows).await;
 
@@ -644,7 +644,7 @@ async fn create_branch(main: &SessionContext<SlateDB>, name: &str) -> String {
 
 async fn modify_rows(engine: &Engine<SlateDB>, branch: &str, start: usize, count: usize) {
     let session = engine
-        .open_session(branch.to_owned())
+        .open_session_at(branch.to_owned())
         .await
         .expect("open anatomy branch session");
     let mut written = 0usize;

--- a/packages/e2e/examples/expY_untracked_mutation_scaling.rs
+++ b/packages/e2e/examples/expY_untracked_mutation_scaling.rs
@@ -80,7 +80,7 @@ async fn measure(
         .expect("initialize repository");
     let engine = Engine::new(storage.clone()).await.expect("open engine");
     let session = engine
-        .open_workspace_session()
+        .open_session()
         .await
         .expect("open workspace");
 

--- a/packages/e2e/examples/expaa_replay_scope.rs
+++ b/packages/e2e/examples/expaa_replay_scope.rs
@@ -57,7 +57,7 @@ async fn main() {
         .expect("initialize repository");
     let engine = Engine::new(storage.clone()).await.expect("open engine");
     let session = engine
-        .open_workspace_session()
+        .open_session()
         .await
         .expect("open workspace");
     register_schema(&session).await;

--- a/packages/e2e/examples/expab_plan_load.rs
+++ b/packages/e2e/examples/expab_plan_load.rs
@@ -78,7 +78,7 @@ where
         .expect("initialize repository");
     let engine = Engine::new(storage.clone()).await.expect("open engine");
     let session = engine
-        .open_workspace_session()
+        .open_session()
         .await
         .expect("open workspace");
     register_schema(&session).await;
@@ -196,7 +196,7 @@ where
         .expect("create branch")
         .id;
     let branch_session = engine
-        .open_session(branch.clone())
+        .open_session_at(branch.clone())
         .await
         .expect("open branch session");
     for index in 0..8 {

--- a/packages/e2e/examples/expfk_directory_delete_scan.rs
+++ b/packages/e2e/examples/expfk_directory_delete_scan.rs
@@ -72,7 +72,7 @@ async fn main() {
     }
     let engine = Engine::new(storage.clone()).await.expect("open engine");
     let session = engine
-        .open_workspace_session()
+        .open_session()
         .await
         .expect("open workspace");
 

--- a/packages/e2e/examples/exppq_point_query.rs
+++ b/packages/e2e/examples/exppq_point_query.rs
@@ -176,9 +176,9 @@ async fn run_fixture(bundles: usize, rounds: u32, bulk: bool) {
         .expect("initialize fixture");
     let engine = Engine::new(storage).await.expect("open engine");
     let session = engine
-        .open_workspace_session()
+        .open_session()
         .await
-        .expect("open workspace session");
+        .expect("open session");
 
     for schema in schemas() {
         session

--- a/packages/e2e/examples/exppq_write_scaling.rs
+++ b/packages/e2e/examples/exppq_write_scaling.rs
@@ -96,9 +96,9 @@ where
         .expect("initialize fixture");
     let engine = Engine::new(storage).await.expect("open engine");
     let session = engine
-        .open_workspace_session()
+        .open_session()
         .await
-        .expect("open workspace session");
+        .expect("open session");
 
     for schema in schemas() {
         session

--- a/packages/e2e/examples/expu_json_delta.rs
+++ b/packages/e2e/examples/expu_json_delta.rs
@@ -247,7 +247,7 @@ async fn build(corpus: &str, dir: &Path, log_path: &Path) {
         .await
         .expect("open corpus engine");
     let session = engine
-        .open_workspace_session()
+        .open_session()
         .await
         .expect("open corpus workspace");
     let mut log = WriteLog::create(log_path);

--- a/packages/e2e/examples/expv_blind_space_growth.rs
+++ b/packages/e2e/examples/expv_blind_space_growth.rs
@@ -508,7 +508,7 @@ impl Fixture {
             .expect("initialize repository");
         let engine = Engine::new(storage.clone()).await.expect("open engine");
         let session = engine
-            .open_workspace_session()
+            .open_session()
             .await
             .expect("open workspace");
         Self {

--- a/packages/e2e/examples/space_growth.rs
+++ b/packages/e2e/examples/space_growth.rs
@@ -50,7 +50,7 @@ async fn main() {
         .expect("initialize repository");
     let engine = Engine::new(storage.clone()).await.expect("open engine");
     let session = engine
-        .open_workspace_session()
+        .open_session()
         .await
         .expect("open workspace");
     register_schema(&session).await;

--- a/packages/e2e/examples/write_amplification.rs
+++ b/packages/e2e/examples/write_amplification.rs
@@ -156,9 +156,9 @@ async fn seed<S: BenchStorage>(storage: S, rows: usize, seed_width: usize) {
         .await
         .expect("open engine over initialized repository");
     let session = engine
-        .open_workspace_session()
+        .open_session()
         .await
-        .expect("open workspace session");
+        .expect("open session");
 
     let schema = serde_json::json!({
         "x-lix-key": "json_pointer",
@@ -229,9 +229,9 @@ async fn update<S: BenchStorage>(storage: S, updates: usize, width: usize, disti
         .await
         .expect("open engine over initialized repository");
     let session = engine
-        .open_workspace_session()
+        .open_session()
         .await
-        .expect("open workspace session");
+        .expect("open session");
 
     let mut applied = 0_usize;
     while applied < updates {
@@ -271,9 +271,9 @@ async fn read_rows<S: BenchStorage>(storage: S, reads: usize, distinct: usize) {
         .await
         .expect("open engine over initialized repository");
     let session = engine
-        .open_workspace_session()
+        .open_session()
         .await
-        .expect("open workspace session");
+        .expect("open session");
 
     // Warm the plan cache so the measurement is the read, not planning.
     for index in 0..distinct.min(16) {

--- a/packages/e2e/tests/cas_gc_history_retention.rs
+++ b/packages/e2e/tests/cas_gc_history_retention.rs
@@ -81,7 +81,7 @@ where
         .await
         .expect("untracked repository should open");
     let session = engine
-        .open_workspace_session()
+        .open_session()
         .await
         .expect("untracked session should open");
     session
@@ -120,7 +120,7 @@ where
         .await
         .expect("untracked repository should cold reopen");
     let session = engine
-        .open_workspace_session()
+        .open_session()
         .await
         .expect("cold untracked session should open");
     let content = session
@@ -147,7 +147,7 @@ where
         .await
         .expect("history repository should open");
     let session = engine
-        .open_workspace_session()
+        .open_session()
         .await
         .expect("history preparation session should open");
     let branch = session
@@ -160,7 +160,7 @@ where
         .expect("history disposable branch should create");
     let branch_id = branch.id;
     let branch_session = engine
-        .open_session(branch_id.clone())
+        .open_session_at(branch_id.clone())
         .await
         .expect("history disposable branch should open");
     branch_session
@@ -214,7 +214,7 @@ where
         .await
         .expect("history repository should cold reopen");
     let session = engine
-        .open_session(fixture.branch_id.clone())
+        .open_session_at(fixture.branch_id.clone())
         .await
         .expect("history disposable branch should cold reopen");
     let diff = session
@@ -242,7 +242,7 @@ where
     drop(session);
 
     let main = engine
-        .open_workspace_session()
+        .open_session()
         .await
         .expect("history main session should reopen");
     main.execute(
@@ -288,7 +288,7 @@ where
         .await
         .expect("final history repository should reopen");
     let session = engine
-        .open_workspace_session()
+        .open_session()
         .await
         .expect("final history session should open");
     let branches = session

--- a/packages/e2e/tests/checkpoint_branch_merge_reopen.rs
+++ b/packages/e2e/tests/checkpoint_branch_merge_reopen.rs
@@ -101,7 +101,7 @@ async fn checkpoint_preserves_branch_merge_base_after_reopen<S: ReopenStorage>()
         assert_eq!(branch.commit_id, fork_commit_id);
 
         let source = main
-            .open_session(SOURCE_BRANCH_ID)
+            .open_session_at(SOURCE_BRANCH_ID)
             .await
             .expect("open source branch");
         source

--- a/packages/e2e/tests/crdt_benchmarks_baseline.rs
+++ b/packages/e2e/tests/crdt_benchmarks_baseline.rs
@@ -31,7 +31,7 @@ async fn crdt_benchmarks_b2_1_markdown_concurrent_prefix_inserts() {
         let target = format!("{}{}", "a".repeat(N), base);
         let source_text = format!("{}{}", "b".repeat(N), base);
         let peer = lix
-            .open_workspace_session()
+            .open_session()
             .await
             .expect("peer session should open");
         let mut target_transaction = lix.begin_transaction().await.expect("target transaction");
@@ -118,7 +118,7 @@ async fn crdt_benchmarks_b3_1_json_concurrent_map_sets() {
         let mut transactions = Vec::with_capacity(clients);
         for client in 0..clients {
             let peer = lix
-                .open_workspace_session()
+                .open_session()
                 .await
                 .expect("peer session should open");
             let mut transaction = peer
@@ -223,8 +223,8 @@ async fn crdt_benchmarks_b3_1_json_concurrent_map_sets() {
 #[tokio::test]
 async fn ordinary_concurrent_execute_serializes_without_plugin_resolution() {
     let lix = open_lix().await.unwrap();
-    let first = lix.open_workspace_session().await.unwrap();
-    let second = lix.open_workspace_session().await.unwrap();
+    let first = lix.open_session().await.unwrap();
+    let second = lix.open_session().await.unwrap();
     lix.reset_plugin_transition_counters();
     let first_write = async {
         first
@@ -281,7 +281,7 @@ fn same_base_three_writer_cohort_converges_and_reuses_follower_session() {
                     let mut peers = Vec::new();
                     let mut transactions = Vec::new();
                     for value in 0..3 {
-                        let peer = lix.open_workspace_session().await.unwrap();
+                        let peer = lix.open_session().await.unwrap();
                         let mut transaction = peer.begin_transaction().await.unwrap();
                         transaction
                             .execute(
@@ -382,7 +382,7 @@ fn serialized_leader_forces_stale_followers_to_reconcile_without_losing_writes()
                     let mut peers = Vec::new();
                     let mut transactions = Vec::new();
                     for (key, value) in [("a", "1"), ("b", "2"), ("c", "3")] {
-                        let peer = lix.open_workspace_session().await.unwrap();
+                        let peer = lix.open_session().await.unwrap();
                         let mut transaction = peer.begin_transaction().await.unwrap();
                         transaction
                             .execute(
@@ -451,8 +451,8 @@ fn serialized_leader_forces_stale_followers_to_reconcile_without_losing_writes()
 async fn invalid_aggregate_member_does_not_poison_valid_transaction() {
     let lix = open_lix().await.unwrap();
     install_plugin(&lix, "plugin_json", &build_json_plugin_archive()).await;
-    let first = lix.open_workspace_session().await.unwrap();
-    let second = lix.open_workspace_session().await.unwrap();
+    let first = lix.open_session().await.unwrap();
+    let second = lix.open_session().await.unwrap();
     let mut first_transaction = first.begin_transaction().await.unwrap();
     let mut second_transaction = second.begin_transaction().await.unwrap();
     for (transaction, bytes) in [

--- a/packages/e2e/tests/e2e.rs
+++ b/packages/e2e/tests/e2e.rs
@@ -887,8 +887,8 @@ async fn v2_csv_blob_api_preserves_multiplayer_authority_and_rollback() {
         .get::<String>("id")
         .unwrap();
 
-    let first = lix.open_workspace_session().await.unwrap();
-    let second = lix.open_workspace_session().await.unwrap();
+    let first = lix.open_session().await.unwrap();
+    let second = lix.open_session().await.unwrap();
     assert_eq!(
         read_file(&first, path).await.unwrap(),
         Some(initial.clone())
@@ -918,8 +918,8 @@ async fn v2_csv_blob_api_preserves_multiplayer_authority_and_rollback() {
 
     // Both sessions observed the same row version. Transaction commit order is
     // the deterministic LWW tiebreaker for their edits to that row.
-    let lww_first = lix.open_workspace_session().await.unwrap();
-    let lww_second = lix.open_workspace_session().await.unwrap();
+    let lww_first = lix.open_session().await.unwrap();
+    let lww_second = lix.open_session().await.unwrap();
     assert_eq!(
         read_file(&lww_first, path).await.unwrap(),
         Some(composed.clone())
@@ -945,8 +945,8 @@ async fn v2_csv_blob_api_preserves_multiplayer_authority_and_rollback() {
     // A deletion detected from a historical private view is applied to the
     // current renderer document, so an earlier same-row edit does not revive
     // the deleted identity.
-    let edit_session = lix.open_workspace_session().await.unwrap();
-    let delete_session = lix.open_workspace_session().await.unwrap();
+    let edit_session = lix.open_session().await.unwrap();
+    let delete_session = lix.open_session().await.unwrap();
     assert_eq!(
         read_file(&edit_session, path).await.unwrap(),
         Some(lww.clone())
@@ -971,7 +971,7 @@ async fn v2_csv_blob_api_preserves_multiplayer_authority_and_rollback() {
 
     // Conflict objects are not modeled yet. A session that never received the
     // file therefore applies its complete submitted document as last-write-wins.
-    let blind = lix.open_workspace_session().await.unwrap();
+    let blind = lix.open_session().await.unwrap();
     write_file(&blind, path, b"first,ONE\n".to_vec())
         .await
         .unwrap();
@@ -980,7 +980,7 @@ async fn v2_csv_blob_api_preserves_multiplayer_authority_and_rollback() {
 
     // A rolled-back successor is discarded; the accepted actor and its exact
     // observation remain usable for a later committed transition.
-    let rollback_session = lix.open_workspace_session().await.unwrap();
+    let rollback_session = lix.open_session().await.unwrap();
     assert_eq!(
         read_file(&rollback_session, path).await.unwrap(),
         Some(one_row.clone())
@@ -1006,7 +1006,7 @@ async fn v2_csv_blob_api_preserves_multiplayer_authority_and_rollback() {
         Some(b"first,COMMITTED\n".to_vec())
     );
 
-    let insert_session = lix.open_workspace_session().await.unwrap();
+    let insert_session = lix.open_session().await.unwrap();
     assert_eq!(
         read_file(&insert_session, path).await.unwrap(),
         Some(b"first,COMMITTED\n".to_vec())
@@ -1061,8 +1061,8 @@ async fn v2_csv_stale_observation_composes_a_keyless_create_with_a_concurrent_ed
         .get::<String>("id")
         .unwrap();
 
-    let edit_session = lix.open_workspace_session().await.unwrap();
-    let create_session = lix.open_workspace_session().await.unwrap();
+    let edit_session = lix.open_session().await.unwrap();
+    let create_session = lix.open_session().await.unwrap();
     assert_eq!(
         read_file(&edit_session, path).await.unwrap(),
         Some(initial.clone())
@@ -3501,8 +3501,8 @@ async fn v2_json_scalar_lww_composes_and_stale_structure_does_not_resurrect_node
     let file_id = file_id_at_path(&lix, path).await;
 
     // Different scalar changes from the same observed document compose.
-    let left_writer = lix.open_workspace_session().await.unwrap();
-    let right_writer = lix.open_workspace_session().await.unwrap();
+    let left_writer = lix.open_session().await.unwrap();
+    let right_writer = lix.open_session().await.unwrap();
     assert_eq!(
         read_file(&left_writer, path).await.unwrap(),
         Some(initial.clone())
@@ -3534,8 +3534,8 @@ async fn v2_json_scalar_lww_composes_and_stale_structure_does_not_resurrect_node
     assert_eq!(read_file(&lix, path).await.unwrap(), Some(composed.clone()));
 
     // Commit order is the deterministic LWW tiebreaker for the same scalar.
-    let first_lww = lix.open_workspace_session().await.unwrap();
-    let second_lww = lix.open_workspace_session().await.unwrap();
+    let first_lww = lix.open_session().await.unwrap();
+    let second_lww = lix.open_session().await.unwrap();
     assert_eq!(
         read_file(&first_lww, path).await.unwrap(),
         Some(composed.clone())
@@ -3619,8 +3619,8 @@ async fn v2_json_scalar_lww_composes_and_stale_structure_does_not_resurrect_node
 
     // Structure is byte-owned. A stale scalar delta is not allowed to
     // recreate an entity after another writer removes its containing slot.
-    let stale_writer = lix.open_workspace_session().await.unwrap();
-    let structure_writer = lix.open_workspace_session().await.unwrap();
+    let stale_writer = lix.open_session().await.unwrap();
+    let structure_writer = lix.open_session().await.unwrap();
     assert_eq!(
         read_file(&stale_writer, path).await.unwrap(),
         Some(scalar_after_direct_reject.clone())
@@ -7118,7 +7118,7 @@ async fn same_base_json_transactions_resolve_overlap_and_converge() {
         .await
         .unwrap();
     let file_id = file_id_at_path(&first, path).await;
-    let second = first.open_workspace_session().await.unwrap();
+    let second = first.open_session().await.unwrap();
     let mut first_transaction = first.begin_transaction().await.unwrap();
     let mut second_transaction = second.begin_transaction().await.unwrap();
     for (transaction, value) in [
@@ -7167,7 +7167,7 @@ async fn same_base_json_file_edits_compose_disjoint_semantics_without_resolution
     write_file(&first, path, b"{\"a\":\"base\",\"b\":\"base\"}\n".to_vec())
         .await
         .unwrap();
-    let second = first.open_workspace_session().await.unwrap();
+    let second = first.open_session().await.unwrap();
     let mut first_transaction = first.begin_transaction().await.unwrap();
     let mut second_transaction = second.begin_transaction().await.unwrap();
     first_transaction
@@ -7225,7 +7225,7 @@ async fn stale_json_transaction_renders_retained_same_file_edits_with_resolution
     )
     .await
     .unwrap();
-    let winner_client = stale_client.open_workspace_session().await.unwrap();
+    let winner_client = stale_client.open_session().await.unwrap();
     let mut stale = stale_client.begin_transaction().await.unwrap();
     let mut winner = winner_client.begin_transaction().await.unwrap();
     stale
@@ -7299,7 +7299,7 @@ async fn stale_json_transaction_batches_conflicts_into_one_render_transition() {
     )
     .await
     .unwrap();
-    let winner_client = stale_client.open_workspace_session().await.unwrap();
+    let winner_client = stale_client.open_session().await.unwrap();
     let mut stale = stale_client.begin_transaction().await.unwrap();
     let mut winner = winner_client.begin_transaction().await.unwrap();
     for (transaction, value) in [(&mut stale, "stale"), (&mut winner, "winner")] {
@@ -7378,7 +7378,7 @@ async fn stale_plugin_replay_batch_benchmark_probe() {
         )
         .await
         .unwrap();
-        let winner_client = stale_client.open_workspace_session().await.unwrap();
+        let winner_client = stale_client.open_session().await.unwrap();
         let mut stale = stale_client.begin_transaction().await.unwrap();
         let mut winner = winner_client.begin_transaction().await.unwrap();
         for (transaction, value) in [(&mut stale, "stale"), (&mut winner, "winner")] {
@@ -7475,7 +7475,7 @@ async fn same_base_transactions_resolve_reference_plugin_file_overlaps() {
         install_reference_plugin_in_blank_registry(&first, plugin_key, &archive, &schemas).await;
         let path = format!("/transaction-conflict.{extension}");
         write_file(&first, &path, base.clone()).await.unwrap();
-        let second = first.open_workspace_session().await.unwrap();
+        let second = first.open_session().await.unwrap();
         let mut first_transaction = first.begin_transaction().await.unwrap();
         let mut second_transaction = second.begin_transaction().await.unwrap();
         for (transaction, bytes) in [
@@ -8784,7 +8784,7 @@ async fn v2_csv_file_incarnation_fences_old_observations_after_delete_and_recrea
     let old_bytes = b"old,incarnation\n".to_vec();
     write_file(&lix, path, old_bytes.clone()).await.unwrap();
     let old_file_id = file_id_at_path(&lix, path).await;
-    let stale = lix.open_workspace_session().await.unwrap();
+    let stale = lix.open_session().await.unwrap();
     assert_eq!(read_file(&stale, path).await.unwrap(), Some(old_bytes));
 
     lix.execute(
@@ -8873,7 +8873,7 @@ async fn v2_generation_upgrade_preflights_owned_files_and_fences_stale_sessions(
     let bytes = b"first,one\nsecond,two\n".to_vec();
     write_file(&lix, path, bytes.clone()).await.unwrap();
 
-    let stale = lix.open_workspace_session().await.unwrap();
+    let stale = lix.open_session().await.unwrap();
     assert_eq!(read_file(&stale, path).await.unwrap(), Some(bytes.clone()));
 
     // A packaging-only archive generation change exercises the complete
@@ -8935,7 +8935,7 @@ async fn v2_generation_upgrade_preflights_owned_files_and_fences_stale_sessions(
         "failed upgrades must leave the compatible generation authoritative"
     );
     assert_eq!(read_file(&lix, path).await.unwrap(), Some(bytes.clone()));
-    let fresh = lix.open_workspace_session().await.unwrap();
+    let fresh = lix.open_session().await.unwrap();
     assert_eq!(read_file(&fresh, path).await.unwrap(), Some(bytes));
     fresh.reset_plugin_transition_counters();
     write_file(&fresh, path, b"first,ONE\nsecond,two\n".to_vec())
@@ -9117,7 +9117,7 @@ async fn v2_csv_path_only_rename_rekeys_actor_and_cleans_owner_on_unmatch() {
 
     // This reader must become stale solely because the accepted actor moves
     // to the descriptor-successor key, not because file bytes changed.
-    let stale = lix.open_workspace_session().await.unwrap();
+    let stale = lix.open_session().await.unwrap();
     assert_eq!(
         read_file(&stale, before_path).await.unwrap(),
         Some(initial.clone())
@@ -9126,7 +9126,7 @@ async fn v2_csv_path_only_rename_rekeys_actor_and_cleans_owner_on_unmatch() {
     // A path-only UPDATE is ordinary SQL. Its DML source reads the exact
     // materialized bytes and establishes the observation needed for the warm
     // empty-splice descriptor transition.
-    let renamer = lix.open_workspace_session().await.unwrap();
+    let renamer = lix.open_session().await.unwrap();
     let renamed = renamer
         .execute(
             "UPDATE lix_file SET path = $1 WHERE path = $2",
@@ -9649,7 +9649,7 @@ async fn lix_owned_sql_write_semantics_rocksdb_reopen() {
     let lix = open_rocksdb_lix(root.path()).await;
     qualify_lix_owned_sql_write_semantics(&lix, "rocks").await;
     let winner = lix
-        .open_workspace_session()
+        .open_session()
         .await
         .expect("open winner RocksDB session");
     qualify_stale_sql_write_owner(&lix, &winner, "rocks").await;
@@ -9680,7 +9680,7 @@ async fn lix_owned_sql_write_semantics_slatedb_reopen() {
         .expect("open SQL write-owner workspace");
     qualify_lix_owned_sql_write_semantics(&lix, "slate").await;
     let winner = lix
-        .open_workspace_session()
+        .open_session()
         .await
         .expect("open winner SlateDB session");
     qualify_stale_sql_write_owner(&lix, &winner, "slate").await;

--- a/packages/e2e/tests/exact_file_read_benchmark.rs
+++ b/packages/e2e/tests/exact_file_read_benchmark.rs
@@ -77,7 +77,7 @@ where
         .expect("initialize benchmark storage");
     let engine = Engine::new(storage).await.expect("open benchmark engine");
     let session = engine
-        .open_workspace_session()
+        .open_session()
         .await
         .expect("open benchmark session");
 

--- a/packages/e2e/tests/large_payload_read_qualification.rs
+++ b/packages/e2e/tests/large_payload_read_qualification.rs
@@ -437,7 +437,7 @@ where
         .await
         .expect("open media qualification engine");
     let main = engine
-        .open_session(&main_branch_id)
+        .open_session_at(&main_branch_id)
         .await
         .expect("open qualification main session");
 
@@ -574,7 +574,7 @@ where
     );
 
     let source = engine
-        .open_session(&branch.id)
+        .open_session_at(&branch.id)
         .await
         .expect("open large media source branch");
     let branch_range = measured(
@@ -829,7 +829,7 @@ async fn qualify_reopen<S>(
     .await
     .expect("reopen media qualification engine");
     let main = engine
-        .open_session(&expected.main_branch_id)
+        .open_session_at(&expected.main_branch_id)
         .await
         .expect("open reopened main session");
     let read = measured(

--- a/packages/e2e/tests/movie_workspace_qualification.rs
+++ b/packages/e2e/tests/movie_workspace_qualification.rs
@@ -354,7 +354,7 @@ where
         .expect("initialize movie workspace");
     let engine = Engine::new(storage).await.expect("open movie workspace");
     let seed = engine
-        .open_session(receipt.main_branch_id.clone())
+        .open_session_at(receipt.main_branch_id.clone())
         .await
         .expect("open seed session");
     for revision in 0..HISTORY_COMMITS {
@@ -387,25 +387,25 @@ where
 
     let ingest = Arc::new(
         engine
-            .open_session(receipt.main_branch_id.clone())
+            .open_session_at(receipt.main_branch_id.clone())
             .await
             .expect("open ingest session"),
     );
     let saver = Arc::new(
         engine
-            .open_session(receipt.main_branch_id.clone())
+            .open_session_at(receipt.main_branch_id.clone())
             .await
             .expect("open project-save session"),
     );
     let first_reader = Arc::new(
         engine
-            .open_session(receipt.main_branch_id.clone())
+            .open_session_at(receipt.main_branch_id.clone())
             .await
             .expect("open first playback session"),
     );
     let second_reader = Arc::new(
         engine
-            .open_session(receipt.main_branch_id)
+            .open_session_at(receipt.main_branch_id)
             .await
             .expect("open second playback session"),
     );
@@ -548,7 +548,7 @@ where
         .expect("initialize restart fixture");
     let engine = Engine::new(storage).await.expect("open first engine");
     let session = engine
-        .open_session(receipt.main_branch_id)
+        .open_session_at(receipt.main_branch_id)
         .await
         .expect("open first restart session");
     let total = FILE_UPLOAD_PART_BYTES as u64 + 9;
@@ -571,7 +571,7 @@ where
 {
     let engine = Engine::new(storage).await.expect("reopen engine");
     let session = engine
-        .open_workspace_session()
+        .open_session()
         .await
         .expect("open resumed session");
     let total = FILE_UPLOAD_PART_BYTES as u64 + 9;

--- a/packages/e2e/tests/realtime_collaboration_capacity.rs
+++ b/packages/e2e/tests/realtime_collaboration_capacity.rs
@@ -191,7 +191,7 @@ impl LocalCapacityBackend {
         let mut observations = Vec::with_capacity(clients);
         for _ in 0..clients {
             let peer = root
-                .open_workspace_session()
+                .open_session()
                 .await
                 .expect("collaborator session should open");
             let mut events = peer
@@ -418,7 +418,7 @@ async fn abandoned_transactions_and_sessions_release_resources() {
         let mut transactions = Vec::with_capacity(clients);
         for client in 0..clients {
             let peer = lix
-                .open_workspace_session()
+                .open_session()
                 .await
                 .expect("soak session should open");
             let mut transaction = peer

--- a/packages/e2e/tests/rust_sdk_api.rs
+++ b/packages/e2e/tests/rust_sdk_api.rs
@@ -25,7 +25,18 @@ async fn rs_sdk_telemetry_is_explicit_and_redacts_sql_literals() {
     let spans = spans.lock().unwrap();
     let span = spans
         .iter()
-        .find(|span| span.start.name == "lix.sql.query")
+        .find(|span| {
+            span.start.name == "lix.sql.query"
+                && span.start.attributes.iter().any(|attribute| {
+                    matches!(
+                        (&attribute.key, &attribute.value),
+                        (
+                            &"db.query.text",
+                            TelemetryValue::String(value)
+                        ) if value == "SELECT ? AS value, ? AS number"
+                    )
+                })
+        })
         .expect("query telemetry should be emitted when configured");
     let query_text = span
         .start

--- a/packages/js-sdk/src/client-state.ts
+++ b/packages/js-sdk/src/client-state.ts
@@ -2,7 +2,6 @@ import type { LixBinding } from "./binding-types.js";
 import type { JsonValue } from "./types.js";
 import { Value } from "./value.js";
 
-export const ACTIVE_BRANCH_CLIENT_STATE_KEY = "lix_active_branch_id";
 export const ACTIVE_ACCOUNT_CLIENT_STATE_KEY = "lix_active_account_id";
 
 export type LixClientState = {

--- a/packages/js-sdk/src/lix-lifecycle.test.ts
+++ b/packages/js-sdk/src/lix-lifecycle.test.ts
@@ -5,7 +5,6 @@ import { Lix } from "./lix.js";
 
 test("managed Lix close rejects new work and drains an in-flight branch switch", async () => {
 	const remoteSwitch = deferred<{ branchId: string }>();
-	const localPersistence = deferred<void>();
 	const order: string[] = [];
 	const execute = vi.fn(async () => {
 		throw new Error("execute must not reach the binding after close starts");
@@ -22,13 +21,8 @@ test("managed Lix close rejects new work and drains an in-flight branch switch",
 			order.push("remote binding closed");
 		},
 	} as unknown as LixBinding;
-	const clientStateSet = vi.fn(async () => {
-			order.push("client persistence started");
-			await localPersistence.promise;
-			order.push("client persistence finished");
-		});
 	const clientBinding = {
-		clientStateSet,
+		clientStateSet: vi.fn(async () => undefined),
 		close: async () => {
 			order.push("client binding closed");
 		},
@@ -57,25 +51,16 @@ test("managed Lix close rejects new work and drains an in-flight branch switch",
 	await expect(stateWriteAfterClose).rejects.toMatchObject({
 		code: "LIX_ERROR_CLOSED",
 	});
-	expect(clientStateSet).not.toHaveBeenCalled();
 	expect(order).toEqual(["remote switch started"]);
 
 	remoteSwitch.resolve({ branchId: "draft" });
-	await vi.waitFor(() => {
-		expect(order).toContain("client persistence started");
-	});
-	expect(order).not.toContain("client binding closed");
-	expect(order).not.toContain("remote binding closed");
-
-	localPersistence.resolve();
 	await expect(switching).resolves.toEqual({ branchId: "draft" });
+	expect(clientBinding.clientStateSet).not.toHaveBeenCalled();
 	await expect(closing).resolves.toBeUndefined();
 	expect(branchListener).toHaveBeenCalledOnce();
 	expect(order).toEqual([
 		"remote switch started",
 		"remote switch finished",
-		"client persistence started",
-		"client persistence finished",
 		"remote binding closed",
 		"client binding closed",
 	]);

--- a/packages/js-sdk/src/lix.ts
+++ b/packages/js-sdk/src/lix.ts
@@ -1,10 +1,6 @@
 import { invalidArgument } from "./errors.js";
-import {
-	ACTIVE_BRANCH_CLIENT_STATE_KEY,
-	type LixClientState,
-	type ManagedClientState,
-	unavailableClientState,
-} from "./client-state.js";
+import type { LixClientState, ManagedClientState } from "./client-state.js";
+import { unavailableClientState } from "./client-state.js";
 import type {
 	BindingObserveEvent,
 	LixBinding,
@@ -199,18 +195,6 @@ export class Lix {
 	): Promise<SwitchBranchReceipt> {
 		return this.#runOperation(async () => {
 			const receipt = await this.binding.switchBranch(options);
-			try {
-				if (this.managedClientState) {
-					await this.managedClientState.set(
-						ACTIVE_BRANCH_CLIENT_STATE_KEY,
-						receipt.branchId,
-					);
-				}
-			} catch {
-				// The remote branch switch already committed. Client persistence is a
-				// best-effort reopen preference and cannot turn that success into a
-				// rejected switch with ambiguous branch state.
-			}
 			for (const listener of [...this.#activeBranchListeners]) {
 				try {
 					listener();

--- a/packages/js-sdk/src/open-lix.browser.test.ts
+++ b/packages/js-sdk/src/open-lix.browser.test.ts
@@ -34,7 +34,13 @@ test("forwards opt-in SQL telemetry from browser WASM", async () => {
 	const lix = await openLix({
 		telemetry: {
 			onSpan(span) {
-				if (span.name === "lix.sql.query") resolveSpan(span);
+				if (
+					span.name === "lix.sql.query" &&
+					span.attributes["db.query.text"] ===
+						"SELECT ? AS value, ? AS number"
+				) {
+					resolveSpan(span);
+				}
 			},
 		},
 	});

--- a/packages/js-sdk/src/open-lix.browser.test.ts
+++ b/packages/js-sdk/src/open-lix.browser.test.ts
@@ -140,14 +140,14 @@ test("executes a globally ordered union plan in browser WASM", async () => {
 	}
 });
 
-test("remote client state and active branch survive reopen without reaching the server", async () => {
+test("remote client state survives reopen while the server selects the session branch", async () => {
 	const { IndexedDbStorage, openLix } = await import("@lix-js/sdk");
 	const storage = new IndexedDbStorage({
 		name: `lix-client-state-test:${crypto.randomUUID()}`,
 	});
 	const sessions = new Map<string, string>();
-	const availableBranches = new Set(["main", "draft"]);
 	const initialBranchRequests: Array<string | null> = [];
+	const initialAccountRequests: Array<string | null> = [];
 	const requestBodies: string[] = [];
 	let nextSession = 0;
 	const remoteFetch = async (input: RequestInfo | URL, init?: RequestInit) => {
@@ -158,19 +158,7 @@ test("remote client state and active branch survive reopen without reaching the 
 			const requestedBranch = url.searchParams.get("activeBranchId");
 			if (!suppliedSession) {
 				initialBranchRequests.push(requestedBranch);
-				expect(url.searchParams.has("activeAccountId")).toBe(false);
-				if (requestedBranch && !availableBranches.has(requestedBranch)) {
-					return Response.json(
-						{
-							error: {
-								code: "LIX_BRANCH_NOT_FOUND",
-								message: "Branch not found",
-								details: { branchId: requestedBranch },
-							},
-						},
-						{ status: 404 },
-					);
-				}
+				initialAccountRequests.push(url.searchParams.get("activeAccountId"));
 			}
 			const sessionId = suppliedSession ?? `session-${++nextSession}`;
 			if (!sessions.has(sessionId)) {
@@ -213,7 +201,7 @@ test("remote client state and active branch survive reopen without reaching the 
 
 	const second = await openLix(options);
 	try {
-		expect(await second.activeBranchId()).toBe("draft");
+		expect(await second.activeBranchId()).toBe("main");
 		await expect(second.clientState.get("atelier")).resolves.toEqual({
 			focusedPanel: "right",
 		});
@@ -222,25 +210,11 @@ test("remote client state and active branch survive reopen without reaching the 
 	} finally {
 		await second.close();
 	}
-
-	availableBranches.delete("draft");
-	const fallback = await openLix(options);
-	expect(await fallback.activeBranchId()).toBe("main");
-	await fallback.close();
-
-	const reopenedFallback = await openLix(options);
-	try {
-		expect(await reopenedFallback.activeBranchId()).toBe("main");
-		expect(initialBranchRequests).toEqual([
-			null,
-			"draft",
-			"draft",
-			null,
-			"main",
-		]);
-	} finally {
-		await reopenedFallback.close();
-	}
+	expect(initialBranchRequests).toEqual([null, null]);
+	expect(initialAccountRequests).toEqual([
+		null,
+		"00000000-0000-7000-8000-000000000002",
+	]);
 });
 
 test("IndexedDbStorage persists a complete local Lix", async () => {

--- a/packages/js-sdk/src/open-lix.test.ts
+++ b/packages/js-sdk/src/open-lix.test.ts
@@ -46,7 +46,13 @@ test("openLix forwards opt-in SQL telemetry from the engine", async () => {
 	const lix = await openLix({
 		telemetry: {
 			onSpan(span) {
-				if (span.name === "lix.sql.query") resolveSpan(span);
+				if (
+					span.name === "lix.sql.query" &&
+					span.attributes["db.query.text"] ===
+						"SELECT ? AS value, ? AS number"
+				) {
+					resolveSpan(span);
+				}
 			},
 		},
 	});

--- a/packages/js-sdk/src/open-lix.ts
+++ b/packages/js-sdk/src/open-lix.ts
@@ -5,7 +5,6 @@ import {
 import type { LixBinding } from "./binding-types.js";
 import {
 	ACTIVE_ACCOUNT_CLIENT_STATE_KEY,
-	ACTIVE_BRANCH_CLIENT_STATE_KEY,
 	openClientState,
 } from "./client-state.js";
 import { Lix } from "./lix.js";
@@ -138,25 +137,13 @@ export async function openLix(options: OpenLixOptions = {}): Promise<Lix> {
 
 		let remoteBinding: LixBinding | undefined;
 		try {
-			const restoredBranchId = await clientState.get<string>(
-				ACTIVE_BRANCH_CLIENT_STATE_KEY,
-			);
 			const restoredAccountId = await clientState.get<string>(
 				ACTIVE_ACCOUNT_CLIENT_STATE_KEY,
 			);
-			try {
-				remoteBinding = await openRemoteLixBinding(options.server, {
-					initialActiveBranchId: restoredBranchId,
-				});
-			} catch (error) {
-				if (!restoredBranchId || !isBranchNotFoundError(error)) throw error;
-				remoteBinding = await openRemoteLixBinding(options.server);
-			}
-			const activeBranchId = await remoteBinding.activeBranchId();
+			remoteBinding = await openRemoteLixBinding(options.server, {
+				initialActiveAccountId: restoredAccountId,
+			});
 			const activeAccountId = await remoteBinding.activeAccountId();
-			if (activeBranchId !== restoredBranchId) {
-				await clientState.set(ACTIVE_BRANCH_CLIENT_STATE_KEY, activeBranchId);
-			}
 			if (activeAccountId !== restoredAccountId) {
 				await clientState.set(ACTIVE_ACCOUNT_CLIENT_STATE_KEY, activeAccountId);
 			}
@@ -245,14 +232,4 @@ function remoteIndexedDbName(storageName: string, value: string | URL): string {
 	url.search = "";
 	url.hash = "";
 	return `${storageName}:remote:${url.href}`;
-}
-
-function isBranchNotFoundError(
-	error: unknown,
-): error is Error & { code: "LIX_BRANCH_NOT_FOUND" } {
-	return (
-		error instanceof Error &&
-		"code" in error &&
-		error.code === "LIX_BRANCH_NOT_FOUND"
-	);
 }

--- a/packages/lix/README.md
+++ b/packages/lix/README.md
@@ -4,7 +4,7 @@
 let lix = lix::open_lix().await?;
 ```
 
-`lix` opens an in-memory workspace by default. It owns Lix's SQL, files,
+`lix` opens an in-memory repository by default. It owns Lix's SQL, files,
 branches, transactions, and Wasmtime plugin runtime without pulling in a
 persistent backend.
 
@@ -20,6 +20,14 @@ let lix = open_lix().with_storage(storage).await?;
 # Ok(())
 # }
 ```
+
+`open_lix()` opens the client's primary session. Its active branch is restored
+from client state (`lix_primary_session_branch_id`) and falls back to the
+repository's tracked `lix_default_branch_id`, which points to `main` in a new
+repository. `lix.open_session()` creates an independent session on the primary
+session's current branch; `lix.open_session_at(branch_id)` selects a branch
+explicitly. Switching an independent session never changes the primary-session
+preference or the repository default.
 
 Storage adapters implement the public `lix::storage` contract and release on
 their own cadence. The official packages are `lix-storage-rocksdb`,

--- a/packages/lix/benches/diff_commands.rs
+++ b/packages/lix/benches/diff_commands.rs
@@ -185,7 +185,7 @@ async fn new_session() -> SessionContext<Memory> {
         .expect("initialize benchmark storage");
     let engine = Engine::new(storage).await.expect("open benchmark engine");
     engine
-        .open_workspace_session()
+        .open_session()
         .await
         .expect("open benchmark session")
 }

--- a/packages/lix/benches/entity_default_values.rs
+++ b/packages/lix/benches/entity_default_values.rs
@@ -27,7 +27,7 @@ fn fixture(runtime: &tokio::runtime::Runtime) -> SessionContext<Memory> {
             .expect("initialize benchmark storage");
         let engine = Engine::new(storage).await.expect("open benchmark engine");
         let session = engine
-            .open_workspace_session()
+            .open_session()
             .await
             .expect("open benchmark session");
         let schema = json!({

--- a/packages/lix/benches/profile_sql_point_queries.rs
+++ b/packages/lix/benches/profile_sql_point_queries.rs
@@ -60,7 +60,7 @@ async fn open_initialized(path: &Path) -> (SlateDB, SessionContext<SlateDB>) {
         .await
         .expect("open point-query engine");
     let session = engine
-        .open_workspace_session()
+        .open_session()
         .await
         .expect("open point-query session");
     (storage, session)
@@ -77,7 +77,7 @@ async fn setup(path: &Path, rows: usize) {
         .await
         .expect("open initialized point-query fixture");
     let session = engine
-        .open_workspace_session()
+        .open_session()
         .await
         .expect("open point-query setup session");
     let schema = serde_json::json!({

--- a/packages/lix/benches/profile_sql_result_streaming.rs
+++ b/packages/lix/benches/profile_sql_result_streaming.rs
@@ -249,7 +249,7 @@ async fn seed_fixture(rows: usize) -> SessionContext<Memory> {
         .await
         .expect("open result streaming profile engine");
     let session = engine
-        .open_workspace_session()
+        .open_session()
         .await
         .expect("open result streaming profile session");
     let rows_per_table = rows.div_ceil(PARTITIONS);

--- a/packages/lix/benches/registered_entity_returning.rs
+++ b/packages/lix/benches/registered_entity_returning.rs
@@ -466,7 +466,7 @@ async fn new_fixture() -> SessionContext<Memory> {
         .await
         .expect("open registered-entity RETURNING benchmark engine");
     let session = engine
-        .open_workspace_session()
+        .open_session()
         .await
         .expect("open registered-entity RETURNING benchmark session");
     let registration = session

--- a/packages/lix/benches/undo_redo.rs
+++ b/packages/lix/benches/undo_redo.rs
@@ -14,7 +14,7 @@ fn seeded_storage(runtime: &tokio::runtime::Runtime, history_depth: usize) -> Ve
             .await
             .expect("benchmark engine opens");
         let session = engine
-            .open_workspace_session()
+            .open_session()
             .await
             .expect("benchmark session opens");
         session
@@ -49,7 +49,7 @@ fn seeded_sparse_gap_storage(runtime: &tokio::runtime::Runtime, history_depth: u
             .await
             .expect("benchmark engine opens");
         let session = engine
-            .open_workspace_session()
+            .open_session()
             .await
             .expect("benchmark session opens");
         session
@@ -93,7 +93,7 @@ fn seeded_wide_parent_storage(runtime: &tokio::runtime::Runtime, parent_width: u
             .await
             .expect("benchmark engine opens");
         let session = engine
-            .open_workspace_session()
+            .open_session()
             .await
             .expect("benchmark session opens");
         session
@@ -140,7 +140,7 @@ fn seeded_wide_transition_storage(
             .await
             .expect("benchmark engine opens");
         let session = engine
-            .open_workspace_session()
+            .open_session()
             .await
             .expect("benchmark session opens");
         let before = "b".repeat(256);
@@ -188,7 +188,7 @@ fn seeded_descriptor_unrelated_width_storage(
             .await
             .expect("benchmark engine opens");
         let session = engine
-            .open_workspace_session()
+            .open_session()
             .await
             .expect("benchmark session opens");
         session
@@ -227,7 +227,7 @@ fn open_session(runtime: &tokio::runtime::Runtime, storage: Memory) -> SessionCo
         Engine::new(storage)
             .await
             .expect("benchmark engine opens")
-            .open_workspace_session()
+            .open_session()
             .await
             .expect("benchmark session opens")
     })

--- a/packages/lix/src/account.rs
+++ b/packages/lix/src/account.rs
@@ -153,7 +153,7 @@ mod tests {
         );
 
         let session = lix
-            .open_session_with_account(
+            .open_session_at_with_account(
                 lix.active_branch_id().await.expect("active branch"),
                 AUTHOR_ID,
             )
@@ -185,7 +185,7 @@ mod tests {
         );
 
         let system = lix
-            .open_session_with_account(
+            .open_session_at_with_account(
                 lix.active_branch_id().await.expect("active branch"),
                 crate::SYSTEM_ACCOUNT_ID,
             )

--- a/packages/lix/src/branch/lifecycle.rs
+++ b/packages/lix/src/branch/lifecycle.rs
@@ -12,7 +12,7 @@ pub(crate) enum BranchOperation {
     MergeBranch,
     MergeBranchPreview,
     CreateCheckpoint,
-    LoadWorkspaceSelector,
+    LoadDefaultBranch,
 }
 
 impl BranchOperation {
@@ -23,7 +23,7 @@ impl BranchOperation {
             Self::MergeBranch => "merge_branch",
             Self::MergeBranchPreview => "merge_branch_preview",
             Self::CreateCheckpoint => "create_checkpoint",
-            Self::LoadWorkspaceSelector => "load_workspace_branch_id",
+            Self::LoadDefaultBranch => "load_default_branch_id",
         }
     }
 }
@@ -32,7 +32,7 @@ impl BranchOperation {
 pub(crate) enum BranchReferenceRole {
     Source,
     Target,
-    WorkspaceSelector,
+    DefaultBranch,
     CommitSource,
 }
 
@@ -41,7 +41,7 @@ impl BranchReferenceRole {
         match self {
             Self::Source => "source",
             Self::Target => "target",
-            Self::WorkspaceSelector => "workspace_selector",
+            Self::DefaultBranch => "default_branch",
             Self::CommitSource => "commit_source",
         }
     }

--- a/packages/lix/src/catalog/revision.rs
+++ b/packages/lix/src/catalog/revision.rs
@@ -107,7 +107,7 @@ mod tests {
             .await
             .expect("engine should open");
         let session = engine
-            .open_session(&receipt.main_branch_id)
+            .open_session_at(&receipt.main_branch_id)
             .await
             .expect("main session should open");
         session
@@ -211,11 +211,11 @@ mod tests {
             .await
             .expect("second engine should open");
         let session_a = engine_a
-            .open_session(&receipt.main_branch_id)
+            .open_session_at(&receipt.main_branch_id)
             .await
             .expect("first session should open");
         let session_b = engine_b
-            .open_session(&receipt.main_branch_id)
+            .open_session_at(&receipt.main_branch_id)
             .await
             .expect("second session should open");
 
@@ -285,7 +285,7 @@ mod tests {
             .await
             .expect("engine should open");
         let session = engine
-            .open_session(&receipt.main_branch_id)
+            .open_session_at(&receipt.main_branch_id)
             .await
             .expect("main session should open");
         let initial_head = engine
@@ -347,7 +347,7 @@ mod tests {
         let adapter = StorageAdapter::new(storage.clone());
         let engine = Engine::new(storage).await.expect("engine should open");
         let main = engine
-            .open_session(&receipt.main_branch_id)
+            .open_session_at(&receipt.main_branch_id)
             .await
             .expect("main session should open");
         let revision_before_branch = current_revision(&adapter).await;
@@ -360,7 +360,7 @@ mod tests {
         .expect("draft branch should be created");
         assert_ne!(current_revision(&adapter).await, revision_before_branch);
         let draft = engine
-            .open_session(draft_branch_id)
+            .open_session_at(draft_branch_id)
             .await
             .expect("draft session should open");
         if diverge_target {

--- a/packages/lix/src/client_state.rs
+++ b/packages/lix/src/client_state.rs
@@ -6,8 +6,9 @@ use lix::{GLOBAL_BRANCH_ID, LixError, Memory, Value};
 
 // Client-state rows deliberately use ordinary `lix_key_value` entities. The
 // private physical prefix keeps their key identity disjoint from built-in and
-// workspace KV rows even when the client store is inspected through SQL.
+// repository KV rows even when the client store is inspected through SQL.
 const CLIENT_STATE_KEY_PREFIX: &str = "lix_client_state:";
+pub(crate) const PRIMARY_SESSION_BRANCH_KEY: &str = "lix_primary_session_branch_id";
 
 const GET_SQL: &str = "SELECT value \
     FROM lix_key_value_by_branch \
@@ -42,7 +43,7 @@ const DELETE_SQL: &str = "DELETE FROM lix_key_value_by_branch \
 ///
 /// Placement is determined by which Lix owns this handle. Remote SDKs should
 /// construct this handle from their local client-only Lix, not from the remote
-/// workspace Lix.
+/// repository Lix.
 #[derive(Clone, Copy)]
 #[expect(missing_debug_implementations)]
 pub struct ClientState<'lix, StorageImpl = Memory>

--- a/packages/lix/src/common/error.rs
+++ b/packages/lix/src/common/error.rs
@@ -130,7 +130,7 @@ impl LixError {
     /// engine never guesses identity authority from equal byte hashes.
     pub const CODE_PLUGIN_OBSERVATION_STALE: &'static str = "LIX_ERROR_PLUGIN_OBSERVATION_STALE";
 
-    /// Creating another live plugin Store would exceed the workspace-wide
+    /// Creating another live plugin Store would exceed the repository-wide
     /// runtime admission limit configured for this Engine.
     pub const CODE_PLUGIN_RESOURCE_LIMIT: &'static str = "LIX_ERROR_PLUGIN_RESOURCE_LIMIT";
 

--- a/packages/lix/src/engine.rs
+++ b/packages/lix/src/engine.rs
@@ -93,7 +93,7 @@ impl EngineOptions {
     /// 1.875 GiB before host-side document state. Cached actors, active
     /// existing-document transaction leases, pending publications, cold-open
     /// candidates, and upgrade preflight Stores consume the same
-    /// workspace-wide budget. Completed publications may retire their Stores
+    /// repository-wide budget. Completed publications may retire their Stores
     /// under pressure and cold-open again after commit.
     pub fn with_plugin_resource_limits(
         mut self,
@@ -223,22 +223,22 @@ where
         Ok(result)
     }
 
-    pub async fn open_session(
+    pub async fn open_session_at(
         &self,
         active_branch_id: impl Into<String>,
     ) -> Result<SessionContext<StorageImpl>, LixError> {
-        self.open_session_with_account(active_branch_id, crate::ANONYMOUS_ACCOUNT_ID)
+        self.open_session_at_with_account(active_branch_id, crate::ANONYMOUS_ACCOUNT_ID)
             .await
     }
 
-    pub async fn open_session_with_account(
+    pub async fn open_session_at_with_account(
         &self,
         active_branch_id: impl Into<String>,
         active_account_id: impl Into<String>,
     ) -> Result<SessionContext<StorageImpl>, LixError> {
         let active_account_id = active_account_id.into();
         self.validate_active_account(&active_account_id).await?;
-        SessionContext::open(
+        SessionContext::open_at(
             active_branch_id.into(),
             active_account_id,
             self.storage(),
@@ -259,18 +259,18 @@ where
         .await
     }
 
-    pub async fn open_workspace_session(&self) -> Result<SessionContext<StorageImpl>, LixError> {
-        self.open_workspace_session_with_account(crate::ANONYMOUS_ACCOUNT_ID)
+    pub async fn open_session(&self) -> Result<SessionContext<StorageImpl>, LixError> {
+        self.open_session_with_account(crate::ANONYMOUS_ACCOUNT_ID)
             .await
     }
 
-    pub async fn open_workspace_session_with_account(
+    pub async fn open_session_with_account(
         &self,
         active_account_id: impl Into<String>,
     ) -> Result<SessionContext<StorageImpl>, LixError> {
         let active_account_id = active_account_id.into();
         self.validate_active_account(&active_account_id).await?;
-        SessionContext::open_workspace(
+        SessionContext::open_default(
             active_account_id,
             self.storage(),
             Arc::clone(&self.hot_state),
@@ -298,7 +298,7 @@ where
     }
 
     /// Resets the process-local v2 transition aggregate used by profiling and
-    /// invariant tests. This does not mutate durable workspace state.
+    /// invariant tests. This does not mutate durable repository state.
     #[doc(hidden)]
     pub fn reset_plugin_transition_counters(&self) {
         self.plugin_host.reset_transition_counters();
@@ -994,9 +994,9 @@ mod tests {
             .await
             .expect("initialized engine should open");
         let session = engine
-            .open_workspace_session()
+            .open_session()
             .await
-            .expect("workspace session should open");
+            .expect("session should open");
         register_json_pointer_schema(&session).await;
         assert_eq!(
             session
@@ -1043,9 +1043,9 @@ mod tests {
             .await
             .expect("initialized engine should open");
         let session = engine
-            .open_workspace_session()
+            .open_session()
             .await
-            .expect("workspace session should open");
+            .expect("session should open");
         register_json_pointer_schema(&session).await;
 
         // These values exercise the order-preserving tracked-head codec's
@@ -1116,9 +1116,9 @@ mod tests {
             .await
             .expect("initialized engine should open");
         let session = engine
-            .open_workspace_session()
+            .open_session()
             .await
-            .expect("workspace session should open");
+            .expect("session should open");
         register_json_pointer_schema(&session).await;
         session
             .execute(
@@ -1167,9 +1167,9 @@ mod tests {
             .await
             .expect("initialized engine should open");
         let session = engine
-            .open_workspace_session()
+            .open_session()
             .await
-            .expect("workspace session should open");
+            .expect("session should open");
         register_json_pointer_schema(&session).await;
         session
             .execute(
@@ -1305,9 +1305,9 @@ mod tests {
             .await
             .expect("initialized engine should open");
         let session = engine
-            .open_workspace_session()
+            .open_session()
             .await
-            .expect("workspace session should open");
+            .expect("session should open");
         register_json_pointer_schema(&session).await;
 
         let head_before = engine
@@ -1409,9 +1409,9 @@ mod tests {
             .await
             .expect("initialized engine should open");
         let session = engine
-            .open_workspace_session()
+            .open_session()
             .await
-            .expect("workspace session should open");
+            .expect("session should open");
         register_json_pointer_schema(&session).await;
 
         for path in ["/clean", "/modified", "/removed", "/recycled-source"] {
@@ -1626,9 +1626,9 @@ mod tests {
             .await
             .expect("initialized engine should open");
         let session = engine
-            .open_workspace_session()
+            .open_session()
             .await
-            .expect("workspace session should open");
+            .expect("session should open");
         register_json_pointer_schema(&session).await;
 
         let files = [
@@ -1867,9 +1867,9 @@ mod tests {
             .await
             .expect("initialized engine should open");
         let session = engine
-            .open_workspace_session()
+            .open_session()
             .await
-            .expect("workspace session should open");
+            .expect("session should open");
         register_json_pointer_schema(&session).await;
 
         let files = ["66696c65-0000-8000-8000-000000000000", "66696c65-0001-8000-8000-000000000001"];
@@ -2040,9 +2040,9 @@ mod tests {
             .await
             .expect("initialized engine should open");
         let session = engine
-            .open_workspace_session()
+            .open_session()
             .await
-            .expect("workspace session should open");
+            .expect("session should open");
         register_json_pointer_schema(&session).await;
         session
             .execute(
@@ -2130,9 +2130,9 @@ mod tests {
             .await
             .expect("initialized engine should open");
         let session = engine
-            .open_workspace_session()
+            .open_session()
             .await
-            .expect("workspace session should open");
+            .expect("session should open");
         register_json_pointer_schema(&session).await;
         session
             .execute(
@@ -2209,7 +2209,7 @@ mod tests {
             .await
             .expect("initialized engine should open");
         let global_session = engine
-            .open_session(GLOBAL_BRANCH_ID)
+            .open_session_at(GLOBAL_BRANCH_ID)
             .await
             .expect("global session should open");
         register_global_json_pointer_schema(&global_session).await;
@@ -2223,9 +2223,9 @@ mod tests {
             .expect("write global tracked entity row");
 
         let session = engine
-            .open_workspace_session()
+            .open_session()
             .await
-            .expect("workspace session should open");
+            .expect("session should open");
         register_json_pointer_schema(&session).await;
         let rows = session
             .execute("SELECT path, value FROM json_pointer ORDER BY path", &[])
@@ -2251,9 +2251,9 @@ mod tests {
             .await
             .expect("initialized engine should open");
         let session = engine
-            .open_workspace_session()
+            .open_session()
             .await
-            .expect("workspace session should open");
+            .expect("session should open");
 
         let rows = session
             .execute("SELECT id, commit_id FROM lix_branch_ref ORDER BY id", &[])
@@ -2368,7 +2368,7 @@ mod tests {
             .await
             .expect("engine should open");
         let session = engine
-            .open_workspace_session()
+            .open_session()
             .await
             .expect("session should open");
         for schema in [
@@ -2470,7 +2470,7 @@ mod tests {
             .await
             .expect("engine should open");
         let session = engine
-            .open_workspace_session()
+            .open_session()
             .await
             .expect("session should open");
         (storage, session)

--- a/packages/lix/src/gc.rs
+++ b/packages/lix/src/gc.rs
@@ -4255,7 +4255,7 @@ mod tests {
             .await
             .expect("untracked-file repository should open");
         let session = engine
-            .open_workspace_session()
+            .open_session()
             .await
             .expect("untracked-file session should open");
         let live_bytes = b"current-only-untracked-file-blob";
@@ -4317,7 +4317,7 @@ mod tests {
             .await
             .expect("repository should cold reopen after untracked-file GC");
         let reopened_session = reopened
-            .open_workspace_session()
+            .open_session()
             .await
             .expect("cold untracked-file session should open");
         let content = reopened_session
@@ -4362,7 +4362,7 @@ mod tests {
         .await
         .expect("plugin-GC repository should open");
         let session = engine
-            .open_workspace_session()
+            .open_session()
             .await
             .expect("plugin-GC session should open");
         let (archive, wasm) = gc_csv_plugin_archive();
@@ -4418,7 +4418,7 @@ mod tests {
         .await
         .expect("plugin-GC repository should cold reopen");
         let session = engine
-            .open_workspace_session()
+            .open_session()
             .await
             .expect("cold plugin-GC session should open");
         session
@@ -4456,7 +4456,7 @@ mod tests {
         .await
         .expect("shared-plugin repository should open");
         let session = engine
-            .open_workspace_session()
+            .open_session()
             .await
             .expect("shared-plugin session should open");
         let (archive, wasm) = gc_csv_plugin_archive();
@@ -4946,9 +4946,9 @@ mod tests {
             .await
             .expect("repository should open");
         let session = engine
-            .open_workspace_session()
+            .open_session()
             .await
-            .expect("workspace session should open");
+            .expect("session should open");
         let schema = serde_json::json!({
             "x-lix-key": "gc_history_fixture",
             "x-lix-primary-key": ["/path"],
@@ -5070,9 +5070,9 @@ mod tests {
             .await
             .expect("repository should reopen after GC");
         let session = reopened_engine
-            .open_workspace_session()
+            .open_session()
             .await
-            .expect("reopened workspace session should open");
+            .expect("reopened session should open");
         let head = session
             .execute("SELECT commit_id FROM lix_branch WHERE name = 'main'", &[])
             .await
@@ -5103,7 +5103,7 @@ mod tests {
             .await
             .expect("historical blob repository should open");
         let main = engine
-            .open_workspace_session()
+            .open_session()
             .await
             .expect("historical blob main session should open");
         let branch = main
@@ -5116,7 +5116,7 @@ mod tests {
             .expect("historical disposable branch should create");
         let branch_id = branch.id;
         let session = engine
-            .open_session(branch_id.clone())
+            .open_session_at(branch_id.clone())
             .await
             .expect("historical disposable session should open");
         let v1 = b"historical-file-v1";
@@ -5169,7 +5169,7 @@ mod tests {
             .await
             .expect("historical blob repository should cold reopen");
         let session = reopened
-            .open_session(branch_id.clone())
+            .open_session_at(branch_id.clone())
             .await
             .expect("historical disposable branch should cold reopen");
         let diff = session
@@ -5208,7 +5208,7 @@ mod tests {
         drop(session);
 
         let main = reopened
-            .open_workspace_session()
+            .open_session()
             .await
             .expect("historical main session should reopen");
         main.execute(
@@ -5231,7 +5231,7 @@ mod tests {
             .await
             .expect("historical repository should reopen after branch retirement");
         let final_main = final_engine
-            .open_workspace_session()
+            .open_session()
             .await
             .expect("historical main should open after branch retirement");
         let branches = final_main
@@ -6105,7 +6105,7 @@ mod tests {
             .await
             .expect("generation fixture should open");
         let session = engine
-            .open_workspace_session()
+            .open_session()
             .await
             .expect("generation fixture session should open");
         let schema = serde_json::json!({
@@ -6147,7 +6147,7 @@ mod tests {
             .await
             .expect("generation fixture branch should create");
         let branch_session = engine
-            .open_session(branch.id.clone())
+            .open_session_at(branch.id.clone())
             .await
             .expect("generation fixture branch session should open");
         for row in 0..16 {

--- a/packages/lix/src/handle.rs
+++ b/packages/lix/src/handle.rs
@@ -19,7 +19,7 @@ use crate::client_state::ClientState;
 use crate::engine::{Engine, EngineOptions};
 use crate::session::SessionContext;
 
-/// Configures a Lix workspace session before it is opened.
+/// Configures the primary session for a Lix repository.
 ///
 /// The default builder opens an in-memory Lix. Configure a persistent adapter
 /// with [`OpenLixBuilder::with_storage`] and then await the builder.
@@ -66,7 +66,12 @@ impl<StorageImpl> OpenLixBuilder<StorageImpl> {
     }
 }
 
-/// Starts configuring a Lix workspace session.
+/// Starts configuring the primary session for a Lix repository.
+///
+/// The primary session restores `lix_primary_session_branch_id` from client
+/// state. When that preference is absent or names a deleted branch, it starts
+/// on the repository's tracked `lix_default_branch_id` and records the result
+/// in client state.
 ///
 /// Await the returned builder to open a new in-memory Lix:
 ///
@@ -88,18 +93,24 @@ where
     type IntoFuture = Pin<Box<dyn Future<Output = Self::Output> + Send>>;
 
     fn into_future(self) -> Self::IntoFuture {
-        Box::pin(
-            async move { open_lix_inner(self.storage, self.wasm_runtime, self.telemetry).await },
-        )
+        // SAFETY: the builder owns Send storage/runtime/telemetry values, and
+        // the returned Lix contains only Send synchronization primitives. The
+        // compiler cannot prove the deeply nested SQL futures are Send across
+        // the primary-session client-state restoration path.
+        Box::pin(unsafe {
+            crate::session::AssumeSendFuture::new(async move {
+                open_lix_inner(self.storage, self.wasm_runtime, self.telemetry).await
+            })
+        })
     }
 }
 
-/// Clonable workspace-session handle for a Lix repository.
+/// Clonable session handle for a Lix repository.
 ///
 /// Clones are concurrent handles to the same logical session: they share the
-/// active workspace branch, transaction exclusion, file-view state, and close
+/// active branch, transaction exclusion, file-view state, and close
 /// lifecycle. Use [`Lix::open_session`] when an operation needs an independent
-/// pinned session and lifecycle.
+/// session and lifecycle.
 #[derive(Clone)]
 #[expect(missing_debug_implementations)]
 pub struct Lix<StorageImpl = Memory>
@@ -108,6 +119,7 @@ where
 {
     engine: Arc<Engine<StorageImpl>>,
     session: Arc<SessionContext<StorageImpl>>,
+    primary_switch_gate: Option<Arc<tokio::sync::Mutex<()>>>,
 }
 
 async fn open_lix_inner<StorageImpl>(
@@ -119,11 +131,38 @@ where
     StorageImpl: Storage + Clone + Send + Sync + 'static,
 {
     let engine = open_or_initialize_engine(storage, wasm_runtime, telemetry, None).await?;
-    let session = engine.open_workspace_session().await?;
-    Ok(Lix {
+    let session = engine.open_session().await?;
+    let lix = Lix {
         engine: Arc::new(engine),
         session: Arc::new(session),
-    })
+        primary_switch_gate: Some(Arc::new(tokio::sync::Mutex::new(()))),
+    };
+    let stored_branch_id = lix
+        .client_state()
+        .get(crate::client_state::PRIMARY_SESSION_BRANCH_KEY)
+        .await?
+        .and_then(|value| value.as_str().map(str::to_owned))
+        .filter(|value| !value.is_empty());
+    if let Some(branch_id) = stored_branch_id.as_deref()
+        && lix.engine.load_branch_head_commit_id(branch_id).await?.is_some()
+        && branch_id != lix.active_branch_id().await?
+    {
+        lix.session
+            .switch_branch(SwitchBranchOptions {
+                branch_id: branch_id.to_string(),
+            })
+            .await?;
+    }
+    let active_branch_id = lix.active_branch_id().await?;
+    if stored_branch_id.as_deref() != Some(active_branch_id.as_str()) {
+        lix.client_state()
+            .set(
+                crate::client_state::PRIMARY_SESSION_BRANCH_KEY,
+                serde_json::Value::String(active_branch_id),
+            )
+            .await?;
+    }
+    Ok(lix)
 }
 
 impl<StorageImpl> Lix<StorageImpl>
@@ -133,51 +172,46 @@ where
     /// Returns a borrowed handle to JSON state owned by this client storage.
     ///
     /// Remote SDK integrations should expose this handle from a separate
-    /// client-only local Lix while continuing to route workspace operations to
-    /// the remote Lix.
+    /// client-only local Lix while continuing to route repository operations
+    /// to the remote Lix.
     pub fn client_state(&self) -> ClientState<'_, StorageImpl> {
         ClientState::new(self)
     }
 
-    /// Opens another workspace session on this handle's existing engine.
+    /// Opens an independent session on this handle's current branch.
     ///
     /// The returned handle has independent session-local state, including its
     /// acknowledged plugin file views and lifecycle. It deliberately clones
     /// the existing [`Engine`] instead of constructing another engine over the
     /// same storage, so engine-wide collaboration and runtime gates remain
     /// shared by every session.
-    pub async fn open_workspace_session(&self) -> Result<Self, LixError> {
+    pub async fn open_session(&self) -> Result<Self, LixError> {
         if self.session.is_closed() {
             return Err(LixError::new(
                 LixError::CODE_CLOSED,
-                "cannot open a workspace session from a closed Lix handle",
+                "cannot open a session from a closed Lix handle",
             ));
         }
-        let session = self.engine.open_workspace_session().await?;
-        Ok(Self {
-            engine: self.engine.clone(),
-            session: Arc::new(session),
-        })
+        let active_branch_id = self.active_branch_id().await?;
+        self.open_session_at(active_branch_id).await
     }
 
-    /// Opens an independent session pinned to `active_branch_id` on this
-    /// handle's existing engine.
+    /// Opens an independent session on `active_branch_id` using this handle's
+    /// existing engine.
     ///
-    /// Unlike a workspace session, a pinned session never reads or writes the
-    /// shared workspace branch selector. The requested branch is validated
-    /// before the child handle is returned. Branch switches update this
-    /// handle and its clones in place.
-    pub async fn open_session(
+    /// The requested branch is validated before the new handle is returned.
+    /// Branch switches update that handle and its clones in place.
+    pub async fn open_session_at(
         &self,
         active_branch_id: impl Into<String>,
     ) -> Result<Self, LixError> {
-        self.open_session_with_account(active_branch_id, lix::ANONYMOUS_ACCOUNT_ID)
+        self.open_session_at_with_account(active_branch_id, lix::ANONYMOUS_ACCOUNT_ID)
             .await
     }
 
-    /// Opens an independent branch-pinned session whose changes are attributed
-    /// to `active_account_id`.
-    pub async fn open_session_with_account(
+    /// Opens an independent session on `active_branch_id` whose changes are
+    /// attributed to `active_account_id`.
+    pub async fn open_session_at_with_account(
         &self,
         active_branch_id: impl Into<String>,
         active_account_id: impl Into<String>,
@@ -185,7 +219,7 @@ where
         if self.session.is_closed() {
             return Err(LixError::new(
                 LixError::CODE_CLOSED,
-                "cannot open a pinned session from a closed Lix handle",
+                "cannot open a session from a closed Lix handle",
             ));
         }
         let active_branch_id = active_branch_id.into();
@@ -203,11 +237,12 @@ where
         }
         let session = self
             .engine
-            .open_session_with_account(active_branch_id, active_account_id)
+            .open_session_at_with_account(active_branch_id, active_account_id)
             .await?;
         Ok(Self {
             engine: self.engine.clone(),
             session: Arc::new(session),
+            primary_switch_gate: None,
         })
     }
 
@@ -436,7 +471,7 @@ where
     pub async fn ensure_account(&self, id: &str, name: &str, kind: &str) -> Result<(), LixError> {
         let branch_id = self.active_branch_id().await?;
         let system = self
-            .open_session_with_account(branch_id, lix::SYSTEM_ACCOUNT_ID)
+            .open_session_at_with_account(branch_id, lix::SYSTEM_ACCOUNT_ID)
             .await?;
         system
             .execute(
@@ -477,11 +512,31 @@ where
         self.session.redo().await
     }
 
-    pub async fn switch_branch(
+    pub fn switch_branch(
         &self,
         options: SwitchBranchOptions,
-    ) -> Result<SwitchBranchReceipt, LixError> {
-        self.session.switch_branch(options).await
+    ) -> impl Future<Output = Result<SwitchBranchReceipt, LixError>> + Send + '_ {
+        // SAFETY: the future borrows a Send + Sync Lix handle and owns its
+        // switch options. The compiler cannot prove the nested client-state
+        // SQL future is Send for every storage read lifetime.
+        unsafe {
+            crate::session::AssumeSendFuture::new(async move {
+                let _primary_switch_guard = match &self.primary_switch_gate {
+                    Some(gate) => Some(gate.lock().await),
+                    None => None,
+                };
+                let receipt = self.session.switch_branch(options).await?;
+                if self.primary_switch_gate.is_some() {
+                    self.client_state()
+                        .set(
+                            crate::client_state::PRIMARY_SESSION_BRANCH_KEY,
+                            serde_json::Value::String(receipt.branch_id.clone()),
+                        )
+                        .await?;
+                }
+                Ok(receipt)
+            })
+        }
     }
 
     pub async fn merge_branch(
@@ -644,14 +699,14 @@ mod tests {
     use super::*;
 
     #[tokio::test]
-    async fn workspace_sessions_share_one_engine_but_have_independent_lifecycles() {
+    async fn sessions_share_one_engine_but_have_independent_lifecycles() {
         let root = open_lix().await.expect("open root Lix");
         let first = root
-            .open_workspace_session()
+            .open_session()
             .await
             .expect("open first child session");
         let second = root
-            .open_workspace_session()
+            .open_session()
             .await
             .expect("open second child session");
 
@@ -672,7 +727,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn pinned_sessions_validate_and_retain_branch_switches() {
+    async fn sessions_validate_and_retain_branch_switches() {
         let root = open_lix().await.expect("open root Lix");
         let main_branch_id = root.active_branch_id().await.expect("main branch");
         let draft = root
@@ -684,33 +739,107 @@ mod tests {
             .await
             .expect("create draft");
 
-        let pinned = root
-            .open_session(main_branch_id.clone())
+        let session = root
+            .open_session_at(main_branch_id.clone())
             .await
-            .expect("open pinned main session");
-        let pinned_clone = pinned.clone();
-        let receipt = pinned
+            .expect("open main session");
+        let session_clone = session.clone();
+        let receipt = session
             .switch_branch(SwitchBranchOptions {
                 branch_id: draft.id.clone(),
             })
             .await
-            .expect("switch pinned session");
+            .expect("switch session");
 
         assert_eq!(receipt.branch_id, draft.id);
         assert_eq!(
-            pinned.active_branch_id().await.unwrap(),
+            session.active_branch_id().await.unwrap(),
             "01920000-0000-7000-8000-000000000501"
         );
         assert_eq!(
-            pinned_clone.active_branch_id().await.unwrap(),
+            session_clone.active_branch_id().await.unwrap(),
             "01920000-0000-7000-8000-000000000501"
         );
         assert_eq!(root.active_branch_id().await.unwrap(), main_branch_id);
 
-        let Err(error) = root.open_session("missing-branch").await else {
+        let Err(error) = root.open_session_at("missing-branch").await else {
             panic!("missing branch must not open");
         };
         assert_eq!(error.code, LixError::CODE_BRANCH_NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn primary_session_restores_its_branch_without_changing_repository_default() {
+        let storage = Memory::new();
+        let primary = open_lix()
+            .with_storage(storage.clone())
+            .await
+            .expect("open primary session");
+        let main_branch_id = primary.active_branch_id().await.expect("main branch");
+        let draft = primary
+            .create_branch(CreateBranchOptions {
+                id: Some("01920000-0000-7000-8000-000000000502".to_string()),
+                name: "Primary draft".to_string(),
+                from_commit_id: None,
+            })
+            .await
+            .expect("create draft");
+
+        primary
+            .switch_branch(SwitchBranchOptions {
+                branch_id: draft.id.clone(),
+            })
+            .await
+            .expect("switch primary session");
+        let secondary = primary.open_session().await.expect("open secondary session");
+        secondary
+            .switch_branch(SwitchBranchOptions {
+                branch_id: main_branch_id.clone(),
+            })
+            .await
+            .expect("switch secondary session");
+        secondary.close().await.expect("close secondary session");
+        primary.close().await.expect("close primary session");
+
+        let reopened = open_lix()
+            .with_storage(storage.clone())
+            .await
+            .expect("reopen primary session");
+        assert_eq!(reopened.active_branch_id().await.unwrap(), draft.id);
+
+        let engine = Engine::new(storage.clone())
+            .await
+            .expect("reopen repository engine");
+        let repository_default = engine.open_session().await.expect("open default session");
+        assert_eq!(
+            repository_default.active_branch_id().await.unwrap(),
+            main_branch_id,
+            "primary-session switching must not mutate lix_default_branch_id"
+        );
+
+        repository_default
+            .execute(
+                "DELETE FROM lix_branch WHERE id = $1",
+                &[Value::Text(draft.id)],
+            )
+            .await
+            .expect("non-default draft should delete");
+        reopened.close().await.expect("close restored primary session");
+        repository_default
+            .close()
+            .await
+            .expect("close repository-default session");
+        drop(engine);
+
+        let fallback = open_lix()
+            .with_storage(storage)
+            .await
+            .expect("missing primary preference should fall back");
+        assert_eq!(
+            fallback.active_branch_id().await.unwrap(),
+            main_branch_id,
+            "a deleted primary preference must fall back to lix_default_branch_id"
+        );
     }
 
     #[tokio::test]
@@ -727,7 +856,7 @@ mod tests {
             .expect("provision unused account");
 
         let author = root
-            .open_session_with_account(
+            .open_session_at_with_account(
                 root.active_branch_id().await.expect("active branch"),
                 AUTHOR_ID,
             )
@@ -767,7 +896,7 @@ mod tests {
         );
 
         let system = root
-            .open_session_with_account(
+            .open_session_at_with_account(
                 root.active_branch_id().await.expect("active branch"),
                 lix::SYSTEM_ACCOUNT_ID,
             )
@@ -797,7 +926,7 @@ mod tests {
         );
 
         let unused = root
-            .open_session_with_account(
+            .open_session_at_with_account(
                 root.active_branch_id().await.expect("active branch"),
                 UNUSED_ID,
             )

--- a/packages/lix/src/hot_index_aging_probe.rs
+++ b/packages/lix/src/hot_index_aging_probe.rs
@@ -44,7 +44,7 @@ async fn open_session() -> (Memory, SessionContext<Memory>) {
         .await
         .expect("engine should open");
     let session = engine
-        .open_workspace_session()
+        .open_session()
         .await
         .expect("session should open");
     (storage, session)

--- a/packages/lix/src/hot_row_tombstone_probe.rs
+++ b/packages/lix/src/hot_row_tombstone_probe.rs
@@ -50,7 +50,7 @@ async fn open_session() -> (Memory, SessionContext<Memory>) {
         .await
         .expect("engine should open");
     let session = engine
-        .open_workspace_session()
+        .open_session()
         .await
         .expect("session should open");
     (storage, session)

--- a/packages/lix/src/hot_state/context.rs
+++ b/packages/lix/src/hot_state/context.rs
@@ -1018,7 +1018,7 @@ where
         // Even an untracked-only exact batch therefore needs the branch
         // controls that select the active generation; treating that request
         // as "not tracked" used to skip the controls entirely and made the
-        // workspace selector (an untracked row) invisible after hot-index init.
+        // global untracked rows invisible after hot-index initialization.
         let scope = scan_scope(
             &self.store,
             &scope_request,

--- a/packages/lix/src/init.rs
+++ b/packages/lix/src/init.rs
@@ -37,21 +37,21 @@ use serde_json::json;
 
 const KEY_VALUE_SCHEMA_KEY: &str = "lix_key_value";
 const LIX_ID_KEY: &str = "lix_id";
-const WORKSPACE_BRANCH_KEY: &str = "lix_workspace_branch_id";
+pub(crate) const DEFAULT_BRANCH_KEY: &str = "lix_default_branch_id";
 const REGISTERED_SCHEMA_KEY: &str = "lix_registered_schema";
 
 /// Repository-wide compatibility gate for physical storage protocols.
 ///
-/// V65 removes per-row ChangeId copies from directly addressable immutable
-/// mutation leaves. The hard cut rejects repositories whose packed history
-/// predates that physical authority instead of retaining a second decoder.
+/// V66 makes the repository default branch a tracked bootstrap fact and
+/// removes the mutable workspace-branch selector. The hard cut rejects older
+/// repositories instead of inferring or migrating the removed selector.
 pub(crate) const REPOSITORY_PROTOCOL_SPACE: StorageSpace = StorageSpace::declare(
     StorageSpaceId(0x0004_0011),
     "repository.protocol.v1",
     ValueSemantics::Mutable,
 );
 pub(crate) const REPOSITORY_PROTOCOL_KEY: &[u8] = b"current";
-const REPOSITORY_PROTOCOL_VALUE: &[u8] = b"direct-change-id-leaf.v65";
+const REPOSITORY_PROTOCOL_VALUE: &[u8] = b"tracked-default-branch.v66";
 
 /// Raw status of the repository protocol marker. Engine opening consults this
 /// before it touches any tracked-head space, whose physical IDs deliberately
@@ -103,13 +103,11 @@ pub(crate) fn unsupported_repository_protocol_error() -> LixError {
 ///
 /// Tracked bootstrap facts go to the changelog. Moving heads are seeded in
 /// the direct current-state control plane and retain a standalone immutable
-/// branch-ref ledger change; ordinary untracked data shares the same current
-/// state generation without creating a changelog fact.
+/// branch-ref ledger change.
 pub(crate) struct InitSeedPlan {
     commit: InitSeedCommit,
     changes: Vec<InitSeedChange>,
     branch_controls: Vec<InitBranchHeadControl>,
-    untracked_rows: Vec<InitSeedLiveRow>,
     pub(crate) receipt: InitReceipt,
 }
 
@@ -284,11 +282,11 @@ pub(crate) fn plan_init_seed(functions: FunctionProviderHandle) -> Result<InitSe
         },
         branch_ref_change: main_branch_ref_change,
     };
-    let workspace_branch_row = untracked_row(
+    let default_branch_change = canonical_change(
         functions.call_uuid_v7(),
-        EntityPk::single(WORKSPACE_BRANCH_KEY),
+        EntityPk::single(DEFAULT_BRANCH_KEY),
         KEY_VALUE_SCHEMA_KEY,
-        key_value_snapshot(WORKSPACE_BRANCH_KEY, &main_branch_id)?,
+        key_value_snapshot(DEFAULT_BRANCH_KEY, &main_branch_id)?,
         timestamp,
     );
 
@@ -300,13 +298,13 @@ pub(crate) fn plan_init_seed(functions: FunctionProviderHandle) -> Result<InitSe
                 global_branch_descriptor_change,
                 main_branch_descriptor_change,
                 kv_lix_id_change,
+                default_branch_change,
                 initial_checkpoint_change,
                 system_account_change,
                 anonymous_account_change,
             ])
             .collect(),
         branch_controls: vec![global_branch_control, main_branch_control],
-        untracked_rows: vec![workspace_branch_row],
         receipt: InitReceipt {
             lix_id,
             global_branch_id: GLOBAL_BRANCH_ID.to_string(),
@@ -456,26 +454,6 @@ where
             if branch.branch_id != GLOBAL_BRANCH_ID {
                 head_deltas.retain(|delta| delta.schema_key != CHECKPOINT_SCHEMA_KEY);
             }
-            if branch.branch_id == GLOBAL_BRANCH_ID {
-                head_deltas.extend(plan.untracked_rows.iter().map(|row| CurrentStateDeltaRef {
-                    schema_key: &row.schema_key,
-                    file_id: None,
-                    entity_pk: &row.entity_pk,
-                    // The seed already minted this id (`untracked_row`, via the
-                    // functions provider). Init stages straight into the head
-                    // without passing the transaction prepared-row path, so
-                    // carrying it here is what gives the seed row an identity.
-                    change_id: Some(row.id),
-                    commit_id: None,
-                    untracked: true,
-                    deleted: false,
-                    created_at: row.created_at,
-                    updated_at: row.updated_at,
-                    snapshot: crate::json_store::JsonSlotRef::Inline(&row.snapshot_content),
-                    metadata: crate::json_store::JsonSlotRef::None,
-                    columnar_base_coordinate: None,
-                }));
-            }
             let mut working_diff_coverage = WorkingDiffIndexCoverage::default();
             tracked_head
                 .writer(&read, &mut writes)
@@ -591,11 +569,6 @@ fn stage_init_json_payloads(
             .iter()
             .map(|change| change.snapshot_content.as_str())
             .chain(
-                plan.untracked_rows
-                    .iter()
-                    .map(|row| row.snapshot_content.as_str()),
-            )
-            .chain(
                 plan.branch_controls
                     .iter()
                     .map(|branch| branch.branch_ref_change.snapshot_content.as_str()),
@@ -629,25 +602,6 @@ async fn stage_init_changelog_commit(
             changes,
         })
         .await
-}
-
-fn untracked_row(
-    id: uuid::Uuid,
-    entity_pk: EntityPk,
-    schema_key: &str,
-    snapshot_content: String,
-    timestamp: LixTimestamp,
-) -> InitSeedLiveRow {
-    InitSeedLiveRow {
-        id: ChangeId::from(id),
-        entity_pk,
-        schema_key: schema_key.to_string(),
-        snapshot_content,
-        created_at: timestamp,
-        updated_at: timestamp,
-        global: true,
-        branch_id: GLOBAL_BRANCH_ID.to_string(),
-    }
 }
 
 /// The direct control owns a branch ref's current visibility, while this
@@ -746,11 +700,10 @@ mod tests {
     use crate::tracked_state::TrackedStateContext;
 
     #[test]
-    fn plan_init_seed_returns_tracked_changes_and_untracked_workspace_state() {
+    fn plan_init_seed_returns_tracked_repository_bootstrap_changes() {
         let plan = plan_init_seed(test_functions()).expect("init seed should plan");
 
-        assert_eq!(plan.changes.len(), seed_schema_definitions().len() + 6);
-        assert_eq!(plan.untracked_rows.len(), 1);
+        assert_eq!(plan.changes.len(), seed_schema_definitions().len() + 7);
         assert_eq!(plan.receipt.global_branch_id, GLOBAL_BRANCH_ID);
         assert_eq!(plan.receipt.main_branch_id, test_uuid(1));
         assert_eq!(plan.receipt.lix_id, test_uuid(2));
@@ -783,7 +736,7 @@ mod tests {
             .iter()
             .map(|change| change.id.to_string())
             .collect::<Vec<_>>();
-        assert_eq!(change_ids.len(), seed_schema_definitions().len() + 6);
+        assert_eq!(change_ids.len(), seed_schema_definitions().len() + 7);
         let first_seed_change_id = test_uuid(4);
         assert!(change_ids.contains(&first_seed_change_id));
         assert!(!change_ids.contains(&plan.commit.change_id.to_string()));
@@ -827,14 +780,8 @@ mod tests {
     }
 
     #[test]
-    fn plan_init_seed_keeps_branch_heads_out_of_untracked_state() {
+    fn plan_init_seed_keeps_branch_heads_out_of_tracked_state() {
         let plan = plan_init_seed(test_functions()).expect("init seed should plan");
-        assert_eq!(plan.untracked_rows.len(), 1);
-        assert!(
-            plan.untracked_rows
-                .iter()
-                .all(|row| row.schema_key != "lix_branch_ref")
-        );
         assert!(
             plan.changes
                 .iter()
@@ -857,23 +804,21 @@ mod tests {
     }
 
     #[test]
-    fn plan_init_seed_workspace_branch_points_to_main_branch() {
+    fn plan_init_seed_tracks_default_branch_pointing_to_main() {
         let plan = plan_init_seed(test_functions()).expect("init seed should plan");
-        let workspace_row = plan
-            .untracked_rows
+        let default_branch_change = plan
+            .changes
             .iter()
-            .find(|row| {
-                row.schema_key == KEY_VALUE_SCHEMA_KEY
-                    && row.entity_pk == EntityPk::single(WORKSPACE_BRANCH_KEY)
+            .find(|change| {
+                change.schema_key == KEY_VALUE_SCHEMA_KEY
+                    && change.entity_pk == EntityPk::single(DEFAULT_BRANCH_KEY)
             })
-            .expect("workspace branch row should exist");
+            .expect("tracked default branch change should exist");
 
-        assert_eq!(workspace_row.branch_id, GLOBAL_BRANCH_ID);
-        assert!(workspace_row.global);
-        let snapshot = untracked_snapshot(workspace_row);
+        let snapshot = snapshot(default_branch_change);
         assert_eq!(
             snapshot.get("key").and_then(JsonValue::as_str),
-            Some(WORKSPACE_BRANCH_KEY)
+            Some(DEFAULT_BRANCH_KEY)
         );
         assert_eq!(
             snapshot.get("value").and_then(JsonValue::as_str),
@@ -916,7 +861,7 @@ mod tests {
             crate::tracked_state::load_commit_delta_change_ids(&membership_read, record.commit_id)
                 .await
                 .expect("initial commit membership should load");
-        assert_eq!(change_refs.len(), seed_schema_definitions().len() + 6);
+        assert_eq!(change_refs.len(), seed_schema_definitions().len() + 7);
         assert!(
             !change_refs.contains(&record.change_id()),
             "initial commit row is derived from changelog.commit, not stored in its packed delta"

--- a/packages/lix/src/lib.rs
+++ b/packages/lix/src/lib.rs
@@ -1,3 +1,5 @@
+#![recursion_limit = "256"]
+
 //! Rust SDK for Lix.
 //!
 //! Embedded version control for files and data.
@@ -11,7 +13,7 @@
 //! # }
 //! ```
 //!
-//! [`open_lix`] opens an in-memory workspace. Add a storage adapter with
+//! [`open_lix`] opens an in-memory repository. Add a storage adapter with
 //! [`OpenLixBuilder::with_storage`] when persistence is needed.
 
 #![recursion_limit = "256"]
@@ -123,7 +125,7 @@ pub mod wasm;
 ///
 /// Most applications should use [`open_lix`] and [`Lix`] instead. This module
 /// is intentionally separate so the everyday SDK surface stays focused on a
-/// workspace handle, while storage adapters can still compose with the
+/// repository handle, while storage adapters can still compose with the
 /// initialized engine they need to provide host behavior.
 pub mod integration {
     pub use crate::engine::{Engine, EngineOptions};

--- a/packages/lix/src/plugin/actor.rs
+++ b/packages/lix/src/plugin/actor.rs
@@ -503,7 +503,7 @@ struct PluginActorAcceptedState {
 }
 
 /// One instantiated Component Store together with the admission token that
-/// keeps it within the workspace-wide live-Store bound.
+/// keeps it within the repository-wide live-Store bound.
 ///
 /// Field order is deliberate: Rust drops fields in declaration order, so the
 /// actor (and its Wasmtime Store) is destroyed before the permit is returned.
@@ -572,7 +572,7 @@ struct PluginActorPendingCheckpoint {
     last_used: u64,
 }
 
-/// Workspace-local index and hard admission bound for per-file actors.
+/// Repository-local index and hard admission bound for per-file actors.
 #[derive(Clone)]
 pub(crate) struct PluginActorCache {
     capacity: NonZeroUsize,
@@ -828,14 +828,14 @@ impl PluginActorCache {
         }
     }
 
-    /// Serializes cold actor construction. The gate is workspace-wide rather
+    /// Serializes cold actor construction. The gate is repository-wide rather
     /// than per-key because cold opens are uncommon and may otherwise retain
     /// multiple full semantic snapshots plus Wasm Stores concurrently.
     pub(crate) async fn cold_open_guard(&self) -> OwnedMutexGuard<()> {
         Arc::clone(&self.cold_open_gate).lock_owned().await
     }
 
-    /// Reserves one workspace-wide live Store slot before a Component actor is
+    /// Reserves one repository-wide live Store slot before a Component actor is
     /// instantiated. This intentionally fails fast instead of waiting: a
     /// transaction may already retain a pending actor through its durable
     /// commit point, so waiting could deadlock the transaction against itself.

--- a/packages/lix/src/server_protocol/mod.rs
+++ b/packages/lix/src/server_protocol/mod.rs
@@ -9655,8 +9655,11 @@ mod tests {
         let spans = spans.lock().expect("capture spans");
         let sql_span = spans
             .iter()
-            .find(|span| span.name == "lix.sql.query")
-            .expect("SQL span");
+            .find(|span| {
+                span.name == "lix.sql.query"
+                    && span.parent.as_ref() == Some(&protocol_span_id)
+            })
+            .expect("SQL span under protocol request");
         assert_eq!(sql_span.parent.as_ref(), Some(&protocol_span_id));
     }
 

--- a/packages/lix/src/server_protocol/mod.rs
+++ b/packages/lix/src/server_protocol/mod.rs
@@ -1745,7 +1745,7 @@ where
         let child = match self
             .inner
             .root
-            .open_session_with_account(active_branch_id, active_account_id)
+            .open_session_at_with_account(active_branch_id, active_account_id)
             .await
         {
             Ok(child) => child,

--- a/packages/lix/src/session/context.rs
+++ b/packages/lix/src/session/context.rs
@@ -40,11 +40,9 @@ use crate::transaction::{CertifiedHistoryStoreReader, Transaction, open_transact
 use super::transaction::{SessionOperationGuard, SessionTransactionManager, SessionWriteLease};
 use crate::transaction::CommitCoordinator;
 
-pub(crate) const WORKSPACE_BRANCH_KEY: &str = "lix_workspace_branch_id";
-
-/// Loads the workspace selector from its canonical untracked current-state
-/// member when opening a workspace session.
-pub(crate) async fn load_workspace_branch_id_from_index(
+/// Loads the repository default branch from its canonical tracked key/value
+/// member when opening a primary session.
+pub(crate) async fn load_default_branch_id_from_index(
     hot_state: &HotStateContext,
     branch_ctx: &BranchContext,
     reader: &(impl StorageAdapterRead + ?Sized),
@@ -55,20 +53,20 @@ pub(crate) async fn load_workspace_branch_id_from_index(
             rows: vec![HotStateExactRowRequest {
                 schema_key: "lix_key_value".to_string(),
                 branch_id: GLOBAL_BRANCH_ID.to_string(),
-                entity_pk: EntityPk::single(WORKSPACE_BRANCH_KEY),
+                entity_pk: EntityPk::single(crate::init::DEFAULT_BRANCH_KEY),
                 file_id: None,
             }],
             projection: HotStateProjection {
                 columns: vec!["snapshot_content".to_string()],
             },
-            untracked: Some(true),
+            untracked: Some(false),
             include_tombstones: false,
         })
         .await?;
     let row = rows.row(0).ok_or_else(|| {
         LixError::new(
             "LIX_ERROR_UNKNOWN",
-            "workspace branch selector is missing lix_key_value:lix_workspace_branch_id",
+            "repository default branch is missing lix_key_value:lix_default_branch_id",
         )
     })?;
     let snapshot_content = row
@@ -77,13 +75,13 @@ pub(crate) async fn load_workspace_branch_id_from_index(
         .ok_or_else(|| {
             LixError::new(
                 "LIX_ERROR_UNKNOWN",
-                "workspace branch selector is missing snapshot_content",
+                "repository default branch is missing snapshot_content",
             )
         })?;
     let snapshot = serde_json::from_str::<JsonValue>(snapshot_content).map_err(|error| {
         LixError::new(
             "LIX_ERROR_UNKNOWN",
-            format!("workspace branch selector snapshot is invalid JSON: {error}"),
+            format!("repository default branch snapshot is invalid JSON: {error}"),
         )
     })?;
     let branch_id = snapshot
@@ -93,7 +91,7 @@ pub(crate) async fn load_workspace_branch_id_from_index(
         .ok_or_else(|| {
             LixError::new(
                 "LIX_ERROR_UNKNOWN",
-                "workspace branch selector value must be a non-empty string",
+                "repository default branch value must be a non-empty string",
             )
         })?
         .to_string();
@@ -102,23 +100,47 @@ pub(crate) async fn load_workspace_branch_id_from_index(
     BranchLifecycle::new(&branch_ref)
         .require_existing_ref(
             &branch_id,
-            BranchOperation::LoadWorkspaceSelector,
-            BranchReferenceRole::WorkspaceSelector,
+            BranchOperation::LoadDefaultBranch,
+            BranchReferenceRole::DefaultBranch,
         )
         .await?;
 
-    // The selector is a constrained engine-owned reference: initialization,
-    // branch switching, and branch deletion enforce its target lifecycle at
-    // mutation time. Revalidating the same branch ref on every statement made
-    // workspace sessions pay a second point read for an invariant that no
-    // successful commit can violate.
     Ok(branch_id)
 }
 
 #[derive(Clone)]
-pub(crate) enum SessionMode {
-    Pinned { branch_id: Arc<RwLock<String>> },
-    Workspace { branch_id: Arc<RwLock<String>> },
+pub(crate) struct SessionBranch {
+    branch_id: Arc<RwLock<String>>,
+}
+
+impl SessionBranch {
+    pub(crate) fn new(branch_id: String) -> Self {
+        Self {
+            branch_id: Arc::new(RwLock::new(branch_id)),
+        }
+    }
+
+    pub(crate) fn get(&self) -> Result<String, LixError> {
+        self.branch_id
+            .read()
+            .map(|branch_id| branch_id.clone())
+            .map_err(|_| {
+                LixError::new(
+                    LixError::CODE_INTERNAL_ERROR,
+                    "session branch selector is poisoned",
+                )
+            })
+    }
+
+    pub(crate) fn set(&self, branch_id: String) -> Result<(), LixError> {
+        *self.branch_id.write().map_err(|_| {
+            LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                "session branch selector is poisoned",
+            )
+        })? = branch_id;
+        Ok(())
+    }
 }
 
 /// Session-context state for engine execution.
@@ -131,7 +153,7 @@ pub(crate) enum SessionMode {
 #[derive(Clone)]
 #[expect(missing_debug_implementations)]
 pub struct SessionContext<StorageImpl: Storage + 'static = Memory> {
-    pub(super) mode: SessionMode,
+    pub(super) branch: SessionBranch,
     pub(super) active_account_id: Arc<str>,
     pub(super) storage: StorageAdapter<StorageImpl>,
     pub(super) hot_state: Arc<HotStateContext>,
@@ -155,7 +177,7 @@ impl<StorageImpl> SessionContext<StorageImpl>
 where
     StorageImpl: Storage + Clone + Send + Sync + 'static,
 {
-    pub(crate) async fn open_workspace(
+    pub(crate) async fn open_default(
         active_account_id: String,
         storage: StorageAdapter<StorageImpl>,
         hot_state: Arc<HotStateContext>,
@@ -175,13 +197,11 @@ where
         let read =
             SharedStorageAdapterRead::new(storage.begin_read(StorageReadOptions::default()).await?);
         let branch_id =
-            load_workspace_branch_id_from_index(hot_state.as_ref(), branch_ctx.as_ref(), &read)
+            load_default_branch_id_from_index(hot_state.as_ref(), branch_ctx.as_ref(), &read)
                 .await?;
         drop(read);
         Ok(Self::new(
-            SessionMode::Workspace {
-                branch_id: Arc::new(RwLock::new(branch_id)),
-            },
+            SessionBranch::new(branch_id),
             active_account_id,
             storage,
             hot_state,
@@ -200,7 +220,7 @@ where
         ))
     }
 
-    pub(crate) async fn open(
+    pub(crate) async fn open_at(
         active_branch_id: String,
         active_account_id: String,
         storage: StorageAdapter<StorageImpl>,
@@ -219,9 +239,7 @@ where
         telemetry: Option<Arc<dyn TelemetrySink>>,
     ) -> Result<Self, LixError> {
         Ok(Self::new(
-            SessionMode::Pinned {
-                branch_id: Arc::new(RwLock::new(active_branch_id)),
-            },
+            SessionBranch::new(active_branch_id),
             active_account_id,
             storage,
             hot_state,
@@ -241,7 +259,7 @@ where
     }
 
     pub(super) fn new(
-        mode: SessionMode,
+        branch: SessionBranch,
         active_account_id: String,
         storage: StorageAdapter<StorageImpl>,
         hot_state: Arc<HotStateContext>,
@@ -259,7 +277,7 @@ where
         telemetry: Option<Arc<dyn TelemetrySink>>,
     ) -> Self {
         Self::new_with_transaction_manager(
-            mode,
+            branch,
             active_account_id,
             storage,
             hot_state,
@@ -281,7 +299,7 @@ where
     }
 
     pub(super) fn new_with_transaction_manager(
-        mode: SessionMode,
+        branch: SessionBranch,
         active_account_id: String,
         storage: StorageAdapter<StorageImpl>,
         hot_state: Arc<HotStateContext>,
@@ -301,7 +319,7 @@ where
         file_views: SessionFileViews,
     ) -> Self {
         Self {
-            mode,
+            branch,
             active_account_id: Arc::from(active_account_id),
             storage,
             hot_state,
@@ -337,11 +355,6 @@ where
     /// Returns the immutable account that authors every change from this session.
     pub fn active_account_id(&self) -> &str {
         &self.active_account_id
-    }
-
-    #[doc(hidden)]
-    pub fn is_pinned(&self) -> bool {
-        matches!(self.mode, SessionMode::Pinned { .. })
     }
 
     #[cfg(test)]
@@ -446,10 +459,8 @@ where
     /// through the transaction capability so the read is scoped to the
     /// same storage transaction as the writes it influences.
     ///
-    /// Pinned sessions are pure in-memory views over one branch. Workspace
-    /// sessions read the shared workspace selector from untracked global
-    /// `lix_key_value` state so multiple open app sessions can observe the same
-    /// active workspace branch.
+    /// Every session owns an in-memory branch selector. Cloned handles share
+    /// it; independently opened sessions do not.
     pub async fn active_branch_id(&self) -> Result<String, LixError> {
         let _operation_guard = self.begin_waitable_session_operation().await?;
         let read = SharedStorageAdapterRead::new(
@@ -482,17 +493,7 @@ where
         S: StorageAdapterRead + ?Sized,
     {
         self.ensure_open()?;
-        match &self.mode {
-            SessionMode::Pinned { branch_id } | SessionMode::Workspace { branch_id } => branch_id
-                .read()
-                .map(|branch_id| branch_id.clone())
-                .map_err(|_| {
-                    LixError::new(
-                        LixError::CODE_INTERNAL_ERROR,
-                        "session branch selector is poisoned",
-                    )
-                }),
-        }
+        self.branch.get()
     }
 
     /// Runs a transaction with a lending async closure.
@@ -530,7 +531,7 @@ where
         // truth for the mode.
         let _deterministic_runtime_guard = self.lock_deterministic_runtime().await;
         let opened = Box::pin(open_transaction(
-            &self.mode,
+            &self.branch,
             self.active_account_id.to_string(),
             self.storage.clone(),
             Arc::clone(&self.hot_state),
@@ -856,9 +857,9 @@ mod tests {
             .expect("initialized storage should create engine");
         std::sync::Arc::new(
             engine
-                .open_workspace_session()
+                .open_session()
                 .await
-                .expect("workspace session should open"),
+                .expect("session should open"),
         )
     }
 
@@ -877,9 +878,9 @@ mod tests {
         (
             std::sync::Arc::new(
                 engine
-                    .open_workspace_session()
+                    .open_session()
                     .await
-                    .expect("workspace session should open"),
+                    .expect("session should open"),
             ),
             gate,
         )
@@ -900,9 +901,9 @@ mod tests {
         (
             std::sync::Arc::new(
                 engine
-                    .open_workspace_session()
+                    .open_session()
                     .await
-                    .expect("workspace session should open"),
+                    .expect("session should open"),
             ),
             gate,
         )

--- a/packages/lix/src/session/execute.rs
+++ b/packages/lix/src/session/execute.rs
@@ -4489,9 +4489,9 @@ mod tests {
             .await
             .expect("initialized storage should create engine");
         engine
-            .open_workspace_session()
+            .open_session()
             .await
-            .expect("workspace session should open")
+            .expect("session should open")
     }
 
     async fn assert_columnar_lifecycle_current(
@@ -4595,9 +4595,9 @@ mod tests {
                 .await
                 .expect("initialized storage should create engine");
         engine
-            .open_workspace_session()
+            .open_session()
             .await
-            .expect("workspace session should open")
+            .expect("session should open")
     }
 
     fn batch_statement(sql: &str) -> ExecuteBatchStatement {
@@ -5989,9 +5989,9 @@ mod tests {
             .await
             .expect("initialized storage should create engine");
         let main = engine
-            .open_workspace_session_with_account(crate::SYSTEM_ACCOUNT_ID)
+            .open_session_with_account(crate::SYSTEM_ACCOUNT_ID)
             .await
-            .expect("workspace session should open");
+            .expect("session should open");
         let main_branch_id = main
             .active_branch_id()
             .await
@@ -6314,7 +6314,7 @@ mod tests {
             .await
             .expect("checkpoint branch should create");
         let draft_session = engine
-            .open_session(draft.id.clone())
+            .open_session_at(draft.id.clone())
             .await
             .expect("draft session should open");
         draft_session
@@ -6425,7 +6425,7 @@ mod tests {
             .await
             .expect("corrupt storage should still open structurally");
         let reopened_session = reopened
-            .open_workspace_session()
+            .open_session()
             .await
             .expect("corrupt storage session should open");
         assert!(
@@ -7013,7 +7013,7 @@ mod tests {
         let engine = Engine::new(storage)
             .await
             .expect("initialized storage should create engine");
-        let setup = engine.open_workspace_session().await.unwrap();
+        let setup = engine.open_session().await.unwrap();
         let schema = serde_json::json!({
             "$schema": "https://json-schema.org/draft/2020-12/schema",
             "x-lix-key": "concurrent_parameter_insert_probe",
@@ -7034,8 +7034,8 @@ mod tests {
             .await
             .unwrap();
 
-        let first = engine.open_workspace_session().await.unwrap();
-        let second = engine.open_workspace_session().await.unwrap();
+        let first = engine.open_session().await.unwrap();
+        let second = engine.open_session().await.unwrap();
         let sql = "INSERT INTO concurrent_parameter_insert_probe (id, value) VALUES ($1, $2)";
         let first_statements = [
             ExecuteBatchStatement {
@@ -10288,11 +10288,11 @@ mod tests {
             .await
             .expect("initialized storage should create engine");
         let session = engine
-            .open_workspace_session()
+            .open_session()
             .await
             .expect("replacement session should open");
         let concurrent_session = engine
-            .open_workspace_session()
+            .open_session()
             .await
             .expect("concurrent session should open");
         let schema = serde_json::json!({
@@ -10950,13 +10950,13 @@ mod tests {
             .await
             .expect("initialized storage should create engine");
         let session = engine
-            .open_workspace_session()
+            .open_session()
             .await
-            .expect("first workspace session should open");
+            .expect("first session should open");
         let concurrent = engine
-            .open_workspace_session()
+            .open_session()
             .await
-            .expect("second workspace session should open");
+            .expect("second session should open");
         let schema = serde_json::json!({
             "x-lix-key": "read_plan_probe",
             "x-lix-primary-key": ["/id"],

--- a/packages/lix/src/session/media_upload.rs
+++ b/packages/lix/src/session/media_upload.rs
@@ -1399,7 +1399,7 @@ mod tests {
             .expect("initialize storage");
         let engine = Engine::new(storage.clone()).await.expect("open engine");
         let first_session = engine
-            .open_workspace_session()
+            .open_session()
             .await
             .expect("open first session");
         let first = vec![0x31; FILE_UPLOAD_PART_BYTES];
@@ -1427,7 +1427,7 @@ mod tests {
         );
 
         let resumed_session = engine
-            .open_workspace_session()
+            .open_session()
             .await
             .expect("open resumed session");
         let progress = resumed_session
@@ -1582,7 +1582,7 @@ mod tests {
             .await
             .expect("initialize storage");
         let engine = Engine::new(storage.clone()).await.expect("open engine");
-        let session = engine.open_workspace_session().await.expect("open session");
+        let session = engine.open_session().await.expect("open session");
         let total_size = 4 * FILE_UPLOAD_PART_BYTES as u64;
 
         let second = session.upsert_file_content_part(

--- a/packages/lix/src/session/mod.rs
+++ b/packages/lix/src/session/mod.rs
@@ -39,7 +39,7 @@ pub use crate::common::{
 };
 pub use checkpoint::CreateCheckpointReceipt;
 pub use context::SessionContext;
-pub(crate) use context::SessionMode;
+pub(crate) use context::SessionBranch;
 pub use create_branch::{CreateBranchOptions, CreateBranchReceipt};
 pub use execute::{
     CoherentReadBatch, ExecuteBatchStatement, ExecuteOptions, ExecuteResult, ExecutionDisposition,
@@ -64,10 +64,10 @@ pub use undo_redo::{RedoReceipt, UndoReceipt};
 /// opaque async call contains higher-ranked references. Construction is unsafe:
 /// callers must verify that every value retained across suspension is `Send`.
 #[repr(transparent)]
-pub(super) struct AssumeSendFuture<F>(F);
+pub(crate) struct AssumeSendFuture<F>(F);
 
 impl<F> AssumeSendFuture<F> {
-    pub(super) unsafe fn new(future: F) -> Self {
+    pub(crate) unsafe fn new(future: F) -> Self {
         Self(future)
     }
 }

--- a/packages/lix/src/session/observe.rs
+++ b/packages/lix/src/session/observe.rs
@@ -11,7 +11,7 @@ use crate::storage_adapter::Memory;
 use crate::storage_adapter::Storage;
 use crate::{ExecuteResult, LixError, Value, sql2};
 
-use super::{SessionContext, SessionMode};
+use super::SessionContext;
 
 #[derive(Debug, Clone)]
 struct ObserveQuery {
@@ -289,19 +289,10 @@ where
     }
 
     fn observe_scope(&self) -> ObserveSessionScope {
-        match &self.mode {
-            SessionMode::Workspace { branch_id } => ObserveSessionScope::Branch(
-                branch_id
-                    .read()
-                    .unwrap_or_else(std::sync::PoisonError::into_inner)
-                    .clone(),
-            ),
-            SessionMode::Pinned { branch_id } => ObserveSessionScope::Branch(
-                branch_id
-                    .read()
-                    .unwrap_or_else(std::sync::PoisonError::into_inner)
-                    .clone(),
-            ),
-        }
+        ObserveSessionScope::Branch(
+            self.branch
+                .get()
+                .expect("session branch selector should be readable"),
+        )
     }
 }

--- a/packages/lix/src/session/switch_branch.rs
+++ b/packages/lix/src/session/switch_branch.rs
@@ -1,14 +1,7 @@
-use serde_json::json;
-
-use crate::GLOBAL_BRANCH_ID;
 use crate::LixError;
 use crate::branch::{BranchLifecycle, BranchOperation, BranchReferenceRole};
 use crate::storage_adapter::{SharedStorageAdapterRead, Storage, StorageReadOptions};
-use crate::transaction_types::{RawWriteBatch, TransactionJson, TransactionWriteRow};
-
-use super::context::{SessionContext, SessionMode, WORKSPACE_BRANCH_KEY};
-
-const KEY_VALUE_SCHEMA_KEY: &str = "lix_key_value";
+use super::context::SessionContext;
 
 /// Options for switching a session to another branch.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -26,116 +19,40 @@ impl<StorageImpl> SessionContext<StorageImpl>
 where
     StorageImpl: Storage + Clone + Send + Sync + 'static,
 {
-    /// Switches the session's active branch selector.
+    /// Switches this session's active branch.
     ///
-    /// Pinned sessions update their in-memory selector. Workspace sessions
-    /// additionally persist the workspace selector. Clones of this session
-    /// observe the switch in place; independently opened sessions retain the
-    /// branch snapshot they opened with.
+    /// Clones of this session observe the switch in place. Independently
+    /// opened sessions and the repository's default branch are unchanged.
     pub async fn switch_branch(
         &self,
         options: SwitchBranchOptions,
     ) -> Result<SwitchBranchReceipt, LixError> {
         let branch_id = options.branch_id;
-        let receipt_branch_id = branch_id.clone();
-        let current_mode = self.mode.clone();
-        let selector = match &self.mode {
-            SessionMode::Pinned { branch_id } | SessionMode::Workspace { branch_id } => {
-                branch_id.clone()
-            }
-        };
-        let observe_invalidation = self.observe_invalidation.clone();
-        match current_mode {
-            SessionMode::Pinned { .. } => {
-                // A pinned switch changes only this session's in-memory
-                // selector. Keep the existing session/collaboration lease so
-                // branch deletion cannot race target validation, but do not
-                // open and commit an empty repository transaction: the target
-                // branch-head control is the sole authority this path needs.
-                let _write_access = self.begin_session_write_access().await?;
-                let read = SharedStorageAdapterRead::new(
-                    self.storage
-                        .begin_read(StorageReadOptions::default())
-                        .await?,
-                );
-                let reader = self.branch_ctx.ref_reader(&read);
-                BranchLifecycle::new(&reader)
-                    .require_existing_commit_id(
-                        &branch_id,
-                        BranchOperation::SwitchBranch,
-                        BranchReferenceRole::Target,
-                    )
-                    .await?;
-                self.ensure_open()?;
-                *selector.write().map_err(|_| {
-                    LixError::new(
-                        LixError::CODE_INTERNAL_ERROR,
-                        "session branch selector is poisoned",
-                    )
-                })? = receipt_branch_id.clone();
-                observe_invalidation.bump();
-            }
-            SessionMode::Workspace { .. } => {
-                let write_access = self.begin_session_write_access().await?;
-                self.with_write_transaction_reserved_lending(
-                    write_access,
-                    async move |transaction| {
-                        {
-                            let reader = transaction.branch_ref_reader().await;
-                            BranchLifecycle::new(&reader)
-                                .require_existing_commit_id(
-                                    &branch_id,
-                                    BranchOperation::SwitchBranch,
-                                    BranchReferenceRole::Target,
-                                )
-                                .await?
-                        };
-                        let mut rows = RawWriteBatch::with_capacity(1);
-                        rows.push(workspace_branch_stage_row(&branch_id)?);
-                        transaction.stage_rows(rows).await?;
-                        Ok(())
-                    },
-                    |()| {
-                        *selector.write().map_err(|_| {
-                            LixError::new(
-                                LixError::CODE_INTERNAL_ERROR,
-                                "session branch selector is poisoned",
-                            )
-                        })? = receipt_branch_id.clone();
-                        observe_invalidation.bump();
-                        Ok(())
-                    },
-                )
-                .await?;
-            }
-        }
+        // Keep the existing session/collaboration lease so branch deletion
+        // cannot race target validation. Switching is session-local and does
+        // not create a repository commit.
+        let _write_access = self.begin_session_write_access().await?;
+        let read = SharedStorageAdapterRead::new(
+            self.storage
+                .begin_read(StorageReadOptions::default())
+                .await?,
+        );
+        let reader = self.branch_ctx.ref_reader(&read);
+        BranchLifecycle::new(&reader)
+            .require_existing_commit_id(
+                &branch_id,
+                BranchOperation::SwitchBranch,
+                BranchReferenceRole::Target,
+            )
+            .await?;
+        self.ensure_open()?;
+        self.branch.set(branch_id.clone())?;
+        self.observe_invalidation.bump();
 
         Ok(SwitchBranchReceipt {
-            branch_id: receipt_branch_id,
+            branch_id,
         })
     }
-}
-
-#[expect(clippy::unnecessary_wraps)]
-fn workspace_branch_stage_row(branch_id: &str) -> Result<TransactionWriteRow, LixError> {
-    Ok(TransactionWriteRow {
-        entity_pk: Some(crate::entity_pk::EntityPk::single(WORKSPACE_BRANCH_KEY)),
-        schema_key: KEY_VALUE_SCHEMA_KEY.into(),
-        file_id: None,
-        snapshot: Some(TransactionJson::from_value_unchecked(json!({
-            "key": WORKSPACE_BRANCH_KEY,
-            "value": branch_id,
-        }))),
-        metadata: None,
-        origin: None,
-        created_at: None,
-        updated_at: None,
-        global: true,
-        change_id: None,
-        commit_id: None,
-        untracked: true,
-        branch_id: GLOBAL_BRANCH_ID.into(),
-    })
 }
 
 #[cfg(test)]
@@ -276,7 +193,7 @@ mod tests {
             .await
             .expect("open switch benchmark engine");
         let session = engine
-            .open_session(&receipt.main_branch_id)
+            .open_session_at(&receipt.main_branch_id)
             .await
             .expect("open pinned main session");
         let branch = session

--- a/packages/lix/src/session/transaction.rs
+++ b/packages/lix/src/session/transaction.rs
@@ -60,7 +60,7 @@ where
             .await;
         let (mut opened, deterministic_runtime_guard) =
             match open_transaction_with_runtime_boundary(
-                &self.mode,
+                &self.branch,
                 self.active_account_id.to_string(),
                 self.storage.clone(),
                 Arc::clone(&self.hot_state),

--- a/packages/lix/src/session/undo_redo.rs
+++ b/packages/lix/src/session/undo_redo.rs
@@ -531,7 +531,7 @@ mod tests {
     async fn setup() -> crate::session::SessionContext<Memory> {
         setup_engine()
             .await
-            .open_workspace_session()
+            .open_session()
             .await
             .expect("session opens")
     }
@@ -723,7 +723,7 @@ mod tests {
     async fn branch_forked_at_checkpoint_starts_at_an_undo_floor() {
         let engine = setup_engine().await;
         let session = engine
-            .open_workspace_session()
+            .open_session()
             .await
             .expect("session opens");
         session
@@ -745,7 +745,7 @@ mod tests {
             })
             .await
             .expect("branch creates");
-        let fork = engine.open_session(branch.id).await.expect("fork opens");
+        let fork = engine.open_session_at(branch.id).await.expect("fork opens");
 
         let error = fork
             .undo()
@@ -759,7 +759,7 @@ mod tests {
     async fn branch_forked_at_undo_commit_resets_undo_history() {
         let engine = setup_engine().await;
         let session = engine
-            .open_workspace_session()
+            .open_session()
             .await
             .expect("session opens");
         session
@@ -778,7 +778,7 @@ mod tests {
             })
             .await
             .expect("branch creates");
-        let fork = engine.open_session(branch.id).await.expect("fork opens");
+        let fork = engine.open_session_at(branch.id).await.expect("fork opens");
 
         let error = fork
             .undo()
@@ -1060,7 +1060,7 @@ mod tests {
             .expect("storage initializes");
         let engine = Engine::new(storage).await.expect("engine opens");
         let first = engine
-            .open_workspace_session()
+            .open_session()
             .await
             .expect("first session opens");
         first
@@ -1075,7 +1075,7 @@ mod tests {
         drop(first);
 
         let reopened = engine
-            .open_session(branch_id)
+            .open_session_at(branch_id)
             .await
             .expect("fresh pinned session opens");
         reopened.redo().await.expect("redo survives session loss");
@@ -1090,7 +1090,7 @@ mod tests {
             .expect("storage initializes");
         let engine = Engine::new(storage).await.expect("engine opens");
         let main = engine
-            .open_workspace_session()
+            .open_session()
             .await
             .expect("main session opens");
         let draft = main
@@ -1102,7 +1102,7 @@ mod tests {
             .await
             .expect("draft creates");
         let draft_session = engine
-            .open_session(draft.id.clone())
+            .open_session_at(draft.id.clone())
             .await
             .expect("draft session opens");
         draft_session

--- a/packages/lix/src/sql2/exec/datafusion.rs
+++ b/packages/lix/src/sql2/exec/datafusion.rs
@@ -5031,7 +5031,7 @@ mod tests {
             .expect("engine should initialize");
         let engine = Engine::new(storage).await.expect("engine should open");
         let session = engine
-            .open_session(init_receipt.main_branch_id)
+            .open_session_at(init_receipt.main_branch_id)
             .await
             .expect("session should open");
         session
@@ -5141,7 +5141,7 @@ mod tests {
         let storage = Memory::new();
         let init_receipt = Engine::initialize(storage.clone()).await?;
         let engine = Engine::new(storage).await?;
-        let session = engine.open_session(init_receipt.main_branch_id).await?;
+        let session = engine.open_session_at(init_receipt.main_branch_id).await?;
 
         session
             .execute(
@@ -5199,7 +5199,7 @@ mod tests {
         let engine = Engine::new(storage).await.expect("engine should open");
         let branch_id = init_receipt.main_branch_id.clone();
         let session = engine
-            .open_session(init_receipt.main_branch_id)
+            .open_session_at(init_receipt.main_branch_id)
             .await
             .expect("session should open");
         session
@@ -5331,7 +5331,7 @@ mod tests {
             .await
             .expect("branching from the deleted collection should succeed");
         let checkout_session = engine
-            .open_session(checkout.id)
+            .open_session_at(checkout.id)
             .await
             .expect("checkout branch session should open");
         let selected = checkout_session
@@ -5384,7 +5384,7 @@ mod tests {
             .expect("engine should initialize");
         let engine = Engine::new(storage).await.expect("engine should open");
         let session = engine
-            .open_session(init_receipt.main_branch_id)
+            .open_session_at(init_receipt.main_branch_id)
             .await
             .expect("session should open");
         session
@@ -5516,7 +5516,7 @@ mod tests {
             .expect("engine should initialize");
         let engine = Engine::new(storage).await.expect("engine should open");
         let session = engine
-            .open_session(init_receipt.main_branch_id)
+            .open_session_at(init_receipt.main_branch_id)
             .await
             .expect("session should open");
         session
@@ -5565,7 +5565,7 @@ mod tests {
             .expect("engine should initialize");
         let engine = Engine::new(storage).await.expect("engine should open");
         let main = engine
-            .open_session(init_receipt.main_branch_id)
+            .open_session_at(init_receipt.main_branch_id)
             .await
             .expect("main session should open");
         main.execute(
@@ -5594,7 +5594,7 @@ mod tests {
             .await
             .expect("source branch should create");
         let source_session = engine
-            .open_session(source.id.clone())
+            .open_session_at(source.id.clone())
             .await
             .expect("source session should open");
         let deleted = source_session
@@ -5641,7 +5641,7 @@ mod tests {
             .expect("engine should initialize");
         let engine = Engine::new(storage).await.expect("engine should open");
         let session = engine
-            .open_session(init_receipt.main_branch_id)
+            .open_session_at(init_receipt.main_branch_id)
             .await
             .expect("session should open");
 
@@ -5703,7 +5703,7 @@ mod tests {
             .expect("engine should initialize");
         let engine = Engine::new(storage).await.expect("engine should open");
         let session = engine
-            .open_session(init_receipt.main_branch_id)
+            .open_session_at(init_receipt.main_branch_id)
             .await
             .expect("session should open");
 

--- a/packages/lix/src/sql2/providers/branch.rs
+++ b/packages/lix/src/sql2/providers/branch.rs
@@ -22,8 +22,8 @@ use crate::branch::{
 use crate::changelog::CommitId;
 use crate::entity_pk::EntityPk;
 use crate::hot_state::{
-    HotStateFilter, HotStateProjection, HotStateReader, HotStateScanRequest,
-    MaterializedHotStateRowRef,
+    HotStateExactBatchRequest, HotStateExactRowRequest, HotStateFilter, HotStateProjection,
+    HotStateReader, HotStateScanRequest, MaterializedHotStateRowRef,
 };
 use crate::sql2::error::lix_error_to_datafusion_error;
 use crate::sql2::write_normalization::{
@@ -290,7 +290,12 @@ impl TableSpec for BranchSpec {
                 let active_branch_id = active_branch_id.clone();
                 async move {
                     let branch_rows = branch_rows_from_batch(&matched_batch)?;
-                    reject_protected_branch_deletes(&branch_rows, &active_branch_id)?;
+                    let default_branch_id = load_default_branch_id(&write_ctx).await?;
+                    reject_protected_branch_deletes(
+                        &branch_rows,
+                        &active_branch_id,
+                        &default_branch_id,
+                    )?;
                     let count = u64::try_from(branch_rows.len()).map_err(|_| {
                         DataFusionError::Execution("DELETE row count overflow".to_string())
                     })?;
@@ -1022,7 +1027,43 @@ fn branch_rows_from_batch(batch: &RecordBatch) -> Result<Vec<BranchRow>> {
         .collect()
 }
 
-fn reject_protected_branch_deletes(rows: &[BranchRow], active_branch_id: &str) -> Result<()> {
+async fn load_default_branch_id(write_ctx: &SqlWriteContext) -> Result<String> {
+    let rows = write_ctx
+        .load_exact_hot_state_batch(&HotStateExactBatchRequest {
+            rows: vec![HotStateExactRowRequest {
+                schema_key: "lix_key_value".to_string(),
+                branch_id: GLOBAL_BRANCH_ID.to_string(),
+                entity_pk: EntityPk::single(crate::init::DEFAULT_BRANCH_KEY),
+                file_id: None,
+            }],
+            projection: HotStateProjection {
+                columns: vec!["snapshot_content".to_string()],
+            },
+            untracked: Some(false),
+            include_tombstones: false,
+        })
+        .await
+        .map_err(lix_error_to_datafusion_error)?;
+    let snapshot = rows
+        .row(0)
+        .and_then(MaterializedHotStateRowRef::snapshot_content)
+        .ok_or_else(|| {
+            DataFusionError::Execution("repository default branch is missing".to_string())
+        })?;
+    serde_json::from_str::<JsonValue>(snapshot)
+        .ok()
+        .and_then(|value| value.get("value").and_then(JsonValue::as_str).map(str::to_owned))
+        .filter(|value| !value.is_empty())
+        .ok_or_else(|| {
+            DataFusionError::Execution("repository default branch is invalid".to_string())
+        })
+}
+
+fn reject_protected_branch_deletes(
+    rows: &[BranchRow],
+    active_branch_id: &str,
+    default_branch_id: &str,
+) -> Result<()> {
     for row in rows {
         if row.id == GLOBAL_BRANCH_ID {
             return Err(DataFusionError::Execution(
@@ -1032,6 +1073,12 @@ fn reject_protected_branch_deletes(rows: &[BranchRow], active_branch_id: &str) -
         if row.id == active_branch_id {
             return Err(DataFusionError::Execution(format!(
                 "DELETE FROM lix_branch cannot delete active branch '{}'",
+                row.id
+            )));
+        }
+        if row.id == default_branch_id {
+            return Err(DataFusionError::Execution(format!(
+                "DELETE FROM lix_branch cannot delete repository default branch '{}'",
                 row.id
             )));
         }
@@ -1240,7 +1287,7 @@ mod tests {
     impl HotStateReader for RowsHotStateReader {
         async fn load_exact_batch(
             &self,
-            request: &crate::hot_state::HotStateExactBatchRequest,
+            request: &HotStateExactBatchRequest,
         ) -> Result<crate::hot_state::MaterializedHotStateExactBatch, LixError> {
             crate::hot_state::load_exact_batch_via_scan_for_test(self, request).await
         }
@@ -1270,7 +1317,7 @@ mod tests {
     impl HotStateReader for RoutingHotStateReader {
         async fn load_exact_batch(
             &self,
-            request: &crate::hot_state::HotStateExactBatchRequest,
+            request: &HotStateExactBatchRequest,
         ) -> Result<crate::hot_state::MaterializedHotStateExactBatch, LixError> {
             crate::hot_state::load_exact_batch_via_scan_for_test(self, request).await
         }

--- a/packages/lix/src/sql2/test_support/differential.rs
+++ b/packages/lix/src/sql2/test_support/differential.rs
@@ -123,9 +123,9 @@ mod tests {
     async fn run_case(case: &DifferentialSqlCase, mode: WriteExecutorMode) -> DifferentialOutcome {
         let engine = open_initialized_engine().await;
         let session = engine
-            .open_workspace_session()
+            .open_session()
             .await
-            .expect("workspace session should open");
+            .expect("session should open");
         create_probe_branches(&session).await;
         let active_branch_id = session
             .active_branch_id()
@@ -208,9 +208,9 @@ mod tests {
     async fn run_baseline(case: &DifferentialSqlCase) -> DifferentialOutcome {
         let engine = open_initialized_engine().await;
         let session = engine
-            .open_workspace_session()
+            .open_session()
             .await
-            .expect("workspace session should open");
+            .expect("session should open");
         create_probe_branches(&session).await;
         let active_branch_id = session
             .active_branch_id()

--- a/packages/lix/src/sql_profile.rs
+++ b/packages/lix/src/sql_profile.rs
@@ -257,7 +257,7 @@ mod tests {
             .await
             .expect("profile test engine should open");
         let session = engine
-            .open_workspace_session()
+            .open_session()
             .await
             .expect("profile test session should open");
         let schema = serde_json::json!({
@@ -324,7 +324,7 @@ mod tests {
             .await
             .expect("rows-examined engine should open");
         let session = engine
-            .open_workspace_session()
+            .open_session()
             .await
             .expect("rows-examined session should open");
         let schema = serde_json::json!({
@@ -404,7 +404,7 @@ mod tests {
             .await
             .expect("profile cancellation engine should open");
         let session = engine
-            .open_workspace_session()
+            .open_session()
             .await
             .expect("profile cancellation session should open");
 

--- a/packages/lix/src/storage_bench.rs
+++ b/packages/lix/src/storage_bench.rs
@@ -3521,7 +3521,7 @@ mod tests {
             .await
             .expect("open benchmark engine");
         let main = engine
-            .open_workspace_session()
+            .open_session()
             .await
             .expect("open benchmark main session");
         let schema = serde_json::json!({
@@ -3551,7 +3551,7 @@ mod tests {
             .await
             .expect("create benchmark branch");
         let branch_session = engine
-            .open_session(branch.id.clone())
+            .open_session_at(branch.id.clone())
             .await
             .expect("open benchmark branch session");
         for commit_index in 0..10 {

--- a/packages/lix/src/transaction/bench_support.rs
+++ b/packages/lix/src/transaction/bench_support.rs
@@ -17,7 +17,7 @@ use crate::hot_state::{
     CurrentStateDeltaRef, HotStateContext, HotStateFilter, HotStateProjection,
     HotStateRowRequest, HotStateScanRequest, TrackedHeadContext, WorkingDiffIndexCoverage,
 };
-use crate::session::SessionMode;
+use crate::session::SessionBranch;
 use crate::storage_adapter::Storage;
 use crate::storage_adapter::{
     SharedStorageAdapterRead, StorageAdapter, StorageReadOptions, StorageWriteSet,
@@ -297,9 +297,7 @@ where
     async fn commit_rows(&mut self, rows: RawWriteBatch) -> BenchWriteAccounting {
         let logical_rows = rows.len();
         let opened = super::open_transaction(
-            &SessionMode::Pinned {
-                branch_id: Arc::new(std::sync::RwLock::new(BENCH_BRANCH_ID.to_string())),
-            },
+            &SessionBranch::new(BENCH_BRANCH_ID.to_string()),
             crate::ANONYMOUS_ACCOUNT_ID.to_string(),
             self.storage.clone(),
             Arc::clone(&self.hot_state),

--- a/packages/lix/src/transaction/commit.rs
+++ b/packages/lix/src/transaction/commit.rs
@@ -8003,7 +8003,7 @@ mod tests {
             .await
             .expect("repository should reopen after rootless GC");
         let session = reopened
-            .open_workspace_session()
+            .open_session()
             .await
             .expect("workspace should reopen after rootless GC");
         let main = session

--- a/packages/lix/src/transaction/context.rs
+++ b/packages/lix/src/transaction/context.rs
@@ -21,8 +21,8 @@ use tracing::Instrument as _;
 use crate::GLOBAL_BRANCH_ID;
 use crate::binary_cas::{BinaryCasContext, BlobBytesBatch, BlobDataReader, BlobId};
 use crate::branch::{
-    BRANCH_REF_SCHEMA_KEY, BranchContext, BranchHeadControlContext, BranchLifecycle,
-    BranchOperation, BranchRefReader, BranchReferenceRole, branch_ref_stage_row,
+    BRANCH_REF_SCHEMA_KEY, BranchContext, BranchHeadControlContext, BranchRefReader,
+    branch_ref_stage_row,
 };
 use crate::catalog::{
     CatalogContext, CatalogFingerprint, CatalogRevision, CatalogSnapshot, SchemaPlanId,
@@ -78,7 +78,7 @@ use crate::plugin::{
     transport_splice_preserves_utf8, validate_create_changes, validate_create_reservation,
 };
 use crate::session::{
-    EXECUTE_IDEMPOTENCY_RECEIPT_SPACE, ExecuteIdempotency, ExecuteIdempotencyReceipt, SessionMode,
+    EXECUTE_IDEMPOTENCY_RECEIPT_SPACE, ExecuteIdempotency, ExecuteIdempotencyReceipt, SessionBranch,
     encode_receipt,
 };
 use crate::sql2::{
@@ -1510,7 +1510,7 @@ where
 
     /// Opens an execution-scoped staging area for SQL/provider hooks.
     async fn open<T, F>(
-        mode: &SessionMode,
+        session_branch: &SessionBranch,
         active_account_id: String,
         storage: StorageAdapter<StorageImpl>,
         hot_state: Arc<HotStateContext>,
@@ -1535,9 +1535,7 @@ where
         let opening_read = SharedStorageAdapterRead::new(read);
         let read = opening_read.clone();
         let setup_result = async {
-            let active_branch_id =
-                resolve_active_branch_id(mode, hot_state.as_ref(), branch_ctx.as_ref(), &read)
-                    .await?;
+            let active_branch_id = session_branch.get()?;
             let runtime_functions = FunctionContext::prepare(&read).await?;
             let runtime_boundary_result = runtime_boundary(&runtime_functions).await?;
             let functions = runtime_functions.provider();
@@ -2528,7 +2526,7 @@ where
         };
 
         // Static conflict resolution is short lived, but it still owns a
-        // Wasmtime Store and must honor the same workspace-wide admission
+        // Wasmtime Store and must honor the same repository-wide admission
         // bound as retained document actors.
         let permit = self.plugin_host.actor_cache().admit_store()?;
         let actor = factory
@@ -6602,6 +6600,7 @@ where
     }
 
     /// Convenience helper for programmatic APIs that only stage state rows.
+    #[cfg(any(test, feature = "storage-benches"))]
     pub(crate) async fn stage_rows(
         &mut self,
         rows: RawWriteBatch,
@@ -8985,7 +8984,7 @@ pub(crate) struct OpenTransaction<StorageImpl: Storage + 'static = Memory> {
 }
 
 pub(crate) async fn open_transaction<StorageImpl>(
-    mode: &SessionMode,
+    session_branch: &SessionBranch,
     active_account_id: String,
     storage: StorageAdapter<StorageImpl>,
     hot_state: Arc<HotStateContext>,
@@ -9001,7 +9000,7 @@ where
     StorageImpl: Storage + Clone + Send + Sync + 'static,
 {
     let (opened, ()) = Transaction::open(
-        mode,
+        session_branch,
         active_account_id,
         storage,
         hot_state,
@@ -9019,7 +9018,7 @@ where
 }
 
 pub(crate) async fn open_transaction_with_runtime_boundary<StorageImpl, T, F>(
-    mode: &SessionMode,
+    session_branch: &SessionBranch,
     active_account_id: String,
     storage: StorageAdapter<StorageImpl>,
     hot_state: Arc<HotStateContext>,
@@ -9037,7 +9036,7 @@ where
     F: for<'runtime> AsyncFnOnce(&'runtime FunctionContext) -> Result<T, LixError>,
 {
     Transaction::open(
-        mode,
+        session_branch,
         active_account_id,
         storage,
         hot_state,
@@ -11858,45 +11857,6 @@ fn require_valid_storage_scope(branch_id: &str, global: bool) -> Result<(), LixE
     Ok(())
 }
 
-async fn resolve_active_branch_id(
-    mode: &SessionMode,
-    _hot_state: &HotStateContext,
-    branch_ctx: &BranchContext,
-    read: &(impl StorageAdapterRead + ?Sized),
-) -> Result<String, LixError> {
-    match mode {
-        SessionMode::Pinned { branch_id } => branch_id
-            .read()
-            .map(|branch_id| branch_id.clone())
-            .map_err(|_| {
-                LixError::new(
-                    LixError::CODE_INTERNAL_ERROR,
-                    "session branch selector is poisoned",
-                )
-            }),
-        SessionMode::Workspace { branch_id } => {
-            let branch_id = branch_id
-                .read()
-                .map(|branch_id| branch_id.clone())
-                .map_err(|_| {
-                    LixError::new(
-                        LixError::CODE_INTERNAL_ERROR,
-                        "workspace branch selector cache is poisoned",
-                    )
-                })?;
-            let branch_ref = branch_ctx.ref_reader(read);
-            BranchLifecycle::new(&branch_ref)
-                .require_existing_ref(
-                    &branch_id,
-                    BranchOperation::LoadWorkspaceSelector,
-                    BranchReferenceRole::WorkspaceSelector,
-                )
-                .await?;
-            Ok(branch_id.clone())
-        }
-    }
-}
-
 fn validated_uuid_entity_pk(value: &str) -> Result<EntityPk, LixError> {
     EntityPk::uuid_from_canonical(value).map_err(|error| {
         LixError::new(
@@ -12785,9 +12745,9 @@ mod tests {
             .await
             .expect("engine should open initialized storage");
         let session = engine
-            .open_workspace_session()
+            .open_session()
             .await
-            .expect("workspace session should open");
+            .expect("session should open");
 
         let values = (0..32)
             .map(|index| format!("('/seed-{index:02}.md', CAST('byte-01' AS BYTEA))"))
@@ -12874,9 +12834,9 @@ mod tests {
             .await
             .expect("engine should open initialized storage");
         let session = engine
-            .open_workspace_session()
+            .open_session()
             .await
-            .expect("workspace session should open");
+            .expect("session should open");
 
         let values = (0..file_count)
             .map(|index| format!("('/seed-{index:05}.md', CAST('byte-01' AS BYTEA))"))
@@ -12971,9 +12931,9 @@ mod tests {
             .await
             .expect("engine should open initialized storage");
         let session = engine
-            .open_workspace_session()
+            .open_session()
             .await
-            .expect("workspace session should open");
+            .expect("session should open");
 
         let values = (0..file_count)
             .map(|index| {
@@ -13066,9 +13026,9 @@ mod tests {
             .await
             .expect("engine should open initialized storage");
         let session = engine
-            .open_workspace_session()
+            .open_session()
             .await
-            .expect("workspace session should open");
+            .expect("session should open");
 
         session
             .execute(
@@ -13134,9 +13094,7 @@ mod tests {
         let branch_ctx = Arc::new(BranchContext::new());
         let catalog_context = Arc::new(CatalogContext::new());
         let opened = open_transaction(
-            &SessionMode::Pinned {
-                branch_id: Arc::new(std::sync::RwLock::new(GLOBAL_BRANCH_ID.to_string())),
-            },
+            &SessionBranch::new(GLOBAL_BRANCH_ID.to_string()),
             crate::ANONYMOUS_ACCOUNT_ID.to_string(),
             storage.clone(),
             Arc::clone(&hot_state),
@@ -13460,9 +13418,7 @@ mod tests {
         let branch_ctx = Arc::new(BranchContext::new());
         let catalog_context = Arc::new(CatalogContext::new());
         let opened = open_transaction(
-            &SessionMode::Pinned {
-                branch_id: Arc::new(std::sync::RwLock::new(GLOBAL_BRANCH_ID.to_string())),
-            },
+            &SessionBranch::new(GLOBAL_BRANCH_ID.to_string()),
             crate::ANONYMOUS_ACCOUNT_ID.to_string(),
             storage.clone(),
             Arc::clone(&hot_state),
@@ -13913,9 +13869,7 @@ mod tests {
         let branch_ctx = Arc::new(BranchContext::new());
         let catalog_context = Arc::new(CatalogContext::new());
         let opened = open_transaction(
-            &SessionMode::Pinned {
-                branch_id: Arc::new(std::sync::RwLock::new(GLOBAL_BRANCH_ID.to_string())),
-            },
+            &SessionBranch::new(GLOBAL_BRANCH_ID.to_string()),
             crate::ANONYMOUS_ACCOUNT_ID.to_string(),
             storage,
             Arc::clone(&hot_state),

--- a/packages/lix/tests/adapter_deterministic_sequence_corruption.rs
+++ b/packages/lix/tests/adapter_deterministic_sequence_corruption.rs
@@ -22,9 +22,9 @@ where
         .expect("storage should initialize");
     let engine = Engine::new(storage).await.expect("engine should open");
     let session = engine
-        .open_workspace_session()
+        .open_session()
         .await
-        .expect("workspace session should open");
+        .expect("session should open");
     session
         .execute(
             "INSERT INTO lix_key_value (key, value, lixcol_global, lixcol_untracked) \
@@ -41,9 +41,9 @@ where
 {
     let engine = Engine::new(storage).await.expect("engine should reopen");
     let session = engine
-        .open_workspace_session()
+        .open_session()
         .await
-        .expect("workspace session should reopen");
+        .expect("session should reopen");
     let result = session
         .execute("SELECT lix_uuid_v7() AS value", &[])
         .await
@@ -143,7 +143,7 @@ where
         .await
         .expect("member-corrupt repository should open structurally");
     let session = engine
-        .open_workspace_session()
+        .open_session()
         .await
         .expect("member-corrupt session should open");
     let error = session

--- a/packages/lix/tests/adapter_undo_redo_checkpoint.rs
+++ b/packages/lix/tests/adapter_undo_redo_checkpoint.rs
@@ -40,9 +40,9 @@ where
     S: Storage + Clone + Send + Sync + 'static,
 {
     let session = engine
-        .open_workspace_session()
+        .open_session()
         .await
-        .expect("workspace session opens");
+        .expect("session opens");
     session
         .execute(
             "INSERT INTO lix_key_value (key, value) VALUES ($1, 'a0'), ($2, 'b0')",
@@ -91,7 +91,7 @@ where
     S: Storage + Clone + Send + Sync + 'static,
 {
     let session = engine
-        .open_session(branch_id)
+        .open_session_at(branch_id)
         .await
         .expect("cold session opens after undo");
     assert_values(&session, "a1", "b0").await;
@@ -104,7 +104,7 @@ where
     S: Storage + Clone + Send + Sync + 'static,
 {
     let session = engine
-        .open_session(branch_id)
+        .open_session_at(branch_id)
         .await
         .expect("cold session opens after redo");
     assert_values(&session, "a1", "b1").await;

--- a/packages/lix/tests/integration/branching.rs
+++ b/packages/lix/tests/integration/branching.rs
@@ -149,7 +149,7 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let main = sim.wrap_session(
             engine
-                .open_session(sim.main_branch_id())
+                .open_session_at(sim.main_branch_id())
                 .await
                 .expect("main session should open"),
             &engine,
@@ -185,7 +185,7 @@ simulation_test!(
 
         let from_initial = main.wrap_session(
             engine
-                .open_session("01930000-0000-7000-8000-000000000003")
+                .open_session_at("01930000-0000-7000-8000-000000000003")
                 .await
                 .expect("explicit commit branch session should open"),
             &engine,
@@ -204,7 +204,7 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let main = sim.wrap_session(
             engine
-                .open_session(sim.main_branch_id())
+                .open_session_at(sim.main_branch_id())
                 .await
                 .expect("main session should open"),
             &engine,
@@ -246,22 +246,22 @@ simulation_test!(created_branch_sees_inherited_state, |sim| async move {
 });
 
 simulation_test!(
-    open_workspace_session_starts_on_seeded_main_branch,
+    open_session_starts_on_seeded_repository_default_branch,
     |sim| async move {
         let engine = sim.boot_engine().await;
-        let workspace = sim.wrap_session(
+        let session = sim.wrap_session(
             engine
-                .open_workspace_session()
+                .open_session()
                 .await
-                .expect("workspace session should open"),
+                .expect("session should open"),
             &engine,
         );
 
         assert_eq!(
-            workspace
+            session
                 .active_branch_id()
                 .await
-                .expect("workspace active branch should resolve"),
+                .expect("active branch should resolve"),
             sim.main_branch_id()
         );
     }
@@ -336,13 +336,30 @@ simulation_test!(switch_branch_updates_session_in_place, |sim| async move {
     drop(engine);
 });
 
+simulation_test!(cannot_delete_repository_default_branch, |sim| async move {
+    let (_engine, _main, draft) = create_draft_from_main(&sim).await;
+
+    let error = draft
+        .execute(
+            "DELETE FROM lix_branch WHERE id = $1",
+            &[Value::Text(sim.main_branch_id().to_string())],
+        )
+        .await
+        .expect_err("repository default branch deletion should fail");
+
+    assert!(
+        error.message.contains("cannot delete repository default branch"),
+        "unexpected error: {error:?}"
+    );
+});
+
 simulation_test!(
     cached_write_templates_are_isolated_across_branch_switches,
     |sim| async move {
         let (engine, main, _draft) = create_draft_from_main(&sim).await;
         let main_snapshot = sim.wrap_session(
             engine
-                .open_session(sim.main_branch_id().to_string())
+                .open_session_at(sim.main_branch_id().to_string())
                 .await
                 .expect("open independent main session"),
             &engine,
@@ -384,7 +401,7 @@ simulation_test!(
 );
 
 simulation_test!(
-    pinned_switch_branch_is_ephemeral_and_does_not_advance_refs,
+    switch_branch_is_session_local_and_does_not_advance_refs,
     |sim| async move {
         let (engine, main, _draft) = create_draft_from_main(&sim).await;
         let main_head_before = engine
@@ -395,20 +412,20 @@ simulation_test!(
             .load_branch_head_commit_id("01930000-0000-7000-8000-000000000001")
             .await
             .expect("draft head should load");
-        let workspace_before = sim.wrap_session(
+        let default_before = sim.wrap_session(
             engine
-                .open_workspace_session()
+                .open_session()
                 .await
-                .expect("workspace session should open"),
+                .expect("default session should open"),
             &engine,
         );
         assert_eq!(
-            workspace_before
+            default_before
                 .active_branch_id()
                 .await
-                .expect("workspace selector should resolve"),
+                .expect("default branch should resolve"),
             sim.main_branch_id(),
-            "pinned session setup should not have moved the workspace selector"
+            "session setup should not move the repository default"
         );
 
         main.switch_branch(SwitchBranchOptions {
@@ -433,31 +450,31 @@ simulation_test!(
             draft_head_before,
             "switching must not mutate the target branch ref"
         );
-        let workspace_after = sim.wrap_session(
+        let default_after = sim.wrap_session(
             engine
-                .open_workspace_session()
+                .open_session()
                 .await
-                .expect("workspace session should open"),
+                .expect("default session should open"),
             &engine,
         );
         assert_eq!(
-            workspace_after
+            default_after
                 .active_branch_id()
                 .await
-                .expect("workspace selector should resolve"),
+                .expect("default branch should resolve"),
             sim.main_branch_id(),
-            "pinned switching must not mutate the shared workspace selector"
+            "switching must not mutate the repository default"
         );
     }
 );
 
 simulation_test!(
-    workspace_switch_branch_updates_shared_workspace_selector,
+    independently_opened_sessions_keep_independent_branch_selection,
     |sim| async move {
         let (engine, main, draft) = create_draft_from_main(&sim).await;
         draft
             .execute(
-                "INSERT INTO lix_key_value (key, value) VALUES ('workspace-draft-only', 'draft')",
+                "INSERT INTO lix_key_value (key, value) VALUES ('session-draft-only', 'draft')",
                 &[],
             )
             .await
@@ -471,75 +488,75 @@ simulation_test!(
             .await
             .expect("draft head should load");
 
-        let workspace_a = sim.wrap_session(
+        let session_a = sim.wrap_session(
             engine
-                .open_workspace_session()
+                .open_session()
                 .await
-                .expect("workspace session should open"),
+                .expect("session should open"),
             &engine,
         );
-        let workspace_b = sim.wrap_session(
+        let session_b = sim.wrap_session(
             engine
-                .open_workspace_session()
+                .open_session()
                 .await
-                .expect("second workspace session should open"),
+                .expect("second session should open"),
             &engine,
         );
         assert_eq!(
-            workspace_a
+            session_a
                 .active_branch_id()
                 .await
-                .expect("workspace selector should resolve"),
+                .expect("session branch should resolve"),
             sim.main_branch_id()
         );
 
-        let receipt = workspace_a
+        let receipt = session_a
             .switch_branch(SwitchBranchOptions {
                 branch_id: "01930000-0000-7000-8000-000000000001".to_string(),
             })
             .await
-            .expect("workspace switch should succeed");
+            .expect("session switch should succeed");
 
         assert_eq!(receipt.branch_id, "01930000-0000-7000-8000-000000000001");
         assert_eq!(
-            workspace_a
+            session_a
                 .active_branch_id()
                 .await
-                .expect("switched workspace selector should resolve"),
+                .expect("switched session branch should resolve"),
             "01930000-0000-7000-8000-000000000001"
         );
         assert_eq!(
-            workspace_b
+            session_b
                 .active_branch_id()
                 .await
-                .expect("existing workspace session should retain its branch"),
+                .expect("independent session should retain its branch"),
             sim.main_branch_id(),
-            "workspace sessions pin the selector observed when they open"
+            "independent sessions retain their own branch selection"
         );
-        assert_key_value(&workspace_b, "workspace-draft-only", None).await;
-        let workspace_c = sim.wrap_session(
+        assert_key_value(&session_b, "session-draft-only", None).await;
+        let session_c = sim.wrap_session(
             engine
-                .open_workspace_session()
+                .open_session()
                 .await
-                .expect("new workspace session should open"),
+                .expect("new default session should open"),
             &engine,
         );
         assert_eq!(
-            workspace_c
+            session_c
                 .active_branch_id()
                 .await
-                .expect("new workspace session should observe selector"),
-            "01930000-0000-7000-8000-000000000001"
+                .expect("repository default should resolve"),
+            sim.main_branch_id()
         );
-        assert_key_value(&workspace_c, "workspace-draft-only", Some("\"draft\"")).await;
-        assert_key_value(&main, "workspace-draft-only", None).await;
+        assert_key_value(&session_c, "session-draft-only", None).await;
+        assert_key_value(&main, "session-draft-only", None).await;
         assert_eq!(
             engine
                 .load_branch_head_commit_id(sim.main_branch_id())
                 .await
                 .expect("main head should load"),
             main_head_before,
-            "workspace switching must not mutate the old branch ref"
+            "session switching must not mutate the old branch ref"
         );
         assert_eq!(
             engine
@@ -547,63 +564,58 @@ simulation_test!(
                 .await
                 .expect("draft head should load"),
             draft_head_before,
-            "workspace switching must not mutate the new branch ref"
+            "session switching must not mutate the new branch ref"
         );
     }
 );
 
 simulation_test!(
-    workspace_switch_branch_persists_across_reopened_engine,
+    session_switch_does_not_persist_across_reopened_engine,
     |sim| async move {
         let (engine, _main, draft) = create_draft_from_main(&sim).await;
         draft
             .execute(
-                "INSERT INTO lix_key_value (key, value) VALUES ('workspace-reopen-draft', 'draft')",
+                "INSERT INTO lix_key_value (key, value) VALUES ('session-reopen-draft', 'draft')",
                 &[],
             )
             .await
             .expect("draft write should succeed");
 
-        let workspace = sim.wrap_session(
+        let session = sim.wrap_session(
             engine
-                .open_workspace_session()
+                .open_session()
                 .await
-                .expect("workspace session should open"),
+                .expect("session should open"),
             &engine,
         );
-        workspace
+        session
             .switch_branch(SwitchBranchOptions {
                 branch_id: "01930000-0000-7000-8000-000000000001".to_string(),
             })
             .await
-            .expect("workspace switch should persist");
+            .expect("session switch should succeed");
 
         let reopened_engine = sim
             .reboot_engine_from_current_snapshot()
             .await
             .expect("engine should reopen from current snapshot");
-        let reopened_workspace = sim.wrap_session(
+        let reopened_session = sim.wrap_session(
             reopened_engine
-                .open_workspace_session()
+                .open_session()
                 .await
-                .expect("reopened workspace session should open"),
+                .expect("reopened session should open"),
             &reopened_engine,
         );
 
         assert_eq!(
-            reopened_workspace
+            reopened_session
                 .active_branch_id()
                 .await
-                .expect("workspace selector should resolve after reopen"),
-            "01930000-0000-7000-8000-000000000001",
-            "workspace switch should survive reopening the engine"
+                .expect("repository default should resolve after reopen"),
+            sim.main_branch_id(),
+            "session switching must not change the repository default"
         );
-        assert_key_value(
-            &reopened_workspace,
-            "workspace-reopen-draft",
-            Some("\"draft\""),
-        )
-        .await;
+        assert_key_value(&reopened_session, "session-reopen-draft", None).await;
     }
 );
 
@@ -613,7 +625,7 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let main = sim.wrap_session(
             engine
-                .open_workspace_session()
+                .open_session()
                 .await
                 .expect("main session should open"),
             &engine,
@@ -783,7 +795,7 @@ simulation_test!(
 
         let global = sim.wrap_session(
             engine
-                .open_session("ffffffff-ffff-7fff-bfff-ffffffffffff")
+                .open_session_at("ffffffff-ffff-7fff-bfff-ffffffffffff")
                 .await
                 .expect("global session should open"),
             &engine,
@@ -908,7 +920,7 @@ simulation_test!(
 
         let global = sim.wrap_session(
             engine
-                .open_session("ffffffff-ffff-7fff-bfff-ffffffffffff")
+                .open_session_at("ffffffff-ffff-7fff-bfff-ffffffffffff")
                 .await
                 .expect("global session should open"),
             &engine,
@@ -1074,7 +1086,7 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let main = sim.wrap_session(
             engine
-                .open_session(sim.main_branch_id())
+                .open_session_at(sim.main_branch_id())
                 .await
                 .expect("main session should open"),
             &engine,
@@ -1107,7 +1119,7 @@ simulation_test!(
         assert_eq!(branch.commit_id, fork_commit_id);
         let draft = sim.wrap_session(
             engine
-                .open_session("01930000-0000-7000-8000-000000000001")
+                .open_session_at("01930000-0000-7000-8000-000000000001")
                 .await
                 .expect("recovered source session should open"),
             &engine,
@@ -1164,7 +1176,7 @@ simulation_test!(
 
         let global = sim.wrap_session(
             engine
-                .open_session("ffffffff-ffff-7fff-bfff-ffffffffffff")
+                .open_session_at("ffffffff-ffff-7fff-bfff-ffffffffffff")
                 .await
                 .expect("global session should open"),
             &engine,
@@ -1188,7 +1200,7 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let main = sim.wrap_session(
             engine
-                .open_session(sim.main_branch_id())
+                .open_session_at(sim.main_branch_id())
                 .await
                 .expect("main session should open"),
             &engine,
@@ -1218,7 +1230,7 @@ simulation_test!(
         .expect("recovered conflict source should remain branchable");
         let source = sim.wrap_session(
             engine
-                .open_session("01930000-0000-7000-8000-000000000002")
+                .open_session_at("01930000-0000-7000-8000-000000000002")
                 .await
                 .expect("conflict source session should open"),
             &engine,
@@ -1296,7 +1308,7 @@ simulation_test!(
 
         let global = sim.wrap_session(
             engine
-                .open_session("ffffffff-ffff-7fff-bfff-ffffffffffff")
+                .open_session_at("ffffffff-ffff-7fff-bfff-ffffffffffff")
                 .await
                 .expect("global session should open"),
             &engine,
@@ -1373,7 +1385,7 @@ simulation_test!(
 
         let reopened_main = sim.wrap_session(
             engine
-                .open_session(sim.main_branch_id())
+                .open_session_at(sim.main_branch_id())
                 .await
                 .expect("main session should reopen after merge"),
             &engine,
@@ -1768,7 +1780,7 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let main = sim.wrap_session(
             engine
-                .open_workspace_session()
+                .open_session()
                 .await
                 .expect("main session should open"),
             &engine,
@@ -1812,7 +1824,7 @@ simulation_test!(merge_branch_rejects_self_merge, |sim| async move {
     let engine = sim.boot_engine().await;
     let main = sim.wrap_session(
         engine
-            .open_workspace_session()
+            .open_session()
             .await
             .expect("main session should open"),
         &engine,
@@ -1869,7 +1881,7 @@ async fn create_draft_after_shared_write(
     let engine = sim.boot_engine().await;
     let main = sim.wrap_session(
         engine
-            .open_session(sim.main_branch_id())
+            .open_session_at(sim.main_branch_id())
             .await
             .expect("main session should open"),
         &engine,
@@ -1895,7 +1907,7 @@ async fn create_draft_from_main(
     let engine = sim.boot_engine().await;
     let main = sim.wrap_session(
         engine
-            .open_session(sim.main_branch_id())
+            .open_session_at(sim.main_branch_id())
             .await
             .expect("main session should open"),
         &engine,
@@ -1937,7 +1949,7 @@ async fn create_draft(
     );
     main.wrap_session(
         engine
-            .open_session(receipt.id)
+            .open_session_at(receipt.id)
             .await
             .expect("draft session should open"),
         engine,
@@ -2138,7 +2150,7 @@ async fn assert_empty_merge_commit(
 
     let global = session.wrap_session(
         engine
-            .open_session("ffffffff-ffff-7fff-bfff-ffffffffffff")
+            .open_session_at("ffffffff-ffff-7fff-bfff-ffffffffffff")
             .await
             .expect("global session should open"),
         engine,
@@ -2166,7 +2178,7 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let main = sim.wrap_session(
             engine
-                .open_session(sim.main_branch_id())
+                .open_session_at(sim.main_branch_id())
                 .await
                 .expect("main session should open"),
             &engine,
@@ -2221,7 +2233,7 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let main = sim.wrap_session(
             engine
-                .open_session(sim.main_branch_id())
+                .open_session_at(sim.main_branch_id())
                 .await
                 .expect("main session should open"),
             &engine,
@@ -2266,7 +2278,7 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let main = sim.wrap_session(
             engine
-                .open_session(sim.main_branch_id())
+                .open_session_at(sim.main_branch_id())
                 .await
                 .expect("main session should open"),
             &engine,
@@ -2333,7 +2345,7 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let main = sim.wrap_session(
             engine
-                .open_session(sim.main_branch_id())
+                .open_session_at(sim.main_branch_id())
                 .await
                 .expect("main session should open"),
             &engine,
@@ -2395,7 +2407,7 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let main = sim.wrap_session(
             engine
-                .open_session(sim.main_branch_id())
+                .open_session_at(sim.main_branch_id())
                 .await
                 .expect("main session should open"),
             &engine,
@@ -2495,7 +2507,7 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let main = sim.wrap_session(
             engine
-                .open_session(sim.main_branch_id())
+                .open_session_at(sim.main_branch_id())
                 .await
                 .expect("main session should open"),
             &engine,
@@ -2553,7 +2565,7 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let main = sim.wrap_session(
             engine
-                .open_session(sim.main_branch_id())
+                .open_session_at(sim.main_branch_id())
                 .await
                 .expect("main session should open"),
             &engine,
@@ -2608,7 +2620,7 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let main = sim.wrap_session(
             engine
-                .open_session(sim.main_branch_id())
+                .open_session_at(sim.main_branch_id())
                 .await
                 .expect("main session should open"),
             &engine,
@@ -2654,7 +2666,7 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let main = sim.wrap_session(
             engine
-                .open_session(sim.main_branch_id())
+                .open_session_at(sim.main_branch_id())
                 .await
                 .expect("main session should open"),
             &engine,

--- a/packages/lix/tests/integration/checkpoint_gc.rs
+++ b/packages/lix/tests/integration/checkpoint_gc.rs
@@ -12,9 +12,9 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
             engine
-                .open_workspace_session()
+                .open_session()
                 .await
-                .expect("workspace session should open"),
+                .expect("session should open"),
             &engine,
         );
 
@@ -101,9 +101,9 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let main = sim.wrap_session(
             engine
-                .open_workspace_session()
+                .open_session()
                 .await
-                .expect("workspace session should open"),
+                .expect("session should open"),
             &engine,
         );
 
@@ -136,7 +136,7 @@ simulation_test!(
         .expect("branch should be created from the recoverable auto-commit");
         let protected = sim.wrap_session(
             engine
-                .open_session("01920000-0000-7000-8000-000000000510")
+                .open_session_at("01920000-0000-7000-8000-000000000510")
                 .await
                 .expect("protected branch session should open"),
             &engine,
@@ -202,9 +202,9 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let main = sim.wrap_session(
             engine
-                .open_workspace_session()
+                .open_session()
                 .await
-                .expect("workspace session should open"),
+                .expect("session should open"),
             &engine,
         );
         main.create_branch(CreateBranchOptions {
@@ -216,7 +216,7 @@ simulation_test!(
         .expect("other branch should be created");
         let other = sim.wrap_session(
             engine
-                .open_session("01920000-0000-7000-8000-000000000511")
+                .open_session_at("01920000-0000-7000-8000-000000000511")
                 .await
                 .expect("other branch session should open"),
             &engine,
@@ -305,9 +305,9 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
             engine
-                .open_workspace_session()
+                .open_session()
                 .await
-                .expect("workspace session should open"),
+                .expect("session should open"),
             &engine,
         );
 
@@ -426,9 +426,9 @@ simulation_test!(
             .expect("engine should reopen after replay GC");
         let reopened = sim.wrap_session(
             reopened_engine
-                .open_workspace_session()
+                .open_session()
                 .await
-                .expect("reopened workspace session should open"),
+                .expect("reopened session should open"),
             &reopened_engine,
         );
         assert_replay_gc_state(&reopened).await;

--- a/packages/lix/tests/integration/code_structure.rs
+++ b/packages/lix/tests/integration/code_structure.rs
@@ -2647,7 +2647,7 @@ fn internal_metadata_crud_is_centralized_in_owner_storage() {
 
     assert!(
         violations.is_empty(),
-        "internal metadata CRUD for workspace selectors, commit idempotency, and undo/redo log should live in owner-local `storage.rs` seams, not scattered through `api/*`, `init/*`, `session/*`, or `transaction/*`.\n\nCurrent violations:\n{}",
+        "internal metadata CRUD for primary-session state, commit idempotency, and undo/redo log should live in owner-local `storage.rs` seams, not scattered through `api/*`, `init/*`, `session/*`, or `transaction/*`.\n\nCurrent violations:\n{}",
         render_grouped_raw_sql_execution_violations(&violations),
     );
 }

--- a/packages/lix/tests/integration/commit_graph.rs
+++ b/packages/lix/tests/integration/commit_graph.rs
@@ -5,7 +5,7 @@ simulation_test!(branch_ref_advances_after_tracked_commit, |sim| async move {
     let engine = sim.boot_engine().await;
     let session = sim.wrap_session(
         engine
-            .open_workspace_session()
+            .open_session()
             .await
             .expect("main session should open"),
         &engine,
@@ -40,14 +40,14 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
             engine
-                .open_workspace_session()
+                .open_session()
                 .await
                 .expect("main session should open"),
             &engine,
         );
         let global_session = sim.wrap_session(
             engine
-                .open_session("ffffffff-ffff-7fff-bfff-ffffffffffff")
+                .open_session_at("ffffffff-ffff-7fff-bfff-ffffffffffff")
                 .await
                 .expect("global session should open"),
             &engine,
@@ -105,14 +105,14 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
             engine
-                .open_workspace_session()
+                .open_session()
                 .await
                 .expect("main session should open"),
             &engine,
         );
         let global_session = sim.wrap_session(
             engine
-                .open_session("ffffffff-ffff-7fff-bfff-ffffffffffff")
+                .open_session_at("ffffffff-ffff-7fff-bfff-ffffffffffff")
                 .await
                 .expect("global session should open"),
             &engine,

--- a/packages/lix/tests/integration/constraint_fuzz.rs
+++ b/packages/lix/tests/integration/constraint_fuzz.rs
@@ -12,7 +12,7 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
             engine
-                .open_workspace_session()
+                .open_session()
                 .await
                 .expect("main session should open"),
             &engine,
@@ -185,7 +185,7 @@ simulation_test!(
                         .unwrap_or_else(|error| panic!("{label}: reopen failed: {error:?}"));
                     let reopened = sim.wrap_session(
                         reopened_engine
-                            .open_workspace_session()
+                            .open_session()
                             .await
                             .unwrap_or_else(|error| {
                                 panic!("{label}: reopened session failed: {error:?}")

--- a/packages/lix/tests/integration/correlated_hot_state_perf.rs
+++ b/packages/lix/tests/integration/correlated_hot_state_perf.rs
@@ -334,7 +334,7 @@ async fn seed_snapshot(config: &Config, ids: &[String]) -> Vec<u8> {
         .await
         .expect("benchmark engine should open");
     let session = engine
-        .open_workspace_session()
+        .open_session()
         .await
         .expect("benchmark session should open");
 
@@ -431,7 +431,7 @@ async fn open_case(seed_snapshot: &[u8]) -> (CountingStorage, SessionContext<Cou
         .await
         .expect("benchmark engine should open from seed snapshot");
     let session = engine
-        .open_workspace_session()
+        .open_session()
         .await
         .expect("benchmark session should open from seed snapshot");
     (storage, session)

--- a/packages/lix/tests/integration/corruption_fuzz.rs
+++ b/packages/lix/tests/integration/corruption_fuzz.rs
@@ -12,7 +12,7 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
             engine
-                .open_workspace_session()
+                .open_session()
                 .await
                 .expect("main session should open"),
             &engine,
@@ -121,7 +121,7 @@ simulation_test!(
                         .unwrap_or_else(|error| panic!("{label}: reopen failed: {error:?}"));
                     let reopened = sim.wrap_session(
                         reopened_engine
-                            .open_workspace_session()
+                            .open_session()
                             .await
                             .unwrap_or_else(|error| {
                                 panic!("{label}: reopened session failed: {error:?}")

--- a/packages/lix/tests/integration/durable_function_fast_path.rs
+++ b/packages/lix/tests/integration/durable_function_fast_path.rs
@@ -105,9 +105,9 @@ async fn open_session() -> (CountingStorage, SessionContext<CountingStorage>) {
         .await
         .expect("initialized storage should create engine");
     let session = engine
-        .open_workspace_session()
+        .open_session()
         .await
-        .expect("workspace session should open");
+        .expect("session should open");
     (storage, session)
 }
 

--- a/packages/lix/tests/integration/engine.rs
+++ b/packages/lix/tests/integration/engine.rs
@@ -18,14 +18,14 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
             engine
-                .open_session("ffffffff-ffff-7fff-bfff-ffffffffffff")
+                .open_session_at("ffffffff-ffff-7fff-bfff-ffffffffffff")
                 .await
                 .expect("initialized storage should open global session"),
             &engine,
         );
         let main_session = sim.wrap_session(
             engine
-                .open_workspace_session()
+                .open_session()
                 .await
                 .expect("initialized storage should open main session"),
             &engine,
@@ -103,7 +103,7 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
             engine
-                .open_workspace_session()
+                .open_session()
                 .await
                 .expect("storage should open a session"),
             &engine,
@@ -156,7 +156,7 @@ simulation_test!(
     |sim| async move {
         let engine = sim.boot_engine().await;
         let session = engine
-            .open_workspace_session()
+            .open_session()
             .await
             .expect("storage should open a session");
 
@@ -196,7 +196,7 @@ simulation_test!(
     |sim| async move {
         let engine = sim.boot_engine().await;
         let session = engine
-            .open_workspace_session()
+            .open_session()
             .await
             .expect("storage should open a session");
 
@@ -275,7 +275,7 @@ simulation_test!(
     |sim| async move {
         let engine = sim.boot_engine().await;
         let session = engine
-            .open_workspace_session()
+            .open_session()
             .await
             .expect("storage should open a session");
         let cloned_session = session.clone();
@@ -305,7 +305,7 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
             engine
-                .open_workspace_session()
+                .open_session()
                 .await
                 .expect("storage should open first session"),
             &engine,
@@ -339,7 +339,7 @@ simulation_test!(
 
         let second_session = sim.wrap_session(
             engine
-                .open_workspace_session()
+                .open_session()
                 .await
                 .expect("storage should open second session"),
             &engine,
@@ -384,7 +384,7 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
             engine
-                .open_workspace_session()
+                .open_session()
                 .await
                 .expect("storage should open a session"),
             &engine,
@@ -445,7 +445,7 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
             engine
-                .open_workspace_session()
+                .open_session()
                 .await
                 .expect("storage should open first session"),
             &engine,
@@ -462,7 +462,7 @@ simulation_test!(
 
         let second_session = sim.wrap_session(
             engine
-                .open_workspace_session()
+                .open_session()
                 .await
                 .expect("storage should open second session"),
             &engine,
@@ -503,7 +503,7 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
             engine
-                .open_workspace_session()
+                .open_session()
                 .await
                 .expect("storage should open first session"),
             &engine,
@@ -519,7 +519,7 @@ simulation_test!(
             .expect("deterministic mode insert should succeed");
         let second_session = sim.wrap_session(
             engine
-                .open_workspace_session()
+                .open_session()
                 .await
                 .expect("storage should open second session"),
             &engine,

--- a/packages/lix/tests/integration/execute_batch_benchmark.rs
+++ b/packages/lix/tests/integration/execute_batch_benchmark.rs
@@ -132,7 +132,7 @@ async fn execute_batch_benchmark_probe() {
     let storage = CountingStorage::new();
     Engine::initialize(storage.clone()).await.unwrap();
     let engine = Engine::new(storage.clone()).await.unwrap();
-    let session = engine.open_workspace_session().await.unwrap();
+    let session = engine.open_session().await.unwrap();
     seed_files(&session, file_count).await;
 
     for (workload, statements) in [

--- a/packages/lix/tests/integration/filesystem_fuzz.rs
+++ b/packages/lix/tests/integration/filesystem_fuzz.rs
@@ -27,7 +27,7 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
             engine
-                .open_workspace_session()
+                .open_session()
                 .await
                 .expect("main session should open"),
             &engine,
@@ -161,7 +161,7 @@ simulation_test!(
                         .unwrap_or_else(|error| panic!("{label}: reopen failed: {error:?}"));
                     let reopened = sim.wrap_session(
                         reopened_engine
-                            .open_workspace_session()
+                            .open_session()
                             .await
                             .unwrap_or_else(|error| {
                                 panic!("{label}: reopened session failed: {error:?}")

--- a/packages/lix/tests/integration/fs_api.rs
+++ b/packages/lix/tests/integration/fs_api.rs
@@ -10,9 +10,9 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
             engine
-                .open_workspace_session()
+                .open_session()
                 .await
-                .expect("workspace session should open"),
+                .expect("session should open"),
             &engine,
         );
 
@@ -48,9 +48,9 @@ simulation_test!(sql_path_only_file_reads_as_empty, |sim| async move {
     let engine = sim.boot_engine().await;
     let session = sim.wrap_session(
         engine
-            .open_workspace_session()
+            .open_session()
             .await
-            .expect("workspace session should open"),
+            .expect("session should open"),
         &engine,
     );
 
@@ -73,9 +73,9 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
             engine
-                .open_workspace_session()
+                .open_session()
                 .await
-                .expect("workspace session should open"),
+                .expect("session should open"),
             &engine,
         );
 
@@ -133,11 +133,11 @@ async fn raw_stale_writes_use_whole_file_last_writer_wins() {
         .expect("storage should initialize");
     let engine = Engine::new(storage).await.expect("engine should open");
     let session_a = engine
-        .open_session(receipt.main_branch_id.clone())
+        .open_session_at(receipt.main_branch_id.clone())
         .await
         .expect("session A should open");
     let session_b = engine
-        .open_session(receipt.main_branch_id)
+        .open_session_at(receipt.main_branch_id)
         .await
         .expect("session B should open");
 
@@ -167,9 +167,9 @@ async fn sql_update_path_to_plugin_storage_rejects_archive_rename() {
         .expect("storage should initialize");
     let engine = Engine::new(storage).await.expect("engine should open");
     let session = engine
-        .open_workspace_session()
+        .open_session()
         .await
-        .expect("workspace session should open");
+        .expect("session should open");
 
     write_file(&session, "/normal.txt", b"normal".to_vec())
         .await
@@ -198,9 +198,9 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
             engine
-                .open_workspace_session()
+                .open_session()
                 .await
-                .expect("workspace session should open"),
+                .expect("session should open"),
             &engine,
         );
 
@@ -230,9 +230,9 @@ simulation_test!(sql_write_file_upserts_existing_data, |sim| async move {
     let engine = sim.boot_engine().await;
     let session = sim.wrap_session(
         engine
-            .open_workspace_session()
+            .open_session()
             .await
-            .expect("workspace session should open"),
+            .expect("session should open"),
         &engine,
     );
 
@@ -271,9 +271,9 @@ simulation_test!(sql_rm_file_and_recursive_directory, |sim| async move {
     let engine = sim.boot_engine().await;
     let session = sim.wrap_session(
         engine
-            .open_workspace_session()
+            .open_session()
             .await
-            .expect("workspace session should open"),
+            .expect("session should open"),
         &engine,
     );
 
@@ -310,9 +310,9 @@ simulation_test!(sql_file_directory_path_constraints, |sim| async move {
     let engine = sim.boot_engine().await;
     let session = sim.wrap_session(
         engine
-            .open_workspace_session()
+            .open_session()
             .await
-            .expect("workspace session should open"),
+            .expect("session should open"),
         &engine,
     );
 

--- a/packages/lix/tests/integration/merge_fuzz.rs
+++ b/packages/lix/tests/integration/merge_fuzz.rs
@@ -12,7 +12,7 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let main = sim.wrap_session(
             engine
-                .open_workspace_session()
+                .open_session()
                 .await
                 .expect("main session should open"),
             &engine,
@@ -35,7 +35,7 @@ simulation_test!(
                 .unwrap_or_else(|error| panic!("seed {seed:#018x}: create failed: {error:?}"));
             let source = sim.wrap_session(
                 engine
-                    .open_session(receipt.id)
+                    .open_session_at(receipt.id)
                     .await
                     .unwrap_or_else(|error| {
                         panic!("seed {seed:#018x}: source open failed: {error:?}")
@@ -126,7 +126,7 @@ simulation_test!(
                         .unwrap_or_else(|error| panic!("{label}: reopen failed: {error:?}"));
                     let reopened_main = sim.wrap_session(
                         reopened_engine
-                            .open_workspace_session()
+                            .open_session()
                             .await
                             .unwrap_or_else(|error| {
                                 panic!("{label}: reopened main failed: {error:?}")
@@ -135,7 +135,7 @@ simulation_test!(
                     );
                     let reopened_source = sim.wrap_session(
                         reopened_engine
-                            .open_session(branch_id.clone())
+                            .open_session_at(branch_id.clone())
                             .await
                             .unwrap_or_else(|error| {
                                 panic!("{label}: reopened source failed: {error:?}")

--- a/packages/lix/tests/integration/observe.rs
+++ b/packages/lix/tests/integration/observe.rs
@@ -17,11 +17,11 @@ const NEXT_TIMEOUT: Duration = Duration::from_secs(1);
 const NO_EVENT_TIMEOUT: Duration = Duration::from_millis(250);
 const KEY_VALUE_SQL: &str = "SELECT key, value FROM lix_key_value WHERE key = $1 ORDER BY key";
 
-async fn open_workspace_session(sim: &Simulation, engine: &Engine) -> (SessionContext, SimSession) {
+async fn open_default_session(sim: &Simulation, engine: &Engine) -> (SessionContext, SimSession) {
     let raw_session = engine
-        .open_workspace_session()
+        .open_session()
         .await
-        .expect("workspace session should open");
+        .expect("session should open");
     let session = sim.wrap_session(raw_session.clone(), engine);
     (raw_session, session)
 }
@@ -70,7 +70,7 @@ fn assert_key_value_row(event: &ObserveEvent, key: &str, value: &str) {
 
 simulation_test!(observe_next_returns_initial_snapshot, |sim| async move {
     let engine = sim.boot_engine().await;
-    let (raw_session, session) = open_workspace_session(&sim, &engine).await;
+    let (raw_session, session) = open_default_session(&sim, &engine).await;
     session
         .execute(
             "INSERT INTO lix_key_value (key, value) VALUES ('observe-initial', 'v0')",
@@ -90,7 +90,7 @@ simulation_test!(observe_next_returns_initial_snapshot, |sim| async move {
 
 simulation_test!(observe_follows_in_place_branch_switch, |sim| async move {
     let engine = sim.boot_engine().await;
-    let (raw_session, session) = open_workspace_session(&sim, &engine).await;
+    let (raw_session, session) = open_default_session(&sim, &engine).await;
     session
         .execute(
             "INSERT INTO lix_key_value (key, value) VALUES ('observe-switch', 'main')",
@@ -154,9 +154,9 @@ async fn observe_initial_next_waits_without_rejecting_same_session_write() {
     let engine = Engine::new(storage).await.expect("engine should open");
     let session = Arc::new(
         engine
-            .open_workspace_session()
+            .open_session()
             .await
-            .expect("workspace session should open"),
+            .expect("session should open"),
     );
     let mut warmup = session
         .observe("SELECT 1", &[])
@@ -215,9 +215,9 @@ async fn observe_close_during_initial_evaluation_does_not_publish_a_final_snapsh
     let engine = Engine::new(storage).await.expect("engine should open");
     let session = Arc::new(
         engine
-            .open_workspace_session()
+            .open_session()
             .await
-            .expect("workspace session should open"),
+            .expect("session should open"),
     );
     let mut events = session
         .observe("SELECT 1", &[])
@@ -268,9 +268,9 @@ async fn observe_registration_allows_automatic_write_instead_of_rejecting() {
     let engine = Engine::new(storage).await.expect("engine should open");
     let session = Arc::new(
         engine
-            .open_workspace_session()
+            .open_session()
             .await
-            .expect("workspace session should open"),
+            .expect("session should open"),
     );
 
     gate.block_next();
@@ -317,9 +317,9 @@ async fn observe_initial_next_waits_for_automatic_write_instead_of_rejecting() {
     let engine = Engine::new(storage).await.expect("engine should open");
     let session = Arc::new(
         engine
-            .open_workspace_session()
+            .open_session()
             .await
-            .expect("workspace session should open"),
+            .expect("session should open"),
     );
     let params = [Value::Text("observe-after-automatic-write".to_string())];
     let mut events = session
@@ -368,7 +368,7 @@ simulation_test!(
     observe_emits_after_committed_mutation_changes_result,
     |sim| async move {
         let engine = sim.boot_engine().await;
-        let (raw_session, session) = open_workspace_session(&sim, &engine).await;
+        let (raw_session, session) = open_default_session(&sim, &engine).await;
         let mut events = observe_key(&raw_session, "observe-update");
 
         let initial = next_event(&mut events, "initial empty snapshot").await;
@@ -397,8 +397,8 @@ simulation_test!(
     observe_sees_mutation_from_another_session,
     |sim| async move {
         let engine = sim.boot_engine().await;
-        let (observer_raw_session, _) = open_workspace_session(&sim, &engine).await;
-        let (_, writer_session) = open_workspace_session(&sim, &engine).await;
+        let (observer_raw_session, _) = open_default_session(&sim, &engine).await;
+        let (_, writer_session) = open_default_session(&sim, &engine).await;
         let mut events = observe_key(&observer_raw_session, "observe-cross-session");
 
         let initial = next_event(&mut events, "initial empty snapshot").await;
@@ -426,7 +426,7 @@ simulation_test!(
     observe_does_not_emit_for_read_only_execute,
     |sim| async move {
         let engine = sim.boot_engine().await;
-        let (raw_session, session) = open_workspace_session(&sim, &engine).await;
+        let (raw_session, session) = open_default_session(&sim, &engine).await;
         let mut events = observe_key(&raw_session, "observe-read-only");
         let _initial = next_event(&mut events, "initial snapshot").await;
 
@@ -443,7 +443,7 @@ simulation_test!(
     observe_does_not_emit_when_unrelated_mutation_leaves_rows_unchanged,
     |sim| async move {
         let engine = sim.boot_engine().await;
-        let (raw_session, session) = open_workspace_session(&sim, &engine).await;
+        let (raw_session, session) = open_default_session(&sim, &engine).await;
         let mut events = observe_key(&raw_session, "observe-target");
         let _initial = next_event(&mut events, "initial snapshot").await;
 
@@ -461,7 +461,7 @@ simulation_test!(
 
 simulation_test!(observe_does_not_emit_after_failed_write, |sim| async move {
     let engine = sim.boot_engine().await;
-    let (raw_session, session) = open_workspace_session(&sim, &engine).await;
+    let (raw_session, session) = open_default_session(&sim, &engine).await;
     let mut events = observe_key(&raw_session, "observe-failed-write");
     let initial = next_event(&mut events, "initial empty snapshot").await;
     assert!(initial.rows.is_empty());
@@ -491,7 +491,7 @@ simulation_test!(
     observe_emits_only_after_explicit_transaction_commit,
     |sim| async move {
         let engine = sim.boot_engine().await;
-        let (raw_session, session) = open_workspace_session(&sim, &engine).await;
+        let (raw_session, session) = open_default_session(&sim, &engine).await;
         let mut events = observe_key(&raw_session, "observe-transaction");
         let _initial = next_event(&mut events, "initial snapshot").await;
 
@@ -523,7 +523,7 @@ simulation_test!(
     observe_does_not_emit_after_explicit_transaction_rollback,
     |sim| async move {
         let engine = sim.boot_engine().await;
-        let (raw_session, session) = open_workspace_session(&sim, &engine).await;
+        let (raw_session, session) = open_default_session(&sim, &engine).await;
         let mut events = observe_key(&raw_session, "observe-rollback");
         let _initial = next_event(&mut events, "initial snapshot").await;
 
@@ -563,7 +563,7 @@ simulation_test!(
     observe_coalesces_multiple_writes_before_next_into_latest_snapshot,
     |sim| async move {
         let engine = sim.boot_engine().await;
-        let (raw_session, session) = open_workspace_session(&sim, &engine).await;
+        let (raw_session, session) = open_default_session(&sim, &engine).await;
         let mut events = observe_key(&raw_session, "observe-coalesce");
         let initial = next_event(&mut events, "initial snapshot").await;
         assert!(initial.rows.is_empty());
@@ -598,7 +598,7 @@ simulation_test!(
     observe_multiple_observers_receive_updates_independently,
     |sim| async move {
         let engine = sim.boot_engine().await;
-        let (raw_session, session) = open_workspace_session(&sim, &engine).await;
+        let (raw_session, session) = open_default_session(&sim, &engine).await;
         let mut events_a = observe_key(&raw_session, "observe-multi");
         let mut events_b = observe_key(&raw_session, "observe-multi");
         let initial_a = next_event(&mut events_a, "first initial snapshot").await;
@@ -635,9 +635,9 @@ async fn observe_identical_queries_share_one_evaluation_per_generation() {
         .await
         .expect("engine should open");
     let session = engine
-        .open_workspace_session()
+        .open_session()
         .await
-        .expect("workspace session should open");
+        .expect("session should open");
     let params = [Value::Text("observe-singleflight".to_string())];
     let mut first = session
         .observe(KEY_VALUE_SQL, &params)
@@ -681,9 +681,9 @@ async fn closing_retained_observer_releases_external_watcher_demand() {
         .await
         .expect("engine should open");
     let session = engine
-        .open_workspace_session()
+        .open_session()
         .await
-        .expect("workspace session should open");
+        .expect("session should open");
     let mut events = session
         .observe("SELECT 1", &[])
         .expect("observe should open");
@@ -711,7 +711,7 @@ simulation_test!(
     observe_new_subscriber_receives_current_rows_after_unchanged_generation,
     |sim| async move {
         let engine = sim.boot_engine().await;
-        let (raw_session, session) = open_workspace_session(&sim, &engine).await;
+        let (raw_session, session) = open_default_session(&sim, &engine).await;
         session
             .execute(
                 "INSERT INTO lix_key_value (key, value) VALUES ('observe-current', 'v0')",
@@ -760,7 +760,7 @@ simulation_test!(
     observe_rejects_durable_runtime_functions,
     |sim| async move {
         let engine = sim.boot_engine().await;
-        let (raw_session, _) = open_workspace_session(&sim, &engine).await;
+        let (raw_session, _) = open_default_session(&sim, &engine).await;
 
         match raw_session.observe("SELECT lix_uuid_v7()", &[]) {
             Ok(_) => panic!("observe should reject durable runtime functions"),
@@ -779,9 +779,9 @@ simulation_test!(
     observe_next_rejects_active_transaction_even_when_shared_cache_is_warm,
     |sim| async move {
         let engine = sim.boot_engine().await;
-        let (blocked_raw_session, _) = open_workspace_session(&sim, &engine).await;
-        let (cache_raw_session, _) = open_workspace_session(&sim, &engine).await;
-        let (_, writer_session) = open_workspace_session(&sim, &engine).await;
+        let (blocked_raw_session, _) = open_default_session(&sim, &engine).await;
+        let (cache_raw_session, _) = open_default_session(&sim, &engine).await;
+        let (_, writer_session) = open_default_session(&sim, &engine).await;
         let params = [Value::Text("observe-active-transaction-cache".to_string())];
         let mut blocked_events = blocked_raw_session
             .observe(KEY_VALUE_SQL, &params)
@@ -830,7 +830,7 @@ simulation_test!(
 
 simulation_test!(observe_close_makes_next_return_none, |sim| async move {
     let engine = sim.boot_engine().await;
-    let (raw_session, _) = open_workspace_session(&sim, &engine).await;
+    let (raw_session, _) = open_default_session(&sim, &engine).await;
     let mut events = observe_key(&raw_session, "observe-close");
     let _initial = next_event(&mut events, "initial snapshot").await;
 
@@ -845,7 +845,7 @@ simulation_test!(observe_close_makes_next_return_none, |sim| async move {
 
 simulation_test!(observe_rejects_closed_session, |sim| async move {
     let engine = sim.boot_engine().await;
-    let (raw_session, _) = open_workspace_session(&sim, &engine).await;
+    let (raw_session, _) = open_default_session(&sim, &engine).await;
 
     raw_session
         .close()
@@ -861,7 +861,7 @@ simulation_test!(observe_rejects_closed_session, |sim| async move {
 
 simulation_test!(observe_rejects_active_transaction, |sim| async move {
     let engine = sim.boot_engine().await;
-    let (raw_session, _) = open_workspace_session(&sim, &engine).await;
+    let (raw_session, _) = open_default_session(&sim, &engine).await;
     let transaction = raw_session
         .begin_transaction()
         .await
@@ -883,7 +883,7 @@ simulation_test!(
     observe_pending_next_returns_none_when_session_closes,
     |sim| async move {
         let engine = sim.boot_engine().await;
-        let (raw_session, _) = open_workspace_session(&sim, &engine).await;
+        let (raw_session, _) = open_default_session(&sim, &engine).await;
         let mut events = observe_key(&raw_session, "observe-session-close");
         let _initial = next_event(&mut events, "initial snapshot").await;
 
@@ -1184,7 +1184,7 @@ simulation_test!(
     },
     |sim| async move {
         let engine = sim.boot_engine().await;
-        let (raw_session, session) = open_workspace_session(&sim, &engine).await;
+        let (raw_session, session) = open_default_session(&sim, &engine).await;
         session
             .execute(
                 "INSERT INTO lix_key_value (key, value, lixcol_global, lixcol_untracked) \

--- a/packages/lix/tests/integration/observe_mutation_revision.rs
+++ b/packages/lix/tests/integration/observe_mutation_revision.rs
@@ -74,11 +74,11 @@ fn assert_key_value_row(event: &ObserveEvent, key: &str, value: &str) {
 async fn observe_emits_when_another_engine_commits() {
     let (observer_engine, writer_engine) = open_two_engines().await;
     let observer_session = observer_engine
-        .open_workspace_session()
+        .open_session()
         .await
         .expect("observer session should open");
     let writer_session = writer_engine
-        .open_workspace_session()
+        .open_session()
         .await
         .expect("writer session should open");
     let mut events = observe_key(&observer_session, "mutation-revision-external");
@@ -104,15 +104,15 @@ async fn observe_emits_when_another_engine_commits() {
 async fn observe_emits_after_local_generation_bump_without_storage_revision_change() {
     let (observer_engine, writer_engine) = open_two_engines().await;
     let observer_session = observer_engine
-        .open_workspace_session()
+        .open_session()
         .await
         .expect("observer session should open");
     let local_session = observer_engine
-        .open_workspace_session()
+        .open_session()
         .await
         .expect("local session should open");
     let writer_session = writer_engine
-        .open_workspace_session()
+        .open_session()
         .await
         .expect("writer session should open");
     let mut events = observe_key(&observer_session, "mutation-revision-after-close");
@@ -144,11 +144,11 @@ async fn observe_emits_after_local_generation_bump_without_storage_revision_chan
 async fn observe_external_transaction_emits_only_after_commit() {
     let (observer_engine, writer_engine) = open_two_engines().await;
     let observer_session = observer_engine
-        .open_workspace_session()
+        .open_session()
         .await
         .expect("observer session should open");
     let writer_session = writer_engine
-        .open_workspace_session()
+        .open_session()
         .await
         .expect("writer session should open");
     let mut events = observe_key(&observer_session, "mutation-revision-transaction");
@@ -184,11 +184,11 @@ async fn observe_external_transaction_emits_only_after_commit() {
 async fn observe_external_rollback_does_not_emit() {
     let (observer_engine, writer_engine) = open_two_engines().await;
     let observer_session = observer_engine
-        .open_workspace_session()
+        .open_session()
         .await
         .expect("observer session should open");
     let writer_session = writer_engine
-        .open_workspace_session()
+        .open_session()
         .await
         .expect("writer session should open");
     let mut events = observe_key(&observer_session, "mutation-revision-rollback");
@@ -219,11 +219,11 @@ async fn observe_external_rollback_does_not_emit() {
 async fn observe_external_writes_can_coalesce_to_latest_snapshot() {
     let (observer_engine, writer_engine) = open_two_engines().await;
     let observer_session = observer_engine
-        .open_workspace_session()
+        .open_session()
         .await
         .expect("observer session should open");
     let writer_session = writer_engine
-        .open_workspace_session()
+        .open_session()
         .await
         .expect("writer session should open");
     let mut events = observe_key(&observer_session, "mutation-revision-coalesce");

--- a/packages/lix/tests/integration/physical_plan_cache.rs
+++ b/packages/lix/tests/integration/physical_plan_cache.rs
@@ -17,9 +17,9 @@ async fn reusable_physical_read_plan_rebinds_snapshot_and_exact_parameters() {
         .await
         .expect("initialized storage should open");
     let session = engine
-        .open_workspace_session()
+        .open_session()
         .await
-        .expect("workspace session should open");
+        .expect("session should open");
 
     for schema in multi_entity_schemas() {
         session
@@ -159,9 +159,9 @@ async fn reusable_physical_read_plan_rebinds_snapshot_and_exact_parameters() {
 
     session.close().await.expect("session should close");
     let reopened = engine
-        .open_workspace_session()
+        .open_session()
         .await
-        .expect("workspace session should reopen");
+        .expect("session should reopen");
     assert_eq!(
         reopened
             .execute(MULTI_ENTITY_SQL, &bundle_1)

--- a/packages/lix/tests/integration/pooled_session_reuse.rs
+++ b/packages/lix/tests/integration/pooled_session_reuse.rs
@@ -42,9 +42,9 @@ fn text(rows: &lix::ExecuteResult, column: &str) -> Option<String> {
 async fn execution_functions_follow_a_branch_switch_on_a_reused_session() {
     let engine = open_engine().await;
     let session = engine
-        .open_workspace_session()
+        .open_session()
         .await
-        .expect("workspace session should open");
+        .expect("session should open");
 
     session
         .create_branch(CreateBranchOptions {
@@ -107,9 +107,9 @@ async fn execution_functions_follow_a_branch_switch_on_a_reused_session() {
 async fn active_commit_id_advances_between_executions_of_one_shape() {
     let engine = open_engine().await;
     let session = engine
-        .open_workspace_session()
+        .open_session()
         .await
-        .expect("workspace session should open");
+        .expect("session should open");
 
     let sql = "SELECT lix_active_branch_commit_id() AS commit_id";
     let first = text(
@@ -143,9 +143,9 @@ async fn active_commit_id_advances_between_executions_of_one_shape() {
 async fn volatile_execution_functions_stay_fresh_on_a_reused_session() {
     let engine = open_engine().await;
     let session = engine
-        .open_workspace_session()
+        .open_session()
         .await
-        .expect("workspace session should open");
+        .expect("session should open");
 
     let sql = "SELECT lix_uuid_v7() AS first, lix_uuid_v7() AS second, \
         lix_timestamp() AS stamp";
@@ -176,9 +176,9 @@ async fn volatile_execution_functions_stay_fresh_on_a_reused_session() {
 async fn a_reused_session_reads_rows_committed_after_its_plan_was_cached() {
     let engine = open_engine().await;
     let session = engine
-        .open_workspace_session()
+        .open_session()
         .await
-        .expect("workspace session should open");
+        .expect("session should open");
 
     let sql = "SELECT key FROM lix_key_value WHERE key LIKE 'pooled-visibility-%' ORDER BY key";
     for round in 0..4 {
@@ -216,9 +216,9 @@ async fn a_reused_session_reads_rows_committed_after_its_plan_was_cached() {
 async fn information_schema_stays_available_across_pooled_statements() {
     let engine = open_engine().await;
     let session = engine
-        .open_workspace_session()
+        .open_session()
         .await
-        .expect("workspace session should open");
+        .expect("session should open");
 
     let information_schema_sql =
         "SELECT table_name FROM information_schema.tables WHERE table_name = 'lix_key_value'";

--- a/packages/lix/tests/integration/sql/checkpoint.rs
+++ b/packages/lix/tests/integration/sql/checkpoint.rs
@@ -9,9 +9,9 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
             engine
-                .open_workspace_session()
+                .open_session()
                 .await
-                .expect("workspace session should open"),
+                .expect("session should open"),
             &engine,
         );
         let initial_commit_id = sim.initial_commit_id().to_string();
@@ -236,9 +236,9 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
             engine
-                .open_workspace_session()
+                .open_session()
                 .await
-                .expect("workspace session should open"),
+                .expect("session should open"),
             &engine,
         );
 
@@ -281,9 +281,9 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
             engine
-                .open_workspace_session()
+                .open_session()
                 .await
-                .expect("workspace session should open"),
+                .expect("session should open"),
             &engine,
         );
 
@@ -355,9 +355,9 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
             engine
-                .open_workspace_session()
+                .open_session()
                 .await
-                .expect("workspace session should open"),
+                .expect("session should open"),
             &engine,
         );
         let file_id = "01950000-0000-7000-8000-000000000099";
@@ -490,9 +490,9 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
             engine
-                .open_workspace_session()
+                .open_session()
                 .await
-                .expect("workspace session should open"),
+                .expect("session should open"),
             &engine,
         );
 

--- a/packages/lix/tests/integration/sql/delete_returning.rs
+++ b/packages/lix/tests/integration/sql/delete_returning.rs
@@ -9,9 +9,9 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
             engine
-                .open_workspace_session()
+                .open_session()
                 .await
-                .expect("workspace session should open"),
+                .expect("session should open"),
             &engine,
         );
 
@@ -96,9 +96,9 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
             engine
-                .open_workspace_session()
+                .open_session()
                 .await
-                .expect("workspace session should open"),
+                .expect("session should open"),
             &engine,
         );
 
@@ -180,9 +180,9 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
             engine
-                .open_workspace_session()
+                .open_session()
                 .await
-                .expect("workspace session should open"),
+                .expect("session should open"),
             &engine,
         );
 

--- a/packages/lix/tests/integration/sql/diff_commands.rs
+++ b/packages/lix/tests/integration/sql/diff_commands.rs
@@ -9,9 +9,9 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
             engine
-                .open_workspace_session()
+                .open_session()
                 .await
-                .expect("workspace session should open"),
+                .expect("session should open"),
             &engine,
         );
         let baseline = sim.initial_commit_id().to_string();

--- a/packages/lix/tests/integration/sql/entity_history.rs
+++ b/packages/lix/tests/integration/sql/entity_history.rs
@@ -9,7 +9,7 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
             engine
-                .open_workspace_session()
+                .open_session()
                 .await
                 .expect("main session should open"),
             &engine,
@@ -104,7 +104,7 @@ simulation_test!(entity_history_defaults_to_active_head, |sim| async move {
     let engine = sim.boot_engine().await;
     let session = sim.wrap_session(
         engine
-            .open_workspace_session()
+            .open_session()
             .await
             .expect("main session should open"),
         &engine,
@@ -157,7 +157,7 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
             engine
-                .open_workspace_session()
+                .open_session()
                 .await
                 .expect("main session should open"),
             &engine,

--- a/packages/lix/tests/integration/sql/entity_view.rs
+++ b/packages/lix/tests/integration/sql/entity_view.rs
@@ -10,7 +10,7 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
             engine
-                .open_workspace_session()
+                .open_session()
                 .await
                 .expect("main session should open"),
             &engine,
@@ -44,7 +44,7 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
             engine
-                .open_workspace_session()
+                .open_session()
                 .await
                 .expect("main session should open"),
             &engine,
@@ -71,7 +71,7 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
             engine
-                .open_workspace_session()
+                .open_session()
                 .await
                 .expect("main session should open"),
             &engine,
@@ -99,7 +99,7 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
             engine
-                .open_workspace_session()
+                .open_session()
                 .await
                 .expect("main session should open"),
             &engine,
@@ -128,7 +128,7 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
             engine
-                .open_workspace_session()
+                .open_session()
                 .await
                 .expect("main session should open"),
             &engine,
@@ -152,7 +152,7 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
             engine
-                .open_workspace_session()
+                .open_session()
                 .await
                 .expect("main session should open"),
             &engine,
@@ -186,7 +186,7 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
             engine
-                .open_workspace_session()
+                .open_session()
                 .await
                 .expect("main session should open"),
             &engine,
@@ -234,7 +234,7 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
             engine
-                .open_workspace_session()
+                .open_session()
                 .await
                 .expect("main session should open"),
             &engine,

--- a/packages/lix/tests/integration/sql/errors.rs
+++ b/packages/lix/tests/integration/sql/errors.rs
@@ -5,7 +5,7 @@ simulation_test!(sql_missing_table_has_lix_error_code, |sim| async move {
     let engine = sim.boot_engine().await;
     let session = sim.wrap_session(
         engine
-            .open_workspace_session()
+            .open_session()
             .await
             .expect("main session should open"),
         &engine,
@@ -24,7 +24,7 @@ simulation_test!(sql_missing_column_has_lix_error_code, |sim| async move {
     let engine = sim.boot_engine().await;
     let session = sim.wrap_session(
         engine
-            .open_workspace_session()
+            .open_session()
             .await
             .expect("main session should open"),
         &engine,
@@ -44,7 +44,7 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
             engine
-                .open_workspace_session()
+                .open_session()
                 .await
                 .expect("main session should open"),
             &engine,
@@ -64,7 +64,7 @@ simulation_test!(
     |sim| async move {
         let engine = sim.boot_engine().await;
         let session = engine
-            .open_workspace_session()
+            .open_session()
             .await
             .expect("main session should open");
 
@@ -121,7 +121,7 @@ simulation_test!(sql_anonymous_placeholders_are_rejected, |sim| async move {
     let engine = sim.boot_engine().await;
     let session = sim.wrap_session(
         engine
-            .open_workspace_session()
+            .open_session()
             .await
             .expect("main session should open"),
         &engine,
@@ -141,7 +141,7 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
             engine
-                .open_workspace_session()
+                .open_session()
                 .await
                 .expect("main session should open"),
             &engine,
@@ -199,7 +199,7 @@ simulation_test!(sql_explain_is_read_shaped, |sim| async move {
     let engine = sim.boot_engine().await;
     let session = sim.wrap_session(
         engine
-            .open_workspace_session()
+            .open_session()
             .await
             .expect("main session should open"),
         &engine,
@@ -229,7 +229,7 @@ simulation_test!(sql_json_function_miss_has_lix_udf_hint, |sim| async move {
     let engine = sim.boot_engine().await;
     let session = sim.wrap_session(
         engine
-            .open_workspace_session()
+            .open_session()
             .await
             .expect("main session should open"),
         &engine,
@@ -255,7 +255,7 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
             engine
-                .open_workspace_session()
+                .open_session()
                 .await
                 .expect("main session should open"),
             &engine,
@@ -282,7 +282,7 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
             engine
-                .open_workspace_session()
+                .open_session()
                 .await
                 .expect("main session should open"),
             &engine,
@@ -303,7 +303,7 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
             engine
-                .open_workspace_session()
+                .open_session()
                 .await
                 .expect("main session should open"),
             &engine,
@@ -334,7 +334,7 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
             engine
-                .open_workspace_session()
+                .open_session()
                 .await
                 .expect("main session should open"),
             &engine,
@@ -364,7 +364,7 @@ simulation_test!(sql_create_table_returns_error, |sim| async move {
     let engine = sim.boot_engine().await;
     let session = sim.wrap_session(
         engine
-            .open_workspace_session()
+            .open_session()
             .await
             .expect("main session should open"),
         &engine,
@@ -384,7 +384,7 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
             engine
-                .open_workspace_session()
+                .open_session()
                 .await
                 .expect("main session should open"),
             &engine,

--- a/packages/lix/tests/integration/sql/history_conformance.rs
+++ b/packages/lix/tests/integration/sql/history_conformance.rs
@@ -9,7 +9,7 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
             engine
-                .open_workspace_session()
+                .open_session()
                 .await
                 .expect("main session should open"),
             &engine,
@@ -51,7 +51,7 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
             engine
-                .open_workspace_session()
+                .open_session()
                 .await
                 .expect("main session should open"),
             &engine,
@@ -102,7 +102,7 @@ simulation_test!(typed_entity_history_exposes_tombstones, |sim| async move {
     let engine = sim.boot_engine().await;
     let session = sim.wrap_session(
         engine
-            .open_workspace_session()
+            .open_session()
             .await
             .expect("main session should open"),
         &engine,
@@ -174,7 +174,7 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
             engine
-                .open_workspace_session()
+                .open_session()
                 .await
                 .expect("main session should open"),
             &engine,
@@ -231,7 +231,7 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
             engine
-                .open_workspace_session()
+                .open_session()
                 .await
                 .expect("main session should open"),
             &engine,
@@ -304,7 +304,7 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
             engine
-                .open_workspace_session()
+                .open_session()
                 .await
                 .expect("main session should open"),
             &engine,
@@ -391,7 +391,7 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
             engine
-                .open_workspace_session()
+                .open_session()
                 .await
                 .expect("main session should open"),
             &engine,
@@ -449,7 +449,7 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
             engine
-                .open_workspace_session()
+                .open_session()
                 .await
                 .expect("main session should open"),
             &engine,
@@ -508,7 +508,7 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
             engine
-                .open_workspace_session()
+                .open_session()
                 .await
                 .expect("main session should open"),
             &engine,
@@ -653,7 +653,7 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
             engine
-                .open_workspace_session()
+                .open_session()
                 .await
                 .expect("main session should open"),
             &engine,
@@ -679,7 +679,7 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
             engine
-                .open_workspace_session()
+                .open_session()
                 .await
                 .expect("main session should open"),
             &engine,
@@ -724,7 +724,7 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
             engine
-                .open_workspace_session()
+                .open_session()
                 .await
                 .expect("main session should open"),
             &engine,
@@ -817,7 +817,7 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
             engine
-                .open_workspace_session()
+                .open_session()
                 .await
                 .expect("main session should open"),
             &engine,

--- a/packages/lix/tests/integration/sql/information_schema.rs
+++ b/packages/lix/tests/integration/sql/information_schema.rs
@@ -8,7 +8,7 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
             engine
-                .open_workspace_session()
+                .open_session()
                 .await
                 .expect("main session should open"),
             &engine,
@@ -57,7 +57,7 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
             engine
-                .open_workspace_session()
+                .open_session()
                 .await
                 .expect("main session should open"),
             &engine,
@@ -118,7 +118,7 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
             engine
-                .open_workspace_session()
+                .open_session()
                 .await
                 .expect("main session should open"),
             &engine,
@@ -572,7 +572,7 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
             engine
-                .open_workspace_session()
+                .open_session()
                 .await
                 .expect("main session should open"),
             &engine,
@@ -871,7 +871,7 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
             engine
-                .open_workspace_session()
+                .open_session()
                 .await
                 .expect("main session should open"),
             &engine,
@@ -1207,7 +1207,7 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
             engine
-                .open_workspace_session()
+                .open_session()
                 .await
                 .expect("main session should open"),
             &engine,
@@ -1381,7 +1381,7 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
             engine
-                .open_workspace_session()
+                .open_session()
                 .await
                 .expect("main session should open"),
             &engine,
@@ -1464,7 +1464,7 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
             engine
-                .open_workspace_session()
+                .open_session()
                 .await
                 .expect("main session should open"),
             &engine,
@@ -1668,7 +1668,7 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
             engine
-                .open_workspace_session()
+                .open_session()
                 .await
                 .expect("main session should open"),
             &engine,

--- a/packages/lix/tests/integration/sql/lix_branch.rs
+++ b/packages/lix/tests/integration/sql/lix_branch.rs
@@ -6,7 +6,7 @@ simulation_test!(lix_branch_lists_descriptors_with_refs, |sim| async move {
     let engine = sim.boot_engine().await;
     let session = sim.wrap_session(
         engine
-            .open_session("ffffffff-ffff-7fff-bfff-ffffffffffff")
+            .open_session_at("ffffffff-ffff-7fff-bfff-ffffffffffff")
             .await
             .expect("global session should open"),
         &engine,
@@ -47,7 +47,7 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
             engine
-                .open_session("ffffffff-ffff-7fff-bfff-ffffffffffff")
+                .open_session_at("ffffffff-ffff-7fff-bfff-ffffffffffff")
                 .await
                 .expect("global session should open"),
             &engine,
@@ -112,7 +112,7 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
             engine
-                .open_session("ffffffff-ffff-7fff-bfff-ffffffffffff")
+                .open_session_at("ffffffff-ffff-7fff-bfff-ffffffffffff")
                 .await
                 .expect("global session should open"),
             &engine,
@@ -139,9 +139,9 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
             engine
-                .open_workspace_session()
+                .open_session()
                 .await
-                .expect("workspace session should open"),
+                .expect("session should open"),
             &engine,
         );
         let branch_id = sim.main_branch_id();
@@ -221,9 +221,9 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
             engine
-                .open_workspace_session()
+                .open_session()
                 .await
-                .expect("workspace session should open"),
+                .expect("session should open"),
             &engine,
         );
 
@@ -270,9 +270,9 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
             engine
-                .open_workspace_session()
+                .open_session()
                 .await
-                .expect("workspace session should open"),
+                .expect("session should open"),
             &engine,
         );
 
@@ -306,9 +306,9 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
             engine
-                .open_workspace_session()
+                .open_session()
                 .await
-                .expect("workspace session should open"),
+                .expect("session should open"),
             &engine,
         );
 
@@ -376,9 +376,9 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
             engine
-                .open_workspace_session()
+                .open_session()
                 .await
-                .expect("workspace session should open"),
+                .expect("session should open"),
             &engine,
         );
 
@@ -433,9 +433,9 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
             engine
-                .open_workspace_session()
+                .open_session()
                 .await
-                .expect("workspace session should open"),
+                .expect("session should open"),
             &engine,
         );
 
@@ -494,9 +494,9 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
             engine
-                .open_workspace_session()
+                .open_session()
                 .await
-                .expect("workspace session should open"),
+                .expect("session should open"),
             &engine,
         );
 
@@ -603,9 +603,9 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
             engine
-                .open_workspace_session()
+                .open_session()
                 .await
-                .expect("workspace session should open"),
+                .expect("session should open"),
             &engine,
         );
 
@@ -672,9 +672,9 @@ simulation_test!(lix_branch_duplicate_insert_rejects, |sim| async move {
     let engine = sim.boot_engine().await;
     let session = sim.wrap_session(
         engine
-            .open_workspace_session()
+            .open_session()
             .await
-            .expect("workspace session should open"),
+            .expect("session should open"),
         &engine,
     );
 
@@ -711,9 +711,9 @@ simulation_test!(lix_branch_duplicate_name_insert_rejects, |sim| async move {
     let engine = sim.boot_engine().await;
     let session = sim.wrap_session(
         engine
-            .open_workspace_session()
+            .open_session()
             .await
-            .expect("workspace session should open"),
+            .expect("session should open"),
         &engine,
     );
 
@@ -745,9 +745,9 @@ simulation_test!(lix_branch_duplicate_name_update_rejects, |sim| async move {
     let engine = sim.boot_engine().await;
     let session = sim.wrap_session(
         engine
-            .open_workspace_session()
+            .open_session()
             .await
-            .expect("workspace session should open"),
+            .expect("session should open"),
         &engine,
     );
 
@@ -790,9 +790,9 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
             engine
-                .open_workspace_session()
+                .open_session()
                 .await
-                .expect("workspace session should open"),
+                .expect("session should open"),
             &engine,
         );
 
@@ -821,9 +821,9 @@ simulation_test!(lix_branch_update_rejects_id_change, |sim| async move {
     let engine = sim.boot_engine().await;
     let session = sim.wrap_session(
         engine
-            .open_workspace_session()
+            .open_session()
             .await
-            .expect("workspace session should open"),
+            .expect("session should open"),
         &engine,
     );
 
@@ -872,9 +872,9 @@ simulation_test!(lix_branch_update_rejects_global_branch, |sim| async move {
     let engine = sim.boot_engine().await;
     let session = sim.wrap_session(
         engine
-            .open_workspace_session()
+            .open_session()
             .await
-            .expect("workspace session should open"),
+            .expect("session should open"),
         &engine,
     );
 
@@ -906,9 +906,9 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
             engine
-                .open_workspace_session()
+                .open_session()
                 .await
-                .expect("workspace session should open"),
+                .expect("session should open"),
             &engine,
         );
 
@@ -929,9 +929,9 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
             engine
-                .open_workspace_session()
+                .open_session()
                 .await
-                .expect("workspace session should open"),
+                .expect("session should open"),
             &engine,
         );
 
@@ -980,9 +980,9 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
             engine
-                .open_workspace_session()
+                .open_session()
                 .await
-                .expect("workspace session should open"),
+                .expect("session should open"),
             &engine,
         );
 
@@ -1023,9 +1023,9 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
             engine
-                .open_workspace_session()
+                .open_session()
                 .await
-                .expect("workspace session should open"),
+                .expect("session should open"),
             &engine,
         );
 

--- a/packages/lix/tests/integration/sql/lix_change.rs
+++ b/packages/lix/tests/integration/sql/lix_change.rs
@@ -9,7 +9,7 @@ simulation_test!(lix_change_queries_durable_change_facts, |sim| async move {
     let engine = sim.boot_engine().await;
     let session = sim.wrap_session(
         engine
-            .open_workspace_session()
+            .open_session()
             .await
             .expect("main session should open"),
         &engine,
@@ -48,7 +48,7 @@ simulation_test!(lix_change_includes_commit_changes, |sim| async move {
     let engine = sim.boot_engine().await;
     let session = sim.wrap_session(
         engine
-            .open_workspace_session()
+            .open_session()
             .await
             .expect("main session should open"),
         &engine,
@@ -83,7 +83,7 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
             engine
-                .open_workspace_session()
+                .open_session()
                 .await
                 .expect("main session should open"),
             &engine,
@@ -141,7 +141,7 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
             engine
-                .open_workspace_session()
+                .open_session()
                 .await
                 .expect("main session should open"),
             &engine,
@@ -176,7 +176,7 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
             engine
-                .open_workspace_session()
+                .open_session()
                 .await
                 .expect("main session should open"),
             &engine,
@@ -195,7 +195,7 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
             engine
-                .open_workspace_session()
+                .open_session()
                 .await
                 .expect("main session should open"),
             &engine,

--- a/packages/lix/tests/integration/sql/lix_commit.rs
+++ b/packages/lix/tests/integration/sql/lix_commit.rs
@@ -10,7 +10,7 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
             engine
-                .open_workspace_session()
+                .open_session()
                 .await
                 .expect("main session should open"),
             &engine,
@@ -171,7 +171,7 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let main = sim.wrap_session(
             engine
-                .open_workspace_session()
+                .open_session()
                 .await
                 .expect("main session should open"),
             &engine,
@@ -194,7 +194,7 @@ simulation_test!(
 
         let branch = sim.wrap_session(
             engine
-                .open_session("01930000-0000-7000-8000-000000000006")
+                .open_session_at("01930000-0000-7000-8000-000000000006")
                 .await
                 .expect("branch session should open"),
             &engine,
@@ -256,7 +256,7 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let main = sim.wrap_session(
             engine
-                .open_workspace_session()
+                .open_session()
                 .await
                 .expect("main session should open"),
             &engine,
@@ -286,7 +286,7 @@ simulation_test!(
 
         let branch_a = sim.wrap_session(
             engine
-                .open_session("01930000-0000-7000-8000-000000000007")
+                .open_session_at("01930000-0000-7000-8000-000000000007")
                 .await
                 .expect("01930000-0000-7000-8000-000000000007 session should open"),
             &engine,
@@ -301,7 +301,7 @@ simulation_test!(
 
         let branch_b = sim.wrap_session(
             engine
-                .open_session("01930000-0000-7000-8000-000000000008")
+                .open_session_at("01930000-0000-7000-8000-000000000008")
                 .await
                 .expect("01930000-0000-7000-8000-000000000008 session should open"),
             &engine,
@@ -336,7 +336,7 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
             engine
-                .open_workspace_session()
+                .open_session()
                 .await
                 .expect("main session should open"),
             &engine,
@@ -367,7 +367,7 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
             engine
-                .open_workspace_session()
+                .open_session()
                 .await
                 .expect("main session should open"),
             &engine,

--- a/packages/lix/tests/integration/sql/lix_directory.rs
+++ b/packages/lix/tests/integration/sql/lix_directory.rs
@@ -11,7 +11,7 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
             engine
-                .open_workspace_session()
+                .open_session()
                 .await
                 .expect("main session should open"),
             &engine,
@@ -66,7 +66,7 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
             engine
-                .open_workspace_session()
+                .open_session()
                 .await
                 .expect("main session should open"),
             &engine,
@@ -125,7 +125,7 @@ simulation_test!(lix_directory_insert_reads_nested_paths, |sim| async move {
     let engine = sim.boot_engine().await;
     let session = sim.wrap_session(
         engine
-            .open_workspace_session()
+            .open_session()
             .await
             .expect("main session should open"),
         &engine,
@@ -189,7 +189,7 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
             engine
-                .open_workspace_session()
+                .open_session()
                 .await
                 .expect("main session should open"),
             &engine,
@@ -238,7 +238,7 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
             engine
-                .open_workspace_session()
+                .open_session()
                 .await
                 .expect("main session should open"),
             &engine,
@@ -283,7 +283,7 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
             engine
-                .open_workspace_session()
+                .open_session()
                 .await
                 .expect("main session should open"),
             &engine,
@@ -308,7 +308,7 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
             engine
-                .open_workspace_session()
+                .open_session()
                 .await
                 .expect("main session should open"),
             &engine,
@@ -348,7 +348,7 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
             engine
-                .open_workspace_session()
+                .open_session()
                 .await
                 .expect("main session should open"),
             &engine,
@@ -398,7 +398,7 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
             engine
-                .open_workspace_session()
+                .open_session()
                 .await
                 .expect("main session should open"),
             &engine,
@@ -424,7 +424,7 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
             engine
-                .open_workspace_session()
+                .open_session()
                 .await
                 .expect("main session should open"),
             &engine,
@@ -457,7 +457,7 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
             engine
-                .open_workspace_session()
+                .open_session()
                 .await
                 .expect("main session should open"),
             &engine,
@@ -493,7 +493,7 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
             engine
-                .open_workspace_session()
+                .open_session()
                 .await
                 .expect("main session should open"),
             &engine,
@@ -525,7 +525,7 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
             engine
-                .open_workspace_session()
+                .open_session()
                 .await
                 .expect("main session should open"),
             &engine,
@@ -547,7 +547,7 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
             engine
-                .open_workspace_session()
+                .open_session()
                 .await
                 .expect("main session should open"),
             &engine,
@@ -573,7 +573,7 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
             engine
-                .open_workspace_session()
+                .open_session()
                 .await
                 .expect("main session should open"),
             &engine,
@@ -615,7 +615,7 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
             engine
-                .open_workspace_session()
+                .open_session()
                 .await
                 .expect("main session should open"),
             &engine,
@@ -677,7 +677,7 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
             engine
-                .open_workspace_session()
+                .open_session()
                 .await
                 .expect("main session should open"),
             &engine,
@@ -703,7 +703,7 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
             engine
-                .open_workspace_session()
+                .open_session()
                 .await
                 .expect("main session should open"),
             &engine,
@@ -737,7 +737,7 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
             engine
-                .open_workspace_session()
+                .open_session()
                 .await
                 .expect("main session should open"),
             &engine,
@@ -790,7 +790,7 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
             engine
-                .open_workspace_session()
+                .open_session()
                 .await
                 .expect("main session should open"),
             &engine,
@@ -865,7 +865,7 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
             engine
-                .open_workspace_session()
+                .open_session()
                 .await
                 .expect("main session should open"),
             &engine,
@@ -918,7 +918,7 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
             engine
-                .open_workspace_session()
+                .open_session()
                 .await
                 .expect("main session should open"),
             &engine,
@@ -959,7 +959,7 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
             engine
-                .open_workspace_session()
+                .open_session()
                 .await
                 .expect("main session should open"),
             &engine,
@@ -1010,7 +1010,7 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
             engine
-                .open_workspace_session()
+                .open_session()
                 .await
                 .expect("main session should open"),
             &engine,
@@ -1068,7 +1068,7 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
             engine
-                .open_workspace_session()
+                .open_session()
                 .await
                 .expect("main session should open"),
             &engine,
@@ -1100,7 +1100,7 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
             engine
-                .open_workspace_session()
+                .open_session()
                 .await
                 .expect("main session should open"),
             &engine,
@@ -1167,7 +1167,7 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
             engine
-                .open_workspace_session()
+                .open_session()
                 .await
                 .expect("main session should open"),
             &engine,
@@ -1219,7 +1219,7 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
             engine
-                .open_workspace_session()
+                .open_session()
                 .await
                 .expect("main session should open"),
             &engine,
@@ -1271,7 +1271,7 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
             engine
-                .open_workspace_session()
+                .open_session()
                 .await
                 .expect("main session should open"),
             &engine,
@@ -1314,7 +1314,7 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
             engine
-                .open_workspace_session()
+                .open_session()
                 .await
                 .expect("main session should open"),
             &engine,
@@ -1363,7 +1363,7 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
             engine
-                .open_workspace_session()
+                .open_session()
                 .await
                 .expect("main session should open"),
             &engine,
@@ -1412,7 +1412,7 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
             engine
-                .open_workspace_session()
+                .open_session()
                 .await
                 .expect("main session should open"),
             &engine,
@@ -1467,7 +1467,7 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
             engine
-                .open_workspace_session()
+                .open_session()
                 .await
                 .expect("main session should open"),
             &engine,
@@ -1500,7 +1500,7 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
             engine
-                .open_workspace_session()
+                .open_session()
                 .await
                 .expect("main session should open"),
             &engine,
@@ -1525,7 +1525,7 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
             engine
-                .open_workspace_session()
+                .open_session()
                 .await
                 .expect("main session should open"),
             &engine,
@@ -1560,7 +1560,7 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
             engine
-                .open_workspace_session()
+                .open_session()
                 .await
                 .expect("main session should open"),
             &engine,
@@ -1613,7 +1613,7 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
             engine
-                .open_workspace_session()
+                .open_session()
                 .await
                 .expect("main session should open"),
             &engine,
@@ -1719,7 +1719,7 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
             engine
-                .open_workspace_session()
+                .open_session()
                 .await
                 .expect("main session should open"),
             &engine,
@@ -1776,7 +1776,7 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
             engine
-                .open_workspace_session()
+                .open_session()
                 .await
                 .expect("main session should open"),
             &engine,
@@ -1832,7 +1832,7 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
             engine
-                .open_workspace_session()
+                .open_session()
                 .await
                 .expect("main session should open"),
             &engine,
@@ -1879,7 +1879,7 @@ simulation_test!(
         {
             let session = sim.wrap_session(
                 engine
-                    .open_workspace_session()
+                    .open_session()
                     .await
                     .expect("main session should open"),
                 &engine,
@@ -1914,7 +1914,7 @@ simulation_test!(
             .expect("engine should reboot from the current snapshot");
         let session = sim.wrap_session(
             rebooted
-                .open_workspace_session()
+                .open_session()
                 .await
                 .expect("session should open after reboot"),
             &rebooted,

--- a/packages/lix/tests/integration/sql/lix_directory_history.rs
+++ b/packages/lix/tests/integration/sql/lix_directory_history.rs
@@ -11,7 +11,7 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
             engine
-                .open_workspace_session()
+                .open_session()
                 .await
                 .expect("main session should open"),
             &engine,
@@ -139,7 +139,7 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
             engine
-                .open_workspace_session()
+                .open_session()
                 .await
                 .expect("main session should open"),
             &engine,
@@ -179,7 +179,7 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let main = sim.wrap_session(
             engine
-                .open_session(sim.main_branch_id())
+                .open_session_at(sim.main_branch_id())
                 .await
                 .expect("main session should open"),
             &engine,
@@ -199,7 +199,7 @@ simulation_test!(
         .expect("draft branch should be created");
         let draft = sim.wrap_session(
             engine
-                .open_session("01930000-0000-7000-8000-000000000009")
+                .open_session_at("01930000-0000-7000-8000-000000000009")
                 .await
                 .expect("draft session should open"),
             &engine,
@@ -288,7 +288,7 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
             engine
-                .open_workspace_session()
+                .open_session()
                 .await
                 .expect("main session should open"),
             &engine,

--- a/packages/lix/tests/integration/sql/lix_file.rs
+++ b/packages/lix/tests/integration/sql/lix_file.rs
@@ -12,7 +12,7 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
             engine
-                .open_workspace_session()
+                .open_session()
                 .await
                 .expect("main session should open"),
             &engine,
@@ -151,7 +151,7 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
             engine
-                .open_workspace_session()
+                .open_session()
                 .await
                 .expect("main session should open"),
             &engine,
@@ -316,7 +316,7 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
             engine
-                .open_workspace_session()
+                .open_session()
                 .await
                 .expect("main session should open"),
             &engine,
@@ -379,7 +379,7 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
             engine
-                .open_workspace_session()
+                .open_session()
                 .await
                 .expect("main session should open"),
             &engine,
@@ -416,7 +416,7 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let missing = sim.wrap_session(
             engine
-                .open_session("missing-file-branch")
+                .open_session_at("missing-file-branch")
                 .await
                 .expect("a pinned session may open before its branch is resolved"),
             &engine,
@@ -440,7 +440,7 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
             engine
-                .open_workspace_session()
+                .open_session()
                 .await
                 .expect("main session should open"),
             &engine,
@@ -460,7 +460,7 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
             engine
-                .open_workspace_session()
+                .open_session()
                 .await
                 .expect("main session should open"),
             &engine,
@@ -481,7 +481,7 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
             engine
-                .open_workspace_session()
+                .open_session()
                 .await
                 .expect("main session should open"),
             &engine,
@@ -586,7 +586,7 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
             engine
-                .open_workspace_session()
+                .open_session()
                 .await
                 .expect("main session should open"),
             &engine,
@@ -611,7 +611,7 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
             engine
-                .open_workspace_session()
+                .open_session()
                 .await
                 .expect("main session should open"),
             &engine,
@@ -666,7 +666,7 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
             engine
-                .open_workspace_session()
+                .open_session()
                 .await
                 .expect("main session should open"),
             &engine,
@@ -719,7 +719,7 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
             engine
-                .open_workspace_session()
+                .open_session()
                 .await
                 .expect("main session should open"),
             &engine,
@@ -780,7 +780,7 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
             engine
-                .open_workspace_session()
+                .open_session()
                 .await
                 .expect("main session should open"),
             &engine,
@@ -865,7 +865,7 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
             engine
-                .open_workspace_session()
+                .open_session()
                 .await
                 .expect("main session should open"),
             &engine,
@@ -891,7 +891,7 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
             engine
-                .open_workspace_session()
+                .open_session()
                 .await
                 .expect("main session should open"),
             &engine,
@@ -933,7 +933,7 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
             engine
-                .open_workspace_session()
+                .open_session()
                 .await
                 .expect("main session should open"),
             &engine,
@@ -956,7 +956,7 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
             engine
-                .open_workspace_session()
+                .open_session()
                 .await
                 .expect("main session should open"),
             &engine,
@@ -1012,7 +1012,7 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
             engine
-                .open_workspace_session()
+                .open_session()
                 .await
                 .expect("main session should open"),
             &engine,
@@ -1089,7 +1089,7 @@ simulation_test!(lix_file_insert_applies_defaulted_id, |sim| async move {
     let engine = sim.boot_engine().await;
     let session = sim.wrap_session(
         engine
-            .open_workspace_session()
+            .open_session()
             .await
             .expect("main session should open"),
         &engine,
@@ -1147,7 +1147,7 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
             engine
-                .open_workspace_session()
+                .open_session()
                 .await
                 .expect("main session should open"),
             &engine,
@@ -1205,7 +1205,7 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
             engine
-                .open_workspace_session()
+                .open_session()
                 .await
                 .expect("main session should open"),
             &engine,
@@ -1245,7 +1245,7 @@ simulation_test!(lix_file_content_is_not_nullable, |sim| async move {
     let engine = sim.boot_engine().await;
     let session = sim.wrap_session(
         engine
-            .open_workspace_session()
+            .open_session()
             .await
             .expect("main session should open"),
         &engine,
@@ -1270,7 +1270,7 @@ simulation_test!(lix_file_insert_rejects_null_content, |sim| async move {
     let engine = sim.boot_engine().await;
     let session = sim.wrap_session(
         engine
-            .open_workspace_session()
+            .open_session()
             .await
             .expect("main session should open"),
         &engine,
@@ -1315,7 +1315,7 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
             engine
-                .open_workspace_session()
+                .open_session()
                 .await
                 .expect("main session should open"),
             &engine,
@@ -1389,7 +1389,7 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
             engine
-                .open_workspace_session()
+                .open_session()
                 .await
                 .expect("main session should open"),
             &engine,
@@ -1426,7 +1426,7 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
             engine
-                .open_workspace_session()
+                .open_session()
                 .await
                 .expect("main session should open"),
             &engine,
@@ -1468,7 +1468,7 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
             engine
-                .open_workspace_session()
+                .open_session()
                 .await
                 .expect("main session should open"),
             &engine,
@@ -1557,7 +1557,7 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
             engine
-                .open_workspace_session()
+                .open_session()
                 .await
                 .expect("main session should open"),
             &engine,
@@ -1601,7 +1601,7 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
             engine
-                .open_workspace_session()
+                .open_session()
                 .await
                 .expect("main session should open"),
             &engine,
@@ -1628,7 +1628,7 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
             engine
-                .open_workspace_session()
+                .open_session()
                 .await
                 .expect("main session should open"),
             &engine,
@@ -1674,7 +1674,7 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
             engine
-                .open_workspace_session()
+                .open_session()
                 .await
                 .expect("main session should open"),
             &engine,
@@ -1706,7 +1706,7 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
             engine
-                .open_workspace_session()
+                .open_session()
                 .await
                 .expect("main session should open"),
             &engine,
@@ -1748,7 +1748,7 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
             engine
-                .open_workspace_session()
+                .open_session()
                 .await
                 .expect("main session should open"),
             &engine,
@@ -1788,7 +1788,7 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
             engine
-                .open_workspace_session()
+                .open_session()
                 .await
                 .expect("main session should open"),
             &engine,
@@ -1822,7 +1822,7 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
             engine
-                .open_workspace_session()
+                .open_session()
                 .await
                 .expect("main session should open"),
             &engine,
@@ -1872,7 +1872,7 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
             engine
-                .open_workspace_session()
+                .open_session()
                 .await
                 .expect("main session should open"),
             &engine,
@@ -1902,7 +1902,7 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
             engine
-                .open_workspace_session()
+                .open_session()
                 .await
                 .expect("main session should open"),
             &engine,
@@ -1937,7 +1937,7 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
             engine
-                .open_workspace_session()
+                .open_session()
                 .await
                 .expect("main session should open"),
             &engine,
@@ -1963,7 +1963,7 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
             engine
-                .open_workspace_session()
+                .open_session()
                 .await
                 .expect("main session should open"),
             &engine,
@@ -1996,7 +1996,7 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
             engine
-                .open_workspace_session()
+                .open_session()
                 .await
                 .expect("main session should open"),
             &engine,
@@ -2032,7 +2032,7 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
             engine
-                .open_workspace_session()
+                .open_session()
                 .await
                 .expect("main session should open"),
             &engine,
@@ -2057,7 +2057,7 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
             engine
-                .open_workspace_session()
+                .open_session()
                 .await
                 .expect("main session should open"),
             &engine,
@@ -2112,7 +2112,7 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
             engine
-                .open_workspace_session()
+                .open_session()
                 .await
                 .expect("main session should open"),
             &engine,
@@ -2148,7 +2148,7 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
             engine
-                .open_workspace_session()
+                .open_session()
                 .await
                 .expect("main session should open"),
             &engine,
@@ -2198,7 +2198,7 @@ simulation_test!(lix_file_path_update_preserves_content, |sim| async move {
     let engine = sim.boot_engine().await;
     let session = sim.wrap_session(
         engine
-            .open_workspace_session()
+            .open_session()
             .await
             .expect("main session should open"),
         &engine,
@@ -2269,7 +2269,7 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
             engine
-                .open_workspace_session()
+                .open_session()
                 .await
                 .expect("main session should open"),
             &engine,
@@ -2359,7 +2359,7 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
             engine
-                .open_workspace_session()
+                .open_session()
                 .await
                 .expect("main session should open"),
             &engine,
@@ -2461,7 +2461,7 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
             engine
-                .open_workspace_session()
+                .open_session()
                 .await
                 .expect("main session should open"),
             &engine,
@@ -2564,7 +2564,7 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
             engine
-                .open_workspace_session()
+                .open_session()
                 .await
                 .expect("main session should open"),
             &engine,
@@ -2620,7 +2620,7 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
             engine
-                .open_workspace_session()
+                .open_session()
                 .await
                 .expect("main session should open"),
             &engine,
@@ -2708,7 +2708,7 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
             engine
-                .open_workspace_session()
+                .open_session()
                 .await
                 .expect("main session should open"),
             &engine,
@@ -2776,7 +2776,7 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
             engine
-                .open_workspace_session()
+                .open_session()
                 .await
                 .expect("main session should open"),
             &engine,
@@ -2818,7 +2818,7 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
             engine
-                .open_workspace_session()
+                .open_session()
                 .await
                 .expect("main session should open"),
             &engine,
@@ -2893,7 +2893,7 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
             engine
-                .open_workspace_session()
+                .open_session()
                 .await
                 .expect("main session should open"),
             &engine,
@@ -3045,7 +3045,7 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
             engine
-                .open_workspace_session()
+                .open_session()
                 .await
                 .expect("main session should open"),
             &engine,
@@ -3085,7 +3085,7 @@ simulation_test!(lix_file_by_branch_expands_global_rows, |sim| async move {
     let engine = sim.boot_engine().await;
     let session = sim.wrap_session(
         engine
-            .open_workspace_session()
+            .open_session()
             .await
             .expect("main session should open"),
         &engine,
@@ -3137,7 +3137,7 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
             engine
-                .open_workspace_session()
+                .open_session()
                 .await
                 .expect("main session should open"),
             &engine,
@@ -3178,7 +3178,7 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
             engine
-                .open_workspace_session()
+                .open_session()
                 .await
                 .expect("main session should open"),
             &engine,
@@ -3240,7 +3240,7 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
             engine
-                .open_workspace_session()
+                .open_session()
                 .await
                 .expect("main session should open"),
             &engine,
@@ -3307,7 +3307,7 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
             engine
-                .open_workspace_session()
+                .open_session()
                 .await
                 .expect("main session should open"),
             &engine,
@@ -3357,7 +3357,7 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
             engine
-                .open_workspace_session()
+                .open_session()
                 .await
                 .expect("main session should open"),
             &engine,
@@ -3407,7 +3407,7 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
             engine
-                .open_workspace_session()
+                .open_session()
                 .await
                 .expect("main session should open"),
             &engine,
@@ -3448,7 +3448,7 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
             engine
-                .open_workspace_session()
+                .open_session()
                 .await
                 .expect("main session should open"),
             &engine,
@@ -3488,7 +3488,7 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
             engine
-                .open_workspace_session()
+                .open_session()
                 .await
                 .expect("main session should open"),
             &engine,
@@ -3547,7 +3547,7 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
             engine
-                .open_workspace_session()
+                .open_session()
                 .await
                 .expect("main session should open"),
             &engine,
@@ -3603,7 +3603,7 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
             engine
-                .open_workspace_session()
+                .open_session()
                 .await
                 .expect("main session should open"),
             &engine,
@@ -3636,7 +3636,7 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
             engine
-                .open_workspace_session()
+                .open_session()
                 .await
                 .expect("main session should open"),
             &engine,
@@ -3661,7 +3661,7 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
             engine
-                .open_workspace_session()
+                .open_session()
                 .await
                 .expect("main session should open"),
             &engine,
@@ -3696,7 +3696,7 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
             engine
-                .open_workspace_session()
+                .open_session()
                 .await
                 .expect("main session should open"),
             &engine,
@@ -3749,7 +3749,7 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
             engine
-                .open_workspace_session()
+                .open_session()
                 .await
                 .expect("main session should open"),
             &engine,
@@ -3779,7 +3779,7 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
             engine
-                .open_workspace_session()
+                .open_session()
                 .await
                 .expect("main session should open"),
             &engine,
@@ -3921,7 +3921,7 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
             engine
-                .open_workspace_session()
+                .open_session()
                 .await
                 .expect("main session should open"),
             &engine,
@@ -4032,14 +4032,14 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
             engine
-                .open_workspace_session()
+                .open_session()
                 .await
                 .expect("transaction session should open"),
             &engine,
         );
         let other_session = sim.wrap_session(
             engine
-                .open_workspace_session()
+                .open_session()
                 .await
                 .expect("other session should open"),
             &engine,
@@ -4125,7 +4125,7 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let main = sim.wrap_session(
             engine
-                .open_session(sim.main_branch_id())
+                .open_session_at(sim.main_branch_id())
                 .await
                 .expect("main session should open"),
             &engine,
@@ -4139,7 +4139,7 @@ simulation_test!(
         .expect("draft branch should create");
         let draft = main.wrap_session(
             engine
-                .open_session("01930000-0000-7000-8000-00000000000a")
+                .open_session_at("01930000-0000-7000-8000-00000000000a")
                 .await
                 .expect("draft session should open"),
             &engine,
@@ -4163,7 +4163,7 @@ simulation_test!(
 
         let transaction_session = main.wrap_session(
             engine
-                .open_session(sim.main_branch_id())
+                .open_session_at(sim.main_branch_id())
                 .await
                 .expect("transaction session should open"),
             &engine,

--- a/packages/lix/tests/integration/sql/lix_file_history.rs
+++ b/packages/lix/tests/integration/sql/lix_file_history.rs
@@ -143,9 +143,9 @@ async fn lix_file_history_point_lookup_does_not_rescan_unrelated_observed_state(
         .await
         .expect("engine should open");
     let session = engine
-        .open_workspace_session()
+        .open_session()
         .await
-        .expect("workspace session should open");
+        .expect("session should open");
 
     let unrelated_values = (0..UNRELATED_FILE_COUNT)
         .map(|index| {
@@ -277,9 +277,9 @@ async fn lix_file_history_path_lookup_does_not_rescan_unrelated_observed_state()
         .await
         .expect("engine should open");
     let session = engine
-        .open_workspace_session()
+        .open_session()
         .await
-        .expect("workspace session should open");
+        .expect("session should open");
 
     let unrelated_values = (0..UNRELATED_FILE_COUNT)
         .map(|index| {
@@ -401,9 +401,9 @@ async fn lix_file_history_path_filter_equals_unfiltered_scan_over_many_files() {
         .await
         .expect("engine should open");
     let session = engine
-        .open_workspace_session()
+        .open_session()
         .await
-        .expect("workspace session should open");
+        .expect("session should open");
 
     let bulk_values = (0..BULK_FILE_COUNT)
         .map(|index| format!("('/bulk/f{index:03}.txt', CAST('bulk' AS BYTEA))"))
@@ -549,9 +549,9 @@ async fn lix_file_history_ancestor_point_lookup_keeps_parent_evidence_bounded() 
         .await
         .expect("engine should open");
     let session = engine
-        .open_workspace_session()
+        .open_session()
         .await
-        .expect("workspace session should open");
+        .expect("session should open");
 
     let unrelated_directories = (0..UNRELATED_DIRECTORY_COUNT)
         .map(|index| {
@@ -657,7 +657,7 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
             engine
-                .open_workspace_session()
+                .open_session()
                 .await
                 .expect("main session should open"),
             &engine,
@@ -785,7 +785,7 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
             engine
-                .open_workspace_session()
+                .open_session()
                 .await
                 .expect("main session should open"),
             &engine,
@@ -913,7 +913,7 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let main = sim.wrap_session(
             engine
-                .open_session(sim.main_branch_id())
+                .open_session_at(sim.main_branch_id())
                 .await
                 .expect("main session should open"),
             &engine,
@@ -942,7 +942,7 @@ simulation_test!(
         .expect("sibling branch should create");
         let draft = sim.wrap_session(
             engine
-                .open_session("01930000-0000-7000-8000-00000000000b")
+                .open_session_at("01930000-0000-7000-8000-00000000000b")
                 .await
                 .expect("draft session should open"),
             &engine,
@@ -1022,7 +1022,7 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
             engine
-                .open_workspace_session()
+                .open_session()
                 .await
                 .expect("main session should open"),
             &engine,
@@ -1175,7 +1175,7 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
             engine
-                .open_workspace_session()
+                .open_session()
                 .await
                 .expect("main session should open"),
             &engine,
@@ -1321,7 +1321,7 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
             engine
-                .open_workspace_session()
+                .open_session()
                 .await
                 .expect("main session should open"),
             &engine,
@@ -1369,7 +1369,7 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let main = sim.wrap_session(
             engine
-                .open_session(sim.main_branch_id())
+                .open_session_at(sim.main_branch_id())
                 .await
                 .expect("main session should open"),
             &engine,
@@ -1390,7 +1390,7 @@ simulation_test!(
         .expect("draft branch should be created");
         let draft = sim.wrap_session(
             engine
-                .open_session("01930000-0000-7000-8000-00000000000c")
+                .open_session_at("01930000-0000-7000-8000-00000000000c")
                 .await
                 .expect("draft session should open"),
             &engine,
@@ -1492,7 +1492,7 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
             engine
-                .open_workspace_session()
+                .open_session()
                 .await
                 .expect("main session should open"),
             &engine,
@@ -1555,7 +1555,7 @@ simulation_test!(lix_file_history_reads_bound_id_in_list, |sim| async move {
     let engine = sim.boot_engine().await;
     let session = sim.wrap_session(
         engine
-            .open_workspace_session()
+            .open_session()
             .await
             .expect("main session should open"),
         &engine,
@@ -1614,7 +1614,7 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
             engine
-                .open_workspace_session()
+                .open_session()
                 .await
                 .expect("main session should open"),
             &engine,
@@ -1672,7 +1672,7 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
             engine
-                .open_workspace_session()
+                .open_session()
                 .await
                 .expect("main session should open"),
             &engine,
@@ -1722,7 +1722,7 @@ simulation_test!(lix_file_history_defaults_to_active_head, |sim| async move {
     let engine = sim.boot_engine().await;
     let session = sim.wrap_session(
         engine
-            .open_workspace_session()
+            .open_session()
             .await
             .expect("main session should open"),
         &engine,
@@ -1761,7 +1761,7 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
             engine
-                .open_workspace_session()
+                .open_session()
                 .await
                 .expect("main session should open"),
             &engine,
@@ -1819,7 +1819,7 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
             engine
-                .open_workspace_session()
+                .open_session()
                 .await
                 .expect("main session should open"),
             &engine,

--- a/packages/lix/tests/integration/sql/lix_json.rs
+++ b/packages/lix/tests/integration/sql/lix_json.rs
@@ -9,7 +9,7 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
             engine
-                .open_workspace_session()
+                .open_session()
                 .await
                 .expect("main session should open"),
             &engine,
@@ -43,7 +43,7 @@ simulation_test!(lix_json_get_uses_variadic_path_segments, |sim| async move {
     let engine = sim.boot_engine().await;
     let session = sim.wrap_session(
         engine
-            .open_workspace_session()
+            .open_session()
             .await
             .expect("main session should open"),
         &engine,
@@ -64,7 +64,7 @@ simulation_test!(lix_json_get_rejects_jsonpath_strings, |sim| async move {
     let engine = sim.boot_engine().await;
     let session = sim.wrap_session(
         engine
-            .open_workspace_session()
+            .open_session()
             .await
             .expect("main session should open"),
         &engine,
@@ -91,7 +91,7 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
             engine
-                .open_workspace_session()
+                .open_session()
                 .await
                 .expect("main session should open"),
             &engine,
@@ -119,7 +119,7 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
             engine
-                .open_workspace_session()
+                .open_session()
                 .await
                 .expect("main session should open"),
             &engine,
@@ -169,7 +169,7 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
             engine
-                .open_workspace_session()
+                .open_session()
                 .await
                 .expect("main session should open"),
             &engine,
@@ -191,7 +191,7 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
             engine
-                .open_workspace_session()
+                .open_session()
                 .await
                 .expect("main session should open"),
             &engine,
@@ -250,7 +250,7 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
             engine
-                .open_workspace_session()
+                .open_session()
                 .await
                 .expect("main session should open"),
             &engine,

--- a/packages/lix/tests/integration/sql/lix_key_value.rs
+++ b/packages/lix/tests/integration/sql/lix_key_value.rs
@@ -6,7 +6,7 @@ simulation_test!(lix_key_value_roundtrips_arbitrary_json, |sim| async move {
     let engine = sim.boot_engine().await;
     let session = sim.wrap_session(
         engine
-            .open_workspace_session()
+            .open_session()
             .await
             .expect("main session should open"),
         &engine,
@@ -37,14 +37,14 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
             engine
-                .open_workspace_session()
+                .open_session()
                 .await
                 .expect("main session should open"),
             &engine,
         );
         let global_session = sim.wrap_session(
             engine
-                .open_session("ffffffff-ffff-7fff-bfff-ffffffffffff")
+                .open_session_at("ffffffff-ffff-7fff-bfff-ffffffffffff")
                 .await
                 .expect("global session should open"),
             &engine,
@@ -107,7 +107,7 @@ simulation_test!(lix_key_value_duplicate_insert_rejects, |sim| async move {
     let engine = sim.boot_engine().await;
     let session = sim.wrap_session(
         engine
-            .open_workspace_session()
+            .open_session()
             .await
             .expect("main session should open"),
         &engine,
@@ -154,7 +154,7 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
             engine
-                .open_workspace_session()
+                .open_session()
                 .await
                 .expect("main session should open"),
             &engine,
@@ -206,7 +206,7 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
             engine
-                .open_workspace_session()
+                .open_session()
                 .await
                 .expect("main session should open"),
             &engine,
@@ -248,7 +248,7 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
             engine
-                .open_workspace_session()
+                .open_session()
                 .await
                 .expect("main session should open"),
             &engine,
@@ -291,14 +291,14 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
             engine
-                .open_workspace_session()
+                .open_session()
                 .await
                 .expect("main session should open"),
             &engine,
         );
         let global_session = sim.wrap_session(
             engine
-                .open_session("ffffffff-ffff-7fff-bfff-ffffffffffff")
+                .open_session_at("ffffffff-ffff-7fff-bfff-ffffffffffff")
                 .await
                 .expect("global session should open"),
             &engine,
@@ -349,7 +349,7 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
             engine
-                .open_workspace_session()
+                .open_session()
                 .await
                 .expect("main session should open"),
             &engine,

--- a/packages/lix/tests/integration/sql/lix_registered_schema.rs
+++ b/packages/lix/tests/integration/sql/lix_registered_schema.rs
@@ -12,7 +12,7 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
             engine
-                .open_workspace_session()
+                .open_session()
                 .await
                 .expect("main session should open"),
             &engine,
@@ -102,7 +102,7 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
             engine
-                .open_workspace_session()
+                .open_session()
                 .await
                 .expect("main session should open"),
             &engine,
@@ -159,7 +159,7 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
             engine
-                .open_workspace_session()
+                .open_session()
                 .await
                 .expect("main session should open"),
             &engine,
@@ -204,7 +204,7 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
             engine
-                .open_workspace_session()
+                .open_session()
                 .await
                 .expect("main session should open"),
             &engine,
@@ -276,7 +276,7 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
             engine
-                .open_workspace_session()
+                .open_session()
                 .await
                 .expect("main session should open"),
             &engine,
@@ -315,7 +315,7 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
             engine
-                .open_workspace_session()
+                .open_session()
                 .await
                 .expect("main session should open"),
             &engine,
@@ -388,7 +388,7 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
             engine
-                .open_workspace_session()
+                .open_session()
                 .await
                 .expect("main session should open"),
             &engine,
@@ -504,7 +504,7 @@ simulation_test!(lix_registered_schema_delete_is_rejected, |sim| async move {
     let engine = sim.boot_engine().await;
     let session = sim.wrap_session(
         engine
-            .open_workspace_session()
+            .open_session()
             .await
             .expect("main session should open"),
         &engine,
@@ -594,7 +594,7 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
             engine
-                .open_workspace_session()
+                .open_session()
                 .await
                 .expect("main session should open"),
             &engine,
@@ -694,7 +694,7 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
             engine
-                .open_workspace_session()
+                .open_session()
                 .await
                 .expect("main session should open"),
             &engine,
@@ -740,7 +740,7 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
             engine
-                .open_workspace_session()
+                .open_session()
                 .await
                 .expect("main session should open"),
             &engine,
@@ -779,7 +779,7 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let main = sim.wrap_session(
             engine
-                .open_session(sim.main_branch_id())
+                .open_session_at(sim.main_branch_id())
                 .await
                 .expect("main session should open"),
             &engine,
@@ -829,7 +829,7 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let main = sim.wrap_session(
             engine
-                .open_session(sim.main_branch_id())
+                .open_session_at(sim.main_branch_id())
                 .await
                 .expect("main session should open"),
             &engine,
@@ -880,7 +880,7 @@ simulation_test!(
 
         let target = sim.wrap_session(
             engine
-                .open_session("01930000-0000-7000-8000-000000000012")
+                .open_session_at("01930000-0000-7000-8000-000000000012")
                 .await
                 .expect("target session should open"),
             &engine,
@@ -929,7 +929,7 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let main = sim.wrap_session(
             engine
-                .open_session(sim.main_branch_id())
+                .open_session_at(sim.main_branch_id())
                 .await
                 .expect("main session should open"),
             &engine,
@@ -989,7 +989,7 @@ simulation_test!(
 
         let draft = sim.wrap_session(
             engine
-                .open_session("01930000-0000-7000-8000-000000000014")
+                .open_session_at("01930000-0000-7000-8000-000000000014")
                 .await
                 .expect("draft session should open"),
             &engine,
@@ -1047,7 +1047,7 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let main = sim.wrap_session(
             engine
-                .open_session(sim.main_branch_id())
+                .open_session_at(sim.main_branch_id())
                 .await
                 .expect("main session should open"),
             &engine,
@@ -1128,7 +1128,7 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
             engine
-                .open_workspace_session()
+                .open_session()
                 .await
                 .expect("main session should open"),
             &engine,
@@ -1183,7 +1183,7 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
             engine
-                .open_workspace_session()
+                .open_session()
                 .await
                 .expect("main session should open"),
             &engine,
@@ -1247,14 +1247,14 @@ simulation_test!(entity_by_branch_expands_global_rows, |sim| async move {
     let engine = sim.boot_engine().await;
     let global_session = sim.wrap_session(
         engine
-            .open_session("ffffffff-ffff-7fff-bfff-ffffffffffff")
+            .open_session_at("ffffffff-ffff-7fff-bfff-ffffffffffff")
             .await
             .expect("global session should open"),
         &engine,
     );
     let session = sim.wrap_session(
         engine
-            .open_workspace_session()
+            .open_session()
             .await
             .expect("main session should open"),
         &engine,
@@ -1333,7 +1333,7 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
             engine
-                .open_workspace_session()
+                .open_session()
                 .await
                 .expect("main session should open"),
             &engine,
@@ -1376,7 +1376,7 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
             engine
-                .open_workspace_session()
+                .open_session()
                 .await
                 .expect("main session should open"),
             &engine,
@@ -1433,7 +1433,7 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
             engine
-                .open_workspace_session()
+                .open_session()
                 .await
                 .expect("main session should open"),
             &engine,
@@ -1491,7 +1491,7 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
             engine
-                .open_workspace_session()
+                .open_session()
                 .await
                 .expect("main session should open"),
             &engine,
@@ -1577,7 +1577,7 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
             engine
-                .open_workspace_session()
+                .open_session()
                 .await
                 .expect("main session should open"),
             &engine,
@@ -1634,7 +1634,7 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
             engine
-                .open_workspace_session()
+                .open_session()
                 .await
                 .expect("main session should open"),
             &engine,
@@ -1691,7 +1691,7 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let main = sim.wrap_session(
             engine
-                .open_session(sim.main_branch_id())
+                .open_session_at(sim.main_branch_id())
                 .await
                 .expect("main session should open"),
             &engine,
@@ -1719,7 +1719,7 @@ simulation_test!(
 
         let draft = sim.wrap_session(
             engine
-                .open_session("01930000-0000-7000-8000-00000000000d")
+                .open_session_at("01930000-0000-7000-8000-00000000000d")
                 .await
                 .expect("draft session should open"),
             &engine,
@@ -1767,7 +1767,7 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let main = sim.wrap_session(
             engine
-                .open_session(sim.main_branch_id())
+                .open_session_at(sim.main_branch_id())
                 .await
                 .expect("main session should open"),
             &engine,
@@ -1824,7 +1824,7 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
             engine
-                .open_workspace_session()
+                .open_session()
                 .await
                 .expect("main session should open"),
             &engine,
@@ -1868,7 +1868,7 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
             engine
-                .open_workspace_session()
+                .open_session()
                 .await
                 .expect("main session should open"),
             &engine,
@@ -1912,7 +1912,7 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
             engine
-                .open_workspace_session()
+                .open_session()
                 .await
                 .expect("main session should open"),
             &engine,
@@ -1955,7 +1955,7 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let main = sim.wrap_session(
             engine
-                .open_session(sim.main_branch_id())
+                .open_session_at(sim.main_branch_id())
                 .await
                 .expect("main session should open"),
             &engine,
@@ -2011,7 +2011,7 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let main = sim.wrap_session(
             engine
-                .open_session(sim.main_branch_id())
+                .open_session_at(sim.main_branch_id())
                 .await
                 .expect("main session should open"),
             &engine,
@@ -2048,7 +2048,7 @@ simulation_test!(
 
         let draft = sim.wrap_session(
             engine
-                .open_session("01930000-0000-7000-8000-000000000010")
+                .open_session_at("01930000-0000-7000-8000-000000000010")
                 .await
                 .expect("draft session should open"),
             &engine,
@@ -2107,7 +2107,7 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let main = sim.wrap_session(
             engine
-                .open_session(sim.main_branch_id())
+                .open_session_at(sim.main_branch_id())
                 .await
                 .expect("main session should open"),
             &engine,
@@ -2144,7 +2144,7 @@ simulation_test!(
 
         let draft = sim.wrap_session(
             engine
-                .open_session("01930000-0000-7000-8000-000000000011")
+                .open_session_at("01930000-0000-7000-8000-000000000011")
                 .await
                 .expect("draft session should open"),
             &engine,
@@ -2204,7 +2204,7 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let main = sim.wrap_session(
             engine
-                .open_session(sim.main_branch_id())
+                .open_session_at(sim.main_branch_id())
                 .await
                 .expect("main session should open"),
             &engine,
@@ -2241,7 +2241,7 @@ simulation_test!(
 
         let draft = sim.wrap_session(
             engine
-                .open_session("01930000-0000-7000-8000-00000000000f")
+                .open_session_at("01930000-0000-7000-8000-00000000000f")
                 .await
                 .expect("draft session should open"),
             &engine,
@@ -2315,7 +2315,7 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
             engine
-                .open_workspace_session()
+                .open_session()
                 .await
                 .expect("main session should open"),
             &engine,
@@ -2372,7 +2372,7 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
             engine
-                .open_workspace_session()
+                .open_session()
                 .await
                 .expect("main session should open"),
             &engine,
@@ -2437,7 +2437,7 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
             engine
-                .open_workspace_session()
+                .open_session()
                 .await
                 .expect("main session should open"),
             &engine,

--- a/packages/lix/tests/integration/sql/metadata.rs
+++ b/packages/lix/tests/integration/sql/metadata.rs
@@ -8,7 +8,7 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
             engine
-                .open_workspace_session()
+                .open_session()
                 .await
                 .expect("main session should open"),
             &engine,
@@ -54,7 +54,7 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
             engine
-                .open_workspace_session()
+                .open_session()
                 .await
                 .expect("main session should open"),
             &engine,
@@ -100,7 +100,7 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
             engine
-                .open_workspace_session()
+                .open_session()
                 .await
                 .expect("main session should open"),
             &engine,
@@ -156,7 +156,7 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
             engine
-                .open_workspace_session()
+                .open_session()
                 .await
                 .expect("main session should open"),
             &engine,
@@ -512,7 +512,7 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
             engine
-                .open_workspace_session()
+                .open_session()
                 .await
                 .expect("main session should open"),
             &engine,

--- a/packages/lix/tests/integration/sql/read_only.rs
+++ b/packages/lix/tests/integration/sql/read_only.rs
@@ -6,9 +6,9 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
             engine
-                .open_workspace_session()
+                .open_session()
                 .await
-                .expect("workspace session should open"),
+                .expect("session should open"),
             &engine,
         );
 
@@ -55,9 +55,9 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
             engine
-                .open_workspace_session()
+                .open_session()
                 .await
-                .expect("workspace session should open"),
+                .expect("session should open"),
             &engine,
         );
 
@@ -98,9 +98,9 @@ simulation_test!(read_only_history_views_reject_dml, |sim| async move {
     let engine = sim.boot_engine().await;
     let session = sim.wrap_session(
         engine
-            .open_workspace_session()
+            .open_session()
             .await
-            .expect("workspace session should open"),
+            .expect("session should open"),
         &engine,
     );
 
@@ -130,9 +130,9 @@ simulation_test!(read_only_typed_history_views_reject_dml, |sim| async move {
     let engine = sim.boot_engine().await;
     let session = sim.wrap_session(
         engine
-            .open_workspace_session()
+            .open_session()
             .await
-            .expect("workspace session should open"),
+            .expect("session should open"),
         &engine,
     );
 
@@ -168,14 +168,14 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let reader = sim.wrap_session(
             engine
-                .open_workspace_session()
+                .open_session()
                 .await
                 .expect("reader session should open"),
             &engine,
         );
         let writer = sim.wrap_session(
             engine
-                .open_workspace_session()
+                .open_session()
                 .await
                 .expect("writer session should open"),
             &engine,

--- a/packages/lix/tests/integration/sql/subquery_reads.rs
+++ b/packages/lix/tests/integration/sql/subquery_reads.rs
@@ -16,7 +16,7 @@ simulation_test!(subquery_reads_do_not_leak_storage_read_handles, |sim| async mo
     let engine = sim.boot_engine().await;
     let session = sim.wrap_session(
         engine
-            .open_workspace_session()
+            .open_session()
             .await
             .expect("main session should open"),
         &engine,

--- a/packages/lix/tests/integration/sql/subquery_writes.rs
+++ b/packages/lix/tests/integration/sql/subquery_writes.rs
@@ -21,7 +21,7 @@ simulation_test!(subquery_writes_do_not_leak_storage_read_handles, |sim| async m
     let engine = sim.boot_engine().await;
     let session = sim.wrap_session(
         engine
-            .open_workspace_session()
+            .open_session()
             .await
             .expect("main session should open"),
         &engine,

--- a/packages/lix/tests/integration/sql/udfs.rs
+++ b/packages/lix/tests/integration/sql/udfs.rs
@@ -7,7 +7,7 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
             engine
-                .open_workspace_session()
+                .open_session()
                 .await
                 .expect("main session should open"),
             &engine,
@@ -46,7 +46,7 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let main = sim.wrap_session(
             engine
-                .open_session(sim.main_branch_id())
+                .open_session_at(sim.main_branch_id())
                 .await
                 .expect("main session should open"),
             &engine,
@@ -60,7 +60,7 @@ simulation_test!(
         .expect("draft branch should be created");
         let draft = sim.wrap_session(
             engine
-                .open_session("01930000-0000-7000-8000-000000000016")
+                .open_session_at("01930000-0000-7000-8000-000000000016")
                 .await
                 .expect("draft session should open"),
             &engine,
@@ -130,7 +130,7 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
             engine
-                .open_workspace_session()
+                .open_session()
                 .await
                 .expect("main session should open"),
             &engine,

--- a/packages/lix/tests/integration/sql/untracked_current_state.rs
+++ b/packages/lix/tests/integration/sql/untracked_current_state.rs
@@ -4,9 +4,9 @@ simulation_test!(untracked_insert_is_current_state_only, |sim| async move {
     let engine = sim.boot_engine().await;
     let session = sim.wrap_session(
         engine
-            .open_workspace_session()
+            .open_session()
             .await
-            .expect("workspace session should open"),
+            .expect("session should open"),
         &engine,
     );
     let head_before = branch_head(&session, sim.main_branch_id()).await;
@@ -39,9 +39,9 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
             engine
-                .open_workspace_session()
+                .open_session()
                 .await
-                .expect("workspace session should open"),
+                .expect("session should open"),
             &engine,
         );
         let head_before = branch_head(&session, sim.main_branch_id()).await;
@@ -117,9 +117,9 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
             engine
-                .open_workspace_session()
+                .open_session()
                 .await
-                .expect("workspace session should open"),
+                .expect("session should open"),
             &engine,
         );
 
@@ -167,9 +167,9 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
             engine
-                .open_workspace_session()
+                .open_session()
                 .await
-                .expect("workspace session should open"),
+                .expect("session should open"),
             &engine,
         );
 
@@ -226,9 +226,9 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
             engine
-                .open_workspace_session()
+                .open_session()
                 .await
-                .expect("workspace session should open"),
+                .expect("session should open"),
             &engine,
         );
         let initial_head = branch_head(&session, sim.main_branch_id()).await;
@@ -333,9 +333,9 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
             engine
-                .open_workspace_session()
+                .open_session()
                 .await
-                .expect("workspace session should open"),
+                .expect("session should open"),
             &engine,
         );
         let mut transaction = session
@@ -372,9 +372,9 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
             engine
-                .open_workspace_session()
+                .open_session()
                 .await
-                .expect("workspace session should open"),
+                .expect("session should open"),
             &engine,
         );
 
@@ -413,9 +413,9 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
             engine
-                .open_workspace_session()
+                .open_session()
                 .await
-                .expect("workspace session should open"),
+                .expect("session should open"),
             &engine,
         );
 

--- a/packages/lix/tests/integration/sql/write_returning.rs
+++ b/packages/lix/tests/integration/sql/write_returning.rs
@@ -8,9 +8,9 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
             engine
-                .open_workspace_session()
+                .open_session()
                 .await
-                .expect("workspace session should open"),
+                .expect("session should open"),
             &engine,
         );
 
@@ -169,9 +169,9 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
             engine
-                .open_workspace_session()
+                .open_session()
                 .await
-                .expect("workspace session should open"),
+                .expect("session should open"),
             &engine,
         );
 
@@ -467,9 +467,9 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
             engine
-                .open_workspace_session()
+                .open_session()
                 .await
-                .expect("workspace session should open"),
+                .expect("session should open"),
             &engine,
         );
 
@@ -626,9 +626,9 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
             engine
-                .open_workspace_session()
+                .open_session()
                 .await
-                .expect("workspace session should open"),
+                .expect("session should open"),
             &engine,
         );
 

--- a/packages/lix/tests/integration/support/simulation_test/engine/macro_runtime.rs
+++ b/packages/lix/tests/integration/support/simulation_test/engine/macro_runtime.rs
@@ -111,7 +111,7 @@ pub(crate) async fn enable_deterministic_mode(
     mode: SimulationMode,
 ) -> Result<(), LixError> {
     let timestamp_shuffle = deterministic_timestamp_shuffle_for(mode);
-    let session = engine.open_session(receipt.main_branch_id.clone()).await?;
+    let session = engine.open_session_at(receipt.main_branch_id.clone()).await?;
     match session
         .execute(&deterministic_mode_insert_sql(timestamp_shuffle), &[])
         .await

--- a/packages/lix/tests/integration/transaction.rs
+++ b/packages/lix/tests/integration/transaction.rs
@@ -19,7 +19,7 @@ where
     StorageImpl: Storage + Clone + Send + Sync + 'static,
 {
     let setup = engine
-        .open_workspace_session()
+        .open_session()
         .await
         .expect("setup session should open");
     setup
@@ -58,11 +58,11 @@ async fn stale_transaction_composes_disjoint_semantic_writes() {
         .await
         .expect("initialized storage should create an engine");
     let stale_session = engine
-        .open_workspace_session()
+        .open_session()
         .await
         .expect("stale session should open");
     let winner_session = engine
-        .open_workspace_session()
+        .open_session()
         .await
         .expect("winner session should open");
 
@@ -126,11 +126,11 @@ async fn committed_media_ingest_part_does_not_invalidate_a_concurrent_project_sa
         .await
         .expect("initialized storage should create an engine");
     let ingest = engine
-        .open_workspace_session()
+        .open_session()
         .await
         .expect("media ingest session should open");
     let saver = engine
-        .open_workspace_session()
+        .open_session()
         .await
         .expect("project-save session should open");
     saver
@@ -197,11 +197,11 @@ async fn stale_transaction_reports_overlapping_ordinary_insert_atomically() {
         .await
         .expect("initialized storage should create an engine");
     let stale_session = engine
-        .open_workspace_session()
+        .open_session()
         .await
         .expect("stale session should open");
     let winner_session = engine
-        .open_workspace_session()
+        .open_session()
         .await
         .expect("winner session should open");
 
@@ -250,8 +250,8 @@ async fn explicit_transaction_reads_stable_snapshot_and_own_writes() {
         .await
         .expect("storage should initialize");
     let engine = Engine::new(storage).await.expect("engine should open");
-    let transaction_session = engine.open_workspace_session().await.unwrap();
-    let concurrent_session = engine.open_workspace_session().await.unwrap();
+    let transaction_session = engine.open_session().await.unwrap();
+    let concurrent_session = engine.open_session().await.unwrap();
     concurrent_session
         .execute(
             "INSERT INTO lix_key_value (key, value, lixcol_untracked) \
@@ -318,9 +318,9 @@ simulation_test!(
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
             engine
-                .open_workspace_session()
+                .open_session()
                 .await
-                .expect("workspace session should open"),
+                .expect("session should open"),
             &engine,
         );
         session
@@ -382,9 +382,9 @@ async fn deferred_active_branch_check_rejects_deleted_branch_at_commit() {
         .await
         .expect("initialized storage should create setup engine");
     let setup_session = setup_engine
-        .open_workspace_session()
+        .open_session()
         .await
-        .expect("setup workspace session should open");
+        .expect("setup session should open");
     setup_session
         .create_branch(CreateBranchOptions {
             id: Some("01930000-0000-7000-8000-000000000017".to_string()),
@@ -403,13 +403,13 @@ async fn deferred_active_branch_check_rejects_deleted_branch_at_commit() {
         .await
         .expect("delete engine should open");
     let branch_session = branch_engine
-        .open_session("01930000-0000-7000-8000-000000000017")
+        .open_session_at("01930000-0000-7000-8000-000000000017")
         .await
         .expect("local branch session should open");
     let delete_session = delete_engine
-        .open_workspace_session()
+        .open_session()
         .await
-        .expect("delete workspace session should open");
+        .expect("delete session should open");
 
     let mut transaction = branch_session
         .begin_transaction()
@@ -468,11 +468,11 @@ async fn untracked_commit_retries_when_tracked_fk_target_changes_after_validatio
         .await
         .expect("untracked engine should open");
     let tracked_session = tracked_engine
-        .open_session(UNTRACKED_RACE_BRANCH_ID)
+        .open_session_at(UNTRACKED_RACE_BRANCH_ID)
         .await
         .expect("tracked session should open");
     let untracked_session = untracked_engine
-        .open_session(UNTRACKED_RACE_BRANCH_ID)
+        .open_session_at(UNTRACKED_RACE_BRANCH_ID)
         .await
         .expect("untracked session should open");
 
@@ -547,7 +547,7 @@ fn join_thread<T>(handle: thread::JoinHandle<T>, description: &str) -> T {
 }
 
 #[tokio::test]
-async fn existing_workspace_session_ignores_later_selector_corruption() {
+async fn existing_session_ignores_later_default_branch_corruption() {
     let storage = RecordingStorage::new();
     let _receipt = Engine::initialize(storage.clone())
         .await
@@ -556,18 +556,20 @@ async fn existing_workspace_session_ignores_later_selector_corruption() {
         .await
         .expect("initialized storage should create an engine");
     let session = engine
-        .open_workspace_session()
+        .open_session()
         .await
-        .expect("workspace session should open");
+        .expect("session should open");
 
     session
         .execute(
-            "UPDATE lix_key_value SET value = '6d697373-696e-872d-8272-616e63680000' \
-             WHERE key = 'lix_workspace_branch_id'",
+            "UPDATE lix_key_value_by_branch \
+             SET value = '6d697373-696e-872d-8272-616e63680000' \
+             WHERE key = 'lix_default_branch_id' \
+               AND lixcol_branch_id = 'ffffffff-ffff-7fff-bfff-ffffffffffff'",
             &[],
         )
         .await
-        .expect("test should corrupt workspace selector");
+        .expect("test should corrupt the repository default branch");
 
     let before = storage.stats();
     session
@@ -579,14 +581,14 @@ async fn existing_workspace_session_ignores_later_selector_corruption() {
     assert_eq!(delta.read_opened, 1, "read SQL should open one read tx");
     assert_eq!(delta.write_opened, 0, "read SQL must not open writes");
     engine
-        .open_workspace_session()
+        .open_session()
         .await
         .err()
-        .expect("a new workspace session should reject the corrupt selector");
+        .expect("a new session should reject the corrupt repository default");
 }
 
 #[tokio::test]
-async fn explicit_transaction_open_uses_one_authoritative_snapshot_in_every_session_mode() {
+async fn explicit_transaction_open_uses_one_authoritative_snapshot() {
     let storage = RecordingStorage::new();
     let receipt = Engine::initialize(storage.clone())
         .await
@@ -594,26 +596,26 @@ async fn explicit_transaction_open_uses_one_authoritative_snapshot_in_every_sess
     let engine = Engine::new(storage.clone())
         .await
         .expect("initialized storage should create an engine");
-    let workspace = engine
-        .open_workspace_session()
+    let session = engine
+        .open_session()
         .await
-        .expect("workspace session should open");
+        .expect("session should open");
 
     let before = storage.stats();
-    let workspace_transaction = workspace
+    let transaction = session
         .begin_transaction()
         .await
-        .expect("workspace transaction should open");
+        .expect("transaction should open");
     let delta = storage.stats().delta_since(&before);
-    assert_eq!(delta.read_opened, 1, "workspace open must own one snapshot");
+    assert_eq!(delta.read_opened, 1, "session open must own one snapshot");
     assert_eq!(delta.write_opened, 0, "transaction open must not write");
-    workspace_transaction
+    transaction
         .rollback()
         .await
-        .expect("workspace transaction should roll back");
+        .expect("transaction should roll back");
 
     let pinned = engine
-        .open_session(receipt.main_branch_id)
+        .open_session_at(receipt.main_branch_id)
         .await
         .expect("pinned session should open");
     let before = storage.stats();
@@ -631,7 +633,7 @@ async fn explicit_transaction_open_uses_one_authoritative_snapshot_in_every_sess
 }
 
 #[tokio::test]
-async fn existing_workspace_session_writes_to_its_pinned_branch() {
+async fn existing_session_writes_to_its_selected_branch() {
     let storage = RecordingStorage::new();
     let _receipt = Engine::initialize(storage.clone())
         .await
@@ -640,18 +642,20 @@ async fn existing_workspace_session_writes_to_its_pinned_branch() {
         .await
         .expect("initialized storage should create an engine");
     let session = engine
-        .open_workspace_session()
+        .open_session()
         .await
-        .expect("workspace session should open");
+        .expect("session should open");
 
     session
         .execute(
-            "UPDATE lix_key_value SET value = '6d697373-696e-872d-8272-616e63680000' \
-             WHERE key = 'lix_workspace_branch_id'",
+            "UPDATE lix_key_value_by_branch \
+             SET value = '6d697373-696e-872d-8272-616e63680000' \
+             WHERE key = 'lix_default_branch_id' \
+               AND lixcol_branch_id = 'ffffffff-ffff-7fff-bfff-ffffffffffff'",
             &[],
         )
         .await
-        .expect("test should corrupt workspace selector");
+        .expect("test should corrupt the repository default branch");
 
     let before = storage.stats();
     session
@@ -672,10 +676,10 @@ async fn existing_workspace_session_writes_to_its_pinned_branch() {
         "the pinned-session write should commit"
     );
     engine
-        .open_workspace_session()
+        .open_session()
         .await
         .err()
-        .expect("a new workspace session should reject the corrupt selector");
+        .expect("a new session should reject the corrupt repository default");
 }
 
 #[tokio::test]
@@ -717,9 +721,9 @@ async fn write_changelog_commit_failure_does_not_commit_storage_write() {
         .await
         .expect("initialized storage should create an engine");
     let session = engine
-        .open_workspace_session()
+        .open_session()
         .await
-        .expect("workspace session should open");
+        .expect("session should open");
 
     storage.fail_write_space(CHANGELOG_COMMIT_SPACE_ID);
     let before = storage.stats();
@@ -753,9 +757,9 @@ async fn active_transaction_blocks_session_read_and_allows_transaction_read() {
         .await
         .expect("initialized storage should create an engine");
     let session = engine
-        .open_workspace_session()
+        .open_session()
         .await
-        .expect("workspace session should open");
+        .expect("session should open");
 
     session
         .execute(
@@ -811,9 +815,9 @@ async fn transaction_read_can_query_history_surfaces() {
         .await
         .expect("initialized storage should create an engine");
     let session = engine
-        .open_workspace_session()
+        .open_session()
         .await
-        .expect("workspace session should open");
+        .expect("session should open");
 
     session
         .execute(
@@ -853,9 +857,9 @@ async fn close_rejects_idle_explicit_transaction_without_dropping_it() {
         .expect("initialized storage should create an engine");
     let session = Arc::new(
         engine
-            .open_workspace_session()
+            .open_session()
             .await
-            .expect("workspace session should open"),
+            .expect("session should open"),
     );
 
     let mut tx = session
@@ -889,7 +893,7 @@ async fn close_rejects_idle_explicit_transaction_without_dropping_it() {
         .expect("transaction rollback should succeed after rejected close");
 
     let reopened = engine
-        .open_workspace_session()
+        .open_session()
         .await
         .expect("new session should open after closing previous session");
     let result = reopened
@@ -917,9 +921,9 @@ async fn closed_session_still_allows_active_transaction_rollback() {
         .expect("initialized storage should create an engine");
     let session = Arc::new(
         engine
-            .open_workspace_session()
+            .open_session()
             .await
-            .expect("workspace session should open"),
+            .expect("session should open"),
     );
 
     let tx = session
@@ -951,9 +955,9 @@ async fn closed_session_active_branch_id_does_not_open_storage_read() {
         .await
         .expect("initialized storage should create an engine");
     let session = engine
-        .open_workspace_session()
+        .open_session()
         .await
-        .expect("workspace session should open");
+        .expect("session should open");
 
     session.close().await.expect("session close should succeed");
     let before = storage.stats();
@@ -982,9 +986,9 @@ async fn close_during_transaction_open_rejects_opened_transaction() {
         .expect("initialized storage should create an engine");
     let session = Arc::new(
         engine
-            .open_workspace_session()
+            .open_session()
             .await
-            .expect("workspace session should open"),
+            .expect("session should open"),
     );
 
     gate.block_next_write();
@@ -1031,9 +1035,9 @@ async fn close_during_transaction_commit_waits_after_commit_boundary() {
         .expect("initialized storage should create an engine");
     let session = Arc::new(
         engine
-            .open_workspace_session()
+            .open_session()
             .await
-            .expect("workspace session should open"),
+            .expect("session should open"),
     );
 
     let mut tx = session
@@ -1101,9 +1105,9 @@ async fn close_waits_for_transaction_blocked_in_storage_commit() {
         .expect("initialized storage should create an engine");
     let session = Arc::new(
         engine
-            .open_workspace_session()
+            .open_session()
             .await
-            .expect("workspace session should open"),
+            .expect("session should open"),
     );
 
     let mut tx = session
@@ -1176,9 +1180,9 @@ async fn begin_transaction_cannot_race_with_opening_session_write() {
         .expect("initialized storage should create an engine");
     let session = Arc::new(
         engine
-            .open_workspace_session()
+            .open_session()
             .await
-            .expect("workspace session should open"),
+            .expect("session should open"),
     );
 
     gate.block_next_write();
@@ -1233,9 +1237,9 @@ async fn session_read_waits_for_automatic_write_instead_of_rejecting() {
         .expect("initialized storage should create an engine");
     let session = Arc::new(
         engine
-            .open_workspace_session()
+            .open_session()
             .await
-            .expect("workspace session should open"),
+            .expect("session should open"),
     );
 
     gate.block_next_write();

--- a/packages/lix/tests/point_join_scan_scaling.rs
+++ b/packages/lix/tests/point_join_scan_scaling.rs
@@ -200,9 +200,9 @@ async fn seeded_session(bundles: usize) -> SessionContext<Memory> {
         .expect("initialize fixture");
     let engine = Engine::new(storage).await.expect("open engine");
     let session = engine
-        .open_workspace_session()
+        .open_session()
         .await
-        .expect("open workspace session");
+        .expect("open session");
     for schema in schemas() {
         session
             .execute(

--- a/packages/lix/tests/send_futures.rs
+++ b/packages/lix/tests/send_futures.rs
@@ -1,6 +1,6 @@
 #![recursion_limit = "256"]
 
-use lix::{ExecuteBatchStatement, Lix, open_lix};
+use lix::{ExecuteBatchStatement, Lix, SwitchBranchOptions, open_lix};
 
 fn assert_send<T: Send>(_: T) {}
 fn assert_send_sync<T: Send + Sync>() {}
@@ -17,6 +17,9 @@ async fn public_execution_and_observation_futures_are_send() {
         params: Vec::new(),
     }]));
     assert_send(lix.begin_transaction());
+    assert_send(lix.switch_branch(SwitchBranchOptions {
+        branch_id: lix.active_branch_id().await.expect("active branch"),
+    }));
 
     let mut events = lix.observe("SELECT 1", &[]).expect("observe query");
     assert_send(events.next());

--- a/packages/storage-filesystem/src/filesystem.rs
+++ b/packages/storage-filesystem/src/filesystem.rs
@@ -559,7 +559,7 @@ where
         validate_filesystem_root_directory(&layout.root)?;
         validate_filesystem_lix_directory(&layout.lix_dir)?;
         let path_filter = FilesystemPathFilter::from_sync_all_files(sync_all_files);
-        let session = engine.open_workspace_session().await?;
+        let session = engine.open_session().await?;
         let state = Arc::new(FilesystemState {
             session,
             layout,
@@ -2514,7 +2514,7 @@ mod tests {
             .await
             .unwrap();
         FilesystemState {
-            session: engine.open_workspace_session().await.unwrap(),
+            session: engine.open_session().await.unwrap(),
             layout,
             path_filter: Mutex::new(path_filter),
             sync_lock: tokio::sync::Mutex::new(()),

--- a/packages/storage-filesystem/src/lib.rs
+++ b/packages/storage-filesystem/src/lib.rs
@@ -1,7 +1,7 @@
 //! Filesystem-backed Lix storage and synchronization.
 //!
 //! This adapter uses the RocksDB storage adapter for Lix metadata while keeping
-//! a working directory synchronized with the workspace session.
+//! a working directory synchronized with a Lix repository session.
 
 mod filesystem;
 

--- a/packages/storage-rocksdb/tests/storage/file_sql.rs
+++ b/packages/storage-rocksdb/tests/storage/file_sql.rs
@@ -12,9 +12,9 @@ async fn file_sql_bytea_hard_cut_roundtrips_after_rocksdb_reopen() {
         .expect("initialize RocksDB storage");
     let engine = Engine::new(storage.clone()).await.expect("open engine");
     let session = engine
-        .open_workspace_session()
+        .open_session()
         .await
-        .expect("open workspace session");
+        .expect("open session");
 
     session
         .execute(
@@ -71,9 +71,9 @@ async fn file_sql_bytea_hard_cut_roundtrips_after_rocksdb_reopen() {
     let reopened = RocksDB::open(&path).expect("reopen RocksDB storage");
     let engine = Engine::new(reopened).await.expect("reopen engine");
     let session = engine
-        .open_workspace_session()
+        .open_session()
         .await
-        .expect("reopen workspace session");
+        .expect("reopen session");
     let result = session
         .execute(
             "SELECT content, OCTET_LENGTH(content) AS octets FROM lix_file WHERE path = $1",

--- a/packages/storage-rocksdb/tests/storage/native_file_read.rs
+++ b/packages/storage-rocksdb/tests/storage/native_file_read.rs
@@ -22,9 +22,9 @@ where
         .expect("initialize storage");
     let engine = Engine::new(storage).await.expect("open engine");
     let session = engine
-        .open_workspace_session()
+        .open_session()
         .await
-        .expect("open workspace session");
+        .expect("open session");
 
     assert_eq!(
         session

--- a/packages/storage-rocksdb/tests/storage/native_file_upsert.rs
+++ b/packages/storage-rocksdb/tests/storage/native_file_upsert.rs
@@ -22,9 +22,9 @@ where
         .expect("initialize storage");
     let engine = Engine::new(storage).await.expect("open engine");
     let session = engine
-        .open_workspace_session()
+        .open_session()
         .await
-        .expect("open workspace session");
+        .expect("open session");
 
     assert_eq!(
         session

--- a/packages/storage-slatedb/tests/storage.rs
+++ b/packages/storage-slatedb/tests/storage.rs
@@ -63,9 +63,9 @@ async fn file_sql_bytea_hard_cut_roundtrips_after_slatedb_reopen() {
         .expect("initialize SlateDB storage");
     let engine = Engine::new(storage.clone()).await.expect("open engine");
     let session = engine
-        .open_workspace_session()
+        .open_session()
         .await
-        .expect("open workspace session");
+        .expect("open session");
 
     session
         .execute(
@@ -122,9 +122,9 @@ async fn file_sql_bytea_hard_cut_roundtrips_after_slatedb_reopen() {
     let reopened = SlateDB::open(&path).expect("reopen SlateDB storage");
     let engine = Engine::new(reopened).await.expect("reopen engine");
     let session = engine
-        .open_workspace_session()
+        .open_session()
         .await
-        .expect("reopen workspace session");
+        .expect("reopen session");
     let result = session
         .execute(
             "SELECT content, OCTET_LENGTH(content) AS octets FROM lix_file WHERE path = $1",


### PR DESCRIPTION
## Summary

- replace the shared workspace branch selector with independent session-local branch selection
- seed tracked `lix_default_branch_id` in the repository's initial commit and protect that branch from deletion
- make Rust `open_lix()` restore the client-owned `lix_primary_session_branch_id`, with fallback to the repository default
- make `open_session()` create an independent session and use `open_session_at()` for explicit branch selection
- remove JavaScript-owned active-branch persistence so JS delegates branch semantics to Rust
- hard-cut the repository protocol and Rust session API without compatibility shims

## Validation

- `cargo test -p lix --features all-simulations,storage-benches`
- `cargo clippy --profile test --workspace --all-targets --all-features -- -D warnings`
- `npm run build` in `packages/js-sdk`
- `npm run typecheck` in `packages/js-sdk`
- focused JS wrapper tests: 6 passed
- focused browser test for server-selected remote sessions: 1 passed

## Semantics

- `lix_default_branch_id`: tracked, repository-owned, initialized to `main`
- `lix_primary_session_branch_id`: untracked, client-owned, restored by Rust `open_lix()`
- switching an independent session does not alter either the primary-session preference or repository default
