### PR TITLE
perf(lix): skip the descriptor parse path resolution cannot match

### DIFF
--- a/packages/e2e/tests/history_scaling_probe.rs
+++ b/packages/e2e/tests/history_scaling_probe.rs
@@ -314,6 +314,51 @@ async fn history_member_scan_census() {
     }
 }
 
+/// Descriptor snapshots parsed by path resolution, swept over file count.
+///
+/// Counted at the `serde_json::from_str` the prefilter is meant to avoid, not
+/// at the resolved id set -- that set is the same either way and cannot tell a
+/// skipped parse from a performed one. `prefilter_on/off` is printed so a zero
+/// `prefiltered` is readable: it means either "every descriptor matched" or
+/// "the prefilter refused these names", which are different findings.
+#[tokio::test]
+#[ignore = "manual history-scaling probe"]
+async fn history_path_resolver_census() {
+    let file_bytes = env_usize("LIX_HISTORY_SCALE_FILE_BYTES", 4 * 1024);
+    let edits = env_usize("LIX_HISTORY_SCALE_EDITS", 20);
+    let depth = env_usize("LIX_HISTORY_SCALE_DEPTH", 20);
+
+    for files in env_list("LIX_HISTORY_SCALE_FILES", "500,5000") {
+        let dir = tempfile::tempdir().expect("probe tempdir");
+        let lix = open_at(dir.path()).await;
+        let probe_path = "/probe/f00000.bin".to_string();
+        seed(&lix, files, file_bytes, files, edits, &probe_path).await;
+        let head = active_commit(&lix).await;
+        let by_path = format!(
+            "SELECT lixcol_depth FROM lix_file_history($1) WHERE path = $2 \
+             ORDER BY lixcol_depth LIMIT {depth}"
+        );
+        let params = [Value::Text(head.clone()), Value::Text(probe_path.clone())];
+        let _ = lix.execute(&by_path, &params).await.expect("warm probe query");
+        let _ = lix::storage_bench::take_path_resolver_census();
+        let rows = lix
+            .execute(&by_path, &params)
+            .await
+            .expect("probe query")
+            .rows()
+            .len();
+        let (seen, parsed, prefiltered, metadata_present, prefilter_on, prefilter_off) =
+            lix::storage_bench::take_path_resolver_census();
+        eprintln!(
+            "path_resolver_census files={files} commits={} rows={rows} seen={seen} \
+             parsed={parsed} prefiltered={prefiltered} metadata_slots={metadata_present} \
+             prefilter_on={prefilter_on} prefilter_off={prefilter_off}",
+            edits + 1,
+        );
+        lix.close().await.expect("close probe");
+    }
+}
+
 /// Vary the number of reachable commits with file count AND answer size held
 /// constant.
 ///

--- a/packages/lix/src/sql2/exec/datafusion.rs
+++ b/packages/lix/src/sql2/exec/datafusion.rs
@@ -6298,6 +6298,144 @@ mod tests {
         );
     }
 
