### PR TITLE
fix(diff): make diff_id blind to a checkpointed delete tombstone

### DIFF
--- a/.changenotes/stable-diff-ids-after-a-checkpointed-delete.md
+++ b/.changenotes/stable-diff-ids-after-a-checkpointed-delete.md
@@ -1,0 +1,7 @@
+---
+type: patch
+---
+
+Re-adding an entity that was deleted in an earlier checkpoint now reports the same `diff_id` as adding an entity for the first time.
+
+Deleting an entity leaves an internal tombstone behind at the next checkpoint, and that tombstone was leaking into the `diff_id` of a later re-add — so two identical "this row is now here" changes could carry different ids depending on the entity's older history. `diff_type`, `before_change_id`, and `after_change_id` are unchanged.

--- a/docs/diff-commands.md
+++ b/docs/diff-commands.md
@@ -134,5 +134,12 @@ current textual form starts with `d1.`), but clients must not construct or
 decode it. Use `before_change_id` and `after_change_id` for joins to
 `lix_change` and for debugging.
 
+A `diff_id` is only valid while the entity is still on the side the command
+starts from, so it is a short-lived selection token rather than a durable
+handle — do not persist one and expect it to resolve later. It also describes a
+change, not an entity's history: an entity that was deleted in an earlier
+checkpoint and later re-added encodes the same way as one that was never
+present, even though `before_change_id` still reports the underlying row.
+
 These command names describe state transformations. They are not a session
 undo/redo stack.

--- a/packages/lix/src/sql2/providers/diff.rs
+++ b/packages/lix/src/sql2/providers/diff.rs
@@ -15,7 +15,6 @@ use crate::sql2::SqlChangelogQuerySource;
 use crate::sql2::error::lix_error_to_datafusion_error;
 use crate::sql2::result_metadata::json_field;
 use crate::storage_adapter::StorageAdapterRead;
-use crate::tracked_state::encode_diff_id;
 use crate::tracked_state::{
     TrackedStateContext, TrackedStateDiffKind, TrackedStateDiffRequest, TrackedStateFilter,
 };
