### PR TITLE
perf(gc): key the reclaim trigger to yield against inventory, and stop it latching

### DIFF
--- a/packages/lix/src/gc.rs
+++ b/packages/lix/src/gc.rs
@@ -43,7 +43,7 @@ pub(crate) const CHECKPOINT_GC_STATE_NAMESPACE: &str = "checkpoint.gc_state.v1";
 pub(crate) const CHECKPOINT_GC_STATE_SPACE: StorageSpace =
     StorageSpace::mutable(StorageSpaceId(0x0008_0002), CHECKPOINT_GC_STATE_NAMESPACE);
 const CHECKPOINT_RECOVERY_REF_FORMAT_VERSION: u32 = 3;
-const CHECKPOINT_GC_STATE_FORMAT_VERSION: u32 = 1;
+const CHECKPOINT_GC_STATE_FORMAT_VERSION: u32 = 2;
 const CHECKPOINT_GC_STATE_KEY: &[u8] = b"repository";
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct AuthenticatedControlCommitReachability {
@@ -139,6 +139,19 @@ pub(crate) struct CheckpointGcState {
     pub(crate) checkpoint_sequence: u64,
     pub(crate) last_gc_sequence: u64,
     pub(crate) collectible_interval_count: u64,
+    /// Live commit-manifest count observed by the last successful reclaim.
+    ///
+    /// Approximate between sweeps and trued up by every sweep, which already
+    /// enumerates the plane. This is a trigger heuristic and never an
+    /// authority: drift costs a slightly early or late sweep and nothing else.
+    pub(crate) live_manifest_estimate: u64,
+    /// Retired commits per collectible interval observed by the last
+    /// successful reclaim. Same status: approximate and self-correcting.
+    pub(crate) yield_per_interval_estimate: u64,
+    /// Consecutive reclaim attempts that failed before reaching
+    /// `mark_collected`. Damps the retry so a persistently failing sweep
+    /// cannot re-arm a full repository pass on every checkpoint.
+    pub(crate) consecutive_reclaim_failures: u64,
 }
 
 impl CheckpointGcState {
@@ -153,9 +166,20 @@ impl CheckpointGcState {
         self.collectible_interval_count > 0
     }
 
-    pub(crate) fn mark_collected(&mut self) {
+    /// Records one successful reclaim and re-derives both trigger estimates
+    /// from what that sweep actually observed.
+    pub(crate) fn mark_collected(&mut self, reclaimed_commits: u64, live_manifest_count: u64) {
+        let intervals = self.collectible_interval_count.max(1);
+        self.yield_per_interval_estimate = reclaimed_commits / intervals;
+        self.live_manifest_estimate = live_manifest_count;
         self.last_gc_sequence = self.checkpoint_sequence;
         self.collectible_interval_count = 0;
+        self.consecutive_reclaim_failures = 0;
+    }
+
+    /// Records one reclaim attempt that did not reach [`Self::mark_collected`].
+    pub(crate) fn note_reclaim_failure(&mut self) {
+        self.consecutive_reclaim_failures = self.consecutive_reclaim_failures.saturating_add(1);
     }
 }
 
@@ -188,6 +212,9 @@ struct StoredCheckpointGcState {
     checkpoint_sequence: u64,
     last_gc_sequence: u64,
     collectible_interval_count: u64,
+    live_manifest_estimate: u64,
+    yield_per_interval_estimate: u64,
+    consecutive_reclaim_failures: u64,
 }
 
 /// One authenticated checkpoint replacement that is still pending physical
@@ -265,6 +292,9 @@ pub(crate) fn stage_checkpoint_gc_state(
             checkpoint_sequence: state.checkpoint_sequence,
             last_gc_sequence: state.last_gc_sequence,
             collectible_interval_count: state.collectible_interval_count,
+            live_manifest_estimate: state.live_manifest_estimate,
+            yield_per_interval_estimate: state.yield_per_interval_estimate,
+            consecutive_reclaim_failures: state.consecutive_reclaim_failures,
         },
     )?;
     writes.put(
@@ -568,6 +598,9 @@ pub(crate) async fn load_checkpoint_gc_state(
         checkpoint_sequence: stored.checkpoint_sequence,
         last_gc_sequence: stored.last_gc_sequence,
         collectible_interval_count: stored.collectible_interval_count,
+        live_manifest_estimate: stored.live_manifest_estimate,
+        yield_per_interval_estimate: stored.yield_per_interval_estimate,
+        consecutive_reclaim_failures: stored.consecutive_reclaim_failures,
     };
     validate_checkpoint_gc_state(state)?;
     Ok(state)
@@ -624,6 +657,9 @@ fn validate_stored_recovery_ref(
 
 #[derive(Clone, Debug, Default, Eq, PartialEq)]
 pub(crate) struct RepositoryGcSweep {
+    /// Live commit manifests this sweep had to scan to plan. Feeds the reclaim
+    /// trigger's inventory estimate; in-memory only, never persisted here.
+    pub(crate) live_manifest_count: u64,
     pub(crate) tracked_commit_roots: Vec<CommitId>,
     pub(crate) standalone_changes: Vec<ChangeId>,
     /// Derived serving rows reclaimed from branch generations that no live
@@ -1425,6 +1461,9 @@ where
 
     // Retirement candidates are derived here, not read from a ledger.
     let candidates = derive_retirement_candidates(&store).await?;
+    // The inventory this sweep had to scan. Feeds the reclaim trigger's
+    // self-correcting denominator; captured before `candidates` is consumed.
+    let live_manifest_count = candidates.len() as u64;
 
     // Derive both physical retirement and logical CAS retention from the one
     // authenticated serving closure. In particular, do not perform a second
@@ -1563,6 +1602,7 @@ where
             repair: GcRepairSet::default(),
         },
         sweep: RepositoryGcSweep {
+            live_manifest_count,
             tracked_commit_roots: reclaimed_commits.into_iter().collect(),
             // Superseded branch-ref facts and stale serving generations are
             // retired by the publication that supersedes them, in that same
@@ -1641,6 +1681,10 @@ where
     Ok(RepositoryGcPlan {
         changelog: changelog_plan,
         sweep: RepositoryGcSweep {
+            // The recovery-only rebuild path never feeds the reclaim trigger;
+            // it rediscovers liveness by scanning rather than from the
+            // manifest inventory, so it has no inventory figure to report.
+            live_manifest_count: 0,
             tracked_commit_roots: swept_snapshot_authorities,
             standalone_changes: Vec::new(),
             reclaimed_generation_rows: 0,
@@ -4159,6 +4203,108 @@ mod tests {
             .expect("payload fixture schema should register");
     }
 
+    /// Demonstrates, mechanically, that the in-record `format_version` cannot
+    /// gate an arity change to `StoredCheckpointGcState`.
+    ///
+    /// Every storage record is `#[musli(packed)]` -- positional and untagged --
+    /// so a reader's field count is part of its wire contract. Decoding fails on
+    /// **arity**, before any field value (including `format_version`) can be
+    /// inspected. The upgrade mechanism for such a change is therefore
+    /// `REPOSITORY_PROTOCOL_VALUE`, which makes `Engine::new` reject the
+    /// repository outright, not the per-record version field.
+    ///
+    /// Reading the derive is not evidence for this; the readers below are
+    /// constructed and run.
+    #[test]
+    fn packed_arity_change_cannot_be_gated_by_the_in_record_format_version() {
+        // Today's shipping shape: format_version + 3 counters.
+        #[derive(musli::Encode, musli::Decode)]
+        #[musli(packed)]
+        struct ArityOld {
+            format_version: u32,
+            checkpoint_sequence: u64,
+            last_gc_sequence: u64,
+            collectible_interval_count: u64,
+        }
+
+        // Proposed shape: the same, plus the two self-correcting estimates the
+        // ratio trigger needs.
+        #[derive(musli::Encode, musli::Decode)]
+        #[musli(packed)]
+        struct ArityNew {
+            format_version: u32,
+            checkpoint_sequence: u64,
+            last_gc_sequence: u64,
+            collectible_interval_count: u64,
+            live_manifest_estimate: u64,
+            yield_per_interval_estimate: u64,
+        }
+
+        let new_bytes = crate::storage_codec::encode(
+            "arity demo new",
+            &ArityNew {
+                format_version: 2,
+                checkpoint_sequence: 7,
+                last_gc_sequence: 3,
+                collectible_interval_count: 4,
+                live_manifest_estimate: 512,
+                yield_per_interval_estimate: 9,
+            },
+        )
+        .expect("new record should encode");
+
+        let old_bytes = crate::storage_codec::encode(
+            "arity demo old",
+            &ArityOld {
+                format_version: 1,
+                checkpoint_sequence: 7,
+                last_gc_sequence: 3,
+                collectible_interval_count: 4,
+            },
+        )
+        .expect("old record should encode");
+
+        // Direction 1: an OLD reader against a NEW record.
+        let old_reads_new = crate::storage_codec::decode::<ArityOld>("arity demo", &new_bytes);
+        let old_reads_new_err = old_reads_new
+            .err()
+            .expect("a 4-field reader must reject a 6-field record");
+        println!("ARITY old_reader_vs_new_record: {}", old_reads_new_err.message);
+
+        // Direction 2: a NEW reader against an OLD record.
+        let new_reads_old = crate::storage_codec::decode::<ArityNew>("arity demo", &old_bytes);
+        let new_reads_old_err = new_reads_old
+            .err()
+            .expect("a 6-field reader must reject a 4-field record");
+        println!("ARITY new_reader_vs_old_record: {}", new_reads_old_err.message);
+
+        // The sharp point: bumping `format_version` inside the record does not
+        // help, because a same-arity record still decodes cleanly and a
+        // different-arity record never reaches the field at all. So the version
+        // field can express "same shape, new meaning" and can never express
+        // "new shape".
+        let bumped = crate::storage_codec::encode(
+            "arity demo bumped",
+            &ArityOld {
+                format_version: 999,
+                checkpoint_sequence: 7,
+                last_gc_sequence: 3,
+                collectible_interval_count: 4,
+            },
+        )
+        .expect("bumped record should encode");
+        let decoded = crate::storage_codec::decode::<ArityOld>("arity demo", &bumped)
+            .expect("a same-arity record decodes regardless of its version value");
+        assert_eq!(
+            decoded.format_version, 999,
+            "the version field is only observable once arity already matched"
+        );
+        println!(
+            "ARITY same_arity_decodes_despite_version=999 checkpoint_sequence={}",
+            decoded.checkpoint_sequence
+        );
+    }
+
     async fn run_shipping_repository_gc(backend: &Memory) -> super::RepositoryGcPlan {
         let storage = StorageAdapter::new(backend.clone());
         let read = SharedStorageAdapterRead::new(
@@ -5063,10 +5209,16 @@ mod tests {
     #[tokio::test]
     async fn repository_gc_state_round_trips() {
         let storage = StorageAdapter::new(Memory::new());
+        // Distinct values per field: a positional `#[musli(packed)]` record
+        // will round-trip a permuted field order undetected if the values
+        // collide.
         let expected = CheckpointGcState {
             checkpoint_sequence: 129,
             last_gc_sequence: 64,
             collectible_interval_count: 65,
+            live_manifest_estimate: 4_096,
+            yield_per_interval_estimate: 7,
+            consecutive_reclaim_failures: 3,
         };
         let mut writes = storage.new_write_set();
         stage_checkpoint_gc_state(&mut writes, &expected)

--- a/packages/lix/src/init.rs
+++ b/packages/lix/src/init.rs
@@ -59,7 +59,7 @@ pub(crate) const REPOSITORY_PROTOCOL_KEY: &[u8] = b"current";
 /// open, where `unsupported_repository_protocol_error` tells the operator to
 /// recreate the repository. Every hard cut to a persisted record shape has to
 /// move this value with it.
-const REPOSITORY_PROTOCOL_VALUE: &[u8] = b"tracked-default-branch.v67";
+const REPOSITORY_PROTOCOL_VALUE: &[u8] = b"tracked-default-branch.v69";
 
 /// Raw status of the repository protocol marker. Engine opening consults this
 /// before it touches any tracked-head space, whose physical IDs deliberately

--- a/packages/lix/src/session/checkpoint.rs
+++ b/packages/lix/src/session/checkpoint.rs
@@ -18,11 +18,19 @@ pub struct CreateCheckpointReceipt {
     pub change_id: String,
 }
 
-const CHECKPOINT_GC_MIN_AGE: u64 = 64;
-// Once history is mature, each successful sweep grows the next interval in
-// proportion to retained checkpoint history. Full-sweep positions therefore
-// grow geometrically instead of producing fixed-cadence quadratic work.
-const CHECKPOINT_GC_HISTORY_FRACTION: u64 = 1;
+/// Reclaim when the estimated retirable set reaches this fraction of the live
+/// inventory the sweep must scan.
+const RECLAIM_YIELD_DENOMINATOR: u64 = 4;
+/// Inventory floor, so a small repository does not sweep on every checkpoint.
+const RECLAIM_MIN_INVENTORY: u64 = 64;
+/// Cap on retry damping, so a repository whose sweep recovers is not locked
+/// out for an unbounded number of checkpoints.
+const RECLAIM_FAILURE_BACKOFF_CAP: u32 = 10;
+/// Staleness backstop: collectible debt may not sit uncollected for longer
+/// than this many checkpoints, whatever the yield ratio says. Grows with
+/// retained history exactly as the previous rule did, which is what keeps
+/// full-sweep positions sublinear.
+const RECLAIM_MAX_STALENESS: u64 = 64;
 
 struct CreateCheckpointOutcome {
     receipt: CreateCheckpointReceipt,
@@ -171,6 +179,21 @@ where
     }
 }
 
+/// Decides whether a repository-wide reclaim is worth running.
+///
+/// The sweep costs O(live commit manifests) to plan and yields O(retired
+/// commits), so amortised cost per reclaimed commit is bounded only when yield
+/// is proportional to the inventory the sweep must scan. The previous rule
+/// keyed its magnitude to checkpoint *count*, which is blind to how much
+/// garbage an interval actually holds: a repository checkpointing once every
+/// thousand commits accrued debt a thousand times more slowly than it accrued
+/// garbage, while one checkpointing every commit accrued debt far faster.
+///
+/// Evaluated at checkpoints, and that is correct rather than a compromise.
+/// Debt rises only at a checkpoint and the denominator only at ordinary
+/// commits, so the ratio can only ever cross *upward* at a checkpoint.
+/// Checkpointing is also what makes an interval collectible in the first
+/// place, so there is no cadence that reclaims without one.
 pub(crate) fn checkpoint_gc_due(state: CheckpointGcState) -> Result<bool, LixError> {
     if !state.has_collectible_debt() {
         return Ok(false);
@@ -184,9 +207,39 @@ pub(crate) fn checkpoint_gc_due(state: CheckpointGcState) -> Result<bool, LixErr
                 "checkpoint GC sequence is ahead of checkpoint sequence",
             )
         })?;
-    let age_limit =
-        CHECKPOINT_GC_MIN_AGE.max(state.last_gc_sequence / CHECKPOINT_GC_HISTORY_FRACTION);
-    Ok(checkpoint_age >= age_limit)
+    // Bootstrap: before any sweep has reported, assume one retired commit per
+    // interval, which reduces this to the old interval count.
+    let yield_estimate = state.yield_per_interval_estimate.max(1);
+    let estimated_reclaimable = state
+        .collectible_interval_count
+        .saturating_mul(yield_estimate);
+    // Retry damping. Without this the predicate latches: a failing sweep never
+    // reaches `mark_collected`, so the estimates freeze while debt grows and
+    // every later checkpoint re-arms a full repository pass. Measured at
+    // 5000 of 5000 checkpoints before this was added.
+    let shift = state
+        .consecutive_reclaim_failures
+        .min(u64::from(RECLAIM_FAILURE_BACKOFF_CAP)) as u32;
+    let backoff = 1u64.checked_shl(shift).unwrap_or(u64::MAX);
+    let inventory = state
+        .live_manifest_estimate
+        .max(RECLAIM_MIN_INVENTORY)
+        .saturating_mul(backoff);
+    // Cost trigger: sweep once the estimated yield pays for the scan. This
+    // fires *earlier* than the backstop when an interval holds dense garbage,
+    // which is the case the old checkpoint-count rule could not see.
+    let yield_due = estimated_reclaimable.saturating_mul(RECLAIM_YIELD_DENOMINATOR) >= inventory;
+    // Staleness backstop, retained from the previous rule and load-bearing.
+    // The ratio bounds cost but says nothing about *delay*: a repository whose
+    // garbage is real but sparse would otherwise wait indefinitely, since a
+    // small debt never reaches a fraction of the inventory. Empty padding
+    // checkpoints accrue no debt at all, so this is the only thing that
+    // collects such a repository.
+    let age_limit = RECLAIM_MAX_STALENESS
+        .max(state.last_gc_sequence)
+        .saturating_mul(backoff);
+    let stale_due = checkpoint_age >= age_limit;
+    Ok(yield_due || stale_due)
 }
 
 fn push_selected_change(
@@ -220,7 +273,10 @@ fn push_selected_change(
 
 #[cfg(test)]
 mod tests {
-    use super::{CHECKPOINT_GC_MIN_AGE, checkpoint_gc_due, push_selected_change};
+    use super::{
+        RECLAIM_MIN_INVENTORY, RECLAIM_YIELD_DENOMINATOR, checkpoint_gc_due,
+        push_selected_change,
+    };
     use crate::changelog::{ChangeId, CommitId};
     use crate::common::LixTimestamp;
     use crate::entity_pk::EntityPk;
@@ -269,39 +325,258 @@ mod tests {
             checkpoint_sequence: sequence,
             last_gc_sequence,
             collectible_interval_count: 1,
+            ..CheckpointGcState::default()
         }
     }
 
+    /// The trigger must key off estimated yield against inventory, not off
+    /// how many checkpoints have happened. Verified by inversion: the same
+    /// interval count produces opposite verdicts when only the observed yield
+    /// differs, and again when only the inventory differs.
     #[test]
-    fn sparse_gc_cadence_grows_with_checkpoint_history() {
-        let mut early = state(CHECKPOINT_GC_MIN_AGE - 1, 0);
-        assert!(!checkpoint_gc_due(early).expect("early GC state should be valid"));
-        early.checkpoint_sequence = CHECKPOINT_GC_MIN_AGE;
-        assert!(checkpoint_gc_due(early).expect("initial GC state should be due"));
+    fn reclaim_keys_off_yield_against_inventory_not_checkpoint_count() {
+        let intervals = 8;
+        let inventory = 1_024;
 
-        let last_gc_sequence = 8_000;
-        let scaled_age = last_gc_sequence;
-        let mut mature = state(last_gc_sequence + scaled_age - 1, last_gc_sequence);
-        assert!(!checkpoint_gc_due(mature).expect("mature GC state should be valid"));
-        mature.checkpoint_sequence += 1;
-        assert!(checkpoint_gc_due(mature).expect("scaled GC state should be due"));
+        // Yield too low for this inventory -> refuses.
+        // `last_gc_sequence` is large and the age small, so the staleness
+        // backstop cannot fire and the yield ratio is the only thing deciding.
+        let lean = CheckpointGcState {
+            checkpoint_sequence: 100_000 + intervals,
+            last_gc_sequence: 100_000,
+            collectible_interval_count: intervals,
+            live_manifest_estimate: inventory,
+            yield_per_interval_estimate: 4,
+            consecutive_reclaim_failures: 0,
+        };
+        assert!(
+            !checkpoint_gc_due(lean).expect("lean state should be valid"),
+            "8 intervals x 4 = 32 retirable against 1024 inventory must not sweep"
+        );
+
+        // Same interval count, richer intervals -> fires.
+        let rich = CheckpointGcState {
+            yield_per_interval_estimate: 64,
+            ..lean
+        };
+        assert!(
+            checkpoint_gc_due(rich).expect("rich state should be valid"),
+            "8 intervals x 64 = 512 retirable against 1024 inventory must sweep"
+        );
+
+        // Same yield, smaller inventory -> also fires. The denominator is the
+        // thing the old rule could not see.
+        let small = CheckpointGcState {
+            live_manifest_estimate: 64,
+            ..lean
+        };
+        assert!(
+            checkpoint_gc_due(small).expect("small state should be valid"),
+            "the same debt against a small inventory must sweep"
+        );
     }
 
+    /// The ratio boundary itself, both sides, so a change to the constants
+    /// cannot silently move the trigger without failing here.
     #[test]
-    fn sweep_count_stays_sublinear_through_ten_thousand_checkpoints() {
+    fn reclaim_fires_exactly_at_the_ratio_boundary() {
+        let inventory = 4_096;
+        let at_boundary = inventory / RECLAIM_YIELD_DENOMINATOR;
+        // Same isolation as above: staleness must not be able to decide.
+        let mut just_under = CheckpointGcState {
+            checkpoint_sequence: 10_000_000 + at_boundary,
+            last_gc_sequence: 10_000_000,
+            collectible_interval_count: at_boundary - 1,
+            live_manifest_estimate: inventory,
+            yield_per_interval_estimate: 1,
+            consecutive_reclaim_failures: 0,
+        };
+        assert!(!checkpoint_gc_due(just_under).expect("valid"), "just under must refuse");
+        just_under.collectible_interval_count = at_boundary;
+        assert!(checkpoint_gc_due(just_under).expect("valid"), "at the boundary must fire");
+    }
+
+    /// A repository smaller than the inventory floor must not sweep on every
+    /// checkpoint just because its inventory is tiny.
+    #[test]
+    fn small_repositories_are_floored_not_swept_constantly() {
+        let tiny = CheckpointGcState {
+            checkpoint_sequence: 5,
+            last_gc_sequence: 0,
+            collectible_interval_count: 1,
+            live_manifest_estimate: 4,
+            yield_per_interval_estimate: 1,
+            consecutive_reclaim_failures: 0,
+        };
+        assert!(
+            !checkpoint_gc_due(tiny).expect("tiny state should be valid"),
+            "one interval against the {RECLAIM_MIN_INVENTORY}-manifest floor must not sweep"
+        );
+    }
+
+    /// The latch. A failing sweep never reaches `mark_collected`, so without
+    /// damping the estimates freeze while debt grows and every later
+    /// checkpoint re-arms a full repository pass -- measured at 5000 of 5000.
+    /// Damping must break that, and must not be permanent.
+    #[test]
+    fn repeated_reclaim_failures_damp_the_retry() {
+        let base = CheckpointGcState {
+            checkpoint_sequence: 1_000,
+            last_gc_sequence: 0,
+            collectible_interval_count: 64,
+            live_manifest_estimate: 256,
+            yield_per_interval_estimate: 1,
+            consecutive_reclaim_failures: 0,
+        };
+        assert!(
+            checkpoint_gc_due(base).expect("valid"),
+            "fixture must be due with no failures, or the damping below is vacuous"
+        );
+
+        let damped = CheckpointGcState {
+            consecutive_reclaim_failures: 4,
+            ..base
+        };
+        assert!(
+            !checkpoint_gc_due(damped).expect("valid"),
+            "repeated failures must stop re-arming a full sweep every checkpoint"
+        );
+
+        // Damping is a delay, not a lockout: enough further debt still fires.
+        let recovered = CheckpointGcState {
+            collectible_interval_count: 64 * 32,
+            ..damped
+        };
+        assert!(
+            checkpoint_gc_due(recovered).expect("valid"),
+            "damping must yield once the estimated reclaimable set grows enough"
+        );
+    }
+
+    /// The property the ratio actually buys is **bounded amortised cost per
+    /// reclaimed commit**, not a small sweep count.
+    ///
+    /// A sweep scans O(live commit manifests) and reclaims some number of
+    /// commits; the trigger only fires when the estimated reclaimable set is
+    /// at least `1/RECLAIM_YIELD_DENOMINATOR` of that inventory, so total
+    /// scanned work stays within a constant factor of total reclaimed work no
+    /// matter how the user checkpoints. That is the invariant asserted here.
+    ///
+    /// Asserting a sweep *count* instead is a proxy and a misleading one: an
+    /// earlier version of this test held inventory at the small-repository
+    /// floor, where the floor alone set the cadence, and read 625 sweeps while
+    /// the cost invariant was never in danger.
+    #[test]
+    fn reclaim_cost_stays_within_a_constant_factor_of_what_it_reclaims() {
         let mut state = CheckpointGcState::default();
-        let mut sweep_count = 0;
+        // Each checkpoint publishes one commit that stays live forever and
+        // three that become retirable -- a repository that genuinely grows.
+        let mut live = 0u64;
+        let mut garbage = 0u64;
+        let mut total_scanned = 0u64;
+        let mut total_reclaimed = 0u64;
+        let mut sweeps = 0u64;
+        let mut first_half_scanned = 0u64;
+        let mut first_half_reclaimed = 0u64;
+        let mut second_half_scanned = 0u64;
+        let mut second_half_reclaimed = 0u64;
         for sequence in 1..=10_000 {
             state.checkpoint_sequence = sequence;
             state.add_collectible_interval(true);
-            if checkpoint_gc_due(state).expect("simulated GC state should be valid") {
-                sweep_count += 1;
-                state.mark_collected();
+            live += 1;
+            garbage += 3;
+            if checkpoint_gc_due(state).expect("simulated state should be valid") {
+                sweeps += 1;
+                total_scanned += live + garbage;
+                total_reclaimed += garbage;
+                if sequence <= 5_000 {
+                    first_half_scanned += live + garbage;
+                    first_half_reclaimed += garbage;
+                } else {
+                    second_half_scanned += live + garbage;
+                    second_half_reclaimed += garbage;
+                }
+                let reclaimed = garbage;
+                garbage = 0;
+                state.mark_collected(reclaimed, live);
             }
         }
+        let first_half_ratio_x100 =
+            first_half_scanned.saturating_mul(100) / first_half_reclaimed.max(1);
+        let second_half_ratio_x100 =
+            second_half_scanned.saturating_mul(100) / second_half_reclaimed.max(1);
+
         assert!(
-            sweep_count < 10,
-            "geometric cadence unexpectedly scheduled {sweep_count} sweeps"
+            sweeps > 0 && total_reclaimed > 0,
+            "the simulation must actually sweep and reclaim, or the bounds below are vacuous"
+        );
+
+        // Bounded: a sweep scans `live + garbage` while the trigger compares
+        // against the live estimate alone, so the achievable constant is
+        // `RECLAIM_YIELD_DENOMINATOR + 1` plus one sweep of estimate lag --
+        // not the denominator itself. Measured ~5.3x. The assertion is
+        // deliberately loose rather than tuned to that number: the claim is
+        // that the factor is constant, not that it equals any given value.
+        let ratio_x100 = total_scanned.saturating_mul(100) / total_reclaimed;
+        assert!(
+            ratio_x100 < 800,
+            "scanned {total_scanned} manifests to reclaim {total_reclaimed} commits \
+             across {sweeps} sweeps ({ratio_x100} per 100), above a constant factor"
+        );
+
+        // And constant: the factor must not grow with repository size, which
+        // is the whole amortisation claim. A cadence keyed to checkpoint count
+        // fails here while passing the bound above.
+        assert!(
+            second_half_ratio_x100 <= first_half_ratio_x100.saturating_mul(2),
+            "cost factor grew from {first_half_ratio_x100} to {second_half_ratio_x100} \
+             per 100 as the repository aged; amortised cost is not bounded"
+        );
+
+        // Sweeps must stay well short of one per checkpoint.
+        assert!(
+            sweeps < 10_000 / 4,
+            "ratio cadence scheduled {sweeps} sweeps in 10000 checkpoints"
+        );
+    }
+
+    /// The staleness backstop. The ratio bounds cost but says nothing about
+    /// delay: a repository whose garbage is real but sparse never reaches a
+    /// fraction of its inventory, and empty padding checkpoints accrue no debt
+    /// at all. Without this, such a repository would wait indefinitely --
+    /// which is exactly how the history-retention fix's own acceptance test
+    /// caught the omission.
+    #[test]
+    fn sparse_debt_still_collects_via_the_staleness_backstop() {
+        let sparse = CheckpointGcState {
+            checkpoint_sequence: 70,
+            last_gc_sequence: 0,
+            collectible_interval_count: 6,
+            live_manifest_estimate: 0,
+            yield_per_interval_estimate: 0,
+            consecutive_reclaim_failures: 0,
+        };
+        // The ratio alone refuses: 6 intervals x 1 estimated = 6, and
+        // 6 * 4 = 24 is below the 64-manifest floor.
+        assert!(
+            6u64 * RECLAIM_YIELD_DENOMINATOR < RECLAIM_MIN_INVENTORY,
+            "fixture must be below the ratio, or this proves nothing about the backstop"
+        );
+        assert!(
+            checkpoint_gc_due(sparse).expect("valid"),
+            "sparse but real debt must still collect once it goes stale"
+        );
+
+        // And the backstop is not a fixed cadence: it grows with retained
+        // history, which is what keeps full-sweep positions sublinear.
+        let mature = CheckpointGcState {
+            checkpoint_sequence: 8_100,
+            last_gc_sequence: 8_000,
+            ..sparse
+        };
+        assert!(
+            !checkpoint_gc_due(mature).expect("valid"),
+            "a mature repository must not fall back to a fixed 64-checkpoint cadence"
         );
     }
 

--- a/packages/lix/src/session/gc.rs
+++ b/packages/lix/src/session/gc.rs
@@ -1,4 +1,5 @@
 use crate::LixError;
+use std::sync::atomic::{AtomicU64, Ordering};
 use crate::gc::{
     RepositoryGcPlan, load_checkpoint_gc_state, stage_checkpoint_gc_state,
     stage_repository_gc_with_preconditions,
@@ -36,7 +37,10 @@ where
         let mut preconditions = Vec::new();
         let plan =
             stage_repository_gc_with_preconditions(read, &mut writes, &mut preconditions).await?;
-        gc_state.mark_collected();
+        gc_state.mark_collected(
+            plan.sweep.tracked_commit_roots.len() as u64,
+            plan.sweep.live_manifest_count,
+        );
         stage_checkpoint_gc_state(&mut writes, &gc_state)?;
         let commit_boundary = self.transaction_commit_boundary();
         let _commit_guard = begin_commit_boundary(Some(&commit_boundary));
@@ -60,6 +64,27 @@ where
         Ok(Some(plan))
     }
 
+    /// Persists one failed reclaim attempt so the trigger can damp its retry.
+    ///
+    /// Deliberately a tiny single-key write rather than part of the sweep's
+    /// write set: the sweep's write set is exactly what did not commit.
+    async fn record_reclaim_failure(&self) -> Result<(), LixError> {
+        let read = SharedStorageAdapterRead::new(
+            self.storage
+                .begin_read(StorageReadOptions::default())
+                .await?,
+        );
+        let mut gc_state = load_checkpoint_gc_state(&read).await?;
+        drop(read);
+        gc_state.note_reclaim_failure();
+        let mut writes = self.storage.new_write_set();
+        stage_checkpoint_gc_state(&mut writes, &gc_state)?;
+        self.storage
+            .commit_write_set(writes, StorageWriteOptions::default())
+            .await?;
+        Ok(())
+    }
+
     /// Checkpoint creation must not fail merely because opportunistic cleanup
     /// could not complete. Repository-global debt is cleared only in the same
     /// atomic write as a successful sweep, so every later checkpoint retries
@@ -81,6 +106,19 @@ where
             }
             Ok(None) => {}
             Err(error) => {
+                // Persistent failure here used to be undetectable: one
+                // `tracing::warn!` and no counter, invisible in production
+                // without a subscriber and invisible in tests entirely. Record
+                // it so the next occurrence is findable, and damp the retry so
+                // a failing sweep cannot re-arm a full repository pass on every
+                // checkpoint.
+                reclaim_failures_total().fetch_add(1, Ordering::Relaxed);
+                if let Err(record_error) = self.record_reclaim_failure().await {
+                    tracing::warn!(
+                        error = %record_error,
+                        "could not record reclaim failure; retry damping is skipped"
+                    );
+                }
                 tracing::warn!(
                     error = %error,
                     "post-checkpoint garbage collection failed; checkpoint remains committed"
@@ -345,4 +383,16 @@ mod tests {
             "the delta this test reclaimed by hand must be counted as tolerated, not swallowed"
         );
     }
+}
+
+/// Process-global count of reclaim attempts that failed before reaching
+/// `mark_collected`.
+///
+/// A persistently failing sweep previously produced no observable signal at
+/// all, which is why one went unnoticed. This is the cheap half of making the
+/// next one findable; the persisted `consecutive_reclaim_failures` is the half
+/// that survives a restart.
+pub(crate) fn reclaim_failures_total() -> &'static AtomicU64 {
+    static RECLAIM_FAILURES_TOTAL: AtomicU64 = AtomicU64::new(0);
+    &RECLAIM_FAILURES_TOTAL
 }

--- a/packages/lix/src/session/gc.rs
+++ b/packages/lix/src/session/gc.rs
@@ -79,9 +79,19 @@ where
         gc_state.note_reclaim_failure();
         let mut writes = self.storage.new_write_set();
         stage_checkpoint_gc_state(&mut writes, &gc_state)?;
-        self.storage
-            .commit_write_set(writes, StorageWriteOptions::default())
+        // Through the commit boundary like every other session write, so a
+        // concurrent close cannot race the final pre-commit check.
+        let commit_boundary = self.transaction_commit_boundary();
+        let _commit_guard = begin_commit_boundary(Some(&commit_boundary));
+        let prepared_commit = self
+            .storage
+            .prepare_write_set(writes, StorageWriteOptions::default())
             .await?;
+        commit_at_boundary(Some(&commit_boundary), || async move {
+            let (_, stats) = prepared_commit.commit().await?;
+            Ok(stats)
+        })
+        .await?;
         Ok(())
     }
 

--- a/packages/lix/src/session/gc.rs
+++ b/packages/lix/src/session/gc.rs
@@ -142,10 +142,14 @@ mod tests {
     use crate::storage_adapter::{SharedStorageAdapterRead, StorageReadOptions, StorageWriteOptions};
     use crate::{LixError, Value};
 
-    /// Checkpoints a fresh repository must accumulate before a sweep is due.
-    /// Mirrors `CHECKPOINT_GC_MIN_AGE` in `session::checkpoint`, which is
-    /// private to that module.
-    const CHECKPOINT_GC_MIN_AGE: usize = 64;
+    /// Checkpoints a fresh repository must accumulate before the staleness
+    /// backstop makes a sweep due. Mirrors `RECLAIM_MAX_STALENESS` in
+    /// `session::checkpoint`, which is private to that module.
+    ///
+    /// The yield ratio can make a sweep due *earlier* than this; the backstop
+    /// is the bound that holds when debt is sparse, which is the case these
+    /// fixtures build (empty padding checkpoints accrue no debt at all).
+    const RECLAIM_MAX_STALENESS: usize = 64;
 
     /// Checkpointed rounds of writes built before the repository is made
     /// legacy. Each round after the first contributes one interior commit the
@@ -187,6 +191,102 @@ mod tests {
             }
         }
         present
+    }
+
+
+    /// End-to-end engagement for the ratio trigger's two estimates.
+    ///
+    /// Both are produced by the sweep and written in its write set, so
+    /// asserting them off the returned plan is *not* an end-to-end check:
+    /// staging, preparing and committing all sit between the plan and
+    /// persistence. This reads them back out of committed storage, the same
+    /// bar the history-retention fix set for the un-latch.
+    #[tokio::test]
+    async fn reclaim_trigger_persists_its_estimates_to_committed_storage() {
+        let (_engine, session) = open().await;
+
+        for round in 0..ROUNDS {
+            for write in 0..WRITES_PER_ROUND {
+                session
+                    .execute(
+                        "INSERT INTO lix_key_value (key, value) VALUES ($1, $2) \
+                         ON CONFLICT (key) DO UPDATE SET value = excluded.value",
+                        &[
+                            Value::Text(format!("gc-estimate-k{write}")),
+                            Value::Json(json!({ "round": round, "write": write }).into()),
+                        ],
+                    )
+                    .await
+                    .expect("write commits");
+            }
+            session
+                .create_checkpoint()
+                .await
+                .expect("round checkpoint succeeds");
+        }
+
+        async fn committed_state(
+            session: &SessionContext<Memory>,
+        ) -> crate::gc::CheckpointGcState {
+            let read = SharedStorageAdapterRead::new(
+                session
+                    .storage
+                    .begin_read(StorageReadOptions::default())
+                    .await
+                    .expect("gc state read opens"),
+            );
+            let state = load_checkpoint_gc_state(&read)
+                .await
+                .expect("checkpoint gc state loads");
+            drop(read);
+            state
+        }
+
+        // Non-vacuity: both estimates must start unset, or the assertions
+        // below could pass against a default-constructed state.
+        let before = committed_state(&session).await;
+        assert_eq!(
+            (before.live_manifest_estimate, before.yield_per_interval_estimate),
+            (0, 0),
+            "estimates must be unset before any sweep, or this proves nothing"
+        );
+
+        // Empty padding accrues no debt, so the staleness backstop is what
+        // makes this due -- deliberately the harder path for the estimates.
+        for _ in 0..RECLAIM_MAX_STALENESS {
+            session
+                .create_checkpoint()
+                .await
+                .expect("padding checkpoint succeeds");
+        }
+
+        let plan = session
+            .collect_checkpoint_garbage()
+            .await
+            .expect("the sweep must succeed")
+            .expect("the sweep must have been due, or nothing below is measured");
+        assert!(
+            plan.sweep.live_manifest_count > 0,
+            "the sweep must have scanned a real inventory to report one"
+        );
+
+        let after = committed_state(&session).await;
+        assert!(
+            after.last_gc_sequence > 0,
+            "`mark_collected` must have persisted, not merely been staged"
+        );
+        assert_eq!(
+            after.live_manifest_estimate, plan.sweep.live_manifest_count,
+            "the persisted inventory estimate must be exactly what the sweep observed"
+        );
+        assert_eq!(
+            after.consecutive_reclaim_failures, 0,
+            "a successful sweep must clear the failure damping"
+        );
+        assert!(
+            !checkpoint_gc_due(after).expect("due predicate evaluates"),
+            "a successful sweep must un-latch the trigger, not re-arm it"
+        );
     }
 
     /// Deletes one commit's physical delta the way the sweep that shipped
@@ -301,7 +401,7 @@ mod tests {
             .expect("the pre-fix reclaim stages and commits");
 
         // Cross the collection interval.
-        for _ in 0..CHECKPOINT_GC_MIN_AGE {
+        for _ in 0..RECLAIM_MAX_STALENESS {
             session
                 .create_checkpoint()
                 .await


### PR DESCRIPTION
Stacked on #1459 (`claude-7-gc-history-retention`). Draft.

Keys the reclaim trigger's magnitude to **how much garbage there is**, rather than to how many checkpoints have happened — and stops the trigger latching when a sweep fails.

## The trigger

Reclaim scans O(live commit manifests) to plan and reclaims O(retired commits). The old rule fired on checkpoint *count* (`age_limit = max(64, last_gc_sequence)`), which is blind to how much garbage an interval actually holds: a repository checkpointing once every thousand commits accrued debt a thousand times more slowly than it accrued garbage, while one checkpointing every commit accrued debt far faster than it accrued anything to collect. Neither rate is a property anyone chose.

The new rule fires when the estimated reclaimable set reaches a fixed fraction of the inventory the sweep must scan, so amortised cost per reclaimed commit is bounded regardless of checkpoint habits. Both inputs are written by the sweep itself from data it already has — `candidates.len()` and `tracked_commit_roots.len()` — so they are approximate between sweeps and trued up by each one. **No per-commit lockstep counter**, and drift costs at most a slightly early or late sweep.

**Evaluated at checkpoints, and that is correct rather than a compromise.** Debt rises only at a checkpoint and the denominator only at ordinary commits, so the ratio can only ever cross *upward* at a checkpoint. Checkpointing is also what makes an interval collectible at all, so there is no cadence that reclaims without one.

## The staleness backstop, and how it was found

The first version of this change **kept only the ratio, and that was wrong.** A ratio bounds what a sweep *costs* and says nothing about how long collectible garbage may *sit*. The old checkpoint-count rule had been providing that second guarantee silently, which is exactly why replacing it looked safe.

This surfaced as a **merge-only break**: green on #1459, green here, broken together, with no shared symbol and no textual conflict. #1459's acceptance test pads with *empty* checkpoints, which accrue no debt at all (`add_collectible_interval` only counts intervals that have commits), so debt sat at ~6 while the old rule fired on age. The ratio saw 6 estimated retirable commits against the 64-manifest floor and correctly refused — forever.

So both are kept. The ratio fires **earlier** when an interval holds dense garbage, the case the old rule could not see; the previous geometric rule is retained as a staleness bound, still growing with `last_gc_sequence` so full-sweep positions stay sublinear. #1459's test passes again and now runs in **0.22 s instead of 120.19 s** — it had been spinning to its deadline rather than collecting.

## The latch

A failing sweep never reaches `mark_collected`, so the estimates froze while debt grew and **every later checkpoint re-armed a full repository pass — measured at 5000 of 5000.** The error path was one `tracing::warn!` with no counter: invisible in production without a subscriber and invisible in tests entirely, which is why this went unnoticed.

Both halves are addressed. Failures are counted in a process-global counter on the `Err` arm, and persisted in `consecutive_reclaim_failures`, which damps the retry with a capped exponential backoff — a delay, not a lockout, asserted in both directions. The persisted write is a deliberately tiny single-key transaction rather than part of the sweep's write set, since that write set is exactly what did not commit.

## Format break

`CheckpointGcState` 3→6 fields (stored record 4→7) and `CHECKPOINT_GC_STATE_FORMAT_VERSION` 1→2, gated by **`REPOSITORY_PROTOCOL_VALUE` v67→v69**. My bump covers exactly those two changes; final reconciliation is the coordinator's — `v68` is claimed by #1447.

The in-record `format_version` **cannot** gate this, and that is demonstrated rather than argued (`packed_arity_change_cannot_be_gated_by_the_in_record_format_version`):

```
old_reader_vs_new_record: ... 3 trailing bytes
new_reader_vs_old_record: ... Tried to read 1 bytes from slice, with 0 byte remaining
same_arity_decodes_despite_version=999  checkpoint_sequence=7
```

Two directions rejecting via two *different* mechanisms, neither reaching a field value — and the third line is the constructive half: a record carrying `format_version: 999` decodes cleanly when arity matches. The version field can express "same shape, new meaning" and can never express "new shape", because it is only observable after arity has already succeeded.

The round-trip test now uses **distinct values per field**. A positional `#[musli(packed)]` record round-trips a permuted field order undetected when values collide, so placeholder values make such a test weaker than it looks.

## Testing notes worth reading

**The cost test asserts the property, not a proxy.** An earlier version asserted *sweep count* and read 625 — passing for the wrong reason, because the simulation held inventory at the small-repository floor so the floor alone set the cadence. It now asserts what the ratio actually guarantees: total scanned within a constant factor of total reclaimed, **and that the factor does not grow as the repository ages**, which is the amortisation claim. The measured factor is ~5.3×, not 4×, because a sweep scans `live + garbage` while the trigger compares against the live estimate alone. The assertion is deliberately left loose rather than tuned to 5.3 — the claim is that the factor is constant, not that it equals any particular value.

**Engagement is read out of committed storage, not out of the plan.** Three fallible steps sit between staging and persistence, so a plan assertion is not an end-to-end one. `reclaim_trigger_persists_its_estimates_to_committed_storage` asserts both estimates start unset, then that the persisted inventory estimate is *exactly* what the sweep observed.

## Known residual, not addressed here

The sweep is still O(live commit-manifest count) via a **key-only** scan (`derive_retirement_candidates` → `scan_commit_state_manifest_commit_ids`, `StorageCoreProjection::KeyOnly`). A fair future target for an incremental index; not a claim this PR makes.

## Gate

Scope re-derived from `ci.yml` at the gated sha. The gate script asserts its **own expected sha** before running anything, and checks each new test by its **actual emitted name** rather than a naive grep.

```
git rev-parse HEAD       e1a2aaa4596e8996f905e9780a1108ff61db72c4   (before AND after)
git status --porcelain   empty                                      (before AND after)
CI_SCOPE_CONFIRMED_AT=e1a2aaa4596e8996f905e9780a1108ff61db72c4

EXIT_clippy=0  EXIT_test_workspace=0  EXIT_test_e2e=0
EXIT_check_nodefault=0  EXIT_check_wasm=0

EXECUTED_TARGETS workspace_targets=38  workspace_passed=3447
EXECUTED_TARGETS e2e_targets=27        e2e_passed=172

NEW_TESTS_BY_EMITTED_NAME (all present in the executed log):
  reclaim_keys_off_yield_against_inventory_not_checkpoint_count      -> 1
  reclaim_fires_exactly_at_the_ratio_boundary                        -> 1
  reclaim_cost_stays_within_a_constant_factor_of_what_it_reclaims    -> 1
  repeated_reclaim_failures_damp_the_retry                           -> 1
  sparse_debt_still_collects_via_the_staleness_backstop              -> 1
  small_repositories_are_floored_not_swept_constantly                -> 1
  packed_arity_change_cannot_be_gated_by_the_in_record_format_version -> 1
  repository_gc_state_round_trips                                    -> 1
```

One further break was caught by the gate and fixed: a structural rule requires session writes to go through `commit_at_boundary` so a concurrent close cannot race the final pre-commit check. The failure-record write was calling `commit_write_set` directly; it now matches the neighbouring sweep.

## Two things a reviewer should push on

**The `~5.3x` factor is honest, not tuned.** A sweep scans `live + garbage` while the trigger compares against the live estimate alone, so the achievable constant is `RECLAIM_YIELD_DENOMINATOR + 1` plus one sweep of estimate lag. The arithmetic is checkable rather than asserted from a measurement.

**`RECLAIM_YIELD_DENOMINATOR = 4` and `RECLAIM_MIN_INVENTORY = 64` are not validated against real workloads.** They are defensible from the cost argument and the simulation, but there is no production evidence for those particular values, and constants like these quietly become load-bearing.

**Why a wrong guess here is safe:** the staleness backstop is the floor on behaviour. If the ratio is tuned too conservatively it simply never fires first, and reclaim falls back to the previous checkpoint-count rule — the behaviour that shipped before this PR. If it is tuned too aggressively, the cost invariant test fails rather than a repository silently paying for it. So the failure mode of a bad constant is *degradation to the status quo*, not breakage. Retuning is a one-line change with no format implication.
