### PR TITLE
test(session): extend AssumeSendFuture proofs to a borrowing Read<'a> adapter

### DIFF
--- a/packages/lix/src/handle.rs
+++ b/packages/lix/src/handle.rs
@@ -1048,3 +1048,4 @@ mod assume_send_future_proofs {
         assert_sync::<Lix<S>>();
     }
 }
+

--- a/packages/lix/src/session/execute.rs
+++ b/packages/lix/src/session/execute.rs
@@ -11160,3 +11160,88 @@ mod assume_send_future_proofs {
         assert_send::<crate::storage::GetManyResult>();
     }
 }
+
+
+/// Borrowing-adapter half of the `AssumeSendFuture` proofs.
+///
+/// # What this covers, and the limit
+///
+/// `assume_send_future_proofs` instantiates the wrapped futures at `Memory`,
+/// where `Read<'a> = MemoryRead` is lifetime-independent. That collapses the
+/// higher-ranked obstruction and lets rustc walk the *complete* suspension
+/// state. The shipping RocksDB adapter is `Read<'a> = RocksDBRead<'a>`, so that
+/// proof covers the easy case.
+///
+/// **A whole-future proof at a lifetime-dependent `Read<'a>` is not achievable,
+/// even for a fully concrete adapter.** Measured against `BorrowingStorage`
+/// below: five of the six remaining wrapper sites fail with the same
+/// `implementation of 'Send' is not general enough` diagnostic that forces the
+/// wrapper generically. The borrowing shape *is* the obstruction; making the
+/// adapter concrete does not remove it. That is a rustc limitation on
+/// higher-ranked auto-trait obligations, not a property of this code.
+///
+/// So the borrowing case is covered in two pieces instead:
+///
+/// 1. `read_file_content_inner` — which carries no wrapper since its
+///    `with_static_session_sql_read` bound was relaxed — is proven `Send`
+///    against the borrowing adapter directly, and generically for every
+///    `StorageImpl` by its own `+ Send` signature.
+/// 2. Every type rustc names in the remaining obstructions is proven `Sync`
+///    below, **universally quantified over the lifetime**. `&'x T: Send` holds
+///    exactly when `T: Sync`, so these discharge the named obligations for all
+///    lifetimes; rustc simply cannot assemble them inside a generator. Combined
+///    with the `Memory` walk — which enumerates the complete suspension state,
+///    and finds no `Rc`, `RefCell` guard, or raw pointer anywhere — this is the
+///    tightest statement the type system supports.
+#[cfg(test)]
+mod assume_send_future_proofs_borrowing {
+    use super::*;
+    use crate::session::borrowing_proof_storage::{BorrowingRead, BorrowingStorage};
+
+    fn is_send<T: Send>(_: &T) {}
+    fn assert_send<T: Send + ?Sized>() {}
+    fn assert_sync<T: Sync + ?Sized>() {}
+
+    /// Whole-future proof, borrowing adapter. This site has no wrapper.
+    #[allow(dead_code)]
+    fn read_file_content_inner_is_send(session: &SessionContext<BorrowingStorage>) {
+        is_send(&session.read_file_content_inner(String::new(), None));
+    }
+
+    /// The shared read wrapper is `Send + Sync` for every storage adapter and
+    /// **every lifetime** — `'a` is a free parameter here, so this is a genuine
+    /// `for<'a>` proof of the obligation rustc reports as "not general enough".
+    #[allow(dead_code)]
+    fn shared_read_is_send_for_every_storage_and_lifetime<'a, S>()
+    where
+        S: Storage + Clone + Send + Sync + 'a,
+    {
+        assert_send::<SharedStorageAdapterRead<S::Read<'a>>>();
+        assert_sync::<SharedStorageAdapterRead<S::Read<'a>>>();
+        assert_send::<S::Read<'a>>();
+        assert_sync::<S::Read<'a>>();
+    }
+
+    /// The same, pinned at the concrete borrowing adapter.
+    #[allow(dead_code)]
+    fn shared_read_is_send_for_borrowing_adapter<'a>() {
+        assert_send::<SharedStorageAdapterRead<BorrowingRead<'a>>>();
+        assert_sync::<SharedStorageAdapterRead<BorrowingRead<'a>>>();
+    }
+
+    /// Every remaining type named by a "not general enough" obstruction, proven
+    /// `Sync` — which is exactly `for<'x> &'x T: Send`.
+    #[allow(dead_code)]
+    fn obstruction_pointees_are_sync<S>()
+    where
+        S: Storage + Clone + Send + Sync + 'static,
+    {
+        assert_sync::<str>();
+        assert_sync::<[Value]>();
+        assert_sync::<[ExecuteBatchStatement]>();
+        assert_sync::<SessionContext<S>>();
+        assert_sync::<crate::Lix<S>>();
+        assert_sync::<crate::storage_adapter::Memory>();
+        assert_sync::<tokio::sync::Mutex<()>>();
+    }
+}

--- a/packages/lix/src/session/mod.rs
+++ b/packages/lix/src/session/mod.rs
@@ -97,3 +97,86 @@ where
         unsafe { self.map_unchecked_mut(|wrapped| &mut wrapped.0) }.poll(context)
     }
 }
