### PR TITLE
fix(gc): retain the commit delta of every graph-reachable commit (entity history destruction)

### DIFF
--- a/packages/lix/src/gc.rs
+++ b/packages/lix/src/gc.rs
@@ -837,10 +837,24 @@ async fn load_authenticated_serving_dependency_closure<S>(
     chronology_roots: BTreeSet<CommitId>,
     serving_dependencies: BTreeSet<CommitId>,
     history_dependencies: BTreeSet<CommitId>,
-    // Commits reachable from the roots through canonical parent links. This
-    // retains the *semantic* plane only: the public history surfaces walk the
-    // commit graph, so their projections are load-bearing, while their physical
-    // delta segments are exactly what compaction is supposed to free.
+    // Commits reachable from the roots through canonical parent links.
+    //
+    // These retain **both** planes. It is tempting to retain only the semantic
+    // projection here and let the physical delta segments go, on the grounds
+    // that compaction is supposed to free them — that is what this code did,
+    // and it silently truncated entity history. An entity `_history()` row is
+    // served out of the per-commit delta, not out of the projection:
+    // `CommitGraphContext::change_history_from_commit` walks the graph and then
+    // calls `load_member_changes`, which reads
+    // `load_commit_delta_members_with_payloads_for_schemas`. That function
+    // returns an empty member list for a commit whose replay state is gone, so
+    // a commit whose delta was retired is indistinguishable from a commit that
+    // changed nothing, and the history rows disappear without an error.
+    //
+    // What compaction frees is the *unreachable* interior: an intra-interval
+    // commit stops being on the canonical parent chain once the checkpoint
+    // supersedes it, so it never enters this set and is still retired. The set
+    // retained here is the checkpoint chain, which compaction shortens.
     graph_reachable: BTreeSet<CommitId>,
 ) -> Result<AuthenticatedServingDependencyClosure, LixError>
 where
@@ -864,6 +878,7 @@ where
     physical_dependencies.extend(history_dependencies.iter().copied());
     let mut semantic_dependencies = serving_dependencies;
     semantic_dependencies.extend(history_dependencies.iter().copied());
+    physical_dependencies.extend(graph_reachable.iter().copied());
     semantic_dependencies.extend(graph_reachable);
     let mut cas_logical_dependencies = history_dependencies;
     let mut manifests = BTreeMap::new();
@@ -1086,8 +1101,12 @@ where
 /// links.
 ///
 /// This is the reachability the public history surfaces actually read: a
-/// `_history()` query walks the commit graph, so a projection on that chain is
-/// load-bearing no matter how far below the serving checkpoint it sits. The
+/// `_history()` query walks the commit graph, so a commit on that chain is
+/// load-bearing no matter how far below the serving checkpoint it sits — and
+/// load-bearing in **both** planes, because an entity history row is served out
+/// of the commit delta while only the commit metadata comes from the
+/// projection. Retaining the projection alone leaves the walk finding the
+/// commit and reading zero members from it, which is silent truncation. The
 /// ledger expressed the same retention by pinning every checkpoint commit it
 /// had ever seen, forever, in a row it could never consume. Walking refs states
 /// it directly, costs one commit-record read per reachable commit, and shrinks

--- a/packages/lix/src/gc.rs
+++ b/packages/lix/src/gc.rs
@@ -641,6 +641,10 @@ pub(crate) struct RepositoryGcPlan {
 
 #[derive(Clone, Debug, Default, Eq, PartialEq)]
 pub(crate) struct RepositoryGcProfile {
+    /// Graph-reachable commits this sweep found with no physical manifest --
+    /// history a sweep predating the history-retention fix already reclaimed.
+    /// Reported so the condition is observable; never a retention input.
+    pub(crate) history_manifests_missing: u64,
     pub(crate) root_discovery_us: u64,
     pub(crate) changelog_us: u64,
     pub(crate) tracked_root_stage_us: u64,
@@ -830,6 +834,10 @@ struct AuthenticatedServingDependencyClosure {
     /// payload_refs_digest` pairing exists, so the walk has to carry it out.
     /// Rediscovering it later would mean re-reading the scoped-range trees.
     native_part_refs_digests: BTreeSet<[u8; 32]>,
+    /// Graph-reachable commits with no physical manifest, i.e. commits whose
+    /// history delta a pre-fix sweep already reclaimed. Counted so the
+    /// condition is observable; never a retention input.
+    history_manifests_missing: u64,
 }
 
 async fn load_authenticated_serving_dependency_closure<S>(
@@ -878,7 +886,47 @@ where
     physical_dependencies.extend(history_dependencies.iter().copied());
     let mut semantic_dependencies = serving_dependencies;
     semantic_dependencies.extend(history_dependencies.iter().copied());
-    physical_dependencies.extend(graph_reachable.iter().copied());
+    // Retain the delta of every graph-reachable commit that still has one.
+    //
+    // Tolerating absence is deliberate, and it is scoped to exactly this set.
+    // A repository swept by the code that shipped before this fix has commits
+    // that are graph-reachable and have no manifest, because that sweep deleted
+    // it; those manifests are gone and cannot be recomputed. Demanding one here
+    // would abort every future sweep on such a repository -- silently, because
+    // `collect_checkpoint_garbage_best_effort` swallows the error, so
+    // collection would simply stop forever while writes kept succeeding.
+    //
+    // Nothing else is relaxed. Serving dependencies, selected-source owners and
+    // physical authorities keep their existing hard demand, so a manifest
+    // missing from any of those classes still fails the sweep exactly as it
+    // does today. Within this set we *cannot* tell a commit swept before the
+    // fix from a manifest missing for a reason that should not happen -- after
+    // this fix no graph-reachable commit is ever swept, so absence is either
+    // legacy or corruption and nothing at hand separates them. Both are
+    // tolerated and both are counted, so the condition is observable rather
+    // than silent.
+    let graph_reachable_ids = graph_reachable.iter().copied().collect::<Vec<_>>();
+    let graph_reachable_manifests =
+        crate::tracked_state::load_commit_state_manifests(store, &graph_reachable_ids).await?;
+    let mut history_manifests_missing = 0u64;
+    for (commit_id, manifest) in graph_reachable_ids
+        .into_iter()
+        .zip(graph_reachable_manifests)
+    {
+        if manifest.is_some() {
+            physical_dependencies.insert(commit_id);
+        } else {
+            history_manifests_missing += 1;
+        }
+    }
+    if history_manifests_missing > 0 {
+        tracing::warn!(
+            history_manifests_missing,
+            "repository contains commits whose history delta was reclaimed by a garbage \
+             collection sweep predating the history-retention fix; their entity history is \
+             permanently truncated and cannot be recovered"
+        );
+    }
     semantic_dependencies.extend(graph_reachable);
     let mut cas_logical_dependencies = history_dependencies;
     let mut manifests = BTreeMap::new();
@@ -1063,6 +1111,7 @@ where
         scoped_nodes,
         native_parts,
         native_part_refs_digests,
+        history_manifests_missing,
     })
 }
 
@@ -1371,6 +1420,7 @@ where
         scoped_nodes: active_scoped_nodes,
         native_parts: active_current_parts,
         native_part_refs_digests: active_current_part_refs_digests,
