### PR TITLE
Finish the Lix Server Protocol terminology cut

### DIFF
--- a/.changenotes/bounded-commit-root-availability-proof.md
+++ b/.changenotes/bounded-commit-root-availability-proof.md
@@ -2,6 +2,6 @@
 type: patch
 ---
 
-Commit no longer re-reads the whole workspace state to decide where a commit-root replay may resume.
+Commit no longer re-reads the whole repository state to decide where a commit-root replay may resume.
 
 Closing a rootless replay interval checked that the previous durable state root was readable by traversing every row of the tree it addresses. That check cost time proportional to total state size and ran once per replay interval, so commit still carried a quadratic term even after replay itself was bounded. The commit path now proves only that the resume point is addressable, which is what actually distinguishes a usable root from a damaged one; the completeness of the chunk closure is already guaranteed by atomic publication and by garbage collection reaching chunks from refs. Explicit repair (`rebuild_tracked_state_for_branch`) still proves the whole closure, so a damaged root is still never resumed from during repair and repair stays total.

--- a/.changenotes/file-history-path-pruning.md
+++ b/.changenotes/file-history-path-pruning.md
@@ -4,4 +4,4 @@ type: patch
 
 `lix_file_history()` filtered by `path` now costs what the answer costs instead of scanning every file at every commit.
 
-A `WHERE path = '...'` predicate is resolved to the files that could ever render that path and then routed like a `WHERE id = '...'` lookup, so the traversal no longer reconstructs the whole filesystem at each observed commit. Reading one file's history in a workspace with five thousand files drops from over a second to a few milliseconds, and the cost stops growing with the number of files in the repository. Results are unchanged, including for paths a file has since been renamed away from.
+A `WHERE path = '...'` predicate is resolved to the files that could ever render that path and then routed like a `WHERE id = '...'` lookup, so the traversal no longer reconstructs the whole filesystem at each observed commit. Reading one file's history in a repository with five thousand files drops from over a second to a few milliseconds, and the cost stops growing with the number of files in the repository. Results are unchanged, including for paths a file has since been renamed away from.

--- a/.changenotes/file-history-registry-scan.md
+++ b/.changenotes/file-history-registry-scan.md
@@ -6,4 +6,4 @@ Reading file history no longer reconstructs the plugin registry at every reachab
 
 `lix_file_history()` discovered which plugins existed by rebuilding the plugin registry once per commit in the repository's history, on every query, regardless of how few rows the query asked for. It now reads the registry's own change history once instead: the registry any commit sees was written by a registry change that history already contains, so one traversal yields the same answer as thousands of per-commit reconstructions. Registries are still rebuilt where they are actually compared — commits that changed the registry, and their direct parents.
 
-On a workspace with 2000 commits this cuts a file's history read from 59 ms to 34 ms, and a single-revision read from 56 ms to 39 ms. The saving grows with the number of commits in the repository.
+On a repository with 2000 commits this cuts a file's history read from 59 ms to 34 ms, and a single-revision read from 56 ms to 39 ms. The saving grows with the number of commits in the repository.

--- a/.changenotes/plugins-run-on-untracked-files.md
+++ b/.changenotes/plugins-run-on-untracked-files.md
@@ -6,6 +6,6 @@ Plugins now run on untracked files, so an untracked file's contents are queryabl
 
 Previously plugin reconciliation was skipped for untracked writes: an untracked JSON file was stored as a descriptor plus an opaque content blob with no entity rows at all, and none of its contents could be queried. A file's entity rows now follow the file's own lane, so the same file behaves the same way whether it is tracked or untracked — untracked rows carrying a change id and no commit id, exactly as other untracked state does. Editing one of those rows re-renders the file's bytes on both lanes alike.
 
-Untracked files intentionally receive no durable plugin checkpoint, because a checkpoint is a persisted accelerator and untracked state is defined not to be durable. A large untracked file is therefore re-parsed each time the workspace is opened.
+Untracked files intentionally receive no durable plugin checkpoint, because a checkpoint is a persisted accelerator and untracked state is defined not to be durable. A large untracked file is therefore re-parsed each time the repository is opened.
 
 Untracked change ids identify a row within the session that wrote it. They are not stable across sessions and should not be compared between them.

--- a/.changenotes/primary-session-hard-cut.md
+++ b/.changenotes/primary-session-hard-cut.md
@@ -2,9 +2,9 @@
 type: minor
 ---
 
-Replace workspace sessions with client-owned primary sessions. New repositories
+Replace repository sessions with client-owned primary sessions. New repositories
 track `lix_default_branch_id` in their initial commit, while `open_lix()` restores
 the primary session from untracked client state at
 `lix_primary_session_branch_id`. Additional sessions are independent and branch
 switches no longer mutate repository state. This is a storage and API hard cut;
-older repositories and the removed workspace-session methods are unsupported.
+older repositories and the removed repository-session methods are unsupported.

--- a/.changenotes/reclaim-deleted-branch-storage.md
+++ b/.changenotes/reclaim-deleted-branch-storage.md
@@ -4,4 +4,4 @@ type: patch
 
 Garbage collection now reclaims the storage a deleted or superseded branch leaves behind.
 
-Every branch serves its current state from a generation of derived rows. When a branch was deleted, or when a lifecycle publication replaced its generation, those rows were never reclaimed and stayed on disk forever. Repository GC now retires them as part of its ordinary pass, so deleting a branch and collecting frees the space it actually used — measured at roughly 85% less residual storage after deleting a branch in a 10,000-row workspace.
+Every branch serves its current state from a generation of derived rows. When a branch was deleted, or when a lifecycle publication replaced its generation, those rows were never reclaimed and stayed on disk forever. Repository GC now retires them as part of its ordinary pass, so deleting a branch and collecting frees the space it actually used — measured at roughly 85% less residual storage after deleting a branch in a 10,000-row repository.

--- a/.changenotes/root-backed-branch-head-moves.md
+++ b/.changenotes/root-backed-branch-head-moves.md
@@ -4,4 +4,4 @@ type: patch
 
 Moving a branch head — most visibly a fast-forward merge — no longer copies the whole working set into storage.
 
-Creating a branch already published a single reference to the shared, immutable state at its head. Moving an existing branch's head did not: it wrote one row per tracked entity into that branch's private serving storage, so a fast-forward merge of a ten-row change in a hundred-thousand-row workspace grew the repository by roughly ten times its own size. Head moves now publish the same one-reference form, and the cost of a merge tracks the size of the merge rather than the size of the repository.
+Creating a branch already published a single reference to the shared, immutable state at its head. Moving an existing branch's head did not: it wrote one row per tracked entity into that branch's private serving storage, so a fast-forward merge of a ten-row change in a hundred-thousand-row repository grew the repository by roughly ten times its own size. Head moves now publish the same one-reference form, and the cost of a merge tracks the size of the merge rather than the size of the repository.

--- a/.changenotes/server-protocol-in-lix.md
+++ b/.changenotes/server-protocol-in-lix.md
@@ -2,6 +2,6 @@
 type: minor
 ---
 
-Lix now provides its canonical server protocol directly through the optional Rust `server-protocol` feature.
+Lix now provides the canonical Lix Server Protocol directly through the optional Rust `server-protocol` feature.
 
 Server hosts can dispatch framework-neutral HTTP requests through `LixServerProtocol`, while authenticated account identity and idempotency scope are supplied as trusted host context instead of client-controlled handshake parameters.

--- a/.changenotes/server-protocol-terminology.md
+++ b/.changenotes/server-protocol-terminology.md
@@ -1,0 +1,10 @@
+---
+type: minor
+---
+
+Finish the pre-0.12 terminology hard cut. The JavaScript protocol entry point is
+now `@lix-js/sdk/server-protocol`, its public constants and wire types use
+`ServerProtocol` names, and invalid wire data reports
+`LIX_SERVER_PROTOCOL_ERROR`. The previous entry point and names have no
+compatibility aliases. SDK documentation and examples now use repository
+terminology throughout.

--- a/.changenotes/untracked-plugin-files-keep-their-checkpoint.md
+++ b/.changenotes/untracked-plugin-files-keep-their-checkpoint.md
@@ -4,4 +4,4 @@ type: patch
 
 Untracked plugin files no longer re-parse from scratch on every session.
 
-An untracked file that a plugin understands now keeps the same durable actor checkpoint a tracked file keeps, so reopening a workspace restores it instead of parsing the whole file again. The checkpoint stays a pure accelerator: it is validated against the file's current content and is discarded automatically whenever it no longer matches, and it disappears with the file or its branch.
+An untracked file that a plugin understands now keeps the same durable actor checkpoint a tracked file keeps, so reopening a repository restores it instead of parsing the whole file again. The checkpoint stays a pure accelerator: it is validated against the file's current content and is discarded automatically whenever it no longer matches, and it disappears with the file or its branch.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@
 - Added repository-native accounts and single-account change attribution across local and remote sessions.
 
   Every change now has one required account, anonymous work uses the built-in anonymous account, and applications can select an active account through the Rust, JavaScript, SQL, and server-protocol APIs.
-- Added persistent undo and redo for tracked branch history across the Rust SDK, JavaScript SDK, remote protocol, and CLI.
+- Added persistent undo and redo for tracked branch history across the Rust SDK, JavaScript SDK, Lix Server Protocol, and CLI.
 
   Undo and redo append inverse and replay commits without rewinding branch history. Atomic batches and transactions remain one undo unit, while untracked state remains unchanged; checkpoints and merge commits form undo boundaries.
 - Renamed the `lix_file`, `lix_file_by_branch`, and `lix_file_history` binary payload column from `data` to `content`. Native file read and write APIs now use `content` names as well; the former `data` surface is not supported.
