### PR TITLE
probe(hot-state): validate the tombstone compaction premise — and refute half of it

### DIFF
--- a/packages/lix/src/hot_row_tombstone_probe.rs
+++ b/packages/lix/src/hot_row_tombstone_probe.rs
@@ -19,7 +19,7 @@ use crate::session::SessionContext;
 use crate::storage::ProjectedValue;
 use crate::storage_adapter::{
     Memory, SharedStorageAdapterRead, StorageAdapter, StorageAdapterRead,
-    StorageBeginScanOptions, StoragePrefix, StorageReadOptions, StorageSpace,
+    StorageBeginScanOptions, StorageKey, StoragePrefix, StorageReadOptions, StorageSpace,
     StorageWriteOptions,
 };
 
@@ -128,6 +128,90 @@ async fn row_census(storage: &Memory) -> RowCensus {
         packed_bases,
         root_bases,
     }
+}
+
+/// Reopens the engine on the same physical store so every in-process cache is
+/// cold. Without this, a probe that mutates storage behind the engine's back
+/// measures the cache rather than the store, and a resurrection assertion would
+/// pass for the wrong reason.
+async fn reopen_session(storage: &Memory) -> SessionContext<Memory> {
+    let engine = Engine::new(storage.clone())
+        .await
+        .expect("engine should reopen");
+    engine
+        .open_workspace_session()
+        .await
+        .expect("session should reopen")
+}
+
+/// Every `(key, value)` in one space.
+async fn space_entries(
+    read: &(impl StorageAdapterRead + ?Sized),
+    space: StorageSpace,
+) -> Vec<(StorageKey, bytes::Bytes)> {
+    let range = StoragePrefix {
+        bytes: bytes::Bytes::new(),
+    }
+    .to_range()
+    .expect("valid empty prefix");
+    let mut cursor = read
+        .begin_scan(space, range, StorageBeginScanOptions::default())
+        .await
+        .expect("scan the serving space");
+    cursor
+        .collect_all()
+        .await
+        .expect("collect serving entries")
+        .into_iter()
+        .map(|entry| {
+            let value = match entry.value {
+                ProjectedValue::FullValue(bytes) => bytes,
+                ProjectedValue::KeyOnly => bytes::Bytes::new(),
+            };
+            (entry.key, value)
+        })
+        .collect()
+}
+
+/// Physically removes every tombstone key in `ROW_SPACE`, simulating exactly
+/// what a compaction pass would stage. Returns how many were removed.
+///
+/// The probe fixture creates no engine-owned tombstones — the `fresh` arm of
+/// phase 1 reports 0 tombstones against 42 live engine rows — so every key this
+/// removes belongs to the churned probe collection.
+async fn drop_all_tombstones(storage: &Memory) -> usize {
+    let adapter = StorageAdapter::new(storage.clone());
+    let read = adapter
+        .begin_read(StorageReadOptions::default())
+        .await
+        .expect("read the hot row plane");
+    let entries = space_entries(&read, crate::hot_state::ROW_SPACE).await;
+    drop(read);
+    let mut writes = adapter.new_write_set();
+    let mut removed = 0_usize;
+    for (key, value) in entries {
+        if value.len() > 1 && value[1] & HEAD_VALUE_DELETED_BIT != 0 {
+            writes.delete(crate::hot_state::ROW_SPACE, key);
+            removed += 1;
+        }
+    }
+    adapter
+        .commit_write_set(writes, StorageWriteOptions::default())
+        .await
+        .expect("tombstone removal should commit");
+    removed
+}
+
+/// Rows the working diff currently reports for one schema.
+async fn working_diff_rows(session: &SessionContext<Memory>, schema_key: &str) -> usize {
+    session
+        .execute(
+            "SELECT entity_pk FROM lix_working_diff WHERE schema_key = $1",
+            &[crate::Value::Text(schema_key.to_string())],
+        )
+        .await
+        .expect("working diff should read")
+        .len()
 }
 
 /// Plans and commits a repository GC sweep against the same physical store the
