### PR TITLE
Define the crates.io publish surface

### DIFF
--- a/.changenotes/define-cargo-publish-surface.md
+++ b/.changenotes/define-cargo-publish-surface.md
@@ -1,0 +1,8 @@
+---
+type: patch
+---
+
+Restrict the crates.io release surface to `lix` and the three independently
+versioned `lix-storage-*` crates. The CLI, JavaScript binding implementation,
+plugins, vendored dependencies, tests, and tooling are private workspace crates,
+and CI now rejects accidental additions to the public Cargo surface.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,8 +49,8 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Validate Cargo configuration
-        run: cargo metadata --format-version 1 --no-deps
+      - name: Validate Cargo configuration and publish surface
+        run: node scripts/validate-cargo-publish-surface.mjs
 
   cargo:
     name: Cargo ${{ matrix.name }}

--- a/packages/cli/Cargo.toml
+++ b/packages/cli/Cargo.toml
@@ -12,6 +12,7 @@ readme.workspace = true
 keywords.workspace = true
 categories = ["command-line-utilities", "development-tools", "artificial-intelligence", "filesystem"]
 rust-version.workspace = true
+publish = false
 
 [lints]
 workspace = true

--- a/packages/js-sdk/Cargo.toml
+++ b/packages/js-sdk/Cargo.toml
@@ -12,6 +12,7 @@ readme.workspace = true
 keywords.workspace = true
 categories.workspace = true
 rust-version.workspace = true
+publish = false
 
 [lints]
 workspace = true

--- a/plugins/text/Cargo.toml
+++ b/plugins/text/Cargo.toml
@@ -12,6 +12,7 @@ readme = "README.md"
 keywords.workspace = true
 categories.workspace = true
 rust-version.workspace = true
+publish = false
 
 [lints]
 workspace = true

--- a/scripts/validate-cargo-publish-surface.mjs
+++ b/scripts/validate-cargo-publish-surface.mjs
@@ -1,0 +1,55 @@
+#!/usr/bin/env node
+
+import { execFileSync } from "node:child_process";
+
+const CRATES_IO_PACKAGES = new Set([
+	"lix",
+	"lix-storage-filesystem",
+	"lix-storage-rocksdb",
+	"lix-storage-slatedb",
+]);
+
+const metadata = JSON.parse(
+	execFileSync(
+		"cargo",
+		["metadata", "--format-version", "1", "--no-deps"],
+		{ encoding: "utf8" },
+	),
+);
+
+const failures = [];
+for (const cargoPackage of metadata.packages) {
+	const shouldPublish = CRATES_IO_PACKAGES.has(cargoPackage.name);
+	const publishesToCratesIo = cargoPackage.publish === null;
+	const publishesElsewhere =
+		Array.isArray(cargoPackage.publish) && cargoPackage.publish.length > 0;
+
+	if (shouldPublish && !publishesToCratesIo) {
+		failures.push(
+			`${cargoPackage.name} must remain publishable to crates.io (remove package.publish)`,
+		);
+	}
+	if (!shouldPublish && (publishesToCratesIo || publishesElsewhere)) {
+		failures.push(
+			`${cargoPackage.name} must set package.publish = false`,
+		);
+	}
+}
+
+for (const packageName of CRATES_IO_PACKAGES) {
+	if (!metadata.packages.some((cargoPackage) => cargoPackage.name === packageName)) {
+		failures.push(`${packageName} is missing from the Cargo workspace`);
+	}
+}
+
+if (failures.length > 0) {
+	console.error("Invalid Cargo publish surface:");
+	for (const failure of failures) console.error(`- ${failure}`);
+	process.exit(1);
+}
+
+const published = metadata.packages
+	.filter((cargoPackage) => CRATES_IO_PACKAGES.has(cargoPackage.name))
+	.map((cargoPackage) => `${cargoPackage.name}@${cargoPackage.version}`)
+	.sort();
+console.log(`Validated crates.io publish surface: ${published.join(", ")}`);

--- a/vendor/markdown-syntax/Cargo.toml
+++ b/vendor/markdown-syntax/Cargo.toml
@@ -9,10 +9,11 @@ repository = "https://github.com/plimeor/markdown-syntax"
 license = "MIT OR Apache-2.0"
 keywords = ["markdown", "commonmark", "gfm", "parser", "ast"]
 categories = ["parser-implementations", "text-processing", "no-std"]
+publish = false
 
-# The published package ships only the library, license, and readme. The vendored
-# conformance corpus under tests/ is dev-only and is intentionally NOT
-# redistributed (it contains third-party CommonMark/GFM/comrak/markdown-rs cases).
+# Keep the vendored source aligned with the upstream package contents. The
+# conformance corpus under tests/ is dev-only and contains third-party
+# CommonMark/GFM/comrak/markdown-rs cases.
 include = [
     "Cargo.toml",
     "README.md",


### PR DESCRIPTION
## Summary

- restrict the crates.io surface to `lix`, `lix-storage-filesystem`, `lix-storage-rocksdb`, and `lix-storage-slatedb`
- mark `lix_cli`, the `lix_js_sdk` Rust binding crate, `plugin_text`, and vendored `markdown-syntax` as non-publishable
- keep every plugin private for now; the other plugin manifests were already `publish = false`
- add a Cargo-metadata allowlist check to CI so new internal workspace crates cannot silently become publishable

## Versioning boundary

- `lix` is released on the Lix/JS SDK version line (next: `0.12.0`)
- each `lix-storage-*` adapter retains its independent version line (currently `0.1.0`)
- npm publication of `@lix-js/sdk` remains independent of the private `lix_js_sdk` Cargo implementation crate

The crates.io release order must be `lix` first and the storage adapters second, because Cargo validates adapter dependency requirements against the registry.

## Validation

- `node scripts/validate-cargo-publish-surface.mjs`
- `cargo metadata --no-deps --format-version 1`
- `node scripts/validate-changes.mjs`
- `node --test scripts/release.test.mjs` (10 passed)
- `cargo package --locked --allow-dirty --no-verify -p lix`
- `git diff --check`