@@ -70,7 +70,7 @@
 - Rename the filesystem working-diff SQL surfaces for consistent terminology.
 
   `lix_file_working_diff`, `lix_file_working_diff_by_branch`, `lix_directory_working_diff`, and `lix_directory_working_diff_by_branch` replace their `*_working_change*` predecessors. The old names are not retained as aliases.
-- Lix is substantially faster and more storage-efficient for large files and workspaces.
+- Lix is substantially faster and more storage-efficient for large files and repositories.
 
   v0.9 adds indexed and batched file operations, faster SQL reads and writes, compressed native storage, lower-copy blob handling, and more efficient tracked-state merges. Remote clients also transfer localized file and query changes instead of repeatedly sending complete payloads.
 
@@ -82,7 +82,7 @@
 
   Reference plugins for CSV and TSV, JSON, Markdown, Excalidraw, and Git-compatible text turn localized file edits into sparse semantic changes without reparsing or rendering the complete document. Concurrent edits merge at the entity level, and plugin authors can build on the same public Rust API used by the bundled plugins.
 - Git replay can now target RocksDB or SlateDB and compare the full semantic plugin path with an explicit no-plugin control. Replay profiles identify the selected adapter and include per-commit WASM transition work counters.
-- Run Lix workspaces remotely with live, low-latency clients.
+- Run Lix repositories remotely with live, low-latency clients.
 
   `openLix()` can connect to the versioned Lix HTTP protocol for SQL, branches, atomic batches, binary file operations, and multiplexed live queries. Each client gets an isolated branch-pinned session, retries writes safely, persists private local state locally, and sends compact deltas for localized edits.
 - Plugin-backed atomic imports now scale independently of document count. The engine automatically reuses its bounded live-Store working set for fresh and existing documents while preserving actively contested same-file leases, so callers no longer need a special single-writer ingestion API or actor-retention policy. Retained session observations also recover from benign working-set eviction when their exact durable semantic root is unchanged.
@@ -151,12 +151,12 @@
 - Added `LocalFilesystem.syncDiskToLix()` as an awaitable filesystem sync barrier.
 
   The filesystem storage picks up disk edits in the background with debouncing. `storage.syncDiskToLix()` flushes pending on-disk changes into Lix and resolves once they are materialized, so subsequent queries reflect the current disk state.
-- Added a `lixDir` option to `LocalFilesystem` for storing lix state outside the workspace.
+- Added a `lixDir` option to `LocalFilesystem` for storing lix state outside the repository.
 
-  By default, state lives in `<workspace>/.lix`. Passing `lixDir` keeps repository metadata in an external `.lix` directory and writes no `.lix` directory into the workspace. Pointing `lixDir` at a temporary directory gives ephemeral filesystem sync: workspace files are imported and watched without persisting lix state.
+  By default, state lives in `<repository>/.lix`. Passing `lixDir` keeps repository metadata in an external `.lix` directory and writes no `.lix` directory into the repository. Pointing `lixDir` at a temporary directory gives ephemeral filesystem sync: repository files are imported and watched without persisting lix state.
 - `LocalFilesystem` now requires an explicit `syncAllFiles` option and supports on-demand file sync.
 