+        history_manifests_missing,
     } = load_authenticated_repository_retention(&store, &controls).await?;
 
     // Retirement candidates are derived here, not read from a ledger.
@@ -1522,6 +1572,7 @@ where
             binary_cas,
         },
         profile: RepositoryGcProfile {
+            history_manifests_missing,
             root_discovery_us: elapsed_micros(started),
             changelog_us: 0,
             tracked_root_stage_us: 0,
@@ -1596,6 +1647,9 @@ where
             binary_cas: Default::default(),
         },
         profile: RepositoryGcProfile {
+            // The recovery-only rebuild path rediscovers liveness by scanning;
+            // it does not consult the graph-reachable manifest set at all.
+            history_manifests_missing: 0,
             root_discovery_us,
             changelog_us,
             tracked_root_stage_us,
@@ -2424,6 +2478,87 @@ mod tests {
         );
         assert!(reachability.serving_dependencies.is_empty());
         assert!(!reachability.chronology_roots.contains(&tracked_generation));
+    }
+
+    /// Builds `old_root -> active` with the head at `active`, optionally
+    /// omitting `old_root`'s physical manifest to model a repository already
+    /// swept by the code that shipped before the history-retention fix.
+    async fn history_retention_fixture(with_old_manifest: bool) -> super::RepositoryGcPlan {
+        let storage = StorageAdapter::new(Memory::new());
+        let timestamp =
+            LixTimestamp::expect_parse("history retention timestamp", "2026-01-01T00:00:00Z");
+        let old_root = replay_commit_record("history-retained-old", 0, None, timestamp);
+        let active = replay_commit_record(
+            "history-retained-active",
+            1,
+            Some(old_root.commit_id),
+            timestamp,
+        );
+        let mut old_manifest =
+            test_commit_state_manifest(&old_root, CommitStateMutationInventory::default());
+        old_manifest.replay_debt = CommitStateReplayDebt::default();
+        old_manifest.snapshot_root = Some(Box::new(test_snapshot_root(old_root.commit_id)));
+        let mut active_manifest =
+            test_commit_state_manifest(&active, CommitStateMutationInventory::default());
+        active_manifest.replay_debt = CommitStateReplayDebt::default();
+        active_manifest.snapshot_root = Some(Box::new(test_snapshot_root(active.commit_id)));
+
+        let control_ref = ChangeId::for_test_label("history-retained-control");
+        let active_control = replay_branch_control(active.commit_id, control_ref, timestamp);
+        let mut writes = storage.new_write_set();
+        stage_branch_head_control(&mut writes, "main", active_control)
+            .expect("history retention control should stage");
+        let manifests = if with_old_manifest {
+            vec![old_manifest, active_manifest]
+        } else {
+            vec![active_manifest]
+        };
+        persist_replay_closure_fixture(
+            &storage,
+            writes,
+            &[old_root.clone(), active.clone()],
+            &manifests,
+        )
+        .await;
+
+        let plan = run_ordinary_repository_gc(&storage).await;
+        assert!(
+            !plan.sweep.tracked_commit_roots.contains(&old_root.commit_id),
+            "an ancestor of the live head is what _history() reads; it must not be retired"
+        );
+        plan
+    }
+
+    /// The fix: a commit reachable from the head through parent links keeps its
+    /// physical delta, because that delta is what an entity `_history()` row is
+    /// served out of.
+    #[tokio::test]
+    async fn ordinary_gc_retains_the_delta_of_a_graph_reachable_commit() {
+        let plan = history_retention_fixture(true).await;
+        assert_eq!(
+            plan.profile.history_manifests_missing, 0,
+            "a repository with intact history reports nothing missing"
+        );
+    }
+
+    /// The tolerance, and its inversion against the test above: the same
+    /// repository with that manifest already reclaimed by a pre-fix sweep must
+    /// still complete a sweep, and must say so rather than tolerating silently.
+    ///
+    /// Demanding the manifest here would abort every future sweep on such a
+    /// repository, and `collect_checkpoint_garbage_best_effort` swallows the
+    /// error, so collection would stop permanently while writes kept
+    /// succeeding. Worse, `checkpoint_gc_due` derives its age limit from
+    /// `last_gc_sequence`, which only a *successful* sweep advances, so the
+    /// due-predicate would latch: every later checkpoint would pay for a
+    /// doomed full-repository sweep, forever.
+    #[tokio::test]
+    async fn ordinary_gc_tolerates_and_counts_history_reclaimed_before_the_fix() {
+        let plan = history_retention_fixture(false).await;
+        assert_eq!(
+            plan.profile.history_manifests_missing, 1,
+            "the commit whose delta a pre-fix sweep reclaimed must be counted, not swallowed"
+        );
     }
 
     #[tokio::test]

--- a/packages/lix/src/gc.rs
+++ b/packages/lix/src/gc.rs
@@ -2568,13 +2568,35 @@ mod tests {
             "rootless serving generation timestamp",
             "2026-01-01T00:00:00Z",
         );
-        let old_root = replay_commit_record("rootless-serving-old", 0, None, timestamp);
+        // The checkpoint parents onto a fresh interval base rather than onto
+        // `old_root`, which is what compaction actually produces: `old_root` is an
+        // interior commit of the interval the checkpoint closes, so the
+        // checkpoint supersedes it and it leaves the first-parent chain.
+        //
+        // This fixture used to parent the checkpoint directly onto `old_root` --
+        // a raw parent chain no real checkpoint ever produces. That kept
+        // `old_root` reachable from the live head forever, and a commit reachable
+        // from the head now keeps its delta because that delta is what an
+        // entity `_history()` row is served out of. The release under test here
+        // is a rootless tracked serving generation, not graph reachability, so the fixture models the
+        // compaction instead of contradicting it.
+        let base = replay_commit_record("rootless-serving-base", 0, None, timestamp);
+        let old_root = replay_commit_record(
+            "rootless-serving-old",
+            1,
+            Some(base.commit_id),
+            timestamp,
+        );
         let active = replay_commit_record(
             "rootless-serving-active",
             1,
-            Some(old_root.commit_id),
+            Some(base.commit_id),
             timestamp,
         );
+        let mut base_manifest =
+            test_commit_state_manifest(&base, CommitStateMutationInventory::default());
+        base_manifest.replay_debt = CommitStateReplayDebt::default();
+        base_manifest.snapshot_root = Some(Box::new(test_snapshot_root(base.commit_id)));
         let mut old_manifest =
             test_commit_state_manifest(&old_root, CommitStateMutationInventory::default());
         old_manifest.replay_debt = CommitStateReplayDebt::default();
@@ -2596,8 +2618,8 @@ mod tests {
         persist_replay_closure_fixture(
             &storage,
             writes,
-            &[old_root.clone(), active.clone()],
-            &[old_manifest, active_manifest],
+            &[base.clone(), old_root.clone(), active.clone()],
+            &[base_manifest, old_manifest, active_manifest],
         )
         .await;
 
@@ -2624,6 +2646,14 @@ mod tests {
                 .sweep
                 .tracked_commit_roots
                 .contains(&serving_generation)
+        );
+        // The interval base is still on the head's first-parent chain, so it is
+        // what `_history()` reads and must survive the same sweep. Without this
+        // the fixture would pass just as well against a collector that retires
+        // the whole chain.
+        assert!(
+            !plan.sweep.tracked_commit_roots.contains(&base.commit_id),
+            "a commit reachable from the live head owns entity history and must not be retired"
         );
     }
 
