### PR TITLE
perf(hot-state): stop cloning shared row buffers on every scanned row

### DIFF
--- a/packages/e2e/Cargo.toml
+++ b/packages/e2e/Cargo.toml
@@ -522,3 +522,8 @@ required-features = ["sdk-tests", "storage-benches", "slatedb"]
 name = "exppth2_txn_probe"
 path = "examples/exppth2_txn_probe.rs"
 required-features = ["storage-benches"]
+
+[[test]]
+name = "hot_scan_refcount_census"
+path = "tests/hot_scan_refcount_census.rs"
+required-features = ["storage-benches"]

--- a/packages/e2e/tests/hot_scan_refcount_census.rs
+++ b/packages/e2e/tests/hot_scan_refcount_census.rs
@@ -1,0 +1,146 @@
+//! Deterministic census of refcounted-buffer handle clones on the HOT scan
+//! read path.
+//!
+//! **Why a count and not a nanosecond figure.** A rate only travels within a
+//! host class — this fleet spans a 5.4x gap between its slowest and fastest
+//! machines, so "585 ns per scanned row" is a fact about one box. The number
+//! of times the scan duplicates a refcounted buffer handle is identical
+//! everywhere, so it is the half of a "we stopped cloning" claim that can be
+//! re-run anywhere and compared across agents and rounds.
+//!
+//! **Own process on purpose.** The counters in `lix::storage_bench` are
+//! process-global; an exact assertion on them inside the shared suite reads
+//! whatever every other concurrently running test happened to scan. A
+//! dedicated `[[test]]` target is its own process, which is what makes the
+//! exact per-row equalities below legitimate rather than flaky.
+//!
+//! The census counters sit on the clone expressions themselves, not on the
+//! functions containing them, so a site that stops cloning stops counting.
+
+use lix::storage_bench::take_hot_scan_refcount_census;
+use lix::{Value, open_lix};
+
+const ROWS: usize = 2_000;
+const SCHEMA_KEY: &str = "hot_scan_refcount_census_probe";
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn a_full_scan_clones_a_bounded_number_of_shared_handles_per_row() {
+    let lix = open_lix().await.expect("open in-memory lix");
+
+    let schema = serde_json::json!({
+        "x-lix-key": SCHEMA_KEY,
+        "x-lix-primary-key": ["/id"],
+        "type": "object",
+        "properties": {
+            "id": { "type": "string" },
+            "ordinal": { "type": "number" },
+            "lane": { "type": "string" }
+        },
+        "required": ["id", "ordinal", "lane"],
+        "additionalProperties": false
+    });
+    lix.execute(
+        "INSERT INTO lix_registered_schema (value) VALUES (lix_json($1))",
+        &[Value::Text(schema.to_string())],
+    )
+    .await
+    .expect("register census schema");
+
+    for chunk in (0..ROWS).collect::<Vec<_>>().chunks(500) {
+        let mut sql = format!("INSERT INTO {SCHEMA_KEY} (id, ordinal, lane) VALUES ");
+        let mut params = Vec::new();
+        for (offset, ordinal) in chunk.iter().enumerate() {
+            if offset > 0 {
+                sql.push(',');
+            }
+            let base = offset * 3;
+            sql.push_str(&format!("(${}, ${}, ${})", base + 1, base + 2, base + 3));
+            params.push(Value::Text(format!("/census/{ordinal:09}")));
+            params.push(Value::Integer(i64::try_from(*ordinal).expect("fits i64")));
+            params.push(Value::Text(format!("lane-{:02}", ordinal % 8)));
+        }
+        let result = lix.execute(&sql, &params).await.expect("seed census rows");
+        assert!(
+            result.rows_affected() > 0,
+            "a seed statement that affects no rows produces the same zero counters as a route that never ran"
+        );
+    }
+    lix.create_checkpoint()
+        .await
+        .expect("drive the census fixture to packed-base steady state");
+
+    // Discard everything the seed and the checkpoint decoded.
+    let _ = take_hot_scan_refcount_census();
+
+    // A predicate on a non-key column, so the entity provider parses each
+    // row's snapshot and filters it — the shape that used to rebuild the whole
+    // materialized batch row by row.
+    let result = lix
+        .execute(
+            &format!("SELECT id, ordinal, lane FROM {SCHEMA_KEY} WHERE ordinal >= $1 AND ordinal < $2"),
+            &[Value::Integer(0), Value::Integer(i64::try_from(ROWS).expect("fits i64"))],
+        )
+        .await
+        .expect("scan census rows");
+    assert_eq!(result.rows().len(), ROWS, "the census must observe a full scan");
+
+    let (rows_decoded, key_clones, value_clones, row_clones) = take_hot_scan_refcount_census();
+
+    // The route ran at all. A zero here is indistinguishable from a census
+    // that never fired, which is why it is asserted before any ratio.
+    assert!(
+        rows_decoded >= ROWS as u64,
+        "hot scan decoded {rows_decoded} rows for a {ROWS}-row answer; the scan route was not taken"
+    );
+
+    let per_row = |count: u64| count as f64 / rows_decoded as f64;
+    println!(
+        "HOT_SCAN_REFCOUNT_CENSUS rows_decoded={rows_decoded} \
+         key_handle_clones={key_clones} ({:.3}/row) \
+         value_handle_clones={value_clones} ({:.3}/row) \
+         row_handle_clones={row_clones} ({:.3}/row) \
+         total={} ({:.3}/row)",
+        per_row(key_clones),
+        per_row(value_clones),
+        per_row(row_clones),
+        key_clones + value_clones + row_clones,
+        per_row(key_clones + value_clones + row_clones),
+    );
+
+    // One string primary-key component per row, cloned onto the row's own
+    // physical key buffer while decoding it. This is the traffic that is still
+    // standing after the in-place filter landed.
+    assert_eq!(
+        key_clones, rows_decoded,
+        "each decoded row should duplicate exactly one handle onto its own key"
+    );
+
+    // The ceiling that actually regresses, and the reason this file exists.
+    // Before materialized batches were compacted in place, each surviving row
+    // was cloned into a second columnar owner twice over — once by the entity
+    // provider's filter rebuild and once by the materialization path — and
+    // this lane measured **5.015 batch-rebuild handle clones per decoded
+    // row**. It now measures 0.043, from the handful of point-shaped reads the
+    // statement still issues around the scan.
+    //
+    // The threshold is a tenth of a clone per row: fifty times the observed
+    // value and fifty times below the pre-fix value, so it cannot be tripped
+    // by fixture drift but cannot survive the rebuild coming back either.
+    // It is a threshold and not an equality because these counters are
+    // process-global and the surrounding statement is not the only thing in
+    // the process that materializes a row.
+    assert!(
+        row_clones * 10 <= rows_decoded,
+        "materialized batches should be compacted in place, not rebuilt row by row; \
+         got {row_clones} batch-rebuild handle clones for {rows_decoded} decoded rows \
+         ({:.3}/row, ceiling 0.100/row)",
+        per_row(row_clones)
+    );
+
+    // Bounded, not exact: a row's inline JSON slots are snapshot content and
+    // metadata, and this schema writes no metadata.
+    assert!(
+        value_clones <= rows_decoded,
+        "got {value_clones} value handle clones for {rows_decoded} rows"
+    );
+}