@@ -163,10 +162,7 @@ where
                             continue;
                         }
                         rows.push(DiffSqlRow {
-                            diff_id: encode_diff_id(
-                                entry.before.as_ref().map(|row| row.change_id),
-                                entry.after.as_ref().map(|row| row.change_id),
-                            ),
+                            diff_id: entry.diff_id(),
                             entity_pk: entry.identity.entity_pk().as_json_array_text(),
                             schema_key: entry.identity.schema_key().to_owned(),
                             file_id: entry.identity.file_id().map(str::to_owned),

--- a/packages/lix/src/sql2/providers/working_diff.rs
+++ b/packages/lix/src/sql2/providers/working_diff.rs
@@ -16,7 +16,6 @@ use crate::hot_state::TrackedHeadContext;
 use crate::sql2::result_metadata::json_field;
 use crate::sql2::{SqlChangelogQuerySource, WriteAccess};
 use crate::storage_adapter::StorageAdapterRead;
-use crate::tracked_state::encode_diff_id;
 use crate::tracked_state::{
     TrackedStateContext, TrackedStateDiffKind, TrackedStateDiffRequest, TrackedStateFilter,
 };
@@ -190,10 +189,7 @@ where
                                 continue;
                             }
                             rows.push(WorkingDiffSqlRow {
-                                diff_id: encode_diff_id(
-                                    entry.before.as_ref().map(|row| row.change_id),
-                                    entry.after.as_ref().map(|row| row.change_id),
-                                ),
+                                diff_id: entry.diff_id(),
                                 entity_pk: entry.identity.entity_pk().as_json_array_text(),
                                 schema_key: entry.identity.schema_key().to_owned(),
                                 file_id: entry.identity.file_id().map(str::to_owned),

--- a/packages/lix/src/tracked_state/diff.rs
+++ b/packages/lix/src/tracked_state/diff.rs
@@ -1304,11 +1304,9 @@ mod tests {
             created_at,
             updated_at,
         };
-        let after = value(after_change_id, false);
-
         let entry = |before: Option<TrackedStateIndexValue>| {
             let mut batch = TrackedStateTreeDiffBatchBuilder::with_row_capacity(1);
-            batch.push_shared(key(), before, Some(after));
+            batch.push_shared(key(), before, Some(value(after_change_id, false)));
             let batch = batch.finish().expect("tree batch should seal");
             classify_tree_diff_batch(batch, &TrackedStatePayloadBatch::default())
                 .expect("rows should classify")

--- a/packages/lix/src/tracked_state/diff.rs
+++ b/packages/lix/src/tracked_state/diff.rs
@@ -11,6 +11,7 @@ use crate::changelog::{ChangeId, CommitId};
 use crate::common::{LixTimestamp, SharedStr};
 use crate::json_store::JsonSlot;
 use crate::tracked_state::codec::DecodedTrackedStateKeyShared;
+use crate::tracked_state::diff_id::encode_diff_id;
 use crate::tracked_state::types::{
     TrackedStateIndexValue, TrackedStateKey, TrackedStateKeyRef, TrackedStateTreeScanRequest,
 };
@@ -1202,7 +1203,6 @@ impl TrackedStateDiffEntry {
         self.visible_after().is_some()
     }
 
-    #[cfg(test)]
     pub(crate) fn visible_before(&self) -> Option<&TrackedStateDiffRow> {
         self.before.as_ref().filter(|row| !row.deleted)
     }
@@ -1210,6 +1210,29 @@ impl TrackedStateDiffEntry {
     #[cfg(test)]
     pub(crate) fn visible_after(&self) -> Option<&TrackedStateDiffRow> {
         self.after.as_ref().filter(|row| !row.deleted)
+    }
+
+    /// Stable `diff_id` for this entry.
+    ///
+    /// The before side is the **visible** before row, so a checkpointed delete
+    /// (which leaves a tombstone in the left root) encodes identically to an
+    /// identity that was never present. Both describe the same change — "this
+    /// row is not there, and now it is" — and every other consumer of the
+    /// before side already normalizes them: `classify_hot_working_diff_entry`
+    /// filters deleted before rows before choosing the kind, and the
+    /// apply/revert precondition treats `None` as "absent or tombstoned".
+    /// Encoding the raw tombstone here would make the id depend on whether a
+    /// tombstone happens to be retained, which is a storage-layer detail.
+    ///
+    /// The after side stays **raw** on purpose. A `Removed` entry's after row
+    /// *is* the tombstone, and merge relies on it to apply deletes without
+    /// reloading the source root. Do not "fix" this asymmetry — the two sides
+    /// answer different questions.
+    pub(crate) fn diff_id(&self) -> Result<String, LixError> {
+        encode_diff_id(
+            self.visible_before().map(|row| row.change_id),
+            self.after.as_ref().map(|row| row.change_id),
+        )
     }
 }
 
@@ -1255,6 +1278,128 @@ mod tests {
         crate::tracked_state::storage::stage_resealed_commit_state_manifest_for_test(
             writes, &manifest,
         )
+    }
+
+    /// A checkpointed delete leaves a tombstone in the left root, so the same
+    /// logical history ("this identity is not here, and now it is") reaches the
+    /// diff surface with either `before = None` or `before = Some(tombstone)`.
+    /// The `diff_id` must not be able to tell those apart, otherwise physically
+    /// compacting tombstones away would silently renumber every
+    /// delete-then-reinsert diff.
+    #[test]
+    fn diff_id_is_blind_to_a_tombstoned_before_row() {
+        let created_at = ts("2024-01-01T00:00:00.000Z");
+        let updated_at = ts("2024-01-02T00:00:00.000Z");
+        let after_change_id = ChangeId::for_test_label("reinserted-after");
+        let commit_id = CommitId::for_test_label("diff-id-commit");
+        let key = || DecodedTrackedStateKeyShared {
+            schema_key: SharedStr::from_static("test_schema"),
+            file_id: None,
+            entity_pk: EntityPk::single("entity-0"),
+        };
+        let value = |change_id: ChangeId, deleted: bool| TrackedStateIndexValue {
+            change_id,
+            commit_id,
+            deleted,
+            created_at,
+            updated_at,
+        };
+        let after = value(after_change_id, false);
+
+        let entry = |before: Option<TrackedStateIndexValue>| {
+            let mut batch = TrackedStateTreeDiffBatchBuilder::with_row_capacity(1);
+            batch.push_shared(key(), before, Some(after));
+            let batch = batch.finish().expect("tree batch should seal");
+            classify_tree_diff_batch(batch, &TrackedStatePayloadBatch::default())
+                .expect("rows should classify")
+                .pop()
+                .expect("one entry")
+        };
+
+        let never_present = entry(None);
+        let tombstoned =
+            entry(Some(value(ChangeId::for_test_label("checkpointed-delete"), true)));
+
+        // The fixture is only meaningful if the tombstone actually survives on
+        // the entry — otherwise this would pass vacuously against a before-image
+        // that was already dropped upstream.
+        assert!(
+            tombstoned
+                .before
+                .as_ref()
+                .is_some_and(|row| row.deleted),
+            "fixture must carry a tombstoned before row"
+        );
+        assert!(never_present.before.is_none());
+        assert_eq!(never_present.kind, TrackedStateDiffKind::Added);
+        assert_eq!(tombstoned.kind, TrackedStateDiffKind::Added);
+
+        assert_eq!(
+            tombstoned.diff_id().expect("tombstoned diff id"),
+            never_present.diff_id().expect("absent diff id"),
+            "a retained tombstone must not change the diff_id"
+        );
+
+        // Guard the other direction: normalization must not swallow a *live*
+        // before row, which is a genuinely different change.
+        let modified = entry(Some(value(
+            ChangeId::for_test_label("live-before"),
+            false,
+        )));
+        assert_eq!(modified.kind, TrackedStateDiffKind::Modified);
+        assert_ne!(
+            modified.diff_id().expect("modified diff id"),
+            never_present.diff_id().expect("absent diff id"),
+            "a live before row must still contribute to the diff_id"
+        );
+    }
+
+    /// The after side must stay raw: a `Removed` entry's after row *is* the
+    /// tombstone, and merge relies on it. If normalization ever leaks across to
+    /// `after`, every delete would encode as a sideless diff and fail to encode
+    /// at all.
+    #[test]
+    fn diff_id_keeps_a_tombstoned_after_row() {
+        let created_at = ts("2024-01-01T00:00:00.000Z");
+        let updated_at = ts("2024-01-02T00:00:00.000Z");
+        let commit_id = CommitId::for_test_label("diff-id-commit");
+        let mut batch = TrackedStateTreeDiffBatchBuilder::with_row_capacity(1);
+        batch.push_shared(
+            DecodedTrackedStateKeyShared {
+                schema_key: SharedStr::from_static("test_schema"),
+                file_id: None,
+                entity_pk: EntityPk::single("entity-0"),
+            },
+            Some(TrackedStateIndexValue {
+                change_id: ChangeId::for_test_label("live-before"),
+                commit_id,
+                deleted: false,
+                created_at,
+                updated_at,
+            }),
+            Some(TrackedStateIndexValue {
+                change_id: ChangeId::for_test_label("delete-after"),
+                commit_id,
+                deleted: true,
+                created_at,
+                updated_at,
+            }),
+        );
+        let batch = batch.finish().expect("tree batch should seal");
+        let entry = classify_tree_diff_batch(batch, &TrackedStatePayloadBatch::default())
+            .expect("rows should classify")
+            .pop()
+            .expect("one entry");
+        assert_eq!(entry.kind, TrackedStateDiffKind::Removed);
+        assert!(entry.after.as_ref().is_some_and(|row| row.deleted));
+        let sides = crate::tracked_state::decode_diff_id(&entry.diff_id().expect("removed diff id"))
+            .expect("removed diff id should decode");
+        assert_eq!(
+            sides.after,
+            Some(ChangeId::for_test_label("delete-after")),
+            "the after tombstone must survive into the diff_id"
+        );
+        assert_eq!(sides.before, Some(ChangeId::for_test_label("live-before")));
     }
 
     #[test]

--- a/packages/lix/src/tracked_state/mod.rs
+++ b/packages/lix/src/tracked_state/mod.rs
@@ -47,7 +47,7 @@ pub(crate) use diff::{
     TrackedStateDiff, TrackedStateDiffEntry, TrackedStateDiffIdentity, TrackedStateDiffKind,
     TrackedStateDiffRequest, TrackedStateDiffRow, TrackedStatePayloadBatch, TrackedStatePayloadRef,
 };
-pub(crate) use diff_id::{decode_diff_id, encode_diff_id};
+pub(crate) use diff_id::decode_diff_id;
 pub(crate) use merge::{
     TrackedStateMergeConflict, TrackedStateMergePick, TrackedStateMergePlan,
     merge_payload_fallback_ids, plan_merge,

--- a/packages/lix/src/transaction/context.rs
+++ b/packages/lix/src/transaction/context.rs
@@ -8102,10 +8102,7 @@ where
             entry.identity.schema_key() != CHECKPOINT_SCHEMA_KEY
                 && entry.identity.schema_key() != crate::undo_redo::UNDO_REDO_MARKER_SCHEMA_KEY
         }) {
-            let diff_id = crate::tracked_state::encode_diff_id(
-                entry.before.as_ref().map(|row| row.change_id),
-                entry.after.as_ref().map(|row| row.change_id),
-            )?;
+            let diff_id = entry.diff_id()?;
             let target = entry.after.ok_or_else(|| {
                 LixError::new(
                     LixError::CODE_INTERNAL_ERROR,

--- a/packages/lix/tests/integration/sql/diff_commands.rs
+++ b/packages/lix/tests/integration/sql/diff_commands.rs
@@ -222,3 +222,137 @@ simulation_test!(
         assert_eq!(head_after_empty, head_before_empty);
     }
 );
+
+// A checkpointed delete is a *soft* delete: the checkpoint root keeps a
+// tombstone for the identity. Re-inserting that identity therefore produces an
+// `added` working-diff row whose before-image is `BeforePresent { deleted:
+// true }` rather than absent. `diff_id` must encode only the after side in that
+// case, exactly as it does for an identity that was never present — otherwise
+// physically compacting tombstones away would renumber the id.
+simulation_test!(
+    diff_id_ignores_a_checkpointed_delete_tombstone,
+    |sim| async move {
+        let engine = sim.boot_engine().await;
+        let session = sim.wrap_session(
+            engine.open_session().await.expect("session should open"),
+            &engine,
+        );
+
+        // A `d1.` id carries a one-byte side mask plus one 16-byte UUID per
+        // present side, base64url-unpadded: 3 + 23 = 26 chars for one side,
+        // 3 + 44 = 47 for two. Length is the only way to observe the encoded
+        // side count from SQL, since clients must not decode a diff_id.
+        const AFTER_ONLY_LEN: usize = 26;
+
+        // Control: an identity that was never present before the checkpoint.
+        session
+            .execute(
+                "INSERT INTO lix_key_value (key, value) VALUES ('fresh', 'one')",
+                &[],
+            )
+            .await
+            .expect("fresh insert should succeed");
+        let fresh = select_rows(
+            &session,
+            "SELECT diff_id, diff_type, before_change_id FROM lix_working_diff \
+             WHERE schema_key = 'lix_key_value' AND entity_pk = lix_json('[\"fresh\"]')",
+        )
+        .await;
+        assert_eq!(fresh.len(), 1);
+        assert_eq!(fresh[0][1], Value::Text("added".to_string()));
+        assert_eq!(
+            fresh[0][2],
+            Value::Null,
+            "an identity that never existed has no before row"
+        );
+        let Value::Text(fresh_diff_id) = &fresh[0][0] else {
+            panic!("diff_id should be text, got {:?}", fresh[0][0]);
+        };
+        assert_eq!(fresh_diff_id.len(), AFTER_ONLY_LEN);
+
+        // Now build the tombstone history: insert, checkpoint, delete,
+        // checkpoint (which retains the tombstone), then re-insert.
+        session
+            .execute(
+                "INSERT INTO lix_key_value (key, value) VALUES ('recycled', 'one')",
+                &[],
+            )
+            .await
+            .expect("first insert should succeed");
+        session
+            .execute(
+                "INSERT INTO lix_create_checkpoint (diff_id) \
+                 SELECT diff_id FROM lix_working_diff",
+                &[],
+            )
+            .await
+            .expect("checkpoint of the insert should succeed");
+        session
+            .execute("DELETE FROM lix_key_value WHERE key = 'recycled'", &[])
+            .await
+            .expect("delete should succeed");
+        session
+            .execute(
+                "INSERT INTO lix_create_checkpoint (diff_id) \
+                 SELECT diff_id FROM lix_working_diff",
+                &[],
+            )
+            .await
+            .expect("checkpoint of the delete should succeed");
+        session
+            .execute(
+                "INSERT INTO lix_key_value (key, value) VALUES ('recycled', 'two')",
+                &[],
+            )
+            .await
+            .expect("re-insert should succeed");
+
+        let recycled = select_rows(
+            &session,
+            "SELECT diff_id, diff_type, before_change_id FROM lix_working_diff \
+             WHERE schema_key = 'lix_key_value' AND entity_pk = lix_json('[\"recycled\"]')",
+        )
+        .await;
+        assert_eq!(recycled.len(), 1);
+        assert_eq!(recycled[0][1], Value::Text("added".to_string()));
+
+        // Non-vacuity: this scenario only tests anything if the checkpointed
+        // delete really did leave a tombstone that reaches the diff surface.
+        // `before_change_id` reports the raw before row, so it stays populated.
+        assert!(
+            matches!(&recycled[0][2], Value::Text(id) if !id.is_empty()),
+            "fixture must retain a tombstoned before row, got {:?}",
+            recycled[0][2]
+        );
+
+        let Value::Text(recycled_diff_id) = &recycled[0][0] else {
+            panic!("diff_id should be text, got {:?}", recycled[0][0]);
+        };
+        assert_eq!(
+            recycled_diff_id.len(),
+            AFTER_ONLY_LEN,
+            "a tombstoned before row must not add a side to the diff_id"
+        );
+
+        // The normalized id must still drive a command end to end.
+        let reverted = session
+            .execute(
+                "INSERT INTO lix_revert (diff_id) \
+                 SELECT diff_id FROM (VALUES ($1)) AS selected(diff_id) \
+                 RETURNING commit_id",
+                &[recycled[0][0].clone()],
+            )
+            .await
+            .expect("revert of a tombstone-backed add should succeed");
+        assert_eq!(reverted.rows_affected(), 1);
+        assert_eq!(
+            select_rows(
+                &session,
+                "SELECT key FROM lix_key_value WHERE key = 'recycled'",
+            )
+            .await,
+            Vec::<Vec<Value>>::new(),
+            "reverting the re-insert must return the identity to absent"
+        );
+    }
+);


### PR DESCRIPTION
## What changed

A checkpointed delete is a **soft** delete: the checkpoint root retains a tombstone for the identity. Re-inserting that identity therefore reaches the diff surface with a before-image of `BeforePresent { deleted: true }` rather than `BeforeAbsent` — and `diff_id` was encoding that raw tombstone as a present before side.

The three sites that encode a `diff_id` now share one method, `TrackedStateDiffEntry::diff_id()`, which takes the **visible** before row (`visible_before()`, previously `#[cfg(test)]`-only) and leaves the after side raw.

- `packages/lix/src/sql2/providers/diff.rs` (`lix_diff`)
- `packages/lix/src/sql2/providers/working_diff.rs` (`lix_working_diff`)
- `packages/lix/src/transaction/context.rs` (`execute_checkpoint_selection`)

All three previously inlined the identical `encode_diff_id(entry.before…, entry.after…)` expression. Collapsing them into one method is load-bearing, not tidiness: `execute_checkpoint_selection` uses the `diff_id` as a **matching key** against ids the caller selected from `lix_working_diff`, so if those sites ever normalized differently, partial checkpoints would silently stop matching. `encode_diff_id` itself is unchanged — it only ever receives `Option<ChangeId>` and cannot see `deleted`, so normalization has to happen at the entry.

**The after side stays raw, deliberately.** A `Removed` entry's after row *is* the tombstone, and merge relies on it to apply deletes without reloading the source root — that justification is already written on the field. No such justification exists for `before`; its doc comment instead says callers needing user-visible semantics should use `visible_before()`. This change makes the diff-id sites do what that comment always asked for. A test pins the asymmetry so the next reader does not "fix" it.

Nothing removed beyond the now-unused `encode_diff_id` re-export from `tracked_state/mod.rs`. No adapter API touched. No public API, SQL surface, or JS SDK surface change.

## Why this is sound

Every other consumer of the before side already treats "absent" and "present-but-deleted" as the same state:

| consumer | treatment |
|---|---|
| `classify_hot_working_diff_entry` (`hot.rs`) | `before_row.as_ref().filter(\|row\| !row.deleted)` before choosing the kind |
| apply/revert precondition (`context.rs`) | `None => current.as_ref().is_none_or(\|row\| row.deleted)` |
| `diff_id` (before this PR) | **encoded the raw tombstone** |

The precondition is the decisive one: at the exact point where a `diff_id`'s before side is checked against live state, `None` already accepts a tombstone. So the engine had already ruled the two states equivalent, and `diff_id` was the lone dissenter.

The revert target is unaffected in outcome. `Some(tombstone)` loads the payload and stages `TransactionWriteRow { snapshot: <null>, … }`; `None` stages `TransactionWriteRow { snapshot: None, … }`. Both land as a delete. The `Some` path additionally requires `required_diff_change` to resolve and `payload.identity` to be present, so normalizing also removes two `CODE_INTERNAL_ERROR` paths.

One honest consequence to record: on the **apply** path the precondition moves from `current.change_id == <specific tombstone>` to `current is absent or tombstoned`. That is a slightly weaker check — it no longer pins *which* tombstone. It is still a CAS check against live state, and the tombstone's change id carries no user-visible information the diff describes, but it is a loosening rather than a pure no-op and should be read as such.

## Breaking status: user-visible ids change once; no client following the contract can observe it

`diff_id`s for delete-checkpointed-then-reinserted identities change value once (47 chars → 26). That is a real change to bytes a user can see, so the question is whether anything can depend on the old value.

It cannot, because **`diff_id` is a selection token carrying an expected pre-state, not a durable handle**:

- `docs/diff-commands.md`: *"Treat `diff_id` as opaque: select it, pipe it into a command"*, and *"clients must not construct or decode it"*.
- The error text is `"stale or unknown diff_id; re-evaluate the source diff and retry"` — re-derivation, not resolution.
- `packages/lix/tests/integration/sql/diff_commands.rs` proves the point directly: it applies a diff, then re-runs the **identical** `lix_diff(baseline, original_head)` selection. That id is bit-identical and both change records still resolve — and it is **rejected** with `CODE_CONSTRAINT_VIOLATION`, because live state moved. A persisted `diff_id` already does not work.

So a client that persisted a `diff_id` was already broken; a client following the documented select-then-pipe pattern re-derives the id in the same statement and never sees the old form. Marked `patch`.

The motivating case is the in-flight tombstone-compaction change, which physically removes tombstones at checkpoint. That flips the before-image from `BeforePresent{deleted:true}` to `BeforeAbsent` — which, before this PR, would have changed these same ids with no gate catching it. After this PR that flip is **id-neutral by construction**, and the new test is what enforces it.

## Tests

`diff_id_is_blind_to_a_tombstoned_before_row` (unit, `tracked_state/diff.rs`) — same after change id, before `None` vs before `Some(tombstone)` ⇒ **same** `diff_id`; before `Some(live)` ⇒ **different** `diff_id`, so normalization cannot over-reach.

`diff_id_keeps_a_tombstoned_after_row` (unit) — a `Removed` entry's after tombstone still decodes out of the id. Guards the asymmetry.

`diff_id_ignores_a_checkpointed_delete_tombstone` (integration, `diff_commands.rs`) — real history: insert → checkpoint → delete → checkpoint → re-insert. Asserts `before_change_id IS NOT NULL` (non-vacuity: the tombstone genuinely reaches the diff surface) and that the id encodes one side only, then reverts through that id end to end.

**Engagement proof.** I reverted just the normalization (`visible_before()` → `self.before`) on the machine and re-ran: both simulation variants of the integration test **FAILED** on exactly `"a tombstoned before row must not add a side to the diff_id"`, and pass with it. So the guard is not vacuous, and the premise is measured rather than inferred — on base, this pattern really does produce a two-sided id.

## Layout invariants

1. **Single authority** — no new authority. Three duplicated expressions collapse into one method; the duplication is deleted, not relocated.
2. **Commit canonicality** — untouched.
3. **Derived views are caches** — `diff_id` is a derived, per-query token; this makes it depend on less state, not more.
4. **Atomic publication** — untouched.
5. **GC from refs** — untouched. Note the tombstone keeps its storage-layer role of suppressing fall-through to a base/global row; this PR changes only how it is *described* on the diff surface, and the five tests pinning "branch tombstone hides global row" are unaffected.
6. **SQL reads canonical records** — unchanged.

## Performance

Not a performance change. One `filter` on an `Option<&Row>` per emitted diff entry. No benchmarks run; no lane could plausibly resolve it.

## Gate

Full CI-scope gate on `ryzen-9950x-III`, branch head `249aca377` on top of base `2db93c60b`.

```
git rev-parse HEAD      -> 249aca377d6b9ee9282fa4ee2022db07f7323909
git status --porcelain  -> (empty)
CI_SCOPE_CONFIRMED_AT=249aca377d6b9ee9282fa4ee2022db07f7323909
EXECUTED_TARGETS test1=3413 test2=165
```

`CI_SCOPE_CONFIRMED_AT` re-derived from that sha's own `.github/workflows/ci.yml`, not from the runbook.

| stage | command | rc |
|---|---|---|
| check | `cargo check --workspace --all-targets --all-features` | 0 |
| clippy | `cargo clippy --profile test --workspace --all-targets --all-features -- -D warnings` | 0 |
| features-off | `cargo check -p lix --no-default-features` | 0 |
| wasm | `cargo check -p lix_js_sdk --target wasm32-unknown-unknown` | 0 |
| test1 | `cargo test --profile test --workspace --exclude lix_e2e --all-features --no-fail-fast` | 0 (3413 passed) |
| test2 | `cargo test --profile test -p lix_e2e --features sdk-tests,storage-benches,slatedb,root-replay-trace --no-fail-fast` | 0 (165 passed) |
| canary | `--test cas_gc_history_retention slatedb_history_blob_survives_until_final_root_release -- --exact --test-threads=1` | 0 (1 passed) |

Stack canary run by name with `--exact`, matching exactly one test — `1 passed`, no abort. This PR adds no async frame to any read or write path (one synchronous `Option::filter`), so the budget is untouched, but it was run because the runbook requires it.

Zero failures across every lane; logs grepped for `failures:`, `test result: FAILED`, and `^error`, not tailed.

Base `claude-6-optimizations` was still `2db93c60b` when the PR was opened — the same commit gated on.
