### PR TITLE
fix(lix): restore the build of the integration head

### DIFF
--- a/packages/lix/src/gc.rs
+++ b/packages/lix/src/gc.rs
@@ -3967,7 +3967,7 @@ mod tests {
             .await
             .expect("shared-payload repository should open");
         let session = engine
-            .open_workspace_session()
+            .open_session()
             .await
             .expect("shared-payload session should open");
         register_payload_schema(&session, "gc_payload_row").await;
@@ -4068,7 +4068,7 @@ mod tests {
             .await
             .expect("co-owned payload repository should open");
         let session = engine
-            .open_workspace_session()
+            .open_session()
             .await
             .expect("co-owned payload session should open");
         for schema_key in [
@@ -4176,7 +4176,7 @@ mod tests {
             .await
             .expect("superseded payload repository should open");
         let session = engine
-            .open_workspace_session()
+            .open_session()
             .await
             .expect("superseded payload session should open");
         register_payload_schema(&session, "gc_payload_row").await;

--- a/packages/lix/src/hot_row_tombstone_probe.rs
+++ b/packages/lix/src/hot_row_tombstone_probe.rs
@@ -143,7 +143,7 @@ async fn reopen_session(storage: &Memory) -> SessionContext<Memory> {
         .await
         .expect("engine should reopen");
     engine
-        .open_workspace_session()
+        .open_session()
         .await
         .expect("session should reopen")
 }

--- a/packages/lix/src/lib.rs
+++ b/packages/lix/src/lib.rs
@@ -16,7 +16,6 @@
 //! [`open_lix`] opens an in-memory repository. Add a storage adapter with
 //! [`OpenLixBuilder::with_storage`] when persistence is needed.
 
-#![recursion_limit = "256"]
 #![cfg_attr(
     test,
     allow(
@@ -98,7 +97,12 @@ pub mod storage;
 pub mod storage_adapter;
 #[cfg(not(feature = "storage-benches"))]
 pub(crate) mod storage_adapter;
-#[cfg(feature = "storage-benches")]
+// `gc.rs`'s `cfg(test)` census helpers consume `space_inventory`, so this module
+// needs the same gate as `registered_spaces` above rather than the feature
+// alone. Without the `test` arm a plain `cargo test -p lix` cannot compile the
+// crate, while every `--all-features` command still passes — the features-OFF
+// blind spot running in reverse.
+#[cfg(any(test, feature = "storage-benches"))]
 pub mod storage_bench;
 pub(crate) mod storage_codec;
 // Unconditional: `StorageSpace::mutable`/`::immutable` check the id they are

--- a/packages/lix/src/lib.rs
+++ b/packages/lix/src/lib.rs
@@ -97,12 +97,7 @@ pub mod storage;
 pub mod storage_adapter;
 #[cfg(not(feature = "storage-benches"))]
 pub(crate) mod storage_adapter;
-// `gc.rs`'s `cfg(test)` census helpers consume `space_inventory`, so this module
-// needs the same gate as `registered_spaces` above rather than the feature
-// alone. Without the `test` arm a plain `cargo test -p lix` cannot compile the
-// crate, while every `--all-features` command still passes — the features-OFF
-// blind spot running in reverse.
-#[cfg(any(test, feature = "storage-benches"))]
+#[cfg(feature = "storage-benches")]
 pub mod storage_bench;
 pub(crate) mod storage_codec;
 // Unconditional: `StorageSpace::mutable`/`::immutable` check the id they are


### PR DESCRIPTION
# fix(lix): restore the build of the integration head

`claude-6-optimizations` at `d187cb33` does not compile. **Two of the three breaks fail the shipped
crate, not just the test target:**

```
$ cargo clippy --profile test -p lix --all-targets --all-features -- -D warnings
error: duplicated attribute
error: unused attribute
error[E0599]: no method named `open_workspace_session` found ... (×4)
error: could not compile `lix` (lib) due to 2 previous errors
error: could not compile `lix` (lib test) due to 6 previous errors
```

Reproduced on a pristine checkout of the integration head with no diff, so this is the branch and not
a local tree. That command is CI's own lint step.

## The three breaks

| # | site | cause |
|---|---|---|
| 1 | `gc.rs:3970, 4071, 4179` | `.open_workspace_session()` — #1409 renamed it to `open_session` and missed three `#[cfg(test)]` call sites |
| 2 | `hot_row_tombstone_probe.rs:146` | the same rename, in the probe merged by #1414 |
| 3 | `lib.rs:1` and `lib.rs:19` | `#![recursion_limit = "256"]` declared twice |

Each arrived **green at its own base**. #1409 was green, #1414 was green; the *combination* is red.
Nothing gated the pair. That is the entire failure mode, and it is why the fix is three unrelated
one-liners rather than one mistake.

Fixes: follow the rename at all four call sites; drop the duplicate attribute, keeping the one at the
top of the file where it already lived.

## A fourth "break" that was my own instrument, retracted

I initially reported a fourth item — `gc.rs:3028, 3920` referencing `crate::storage_bench` while
`lib.rs` gated `mod storage_bench` on the `storage-benches` feature alone — and shipped a fix
widening that gate to `#[cfg(any(test, feature = "storage-benches"))]`, matching `registered_spaces`
four lines above.

**That was wrong twice over and the gate caught it.**

- It is **not a break**. It only appears under `cargo test -p lix --lib --no-run` *without features*,
  which was a command in my own diagnostic script. Every CI test command is `--all-features`
  (`ci.yml:137,138,154,155`), and the runbook's features-OFF step is `cargo check -p lix
  --no-default-features` — a `check`, which does not build test targets. No supported configuration
  compiles `storage_bench`'s consumers without the feature.
- The fix **cascaded**. `storage_bench` is not self-contained: widening its gate pulled in
  `crate::changelog::bench`, `crate::session::analyze_merge_for_bench`,
  `crate::binary_cas::BinaryCasManifest`, `decode_change_locator` and a dozen more, all themselves
  feature-gated. The first gate run turned up ~20 fresh `E0432`/`E0425`/`E0433` errors that the head
  never had.

`storage_bench` and its dependencies are gated as a unit, deliberately. Reverted; the diff no longer
touches `lib.rs`'s module gates.

## The structural finding that survives

### `cargo check -p lix` passes while clippy fails on `(lib)`

The documented blind spot, reproduced exactly. On the broken head:

```
$ cargo check -p lix
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 1m 47s     # green

$ cargo clippy --profile test -p lix --all-targets --all-features -- -D warnings
error: could not compile `lix` (lib) due to 2 previous errors                 # red
```

A bare `check` builds neither test targets nor the lint set, so it cannot see any of the three
breaks. `--all-targets --all-features` is not a nicety. Both commands are in the gate below — the
clippy one first, so the regression is pinned by the command that actually exposed it, and the bare
check kept alongside it as the recorded negative.

**But note what even that does not buy.** Running both halves of a *single* branch still cannot see a
break that exists only in the merge. Nothing short of gating the combination would have caught this,
which is the real lesson and not a property of any command list.

## What is NOT in this diff

No behaviour change. Four call sites follow a rename; one duplicated attribute is removed. No engine
logic, no module gates, no storage space, no encoding, no public API.

## Layout invariants

Not applicable — a build fix touching no layout, authority, publication or reachability concern.
Invariants 1–6 unaffected in both directions.

## Gate

Full CI scope, **re-read from `origin/claude-6-optimizations:.github/workflows/ci.yml` rather than
from the runbook** — it had changed: `lix_benchmarks` is now `lix_e2e` and the feature list gained
`sdk-tests`. A gate script copied from the previous round would have run the wrong command against
the wrong package name.

Provenance printed inside the run; `--no-fail-fast`; full log captured to a file and grepped, never
tailed.

```
worktree: /root/claude5/cand
HEAD: 46641dfc9e38996beb6aae12dd89738e5bd17a44
status.porcelain: []
base: d187cb336362b050d1509ecb445252fd6748ee06
```

**Result: green. 64 test targets ok, 0 failed, 0 errors across every step.**

| step | result |
|---|---|
| `cargo clippy --profile test -p lix --all-targets --all-features -- -D warnings` | **pass** — this is the exact command that failed on the broken head |
| `cargo check -p lix` | pass (it also passed while the head was broken — recorded as the negative) |
| `cargo clippy --profile test --workspace --all-targets --all-features -- -D warnings` | pass |
| `cargo test --profile test --workspace --exclude lix_e2e --all-features --no-fail-fast` | pass |
| `cargo test --profile test -p lix_e2e --features sdk-tests,storage-benches,slatedb,root-replay-trace --no-fail-fast` | pass |
| `cargo check -p lix --no-default-features` | pass |
| `cargo check -p lix_js_sdk --target wasm32-unknown-unknown` | pass |
| `node scripts/validate-changes.mjs` | pass — 44 fragments |
