### PR TITLE
perf(hot-state): materialize a rotated generation's serving view once, not per read

### DIFF
--- a/packages/lix/src/hot_row_tombstone_probe.rs
+++ b/packages/lix/src/hot_row_tombstone_probe.rs
@@ -817,3 +817,59 @@ async fn rotated_generation_read_scaling() {
         }
     }
 }
+
+/// Connectivity guard for the root-base serving cache.
+///
+/// A serving cache that is built but never reached is invisible to a timing
+/// sweep: the numbers simply do not move, which reads as "the change did not
+/// help" rather than "the change is not wired up". That happened once while
+/// building this cache — three plausible reader-construction sites were wired
+/// and the lane that actually serves a SQL collection scan
+/// (`HotStateContextReader::scan_hot_branch_rows`) was not among them, and the
+/// A/B came back flat. This asserts engagement directly instead.
+///
+/// Note the counters are process-global, so under a parallel test run another
+/// test could contribute hits. That can only make this pass spuriously, never
+/// fail spuriously; it is a connectivity guard, not an exact accounting test.
+#[cfg(feature = "storage-benches")]
+#[tokio::test]
+async fn rotated_generation_serving_view_is_cached_after_the_first_read() {
+    let (_storage, session) = open_session().await;
+    register(&session, probe_schema("cachedrow")).await;
+    insert_rows(&session, "cachedrow", 50).await;
+    let branch = session
+        .create_branch(crate::CreateBranchOptions {
+            id: None,
+            name: "e51-cache-guard".to_string(),
+            from_commit_id: None,
+        })
+        .await
+        .expect("branch should create");
+    session
+        .switch_branch(crate::SwitchBranchOptions {
+            branch_id: branch.id.clone(),
+        })
+        .await
+        .expect("branch should switch");
+
+    // Discard whatever branch creation and the switch themselves recorded.
+    let _ = crate::storage_bench::take_root_base_batch_cache_accounting();
+
+    for _ in 0..5 {
+        let rows = session
+            .execute(&scan_sql("cachedrow"), &[])
+            .await
+            .expect("rotated scan should run");
+        assert_eq!(rows.len(), 1, "the rotated generation must serve one row");
+    }
+    let (hits, misses) = crate::storage_bench::take_root_base_batch_cache_accounting();
+    assert!(
+        misses > 0,
+        "the first rotated read must materialize the serving view (hits={hits} misses={misses})"
+    );
+    assert!(
+        hits > 0,
+        "later rotated reads must be served from the materialized view, \
+         not re-derived from canonical records (hits={hits} misses={misses})"
+    );
+}

--- a/packages/lix/src/hot_row_tombstone_probe.rs
+++ b/packages/lix/src/hot_row_tombstone_probe.rs
@@ -748,3 +748,72 @@ async fn hot_row_tombstone_compaction_premise() {
         );
     }
 }
+
+/// PHASE 5 — is the rotated-generation read cost proportional to the base, or
+/// is it a fixed setup cost?
+///
+/// Phase 3 measured a 3.9x penalty on a *churned* collection, which confounds
+/// two things: the accumulated tombstones and the root-backed serving path. This
+/// phase removes the churn entirely — every arm inserts `n` rows and deletes
+/// none, so there are zero tombstones — and varies only `n`, holding the answer
+/// at exactly one row.
+///
+/// - `live_main` serves the answer from the branch's own hot generation.
+/// - `live_rot` creates a branch over that head and switches to it, so the same
+///   answer is served by a sparse generation over a root current base.
+///
+/// If the penalty is a fixed setup cost it is the same number of microseconds at
+/// n = 1 and at n = 10 000. If it is proportional to the base it grows with `n`
+/// while the answer stays at one row.
+///
+/// The point lane (`WHERE id = 'row-0'`, equality on the declared primary key)
+/// is measured in the same arms because it is the lane that has an exact
+/// root-base route (`load_root_current_base_exact`) available to it; the
+/// collection lane does not.
+#[tokio::test]
+#[ignore = "measurement probe, not a gate"]
+async fn rotated_generation_read_scaling() {
+    let sizes = sizes_from_env("LIX_TOMBSTONE_SIZES", &[1, 100, 1_000, 10_000]);
+    let reps = reps_from_env(5);
+    println!(
+        "phase5 | arm,n,row_entries,tombstones,live_entries,packed_bases,root_bases,scan_us,point_us"
+    );
+    let point_sql = "SELECT id FROM liverow WHERE id = 'row-0'";
+    for n in sizes {
+        for rotate in [false, true] {
+            let (storage, session) = open_session().await;
+            register(&session, probe_schema("liverow")).await;
+            insert_rows(&session, "liverow", n).await;
+            if rotate {
+                let branch = session
+                    .create_branch(crate::CreateBranchOptions {
+                        id: None,
+                        name: "e51-rotation".to_string(),
+                        from_commit_id: None,
+                    })
+                    .await
+                    .expect("branch should create");
+                session
+                    .switch_branch(crate::SwitchBranchOptions {
+                        branch_id: branch.id.clone(),
+                    })
+                    .await
+                    .expect("branch should switch");
+            }
+            let census = row_census(&storage).await;
+            let scan = timed_scan(&session, &scan_sql("liverow"), 1, reps).await;
+            let point = timed_scan(&session, point_sql, 1, reps).await;
+            println!(
+                "{},{n},{},{},{},{},{},{},{}",
+                if rotate { "live_rot" } else { "live_main" },
+                census.entries,
+                census.tombstones,
+                census.live(),
+                census.packed_bases,
+                census.root_bases,
+                scan.as_micros(),
+                point.as_micros()
+            );
+        }
+    }
+}

--- a/packages/lix/src/hot_state/context.rs
+++ b/packages/lix/src/hot_state/context.rs
@@ -366,6 +366,7 @@ pub(crate) struct HotStateContext {
         std::sync::Arc<std::sync::Mutex<crate::hot_state::EntityColumnarShadowMaskCache>>,
     entity_decoded_column_cache: crate::hot_state::EntityDecodedColumnCache,
     global_key_value_rows: std::sync::Arc<GlobalKeyValueRowCache>,
+    root_base_cache: std::sync::Arc<crate::hot_state::tracked_head::RootBaseBatchCache>,
 }
 
 impl HotStateContext {
@@ -397,6 +398,7 @@ impl HotStateContext {
                     entity_columnar_array_budget,
                 ),
             global_key_value_rows: std::sync::Arc::new(GlobalKeyValueRowCache::default()),
+            root_base_cache: std::sync::Arc::default(),
         }
     }
 
@@ -425,6 +427,7 @@ impl HotStateContext {
             entity_point_snapshot_cache: std::sync::Arc::clone(&self.entity_point_snapshot_cache),
             entity_columnar_layout_cache: std::sync::Arc::clone(&self.entity_columnar_layout_cache),
             branch_head_control_cache: None,
+            root_base_cache: std::sync::Arc::clone(&self.root_base_cache),
         }
     }
 
@@ -446,6 +449,7 @@ impl HotStateContext {
             entity_point_snapshot_cache: std::sync::Arc::clone(&self.entity_point_snapshot_cache),
             entity_columnar_layout_cache: std::sync::Arc::clone(&self.entity_columnar_layout_cache),
             branch_head_control_cache: Some(branch_head_control_cache),
+            root_base_cache: std::sync::Arc::clone(&self.root_base_cache),
         }
     }
 
@@ -477,6 +481,7 @@ impl HotStateContext {
             entity_point_snapshot_cache: std::sync::Arc::new(EntityPointSnapshotCache::default()),
             entity_columnar_layout_cache: std::sync::Arc::new(EntityColumnarLayoutCache::default()),
             branch_head_control_cache: None,
+            root_base_cache: std::sync::Arc::clone(&self.root_base_cache),
         }
     }
 
