### PR TITLE
refactor(tracked-state): make the current-state part locator a real enum

### DIFF
--- a/packages/lix/src/gc.rs
+++ b/packages/lix/src/gc.rs
@@ -921,21 +921,22 @@ where
         for part in reachable.parts {
             let descriptor =
                 crate::tracked_state::current_state_descriptor_from_scoped_range_part(&part)?;
-            match descriptor.source_kind {
-                0 | 2 => {
+            match descriptor.source {
+                crate::tracked_state::CurrentStatePartSource::Replacement(source) => {
                     physical_authorities.insert(CommitId::new(uuid::Uuid::from_bytes(
-                        descriptor.owner_commit_id,
+                        source.owner_commit_id,
                     )));
                 }
-                1 => {
-                    native_parts.insert(descriptor.content_digest);
-                    native_part_refs_digests.insert(descriptor.payload_refs_digest);
+                crate::tracked_state::CurrentStatePartSource::ColumnarPage(source) => {
+                    physical_authorities.insert(CommitId::new(uuid::Uuid::from_bytes(
+                        source.owner_commit_id,
+                    )));
                 }
-                _ => {
-                    return Err(LixError::new(
-                        LixError::CODE_INTERNAL_ERROR,
-                        "active current-state scoped range has an unknown source kind",
-                    ));
+                crate::tracked_state::CurrentStatePartSource::NativeDataPart {
+                    payload_refs_digest,
+                } => {
+                    native_parts.insert(descriptor.content_digest);
+                    native_part_refs_digests.insert(payload_refs_digest);
                 }
             }
         }
@@ -1789,9 +1790,9 @@ where
     for part in reachable.parts {
         let descriptor =
             crate::tracked_state::current_state_descriptor_from_scoped_range_part(&part)?;
-        match descriptor.source_kind {
-            0 => {
-                let owner = CommitId::new(uuid::Uuid::from_bytes(descriptor.owner_commit_id));
+        match descriptor.source {
+            crate::tracked_state::CurrentStatePartSource::Replacement(source) => {
+                let owner = CommitId::new(uuid::Uuid::from_bytes(source.owner_commit_id));
                 if !packed.commits.contains_key(&owner) {
                     return Err(LixError::new(
                         LixError::CODE_INTERNAL_ERROR,
@@ -1802,11 +1803,13 @@ where
                 }
                 retained_authority_commits.insert(owner);
             }
-            1 => {
+            crate::tracked_state::CurrentStatePartSource::NativeDataPart {
+                payload_refs_digest,
+            } => {
                 live_current_state_data_parts.insert(descriptor.content_digest);
                 if let Some(previous) = live_current_state_ref_summaries
-                    .insert(descriptor.content_digest, descriptor.payload_refs_digest)
-                    && previous != descriptor.payload_refs_digest
+                    .insert(descriptor.content_digest, payload_refs_digest)
+                    && previous != payload_refs_digest
                 {
                     return Err(LixError::new(
                         LixError::CODE_INTERNAL_ERROR,
@@ -1814,26 +1817,16 @@ where
                     ));
                 }
             }
-            2 => {
-                let owner = CommitId::new(uuid::Uuid::from_bytes(descriptor.owner_commit_id));
+            crate::tracked_state::CurrentStatePartSource::ColumnarPage(source) => {
+                let owner = CommitId::new(uuid::Uuid::from_bytes(source.owner_commit_id));
                 if !packed.commits.contains_key(&owner) {
                     return Err(LixError::new(
                         LixError::CODE_INTERNAL_ERROR,
                         format!("live scoped range references missing columnar owner '{owner}'"),
                     ));
                 }
-                live_columnar_sources.insert((
-                    owner,
-                    descriptor.source_id,
-                    descriptor.content_digest,
-                ));
+                live_columnar_sources.insert((owner, source.source_id, descriptor.content_digest));
                 retained_authority_commits.insert(owner);
-            }
-            _ => {
-                return Err(LixError::new(
-                    LixError::CODE_INTERNAL_ERROR,
-                    "live scoped range contains an unknown part source",
-                ));
             }
         }
     }
@@ -3072,17 +3065,17 @@ mod tests {
             first_key: encoded_key.clone(),
             last_key: encoded_key,
             content_digest: owner_inventory.replacement_part_digests[0],
-            payload_refs_digest: [0; 32],
-            source_kind: 0,
-            source_id: [0; 16],
-            owner_commit_id: *owner.commit_id.as_uuid().as_bytes(),
-            part_index: 0,
-            source_page_index: 0,
+            source: crate::tracked_state::CurrentStatePartSource::Replacement(
+                crate::tracked_state::ReplacementPartSource {
+                    owner_commit_id: *owner.commit_id.as_uuid().as_bytes(),
+                    part_index: 0,
+                    uniform_created_at: timestamp,
+                    uniform_updated_at: timestamp,
+                },
+            ),
             source_row_offset: 0,
             row_count: 1,
             fragmented: false,
-            uniform_created_at: timestamp,
-            uniform_updated_at: timestamp,
         };
         let part = crate::tracked_state::current_state_envelope::scoped_range_part_from_current_state_descriptor(
             &scope,
@@ -3217,17 +3210,12 @@ mod tests {
             first_key: encoded.first_key.clone(),
             last_key: encoded.last_key.clone(),
             content_digest: encoded.digest,
-            payload_refs_digest: encoded.refs_digest,
-            source_kind: 1,
-            source_id: [0; 16],
-            owner_commit_id: [0; 16],
-            part_index: 0,
-            source_page_index: 0,
+            source: crate::tracked_state::CurrentStatePartSource::NativeDataPart {
+                payload_refs_digest: encoded.refs_digest,
+            },
             source_row_offset: 0,
             row_count: encoded.row_count,
             fragmented: false,
-            uniform_created_at: LixTimestamp::from_unix_millis_utc_lossy(0),
-            uniform_updated_at: LixTimestamp::from_unix_millis_utc_lossy(0),
         };
         let part = crate::tracked_state::current_state_envelope::scoped_range_part_from_current_state_descriptor(
             &scope,
@@ -3491,8 +3479,6 @@ mod tests {
                 changed_key_count: 0,
                 row_count_estimate: 0,
                 tree_height: 1,
-                primary_chunk_count: 1,
-                primary_chunk_bytes: root_bytes.len() as u64,
             })),
         };
         let control = BranchHeadControl {
@@ -3598,8 +3584,6 @@ mod tests {
             changed_key_count: 1,
             row_count_estimate: 1,
             tree_height: 1,
-            primary_chunk_count: 1,
-            primary_chunk_bytes: owner_bytes.len() as u64,
         };
         let active_root = TrackedStateCommitRoot {
             commit_id: active,
@@ -3611,8 +3595,6 @@ mod tests {
             changed_key_count: 1,
             row_count_estimate: 1,
             tree_height: 1,
-            primary_chunk_count: 1,
-            primary_chunk_bytes: active_bytes.len() as u64,
         };
         let manifest = |commit_id, snapshot_root| CommitStateManifest {
             commit_id,
@@ -6306,7 +6288,7 @@ mod tests {
     }
 
     fn test_snapshot_root(commit_id: CommitId) -> TrackedStateCommitRoot {
-        let (root_hash, root_bytes) = test_snapshot_chunk(commit_id);
+        let (root_hash, _root_bytes) = test_snapshot_chunk(commit_id);
         TrackedStateCommitRoot {
             commit_id,
             root_id: TrackedStateRootId::new(root_hash),
@@ -6314,8 +6296,6 @@ mod tests {
             changed_key_count: 1,
             row_count_estimate: 1,
             tree_height: 1,
-            primary_chunk_count: 1,
-            primary_chunk_bytes: root_bytes.len() as u64,
         }
     }
 

--- a/packages/lix/src/hot_state/tracked_head.rs
+++ b/packages/lix/src/hot_state/tracked_head.rs
@@ -962,8 +962,9 @@ const GENERATION_BYTES: usize = 16;
 /// Order-preserving tracked-head key encoding.
 ///
 /// The head table is the normal read serving index, so its storage ordering is
-/// also the visible row ordering: `(branch, generation, schema, entity,
-/// file)`. Musli's storage encoding is excellent for values and structural
+/// also the visible row ordering: `(branch, generation, schema, file,
+/// entity)` - see `encode_hot_row_key_parts`, which writes the file id before
+/// the entity primary key. Musli's storage encoding is excellent for values and structural
 /// prefixes, but length-prefixed strings do not preserve lexical order. This
 /// codec retains exact prefix scans while making every table scan already
 /// ordered and duplicate-free for one branch generation.

--- a/packages/lix/src/init.rs
+++ b/packages/lix/src/init.rs
@@ -59,7 +59,7 @@ pub(crate) const REPOSITORY_PROTOCOL_KEY: &[u8] = b"current";
 /// open, where `unsupported_repository_protocol_error` tells the operator to
 /// recreate the repository. Every hard cut to a persisted record shape has to
 /// move this value with it.
-const REPOSITORY_PROTOCOL_VALUE: &[u8] = b"tracked-default-branch.v67";
+const REPOSITORY_PROTOCOL_VALUE: &[u8] = b"tracked-default-branch.v68";
 
 /// Raw status of the repository protocol marker. Engine opening consults this
 /// before it touches any tracked-head space, whose physical IDs deliberately

--- a/packages/lix/src/session/execute.rs
+++ b/packages/lix/src/session/execute.rs
@@ -6136,12 +6136,15 @@ mod tests {
                 .parts
                 .iter()
                 .map(|part| {
-                    crate::tracked_state::current_state_descriptor_from_scoped_range_part(part)
-                        .expect("columnar locator should decode")
-                        .source_kind
+                    matches!(
+                        crate::tracked_state::current_state_descriptor_from_scoped_range_part(part)
+                            .expect("columnar locator should decode")
+                            .source,
+                        crate::tracked_state::CurrentStatePartSource::ColumnarPage(_)
+                    )
                 })
                 .collect::<Vec<_>>(),
-            vec![2; 33]
+            vec![true; 33]
         );
         let owner =
             crate::changelog::CommitId::parse_lix(&inserted_head, "typed lifecycle serving owner")
@@ -8727,7 +8730,12 @@ mod tests {
                 .collect::<Result<Vec<_>, _>>()
                 .expect("active head part descriptors should decode")
                 .into_iter()
-                .find(|descriptor| descriptor.source_kind == 1);
+                .find(|descriptor| {
+                    matches!(
+                        descriptor.source,
+                        crate::tracked_state::CurrentStatePartSource::NativeDataPart { .. }
+                    )
+                });
             if live_descriptor.is_some() {
                 break;
             }

--- a/packages/lix/src/tracked_state/commit_root_rebuild.rs
+++ b/packages/lix/src/tracked_state/commit_root_rebuild.rs
@@ -145,7 +145,7 @@ where
                 )
             })?;
         if let Some(expected) = manifest.snapshot_root.as_ref()
-            && !expected.has_same_authoritative_layout(&snapshot_root)
+            && **expected != snapshot_root
         {
             return Err(LixError::new(
                 LixError::CODE_INTERNAL_ERROR,

--- a/packages/lix/src/tracked_state/context.rs
+++ b/packages/lix/src/tracked_state/context.rs
@@ -3946,8 +3946,6 @@ where
                 changed_key_count: 0,
                 row_count_estimate: parent_metadata.row_count_estimate,
                 tree_height: parent_metadata.tree_height,
-                primary_chunk_count: 0,
-                primary_chunk_bytes: 0,
             };
             self.staged_roots.insert(commit_id.to_string(), metadata);
             return Ok(TrackedStateWriteReport {
@@ -4236,18 +4234,6 @@ where
                     "tracked_state commit_root tree height exceeds u32",
                 )
             })?,
-            primary_chunk_count: u64::try_from(result.chunk_count).map_err(|_| {
-                LixError::new(
-                    LixError::CODE_INTERNAL_ERROR,
-                    "tracked_state commit_root chunk count exceeds u64",
-                )
-            })?,
-            primary_chunk_bytes: u64::try_from(result.chunk_bytes).map_err(|_| {
-                LixError::new(
-                    LixError::CODE_INTERNAL_ERROR,
-                    "tracked_state commit_root chunk bytes exceeds u64",
-                )
-            })?,
         };
         self.staged_roots.insert(commit_id.to_string(), metadata);
 
@@ -4436,18 +4422,6 @@ where
                 LixError::new(
                     LixError::CODE_INTERNAL_ERROR,
                     "tracked_state commit_root tree height exceeds u32",
-                )
-            })?,
-            primary_chunk_count: u64::try_from(result.chunk_count).map_err(|_| {
-                LixError::new(
-                    LixError::CODE_INTERNAL_ERROR,
-                    "tracked_state commit_root chunk count exceeds u64",
-                )
-            })?,
-            primary_chunk_bytes: u64::try_from(result.chunk_bytes).map_err(|_| {
-                LixError::new(
-                    LixError::CODE_INTERNAL_ERROR,
-                    "tracked_state commit_root chunk bytes exceeds u64",
                 )
             })?,
         };
@@ -5184,8 +5158,6 @@ mod tests {
         assert_eq!(metadata.changed_key_count, 2);
         assert_eq!(metadata.row_count_estimate, 2);
         assert!(metadata.tree_height >= 1);
-        assert!(metadata.primary_chunk_count >= 1);
-        assert!(metadata.primary_chunk_bytes > 0);
     }
 
     #[tokio::test]
@@ -6582,8 +6554,6 @@ mod tests {
             parent_metadata.row_count_estimate
         );
         assert_eq!(child_metadata.tree_height, parent_metadata.tree_height);
-        assert_eq!(child_metadata.primary_chunk_count, 0);
-        assert_eq!(child_metadata.primary_chunk_bytes, 0);
         assert_eq!(child_metadata.parent_roots.len(), 1);
         assert_eq!(child_metadata.parent_roots[0].commit_id, "parent");
         assert_eq!(
@@ -9773,8 +9743,6 @@ mod tests {
             changed_key_count: rows.len() as u64,
             row_count_estimate: result.row_count as u64,
             tree_height: result.tree_height as u32,
-            primary_chunk_count: result.chunk_count as u64,
-            primary_chunk_bytes: result.chunk_bytes as u64,
         };
         let published = storage::load_published_commit_state_manifest(&read, typed_commit_id)
             .await

--- a/packages/lix/src/tracked_state/current_state_envelope.rs
+++ b/packages/lix/src/tracked_state/current_state_envelope.rs
@@ -4,25 +4,25 @@
 use crate::tracked_state::scoped_range::{
     ScopedRangePart, ScopedRangePartPayload, ScopedRangePrefix,
 };
-use crate::tracked_state::types::{CommitDeltaReplacementScope, CurrentStatePartDescriptor};
+use crate::tracked_state::types::{
+    CommitDeltaReplacementScope, CurrentStatePartDescriptor, CurrentStatePartSource,
+};
 use crate::{LixError, storage_codec};
 
-const LOCATOR_PAYLOAD_VERSION: u16 = 3;
+const LOCATOR_PAYLOAD_VERSION: u16 = 4;
 
+/// Wire form of one part locator.
+///
+/// Only the fields every source kind uses live here; the rest live in the
+/// variant that uses them, so a locator never spends bytes on another kind's
+/// addressing.
 #[derive(musli::Encode, musli::Decode)]
 #[musli(packed)]
 struct CurrentStatePartLocatorPayload {
     content_digest: [u8; 32],
-    payload_refs_digest: [u8; 32],
-    source_kind: u8,
-    source_id: [u8; 16],
-    owner_commit_id: [u8; 16],
-    part_index: u32,
-    source_page_index: u16,
     source_row_offset: u16,
     fragmented: bool,
-    uniform_created_at: crate::common::LixTimestamp,
-    uniform_updated_at: crate::common::LixTimestamp,
+    source: CurrentStatePartSource,
 }
 
 pub(crate) fn current_state_scope_prefix(
@@ -58,16 +58,9 @@ pub(crate) fn scoped_range_part_from_current_state_descriptor(
                 "current-state scoped-range locator payload",
                 &CurrentStatePartLocatorPayload {
                     content_digest: descriptor.content_digest,
-                    payload_refs_digest: descriptor.payload_refs_digest,
-                    source_kind: descriptor.source_kind,
-                    source_id: descriptor.source_id,
-                    owner_commit_id: descriptor.owner_commit_id,
-                    part_index: descriptor.part_index,
-                    source_page_index: descriptor.source_page_index,
                     source_row_offset: descriptor.source_row_offset,
                     fragmented: descriptor.fragmented,
-                    uniform_created_at: descriptor.uniform_created_at,
-                    uniform_updated_at: descriptor.uniform_updated_at,
+                    source: descriptor.source.clone(),
                 },
             )?,
         },
@@ -88,60 +81,50 @@ pub(crate) fn current_state_descriptor_from_scoped_range_part(
         first_key: part.first_key.clone(),
         last_key: part.last_key.clone(),
         content_digest: payload.content_digest,
-        payload_refs_digest: payload.payload_refs_digest,
-        source_kind: payload.source_kind,
-        source_id: payload.source_id,
-        owner_commit_id: payload.owner_commit_id,
-        part_index: payload.part_index,
-        source_page_index: payload.source_page_index,
+        source: payload.source,
         source_row_offset: payload.source_row_offset,
         row_count: u16::try_from(part.row_count)
             .map_err(|_| envelope_error("part row count exceeds its locator codec"))?,
         fragmented: payload.fragmented,
-        uniform_created_at: payload.uniform_created_at,
-        uniform_updated_at: payload.uniform_updated_at,
     };
     validate_current_state_descriptor(&descriptor)?;
     Ok(descriptor)
 }
 
+/// Checks the invariants the type system cannot carry.
+///
+/// Every "this field must be zero for this kind" clause this validator used to
+/// run is gone: those fields no longer exist outside the variant that owns
+/// them. What remains is genuine content validation - key bounds, the source's
+/// physical row bound, and identifiers that must be present.
 fn validate_current_state_descriptor(
     descriptor: &CurrentStatePartDescriptor,
 ) -> Result<(), LixError> {
     let slice_end = u32::from(descriptor.source_row_offset)
         .checked_add(u32::from(descriptor.row_count))
         .ok_or_else(|| envelope_error("part source slice overflows"))?;
+    let source_row_bound = match descriptor.source {
+        CurrentStatePartSource::ColumnarPage(_) => {
+            crate::columnar_row_group::ROW_GROUP_PAGE_ROWS as u32
+        }
+        _ => crate::tracked_state::current_state_data_part::CURRENT_STATE_DATA_PART_MAX_ROWS as u32,
+    };
+    let source_identifiers_present = match &descriptor.source {
+        CurrentStatePartSource::Replacement(source) => source.owner_commit_id != [0; 16],
+        CurrentStatePartSource::NativeDataPart {
+            payload_refs_digest,
+        } => *payload_refs_digest != [0; 32],
+        CurrentStatePartSource::ColumnarPage(source) => {
+            source.source_id != [0; 16] && source.owner_commit_id != [0; 16]
+        }
+    };
     if descriptor.first_key.is_empty()
         || descriptor.last_key.is_empty()
         || descriptor.first_key > descriptor.last_key
         || descriptor.row_count == 0
-        || slice_end
-            > match descriptor.source_kind {
-                2 => crate::columnar_row_group::ROW_GROUP_PAGE_ROWS as u32,
-                _ => {
-                    crate::tracked_state::current_state_data_part::CURRENT_STATE_DATA_PART_MAX_ROWS
-                        as u32
-                }
-            }
+        || slice_end > source_row_bound
         || descriptor.content_digest == [0; 32]
-        || descriptor.source_kind > 2
-        || (descriptor.source_kind == 0
-            && (descriptor.source_id != [0; 16]
-                || descriptor.source_page_index != 0
-                || descriptor.owner_commit_id == [0; 16]
-                || descriptor.payload_refs_digest != [0; 32]))
-        || (descriptor.source_kind == 1
-            && (descriptor.source_id != [0; 16]
-                || descriptor.source_page_index != 0
-                || descriptor.owner_commit_id != [0; 16]
-                || descriptor.part_index != 0
-                || descriptor.payload_refs_digest == [0; 32]
-                || descriptor.uniform_created_at.packed() != 0
-                || descriptor.uniform_updated_at.packed() != 0))
-        || (descriptor.source_kind == 2
-            && (descriptor.source_id == [0; 16]
-                || descriptor.owner_commit_id == [0; 16]
-                || descriptor.payload_refs_digest != [0; 32]))
+        || !source_identifiers_present
     {
         return Err(envelope_error("part locator invariants are invalid"));
     }
@@ -186,4 +169,189 @@ fn envelope_error(message: impl std::fmt::Display) -> LixError {
         LixError::CODE_INTERNAL_ERROR,
         format!("tracked_state current-state scoped-range envelope {message}"),
     )
+}
+
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::common::LixTimestamp;
+    use crate::tracked_state::types::{ColumnarPageSource, ReplacementPartSource};
+
+    /// The v3 locator payload: one flattened tagged union whose every locator
+    /// carried the other kinds' fields pinned to zero.
+    #[derive(musli::Encode, musli::Decode)]
+    #[musli(packed)]
+    struct LocatorPayloadV3 {
+        content_digest: [u8; 32],
+        payload_refs_digest: [u8; 32],
+        source_kind: u8,
+        source_id: [u8; 16],
+        owner_commit_id: [u8; 16],
+        part_index: u32,
+        source_page_index: u16,
+        source_row_offset: u16,
+        fragmented: bool,
+        uniform_created_at: LixTimestamp,
+        uniform_updated_at: LixTimestamp,
+    }
+
+    const PART_INDEX: u32 = 3;
+    const PAGE_INDEX: u16 = 5;
+    const CREATED_AT_MS: i64 = 1_760_000_000_000;
+    const UPDATED_AT_MS: i64 = 1_760_000_060_000;
+
+    fn scope() -> CommitDeltaReplacementScope {
+        CommitDeltaReplacementScope {
+            schema_key: "locator_bytes".to_owned(),
+            file_id: None,
+        }
+    }
+
+    fn descriptor(source: CurrentStatePartSource) -> CurrentStatePartDescriptor {
+        CurrentStatePartDescriptor {
+            first_key: vec![1],
+            last_key: vec![2],
+            content_digest: [7; 32],
+            source,
+            source_row_offset: 0,
+            row_count: 1,
+            fragmented: false,
+        }
+    }
+
+    fn replacement() -> CurrentStatePartSource {
+        CurrentStatePartSource::Replacement(ReplacementPartSource {
+            owner_commit_id: [3; 16],
+            part_index: PART_INDEX,
+            uniform_created_at: LixTimestamp::from_unix_millis_utc_lossy(CREATED_AT_MS),
+            uniform_updated_at: LixTimestamp::from_unix_millis_utc_lossy(UPDATED_AT_MS),
+        })
+    }
+
+    fn native() -> CurrentStatePartSource {
+        CurrentStatePartSource::NativeDataPart {
+            payload_refs_digest: [9; 32],
+        }
+    }
+
+    fn columnar() -> CurrentStatePartSource {
+        CurrentStatePartSource::ColumnarPage(ColumnarPageSource {
+            source_id: [2; 16],
+            owner_commit_id: [3; 16],
+            part_index: PART_INDEX,
+            source_page_index: PAGE_INDEX,
+            uniform_created_at: LixTimestamp::from_unix_millis_utc_lossy(CREATED_AT_MS),
+            uniform_updated_at: LixTimestamp::from_unix_millis_utc_lossy(UPDATED_AT_MS),
+        })
+    }
+
+    fn payload_len(source: CurrentStatePartSource) -> usize {
+        scoped_range_part_from_current_state_descriptor(&scope(), &descriptor(source))
+            .expect("descriptor should encode")
+            .payload
+            .bytes
+            .len()
+    }
+
+    fn v3_len(kind: u8) -> usize {
+        v3_encoded(kind).len()
+    }
+
+    /// The same locator, in the shape v3 required: every field present, with
+    /// the ones this kind may not use pinned to zero.
+    fn v3_encoded(kind: u8) -> Vec<u8> {
+        storage_codec::encode(
+            "v3 locator payload",
+            &LocatorPayloadV3 {
+                content_digest: [7; 32],
+                payload_refs_digest: if kind == 1 { [9; 32] } else { [0; 32] },
+                source_kind: kind,
+                source_id: if kind == 2 { [2; 16] } else { [0; 16] },
+                owner_commit_id: if kind == 1 { [0; 16] } else { [3; 16] },
+                part_index: if kind == 1 { 0 } else { PART_INDEX },
+                source_page_index: if kind == 2 { PAGE_INDEX } else { 0 },
+                source_row_offset: 0,
+                fragmented: false,
+                uniform_created_at: if kind == 1 {
+                    LixTimestamp::from_unix_millis_utc_lossy(0)
+                } else {
+                    LixTimestamp::from_unix_millis_utc_lossy(CREATED_AT_MS)
+                },
+                uniform_updated_at: if kind == 1 {
+                    LixTimestamp::from_unix_millis_utc_lossy(0)
+                } else {
+                    LixTimestamp::from_unix_millis_utc_lossy(UPDATED_AT_MS)
+                },
+            },
+        )
+        .expect("v3 payload should encode")
+    }
+
+    /// Every part locator is embedded per part inside a serving-tree leaf, so
+    /// these byte counts are fetched and decoded on every scoped-range read.
+    ///
+    /// v3 spent the same bytes on every locator whatever its kind, because the
+    /// fields a kind could not use were still encoded - pinned to zero and
+    /// re-proved zero by the validator on each decode. These figures are the
+    /// same three locators, measured through the same codec.
+    #[test]
+    fn locator_payload_spends_no_bytes_on_other_kinds_fields() {
+        assert_eq!(
+            [
+                (v3_len(0), payload_len(replacement())),
+                (v3_len(1), payload_len(native())),
+                (v3_len(2), payload_len(columnar())),
+            ],
+            [(121, 72), (107, 71), (121, 90)]
+        );
+    }
+
+    /// `#[musli(packed)]` records are positional and untagged, so a format
+    /// break is only safe if an old reader cannot silently accept new bytes.
+    #[test]
+    fn v3_readers_and_v4_records_are_mutually_undecodable() {
+        for source in [replacement(), native(), columnar()] {
+            let part = scoped_range_part_from_current_state_descriptor(&scope(), &descriptor(source))
+                .expect("descriptor should encode");
+            assert_eq!(part.payload.version, LOCATOR_PAYLOAD_VERSION);
+            assert!(
+                storage_codec::decode::<LocatorPayloadV3>("v3 locator payload", &part.payload.bytes)
+                    .is_err(),
+                "a v3 reader must not decode a v4 record"
+            );
+        }
+
+        let v3_bytes = v3_encoded(0);
+        assert!(
+            storage_codec::decode::<CurrentStatePartLocatorPayload>(
+                "current-state scoped-range locator payload",
+                &v3_bytes,
+            )
+            .is_err(),
+            "a v4 reader must not decode a v3 record"
+        );
+    }
+
+    /// The payload codec self-versions, so a v3 part is refused before its
+    /// bytes are ever handed to a decoder.
+    #[test]
+    fn stale_payload_version_is_refused_before_decoding() {
+        let mut part = scoped_range_part_from_current_state_descriptor(&scope(), &descriptor(replacement()))
+            .expect("descriptor should encode");
+        part.payload.version = 3;
+        assert!(current_state_descriptor_from_scoped_range_part(&part).is_err());
+    }
+
+    #[test]
+    fn locator_round_trips_every_source_kind() {
+        for source in [replacement(), native(), columnar()] {
+            let expected = descriptor(source);
+            let part = scoped_range_part_from_current_state_descriptor(&scope(), &expected)
+                .expect("descriptor should encode");
+            let decoded = current_state_descriptor_from_scoped_range_part(&part)
+                .expect("descriptor should decode");
+            assert_eq!(decoded, expected);
+        }
+    }
 }

--- a/packages/lix/src/tracked_state/diff.rs
+++ b/packages/lix/src/tracked_state/diff.rs
@@ -2158,8 +2158,6 @@ mod tests {
                     changed_key_count: 1,
                     row_count_estimate: result.row_count as u64,
                     tree_height: result.tree_height as u32,
-                    primary_chunk_count: result.chunk_count as u64,
-                    primary_chunk_bytes: result.chunk_bytes as u64,
                 },
             )
             .await
@@ -2363,8 +2361,6 @@ mod tests {
                     changed_key_count: 1,
                     row_count_estimate: result.row_count as u64,
                     tree_height: result.tree_height as u32,
-                    primary_chunk_count: result.chunk_count as u64,
-                    primary_chunk_bytes: result.chunk_bytes as u64,
                 },
             )
             .await
@@ -3550,8 +3546,6 @@ mod tests {
                 changed_key_count,
                 row_count_estimate: result.row_count as u64,
                 tree_height: result.tree_height as u32,
-                primary_chunk_count: result.chunk_count as u64,
-                primary_chunk_bytes: result.chunk_bytes as u64,
             },
         )
         .await

--- a/packages/lix/src/tracked_state/mod.rs
+++ b/packages/lix/src/tracked_state/mod.rs
@@ -135,8 +135,11 @@ pub(crate) use types::{
     TrackedStateDeltaRef, TrackedStateFilter, TrackedStateIndexValue, TrackedStateReadColumns,
     TrackedStateRootMutationRef, TrackedStateScanRequest, TrackedStateSingleStringReplacementRef,
 };
+pub(crate) use types::CurrentStatePartSource;
 #[cfg(test)]
-pub(crate) use types::{CurrentStatePartDescriptor, TrackedStateCommitRootParent};
+pub(crate) use types::{
+    CurrentStatePartDescriptor, ReplacementPartSource, TrackedStateCommitRootParent,
+};
 pub(crate) use types::{TrackedStateKey, TrackedStateKeyRef};
 
 /// Builds an authenticated content-addressed closure for a set of retained

--- a/packages/lix/src/tracked_state/scoped_current_state.rs
+++ b/packages/lix/src/tracked_state/scoped_current_state.rs
@@ -12,8 +12,9 @@ use crate::tracked_state::scoped_range::{
     load_scoped_range_coverage_with_staged, stage_replace_scoped_range, stage_scoped_range_tree,
 };
 use crate::tracked_state::types::{
-    CommitDeltaReplacementScope, CommitStateManifest, CommitStateMutationInventory,
-    CommitStateTouchedScopeFilter, CurrentStatePartDescriptor, CurrentStateScopedRangeRoot,
+    ColumnarPageSource, CommitDeltaReplacementScope, CommitStateManifest,
+    CommitStateMutationInventory, CommitStateTouchedScopeFilter, CurrentStatePartDescriptor,
+    CurrentStatePartSource, CurrentStateScopedRangeRoot, ReplacementPartSource,
 };
 
 const TRANSITION_CONTEXT: &str = "lix current-state scoped-range transition v2";
@@ -103,19 +104,19 @@ async fn stage_disjoint_columnar_current_state_pages(
                 first_key: first_key.clone(),
                 last_key: last_key.clone(),
                 content_digest: parts.manifest_digest,
-                payload_refs_digest: [0; 32],
-                source_kind: 2,
-                source_id: parts.row_group_set_id,
-                owner_commit_id: parts.owner_commit_id,
-                part_index: u32::try_from(group_index)
-                    .map_err(|_| scoped_state_error("columnar group index exceeds u32"))?,
-                source_page_index: u16::try_from(page_index)
-                    .map_err(|_| scoped_state_error("columnar page index exceeds u16"))?,
+                source: CurrentStatePartSource::ColumnarPage(ColumnarPageSource {
+                    source_id: parts.row_group_set_id,
+                    owner_commit_id: parts.owner_commit_id,
+                    part_index: u32::try_from(group_index)
+                        .map_err(|_| scoped_state_error("columnar group index exceeds u32"))?,
+                    source_page_index: u16::try_from(page_index)
+                        .map_err(|_| scoped_state_error("columnar page index exceeds u16"))?,
+                    uniform_created_at: parts.uniform_created_at,
+                    uniform_updated_at: parts.uniform_updated_at,
+                }),
                 source_row_offset: 0,
                 row_count,
                 fragmented: false,
-                uniform_created_at: parts.uniform_created_at,
-                uniform_updated_at: parts.uniform_updated_at,
             });
             global_ordinal = global_ordinal
                 .checked_add(u64::from(row_count))
@@ -580,18 +581,16 @@ pub(crate) async fn stage_complete_replacement_scoped_range_root(
                 first_key: bounds.first_key.clone(),
                 last_key: bounds.last_key.clone(),
                 content_digest: part.content_digest,
-                payload_refs_digest: [0; 32],
-                source_kind: 0,
-                source_id: [0; 16],
-                owner_commit_id: part.owner_commit_id,
-                part_index: u32::try_from(part_index)
-                    .map_err(|_| scoped_state_error("replacement part index overflows"))?,
-                source_page_index: 0,
+                source: CurrentStatePartSource::Replacement(ReplacementPartSource {
+                    owner_commit_id: part.owner_commit_id,
+                    part_index: u32::try_from(part_index)
+                        .map_err(|_| scoped_state_error("replacement part index overflows"))?,
+                    uniform_created_at: part.uniform_created_at,
+                    uniform_updated_at: part.uniform_updated_at,
+                }),
                 source_row_offset: 0,
                 row_count,
                 fragmented: false,
-                uniform_created_at: part.uniform_created_at,
-                uniform_updated_at: part.uniform_updated_at,
             })
         })
         .collect::<Result<Vec<_>, LixError>>()?;
