### PR TITLE
fix(sql2): revoke the write-context pointer when its transaction is torn down

### DIFF
--- a/packages/lix/src/handle.rs
+++ b/packages/lix/src/handle.rs
@@ -111,6 +111,22 @@ where
 /// active branch, transaction exclusion, file-view state, and close
 /// lifecycle. Use [`Lix::open_session`] when an operation needs an independent
 /// session and lifecycle.
+///
+/// # Spawning a query onto a runtime
+///
+/// `tokio::spawn` on a future that contains [`Lix::execute`] can fail to
+/// compile with `overflow evaluating the requirement ...: Send`. The query
+/// futures nest deeply enough that proving the `Send` obligation exceeds
+/// rustc's default recursion limit. This is a compile-time limit, not a
+/// soundness problem, and the limit is per-crate — so it has to be raised in
+/// **your** crate, at the top of its root module:
+///
+/// ```ignore
+/// #![recursion_limit = "2048"]
+/// ```
+///
+/// Awaiting the query directly, or driving it with `futures::join!`, does not
+/// hit this.
 #[derive(Clone)]
 #[expect(missing_debug_implementations)]
 pub struct Lix<StorageImpl = Memory>

--- a/packages/lix/src/sql2/context.rs
+++ b/packages/lix/src/sql2/context.rs
@@ -169,6 +169,14 @@ pub(crate) trait SqlExecutionContext: Sync {
 #[async_trait]
 pub(crate) trait SqlWriteExecutionContext: Send {
     fn active_branch_id(&self) -> &str;
+    /// Revocation token for this context's borrow.
+    ///
+    /// The default hands back a token that is never retired, which is correct
+    /// for contexts that are not the engine `Transaction`: they own no borrow
+    /// that a `SqlWriteContext` can outlive.
+    fn write_context_liveness(&self) -> WriteContextLiveness {
+        WriteContextLiveness::new()
+    }
     fn datafusion_session(&self) -> datafusion::prelude::SessionContext {
         super::session::new_sql_session_context()
     }
@@ -314,12 +322,54 @@ pub(crate) trait SqlWriteExecutionContext: Send {
 pub(crate) struct SqlWriteContext {
     ptr: Arc<SqlWriteContextPtr>,
     gate: Arc<Mutex<()>>,
+    liveness: WriteContextLiveness,
     shared: Arc<SqlWriteContextShared>,
     explicit_insert_columns: Option<Arc<BTreeSet<String>>>,
     write_targets: Option<Arc<super::providers::WriteTargetRegistry>>,
 }
 
 struct SqlWriteContextPtr(NonNull<dyn SqlWriteExecutionContext>);
+
+/// Revocation token for the transaction context behind `SqlWriteContextPtr`.
+///
+/// `SqlWriteContext::new` forges a `'static` pointer out of a `&mut` borrow, and
+/// the borrow's real lifetime cannot be recovered by the type system (see the
+/// note on `SqlWriteContextPtr` below). This token is the runtime substitute:
+/// the borrowed `Transaction` flips it on teardown, and every gated
+/// dereference checks it first, so a pointer that outlives its pointee produces
+/// a deterministic `LixError` instead of undefined behaviour.
+///
+/// Measured before this existed: in one `cargo test -p lix -p lix_e2e` run,
+/// **249 distinct `Transaction` objects were destroyed while a
+/// `SqlWriteContext` still pointed at them** (116 with one live pointer, 49
+/// with two, one with 26). None of them was dereferenced afterwards, so this is
+/// hardening rather than a bug fix — but the safety of the whole construction
+/// rested on drop ordering that nothing enforced or tested.
+#[derive(Clone, Debug)]
+pub(crate) struct WriteContextLiveness(Arc<std::sync::atomic::AtomicBool>);
+
+impl WriteContextLiveness {
+    pub(crate) fn new() -> Self {
+        Self(Arc::new(std::sync::atomic::AtomicBool::new(true)))
+    }
+
+    /// Called when the borrowed context is torn down. Idempotent.
+    pub(crate) fn retire(&self) {
+        self.0.store(false, std::sync::atomic::Ordering::Release);
+    }
+
+    pub(crate) fn is_live(&self) -> bool {
+        self.0.load(std::sync::atomic::Ordering::Acquire)
+    }
+}
+
+impl Default for WriteContextLiveness {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+
 
 /// Values captured from the write execution context at construction time.
 ///
@@ -346,15 +396,56 @@ struct SqlWriteContextShared {
 }
 
 // DataFusion stores providers as owned Send + Sync trait objects. This context
-// is only constructed for one write execution and never outlives the borrowed
-// transaction context that owns it.
+// is only constructed for one write execution.
 //
-// SAFETY SCOPE: the pointer is now reached only by the gate-serialized methods
-// that reconstitute `&mut`. The shared accessors read `SqlWriteContextShared`
-// and never touch it, so no `&dyn` into the transaction context can be alive
-// while one of those `&mut` borrows is held.
+// SAFETY SCOPE: the pointer is reached only by the gate-serialized methods that
+// reconstitute `&mut`. The shared accessors read `SqlWriteContextShared` and
+// never touch it, so no `&dyn` into the transaction context can be alive while
+// one of those `&mut` borrows is held.
+//
+// LIFETIME: this context CAN outlive the borrowed transaction context. The
+// comment here used to claim it never did; that was false, and
+// `WriteContextLiveness` above carries the measurement. Every gated
+// dereference is therefore guarded at runtime.
+//
+// WHY THE LIFETIME IS FORGED, AND WHY IT CANNOT BE FIXED WITH A LIFETIME
+// PARAMETER. A `SqlWriteContext<'ctx>` cannot reach DataFusion at all:
+// `SessionContext::register_table` takes `Arc<dyn TableProvider>`, which is
+// `Arc<dyn TableProvider + 'static>`, and `TableProvider::as_any` returns
+// `&dyn Any` where `trait Any: 'static`. `ExecutionPlan` carries the same
+// `as_any` requirement. Both bounds are unconditional in the DataFusion
+// provider API, so the `'static` here is forced by that boundary rather than
+// chosen. That is precisely why the invariant is enforced at runtime by
+// `WriteContextLiveness` instead of by a lifetime: it is not expressible.
 unsafe impl Send for SqlWriteContextPtr {}
 unsafe impl Sync for SqlWriteContextPtr {}
+
+impl SqlWriteContext {
+    /// Refuses a dereference of a transaction context that has been torn down.
+    ///
+    /// Always compiled in: the whole point is to be present in the release
+    /// configuration where a dangling dereference would actually bite.
+    fn ensure_context_live(&self, site: &'static str) -> Result<(), LixError> {
+        if self.liveness.is_live() {
+            return Ok(());
+        }
+        Err(
+            LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                "SQL write context outlived the transaction it borrows; refusing to dereference a retired context",
+            )
+            .with_details(serde_json::json!({
+                "invariant": "SqlWriteContext must not outlive the Transaction it borrows",
+                "site": site,
+            })),
+        )
+    }
+
+    #[cfg(test)]
+    pub(crate) fn liveness_for_test(&self) -> &WriteContextLiveness {
+        &self.liveness
+    }
+}
 
 impl SqlWriteContext {
     pub(crate) fn new(ctx: &mut dyn SqlWriteExecutionContext) -> Self {
@@ -368,6 +459,7 @@ impl SqlWriteContext {
             plugin_host: ctx.plugin_host(),
             session_file_views: ctx.session_file_views(),
         });
+        let liveness = ctx.write_context_liveness();
         let ptr = NonNull::from(ctx);
         let ptr = unsafe {
             std::mem::transmute::<
@@ -378,6 +470,7 @@ impl SqlWriteContext {
         Self {
             ptr: Arc::new(SqlWriteContextPtr(ptr)),
             gate: Arc::new(Mutex::new(())),
+            liveness,
             shared,
             explicit_insert_columns: None,
             write_targets: Some(Arc::new(super::providers::WriteTargetRegistry::default())),
@@ -442,6 +535,7 @@ impl SqlWriteContext {
         request: &HotStateScanRequest,
     ) -> Result<MaterializedHotStateBatch, LixError> {
         let _guard = self.gate.lock().await;
+        self.ensure_context_live("scan_hot_state_batch")?;
         unsafe {
             self.ptr
                 .0
@@ -458,6 +552,7 @@ impl SqlWriteContext {
         request: &HotStateExactBatchRequest,
     ) -> Result<MaterializedHotStateExactBatch, LixError> {
         let _guard = self.gate.lock().await;
+        self.ensure_context_live("load_exact_hot_state_batch")?;
         unsafe {
             self.ptr
                 .0
@@ -474,6 +569,7 @@ impl SqlWriteContext {
         hashes: &[BlobId],
     ) -> Result<BlobBytesBatch, LixError> {
         let _guard = self.gate.lock().await;
+        self.ensure_context_live("load_bytes_many")?;
         unsafe {
             self.ptr
                 .0
@@ -490,6 +586,7 @@ impl SqlWriteContext {
         branch_id: &str,
     ) -> Result<Option<CommitId>, LixError> {
         let _guard = self.gate.lock().await;
+        self.ensure_context_live("load_branch_head")?;
         unsafe {
             self.ptr
                 .0
@@ -506,6 +603,7 @@ impl SqlWriteContext {
         request: &FilesystemPathIndexRequest,
     ) -> Result<Arc<FilesystemPathIndex>, LixError> {
         let _guard = self.gate.lock().await;
+        self.ensure_context_live("filesystem_path_index")?;
         unsafe {
             self.ptr
                 .0
@@ -522,6 +620,7 @@ impl SqlWriteContext {
         write: TransactionWrite,
     ) -> Result<TransactionWriteOutcome, LixError> {
         let _guard = self.gate.lock().await;
+        self.ensure_context_live("stage_write")?;
         unsafe {
             self.ptr
                 .0
@@ -539,6 +638,7 @@ impl SqlWriteContext {
         diff_ids: Vec<String>,
     ) -> Result<DiffCommandOutcome, LixError> {
         let _guard = self.gate.lock().await;
+        self.ensure_context_live("execute_diff_command")?;
         unsafe {
             self.ptr
                 .0

--- a/packages/lix/src/sql2/exec/datafusion.rs
+++ b/packages/lix/src/sql2/exec/datafusion.rs
@@ -4599,6 +4599,39 @@ mod tests {
         }
     }
 
+    /// The revocation guard refuses a retired write context instead of
+    /// dereferencing a pointer into a destroyed `Transaction`.
+    ///
+    /// The first half is load-bearing: it proves the guard is *reached* on this
+    /// path. Without it a green result could mean "never checked" rather than
+    /// "checked and live", which is exactly how a null instrument result lies.
+    #[tokio::test]
+    async fn retired_write_context_is_refused_instead_of_dereferenced() {
+        const BRANCH: &str = "01920000-0000-7000-8000-0000000000a1";
+        const REFUSAL: &str = "refusing to dereference a retired context";
+
+        let (mut ctx, _staged, _scans) = counting_write_context(vec![]);
+        let write_ctx = crate::sql2::SqlWriteContext::new(&mut ctx);
+
+        let live = write_ctx.load_branch_head(BRANCH).await;
+        assert!(
+            !format!("{live:?}").contains(REFUSAL),
+            "guard must not fire while the borrowed context is live: {live:?}"
+        );
+
+        // Exactly what `Transaction::drop` does.
+        write_ctx.liveness_for_test().retire();
+
+        let error = write_ctx
+            .load_branch_head(BRANCH)
+            .await
+            .expect_err("a retired write context must be refused");
+        assert!(
+            format!("{error:?}").contains(REFUSAL),
+            "retired context produced the wrong failure: {error:?}"
+        );
+    }
+
     fn counting_write_context(
         rows: Vec<MaterializedHotStateRow>,
     ) -> (

--- a/packages/lix/src/sql2/mod.rs
+++ b/packages/lix/src/sql2/mod.rs
@@ -46,6 +46,7 @@ pub(crate) use catalog::{
     entity_visible_fields,
 };
 pub(crate) use change_materialization::MaterializedChange;
+pub(crate) use context::WriteContextLiveness;
 pub(crate) use context::{
     CertifiedHistoryChange, CertifiedHistoryReader, ChangelogQuerySource, DiffCommand,
     DiffCommandOutcome, HistoryQuerySource, SqlChangelogQuerySource, SqlExecutionContext,

--- a/packages/lix/src/transaction/context.rs
+++ b/packages/lix/src/transaction/context.rs
@@ -517,7 +517,17 @@ fn record_transaction_path_index_build(descriptor_rows: usize) {
 /// that may write. Write-relevant reads must be exposed from this transaction,
 /// after the storage write transaction has begun, rather than from session-level
 /// helpers.
+/// Retires the write-context revocation token so any `SqlWriteContext` that
+/// outlives this transaction fails deterministically instead of dereferencing
+/// freed memory. See `sql2::WriteContextLiveness`.
+impl<StorageImpl: Storage + 'static> Drop for Transaction<StorageImpl> {
+    fn drop(&mut self) {
+        self.write_context_liveness.retire();
+    }
+}
+
 pub(crate) struct Transaction<StorageImpl: Storage + 'static = Memory> {
+    write_context_liveness: crate::sql2::WriteContextLiveness,
     active_branch_id: String,
     active_account_id: String,
     hot_state: Arc<HotStateContext>,
@@ -1623,6 +1633,7 @@ where
         Ok((
             OpenTransaction {
                 transaction: Self {
+                    write_context_liveness: crate::sql2::WriteContextLiveness::new(),
                     active_branch_id,
                     active_account_id,
                     hot_state,
@@ -9058,6 +9069,10 @@ impl<StorageImpl> SqlWriteExecutionContext for Transaction<StorageImpl>
 where
     StorageImpl: Storage + Clone + Send + Sync + 'static,
 {
+
+    fn write_context_liveness(&self) -> crate::sql2::WriteContextLiveness {
+        self.write_context_liveness.clone()
+    }
     fn active_branch_id(&self) -> &str {
         &self.active_branch_id
     }


### PR DESCRIPTION
# Revoke the write-context pointer when its transaction is torn down

Hardening for `SqlWriteContextPtr`, the last unsafe surface in the SQL write context. Also fixes a **false safety comment** and documents why the lifetime cannot be expressed in the type system.

## The problem

`SqlWriteContext::new` builds a `NonNull<dyn SqlWriteExecutionContext>` from a `&mut` borrow and `mem::transmute`s its lifetime to `'static`. The comment claimed this context "never outlives the borrowed transaction context that owns it".

**That claim was false.** Measured with a generation-keyed instrument over `cargo test -p lix` + `-p lix_e2e`:

- **249 distinct `Transaction` objects were destroyed while a `SqlWriteContext` still pointed at them.**
- Distribution of live pointers at the moment of death: 116 pointees with 1, 49 with 2, 24 with 3, 13 with 4, 10 with 5, a long tail, and **one with 26**.
- Only 93 distinct addresses were involved, so an address-keyed count merges distinct objects — the generation key is what makes 249 exact.

This is the normal shape of the write path, not an edge case.

**No use-after-free exists today.** A separate instrument marked each pointee dead on `Transaction::drop` and panicked if any of the 7 gated `as_mut()` sites dereferenced a retired pointee: **0 hits across 3312 passing tests / 34 targets.** The `SqlWriteContext` dies moments after its `Transaction`, in the same scope, and nothing touches it in between.

That null was verified rather than assumed: forcing the check to `if true` made 11 tests panic immediately at the check site, proving the check is reached on those paths.

So: the invariant is false, and the only thing standing between that and undefined behaviour is drop ordering that nothing enforces or tests. One `drop` moved earlier, or one `SqlWriteContext` parked a scope wider, converts 249 latent events into a UAF with nothing to catch it.

## The change

`WriteContextLiveness` — an `Arc<AtomicBool>` revocation token. `Transaction` owns one and retires it in `Drop`; `SqlWriteContext::new` captures a clone; each of the 7 gated methods checks it before dereferencing.

- **Atomic, not a map.** One `Acquire` load per gated call.
- **Always on.** Not `debug_assertions`-gated — the entire value is converting a silent UAF into a deterministic failure in the release configuration where it would actually bite.
- **`LixError`, not a panic.** All 7 gated methods already return `Result<_, LixError>`. The error is `LIX_INTERNAL_ERROR` with `details.invariant` and `details.site`, so an operator can tell this fired and which call site hit it.
- Defaulted trait method, so the test contexts that implement `SqlWriteExecutionContext` need no change; they get a token that is never retired, which is correct — they own no revocable borrow.

## Why this is runtime-checked rather than lifetime-checked

Recorded in the code, because it will otherwise be re-litigated. A `SqlWriteContext<'ctx>` **cannot reach DataFusion at all**:

- `SessionContext::register_table` takes `Arc<dyn TableProvider>`, which is `Arc<dyn TableProvider + 'static>`.
- `TableProvider::as_any` returns `&dyn Any`, and `trait Any: 'static`. `ExecutionPlan` carries the same `as_any` requirement.

Both bounds are unconditional in the DataFusion provider API. The `'static` is **forced by that boundary**, not chosen, so the invariant is not expressible as a lifetime and a runtime check is the only option.

## What the regression test asserts

`retired_write_context_is_refused_instead_of_dereferenced` pins **no-deref-after-death, not no-outlive**. Asserting that no `SqlWriteContext` outlives its `Transaction` would fail immediately, 249 times — that is the status quo and this PR does not change it.

The test has two halves, and the first is load-bearing: it asserts the guard does **not** fire while the context is live, which proves the check is reached on that path. Without it, a green result could mean "never checked" rather than "checked and live".

Beyond the unit test, the always-on guard turns the whole suite into the assertion: any dereference-after-death now returns an error and fails whatever test triggered it.

## Performance — and an honest negative

**The guard is not on any benchmarked lane.** Verified by inversion (forcing the guard to always fail, then running the lane and looking for refusals):

| Lane | Refusals with guard forced to fail |
|---|---|
| `tracked_state_crud/sql_session/lix_rocksdb/smoke/{update_one_by_pk,delete_one_by_pk}/1k` | 0 |
| `diff_commands` (full) | 0 |
| `working_diff_file_scope rocksdb 20 50 5 10 3` | 0 |

None of them calls the 7 gated methods. The guarded path is the DataFusion write-session path used by predicated `lix_file` writes, which the standard benchmark set does not cover — **a benchmark blind spot worth recording independently of this PR.**

The A/B below is therefore reported as **vacuous for the guard**, not as evidence that it is free:

| id | base median | cand median | delta |
|---|---|---|---|
| `sql_session/lix_rocksdb/smoke/update_one_by_pk/1k` | 366.24 µs | 364.71 µs | −0.42% |
| `sql_session/lix_rocksdb/smoke/delete_one_by_pk/1k` | 343.16 µs | 342.39 µs | −0.22% |

5 reps per arm, interleaved with rotated arm order, machine `ryzen-9950x-I`, base `e3e790728`. Base raw spread on `delete_one_by_pk` was 338.85–359.48 µs (**6.1%**), so anything under roughly ±6% is unresolvable on this lane; both deltas are far inside it.

Analytic cost where the guard *is* on the path: one `Acquire` load per gated call (5185 calls in a full suite run) and one `Arc<AtomicBool>` allocation per `SqlWriteContext::new` (1875 in a full suite run).

## Breaking change: no — argued

- `SqlWriteContext`, `SqlWriteContextPtr`, `WriteContextLiveness` and `SqlWriteExecutionContext` are all `pub(crate)`. Nothing here appears in `lib.rs` exports, the SQL surface, or the JS SDK surface.
- No on-disk format, key layout, or storage-space change. No storage adapter API change.
- The new trait method is **defaulted**, so no implementor requires modification.
- No public signature changes; the 7 gated methods already returned `Result<_, LixError>`.

The one thing that could surprise is the **new always-on error path**. It is reachable only in a state that is currently unreachable — 0 dereferences-after-death across 3312 tests — and in that state the alternative is undefined behaviour. `LIX_INTERNAL_ERROR` is an existing code, so no new public constant is introduced.

## Also included

Crate docs on `Lix` for a user-facing sharp edge reproduced twice during this work: `tokio::spawn` on a future containing `Lix::execute` fails to compile with `overflow evaluating the requirement ...: Send`. The query futures nest deeply enough to exceed rustc's default recursion limit. The limit is per-crate, so the fix has to be `#![recursion_limit = "2048"]` in the **user's** crate — which makes documenting it the whole obligation.

## Gate

```
GATE_HEAD=7273b9c736f168c7791bf9c60442a2601206fbd6
GATE_STATUS: (empty)
CI_SCOPE_CONFIRMED_AT=e3e790728c403e2b74f43609b1c79733a3d6e66c
EXECUTED_TARGETS=65; 3558 passed, 0 failed
```

`cargo clippy --profile test --workspace --all-targets --all-features -- -D warnings`, `cargo test --profile test --workspace --exclude lix_e2e --all-features --no-fail-fast`, `cargo test --profile test -p lix_e2e --features sdk-tests,storage-benches,slatedb,root-replay-trace --no-fail-fast`, and `cargo check -p lix --no-default-features` all green.

Stack-overflow canary `slatedb_history_blob_survives_until_final_root_release` ran and passed; zero occurrences of "stack overflow" in the gate log.

## Layout invariants

1. **Single authority** — no new authority for any fact; the token is a liveness flag, not data.
2. **Commit canonicality** — untouched.
3. **Derived views are caches** — untouched.
4. **Atomic publication** — untouched.
5. **GC from refs** — untouched.
6. **SQL reads canonical records** — untouched.
