### PR TITLE
perf(filesystem): substitute path-index values in place during blob hydration

### DIFF
--- a/packages/lix/src/filesystem/path_index.rs
+++ b/packages/lix/src/filesystem/path_index.rs
@@ -633,6 +633,14 @@ impl FilesystemPathIndex {
                 requests.len()
             )));
         }
+        // `cached_blob_data` participates in no sort key, so hydration can only
+        // change values. Re-inserting each entry would remove and reinsert it in
+        // five AVL maps, path-copying and reallocating O(log n) nodes ten times
+        // per file; the substitution below rewrites each map once in one linear
+        // pass with the tree shape preserved.
+        let mut hydrated_by_identity =
+            BTreeMap::<FilesystemPathEntryIdentity, Arc<FilesystemPathEntry>>::new();
+        let mut heap_bytes_delta: isize = 0;
         for ((_, (hash, size_bytes, entries)), data) in requests.into_iter().zip(values) {
             let Some(data) = data else {
                 continue;
@@ -644,9 +652,28 @@ impl FilesystemPathIndex {
             for entry in entries {
                 let mut hydrated = (*entry).clone();
                 hydrated.cached_blob_data = Some(data.clone());
-                self.insert_entry(Arc::new(hydrated));
+                let hydrated = Arc::new(hydrated);
+                heap_bytes_delta += estimated_entry_index_bytes(&hydrated) as isize
+                    - estimated_entry_index_bytes(&entry) as isize;
+                hydrated_by_identity.insert(entry_identity(&entry), hydrated);
             }
         }
+        if hydrated_by_identity.is_empty() {
+            return Ok(self);
+        }
+        let substitute = |entry: &Arc<FilesystemPathEntry>| -> Arc<FilesystemPathEntry> {
+            hydrated_by_identity
+                .get(&entry_identity(entry))
+                .map_or_else(|| Arc::clone(entry), Arc::clone)
+        };
+        self.entries_by_path = self.entries_by_path.map_values(substitute);
+        self.entries_by_identity = self.entries_by_identity.map_values(substitute);
+        self.entries_by_descriptor_id = self.entries_by_descriptor_id.map_values(substitute);
+        self.files_by_id = self.files_by_id.map_values(substitute);
+        self.children_by_parent = self.children_by_parent.map_values(substitute);
+        self.estimated_heap_bytes = self
+            .estimated_heap_bytes
+            .saturating_add_signed(heap_bytes_delta);
         Ok(self)
     }
 

--- a/packages/lix/src/filesystem/persistent_map.rs
+++ b/packages/lix/src/filesystem/persistent_map.rs
@@ -95,6 +95,22 @@ where
         }
     }
 
