### PR TITLE
perf(lix): pin the file id on the by-id content-update blob-ref probe

### DIFF
--- a/packages/lix/src/sql2/providers/file.rs
+++ b/packages/lix/src/sql2/providers/file.rs
@@ -3290,6 +3290,22 @@ async fn execute_fast_lix_file_content_update_by_id_impl(
     let mut blob_request = lix_file_scan_request(Some(&active_branch_id), None, None);
     blob_request.filter.schema_keys = vec![BLOB_REF_SCHEMA_KEY.to_string()];
     blob_request.filter.entity_pks = vec![file_id_entity_pk(&file_id)?];
+    // Pin the file id too. The hot index key is file-first, so an entity PK on
+    // its own cannot form a point key: `hot_scan_entries` refuses the MultiGet
+    // route for any schema with file-backed members -- a null-file point key
+    // would miss the real row -- and `hot_file_scan_prefixes` requires a file
+    // id. Without this the request fell through to walking every
+    // `lix_binary_blob_ref` row in the branch and filtering in memory, which is
+    // O(files) *per statement* and cost ~0.20 us per file in the branch.
+    //
+    // The pin cannot reject the row it is looking for, because for this schema
+    // the file id and the entity PK are the same value by construction: both
+    // producers in `filesystem::planner` (`BlobRefRowInput::append_to` and
+    // `append_blob_ref_tombstone_row`, tombstones included) set the row's
+    // entity PK and its `file_id` from one variable, and `lix_binary_blob_ref`
+    // is a read-only public surface, so no caller can supply a divergent pair.
+    // The exact-batch route below already pairs them the same way.
+    blob_request.filter.file_ids = vec![crate::NullableKeyFilter::Value(file_id.clone())];
     let rows = ctx.scan_hot_state_batch(&blob_request).await?;
 
     let prepared = prepare_indexed_lix_file_rows(&indexed_matches, rows)?;

--- a/packages/lix/src/transaction/context.rs
+++ b/packages/lix/src/transaction/context.rs
@@ -12945,6 +12945,266 @@ mod tests {
         );
     }
 
