### PR TITLE
test(tracked-state): end-to-end coverage for the scoped current-state root accelerator

### DIFF
--- a/packages/e2e/Cargo.toml
+++ b/packages/e2e/Cargo.toml
@@ -191,6 +191,14 @@ name = "tracked_state_crud_public_result"
 path = "tests/tracked_state_crud_public_result.rs"
 required-features = ["storage-benches"]
 
+# Deliberately its own target rather than a `-p lix` unit test: the scoped-root
+# census counters it reads are process-global, and a dedicated test binary with
+# a single test keeps them free of concurrent contributors.
+[[test]]
+name = "current_state_scoped_root_engagement"
+path = "tests/current_state_scoped_root_engagement.rs"
+required-features = ["storage-benches"]
+
 [[test]]
 name = "movie_workspace_qualification"
 path = "tests/movie_workspace_qualification.rs"

--- a/packages/e2e/tests/current_state_scoped_root_engagement.rs
+++ b/packages/e2e/tests/current_state_scoped_root_engagement.rs
@@ -1,0 +1,146 @@
+//! End-to-end coverage for `current_state_scoped_ranges`, the per-scope
+//! current-state read accelerator.
+//!
+//! Before this test the mechanism had no production coverage at all. Every
+//! unconditional `Some(..)` write to `current_state_scoped_ranges` in the tree
+//! is `#[cfg(test)]` fixture state, so its correctness was only ever exercised
+//! against roots the tests fabricated — never against a root the engine
+//! actually published.
+//!
+//! Reaching it from the public API requires one specific shape:
+//!
+//! * `TYPED_CERTIFIED_INSERT_MIN_ROWS` (`32 * 1024`, in
+//!   `sql2/exec/bound_public_write.rs`) rows,
+//! * in a single `execute_batch` of same-shape parameterized single-row
+//!   INSERTs,
+//! * against a **user-registered** entity schema.
+//!
+//! `PACKED_CURRENT_BASE_MIN_ROWS` (`512`, in `transaction/commit.rs`) is
+//! necessary but *not* sufficient, and reading it as the threshold is why this
+//! mechanism looked untestable: at 512–32,767 rows the batch still certifies
+//! and the columnar arm is still never taken. `certified_entity_insert_*`
+//! counters therefore cannot stand in for the assertions below — they are
+//! already non-zero at 511 rows with no columnar publication anywhere.
+//!
+//! The test asserts both halves, which fail independently:
+//!
+//! 1. **bootstrap** — the bulk batch mints a scoped root out of the
+//!    `parent_root == None` fixed point;
+//! 2. **sustain** — later commits *in the same scope* find that parent root
+//!    and carry it forward. Nothing else in the tree asserts this, and a
+//!    regression that bootstraps and then self-extinguishes leaves half 1
+//!    green.
+
+use lix::storage_bench::certified_current_state_publication_counters;
+use lix::{ExecuteBatchStatement, Value, open_lix};
+
+/// Must stay at or above `TYPED_CERTIFIED_INSERT_MIN_ROWS`. Below it the
+/// columnar arm is not reached and half 1 of this test cannot pass.
+const BULK_ROWS: usize = 32 * 1024;
+
+/// Same-scope commits issued after the bulk load. Four is enough to
+/// distinguish "sustains" from "engaged once and died": an accelerator that
+/// self-extinguishes yields at most one parent-root hit.
+const FOLLOW_UP_COMMITS: usize = 4;
+
+const SCHEMA_KEY: &str = "scoped_root_engagement_probe";
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn bulk_typed_insert_bootstraps_and_sustains_a_scoped_current_state_root() {
+    let lix = open_lix().await.expect("open in-memory lix");
+
+    let schema = serde_json::json!({
+        "x-lix-key": SCHEMA_KEY,
+        "x-lix-primary-key": ["/id"],
+        "type": "object",
+        "properties": {
+            "id": { "type": "string" },
+            "value": { "type": "string" }
+        },
+        "required": ["id", "value"],
+        "additionalProperties": false
+    });
+    lix.execute(
+        "INSERT INTO lix_registered_schema (value) VALUES (lix_json($1))",
+        &[Value::Text(schema.to_string())],
+    )
+    .await
+    .expect("register the scoped-root probe schema");
+
+    // The counters are process-global and read without reset, so every
+    // assertion below is a threshold on a snapshot delta rather than an exact
+    // value. A concurrent contributor can only inflate a delta, never hide a
+    // mechanism that stopped engaging. This target also runs as its own test
+    // binary with a single test, so in practice nothing else contributes.
+    let before_bulk = certified_current_state_publication_counters();
+
+    let insert_sql = format!("INSERT INTO {SCHEMA_KEY} (id, value) VALUES ($1, $2)");
+    let statements = (0..BULK_ROWS)
+        .map(|row| ExecuteBatchStatement {
+            label: None,
+            sql: insert_sql.clone(),
+            params: vec![
+                Value::Text(format!("bulk-{row:08}")),
+                Value::Text(format!("value-{row}")),
+            ],
+        })
+        .collect::<Vec<_>>();
+    let results = lix
+        .execute_batch(&statements)
+        .await
+        .expect("bulk typed INSERT batch");
+    assert_eq!(
+        results.len(),
+        BULK_ROWS,
+        "the batch must carry at least TYPED_CERTIFIED_INSERT_MIN_ROWS rows, \
+         or the columnar arm is never reached"
+    );
+
+    let after_bulk = certified_current_state_publication_counters();
+    let columnar_publications = after_bulk
+        .columnar_root_publications
+        .saturating_sub(before_bulk.columnar_root_publications);
+    assert!(
+        columnar_publications >= 1,
+        "half 1 (bootstrap): a {BULK_ROWS}-row certified typed INSERT batch published no columnar \
+         scoped current-state root (delta {columnar_publications}). The accelerator never left the \
+         parent_root == None fixed point, so no later commit can inherit one."
+    );
+
+    // Same-scope follow-up commits. Each one must find the root the bulk load
+    // published; a commit in a *different* scope would legitimately drop the
+    // accelerator, because roots are per-scope.
+    for round in 0..FOLLOW_UP_COMMITS {
+        lix.execute(
+            &insert_sql,
+            &[
+                Value::Text(format!("follow-{round:08}")),
+                Value::Text(format!("follow-value-{round}")),
+            ],
+        )
+        .await
+        .expect("same-scope follow-up insert");
+    }
+
+    let after_follow_ups = certified_current_state_publication_counters();
+    let parent_root_hits = after_follow_ups
+        .parent_root_hits
+        .saturating_sub(after_bulk.parent_root_hits);
+    assert!(
+        parent_root_hits >= 2,
+        "half 2 (sustain): {FOLLOW_UP_COMMITS} same-scope commits after the bulk load found a \
+         parent scoped root only {parent_root_hits} time(s). The accelerator bootstrapped and then \
+         self-extinguished, which leaves the bootstrap assertion above green."
+    );
+
+    let count = lix
+        .execute(&format!("SELECT COUNT(*) AS count FROM {SCHEMA_KEY}"), &[])
+        .await
+        .expect("read the probe collection back");
+    assert_eq!(
+        count.rows()[0].get::<i64>("count").unwrap(),
+        (BULK_ROWS + FOLLOW_UP_COMMITS) as i64
+    );
+
+    lix.close().await.expect("close the probe repository");
+}