@@ -500,6 +505,7 @@ pub(crate) struct HotStateContextReader<S> {
     entity_point_snapshot_cache: std::sync::Arc<EntityPointSnapshotCache>,
     entity_columnar_layout_cache: std::sync::Arc<EntityColumnarLayoutCache>,
     branch_head_control_cache: Option<std::sync::Arc<BranchHeadControlCache>>,
+    root_base_cache: std::sync::Arc<crate::hot_state::tracked_head::RootBaseBatchCache>,
 }
 
 impl<S> HotStateContextReader<S>
@@ -565,6 +571,7 @@ where
         let snapshots = self
             .tracked_head
             .reader(&self.store)
+            .with_root_base_cache(std::sync::Arc::clone(&self.root_base_cache))
             .scan_entity_snapshots(
                 &requested_branch_id,
                 requested_control,
@@ -594,6 +601,7 @@ where
         };
         self.tracked_head
             .reader(&self.store)
+            .with_root_base_cache(std::sync::Arc::clone(&self.root_base_cache))
             .scan_entity_primary_keys(
                 &branch_id,
                 control,
@@ -982,13 +990,17 @@ where
             return Ok(Some(MaterializedHotStateBatch::default()));
         }
         let tracked_request = tracked_scan_request_from_live(request);
-        let tracked_head = self.branch_head_control_cache.as_ref().map_or_else(
-            || self.tracked_head.reader(&self.store),
-            |cache| {
-                self.tracked_head
-                    .transaction_reader(&self.store, std::sync::Arc::clone(&cache.hot_state))
-            },
-        );
+        let tracked_head = self
+            .branch_head_control_cache
+            .as_ref()
+            .map_or_else(
+                || self.tracked_head.reader(&self.store),
+                |cache| {
+                    self.tracked_head
+                        .transaction_reader(&self.store, std::sync::Arc::clone(&cache.hot_state))
+                },
+            )
+            .with_root_base_cache(std::sync::Arc::clone(&self.root_base_cache));
         let rows_by_branch = tracked_head
             .scan_live_batches_for_controls(&controls, &tracked_request, request.filter.untracked)
             .await?;
@@ -1371,6 +1383,7 @@ where
                     let rows = self
                         .tracked_head
                         .reader(store)
+                        .with_root_base_cache(std::sync::Arc::clone(&self.root_base_cache))
                         .scan_live_batch_for_retention(
                             &branch_id,
                             control,

--- a/packages/lix/src/hot_state/tracked_head.rs
+++ b/packages/lix/src/hot_state/tracked_head.rs
@@ -17,6 +17,7 @@ pub(crate) use hot::WORKING_DIFF_PATH_HITS;
 #[cfg(test)]
 pub(crate) use hot::hot_generation_scope_prefix;
 pub(crate) use hot::{
+    RootBaseBatchCache,
     CERTIFIED_ENTITY_BATCH_MANIFEST_SPACE, CERTIFIED_ENTITY_BATCH_PAGE_SPACE,
     CERTIFIED_ENTITY_BATCH_SPACE, CertifiedEntityBatchFileRef, DeferredFreshHotPlan,
     DeferredFreshHotRowRef, DeferredFreshHotRows, EntityColumnarOverlayRow,
@@ -501,6 +502,7 @@ impl TrackedHeadContext {
         hot::HotStateStoreReader {
             store,
             transaction_cache: None,
+            root_base_cache: None,
         }
     }
 
@@ -516,6 +518,7 @@ impl TrackedHeadContext {
         hot::HotStateStoreReader {
             store,
             transaction_cache: Some(cache),
+            root_base_cache: None,
         }
     }
 

--- a/packages/lix/src/hot_state/tracked_head/hot.rs
+++ b/packages/lix/src/hot_state/tracked_head/hot.rs
@@ -3480,14 +3480,38 @@ async fn scan_root_current_base_rows(
     generation: CommitId,
     active_checkpoint_commit_id: Option<CommitId>,
     request: &TrackedStateScanRequest,
+    root_base_cache: Option<&RootBaseBatchCache>,
 ) -> Result<MaterializedHotStateBatch, LixError> {
     let Some(base_commit_id) = load_root_current_base_commit(store, branch_id, generation).await?
     else {
         return Ok(MaterializedHotStateBatch::default());
     };
-    let mut reader = crate::tracked_state::TrackedStateContext::new().reader(store);
-    let tracked =
-        Box::pin(reader.scan_batch_at_commit(&base_commit_id.to_string(), request)).await?;
+    // Only unbounded requests are memoized. A pushed-down LIMIT varies with the
+    // number of sparse candidates that could shadow a root row, so caching by
+    // it would churn the cache with near-duplicate entries for no reuse.
+    let cache = root_base_cache.filter(|_| request.limit.is_none());
+    let tracked = match cache.and_then(|cache| cache.get(base_commit_id, request)) {
+        Some(cached) => {
+            #[cfg(feature = "storage-benches")]
+            crate::storage_bench::record_root_base_batch_cache_hit();
+            cached
+        }
+        None => {
+            #[cfg(feature = "storage-benches")]
+            if cache.is_some() {
+                crate::storage_bench::record_root_base_batch_cache_miss();
+            }
+            let mut reader = crate::tracked_state::TrackedStateContext::new().reader(store);
+            let produced = Arc::new(
+                Box::pin(reader.scan_batch_at_commit(&base_commit_id.to_string(), request))
+                    .await?,
+            );
+            if let Some(cache) = cache {
+                cache.insert(base_commit_id, request.clone(), Arc::clone(&produced));
+            }
+            produced
+        }
+    };
     // Tracked rows arrive ordered by `(schema_key, file_id, entity_pk)`, so a
     // scope repeats across a contiguous run and the set this builds is the
     // number of collections in the base — one, for an ordinary collection scan.
@@ -3557,6 +3581,7 @@ async fn scan_root_current_base_rows_for_merge(
     active_checkpoint_commit_id: Option<CommitId>,
     request: &TrackedStateScanRequest,
     other_candidate_count: usize,
+    root_base_cache: Option<&RootBaseBatchCache>,
 ) -> Result<MaterializedHotStateBatch, LixError> {
     let Some(base_commit_id) = load_root_current_base_commit(store, branch_id, generation).await?
     else {
@@ -3683,6 +3708,7 @@ async fn scan_root_current_base_rows_for_merge(
         generation,
         active_checkpoint_commit_id,
         &root_request,
+        root_base_cache,
     )
     .await
 }
@@ -4797,10 +4823,133 @@ fn exclude_ordered_live_batch_identities(
     )
 }
 
+/// Serving cache for the materialized tracked state at a root current base.
+///
+/// A rotated (branch) generation does not serve reads from materialized hot
+/// rows. Branch lifecycle publication writes a 16-byte reference to a commit
+/// and copies nothing, so every collection scan on that branch re-derives the
+/// collection from canonical records: a tracked-state tree walk, a key decode
+/// per row, and a commit-delta payload fetch per owning commit. Measured, that
+/// is 2.733 µs per base row against 0.686 for the same answer served from a
+/// branch's own hot generation, and the branch pays it on **every** read for
+/// the rest of its life because nothing ever discharges the deferral.
+///
+/// What makes it cacheable with no invalidation rule at all is that the
+/// re-derivation is a pure function of an **immutable** commit's tracked state
+/// and the request. A commit's tracked state never changes, so a hit on
+/// `(base_commit_id, request)` is exact by construction — there is no revision
+/// to compare and no staleness window. Everything about a rotated generation
+/// that *can* change is deliberately outside what is cached: the branch's
+/// stored collection controls and its working-diff checkpoint are applied by
+/// [`scan_root_current_base_rows`] to the rows this returns, after the fact.
+///
+/// This is a disposable derived view under layout invariant 3: never an
+/// authority, rebuildable by re-running the scan, and dropping it costs only
+/// time. Branch creation therefore stays O(1) — nothing is materialized when a
+/// branch is created — and the first read of a rotated generation pays the
+/// materialization once instead of every read paying it forever.
+#[derive(Default)]
+pub(crate) struct RootBaseBatchCache {
+    entries: std::sync::Mutex<RootBaseBatchCacheEntries>,
+}
+
+#[derive(Default)]
+struct RootBaseBatchCacheEntries {
+    /// Most recently used first.
+    resident: Vec<RootBaseBatchCacheEntry>,
+    rows: usize,
+}
+
+struct RootBaseBatchCacheEntry {
+    base_commit_id: CommitId,
+    request: TrackedStateScanRequest,
+    batch: Arc<crate::tracked_state::MaterializedTrackedStateBatch>,
+}
+
+/// A rotated generation holds one base commit and a handful of request shapes,
+/// so a small cache covers it. The row budget is the real bound; the entry
+/// count only keeps the linear scan short.
+const ROOT_BASE_BATCH_CACHE_MAX_ENTRIES: usize = 16;
+const ROOT_BASE_BATCH_CACHE_MAX_ROWS: usize = 250_000;
+
+impl RootBaseBatchCache {
+    /// A poisoned cache lock degrades to a miss rather than an error. A serving
+    /// cache must never be able to fail a read that would otherwise succeed.
+    fn entries(&self) -> std::sync::MutexGuard<'_, RootBaseBatchCacheEntries> {
+        self.entries
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+    }
+
+    fn get(
+        &self,
+        base_commit_id: CommitId,
+        request: &TrackedStateScanRequest,
+    ) -> Option<Arc<crate::tracked_state::MaterializedTrackedStateBatch>> {
+        let mut entries = self.entries();
+        let index = entries.resident.iter().position(|entry| {
+            entry.base_commit_id == base_commit_id && &entry.request == request
+        })?;
+        let entry = entries.resident.remove(index);
+        let batch = Arc::clone(&entry.batch);
+        entries.resident.insert(0, entry);
+        Some(batch)
+    }
+
+    fn insert(
+        &self,
+        base_commit_id: CommitId,
+        request: TrackedStateScanRequest,
+        batch: Arc<crate::tracked_state::MaterializedTrackedStateBatch>,
+    ) {
+        let rows = batch.len();
+        if rows > ROOT_BASE_BATCH_CACHE_MAX_ROWS {
+            return;
+        }
+        let mut entries = self.entries();
+        if let Some(index) = entries.resident.iter().position(|entry| {
+            entry.base_commit_id == base_commit_id && entry.request == request
+        }) {
+            let previous = entries.resident.remove(index);
+            entries.rows = entries.rows.saturating_sub(previous.batch.len());
+        }
+        entries.resident.insert(
+            0,
+            RootBaseBatchCacheEntry {
+                base_commit_id,
+                request,
+                batch,
+            },
+        );
+        entries.rows = entries.rows.saturating_add(rows);
+        while entries.resident.len() > ROOT_BASE_BATCH_CACHE_MAX_ENTRIES
+            || entries.rows > ROOT_BASE_BATCH_CACHE_MAX_ROWS
+        {
+            let Some(evicted) = entries.resident.pop() else {
+                break;
+            };
+            entries.rows = entries.rows.saturating_sub(evicted.batch.len());
+        }
+    }
+}
+
 /// Direct reader for one published hot generation.
 pub(crate) struct HotStateStoreReader<S> {
     pub(super) store: S,
     pub(super) transaction_cache: Option<Arc<HotStateTransactionCache>>,
+    pub(super) root_base_cache: Option<Arc<RootBaseBatchCache>>,
+}
+
+impl<S> HotStateStoreReader<S> {
+    /// Attaches the engine-lifetime root-base serving cache.
+    ///
+    /// Readers built for write/GC paths deliberately leave this unset: they
+    /// read a generation once as part of producing a write set, so caching
+    /// buys nothing and only holds memory.
+    pub(crate) fn with_root_base_cache(mut self, cache: Arc<RootBaseBatchCache>) -> Self {
+        self.root_base_cache = Some(cache);
+        self
+    }
 }
 
 impl<S> HotStateStoreReader<S>
@@ -5325,6 +5474,7 @@ where
                         // a retired row while a later live row still exists.
                         limit: None,
                     },
+                    self.root_base_cache.as_deref(),
                 ))
                 .await?
             } else {
@@ -5905,6 +6055,7 @@ where
             rows.len()
                 .saturating_add(packed_rows.len())
                 .saturating_add(certified_rows.len()),
+            self.root_base_cache.as_deref(),
         ))
         .await?;
         // HOT and packed rows carry comparable commit ownership; their