+    /// The by-id content update must reach its blob-ref row by a point read,
+    /// never by walking the branch's blob-ref collection.
+    ///
+    /// This asserts on counters taken INSIDE `hot_scan_entries`, at the loop
+    /// that decodes each storage key. The predecessor of this test counted
+    /// `scan_batch`'s return value instead, which is already post
+    /// `matches_filter` and therefore reads identically under a seek and under
+    /// a full-prefix walk -- it reported "already a seek" for what was a walk
+    /// over every file in the branch. `entries_decoded` is the number that can
+    /// tell those apart, and `calls` makes a zero readable as "this arm did not
+    /// run" rather than "the counter did not run".
+    #[cfg(feature = "storage-benches")]
+    #[tokio::test]
+    async fn content_update_blob_ref_probe_takes_the_point_route() {
+        async fn measure(files: usize, updates: usize) -> (u64, u64, u64, u64, u64) {
+            let storage = Memory::new();
+            Engine::initialize(storage.clone())
+                .await
+                .expect("storage should initialize");
+            let engine = Engine::new(storage)
+                .await
+                .expect("engine should open initialized storage");
+            let session = engine.open_session().await.expect("session should open");
+
+            let values = (0..files)
+                .map(|index| format!("('/seed-{index:05}.md', CAST('byte-01' AS BYTEA))"))
+                .collect::<Vec<_>>()
+                .join(", ");
+            session
+                .execute(
+                    &format!("INSERT INTO lix_file (path, content) VALUES {values}"),
+                    &[],
+                )
+                .await
+                .expect("fixture files should commit");
+
+            let rows = session
+                .execute("SELECT id FROM lix_file ORDER BY path", &[])
+                .await
+                .expect("file ids should read back");
+            let ids = rows
+                .rows()
+                .iter()
+                .map(|row| {
+                    row.get::<String>("id")
+                        .expect("file row should carry an id")
+                })
+                .collect::<Vec<_>>();
+            assert!(ids.len() >= updates, "fixture must cover every update");
+
+            let _ = crate::storage_bench::take_hot_blob_ref_scan_accounting();
+            for id in ids.iter().take(updates) {
+                session
+                    .execute(
+                        "UPDATE lix_file SET content = $1 WHERE id = $2",
+                        &[
+                            Value::Blob(b"byte-02".to_vec().into()),
+                            Value::Text(id.clone()),
+                        ],
+                    )
+                    .await
+                    .expect("content update should commit");
+            }
+            let (calls, point_batch, file_prefix, fallback, decoded, matched) =
+                crate::storage_bench::take_hot_blob_ref_scan_accounting();
+
+            // The update must actually have landed, or a cheap route would be
+            // cheap for the wrong reason.
+            for id in ids.iter().take(updates) {
+                let read = session
+                    .execute("SELECT content FROM lix_file WHERE id = $1", &[
+                        Value::Text(id.clone()),
+                    ])
+                    .await
+                    .expect("content should read back");
+                let row = read.rows().first().expect("updated file should be visible");
+                let content = read
+                    .get(row, "content")
+                    .expect("content column should be present");
+                assert!(
+                    matches!(content, Value::Blob(bytes) if bytes.as_ref() == b"byte-02"),
+                    "content update must be visible after the pinned probe"
+                );
+            }
+            let _ = crate::storage_bench::take_hot_blob_ref_scan_accounting();
+            let _ = (file_prefix, matched);
+            (calls, point_batch, fallback, decoded, matched)
+        }
+
+        let updates = 10;
+        let (small_calls, small_point, small_fallback, small_decoded, _) =
+            measure(50, updates).await;
+        let (large_calls, large_point, large_fallback, large_decoded, _) =
+            measure(500, updates).await;
+        println!(
+            "BLOBROUTE files=50 calls={small_calls} point={small_point} \
+fallback={small_fallback} decoded={small_decoded}"
+        );
+        println!(
+            "BLOBROUTE files=500 calls={large_calls} point={large_point} \
+fallback={large_fallback} decoded={large_decoded}"
+        );
+
+        // Connectivity: the probe really is issued, so the zeros below are
+        // readable as "that arm did not run".
+        assert!(
+            small_calls >= updates as u64 && large_calls >= updates as u64,
+            "every content update should issue a blob-ref probe: \
+             50 files {small_calls} calls, 500 files {large_calls} calls"
+        );
+
+        // The claim under test: the point route runs and the walk does not.
+        assert_eq!(small_fallback, 0, "50-file update must not walk the branch");
+        assert_eq!(large_fallback, 0, "500-file update must not walk the branch");
+        assert!(
+            small_point >= updates as u64 && large_point >= updates as u64,
+            "the point route must serve every probe"
+        );
+
+        // The number that distinguishes a seek from a walk, at both sizes. A
+        // 10x larger repository must not decode 10x more keys.
+        assert_eq!(
+            small_decoded, 0,
+            "a pinned probe decodes no scanned keys at 50 files"
+        );
+        assert_eq!(
+            large_decoded, 0,
+            "a pinned probe decodes no scanned keys at 500 files"
+        );
+    }
+
+    /// A blob-ref tombstone must not be mistaken for the live row, and must not
+    /// hide it.
+    ///
+    /// `append_blob_ref_tombstone_row` (reached here by deleting the file)
+    /// writes the tombstone with its `file_id` set from the same value as its
+    /// entity PK, so pinning the file id cannot change which rows are visible.
+    /// A filter that missed the live row would look like a large speedup rather
+    /// than a bug, so this is asserted rather than argued: the file is deleted,
+    /// recreated under the SAME id so a tombstone and a live blob ref share one
+    /// file id, and then updated through the pinned by-id route.
+    #[tokio::test]
+    async fn content_update_after_blob_ref_tombstone_still_resolves() {
+        const ID: &str = "01920000-0000-7000-8000-0000000004a1";
+        const OTHER: &str = "01920000-0000-7000-8000-0000000004a2";
+
+        let storage = Memory::new();
+        Engine::initialize(storage.clone())
+            .await
+            .expect("storage should initialize");
+        let engine = Engine::new(storage)
+            .await
+            .expect("engine should open initialized storage");
+        let session = engine.open_session().await.expect("session should open");
+
+        session
+            .execute(
+                &format!(
+                    "INSERT INTO lix_file (id, path, content) VALUES \
+                     ('{ID}', '/a.md', CAST('one' AS BYTEA)), \
+                     ('{OTHER}', '/b.md', CAST('keep' AS BYTEA))"
+                ),
+                &[],
+            )
+            .await
+            .expect("fixture should commit");
+
+        // Deleting the file tombstones its blob ref.
+        session
+            .execute(
+                &format!("DELETE FROM lix_file WHERE id = '{ID}'"),
+                &[],
+            )
+            .await
+            .expect("delete should commit");
+
+        // Recreate under the same id, so one file id now owns both a blob-ref
+        // tombstone and a live blob ref.
+        session
+            .execute(
+                &format!(
+                    "INSERT INTO lix_file (id, path, content) VALUES \
+                     ('{ID}', '/a.md', CAST('two' AS BYTEA))"
+                ),
+                &[],
+            )
+            .await
+            .expect("recreate should commit");
+
+        let affected = session
+            .execute(
+                "UPDATE lix_file SET content = $1 WHERE id = $2",
+                &[
+                    Value::Blob(b"three".to_vec().into()),
+                    Value::Text(ID.to_string()),
+                ],
+            )
+            .await
+            .expect("content rewrite should commit");
+        assert_eq!(
+            affected.rows_affected(),
+            1,
+            "the pinned probe must still resolve a file whose id also owns a tombstone"
+        );
+
+        let read = session
+            .execute(
+                "SELECT content FROM lix_file WHERE id = $1",
+                &[Value::Text(ID.to_string())],
+            )
+            .await
+            .expect("content should read back");
+        let row = read.rows().first().expect("file should be visible");
+        let content = read
+            .get(row, "content")
+            .expect("content column should be present");
+        assert!(
+            matches!(content, Value::Blob(bytes) if bytes.as_ref() == b"three"),
+            "a rewrite over a tombstoned blob ref must resolve through the pinned probe, got {content:?}"
+        );
+
+        // The untouched sibling must be unaffected by pinning another file id.
+        let other = session
+            .execute("SELECT content FROM lix_file WHERE path = '/b.md'", &[])
+            .await
+            .expect("sibling should read back");
+        let other_row = other.rows().first().expect("sibling should be visible");
+        let other_content = other
+            .get(other_row, "content")
+            .expect("sibling content should be present");
+        assert!(
+            matches!(other_content, Value::Blob(bytes) if bytes.as_ref() == b"keep"),
+            "pinning one file id must not disturb another file"
+        );
+
+        // A file that is only tombstoned must match nothing, not a stale row.
+        session
+            .execute(
+                &format!("DELETE FROM lix_file WHERE id = '{OTHER}'"),
+                &[],
+            )
+            .await
+            .expect("second delete should commit");
+        let missing = session
+            .execute(
+                "UPDATE lix_file SET content = $1 WHERE id = $2",
+                &[
+                    Value::Blob(b"nope".to_vec().into()),
+                    Value::Text(OTHER.to_string()),
+                ],
+            )
+            .await
+            .expect("update against a deleted file should not error");
+        assert_eq!(
+            missing.rows_affected(),
+            0,
+            "a deleted file must not be resurrected by the pinned probe"
+        );
+    }
+
     #[tokio::test]
     async fn staged_descriptor_batches_advance_transaction_path_index() {
         let storage = Memory::new();


### PR DESCRIPTION
## Pin the file id on the by-id content-update blob-ref probe

**Stacked on #1441, which is stacked on #1439.** #1441 carries the route census this PR's test asserts
on; merge order is #1439 → #1441 → this.

One-line behaviour change in `execute_fast_lix_file_content_update_by_id_impl`:

```rust
blob_request.filter.file_ids = vec![crate::NullableKeyFilter::Value(file_id.clone())];
```

### What it fixes

The hot index key is **file-first**. The probe supplied an entity PK but no file id, so neither seek
route in `hot_scan_entries` could be taken — the MultiGet route is refused for a schema with
file-backed members (a null-file point key would miss the real row), and `hot_file_scan_prefixes`
requires a file id and rejects a non-empty `entity_pks`. The request fell through to walking the
`scope + schema_key` prefix, which holds **one `lix_binary_blob_ref` row per file in the branch**,
decoding and copying every key and filtering in memory. That is **O(files) per statement**, immune to
batching, and invisible to a DataFusion plan.

### Why the pin cannot drop the row it looks for

Re-verified on `0c9467d96` (the rebased tree), and for the **storage** `file_id` the filter keys
on, not merely the snapshot pair:

- Both production producers live in `filesystem::planner` and set the entity PK and
  `FilesystemRowContext.file_id` **from one variable**: `BlobRefRowInput::append_to` and
  `append_blob_ref_tombstone_row` (tombstones included).
- Every other `BLOB_REF_SCHEMA_KEY` construction site in the crate is inside a `mod tests`
  (`transaction/context.rs` tests start at 11883, `validation.rs` at 3576).
- `lix_binary_blob_ref` is a **read-only public surface** (`sql2/read_only.rs`), so no caller can
  supply a divergent pair.
- The exact-batch route in this same file already pairs them the same way —
  `entity_pk: file_id_entity_pk(file_id)?` next to `file_id: Some(file_id.clone())`.

### The route actually changed — counted before timing

Same driver, route counters taken **inside** `hot_scan_entries` at the per-entry decode loop:

| files | | calls | point_batch | fallback | entries_decoded | decoded **per update** |
|---|---|---|---|---|---|---|
| 200 | before | 200 | 0 | 200 | 40 000 | **200.0** |
| 200 | after | 400 | 400 | **0** | **0** | **0.0** |
| 8 000 | before | 200 | 0 | 200 | 1 600 000 | **8 000.0** |
| 8 000 | after | 400 | 400 | **0** | **0** | **0.0** |

`decoded per update` tracked the file count exactly; it is now zero. `calls` doubles because
`expanded_branch_ids` appends the global branch, so the pinned route issues one **O(1)** point read
per visibility scope where the walk previously short-circuited after the first scope — two point
reads replacing one full-branch walk.

### The curve — µs per update, RocksDB, `ryzen-9950x-I`, 3 reps with arm rotation (1 rep at 20 000)

**`by_id_per_stmt`** — the target lane:

| files | base | fixed | speedup |
|---|---|---|---|
| 200 | 326.26 | 278.73 | 1.17x |
| 2 000 | 726.43 | 298.17 | 2.44x |
| 8 000 | 1 949.16 | 314.22 | 6.20x |
| 20 000 | 4 336.35 | 319.79 | **13.6x** |

Slope **0.2025 → 0.00207 µs/file**, a 98x flattening. Raw per-rep ranges are disjoint at every size
above 200.

**Controls — neither lane can execute the change:**

| lane | 200 | 2 000 | 8 000 | 20 000 |
|---|---|---|---|---|
| `by_path_per_stmt` | +0.39% | +0.40% | −1.76% | −0.40% |
| `native_per_stmt` | +0.65% | −0.79% | +2.50% | −1.21% |

All inside the ±5% band the runbook says is not evidence. **The fixed by-id lane now tracks the
native API within ~9% at every size** (native: 256.3 / 276.3 / 282.2 / 295.6) with the same slope.

### Reported rather than explained away

**`by_id_one_txn` improves but does not go flat:** 133.31 → 98.32 (200 files) and 4 811.55 → 487.88
(20 000). Slope **0.2363 → 0.0197 µs/file** — 12x flatter, but ~10x steeper than the per-statement
lane, and at 20 000 files the batched arm is now **slower** than the unbatched one (487.88 vs 319.79).
Something else that scales with repository size remains in the batched path. It is not this defect and
is not addressed here.

**A sibling site with the same shape**, not fixed here because it is not a safe one-liner:
`sql2/providers/file.rs` builds `file_request.filter.entity_pks` for the multi-file lane with
`schema_keys = [lix_file_descriptor, lix_binary_blob_ref]` and no `file_ids`. A single file-id pin
would be wrong for the descriptor rows, which are not file-backed. `by_path` still carries a
0.0277 µs/file slope, which is the natural place to look next.

### Tests

- `content_update_blob_ref_probe_takes_the_point_route` — replaces the argument with counters at the
  decode loop: asserts `fallback == 0`, `point_batch >= updates`, and `entries_decoded == 0` at both
  50 and 500 files, plus a connectivity assertion on `calls` so the zeros read as "that arm did not
  run" rather than "the counter did not run", and a content read-back so a cheap route cannot be
  cheap for the wrong reason.
- `content_update_after_blob_ref_tombstone_still_resolves` — clears content (writing a blob-ref
  tombstone via `append_blob_ref_tombstone_row`), rewrites through the pinned route, and asserts both
  the rewrite and an untouched sibling.

### Gate — top of the rebased stack, `7b8eb2f09`

Rebased onto `0c9467d96`, so the top of the stack **is** the merged tree; a merge-only break is in
scope. All three branches' added/removed lines are byte-identical to their pre-rebase diffs.

```
git rev-parse HEAD                    7b8eb2f098d673baef52edb91c4623bca96fdc73  (before and after)
git status --porcelain                empty (before and after)
CI_SCOPE_CONFIRMED_AT                 0c9467d9685a5911cb2c50e89dfb2ff23b2ed4e7
EXECUTED_TARGETS                      test1=3430 targets=38  test2=172 targets=27  failed=0
```

clippy `-D warnings` 0, features-off 0, wasm 0. The `lix_e2e` feature list was **extracted from that
sha's own `ci.yml`** by the script, not typed: `sdk-tests,plugin-tests,server-protocol,storage-benches,slatedb,root-replay-trace` (6).

**The +4 on test1 against the 3426 reference, by name, each confirmed `... ok` individually:**
`content_updates_hit_the_path_index_cache_and_do_not_rebuild_it` and
`content_update_blob_ref_probe_scans_only_its_own_row` (#1439), plus this PR's
`content_update_blob_ref_probe_takes_the_point_route` and
`content_update_after_blob_ref_tombstone_still_resolves`.

**Stated deviation:** the gate ran with the measurement env's `RUSTFLAGS`
(`-C force-frame-pointers=yes -C target-feature=+sse4.2,+pclmulqdq`) still exported. That reproduces
CI's target features but replaces the config table, so mold linking is absent and two benign
`-Ctarget-feature` *command-line* warnings appear on wasm-targeted crates. Lints are source-driven and
`-D warnings` passed, so this cannot mask a lint or test failure — but it is not a byte-exact CI
reproduction, and I will rerun with clean flags on request.

**Draft. Do not merge.**
