### PR TITLE
perf(lix): stop loading discarded blob-ref and directory context in lix_file_history

### DIFF
--- a/packages/lix/src/sql2/exec/datafusion.rs
+++ b/packages/lix/src/sql2/exec/datafusion.rs
@@ -6298,6 +6298,181 @@ mod tests {
         );
     }
 
+    /// Number of content commits on a file the depth-bounded query never asks
+    /// about.
+    const DEPTH_BOUNDED_CONTEXT_NOISE_COMMITS: u64 = 12;
+
+    /// Depth-bounded file history by path: engagement, then the answer.
+    ///
+    /// `HistoryRoute::anchors_only` drops the depth bounds by construction, so
+    /// a depth predicate is the **only** shape in which the event route and the
+    /// context route differ — and therefore the only shape that loads context
+    /// descriptors separately at all. Every other file-history test in this
+    /// suite compares the two routes equal and takes the reuse branch, so
+    /// without this test the separate context load is never executed and a
+    /// regression in it would gate green.
+    ///
+    /// The census is thread-local and counts inside
+    /// `load_file_history_filesystem_context` itself, one layer below the SQL
+    /// surface, and asserts a hit *and* a miss: the depth-bounded read must take
+    /// the separate load, the unbounded read must take the reuse branch.
+    ///
+    /// The oracle is the unfiltered read. A `lix_file_history` query with no
+    /// `id`/`path` predicate resolves no lookup IDs and never builds either
+    /// pinned route, so it is the answer a completely unpruned traversal
+    /// produces; the depth-bounded path answer must equal it restricted to the
+    /// same path and depth.
+    #[tokio::test]
+    async fn depth_bounded_file_history_by_path_matches_the_unfiltered_answer() {
+        let (session, _) = setup_engine_history_fixture()
+            .await
+            .expect("history fixture should initialize");
+
+        for statement in [
+            "INSERT INTO lix_file (id, path, content) \
+             VALUES ('01920000-0000-7000-8000-0000000000d1', '/docs/moved.md', CAST('m0' AS BYTEA))",
+            "UPDATE lix_file SET content = CAST('m1' AS BYTEA) WHERE path = '/docs/moved.md'",
+            // A rename: the descriptor changes without any content change, and
+            // it is the shape the context descriptors exist to resolve.
+            "UPDATE lix_file SET path = '/docs/moved-again.md' WHERE path = '/docs/moved.md'",
+            "UPDATE lix_file SET content = CAST('m2' AS BYTEA) WHERE path = '/docs/moved-again.md'",
+            "INSERT INTO lix_file (id, path, content) \
+             VALUES ('01920000-0000-7000-8000-0000000000d2', '/docs/noise2.md', CAST('n0' AS BYTEA))",
+        ] {
+            session
+                .execute(statement, &[])
+                .await
+                .unwrap_or_else(|error| panic!("fixture statement failed: {statement}: {error}"));
+        }
+        for revision in 0..DEPTH_BOUNDED_CONTEXT_NOISE_COMMITS {
+            session
+                .execute(
+                    &format!(
+                        "UPDATE lix_file SET content = CAST('n{revision}' AS BYTEA) \
+                         WHERE id = '01920000-0000-7000-8000-0000000000d2'"
+                    ),
+                    &[],
+                )
+                .await
+                .expect("noise commit should apply");
+        }
+
+        let head_commit_id = session
+            .execute("SELECT lix_active_branch_commit_id()", &[])
+            .await
+            .expect("active commit should resolve")
+            .rows()[0]
+            .values()[0]
+            .clone();
+        let Value::Text(head_commit_id) = head_commit_id else {
+            panic!("active branch commit id should be text");
+        };
+
+        let projection = format!(
+            "SELECT id, path, lixcol_depth, lixcol_observed_commit_id \
+             FROM lix_file_history('{head_commit_id}')"
+        );
+        let key = |row: &Vec<Value>| format!("{row:?}");
+        let unfiltered = rows_from_execute_result(
+            session
+                .execute(&projection, &[])
+                .await
+                .expect("unfiltered history should execute"),
+        )
+        .1;
+        assert!(
+            !unfiltered.is_empty(),
+            "the unfiltered oracle must produce rows"
+        );
+
+        // Miss: no depth predicate, so the routes compare equal and the context
+        // descriptors are reused from the event set.
+        crate::sql2::providers::reset_file_history_context_census();
+        let _ = session
+            .execute(
+                &format!("{projection} WHERE path = '/docs/moved-again.md'"),
+                &[],
+            )
+            .await
+            .expect("unbounded path history should execute");
+        let (loads, reuses) = crate::sql2::providers::file_history_context_census();
+        assert_eq!(
+            (loads, reuses),
+            (0, 1),
+            "a depth-unbounded path read must reuse the event descriptors"
+        );
+
+        // The depths this path actually has rows at, plus depth 0, which the
+        // noise commits made empty for it -- an empty answer that must stay
+        // empty is the negative case of the same comparison.
+        let mut probe_depths = unfiltered
+            .iter()
+            .filter(|row| row[1] == Value::Text("/docs/moved-again.md".to_string()))
+            .filter_map(|row| match row[2] {
+                Value::Integer(depth) => Some(depth),
+                _ => None,
+            })
+            .collect::<BTreeSet<_>>();
+        assert!(
+            probe_depths.len() >= 2,
+            "the fixture must put rows for this path at more than one depth, or \
+             the comparison is vacuous: {probe_depths:?}"
+        );
+        probe_depths.insert(0);
+
+        let mut covered_depths = 0_usize;
+        for depth in probe_depths {
+            let expected: BTreeSet<String> = unfiltered
+                .iter()
+                .filter(|row| {
+                    row[1] == Value::Text("/docs/moved-again.md".to_string())
+                        && row[2] == Value::Integer(depth)
+                })
+                .map(key)
+                .collect();
+
+            // Hit: the depth predicate makes the event route and the anchor
+            // route differ, which is the only shape that loads the context
+            // descriptors separately.
+            crate::sql2::providers::reset_file_history_context_census();
+            let actual: BTreeSet<String> = rows_from_execute_result(
+                session
+                    .execute(
+                        &format!(
+                            "{projection} WHERE path = '/docs/moved-again.md' \
+                             AND lixcol_depth = {depth}"
+                        ),
+                        &[],
+                    )
+                    .await
+                    .expect("depth-bounded path history should execute"),
+            )
+            .1
+            .iter()
+            .map(key)
+            .collect();
+            let (loads, reuses) = crate::sql2::providers::file_history_context_census();
+            assert_eq!(
+                (loads, reuses),
+                (1, 0),
+                "a depth-bounded path read must load the context descriptors separately"
+            );
+
+            assert_eq!(
+                expected, actual,
+                "the depth-bounded answer at depth {depth} must equal the \
+                 unfiltered oracle restricted to the same path and depth"
+            );
+            if !expected.is_empty() {
+                covered_depths += 1;
+            }
+        }
+        assert!(
+            covered_depths >= 2,
+            "the non-empty depths must have been compared, not skipped"
+        );
+    }
+
     #[tokio::test]
     async fn execute_sql_rejects_writes_to_history_views_before_planning() {
         for sql in [

--- a/packages/lix/src/sql2/providers/file_history.rs
+++ b/packages/lix/src/sql2/providers/file_history.rs
@@ -1086,31 +1086,80 @@ async fn load_file_history_filesystem_context<S>(
 where
     S: StorageAdapterRead + Clone + Send + Sync + 'static,
 {
-    let lookup_ids = lookup_ids.cloned();
-    let (event_entries, context_entries) =
-        load_file_history_entry_sets(event_route, context_route, move |route| {
-            let commit_graph = Arc::clone(&commit_graph);
-            let query_source = query_source.clone();
-            let lookup_ids = lookup_ids.clone();
-            async move {
-                load_file_history_filesystem_entries(
-                    commit_graph,
-                    query_source,
-                    &route,
-                    lookup_ids.as_ref(),
-                    metadata_projection,
-                )
-                .await
-            }
-        })
+    let event_entries = load_file_history_filesystem_entries(
+        Arc::clone(&commit_graph),
+        query_source.clone(),
+        event_route,
+        lookup_ids,
+        metadata_projection,
+    )
+    .await?;
+    let event_descriptors = parse_file_history_descriptors(&event_entries)?;
+    // The context set contributes descriptors and nothing else (see
+    // `FileHistoryFilesystemContext::descriptors`, whose only consumer is
+    // `file_history_events`' `context_descriptors`). Loading the blob-ref and
+    // directory projections over the anchor route as well materialized one
+    // change per reachable content commit and then dropped every one of them,
+    // and it widened the touched-scope digest's schema-family test from
+    // `lix_file_descriptor` alone to a family every content commit touches --
+    // so the anchor walk could not prune the commits it was about to discard.
+    let descriptors = if event_route == context_route {
+        event_descriptors.clone()
+    } else {
+        let context_entries = load_file_history_descriptor_entries(
+            commit_graph,
+            query_source,
+            context_route,
+            lookup_ids,
+            metadata_projection,
+        )
         .await?;
+        parse_file_history_descriptors(&context_entries)?
+    };
 
     Ok(FileHistoryFilesystemContext {
-        event_descriptors: parse_file_history_descriptors(&event_entries)?,
         event_directories: parse_file_history_directories(&event_entries)?,
         event_blobs: parse_file_history_blobs(&event_entries)?,
-        descriptors: parse_file_history_descriptors(&context_entries)?,
+        event_descriptors,
+        descriptors,
     })
+}
+
+/// Loads the descriptor-only projection a shaped file-history row needs for
+/// path context.
+///
+/// This is deliberately narrower than
+/// [`load_file_history_filesystem_entries`]: restricting the traversal to
+/// `lix_file_descriptor` is what lets `scope_digest_outcome`'s schema-family
+/// test prove a content-only commit absent, which it cannot do once
+/// `lix_binary_blob_ref` is in the same request.
+async fn load_file_history_descriptor_entries<S>(
+    commit_graph: Arc<Mutex<Box<dyn CommitGraphReader>>>,
+    query_source: SqlHistoryQuerySource<S>,
+    route: &HistoryRoute,
+    lookup_ids: Option<&FileHistoryLookupIds>,
+    metadata_projection: HistoryMetadataProjection,
+) -> Result<Vec<HistoryEntry>, LixError>
+where
+    S: StorageAdapterRead + Clone + Send + Sync + 'static,
+{
+    let route = match lookup_ids {
+        Some(lookup_ids) => file_history_descriptor_blob_route(route, lookup_ids)?,
+        None => route.clone(),
+    };
+    load_history_entries(
+        HistoryViewDescriptor {
+            view_name: "lix_file_history",
+            as_of_commit_column: HISTORY_COL_AS_OF_COMMIT_ID,
+        },
+        commit_graph,
+        query_source,
+        &route,
+        vec![FILE_DESCRIPTOR_SCHEMA_KEY.to_string()],
+        metadata_projection,
+        None,
+    )
+    .await
 }
 
 async fn load_file_history_observed_states<S>(

--- a/packages/lix/src/sql2/providers/file_history.rs
+++ b/packages/lix/src/sql2/providers/file_history.rs
@@ -1075,6 +1075,35 @@ where
     Ok(Some(FileHistoryLookupIds(file_ids)))
 }
 
+// Engagement counters for the descriptor-only context load.
+//
+// Thread-local, not process-global: `cargo test` runs many tests concurrently
+// in one binary and a global counter reports every other test's history reads
+// too, which makes an exact assertion pass in isolation and fail in a full run.
+// `#[tokio::test]` drives its future on the calling thread, so a test observes
+// exactly its own loads. The same reasoning is written out at
+// `filesystem::path_index`'s rebuild counters.
+#[cfg(test)]
+thread_local! {
+    static CONTEXT_DESCRIPTOR_LOADS: std::cell::Cell<usize> = const { std::cell::Cell::new(0) };
+    static CONTEXT_DESCRIPTOR_REUSES: std::cell::Cell<usize> = const { std::cell::Cell::new(0) };
+}
+
+#[cfg(test)]
+pub(crate) fn reset_file_history_context_census() {
+    CONTEXT_DESCRIPTOR_LOADS.with(|loads| loads.set(0));
+    CONTEXT_DESCRIPTOR_REUSES.with(|reuses| reuses.set(0));
+}
+
+/// `(separate descriptor-only anchor loads, reuses of the event descriptors)`.
+#[cfg(test)]
+pub(crate) fn file_history_context_census() -> (usize, usize) {
+    (
+        CONTEXT_DESCRIPTOR_LOADS.with(std::cell::Cell::get),
+        CONTEXT_DESCRIPTOR_REUSES.with(std::cell::Cell::get),
+    )
+}
+
 async fn load_file_history_filesystem_context<S>(
     commit_graph: Arc<Mutex<Box<dyn CommitGraphReader>>>,
     query_source: SqlHistoryQuerySource<S>,
@@ -1104,8 +1133,12 @@ where
     // `lix_file_descriptor` alone to a family every content commit touches --
     // so the anchor walk could not prune the commits it was about to discard.
     let descriptors = if event_route == context_route {
+        #[cfg(test)]
+        CONTEXT_DESCRIPTOR_REUSES.with(|reuses| reuses.set(reuses.get() + 1));
         event_descriptors.clone()
     } else {
+        #[cfg(test)]
+        CONTEXT_DESCRIPTOR_LOADS.with(|loads| loads.set(loads.get() + 1));
         let context_entries = load_file_history_descriptor_entries(
             commit_graph,
             query_source,

--- a/packages/lix/src/sql2/providers/mod.rs
+++ b/packages/lix/src/sql2/providers/mod.rs
@@ -1191,3 +1191,6 @@ mod tests {
         }
     }
 }
+
+#[cfg(test)]
+pub(crate) use file_history::{file_history_context_census, reset_file_history_context_census};


### PR DESCRIPTION
## What this is

I was sent to verify and fix a claim that `lix_file_history(...) WHERE path = ?` pays a
second full history traversal to resolve the path, with a `serde_json` decode per
descriptor. **The claim is partly right and its stated mechanism is wrong.** What the
measurement turned up instead is a larger, adjacent defect in the same function, which is
what this PR fixes.

## The verification (established, on `0b97f3c45`)

`resolve_file_history_path_lookup_ids` does run a second history read before the main
walk, over `route.anchors_only()` — which drops `min_depth`/`max_depth` by construction, so
it is genuinely unbounded. It does `serde_json::from_str` every returned descriptor
snapshot.

But two of the brief's premises do not survive the code:

* **The resolution walk is *not* un-pruned.** `scope_digest_outcome`'s schema-family test
  applies to it with `member_schema_keys = [lix_file_descriptor]` — the *sharpest* family
  prune available, since content-only commits touch no descriptor.
* **The JSON decode is not the cost.** Frame-pointer profile,
  `history_files_at_fixed_commits` at 5 000 files: `serde_json::from_str::<FileDescriptorSnapshot>`
  is ~14% of the resolution's samples. The rest is the commit-delta member load plus
  `materialize_located_history_change`'s per-change JSON slot reads.

Measured cost of path resolution, as `by_path − by_id` (a `WHERE id = ?` read resolves its
lookup IDs from the predicate and never calls the resolver, so the gap is exactly this work):

| axis | resolution cost | share of `by_path` |
|---|---|---|
| 50 files / 21 commits | 0.26 ms | 9.4% |
| 500 files / 21 commits | 0.65 ms | 16.4% |
| 5 000 files / 21 commits | 6.57 ms | 38.3% |
| 200 files / 20 commits | 0.33 ms | 10.3% |
| 200 files / 200 commits | 0.52 ms | 11.2% |
| 200 files / 2 000 commits | 2.55 ms | 14.3% |

So it is linear in file count (500 → 5 000 files: 10× files, 10.1× cost) and a modest
share on the depth axis. Real, but a constant-factor target, and **this PR does not
change it** — see "Not fixed here".

## What this PR fixes

While decomposing that, the depth-bounded lane turned out to be the outlier: at 2 000
commits, `WHERE path = ? AND lixcol_depth = 0` — **one row** — cost **21.5 ms**, more than
the same query with no depth bound at all (17.9 ms), against a 5.0 ms null-control floor.

`load_file_history_filesystem_context` loads the descriptor + blob-ref + directory
projection over **both** the event route and the anchor route. The context set contributes
exactly one field, `FileHistoryFilesystemContext::descriptors`, whose only consumer is
`file_history_events`' `context_descriptors`. **Every blob-ref and directory change the
anchor walk returned was materialized — one JSON slot load each — and then dropped.**

Because the anchor route has no depth bound, the discarded work was unbounded in history
depth. It also defeated the digest: with `lix_binary_blob_ref` in the request, the
schema-family test can never prove a content commit absent, so the walk loaded the very
commit deltas it was about to throw away.

The context load now requests `lix_file_descriptor` only. When the two routes compare
equal — every depth-unbounded query — the descriptors are reused from the event set exactly
as before, so **only depth-bounded reads change route**.

## Measurement

`ryzen-9950x-III`, rocksdb, `history_scaling_probe`, both arms prebuilt, 3 interleaved reps
with arm-order rotation, 5 samples per lane. Fixture: files seeded in one statement, then
N content-only commits on a file the query never asks about; no explicit checkpoints.

```
by_path_depth0   200 files / 2000 commits   base p50 21.384 21.571 21.843 ms
                                            cand p50 10.486 10.777 10.645 ms   -50.6%  disjoint
by_path_depth0   200 files /  200 commits   base p50  3.432  3.464  3.565 ms
                                            cand p50  2.070  2.102  2.136 ms   -39.3%  disjoint
null_control_kv  200 files / 2000 commits   base p50  5.010  5.066  5.190 ms
                                            cand p50  4.983  5.171  5.092 ms   overlapping
by_id            200 files / 2000 commits   base p50 15.429 15.591 15.834 ms
                                            cand p50 15.531 15.753 15.626 ms   overlapping
by_path 5000 files / 21 commits             base p50 17.549 16.965 16.857 ms
                                            cand p50 17.526 17.204 17.594 ms   overlapping
```

The overlapping lanes are the expected result, not a disappointment: those routes compare
equal and take the reuse branch. The null control confirms the harness floor did not move.

## Engagement

Every pre-existing file-history test compares the two routes equal, so **the separate
context load was never executed by the suite** — a regression in it would have gated green.
The second commit adds the only shape that can execute it (a depth predicate) and asserts
a **hit and a miss** against a thread-local census incremented inside
`load_file_history_filesystem_context` itself: a depth-bounded read must take the separate
load `(1, 0)`, a depth-unbounded read must take the reuse branch `(0, 1)`. The answer is
checked against the unfiltered read — which resolves no lookup IDs and builds neither
pinned route — at every depth the path has rows at, and at depth 0 where it must stay
empty.

The census is thread-local, not process-global, for the reason written out at
`filesystem::path_index`'s rebuild counters: this binary runs tests concurrently and a
global counter reports every other test's history reads.

## Not fixed here

The path-resolution term above is untouched. Its shape is a genuine `O(files)` cost, and
the levers I could see are constant-factor: the resolver materializes `metadata` it never
reads, and decodes every snapshot rather than only the name-matching candidates. Together
those are maybe a quarter of the term. I did **not** find a structural fix: a superset is
all the resolver owes (the residual predicate decides every row), but the correct superset
is "every file that ever carried this basename", and neither the current-state
`filesystem::path_index` (which cannot see renamed-away files) nor a name-scoped digest
token (which would not prune the seed commit that holds every descriptor) produces it.

## Format

No format change, no persisted field, no write-path or encoding symbol touched.
`REPOSITORY_PROTOCOL_VALUE` unchanged.

## Gate

Re-derived from `0b97f3c45`'s own `ci.yml`. Note it has **no** `--no-default-features` or
`wasm32-unknown-unknown` cargo step; the runbook's copy is stale on that point.

```
git rev-parse HEAD          e481a87103654a9caca1d97178e5adeee18c9b9b (before and after)
git status --porcelain      empty
CI_SCOPE_CONFIRMED_AT       0b97f3c45
cargo clippy --profile test --workspace --all-targets --all-features -- -D warnings   exit 0
cargo test --profile test --workspace --exclude lix_e2e --all-features --no-fail-fast exit 0
cargo test --profile test -p lix_e2e --features \
  sdk-tests,plugin-tests,server-protocol,storage-benches,slatedb,root-replay-trace \
  --no-fail-fast                                                                      exit 0

EXECUTED_TARGETS  test1=3431 passed across 38 targets   test2=172 passed across 27 targets
```

3431 vs 3430 on the base tree: the one added test.
