### PR TITLE
probe(tracked-state): census the per-row identity allocation on the commit-delta payload fetch

### DIFF
--- a/packages/lix/src/hot_row_tombstone_probe.rs
+++ b/packages/lix/src/hot_row_tombstone_probe.rs
@@ -1128,3 +1128,117 @@ async fn retention_fence_durability_across_supported_operations() {
         drop(session);
     }
 }
+
+/// PHASE 8 — the allocation census, and the decision point for whether the
+/// per-row identity work on the payload fetch is worth removing.
+///
+/// The retained profile that motivated this attributed ~6.6% of a rotated
+/// collection scan to `load_commit_delta_entry_at_index` and ~6.7% to
+/// `codec::decode_key`. That profile was recorded at `49a4bf45a`, which is
+/// **before** the root-base serving cache landed. The cache changes the
+/// question from "what does one read cost" to "how many reads pay it at all",
+/// and no percentage from that profile can answer the second question.
+///
+/// So this counts, per scan, at the sites themselves:
+///
+/// - `rows` — `load_commit_delta_entry_at_index` calls, the per-row payload fetch.
+/// - `decodes` / `dec_in_b` — `codec::decode_key` calls and the encoded bytes
+///   they consumed, all callers.
+/// - `own_b` / `esc` — the bytes `into_owned()` copies over what
+///   `decode_key_borrowed` already produced, and how many of those strings were
+///   escaped and so allocate regardless. `own_b` is the ceiling on what a
+///   borrow-based fix at that site can remove; it is not the cost of the decode.
+/// - `acct_b` — the per-row `account_id.to_string()`.
+/// - `enc` / `enc_b` — per-row `encode_key_ref` reaching the binary search.
+/// - `clones` / `clone_b` — the deep key clone `load_commit_delta_change_records`
+///   makes to build its request vector.
+/// - `matkey` / `matkey_b` — owned `TrackedStateKey` values
+///   `materialize_index_payloads` builds from keys it already holds borrowed.
+/// - `reverify` — rows reaching the post-fetch identity re-check.
+/// - `hit` / `miss` — root-base serving cache, and `dur`/`exa`/`rep` the
+///   `scan_batch_at_commit` arm, so a zero census is never ambiguous between
+///   "no allocation" and "the lane never ran".
+///
+/// `cold` is the first read of the rotated generation; `warm` aggregates the
+/// next `reps` reads. Per-scan numbers are `warm / reps`.
+#[cfg(feature = "storage-benches")]
+#[tokio::test]
+#[ignore = "measurement probe, not a gate"]
+async fn rotated_generation_key_allocation_census() {
+    let sizes = sizes_from_env("LIX_TOMBSTONE_SIZES", &[100, 1_000, 10_000]);
+    let reps = reps_from_env(5);
+    println!(
+        "phase8 | arm,n,phase,scans,rows,decodes,dec_in_b,own_b,esc,acct_b,enc,enc_b,\
+clones,clone_b,matkey,matkey_b,reverify,hit,miss,dur,exa,rep,us"
+    );
+    for n in sizes {
+        for rotate in [false, true] {
+            let (_storage, session) = open_session().await;
+            register(&session, probe_schema("censusrow")).await;
+            insert_rows(&session, "censusrow", n).await;
+            if rotate {
+                let branch = session
+                    .create_branch(crate::CreateBranchOptions {
+                        id: None,
+                        name: "e52-census".to_string(),
+                        from_commit_id: None,
+                    })
+                    .await
+                    .expect("branch should create");
+                session
+                    .switch_branch(crate::SwitchBranchOptions {
+                        branch_id: branch.id.clone(),
+                    })
+                    .await
+                    .expect("branch should switch");
+            }
+            let scan = scan_sql("censusrow");
+            let arm = if rotate { "rot" } else { "main" };
+
+            // Discard everything setup recorded, so the cold line is the cold
+            // read and nothing else.
+            let _ = crate::storage_bench::take_tracked_key_allocation_census();
+            let _ = crate::storage_bench::take_root_base_batch_cache_accounting();
+            let _ = crate::storage_bench::take_tracked_scan_branch_accounting();
+
+            let started = Instant::now();
+            let rows = session.execute(&scan, &[]).await.expect("cold scan");
+            let cold_us = started.elapsed().as_micros();
+            assert_eq!(rows.len(), 1, "the cold scan must answer exactly one row");
+            print_census_line(arm, n, "cold", 1, cold_us);
+
+            let started = Instant::now();
+            for _ in 0..reps {
+                let rows = session.execute(&scan, &[]).await.expect("warm scan");
+                assert_eq!(rows.len(), 1, "the warm scan must answer exactly one row");
+            }
+            let warm_us = started.elapsed().as_micros();
+            print_census_line(arm, n, "warm", reps, warm_us);
+        }
+    }
+}
+
+/// Drains every census counter and prints one CSV line. Draining is what makes
+/// the next phase's line attributable to that phase alone.
+#[cfg(feature = "storage-benches")]
+fn print_census_line(arm: &str, n: usize, phase: &str, scans: usize, us: u128) {
+    let c = crate::storage_bench::take_tracked_key_allocation_census();
+    let (hit, miss) = crate::storage_bench::take_root_base_batch_cache_accounting();
+    let (dur, exa, rep) = crate::storage_bench::take_tracked_scan_branch_accounting();
+    println!(
+        "{arm},{n},{phase},{scans},{},{},{},{},{},{},{},{},{},{},{},{},{},{hit},{miss},{dur},{exa},{rep},{us}",
+        c.commit_delta_rows_loaded,
+        c.key_decode_calls,
+        c.key_decode_input_bytes,
+        c.key_decode_owned_string_bytes,
+        c.key_decode_escaped_strings,
+        c.commit_delta_account_id_bytes,
+        c.commit_delta_point_key_encodes,
+        c.commit_delta_point_key_encode_bytes,
+        c.commit_delta_request_key_clones,
+        c.commit_delta_request_key_clone_bytes,
+        c.materialize_owned_key_builds,
+        c.materialize_owned_key_bytes,
+        c.materialize_reverify_rows,
+    );
+}

--- a/packages/lix/src/storage_bench.rs
+++ b/packages/lix/src/storage_bench.rs
@@ -69,6 +69,7 @@ static COMMIT_DELTA_REQUEST_KEY_CLONE_BYTES: AtomicU64 = AtomicU64::new(0);
 static MATERIALIZE_OWNED_KEY_BUILDS: AtomicU64 = AtomicU64::new(0);
 static MATERIALIZE_OWNED_KEY_BYTES: AtomicU64 = AtomicU64::new(0);
 static MATERIALIZE_REVERIFY_ROWS: AtomicU64 = AtomicU64::new(0);
+static COMMIT_DELTA_COLUMNAR_ROWS: AtomicU64 = AtomicU64::new(0);
 static ENTITY_POINT_SNAPSHOT_CACHE_HITS: AtomicU64 = AtomicU64::new(0);
 static ENTITY_POINT_SNAPSHOT_CACHE_MISSES: AtomicU64 = AtomicU64::new(0);
 static CRUD_PHYSICAL_PUTS: AtomicU64 = AtomicU64::new(0);
