### PR TITLE
perf(lix): range access path for entity surfaces via the hot index

### DIFF
--- a/packages/lix/Cargo.toml
+++ b/packages/lix/Cargo.toml
@@ -120,6 +120,13 @@ required-features = ["storage-benches"]
 name = "plugin_arena_scorecard"
 path = "tests/plugin_arena_scorecard.rs"
 
+# Its own process: `storage_bench` counters are process-global, and this target
+# asserts two *upper* bounds that a concurrent test could inflate into a
+# spurious failure.
+[[test]]
+name = "hot_index_range_probe"
+path = "tests/hot_index_range_probe.rs"
+
 [dependencies]
 
 [target.'cfg(any(not(target_arch = "wasm32"), all(target_arch = "wasm32", target_os = "wasi", target_env = "p2")))'.dependencies]

--- a/packages/lix/src/hot_state/context.rs
+++ b/packages/lix/src/hot_state/context.rs
@@ -873,21 +873,27 @@ where
         request: &HotStateScanRequest,
         scope: &HotStateScanScope,
     ) -> Result<Option<HotStateScanRequest>, LixError> {
-        let Some(predicate) = request.filter.declared_column_eq.as_ref() else {
+        if request.filter.declared_column_eq.is_none()
+            && request.filter.declared_column_range.is_none()
+        {
             return Ok(None);
-        };
-        if !request.filter.entity_pks.is_empty() {
-            let mut rewritten = request.clone();
-            rewritten.filter.declared_column_eq = None;
-            return Ok(Some(rewritten));
         }
         let mut rewritten = request.clone();
         rewritten.filter.declared_column_eq = None;
+        rewritten.filter.declared_column_range = None;
+        // An identity filter already names its rows, so no index can narrow it.
+        if !request.filter.entity_pks.is_empty() {
+            return Ok(Some(rewritten));
+        }
         // Every branch in scope must be witnessed. A branch whose index is
         // incomplete would contribute no candidates and silently drop its
         // rows, which is the false negative this design cannot have — so one
         // unwitnessed branch sends the whole read back to the scan.
         let mut unique = std::collections::BTreeSet::new();
+        // An equality probe is a point prefix per value and is strictly
+        // cheaper than walking an interval, so when a scan carries both the
+        // equality wins and the range stays a residual predicate.
+        if let Some(predicate) = request.filter.declared_column_eq.as_ref() {
         for branch_id in &scope.storage_branch_ids {
             let Some(control) = scope.branch_heads.get(branch_id).copied() else {
                 return Ok(Some(rewritten));
@@ -916,6 +922,39 @@ where
                 return Ok(Some(rewritten));
             };
             unique.extend(candidates);
+        }
+            crate::storage_bench::record_hot_index_equality_probe_engaged();
+        } else if let Some(predicate) = request.filter.declared_column_range.as_ref() {
+            for branch_id in &scope.storage_branch_ids {
+                let Some(control) = scope.branch_heads.get(branch_id).copied() else {
+                    return Ok(Some(rewritten));
+                };
+                if !control.may_have_schema(&predicate.schema_key) {
+                    continue;
+                }
+                let Some(candidates) = self
+                    .tracked_head
+                    .reader(&self.store)
+                    .scan_hot_index_range_candidates(
+                        branch_id,
+                        control.tracked_generation,
+                        &predicate.schema_key,
+                        predicate.ordinal,
+                        predicate
+                            .lower
+                            .as_ref()
+                            .map(|(value, inclusive)| (value, *inclusive)),
+                        predicate
+                            .upper
+                            .as_ref()
+                            .map(|(value, inclusive)| (value, *inclusive)),
+                    )
+                    .await?
+                else {
+                    return Ok(Some(rewritten));
+                };
+                unique.extend(candidates);
+            }
         }
         if unique.is_empty() {
             rewritten.filter.rows = HotStateRowFilter::None;

--- a/packages/lix/src/hot_state/context.rs
+++ b/packages/lix/src/hot_state/context.rs
@@ -923,6 +923,7 @@ where
             };
             unique.extend(candidates);
         }
+            #[cfg(feature = "storage-benches")]
             crate::storage_bench::record_hot_index_equality_probe_engaged();
         } else if let Some(predicate) = request.filter.declared_column_range.as_ref() {
             for branch_id in &scope.storage_branch_ids {

--- a/packages/lix/src/hot_state/mod.rs
+++ b/packages/lix/src/hot_state/mod.rs
@@ -70,6 +70,7 @@ pub(crate) use tracked_head::{
 #[allow(unused_imports)]
 pub(crate) use types::{
     DeclaredColumnEq,
+    DeclaredColumnRange,
     Bound, HotStateExactBatchRequest, HotStateExactRowRequest, HotStateFilter,
     HotStateProjection, HotStateRowFilter, HotStateRowIdentityRef, HotStateRowRequest,
     HotStateScanRequest, MaterializedHotStateBatch, MaterializedHotStateBatchBuilder,

--- a/packages/lix/src/hot_state/tracked_head/hot.rs
+++ b/packages/lix/src/hot_state/tracked_head/hot.rs
@@ -5468,7 +5468,6 @@ where
     ///
     /// Bounds are half-open in key space and closed in value space, so each
     /// inclusive value bound becomes an exclusive key bound one successor up.
-    #[expect(clippy::too_many_arguments)]
     pub(crate) async fn scan_hot_index_range_candidates(
         &self,
         branch_id: &str,

--- a/packages/lix/src/hot_state/tracked_head/hot.rs
+++ b/packages/lix/src/hot_state/tracked_head/hot.rs
@@ -5502,42 +5502,44 @@ where
         let budget = hot_index_candidate_budget(entries_published);
 
         let column_prefix = hot_index_column_prefix(branch_id, generation, schema_key, ordinal);
-        let lower_bound = match lower {
+        let value_prefix = |value: &HotIndexValue| {
+            hot_index_value_prefix(branch_id, generation, schema_key, ordinal, value)
+        };
+        let lower_key = match lower {
             // `>= v` starts at the value prefix, which sorts below every entry
             // carrying that value.
-            Some((value, true)) => std::ops::Bound::Included(StorageKey(Bytes::from(hot_index_value_prefix(
-                branch_id, generation, schema_key, ordinal, value,
-            )))),
-            // `> v` must clear every entry of `v`, so it starts one successor up.
-            Some((value, false)) => {
-                let prefix =
-                    hot_index_value_prefix(branch_id, generation, schema_key, ordinal, value);
-                match hot_index_key_successor(&prefix) {
-                    Some(successor) => std::ops::Bound::Included(StorageKey(Bytes::from(successor))),
-                    None => return Ok(Some(Vec::new())),
-                }
-            }
-            None => std::ops::Bound::Included(StorageKey(Bytes::from(column_prefix.clone()))),
+            Some((value, true)) => value_prefix(value),
+            // `> v` must clear every entry of `v`, so it starts one successor
+            // up. No successor means no key can exceed `v`, so nothing matches.
+            Some((value, false)) => match hot_index_key_successor(&value_prefix(value)) {
+                Some(successor) => successor,
+                None => return Ok(Some(Vec::new())),
+            },
+            None => column_prefix.clone(),
         };
-        let upper_bound = match upper {
+        let upper_key = match upper {
             // `<= v` must retain every entry of `v`, which all sort above the
             // value prefix — so the bound is the successor, not the prefix.
-            Some((value, true)) => {
-                let prefix =
-                    hot_index_value_prefix(branch_id, generation, schema_key, ordinal, value);
-                match hot_index_key_successor(&prefix) {
-                    Some(successor) => std::ops::Bound::Excluded(StorageKey(Bytes::from(successor))),
-                    None => std::ops::Bound::Unbounded,
-                }
-            }
+            // This is the inclusive-upper trap: bounding at the prefix drops
+            // every row equal to `v` and still returns a plausible answer.
+            Some((value, true)) => hot_index_key_successor(&value_prefix(value)),
             // `< v` excludes them, and the value prefix sorts below them all.
-            Some((value, false)) => std::ops::Bound::Excluded(StorageKey(Bytes::from(hot_index_value_prefix(
-                branch_id, generation, schema_key, ordinal, value,
-            )))),
-            None => match hot_index_key_successor(&column_prefix) {
-                Some(successor) => std::ops::Bound::Excluded(StorageKey(Bytes::from(successor))),
-                None => std::ops::Bound::Unbounded,
-            },
+            Some((value, false)) => Some(value_prefix(value)),
+            None => hot_index_key_successor(&column_prefix),
+        };
+        // An inverted or empty interval — `BETWEEN 8 AND -5`, or two bounds
+        // that meet — names no rows. The store rejects a cursor whose lower
+        // bound does not sort below its upper, so this has to be answered
+        // without opening one rather than by scanning and finding nothing.
+        if let Some(upper_key) = upper_key.as_ref()
+            && lower_key >= *upper_key
+        {
+            return Ok(Some(Vec::new()));
+        }
+        let lower_bound = std::ops::Bound::Included(StorageKey(Bytes::from(lower_key)));
+        let upper_bound = match upper_key {
+            Some(upper_key) => std::ops::Bound::Excluded(StorageKey(Bytes::from(upper_key))),
+            None => std::ops::Bound::Unbounded,
         };
 
         let mut candidates = Vec::new();

--- a/packages/lix/src/hot_state/tracked_head/hot.rs
+++ b/packages/lix/src/hot_state/tracked_head/hot.rs
@@ -5458,6 +5458,127 @@ where
         Ok(Some(candidates))
     }
 
+    /// Candidate entity primary keys whose indexed column falls in a range.
+    ///
+    /// The equality sibling's contract holds unchanged: `Some` is a candidate
+    /// **superset**, never an answer. Entries are not deleted within a
+    /// generation, so a candidate may name a row that has since changed value
+    /// or been deleted, and the caller re-applies its own predicate. The set
+    /// never omits a live matching row.
+    ///
+    /// Bounds are half-open in key space and closed in value space, so each
+    /// inclusive value bound becomes an exclusive key bound one successor up.
+    #[expect(clippy::too_many_arguments)]
+    pub(crate) async fn scan_hot_index_range_candidates(
+        &self,
+        branch_id: &str,
+        generation: CommitId,
+        schema_key: &str,
+        ordinal: u16,
+        lower: Option<(&HotIndexValue, bool)>,
+        upper: Option<(&HotIndexValue, bool)>,
+    ) -> Result<Option<Vec<EntityPk>>, LixError> {
+        if lower.is_none() && upper.is_none() {
+            return Ok(None);
+        }
+        let witness = StorageKey(Bytes::from(encode_hot_index_witness_key(
+            branch_id,
+            generation,
+            schema_key,
+            ordinal,
+        )));
+        let present = PointReadPlan::new(INDEX_SPACE, &[witness])
+            .materialize(&self.store, StorageGetOptions::default())
+            .await?;
+        let Some(StorageProjectedValue::FullValue(witness_value)) =
+            present.value.into_iter().next().flatten()
+        else {
+            crate::storage_bench::record_hot_index_probe_refused_unwitnessed();
+            return Ok(None);
+        };
+        let Some(entries_published) = decode_hot_index_witness(&witness_value) else {
+            crate::storage_bench::record_hot_index_probe_refused_unwitnessed();
+            return Ok(None);
+        };
+        let budget = hot_index_candidate_budget(entries_published);
+
+        let column_prefix = hot_index_column_prefix(branch_id, generation, schema_key, ordinal);
+        let lower_bound = match lower {
+            // `>= v` starts at the value prefix, which sorts below every entry
+            // carrying that value.
+            Some((value, true)) => std::ops::Bound::Included(StorageKey(Bytes::from(hot_index_value_prefix(
+                branch_id, generation, schema_key, ordinal, value,
+            )))),
+            // `> v` must clear every entry of `v`, so it starts one successor up.
+            Some((value, false)) => {
+                let prefix =
+                    hot_index_value_prefix(branch_id, generation, schema_key, ordinal, value);
+                match hot_index_key_successor(&prefix) {
+                    Some(successor) => std::ops::Bound::Included(StorageKey(Bytes::from(successor))),
+                    None => return Ok(Some(Vec::new())),
+                }
+            }
+            None => std::ops::Bound::Included(StorageKey(Bytes::from(column_prefix.clone()))),
+        };
+        let upper_bound = match upper {
+            // `<= v` must retain every entry of `v`, which all sort above the
+            // value prefix — so the bound is the successor, not the prefix.
+            Some((value, true)) => {
+                let prefix =
+                    hot_index_value_prefix(branch_id, generation, schema_key, ordinal, value);
+                match hot_index_key_successor(&prefix) {
+                    Some(successor) => std::ops::Bound::Excluded(StorageKey(Bytes::from(successor))),
+                    None => std::ops::Bound::Unbounded,
+                }
+            }
+            // `< v` excludes them, and the value prefix sorts below them all.
+            Some((value, false)) => std::ops::Bound::Excluded(StorageKey(Bytes::from(hot_index_value_prefix(
+                branch_id, generation, schema_key, ordinal, value,
+            )))),
+            None => match hot_index_key_successor(&column_prefix) {
+                Some(successor) => std::ops::Bound::Excluded(StorageKey(Bytes::from(successor))),
+                None => std::ops::Bound::Unbounded,
+            },
+        };
+
+        let mut candidates = Vec::new();
+        let mut cursor = self
+            .store
+            .begin_scan(
+                INDEX_SPACE,
+                crate::storage_adapter::StorageKeyRange {
+                    lower: lower_bound,
+                    upper: upper_bound,
+                },
+                StorageBeginScanOptions::default(),
+            )
+            .await?;
+        loop {
+            let want = (budget + 1 - candidates.len()).min(HOT_INDEX_CANDIDATE_PAGE);
+            let (page, page_has_more) = cursor.next_page(want).await?.into_parts();
+            for entry in &page {
+                let StorageProjectedValue::FullValue(value) = &entry.value else {
+                    continue;
+                };
+                let text = std::str::from_utf8(value).map_err(|error| {
+                    head_value_error(format!("hot index entry is not utf-8: {error}"))
+                })?;
+                candidates.push(EntityPk::from_json_array_text(text).map_err(|error| {
+                    head_value_error(format!("hot index entry has an invalid entity pk: {error}"))
+                })?);
+            }
+            if candidates.len() > budget {
+                crate::storage_bench::record_hot_index_probe_refused_over_budget();
+                return Ok(None);
+            }
+            if !page_has_more {
+                break;
+            }
+        }
+        crate::storage_bench::record_hot_index_range_probe_engaged(candidates.len());
+        Ok(Some(candidates))
+    }
+
     pub(crate) async fn has_schema_rows(
         &self,
         branch_id: &str,
@@ -12801,6 +12922,45 @@ pub(crate) fn hot_index_value_prefix(
     key.extend_from_slice(&ordinal.to_be_bytes());
     value.write(&mut key);
     key
+}
+
+/// Every entry for one `(collection, column)`, whatever the value: the range
+/// access path's outer bound.
+pub(crate) fn hot_index_column_prefix(
+    branch_id: &str,
+    generation: CommitId,
+    schema_key: &str,
+    ordinal: u16,
+) -> Vec<u8> {
+    let mut key = hot_scope_prefix(branch_id, generation);
+    write_key_string(&mut key, schema_key, KEY_PART_FINAL);
+    key.push(HOT_INDEX_ENTRY_TAG);
+    key.extend_from_slice(&ordinal.to_be_bytes());
+    key
+}
+
+/// The least key strictly greater than every key having `prefix` as a prefix.
+///
+/// This is the whole of inclusive-upper-bound correctness. Entries for value
+/// `v` are `prefix_v ++ entity_pk`, so they all sort **after** `prefix_v`
+/// itself. An upper bound of `Excluded(prefix_v)` therefore excludes every row
+/// equal to `v` — right for `< v`, and silently wrong for `<= v`, which is the
+/// one place a range seek loses rows while still returning a plausible answer.
+/// `<= v` must bound with `Excluded(successor(prefix_v))`.
+///
+/// `None` means the prefix is all `0xff` and no successor exists, in which case
+/// the range runs to the end of the space.
+fn hot_index_key_successor(prefix: &[u8]) -> Option<Vec<u8>> {
+    let mut successor = prefix.to_vec();
+    while let Some(last) = successor.last_mut() {
+        if *last == u8::MAX {
+            successor.pop();
+        } else {
+            *last += 1;
+            return Some(successor);
+        }
+    }
+    None
 }
 
 /// Asserts that this plane holds every row of one `(collection, column)` for

--- a/packages/lix/src/hot_state/tracked_head/hot.rs
+++ b/packages/lix/src/hot_state/tracked_head/hot.rs
@@ -5492,10 +5492,12 @@ where
         let Some(StorageProjectedValue::FullValue(witness_value)) =
             present.value.into_iter().next().flatten()
         else {
+            #[cfg(feature = "storage-benches")]
             crate::storage_bench::record_hot_index_probe_refused_unwitnessed();
             return Ok(None);
         };
         let Some(entries_published) = decode_hot_index_witness(&witness_value) else {
+            #[cfg(feature = "storage-benches")]
             crate::storage_bench::record_hot_index_probe_refused_unwitnessed();
             return Ok(None);
         };
@@ -5569,6 +5571,7 @@ where
                 })?);
             }
             if candidates.len() > budget {
+                #[cfg(feature = "storage-benches")]
                 crate::storage_bench::record_hot_index_probe_refused_over_budget();
                 return Ok(None);
             }
@@ -5576,6 +5579,7 @@ where
                 break;
             }
         }
+        #[cfg(feature = "storage-benches")]
         crate::storage_bench::record_hot_index_range_probe_engaged(candidates.len());
         Ok(Some(candidates))
     }