@@ -948,8 +947,8 @@ mod tests {
     use crate::tracked_state::types::{
         CommitDeltaLifecycleSummary, CommitDeltaReplacementScope, CommitStateManifest,
         CommitStateMutationInventory, CommitStateMutationPart, CommitStateReplayDebt,
-        CommitStateTouchedScopeFilter, TrackedStateCommitDeltaRef, TrackedStateDeltaRef,
-        TrackedStateKeyRef, TrackedStateSingleStringReplacementRef,
+        CommitStateTouchedScopeFilter, CurrentStatePartSource, TrackedStateCommitDeltaRef,
+        TrackedStateDeltaRef, TrackedStateKeyRef, TrackedStateSingleStringReplacementRef,
     };
 
     use super::{
@@ -1302,13 +1301,13 @@ mod tests {
             descriptors
                 .iter()
                 .map(|descriptor| (
-                    descriptor.source_kind,
+                    matches!(descriptor.source, CurrentStatePartSource::Replacement(_)),
                     descriptor.source_row_offset,
                     descriptor.row_count,
                     descriptor.fragmented,
                 ))
                 .collect::<Vec<_>>(),
-            vec![(0, 0, 1, true), (0, 2, 1, true), (1, 0, 1, true)],
+            vec![(true, 0, 1, true), (true, 2, 1, true), (false, 0, 1, true)],
             "sparse delete/insert must retain two immutable source slices and write only the insert",
         );
     }

--- a/packages/lix/src/tracked_state/storage.rs
+++ b/packages/lix/src/tracked_state/storage.rs
@@ -33,8 +33,8 @@ pub(crate) use crate::tracked_state::types::{
     CommitDeltaLifecycleSummary, CommitDeltaReplacementScope,
 };
 use crate::tracked_state::types::{
-    CommitStateManifest, CommitStateMutationInventory, CommitStateMutationPart,
-    CurrentStatePartDescriptor, CurrentStateScopedRangeRoot,
+    ColumnarPageSource, CommitStateManifest, CommitStateMutationInventory, CommitStateMutationPart,
+    CurrentStatePartDescriptor, CurrentStatePartSource, CurrentStateScopedRangeRoot,
     StoredCommitDeltaReplacementGeneration, StoredReplacementPart, StoredReplacementPartsAuthority,
     TRACKED_STATE_HASH_BYTES, TrackedStateBaseCoordinate, TrackedStateCommitDeltaRef,
     TrackedStateCommitRoot, TrackedStateIndexValue, TrackedStateIndexValueRef, TrackedStateKey,
@@ -954,7 +954,7 @@ async fn load_current_state_values_from_descriptors(
         ));
     }
     let mut routed = BTreeMap::<
