### PR TITLE
test(lix): instrument the lix_file content-update scaling defect (three eliminations, no fix)

### DIFF
--- a/packages/e2e/Cargo.toml
+++ b/packages/e2e/Cargo.toml
@@ -517,3 +517,8 @@ required-features = ["sdk-tests", "storage-benches", "slatedb"]
 name = "e16_write_file_scaling"
 path = "examples/e16_write_file_scaling.rs"
 required-features = ["sdk-tests", "storage-benches", "slatedb"]
+
+[[example]]
+name = "exppth2_txn_probe"
+path = "examples/exppth2_txn_probe.rs"
+required-features = ["storage-benches"]

--- a/packages/e2e/examples/exppth2_txn_probe.rs
+++ b/packages/e2e/examples/exppth2_txn_probe.rs
@@ -1,0 +1,164 @@
+//! EXPPTH2: does batching content updates into ONE explicit transaction
+//! collapse the per-statement O(repository size) term?
+//!
+//! Arms, all doing the SAME N content updates against the SAME fixture:
+//!
+//! 1. `by_id_per_stmt`  -- `UPDATE ... WHERE id = $2`, one implicit transaction
+//!                         per statement. This is the arm that showed a linear
+//!                         term (~0.23 us per file in the branch).
+//! 2. `by_id_one_txn`   -- the identical statements inside ONE explicit
+//!                         transaction, committed once at the end.
+//! 3. `by_path_per_stmt`-- `UPDATE ... WHERE path = $2` (DataFusion), the arm
+//!                         measured flat in repository size. In-run control.
+//!
+//! Discriminating prediction: if the cause is a revision bump per COMMIT
+//! busting a revision-keyed cache, arm 2 is flat in file count while arm 1
+//! grows. If arm 2 grows too, the cause is elsewhere.
+//!
+//! Usage: `exppth2_txn_probe [files] [updates] [reps] [payload_bytes]`
+
+use std::time::Instant;
+
+use lix::{Value, open_lix};
+use lix_storage_rocksdb::RocksDB;
+
+#[tokio::main(flavor = "current_thread")]
+async fn main() {
+    let args: Vec<String> = std::env::args().collect();
+    let files: usize = args.get(1).and_then(|v| v.parse().ok()).unwrap_or(2000);
+    let updates: usize = args.get(2).and_then(|v| v.parse().ok()).unwrap_or(200);
+    let reps: usize = args.get(3).and_then(|v| v.parse().ok()).unwrap_or(3);
+    let payload: usize = args.get(4).and_then(|v| v.parse().ok()).unwrap_or(4096);
+
+    let orders = [
+        ["by_id_per_stmt", "by_id_one_txn", "by_path_per_stmt"],
+        ["by_id_one_txn", "by_path_per_stmt", "by_id_per_stmt"],
+        ["by_path_per_stmt", "by_id_per_stmt", "by_id_one_txn"],
+    ];
+
+    let mut samples: Vec<(String, f64)> = Vec::new();
+    for rep in 0..reps {
+        for arm in orders[rep % orders.len()] {
+            let ms = run_arm(arm, files, updates, payload).await;
+            println!(
+                "EXPPTH2 files={files} rep={rep} arm={arm} total_ms={ms:.3} per_op_us={:.2}",
+                ms * 1000.0 / updates as f64
+            );
+            samples.push((arm.to_string(), ms));
+        }
+    }
+
+    println!();
+    for arm in ["by_id_per_stmt", "by_id_one_txn", "by_path_per_stmt"] {
+        let mut arm_samples: Vec<f64> = samples
+            .iter()
+            .filter(|(name, _)| name == arm)
+            .map(|(_, ms)| *ms)
+            .collect();
+        arm_samples.sort_by(|a, b| a.partial_cmp(b).expect("finite"));
+        let median = arm_samples[arm_samples.len() / 2];
+        println!(
+            "EXPPTH2_SUMMARY files={files} arm={arm} median_total_ms={median:.3} median_per_op_us={:.2} raw={:?}",
+            median * 1000.0 / updates as f64,
+            arm_samples
+                .iter()
+                .map(|v| format!("{v:.2}"))
+                .collect::<Vec<_>>()
+        );
+    }
+}
+
+async fn run_arm(arm: &str, files: usize, updates: usize, payload: usize) -> f64 {
+    let root = tempfile::Builder::new()
+        .prefix("expPTH2-")
+        .tempdir()
+        .expect("create dir");
+    let storage = RocksDB::open(&root.path().join("db")).expect("open RocksDB");
+    let lix = open_lix()
+        .with_storage(storage.clone())
+        .await
+        .expect("open Lix");
+
+    // Identical fixture for every arm. Seeded in one transaction so fixture
+    // build time does not dominate at large file counts.
+    let seed: Vec<u8> = vec![b'a'; payload];
+    let mut transaction = lix.begin_transaction().await.expect("begin seed");
+    for index in 0..files {
+        transaction
+            .execute(
+                "INSERT INTO lix_file (path, content) VALUES ($1, $2)",
+                &[
+                    Value::Text(format!("/exppth2-{index:06}.bin")),
+                    Value::Blob(seed.clone().into()),
+                ],
+            )
+            .await
+            .expect("seed insert");
+    }
+    transaction.commit().await.expect("commit seed");
+
+    let rows = lix
+        .execute("SELECT id FROM lix_file ORDER BY path", &[])
+        .await
+        .expect("read ids back");
+    let ids = rows
+        .rows()
+        .iter()
+        .map(|row| match rows.get(row, "id").expect("file id") {
+            Value::Text(text) => text.clone(),
+            other => panic!("unexpected id value {other:?}"),
+        })
+        .collect::<Vec<_>>();
+    assert!(ids.len() >= updates, "fixture must cover every update");
+
+    let updated: Vec<u8> = vec![b'b'; payload];
+    let started = Instant::now();
+    match arm {
+        "by_id_per_stmt" => {
+            for id in ids.iter().take(updates) {
+                lix.execute(
+                    "UPDATE lix_file SET content = $1 WHERE id = $2",
+                    &[
+                        Value::Blob(updated.clone().into()),
+                        Value::Text(id.clone()),
+                    ],
+                )
+                .await
+                .expect("update by id");
+            }
+        }
+        "by_id_one_txn" => {
+            let mut transaction = lix.begin_transaction().await.expect("begin updates");
+            for id in ids.iter().take(updates) {
+                transaction
+                    .execute(
+                        "UPDATE lix_file SET content = $1 WHERE id = $2",
+                        &[
+                            Value::Blob(updated.clone().into()),
+                            Value::Text(id.clone()),
+                        ],
+                    )
+                    .await
+                    .expect("update by id in transaction");
+            }
+            transaction.commit().await.expect("commit updates");
+        }
+        "by_path_per_stmt" => {
+            for index in 0..updates {
+                lix.execute(
+                    "UPDATE lix_file SET content = $1 WHERE path = $2",
+                    &[
+                        Value::Blob(updated.clone().into()),
+                        Value::Text(format!("/exppth2-{index:06}.bin")),
+                    ],
+                )
+                .await
+                .expect("update by path");
+            }
+        }
+        other => panic!("unknown arm {other}"),
+    }
+    let elapsed = started.elapsed().as_secs_f64() * 1000.0;
+    storage.flush().ok();
+    elapsed
+}

