### PR TITLE
fix(lix): make `cargo test -p lix` compile again, and build that configuration in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,6 +108,21 @@ jobs:
         if: matrix.task == 'clippy'
         run: cargo clippy --profile test --workspace --all-targets --all-features -- -D warnings
 
+      # The one supported configuration nothing else here builds: `cfg(test)`
+      # with `storage-benches` OFF, which is exactly what a plain
+      # `cargo test -p lix` — the dev loop `packages/lix/AGENTS.md` documents —
+      # compiles. Every other step has the feature on (`--all-features`), and a
+      # `--no-default-features` check has no test targets at all, so a
+      # `#[cfg(test)]` item that calls the feature-only `storage_bench` module
+      # breaks `cargo test -p lix` while clippy, the full test matrix and the
+      # `--all-features` build all stay green. Two such call sites had
+      # accumulated in `gc.rs` before this step existed. `check` rather than
+      # `test`: the matrix below already runs the tests, this only has to prove
+      # the configuration compiles.
+      - name: Check lix test targets with default features
+        if: matrix.task == 'clippy'
+        run: cargo check -p lix --tests
+
       # `--all-features` is deliberate: it is the only thing that compiles
       # feature-gated sources such as `packages/lix/src/storage_bench.rs`
       # (behind `lix/storage-benches`), where a stale assertion once survived

--- a/packages/e2e/REALTIME_COLLABORATION_CAPACITY.md
+++ b/packages/e2e/REALTIME_COLLABORATION_CAPACITY.md
@@ -149,8 +149,18 @@ cargo test -p lix_e2e \
   abandoned_transactions_and_sessions_release_resources \
   -- --ignored --exact --nocapture
 
+# ⚠️ INERT — this command runs zero tests and exits 0. Do not read it as a pass.
+# `server_protocol_converges_to_one_hundred_clients_below_one_hundred_ms_p95`
+# carries `#[cfg(any())]` in packages/lix/src/server_protocol/mod.rs, together
+# with the whole `RemoteCapacityBackend` apparatus it needs, so it compiles in
+# no configuration. Measured: exit 0, `running 0 tests ... 2301 filtered out`.
+# The filter is also mis-spelled independently of that — the emitted name is
+# `server_protocol::tests::…`, so `--exact` on `tests::…` matches nothing even
+# once the item is compiled back in. The two `--test
+# realtime_collaboration_capacity` commands above are the live gate; unlike this
+# one they name a target, so a stale name there exits 101 instead of 0.
 cargo test -p lix --features "server-protocol storage-benches" --release \
-  tests::server_protocol_converges_to_one_hundred_clients_below_one_hundred_ms_p95 \
+  server_protocol::tests::server_protocol_converges_to_one_hundred_clients_below_one_hundred_ms_p95 \
   -- --ignored --exact --nocapture
 ```
 

--- a/packages/lix/src/gc.rs
+++ b/packages/lix/src/gc.rs
@@ -2871,6 +2871,13 @@ mod tests {
         assert!(!closure.cas_logical_dependencies.contains(&owner.commit_id));
     }
 
+    // `crate::storage_bench` exists only under `feature = "storage-benches"`,
+    // so every `#[cfg(test)]` item that reaches into it must carry the same
+    // gate. Without it `cargo check -p lix --tests` — `cfg(test)` with the
+    // feature off, which is what a plain `cargo test -p lix` builds — fails
+    // to compile the whole lib test target, while `--all-features` and CI
+    // stay green.
+    #[cfg(feature = "storage-benches")]
     #[tokio::test]
     async fn ordinary_gc_releases_finite_selected_owner_only_after_checkpoint_release() {
         let storage = StorageAdapter::new(Memory::new());
@@ -3015,6 +3022,7 @@ mod tests {
         );
     }
 
+    #[cfg(feature = "storage-benches")]
     /// Is there still a row in the change-locator plane for `change_id`?
     async fn locator_row_exists<R>(read: &R, change_id: ChangeId) -> bool
     where
