### PR TITLE
fix(hot-state): make the retention fence survive a missing hot tombstone

### DIFF
--- a/packages/lix/src/hot_row_tombstone_probe.rs
+++ b/packages/lix/src/hot_row_tombstone_probe.rs
@@ -873,3 +873,258 @@ async fn rotated_generation_serving_view_is_cached_after_the_first_read() {
          not re-derived from canonical records (hits={hits} misses={misses})"
     );
 }
+
+/// PHASE 6 — write-path question 2: undo/redo must replay from canonical
+/// changes, demonstrated rather than argued.
+///
+/// The code answer is that `session/undo_redo.rs` reads only through
+/// `tracked_state_reader()` — `commit_delta_values_for_schemas` and
+/// `load_projected_batch_at_commit` — both canonical tracked state at a commit,
+/// and never touches `ROW_SPACE`. This is the experiment that shows it.
+///
+/// Delete a row, physically remove its tombstone, reopen the engine cold, then
+/// undo. If undo depended on the `ROW_SPACE` tombstone in any way, the row
+/// could not come back.
+#[tokio::test]
+#[ignore = "measurement probe, not a gate"]
+async fn undo_restores_a_row_whose_tombstone_was_removed() {
+    let (storage, session) = open_session().await;
+    register(&session, probe_schema("undorow")).await;
+    insert_rows(&session, "undorow", 3).await;
+    let before = session
+        .execute("SELECT id FROM undorow", &[])
+        .await
+        .expect("collection reads")
+        .len();
+
+    session
+        .execute("DELETE FROM undorow WHERE id = 'row-1'", &[])
+        .await
+        .expect("delete should commit");
+    let census_after_delete = row_census(&storage).await;
+    let after_delete = session
+        .execute("SELECT id FROM undorow", &[])
+        .await
+        .expect("collection reads")
+        .len();
+
+    let removed = drop_all_tombstones(&storage).await;
+    let session = reopen_session(&storage).await;
+    let census_after_drop = row_census(&storage).await;
+    let after_drop = session
+        .execute("SELECT id FROM undorow", &[])
+        .await
+        .expect("collection reads")
+        .len();
+
+    session.undo().await.expect("undo should publish");
+    let after_undo = session
+        .execute("SELECT id FROM undorow", &[])
+        .await
+        .expect("collection reads")
+        .len();
+    let restored = session
+        .execute("SELECT id, locale FROM undorow WHERE id = 'row-1'", &[])
+        .await
+        .expect("restored row reads");
+
+    println!(
+        "phase6 | before={before} after_delete={after_delete} tombstones_after_delete={} \
+         removed={removed} after_drop={after_drop} tombstones_after_drop={} after_undo={after_undo} \
+         restored_rows={}",
+        census_after_delete.tombstones,
+        census_after_drop.tombstones,
+        restored.len()
+    );
+
+    assert_eq!(before, 3, "fixture should start with three rows");
+    assert_eq!(after_delete, 2, "the delete should be visible");
+    assert_eq!(removed, 1, "the delete should have left exactly one tombstone");
+    assert_eq!(
+        after_drop, 2,
+        "removing the tombstone must not resurrect the row"
+    );
+    assert_eq!(
+        after_undo, 3,
+        "undo must restore the deleted row with its tombstone already gone; \
+         if this fails, undo depends on the ROW_SPACE tombstone and the \
+         never-write design is unsafe"
+    );
+    assert_eq!(restored.len(), 1, "the restored row must be readable");
+}
+
+/// PHASE 7 — is `reject_retention_change` an invariant, or an artefact of
+/// tombstone lifetime?
+///
+/// The fence refuses an untracked INSERT over a tracked-deleted identity, and
+/// it refuses it *because the tombstone is physically present* — `existing` is
+/// the predecessor row. `absence_guards` does not cover this case: those are
+/// pure "must not be live" assertions, so an absent identity and a tombstone
+/// pass identically.
+///
+/// So if any supported operation on `main` already clears that tombstone, the
+/// fence is not durable and the hole is open today — compaction would change
+/// *when* it stops fencing, not *whether*. If nothing clears it, the fence is
+/// real and compaction would breach it.
+///
+/// This tries every route to the no-tombstone state and reports which, if any,
+/// reaches it. Nothing here compacts anything.
+#[tokio::test]
+#[ignore = "measurement probe, not a gate"]
+async fn retention_fence_durability_across_supported_operations() {
+    async fn untracked_insert(
+        session: &SessionContext<Memory>,
+        table: &str,
+    ) -> Result<(), String> {
+        session
+            .execute(
+                &format!(
+                    "INSERT INTO {table} (id, locale, lixcol_untracked) VALUES ('row-0', 'u', TRUE)"
+                ),
+                &[],
+            )
+            .await
+            .map(|_| ())
+            .map_err(|error| error.to_string())
+    }
+
+    println!("phase6 | route,tombstones,untracked_insert_result");
+
+    // Each route gets a fresh fixture so the routes cannot contaminate one
+    // another. `base` is the control: no route applied.
+    for route in [
+        "base",
+        "checkpoint",
+        "branch_roundtrip",
+        "on_new_branch",
+        "tombstone_dropped",
+    ] {
+        let (storage, session) = open_session().await;
+        register(&session, probe_schema("fencerow")).await;
+        session
+            .execute(
+                "INSERT INTO fencerow (id, locale) VALUES ('row-0', 'keep')",
+                &[],
+            )
+            .await
+            .expect("tracked insert should commit");
+        session
+            .execute("DELETE FROM fencerow WHERE id = 'row-0'", &[])
+            .await
+            .expect("tracked delete should commit");
+
+        let mut session = session;
+        match route {
+            "base" => {}
+            "checkpoint" => {
+                session
+                    .create_checkpoint()
+                    .await
+                    .expect("checkpoint should publish");
+            }
+            "branch_roundtrip" => {
+                let main_branch_id = session
+                    .active_branch_id()
+                    .await
+                    .expect("active branch resolves");
+                let branch = session
+                    .create_branch(crate::CreateBranchOptions {
+                        id: None,
+                        name: "e45-fence-roundtrip".to_string(),
+                        from_commit_id: None,
+                    })
+                    .await
+                    .expect("branch should create");
+                session
+                    .switch_branch(crate::SwitchBranchOptions {
+                        branch_id: branch.id,
+                    })
+                    .await
+                    .expect("switch to branch");
+                session
+                    .switch_branch(crate::SwitchBranchOptions {
+                        branch_id: main_branch_id,
+                    })
+                    .await
+                    .expect("switch back to main");
+            }
+            "on_new_branch" => {
+                // The interesting one: a fresh branch's generation is sparse
+                // over a root base and owns no HOT_ROW tombstone of its own.
+                let branch = session
+                    .create_branch(crate::CreateBranchOptions {
+                        id: None,
+                        name: "e45-fence-newbranch".to_string(),
+                        from_commit_id: None,
+                    })
+                    .await
+                    .expect("branch should create");
+                session
+                    .switch_branch(crate::SwitchBranchOptions {
+                        branch_id: branch.id,
+                    })
+                    .await
+                    .expect("switch to branch");
+            }
+            // The state compaction would create, reached here by removing the
+            // tombstone directly rather than by compacting. No supported
+            // operation reaches this state today; compaction would be the
+            // first. If the fence stops holding here, that is the hole
+            // compaction opens, and it is what PR 1 exists to close.
+            "tombstone_dropped" => {
+                let removed = drop_all_tombstones(&storage).await;
+                assert_eq!(removed, 1, "the tracked delete should leave one tombstone");
+                session = reopen_session(&storage).await;
+            }
+            _ => unreachable!(),
+        }
+
+        let census = row_census(&storage).await;
+        let result = untracked_insert(&session, "fencerow").await;
+        // Every route, including the one that removes the tombstone the fence
+        // used to ride on, must refuse. Before the narrowed fence landed,
+        // `tombstone_dropped` SUCCEEDED here while the other four refused —
+        // that gap is what the fence closes, and this assertion is what proves
+        // it rather than restating it.
+        assert!(
+            result.is_err(),
+            "route '{route}' let an untracked row take a tracked-deleted identity; \
+             the retention fence does not survive this state"
+        );
+        let verdict = match &result {
+            Ok(()) => "SUCCEEDED".to_string(),
+            Err(message) => format!("refused: {}", message.replace(',', ";")),
+        };
+        println!("{route},{},{verdict}", census.tombstones);
+
+        // If the untracked insert got in, the identity is now untracked while a
+        // tracked delete of the same identity sits in canonical history. Undo
+        // replays that delete from canonical history (phase 5). If undo brings
+        // the tracked row back, the identity is simultaneously tracked and
+        // untracked.
+        if result.is_ok() {
+            let undo = session.undo().await;
+            match undo {
+                Ok(_) => {
+                    let rows = session
+                        .execute(
+                            "SELECT id, lixcol_untracked FROM fencerow WHERE id = 'row-0'",
+                            &[],
+                        )
+                        .await
+                        .expect("identity reads after undo");
+                    println!(
+                        "{route},POST_UNDO,rows_for_identity={} <- 2 means tracked+untracked \
+                         coexist",
+                        rows.len()
+                    );
+                }
+                Err(error) => println!(
+                    "{route},POST_UNDO,undo_refused: {}",
+                    error.to_string().replace(',', ";")
+                ),
+            }
+        }
+        drop(session);
+    }
+}

