### PR TITLE
perf(file-history): load the unbounded context route before the depth-bounded event route [NEGATIVE RESULT]

### DIFF
--- a/packages/lix/src/commit_graph/context.rs
+++ b/packages/lix/src/commit_graph/context.rs
@@ -64,6 +64,7 @@ pub(crate) mod reachable_census {
     }
 
     /// Returns the counters in slot order, for delta comparison around a query.
+    #[cfg(test)]
     pub(crate) fn snapshot() -> [u64; 4] {
         [
             COUNTERS[EXACT_HIT].load(Ordering::Relaxed),

--- a/packages/lix/src/commit_graph/context.rs
+++ b/packages/lix/src/commit_graph/context.rs
@@ -28,6 +28,52 @@ use crate::storage_adapter::{
 use crate::storage_codec;
 use bytes::Bytes;
 
+/// Engagement census for [`CommitGraphStoreReader::reachable_nodes_within_depth`].
+///
+/// The reachable-node cache is keyed by `(head, depth bound)`. A *bounded*
+/// result can never serve a later *unbounded* request, but an unbounded result
+/// serves every bounded one by truncation. Which of the two a caller asks for
+/// first therefore decides whether the second one traverses storage at all —
+/// and that is invisible from any layer above this function, because both
+/// callers get the same answer either way.
+///
+/// These counters exist so a change to that ordering can be shown to engage
+/// rather than assumed to. They are process-global, incremented once per
+/// traversal request (not per commit and not per row), and read only by tests.
+pub(crate) mod reachable_census {
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    /// The exact `(head, bound)` key was already cached.
+    pub(crate) const EXACT_HIT: usize = 0;
+    /// A bounded request was served by truncating a cached unbounded walk.
+    pub(crate) const BOUNDED_FROM_UNBOUNDED: usize = 1;
+    /// A bounded request had to traverse storage itself.
+    pub(crate) const WALK_BOUNDED: usize = 2;
+    /// An unbounded request had to traverse storage itself.
+    pub(crate) const WALK_UNBOUNDED: usize = 3;
+
+    static COUNTERS: [AtomicU64; 4] = [
+        AtomicU64::new(0),
+        AtomicU64::new(0),
+        AtomicU64::new(0),
+        AtomicU64::new(0),
+    ];
+
+    pub(crate) fn record(slot: usize) {
+        COUNTERS[slot].fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// Returns the counters in slot order, for delta comparison around a query.
+    pub(crate) fn snapshot() -> [u64; 4] {
+        [
+            COUNTERS[EXACT_HIT].load(Ordering::Relaxed),
+            COUNTERS[BOUNDED_FROM_UNBOUNDED].load(Ordering::Relaxed),
+            COUNTERS[WALK_BOUNDED].load(Ordering::Relaxed),
+            COUNTERS[WALK_UNBOUNDED].load(Ordering::Relaxed),
+        ]
+    }
+}
+
 const COMMIT_SCHEMA_KEY: &str = "lix_commit";
 /// Read model for resolving changelog commit facts at a head.
 ///
@@ -201,11 +247,13 @@ where
         max_depth: Option<u32>,
     ) -> Result<Arc<[ReachableCommitGraphNode]>, LixError> {
         if let Some(nodes) = self.reachable_nodes_cache.get(&(*head_commit_id, max_depth)) {
+            reachable_census::record(reachable_census::EXACT_HIT);
             return Ok(Arc::clone(nodes));
         }
         if let Some(max_depth_value) = max_depth
             && let Some(nodes) = self.reachable_nodes_cache.get(&(*head_commit_id, None))
         {
+            reachable_census::record(reachable_census::BOUNDED_FROM_UNBOUNDED);
             let bounded = nodes
                 .iter()
                 .take_while(|reachable| reachable.depth <= max_depth_value)
@@ -215,6 +263,11 @@ where
                 .insert((*head_commit_id, max_depth), Arc::clone(&bounded));
             return Ok(bounded);
         }
+        reachable_census::record(if max_depth.is_some() {
+            reachable_census::WALK_BOUNDED
+        } else {
+            reachable_census::WALK_UNBOUNDED
+        });
         let nodes = Arc::from(walk_reachable_nodes(self, head_commit_id, max_depth).await?);
         self.reachable_nodes_cache
             .insert((*head_commit_id, max_depth), Arc::clone(&nodes));

--- a/packages/lix/src/commit_graph/mod.rs
+++ b/packages/lix/src/commit_graph/mod.rs
@@ -2,6 +2,7 @@ mod context;
 mod types;
 mod walker;
 
+pub(crate) use context::reachable_census;
 pub(crate) use context::{CommitGraphContext, CommitGraphStoreReader, canonical_commit_change};
 pub(crate) use types::{
     CommitGraphChange, CommitGraphChangeHistoryEntry, CommitGraphChangeHistoryRequest,

--- a/packages/lix/src/commit_graph/mod.rs
+++ b/packages/lix/src/commit_graph/mod.rs
@@ -2,6 +2,8 @@ mod context;
 mod types;
 mod walker;
 
+/// Test-only engagement counters for the reachable-node cache.
+#[cfg(test)]
 pub(crate) use context::reachable_census;
 pub(crate) use context::{CommitGraphContext, CommitGraphStoreReader, canonical_commit_change};
 pub(crate) use types::{

--- a/packages/lix/src/sql2/providers/file_history.rs
+++ b/packages/lix/src/sql2/providers/file_history.rs
@@ -3391,7 +3391,7 @@ mod tests {
             .await
             .expect("seed commit");
         }
-        let text = |result: crate::SqlQueryResult, column: usize| match &result.rows()[0].values()
+        let text = |result: crate::ExecuteResult, column: usize| match &result.rows()[0].values()
             [column]
         {
             crate::Value::Text(text) => text.clone(),

--- a/packages/lix/src/sql2/providers/file_history.rs
+++ b/packages/lix/src/sql2/providers/file_history.rs
@@ -3478,8 +3478,13 @@ mod tests {
     async fn depth_bounded_file_history_is_served_by_the_unbounded_traversal() {
         use crate::commit_graph::reachable_census;
 
+        // Census every shape BEFORE asserting, so a failure reports the whole
+        // picture instead of stopping at the first shape that regressed.
+        let mut census = Vec::new();
         for shape in ["path", "id", "unfiltered"] {
-            let delta = depth_bounded_history_census(shape).await;
+            census.push((shape, depth_bounded_history_census(shape).await));
+        }
+        for (shape, delta) in census {
             assert!(
                 delta[reachable_census::WALK_UNBOUNDED] > 0,
                 "{shape}: expected at least one real (missing) unbounded traversal"

--- a/packages/lix/src/sql2/providers/file_history.rs
+++ b/packages/lix/src/sql2/providers/file_history.rs
@@ -3431,6 +3431,17 @@ mod tests {
                 "SELECT lixcol_depth FROM lix_file_history($1) WHERE lixcol_depth = 0",
                 vec![crate::Value::Text(head)],
             ),
+            // Resolves to an empty lookup-ID set, so `load_file_history_rows`
+            // returns at its `resolved_lookup_ids.is_empty()` early return and
+            // never reaches `load_file_history_entry_sets` at all.
+            "missing_path" => (
+                "SELECT lixcol_depth FROM lix_file_history($1) \
+                 WHERE path = $2 AND lixcol_depth = 0",
+                vec![
+                    crate::Value::Text(head),
+                    crate::Value::Text("/probe/never-existed.txt".to_string()),
+                ],
+            ),
             other => panic!("unknown shape {other}"),
         };
 
@@ -3440,7 +3451,9 @@ mod tests {
             .await
             .expect("depth-bounded history query");
         let after = reachable_census::snapshot();
-        assert!(!rows.rows().is_empty(), "{shape} query returned no rows");
+        if shape != "missing_path" {
+            assert!(!rows.rows().is_empty(), "{shape} query returned no rows");
+        }
         lix.close().await.expect("close lix");
 
         let delta = [
@@ -3481,10 +3494,13 @@ mod tests {
         // Census every shape BEFORE asserting, so a failure reports the whole
         // picture instead of stopping at the first shape that regressed.
         let mut census = Vec::new();
-        for shape in ["path", "id", "unfiltered"] {
+        for shape in ["path", "id", "unfiltered", "missing_path"] {
             census.push((shape, depth_bounded_history_census(shape).await));
         }
-        for (shape, delta) in census {
+        // `missing_path` short-circuits upstream of the reordered function, so
+        // it is censused for the record but carries no expectation of a
+        // depth-bounded traversal.
+        for (shape, delta) in census.into_iter().filter(|(shape, _)| *shape != "missing_path") {
             assert!(
                 delta[reachable_census::WALK_UNBOUNDED] > 0,
                 "{shape}: expected at least one real (missing) unbounded traversal"

--- a/packages/lix/src/sql2/providers/file_history.rs
+++ b/packages/lix/src/sql2/providers/file_history.rs
@@ -3366,6 +3366,97 @@ mod tests {
         assert_eq!(order.lock().unwrap().as_slice(), &[None, Some(3)]);
     }
 
+    /// Runs one depth-bounded `lix_file_history` query on a fresh workspace and
+    /// returns the reachable-node census delta for it.
+    ///
+    /// A fresh workspace per shape is deliberate: the reachable-node cache
+    /// lives on the registered surface, so reusing one handle would let the
+    /// first shape's traversal serve the next one and make every shape after
+    /// the first read as a hit.
+    #[cfg(test)]
+    async fn depth_bounded_history_census(shape: &str) -> [u64; 4] {
+        use crate::commit_graph::reachable_census;
+
+        let probe_path = "/probe/census.txt";
+        let lix = crate::open_lix().await.expect("open lix");
+        for revision in 0..4u32 {
+            lix.execute(
+                "INSERT INTO lix_file (path, content) VALUES ($1, $2) \
+                 ON CONFLICT (path) DO UPDATE SET content = excluded.content",
+                &[
+                    crate::Value::Text(probe_path.to_string()),
+                    crate::Value::Blob(format!("rev-{revision}").into_bytes().into()),
+                ],
+            )
+            .await
+            .expect("seed commit");
+        }
+        let text = |result: crate::SqlQueryResult, column: usize| match &result.rows()[0].values()
+            [column]
+        {
+            crate::Value::Text(text) => text.clone(),
+            other => panic!("expected text, got {other:?}"),
+        };
+        let head = text(
+            lix.execute("SELECT lix_active_branch_commit_id()", &[])
+                .await
+                .expect("active commit"),
+            0,
+        );
+        let file_id = text(
+            lix.execute(
+                "SELECT id FROM lix_file WHERE path = $1",
+                &[crate::Value::Text(probe_path.to_string())],
+            )
+            .await
+            .expect("probe file id"),
+            0,
+        );
+
+        let (sql, params) = match shape {
+            "path" => (
+                "SELECT lixcol_depth FROM lix_file_history($1) \
+                 WHERE path = $2 AND lixcol_depth = 0",
+                vec![
+                    crate::Value::Text(head),
+                    crate::Value::Text(probe_path.to_string()),
+                ],
+            ),
+            "id" => (
+                "SELECT lixcol_depth FROM lix_file_history($1) \
+                 WHERE id = $2 AND lixcol_depth = 0",
+                vec![crate::Value::Text(head), crate::Value::Text(file_id)],
+            ),
+            "unfiltered" => (
+                "SELECT lixcol_depth FROM lix_file_history($1) WHERE lixcol_depth = 0",
+                vec![crate::Value::Text(head)],
+            ),
+            other => panic!("unknown shape {other}"),
+        };
+
+        let before = reachable_census::snapshot();
+        let rows = lix
+            .execute(sql, &params)
+            .await
+            .expect("depth-bounded history query");
+        let after = reachable_census::snapshot();
+        assert!(!rows.rows().is_empty(), "{shape} query returned no rows");
+        lix.close().await.expect("close lix");
+
+        let delta = [
+            after[0] - before[0],
+            after[1] - before[1],
+            after[2] - before[2],
+            after[3] - before[3],
+        ];
+        eprintln!(
+            "reachable_census shape={shape} exact_hit={} bounded_from_unbounded={} \
+             walk_bounded={} walk_unbounded={}",
+            delta[0], delta[1], delta[2], delta[3],
+        );
+        delta
+    }
+
     /// Connectivity check for the route ordering above, at the layer the
     /// ordering actually pays off: the reachable-node cache.
     ///
@@ -3375,75 +3466,33 @@ mod tests {
     /// sits at the SQL surface: a query-level timer cannot distinguish "the
     /// bounded traversal was skipped" from "the bounded traversal was cheap".
     ///
-    /// Asserts both a miss (`WALK_UNBOUNDED`, the traversal that is genuinely
-    /// paid for) and a hit (`BOUNDED_FROM_UNBOUNDED`, the traversal the
-    /// ordering removes).
+    /// Asserts both a miss (`WALK_UNBOUNDED`, the traversal genuinely paid for)
+    /// and a hit (`BOUNDED_FROM_UNBOUNDED`, the traversal the ordering removes)
+    /// for every depth-bounded shape.
+    ///
+    /// The `path` shape reaches this state without the ordering change, because
+    /// `resolve_file_history_path_lookup_ids` already loads the unbounded
+    /// anchor route to resolve the path. The `id` and `unfiltered` shapes have
+    /// no such pre-pass, and it is those two that the ordering fixes.
     #[tokio::test]
     async fn depth_bounded_file_history_is_served_by_the_unbounded_traversal() {
         use crate::commit_graph::reachable_census;
 
-        let lix = crate::open_lix().await.expect("open lix");
-        for revision in 0..4u32 {
-            lix.execute(
-                "INSERT INTO lix_file (path, content) VALUES ($1, $2) \
-                 ON CONFLICT (path) DO UPDATE SET content = excluded.content",
-                &[
-                    crate::Value::Text("/probe/census.txt".to_string()),
-                    crate::Value::Blob(format!("rev-{revision}").into_bytes().into()),
-                ],
-            )
-            .await
-            .expect("seed commit");
+        for shape in ["path", "id", "unfiltered"] {
+            let delta = depth_bounded_history_census(shape).await;
+            assert!(
+                delta[reachable_census::WALK_UNBOUNDED] > 0,
+                "{shape}: expected at least one real (missing) unbounded traversal"
+            );
+            assert!(
+                delta[reachable_census::BOUNDED_FROM_UNBOUNDED] > 0,
+                "{shape}: expected the depth-bounded request to be served by \
+                 truncating the unbounded traversal"
+            );
+            assert_eq!(
+                delta[reachable_census::WALK_BOUNDED], 0,
+                "{shape}: a depth-bounded query must not traverse storage on its own"
+            );
         }
-        let head = match &lix
-            .execute("SELECT lix_active_branch_commit_id()", &[])
-            .await
-            .expect("active commit")
-            .rows()[0]
-            .values()[0]
-        {
-            crate::Value::Text(text) => text.clone(),
-            other => panic!("expected text commit id, got {other:?}"),
-        };
-
-        let before = reachable_census::snapshot();
-        let rows = lix
-            .execute(
-                "SELECT lixcol_depth FROM lix_file_history($1) \
-                 WHERE path = $2 AND lixcol_depth = 0",
-                &[
-                    crate::Value::Text(head),
-                    crate::Value::Text("/probe/census.txt".to_string()),
-                ],
-            )
-            .await
-            .expect("depth-bounded history query");
-        let after = reachable_census::snapshot();
-        assert!(!rows.rows().is_empty(), "probe query returned no rows");
-
-        let delta = |slot: usize| after[slot] - before[slot];
-        let census = format!(
-            "exact_hit={} bounded_from_unbounded={} walk_bounded={} walk_unbounded={}",
-            delta(reachable_census::EXACT_HIT),
-            delta(reachable_census::BOUNDED_FROM_UNBOUNDED),
-            delta(reachable_census::WALK_BOUNDED),
-            delta(reachable_census::WALK_UNBOUNDED),
-        );
-        eprintln!("reachable_census {census}");
-        assert!(
-            delta(reachable_census::WALK_UNBOUNDED) > 0,
-            "expected at least one real (missing) unbounded traversal: {census}"
-        );
-        assert!(
-            delta(reachable_census::BOUNDED_FROM_UNBOUNDED) > 0,
-            "expected the depth-bounded request to be served by truncating the \
-             unbounded traversal: {census}"
-        );
-        assert_eq!(
-            delta(reachable_census::WALK_BOUNDED),
-            0,
-            "a depth-bounded query must not traverse storage on its own: {census}"
-        );
-        lix.close().await.expect("close lix");
     }
 }

--- a/packages/lix/src/sql2/providers/file_history.rs
+++ b/packages/lix/src/sql2/providers/file_history.rs
@@ -1580,11 +1580,21 @@ where
     Load: Fn(HistoryRoute) -> LoadFuture,
     LoadFuture: Future<Output = Result<Vec<HistoryEntry>, LixError>>,
 {
-    let event_entries = load(event_route.clone()).await?;
-    let context_entries = if event_route == context_route {
-        event_entries.clone()
+    // Load the context (anchor-only, unbounded) route FIRST, then the event
+    // (depth-bounded) route.
+    //
+    // Both sets are always computed, so this is ordering only. It matters
+    // because the reachable-node cache is keyed by `(head, depth bound)`: a
+    // bounded traversal cannot satisfy a later unbounded request, while an
+    // unbounded traversal satisfies every bounded one by truncation
+    // (`CommitGraphStoreReader::reachable_nodes_within_depth`). Running the
+    // bounded route first therefore pays for two traversals; running the
+    // unbounded route first pays for one.
+    let context_entries = load(context_route.clone()).await?;
+    let event_entries = if event_route == context_route {
+        context_entries.clone()
     } else {
-        load(context_route.clone()).await?
+        load(event_route.clone()).await?
     };
     Ok((event_entries, context_entries))
 }
@@ -3336,11 +3346,11 @@ mod tests {
         let context_route = route.anchors_only();
         assert_ne!(event_route, context_route);
 
-        let loads = Arc::new(AtomicUsize::new(0));
-        let counted_loads = Arc::clone(&loads);
+        let order = Arc::new(StdMutex::new(Vec::<Option<i64>>::new()));
+        let recorded_order = Arc::clone(&order);
         let (event_entries, context_entries) =
-            load_file_history_entry_sets(&event_route, &context_route, move |_| {
-                counted_loads.fetch_add(1, Ordering::SeqCst);
+            load_file_history_entry_sets(&event_route, &context_route, move |route| {
+                recorded_order.lock().unwrap().push(route.max_depth);
                 async { Ok(Vec::new()) }
             })
             .await
@@ -3348,6 +3358,92 @@ mod tests {
 
         assert!(event_entries.is_empty());
         assert!(context_entries.is_empty());
-        assert_eq!(loads.load(Ordering::SeqCst), 2);
+        // The unbounded context route must be loaded FIRST. The reachable-node
+        // cache is keyed by `(head, depth bound)`, so an unbounded traversal
+        // serves the bounded one by truncation while the reverse forces a
+        // second traversal. Loading them the other way round is silently
+        // correct and costs an extra walk of the whole reachable set.
+        assert_eq!(order.lock().unwrap().as_slice(), &[None, Some(3)]);
+    }
+
+    /// Connectivity check for the route ordering above, at the layer the
+    /// ordering actually pays off: the reachable-node cache.
+    ///
+    /// The counter hooked here is `commit_graph::context::reachable_census`,
+    /// *inside* `reachable_nodes_within_depth`'s `max_depth` fallback branch.
+    /// It is deliberately a different layer from any timing instrument, which
+    /// sits at the SQL surface: a query-level timer cannot distinguish "the
+    /// bounded traversal was skipped" from "the bounded traversal was cheap".
+    ///
+    /// Asserts both a miss (`WALK_UNBOUNDED`, the traversal that is genuinely
+    /// paid for) and a hit (`BOUNDED_FROM_UNBOUNDED`, the traversal the
+    /// ordering removes).
+    #[tokio::test]
+    async fn depth_bounded_file_history_is_served_by_the_unbounded_traversal() {
+        use crate::commit_graph::reachable_census;
+
+        let lix = crate::open_lix().await.expect("open lix");
+        for revision in 0..4u32 {
+            lix.execute(
+                "INSERT INTO lix_file (path, content) VALUES ($1, $2) \
+                 ON CONFLICT (path) DO UPDATE SET content = excluded.content",
+                &[
+                    crate::Value::Text("/probe/census.txt".to_string()),
+                    crate::Value::Blob(format!("rev-{revision}").into_bytes().into()),
+                ],
+            )
+            .await
+            .expect("seed commit");
+        }
+        let head = match &lix
+            .execute("SELECT lix_active_branch_commit_id()", &[])
+            .await
+            .expect("active commit")
+            .rows()[0]
+            .values()[0]
+        {
+            crate::Value::Text(text) => text.clone(),
+            other => panic!("expected text commit id, got {other:?}"),
+        };
+
+        let before = reachable_census::snapshot();
+        let rows = lix
+            .execute(
+                "SELECT lixcol_depth FROM lix_file_history($1) \
+                 WHERE path = $2 AND lixcol_depth = 0",
+                &[
+                    crate::Value::Text(head),
+                    crate::Value::Text("/probe/census.txt".to_string()),
+                ],
+            )
+            .await
+            .expect("depth-bounded history query");
+        let after = reachable_census::snapshot();
+        assert!(!rows.rows().is_empty(), "probe query returned no rows");
+
+        let delta = |slot: usize| after[slot] - before[slot];
+        let census = format!(
+            "exact_hit={} bounded_from_unbounded={} walk_bounded={} walk_unbounded={}",
+            delta(reachable_census::EXACT_HIT),
+            delta(reachable_census::BOUNDED_FROM_UNBOUNDED),
+            delta(reachable_census::WALK_BOUNDED),
+            delta(reachable_census::WALK_UNBOUNDED),
+        );
+        eprintln!("reachable_census {census}");
+        assert!(
+            delta(reachable_census::WALK_UNBOUNDED) > 0,
+            "expected at least one real (missing) unbounded traversal: {census}"
+        );
+        assert!(
+            delta(reachable_census::BOUNDED_FROM_UNBOUNDED) > 0,
+            "expected the depth-bounded request to be served by truncating the \
+             unbounded traversal: {census}"
+        );
+        assert_eq!(
+            delta(reachable_census::WALK_BOUNDED),
+            0,
+            "a depth-bounded query must not traverse storage on its own: {census}"
+        );
+        lix.close().await.expect("close lix");
     }
 }


### PR DESCRIPTION
# NEGATIVE RESULT — recommend NOT merging as a performance change

Experiment `expfr`. Machine `ryzen-9950x-III`. Base `c86c5cf0b` (`claude-6-optimizations`).

**The mechanism engages exactly as predicted and removes exactly one commit-graph
traversal per depth-bounded history query. It does not move any timing lane above
the instrument's noise floor, because the redundancy it removes had already been
absorbed by `CommitGraphStoreReader::node_cache` one layer down.**

Every lane, base and candidate, overlaps at 18 samples per arm. Under the
acceptance gate this is not a >10% win, not a cut that removes an authority or an
asymptotic term, and not a bug fix. Per the runbook ("do not land something that
is merely 'not worse'") the recommendation is to **close this without merging**
and keep the finding.

## What changed

`load_file_history_entry_sets` (`packages/lix/src/sql2/providers/file_history.rs`)
loaded the depth-bounded *event* route first and the unbounded *context* route
second. Swapped, keeping the `event_route == context_route` short-circuit. Both
entry sets are still computed; only the order differs.

Rationale: `reachable_nodes_within_depth`
(`packages/lix/src/commit_graph/context.rs`) keys its cache on
`(head, depth bound)` and has an explicit fallback that serves a bounded request
by `take_while`-truncating a cached unbounded result. A bounded result can never
serve an unbounded request; an unbounded result serves every bounded one. So the
bounded request should be asked for second.

Also adds `commit_graph::context::reachable_census`: four process-global
counters incremented once per traversal request (not per commit, not per row),
`pub(crate)`, read only by tests.

## Engagement — counter inside the changed route, before any timing

Counter layer: inside `reachable_nodes_within_depth`, on the `max_depth`
fallback branch itself. Timing layer: the SQL surface, in
`packages/e2e/tests/history_scaling_probe.rs`. Different layers, as required — a
query-level timer cannot distinguish "the bounded traversal was skipped" from
"the bounded traversal was cheap".

Shipped as a real (non-`#[ignore]`d) test,
`depth_bounded_file_history_is_served_by_the_unbounded_traversal`, asserting both
a miss (`walk_unbounded > 0`) and a hit (`bounded_from_unbounded > 0`) for every
depth-bounded shape. Deltas for one query, fresh workspace per shape:

| shape | arm | exact_hit | bounded_from_unbounded | walk_bounded | walk_unbounded |
|---|---|---|---|---|---|
| `path = ? AND depth = 0` | base | 7 | 1 | 0 | 1 |
| `path = ? AND depth = 0` | cand | 7 | 1 | 0 | 1 |
| `id = ? AND depth = 0` | base | 6 | 0 | **1** | 1 |
| `id = ? AND depth = 0` | cand | 6 | **1** | **0** | 1 |
| `depth = 0` (no entity) | base | 4 | 0 | **1** | 1 |
| `depth = 0` (no entity) | cand | 4 | **1** | **0** | 1 |
| `path = '<missing>' AND depth = 0` | base | 0 | 0 | 0 | 1 |
| `path = '<missing>' AND depth = 0` | cand | 0 | 0 | 0 | 1 |

Two findings the handover did not have:

1. **The `path` shape was already optimal on base.** `load_file_history_rows`
   calls `resolve_file_history_path_lookup_ids` with the *unbounded* anchor
   route (`file_history.rs:643-650`) before it loads either entry set, so an
   exact-path predicate already materializes the unbounded reachable set. The
   ordering therefore cannot affect any path-predicated query — including
   `by_path_depth0`, **the only depth-bounded lane the standard
   `history_scaling_probe` has**. The prediction that this "helps the depth-0
   shape most" is wrong in the specific sense that the probe's depth-0 shape is
   a path shape and is unaffected.
2. The shapes it does fix are `id = ? AND depth <= K` and bare `depth <= K` —
   depth-bounded queries with no exact-path pre-pass.

## Why one fewer traversal is worth nothing

`walk_reachable_nodes` loads commit records through
`CommitGraphStoreReader::load_nodes`, which filters against a **separate**
`node_cache` on the same reader (`context.rs:160-166`). On base the bounded walk
loads `K+1` commit records from storage and the unbounded walk then loads only
the remaining `N-K-1`; total storage reads `N`. On the candidate the unbounded
walk loads `N` and the bounded request is a prefix clone; total storage reads
`N`. **Identical.**

What the reorder actually removes is the in-memory BFS bookkeeping of one
bounded walk — a `BTreeSet` insert per parent edge, one sort, and a `Vec` of
node clones over records that are already decoded. Sub-noise, and the
measurement below confirms it.

This is the part I would flag as the reusable lesson: the counter proved the
branch engaged, and engagement was still not sufficient, because a *second*
cache one layer down had already removed the cost the first cache appeared to be
missing.

## Measurement

Instrument: in-tree `packages/e2e/tests/history_scaling_probe.rs`, unmodified,
env-driven (`LIX_HISTORY_SCALE_SAMPLES=3`, `LIX_HISTORY_SCALE_FILES=50,500,5000`,
`LIX_HISTORY_SCALE_COMMITS=20,200,2000`). Storage RocksDB (the probe's backend).

Supplementary instrument `expfr_depth_probe`: lanes the standard probe does not
have — `id = ? AND depth = 0`, `id = ? AND depth <= 1000`, bare `depth = 0`, plus
`null_control_id_nodepth`. It was applied **identically to both arms** on
throwaway branches (`expfr-timing-base` `b6ddaf2b0`, `expfr-timing-cand`
`7cc9f9d93`; `git diff --stat` between the arms over `packages/e2e` is empty) and
is **not part of this PR**. Without it the mandated instrument has no lane that
can execute the changed branch at all.

Protocol: both arms built fully (`--no-run`) before any timing; prebuilt release
test binaries exec'd directly; arm order rotated per round; 6 interleaved rounds
total across two passes; 3 in-process samples per point → **18 samples per arm**.

### Lanes that CAN execute the changed branch

| lane (2000 noise commits, 200 files) | base med | cand med | delta | base range | cand range | overlap |
|---|---|---|---|---|---|---|
| `id_depth0` | 30.547 | 31.075 | +1.73% | 30.21–32.05 | 30.16–33.26 | YES |
| `id_depth_high` (`depth <= 1000`) | 124.613 | 122.282 | −1.87% | 121.92–126.65 | 117.90–129.12 | YES |
| `unfiltered_depth0` (200 files) | 1.990 | 1.953 | −1.86% | 1.92–2.30 | 1.92–2.23 | YES |
| `id_depth0` @200 | 4.242 | 4.260 | +0.42% | 4.18–4.43 | 4.20–4.32 | YES |
| `id_depth_high` @200 | 21.737 | 22.219 | +2.22% | 21.18–22.42 | 21.32–22.52 | YES |

Signs disagree between sizes and every arm pair overlaps. `id_depth_high` is the
best case the mechanism has — a bound near the height of the history, so the
bounded walk it removes is nearly a full traversal — and it is still inside the
noise.

### Null control

`null_control_id_nodepth` (`id = ?`, no depth predicate): the routes are equal,
so the reordered `if` short-circuits identically and the arms run byte-identical
logic.

| size | base med | cand med | delta |
|---|---|---|---|
| 20 commits | 3.643 | 3.604 | −1.07% |
| 200 commits | 21.252 | 21.299 | +0.22% |
| 2000 commits | 216.679 | 215.408 | −0.59% |

Resolution floor ≈ ±2%. Two *unaffected* lanes (`fixed_files by_id 2000`,
`by_path_depth0 2000`) showed non-overlapping ranges of −2.7%/−2.9% in the
single-pass data before the passes were pooled, which is the sharper calibration:
this harness produces apparently-significant differences on code that is
byte-identical between arms. Nothing at this magnitude is resolvable here.

### Standard probe curve (guard — none of these can execute the changed branch)

| lane | base med | cand med | delta | overlap |
|---|---|---|---|---|
| `fixed_commits by_path files=50` | 3.402 | 3.120 | −8.29% | YES (n=9, base has a warm-up outlier) |
| `fixed_commits by_path files=500` | 4.419 | 4.392 | −0.62% | YES |
| `fixed_commits by_path files=5000` | 17.433 | 17.694 | +1.50% | YES |
| `fixed_commits by_id files=50` | 2.829 | 2.779 | −1.75% | YES |
| `fixed_commits by_id files=500` | 3.622 | 3.631 | +0.25% | YES |
| `fixed_commits by_id files=5000` | 10.784 | 11.009 | +2.09% | YES |
| `fixed_files by_path 20/200/2000` | 3.953 / 7.298 / 42.693 | 3.826 / 7.256 / 41.671 | −3.21% / −0.57% / −2.39% | YES |
| `fixed_files by_id 20/200/2000` | 3.375 / 6.114 / 33.808 | 3.319 / 6.107 / 33.123 | −1.64% / −0.12% / −2.02% | YES |
| `fixed_files by_path_depth0 20/200/2000` | 1.995 / 5.462 / 39.264 | 1.965 / 5.469 / 38.558 | −1.53% / +0.13% / −1.80% | YES |

`by_path` and `by_id` carry no depth predicate, so `traversal_only() ==
anchors_only()` and the short-circuit fires — one load, both arms.
`by_path_depth0` is a path shape and is covered by finding (1) above. So the
whole standard probe is, for this change, an elaborate null control. It shows no
regression, which is the only thing it was ever able to show.

Slope is unchanged everywhere. `fixed_files by_path` grows 7.298→42.693 on base
and 7.256→41.671 on cand from 200 to 2000 commits (5.85x vs 5.74x);
`fixed_commits by_path` grows 4.419→17.433 on base and 4.392→17.694 on cand from
500 to 5000 files (3.95x vs 4.03x). No asymptotic term moved in either
direction, which is expected — the change removes at most a constant factor on a
sub-dominant term, and the measurement above says it does not remove even that.

## The specific regression risk that was asked about

Checked: the `resolved_lookup_ids.is_empty()` early return at
`file_history.rs:652`. **The reorder cannot trade work in that direction**, for
two independent reasons:

1. That early return is textually *upstream* of
   `load_file_history_filesystem_context` (line 660), which is the only path
   into `load_file_history_entry_sets` from `load_file_history_rows`. A query
   that short-circuits there never enters the reordered function on either arm.
2. To *reach* that early return a query must already have run
   `resolve_file_history_path_lookup_ids`, which loads the unbounded context
   route. So such a query has already paid for the unbounded traversal on both
   arms.

Measured, not only argued: the `missing_path` row of the census table above is
`0 / 0 / 0 / 1` on both arms — one unbounded walk, no bounded walk, identical.

There is also no early return *between* the two loads: both entry sets are
unconditionally produced, or the routes are equal and one load serves both.

## Stack canary

`slatedb_history_blob_survives_until_final_root_release` run explicitly by name
(it aborts the process rather than failing a lane, so a timing sweep cannot see
it). Result in the gate block below. The change adds no `async` frame — it
reorders two existing `await`s inside an existing future.

## Breaking change: NO

- **On-disk format**: nothing is written differently. Neither route is a writer;
  both are read paths over already-durable commit records. No key, space,
  encoding, or version identifier is touched.
- **Observable behaviour**: the function returns the same `(event_entries,
  context_entries)` tuple with the same contents. Both sets were, and are,
  computed unconditionally; the short-circuit branch is preserved and its
  equality predicate is unchanged.
- **Public API**: no change to `packages/lix/src/lib.rs` exports, the SQL
  surface, or the JS SDK surface. `reachable_census` is `pub(crate)`.
- **Storage adapter API**: nothing added, changed, or removed.

Argued from what an older reader would do, as asked: an older reader is a reader
of *storage*, and the set of storage reads this change causes is a subset of what
base caused — the same commit records, in a different order within one query, all
of them already durable before the query began. There is no record an old reader
could encounter that it could not have encountered before, because no record is
produced. The ordering is not observable outside the process: it is not part of
any write set, so `git`-visible bytes, the atomic publication set, and the ref
move are all untouched.

## Layout invariants

1. **Single authority** — no. Adds no writer, no materialization, no index. The
   census counters are diagnostics with no correctness role.
2. **Commit canonicality** — unaffected. Traversal still reads commit records;
   no parallel graph.
3. **Derived views are caches** — the `reachable_nodes_cache` this exploits is
   already a disposable per-reader cache, keyed by `(head, depth bound)`, and is
   not a correctness authority. This change only alters the order in which it is
   populated.
4. **Atomic publication** — not a write path.
5. **GC from refs** — untouched.
6. **SQL reads canonical records** — unchanged; still the commit-state
   authority.

## What regressed

Nothing measurably. `id_depth0` at 2000 commits reads +1.73% and `id_depth_high`
at 200 reads +2.22%, both inside the null control's spread and both overlapping.
I am not claiming those as regressions any more than I am claiming the negative
deltas as wins.

## What I could not resolve

Whether the reorder is worth anything on **object storage**, where a commit-record
round trip costs orders of magnitude more than on local RocksDB. It should still
be worth nothing, because `node_cache` deduplicates the reads regardless of how
expensive they are — the redundancy was never in the read count. But I did not
measure it, and SlateDB-against-object-storage is the configuration where that
reasoning could fail for a reason I have not thought of.
