### PR TITLE
bench: hot-generation retire locality census (and the NO-GO it produced)

### DIFF
--- a/packages/e2e/Cargo.toml
+++ b/packages/e2e/Cargo.toml
@@ -106,6 +106,18 @@ path = "examples/expab_plan_load.rs"
 required-features = ["storage-benches", "slatedb"]
 
 [[example]]
+name = "e53_hot_locality"
+required-features = ["storage-benches"]
+
+[[example]]
+name = "e53_write_amplification"
+required-features = ["storage-benches"]
+
+[[example]]
+name = "e53_hot_locality_slatedb"
+required-features = ["storage-benches", "slatedb"]
+
+[[example]]
 name = "space_growth"
 path = "examples/space_growth.rs"
 required-features = ["storage-benches"]

--- a/packages/e2e/examples/e53_hot_locality.rs
+++ b/packages/e2e/examples/e53_hot_locality.rs
@@ -1,0 +1,227 @@
+//! Does retiring a *fixed* amount of hot-generation garbage cost more as the
+//! repository grows?
+//!
+//! All ~41 storage spaces share one flat physical keyspace: `encode_physical_key`
+//! writes a four-byte space id in front of every logical key, and on RocksDB
+//! every mutable space lives in one column family. So the space id is the
+//! outermost sort dimension of the whole store, and the eight
+//! `GENERATION_SCOPED_SPACES` that make up one branch generation's serving
+//! planes sit in eight regions separated by the entire contents of the
+//! intervening spaces.
+//!
+//! `stage_retire_hot_generation` therefore performs eight independent prefix
+//! seeks to retire one generation. This example measures what those eight seeks
+//! cost, and whether that cost grows with total repository size.
+//!
+//! Two probes per checkpoint:
+//!
+//! * `phantom` -- the same eight scans against a generation uuid no row can
+//!   carry. Garbage is exactly zero by construction, so every block the engine
+//!   fetches is the fixed cost of *positioning* eight iterators. This is the
+//!   falsifiable curve: fix the garbage at zero, grow the repository, and see
+//!   whether the cost moves.
+//! * `live` -- the same eight scans against the branch's live generation, which
+//!   is also the multi-plane hot read over ROW/FILE/INDEX/PACKED_CURRENT_BASE
+//!   for one `(branch, generation)`.
+//!
+//! Block fetches are counted with RocksDB's thread-local perf context, which is
+//! why this runs on a `current_thread` runtime.
+//!
+//! Usage: `e53_hot_locality [rows_per_commit] [checkpoint...]`
+//! Default checkpoints: 25 50 100 200 400 800.
+
+use lix::Value;
+use lix::integration::{Engine, SessionContext};
+use lix::storage::Storage;
+use lix::storage_adapter::{StorageAdapter, StorageReadOptions};
+use lix::storage_bench::{hot_generation_branches, layout_accounting, probe_hot_generation_planes};
+use lix_storage_rocksdb::{BlockFetchCounters, PerfProbe, RocksDB};
+
+const PROBE_REPS: usize = 3;
+
+#[tokio::main(flavor = "current_thread")]
+async fn main() {
+    let mut args = std::env::args().skip(1);
+    let rows_per_commit = args
+        .next()
+        .and_then(|value| value.parse::<usize>().ok())
+        .unwrap_or(10);
+    let mut checkpoints = args
+        .filter_map(|value| value.parse::<usize>().ok())
+        .collect::<Vec<_>>();
+    if checkpoints.is_empty() {
+        checkpoints = vec![25, 50, 100, 200, 400, 800];
+    }
+    checkpoints.sort_unstable();
+
+    let directory = tempfile::tempdir().expect("create RocksDB directory");
+    let storage = RocksDB::open(directory.path()).expect("open RocksDB");
+    Engine::initialize(storage.clone())
+        .await
+        .expect("initialize repository");
+    let engine = Engine::new(storage.clone()).await.expect("open engine");
+    let session = engine.open_session().await.expect("open workspace");
+    register_schema(&session).await;
+
+    let mut perf = PerfProbe::new();
+
+    let branch = pick_branch(&storage).await;
+    println!(
+        "e53_hot_locality rows_per_commit={rows_per_commit} probe_reps={PROBE_REPS} branch={branch}"
+    );
+    println!(
+        "{:>8} {:>12} {:>13} {:>6} {:>8} {:>10} {:>10} {:>12} {:>12} {:>12}",
+        "commits",
+        "store_rows",
+        "store_bytes",
+        "probe",
+        "deleted",
+        "fetches",
+        "reads",
+        "read_bytes",
+        "key_cmps",
+        "nanos",
+    );
+
+    let mut committed = 0usize;
+    for checkpoint in checkpoints {
+        while committed < checkpoint {
+            commit_batch(&session, committed, rows_per_commit).await;
+            committed += 1;
+        }
+        // Retire measurements must see SSTs, not a memtable.
+        storage.flush().expect("flush rocksdb");
+
+        let (store_rows, store_bytes) = store_size(&storage).await;
+
+        for (label, phantom) in [("phantom", true), ("live", false)] {
+            let mut last = (0_u64, 0_u64, BlockFetchCounters::default());
+            let mut per_space = Vec::new();
+            for _ in 0..PROBE_REPS {
+                let adapter = StorageAdapter::new(storage.clone());
+                let read = adapter
+                    .begin_read(StorageReadOptions::default())
+                    .await
+                    .expect("open storage snapshot");
+                perf.reset();
+                let probe = probe_hot_generation_planes(&read, &branch, phantom)
+                    .await
+                    .expect("probe hot generation planes");
+                let counters = perf.read();
+                drop(read);
+                last = (probe.deleted_rows, probe.total_nanos, counters);
+                per_space = probe.spaces;
+            }
+            let (deleted, nanos, counters) = last;
+            println!(
+                "{committed:>8} {store_rows:>12} {store_bytes:>13} {label:>6} {deleted:>8} {:>10} {:>10} {:>12} {:>12} {nanos:>12}",
+                counters.block_fetches(),
+                counters.block_reads,
+                counters.block_read_bytes,
+                counters.user_key_comparisons,
+            );
+            if label == "phantom" {
+                for space in &per_space {
+                    println!(
+                        "    space=0x{:08x} rows={} pages={} open_nanos={} total_nanos={}",
+                        space.space_id, space.rows, space.pages, space.open_nanos, space.total_nanos
+                    );
+                }
+            } else {
+                for space in &per_space {
+                    println!(
+                        "  L space=0x{:08x} rows={} pages={} open_nanos={} total_nanos={}",
+                        space.space_id, space.rows, space.pages, space.open_nanos, space.total_nanos
+                    );
+                }
+            }
+        }
+    }
+}
+
+async fn pick_branch<S>(storage: &S) -> String
+where
+    S: Storage + Clone + Send + Sync + 'static,
+{
+    let adapter = StorageAdapter::new(storage.clone());
+    let read = adapter
+        .begin_read(StorageReadOptions::default())
+        .await
+        .expect("open storage snapshot");
+    let branches = hot_generation_branches(&read)
+        .await
+        .expect("enumerate branch controls");
+    drop(read);
+    eprintln!("branch controls: {branches:?}");
+    branches
+        .iter()
+        .find(|branch_id| branch_id.as_str() != lix::GLOBAL_BRANCH_ID)
+        .or_else(|| branches.first())
+        .expect("at least one branch control")
+        .clone()
+}
+
+async fn store_size<S>(storage: &S) -> (u64, u64)
+where
+    S: Storage + Clone + Send + Sync + 'static,
+{
+    let adapter = StorageAdapter::new(storage.clone());
+    let read = adapter
+        .begin_read(StorageReadOptions::default())
+        .await
+        .expect("open storage snapshot");
+    let accounting = layout_accounting(&read).await;
+    let rows = accounting.iter().map(|entry| entry.rows).sum();
+    let bytes = accounting
+        .iter()
+        .map(|entry| entry.key_bytes + entry.value_bytes)
+        .sum();
+    drop(read);
+    (rows, bytes)
+}
+
+async fn commit_batch<S>(session: &SessionContext<S>, batch: usize, rows: usize)
+where
+    S: Storage + Clone + Send + Sync + 'static,
+{
+    let mut transaction = session.begin_transaction().await.expect("begin commit");
+    for index in 0..rows {
+        transaction
+            .execute(
+                "INSERT INTO e53_locality (path, value) VALUES ($1, lix_json($2))",
+                &[
+                    Value::Text(format!("/row/{batch:08}/{index:08}")),
+                    Value::Text(format!(r#"{{"batch":{batch},"index":{index}}}"#)),
+                ],
+            )
+            .await
+            .expect("insert row");
+    }
+    transaction.commit().await.expect("commit batch");
+}
+
+async fn register_schema<S>(session: &SessionContext<S>)
+where
+    S: Storage + Clone + Send + Sync + 'static,
+{
+    let schema = serde_json::json!({
+        "x-lix-key": "e53_locality",
+        "x-lix-primary-key": ["/path"],
+        "type": "object",
+        "required": ["path", "value"],
+        "properties": {
+            "path": { "type": "string" },
+            "value": {
+                "type": ["object", "array", "string", "number", "integer", "boolean", "null"]
+            }
+        },
+        "additionalProperties": false
+    });
+    session
+        .execute(
+            "INSERT INTO lix_registered_schema (value, lixcol_global, lixcol_untracked) VALUES (lix_json($1), false, false)",
+            &[Value::Text(schema.to_string())],
+        )
+        .await
+        .expect("register schema");
+}

--- a/packages/e2e/examples/e53_hot_locality_slatedb.rs
+++ b/packages/e2e/examples/e53_hot_locality_slatedb.rs
@@ -1,0 +1,263 @@
+//! `e53_hot_locality`, on SlateDB, where a block fetch is an object-store GET.
+//!
+//! The RocksDB run of this experiment found the eight-space layout costs eight
+//! separate iterator positionings, growing by one block fetch per space per
+//! doubling of the store -- but every one of those fetches was a *block cache
+//! hit*, worth tens of nanoseconds, so the defect landed at a few percent of
+//! the retire's cost. That result says nothing about SlateDB, where the same
+//! structural fetch is a range GET against an object store.
+//!
+//! This drives the identical probe against SlateDB and counts
+//! `SlateDBIoSnapshot::read_objects` -- actual object-store GETs -- around it.
+//! The `phantom` probe holds the garbage at exactly zero, so its GET count is
+//! purely the cost of positioning eight iterators in eight regions of one
+//! keyspace.
+//!
+//! Usage: `e53_hot_locality_slatedb [rows_per_commit] [checkpoint...]`
+
+use lix::Value;
+use lix::integration::{Engine, SessionContext};
+use lix::storage::Storage;
+use lix::storage_adapter::{StorageAdapter, StorageReadOptions};
+use lix::storage_bench::{hot_generation_branches, layout_accounting, probe_hot_generation_planes};
+use lix_storage_slatedb::{SlateDB, SlateDBIoCounters, SlateDBIoSnapshot};
+
+const PROBE_REPS: usize = 3;
+
+#[tokio::main(flavor = "multi_thread", worker_threads = 4)]
+async fn main() {
+    let mut args = std::env::args().skip(1);
+    let rows_per_commit = args
+        .next()
+        .and_then(|value| value.parse::<usize>().ok())
+        .unwrap_or(10);
+    let mut checkpoints = args
+        .filter_map(|value| value.parse::<usize>().ok())
+        .collect::<Vec<_>>();
+    if checkpoints.is_empty() {
+        checkpoints = vec![50, 100, 200, 400, 800];
+    }
+    checkpoints.sort_unstable();
+
+    let directory = tempfile::tempdir().expect("create SlateDB directory");
+    let path = directory.path().to_path_buf();
+    {
+        let counters = SlateDBIoCounters::default();
+        let storage =
+            SlateDB::open_with_io_counters(&path, counters.clone()).expect("open SlateDB");
+        Engine::initialize(storage.clone())
+            .await
+            .expect("initialize repository");
+        let engine = Engine::new(storage.clone()).await.expect("open engine");
+        let session = engine.open_session().await.expect("open workspace");
+        register_schema(&session).await;
+        storage.flush().await.expect("flush slatedb");
+    }
+    let branch = {
+        let counters = SlateDBIoCounters::default();
+        let storage =
+            SlateDB::open_with_io_counters(&path, counters.clone()).expect("open SlateDB");
+        let picked = pick_branch(&storage).await;
+        storage.flush().await.expect("flush slatedb");
+        picked
+    };
+    println!(
+        "e53_hot_locality_slatedb rows_per_commit={rows_per_commit} probe_reps={PROBE_REPS} branch={branch}"
+    );
+    println!(
+        "{:>8} {:>12} {:>13} {:>8} {:>6} {:>8} {:>10} {:>12} {:>11} {:>10} {:>12}",
+        "commits",
+        "store_rows",
+        "store_bytes",
+        "probe",
+        "rep",
+        "deleted",
+        "read_objs",
+        "read_bytes",
+        "cache_rds",
+        "list_ops",
+        "nanos",
+    );
+
+    let mut committed = 0usize;
+    for checkpoint in checkpoints {
+        {
+            // Writer handle: committed, flushed, then dropped so the probe
+            // handle below opens against a cold cache.
+            let counters = SlateDBIoCounters::default();
+            let storage =
+                SlateDB::open_with_io_counters(&path, counters.clone()).expect("open SlateDB");
+            let engine = Engine::new(storage.clone()).await.expect("open engine");
+            let session = engine.open_session().await.expect("open workspace");
+            while committed < checkpoint {
+                commit_batch(&session, committed, rows_per_commit).await;
+                committed += 1;
+            }
+            storage.flush().await.expect("flush slatedb");
+        }
+
+        // Repository size comes off a DISPOSABLE handle. A full layout scan
+        // pulls the whole database into SlateDB's block cache, so running it on
+        // the probe handle would warm exactly the cache the probe is supposed
+        // to arrive cold to -- which is what the first version of this example
+        // did, and it read as "the probe does no object-store IO".
+        let (store_rows, store_bytes) = {
+            let counters = SlateDBIoCounters::default();
+            let storage =
+                SlateDB::open_with_io_counters(&path, counters.clone()).expect("open SlateDB");
+            let size = store_size(&storage).await;
+            drop(storage);
+            size
+        };
+
+        // Fresh handle, fresh counters: every block this probe needs must be
+        // fetched from the object store. Rep 0 is the cold number; later reps
+        // measure the warm steady state.
+        let counters = SlateDBIoCounters::default();
+        let storage =
+            SlateDB::open_with_io_counters(&path, counters.clone()).expect("open SlateDB");
+
+        for (label, phantom) in [("phantom", true), ("live", false)] {
+            let mut per_space = Vec::new();
+            for rep in 0..PROBE_REPS {
+                let adapter = StorageAdapter::new(storage.clone());
+                let read = adapter
+                    .begin_read(StorageReadOptions::default())
+                    .await
+                    .expect("open storage snapshot");
+                let before = counters.snapshot();
+                let probe = probe_hot_generation_planes(&read, &branch, phantom)
+                    .await
+                    .expect("probe hot generation planes");
+                let after = counters.snapshot();
+                drop(read);
+                let delta = diff(&before, &after);
+                println!(
+                    "{committed:>8} {store_rows:>12} {store_bytes:>13} {label:>8} {rep:>6} {:>8} {:>10} {:>12} {:>11} {:>10} {:>12}",
+                    probe.deleted_rows,
+                    delta.0,
+                    delta.1,
+                    delta.2,
+                    delta.3,
+                    probe.total_nanos,
+                );
+                per_space = probe.spaces;
+            }
+            for space in &per_space {
+                println!(
+                    "    [{label}] space=0x{:08x} rows={} pages={} open_nanos={} total_nanos={}",
+                    space.space_id, space.rows, space.pages, space.open_nanos, space.total_nanos
+                );
+            }
+        }
+        let before_check = counters.snapshot();
+        let _ = store_size(&storage).await;
+        let after_check = counters.snapshot();
+        eprintln!(
+            "engagement check @{committed}: a full layout scan on the probe handle moved \
+             read_objects by {} (read_bytes {}) -- run AFTER the probes so it cannot warm them",
+            after_check.read_objects - before_check.read_objects,
+            after_check.read_bytes - before_check.read_bytes,
+        );
+        drop(storage);
+    }
+}
+
+/// `(read_objects, read_bytes, cache_filesystem_reads, list_operations)`.
+fn diff(before: &SlateDBIoSnapshot, after: &SlateDBIoSnapshot) -> (u64, u64, u64, u64) {
+    (
+        after.read_objects.saturating_sub(before.read_objects),
+        after.read_bytes.saturating_sub(before.read_bytes),
+        after
+            .cache_filesystem_reads
+            .saturating_sub(before.cache_filesystem_reads),
+        after.list_operations.saturating_sub(before.list_operations),
+    )
+}
+
+async fn pick_branch<S>(storage: &S) -> String
+where
+    S: Storage + Clone + Send + Sync + 'static,
+{
+    let adapter = StorageAdapter::new(storage.clone());
+    let read = adapter
+        .begin_read(StorageReadOptions::default())
+        .await
+        .expect("open storage snapshot");
+    let branches = hot_generation_branches(&read)
+        .await
+        .expect("enumerate branch controls");
+    drop(read);
+    eprintln!("branch controls: {branches:?}");
+    branches
+        .iter()
+        .find(|branch_id| branch_id.as_str() != lix::GLOBAL_BRANCH_ID)
+        .or_else(|| branches.first())
+        .expect("at least one branch control")
+        .clone()
+}
+
+async fn store_size<S>(storage: &S) -> (u64, u64)
+where
+    S: Storage + Clone + Send + Sync + 'static,
+{
+    let adapter = StorageAdapter::new(storage.clone());
+    let read = adapter
+        .begin_read(StorageReadOptions::default())
+        .await
+        .expect("open storage snapshot");
+    let accounting = layout_accounting(&read).await;
+    let rows = accounting.iter().map(|entry| entry.rows).sum();
+    let bytes = accounting
+        .iter()
+        .map(|entry| entry.key_bytes + entry.value_bytes)
+        .sum();
+    drop(read);
+    (rows, bytes)
+}
+
+async fn commit_batch<S>(session: &SessionContext<S>, batch: usize, rows: usize)
+where
+    S: Storage + Clone + Send + Sync + 'static,
+{
+    let mut transaction = session.begin_transaction().await.expect("begin commit");
+    for index in 0..rows {
+        transaction
+            .execute(
+                "INSERT INTO e53_locality (path, value) VALUES ($1, lix_json($2))",
+                &[
+                    Value::Text(format!("/row/{batch:08}/{index:08}")),
+                    Value::Text(format!(r#"{{"batch":{batch},"index":{index}}}"#)),
+                ],
+            )
+            .await
+            .expect("insert row");
+    }
+    transaction.commit().await.expect("commit batch");
+}
+
+async fn register_schema<S>(session: &SessionContext<S>)
+where
+    S: Storage + Clone + Send + Sync + 'static,
+{
+    let schema = serde_json::json!({
+        "x-lix-key": "e53_locality",
+        "x-lix-primary-key": ["/path"],
+        "type": "object",
+        "required": ["path", "value"],
+        "properties": {
+            "path": { "type": "string" },
+            "value": {
+                "type": ["object", "array", "string", "number", "integer", "boolean", "null"]
+            }
+        },
+        "additionalProperties": false
+    });
+    session
+        .execute(
+            "INSERT INTO lix_registered_schema (value, lixcol_global, lixcol_untracked) VALUES (lix_json($1), false, false)",
+            &[Value::Text(schema.to_string())],
+        )
+        .await
+        .expect("register schema");
+}

--- a/packages/e2e/examples/e53_write_amplification.rs
+++ b/packages/e2e/examples/e53_write_amplification.rs
@@ -22,7 +22,7 @@
 //!
 //! Usage: `e53_write_amplification [rows_per_commit] [commits] [report_every]`
 
-use lix::Value;
+use lix::{ExecuteBatchStatement, Value};
 use lix::integration::{Engine, SessionContext};
 use lix::storage::Storage;
 use lix::storage_adapter::{StorageAdapter, StorageReadOptions};
@@ -48,6 +48,15 @@ async fn main() {
         .next()
         .and_then(|value| value.parse::<usize>().ok())
         .unwrap_or(50);
+    // Seeded via execute_batch in ONE commit. PACKED_CURRENT_BASE_MIN_ROWS is a
+    // floor on rows staged by a single transaction, so this is the knob that
+    // decides whether a packed base exists before the incremental lane starts.
+    // 500 is the `untracked_state_crud` chunk size -- deliberately just under
+    // 512 -- and is the trap this argument exists to make visible.
+    let seed_rows = args
+        .next()
+        .and_then(|value| value.parse::<usize>().ok())
+        .unwrap_or(0);
 
     let directory = tempfile::tempdir().expect("create RocksDB directory");
     let storage = RocksDB::open(directory.path()).expect("open RocksDB");
@@ -60,7 +69,8 @@ async fn main() {
 
     println!(
         "e53_write_amplification rows_per_commit={rows_per_commit} commits={commits} \
-         packed_min_rows={PACKED_CURRENT_BASE_MIN_ROWS_VALUE} backend=rocksdb checkpoints=none"
+         seed_rows={seed_rows} packed_min_rows={PACKED_CURRENT_BASE_MIN_ROWS_VALUE} \
+         backend=rocksdb checkpoints=none"
     );
     println!(
         "{:>8} {:>12} {:>12} {:>10} {:>10} {:>10} {:>12} {:>8} {:>12} {:>8} {:>8} {:>8} {:>12}",
@@ -84,6 +94,32 @@ async fn main() {
     let _ = take_hot_retire_invocations();
     let _ = take_packed_base_publication_census();
     let mut last_bytes = 0_u64;
+
+    if seed_rows > 0 {
+        let sql = "INSERT INTO e53_amp (path, value) VALUES ($1, lix_json($2))";
+        let statements = (0..seed_rows)
+            .map(|row_index| ExecuteBatchStatement {
+                label: None,
+                sql: sql.to_string(),
+                params: vec![
+                    Value::Text(format!("/seed/{row_index:08}")),
+                    Value::Text(format!(r#"{{"seed":{row_index}}}"#)),
+                ],
+            })
+            .collect::<Vec<_>>();
+        let start = std::time::Instant::now();
+        session.execute_batch(&statements).await.expect("seed batch");
+        let seed_nanos = start.elapsed().as_nanos();
+        let packed = take_packed_base_publication_census();
+        let (retires, retired_rows) = take_hot_retire_invocations();
+        let (rows, bytes) = store_rows(&storage).await;
+        last_bytes = bytes;
+        println!(
+            "SEED rows={seed_rows} store_rows={rows} store_bytes={bytes} nanos={seed_nanos} \
+             retires={retires} retired_rows={retired_rows} pk_ord={} pk_col={} pk_rep={}",
+            packed.ordered, packed.certified_columnar, packed.complete_replacement
+        );
+    }
 
     for index in 0..commits {
         let start = std::time::Instant::now();
@@ -177,7 +213,7 @@ where
             .execute(
                 "INSERT INTO e53_amp (path, value) VALUES ($1, lix_json($2))",
                 &[
-                    Value::Text(format!("/row/{batch:08}/{index:08}")),
+                    Value::Text(format!("/inc/{batch:08}/{index:08}")),
                     Value::Text(format!(r#"{{"batch":{batch},"index":{index}}}"#)),
                 ],
             )

--- a/packages/e2e/examples/e53_write_amplification.rs
+++ b/packages/e2e/examples/e53_write_amplification.rs
@@ -1,0 +1,214 @@
+//! Does a commit's physical write cost grow with repository size?
+//!
+//! A probe replay of `stage_retire_hot_generation` against a branch's live
+//! generation found it would delete the branch's *entire* row set -- 8 026 rows
+//! at 800 commits. That is a measurement of how many rows one generation holds.
+//! It is **not** a measurement of how often a generation is retired, and the
+//! difference decides whether ordinary commits are O(repository) or O(batch):
+//! `stage_retire_hot_generation` is called only when a publication moves the
+//! branch's `tracked_generation`, so a lane that never rotates the generation
+//! pays nothing.
+//!
+//! This measures the real commit lane directly, per commit:
+//!
+//! * `staged_puts` / `staged_deletes` / `written_bytes` from the write set
+//! * real `stage_retire_hot_generation` invocations and rows they deleted
+//! * which packed-current-base publication route fired, if any
+//!
+//! `PACKED_CURRENT_BASE_MIN_ROWS` is a floor on the rows staged by a *single
+//! transaction*, so `--rows-per-commit` sweeps across it decide whether the
+//! packed base is unreachable in ordinary incremental use or merely unused by
+//! small commits.
+//!
+//! Usage: `e53_write_amplification [rows_per_commit] [commits] [report_every]`
+
+use lix::Value;
+use lix::integration::{Engine, SessionContext};
+use lix::storage::Storage;
+use lix::storage_adapter::{StorageAdapter, StorageReadOptions};
+use lix::storage_bench::{
+    PACKED_CURRENT_BASE_MIN_ROWS_VALUE, hot_generation_branches, layout_accounting,
+    probe_hot_generation_planes, take_crud_physical_write_accounting, take_hot_retire_invocations,
+    take_packed_base_publication_census,
+};
+use lix_storage_rocksdb::RocksDB;
+
+#[tokio::main(flavor = "current_thread")]
+async fn main() {
+    let mut args = std::env::args().skip(1);
+    let rows_per_commit = args
+        .next()
+        .and_then(|value| value.parse::<usize>().ok())
+        .unwrap_or(10);
+    let commits = args
+        .next()
+        .and_then(|value| value.parse::<usize>().ok())
+        .unwrap_or(400);
+    let report_every = args
+        .next()
+        .and_then(|value| value.parse::<usize>().ok())
+        .unwrap_or(50);
+
+    let directory = tempfile::tempdir().expect("create RocksDB directory");
+    let storage = RocksDB::open(directory.path()).expect("open RocksDB");
+    Engine::initialize(storage.clone())
+        .await
+        .expect("initialize repository");
+    let engine = Engine::new(storage.clone()).await.expect("open engine");
+    let session = engine.open_session().await.expect("open workspace");
+    register_schema(&session).await;
+
+    println!(
+        "e53_write_amplification rows_per_commit={rows_per_commit} commits={commits} \
+         packed_min_rows={PACKED_CURRENT_BASE_MIN_ROWS_VALUE} backend=rocksdb checkpoints=none"
+    );
+    println!(
+        "{:>8} {:>12} {:>12} {:>10} {:>10} {:>10} {:>12} {:>8} {:>12} {:>8} {:>8} {:>8} {:>12}",
+        "commit",
+        "store_rows",
+        "store_bytes",
+        "grew_bytes",
+        "puts",
+        "deletes",
+        "wr_bytes",
+        "retires",
+        "retired_rws",
+        "pk_ord",
+        "pk_col",
+        "pk_rep",
+        "nanos",
+    );
+
+    // Drain anything the schema registration left in the process-global counters.
+    let _ = take_crud_physical_write_accounting();
+    let _ = take_hot_retire_invocations();
+    let _ = take_packed_base_publication_census();
+    let mut last_bytes = 0_u64;
+
+    for index in 0..commits {
+        let start = std::time::Instant::now();
+        commit_batch(&session, index, rows_per_commit).await;
+        let nanos = start.elapsed().as_nanos();
+
+        let physical = take_crud_physical_write_accounting();
+        let (retires, retired_rows) = take_hot_retire_invocations();
+        let packed = take_packed_base_publication_census();
+
+        let report = index + 1 == commits
+            || (index + 1) % report_every == 0
+            || index < 3
+            || retires > 0
+            || packed.ordered + packed.certified_columnar + packed.complete_replacement > 0;
+        if report {
+            let (store_rows, store_bytes) = store_rows(&storage).await;
+            let grew = store_bytes.saturating_sub(last_bytes);
+            last_bytes = store_bytes;
+            println!(
+                "{:>8} {store_rows:>12} {store_bytes:>12} {grew:>10} {:>10} {:>10} {:>12} {retires:>8} {retired_rows:>12} {:>8} {:>8} {:>8} {nanos:>12}",
+                index + 1,
+                physical.puts,
+                physical.deletes,
+                physical.written_bytes,
+                packed.ordered,
+                packed.certified_columnar,
+                packed.complete_replacement,
+            );
+        }
+    }
+
+    // ENGAGEMENT CHECK. "retires = 0" is only a fact about the commit lane if
+    // the counter is capable of moving in this process. Force one real
+    // `stage_retire_hot_generation` through the probe and read it back; if this
+    // prints 0 the counter is dead and every zero above is meaningless.
+    let adapter = StorageAdapter::new(storage.clone());
+    let read = adapter
+        .begin_read(StorageReadOptions::default())
+        .await
+        .expect("open storage snapshot");
+    let branches = hot_generation_branches(&read)
+        .await
+        .expect("enumerate branch controls");
+    let branch = branches
+        .iter()
+        .find(|branch_id| branch_id.as_str() != lix::GLOBAL_BRANCH_ID)
+        .or_else(|| branches.first())
+        .expect("at least one branch control")
+        .clone();
+    let _ = take_hot_retire_invocations();
+    let probe = probe_hot_generation_planes(&read, &branch, false)
+        .await
+        .expect("probe hot generation planes");
+    drop(read);
+    let (forced_calls, forced_rows) = take_hot_retire_invocations();
+    println!(
+        "engagement check: forcing one retire moved the counter to calls={forced_calls} \
+         rows={forced_rows} (probe reported deleted={}) -- if calls==0 the zeros above are a dead \
+         instrument, not a result",
+        probe.deleted_rows
+    );
+}
+
+async fn store_rows<S>(storage: &S) -> (u64, u64)
+where
+    S: Storage + Clone + Send + Sync + 'static,
+{
+    let adapter = StorageAdapter::new(storage.clone());
+    let read = adapter
+        .begin_read(StorageReadOptions::default())
+        .await
+        .expect("open storage snapshot");
+    let accounting = layout_accounting(&read).await;
+    let rows = accounting.iter().map(|entry| entry.rows).sum();
+    let bytes = accounting
+        .iter()
+        .map(|entry| entry.key_bytes + entry.value_bytes)
+        .sum();
+    drop(read);
+    (rows, bytes)
+}
+
+async fn commit_batch<S>(session: &SessionContext<S>, batch: usize, rows: usize)
+where
+    S: Storage + Clone + Send + Sync + 'static,
+{
+    let mut transaction = session.begin_transaction().await.expect("begin commit");
+    for index in 0..rows {
+        transaction
+            .execute(
+                "INSERT INTO e53_amp (path, value) VALUES ($1, lix_json($2))",
+                &[
+                    Value::Text(format!("/row/{batch:08}/{index:08}")),
+                    Value::Text(format!(r#"{{"batch":{batch},"index":{index}}}"#)),
+                ],
+            )
+            .await
+            .expect("insert row");
+    }
+    transaction.commit().await.expect("commit batch");
+}
+
+async fn register_schema<S>(session: &SessionContext<S>)
+where
+    S: Storage + Clone + Send + Sync + 'static,
+{
+    let schema = serde_json::json!({
+        "x-lix-key": "e53_amp",
+        "x-lix-primary-key": ["/path"],
+        "type": "object",
+        "required": ["path", "value"],
+        "properties": {
+            "path": { "type": "string" },
+            "value": {
+                "type": ["object", "array", "string", "number", "integer", "boolean", "null"]
+            }
+        },
+        "additionalProperties": false
+    });
+    session
+        .execute(
+            "INSERT INTO lix_registered_schema (value, lixcol_global, lixcol_untracked) VALUES (lix_json($1), false, false)",
+            &[Value::Text(schema.to_string())],
+        )
+        .await
+        .expect("register schema");
+}

--- a/packages/lix/src/hot_state/tracked_head/hot.rs
+++ b/packages/lix/src/hot_state/tracked_head/hot.rs
@@ -13045,11 +13045,18 @@ where
     let prefix = StoragePrefix {
         bytes: Bytes::from(encode_scope_prefix(branch_id, generation)),
     };
+    // Counted at the top of the real function, so a commit lane that never
+    // rotates its generation reads as zero calls rather than as "the symbol
+    // exists, therefore the branch ran".
+    #[cfg(feature = "storage-benches")]
+    crate::storage_bench::record_hot_retire_call();
     let mut deleted = 0_u64;
     for space in GENERATION_SCOPED_SPACES {
         // A publication that supersedes this generation stages its own
         // lifecycle mutations first. Restating one of those keys here is a
         // duplicate mutation, not an idempotent delete.
+        #[cfg(feature = "storage-benches")]
+        let space_start = std::time::Instant::now();
         let declared = writes.declared_keys(*space);
         let mut cursor = store
             .begin_scan(
@@ -13061,11 +13068,28 @@ where
                 },
             )
             .await?;
+        #[cfg(feature = "storage-benches")]
+        let open_nanos = u64::try_from(space_start.elapsed().as_nanos()).unwrap_or(u64::MAX);
+        #[cfg(feature = "storage-benches")]
+        let mut space_rows = 0_u64;
+        #[cfg(feature = "storage-benches")]
+        let mut space_pages = 0_u64;
         loop {
             let (page, page_has_more) = cursor
                 .next_page(crate::storage_adapter::MAX_SCAN_PAGE_ROWS)
                 .await?.into_parts();
+            #[cfg(feature = "storage-benches")]
+            {
+                space_pages = space_pages.saturating_add(1);
+            }
             for entry in page {
+                // Counted here, inside the per-entry decode loop that does the
+                // work, not at the layer that returns the answer: a post-filter
+                // count cannot distinguish a seek from a full-prefix walk.
+                #[cfg(feature = "storage-benches")]
+                {
+                    space_rows = space_rows.saturating_add(1);
+                }
                 if declared.contains(entry.key.0.as_ref()) {
                     continue;
                 }
@@ -13076,7 +13100,17 @@ where
                 break;
             }
         }
+        #[cfg(feature = "storage-benches")]
+        crate::storage_bench::record_hot_retire_space(
+            space.id.0,
+            space_rows,
+            space_pages,
+            open_nanos,
+            u64::try_from(space_start.elapsed().as_nanos()).unwrap_or(u64::MAX),
+        );
     }
+    #[cfg(feature = "storage-benches")]
+    crate::storage_bench::record_hot_retire_deleted(deleted);
     Ok(deleted)
 }
 

--- a/packages/lix/src/storage_bench.rs
+++ b/packages/lix/src/storage_bench.rs
@@ -94,6 +94,169 @@ static MEDIA_UPLOAD_SUMMARIZED_CHUNK_ROWS: AtomicU64 = AtomicU64::new(0);
 static MEDIA_UPLOAD_CHUNK_PAYLOAD_HASH_BYTES: AtomicU64 = AtomicU64::new(0);
 static IMMUTABLE_SEGMENT_IDENTITY_HASH_BYTES: AtomicU64 = AtomicU64::new(0);
 
+/// Lifetime counts of real `stage_retire_hot_generation` invocations.
+///
+/// Separate from `HOT_RETIRE_CENSUS`, which a probe resets. A commit lane whose
+/// branch never rotates its tracked generation performs **zero** retires, so
+/// this is what distinguishes "every commit rewrites the plane" from "the plane
+/// is generation-keyed and the generation rarely moves".
+static HOT_RETIRE_CALLS: AtomicU64 = AtomicU64::new(0);
+static HOT_RETIRE_DELETED_ROWS: AtomicU64 = AtomicU64::new(0);
+
+pub(crate) fn record_hot_retire_call() {
+    HOT_RETIRE_CALLS.fetch_add(1, Ordering::Relaxed);
+}
+
+pub(crate) fn record_hot_retire_deleted(rows: u64) {
+    HOT_RETIRE_DELETED_ROWS.fetch_add(rows, Ordering::Relaxed);
+}
+
+/// `(calls, deleted_rows)` since the last take.
+pub fn take_hot_retire_invocations() -> (u64, u64) {
+    (
+        HOT_RETIRE_CALLS.swap(0, Ordering::Relaxed),
+        HOT_RETIRE_DELETED_ROWS.swap(0, Ordering::Relaxed),
+    )
+}
+
+/// Which packed-current-base publication route fired, if any.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct PackedBasePublicationCensus {
+    pub ordered: usize,
+    pub certified_columnar: usize,
+    pub complete_replacement: usize,
+}
+
+/// The single-transaction row count a commit must stage before any packed
+/// current base is eligible. Mirrors `PACKED_CURRENT_BASE_MIN_ROWS`.
+pub const PACKED_CURRENT_BASE_MIN_ROWS_VALUE: usize = 512;
+
+pub fn take_packed_base_publication_census() -> PackedBasePublicationCensus {
+    PackedBasePublicationCensus {
+        ordered: crate::transaction::take_ordered_packed_current_base_publications(),
+        certified_columnar: crate::transaction::take_certified_columnar_current_base_publications(),
+        complete_replacement:
+            crate::transaction::take_complete_replacement_packed_current_base_publications(),
+    }
+}
+
+/// Per-space census of one `stage_retire_hot_generation` call.
+///
+/// One row per entry in `GENERATION_SCOPED_SPACES`, in the order the retire
+/// visits them. `rows` is incremented inside the per-entry decode loop, so it
+/// counts entries the scan actually materialized, not entries it returned.
+#[derive(Clone, Copy, Debug, Default)]
+pub struct HotRetireSpaceCensus {
+    pub space_id: u32,
+    pub rows: u64,
+    pub pages: u64,
+    /// Wall time from entering the space to the `begin_scan` future resolving,
+    /// i.e. the seek that positions the iterator at the generation prefix.
+    pub open_nanos: u64,
+    pub total_nanos: u64,
+}
+
+static HOT_RETIRE_CENSUS: std::sync::Mutex<Vec<HotRetireSpaceCensus>> =
+    std::sync::Mutex::new(Vec::new());
+
+pub(crate) fn record_hot_retire_space(
+    space_id: u32,
+    rows: u64,
+    pages: u64,
+    open_nanos: u64,
+    total_nanos: u64,
+) {
+    if let Ok(mut census) = HOT_RETIRE_CENSUS.lock() {
+        census.push(HotRetireSpaceCensus {
+            space_id,
+            rows,
+            pages,
+            open_nanos,
+            total_nanos,
+        });
+    }
+}
+
+pub fn begin_hot_retire_census() {
+    if let Ok(mut census) = HOT_RETIRE_CENSUS.lock() {
+        census.clear();
+    }
+}
+
+pub fn take_hot_retire_census() -> Vec<HotRetireSpaceCensus> {
+    HOT_RETIRE_CENSUS
+        .lock()
+        .map(|mut census| std::mem::take(&mut *census))
+        .unwrap_or_default()
+}
+
+/// Every branch id with a durable branch-head control, in branch-id order.
+pub async fn hot_generation_branches<R>(read: &R) -> Result<Vec<String>, crate::LixError>
+where
+    R: StorageAdapterRead,
+{
+    Ok(crate::branch::BranchHeadControlContext::new()
+        .reader(read)
+        .scan()
+        .await?
+        .into_iter()
+        .map(|(branch_id, _)| branch_id)
+        .collect())
+}
+
+/// One `stage_retire_hot_generation` invocation, measured.
+#[derive(Clone, Debug, Default)]
+pub struct HotGenerationProbe {
+    pub deleted_rows: u64,
+    pub total_nanos: u64,
+    pub spaces: Vec<HotRetireSpaceCensus>,
+}
+
+/// Replays the production retire scan for one branch's live generation.
+///
+/// This calls `stage_retire_hot_generation` itself -- the same eight prefix
+/// scans a real publication performs -- and throws the resulting write set
+/// away, so the probe is read-only. With `phantom` the generation is a uuid no
+/// row can carry, which makes the garbage exactly zero by construction: every
+/// byte the storage engine touches is the fixed cost of positioning eight
+/// iterators in eight regions of one keyspace.
+pub async fn probe_hot_generation_planes<R>(
+    read: &R,
+    branch_id: &str,
+    phantom: bool,
+) -> Result<HotGenerationProbe, crate::LixError>
+where
+    R: StorageAdapterRead,
+{
+    let generation = if phantom {
+        crate::changelog::CommitId::new(uuid::Uuid::from_u128(0x0e53_0e53_0e53_0e53_0e53_0e53_0e53_0e53))
+    } else {
+        crate::branch::BranchHeadControlContext::new()
+            .reader(read)
+            .load(branch_id)
+            .await?
+            .ok_or_else(|| {
+                crate::LixError::new(
+                    crate::LixError::CODE_INTERNAL_ERROR,
+                    format!("no branch-head control for '{branch_id}'"),
+                )
+            })?
+            .tracked_generation
+    };
+    let mut writes = StorageWriteSet::new();
+    begin_hot_retire_census();
+    let start = std::time::Instant::now();
+    let deleted =
+        crate::hot_state::stage_retire_hot_generation(read, &mut writes, branch_id, generation)
+            .await?;
+    let total_nanos = u64::try_from(start.elapsed().as_nanos()).unwrap_or(u64::MAX);
+    Ok(HotGenerationProbe {
+        deleted_rows: deleted,
+        total_nanos,
+        spaces: take_hot_retire_census(),
+    })
+}
+
 /// Matched transaction ownership counters used by the CRUD profile.  These
 /// counters are deliberately disabled unless the profile enables them, so the
 /// common instrumentation does not perturb normal engine execution.

--- a/packages/lix/src/transaction/commit.rs
+++ b/packages/lix/src/transaction/commit.rs
@@ -84,7 +84,7 @@ fn compare_certified_predecessors(
         .then_with(|| left.file_id.cmp(&right.file_id))
 }
 
-#[cfg(test)]
+#[cfg(any(test, feature = "storage-benches"))]
 std::thread_local! {
     static ORDERED_PACKED_CURRENT_BASE_PUBLICATIONS: std::cell::Cell<usize> =
         const { std::cell::Cell::new(0) };
@@ -103,17 +103,17 @@ static DIRECT_JOURNAL_REPLACEMENT_PUBLICATIONS: std::sync::LazyLock<
     std::sync::Mutex<BTreeMap<String, usize>>,
 > = std::sync::LazyLock::new(|| std::sync::Mutex::new(BTreeMap::new()));
 
-#[cfg(test)]
+#[cfg(any(test, feature = "storage-benches"))]
 pub(crate) fn take_ordered_packed_current_base_publications() -> usize {
     ORDERED_PACKED_CURRENT_BASE_PUBLICATIONS.with(|publications| publications.replace(0))
 }
 
-#[cfg(test)]
+#[cfg(any(test, feature = "storage-benches"))]
 pub(crate) fn take_certified_columnar_current_base_publications() -> usize {
     CERTIFIED_COLUMNAR_CURRENT_BASE_PUBLICATIONS.with(|publications| publications.replace(0))
 }
 
-#[cfg(test)]
+#[cfg(any(test, feature = "storage-benches"))]
 pub(crate) fn take_complete_replacement_packed_current_base_publications() -> usize {
     COMPLETE_REPLACEMENT_PACKED_CURRENT_BASE_PUBLICATIONS
         .with(|publications| publications.replace(0))
@@ -3979,7 +3979,7 @@ async fn stage_tracked_head(
                     "immutable replacement journal entered an incompatible HOT publication lane",
                 ));
             }
-            #[cfg(test)]
+            #[cfg(any(test, feature = "storage-benches"))]
             COMPLETE_REPLACEMENT_PACKED_CURRENT_BASE_PUBLICATIONS.with(|publications| {
                 publications.set(publications.get().saturating_add(1));
             });
@@ -4027,7 +4027,7 @@ async fn stage_tracked_head(
             continue;
         }
         if can_publish_ordered_packed_current_base {
-            #[cfg(test)]
+            #[cfg(any(test, feature = "storage-benches"))]
             ORDERED_PACKED_CURRENT_BASE_PUBLICATIONS.with(|publications| {
                 publications.set(publications.get().saturating_add(1));
             });
@@ -4042,7 +4042,7 @@ async fn stage_tracked_head(
                 certified_columnar_parts,
                 inventory.lifecycle_summary.as_ref(),
             ) {
-                #[cfg(test)]
+                #[cfg(any(test, feature = "storage-benches"))]
                 CERTIFIED_COLUMNAR_CURRENT_BASE_PUBLICATIONS.with(|publications| {
                     publications.set(publications.get().saturating_add(1));
                 });
@@ -4120,7 +4120,7 @@ async fn stage_tracked_head(
             continue;
         }
         if let Some(schema_key) = complete_replacement_schema {
-            #[cfg(test)]
+            #[cfg(any(test, feature = "storage-benches"))]
             COMPLETE_REPLACEMENT_PACKED_CURRENT_BASE_PUBLICATIONS.with(|publications| {
                 publications.set(publications.get().saturating_add(1));
             });

--- a/packages/lix/src/transaction/mod.rs
+++ b/packages/lix/src/transaction/mod.rs
@@ -16,15 +16,18 @@ pub mod bench {
     pub use super::bench_support::*;
 }
 
-#[cfg(test)]
+#[cfg(any(test, feature = "storage-benches"))]
+#[allow(unused_imports)]
 pub(crate) use commit::take_certified_columnar_current_base_publications;
-#[cfg(test)]
+#[cfg(any(test, feature = "storage-benches"))]
+#[allow(unused_imports)]
 pub(crate) use commit::take_complete_replacement_packed_current_base_publications;
 #[cfg(test)]
 pub(crate) use commit::take_complete_replacement_packed_current_base_retirements;
 #[cfg(test)]
 pub(crate) use commit::take_direct_journal_replacement_publications;
-#[cfg(test)]
+#[cfg(any(test, feature = "storage-benches"))]
+#[allow(unused_imports)]
 pub(crate) use commit::take_ordered_packed_current_base_publications;
 #[cfg(test)]
 pub(crate) use commit::take_rootless_replacement_generation_publications;

--- a/packages/storage-rocksdb/src/lib.rs
+++ b/packages/storage-rocksdb/src/lib.rs
@@ -3,3 +3,66 @@
 mod rocksdb;
 
 pub use rocksdb::{RocksDB, RocksDBFactory, RocksDBFixture, RocksDBRead, RocksDBWrite};
+
+/// Counts of the block fetches RocksDB performed on the calling thread.
+///
+/// `block_cache_hits + block_reads` is the number of times the table reader had
+/// to fetch a block: on RocksDB a hit is a cache lookup and a read is a file
+/// read, but on a remote object-store LSM every one of these is a range GET.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct BlockFetchCounters {
+    pub block_cache_hits: u64,
+    pub block_reads: u64,
+    pub block_read_bytes: u64,
+    pub user_key_comparisons: u64,
+    pub internal_keys_skipped: u64,
+}
+
+impl BlockFetchCounters {
+    #[must_use]
+    pub fn block_fetches(&self) -> u64 {
+        self.block_cache_hits + self.block_reads
+    }
+}
+
+/// A handle on the calling thread's RocksDB perf context.
+///
+/// RocksDB's perf context is thread-local and cumulative, so the caller must
+/// create, reset and read this on one thread. Drive the measurement on a
+/// `current_thread` runtime; a multi-thread runtime may resume the future on a
+/// different worker and read a context that never saw the work.
+pub struct PerfProbe {
+    context: ::rocksdb::perf::PerfContext,
+}
+
+impl Default for PerfProbe {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl PerfProbe {
+    #[must_use]
+    pub fn new() -> Self {
+        ::rocksdb::perf::set_perf_stats(::rocksdb::perf::PerfStatsLevel::EnableCount);
+        Self {
+            context: ::rocksdb::perf::PerfContext::default(),
+        }
+    }
+
+    pub fn reset(&mut self) {
+        self.context.reset();
+    }
+
+    #[must_use]
+    pub fn read(&self) -> BlockFetchCounters {
+        use ::rocksdb::perf::PerfMetric;
+        BlockFetchCounters {
+            block_cache_hits: self.context.metric(PerfMetric::BlockCacheHitCount),
+            block_reads: self.context.metric(PerfMetric::BlockReadCount),
+            block_read_bytes: self.context.metric(PerfMetric::BlockReadByte),
+            user_key_comparisons: self.context.metric(PerfMetric::UserKeyComparisonCount),
+            internal_keys_skipped: self.context.metric(PerfMetric::InternalKeySkippedCount),
+        }
+    }
+}

--- a/packages/storage-rocksdb/src/lib.rs
+++ b/packages/storage-rocksdb/src/lib.rs
@@ -35,6 +35,18 @@ pub struct PerfProbe {
     context: ::rocksdb::perf::PerfContext,
 }
 
+// `rocksdb::perf::PerfContext` is a raw FFI handle and implements no traits, so
+// the workspace `missing_debug_implementations` lint needs this by hand. The
+// counters are the interesting state and they are read through `read()`.
+impl std::fmt::Debug for PerfProbe {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("PerfProbe")
+            .field("counters", &self.read())
+            .finish()
+    }
+}
+
 impl Default for PerfProbe {
     fn default() -> Self {
         Self::new()


### PR DESCRIPTION
## What this is

Measurement apparatus, plus the evidence that **retires a proposed relayout**. No production behaviour changes.

The hypothesis under test: all ~41 spaces share one flat physical keyspace (`encode_physical_key` writes a `u32` space id in front of every logical key, and on RocksDB every mutable space shares one column family), so `SpaceId` is the outermost sort dimension of the whole store. The eight `GENERATION_SCOPED_SPACES` that make up one branch generation therefore sit in eight regions separated by the entire contents of the intervening spaces, and `stage_retire_hot_generation` does eight separate prefix seeks to retire one generation. The proposal was to merge them into one `HOT_GENERATION_SPACE` keyed `branch_id || generation || plane_tag || rest` — a days-long, deeply load-bearing change.

**Verdict: NO-GO.** The premise is true and the conclusion does not follow.

## The measurement

`phantom` probe: the real `stage_retire_hot_generation`, against a generation uuid no row can carry, so **garbage is fixed at exactly zero by construction** and the only cost is positioning eight iterators. Grow the repository, watch the cost. That is the falsifiable form of the claim.

**SlateDB, cold cache, `read_objects` = real object-store GETs:**

| commits | store MB | GETs | read_bytes |
|---|---|---|---|
| 50 | 0.31 | **4** | **2,136** |
| 100 | 0.61 | **4** | **2,136** |
| 200 | 1.19 | **4** | **2,136** |
| 400 | 2.36 | **4** | **2,136** |
| 800 | 4.67 | **4** | **2,136** |

Flat, byte-identical, across a 15× growth in repository size. And `4 < 8`: the eight seeks **share** fetches, because SlateDB's few large objects hold the eight index blocks together — the opposite of what the hypothesis predicted.

Engagement control on the same handle, run *after* the probes so it cannot warm them: a full layout scan moves `read_objects` by 147 / 263 / 484 / 899 / 1717. The counter is alive and scales with data volume; the flat 4 is a measurement, not a dead instrument.

**RocksDB** (`BlockCacheHitCount + BlockReadCount`): 9 → 17 → 25 → 33 across the same sizes, then **collapses to 16 at 800 commits when compaction merges levels**. Log-shaped and compaction-bounded, and `block_reads` was 0 at every point but one — every "extra fetch" was a block-cache hit worth tens of nanoseconds.

**Why the premise fails:** seek cost is not proportional to key-space distance. It is proportional to the number of objects/SSTs a seek must consult, and both engines index into those directly.

## Also established

- **No cross-branch or all-generations whole-space scan of any of the eight exists in production code** (205 call sites audited; every production range anchored at `encode_scope_prefix`). `collect_hot_json_refs` iterates per branch but pins each scan to that branch's `tracked_generation` — a partial hit, not a counterexample.
- **Ordinary commits do not rotate the tracked generation.** `stage_retire_hot_generation` is called **0 times across 400 commits**; the counter is proven live in the same process by forcing one retire (calls=1, rows=4026). Per-commit physical growth is flat at ~5.1–5.9 KB and commit latency is flat at 2.3–2.9 ms while the repository grows 40 KB → 2.3 MB. **No O(repository) write amplification.**

## Contents

- `storage_bench`: per-space retire census, counted **inside the per-entry decode loop** — a post-filter count at the page-return layer reads identically under a seek and under a full walk.
- `storage_bench`: `probe_hot_generation_planes` (replays the real retire, discards the write set), lifetime retire invocation counters separate from the probe-resettable census.
- `lix-storage-rocksdb`: `PerfProbe` over RocksDB's thread-local perf context.
- `transaction`: three packed-current-base publication counters widened from `cfg(test)` to also compile under `storage-benches`.
- Three e2e examples: `e53_hot_locality`, `e53_hot_locality_slatedb`, `e53_write_amplification`.

## ⚠️ Gate not yet run — do not merge

This is opened as a **draft** at the coordinator's request so the instrument is not lost. The full CI gate has **not** been run against this sha. The `cfg(test)` → `cfg(any(test, feature = "storage-benches"))` widening in `transaction/commit.rs` and `transaction/mod.rs` touches items the non-test lib build compiles, which is exactly the shape that only `clippy --all-targets` catches. **Gate before any merge consideration, and I did not merge it.**

## Limits

- Six of the eight planes are empty in this fixture (no packed-base steady state, checkpoint cadence: none). The magnitude `4` is a floor that could rise toward ~16 at steady state; the **flatness with repository size** — the property the claim rested on — is unaffected.
- Backends measured: RocksDB and SlateDB, single host, local object store standing in for remote.
