### PR TITLE
perf(filesystem): plan file creates from the written path, not the whole branch

### DIFF
--- a/packages/lix/src/filesystem/mod.rs
+++ b/packages/lix/src/filesystem/mod.rs
@@ -22,8 +22,9 @@ pub(crate) use self::planner::{
     FileDescriptorWriteInput, FileDescriptorWriteIntent, FilesystemBlobRefKey,
     FilesystemDeletePlan, FilesystemDescriptorKey, FilesystemRowContext, FilesystemWritePlan,
     append_blob_ref_tombstone_row, create_directory_path_with_leaf_id_with_resolvers,
-    directory_path_resolvers_from_hot_state, directory_path_resolvers_from_path_index,
-    filesystem_storage_scope_key, plan_file_delete, plan_file_descriptor_write,
+    directory_path_resolvers_for_paths, directory_path_resolvers_from_hot_state,
+    directory_path_resolvers_from_path_index, filesystem_storage_scope_key, plan_file_delete,
+    plan_file_descriptor_write,
     plan_parsed_directory_path_update_with_resolvers, plan_parsed_file_path_update_with_resolvers,
     plan_parsed_file_path_write_with_resolvers, plan_recursive_directory_delete,
 };

--- a/packages/lix/src/filesystem/planner.rs
+++ b/packages/lix/src/filesystem/planner.rs
@@ -1568,6 +1568,107 @@ pub(crate) fn directory_path_resolvers_from_path_index(
     Ok(resolvers)
 }
 