@@ -3030,17 +3060,46 @@ mod tests {
         let storage = StorageAdapter::new(Memory::new());
         let timestamp =
             LixTimestamp::expect_parse("selected owner timestamp", "2026-01-01T00:00:00Z");
-        let owner = replay_commit_record("selected-owner-source", 0, None, timestamp);
+        // The checkpoint parents onto a fresh interval base rather than onto
+        // `owner`, which is what compaction actually produces: `owner` is an
+        // interior commit of the interval the checkpoint closes, so the
+        // checkpoint supersedes it and it leaves the first-parent chain.
+        //
+        // This fixture used to parent the checkpoint directly onto `owner` --
+        // a raw parent chain no real checkpoint ever produces. That kept
+        // `owner` reachable from the live head forever, and a commit reachable
+        // from the head now keeps its delta because that delta is what an
+        // entity `_history()` row is served out of. The release under test here
+        // is the finite selected-source owner pin, not graph reachability, so the fixture models the
+        // compaction instead of contradicting it.
+        let base = replay_commit_record("selected-owner-base", 0, None, timestamp);
+        let owner = replay_commit_record(
+            "selected-owner-source",
+            1,
+            Some(base.commit_id),
+            timestamp,
+        );
         let checkpoint = replay_commit_record(
             "selected-owner-checkpoint",
             1,
-            Some(owner.commit_id),
+            Some(base.commit_id),
             timestamp,
         );
+        let mut base_manifest =
+            test_commit_state_manifest(&base, CommitStateMutationInventory::default());
+        base_manifest.replay_debt = CommitStateReplayDebt::default();
+        base_manifest.snapshot_root = Some(Box::new(test_snapshot_root(base.commit_id)));
+        // `released` parents onto the interval base too, because the commit
+        // holding the selection is itself interior. A commit that is still
+        // graph-reachable keeps its delta, and that delta is what names the
+        // selected source -- so while the selecting commit is on the chain the
+        // owner is correctly pinned by it, and the release under test could
+        // never be reached. Superseding the selector is the event that
+        // releases the owner, which is exactly what this test is named for.
         let released = replay_commit_record(
             "selected-owner-released",
-            2,
-            Some(checkpoint.commit_id),
+            1,
+            Some(base.commit_id),
             timestamp,
         );
         let selected_change = packed_change(
@@ -3091,8 +3150,13 @@ mod tests {
         persist_replay_closure_fixture(
             &storage,
             writes,
-            &[owner.clone(), checkpoint.clone(), released.clone()],
-            &[owner_manifest, checkpoint_manifest],
+            &[
+                base.clone(),
+                owner.clone(),
+                checkpoint.clone(),
+                released.clone(),
+            ],
+            &[base_manifest, owner_manifest, checkpoint_manifest],
         )
         .await;
 
@@ -3152,6 +3216,10 @@ mod tests {
                 .tracked_commit_roots
                 .contains(&owner.commit_id)
         );
+        assert!(
+            !released_plan.sweep.tracked_commit_roots.contains(&base.commit_id),
+            "the interval base stays on the head's first-parent chain and owns entity history"
+        );
         let read = storage
             .begin_read(StorageReadOptions::default())
             .await
@@ -3189,13 +3257,35 @@ mod tests {
         let storage = StorageAdapter::new(Memory::new());
         let timestamp =
             LixTimestamp::expect_parse("scoped owner timestamp", "2026-01-01T00:00:00Z");
-        let owner = replay_commit_record("scoped-part-owner", 0, None, timestamp);
+        // The checkpoint parents onto a fresh interval base rather than onto
+        // `owner`, which is what compaction actually produces: `owner` is an
+        // interior commit of the interval the checkpoint closes, so the
+        // checkpoint supersedes it and it leaves the first-parent chain.
+        //
+        // This fixture used to parent the checkpoint directly onto `owner` --
+        // a raw parent chain no real checkpoint ever produces. That kept
+        // `owner` reachable from the live head forever, and a commit reachable
+        // from the head now keeps its delta because that delta is what an
+        // entity `_history()` row is served out of. The release under test here
+        // is the scoped-descriptor owner pin, not graph reachability, so the fixture models the
+        // compaction instead of contradicting it.
+        let base = replay_commit_record("scoped-part-base", 0, None, timestamp);
+        let owner = replay_commit_record(
+            "scoped-part-owner",
+            1,
+            Some(base.commit_id),
+            timestamp,
+        );
         let checkpoint = replay_commit_record(
             "scoped-part-checkpoint",
             1,
-            Some(owner.commit_id),
+            Some(base.commit_id),
             timestamp,
         );
+        let mut base_manifest =
+            test_commit_state_manifest(&base, CommitStateMutationInventory::default());
+        base_manifest.replay_debt = CommitStateReplayDebt::default();
+        base_manifest.snapshot_root = Some(Box::new(test_snapshot_root(base.commit_id)));
         let released = replay_commit_record(
             "scoped-part-released",
             2,
@@ -3285,8 +3375,13 @@ mod tests {
         persist_replay_closure_fixture(
             &storage,
             writes,
-            &[owner.clone(), checkpoint.clone(), released.clone()],
-            &[owner_manifest, checkpoint_manifest],
+            &[
+                base.clone(),
+                owner.clone(),
+                checkpoint.clone(),
+                released.clone(),
+            ],
+            &[base_manifest, owner_manifest, checkpoint_manifest],
         )
         .await;
 
@@ -3320,6 +3415,10 @@ mod tests {
                 .tracked_commit_roots
                 .contains(&owner.commit_id)
         );
+        assert!(
+            !released_plan.sweep.tracked_commit_roots.contains(&base.commit_id),
+            "the interval base stays on the head's first-parent chain and owns entity history"
+        );
         let read = storage
             .begin_read(StorageReadOptions::default())
             .await
@@ -3337,9 +3436,26 @@ mod tests {
         let storage = StorageAdapter::new(Memory::new());
         let timestamp =
             LixTimestamp::expect_parse("native row owner timestamp", "2026-01-01T00:00:00Z");
-        let owner = replay_commit_record("native-row-owner", 0, None, timestamp);
+        // The checkpoint parents onto a fresh interval base rather than onto
+        // `owner`, which is what compaction actually produces: `owner` is an
+        // interior commit of the interval the checkpoint closes, so the
+        // checkpoint supersedes it and it leaves the first-parent chain.
+        //
+        // This fixture used to parent the checkpoint directly onto `owner` --
+        // a raw parent chain no real checkpoint ever produces. That kept
+        // `owner` reachable from the live head forever, and a commit reachable
+        // from the head now keeps its delta because that delta is what an
+        // entity `_history()` row is served out of. The release under test here
+        // is the native-row owner pin, not graph reachability, so the fixture models the
+        // compaction instead of contradicting it.
+        let base = replay_commit_record("native-row-base", 0, None, timestamp);
+        let owner = replay_commit_record("native-row-owner", 1, Some(base.commit_id), timestamp);
         let checkpoint =
-            replay_commit_record("native-row-checkpoint", 1, Some(owner.commit_id), timestamp);
+            replay_commit_record("native-row-checkpoint", 1, Some(base.commit_id), timestamp);
+        let mut base_manifest =
+            test_commit_state_manifest(&base, CommitStateMutationInventory::default());
+        base_manifest.replay_debt = CommitStateReplayDebt::default();
+        base_manifest.snapshot_root = Some(Box::new(test_snapshot_root(base.commit_id)));
         let released = replay_commit_record(
             "native-row-released",
             2,
@@ -3487,8 +3603,13 @@ mod tests {
         persist_replay_closure_fixture(
             &storage,
             writes,
-            &[owner.clone(), checkpoint.clone(), released.clone()],
-            &[owner_manifest, checkpoint_manifest],
+            &[
+                base.clone(),
+                owner.clone(),
+                checkpoint.clone(),
+                released.clone(),
+            ],
+            &[base_manifest, owner_manifest, checkpoint_manifest],
         )
         .await;
 
@@ -3601,6 +3722,10 @@ mod tests {
                 .sweep
                 .tracked_commit_roots
                 .contains(&owner.commit_id)
+        );
+        assert!(
+            !released_plan.sweep.tracked_commit_roots.contains(&base.commit_id),
+            "the interval base stays on the head's first-parent chain and owns entity history"
         );
         let read = storage
             .begin_read(StorageReadOptions::default())

--- a/packages/lix/src/session/gc.rs
+++ b/packages/lix/src/session/gc.rs
@@ -71,6 +71,7 @@ where
                     swept_commits = plan.changelog.sweep.commits.len(),
                     swept_changes = plan.changelog.sweep.changes.len(),
                     swept_tracked_roots = plan.sweep.tracked_commit_roots.len(),
+                    history_manifests_missing = plan.profile.history_manifests_missing,
                     root_discovery_us = plan.profile.root_discovery_us,
                     changelog_us = plan.profile.changelog_us,
                     tracked_root_stage_us = plan.profile.tracked_root_stage_us,

--- a/packages/lix/src/session/gc.rs
+++ b/packages/lix/src/session/gc.rs
@@ -89,3 +89,260 @@ where
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+    use tokio::time::{Duration, Instant};
+
+    use super::checkpoint_gc_due;
+    use crate::changelog::CommitId;
+    use crate::engine::Engine;
+    use crate::gc::{load_checkpoint_gc_state, stage_repository_gc_with_preconditions};
+    use crate::session::SessionContext;
+    use crate::storage::Memory;
+    use crate::storage_adapter::{SharedStorageAdapterRead, StorageReadOptions, StorageWriteOptions};
+    use crate::{LixError, Value};
+
+    /// Checkpoints a fresh repository must accumulate before a sweep is due.
+    /// Mirrors `CHECKPOINT_GC_MIN_AGE` in `session::checkpoint`, which is
+    /// private to that module.
+    const CHECKPOINT_GC_MIN_AGE: usize = 64;
+
+    /// Checkpointed rounds of writes built before the repository is made
+    /// legacy. Each round after the first contributes one interior commit the
+    /// sweep is required to reclaim.
+    const ROUNDS: usize = 6;
+    const WRITES_PER_ROUND: usize = 3;
+
+    async fn open() -> (Engine<Memory>, SessionContext<Memory>) {
+        let storage = Memory::new();
+        Engine::initialize(storage.clone())
+            .await
+            .expect("storage initializes");
+        let engine = Engine::new(storage).await.expect("engine opens");
+        let session = engine.open_session().await.expect("session opens");
+        (engine, session)
+    }
+
+    async fn head(engine: &Engine<Memory>, branch_id: &str) -> String {
+        engine
+            .load_branch_head_commit_id(branch_id)
+            .await
+            .expect("branch head loads")
+            .expect("branch head exists")
+    }
+
+    /// Which of `commit_ids` the changelog still serves.
+    async fn present(session: &SessionContext<Memory>, commit_ids: &[String]) -> Vec<String> {
+        let mut present = Vec::new();
+        for commit_id in commit_ids {
+            let result = session
+                .execute(
+                    "SELECT id FROM lix_commit WHERE id = $1",
+                    &[Value::Text(commit_id.clone())],
+                )
+                .await
+                .expect("commit existence query succeeds");
+            if !result.is_empty() {
+                present.push(commit_id.clone());
+            }
+        }
+        present
+    }
+
+    /// Deletes one commit's physical delta the way the sweep that shipped
+    /// before the history-retention fix did, leaving the commit record itself
+    /// in place. This is `pub(crate)` on purpose and stays that way: a
+    /// publicly reachable way to delete a manifest is a footgun that would
+    /// outlive the fixture it was added for, so this test lives in-crate
+    /// rather than in the integration suite.
+    async fn reclaim_history_delta_like_a_pre_fix_sweep(
+        session: &SessionContext<Memory>,
+        commit_id: CommitId,
+    ) -> Result<(), LixError> {
+        let read = session
+            .storage
+            .begin_read(StorageReadOptions::default())
+            .await?;
+        let manifest = crate::tracked_state::load_commit_state_manifest(&read, commit_id)
+            .await?
+            .expect("a commit on the head's first-parent chain still owns its physical delta");
+        let mut writes = session.storage.new_write_set();
+        crate::tracked_state::stage_delete_commit_state_manifest_for_gc(
+            &read,
+            &mut writes,
+            commit_id,
+            &manifest,
+        )
+        .await?;
+        drop(read);
+        session
+            .storage
+            .commit_write_set(writes, StorageWriteOptions::default())
+            .await?;
+        Ok(())
+    }
+
+    /// A repository whose entity history a pre-fix sweep already took must
+    /// still *reclaim*, not merely still *plan*.
+    ///
+    /// # Why a plan is not enough
+    ///
+    /// A failed sweep latches. `checkpoint_gc_due` derives its age limit as
+    /// `CHECKPOINT_GC_MIN_AGE.max(last_gc_sequence)`, and only a successful
+    /// sweep advances `last_gc_sequence` — so once a sweep starts failing, the
+    /// limit freezes while `checkpoint_sequence` keeps climbing and the
+    /// predicate returns true at every later checkpoint, forever. Each of those
+    /// checkpoints then pays for a doomed full-repository sweep, and
+    /// [`SessionContext::collect_checkpoint_garbage_best_effort`] swallows the
+    /// error, so nothing surfaces. Reaching `mark_collected` is what un-latches
+    /// it.
+    ///
+    /// `mark_collected()` is the statement immediately after the staging `?`,
+    /// so a successful *plan* implies the un-latch is staged — but three
+    /// fallible steps follow it (`stage_checkpoint_gc_state`,
+    /// `prepare_write_set`, and the commit itself), so it does not imply the
+    /// un-latch is *persisted*. This test therefore asserts the reclaim and the
+    /// advanced sequence out of committed storage, not out of the plan.
+    ///
+    /// # What it asserts, and what it deliberately does not
+    ///
+    /// Interior commits — the intra-interval heads a round's checkpoint
+    /// supersedes — must be gone. Checkpoint commits must not: they stay on the
+    /// head's first-parent chain, and a test asserting they leave would encode
+    /// a false invariant and pass for the wrong reason.
+    #[tokio::test]
+    async fn checkpoint_gc_reclaims_on_a_repository_already_swept_before_the_history_fix() {
+        let (engine, session) = open().await;
+        let branch_id = session.branch.get().expect("session branch resolves");
+
+        // Interior commits: the head after the first write of every round
+        // after the first. The round's checkpoint supersedes each one, it
+        // leaves the first-parent chain, and the collector is entitled to it.
+        // Round 0's is deliberately not recorded — it is the branch's oldest
+        // interval anchor and the collector keeps it, so requiring its removal
+        // would fail for a reason unrelated to reclaim.
+        let mut interior_commits = Vec::new();
+        let mut checkpoints = Vec::new();
+        for round in 0..ROUNDS {
+            for write in 0..WRITES_PER_ROUND {
+                session
+                    .execute(
+                        "INSERT INTO lix_key_value (key, value) VALUES ($1, $2) \
+                         ON CONFLICT (key) DO UPDATE SET value = excluded.value",
+                        &[
+                            Value::Text(format!("gc-legacy-k{write}")),
+                            Value::Json(json!({ "round": round, "write": write }).into()),
+                        ],
+                    )
+                    .await
+                    .expect("write commits");
+                if write == 0 && round > 0 {
+                    interior_commits.push(head(&engine, &branch_id).await);
+                }
+            }
+            checkpoints.push(
+                session
+                    .create_checkpoint()
+                    .await
+                    .expect("round checkpoint succeeds")
+                    .commit_id,
+            );
+        }
+        assert_eq!(interior_commits.len(), ROUNDS - 1);
+
+        // Make this a legacy repository: take the physical delta of a commit
+        // that is still on the head's first-parent chain, which is exactly
+        // what the pre-fix sweep did and what cannot be recomputed.
+        let legacy_commit_id = checkpoints[1].clone();
+        let legacy = CommitId::parse_lix(&legacy_commit_id, "legacy checkpoint commit id")
+            .expect("checkpoint commit id parses");
+        reclaim_history_delta_like_a_pre_fix_sweep(&session, legacy)
+            .await
+            .expect("the pre-fix reclaim stages and commits");
+
+        // Cross the collection interval.
+        for _ in 0..CHECKPOINT_GC_MIN_AGE {
+            session
+                .create_checkpoint()
+                .await
+                .expect("padding checkpoint succeeds");
+        }
+
+        // `create_checkpoint` spawns the sweep, so drive one here rather than
+        // racing it; an explicit call is a no-op once the debt is clear, so
+        // whichever runs first, the assertions below read the same committed
+        // outcome. Without the tolerance this call is what fails, loudly:
+        // the sweep hard-errors on the missing manifest.
+        let deadline = Instant::now() + Duration::from_secs(120);
+        loop {
+            session
+                .collect_checkpoint_garbage()
+                .await
+                .expect("a sweep must not fail on a repository swept before the fix");
+            let remaining = present(&session, &interior_commits).await;
+            if remaining.is_empty() {
+                break;
+            }
+            assert!(
+                Instant::now() < deadline,
+                "checkpoint GC did not reclaim the interior commits {remaining:?}; a repository \
+                 whose history a pre-fix sweep already took must still collect"
+            );
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        }
+
+        // The un-latch, read back out of committed storage rather than out of
+        // the plan.
+        let read = SharedStorageAdapterRead::new(
+            session
+                .storage
+                .begin_read(StorageReadOptions::default())
+                .await
+                .expect("gc state read opens"),
+        );
+        let state = load_checkpoint_gc_state(&read)
+            .await
+            .expect("checkpoint gc state loads");
+        drop(read);
+        assert!(
+            state.last_gc_sequence > 0,
+            "a sweep that reclaimed must have persisted `mark_collected`; a staged-but-unpersisted \
+             un-latch leaves every later checkpoint paying for a doomed sweep"
+        );
+        assert!(
+            !checkpoint_gc_due(state).expect("due predicate evaluates"),
+            "collection debt must be cleared, not re-armed at every checkpoint"
+        );
+
+        // The tolerance is scoped, and this is the half that says so: the
+        // commit whose delta is gone keeps its place on the chain, and every
+        // checkpoint commit does too. Only the interior commits left.
+        assert_eq!(
+            present(&session, &checkpoints).await,
+            checkpoints,
+            "a checkpoint commit stays on the head's first-parent chain across a sweep"
+        );
+
+        // And the sweep that ran was the tolerant one. Planning the same
+        // repository again still finds the reclaimed delta and counts it,
+        // rather than demanding it.
+        let read = SharedStorageAdapterRead::new(
+            session
+                .storage
+                .begin_read(StorageReadOptions::default())
+                .await
+                .expect("tolerance plan read opens"),
+        );
+        let mut writes = session.storage.new_write_set();
+        let mut preconditions = Vec::new();
+        let plan = stage_repository_gc_with_preconditions(read, &mut writes, &mut preconditions)
+            .await
+            .expect("a legacy repository must still plan");
+        assert!(
+            plan.profile.history_manifests_missing >= 1,
+            "the delta this test reclaimed by hand must be counted as tolerated, not swallowed"
+        );
+    }
+}

--- a/packages/lix/src/tracked_state/mod.rs
+++ b/packages/lix/src/tracked_state/mod.rs
@@ -102,8 +102,18 @@ pub(crate) use storage::{
 pub(crate) use storage::{
     RetainedPhysicalState, collect_current_state_part_json_refs,
     collect_local_commit_delta_json_refs, load_native_current_state_part_owners,
-    stage_delete_commit_state_manifest_for_gc, stage_retire_commit_physical_state,
+    stage_retire_commit_physical_state,
 };
+// Manufacturing a repository swept by the code that shipped before the
+// history-retention fix is the only caller: `session::gc` needs to delete one
+// commit's physical delta the way that sweep did. Deliberately test-gated
+// rather than exported outright -- production reclaim reaches this through
+// `stage_retire_commit_physical_state`, and a second, unconditional route to
+// deleting a manifest is a footgun that would outlive the fixture it was added
+// for. This attribute belongs to the `use` on the next line and nothing else;
+// do not insert between them.
+#[cfg(test)]
+pub(crate) use storage::stage_delete_commit_state_manifest_for_gc;
 #[cfg(feature = "storage-benches")]
 pub(crate) use storage::decode_change_locator;
 // The storage-space constants are what the space registry

--- a/packages/lix/src/tracked_state/mod.rs
+++ b/packages/lix/src/tracked_state/mod.rs
@@ -102,7 +102,7 @@ pub(crate) use storage::{
 pub(crate) use storage::{
     RetainedPhysicalState, collect_current_state_part_json_refs,
     collect_local_commit_delta_json_refs, load_native_current_state_part_owners,
-    stage_retire_commit_physical_state,
+    stage_delete_commit_state_manifest_for_gc, stage_retire_commit_physical_state,
 };
 #[cfg(feature = "storage-benches")]
 pub(crate) use storage::decode_change_locator;

--- a/packages/lix/tests/integration/version_control_model_fuzz.rs
+++ b/packages/lix/tests/integration/version_control_model_fuzz.rs
@@ -46,12 +46,11 @@
 //! done   # every one of these must fail
 //! ```
 //!
-//! # Open finding
+//! # A defect this found
 //!
-//! [`assert_history_survived_gc`] documents a divergence this harness found on
-//! its first green run: a checkpoint GC sweep truncates entity history that
-//! `gc.rs` documents as load-bearing. `LIX_VC_MODEL_GC_HISTORY=strict` is the
-//! reproducer.
+//! On its first green run this harness found a checkpoint GC sweep truncating
+//! entity history that `gc.rs` documents as load-bearing. That is fixed;
+//! [`assert_history_survived_gc`] is now the guard, and asserts equality.
 
 use std::collections::BTreeMap;
 
@@ -763,42 +762,40 @@ async fn assert_history(session: &SimSession, prefix: &str, model: &BranchModel,
     assert_eq!(actual, expected, "{label}: history diverged from the model");
 }
 
-/// Asserts what a checkpoint GC sweep is allowed to do to observable history.
+/// Asserts that a checkpoint GC sweep does not change observable history.
 ///
-/// # The finding this encodes
+/// # The defect this now guards
 ///
-/// A sweep today truncates entity history: with six checkpointed rounds of
-/// writes followed by padding checkpoints, every key's history stays at six
-/// entries through 56 padding checkpoints and collapses to one at the padding
-/// checkpoint where the live commit count drops — that is, at the sweep. It is
-/// the sweep and not checkpoint compaction: compaction would truncate as
-/// checkpoints accumulate, and history is flat across all of them until the
-/// commit count falls.
+/// A sweep used to truncate entity history to the newest couple of
+/// checkpoints. `collect_ref_reachable_commit_ids` fed its result to the
+/// *semantic* retention only, so a graph-reachable commit kept its projection
+/// and lost its delta segments — and an entity history row is served out of the
+/// delta. `load_commit_delta_members_with_payloads_for_schemas` returns an
+/// empty member list for a commit whose replay state is gone, so the truncation
+/// raised no error: the swept commits read as commits that changed nothing.
+/// Current state was unaffected throughout, which is why nothing else caught
+/// it.
 ///
-/// `gc.rs::collect_ref_reachable_commit_ids` documents the opposite intent:
-/// *"a `_history()` query walks the commit graph, so a projection on that chain
-/// is load-bearing no matter how far below the serving checkpoint it sits."*
+/// Equality is the right assertion and not an over-strong one. A sweep frees
+/// the *unreachable* interior — the intra-interval commits the checkpoint
+/// superseded — and those never contributed a history entry, because the engine
+/// collapses an un-checkpointed interval into one commit. Nothing a sweep is
+/// entitled to collect is observable here, so any change at all is a defect.
 ///
-/// Until that is resolved — either as a bug fix or as a stated retention
-/// policy — this asserts the invariant that does hold and is still worth
-/// guarding: a sweep may drop the **oldest** history entries, but what remains
-/// must be an exact newest-first prefix of what was there before, and no key
-/// that still has state may lose its history entirely. That catches a sweep
-/// that returns wrong, reordered, or resurrected history, which is the failure
-/// mode a physical-layout break would produce.
-///
-/// `LIX_VC_MODEL_GC_HISTORY=strict` upgrades this to full equality, which is
-/// the reproducer for the finding above. It is not the default because the
-/// default must be a gate the tree can pass.
+/// `LIX_VC_MODEL_GC_HISTORY=prefix` weakens this back to the pre-fix invariant
+/// (what remains must be an exact newest-first prefix, and no key that still
+/// has state may lose its history entirely). That is retained as the inversion
+/// control: it is the assertion that passed while the defect was live, so a run
+/// under it must still pass, proving the strict form is what does the work.
 fn assert_history_survived_gc(
     before: &BTreeMap<String, Vec<Option<JsonValue>>>,
     after: &BTreeMap<String, Vec<Option<JsonValue>>>,
     label: &str,
 ) {
-    let strict = std::env::var("LIX_VC_MODEL_GC_HISTORY")
-        .map(|value| value.trim() == "strict")
+    let prefix_only = std::env::var("LIX_VC_MODEL_GC_HISTORY")
+        .map(|value| value.trim() == "prefix")
         .unwrap_or(false);
-    if strict {
+    if !prefix_only {
         assert_eq!(
             before, after,
             "{label}: checkpoint GC changed the observable history"

--- a/packages/lix/tests/integration/version_control_model_fuzz.rs
+++ b/packages/lix/tests/integration/version_control_model_fuzz.rs
@@ -40,7 +40,7 @@
 //! to [`InjectedFault::None`], so a normal run is unaffected.
 //!
 //! ```text
-//! for fault in state working_diff history merge reboot reclaim; do
+//! for fault in state working_diff history merge reboot reclaim gc_history; do
 //!   LIX_VC_MODEL_INJECT=$fault cargo test --profile test -p lix \
 //!     --test integration --all-features -- --test-threads=1 vc_model_
 //! done   # every one of these must fail
@@ -92,6 +92,8 @@ enum InjectedFault {
     Reboot,
     /// Assert the post-GC snapshot against a mutated expectation.
     Reclaim,
+    /// Mutate the pre-sweep history the post-sweep history is compared against.
+    GcHistory,
 }
 
 impl InjectedFault {
@@ -107,9 +109,11 @@ impl InjectedFault {
             "merge" => Self::Merge,
             "reboot" => Self::Reboot,
             "reclaim" => Self::Reclaim,
+            "gc_history" => Self::GcHistory,
             other => panic!(
                 "LIX_VC_MODEL_INJECT must be one of \
-                 none|state|working_diff|history|merge|reboot|reclaim, got {other:?}"
+                 none|state|working_diff|history|merge|reboot|reclaim|gc_history, \
+                 got {other:?}"
             ),
         }
     }
@@ -543,7 +547,7 @@ simulation_test!(
 
         assert_state(&main, prefix, &model.state, "before gc").await;
         assert_history(&main, prefix, &model, "before gc").await;
-        let history_before = read_history(&main, prefix).await;
+        let mut history_before = read_history(&main, prefix).await;
 
         // Cross the collection interval.
         for _ in 0..CHECKPOINT_GC_INTERVAL {
@@ -567,6 +571,12 @@ simulation_test!(
         // Current state must survive the sweep exactly. This is the strongest
         // reclaim property and it holds today.
         assert_state(&main, prefix, &model.state, "after gc").await;
+
+        if fault == InjectedFault::GcHistory {
+            if let Some((_, entries)) = history_before.iter_mut().next() {
+                entries.remove(0);
+            }
+        }
 
         let history_after = read_history(&main, prefix).await;
         assert_history_survived_gc(&history_before, &history_after, "after gc");
@@ -764,73 +774,50 @@ async fn assert_history(session: &SimSession, prefix: &str, model: &BranchModel,
 
 /// Asserts that a checkpoint GC sweep does not change observable history.
 ///
-/// # The defect this now guards
+/// # The defect this guards
 ///
-/// A sweep used to truncate entity history to the newest couple of
-/// checkpoints. `collect_ref_reachable_commit_ids` fed its result to the
-/// *semantic* retention only, so a graph-reachable commit kept its projection
-/// and lost its delta segments — and an entity history row is served out of the
-/// delta. `load_commit_delta_members_with_payloads_for_schemas` returns an
-/// empty member list for a commit whose replay state is gone, so the truncation
-/// raised no error: the swept commits read as commits that changed nothing.
-/// Current state was unaffected throughout, which is why nothing else caught
-/// it.
+/// A sweep used to damage entity history. `collect_ref_reachable_commit_ids`
+/// fed its result to the *semantic* retention only, so a graph-reachable commit
+/// kept its projection and lost its delta segments — and an entity history row
+/// is served out of the delta.
+/// `load_commit_delta_members_with_payloads_for_schemas` returns an empty
+/// member list for a commit whose replay state is gone, so the damage raised no
+/// error: the swept commits read as commits that changed nothing. Current state
+/// was unaffected throughout, which is why nothing else caught it.
 ///
-/// Equality is the right assertion and not an over-strong one. A sweep frees
-/// the *unreachable* interior — the intra-interval commits the checkpoint
-/// superseded — and those never contributed a history entry, because the engine
-/// collapses an un-checkpointed interval into one commit. Nothing a sweep is
-/// entitled to collect is observable here, so any change at all is a defect.
+/// # Why equality, and not "a sweep may drop the oldest entries"
 ///
-/// `LIX_VC_MODEL_GC_HISTORY=prefix` weakens this back to the pre-fix invariant
-/// (what remains must be an exact newest-first prefix, and no key that still
-/// has state may lose its history entirely). That is retained as the inversion
-/// control: it is the assertion that passed while the defect was live, so a run
-/// under it must still pass, proving the strict form is what does the work.
+/// That weaker invariant — what remains must be an exact newest-first prefix of
+/// what was there before — was the first form of this assertion, chosen to be a
+/// gate the tree could pass while the defect was open. Measuring the defect
+/// disproved it. At six checkpointed rounds the sweep truncated; at twelve it
+/// dropped entries out of the *middle*, so the surviving sequence closed up and
+/// an older value appeared at the position a newer one had occupied:
+///
+/// ```text
+/// before: [ ...7189b9e18, 1582bff8a4dd11c8 ]
+/// after:  [ ...7189b9e18, b1bba5cbd88ff978 ]   <- wrong value, same depth
+/// ```
+///
+/// So the weak form was not merely weak, it was false, and a blame query could
+/// return a wrong answer rather than a missing one.
+///
+/// Equality is also not over-strong. A sweep frees the *unreachable* interior —
+/// the intra-interval commits a checkpoint superseded — and those never
+/// contributed a history entry, because the engine collapses an
+/// un-checkpointed interval into one commit. Nothing a sweep is entitled to
+/// collect is observable here, so any change at all is a defect.
+///
+/// `LIX_VC_MODEL_INJECT=gc_history` proves this assertion can fail.
 fn assert_history_survived_gc(
     before: &BTreeMap<String, Vec<Option<JsonValue>>>,
     after: &BTreeMap<String, Vec<Option<JsonValue>>>,
     label: &str,
 ) {
-    let prefix_only = std::env::var("LIX_VC_MODEL_GC_HISTORY")
-        .map(|value| value.trim() == "prefix")
-        .unwrap_or(false);
-    if !prefix_only {
-        assert_eq!(
-            before, after,
-            "{label}: checkpoint GC changed the observable history"
-        );
-        return;
-    }
-
-    for (key, before_entries) in before {
-        let Some(after_entries) = after.get(key) else {
-            panic!("{label}: checkpoint GC removed all history for {key}");
-        };
-        assert!(
-            !after_entries.is_empty(),
-            "{label}: checkpoint GC left {key} with an empty history"
-        );
-        assert!(
-            after_entries.len() <= before_entries.len(),
-            "{label}: checkpoint GC grew the history for {key}: \
-             {} entries became {}",
-            before_entries.len(),
-            after_entries.len()
-        );
-        assert_eq!(
-            &before_entries[..after_entries.len()],
-            &after_entries[..],
-            "{label}: the history checkpoint GC kept for {key} is not a prefix of the history \
-             that was there before the sweep"
-        );
-    }
-    for key in after.keys() {
-        assert!(
-            before.contains_key(key),
-            "{label}: checkpoint GC invented history for {key}"
-        );
-    }
+    assert_eq!(
+        before, after,
+        "{label}: checkpoint GC changed the observable history"
+    );
 }
 
 async fn branch_head(engine: &lix::integration::Engine, branch_id: &str) -> String {


### PR DESCRIPTION
A repository GC sweep permanently destroys entity history. This fixes it, proves the fix end to end, and tolerates the damage already done.

**Stacked on #1448** (`claude-7-correctness-harness`), which contributes the differential harness this was found with. Base moves to `claude-7-optimizations` once #1448 lands. **Draft — do not merge.**

## The defect

`collect_ref_reachable_commit_ids` produces `graph_reachable`, and that set was routed into the **semantic** retention only, never the **physical** one. So a commit reachable from the live head kept its projection and lost its delta segments — and an entity `lix_<schema>_history()` row is served out of the delta.

The damage raises no error. `load_commit_delta_members_with_payloads_for_schemas` returns an empty member list for a commit whose replay state is gone, and `load_point_replay_commit_state` returning `None` makes a retired commit **indistinguishable from one that changed nothing**. Current state is unaffected throughout, which is why nothing else caught it.

### Severity, measured

Not truncation. At six checkpointed rounds the sweep truncated the tail; at twelve it dropped entries out of the **middle**, so the surviving sequence closed up and an older value landed at the depth a newer one had occupied:

```text
before: [ ...7189b9e18, 1582bff8a4dd11c8 ]
after:  [ ...7189b9e18, b1bba5cbd88ff978 ]   <- wrong value, same depth
```

A blame query returns a **wrong** answer, not a missing one. Surviving depth is a **constant 3 regardless of repository age**, so the absolute loss grows without bound. Blast radius is every `lix_<schema>_history()` surface — blame, time travel, diff against an old commit — for all tracked entity data, on every branch, unrecoverable.

## Why it went unnoticed, and why this has to be right the first time

**GC errors are swallowed.** `collect_checkpoint_garbage_best_effort` catches every failure from `collect_checkpoint_garbage`, emits one `tracing::warn!`, and returns. There is no counter, no metric, and no test that would notice; the checkpoint that triggered the sweep stays committed and the caller sees success. A sweep can be failing on every checkpoint of a repository indefinitely and the only evidence is a log line nobody is collecting. That is why a latent correctness bug in this path survived, and it is why the tolerance below is scoped tightly rather than broadly: a wrong relaxation here is equally invisible.

## The fix

`packages/lix/src/gc.rs` — every graph-reachable commit that still has a manifest becomes a **physical** dependency, not only a semantic one.

Cost is **flat at ~2.1 KB per checkpointed round** that changed data, and does not grow with sweep count. What compaction frees is the *unreachable interior*: an intra-interval commit stops being on the canonical parent chain once the checkpoint supersedes it, so it never enters this set and is still retired. The set retained here is the checkpoint chain, which compaction shortens.

### The tolerance, and the design trade

A repository swept by the code that shipped before this fix has commits that are graph-reachable and have **no** manifest, because that sweep deleted it. Demanding one would abort every future sweep on such a repository — silently, per the paragraph above — while writes kept succeeding.

Worse, **a failed sweep latches.** `checkpoint_gc_due` takes `age_limit = CHECKPOINT_GC_MIN_AGE.max(last_gc_sequence)` and only a successful sweep advances `last_gc_sequence`, so the limit freezes while `checkpoint_sequence` climbs: the predicate returns true forever — measured at **5000 of 5000** subsequent checkpoints — and every one of them pays for a doomed full-repository sweep.

So the sweep tolerates a missing manifest **only** in that set. The implementation pre-loads manifests for the graph-reachable commits in one bulk read and inserts only those that resolve, counting the rest on `RepositoryGcProfile::history_manifests_missing` and warning once per sweep.

**The trade, stated deliberately: one extra bulk manifest load per sweep.** It buys a tolerance whose scope is exactly *"graph-reachable commits that still have a delta"*, with **no interaction at any other demand site**. Serving dependencies, selected-source owners and physical authorities keep their existing hard demand — a commit that is also a serving dependency still hard-errors, through that path, unchanged. The alternative (tolerating absence at the shared demand site) is one fewer read and a far larger blast radius.

Within the tolerated set the sweep genuinely cannot distinguish a pre-fix casualty from corruption: after this fix no graph-reachable commit is ever swept, so absence is either legacy or corruption and nothing at hand separates them. Both are tolerated and both are **counted**, so the condition is observable rather than silent.

## Upgrade note

**History already lost is not recoverable.** Those deltas are deleted and cannot be recomputed. The manifestation is **absence only** — no corruption, no ongoing degradation, and the repository keeps collecting normally. Measured on a repository swept by the pre-fix code: **66 tolerated missing manifests, 3 pre-sweep entries intact, 9 new entries retained** after the fix. New history written after upgrading is retained correctly; history written before it and already swept is gone.

`history_manifests_missing` on `RepositoryGcProfile`, plus the one-per-sweep `tracing::warn!`, is how an operator sees whether a given repository was affected.

## Tests

**`vc_model_state_and_history_survive_checkpoint_gc`** (in #1448's harness) now asserts history **equality** across a sweep, unconditionally. The weaker form — "what remains must be an exact newest-first prefix" — was tried first and disproved by measurement: entries drop out of the middle, so the weak invariant was not merely weak, it was false. Equality is also not over-strong, because everything a sweep is entitled to collect is an intra-interval commit that never contributed a history entry. `LIX_VC_MODEL_INJECT=gc_history` is its inversion.

**Two `gc::tests`** prove the tolerance in both directions at plan level: intact history reports `history_manifests_missing == 0`, a pre-fix-swept repository reports `1` and still plans.

**A new in-crate session-level test** proves a *reclaim*, not a plan. That distinction matters because of the latch: `mark_collected()` is the statement immediately after the staging `?`, so a successful plan implies the un-latch is **staged** — but three fallible steps follow it (`stage_checkpoint_gc_state`, `prepare_write_set`, the commit), so it does not imply the un-latch is **persisted**. The test builds six checkpointed rounds, deletes one on-chain commit's physical delta exactly as the pre-fix sweep did, crosses the collection interval, and requires that every recorded **interior** commit is reclaimed — then reads `last_gc_sequence` and the due-predicate back out of committed storage.

It lives in-crate because manufacturing a legacy repository needs `stage_delete_commit_state_manifest_for_gc`, which is `pub(crate)`, and the integration suite sees only the public API. **No test-only public hook was added**: a publicly reachable way to delete a manifest is a footgun that outlives its purpose, and the post-hard-cut public surface stays narrow. The one visibility change is a `#[cfg(test)]`-gated `pub(crate)` re-export inside the crate.

**Inversion, run rather than argued.** Making the tolerance hard-error instead fails exactly two tests — `ordinary_gc_tolerates_and_counts_history_reclaimed_before_the_fix` and the new session-level test — at the expected site, and leaves the other 41 green. So the new test is not a property that cannot fail, and the four rewritten fixtures below no longer depend on the tolerance at all.

### Four rewritten fixtures — read this before assuming they were bent to fit

`ordinary_gc_accepts_rootless_tracked_serving_generation` and the `..._finite_selected_owner_...` / `..._scoped_descriptor_owner_...` / `..._native_row_owner_...` release fixtures all failed on the identical assertion `sweep.tracked_commit_roots.contains(&owner_or_old_root)`. **They failed because the fix works**: each built its release path through a raw `owner -> checkpoint -> released` parent chain that a real checkpoint never produces, which left the owner an ancestor of the live head — so each was asserting the defect at unit level.

They are rewritten by **severing the owner**, not by relaxing the assertion. Each fixture now carries an explicit interval `base` and parents the checkpoint onto it, simulating the compaction the real path performs: the owner is an interior commit of the interval the checkpoint closes, so the checkpoint supersedes it and it leaves the first-parent chain. Each keeps proving its original subject — selected-source, scoped-descriptor and native-row owner release ordering. Each also gains a positive assertion that the interval base is *not* retired, without which they would pass equally well against a collector that retires the whole chain.

Only **interior** commits are asserted to leave the chain. Measured on the real path: **10 of 10 interior commits drop off the first-parent chain, 5 of 5 checkpoints stay on it**, with `chain_len == checkpoints + 1`. A test asserting that checkpoints leave would encode a false invariant and pass for the wrong reason.

## Closed off

`history_dependencies` is **inert for this outcome** — removing it entirely produces an identical failure. Widening `authenticated_control_commit_reachability` would change nothing while looking exactly like a fix. Recorded so it is not re-proposed.

## Gate

Scope re-derived from this sha's own `ci.yml`, plus `cargo check -p lix --no-default-features`, which is **not** a CI step here and is the only one that sees an ungated `storage_bench` call.

```
HEAD_BEFORE=0889a20ef25e62c78a23d7e62e6f8c7a2ffa75cf
HEAD_AFTER=0889a20ef25e62c78a23d7e62e6f8c7a2ffa75cf
status.porcelain: []
CI_SCOPE_CONFIRMED_AT=0889a20ef25e62c78a23d7e62e6f8c7a2ffa75cf
NODEFAULT_EXIT=0  CLIPPY_EXIT=0  TEST1_EXIT=0  TEST2_EXIT=0
EXECUTED_TARGETS test1=25 test2=27
TEST1_PASSED=3441  TEST1_FAILED=0
TEST2_PASSED=172  TEST2_FAILED=0
NEW_TEST_PRESENT=1
```

`3430 -> 3441` reconciles exactly: **+8** from #1448's harness (4 `simulation_test!` cases x 2 variants), **+2** from the tolerance `gc::tests`, **+1** from the session-level reclaim test. Executables stay at 25 because no `[[test]]` target is added; `lix_e2e` is unchanged at 172 / 27. Every test named above is confirmed to have *run* by name in the executed log, not inferred from the count.

## Collision note

Per the round's collision map this must be gated on the **merge** with #1444, not merely alongside it. #1444 pins undo-to-last-checkpoint against reclaim at every commit, which is exactly the retention behaviour this PR changes; the collision is behavioural rather than textual, so it can pass on both parents and fail on the merge.
