### PR TITLE
test(gc): pin undo-to-last-checkpoint against reclaim at every commit

### DIFF
--- a/packages/lix/src/gc.rs
+++ b/packages/lix/src/gc.rs
@@ -3919,6 +3919,31 @@ mod tests {
     /// all about undo retention: a sweep that retires nothing trivially
     /// preserves undo. The assertions below are only evidence because the sweep
     /// underneath them is doing real work.
+    /// # This test is about undo, not history
+    ///
+    /// **Undo survives reclaim; entity history does not.** These are different
+    /// properties over different planes, and this test asserts only the first.
+    /// Do not read its name as "reclaim is safe for history".
+    ///
+    /// Undo reads current state, which the sweep leaves intact. `_history()`
+    /// reads each commit's *delta*, and the sweep deletes those. The commit
+    /// record survives -- `collect_ref_reachable_commit_ids` feeds
+    /// `graph_reachable` into `semantic_dependencies`, so
+    /// `stage_delete_commit_projection` retains it -- but the delta does not,
+    /// because `graph_reachable` never reaches `physical_dependencies`, so
+    /// `stage_retire_commit_physical_state` frees it. The loss is silent by
+    /// construction: `load_point_replay_commit_state` returning `None` makes a
+    /// commit whose manifest was retired indistinguishable from one that
+    /// changed nothing, so the walk emits zero rows and no error is possible.
+    ///
+    /// Measured on this engine -- checkpointed rounds, then one sweep, history
+    /// depth before -> after: 4 -> 3, 8 -> 3, 12 -> 3, with **zero** semantic
+    /// projections deleted in every case. The survivor count is a constant,
+    /// not a fraction, so the loss grows without bound as a repository ages.
+    ///
+    /// This is a known defect under repair at the time of writing; the
+    /// retention fix belongs to `physical_dependencies`, not here. When it
+    /// lands, a sibling test should pin history the way this one pins undo.
     #[tokio::test]
     async fn undo_to_last_checkpoint_survives_reclaim_after_every_commit() {
         let backend = Memory::new();

--- a/packages/lix/src/gc.rs
+++ b/packages/lix/src/gc.rs
@@ -3880,6 +3880,146 @@ mod tests {
             .expect("payload fixture schema should register");
     }
 
+
+    /// Undo-to-last-checkpoint must survive reclaim at any cadence.
+    ///
+    /// The retention floor for the undo interval is
+    /// `BranchHeadTrackedReachability::serving_checkpoint_commit_id`, read from
+    /// the *live* branch head control at sweep time -- see
+    /// `authenticated_control_commit_reachability`. It is not derived from the
+    /// reclaim schedule or from any stored sequence, so no cadence can move it.
+    ///
+    /// This test pins that property mechanically by running the full shipping
+    /// sweep after **every single commit**, which is strictly more aggressive
+    /// than any cadence the engine would ever schedule. If a future change ties
+    /// the undo floor to reclaim scheduling, this fails loudly.
+    ///
+    /// # Two things this fixture already paid for
+    ///
+    /// **1. The churn ordering is load-bearing.** `update -> checkpoint ->
+    /// sweep` retires commits; `checkpoint -> update -> sweep` retires
+    /// *nothing*, because the sweep then never observes a released interval.
+    /// Two earlier versions of this test used the second ordering and retired
+    /// zero across every iteration. If you reorder the churn loop below, expect
+    /// the `retired_total` guard to fire — that is the guard working, not a
+    /// broken fixture. Measured onset with the correct ordering, checkpointing
+    /// every revision: `tracked_roots` is 0, 1, 0, then 2 from revision 4 on.
+    ///
+    /// **2. `tracked_commit_roots` is the counter that observes retirement.**
+    /// The plausibly-named `plan.changelog.sweep.commits` reads **0 at every
+    /// iteration** on this fixture while `tracked_commit_roots` is non-zero, so
+    /// a guard written against it would fail forever against working code — and
+    /// would eventually be "fixed" by deleting the guard. Do not swap the
+    /// counter without re-running the measurement.
+    ///
+    /// # Keep the non-vacuity guard
+    ///
+    /// `retired_total > 0` is the most important line here. It failed two
+    /// fixtures that would otherwise have gone green while proving nothing at
+    /// all about undo retention: a sweep that retires nothing trivially
+    /// preserves undo. The assertions below are only evidence because the sweep
+    /// underneath them is doing real work.
+    #[tokio::test]
+    async fn undo_to_last_checkpoint_survives_reclaim_after_every_commit() {
+        let backend = Memory::new();
+        Engine::initialize(backend.clone())
+            .await
+            .expect("repository should initialize");
+        let engine = Engine::new(backend.clone())
+            .await
+            .expect("repository should open");
+        let session = engine.open_session().await.expect("session should open");
+        let schema = serde_json::json!({
+            "x-lix-key": "gc_undo_cadence_fixture",
+            "x-lix-primary-key": ["/path"],
+            "type": "object",
+            "required": ["path", "value"],
+            "properties": {
+                "path": { "type": "string" },
+                "value": { "type": "string" }
+            },
+            "additionalProperties": false
+        });
+        session
+            .execute(
+                "INSERT INTO lix_registered_schema (value, lixcol_global, lixcol_untracked) VALUES (lix_json($1), false, false)",
+                &[Value::Text(schema.to_string())],
+            )
+            .await
+            .expect("undo cadence fixture schema should register");
+        session
+            .execute(
+                "INSERT INTO gc_undo_cadence_fixture (path, value) VALUES ('/row', 'v0')",
+                &[],
+            )
+            .await
+            .expect("seed row should publish");
+
+        // Churn phase: `update -> checkpoint -> sweep`, the ordering that
+        // actually retires. See the note above before changing it.
+        const CHURN: usize = 8;
+        let mut retired_total = 0usize;
+        for revision in 1..=CHURN {
+            session
+                .execute(
+                    "UPDATE gc_undo_cadence_fixture SET value = $1 WHERE path = '/row'",
+                    &[Value::Text(format!("v{revision}"))],
+                )
+                .await
+                .expect("churn commit should publish");
+            session
+                .create_checkpoint()
+                .await
+                .expect("churn checkpoint should publish");
+            let plan = run_shipping_repository_gc(&backend).await;
+            retired_total += plan.sweep.tracked_commit_roots.len();
+        }
+
+        // Non-vacuity. Do not remove: a sweep that never retires anything would
+        // let every assertion below pass while proving nothing about retention.
+        assert!(
+            retired_total > 0,
+            "the fixture must actually retire commits, or the undo assertions below are vacuous"
+        );
+
+        // Undo phase: two commits past the last checkpoint, still sweeping
+        // after each, so the retained undo interval is exactly {v9, v10}.
+        for revision in (CHURN + 1)..=(CHURN + 2) {
+            session
+                .execute(
+                    "UPDATE gc_undo_cadence_fixture SET value = $1 WHERE path = '/row'",
+                    &[Value::Text(format!("v{revision}"))],
+                )
+                .await
+                .expect("post-checkpoint commit should publish");
+            run_shipping_repository_gc(&backend).await;
+        }
+
+        // Undo must walk back to the last checkpoint's state (v8). Undo *past*
+        // the last checkpoint is deliberately not asserted: checkpointing is
+        // permitted to retire the last-1 interval.
+        for expected in ["v9", "v8"] {
+            session
+                .undo()
+                .await
+                .expect("undo must survive reclaim at every commit");
+            let value = session
+                .execute(
+                    "SELECT value FROM gc_undo_cadence_fixture WHERE path = '/row'",
+                    &[],
+                )
+                .await
+                .expect("undone row should read")
+                .rows()[0]
+                .get::<String>("value")
+                .expect("undone row should have a value");
+            assert_eq!(
+                value, expected,
+                "undo landed on the wrong revision after reclaim"
+            );
+        }
+    }
+
     async fn run_shipping_repository_gc(backend: &Memory) -> super::RepositoryGcPlan {
         let storage = StorageAdapter::new(backend.clone());
         let read = SharedStorageAdapterRead::new(


### PR DESCRIPTION
Machine-checks the owner's stated correctness constraint for reclaim: **a user must still be able to undo a checkpoint.**

## What this asserts

`undo_to_last_checkpoint_survives_reclaim_after_every_commit` runs the **full shipping repository sweep after every single commit** — strictly more aggressive than any cadence the engine would ever schedule — and then asserts undo walks the entire retained interval back to the last checkpoint's state.

It passes because the property is safe *by construction*:

`authenticated_control_commit_reachability` (`gc.rs:55`) walks from the branch head back to `BranchHeadTrackedReachability::serving_checkpoint_commit_id` and retains every commit in between. **That floor is read from the live branch head control at sweep time** — not from the reclaim schedule, not from `CheckpointGcState`, not from any stored sequence. No cadence can move it. This test pins that, so a future change tying the undo floor to reclaim scheduling fails loudly instead of silently shortening undo.

Undo *past* the last checkpoint is deliberately not asserted: checkpointing is permitted to retire the last−1 interval, which is the agreed heuristic.

## This is about undo, not history — and that distinction is load-bearing

**Undo survives reclaim. Entity history does not.** The doc comment says so explicitly so nobody reads the test's name as the stronger guarantee.

The sweep retains each commit *record* (`collect_ref_reachable_commit_ids` feeds `graph_reachable` into `semantic_dependencies`) but frees each commit *delta*, which is what `_history()` actually reads, because `graph_reachable` never reaches `physical_dependencies`. The loss is silent by construction: `load_point_replay_commit_state` returning `None` makes a commit whose manifest was retired indistinguishable from one that changed nothing, so the walk emits zero rows and no error is possible.

Measured on this engine — checkpointed rounds, one sweep, history depth before → after:

| rounds | before | after sweep 1 | after sweep 2 | semantic projections deleted |
|---|---|---|---|---|
| 4 | 4 | 3 | 3 | 0 |
| 8 | 8 | 3 | 3 | 0 |
| 12 | 12 | 3 | 3 | 0 |

**The survivor count is a constant, not a fraction** — the loss is everything below a fixed horizon, so the absolute amount destroyed grows without bound as a repository ages. Zero semantic projections were deleted in every case: the retention worked exactly as designed on the plane it covers, and history died anyway.

That defect is **not** fixed here; it is being repaired separately and the fix belongs to `physical_dependencies`. This PR only makes sure the test does not overclaim.

### A near-miss worth recording

While investigating, I concluded `history_dependencies` was the mechanism protecting history and was ready to propose widening it, with `collect_ref_reachable_commit_ids`'s own doc comment as the argument. An inversion — removing it entirely — produced an *identical* failure, proving it inert on this path. **A fix that changes nothing and looks right is the most expensive kind**, and only running the code caught it. That is why the guard below exists in the form it does.

## The non-vacuity guard is the most important line in the diff

```rust
assert!(retired_total > 0, "the fixture must actually retire commits, or the undo assertions below are vacuous");
```

**A sweep that retires nothing trivially preserves undo.** Without this guard the test is not evidence — and this is not hypothetical: the guard **failed two earlier versions of this fixture**, both of which would have gone green while proving nothing. Please do not remove it to make a future fixture pass; that inverts its purpose. The two failures are also the inversion evidence — it fires when the lane is vacuous and passes when the sweep does real work.

## Two findings written into the doc comment, not just this PR

**1. The churn ordering is load-bearing.** `update → checkpoint → sweep` retires commits; `checkpoint → update → sweep` retires **nothing**. Both earlier fixtures used the second ordering. Measured onset with the correct ordering: `tracked_roots` = 0, 1, 0, then 2 from revision 4 onward.

**2. `tracked_commit_roots` is the counter that observes retirement.** The plausibly-named `plan.changelog.sweep.commits` reads **0 at every iteration** while `tracked_commit_roots` is non-zero. A guard written against it would fail forever against working code, and would eventually be "fixed" by deleting the guard.

## Scope

**Test and comments only.** No format change, no protocol bump, no behaviour change, no new persisted field.

A follow-up changing the reclaim trigger's magnitude (ratio keyed to live inventory rather than checkpoint count) is designed but **deliberately held**: it makes the sweep fire more responsively, which on the current sweep would advance the history horizon more often and strictly increase permanent loss. It will be rebased onto the retention fix and re-measured against the fixed sweep, since retaining deltas changes both the inventory denominator and the per-sweep cost the ratio is meant to amortise.

## Known residual, not addressed here

The shipping sweep is O(live commit-manifest count) via a **key-only** scan (`derive_retirement_candidates` → `scan_commit_state_manifest_commit_ids`, `StorageCoreProjection::KeyOnly`). A fair future target for an incremental index; not a claim this PR makes.

## Gate

Scope re-derived from `ci.yml` at the gated sha (`lix_e2e` feature list confirmed to include `plugin-tests,server-protocol`).

```
git rev-parse HEAD       c4729f941351b46262bfeb9f2d7a8932add7ce1b   (before AND after the build)
git status --porcelain   empty                                      (before AND after)
CI_SCOPE_CONFIRMED_AT=c4729f941351b46262bfeb9f2d7a8932add7ce1b

CLIPPY_EXIT=0  TEST1_EXIT=0  TEST2_EXIT=0  NODEFAULT_EXIT=0  WASM_EXIT=0

EXECUTED_TARGETS  test_result_lines=65  passed=3603  failed=0
```

The new test is confirmed present in the executed test log, so it ran rather than being silently filtered out.
