### PR TITLE
perf(hot-state): recover created_at from canonical, and fix the lints that blocked the gate

### DIFF
--- a/packages/lix/src/hot_row_tombstone_probe.rs
+++ b/packages/lix/src/hot_row_tombstone_probe.rs
@@ -1240,6 +1240,9 @@ fn print_census_line(arm: &str, n: usize, phase: &str, scans: usize, us: u128) {
         c.materialize_owned_key_builds,
         c.materialize_owned_key_bytes,
         c.materialize_reverify_rows,
+    );
+}
+
 /// Reads back the `created_at` the engine currently reports for one identity.
 async fn created_at_of(session: &SessionContext<Memory>, table: &str, id: &str) -> String {
     let result = session
@@ -1254,7 +1257,10 @@ async fn created_at_of(session: &SessionContext<Memory>, table: &str, id: &str) 
         .expect("created_at is text")
 }
 
-/// PHASE 8 — the `created_at` consequence of compaction, and who rejects it.
+/// PHASE 9 — the `created_at` consequence of compaction, and who rejects it.
+///
+/// Numbered 9 because #1427 landed its own PHASE 8 (the allocation census)
+/// on the integration branch while this work was in flight.
 ///
 /// Phase 4 established that removing an already-checkpointed delete's tombstone
 /// is safe for *serving*. This phase asks the separate write-path question the