--- a/packages/lix/src/hot_state/types.rs
+++ b/packages/lix/src/hot_state/types.rs
@@ -1259,6 +1259,20 @@ pub(crate) struct DeclaredColumnEq {
     pub(crate) values: Vec<crate::hot_state::HotIndexValue>,
 }
 
+/// One half-open interval on an indexed column, resolved through the index
+/// plane before a route is chosen.
+///
+/// Each bound carries its own inclusivity because the key encoding is
+/// order-preserving but the key space is half-open: an inclusive value bound
+/// becomes an exclusive key bound one successor above the value prefix.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub(crate) struct DeclaredColumnRange {
+    pub(crate) schema_key: String,
+    pub(crate) ordinal: u16,
+    pub(crate) lower: Option<(crate::hot_state::HotIndexValue, bool)>,
+    pub(crate) upper: Option<(crate::hot_state::HotIndexValue, bool)>,
+}
+
 /// Identity-centered filter for visible live entities.
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, Default)]
 pub(crate) struct HotStateFilter {
@@ -1284,6 +1298,10 @@ pub(crate) struct HotStateFilter {
     /// candidates, so the caller's predicate is what rejects stale ones.
     #[serde(default)]
     pub(crate) declared_column_eq: Option<DeclaredColumnEq>,
+    /// A range on an indexed column, resolved the same way and under the same
+    /// candidate-superset contract as [`Self::declared_column_eq`].
+    #[serde(default)]
+    pub(crate) declared_column_range: Option<DeclaredColumnRange>,
     #[serde(default)]
     pub(crate) include_tombstones: bool,
 }

--- a/packages/lix/src/hot_state/types.rs
+++ b/packages/lix/src/hot_state/types.rs
@@ -1300,8 +1300,16 @@ pub(crate) struct HotStateFilter {
     pub(crate) declared_column_eq: Option<DeclaredColumnEq>,
     /// A range on an indexed column, resolved the same way and under the same
     /// candidate-superset contract as [`Self::declared_column_eq`].
+    ///
+    /// **Boxed deliberately.** This filter is carried inside
+    /// `HotStateScanRequest`, which is cloned through deep async chains, and an
+    /// async state machine sizes its frames from the types it holds. Inline,
+    /// this variant added ~100 bytes to every such frame and overflowed
+    /// libtest's 2 MiB worker stack in `cas_gc_history_retention` — a test with
+    /// no logical connection to range predicates, which aborted rather than
+    /// failed. Boxing keeps the growth to one pointer. Do not unbox it.
     #[serde(default)]
-    pub(crate) declared_column_range: Option<DeclaredColumnRange>,
+    pub(crate) declared_column_range: Option<Box<DeclaredColumnRange>>,
     #[serde(default)]
     pub(crate) include_tombstones: bool,
 }

--- a/packages/lix/src/sql2/providers/entity.rs
+++ b/packages/lix/src/sql2/providers/entity.rs
@@ -1902,7 +1902,7 @@ fn declared_column_eq(
 fn declared_column_range(
     spec: &EntitySurfaceSpec,
     row_filters: &[EntityRowFilter],
-) -> Option<crate::hot_state::DeclaredColumnRange> {
+) -> Option<Box<crate::hot_state::DeclaredColumnRange>> {
     let mut bounds = Vec::new();
     for filter in row_filters {
         collect_conjunctive_ranges(filter, &mut bounds);
@@ -1929,12 +1929,12 @@ fn declared_column_range(
             }
         }
         if lower.is_some() || upper.is_some() {
-            return Some(crate::hot_state::DeclaredColumnRange {
+            return Some(Box::new(crate::hot_state::DeclaredColumnRange {
                 schema_key: spec.schema_key.clone(),
                 ordinal: indexed.ordinal,
                 lower,
                 upper,
-            });
+            }));
         }
     }
     None

--- a/packages/lix/src/sql2/providers/entity.rs
+++ b/packages/lix/src/sql2/providers/entity.rs
@@ -1907,7 +1907,9 @@ fn declared_column_membership(filter: &EntityRowFilter) -> Option<(&str, Vec<&En
             values.extend(right_values);
             Some((column, values))
         }
-        EntityRowFilter::And(..) => None,
+        // A range names no finite value set, so it cannot become an
+        // equality/IN probe. The index range seek is a separate access path.
+        EntityRowFilter::ColumnRange { .. } | EntityRowFilter::And(..) => None,
     }
 }
 