--- a/packages/lix/src/storage_bench.rs
+++ b/packages/lix/src/storage_bench.rs
@@ -80,6 +80,8 @@ static CRUD_CURRENT_STATE_SCOPED_RANGE_FALLBACKS: AtomicU64 = AtomicU64::new(0);
 static CRUD_CURRENT_STATE_SCOPED_RANGE_ATTEMPTS: AtomicU64 = AtomicU64::new(0);
 static CRUD_CURRENT_STATE_SCOPED_RANGE_HITS: AtomicU64 = AtomicU64::new(0);
 static CRUD_CURRENT_STATE_SCOPED_RANGE_ERRORS: AtomicU64 = AtomicU64::new(0);
+static CERTIFIED_CURRENT_STATE_COLUMNAR_ROOT_PUBLICATIONS: AtomicU64 = AtomicU64::new(0);
+static CERTIFIED_CURRENT_STATE_PARENT_ROOT_HITS: AtomicU64 = AtomicU64::new(0);
 static CRUD_SEALED_MANIFEST_LOADS: AtomicU64 = AtomicU64::new(0);
 static CRUD_REPLAY_MANIFEST_LOADS: AtomicU64 = AtomicU64::new(0);
 static CRUD_ORDERED_DELTA_FALLBACKS: AtomicU64 = AtomicU64::new(0);
