### PR TITLE
perf(hot-state): reclaim discharged tombstones at the checkpoint

### DIFF
--- a/packages/lix/src/hot_row_tombstone_probe.rs
+++ b/packages/lix/src/hot_row_tombstone_probe.rs
@@ -1380,7 +1380,16 @@ async fn recreated_identity_created_at_after_compaction() {
          entries {}->{} tombstones {}->{}",
         before.entries, after.entries, before.tombstones, after.tombstones
     );
-    assert!(removed > 0, "the delete must have left a tombstone to remove");
+    // The engine now compacts a discharged tombstone at the checkpoint itself
+    // (`hot_compaction_mask`), so by this point there is usually nothing left
+    // for the simulation to remove. Either state is a valid entry into the
+    // question this arm asks — what a re-insert over a *missing* tombstone
+    // gets — and phase 10 pins the engine-driven route with its own test. What
+    // must hold here is that no tombstone survives into the re-insert.
+    assert_eq!(
+        after.tombstones, 0,
+        "the identity must carry no tombstone into the re-insert (removed={removed})"
+    );
 
     let session = reopen_session(&storage).await;
     let hits_before = crate::hot_state::BROAD_CANONICAL_CREATED_AT_HITS
@@ -1496,4 +1505,299 @@ async fn broad_canonical_created_at_recovery_misses_for_new_identities() {
         hits, 0,
         "a genuinely new identity has no canonical ancestor to inherit from"
     );
+}
+
+/// Compaction engagement, read from inside the route.
+///
+/// Process-global by construction, so only *deltas* and only *thresholds*
+/// scaled to a fixture no concurrent test can reach are meaningful here.
+#[derive(Clone, Copy, Debug)]
+struct CompactionCounters {
+    /// Publications that reached the mask at all.
+    routes: u64,
+    /// Deltas those publications offered it.
+    offered: u64,
+    /// Of those, tombstones eligible on shape alone.
+    candidates: u64,
+    /// Of those, tombstones every gate cleared.
+    compacted: u64,
+}
+
+fn compaction_counters() -> CompactionCounters {
+    let load = |counter: &std::sync::atomic::AtomicU64| {
+        counter.load(std::sync::atomic::Ordering::Relaxed)
+    };
+    CompactionCounters {
+        routes: load(&crate::hot_state::COMPACTED_TOMBSTONE_ROUTES),
+        offered: load(&crate::hot_state::COMPACTED_TOMBSTONE_OFFERED),
+        candidates: load(&crate::hot_state::COMPACTED_TOMBSTONE_CANDIDATES),
+        compacted: load(&crate::hot_state::COMPACTED_TOMBSTONE_COMPACTED),
+    }
+}
+
+impl CompactionCounters {
+    fn since(self, before: Self) -> Self {
+        Self {
+            routes: self.routes - before.routes,
+            offered: self.offered - before.offered,
+            candidates: self.candidates - before.candidates,
+            compacted: self.compacted - before.compacted,
+        }
+    }
+}
+
+impl std::fmt::Display for CompactionCounters {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "routes={} offered={} candidates={} compacted={}",
+            self.routes, self.offered, self.candidates, self.compacted
+        )
+    }
+}
+
+/// PHASE 10 — the landed engine change: a checkpoint reclaims the tombstones
+/// it has just discharged.
+///
+/// Numbered 10 because phases 1–7 are shared, 8 is #1427's allocation census
+/// and 9 is the canonical `created_at` recovery that #1432 landed.
+///
+/// Phase 4 proved the *premise* by removing tombstones behind the engine's
+/// back. This phase asserts the engine now does it itself, at the checkpoint,
+/// through `hot_compaction_mask`. Both the hit and the refusal are asserted in
+/// non-`#[ignore]`d tests, because a design whose every gate is conservative
+/// fails silently inert, and a row-count instrument one layer up cannot tell
+/// "reclaimed nothing here" from "never ran".
+#[tokio::test]
+async fn checkpoint_compacts_discharged_branch_tombstones() {
+    const N: usize = 300;
+    let (storage, session) = open_session().await;
+    register(&session, probe_schema("cp10row")).await;
+    insert_rows(&session, "cp10row", N).await;
+    // MEASURED, and it is the shape of the whole result: a checkpoint
+    // republishes the interval's *dirty set*, and a delete only joins that set
+    // while a checkpoint interval is open. Churn before a repository's first
+    // checkpoint reaches the compaction route with `offered=2` — the route
+    // runs, the deletes are simply not in it. Compaction therefore reclaims
+    // deletes made inside an interval, which is the steady state; a
+    // never-checkpointed branch's tombstones are a separate, larger problem
+    // this change does not claim.
+    session
+        .create_checkpoint()
+        .await
+        .expect("baseline checkpoint should publish");
+    delete_all_but_first(&session, "cp10row", N).await;
+
+    let before = row_census(&storage).await;
+    assert!(
+        before.tombstones >= N - 1,
+        "the churn must leave one tombstone per delete, saw {}",
+        before.tombstones
+    );
+
+    let counters_before = compaction_counters();
+    session
+        .create_checkpoint()
+        .await
+        .expect("checkpoint should publish");
+    let counters = compaction_counters().since(counters_before);
+    let after = row_census(&storage).await;
+
+    println!(
+        "phase10 | compaction entries {}->{} tombstones {}->{} {counters}",
+        before.entries, after.entries, before.tombstones, after.tombstones
+    );
+
+    // Engagement first: a flat row count is ambiguous, these counts are not.
+    assert!(
+        counters.candidates >= (N - 1) as u64,
+        "every discharged tombstone must reach the compaction route, saw {}",
+        counters.candidates
+    );
+    assert!(
+        counters.compacted >= (N - 1) as u64,
+        "every gate must clear for a branch-local schema with no base, saw {}",
+        counters.compacted
+    );
+
+    // Then the effect the counters predict.
+    assert!(
+        after.tombstones * 10 < before.tombstones,
+        "the checkpoint must reclaim the tombstones it discharged, {} -> {}",
+        before.tombstones,
+        after.tombstones
+    );
+    assert!(
+        after.entries < before.entries,
+        "reclaimed tombstones must leave the serving view smaller"
+    );
+
+    // And the answer, cold, so nothing passes off a warm cache.
+    let session = reopen_session(&storage).await;
+    let survivors = session
+        .execute("SELECT id FROM cp10row", &[])
+        .await
+        .expect("collection scan should run");
+    assert_eq!(
+        survivors.len(),
+        1,
+        "compaction must not resurrect a deleted row"
+    );
+    let answer = session
+        .execute(&scan_sql("cp10row"), &[])
+        .await
+        .expect("scan should run");
+    assert_eq!(answer.len(), 1, "the surviving row must still answer");
+    assert_eq!(
+        working_diff_rows(&session, "cp10row").await,
+        0,
+        "a checkpoint discharges every delete, compacted or not"
+    );
+}
+
+/// The refusal is asserted where it can be made deterministic:
+/// `hot_state::tracked_head::hot::tests::
+/// checkpoint_compaction_keeps_only_globally_shadowed_tombstones` seeds a
+/// global-branch row and a branch tombstone in the same schema and checks the
+/// tombstone survives the checkpoint, alongside a same-publication control in
+/// a schema global has no rows in that is reclaimed.
+///
+/// It is not asserted through SQL here because there is no reachable SQL path
+/// to a global row in a probe-defined schema: a branch-registered schema is
+/// not visible to a global write, and a globally registered one is never bound
+/// as a table.
+/// The `created_at` consequence, pinned against *real* compaction.
+///
+/// Phase 9 pins the same behaviour against `drop_all_tombstones`, a simulation.
+/// This is the version that fails if the engine's own compaction and the
+/// canonical `created_at` recovery ever stop lining up — the failure mode with
+/// no other guard, because a wrong timestamp is written silently and only
+/// surfaces on a later rebuild.
+#[tokio::test]
+async fn recreated_identity_inherits_created_at_after_engine_compaction() {
+    let (storage, session) = open_session().await;
+    register(&session, probe_schema("ci10row")).await;
+    session
+        .execute(
+            "INSERT INTO ci10row (id, locale) VALUES ('row-0', 'first')",
+            &[],
+        )
+        .await
+        .expect("first insert should commit");
+    // The insert must be canonical before the delete, or the pair cancels
+    // inside one checkpoint interval and a fresh timestamp is the right answer.
+    session
+        .create_checkpoint()
+        .await
+        .expect("baseline checkpoint should publish");
+    let first = created_at_of(&session, "ci10row", "row-0").await;
+
+    session
+        .execute("DELETE FROM ci10row WHERE id = 'row-0'", &[])
+        .await
+        .expect("delete should commit");
+    let counters_before = compaction_counters();
+    session
+        .create_checkpoint()
+        .await
+        .expect("checkpoint should publish");
+    let counters = compaction_counters().since(counters_before);
+    assert!(
+        counters.compacted > 0,
+        "this test is about a compacted identity; nothing was compacted"
+    );
+
+    let hits_before = crate::hot_state::BROAD_CANONICAL_CREATED_AT_HITS
+        .load(std::sync::atomic::Ordering::Relaxed);
+    session
+        .execute(
+            "INSERT INTO ci10row (id, locale) VALUES ('row-0', 'second')",
+            &[],
+        )
+        .await
+        .expect("re-insert should commit");
+    let hits = crate::hot_state::BROAD_CANONICAL_CREATED_AT_HITS
+        .load(std::sync::atomic::Ordering::Relaxed)
+        - hits_before;
+    let second = created_at_of(&session, "ci10row", "row-0").await;
+    println!(
+        "phase10 | created_at first={first} second={second} inherited={} \
+         canonical_hits={hits} compacted={}",
+        first == second,
+        counters.compacted
+    );
+
+    assert!(
+        hits > 0,
+        "the re-insert must have sourced its created_at from canonical state"
+    );
+    assert_eq!(
+        second, first,
+        "a re-insert over a compacted identity inherits its original created_at"
+    );
+
+    drop(session);
+    let engine = Engine::new(storage.clone())
+        .await
+        .expect("engine should reopen for rebuild");
+    let branch_id = engine
+        .open_session()
+        .await
+        .expect("session should open")
+        .active_branch_id()
+        .await
+        .expect("active branch id reads");
+    engine
+        .rebuild_tracked_state_for_branch(&branch_id)
+        .await
+        .expect("a compacted branch must still rebuild");
+}
+
+/// The measurement the change exists for: what a checkpoint now costs a
+/// churned collection's scan, at three sizes so the removed term shows as a
+/// slope rather than a point.
+#[tokio::test]
+#[ignore = "measurement probe, not a gate"]
+async fn checkpoint_compaction_scan_cost() {
+    let sizes = sizes_from_env("LIX_TOMBSTONE_SIZES", &[100, 1_000, 10_000]);
+    let reps = reps_from_env(5);
+    println!("phase10 | n,event,row_entries,tombstones,scan_us,counters");
+    for n in sizes {
+        let (storage, session) = open_session().await;
+        register(&session, probe_schema("m10row")).await;
+        insert_rows(&session, "m10row", n).await;
+        // The deletes have to fall inside an open checkpoint interval to join
+        // the dirty set the next checkpoint republishes. See
+        // `checkpoint_compacts_discharged_branch_tombstones`.
+        session
+            .create_checkpoint()
+            .await
+            .expect("baseline checkpoint should publish");
+        delete_all_but_first(&session, "m10row", n).await;
+
+        let census = row_census(&storage).await;
+        let scan = timed_scan(&session, &scan_sql("m10row"), 1, reps).await;
+        println!(
+            "{n},after_churn,{},{},{},-",
+            census.entries,
+            census.tombstones,
+            scan.as_micros()
+        );
+
+        let counters_before = compaction_counters();
+        session
+            .create_checkpoint()
+            .await
+            .expect("checkpoint should publish");
+        let counters = compaction_counters().since(counters_before);
+        let census = row_census(&storage).await;
+        let scan = timed_scan(&session, &scan_sql("m10row"), 1, reps).await;
+        println!(
+            "{n},after_checkpoint,{},{},{},{}",
+            census.entries,
+            census.tombstones,
+            scan.as_micros(),
+            counters
+        );
+    }
 }