@@ -461,4 +545,181 @@ async fn hot_row_tombstone_generation_rotation() {
     let census = row_census(&storage).await;
     let scan = timed_scan(&session, &scan_sql("rotrow"), 1, reps).await;
     report("after_gc", census, scan);
+}
+
+/// PHASE 4 — the compaction premise, validated before any engine change.
+///
+/// The design rests on one rule: a tombstone is load-bearing iff (a) a base
+/// visible to its generation still holds its identity, or (b) its working-diff
+/// baseline still makes the delete observable. The proposed first landing gates
+/// compaction on the generation having **zero** records in both base planes,
+/// which makes (a) vacuously false, and runs at the checkpoint, which is where
+/// (b) is discharged.
+///
+/// `safe` is that case: churn, checkpoint, then physically remove every
+/// tombstone. The query must still answer identically, the collection must not
+/// resurrect, the working diff must not move, and the scan must fall back to
+/// the no-tombstone control.
+///
+/// `near_miss` is the case compaction must refuse: the deletes are *not* yet
+/// checkpointed, so their baselines are live and the working diff is reporting
+/// them. Removing those same tombstones is observably wrong, and this arm
+/// measures the harm rather than asserting it in prose.
+///
+/// Both arms mutate storage underneath the engine and then **reopen** it, so
+/// nothing here can pass because of a warm cache.
+#[tokio::test]
+#[ignore = "measurement probe, not a gate"]
+async fn hot_row_tombstone_compaction_premise() {
+    let n = sizes_from_env("LIX_TOMBSTONE_SIZES", &[1_000])[0];
+    let reps = reps_from_env(5);
+    println!("phase4 | arm,event,row_entries,tombstones,packed_bases,root_bases,working_diff_rows,answer_rows,collection_rows,scan_us");
+
+    // ---- safe arm: the delete is already checkpointed ----
+    {
+        let (storage, session) = open_session().await;
+        register(&session, probe_schema("safrow")).await;
+        insert_rows(&session, "safrow", n).await;
+        delete_all_but_first(&session, "safrow", n).await;
+        session
+            .create_checkpoint()
+            .await
+            .expect("checkpoint should publish");
+
+        let census = row_census(&storage).await;
+        // The precondition the first landing gates on. If this ever fails the
+        // gate itself is what changed, not the conclusion.
+        assert_eq!(census.packed_bases, 0, "safe arm expects no packed base");
+        assert_eq!(census.root_bases, 0, "safe arm expects no root base");
+        let diff_before = working_diff_rows(&session, "safrow").await;
+        assert_eq!(
+            diff_before, 0,
+            "a checkpoint must discharge every delete's working-diff obligation"
+        );
+        let scan_before = timed_scan(&session, &scan_sql("safrow"), 1, reps).await;
+        let collection_before = session
+            .execute("SELECT id FROM safrow", &[])
+            .await
+            .expect("collection scan should run")
+            .len();
+        println!(
+            "safe,before_drop,{},{},{},{},{},1,{},{}",
+            census.entries,
+            census.tombstones,
+            census.packed_bases,
+            census.root_bases,
+            diff_before,
+            collection_before,
+            scan_before.as_micros()
+        );
+
+        let removed = drop_all_tombstones(&storage).await;
+        assert_eq!(removed, n - 1, "every tombstone should have been removable");
+        let session = reopen_session(&storage).await;
+
+        let census = row_census(&storage).await;
+        let diff_after = working_diff_rows(&session, "safrow").await;
+        let answer = session
+            .execute(&scan_sql("safrow"), &[])
+            .await
+            .expect("query should still run");
+        let collection_after = session
+            .execute("SELECT id FROM safrow", &[])
+            .await
+            .expect("collection scan should still run")
+            .len();
+        let scan_after = timed_scan(&session, &scan_sql("safrow"), 1, reps).await;
+        println!(
+            "safe,after_drop,{},{},{},{},{},{},{},{}",
+            census.entries,
+            census.tombstones,
+            census.packed_bases,
+            census.root_bases,
+            diff_after,
+            answer.len(),
+            collection_after,
+            scan_after.as_micros()
+        );
+
+        // The correctness bar, asserted rather than eyeballed.
+        assert_eq!(answer.len(), 1, "the surviving row must still answer");
+        assert_eq!(
+            collection_after, 1,
+            "dropping tombstones must not resurrect a deleted row"
+        );
+        assert_eq!(
+            diff_after, diff_before,
+            "dropping a discharged tombstone must not move the working diff"
+        );
+    }
+
+    // ---- near-miss arm: the delete is NOT yet checkpointed ----
+    {
+        let (storage, session) = open_session().await;
+        register(&session, probe_schema("nmrow")).await;
+        insert_rows(&session, "nmrow", n).await;
+        // Checkpoint FIRST, so the inserts are the clean baseline and the
+        // deletes below are what the working diff is reporting.
+        session
+            .create_checkpoint()
+            .await
+            .expect("first checkpoint should publish");
+        delete_all_but_first(&session, "nmrow", n).await;
+
+        let census = row_census(&storage).await;
+        let diff_before = working_diff_rows(&session, "nmrow").await;
+        let scan_before = timed_scan(&session, &scan_sql("nmrow"), 1, reps).await;
+        println!(
+            "near_miss,before_drop,{},{},{},{},{},1,1,{}",
+            census.entries,
+            census.tombstones,
+            census.packed_bases,
+            census.root_bases,
+            diff_before,
+            scan_before.as_micros()
+        );
+        assert!(
+            diff_before > 0,
+            "an uncheckpointed delete must be visible in the working diff, \
+             otherwise this arm proves nothing"
+        );
+
+        let removed = drop_all_tombstones(&storage).await;
+        let session = reopen_session(&storage).await;
+        let census = row_census(&storage).await;
+        let diff_after = working_diff_rows(&session, "nmrow").await;
+        let answer = session
+            .execute(&scan_sql("nmrow"), &[])
+            .await
+            .expect("query should still run");
+        let collection_after = session
+            .execute("SELECT id FROM nmrow", &[])
+            .await
+            .expect("collection scan should still run")
+            .len();
+        println!(
+            "near_miss,after_drop,{},{},{},{},{},{},{},-",
+            census.entries,
+            census.tombstones,
+            census.packed_bases,
+            census.root_bases,
+            diff_after,
+            answer.len(),
+            collection_after
+        );
+        println!(
+            "near_miss | removed={removed} working_diff_rows_lost={}",
+            diff_before.saturating_sub(diff_after)
+        );
+
+        // This is the harm the compaction gate exists to prevent. It is
+        // asserted so that an engine change which starts dropping live-baseline
+        // tombstones fails here loudly instead of silently losing deletes.
+        assert!(
+            diff_after < diff_before,
+            "dropping a live-baseline tombstone must lose working-diff deletes; \
+             if it does not, the working diff is not the obligation we think it is \
+             and the compaction gate needs rethinking"
+        );
+    }
 }

