### PR TITLE
fix(lix): repair latest main hard cuts

### DIFF
--- a/packages/js-sdk/src/open-lix.browser.test.ts
+++ b/packages/js-sdk/src/open-lix.browser.test.ts
@@ -146,7 +146,7 @@ test("executes a globally ordered union plan in browser WASM", async () => {
 	}
 });
 
-test("remote client state survives reopen while the server selects the session branch", async () => {
+test("remote client state survives reopen without selecting protocol identity", async () => {
 	const { IndexedDbStorage, openLix } = await import("@lix-js/sdk");
 	const storage = new IndexedDbStorage({
 		name: `lix-client-state-test:${crypto.randomUUID()}`,
@@ -217,10 +217,7 @@ test("remote client state survives reopen while the server selects the session b
 		await second.close();
 	}
 	expect(initialBranchRequests).toEqual([null, null]);
-	expect(initialAccountRequests).toEqual([
-		null,
-		"00000000-0000-7000-8000-000000000002",
-	]);
+	expect(initialAccountRequests).toEqual([null, null]);
 });
 
 test("IndexedDbStorage persists a complete local Lix", async () => {

--- a/packages/js-sdk/src/open-lix.ts
+++ b/packages/js-sdk/src/open-lix.ts
@@ -140,9 +140,7 @@ export async function openLix(options: OpenLixOptions = {}): Promise<Lix> {
 			const restoredAccountId = await clientState.get<string>(
 				ACTIVE_ACCOUNT_CLIENT_STATE_KEY,
 			);
-			remoteBinding = await openRemoteLixBinding(options.server, {
-				initialActiveAccountId: restoredAccountId,
-			});
+			remoteBinding = await openRemoteLixBinding(options.server);
 			const activeAccountId = await remoteBinding.activeAccountId();
 			if (activeAccountId !== restoredAccountId) {
 				await clientState.set(ACTIVE_ACCOUNT_CLIENT_STATE_KEY, activeAccountId);

--- a/packages/lix/src/gc.rs
+++ b/packages/lix/src/gc.rs
@@ -3967,7 +3967,7 @@ mod tests {
             .await
             .expect("shared-payload repository should open");
         let session = engine
-            .open_workspace_session()
+            .open_session()
             .await
             .expect("shared-payload session should open");
         register_payload_schema(&session, "gc_payload_row").await;
@@ -4068,7 +4068,7 @@ mod tests {
             .await
             .expect("co-owned payload repository should open");
         let session = engine
-            .open_workspace_session()
+            .open_session()
             .await
             .expect("co-owned payload session should open");
         for schema_key in [
@@ -4176,7 +4176,7 @@ mod tests {
             .await
             .expect("superseded payload repository should open");
         let session = engine
-            .open_workspace_session()
+            .open_session()
             .await
             .expect("superseded payload session should open");
         register_payload_schema(&session, "gc_payload_row").await;

--- a/packages/lix/src/handle.rs
+++ b/packages/lix/src/handle.rs
@@ -144,7 +144,11 @@ where
         .and_then(|value| value.as_str().map(str::to_owned))
         .filter(|value| !value.is_empty());
     if let Some(branch_id) = stored_branch_id.as_deref()
-        && lix.engine.load_branch_head_commit_id(branch_id).await?.is_some()
+        && lix
+            .engine
+            .load_branch_head_commit_id(branch_id)
+            .await?
+            .is_some()
         && branch_id != lix.active_branch_id().await?
     {
         lix.session
@@ -469,12 +473,12 @@ where
     /// Creates an active global account if it does not exist. Existing mutable
     /// account fields are deliberately left unchanged.
     pub async fn ensure_account(&self, id: &str, name: &str, kind: &str) -> Result<(), LixError> {
-        let branch_id = self.active_branch_id().await?;
-        let system = self
-            .open_session_at_with_account(branch_id, lix::SYSTEM_ACCOUNT_ID)
-            .await?;
-        system
-            .execute(
+        let branch_id = Box::pin(self.active_branch_id()).await?;
+        let system = Box::pin(
+            self.open_session_at_with_account(branch_id, lix::SYSTEM_ACCOUNT_ID),
+        )
+        .await?;
+        Box::pin(system.execute(
                 "INSERT INTO lix_account_by_branch \
                  (id, name, kind, status, lixcol_branch_id, lixcol_global, lixcol_untracked) \
                  VALUES ($1, $2, $3, 'active', $4, true, false) \
@@ -486,9 +490,9 @@ where
                     Value::Text(kind.to_string()),
                     Value::Text(lix::GLOBAL_BRANCH_ID.to_string()),
                 ],
-            )
-            .await?;
-        system.close().await
+            ))
+        .await?;
+        Box::pin(system.close()).await
     }
 
     pub async fn create_branch(
@@ -701,10 +705,7 @@ mod tests {
     #[tokio::test]
     async fn sessions_share_one_engine_but_have_independent_lifecycles() {
         let root = open_lix().await.expect("open root Lix");
-        let first = root
-            .open_session()
-            .await
-            .expect("open first child session");
+        let first = root.open_session().await.expect("open first child session");
         let second = root
             .open_session()
             .await
@@ -791,7 +792,10 @@ mod tests {
             })
             .await
             .expect("switch primary session");
-        let secondary = primary.open_session().await.expect("open secondary session");
+        let secondary = primary
+            .open_session()
+            .await
+            .expect("open secondary session");
         secondary
             .switch_branch(SwitchBranchOptions {
                 branch_id: main_branch_id.clone(),
@@ -824,7 +828,10 @@ mod tests {
             )
             .await
             .expect("non-default draft should delete");
-        reopened.close().await.expect("close restored primary session");
+        reopened
+            .close()
+            .await
+            .expect("close restored primary session");
         repository_default
             .close()
             .await

--- a/packages/lix/src/hot_row_tombstone_probe.rs
+++ b/packages/lix/src/hot_row_tombstone_probe.rs
@@ -143,7 +143,7 @@ async fn reopen_session(storage: &Memory) -> SessionContext<Memory> {
         .await
         .expect("engine should reopen");
     engine
-        .open_workspace_session()
+        .open_session()
         .await
         .expect("session should reopen")
 }

--- a/packages/lix/src/lib.rs
+++ b/packages/lix/src/lib.rs
@@ -16,7 +16,6 @@
 //! [`open_lix`] opens an in-memory repository. Add a storage adapter with
 //! [`OpenLixBuilder::with_storage`] when persistence is needed.
 
-#![recursion_limit = "256"]
 #![cfg_attr(
     test,
     allow(

--- a/packages/lix/src/server_protocol/mod.rs
+++ b/packages/lix/src/server_protocol/mod.rs
@@ -2036,12 +2036,12 @@ where
                 context.principal,
                 ServerProtocolPrincipal::Authenticated { .. }
             ) {
-                state
-                    .server
-                    .inner
-                    .root
-                    .ensure_account(&active_account_id, &active_account_id, "human")
-                    .await?;
+                Box::pin(state.server.inner.root.ensure_account(
+                    &active_account_id,
+                    &active_account_id,
+                    "human",
+                ))
+                .await?;
             }
             state
                 .server
@@ -9656,8 +9656,7 @@ mod tests {
         let sql_span = spans
             .iter()
             .find(|span| {
-                span.name == "lix.sql.query"
-                    && span.parent.as_ref() == Some(&protocol_span_id)
+                span.name == "lix.sql.query" && span.parent.as_ref() == Some(&protocol_span_id)
             })
             .expect("SQL span under protocol request");
         assert_eq!(sql_span.parent.as_ref(), Some(&protocol_span_id));

--- a/packages/lix/src/server_protocol/mod.rs
+++ b/packages/lix/src/server_protocol/mod.rs
@@ -1495,7 +1495,9 @@ where
                 Ok(query) => query,
                 Err(error) => return error.into_response(),
             };
-            return result_response(handshake(state, query, parts.headers, context).await);
+            return result_response(
+                Box::pin(handshake(state, query, parts.headers, context)).await,
+            );
         }
 
         if path == "/lix/v1/session" {


### PR DESCRIPTION
## Summary

- remove the stale client-controlled active account restoration call after the server protocol hard cut
- remove the duplicate crate attribute that fails strict Rust checks
- update stale internal session method names introduced by the primary-session cut

## Validation

- `pnpm --dir packages/js-sdk run build:native`
- `cargo clippy --profile test -p lix --all-targets --all-features -- -D warnings`