--- a/packages/lix/src/hot_state/mod.rs
+++ b/packages/lix/src/hot_state/mod.rs
@@ -48,7 +48,8 @@ pub(crate) use tracked_head::stage_retire_hot_generation;
 #[allow(unused_imports)]
 pub(crate) use tracked_head::{
     BROAD_CANONICAL_CREATED_AT_HITS, BROAD_CANONICAL_CREATED_AT_KEYS,
-    BROAD_CANONICAL_CREATED_AT_LOOKUPS,
+    BROAD_CANONICAL_CREATED_AT_LOOKUPS, COMPACTED_TOMBSTONE_CANDIDATES,
+    COMPACTED_TOMBSTONE_COMPACTED, COMPACTED_TOMBSTONE_OFFERED, COMPACTED_TOMBSTONE_ROUTES,
 };
 #[allow(unused_imports)]
 pub(crate) use tracked_head::{

--- a/packages/lix/src/hot_state/tracked_head.rs
+++ b/packages/lix/src/hot_state/tracked_head.rs
@@ -15,7 +15,8 @@ pub(crate) use crate::hot_state::HotStateReadDomain;
 #[cfg(any(test, feature = "storage-benches"))]
 pub(crate) use hot::{
     BROAD_CANONICAL_CREATED_AT_HITS, BROAD_CANONICAL_CREATED_AT_KEYS,
-    BROAD_CANONICAL_CREATED_AT_LOOKUPS,
+    BROAD_CANONICAL_CREATED_AT_LOOKUPS, COMPACTED_TOMBSTONE_CANDIDATES,
+    COMPACTED_TOMBSTONE_COMPACTED, COMPACTED_TOMBSTONE_OFFERED, COMPACTED_TOMBSTONE_ROUTES,
 };
 #[cfg(test)]
 pub(crate) use hot::WORKING_DIFF_PATH_HITS;
@@ -536,7 +537,15 @@ impl TrackedHeadContext {
     where
         S: StorageAdapterRead + ?Sized,
     {
-        hot::HotStateWriter { store, writes }
+        // `transaction_global_schema_keys: None` is the safe default: it
+        // disables serving-view tombstone compaction. Only a caller holding
+        // the transaction's complete prepared inputs may relax it, through
+        // `HotStateWriter::with_transaction_global_schema_keys`.
+        hot::HotStateWriter {
+            store,
+            writes,
+            transaction_global_schema_keys: None,
+        }
     }
 }
 

--- a/packages/lix/src/hot_state/tracked_head/hot.rs
+++ b/packages/lix/src/hot_state/tracked_head/hot.rs
@@ -109,6 +109,32 @@ pub(crate) static BROAD_CANONICAL_CREATED_AT_KEYS: std::sync::atomic::AtomicU64 
 #[cfg(any(test, feature = "storage-benches"))]
 pub(crate) static BROAD_CANONICAL_CREATED_AT_HITS: std::sync::atomic::AtomicU64 =
     std::sync::atomic::AtomicU64::new(0);
+
+/// Engagement counters for serving-view tombstone compaction.
+///
+/// Both sit *inside* `hot_compaction_mask`, the route they measure, rather than
+/// at the publication layer above it. `CANDIDATES` counts tombstones the
+/// checkpoint offered, `COMPACTED` the ones the gates actually cleared. A
+/// timing or row-count instrument one layer up cannot distinguish "compaction
+/// reclaimed nothing here" from "compaction never ran", and the second is the
+/// failure mode this design is most exposed to: every gate is conservative, so
+/// one wrong polarity makes the pass silently inert.
+///
+/// `ROUTES` and `OFFERED` sit above both, at the mask's first line, because
+/// "the checkpoint offered no tombstone" and "the checkpoint never reached the
+/// mask" are different faults with identical readings at `CANDIDATES`.
+#[cfg(any(test, feature = "storage-benches"))]
+pub(crate) static COMPACTED_TOMBSTONE_ROUTES: std::sync::atomic::AtomicU64 =
+    std::sync::atomic::AtomicU64::new(0);
+#[cfg(any(test, feature = "storage-benches"))]
+pub(crate) static COMPACTED_TOMBSTONE_OFFERED: std::sync::atomic::AtomicU64 =
+    std::sync::atomic::AtomicU64::new(0);
+#[cfg(any(test, feature = "storage-benches"))]
+pub(crate) static COMPACTED_TOMBSTONE_CANDIDATES: std::sync::atomic::AtomicU64 =
+    std::sync::atomic::AtomicU64::new(0);
+#[cfg(any(test, feature = "storage-benches"))]
+pub(crate) static COMPACTED_TOMBSTONE_COMPACTED: std::sync::atomic::AtomicU64 =
+    std::sync::atomic::AtomicU64::new(0);
 /// Generation-local immutable current-state bases.
 ///
 /// Each tiny record points at one already-authored packed commit delta. Fresh
@@ -6676,6 +6702,40 @@ impl HotTrackedSnapshot {
 pub(crate) struct HotStateWriter<'a, S: ?Sized> {
     pub(super) store: &'a S,
     pub(super) writes: &'a mut StorageWriteSet,
+    /// Schema keys this transaction publishes on the global branch, when the
+    /// caller can enumerate them completely.
+    ///
+    /// A property of the transaction rather than of any one call, which is why
+    /// it lives here instead of being threaded through the staging wrappers.
+    /// Only serving-view tombstone compaction reads it; see
+    /// [`hot_compaction_mask`].
+    ///
+    /// **Polarity.** `None` means "this caller cannot say", and it *disables*
+    /// compaction — the safe verdict. A construction site that is unsure must
+    /// leave it `None`; the factory default is `None` for exactly that reason.
+    /// Only a caller holding the transaction's complete prepared inputs may
+    /// supply a set, and a schema key present in that set likewise disables
+    /// compaction for that schema.
+    pub(super) transaction_global_schema_keys: Option<&'a BTreeSet<String>>,
+}
+
+impl<'a, S: ?Sized> HotStateWriter<'a, S> {
+    /// Declares the schema keys this transaction publishes on the global
+    /// branch, unlocking serving-view tombstone compaction for every other
+    /// schema.
+    ///
+    /// The caller must derive the set from the transaction's prepared inputs,
+    /// not from the write set: `tracked_roots_parent_first` orders roots by
+    /// `parent_commit_id` alone and never consults `branch_id`, so a global
+    /// root is not guaranteed to be staged before a non-global one and a
+    /// write-set consultation would see an incomplete picture.
+    pub(crate) fn with_transaction_global_schema_keys(
+        mut self,
+        schema_keys: &'a BTreeSet<String>,
+    ) -> Self {
+        self.transaction_global_schema_keys = Some(schema_keys);
+        self
+    }
 }
 
 impl<S> HotStateWriter<'_, S>
@@ -8322,6 +8382,27 @@ where
         } else {
             (sorted, previous_values, created_ats)
         };