+
+
+/// A storage adapter whose `Read<'a>` genuinely borrows `'a`.
+///
+/// `Memory::Read<'a> = MemoryRead` is lifetime-independent, so proofs written
+/// against `Memory` alone exercise the easy case: the higher-ranked obstruction
+/// that forces `AssumeSendFuture` collapses before rustc ever gets there. The
+/// shipping RocksDB adapter is `Read<'a> = RocksDBRead<'a>`, and
+/// `LocalFilesystem` borrows in both `Read` and `Write`. This adapter
+/// reproduces that shape over `Memory`'s storage so the `Send` proofs cover the
+/// configuration that actually ships.
+#[cfg(test)]
+pub(crate) mod borrowing_proof_storage {
+    use std::future::Future;
+
+    use crate::storage_adapter::{
+        Memory, MemoryRead, MemoryWrite, Storage, StorageBeginScanOptions, StorageError,
+        StorageGetManyRequest, StorageGetManyResult, StorageKeyRange, StorageRead,
+        StorageReadOptions, StorageScanCursor, StorageSpace, StorageWriteOptions,
+    };
+
+    /// Read handle carrying a real `'a` borrow of the owning storage.
+    pub(crate) struct BorrowingRead<'a> {
+        inner: MemoryRead,
+        _borrow: &'a Memory,
+    }
+
+    impl StorageRead for BorrowingRead<'_> {
+        fn snapshot_cache_key(&self) -> Option<u128> {
+            self.inner.snapshot_cache_key()
+        }
+
+        fn get_many(
+            &self,
+            requests: &[StorageGetManyRequest<'_>],
+        ) -> impl Future<Output = Result<StorageGetManyResult, StorageError>> + Send {
+            self.inner.get_many(requests)
+        }
+
+        fn begin_scan(
+            &self,
+            space: StorageSpace,
+            range: StorageKeyRange,
+            opts: StorageBeginScanOptions,
+        ) -> impl Future<Output = Result<StorageScanCursor<'_>, StorageError>> + Send {
+            self.inner.begin_scan(space, range, opts)
+        }
+    }
+
+    #[derive(Clone, Default)]
+    pub(crate) struct BorrowingStorage(Memory);
+
+    impl Storage for BorrowingStorage {
+        type Read<'a>
+            = BorrowingRead<'a>
+        where
+            Self: 'a;
+
+        type Write<'a>
+            = MemoryWrite
+        where
+            Self: 'a;
+
+        fn begin_read(
+            &self,
+            opts: StorageReadOptions,
+        ) -> impl Future<Output = Result<Self::Read<'_>, StorageError>> + Send {
+            async move {
+                Ok(BorrowingRead {
+                    inner: self.0.begin_read(opts).await?,
+                    _borrow: &self.0,
+                })
+            }
+        }
+
+        fn begin_write(
+            &self,
+            opts: StorageWriteOptions,
+        ) -> impl Future<Output = Result<Self::Write<'_>, StorageError>> + Send {
+            self.0.begin_write(opts)
+        }
+    }
+}

--- a/packages/lix/src/session/observe.rs
+++ b/packages/lix/src/session/observe.rs
@@ -319,3 +319,4 @@ mod assume_send_future_proofs {
         assert_send::<ObserveEvents<S>>();
     }
 }
+


### PR DESCRIPTION
Follow-up to #1421, which proved the `AssumeSendFuture` safety obligation by compilation at `Memory` — whose `Read<'a> = MemoryRead` is lifetime-*independent*. RocksDB's `Read<'a> = RocksDBRead<'a>` is genuinely lifetime-dependent, so that configuration rested on the `Storage` trait contract rather than on compilation. This closes that gap as far as the type system permits, and documents the limit it found.

Test-only. No production code changed.

## A real limit, found and now documented

`BorrowingStorage` — `Read<'a> = BorrowingRead<'a>`, a genuine `'a` borrow matching RocksDB's shape — was built and every proof re-run against it.

**A whole-future `Send` proof at a lifetime-dependent `Read<'a>` is not achievable, even for a fully concrete adapter.** Five of the six remaining wrapper sites fail with the identical `implementation of Send is not general enough`. Making the adapter concrete does not help, because **the borrowing shape *is* the obstruction** — it is precisely what forces the wrapper in the first place. This is now recorded next to the proofs so nobody re-derives it.

## What is nonetheless proven

- **`read_file_content_inner` passes at the borrowing adapter.** The site whose wrapper #1421 deleted is proven `Send` for a RocksDB-shaped `Read<'a>`, and in fact for every `StorageImpl`, since it now carries `+ Send` in its signature with no wrapper. That site's coverage is complete.
- **Every obstruction rustc names is individually provable, universally over the lifetime.** `&'x T: Send` holds exactly when `T: Sync`, so proving `T: Sync` discharges the named obligation for all lifetimes. Landed: `SharedStorageAdapterRead<S::Read<'a>>: Send + Sync` and `S::Read<'a>: Send + Sync` with `'a` a free parameter (a genuine `for<'a>` proof), the same at the concrete borrowing adapter, and `Sync` for `str`, `[Value]`, `[ExecuteBatchStatement]`, `SessionContext<S>`, `Lix<S>`, `Memory`, and `tokio::sync::Mutex<()>`.

## Resulting standing claim

rustc walks the **complete** suspension state at `Memory` and finds nothing `!Send`. At a borrowing adapter it cannot assemble the whole-future conclusion, but every obligation it names is separately proven, and in that configuration its obstruction list likewise contains **zero** genuine `!Send` complaints — no `Rc`, no `RefCell` guard, no raw pointer.

What remains uncovered is only "some *unnamed* value in the borrowing instantiation's suspension state differs from the `Memory` one", which would require a storage-parameterized value that is neither `S`, `S::Read`, `S::Write`, nor a wrapper over them. None is known to exist — but that last step is argument, not compilation, and is stated as such.

## Gate

`cargo check -p lix --all-targets --all-features` and `cargo clippy -D warnings` both green at `b882b7a56`.