### PR TITLE
perf(open): point-read the primary-session branch instead of running SQL

### DIFF
--- a/packages/lix/src/client_state.rs
+++ b/packages/lix/src/client_state.rs
@@ -10,6 +10,14 @@ use lix::{GLOBAL_BRANCH_ID, LixError, Memory, Value};
 const CLIENT_STATE_KEY_PREFIX: &str = "lix_client_state:";
 pub(crate) const PRIMARY_SESSION_BRANCH_KEY: &str = "lix_primary_session_branch_id";
 
+/// Physical entity key of the primary-session branch preference.
+///
+/// `open_lix` point-reads this row instead of running [`ClientState::get`],
+/// so the prefix has to be reachable without building a SQL context.
+pub(crate) fn primary_session_branch_physical_key() -> String {
+    format!("{CLIENT_STATE_KEY_PREFIX}{PRIMARY_SESSION_BRANCH_KEY}")
+}
+
 const GET_SQL: &str = "SELECT value \
     FROM lix_key_value_by_branch \
     WHERE key = $1 \

--- a/packages/lix/src/engine.rs
+++ b/packages/lix/src/engine.rs
@@ -223,6 +223,52 @@ where
         Ok(result)
     }
 
+    /// Point-reads one global, untracked `lix_key_value` row by physical key.
+    ///
+    /// Client-state rows are ordinary global untracked KV entities, so a single
+    /// preference lookup does not need a SQL context. `open_lix` runs before any
+    /// statement in the process, where routing through `execute` would pay
+    /// catalog construction and DataFusion planning for one key.
+    pub(crate) async fn load_untracked_global_key_value(
+        &self,
+        physical_key: &str,
+    ) -> Result<Option<serde_json::Value>, LixError> {
+        let read = SharedStorageAdapterRead::new(
+            self.storage
+                .begin_read(StorageReadOptions::default())
+                .await?,
+        );
+        let Some(row) = self
+            .hot_state
+            .reader(read)
+            .load_row(&HotStateRowRequest {
+                schema_key: "lix_key_value".to_string(),
+                branch_id: GLOBAL_BRANCH_ID.to_string(),
+                entity_pk: EntityPk::single(physical_key),
+                file_id: NullableKeyFilter::Null,
+            })
+            .await?
+        else {
+            return Ok(None);
+        };
+        // Client state is only ever written untracked; a tracked row under the
+        // same key is not client state and must not answer this read.
+        if row.deleted || !row.untracked {
+            return Ok(None);
+        }
+        let Some(snapshot_content) = row.snapshot_content.as_deref() else {
+            return Ok(None);
+        };
+        let snapshot: serde_json::Value =
+            serde_json::from_str(snapshot_content).map_err(|error| {
+                LixError::new(
+                    LixError::CODE_INTERNAL_ERROR,
+                    format!("invalid lix_key_value snapshot JSON: {error}"),
+                )
+            })?;
+        Ok(snapshot.get("value").cloned())
+    }
+
     pub async fn open_session_at(
         &self,
         active_branch_id: impl Into<String>,

--- a/packages/lix/src/handle.rs
+++ b/packages/lix/src/handle.rs
@@ -137,9 +137,13 @@ where
         session: Arc::new(session),
         primary_switch_gate: Some(Arc::new(tokio::sync::Mutex::new(()))),
     };
+    // A point read on the same context `load_branch_head_commit_id` uses.
+    // Opening must not build a SQL context to answer one key.
     let stored_branch_id = lix
-        .client_state()
-        .get(crate::client_state::PRIMARY_SESSION_BRANCH_KEY)
+        .engine
+        .load_untracked_global_key_value(
+            &crate::client_state::primary_session_branch_physical_key(),
+        )
         .await?
         .and_then(|value| value.as_str().map(str::to_owned))
         .filter(|value| !value.is_empty());
@@ -153,15 +157,11 @@ where
             })
             .await?;
     }
