### PR TITLE
perf(commit): prove the active account from a revision token instead of re-reading it

### DIFF
--- a/packages/lix/src/account.rs
+++ b/packages/lix/src/account.rs
@@ -105,6 +105,10 @@ mod tests {
     use crate::storage_adapter::{Memory, StorageAdapter, StorageReadOptions};
     use crate::{Value, open_lix};
 
+    /// The cache is one process-wide static, so the tests that assert on its
+    /// contents take turns rather than racing each other.
+    static CACHE_TESTS: Mutex<()> = Mutex::new(());
+
     fn token(byte: u8) -> Bytes {
         Bytes::from(vec![byte; 16])
     }
@@ -220,12 +224,14 @@ mod tests {
 
     #[test]
     fn a_missing_token_never_matches() {
+        let _guard = CACHE_TESTS.lock().expect("cache test guard");
         record_account_proven_active(None, "account-a");
         assert!(!account_proven_active(None, "account-a"));
     }
 
     #[test]
     fn a_different_token_misses() {
+        let _guard = CACHE_TESTS.lock().expect("cache test guard");
         clear_validated_accounts_for_test();
         record_account_proven_active(Some(&token(1)), "account-a");
         assert!(account_proven_active(Some(&token(1)), "account-a"));
@@ -241,6 +247,7 @@ mod tests {
 
     #[test]
     fn the_cache_is_bounded() {
+        let _guard = CACHE_TESTS.lock().expect("cache test guard");
         clear_validated_accounts_for_test();
         for index in 0..(MAX_VALIDATED_ACCOUNTS as u8 + 8) {
             record_account_proven_active(Some(&token(index)), "account-a");

--- a/packages/lix/src/account.rs
+++ b/packages/lix/src/account.rs
@@ -1,0 +1,258 @@
+//! Active-account validation and its storage-snapshot identity token.
+//!
+//! Every commit must prove that the account it is attributed to still exists
+//! and is enabled. That proof is a hot-state point read plus a JSON parse of
+//! the account snapshot — measured at 13.8 µs, ~8% of `commit_prepared`, on a
+//! single-row update whose account state had not changed in thousands of
+//! commits.
+//!
+//! The token here is the same device the filesystem path index and the schema
+//! catalog use: a uuid-v7 written into [`REVISION_SPACE`] **only** by a commit
+//! that can change which account rows are visible. Equality is its only
+//! meaningful operation, and equality is one-directional by construction — a
+//! reader holding an older token can never match a newer view, so it misses
+//! and re-reads. It cannot be served a newer view under an older token,
+//! because a new view always carries a freshly generated token.
+
+use std::collections::VecDeque;
+use std::sync::{LazyLock, Mutex};
+
+use bytes::Bytes;
+
+use crate::LixError;
+use crate::storage_adapter::{
+    REVISION_KEY_ACCOUNT, REVISION_SPACE, StorageAdapterRead, StorageValue, StorageWriteSet,
+    load_revision, revision_key,
+};
+
+/// Storage-snapshot identity for the visible `lix_account` rows.
+pub(crate) async fn load_account_revision(
+    store: &(impl StorageAdapterRead + ?Sized),
+) -> Result<Option<Bytes>, LixError> {
+    Ok(load_revision(store, REVISION_KEY_ACCOUNT).await?)
+}
+
+/// Rotates the account token. Called by every commit that writes an account
+/// row or moves a branch ref, and once at repository initialization.
+pub(crate) fn stage_account_revision(writes: &mut StorageWriteSet) {
+    writes.put(
+        REVISION_SPACE,
+        revision_key(REVISION_KEY_ACCOUNT),
+        StorageValue {
+            bytes: Bytes::copy_from_slice(uuid::Uuid::now_v7().as_bytes()),
+        },
+    );
+}
+
+/// Bounded set of `(account token, account id)` pairs already proven active.
+///
+/// The token is a uuid-v7 minted by the write that produced the view, so a
+/// pair is globally unique and permanently true: "under this exact account
+/// view, this account was active". Two repositories cannot collide on one,
+/// which is what makes a process-wide cache sound. A missing token (`None`)
+/// never matches, so a repository that has never rotated one simply keeps
+/// paying the full read.
+///
+/// The queue is capped, so a process cycling through unrelated repositories
+/// or accounts evicts rather than grows.
+const MAX_VALIDATED_ACCOUNTS: usize = 16;
+
+static VALIDATED_ACCOUNTS: LazyLock<Mutex<VecDeque<(Bytes, String)>>> =
+    LazyLock::new(|| Mutex::new(VecDeque::new()));
+
+pub(crate) fn account_proven_active(revision: Option<&Bytes>, account_id: &str) -> bool {
+    let Some(revision) = revision else {
+        return false;
+    };
+    VALIDATED_ACCOUNTS
+        .lock()
+        .expect("validated account cache lock poisoned")
+        .iter()
+        .any(|(token, id)| token == revision && id == account_id)
+}
+
+pub(crate) fn record_account_proven_active(revision: Option<&Bytes>, account_id: &str) {
+    let Some(revision) = revision else {
+        return;
+    };
+    let mut cache = VALIDATED_ACCOUNTS
+        .lock()
+        .expect("validated account cache lock poisoned");
+    if cache
+        .iter()
+        .any(|(token, id)| token == revision && id == account_id)
+    {
+        return;
+    }
+    cache.push_back((revision.clone(), account_id.to_string()));
+    while cache.len() > MAX_VALIDATED_ACCOUNTS {
+        cache.pop_front();
+    }
+}
+
+#[cfg(test)]
+pub(crate) fn clear_validated_accounts_for_test() {
+    VALIDATED_ACCOUNTS
+        .lock()
+        .expect("validated account cache lock poisoned")
+        .clear();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use crate::storage_adapter::{Memory, StorageAdapter, StorageReadOptions};
+    use crate::{Value, open_lix};
+
+    fn token(byte: u8) -> Bytes {
+        Bytes::from(vec![byte; 16])
+    }
+
+    async fn current_token(adapter: &StorageAdapter<Memory>) -> Option<Bytes> {
+        let read = adapter
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("token read should open");
+        load_account_revision(&read)
+            .await
+            .expect("account token should load")
+    }
+
+    /// The whole win rests on this asymmetry: ordinary row commits must leave
+    /// the token alone (or the cache never hits), and any commit that can
+    /// change the visible account rows must rotate it (or a disabled account
+    /// keeps committing off a warm cache).
+    #[tokio::test]
+    async fn ordinary_commits_keep_the_token_while_account_writes_rotate_it() {
+        const AUTHOR_ID: &str = "01920000-0000-7000-8000-0000000006a1";
+        let storage = Memory::new();
+        let adapter = StorageAdapter::new(storage.clone());
+        let lix = open_lix()
+            .with_storage(storage)
+            .await
+            .expect("repository should open");
+
+        let initialized = current_token(&adapter)
+            .await
+            .expect("initialization stages an account token");
+
+        lix.ensure_account(AUTHOR_ID, "Ada", "human")
+            .await
+            .expect("provision author");
+        let after_account_write = current_token(&adapter)
+            .await
+            .expect("account write keeps a token");
+        assert_ne!(
+            after_account_write, initialized,
+            "writing an account row must rotate the token"
+        );
+
+        let session = lix
+            .open_session_with_account(
+                lix.active_branch_id().await.expect("active branch"),
+                AUTHOR_ID,
+            )
+            .await
+            .expect("attributed session should open");
+        session
+            .execute(
+                "INSERT INTO lix_key_value (key, value) VALUES ('token-control', lix_json('1'))",
+                &[],
+            )
+            .await
+            .expect("ordinary write should commit");
+        assert_eq!(
+            current_token(&adapter).await,
+            Some(after_account_write.clone()),
+            "ordinary CRUD must not rotate the account token"
+        );
+        session
+            .execute(
+                "UPDATE lix_key_value SET value = lix_json('2') WHERE key = 'token-control'",
+                &[],
+            )
+            .await
+            .expect("second ordinary write should commit");
+        assert_eq!(
+            current_token(&adapter).await,
+            Some(after_account_write.clone()),
+            "the token is stable across repeated ordinary commits"
+        );
+
+        let system = lix
+            .open_session_with_account(
+                lix.active_branch_id().await.expect("active branch"),
+                crate::SYSTEM_ACCOUNT_ID,
+            )
+            .await
+            .expect("system session should open");
+        system
+            .execute(
+                "UPDATE lix_account_by_branch SET status = 'disabled' \
+                 WHERE id = $1 AND lixcol_branch_id = $2",
+                &[
+                    Value::Text(AUTHOR_ID.to_string()),
+                    Value::Text(crate::GLOBAL_BRANCH_ID.to_string()),
+                ],
+            )
+            .await
+            .expect("disable author");
+        let after_disable = current_token(&adapter)
+            .await
+            .expect("disabling keeps a token");
+        assert_ne!(
+            after_disable, after_account_write,
+            "disabling an account must rotate the token"
+        );
+
+        // The warm session proved itself active moments ago; the rotated token
+        // is what makes it re-read and fail.
+        let error = session
+            .execute(
+                "INSERT INTO lix_key_value (key, value) VALUES ('after-disable', lix_json('1'))",
+                &[],
+            )
+            .await
+            .expect_err("a disabled account must not commit off a warm proof");
+        assert_eq!(error.code, "LIX_ACCOUNT_DISABLED");
+    }
+
+    #[test]
+    fn a_missing_token_never_matches() {
+        record_account_proven_active(None, "account-a");
+        assert!(!account_proven_active(None, "account-a"));
+    }
+
+    #[test]
+    fn a_different_token_misses() {
+        clear_validated_accounts_for_test();
+        record_account_proven_active(Some(&token(1)), "account-a");
+        assert!(account_proven_active(Some(&token(1)), "account-a"));
+        assert!(
+            !account_proven_active(Some(&token(2)), "account-a"),
+            "a rotated token must miss, which is what makes a disabled account re-read"
+        );
+        assert!(
+            !account_proven_active(Some(&token(1)), "account-b"),
+            "another account under the same view must prove itself"
+        );
+    }
+
+    #[test]
+    fn the_cache_is_bounded() {
+        clear_validated_accounts_for_test();
+        for index in 0..(MAX_VALIDATED_ACCOUNTS as u8 + 8) {
+            record_account_proven_active(Some(&token(index)), "account-a");
+        }
+        let len = VALIDATED_ACCOUNTS
+            .lock()
+            .expect("validated account cache lock poisoned")
+            .len();
+        assert_eq!(len, MAX_VALIDATED_ACCOUNTS);
+        assert!(
+            !account_proven_active(Some(&token(0)), "account-a"),
+            "the oldest entry must have been evicted"
+        );
+    }
+}

--- a/packages/lix/src/init.rs
+++ b/packages/lix/src/init.rs
@@ -506,6 +506,7 @@ where
         }
     }
     crate::catalog::stage_catalog_revision(&mut writes);
+    crate::account::stage_account_revision(&mut writes);
     stage_repository_protocol(&mut writes);
 
     storage

--- a/packages/lix/src/lib.rs
+++ b/packages/lix/src/lib.rs
@@ -30,6 +30,7 @@
 // consumers now that the former engine and SDK share one crate.
 extern crate self as lix;
 
+pub(crate) mod account;
 mod binary_cas;
 pub(crate) mod branch;
 pub(crate) mod catalog;

--- a/packages/lix/src/module_layers.rs
+++ b/packages/lix/src/module_layers.rs
@@ -34,7 +34,7 @@ const MODULE_LAYERS: &[&[&str]] = &[
     // its bytes through.
     &["storage_adapter"],
     // Value types and generic containers layered directly on the key space.
-    &["binary_cas", "columnar_row_group", "common", "json_store"],
+    &["account", "binary_cas", "columnar_row_group", "common", "json_store"],
     &["entity_pk"],
     // The order-preserving key byte format. A pure encoding over `entity_pk`
     // with no repository semantics, and the single authority for how a key

--- a/packages/lix/src/storage_adapter/mod.rs
+++ b/packages/lix/src/storage_adapter/mod.rs
@@ -46,9 +46,9 @@ pub use point::{PointReadPlan, PointValues, RequestedToUnique, RequestedToUnique
 pub(crate) use read_scope::SharedStorageAdapterRead;
 pub use read_scope::{StorageAdapterRead, StorageAdapterReadScope};
 pub(crate) use spaces::{
-    REVISION_KEY_BINARY_CAS_PUBLICATION, REVISION_KEY_BINARY_CAS_RECLAMATION, REVISION_KEY_CATALOG,
-    REVISION_KEY_FILESYSTEM_PATH, REVISION_KEY_TRACKED_MUTATION, REVISION_SPACE, load_revision,
-    load_revisions, revision_key,
+    REVISION_KEY_ACCOUNT, REVISION_KEY_BINARY_CAS_PUBLICATION,
+    REVISION_KEY_BINARY_CAS_RECLAMATION, REVISION_KEY_CATALOG, REVISION_KEY_FILESYSTEM_PATH,
+    REVISION_KEY_TRACKED_MUTATION, REVISION_SPACE, load_revision, load_revisions, revision_key,
 };
 pub use stats::{
     StorageReadResult, StorageReadStats, StorageReadStatsCollector, StorageWriteSetStats,

--- a/packages/lix/src/storage_adapter/spaces.rs
+++ b/packages/lix/src/storage_adapter/spaces.rs
@@ -24,6 +24,10 @@ pub(crate) const REVISION_SPACE: StorageSpace = StorageSpace::declare(
     ValueSemantics::Mutable,
 );
 
+/// Active-account visibility token. Rotated only by a commit that writes an
+/// account row or moves a branch ref, so an ordinary CRUD commit leaves it
+/// alone and a disabled account rotates it.
+pub(crate) const REVISION_KEY_ACCOUNT: &[u8] = b"a";
 /// Binary-CAS reclamation token. Rotated only by an authenticated CAS sweep,
 /// and asserted unchanged by every CAS publisher, so a publisher that planned
 /// against payload rows a sweep then deleted cannot commit.

--- a/packages/lix/src/transaction/commit.rs
+++ b/packages/lix/src/transaction/commit.rs
@@ -301,6 +301,18 @@ pub(crate) async fn commit_prepared_writes_with_parent_heads(
                 "lix_file_descriptor" | "lix_directory_descriptor" | "lix_binary_blob_ref"
             )
         });
+    // Which account rows are visible changes when an account row is written
+    // and when a branch ref moves (the account rows live in the global
+    // branch's tracked state, so a head move can change the view without any
+    // account row in this commit). Both cases rotate the token; ordinary CRUD
+    // does not, which is the whole point.
+    let account_view_changed = prepared_writes.state_rows.iter().any(|row| {
+        matches!(row.schema_key.as_str(), ACCOUNT_SCHEMA_KEY | BRANCH_REF_SCHEMA_KEY)
+    }) || prepared_writes
+        .commit_change_refs_by_branch
+        .values()
+        .flat_map(StagedCommitChangeRefs::selected_changes)
+        .any(|change_ref| change_ref.schema_key() == ACCOUNT_SCHEMA_KEY);
     let mut state_rows = prepared_writes.state_rows;
     #[cfg(feature = "storage-benches")]
     state_rows.record_ownership(crate::storage_bench::CRUD_OWNERSHIP_AUTHORITY);
@@ -874,6 +886,9 @@ pub(crate) async fn commit_prepared_writes_with_parent_heads(
     }
     if filesystem_view_changed {
         stage_path_index_revision(&mut writes);
+    }
+    if account_view_changed {
+        crate::account::stage_account_revision(&mut writes);
     }
     Ok(MaterializedCommit {
         writes,
@@ -3321,6 +3336,7 @@ async fn build_lifecycle_tracked_snapshots(
         .collect()
 }
 
+const ACCOUNT_SCHEMA_KEY: &str = "lix_account";
 const FILE_DESCRIPTOR_SCHEMA_KEY: &str = "lix_file_descriptor";
 const DIRECTORY_DESCRIPTOR_SCHEMA_KEY: &str = "lix_directory_descriptor";
 
@@ -6430,6 +6446,22 @@ async fn validate_active_account_and_account_rows(
             format!("active account id '{active_account_id}' is not a canonical UUID"),
         )
     })?;
+    // Proving the account is active is a hot-state point read plus a JSON
+    // parse of its snapshot, and it re-proves the same fact on every commit.
+    // The account token identifies the account view this snapshot sees: a
+    // commit that could change that view rotates it, so an equal token means
+    // an equal view and the proof still holds. A commit that writes account
+    // rows itself always re-reads — it is the one changing the answer.
+    let account_revision = crate::account::load_account_revision(&*read).await?;
+    let writes_account_rows = prepared_writes
+        .state_rows
+        .iter()
+        .any(|row| row.schema_key.as_str() == "lix_account");
+    if !writes_account_rows
+        && crate::account::account_proven_active(account_revision.as_ref(), active_account_id)
+    {
+        return validate_prepared_account_rows(prepared_writes);
+    }
     let account = HotStateContext::new(
         TrackedStateContext::new(),
         crate::commit_graph::CommitGraphContext::new(),
@@ -6466,6 +6498,7 @@ async fn validate_active_account_and_account_rows(
                 format!("active account '{active_account_id}' is disabled"),
             ));
         }
+        crate::account::record_account_proven_active(account_revision.as_ref(), active_account_id);
     } else if crate::init::repository_protocol_status(&*read).await?
         == crate::init::RepositoryProtocolStatus::Current
     {
@@ -6475,6 +6508,12 @@ async fn validate_active_account_and_account_rows(
         ));
     }
 
+    validate_prepared_account_rows(prepared_writes)
+}
+
+/// Shape rules for account rows carried by this commit. These read nothing and
+/// run on every commit, cached account proof or not.
+fn validate_prepared_account_rows(prepared_writes: &PreparedWriteSet) -> Result<(), LixError> {
     for row in prepared_writes
         .state_rows
         .iter()


### PR DESCRIPTION
# perf(commit): prove the active account from a revision token instead of re-reading it

**Headline from the profile that motivated this, worth stating before the change itself: only 17.1 µs of a
294 µs single-row write is the atomic publication** (`rocksdb_write` 13.2 µs + `check_preconditions`
3.9 µs). The durability property is ~6% of the operation; everything else is *computing what to
publish*. The write path is not expensive because it is atomic.

This PR takes one item out of that computation.

## What changed

Every commit re-proved that the account it is attributed to still exists and is enabled:
`validate_active_account_and_account_rows` opened with a hot-state point read of the `lix_account`
row in the global branch (`HotStateContext::load_row` → `scan_batch` → full scan-scope +
branch-head-control resolution) and a `serde_json::from_str` of the account snapshot to check
`status == "active"`. Measured at **13.8 µs, ~8% of `commit_prepared`** — it was the only hot-state
`scan_batch` on the non-test commit path, and it re-derived a fact that had not changed in thousands
of commits.

The account view now carries a **revision token**, the same device the filesystem path index and the
schema catalog already use:

- New key `REVISION_KEY_ACCOUNT` (`b"a"`) in the existing shared `lix.revision.v1` space. **No new
  storage space** — the revision singletons deliberately share one space so they land in adjacent
  physical keys, and this is one more one-byte key in it.
- The token is rotated by `commit_prepared_writes_with_parent_heads` when the commit writes a
  `lix_account` row **or moves a branch ref** (account rows are global-branch tracked state, so a
  head move can change which account rows are visible without any account row in the commit — this
  mirrors the filesystem check, which includes `BRANCH_REF_SCHEMA_KEY` for the same reason), and
  once by `init` so a fresh repository starts with one.
- A commit whose snapshot shows a token already proven for its account skips the read. Anything else
  reads.
- The structural validation of account rows *carried by* the commit (`validate_prepared_account_rows`)
  reads nothing and still runs on every commit, cached or not.

**Removed:** the per-commit hot-state point read and JSON parse of the active account row on the
warm path. **Added:** one batched-point-read revision load (~0.6 µs on this host).

## How a reader that should miss still misses

This is the constraint that matters, so it is stated mechanically rather than asserted:

1. The cache key is `(token, account_id)` where the token is a **uuid-v7 minted by the write that
   produced that view**. A pair is therefore globally unique and *permanently true*: "under this
   exact account view, this account was active". It never needs invalidating — it needs superseding,
   which is what rotation does.
2. Disabling or deleting an account writes a `lix_account` row, so that commit rotates the token.
   The next commit reads the **new** token, finds no proof for it, does the full read, and fails with
   `LIX_ACCOUNT_DISABLED` / `LIX_ACCOUNT_NOT_FOUND`. A warm proof cannot outlive the view it was
   taken under.
3. Equality is one-directional by construction: an older reader can only ever *miss*, because a newer
   view always carries a token that no earlier proof mentions. There is no path by which an old token
   is served a new view.
4. A commit that writes account rows itself always re-reads — it is the one changing the answer.
5. A missing token (`None`) never matches, so a repository that has never rotated one keeps paying
   the full read rather than trusting a shared default. This is also why two repositories cannot
   collide in the process-wide cache: there is no shared "empty" key, and uuid-v7 tokens are not
   shared across repositories.
6. The cache is capped at 16 entries (`MAX_VALIDATED_ACCOUNTS`), so a process cycling through
   repositories or accounts evicts rather than grows.

Concurrency is unchanged: the token is read from the same coherent snapshot the validation used
before, so a commit sees exactly the account view it would have read directly.

## Layout invariants

1. **Single authority** — no new authority. The account rows remain the only truth; the token is an
   identity tag for the view, and the cache is a memo of a proof already taken. Delete the token and
   every commit simply re-reads.
2. **Commit canonicality** — untouched.
3. **Derived views are caches** — the proof cache is disposable, bounded, process-local, and keyed by
   the source view's revision. Nothing reads it as an authority.
4. **Atomic publication** — the token is staged into the same write set as the commit that changes
   the account view, so it publishes atomically with the rows it describes. No reader can observe a
   rotated token without the rows, or the rows without the rotation.
5. **GC from refs** — untouched. The token is a singleton key, not retention metadata.
6. **SQL reads canonical records** — unchanged; the SQL surface still reads account rows directly.

## Verification

New tests in `packages/lix/src/account.rs`:

- `ordinary_commits_keep_the_token_while_account_writes_rotate_it` — end-to-end through `open_lix`:
  provisioning an account rotates the token; two ordinary `lix_key_value` commits leave it byte-equal
  (without which the cache would never hit); disabling the account rotates it; **and the already-warm
  session's next commit then fails with `LIX_ACCOUNT_DISABLED`** — the exact "must not keep
  committing off a warm cache" case.
- `a_missing_token_never_matches`, `a_different_token_misses`, `the_cache_is_bounded`.

The pre-existing `handle.rs::accounts_are_mutable_and_changes_have_one_required_account` is an
independent guard on the same property: its author session commits (warming the proof) *before* being
disabled, and still fails afterwards.

### A/B — ryzen-9950x-III, RocksDB, warm `sql_session` hot lane, base `dabb0b87`

**Both arms were built from the same worktree path into the same target dir** (`~/claude5/cand`,
`target-cand`), with the base binary copied aside before the candidate build. The runbook's measured
worktree-path binary-layout artifact — **+3.0% on exactly this lane** — is therefore identical for
both arms and cancels, rather than being controlled for after the fact.

| lane | rows | reps | base median | cand median | delta |
|---|---:|---:|---:|---:|---:|
| **update_one_by_pk** | 10k | 9 | **180.89 µs** | **157.60 µs** | **−12.87%** |
| update_one_by_pk | 1k | 3 | 176.62 µs | 151.16 µs | −14.4% |
| update_one_by_pk | 100k | 3 | 229.12 µs | 203.69 µs | −11.1% |
| read_one_by_pk (null control) | 10k | 5 | 20.00 µs | 19.97 µs | −0.18% |

Raw per-rep (µs), 10k, interleaved with rotating arm order:

- base: 176.2 177.7 178.7 179.4 **180.9** 182.0 183.3 185.0 199.9
- cand: 155.0 155.2 155.3 157.4 **157.6** 157.9 158.0 158.0 159.7

**The ranges are disjoint** (base min 176.2 > cand max 159.7).

**Null control**: `read_one_by_pk` runs in the same two binaries and never enters `commit_prepared`,
so it executes none of the changed code — it moves −0.18%, which is the instrument's floor on this
lane. (`kv_layout` was not used: it never builds an Engine, so per the runbook it would measure
codegen layout rather than guard anything.)

**The curve is flat in absolute terms** — −25.5 µs at 1k, −23.3 µs at 10k, −25.4 µs at 100k. This is
a fixed per-commit term removed, not a scaling change: the saving does not grow or shrink over two
orders of magnitude of table size, which is what a per-statement setup cost looks like when it goes
away.

The saving (~23–25 µs) exceeds the 13.8 µs the profile attributed to the `scan_batch` subtree,
because the profile bucket covered only the scan itself — the `HotStateContext` construction, the
`EntityPk`/request allocation, the snapshot JSON parse, and the extra RocksDB point gets it issued
are removed with it.

### Gate — full CI scope on ryzen-9950x-III

Scope re-read from `origin/main:.github/workflows/ci.yml` (lines 109, 151–152) at the time of the
run. Branch head and worktree status printed inside the run: `GATE HEAD=e6bfcaf9c`, `GATE STATUS=[]`.

The A/B binaries were built from `cf3547968`; the only later commit (`e6bfcaf9c`) adds `account` to
the `MODULE_LAYERS` const list, which the module-layer guard reads and no engine code executes, so
the measured binaries and the gated head differ by nothing that runs.

| step | result |
|---|---|
| `cargo clippy --profile test --workspace --all-targets --all-features -- -D warnings` | exit 0 |
| `cargo test --profile test --workspace --exclude lix_benchmarks --all-features --no-fail-fast` | **3506 passed, 0 failed** |
| `cargo test --profile test -p lix_benchmarks --features storage-benches,slatedb,root-replay-trace --no-fail-fast` | **33 passed, 0 failed** |
| `cargo check -p lix --no-default-features` | exit 0 |
| `cargo check -p lix_js_sdk --target wasm32-unknown-unknown` | exit 0 |

Logs on the host: `~/claude5/e47-gate-*.log`. Raw A/B: `~/claude5/e47-ab.csv`,
`~/claude5/e47-curve.csv`.

### Against SQLite, same host, same fixture

The claim-3 SQLite arm (3.46.0 bundled, WAL, `synchronous=NORMAL`, 4 KiB pages, same 10k-row
`pnpm-lock` fixture) medians **1.109 µs** on this host across 3 runs (1.085–1.111, spread 2.4%). The
point write moves **163.1x → 142.1x** SQLite. It remains the worst lane by two orders of magnitude;
this is one setup cost off it, not a change in the story.

## What regressed

Nothing measured. Every commit that changes the account view now writes one extra 16-byte value into
the revision space — account writes and branch-ref moves only, never ordinary CRUD, and it rides the
same atomic write set. `read_one` is flat.
