### PR TITLE
Fix primary session server protocol integration

### DIFF
--- a/.changenotes/fix-primary-session-server-protocol-integration.md
+++ b/.changenotes/fix-primary-session-server-protocol-integration.md
@@ -1,0 +1,6 @@
+---
+type: patch
+---
+
+Fix the JavaScript SDK build after integrating Rust-owned primary sessions with
+the Lix Server Protocol.

--- a/packages/js-sdk/src/open-lix.browser.test.ts
+++ b/packages/js-sdk/src/open-lix.browser.test.ts
@@ -217,10 +217,7 @@ test("remote client state survives reopen while the server selects the session b
 		await second.close();
 	}
 	expect(initialBranchRequests).toEqual([null, null]);
-	expect(initialAccountRequests).toEqual([
-		null,
-		"00000000-0000-7000-8000-000000000002",
-	]);
+	expect(initialAccountRequests).toEqual([null, null]);
 });
 
 test("IndexedDbStorage persists a complete local Lix", async () => {

--- a/packages/js-sdk/src/open-lix.ts
+++ b/packages/js-sdk/src/open-lix.ts
@@ -140,9 +140,7 @@ export async function openLix(options: OpenLixOptions = {}): Promise<Lix> {
 			const restoredAccountId = await clientState.get<string>(
 				ACTIVE_ACCOUNT_CLIENT_STATE_KEY,
 			);
-			remoteBinding = await openRemoteLixBinding(options.server, {
-				initialActiveAccountId: restoredAccountId,
-			});
+			remoteBinding = await openRemoteLixBinding(options.server);
 			const activeAccountId = await remoteBinding.activeAccountId();
 			if (activeAccountId !== restoredAccountId) {
 				await clientState.set(ACTIVE_ACCOUNT_CLIENT_STATE_KEY, activeAccountId);

--- a/packages/lix/src/gc.rs
+++ b/packages/lix/src/gc.rs
@@ -3967,7 +3967,7 @@ mod tests {
             .await
             .expect("shared-payload repository should open");
         let session = engine
-            .open_workspace_session()
+            .open_session()
             .await
             .expect("shared-payload session should open");
         register_payload_schema(&session, "gc_payload_row").await;
@@ -4068,7 +4068,7 @@ mod tests {
             .await
             .expect("co-owned payload repository should open");
         let session = engine
-            .open_workspace_session()
+            .open_session()
             .await
             .expect("co-owned payload session should open");
         for schema_key in [
@@ -4176,7 +4176,7 @@ mod tests {
             .await
             .expect("superseded payload repository should open");
         let session = engine
-            .open_workspace_session()
+            .open_session()
             .await
             .expect("superseded payload session should open");
         register_payload_schema(&session, "gc_payload_row").await;

--- a/packages/lix/src/hot_row_tombstone_probe.rs
+++ b/packages/lix/src/hot_row_tombstone_probe.rs
@@ -143,7 +143,7 @@ async fn reopen_session(storage: &Memory) -> SessionContext<Memory> {
         .await
         .expect("engine should reopen");
     engine
-        .open_workspace_session()
+        .open_session()
         .await
         .expect("session should reopen")
 }

--- a/packages/lix/src/lib.rs
+++ b/packages/lix/src/lib.rs
@@ -16,7 +16,6 @@
 //! [`open_lix`] opens an in-memory repository. Add a storage adapter with
 //! [`OpenLixBuilder::with_storage`] when persistence is needed.
 
-#![recursion_limit = "256"]
 #![cfg_attr(
     test,
     allow(


### PR DESCRIPTION
Follow-up to #1409 after its final rebase incorporated #1411.

- remove the obsolete `initialActiveAccountId` option from the neutral server-protocol client call
- remove the duplicate crate-level recursion limit introduced by combining the hard cuts

Validation: `npm run typecheck`; `node scripts/validate-changes.mjs`; `git diff --check`.