-    let active_branch_id = lix.active_branch_id().await?;
-    if stored_branch_id.as_deref() != Some(active_branch_id.as_str()) {
-        lix.client_state()
-            .set(
-                crate::client_state::PRIMARY_SESSION_BRANCH_KEY,
-                serde_json::Value::String(active_branch_id),
-            )
-            .await?;
-    }
+    // No writeback here. An absent preference already means "follow the
+    // repository's default branch", which is exactly what this function
+    // computes when the key is missing, so materializing it bought nothing and
+    // made the first open of any repository perform a commit before returning
+    // a usable handle. `switch_branch` persists the key on every actual change.
     Ok(lix)
 }
 

--- a/packages/lix/src/handle.rs
+++ b/packages/lix/src/handle.rs
@@ -157,11 +157,20 @@ where
             })
             .await?;
     }
-    // No writeback here. An absent preference already means "follow the
-    // repository's default branch", which is exactly what this function
-    // computes when the key is missing, so materializing it bought nothing and
-    // made the first open of any repository perform a commit before returning
-    // a usable handle. `switch_branch` persists the key on every actual change.
+    // The writeback stays on the open path. It only runs when the stored key
+    // does not already name the active branch, so it costs nothing after the
+    // first open -- and `ClientState::entries`/`get` are public API, so making
+    // the key appear only after an explicit switch would change observable
+    // output for a repository that has never switched.
+    let active_branch_id = lix.active_branch_id().await?;
+    if stored_branch_id.as_deref() != Some(active_branch_id.as_str()) {
+        lix.client_state()
+            .set(
+                crate::client_state::PRIMARY_SESSION_BRANCH_KEY,
+                serde_json::Value::String(active_branch_id),
+            )
+            .await?;
+    }
     Ok(lix)
 }
 

--- a/packages/lix/tests/client_state.rs
+++ b/packages/lix/tests/client_state.rs
@@ -1,4 +1,4 @@
-use lix::{GLOBAL_BRANCH_ID, Memory, Value, open_lix};
+use lix::{CreateBranchOptions, GLOBAL_BRANCH_ID, Memory, SwitchBranchOptions, Value, open_lix};
 use serde_json::{Value as JsonValue, json};
 
 #[tokio::test]
@@ -170,4 +170,72 @@ async fn client_state_survives_memory_snapshot_reopen() {
     );
 
     restored.close().await.expect("restored memory Lix closes");
+}
+
+/// `open_lix` restores the primary-session branch through a point read on the
+/// hot-state context, while `ClientState::set` writes it through SQL. This
+/// pins that the two routes agree across a reopen: a value written by the SQL
+/// writer must be seen by the point reader, with the same branch and
+/// untracked-global scope.
+#[tokio::test]
+async fn primary_session_branch_is_restored_by_the_point_read() {
+    let storage = Memory::new();
+    let branch_id = {
+        let lix = open_lix()
+            .with_storage(storage.clone())
+            .await
+            .expect("first open");
+        let receipt = lix
+            .create_branch(CreateBranchOptions {
+                id: None,
+                name: "restored".to_string(),
+                from_commit_id: None,
+            })
+            .await
+            .expect("branch creates");
+        lix.switch_branch(SwitchBranchOptions {
+            branch_id: receipt.id.clone(),
+        })
+        .await
+        .expect("branch switches");
+        assert_eq!(
+            lix.active_branch_id().await.expect("active branch reads"),
+            receipt.id
+        );
+        lix.close().await.expect("first handle closes");
+        receipt.id
+    };
+
+    let reopened = open_lix()
+        .with_storage(storage)
+        .await
+        .expect("reopen restores the primary session");
+    assert_eq!(
+        reopened
+            .active_branch_id()
+            .await
+            .expect("restored branch reads"),
+        branch_id,
+        "the point read must resolve the branch the SQL writer stored"
+    );
+}
+
+/// The open-time writeback is observable through public API, so a repository
+/// that has never switched branches still reports the key.
+#[tokio::test]
+async fn open_records_the_primary_session_branch_for_a_fresh_repository() {
+    let lix = open_lix().await.expect("memory Lix opens");
+    let active = lix.active_branch_id().await.expect("active branch reads");
+    let entries = lix
+        .client_state()
+        .entries()
+        .await
+        .expect("client state entries read");
+    assert!(
+        entries.contains(&(
+            "lix_primary_session_branch_id".to_string(),
+            serde_json::Value::String(active)
+        )),
+        "a fresh open must record its primary-session branch: {entries:?}"
+    );
 }


