### PR TITLE
probe(lix): measure what a JSON-column equality costs the entity provider

### DIFF
--- a/packages/lix/src/json_predicate_pushdown_probe.rs
+++ b/packages/lix/src/json_predicate_pushdown_probe.rs
@@ -1,0 +1,188 @@
+//! Does a JSON-column equality reach the entity provider?
+//!
+//! Not a product module. `filterable_column_name` returns `None` for
+//! `EntityColumnType::Json`, so a JSON-column equality cannot become an
+//! `EntityRowFilter`. What that costs is the open question: the predicate is
+//! still *answered*, by DataFusion's `FilterExec` one layer above the
+//! provider, so the rows are materialised and then discarded.
+//!
+//! The text spelling (`WHERE v = '{"n":1}'`) is a type error
+//! (`LIX_ERROR_TYPE_MISMATCH`) and never runs, so it cannot be the shape under
+//! test. This probe uses the spelling that type-checks,
+//! `WHERE v = lix_json('...')`, and a String-column arm as the control: same
+//! fixture size, same one-row answer, on a column that *is* pushable.
+//!
+//! Counted at the materialisation boundary (`apply_entity_batch_filters`),
+//! above its `filters.is_empty()` early return, because a profile of that
+//! function reads identically for "nothing to filter" and "never ran".
+
+use serde_json::json;
+
+use crate::engine::Engine;
+use crate::session::SessionContext;
+use crate::storage_adapter::Memory;
+
+async fn open_session() -> SessionContext<Memory> {
+    let storage = Memory::new();
+    Engine::initialize(storage.clone())
+        .await
+        .expect("engine should initialize");
+    let engine = Engine::new(storage.clone())
+        .await
+        .expect("engine should open");
+    engine.open_session().await.expect("session should open")
+}
+
+async fn register(session: &SessionContext<Memory>, key: &str) {
+    let schema = json!({
+        "x-lix-key": key,
+        "x-lix-primary-key": ["/id"],
+        "type": "object",
+        "properties": {
+            "id": { "type": "string" },
+            "k": { "type": "string" },
+            "v": { "type": "object" }
+        },
+        "required": ["id", "k", "v"],
+        "additionalProperties": false
+    });
+    session
+        .execute(
+            "INSERT INTO lix_registered_schema (value) VALUES (lix_json($1))",
+            &[crate::Value::Text(schema.to_string())],
+        )
+        .await
+        .expect("schema should register");
+}
+
+async fn seed(session: &SessionContext<Memory>, table: &str, count: usize) {
+    const CHUNK: usize = 250;
+    let mut index = 0;
+    while index < count {
+        let end = (index + CHUNK).min(count);
+        let values = (index..end)
+            .map(|i| format!("('r-{i}', 'k-{i}', lix_json('{{\"n\":{i}}}'))"))
+            .collect::<Vec<_>>()
+            .join(",");
+        session
+            .execute(
+                &format!("INSERT INTO {table} (id, k, v) VALUES {values}"),
+                &[],
+            )
+            .await
+            .expect("rows should insert");
+        index = end;
+    }
+}
+
+/// The two spellings, same fixture, same one-row answer.
+///
+/// Counted with `provider_rows_examined`, the engine's own instrument, whose
+/// documentation states the exact contract this probe needs: it is recorded
+/// *before* a provider applies its row filters, at **every route an entity
+/// surface can take**, so a route that never reaches
+/// `apply_entity_batch_filters` is still counted. A census at that one
+/// function is blind to the columnar and overlay routes, which is how a
+/// "zero frames" reading can mean "different route" rather than "did nothing".
+/// It is also task-local rather than process-global, so it cannot bleed.
+///
+/// `scan_rows` is reported alongside it because the pair is what makes the
+/// claim falsifiable: a change that only moves filtering earlier in the plan
+/// moves `scan_rows` and leaves `provider_rows_examined` alone.
+#[tokio::test]
+#[ignore = "measurement probe, not a gate"]
+async fn json_column_equality_materialization() {
+    let n: usize = std::env::var("LIX_JPP_ROWS")
+        .ok()
+        .and_then(|raw| raw.parse().ok())
+        .unwrap_or(10_000);
+
+    println!("jpp | arm,n,answer_rows,provider_rows_examined,scan_rows,examined_per_answer_row");
+
+    // Control: a String column, which IS pushable. Same fixture size, same
+    // one-row answer, and no indexed access path either - so it isolates the
+    // JSON refusal from "this column has no access path".
+    {
+        let session = open_session().await;
+        register(&session, "jppstr").await;
+        seed(&session, "jppstr", n).await;
+        let (result, profile) = session
+            .execute_profiled("SELECT id FROM jppstr WHERE k = 'k-7'", &[])
+            .await
+            .expect("string-column scan should run");
+        println!(
+            "string,{n},{},{},{},{}",
+            result.rows().len(),
+            profile.provider_rows_examined,
+            profile.scan_rows,
+            profile.provider_rows_examined as f64 / result.rows().len().max(1) as f64
+        );
+        assert_eq!(
+            result.rows().len(),
+            1,
+            "the string arm must answer exactly one row"
+        );
+    }
+
+    {
+        let session = open_session().await;
+        register(&session, "jppjson").await;
+        seed(&session, "jppjson", n).await;
+
+        // The text spelling is a type error and never runs. Asserted so this
+        // probe cannot silently measure the wrong shape.
+        let text_spelling = session
+            .execute("SELECT id FROM jppjson WHERE v = '{\"n\":7}'", &[])
+            .await;
+        println!(
+            "jpp | text_spelling_err={:?}",
+            text_spelling.as_ref().err().map(|error| error.code.clone())
+        );
+        assert!(
+            text_spelling.is_err(),
+            "the text spelling must remain a type error"
+        );
+
+        let (result, profile) = session
+            .execute_profiled(
+                "SELECT id FROM jppjson WHERE v = lix_json('{\"n\":7}')",
+                &[],
+            )
+            .await
+            .expect("json-column scan should run");
+        println!(
+            "json,{n},{},{},{},{}",
+            result.rows().len(),
+            profile.provider_rows_examined,
+            profile.scan_rows,
+            profile.provider_rows_examined as f64 / result.rows().len().max(1) as f64
+        );
+        assert_eq!(
+            result.rows().len(),
+            1,
+            "the json arm must answer exactly one row"
+        );
+    }
+
+    // A primary-key equality, which DOES have an exact access path. Present as
+    // the upper bound: it is what "the provider examined only what it needed"
+    // looks like on this fixture, so the two arms above can be read against a
+    // number the engine can actually reach rather than against zero.
+    {
+        let session = open_session().await;
+        register(&session, "jpppk").await;
+        seed(&session, "jpppk", n).await;
+        let (result, profile) = session
+            .execute_profiled("SELECT id FROM jpppk WHERE id = 'r-7'", &[])
+            .await
+            .expect("primary-key scan should run");
+        println!(
+            "primary_key,{n},{},{},{},{}",
+            result.rows().len(),
+            profile.provider_rows_examined,
+            profile.scan_rows,
+            profile.provider_rows_examined as f64 / result.rows().len().max(1) as f64
+        );
+        assert_eq!(result.rows().len(), 1, "the pk arm must answer one row");
+    }
+}

