### PR TITLE
fix(sql2): capture SqlWriteContext shared surface instead of reading it through the raw pointer

### DIFF
--- a/packages/lix/src/sql2/context.rs
+++ b/packages/lix/src/sql2/context.rs
@@ -314,20 +314,60 @@ pub(crate) trait SqlWriteExecutionContext: Send {
 pub(crate) struct SqlWriteContext {
     ptr: Arc<SqlWriteContextPtr>,
     gate: Arc<Mutex<()>>,
+    shared: Arc<SqlWriteContextShared>,
     explicit_insert_columns: Option<Arc<BTreeSet<String>>>,
     write_targets: Option<Arc<super::providers::WriteTargetRegistry>>,
 }
 
 struct SqlWriteContextPtr(NonNull<dyn SqlWriteExecutionContext>);
 
+/// Values captured from the write execution context at construction time.
+///
+/// These were previously read back through `SqlWriteContextPtr` on every call,
+/// producing a `&dyn` into the transaction context with no synchronization
+/// while the gated methods could concurrently hold a reconstituted `&mut` to
+/// the same object. Every one of them is a cheap getter returning owned,
+/// `Arc`'d, or cloned data that is stable for this context's lifetime, so
+/// capturing them here removes that shared borrow outright rather than
+/// serializing it. Nothing below reads through the raw pointer.
+struct SqlWriteContextShared {
+    functions: FunctionProviderHandle,
+    /// Stored as the `Result` it was: the underlying catalog is memoized on a
+    /// fingerprint that is fixed for the context's lifetime
+    /// (`sql_schema_snapshot` is assigned once at construction and never
+    /// reassigned), so a captured value cannot go stale.
+    public_catalog: Result<Arc<PublicCatalog>, LixError>,
+    active_branch_id: String,
+    active_account_id: String,
+    plugin_host: PluginRuntimeHost,
+    /// A shared `Arc<Mutex<..>>` handle, not a snapshot: mutations made through
+    /// a captured clone are observed by every other holder.
+    session_file_views: Option<SessionFileViews>,
+}
+
 // DataFusion stores providers as owned Send + Sync trait objects. This context
 // is only constructed for one write execution and never outlives the borrowed
 // transaction context that owns it.
+//
+// SAFETY SCOPE: the pointer is now reached only by the gate-serialized methods
+// that reconstitute `&mut`. The shared accessors read `SqlWriteContextShared`
+// and never touch it, so no `&dyn` into the transaction context can be alive
+// while one of those `&mut` borrows is held.
 unsafe impl Send for SqlWriteContextPtr {}
 unsafe impl Sync for SqlWriteContextPtr {}
 
 impl SqlWriteContext {
     pub(crate) fn new(ctx: &mut dyn SqlWriteExecutionContext) -> Self {
+        // Capture the shared surface while the `&mut` borrow is still held
+        // legitimately, so no later call has to forge one.
+        let shared = Arc::new(SqlWriteContextShared {
+            functions: ctx.functions(),
+            public_catalog: ctx.public_catalog(),
+            active_branch_id: ctx.active_branch_id().to_string(),
+            active_account_id: ctx.active_account_id().to_string(),
+            plugin_host: ctx.plugin_host(),
+            session_file_views: ctx.session_file_views(),
+        });
         let ptr = NonNull::from(ctx);
         let ptr = unsafe {
             std::mem::transmute::<
@@ -338,6 +378,7 @@ impl SqlWriteContext {
         Self {
             ptr: Arc::new(SqlWriteContextPtr(ptr)),
             gate: Arc::new(Mutex::new(())),
+            shared,
             explicit_insert_columns: None,
             write_targets: Some(Arc::new(super::providers::WriteTargetRegistry::default())),
         }
@@ -369,7 +410,7 @@ impl SqlWriteContext {
     }
 
     pub(crate) fn functions(&self) -> FunctionProviderHandle {
-        unsafe { self.ptr.0.as_ref().functions() }
+        self.shared.functions.clone()
     }
 
     pub(crate) fn blob_reader(&self) -> Arc<dyn BlobDataReader> {
@@ -377,23 +418,23 @@ impl SqlWriteContext {
     }
 
     pub(crate) fn public_catalog(&self) -> Result<Arc<PublicCatalog>, LixError> {
-        unsafe { self.ptr.0.as_ref().public_catalog() }
+        self.shared.public_catalog.clone()
     }
 
     pub(crate) fn active_branch_id(&self) -> String {
-        unsafe { self.ptr.0.as_ref().active_branch_id().to_string() }
+        self.shared.active_branch_id.clone()
     }
 
     pub(crate) fn active_account_id(&self) -> String {
-        unsafe { self.ptr.0.as_ref().active_account_id().to_string() }
+        self.shared.active_account_id.clone()
     }
 
     pub(crate) fn plugin_host(&self) -> PluginRuntimeHost {
-        unsafe { self.ptr.0.as_ref().plugin_host() }
+        self.shared.plugin_host.clone()
     }
 
     pub(crate) fn session_file_views(&self) -> Option<SessionFileViews> {
-        unsafe { self.ptr.0.as_ref().session_file_views() }
+        self.shared.session_file_views.clone()
     }
 
     pub(crate) async fn scan_hot_state_batch(


### PR DESCRIPTION
Removes the `&`/`&mut` aliasing shape in `SqlWriteContext` rather than synchronizing it.

## The hazard

`SqlWriteContext` is `Clone`, holds `Arc<SqlWriteContextPtr>` — a `NonNull<dyn SqlWriteExecutionContext>` built by `mem::transmute`-ing a `&mut dyn` borrow's lifetime to `'static` — and is `Send + Sync` by unconditional unsafe impl. Its methods split over that same pointer:

- **Gated** (7 methods): lock `self.gate`, then `as_mut()` — reconstituting `&mut dyn` **and holding it across `.await`**.
- **Ungated** (6 accessors): `as_ref()` — producing `&dyn` — **with no gate at all**.

The gate serialized the mutable group against itself. **Nothing serialized the shared group against the mutable group**, so a `&` and a `&mut` to the same object could be live simultaneously — on different threads, because the type is `Sync`. In Rust that is UB via `noalias` regardless of whether a data race occurs.

**Reachability was investigated and not established.** An instrumented run — a depth counter over every gated `&mut` region, with all six ungated accessors panicking if they produced a `&dyn` while depth > 0 — found **0 alias hits across 5185 mutable-borrow regions and 10764 shared accesses** (3144 tests), and 0 across a targeted 8-worker multi-threaded run. Instrument liveness was verified: all 7 gated methods and all 6 accessors appear in the event log. Caveat stated plainly: 1144 of 1148 lix tests are current-thread, so **re-entrancy is covered thoroughly and parallel partition execution barely at all**. Verdict was *structurally unsound, reachability unproven after a real attempt*.

## The fix

All six ungated accessors already returned owned, `Arc`'d or cloned values — none returned a borrow. The `&dyn` was purely transient, used only to call a cheap getter. They are now **plain field reads on a captured `SqlWriteContextShared`, populated in `new()` where `&mut ctx` is legitimately held**. All six contain no `unsafe`. Signatures are unchanged, so there is zero call-site churn.

Verified structurally: **every remaining reference to the raw pointer is one of the 7 gated `as_mut()` sites**, and there are exactly 7 `gate.lock()` acquisitions. The shared group no longer touches the pointer, so no `&dyn` into the transaction context can exist while a gated `&mut` is live. **The aliasing shape is gone rather than serialized.**

## Semantic gate — passed, but not at the expected accessor

`session_file_views` was flagged as the risk and is in fact the safest: `#[derive(Clone)]` over `Arc<Mutex<SessionFileViewsState>>` — a **shared handle, not a snapshot** — so a captured clone observes every mutation other holders make.

**The one that needed checking was `public_catalog`**, which is not a stable field but a *fingerprint-keyed memo*: `sql_planning_cache.public_catalog(self.sql_catalog_fingerprint(), ..)`. A moving fingerprint would make a captured value a silently stale catalog. It cannot move: the fingerprint derives from `sql_schema_snapshot: Arc<CatalogSnapshot>`, assigned once at construction (`transaction/context.rs:1634`) and **never reassigned anywhere in the crate**. Stored as the `Result`, which also preserves existing behaviour exactly — a failing catalog still surfaces its error at the accessor, not at construction.

The other four are plain stable field reads.

## Scope reduction, not elimination — correcting an earlier suggestion

It was suggested that with no shared accessors left, `unsafe impl Sync` might be removable. **It is not.** Deleting it produces 166 errors, because `SqlWriteContext` still lives inside DataFusion's `Send + Sync` trait objects (`WriteContextBlobDataReader`, `WriteContextHotStateReader`, …) and the gated methods take `&self`.

What changed is what `Sync` now licenses: previously unsynchronized `&dyn` production from any thread; now only gate-serialized `&mut` production. **The remaining obligation is uniform** — which was the criterion — but the unsafe surface shrank rather than disappeared.

**Residual, unchanged and untouched:** the forged `'static` lifetime on an `Arc`-shared pointer. Nothing here makes that checkable.

## Cost — reasoned, not measured

Per-call cost is equal or lower: `active_branch_id` was `.to_string()`, now `.clone()`; `functions`/`plugin_host`/`session_file_views` were handle clones before and after; `public_catalog` was a fingerprint hash plus memo lookup and is now an `Arc` clone, i.e. cheaper. The only new cost is six captures per `SqlWriteContext::new()` — 1875 constructions across a full suite run, against 10764 accessor calls it makes cheaper.

## Not a breaking change

No on-disk format (no encoded type touched), no observable behaviour (`public_catalog`'s error still surfaces at the accessor), no public API (`SqlWriteContext` is internal to `sql2`; all six signatures unchanged).

## Gate

```
GATE_HEAD=fb158ec008746cb5f6e9d4b16b476ebeee13e5be
GATE_STATUS: (empty)
CI_SCOPE_CONFIRMED_AT=acb216f772369cd3cb9fee5f4996fc88b95c52a7
EXECUTED_TARGETS=64; 3553 passed, 0 failed
```

Clippy `-D warnings`, workspace tests, `lix_e2e`, and features-off check all green.