### PR TITLE
perf(transaction): stop re-proving that deterministic mode is off on every write

### DIFF
--- a/packages/lix/src/functions/context.rs
+++ b/packages/lix/src/functions/context.rs
@@ -5,6 +5,7 @@ use crate::functions::{
     DeterministicFunctionProvider, DeterministicSequence, FunctionProvider, FunctionProviderHandle,
     SystemFunctionProvider, state,
 };
+use crate::hot_state::GlobalKeyValueRowCache;
 use crate::storage_adapter::{StorageAdapterRead, StoragePrecondition, StorageWriteSet};
 
 /// Execution-scoped runtime function context.
@@ -36,16 +37,22 @@ impl FunctionContext {
     ///
     /// If deterministic mode is absent or disabled, the context uses system
     /// functions. If enabled, it starts from the persisted sequence + 1.
+    ///
+    /// `cache` memoizes the deterministic-state rows against the global
+    /// branch-head control they were resolved under. Pass `None` from a caller
+    /// that has no engine-lifetime cache to hand; the read is then always
+    /// canonical.
     #[expect(trivial_casts)]
     pub(crate) async fn prepare(
         read: &(impl StorageAdapterRead + ?Sized),
+        cache: Option<&GlobalKeyValueRowCache>,
     ) -> Result<Self, LixError> {
-        let mode = state::load_mode(read).await?;
+        let mode = state::load_mode(read, cache).await?;
         if !mode.enabled {
             return Ok(Self::system_for_function_free_read());
         }
 
-        let sequence = state::load_sequence(read).await?;
+        let sequence = state::load_sequence(read, cache).await?;
         // Deterministic mode must produce byte-identical state across runs;
         // bookkeeping rows (sequence persistence) take a timestamp derived
         // from the persisted sequence instead of the system clock, without
@@ -151,7 +158,7 @@ mod tests {
             .await
             .expect("read should open");
 
-        let context = FunctionContext::prepare(&read)
+        let context = FunctionContext::prepare(&read, None)
             .await
             .expect("runtime context should prepare");
 
@@ -180,7 +187,7 @@ mod tests {
             .begin_read(StorageReadOptions::default())
             .await
             .expect("read should open");
-        let context = FunctionContext::prepare(&read)
+        let context = FunctionContext::prepare(&read, None)
             .await
             .expect("runtime context should prepare");
         let functions = context.provider();
@@ -224,7 +231,7 @@ mod tests {
             .begin_read(StorageReadOptions::default())
             .await
             .expect("read should open");
-        let context = FunctionContext::prepare(&read)
+        let context = FunctionContext::prepare(&read, None)
             .await
             .expect("runtime context should prepare");
         let functions = context.provider();
@@ -260,7 +267,7 @@ mod tests {
                 .begin_read(StorageReadOptions::default())
                 .await
                 .expect("read should open");
-            FunctionContext::prepare(&read)
+            FunctionContext::prepare(&read, None)
                 .await
                 .expect("runtime context should prepare")
         };
@@ -284,7 +291,7 @@ mod tests {
             .begin_read(StorageReadOptions::default())
             .await
             .expect("read should open");
-        let sequence = load_sequence(&read).await.expect("sequence should load");
+        let sequence = load_sequence(&read, None).await.expect("sequence should load");
         assert_eq!(sequence, DeterministicSequence { highest_seen: 0 });
 
         // Deterministic mode must stamp the bookkeeping row from the
@@ -316,7 +323,7 @@ mod tests {
             .begin_read(StorageReadOptions::default())
             .await
             .expect("read should open");
-        let context = FunctionContext::prepare(&read)
+        let context = FunctionContext::prepare(&read, None)
             .await
             .expect("runtime context should prepare");
 
@@ -335,7 +342,7 @@ mod tests {
             .begin_read(StorageReadOptions::default())
             .await
             .expect("read should open");
-        let sequence = load_sequence(&read)
+        let sequence = load_sequence(&read, None)
             .await
             .expect("missing sequence should load");
         assert_eq!(sequence, DeterministicSequence::uninitialized());

--- a/packages/lix/src/functions/state.rs
+++ b/packages/lix/src/functions/state.rs
@@ -14,7 +14,8 @@ use crate::json_store::{
     JsonSlot, JsonStoreContext, JsonWritePlacementRef, NormalizedJson, NormalizedJsonRef,
 };
 use crate::hot_state::{
-    CurrentStateDeltaRef, HotStateReadDomain, MaterializedHotStateRow, TrackedHeadContext,
+    CurrentStateDeltaRef, GlobalKeyValueRowCache, HotStateReadDomain, MaterializedHotStateRow,
+    TrackedHeadContext,
 };
 use crate::storage_adapter::{StorageAdapterRead, StoragePrecondition, StorageWriteSet};
 use crate::tracked_state::{TrackedStateKey, TrackedStateKeyRef};
@@ -32,8 +33,9 @@ const KEY_VALUE_SCHEMA_KEY: &str = "lix_key_value";
 /// is engine-owned global state and has no changelog or commit history.
 pub(crate) async fn load_mode(
     read: &(impl StorageAdapterRead + ?Sized),
+    cache: Option<&GlobalKeyValueRowCache>,
 ) -> Result<DeterministicMode, LixError> {
-    let Some(row) = load_key_value_row(read, DETERMINISTIC_MODE_KEY).await? else {
+    let Some(row) = load_key_value_row(read, cache, DETERMINISTIC_MODE_KEY).await? else {
         return Ok(DeterministicMode::disabled());
     };
     let value = key_value_payload(&row, DETERMINISTIC_MODE_KEY)?;
@@ -46,8 +48,9 @@ pub(crate) async fn load_mode(
 /// execution starts at sequence zero.
 pub(crate) async fn load_sequence(
     read: &(impl StorageAdapterRead + ?Sized),
+    cache: Option<&GlobalKeyValueRowCache>,
 ) -> Result<DeterministicSequence, LixError> {
-    let Some(row) = load_key_value_row(read, DETERMINISTIC_SEQUENCE_KEY).await? else {
+    let Some(row) = load_key_value_row(read, cache, DETERMINISTIC_SEQUENCE_KEY).await? else {
         return Ok(DeterministicSequence::uninitialized());
     };
     let value = key_value_payload(&row, DETERMINISTIC_SEQUENCE_KEY)?;
@@ -142,6 +145,7 @@ pub(crate) async fn stage_sequence(
 
 async fn load_key_value_row(
     read: &(impl StorageAdapterRead + ?Sized),
+    cache: Option<&GlobalKeyValueRowCache>,
     key: &str,
 ) -> Result<Option<MaterializedHotStateRow>, LixError> {
     let Some(control) = BranchHeadControlContext::new()
@@ -151,56 +155,78 @@ async fn load_key_value_row(
     else {
         return Ok(None);
     };
-    let keys = [TrackedStateKey {
-        schema_key: KEY_VALUE_SCHEMA_KEY.to_string(),
-        entity_pk: EntityPk::single(key),
-        file_id: None,
-    }];
-    let projection = ChangeRecordProjection {
-        snapshot_content: true,
-        metadata: false,
-    };
-    let reader = TrackedHeadContext::new().reader(read);
-    let key_refs = keys
-        .iter()
-        .map(|key| TrackedStateKeyRef {
-            schema_key: key.schema_key.as_str(),
-            entity_pk: &key.entity_pk,
-            file_id: key.file_id.as_deref(),
-        })
-        .collect::<Vec<_>>();
-    let rows = reader
-        .load_projected_live_batch_refs_for_domain(
-            GLOBAL_BRANCH_ID,
-            control,
-            &key_refs,
-            &projection,
-            HotStateReadDomain::Untracked,
-        )
-        .await?;
-    let Some(row) = rows.row(0) else {
-        reader
-            .validate_exact_collection_closure(
+    // The control is the fence, not just the read's input: it is republished
+    // under a CAS by every write to this plane, so an unchanged control means
+    // the row below — and the collection closure validated with it — cannot
+    // have moved.
+    if let Some(cache) = cache
+        && let Some(row) = cache.get(control, key)
+    {
+        return Ok(row);
+    }
+    // Deliberately one function, not two. Extracting the canonical read into
+    // its own `async fn` would add a poll frame to a path that runs inside
+    // `Transaction::open`, and this codebase's async future-size budget is
+    // tight enough that the sign of such a change cannot be assumed. The
+    // labelled block gives the same early-exit shape with no extra future.
+    let row = 'resolved: {
+        let keys = [TrackedStateKey {
+            schema_key: KEY_VALUE_SCHEMA_KEY.to_string(),
+            entity_pk: EntityPk::single(key),
+            file_id: None,
+        }];
+        let projection = ChangeRecordProjection {
+            snapshot_content: true,
+            metadata: false,
+        };
+        let reader = TrackedHeadContext::new().reader(read);
+        let key_refs = keys
+            .iter()
+            .map(|key| TrackedStateKeyRef {
+                schema_key: key.schema_key.as_str(),
+                entity_pk: &key.entity_pk,
+                file_id: key.file_id.as_deref(),
+            })
+            .collect::<Vec<_>>();
+        let rows = reader
+            .load_projected_live_batch_refs_for_domain(
                 GLOBAL_BRANCH_ID,
-                control.tracked_generation,
-                crate::collection_generation::CollectionScopeRef {
-                    schema_key: KEY_VALUE_SCHEMA_KEY,
-                    file_id: None,
-                },
-                key_refs[0],
+                control,
+                &key_refs,
+                &projection,
                 HotStateReadDomain::Untracked,
-                control.current_state_revision == 0,
             )
             .await?;
-        return Ok(None);
+        let Some(row) = rows.row(0) else {
+            reader
+                .validate_exact_collection_closure(
+                    GLOBAL_BRANCH_ID,
+                    control.tracked_generation,
+                    crate::collection_generation::CollectionScopeRef {
+                        schema_key: KEY_VALUE_SCHEMA_KEY,
+                        file_id: None,
+                    },
+                    key_refs[0],
+                    HotStateReadDomain::Untracked,
+                    control.current_state_revision == 0,
+                )
+                .await?;
+            break 'resolved None;
+        };
+        if !row.untracked() || row.deleted() {
+            return Err(LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                format!(
+                    "deterministic key-value row '{key}' is not a live untracked authority member"
+                ),
+            ));
+        }
+        Some(row.to_owned())
     };
-    if !row.untracked() || row.deleted() {
-        return Err(LixError::new(
-            LixError::CODE_INTERNAL_ERROR,
-            format!("deterministic key-value row '{key}' is not a live untracked authority member"),
-        ));
+    if let Some(cache) = cache {
+        cache.insert(control, key, row.clone());
     }
-    Ok(Some(row.to_owned()))
+    Ok(row)
 }
 
 fn key_value_payload(row: &MaterializedHotStateRow, key: &str) -> Result<JsonValue, LixError> {
@@ -293,7 +319,7 @@ mod tests {
             .await
             .expect("read should open");
 
-        let mode = load_mode(&read).await.expect("missing mode should decode");
+        let mode = load_mode(&read, None).await.expect("missing mode should decode");
 
         assert_eq!(mode, DeterministicMode::disabled());
     }
@@ -316,7 +342,7 @@ mod tests {
             .begin_read(StorageReadOptions::default())
             .await
             .expect("read should open");
-        let mode = load_mode(&read).await.expect("valid mode should decode");
+        let mode = load_mode(&read, None).await.expect("valid mode should decode");
 
         assert_eq!(
             mode,
@@ -336,7 +362,7 @@ mod tests {
             .await
             .expect("read should open");
 
-        let sequence = load_sequence(&read)
+        let sequence = load_sequence(&read, None)
             .await
             .expect("missing sequence should decode");
 
@@ -441,7 +467,7 @@ mod tests {
             .begin_read(StorageReadOptions::default())
             .await
             .expect("corrupt sequence storage should read");
-        let error = load_sequence(&read)
+        let error = load_sequence(&read, None)
             .await
             .expect_err("missing selected sequence member must fail closed");
         assert!(
@@ -467,7 +493,7 @@ mod tests {
             .begin_read(StorageReadOptions::default())
             .await
             .expect("read should open");
-        let sequence = load_sequence(&read)
+        let sequence = load_sequence(&read, None)
             .await
             .expect("valid sequence should decode");
 

--- a/packages/lix/src/hot_state/context.rs
+++ b/packages/lix/src/hot_state/context.rs
@@ -55,6 +55,64 @@ pub(crate) struct BranchHeadControlCache {
     hot_state: std::sync::Arc<HotStateTransactionCache>,
 }
 
+/// Engine bookkeeping rows that live in the global branch's untracked
+/// `lix_key_value` plane and are consulted on **every** transaction open.
+///
+/// Resolving one costs a projected live batch read plus — on the expected
+/// miss, because the row is absent in a repository that never enabled the
+/// feature — a full `validate_exact_collection_closure` scan of the global
+/// `lix_key_value` collection. Both are functions of the global branch-head
+/// control's generation and current-state revision, and every write to that
+/// plane republishes the control under a CAS with a bumped
+/// `current_state_revision`. An unchanged control therefore proves the
+/// resolved row, and the closure validated alongside it, unchanged.
+///
+/// Disposable cache: tagged with the exact control it was resolved under,
+/// rebuilt from canonical records on any change, never an authority.
+#[derive(Debug, Default)]
+pub(crate) struct GlobalKeyValueRowCache {
+    entries: StdMutex<Vec<(BranchHeadControl, String, Option<MaterializedHotStateRow>)>>,
+}
+
+const GLOBAL_KEY_VALUE_ROW_CACHE_MAX_ENTRIES: usize = 8;
+
+impl GlobalKeyValueRowCache {
+    pub(crate) fn get(
+        &self,
+        control: BranchHeadControl,
+        key: &str,
+    ) -> Option<Option<MaterializedHotStateRow>> {
+        let entries = self
+            .entries
+            .lock()
+            .expect("global key-value row cache lock should not be poisoned");
+        entries
+            .iter()
+            .find(|(entry_control, entry_key, _)| *entry_control == control && entry_key == key)
+            .map(|(_, _, row)| row.clone())
+    }
+
+    pub(crate) fn insert(
+        &self,
+        control: BranchHeadControl,
+        key: &str,
+        row: Option<MaterializedHotStateRow>,
+    ) {
+        let mut entries = self
+            .entries
+            .lock()
+            .expect("global key-value row cache lock should not be poisoned");
+        // A control change retires every entry: they were all resolved under
+        // the previous one and none of them can be reused.
+        entries
+            .retain(|(entry_control, entry_key, _)| *entry_control == control && entry_key != key);
+        if entries.len() >= GLOBAL_KEY_VALUE_ROW_CACHE_MAX_ENTRIES {
+            entries.remove(0);
+        }
+        entries.push((control, key.to_string(), row));
+    }
+}
+
 #[derive(Debug, PartialEq, Eq)]
 struct EntityPointSnapshotCacheKey {
     branch_id: String,
@@ -307,9 +365,16 @@ pub(crate) struct HotStateContext {
     entity_columnar_scan_cache:
         std::sync::Arc<std::sync::Mutex<crate::hot_state::EntityColumnarShadowMaskCache>>,
     entity_decoded_column_cache: crate::hot_state::EntityDecodedColumnCache,
+    global_key_value_rows: std::sync::Arc<GlobalKeyValueRowCache>,
 }
 
 impl HotStateContext {
+    /// Engine-lifetime cache for the global untracked `lix_key_value` rows read
+    /// at every transaction open, fenced by the global branch-head control.
+    pub(crate) fn global_key_value_rows(&self) -> &GlobalKeyValueRowCache {
+        &self.global_key_value_rows
+    }
+
     pub(crate) fn new(
         _tracked_state: TrackedStateContext,
         commit_graph: CommitGraphContext,
@@ -331,6 +396,7 @@ impl HotStateContext {
                 crate::hot_state::EntityDecodedColumnCache::with_array_budget(
                     entity_columnar_array_budget,
                 ),
+            global_key_value_rows: std::sync::Arc::new(GlobalKeyValueRowCache::default()),
         }
     }
 

--- a/packages/lix/src/hot_state/mod.rs
+++ b/packages/lix/src/hot_state/mod.rs
@@ -10,7 +10,9 @@ mod types;
 pub(crate) mod visibility;
 
 #[allow(unused_imports)]
-pub(crate) use context::{BranchHeadControlCache, HotStateContext, HotStateContextReader};
+pub(crate) use context::{
+    BranchHeadControlCache, GlobalKeyValueRowCache, HotStateContext, HotStateContextReader,
+};
 /// Re-exported for the consumers that already spell these `crate::hot_state::…`.
 /// The definitions live in the top-level `entity_columnar` module, which sits
 /// below both state planes; this facade only exists so the move did not have to

--- a/packages/lix/src/session/execute.rs
+++ b/packages/lix/src/session/execute.rs
@@ -2399,7 +2399,7 @@ where
         let hot_state: Arc<dyn crate::hot_state::HotStateReader> =
             Arc::new(self.hot_state.reader(read_store.clone()));
         let runtime_functions = if has_durable_runtime_function {
-            Some(FunctionContext::prepare(&read_store).await?)
+            Some(FunctionContext::prepare(&read_store, None).await?)
         } else {
             None
         };

--- a/packages/lix/src/transaction/commit.rs
+++ b/packages/lix/src/transaction/commit.rs
@@ -10014,7 +10014,7 @@ mod tests {
                 .begin_read(StorageReadOptions::default())
                 .await
                 .expect("read should open");
-            FunctionContext::prepare(&read)
+            FunctionContext::prepare(&read, None)
                 .await
                 .expect("runtime context should prepare")
         };

--- a/packages/lix/src/transaction/context.rs
+++ b/packages/lix/src/transaction/context.rs
@@ -1536,7 +1536,8 @@ where
         let read = opening_read.clone();
         let setup_result = async {
             let active_branch_id = session_branch.get()?;
-            let runtime_functions = FunctionContext::prepare(&read).await?;
+            let runtime_functions =
+                FunctionContext::prepare(&read, Some(hot_state.global_key_value_rows())).await?;
             let runtime_boundary_result = runtime_boundary(&runtime_functions).await?;
             let functions = runtime_functions.provider();
             // Transaction open needs the catalog revision and the tracked


### PR DESCRIPTION
# perf(transaction): stop re-proving that deterministic mode is off on every write

**`Transaction::open` spends 61.7% of its time — 24.4 µs of 39.5 — proving that deterministic mode
is off.** It is off in every repository that never enabled it, so the point read that asks the
question *misses every time*, and the miss path is the expensive one: it ends in
`validate_exact_collection_closure`, a **full range scan of the global `lix_key_value` collection**
whose cost grows with that collection while the fact it establishes does not.

That is worth naming as its own defect class. This round has found six fast paths that were never
reached; this is the opposite and worse shape — **a miss path that costs more than the hit path**,
on by default, paid by every write, for a feature nobody turned on.

This fences that proof on the branch-head control that already gates it.

**The two numbers to judge this on:**

- **20.8 µs of direct work removed per transaction open** (`kv_live_batch` 11.7 + `kv_closure` 9.1),
  out of the 39.5 µs the whole open costs.
- **Fence hit rate 4999/5000** — measured, not assumed: over 5 000 opens on the write lane the probe
  reported `control_same=4999 control_changed=1`.

Wall-clock follows and is the softer number: `update_one_by_pk` **282.2 µs → 251.4 µs** raw
(−10.9% median, 21 interleaved reps, 20/21 negative). Corrected for the null control's own −2.83%
bias that is **−7.3%, or 20.6 µs**, which is the figure that matches the probe and an independent
profile — see the reconciliation below. The claim is the 20.8 µs, not the raw percentage.

Scope: transaction **open** only. Nothing here touches commit staging (`commit_prepared`) or the
write-side read. The redundant branch-head-control point reads I also found in this term are
**deliberately left alone** — they belong to the per-transaction head-control memo being built
separately, which is strictly broader; this composes with it rather than competing.

---

## The decomposition that motivated it

Not `perf`: at 13.7% of a write, a sampled profile cannot resolve the interior of this term. The
phase boundaries of `Transaction::open` were timed directly (`Instant::now()`, 12 laps ≈ 300 ns of a
288 µs operation) behind an env gate. Phases are disjoint and sum to the call. Cumulative mean over
5 000 opens, hot `update_one` lane, RocksDB, 10 000 rows, hetzner-cpx62:

| phase | ns | % of open |
|---|---:|---:|
| **`FunctionContext::prepare`** | **24 374** | **61.7%** |
| `load_head_commit_id(active)` + `(global)` | 4 621 | 11.7% |
| workspace-selector existence check | 3 989 | 10.1% |
| compiled catalog (untracked-visible) | 2 622 | 6.6% |
| `load_revisions` | 2 060 | 5.2% |
| tail (schema resolver, write buffer, struct) | 1 030 | 2.6% |
| `begin_read` (RocksDB snapshot pin) | 408 | 1.0% |
| compiled catalog (tracked) | 382 | 1.0% |
| runtime boundary closure | 50 | 0.1% |
| **total** | **39 535** | **13.7% of the 288 µs write** |

Two notes on this table's provenance. It was taken at `892bcba04` on hetzner-cpx62; the
workspace-selector row has since been removed upstream (`session_branch.get()` is now a pure
in-memory call), so that 3 989 ns is no longer part of the term. And an independent frame-pointer
profile at `6ddaaf02d` on a faster host puts the whole of `open_transaction` at **20.1 µs**, which
is this 39.5 µs scaled by that host factor. The *shares* are what transfer; the absolutes are not.

`FunctionContext::prepare` breaks down as:

| phase | ns | what it is |
|---|---:|---|
| `kv_control` | 2 788 | global branch-head control point read |
| **`kv_live_batch`** | **11 667** | one-key projected live batch read of `lix_key_value`, untracked domain |
| **`kv_closure`** | **9 121** | `validate_exact_collection_closure` — **a full range scan of the global `lix_key_value` collection**, entered *because the point read missed* |

`lix_deterministic_mode` is an untracked `lix_key_value` row on the global branch. It is **absent in
any repository that never enabled deterministic mode**, so the point read misses every time, and the
miss path — which exists to distinguish legitimate absence from a missing HOT member — is the one
that always runs. `kv_closure` walks every member of the collection and recomputes the ordered
identity digest, so **its cost grows with the number of global key-values while the fact it
establishes does not**. That is an asymptotic term hiding inside a phase that looks like a constant.

Two corrections to previously circulated numbers fall out of this:

- **`FunctionContext::prepare` is inside `open_transaction`, not beside it.** E38 listed them
  separately at 10.2 µs and 5.4 µs. It is phase 2 of the open, and it is five times larger than
  everything else in the open combined.
- **`begin_read` is 408 ns — 1.0% of open.** Snapshot acquisition is not the cost.

## What changed

`GlobalKeyValueRowCache` on `HotStateContext` (engine lifetime, beside the existing entity
point-snapshot cache) memoizes the resolved global untracked `lix_key_value` row against the exact
`BranchHeadControl` it was resolved under.

The correctness argument is that the control is not merely an input to the read but its **fence**:
every write to the global untracked plane republishes the control under a CAS with a bumped
`current_state_revision` (`functions::state::stage_sequence` is the in-tree example). An unchanged
control therefore proves both the resolved row *and* the collection closure validated alongside it
are unchanged. Any control change misses the cache and runs the full canonical path, closure
validation included. The cache is bounded at 8 entries, holds at most the two deterministic-state
keys in practice, and a control change retires every entry.

`load_key_value_row` still performs its own `kv_control` point read — that read is the head-control
memo's to remove, not this PR's.

The fence's hit rate was measured rather than assumed: over 5 000 opens on the write lane the probe
reported **`control_same=4999 control_changed=1`**. Tracked writes land on the active branch and do
not republish the global control.

`FunctionContext::prepare`, `state::load_mode` and `state::load_sequence` gain an
`Option<&GlobalKeyValueRowCache>` parameter. Transaction open passes the engine cache; the commit
path, the read-session path, and tests pass `None` and are therefore always canonical. No public
API, SQL surface, JS SDK surface, or storage-adapter API changed. Nothing was removed.

## Layout invariants

1. **Single authority.** No second authority. The cache is not a writer; the canonical record
   remains the untracked `lix_key_value` row, and the branch-head control remains its fence.
2. **Commit canonicality.** Unchanged — nothing here writes commits, parents, or state roots.
3. **Derived views are caches.** Yes, and this is the crux. The entry is tagged with the exact
   `BranchHeadControl` it was built under, rebuilt from canonical records on any change, bounded,
   dropped with the engine, and never consulted as an authority.
4. **Atomic publication.** Unchanged; this is a read-side change inside transaction open.
5. **GC from refs.** Unchanged.
6. **SQL reads canonical records.** Unchanged. The cache sits below SQL on the engine's own
   bookkeeping read, and its miss path is the canonical read.

## A/B

Base **`d187cb336`** (= `claude-6-optimizations` at creation), candidate **`059bc85a8`**.
Host **hetzner-cpx62**, RocksDB. All arms built from **one worktree into one target dir**, so the
~3% cross-worktree fingerprint artifact cannot contribute. `base2` is a **byte-identical copy of
`base1`** — the null control is the same binary, so build variation is removed by construction and
whatever it shows is the harness's own bias and noise.

Per run: `LIX_TRACKED_STATE_CRUD_PROFILE=1 …_LAYER=sql_session …_OP=update_one …_STORAGE=rocksdb
…_ROW_COUNT=10000 …_HOT_REPEATS=5000 <bin> --bench`, rotating interleave so each arm takes each
position equally, **21 reps**.

| rep | base1 | base2 | cand2 | cand2 vs mean(base) | null (base2 vs base1) |
|---|---:|---:|---:|---:|---:|
| 1 | 284.7 | 269.8 | 251.4 | -9.3% | -5.2% |
| 2 | 277.0 | 276.3 | 260.1 | -6.0% | -0.3% |
| 3 | 294.9 | 281.1 | 250.9 | -12.9% | -4.7% |
| 4 | 282.7 | 274.9 | 267.8 | -3.9% | -2.8% |
| 5 | 276.0 | 281.9 | 251.7 | -9.8% | +2.1% |
| 6 | 286.5 | 266.5 | 244.5 | -11.6% | -7.0% |
| 7 | 288.2 | 268.6 | 240.2 | -13.7% | -6.8% |
| 8 | 283.2 | 267.8 | 243.9 | -11.5% | -5.4% |
| 9 | 287.2 | 281.3 | 285.6 | +0.5% | -2.1% |
| 10 | 271.0 | 292.6 | 260.4 | -7.6% | +8.0% |
| 11 | 294.7 | 291.6 | 279.7 | -4.6% | -1.0% |
| 12 | 322.7 | 286.9 | 261.9 | -14.1% | -11.1% |
| 13 | 287.2 | 281.1 | 238.5 | -16.1% | -2.1% |
| 14 | 278.8 | 276.2 | 252.0 | -9.2% | -0.9% |
| 15 | 277.4 | 286.0 | 244.4 | -13.2% | +3.1% |
| 16 | 278.5 | 278.5 | 242.6 | -12.9% | +0.0% |
| 17 | 289.0 | 274.9 | 250.3 | -11.2% | -4.9% |
| 18 | 308.4 | 278.1 | 249.4 | -15.0% | -9.8% |
| 19 | 292.8 | 279.4 | 272.0 | -4.9% | -4.6% |
| 20 | 308.3 | 282.6 | 249.6 | -15.5% | -8.3% |
| 21 | 292.8 | 305.7 | 267.4 | -10.6% | +4.4% |

| arm | n | median µs | mean µs | p95 µs | min | max | sd |
|---|---:|---:|---:|---:|---:|---:|---:|
| base1 | 21 | 287.2 | 288.7 | 308.4 | 271.0 | 322.7 | 12.4 |
| base2 (identical binary) | 21 | 279.4 | 280.1 | 292.6 | 266.5 | 305.7 | 9.2 |
| **base pooled** | 42 | **282.2** | 284.4 | — | 266.5 | 322.7 | — |
| **cand2** | 21 | **251.4** | 255.5 | 279.7 | 238.5 | 285.6 | 13.0 |

**`update_one_by_pk` 282.2 → 251.4 µs, −10.91% median.**

Stated three ways, because the null control is not zero and I would rather show that than bury it:

- **Paired, per rep:** median **−11.23%**, mean **−10.14%**, 95% CI **[−12.01%, −8.28%]**.
  **20 of 21** reps negative (sign test p ≈ 1e-5).
- **Against each base copy separately:** −12.5% vs `base1`, −10.0% vs `base2`. The true value is
  bracketed by those, and **both ends clear 10%**.
- **Null control (identical binary):** median **−2.76%**, mean **−2.83%**, 95% CI
  **[−4.87%, −0.79%]**. It is *not* centred on zero: two 1.27 GB copies of the same binary do not
  sit identically in page cache on a 30 GB host, and that is exactly the kind of bias a null control
  exists to expose. Subtracting the full null bias from the candidate still leaves **−7.3 pp**, so
  even the most conservative reading of this data is a ~7% win, and the CIs of the two do not
  overlap.

At 9 reps this lane gave −10.11% against a −4.57% null; at 21 reps the candidate is stable
(−10.9%) and the null halves (−2.8%), which is what a real effect against a noisy floor looks like.

### Reconciling the measurements — the claim is 20.8 µs

**The saving is 20.8 µs per transaction open.** Three independent methods agree on it:

| method | figure |
|---|---|
| this PR's phase probe (`kv_live_batch` 11.7 + `kv_closure` 9.1), hetzner-cpx62 | **20.8 µs** |
| independent frame-pointer profile of whole `open_transaction` at `6ddaaf02d`, ryzen-9950x-III | **20.1–20.3 µs** |
| this PR's A/B, **corrected for its own null-control bias** | **20.6 µs**, 95% CI [14.3, 27.0] |

The scope note matters: the profile's **13.9 µs** figure is `load_key_value_row` alone, while 20.8 µs
is the prologue that read lives in — the ~6.4 µs between them is `load_head_commit_id` plus residue,
which this change also drops. Comparing 20.8 against 20.1–20.3 is the like-for-like comparison, and
they match.

**The raw wall-clock delta was −10.9% (30.8 µs). I am not claiming that number.** It exceeds the
entire `open_transaction` block, and no independent profile of this lane shows a second site to draw
it from. The explanation is in my own null control: the identical-binary arms differ by **−2.83%
(8.0 µs)**, and subtracting that bias gives **−7.31% = 20.6 µs**, which lands on the probe
prediction and the independent profile. The raw −10.9% is best read as the *upper* bound of a
measurement whose floor is not zero.

**A rare-but-expensive-miss explanation is ruled out**, and it is worth recording why, because it is
the natural guess and it is wrong here. The probe prints calls-per-open beside each phase:

```
kv_control=2788/1.00  kv_live_batch=11667/1.00  kv_closure=9121/1.00
```

`1.00` calls per open. At base there is **no cache at all**, so the live batch *and* the collection
scan run on **every single open** — the expensive branch is not the rare one, it is the only one.
That is precisely the defect: `lix_deterministic_mode` is absent, so the point read misses every
time and the miss path is what always executes. The `control_same=4999 / control_changed=1` figure
is a *prediction* of the fence's hit rate derived from control stability on the un-cached base, not
a measurement of cache hits.

**Fixture state was identical across arms by construction.** Every rep is a fresh process running
the same binary path with the same environment (`ROW_COUNT=10000`, `HOT_REPEATS=5000`,
`STORAGE=rocksdb`), so each run builds and seeds its own RocksDB fixture the same way; `TMPDIR` is
`$HOME/claude5/tmp` on the **ext4 root volume, not tmpfs**. Arms rotate through every position
equally. Packed-base warmth therefore cannot differ *between* arms — it sets the absolute level of
all three equally and cannot produce a between-arm delta.

### Guards

Matched to the layer touched. `Transaction::open` is reached only through
`with_write_transaction_lending`, so **read lanes cannot execute this code at all** — `read_one` /
`read_all` build a `ReadSqlSession` and never open a transaction. Running them would measure codegen
layout, so they are skipped on that ground rather than for time. No encoding, no writes, and no new
storage rows: physical-bytes, storage-amplification, and commit-path metrics cannot move. The one
real cost is memory — an 8-entry cache per engine holding at most two small JSON key-value rows.

## Gate

CI scope re-read from `origin/main:.github/workflows/ci.yml` at the time of the run (no
`cargo check --workspace` step in CI; it runs clippy `--profile test`, a `--no-run` compile, then
the tests), with `sdk-tests` in the `lix_e2e` feature list and `lix_e2e` as the crate name:

```
cargo check --workspace --all-targets --all-features        # not a CI step; catches test targets
cargo check -p lix --no-default-features                    # features-OFF
cargo check -p lix_js_sdk --target wasm32-unknown-unknown
cargo clippy --profile test --workspace --all-targets --all-features -- -D warnings
cargo test  --profile test --workspace --exclude lix_e2e --all-features --no-fail-fast
cargo test  --profile test -p lix_e2e --features sdk-tests,storage-benches,slatedb,root-replay-trace --no-fail-fast
```

Inside the run: `git rev-parse HEAD` = `900b3c09ce4adc85eeb8971b342cb99c36f5a394`,
`git status --porcelain` = empty, and the scope line
`CI_SCOPE_CONFIRMED_AT=6ddaaf02d lix_e2e sdk-tests,storage-benches,slatedb,root-replay-trace`
re-derived from `ci.yml` at the base commit — the crate is `lix_e2e`, not `lix_benchmarks`, and the
feature list includes `sdk-tests`.

| step | rc |
|---|---|
| `cargo check --workspace --all-targets --all-features` | **0** |
| `cargo check -p lix --no-default-features` | **0** |
| `cargo check -p lix_js_sdk --target wasm32-unknown-unknown` | **0** |
| `cargo clippy --profile test --workspace --all-targets --all-features -- -D warnings` | **0** |
| `cargo test --profile test --workspace --exclude lix_e2e --all-features --no-fail-fast` | **0** |
| `cargo test --profile test -p lix_e2e --features sdk-tests,storage-benches,slatedb,root-replay-trace --no-fail-fast` | **0** |

Logs captured to files and grepped for `^error`, `panicked`, `test result: FAILED`, `failures:`,
`overflowed its stack` — never tailed. **A gate that runs nothing reports green**, so the run also
asserts target counts: `EXECUTED_TARGETS test1=42 test2=22`. Both non-zero, so neither command
passed by targeting a package that no longer exists.

### Stack canary run on this branch, not inferred

`slatedb_history_blob_survives_until_final_root_release` sits within ~12% of libtest's 2 MiB default
worker stack, so any change to async frame structure can cross it, and a timing sweep cannot see it
— it aborts the process rather than failing a lane. Run as a test in the debug/test profile on
**both arms, back to back, same worktree**:

| rev | rc | result |
|---|---|---|
| `6ddaaf02d` (`claude-6-optimizations`) | **0** | `4 passed; 0 failed` |
| `900b3c09c` (this branch) | **0** | `4 passed; 0 failed` |

It **did** abort at `ab4277d9c`, which I hit on my original base and reproduced on both arms there;
that was real and is already fixed on the current line.

I originally extracted the canonical read into its own `async fn`, and claimed that was the
shrinking direction for poll-frame nesting. **That was an assertion, not a measurement.** The
extraction has been removed: the cache check and the canonical read now live in one function, with a
labelled block giving the same early-exit shape and **no additional future**. So this PR adds no
poll frame to a path reachable from `Transaction::open`, by construction as well as by test.