--- a/packages/lix/src/lib.rs
+++ b/packages/lix/src/lib.rs
@@ -71,6 +71,8 @@ mod handle;
 mod hot_index_aging_probe;
 #[cfg(test)]
 mod hot_row_tombstone_probe;
+#[cfg(test)]
+mod json_predicate_pushdown_probe;
 pub(crate) mod init;
 pub(crate) mod json_store;
 pub(crate) mod hot_state;

--- a/packages/lix/src/module_layers.rs
+++ b/packages/lix/src/module_layers.rs
@@ -104,6 +104,7 @@ const UNLAYERED_MODULES: &[(&str, &str)] = &[
     ("hot_index_aging_probe", "cfg(test) measurement probe"),
     ("hot_row_tombstone_probe", "cfg(test) measurement probe"),
     ("init", "entry point; reaches everywhere by design"),
+    ("json_predicate_pushdown_probe", "cfg(test) measurement probe"),
     ("lib", "crate root"),
     ("module_layers", "this guard"),
     ("observe_coordinator", "not yet analysed"),

--- a/packages/lix/src/sql2/providers/entity.rs
+++ b/packages/lix/src/sql2/providers/entity.rs
@@ -2422,9 +2422,47 @@ impl<'a> EntityRowFilterAnalyzer<'a> {
             EntityColumnType::String
             | EntityColumnType::Boolean
             | EntityColumnType::Integer
-            | EntityColumnType::Number => Some(column.name.as_str()),
-            EntityColumnType::Json => None,
+            | EntityColumnType::Number => {
+                #[cfg(any(test, feature = "storage-benches"))]
+                record_filterable_column(&self.spec.schema_key, column_name, true);
+                Some(column.name.as_str())
+            }
+            EntityColumnType::Json => {
+                #[cfg(any(test, feature = "storage-benches"))]
+                record_filterable_column(&self.spec.schema_key, column_name, false);
+                None
+            }
         }
+    }
+}
+
+/// Census of `filterable_column_name`, at the refusal itself.
+///
+/// Question being answered: how often does a real query shape ask to push a
+/// predicate on a JSON column? A counter cannot say *which* schema and column,
+/// and the shape is the whole point, so each decision is appended as one line
+/// and aggregated afterwards.
+///
+/// Inert unless `LIX_FILTERABLE_CENSUS` names a file, so it costs nothing in
+/// an ordinary test run and cannot perturb a timing measurement.
+///
+/// One `write_all` of a complete line, in append mode: short appends to the
+/// same fd from several threads and processes do not interleave on Linux, and
+/// the aggregate only needs line counts per key.
+#[cfg(any(test, feature = "storage-benches"))]
+fn record_filterable_column(schema_key: &str, column_name: &str, accepted: bool) {
+    use std::io::Write as _;
+    static PATH: std::sync::OnceLock<Option<String>> = std::sync::OnceLock::new();
+    let Some(path) = PATH
+        .get_or_init(|| std::env::var("LIX_FILTERABLE_CENSUS").ok())
+        .as_deref()
+    else {
+        return;
+    };
+    let verdict = if accepted { "accept" } else { "refuse_json" };
+    let line = format!("{verdict}\t{schema_key}\t{column_name}\n");
+    if let Ok(mut file) = std::fs::OpenOptions::new().create(true).append(true).open(path) {
+        let _ = file.write_all(line.as_bytes());
     }
 }
 