@@ -440,6 +441,12 @@ pub struct TrackedKeyAllocationCensus {
     /// Rows that reached the post-fetch re-verification in
     /// `materialize_index_payloads`.
     pub materialize_reverify_rows: u64,
+    /// Rows served by `load_columnar_owned_entries` — the commit-delta route
+    /// that has **no** byte-equality assert and matches identity through JSON
+    /// text instead. Counted separately from `commit_delta_rows_loaded` because
+    /// the two routes establish identity by different means, and a test about
+    /// one of them proves nothing unless it can show which one ran.
+    pub commit_delta_columnar_rows: u64,
 }
 
 pub(crate) fn record_key_decode_owned(input_bytes: usize, owned_string_bytes: usize, escaped: u32) {
@@ -474,6 +481,10 @@ pub(crate) fn record_materialize_reverify_row() {
     MATERIALIZE_REVERIFY_ROWS.fetch_add(1, Ordering::Relaxed);
 }
 
+pub(crate) fn record_commit_delta_columnar_row() {
+    COMMIT_DELTA_COLUMNAR_ROWS.fetch_add(1, Ordering::Relaxed);
+}
+
 pub fn take_tracked_key_allocation_census() -> TrackedKeyAllocationCensus {
     TrackedKeyAllocationCensus {
         key_decode_calls: KEY_DECODE_OWNED_CALLS.swap(0, Ordering::Relaxed),
@@ -492,6 +503,7 @@ pub fn take_tracked_key_allocation_census() -> TrackedKeyAllocationCensus {
         materialize_owned_key_builds: MATERIALIZE_OWNED_KEY_BUILDS.swap(0, Ordering::Relaxed),
         materialize_owned_key_bytes: MATERIALIZE_OWNED_KEY_BYTES.swap(0, Ordering::Relaxed),
         materialize_reverify_rows: MATERIALIZE_REVERIFY_ROWS.swap(0, Ordering::Relaxed),
+        commit_delta_columnar_rows: COMMIT_DELTA_COLUMNAR_ROWS.swap(0, Ordering::Relaxed),
     }
 }
 

--- a/packages/lix/src/storage_bench.rs
+++ b/packages/lix/src/storage_bench.rs
@@ -52,6 +52,23 @@ static CERTIFIED_ENTITY_UPDATE_VALUE_BATCH_HITS: AtomicU64 = AtomicU64::new(0);
 static CERTIFIED_ENTITY_UPDATE_VALUE_BATCH_ROWS: AtomicU64 = AtomicU64::new(0);
 static ROOT_BASE_BATCH_CACHE_HITS: AtomicU64 = AtomicU64::new(0);
 static ROOT_BASE_BATCH_CACHE_MISSES: AtomicU64 = AtomicU64::new(0);
+static TRACKED_SCAN_DURABLE_ROOT: AtomicU64 = AtomicU64::new(0);
+static TRACKED_SCAN_EXACT_KEYS: AtomicU64 = AtomicU64::new(0);
+static TRACKED_SCAN_ROOTLESS_REPLAY: AtomicU64 = AtomicU64::new(0);
+static KEY_DECODE_OWNED_CALLS: AtomicU64 = AtomicU64::new(0);
+static KEY_DECODE_OWNED_INPUT_BYTES: AtomicU64 = AtomicU64::new(0);
+static KEY_DECODE_OWNED_STRING_BYTES: AtomicU64 = AtomicU64::new(0);
+static KEY_DECODE_OWNED_ESCAPED_STRINGS: AtomicU64 = AtomicU64::new(0);
+static COMMIT_DELTA_ROWS_LOADED: AtomicU64 = AtomicU64::new(0);
+static COMMIT_DELTA_ROW_KEY_DECODES: AtomicU64 = AtomicU64::new(0);
+static COMMIT_DELTA_ACCOUNT_ID_BYTES: AtomicU64 = AtomicU64::new(0);
+static COMMIT_DELTA_POINT_KEY_ENCODES: AtomicU64 = AtomicU64::new(0);
+static COMMIT_DELTA_POINT_KEY_ENCODE_BYTES: AtomicU64 = AtomicU64::new(0);
+static COMMIT_DELTA_REQUEST_KEY_CLONES: AtomicU64 = AtomicU64::new(0);
+static COMMIT_DELTA_REQUEST_KEY_CLONE_BYTES: AtomicU64 = AtomicU64::new(0);
+static MATERIALIZE_OWNED_KEY_BUILDS: AtomicU64 = AtomicU64::new(0);
+static MATERIALIZE_OWNED_KEY_BYTES: AtomicU64 = AtomicU64::new(0);
+static MATERIALIZE_REVERIFY_ROWS: AtomicU64 = AtomicU64::new(0);
 static ENTITY_POINT_SNAPSHOT_CACHE_HITS: AtomicU64 = AtomicU64::new(0);
 static ENTITY_POINT_SNAPSHOT_CACHE_MISSES: AtomicU64 = AtomicU64::new(0);
 static CRUD_PHYSICAL_PUTS: AtomicU64 = AtomicU64::new(0);
@@ -355,6 +372,127 @@ pub fn take_root_base_batch_cache_accounting() -> (u64, u64) {
         ROOT_BASE_BATCH_CACHE_HITS.swap(0, Ordering::Relaxed),
         ROOT_BASE_BATCH_CACHE_MISSES.swap(0, Ordering::Relaxed),
     )
+}
+
+pub(crate) fn record_tracked_scan_durable_root() {
+    TRACKED_SCAN_DURABLE_ROOT.fetch_add(1, Ordering::Relaxed);
+}
+
+pub(crate) fn record_tracked_scan_exact_keys() {
+    TRACKED_SCAN_EXACT_KEYS.fetch_add(1, Ordering::Relaxed);
+}
+
+pub(crate) fn record_tracked_scan_rootless_replay() {
+    TRACKED_SCAN_ROOTLESS_REPLAY.fetch_add(1, Ordering::Relaxed);
+}
+
+/// Which arm of `scan_batch_at_commit` ran, since the last call:
+/// `(durable_root, exact_keys, rootless_replay)`.
+///
+/// Symbol presence in a profile is not attribution — a claim about which arm
+/// executed has to come from the branch itself. This exists because inferring
+/// it from which symbols appeared got it exactly backwards once.
+pub fn take_tracked_scan_branch_accounting() -> (u64, u64, u64) {
+    (
+        TRACKED_SCAN_DURABLE_ROOT.swap(0, Ordering::Relaxed),
+        TRACKED_SCAN_EXACT_KEYS.swap(0, Ordering::Relaxed),
+        TRACKED_SCAN_ROOTLESS_REPLAY.swap(0, Ordering::Relaxed),
+    )
+}
+
+/// Per-row identity allocation on the commit-delta payload fetch.
+///
+/// Each field names the exact site it counts, because the question this
+/// answers is whether one identity is decoded, cloned and re-encoded once per
+/// row or once per batch — and a count taken at any layer above the payload
+/// fetch cannot tell those apart.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct TrackedKeyAllocationCensus {
+    /// `codec::decode_key` calls, all callers.
+    pub key_decode_calls: u64,
+    /// Encoded key bytes handed to `codec::decode_key`.
+    pub key_decode_input_bytes: u64,
+    /// Heap bytes copied by `decode_key`'s `into_owned()` over what
+    /// `decode_key_borrowed` already produced — the ceiling on what a
+    /// borrow-based fix at that site can remove.
+    pub key_decode_owned_string_bytes: u64,
+    /// Of those, strings whose encoding contained an escape and so were
+    /// already `Cow::Owned` before `into_owned()` — unavoidable by borrowing.
+    pub key_decode_escaped_strings: u64,
+    /// `load_commit_delta_entry_at_index` calls: rows fetched from a packed
+    /// commit delta.
+    pub commit_delta_rows_loaded: u64,
+    /// `decode_key` calls made by `load_commit_delta_entry_at_index` itself.
+    pub commit_delta_row_key_decodes: u64,
+    /// Bytes allocated by the per-row `account_id.to_string()`.
+    pub commit_delta_account_id_bytes: u64,
+    /// Per-request `encode_key_ref` calls on the point-read commit-delta route.
+    pub commit_delta_point_key_encodes: u64,
+    pub commit_delta_point_key_encode_bytes: u64,
+    /// `TrackedStateKey` deep clones made by `load_commit_delta_change_records`
+    /// to build its request vector.
+    pub commit_delta_request_key_clones: u64,
+    pub commit_delta_request_key_clone_bytes: u64,
+    /// Owned `TrackedStateKey` values built by `materialize_index_payloads`
+    /// from keys it already holds borrowed.
+    pub materialize_owned_key_builds: u64,
+    pub materialize_owned_key_bytes: u64,
+    /// Rows that reached the post-fetch re-verification in
+    /// `materialize_index_payloads`.
+    pub materialize_reverify_rows: u64,
+}
+
+pub(crate) fn record_key_decode_owned(input_bytes: usize, owned_string_bytes: usize, escaped: u32) {
+    KEY_DECODE_OWNED_CALLS.fetch_add(1, Ordering::Relaxed);
+    KEY_DECODE_OWNED_INPUT_BYTES.fetch_add(input_bytes as u64, Ordering::Relaxed);
+    KEY_DECODE_OWNED_STRING_BYTES.fetch_add(owned_string_bytes as u64, Ordering::Relaxed);
+    KEY_DECODE_OWNED_ESCAPED_STRINGS.fetch_add(u64::from(escaped), Ordering::Relaxed);
+}
+
+pub(crate) fn record_commit_delta_row_loaded(account_id_bytes: usize) {
+    COMMIT_DELTA_ROWS_LOADED.fetch_add(1, Ordering::Relaxed);
+    COMMIT_DELTA_ROW_KEY_DECODES.fetch_add(1, Ordering::Relaxed);
+    COMMIT_DELTA_ACCOUNT_ID_BYTES.fetch_add(account_id_bytes as u64, Ordering::Relaxed);
+}
+
+pub(crate) fn record_commit_delta_point_key_encode(bytes: usize) {
+    COMMIT_DELTA_POINT_KEY_ENCODES.fetch_add(1, Ordering::Relaxed);
+    COMMIT_DELTA_POINT_KEY_ENCODE_BYTES.fetch_add(bytes as u64, Ordering::Relaxed);
+}
+
+pub(crate) fn record_commit_delta_request_key_clone(bytes: usize) {
+    COMMIT_DELTA_REQUEST_KEY_CLONES.fetch_add(1, Ordering::Relaxed);
+    COMMIT_DELTA_REQUEST_KEY_CLONE_BYTES.fetch_add(bytes as u64, Ordering::Relaxed);
+}
+
+pub(crate) fn record_materialize_owned_key(bytes: usize) {
+    MATERIALIZE_OWNED_KEY_BUILDS.fetch_add(1, Ordering::Relaxed);
+    MATERIALIZE_OWNED_KEY_BYTES.fetch_add(bytes as u64, Ordering::Relaxed);
+}
+
+pub(crate) fn record_materialize_reverify_row() {
+    MATERIALIZE_REVERIFY_ROWS.fetch_add(1, Ordering::Relaxed);
+}
+
+pub fn take_tracked_key_allocation_census() -> TrackedKeyAllocationCensus {
+    TrackedKeyAllocationCensus {
+        key_decode_calls: KEY_DECODE_OWNED_CALLS.swap(0, Ordering::Relaxed),
+        key_decode_input_bytes: KEY_DECODE_OWNED_INPUT_BYTES.swap(0, Ordering::Relaxed),
+        key_decode_owned_string_bytes: KEY_DECODE_OWNED_STRING_BYTES.swap(0, Ordering::Relaxed),
+        key_decode_escaped_strings: KEY_DECODE_OWNED_ESCAPED_STRINGS.swap(0, Ordering::Relaxed),
+        commit_delta_rows_loaded: COMMIT_DELTA_ROWS_LOADED.swap(0, Ordering::Relaxed),
+        commit_delta_row_key_decodes: COMMIT_DELTA_ROW_KEY_DECODES.swap(0, Ordering::Relaxed),
+        commit_delta_account_id_bytes: COMMIT_DELTA_ACCOUNT_ID_BYTES.swap(0, Ordering::Relaxed),
+        commit_delta_point_key_encodes: COMMIT_DELTA_POINT_KEY_ENCODES.swap(0, Ordering::Relaxed),
+        commit_delta_point_key_encode_bytes: COMMIT_DELTA_POINT_KEY_ENCODE_BYTES
+            .swap(0, Ordering::Relaxed),
+        commit_delta_request_key_clones: COMMIT_DELTA_REQUEST_KEY_CLONES.swap(0, Ordering::Relaxed),
+        commit_delta_request_key_clone_bytes: COMMIT_DELTA_REQUEST_KEY_CLONE_BYTES
+            .swap(0, Ordering::Relaxed),
+        materialize_owned_key_builds: MATERIALIZE_OWNED_KEY_BUILDS.swap(0, Ordering::Relaxed),
+        materialize_owned_key_bytes: MATERIALIZE_OWNED_KEY_BYTES.swap(0, Ordering::Relaxed),
+        materialize_reverify_rows: MATERIALIZE_REVERIFY_ROWS.swap(0, Ordering::Relaxed),
+    }
 }
 
 pub(crate) fn record_entity_point_snapshot_cache_hit() {

--- a/packages/lix/src/tracked_state/codec.rs
+++ b/packages/lix/src/tracked_state/codec.rs
@@ -541,6 +541,25 @@ pub(crate) fn encode_schema_file_prefix(schema_key: &str, file_id: Option<&str>)
 
 pub(crate) fn decode_key(bytes: &[u8]) -> Result<TrackedStateKey, LixError> {
     let key = decode_key_borrowed(bytes)?;
+    #[cfg(feature = "storage-benches")]
+    {
+        // Counted here, inside the owned decode, because the whole question is
+        // how much `into_owned()` adds over the borrowed decode that already
+        // ran. A count taken at either caller cannot separate the two.
+        let mut owned_bytes = 0usize;
+        let mut escaped = 0u32;
+        if matches!(key.schema_key, Cow::Owned(_)) {
+            escaped += 1;
+        }
+        owned_bytes += key.schema_key.len();
+        if let Some(file_id) = key.file_id.as_ref() {
+            if matches!(file_id, Cow::Owned(_)) {
+                escaped += 1;
+            }
+            owned_bytes += file_id.len();
+        }
+        crate::storage_bench::record_key_decode_owned(bytes.len(), owned_bytes, escaped);
+    }
     Ok(TrackedStateKey {
         schema_key: key.schema_key.into_owned(),
         file_id: key.file_id.map(Cow::into_owned),

--- a/packages/lix/src/tracked_state/context.rs
+++ b/packages/lix/src/tracked_state/context.rs
@@ -1071,6 +1071,12 @@ where
         let materialization = ChangeRecordProjection::from_columns(&request.read_columns.columns);
         let durable_root = self.tree.load_root(&self.store, commit_id).await?;
         if request_has_exact_keys(&tree_request) || durable_root.is_some() {
+            #[cfg(feature = "storage-benches")]
+            if durable_root.is_some() {
+                crate::storage_bench::record_tracked_scan_durable_root();
+            } else {
+                crate::storage_bench::record_tracked_scan_exact_keys();
+            }
             let mut entries = self
                 .index_entries_from_exact_or_durable_root(
                     commit_id,
@@ -1088,6 +1094,8 @@ where
                 .await;
         }
 
+        #[cfg(feature = "storage-benches")]
+        crate::storage_bench::record_tracked_scan_rootless_replay();
         let replay = self
             .replay_index_batch_for_request_at_commit(commit_id, &tree_request)
             .await?;

--- a/packages/lix/src/tracked_state/row_materialization.rs
+++ b/packages/lix/src/tracked_state/row_materialization.rs
@@ -795,8 +795,12 @@ mod tests {
                     } else {
                         format!("row-{index}")
                     };
-                    let locale = if index == 0 { "keep" } else { "drop" };
-                    format!("('{id}', '{locale}')")
+                    // Distinct per row on purpose. `derive_entity_row_groups`
+                    // refuses the columnar layout when a non-key string column
+                    // has between 2 and 64 distinct values -- it clusters
+                    // instead -- so a two-valued flag column here silently
+                    // produces no columnar commit at all.
+                    format!("('{id}', 'loc-{index}')")
                 })
                 .collect::<Vec<_>>()
                 .join(",");
@@ -827,7 +831,10 @@ mod tests {
 
             let _ = crate::storage_bench::take_tracked_key_allocation_census();
             let rows = session
-                .execute(&format!("SELECT id FROM {schema_key} WHERE locale = 'keep'"), &[])
+                .execute(
+                    &format!("SELECT id FROM {schema_key} WHERE locale = 'loc-0'"),
+                    &[],
+                )
                 .await
                 .expect("the rotated scan must succeed, not reject its own payload");
             let census = crate::storage_bench::take_tracked_key_allocation_census();

--- a/packages/lix/src/tracked_state/row_materialization.rs
+++ b/packages/lix/src/tracked_state/row_materialization.rs
@@ -763,6 +763,14 @@ mod tests {
         // is why arm A asserts engagement rather than assuming it.
         const ROWS: usize = 32 * 1024;
 
+        // The census counters are process-global and the CI suite runs tests in
+        // parallel, so these assertions are thresholds against this test's own
+        // row count rather than equalities. Measured: inside the full suite the
+        // uuid arm read `columnar=2` from a concurrent test, which failed an
+        // `== 0` assertion while the isolated run read 0. A stray handful of
+        // rows cannot reach 32,768, so the thresholds stay decisive without
+        // being flaky.
+
         async fn run(schema_key: &str, uuid_pk: bool) -> (u64, u64, usize) {
             let storage = Memory::new();
             Engine::initialize(storage.clone())
@@ -856,9 +864,9 @@ mod tests {
         );
         assert_eq!(string_rows, 1, "the string-pk arm must answer one row");
         assert!(
-            string_columnar > 0,
-            "arm A must actually reach the columnar route, otherwise arm B's zero \
-             proves nothing (columnar={string_columnar} packed={string_packed})"
+            string_columnar >= ROWS as u64,
+            "arm A must actually reach the columnar route, otherwise arm B proves nothing \
+             (columnar={string_columnar} packed={string_packed})"
         );
 
         let (uuid_columnar, uuid_packed, uuid_rows) = run("coluuid", true).await;
@@ -869,14 +877,15 @@ mod tests {
             uuid_rows, 1,
             "the uuid-pk arm must answer one row -- a rejected payload would surface here"
         );
-        assert_eq!(
-            uuid_columnar, 0,
-            "a uuid primary key must never be served by the columnar route, whose \
-             identity match cannot round-trip it (columnar={uuid_columnar} packed={uuid_packed})"
+        assert!(
+            uuid_packed >= ROWS as u64,
+            "every row of the uuid arm must be fetched through the packed route \
+             (columnar={uuid_columnar} packed={uuid_packed})"
         );
         assert!(
-            uuid_packed > 0,
-            "the uuid arm must still have fetched payloads, through the packed route"
+            uuid_columnar < ROWS as u64,
+            "a uuid primary key must never be served by the columnar route, whose identity \
+             match cannot round-trip it (columnar={uuid_columnar} packed={uuid_packed})"
         );
     }
 

--- a/packages/lix/src/tracked_state/row_materialization.rs
+++ b/packages/lix/src/tracked_state/row_materialization.rs
@@ -851,6 +851,9 @@ mod tests {
         }
 
         let (string_columnar, string_packed, string_rows) = run("colstr", false).await;
+        println!(
+            "columnar_identity | string_pk columnar={string_columnar} packed={string_packed} rows={string_rows}"
+        );
         assert_eq!(string_rows, 1, "the string-pk arm must answer one row");
         assert!(
             string_columnar > 0,
@@ -859,6 +862,9 @@ mod tests {
         );
 
         let (uuid_columnar, uuid_packed, uuid_rows) = run("coluuid", true).await;
+        println!(
+            "columnar_identity | uuid_pk columnar={uuid_columnar} packed={uuid_packed} rows={uuid_rows}"
+        );
         assert_eq!(
             uuid_rows, 1,
             "the uuid-pk arm must answer one row -- a rejected payload would surface here"

--- a/packages/lix/src/tracked_state/row_materialization.rs
+++ b/packages/lix/src/tracked_state/row_materialization.rs
@@ -596,6 +596,130 @@ mod tests {
             .expect("one integer is a valid entity primary key")
     }
 
+    /// Which `EntityPk` shapes survive the JSON identity round trip that the
+    /// **columnar** commit-delta route uses to match a row.
+    ///
+    /// `materialize_index_payloads` re-checks `schema_key`/`file_id`/`entity_pk`
+    /// on every fetched row. On the packed route that check is
+    /// `decode(encode(K)) == K`, guaranteed by the byte-equality assert in
+    /// `find_commit_delta_entry_index`. The columnar route
+    /// (`load_columnar_owned_entries`) has no such assert: it matches on
+    /// `as_json_array_text` and rebuilds the identity with
+    /// `from_json_array_text`, and `untyped_component_from_json_value` maps
+    /// every JSON string back to `EntityPkComponent::String`.
+    ///
+    /// So `Uuid` and `Bytes` components do **not** survive, and on a route that
+    /// admitted them the re-check would reject a correctly-fetched row. This
+    /// test pins exactly where that boundary is; the companion test below pins
+    /// the gate that keeps those shapes off the columnar route entirely.
+    #[test]
+    fn only_string_and_integer_entity_pk_components_survive_the_json_identity_round_trip() {
+        fn round_trips(entity_pk: &EntityPk) -> bool {
+            let text = entity_pk
+                .as_json_array_text()
+                .expect("identity should encode as JSON");
+            let decoded =
+                EntityPk::from_json_array_text(&text).expect("identity should decode from JSON");
+            decoded == *entity_pk
+        }
+
+        let string_pk =
+            EntityPk::from_components(smallvec::smallvec![EntityPkComponent::String("row-0".into())])
+                .expect("one string is a valid entity primary key");
+        assert!(
+            round_trips(&string_pk),
+            "a single-string identity must survive; it is the only shape the columnar \
+             staging gate admits"
+        );
+
+        assert!(
+            round_trips(&integer_entity_pk(42)),
+            "an integer identity survives as a JSON number"
+        );
+
+        let composite = EntityPk::from_components(smallvec::smallvec![
+            EntityPkComponent::String("left".into()),
+            EntityPkComponent::String("right".into())
+        ])
+        .expect("two strings are a valid entity primary key");
+        assert!(round_trips(&composite), "composite strings survive");
+
+        let uuid_pk = EntityPk::from_components(smallvec::smallvec![EntityPkComponent::Uuid(
+            *uuid::Uuid::from_u128(7).as_bytes()
+        )])
+        .expect("one uuid is a valid entity primary key");
+        assert!(
+            !round_trips(&uuid_pk),
+            "a uuid identity must NOT survive the JSON round trip -- it returns as a \
+             String component. If this ever starts passing, the columnar identity \
+             re-check stops being load-bearing and this test should be re-read, not deleted."
+        );
+
+        let bytes_pk = EntityPk::from_components(smallvec::smallvec![EntityPkComponent::Bytes(
+            bytes::Bytes::from_static(&[1, 2, 3])
+        )])
+        .expect("one byte string is a valid entity primary key");
+        assert!(
+            !round_trips(&bytes_pk),
+            "a bytes identity must NOT survive the JSON round trip -- it returns as a \
+             base64 String component"
+        );
+    }
+
+    /// The gate that makes the above safe.
+    ///
+    /// `try_stage_lossless_columnar_mutations` refuses to stage a commit
+    /// columnar unless **every** row's identity passes
+    /// `EntityPk::as_single_string()`, which accepts exactly one
+    /// `EntityPkComponent::String`. That is the same predicate, asserted
+    /// directly: the shapes the JSON round trip loses are precisely the shapes
+    /// that can never reach the columnar route.
+    #[test]
+    fn the_columnar_staging_gate_rejects_every_identity_shape_the_json_round_trip_loses() {
+        let string_pk =
+            EntityPk::from_components(smallvec::smallvec![EntityPkComponent::String("row-0".into())])
+                .expect("one string is a valid entity primary key");
+        assert_eq!(
+            string_pk
+                .as_single_string()
+                .expect("a single string identity is columnar-eligible"),
+            "row-0"
+        );
+
+        let uuid_pk = EntityPk::from_components(smallvec::smallvec![EntityPkComponent::Uuid(
+            *uuid::Uuid::from_u128(7).as_bytes()
+        )])
+        .expect("one uuid is a valid entity primary key");
+        assert!(
+            uuid_pk.as_single_string().is_err(),
+            "a uuid identity must be refused by the columnar staging gate"
+        );
+
+        let bytes_pk = EntityPk::from_components(smallvec::smallvec![EntityPkComponent::Bytes(
+            bytes::Bytes::from_static(&[1, 2, 3])
+        )])
+        .expect("one byte string is a valid entity primary key");
+        assert!(
+            bytes_pk.as_single_string().is_err(),
+            "a bytes identity must be refused by the columnar staging gate"
+        );
+
+        assert!(
+            integer_entity_pk(42).as_single_string().is_err(),
+            "an integer identity is refused too, so the columnar route never sees one"
+        );
+
+        let composite = EntityPk::from_components(smallvec::smallvec![
+            EntityPkComponent::String("left".into()),
+            EntityPkComponent::String("right".into())
+        ])
+        .expect("two strings are a valid entity primary key");
+        assert!(
+            composite.as_single_string().is_err(),
+            "a composite identity is refused"
+        );
+    }
+
     fn index_value(index: usize) -> TrackedStateIndexValue {
         let timestamp = LixTimestamp::from_unix_millis_utc_lossy(1_700_000_000_000);
         TrackedStateIndexValue {
@@ -607,6 +731,135 @@ mod tests {
             created_at: timestamp,
             updated_at: timestamp,
         }
+    }
+
+    /// The constructed case for the columnar identity round trip.
+    ///
+    /// Arm A uses a single-string primary key, which the staging gate admits,
+    /// and asserts the columnar route actually served the rows. Without that
+    /// assertion arm B proves nothing: "no columnar rows" would be
+    /// indistinguishable from "the test never built a columnar commit".
+    ///
+    /// Arm B declares the same schema with `"format": "uuid"` on the primary
+    /// key, which makes the identity an `EntityPkComponent::Uuid` — the shape
+    /// that does not survive the JSON round trip. It must read back correctly
+    /// **and** never take the columnar route. If a future change widens the
+    /// staging gate, arm B's rows would be fetched through a JSON identity
+    /// match, the re-check in `materialize_index_payloads` would reject them,
+    /// and this test fails instead of the read failing in production.
+    #[cfg(feature = "storage-benches")]
+    #[tokio::test]
+    async fn a_uuid_primary_key_never_reaches_the_columnar_commit_delta_route() {
+        use crate::engine::Engine;
+        use crate::storage_adapter::Memory;
+        use serde_json::json;
+
+        const ROWS: usize = 250;
+
+        async fn run(schema_key: &str, uuid_pk: bool) -> (u64, u64, usize) {
+            let storage = Memory::new();
+            Engine::initialize(storage.clone())
+                .await
+                .expect("engine should initialize");
+            let engine = Engine::new(storage.clone())
+                .await
+                .expect("engine should open");
+            let session = engine.open_session().await.expect("session should open");
+
+            let mut id_property = json!({ "type": "string" });
+            if uuid_pk {
+                id_property["format"] = json!("uuid");
+            }
+            let schema = json!({
+                "x-lix-key": schema_key,
+                "x-lix-primary-key": ["/id"],
+                "type": "object",
+                "properties": { "id": id_property, "locale": { "type": "string" } },
+                "required": ["id", "locale"],
+                "additionalProperties": false
+            });
+            session
+                .execute(
+                    "INSERT INTO lix_registered_schema (value) VALUES (lix_json($1))",
+                    &[crate::Value::Text(schema.to_string())],
+                )
+                .await
+                .expect("schema should register");
+
+            // One dense multi-row INSERT: the shape the lossless columnar
+            // staging path is written for.
+            let values = (0..ROWS)
+                .map(|index| {
+                    let id = if uuid_pk {
+                        uuid::Uuid::from_u128(index as u128 + 1).to_string()
+                    } else {
+                        format!("row-{index}")
+                    };
+                    let locale = if index == 0 { "keep" } else { "drop" };
+                    format!("('{id}', '{locale}')")
+                })
+                .collect::<Vec<_>>()
+                .join(",");
+            session
+                .execute(
+                    &format!("INSERT INTO {schema_key} (id, locale) VALUES {values}"),
+                    &[],
+                )
+                .await
+                .expect("rows should insert");
+
+            // Rotate onto a branch so the read is served from a root current
+            // base and must fetch payloads from the owning commit delta.
+            let branch = session
+                .create_branch(crate::CreateBranchOptions {
+                    id: None,
+                    name: format!("e52-columnar-{schema_key}"),
+                    from_commit_id: None,
+                })
+                .await
+                .expect("branch should create");
+            session
+                .switch_branch(crate::SwitchBranchOptions {
+                    branch_id: branch.id.clone(),
+                })
+                .await
+                .expect("branch should switch");
+
+            let _ = crate::storage_bench::take_tracked_key_allocation_census();
+            let rows = session
+                .execute(&format!("SELECT id FROM {schema_key} WHERE locale = 'keep'"), &[])
+                .await
+                .expect("the rotated scan must succeed, not reject its own payload");
+            let census = crate::storage_bench::take_tracked_key_allocation_census();
+            (
+                census.commit_delta_columnar_rows,
+                census.commit_delta_rows_loaded,
+                rows.len(),
+            )
+        }
+
+        let (string_columnar, string_packed, string_rows) = run("colstr", false).await;
+        assert_eq!(string_rows, 1, "the string-pk arm must answer one row");
+        assert!(
+            string_columnar > 0,
+            "arm A must actually reach the columnar route, otherwise arm B's zero \
+             proves nothing (columnar={string_columnar} packed={string_packed})"
+        );
+
+        let (uuid_columnar, uuid_packed, uuid_rows) = run("coluuid", true).await;
+        assert_eq!(
+            uuid_rows, 1,
+            "the uuid-pk arm must answer one row -- a rejected payload would surface here"
+        );
+        assert_eq!(
+            uuid_columnar, 0,
+            "a uuid primary key must never be served by the columnar route, whose \
+             identity match cannot round-trip it (columnar={uuid_columnar} packed={uuid_packed})"
+        );
+        assert!(
+            uuid_packed > 0,
+            "the uuid arm must still have fetched payloads, through the packed route"
+        );
     }
 
     #[test]

--- a/packages/lix/src/tracked_state/row_materialization.rs
+++ b/packages/lix/src/tracked_state/row_materialization.rs
@@ -754,7 +754,14 @@ mod tests {
         use crate::storage_adapter::Memory;
         use serde_json::json;
 
-        const ROWS: usize = 250;
+        // The dense columnar lane is only taken by a *certified parameter
+        // batch* of at least `TYPED_CERTIFIED_INSERT_MIN_ROWS` (32,768) rows;
+        // below that `certified_entity_insert_parameter_batch` falls to the raw
+        // lane, which carries no encoded row groups, and
+        // `try_stage_lossless_columnar_mutations` then sees no dense write set.
+        // A smaller fixture silently produces no columnar commit at all, which
+        // is why arm A asserts engagement rather than assuming it.
+        const ROWS: usize = 32 * 1024;
 
         async fn run(schema_key: &str, uuid_pk: bool) -> (u64, u64, usize) {
             let storage = Memory::new();
@@ -786,31 +793,29 @@ mod tests {
                 .await
                 .expect("schema should register");
 
-            // One dense multi-row INSERT: the shape the lossless columnar
-            // staging path is written for.
-            let values = (0..ROWS)
-                .map(|index| {
-                    let id = if uuid_pk {
-                        uuid::Uuid::from_u128(index as u128 + 1).to_string()
-                    } else {
-                        format!("row-{index}")
-                    };
-                    // Distinct per row on purpose. `derive_entity_row_groups`
-                    // refuses the columnar layout when a non-key string column
-                    // has between 2 and 64 distinct values -- it clusters
-                    // instead -- so a two-valued flag column here silently
-                    // produces no columnar commit at all.
-                    format!("('{id}', 'loc-{index}')")
+            let sql = format!("INSERT INTO {schema_key} (id, locale) VALUES ($1, $2)");
+            let statements = (0..ROWS)
+                .map(|index| crate::session::ExecuteBatchStatement {
+                    label: None,
+                    sql: sql.clone(),
+                    params: vec![
+                        crate::Value::Text(if uuid_pk {
+                            uuid::Uuid::from_u128(index as u128 + 1).to_string()
+                        } else {
+                            format!("row-{index:07}")
+                        }),
+                        // Distinct per row: `derive_entity_row_groups` refuses
+                        // the columnar layout when a non-key string column has
+                        // 2..=64 distinct values, so a flag column here would
+                        // also silently defeat the fixture.
+                        crate::Value::Text(format!("loc-{index:07}")),
+                    ],
                 })
-                .collect::<Vec<_>>()
-                .join(",");
+                .collect::<Vec<_>>();
             session
-                .execute(
-                    &format!("INSERT INTO {schema_key} (id, locale) VALUES {values}"),
-                    &[],
-                )
+                .execute_batch(&statements)
                 .await
-                .expect("rows should insert");
+                .expect("the certified parameter batch should insert");
 
             // Rotate onto a branch so the read is served from a root current
             // base and must fetch payloads from the owning commit delta.
@@ -832,7 +837,7 @@ mod tests {
             let _ = crate::storage_bench::take_tracked_key_allocation_census();
             let rows = session
                 .execute(
-                    &format!("SELECT id FROM {schema_key} WHERE locale = 'loc-0'"),
+                    &format!("SELECT id FROM {schema_key} WHERE locale = 'loc-0000000'"),
                     &[],
                 )
                 .await

--- a/packages/lix/src/tracked_state/row_materialization.rs
+++ b/packages/lix/src/tracked_state/row_materialization.rs
@@ -386,6 +386,10 @@ where
 {
     let mut by_commit = BTreeMap::<CommitId, Vec<(TrackedStateKey, ChangeId, LixTimestamp)>>::new();
     for (key, value) in entries.filter(|(_, value)| !value.deleted) {
+        #[cfg(feature = "storage-benches")]
+        crate::storage_bench::record_materialize_owned_key(
+            key.schema_key.len() + key.file_id.map_or(0, str::len),
+        );
         by_commit.entry(value.commit_id).or_default().push((
             TrackedStateKey {
                 schema_key: key.schema_key.to_owned(),
@@ -414,6 +418,8 @@ where
                     ),
                 )
             })?;
+            #[cfg(feature = "storage-benches")]
+            crate::storage_bench::record_materialize_reverify_row();
             if record.change_id != change_id
                 || record.schema_key != key.schema_key
                 || record.file_id != key.file_id

--- a/packages/lix/src/tracked_state/storage.rs
+++ b/packages/lix/src/tracked_state/storage.rs
@@ -7694,16 +7694,15 @@ pub(crate) async fn load_commit_delta_change_records(
     commit_id: CommitId,
     keys: &[TrackedStateKey],
 ) -> Result<Vec<Option<crate::changelog::ChangeRecord>>, LixError> {
+    #[cfg(feature = "storage-benches")]
+    for key in keys {
+        crate::storage_bench::record_commit_delta_request_key_clone(
+            key.schema_key.len() + key.file_id.as_ref().map_or(0, String::len),
+        );
+    }
     let requests = keys
         .iter()
         .cloned()
-        .inspect(|key| {
-            #[cfg(feature = "storage-benches")]
-            crate::storage_bench::record_commit_delta_request_key_clone(
-                key.schema_key.len() + key.file_id.as_ref().map_or(0, String::len),
-            );
-            let _ = key;
-        })
         .map(|key| (commit_id, key))
         .collect::<Vec<_>>();
     Ok(load_owned_commit_delta_entries(store, &requests)

--- a/packages/lix/src/tracked_state/storage.rs
+++ b/packages/lix/src/tracked_state/storage.rs
@@ -7697,6 +7697,13 @@ pub(crate) async fn load_commit_delta_change_records(
     let requests = keys
         .iter()
         .cloned()
+        .inspect(|key| {
+            #[cfg(feature = "storage-benches")]
+            crate::storage_bench::record_commit_delta_request_key_clone(
+                key.schema_key.len() + key.file_id.as_ref().map_or(0, String::len),
+            );
+            let _ = key;
+        })
         .map(|key| (commit_id, key))
         .collect::<Vec<_>>();
     Ok(load_owned_commit_delta_entries(store, &requests)
@@ -12320,6 +12327,11 @@ fn find_loaded_commit_delta_entry<S>(
 where
     S: AsRef<[u8]>,
 {
+    // One encoded key reaches the search per point request, so counting it
+    // here counts the caller's per-row `encode_key_ref` without instrumenting
+    // eleven separate call sites.
+    #[cfg(feature = "storage-benches")]
+    crate::storage_bench::record_commit_delta_point_key_encode(target_key.len());
     let Some(index) = find_commit_delta_entry_index(leaf, target_key)? else {
         return Ok(None);
     };
@@ -12356,6 +12368,11 @@ where
         ));
     }
     let payload = payloads.decode(index)?;
+    // Inside the payload fetch, not above it: this is the row-granular site the
+    // profile attributed the cost to, and it is the one that re-proves an
+    // identity `find_commit_delta_entry_index` already asserted byte-equal.
+    #[cfg(feature = "storage-benches")]
+    crate::storage_bench::record_commit_delta_row_loaded(account_id.len());
     let key = decode_key(entry.key)?;
     let (snapshot, metadata, origin_key, base_coordinate, selected_ref) = match payload {
         CommitDeltaPayload::Authored(payload) => (

--- a/packages/lix/src/tracked_state/storage.rs
+++ b/packages/lix/src/tracked_state/storage.rs
@@ -7659,6 +7659,11 @@ async fn load_columnar_owned_entries(
                 .checked_add(1)
                 .ok_or_else(|| replacement_payload_error("columnar mutation address overflows"))?;
             let change_id = change_id_from_packed_address(commit_id, packed);
+            // The columnar route establishes identity by JSON text match, not
+            // by the byte-equality assert the packed route uses. Counted here
+            // so a test can prove which of the two served a row.
+            #[cfg(feature = "storage-benches")]
+            crate::storage_bench::record_commit_delta_columnar_row();
             output[output_index] = Some(LoadedCommitDeltaEntry {
                 value: TrackedStateIndexValue {
                     change_id,


### PR DESCRIPTION
# probe(tracked-state): census the per-row identity allocation on the commit-delta payload fetch

**Instrument + negative result. No engine behaviour changes.** Every line added is behind
`#[cfg(feature = "storage-benches")]` or `#[cfg(test)]`.

This was opened to decide whether to remove the per-row identity allocation on the rotated-generation
read path. **The census says no, and says why.** The measurement is the deliverable; the recommended
follow-on work is "none".

## What this adds

1. `storage_bench::take_tracked_key_allocation_census()` — a 14-field census counted **at the sites
   themselves**, not at a layer above them:
   - `codec::decode_key` calls, the encoded bytes they consume, the bytes `into_owned()` copies over
     what `decode_key_borrowed` already produced, and how many of those strings were escaped;
   - `load_commit_delta_entry_at_index` calls (the per-row payload fetch) and the per-row
     `account_id.to_string()`;
   - the per-row `encode_key_ref` reaching the binary search;
   - the request-vector key clone in `load_commit_delta_change_records`;
   - the owned `TrackedStateKey` that `materialize_index_payloads` builds from a key it already
     holds borrowed;
   - rows reaching the post-fetch identity re-verification.
2. `storage_bench::take_tracked_scan_branch_accounting()` — the three `scan_batch_at_commit` arm
   counters (`durable_root` / `exact_keys` / `rootless_replay`), carried over from
   `claude-6/e51-checkpoint-distance`. **"Which arm ran" is an instrument this campaign has needed
   repeatedly**, and it is what makes a zero census unambiguous between "nothing allocated" and "the
   lane never ran".
3. `commit_delta_columnar_rows` — counts rows served by `load_columnar_owned_entries`, the route
   that has **no** byte-equality assert. Counted apart from the packed route because a test about
   one of them proves nothing unless it can show which one ran.
4. `rotated_generation_key_allocation_census` (PHASE 8) — an `#[ignore]`d probe that drives a rotated
   collection scan and prints the census for the cold read and the warm reads separately.
5. Three ungated tests resolving the columnar identity round trip (see below).

## The finding

### The motivating profile predates the fix

The attribution that motivated this work — `find_loaded_commit_delta_entry` 8.03% inclusive,
`load_commit_delta_entry_at_index` 6.63%, `codec::decode_key` 6.72% — was recorded at **`49a4bf45a`**
with `LIX_TOMBSTONE_REPS=200`, i.e. 200 reads of one rotated generation.

`49a4bf45a` is **before** #1417, which added the root-base serving cache. On the integration head
that cache means read 1 materializes the serving view and reads 2..200 do not. The profile therefore
measured 200 payment events for a cost the head pays once.

`packages/lix/src/tracked_state/` is byte-identical between `b882b7a56` (the pre-cache base the
profile's tree descends from) and `c86c5cf0b` — so the payload-fetch code did not change. **What
changed is how many reads reach it**, which is exactly the thing a percentage from that profile
cannot express.

### The census, on the integration head

`hetzner-cpx62-II`, `HEAD=0eb42ae8e`, release, `--features storage-benches`.
Counts are deterministic — the full table reproduced **byte-for-byte** across two runs (only the
`us` column moved), so these are 1-rep numbers per the runbook.

Cold = first read of the rotated generation. Warm = the next 5 reads, aggregated.

| arm | n | phase | scans | rows | decodes | own_b | esc | acct_b | enc | clones | matkey | reverify | cache hit/miss | arm dur/exa/rep |
|---|---:|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---|---|
| main | 1000 | cold | 1 | 0 | 0 | 0 | 0 | 0 | 0 | 0 | 0 | 0 | 0/0 | 0/0/0 |
| main | 1000 | warm | 5 | 0 | 0 | 0 | 0 | 0 | 0 | 0 | 0 | 0 | 0/0 | 0/0/0 |
| rot | 1000 | cold | 1 | 1015 | 1025 | 9443 | 0 | 36540 | 1015 | 1015 | 1015 | 1015 | 1/2 | 0/0/3 |
| **rot** | **1000** | **warm** | **5** | **0** | **0** | **0** | **0** | **0** | **0** | **0** | **0** | **0** | **5/0** | **0/0/5** |
| rot | 100 | cold | 1 | 115 | 121 | 1307 | 0 | 4140 | 115 | 115 | 115 | 115 | 1/2 | 0/0/3 |
| rot | 100 | warm | 5 | 0 | 0 | 0 | 0 | 0 | 0 | 0 | 0 | 0 | 5/0 | 0/0/5 |
| rot | 10000 | cold | 1 | 10015 | 18097 | 163091 | 0 | 360540 | 10015 | 10015 | 10015 | 10015 | 1/2 | 0/0/3 |
| rot | 10000 | warm | 5 | 0 | 0 | 0 | 0 | 0 | 0 | 0 | 0 | 0 | 5/0 | 0/0/5 |
| rot | 260000 | cold | 1 | 260015 | 517597 | 4658591 | 0 | 9360540 | 260015 | 260015 | 260015 | 260015 | 1/2 | 0/0/3 |
| **rot** | **260000** | **warm** | **3** | **780000** | **1552734** | **13974606** | **0** | **28080000** | **780000** | **780000** | **780000** | **780000** | **0/3** | **0/0/6** |

**Two things fall out.**

**(a) The allocation is real, and it is exactly one per row.** On the cold read every per-row
counter is 1.000 per payload-fetch row, linear across three orders of magnitude (115 / 1015 / 10015
rows for n = 100 / 1000 / 10000). Per row, on that one read:

| site | per row | bytes/row |
|---|---:|---:|
| `encode_key_ref` reaching the binary search | 1.000 | 23.2 |
| request-vector key clone (`load_commit_delta_change_records`) | 1.000 | 9.18 |
| owned `TrackedStateKey` (`materialize_index_payloads`) | 1.000 | 9.18 |
| `decode_key` `into_owned()` copy | 1.010 decodes/row | 9.30 |
| `account_id.to_string()` | 1.000 | **36.0** |
| post-fetch identity re-verification | 1.000 | — |

≈ **87 bytes and ~5 allocations per row**, for an identity the caller already holds. `esc = 0`
everywhere, so none of the string copies is forced by an escape — all of them are borrowable in
principle.

Note the largest single stream is not the key decode at all. It is `account_id.to_string()` at 36
bytes/row — a UUID string re-allocated per row from a `&str` the caller already has — which is
nearly 4x the `decode_key` `into_owned()` copy the finding was aimed at.

**(b) Below the cache's admission cap, that read happens once per generation, not once per read.**
At n = 100 / 1000 / 10000 every warm counter is **zero**, with `cache hit/miss = 5/0`. The `main` arm
never touches the payload fetch at any size.

**(c) Above the cap, every read pays in full.** `ROOT_BASE_BATCH_CACHE_MAX_ROWS = 250_000`, and a
batch larger than that is **never admitted** (`hot.rs:4906`). At n = 260,000 the warm line shows
`cache hit/miss = 0/3` and `rows = 780000` for 3 scans — exactly 260,000 payload-fetch rows *per
read*, with every other counter scaling to match. The cache also holds at most
`ROOT_BASE_BATCH_CACHE_MAX_ENTRIES = 16` entries under LRU, so aggregate pressure can evict too;
I measured the row cap, not the entry cap.

So the cost the finding targets is a **once-per-rotated-generation** cost below 250k rows, and a
**per-read** cost above it. The regime boundary, not the per-row number, is the result.

### Recommendation: do not do the `ChangeRecord` refactor

`ChangeRecord` is `pub(crate)`: **31 construction sites, 28 files, 245 references**. It is
constructed in `transaction/commit.rs`, `session/merge/branch.rs`, `changelog/*`, `gc.rs`, `init.rs`,
`commit_graph/context.rs` and `hot_state/tracked_head/hot.rs` among others.

Borrowing is not available — the record is returned by value from an `async fn` and outlives the
decoded leaf arena — so the change would be `schema_key: String → SharedStr` (and `file_id`,
`account_id`). That is mechanically *feasible*: `DecodedLeafNodeRef` holds its `arena: Bytes`,
`codec::decode_key_shared` already exists and returns `SharedStr` fields, and
`SharedStr::from_utf8_slice` takes a zero-copy view of a `Bytes` with a pointer-containment check.

Below the cap that is a 28-file refactor of a core internal type to remove ~87 bytes/row on **one read
per branch**. Not a >10% improvement on any target metric, and not a cut that removes an authority or
an asymptotic term. **Recommended: no.**

Above the cap the allocation is live on every read — but it is still the wrong lever, and the same
census says so. At n = 260,000 the identity work is ~97 bytes and ~6 allocations per row (the decode
count rises to ~1.99 per row at that size, from ~1.01 at n = 1000, so a second `decode_key` site
joins in). Set against the measured gap between the rotated and non-rotated warm reads at that size —
~992 ms vs ~352 ms per scan, i.e. ~2.5 µs per row — a hundred bytes and six allocations is a small
single-digit fraction. That is consistent with the original profile's own 6.6%, and it means removing
**all** of the identity allocation still leaves ~90% of the rotated-read penalty in place.

The lever above the cap is the admission cap and the re-derivation it forces, not the allocation
inside it. That is `hot.rs` work, which another agent owns.

The one piece worth having on its own merits is `account_id.to_string()` — the biggest single stream
at 36 bytes/row, a one-line fix, and independent of the `ChangeRecord` shape. It is not in this PR
because below the cap it is paid once per generation and above the cap it is ~1/3 of a term that is
itself ~10% of the problem.

**Timing caveat.** The µs figures in this section are single-rep, taken from the probe's own output,
and are used only to size an order of magnitude. They are not an A/B, there is no null control, and
nothing here should be quoted as a speed claim.

## The columnar identity round trip — resolved, and it is NOT a bug

`materialize_index_payloads` re-checks `change_id`, `schema_key`, `file_id`, `entity_pk`,
`snapshot.is_none()` and `created_at` against the key the row was looked up by. The two commit-delta
routes establish identity by different means, so the check has to be reasoned about per route.

**Packed route — the comparison provably cannot fail.** `find_commit_delta_entry_index` returns
`Some(i)` only after `entry.key != target_key` fails, i.e. byte equality against
`encode_key_ref(K)`; the record's identity fields are then `decode_key(entry.key)`. So
`schema_key`/`file_id`/`entity_pk` compare `decode(encode(K))` against `K`. They test **codec
round-trip fidelity**, not data integrity.

**Columnar route — no byte-equality assert exists.** `load_columnar_owned_entries` matches on the
JSON identity text (`as_json_array_text`) and rebuilds the identity with `from_json_array_text`, and
`untyped_component_from_json_value` maps every JSON string back to `EntityPkComponent::String`. So a
`Uuid` or `Bytes` component would **not** survive, and the re-check would reject a correctly-fetched
row.

**The question that mattered: can such an identity reach that route?** Answered by construction, not
by argument. `try_stage_lossless_columnar_mutations` refuses to stage a commit columnar unless every
row's identity passes `EntityPk::as_single_string()`, which accepts **exactly one
`EntityPkComponent::String`** — precisely the shape that survives the round trip.

Three tests pin it, all in the CI-scope suite (none `#[ignore]`d):

1. `only_string_and_integer_entity_pk_components_survive_the_json_identity_round_trip` — the fidelity
   map: `String`, `Integer` and composite-string survive; `Uuid` and `Bytes` do not.
2. `the_columnar_staging_gate_rejects_every_identity_shape_the_json_round_trip_loses` — the gate
   predicate refuses `Uuid`, `Bytes`, `Integer` and composite identities.
3. `a_uuid_primary_key_never_reaches_the_columnar_commit_delta_route` — the constructed end-to-end
   case, measured:

| arm | columnar rows | packed rows | answer |
|---|---:|---:|---:|
| single-string pk | **32768** | 15 | 1 row |
| `"format": "uuid"` pk | **0** | 32783 | 1 row |

The uuid arm reads back correctly and never touches the columnar route. The string arm asserts
engagement, which is what makes the uuid arm's zero mean something — **the first two attempts at this
fixture reported `columnar=0` on *both* arms**, once because a two-valued non-key string column makes
`derive_entity_row_groups` cluster instead of encoding columnar, and once because the dense lane needs
a **certified parameter batch of ≥ 32,768 rows** (`TYPED_CERTIFIED_INSERT_MIN_ROWS`). Either fixture
would have produced a confident, vacuous pass.

One further correction found by the gate rather than by inspection: the first version of test 3
asserted `uuid_columnar == 0`, which passed in isolation and **failed inside the full parallel
suite at `columnar=2`**. The census counters are process-global, so an exact-zero assertion on them
is flaky by construction. The assertions are now thresholds against the test's own 32,768 rows —
arm A's rows went columnar, arm B's went packed and did not go columnar — which a stray handful of
concurrently-counted rows cannot reach.

**Verdict: no bug, no data loss, no dropped rows.** The comparison on the columnar route is
unreachable-by-construction rather than load-bearing, and on the packed route it cannot fail.

**No comparison is removed on either route.** The redundancy is real but the check is cheap, it is
the only thing that would catch a future widening of the staging gate, and test 3 now fails loudly if
that widening ever happens. Removing it would trade a free assertion for nothing measurable — on the
rotated lane it is 1.000 per row on the cold read and 0 on every warm read.

## Open edges

Stated rather than resolved:

- **The 16-entry LRU.** `ROOT_BASE_BATCH_CACHE_MAX_ENTRIES = 16` can evict a generation *below* the
  250k row cap under aggregate pressure. I measured the row cap only.
- **A second `decode_key` site at scale.** `decode_key` runs ~1.01x per payload-fetch row at
  n = 1000 but ~1.81x at n = 10000 and ~1.99x at n = 260000, so a second decoder joins as the batch
  grows. I did not identify it; it is outside the payload fetch this PR instruments.
- **`phase6` label reuse.** The probe file's PHASE 7 body prints a `phase6 |` prefix
  (`hot_row_tombstone_probe.rs`, pre-existing, from #1425). Not touched — renumbering another
  owner's phase is exactly the kind of edit-at-a-distance this file has already been bitten by.

## Layout invariants

1. **Single authority** — no. Counters only; no writer, no materialization, no index.
2. **Commit canonicality** — unaffected.
3. **Derived views are caches** — unaffected. This PR observes #1417's cache, it does not add one.
4. **Atomic publication** — unaffected; nothing is written.
5. **GC from refs** — unaffected.
6. **SQL reads canonical records** — unaffected.

## Breaking change: none

Argued from the bytes: **nothing is written**, so there is no byte for an older reader to read
differently. No on-disk format change, no encoding version bump, no space added or removed. No
observable behaviour change: every added statement is a `#[cfg(feature = "storage-benches")]`
`fetch_add` on a process-global `AtomicU64`, or lives in a `#[cfg(test)]` module. The two new `pub
fn`s are in `storage_bench`, which is itself `#[cfg(feature = "storage-benches")] pub mod`, so the
default public surface (`lib.rs` exports, SQL surface, JS SDK surface) is unchanged. No storage
adapter API was added, changed, or removed.

## Gate

Run on `hetzner-cpx62-II`. `CI_SCOPE_CONFIRMED_AT` re-derived from this SHA's `ci.yml`
(clippy at line 109; the two test commands at lines 143-145), not from the runbook.

```
GATE_HEAD=b65d4d6aa5eace50148b149a2a060834e84d4a1b
git status --porcelain          -> empty
CI_SCOPE_CONFIRMED_AT=b65d4d6aa5eace50148b149a2a060834e84d4a1b
EXECUTED_TARGETS test1=42 test2=22
```

`CLIPPY_RC=0`, `TEST1_RC=0` (3396 passed), `TEST2_RC=0` (164 passed), zero `test result: FAILED`,
zero `panicked at`, zero `fatal runtime`. `slatedb_history_blob_survives_until_final_root_release`
run by name: passed.

Re-gated in full after the columnar work, because it changed `storage.rs`, `storage_bench.rs` and
`row_materialization.rs`. The gate runs CI's exact commands, re-read from this SHA's `ci.yml`
(clippy at line 109; the two test commands at lines 154-155).

`slatedb_history_blob_survives_until_final_root_release` run by name — this PR adds no future frame
to any read or write path, but the canary aborts the process rather than failing a lane, so it is
run explicitly rather than assumed.

Also run, outside CI scope, because this PR references a `#[cfg]`-gated module from
tracked-state code: `cargo check -p lix --no-default-features` and
`cargo check -p lix_js_sdk --target wasm32-unknown-unknown`.

## Bench commands

```
LIX_TOMBSTONE_SIZES=100,1000,10000 LIX_TOMBSTONE_REPS=5 \
  <lix test bin> rotated_generation_key_allocation_census --ignored --nocapture --test-threads=1

LIX_TOMBSTONE_SIZES=260000 LIX_TOMBSTONE_REPS=3 \
  <lix test bin> rotated_generation_key_allocation_census --ignored --nocapture --test-threads=1
```

No A/B table and no null control: this PR makes **no timing claim**. The census is a count, it is
deterministic, and it reproduced byte-for-byte across two runs. The `us` column in the probe output
is context only — single-rep, unrotated, not an A/B, and it must not be read as one.