@@ -619,6 +621,56 @@ pub fn take_crud_current_state_scoped_range_accounting() -> CrudCurrentStateScop
         commit_delta_direct_rows: COMMIT_DELTA_DIRECT_ROWS.swap(0, Ordering::Relaxed),
         commit_delta_generic_segments: COMMIT_DELTA_GENERIC_SEGMENTS.swap(0, Ordering::Relaxed),
         commit_delta_generic_rows: COMMIT_DELTA_GENERIC_ROWS.swap(0, Ordering::Relaxed),
+    }
+}
+
+/// Publication-side census for `current_state_scoped_ranges`, the per-scope
+/// read accelerator.
+///
+/// These are deliberately **not** the `crud_current_state_scoped_range_*`
+/// counters above: those record `attempts`/`hits` inside
+/// `resolve_rootless_index_values_at_commit`, which is the rootless replay
+/// *read* path. Nothing there observes whether a commit published a scoped
+/// root, so a test asserting on them passes whether or not the accelerator
+/// ever engaged.
+///
+/// The two fields split the accelerator's two halves, which fail
+/// independently:
+///
+/// * `columnar_root_publications` — a commit whose mutation inventory carried
+///   columnar parts bootstrapped a scoped root out of the `parent_root ==
+///   None` fixed point. Reached only by a certified typed INSERT batch of at
+///   least `TYPED_CERTIFIED_INSERT_MIN_ROWS` (32,768) rows against a
+///   user-registered entity schema.
+/// * `parent_root_hits` — a later publication found a parent scoped root and
+///   carried it forward. This is what proves the accelerator *sustains*; a
+///   regression that bootstraps and then self-extinguishes leaves
+///   `columnar_root_publications` intact and drives this to zero.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct CertifiedCurrentStatePublicationCounters {
+    pub columnar_root_publications: u64,
+    pub parent_root_hits: u64,
+}
+
+pub(crate) fn record_certified_current_state_columnar_root_publication() {
+    CERTIFIED_CURRENT_STATE_COLUMNAR_ROOT_PUBLICATIONS.fetch_add(1, Ordering::Relaxed);
+}
+
+pub(crate) fn record_certified_current_state_parent_root_hit() {
+    CERTIFIED_CURRENT_STATE_PARENT_ROOT_HITS.fetch_add(1, Ordering::Relaxed);
+}
+
+/// Reads the cumulative scoped-root publication counters **without** resetting
+/// them. These statics are process-global and test binaries run their tests in
+/// parallel, so a `swap`-style reader would let two fixtures steal each other's
+/// counts. Subtract a pre-operation snapshot from a post-operation snapshot and
+/// assert a threshold on the delta; concurrent contributions can only inflate
+/// it, never hide a mechanism that stopped engaging.
+pub fn certified_current_state_publication_counters() -> CertifiedCurrentStatePublicationCounters {
+    CertifiedCurrentStatePublicationCounters {
+        columnar_root_publications: CERTIFIED_CURRENT_STATE_COLUMNAR_ROOT_PUBLICATIONS
+            .load(Ordering::Relaxed),
+        parent_root_hits: CERTIFIED_CURRENT_STATE_PARENT_ROOT_HITS.load(Ordering::Relaxed),
     }
 }
 