--- a/packages/lix/src/filesystem/mod.rs
+++ b/packages/lix/src/filesystem/mod.rs
@@ -14,7 +14,9 @@ pub(crate) use self::path_index::{
     stage_path_index_revision,
 };
 #[cfg(test)]
-pub(crate) use self::path_index::{full_rebuild_stats, reset_full_rebuild_stats};
+pub(crate) use self::path_index::{
+    full_rebuild_stats, path_index_cache_stats, reset_full_rebuild_stats,
+};
 pub(crate) use self::persistent_map::{PersistentMap, PersistentMapRangeCursor};
 pub(crate) use self::planner::directory_path_resolvers_from_state_batch;
 pub(crate) use self::planner::{

--- a/packages/lix/src/filesystem/path_index.rs
+++ b/packages/lix/src/filesystem/path_index.rs
@@ -53,10 +53,21 @@ thread_local! {
     static FULL_REBUILD_DESCRIPTOR_ROWS: std::cell::Cell<usize> = const { std::cell::Cell::new(0) };
 }
 
+// Cache lookups are counted next to the rebuild counter so a zero rebuild
+// count can be read positively. Without these, "no rebuilds" is
+// indistinguishable from "this lane was never reached".
+#[cfg(test)]
+thread_local! {
+    static PATH_INDEX_CACHE_HITS: std::cell::Cell<usize> = const { std::cell::Cell::new(0) };
+    static PATH_INDEX_CACHE_MISSES: std::cell::Cell<usize> = const { std::cell::Cell::new(0) };
+}
+
 #[cfg(test)]
 pub(crate) fn reset_full_rebuild_stats() {
     FULL_REBUILD_BUILDS.with(|builds| builds.set(0));
     FULL_REBUILD_DESCRIPTOR_ROWS.with(|rows| rows.set(0));
+    PATH_INDEX_CACHE_HITS.with(|hits| hits.set(0));
+    PATH_INDEX_CACHE_MISSES.with(|misses| misses.set(0));
 }
 
 #[cfg(test)]
@@ -64,6 +75,15 @@ pub(crate) fn full_rebuild_stats() -> (usize, usize) {
     (
         FULL_REBUILD_BUILDS.with(std::cell::Cell::get),
         FULL_REBUILD_DESCRIPTOR_ROWS.with(std::cell::Cell::get),
+    )
+}
+
+/// `(hits, misses)` on the filesystem path-index cache.
+#[cfg(test)]
+pub(crate) fn path_index_cache_stats() -> (usize, usize) {
+    (
+        PATH_INDEX_CACHE_HITS.with(std::cell::Cell::get),
+        PATH_INDEX_CACHE_MISSES.with(std::cell::Cell::get),
     )
 }
 
@@ -1242,7 +1262,13 @@ impl FilesystemPathIndexCache {
             .entries
             .lock()
             .expect("filesystem path cache lock poisoned");
-        let index = entries.iter().position(|candidate| candidate.key == key)?;
+        let Some(index) = entries.iter().position(|candidate| candidate.key == key) else {
+            #[cfg(test)]
+            PATH_INDEX_CACHE_MISSES.with(|misses| misses.set(misses.get().saturating_add(1)));
+            return None;
+        };
+        #[cfg(test)]
+        PATH_INDEX_CACHE_HITS.with(|hits| hits.set(hits.get().saturating_add(1)));
         let entry = entries.remove(index);
         let result = Arc::clone(&entry.index);
         entries.push(entry);

--- a/packages/lix/src/hot_state/mod.rs
+++ b/packages/lix/src/hot_state/mod.rs
@@ -82,3 +82,5 @@ pub(crate) use visibility::{
     overlay_load_exact_batch, overlay_scan_batch, overlay_scan_tracked_batch,
     resolve_visible_batch,
 };
+#[cfg(test)]
+pub(crate) use visibility::{blob_ref_probe_stats, reset_blob_ref_probe_stats};

--- a/packages/lix/src/hot_state/visibility.rs
+++ b/packages/lix/src/hot_state/visibility.rs
@@ -8,6 +8,45 @@ use crate::hot_state::{
     MaterializedHotStateExactBatch, MaterializedHotStateRowRef,
 };
 
+// Scanned-vs-returned accounting for the single-entity `lix_binary_blob_ref`
+// probe that every `lix_file` content update issues. `calls` exists so a zero
+// scanned count is readable as "the pushdown works" rather than as "this
+// counter never ran" -- the two are otherwise indistinguishable.
+#[cfg(test)]
+thread_local! {
+    static BLOB_REF_PROBE_CALLS: std::cell::Cell<usize> = const { std::cell::Cell::new(0) };
+    static BLOB_REF_PROBE_ROWS_SCANNED: std::cell::Cell<usize> = const { std::cell::Cell::new(0) };
+    static BLOB_REF_PROBE_ROWS_RETURNED: std::cell::Cell<usize> =
+        const { std::cell::Cell::new(0) };
+}
+
+#[cfg(test)]
+pub(crate) fn reset_blob_ref_probe_stats() {
+    BLOB_REF_PROBE_CALLS.with(|calls| calls.set(0));
+    BLOB_REF_PROBE_ROWS_SCANNED.with(|rows| rows.set(0));
+    BLOB_REF_PROBE_ROWS_RETURNED.with(|rows| rows.set(0));
+}
+
+/// `(calls, rows_scanned, rows_returned)` for single-entity blob-ref probes.
+///
+/// `rows_scanned` counts what the underlying hot-state scan handed back before
+/// visibility resolution -- i.e. what the storage layer actually read. If
+/// `entity_pks` is pushed down to a seek this tracks `rows_returned`; if it is
+/// applied as an in-memory filter it tracks the branch's blob-ref count.
+#[cfg(test)]
+pub(crate) fn blob_ref_probe_stats() -> (usize, usize, usize) {
+    (
+        BLOB_REF_PROBE_CALLS.with(std::cell::Cell::get),
+        BLOB_REF_PROBE_ROWS_SCANNED.with(std::cell::Cell::get),
+        BLOB_REF_PROBE_ROWS_RETURNED.with(std::cell::Cell::get),
+    )
+}
+
+#[cfg(test)]
+fn is_single_entity_blob_ref_probe(request: &HotStateScanRequest) -> bool {
+    request.filter.schema_keys == ["lix_binary_blob_ref"] && request.filter.entity_pks.len() == 1
+}
+
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub(crate) struct VisibilityRequest {
     pub(crate) branch_scope: VisibilityBranchScope,
@@ -148,7 +187,9 @@ where
     candidate_request.filter.branch_ids = expanded_branch_ids(&visible_branch_ids);
     let staged_rows = staged.staged_batch(&candidate_request)?;
     let rows = base.scan_batch(&candidate_request).await?;
-    Ok(resolve_visible_batch(
+    #[cfg(test)]
+    let scanned = rows.len();
+    let resolved = resolve_visible_batch(
         rows,
         staged_rows,
         &VisibilityRequest {
@@ -158,7 +199,15 @@ where
             include_tombstones: request.filter.include_tombstones,
             limit: request.limit,
         },
-    ))
+    );
+    #[cfg(test)]
+    if is_single_entity_blob_ref_probe(request) {
+        BLOB_REF_PROBE_CALLS.with(|calls| calls.set(calls.get().saturating_add(1)));
+        BLOB_REF_PROBE_ROWS_SCANNED.with(|rows| rows.set(rows.get().saturating_add(scanned)));
+        BLOB_REF_PROBE_ROWS_RETURNED
+            .with(|rows| rows.set(rows.get().saturating_add(resolved.len())));
+    }
+    Ok(resolved)
 }
 
 pub(crate) async fn overlay_scan_tracked_batch<S>(

--- a/packages/lix/src/transaction/context.rs
+++ b/packages/lix/src/transaction/context.rs
@@ -12748,6 +12748,104 @@ mod tests {
         assert!(successor.contains(&replacement_key));
     }
 
+    /// Mechanism probe for the `lix_file` content-update scaling defect.
+    ///
+    /// A content-only update changes no descriptor -- same path, same name,
+    /// same parent -- so the visible filesystem path index is unchanged by it.
+    /// This measures how many times that index is nevertheless rebuilt from
+    /// scratch, and how many descriptor rows each rebuild reads, so the cost
+    /// can be attributed to repository size rather than inferred from timings.
+    ///
+    /// The counter lives inside `build_path_index`, the only full-rebuild site,
+    /// which is a different layer from the timing instrument that first showed
+    /// the slope.
+    #[tokio::test]
+    async fn content_updates_rebuild_the_whole_path_index_once_per_statement() {
+        async fn measure(files: usize, updates: usize) -> (usize, usize) {
+            let storage = Memory::new();
+            Engine::initialize(storage.clone())
+                .await
+                .expect("storage should initialize");
+            let engine = Engine::new(storage)
+                .await
+                .expect("engine should open initialized storage");
+            let session = engine.open_session().await.expect("session should open");
+
+            let values = (0..files)
+                .map(|index| format!("('/seed-{index:05}.md', CAST('byte-01' AS BYTEA))"))
+                .collect::<Vec<_>>()
+                .join(", ");
+            session
+                .execute(
+                    &format!("INSERT INTO lix_file (path, content) VALUES {values}"),
+                    &[],
+                )
+                .await
+                .expect("fixture files should commit");
+
+            let rows = session
+                .execute("SELECT id FROM lix_file ORDER BY path", &[])
+                .await
+                .expect("file ids should read back");
+            let ids = rows
+                .rows()
+                .iter()
+                .map(|row| {
+                    row.get::<String>("id")
+                        .expect("file row should carry an id")
+                })
+                .collect::<Vec<_>>();
+            assert!(ids.len() >= updates, "fixture must cover every update");
+
+            crate::filesystem::reset_full_rebuild_stats();
+            for id in ids.iter().take(updates) {
+                session
+                    .execute(
+                        "UPDATE lix_file SET content = $1 WHERE id = $2",
+                        &[
+                            crate::Value::Blob(b"byte-02".to_vec().into()),
+                            crate::Value::Text(id.clone()),
+                        ],
+                    )
+                    .await
+                    .expect("content update should commit");
+            }
+            crate::filesystem::full_rebuild_stats()
+        }
+
+        let updates = 10;
+        let (small_builds, small_rows) = measure(50, updates).await;
+        let (large_builds, large_rows) = measure(500, updates).await;
+
+        // One full reconstruction per statement: the per-commit advance does
+        // not keep this cache warm across content updates.
+        assert_eq!(
+            small_builds, updates,
+            "50-file repository rebuilt {small_builds} times for {updates} content updates"
+        );
+        assert_eq!(
+            large_builds, updates,
+            "500-file repository rebuilt {large_builds} times for {updates} content updates"
+        );
+
+        // ... and each rebuild reads the whole repository, so the per-statement
+        // cost is O(descriptors), not O(rows touched).
+        let small_per_build = small_rows / small_builds;
+        let large_per_build = large_rows / large_builds;
+        assert!(
+            small_per_build >= 50,
+            "each rebuild should read the whole 50-file repository, read {small_per_build}"
+        );
+        assert!(
+            large_per_build >= 500,
+            "each rebuild should read the whole 500-file repository, read {large_per_build}"
+        );
+        assert!(
+            large_per_build >= small_per_build * 5,
+            "rebuild cost must track descriptor count: {small_per_build} -> {large_per_build}"
+        );
+    }
+
     #[tokio::test]
     async fn staged_descriptor_batches_advance_transaction_path_index() {
         let storage = Memory::new();

--- a/packages/lix/src/transaction/context.rs
+++ b/packages/lix/src/transaction/context.rs
@@ -12760,8 +12760,8 @@ mod tests {
     /// which is a different layer from the timing instrument that first showed
     /// the slope.
     #[tokio::test]
-    async fn content_updates_rebuild_the_whole_path_index_once_per_statement() {
-        async fn measure(files: usize, updates: usize) -> (usize, usize) {
+    async fn content_updates_hit_the_path_index_cache_and_do_not_rebuild_it() {
+        async fn measure(files: usize, updates: usize) -> (usize, usize, usize, usize) {
             let storage = Memory::new();
             Engine::initialize(storage.clone())
                 .await
@@ -12810,40 +12810,41 @@ mod tests {
                     .await
                     .expect("content update should commit");
             }
-            crate::filesystem::full_rebuild_stats()
+            let (builds, rows) = crate::filesystem::full_rebuild_stats();
+            let (hits, misses) = crate::filesystem::path_index_cache_stats();
+            (builds, rows, hits, misses)
         }
 
         let updates = 10;
-        let (small_builds, small_rows) = measure(50, updates).await;
-        let (large_builds, large_rows) = measure(500, updates).await;
-
-        // One full reconstruction per statement: the per-commit advance does
-        // not keep this cache warm across content updates.
-        assert_eq!(
-            small_builds, updates,
-            "50-file repository rebuilt {small_builds} times for {updates} content updates"
+        let (small_builds, small_rows, small_hits, small_misses) = measure(50, updates).await;
+        let (large_builds, large_rows, large_hits, large_misses) = measure(500, updates).await;
+        println!(
+            "PATHINDEX files=50 builds={small_builds} rebuilt_rows={small_rows} hits={small_hits} misses={small_misses}"
         );
-        assert_eq!(
-            large_builds, updates,
-            "500-file repository rebuilt {large_builds} times for {updates} content updates"
+        println!(
+            "PATHINDEX files=500 builds={large_builds} rebuilt_rows={large_rows} hits={large_hits} misses={large_misses}"
         );
 
-        // ... and each rebuild reads the whole repository, so the per-statement
-        // cost is O(descriptors), not O(rows touched).
-        let small_per_build = small_rows / small_builds;
-        let large_per_build = large_rows / large_builds;
+        // Connectivity: the lane really is exercised, so a zero rebuild count
+        // below is a positive result and not an instrument pointed elsewhere.
         assert!(
-            small_per_build >= 50,
-            "each rebuild should read the whole 50-file repository, read {small_per_build}"
+            small_hits >= updates && large_hits >= updates,
+            "each content update must consult the path-index cache: {small_hits} / {large_hits}"
         );
-        assert!(
-            large_per_build >= 500,
-            "each rebuild should read the whole 500-file repository, read {large_per_build}"
+
+        // The measured result: content updates HIT this cache. The visible
+        // filesystem path index is NOT rebuilt per statement, so it is not the
+        // source of the per-statement cost that scales with repository size.
+        assert_eq!(
+            small_builds, 0,
+            "50-file repository rebuilt the path index {small_builds} times"
         );
-        assert!(
-            large_per_build >= small_per_build * 5,
-            "rebuild cost must track descriptor count: {small_per_build} -> {large_per_build}"
+        assert_eq!(
+            large_builds, 0,
+            "500-file repository rebuilt the path index {large_builds} times"
         );
+        assert_eq!(small_rows, 0, "no rebuild should read descriptor rows");
+        assert_eq!(large_rows, 0, "no rebuild should read descriptor rows");
     }
 
     #[tokio::test]

--- a/packages/lix/src/transaction/context.rs
+++ b/packages/lix/src/transaction/context.rs
@@ -12803,8 +12803,8 @@ mod tests {
                     .execute(
                         "UPDATE lix_file SET content = $1 WHERE id = $2",
                         &[
-                            crate::Value::Blob(b"byte-02".to_vec().into()),
-                            crate::Value::Text(id.clone()),
+                            Value::Blob(b"byte-02".to_vec().into()),
+                            Value::Text(id.clone()),
                         ],
                     )
                     .await
@@ -12899,8 +12899,8 @@ mod tests {
                     .execute(
                         "UPDATE lix_file SET content = $1 WHERE id = $2",
                         &[
-                            crate::Value::Blob(b"byte-02".to_vec().into()),
-                            crate::Value::Text(id.clone()),
+                            Value::Blob(b"byte-02".to_vec().into()),
+                            Value::Text(id.clone()),
                         ],
                     )
                     .await

--- a/packages/lix/src/transaction/context.rs
+++ b/packages/lix/src/transaction/context.rs
@@ -12847,6 +12847,104 @@ mod tests {
         assert_eq!(large_rows, 0, "no rebuild should read descriptor rows");
     }
 
+    /// Does the single-entity blob-ref probe every `lix_file` content update
+    /// issues push `entity_pks` down to a seek, or scan the branch's whole
+    /// blob-ref collection and filter in memory?
+    ///
+    /// `rows_scanned` is what the hot-state scan handed back before visibility
+    /// resolution -- what storage actually read. `rows_returned` is what the
+    /// update consumed. If the pushdown works these track each other; if not,
+    /// `rows_scanned` tracks the repository size while `rows_returned` stays 1.
+    #[tokio::test]
+    async fn content_update_blob_ref_probe_scans_only_its_own_row() {
+        async fn measure(files: usize, updates: usize) -> (usize, usize, usize) {
+            let storage = Memory::new();
+            Engine::initialize(storage.clone())
+                .await
+                .expect("storage should initialize");
+            let engine = Engine::new(storage)
+                .await
+                .expect("engine should open initialized storage");
+            let session = engine.open_session().await.expect("session should open");
+
+            let values = (0..files)
+                .map(|index| format!("('/seed-{index:05}.md', CAST('byte-01' AS BYTEA))"))
+                .collect::<Vec<_>>()
+                .join(", ");
+            session
+                .execute(
+                    &format!("INSERT INTO lix_file (path, content) VALUES {values}"),
+                    &[],
+                )
+                .await
+                .expect("fixture files should commit");
+
+            let rows = session
+                .execute("SELECT id FROM lix_file ORDER BY path", &[])
+                .await
+                .expect("file ids should read back");
+            let ids = rows
+                .rows()
+                .iter()
+                .map(|row| {
+                    row.get::<String>("id")
+                        .expect("file row should carry an id")
+                })
+                .collect::<Vec<_>>();
+            assert!(ids.len() >= updates, "fixture must cover every update");
+
+            crate::hot_state::reset_blob_ref_probe_stats();
+            for id in ids.iter().take(updates) {
+                session
+                    .execute(
+                        "UPDATE lix_file SET content = $1 WHERE id = $2",
+                        &[
+                            crate::Value::Blob(b"byte-02".to_vec().into()),
+                            crate::Value::Text(id.clone()),
+                        ],
+                    )
+                    .await
+                    .expect("content update should commit");
+            }
+            crate::hot_state::blob_ref_probe_stats()
+        }
+
+        let updates = 10;
+        let (small_calls, small_scanned, small_returned) = measure(50, updates).await;
+        let (large_calls, large_scanned, large_returned) = measure(500, updates).await;
+        println!(
+            "BLOBPROBE files=50 calls={small_calls} scanned={small_scanned} returned={small_returned}"
+        );
+        println!(
+            "BLOBPROBE files=500 calls={large_calls} scanned={large_scanned} returned={large_returned}"
+        );
+
+        // Connectivity: the probe really is issued once per content update, so
+        // a low scanned count below means the pushdown works rather than that
+        // this counter never ran.
+        assert_eq!(
+            small_calls, updates,
+            "each content update should issue exactly one blob-ref probe"
+        );
+        assert_eq!(
+            large_calls, updates,
+            "each content update should issue exactly one blob-ref probe"
+        );
+
+        // Each probe consumes exactly its own row, at both repository sizes.
+        assert_eq!(small_returned, updates, "one blob-ref row per update");
+        assert_eq!(large_returned, updates, "one blob-ref row per update");
+
+        // The claim under test: what storage READ must not grow with the
+        // repository. A 10x larger repository must not make this probe read
+        // 10x more rows.
+        assert!(
+            large_scanned < small_scanned * 5,
+            "blob-ref probe reads scale with repository size: \
+             50 files scanned {small_scanned}, 500 files scanned {large_scanned}"
+        );
+    }
+
     #[tokio::test]
     async fn staged_descriptor_batches_advance_transaction_path_index() {
         let storage = Memory::new();


### PR DESCRIPTION
## This lands instruments and regression tests, NOT a fix

There is no performance change in this PR and no production behaviour change. Every
counter added here is `#[cfg(test)]`-gated, so the shipped library is byte-identical in
behaviour.

It exists because a real, reproducible scaling defect was chased through **three**
plausible causes today, each of which was **eliminated by reading a counter**. Without
these tests, the next person to suspect any of the three re-derives all of it. The tests
convert "the path index is fine" and "the blob probe is a seek" from arguments into
assertions that fail if either stops being true.

## The defect these instruments were built to chase (still unexplained)

`UPDATE lix_file SET content = $1 WHERE id = $2` — the engine's *fast* file
content-update route — costs time **linear in the total number of files in the
repository**, ~0.19–0.23 µs per file, measured independently by two different drivers.
The DataFusion route for the same statement is comparatively flat. At 20 000 files the
fast route is **11.8x slower** than DataFusion; the crossover is ≈750 files.

That finding is what stopped a separate change (`claude-6/expPTH-file-update-by-path`)
from landing: routing `WHERE path = ?` onto the "fast" route is a **regression** above
~750 files, +1 002% at 20 000. That branch stays unmerged as the record.

## The three eliminations, with evidence

| candidate | verdict | measured evidence |
|---|---|---|
| Full O(N) path-index rebuild per statement | **eliminated** | `builds=0 rebuilt_rows=0 hits=10 misses=0` at both 50 and 500 files |
| Revision-bump-per-`execute` busting a revision-keyed cache | **eliminated** | batching 200 updates into one explicit transaction removes a *constant*, none of the slope |
| Blob-ref probe scanning the branch's whole collection | **eliminated** | `calls=10 scanned=10 returned=10` — one row read per probe, unchanged at 10x repo size |

### 1. The path index is cached correctly and is not rebuilt

```
PATHINDEX files=50  builds=0 rebuilt_rows=0 hits=10 misses=0
PATHINDEX files=500 builds=0 rebuilt_rows=0 hits=10 misses=0
```

Test: `content_updates_hit_the_path_index_cache_and_do_not_rebuild_it`.

A note on instrument choice, because it changes the answer. The obvious counters,
`record_transaction_path_index_build` / `transaction_path_index_build_stats()`, sit in
the **transaction-local** reader. A content update issued through `session.execute`
takes the `descriptor_epoch == 0` short-circuit into `HotStateContextReader::path_index`,
which those counters never observe — so they would have reported a meaningless **zero**
and it would have looked like confirmation of the rebuild hypothesis.

This PR instead counts at `build_path_index`, the only full-rebuild site (its
`FULL_REBUILD_*` counters already existed), and **adds hit/miss counters to
`FilesystemPathIndexCache::get`** so that a zero rebuild count is readable *positively*.
Without the hit counter, "no rebuilds" and "this lane never ran" are indistinguishable.
The test asserts `hits >= updates` as an explicit connectivity check before asserting
`builds == 0`.

Consequence: the filesystem path index already honours layout invariant 3 — it is a
rebuildable cache, revision-keyed, and advanced by delta
(`incremental_filesystem_index_enabled()` is `true` by default; only a test-only env var
disables it). It is not the defect.

### 2. The cost is per-statement, not per-commit

Driver `packages/e2e/examples/exppth2_txn_probe.rs`. Repository size varies; update count
held constant at 200; RocksDB; 3 reps with arm order rotated; µs per update:

| files | `by_id_per_stmt` | `by_id_one_txn` | `by_path_per_stmt` |
|---|---|---|---|
| 200 | 326.12 | **131.72** | 441.57 |
| 2 000 | 709.62 | **514.19** | 502.14 |
| 8 000 | 1 836.82 | **1 859.61** | 618.71 |
| 20 000 | 4 078.87 | **4 550.46** | 986.06 |

Batching buys a **constant** and removes **none** of the slope; by 8 000 files the two
by-id arms are indistinguishable and at 20 000 the batched arm is slightly worse. **This
constrains the remaining search: the cost is per-statement work during execution/staging,
which rules out the commit path.**

> **Read this table with care — `native` is absent from this driver.** Its `by_path`
> absolutes (441 → 986) must **not** be read as a scaling claim, because there is no
> in-run control that is byte-identical across the sizes. The three-arm driver's
> `by_path` figures (444 → 524 across 100x files), which do have `native` alongside, are
> the ones to trust for that claim. Closing this gap is left for the next driver pass.

A finding worth recording on its own: at 200 files, batching 200 updates into one
explicit transaction takes by-id from 326 µs to **131.7 µs — a 2.5x win that beats the
native API.** That is actionable advice for SDK callers independent of any defect.

### 3. `entity_pks` on the blob-ref probe IS pushed down to a seek

```
BLOBPROBE files=50  calls=10 scanned=10 returned=10
BLOBPROBE files=500 calls=10 scanned=10 returned=10
```

Test: `content_update_blob_ref_probe_scans_only_its_own_row`.

The instrument records, at `overlay_scan_batch`, what `base.scan_batch` handed back
**before** visibility resolution — i.e. what storage actually read — scoped to
single-entity `lix_binary_blob_ref` requests so the count is attributable to exactly the
request under test. `calls` is counted separately so a low scanned count reads as "the
pushdown works" rather than "the counter never ran"; the test asserts
`calls == updates` at both sizes first.

Rows scanned tracks rows returned 1:1 and does not move with file count. There is
nothing to push down here; it is already a seek.

## What is in the diff

- `packages/lix/src/filesystem/path_index.rs` — hit/miss counters on the path-index
  cache, `path_index_cache_stats()`, reset extended.
- `packages/lix/src/hot_state/visibility.rs` — scanned/returned/calls counters for the
  single-entity blob-ref probe, `blob_ref_probe_stats()`, `reset_blob_ref_probe_stats()`.
- `packages/lix/src/transaction/context.rs` — the two regression tests above.
- `packages/e2e/examples/exppth2_txn_probe.rs` (+ `Cargo.toml` registration) — the
  batching discriminator driver.

## Layout invariants

1. **Single authority** — no. Adds no writer, no materialization, no index. Counters only.
2. **Commit canonicality** — untouched.
3. **Derived views are caches** — unchanged, and this PR *documents* that the filesystem
   path index already satisfies it.
4. **Atomic publication** — untouched.
5. **GC from refs** — untouched.
6. **SQL reads canonical records** — untouched.

## Breaking status

**Non-breaking.** All added counters are `#[cfg(test)]`. No public API, SQL surface, JS
SDK surface, storage format, or adapter API change. No `REPOSITORY_PROTOCOL_VALUE` bump.
The only non-test files touched gain `#[cfg(test)]` blocks and `pub(crate)` re-exports.

## Gate

CI scope re-derived from `910608a072c370da2e095284f00292e60fbfcd88`'s own `ci.yml`.

```
git rev-parse HEAD                     -> f94b8834139d3560905adb617aa21b62f41cbad7
git status --porcelain                -> (empty)
CI_SCOPE_CONFIRMED_AT=910608a072c370da2e095284f00292e60fbfcd88
EXECUTED_TARGETS test1=3417 test2=165

CLIPPY_EXIT=0            cargo clippy --profile test --workspace --all-targets --all-features -- -D warnings
TEST1_EXIT=0             cargo test --profile test --workspace --exclude lix_e2e --all-features --no-fail-fast
TEST2_EXIT=0             cargo test --profile test -p lix_e2e --features sdk-tests,storage-benches,slatedb,root-replay-trace --no-fail-fast
FEATURES_OFF_EXIT=0      cargo check -p lix --no-default-features

HEAD_AFTER=f94b8834139d3560905adb617aa21b62f41cbad7   status after: (empty)
```

## Next step (not in this PR)

Three eliminations mean the owner of the linear term is still unknown, and guessing a
fourth candidate is what has cost three cycles. The next move is a **frame-pointer
call-graph profile** with inclusive (`--children`) attribution, diffing the `by_id` arm
at 8 000 files versus 200 to find which chain *grows*. A flat profile cannot find it on
this async engine, and the profiling build must carry both the frame pointers and the
`cfg()` table's `+sse4.2,+pclmulqdq` in a separate `target-fp` dir.


HEAD was asserted identical before and after the gate run; worktrees are shared across agents on this host and a reset mid-run would otherwise be invisible.