-        (u8, [u8; 16], [u8; 16], u32, u16, [u8; 32], u16),
+        (CurrentStatePartSource, [u8; 32], u16),
         (CurrentStatePartDescriptor, Vec<usize>),
     >::new();
     for (output_index, descriptor) in descriptors.into_iter().enumerate() {
@@ -963,11 +963,7 @@ async fn load_current_state_values_from_descriptors(
         };
         routed
             .entry((
-                descriptor.source_kind,
-                descriptor.source_id,
-                descriptor.owner_commit_id,
-                descriptor.part_index,
-                descriptor.source_page_index,
+                descriptor.source.clone(),
                 descriptor.content_digest,
                 descriptor.source_row_offset,
             ))
@@ -979,13 +975,18 @@ async fn load_current_state_values_from_descriptors(
 
     let replacement = routed
         .iter()
-        .filter(|(_, (descriptor, _))| descriptor.source_kind == 0)
+        .filter_map(|(_, (descriptor, output_indices))| match &descriptor.source {
+            CurrentStatePartSource::Replacement(source) => {
+                Some((descriptor, source, output_indices))
+            }
+            _ => None,
+        })
         .collect::<Vec<_>>();
     let storage_keys = replacement
         .iter()
-        .map(|(_, (descriptor, _))| {
-            let owner = CommitId::new(uuid::Uuid::from_bytes(descriptor.owner_commit_id));
-            let mut key = commit_delta_segment_key(owner, descriptor.part_index as usize)?;
+        .map(|(descriptor, source, _)| {
+            let owner = CommitId::new(uuid::Uuid::from_bytes(source.owner_commit_id));
+            let mut key = commit_delta_segment_key(owner, source.part_index as usize)?;
             key.extend_from_slice(&descriptor.content_digest);
             Ok(StorageKey(Bytes::from(key)))
         })
@@ -993,11 +994,11 @@ async fn load_current_state_values_from_descriptors(
     let loaded = PointReadPlan::new(TRACKED_STATE_COMMIT_DELTA_SEGMENT_SPACE, &storage_keys)
         .materialize(store, StorageGetOptions::default())
         .await?;
-    for ((_, (descriptor, output_indices)), value) in replacement.into_iter().zip(loaded.value) {
+    for ((descriptor, source, output_indices), value) in replacement.into_iter().zip(loaded.value) {
         let bytes = value.and_then(full_value_bytes).ok_or_else(|| {
             replacement_payload_error("current-state directory references a missing part")
         })?;
-        let owner = CommitId::new(uuid::Uuid::from_bytes(descriptor.owner_commit_id));
+        let owner = CommitId::new(uuid::Uuid::from_bytes(source.owner_commit_id));
         let decoded = crate::tracked_state::replacement_part::decode_replacement_part(
             &descriptor.content_digest,
             &bytes,
@@ -1015,7 +1016,7 @@ async fn load_current_state_values_from_descriptors(
                     "replacement current-state route escaped its source slice",
                 ));
             }
-            let packed = descriptor
+            let packed = source
                 .part_index
                 .checked_mul(
                     u32::try_from(COMMIT_DELTA_SEGMENT_MAX_ROWS).expect("row bound fits u32"),
@@ -1027,14 +1028,19 @@ async fn load_current_state_values_from_descriptors(
                 change_id: change_id_from_packed_address(owner, packed),
                 commit_id: owner,
                 deleted: false,
-                created_at: descriptor.uniform_created_at,
-                updated_at: descriptor.uniform_updated_at,
+                created_at: source.uniform_created_at,
+                updated_at: source.uniform_updated_at,
             });
         }
     }
     let native = routed
         .iter()
-        .filter(|(_, (descriptor, _))| descriptor.source_kind == 1)
+        .filter(|(_, (descriptor, _))| {
+            matches!(
+                descriptor.source,
+                CurrentStatePartSource::NativeDataPart { .. }
+            )
+        })
         .collect::<Vec<_>>();
     let native_keys = native
         .iter()
@@ -1071,13 +1077,18 @@ async fn load_current_state_values_from_descriptors(
     }
     let columnar = routed
         .iter()
-        .filter(|(_, (descriptor, _))| descriptor.source_kind == 2)
+        .filter_map(|(_, (descriptor, output_indices))| match &descriptor.source {
+            CurrentStatePartSource::ColumnarPage(source) => {
+                Some((descriptor, source, output_indices))
+            }
+            _ => None,
+        })
         .collect::<Vec<_>>();
     let mut columnar_manifests = HashMap::new();
-    for (_, (descriptor, _)) in &columnar {
-        let id = crate::columnar_row_group::RowGroupSetId::new(descriptor.source_id);
+    for (_, source, _) in &columnar {
+        let id = crate::columnar_row_group::RowGroupSetId::new(source.source_id);
         if let std::collections::hash_map::Entry::Vacant(entry) =
-            columnar_manifests.entry(descriptor.source_id)
+            columnar_manifests.entry(source.source_id)
         {
             let manifest = crate::columnar_row_group::load_row_group_manifest(store, id)
                 .await?
@@ -1093,15 +1104,15 @@ async fn load_current_state_values_from_descriptors(
                 replacement_payload_error("current-state columnar identity contract drifted")
             })?;
         let mut page_routes = BTreeMap::new();
-        for (_, (descriptor, output_indices)) in &columnar {
-            if descriptor.source_id == source_id {
+        for (descriptor, source, output_indices) in &columnar {
+            if source.source_id == source_id {
                 page_routes
                     .entry((
-                        descriptor.part_index as usize,
-                        usize::from(descriptor.source_page_index),
+                        source.part_index as usize,
+                        usize::from(source.source_page_index),
                     ))
                     .or_insert_with(Vec::new)
-                    .push((descriptor, output_indices.as_slice()));
+                    .push((*descriptor, *source, output_indices.as_slice()));
             }
         }
         let coordinates = page_routes.keys().copied().collect::<Vec<_>>();
@@ -1112,10 +1123,11 @@ async fn load_current_state_values_from_descriptors(
             &coordinates,
             &[identity_column_index],
             |coordinate, batch| {
-                for (descriptor, output_indices) in &page_routes[&coordinate] {
+                for (descriptor, source, output_indices) in &page_routes[&coordinate] {
                     apply_columnar_identity_page(
                         manifest,
                         descriptor,
+                        source,
                         output_indices,
                         &batch,
                         encoded_keys,
@@ -1133,6 +1145,7 @@ async fn load_current_state_values_from_descriptors(
 fn apply_columnar_identity_page(
     manifest: &crate::columnar_row_group::RowGroupManifest,
     descriptor: &CurrentStatePartDescriptor,
+    source: &ColumnarPageSource,
     output_indices: &[usize],
     batch: &datafusion::arrow::record_batch::RecordBatch,
     encoded_keys: &[Bytes],
@@ -1144,19 +1157,19 @@ fn apply_columnar_identity_page(
     if manifest.content_digest()? != descriptor.content_digest
         || manifest.namespace != first_key.schema_key
         || crate::entity_columnar::entity_row_group_set_id(
-            CommitId::new(uuid::Uuid::from_bytes(descriptor.owner_commit_id)),
+            CommitId::new(uuid::Uuid::from_bytes(source.owner_commit_id)),
             &manifest.namespace,
         )
         .as_bytes()
-            != descriptor.source_id
+            != source.source_id
     {
         return Err(replacement_payload_error(
             "current-state columnar descriptor disagrees with its manifest",
         ));
     }
-    let group_index = usize::try_from(descriptor.part_index)
+    let group_index = usize::try_from(source.part_index)
         .map_err(|_| replacement_payload_error("columnar group index exceeds usize"))?;
-    let page_index = usize::from(descriptor.source_page_index);
+    let page_index = usize::from(source.source_page_index);
     let identities = batch
         .column(0)
         .as_any()
@@ -1225,13 +1238,13 @@ fn apply_columnar_identity_page(
             .map_err(|_| replacement_payload_error("columnar row ordinal exceeds u32"))?
             .checked_add(1)
             .ok_or_else(|| replacement_payload_error("columnar change address overflows"))?;
-        let owner = CommitId::new(uuid::Uuid::from_bytes(descriptor.owner_commit_id));
+        let owner = CommitId::new(uuid::Uuid::from_bytes(source.owner_commit_id));
         values[output_index] = Some(TrackedStateIndexValue {
             change_id: change_id_from_packed_address(owner, packed),
             commit_id: owner,
             deleted: false,
-            created_at: descriptor.uniform_created_at,
-            updated_at: descriptor.uniform_updated_at,
+            created_at: source.uniform_created_at,
+            updated_at: source.uniform_updated_at,
         });
     }
     Ok(())
@@ -3175,7 +3188,6 @@ fn stage_scoped_native_current_state_rows(
     if rows.is_empty() {
         return Ok(());
     }
-    let timestamp = crate::common::LixTimestamp::from_unix_millis_utc_lossy(0);
     for part in encode_bounded_current_state_data_parts(rows)? {
         stage_scoped_current_state_bytes(
             writes,
@@ -3193,17 +3205,12 @@ fn stage_scoped_native_current_state_rows(
             first_key: part.first_key,
             last_key: part.last_key,
             content_digest: part.digest,
-            payload_refs_digest: part.refs_digest,
-            source_kind: 1,
-            source_id: [0; 16],
-            owner_commit_id: [0; 16],
-            part_index: 0,
-            source_page_index: 0,
+            source: CurrentStatePartSource::NativeDataPart {
+                payload_refs_digest: part.refs_digest,
+            },
             source_row_offset: 0,
             row_count: part.row_count,
             fragmented,
-            uniform_created_at: timestamp,
-            uniform_updated_at: timestamp,
         });
     }
     Ok(())
@@ -3236,10 +3243,10 @@ async fn load_scoped_current_state_descriptor_rows(
         CURRENT_STATE_DATA_PART_SPACE, CurrentStateDataRow, decode_current_state_data_part,
     };
 
-    let rows = match descriptor.source_kind {
-        0 => {
-            let owner = CommitId::new(uuid::Uuid::from_bytes(descriptor.owner_commit_id));
-            let mut physical_key = commit_delta_segment_key(owner, descriptor.part_index as usize)?;
+    let rows = match &descriptor.source {
+        CurrentStatePartSource::Replacement(source) => {
+            let owner = CommitId::new(uuid::Uuid::from_bytes(source.owner_commit_id));
+            let mut physical_key = commit_delta_segment_key(owner, source.part_index as usize)?;
             physical_key.extend_from_slice(&descriptor.content_digest);
             let bytes = if let Some(bytes) =
                 writes.staged_value(TRACKED_STATE_COMMIT_DELTA_SEGMENT_SPACE, &physical_key)
@@ -3270,7 +3277,7 @@ async fn load_scoped_current_state_descriptor_rows(
                     let encoded_key = decoded.key(ordinal)?.ok_or_else(|| {
                         replacement_payload_error("replacement source omitted a key")
                     })?;
-                    let packed = descriptor
+                    let packed = source
                         .part_index
                         .checked_mul(
                             u32::try_from(COMMIT_DELTA_SEGMENT_MAX_ROWS)
@@ -3289,8 +3296,8 @@ async fn load_scoped_current_state_descriptor_rows(
                             change_id: change_id_from_packed_address(owner, packed),
                             commit_id: owner,
                             deleted: false,
-                            created_at: descriptor.uniform_created_at,
-                            updated_at: descriptor.uniform_updated_at,
+                            created_at: source.uniform_created_at,
+                            updated_at: source.uniform_updated_at,
                         },
                         snapshot: owned_scoped_json_slot(decoded.snapshot(ordinal)?.ok_or_else(
                             || replacement_payload_error("replacement source omitted snapshot"),
@@ -3302,7 +3309,7 @@ async fn load_scoped_current_state_descriptor_rows(
                 })
                 .collect::<Result<Vec<_>, LixError>>()?
         }
-        1 => {
+        CurrentStatePartSource::NativeDataPart { .. } => {
             let physical_key = descriptor.content_digest.to_vec();
             let bytes = if let Some(bytes) =
                 writes.staged_value(CURRENT_STATE_DATA_PART_SPACE, &physical_key)
@@ -3325,8 +3332,8 @@ async fn load_scoped_current_state_descriptor_rows(
                 })?
                 .to_vec()
         }
-        2 => {
-            let id = crate::columnar_row_group::RowGroupSetId::new(descriptor.source_id);
+        CurrentStatePartSource::ColumnarPage(source) => {
+            let id = crate::columnar_row_group::RowGroupSetId::new(source.source_id);
             let staged_manifest =
                 crate::columnar_row_group::load_staged_row_group_manifest(writes, id)?;
             let manifest = match staged_manifest {
@@ -3341,20 +3348,20 @@ async fn load_scoped_current_state_descriptor_rows(
             if manifest.content_digest()? != descriptor.content_digest
                 || manifest.namespace != schema_key
                 || crate::entity_columnar::entity_row_group_set_id(
-                    CommitId::new(uuid::Uuid::from_bytes(descriptor.owner_commit_id)),
+                    CommitId::new(uuid::Uuid::from_bytes(source.owner_commit_id)),
                     &manifest.namespace,
                 )
                 .as_bytes()
-                    != descriptor.source_id
+                    != source.source_id
             {
                 return Err(replacement_payload_error(
                     "columnar current-state source disagrees with its descriptor",
                 ));
             }
             let projection = (0..manifest.fields.len()).collect::<Vec<_>>();
-            let group_index = usize::try_from(descriptor.part_index)
+            let group_index = usize::try_from(source.part_index)
                 .map_err(|_| replacement_payload_error("columnar group index exceeds usize"))?;
-            let page_index = usize::from(descriptor.source_page_index);
+            let page_index = usize::from(source.source_page_index);
             let batch = if crate::columnar_row_group::load_staged_row_group_manifest(writes, id)?
                 .is_some()
             {
@@ -3391,8 +3398,8 @@ async fn load_scoped_current_state_descriptor_rows(
                 )
                 .ok_or_else(|| replacement_payload_error("columnar page base overflows"))?;
             let synthetic_parts = crate::tracked_state::types::ColumnarMutationPartSet {
-                owner_commit_id: descriptor.owner_commit_id,
-                row_group_set_id: descriptor.source_id,
+                owner_commit_id: source.owner_commit_id,
+                row_group_set_id: source.source_id,
                 manifest_digest: descriptor.content_digest,
                 schema_key: manifest.namespace.clone(),
                 row_count: manifest.groups.iter().map(|group| group.row_count).sum(),
@@ -3405,11 +3412,11 @@ async fn load_scoped_current_state_descriptor_rows(
                 last_key: descriptor.last_key.clone(),
                 page_first_keys: vec![descriptor.first_key.clone()],
                 page_last_keys: vec![descriptor.last_key.clone()],
-                uniform_created_at: descriptor.uniform_created_at,
-                uniform_updated_at: descriptor.uniform_updated_at,
+                uniform_created_at: source.uniform_created_at,
+                uniform_updated_at: source.uniform_updated_at,
                 origin_key: None,
             };
-            let owner = CommitId::new(uuid::Uuid::from_bytes(descriptor.owner_commit_id));
+            let owner = CommitId::new(uuid::Uuid::from_bytes(source.owner_commit_id));
             let start = usize::from(descriptor.source_row_offset);
             let end = start + usize::from(descriptor.row_count);
             if end > batch.num_rows() {
@@ -3447,19 +3454,14 @@ async fn load_scoped_current_state_descriptor_rows(
                             change_id,
                             commit_id: owner,
                             deleted: false,
-                            created_at: descriptor.uniform_created_at,
-                            updated_at: descriptor.uniform_updated_at,
+                            created_at: source.uniform_created_at,
+                            updated_at: source.uniform_updated_at,
                         },
                         snapshot: record.snapshot,
                         metadata: record.metadata,
                     })
                 })
                 .collect::<Result<Vec<_>, LixError>>()?
-        }
-        _ => {
-            return Err(replacement_payload_error(
-                "current-state descriptor has unknown source",
-            ));
         }
     };
     if rows.first().map(|row| row.encoded_key.as_slice()) != Some(descriptor.first_key.as_slice())
@@ -10842,7 +10844,9 @@ pub(crate) async fn stage_retire_commit_physical_state(
         for part in reachable.parts {
             let descriptor =
                 crate::tracked_state::current_state_descriptor_from_scoped_range_part(&part)?;
-            if descriptor.source_kind == 1
+            if let CurrentStatePartSource::NativeDataPart {
+                payload_refs_digest,
+            } = descriptor.source
                 && !retained.native_parts.contains(&descriptor.content_digest)
             {
                 writes.delete(
@@ -10851,9 +10855,9 @@ pub(crate) async fn stage_retire_commit_physical_state(
                 );
                 writes.delete(
                     crate::tracked_state::CURRENT_STATE_DATA_PART_REFS_SPACE,
-                    key(descriptor.payload_refs_digest.to_vec()),
+                    key(payload_refs_digest.to_vec()),
                 );
-                released_part_refs_digests.insert(descriptor.payload_refs_digest);
+                released_part_refs_digests.insert(payload_refs_digest);
             }
         }
     }
@@ -13714,6 +13718,7 @@ mod tests {
     use crate::LixError;
     use crate::changelog::{COMMIT_SPACE, ChangeId, CommitId, CommitRecord};
     use crate::common::LixTimestamp;
+    use crate::tracked_state::types::CurrentStatePartSource;
     use crate::entity_pk::EntityPk;
     use crate::storage_adapter::{
         Memory, StorageAdapter, StorageReadOptions, StorageSpace, StorageWriteOptions,
@@ -13796,17 +13801,12 @@ mod tests {
             first_key: rows[0].encoded_key.clone(),
             last_key: rows[1].encoded_key.clone(),
             content_digest: [7; 32],
-            payload_refs_digest: [8; 32],
-            source_kind: 1,
-            source_id: [0; 16],
-            owner_commit_id: [0; 16],
-            part_index: 0,
-            source_page_index: 0,
+            source: CurrentStatePartSource::NativeDataPart {
+                payload_refs_digest: [8; 32],
+            },
             source_row_offset: 4,
             row_count: 2,
             fragmented: false,
-            uniform_created_at: LixTimestamp::from_unix_millis_utc_lossy(0),
-            uniform_updated_at: LixTimestamp::from_unix_millis_utc_lossy(0),
         };
         let mutations = rows
             .iter()
@@ -13836,7 +13836,10 @@ mod tests {
             1,
             "adjacent updates must remain one native run"
         );
-        assert_eq!(output[0].source_kind, 1);
+        assert!(matches!(
+            output[0].source,
+            CurrentStatePartSource::NativeDataPart { .. }
+        ));
         assert_eq!(output[0].row_count, 2);
         let bytes = writes
             .staged_value(CURRENT_STATE_DATA_PART_SPACE, &output[0].content_digest)
@@ -13858,7 +13861,10 @@ mod tests {
         )
         .expect("one native update should retain a source slice");
         assert_eq!(output.len(), 2);
-        assert_eq!(output[1].source_kind, 1);
+        assert!(matches!(
+            output[1].source,
+            CurrentStatePartSource::NativeDataPart { .. }
+        ));
         assert_eq!(output[1].source_row_offset, 5);
         assert_eq!(output[1].row_count, 1);
 
@@ -13893,17 +13899,12 @@ mod tests {
             first_key: alternating_rows[0].encoded_key.clone(),
             last_key: alternating_rows.last().unwrap().encoded_key.clone(),
             content_digest: [9; 32],
-            payload_refs_digest: [10; 32],
-            source_kind: 1,
-            source_id: [0; 16],
-            owner_commit_id: [0; 16],
-            part_index: 0,
-            source_page_index: 0,
+            source: CurrentStatePartSource::NativeDataPart {
+                payload_refs_digest: [10; 32],
+            },
             source_row_offset: 0,
             row_count: alternating_rows.len() as u16,
             fragmented: false,
-            uniform_created_at: LixTimestamp::from_unix_millis_utc_lossy(0),
-            uniform_updated_at: LixTimestamp::from_unix_millis_utc_lossy(0),
         };
         let alternating_mutations = alternating_rows
             .iter()
@@ -13946,17 +13947,12 @@ mod tests {
                     first_key: key.clone(),
                     last_key: key,
                     content_digest: *blake3::hash(&index.to_be_bytes()).as_bytes(),
-                    payload_refs_digest: [8; 32],
-                    source_kind: 1,
-                    source_id: [0; 16],
-                    owner_commit_id: [0; 16],
-                    part_index: 0,
-                    source_page_index: 0,
+                    source: CurrentStatePartSource::NativeDataPart {
+                        payload_refs_digest: [8; 32],
+                    },
                     source_row_offset: 0,
                     row_count: 1,
                     fragmented,
-                    uniform_created_at: LixTimestamp::from_unix_millis_utc_lossy(0),
-                    uniform_updated_at: LixTimestamp::from_unix_millis_utc_lossy(0),
                 },
             )
             .unwrap()
@@ -18259,8 +18255,6 @@ mod tests {
             changed_key_count: 1,
             row_count_estimate: 1,
             tree_height: 1,
-            primary_chunk_count: 1,
-            primary_chunk_bytes: 64,
         };
         let mut writes = storage.new_write_set();
         manifest.snapshot_root = Some(Box::new(authoritative.clone()));
@@ -18326,8 +18320,6 @@ mod tests {
             changed_key_count: 1,
             row_count_estimate: 1,
             tree_height: 1,
-            primary_chunk_count: 1,
-            primary_chunk_bytes: 64,
         };
         original.snapshot_root = Some(Box::new(rebuilt));
         let error = encode_commit_state_manifest(&original)

--- a/packages/lix/src/tracked_state/types.rs
+++ b/packages/lix/src/tracked_state/types.rs
@@ -154,25 +154,6 @@ pub(crate) struct TrackedStateCommitRoot {
     pub(crate) changed_key_count: u64,
     pub(crate) row_count_estimate: u64,
     pub(crate) tree_height: u32,
-    pub(crate) primary_chunk_count: u64,
-    pub(crate) primary_chunk_bytes: u64,
-}
-
-impl TrackedStateCommitRoot {
-    /// Compares immutable serving identity and shape.
-    ///
-    /// Primary chunk counts and bytes describe the publication path's staged
-    /// writes. A rebuild can reach the same content-addressed root through a
-    /// different sequence of intermediate chunks, so those original metrics
-    /// remain manifest-owned accounting rather than rebuilt root identity.
-    pub(crate) fn has_same_authoritative_layout(&self, other: &Self) -> bool {
-        self.commit_id == other.commit_id
-            && self.root_id == other.root_id
-            && self.parent_roots == other.parent_roots
-            && self.changed_key_count == other.changed_key_count
-            && self.row_count_estimate == other.row_count_estimate
-            && self.tree_height == other.tree_height
-    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, musli::Encode, musli::Decode)]
@@ -298,22 +279,9 @@ pub(crate) struct CurrentStatePartDescriptor {
     #[musli(bytes)]
     pub(crate) last_key: Vec<u8>,
     pub(crate) content_digest: [u8; 32],
-    /// Digest of the native part's compact JSON-reference summary. Zero for
-    /// complete-replacement sources whose history authority owns reachability.
-    pub(crate) payload_refs_digest: [u8; 32],
-    /// 0 references an immutable complete-replacement mutation part; 1
-    /// references a native content-addressed current-state data part; 2
-    /// references one authenticated page in a canonical entity row-group set.
-    pub(crate) source_kind: u8,
-    /// Physical immutable source generation. Zero for replacement/native
-    /// sources; the exact row-group-set ID for columnar pages.
-    pub(crate) source_id: [u8; 16],
-    pub(crate) owner_commit_id: [u8; 16],
-    /// Replacement segment index or columnar row-group index. Zero for native
-    /// current-state data parts.
-    pub(crate) part_index: u32,
-    /// Columnar page index inside `part_index`. Zero for other source kinds.
-    pub(crate) source_page_index: u16,
+    /// Which physical source serves this range, plus that source's own
+    /// addressing fields.
+    pub(crate) source: CurrentStatePartSource,
     /// First physical row selected from the source part. Descriptor slicing
     /// allows sparse deletes and updates to retain untouched source bytes.
     pub(crate) source_row_offset: u16,
@@ -322,6 +290,53 @@ pub(crate) struct CurrentStatePartDescriptor {
     /// sparse rewrite. Canonical encodes clear this bit, making compaction
     /// self-stabilizing without guessing from physical row density.
     pub(crate) fragmented: bool,
+}
+
+/// Physical source of one current-state part, with the addressing fields that
+/// source actually uses.
+///
+/// This was previously a `source_kind: u8` discriminator beside the union of
+/// every kind's fields, so each locator carried the other kinds' fields pinned
+/// to zero and a hand-written validator re-proved that pinning on every
+/// decode. Per-variant fields make those combinations unrepresentable instead
+/// of merely rejected, and stop the unused fields from being encoded at all.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, musli::Encode, musli::Decode)]
+pub(crate) enum CurrentStatePartSource {
+    /// An immutable complete-replacement mutation part owned by one commit.
+    Replacement(ReplacementPartSource),
+    /// A native content-addressed current-state data part. The part's own rows
+    /// carry per-row authorship, so the locator has no uniform timestamps and
+    /// no owning commit; reachability is proved by the refs summary instead.
+    NativeDataPart {
+        /// Digest of the part's compact JSON-reference summary.
+        payload_refs_digest: [u8; 32],
+    },
+    /// One authenticated page in a canonical entity row-group set.
+    ColumnarPage(ColumnarPageSource),
+}
+
+/// Addressing for a replacement-part source.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, musli::Encode, musli::Decode)]
+#[musli(packed)]
+pub(crate) struct ReplacementPartSource {
+    pub(crate) owner_commit_id: [u8; 16],
+    /// Replacement segment index within the owner commit.
+    pub(crate) part_index: u32,
+    pub(crate) uniform_created_at: LixTimestamp,
+    pub(crate) uniform_updated_at: LixTimestamp,
+}
+
+/// Addressing for one page of a canonical entity row-group set.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, musli::Encode, musli::Decode)]
+#[musli(packed)]
+pub(crate) struct ColumnarPageSource {
+    /// Physical immutable row-group-set id.
+    pub(crate) source_id: [u8; 16],
+    pub(crate) owner_commit_id: [u8; 16],
+    /// Row-group index within the set.
+    pub(crate) part_index: u32,
+    /// Page index inside `part_index`.
+    pub(crate) source_page_index: u16,
     pub(crate) uniform_created_at: LixTimestamp,
     pub(crate) uniform_updated_at: LixTimestamp,
 }
@@ -662,35 +677,4 @@ pub(crate) struct TrackedStateTreeDiffEntry {
     pub(crate) key: TrackedStateKey,
     pub(crate) before: Option<TrackedStateIndexValue>,
     pub(crate) after: Option<TrackedStateIndexValue>,
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    fn commit_root() -> TrackedStateCommitRoot {
-        TrackedStateCommitRoot {
-            commit_id: CommitId::parse_lix("01920000-0000-7000-8000-000000000001", "test commit")
-                .expect("test commit id should parse"),
-            root_id: TrackedStateRootId::new([1; 32]),
-            parent_roots: Vec::new(),
-            changed_key_count: 3,
-            row_count_estimate: 7,
-            tree_height: 1,
-            primary_chunk_count: 2,
-            primary_chunk_bytes: 128,
-        }
-    }
-
-    #[test]
-    fn authoritative_layout_excludes_publication_write_accounting() {
-        let expected = commit_root();
-        let mut rebuilt = expected.clone();
-        rebuilt.primary_chunk_count = 5;
-        rebuilt.primary_chunk_bytes = 512;
-        assert!(expected.has_same_authoritative_layout(&rebuilt));
-
-        rebuilt.root_id = TrackedStateRootId::new([2; 32]);
-        assert!(!expected.has_same_authoritative_layout(&rebuilt));
-    }
 }


### PR DESCRIPTION
## What

`packages/lix/src/tracked_state/current_state_envelope.rs` encoded the current-state part locator as a **flattened tagged union**: a `source_kind: u8` discriminator beside the union of all three kinds' addressing fields. Every locator therefore carried the *other* kinds' fields pinned to zero, and `validate_current_state_descriptor` re-proved that pinning on every decode:

```rust
|| (descriptor.source_kind == 0
    && (descriptor.source_id != [0; 16]
        || descriptor.source_page_index != 0
        || descriptor.owner_commit_id == [0; 16]
        || descriptor.payload_refs_digest != [0; 32]))
```

That validator was the proof of the defect: fifteen lines whose entire job was re-establishing an invariant the type could have carried itself.

The discriminator and its fields are now `CurrentStatePartSource` — a real enum whose three variants (`Replacement`, `NativeDataPart`, `ColumnarPage`) carry exactly the fields their source uses.

**The correctness win outranks the bytes.** The zero-checking did not get rewritten, it got deleted: those field combinations are no longer representable. The two `_ => "unknown source kind"` error arms in the GC reachability sweeps went with it, because the match is now exhaustive by construction. Every read site that previously filtered on `source_kind == N` and then read fields the filter had *implied* were valid now binds them from the variant, so the implication is checked by the compiler instead of by the reader.

What is left in the validator is genuine content validation: key bounds, the source's physical row bound, and identifiers that must be present.

## Bytes

Secondary, but real. Measured through the actual codec by `locator_payload_spends_no_bytes_on_other_kinds_fields` — the same locator, encoded both ways, with realistic timestamps and indices:

| source kind | v3 | v4 | delta |
| --- | --- | --- | --- |
| replacement | 121 B | 72 B | −49 B (−40.5%) |
| native data part | 107 B | 71 B | −36 B (−33.6%) |
| columnar page | 121 B | 90 B | −31 B (−25.6%) |

These payloads are embedded per part in `StoredScopedRangePart` inside serving-tree leaf nodes and are decoded on every scoped-range read, so the win is **fewer bytes fetched and decoded per node touched**.

**It is not a denser tree.** `const FANOUT: usize = 128` in `scoped_range.rs` is an entry count, not a byte budget. Tree height and the number of node fetches are unchanged. I did not claim otherwise and the tempting version of that claim is false here.

**What I did not establish:** a repository-level aggregate on a real fixture. A scratch probe that built repositories through the public engine API and summed `SCOPED_RANGE_NODE_SPACE` reported zero nodes under every shape I tried (with and without checkpoints, 2k and 32k rows) — the scoped-range serving tree did not publish for those fixtures, so the probe measured nothing rather than measuring a small number. The per-locator figures above are exact and deterministic; the fleet-level total they roll up to is not measured here.

## Folded in

One `REPOSITORY_PROTOCOL_VALUE` bump carries any number of format changes, so two adjacent items ride along:

- **Dropped `primary_chunk_count` / `primary_chunk_bytes` from `TrackedStateCommitRoot`.** They were excluded from `has_same_authoritative_layout` as manifest-owned publication accounting. I re-ran the sweep: every non-construction read in `packages/` is a test assertion — `context.rs` (2), `types.rs` (1). No production reader. With them gone, `has_same_authoritative_layout` compared *every* remaining field, so it was exactly `==`; the method and its now-vacuous test are replaced by `==` at its one call site in `commit_root_rebuild.rs`. `row_count_estimate` drives a compaction heuristic and **stays**.
- **Fixed a wrong doc comment** above `encode_scope_prefix` in `hot_state/tracked_head.rs`. It documented the hot row key as `(branch, generation, schema, entity, file)`, but `encode_hot_row_key_parts` writes `schema_key`, then `write_file_id`, then `write_entity_pk` — file *before* entity. The code is self-consistent; the comment was wrong, and it is a comment a future layout change would be read for.

## Format break — gating

Every storage record here is `#[musli(packed)]`: positional, untagged, no "field missing" state a reader can observe, and `storage_codec::decode` rejects trailing bytes.

- `REPOSITORY_PROTOCOL_VALUE` → `tracked-default-branch.v68`, so `Engine::new` **rejects** an older repository rather than degrading.
- The locator codec also self-versions: `LOCATOR_PAYLOAD_VERSION` 3 → 4, and `stale_payload_version_is_refused_before_decoding` asserts a v3 part is refused before its bytes reach a decoder.
- **I did not reason from the derive.** `v3_readers_and_v4_records_are_mutually_undecodable` defines the actual v3-arity struct and runs it: a v3 reader against a v4 record of each of the three kinds, and a v4 reader against a v3 record. Both directions must error.
- `locator_round_trips_every_source_kind` covers the new codec end to end.

## Gate

Re-derived from this sha's `ci.yml` (the `lix_e2e` feature list is `sdk-tests,plugin-tests,server-protocol,storage-benches,slatedb,root-replay-trace`).

```
git rev-parse HEAD                404ac56caa6d12b3b68a6c6de034244a9c0a4e56
git status --porcelain            (empty, before and after)
CI_SCOPE_CONFIRMED_AT             404ac56caa6d12b3b68a6c6de034244a9c0a4e56
EXECUTED_TARGETS  test1=3433 passed / 0 failed / 28 ignored across 38 targets
                  test2=172  passed / 0 failed / 37 ignored across 27 targets
```

clippy `--profile test --workspace --all-targets --all-features -- -D warnings`: 0 warnings.
`cargo check -p lix --no-default-features`: ok. `cargo check -p lix_js_sdk --target wasm32-unknown-unknown`: ok.

Draft, against `claude-7-optimizations`. Not self-merged.