--- a/packages/lix/src/tracked_state/scoped_current_state.rs
+++ b/packages/lix/src/tracked_state/scoped_current_state.rs
@@ -675,6 +675,10 @@ pub(super) async fn stage_current_state_scoped_ranges_from_topology_refs(
     let inherited_scope_filter =
         advance_touched_scope_filter_from_topology(graph_parents, selected_source, Some(&[]))?;
     if inventory.columnar_parts.is_some() {
+        // Bootstrap half of the accelerator: this is the only arm that can
+        // mint a scoped root with no parent root in hand.
+        #[cfg(feature = "storage-benches")]
+        crate::storage_bench::record_certified_current_state_columnar_root_publication();
         let root = stage_disjoint_columnar_current_state_pages(
             store,
             writes,
@@ -737,6 +741,11 @@ pub(super) async fn stage_current_state_scoped_ranges_from_topology_refs(
             touched_scope_filter,
         });
     };
+    // Sustain half: the fall-through, not the `else` above. Reaching here means
+    // this publication inherited a scoped root from its serving base and will
+    // carry it forward rather than dropping the accelerator.
+    #[cfg(feature = "storage-benches")]
+    crate::storage_bench::record_certified_current_state_parent_root_hit();
     if touched.is_empty() {
         return Ok(CertifiedCommitStatePhysicalPublication {
             write_set_id: writes.identity(),


### PR DESCRIPTION
# test(tracked-state): end-to-end coverage for the scoped current-state root accelerator

**Breaking status: non-breaking, test-only.** Two new `storage_bench` counters plus one test
target. No public API, SQL surface, storage format, or adapter API change. Nothing removed.

## The gap this closes

`current_state_scoped_ranges` — the per-scope current-state read accelerator — had **no production
test coverage at all**. Every unconditional `Some(..)` write to that field in the tree is
`#[cfg(test)]` fixture state (`gc.rs` ×4, `tracked_state/storage.rs` ×1), so the mechanism's
correctness was only ever exercised against roots the tests fabricated, never against a root the
engine published.

This PR adds the two counters that make the mechanism observable, and one end-to-end test that
drives it through the public SDK (`open_lix` → `execute_batch` → `execute`) and asserts **both**
halves of it.

## Why it looked untestable

Two thresholds gate the accelerator and only one of them is binding:

| constant | value | where | role |
|---|---|---|---|
| `TYPED_CERTIFIED_INSERT_MIN_ROWS` | `32 * 1024` | `sql2/exec/bound_public_write.rs:124` | **binding** |
| `PACKED_CURRENT_BASE_MIN_ROWS` | `512` | `transaction/commit.rs:69` | necessary, **not** sufficient |

Reading `512` as *the* threshold is what made this look unreachable. At 512–32,767 rows the batch
still certifies and the columnar arm is still never taken. The trigger is exact:

> ≥ 32,768 rows in a single `execute_batch()` of same-shape parameterized single-row INSERTs
> against a **user-registered** entity schema.

No `session.execute` form reaches the certification path at any size, and literal `VALUES` vs
parameter-bound and autocommit vs explicit transaction make no difference.

## Why two new counters were needed

No existing counter observes either half. Two look right by name and are not:

- `take_crud_current_state_scoped_range_accounting()` / `…_fallbacks()` — their `attempts`/`hits`
  are recorded at `tracked_state/context.rs:3307/3340/3350/3363`, inside
  `resolve_rootless_index_values_at_commit`, which is the **rootless replay read path**, a
  different mechanism. Nothing there observes whether a commit published a scoped root.
- `certified_entity_insert_parameter_batch_counters()` — proves only that the batch *certified*,
  which happens at 511 rows too, with no columnar publication anywhere.

**A test asserting on either would have passed vacuously at 1,024 rows.** So this PR adds the
observable as part of the work:

- `record_certified_current_state_columnar_root_publication()` — at the columnar arm in
  `tracked_state/scoped_current_state.rs`, the only arm that can mint a scoped root with no parent
  root in hand (bootstrap).
- `record_certified_current_state_parent_root_hit()` — on the **fall-through past** the
  `let Some(parent_root) = parent_root else { … }` gate, not the `else` branch (sustain).

Both `#[cfg(feature = "storage-benches")]`, consistent with every neighbouring call site.
`certified_current_state_publication_counters()` **loads without resetting**, unlike the
`take_*` readers: these statics are process-global, so a `swap`-style reader lets two fixtures
steal each other's counts. The test subtracts snapshots and asserts thresholds on the deltas, so a
concurrent contributor can only inflate a delta, never hide a mechanism that stopped engaging.

## What the test asserts — both halves

1. **Bootstrap** — a 32,768-row `execute_batch` publishes ≥ 1 columnar scoped root.
2. **Sustain** — four subsequent **same-scope** commits find a parent root ≥ 2 times.

Half 2 is the one nothing previously asserted and the one that catches a self-extinguishing
regression: a mechanism that bootstraps and then dies leaves half 1 green.

Thresholds, never exact values, per the process-global rule. The 32,768-row fixture is a magnitude
stray concurrent rows cannot reach, and the target is its own test binary with a single test, so in
practice nothing else contributes to the counters.

## Evidence that the test is not vacuous

Observed deltas on the shipped fixture (`hetzner-cpx62`, sha `685c03ff2`, debug/test profile):

| counter | observed delta | assertion |
|---|---|---|
| `columnar_root_publications` | **1** | `>= 1` |
| `parent_root_hits` | **4** — one per same-scope follow-up commit | `>= 2` |

Four negative controls, each run to failure and then reverted:

| control | change | result |
|---|---|---|
| **A** — inverted assertions, fixture unchanged | `>= 1` → `< 1`, `>= 2` → `< 2` | **FAILS**, `delta 1` |
| **B** — fixture below the binding threshold | `BULK_ROWS` 32,768 → 1,024, assertions intact | **FAILS**, `delta 0` |
| **C** — follow-ups in a *different* scope | same-scope INSERTs → `lix_key_value` | half 1 **passes**, half 2 **FAILS** at `1` |
| **D** — thresholds raised to 999 | reports the observed values | `1` and `4` |

**B is the one that matters most.** It is exactly the vacuity trap this mechanism invites: at 1,024
rows the batch still certifies, so every pre-existing counter is non-zero and a test asserting on
them would be green — but the columnar delta is **0**, and this test fails. The test is sensitive to
the 32,768-row threshold, not to "a commit happened".

**C proves half 2 is independent.** With follow-ups routed out of scope the accelerator bootstraps,
survives one commit and then drops — `parent_root_hits` reaches exactly **1** while half 1 stays
green. The `>= 2` threshold sits between the sustaining case (**4**) and the self-extinguishing case
(**1**), with margin on both sides. This reproduces the previously-established per-scope behaviour:
roots are per-scope, and a commit in a different scope legitimately drops the accelerator.

## Lane and measured runtime

**Measured, not guessed.** Debug/test profile on `hetzner-cpx62`, three runs:

```
test result: ok. 1 passed; ... finished in 0.65s     WALL_SECONDS=0.99
test result: ok. 1 passed; ... finished in 0.60s     WALL_SECONDS=0.91
test result: ok. 1 passed; ... finished in 0.64s     WALL_SECONDS=0.94
```

**0.60–0.65 s** of test time (0.91–0.99 s wall including cargo's up-to-date check), against 0.11 s
for the equivalent probe in release. 32,768 rows are cheap because they arrive as one certified
batch, not 32,768 statements — this is the shape the accelerator exists for.

**Lane: `lix_e2e`, gated behind `storage-benches`, as its own `[[test]]` target.** Three reasons,
and runtime is not one of them:

1. The counters only exist under `storage-benches`, so the test must be gated. `lix_e2e` already
   runs with that feature in CI (`--features sdk-tests,storage-benches,slatedb,root-replay-trace`),
   so this runs on every CI test job rather than needing a feature nobody turns on.
2. **A dedicated `[[test]]` target is its own process.** The census statics are process-global, and
   a `-p lix` unit test would share them with the whole lib suite — the configuration in which an
   exact-value assertion on a `storage_bench` counter already failed at 2 elsewhere. One target,
   one test, no concurrent contributors.
3. At 0.65 s it is cheaper than most targets already in that lane, so the gate costs nothing.

`autotests = false` in `packages/e2e/Cargo.toml`, so the `[[test]]` entry is required — without it
the target would silently not exist.

## Layout invariants

1. **Single authority** — no. Test-only observation plus two atomic counters; no new writer, no new
   materialization.
2. **Commit canonicality** — unchanged.
3. **Derived views are caches** — unchanged. The test *documents* that `current_state_scoped_ranges`
   is a disposable per-scope cache published alongside the commit.
4. **Atomic publication** — unchanged; the counters are incremented on the existing publication
   path, not in a new stage.
5. **GC from refs** — unchanged.
6. **SQL reads canonical records** — unchanged.

Adapter API: none added, changed, or removed. Conformance suite untouched.

## Correctness gate

Full CI-scope gate on `hetzner-cpx62`, base `claude-6-optimizations` = `1d67edd98` (unmoved during
this work; confirmed at start and at gate time).

```
git rev-parse HEAD        685c03ff27e568e8fc0dd9686f5a598f831d686f
git status --porcelain    (empty)
CI_SCOPE_CONFIRMED_AT=685c03ff27e568e8fc0dd9686f5a598f831d686f
EXECUTED_TARGETS test1=3405 test2=165
```

`CI_SCOPE_CONFIRMED_AT` is re-derived from that sha's own `ci.yml`, not from any runbook copy:
clippy `--profile test --workspace --all-targets --all-features -- -D warnings`, then
`cargo test --profile test --workspace --exclude lix_e2e --all-features --no-fail-fast` and
`cargo test --profile test -p lix_e2e --features sdk-tests,storage-benches,slatedb,root-replay-trace
--no-fail-fast`. CI has no `cargo check --workspace` step; one was run locally anyway.

| step | exit |
|---|---|
| `cargo clippy --profile test --workspace --all-targets --all-features -- -D warnings` | 0 |
| `cargo check --workspace --all-targets --all-features` | 0 |
| `cargo check -p lix --no-default-features` | 0 |
| `cargo check -p lix_js_sdk --target wasm32-unknown-unknown` | 0 |
| `cargo test … --workspace --exclude lix_e2e --all-features --no-fail-fast` | 0 (**3405** tests) |
| `cargo test … -p lix_e2e --features sdk-tests,storage-benches,slatedb,root-replay-trace` | 0 (**165** tests) |

Zero `FAILED`/`panicked` occurrences in either test log. Both counts are non-zero, so the gate did
not report green by running nothing.

**Stack canary, run explicitly by name** (`--exact`), per the async future-size rule:

```
test slatedb_history_blob_survives_until_final_root_release ... ok
test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 3 filtered out; finished in 0.24s
```

The counters are two `AtomicU64::fetch_add` calls on an existing publication path — no new future
frame, no wrapper `async` block — so this was expected to be unaffected, and it is.

**The new test inside the full parallel `lix_e2e` suite** (the configuration where process-global
counter contention would surface, and the one in which an exact-value assertion failed elsewhere):

```
test bulk_typed_insert_bootstraps_and_sustains_a_scoped_current_state_root ... ok
test result: ok. 1 passed; 0 failed; ... finished in 0.65s
```

No probe scaffolding is carried into the tree: the diff is 4 files, +215/−0 — two counters, two
call sites, one test, one `[[test]]` entry.