--- a/packages/lix/src/entity_pk.rs
+++ b/packages/lix/src/entity_pk.rs
@@ -24,6 +24,25 @@ pub(crate) struct EntityPk {
     pub(crate) components: EntityPkComponents,
 }
 
+impl EntityPk {
+    /// How many refcounted buffer handles one `clone` of this key duplicates.
+    ///
+    /// A composite key shares one `Arc` over its component slice, so it costs
+    /// exactly one handle no matter how many components it has; a single
+    /// string or bytes component costs one; a UUID or integer costs none.
+    #[cfg(feature = "storage-benches")]
+    pub(crate) fn shared_handle_count(&self) -> usize {
+        match &self.components {
+            EntityPkComponents::Empty => 0,
+            EntityPkComponents::Single(component) => match component {
+                EntityPkComponent::String(_) | EntityPkComponent::Bytes(_) => 1,
+                EntityPkComponent::Uuid(_) | EntityPkComponent::Integer(_) => 0,
+            },
+            EntityPkComponents::Shared(_) => 1,
+        }
+    }
+}
+
 /// A single primary-key component stays inline; composite tuples share one
 /// immutable component slice across every identity clone.
 ///

--- a/packages/lix/src/hot_state/tracked_head.rs
+++ b/packages/lix/src/hot_state/tracked_head.rs
@@ -2299,10 +2299,14 @@ fn materialize_live_slot(
     }
     match slot {
         HeadSlotView::None => None,
-        HeadSlotView::Inline(json) | HeadSlotView::InlineFingerprinted { json, .. } => Some(
-            SharedStr::from_utf8_slice(owner.clone(), json)
-                .expect("decoded inline JSON points into its head-value buffer"),
-        ),
+        HeadSlotView::Inline(json) | HeadSlotView::InlineFingerprinted { json, .. } => {
+            #[cfg(feature = "storage-benches")]
+            crate::storage_bench::record_hot_scan_value_handle_clone();
+            Some(
+                SharedStr::from_utf8_slice(owner.clone(), json)
+                    .expect("decoded inline JSON points into its head-value buffer"),
+            )
+        }
         HeadSlotView::Ref(json_ref) => {
             json_refs.push(json_ref);
             deferred.push(DeferredJson {

--- a/packages/lix/src/hot_state/tracked_head/hot.rs
+++ b/packages/lix/src/hot_state/tracked_head/hot.rs
@@ -10459,6 +10459,8 @@ impl HotScanString {
                     // SAFETY: the decoder validated this exact range.
                     unsafe { std::str::from_utf8_unchecked(&key[range]) }
                 };
+                #[cfg(feature = "storage-benches")]
+                crate::storage_bench::record_hot_scan_key_handle_clone();
                 SharedStr::from_utf8_slice(key.clone(), value)
                     .expect("decoded key string remains inside its retained key")
             }
@@ -12360,6 +12362,8 @@ fn decode_hot_scan_row_key_in_scope(key: Bytes, scope: &[u8]) -> Result<HotScanI
     if offset != key.len() {
         return Err(key_codec_error("hot row key has trailing bytes"));
     }
+    #[cfg(feature = "storage-benches")]
+    crate::storage_bench::record_hot_scan_row_decoded();
     Ok(HotScanIdentity {
         key,
         schema_key,
@@ -12551,7 +12555,11 @@ fn read_hot_scan_shared_bytes(
     *offset = part.end;
     let value = match part.value {
         // No escape: hand back a refcounted slice of the same allocation.
-        ScannedKeyValue::Verbatim(range) => bytes.slice(range),
+        ScannedKeyValue::Verbatim(range) => {
+            #[cfg(feature = "storage-benches")]
+            crate::storage_bench::record_hot_scan_key_handle_clone();
+            bytes.slice(range)
+        }
         // Embedded NULs had to be unescaped, so this case owns its buffer.
         ScannedKeyValue::Unescaped(value) => Bytes::from(value),
     };

--- a/packages/lix/src/hot_state/tracked_head/hot.rs
+++ b/packages/lix/src/hot_state/tracked_head/hot.rs
@@ -10574,10 +10574,22 @@ impl LiveMaterializationIdentity for HotScanIdentity {
         untracked: bool,
         branch_id: &str,
     ) {
-        rows.push_materialized_ref(
-            &self.entity_pk,
-            self.schema_key(),
-            self.file_id(),
+        // `self` is consumed here, so the primary key moves into the column
+        // instead of being cloned out of a value about to be dropped. The
+        // identity strings stay borrowed: they are slices of the retained key
+        // and the builder interns them into its shared dictionary.
+        let Self {
+            key,
+            schema_key,
+            entity_pk,
+            file_id,
+        } = self;
+        let schema_key = schema_key.as_str(&key);
+        let file_id = file_id.as_ref().map(|file_id| file_id.as_str(&key));
+        rows.push_materialized_interned(
+            entity_pk,
+            schema_key,
+            file_id,
             snapshot_content,
             metadata,
             deleted,

--- a/packages/lix/src/hot_state/types.rs
+++ b/packages/lix/src/hot_state/types.rs
@@ -1041,6 +1041,8 @@ impl MaterializedHotStateBatchBuilder {
         untracked: bool,
         branch_id: &str,
     ) -> usize {
+        #[cfg(feature = "storage-benches")]
+        crate::storage_bench::record_hot_scan_row_handle_clones(entity_pk.shared_handle_count());
         self.push_materialized_interned(
             entity_pk.clone(),
             schema_key,
@@ -1129,6 +1131,12 @@ impl MaterializedHotStateBatchBuilder {
         row: MaterializedHotStateRowRef<'_>,
         branch_override: Option<&str>,
     ) -> usize {
+        #[cfg(feature = "storage-benches")]
+        crate::storage_bench::record_hot_scan_row_handle_clones(
+            row.entity_pk().shared_handle_count()
+                + usize::from(row.snapshot_content().is_some())
+                + usize::from(row.metadata().is_some()),
+        );
         let ordinal = self.len();
         if self.singleton_capacity {
             let branch_id = branch_override.map_or_else(|| row.branch_owner(), Arc::from);

--- a/packages/lix/src/hot_state/types.rs
+++ b/packages/lix/src/hot_state/types.rs
@@ -258,25 +258,71 @@ impl MaterializedHotStateBatch {
             .map_or_else(|| self.branch_ids[index].0 as usize, |_| 0)
     }
 
+    /// Drops every row rejected by `keep`, compacting the columns this batch
+    /// already owns.
+    ///
+    /// **This consumes the batch on purpose.** Filtering used to build a
+    /// second columnar owner row by row, which cloned every `SharedStr` and
+    /// every `EntityPk` component of every surviving row — one atomic
+    /// increment per shared buffer per row, plus the matching decrement when
+    /// the source batch was dropped. None of that traffic moves any bytes.
+    /// Compacting in place *moves* the same buffers instead, so a filter now
+    /// costs no refcount traffic at all.
+    ///
+    /// The string dictionary is deliberately left uncompacted. It holds one
+    /// entry per *distinct* schema key, file id and branch id rather than one
+    /// per row, so a dropped row strands no per-row allocation, and every
+    /// surviving row keeps the ordinal it was built with.
     pub(crate) fn filter(
-        &self,
+        mut self,
         mut keep: impl FnMut(MaterializedHotStateRowRef<'_>) -> bool,
         limit: Option<usize>,
     ) -> Self {
-        let capacity = limit.map_or_else(|| self.len(), |limit| limit.min(self.len()));
-        let mut builder = MaterializedHotStateBatchBuilder::with_capacity(capacity);
-        if capacity == 0 && limit.is_some() {
-            return builder.finish();
+        if limit == Some(0) {
+            return Self::default();
         }
-        for row in self.iter() {
-            if keep(row) {
-                builder.push_ref(row, None);
-                if builder.len() == capacity && limit.is_some() {
-                    break;
-                }
-            }
+        if self.singleton.is_some() {
+            return if keep(self.row(0)) {
+                self
+            } else {
+                Self::default()
+            };
         }
-        builder.finish()
+        let limit = limit.unwrap_or(usize::MAX);
+        let mut kept = 0_usize;
+        let mut mask = Vec::with_capacity(self.len());
+        for index in 0..self.len() {
+            // Short-circuits once the limit is reached, so `keep` observes the
+            // same prefix of rows a row-by-row rebuild would have shown it.
+            let retain = kept < limit && keep(self.row(index));
+            kept += usize::from(retain);
+            mask.push(retain);
+        }
+        if kept == mask.len() {
+            return self;
+        }
+        if kept == 0 {
+            return Self::default();
+        }
+        retain_by_mask(&mut self.schema_keys, &mask);
+        retain_by_mask(&mut self.file_ids, &mask);
+        retain_by_mask(&mut self.branch_ids, &mask);
+        retain_by_mask(&mut self.entity_pks, &mask);
+        retain_by_mask(&mut self.snapshot_content, &mask);
+        retain_by_mask(&mut self.metadata, &mask);
+        retain_by_mask(&mut self.deleted, &mask);
+        retain_by_mask(&mut self.created_at, &mask);
+        retain_by_mask(&mut self.updated_at, &mask);
+        retain_by_mask(&mut self.global, &mask);
+        retain_by_mask(&mut self.change_id, &mask);
+        retain_by_mask(&mut self.commit_id, &mask);
+        retain_by_mask(&mut self.untracked, &mask);
+        retain_by_mask(&mut self.durable_predecessor, &mask);
+        if let Some(coordinates) = self.columnar_base_coordinate.as_mut() {
+            retain_by_mask(coordinates, &mask);
+        }
+        debug_assert_eq!(self.entity_pks.len(), kept);
+        self
     }
 
     #[cfg(test)]
@@ -695,6 +741,21 @@ impl MaterializedHotStateExactBatch {
     }
 }
 
+/// Keeps the elements whose `mask` entry is `true`, preserving order.
+///
+/// `Vec::retain` visits elements in their original order, so one shared mask
+/// compacts every parallel column of a batch identically. Elements are moved,
+/// never cloned, which is the whole point of filtering in place.
+fn retain_by_mask<T>(values: &mut Vec<T>, mask: &[bool]) {
+    debug_assert_eq!(values.len(), mask.len());
+    let mut index = 0_usize;
+    values.retain(|_| {
+        let retain = mask[index];
+        index += 1;
+        retain
+    });
+}
+
 fn owned_row_dictionary_capacity(rows: &[MaterializedHotStateRow]) -> (usize, usize) {
     let mut seen = HashSet::<&str, FastHashBuilder>::with_capacity_and_hasher(
         rows.len().saturating_mul(3),
@@ -980,10 +1041,53 @@ impl MaterializedHotStateBatchBuilder {
         untracked: bool,
         branch_id: &str,
     ) -> usize {
+        self.push_materialized_interned(
+            entity_pk.clone(),
+            schema_key,
+            file_id,
+            snapshot_content,
+            metadata,
+            deleted,
+            created_at,
+            updated_at,
+            global,
+            change_id,
+            commit_id,
+            untracked,
+            branch_id,
+        )
+    }
+
+    /// Appends a row whose identity strings are interned from borrows but
+    /// whose primary key is **moved** into the column.
+    ///
+    /// A decoded HOT scan row already owns its `EntityPk`, and every component
+    /// of that key is a `Bytes` slice of the retained physical key. Handing it
+    /// to [`Self::push_materialized_ref`] clones each component — an atomic
+    /// increment per component per row, immediately followed by the matching
+    /// decrement when the decoded row is dropped — to produce a value the
+    /// caller was about to discard anyway. Moving it costs nothing.
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn push_materialized_interned(
+        &mut self,
+        entity_pk: EntityPk,
+        schema_key: &str,
+        file_id: Option<&str>,
+        snapshot_content: Option<SharedStr>,
+        metadata: Option<SharedStr>,
+        deleted: bool,
+        created_at: LixTimestamp,
+        updated_at: LixTimestamp,
+        global: bool,
+        change_id: Option<ChangeId>,
+        commit_id: Option<CommitId>,
+        untracked: bool,
+        branch_id: &str,
+    ) -> usize {
         let ordinal = self.len();
         if self.singleton_capacity {
             self.push_owned(MaterializedHotStateRow {
-                entity_pk: entity_pk.clone(),
+                entity_pk,
                 schema_key: schema_key.to_owned(),
                 file_id: file_id.map(str::to_owned),
                 snapshot_content,
@@ -1006,7 +1110,7 @@ impl MaterializedHotStateBatchBuilder {
             schema_key,
             file_id,
             branch_id,
-            entity_pk.clone(),
+            entity_pk,
             snapshot_content,
             metadata,
             deleted,
@@ -1658,18 +1762,73 @@ mod batch_tests {
         let batch = MaterializedHotStateBatch::from_rows(
             (0..10_000).map(|_| row(entity_pk.clone())).collect(),
         );
+        let dictionary_bytes_len = batch.dictionary_bytes_len();
         let filtered = batch.filter(|_| true, None);
 
         assert_eq!(filtered.len(), 10_000);
         assert_eq!(filtered.dictionary_entry_count(), 3);
-        assert_eq!(
-            filtered.dictionary_bytes_len(),
-            batch.dictionary_bytes_len()
-        );
+        assert_eq!(filtered.dictionary_bytes_len(), dictionary_bytes_len);
         assert_eq!(
             filtered.row(0).schema_key().as_ptr(),
             filtered.row(9_999).schema_key().as_ptr()
         );
+    }
+
+    #[test]
+    fn filtering_moves_surviving_rows_instead_of_cloning_their_buffers() {
+        let shared = EntityPk::single("shared_entity");
+        let batch = MaterializedHotStateBatch::from_rows(
+            (0..1_000)
+                .map(|index| {
+                    row(if index % 2 == 0 {
+                        shared.clone()
+                    } else {
+                        EntityPk::single("dropped_entity")
+                    })
+                })
+                .collect(),
+        );
+        let survivors = batch
+            .iter()
+            .filter(|row| row.entity_pk() == &shared)
+            .count();
+        assert_eq!(survivors, 500);
+        let entity_column = batch.entity_column_ptr();
+
+        let filtered = batch.filter(|row| row.entity_pk() == &shared, None);
+
+        assert_eq!(filtered.len(), 500);
+        assert!(filtered.iter().all(|row| row.entity_pk() == &shared));
+        // The surviving rows still live in the allocation they were built in.
+        // A row-by-row rebuild would have cloned every `EntityPk` component
+        // and every `SharedStr` into a second owner, which is the atomic
+        // refcount traffic this filter exists to avoid.
+        assert_eq!(filtered.entity_column_ptr(), entity_column);
+        // The dictionary is carried over rather than rebuilt, so every
+        // surviving row still points at the same interned schema key.
+        assert_eq!(
+            filtered.row(0).schema_key().as_ptr(),
+            filtered.row(499).schema_key().as_ptr()
+        );
+    }
+
+    #[test]
+    fn filtering_stops_calling_the_predicate_once_the_limit_is_reached() {
+        let batch = MaterializedHotStateBatch::from_rows(
+            (0..16).map(|_| row(EntityPk::single("row"))).collect(),
+        );
+        let mut visited = 0_usize;
+
+        let filtered = batch.filter(
+            |_| {
+                visited += 1;
+                true
+            },
+            Some(4),
+        );
+
+        assert_eq!(filtered.len(), 4);
+        assert_eq!(visited, 4);
     }
 
     #[test]

--- a/packages/lix/src/sql2/providers/entity.rs
+++ b/packages/lix/src/sql2/providers/entity.rs
@@ -28,7 +28,7 @@ use crate::hot_state::MaterializedHotStateRow;
 use crate::hot_state::{
     HotStateFilter, HotStateProjection, HotStateReader, HotStateRowFilter, HotStateScanRequest,
 };
-use crate::hot_state::{MaterializedHotStateBatch, MaterializedHotStateBatchBuilder};
+use crate::hot_state::MaterializedHotStateBatch;
 use crate::sql2::branch_scope::{BranchBinding, resolve_provider_branch_ids};
 use crate::sql2::catalog::{
     EntityColumnType, EntitySurfaceShape, EntitySurfaceSpec, PublicCatalog, PublicSurfaceKind,
@@ -2899,36 +2899,55 @@ fn apply_entity_batch_filters(
             parsed_snapshots: None,
         });
     }
-    let mut filtered = MaterializedHotStateBatchBuilder::with_capacity(rows.len());
     let mut parsed_snapshots = Vec::with_capacity(rows.len());
-    for row in rows.iter() {
-        let Some(snapshot_content) = row.snapshot_content().map(AsRef::<str>::as_ref) else {
-            continue;
-        };
-        let snapshot = parse_snapshot_value(snapshot_content).map_err(|error| {
-            DataFusionError::External(Box::new(LixError::new(
-                LixError::CODE_INTERNAL_ERROR,
-                format!(
-                    "entity scan filter could not parse snapshot_content for schema '{}' entity_pk '{:?}': {error}",
-                    row.schema_key(),
-                    row.entity_pk()
-                ),
-            )))
-        })?;
-        let mut matches = true;
-        for filter in filters {
-            if !filter.matches_snapshot(Some(&snapshot), row.schema_key())? {
-                matches = false;
-                break;
+    // The batch is compacted in place. Rebuilding it row by row cloned every
+    // surviving row's shared identity and snapshot buffers and then dropped
+    // the originals, which is pure atomic refcount traffic over bytes that
+    // never move.
+    let mut failure: Option<DataFusionError> = None;
+    let rows = rows.filter(
+        |row| {
+            if failure.is_some() {
+                return false;
             }
-        }
-        if matches {
-            filtered.push_ref(row, None);
+            let Some(snapshot_content) = row.snapshot_content().map(AsRef::<str>::as_ref) else {
+                return false;
+            };
+            let snapshot = match parse_snapshot_value(snapshot_content) {
+                Ok(snapshot) => snapshot,
+                Err(error) => {
+                    failure = Some(DataFusionError::External(Box::new(LixError::new(
+                        LixError::CODE_INTERNAL_ERROR,
+                        format!(
+                            "entity scan filter could not parse snapshot_content for schema '{}' entity_pk '{:?}': {error}",
+                            row.schema_key(),
+                            row.entity_pk()
+                        ),
+                    ))));
+                    return false;
+                }
+            };
+            for filter in filters {
+                match filter.matches_snapshot(Some(&snapshot), row.schema_key()) {
+                    Ok(true) => {}
+                    Ok(false) => return false,
+                    Err(error) => {
+                        failure = Some(error);
+                        return false;
+                    }
+                }
+            }
             parsed_snapshots.push(Some(snapshot));
-        }
+            true
+        },
+        None,
+    );
+    if let Some(failure) = failure {
+        return Err(failure);
     }
+    debug_assert_eq!(rows.len(), parsed_snapshots.len());
     Ok(FilteredEntityBatch {
-        rows: filtered.finish(),
+        rows,
         parsed_snapshots: Some(parsed_snapshots),
     })
 }

--- a/packages/lix/src/storage_bench.rs
+++ b/packages/lix/src/storage_bench.rs
@@ -3931,6 +3931,61 @@ mod tests {
     }
 }
 
+static HOT_SCAN_ROWS_DECODED: AtomicU64 = AtomicU64::new(0);
+static HOT_SCAN_KEY_HANDLE_CLONES: AtomicU64 = AtomicU64::new(0);
+static HOT_SCAN_VALUE_HANDLE_CLONES: AtomicU64 = AtomicU64::new(0);
+static HOT_SCAN_ROW_HANDLE_CLONES: AtomicU64 = AtomicU64::new(0);
+
+pub(crate) fn record_hot_scan_row_decoded() {
+    HOT_SCAN_ROWS_DECODED.fetch_add(1, Ordering::Relaxed);
+}
+
+pub(crate) fn record_hot_scan_key_handle_clone() {
+    HOT_SCAN_KEY_HANDLE_CLONES.fetch_add(1, Ordering::Relaxed);
+}
+
+pub(crate) fn record_hot_scan_value_handle_clone() {
+    HOT_SCAN_VALUE_HANDLE_CLONES.fetch_add(1, Ordering::Relaxed);
+}
+
+pub(crate) fn record_hot_scan_row_handle_clones(count: usize) {
+    if count != 0 {
+        HOT_SCAN_ROW_HANDLE_CLONES.fetch_add(count as u64, Ordering::Relaxed);
+    }
+}
+
+/// Refcounted-buffer handle clones on the HOT scan read path, as
+/// `(rows_decoded, key_handle_clones, value_handle_clones, row_handle_clones)`.
+///
+/// **A count, not a rate.** Nanoseconds per row only travel within a host
+/// class; this number is identical on every machine, so it is the portable
+/// half of any "we stopped cloning" claim.
+///
+/// Every counter sits on the clone expression itself rather than on the
+/// function that contains it, so a site that stops cloning stops counting and
+/// a site that is merely renamed keeps counting. The buckets are:
+///
+/// * `rows_decoded` — one per HOT scan row key decoded. The denominator.
+/// * `key_handle_clones` — handles duplicated onto a row's own **physical
+///   key** buffer while decoding it (one per string or bytes primary-key
+///   component).
+/// * `value_handle_clones` — handles duplicated onto a row's **head value**
+///   buffer while materializing inline JSON.
+/// * `row_handle_clones` — handles duplicated while building or rebuilding a
+///   materialized batch (`push_ref`, `push_materialized_ref`). A batch
+///   rebuilt row by row pays these; a batch compacted in place does not.
+///
+/// These are process-global. Read them from a dedicated `[[test]]` target, or
+/// swap them immediately before the measured statement.
+pub fn take_hot_scan_refcount_census() -> (u64, u64, u64, u64) {
+    (
+        HOT_SCAN_ROWS_DECODED.swap(0, Ordering::Relaxed),
+        HOT_SCAN_KEY_HANDLE_CLONES.swap(0, Ordering::Relaxed),
+        HOT_SCAN_VALUE_HANDLE_CLONES.swap(0, Ordering::Relaxed),
+        HOT_SCAN_ROW_HANDLE_CLONES.swap(0, Ordering::Relaxed),
+    )
+}
+
 static HOT_BLOB_REF_SCAN_CALLS: AtomicU64 = AtomicU64::new(0);
 static HOT_BLOB_REF_SCAN_POINT_BATCH: AtomicU64 = AtomicU64::new(0);
 static HOT_BLOB_REF_SCAN_FILE_PREFIX: AtomicU64 = AtomicU64::new(0);


### PR DESCRIPTION
## What this is

A frame-pointer profile of a 200 000-row range scan, self time gated through
`execute_read_statement_with_store`, attributed **36% of the scan to `bytes::Bytes`
refcounting** and **0.08% to Arrow**. That share is atomic refcount traffic, not
data movement: a contended increment per clone and a decrement per drop, per row,
per scan.

This removes the three call sites responsible. **No format change** — nothing
persisted changes shape, and the diff touches no write path or encoding symbol.

## Where the clones were

Every one of them cloned a buffer the caller was about to discard.

| site | what it did |
|---|---|
| `MaterializedHotStateBatch::filter` | rebuilt a **second columnar owner row by row** through `push_ref`, cloning each surviving row's `SharedStr`s and each `EntityPk` component, then dropped the original |
| `apply_entity_batch_filters` (entity provider) | the same rebuild again, one layer up |
| `HotScanIdentity::push_materialized` | consumes `self`, yet called `push_materialized_ref`, which **cloned the primary key out of a value dropped on the next line** |

## What it does now

`filter` **consumes** the batch and compacts the columns it already owns against one
shared keep mask, so surviving rows are *moved*. The string dictionary is carried over
rather than rebuilt — it holds one entry per *distinct* schema key, file id and branch
id, not one per row, so a dropped row strands no per-row allocation. A new
`push_materialized_interned` interns the identity strings from borrows while *moving*
the key.

No `unsafe`, no new lifetime relationships, no borrow escaping a buffer's owner.

## Evidence

Machine `ryzen-9950x-I`. RocksDB, **mimalloc** as `#[global_allocator]`, 200 000 rows,
one checkpoint, `range` shape, 3 interleaved reps with arm-order rotation. Both arms
built from `0b97f3c45`; the candidate binary was verified to contain
`push_materialized_interned` and the baseline binary verified not to.

Raw per-rep milliseconds:

| n | baseline | candidate | median delta |
|---|---|---|---|
| 1 000 | 184.4 183.8 185.3 | 145.0 145.0 144.7 | **−21.4%** |
| 10 000 | 185.8 185.4 187.8 | 146.6 146.7 147.9 | **−21.0%** |
| 100 000 | 203.3 202.6 204.6 | 162.8 163.8 163.3 | **−19.7%** |

**Ranges are disjoint at every size.** A **null control** of two consecutive baseline
runs read 184.9–190.8 ms — overlapping the baseline, nowhere near the candidate.

**Both arms return byte-identical answers**: the bench's result fold is
`328159715142113358` in every run of both arms, including the frame-pointer runs.

### Same instrument before and after

`perf record -F 2999 --call-graph fp`, frame pointers and `+sse4.2,+pclmulqdq` via env
`RUSTFLAGS` into a separate target dir, self time gated to the read subtree:

| symbol | base | cand |
|---|---|---|
| `shared_clone` | 15.25% | **1.73%** |
| `shared_drop` | 11.02% | **4.72%** |
| `shallow_clone_vec` | 4.07% | 4.70% |
| `promotable_even_drop` | 3.38% | 4.84% |
| `promotable_even_clone` | 2.64% | **0.03%** |
| **total refcount** | **36.35%** | **16.02%** |

Those are shares of a pie that itself shrank. Per query, refcount work falls **66%**
(0.375 → 0.128 Gcycles/query; gated cycles/query 1.033 → 0.801, −22.4%, matching the
wall clock).

All three targeted callers disappear from the attribution:
`filter → shared_clone` 11.08% → 0, `push_ref → {promotable_even_clone, shared_drop}`
5.80% → 0, `push_materialized → shared_clone` 2.96% → 0.

The two symbols that did **not** fall are the promotion and drop of each row's own
physical key inside `decode_hot_scan_row_key_in_scope`. This change does not address
them and their absolute cost is flat; they are the next target on this axis.

### A trap worth recording

The first candidate frame-pointer build was a **no-op**: `cargo build` with a shared
`CARGO_TARGET_DIR` across two worktrees at the same sha reported `Finished in 0.12s`
and left the *baseline* binary in place, so the "candidate" profile was the baseline
profile. It was caught because the candidate's wall clock matched the baseline's to
0.05%. Every arm here uses a **dedicated target dir**, and arm identity is asserted by
symbol presence in the binary, not by which directory it came from.

## Not in scope

The other 30% of the scan is `serde_json` re-parsing each row's snapshot on every scan.
That needs typed columns in the packed base and therefore a `REPOSITORY_PROTOCOL_VALUE`
break; it is being scoped separately.
