### PR TITLE
perf(history): pin file_ids on the file-history descriptor/blob route

### DIFF
--- a/packages/e2e/tests/history_scaling_probe.rs
+++ b/packages/e2e/tests/history_scaling_probe.rs
@@ -16,7 +16,10 @@
 //!   count and the answer size pinned, by committing edits to a file the query
 //!   never asks about. Growth here is a real `O(commits traversed)` term. Its
 //!   `depth0` lane asks for a single row via `lixcol_depth = 0`, so any growth
-//!   there is work that a depth bound failed to prune.
+//!   there is work that a depth bound failed to prune. Its `null_control_kv`
+//!   lane reads a *different* history surface over the same commit graph, so it
+//!   cannot execute any `lix_file_history` routing change: whatever spread that
+//!   lane shows between two arms is the harness's noise floor.
 //!
 //! Both are `#[ignore]`d; run them by name with `--release`. Every knob is an
 //! environment variable so a curve can be widened without editing this file.
@@ -297,19 +300,39 @@ async fn history_commits_at_fixed_files() {
         let by_path_depth0 = "SELECT lixcol_depth FROM lix_file_history($1) \
                               WHERE path = $2 AND lixcol_depth = 0"
             .to_string();
+        // Null control. This walks the same commit graph over the same fixture
+        // through the same `load_history_entries` traversal and the same
+        // touched-scope digest, but it is a different history surface, so it
+        // cannot reach `lix_file_history`'s descriptor/blob route at all. Any
+        // arm-to-arm movement it shows is this harness's noise floor: a
+        // `lix_file_history` delta smaller than it is unresolvable.
+        let null_control_kv = "SELECT lixcol_depth FROM lix_key_value_history($1) \
+                               ORDER BY lixcol_depth DESC"
+            .to_string();
 
-        for (label, sql, arg) in [
-            ("by_path", &by_path, probe_path.clone()),
-            ("by_id", &by_id, file_id.clone()),
-            ("by_path_depth0", &by_path_depth0, noise_path.clone()),
+        for (label, sql, params) in [
+            (
+                "by_path",
+                &by_path,
+                vec![Value::Text(head.clone()), Value::Text(probe_path.clone())],
+            ),
+            (
+                "by_id",
+                &by_id,
+                vec![Value::Text(head.clone()), Value::Text(file_id.clone())],
+            ),
+            (
+                "by_path_depth0",
+                &by_path_depth0,
+                vec![Value::Text(head.clone()), Value::Text(noise_path.clone())],
+            ),
+            (
+                "null_control_kv",
+                &null_control_kv,
+                vec![Value::Text(head.clone())],
+            ),
         ] {
-            let (d, rows) = timed(
-                &lix,
-                sql,
-                &[Value::Text(head.clone()), Value::Text(arg)],
-                samples,
-            )
-            .await;
+            let (d, rows) = timed(&lix, sql, &params, samples).await;
             emit(
                 &format!(
                     "fixed_files {label} files={files} noise_commits={noise_commits} rows={rows}"

--- a/packages/lix/src/sql2/exec/datafusion.rs
+++ b/packages/lix/src/sql2/exec/datafusion.rs
@@ -6028,6 +6028,276 @@ mod tests {
         }
     }
 
+    /// The pinned descriptor/blob route must not narrow the answer.
+    ///
+    /// Pinning `file_ids` makes `change_matches_history_request` require a
+    /// non-null `file_id`, so a descriptor or blob-ref change carrying a null
+    /// or divergent one would silently vanish from file history — a
+    /// correctness bug wearing a performance win's clothes.
+    ///
+    /// The oracle is the **unfiltered** read. A `lix_file_history` query with
+    /// no `id`/`path` predicate resolves no lookup IDs at all, so it never
+    /// constructs the descriptor/blob route and cannot execute the pin; it is
+    /// the answer a completely unpruned traversal produces. Every filtered read
+    /// must equal that answer restricted to the same file.
+    ///
+    /// The shapes are the ones that could plausibly carry a null or divergent
+    /// `file_id`: a file inserted with **no explicit id**, where the planner
+    /// really does emit a descriptor row with `file_id: None` and only
+    /// `canonicalize_descriptor_file_id` fills it in; a rename, which rewrites
+    /// the descriptor without touching content; a content clear, which
+    /// tombstones the blob ref while the descriptor survives; a delete, which
+    /// tombstones both through the snapshot-less row builder; and a recreation
+    /// at the same path under a **different** id, so a path lookup resolves two
+    /// IDs and the per-file discrimination has to be exact rather than
+    /// vacuous.
+    #[tokio::test]
+    async fn pinned_file_history_route_returns_the_unfiltered_answer() {
+        let (session, _) = setup_engine_history_fixture()
+            .await
+            .expect("history fixture should initialize");
+
+        // Inserted with no explicit id: the engine mints one, and the planner
+        // stages the descriptor row with `file_id: None`.
+        session
+            .execute(
+                "INSERT INTO lix_file (path, content) \
+                 VALUES ('/docs/minted.md', CAST('v0' AS BYTEA))",
+                &[],
+            )
+            .await
+            .expect("id-less file insert should succeed");
+        let minted_id = session
+            .execute(
+                "SELECT id FROM lix_file WHERE path = '/docs/minted.md'",
+                &[],
+            )
+            .await
+            .expect("minted file id should resolve")
+            .rows()[0]
+            .values()[0]
+            .clone();
+        let Value::Text(minted_id) = minted_id else {
+            panic!("file id should be text");
+        };
+
+        for statement in [
+            // Content revisions: blob-ref rows.
+            "UPDATE lix_file SET content = CAST('v1' AS BYTEA) WHERE path = '/docs/minted.md'",
+            "UPDATE lix_file SET content = CAST('v2' AS BYTEA) WHERE path = '/docs/minted.md'",
+            // Rename: a descriptor rewrite with no content change.
+            "UPDATE lix_file SET path = '/docs/renamed.md' WHERE path = '/docs/minted.md'",
+            // Clear the content: blob-ref tombstone, descriptor survives.
+            "UPDATE lix_file SET content = CAST('' AS BYTEA) WHERE path = '/docs/renamed.md'",
+            // Content on the fixture's own file, so the oracle is not trivially
+            // a single-file history.
+            "UPDATE lix_file SET content = CAST('hello2' AS BYTEA) \
+             WHERE id = '01920000-0000-7000-8000-0000000000a2'",
+            // Delete: descriptor and blob-ref tombstones for the same file.
+            "DELETE FROM lix_file WHERE path = '/docs/renamed.md'",
+            // Recreate at a path the deleted file once occupied, under a
+            // different id.
+            "INSERT INTO lix_file (id, path, content) \
+             VALUES ('01920000-0000-7000-8000-0000000000c4', '/docs/minted.md', \
+             CAST('w0' AS BYTEA))",
+            "UPDATE lix_file SET content = CAST('w1' AS BYTEA) WHERE path = '/docs/minted.md'",
+        ] {
+            session
+                .execute(statement, &[])
+                .await
+                .unwrap_or_else(|error| panic!("fixture statement failed: {statement}: {error}"));
+        }
+
+        let head_commit_id = session
+            .execute("SELECT lix_active_branch_commit_id()", &[])
+            .await
+            .expect("active commit should resolve")
+            .rows()[0]
+            .values()[0]
+            .clone();
+        let Value::Text(head_commit_id) = head_commit_id else {
+            panic!("active branch commit id should be text");
+        };
+
+        let projection = format!(
+            "SELECT id, path, lixcol_depth, lixcol_observed_commit_id \
+             FROM lix_file_history('{head_commit_id}')"
+        );
+        let key = |row: &Vec<Value>| format!("{:?}", row);
+        let unfiltered = rows_from_execute_result(
+            session
+                .execute(&projection, &[])
+                .await
+                .expect("unfiltered history should execute"),
+        )
+        .1;
+        assert!(
+            !unfiltered.is_empty(),
+            "the unfiltered oracle must produce rows"
+        );
+
+        for (id, path) in [
+            (
+                minted_id.as_str(),
+                // The minted file's last path before it was deleted.
+                "/docs/renamed.md",
+            ),
+            (
+                "01920000-0000-7000-8000-0000000000c4",
+                "/docs/minted.md",
+            ),
+            (
+                "01920000-0000-7000-8000-0000000000a2",
+                "/docs/readme.md",
+            ),
+        ] {
+            let expected_by_id: BTreeSet<String> = unfiltered
+                .iter()
+                .filter(|row| row[0] == Value::Text(id.to_string()))
+                .map(key)
+                .collect();
+            assert!(
+                !expected_by_id.is_empty(),
+                "the oracle must carry history for {id}"
+            );
+            let actual_by_id: BTreeSet<String> = rows_from_execute_result(
+                session
+                    .execute(&format!("{projection} WHERE id = '{id}'"), &[])
+                    .await
+                    .expect("id-filtered history should execute"),
+            )
+            .1
+            .iter()
+            .map(key)
+            .collect();
+            assert_eq!(
+                expected_by_id, actual_by_id,
+                "pinning file_ids changed the id-filtered answer for {id}"
+            );
+
+            let expected_by_path: BTreeSet<String> = unfiltered
+                .iter()
+                .filter(|row| row[1] == Value::Text(path.to_string()))
+                .map(key)
+                .collect();
+            assert!(
+                !expected_by_path.is_empty(),
+                "the oracle must carry history for {path}"
+            );
+            let actual_by_path: BTreeSet<String> = rows_from_execute_result(
+                session
+                    .execute(&format!("{projection} WHERE path = '{path}'"), &[])
+                    .await
+                    .expect("path-filtered history should execute"),
+            )
+            .1
+            .iter()
+            .map(key)
+            .collect();
+            assert_eq!(
+                expected_by_path, actual_by_path,
+                "pinning file_ids changed the path-filtered answer for {path}"
+            );
+        }
+    }
+
+    /// Number of commits that touch a file the query never asks about.
+    ///
+    /// The assertion below is a **threshold** scaled to this fixture, not an
+    /// exact value: the projection census is process-global, so concurrent
+    /// tests in this binary can only ever push the count up.
+    const DESCRIPTOR_BLOB_PRUNE_NOISE_COMMITS: u64 = 32;
+
+    /// Engagement check for pinning `file_ids` on the descriptor + blob-ref
+    /// route.
+    ///
+    /// `lix_binary_blob_ref` is touched by every content commit, so the
+    /// digest's schema-family test cannot prune this projection: without a
+    /// pinned `file_id` the membership test answers `LoadedPresent` for every
+    /// content commit in the repository and the traversal loads one commit
+    /// delta each. Pinning lets the same already-shipped digest answer the
+    /// sharper `(schema_key, file_id)` pair question instead.
+    ///
+    /// This counts inside the membership test itself, one layer below the SQL
+    /// timing instrument, and fails on a tree without the pin — the whole point
+    /// is that a flat timing result and "the changed code never ran" are
+    /// otherwise indistinguishable.
+    #[tokio::test]
+    async fn file_history_by_path_prunes_content_commits_for_other_files() {
+        let (session, _) = setup_engine_history_fixture()
+            .await
+            .expect("history fixture should initialize");
+
+        session
+            .execute(
+                "INSERT INTO lix_file (id, path, content) \
+                 VALUES ('01920000-0000-7000-8000-0000000000b8', '/docs/noise.md', CAST('n0' AS BYTEA))",
+                &[],
+            )
+            .await
+            .expect("noise file should insert");
+        for revision in 0..DESCRIPTOR_BLOB_PRUNE_NOISE_COMMITS {
+            session
+                .execute(
+                    &format!(
+                        "UPDATE lix_file SET content = CAST('n{revision}' AS BYTEA) \
+                         WHERE id = '01920000-0000-7000-8000-0000000000b8'"
+                    ),
+                    &[],
+                )
+                .await
+                .expect("noise commit should apply");
+        }
+
+        let head_commit_id = session
+            .execute("SELECT lix_active_branch_commit_id()", &[])
+            .await
+            .expect("active commit should resolve")
+            .rows()[0]
+            .values()[0]
+            .clone();
+        let Value::Text(head_commit_id) = head_commit_id else {
+            panic!("active branch commit id should be text");
+        };
+
+        let _ = crate::commit_graph::scope_digest_census::by_projection::take();
+        let result = session
+            .execute(
+                &format!(
+                    "SELECT id, path, lixcol_depth FROM lix_file_history('{head_commit_id}') \
+                     WHERE path = '/docs/readme.md' ORDER BY lixcol_depth"
+                ),
+                &[],
+            )
+            .await
+            .expect("by-path history should execute");
+        let by_projection = crate::commit_graph::scope_digest_census::by_projection::take();
+        for (projection, buckets) in &by_projection {
+            eprintln!("descriptor_blob_prune_projection {projection} {buckets:?}");
+        }
+
+        assert!(
+            !result.rows().is_empty(),
+            "the queried path must still have history rows"
+        );
+        let projection = "lix_binary_blob_ref+lix_file_descriptor";
+        let buckets = by_projection.get(projection).unwrap_or_else(|| {
+            panic!("by-path history should traverse {projection}: {by_projection:?}")
+        });
+        assert!(
+            buckets.get("pruned").copied().unwrap_or(0)
+                >= DESCRIPTOR_BLOB_PRUNE_NOISE_COMMITS,
+            "{projection} must prune every content commit that belongs to another \
+             file; without a pinned file_id the membership test answers \
+             LoadedPresent for all of them: {by_projection:?}"
+        );
+        assert_eq!(
+            buckets.get("loaded_absent").copied().unwrap_or(0),
+            0,
+            "{projection} must never hit the pre-digest fallback: {by_projection:?}"
+        );
+    }
+
     #[tokio::test]
     async fn execute_sql_rejects_writes_to_history_views_before_planning() {
         for sql in [

--- a/packages/lix/src/sql2/providers/file_history.rs
+++ b/packages/lix/src/sql2/providers/file_history.rs
@@ -1461,12 +1461,54 @@ where
     Ok(entries)
 }
 
+/// Routes the descriptor + blob-ref traversal for a known set of file IDs.
+///
+/// # Why this pins `file_ids` as well as the entity primary keys
+///
+/// `lix_binary_blob_ref` is touched by *every* content commit, so the
+/// touched-scope digest's schema-family test can never prove this projection
+/// absent: some commit in almost every workload has a blob-ref member. The
+/// digest also carries a `(schema_key, file_id)` **pair** token, which is
+/// exactly the discriminator this traversal needs — but `scope_digest_outcome`
+/// only reaches the pair probe when the request pins `file_ids`, and returns
+/// `LoadedPresent` otherwise. Leaving `file_ids` empty therefore loaded one
+/// commit delta per reachable commit to discover that its blob-ref member
+/// belongs to a different file.
+///
+/// # Why pinning cannot drop a history row
+///
+/// `change_matches_history_request` treats a non-empty `file_ids` as requiring
+/// a non-null `file_id` that is in the set, so pinning would be a correctness
+/// bug if any matching row could carry a null or different `file_id`. It
+/// cannot, for either of this route's two schema keys:
+///
+/// * `lix_file_descriptor` — `canonicalize_descriptor_file_id` rewrites
+///   `file_id` to the row's own `entity_pk` on **every** normalized descriptor
+///   row, on all three exits of the row normalizer and for tombstones as well
+///   as live rows, and errors if that identity is not a single value. The
+///   planner really can hand it a descriptor row with `file_id: None` (an
+///   `INSERT` that leaves the file ID to the engine), and normalization is what
+///   closes that hole. `delete_restriction_source_domains` already depends on
+///   the same invariant.
+/// * `lix_binary_blob_ref` — every producer (`BlobRefRowInput::append_to` and
+///   `append_blob_ref_tombstone_row`) sets `entity_pk` and `file_id` from the
+///   same file ID, and both schemas are read-only public surfaces, so no caller
+///   can supply a divergent pair.
+///
+/// Because `file_id == entity_pk` holds for both, and this route already pins
+/// `resolved_entity_pks` to the same IDs, the added predicate is implied by the
+/// one already applied: it cannot reject a change the existing entity-PK test
+/// accepts. The identities compare byte-for-byte rather than merely
+/// semantically because `EntityPk::uuid_from_canonical` accepts only the exact
+/// lowercase hyphenated form — a file ID that is not canonical already fails
+/// this function before any pinning happens.
 fn file_history_descriptor_blob_route(
     route: &HistoryRoute,
     lookup_ids: &FileHistoryLookupIds,
 ) -> Result<HistoryRoute, LixError> {
     let mut route = route.clone();
     route.entity_pks = lookup_ids.entity_pks()?;
+    route.file_ids = lookup_ids.0.iter().cloned().collect();
     route.resolved_entity_pks = lookup_ids
         .0
         .iter()
@@ -3069,6 +3111,16 @@ mod tests {
             vec![
                 r#"["01920000-0000-7000-8000-0000000000a2"]"#.to_string(),
                 r#"["01920000-0000-7000-8000-0000000000b2"]"#.to_string()
+            ]
+        );
+        // The digest's `(schema_key, file_id)` pair probe is only reached when
+        // the request pins `file_ids`; without this the blob-ref projection
+        // loads one commit delta per reachable content commit.
+        assert_eq!(
+            route.file_ids,
+            vec![
+                "01920000-0000-7000-8000-0000000000a2".to_string(),
+                "01920000-0000-7000-8000-0000000000b2".to_string()
             ]
         );
         assert_eq!(route.as_of_commit_ids, vec!["commit-start".to_string()]);


### PR DESCRIPTION
## Summary

`lix_file_history(...) WHERE path = ?` runs a separate commit-graph traversal for the
`lix_file_descriptor + lix_binary_blob_ref` projection. Blob-ref rows are written by **every**
content commit, so the touched-scope digest's schema-family test can never prove that projection
absent — and the route left `route.file_ids` empty, so `scope_digest_outcome` returned
`LoadedPresent` **before** the digest's `(schema_key, file_id)` **pair** token could discriminate.
Every reachable content commit therefore loaded a commit delta only to discover its blob-ref member
belonged to a different file.

The fix is one line: pin `route.file_ids` to the same lookup IDs the route already pins as
`resolved_entity_pks`.

**This is the free alternative to a format change.** It prunes the same commits with **no format
change, no protocol bump, no bytes added to every merge-base and GC read, no write cost, and no new
hash** — as against a `v67 -> v68` bump for a `(schema_key, entity_pk)` token set with the same
measured ceiling.

**Breaking status: NON-BREAKING.** Route change only. No persisted record, no `#[musli(packed)]`
type, no `REPOSITORY_PROTOCOL_VALUE`, no public API, no storage-adapter API touched.

---

## The correctness question, settled by construction

> Can `change_matches_history_request`'s non-null `file_id` requirement ever drop a matching
> descriptor row?

**No — and the pin cannot reject any change the predicate already applied on this route accepts.**

`change_matches_history_request` treats a non-empty `file_ids` as requiring a **non-null** `file_id`
that is in the set, so pinning would silently lose history if any matching row could carry a null or
divergent one. Three classes were checked:

**1. Rows on the `lix_file_descriptor` side — cannot be null.**
`transaction/normalization.rs::canonicalize_descriptor_file_id` rewrites `file_id` to the row's own
`entity_pk` for **every** normalized descriptor row, and it is called on **all three** exits of the
row normalizer (`normalization.rs:116`, `:138`, `:217`), for tombstones as well as live rows. It
errors if that identity is not a single value.

This is not a theoretical hole that happens to be closed — the planner really does produce a
descriptor row with `file_id: None`. `FileDescriptorRowInput::append_to` (`filesystem/planner.rs`)
passes `file_id: self.id` where `self.id: Option<String>`, so an `INSERT INTO lix_file` that leaves
the ID to the engine stages a descriptor row with a null `file_id`. Normalization is what closes it,
after `entity_pk` has been assigned. The tree already depends on this invariant elsewhere, in
`validation.rs::delete_restriction_source_domains`:

> *"Because `canonicalize_descriptor_file_id` forces `lix_file_descriptor.file_id` to equal the
> row's own entity id..."*

**2. Rows whose `file_id` differs from the queried file's ID — cannot exist on this route.**
For `lix_binary_blob_ref` there are exactly two producers, `BlobRefRowInput::append_to` and
`append_blob_ref_tombstone_row`, and both set `entity_pk` and `file_id` from the same single file
ID. So `file_id == entity_pk` holds for both of this route's schema keys — and the route **already**
pins `resolved_entity_pks` to those IDs, which `change_matches_history_request` already tests. The
added predicate is therefore *implied by* the one already applied: it is logically redundant on the
match, and newly load-bearing only on the digest prune.

The identities compare **byte-for-byte**, not merely semantically:
`EntityPk::uuid_from_canonical` -> `uuid_bytes_from_canonical` accepts **only** the exact lowercase
hyphenated form (`storage_codec.rs:105-110`, and
`uuid_bytes_from_canonical_accepts_only_the_exact_canonical_form` pins it). A non-canonical or
uppercase file ID already fails `file_history_descriptor_blob_route` today, before any pinning
happens, so there is no case-folding gap between the string `file_ids` test and the byte-wise
`entity_pk` test.

**3. Any path that writes a descriptor row without a `file_id` — no user-reachable one.**
Both `lix_file_descriptor` and `lix_binary_blob_ref` are **read-only public surfaces**
(`sql2/read_only.rs:43-49`: *"Use the writable lix_file surface..."* / *"Use the writable lix_file
content column..."*). No caller can supply a divergent or null pair; every such row originates in the
filesystem planner and passes through normalization.

Lookup IDs themselves come from the descriptor snapshot's own `id`
(`resolve_file_history_path_lookup_ids`), which is the same value that becomes `entity_pk` and
`file_id`, and that function already declines to prune when the ID is not a canonical UUID.

### ...and confirmed by test

Branch `claude-6/expBRP-tests-without-pin` (`7bfcefbec`) is commit B with the one pinning line
removed, so the same tests run against a tree without the pin.

`pinned_file_history_route_returns_the_unfiltered_answer` uses the **unfiltered** read as the
oracle: a `lix_file_history` query with no `id`/`path` predicate resolves no lookup IDs, never
constructs the descriptor/blob route, and therefore *cannot execute the pin*. Every filtered read
must equal that answer restricted to the same file. The fixture is deliberately the set of shapes
that could carry a null or divergent `file_id`:

- an insert with **no explicit id** (the planner's real `file_id: None` path),
- content revisions (blob-ref rows),
- a rename (descriptor rewrite, no content change),
- a content clear (blob-ref **tombstone**, descriptor survives),
- a delete (descriptor **and** blob-ref tombstones through the snapshot-less builder),
- a **recreation at the same path under a different id**, so a path lookup resolves two IDs and the
  per-file discrimination has to be exact rather than vacuous.

| test | without pin (`7bfcefbec`) | with pin (`521a5b8d8`) |
|---|---|---|
| `pinned_file_history_route_returns_the_unfiltered_answer` | **1 passed** | **1 passed** |
| `file_history_by_path_prunes_content_commits_for_other_files` | **FAILED** | **1 passed** |
| `exact_public_ids_route_only_descriptor_and_blob_history` | **FAILED** | **1 passed** |

Both runs used the fully-qualified test path with `--exact --test-threads=1` and were confirmed
against `--list` first (`LISTED ... = 1` for each) — a bare-name `--exact` filter matches nothing and
exits 0, which is exactly what the first attempt did.

---

## Engagement: counted inside the route, before timing

`file_history_by_path_prunes_content_commits_for_other_files` counts in the **membership test
itself** (`scope_digest_census::by_projection`, recorded at `commit_graph/context.rs:559`), one layer
below the SQL timing instrument. Fixture: one queried file plus **32** commits that touch a different
file.

| projection | without pin | with pin |
|---|---|---|
| **`lix_binary_blob_ref+lix_file_descriptor`** | `pruned: 4, loaded_present: 34` | **`pruned: 37, loaded_present: 1`** |
| `lix_directory_descriptor` | `pruned: 37, loaded_present: 1` | `pruned: 37, loaded_present: 1` |
| `lix_file_descriptor` | `pruned: 36, loaded_present: 2` | `pruned: 36, loaded_present: 2` |
| `lix_key_value` | `pruned: 75, loaded_present: 1` | `pruned: 75, loaded_present: 1` |

**34 loaded commit deltas -> 1.** The three other projections are identical between arms, so the
census carries its own in-test null control. `loaded_absent` is 0 everywhere.

The assertion is a **threshold scaled to the fixture** (`pruned >= 32`), not an exact value: these
counters are process-global, so concurrent tests can only push the count up.

---

## Measurement

Machine `ryzen-9950x-IV` (32-core, idle, `pgrep -c cargo == 0`, load < 1 before the run).
Both arms built `--no-run` first; the prebuilt release binaries were exec'd directly so no compile
landed in a timing window.

- **base arm** `4257fc7ad` (`claude-6/expBRP-null-control`) — engine at `be813172a`, instrument only
- **cand arm** `521a5b8d8` (`claude-6/expBRP-file-id-pin`) — the same instrument + the pin

The arms differ by **exactly the engine change**: the null-control lane is committed separately and
carried by both. HEAD asserted before **and** after each build (`HEAD_BEFORE == HEAD_AFTER`, status
empty), and both binaries grepped for the instrument's own strings
(`null_control_kv`, `lix_key_value_history` present in each).

`packages/e2e/tests/history_scaling_probe.rs :: history_commits_at_fixed_files`,
`LIX_HISTORY_SCALE_COMMITS=20,200,2000`, `LIX_HISTORY_SCALE_SAMPLES=3`, **12 rounds with arm-order
rotation** (`base cand cand base base cand base cand cand base cand base`) = **18 samples per lane
per arm**, pooled. Every fixture is built from scratch in a fresh tempdir per round, so nothing
predates the v67 bump.

| lane | base med | cand med | delta | base p95 | cand p95 | base range | cand range | overlap |
|---|---|---|---|---|---|---|---|---|
| `by_path` commits=20 | 3.690 | 3.469 | **-5.99%** | 4.725 | 3.836 | 3.45-4.72 | 3.40-3.84 | yes |
| `by_path` commits=200 | 5.539 | 4.752 | **-14.22%** | 7.053 | 4.841 | 5.25-7.05 | 4.67-4.84 | **no** |
| `by_path` commits=2000 | 25.696 | 19.057 | **-25.83%** | 26.780 | 19.819 | 24.70-26.78 | 18.21-19.82 | **no** |
| `by_id` commits=20 | 3.144 | 3.081 | -2.00% | 3.962 | 3.144 | 3.06-3.96 | 3.00-3.14 | yes |
| `by_id` commits=200 | 4.965 | 4.223 | **-14.95%** | 6.078 | 4.301 | 4.80-6.08 | 4.12-4.30 | **no** |
| `by_id` commits=2000 | 22.544 | 16.052 | **-28.80%** | 23.116 | 16.378 | 22.20-23.12 | 15.62-16.38 | **no** |
| `by_path_depth0` commits=20 | 1.629 | 1.538 | -5.65% | 2.083 | 1.700 | 1.57-2.08 | 1.51-1.70 | yes |
| `by_path_depth0` commits=200 | 3.612 | 3.564 | -1.30% | 4.545 | 3.643 | 3.51-4.54 | 3.48-3.64 | yes |
| `by_path_depth0` commits=2000 | 21.476 | 22.343 | **+4.04%** | 22.118 | 23.410 | 21.02-22.12 | 21.70-23.41 | yes |
| **`null_control_kv`** commits=20 | 0.400 | 0.401 | +0.25% | 0.601 | 0.500 | 0.38-0.60 | 0.38-0.50 | yes |
| **`null_control_kv`** commits=200 | 0.875 | 0.859 | -1.94% | 1.137 | 0.922 | 0.84-1.14 | 0.81-0.92 | yes |
| **`null_control_kv`** commits=2000 | 5.191 | 5.215 | +0.47% | 5.373 | 5.374 | 5.03-5.37 | 5.06-5.37 | yes |

### Null control

`null_control_kv` reads `lix_key_value_history` over the same commit graph and the same fixture,
through the same `load_history_entries` traversal and the same touched-scope digest — but on a
different history surface, so it **cannot** reach the file-history descriptor/blob route. Its code is
byte-identical between arms. It moved **+0.25% / -1.94% / +0.47%**, so this harness's noise floor is
under ~2%. The 25.8% and 14.2% results are an order of magnitude outside it and their raw ranges do
not overlap at all.

### Against the predicted band

Predicted: 2000 loads x 2.0-3.4 us => 4.0-6.8 ms off a 27.2 ms lane, roughly 1.15-1.3x.
Measured: **6.64 ms off a 25.70 ms lane, 1.348x.**

The absolute saving lands at the **top of** the predicted band. The **ratio is above it** (1.348x vs
1.3x) — not because the saving was larger than predicted but because the base lane measured 25.70 ms
here rather than 27.20 ms, so the same absolute saving is a larger fraction. Stating it plainly
rather than rounding it into the band.

### The one regression, and why it is the right trade

`by_path_depth0` at 2000 commits is **+4.04%** (+0.87 ms). This lane queries the **noise** path — the
file that *every* commit touches. The context load runs on the unbounded `anchors_only` route, so the
pair probe fires on all 2000 commits, finds the blob-ref member **present** every time, and the delta
is loaded anyway: two extra BLAKE3 keyed hashes per commit with no prune to pay for them
(~0.43 us/commit, which is the right order for two keyed hashes).

That is the honest worst case for this change: a path query for a file edited in literally every
commit pays ~4%, while a path query for a file that is not pays -26%. The regression is within the
~5% bound, the ranges overlap, and the trade is the correct one — a workload where the queried file
is in every commit has no pruning available to it under any design.

`MAX_PROBED_SCOPE_PAIRS = 32` already bounds this: 2 schema keys x N file IDs, so a wide file filter
falls back to the schema-only test rather than turning the probe into a hashing loop.

---

## Layout invariants

1. **Single authority.** No. Adds no writer, no materialization, no index. It narrows a *read*
   request so an existing digest can answer a question it already carries a token for.
2. **Commit canonicality.** Unchanged. No commit record, parent link or state root is touched.
3. **Derived views are caches.** Unchanged. The touched-scope digest is unmodified — this only
   changes which question is asked of it.
4. **Atomic publication.** Unchanged. Read path only; nothing publishes.
5. **GC from refs.** Unchanged. No retention metadata, no reachability change. Notably this is the
   *point*: the rejected alternative would have added bytes to every merge-base and GC read.
6. **SQL reads canonical records.** Unchanged. The traversal still reads commit records and commit
   deltas; the pin only skips deltas the digest proves cannot contribute.

## What was removed

Nothing. No adapter API added, changed or removed; both shipping adapters and the conformance suite
are untouched.

---

## Gate

Full CI scope, re-derived from the gated sha's own `ci.yml` (not from the runbook), on
`ryzen-9950x-IV`:

```
git rev-parse HEAD                521a5b8d8d7b64a0f5c84e4440e146c3aafe2bf1
git status --porcelain            (empty)
CI_SCOPE_CONFIRMED_AT             521a5b8d8d7b64a0f5c84e4440e146c3aafe2bf1
EXECUTED_TARGETS                  test1=3415 test2=165
```

```
cargo clippy --profile test --workspace --all-targets --all-features -- -D warnings   exit 0 (0 errors/warnings)
cargo test --profile test --workspace --exclude lix_e2e --all-features --no-fail-fast exit 0 (3415 passed, 0 FAILED)
cargo test --profile test -p lix_e2e --features sdk-tests,storage-benches,slatedb,root-replay-trace --no-fail-fast
                                                                                      exit 0 (165 passed, 0 FAILED)
cargo check -p lix --no-default-features                                              exit 0
cargo check -p lix_js_sdk --target wasm32-unknown-unknown                              exit 0
```

`GATE_HEAD_BEFORE == GATE_HEAD_AFTER == 521a5b8d8`, `git status --porcelain` empty after the run, so
the result is attributable to a commit rather than a tree.

**Async-frame canary run by name** (this change adds no future frame, but the route is on a universal
read path):

```
cargo test --profile test -p lix_e2e --features sdk-tests,storage-benches,slatedb,root-replay-trace \
  --test cas_gc_history_retention slatedb_history_blob_survives_until_final_root_release -- --exact --test-threads=1
test result: ok. 1 passed; 0 failed
```

## Base

Branched from `claude-6-optimizations` at **`be813172a`**, which is still the integration head. The
`diff_id` normalization (#1434) that landed in that base touches `sql2/providers/diff.rs`,
`working_diff.rs`, `tracked_state/diff.rs` and `transaction/context.rs`: **zero overlap** with this
diff, which touches `sql2/providers/file_history.rs`, `sql2/exec/datafusion.rs` and
`e2e/tests/history_scaling_probe.rs` only. Every fixture in every measurement and test is created
from scratch by `Engine::initialize` or a fresh tempdir, so nothing predates the v67 bump.