--- a/packages/lix/src/hot_row_tombstone_probe.rs
+++ b/packages/lix/src/hot_row_tombstone_probe.rs
@@ -1360,6 +1360,12 @@ async fn recreated_identity_created_at_after_compaction() {
     assert!(removed > 0, "the delete must have left a tombstone to remove");
 
     let session = reopen_session(&storage).await;
+    let hits_before = crate::hot_state::BROAD_CANONICAL_CREATED_AT_HITS
+        .load(std::sync::atomic::Ordering::Relaxed);
+    let keys_before = crate::hot_state::BROAD_CANONICAL_CREATED_AT_KEYS
+        .load(std::sync::atomic::Ordering::Relaxed);
+    let lookups_before = crate::hot_state::BROAD_CANONICAL_CREATED_AT_LOOKUPS
+        .load(std::sync::atomic::Ordering::Relaxed);
     session
         .execute(
             "INSERT INTO c8row (id, locale) VALUES ('row-0', 'second')",
@@ -1367,13 +1373,35 @@ async fn recreated_identity_created_at_after_compaction() {
         )
         .await
         .expect("re-insert should commit");
+    let hits = crate::hot_state::BROAD_CANONICAL_CREATED_AT_HITS
+        .load(std::sync::atomic::Ordering::Relaxed)
+        - hits_before;
+    let keys = crate::hot_state::BROAD_CANONICAL_CREATED_AT_KEYS
+        .load(std::sync::atomic::Ordering::Relaxed)
+        - keys_before;
+    let lookups = crate::hot_state::BROAD_CANONICAL_CREATED_AT_LOOKUPS
+        .load(std::sync::atomic::Ordering::Relaxed)
+        - lookups_before;
     let second = created_at_of(&session, "c8row", "row-0").await;
     println!(
         "phase8 | arm=compacted first_created_at={first} second_created_at={second} \
-         inherited={}",
+         inherited={} lookups={lookups} keys={keys} hits={hits}",
         first == second
     );
     drop(session);
+
+    // Engagement, counted inside the route rather than inferred from a timing
+    // result. A hit proves the recovery fired; the run below proves it can
+    // also miss, so the route is not trivially returning a constant.
+    assert!(lookups > 0, "the canonical lookup must have run");
+    assert!(
+        hits > 0,
+        "the re-insert over a compacted identity must have inherited from canonical"
+    );
+    assert_eq!(
+        second, first,
+        "canonical must supply the created_at the compacted tombstone used to carry"
+    );
 
     // `validate_diff_row_created_at` derives its expectation from the parent
     // commit's canonical tracked-state index value and never inspects
@@ -1406,5 +1434,43 @@ async fn recreated_identity_created_at_after_compaction() {
         "phase8 | verdict inherited={} rebuild_ok={} created_at_validations={validations}",
         first == second,
         rebuild.is_ok()
+    );
+}
+
+/// The miss side of the same route. A commit that introduces genuinely new
+/// identities submits keys to the canonical lookup and must come back empty —
+/// a route that only ever hits would be inheriting timestamps for rows that
+/// have no canonical ancestor, which is the failure this pairs against.
+#[tokio::test]
+async fn broad_canonical_created_at_recovery_misses_for_new_identities() {
+    let (_storage, session) = open_session().await;
+    register(&session, probe_schema("c8new")).await;
+
+    let keys_before = crate::hot_state::BROAD_CANONICAL_CREATED_AT_KEYS
+        .load(std::sync::atomic::Ordering::Relaxed);
+    let hits_before = crate::hot_state::BROAD_CANONICAL_CREATED_AT_HITS
+        .load(std::sync::atomic::Ordering::Relaxed);
+    session
+        .execute(
+            "INSERT INTO c8new (id, locale) VALUES ('new-0', 'a'), ('new-1', 'b')",
+            &[],
+        )
+        .await
+        .expect("new rows should commit");
+    let keys = crate::hot_state::BROAD_CANONICAL_CREATED_AT_KEYS
+        .load(std::sync::atomic::Ordering::Relaxed)
+        - keys_before;
+    let hits = crate::hot_state::BROAD_CANONICAL_CREATED_AT_HITS
+        .load(std::sync::atomic::Ordering::Relaxed)
+        - hits_before;
+
+    println!("phase8 | arm=new_identities keys={keys} hits={hits}");
+    assert!(
+        keys >= 2,
+        "both new identities must reach the canonical lookup"
+    );
+    assert_eq!(
+        hits, 0,
+        "a genuinely new identity has no canonical ancestor to inherit from"
     );
 }

--- a/packages/lix/src/hot_row_tombstone_probe.rs
+++ b/packages/lix/src/hot_row_tombstone_probe.rs
@@ -1385,7 +1385,15 @@ async fn recreated_identity_created_at_after_compaction() {
     let engine = Engine::new(storage.clone())
         .await
         .expect("engine should reopen for rebuild");
+    // An instrument that never executes reports exactly what a clean pass
+    // reports. Count the validator's entries across the rebuild so "accepted"
+    // cannot be confused with "never reached".
+    let validations_before = crate::tracked_state::DIFF_ROW_CREATED_AT_VALIDATIONS
+        .load(std::sync::atomic::Ordering::Relaxed);
     let rebuild = engine.rebuild_tracked_state_for_branch(&branch_id).await;
+    let validations = crate::tracked_state::DIFF_ROW_CREATED_AT_VALIDATIONS
+        .load(std::sync::atomic::Ordering::Relaxed)
+        - validations_before;
     match &rebuild {
         Ok(()) => println!("phase8 | arm=compacted rebuild=accepted"),
         Err(error) => println!(
@@ -1395,7 +1403,7 @@ async fn recreated_identity_created_at_after_compaction() {
     }
 
     println!(
-        "phase8 | verdict inherited={} rebuild_ok={}",
+        "phase8 | verdict inherited={} rebuild_ok={} created_at_validations={validations}",
         first == second,
         rebuild.is_ok()
     );

--- a/packages/lix/src/hot_row_tombstone_probe.rs
+++ b/packages/lix/src/hot_row_tombstone_probe.rs
@@ -1240,5 +1240,163 @@ fn print_census_line(arm: &str, n: usize, phase: &str, scans: usize, us: u128) {
         c.materialize_owned_key_builds,
         c.materialize_owned_key_bytes,
         c.materialize_reverify_rows,
+/// Reads back the `created_at` the engine currently reports for one identity.
+async fn created_at_of(session: &SessionContext<Memory>, table: &str, id: &str) -> String {
+    let result = session
+        .execute(
+            &format!("SELECT lixcol_created_at AS created_at FROM {table} WHERE id = '{id}'"),
+            &[],
+        )
+        .await
+        .expect("created_at reads");
+    result.rows()[0]
+        .get::<String>("created_at")
+        .expect("created_at is text")
+}
+
+/// PHASE 8 — the `created_at` consequence of compaction, and who rejects it.
+///
+/// Phase 4 established that removing an already-checkpointed delete's tombstone
+/// is safe for *serving*. This phase asks the separate write-path question the
+/// compaction design turns on: once the tombstone is gone, what `created_at`
+/// does a later re-insert of that identity receive, and does anything reject
+/// the result?
+///
+/// Today `created_at` reaches a re-inserted row by a two-hop chain — a delete
+/// copies the live row's `created_at` into the tombstone, and a re-insert
+/// copies the tombstone's forward. Compaction removes the middle hop.
+/// Canonical tracked state still retains the original `created_at` for the
+/// deleted identity, on a plane compaction never touches, so the value is
+/// recoverable. The question is whether the engine recovers it unaided.
+///
+/// The control arm runs the same sequence with the tombstone left in place, so
+/// any difference is attributable to its removal and nothing else.
+#[tokio::test]
+async fn recreated_identity_created_at_without_compaction() {
+    let (_storage, session) = open_session().await;
+    register(&session, probe_schema("c8row")).await;
+
+    session
+        .execute("INSERT INTO c8row (id, locale) VALUES ('row-0', 'first')", &[])
+        .await
+        .expect("first insert should commit");
+    let first = created_at_of(&session, "c8row", "row-0").await;
+
+    session
+        .execute("DELETE FROM c8row WHERE id = 'row-0'", &[])
+        .await
+        .expect("delete should commit");
+    session
+        .create_checkpoint()
+        .await
+        .expect("checkpoint should publish");
+    session
+        .execute(
+            "INSERT INTO c8row (id, locale) VALUES ('row-0', 'second')",
+            &[],
+        )
+        .await
+        .expect("re-insert should commit");
+    let second = created_at_of(&session, "c8row", "row-0").await;
+
+    println!(
+        "phase8 | arm=control first_created_at={first} second_created_at={second} \
+         inherited={}",
+        first == second
+    );
+
+    // This is the behaviour compaction must preserve. It is asserted rather
+    // than merely printed because it is the regression guard for the
+    // canonical-sourced `created_at` that compaction requires: if that
+    // sourcing silently stops firing, this is the assertion that catches it.
+    assert_eq!(
+        second, first,
+        "a re-inserted identity inherits its deleted predecessor's created_at"
+    );
+}
+
+/// The compaction arm of phase 8. Simulates compaction with the same physical
+/// tombstone removal phases 4 and 7 use, then re-inserts and asks the engine
+/// what it thinks the identity's `created_at` is — and whether a commit-root
+/// rebuild, which is where `validate_diff_row_created_at` runs in production,
+/// still accepts the result.
+#[tokio::test]
+async fn recreated_identity_created_at_after_compaction() {
+    let (storage, session) = open_session().await;
+    register(&session, probe_schema("c8row")).await;
+    let branch_id = session
+        .active_branch_id()
+        .await
+        .expect("active branch id reads");
+
+    session
+        .execute("INSERT INTO c8row (id, locale) VALUES ('row-0', 'first')", &[])
+        .await
+        .expect("first insert should commit");
+    let first = created_at_of(&session, "c8row", "row-0").await;
+
+    session
+        .execute("DELETE FROM c8row WHERE id = 'row-0'", &[])
+        .await
+        .expect("delete should commit");
+    // Compaction is a checkpoint-time operation, and the checkpoint is what
+    // discharges the delete's working-diff obligation and commits it to
+    // canonical state. Removing the tombstone before that point would be
+    // testing an operation the design never performs.
+    session
+        .create_checkpoint()
+        .await
+        .expect("checkpoint should publish");
+    drop(session);
+
+    let before = row_census(&storage).await;
+    let removed = drop_all_tombstones(&storage).await;
+    let after = row_census(&storage).await;
+    println!(
+        "phase8 | arm=compacted tombstones_removed={removed} \
+         entries {}->{} tombstones {}->{}",
+        before.entries, after.entries, before.tombstones, after.tombstones
+    );
+    assert!(removed > 0, "the delete must have left a tombstone to remove");
+
+    let session = reopen_session(&storage).await;
+    session
+        .execute(
+            "INSERT INTO c8row (id, locale) VALUES ('row-0', 'second')",
+            &[],
+        )
+        .await
+        .expect("re-insert should commit");
+    let second = created_at_of(&session, "c8row", "row-0").await;
+    println!(
+        "phase8 | arm=compacted first_created_at={first} second_created_at={second} \
+         inherited={}",
+        first == second
+    );
+    drop(session);
+
+    // `validate_diff_row_created_at` derives its expectation from the parent
+    // commit's canonical tracked-state index value and never inspects
+    // `deleted`, so a tombstoned ancestor still supplies a `created_at` it
+    // will insist on. In production that validator runs behind
+    // `Engine::rebuild_tracked_state_for_branch`, which means a mismatch is
+    // latent: it is written silently and only surfaces when a rebuild or
+    // repair is performed.
+    let engine = Engine::new(storage.clone())
+        .await
+        .expect("engine should reopen for rebuild");
+    let rebuild = engine.rebuild_tracked_state_for_branch(&branch_id).await;
+    match &rebuild {
+        Ok(()) => println!("phase8 | arm=compacted rebuild=accepted"),
+        Err(error) => println!(
+            "phase8 | arm=compacted rebuild=REJECTED {}",
+            error.to_string().replace('\n', " ")
+        ),
+    }
+
+    println!(
+        "phase8 | verdict inherited={} rebuild_ok={}",
+        first == second,
+        rebuild.is_ok()
     );
 }

--- a/packages/lix/src/hot_row_tombstone_probe.rs
+++ b/packages/lix/src/hot_row_tombstone_probe.rs
@@ -1280,6 +1280,12 @@ async fn recreated_identity_created_at_without_compaction() {
         .execute("INSERT INTO c8row (id, locale) VALUES ('row-0', 'first')", &[])
         .await
         .expect("first insert should commit");
+    // Mirrors the compacted arm's shape exactly, so the only difference
+    // between the two is whether the tombstone survives.
+    session
+        .create_checkpoint()
+        .await
+        .expect("baseline checkpoint should publish");
     let first = created_at_of(&session, "c8row", "row-0").await;
 
     session
@@ -1333,6 +1339,17 @@ async fn recreated_identity_created_at_after_compaction() {
         .execute("INSERT INTO c8row (id, locale) VALUES ('row-0', 'first')", &[])
         .await
         .expect("first insert should commit");
+    // The insert has to be checkpointed before the delete, or the two cancel
+    // within one checkpoint interval and canonical records the identity as
+    // never having existed. In that case a fresh `created_at` on re-insert is
+    // the correct answer and there is nothing to recover — measured: the
+    // lookup fires with the right key and canonical returns nothing. The
+    // interesting case, and the one compaction actually creates, is a delete
+    // whose *insert* is already canonical.
+    session
+        .create_checkpoint()
+        .await
+        .expect("baseline checkpoint should publish");
     let first = created_at_of(&session, "c8row", "row-0").await;
 
     session

--- a/packages/lix/src/hot_state/mod.rs
+++ b/packages/lix/src/hot_state/mod.rs
@@ -38,6 +38,11 @@ pub(crate) use tracked_head::hot_generation_scope_prefix;
 #[cfg(test)]
 pub(crate) use tracked_head::stage_collect_stale_working_diff_indexes;
 pub(crate) use tracked_head::stage_retire_hot_generation;
+#[cfg(any(test, feature = "storage-benches"))]
+pub(crate) use tracked_head::{
+    BROAD_CANONICAL_CREATED_AT_HITS, BROAD_CANONICAL_CREATED_AT_KEYS,
+    BROAD_CANONICAL_CREATED_AT_LOOKUPS,
+};
 #[allow(unused_imports)]
 pub(crate) use tracked_head::{
     CERTIFIED_ENTITY_BATCH_MANIFEST_SPACE, CERTIFIED_ENTITY_BATCH_PAGE_SPACE,

--- a/packages/lix/src/hot_state/mod.rs
+++ b/packages/lix/src/hot_state/mod.rs
@@ -38,7 +38,14 @@ pub(crate) use tracked_head::hot_generation_scope_prefix;
 #[cfg(test)]
 pub(crate) use tracked_head::stage_collect_stale_working_diff_indexes;
 pub(crate) use tracked_head::stage_retire_hot_generation;
+// Read only by `#[cfg(test)]` probes, so a features-on *library* build compiles
+// the counters and re-exports them without any in-crate reader. `cargo test`
+// cannot see that — under `--profile test` the probe module exists and the
+// imports are used — so this surfaces only as a `clippy --all-targets` failure
+// on the non-test lib. Matches the `#[allow(unused_imports)]` on the re-export
+// block directly below, which exists for the same reason.
 #[cfg(any(test, feature = "storage-benches"))]
+#[allow(unused_imports)]
 pub(crate) use tracked_head::{
     BROAD_CANONICAL_CREATED_AT_HITS, BROAD_CANONICAL_CREATED_AT_KEYS,
     BROAD_CANONICAL_CREATED_AT_LOOKUPS,

--- a/packages/lix/src/hot_state/tracked_head.rs
+++ b/packages/lix/src/hot_state/tracked_head.rs
@@ -12,6 +12,11 @@ mod hot;
 pub(crate) use hot::hot_decode_entity_pk_probe;
 
 pub(crate) use crate::hot_state::HotStateReadDomain;
+#[cfg(any(test, feature = "storage-benches"))]
+pub(crate) use hot::{
+    BROAD_CANONICAL_CREATED_AT_HITS, BROAD_CANONICAL_CREATED_AT_KEYS,
+    BROAD_CANONICAL_CREATED_AT_LOOKUPS,
+};
 #[cfg(test)]
 pub(crate) use hot::WORKING_DIFF_PATH_HITS;
 #[cfg(test)]

--- a/packages/lix/src/hot_state/tracked_head/hot.rs
+++ b/packages/lix/src/hot_state/tracked_head/hot.rs
@@ -91,6 +91,24 @@ pub(crate) const COLLECTION_CONTROL_SPACE: StorageSpace = StorageSpace::declare(
     COLLECTION_CONTROL_NAMESPACE,
     ValueSemantics::Mutable,
 );
+
+/// Engagement counters for the canonical `created_at` recovery that shares the
+/// retention fence's batch.
+///
+/// These sit *inside* the route they measure: `LOOKUPS` counts commits that
+/// submitted a non-empty key list, `KEYS` the identities submitted, and `HITS`
+/// the inheritances actually applied. A timing instrument one layer up cannot
+/// distinguish "the recovery is free" from "the recovery never ran", so the
+/// counts are read directly rather than inferred from a flat measurement.
+#[cfg(any(test, feature = "storage-benches"))]
+pub(crate) static BROAD_CANONICAL_CREATED_AT_LOOKUPS: std::sync::atomic::AtomicU64 =
+    std::sync::atomic::AtomicU64::new(0);
+#[cfg(any(test, feature = "storage-benches"))]
+pub(crate) static BROAD_CANONICAL_CREATED_AT_KEYS: std::sync::atomic::AtomicU64 =
+    std::sync::atomic::AtomicU64::new(0);
+#[cfg(any(test, feature = "storage-benches"))]
+pub(crate) static BROAD_CANONICAL_CREATED_AT_HITS: std::sync::atomic::AtomicU64 =
+    std::sync::atomic::AtomicU64::new(0);
 /// Generation-local immutable current-state bases.
 ///
 /// Each tiny record points at one already-authored packed commit delta. Fresh
@@ -8071,7 +8089,15 @@ where
         // so checkpoint-expanded tombstones do not decrement the freshly reset
         // live count.
         apply_incremental_collection_generation_deltas(&mut collection_controls, &sorted)?;
-        for (delta, previous) in sorted.iter().zip(&mut previous_values) {
+        // A predecessor nulled here is absent for a reason that has nothing to
+        // do with a missing serving row: its generation was retired. Canonical
+        // state still holds that identity, so a canonical `created_at` lookup
+        // would happily resolve it and silently change the timestamp a
+        // re-insert after a generation retirement reports today. Remember which
+        // slots were nulled for that reason so the lookup below can exclude
+        // them. This is transaction-local and durably stores nothing.
+        let mut retired_predecessor = vec![false; previous_values.len()];
+        for (index, (delta, previous)) in sorted.iter().zip(&mut previous_values).enumerate() {
             if delta.schema_key == crate::collection_generation::COLLECTION_GENERATION_SCHEMA_KEY {
                 continue;
             }
@@ -8091,6 +8117,7 @@ where
                 });
             if belongs_to_retired_generation {
                 *previous = None;
+                retired_predecessor[index] = true;
             }
         }
         // Narrowed retention fence.
@@ -8110,19 +8137,43 @@ where
         // insert. Cost is bounded to commits that actually contain an
         // untracked write with an unresolvable predecessor; every other commit
         // builds an empty key list and performs no additional I/O.
+        // The same batch answers a second question. A tracked insert whose
+        // predecessor is absent is either a genuinely new identity — canonical
+        // holds nothing, the lookup misses, and `delta.created_at` stands — or
+        // an identity whose serving-view predecessor is gone while canonical
+        // still carries its `created_at`. Serving-layer tombstone compaction
+        // creates exactly the second case, and nothing else in the engine
+        // rejects the fresh timestamp that would otherwise be minted, so the
+        // recovery has to happen here.
+        //
+        // This rides the retention fence's existing read: same commit, same
+        // key list, same `identity_only` projection. `created_at` is a
+        // descriptor column rather than a change-record payload, so it is
+        // already materialized and the projection does not widen. What does
+        // change is how often the block runs: the untracked-only filter left
+        // it empty on ordinary tracked inserts, and it now executes whenever a
+        // commit introduces a new identity.
+        let mut canonical_created_ats: Vec<Option<crate::common::LixTimestamp>> = Vec::new();
         {
-            let unresolved = sorted
-                .iter()
-                .zip(&previous_values)
-                .filter(|(delta, previous)| {
-                    delta.untracked && !delta.deleted && previous.is_none()
-                })
-                .map(|(delta, _)| TrackedStateKeyRef {
+            let mut unresolved = Vec::new();
+            let mut unresolved_slots = Vec::new();
+            for (index, (delta, previous)) in sorted.iter().zip(&previous_values).enumerate() {
+                if delta.deleted || previous.is_some() || retired_predecessor[index] {
+                    continue;
+                }
+                unresolved.push(TrackedStateKeyRef {
                     schema_key: delta.schema_key,
                     file_id: delta.file_id,
                     entity_pk: delta.entity_pk,
-                })
-                .collect::<Vec<_>>();
+                });
+                unresolved_slots.push((index, delta.untracked));
+            }
+            #[cfg(any(test, feature = "storage-benches"))]
+            if !unresolved.is_empty() {
+                BROAD_CANONICAL_CREATED_AT_LOOKUPS.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                BROAD_CANONICAL_CREATED_AT_KEYS
+                    .fetch_add(unresolved.len() as u64, std::sync::atomic::Ordering::Relaxed);
+            }
             if !unresolved.is_empty()
                 && let Some(control) = BranchHeadControlContext::new()
                     .reader(self.store)
@@ -8153,11 +8204,17 @@ where
                         &ChangeRecordProjection::identity_only(),
                     )
                     .await?;
-                for (slot, key) in unresolved.iter().enumerate() {
-                    // Any canonical row for the identity — live or tombstoned —
-                    // means it has been tracked, which is exactly what
-                    // `reject_retention_change` refuses to flip.
-                    if canonical.row(slot).is_some() {
+                canonical_created_ats = vec![None; sorted.len()];
+                for (slot, (index, untracked)) in unresolved_slots.iter().copied().enumerate() {
+                    let Some(row) = canonical.row(slot) else {
+                        continue;
+                    };
+                    if untracked {
+                        // Any canonical row for the identity — live or
+                        // tombstoned — means it has been tracked, which is
+                        // exactly what `reject_retention_change` refuses to
+                        // flip.
+                        let key = &unresolved[slot];
                         return Err(LixError::new(
                             LixError::CODE_UNIQUE,
                             format!(
@@ -8166,13 +8223,30 @@ where
                             ),
                         ));
                     }
+                    // A tracked insert over an identity canonical still knows.
+                    // Inherit its first `created_at` rather than minting a new
+                    // one, which is what the serving view's predecessor would
+                    // have supplied had it still been there.
+                    canonical_created_ats[index] = Some(row.created_at());
+                    #[cfg(any(test, feature = "storage-benches"))]
+                    BROAD_CANONICAL_CREATED_AT_HITS
+                        .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
                 }
             }
         }
         let mut created_ats = Vec::with_capacity(sorted.len());
-        for (delta, previous) in sorted.iter().zip(&previous_values) {
+        for (index, (delta, previous)) in sorted.iter().zip(&previous_values).enumerate() {
             let Some(previous) = previous else {
-                created_ats.push(delta.created_at);
+                // Canonical supplies the timestamp when it still knows the
+                // identity; otherwise this is a genuinely new row and mints
+                // its own.
+                created_ats.push(
+                    canonical_created_ats
+                        .get(index)
+                        .copied()
+                        .flatten()
+                        .unwrap_or(delta.created_at),
+                );
                 continue;
             };
             let existing = previous.view()?;

--- a/packages/lix/src/hot_state/tracked_head/hot.rs
+++ b/packages/lix/src/hot_state/tracked_head/hot.rs
@@ -8134,9 +8134,12 @@ where
         //
         // Consulting canonical state at the branch head restores the fence
         // where the serving view cannot carry it, and keeps the refusal on the
-        // insert. Cost is bounded to commits that actually contain an
-        // untracked write with an unresolvable predecessor; every other commit
-        // builds an empty key list and performs no additional I/O.
+        // insert.
+        //
+        // This block's key list used to be untracked-only, which left it empty
+        // on every ordinary commit. It no longer is — see the note below on
+        // the second question the same batch now answers, and the cost that
+        // widening carries.
         // The same batch answers a second question. A tracked insert whose
         // predecessor is absent is either a genuinely new identity — canonical
         // holds nothing, the lookup misses, and `delta.created_at` stands — or

--- a/packages/lix/src/hot_state/tracked_head/hot.rs
+++ b/packages/lix/src/hot_state/tracked_head/hot.rs
@@ -12790,6 +12790,79 @@ mod tests {
         StorageWriteOptions,
     };
 
+    /// `HotCollectionControl` is `#[musli(packed)]`: its fields are positional
+    /// and the encoding carries no field tags or length prefix. Appending a
+    /// fourth field therefore appends bytes that a three-field reader cannot
+    /// account for, and `storage_codec::decode` rejects trailing bytes rather
+    /// than ignoring them.
+    ///
+    /// This pins the cost of carrying a per-collection flag (for example a
+    /// "this collection has been compacted" bit) on the control record: it is
+    /// an on-disk format break that requires a repository protocol bump, the
+    /// same way the `ordered_identity_digest` field did. It is not an additive
+    /// change.
+    #[test]
+    fn adding_a_field_to_the_packed_collection_control_breaks_older_readers() {
+        #[derive(musli::Encode)]
+        #[musli(packed)]
+        struct WidenedHotCollectionControl {
+            active_generation: CommitId,
+            live_count: u64,
+            ordered_identity_digest: Option<[u8; 32]>,
+            compacted: bool,
+        }
+
+        let generation = CommitId::for_test_label("compaction-arity");
+
+        // Both digest states matter. A `None` option and a `Some` option lay
+        // out differently in packed mode, so each has to be checked
+        // separately: the danger to rule out is not only a loud failure but a
+        // decode that silently succeeds with wrong field values.
+        for digest in [None, Some([0xA5u8; 32])] {
+            let current = HotCollectionControl {
+                active_generation: generation,
+                live_count: 7,
+                ordered_identity_digest: digest,
+            };
+            let current_bytes = storage_codec::encode("hot collection control", &current)
+                .expect("current control should encode");
+
+            // Sanity: the three-field control round-trips today, so any
+            // failure below is caused by the added field and nothing else.
+            let round_tripped: HotCollectionControl =
+                storage_codec::decode("hot collection control", &current_bytes)
+                    .expect("current control should round-trip");
+            assert_eq!(round_tripped, current);
+
+            let widened = WidenedHotCollectionControl {
+                active_generation: generation,
+                live_count: 7,
+                ordered_identity_digest: digest,
+                compacted: true,
+            };
+            let widened_bytes = storage_codec::encode("widened hot collection control", &widened)
+                .expect("widened control should encode");
+            assert!(
+                widened_bytes.len() > current_bytes.len(),
+                "the fourth positional field must actually widen the encoding"
+            );
+
+            let error = storage_codec::decode::<HotCollectionControl>(
+                "hot collection control",
+                &widened_bytes,
+            )
+            .expect_err(
+                "a three-field reader must reject a four-field control rather than \
+                 silently decoding it",
+            );
+            let message = error.to_string();
+            assert!(
+                message.contains("failed to decode hot collection control"),
+                "expected a decode rejection, got: {message}"
+            );
+        }
+    }
+
     /// The root-base cache has no invalidation rule — it relies entirely on the
     /// key being exact. So the key must actually discriminate: a different base
     /// commit, a different filter, or a different projection must all miss.

--- a/packages/lix/src/hot_state/tracked_head/hot.rs
+++ b/packages/lix/src/hot_state/tracked_head/hot.rs
@@ -8158,7 +8158,15 @@ where
             let mut unresolved = Vec::new();
             let mut unresolved_slots = Vec::new();
             for (index, (delta, previous)) in sorted.iter().zip(&previous_values).enumerate() {
-                if delta.deleted || previous.is_some() || retired_predecessor[index] {
+                // The fence's key set must be preserved exactly: it always
+                // included retired-generation slots, and dropping them here
+                // would quietly weaken it. Only the *tracked* retired slots
+                // are excluded, and only because they must not inherit — they
+                // never reached the fence in the first place.
+                if delta.deleted
+                    || previous.is_some()
+                    || (!delta.untracked && retired_predecessor[index])
+                {
                     continue;
                 }
                 unresolved.push(TrackedStateKeyRef {

--- a/packages/lix/src/hot_state/tracked_head/hot.rs
+++ b/packages/lix/src/hot_state/tracked_head/hot.rs
@@ -8156,7 +8156,7 @@ where
         // change is how often the block runs: the untracked-only filter left
         // it empty on ordinary tracked inserts, and it now executes whenever a
         // commit introduces a new identity.
-        let mut canonical_created_ats: Vec<Option<crate::common::LixTimestamp>> = Vec::new();
+        let mut canonical_created_ats: Vec<Option<LixTimestamp>> = Vec::new();
         {
             let mut unresolved = Vec::new();
             let mut unresolved_slots = Vec::new();

--- a/packages/lix/src/tracked_state/context.rs
+++ b/packages/lix/src/tracked_state/context.rs
@@ -54,6 +54,15 @@ use base64::Engine as _;
 use bytes::Bytes;
 use xxhash_rust::xxh3::xxh3_64;
 
+/// Counts `validate_diff_row_created_at` entries so a probe can distinguish
+/// "the validator ran and accepted this row" from "the validator never ran".
+/// A null result from a validator that was never reached is indistinguishable
+/// from a null result from one that passed, so the count has to be observed
+/// rather than assumed.
+#[cfg(test)]
+pub(crate) static DIFF_ROW_CREATED_AT_VALIDATIONS: std::sync::atomic::AtomicUsize =
+    std::sync::atomic::AtomicUsize::new(0);
+
 const FILE_DESCRIPTOR_SCHEMA_KEY: &str = "lix_file_descriptor";
 const REGISTERED_SCHEMA_KEY: &str = "lix_registered_schema";
 // A right-edge probe is worthwhile for a real append batch, but would add a
@@ -1959,6 +1968,8 @@ where
         commit_id: &str,
         change_created_at: crate::common::LixTimestamp,
     ) -> Result<(), LixError> {
+        #[cfg(test)]
+        DIFF_ROW_CREATED_AT_VALIDATIONS.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
         let mut expected_created_at = change_created_at;
         if let Some(metadata) = storage::load_snapshot_commit_root(&self.store, commit_id).await? {
             if let Some(parent) = metadata.parent_roots.first() {

--- a/packages/lix/src/tracked_state/mod.rs
+++ b/packages/lix/src/tracked_state/mod.rs
@@ -34,6 +34,8 @@ pub(crate) use commit_root_rebuild::{
 pub(crate) use context::{
     TrackedStateContext, TrackedStateStoreReader, descriptor_dependency_cascade_file_ids,
 };
+#[cfg(test)]
+pub(crate) use context::DIFF_ROW_CREATED_AT_VALIDATIONS;
 pub(crate) use current_state_data_part::{
     CURRENT_STATE_DATA_PART_REFS_SPACE, CURRENT_STATE_DATA_PART_SPACE,
     decode_current_state_data_part_commit_ids, decode_current_state_data_part_refs,


### PR DESCRIPTION
## Summary

Lands **option 3 — canonical `created_at` sourcing**, the prerequisite for serving-layer
tombstone compaction, plus the two lints that stopped the branch passing its own gate.

It also reports the result of the compaction investigation this branch exists to support:
**compaction is not ready to ship, and the reason is gate (b), the global-shadow gate.** That is
argued from the code below, with the measured prize attached so the decision is falsifiable.

---

## What changed

**`perf(hot-state)`: recover `created_at` from canonical on the retention fence's existing batch.**
A tracked insert whose serving-view predecessor is absent is either a genuinely new identity —
canonical holds nothing, the lookup misses, `delta.created_at` stands — or an identity whose
predecessor is gone while canonical still carries its first `created_at`. The second case is
exactly what compaction would create. The recovery rides the retention fence's **existing** read:
same commit, same key list, same `ChangeRecordProjection::identity_only()`. `created_at` and
`deleted` are descriptor columns on the materialized row, so the projection does **not** widen.

**Nothing was removed.** No new storage space, no new writer, no adapter API change.

**`fix(hot-state)`: two lints `cargo test` structurally cannot see.** At `01cf24571`,
`cargo clippy --profile test -p lix --all-targets --all-features -- -D warnings` failed with:

- `unused_qualifications` on `crate::common::LixTimestamp` (already imported unqualified);
- `unused_imports` on the `BROAD_CANONICAL_CREATED_AT_*` re-export in `hot_state/mod.rs` — the
  counters are read only by `#[cfg(test)]` probes, so a features-on **library** build compiles and
  re-exports them with no in-crate reader.

Under `--profile test` both items *are* used, so `cargo test --all-features` passes either way.
This is the runbook's documented "`--all-features` cannot catch a lint on a test-only-read item"
trap, and it is why the branch's reported `2260 passed, 0 failed` did not imply a green gate.

---

## Layout invariants

1. **Single authority.** No. Canonical tracked state remains the sole authority for `created_at`;
   this reads it rather than introducing a second record of it. The serving view stays a cache.
2. **Commit canonicality.** Unchanged — no commit records, parent links, or state roots touched.
3. **Derived views are caches.** Strengthened. The HOT row previously had to *carry* a `created_at`
   forward through a tombstone for the value to survive; it can now be re-derived from canonical,
   which is what a cache is supposed to be able to do.
4. **Atomic publication.** Unchanged. The lookup is a read inside the existing publication; it
   stages nothing of its own.
5. **GC from refs.** Unchanged.
6. **SQL reads canonical records.** Unchanged.

---

## Numbers

**Write-path cost of option 3** — inherited from the prior agent on this thread, measured on
`hetzner-cpx62-III`, base `e3e790728` vs candidate, `tracked_state_crud --bench insert_all`,
rocksdb, 3 interleaved reps with arm order rotated. Reported as inherited, not re-measured:

| lane | base | cand | delta |
|---|---|---|---|
| kv_layout/1k — **null control** | 1.3253 ms | 1.2852 ms | **−3.0%** |
| kv_layout/10k — **null control** | 10.437 ms | 10.229 ms | **−2.0%** |
| transaction/1k | 6.7277 ms | 6.7980 ms | +1.04% |
| sql_session/1k | 8.5807 ms | 8.7035 ms | +1.43% |
| transaction/10k | 39.433 ms | 39.921 ms | +1.24% |
| sql_session/10k | 42.068 ms | 42.237 ms | +0.40% |

`kv_layout` bypasses the commit path, so it is a genuine in-run null control. Its own spread is
−2.0%/−3.0% on byte-identical code, which is the noise floor. **Every engine delta sits inside
it**, so the honest reading is that the arms overlap — not that the change costs ~1.2%.
**10k deltas are no larger than 1k, so no O(N) term was added.** No metric regressed beyond the
control's spread.

**Engagement, counted inside the route** (`BROAD_CANONICAL_CREATED_AT_{LOOKUPS,KEYS,HITS}`,
incremented inside the lookup, not one layer above it). Both directions are asserted in
**non-`#[ignore]`d** tests:

- `recreated_identity_created_at_after_compaction` — asserts `lookups > 0`, `hits > 0`, and
  `assert_eq!(second, first)`: a re-insert over a compacted identity inherits its original
  `created_at`. This is the only guard that option 3 actually fires; nothing else in the engine
  rejects a silently-fresh timestamp.
- `broad_canonical_created_at_recovery_misses_for_new_identities` — asserts `keys >= 2` and
  `hits == 0`, so the route is not trivially returning a constant.

---

## Compaction: measured prize, and why it is not in this PR

Run on `hetzner-cpx62-III` at `01cf24571`. Deterministic counts, 1 rep, `--test-threads=1`.

**The prize is real and asymptotic.** `hot_row_tombstone_compaction_premise`, n=1000, one live row:

| arm | row_entries | tombstones | packed_bases | root_bases | scan |
|---|---|---|---|---|---|
| before drop | 1043 | 999 | 0 | 0 | 570 µs |
| after drop | 44 | 0 | 0 | 0 | **128 µs** |

96% of the rows and 4.45x of the scan are tombstones for a collection whose answer is one row.
The serving layer carries an **O(deletes ever performed)** term where it should carry O(live).

**Nothing reclaims them.** `hot_row_tombstone_reclamation_events`, n=1000:

| event | row_entries | tombstones | packed_bases | root_bases |
|---|---|---|---|---|
| after_churn | 1043 | 999 | 0 | 0 |
| after_20_commits | 1063 | 999 | 0 | 0 |
| after_checkpoint | 1064 | 999 | 0 | 0 |
| after_gc | 1064 | 999 | 0 | 0 |
| after_ckpt2_gc | 1066 | 999 | 0 | 0 |

### What survived contact with the code

- **Gate (a), zero bases, is satisfiable — and this is new information.** A checkpoint publishes
  **no** packed or root current base (`packed_bases=0, root_bases=0` at every event above), so
  "zero bases" is the *normal* state at a checkpoint rather than an exotic one. Half of the gate is
  free besides: `load_root_current_base_commit(self.store, branch_id, generation)` is **already
  called** in `stage_current_state_with_working_diff_inner` before the point compaction would run.
- **Gate (c), dirty-only-against-the-retired-epoch, is free and assertable.** At a checkpoint
  publication `reset_working_diff_baselines` forces `(WorkingDiffBaseline::Clean, newly_dirty=false)`
  for every tracked delta, and the new epoch's `HOT_DIFF` scope starts empty. A compacted row is
  provably clean at the instant of removal, so the invariant the code cites twice — *"a tracked
  delete writes a tombstone that keeps its baseline, so a dirty row cannot vanish"* — survives.
- **The hook is right, and cheaper than the brief assumed.** `stage_hot_mutation_batch` already
  routes a `None` value range to a physical `row_delete`, and
  `next_value_ranges.push(if delta.physically_deletes() { None } else { … })` is already the site
  that decides it. Compaction is one extra disjunct on an existing branch — no new staging
  function, no new space, no `HotCollectionControl` widening, no protocol bump.

### What did not survive: gate (b)

The brief scoped gate (b) as a cheap per-identity skip, "nothing to do with bases". All three parts
of that are wrong, and the third is disqualifying:

1. **It is entirely about bases.** A global row's authority may be the global branch's *packed or
   root current base*, not a `ROW_SPACE` row. A raw `ROW_SPACE` probe would miss those and compact
   wrongly. `has_schema_rows` does a three-way ROW_SPACE + packed-base + root-base check for
   exactly this reason.
2. **The overlap is pervasive, not rare.** `init.rs` stages the same seed deltas into both the
   global generation and main's, so dozens of identities (`lix_registered_schema`, both branch
   descriptors, `lix_key_value`, `lix_account`) exist in **both** scopes from repository creation.
   Deleting one on `main` writes a branch tombstone shadowing a live, identical global row.
   Five existing tests pin this as contractual, e.g.
   `branch_tombstone_hides_global_row_after_visibility_resolution` and
   `base_branch_tombstone_hides_staged_global_row`, both asserting `rows.is_empty()`.
3. **No write path in the engine reads the global branch today.** Compaction would introduce the
   first cross-branch read in the publication path — on the path guarded by the
   `slatedb_history_blob_survives_until_final_root_release` stack canary — and that read would be
   **blind to global rows staged in the same transaction**: it sees the transaction's read snapshot,
   not the in-flight `StorageWriteSet`, and root ordering is `tracked_roots_parent_first`, which is
   not global-first. So the guard cannot be made sound by reading alone.

A conservative schema-key gate — skip any identity whose schema key has any global row, via
`has_schema_rows(GLOBAL_BRANCH_ID, …)` — is base-complete, costs one read per distinct schema key
rather than per identity, correctly skips every init-seeded overlap, and would still capture the
prize above for ordinary user tables. It does **not** close the same-transaction hole in (3).
That residual is narrow but it is a visibility hole in the engine's most contended function, so it
is the coordinator's call, not mine.

### A fourth observable axis, distinct from the one the brief retired

Compaction also changes the **working-diff before-image**. A re-insert over a compacted identity
yields `BeforeAbsent` where today it yields `BeforePresent { version.deleted = true }`.
`classify_hot_working_diff_entry` filters deleted before-rows, so the diff **kind** is unchanged
(`Added` either way) and `visible_before()` is identical. But the raw `before` feeds
`encode_diff_id(before.change_id, after.change_id)`, so **`diff_id`s for that pattern change**.
Both arms are self-consistent and `diff_id`s are already documented as staleable, so this is not
corruption — but it is user-visible and would have to be declared, and no gate would catch it.

---

## Breaking status — non-breaking on all three axes

Argued from what an older reader does with the bytes.

- **Storage format:** non-breaking. No record gained, lost, or reordered a field. Every musli
  storage record in the engine is `#[musli(packed)]`, so an arity change would be a hard decode
  error — this PR makes none. An older reader decodes every byte this writes.
- **Protocol:** non-breaking. `REPOSITORY_PROTOCOL_VALUE` stays `tracked-default-branch.v66`. No
  bump, so no "recreate the repository" rejection.
- **Public API:** non-breaking. No change to `packages/lix/src/lib.rs` exports, the SQL surface, or
  the JS SDK surface. The new counters are `pub(crate)` and `#[cfg]`-gated.

The one behavioural change is that a tracked insert whose predecessor is absent may now inherit a
`created_at` from canonical instead of minting a fresh one. That is a *correction* — it restores
the value the serving view would have supplied had its predecessor still been there — and it is the
behaviour `recreated_identity_created_at_without_compaction` already asserted before this change.

---

## Gate

Full CI scope, re-derived from this PR's own sha rather than from the runbook.
Machine `hetzner-cpx62-III`.

```
git rev-parse HEAD        63c69079467486aa27b768e1268612a3f42d92b9
git status --porcelain    (empty)
CI_SCOPE_CONFIRMED_AT=63c69079467486aa27b768e1268612a3f42d92b9
EXECUTED_TARGETS test1=3409 test2=164
```

Commands, taken from `git show 63c690794:.github/workflows/ci.yml`:

```
cargo clippy --profile test --workspace --all-targets --all-features -- -D warnings          # exit 0
cargo test --profile test --workspace --exclude lix_e2e --all-features --no-fail-fast        # exit 0, 3409 tests
cargo test --profile test -p lix_e2e \
  --features sdk-tests,storage-benches,slatedb,root-replay-trace --no-fail-fast              # exit 0, 164 tests
```

Plus the two features-OFF checks `--all-features` cannot cover, and the stack canary run **by
name** because it aborts the process rather than failing a lane:

```
cargo check -p lix --no-default-features                          # exit 0
cargo check -p lix_js_sdk --target wasm32-unknown-unknown         # exit 0
… slatedb_history_blob_survives_until_final_root_release -- --test-threads=1
  → test slatedb_history_blob_survives_until_final_root_release ... ok   (1 passed)
```

Zero failures across all logs (`failures:` / `test result: FAILED` / `panicked` / `^error` all
empty). Full logs on `hetzner-cpx62-III` at `~/claude5/logs/e45c-*`.

Rebased onto `1d67edd98` (**v67**; `0707e8e24` merged `main`, then #1427). The probe file
conflicted because #1427 landed its own **PHASE 8**; both sides appended independent tests, so the
resolution keeps integration's file intact and renumbers this branch's phase to **9**.

**Clippy was red at `01cf24571` and is green here** — that delta is the second commit's whole
purpose, and it is why this branch could not have been gated as it stood.
