### PR TITLE
test(lix): pin the set of places that write a commit record

### DIFF
--- a/packages/lix/src/changelog/store.rs
+++ b/packages/lix/src/changelog/store.rs
@@ -147,4 +147,132 @@ mod tests {
             "binary key order must match hyphenated text order"
         );
     }
+
+
+    /// The set of places that WRITE a commit record must not grow silently.
+    ///
+    /// # What this defends
+    ///
+    /// A commit record entering storage is the moment a file name becomes part
+    /// of history. Any derived index over those names -- the persisted path
+    /// index scoped for `lix_file_history(...) WHERE path = ?` is the live
+    /// proposal -- can only be maintained at one site if there *is* only one
+    /// site. That premise was established by compiler enumeration; without a
+    /// guard it decays into a comment, and the failure it would hide is the
+    /// silent one: an index that misses names under-approximates, and a history
+    /// query then drops rows rather than erroring.
+    ///
+    /// Note that head movement is deliberately NOT part of this set.
+    /// `MergeOutcome::FastForward` and branch-ref creation make whole
+    /// ancestries reachable without staging any descriptor row, so an index
+    /// keyed to *reachability* would need hooks in several places. Keying it to
+    /// commit *ingestion* instead makes those cases no-ops by construction --
+    /// which is exactly why this set, and not that one, is the thing worth
+    /// pinning.
+    ///
+    /// # How the expectation was derived, and what is production
+    ///
+    /// By breaking the *type* of the space constant while leaving its name
+    /// resolvable, so imports still resolve and every use fails type-check.
+    /// **Do not use `#[cfg(any())]` for this**: the constant then fails to
+    /// resolve, compilation stops at `E0432 unresolved import`, downstream
+    /// users are never type-checked, and the enumeration silently truncates --
+    /// measured here at 4 sites instead of 27, which looks complete and is not.
+    ///
+    /// Against the non-test build (`cargo check -p lix --all-features`), the
+    /// only writers are:
+    ///
+    /// * `changelog/context.rs` x2 -- `stage_transaction_append` and
+    ///   `stage_append_records`. **This is the choke point.** Its only
+    ///   production caller is `transaction/commit.rs`.
+    /// * `changelog/gc.rs` `.delete(` -- reclamation, which removes commit
+    ///   records and never introduces a name.
+    ///
+    /// Every other entry below is absent from the non-test build and is a test
+    /// fixture. This scan cannot tell the two apart, which is deliberate: a new
+    /// site of either kind should stop a human and make them classify it.
+    ///
+    /// # What this cannot see
+    ///
+    /// A write that reaches the space without naming the constant -- through an
+    /// alias, or a space value computed at runtime. Nothing does that today
+    /// (`server_protocol` writes no storage at all), but a scan is a
+    /// convention where the type-break is a mechanism. Re-run the type-break
+    /// when this test's answer matters.
+    #[test]
+    fn commit_record_write_sites_are_the_sanctioned_ones() {
+        let src = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("src");
+        let mut files = Vec::new();
+        let mut stack = vec![src.clone()];
+        while let Some(dir) = stack.pop() {
+            for entry in std::fs::read_dir(&dir).expect("src dir should read") {
+                let path = entry.expect("dir entry should read").path();
+                if path.is_dir() {
+                    stack.push(path);
+                } else if path.extension().is_some_and(|extension| extension == "rs") {
+                    files.push(path);
+                }
+            }
+        }
+        files.sort();
+
+        // Assembled rather than written literally so this test's own source
+        // does not register as a use site of the constant it scans for.
+        let needle = concat!("COMMIT", "_SPACE");
+        let verbs = [".put(", ".delete(", ".delete_batch(", ".stage("];
+        let mut found = std::collections::BTreeMap::<String, usize>::new();
+        for file in &files {
+            let text = std::fs::read_to_string(file).expect("source file should read");
+            let relative = file
+                .strip_prefix(&src)
+                .expect("scanned file should live under src")
+                .to_string_lossy()
+                .replace('\\', "/");
+            let mut from = 0usize;
+            while let Some(offset) = text[from..].find(needle) {
+                let at = from + offset;
+                from = at + needle.len();
+                // Walk back to the nearest call verb. A statement terminator or
+                // a block end between the two means the constant is not this
+                // call's argument.
+                let window = &text[at.saturating_sub(160)..at];
+                let Some((position, verb)) = verbs
+                    .iter()
+                    .filter_map(|verb| window.rfind(verb).map(|position| (position, *verb)))
+                    .max_by_key(|(position, _)| *position)
+                else {
+                    continue;
+                };
+                if window[position..].contains(';') || window[position..].contains('}') {
+                    continue;
+                }
+                *found.entry(format!("{relative} {verb}")).or_default() += 1;
+            }
+        }
+
+        let expected: std::collections::BTreeMap<String, usize> = [
+            // Production. The choke point every commit record enters through.
+            ("changelog/context.rs .stage(", 2),
+            // Production. Reclamation only: removes records, introduces no name.
+            ("changelog/gc.rs .delete(", 1),
+            // Test fixtures, all absent from the non-test build.
+            ("changelog/gc.rs .delete_batch(", 1),
+            ("commit_graph/walker.rs .delete(", 2),
+            ("commit_graph/walker.rs .put(", 4),
+            ("tracked_state/context.rs .put(", 1),
+            ("tracked_state/storage.rs .put(", 1),
+        ]
+        .into_iter()
+        .map(|(site, count)| (site.to_string(), count))
+        .collect();
+
+        assert_eq!(
+            found, expected,
+            "the set of places that write a commit record changed. If you added \
+             a writer, the persisted-path-index design's single-choke-point \
+             premise needs re-deriving -- see this test's doc comment -- and any \
+             index must be maintained at the new site too, or refuse coverage. \
+             If you only moved code, update the expectation."
+        );
+    }
 }