@@ -2360,11 +2362,66 @@ impl<'a> EntityRowFilterAnalyzer<'a> {
     }
 
     fn analyze_binary(&self, binary_expr: &BinaryExpr) -> Option<EntityRowFilter> {
-        if binary_expr.op != Operator::Eq {
+        if binary_expr.op == Operator::Eq {
+            return self
+                .analyze_column_literal(&binary_expr.left, &binary_expr.right)
+                .or_else(|| self.analyze_column_literal(&binary_expr.right, &binary_expr.left));
+        }
+        let op = EntityRangeOp::from_operator(binary_expr.op)?;
+        self.analyze_column_literal_range(&binary_expr.left, &binary_expr.right, op)
+            .or_else(|| {
+                self.analyze_column_literal_range(
+                    &binary_expr.right,
+                    &binary_expr.left,
+                    op.reversed(),
+                )
+            })
+    }
+
+    /// A `column OP literal` range predicate, when the column can carry one.
+    ///
+    /// Restricted to `Integer` and `String`. Those are the types with a total
+    /// order, and — not coincidentally — the two the hot index can encode
+    /// order-preservingly, so this is the same admissible set a later index
+    /// range seek needs. `Number` is refused because NaN makes the order
+    /// partial; `Boolean` and `Json` have no useful range.
+    fn analyze_column_literal_range(
+        &self,
+        column_expr: &Expr,
+        literal_expr: &Expr,
+        op: EntityRangeOp,
+    ) -> Option<EntityRowFilter> {
+        let Expr::Column(column) = column_expr else {
+            return None;
+        };
+        let column_name = self.filterable_column_name(&column.name)?;
+        let column_type = self
+            .spec
+            .visible_column(column_name)
+            .expect("filterable column should exist")
+            .column_type;
+        if !matches!(
+            column_type,
+            EntityColumnType::Integer | EntityColumnType::String
+        ) {
             return None;
         }
-        self.analyze_column_literal(&binary_expr.left, &binary_expr.right)
-            .or_else(|| self.analyze_column_literal(&binary_expr.right, &binary_expr.left))
+        let value = entity_filter_value_literal(literal_expr, column_type)?;
+        // A literal that widened into another representation (an integer
+        // column compared against a float, say) has no total order against the
+        // stored value, so it must not become a range.
+        if !matches!(
+            value,
+            EntityFilterValue::Integer(_) | EntityFilterValue::String(_)
+        ) {
+            return None;
+        }
+        Some(EntityRowFilter::ColumnRange {
+            column: column_name.to_string(),
+            column_type,
+            op,
+            value,
+        })
     }
 
     fn analyze_in_list(&self, in_list: &InList) -> Option<EntityRowFilter> {
@@ -2448,8 +2505,66 @@ enum EntityRowFilter {
         column_type: EntityColumnType,
         values: Vec<EntityFilterValue>,
     },
+    /// One half-bounded comparison against a literal.
+    ///
+    /// `BETWEEN` reaches the analyzer already desugared into `>= AND <=`, so a
+    /// single bound per node composes into a closed interval through the
+    /// existing [`EntityRowFilter::And`] arm. Carrying one bound rather than
+    /// two keeps every consumer's arm total and means the interval logic lives
+    /// in exactly one place.
+    ColumnRange {
+        column: String,
+        column_type: EntityColumnType,
+        op: EntityRangeOp,
+        value: EntityFilterValue,
+    },
     And(Box<Self>, Box<Self>),
     Or(Box<Self>, Box<Self>),
+}
+
+/// The comparison a [`EntityRowFilter::ColumnRange`] applies.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum EntityRangeOp {
+    Lt,
+    LtEq,
+    Gt,
+    GtEq,
+}
+
+impl EntityRangeOp {
+    fn from_operator(op: Operator) -> Option<Self> {
+        match op {
+            Operator::Lt => Some(Self::Lt),
+            Operator::LtEq => Some(Self::LtEq),
+            Operator::Gt => Some(Self::Gt),
+            Operator::GtEq => Some(Self::GtEq),
+            _ => None,
+        }
+    }
+
+    /// The same predicate with the operands swapped.
+    ///
+    /// `5 < ordinal` and `ordinal < 5` are different predicates, so the
+    /// literal-on-the-left spelling must reverse the comparison rather than
+    /// reuse it. Reusing it silently returns the complement of the requested
+    /// rows.
+    fn reversed(self) -> Self {
+        match self {
+            Self::Lt => Self::Gt,
+            Self::LtEq => Self::GtEq,
+            Self::Gt => Self::Lt,
+            Self::GtEq => Self::LtEq,
+        }
+    }
+
+    fn matches(self, ordering: std::cmp::Ordering) -> bool {
+        match self {
+            Self::Lt => ordering.is_lt(),
+            Self::LtEq => ordering.is_le(),
+            Self::Gt => ordering.is_gt(),
+            Self::GtEq => ordering.is_ge(),
+        }
+    }
 }
 
 impl EntityRowFilter {
@@ -2481,6 +2596,15 @@ impl EntityRowFilter {
                     }
                 }
                 (!unknown).then_some(false)
+            }
+            Self::ColumnRange {
+                column, op, value, ..
+            } => {
+                let index = manifest
+                    .fields
+                    .iter()
+                    .position(|field| field.name == *column)?;
+                entity_filter_range_in_statistics(*op, value, &group.columns[index], group.row_count)
             }
             Self::And(left, right) => match (
                 left.may_match_group(manifest, group),
@@ -2524,6 +2648,16 @@ impl EntityRowFilter {
                     },
                 ),
             ),
+            Self::ColumnRange {
+                column,
+                column_type,
+                op,
+                value,
+            } => Ok(
+                entity_snapshot_value(snapshot, schema_key, column, *column_type)?
+                    .and_then(|actual| entity_filter_value_cmp(&actual, value))
+                    .is_some_and(|ordering| op.matches(ordering)),
+            ),
             Self::And(left, right) => Ok(left.matches_snapshot(snapshot, schema_key)?
                 && right.matches_snapshot(snapshot, schema_key)?),
             Self::Or(left, right) => Ok(left.matches_snapshot(snapshot, schema_key)?
@@ -2563,6 +2697,73 @@ fn entity_filter_value_in_statistics(
             RowGroupScalar::String(min),
             RowGroupScalar::String(max),
         ) => Some(min <= value && value <= max),
+        _ => None,
+    }
+}
+
+/// Whether any row of `statistics` can satisfy `op` against `value`.
+///
+/// A lower-bounded predicate can only be satisfied by a group whose **maximum**
+/// clears the bound; an upper-bounded one by a group whose **minimum** does.
+/// Comparing against the wrong end of the interval prunes groups that contain
+/// matching rows, so the pairing here is the correctness core of range pruning.
+///
+/// `None` means "cannot tell" and the group is kept — this predicate is pushed
+/// down as [`TableProviderFilterPushDown::Inexact`], so keeping too many groups
+/// costs time while dropping too few is a wrong answer.
+fn entity_filter_range_in_statistics(
+    op: EntityRangeOp,
+    value: &EntityFilterValue,
+    statistics: &crate::columnar_row_group::RowGroupColumnStatistics,
+    row_count: u32,
+) -> Option<bool> {
+    if statistics.null_count == row_count && statistics.min.is_none() && statistics.max.is_none() {
+        return Some(false);
+    }
+    let bound = match op {
+        EntityRangeOp::Gt | EntityRangeOp::GtEq => statistics.max.as_ref()?,
+        EntityRangeOp::Lt | EntityRangeOp::LtEq => statistics.min.as_ref()?,
+    };
+    Some(op.matches(entity_scalar_value_cmp(bound, value)?))
+}
+
+/// Orders a row-group statistic against a filter literal.
+///
+/// Only the two types with a total order are comparable. `Float64` is
+/// deliberately absent: NaN makes the order partial, and a partial order here
+/// would prune a group that holds matching rows.
+fn entity_scalar_value_cmp(
+    scalar: &crate::columnar_row_group::RowGroupScalar,
+    value: &EntityFilterValue,
+) -> Option<std::cmp::Ordering> {
+    use crate::columnar_row_group::RowGroupScalar;
+    match (scalar, value) {
+        (RowGroupScalar::Int64(scalar), EntityFilterValue::Integer(value)) => {
+            Some(scalar.cmp(value))
+        }
+        (RowGroupScalar::String(scalar), EntityFilterValue::String(value)) => {
+            Some(scalar.as_str().cmp(value.as_str()))
+        }
+        _ => None,
+    }
+}
+
+/// Orders a decoded snapshot value against a filter literal.
+///
+/// `None` — a missing column, a type mismatch, or a value with no total order —
+/// makes the comparison unsatisfied, matching SQL's treatment of a comparison
+/// against NULL as unknown rather than true.
+fn entity_filter_value_cmp(
+    actual: &EntityFilterValue,
+    expected: &EntityFilterValue,
+) -> Option<std::cmp::Ordering> {
+    match (actual, expected) {
+        (EntityFilterValue::Integer(actual), EntityFilterValue::Integer(expected)) => {
+            Some(actual.cmp(expected))
+        }
+        (EntityFilterValue::String(actual), EntityFilterValue::String(expected)) => {
+            Some(actual.as_str().cmp(expected.as_str()))
+        }
         _ => None,
     }
 }

--- a/packages/lix/src/sql2/providers/entity.rs
+++ b/packages/lix/src/sql2/providers/entity.rs
@@ -328,6 +328,7 @@ impl EntitySpec {
         apply_exact_entity_pk_filters(&mut request, &self.spec, filters)?;
         apply_exact_file_id_filter(&mut request, exact_file_ids_from_filters(filters)?);
         request.filter.declared_column_eq = declared_column_eq(&self.spec, &row_filters);
+        request.filter.declared_column_range = declared_column_range(&self.spec, &row_filters);
         Ok((projected_schema, request, row_filters))
     }
 
