### PR TITLE
perf(lix): pin the file id on the by-id content-update blob-ref probe (+ route census)

### DIFF
--- a/packages/e2e/examples/exppth2_txn_probe.rs
+++ b/packages/e2e/examples/exppth2_txn_probe.rs
@@ -36,15 +36,41 @@ async fn main() {
         return;
     }
 
-    let orders = [
-        ["by_id_per_stmt", "by_id_one_txn", "by_path_per_stmt"],
-        ["by_id_one_txn", "by_path_per_stmt", "by_id_per_stmt"],
-        ["by_path_per_stmt", "by_id_per_stmt", "by_id_one_txn"],
+    let all_arms = [
+        "by_id_per_stmt",
+        "by_id_one_txn",
+        "by_path_per_stmt",
+        "native_per_stmt",
     ];
+    // Only arms named here run, so a control can be re-measured without paying
+    // for every fixture again.
+    let selected = std::env::var("EXPPTH2_ARMS").unwrap_or_default();
+    let selected = if selected.is_empty() {
+        all_arms.to_vec()
+    } else {
+        selected
+            .split(',')
+            .map(str::trim)
+            .filter(|arm| !arm.is_empty())
+            .map(|arm| {
+                all_arms
+                    .into_iter()
+                    .find(|candidate| *candidate == arm)
+                    .unwrap_or_else(|| panic!("unknown arm {arm}"))
+            })
+            .collect::<Vec<_>>()
+    };
+    let orders = (0..selected.len().max(1))
+        .map(|offset| {
+            let mut rotated = selected.clone();
+            rotated.rotate_left(offset % selected.len().max(1));
+            rotated
+        })
+        .collect::<Vec<_>>();
 
     let mut samples: Vec<(String, f64)> = Vec::new();
     for rep in 0..reps {
-        for arm in orders[rep % orders.len()] {
+        for arm in orders[rep % orders.len()].iter().copied() {
             let ms = run_arm(arm, files, updates, payload).await;
             println!(
                 "EXPPTH2 files={files} rep={rep} arm={arm} total_ms={ms:.3} per_op_us={:.2}",
@@ -55,7 +81,7 @@ async fn main() {
     }
 
     println!();
-    for arm in ["by_id_per_stmt", "by_id_one_txn", "by_path_per_stmt"] {
+    for arm in selected.iter().copied() {
         let mut arm_samples: Vec<f64> = samples
             .iter()
             .filter(|(name, _)| name == arm)
@@ -164,6 +190,10 @@ entries_decoded={decoded} entries_matched={matched} decoded_per_update={:.1}",
     println!("EXPPTH2_PROFILE_DONE");
 }
 
+fn crate_blob(bytes: &[u8]) -> lix::Blob {
+    lix::Blob::from(bytes.to_vec())
+}
+
 async fn run_arm(arm: &str, files: usize, updates: usize, payload: usize) -> f64 {
     let root = tempfile::Builder::new()
         .prefix("expPTH2-")
@@ -250,6 +280,16 @@ async fn run_arm(arm: &str, files: usize, updates: usize, payload: usize) -> f64
                 )
                 .await
                 .expect("update by path");
+            }
+        }
+        "native_per_stmt" => {
+            for index in 0..updates {
+                lix.upsert_file_content(
+                    format!("/exppth2-{index:06}.bin"),
+                    crate_blob(&updated),
+                )
+                .await
+                .expect("native upsert");
             }
         }
         other => panic!("unknown arm {other}"),

--- a/packages/e2e/examples/exppth2_txn_probe.rs
+++ b/packages/e2e/examples/exppth2_txn_probe.rs
@@ -30,6 +30,12 @@ async fn main() {
     let reps: usize = args.get(3).and_then(|v| v.parse().ok()).unwrap_or(3);
     let payload: usize = args.get(4).and_then(|v| v.parse().ok()).unwrap_or(4096);
 
+    if let Ok(loops) = std::env::var("EXPPTH2_PROFILE_LOOPS") {
+        let loops: usize = loops.parse().unwrap_or(1);
+        run_profile(files, updates, payload, loops).await;
+        return;
+    }
+
     let orders = [
         ["by_id_per_stmt", "by_id_one_txn", "by_path_per_stmt"],
         ["by_id_one_txn", "by_path_per_stmt", "by_id_per_stmt"],
@@ -66,6 +72,96 @@ async fn main() {
                 .collect::<Vec<_>>()
         );
     }
+}
+
+/// Single-arm `by_id_per_stmt` driver with the fixture build gated OUT of the
+/// profiling window, and the update phase repeated so a short measured region
+/// still yields enough samples. Per-loop timings are printed so drift caused by
+/// the growing commit history can be ruled out rather than assumed away.
+async fn run_profile(files: usize, updates: usize, payload: usize, loops: usize) {
+    use std::io::Write as _;
+
+    let root = tempfile::Builder::new()
+        .prefix("expPTH2p-")
+        .tempdir()
+        .expect("create dir");
+    let storage = RocksDB::open(&root.path().join("db")).expect("open RocksDB");
+    let lix = open_lix()
+        .with_storage(storage.clone())
+        .await
+        .expect("open Lix");
+
+    let seed: Vec<u8> = vec![b'a'; payload];
+    let mut transaction = lix.begin_transaction().await.expect("begin seed");
+    for index in 0..files {
+        transaction
+            .execute(
+                "INSERT INTO lix_file (path, content) VALUES ($1, $2)",
+                &[
+                    Value::Text(format!("/exppth2-{index:06}.bin")),
+                    Value::Blob(seed.clone().into()),
+                ],
+            )
+            .await
+            .expect("seed insert");
+    }
+    transaction.commit().await.expect("commit seed");
+
+    let rows = lix
+        .execute("SELECT id FROM lix_file ORDER BY path", &[])
+        .await
+        .expect("read ids back");
+    let ids = rows
+        .rows()
+        .iter()
+        .map(|row| match rows.get(row, "id").expect("file id") {
+            Value::Text(text) => text.clone(),
+            other => panic!("unexpected id value {other:?}"),
+        })
+        .collect::<Vec<_>>();
+    assert!(ids.len() >= updates, "fixture must cover every update");
+
+    let gate = std::env::var("EXPPTH2_GATE").unwrap_or_default();
+    println!(
+        "EXPPTH2_READY pid={} files={files} updates={updates} loops={loops}",
+        std::process::id()
+    );
+    std::io::stdout().flush().ok();
+    if !gate.is_empty() {
+        while !std::path::Path::new(&gate).exists() {
+            std::thread::sleep(std::time::Duration::from_millis(20));
+        }
+    }
+
+    for loop_index in 0..loops {
+        let payload_byte = if loop_index % 2 == 0 { b'b' } else { b'c' };
+        let updated: Vec<u8> = vec![payload_byte; payload];
+        let started = Instant::now();
+        for id in ids.iter().take(updates) {
+            lix.execute(
+                "UPDATE lix_file SET content = $1 WHERE id = $2",
+                &[
+                    Value::Blob(updated.clone().into()),
+                    Value::Text(id.clone()),
+                ],
+            )
+            .await
+            .expect("update by id");
+        }
+        let ms = started.elapsed().as_secs_f64() * 1000.0;
+        let (calls, point_batch, file_prefix, fallback, decoded, matched) =
+            lix::storage_bench::take_hot_blob_ref_scan_accounting();
+        println!(
+            "EXPPTH2_LOOP files={files} loop={loop_index} total_ms={ms:.3} per_op_us={:.2} \
+blob_ref_calls={calls} point_batch={point_batch} file_prefix={file_prefix} fallback={fallback} \
+entries_decoded={decoded} entries_matched={matched} decoded_per_update={:.1}",
+            ms * 1000.0 / updates as f64,
+            decoded as f64 / updates as f64
+        );
+        std::io::stdout().flush().ok();
+    }
+    storage.flush().ok();
+    println!("EXPPTH2_PROFILE_DONE");
 }
 
 async fn run_arm(arm: &str, files: usize, updates: usize, payload: usize) -> f64 {

--- a/packages/lix/src/hot_state/tracked_head/hot.rs
+++ b/packages/lix/src/hot_state/tracked_head/hot.rs
@@ -11647,11 +11647,24 @@ async fn hot_scan_entries<'a>(
     // single MultiGet only when this schema has no file-backed members; if it
     // does, fall through to the complete primary-prefix route so UPDATE and
     // DELETE still see every candidate member.
+    #[cfg(feature = "storage-benches")]
+    let is_blob_ref_probe = filter.schema_keys.len() == 1
+        && filter.schema_keys[0] == "lix_binary_blob_ref"
+        && !filter.entity_pks.is_empty();
+    #[cfg(feature = "storage-benches")]
+    if is_blob_ref_probe {
+        crate::storage_bench::record_hot_blob_ref_scan_call();
+    }
+
     if let Some(identities) = hot_exact_identity_batches(branch_id, generation, filter) {
         let may_use_null_point_batch = !filter.file_ids.is_empty()
             || !hot_schema_has_file_members(store, branch_id, generation, &filter.schema_keys)
                 .await?;
         if may_use_null_point_batch {
+            #[cfg(feature = "storage-benches")]
+            if is_blob_ref_probe {
+                crate::storage_bench::record_hot_blob_ref_scan_point_batch();
+            }
             let entries = HotScanEntries::Finite(
                 hot_scan_finite_identity_batches(store, identities, limit).await?,
             );
@@ -11663,12 +11676,20 @@ async fn hot_scan_entries<'a>(
     // `WHERE file_id = $1` read one contiguous hydrated range without a second
     // value projection or random point-read hydration.
     if let Some(prefixes) = hot_file_scan_prefixes(branch_id, generation, filter) {
+        #[cfg(feature = "storage-benches")]
+        if is_blob_ref_probe {
+            crate::storage_bench::record_hot_blob_ref_scan_file_prefix();
+        }
         let entries = HotScanEntries::Decoded(
             scan_hot_file_entries(store, branch_id, generation, prefixes, filter, limit).await?,
         );
         return Ok(hot_scan_entries_fit_budget(entries, retained_byte_budget));
     }
 
+    #[cfg(feature = "storage-benches")]
+    if is_blob_ref_probe {
+        crate::storage_bench::record_hot_blob_ref_scan_fallback();
+    }
     let scope = hot_scope_prefix(branch_id, generation);
     let mut prefixes = hot_row_scan_prefixes(&scope, filter);
     prefixes.sort();
@@ -11706,6 +11727,12 @@ async fn hot_scan_entries<'a>(
             for entry in page {
                 let encoded_key_bytes = entry.key.0.len();
                 let identity = decode_hot_scan_row_key_in_scope(entry.key.0, &scope)?;
+                #[cfg(feature = "storage-benches")]
+                if is_blob_ref_probe {
+                    crate::storage_bench::record_hot_blob_ref_scan_entry(
+                        identity.matches_filter(filter),
+                    );
+                }
                 if identity.matches_filter(filter) {
                     saw_file_backed_row |= identity.file_id().is_some();
                     let value = full_value_bytes(entry.value)?;

--- a/packages/lix/src/sql2/providers/file.rs
+++ b/packages/lix/src/sql2/providers/file.rs
@@ -3290,6 +3290,22 @@ async fn execute_fast_lix_file_content_update_by_id_impl(
     let mut blob_request = lix_file_scan_request(Some(&active_branch_id), None, None);
     blob_request.filter.schema_keys = vec![BLOB_REF_SCHEMA_KEY.to_string()];
     blob_request.filter.entity_pks = vec![file_id_entity_pk(&file_id)?];
+    // Pin the file id too. The hot index key is file-first, so an entity PK on
+    // its own cannot form a point key: `hot_scan_entries` refuses the MultiGet
+    // route for any schema with file-backed members -- a null-file point key
+    // would miss the real row -- and `hot_file_scan_prefixes` requires a file
+    // id. Without this the request fell through to walking every
+    // `lix_binary_blob_ref` row in the branch and filtering in memory, which is
+    // O(files) *per statement* and cost ~0.20 us per file in the branch.
+    //
+    // The pin cannot reject the row it is looking for, because for this schema
+    // the file id and the entity PK are the same value by construction: both
+    // producers in `filesystem::planner` (`BlobRefRowInput::append_to` and
+    // `append_blob_ref_tombstone_row`, tombstones included) set the row's
+    // entity PK and its `file_id` from one variable, and `lix_binary_blob_ref`
+    // is a read-only public surface, so no caller can supply a divergent pair.
+    // The exact-batch route below already pairs them the same way.
+    blob_request.filter.file_ids = vec![crate::NullableKeyFilter::Value(file_id.clone())];
     let rows = ctx.scan_hot_state_batch(&blob_request).await?;
 
     let prepared = prepare_indexed_lix_file_rows(&indexed_matches, rows)?;

--- a/packages/lix/src/storage_bench.rs
+++ b/packages/lix/src/storage_bench.rs
@@ -3930,3 +3930,55 @@ mod tests {
         assert_eq!(after_first_layout, after_second_layout);
     }
 }
+
+static HOT_BLOB_REF_SCAN_CALLS: AtomicU64 = AtomicU64::new(0);
+static HOT_BLOB_REF_SCAN_POINT_BATCH: AtomicU64 = AtomicU64::new(0);
+static HOT_BLOB_REF_SCAN_FILE_PREFIX: AtomicU64 = AtomicU64::new(0);
+static HOT_BLOB_REF_SCAN_FALLBACK: AtomicU64 = AtomicU64::new(0);
+static HOT_BLOB_REF_SCAN_ENTRIES_DECODED: AtomicU64 = AtomicU64::new(0);
+static HOT_BLOB_REF_SCAN_ENTRIES_MATCHED: AtomicU64 = AtomicU64::new(0);
+
+pub(crate) fn record_hot_blob_ref_scan_call() {
+    HOT_BLOB_REF_SCAN_CALLS.fetch_add(1, Ordering::Relaxed);
+}
+
+pub(crate) fn record_hot_blob_ref_scan_point_batch() {
+    HOT_BLOB_REF_SCAN_POINT_BATCH.fetch_add(1, Ordering::Relaxed);
+}
+
+pub(crate) fn record_hot_blob_ref_scan_file_prefix() {
+    HOT_BLOB_REF_SCAN_FILE_PREFIX.fetch_add(1, Ordering::Relaxed);
+}
+
+pub(crate) fn record_hot_blob_ref_scan_fallback() {
+    HOT_BLOB_REF_SCAN_FALLBACK.fetch_add(1, Ordering::Relaxed);
+}
+
+pub(crate) fn record_hot_blob_ref_scan_entry(matched: bool) {
+    HOT_BLOB_REF_SCAN_ENTRIES_DECODED.fetch_add(1, Ordering::Relaxed);
+    if matched {
+        HOT_BLOB_REF_SCAN_ENTRIES_MATCHED.fetch_add(1, Ordering::Relaxed);
+    }
+}
+
+/// Accounting for the single-entity `lix_binary_blob_ref` probe every
+/// `lix_file` content update issues:
+/// `(calls, point_batch, file_prefix, fallback, entries_decoded, entries_matched)`.
+///
+/// Counted INSIDE `hot_scan_entries`, at the iterator loop that decodes each
+/// storage key — not at `scan_batch`'s return value. Those are different
+/// numbers: `hot_scan_entries` applies `identity.matches_filter` in memory
+/// before returning, so a count taken above it reports the surviving rows and
+/// cannot distinguish a seek from a full-prefix walk. The three route counters
+/// exist so that a zero is readable as "this arm did not run" rather than as
+/// "the counter never ran".
+pub fn take_hot_blob_ref_scan_accounting() -> (u64, u64, u64, u64, u64, u64) {
+    (
+        HOT_BLOB_REF_SCAN_CALLS.swap(0, Ordering::Relaxed),
+        HOT_BLOB_REF_SCAN_POINT_BATCH.swap(0, Ordering::Relaxed),
+        HOT_BLOB_REF_SCAN_FILE_PREFIX.swap(0, Ordering::Relaxed),
+        HOT_BLOB_REF_SCAN_FALLBACK.swap(0, Ordering::Relaxed),
+        HOT_BLOB_REF_SCAN_ENTRIES_DECODED.swap(0, Ordering::Relaxed),
+        HOT_BLOB_REF_SCAN_ENTRIES_MATCHED.swap(0, Ordering::Relaxed),
+    )
+}

--- a/packages/lix/src/transaction/context.rs
+++ b/packages/lix/src/transaction/context.rs
@@ -12945,6 +12945,266 @@ mod tests {
         );
     }
 
+    /// The by-id content update must reach its blob-ref row by a point read,
+    /// never by walking the branch's blob-ref collection.
+    ///
+    /// This asserts on counters taken INSIDE `hot_scan_entries`, at the loop
+    /// that decodes each storage key. The predecessor of this test counted
+    /// `scan_batch`'s return value instead, which is already post
+    /// `matches_filter` and therefore reads identically under a seek and under
+    /// a full-prefix walk -- it reported "already a seek" for what was a walk
+    /// over every file in the branch. `entries_decoded` is the number that can
+    /// tell those apart, and `calls` makes a zero readable as "this arm did not
+    /// run" rather than "the counter did not run".
+    #[cfg(feature = "storage-benches")]
+    #[tokio::test]
+    async fn content_update_blob_ref_probe_takes_the_point_route() {
+        async fn measure(files: usize, updates: usize) -> (u64, u64, u64, u64, u64) {
+            let storage = Memory::new();
+            Engine::initialize(storage.clone())
+                .await
+                .expect("storage should initialize");
+            let engine = Engine::new(storage)
+                .await
+                .expect("engine should open initialized storage");
+            let session = engine.open_session().await.expect("session should open");
+
+            let values = (0..files)
+                .map(|index| format!("('/seed-{index:05}.md', CAST('byte-01' AS BYTEA))"))
+                .collect::<Vec<_>>()
+                .join(", ");
+            session
+                .execute(
+                    &format!("INSERT INTO lix_file (path, content) VALUES {values}"),
+                    &[],
+                )
+                .await
+                .expect("fixture files should commit");
+
+            let rows = session
+                .execute("SELECT id FROM lix_file ORDER BY path", &[])
+                .await
+                .expect("file ids should read back");
+            let ids = rows
+                .rows()
+                .iter()
+                .map(|row| {
+                    row.get::<String>("id")
+                        .expect("file row should carry an id")
+                })
+                .collect::<Vec<_>>();
+            assert!(ids.len() >= updates, "fixture must cover every update");
+
+            let _ = crate::storage_bench::take_hot_blob_ref_scan_accounting();
+            for id in ids.iter().take(updates) {
+                session
+                    .execute(
+                        "UPDATE lix_file SET content = $1 WHERE id = $2",
+                        &[
+                            Value::Blob(b"byte-02".to_vec().into()),
+                            Value::Text(id.clone()),
+                        ],
+                    )
+                    .await
+                    .expect("content update should commit");
+            }
+            let (calls, point_batch, file_prefix, fallback, decoded, matched) =
+                crate::storage_bench::take_hot_blob_ref_scan_accounting();
+
+            // The update must actually have landed, or a cheap route would be
+            // cheap for the wrong reason.
+            for id in ids.iter().take(updates) {
+                let read = session
+                    .execute("SELECT content FROM lix_file WHERE id = $1", &[
+                        Value::Text(id.clone()),
+                    ])
+                    .await
+                    .expect("content should read back");
+                let row = read.rows().first().expect("updated file should be visible");
+                let content = read
+                    .get(row, "content")
+                    .expect("content column should be present");
+                assert!(
+                    matches!(content, Value::Blob(bytes) if bytes.as_ref() == b"byte-02"),
+                    "content update must be visible after the pinned probe"
+                );
+            }
+            let _ = crate::storage_bench::take_hot_blob_ref_scan_accounting();
+            let _ = (file_prefix, matched);
+            (calls, point_batch, fallback, decoded, matched)
+        }
+
+        let updates = 10;
+        let (small_calls, small_point, small_fallback, small_decoded, _) =
+            measure(50, updates).await;
+        let (large_calls, large_point, large_fallback, large_decoded, _) =
+            measure(500, updates).await;
+        println!(
+            "BLOBROUTE files=50 calls={small_calls} point={small_point} \
+fallback={small_fallback} decoded={small_decoded}"
+        );
+        println!(
+            "BLOBROUTE files=500 calls={large_calls} point={large_point} \
+fallback={large_fallback} decoded={large_decoded}"
+        );
+
+        // Connectivity: the probe really is issued, so the zeros below are
+        // readable as "that arm did not run".
+        assert!(
+            small_calls >= updates as u64 && large_calls >= updates as u64,
+            "every content update should issue a blob-ref probe: \
+             50 files {small_calls} calls, 500 files {large_calls} calls"
+        );
+
+        // The claim under test: the point route runs and the walk does not.
+        assert_eq!(small_fallback, 0, "50-file update must not walk the branch");
+        assert_eq!(large_fallback, 0, "500-file update must not walk the branch");
+        assert!(
+            small_point >= updates as u64 && large_point >= updates as u64,
+            "the point route must serve every probe"
+        );
+
+        // The number that distinguishes a seek from a walk, at both sizes. A
+        // 10x larger repository must not decode 10x more keys.
+        assert_eq!(
+            small_decoded, 0,
+            "a pinned probe decodes no scanned keys at 50 files"
+        );
+        assert_eq!(
+            large_decoded, 0,
+            "a pinned probe decodes no scanned keys at 500 files"
+        );
+    }
+
+    /// A blob-ref tombstone must not be mistaken for the live row, and must not
+    /// hide it.
+    ///
+    /// `append_blob_ref_tombstone_row` (reached here by deleting the file)
+    /// writes the tombstone with its `file_id` set from the same value as its
+    /// entity PK, so pinning the file id cannot change which rows are visible.
+    /// A filter that missed the live row would look like a large speedup rather
+    /// than a bug, so this is asserted rather than argued: the file is deleted,
+    /// recreated under the SAME id so a tombstone and a live blob ref share one
+    /// file id, and then updated through the pinned by-id route.
+    #[tokio::test]
+    async fn content_update_after_blob_ref_tombstone_still_resolves() {
+        const ID: &str = "01920000-0000-7000-8000-0000000004a1";
+        const OTHER: &str = "01920000-0000-7000-8000-0000000004a2";
+
+        let storage = Memory::new();
+        Engine::initialize(storage.clone())
+            .await
+            .expect("storage should initialize");
+        let engine = Engine::new(storage)
+            .await
+            .expect("engine should open initialized storage");
+        let session = engine.open_session().await.expect("session should open");
+
+        session
+            .execute(
+                &format!(
+                    "INSERT INTO lix_file (id, path, content) VALUES \
+                     ('{ID}', '/a.md', CAST('one' AS BYTEA)), \
+                     ('{OTHER}', '/b.md', CAST('keep' AS BYTEA))"
+                ),
+                &[],
+            )
+            .await
+            .expect("fixture should commit");
+
+        // Deleting the file tombstones its blob ref.
+        session
+            .execute(
+                &format!("DELETE FROM lix_file WHERE id = '{ID}'"),
+                &[],
+            )
+            .await
+            .expect("delete should commit");
+
+        // Recreate under the same id, so one file id now owns both a blob-ref
+        // tombstone and a live blob ref.
+        session
+            .execute(
+                &format!(
+                    "INSERT INTO lix_file (id, path, content) VALUES \
+                     ('{ID}', '/a.md', CAST('two' AS BYTEA))"
+                ),
+                &[],
+            )
+            .await
+            .expect("recreate should commit");
+
+        let affected = session
+            .execute(
+                "UPDATE lix_file SET content = $1 WHERE id = $2",
+                &[
+                    Value::Blob(b"three".to_vec().into()),
+                    Value::Text(ID.to_string()),
+                ],
+            )
+            .await
+            .expect("content rewrite should commit");
+        assert_eq!(
+            affected.rows_affected(),
+            1,
+            "the pinned probe must still resolve a file whose id also owns a tombstone"
+        );
+
+        let read = session
+            .execute(
+                "SELECT content FROM lix_file WHERE id = $1",
+                &[Value::Text(ID.to_string())],
+            )
+            .await
+            .expect("content should read back");
+        let row = read.rows().first().expect("file should be visible");
+        let content = read
+            .get(row, "content")
+            .expect("content column should be present");
+        assert!(
+            matches!(content, Value::Blob(bytes) if bytes.as_ref() == b"three"),
+            "a rewrite over a tombstoned blob ref must resolve through the pinned probe, got {content:?}"
+        );
+
+        // The untouched sibling must be unaffected by pinning another file id.
+        let other = session
+            .execute("SELECT content FROM lix_file WHERE path = '/b.md'", &[])
+            .await
+            .expect("sibling should read back");
+        let other_row = other.rows().first().expect("sibling should be visible");
+        let other_content = other
+            .get(other_row, "content")
+            .expect("sibling content should be present");
+        assert!(
+            matches!(other_content, Value::Blob(bytes) if bytes.as_ref() == b"keep"),
+            "pinning one file id must not disturb another file"
+        );
+
+        // A file that is only tombstoned must match nothing, not a stale row.
+        session
+            .execute(
+                &format!("DELETE FROM lix_file WHERE id = '{OTHER}'"),
+                &[],
+            )
+            .await
+            .expect("second delete should commit");
+        let missing = session
+            .execute(
+                "UPDATE lix_file SET content = $1 WHERE id = $2",
+                &[
+                    Value::Blob(b"nope".to_vec().into()),
+                    Value::Text(OTHER.to_string()),
+                ],
+            )
+            .await
+            .expect("update against a deleted file should not error");
+        assert_eq!(
+            missing.rows_affected(),
+            0,
+            "a deleted file must not be resurrected by the pinned probe"
+        );
+    }
+
     #[tokio::test]
     async fn staged_descriptor_batches_advance_transaction_path_index() {
         let storage = Memory::new();


### PR DESCRIPTION
## The by-id `lix_file` content-update linear term: located, and closed

**Rebased onto `7fece1d41` after #1439 merged as a squash.** The five original probe commits are
dropped (they are in trunk now); what remains is the route census, the probe's native arm, and
**#1443's fix, which was merged into this branch** rather than into trunk.

### The defect

`execute_fast_lix_file_content_update_by_id_impl` probed for its blob-ref row with an entity PK but
**no file id**. The hot index key is file-first, so neither seek route in `hot_scan_entries` could be
taken — the MultiGet route is refused for a schema with file-backed members (a null-file point key
would miss the real row), and `hot_file_scan_prefixes` requires a file id and rejects a non-empty
`entity_pks`. The request fell through to walking the `scope + schema_key` prefix, which holds **one
`lix_binary_blob_ref` row per file in the branch**, decoding and copying every key and filtering in
memory: **O(files) per statement**, immune to batching, invisible to a DataFusion plan.

The fix pins the file id the route already holds:

```rust
blob_request.filter.file_ids = vec![crate::NullableKeyFilter::Value(file_id.clone())];
```

### Why the pin cannot drop the row it looks for

Re-verified on the rebased tree, for the **storage** `file_id` the filter keys on — not merely the
snapshot pair. `#1440` touched neither `planner.rs` nor `read_only.rs`.

- Both production producers set the entity PK and `FilesystemRowContext.file_id` **from one
  variable**: `BlobRefRowInput::append_to` and `append_blob_ref_tombstone_row`, tombstones included.
- Every other `BLOB_REF_SCHEMA_KEY` construction site in the crate is inside a `mod tests`.
- `lix_binary_blob_ref` is a **read-only public surface**, so no caller can supply a divergent pair.
- The exact-batch route in this same file already pairs them the same way.

### Route proven changed before any timing

Counters taken **inside `hot_scan_entries`**, at the per-entry decode loop:

| files | | calls | point_batch | fallback | decoded **per update** |
|---|---|---|---|---|---|
| 200 | before | 200 | 0 | 200 | **200.0** |
| 200 | after | 400 | 400 | **0** | **0.0** |
| 8 000 | before | 200 | 0 | 200 | **8 000.0** |
| 8 000 | after | 400 | 400 | **0** | **0.0** |

`decoded per update` tracked the file count exactly; it is now zero. `calls` doubles because
`expanded_branch_ids` appends the global branch, so the pinned route issues one **O(1)** point read
per visibility scope where the walk previously short-circuited after the first — two point reads
replacing one full-branch walk.

**Verified by inversion:** with the fix reverted, the new test fails with `point=0 fallback=10
decoded=500` at 50 files and `decoded=5000` at 500 — the guard is real, not vacuous.

### The curve — µs per update, RocksDB, `ryzen-9950x-I`, 3 reps with arm rotation (1 at 20 000)

| files | `by_id_per_stmt` base | fixed | speedup |
|---|---|---|---|
| 200 | 326.26 | 278.73 | 1.17x |
| 2 000 | 726.43 | 298.17 | 2.44x |
| 8 000 | 1 949.16 | 314.22 | 6.20x |
| 20 000 | 4 336.35 | 319.79 | **13.6x** |

Slope **0.2025 → 0.00207 µs/file**. Two controls, neither able to execute the change:
`by_path_per_stmt` within **±1.8%**, `native_per_stmt` within **±2.5%** — both inside the band the
runbook says is not evidence. The fixed lane now **tracks the native API within ~9% at every size,
with the same slope**.

### Reported rather than explained away

**`by_id_one_txn` improves but does not go flat:** slope 0.2363 → 0.0197 µs/file — 12x flatter, but
~10x steeper than the per-statement lane, and at 20 000 files the batched arm is now **slower** than
the unbatched one (487.88 vs 319.79). Something else that scales with repository size remains in the
batched path. Not this defect, not addressed here.

**A sibling site with the same shape**, deliberately not fixed: the multi-file lane builds
`entity_pks` with no `file_ids` over `schema_keys = [lix_file_descriptor, lix_binary_blob_ref]`. A
single file-id pin would be **wrong** there because descriptor rows are not file-backed. `by_path`
still carries a 0.0277 µs/file slope, which is the natural place to look next.

### Why the earlier census reported a false null

Its predecessor counted `scan_batch`'s **return value** in `overlay_scan_batch`. `matches_filter` is
applied one layer below, inside `hot_scan_entries`, so that count is post-filter and reads
identically under a seek and under a full walk — the exact ambiguity it was built to resolve. It
reported `scanned=10 returned=10` for a walk over every file in the branch, and the true culprit was
retired for three cycles. **Count at the layer that does the work, not at the layer that returns the
answer.**

### Gate — `70b355180`, re-gated after the rebase

```
git rev-parse HEAD                    70b355180e55b8cffe9922b414fb7a029ad8c061  (before and after)
git status --porcelain                empty (before and after)
CI_SCOPE_CONFIRMED_AT                 7fece1d41bae40ae07726c7decb27ce4de20a316
EXECUTED_TARGETS                      test1=3430 targets=38   test2=172 targets=27   failed=0
```

clippy `-D warnings` 0, features-off 0, wasm 0. The `lix_e2e` feature list was **extracted by the
script from that sha's own `ci.yml`**, not typed: six features,
`sdk-tests,plugin-tests,server-protocol,storage-benches,slatedb,root-replay-trace`.

**Delta accounted for by name:** this branch adds exactly two test functions against trunk —
`content_update_blob_ref_probe_takes_the_point_route` and
`content_update_after_blob_ref_tombstone_still_resolves` — each confirmed `... ok` individually.
Trunk's 3 428 plus 2 is 3 430.

**Rebase verified by content:** the resulting tree is **byte-identical** to the previously gated
`7b8eb2f09` (`git diff` empty), and the census counters still sit inside `hot_scan_entries` at the
decode loop in the file #1440 rewrote.

**Stated deviation, now closed by CI:** the local gate ran with the measurement env's `RUSTFLAGS`
(`-C force-frame-pointers=yes -C target-feature=+sse4.2,+pclmulqdq`) still exported, which reproduces
CI's target features but replaces the config table, so mold linking was absent and two benign
`-Ctarget-feature` *command-line* warnings appeared on wasm-targeted crates. That made the local run
not a byte-exact CI reproduction. **GitHub CI has since run on this exact sha with its own flags and
all eight checks pass** — `Cargo Clippy`, `Cargo Test`, `Changelog`, `JS SDK Browser`/`Native Test`,
and `Cargo config` on Linux x64 / macOS arm64 / Windows x64 — so the caveat is resolved rather than
merely argued.

**Not merged by me — reporting to the coordinator.** (This PR was marked ready-for-review
upstream, so GitHub CI ran on it; it is `mergeable_state=clean`.)