+    /// Rebuilds the map with every value replaced by `project`, preserving the
+    /// existing tree shape exactly.
+    ///
+    /// Keys are untouched, so no comparison, rebalancing, or path copying is
+    /// needed: this is one linear pass that allocates one node per entry.
+    /// Callers must only use it when the substitution cannot change any key.
+    pub(crate) fn map_values<F>(&self, project: F) -> Self
+    where
+        F: Fn(&V) -> V,
+    {
+        Self {
+            root: map_values_node(self.root.as_deref(), &project),
+            len: self.len,
+        }
+    }
+
     pub(crate) fn values(&self) -> Vec<V> {
         let mut values = Vec::with_capacity(self.len);
         collect_values(self.root.as_deref(), &mut values);
@@ -383,6 +399,21 @@ fn leftmost<K, V>(mut node: &Arc<Node<K, V>>) -> &Arc<Node<K, V>> {
         node = left;
     }
     node
+}
+
+fn map_values_node<K, V, F>(node: Option<&Node<K, V>>, project: &F) -> Option<Arc<Node<K, V>>>
+where
+    K: Clone,
+    F: Fn(&V) -> V,
+{
+    let node = node?;
+    Some(Arc::new(Node {
+        key: node.key.clone(),
+        value: project(&node.value),
+        height: node.height,
+        left: map_values_node(node.left.as_deref(), project),
+        right: map_values_node(node.right.as_deref(), project),
+    }))
 }
 
 fn collect_values<K, V: Clone>(node: Option<&Node<K, V>>, values: &mut Vec<V>) {


### PR DESCRIPTION
# perf(filesystem): substitute path-index values in place during blob hydration

Cold open — what every CLI invocation and every agent tool call pays before doing
any useful work — was never owned this round. This PR measures it, shows the
reported regression was host drift, and removes the largest term that scales with
repository size.

## What changed physically/algorithmically

The first path-predicated `lix_file` query in a process builds the whole
filesystem path index for the branch. `FilesystemPathIndex::from_live_batch`
builds it correctly — five `PersistentMap`s constructed with
`PersistentMap::from_sorted`, an O(n) bulk build with no rebalancing.

`hydrate_small_blob_data` then attached each entry's cached small-blob payload by
calling `insert_entry(Arc::new(hydrated))` **once per file**. `insert_entry`
first calls `remove_entry` for the existing identity, so every file performed
**five removes and five inserts across five immutable AVL maps** — ten
path-copies of O(log n) freshly `Arc`-allocated nodes each. The bulk-build fast
path existed and this step did not reach it.

`cached_blob_data` participates in no sort key (`path_sort_key`,
`entry_identity`, `descriptor_id_sort_key`, `file_id_sort_key`,
`FilesystemChildSortKey` all ignore it), so hydration can only ever change
*values*. This PR replaces the re-insertion with `PersistentMap::map_values`, a
new structure-preserving substitution that rewrites each map once in a single
linear pass, cloning keys and reusing node heights verbatim.

**Added:** `PersistentMap::map_values` (+ its recursive helper).
**Removed:** the per-entry `insert_entry` call in `hydrate_small_blob_data`.
**No public API change**, no storage-adapter change, no format change.

## The measurement that motivated it

Instrument: a per-process cold-open probe (`open storage → open engine → one
materialized read`), public API only. **One process = one cold open**, which is
what an agent actually pays per task. This matters: the existing
`markdown_git_benchmark` cold lanes take 5 samples *inside one process*, so
anything process-once is amortized away and invisible there.

### Cold open decomposes as a fixed part and a per-file part

`main` @ `dabb0b878`, RocksDB, `ryzen-9950x-IV`, 9 reps, medians in ms:

| config | rocksdb open | wasm runtime | engine open | **first read** | total |
|---|---|---|---|---|---|
| 100 files | 2.66 | 0.09 | 0.94 | 2.27 | 6.33 |
| 1,000 files | 2.44 | 0.08 | 0.91 | 22.91 | 26.74 |
| 10,000 files | 2.75 | 0.09 | 0.97 | **269.46** | 273.50 |
| 100 files + 1,000 commits | 2.52 | 0.08 | 0.86 | 2.35 | 6.13 |
| 100 files + 100 branches | 2.40 | 0.08 | 0.88 | 2.22 | 5.87 |

- **~3.7 ms is fixed**: `RocksDB::open` 2.4–2.8 ms, engine open 0.9 ms, wasmtime
  runtime 0.08 ms, tokio runtime 0.11 ms. Flat in every axis.
- **History depth and branch count do not affect cold open at all** — 1,000
  commits and 100 branches are indistinguishable from 1 commit and 0 branches.
- **File count does, linearly**: ~27 µs per file, dominating everything else
  beyond a few hundred files.

The per-file term is entirely a **one-time process-local fill**, not a per-query
cost. Repeat reads in the same process, 10,000-file repo:

| read | 1 (cold) | 2 | 3 | 4 | 5 (different path) |
|---|---|---|---|---|---|
| µs | **268,302** | 128 | 82 | 70 | 70 |

Reads 2–5 are flat in file count (100-file repo: 121/73/65/62 µs). A single-row
point lookup pays O(all files) exactly once per process.

### Where the time went (frame pointers, `--children`, one call chain, no fan-in)

`perf record -F 4999 --call-graph fp` over three cold-open processes at 10,000
files, built into a separate `target-fp`:

```
89.99%  SessionContext::execute_read_statement_with_store
89.64%   HotStateContextReader as FilesystemPathIndexReader>::path_index
47.33%    FilesystemPathIndex::insert_entry
23.72%    FilesystemPathIndex::remove_entry
15.29%    binary_cas::kv::load_bytes_many
 7.36%    blake3_hash_many_avx512
29.84%  malloc      24.44% cfree      20.20% Arc::clone
```

**71% of the entire cold-open process was `insert_entry` + `remove_entry`.**

## A/B — this change

Same host, same 9 reps, interleaved with **arm order rotated** each rep, base and
candidate both at `dabb0b878` (candidate = base + this commit only).
Base SHA: `dabb0b878014fd081f5d8b1ea0c0a339139a931c`.

| config | base total | cand total | Δ total | base first read | cand first read | Δ read |
|---|---|---|---|---|---|---|
| 100 files | 6.33 ms | 5.48 ms | **−13.4%** | 2.27 ms | 1.67 ms | −26.4% |
| 1,000 files | 26.74 ms | 16.02 ms | **−40.1%** | 22.91 ms | 12.38 ms | −45.9% |
| 10,000 files | 273.50 ms | 145.14 ms | **−46.9%** | 269.46 ms | 141.20 ms | −47.6% |
| 100 files + 100 commits | 6.33 ms | 5.66 ms | −10.6% | 2.34 ms | 1.75 ms | −25.1% |
| 100 files + 1,000 commits | 6.13 ms | 5.47 ms | −10.9% | 2.35 ms | 1.74 ms | −25.9% |
| 100 files + 10 branches | 5.91 ms | 5.25 ms | −11.1% | 2.22 ms | 1.61 ms | −27.2% |
| 100 files + 100 branches | 5.87 ms | 5.16 ms | −12.0% | 2.22 ms | 1.62 ms | −27.1% |

Raw per-rep totals at 10,000 files — the ranges do not overlap:

```
base [275.21 272.91 273.75 274.15 272.33 273.38 273.08 273.74 273.50]
cand [145.08 146.26 144.86 145.14 145.92 145.09 144.55 147.78 146.87]
```

**Slope, not just endpoint.** Per-file cost of the first read:
**27.4 µs/file → 14.3 µs/file**. The term is still linear; this halves its
constant. The remainder is `binary_cas::load_bytes_many` plus blake3
verification of every small blob and the hot-state scan — see "what is left"
below.

Guards that could plausibly move and did not (same run, same reps): `RocksDB::open`
−2.3%…+1.1%, wasmtime runtime −3.5%…+2.5%, engine open −3.7%…−0.4%. These lanes
execute no changed code; they are reported to show the win is not a reshuffle.

### Null control

A lix-free lane in the same interleaved run (`read 8 MiB` + 8× blake3, identical
source in both arms) moved **−2.2%** between arms — that is the noise floor for
this harness on this host. Every fixed lane above sits inside it; the read lanes
are 10–20× outside it.

## Was the reported `cold_open_read` regression real? No — it was drift

Before this change, the same probe compared the round base `256b22587` against
`dabb0b878` (~30 PRs, including the certified-manifest scan drain #1367,
schema-set manifest values #1374, and index witness maintenance #1390):

| config | Δ storage open | Δ engine open | Δ first read | Δ total |
|---|---|---|---|---|
| 100 files | −0.5% | +1.0% | −0.6% | −1.6% |
| 1,000 files | +1.2% | +4.4% | −0.7% | −1.2% |
| 10,000 files | +3.6% | +4.2% | −0.5% | −0.5% |
| 100 files + 1,000 commits | −3.6% | +0.0% | −0.9% | −2.0% |
| 100 files + 100 branches | −0.3% | +2.0% | +1.0% | −0.2% |

Null control that run: +0.9%. **Nothing moved outside the noise floor**, so no
bisect was warranted. The 3.06–5.38 ms → 5.25–6.20 ms reading in the end-to-end
reconciliation is not reproducible under rotation.

## Layout invariants

1. **Single authority.** No. The path index remains a disposable process-local
   cache; this changes only how its values are rewritten in memory.
2. **Commit canonicality.** Unaffected — no commit, ref, or parent-link code is
   touched.
3. **Derived views are caches.** Preserved. `FilesystemPathIndex` is still keyed
   by `(branch_ids, revision, include_blob_refs, cache_small_blob_data)`, still
   rebuilt from canonical rows on a revision change, and still never an
   authority.
4. **Atomic publication.** Unaffected — read path only.
5. **GC from refs.** Unaffected.
6. **SQL reads canonical records.** Unchanged; the index is the same disposable
   cache it was, built from the same scan.

## Correctness argument

The substitution is safe because the hydrated entry differs from the original
only in `cached_blob_data`, which no sort key reads. Keys, tree shape, node
heights, `len`, `file_count`, and `directory_count` are therefore invariant by
construction — `map_values` clones keys and heights verbatim rather than
recomputing them. `estimated_heap_bytes` is adjusted by the exact same per-entry
delta the old remove/insert pair produced. `map_values` is `pub(crate)` and has
exactly one caller; the incremental commit path (`apply_committed_rows`) still
uses `insert_entry`/`remove_entry`, which are unchanged.

## What is left, and what it costs

Cold open after this change, at 10,000 files: **145 ms**, of which ~3.7 ms is
fixed and ~141 ms is still linear in file count at 14.3 µs/file. The remaining
per-file work is `hydrate_small_blob_data` **loading and blake3-verifying the
content of every file under 32 KiB** in order to answer a single-row point read.
Removing that requires scoping hydration to the entries a query actually selects,
which changes when exact file reads pay their CAS round trip — a semantics
decision, not a mechanical one, so it is deliberately not in this PR.

## Regressions

None measured. Every non-read lane is inside a −2.2% null control.

## Gate

Full CI-scope suite on `ryzen-9950x-IV`, `--no-fail-fast`, logs grepped not
tailed. `git rev-parse HEAD` and `git status --porcelain` printed inside the run.
```
HEAD 9e5b1a979bd9e4301a93f7aae46f5a7d3b028dbc
git status --porcelain: (empty)
diff vs origin/main: 2 files changed, 59 insertions(+), 1 deletion(-)

cargo check --workspace --all-targets --all-features                       exit 0
cargo clippy --profile test --workspace --all-targets --all-features -D warnings  exit 0
cargo check -p lix --no-default-features                                   exit 0
cargo check -p lix_js_sdk --target wasm32-unknown-unknown                   exit 0
cargo test --profile test --workspace --exclude lix_benchmarks --all-features --no-fail-fast   exit 0
cargo test --profile test -p lix_benchmarks --features storage-benches,slatedb,root-replay-trace --no-fail-fast  exit 0

grep of the full log: 0 `failures:`, 0 `panicked`, 0 `test result: FAILED`, 0 `^error`
total: 3535 passed / 0 failed   (round baseline 3533; +2 from PRs merged since)
```

## Bench commands

```
# probe (public API only, one process per cold open), 9 reps, arm order rotated
e48_cold_open seed <dir> <files> <extra_commits> <branches>
e48_cold_open open <dir> /f/000000.txt /f/000001.txt
e48_cold_open control <8MiB file>          # null control

# profile
CARGO_TARGET_DIR=~/claude5/target-fp cargo build -p lix --release --example e48_cold_open \
  --config 'target.x86_64-unknown-linux-gnu.rustflags=["-C","force-frame-pointers=yes","-C","debuginfo=1","-C","link-arg=-fuse-ld=mold"]'
perf record -F 4999 --call-graph fp -o e48-cold.perf -- bash -c 'for i in 1 2 3; do <bin> open <dir> ...; done'
perf report -i e48-cold.perf --children --sort symbol -g none --percent-limit 3
```

The probe is deliberately **not** in this PR: it needs a `lix_storage_rocksdb`
dev-dependency on `packages/lix`, and `packages/e2e` / `packages/rs-sdk-tests`
are off-limits while their fold is in flight. It lives in the round scratchpad as
`e48-cold-open.rs` and can be re-added as a fixture under `packages/lix` if the
lane should be permanent.