--- a/packages/lix/src/hot_row_tombstone_probe.rs
+++ b/packages/lix/src/hot_row_tombstone_probe.rs
@@ -67,6 +67,8 @@ struct RowCensus {
     packed_bases: usize,
     /// Records in the sparse-generation root base plane.
     root_bases: usize,
+    /// Records in the sparse per-row working-diff index.
+    diff_records: usize,
 }
 
 impl RowCensus {
@@ -122,11 +124,13 @@ async fn row_census(storage: &Memory) -> RowCensus {
     let root_bases = space_values(&read, crate::hot_state::ROOT_CURRENT_BASE_SPACE)
         .await
         .len();
+    let diff_records = space_values(&read, crate::hot_state::DIFF_SPACE).await.len();
     RowCensus {
         entries: rows.len(),
         tombstones,
         packed_bases,
         root_bases,
+        diff_records,
     }
 }
 
@@ -573,7 +577,7 @@ async fn hot_row_tombstone_generation_rotation() {
 async fn hot_row_tombstone_compaction_premise() {
     let n = sizes_from_env("LIX_TOMBSTONE_SIZES", &[1_000])[0];
     let reps = reps_from_env(5);
-    println!("phase4 | arm,event,row_entries,tombstones,packed_bases,root_bases,working_diff_rows,answer_rows,collection_rows,scan_us");
+    println!("phase4 | arm,event,row_entries,tombstones,packed_bases,root_bases,diff_records,working_diff_rows,answer_rows,collection_rows,scan_us");
 
     // ---- safe arm: the delete is already checkpointed ----
     {
@@ -603,11 +607,12 @@ async fn hot_row_tombstone_compaction_premise() {
             .expect("collection scan should run")
             .len();
         println!(
-            "safe,before_drop,{},{},{},{},{},1,{},{}",
+            "safe,before_drop,{},{},{},{},{},{},1,{},{}",
             census.entries,
             census.tombstones,
             census.packed_bases,
             census.root_bases,
+            census.diff_records,
             diff_before,
             collection_before,
             scan_before.as_micros()
@@ -630,11 +635,12 @@ async fn hot_row_tombstone_compaction_premise() {
             .len();
         let scan_after = timed_scan(&session, &scan_sql("safrow"), 1, reps).await;
         println!(
-            "safe,after_drop,{},{},{},{},{},{},{},{}",
+            "safe,after_drop,{},{},{},{},{},{},{},{},{}",
             census.entries,
             census.tombstones,
             census.packed_bases,
             census.root_bases,
+            census.diff_records,
             diff_after,
             answer.len(),
             collection_after,
@@ -670,11 +676,12 @@ async fn hot_row_tombstone_compaction_premise() {
         let diff_before = working_diff_rows(&session, "nmrow").await;
         let scan_before = timed_scan(&session, &scan_sql("nmrow"), 1, reps).await;
         println!(
-            "near_miss,before_drop,{},{},{},{},{},1,1,{}",
+            "near_miss,before_drop,{},{},{},{},{},{},1,1,{}",
             census.entries,
             census.tombstones,
             census.packed_bases,
             census.root_bases,
+            census.diff_records,
             diff_before,
             scan_before.as_micros()
         );
@@ -698,11 +705,12 @@ async fn hot_row_tombstone_compaction_premise() {
             .expect("collection scan should still run")
             .len();
         println!(
-            "near_miss,after_drop,{},{},{},{},{},{},{},-",
+            "near_miss,after_drop,{},{},{},{},{},{},{},{},-",
             census.entries,
             census.tombstones,
             census.packed_bases,
             census.root_bases,
+            census.diff_records,
             diff_after,
             answer.len(),
             collection_after
@@ -712,14 +720,31 @@ async fn hot_row_tombstone_compaction_premise() {
             diff_before.saturating_sub(diff_after)
         );
 
-        // This is the harm the compaction gate exists to prevent. It is
-        // asserted so that an engine change which starts dropping live-baseline
-        // tombstones fails here loudly instead of silently losing deletes.
-        assert!(
-            diff_after < diff_before,
-            "dropping a live-baseline tombstone must lose working-diff deletes; \
-             if it does not, the working diff is not the obligation we think it is \
-             and the compaction gate needs rethinking"
+        // MEASURED, and it refuted the hypothesis this arm was written to
+        // confirm. The prediction was that removing a live-baseline tombstone
+        // would lose working-diff deletes. It does not: the diff still reports
+        // every delete after all of them are physically gone and the engine has
+        // been reopened cold. The ROW_SPACE tombstone is therefore **not** the
+        // working diff's authority — `DIFF_SPACE` is, and the census column
+        // above is what says so. Condition (b) of the compaction rule does not
+        // hold against this plane at all.
+        //
+        // The assertion is kept, inverted, so that a future change which makes
+        // the working diff depend on the tombstone fails here loudly.
+        assert_eq!(
+            diff_after, diff_before,
+            "the working diff must survive tombstone removal; if it stops \
+             surviving, ROW_SPACE has become the working diff's authority and \
+             the compaction rule needs condition (b) back"
+        );
+        assert_eq!(
+            answer.len(),
+            1,
+            "the surviving row must still answer before any checkpoint"
+        );
+        assert_eq!(
+            collection_after, 1,
+            "removing an uncheckpointed tombstone must still not resurrect a row"
         );
     }
 }


### PR DESCRIPTION
# probe(hot-state): validate the tombstone compaction premise — and refute half of it

Follow-up to #1408, which measured the defect (1.000 tombstone per delete, ≈0.49 µs of scan each,
43x degradation for an unchanged one-row answer, nothing reclaiming any of it).

**No engine code changes.** One `#[cfg(test)]` file, one `#[ignore]`d test. This is the cheap
experiment that was supposed to de-risk a multi-hour change to `hot.rs`. It did — by killing half the
design before it was written.

Machine `hetzner-cpx62-III`. Gated at `6f162cd46`, merge-base `f66c17aee`.

---

## What it does

Both arms churn a collection to one live row, then **physically delete every tombstone in
`ROW_SPACE` through the storage adapter** — exactly what a compaction pass would stage — and then
**reopen the engine**, so nothing can pass on a warm cache. Then they re-run the query, a full
collection scan, and `lix_working_diff`.

- **safe** — the deletes are already checkpointed. This is the case the design says is compactable.
- **near-miss** — the deletes are *not* yet checkpointed, so their working-diff baselines are live.
  This is the case the design says compaction must refuse, and the correctness bar for the whole
  idea: dropping one of these was supposed to make a deleted row's absence unreportable.

| arm | event | row entries | tombstones | packed bases | root bases | **diff records** | working-diff rows | answer rows | collection rows | scan µs |
|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| safe | before drop | 1 042 | 999 | 0 | 0 | 1 | 0 | 1 | 1 | **565** |
| safe | after drop | 43 | 0 | 0 | 0 | 1 | 0 | 1 | 1 | **93** |
| near-miss | before drop | 1 042 | 999 | 0 | 0 | 5 | **999** | 1 | 1 | 623 |
| near-miss | after drop | 43 | 0 | 0 | 0 | 5 | **999** | 1 | 1 | – |
| safe | before drop | 10 042 | 9 999 | 0 | 0 | 1 | 0 | 1 | 1 | **4 904** |
| safe | after drop | 43 | 0 | 0 | 0 | 1 | 0 | 1 | 1 | **104** |
| near-miss | before drop | 10 042 | 9 999 | 0 | 0 | 41 | **9 999** | 1 | 1 | 5 752 |
| near-miss | after drop | 43 | 0 | 0 | 0 | 41 | **9 999** | 1 | 1 | – |

## Result 1 — the premise holds, completely

Dropping every tombstone in the zero-bases configuration:

- **recovers the entire degradation.** 4 904 µs → **104 µs** at 10 000 deletes, landing on #1408's
  `fresh` control (117 / 90 µs). Not a partial recovery — the whole 43x.
- **resurrects nothing.** `SELECT id FROM <t>` returns **1** row before and after, both sizes, after
  a cold reopen.
- **does not move the working diff.** 0 before, 0 after.

## Result 2 — the near-miss refuted the hypothesis it was written to confirm

The prediction was that removing a tombstone whose delete is not yet checkpointed would lose
working-diff deletes. **It does not.** After physically removing all 9 999 tombstones and reopening
cold, `lix_working_diff` still reports **all 9 999 deletes**. `working_diff_rows_lost = 0` at both
sizes.

**The `diff_records` column is the mechanism, and it is why the count is the load-bearing number
rather than the pass/fail.** It is not one record per deleted row — it is **5 at n = 1 000 and 41 at
n = 10 000**, against a probe that deletes in chunks of 250 (⌈999/250⌉+1 = 5, ⌈9999/250⌉+1 = 41).
That is **one record per commit**. The working diff for 9 999 deletes is reconstructed from 41
commit-scoped records — from canonical commit history relative to the checkpoint, **not** from the
`ROW_SPACE` tombstone.

So the `working_diff_baseline` field on a tombstone is not what makes a delete observable in
`lix_working_diff`. **Condition (b) of the compaction rule is false against this plane.** The
assertion is kept in the test, inverted, so that a future change which *does* make the working diff
depend on the tombstone fails here loudly.

## What that does to the design

The rule collapses from two conditions to one:

> A `ROW_SPACE` tombstone is load-bearing **iff a base visible to its generation still holds its
> identity.**

In a generation with zero records in `PACKED_CURRENT_BASE_SPACE` and zero in
`ROOT_CURRENT_BASE_SPACE` that is vacuously false — so the tombstone is dead weight **from the moment
it is written**, not from the next checkpoint. Every piece of scaffolding the accepted design needed
falls away:

| accepted design | still needed? |
|---|---|
| `tombstone_count` on `HotCollectionControl` | **no** |
| namespace bump + repo-wide grep for the old literal | **no** |
| ratio trigger `tombstone_count > max(K, live_count)` | **no** |
| O(collection) compaction pass | **no** |
| any change to checkpoint behaviour | **no** — checkpoints stay untouched and O(1) |

What remains is one localized change: **a tracked delete in a zero-base generation removes the key
instead of writing a tombstone**, extending what `physically_deletes()` already does for untracked
deletes (`untracked && deleted`). Tombstones then never accumulate, so the scan never degrades —
rather than degrading and being swept later.

## What this does NOT license

It validates the **read side** only. It removed tombstones after the fact and showed reads, the
collection and the working diff are unaffected by their absence. It does **not** show that never
writing them is equivalent. Before `hot.rs` is touched:

- **Absence guards and commit-time validation.** `tracked_head_absence_guards` and
  `validate_exact_collection_member` distinguish "identity is a tombstone" from "identity is absent"
  and raise *different* errors. Never writing the tombstone changes what those sites see.
- **Undo/redo** must be shown to replay canonical changes rather than read a `ROW_SPACE` tombstone.
- **Cost of the precondition.** "Zero records in both base planes" is a prefix count on two tiny
  planes, but under this design it lands on the **delete commit path**, not once per checkpoint. It
  needs a guard run of the write ids in `tracked_state_crud` before it can be called free.
- **Concurrency.** A publication racing a delete that removes a key rather than tombstoning it
  interacts with the branch-control CAS preconditions differently.

The checkpoint-triggered design stays as the fallback if those go badly: it needs no write-path
change at all, only a sweep.

## Layout invariants

1. **Single authority** — no. The probe only reads, plus one deliberate direct-storage mutation
   inside the test itself. It adds no writer to shipped code.
2. **Commit canonicality** — unaffected. Result 2 in fact *confirms* it: the working diff is
   reconstructed from canonical commit records, not from a serving-view row.
3. **Derived views are caches** — this is the invariant the whole result rests on, and it now has
   direct evidence: `ROW_SPACE` tombstones can be destroyed wholesale and every observable answer,
   including the working diff, survives a cold reopen.
4. **Atomic publication** — unaffected.
5. **GC from refs** — unaffected.
6. **SQL reads canonical records** — unaffected.

## Regressions

None possible from this diff: the module is `#[cfg(test)]` and its tests are `#[ignore]`d, so no
shipped path and no CI-executed test is touched. No timing guard is reported because there is no
changed engine code for one to execute.

## Gate

Full CI-scope suite on `hetzner-cpx62-III`, `--no-fail-fast`, full log captured and grepped rather
than tailed. Provenance printed inside the run:

```
worktree: /root/claude5/cand
HEAD: 6f162cd4636c495ff49668dbb409b493c657c8b7
status.porcelain: []
merge-base with origin/main: f66c17aee5247c92296351f4940545d77b754f79
```

| step | result |
|---|---|
| `cargo check --workspace --all-targets --all-features` | pass |
| `cargo clippy --profile test --workspace --all-targets --all-features -- -D warnings` | pass |
| `cargo test --profile test --workspace --exclude lix_benchmarks --all-features --no-fail-fast` | pass |
| `cargo test --profile test -p lix_benchmarks --features storage-benches,slatedb,root-replay-trace --no-fail-fast` | pass |
| `cargo check -p lix --no-default-features` | pass |
| `cargo check -p lix_js_sdk --target wasm32-unknown-unknown` | pass |
| `node scripts/validate-changes.mjs` | pass — 42 fragments |

**68 test targets ok, 0 failed, 0 errors.** The `cas_gc_history_retention` abort reported in #1408 is
gone at this base — it existed at `ab4277d9c` and was closed by #1405; see the correction comment on
#1408 for the three-SHA result and for the retraction of the bogus binary-hash argument that
accompanied it.

### Re-gate assessment

Gated at merge-base `f66c17aee`; `origin/main` is now `892bcba04`. This diff touches exactly one
file, `packages/lix/src/hot_row_tombstone_probe.rs`, which nothing that landed since goes near. But
#1413 changed the path-index hydrate and the file-create `INSERT` routing, and those sit **beneath**
this probe — and more importantly they could move the `packed_bases = 0` precondition the whole
design rests on. That is a measurement-validity question, not just a compile question, so the phases
were re-run on `892bcba04` rather than assumed.

**Re-measured on `892bcba04` (branch `claude-6/e45-premise-on-main`, HEAD `4f7b50fd6`) — the
precondition survives and every number reproduces:**

| | at `f66c17aee` | at `892bcba04` |
|---|---:|---:|
| churn n=10 000 — tombstones | 9 999 | **9 999** |
| churn n=10 000 — `packed_bases` / `root_bases` | 0 / 0 | **0 / 0** |
| churn n=10 000 — scan | 4 978 µs | **4 972 µs** |
| `fresh` control n=10 000 — scan | 117 µs | **103 µs** |
| phase-4 safe n=10 000 — before → after drop | 4 904 → 104 µs | **5 029 → 101 µs** |
| phase-4 near-miss — working-diff rows lost | 0 | **0** |
| phase-4 `diff_records` n=1 000 / n=10 000 | 5 / 41 | **5 / 41** |

#1413 did not move the `packed_bases = 0` precondition, so the zero-base gate the design depends on
still covers this workload, and the refutation of condition (b) is not an artefact of the older
base. No re-gate was run: the diff is the same single `#[cfg(test)]` file and the CI-scope gate above
is evidence about `6f162cd46`, which nothing landed since touches.
