### PR TITLE
perf(history): bound commit-delta member reads on schema_key|file_id

### DIFF
--- a/packages/e2e/tests/history_scaling_probe.rs
+++ b/packages/e2e/tests/history_scaling_probe.rs
@@ -237,6 +237,83 @@ async fn history_files_at_fixed_commits() {
     }
 }
 
+/// Decoded commit-delta entries per answer row, swept over file count.
+///
+/// A timing sweep cannot tell "the read is bounded" from "the read is wide but
+/// cheap on this fixture". This reads the census counted inside
+/// `collect_strict_commit_delta_members`' per-entry decode loop, one layer below
+/// the member vector the scan returns, and reports it against the number of rows
+/// the query actually answered with.
+///
+/// The route counters are printed alongside deliberately: a flat
+/// `entries_decoded` with `file_bounded=0` means the narrowed route never ran,
+/// which is a different finding from "the narrowing did not help".
+#[tokio::test]
+#[ignore = "manual history-scaling probe"]
+async fn history_member_scan_census() {
+    let file_bytes = env_usize("LIX_HISTORY_SCALE_FILE_BYTES", 4 * 1024);
+    let edits = env_usize("LIX_HISTORY_SCALE_EDITS", 20);
+    let depth = env_usize("LIX_HISTORY_SCALE_DEPTH", 20);
+
+    for files in env_list("LIX_HISTORY_SCALE_FILES", "50,500,5000") {
+        let dir = tempfile::tempdir().expect("probe tempdir");
+        let lix = open_at(dir.path()).await;
+        let probe_path = "/probe/f00000.bin".to_string();
+        seed(&lix, files, file_bytes, files, edits, &probe_path).await;
+
+        let head = active_commit(&lix).await;
+        let file_id: String = lix
+            .execute(
+                "SELECT id FROM lix_file WHERE path = $1",
+                &[Value::Text(probe_path.clone())],
+            )
+            .await
+            .expect("probe file id")
+            .rows()[0]
+            .get("id")
+            .expect("id text");
+
+        let by_path = format!(
+            "SELECT lixcol_depth FROM lix_file_history($1) WHERE path = $2 \
+             ORDER BY lixcol_depth LIMIT {depth}"
+        );
+        let by_id = format!(
+            "SELECT lixcol_depth FROM lix_file_history($1) WHERE id = $2 \
+             ORDER BY lixcol_depth LIMIT {depth}"
+        );
+
+        for (label, sql, arg) in [
+            ("by_path", &by_path, probe_path.clone()),
+            ("by_id", &by_id, file_id.clone()),
+        ] {
+            // Warm the caches, then clear the census so the reported numbers
+            // belong to one steady-state read.
+            let _ = lix
+                .execute(sql, &[Value::Text(head.clone()), Value::Text(arg.clone())])
+                .await
+                .expect("warm probe query");
+            let _ = lix::storage_bench::take_commit_delta_member_scan_census();
+            let rows = lix
+                .execute(sql, &[Value::Text(head.clone()), Value::Text(arg.clone())])
+                .await
+                .expect("probe query")
+                .rows()
+                .len();
+            let (decoded, kept, schema_only, file_bounded, ranges) =
+                lix::storage_bench::take_commit_delta_member_scan_census();
+            eprintln!(
+                "member_scan_census {label} files={files} commits={} rows={rows} \
+                 entries_decoded={decoded} members_kept={kept} \
+                 scans_schema_only={schema_only} scans_file_bounded={file_bounded} \
+                 ranges={ranges} decoded_per_row={:.1}",
+                edits + 1,
+                decoded as f64 / rows.max(1) as f64,
+            );
+        }
+        lix.close().await.expect("close probe");
+    }
+}
+
 /// Vary the number of reachable commits with file count AND answer size held
 /// constant.
 ///

--- a/packages/lix/src/commit_graph/context.rs
+++ b/packages/lix/src/commit_graph/context.rs
@@ -79,7 +79,8 @@ where
     // A reader is bound to one pinned storage snapshot for the duration of a
     // SQL statement. File-history shaping asks the same reader for distinct
     // schema slices of that history, so retain immutable change records here.
-    member_changes_cache: HashMap<Vec<String>, HashMap<CommitId, Vec<CommitGraphChange>>>,
+    member_changes_cache:
+        HashMap<(Vec<String>, Vec<String>), HashMap<CommitId, Vec<CommitGraphChange>>>,
 }
 
 enum LinearMergeBase {
@@ -565,7 +566,11 @@ where
         }
 
         for change in self
