### PR TITLE
perf(lix): bound the lix_file RETURNING readback on file_id instead of entity_pk

### DIFF
--- a/packages/lix/src/hot_state/tracked_head/hot.rs
+++ b/packages/lix/src/hot_state/tracked_head/hot.rs
@@ -11651,6 +11651,22 @@ async fn hot_scan_entries<'a>(
     let is_blob_ref_probe = filter.schema_keys.len() == 1
         && filter.schema_keys[0] == "lix_binary_blob_ref"
         && !filter.entity_pks.is_empty();
+    // Site A: the `scan_lix_file_live_batch` request shape. Keyed on the schema
+    // pair alone so the gate is arm-invariant.
+    #[cfg(feature = "storage-benches")]
+    let is_file_live_batch = filter.schema_keys.len() == 2
+        && filter
+            .schema_keys
+            .iter()
+            .any(|key| key == "lix_file_descriptor")
+        && filter
+            .schema_keys
+            .iter()
+            .any(|key| key == "lix_binary_blob_ref");
+    #[cfg(feature = "storage-benches")]
+    if is_file_live_batch {
+        crate::storage_bench::record_file_live_scan_call();
+    }
     #[cfg(feature = "storage-benches")]
     if is_blob_ref_probe {
         crate::storage_bench::record_hot_blob_ref_scan_call();
@@ -11664,6 +11680,10 @@ async fn hot_scan_entries<'a>(
             #[cfg(feature = "storage-benches")]
             if is_blob_ref_probe {
                 crate::storage_bench::record_hot_blob_ref_scan_point_batch();
+            }
+            #[cfg(feature = "storage-benches")]
+            if is_file_live_batch {
+                crate::storage_bench::record_file_live_scan_point_batch();
             }
             let entries = HotScanEntries::Finite(
                 hot_scan_finite_identity_batches(store, identities, limit).await?,
@@ -11680,6 +11700,10 @@ async fn hot_scan_entries<'a>(
         if is_blob_ref_probe {
             crate::storage_bench::record_hot_blob_ref_scan_file_prefix();
         }
+        #[cfg(feature = "storage-benches")]
+        if is_file_live_batch {
+            crate::storage_bench::record_file_live_scan_file_prefix();
+        }
         let entries = HotScanEntries::Decoded(
             scan_hot_file_entries(store, branch_id, generation, prefixes, filter, limit).await?,
         );
@@ -11689,6 +11713,10 @@ async fn hot_scan_entries<'a>(
     #[cfg(feature = "storage-benches")]
     if is_blob_ref_probe {
         crate::storage_bench::record_hot_blob_ref_scan_fallback();
+    }
+    #[cfg(feature = "storage-benches")]
+    if is_file_live_batch {
+        crate::storage_bench::record_file_live_scan_fallback();
     }
     let scope = hot_scope_prefix(branch_id, generation);
     let mut prefixes = hot_row_scan_prefixes(&scope, filter);
@@ -11730,6 +11758,12 @@ async fn hot_scan_entries<'a>(
                 #[cfg(feature = "storage-benches")]
                 if is_blob_ref_probe {
                     crate::storage_bench::record_hot_blob_ref_scan_entry(
+                        identity.matches_filter(filter),
+                    );
+                }
+                #[cfg(feature = "storage-benches")]
+                if is_file_live_batch {
+                    crate::storage_bench::record_file_live_scan_entry(
                         identity.matches_filter(filter),
                     );
                 }
@@ -12012,6 +12046,21 @@ async fn scan_hot_file_entries(
                 .await?.into_parts();
             for entry in page {
                 let identity = decode_hot_scan_row_key_in_scope(entry.key.0, &scope)?;
+                #[cfg(feature = "storage-benches")]
+                if filter.schema_keys.len() == 2
+                    && filter
+                        .schema_keys
+                        .iter()
+                        .any(|key| key == "lix_file_descriptor")
+                    && filter
+                        .schema_keys
+                        .iter()
+                        .any(|key| key == "lix_binary_blob_ref")
+                {
+                    crate::storage_bench::record_file_live_scan_entry(
+                        identity.matches_filter(filter),
+                    );
+                }
                 if identity.matches_filter(filter) {
                     rows.push((identity, full_value_bytes(entry.value)?));
                 }

--- a/packages/lix/src/sql2/providers/file.rs
+++ b/packages/lix/src/sql2/providers/file.rs
@@ -5908,10 +5908,47 @@ async fn scan_lix_file_live_batch(
         FILE_DESCRIPTOR_SCHEMA_KEY.to_string(),
         BLOB_REF_SCHEMA_KEY.to_string(),
     ];
-    file_request.filter.entity_pks = target_file_ids
+    // Bound this read on the file id, not the entity PK.
+    //
+    // The hot index key is file-first -- `scope(branch, generation) ++
+    // schema_key ++ file_id ++ entity_pk` -- so an entity PK on its own names
+    // neither a point key nor a prefix. With `entity_pks` set and `file_ids`
+    // empty, `hot_exact_identity_batches` returns a batch but
+    // `may_use_null_point_batch` refuses it (both schema keys here have
+    // file-backed members, and a null-file point key would miss the real row),
+    // `hot_file_scan_prefixes` declines for want of a file id, and the request
+    // lands on the widest arm: a full walk of every `lix_file_descriptor` and
+    // every `lix_binary_blob_ref` row in the branch, filtered in memory. That
+    // is O(files in branch) per statement.
+    //
+    // Pinning `file_ids` *instead of* `entity_pks` -- not in addition to --
+    // routes to `hot_file_scan_prefixes`, one tight `(branch, generation,
+    // schema_key, file_id)` prefix seek per target file. Adding the pin while
+    // keeping `entity_pks` would be much worse than the walk it replaces:
+    // `FiniteHotIdentityBatchRef::new` builds the *cross product*
+    // `entity_pks.len() * file_ids.len()`, so N target files would encode N^2
+    // point keys per schema key.
+    //
+    // Dropping `entity_pks` cannot widen the answer, because `file_id ==
+    // entity_pk` holds by construction for both of these schema keys:
+    // `transaction::normalization::canonicalize_descriptor_file_id` *derives*
+    // the descriptor row's `file_id` from its entity PK on every normalized
+    // write, and both `lix_binary_blob_ref` producers in `filesystem::planner`
+    // (`BlobRefRowInput::append_to` and `append_blob_ref_tombstone_row`,
+    // tombstones included) set the pair from one variable. Both surfaces are
+    // read-only, so no caller can supply a divergent pair.
+    // `scan_exact_file_blob_batch` below already pairs them the same way.
+    file_request.filter.entity_pks.clear();
+    file_request.filter.file_ids = target_file_ids
         .iter()
-        .map(|file_id| file_id_entity_pk(file_id))
-        .collect::<Result<Vec<_>, _>>()?;
+        .map(|file_id| crate::NullableKeyFilter::Value(file_id.clone()))
+        .collect();
+    // Preserve the canonical-UUID validation the entity-PK projection used to
+    // perform, so a malformed file id stays an error instead of becoming a
+    // silently empty answer.
+    for file_id in target_file_ids {
+        file_id_entity_pk(file_id)?;
+    }
 
     let file_rows = hot_state.scan_batch(&file_request).await?;
 

--- a/packages/lix/src/storage_bench.rs
+++ b/packages/lix/src/storage_bench.rs
@@ -3982,3 +3982,54 @@ pub fn take_hot_blob_ref_scan_accounting() -> (u64, u64, u64, u64, u64, u64) {
         HOT_BLOB_REF_SCAN_ENTRIES_MATCHED.swap(0, Ordering::Relaxed),
     )
 }
+
+static FILE_LIVE_SCAN_CALLS: AtomicU64 = AtomicU64::new(0);
+static FILE_LIVE_SCAN_POINT_BATCH: AtomicU64 = AtomicU64::new(0);
+static FILE_LIVE_SCAN_FILE_PREFIX: AtomicU64 = AtomicU64::new(0);
+static FILE_LIVE_SCAN_FALLBACK: AtomicU64 = AtomicU64::new(0);
+static FILE_LIVE_SCAN_ENTRIES_DECODED: AtomicU64 = AtomicU64::new(0);
+static FILE_LIVE_SCAN_ENTRIES_MATCHED: AtomicU64 = AtomicU64::new(0);
+
+pub(crate) fn record_file_live_scan_call() {
+    FILE_LIVE_SCAN_CALLS.fetch_add(1, Ordering::Relaxed);
+}
+
+pub(crate) fn record_file_live_scan_point_batch() {
+    FILE_LIVE_SCAN_POINT_BATCH.fetch_add(1, Ordering::Relaxed);
+}
+
+pub(crate) fn record_file_live_scan_file_prefix() {
+    FILE_LIVE_SCAN_FILE_PREFIX.fetch_add(1, Ordering::Relaxed);
+}
+
+pub(crate) fn record_file_live_scan_fallback() {
+    FILE_LIVE_SCAN_FALLBACK.fetch_add(1, Ordering::Relaxed);
+}
+
+pub(crate) fn record_file_live_scan_entry(matched: bool) {
+    FILE_LIVE_SCAN_ENTRIES_DECODED.fetch_add(1, Ordering::Relaxed);
+    if matched {
+        FILE_LIVE_SCAN_ENTRIES_MATCHED.fetch_add(1, Ordering::Relaxed);
+    }
+}
+
+/// Accounting for the two-schema `scan_lix_file_live_batch` read that every
+/// `lix_file ... RETURNING` statement issues:
+/// `(calls, point_batch, file_prefix, fallback, entries_decoded, entries_matched)`.
+///
+/// The engagement gate is the request's schema-key pair, which is identical in
+/// both arms, so a zero reads as "this route did not run" and never as "the
+/// counter did not run". Entries are counted at BOTH per-entry decode loops --
+/// the wide arm's in `hot_scan_entries` and the prefix arm's in
+/// `scan_hot_file_entries` -- because counting only the wide arm would make a
+/// seek indistinguishable from a census that never fired.
+pub fn take_file_live_scan_accounting() -> (u64, u64, u64, u64, u64, u64) {
+    (
+        FILE_LIVE_SCAN_CALLS.swap(0, Ordering::Relaxed),
+        FILE_LIVE_SCAN_POINT_BATCH.swap(0, Ordering::Relaxed),
+        FILE_LIVE_SCAN_FILE_PREFIX.swap(0, Ordering::Relaxed),
+        FILE_LIVE_SCAN_FALLBACK.swap(0, Ordering::Relaxed),
+        FILE_LIVE_SCAN_ENTRIES_DECODED.swap(0, Ordering::Relaxed),
+        FILE_LIVE_SCAN_ENTRIES_MATCHED.swap(0, Ordering::Relaxed),
+    )
+}

--- a/packages/lix/tests/integration/lix_file_returning_route.rs
+++ b/packages/lix/tests/integration/lix_file_returning_route.rs
@@ -1,0 +1,244 @@
+//! Site A: the `lix_file ... RETURNING` readback route.
+//!
+//! `returning_post_image` reloads the just-staged rows through
+//! `scan_lix_file_live_batch`. It is the one caller that reaches that function
+//! with `FileIdConstraint::Ids` and no path index, so it is the only caller
+//! whose readback can degrade to a full branch walk.
+
+use lix::integration::Engine;
+use lix::storage::Memory;
+use lix::storage_bench::take_file_live_scan_accounting;
+use lix::Value;
+
+async fn seed(files: usize) -> lix::integration::SessionContext<Memory> {
+    let storage = Memory::new();
+    Engine::initialize(storage.clone())
+        .await
+        .expect("storage should initialize");
+    let engine = Engine::new(storage.clone())
+        .await
+        .expect("engine should open");
+    let session = engine.open_session().await.expect("session should open");
+    for chunk_start in (0..files).step_by(500) {
+        let values = (chunk_start..(chunk_start + 500).min(files))
+            .map(|i| format!("('/seed-{i:08}.bin', CAST('byte-00' AS BYTEA))"))
+            .collect::<Vec<_>>()
+            .join(",");
+        session
+            .execute(
+                &format!("INSERT INTO lix_file (path, content) VALUES {values}"),
+                &[],
+            )
+            .await
+            .expect("seed insert should succeed");
+    }
+    session
+}
+
+fn text(value: &Value) -> String {
+    match value {
+        Value::Text(text) => text.clone(),
+        other => panic!("expected text, got {other:?}"),
+    }
+}
+
+/// Decoded entries per answer row, swept over branch size.
+///
+/// This is a *count*, not a timing: it is deterministic, so one rep settles it,
+/// and it cannot be confused by scheduler noise. The counters sit at both
+/// per-entry decode loops (`hot_scan_entries`' wide arm and
+/// `scan_hot_file_entries`' prefix arm), so a low number here means "few rows
+/// were decoded", never "the census did not run" -- the route counters prove
+/// separately which arm executed.
+#[tokio::test(flavor = "current_thread")]
+async fn returning_readback_decodes_a_bounded_number_of_entries() {
+    let mut observed = Vec::new();
+    for &files in &[250_usize, 500, 1000] {
+        let session = seed(files).await;
+        let id = text(
+            &session
+                .execute("SELECT id FROM lix_file WHERE path = '/seed-00000007.bin'", &[])
+                .await
+                .expect("target file should resolve")
+                .rows()[0]
+                .values()[0],
+        );
+
+        // Drain anything the seed produced so the measurement is this
+        // statement's alone.
+        let _ = take_file_live_scan_accounting();
+
+        session
+            .execute(
+                &format!(
+                    "UPDATE lix_file SET content = CAST('byte-01' AS BYTEA) \
+                     WHERE id = '{id}' RETURNING id, path"
+                ),
+                &[],
+            )
+            .await
+            .expect("returning update should succeed");
+
+        let (calls, point_batch, file_prefix, fallback, decoded, matched) =
+            take_file_live_scan_accounting();
+
+        assert!(
+            calls > 0,
+            "the RETURNING readback must reach scan_lix_file_live_batch; \
+             a zero here means the lane never executed and every other \
+             number below is vacuous"
+        );
+        assert_eq!(
+            matched, 2,
+            "one descriptor + one blob ref should survive the filter at {files} files"
+        );
+        observed.push((files, calls, point_batch, file_prefix, fallback, decoded));
+        session.close().await.expect("session should close");
+    }
+
+    for &(files, calls, point_batch, file_prefix, fallback, decoded) in &observed {
+        println!(
+            "files={files} calls={calls} point_batch={point_batch} \
+             file_prefix={file_prefix} fallback={fallback} decoded={decoded}"
+        );
+    }
+
+    // Routing, positively: the pinned request must take the file-prefix arm and
+    // must NOT take the widest arm. Asking which symbol is *missing* is the
+    // attribution -- a fallback of zero is what the unpinned request could
+    // never produce.
+    for &(files, _, _, file_prefix, fallback, _) in &observed {
+        assert!(
+            file_prefix > 0,
+            "at {files} files the pinned request should resolve as a file prefix seek"
+        );
+        assert_eq!(
+            fallback, 0,
+            "at {files} files the request still fell through to the full branch walk"
+        );
+    }
+
+    // The slope is the claim. Decoded entries must not grow with branch size.
+    let smallest = observed.first().expect("swept at least one size").5;
+    let largest = observed.last().expect("swept at least one size").5;
+    assert!(
+        largest <= smallest * 2,
+        "decoded entries grew with branch size ({observed:?}); the read is still O(files)"
+    );
+}
+
+/// The pin must not narrow the answer.
+///
+/// The oracle is the **unfiltered** read. `SELECT * FROM lix_file` resolves no
+/// target ids at all, so `scan_lix_file_live_batch` takes its
+/// `FileIdConstraint::All` early return and structurally cannot execute the
+/// pin. Every `RETURNING` post-image must agree with it.
+///
+/// The shapes are the ones that could plausibly carry a null or divergent
+/// `file_id`: an insert with **no explicit id**, where the planner really does
+/// stage the descriptor with `file_id: None` and only
+/// `canonicalize_descriptor_file_id` fills it in; a rename, which rewrites the
+/// descriptor without touching content; a content clear, which tombstones the
+/// blob ref while the descriptor survives; a delete, which tombstones both; and
+/// a recreation at the same path under a **different** id.
+#[tokio::test(flavor = "current_thread")]
+async fn pinned_returning_readback_agrees_with_the_unfiltered_read() {
+    let session = seed(8).await;
+
+    async fn check(
+        session: &lix::integration::SessionContext<Memory>,
+        id: &str,
+        path: &str,
+    ) {
+        let oracle = session
+            .execute("SELECT id, path FROM lix_file", &[])
+            .await
+            .expect("unfiltered read should succeed");
+        let found = oracle
+            .rows()
+            .iter()
+            .find(|row| text(&row.values()[0]) == id)
+            .map(|row| text(&row.values()[1]));
+        assert_eq!(
+            found.as_deref(),
+            Some(path),
+            "RETURNING post-image disagreed with the unfiltered read for {id}"
+        );
+    }
+
+    // 1. Insert with no explicit id.
+    let inserted = session
+        .execute(
+            "INSERT INTO lix_file (path, content) VALUES ('/oracle/minted.md', \
+             CAST('v0' AS BYTEA)) RETURNING id, path",
+            &[],
+        )
+        .await
+        .expect("id-less insert should return its post-image");
+    let minted = text(&inserted.rows()[0].values()[0]);
+    assert_eq!(text(&inserted.rows()[0].values()[1]), "/oracle/minted.md");
+    check(&session, &minted, "/oracle/minted.md").await;
+
+    // 2. Rename: descriptor rewrite, no content change.
+    let renamed = session
+        .execute(
+            &format!(
+                "UPDATE lix_file SET path = '/oracle/renamed.md' WHERE id = '{minted}' \
+                 RETURNING id, path"
+            ),
+            &[],
+        )
+        .await
+        .expect("rename should return its post-image");
+    assert_eq!(text(&renamed.rows()[0].values()[1]), "/oracle/renamed.md");
+    check(&session, &minted, "/oracle/renamed.md").await;
+
+    // 3. Content clear: blob-ref tombstone, descriptor survives.
+    let cleared = session
+        .execute(
+            &format!(
+                "UPDATE lix_file SET content = CAST('' AS BYTEA) WHERE id = '{minted}' \
+                 RETURNING id, path"
+            ),
+            &[],
+        )
+        .await
+        .expect("content clear should return its post-image");
+    assert_eq!(cleared.rows().len(), 1, "content clear should return one row");
+    check(&session, &minted, "/oracle/renamed.md").await;
+
+    // 4. Delete: tombstones both rows.
+    let deleted = session
+        .execute(
+            &format!("DELETE FROM lix_file WHERE id = '{minted}' RETURNING id"),
+            &[],
+        )
+        .await
+        .expect("delete should return its pre-image");
+    assert_eq!(text(&deleted.rows()[0].values()[0]), minted);
+    let after = session
+        .execute("SELECT id FROM lix_file", &[])
+        .await
+        .expect("unfiltered read should succeed");
+    assert!(
+        !after.rows().iter().any(|row| text(&row.values()[0]) == minted),
+        "deleted file should be absent from the unfiltered read"
+    );
+
+    // 5. Recreation at the same path under a different id, so a path lookup
+    //    resolves two ids over history and per-file discrimination must be
+    //    exact rather than vacuous.
+    let recreated = session
+        .execute(
+            "INSERT INTO lix_file (path, content) VALUES ('/oracle/renamed.md', \
+             CAST('v9' AS BYTEA)) RETURNING id, path",
+            &[],
+        )
+        .await
+        .expect("recreation should return its post-image");
+    let second = text(&recreated.rows()[0].values()[0]);
+    assert_ne!(second, minted, "recreation should mint a fresh id");
+    check(&session, &second, "/oracle/renamed.md").await;
+
+    session.close().await.expect("session should close");
+}

--- a/packages/lix/tests/integration/main.rs
+++ b/packages/lix/tests/integration/main.rs
@@ -16,6 +16,7 @@ mod execute_batch_benchmark;
 mod filesystem_fuzz;
 mod fs_api;
 mod json_pointer_crud_storage;
+mod lix_file_returning_route;
 mod merge_fuzz;
 mod observe;
 mod observe_mutation_revision;


### PR DESCRIPTION
## What

`returning_post_image` reloads the just-staged rows for a `lix_file`
`INSERT`/`UPDATE`/`DELETE … RETURNING`. Its request set `entity_pks` and left
`file_ids` empty. The hot index key is **file-first** —
`scope(branch, generation) ++ schema_key ++ file_id ++ entity_pk` — so an entity
PK on its own names neither a point key nor a prefix:

- `hot_exact_identity_batches` returns a batch, but `may_use_null_point_batch`
  refuses it (both schema keys here have file-backed members, and a null-file
  point key would miss the real row);
- `hot_file_scan_prefixes` declines for want of a file id;
- so the read fell through to the widest arm — a full walk of **every**
  `lix_file_descriptor` and **every** `lix_binary_blob_ref` row in the branch,
  filtered in memory. O(files in branch), per statement.

This pins `file_ids` and **clears** `entity_pks`, routing to
`hot_file_scan_prefixes`: one tight `(branch, generation, schema_key, file_id)`
prefix seek per target file.

## Scope — narrower than "the read path"

This is a **`RETURNING`-path defect**, not a general read-path one.
`scan_lix_file_live_batch` has four callers; three already divert
`FileIdConstraint::Ids` to `scan_exact_file_blob_batch`, which pairs the entity
PK with its file id correctly. `returning_post_image` is the only caller that
reaches it with `Ids` and no path index, because it passes `None` for
`indexed_matches` explicitly.

## The pin replaces `entity_pks` — it does not join it

Adding `file_ids` while keeping `entity_pks` would be **much worse than the walk
it replaces**. `FiniteHotIdentityBatchRef::new` builds the *cross product*:

```rust
let identity_count = entity_pks.len().checked_mul(file_ids.len())?;
```

N target files would encode N² point keys per schema key. The reference fix
`0b97f3c45` was safe only because it was single-entity (1×1). This is a batch.

## Why dropping `entity_pks` cannot widen the answer

`file_id == entity_pk` holds **by construction** for both schema keys:

- `lix_file_descriptor` — `transaction::normalization::canonicalize_descriptor_file_id`
  *derives* the row's `file_id` from its entity PK on every normalized write.
  This is enforcement, not a coincidence of producers agreeing.
- `lix_binary_blob_ref` — both producers in `filesystem::planner`
  (`BlobRefRowInput::append_to` and `append_blob_ref_tombstone_row`, tombstones
  included) set the pair from one variable.

Both surfaces are read-only, so no caller can supply a divergent pair, and
`scan_exact_file_blob_batch` already relies on the same equality. Same invariant
and same two schema keys as the already-shipped `910608a07`.

The canonical-UUID validation that the entity-PK projection performed is
**retained explicitly**, so a malformed file id stays an error rather than
becoming a silently empty answer.

## Evidence — a slope, not a delta

Decoded entries counted at the **per-entry decode loop**, swept over branch size.
Deterministic counts, so one rep settles it.

| files in branch | arm | route | decoded entries | answer rows |
|---|---|---|---|---|
| 250 | before | `fallback` | 500 | 2 |
| 500 | before | `fallback` | 1000 | 2 |
| 1000 | before | `fallback` | 2000 | 2 |
| 250 | after | `file_prefix` | **2** | 2 |
| 500 | after | `file_prefix` | **2** | 2 |
| 1000 | after | `file_prefix` | **2** | 2 |

Before: exactly `2 × files` decoded — 1000 decoded entries per answer row at
1000 files, growing without bound. After: **flat at 2**, i.e. 1.0 decoded
entries per answer row at every size.

Routing is attributed **positively and by absence**: after the change
`file_prefix > 0` and `fallback == 0`. A zero fallback is precisely what the
unpinned request could never produce.

## On the census

The existing `0b97f3c45` counters **cannot see this route** — their gate requires
a single schema key (`lix_binary_blob_ref`) and a non-empty `entity_pks`, and
this request carries two schema keys. Reusing them would have reported zero
decoded entries in *both* arms: a clean-looking win over a route never observed.

So the new census gates on the **schema-key pair alone**, which is deliberately
arm-invariant (the candidate empties `entity_pks`, the baseline empties
`file_ids`). And it counts at **both** per-entry decode loops — the wide arm in
`hot_scan_entries` *and* the prefix arm in `scan_hot_file_entries` — because with
only the wide arm instrumented a successful seek reads identically to a census
that never fired. Both zeros, indistinguishable.

## Tests

- **Oracle** — the unfiltered read is the oracle: `SELECT * FROM lix_file`
  resolves no target ids, so `scan_lix_file_live_batch` takes its
  `FileIdConstraint::All` early return and *structurally cannot execute the pin*.
  Covers id-less insert (where the planner really does stage the descriptor with
  `file_id: None`), rename, content clear, delete, and same-path recreation under
  a different id. Passes on **both** arms, as an invariant test should.
- **Engagement** — the table above. **Fails on the unpinned tree** (`fallback=1`,
  `decoded=2000`).

## Format

No format change, no protocol bump, no new persisted bytes, no write-path change.
The diff touches a read request's filter, a census, and tests.