@@ -3832,6 +3840,7 @@ mod tests {
     /// probe: a payload at or under 1 KiB never reaches the store at all, and
     /// the store is content addressed, so re-writing byte-identical content
     /// dedups onto one row and leaks nothing.
+    #[cfg(feature = "storage-benches")]
     fn out_of_band_payload(revision: usize) -> String {
         let filler = format!("rev-{revision:08}-");
         let mut body = String::with_capacity(2_048);
@@ -3851,6 +3860,7 @@ mod tests {
     /// distinct owners a co-ownership fixture needs. (An earlier version used
     /// two different paths, believed it had proved dedup, and was measuring two
     /// unrelated payloads.)
+    #[cfg(feature = "storage-benches")]
     async fn register_payload_schema<S>(
         session: &crate::integration::SessionContext<S>,
         schema_key: &str,
@@ -3880,6 +3890,7 @@ mod tests {
             .expect("payload fixture schema should register");
     }
 
+    #[cfg(feature = "storage-benches")]
     async fn run_shipping_repository_gc(backend: &Memory) -> super::RepositoryGcPlan {
         let storage = StorageAdapter::new(backend.clone());
         let read = SharedStorageAdapterRead::new(
@@ -3907,6 +3918,7 @@ mod tests {
         plan
     }
 
+    #[cfg(feature = "storage-benches")]
     async fn json_payload_refs(backend: &Memory) -> BTreeSet<JsonRef> {
         let storage = StorageAdapter::new(backend.clone());
         let read = storage
@@ -3928,6 +3940,7 @@ mod tests {
     /// engine's JSON normalization in the test. Re-deriving the content address
     /// here would make the fixture depend on a normalization detail rather than
     /// on the reachability behaviour under test.
+    #[cfg(feature = "storage-benches")]
     async fn payload_ref_added_by<F, Fut>(backend: &Memory, publish: F) -> JsonRef
     where
         F: FnOnce() -> Fut,
@@ -3953,6 +3966,7 @@ mod tests {
     /// owner does **not** write a second payload — it resolves onto the row the
     /// first owner already produced. Retiring the commit that happened to
     /// author it first must therefore not be read as "nobody names this".
+    #[cfg(feature = "storage-benches")]
     #[tokio::test]
     async fn repository_gc_keeps_a_payload_a_second_owner_still_names() {
         let backend = Memory::new();
@@ -4054,6 +4068,7 @@ mod tests {
     /// Untracked rows live only in the hot serving plane — no commit names
     /// them — so a live set derived from commits alone deletes this payload out
     /// from under both of them.
+    #[cfg(feature = "storage-benches")]
     #[tokio::test]
     async fn repository_gc_keeps_a_payload_co_owned_by_history_and_untracked_rows() {
         let backend = Memory::new();
@@ -4162,6 +4177,7 @@ mod tests {
 
     /// The leak this reclamation exists to close: superseded payloads are
     /// actually reclaimed, and the live one is not.
+    #[cfg(feature = "storage-benches")]
     #[tokio::test]
     async fn repository_gc_reclaims_superseded_out_of_band_payloads() {
         let backend = Memory::new();


### PR DESCRIPTION
## `cargo test -p lix` did not compile

`cfg(test)` with `storage-benches` **off** is reached by no build in this repo:

| build | `cfg(test)` | `storage-benches` |
|---|---|---|
| `cargo clippy … --all-features` (CI) | on | **on** |
| `cargo test … --all-features` (CI) | on | **on** |
| `cargo check -p lix --no-default-features` | **off** | off |
| `cargo test -p lix` — the dev loop `packages/lix/AGENTS.md` documents in its first bullet | on | off |

Nothing built the last row, and `ci.yml` names the hole in its own comment justifying `--all-features`:
*"a stale assertion once survived roughly ten pull requests because a plain `cargo test -p lix` never
built it."* The comment is right about the cause and stops one step short of the consequence — the
configuration is not merely under-tested, it does not compile.

**Measured on `ryzen-9950x-II` at `0b97f3c45`, the integration head, before this change:**

```
$ cargo check -p lix --tests
error[E0433]: cannot find `storage_bench` in `crate`   packages/lix/src/gc.rs:3024
error[E0433]: cannot find `storage_bench` in `crate`   packages/lix/src/gc.rs:3916
error: could not compile `lix` (lib test) due to 2 previous errors
EXIT=101
```

Both sites sit in the single `#[cfg(test)] mod tests` at `gc.rs:2292` and call
`crate::storage_bench::space_inventory`; `storage_bench` is `#[cfg(feature = "storage-benches")]` at
`lib.rs:105`. **Pre-existing, not a merge break** — `main` (`b4ad2f732`) carries the identical gate at
its `lib.rs:109`, and no open PR on this branch touches `gc.rs`'s test module.

## The fix

Gate the seven `#[cfg(test)]` items that reach into `storage_bench` on the feature as well — the rule
`ci.yml` already states. Under `--all-features` nothing moves: **3430 passed, same 25 executables,
same 38 result lines as the base**, and the four affected tests are asserted by emitted name to still
run (below).

**The wider fix does not work, so that nobody re-attempts it.** Widening `storage_bench`'s own gate in
`lib.rs` to `#[cfg(any(test, feature = "storage-benches"))]`, so the module simply exists in the test
configuration, is what the neighbours `registered_spaces` and `test_support` do and looks like the
structural answer. **Measured: 36 errors.** `storage_bench.rs` itself depends on ~12 further
feature-only items — `binary_cas::BinaryCasManifest`, `changelog::bench`,
`session::analyze_merge_for_bench`, `CommitDeltaMember::is_selected_payload_ref`, … — each of which
would have to be widened in turn. Gate the call sites, not the module.

## A mechanism, not a convention

Gating call sites is a rule someone has to remember, and no build in CI could notice a lapse — which
is how two of them accumulated. So this also adds `cargo check -p lix --tests` to the `clippy` matrix
task. It is a `check`, not a `test`: the matrix below it already runs the tests, this only has to
prove the configuration compiles.

**Do not spell it `--no-default-features`.** Measured: `cargo check -p lix --tests
--no-default-features` also exits 101, but partly for an unrelated pre-existing reason — `error: The
runtime flavor multi_thread requires the rt-multi-thread feature` in `tests/send_futures.rs`, because
tokio's features arrive through a default-feature chain. That configuration is not currently
buildable, so it is the wrong instrument: it reports a second failure that has nothing to do with
this one. Plain `--tests` is the invocation.

## Gate

Wider than CI, re-derived from this sha's own `ci.yml`. Run on `ryzen-9950x-II`.

```
HEAD_BEFORE=e3e30ba4eefafdcb7e240a5746a4a810ed133b3b
HEAD_AFTER =e3e30ba4eefafdcb7e240a5746a4a810ed133b3b
git status --porcelain           (empty, before and after)
CI_SCOPE_CONFIRMED_AT=e3e30ba4eefafdcb7e240a5746a4a810ed133b3b

EXIT_newconfig=0    cargo check -p lix --tests                    <- 101 on the base tree
EXIT_nodefault=0    cargo check -p lix --no-default-features
EXIT_checkall=0     cargo check --workspace --all-targets --all-features
EXIT_clippy=0       cargo clippy --profile test --workspace --all-targets --all-features -- -D warnings
EXIT_norun1=0 / EXIT_norun2=0
EXIT_test1=0        cargo test --profile test --workspace --exclude lix_e2e --all-features --no-fail-fast
EXIT_test2=0        cargo test --profile test -p lix_e2e --features sdk-tests,plugin-tests,server-protocol,storage-benches,slatedb,root-replay-trace --no-fail-fast

EXECUTED_TARGETS test1=25 test2=27          (no-run executables: 25 / 27)
PASSED           test1=3430 test2=172       (28 and 37 ignored, contributing +0)
FAILED           test1=0 test2=0
```

`25` / `3430` / `27` / `172` are the base values at `0b97f3c45` unchanged, which is the correct
outcome: this change adds no test and must remove none.

**Witness, in place of `NEW_TEST_PRESENT`.** This PR adds no test, so an unmoved count proves nothing
by itself — the failure mode to rule out is the opposite one, silently gating tests *out*. Asserted by
emitted name in the executed `test1` log:

```
test gc::tests::ordinary_gc_releases_finite_selected_owner_only_after_checkpoint_release ... ok
test gc::tests::repository_gc_keeps_a_payload_a_second_owner_still_names ... ok
test gc::tests::repository_gc_keeps_a_payload_co_owned_by_history_and_untracked_rows ... ok
test gc::tests::repository_gc_reclaims_superseded_out_of_band_payloads ... ok
```

## One doc annotated

`packages/e2e/REALTIME_COLLABORATION_CAPACITY.md` ended with

```
cargo test -p lix --features "server-protocol storage-benches" --release \
  tests::server_protocol_converges_to_one_hundred_clients_below_one_hundred_ms_p95 \
  -- --ignored --exact --nocapture
```

**Measured: `EXIT=0`, `running 0 tests … 2301 filtered out`** — a green exit in a document that reads
as a verified capacity gate. Two independent defects, either alone enough to silence it:

1. That test carries **`#[cfg(any())]`** (`server_protocol/mod.rs:8233`), as do nine sibling items at
   4382/4394/4401/6015/7823/7943/7951/8023/8268 — the whole `RemoteCapacityBackend` apparatus plus
   `same_base_remote_plugin_writes_resolve_and_converge`. It compiles in no configuration at all.
2. The `--exact` filter omits the module prefix; the emitted name is `server_protocol::tests::…`.

Fixed (2) and annotated (1) inline with the measurement. **Did not re-enable the `#[cfg(any())]`
items** — that is a real decision about a capacity gate, not hygiene, and `#[cfg(any())]` is also the
shape an unreverted cfg-inversion probe leaves behind, so someone should confirm which it is. Both
conditions are on `main` as well as here.

Note the general shape, since it is the useful part: a doc naming a **target** fails loudly — measured,
`--bench <removed>` and `-p <wrong-package>` both exit 101 with a did-you-mean — while a doc naming a
**filter** exits 0 having run nothing. The two `--test realtime_collaboration_capacity` commands
earlier in that same file are safe for exactly that reason.

## Reported, deliberately not fixed here

`cargo check --workspace --all-targets` with default features exits **101** on this branch and on the
base: 8× `E0603 module storage_adapter is private`, 3× `E0432 unresolved import lix::storage_bench`,
2× `E0432 unresolved import lix::registered_spaces`, in three `lix_e2e` examples — `e1_json_leak`,
`e29_locator_leak`, `expY_untracked_mutation_scaling`.

Same class, different mechanism: `packages/e2e/Cargo.toml` declares 23 `[[example]]` targets, **21 of
them carrying `required-features`**, while `packages/e2e/examples/` holds **29 files**. The five
undeclared ones are auto-discovered, so they cannot carry `required-features` and cannot be skipped.
`required-features` is a mechanism; *remembering to declare the target so it can carry one* is a
convention, and autodiscovery quietly converts the first into the second.

The fix is three `[[example]]` entries mirroring their 21 siblings, but `packages/e2e/Cargo.toml` is
touched by #1454 and #1450, so it belongs in its own change rather than widening this one across two
other PRs.