-            .load_member_changes(node.commit_id, &shaping.member_schema_keys)
+            .load_member_changes(
+                node.commit_id,
+                &shaping.member_schema_keys,
+                &shaping.member_file_ids,
+            )
             .await?
         {
             if !state.seen_changes.insert(history_change_identity(&change)) {
@@ -587,10 +592,12 @@ where
         &mut self,
         commit_id: CommitId,
         schema_keys: &[String],
+        file_ids: &[String],
     ) -> Result<Vec<CommitGraphChange>, LixError> {
+        let cache_key = (schema_keys.to_vec(), file_ids.to_vec());
         if let Some(changes) = self
             .member_changes_cache
-            .get(schema_keys)
+            .get(&cache_key)
             .and_then(|by_commit| by_commit.get(&commit_id))
         {
             return Ok(changes.clone());
@@ -599,6 +606,7 @@ where
             &self.store,
             commit_id,
             schema_keys,
+            file_ids,
             usize::MAX,
         )
         .await?
@@ -609,7 +617,7 @@ where
             .collect::<Vec<_>>();
         changes.sort_by_key(|change| change.id);
         self.member_changes_cache
-            .entry(schema_keys.to_vec())
+            .entry(cache_key)
             .or_default()
             .insert(commit_id, changes.clone());
         Ok(changes)
@@ -620,6 +628,15 @@ where
 /// walks the graph.
 struct HistoryShaping {
     member_schema_keys: Vec<String>,
+    /// Files the request restricts member changes to.
+    ///
+    /// `change_matches_history_request` discards any member whose `file_id` is
+    /// not in `request.file_ids`, so bounding the storage read on the same
+    /// component returns the same entries. It is only a selector when the
+    /// schema list is also known: a `schema_key | file_id` range needs both
+    /// components, and without the schema list the read visits every schema
+    /// anyway.
+    member_file_ids: Vec<String>,
     may_include_members: bool,
     may_include_commits: bool,
 }
@@ -634,6 +651,13 @@ impl HistoryShaping {
             .collect::<Vec<_>>();
         member_schema_keys.sort();
         member_schema_keys.dedup();
+        let mut member_file_ids = if member_schema_keys.is_empty() {
+            Vec::new()
+        } else {
+            request.file_ids.clone()
+        };
+        member_file_ids.sort();
+        member_file_ids.dedup();
         let may_include_members = request.schema_keys.is_empty() || !member_schema_keys.is_empty();
         let may_include_commits = request.schema_keys.is_empty()
             || request
@@ -642,6 +666,7 @@ impl HistoryShaping {
                 .any(|schema_key| schema_key == COMMIT_SCHEMA_KEY);
         Self {
             member_schema_keys,
+            member_file_ids,
             may_include_members,
             may_include_commits,
         }

--- a/packages/lix/src/hot_state/tracked_head/hot.rs
+++ b/packages/lix/src/hot_state/tracked_head/hot.rs
@@ -4090,6 +4090,11 @@ async fn scan_packed_current_base_rows(
                     store,
                     base_ref.commit_id,
                     &request.filter.schema_keys,
+                    // Not narrowed on file id: this function is reached only when
+                    // `request.filter.file_ids` is empty, so there is nothing to
+                    // narrow on. Revisiting that guard is what would make this
+                    // call site a candidate.
+                    &[],
                     // This API materializes the complete requested public
                     // result. Segment count is a physical-layout detail, not
                     // a memory budget, so it must not select a different read
@@ -5602,6 +5607,7 @@ where
                 &self.store,
                 commit_id,
                 &[schema_key.to_owned()],
+                &[],
                 // The exclusive publication's live count already defines the
                 // exact materialized result below. Do not impose a second
                 // physical-segment cardinality policy on the same result.

--- a/packages/lix/src/storage_bench.rs
+++ b/packages/lix/src/storage_bench.rs
@@ -458,6 +458,56 @@ pub(crate) fn record_key_decode_owned(input_bytes: usize, owned_string_bytes: us
     KEY_DECODE_OWNED_ESCAPED_STRINGS.fetch_add(u64::from(escaped), Ordering::Relaxed);
 }
 
+static COMMIT_DELTA_SEGMENT_ENTRIES_DECODED: AtomicU64 = AtomicU64::new(0);
+static COMMIT_DELTA_SEGMENT_MEMBERS_KEPT: AtomicU64 = AtomicU64::new(0);
+static COMMIT_DELTA_BOUNDED_SCANS_SCHEMA_ONLY: AtomicU64 = AtomicU64::new(0);
+static COMMIT_DELTA_BOUNDED_SCANS_FILE_BOUNDED: AtomicU64 = AtomicU64::new(0);
+static COMMIT_DELTA_BOUNDED_RANGES: AtomicU64 = AtomicU64::new(0);
+
+/// Counted INSIDE `collect_strict_commit_delta_members`' per-entry loop, at the
+/// `decode_value` / `decode_key` pair that does the work -- not at the member
+/// vector the scan returns. Those are different numbers: a selected segment is
+/// decoded whole and the schema/file retain is applied afterwards, so a count
+/// taken at the return value reports the surviving members and cannot
+/// distinguish a two-component seek from a schema-wide walk.
+pub(crate) fn record_commit_delta_segment_entry_decoded() {
+    COMMIT_DELTA_SEGMENT_ENTRIES_DECODED.fetch_add(1, Ordering::Relaxed);
+}
+
+pub(crate) fn record_commit_delta_segment_members_kept(members: usize) {
+    COMMIT_DELTA_SEGMENT_MEMBERS_KEPT.fetch_add(members as u64, Ordering::Relaxed);
+}
+
+/// Route counter for the directory-bounded member scan.
+///
+/// Without it a flat `entries_decoded` is unreadable: "the narrowing did not
+/// help" and "the narrowed route never ran" produce the same number. Note that
+/// `collect_strict_commit_delta_members` also serves the manifest route, which
+/// has no directory root and cannot be range-bounded at all -- these two
+/// counters are what separates the two.
+pub(crate) fn record_commit_delta_bounded_scan(file_bounded: bool, ranges: usize) {
+    if file_bounded {
+        COMMIT_DELTA_BOUNDED_SCANS_FILE_BOUNDED.fetch_add(1, Ordering::Relaxed);
+    } else {
+        COMMIT_DELTA_BOUNDED_SCANS_SCHEMA_ONLY.fetch_add(1, Ordering::Relaxed);
+    }
+    COMMIT_DELTA_BOUNDED_RANGES.fetch_add(ranges as u64, Ordering::Relaxed);
+}
+
+/// `(entries_decoded, members_kept, scans_schema_only, scans_file_bounded, ranges)`.
+///
+/// Process-global, like every counter in this module: assert thresholds scaled
+/// to your own fixture, never exact values, unless the test owns its process.
+pub fn take_commit_delta_member_scan_census() -> (u64, u64, u64, u64, u64) {
+    (
+        COMMIT_DELTA_SEGMENT_ENTRIES_DECODED.swap(0, Ordering::Relaxed),
+        COMMIT_DELTA_SEGMENT_MEMBERS_KEPT.swap(0, Ordering::Relaxed),
+        COMMIT_DELTA_BOUNDED_SCANS_SCHEMA_ONLY.swap(0, Ordering::Relaxed),
+        COMMIT_DELTA_BOUNDED_SCANS_FILE_BOUNDED.swap(0, Ordering::Relaxed),
+        COMMIT_DELTA_BOUNDED_RANGES.swap(0, Ordering::Relaxed),
+    )
+}
+
 pub(crate) fn record_commit_delta_row_loaded(account_id_bytes: usize) {
     COMMIT_DELTA_ROWS_LOADED.fetch_add(1, Ordering::Relaxed);
     COMMIT_DELTA_ROW_KEY_DECODES.fetch_add(1, Ordering::Relaxed);

--- a/packages/lix/src/tracked_state/storage.rs
+++ b/packages/lix/src/tracked_state/storage.rs
@@ -27,7 +27,8 @@ use crate::tracked_state::codec::{
     DecodedLeafNodeRef, DecodedNodeRef, EncodedLeafEntry, EncodedLeafEntryRef, PendingChunkBatch,
     TrackedStateKeyBatchBuilder, TrackedStateMutationBatchBuilder, decode_key, decode_key_shared,
     decode_node_ref, decode_value, encode_key_ref, encode_key_ref_into, encode_leaf_node_refs,
-    encode_schema_key_prefix, encode_single_string_key_ref_into, encode_value_ref,
+    encode_schema_file_prefix, encode_schema_key_prefix, encode_single_string_key_ref_into,
+    encode_value_ref,
 };
 pub(crate) use crate::tracked_state::types::{
     CommitDeltaLifecycleSummary, CommitDeltaReplacementScope,
@@ -7803,7 +7804,7 @@ pub(crate) async fn load_commit_delta_members_with_payloads(
     commit_id: CommitId,
 ) -> Result<Vec<CommitDeltaMember>, LixError> {
     Ok(
-        load_commit_delta_members_with_payloads_for_schemas(store, commit_id, &[], usize::MAX)
+        load_commit_delta_members_with_payloads_for_schemas(store, commit_id, &[], &[], usize::MAX)
             .await?
             .expect("unbounded commit-delta payload scan cannot exceed its segment limit"),
     )
@@ -7818,6 +7819,7 @@ pub(crate) async fn load_commit_delta_members_with_payloads_for_schemas(
     store: &(impl StorageAdapterRead + ?Sized),
     commit_id: CommitId,
     schema_keys: &[String],
+    file_ids: &[String],
     max_segment_count: usize,
 ) -> Result<Option<Vec<CommitDeltaMember>>, LixError> {
     let Some(state) = load_point_replay_commit_state(store, commit_id).await? else {
@@ -7828,6 +7830,7 @@ pub(crate) async fn load_commit_delta_members_with_payloads_for_schemas(
             store,
             &state,
             schema_keys,
+            file_ids,
             max_segment_count,
             true,
         )
@@ -7854,6 +7857,7 @@ pub(crate) async fn load_commit_delta_members_with_payloads_for_schemas(
         store,
         &source,
         schema_keys,
+        file_ids,
         max_segment_count.saturating_sub(local_segment_count),
         true,
     )
@@ -7889,6 +7893,7 @@ pub(crate) async fn load_local_selected_change_owner_commit_ids(
     let Some((members, _)) = load_authenticated_local_commit_delta_members_for_schemas(
         store,
         &state,
+        &[],
         &[],
         usize::MAX,
         false,
@@ -8111,6 +8116,7 @@ pub(crate) async fn load_retained_commit_snapshots_for_schemas(
         store,
         commit_id,
         schema_keys,
+        &[],
         usize::MAX,
     )
     .await?
@@ -8170,6 +8176,7 @@ async fn load_authenticated_local_commit_delta_members_for_schemas(
     store: &(impl StorageAdapterRead + ?Sized),
     state: &AuthenticatedReplayCommitStateManifest,
     schema_keys: &[String],
+    file_ids: &[String],
     max_segment_count: usize,
     hydrate_selected_payloads: bool,
 ) -> Result<Option<(Vec<CommitDeltaMember>, usize)>, LixError> {
@@ -8198,6 +8205,7 @@ async fn load_authenticated_local_commit_delta_members_for_schemas(
             store,
             state,
             schema_keys,
+            file_ids,
             max_segment_count,
             hydrate_selected_payloads,
         )
@@ -8270,10 +8278,68 @@ async fn load_authenticated_local_commit_delta_members_for_schemas(
     )))
 }
 
+/// Builds the commit-delta key ranges a member scan should read.
+///
+/// The key codec is `schema_key | file_id | entity_pk`, so a caller that knows
+/// which files it wants can bound the scan on two components instead of one.
+///
+/// # Why narrowing cannot change the answer
+///
+/// The only caller that passes a non-empty `file_ids` is the commit-graph
+/// history read, and `change_matches_history_request` treats a non-empty
+/// `request.file_ids` as requiring a **non-null** `file_id` that is in the set —
+/// so every member this range excludes is one that caller discards anyway.
+/// Members carrying a null `file_id` are excluded by construction, which is
+/// exactly what that post-filter does to them. The retains at the end of the
+/// scan still run: a range selects segments, and a segment is decoded whole.
+///
+/// # Why it matters
+///
+/// Without the file bound, a point-routed history read decodes every entity a
+/// bulk commit wrote. Measured on this tree with the per-entry decode census:
+/// 10 170 decoded entries for a 20-row answer when one commit touched 5 000
+/// files, growing as `2 * bulk_entities`.
+///
+/// The directory router requires sorted, non-overlapping selectors and never
+/// sorts defensively. Distinct `(schema_key, file_id)` prefixes are disjoint
+/// because `write_file_id` terminates the file component, and the ranges are
+/// sorted by encoded start key here rather than relying on the encoder to
+/// preserve `BTreeSet` ordering.
+fn bounded_commit_delta_key_ranges(
+    requested_schemas: &BTreeSet<&str>,
+    requested_files: &BTreeSet<&str>,
+) -> Vec<super::mutation_directory::MutationDirectoryKeyRange> {
+    fn range_from_prefix(prefix: Vec<u8>) -> super::mutation_directory::MutationDirectoryKeyRange {
+        super::mutation_directory::MutationDirectoryKeyRange {
+            end: prefix_successor(&prefix).map(Bytes::from),
+            start: Bytes::from(prefix),
+        }
+    }
+
+    let mut ranges = if requested_files.is_empty() {
+        requested_schemas
+            .iter()
+            .map(|schema_key| range_from_prefix(encode_schema_key_prefix(schema_key)))
+            .collect::<Vec<_>>()
+    } else {
+        requested_schemas
+            .iter()
+            .flat_map(|schema_key| {
+                requested_files.iter().map(move |file_id| {
+                    range_from_prefix(encode_schema_file_prefix(schema_key, Some(file_id)))
+                })
+            })
+            .collect::<Vec<_>>()
+    };
+    ranges.sort_by(|left, right| left.start.cmp(&right.start));
+    ranges
+}
+
 async fn load_bounded_commit_delta_members_for_schemas(
     store: &(impl StorageAdapterRead + ?Sized),
     state: &AuthenticatedReplayCommitStateManifest,
     schema_keys: &[String],
+    file_ids: &[String],
     max_segment_count: usize,
     hydrate_selected_payloads: bool,
 ) -> Result<Option<(Vec<CommitDeltaMember>, usize)>, LixError> {
@@ -8284,18 +8350,13 @@ async fn load_bounded_commit_delta_members_for_schemas(
         .iter()
         .map(String::as_str)
         .collect::<BTreeSet<_>>();
-    let ranges = requested_schemas
-        .iter()
-        .map(|schema_key| {
-            let start = encode_schema_key_prefix(schema_key);
-            super::mutation_directory::MutationDirectoryKeyRange {
-                end: prefix_successor(&start).map(Bytes::from),
-                start: Bytes::from(start),
-            }
-        })
-        .collect::<Vec<_>>();
+    let requested_files = file_ids.iter().map(String::as_str).collect::<BTreeSet<_>>();
+    let ranges = bounded_commit_delta_key_ranges(&requested_schemas, &requested_files);
     #[cfg(feature = "storage-benches")]
-    crate::storage_bench::record_commit_delta_bounded_scan(false, ranges.len());
+    crate::storage_bench::record_commit_delta_bounded_scan(
+        !requested_files.is_empty(),
+        ranges.len(),
+    );
     let runs = super::mutation_directory::load_mutation_part_read_plan(
         store,
         root,
@@ -8366,8 +8427,22 @@ async fn load_bounded_commit_delta_members_for_schemas(
         )?;
         validate_bounded_direct_row_count(root.layout, direct_row_count, members.len() - before)?;
     }
+    // Both retains survive the range narrowing and neither is redundant with
+    // it. A directory range selects *segments*, and a selected segment is
+    // decoded whole, so the first and last segment of any range routinely carry
+    // entries outside it. Dropping either would be a semantic change wearing a
+    // range-narrowing's clothes.
     if !requested_schemas.is_empty() {
         members.retain(|member| requested_schemas.contains(member.key.schema_key.as_str()));
+    }
+    if !requested_files.is_empty() {
+        members.retain(|member| {
+            member
+                .key
+                .file_id
+                .as_deref()
+                .is_some_and(|file_id| requested_files.contains(file_id))
+        });
     }
     #[cfg(feature = "storage-benches")]
     crate::storage_bench::record_commit_delta_segment_members_kept(members.len());
@@ -10733,6 +10808,7 @@ pub(crate) async fn collect_local_commit_delta_json_refs(
     let Some((members, _)) = Box::pin(load_authenticated_local_commit_delta_members_for_schemas(
         store,
         &state,
+        &[],
         &[],
         usize::MAX,
         false,
@@ -16149,6 +16225,145 @@ mod tests {
         );
     }
 
+    /// A file-bounded member scan must return the schema-bounded answer,
+    /// restricted.
+    ///
+    /// The oracle is the **unbounded** read: a scan with no `file_ids` builds a
+    /// `schema_key`-only range and cannot execute the narrowing at all, so it is
+    /// the answer a caller got before this bound existed. Filtering it in memory
+    /// on the same component the range bounds is what the narrowed read must
+    /// reproduce, exactly — including for a file id that does not exist, and
+    /// including the exclusion of members carrying a null `file_id`, which is
+    /// what `change_matches_history_request` does to them anyway.
+    ///
+    /// The fixture deliberately interleaves two schemas, three files and a
+    /// null-file member across enough entities to span several segments, since a
+    /// selected segment is decoded whole and the retains — not the ranges — are
+    /// what make partial-segment overlap invisible.
+    #[tokio::test]
+    async fn file_bounded_commit_delta_members_match_the_unbounded_answer() {
+        let storage = StorageAdapter::new(Memory::new());
+        let commit_id = CommitId::for_test_label("file-bounded-delta-commit");
+        let files = ["file-a", "file-b", "file-c"];
+        let fixtures = (0..300)
+            .map(|index: usize| CommitDeltaFixture {
+                schema_key: if index % 2 == 0 {
+                    "alpha".to_string()
+                } else {
+                    "beta".to_string()
+                },
+                // Every fourth member carries no file id at all.
+                file_id: if index % 4 == 3 {
+                    None
+                } else {
+                    Some(files[index % files.len()].to_string())
+                },
+                entity_pk: EntityPk::single(format!("entity-{index:04}")),
+                change_id: ChangeId::for_test_label(&format!("file-bounded-change-{index}")),
+                deleted: index % 7 == 0,
+                created_at: LixTimestamp::from_unix_millis_utc_lossy(index as i64),
+                updated_at: LixTimestamp::from_unix_millis_utc_lossy(index as i64 + 1),
+            })
+            .collect::<Vec<_>>();
+        let deltas = commit_delta_refs(commit_id, &fixtures);
+        let mut writes = storage.new_write_set();
+        stage_commit_deltas(&mut writes, &deltas).expect("file-bounded deltas should stage");
+        drop(deltas);
+        storage
+            .commit_write_set(writes, StorageWriteOptions::default())
+            .await
+            .expect("file-bounded delta commit should publish");
+        let read = storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("file-bounded delta read should open");
+
+        let schemas = ["alpha".to_string(), "beta".to_string()];
+        let unbounded = super::load_commit_delta_members_with_payloads_for_schemas(
+            &read, commit_id, &schemas, &[], usize::MAX,
+        )
+        .await
+        .expect("unbounded schema scan should load")
+        .expect("unbounded schema scan should be accepted");
+        assert!(
+            unbounded.len() > 200,
+            "the oracle must be a wide read, not a degenerate one: {}",
+            unbounded.len()
+        );
+
+        for requested in [
+            vec!["file-a".to_string()],
+            vec!["file-b".to_string(), "file-c".to_string()],
+            vec!["file-a".to_string(), "file-missing".to_string()],
+            vec!["file-missing".to_string()],
+        ] {
+            let expected = unbounded
+                .iter()
+                .filter(|member| {
+                    member
+                        .key
+                        .file_id
+                        .as_deref()
+                        .is_some_and(|file_id| requested.iter().any(|want| want == file_id))
+                })
+                .map(|member| (member.key.clone(), member.change.change_id))
+                .collect::<Vec<_>>();
+            let actual = super::load_commit_delta_members_with_payloads_for_schemas(
+                &read, commit_id, &schemas, &requested, usize::MAX,
+            )
+            .await
+            .expect("file-bounded scan should load")
+            .expect("file-bounded scan should be accepted")
+            .into_iter()
+            .map(|member| (member.key, member.change.change_id))
+            .collect::<Vec<_>>();
+            assert_eq!(
+                actual, expected,
+                "the file-bounded read must equal the unbounded read restricted to {requested:?}"
+            );
+        }
+
+        // Engagement, in the same process as the assertions above. Lower bounds
+        // only: these counters are process-global, so a concurrent test in this
+        // binary can push them up but never down.
+        #[cfg(feature = "storage-benches")]
+        {
+            let _ = crate::storage_bench::take_commit_delta_member_scan_census();
+            let _ = super::load_commit_delta_members_with_payloads_for_schemas(
+                &read,
+                commit_id,
+                &schemas,
+                &["file-a".to_string()],
+                usize::MAX,
+            )
+            .await
+            .expect("file-bounded scan should load");
+            let (decoded, _kept, schema_only, file_bounded, ranges) =
+                crate::storage_bench::take_commit_delta_member_scan_census();
+            assert!(
+                file_bounded >= 1 && ranges >= 2,
+                "a scan given file ids must take the file-bounded route:                  decoded={decoded} schema_only={schema_only} file_bounded={file_bounded}                  ranges={ranges}"
+            );
+
+            let _ = crate::storage_bench::take_commit_delta_member_scan_census();
+            let _ = super::load_commit_delta_members_with_payloads_for_schemas(
+                &read,
+                commit_id,
+                &schemas,
+                &[],
+                usize::MAX,
+            )
+            .await
+            .expect("unbounded scan should load");
+            let (_decoded, _kept, schema_only, _file_bounded, _ranges) =
+                crate::storage_bench::take_commit_delta_member_scan_census();
+            assert!(
+                schema_only >= 1,
+                "a scan given no file ids must keep the schema-only route"
+            );
+        }
+    }
+
     #[tokio::test]
     async fn packed_commit_deltas_preserve_point_and_schema_replay() {
         let storage = StorageAdapter::new(Memory::new());
@@ -16228,6 +16443,7 @@ mod tests {
             &read,
             commit_id,
             &["alpha".to_string()],
+            &[],
             usize::MAX,
         )
         .await
@@ -16249,6 +16465,7 @@ mod tests {
                 &read,
                 commit_id,
                 &["alpha".to_string()],
+                &[],
                 0,
             )
             .await

--- a/packages/lix/src/tracked_state/storage.rs
+++ b/packages/lix/src/tracked_state/storage.rs
@@ -8294,6 +8294,8 @@ async fn load_bounded_commit_delta_members_for_schemas(
             }
         })
         .collect::<Vec<_>>();
+    #[cfg(feature = "storage-benches")]
+    crate::storage_bench::record_commit_delta_bounded_scan(false, ranges.len());
     let runs = super::mutation_directory::load_mutation_part_read_plan(
         store,
         root,
@@ -8367,6 +8369,8 @@ async fn load_bounded_commit_delta_members_for_schemas(
     if !requested_schemas.is_empty() {
         members.retain(|member| requested_schemas.contains(member.key.schema_key.as_str()));
     }
+    #[cfg(feature = "storage-benches")]
+    crate::storage_bench::record_commit_delta_segment_members_kept(members.len());
     if hydrate_selected_payloads {
         hydrate_selected_members(store, &mut members).await?;
     }
@@ -11031,6 +11035,11 @@ fn collect_strict_commit_delta_members(
     let (leaf, payloads) = decode_commit_delta_with_payloads(bytes, expected_bounds)?;
     visit_commit_delta_leaf(&leaf, expected_commit_id, |_, _, _| Ok(()))?;
     for entry_index in 0..leaf.len() {
+        // The per-entry decode loop. A selected segment is decoded whole, so
+        // this is the only layer at which "how much did this scan read" and
+        // "how much did it return" are distinguishable.
+        #[cfg(feature = "storage-benches")]
+        crate::storage_bench::record_commit_delta_segment_entry_decoded();
         let entry = leaf.entry(entry_index)?.ok_or_else(|| {
             LixError::new(
                 LixError::CODE_INTERNAL_ERROR,


### PR DESCRIPTION
## The defect

`load_bounded_commit_delta_members_for_schemas` built its mutation-directory key range from
the **schema key alone**, though the commit-delta key codec is
`schema_key | file_id | entity_pk` and the commit-graph history request already carries the
file ids. A selected segment is decoded **whole**, so a point-routed history read decoded
every entity a bulk commit wrote.

## Measurement

Counted inside `collect_strict_commit_delta_members`' per-entry decode loop — the
`decode_value` / `decode_key` pair that does the work — not at the member vector the scan
returns. Those are different numbers, and only the first can distinguish a two-component
seek from a schema-wide walk.

**Neither pre-existing counter can serve this**, which is why the first commit adds one:

* `take_hot_blob_ref_scan_accounting` gates on
  `filter.schema_keys.len() == 1 && filter.schema_keys[0] == "lix_binary_blob_ref"`, so it
  reports **zero in both arms** on the two-schema `descriptor + blob_ref` request file
  history actually issues — a zero that reads as a clean win over a route it never observed.
* `record_commit_delta_row_loaded` is the point-lookup path, not this one.
* `PlanLoadAttribution::members_decoded` is root replay (`commit_root_rebuild.rs`).

20-row answer, one commit touching N files, 3 interleaved reps per arm — **identical in all
three reps on both arms**:

| `WHERE id = ?` | 500 files | 5 000 files |
|---|---|---|
| entries decoded, schema-key range only | 1 170 | **10 170** |
| entries decoded, `schema_key\|file_id` range | 425 | **425** |
| members kept after the retains | 1 001 → 3 | 10 001 → 3 |

The narrowed read is **flat in file count**. The old one grew as `2 * bulk_entities`
(one descriptor + one blob-ref per file). Route counters confirm engagement:
`scans_file_bounded` 0 → 2, `scans_schema_only` 3 → 2.

`WHERE path = ?` improves 15 179 → 5 434 but stays `O(files)`: its residual is the
**path-resolution walk**, which resolves a basename to file ids and therefore has no file ids
to bound on, by construction. That is a separate, already-characterised term (see the
"Not fixed here" note on #1445).

### Timing

`ryzen-9950x-III`, rocksdb, both arms prebuilt, 3 interleaved reps with arm-order rotation,
5 samples per lane, 5 000 files / 21 commits, no explicit checkpoints:

```
by_id     base p50 10.847 10.921 11.095 ms
          cand p50  3.493  3.683  3.537 ms   -67%,   ranges disjoint
by_path   base p50 17.342 17.804 17.774 ms
          cand p50  9.734  9.848  9.813 ms   -44.5%, ranges disjoint
500 files by_id    3.475 3.457 3.492  ->  2.858 2.968 2.850   -16.6%, disjoint
2000 commits / 200 files: both arms overlap on every lane, as expected -- the
  term is O(entities in a bulk commit), not O(commits).
null_control_kv: overlapping in both arms.
```

## Correctness

`change_matches_history_request` treats a non-empty `request.file_ids` as requiring a
**non-null** `file_id` that is in the set, and the commit-graph history read is the only
caller that passes a non-empty `file_ids` (every other call site passes `&[]` explicitly).
So every member the narrowed range excludes — including every null-file member — is one that
caller discards anyway.

**Both retains are kept and neither is redundant with the ranges.** A range selects
*segments*, and a segment is decoded whole, so the first and last segment of any range
routinely carry entries outside it. `file_bounded_commit_delta_members_match_the_unbounded_answer`
compares the narrowed read against the **unbounded** read — which builds a schema-only range
and cannot execute the narrowing at all — restricted in memory on the same component, over a
fixture interleaving two schemas, three files and null-file members across several segments,
including a file id that does not exist. **Verified by inversion: deleting the file retain
fails that test.**

The same test carries the engagement assertions, as lower bounds only (these counters are
process-global): a scan given file ids must take the file-bounded route; a scan given none
must keep the schema-only route.

The pre-existing `pinned_file_history_route_returns_the_unfiltered_answer` oracle covers the
SQL surface over renames, content clears, deletes and same-path recreation, and runs in the
gate.

## Relationship to the off-branch draft `50892d1fc`

I read it first, as instructed, and treated it as a draft. Both suspected problems are
**confirmed, and there is a third**:

1. Context drift at `commit_graph/context.rs @@ -538` — `git apply -C1` resolves it. Confirmed.
2. It deletes the `let requested_schemas` binding while the `members.retain(...)` that
   references it remains. Confirmed **empirically**, not by reading: applying it to
   `0b97f3c45` and running `cargo check -p lix --all-features` gives
   `error[E0425]: cannot find value 'requested_schemas' in this scope` ×2.
3. **Not previously known:** it misses a second call site. There are **two**
   `load_authenticated_local_commit_delta_members_for_schemas(store, &state, &[], usize::MAX,
   false)` calls (`storage.rs` ~7889 and ~10733); the draft patches only one, giving
   `error[E0061]: this function takes 6 arguments but 5 arguments were supplied`.

This PR is a reimplementation, not a port: the range builder takes the already-computed
`BTreeSet` borrows rather than rebuilding them, the file retain is added (the draft had
none), and the correctness argument is discharged by a test rather than by the commit message.

## Note for site B

`scan_packed_current_base_rows` is reached only when `request.filter.file_ids.is_empty()`, so
it has nothing to narrow on and this PR passes `&[]` there with a comment saying so.
**Revisiting that guard is what would make that call site a candidate** — narrowing it
without touching the guard is a flat measurement waiting to happen.

`scan_bounded_commit_delta_values` (the values twin) is **not** changed here: its callers do
not currently carry file ids in scope. It is a real follow-up, not a no-op — the file-history
observed-state scan does have a lookup-id set available.

## Format

No format change, no persisted field, no write-path or encoding symbol touched. The key codec
is read, never written differently. `REPOSITORY_PROTOCOL_VALUE` unchanged.

## Gate

Re-derived from `0b97f3c45`'s own `ci.yml` (no `--no-default-features` step, no
`wasm32-unknown-unknown` cargo step on that sha).

```
git rev-parse HEAD          601b2f2f47ffb45b3f60e245c5b692f376b48ec2 (before and after)
git status --porcelain      empty
CI_SCOPE_CONFIRMED_AT       0b97f3c45
cargo clippy --profile test --workspace --all-targets --all-features -- -D warnings   exit 0
cargo test --profile test --workspace --exclude lix_e2e --all-features --no-fail-fast exit 0
cargo test --profile test -p lix_e2e --features \
  sdk-tests,plugin-tests,server-protocol,storage-benches,slatedb,root-replay-trace \
  --no-fail-fast                                                                      exit 0

EXECUTED_TARGETS  test1=3431 passed across 38 targets   test2=172 passed across 27 targets
```

3431 vs the 3430/38 reference: the one added test.

## Harness note

The 50-file lane of `history_member_scan_census` is **not deterministic**: on a byte-identical
binary I measured 243 and 445 decoded entries for the same query. At that size the
directory-bounded route does not run at all (`scans_schema_only = scans_file_bounded = 0` —
the manifest route serves it), and minted UUID file ids reshuffle which entries share a
segment. The 500- and 5 000-file lanes were identical in 3/3 reps on both arms. Report those;
do not read the 50-file lane as a delta.