@@ -6723,6 +6874,7 @@ where
             let reader = HotStateStoreReader {
                 store: &*self.store,
                 transaction_cache: None,
+                root_base_cache: None,
             };
             reader
                 .exact_collection_live_count(
@@ -12562,6 +12714,84 @@ mod tests {
         StorageWriteOptions,
     };
 
+    /// The root-base cache has no invalidation rule — it relies entirely on the
+    /// key being exact. So the key must actually discriminate: a different base
+    /// commit, a different filter, or a different projection must all miss.
+    /// A false hit here would serve one collection's rows for another's query.
+    #[test]
+    fn root_base_batch_cache_key_is_exact() {
+        let cache = RootBaseBatchCache::default();
+        let first = CommitId::for_test_label("root-base-cache-first");
+        let second = CommitId::for_test_label("root-base-cache-second");
+        let request = |schema_key: &str, columns: &[&str], limit: Option<usize>| {
+            TrackedStateScanRequest {
+                filter: TrackedStateFilter {
+                    schema_keys: vec![schema_key.to_owned()],
+                    ..TrackedStateFilter::default()
+                },
+                read_columns: TrackedStateReadColumns {
+                    columns: columns.iter().map(|column| (*column).to_owned()).collect(),
+                },
+                limit,
+            }
+        };
+        let batch = Arc::new(crate::tracked_state::MaterializedTrackedStateBatch::default());
+
+        let stored = request("s", &["change_id"], None);
+        cache.insert(first, stored.clone(), Arc::clone(&batch));
+
+        assert!(cache.get(first, &stored).is_some(), "exact key must hit");
+        assert!(
+            cache.get(second, &stored).is_none(),
+            "a different base commit must miss"
+        );
+        assert!(
+            cache.get(first, &request("other", &["change_id"], None)).is_none(),
+            "a different schema filter must miss"
+        );
+        assert!(
+            cache.get(first, &request("s", &["snapshot_content"], None)).is_none(),
+            "a different projection must miss"
+        );
+        assert!(
+            cache.get(first, &request("s", &["change_id"], Some(1))).is_none(),
+            "a different limit must miss"
+        );
+    }
+
+    /// The cache is bounded by entry count, so a rotated generation that is
+    /// scanned under many request shapes cannot grow it without limit.
+    #[test]
+    fn root_base_batch_cache_evicts_least_recently_used() {
+        let cache = RootBaseBatchCache::default();
+        let commit_id = CommitId::for_test_label("root-base-cache-evict");
+        let request = |index: usize| TrackedStateScanRequest {
+            filter: TrackedStateFilter {
+                schema_keys: vec![format!("s{index}")],
+                ..TrackedStateFilter::default()
+            },
+            ..TrackedStateScanRequest::default()
+        };
+        let batch = Arc::new(crate::tracked_state::MaterializedTrackedStateBatch::default());
+        for index in 0..=ROOT_BASE_BATCH_CACHE_MAX_ENTRIES {
+            cache.insert(commit_id, request(index), Arc::clone(&batch));
+        }
+        assert_eq!(
+            cache.entries().resident.len(),
+            ROOT_BASE_BATCH_CACHE_MAX_ENTRIES
+        );
+        assert!(
+            cache.get(commit_id, &request(0)).is_none(),
+            "the oldest entry must have been evicted"
+        );
+        assert!(
+            cache
+                .get(commit_id, &request(ROOT_BASE_BATCH_CACHE_MAX_ENTRIES))
+                .is_some(),
+            "the newest entry must be resident"
+        );
+    }
+
     /// The memo replaced a per-row recomputation with a per-scope one, and it
     /// also replaced `all(|scope| created_at >= scope.floor)` with a single
     /// comparison against the largest floor. Both rewrites are only sound if
@@ -12612,52 +12842,35 @@ mod tests {
             ordered_identity_digest: None,
         };
 
-        let mut cases: Vec<(
+        let generation = |created_at: LixTimestamp| RootCollectionGeneration {
+            commit_id: root_generation,
+            created_at,
+        };
+        // Floor on the unfiled scope only.
+        let unfiled_floor = BTreeMap::from([(unfiled.clone(), generation(high))]);
+        // Two floors, the larger on the filed scope — the `max` case.
+        let both_floors = BTreeMap::from([
+            (unfiled.clone(), generation(low)),
+            (filed.clone(), generation(high)),
+        ]);
+        let cases: Vec<(
             BTreeMap<(String, Option<String>), RootCollectionGeneration>,
             BTreeMap<(String, Option<String>), HotCollectionControl>,
-        )> = Vec::new();
-        cases.push((BTreeMap::new(), BTreeMap::new()));
-        // Floor on the unfiled scope only.
-        cases.push((
-            BTreeMap::from([(
-                unfiled.clone(),
-                RootCollectionGeneration {
-                    commit_id: root_generation,
-                    created_at: high,
-                },
-            )]),
-            BTreeMap::new(),
-        ));
-        // Two floors, the larger on the filed scope — the `max` case.
-        cases.push((
-            BTreeMap::from([
-                (
-                    unfiled.clone(),
-                    RootCollectionGeneration {
-                        commit_id: root_generation,
-                        created_at: low,
-                    },
-                ),
-                (
-                    filed.clone(),
-                    RootCollectionGeneration {
-                        commit_id: root_generation,
-                        created_at: high,
-                    },
-                ),
-            ]),
-            BTreeMap::new(),
-        ));
-        // Disqualifying control on the filed scope only.
-        cases.push((
-            BTreeMap::new(),
-            BTreeMap::from([(filed.clone(), control(root_generation))]),
-        ));
-        // Agreeing control: must not disqualify.
-        cases.push((
-            BTreeMap::new(),
-            BTreeMap::from([(unfiled.clone(), control(branch_generation))]),
-        ));
+        )> = vec![
+            (BTreeMap::new(), BTreeMap::new()),
+            (unfiled_floor, BTreeMap::new()),
+            (both_floors, BTreeMap::new()),
+            // Disqualifying control on the filed scope only.
+            (
+                BTreeMap::new(),
+                BTreeMap::from([(filed.clone(), control(root_generation))]),
+            ),
+            // Agreeing control: must not disqualify.
+            (
+                BTreeMap::new(),
+                BTreeMap::from([(unfiled.clone(), control(branch_generation))]),
+            ),
+        ];
 
         for (index, (active, stored)) in cases.iter().enumerate() {
             for file_id in [None, Some("f")] {
@@ -12906,6 +13119,7 @@ mod tests {
                 scan_calls: None,
             },
             transaction_cache: Some(Arc::new(HotStateTransactionCache::default())),
+            root_base_cache: None,
         };
         for _ in 0..2 {
             let control = reader
@@ -13222,6 +13436,7 @@ mod tests {
         let reader = HotStateStoreReader {
             store: &read,
             transaction_cache: None,
+            root_base_cache: None,
         };
         let missing_entity_pk = EntityPk::single("missing-member");
         let missing_identity = TrackedStateKeyRef {
@@ -13293,6 +13508,7 @@ mod tests {
         HotStateStoreReader {
             store: &read,
             transaction_cache: None,
+            root_base_cache: None,
         }
         .validate_exact_collection_closure(
             BRANCH_ID,
@@ -13383,6 +13599,7 @@ mod tests {
         let reader = HotStateStoreReader {
             store: &read,
             transaction_cache: None,
+            root_base_cache: None,
         };
         let batch = reader
             .scan_live_batch_for_generation(
@@ -13436,6 +13653,7 @@ mod tests {
         let reader = HotStateStoreReader {
             store: &read,
             transaction_cache: None,
+            root_base_cache: None,
         };
         reader
             .validate_exact_collection_closure(
@@ -13486,6 +13704,7 @@ mod tests {
         let error = HotStateStoreReader {
             store: &read,
             transaction_cache: None,
+            root_base_cache: None,
         }
         .validate_exact_collection_closure(
             BRANCH_ID,
@@ -13604,6 +13823,7 @@ mod tests {
             let error = HotStateStoreReader {
                 store: &read,
                 transaction_cache: None,
+                root_base_cache: None,
             }
             .validate_exact_collection_closure(
                 BRANCH_ID,
@@ -13887,6 +14107,7 @@ mod tests {
         let reader = HotStateStoreReader {
             store: read,
             transaction_cache: Some(transaction_cache),
+            root_base_cache: None,
         };
         let control = BranchHeadControl {
             head_commit_id: generation,
@@ -14609,6 +14830,7 @@ mod tests {
                 .await
                 .expect("open exact HOT read"),
             transaction_cache: None,
+            root_base_cache: None,
         };
         let result = reader
             .load_projected_live_batch_for_generation_refs(

--- a/packages/lix/src/hot_state/tracked_head/hot.rs
+++ b/packages/lix/src/hot_state/tracked_head/hot.rs
@@ -3488,21 +3488,31 @@ async fn scan_root_current_base_rows(
     let mut reader = crate::tracked_state::TrackedStateContext::new().reader(store);
     let tracked =
         Box::pin(reader.scan_batch_at_commit(&base_commit_id.to_string(), request)).await?;
-    let scopes = tracked
-        .iter()
-        .filter(|row| {
-            row.schema_key() != crate::collection_generation::COLLECTION_GENERATION_SCHEMA_KEY
-        })
-        .flat_map(|row| {
-            [
-                Some((row.schema_key().to_owned(), None)),
-                row.file_id()
-                    .map(|file_id| (row.schema_key().to_owned(), Some(file_id.to_owned()))),
-            ]
-            .into_iter()
-            .flatten()
-        })
-        .collect::<BTreeSet<_>>();
+    // Tracked rows arrive ordered by `(schema_key, file_id, entity_pk)`, so a
+    // scope repeats across a contiguous run and the set this builds is the
+    // number of collections in the base — one, for an ordinary collection scan.
+    // Allocating the identity per row to insert a duplicate is O(base) heap
+    // traffic for an O(scopes) answer, so skip a row whose scope equals the one
+    // before it. Comparing borrowed `&str` is allocation-free, and the skip is
+    // sound irrespective of ordering: an equal scope is already in the set.
+    let mut scopes = BTreeSet::<(String, Option<String>)>::new();
+    let mut previous_scope: Option<(String, Option<String>)> = None;
+    for row in tracked.iter() {
+        if row.schema_key() == crate::collection_generation::COLLECTION_GENERATION_SCHEMA_KEY {
+            continue;
+        }
+        if previous_scope.as_ref().is_some_and(|(schema_key, file_id)| {
+            schema_key == row.schema_key() && file_id.as_deref() == row.file_id()
+        }) {
+            continue;
+        }
+        let scope = (row.schema_key().to_owned(), row.file_id().map(str::to_owned));
+        scopes.insert((scope.0.clone(), None));
+        if scope.1.is_some() {
+            scopes.insert(scope.clone());
+        }
+        previous_scope = Some(scope);
+    }
     let scope_refs = scopes
         .iter()
         .map(
@@ -3524,8 +3534,15 @@ async fn scan_root_current_base_rows(
         .filter_map(|(scope, control)| control.map(|control| (scope, control)))
         .collect::<BTreeMap<_, _>>();
     let mut rows = MaterializedHotStateBatchBuilder::with_capacity(tracked.len());
+    let mut scope_memo = RootScopeMemo::default();
     for row in tracked.iter() {
-        if !root_tracked_row_is_active(row, generation, &active_generations, &stored_controls) {
+        if !root_tracked_row_is_active(
+            row,
+            generation,
+            &active_generations,
+            &stored_controls,
+            &mut scope_memo,
+        ) {
             continue;
         }
         push_root_current_base_row(&mut rows, row, branch_id, active_checkpoint_commit_id);
@@ -3729,6 +3746,7 @@ async fn load_root_current_base_exact(
         .collect::<BTreeMap<_, _>>();
     let mut rows = MaterializedHotStateBatchBuilder::with_capacity(keys.len());
     let mut slots = Vec::with_capacity(keys.len());
+    let mut scope_memo = RootScopeMemo::default();
     for index in 0..tracked.len() {
         slots.push(
             tracked
@@ -3739,6 +3757,7 @@ async fn load_root_current_base_exact(
                         generation,
                         &active_generations,
                         &stored_controls,
+                        &mut scope_memo,
                     )
                 })
                 .map(|row| {
@@ -3825,36 +3844,115 @@ struct RootCollectionGeneration {
     created_at: LixTimestamp,
 }
 
+/// The part of [`root_tracked_row_is_active`] that depends only on the scope.
+///
+/// Neither the stored-control mismatch nor the collection-generation floors
+/// depend on the row, and `all(|scope| row.created_at() >= scope.created_at)`
+/// is one comparison against the largest floor. So the whole per-row decision
+/// reduces to a flag and one timestamp compare once the scope is known.
+#[derive(Clone, Copy, Default)]
+struct RootScopeVerdict {
+    /// A stored collection control disagrees with the root's active
+    /// generation, which retires every row of the scope regardless of age.
+    disqualified: bool,
+    /// `max` over the scope's collection-generation `created_at` values.
+    floor: Option<LixTimestamp>,
+}
+
+/// One-entry memo over [`RootScopeVerdict`].
+///
+/// The verdict used to be recomputed per row, and computing it needed the
+/// scope as an owned `(String, Option<String>)` — two heap allocations per row
+/// to probe a map that holds one entry for an ordinary collection scan. Tracked
+/// rows arrive ordered by `(schema_key, file_id, entity_pk)`, so remembering
+/// the previous scope collapses that to one computation per scope run. The
+/// memo is keyed on the full scope, so a cache hit is an exact scope match and
+/// a miss simply recomputes — it cannot serve another scope's verdict even if
+/// the rows were unordered.
+#[derive(Default)]
+struct RootScopeMemo {
+    schema_key: String,
+    file_id: Option<String>,
+    primed: bool,
+    verdict: RootScopeVerdict,
+}
+
+impl RootScopeMemo {
+    fn verdict(
+        &mut self,
+        schema_key: &str,
+        file_id: Option<&str>,
+        branch_generation: CommitId,
+        active_generations: &BTreeMap<(String, Option<String>), RootCollectionGeneration>,
+        stored_controls: &BTreeMap<(String, Option<String>), HotCollectionControl>,
+    ) -> RootScopeVerdict {
+        if self.primed && self.schema_key == schema_key && self.file_id.as_deref() == file_id {
+            return self.verdict;
+        }
+        let mut verdict = RootScopeVerdict::default();
+        for scope in [
+            Some((schema_key.to_owned(), None)),
+            file_id.map(|file_id| (schema_key.to_owned(), Some(file_id.to_owned()))),
+        ]
+        .into_iter()
+        .flatten()
+        {
+            let root_generation = active_generations
+                .get(&scope)
+                .map_or(branch_generation, |generation| generation.commit_id);
+            if stored_controls
+                .get(&scope)
+                .is_some_and(|control| control.active_generation != root_generation)
+            {
+                verdict.disqualified = true;
+            }
+            if let Some(generation) = active_generations.get(&scope) {
+                verdict.floor = Some(match verdict.floor {
+                    Some(floor) if floor >= generation.created_at => floor,
+                    _ => generation.created_at,
+                });
+            }
+        }
+        // Reuse the buffers rather than reallocating them per scope run.
+        self.schema_key.clear();
+        self.schema_key.push_str(schema_key);
+        match file_id {
+            Some(file_id) => {
+                let buffer = self.file_id.get_or_insert_with(String::new);
+                buffer.clear();
+                buffer.push_str(file_id);
+            }
+            None => self.file_id = None,
+        }
+        self.primed = true;
+        self.verdict = verdict;
+        verdict
+    }
+}
+
 fn root_tracked_row_is_active(
     row: crate::tracked_state::MaterializedTrackedStateRowRef<'_>,
     branch_generation: CommitId,
     active_generations: &BTreeMap<(String, Option<String>), RootCollectionGeneration>,
     stored_controls: &BTreeMap<(String, Option<String>), HotCollectionControl>,
+    memo: &mut RootScopeMemo,
 ) -> bool {
     if row.schema_key() == crate::collection_generation::COLLECTION_GENERATION_SCHEMA_KEY {
         return true;
     }
-    [
-        Some((row.schema_key().to_owned(), None)),
-        row.file_id()
-            .map(|file_id| (row.schema_key().to_owned(), Some(file_id.to_owned()))),
-    ]
-    .into_iter()
-    .flatten()
-    .all(|scope| {
-        let root_generation = active_generations
-            .get(&scope)
-            .map_or(branch_generation, |generation| generation.commit_id);
-        if stored_controls
-            .get(&scope)
-            .is_some_and(|control| control.active_generation != root_generation)
-        {
-            return false;
-        }
-        active_generations
-            .get(&scope)
-            .is_none_or(|generation| row.created_at() >= generation.created_at)
-    })
+    let verdict = memo.verdict(
+        row.schema_key(),
+        row.file_id(),
+        branch_generation,
+        active_generations,
+        stored_controls,
+    );
+    if verdict.disqualified {
+        return false;
+    }
+    verdict
+        .floor
+        .is_none_or(|floor| row.created_at() >= floor)
 }
 
 fn materialize_packed_slot(
@@ -12463,6 +12561,144 @@ mod tests {
         StorageGetManyResult, StorageKeyRange, StorageReadOptions, StorageScanCursor,
         StorageWriteOptions,
     };
+
+    /// The memo replaced a per-row recomputation with a per-scope one, and it
+    /// also replaced `all(|scope| created_at >= scope.floor)` with a single
+    /// comparison against the largest floor. Both rewrites are only sound if
+    /// the verdict is a pure function of the scope, so check it directly
+    /// against the rule it encodes, including the cases that used to be
+    /// separate scopes: a filed row is governed by its unfiled scope *and* its
+    /// filed scope, and either can disqualify it or raise its floor.
+    #[test]
+    fn root_scope_memo_reproduces_the_per_scope_rule() {
+        let branch_generation = CommitId::for_test_label("memo-branch-generation");
+        let root_generation = CommitId::for_test_label("memo-root-generation");
+        let unfiled = ("s".to_owned(), None);
+        let filed = ("s".to_owned(), Some("f".to_owned()));
+
+        // Reference implementation: the pre-memo predicate, verbatim.
+        let reference = |created_at: LixTimestamp,
+                         file_id: Option<&str>,
+                         active: &BTreeMap<(String, Option<String>), RootCollectionGeneration>,
+                         stored: &BTreeMap<(String, Option<String>), HotCollectionControl>| {
+            [
+                Some(("s".to_owned(), None)),
+                file_id.map(|file_id| ("s".to_owned(), Some(file_id.to_owned()))),
+            ]
+            .into_iter()
+            .flatten()
+            .all(|scope| {
+                let root = active
+                    .get(&scope)
+                    .map_or(branch_generation, |generation| generation.commit_id);
+                if stored
+                    .get(&scope)
+                    .is_some_and(|control| control.active_generation != root)
+                {
+                    return false;
+                }
+                active
+                    .get(&scope)
+                    .is_none_or(|generation| created_at >= generation.created_at)
+            })
+        };
+
+        let stamp = |text: &str| LixTimestamp::expect_parse("memo test timestamp", text);
+        let low = stamp("2026-01-01T00:00:00Z");
+        let high = stamp("2026-03-01T00:00:00Z");
+        let control = |generation: CommitId| HotCollectionControl {
+            active_generation: generation,
+            live_count: 0,
+            ordered_identity_digest: None,
+        };
+
+        let mut cases: Vec<(
+            BTreeMap<(String, Option<String>), RootCollectionGeneration>,
+            BTreeMap<(String, Option<String>), HotCollectionControl>,
+        )> = Vec::new();
+        cases.push((BTreeMap::new(), BTreeMap::new()));
+        // Floor on the unfiled scope only.
+        cases.push((
+            BTreeMap::from([(
+                unfiled.clone(),
+                RootCollectionGeneration {
+                    commit_id: root_generation,
+                    created_at: high,
+                },
+            )]),
+            BTreeMap::new(),
+        ));
+        // Two floors, the larger on the filed scope — the `max` case.
+        cases.push((
+            BTreeMap::from([
+                (
+                    unfiled.clone(),
+                    RootCollectionGeneration {
+                        commit_id: root_generation,
+                        created_at: low,
+                    },
+                ),
+                (
+                    filed.clone(),
+                    RootCollectionGeneration {
+                        commit_id: root_generation,
+                        created_at: high,
+                    },
+                ),
+            ]),
+            BTreeMap::new(),
+        ));
+        // Disqualifying control on the filed scope only.
+        cases.push((
+            BTreeMap::new(),
+            BTreeMap::from([(filed.clone(), control(root_generation))]),
+        ));
+        // Agreeing control: must not disqualify.
+        cases.push((
+            BTreeMap::new(),
+            BTreeMap::from([(unfiled.clone(), control(branch_generation))]),
+        ));
+
+        for (index, (active, stored)) in cases.iter().enumerate() {
+            for file_id in [None, Some("f")] {
+                let mut memo = RootScopeMemo::default();
+                for created_at in [
+                    stamp("2025-01-01T00:00:00Z"),
+                    stamp("2026-01-01T00:00:00Z"),
+                    stamp("2026-03-01T00:00:00Z"),
+                    stamp("2027-01-01T00:00:00Z"),
+                ] {
+                    let verdict =
+                        memo.verdict("s", file_id, branch_generation, active, stored);
+                    let actual = !verdict.disqualified
+                        && verdict.floor.is_none_or(|floor| created_at >= floor);
+                    assert_eq!(
+                        actual,
+                        reference(created_at, file_id, active, stored),
+                        "case {index}, file_id {file_id:?}, created_at {created_at:?}"
+                    );
+                }
+            }
+        }
+
+        // A primed memo must not answer for a different scope.
+        let active = BTreeMap::from([(
+            filed.clone(),
+            RootCollectionGeneration {
+                commit_id: root_generation,
+                created_at: high,
+            },
+        )]);
+        let stored = BTreeMap::new();
+        let mut memo = RootScopeMemo::default();
+        let filed_verdict = memo.verdict("s", Some("f"), branch_generation, &active, &stored);
+        let unfiled_verdict = memo.verdict("s", None, branch_generation, &active, &stored);
+        assert_eq!(filed_verdict.floor, Some(high));
+        assert_eq!(
+            unfiled_verdict.floor, None,
+            "the unfiled scope has no collection generation and must not inherit the filed floor"
+        );
+    }
 
     #[test]
     fn certified_batch_reader_rejects_legacy_ceb1_magic() {

--- a/packages/lix/src/storage_bench.rs
+++ b/packages/lix/src/storage_bench.rs
@@ -50,6 +50,8 @@ static CERTIFIED_ENTITY_INSERT_PARAMETER_BATCH_EXECUTIONS: AtomicU64 = AtomicU64
 static CERTIFIED_ENTITY_UPDATE_VALUE_BATCH_ATTEMPTS: AtomicU64 = AtomicU64::new(0);
 static CERTIFIED_ENTITY_UPDATE_VALUE_BATCH_HITS: AtomicU64 = AtomicU64::new(0);
 static CERTIFIED_ENTITY_UPDATE_VALUE_BATCH_ROWS: AtomicU64 = AtomicU64::new(0);
+static ROOT_BASE_BATCH_CACHE_HITS: AtomicU64 = AtomicU64::new(0);
+static ROOT_BASE_BATCH_CACHE_MISSES: AtomicU64 = AtomicU64::new(0);
 static ENTITY_POINT_SNAPSHOT_CACHE_HITS: AtomicU64 = AtomicU64::new(0);
 static ENTITY_POINT_SNAPSHOT_CACHE_MISSES: AtomicU64 = AtomicU64::new(0);
 static CRUD_PHYSICAL_PUTS: AtomicU64 = AtomicU64::new(0);
@@ -335,6 +337,24 @@ pub fn take_certified_entity_update_value_batch_accounting() -> CrudCertificateA
 pub struct EntityPointSnapshotCacheAccounting {
     pub hits: u64,
     pub misses: u64,
+}
+
+pub(crate) fn record_root_base_batch_cache_hit() {
+    ROOT_BASE_BATCH_CACHE_HITS.fetch_add(1, Ordering::Relaxed);
+}
+
+pub(crate) fn record_root_base_batch_cache_miss() {
+    ROOT_BASE_BATCH_CACHE_MISSES.fetch_add(1, Ordering::Relaxed);
+}
+
+/// Hits and misses since the last call. A rotated generation that is scanned
+/// repeatedly must show hits; zero hits means the serving cache is not
+/// connected to the lane under test, which is not visible in a timing sweep.
+pub fn take_root_base_batch_cache_accounting() -> (u64, u64) {
+    (
+        ROOT_BASE_BATCH_CACHE_HITS.swap(0, Ordering::Relaxed),
+        ROOT_BASE_BATCH_CACHE_MISSES.swap(0, Ordering::Relaxed),
+    )
 }
 
 pub(crate) fn record_entity_point_snapshot_cache_hit() {


### PR DESCRIPTION
> ## ⚠️ CORRECTION (post-merge) — the mechanism analysis below is partly wrong
>
> Retracted by the PR author after caller-attributing the retained profile rather than reading symbol
> presence. **The measured result, the cache, and its correctness argument all stand — the −86.0% is
> unaffected.** What is struck is the *explanation* of where the cost comes from:
>
> - **STRUCK: "this is the durable-root path, not the rootless replay, so it is not a history-length
>   term."** The opposite is true. `scan_batch_at_commit`'s output is built by `{closure#3}` into
>   `Vec<(TrackedStateKeyRef, …)>` — `KeyRef` and `closure#3` are the **rootless replay** arm
>   (`context.rs:1114-1119`). The durable-root arm produces owned `TrackedStateKey` and calls
>   `materialize_batch_from_index_entries`, **a symbol that does not appear in the profile at all**.
>   Filtering to ≥0.2% shows `replay_index_values_for_keys_at_commit`, `point_replay_interval` and
>   `load_point_replay_commit_state` — all replay symbols. The probe never checkpoints before
>   branching, so the base commit has no sealed durable root and the read replays the first-parent
>   interval (~40 commits at n=10 000). **A history-length term is very likely the actual mechanism.**
> - **STRUCK: `TrackedStateTree::scan` at 5.91% being under the rotated scan.** It belongs to another lane.
> - **STRUCK: "~20.8% re-decoding canonical tracked-state keys."** Mis-located, not just mis-labelled.
>   The decode is inside the *payload fetch*: `materialize_batch_from_index_entry_refs` (34.45%) →
>   `load_commit_delta_change_records` (14.12%) → `load_local_owned_commit_delta_entries_one_ordered`
>   (11.52%) → `find_loaded_commit_delta_entry` (8.03%) → `load_commit_delta_entry_at_index` (6.63%) →
>   `codec::decode_key` (3.50%). That is a **per-row search through commit-delta segments, decoding
>   each candidate entry's key to locate the row's payload**, where the number of segments in play is a
>   function of commits since the last durable root — a checkpoint-distance term, not an avoidable decode.
>
> **What survives unchanged:** the −86.0% at 10k with disjoint raw medians, the `live_main` null
> control, the cache and its correctness argument, and the top-level mechanism — *a rotated generation
> re-derives its collection from canonical records on every read*. The cache memoizes the replay too,
> so the fix is if anything better-founded than the body claimed.
>
> **Method lesson:** symbol *presence* is not attribution. The original claim inferred which branch ran
> from which symbols appeared; only caller-attribution settled it, and it settled it the other way.

## What this is

The diagnosis of the ~4x rotated-generation read penalty from #1408, **and the fix**.

#1408 attributed the penalty to "base/overlay merge cost" and left it out of scope. That attribution
is wrong. The cost is entirely in *producing* the base batch — a rotated generation re-derives its
whole collection from canonical records on every single query — and once that is named correctly the
fix is a memoization with no invalidation rule at all.

Three commits, deliberately separate so each can be judged on its own number:

| commit | what | measured effect |
|---|---|---|
| `6ba9bd952` | the probe arm that separates "cost ∝ base" from "fixed setup cost" | instrument |
| `6b7b3fdd6` | **Option 2** — stop allocating a scope identity per base row | **below noise; landed on cleanliness grounds** |
| `50e556fa6` | **Option 1** — materialize a rotated generation's serving view once, not per read | **−86.0% at 10k rows** |

Rebased onto `b882b7a56` (current integration tip; #1418, #1419 and #1421 all landed under me). The earlier conflict was against `d187cb336`, which did not compile;
#1418 fixed that and my own equivalent unblock commit was dropped as redundant during the rebase
(`patch contents already upstream`).

## The diagnosis

> Is the rotated-generation cost proportional to the base's size, or to the answer?

**Proportional to the base.** New probe arm: every arm inserts `n` rows and deletes none (zero
tombstones, so the #1408 arm's confound is gone), row 0 carries `locale = 'keep'` and the rest
`'drop'`, so **the answer is exactly one row at every size**. Varying `n` over four orders of
magnitude, both arms are linear in base size; the rotated arm's per-row constant was **3.98x**
main's and the fixed setup component was ~121 µs — 0.6% of the penalty at 10 000 rows.

It is **not** a new asymptotic term in `n`: the predicate is equality on a column the schema neither
keys nor declares, so O(base) is correct on both arms. **The wrong-variable term is in `reads`.**
Branch creation is O(1) because it *defers* building the serving view, and nothing ever discharges
the deferral — so the branch pays `4·R·B` for its whole life where an eagerly materialized
generation pays `B` once plus `R·B`.

### Mechanism

`stage_root_backed_branch_publication` (`transaction/commit.rs`) writes a **16-byte commit
reference** into `ROOT_CURRENT_BASE_SPACE` and copies no rows. That is the whole of branch creation.
There is no inverse anywhere: `stage_root_current_base` has exactly one production call site, and no
commit, checkpoint or GC ever promotes the reference into hot rows (measured — the rotated arm costs
the same before and after a GC sweep).

So every collection scan on that branch runs `scan_root_current_base_rows` →
`TrackedStateContext::scan_batch_at_commit`, re-deriving the collection from canonical records.
Frame-pointer profile (23 324 samples, 0 lost), inclusive, % of the whole run:

| symbol | incl. % |
|---|---:|
| **`scan_root_current_base_rows_for_merge`** (rotated arm only) | **66.60** |
| ├ `scan_batch_at_commit` | 58.08 |
| │  ├ `materialize_batch_from_index_entry_refs` | 34.45 |
| │  │  └ `load_commit_delta_change_records` → `…_one_ordered` | 14.12 / 11.52 |
| │  ├ `TrackedStateTree::scan` (the B-tree walk) | 5.91 |
| │  └ `tracked_state::codec::decode_key` / `read_entity_pk*` | ~20.8 |
| └ hot-layer re-wrap (scope set, `root_tracked_row_is_active`, push) | 6.68 |

The B-tree walk is the *cheap* part. The expense is re-decoding canonical tracked-state keys —
~20.8%, against main's hot-row key decode which does not clear 0.7% — and fetching row payloads back
out of commit-delta segments to re-materialize them. `TrackedStateTree::scan` being present also
rules out the other candidate: this is the durable-root path, **not** the rootless replay, so it is
not a history-length term.

**Why #1408's attribution was wrong:** `merge_ordered_live_batches` short-circuits when either side
is empty, and on a fresh branch the overlay *is* empty — so no merge copy happens at all.

**The precise defect: the hot row plane stores an identity and its snapshot together in one decoded
fixed-format record; a rotated generation throws that away and rebuilds it, per row, per query.**

## Option 1 — the fix

The re-derivation is a pure function of an **immutable** commit's tracked state and the request, so
it is memoizable with **no invalidation rule at all**: a hit on `(base_commit_id, request)` is exact
by construction, because a commit's tracked state never changes. There is no revision to compare and
no staleness window.

Everything about a rotated generation that *can* change stays outside the cache — the branch's
stored collection controls and its working-diff checkpoint are applied to the returned rows
afterwards, exactly as before.

Branch creation stays O(1): nothing is materialized at creation. The first read of a rotated
generation pays the materialization once; every read after it is an ordinary read.

### The failure this went through first, because it is the round's recurring one

The first implementation wired the cache into three plausible reader-construction sites in
`hot_state/context.rs` and **the A/B came back flat (−2.8%)**. The lane that actually serves a SQL
collection scan is `HotStateContextReader::scan_hot_branch_rows`, which was not among them. A cache
that is built but never reached is invisible to a timing sweep — it reads as "the change did not
help", not as "the change is not connected".

So this PR ships a **connectivity guard**, not an inference:
`rotated_generation_serving_view_is_cached_after_the_first_read` asserts `misses > 0` (the first read
materializes) **and** `hits > 0` (later reads are served), via counters that hook at the cache
itself. It is a real test, not `#[ignore]`d. The timing instrument sits *above* the change
(`session.execute` wall-clock) and the counter sits *at* it; both are reported.

## A/B

Machine `hetzner-cpx62-II` (16c/30G). Three binaries, interleaved, **arm order rotated across the
three rounds** (`base opt2 opt12` / `opt2 opt12 base` / `opt12 base opt2`). In-process `Memory`
adapter, `--release`, `--test-threads=1`, 9 reps per point after 2 warmups, median of the 9; three
rounds per arm, median of the three round-medians reported.

Base arm binary is `901006130` = `d187cb336` + this probe + the same build unblock #1418 landed. It
differs from `6ddaaf02d` only in `#[cfg(test)]` call-site renames and a duplicate `recursion_limit`
attribute — nothing on the read path — so it is a valid measurement arm and saved a 14-minute
rebuild.

### `live_rot` — the rotated generation, one-row answer (µs, lower is better)

| n | base | opt2 | **opt1+2** | opt2 vs base | **opt1+2 vs base** |
|---:|---:|---:|---:|---:|---:|
| 100 | 451 | 437 | **200** | −3.1% | **−55.7%** |
| 1 000 | 2 541 | 2 582 | **753** | +1.6% | **−70.4%** |
| 10 000 | 25 988 | 26 612 | **3 644** | +2.4% | **−86.0%** |

Raw per-round medians at n = 10 000: base `[25735, 25988, 26302]`, opt1+2 `[3632, 3644, 3647]`.
**The ranges do not overlap at all**, which is the runbook's condition for accepting 3 reps.

### `live_main` — the null control

`live_main` runs the same binary, the same SQL and the same scan machinery, and has
`root_bases = 0`, so it **cannot execute the changed code**. Its spread across arms is this bench's
resolution limit.

| n | base | opt2 | opt1+2 |
|---:|---:|---:|---:|
| 100 | 121 | 160 | 113 |
| 1 000 | 732 | 718 | 699 |
| 10 000 | 7 006 | 7 270 | 6 754 |

−3.6% to −6.6% on opt1+2 and +32.2% to −1.9% on opt2 — all noise. The point-read lane
(`WHERE id = 'row-0'`) is 22 µs median in every arm at every size, unchanged.

### The slope, which is the actual result

| arm | µs per base row (100 → 10 000) |
|---|---:|
| `live_rot` base | **2.579** |
| `live_rot` opt1+2 | **0.348** |
| `live_main` base (reference) | 0.695 |

The rotated read's per-row constant drops **7.4x**, from **3.71x** main's own hot scan to **0.50x**.
It ends up cheaper per row than main because main re-scans its hot `ROW_SPACE` on every query while
the rotated generation now reuses a materialized batch. That is *not* an argument for caching main's
scan too — main's generation mutates, so that cache would need a real invalidation rule and none of
this PR's "the key is an immutable commit" argument would carry over.

### What is measured, stated plainly

`timed_scan` takes 2 warmups before its 9 timed reps, so **every timed rep is a cache hit**. This
measures the steady state — reads 2..R — which is exactly the claim. The *first* read of a rotated
generation still pays the full re-derivation and is unchanged.

## Option 2, honestly

−3.1% / +1.6% / +2.4% on the lane it targets, inside a control that itself moves ±5%. **It is below
this bench's noise floor and I am not claiming it as a performance win.** It removes three heap
allocations per base row that existed to build and probe maps of cardinality ≤ 2, and it is landed
on cleanliness grounds. It shrinks the cost of the one cold materialization Option 1 still pays; that
is not separately resolvable here.

If you would rather not carry it, dropping `6b7b3fdd6` leaves Option 1 intact.

## Breaking change: **no**, and here is the argument in the form asked for

**On-disk format — no new bytes exist at all.** This is stronger than "inert in both directions".
The diff adds **zero** writes: mechanically, `git diff <base>...HEAD | grep '^+'` matches
`StorageWriteSet|stage_|writes\.|StorageSpace::declare|musli::(Encode|Decode)|#[musli|storage_codec::encode`
**zero times**. No space is declared, renamed or reshaped; no persisted struct gains, loses or
reorders a field; no manifest changes. A store written by an engine carrying this change is
byte-identical to one written without it, because the change is confined to how a read is *served*,
never to what is stored. So the question "what does an older reader do with the new bytes" has no
new bytes to ask about — an older reader sees exactly the bytes it sees today, and a newer reader
sees exactly the bytes an older writer produced.

**Observable behaviour — no.** The cache returns the same `MaterializedTrackedStateBatch` that
`scan_batch_at_commit` would have returned for the same `(base_commit_id, request)`, keyed on exact
structural equality of the *whole* request (`TrackedStateScanRequest: Eq` — filter, projection and
limit), against a commit whose tracked state is immutable by design. Everything mutable stays
outside: the branch's stored collection controls and working-diff checkpoint are still applied to
those rows on every read. The one hazard worth naming — a reader pinned to an older storage snapshot
being served a newer view — cannot occur, because the root base reference and the commit's data
publish in one atomic write set, so a snapshot predating the data does not see the reference and
never reaches the cache. No query returns different rows or column values, and no operation starts
or stops erroring.

Option 2 is a pure predicate refactor, and `root_scope_memo_reproduces_the_per_scope_rule` checks it
against the **verbatim** pre-change predicate over every combination of floors and disqualifying
controls, filed and unfiled, rather than asserting equivalence in prose.

**Public API — no.** No change to `lib.rs` exports under default features, the SQL surface, or the
JS SDK surface. The one new `pub` item, `storage_bench::take_root_base_batch_cache_accounting`, sits
in `pub mod storage_bench`, which is `#[cfg(feature = "storage-benches")]` — it does not exist in a
default build, so it is invisible to the JS SDK and to any ordinary consumer. It is additive and
mirrors the existing `take_entity_point_snapshot_cache_accounting`.

**Nothing here needs to land before the release.**

## Layout invariants

1. **Single authority** — no. The cache is never consulted as truth: it holds the *result* of a scan
   of canonical records, and the branch-mutable state (collection controls, working-diff checkpoint)
   is still applied to those rows on every read.
2. **Commit canonicality** — unaffected; no graph or ref change.
3. **Derived views are caches** — yes, and this is the invariant the change relies on. The cache is
   rebuildable by re-running the scan, tagged by the source commit id (the tag *is* the key), never
   an authority, bounded by entry count and resident rows, and it degrades to a miss on a poisoned
   lock rather than failing a read.
4. **Atomic publication** — unaffected, and it is load-bearing for correctness here: a reader pinned
   to an older storage snapshot cannot be served a newer view, because the root base reference and
   the commit's data publish in one write set — a snapshot predating the data does not see the
   reference and never reaches the cache.
5. **GC from refs** — unaffected. A root base commit is reachable from the branch ref for as long as
   the branch exists.
6. **SQL reads canonical records** — yes; the cached batch *is* the materialization of canonical
   records at an immutable commit.

## Public API

Unchanged. `packages/lix/src/lib.rs` exports, SQL surface and JS SDK surface are untouched.
`take_root_base_batch_cache_accounting` is `storage-benches`-gated instrumentation.

## Async future size

E47's finding applies to any change on a read path: adding a future frame can abort
`cas_gc_history_retention :: slatedb_history_blob_survives_until_final_root_release` with a stack
overflow, and a timing sweep cannot see it. This change adds **no new `async` block and no new
`.await`** — the existing `Box::pin(reader.scan_batch_at_commit(...))` is preserved verbatim inside
a `match` arm, and `with_root_base_cache` is synchronous. That test was run explicitly; result in the
gate section.

## Gate

Run at the rebased head with `git rev-parse HEAD` and `git status --porcelain` printed inside the
run, and `ci.yml` re-read from `b882b7a56` **inside the same run** rather than from memory — because
the package was renamed `lix_benchmarks` → `lix_e2e` and the features gained `sdk-tests`, so a
carried-over gate command would have targeted a package that no longer exists and passed by doing
nothing.

```
cargo clippy --profile test --workspace --all-targets --all-features -- -D warnings
cargo test  --profile test --workspace --exclude lix_e2e --all-features --no-fail-fast
cargo test  --profile test -p lix_e2e --features sdk-tests,storage-benches,slatedb,root-replay-trace --no-fail-fast
cargo check -p lix --no-default-features
cargo check -p lix_js_sdk --target wasm32-unknown-unknown
```

Full logs captured to file and grepped (`failures:`, `panicked`, `^error`, `stack overflow`,
`test result: FAILED`), never tailed.

```
GATE_HEAD=50e556fa67c415c55d3e0675e965b44e47922d26
GATE_STATUS_BEGIN
GATE_STATUS_END                       <- empty working tree
CI_SCOPE_CONFIRMED_AT=b882b7a563737982b9664f9365bf5d36ee45a9e1
clippy_exit=0
test1_exit=0
test2_exit=0
EXECUTED_TARGETS test1=42 test2=22
TESTS_RUN test1=3391 test2=164
failures/panics/stack overflow/FAILED across both logs: none
nodefault_exit=0
wasm_exit=0
```

Named checks, by name rather than by absence:

```
test slatedb_history_blob_survives_until_final_root_release ... ok      <- E47 stack-overflow guard
test hot_row_tombstone_probe::rotated_generation_serving_view_is_cached_after_the_first_read ... ok
```

`EXECUTED_TARGETS` is non-zero on both steps, which is the check that matters here: the package was
renamed `lix_benchmarks` → `lix_e2e` and the features gained `sdk-tests`, so a gate command carried
over from an earlier round names a package that no longer exists and **exits success having run zero
tests**. `ci.yml` was re-read from `b882b7a56` inside the run and its cargo lines are echoed in the
log, rather than trusted from memory.

`rustfmt --check` on the one leaf file this PR touches reports two hunks, **both pre-existing at the
integration tip** (verified by running it against `b882b7a56`'s own copy of the file): the
`use crate::storage_adapter::{…}` block that arrived with #1408, and the `open_session()` call
reflowed by #1418's rename. None of the lines this PR adds are reported. Per the runbook, `cargo fmt`
is dirty repo-wide and reformatting here would bury the diff in unrelated churn.