### PR DESCRIPTION
**Standalone — depends on nothing, stacked on nothing.** Based directly on `claude-7-optimizations`.

## What it defends

A commit record entering storage is the moment a file name becomes part of history. Any derived
index over those names — the persisted path index scoped for `lix_file_history(...) WHERE path = ?`
is the live proposal — can be maintained at one site only **if there is one site**.

That premise was established by compiler enumeration while scoping the index. Without a guard it
decays into a comment, and the failure it hides is the silent one: an index that misses names
**under-approximates**, and a history query then drops rows rather than erroring.

## What the set is, and which entries are production

Established against the **non-test** build (`cargo check -p lix --all-features`):

| site | kind |
|---|---|
| `changelog/context.rs` ×2 (`.stage(`) | **Production. The choke point.** `stage_transaction_append` and `stage_append_records`; the only production caller of the former is `transaction/commit.rs` |
| `changelog/gc.rs` (`.delete(`) | Production. Reclamation only — removes records, introduces no name |
| `changelog/gc.rs` (`.delete_batch(`), `commit_graph/walker.rs` ×6, `tracked_state/context.rs`, `tracked_state/storage.rs` | Test fixtures — all absent from the non-test build |

The scan cannot tell test from production. That is deliberate: a new site of **either** kind should
stop a human and make them classify it.

**Head movement is deliberately not in this set.** `MergeOutcome::FastForward` and branch-ref
creation make whole ancestries reachable without staging any descriptor row — which is why an index
keyed to *reachability* would need hooks in several places and one keyed to commit *ingestion* does
not. Pinning this set is what makes the ingestion-keyed design checkable.

## The technique, and the trap in it

The expectation was derived by **breaking the *type*** of the space constant while leaving its name
resolvable, so imports still resolve and every *use* fails type-check.

**Do not use `#[cfg(any())]` for this.** The constant then fails to resolve, compilation stops at
`E0432 unresolved import`, downstream users are never type-checked, and the enumeration silently
truncates — **measured here at 4 sites instead of 27.** A truncated enumeration is worse than none
because it looks complete. That qualification is in the test's doc comment, because it is the part
that makes the technique safe to reuse.

## Verification

**By inversion: adding one more commit-record write site fails this test.** (Duplicated an existing
`writes.delete(COMMIT_SPACE, …)` in `commit_graph/walker.rs`; the guard trips on the count change,
then reverted.)

## What it cannot see, stated in the test itself

A write that reaches the space **without naming the constant** — through an alias, or a space value
computed at runtime. Nothing does that today: `server_protocol` writes no storage at all (no
`StorageWriteSet`, no `.put(`, no `commit_write_set`; its only space reference is a numeric id in a
read-fencing test harness). **The scan is a convention where the type-break is a mechanism**, and the
doc comment says to re-run the type-break when the answer matters.

A compiler-enforced version was considered and rejected as out of scope here: `put`, `delete` and
`delete_batch` all take `S: IntoStorageSpace`, so restricting one space to one writer means splitting
read and write capability across the whole storage adapter — a broad refactor touching every space,
not a small standalone guard.

## Gate

```
git rev-parse HEAD          b067088fc304e3e46896aa66411304fda11cfe69 (before and after)
git status --porcelain      empty
CI_SCOPE_CONFIRMED_AT       0b97f3c45
cargo clippy --profile test --workspace --all-targets --all-features -- -D warnings   exit 0
cargo test --profile test --workspace --exclude lix_e2e --all-features --no-fail-fast exit 0
cargo test --profile test -p lix_e2e --features \
  sdk-tests,plugin-tests,server-protocol,storage-benches,slatedb,root-replay-trace \
  --no-fail-fast                                                                      exit 0

EXECUTED_TARGETS  test1=3431 passed across 38 targets   test2=172 passed across 27 targets
```

3431 reconciles as the 3430 baseline plus this one test.

## Format

Test-only. No format change, no persisted field, no production code touched.