### PR DESCRIPTION
# perf(open): point-read the primary-session branch instead of running SQL

Fixes an unowned **+4.36 ms regression on every process open** introduced by
`74d4a8140` ("Make primary session restoration Rust-owned", #1409). Found while
decomposing cold open; it is larger than the entire fixed floor of cold open.

## The regression

Per-process cold-open probe (public API only; one process = one open), f100
corpus, 9 reps, arm order rotated, with `storage_open` as an in-probe control.

`0d583e40a` (after #1411) → `74d4a8140` (#1409):

| lane | `0d583e40a` | `74d4a8140` | delta |
|---|---|---|---|
| `rt` | 0.105 ms | 0.106 ms | +1.0% |
| **`storage_open` (control)** | **2.401 ms** | **2.423 ms** | **+0.9%** |
| `wasm` | 0.082 ms | 0.081 ms | −1.2% |
| **`engine_open`** | **0.930 ms** | **5.039 ms** | **+441.8%** |
| first read | 1.678 ms | 1.484 ms | −11.6% |

Raw `engine_us` disjoint: `[0.779 … 1.571]` vs `[4.818 … 5.801]`.

**Net cost is +3.92 ms, not +4.11.** The first-read lane got *cheaper* across the
same boundary: catalog construction and DataFusion plan-cache warm-up were
**relocated** out of the first user query into open, not purely added. That is
also why this hid — **every benchmark in the repository measures queries, not
process startup.**

## Mechanism

`open_lix_inner` gained a restore block that runs on every open. Step 1 is
`ClientState::get(PRIMARY_SESSION_BRANCH_KEY)` →
`SELECT value FROM lix_key_value_by_branch WHERE key = $1 AND lixcol_branch_id = $2
AND lixcol_untracked = true` through `execute` — a full SQL statement, on the one
process where nothing has warmed the catalog or the plan cache, to read one key.

The engine already has the point route, used **two lines away**:
`load_branch_head_commit_id`, and `assert_initialized`, both read through the
hot-state context with no SQL involved.

## What changed

`Engine::load_untracked_global_key_value(physical_key)` point-reads the row with
the same `(schema_key = "lix_key_value", branch_id = GLOBAL_BRANCH_ID, entity_pk,
file_id = Null)` tuple `assert_initialized` uses, and rejects `deleted` or
non-`untracked` rows to match the SQL predicate. `open_lix_inner` calls it
instead of `ClientState::get`. `ClientState` public API is untouched and still
uses SQL.

## Result

`6ddaaf02d` vs this branch, f100, 9 reps rotated:

| lane | base | cand | delta |
|---|---|---|---|
| `rt` | 0.107 ms | 0.107 ms | +0.0% |
| **`storage_open` (control)** | **2.467 ms** | **2.511 ms** | **+1.8%** |
| `wasm` | 0.082 ms | 0.078 ms | −4.9% |
| **`engine_open`** | **5.261 ms** | **0.891 ms** | **−83.1%** |
| first read | 1.520 ms | 1.629 ms | +7.2% |
| **cold open total** | **9.447 ms** | **5.185 ms** | **−45.1%** |

Raw `engine_us` disjoint: base `[4.901 … 5.468]`, cand `[0.790 … 1.765]`.
**0.891 ms is below the pre-#1409 0.930 ms — the regression is fully recovered.**

The **+7.2% on first read is the relocation reappearing**, and it is expected and
reported rather than hidden: with the restore no longer running SQL at open, the
first user query pays the catalog/plan warm-up again (+0.11 ms here, against
−0.19 ms measured at the #1409 boundary). Net per process is −4.26 ms.

First-ever open of a fresh repository: **10.657 ms → 6.916 ms**.

## Behaviour — no change, and one I nearly shipped

I first also removed the open-time writeback (step 4), which makes a fresh
repository commit before returning a usable handle. **That was a public-API
behaviour change** — `ClientState::entries()`/`get()` would stop reporting
`lix_primary_session_branch_id` for a repository that had never switched
branches. It passed a full green gate; no test covered it.

**It is restored.** The writeback only runs when the stored key does not already
name the active branch, so it never executes in steady state — the entire
4.36 ms was the read. Re-measured with it restored: identical (−83.1%). Keeping
it makes this change purely internal routing.

Two tests added, because equivalence here should be demonstrated rather than
assumed:

- `primary_session_branch_is_restored_by_the_point_read` — creates a branch,
  switches (persisted **through SQL** by `switch_branch`), closes, reopens on the
  same storage, and asserts the **point reader** restores that branch. This is
  the round trip that proves the two routes agree.
- `open_records_the_primary_session_branch_for_a_fresh_repository` — pins the
  writeback that public API observes.

Scope boundary worth stating: the point read is used **only at open**, where no
transaction exists on the handle, so it cannot miss a transaction overlay that
the SQL route would see. `ClientState::get` is unchanged for every other caller.

**No on-disk format change, no migration.** Nothing persisted is touched: the new
method only reads an existing row shape.

## Layout invariants

1. **Single authority.** No. One fewer route to the same row, not a second one.
2. **Commit canonicality.** Unaffected.
3. **Derived views are caches.** Unaffected.
4. **Atomic publication.** Unaffected; the writeback is unchanged.
5. **GC from refs.** Unaffected.
6. **SQL reads canonical records.** The point read reads the same canonical
   hot-state row the SQL path resolves.

## Gate

`ryzen-9950x-IV`, CI scope re-read from `origin/main`, `--no-fail-fast`, log
grepped not tailed.

```
HEAD 341241131fa09fe30b5a5421fef340d169d7b2b7
git status --porcelain: (empty)
diff vs claude-6-optimizations: 4 files changed, 134 insertions(+), 3 deletions(-)

cargo check --workspace --all-targets --all-features                      exit 0
cargo clippy --profile test --workspace --all-targets --all-features -D warnings  exit 0
cargo check -p lix --no-default-features                                  exit 0
cargo check -p lix_js_sdk --target wasm32-unknown-unknown                  exit 0
cargo test --profile test --workspace --exclude lix_e2e --all-features --no-fail-fast          exit 0
cargo test --profile test -p lix_e2e --features sdk-tests,storage-benches,slatedb,root-replay-trace --no-fail-fast  exit 0

grep: 0 `failures:`, 0 `panicked`, 0 `test result: FAILED`, 0 `^error`
total: 3554 passed / 0 failed
```

Named canary run explicitly, per the fleet finding that an extra future frame
aborts the process rather than failing a lane:
`slatedb_history_blob_survives_until_final_root_release ... ok` (twice: in the
suite and in a `--exact` run). This change adds no future frame — it replaces one
`await` chain with a shallower one.

## Instrument note

The probe is public-API only and hooks strictly **above** the changed code, so it
measures the change end-to-end rather than the layer it sits at. It is not in
this PR (it needs a `lix_storage_rocksdb` dev-dependency on `packages/lix`); it
lives in the round scratchpad as `e48-cold-open.rs`.