+    /// The raw-byte prefilter in path resolution must not change any answer,
+    /// including for names it refuses to accelerate.
+    ///
+    /// The prefilter is a necessary-condition test on the snapshot text, so its
+    /// only possible failure is the silent one: skipping a parse that would
+    /// have matched, which drops history rows rather than erroring. That can
+    /// only happen if a name is written to JSON as something other than its
+    /// source bytes, so the fixture uses exactly those names —
+    /// backslash, quote, non-ASCII, emoji — alongside a plain ASCII one.
+    ///
+    /// The oracle is the unfiltered read, which resolves no lookup ids and
+    /// therefore never runs the resolver at all.
+    ///
+    /// The census assertions are the hit and the miss: a plain-ASCII name must
+    /// take the accelerated route AND actually skip parses, and a name carrying
+    /// a character `serde_json` escapes must refuse it. Lower bounds only —
+    /// these counters are process-global.
+    #[tokio::test]
+    async fn path_resolution_prefilter_preserves_every_answer() {
+        let (session, _) = setup_engine_history_fixture()
+            .await
+            .expect("history fixture should initialize");
+
+        // Plain ASCII first, then the shapes whose JSON encoding may differ
+        // from their source text.
+        let names = ["plain.md", "with space.md", "quo\"te.md", "back\\slash.md", "ünïcode.md", "emoji-🙂.md"];
+        for (index, name) in names.iter().enumerate() {
+            let statement = format!(
+                "INSERT INTO lix_file (path, content) VALUES ('/docs/{name}', CAST('c{index}' AS BYTEA))"
+            );
+            session
+                .execute(&statement, &[])
+                .await
+                .unwrap_or_else(|error| panic!("insert of {name} should succeed: {error}"));
+            session
+                .execute(
+                    &format!(
+                        "UPDATE lix_file SET content = CAST('c{index}b' AS BYTEA) \
+                         WHERE path = '/docs/{name}'"
+                    ),
+                    &[],
+                )
+                .await
+                .unwrap_or_else(|error| panic!("update of {name} should succeed: {error}"));
+        }
+
+        let head_commit_id = session
+            .execute("SELECT lix_active_branch_commit_id()", &[])
+            .await
+            .expect("active commit should resolve")
+            .rows()[0]
+            .values()[0]
+            .clone();
+        let Value::Text(head_commit_id) = head_commit_id else {
+            panic!("active branch commit id should be text");
+        };
+
+        let projection = format!(
+            "SELECT id, path, lixcol_depth, lixcol_observed_commit_id \
+             FROM lix_file_history('{head_commit_id}')"
+        );
+        let key = |row: &Vec<Value>| format!("{row:?}");
+        let unfiltered = rows_from_execute_result(
+            session
+                .execute(&projection, &[])
+                .await
+                .expect("unfiltered history should execute"),
+        )
+        .1;
+
+        for name in names {
+            let path = format!("/docs/{name}");
+            let expected: BTreeSet<String> = unfiltered
+                .iter()
+                .filter(|row| row[1] == Value::Text(path.clone()))
+                .map(key)
+                .collect();
+            assert!(
+                !expected.is_empty(),
+                "the oracle must carry history for {path}"
+            );
+            let actual: BTreeSet<String> = rows_from_execute_result(
+                session
+                    .execute(
+                        &format!("{projection} WHERE path = $1"),
+                        &[Value::Text(path.clone())],
+                    )
+                    .await
+                    .unwrap_or_else(|error| panic!("path history for {path} should execute: {error}")),
+            )
+            .1
+            .iter()
+            .map(key)
+            .collect();
+            assert_eq!(
+                expected, actual,
+                "the prefilter changed the answer for {path}"
+            );
+        }
+
+        #[cfg(feature = "storage-benches")]
+        {
+            // Hit: a plain-ASCII name accelerates and actually skips parses.
+            let _ = crate::storage_bench::take_path_resolver_census();
+            let _ = session
+                .execute(
+                    &format!("{projection} WHERE path = $1"),
+                    &[Value::Text("/docs/plain.md".to_string())],
+                )
+                .await
+                .expect("plain path history should execute");
+            let (seen, parsed, prefiltered, _metadata, on, off) =
+                crate::storage_bench::take_path_resolver_census();
+            assert!(
+                on >= 1 && prefiltered >= 1 && seen > parsed,
+                "a plain ASCII name must take the accelerated route and skip parses:                  seen={seen} parsed={parsed} prefiltered={prefiltered} on={on} off={off}"
+            );
+
+            // Miss: a name carrying a character `serde_json` escapes must
+            // refuse the accelerator rather than risk a wrong byte test.
+            let _ = crate::storage_bench::take_path_resolver_census();
+            let _ = session
+                .execute(
+                    &format!("{projection} WHERE path = $1"),
+                    &[Value::Text("/docs/quo\"te.md".to_string())],
+                )
+                .await
+                .expect("quoted path history should execute");
+            let (_seen, _parsed, _prefiltered, _metadata, _on, off) =
+                crate::storage_bench::take_path_resolver_census();
+            assert!(
+                off >= 1,
+                "a name whose JSON encoding differs from its source text must \
+                 refuse the prefilter"
+            );
+        }
+    }
+
     #[tokio::test]
     async fn execute_sql_rejects_writes_to_history_views_before_planning() {
         for sql in [

--- a/packages/lix/src/sql2/providers/file_history.rs
+++ b/packages/lix/src/sql2/providers/file_history.rs
@@ -477,6 +477,20 @@ struct FileDescriptorSnapshot {
     name: String,
 }
 
+/// The two fields path resolution reads, borrowed from the snapshot text.
+///
+/// `Cow` rather than `&str` on purpose: a borrowed `&str` deserialize *fails*
+/// on any string containing a JSON escape, which would turn a legally named
+/// file into a query error. `Cow` borrows when it can and allocates when it
+/// must, so the fast path allocates nothing and the escaped path still decodes.
+#[derive(Debug, Deserialize)]
+struct FileDescriptorNameSnapshot<'a> {
+    #[serde(borrow)]
+    id: std::borrow::Cow<'a, str>,
+    #[serde(borrow)]
+    name: std::borrow::Cow<'a, str>,
+}
+
 #[derive(Debug, Deserialize)]
 struct DirectoryDescriptorSnapshot {
     id: String,
@@ -1048,6 +1062,10 @@ where
     )
     .await?;
 
+    let needles = descriptor_name_needles(&names);
+    #[cfg(feature = "storage-benches")]
+    crate::storage_bench::record_path_resolver_prefilter(needles.is_some());
+
     let mut file_ids = BTreeSet::new();
     for entry in &entries {
         // A tombstone carries no name, and the name it retired was written by
@@ -1055,14 +1073,42 @@ where
         let Some(snapshot_content) = entry.change.snapshot_content.as_deref() else {
             continue;
         };
-        let snapshot: FileDescriptorSnapshot =
-            serde_json::from_str(snapshot_content).map_err(|error| {
+        // This is NOT a filter, and it is worth being precise about the
+        // difference: a filter decides the answer, and deciding this answer
+        // genuinely requires the parse -- that is why "filter earlier so fewer
+        // rows are parsed" does not work in `apply_entity_batch_filters`. This
+        // is a *necessary condition* on the raw bytes, evaluated before the
+        // parse and never instead of it. A snapshot whose decoded `name` equals
+        // one of the queried names must contain that name's JSON string token
+        // verbatim, because `descriptor_name_needles` refuses any name whose
+        // encoding is not byte-identical to its source text. Failing the test
+        // therefore proves the parse could not have matched; passing it proves
+        // nothing and still parses.
+        if let Some(needles) = needles.as_deref()
+            && !needles
+                .iter()
+                .any(|needle| snapshot_content.contains(needle.as_str()))
+        {
+            #[cfg(feature = "storage-benches")]
+            crate::storage_bench::record_path_resolver_descriptor(
+                false,
+                !matches!(entry.change.metadata, None),
+            );
+            continue;
+        }
+        #[cfg(feature = "storage-benches")]
+        crate::storage_bench::record_path_resolver_descriptor(
+            true,
+            !matches!(entry.change.metadata, None),
+        );
+        let snapshot: FileDescriptorNameSnapshot<'_> = serde_json::from_str(snapshot_content)
+            .map_err(|error| {
                 LixError::new(
                     "LIX_ERROR_UNKNOWN",
                     format!("invalid lix_file_descriptor history snapshot JSON: {error}"),
                 )
             })?;
-        if !names.contains(&snapshot.name) {
+        if !names.contains(snapshot.name.as_ref()) {
             continue;
         }
         if EntityPk::uuid_from_canonical(&snapshot.id).is_err() {
@@ -1070,9 +1116,35 @@ where
             // one cannot be routed, so keep the complete traversal.
             return Ok(None);
         }
-        file_ids.insert(snapshot.id);
+        file_ids.insert(snapshot.id.into_owned());
     }
     Ok(Some(FileHistoryLookupIds(file_ids)))
+}
+
+/// The JSON string tokens a matching descriptor snapshot must contain verbatim.
+///
+/// Returns `None` when any queried name cannot be reduced to such a token, in
+/// which case the caller parses every snapshot exactly as it did before. The
+/// accepted set is deliberately narrow -- printable ASCII, no `"` and no `\` --
+/// because those are exactly the names `serde_json` writes back byte-identical
+/// to their source text. A name outside it may be written with an escape
+/// (`\u0041`, `\"`), and a byte test for the unescaped form would then miss a
+/// real match and silently drop history rows. Narrowing here is free: the test
+/// is an accelerator, and refusing it costs only the parse that already
+/// happened before.
+fn descriptor_name_needles(names: &BTreeSet<String>) -> Option<Vec<String>> {
+    let mut needles = Vec::with_capacity(names.len());
+    for name in names {
+        if name.is_empty()
+            || !name
+                .bytes()
+                .all(|byte| (byte.is_ascii_graphic() || byte == b' ') && byte != b'"' && byte != b'\\')
+        {
+            return None;
+        }
+        needles.push(format!("\"{name}\""));
+    }
+    Some(needles)
 }
 
 async fn load_file_history_filesystem_context<S>(

--- a/packages/lix/src/storage_bench.rs
+++ b/packages/lix/src/storage_bench.rs
@@ -508,6 +508,53 @@ pub fn take_commit_delta_member_scan_census() -> (u64, u64, u64, u64, u64) {
     )
 }
 
+static PATH_RESOLVER_DESCRIPTORS_SEEN: AtomicU64 = AtomicU64::new(0);
+static PATH_RESOLVER_DESCRIPTORS_PARSED: AtomicU64 = AtomicU64::new(0);
+static PATH_RESOLVER_DESCRIPTORS_PREFILTERED: AtomicU64 = AtomicU64::new(0);
+static PATH_RESOLVER_METADATA_SLOTS_PRESENT: AtomicU64 = AtomicU64::new(0);
+static PATH_RESOLVER_PREFILTER_ENABLED: AtomicU64 = AtomicU64::new(0);
+static PATH_RESOLVER_PREFILTER_DISABLED: AtomicU64 = AtomicU64::new(0);
+
+/// Counted at the per-descriptor loop in
+/// `resolve_file_history_path_lookup_ids`, at the `serde_json::from_str` the
+/// prefilter is meant to avoid -- not at the resolved id set, which is the same
+/// set either way and therefore cannot tell a skipped parse from a performed
+/// one.
+pub(crate) fn record_path_resolver_descriptor(parsed: bool, metadata_present: bool) {
+    PATH_RESOLVER_DESCRIPTORS_SEEN.fetch_add(1, Ordering::Relaxed);
+    if parsed {
+        PATH_RESOLVER_DESCRIPTORS_PARSED.fetch_add(1, Ordering::Relaxed);
+    } else {
+        PATH_RESOLVER_DESCRIPTORS_PREFILTERED.fetch_add(1, Ordering::Relaxed);
+    }
+    if metadata_present {
+        PATH_RESOLVER_METADATA_SLOTS_PRESENT.fetch_add(1, Ordering::Relaxed);
+    }
+}
+
+/// Route counter. A prefiltered count of zero is otherwise unreadable: it means
+/// either "every descriptor matched" or "the prefilter refused this query's
+/// names", and those are different findings.
+pub(crate) fn record_path_resolver_prefilter(enabled: bool) {
+    if enabled {
+        PATH_RESOLVER_PREFILTER_ENABLED.fetch_add(1, Ordering::Relaxed);
+    } else {
+        PATH_RESOLVER_PREFILTER_DISABLED.fetch_add(1, Ordering::Relaxed);
+    }
+}
+
+/// `(seen, parsed, prefiltered, metadata_slots_present, prefilter_on, prefilter_off)`.
+pub fn take_path_resolver_census() -> (u64, u64, u64, u64, u64, u64) {
+    (
+        PATH_RESOLVER_DESCRIPTORS_SEEN.swap(0, Ordering::Relaxed),
+        PATH_RESOLVER_DESCRIPTORS_PARSED.swap(0, Ordering::Relaxed),
+        PATH_RESOLVER_DESCRIPTORS_PREFILTERED.swap(0, Ordering::Relaxed),
+        PATH_RESOLVER_METADATA_SLOTS_PRESENT.swap(0, Ordering::Relaxed),
+        PATH_RESOLVER_PREFILTER_ENABLED.swap(0, Ordering::Relaxed),
+        PATH_RESOLVER_PREFILTER_DISABLED.swap(0, Ordering::Relaxed),
+    )
+}
+
 pub(crate) fn record_commit_delta_row_loaded(account_id_bytes: usize) {
     COMMIT_DELTA_ROWS_LOADED.fetch_add(1, Ordering::Relaxed);
     COMMIT_DELTA_ROW_KEY_DECODES.fetch_add(1, Ordering::Relaxed);


### PR DESCRIPTION
**Stacked on #1451** (`agent/commit-delta-file-bounded-member-reads`). Both branches add counters to
`storage_bench.rs` and tests to `history_scaling_probe.rs` at the same anchors, so they **conflict on
rebase** — this branch carries the resolved merge and the gate below is the gate of the *pair*, per
the merge-only-break rule. #1451 must land first.

## What it does

`resolve_file_history_path_lookup_ids` JSON-parsed every descriptor snapshot reachable from the
anchor in order to compare one field against the queried basenames. It now tests the raw snapshot
text for the name's JSON string token first, and parses only the candidates that pass.

## This is not the move that does not work

A parallel finding says `apply_entity_batch_filters` cannot "filter earlier so fewer rows are
parsed", because there **the parse is what produces the value the filter decides on**. That
objection does not apply here, and the difference is worth stating precisely:

* A **filter** decides the answer. Deciding this answer genuinely requires the parse.
* This is a **necessary condition on the raw bytes**, evaluated *before* the parse and never
  *instead* of it. **Failing it proves the parse could not have matched; passing it proves nothing
  and still parses.**

The set of resolved ids is byte-for-byte the same set either way. That is why the census counts the
parse, not the result — the result cannot tell a skipped parse from a performed one.

## Measurement

Counted at the `serde_json::from_str` itself, 20-row answer, **2/2 reps identical**:

| files | descriptors seen | parsed before → after |
|---|---|---|
| 500 | 500 | 500 → **1** |
| 5 000 | 5 000 | 5 000 → **1** |

**The parse term goes from `O(files)` to `O(1)`.** Route counters read `prefilter_on=1,
prefilter_off=0`, so the zero-parse result is readable as engagement rather than as absence.

### Wall clock: not resolvable, and reported as such

Stacked on #1451, 5 000 files, 3 interleaved reps with arm-order rotation, 5 samples per lane:

```
by_path  base (#1451 alone)  p50 9.708 9.897 9.637 ms
         cand (this branch)  p50 9.379 9.261 9.458 ms   -3.4%
```

The ranges do not overlap — **and that is not evidence here.** The runbook records two lanes on this
same harness that *could not execute the change under test* showing −2.7% and −2.9%, so anything
below ~5% is unresolvable. Measured against `claude-7-optimizations` directly (before #1451 shrinks
the surrounding query) it was −3.1%, equally unresolvable.

**The claim this PR makes is the parse count, which is deterministic. The timing is reported as
unresolved.** The proportion is expected to matter more as the surrounding terms shrink: this term
is ~14% of resolution samples by frame-pointer profile, and resolution is now ~64% of `by_path`.

## Correctness — the only failure direction is the silent one

A necessary-condition test can only fail by skipping a parse that would have matched, which **drops
history rows rather than erroring**. That happens if a name is written to JSON as something other
than its source bytes.

`descriptor_name_needles` therefore **refuses** any name outside printable ASCII, or containing `"`
or `\` — exactly the names `serde_json` may not write back verbatim — and the caller then parses
everything as before. Refusing is free: the accelerator is optional, and refusing costs only the
parse that already happened.

`path_resolution_prefilter_preserves_every_answer` compares path-filtered history against the
**unfiltered** read (which resolves no lookup ids and never runs the resolver) for names carrying a
quote, a backslash, non-ASCII and an emoji, plus a plain ASCII one and one with a space.
**Verified by inversion: deleting the refusal guard fails that test.**

The same test carries the hit and the miss: a plain-ASCII name must take the accelerated route *and*
actually skip parses; a name whose encoding may differ must refuse it.

## The other half of the "cheap alternative" is not implemented, by measurement

The resolver materializes a `metadata` JSON slot it never reads, so skipping it looked free. The
census settles it: **`metadata_slots=0` at both 500 and 5 000 files.** No descriptor change in this
workload carries a metadata slot, so `load_changelog_json_slot` already returns immediately on
`JsonSlot::None` and the skip cannot pay anything. Building it would have added a payload-projection
parameter across eight call sites for a change no benchmark could resolve.

Also in this commit: the snapshot decodes into a two-field **borrowed** struct rather than the
three-field owned one, so a matching descriptor allocates one `String` instead of three. `Cow`
rather than `&str` on purpose — a borrowed `&str` deserialize *fails* on any JSON escape, which
would turn a legally named file into a query error.

## Gate — of the merged pair

```
git rev-parse HEAD          c65ac06dee997757205e77febe2958f0a6a162c2 (before and after)
git status --porcelain      empty
CI_SCOPE_CONFIRMED_AT       0b97f3c45
cargo clippy --profile test --workspace --all-targets --all-features -- -D warnings   exit 0
cargo test --profile test --workspace --exclude lix_e2e --all-features --no-fail-fast exit 0
cargo test --profile test -p lix_e2e --features \
  sdk-tests,plugin-tests,server-protocol,storage-benches,slatedb,root-replay-trace \
  --no-fail-fast                                                                      exit 0

EXECUTED_TARGETS  test1=3432 passed across 38 targets   test2=172 passed across 27 targets
```

3432 reconciles as 3430 baseline + 1 (#1451's oracle) + 1 (this branch's oracle).

## Format

No format change, no persisted field, no write-path or encoding symbol touched.