@@ -1886,6 +1887,91 @@ fn declared_column_eq(
     })
 }
 
+/// The interval an indexed column is constrained to, when a conjunction of
+/// range predicates constrains one.
+///
+/// Only conjunctions contribute. A bound under a disjunction does not hold for
+/// every row the filter admits, so descending into `Or` would produce an
+/// interval that omits matching rows.
+///
+/// When several bounds constrain the same side, the first is taken rather than
+/// the tightest -- so `x > 5 AND x > 100` seeks from 5, not from 100. That is
+/// deliberate, not an oversight. Every conjunct must hold, so any one of them
+/// is a valid bound; a looser one costs candidates, never correctness, and the
+/// caller's residual rejects the surplus.
+fn declared_column_range(
+    spec: &EntitySurfaceSpec,
+    row_filters: &[EntityRowFilter],
+) -> Option<crate::hot_state::DeclaredColumnRange> {
+    let mut bounds = Vec::new();
+    for filter in row_filters {
+        collect_conjunctive_ranges(filter, &mut bounds);
+    }
+    if bounds.is_empty() {
+        return None;
+    }
+    for indexed in &spec.indexed_columns {
+        let mut lower = None;
+        let mut upper = None;
+        for (column, op, value) in &bounds {
+            if *column != indexed.name.as_str() {
+                continue;
+            }
+            let Some(value) = hot_index_value_from_filter_value(value) else {
+                continue;
+            };
+            match op {
+                EntityRangeOp::Gt if lower.is_none() => lower = Some((value, false)),
+                EntityRangeOp::GtEq if lower.is_none() => lower = Some((value, true)),
+                EntityRangeOp::Lt if upper.is_none() => upper = Some((value, false)),
+                EntityRangeOp::LtEq if upper.is_none() => upper = Some((value, true)),
+                _ => {}
+            }
+        }
+        if lower.is_some() || upper.is_some() {
+            return Some(crate::hot_state::DeclaredColumnRange {
+                schema_key: spec.schema_key.clone(),
+                ordinal: indexed.ordinal,
+                lower,
+                upper,
+            });
+        }
+    }
+    None
+}
+
+/// Range bounds that hold for every row the filter admits.
+fn collect_conjunctive_ranges<'a>(
+    filter: &'a EntityRowFilter,
+    out: &mut Vec<(&'a str, EntityRangeOp, &'a EntityFilterValue)>,
+) {
+    match filter {
+        EntityRowFilter::ColumnRange {
+            column, op, value, ..
+        } => out.push((column.as_str(), *op, value)),
+        EntityRowFilter::And(left, right) => {
+            collect_conjunctive_ranges(left, out);
+            collect_conjunctive_ranges(right, out);
+        }
+        _ => {}
+    }
+}
+
+/// The index-plane representation of a filter literal, when one exists.
+fn hot_index_value_from_filter_value(
+    value: &EntityFilterValue,
+) -> Option<crate::hot_state::HotIndexValue> {
+    match value {
+        EntityFilterValue::String(value) => {
+            Some(crate::hot_state::HotIndexValue::String(value.clone()))
+        }
+        EntityFilterValue::Integer(value) => {
+            Some(crate::hot_state::HotIndexValue::Integer(*value))
+        }
+        _ => None,
+    }
+}
+
 /// The column and the value set one row filter constrains it to, when the
 /// filter is a membership test on a single column.
 ///
@@ -3208,9 +3294,27 @@ fn direct_entity_batch_eligible(
     request: &HotStateScanRequest,
     row_filters: &[EntityRowFilter],
 ) -> bool {
+    // A range filter does not disqualify this route *when nothing better is
+    // available*. Ranges are pushed down as `Inexact`, so DataFusion re-checks
+    // them above the scan and this route may legitimately ignore them — which
+    // keeps the pre-range fast path intact instead of demoting every range
+    // query to the generic visibility scan. Equality and IN still disqualify
+    // it, as they always have.
+    //
+    // But a range on an *indexed* column has something better: the index range
+    // seek, which reaches this collection through resolved entity pks instead
+    // of reading it end to end. That seek is resolved on the route this one
+    // bypasses, so admitting the range here would silently disable it — the
+    // fast full read would win the route and the seek would never run. When a
+    // `declared_column_range` is present the range therefore disqualifies this
+    // route, exactly as an equality on an indexed column already does.
     !schema.fields().is_empty()
         && matches!(request.filter.rows, HotStateRowFilter::All)
-        && row_filters.is_empty()
+        && (row_filters.is_empty()
+            || (request.filter.declared_column_range.is_none()
+                && row_filters
+                    .iter()
+                    .all(|filter| matches!(filter, EntityRowFilter::ColumnRange { .. }))))
         && request.filter.file_ids.is_empty()
         && request.filter.constraints.is_empty()
         && schema

--- a/packages/lix/src/storage_bench.rs
+++ b/packages/lix/src/storage_bench.rs
@@ -509,6 +509,72 @@ pub fn take_tracked_key_allocation_census() -> TrackedKeyAllocationCensus {
     }
 }
 
+/// Hot-index probe routing, counted where the probe *decides*.
+///
+/// A probe that resolves candidates rewrites the request's `entity_pks`, which
+/// sends `hot_scan_entries` down its point-batch arm instead of the
+/// full-prefix fallback. Counting the decision here rather than the rows the
+/// scan returns is what distinguishes a seek from a walk: a count taken at the
+/// layer that returns the answer reads identically under both.
+///
+/// The refusal counters exist because a probe that silently declines is
+/// indistinguishable from one that never ran, and "the seek engaged" is
+/// otherwise unfalsifiable. Attribution is the **fallback going to zero**, not
+/// an engaged counter going positive.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct HotIndexProbeCensus {
+    /// Equality/IN probes that resolved a candidate set.
+    pub equality_probes_engaged: u64,
+    /// Range probes that resolved a candidate set.
+    pub range_probes_engaged: u64,
+    /// Candidates resolved by range probes, before the residual re-check.
+    pub range_probe_candidates: u64,
+    /// Probes that fell back because a branch in scope carried no witness.
+    pub probes_refused_unwitnessed: u64,
+    /// Probes that fell back because the candidate set exceeded its budget.
+    pub probes_refused_over_budget: u64,
+}
+
+static HOT_INDEX_EQUALITY_PROBES_ENGAGED: AtomicU64 = AtomicU64::new(0);
+static HOT_INDEX_RANGE_PROBES_ENGAGED: AtomicU64 = AtomicU64::new(0);
+static HOT_INDEX_RANGE_PROBE_CANDIDATES: AtomicU64 = AtomicU64::new(0);
+static HOT_INDEX_PROBES_REFUSED_UNWITNESSED: AtomicU64 = AtomicU64::new(0);
+static HOT_INDEX_PROBES_REFUSED_OVER_BUDGET: AtomicU64 = AtomicU64::new(0);
+
+pub(crate) fn record_hot_index_equality_probe_engaged() {
+    HOT_INDEX_EQUALITY_PROBES_ENGAGED.fetch_add(1, Ordering::Relaxed);
+}
+
+pub(crate) fn record_hot_index_range_probe_engaged(candidates: usize) {
+    HOT_INDEX_RANGE_PROBES_ENGAGED.fetch_add(1, Ordering::Relaxed);
+    HOT_INDEX_RANGE_PROBE_CANDIDATES.fetch_add(candidates as u64, Ordering::Relaxed);
+}
+
+pub(crate) fn record_hot_index_probe_refused_unwitnessed() {
+    HOT_INDEX_PROBES_REFUSED_UNWITNESSED.fetch_add(1, Ordering::Relaxed);
+}
+
+pub(crate) fn record_hot_index_probe_refused_over_budget() {
+    HOT_INDEX_PROBES_REFUSED_OVER_BUDGET.fetch_add(1, Ordering::Relaxed);
+}
+
+/// Drains the hot-index probe census.
+///
+/// These counters are process-global and the suite runs tests in parallel, so
+/// assertions against them must be thresholds scaled to the caller's own
+/// fixture, never exact values.
+pub fn take_hot_index_probe_census() -> HotIndexProbeCensus {
+    HotIndexProbeCensus {
+        equality_probes_engaged: HOT_INDEX_EQUALITY_PROBES_ENGAGED.swap(0, Ordering::Relaxed),
+        range_probes_engaged: HOT_INDEX_RANGE_PROBES_ENGAGED.swap(0, Ordering::Relaxed),
+        range_probe_candidates: HOT_INDEX_RANGE_PROBE_CANDIDATES.swap(0, Ordering::Relaxed),
+        probes_refused_unwitnessed: HOT_INDEX_PROBES_REFUSED_UNWITNESSED
+            .swap(0, Ordering::Relaxed),
+        probes_refused_over_budget: HOT_INDEX_PROBES_REFUSED_OVER_BUDGET
+            .swap(0, Ordering::Relaxed),
+    }
+}
+
 pub(crate) fn record_entity_point_snapshot_cache_hit() {
     ENTITY_POINT_SNAPSHOT_CACHE_HITS.fetch_add(1, Ordering::Relaxed);
 }

--- a/packages/lix/tests/hot_index_range_probe.rs
+++ b/packages/lix/tests/hot_index_range_probe.rs
@@ -1,17 +1,22 @@
-//! The hot-index range seek must actually seek, and must refuse when it cannot.
+//! The hot-index range seek must actually seek, must read a number of entries
+//! set by its **answer** rather than by the collection, and must refuse when it
+//! has no index to seek.
 //!
 //! This lives in its own `[[test]]` target because `storage_bench` counters are
 //! **process-global**. In the shared suite a concurrent test can only inflate
-//! them — harmless for a `>=` assertion, but fatal for the two assertions that
-//! matter here: "resolved fewer candidates than the collection" and "did not
-//! engage at all" are both *upper* bounds, which inflation pushes toward a
-//! spurious failure. A dedicated target is its own process, and both arms run
-//! sequentially inside one `#[test]` so that even libtest's own parallelism
-//! cannot interleave them.
+//! them — harmless for a `>=` assertion, but fatal for the assertions that
+//! matter here, which are *upper* bounds that inflation pushes toward a
+//! spurious failure. A dedicated target is its own process; and every arm runs
+//! sequentially inside one `#[test]` because libtest runs `#[test]` functions
+//! within a single binary concurrently, so a dedicated target alone is
+//! necessary but not sufficient.
 //!
-//! Without these assertions the 144-pair bound differential in the integration
-//! suite is vacuous: it would pass identically against a silently-refusing
-//! seek, proving nothing about the seek while looking like thorough coverage.
+//! Without the engagement assertions the 144-pair bound differential in the
+//! integration suite is vacuous: it passes identically against a
+//! silently-refusing seek, proving nothing about the seek while looking like
+//! thorough coverage. That is not hypothetical — it is what happened during
+//! development, when the direct-route mitigation and the seek cancelled each
+//! other and every correctness test stayed green.
 
 use std::future::Future;
 
