### PR TITLE
docs: rename versions page to branching

### DIFF
--- a/docs/branching.md
+++ b/docs/branching.md
@@ -1,10 +1,10 @@
 ---
-description: Branches are isolated lines of state. Create them, switch between them, read across them with _by_branch tables, and preview merges.
+description: Branches are independent lines of work. Create a branch, switch branches, compare their data, and preview a merge.
 ---
 
-# Branches & Merging
+# Branching
 
-A branch is an isolated line of state. It can change without affecting the main branch, then be merged back.
+A branch is an independent line of work. Changes on one branch do not affect other branches. You can merge the changes into another branch later.
 
 ## Create and switch
 
@@ -22,7 +22,7 @@ await lix.execute("UPDATE acme_section SET title = $1 WHERE id = $2", [
 await lix.switchBranch({ branchId: main });
 ```
 
-`createBranch()` returns `{ id, name, hidden, commitId }`. `switchBranch()` changes which branch later SQL statements read and write.
+`createBranch()` returns `{ id, name, hidden, commitId }`. `switchBranch()` sets the branch that later SQL statements read and write.
 
 Use names that fit your product, such as `"Marketing edit"`, `"Q3 pricing draft"`, or `"Agent task 123"`.
 
@@ -53,7 +53,7 @@ Use `_by_branch` tables for review UIs and side-by-side views. See [SQL Surfaces
 
 ## Preview a merge
 
-`mergeBranchPreview()` reports what `mergeBranch()` would do without changing state.
+`mergeBranchPreview()` shows what `mergeBranch()` would do. It does not change any data.
 
 ```ts
 const preview = await lix.mergeBranchPreview({

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -122,7 +122,7 @@ if (preview.conflicts.length === 0) {
 }
 ```
 
-`mergeBranchPreview()` reports the same decision as `mergeBranch()` without changing state. See [Branches & Merging](./versions.md).
+`mergeBranchPreview()` reports the same decision as `mergeBranch()` without changing state. See [Branching](./branching.md).
 
 ## The loop
 

--- a/docs/lix-for-ai-agents.md
+++ b/docs/lix-for-ai-agents.md
@@ -90,10 +90,10 @@ Use `lix_registered_schema` to discover available schemas. Use `lix_change` for 
 
 Merge is per entity today. Two branches that edit different rows can merge cleanly. Two branches that edit the same row produce a `sameEntityChanged` conflict.
 
-See [Branches & Merging](./versions.md) for preview results and conflict handling.
+See [Branching](./branching.md) for preview results and conflict handling.
 
 ## Next
 
 - [Getting Started](./getting-started.md): the basic setup.
-- [Branches & Merging](./versions.md): previews, conflicts, and side-by-side reads.
+- [Branching](./branching.md): previews, conflicts, and side-by-side reads.
 - [Change History](./history.md): SQL for review and undo.

--- a/docs/schemas.md
+++ b/docs/schemas.md
@@ -33,7 +33,7 @@ INSERT INTO lix_registered_schema (value) VALUES (lix_json('{
 }'));
 ```
 
-After registration, `acme_section` is a SQL table you can `INSERT`, `SELECT`, `UPDATE`, and `DELETE` against. A sibling table `acme_section_by_branch` exposes the same rows across all branches (see [Branches & Merging](./versions.md)).
+After registration, `acme_section` is a SQL table you can `INSERT`, `SELECT`, `UPDATE`, and `DELETE` against. A sibling table `acme_section_by_branch` exposes the same rows across all branches (see [Branching](./branching.md)).
 
 ```sql
 INSERT INTO acme_section (id, title, body) VALUES ($1, $2, $3);

--- a/docs/table_of_contents.json
+++ b/docs/table_of_contents.json
@@ -8,7 +8,7 @@
   "Concepts": [
     { "path": "./schemas.md", "label": "Schemas" },
     { "path": "./semantic-changes.md", "label": "Semantic Changes" },
-    { "path": "./versions.md", "label": "Branches & Merging" },
+    { "path": "./branching.md", "label": "Branching" },
     { "path": "./checkpoints.md", "label": "Checkpoints" },
     { "path": "./diff-commands.md", "label": "Diff Commands" },
     { "path": "./history.md", "label": "Change History" },

--- a/website/public/_redirects
+++ b/website/public/_redirects
@@ -1,4 +1,5 @@
 /docs /docs/what-is-lix 308
 /docs/storage /docs/persistence 308
+/docs/versions /docs/branching 308
 /guide /docs/what-is-lix 308
 /guide/* /docs/:splat 308

--- a/website/src/lib/build-doc-map.test.ts
+++ b/website/src/lib/build-doc-map.test.ts
@@ -80,10 +80,10 @@ describe("resolveDocsMarkdownHref", () => {
       content: "",
       relativePath: "./storage.md",
     },
-    "./versions.md": {
-      slug: "versions",
+    "./branching.md": {
+      slug: "branching",
       content: "",
-      relativePath: "./versions.md",
+      relativePath: "./branching.md",
     },
   };
 
@@ -106,10 +106,10 @@ describe("resolveDocsMarkdownHref", () => {
   test("preserves heading hashes", () => {
     expect(
       resolveDocsMarkdownHref(
-        "./versions.md#merge",
+        "./branching.md#merge",
         currentDoc,
         docsByRelativePath,
       ),
-    ).toBe("/docs/versions#merge");
+    ).toBe("/docs/branching#merge");
   });
 });

--- a/website/src/routes/docs/redirects.json
+++ b/website/src/routes/docs/redirects.json
@@ -1,4 +1,5 @@
 {
   "/docs": "/docs/what-is-lix",
-  "/docs/storage": "/docs/persistence"
+  "/docs/storage": "/docs/persistence",
+  "/docs/versions": "/docs/branching"
 }


### PR DESCRIPTION
## What changed

- rename `docs/versions.md` to `docs/branching.md`
- rename the page and navigation label to **Branching**
- update internal documentation links and route tests to use `/docs/branching`
- redirect the old `/docs/versions` URL to `/docs/branching`
- simplify the page introduction and merge-preview wording

## Why

Lix now uses **branches** as the product term. The documentation filename and URL still used the old **versions** term, which made the terminology inconsistent.

## Impact

Readers now see consistent branch terminology and the canonical documentation URL is `/docs/branching`. Existing links to `/docs/versions` continue to work through a redirect.

## Validation

- `npm test` in `website` — 29 tests passed
- TypeScript check passed
- local Markdown links validated
- JSON files parsed successfully
- `git diff --check` passed