### PR DESCRIPTION
Instruments only. No production behaviour change. Independent of #1452/#1458.

## What this adds

1. **`json_predicate_pushdown_probe.rs`** — three spellings of a one-row-answer equality on the same 10 000-row fixture, measured with `provider_rows_examined`.
2. **A census on `filterable_column_name`**, at the refusal itself, logging *schema key and column* rather than counting — the shape is the question, and a counter cannot say which schema. Inert unless `LIX_FILTERABLE_CENSUS` names a file, env lookup cached in a `OnceLock`.

## What they measured

`packages/lix` lib tests, `Memory` adapter, release profile, `ryzen-9950x-IV`, single test thread. Hot-plane lane, no checkpoint and no packed base. Answer is exactly **one row** in every arm.

| arm | answer rows | `provider_rows_examined` | `scan_rows` |
|---|---|---|---|
| **string** — `k = 'k-7'`, pushable | 1 | **10 000** | **1** |
| **json** — `v = lix_json('{"n":7}')`, refused | 1 | **10 000** | **10 000** |
| **primary key** — `id = 'r-7'` | 1 | **1** | 1 |

### The pushable arm is the point

A JSON-column equality cannot become an `EntityRowFilter`, because `filterable_column_name` returns `None` for `EntityColumnType::Json`. The consequence is visible in `scan_rows`: the provider emits all 10 000 rows and DataFusion's `FilterExec` discards 9 999 above it.

But **`provider_rows_examined` is 10 000 in the pushable arm too.** The stored-row examination is identical, so "all rows are materialised and discarded" is true and is **not** a consequence of the JSON refusal. `EntityRowFilter` at this layer is a **post-materialisation filter**: it runs after the rows are read and only saves Arrow construction plus a `FilterExec` pass for the rows it rejects.

`sql_profile.rs` states the contract this rests on, in the counter's own documentation:

> *"a fix that only moves filtering earlier in the plan changes `scan_rows` and leaves this unchanged"*

A JSON pushdown is exactly such a fix. **Predicted, not measured: `scan_rows` 10 000 → 1, `provider_rows_examined` unchanged at 10 000.** Anyone building it should hold it to that prediction.

### The primary-key arm is the reference point

`examined = 1` is what an access path looks like — four orders of magnitude from either equality arm. **The 10 000× examination cost is shared by every non-PK, non-indexed equality, JSON or not.** That is an access-path problem, not a pushdown problem.

A JSON column can never reach that access path: `derive_indexed_columns` (`sql2/catalog/entity_surface.rs`) admits only `String | Integer`, one layer away from the pushdown. So the large win is structurally unavailable to JSON columns regardless of what `filterable_column_name` returns.

## Why `provider_rows_examined` and not a local census

My first attempt counted at `apply_entity_batch_filters`, above its `filters.is_empty()` early return. **The JSON arm produced no line at all** — that function never ran for it. Entity surfaces take several routes, and `provider_rows_examined` is recorded at **six** sites for that reason, including the columnar and overlay routes.

So a "zero frames in `apply_entity_batch_filters`" reading is consistent with **different route**, not only with "the filter did nothing". That census is deliberately **not** in this PR; the probe uses the instrument that observes every route. It is also task-local rather than process-global, so it cannot bleed across a parallel suite.

## Frequency, with the caveat that matters

Census over both suites:

| suite | accept | refuse_json |
|---|---|---|
| workspace (38 targets, 3 430 tests) | 543 | 6 — all one synthetic test schema |
| `lix_e2e` (27 targets, 172 tests) | 414 | **2 — both `lix_key_value.value`** |

`lix_key_value.value` is a real JSON column, so the shape does occur outside a test schema. **But refusal count is the wrong metric** — one refusal on a 10 000-row table dominates hundreds on small ones — and this is corpus frequency, not production frequency. Neither number should be read as evidence of rarity.

## Not included

No pushdown. The soundness analysis says one is possible — the residual materialises through `entity_json_text_value` → `json_to_string`, so a provider-side push computing the same function over the same `JsonValue` is **bit-identical by construction rather than a superset** — but the measurement above says the win is bounded to Arrow construction plus a `FilterExec` pass, and it is unmeasured in time. Banking the instrument instead.