@@ -22,9 +27,13 @@ use lix::{Memory, Value};
 /// overflows libtest's 2 MiB worker stack in the `test` profile.
 const RANGE_PROBE_TEST_STACK_SIZE: usize = 32 * 1024 * 1024;
 
-/// Ordinals seeded into both fixtures. Spans zero and negatives so the
-/// order-preserving sign flip is exercised, not just the positive half.
-const ORDINALS: [i64; 10] = [-3, -2, -1, 0, 1, 2, 3, 4, 5, 6];
+/// The measured query selects a closed interval of three ordinals.
+const ANSWER_ROWS: u64 = 3;
+
+/// Collection sizes the same three-row answer is read from. The point of the
+/// pair is the *slope*: a seek's candidate count is set by its answer, so it
+/// must not move when the collection grows 20x. A scan's would grow with it.
+const COLLECTION_SIZES: [usize; 2] = [10, 200];
 
 fn run_on_sized_stack<Body, Fut>(name: &str, body: Body)
 where
@@ -47,35 +56,43 @@ where
 }
 
 #[test]
-fn range_seek_engages_on_a_declared_column_and_refuses_on_an_undeclared_one() {
+fn range_seek_reads_candidates_set_by_its_answer_and_refuses_without_an_index() {
     run_on_sized_stack("hot_index_range_probe", || async {
-        // ---- hit: the column declares `x-lix-unique`, so entries exist -----
-        let session = seeded_session("range_seek_note", true).await;
-        // Drain what seeding wrote — uniqueness validation probes the same
-        // index — so the census below describes the read, not the writes.
-        let _ = lix::storage_bench::take_hot_index_probe_census();
-        let answered = ordinal_range_ids(&session, "range_seek_note", 2, 4).await;
-        let hit = lix::storage_bench::take_hot_index_probe_census();
+        // ---- the access-path claim, as a curve rather than a point ---------
+        let mut candidates_by_size = Vec::new();
+        for rows in COLLECTION_SIZES {
+            let session = seeded_session("range_seek_note", true, rows).await;
+            // Seeding a declared-unique collection probes this same index
+            // during uniqueness validation, so drain immediately before the
+            // measured read or the census describes the writes too.
+            let _ = lix::storage_bench::take_hot_index_probe_census();
+            let answered = ordinal_range_ids(&session, "range_seek_note", 2, 4).await;
+            let census = lix::storage_bench::take_hot_index_probe_census();
 
+            assert_eq!(
+                answered,
+                vec!["n5".to_string(), "n6".to_string(), "n7".to_string()],
+                "ordinals 2,3,4 are the sixth through eighth rows at {rows} rows"
+            );
+            assert!(
+                census.range_probes_engaged >= 1,
+                "the range seek should engage on a declared column at {rows} rows; \
+                 census={census:?}"
+            );
+            candidates_by_size.push(census.range_probe_candidates);
+        }
+
+        // A seek reads entries proportional to its answer. A scan would read
+        // the collection, so this is the assertion that distinguishes them.
         assert_eq!(
-            answered,
-            vec!["n5".to_string(), "n6".to_string(), "n7".to_string()],
-            "ordinals 2,3,4 are the sixth through eighth rows of the fixture"
-        );
-        assert!(
-            hit.range_probes_engaged >= 1,
-            "the range seek should engage on a declared column; census={hit:?}"
-        );
-        // A closed interval over 3 of 10 values that resolves all 10 is a walk
-        // wearing a counter, not a seek.
-        assert!(
-            hit.range_probe_candidates < ORDINALS.len() as u64,
-            "seek over 3 of 10 values resolved {} candidates; census={hit:?}",
-            hit.range_probe_candidates
+            candidates_by_size,
+            vec![ANSWER_ROWS, ANSWER_ROWS],
+            "candidates must be set by the {ANSWER_ROWS}-row answer, not by the \
+             collection: {candidates_by_size:?} at sizes {COLLECTION_SIZES:?}"
         );
 
-        // ---- miss: no declaration, so there is no index to seek ------------
-        let session = seeded_session("range_scan_note", false).await;
+        // ---- the refusal: no declaration means no index to seek ------------
+        let session = seeded_session("range_scan_note", false, COLLECTION_SIZES[0]).await;
         let _ = lix::storage_bench::take_hot_index_probe_census();
         let answered = ordinal_range_ids(&session, "range_scan_note", 2, 4).await;
         let miss = lix::storage_bench::take_hot_index_probe_census();
@@ -85,8 +102,8 @@ fn range_seek_engages_on_a_declared_column_and_refuses_on_an_undeclared_one() {
             vec!["n5".to_string(), "n6".to_string(), "n7".to_string()],
             "refusing to seek must not change the answer"
         );
-        // Exact zero is only safe because this is a dedicated process and the
-        // two arms are sequential.
+        // Exact zero is only defensible because this is a dedicated process
+        // and every arm above it ran sequentially.
         assert_eq!(
             miss.range_probes_engaged, 0,
             "an undeclared column has no index entries and must not seek; census={miss:?}"
@@ -119,7 +136,11 @@ async fn ordinal_range_ids(
         .collect()
 }
 
-async fn seeded_session(schema_key: &str, declare_unique: bool) -> SessionContext<Memory> {
+async fn seeded_session(
+    schema_key: &str,
+    declare_unique: bool,
+    rows: usize,
+) -> SessionContext<Memory> {
     let storage = Memory::default();
     Engine::initialize(storage.clone())
         .await
@@ -143,7 +164,10 @@ async fn seeded_session(schema_key: &str, declare_unique: bool) -> SessionContex
         .await
         .expect("register schema");
 
-    for (index, ordinal) in ORDINALS.iter().enumerate() {
+    // Ordinals start at -3 so the range spans zero and negatives, exercising
+    // the order-preserving sign flip rather than only the positive half.
+    for index in 0..rows {
+        let ordinal = index as i64 - 3;
         session
             .execute(
                 &format!("INSERT INTO {schema_key} (id, ordinal) VALUES ($1, {ordinal})"),

--- a/packages/lix/tests/hot_index_range_probe.rs
+++ b/packages/lix/tests/hot_index_range_probe.rs
@@ -1,0 +1,156 @@
+//! The hot-index range seek must actually seek, and must refuse when it cannot.
+//!
+//! This lives in its own `[[test]]` target because `storage_bench` counters are
+//! **process-global**. In the shared suite a concurrent test can only inflate
+//! them — harmless for a `>=` assertion, but fatal for the two assertions that
+//! matter here: "resolved fewer candidates than the collection" and "did not
+//! engage at all" are both *upper* bounds, which inflation pushes toward a
+//! spurious failure. A dedicated target is its own process, and both arms run
+//! sequentially inside one `#[test]` so that even libtest's own parallelism
+//! cannot interleave them.
+//!
+//! Without these assertions the 144-pair bound differential in the integration
+//! suite is vacuous: it would pass identically against a silently-refusing
+//! seek, proving nothing about the seek while looking like thorough coverage.
+
+use std::future::Future;
+
+use lix::integration::{Engine, SessionContext};
+use lix::{Memory, Value};
+
+/// Building and optimizing real DataFusion plans recurses per plan node and
+/// overflows libtest's 2 MiB worker stack in the `test` profile.
+const RANGE_PROBE_TEST_STACK_SIZE: usize = 32 * 1024 * 1024;
+
+/// Ordinals seeded into both fixtures. Spans zero and negatives so the
+/// order-preserving sign flip is exercised, not just the positive half.
+const ORDINALS: [i64; 10] = [-3, -2, -1, 0, 1, 2, 3, 4, 5, 6];
+
+fn run_on_sized_stack<Body, Fut>(name: &str, body: Body)
+where
+    Body: FnOnce() -> Fut + Send + 'static,
+    Fut: Future<Output = ()>,
+{
+    std::thread::Builder::new()
+        .name(name.to_string())
+        .stack_size(RANGE_PROBE_TEST_STACK_SIZE)
+        .spawn(move || {
+            tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .expect("build range-probe test runtime")
+                .block_on(body());
+        })
+        .expect("spawn range-probe test thread")
+        .join()
+        .expect("range-probe test body panicked");
+}
+
+#[test]
+fn range_seek_engages_on_a_declared_column_and_refuses_on_an_undeclared_one() {
+    run_on_sized_stack("hot_index_range_probe", || async {
+        // ---- hit: the column declares `x-lix-unique`, so entries exist -----
+        let session = seeded_session("range_seek_note", true).await;
+        // Drain what seeding wrote — uniqueness validation probes the same
+        // index — so the census below describes the read, not the writes.
+        let _ = lix::storage_bench::take_hot_index_probe_census();
+        let answered = ordinal_range_ids(&session, "range_seek_note", 2, 4).await;
+        let hit = lix::storage_bench::take_hot_index_probe_census();
+
+        assert_eq!(
+            answered,
+            vec!["n5".to_string(), "n6".to_string(), "n7".to_string()],
+            "ordinals 2,3,4 are the sixth through eighth rows of the fixture"
+        );
+        assert!(
+            hit.range_probes_engaged >= 1,
+            "the range seek should engage on a declared column; census={hit:?}"
+        );
+        // A closed interval over 3 of 10 values that resolves all 10 is a walk
+        // wearing a counter, not a seek.
+        assert!(
+            hit.range_probe_candidates < ORDINALS.len() as u64,
+            "seek over 3 of 10 values resolved {} candidates; census={hit:?}",
+            hit.range_probe_candidates
+        );
+
+        // ---- miss: no declaration, so there is no index to seek ------------
+        let session = seeded_session("range_scan_note", false).await;
+        let _ = lix::storage_bench::take_hot_index_probe_census();
+        let answered = ordinal_range_ids(&session, "range_scan_note", 2, 4).await;
+        let miss = lix::storage_bench::take_hot_index_probe_census();
+
+        assert_eq!(
+            answered,
+            vec!["n5".to_string(), "n6".to_string(), "n7".to_string()],
+            "refusing to seek must not change the answer"
+        );
+        // Exact zero is only safe because this is a dedicated process and the
+        // two arms are sequential.
+        assert_eq!(
+            miss.range_probes_engaged, 0,
+            "an undeclared column has no index entries and must not seek; census={miss:?}"
+        );
+    });
+}
+
+async fn ordinal_range_ids(
+    session: &SessionContext<Memory>,
+    table: &str,
+    lower: i64,
+    upper: i64,
+) -> Vec<String> {
+    let result = session
+        .execute(
+            &format!(
+                "SELECT id FROM {table} WHERE ordinal BETWEEN {lower} AND {upper} ORDER BY id"
+            ),
+            &[],
+        )
+        .await
+        .expect("range query should succeed");
+    result
+        .rows()
+        .iter()
+        .filter_map(|row| match row.values().first() {
+            Some(Value::Text(value)) => Some(value.clone()),
+            _ => None,
+        })
+        .collect()
+}
+
+async fn seeded_session(schema_key: &str, declare_unique: bool) -> SessionContext<Memory> {
+    let storage = Memory::default();
+    Engine::initialize(storage.clone())
+        .await
+        .expect("initialize fixture");
+    let engine = Engine::new(storage).await.expect("open engine");
+    let session = engine.open_session().await.expect("open session");
+
+    let unique = if declare_unique {
+        r#""x-lix-unique":[["/ordinal"]],"#
+    } else {
+        ""
+    };
+    let schema = format!(
+        r#"{{"x-lix-key":"{schema_key}","x-lix-primary-key":["/id"],{unique}"type":"object","properties":{{"id":{{"type":"string"}},"ordinal":{{"type":"integer"}}}},"required":["id","ordinal"],"additionalProperties":false}}"#
+    );
+    session
+        .execute(
+            "INSERT INTO lix_registered_schema (value) VALUES (lix_json($1))",
+            &[Value::Text(schema)],
+        )
+        .await
+        .expect("register schema");
+
+    for (index, ordinal) in ORDINALS.iter().enumerate() {
+        session
+            .execute(
+                &format!("INSERT INTO {schema_key} (id, ordinal) VALUES ($1, {ordinal})"),
+                &[Value::Text(format!("n{index}"))],
+            )
+            .await
+            .expect("insert row");
+    }
+    session
+}

--- a/packages/lix/tests/integration/sql/entity_view.rs
+++ b/packages/lix/tests/integration/sql/entity_view.rs
@@ -294,18 +294,18 @@ simulation_test!(
     }
 );
 
-/// The bound-exactness differential.
-///
-/// `StoragePrefix::to_range` yields a half-open `[lo, hi)`, so an inclusive
-/// upper bound is the one place a range access path silently loses rows: every
-/// row equal to `hi` vanishes and the answer is still plausibly shaped. This
-/// sweeps every `(lo, hi)` pair over a fixture that brackets the data on both
-/// sides and compares against the set computed directly from the fixture, so a
-/// bound error at either end fails here rather than in a benchmark.
-///
-/// The ordinals deliberately span zero and negatives: the order-preserving
-/// integer key encoding is `value ^ (1 << 63)`, and a naive encoder that skips
-/// the sign flip orders every negative above every positive.
+// The bound-exactness differential.
+//
+// `StoragePrefix::to_range` yields a half-open `[lo, hi)`, so an inclusive
+// upper bound is the one place a range access path silently loses rows: every
+// row equal to `hi` vanishes and the answer is still plausibly shaped. This
+// sweeps every `(lo, hi)` pair over a fixture that brackets the data on both
+// sides and compares against the set computed directly from the fixture, so a
+// bound error at either end fails here rather than in a benchmark.
+//
+// The ordinals deliberately span zero and negatives: the order-preserving
+// integer key encoding is `value ^ (1 << 63)`, and a naive encoder that skips
+// the sign flip orders every negative above every positive.
 simulation_test!(
     entity_range_pushdown_matches_full_scan_at_every_bound,
     |sim| async move {
@@ -349,13 +349,13 @@ simulation_test!(
     }
 );
 
-/// The same differential for each half-bounded operator, in both operand
-/// orders.
-///
-/// `5 < ordinal` is `ordinal > 5`, so the literal-on-the-left spelling has to
-/// reverse the comparison. Reusing the operator returns the complement of the
-/// requested rows — an error that a one-sided test with the column always on
-/// the left cannot see.
+// The same differential for each half-bounded operator, in both operand
+// orders.
+//
+// `5 < ordinal` is `ordinal > 5`, so the literal-on-the-left spelling has to
+// reverse the comparison. Reusing the operator returns the complement of the
+// requested rows — an error that a one-sided test with the column always on
+// the left cannot see.
 simulation_test!(
     entity_range_pushdown_matches_full_scan_for_each_operator,
     |sim| async move {
@@ -375,14 +375,13 @@ simulation_test!(
         }
 
         for bound in -5_i64..=8 {
-            for (operator, reversed, matches) in [
-                ("<", ">", &(|ordinal: i64, bound: i64| ordinal < bound) as &dyn Fn(i64, i64) -> bool),
-                ("<=", ">=", &|ordinal: i64, bound: i64| ordinal <= bound),
-                (">", "<", &|ordinal: i64, bound: i64| ordinal > bound),
-                (">=", "<=", &|ordinal: i64, bound: i64| ordinal >= bound),
-            ] {
-                let expected =
-                    expected_range_note_ids(&ordinals, |ordinal| matches(ordinal, bound));
+            for (operator, reversed) in [("<", ">"), ("<=", ">="), (">", "<"), (">=", "<=")] {
+                let expected = expected_range_note_ids(&ordinals, |ordinal| match operator {
+                    "<" => ordinal < bound,
+                    "<=" => ordinal <= bound,
+                    ">" => ordinal > bound,
+                    _ => ordinal >= bound,
+                });
 
                 let column_first = session
                     .execute(
@@ -419,13 +418,13 @@ simulation_test!(
     }
 );
 
-/// Engagement, asserted at the plan.
-///
-/// Before this change a range predicate was `Unsupported`: the provider never
-/// saw it, so it could not reach row-group pruning or any index. `Exact` would
-/// be wrong — the hot index returns a candidate superset and the open/closed
-/// bound distinction is enforced by the residual — so the predicate must appear
-/// as a *partial* filter, meaning pushed down **and** still re-checked above.
+// Engagement, asserted at the plan.
+//
+// Before this change a range predicate was `Unsupported`: the provider never
+// saw it, so it could not reach row-group pruning or any index. `Exact` would
+// be wrong — the hot index returns a candidate superset and the open/closed
+// bound distinction is enforced by the residual — so the predicate must appear
+// as a *partial* filter, meaning pushed down **and** still re-checked above.
 simulation_test!(
     entity_range_pushdown_reaches_the_table_scan_inexactly,
     |sim| async move {
@@ -462,12 +461,12 @@ simulation_test!(
     }
 );
 
-/// The rejection cases, asserted as hard as the acceptance cases.
-///
-/// A `Number` column has no total order (NaN), and `Boolean`/`Json` have no
-/// useful range, so none of them may become a pushed range. Over-claiming here
-/// is a wrong answer rather than a slow one, which is why this is asserted
-/// rather than left to the residual.
+// The rejection cases, asserted as hard as the acceptance cases.
+//
+// A `Number` column has no total order (NaN), and `Boolean`/`Json` have no
+// useful range, so none of them may become a pushed range. Over-claiming here
+// is a wrong answer rather than a slow one, which is why this is asserted
+// rather than left to the residual.
 simulation_test!(
     entity_range_pushdown_refuses_columns_without_a_total_order,
     |sim| async move {

--- a/packages/lix/tests/integration/sql/entity_view.rs
+++ b/packages/lix/tests/integration/sql/entity_view.rs
@@ -294,6 +294,292 @@ simulation_test!(
     }
 );
 
+/// The bound-exactness differential.
+///
+/// `StoragePrefix::to_range` yields a half-open `[lo, hi)`, so an inclusive
+/// upper bound is the one place a range access path silently loses rows: every
+/// row equal to `hi` vanishes and the answer is still plausibly shaped. This
+/// sweeps every `(lo, hi)` pair over a fixture that brackets the data on both
+/// sides and compares against the set computed directly from the fixture, so a
+/// bound error at either end fails here rather than in a benchmark.
+///
+/// The ordinals deliberately span zero and negatives: the order-preserving
+/// integer key encoding is `value ^ (1 << 63)`, and a naive encoder that skips
+/// the sign flip orders every negative above every positive.
+simulation_test!(
+    entity_range_pushdown_matches_full_scan_at_every_bound,
+    |sim| async move {
+        let engine = sim.boot_engine().await;
+        let session = sim.wrap_session(
+            engine
+                .open_session()
+                .await
+                .expect("main session should open"),
+            &engine,
+        );
+
+        register_range_note_schema(&session).await;
+        let ordinals: Vec<i64> = vec![-3, -2, -1, 0, 1, 2, 3, 4, 5, 6];
+        for (index, ordinal) in ordinals.iter().enumerate() {
+            insert_range_note(&session, &format!("n{index}"), *ordinal).await;
+        }
+
+        for lower in -5_i64..=8 {
+            for upper in -5_i64..=8 {
+                let result = session
+                    .execute(
+                        &format!(
+                            "SELECT id FROM range_note \
+                             WHERE ordinal BETWEEN {lower} AND {upper} ORDER BY id"
+                        ),
+                        &[],
+                    )
+                    .await
+                    .expect("range query should succeed");
+                let expected = expected_range_note_ids(&ordinals, |ordinal| {
+                    ordinal >= lower && ordinal <= upper
+                });
+                assert_eq!(
+                    range_note_ids(&result),
+                    expected,
+                    "BETWEEN {lower} AND {upper} must return exactly the full-scan answer"
+                );
+            }
+        }
+    }
+);
+
+/// The same differential for each half-bounded operator, in both operand
+/// orders.
+///
+/// `5 < ordinal` is `ordinal > 5`, so the literal-on-the-left spelling has to
+/// reverse the comparison. Reusing the operator returns the complement of the
+/// requested rows — an error that a one-sided test with the column always on
+/// the left cannot see.
+simulation_test!(
+    entity_range_pushdown_matches_full_scan_for_each_operator,
+    |sim| async move {
+        let engine = sim.boot_engine().await;
+        let session = sim.wrap_session(
+            engine
+                .open_session()
+                .await
+                .expect("main session should open"),
+            &engine,
+        );
+
+        register_range_note_schema(&session).await;
+        let ordinals: Vec<i64> = vec![-3, -2, -1, 0, 1, 2, 3, 4, 5, 6];
+        for (index, ordinal) in ordinals.iter().enumerate() {
+            insert_range_note(&session, &format!("n{index}"), *ordinal).await;
+        }
+
+        for bound in -5_i64..=8 {
+            for (operator, reversed, matches) in [
+                ("<", ">", &(|ordinal: i64, bound: i64| ordinal < bound) as &dyn Fn(i64, i64) -> bool),
+                ("<=", ">=", &|ordinal: i64, bound: i64| ordinal <= bound),
+                (">", "<", &|ordinal: i64, bound: i64| ordinal > bound),
+                (">=", "<=", &|ordinal: i64, bound: i64| ordinal >= bound),
+            ] {
+                let expected =
+                    expected_range_note_ids(&ordinals, |ordinal| matches(ordinal, bound));
+
+                let column_first = session
+                    .execute(
+                        &format!(
+                            "SELECT id FROM range_note WHERE ordinal {operator} {bound} ORDER BY id"
+                        ),
+                        &[],
+                    )
+                    .await
+                    .expect("range query should succeed");
+                assert_eq!(
+                    range_note_ids(&column_first),
+                    expected,
+                    "ordinal {operator} {bound} must match the full-scan answer"
+                );
+
+                // The mirrored spelling of the identical predicate.
+                let literal_first = session
+                    .execute(
+                        &format!(
+                            "SELECT id FROM range_note WHERE {bound} {reversed} ordinal ORDER BY id"
+                        ),
+                        &[],
+                    )
+                    .await
+                    .expect("reversed range query should succeed");
+                assert_eq!(
+                    range_note_ids(&literal_first),
+                    expected,
+                    "{bound} {reversed} ordinal must match ordinal {operator} {bound}"
+                );
+            }
+        }
+    }
+);
+
+/// Engagement, asserted at the plan.
+///
+/// Before this change a range predicate was `Unsupported`: the provider never
+/// saw it, so it could not reach row-group pruning or any index. `Exact` would
+/// be wrong — the hot index returns a candidate superset and the open/closed
+/// bound distinction is enforced by the residual — so the predicate must appear
+/// as a *partial* filter, meaning pushed down **and** still re-checked above.
+simulation_test!(
+    entity_range_pushdown_reaches_the_table_scan_inexactly,
+    |sim| async move {
+        let engine = sim.boot_engine().await;
+        let session = sim.wrap_session(
+            engine
+                .open_session()
+                .await
+                .expect("main session should open"),
+            &engine,
+        );
+
+        register_range_note_schema(&session).await;
+
+        let explain = session
+            .execute(
+                "EXPLAIN VERBOSE SELECT id FROM range_note WHERE ordinal BETWEEN 2 AND 4",
+                &[],
+            )
+            .await
+            .expect("EXPLAIN should succeed");
+        let plan = explain_plan_text(&explain);
+
+        let partial = partial_filters_text(&plan)
+            .unwrap_or_else(|| panic!("range predicate should reach the scan:\n{plan}"));
+        assert!(
+            partial.contains("ordinal"),
+            "the ordinal range should be pushed to the scan, got partial_filters={partial}:\n{plan}"
+        );
+        assert!(
+            plan.contains("Filter:") || plan.contains("FilterExec"),
+            "an Inexact pushdown must retain a residual filter above the scan:\n{plan}"
+        );
+    }
+);
+
+/// The rejection cases, asserted as hard as the acceptance cases.
+///
+/// A `Number` column has no total order (NaN), and `Boolean`/`Json` have no
+/// useful range, so none of them may become a pushed range. Over-claiming here
+/// is a wrong answer rather than a slow one, which is why this is asserted
+/// rather than left to the residual.
+simulation_test!(
+    entity_range_pushdown_refuses_columns_without_a_total_order,
+    |sim| async move {
+        let engine = sim.boot_engine().await;
+        let session = sim.wrap_session(
+            engine
+                .open_session()
+                .await
+                .expect("main session should open"),
+            &engine,
+        );
+
+        register_range_note_schema(&session).await;
+        insert_range_note(&session, "n0", 1).await;
+
+        for predicate in ["weight > 1.5", "weight BETWEEN 0.5 AND 2.5"] {
+            let explain = session
+                .execute(
+                    &format!("EXPLAIN VERBOSE SELECT id FROM range_note WHERE {predicate}"),
+                    &[],
+                )
+                .await
+                .expect("EXPLAIN should succeed");
+            let plan = explain_plan_text(&explain);
+            if let Some(partial) = partial_filters_text(&plan) {
+                assert!(
+                    !partial.contains("weight"),
+                    "a float column must not become a pushed range, got partial_filters={partial}:\n{plan}"
+                );
+            }
+        }
+
+        // Refusing to push it must not change the answer.
+        let result = session
+            .execute("SELECT id FROM range_note WHERE weight > 0.5 ORDER BY id", &[])
+            .await
+            .expect("float range query should still answer");
+        assert_eq!(range_note_ids(&result), vec!["n0".to_string()]);
+    }
+);
+
+async fn register_range_note_schema(
+    session: &crate::support::simulation_test::engine::SimSession,
+) {
+    // `ordinal` is declared unique so this one fixture also carries hot-index
+    // entries, letting the same differential cover the index range seek when
+    // that path lands. `weight` is the deliberate negative control: a float
+    // column that must never become a pushed range.
+    session
+        .execute(
+            "INSERT INTO lix_registered_schema (value, lixcol_global, lixcol_untracked) \
+             VALUES (\
+             lix_json('{\"x-lix-key\":\"range_note\",\"x-lix-primary-key\":[\"/id\"],\"x-lix-unique\":[[\"/ordinal\"]],\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\"},\"ordinal\":{\"type\":\"integer\"},\"lane\":{\"type\":\"string\"},\"weight\":{\"type\":\"number\"}},\"required\":[\"id\",\"ordinal\",\"lane\",\"weight\"],\"additionalProperties\":false}'),\
+             false,\
+             false\
+             )",
+            &[],
+        )
+        .await
+        .expect("range_note schema should register");
+}
+
+async fn insert_range_note(
+    session: &crate::support::simulation_test::engine::SimSession,
+    id: &str,
+    ordinal: i64,
+) {
+    session
+        .execute(
+            &format!(
+                "INSERT INTO range_note (id, ordinal, lane, weight) \
+                 VALUES ('{id}', {ordinal}, 'lane-{}', 1.5)",
+                ordinal.rem_euclid(4)
+            ),
+            &[],
+        )
+        .await
+        .expect("range_note row should insert");
+}
+
+fn range_note_ids(result: &ExecuteResult) -> Vec<String> {
+    result
+        .rows()
+        .iter()
+        .filter_map(|row| match row.values().first() {
+            Some(Value::Text(value)) => Some(value.clone()),
+            _ => None,
+        })
+        .collect()
+}
+
+/// The answer computed straight from the fixture, ordered the way the query
+/// orders it. This is the "full scan" side of the differential.
+fn expected_range_note_ids(ordinals: &[i64], matches: impl Fn(i64) -> bool) -> Vec<String> {
+    let mut ids: Vec<String> = ordinals
+        .iter()
+        .enumerate()
+        .filter(|(_, ordinal)| matches(**ordinal))
+        .map(|(index, _)| format!("n{index}"))
+        .collect();
+    ids.sort();
+    ids
+}
+
+/// The `partial_filters=[...]` list from an EXPLAIN, when the scan has one.
+fn partial_filters_text(plan: &str) -> Option<String> {
+    let start = plan.find("partial_filters=[")? + "partial_filters=[".len();
+    let rest = &plan[start..];
+    let end = rest.find(']')?;
+    Some(rest[..end].to_string())
+}
+
 async fn register_pushdown_note_schema(
     session: &crate::support::simulation_test::engine::SimSession,
 ) {


### PR DESCRIPTION
## What this is

A range access path for entity surfaces: `<`, `<=`, `>`, `>=`, `BETWEEN` on a column the schema declares indexable now reach the hot index as a **seek** instead of scanning the branch.

**Format-neutral.** No record changed, no new persisted field, no `REPOSITORY_PROTOCOL_VALUE` bump. The hot-index key encoding was already order-preserving and laid down for exactly this — its own comment says so: *"Integers use the same order-preserving flip as entity-pk components so a future range predicate can reuse this encoding unchanged."*

## Read this first: Phase A alone would have been a regression

This branch was deliberately held rather than landed piecemeal, and the reason should be legible without reading the history.

The starting diagnosis was that range predicates were pushed down as `Inexact` (full scan plus residual). **That was wrong.** `EntityRowFilterAnalyzer::analyze_binary` bailed on any operator that was not `Eq`, so a range was `Unsupported` — the provider never saw it at all, and DataFusion kept it entirely in a `FilterExec` above the scan.

That made the obvious first change ("recognize ranges, feed row-group min/max pruning") look like a general win on ordinary undeclared columns. **It is not, today.** The columnar layout that pruning feeds is constructed at exactly three sites, all gated on `use_typed_certified_insert(row_count)` with `TYPED_CERTIFIED_INSERT_MIN_ROWS = 32 * 1024` — and it requires 32 768 rows **in one certified parameter batch**, which `INSERT … VALUES` cannot produce because it routes through the native fast path. The lane's own test says it plainly: *"A smaller fixture silently produces no columnar commit at all."*

So recognizing ranges on its own would have engaged only the row-plane branch — where a newly non-empty `row_filters` **disqualifies** the direct-batch and PK-projection routes — while the branch it was meant to help never executed. A pure regression in the only case that runs.

**Phase A + Phase B together is the win:** the seek gives a real access path on declared columns, and the mitigation below makes the direct routes provably non-regressing rather than merely tested.

## Correctness

**Pushdown is `Inexact`, never `Exact`.** Two independent reasons, either sufficient: the index returns a **candidate superset** (entries are not deleted within a generation, so a candidate may name a row that has since changed value or been deleted), and the residual is also what enforces the open/closed bound distinction. An `Exact` claim here returns wrong rows.

Worth noting for reviewers: `filter_pushdown` needed **no edit**. Once `analyze` recognizes a range, `supports()` is true and the existing arm returns `Inexact`. The hazard was structurally impossible to express rather than merely tested against.

**Bound exactness is the crux.** `hot_index_key_successor` exists because entries for value `v` are `prefix_v ++ entity_pk` and therefore all sort **above** `prefix_v`. An upper bound of `Excluded(prefix_v)` is right for `< v` and silently drops every row equal to `v` for `<= v` — a plausibly-shaped wrong answer.

**Deliberate looseness, documented in the code:** when several conjuncts bound the same side, the first is taken rather than the tightest, so `x > 5 AND x > 100` seeks from 5. Every conjunct must hold, so any one is a valid bound; a looser one costs candidates, never correctness, and the residual rejects the surplus. Disjunctions contribute nothing — a bound under an `Or` does not hold for every admitted row.

**Refusals, not guesses:** `Number` (NaN has no total order), `Boolean`, and `Json` never become a pushed range. Only `Integer` and `String` — the two types the index encodes order-preservingly.

**An empty interval names no rows, so it must be answered without opening a cursor — not by scanning and finding nothing.** `BETWEEN 8 AND -5` produces a lower bound key that sorts *above* its upper bound, and the store rejects a cursor built that way (`LIX_STORAGE_ERROR: cursor is invalid for this read view`). The bounds are therefore computed as raw keys and compared before any scan is opened.

This one is worth knowing about if you touch the bound construction: it was invisible to `cargo check`, and invisible to the dedicated probe target too, because that target only issues valid intervals. It needs a **real storage cursor** to appear at all. What found it was sweeping `lo` and `hi` **independently** rather than over valid ranges only — a sweep built for bound exactness catching a cursor-construction defect in the degenerate corner.

## Evidence that the seek reads fewer entries than a scan

No timing claim is made here. But *"a seek exists and is correct"* and *"a seek reads fewer rows than a scan"* are different claims, and only the second answers what a reviewer actually wants to know. The second is available as a **deterministic count**, so it is asserted in the test suite rather than benchmarked:

| collection rows | index entries read | answer rows |
|---|---|---|
| 10 | **3** | 3 |
| 200 | **3** | 3 |

The collection grows **20x and the entries read do not move**, because a seek's cost is set by its answer. A scan's would have grown with the collection — that contrast is the whole claim, and it is the reason the assertion is a pair of sizes rather than a single point. Counted at the probe's own decision point, `--test-threads`-independent, and reproducible with:

```
cargo test --profile test -p lix --all-features --test hot_index_range_probe
```

Wall-clock belongs in a follow-up, with lane, backend, row count, and checkpoint cadence stated.

## The instrumentation caught a real defect in this PR

Reviewers reasonably discount census counters as ceremony. This one paid for itself before the branch was opened.

The mitigation (below) and the seek were each individually correct — and they **cancelled**. Admitting range-only filters to `direct_entity_batch_eligible` routed `SELECT id … WHERE ordinal BETWEEN 2 AND 4` down the direct PK-projection path, which is precisely the route that bypasses `resolve_declared_column_predicates`. The fast full read won the route and the seek never ran.

**Every correctness test passed.** The 144-pair bound differential, the operator matrix in both operand orders, the rejection cases — all green, all silently against a full scan. The answer was right; only the route was wrong.

What made it diagnosable was the census reading **all zeros including the refusal counters**. Had the branch run and declined, a refusal fires; had it run and skipped every candidate, the query returns zero rows. Neither happened, so the branch never executed — which pointed at routing, not at the seek logic. An engagement counter alone says *didn't engage*; the refusal counters say *why*.

The fix is conditional: a range disqualifies the direct route **when a `declared_column_range` is present** (mirroring what an equality on an indexed column already does) and is admitted otherwise. `all()` on an empty list is true, so the pre-existing empty case is preserved by construction.

**If you add a fast path near this code, build the counter first.**

## Reachability

Unlike the columnar tier, the index plane is **not** behind the 32 768-row gate. `hot_index_writes_for_commit` has one caller on the unconditional commit path, and stages from the commit's own rows *after* routing — *"correct whichever physical route above published them"*. Ten rows publish entries the same way thirty-three thousand do.

Two real limits, both different in kind from a row-count cliff:

- **The schema must declare the column** (single-column `x-lix-unique` or FK).
- **The collection must start after the plane existed** — the witness is published when the parent generation proves the schema absent. A collection predating the plane never gets a witness and keeps scanning. This bites old repositories, not small ones.

## Scope: what this does *not* fix

lix is ~45x slower than SQLite **per scanned row** on the row pipeline, independent of any access path. That bounds every predicate nobody declared an index for.

**These are two separate findings and this PR claims no causal link between them.** A measurement on this campaign tested whether the unreachable columnar tier explains the per-row cost and found the opposite: with the packed base present, reads were *slower* (2 314 vs 1 743 ns/row, disjoint ranges). The columnar tier being unreachable and the row pipeline being slow are both true, and the first does not explain the second.

### Applicability: this only helps columns someone declared

The honest boundary of what this buys, and it is narrower than "range queries are now fast".

The seek requires the column to appear in a single-column `x-lix-unique` group or foreign key — those are the only sources `derive_indexed_columns` reads. An ordinary attribute nobody declared has **no index entries at all**, and a range on it behaves exactly as it does today.

**The reason most people will not have declared them is a defect in the schema surface, not user error.** `x-lix-unique` currently conflates two separate things — *"index this column"* and *"enforce uniqueness on this column"*. A user who wants a fast `ordinal` range and has no uniqueness requirement must **falsely declare `ordinal` unique** to get one, which is a correctness constraint they did not want and may not be able to honor.

Separating those (an `x-lix-index` declaration) is a product-surface decision, is **not** in this PR, and would need a protocol bump. It is the strongest argument for making that decision, and this PR is the evidence that the machinery behind it already works.

## Tests

- `entity_range_pushdown_matches_full_scan_at_every_bound` — all 144 `(lo, hi)` pairs over `-5..=8` against a fixture bracketing the data on both sides and spanning zero and negatives, compared row-for-row against the answer computed from the fixture. Catches the inclusive-upper off-by-one and a missing sign flip together.
- `entity_range_pushdown_matches_full_scan_for_each_operator` — every operator at every bound, **in both operand orders**. `5 < ordinal` must reverse to `ordinal > 5`; reusing the operator returns the *complement* of the requested rows, which a one-sided test cannot see.
- `entity_range_pushdown_reaches_the_table_scan_inexactly` — the range appears in `partial_filters` **and** a residual survives above the scan.
- `entity_range_pushdown_refuses_columns_without_a_total_order` — a float column never becomes a pushed range, and the answer is unchanged.
- **`hot_index_range_probe`** (new `[[test]]` target) — engagement and refusal. Its own process because `storage_bench` counters are process-global and two of its assertions are *upper* bounds, which a concurrent test could inflate into a spurious failure. Both arms run **sequentially inside one `#[test]`**, because libtest runs `#[test]` functions within a single binary concurrently — a dedicated target alone is necessary but not sufficient. That determinism is what lets the miss arm assert `range_probes_engaged == 0` exactly rather than a hedged threshold. The census is drained immediately before each measured read, since seeding a declared-unique collection probes the same index during uniqueness validation.

Without the engagement assertions the 144-pair differential is **vacuous** — it passes identically against a silently-refusing seek.

## Gate

Scope re-derived from this sha's `ci.yml`, not carried forward.

```
HEAD_BEFORE=47dc70a55952369205af5a1e7aaa5745e175a0ed
STATUS_BEFORE=0
CI_SCOPE_CONFIRMED_AT=47dc70a55952369205af5a1e7aaa5745e175a0ed
CLIPPY_EXIT=0
TEST1_EXIT=0
TEST2_EXIT=0
NODEFAULT_EXIT=0
WASM_EXIT=0
EXECUTED_TARGETS test1=3439 test2=172
FAILED test1=0 test2=0
HEAD_AFTER=47dc70a55952369205af5a1e7aaa5745e175a0ed
STATUS_AFTER=0
```

`HEAD` printed before and after, identical, on a clean tree both times. The only 40-character sha anywhere in the gate summary is `47dc70a55` — checked, because a log clobbered by a concurrent job looks fresh and internally consistent while describing someone else's tree, and `HEAD_BEFORE == HEAD_AFTER` cannot detect that.

**Target counts, named rather than folded into a total** — a tree that runs more targets than its parent is where a merge-only break hides:

- `test1`: **39** target results, 3439 passed. One more target than the parent — **`hot_index_range_probe`**, the one this branch adds, confirmed present in the log.
- `test2`: **27** target results, 172 passed. `cas_gc_history_retention` is back to 4 passing (it aborted at 168/26 before the boxing fix), and `stack overflow` appears **0** times.

`--no-default-features` and the wasm target are both included even though **`--no-default-features` is not a CI step at this sha**. It is the only step that caught the `storage-benches` cfg gap. CI scope is the floor, not the ceiling.

## Interaction with #1453 (`agent/entity-filter-projected-parse`) — read before merging either

#1453 replaces the full-DOM `serde_json` parse in `apply_entity_batch_filters` with a streaming parse that materialises **only the columns the predicate names**, skipping the rest with `IgnoredAny`. That is sound against `EntityRowFilter` as it exists today — `ColumnEq`, `ColumnIn`, `And`, `Or`.

**`ColumnRange` breaks the assumption.** If the range's column is not enumerated by that walk, the predicate evaluates against **absent data** and returns silently wrong rows. It compiles and it runs; the only thing in either branch that catches it is the 144-pair differential here, which does not exist in their tree.

The resolution is the property this PR already leans on: **exhaustiveness** — and it has been verified mechanically rather than by reading. #1453's author added a probe variant standing in for `ColumnRange` and built: `EXIT=101` with four `E0004: non-exhaustive patterns` errors, one per `match self` — `declared_column_membership`, `may_match_group`, **`collect_filter_columns`** (the site that matters), and `matches_snapshot`. Probe reverted, tree clean.

So the column walk is a **total match on `EntityRowFilter` itself**: this variant cannot compile until handled, and the compiler names all four sites. Note that checking this by grep gives the *opposite* of the truth — `impl EntityRowFilter` does contain two `_ => None` arms, but both are on a tuple of `Option<bool>` inside `may_match_group`, not on `Self`.

**The merge-time fix is one line:** in `collect_filter_columns`, a range reads exactly one top-level column, the same shape `ColumnEq` and `ColumnIn` already have, so the new arm folds into the existing `Self::ColumnEq { column, .. } | Self::ColumnIn { column, .. }`.

**Whichever of these lands second must run the 144-pair differential against the merged tree, not against its own branch** — two green branches can compose into a break that exists in neither, and this is that shape exactly.

Once handled, the two compose into a real win: ranges enter the filter path here, and #1453's projected parse then covers them too.

## Five defects, five different instruments

Recorded because it is the argument for keeping all five gate steps rather than mirroring CI:

| defect | found by |
|---|---|
| unfulfilled `#[expect(clippy::too_many_arguments)]` | `clippy -D warnings` |
| invalid cursor on inverted intervals (`BETWEEN 8 AND -5`) | the 144-pair differential |
| census calls unguarded by `storage-benches` | `cargo check --no-default-features` |
| mitigation routing around the seek it shipped with | the probe census |
| `HotStateFilter` frame growth aborting an unrelated GC test | `lix_e2e` |

**None was found by the step I would have reached for first**, and `cargo check --all-features` — the fastest and most tempting — caught none of them. Note that `--no-default-features` is **not a CI step at this sha**: CI scope is the floor, not the ceiling.

## Not for merge

Draft, against `claude-7-optimizations`. No performance number is claimed: this establishes the access path and its correctness. The measured win belongs in a follow-up on a fixture with a declared indexed column, stating lane, backend, row count, and checkpoint cadence.