--- a/packages/lix/src/hot_state/tracked_head/hot.rs
+++ b/packages/lix/src/hot_state/tracked_head/hot.rs
@@ -8093,6 +8093,82 @@ where
                 *previous = None;
             }
         }
+        // Narrowed retention fence.
+        //
+        // `reject_retention_change` below only runs when a predecessor
+        // resolves — from a HOT row, or in a sparse generation from the root
+        // base. An untracked write whose identity has neither skips the check
+        // entirely, so the fence is today only as durable as the tombstone
+        // that carries it. `hot_row_tombstone_probe`'s `tombstone_dropped`
+        // route measures the consequence: the untracked insert that four
+        // supported routes refuse gets in once the tombstone is gone, and
+        // `undo` is refused afterwards instead. The throw moves off the
+        // operation that caused it and onto an innocent one.
+        //
+        // Consulting canonical state at the branch head restores the fence
+        // where the serving view cannot carry it, and keeps the refusal on the
+        // insert. Cost is bounded to commits that actually contain an
+        // untracked write with an unresolvable predecessor; every other commit
+        // builds an empty key list and performs no additional I/O.
+        {
+            let unresolved = sorted
+                .iter()
+                .zip(&previous_values)
+                .filter(|(delta, previous)| {
+                    delta.untracked && !delta.deleted && previous.is_none()
+                })
+                .map(|(delta, _)| TrackedStateKeyRef {
+                    schema_key: delta.schema_key,
+                    file_id: delta.file_id,
+                    entity_pk: delta.entity_pk,
+                })
+                .collect::<Vec<_>>();
+            if !unresolved.is_empty()
+                && let Some(control) = BranchHeadControlContext::new()
+                    .reader(self.store)
+                    .load(branch_id)
+                    .await?
+                // A branch control can legitimately name a head with no
+                // canonical commit state. Replaying against it would turn a
+                // legal write into an internal error, which is worse than the
+                // hole this closes. No canonical authority means no canonical
+                // predecessor, so there is nothing to fence against. This is
+                // the same authority check `validate_diff_row_created_at`
+                // already uses before it trusts an ancestry lookup.
+                && crate::tracked_state::load_commit_state_authority_ids(
+                    self.store,
+                    std::slice::from_ref(&control.head_commit_id),
+                )
+                .await?
+                .into_iter()
+                .next()
+                .flatten()
+                .is_some()
+            {
+                let mut reader = crate::tracked_state::TrackedStateContext::new().reader(self.store);
+                let canonical = reader
+                    .load_projected_batch_at_commit_refs(
+                        &control.head_commit_id.to_string(),
+                        &unresolved,
+                        &ChangeRecordProjection::identity_only(),
+                    )
+                    .await?;
+                for (slot, key) in unresolved.iter().enumerate() {
+                    // Any canonical row for the identity — live or tombstoned —
+                    // means it has been tracked, which is exactly what
+                    // `reject_retention_change` refuses to flip.
+                    if canonical.row(slot).is_some() {
+                        return Err(LixError::new(
+                            LixError::CODE_UNIQUE,
+                            format!(
+                                "cannot insert untracked row in schema '{}' entity_pk {:?}: a tracked row with this identity exists in canonical history; retention is immutable for an identity",
+                                key.schema_key, key.entity_pk,
+                            ),
+                        ));
+                    }
+                }
+            }
+        }
         let mut created_ats = Vec::with_capacity(sorted.len());
         for (delta, previous) in sorted.iter().zip(&previous_values) {
             let Some(previous) = previous else {

--- a/packages/lix/src/tracked_state/mod.rs
+++ b/packages/lix/src/tracked_state/mod.rs
@@ -26,6 +26,7 @@ mod tree;
 mod types;
 
 pub(crate) use codec::{encode_key_ref, encode_single_string_key_ref_into};
+pub(crate) use storage::load_commit_state_authority_ids;
 pub(crate) use commit_root_rebuild::{
     load_rebuild_plans_to_nearest_available_root, stage_rebuild_plan_with_writer,
     try_stage_collapsed_rebuild_plans_with_writer,


### PR DESCRIPTION
# fix(hot-state): make the retention fence survive a missing hot tombstone

Retention is an identity property: an identity that has been tracked cannot be re-inserted as
untracked. Today that rule is enforced by `reject_retention_change`, which **only runs when a
predecessor resolves** — from a `HOT_ROW` row, or in a sparse generation from the root base. An
untracked write whose identity has neither skips the check entirely.

So the fence is currently only as durable as the tombstone that carries it. This makes it hold
without one.

## The gap, measured rather than argued

`hot_row_tombstone_probe`'s phase 7 drives an untracked INSERT over a tracked-**deleted** identity
through every route I could construct to a no-tombstone state. Before this change:

| route | tombstones | untracked insert |
|---|---:|---|
| base | 1 | refused `LIX_ERROR_UNIQUE` |
| checkpoint | 1 | refused `LIX_ERROR_UNIQUE` |
| branch_roundtrip | 1 | refused `LIX_ERROR_UNIQUE` |
| on_new_branch | 1 | refused `LIX_ERROR_UNIQUE` |
| **tombstone_dropped** | **0** | **SUCCEEDED** |

After:

| route | tombstones | untracked insert |
|---|---:|---|
| base / checkpoint / branch_roundtrip / on_new_branch | 1 | refused `LIX_ERROR_UNIQUE` |
| **tombstone_dropped** | **0** | **refused `LIX_ERROR_UNIQUE`** |

One row flips; the other four are unchanged. The test asserts the refusal on **every** route, so it
proves the behaviour change rather than restating it.

Two findings worth keeping from building that table:

- **`on_new_branch` refuses even though the branch's own generation holds no tombstone.** The fence
  needs a *resolvable predecessor*, not specifically a hot tombstone — the lookup falls through to
  the root base. The fence is layered, not fragile. It breaks for exactly one reason: **a zero-base
  generation has nothing to fall through to.**
- **The hole is not latent.** No supported operation reaches the no-tombstone-no-base state today.
  `tombstone_dropped` reaches it by removing the tombstone directly, which is what serving-layer
  compaction would do — so compaction would be the first mechanism to open it, and this lands ahead
  of it.

Without the fence the failure is **fail-closed but displaced**: the untracked insert succeeds, and a
later `undo` of the original delete is refused instead. The throw moves off the operation that
caused it and onto an innocent one — inverted from the standing preference to throw at the edge
case rather than defer it.

## What changed

`stage_current_state_with_working_diff_inner` (`hot.rs`): for deltas that are untracked, not
deletes, and have no resolvable predecessor, consult canonical state at the branch head and refuse
if a canonical row exists for the identity — live **or** tombstoned, since either means the identity
has been tracked.

`tracked_state/mod.rs`: one re-export of `load_commit_state_authority_ids`, the authority check
`validate_diff_row_created_at` already uses internally.

**Cost is bounded to the case that needs it.** Any commit without an untracked write over an
unresolvable identity builds an empty key list and performs **no additional I/O**. When the list is
non-empty it is one branch-control point read, one authority check, and **one batched** canonical
lookup for the whole commit — never per row.

### The authority gate, and why it is there rather than a workaround

The first version of this change gated green on clippy and **failed the workspace test run**:

```
LIX_INTERNAL_ERROR: cannot point-replay tracked_state for unknown commit 'a4fc59e7-…'
  hot_state::context::tests::finite_pk_hot_scan_serves_mixed_current_state
```

That was a real design flaw, not a fixture quirk: a branch control can legitimately name a head with
no canonical commit state, and the fence turned a previously-succeeding write into a hard internal
error. **A fence that converts a legal write into an internal error is worse than the hole it
closes.** The fix is semantic, not defensive — *no canonical authority ⇒ no canonical predecessor ⇒
nothing to fence against*, so the lookup is skipped. It reuses the same established check
`validate_diff_row_created_at` performs before it trusts an ancestry lookup, rather than inventing
one or swallowing the error.

## Interaction with the root-base serving cache (#1417)

**Structurally impossible, not merely unobserved.** `RootBaseBatchCache` lives entirely in
`hot_state` (`hot.rs`, `hot_state/context.rs`). This fence reads through
`crate::tracked_state::TrackedStateContext::load_projected_batch_at_commit_refs`, and `tracked_state`
sits **below** `hot_state` in `MODULE_LAYERS` with the layering guard test enforcing that it cannot
reference upward. The fence therefore reads canonical state and can never be served from — or
shadowed by — that cache.

The insertion point was re-checked after rebasing onto the changed `hot.rs`: the block is inserted
inside a function body immediately after a closing brace, adjacent to no attribute, so it cannot
capture one.

## Layout invariants

1. **Single authority** — no. Adds a *reader* of canonical state; canonical remains the authority and
   the serving view is no longer relied on to carry a rule it cannot durably carry. This moves
   *toward* the invariant.
2. **Commit canonicality** — unaffected; the fence reads commit-scoped canonical state.
3. **Derived views are caches** — strengthened. The rule no longer depends on a derived row surviving.
4. **Atomic publication** — unaffected; a read on the staging path, no new writes.
5. **GC from refs** — unaffected.
6. **SQL reads canonical records** — reinforced.

## Regressions

None measured. No timing claim is made and no timing guard is reported: the change adds zero I/O to
any commit without an untracked write over an unresolvable identity, which is every commit in the
benchmark set, so a guard there would measure codegen layout rather than this code — and a guard that
cannot execute the changed code is not a guard.

## Gate

Pair-gated on the current integration tip `c86c5cf0b`, CI scope re-derived from the gated sha's own
`ci.yml` rather than a carried script.

```
GATE_HEAD=fa3d24c29547bf843f9f5fc2db100b9b8a7f7a9b
GATE_STATUS_PORCELAIN=[]
CI_SCOPE_CONFIRMED_AT=fa3d24c29547bf843f9f5fc2db100b9b8a7f7a9b
EXECUTED_TARGETS=64 PASSED_TESTS=3557 FAILED_TARGETS=0 ERROR_LINES=0
```

| step | exit |
|---|---|
| `cargo clippy --profile test --workspace --all-targets --all-features -- -D warnings` | 0 |
| `cargo test --profile test --workspace --exclude lix_e2e --all-features --no-fail-fast` | 0 |
| `cargo test --profile test -p lix_e2e --features sdk-tests,storage-benches,slatedb,root-replay-trace --no-fail-fast` | 0 |
| `cargo check -p lix --no-default-features` | 0 |
| `cargo check -p lix_js_sdk --target wasm32-unknown-unknown` | 0 |
| `node scripts/validate-changes.mjs` | 0 |

Phase 7 is `#[ignore]`d, so the gate compiles it without running it; the before/after tables above
come from running it explicitly at `fa3d24c29`.

## Note on the probe file

`hot_row_tombstone_probe.rs` now carries a PHASE 5 from another agent (rotated-generation read
scaling). My two tests were appended as PHASE 6 and PHASE 7 rather than colliding with it. The
numbering is the only thing that overlapped; no shared helper was modified.