+        // Serving-view tombstone compaction. Computed here rather than earlier
+        // because the retain filter above rebinds `sorted`, and a mask built
+        // against the pre-filter slice would address the wrong rows.
+        //
+        // `Box::pin` is load-bearing, not style: this is the universal commit
+        // write path, guarded by the
+        // `slatedb_history_blob_survives_until_final_root_release` stack
+        // canary, and the future's size is paid whether or not the branch is
+        // taken. The file already carries nine of these for the same reason.
+        let compacted = if reset_working_diff_baselines {
+            Box::pin(hot_compaction_mask(
+                self.store,
+                branch_id,
+                generation,
+                &sorted,
+                self.transaction_global_schema_keys,
+            ))
+            .await?
+        } else {
+            Vec::new()
+        };
         let identities = encode_hot_mutation_identities(branch_id, generation, &sorted);
         let unmatched_guards = if absence_guards_validated || absence_guards.is_empty() {
             BTreeSet::new()
@@ -8397,8 +8478,10 @@ where
                 "lix.perf.materialization.hot.values"
             )
             .entered();
-            for (delta, (created_at, previous)) in
-                sorted.iter().zip(created_ats.iter().zip(&previous_values))
+            for (index, (delta, (created_at, previous))) in sorted
+                .iter()
+                .zip(created_ats.iter().zip(&previous_values))
+                .enumerate()
             {
                 // Ordinary commits have no active checkpoint, so their baseline
                 // is always disabled. Do not decode the row a second time merely
@@ -8441,7 +8524,22 @@ where
                         value: BufferRange::default(),
                     });
                 }