-  `new LocalFilesystem({ path, syncAllFiles: true })` syncs the full workspace as before. With `syncAllFiles: false`, the lix opens without workspace files and `storage.importPaths(["notes/today.md"])` syncs selected files on demand. Imported paths are exact workspace-relative file paths, not directories or globs. In Rust, use `LocalFilesystemOpenOptions::new(root, sync_all_files)` and `LocalFilesystem::import_paths()`.
+  `new LocalFilesystem({ path, syncAllFiles: true })` syncs the full repository as before. With `syncAllFiles: false`, the lix opens without repository files and `storage.importPaths(["notes/today.md"])` syncs selected files on demand. Imported paths are exact repository-relative file paths, not directories or globs. In Rust, use `LocalFilesystemOpenOptions::new(root, sync_all_files)` and `LocalFilesystem::import_paths()`.
 - Added optional origin keys for tagging Lix writes.
 
   `lix.execute(sql, params, { originKey })` in JavaScript and `execute_with_options(sql, params, options)` in Rust stamp the change records a write produces. The key is exposed as `origin_key` on `lix_change` and as `lixcol_origin_key` on state, file, and history surfaces; writes without an origin key stay `NULL`.

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Run locally with `LocalFilesystem`:
 import { LocalFilesystem, openLix } from "@lix-js/sdk";
 
 const lix = await openLix({
-  storage: new LocalFilesystem({ path: "./workspace", syncAllFiles: true }),
+  storage: new LocalFilesystem({ path: "./repository", syncAllFiles: true }),
 });
 
 await lix.execute("INSERT INTO lix_file (path, content) VALUES ($1, $2)", [
@@ -56,7 +56,7 @@ Or against a server:
 const lix = await openLix({
   server: {
     mode: "remote",
-    url: "https://example.com/workspaces/acme",
+    url: "https://example.com/repositories/acme",
   },
 });
 ```

--- a/packages/e2e/REALTIME_COLLABORATION_CAPACITY.md
+++ b/packages/e2e/REALTIME_COLLABORATION_CAPACITY.md
@@ -48,7 +48,7 @@ five fresh-process repetitions. This avoids selecting the fastest sample.
 | Local / CSV | 100 | 5.484 ms | **23.108 ms** | 23.818 ms | pass |
 | Local / Markdown | 100 | 7.952 ms | **24.780 ms** | 28.850 ms | pass |
 | Local / text | 100 | 5.520 ms | **20.922 ms** | 21.276 ms | pass |
-| Server protocol / JSON | 100 | 13.787 ms | **25.977 ms** | not recorded | pass |
+| Lix Server Protocol / JSON | 100 | 13.787 ms | **25.977 ms** | not recorded | pass |
 
 The server-protocol row runs 100 independent protocol sessions and 100 SSE
 streams through the canonical Axum router. It covers wire value decoding,
@@ -104,7 +104,7 @@ subscriber when a slower capacity run needs attribution.
 Across the corrected six-run matrix, worst local service p95 was 7.952 ms and
 worst local convergence p95 was 24.780 ms. Absolute-deadline schedule-lag p95
 never exceeded 2.081 ms, proving the workload sustained five edits every 50 ms
-instead of moving arrivals after convergence. The in-process server protocol's
+instead of moving arrivals after convergence. The in-process Lix Server Protocol's
 worst service and convergence p95 values were 13.787 ms and 25.977 ms, with
 schedule-lag p95 at or below 1.768 ms. These endpoint measurements identify
 protocol processing and fan-out as the remaining larger slices; a production
@@ -150,7 +150,7 @@ cargo test -p lix_e2e \
   -- --ignored --exact --nocapture
 
 cargo test -p lix --features "server-protocol storage-benches" --release \
-  tests::remote_protocol_converges_to_one_hundred_clients_below_one_hundred_ms_p95 \
+  tests::server_protocol_converges_to_one_hundred_clients_below_one_hundred_ms_p95 \
   -- --ignored --exact --nocapture
 ```
 

--- a/packages/js-sdk/README.md
+++ b/packages/js-sdk/README.md
@@ -22,15 +22,15 @@ console.log(result.rows[0]?.get("message"));
 await lix.close();
 ```
 
-## Remote workspaces
+## Remote repositories
 
-Use the same Lix client as a thin client against a hosted workspace:
+Use the same Lix client as a thin client against a hosted repository:
 
 ```ts
 const lix = await openLix({
 	server: {
 		mode: "remote",
-		url: "https://lixray.com/@namespace/workspace",
+		url: "https://lixray.com/@namespace/repository",
 		headers: async () => ({
 			Authorization: `Bearer ${await accessToken()}`,
 		}),
@@ -63,7 +63,7 @@ import { IndexedDbStorage, openLix } from "@lix-js/sdk";
 const lix = await openLix({
 	server: {
 		mode: "remote",
-		url: "https://lixray.com/@namespace/workspace",
+		url: "https://lixray.com/@namespace/repository",
 	},
 	storage: new IndexedDbStorage({ name: "lixray-client" }),
 });
@@ -74,7 +74,7 @@ await lix.clientState.set("atelier-ui", { sidebar: "history" });
 
 `lix.clientState` reads and writes through the local Lix transaction path. Its
 JSON values and the client's active branch are stored in the local IndexedDB
-database; workspace SQL continues to execute only on the server. Reopening the
+database; repository SQL continues to execute only on the server. Reopening the
 same remote URL with the same storage name restores both. Each
 remote server session is branch-pinned, so switching one client does not switch
 another client.
@@ -90,7 +90,7 @@ import { LocalFilesystem, openLix } from "@lix-js/sdk";
 
 const lix = await openLix({
 	storage: new LocalFilesystem({
-		path: "./workspace",
+		path: "./repository",
 		syncAllFiles: true,
 	}),
 });
@@ -167,11 +167,11 @@ try {
 
 ## Notes
 
-- `openLix()` opens a fresh in-memory Lix. Pass `new LocalFilesystem({ path, syncAllFiles: true })` for a filesystem workspace directory backed by `<path>/.lix/.internal/rocksdb`.
+- `openLix()` opens a fresh in-memory Lix. Pass `new LocalFilesystem({ path, syncAllFiles: true })` for a filesystem repository directory backed by `<path>/.lix/.internal/rocksdb`.
 - In browsers, pass `new IndexedDbStorage({ name })` to persist a complete local Lix across reloads.
 - Only one Lix handle may open an IndexedDB storage name at a time, including across browser tabs.
-- Pass `new LocalFilesystem({ path, lixDir, syncAllFiles: true })` for filesystem sync with repository metadata in an external `.lix` directory and no workspace `.lix` directory.
-- Pass `syncAllFiles: false` to start filesystem sync with no regular workspace files, then call `storage.importPaths(["notes/today.md"])` on the `LocalFilesystem` instance to sync selected files. Imported paths are exact workspace-relative file paths, not directories or globs.
+- Pass `new LocalFilesystem({ path, lixDir, syncAllFiles: true })` for filesystem sync with repository metadata in an external `.lix` directory and no repository `.lix` directory.
+- Pass `syncAllFiles: false` to start filesystem sync with no regular repository files, then call `storage.importPaths(["notes/today.md"])` on the `LocalFilesystem` instance to sync selected files. Imported paths are exact repository-relative file paths, not directories or globs.
 - In browsers, local mode and remote mode with IndexedDB storage load the Rust
   engine as WebAssembly. In remote mode, the local engine contains only client
   state.

--- a/packages/js-sdk/package.json
+++ b/packages/js-sdk/package.json
@@ -17,9 +17,9 @@
 			"workerd": "./dist/workerd.js",
 			"default": "./dist/workerd.js"
 		},
-		"./remote-protocol": {
-			"types": "./dist/remote/protocol.d.ts",
-			"default": "./dist/remote/protocol.js"
+		"./server-protocol": {
+			"types": "./dist/remote/server-protocol.d.ts",
+			"default": "./dist/remote/server-protocol.js"
 		}
 	},
 	"imports": {

--- a/packages/js-sdk/src/open-lix.browser.test.ts
+++ b/packages/js-sdk/src/open-lix.browser.test.ts
@@ -301,16 +301,16 @@ test("remote IndexedDbStorage isolates client state by server URL", async () => 
 			storage: new IndexedDbStorage({ name }),
 		});
 
-	const workspaceA = await openRemote("https://lixray.test/@acme/a");
-	await workspaceA.clientState.set("selected-panel", "history");
-	await workspaceA.close();
+	const repositoryA = await openRemote("https://lixray.test/@acme/a");
+	await repositoryA.clientState.set("selected-panel", "history");
+	await repositoryA.close();
 
-	const workspaceB = await openRemote("https://lixray.test/@acme/b");
+	const repositoryB = await openRemote("https://lixray.test/@acme/b");
 	await expect(
-		workspaceB.clientState.get("selected-panel"),
+		repositoryB.clientState.get("selected-panel"),
 	).resolves.toBeUndefined();
-	await workspaceB.clientState.set("selected-panel", "files");
-	await workspaceB.close();
+	await repositoryB.clientState.set("selected-panel", "files");
+	await repositoryB.close();
 
 	const reopenedA = await openRemote("https://lixray.test/@acme/a/");
 	await expect(reopenedA.clientState.get("selected-panel")).resolves.toBe(

--- a/packages/js-sdk/src/open-lix.test.ts
+++ b/packages/js-sdk/src/open-lix.test.ts
@@ -797,7 +797,7 @@ test("fs storage syncAllFiles validates option shape", () => {
 	).toThrow("LocalFilesystem syncAllFiles must be a boolean");
 });
 
-test("fs storage on-demand sync imports no regular workspace files initially", async () => {
+test("fs storage on-demand sync imports no regular repository files initially", async () => {
 	const dir = tempFsDir();
 	const lixDir = tempExternalLixDir();
 	mkdirSync(dir, { recursive: true });
@@ -947,7 +947,7 @@ test("fs storage on-demand sync matches directory paths by segment boundaries", 
 	await lix.close();
 });
 
-test("fs storage with external lixDir materializes lix storage outside the workspace", async () => {
+test("fs storage with external lixDir materializes lix storage outside the repository", async () => {
 	const dir = tempFsDir();
 	const lixDir = tempExternalLixDir();
 	mkdirSync(dir, { recursive: true });

--- a/packages/js-sdk/src/remote/client.test.ts
+++ b/packages/js-sdk/src/remote/client.test.ts
@@ -3,13 +3,13 @@ import { gunzipSync } from "fflate";
 import { openLix } from "../index.js";
 import { openRemoteLixBinding } from "./client.js";
 
-test("remote handshake requests a restored initial active branch", async () => {
+test("Lix Server Protocol handshake requests a restored initial active branch", async () => {
 	const accountId = "01920000-0000-7000-8000-000000000601";
 	const requests: Request[] = [];
 	const binding = await openRemoteLixBinding(
 		{
 			mode: "remote",
-			url: "https://lixray.test/@acme/workspace",
+			url: "https://lixray.test/@acme/repository",
 			fetch: async (input, init) => {
 				const request = new Request(input, init);
 				requests.push(request);
@@ -30,7 +30,7 @@ test("remote handshake requests a restored initial active branch", async () => {
 	);
 
 	const handshakeUrl = new URL(requests[0]?.url ?? "");
-	expect(handshakeUrl.pathname).toBe("/@acme/workspace/lix/v1/");
+	expect(handshakeUrl.pathname).toBe("/@acme/repository/lix/v1/");
 	expect(handshakeUrl.searchParams.get("activeBranchId")).toBe("draft / one");
 	expect(handshakeUrl.searchParams.has("activeAccountId")).toBe(false);
 	expect(requests[0]?.headers.has("lix-session-id")).toBe(false);
@@ -50,7 +50,7 @@ async function requestJson(request: Request): Promise<unknown> {
 	return JSON.parse(new TextDecoder().decode(decoded));
 }
 
-test("remote mode uses the workspace protocol without loading a local engine", async () => {
+test("remote mode uses the repository protocol without loading a local engine", async () => {
 	const requests: Request[] = [];
 	let headerCalls = 0;
 	const remoteFetch = vi.fn(
@@ -88,7 +88,7 @@ test("remote mode uses the workspace protocol without loading a local engine", a
 	const lix = await openLix({
 		server: {
 			mode: "remote",
-			url: "https://lixray.test/@acme/workspace",
+			url: "https://lixray.test/@acme/repository",
 			fetch: remoteFetch as typeof fetch,
 			headers: () => {
 				headerCalls += 1;
@@ -122,8 +122,8 @@ test("remote mode uses the workspace protocol without loading a local engine", a
 	expect(result.rows[0]?.get("json")).toEqual({ ok: true });
 	expect(headerCalls).toBe(2);
 	expect(requests.map((request) => new URL(request.url).pathname)).toEqual([
-		"/@acme/workspace/lix/v1/",
-		"/@acme/workspace/lix/v1/execute",
+		"/@acme/repository/lix/v1/",
+		"/@acme/repository/lix/v1/execute",
 	]);
 	expect(requests[1]?.headers.get("authorization")).toBe("Bearer token-2");
 	expect(requests[0]?.headers.has("lix-session-id")).toBe(false);
@@ -147,7 +147,7 @@ test("remote mode uses the workspace protocol without loading a local engine", a
 
 	await lix.close();
 	expect(new URL(requests[2]?.url ?? "").pathname).toBe(
-		"/@acme/workspace/lix/v1/session",
+		"/@acme/repository/lix/v1/session",
 	);
 	expect(requests[2]?.method).toBe("DELETE");
 	expect(requests[2]?.headers.get("lix-session-id")).toBe("session-1");
@@ -158,7 +158,7 @@ test("remote mode compresses only large compressible JSON requests", async () =>
 	const lix = await openLix({
 		server: {
 			mode: "remote",
-			url: "https://lixray.test/@acme/workspace",
+			url: "https://lixray.test/@acme/repository",
 			fetch: async (input, init) => {
 				const request = new Request(input, init);
 				const pathname = new URL(request.url).pathname;
@@ -225,7 +225,7 @@ test("remote executeBatch uses the first-class atomic batch endpoint", async () 
 	const lix = await openLix({
 		server: {
 			mode: "remote",
-			url: "https://lixray.test/@acme/workspace",
+			url: "https://lixray.test/@acme/repository",
 			fetch: async (input, init) => {
 				const request = new Request(input, init);
 				requests.push(request.clone());
@@ -273,7 +273,7 @@ test("remote executeBatch uses the first-class atomic batch endpoint", async () 
 		[1, undefined],
 	]);
 	expect(new URL(requests[1]?.url ?? "").pathname).toBe(
-		"/@acme/workspace/lix/v1/execute-batch",
+		"/@acme/repository/lix/v1/execute-batch",
 	);
 	expect(requests[1]?.headers.get("idempotency-key")).toMatch(
 		/^[0-9a-f-]{36}$/,
@@ -301,7 +301,7 @@ test("remote execute sends successful large blob updates as exact splices", asyn
 	const lix = await openLix({
 		server: {
 			mode: "remote",
-			url: "https://lixray.test/workspace",
+			url: "https://lixray.test/repository",
 			fetch: async (input, init) => {
 				const request = new Request(input, init);
 				const pathname = new URL(request.url).pathname;
@@ -373,7 +373,7 @@ test("remote execute splices the exact 10.68 MB CSV-size blob", async () => {
 	const lix = await openLix({
 		server: {
 			mode: "remote",
-			url: "https://lixray.test/workspace",
+			url: "https://lixray.test/repository",
 			fetch: async (input, init) => {
 				const request = new Request(input, init);
 				const pathname = new URL(request.url).pathname;
@@ -421,7 +421,7 @@ test("remote execute retries a missing blob base once with full bytes", async ()
 	const lix = await openLix({
 		server: {
 			mode: "remote",
-			url: "https://lixray.test/workspace",
+			url: "https://lixray.test/repository",
 			fetch: async (input, init) => {
 				const request = new Request(input, init);
 				const pathname = new URL(request.url).pathname;
@@ -474,7 +474,7 @@ test("remote execute uses a caller idempotency key only as a header", async () =
 	const lix = await openLix({
 		server: {
 			mode: "remote",
-			url: "https://lixray.test/workspace",
+			url: "https://lixray.test/repository",
 			fetch: async (input, init) => {
 				const request = new Request(input, init);
 				requests.push(request.clone());
@@ -509,7 +509,7 @@ test("remote execute keeps small and low-saving blob updates full", async () => 
 	const lix = await openLix({
 		server: {
 			mode: "remote",
-			url: "https://lixray.test/workspace",
+			url: "https://lixray.test/repository",
 			fetch: async (input, init) => {
 				const request = new Request(input, init);
 				const pathname = new URL(request.url).pathname;
@@ -540,12 +540,12 @@ test("remote execute keeps small and low-saving blob updates full", async () => 
 	expect(bodies[2]).not.toHaveProperty("cacheBlobs");
 });
 
-test("remote protocol v2 uses blob splices without capability negotiation", async () => {
+test("Lix Server Protocol v2 uses blob splices without capability negotiation", async () => {
 	const bodies: Array<Record<string, unknown>> = [];
 	const lix = await openLix({
 		server: {
 			mode: "remote",
-			url: "https://lixray.test/workspace",
+			url: "https://lixray.test/repository",
 			fetch: async (input, init) => {
 				const request = new Request(input, init);
 				const pathname = new URL(request.url).pathname;
@@ -589,7 +589,7 @@ test("remote executeBatch uses blob splices for stable statement slots", async (
 	const lix = await openLix({
 		server: {
 			mode: "remote",
-			url: "https://lixray.test/workspace",
+			url: "https://lixray.test/repository",
 			fetch: async (input, init) => {
 				const request = new Request(input, init);
 				const pathname = new URL(request.url).pathname;
@@ -631,7 +631,7 @@ test("remote branches preserve local Lix branch semantics", async () => {
 	const lix = await openLix({
 		server: {
 			mode: "remote",
-			url: new URL("https://lixray.test/@acme/workspace/"),
+			url: new URL("https://lixray.test/@acme/repository/"),
 			fetch: (async (input: RequestInfo | URL, init?: RequestInit) => {
 				const request = new Request(input, init);
 				requests.push(request.clone());
@@ -687,7 +687,7 @@ test("remote createCheckpoint posts no body and decodes the receipt", async () =
 	const lix = await openLix({
 		server: {
 			mode: "remote",
-			url: "https://lixray.test/@acme/workspace",
+			url: "https://lixray.test/@acme/repository",
 			fetch: (async (input: RequestInfo | URL, init?: RequestInit) => {
 				const request = new Request(input, init);
 				requests.push(request.clone());
@@ -728,7 +728,7 @@ test("remote undo and redo decode branch-history receipts", async () => {
 	const lix = await openLix({
 		server: {
 			mode: "remote",
-			url: "https://lixray.test/@acme/workspace",
+			url: "https://lixray.test/@acme/repository",
 			fetch: (async (input: RequestInfo | URL, init?: RequestInit) => {
 				const request = new Request(input, init);
 				const pathname = new URL(request.url).pathname;
@@ -780,7 +780,7 @@ test("a failed remote branch switch leaves the active branch unchanged", async (
 	const lix = await openLix({
 		server: {
 			mode: "remote",
-			url: "https://lixray.test/@acme/workspace",
+			url: "https://lixray.test/@acme/repository",
 			fetch: (async (input: RequestInfo | URL, init?: RequestInit) => {
 				const request = new Request(input, init);
 				const pathname = new URL(request.url).pathname;
@@ -833,7 +833,7 @@ test("an ambiguous remote branch switch is reconciled by the next branch read", 
 	const lix = await openLix({
 		server: {
 			mode: "remote",
-			url: "https://lixray.test/@acme/workspace",
+			url: "https://lixray.test/@acme/repository",
 			fetch: (async (input: RequestInfo | URL, init?: RequestInit) => {
 				const request = new Request(input, init);
 				const pathname = new URL(request.url).pathname;
@@ -862,7 +862,7 @@ test("an ambiguous remote branch switch is reconciled by the next branch read", 
 	await expect(
 		lix.switchBranch({ branchId: "draft-id" }),
 	).rejects.toMatchObject({
-		code: "LIX_REMOTE_PROTOCOL_ERROR",
+		code: "LIX_SERVER_PROTOCOL_ERROR",
 	});
 	expect(await lix.activeBranchId()).toBe("draft-id");
 	expect(handshakeCalls).toBe(2);
@@ -875,7 +875,7 @@ test("branch reconciliation rejects and never caches a replacement session", asy
 	const lix = await openLix({
 		server: {
 			mode: "remote",
-			url: "https://lixray.test/@acme/workspace",
+			url: "https://lixray.test/@acme/repository",
 			fetch: (async (input: RequestInfo | URL, init?: RequestInit) => {
 				const request = new Request(input, init);
 				const pathname = new URL(request.url).pathname;
@@ -902,15 +902,15 @@ test("branch reconciliation rejects and never caches a replacement session", asy
 	await expect(
 		lix.switchBranch({ branchId: "draft-id" }),
 	).rejects.toMatchObject({
-		code: "LIX_REMOTE_PROTOCOL_ERROR",
+		code: "LIX_SERVER_PROTOCOL_ERROR",
 	});
 	await expect(lix.activeBranchId()).rejects.toMatchObject({
-		code: "LIX_REMOTE_PROTOCOL_ERROR",
-		message: "remote handshake changed sessionId",
+		code: "LIX_SERVER_PROTOCOL_ERROR",
+		message: "Lix Server Protocol handshake changed sessionId",
 	});
 	await expect(lix.activeBranchId()).rejects.toMatchObject({
-		code: "LIX_REMOTE_PROTOCOL_ERROR",
-		message: "remote handshake changed sessionId",
+		code: "LIX_SERVER_PROTOCOL_ERROR",
+		message: "Lix Server Protocol handshake changed sessionId",
 	});
 	expect(handshakeCalls).toBe(3);
 
@@ -952,7 +952,7 @@ test("remote clients retain independent active branches", async () => {
 	const options = {
 		server: {
 			mode: "remote" as const,
-			url: "https://lixray.test/@acme/workspace",
+			url: "https://lixray.test/@acme/repository",
 			fetch: remoteFetch,
 		},
 	};
@@ -976,7 +976,7 @@ test("remote operations preserve normal Lix call ordering", async () => {
 	const lix = await openLix({
 		server: {
 			mode: "remote",
-			url: "https://lixray.test/@acme/workspace",
+			url: "https://lixray.test/@acme/repository",
 			fetch: async (input, init) => {
 				const request = new Request(input, init);
 				const pathname = new URL(request.url).pathname;
@@ -1035,7 +1035,7 @@ test("remote responses reject malformed rows and non-JSON HTTP errors", async ()
 	const lix = await openLix({
 		server: {
 			mode: "remote",
-			url: "https://lixray.test/@acme/workspace",
+			url: "https://lixray.test/@acme/repository",
 			fetch: async (input, init) => {
 				const request = new Request(input, init);
 				const pathname = new URL(request.url).pathname;
@@ -1064,7 +1064,7 @@ test("remote responses reject malformed rows and non-JSON HTTP errors", async ()
 	});
 
 	await expect(lix.execute("SELECT malformed")).rejects.toMatchObject({
-		code: "LIX_REMOTE_PROTOCOL_ERROR",
+		code: "LIX_SERVER_PROTOCOL_ERROR",
 	});
 	await expect(lix.execute("SELECT unavailable")).rejects.toMatchObject({
 		code: "LIX_REMOTE_REQUEST_FAILED",
@@ -1085,7 +1085,7 @@ test("remote beginTransaction uses one capability-bound server lifecycle", async
 	const lix = await openLix({
 		server: {
 			mode: "remote",
-			url: "https://lixray.test/@acme/workspace",
+			url: "https://lixray.test/@acme/repository",
 			fetch: async (input, init) => {
 				const request = new Request(input, init);
 				const path = new URL(request.url).pathname;
@@ -1140,11 +1140,11 @@ test("remote beginTransaction uses one capability-bound server lifecycle", async
 	await lix.close();
 
 	expect(requests).toEqual([
-		{ method: "GET", path: "/@acme/workspace/lix/v1/" },
-		{ method: "POST", path: "/@acme/workspace/lix/v1/transaction/begin" },
+		{ method: "GET", path: "/@acme/repository/lix/v1/" },
+		{ method: "POST", path: "/@acme/repository/lix/v1/transaction/begin" },
 		{
 			method: "POST",
-			path: "/@acme/workspace/lix/v1/transaction/execute",
+			path: "/@acme/repository/lix/v1/transaction/execute",
 			transactionId: "transaction-1",
 			body: {
 				sql: "SELECT $1 AS value",
@@ -1154,16 +1154,16 @@ test("remote beginTransaction uses one capability-bound server lifecycle", async
 		},
 		{
 			method: "POST",
-			path: "/@acme/workspace/lix/v1/transaction/commit",
+			path: "/@acme/repository/lix/v1/transaction/commit",
 			transactionId: "transaction-1",
 		},
-		{ method: "POST", path: "/@acme/workspace/lix/v1/transaction/begin" },
+		{ method: "POST", path: "/@acme/repository/lix/v1/transaction/begin" },
 		{
 			method: "POST",
-			path: "/@acme/workspace/lix/v1/transaction/rollback",
+			path: "/@acme/repository/lix/v1/transaction/rollback",
 			transactionId: "transaction-1",
 		},
-		{ method: "DELETE", path: "/@acme/workspace/lix/v1/session" },
+		{ method: "DELETE", path: "/@acme/repository/lix/v1/session" },
 	]);
 });
 
@@ -1171,7 +1171,7 @@ test("remote mode rejects unsupported local-only operations honestly", async () 
 	const lix = await openLix({
 		server: {
 			mode: "remote",
-			url: "https://lixray.test/@acme/workspace",
+			url: "https://lixray.test/@acme/repository",
 			fetch: (async () =>
 				Response.json({
 					protocolVersion: 2,
@@ -1199,7 +1199,7 @@ test("remote mode rejects incompatible protocol versions", async () => {
 			storage: undefined,
 			server: {
 				mode: "remote",
-				url: "https://lixray.test/workspace",
+				url: "https://lixray.test/repository",
 				fetch: (async () =>
 					Response.json({
 						protocolVersion: 1,
@@ -1209,7 +1209,7 @@ test("remote mode rejects incompatible protocol versions", async () => {
 					})) as typeof fetch,
 			},
 		}),
-	).rejects.toMatchObject({ code: "LIX_REMOTE_PROTOCOL_ERROR" });
+	).rejects.toMatchObject({ code: "LIX_SERVER_PROTOCOL_ERROR" });
 });
 
 test.each([undefined, "", " contains-space", "contains\nnewline", 42])(
@@ -1219,7 +1219,7 @@ test.each([undefined, "", " contains-space", "contains\nnewline", 42])(
 			openLix({
 				server: {
 					mode: "remote",
-					url: "https://lixray.test/workspace",
+					url: "https://lixray.test/repository",
 					fetch: (async () =>
 						Response.json({
 							protocolVersion: 2,
@@ -1229,7 +1229,7 @@ test.each([undefined, "", " contains-space", "contains\nnewline", 42])(
 						})) as typeof fetch,
 				},
 			}),
-		).rejects.toMatchObject({ code: "LIX_REMOTE_PROTOCOL_ERROR" });
+		).rejects.toMatchObject({ code: "LIX_SERVER_PROTOCOL_ERROR" });
 	},
 );
 
@@ -1238,7 +1238,7 @@ test("active branch reads reuse the initial handshake without another GET", asyn
 	const lix = await openLix({
 		server: {
 			mode: "remote",
-			url: "https://lixray.test/workspace",
+			url: "https://lixray.test/repository",
 			fetch: async (input, init) => {
 				const request = new Request(input, init);
 				if (request.method === "DELETE") {
@@ -1267,7 +1267,7 @@ test("an expired session mutation is propagated without a new handshake or retry
 	const lix = await openLix({
 		server: {
 			mode: "remote",
-			url: "https://lixray.test/workspace",
+			url: "https://lixray.test/repository",
 			fetch: async (input, init) => {
 				const request = new Request(input, init);
 				const pathname = new URL(request.url).pathname;
@@ -1315,7 +1315,7 @@ test("close waits for queued operations before deleting the remote session", asy
 	const lix = await openLix({
 		server: {
 			mode: "remote",
-			url: "https://lixray.test/workspace",
+			url: "https://lixray.test/repository",
 			fetch: async (input, init) => {
 				const request = new Request(input, init);
 				const pathname = new URL(request.url).pathname;

--- a/packages/js-sdk/src/remote/client.ts
+++ b/packages/js-sdk/src/remote/client.ts
@@ -31,14 +31,14 @@ import {
 	errorFromResponseBody,
 	protocolError,
 	record,
-	REMOTE_PROTOCOL_PATH,
+	SERVER_PROTOCOL_PATH,
 	remoteError,
-	type RemoteHandshakeRequest,
-	type RemoteObserveSubscription,
+	type ServerProtocolHandshakeRequest,
+	type ServerProtocolObserveSubscription,
 	type WireRequestBlobSplice,
 	type WireRequestValue,
 	type WireValue,
-} from "./protocol.js";
+} from "./server-protocol.js";
 import { readSseEvents } from "./sse.js";
 
 const OBSERVE_RETRY_BASE_MS = 100;
@@ -65,7 +65,7 @@ const MAX_COMPRESSION_SAMPLE_RATIO = 0.7;
 const MAX_COMPRESSED_BODY_RATIO = 0.9;
 
 type RemoteLixClientOptions = {
-	initialActiveBranchId?: RemoteHandshakeRequest["activeBranchId"];
+	initialActiveBranchId?: ServerProtocolHandshakeRequest["activeBranchId"];
 };
 
 export async function openRemoteLixBinding(
@@ -342,7 +342,9 @@ class RemoteLixBinding implements LixBinding {
 					await this.#requestJson("", { method: "GET" }),
 				);
 				if (handshake.sessionId !== this.#sessionId) {
-					throw protocolError("remote handshake changed sessionId");
+					throw protocolError(
+						"Lix Server Protocol handshake changed sessionId",
+					);
 				}
 				this.#activeBranchId = handshake.activeBranchId;
 			}
@@ -358,7 +360,9 @@ class RemoteLixBinding implements LixBinding {
 					await this.#requestJson("", { method: "GET" }),
 				);
 				if (handshake.sessionId !== this.#sessionId) {
-					throw protocolError("remote handshake changed sessionId");
+					throw protocolError(
+						"Lix Server Protocol handshake changed sessionId",
+					);
 				}
 				this.#activeAccountId = handshake.activeAccountId;
 			}
@@ -581,7 +585,7 @@ class RemoteLixBinding implements LixBinding {
 	}
 
 	async #requestObserveStream(
-		subscriptions: RemoteObserveSubscription[],
+		subscriptions: ServerProtocolObserveSubscription[],
 		signal: AbortSignal,
 	): Promise<Response> {
 		let headers: Headers;
@@ -629,7 +633,7 @@ class RemoteLixBinding implements LixBinding {
 	}
 
 	async #refreshObservation(
-		subscription: RemoteObserveSubscription,
+		subscription: ServerProtocolObserveSubscription,
 	): Promise<BindingExecuteResult> {
 		return this.#enqueue(async () => {
 			const value = await this.#requestJson("execute", {
@@ -988,11 +992,11 @@ type ObserveOutcome =
 
 type RemoteObservationHubOptions = {
 	openStream(
-		subscriptions: RemoteObserveSubscription[],
+		subscriptions: ServerProtocolObserveSubscription[],
 		signal: AbortSignal,
 	): Promise<Response>;
 	refreshObservation(
-		subscription: RemoteObserveSubscription,
+		subscription: ServerProtocolObserveSubscription,
 	): Promise<BindingExecuteResult>;
 };
 
@@ -1016,7 +1020,7 @@ class RemoteObservationHub {
 
 	observe(
 		sql: string,
-		params: RemoteObserveSubscription["params"],
+		params: ServerProtocolObserveSubscription["params"],
 	): RemoteObservation {
 		const id = `observe-${++this.#nextObservationId}`;
 		const observation = new RemoteObservation({
@@ -1309,14 +1313,14 @@ class RemoteObservationHub {
 	}
 }
 
-type RemoteObservationOptions = RemoteObserveSubscription & {
+type RemoteObservationOptions = ServerProtocolObserveSubscription & {
 	onClose(): void;
 };
 
 class RemoteObservation implements ObserveEventsBinding {
 	readonly #id: string;
 	readonly #sql: string;
-	readonly #params: RemoteObserveSubscription["params"];
+	readonly #params: ServerProtocolObserveSubscription["params"];
 	readonly #onClose: () => void;
 	#outcomes: ObserveOutcome[] = [];
 	#waiters: ObserveWaiter[] = [];
@@ -1332,7 +1336,7 @@ class RemoteObservation implements ObserveEventsBinding {
 		this.#onClose = options.onClose;
 	}
 
-	request(): RemoteObserveSubscription {
+	request(): ServerProtocolObserveSubscription {
 		return { id: this.#id, sql: this.#sql, params: this.#params };
 	}
 
@@ -1502,7 +1506,7 @@ function asObserveProtocolError(error: unknown, event: string): Error {
 	if (
 		error instanceof Error &&
 		"code" in error &&
-		(error as { code?: string }).code === "LIX_REMOTE_PROTOCOL_ERROR"
+		(error as { code?: string }).code === "LIX_SERVER_PROTOCOL_ERROR"
 	) {
 		return error;
 	}
@@ -1593,22 +1597,25 @@ function stringArraysEqual(left: string[], right: string[]): boolean {
 }
 
 function protocolBaseUrl(value: string | URL): URL {
-	let workspaceUrl: URL;
+	let repositoryUrl: URL;
 	try {
-		workspaceUrl = new URL(value);
+		repositoryUrl = new URL(value);
 	} catch {
 		throw new TypeError("openLix() remote server url must be an absolute URL");
 	}
-	if (workspaceUrl.protocol !== "http:" && workspaceUrl.protocol !== "https:") {
+	if (
+		repositoryUrl.protocol !== "http:" &&
+		repositoryUrl.protocol !== "https:"
+	) {
 		throw new TypeError("openLix() remote server url must use http or https");
 	}
-	if (workspaceUrl.search || workspaceUrl.hash) {
+	if (repositoryUrl.search || repositoryUrl.hash) {
 		throw new TypeError(
 			"openLix() remote server url must not contain a query or fragment",
 		);
 	}
-	workspaceUrl.pathname = `${workspaceUrl.pathname.replace(/\/$/, "")}${REMOTE_PROTOCOL_PATH}`;
-	return workspaceUrl;
+	repositoryUrl.pathname = `${repositoryUrl.pathname.replace(/\/$/, "")}${SERVER_PROTOCOL_PATH}`;
+	return repositoryUrl;
 }
 
 function unsupportedRemoteOperation(

--- a/packages/js-sdk/src/remote/observe.test.ts
+++ b/packages/js-sdk/src/remote/observe.test.ts
@@ -6,7 +6,7 @@ test("remote observe streams native Lix results", async () => {
 	const lix = await openLix({
 		server: {
 			mode: "remote",
-			url: "https://lixray.test/@acme/workspace",
+			url: "https://lixray.test/@acme/repository",
 			fetch: async (input, init) => {
 				const request = new Request(input, init);
 				requests.push(request.clone());
@@ -33,7 +33,7 @@ test("remote observe streams native Lix results", async () => {
 	expect(requests[1]?.headers.get("accept")).toBe("text/event-stream");
 	expect(requests[1]?.headers.get("lix-session-id")).toBe("session-1");
 	expect(new URL(requests[1]?.url ?? "").pathname).toBe(
-		"/@acme/workspace/lix/v1/observe/multiplex",
+		"/@acme/repository/lix/v1/observe/multiplex",
 	);
 	expect(await requests[1]?.json()).toEqual({
 		subscriptions: [
@@ -91,7 +91,7 @@ test("remote observe applies every blob delta before coalescing delivery", async
 	const lix = await openLix({
 		server: {
 			mode: "remote",
-			url: "https://lixray.test/@acme/workspace",
+			url: "https://lixray.test/@acme/repository",
 			fetch: async (input, init) => {
 				const request = new Request(input, init);
 				if (request.method === "DELETE") return closedSession();
@@ -166,7 +166,7 @@ test("remote observe applies sequential row deltas before coalescing delivery", 
 	const lix = await openLix({
 		server: {
 			mode: "remote",
-			url: "https://lixray.test/@acme/workspace",
+			url: "https://lixray.test/@acme/repository",
 			fetch: async (input, init) => {
 				const request = new Request(input, init);
 				if (request.method === "DELETE") return closedSession();
@@ -205,7 +205,7 @@ test("remote observe multiplexes more than six subscriptions without blocking ex
 	const lix = await openLix({
 		server: {
 			mode: "remote",
-			url: "https://lixray.test/@acme/workspace",
+			url: "https://lixray.test/@acme/repository",
 			headers: () => {
 				headerResolutions += 1;
 				return {};
@@ -310,7 +310,7 @@ test("hub-wide protocol failures abort a held multiplex stream without reconnect
 		const lix = await openLix({
 			server: {
 				mode: "remote",
-				url: "https://lixray.test/@acme/workspace",
+				url: "https://lixray.test/@acme/repository",
 				fetch: async (input, init) => {
 					const request = new Request(input, init);
 					if (new URL(request.url).pathname.endsWith("/lix/v1/")) {
@@ -339,7 +339,7 @@ test("hub-wide protocol failures abort a held multiplex stream without reconnect
 
 		const events = lix.observe("SELECT value");
 		await expect(events.next()).rejects.toMatchObject({
-			code: "LIX_REMOTE_PROTOCOL_ERROR",
+			code: "LIX_SERVER_PROTOCOL_ERROR",
 		});
 		expect(liveObserveRequests).toBe(0);
 		await vi.advanceTimersByTimeAsync(10_000);
@@ -358,7 +358,7 @@ test("remote observe can continue after a semantic SSE error", async () => {
 		const lix = await openLix({
 			server: {
 				mode: "remote",
-				url: "https://lixray.test/@acme/workspace",
+				url: "https://lixray.test/@acme/repository",
 				fetch: async (input, init) => {
 					const request = new Request(input, init);
 					if (new URL(request.url).pathname.endsWith("/lix/v1/")) {
@@ -420,7 +420,7 @@ test("remote observe treats unmarked semantic errors as terminal", async () => {
 		const lix = await openLix({
 			server: {
 				mode: "remote",
-				url: "https://lixray.test/@acme/workspace",
+				url: "https://lixray.test/@acme/repository",
 				fetch: async (input, init) => {
 					const request = new Request(input, init);
 					if (new URL(request.url).pathname.endsWith("/lix/v1/")) {
@@ -464,7 +464,7 @@ test("a successful branch switch restarts observations on the pinned session", a
 	const lix = await openLix({
 		server: {
 			mode: "remote",
-			url: "https://lixray.test/@acme/workspace",
+			url: "https://lixray.test/@acme/repository",
 			fetch: async (input, init) => {
 				const request = new Request(input, init);
 				const pathname = new URL(request.url).pathname;
@@ -544,7 +544,7 @@ test("a local branch switch setup failure preserves a healthy observation", asyn
 	const lix = await openLix({
 		server: {
 			mode: "remote",
-			url: "https://lixray.test/@acme/workspace",
+			url: "https://lixray.test/@acme/repository",
 			headers: () => {
 				if (failHeaders) throw new Error("headers unavailable");
 				return {};
@@ -598,7 +598,7 @@ test("remote observe reconnects retryable failures with fresh headers", async ()
 		const lix = await openLix({
 			server: {
 				mode: "remote",
-				url: "https://lixray.test/@acme/workspace",
+				url: "https://lixray.test/@acme/repository",
 				headers: () => ({ Authorization: `Bearer token-${++headerCalls}` }),
 				fetch: async (input, init) => {
 					const request = new Request(input, init);
@@ -667,7 +667,7 @@ test("closing Lix resolves pending remote observation reads", async () => {
 	const lix = await openLix({
 		server: {
 			mode: "remote",
-			url: "https://lixray.test/@acme/workspace",
+			url: "https://lixray.test/@acme/repository",
 			fetch: async (input, init) => {
 				const request = new Request(input, init);
 				if (request.method === "DELETE") return closedSession();
@@ -691,7 +691,7 @@ test("closing Lix stops observations before an earlier finite request settles", 
 	const lix = await openLix({
 		server: {
 			mode: "remote",
-			url: "https://lixray.test/@acme/workspace",
+			url: "https://lixray.test/@acme/repository",
 			fetch: async (input, init) => {
 				const request = new Request(input, init);
 				const pathname = new URL(request.url).pathname;

--- a/packages/js-sdk/src/remote/server-protocol.test.ts
+++ b/packages/js-sdk/src/remote/server-protocol.test.ts
@@ -5,7 +5,7 @@ import {
 	decodeHandshake,
 	decodeObserveEvent,
 	encodeWireValue,
-} from "./protocol.js";
+} from "./server-protocol.js";
 
 test("remote executeBatch requires positional metadata and preserves labels", () => {
 	const result = decodeExecuteBatchResult({
@@ -89,7 +89,7 @@ test("remote blobs use native typed-array base64 when available", () => {
 			}),
 		).toThrow(
 			expect.objectContaining({
-				code: "LIX_REMOTE_PROTOCOL_ERROR",
+				code: "LIX_SERVER_PROTOCOL_ERROR",
 				message: "blob wire value contains invalid base64",
 			}),
 		);

--- a/packages/js-sdk/src/remote/server-protocol.ts
+++ b/packages/js-sdk/src/remote/server-protocol.ts
@@ -4,8 +4,8 @@ import type {
 } from "../binding-types.js";
 import type { NativeLixValue } from "../value.js";
 
-export const REMOTE_PROTOCOL_VERSION = 2;
-export const REMOTE_PROTOCOL_PATH = "/lix/v1/";
+export const SERVER_PROTOCOL_VERSION = 2;
+export const SERVER_PROTOCOL_PATH = "/lix/v1/";
 
 export type WireValue =
 	| { kind: "null"; value: null }
@@ -27,25 +27,25 @@ export type WireRequestBlobSplice = {
 
 export type WireRequestValue = WireValue | WireRequestBlobSplice;
 
-export type RemoteHandshake = {
+export type ServerProtocolHandshake = {
 	protocolVersion: number;
 	activeBranchId: string;
 	activeAccountId: string;
 	sessionId: string;
 };
 
-export type RemoteHandshakeRequest = {
+export type ServerProtocolHandshakeRequest = {
 	activeBranchId?: string;
 };
 
-export type RemoteExecuteRequest = {
+export type ServerProtocolExecuteRequest = {
 	sql: string;
 	params: WireRequestValue[];
 	options?: { originKey?: string };
 	cacheBlobs?: true;
 };
 
-export type RemoteExecuteBatchRequest = {
+export type ServerProtocolExecuteBatchRequest = {
 	statements: Array<{
 		sql: string;
 		params: WireRequestValue[];
@@ -55,37 +55,38 @@ export type RemoteExecuteBatchRequest = {
 	cacheBlobs?: true;
 };
 
-export type RemoteExecuteResponse = {
+export type ServerProtocolExecuteResponse = {
 	columns: string[];
 	rows: WireValue[][];
 	rowsAffected: number;
 	notices: Array<{ code: string; message: string; hint?: string }>;
 };
 
-export type RemoteExecuteBatchResponse = RemoteExecuteResponse & {
-	statementIndex: number;
-	label?: string;
-};
+export type ServerProtocolExecuteBatchResponse =
+	ServerProtocolExecuteResponse & {
+		statementIndex: number;
+		label?: string;
+	};
 
-export type RemoteObserveRequest = {
+export type ServerProtocolObserveRequest = {
 	sql: string;
 	params: WireValue[];
 };
 
-export type RemoteObserveSubscription = RemoteObserveRequest & {
+export type ServerProtocolObserveSubscription = ServerProtocolObserveRequest & {
 	id: string;
 };
 
-export type RemoteMultiplexObserveRequest = {
-	subscriptions: RemoteObserveSubscription[];
+export type ServerProtocolMultiplexObserveRequest = {
+	subscriptions: ServerProtocolObserveSubscription[];
 };
 
-type RemoteObserveEventBase = {
+type ServerProtocolObserveEventBase = {
 	sequence: number;
 	mutationSequence: number;
 };
 
-export type RemoteObserveBlobDelta = {
+export type ServerProtocolObserveBlobDelta = {
 	kind: "single-blob-splice";
 	baseSequence: number;
 	prefixBytes: number;
@@ -93,7 +94,7 @@ export type RemoteObserveBlobDelta = {
 	insertBase64: string;
 };
 
-type RemoteObserveRowSplice = {
+type ServerProtocolObserveRowSplice = {
 	kind: "row-splice";
 	baseSequence: number;
 	prefixRows: number;
@@ -101,51 +102,53 @@ type RemoteObserveRowSplice = {
 	insertRows: WireValue[][];
 };
 
-type RemoteObserveDelta = RemoteObserveBlobDelta | RemoteObserveRowSplice;
+type ServerProtocolObserveDelta =
+	| ServerProtocolObserveBlobDelta
+	| ServerProtocolObserveRowSplice;
 
-export type RemoteObserveEvent = RemoteObserveEventBase &
+export type ServerProtocolObserveEvent = ServerProtocolObserveEventBase &
 	(
-		| { result: RemoteExecuteResponse; delta?: never }
-		| { result?: never; delta: RemoteObserveDelta }
+		| { result: ServerProtocolExecuteResponse; delta?: never }
+		| { result?: never; delta: ServerProtocolObserveDelta }
 	);
 
-export type RemoteMultiplexObserveEvent = RemoteObserveEvent & {
+export type ServerProtocolMultiplexObserveEvent = ServerProtocolObserveEvent & {
 	subscriptionId: string;
 };
 
-export type RemoteCreateBranchRequest = {
+export type ServerProtocolCreateBranchRequest = {
 	id?: string;
 	name: string;
 	fromCommitId?: string;
 };
 
-export type RemoteCreateBranchResponse = {
+export type ServerProtocolCreateBranchResponse = {
 	id: string;
 	name: string;
 	hidden: boolean;
 	commitId: string;
 };
 
-export type RemoteCreateCheckpointResponse = {
+export type ServerProtocolCreateCheckpointResponse = {
 	commitId: string;
 };
 
-export type RemoteUndoResponse = {
+export type ServerProtocolUndoResponse = {
 	branchId: string;
 	targetCommitId: string;
 	inverseCommitId: string;
 };
 
-export type RemoteRedoResponse = {
+export type ServerProtocolRedoResponse = {
 	branchId: string;
 	targetCommitId: string;
 	replayCommitId: string;
 };
 
-export type RemoteSwitchBranchRequest = { branchId: string };
-export type RemoteSwitchBranchResponse = { branchId: string };
+export type ServerProtocolSwitchBranchRequest = { branchId: string };
+export type ServerProtocolSwitchBranchResponse = { branchId: string };
 
-export type RemoteErrorBody = {
+export type ServerProtocolErrorBody = {
 	error: {
 		code?: string;
 		message?: string;
@@ -154,13 +157,14 @@ export type RemoteErrorBody = {
 	};
 };
 
-export type RemoteObserveErrorEvent = RemoteErrorBody & {
+export type ServerProtocolObserveErrorEvent = ServerProtocolErrorBody & {
 	retryable?: boolean;
 };
 
-export type RemoteMultiplexObserveErrorEvent = RemoteObserveErrorEvent & {
-	subscriptionId?: string;
-};
+export type ServerProtocolMultiplexObserveErrorEvent =
+	ServerProtocolObserveErrorEvent & {
+		subscriptionId?: string;
+	};
 
 export function encodeWireValue(value: NativeLixValue): WireValue {
 	switch (value.kind) {
@@ -247,33 +251,39 @@ export function decodeExecuteBatchResult(value: unknown): BindingExecuteResult {
 	};
 }
 
-export function decodeHandshake(value: unknown): RemoteHandshake {
-	const handshake = record(value, "remote handshake");
-	if (handshake.protocolVersion !== REMOTE_PROTOCOL_VERSION) {
+export function decodeHandshake(value: unknown): ServerProtocolHandshake {
+	const handshake = record(value, "Lix Server Protocol handshake");
+	if (handshake.protocolVersion !== SERVER_PROTOCOL_VERSION) {
 		throw protocolError(
-			`unsupported remote protocol version: ${String(handshake.protocolVersion)}`,
+			`unsupported Lix Server Protocol version: ${String(handshake.protocolVersion)}`,
 		);
 	}
 	if (
 		typeof handshake.activeBranchId !== "string" ||
 		handshake.activeBranchId.length === 0
 	) {
-		throw protocolError("remote handshake requires activeBranchId");
+		throw protocolError(
+			"Lix Server Protocol handshake requires activeBranchId",
+		);
 	}
 	if (
 		typeof handshake.activeAccountId !== "string" ||
 		handshake.activeAccountId.length === 0
 	) {
-		throw protocolError("remote handshake requires activeAccountId");
+		throw protocolError(
+			"Lix Server Protocol handshake requires activeAccountId",
+		);
 	}
 	if (
 		typeof handshake.sessionId !== "string" ||
 		!/^[\x21-\x7e]{1,256}$/.test(handshake.sessionId)
 	) {
-		throw protocolError("remote handshake requires a valid sessionId");
+		throw protocolError(
+			"Lix Server Protocol handshake requires a valid sessionId",
+		);
 	}
 	return {
-		protocolVersion: REMOTE_PROTOCOL_VERSION,
+		protocolVersion: SERVER_PROTOCOL_VERSION,
 		activeBranchId: handshake.activeBranchId,
 		activeAccountId: handshake.activeAccountId,
 		sessionId: handshake.sessionId,
@@ -501,15 +511,15 @@ export function remoteError(
 }
 
 export function protocolError(message: string): Error & { code: string } {
-	return remoteError("LIX_REMOTE_PROTOCOL_ERROR", message);
+	return remoteError("LIX_SERVER_PROTOCOL_ERROR", message);
 }
 
 export function errorFromResponseBody(
 	value: unknown,
 	status?: number,
 ): Error & { code: string } {
-	const body = record(value, "remote error response");
-	const rawError = record(body.error, "remote error response error");
+	const body = record(value, "Lix Server Protocol error response");
+	const rawError = record(body.error, "Lix Server Protocol error response error");
 	return remoteError(
 		typeof rawError.code === "string"
 			? rawError.code

--- a/packages/lix/src/binary_cas/chunking.rs
+++ b/packages/lix/src/binary_cas/chunking.rs
@@ -39,7 +39,7 @@ pub(crate) const CHUNK_ANCHOR_BYTES: usize = 16 * 1024 * 1024;
 
 /// Target average chunk size. Held at the previous fixed chunk size on purpose,
 /// so manifest row count, payload row count and the seek unit the movie
-/// workspace profile qualified all stay where they were; content-defined
+/// repository profile qualified all stay where they were; content-defined
 /// boundaries are the only difference.
 pub(crate) const MEDIA_CHUNK_BYTES: usize = 1024 * 1024;
 const MIN_BINARY_CAS_CHUNK_BYTES: usize = 256 * 1024;

--- a/packages/lix/src/common/execution_metadata.rs
+++ b/packages/lix/src/common/execution_metadata.rs
@@ -90,7 +90,7 @@ impl VerifiedRequestBlob {
 ///
 /// This is execution metadata, not a second public file-write API. Callers
 /// continue to bind the fully reconstructed blob through ordinary SQL. The
-/// remote protocol uses this sidecar so the file write path can hand an
+/// Lix Server Protocol uses this sidecar so the file write path can hand an
 /// incremental runtime the original localized edit without guessing it again
 /// from two complete blobs.
 #[doc(hidden)]

--- a/packages/lix/src/engine.rs
+++ b/packages/lix/src/engine.rs
@@ -2079,22 +2079,22 @@ mod tests {
         session
             .execute(
                 "INSERT INTO json_pointer (path, value, lixcol_untracked) \
-                 VALUES ('/workspace', lix_json('{\"source\":\"untracked\"}'), true)",
+                 VALUES ('/repository', lix_json('{\"source\":\"untracked\"}'), true)",
                 &[],
             )
             .await
             .expect("untracked row should write against the complete hot state");
-        let workspace_row = session
+        let repository_row = session
             .execute(
-                "SELECT value FROM json_pointer WHERE path = '/workspace'",
+                "SELECT value FROM json_pointer WHERE path = '/repository'",
                 &[],
             )
             .await
             .expect("untracked row should read from the complete hot state");
         assert_eq!(
-            workspace_row.rows()[0]
+            repository_row.rows()[0]
                 .get::<serde_json::Value>("value")
-                .expect("workspace value should decode"),
+                .expect("repository value should decode"),
             json!({"source": "untracked"})
         );
 
@@ -2116,7 +2116,7 @@ mod tests {
                 .iter()
                 .map(|row| row.get::<String>("path").expect("row path"))
                 .collect::<Vec<_>>(),
-            ["/after-checkpoint", "/checkpointed", "/workspace"]
+            ["/after-checkpoint", "/checkpointed", "/repository"]
         );
     }
 

--- a/packages/lix/src/gc.rs
+++ b/packages/lix/src/gc.rs
@@ -4535,7 +4535,7 @@ mod tests {
             .expect("corrupt-registry controls should load")
             .into_iter()
             .find(|(branch_id, _)| branch_id != GLOBAL_BRANCH_ID)
-            .expect("workspace branch control should exist");
+            .expect("repository branch control should exist");
         let timestamp =
             LixTimestamp::expect_parse("corrupt registry timestamp", "2026-01-01T00:00:00Z");
         let entity_pk = EntityPk::single(crate::plugin::runtime::PLUGIN_REGISTRY_KEY);

--- a/packages/lix/src/init.rs
+++ b/packages/lix/src/init.rs
@@ -43,7 +43,7 @@ const REGISTERED_SCHEMA_KEY: &str = "lix_registered_schema";
 /// Repository-wide compatibility gate for physical storage protocols.
 ///
 /// V66 makes the repository default branch a tracked bootstrap fact and
-/// removes the mutable workspace-branch selector. The hard cut rejects older
+/// removes the mutable repository-branch selector. The hard cut rejects older
 /// repositories instead of inferring or migrating the removed selector.
 pub(crate) const REPOSITORY_PROTOCOL_SPACE: StorageSpace = StorageSpace::declare(
     StorageSpaceId(0x0004_0011),

--- a/packages/lix/src/plugin/runtime/component.rs
+++ b/packages/lix/src/plugin/runtime/component.rs
@@ -13,7 +13,7 @@ use super::{
     PluginCatalogCache, PluginRegistry,
 };
 
-/// Installed plugins are untrusted workspace data. This is the absolute
+/// Installed plugins are untrusted repository data. This is the absolute
 /// per-export ceiling; a transition's tighter host budget remains authoritative
 /// for normal operations. The cold-file budget may extend up to this ceiling,
 /// but no guest call can exceed it.

--- a/packages/lix/src/plugin/runtime/default/mod.rs
+++ b/packages/lix/src/plugin/runtime/default/mod.rs
@@ -47,7 +47,7 @@ fn create_engine(consume_fuel: bool, epoch_interruption: bool) -> wasmtime::Resu
 
 /// Enables Wasmtime's host-local AOT cache for sandboxed plugin components.
 ///
-/// This cache is deliberately outside the workspace and its storage adapter:
+/// This cache is deliberately outside the repository and its storage adapter:
 /// native compiled artifacts are tied to the host architecture, Wasmtime
 /// version, and engine settings. Wasmtime keys and validates those artifacts
 /// itself, while the optional override makes isolated deployments and tests

--- a/packages/lix/src/plugin/runtime/incremental.rs
+++ b/packages/lix/src/plugin/runtime/incremental.rs
@@ -496,7 +496,7 @@ fn validate_transport_splice(
         .checked_add(provenance.insert().len())
         .and_then(|length| length.checked_add(suffix))
         .ok_or_else(|| invalid_input("transport splice result length overflowed"))?;
-    // This sidecar is constructed only after the remote protocol verifies the
+    // This sidecar is constructed only after the Lix Server Protocol verifies the
     // result hash and reconstructs the ordinary SQL blob. The caller has
     // separately matched the base hash to the actor's exact observed version;
     // rechecking unchanged prefix/suffix here would turn a localized edit back

--- a/packages/lix/src/server_protocol/mod.rs
+++ b/packages/lix/src/server_protocol/mod.rs
@@ -268,7 +268,7 @@ impl Event {
     }
 }
 
-/// Stable URL prefix owned by the Lix server protocol.
+/// Stable URL prefix owned by the Lix Server Protocol.
 pub const PROTOCOL_PATH: &str = "/lix/v1";
 /// Current wire protocol version.
 pub const PROTOCOL_VERSION: u32 = 2;
@@ -401,7 +401,7 @@ impl ServerProtocolContext {
     }
 }
 
-/// Resource limits for one repository's remote protocol sessions.
+/// Resource limits for one repository's Lix Server Protocol sessions.
 #[derive(Clone, Copy, Debug)]
 pub struct ServerProtocolOptions {
     /// Maximum number of retained remote sessions and their per-session caches.
@@ -8233,7 +8233,7 @@ mod tests {
     #[cfg(any())]
     #[tokio::test]
     #[ignore = "manual release-mode remote commit-to-observation capacity gate"]
-    async fn remote_protocol_converges_to_one_hundred_clients_below_one_hundred_ms_p95() {
+    async fn server_protocol_converges_to_one_hundred_clients_below_one_hundred_ms_p95() {
         const WAVE_SIZE: usize = 5;
         let clients = capacity_env_usize("LIX_COLLAB_CLIENTS", 100);
         let operations = capacity_env_usize("LIX_COLLAB_OPERATIONS", 100);
@@ -8789,7 +8789,7 @@ mod tests {
     }
 
     #[test]
-    fn request_blob_caches_share_one_workspace_byte_budget() {
+    fn request_blob_caches_share_one_repository_byte_budget() {
         let budget = Arc::new(RequestBlobCacheBudget::new(
             MIN_REQUEST_BLOB_CACHE_BYTES * 2,
         ));

--- a/packages/lix/src/session/execute.rs
+++ b/packages/lix/src/session/execute.rs
@@ -5729,7 +5729,7 @@ mod tests {
                 branch_id: branch_id.clone(),
             })
             .await
-            .expect("workspace should switch back to the rootless main branch");
+            .expect("repository should switch back to the rootless main branch");
         let main_session = &session;
         session
             .execute(
@@ -5995,7 +5995,7 @@ mod tests {
         let main_branch_id = main
             .active_branch_id()
             .await
-            .expect("workspace branch should resolve");
+            .expect("repository branch should resolve");
         let schema = serde_json::json!({
             "$schema": "https://json-schema.org/draft/2020-12/schema",
             "x-lix-key": "columnar_lifecycle_probe",

--- a/packages/lix/src/session/media_upload.rs
+++ b/packages/lix/src/session/media_upload.rs
@@ -929,7 +929,7 @@ mod tests {
     /// Making publishers share a compare-and-set row broke exactly this. It was
     /// invisible at the public surface because `upsert_file_content_part` retries
     /// a bounded number of times — a full window plus any other concurrent writer
-    /// exhausts that budget, which is how the movie-workspace qualification fails
+    /// exhausts that budget, which is how the movie-repository qualification fails
     /// its upload acknowledgement.
     #[tokio::test]
     async fn concurrent_upload_part_publications_from_one_snapshot_all_commit() {

--- a/packages/lix/src/sql2/catalog/registry.rs
+++ b/packages/lix/src/sql2/catalog/registry.rs
@@ -345,7 +345,7 @@ impl PublicCatalog {
                 ),
             )
             .with_hint(
-                "Custom `lix` and `lix_*` schema keys are incompatible with this Lix version. Migrate the workspace with application-specific tooling before upgrading.",
+                "Custom `lix` and `lix_*` schema keys are incompatible with this Lix version. Migrate the repository with application-specific tooling before upgrading.",
             ));
         }
 

--- a/packages/lix/src/transaction/commit.rs
+++ b/packages/lix/src/transaction/commit.rs
@@ -4700,7 +4700,7 @@ fn packed_current_base_guards_match(
 /// members. The two retention modes must never own the same logical identity.
 ///
 /// This is a merge/checkpoint lifecycle fence, not a normal CRUD-path check.
-/// Point-loading only the selected identities keeps large untracked workspaces
+/// Point-loading only the selected identities keeps large untracked repositories
 /// out of the publication cost.
 async fn reject_selected_tracked_refs_with_untracked_rows(
     read: &(impl StorageAdapterRead + ?Sized),
@@ -8026,7 +8026,7 @@ mod tests {
         let session = reopened
             .open_session()
             .await
-            .expect("workspace should reopen after rootless GC");
+            .expect("repository should reopen after rootless GC");
         let main = session
             .execute("SELECT id FROM lix_branch WHERE name = 'main'", &[])
             .await


### PR DESCRIPTION
## Summary

- hard-cut the JavaScript export from `@lix-js/sdk/remote-protocol` to `@lix-js/sdk/server-protocol`
- rename public protocol constants, wire types, errors, source files, and prose to Lix Server Protocol terminology
- replace remaining repository-domain `workspace` terminology in the SDK, Lix documentation, diagnostics, and tests
- provide no deprecated aliases or compatibility shims before 0.12

## Impact

Consumers must import `@lix-js/sdk/server-protocol`, use the `SERVER_PROTOCOL_*` constants and `ServerProtocol*` wire types, and recognize `LIX_SERVER_PROTOCOL_ERROR` for invalid protocol data.

## Validation

- clean JS SDK native, WebAssembly, TypeScript, and bundled-plugin build
- `npm run typecheck`
- native JS SDK tests: 134 passed
- focused protocol/client tests: 49 passed
- packaged export import and tarball-content verification
- `cargo clippy --profile test -p lix --all-targets --all-features -- -D warnings`
- focused Rust repository-state test with `storage-benches`
- change-fragment validation and repository-wide terminology audit