+/// Seeds directory path resolvers from **only the ancestor chains** of the
+/// paths a statement is about to write, instead of from every entry in the
+/// filesystem path index.
+///
+/// Planning a path write consults the resolver at exactly two kinds of key:
+/// `(parent_id, segment_name)` along the path's own ancestor chain, and
+/// `(directory_id, leaf_name)` for the leaf uniqueness reservation. Nothing
+/// else in the repository can be observed, so seeding the whole index makes
+/// the cost of creating one file linear in the number of resident files *and*
+/// directories. This walks `depth` prefixes per write with an O(log n) index
+/// lookup each.
+///
+/// The leaf path is seeded too, so whatever already occupies the target name —
+/// a file or a directory — is still rejected by the resolver's own uniqueness
+/// check rather than slipping past it.
+pub(crate) fn directory_path_resolvers_for_paths<'a>(
+    index: &super::path_index::FilesystemPathIndex,
+    paths: impl IntoIterator<Item = &'a LixPath>,
+    branch_binding: Option<&str>,
+) -> Result<BTreeMap<String, DirectoryPathResolver>, LixError> {
+    let mut seeds = BTreeMap::<String, BTreeMap<String, DirectoryDescriptorSeed>>::new();
+    let mut files = BTreeMap::<String, Vec<(Option<String>, String, String)>>::new();
+    let mut seen_paths = BTreeSet::<String>::new();
+
+    let absorb = |entry: &super::path_index::FilesystemPathEntry,
+                      seeds: &mut BTreeMap<String, BTreeMap<String, DirectoryDescriptorSeed>>,
+                      files: &mut BTreeMap<String, Vec<(Option<String>, String, String)>>| {
+        let key = &entry.key;
+        let storage_branch_id = if key.global() {
+            GLOBAL_BRANCH_ID
+        } else {
+            key.branch_id()
+        };
+        let resolver_key = filesystem_storage_scope_key(
+            storage_branch_id,
+            key.global(),
+            key.is_untracked(),
+            key.file_id(),
+        );
+        match entry.kind {
+            super::path_index::FilesystemPathKind::Directory => {
+                seeds.entry(resolver_key).or_default().insert(
+                    entry.id().to_string(),
+                    DirectoryDescriptorSeed {
+                        id: entry.id().to_string(),
+                        parent_id: entry.parent_id.clone(),
+                        name: entry.name.clone(),
+                    },
+                );
+            }
+            super::path_index::FilesystemPathKind::File => {
+                files.entry(resolver_key).or_default().push((
+                    entry.parent_id.clone(),
+                    entry.name.clone(),
+                    entry.id().to_string(),
+                ));
+            }
+        }
+    };
+
+    for path in paths {
+        let segments = path.segments().map(ToOwned::to_owned).collect::<Vec<_>>();
+        if segments.is_empty() {
+            continue;
+        }
+        // Ancestor directories, then the leaf itself. Directory and file
+        // entries share the same unsuffixed path spelling in the index, so one
+        // lookup per prefix returns whichever kind occupies it — which is what
+        // makes the leaf lookup a namespace-conflict check as well.
+        for depth in 1..=segments.len() {
+            let prefix = directory_path_from_segments(&segments[..depth]);
+            if !seen_paths.insert(prefix.clone()) {
+                continue;
+            }
+            for entry in index.exact_entries(&prefix) {
+                absorb(&entry, &mut seeds, &mut files);
+            }
+        }
+    }
+
+    let mut resolvers = BTreeMap::new();
+    for (resolver_key, records) in seeds {
+        let scoped_files = files.remove(&resolver_key).unwrap_or_default();
+        resolvers.insert(
+            resolver_key,
+            DirectoryPathResolver::from_existing_descriptors(records.into_values(), scoped_files)?,
+        );
+    }
+    for (resolver_key, scoped_files) in files {
+        resolvers.insert(
+            resolver_key,
+            DirectoryPathResolver::from_existing_descriptors(std::iter::empty(), scoped_files)?,
+        );
+    }
+    if let Some(branch_id) = branch_binding {
+        let key = filesystem_storage_scope_key(branch_id, false, false, None);
+        resolvers.entry(key).or_default();
+    }
+    Ok(resolvers)
+}
+
 pub(crate) fn filesystem_storage_scope_key(
     branch_id: &str,
     global: bool,

--- a/packages/lix/src/sql2/providers/file.rs
+++ b/packages/lix/src/sql2/providers/file.rs
@@ -85,7 +85,7 @@ use crate::filesystem::{
     BlobRefRowInput, DirectoryPathRecord, DirectoryPathResolver, FileDeleteInput,
     FileDescriptorWriteInput, FileDescriptorWriteIntent, FilesystemBlobRefKey,
     FilesystemDeletePlan, FilesystemDescriptorKey, FilesystemRowContext,
-    append_blob_ref_tombstone_row, derive_directory_paths,
+    append_blob_ref_tombstone_row, derive_directory_paths, directory_path_resolvers_for_paths,
     directory_path_resolvers_from_hot_state, directory_path_resolvers_from_path_index,
     directory_path_resolvers_from_state_batch, filesystem_storage_scope_key, plan_file_delete,
     plan_file_descriptor_write, plan_parsed_file_path_update_with_resolvers,
@@ -2653,31 +2653,74 @@ async fn execute_fast_lix_file_id_path_writes_inner(
     let active_branch_id = ctx.active_branch_id().to_string();
     let parsed_writes = parse_fast_lix_file_path_writes(writes)?;
 
+    // Boxed: this function keeps the whole-branch fallback below live in the
+    // same state machine, so inlining the indexed route's futures here makes
+    // one `lix_file` write frame large enough to overflow libtest's 2 MiB
+    // worker stack in a debug build.
     let indexed = if conflict.targets_id() {
-        indexed_file_id_writes(ctx, &active_branch_id, &parsed_writes).await?
-    } else if conflict.updates_existing() {
-        indexed_file_path_writes(ctx, &active_branch_id, &parsed_writes).await?
+        Box::pin(indexed_file_id_writes(
+            ctx,
+            &active_branch_id,
+            &parsed_writes,
+        ))
+        .await?
+    } else if conflict.updates_existing() || conflict == FastLixFilePathWriteConflict::None {
+        // A plain INSERT is a create; it needs the same path lookup an upsert
+        // does and nothing more. Routing it through the path index removes the
+        // whole-branch descriptor scan the fallback below performs.
+        Box::pin(indexed_file_path_writes(
+            ctx,
+            &active_branch_id,
+            &parsed_writes,
+            conflict,
+        ))
+        .await?
     } else {
         None
     };
     if let Some(indexed) = indexed {
-        return stage_indexed_file_path_writes(
+        return Box::pin(stage_indexed_file_path_writes(
             ctx,
             &active_branch_id,
             parsed_writes,
             indexed,
             conflict,
             mutation_identity,
-        )
+        ))
         .await
         .map(Some);
     }
 
+    // Extracted and boxed so the whole-branch fallback's locals are not part of
+    // this function's poll frame. At `opt-level = 0` a single async fn keeps a
+    // stack slot for every local across every branch, and holding both routes
+    // in one frame overflows libtest's 2 MiB worker stack.
+    Box::pin(stage_scanning_file_path_writes(
+        ctx,
+        &active_branch_id,
+        parsed_writes,
+        conflict,
+        mutation_identity,
+    ))
+    .await
+}
+
+/// The canonical fallback: rebuild the branch's filesystem view from a
+/// whole-branch descriptor scan. Taken only when the path index cannot answer
+/// the write (occupied path on a plain INSERT, ambiguous multi-scope entry,
+/// constraint violation while seeding resolvers).
+async fn stage_scanning_file_path_writes(
+    ctx: &mut dyn SqlWriteExecutionContext,
+    active_branch_id: &str,
+    parsed_writes: Vec<FastLixFilePathWrite>,
+    conflict: FastLixFilePathWriteConflict,
+    mutation_identity: Option<MutationIdentity>,
+) -> Result<Option<u64>, LixError> {
     let live_rows = ctx
         .scan_hot_state_batch(&HotStateScanRequest {
             filter: HotStateFilter {
                 schema_keys: filesystem_schema_keys(),
-                branch_ids: vec![active_branch_id.clone()],
+                branch_ids: vec![active_branch_id.to_string()],
                 include_tombstones: false,
                 ..HotStateFilter::default()
             },
@@ -2694,7 +2737,7 @@ async fn execute_fast_lix_file_id_path_writes_inner(
         Err(error) => return Err(error),
     };
     let mut path_resolvers = directory_path_resolvers_from_state_batch(&live_rows)?;
-    let resolver_key = filesystem_storage_scope_key(&active_branch_id, false, false, None);
+    let resolver_key = filesystem_storage_scope_key(active_branch_id, false, false, None);
     path_resolvers.entry(resolver_key).or_default();
     let mut staged = LixFileStagedBatch::with_row_capacity(parsed_writes.len().saturating_mul(3));
 
@@ -2715,7 +2758,7 @@ async fn execute_fast_lix_file_id_path_writes_inner(
                 FastLixFilePathWriteConflict::None => {
                     let file_id = fast_file_write_id(&write, ctx);
                     let context = FilesystemRowContext {
-                        branch_id: active_branch_id.clone(),
+                        branch_id: active_branch_id.to_string(),
                         global: false,
                         untracked: false,
                         file_id: None,
@@ -2797,7 +2840,7 @@ async fn execute_fast_lix_file_id_path_writes_inner(
         } else {
             let file_id = fast_file_write_id(&write, ctx);
             let context = FilesystemRowContext {
-                branch_id: active_branch_id.clone(),
+                branch_id: active_branch_id.to_string(),
                 global: false,
                 untracked: false,
                 file_id: None,
@@ -2830,7 +2873,9 @@ async fn execute_fast_lix_file_id_path_writes_inner(
         | FastLixFilePathWriteConflict::IdUpdateContent
         | FastLixFilePathWriteConflict::IdUpdateContentAndMetadata => TransactionWriteMode::Replace,
     };
-    stage_lix_file_fast_batch(ctx, mode, staged).await.map(Some)
+    Box::pin(stage_lix_file_fast_batch(ctx, mode, staged))
+        .await
+        .map(Some)
 }
 
 struct IndexedFilePathWrites {
@@ -2842,12 +2887,12 @@ async fn indexed_file_path_writes(
     ctx: &mut dyn SqlWriteExecutionContext,
     active_branch_id: &str,
     writes: &[FastLixFilePathWrite],
+    conflict: FastLixFilePathWriteConflict,
 ) -> Result<Option<IndexedFilePathWrites>, LixError> {
-    let index = ctx
-        .filesystem_path_index(&FilesystemPathIndexRequest::new(vec![
-            active_branch_id.to_string(),
-        ]))
-        .await?;
+    let index = Box::pin(ctx.filesystem_path_index(&FilesystemPathIndexRequest::new(vec![
+        active_branch_id.to_string(),
+    ])))
+    .await?;
     let mut existing = Vec::with_capacity(writes.len());
     for write in writes {
         let entries = index.exact_entries(&write.parsed.path);
@@ -2863,6 +2908,12 @@ async fn indexed_file_path_writes(
                 existing.push(None);
             }
             [entry] if entry.kind == FilesystemPathKind::File => {
+                // A plain INSERT onto an occupied path must raise the unique
+                // violation the whole-branch route already produces. Decline
+                // rather than duplicate that error construction here.
+                if conflict == FastLixFilePathWriteConflict::None {
+                    return Ok(None);
+                }
                 existing.push(Some(Arc::clone(entry)));
             }
             _ => return Ok(None),
@@ -2874,7 +2925,12 @@ async fn indexed_file_path_writes(
         .zip(&existing)
         .any(|(write, entry)| entry.is_none() && write.parsed.parsed_path.segments().count() > 1);
     let path_resolvers = if has_missing_nested {
-        match directory_path_resolvers_from_path_index(&index, Some(active_branch_id)) {
+        let missing_paths = writes
+            .iter()
+            .zip(&existing)
+            .filter(|(_, entry)| entry.is_none())
+            .map(|(write, _)| &write.parsed.parsed_path);
+        match directory_path_resolvers_for_paths(&index, missing_paths, Some(active_branch_id)) {
             Ok(resolvers) => Some(resolvers),
             Err(error) if error.code == LixError::CODE_CONSTRAINT_VIOLATION => return Ok(None),
             Err(error) => return Err(error),
@@ -2898,11 +2954,10 @@ async fn indexed_file_id_writes(
     active_branch_id: &str,
     writes: &[FastLixFilePathWrite],
 ) -> Result<Option<IndexedFilePathWrites>, LixError> {
-    let index = ctx
-        .filesystem_path_index(&FilesystemPathIndexRequest::new(vec![
-            active_branch_id.to_string(),
-        ]))
-        .await?;
+    let index = Box::pin(ctx.filesystem_path_index(&FilesystemPathIndexRequest::new(vec![
+        active_branch_id.to_string(),
+    ])))
+    .await?;
     let mut unique_ids = BTreeSet::new();
     let mut existing = Vec::with_capacity(writes.len());
     for write in writes {
@@ -2921,11 +2976,16 @@ async fn indexed_file_id_writes(
         }
     }
     let has_missing = existing.iter().any(Option::is_none);
-    // An ID miss says nothing about path availability. Seed the resolver from
-    // the complete index even for root paths so a different file already at a
-    // proposed path still raises the normal uniqueness error.
+    // An ID miss says nothing about path availability. Seed the resolver with
+    // the proposed paths' own leaves even at root level, so a different file
+    // already at a proposed path still raises the normal uniqueness error.
     let path_resolvers = if has_missing {
-        match directory_path_resolvers_from_path_index(&index, Some(active_branch_id)) {
+        let missing_paths = writes
+            .iter()
+            .zip(&existing)
+            .filter(|(_, entry)| entry.is_none())
+            .map(|(write, _)| &write.parsed.parsed_path);
+        match directory_path_resolvers_for_paths(&index, missing_paths, Some(active_branch_id)) {
             Ok(resolvers) => Some(resolvers),
             Err(error) if error.code == LixError::CODE_CONSTRAINT_VIOLATION => return Ok(None),
             Err(error) => return Err(error),
@@ -2949,8 +3009,21 @@ async fn stage_indexed_file_path_writes(
 ) -> Result<u64, LixError> {
     debug_assert_eq!(writes.len(), indexed.existing.len());
     debug_assert!(
-        conflict.updates_existing() || conflict == FastLixFilePathWriteConflict::IdDoNothing
+        conflict.updates_existing()
+            || conflict == FastLixFilePathWriteConflict::IdDoNothing
+            || conflict == FastLixFilePathWriteConflict::None
     );
+    // `indexed_file_path_writes` declines every plain INSERT that would collide,
+    // so a `None` conflict reaching here is a pure create and stages as one.
+    debug_assert!(
+        conflict != FastLixFilePathWriteConflict::None
+            || indexed.existing.iter().all(Option::is_none)
+    );
+    let write_mode = if conflict == FastLixFilePathWriteConflict::None {
+        TransactionWriteMode::Insert
+    } else {
+        TransactionWriteMode::Replace
+    };
     for (write, entry) in writes.iter().zip(&indexed.existing) {
         if !conflict.targets_id()
             && let Some(entry) = entry
@@ -2970,7 +3043,8 @@ async fn stage_indexed_file_path_writes(
     } else {
         Vec::new()
     };
-    let existing_materializations = load_exact_existing_materializations(ctx, &existing).await?;
+    let existing_materializations =
+        Box::pin(load_exact_existing_materializations(ctx, &existing)).await?;
     let mut staged = LixFileStagedBatch::with_row_capacity(writes.len().saturating_mul(3));
 
     for (write, entry) in writes.into_iter().zip(indexed.existing) {
@@ -3073,7 +3147,7 @@ async fn stage_indexed_file_path_writes(
         }
     }
 
-    stage_lix_file_fast_batch(ctx, TransactionWriteMode::Replace, staged).await
+    Box::pin(stage_lix_file_fast_batch(ctx, write_mode, staged)).await
 }
 
 #[derive(Debug, Clone, Copy, Default)]


### PR DESCRIPTION
# perf(filesystem): plan file creates from the written path, not the whole branch

**E44, round 6.** Machine **ryzen-9950x-II** (32c/186G). Base **`ab4277d9c`** (`origin/main`).
Candidate **`bb5665cf2`** (tree `2e2ee9fa`). RocksDB, release. Instrument:
`packages/rs-sdk-tests/examples/e16_write_file_scaling` (unmodified — `packages/e2e` and
`packages/rs-sdk-tests` were off limits and were not touched).

## The finding: there is no directory-specific term, and the create path never used the index

The assigned target was "file creation is O(directories)": 50.6 → 78.9 ms as directory count goes
1 → 5,000 at a fixed 10,000 resident files. Decomposing the create path by *route* rather than by
symbol located it in one statement:

| shape (10,000 files) | route taken on `main` | dirs=1 | dirs=1000 | dirs=5000 |
|---|---|---:|---:|---:|
| `insert_file_1line` (plain `INSERT`, nested) | whole-branch descriptor scan | 34.77 | 46.38 | 71.29 |
| `insert_root_file` (plain `INSERT`, root) | whole-branch descriptor scan | 34.77 | 46.38 | 71.29 |
| `upsert_file_1line` (`ON CONFLICT`, nested, new file) | path index + **whole-index** resolver | 10.63 | 12.81 | 22.84 |
| `upsert_root_file` (`ON CONFLICT`, root, new file) | path index + **empty** resolver | **2.53** | **2.45** | **2.67** |
| `upsert_existing_file` (`ON CONFLICT`, resident) | path index, no resolver | 2.33 | 2.31 | 2.83 |

`upsert_root_file` creates a brand new file and is **2.5 ms and flat in directories**. So creating a
file is inherently ~2.5 ms; nothing about the operation is O(files) or O(directories). The whole
term is two avoidable whole-repository builds sitting in front of it:

1. **A plain `INSERT` declined the path-index route entirely.**
   `stage_fast_lix_file_path_writes` only consulted `indexed_file_path_writes` when the write was
   classified `UpdateContent*`/`Id*`. A `None` conflict — the ordinary `INSERT INTO lix_file` an
   agent writes — fell through to `scan_hot_state_batch` over every filesystem row in the branch,
   `FilesystemIndex::from_live_batch` over that batch, and
   `directory_path_resolvers_from_state_batch` over it again. **~32 ms at 10k files / 1 dir,
   ~69 ms at 10k / 5k dirs.**
2. **Every nested create seeded a `DirectoryPathResolver` from the entire path index.**
   `directory_path_resolvers_from_path_index` walks `index.entries()`, calling `reserve_directory`
   per directory, `validate_directory_parent_graph` (which re-derives every directory's full path
   string), and `reserve_file` per file. **~8 ms at 10k/1 dir, ~20 ms at 10k/5k dirs.**
   `fallback_path_resolver` then *clones* that resolver once per write.

Directories are ~2.4x more expensive per row than files in that build (extra path derivation), which
is the whole of the "directory term" — it is the same O(entries) term with directories counted as
entries, not a separate one.

Planning a path write can only ever observe the resolver at two kinds of key: `(parent_id, segment)`
along the written path's own ancestor chain, and `(directory_id, leaf_name)` for the leaf
reservation. Nothing else in the repository is reachable.

## What changed

- `packages/lix/src/filesystem/planner.rs`: new `directory_path_resolvers_for_paths`. Seeds
  resolvers from only the ancestor prefixes of the paths being written — `depth` `exact_entries`
  lookups (O(log n) each) per write, instead of a walk over every entry. The leaf prefix is looked
  up too, so a file *or* directory already occupying the target name is still rejected by the
  resolver's own uniqueness check.
- `packages/lix/src/sql2/providers/file.rs`:
  - `indexed_file_path_writes` now takes the conflict mode and serves plain `INSERT` as well. If a
    plain `INSERT` would land on an occupied path it **declines** (`Ok(None)`) and the pre-existing
    whole-branch route produces the unique-violation error verbatim — the error path is unchanged
    by construction rather than by re-derivation.
  - `stage_indexed_file_path_writes` stages with `TransactionWriteMode::Insert` for a `None`
    conflict (it previously hard-coded `Replace`, which only ever saw upserts).
  - `indexed_file_path_writes` / `indexed_file_id_writes` use the scoped seeding.

**Removed:** nothing was deleted. `directory_path_resolvers_from_path_index` remains — it is still
the seeding for `UPDATE ... SET path = ...`, which can move a directory and legitimately needs a
wider view. No adapter API changed. No public API, SQL surface, or JS SDK surface changed. No
storage format changed.

A latent quirk found and deliberately **not** touched: `indexed_file_path_writes` probes for a
directory occupying a root-level file path with `exact_entries(&format!("{}/", path))`, but the
index spells directory paths *without* a trailing slash (`compose_directory_path`), so that probe
can never match. It is a pre-existing decline-check that silently never fires; fixing it is a
behaviour change that belongs in its own PR. (This is the bug that bit the first version of this
patch — the scoped seeding used the same trailing-slash spelling, found no ancestors, and staged a
duplicate directory. It failed loudly on the second nested create.)

## A/B — directory axis, 10,000 resident files

3 process-level reps per arm, arm order rotated (base/cand, cand/base, base/cand), 9 probes per
process, p50 per process. Cells are the median of the three per-process p50s; raw per-rep p50s in
brackets. 3 reps is the runbook's allowance for arms whose raw ranges do not overlap at all — base
[35.07, 36.50] vs cand [1.73, 2.13] at dirs=1 is the case it describes.

| shape | dirs | base p50 | cand p50 | delta | base reps / cand reps |
|---|---:|---:|---:|---:|---|
| `insert_file_1line` | 1 | 35.786 | **1.738** | **−95.1%** | [35.07, 35.79, 36.50] / [1.73, 1.74, 2.13] |
| `insert_file_1line` | 100 | 40.009 | **1.947** | **−95.1%** | [39.13, 40.01, 40.81] / [1.91, 1.95, 2.65] |
| `insert_file_1line` | 1000 | 45.121 | **2.245** | **−95.0%** | [44.79, 45.12, 45.93] / [2.18, 2.25, 2.49] |
| `insert_file_1line` | 5000 | 66.414 | **2.678** | **−96.0%** | [65.25, 66.41, 67.96] / [2.36, 2.68, 2.78] |
| `insert_root_file` | 1 | 35.062 | 1.506 | −95.7% | [34.03, 35.06, 35.81] / [1.50, 1.51, 1.89] |
| `insert_root_file` | 1000 | 44.045 | 1.972 | −95.5% | [43.54, 44.05, 44.88] / [1.76, 1.97, 2.14] |
| `insert_root_file` | 5000 | 64.599 | 2.318 | −96.4% | [63.70, 64.60, 65.34] / [1.93, 2.32, 2.34] |
| `upsert_file_1line` | 1 | 10.951 | 1.599 | −85.4% | [10.84, 10.95, 11.01] / [1.60, 1.60, 2.03] |
| `upsert_file_1line` | 1000 | 12.918 | 2.015 | −84.4% | [12.84, 12.92, 12.98] / [1.90, 2.02, 2.16] |
| `upsert_file_1line` | 5000 | 21.929 | 2.295 | −89.5% | [21.69, 21.93, 21.96] / [2.07, 2.30, 2.39] |
| `upsert_existing_file` | 1 | 3.186 | 1.973 | −38.1% | [2.82, 3.19, 3.32] / [1.93, 1.97, 1.97] |
| `upsert_existing_file` | 1000 | 2.884 | 2.393 | −17.0% | [2.83, 2.88, 3.32] / [2.29, 2.39, 2.81] |
| `upsert_existing_file` | 5000 | 2.877 | 2.312 | −19.6% | [2.82, 2.88, 2.91] / [2.28, 2.31, 2.42] |
| **`key_value_write` (null control)** | 1 | 0.393 | 0.303 | **−22.9%** | [0.393, 0.393, 0.397] / [0.298, 0.303, 0.303] |
| **`key_value_write` (null control)** | 100 | 0.402 | 0.307 | **−23.6%** | [0.398, 0.402, 0.407] / [0.304, 0.307, 0.361] |
| **`key_value_write` (null control)** | 1000 | 0.415 | 0.364 | **−12.3%** | [0.414, 0.415, 0.424] / [0.358, 0.364, 0.364] |
| **`key_value_write` (null control)** | 5000 | 0.442 | 0.359 | **−18.8%** | [0.433, 0.442, 0.445] / [0.359, 0.359, 0.365] |

**The slope is the result, and the slope is within-arm, so arm bias cannot touch it:**

| arm | dirs 1 → 5000 | growth | µs per directory |
|---|---|---:|---:|
| base | 35.79 → 66.41 ms | **+86%** | **+6.13** |
| cand | 1.74 → 2.68 ms | +54% | **+0.19** |

**A 32x smaller slope.** I am not claiming the residual is zero. An independent earlier A/B of the
same change (before the stack refactor described below, release hot path unchanged) put the
candidate at 2.32 → 2.40 ms, a slope of **+0.015 µs/dir**. The two runs bracket the residual at
0.015–0.19 µs/dir, i.e. somewhere between "gone" and "1/32 of base", and the whole spread is under
1 ms. What is unambiguous is that the *linear* term is gone: base pays +30.6 ms for 5,000
directories, cand pays under +1 ms.

## A/B — file axis, 1 directory (100 → 10,000 files, two orders of magnitude)

Measured on the earlier build of the same change; the file axis was not re-run after the stack
refactor, which does not touch the release hot path.

| shape | files | base p50 | cand p50 | delta |
|---|---:|---:|---:|---:|
| `insert_file_1line` | 100 | 1.494 | 1.134 | −24.1% |
| `insert_file_1line` | 1000 | 4.251 | 1.611 | −62.1% |
| `insert_file_1line` | 10000 | 50.977 | **2.217** | **−95.7%** |
| `key_value_write` (control) | 100 | 0.275 | 0.264 | −4.0% |
| `key_value_write` (control) | 1000 | 0.292 | 0.272 | −6.8% |
| `key_value_write` (control) | 10000 | 0.549 | 0.310 | **−43.5%** |

Within-arm: base grows **34x** across a 100x file range (1.49 → 50.98 ms); cand grows **2.0x**
(1.13 → 2.22 ms). The O(files) term goes with the O(directories) term, because they were the same
term.

Bonus, from the fixture build itself (10,000 files, 100 per statement, 100 statements):
seeding is **8676 → 6454 ms, −25.6%**. At 100 and 1,000 files it is +1.8% / +0.7% — the term does
not bite until the branch is large.

## Null control — read this before believing any single cell above

`key_value_write` writes one `lix_key_value` row, touches no file, and its code is byte-identical in
both arms. It moved **−12.3% to −23.6% on the directory axis and −43.5% at 10,000 files**. This is
the E25 instrument trap and it is present here in textbook form: the harness seeds its fixture by
**creating files**, which is exactly the path this PR changes, so the two arms' RocksDB stores are
in different physical states before the first timed operation. On the file axis it shows the
diagnostic signature — agrees at small N (−4.0% / −6.8%) and diverges at large N (−43.5%).

Consequences I am holding myself to:

- The headline (−93% to −96%, 15–32x) is **1.5 to 2 orders of magnitude beyond** the control's
  drift and is not in question.
- The **slope claims are unaffected** — they compare a size range within one arm, and the control is
  flat within each arm across the directory axis (base 0.394→0.437, cand 0.354→0.364).
- The `upsert_existing_file` −17% to −38% is at or barely above the control drift. **I am not claiming it.**
  Treat that lane as unresolved-but-not-regressed. (There is a plausible mechanism — that lane never
  built a resolver, so it should be untouched — which is itself a reason to read it as arm bias.)

**Deterministic metrics do not rescue the contaminated lanes in this harness.** `layout_accounting`
is deterministic for fixed logical input, but this instrument's input carries time-based `uuid_v7`
ids and timestamps, so tree-chunk packing varies run to run. Measured, same binary, two runs:

| metric | base run 1 | base run 2 | cand run 1 | cand run 2 |
|---|---:|---:|---:|---:|
| `tracked_state.tree_chunk` d_bytes | 3,843,908 | 4,939,912 | 4,162,572 | 4,504,676 |
| volume d_rows | 12,694 | 12,621 | 12,900 | 12,532 |

The base range straddles the cand range on both. **No bytes claim in either direction is supported
here**, and the +5% tree_chunk seen in a single paired run is noise, not a regression. Every other
space matched to the byte across arms (`hot_state.row.v21` 2831 rows / 976,523 bytes on both,
`binary_cas.*`, `changelog.commit`, `commit_state_manifest` all identical), which is the evidence
that the change writes the same physical rows.

## A stack-size trap this change surfaced (and how it was resolved)

The first version of this patch passed clippy, both feature-gated checks, the wasm check and the
whole workspace test run, and then failed one `lix_benchmarks` target:
`slatedb_history_blob_survives_until_final_root_release` **overflowed its stack**. Base at
`ab4277d9c` passes the same target.

It is not a logic bug. Bisecting `RUST_MIN_STACK` on the `test` profile (`opt-level = 0`) on the
same test binary:

| arm | overflows at | passes at |
|---|---|---|
| base `ab4277d9c` | 1,835,008 | 2,097,152 |
| candidate, first version | 2,097,152 | 2,621,440 |
| **candidate, this version** | **1,835,008** | **2,097,152** |

**The test sits within ~12% of libtest's 2 MiB worker-stack default on `main` already.** Routing
plain `INSERT` through the indexed route added one async frame to the deepest `lix_file` write
chain and that was enough to cross the line. Boxing the route's futures did **not** fix it — boxing
moves a future's storage to the heap but leaves the poll-frame nesting intact.

What fixed it: extracting the whole-branch fallback into its own `async fn`
(`stage_scanning_file_path_writes`) and boxing the call. At `opt-level = 0` a single `async fn`
keeps a stack slot for every local across every branch, so holding both routes in one body made one
enormous frame. Split, the candidate is back in the *same* bracket as base.

I did not raise `RUST_MIN_STACK` (ci.yml deliberately sets none, with a comment saying tests needing
more must size their own thread) and I did not touch the test — `packages/e2e` was off limits, and
weakening the assertion to fit the change is exactly the move the runbook forbids. That the test has
this little headroom on `main` is a separate fragility and is filed as follow-up work; the
`run_on_sized_stack` helper in `packages/lix` is the existing precedent for it.

## Regressions

None measured. The lanes that could plausibly move (`upsert_*`, `key_value_write`) all moved in the
candidate's favour or were flat; none regressed beyond noise on any of the eight (shape, size)
cells measured. Physical bytes: unresolvable at this sample, see above.

## Layout invariants

1. **Single authority.** No. Nothing gains a second writer or a second materialization. The change
   *narrows* what a create reads: two whole-branch derivations are replaced by point lookups into
   the path index, which was already the serving view for upserts. Reader count goes down, authority
   count is unchanged.
2. **Commit canonicality.** Untouched. No commit record, parent link, or state root is written
   differently; `stage_lix_file_fast_batch` receives the same staged rows.
3. **Derived views are caches.** Upheld and reinforced. `FilesystemPathIndex` is a disposable cache
   tagged with its source revision and rebuildable from canonical descriptor rows; this PR makes
   creates read it instead of re-deriving an equivalent view inline. When the index cannot answer
   (occupied path, ambiguous multi-scope entry, constraint violation while seeding) the code
   declines to the canonical whole-branch route rather than trusting the cache.
4. **Atomic publication.** Untouched. The same single staged write set is published; only the
   `TransactionWriteMode` for a plain `INSERT` is now stated explicitly (`Insert`) on the indexed
   route, matching what the fallback route already passed.
5. **GC from refs.** Untouched. No retention metadata, no reachability change.
6. **SQL reads canonical records.** Upheld. `lix_file` writes still resolve through the transaction's
   staged/committed overlay; the path index is a per-revision cache in front of it, per (3).

## Gate

Run on ryzen-9950x-II against `origin/main:.github/workflows/ci.yml` re-read fresh. CI has no
`cargo check --workspace` step; it runs clippy, a `--no-run` compile, then the test run.
`git rev-parse HEAD` and `git status --porcelain` printed inside the run — see below.

```
cargo clippy --profile test --workspace --all-targets --all-features -- -D warnings
cargo check -p lix --no-default-features
cargo check -p lix_js_sdk --target wasm32-unknown-unknown
cargo test --profile test --workspace --exclude lix_benchmarks --all-features --no-fail-fast
cargo test --profile test -p lix_benchmarks --features storage-benches,slatedb,root-replay-trace --no-fail-fast
```

All green on `GATE_HEAD=ed89cd95f` (`git status --porcelain` empty — tree `2e2ee9fa`, byte-identical
to the squashed commit `bb5665cf2` in this PR; `git rev-parse HEAD^{tree}` matches on both):

```
GATE_HEAD=ed89cd95fc7434df805bbc950c11414d980b2974
GATE_STATUS=[]
CLIPPY_EXIT=0
NODEFAULT_EXIT=0
WASM_EXIT=0
WS_EXIT=0
BENCH_EXIT=0
== failure greps ==            # grep -nE "^error|panicked|test result: FAILED|^failures:" over the
                               # captured logs: no matches
```

Logs captured to files and grepped, not tailed. Largest targets: 868 passed / 0 failed (lix unit),
95 passed / 4 ignored, 80 passed / 18 ignored, and every remaining target `ok`. `rustfmt --check` run
on the two touched files only (clean); repo-wide `cargo fmt --check` is dirty on pristine `main` and
was deliberately not run.

## Bench commands

```
# directory axis
E16_SHAPES=insert_file_1line,insert_root_file,upsert_file_1line,upsert_existing_file,key_value_write \
E16_PROBES=9 E16_DIRS=<1|100|1000|5000> \
  target-<arm>/release/examples/e16_write_file_scaling 10000

# file axis
E16_SHAPES=insert_file_1line,key_value_write E16_PROBES=9 E16_DIRS=1 \
  target-<arm>/release/examples/e16_write_file_scaling 100 1000 10000
```