-                next_value_ranges.push(if delta.physically_deletes() {
+                let compacted_row = compacted.get(index).copied().unwrap_or(false);
+                if compacted_row
+                    && (working_diff_baseline != WorkingDiffBaseline::Clean || newly_dirty)
+                {
+                    // Gate (c), asserted rather than assumed. Compaction runs
+                    // only under `reset_working_diff_baselines`, which forces
+                    // `(Clean, false)` for every tracked delta, so a compacted
+                    // row is provably clean at the moment it is removed and
+                    // "a dirty row cannot vanish" survives. If that stops
+                    // holding, fail the publication rather than drop a row
+                    // whose before-image is still owed.
+                    return Err(head_value_error(
+                        "compacted hot tombstone is not provably clean at removal",
+                    ));
+                }
+                next_value_ranges.push(if delta.physically_deletes() || compacted_row {
                     None
                 } else {
                     let mut value = delta.value_ref(*created_at, working_diff_baseline);
@@ -9453,6 +9551,208 @@ fn checked_add_hot_next_value_capacity(
                 .unwrap_or(0),
         )?;
     total.checked_add(encoded_len)
+}
+
+/// Whether the generation still has any immutable base beneath its HOT rows.
+///
+/// `ROW_SPACE` is a sparse overlay. A tombstone is what shadows a base row for
+/// the same identity, so every plane that can serve a row for this generation
+/// has to be proven empty before a tombstone can be treated as dead weight.
+/// The planes are the same four `has_schema_rows` consults, minus `ROW_SPACE`
+/// itself: the packed current base, its exclusive-schema variant, the sparse
+/// root base, and certified entity batches.
+///
+/// This is one existence probe per plane per publication, not per identity.
+async fn hot_generation_has_any_base(
+    store: &(impl StorageAdapterRead + ?Sized),
+    branch_id: &str,
+    generation: CommitId,
+) -> Result<bool, LixError> {
+    if !packed_current_base_refs(store, branch_id, generation)
+        .await?
+        .is_empty()
+    {
+        return Ok(true);
+    }
+    if load_root_current_base_commit(store, branch_id, generation)
+        .await?
+        .is_some()
+    {
+        return Ok(true);
+    }
+    if hot_space_prefix_has_entry(
+        store,
+        PACKED_CURRENT_EXCLUSIVE_SCHEMA_BASE_SPACE,
+        Bytes::from(hot_scope_prefix(branch_id, generation)),
+    )
+    .await?
+    {
+        return Ok(true);
+    }
+    // Certified entity-batch manifests are keyed by generation alone, which is
+    // what `scan_certified_entity_batch_rows` scans when no file filter
+    // narrows it.
+    hot_space_prefix_has_entry(
+        store,
+        CERTIFIED_ENTITY_BATCH_MANIFEST_SPACE,
+        Bytes::copy_from_slice(generation.as_uuid().as_bytes()),
+    )
+    .await
+}
+
+/// Key-only existence probe for one prefix in one space.
+async fn hot_space_prefix_has_entry(
+    store: &(impl StorageAdapterRead + ?Sized),
+    space: StorageSpace,
+    prefix: Bytes,
+) -> Result<bool, LixError> {
+    let range = StoragePrefix { bytes: prefix }.to_range()?;
+    let mut cursor = store
+        .begin_scan(
+            space,
+            range,
+            StorageBeginScanOptions {
+                projection: StorageCoreProjection::KeyOnly,
+                ..StorageBeginScanOptions::default()
+            },
+        )
+        .await?;
+    let (page, _has_more) = cursor.next_page(1).await?.into_parts();
+    Ok(!page.is_empty())
+}
+
+/// Which of `deltas` may have their serving-view tombstone removed outright
+/// rather than republished as a tombstone.
+///
+/// `ROW_SPACE` is a derived serving view, so nothing here is canonical: a
+/// removed tombstone stays recoverable from history, and `undo` replays from
+/// canonical state rather than from the serving row. The only question is
+/// whether removing it changes an *answer*, which happens exactly when
+/// something below the tombstone would resurface.
+///
+/// Two things can sit below one:
+///
+/// - **(a) a base for the same generation.** Ruled out wholesale by
+///   [`hot_generation_has_any_base`]. A checkpoint publishes no base of its
+///   own, so this is the ordinary state at a checkpoint rather than a rare one.
+/// - **(b) a global-branch row for the same identity.** The global branch sits
+///   beneath every other branch, and a branch tombstone is what hides a global
+///   row from that branch — the behaviour
+///   `main_tombstone_hides_global_row` and its four siblings pin. Ruled out
+///   per *schema key*, against both what is already durable
+///   (`has_schema_rows`, which is base-complete) and what this transaction is
+///   publishing on global (`transaction_global_schema_keys`). Per-schema
+///   granularity is not an optimization: a checkpoint always stages its own
+///   global `lix_checkpoint` row, so a transaction-wide global test would
+///   block every checkpoint and make this pass silently inert.
+///
+/// A third condition — the delete still being observable through its
+/// working-diff baseline — does not exist. `DIFF_SPACE`, not `ROW_SPACE`, is
+/// the working diff's authority; `hot_row_tombstone_probe`'s `near_miss` arm
+/// measures that and keeps an inverted assertion so a change that reintroduces
+/// the dependency fails loudly.
+///
+/// Callers must pass the deltas *after* the checkpoint retain filter, since
+/// that filter rebinds the slice and an earlier mask would misalign.
+async fn hot_compaction_mask(
+    store: &(impl StorageAdapterRead + ?Sized),
+    branch_id: &str,
+    generation: CommitId,
+    deltas: &[&CurrentStateDeltaRef<'_>],
+    transaction_global_schema_keys: Option<&BTreeSet<String>>,
+) -> Result<Vec<bool>, LixError> {
+    let mask = vec![false; deltas.len()];
+    #[cfg(any(test, feature = "storage-benches"))]
+    {
+        COMPACTED_TOMBSTONE_ROUTES.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        COMPACTED_TOMBSTONE_OFFERED
+            .fetch_add(deltas.len() as u64, std::sync::atomic::Ordering::Relaxed);
+    }
+    let is_candidate = |delta: &CurrentStateDeltaRef<'_>| {
+        delta.deleted
+            && !delta.untracked
+            && delta.schema_key != crate::collection_generation::COLLECTION_GENERATION_SCHEMA_KEY
+            // An exact-closure scope proves its membership from a recomputed
+            // identity digest. Leaving its tombstones alone keeps that proof
+            // out of this change's blast radius for no measurable loss.
+            && !scope_requires_exact_closure(branch_id, delta.schema_key, delta.file_id)
+    };
+    let candidates = deltas
+        .iter()
+        .filter(|delta| is_candidate(delta))
+        .count();
+    if candidates == 0 {
+        return Ok(mask);
+    }
+    #[cfg(any(test, feature = "storage-benches"))]
+    COMPACTED_TOMBSTONE_CANDIDATES
+        .fetch_add(candidates as u64, std::sync::atomic::Ordering::Relaxed);
+
+    // Gate (a).
+    if hot_generation_has_any_base(store, branch_id, generation).await? {
+        return Ok(mask);
+    }
+
+    // Gate (b). Nothing sits below the global branch, so it is vacuous there
+    // and neither half of it is consulted.
+    let global_is_below = branch_id != crate::GLOBAL_BRANCH_ID;
+    if global_is_below && transaction_global_schema_keys.is_none() {
+        // The caller cannot enumerate what this transaction stages on global.
+        // That is the disabling verdict wherever global sits below.
+        return Ok(mask);
+    }
+    let global_control = if global_is_below {
+        BranchHeadControlContext::new()
+            .reader(store)
+            .load(crate::GLOBAL_BRANCH_ID)
+            .await?
+    } else {
+        None
+    };
+    let reader = HotStateStoreReader {
+        store,
+        transaction_cache: None,
+        root_base_cache: None,
+    };
+
+    let mut mask = mask;
+    let mut compacted = 0_u64;
+    // One verdict per distinct schema key, not per identity: a churned
+    // collection offers thousands of tombstones in one schema.
+    let mut verdicts: BTreeMap<&str, bool> = BTreeMap::new();
+    for (index, delta) in deltas.iter().enumerate() {
+        if !is_candidate(delta) {
+            continue;
+        }
+        let blocked = if !global_is_below {
+            false
+        } else if let Some(&verdict) = verdicts.get(delta.schema_key) {
+            verdict
+        } else {
+            let verdict = transaction_global_schema_keys
+                .is_some_and(|schema_keys| schema_keys.contains(delta.schema_key))
+                || match global_control {
+                    Some(control) => {
+                        reader
+                            .has_schema_rows(crate::GLOBAL_BRANCH_ID, control, delta.schema_key)
+                            .await?
+                    }
+                    // No global branch control means no published global
+                    // generation, so no global row can be hidden by anything.
+                    None => false,
+                };
+            verdicts.insert(delta.schema_key, verdict);
+            verdict
+        };
+        if !blocked {
+            mask[index] = true;
+            compacted += 1;
+        }
+    }
+    #[cfg(any(test, feature = "storage-benches"))]
+    COMPACTED_TOMBSTONE_COMPACTED.fetch_add(compacted, std::sync::atomic::Ordering::Relaxed);
+    let _ = compacted;
+    Ok(mask)
 }
 
 fn encoded_hot_slot_len(slot: JsonSlotRef<'_>, fingerprint_inline: bool) -> usize {
@@ -14443,6 +14743,7 @@ mod tests {
         let (_, retired) = HotStateWriter {
             store: &read,
             writes: &mut writes,
+            transaction_global_schema_keys: None,
         }
         .stage_complete_collection_replacement_current_base(
             BRANCH_ID,
@@ -14580,6 +14881,7 @@ mod tests {
         let replacement = HotStateWriter {
             store: &read,
             writes: &mut replacement_writes,
+            transaction_global_schema_keys: None,
         }
         .try_stage_exact_collection_replacement_current_base(
             BRANCH_ID,
@@ -14609,6 +14911,7 @@ mod tests {
         let deletion = HotStateWriter {
             store: &read,
             writes: &mut deletion_writes,
+            transaction_global_schema_keys: None,
         }
         .try_stage_exact_collection_delete_current_base(
             BRANCH_ID,
@@ -14721,6 +15024,7 @@ mod tests {
         HotStateWriter {
             store: &read,
             writes: &mut checkpoint_writes,
+            transaction_global_schema_keys: None,
         }
         .stage_checkpoint_current_state(
             BRANCH_ID,
@@ -17292,5 +17596,176 @@ mod tests {
                 .next()
                 .flatten();
         assert!(active_record.is_some(), "active hot record must survive GC");
+    }
+
+    /// Gate (b) of `hot_compaction_mask`, both verdicts, in one publication.
+    ///
+    /// A branch tombstone is what hides a same-identity global row from that
+    /// branch — the contract `main_tombstone_hides_global_row` and its
+    /// siblings pin — so compaction must keep it. A tombstone in a schema the
+    /// global branch has no rows in shadows nothing and must go. Both are
+    /// asserted here rather than only through a checkpoint's row count,
+    /// because a wholly inert pass and a correctly conservative one produce
+    /// the same count.
+    #[tokio::test]
+    async fn checkpoint_compaction_keeps_only_globally_shadowed_tombstones() {
+        const BRANCH_ID: &str = "01920000-0000-7000-8000-0000000000e5";
+        const BRANCH_LABEL: &str = "e45e-compaction-branch";
+        const GLOBAL_LABEL: &str = "e45e-compaction-global";
+        const SHADOWED_SCHEMA: &str = "e45e_shadowed_schema";
+        const PRIVATE_SCHEMA: &str = "e45e_private_schema";
+
+        let storage = StorageAdapter::new(Memory::new());
+        let created_at = timestamp();
+        let shadowed_pk = EntityPk::single("shadowed-row");
+        let private_pk = EntityPk::single("private-row");
+        let global_commit = CommitId::for_test_label(GLOBAL_LABEL);
+        let generation = CommitId::for_test_label(BRANCH_LABEL);
+
+        crate::test_support::seed_branch_head_with_rows(
+            storage.clone(),
+            crate::GLOBAL_BRANCH_ID,
+            GLOBAL_LABEL,
+            &[MaterializedTrackedStateRow {
+                entity_pk: shadowed_pk.clone(),
+                schema_key: SHADOWED_SCHEMA.to_owned(),
+                file_id: None,
+                snapshot_content: Some(r#"{"key":"global-row"}"#.into()),
+                metadata: None,
+                deleted: false,
+                created_at: created_at.to_string(),
+                updated_at: created_at.to_string(),
+                change_id: ChangeId::for_test_label("e45e-global-change"),
+                commit_id: global_commit,
+            }],
+        )
+        .await;
+        crate::test_support::seed_branch_head_with_rows(
+            storage.clone(),
+            BRANCH_ID,
+            BRANCH_LABEL,
+            &[
+                MaterializedTrackedStateRow {
+                    entity_pk: private_pk.clone(),
+                    schema_key: PRIVATE_SCHEMA.to_owned(),
+                    file_id: None,
+                    snapshot_content: Some(r#"{"key":"private-row"}"#.into()),
+                    metadata: None,
+                    deleted: false,
+                    created_at: created_at.to_string(),
+                    updated_at: created_at.to_string(),
+                    change_id: ChangeId::for_test_label("e45e-branch-private"),
+                    commit_id: generation,
+                },
+                MaterializedTrackedStateRow {
+                    entity_pk: shadowed_pk.clone(),
+                    schema_key: SHADOWED_SCHEMA.to_owned(),
+                    file_id: None,
+                    snapshot_content: Some(r#"{"key":"branch-row"}"#.into()),
+                    metadata: None,
+                    deleted: false,
+                    created_at: created_at.to_string(),
+                    updated_at: created_at.to_string(),
+                    change_id: ChangeId::for_test_label("e45e-branch-shadowed"),
+                    commit_id: generation,
+                },
+            ],
+        )
+        .await;
+
+        let read = storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("open compaction gate read");
+        let checkpoint_head = CommitId::for_test_label("e45e-compaction-checkpoint");
+        let deltas = [
+            CurrentStateDeltaRef {
+                schema_key: PRIVATE_SCHEMA,
+                file_id: None,
+                entity_pk: &private_pk,
+                change_id: Some(ChangeId::for_test_label("e45e-delete-private")),
+                commit_id: Some(checkpoint_head),
+                untracked: false,
+                deleted: true,
+                created_at,
+                updated_at: created_at,
+                snapshot: JsonSlotRef::None,
+                metadata: JsonSlotRef::None,
+                columnar_base_coordinate: None,
+            },
+            CurrentStateDeltaRef {
+                schema_key: SHADOWED_SCHEMA,
+                file_id: None,
+                entity_pk: &shadowed_pk,
+                change_id: Some(ChangeId::for_test_label("e45e-delete-shadowed")),
+                commit_id: Some(checkpoint_head),
+                untracked: false,
+                deleted: true,
+                created_at,
+                updated_at: created_at,
+                snapshot: JsonSlotRef::None,
+                metadata: JsonSlotRef::None,
+                columnar_base_coordinate: None,
+            },
+        ];
+        // This transaction publishes nothing on global, so the only global
+        // authority is what the seed already made durable.
+        let staged_on_global = BTreeSet::new();
+        let mut checkpoint_writes = StorageWriteSet::new();
+        let mut coverage = WorkingDiffIndexCoverage::default();
+        HotStateWriter {
+            store: &read,
+            writes: &mut checkpoint_writes,
+            transaction_global_schema_keys: Some(&staged_on_global),
+        }
+        .stage_checkpoint_current_state(
+            BRANCH_ID,
+            generation,
+            checkpoint_head,
+            &deltas,
+            &BTreeSet::new(),
+            checkpoint_head,
+            &mut coverage,
+        )
+        .await
+        .expect("checkpoint should stage");
+        drop(read);
+        storage
+            .commit_write_set(checkpoint_writes, StorageWriteOptions::default())
+            .await
+            .expect("commit compaction checkpoint");
+
+        let read = storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("verify compaction gate");
+        let key = |schema_key: &str, entity_pk: &EntityPk| {
+            StorageKey(Bytes::from(encode_hot_row_key(&HeadIdentity {
+                branch_id: BRANCH_ID.to_owned(),
+                generation,
+                schema_key: schema_key.to_owned(),
+                entity_pk: entity_pk.clone(),
+                file_id: None,
+            })))
+        };
+        let rows = PointReadPlan::new(
+            ROW_SPACE,
+            &[
+                key(SHADOWED_SCHEMA, &shadowed_pk),
+                key(PRIVATE_SCHEMA, &private_pk),
+            ],
+        )
+        .materialize(&read, StorageGetOptions::default())
+        .await
+        .expect("read compacted generation")
+        .value;
+        assert!(
+            rows[0].is_some(),
+            "a tombstone shadowing a global row must survive the checkpoint"
+        );
+        assert!(
+            rows[1].is_none(),
+            "a tombstone shadowing nothing must be reclaimed by the checkpoint"
+        );
     }
 }

--- a/packages/lix/src/transaction/commit.rs
+++ b/packages/lix/src/transaction/commit.rs
@@ -3576,6 +3576,72 @@ fn next_current_state_revision(current: u64) -> Result<u64, LixError> {
 /// Stages the hot serving plane.  Serial normal commits mutate their current
 /// generation; every lifecycle discontinuity publishes a complete fresh
 /// generation before its branch control is made visible.
+/// Every schema key this transaction publishes on the global branch, or `None`
+/// when that set cannot be enumerated completely.
+///
+/// Serving-view tombstone compaction removes a branch tombstone only once
+/// nothing beneath it can resurface, and the global branch sits beneath every
+/// other branch. `HotStateStoreReader::has_schema_rows` answers that for what
+/// is already durable, but not for what this same transaction is about to
+/// publish — and `tracked_roots_parent_first` orders roots by
+/// `parent_commit_id` alone, never consulting `branch_id`, so the global root
+/// is not guaranteed to be staged before a non-global one and a write-set
+/// consultation would be racy. Deriving the set from the transaction's
+/// prepared inputs instead makes it order-independent.
+///
+/// **Polarity.** Every value this returns *restricts* compaction: `None`
+/// disables it outright, and each schema key disables it for that schema. An
+/// omission here is therefore unsound, not merely pessimistic — anything that
+/// can publish a global row has to be enumerated below or force the `None`.
+///
+/// The sources are exactly those that reach `HotStateWriter` for a root:
+/// prepared state rows, engine rows, a root's selected change batches, and the
+/// synthesized `lix_branch_ref` row. A global root carrying a lifecycle
+/// snapshot is not enumerated at all and forces `None`.
+fn global_branch_schema_keys(
+    state_rows: &PreparedStateBatch,
+    engine_rows: &[EngineCurrentRow],
+    tracked_roots: &[PendingTrackedRoot],
+    staged_commits: &BTreeMap<CommitId, StagedChangelogCommit>,
+    tracked_snapshots: &BTreeMap<CommitId, HotTrackedSnapshot>,
+) -> Option<BTreeSet<String>> {
+    let global_root_commits = tracked_roots
+        .iter()
+        .filter(|root| root.branch_id == crate::GLOBAL_BRANCH_ID)
+        .map(|root| root.commit_id)
+        .collect::<BTreeSet<_>>();
+    if global_root_commits
+        .iter()
+        .any(|commit_id| tracked_snapshots.contains_key(commit_id))
+    {
+        return None;
+    }
+    let mut schema_keys = BTreeSet::new();
+    if !global_root_commits.is_empty() {
+        // Each publishing root synthesizes its own branch-ref row.
+        schema_keys.insert(BRANCH_REF_SCHEMA_KEY.to_string());
+    }
+    for row in state_rows.iter() {
+        if row.branch_id.as_str() == crate::GLOBAL_BRANCH_ID {
+            schema_keys.insert(row.schema_key.to_string());
+        }
+    }
+    for row in engine_rows {
+        if row.branch_id == crate::GLOBAL_BRANCH_ID {
+            schema_keys.insert(row.change.schema_key.to_string());
+        }
+    }
+    for commit_id in &global_root_commits {
+        let Some(staged) = staged_commits.get(commit_id) else {
+            continue;
+        };
+        for change_ref in selected_changes(&staged.selected_change_batches) {
+            schema_keys.insert(change_ref.schema_key().to_string());
+        }
+    }
+    Some(schema_keys)
+}
+
 async fn stage_tracked_head(
     read: &(impl StorageAdapterRead + ?Sized),
     writes: &mut StorageWriteSet,
@@ -3631,6 +3697,8 @@ async fn stage_tracked_head(
     let mut controls = BTreeMap::new();
     let mut deferred_fresh_hot_plans = Vec::new();
     let mut exclusive_certified_columnar_publication = false;
+    let transaction_global_schema_keys =
+        global_branch_schema_keys(state_rows, engine_rows, tracked_roots, staged_commits, &tracked_snapshots);
 
     for root in tracked_roots_parent_first(tracked_roots)?
         .into_iter()
@@ -4286,6 +4354,9 @@ async fn stage_tracked_head(
         let has_validated_insert_deltas = staged.selected_change_batches.is_empty()
             && (!absence_guards.is_empty() || certified_fresh_plugin_file_id.is_some());
         let mut writer = tracked_head.writer(read, writes);
+        if let Some(schema_keys) = transaction_global_schema_keys.as_ref() {
+            writer = writer.with_transaction_global_schema_keys(schema_keys);
+        }
         let delete_generation = if exact_delete_candidate {
             writer
                 .try_stage_exact_collection_delete_current_base(


### PR DESCRIPTION
Serving-view tombstone compaction: a checkpoint now reclaims the tombstones it has just discharged.

## The term being removed

`ROW_SPACE` is a sparse serving overlay. A delete publishes a *tombstone* row there rather than removing the key, because the tombstone is what shadows a base row or a global-branch row. **Nothing ever removed one.** Measured (`hot_row_tombstone_probe`, phase 2): 999 tombstones from a 1000-row churn survive a checkpoint, a repository GC, a second checkpoint and a second GC. The serving layer carries an **O(deletes ever)** term where it should carry **O(live)**.

## Measured — the curve, not a point

`hot_row_tombstone_probe::checkpoint_compaction_scan_cost`, one live row at every size, deterministic (1 rep):

| n | entries after churn | entries after checkpoint | scan after churn | scan after checkpoint | compacted |
|---|---|---|---|---|---|
| 100 | 143 | **45** | 157 µs | 99 µs | 99 |
| 1 000 | 1 043 | **45** | 654 µs | 101 µs | 999 |
| 10 000 | 10 043 | **45** | 5 803 µs | 108 µs | 9 999 |

Row entries after the checkpoint are **flat at 45 across two orders of magnitude** while the pre-compaction count grows 70x, and the scan is flat at 99–108 µs while the un-compacted scan grows 37x. That is an asymptotic term removed, not a constant factor shaved. At n=1000 the point result is 1043 → 45 entries and 654 → 101 µs (6.5x).

## How

A checkpoint republishes the interval's dirty set with `reset_working_diff_baselines`, which is the one moment a tombstone's working-diff obligation is discharged. `hot_compaction_mask` runs there and marks what can go; `stage_hot_mutation_batch` already routes a `None` value range to a physical row delete, so removal adds **one disjunct to an existing branch** — no new staging function, no new space, no protocol bump.

Three conditions gate it, all conservative:

- **(a) the generation has no immutable base of any kind.** Packed current base, packed exclusive-schema base, sparse root base, certified entity batch — the four planes `has_schema_rows` composes besides `ROW_SPACE` itself. A checkpoint publishes no base of its own, so this is the ordinary state at a checkpoint. One key-only existence probe per plane per publication, not per identity.
- **(b) the global branch has no rows in the tombstone's schema.** Checked against what is durable (`has_schema_rows`, which is base-complete, so a global row whose authority is a base still counts) **and** against what this transaction publishes on global. Verdicts are cached per distinct schema key. Vacuous when the branch *is* global.
- **(c) the row is provably clean at removal.** `reset_working_diff_baselines` forces `(Clean, newly_dirty=false)` for every tracked delta, so this is free — and it is asserted rather than assumed: a compacted row that is not clean fails the publication.

**There is no fourth condition.** `DIFF_SPACE`, not `ROW_SPACE`, is the working diff's authority. The probe's `near_miss` arm measures that and keeps an inverted assertion so a change that reintroduces the dependency fails loudly.

## Three things in the brief that did not survive contact with the code

**1. Gate (b)'s transaction half, as approved, would have made compaction permanently inert.** The approved design paired the per-schema check with a transaction-wide bool, `tracked_roots.iter().any(|r| r.branch_id == GLOBAL_BRANCH_ID)`. But `checkpoint_stage_row` (`checkpoint.rs:56`) writes the `lix_checkpoint` row with `branch_id: GLOBAL_BRANCH_ID`, so **every checkpoint transaction carries a global tracked root** — and compaction only ever runs at a checkpoint. The bool is `true` every time it is read. This is exactly the failure the brief names ("a wholesale global-branch test blocks every checkpoint, and compaction is silently inert"), arriving through the mechanism proposed to avoid it.

The fix keeps the ordering guarantee and applies the brief's own rule to both halves: the transaction half is a **set of schema keys**, `global_branch_schema_keys`, derived from the transaction's prepared inputs (prepared state rows, engine rows, global roots' selected change batches, the synthesized branch-ref row) rather than from the write set. That is order-independent for the same reason the bool was — it never consults staging order — so it closes the `visit_tracked_root_parent_first` hole completely, while leaving `lix_checkpoint` from blocking an unrelated schema. A global root carrying a lifecycle snapshot is not enumerated and forces the disabling `None`.

**2. Gate (a) is four planes, not two.** The brief and phase 4's premise check `packed_bases` and `root_bases`. The serving view also composes `PACKED_CURRENT_EXCLUSIVE_SCHEMA_BASE_SPACE` and certified entity batches; `has_schema_rows` — the engine's own answer to "does this generation hold rows in this schema" — consults both. A tombstone shadowing either would have resurrected a row. Gate (a) probes all four.

**3. The prize fixture measures a case this change does not reclaim.** The 1043 → 44 premise was measured on *churn, then first-ever checkpoint*. A checkpoint republishes the interval's **dirty set**, and a delete only joins that set while a checkpoint interval is open. Measured on that exact fixture: the route runs and reports `routes=1 offered=2` — the deletes are simply not in the publication. With a baseline checkpoint before the churn (the steady state, and what the corrected fixtures use) the full win lands. **Deletes made before a repository's first checkpoint are a separate, larger problem this change does not claim.** This is stated in a comment on the test that found it.

## Engagement — counted inside the route, before any timing

`COMPACTED_TOMBSTONE_{ROUTES,OFFERED,CANDIDATES,COMPACTED}`, incremented inside `hot_compaction_mask` itself, gated `#[cfg(any(test, feature = "storage-benches"))]`, re-exported with `#[allow(unused_imports)]` (the counters are read only by `#[cfg(test)]` probes, so a features-on *library* build has no reader and only `clippy --all-targets` sees it — the omission that failed #1432's gate).

`ROUTES`/`OFFERED` sit above `CANDIDATES` deliberately: "the checkpoint offered no tombstone" and "the checkpoint never reached the mask" have identical readings at `CANDIDATES`, and that distinction is what found item 3 above.

## Tests

Non-`#[ignore]`d, both verdicts:

- `checkpoint_compacts_discharged_branch_tombstones` — the hit, end to end through SQL: 343 → 45 entries, 299 tombstones → 0, `candidates=299 compacted=299`, answers unchanged after a **cold reopen**, working diff still 0.
- `checkpoint_compaction_keeps_only_globally_shadowed_tombstones` — gate (b), both verdicts in one publication: a global-branch row and a branch tombstone in the same schema (tombstone survives) alongside a control in a schema global has no rows in (reclaimed). Deterministic, at the exact layer.
- `recreated_identity_inherits_created_at_after_engine_compaction` — the inverted h7 pin against **real** compaction rather than the simulated `drop_all_tombstones`: `assert_eq!` that a re-insert over a genuinely compacted identity inherits its original `created_at`, with `canonical_hits > 0` proving the canonical sourcing actually fired, plus a successful `rebuild_tracked_state_for_branch`. This is the failure mode with no other guard — a wrong timestamp is written silently and only surfaces on a later rebuild.
- `checkpoint_compaction_scan_cost` — the `#[ignore]`d measurement above. **Appended as PHASE 10**; phases 1–9 are untouched.

Counter assertions are thresholds scaled to the fixture, never exact values: `storage_bench` counters are process-global.

Phase 9's `recreated_identity_created_at_after_compaction` now finds nothing to remove, because real compaction beat its simulation to the tombstone. Its `removed > 0` assertion is replaced with `after.tombstones == 0` — the property it was actually protecting — with a comment saying why.

**The five global-shadow regression tests are unmodified and green.** `hot_state/visibility.rs` and `hot_state/context.rs`, where four of the five live, are not touched by this diff at all.

## Where the flag lives

`transaction_global_schema_keys` is a **field on `HotStateWriter`**, not a parameter threaded through the staging wrappers, because it is a property of the *transaction* rather than of a call. It is set through a builder (`with_transaction_global_schema_keys`) rather than the factory signature: **1 field + 1 default + 1 call site**, against ~11 sites for a factory-signature change, in the most contended function in the tree.

**Polarity.** `None` is the factory default and **disables** compaction. A construction site that cannot enumerate what its transaction stages on global is therefore safe by omission rather than by vigilance — the inversion that reads as obviously correct in review is not reachable here.

## Layout invariants

1. **Single authority** — no. Nothing gains a second authority; a derived view loses dead weight. Canonical tracked state is untouched, and `TrackedStateDiffEntry.after` keeps its raw tombstone (its doc-comment justifies that as what lets merge apply deletes without reloading the source root).
2. **Commit canonicality** — unaffected. No commit record, parent link or state root changes.
3. **Derived views are caches** — this is the point of the change: `ROW_SPACE` is a rebuildable serving view, and a tombstone that shadows nothing is cache weight. Undo/redo replay from canonical state, not from the serving row (phase 6 measures that).
4. **Atomic publication** — yes. The removals are staged into the checkpoint's own `StorageWriteSet`, so they publish in the same atomic write set as the checkpoint that discharged them. No reader can observe a half-compacted generation.
5. **GC from refs** — unaffected. No retention metadata added.
6. **SQL reads canonical records** — unaffected.

## Breaking status

- **Public API** — non-breaking. No change to `packages/lix/src/lib.rs` exports, the SQL surface, or the JS SDK surface.
- **Storage format / physical layout** — non-breaking. No new persisted field, no new space, no `REPOSITORY_PROTOCOL_VALUE` bump. Compaction removes keys an existing reader already treats as absent.
- **Storage adapter API** — non-breaking. Nothing added, changed or removed on the `StorageAdapter` trait; both shipping adapters and the conformance suite are untouched.

## Gate

Full CI scope, **re-derived from this sha's own `ci.yml`** (the `lix_e2e` feature list is extracted by the gate script itself, not carried forward — it gained `plugin-tests,server-protocol` in the integration, and a stale command would have silently skipped three targets). Run on `hetzner-cpx62-III`.

```
git rev-parse HEAD        7b42d673a02a50600960930478bae1be49222622
git status --porcelain    (empty)
CI_SCOPE_CONFIRMED_AT=7b42d673a02a50600960930478bae1be49222622
EXECUTED_TARGETS test1=3426 test2=172
```

```
E2E_FEATURES_FROM_CI_YML=sdk-tests,plugin-tests,server-protocol,storage-benches,slatedb,root-replay-trace

CLIPPY_EXIT=0      cargo clippy --profile test --workspace --all-targets --all-features -- -D warnings
NODEFAULT_EXIT=0   cargo check -p lix --no-default-features
WASM_EXIT=0        cargo check -p lix_js_sdk --target wasm32-unknown-unknown
TEST1_EXIT=0       cargo test --profile test --workspace --exclude lix_e2e --all-features --no-fail-fast
TEST2_EXIT=0       cargo test --profile test -p lix_e2e --features <from that sha> --no-fail-fast
CANARY_EXIT=0      slatedb_history_blob_survives_until_final_root_release, by name, 1 passed
```

**Counts accounted for.** Against the merged tree's reference (test1 3423 passed, test2 172 passed / 27 targets): test2 matches exactly; test1 is **+3**, which is exactly the three non-`#[ignore]`d tests this PR adds — all three confirmed `... ok` by name in the log. This diff adds no test *target*, only tests inside existing ones. `TARGET_COUNTS test1=38 test2=27`, of which 12 of test1's are doc-test targets.

**The newly reached surface passed, and was not vacuous:** `plugin_gc` → `ok. 2 passed`, `server_protocol_durable_idempotency` → `ok. 2 passed`. Non-zero on both, which is the point of checking.

`GATE_HEAD_BEFORE == GATE_HEAD_AFTER == 7b42d673a` — the worktree is shared across agents on that host, so the gate asserts its own HEAD on both sides of the run. Every log is truncated before the run, so a previous run's result cannot be read as this one's.

## Rebase onto the integration — verified by content

Rebased `be813172a` → **`ae6ef49d0`** (the `main` integration: plugin runtime boundary hard cut). `git` reported zero conflicts, which is not the evidence — this is:

- **My added/removed lines are byte-identical to the pre-rebase gated diff.** Diffed content lines of both patches: no difference.
- **The `main` side survived in my files**: `0` stale `crate::wasm::` / `crate::plugin_wire` / `crate::plugin_layout` references in either `transaction/commit.rs` or `hot_state/tracked_head/hot.rs`, with `8` and `14`+`15` references to the new `crate::plugin::runtime` / `crate::plugin::wire` paths respectively.
- **Every hunk containing a deletion was read end to end** — the four in-place edits (the `.enumerate()` on the values loop, the gate (c) check plus the `physically_deletes() || compacted_row` push, the writer factory, and the counter re-export). No function was spliced; the gate's compile is the independent confirmation.
- **The sealed-owner-boundary assertion in `code_structure.rs` is not triggered:** this diff introduces **no** `plugin::` import at all.
