### PR TITLE
Extract filesystem storage into its own JavaScript package

### DIFF
--- a/.changenotes/extract-js-storage-filesystem.md
+++ b/.changenotes/extract-js-storage-filesystem.md
@@ -1,0 +1,11 @@
+---
+type: minor
+---
+Move filesystem storage from `@lix-js/sdk` to the independently versioned
+`@lix-js/storage-filesystem` package and rename it to `FilesystemStorage`. Rust
+now uses the single `FilesystemStorage::new(path)…open()` configuration path;
+JavaScript uses `new FilesystemStorage({ path })`.
+
+Repository metadata now always lives at `<path>/.lix`; the external `lixDir`
+option and all previous `LocalFilesystem` entry points are removed without
+compatibility aliases.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -273,11 +273,18 @@ jobs:
         with:
           node-version: 24
           cache: npm
-          cache-dependency-path: packages/js-sdk/package-lock.json
+          cache-dependency-path: |
+            packages/js-sdk/package-lock.json
+            packages/storage-filesystem/package-lock.json
 
       - name: Install JS SDK dependencies
         working-directory: packages/js-sdk
         run: npm ci
+
+      - name: Install filesystem storage dependencies
+        if: matrix.runtime == 'native'
+        working-directory: packages/storage-filesystem
+        run: npm ci --legacy-peer-deps
 
       - name: Install Chromium
         if: matrix.runtime == 'browser'
@@ -292,6 +299,19 @@ jobs:
           npm run build:native
           npm run build:ts
           npm run build:plugins
+
+      - name: Build and check filesystem storage package
+        if: matrix.runtime == 'native'
+        working-directory: packages/storage-filesystem
+        run: |
+          npm run build
+          npm run typecheck
+          npm test
+
+      - name: Typecheck native JS SDK
+        if: matrix.runtime == 'native'
+        working-directory: packages/js-sdk
+        run: npm run typecheck
 
       - name: Run native JS SDK tests
         if: matrix.runtime == 'native'

--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -184,15 +184,25 @@ jobs:
         with:
           node-version: 24
           cache: npm
-          cache-dependency-path: packages/js-sdk/package-lock.json
+          cache-dependency-path: |
+            packages/js-sdk/package-lock.json
+            packages/storage-filesystem/package-lock.json
           registry-url: https://registry.npmjs.org
 
       - name: Install JS SDK dependencies
         working-directory: packages/js-sdk
         run: npm install
 
+      - name: Install filesystem storage dependencies
+        working-directory: packages/storage-filesystem
+        run: npm ci --legacy-peer-deps
+
       - name: Build JS SDK package
         working-directory: packages/js-sdk
+        run: npm run build
+
+      - name: Build filesystem storage package
+        working-directory: packages/storage-filesystem
         run: npm run build
 
       - name: Upload JS SDK package build
@@ -202,6 +212,13 @@ jobs:
           path: |
             packages/js-sdk/dist
             packages/js-sdk/lix_js_sdk.node
+          if-no-files-found: error
+
+      - name: Upload filesystem storage package build
+        uses: actions/upload-artifact@v4
+        with:
+          name: storage-filesystem-package-build
+          path: packages/storage-filesystem/dist
           if-no-files-found: error
 
   test-js-sdk:
@@ -222,11 +239,17 @@ jobs:
         with:
           node-version: 24
           cache: npm
-          cache-dependency-path: packages/js-sdk/package-lock.json
+          cache-dependency-path: |
+            packages/js-sdk/package-lock.json
+            packages/storage-filesystem/package-lock.json
 
       - name: Install JS SDK dependencies
         working-directory: packages/js-sdk
         run: npm install
+
+      - name: Install filesystem storage dependencies
+        working-directory: packages/storage-filesystem
+        run: npm ci --legacy-peer-deps
 
       - name: Download JS SDK package build
         uses: actions/download-artifact@v4
@@ -234,9 +257,24 @@ jobs:
           name: js-sdk-package-build
           path: packages/js-sdk
 
+      - name: Download filesystem storage package build
+        uses: actions/download-artifact@v4
+        with:
+          name: storage-filesystem-package-build
+          path: packages/storage-filesystem/dist
+
       - name: Test JS SDK package
         working-directory: packages/js-sdk
-        run: npx vitest run
+        run: |
+          npm run typecheck
+          npx vitest run
+
+      - name: Test filesystem storage package
+        working-directory: packages/storage-filesystem
+        run: |
+          npm run typecheck
+          npm test
+          npm pack --dry-run --ignore-scripts
 
   publish-js-sdk:
     name: Publish @lix-js/sdk packages
@@ -276,6 +314,12 @@ jobs:
           name: js-sdk-package-build
           path: packages/js-sdk
 
+      - name: Download filesystem storage package build
+        uses: actions/download-artifact@v4
+        with:
+          name: storage-filesystem-package-build
+          path: packages/storage-filesystem/dist
+
       - name: Publish JS SDK packages
         env:
           EXPECTED_VERSION: ${{ needs.release-version.outputs.version }}
@@ -283,6 +327,7 @@ jobs:
           set -euo pipefail
           publish_package() {
             local package_dir="$1"
+            local expected_version="${2:-}"
             local package_json="$package_dir/package.json"
             local package_name
             local package_version
@@ -299,8 +344,8 @@ jobs:
             package_version="$(node -p 'require(process.argv[1]).version' "$package_json")"
             package_spec="${package_name}@${package_version}"
 
-            if [ "$package_version" != "$EXPECTED_VERSION" ]; then
-              echo "$package_spec does not match release version $EXPECTED_VERSION." >&2
+            if [ -n "$expected_version" ] && [ "$package_version" != "$expected_version" ]; then
+              echo "$package_spec does not match release version $expected_version." >&2
               return 1
             fi
 
@@ -342,10 +387,11 @@ jobs:
               echo "Missing native package artifact for $suffix." >&2
               exit 1
             fi
-            publish_package "$package_dir"
+            publish_package "$package_dir" "$EXPECTED_VERSION"
           done
 
-          publish_package "$GITHUB_WORKSPACE/packages/js-sdk"
+          publish_package "$GITHUB_WORKSPACE/packages/js-sdk" "$EXPECTED_VERSION"
+          publish_package "$GITHUB_WORKSPACE/packages/storage-filesystem"
 
   create-github-release:
     name: Create GitHub release

--- a/README.md
+++ b/README.md
@@ -32,16 +32,17 @@ AI products want a repository: files for agents, a SQL database for your app, an
 </p>
 
 ```bash
-npm install @lix-js/sdk
+npm install @lix-js/sdk @lix-js/storage-filesystem
 ```
 
-Run locally with `LocalFilesystem`:
+Run locally with `FilesystemStorage`:
 
 ```ts
-import { LocalFilesystem, openLix } from "@lix-js/sdk";
+import { openLix } from "@lix-js/sdk";
+import { FilesystemStorage } from "@lix-js/storage-filesystem";
 
 const lix = await openLix({
-  storage: new LocalFilesystem({ path: "./repository", syncAllFiles: true }),
+  storage: new FilesystemStorage({ path: "./repository" }),
 });
 
 await lix.execute("INSERT INTO lix_file (path, content) VALUES ($1, $2)", [
@@ -117,7 +118,7 @@ Update Lix files and rows in one ACID transaction. Lix records the history autom
 
 Plugins map files to SQL rows. A paragraph, cell, or property becomes a row Lix can version.
 
-With `LocalFilesystem`, the file stays available on disk. Its entities are queryable with SQL. Lix tracks changes to both.
+With `FilesystemStorage`, the file stays available on disk. Its entities are queryable with SQL. Lix tracks changes to both.
 
 <img src="./website/public/assets/file-to-rows.svg" alt="A plugin maps /orders.csv to SQL rows with entity, field, and value columns" width="760" />
 

--- a/blog/007-v0-7-release/index.md
+++ b/blog/007-v0-7-release/index.md
@@ -96,13 +96,11 @@ Every step is recorded in the engine's optimization log, including two designs t
 Lix can now use a plain directory as a filesystem storage:
 
 ```ts
-import { LocalFilesystem, openLix } from "@lix-js/sdk";
+import { openLix } from "@lix-js/sdk";
+import { FilesystemStorage } from "@lix-js/storage-filesystem";
 
 const lix = await openLix({
-  storage: new LocalFilesystem({
-    path: "./workspace",
-    syncAllFiles: true,
-  }),
+	storage: new FilesystemStorage({ path: "./repository" }),
 });
 ```
 

--- a/docs/js-api-reference.md
+++ b/docs/js-api-reference.md
@@ -4,7 +4,10 @@ description: "Reference for opening local and remote Lix instances, running SQL,
 
 # JavaScript API Reference
 
-The main JavaScript SDK exports are `openLix()`, `IndexedDbStorage`, and `LocalFilesystem` from `@lix-js/sdk`. `openLix()` returns a `Lix` instance connected to a local or remote repository.
+The main JavaScript SDK exports `openLix()` and `IndexedDbStorage` from
+`@lix-js/sdk`. Filesystem storage is provided separately by
+`@lix-js/storage-filesystem`. `openLix()` returns a `Lix` instance connected to
+a local or remote repository.
 
 ```ts
 import { openLix } from "@lix-js/sdk";
@@ -22,7 +25,7 @@ Options:
 
 | Option      | Type                                  | Description                                                                         |
 | ----------- | ------------------------------------- | ----------------------------------------------------------------------------------- |
-| `storage`   | `LocalFilesystem \| IndexedDbStorage` | Local storage. Omit it for memory.                                                  |
+| `storage`   | `FilesystemStorage \| IndexedDbStorage` | Local storage. Omit it for memory.                                                  |
 | `server`    | `RemoteLixServerOptions`              | Connect to a remote Lix server. When present, `storage` contains only client state. |
 | `telemetry` | `LixTelemetryOptions`                 | Optional `onSpan(span)` callback that receives telemetry spans. Local mode only.    |
 
@@ -50,29 +53,27 @@ const lix = await openLix({
 });
 ```
 
-Use `LocalFilesystem` for a repository directory backed by RocksDB at
+Use `FilesystemStorage` for a repository directory backed by RocksDB at
 `<repository>/.lix/.internal/rocksdb`:
 
 ```ts
-import { LocalFilesystem, openLix } from "@lix-js/sdk";
+import { openLix } from "@lix-js/sdk";
+import { FilesystemStorage } from "@lix-js/storage-filesystem";
 
 const lix = await openLix({
-  storage: new LocalFilesystem({
-    path: "./repository",
-  }),
+  storage: new FilesystemStorage({ path: "./repository" }),
 });
 ```
 
-Pass `lixDir` for filesystem sync with repository metadata in an external
-`.lix` directory. This does not write `<repository>/.lix`:
+Use selective synchronization when only explicit paths should be imported:
 
 ```ts
-const lix = await openLix({
-  storage: new LocalFilesystem({
-    path: "./repository",
-    lixDir: "/tmp/session/.lix",
-  }),
+const storage = new FilesystemStorage({
+  path: "./repository",
+  syncAllFiles: false,
 });
+const lix = await openLix({ storage });
+await storage.importPaths(["notes/today.md"]);
 ```
 
 Call `storage.syncDiskToLix()` to run one manual sync pass that imports pending

--- a/docs/lix-for-ai-agents.md
+++ b/docs/lix-for-ai-agents.md
@@ -6,7 +6,7 @@ description: Give each agent an isolated branch, preview its changes, then merge
 
 Agents make fast, useful, and sometimes wrong changes. Lix gives each agent task its own branch so a human or policy can review the work before it reaches main.
 
-Agents can work through normal files with `LocalFilesystem`, through SQL, or through a hosted Lix server. All writes stay isolated on the task branch.
+Agents can work through normal files with `FilesystemStorage`, through SQL, or through a hosted Lix server. All writes stay isolated on the task branch.
 
 ## The pattern
 
@@ -41,7 +41,7 @@ if (preview.conflicts.length === 0) {
 
 ## Local file repository
 
-Use `LocalFilesystem` when the agent works with files on disk. See
+Use `FilesystemStorage` when the agent works with files on disk. See
 [Persistence and Storage](./persistence.md#local-filesystem) for setup.
 
 ## Hosted repository

--- a/docs/persistence.md
+++ b/docs/persistence.md
@@ -12,12 +12,12 @@ Lix has pluggable storage. A storage adapter decides where the bytes live. The L
 | ------------------ | ---------------- | ---------------------------------------------- |
 | `Memory` (default) | JavaScript, Rust | tests, demos, and ephemeral work               |
 | `IndexedDbStorage` | JavaScript       | persistent local browser repositories          |
-| `LocalFilesystem`  | JavaScript, Rust | a local directory synchronized with Lix        |
+| `FilesystemStorage`  | JavaScript, Rust | a local directory synchronized with Lix        |
 | `RocksDB`          | Rust             | native embedded persistence                    |
 | `SlateDB`          | Rust             | object storage, for example S3                 |
 | Remote server      | any client       | shared repositories; the server owns persistence |
 
-In JavaScript, `LocalFilesystem` requires Node.js. The default `Memory` storage and `IndexedDbStorage` work in browsers.
+In JavaScript, `FilesystemStorage` requires Node.js. The default `Memory` storage and `IndexedDbStorage` work in browsers.
 
 ## In-memory (default)
 
@@ -33,15 +33,14 @@ await lix.close();
 
 ## Local filesystem
 
-Persist a directory as a Lix repository with `LocalFilesystem`:
+Persist a directory as a Lix repository with `FilesystemStorage`:
 
 ```ts
-import { LocalFilesystem, openLix } from "@lix-js/sdk";
+import { openLix } from "@lix-js/sdk";
+import { FilesystemStorage } from "@lix-js/storage-filesystem";
 
 const lix = await openLix({
-  storage: new LocalFilesystem({
-    path: "/var/data/repository",
-  }),
+  storage: new FilesystemStorage({ path: "/var/data/repository" }),
 });
 ```
 
@@ -52,9 +51,9 @@ repository:
 
 ```rust
 use lix::open_lix;
-use lix_storage_filesystem::LocalFilesystem;
+use lix_storage_filesystem::FilesystemStorage;
 
-let storage = LocalFilesystem::open("./repository")?;
+let storage = FilesystemStorage::new("./repository").open()?;
 let lix = open_lix().with_storage(storage.clone()).await?;
 let sync = storage.start_sync(&lix).await?;
 
@@ -65,9 +64,8 @@ Keep `sync` alive while filesystem synchronization should run. It owns a
 separate session on the existing Lix repository; the storage adapter does not
 open or configure the Lix engine.
 
-One option changes this behavior:
-
-- `lixDir` stores the repository state outside the repository. The repository does not receive a `.lix` directory.
+Pass `syncAllFiles: false` to begin with no regular repository files and import
+selected paths with `storage.importPaths(paths)`.
 
 ## IndexedDB
 

--- a/docs/what-is-lix.md
+++ b/docs/what-is-lix.md
@@ -35,7 +35,7 @@ File plugins map parts of a file to rows. A row can represent a Markdown block, 
 <img src="../website/public/assets/file-to-rows.svg" alt="A plugin maps /orders.csv to SQL rows with entity, field, and value columns" width="760" />
 
 Apps read and write these rows with SQL. Lix records their history. With
-`LocalFilesystem`, it also writes changes back to normal files on disk.
+`FilesystemStorage`, it also writes changes back to normal files on disk.
 
 Diffs are semantic: review the clause, cell, or row that changed, not lines of text. See [Semantic Changes](./semantic-changes.md).
 

--- a/packages/e2e/tests/e2e.rs
+++ b/packages/e2e/tests/e2e.rs
@@ -27,7 +27,7 @@ use lix::{
     MergeBranchPreviewOptions, MergeConflictChangeKind, SwitchBranchOptions,
 };
 use lix::{Value, open_lix};
-use lix_storage_filesystem::{LocalFilesystem, LocalFilesystemSync};
+use lix_storage_filesystem::{FilesystemStorage, FilesystemStorageSync};
 use lix_storage_rocksdb::RocksDB;
 use lix_storage_slatedb::SlateDB;
 use sha2::{Digest as _, Sha256};
@@ -6166,8 +6166,9 @@ async fn v2_csv_ids_survive_insert_edit_reorder_delete_eviction_and_cold_reopen(
 #[tokio::test]
 async fn v2_csv_exact_read_replaces_a_stale_actor_after_an_independent_engine_commit() {
     let tempdir = tempfile::tempdir().unwrap();
-    let storage_a =
-        LocalFilesystem::open(tempdir.path()).expect("first shared filesystem storage opens");
+    let storage_a = FilesystemStorage::new(tempdir.path())
+        .open()
+        .expect("first shared filesystem storage opens");
     let lix_a = open_lix()
         .with_storage(storage_a.clone())
         .await
@@ -6191,8 +6192,9 @@ async fn v2_csv_exact_read_replaces_a_stale_actor_after_an_independent_engine_co
 
     // A separately opened Lix owns a distinct plugin runtime/actor cache while
     // sharing the same durable RocksDB-backed workspace.
-    let storage_b =
-        LocalFilesystem::open(tempdir.path()).expect("second shared filesystem storage opens");
+    let storage_b = FilesystemStorage::new(tempdir.path())
+        .open()
+        .expect("second shared filesystem storage opens");
     let lix_b = open_lix()
         .with_storage(storage_b.clone())
         .await
@@ -6888,12 +6890,12 @@ fn csv_row_id(rows: &[CsvV2Row], cells: &[&str]) -> String {
 }
 
 struct SyncedFilesystemLix {
-    lix: Lix<LocalFilesystem>,
-    _sync: LocalFilesystemSync,
+    lix: Lix<FilesystemStorage>,
+    _sync: FilesystemStorageSync,
 }
 
 impl Deref for SyncedFilesystemLix {
-    type Target = Lix<LocalFilesystem>;
+    type Target = Lix<FilesystemStorage>;
 
     fn deref(&self) -> &Self::Target {
         &self.lix
@@ -6901,7 +6903,7 @@ impl Deref for SyncedFilesystemLix {
 }
 
 async fn open_filesystem_lix(path: &Path) -> SyncedFilesystemLix {
-    let storage = LocalFilesystem::open(path).unwrap();
+    let storage = FilesystemStorage::new(path).open().unwrap();
     let lix = open_lix().with_storage(storage.clone()).await.unwrap();
     let sync = storage.start_sync(&lix).await.unwrap();
     SyncedFilesystemLix { lix, _sync: sync }

--- a/packages/e2e/tests/rust_sdk_api.rs
+++ b/packages/e2e/tests/rust_sdk_api.rs
@@ -4,7 +4,7 @@ use lix::{
     CreateBranchOptions, ExecuteBatchStatement, Lix, LixError, Memory, MergeBranchOptions,
     MergeBranchOutcome, SwitchBranchOptions, Value, open_lix,
 };
-use lix_storage_filesystem::{LocalFilesystem, LocalFilesystemOpenOptions, LocalFilesystemSync};
+use lix_storage_filesystem::{FilesystemStorage, FilesystemStorageSync};
 use std::ops::Deref;
 use std::path::Path;
 use std::sync::{Arc, Mutex};
@@ -728,12 +728,12 @@ async fn filesystem_initialization_wipes_legacy_root_sqlite_and_system_metadata(
 }
 
 struct SyncedFilesystemLix {
-    lix: Lix<LocalFilesystem>,
-    _sync: LocalFilesystemSync,
+    lix: Lix<FilesystemStorage>,
+    _sync: FilesystemStorageSync,
 }
 
 impl Deref for SyncedFilesystemLix {
-    type Target = Lix<LocalFilesystem>;
+    type Target = Lix<FilesystemStorage>;
 
     fn deref(&self) -> &Self::Target {
         &self.lix
@@ -741,15 +741,17 @@ impl Deref for SyncedFilesystemLix {
 }
 
 async fn open_filesystem_lix(path: &Path) -> SyncedFilesystemLix {
-    let storage = LocalFilesystem::open(path).unwrap();
+    let storage = FilesystemStorage::new(path).open().unwrap();
     let lix = open_lix().with_storage(storage.clone()).await.unwrap();
     let sync = storage.start_sync(&lix).await.unwrap();
     SyncedFilesystemLix { lix, _sync: sync }
 }
 
 async fn open_on_demand_filesystem_lix(path: &Path, file_paths: &[&str]) -> SyncedFilesystemLix {
-    let options = LocalFilesystemOpenOptions::new(path.to_path_buf(), false);
-    let storage = LocalFilesystem::open_with_options(options).unwrap();
+    let storage = FilesystemStorage::new(path)
+        .sync_all_files(false)
+        .open()
+        .unwrap();
     let lix = open_lix().with_storage(storage.clone()).await.unwrap();
     let sync = storage.start_sync(&lix).await.unwrap();
     sync.import_paths(file_paths.iter().copied()).await.unwrap();
@@ -759,8 +761,11 @@ async fn open_on_demand_filesystem_lix(path: &Path, file_paths: &[&str]) -> Sync
 #[tokio::test]
 async fn rocksdb_filesystem_storage_allows_same_process_multi_open() {
     let tempdir = tempfile::tempdir().unwrap();
-    let storage_a = LocalFilesystem::open(tempdir.path()).expect("first rocksdb fs storage opens");
-    let storage_b = LocalFilesystem::open(tempdir.path())
+    let storage_a = FilesystemStorage::new(tempdir.path())
+        .open()
+        .expect("first rocksdb fs storage opens");
+    let storage_b = FilesystemStorage::new(tempdir.path())
+        .open()
         .expect("second rocksdb fs storage reuses process-local DB");
     let lix_a = open_lix()
         .with_storage(storage_a.clone())
@@ -1289,7 +1294,7 @@ async fn filesystem_rejects_symlink_root() {
     std::fs::create_dir(tempdir.path().join("real-root")).unwrap();
     symlink("real-root", tempdir.path().join("linked-root")).unwrap();
 
-    let Err(error) = LocalFilesystem::open(tempdir.path().join("linked-root")) else {
+    let Err(error) = FilesystemStorage::new(tempdir.path().join("linked-root")).open() else {
         panic!("symlink root should fail");
     };
 
@@ -1535,7 +1540,7 @@ fn wait_for_disk_file_with_timeout(path: &Path, expected: Option<&[u8]>, timeout
     }
 }
 
-async fn wait_for_lix_file(lix: &Lix<LocalFilesystem>, path: &str, expected: Option<&[u8]>) {
+async fn wait_for_lix_file(lix: &Lix<FilesystemStorage>, path: &str, expected: Option<&[u8]>) {
     let deadline = Instant::now() + Duration::from_secs(5);
     loop {
         let actual = read_file(lix, path).await.unwrap();
@@ -1550,7 +1555,7 @@ async fn wait_for_lix_file(lix: &Lix<LocalFilesystem>, path: &str, expected: Opt
     }
 }
 
-async fn wait_for_lix_directory(lix: &Lix<LocalFilesystem>, path: &str, expected: bool) {
+async fn wait_for_lix_directory(lix: &Lix<FilesystemStorage>, path: &str, expected: bool) {
     let deadline = Instant::now() + Duration::from_secs(10);
     loop {
         let actual = readdir(lix, path).await.unwrap().is_some();

--- a/packages/js-sdk/README.md
+++ b/packages/js-sdk/README.md
@@ -86,13 +86,11 @@ without publishing it to the live client-state facade.
 Filesystem sync uses native Node.js dependencies:
 
 ```ts
-import { LocalFilesystem, openLix } from "@lix-js/sdk";
+import { openLix } from "@lix-js/sdk";
+import { FilesystemStorage } from "@lix-js/storage-filesystem";
 
 const lix = await openLix({
-  storage: new LocalFilesystem({
-    path: "./repository",
-    syncAllFiles: true,
-  }),
+  storage: new FilesystemStorage({ path: "./repository" }),
 });
 
 await lix.execute(
@@ -168,15 +166,14 @@ try {
 
 ## Notes
 
-- `openLix()` opens a fresh in-memory Lix. Pass `new LocalFilesystem({ path, syncAllFiles: true })` for a filesystem repository directory backed by `<path>/.lix/.internal/rocksdb`.
+- `openLix()` opens a fresh in-memory Lix. Install `@lix-js/storage-filesystem` and pass `new FilesystemStorage({ path })` for a filesystem repository directory backed by `<path>/.lix/.internal/rocksdb`.
 - In browsers, pass `new IndexedDbStorage({ name })` to persist a complete local Lix across reloads.
 - Only one Lix handle may open an IndexedDB storage name at a time, including across browser tabs.
-- Pass `new LocalFilesystem({ path, lixDir, syncAllFiles: true })` for filesystem sync with repository metadata in an external `.lix` directory and no repository `.lix` directory.
-- Pass `syncAllFiles: false` to start filesystem sync with no regular repository files, then call `storage.importPaths(["notes/today.md"])` on the `LocalFilesystem` instance to sync selected files. Imported paths are exact repository-relative file paths, not directories or globs.
+- Pass `syncAllFiles: false` to start filesystem sync with no regular repository files, then call `storage.importPaths(["notes/today.md"])` on the `FilesystemStorage` instance to sync selected files. Imported paths are exact repository-relative file paths, not directories or globs.
 - In browsers, local mode and remote mode with IndexedDB storage load the Rust
   engine as WebAssembly. In remote mode, the local engine contains only client
   state.
-- `LocalFilesystem` is Node.js-only. Constructing it is safe in
+- `FilesystemStorage` is Node.js-only. Constructing it is safe in
   shared code, but passing one to `openLix()` in a browser throws an error.
 - The package is ESM-only.
 - The package uses conditional ESM imports internally: Node.js resolves the

--- a/packages/js-sdk/native/napi.rs
+++ b/packages/js-sdk/native/napi.rs
@@ -9,7 +9,7 @@ use lix::{
     ObserveEvents as RsObserveEvents, RedoReceipt, SwitchBranchOptions as RsSwitchBranchOptions,
     SwitchBranchReceipt, UndoReceipt, Value, open_lix,
 };
-use lix_storage_filesystem::{LocalFilesystem, LocalFilesystemOpenOptions, LocalFilesystemSync};
+use lix_storage_filesystem::{FilesystemStorage, FilesystemStorageSync};
 use napi::JsDeferred;
 use napi::bindgen_prelude::*;
 use napi::threadsafe_function::{ThreadsafeFunction, ThreadsafeFunctionCallMode};
@@ -48,17 +48,17 @@ pub struct NativeLix {
 
 enum NativeLixInner {
     Memory(RsLix<Memory>),
-    LocalFilesystem(RsLix<LocalFilesystem>, LocalFilesystemSync),
+    FilesystemStorage(RsLix<FilesystemStorage>, FilesystemStorageSync),
 }
 
 enum NativeLixTransactionInner {
     Memory(RsLixTransaction<Memory>),
-    LocalFilesystem(RsLixTransaction<LocalFilesystem>),
+    FilesystemStorage(RsLixTransaction<FilesystemStorage>),
 }
 
 enum NativeObserveEventsInner {
     Memory(RsObserveEvents<Memory>),
-    LocalFilesystem(RsObserveEvents<LocalFilesystem>),
+    FilesystemStorage(RsObserveEvents<FilesystemStorage>),
 }
 
 #[napi(object)]
@@ -575,7 +575,7 @@ impl NativeLixInner {
                     None => execution.await,
                 }
             }
-            Self::LocalFilesystem(lix, _) => {
+            Self::FilesystemStorage(lix, _) => {
                 let execution = lix.execute(sql, params);
                 match options {
                     Some(origin_key) => execution.with_origin_key(origin_key).await,
@@ -598,7 +598,7 @@ impl NativeLixInner {
                     None => execution.await,
                 }
             }
-            Self::LocalFilesystem(lix, _) => {
+            Self::FilesystemStorage(lix, _) => {
                 let execution = lix.execute_batch(statements);
                 match options {
                     Some(origin_key) => execution.with_origin_key(origin_key).await,
@@ -613,7 +613,7 @@ impl NativeLixInner {
             Self::Memory(lix) => Ok(NativeLixTransactionInner::Memory(
                 lix.begin_transaction().await?,
             )),
-            Self::LocalFilesystem(lix, _) => Ok(NativeLixTransactionInner::LocalFilesystem(
+            Self::FilesystemStorage(lix, _) => Ok(NativeLixTransactionInner::FilesystemStorage(
                 lix.begin_transaction().await?,
             )),
         }
@@ -626,7 +626,7 @@ impl NativeLixInner {
     ) -> std::result::Result<NativeObserveEventsInner, LixError> {
         match self {
             Self::Memory(lix) => Ok(NativeObserveEventsInner::Memory(lix.observe(sql, params)?)),
-            Self::LocalFilesystem(lix, _) => Ok(NativeObserveEventsInner::LocalFilesystem(
+            Self::FilesystemStorage(lix, _) => Ok(NativeObserveEventsInner::FilesystemStorage(
                 lix.observe(sql, params)?,
             )),
         }
@@ -635,14 +635,14 @@ impl NativeLixInner {
     async fn active_branch_id(&self) -> std::result::Result<String, LixError> {
         match self {
             Self::Memory(lix) => lix.active_branch_id().await,
-            Self::LocalFilesystem(lix, _) => lix.active_branch_id().await,
+            Self::FilesystemStorage(lix, _) => lix.active_branch_id().await,
         }
     }
 
     fn active_account_id(&self) -> &str {
         match self {
             Self::Memory(lix) => lix.active_account_id(),
-            Self::LocalFilesystem(lix, _) => lix.active_account_id(),
+            Self::FilesystemStorage(lix, _) => lix.active_account_id(),
         }
     }
 
@@ -652,28 +652,28 @@ impl NativeLixInner {
     ) -> std::result::Result<CreateBranchReceipt, LixError> {
         match self {
             Self::Memory(lix) => lix.create_branch(options).await,
-            Self::LocalFilesystem(lix, _) => lix.create_branch(options).await,
+            Self::FilesystemStorage(lix, _) => lix.create_branch(options).await,
         }
     }
 
     async fn create_checkpoint(&self) -> std::result::Result<CreateCheckpointReceipt, LixError> {
         match self {
             Self::Memory(lix) => lix.create_checkpoint().await,
-            Self::LocalFilesystem(lix, _) => lix.create_checkpoint().await,
+            Self::FilesystemStorage(lix, _) => lix.create_checkpoint().await,
         }
     }
 
     async fn undo(&self) -> std::result::Result<UndoReceipt, LixError> {
         match self {
             Self::Memory(lix) => lix.undo().await,
-            Self::LocalFilesystem(lix, _) => lix.undo().await,
+            Self::FilesystemStorage(lix, _) => lix.undo().await,
         }
     }
 
     async fn redo(&self) -> std::result::Result<RedoReceipt, LixError> {
         match self {
             Self::Memory(lix) => lix.redo().await,
-            Self::LocalFilesystem(lix, _) => lix.redo().await,
+            Self::FilesystemStorage(lix, _) => lix.redo().await,
         }
     }
 
@@ -683,7 +683,7 @@ impl NativeLixInner {
     ) -> std::result::Result<SwitchBranchReceipt, LixError> {
         match self {
             Self::Memory(lix) => lix.switch_branch(options).await,
-            Self::LocalFilesystem(lix, _) => lix.switch_branch(options).await,
+            Self::FilesystemStorage(lix, _) => lix.switch_branch(options).await,
         }
     }
 
@@ -692,7 +692,7 @@ impl NativeLixInner {
         paths: Vec<String>,
     ) -> std::result::Result<(), LixError> {
         match self {
-            Self::LocalFilesystem(_, sync) => sync.import_paths(paths).await,
+            Self::FilesystemStorage(_, sync) => sync.import_paths(paths).await,
             Self::Memory(_) => Err(LixError::new(
                 "LIX_UNSUPPORTED_STORAGE",
                 "importFilesystemPaths requires a filesystem storage",
@@ -706,7 +706,7 @@ impl NativeLixInner {
     ) -> std::result::Result<MergeBranchPreview, LixError> {
         match self {
             Self::Memory(lix) => lix.merge_branch_preview(options).await,
-            Self::LocalFilesystem(lix, _) => lix.merge_branch_preview(options).await,
+            Self::FilesystemStorage(lix, _) => lix.merge_branch_preview(options).await,
         }
     }
 
@@ -716,13 +716,13 @@ impl NativeLixInner {
     ) -> std::result::Result<MergeBranchReceipt, LixError> {
         match self {
             Self::Memory(lix) => lix.merge_branch(options).await,
-            Self::LocalFilesystem(lix, _) => lix.merge_branch(options).await,
+            Self::FilesystemStorage(lix, _) => lix.merge_branch(options).await,
         }
     }
 
     async fn sync_disk_to_lix(&self) -> std::result::Result<(), LixError> {
         match self {
-            Self::LocalFilesystem(_, sync) => sync.sync_disk_to_lix().await,
+            Self::FilesystemStorage(_, sync) => sync.sync_disk_to_lix().await,
             Self::Memory(_) => Err(LixError::new(
                 "LIX_UNSUPPORTED_STORAGE",
                 "syncDiskToLix requires a filesystem storage",
@@ -733,7 +733,7 @@ impl NativeLixInner {
     async fn close(&self) -> std::result::Result<(), LixError> {
         match self {
             Self::Memory(lix) => lix.close().await,
-            Self::LocalFilesystem(lix, _) => lix.close().await,
+            Self::FilesystemStorage(lix, _) => lix.close().await,
         }
     }
 }
@@ -753,7 +753,7 @@ impl NativeLixTransactionInner {
                     None => execution.await,
                 }
             }
-            Self::LocalFilesystem(transaction) => {
+            Self::FilesystemStorage(transaction) => {
                 let execution = transaction.execute(sql, params);
                 match options {
                     Some(origin_key) => execution.with_origin_key(origin_key).await,
@@ -766,14 +766,14 @@ impl NativeLixTransactionInner {
     async fn commit(self) -> std::result::Result<(), LixError> {
         match self {
             Self::Memory(transaction) => transaction.commit().await,
-            Self::LocalFilesystem(transaction) => transaction.commit().await,
+            Self::FilesystemStorage(transaction) => transaction.commit().await,
         }
     }
 
     async fn rollback(self) -> std::result::Result<(), LixError> {
         match self {
             Self::Memory(transaction) => transaction.rollback().await,
-            Self::LocalFilesystem(transaction) => transaction.rollback().await,
+            Self::FilesystemStorage(transaction) => transaction.rollback().await,
         }
     }
 }
@@ -782,22 +782,21 @@ impl NativeObserveEventsInner {
     async fn next(&mut self) -> std::result::Result<Option<RsObserveEvent>, LixError> {
         match self {
             Self::Memory(events) => events.next().await,
-            Self::LocalFilesystem(events) => events.next().await,
+            Self::FilesystemStorage(events) => events.next().await,
         }
     }
 
     fn close(&mut self) {
         match self {
             Self::Memory(events) => events.close(),
-            Self::LocalFilesystem(events) => events.close(),
+            Self::FilesystemStorage(events) => events.close(),
         }
     }
 }
 
 #[expect(missing_debug_implementations)]
-pub struct OpenLocalFilesystemTask {
+pub struct OpenFilesystemStorageTask {
     path: String,
-    lix_dir: Option<String>,
     sync_all_files: bool,
     telemetry_dispatch: Option<SharedJsTelemetryDispatch>,
 }
@@ -807,14 +806,13 @@ pub struct OpenMemoryTask {
     telemetry_dispatch: Option<SharedJsTelemetryDispatch>,
 }
 
-impl Task for OpenLocalFilesystemTask {
+impl Task for OpenFilesystemStorageTask {
     type Output = std::result::Result<NativeLix, LixError>;
     type JsValue = NativeLix;
 
     fn compute(&mut self) -> Result<Self::Output> {
-        Ok(open_local_filesystem_native(
+        Ok(open_filesystem_storage_native(
             std::mem::take(&mut self.path),
-            self.lix_dir.take(),
             self.sync_all_files,
             self.telemetry_dispatch.take(),
         ))
@@ -862,9 +860,8 @@ fn open_memory_native(
     NativeLix::new(NativeLixInner::Memory(lix))
 }
 
-fn open_local_filesystem_native(
+fn open_filesystem_storage_native(
     path: String,
-    lix_dir: Option<String>,
     sync_all_files: bool,
     telemetry_dispatch: Option<SharedJsTelemetryDispatch>,
 ) -> std::result::Result<NativeLix, LixError> {
@@ -872,9 +869,9 @@ fn open_local_filesystem_native(
         .enable_all()
         .build()
         .map_err(|error| LixError::unknown(format!("failed to create tokio runtime: {error}")))?;
-    let mut options = LocalFilesystemOpenOptions::new(path, sync_all_files);
-    options.lix_dir = lix_dir.map(Into::into);
-    let storage = LocalFilesystem::open_with_options(options)?;
+    let storage = FilesystemStorage::new(path)
+        .sync_all_files(sync_all_files)
+        .open()?;
     let lix = match telemetry_dispatch.map(telemetry_sink) {
         Some(telemetry) => rt.block_on(async {
             open_lix()
@@ -885,7 +882,7 @@ fn open_local_filesystem_native(
         None => rt.block_on(async { open_lix().with_storage(storage.clone()).await })?,
     };
     let sync = rt.block_on(storage.start_sync(&lix))?;
-    NativeLix::new(NativeLixInner::LocalFilesystem(lix, sync))
+    NativeLix::new(NativeLixInner::FilesystemStorage(lix, sync))
 }
 
 #[napi]
@@ -899,16 +896,14 @@ impl NativeLix {
         }))
     }
 
-    #[napi(js_name = "openLocalFilesystem")]
-    pub fn open_local_filesystem(
+    #[napi(js_name = "openFilesystemStorage")]
+    pub fn open_filesystem_storage(
         path: String,
-        lix_dir: Option<String>,
         sync_all_files: bool,
         telemetry_dispatch: Option<Function<'_, String, ()>>,
-    ) -> Result<AsyncTask<OpenLocalFilesystemTask>> {
-        Ok(AsyncTask::new(OpenLocalFilesystemTask {
+    ) -> Result<AsyncTask<OpenFilesystemStorageTask>> {
+        Ok(AsyncTask::new(OpenFilesystemStorageTask {
             path,
-            lix_dir,
             sync_all_files,
             telemetry_dispatch: optional_telemetry_dispatch(telemetry_dispatch)?,
         }))

--- a/packages/js-sdk/src/binding-types.ts
+++ b/packages/js-sdk/src/binding-types.ts
@@ -15,6 +15,7 @@ import type {
 	JsonValue,
 } from "./types.js";
 import type { NativeLixValue } from "./value.js";
+import type { LixStorageAdapterConfig } from "./storage-adapter.js";
 
 export type BindingExecuteResult = {
 	statementIndex?: number;
@@ -94,9 +95,4 @@ export type TelemetryDispatch = (span: LixTelemetrySpan) => void;
 export type LixStorageConfig =
 	| { kind: "memory" }
 	| { kind: "indexedDb"; name: string }
-	| {
-			kind: "localFilesystem";
-			path: string;
-			lixDir?: string;
-			syncAllFiles: boolean;
-	  };
+	| LixStorageAdapterConfig;

--- a/packages/js-sdk/src/binding.browser.ts
+++ b/packages/js-sdk/src/binding.browser.ts
@@ -32,7 +32,7 @@ export async function openLixBinding(
 				throw error;
 			}
 		}
-		case "localFilesystem":
-			throw new Error("LocalFilesystem is only available in Node.js");
+		case "filesystem":
+			throw new Error("FilesystemStorage is only available in Node.js");
 	}
 }

--- a/packages/js-sdk/src/binding.node.ts
+++ b/packages/js-sdk/src/binding.node.ts
@@ -12,9 +12,8 @@ type NativeAddon = {
 		openMemory(
 			telemetry?: (spanJson: string) => void,
 		): Promise<LixBinding>;
-		openLocalFilesystem(
+		openFilesystemStorage(
 			path: string,
-			lixDir: string | undefined,
 			syncAllFiles: boolean,
 			telemetry?: (spanJson: string) => void,
 		): Promise<LixBinding>;
@@ -78,18 +77,16 @@ export function openLixBinding(
 			return addon.Lix.openMemory();
 		case "indexedDb":
 			throw new Error("IndexedDbStorage is only available in browsers");
-		case "localFilesystem":
+		case "filesystem":
 			if (nativeTelemetry) {
-				return addon.Lix.openLocalFilesystem(
+				return addon.Lix.openFilesystemStorage(
 					storage.path,
-					storage.lixDir,
 					storage.syncAllFiles,
 					nativeTelemetry,
 				);
 			}
-			return addon.Lix.openLocalFilesystem(
+			return addon.Lix.openFilesystemStorage(
 				storage.path,
-				storage.lixDir,
 				storage.syncAllFiles,
 			);
 	}

--- a/packages/js-sdk/src/errors.ts
+++ b/packages/js-sdk/src/errors.ts
@@ -36,22 +36,3 @@ export function invalidParam(
 	};
 	return error;
 }
-
-export function localFilesystemNotOpen(operation: string): LixJsError {
-	const error = new Error(
-		`LocalFilesystem.${operation}() requires the storage to be opened with openLix() first`,
-	) as LixJsError;
-	error.name = "LixError";
-	error.code = "LIX_LOCAL_FILESYSTEM_NOT_OPEN";
-	error.details = { operation };
-	return error;
-}
-
-export function localFilesystemAlreadyOpen(): LixJsError {
-	const error = new Error(
-		"openLix() LocalFilesystem is already open; close the existing Lix or create a new LocalFilesystem",
-	) as LixJsError;
-	error.name = "LixError";
-	error.code = "LIX_LOCAL_FILESYSTEM_IN_USE";
-	return error;
-}

--- a/packages/js-sdk/src/index.ts
+++ b/packages/js-sdk/src/index.ts
@@ -1,11 +1,15 @@
 export {
-	LocalFilesystem,
 	IndexedDbStorage,
 	Lix,
 	LixTransaction,
 	ObserveEvents,
 	openLix,
 } from "./open-lix.js";
+export type {
+	LixStorage,
+	LixStorageAdapterConfig,
+	LixStorageConnection,
+} from "./storage-adapter.js";
 export {
 	bundledPluginArchives,
 	type BundledPluginArchive,
@@ -22,7 +26,6 @@ export type {
 	ExecuteResult,
 	LixBatchOptions,
 	LixBatchStatement,
-	LocalFilesystemOptions,
 	IndexedDbStorageOptions,
 	JsonValue,
 	LixValue,

--- a/packages/js-sdk/src/open-lix.test.ts
+++ b/packages/js-sdk/src/open-lix.test.ts
@@ -15,13 +15,13 @@ import { promisify } from "node:util";
 import { expect, test } from "vitest";
 import {
 	bundledPluginArchives,
-	LocalFilesystem,
 	openLix,
 	Value,
 	type ExecuteResult,
 	type Lix,
 	type LixTelemetrySpan,
 } from "./index.js";
+import { FilesystemStorage } from "../../storage-filesystem/dist/index.js";
 import { registerMemoryStorageContract } from "../tests/memory-storage-contract.js";
 
 const NATIVE_DRAFT_BRANCH_ID = "01920000-0000-7000-8000-000000000401";
@@ -36,6 +36,12 @@ registerMemoryStorageContract({
 test("SQLite is not part of the JavaScript SDK export surface", async () => {
 	const sdk = await import("./index.js");
 	expect("SQLite" in sdk).toBe(false);
+});
+
+test("filesystem storage is owned by its adapter package", async () => {
+	const sdk = await import("./index.js");
+	expect("FilesystemStorage" in sdk).toBe(false);
+	expect("LocalFilesystem" in sdk).toBe(false);
 });
 
 test("openLix forwards opt-in SQL telemetry from the engine", async () => {
@@ -333,7 +339,7 @@ test.each([
 		"fs",
 		() =>
 			openLix({
-				storage: new LocalFilesystem({
+				storage: new FilesystemStorage({
 					path: tempFsDir(),
 					syncAllFiles: true,
 				}),
@@ -346,9 +352,8 @@ test.each([
 			mkdirSync(dir, { recursive: true });
 			writeFileSync(join(dir, "matrix.md"), "matrix");
 			return openLix({
-				storage: new LocalFilesystem({
+				storage: new FilesystemStorage({
 					path: dir,
-					lixDir: tempExternalLixDir(),
 					syncAllFiles: true,
 				}),
 			});
@@ -446,7 +451,7 @@ test("fs storage imports local files and materializes lix_file writes", async ()
 	writeFileSync(join(dir, "docs", "readme.md"), "local");
 
 	const lix = await openLix({
-		storage: new LocalFilesystem({ path: dir, syncAllFiles: true }),
+		storage: new FilesystemStorage({ path: dir, syncAllFiles: true }),
 	});
 	expect(statSync(join(dir, ".lix")).isDirectory()).toBe(true);
 	expect(
@@ -470,7 +475,7 @@ test("fs storage imports local files and materializes lix_file writes", async ()
 	await lix.close();
 
 	const reopened = await openLix({
-		storage: new LocalFilesystem({ path: dir, syncAllFiles: true }),
+		storage: new FilesystemStorage({ path: dir, syncAllFiles: true }),
 	});
 	const persisted = await reopened.execute(
 		"SELECT content FROM lix_file WHERE directory_id IS NULL AND name = $1",
@@ -578,57 +583,6 @@ test("executeBatch propagates originKey to every write", async () => {
 	await lix.close();
 });
 
-test("fs storage with external lixDir imports the directory and writes normal files back", async () => {
-	const dir = tempFsDir();
-	const filePath = join(dir, "note.md");
-	const siblingPath = join(dir, "sibling.md");
-	mkdirSync(dir, { recursive: true });
-	writeFileSync(filePath, "local");
-	writeFileSync(siblingPath, "sibling");
-
-	const lix = await openLix({
-		storage: new LocalFilesystem({
-			path: dir,
-			lixDir: tempExternalLixDir(),
-			syncAllFiles: true,
-		}),
-	});
-
-	const files = await lix.execute(
-		"SELECT path, content FROM lix_file WHERE path IN ($1, $2) ORDER BY path",
-		["/note.md", "/sibling.md"],
-	);
-	expect(files.rows.map((row) => row.get("path"))).toEqual([
-		"/note.md",
-		"/sibling.md",
-	]);
-	expect(new TextDecoder().decode(get(files, "content") as Uint8Array)).toBe(
-		"local",
-	);
-	expect(existsSync(join(dir, ".lix"))).toBe(false);
-
-	await lix.execute("UPDATE lix_file SET content = $1 WHERE path = $2", [
-		new TextEncoder().encode("updated"),
-		"/note.md",
-	]);
-	expect(readFileSync(filePath, "utf8")).toBe("updated");
-	expect(readFileSync(siblingPath, "utf8")).toBe("sibling");
-
-	await lix.execute("INSERT INTO lix_file (path, content) VALUES ($1, $2)", [
-		"/generated.md",
-		new TextEncoder().encode("generated"),
-	]);
-	expect(readFileSync(join(dir, "generated.md"), "utf8")).toBe("generated");
-	expect(existsSync(join(dir, ".lix"))).toBe(false);
-
-	writeFileSync(filePath, "external");
-	await waitFor(async () => {
-		const bytes = await readFile(lix, "/note.md");
-		return bytes ? new TextDecoder().decode(bytes) : undefined;
-	}, "external");
-
-	await lix.close();
-});
 
 test("fs storage on-demand sync imports selected paths and lix-created files", async () => {
 	const dir = tempFsDir();
@@ -639,9 +593,8 @@ test("fs storage on-demand sync imports selected paths and lix-created files", a
 	writeFileSync(includedPath, "included");
 	writeFileSync(excludedPath, "excluded");
 
-	const storage = new LocalFilesystem({
+	const storage = new FilesystemStorage({
 		path: dir,
-		lixDir: tempExternalLixDir(),
 		syncAllFiles: false,
 	});
 	const lix = await openLix({ storage });
@@ -684,9 +637,8 @@ test("fs storage imports existing files into a filtered filesystem", async () =>
 	mkdirSync(join(dir, "docs"), { recursive: true });
 	writeFileSync(importedPath, "opened");
 
-	const storage = new LocalFilesystem({
+	const storage = new FilesystemStorage({
 		path: dir,
-		lixDir: tempExternalLixDir(),
 		syncAllFiles: false,
 	});
 	const lix = await openLix({ storage });
@@ -708,18 +660,17 @@ test("fs storage imports existing files into a filtered filesystem", async () =>
 });
 
 test("importPaths validates paths and requires an opened storage", async () => {
-	const unopened = new LocalFilesystem({
+	const unopened = new FilesystemStorage({
 		path: tempFsDir(),
 		syncAllFiles: false,
 	});
 	await expect(unopened.importPaths(["note.md"])).rejects.toThrow(
-		"opened with openLix()",
+		"requires an open Lix",
 	);
 
 	const dir = tempFsDir();
-	const storage = new LocalFilesystem({
+	const storage = new FilesystemStorage({
 		path: dir,
-		lixDir: tempExternalLixDir(),
 		syncAllFiles: false,
 	});
 	const lix = await openLix({ storage });
@@ -729,7 +680,7 @@ test("importPaths validates paths and requires an opened storage", async () => {
 	);
 	await lix.close();
 	await expect(storage.importPaths(["note.md"])).rejects.toThrow(
-		"opened with openLix()",
+		"requires an open Lix",
 	);
 });
 
@@ -737,9 +688,8 @@ test("fs storage imports files through installed WASM plugins", async () => {
 	const dir = tempFsDir();
 	mkdirSync(dir, { recursive: true });
 	writeFileSync(join(dir, "note.md"), "# Imported\n");
-	const storage = new LocalFilesystem({
+	const storage = new FilesystemStorage({
 		path: dir,
-		lixDir: tempExternalLixDir(),
 		syncAllFiles: false,
 	});
 	const lix = await openLix({ storage });
@@ -770,7 +720,7 @@ test("fs storage binds to one open lix at a time", async () => {
 	mkdirSync(dir, { recursive: true });
 	writeFileSync(join(dir, "note.md"), "note");
 
-	const storage = new LocalFilesystem({ path: dir, syncAllFiles: true });
+	const storage = new FilesystemStorage({ path: dir, syncAllFiles: true });
 	const lix = await openLix({ storage });
 	await expect(openLix({ storage })).rejects.toThrow("already open");
 
@@ -782,34 +732,31 @@ test("fs storage binds to one open lix at a time", async () => {
 	await reopened.close();
 });
 
-test("fs storage syncAllFiles validates option shape", () => {
+test("fs storage defaults match FilesystemStorage::new(path)", () => {
 	const dir = tempFsDir();
 	mkdirSync(dir, { recursive: true });
 
-	expect(() => new LocalFilesystem({ path: dir } as never)).toThrow(
-		"LocalFilesystem syncAllFiles must be a boolean",
-	);
-	expect(() => new LocalFilesystem({ path: dir, syncAllFiles: true })).not.toThrow();
-	expect(() => new LocalFilesystem({ path: dir, syncAllFiles: false })).not.toThrow();
+	expect(new FilesystemStorage({ path: dir }).syncAllFiles).toBe(true);
+	expect(
+		() => new FilesystemStorage({ path: dir, syncAllFiles: false }),
+	).not.toThrow();
 	expect(
 		() =>
-			new LocalFilesystem({
+			new FilesystemStorage({
 				path: dir,
 				syncAllFiles: {} as boolean,
 			}),
-	).toThrow("LocalFilesystem syncAllFiles must be a boolean");
+	).toThrow("FilesystemStorage syncAllFiles must be a boolean");
 });
 
 test("fs storage on-demand sync imports no regular repository files initially", async () => {
 	const dir = tempFsDir();
-	const lixDir = tempExternalLixDir();
 	mkdirSync(dir, { recursive: true });
 	writeFileSync(join(dir, "note.md"), "excluded");
 
 	const lix = await openLix({
-		storage: new LocalFilesystem({
+		storage: new FilesystemStorage({
 			path: dir,
-			lixDir,
 			syncAllFiles: false,
 		}),
 	});
@@ -820,7 +767,7 @@ test("fs storage on-demand sync imports no regular repository files initially", 
 		"/.lix/app_data/test.bin",
 		new TextEncoder().encode("internal"),
 	);
-	expect(readFileSync(join(lixDir, "app_data", "test.bin"), "utf8")).toBe(
+	expect(readFileSync(join(dir, ".lix", "app_data", "test.bin"), "utf8")).toBe(
 		"internal",
 	);
 	expect(existsSync(join(dir, "note.md"))).toBe(true);
@@ -834,9 +781,8 @@ test("fs storage on-demand sync treats paths as exact filenames", async () => {
 	mkdirSync(dir, { recursive: true });
 	writeFileSync(filePath, "literal whitespace");
 
-	const storage = new LocalFilesystem({
+	const storage = new FilesystemStorage({
 		path: dir,
-		lixDir: tempExternalLixDir(),
 		syncAllFiles: false,
 	});
 	const lix = await openLix({ storage });
@@ -854,9 +800,8 @@ test("fs storage on-demand sync does not create directories for missing imports"
 	const dir = tempFsDir();
 	mkdirSync(dir, { recursive: true });
 
-	const storage = new LocalFilesystem({
+	const storage = new FilesystemStorage({
 		path: dir,
-		lixDir: tempExternalLixDir(),
 		syncAllFiles: false,
 	});
 	const lix = await openLix({ storage });
@@ -878,9 +823,8 @@ test("fs storage on-demand sync propagates deletion of imported files", async ()
 	mkdirSync(dir, { recursive: true });
 	writeFileSync(filePath, "local");
 
-	const storage = new LocalFilesystem({
+	const storage = new FilesystemStorage({
 		path: dir,
-		lixDir: tempExternalLixDir(),
 		syncAllFiles: false,
 	});
 	const lix = await openLix({ storage });
@@ -900,9 +844,8 @@ test("fs storage on-demand sync does not delete excluded files through parent di
 	mkdirSync(join(dir, "docs"), { recursive: true });
 	writeFileSync(includedPath, "local");
 
-	const storage = new LocalFilesystem({
+	const storage = new FilesystemStorage({
 		path: dir,
-		lixDir: tempExternalLixDir(),
 		syncAllFiles: false,
 	});
 	const lix = await openLix({ storage });
@@ -935,9 +878,8 @@ test("fs storage on-demand sync matches directory paths by segment boundaries", 
 	writeFileSync(excludedPath, "outside filter");
 	writeFileSync(includedPath, "local");
 
-	const storage = new LocalFilesystem({
+	const storage = new FilesystemStorage({
 		path: dir,
-		lixDir: tempExternalLixDir(),
 		syncAllFiles: false,
 	});
 	const lix = await openLix({ storage });
@@ -950,98 +892,6 @@ test("fs storage on-demand sync matches directory paths by segment boundaries", 
 	await lix.close();
 });
 
-test("fs storage with external lixDir materializes lix storage outside the repository", async () => {
-	const dir = tempFsDir();
-	const lixDir = tempExternalLixDir();
-	mkdirSync(dir, { recursive: true });
-	writeFileSync(join(dir, "note.md"), "note");
-
-	const lix = await openLix({
-		storage: new LocalFilesystem({ path: dir, lixDir, syncAllFiles: true }),
-	});
-
-	await lix.execute("INSERT INTO lix_file (path, content) VALUES ($1, $2)", [
-		"/.lix/app_data/ephemeral.txt",
-		new TextEncoder().encode("external"),
-	]);
-	expect(existsSync(join(dir, ".lix"))).toBe(false);
-	expect(readFileSync(join(lixDir, "app_data", "ephemeral.txt"), "utf8")).toBe(
-		"external",
-	);
-
-	await lix.close();
-});
-
-test("fs storage with external lixDir persists lix storage when reused", async () => {
-	const dir = tempFsDir();
-	const lixDir = tempExternalLixDir();
-	mkdirSync(dir, { recursive: true });
-	writeFileSync(join(dir, "note.md"), "first");
-
-	const lix = await openLix({
-		storage: new LocalFilesystem({ path: dir, lixDir, syncAllFiles: true }),
-	});
-	await lix.execute("UPDATE lix_file SET content = $1 WHERE path = $2", [
-		new TextEncoder().encode("second"),
-		"/note.md",
-	]);
-	await lix.execute("INSERT INTO lix_file (path, content) VALUES ($1, $2)", [
-		"/.lix/app_data/ephemeral.txt",
-		new TextEncoder().encode("ephemeral"),
-	]);
-	await lix.close();
-
-	const reopened = await openLix({
-		storage: new LocalFilesystem({ path: dir, lixDir, syncAllFiles: true }),
-	});
-	const bytes = await readFile(reopened, "/note.md");
-	expect(bytes ? new TextDecoder().decode(bytes) : undefined).toBe("second");
-	const ephemeral = await readFile(reopened, "/.lix/app_data/ephemeral.txt");
-	expect(ephemeral ? new TextDecoder().decode(ephemeral) : undefined).toBe(
-		"ephemeral",
-	);
-	expect(existsSync(join(dir, ".lix"))).toBe(false);
-
-	await reopened.close();
-});
-
-test("fs storage with a fresh external lixDir reimports disk state without old lix storage", async () => {
-	const dir = tempFsDir();
-	mkdirSync(dir, { recursive: true });
-	writeFileSync(join(dir, "note.md"), "first");
-
-	const lix = await openLix({
-		storage: new LocalFilesystem({
-			path: dir,
-			lixDir: tempExternalLixDir(),
-			syncAllFiles: true,
-		}),
-	});
-	await lix.execute("UPDATE lix_file SET content = $1 WHERE path = $2", [
-		new TextEncoder().encode("second"),
-		"/note.md",
-	]);
-	await lix.execute("INSERT INTO lix_file (path, content) VALUES ($1, $2)", [
-		"/.lix/app_data/ephemeral.txt",
-		new TextEncoder().encode("ephemeral"),
-	]);
-	await lix.close();
-
-	const reopened = await openLix({
-		storage: new LocalFilesystem({
-			path: dir,
-			lixDir: tempExternalLixDir(),
-			syncAllFiles: true,
-		}),
-	});
-	const bytes = await readFile(reopened, "/note.md");
-	expect(bytes ? new TextDecoder().decode(bytes) : undefined).toBe("second");
-	const ephemeral = await readFile(reopened, "/.lix/app_data/ephemeral.txt");
-	expect(ephemeral).toBeUndefined();
-	expect(existsSync(join(dir, ".lix"))).toBe(false);
-
-	await reopened.close();
-});
 
 test.skipIf(process.platform === "win32")(
 	"fs storage ignores unrelated symlinks and diagnoses materialization collisions",
@@ -1054,7 +904,7 @@ test.skipIf(process.platform === "win32")(
 		symlinkSync("docs", join(dir, "linked-docs"));
 
 		const lix = await openLix({
-			storage: new LocalFilesystem({ path: dir, syncAllFiles: true }),
+			storage: new FilesystemStorage({ path: dir, syncAllFiles: true }),
 		});
 		const files = await lix.execute(
 			"SELECT path FROM lix_file WHERE path IN ($1, $2, $3) ORDER BY path",
@@ -1563,7 +1413,7 @@ test("execute rejects invalid runtime arguments before native call", async () =>
 	).rejects.toThrow(/openLix\(\) requires/);
 	await expect(
 		openLix({
-			backend: new LocalFilesystem({
+			backend: new FilesystemStorage({
 				path: tempFsDir(),
 				syncAllFiles: true,
 			}),
@@ -2122,10 +1972,4 @@ function tempFsDir(): string {
 		dir,
 		`lix-fs-test-${Date.now()}-${Math.random().toString(16).slice(2)}`,
 	);
-}
-
-function tempExternalLixDir(): string {
-	const parent = tempFsDir();
-	mkdirSync(parent, { recursive: true });
-	return join(parent, ".lix");
 }

--- a/packages/js-sdk/src/open-lix.ts
+++ b/packages/js-sdk/src/open-lix.ts
@@ -1,22 +1,15 @@
-import {
-	localFilesystemAlreadyOpen,
-	localFilesystemNotOpen,
-} from "./errors.js";
 import type { LixBinding } from "./binding-types.js";
 import {
 	ACTIVE_ACCOUNT_CLIENT_STATE_KEY,
 	openClientState,
 } from "./client-state.js";
 import { Lix } from "./lix.js";
-import type {
-	IndexedDbStorageOptions,
-	LocalFilesystemOptions,
-	OpenLixOptions,
-} from "./types.js";
+import { isLixStorage, type LixStorage } from "./storage-adapter.js";
+import type { IndexedDbStorageOptions, OpenLixOptions } from "./types.js";
 
 export { Lix, LixTransaction, ObserveEvents } from "./lix.js";
 
-const openLocalFilesystems = new WeakMap<LocalFilesystem, LixBinding | null>();
+const openStorages = new WeakSet<LixStorage>();
 const openIndexedDbStorageNames = new Set<string>();
 
 export class IndexedDbStorage {
@@ -27,65 +20,6 @@ export class IndexedDbStorage {
 			throw new TypeError("IndexedDbStorage requires a non-empty name");
 		}
 		this.name = options.name;
-	}
-}
-
-export class LocalFilesystem {
-	readonly path: string;
-	readonly lixDir: string | undefined;
-	readonly syncAllFiles: boolean;
-
-	constructor(options: LocalFilesystemOptions) {
-		if (
-			!options ||
-			typeof options.path !== "string" ||
-			options.path.length === 0
-		) {
-			throw new TypeError("LocalFilesystem requires a non-empty path");
-		}
-		if (
-			options.lixDir !== undefined &&
-			(typeof options.lixDir !== "string" || options.lixDir.length === 0)
-		) {
-			throw new TypeError("LocalFilesystem lixDir must be a non-empty string");
-		}
-		if (typeof options.syncAllFiles !== "boolean") {
-			throw new TypeError("LocalFilesystem syncAllFiles must be a boolean");
-		}
-		this.path = options.path;
-		this.lixDir = options.lixDir;
-		this.syncAllFiles = options.syncAllFiles;
-	}
-
-	async importPaths(paths: readonly string[]): Promise<void> {
-		if (!Array.isArray(paths)) {
-			throw new TypeError("importPaths() paths must be an array");
-		}
-		for (const path of paths) {
-			if (typeof path !== "string" || path.length === 0) {
-				throw new TypeError(
-					"importPaths() paths must contain non-empty strings",
-				);
-			}
-			if (path.endsWith("/")) {
-				throw new TypeError(
-					"importPaths() paths must not end with a trailing slash",
-				);
-			}
-		}
-		await this.client("importPaths").importFilesystemPaths([...paths]);
-	}
-
-	async syncDiskToLix(): Promise<void> {
-		return this.client("syncDiskToLix").syncDiskToLix();
-	}
-
-	private client(operation: string): LixBinding {
-		const client = openLocalFilesystems.get(this);
-		if (!client) {
-			throw localFilesystemNotOpen(operation);
-		}
-		return client;
 	}
 }
 
@@ -162,27 +96,32 @@ export async function openLix(options: OpenLixOptions = {}): Promise<Lix> {
 			),
 		);
 	}
-	if (options.storage instanceof LocalFilesystem) {
+	if (isLixStorage(options.storage)) {
 		const storage = options.storage;
-		if (openLocalFilesystems.has(storage)) {
-			throw localFilesystemAlreadyOpen();
+		if (openStorages.has(storage)) {
+			throw storageAlreadyOpen();
 		}
-		openLocalFilesystems.set(storage, null);
+		openStorages.add(storage);
+		let binding: LixBinding | undefined;
+		const disconnect = () => {
+			storage.lixStorage.connect(undefined);
+			openStorages.delete(storage);
+		};
 		try {
-			const binding = await openLixWorkerBinding(
-				{
-					kind: "localFilesystem",
-					path: storage.path,
-					lixDir: storage.lixDir,
-					syncAllFiles: storage.syncAllFiles,
-				},
-				() => openLocalFilesystems.delete(storage),
+			binding = await openLixWorkerBinding(
+				storage.lixStorage.config,
+				disconnect,
 				options.telemetry,
 			);
-			openLocalFilesystems.set(storage, binding);
+			storage.lixStorage.connect({
+				importFilesystemPaths: (paths) =>
+					binding!.importFilesystemPaths(paths),
+				syncDiskToLix: () => binding!.syncDiskToLix(),
+			});
 			return new Lix(binding);
 		} catch (error) {
-			openLocalFilesystems.delete(storage);
+			disconnect();
+			await binding?.close().catch(() => undefined);
 			throw error;
 		}
 	}
@@ -209,8 +148,17 @@ export async function openLix(options: OpenLixOptions = {}): Promise<Lix> {
 		}
 	}
 	throw new TypeError(
-		"openLix() requires storage to be LocalFilesystem or IndexedDbStorage",
+		"openLix() requires a Lix storage adapter or IndexedDbStorage",
 	);
+}
+
+function storageAlreadyOpen(): Error & { code: string } {
+	const error = new Error(
+		"openLix() storage is already open; close the existing Lix or create a new storage adapter",
+	) as Error & { code: string };
+	error.name = "LixError";
+	error.code = "LIX_STORAGE_IN_USE";
+	return error;
 }
 
 function assertIndexedDbStorage(value: unknown): asserts value is IndexedDbStorage {

--- a/packages/js-sdk/src/storage-adapter.ts
+++ b/packages/js-sdk/src/storage-adapter.ts
@@ -1,0 +1,46 @@
+/**
+ * Operations exposed to a storage adapter while its Lix is open.
+ *
+ * This is intentionally narrower than the engine binding. Storage packages
+ * receive only the controls required to manage their own persistence layer.
+ */
+export type LixStorageConnection = {
+	importFilesystemPaths(paths: string[]): Promise<void>;
+	syncDiskToLix(): Promise<void>;
+};
+
+/** Engine configuration currently supported by external JavaScript storage packages. */
+export type LixStorageAdapterConfig = {
+	kind: "filesystem";
+	path: string;
+	syncAllFiles: boolean;
+};
+
+/**
+ * Protocol implemented by JavaScript storage packages accepted by `openLix()`.
+ *
+ * Applications normally use a concrete package such as
+ * `@lix-js/storage-filesystem` rather than implementing this directly.
+ */
+export type LixStorage = {
+	readonly lixStorage: {
+		readonly version: 1;
+		readonly config: LixStorageAdapterConfig;
+		connect(connection: LixStorageConnection | undefined): void;
+	};
+};
+
+export function isLixStorage(value: unknown): value is LixStorage {
+	if (!value || typeof value !== "object" || !("lixStorage" in value)) {
+		return false;
+	}
+	const adapter = (value as { lixStorage?: unknown }).lixStorage;
+	return Boolean(
+		adapter &&
+			typeof adapter === "object" &&
+			(adapter as { version?: unknown }).version === 1 &&
+			typeof (adapter as { connect?: unknown }).connect === "function" &&
+			(adapter as { config?: { kind?: unknown } }).config?.kind ===
+				"filesystem",
+	);
+}

--- a/packages/js-sdk/src/types.ts
+++ b/packages/js-sdk/src/types.ts
@@ -1,9 +1,3 @@
-export type LocalFilesystemOptions = {
-	path: string;
-	lixDir?: string;
-	syncAllFiles: boolean;
-};
-
 export type IndexedDbStorageOptions = {
 	/**
 	 * Identifies one persistent Lix database within the current origin.
@@ -40,7 +34,7 @@ export type LixTelemetryOptions = {
 export type OpenLixOptions =
 	| {
 			storage?:
-				| import("./open-lix.js").LocalFilesystem
+				| import("./storage-adapter.js").LixStorage
 				| import("./open-lix.js").IndexedDbStorage;
 			server?: never;
 			telemetry?: LixTelemetryOptions;

--- a/packages/lix/src/session/mod.rs
+++ b/packages/lix/src/session/mod.rs
@@ -106,7 +106,7 @@ where
 /// against `Memory` alone exercise the easy case: the higher-ranked obstruction
 /// that forces `AssumeSendFuture` collapses before rustc ever gets there. The
 /// shipping RocksDB adapter is `Read<'a> = RocksDBRead<'a>`, and
-/// `LocalFilesystem` borrows in both `Read` and `Write`. This adapter
+/// `FilesystemStorage` borrows in both `Read` and `Write`. This adapter
 /// reproduces that shape over `Memory`'s storage so the `Send` proofs cover the
 /// configuration that actually ships.
 #[cfg(test)]

--- a/packages/storage-filesystem/Cargo.toml
+++ b/packages/storage-filesystem/Cargo.toml
@@ -8,10 +8,11 @@ license.workspace = true
 homepage.workspace = true
 repository.workspace = true
 documentation.workspace = true
-readme.workspace = true
+readme = "README.md"
 keywords.workspace = true
 categories.workspace = true
 rust-version.workspace = true
+exclude = ["js/", "package.json", "package-lock.json", "tsconfig.json", "tsconfig.test.json"]
 
 [lints]
 workspace = true

--- a/packages/storage-filesystem/README.md
+++ b/packages/storage-filesystem/README.md
@@ -1,0 +1,31 @@
+# `lix-storage-filesystem`
+
+Filesystem-backed storage for Lix. The Rust crate and JavaScript package expose
+the same adapter with independently versioned releases.
+
+## JavaScript
+
+```ts
+import { openLix } from "@lix-js/sdk";
+import { FilesystemStorage } from "@lix-js/storage-filesystem";
+
+const storage = new FilesystemStorage({ path: "./repository" });
+const lix = await openLix({ storage });
+```
+
+The whole repository is synchronized by default. Pass `syncAllFiles: false`
+and use `storage.importPaths(paths)` for selective synchronization.
+
+## Rust
+
+```rust
+use lix::open_lix;
+use lix_storage_filesystem::FilesystemStorage;
+
+# async fn example() -> Result<(), lix::LixError> {
+let storage = FilesystemStorage::new("./repository").open()?;
+let lix = open_lix().with_storage(storage.clone()).await?;
+let _sync = storage.start_sync(&lix).await?;
+# Ok(())
+# }
+```

--- a/packages/storage-filesystem/examples/profile_fs_open.rs
+++ b/packages/storage-filesystem/examples/profile_fs_open.rs
@@ -5,14 +5,14 @@
 //     <src_dir>
 //
 // Copies <src_dir> (sans any existing .lix) into a fresh temp dir, then times
-// LocalFilesystem::open on the cold workspace. Pass --keep-workspace to preserve the
+// FilesystemStorage::new(path).open() on the cold workspace. Pass --keep-workspace to preserve the
 // copied temp workspace for inspection.
 
 use std::path::{Path, PathBuf};
 use std::time::{Duration, Instant};
 
 use lix::{Value, open_lix};
-use lix_storage_filesystem::LocalFilesystem;
+use lix_storage_filesystem::FilesystemStorage;
 
 #[derive(Debug)]
 #[expect(clippy::struct_excessive_bools)]
@@ -116,9 +116,9 @@ fn duration_ms(duration: Duration) -> u128 {
     duration.as_micros() / 1000
 }
 
-async fn open_with_timing(path: &Path) -> (LocalFilesystem, Duration) {
+async fn open_with_timing(path: &Path) -> (FilesystemStorage, Duration) {
     let started = Instant::now();
-    let opened = LocalFilesystem::open(path).unwrap();
+    let opened = FilesystemStorage::new(path).open().unwrap();
     let elapsed = started.elapsed();
     (opened, elapsed)
 }
@@ -130,7 +130,7 @@ fn collect_profile_stats(workspace: &Path) -> ProfileStats {
     stats
 }
 
-async fn run_read_benchmark(storage: &LocalFilesystem, workspace: &Path) -> ReadBenchStats {
+async fn run_read_benchmark(storage: &FilesystemStorage, workspace: &Path) -> ReadBenchStats {
     let files = collect_bench_files(workspace);
     let largest = files.iter().take(4).collect::<Vec<_>>();
     let small_sample = select_small_sample(&files, 16);
@@ -183,7 +183,7 @@ async fn run_read_benchmark(storage: &LocalFilesystem, workspace: &Path) -> Read
     }
 }
 
-async fn time_read_paths(lix: &lix::Lix<LocalFilesystem>, files: &[&BenchFile]) -> (u128, u64) {
+async fn time_read_paths(lix: &lix::Lix<FilesystemStorage>, files: &[&BenchFile]) -> (u128, u64) {
     let started = Instant::now();
     let mut bytes = 0u64;
     for file in files {
@@ -623,7 +623,7 @@ async fn main() {
         let work_i = tmp_i.path().join("workspace");
         copy_dir(src, &work_i);
         let t = Instant::now();
-        let storage = LocalFilesystem::open(&work_i).unwrap();
+        let storage = FilesystemStorage::new(&work_i).open().unwrap();
         if i == repeat - 1 {
             let elapsed = t.elapsed();
             eprintln!("cold open (repeat {repeat}): {elapsed:?}");

--- a/packages/storage-filesystem/examples/sync_repository.rs
+++ b/packages/storage-filesystem/examples/sync_repository.rs
@@ -1,5 +1,5 @@
 use lix::open_lix;
-use lix_storage_filesystem::LocalFilesystem;
+use lix_storage_filesystem::FilesystemStorage;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let root = std::env::args()
@@ -10,7 +10,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         .build()?;
 
     runtime.block_on(async move {
-        let storage = LocalFilesystem::open(&root)?;
+        let storage = FilesystemStorage::new(&root).open()?;
         let lix = open_lix().with_storage(storage.clone()).await?;
         let sync = storage.start_sync(&lix).await?;
 

--- a/packages/storage-filesystem/js/index.test.ts
+++ b/packages/storage-filesystem/js/index.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, test } from "vitest";
+import { FilesystemStorage } from "./index.js";
+
+	describe("FilesystemStorage", () => {
+	test("mirrors the Rust new(path) defaults", () => {
+		const storage = new FilesystemStorage({ path: "./repository" });
+
+		expect(storage.path).toBe("./repository");
+		expect(storage.syncAllFiles).toBe(true);
+		expect(storage.lixStorage.config).toEqual({
+			kind: "filesystem",
+			path: "./repository",
+			syncAllFiles: true,
+		});
+	});
+
+	test("rejects an empty path", () => {
+		expect(
+			() => new FilesystemStorage({ path: "" }),
+		).toThrow("FilesystemStorage requires a non-empty path");
+	});
+
+	test("requires openLix before synchronization controls", async () => {
+		const storage = new FilesystemStorage({ path: "./repository" });
+
+		await expect(storage.syncDiskToLix()).rejects.toMatchObject({
+			code: "LIX_FILESYSTEM_STORAGE_NOT_OPEN",
+		});
+	});
+});

--- a/packages/storage-filesystem/js/index.ts
+++ b/packages/storage-filesystem/js/index.ts
@@ -1,0 +1,98 @@
+/** Options for opening filesystem-backed Lix storage. */
+export type FilesystemStorageOptions = {
+	/** Directory synchronized with the Lix repository. */
+	path: string;
+	/** Whether every file below `path` is synchronized. Defaults to `true`. */
+	syncAllFiles?: boolean;
+};
+
+type FilesystemStorageConnection = {
+	importFilesystemPaths(paths: string[]): Promise<void>;
+	syncDiskToLix(): Promise<void>;
+};
+
+/**
+ * Filesystem-backed storage for Lix.
+ *
+ * Pass an instance to `openLix({ storage })`. The Rust
+ * `lix-storage-filesystem` adapter performs the actual storage and sync work.
+ */
+export class FilesystemStorage {
+	readonly path: string;
+	readonly syncAllFiles: boolean;
+	#connection: FilesystemStorageConnection | undefined;
+
+	readonly lixStorage: {
+		readonly version: 1;
+		readonly config: {
+			readonly kind: "filesystem";
+			readonly path: string;
+			readonly syncAllFiles: boolean;
+		};
+		connect(connection: FilesystemStorageConnection | undefined): void;
+	};
+
+	constructor(options: FilesystemStorageOptions) {
+		if (!options || typeof options !== "object") {
+			throw new TypeError("FilesystemStorage options must be an object");
+		}
+		if (typeof options.path !== "string" || options.path.length === 0) {
+			throw new TypeError("FilesystemStorage requires a non-empty path");
+		}
+		if (
+			options.syncAllFiles !== undefined &&
+			typeof options.syncAllFiles !== "boolean"
+		) {
+			throw new TypeError("FilesystemStorage syncAllFiles must be a boolean");
+		}
+
+		this.path = options.path;
+		this.syncAllFiles = options.syncAllFiles ?? true;
+		this.lixStorage = {
+			version: 1,
+			config: {
+				kind: "filesystem",
+				path: this.path,
+				syncAllFiles: this.syncAllFiles,
+			},
+			connect: (connection) => {
+				this.#connection = connection;
+			},
+		};
+	}
+
+	/** Import selected filesystem paths into the open Lix repository. */
+	async importPaths(paths: readonly string[]): Promise<void> {
+		if (!Array.isArray(paths)) {
+			throw new TypeError("importPaths() paths must be an array");
+		}
+		for (const path of paths) {
+			if (typeof path !== "string" || path.length === 0) {
+				throw new TypeError(
+					"importPaths() paths must contain non-empty strings",
+				);
+			}
+			if (path.endsWith("/")) {
+				throw new TypeError(
+					"importPaths() paths must not end with a trailing slash",
+				);
+			}
+		}
+		await this.#requireConnection("importPaths").importFilesystemPaths([...paths]);
+	}
+
+	/** Immediately synchronize current disk changes into Lix. */
+	async syncDiskToLix(): Promise<void> {
+		await this.#requireConnection("syncDiskToLix").syncDiskToLix();
+	}
+
+	#requireConnection(operation: string): FilesystemStorageConnection {
+		if (this.#connection) return this.#connection;
+		const error = new Error(
+			`FilesystemStorage.${operation}() requires an open Lix using this storage`,
+		) as Error & { code: string };
+		error.name = "LixError";
+		error.code = "LIX_FILESYSTEM_STORAGE_NOT_OPEN";
+		throw error;
+	}
+}

--- a/packages/storage-filesystem/package-lock.json
+++ b/packages/storage-filesystem/package-lock.json
@@ -1,0 +1,1209 @@
+{
+	"name": "@lix-js/storage-filesystem",
+	"version": "0.1.0",
+	"lockfileVersion": 3,
+	"requires": true,
+	"packages": {
+		"": {
+			"name": "@lix-js/storage-filesystem",
+			"version": "0.1.0",
+			"license": "MIT",
+			"devDependencies": {
+				"@types/node": "^24.10.2",
+				"typescript": "^5.5.4",
+				"vitest": "4.1.10"
+			},
+			"peerDependencies": {
+				"@lix-js/sdk": "^0.12.0"
+			}
+		},
+		"node_modules/@jridgewell/sourcemap-codec": {
+			"version": "1.5.5",
+			"resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+			"integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@oxc-project/types": {
+			"version": "0.144.0",
+			"resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.144.0.tgz",
+			"integrity": "sha512-nuhZIOLuI6TFQ32I/WnUx+SCPY7SdSKwgnFHydAuoS1+Z4BRcaP+RRJmGzl9lw+0OFF7UmaESf7KQRXaNLHypg==",
+			"dev": true,
+			"license": "MIT",
+			"funding": {
+				"url": "https://github.com/sponsors/Boshen"
+			}
+		},
+		"node_modules/@rolldown/binding-android-arm64": {
+			"version": "1.2.4",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.2.4.tgz",
+			"integrity": "sha512-jHC2cnyKz5xU2fhECtFl8OZ83cYNt13GZQD+0uMJ/X3o+ijmd56okHhTUwxVSHPx1IRVIJEZ1/1pPzeLCU6XKA==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@rolldown/binding-darwin-arm64": {
+			"version": "1.2.4",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.2.4.tgz",
+			"integrity": "sha512-Dc5mPD8F5F/FS8i01syd7FTF6yB2fVthH/TRkjwJkzUK6EpoxHtqvZQP5Zwq80/5z19TWYHIg1KOHboCgVx/aQ==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@rolldown/binding-darwin-x64": {
+			"version": "1.2.4",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.2.4.tgz",
+			"integrity": "sha512-fpDm4oBo6SqLvWUYCmFhdde3U9KH2fRNNMeAnAPAIwxRL345xutL0EtEUcuoxsoazdJGv/MuDBQHlCDrtbvqOg==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@rolldown/binding-freebsd-x64": {
+			"version": "1.2.4",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.2.4.tgz",
+			"integrity": "sha512-rSJoreDE/HoIzoaib6MTp5jQtCTdMHKIvItAKT/ImS6Y6Ww76oUaeMyp4Vc/fAgd/ehji068IxetHXAnqUwN9A==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"freebsd"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+			"version": "1.2.4",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.2.4.tgz",
+			"integrity": "sha512-/jm8OGHgn7oGaJu3i/qZI9spUGcJ+y/lk43ttQ/iO1tOd9NissG6o97bighBCiL+BKRngmcDuR6ikfwYdJmVuQ==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@rolldown/binding-linux-arm64-gnu": {
+			"version": "1.2.4",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.2.4.tgz",
+			"integrity": "sha512-tIP06BeD9EqvECBrPZ+sqdPlYrT+aYaAiu1wYziVx5elRK/ftm33JxVDy2bXGbr6J0CrtirCkR87/X5a2euEng==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@rolldown/binding-linux-arm64-musl": {
+			"version": "1.2.4",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.2.4.tgz",
+			"integrity": "sha512-Ql1Q0EQqVThvn9VAVlwNzsUvbSFtCMGjLpRRi4pk5i7NZZ4n5ISiLMjHYtus4VQ2PvkSw24zyaCVsiS+sXPj1w==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@rolldown/binding-linux-ppc64-gnu": {
+			"version": "1.2.4",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.2.4.tgz",
+			"integrity": "sha512-GjbjXD4XXfN19D0LZNbmiCBUoDiRACsYHr0yaIbbn8aFsXjHZifcYqu/W5Er5X2X990WjHXFrxarn5chzItorQ==",
+			"cpu": [
+				"ppc64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@rolldown/binding-linux-s390x-gnu": {
+			"version": "1.2.4",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.2.4.tgz",
+			"integrity": "sha512-p5WR0NOwaRmJ/B1b6IjEFLLivwEsf3PrdBIhRbhTCQisbo2SvHHpG4ELB/+FgQNnB88LTOF86upmJmbvZdQ2lw==",
+			"cpu": [
+				"s390x"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@rolldown/binding-linux-x64-gnu": {
+			"version": "1.2.4",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.2.4.tgz",
+			"integrity": "sha512-4/GyVjmhR+Tc6HLJvwc1sOhPqAZtySiSMesOZyX6JQ5XBxoTDEMKQzvo07NIK6nTon/SivlZqvhzvuVBNQhObQ==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@rolldown/binding-linux-x64-musl": {
+			"version": "1.2.4",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.2.4.tgz",
+			"integrity": "sha512-l9eeLsCNvPpmSXUej0etw/J1eqV0Jj1D5G/xG6YTijmE6dkv6E2QezgWbTfQk63v952DPqrjOCoiqxq7Bw0YUQ==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@rolldown/binding-openharmony-arm64": {
+			"version": "1.2.4",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.2.4.tgz",
+			"integrity": "sha512-e0F355MSTMm3+UOqtV3L24gFUp2N5m1f8L/7d56deik6va+AXdrt9F8LbzGpeWGWRbZEDq4m8NVnJDeBtf9DZg==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"openharmony"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@rolldown/binding-win32-arm64-msvc": {
+			"version": "1.2.4",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.2.4.tgz",
+			"integrity": "sha512-AWLi0uBRYh6QlE7OKhiz+phZC0qwtij2QZmhmOdsLdFn64m7oMpooE9ICE3lhm9xMb4SpDo2WbHcxX1iFLFtqw==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@rolldown/binding-win32-x64-msvc": {
+			"version": "1.2.4",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.2.4.tgz",
+			"integrity": "sha512-UwSDJOg3dqCAejWdxclJjCsh3Qq4vLYMDxmyHqo1btz3stK2VqgwNd3mm5tuIwzSlGIQ/1H9Hr+Zn09mrezNqQ==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@rolldown/pluginutils": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+			"integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@standard-schema/spec": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+			"integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@types/chai": {
+			"version": "5.2.3",
+			"resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+			"integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/deep-eql": "*",
+				"assertion-error": "^2.0.1"
+			}
+		},
+		"node_modules/@types/deep-eql": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+			"integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@types/estree": {
+			"version": "1.0.9",
+			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+			"integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@types/node": {
+			"version": "24.13.3",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.3.tgz",
+			"integrity": "sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"undici-types": "~7.18.0"
+			}
+		},
+		"node_modules/@vitest/expect": {
+			"version": "4.1.10",
+			"resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.10.tgz",
+			"integrity": "sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@standard-schema/spec": "^1.1.0",
+				"@types/chai": "^5.2.2",
+				"@vitest/spy": "4.1.10",
+				"@vitest/utils": "4.1.10",
+				"chai": "^6.2.2",
+				"tinyrainbow": "^3.1.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
+		"node_modules/@vitest/mocker": {
+			"version": "4.1.10",
+			"resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.10.tgz",
+			"integrity": "sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@vitest/spy": "4.1.10",
+				"estree-walker": "^3.0.3",
+				"magic-string": "^0.30.21"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			},
+			"peerDependencies": {
+				"msw": "^2.4.9",
+				"vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+			},
+			"peerDependenciesMeta": {
+				"msw": {
+					"optional": true
+				},
+				"vite": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@vitest/pretty-format": {
+			"version": "4.1.10",
+			"resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.10.tgz",
+			"integrity": "sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"tinyrainbow": "^3.1.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
+		"node_modules/@vitest/runner": {
+			"version": "4.1.10",
+			"resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.10.tgz",
+			"integrity": "sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@vitest/utils": "4.1.10",
+				"pathe": "^2.0.3"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
+		"node_modules/@vitest/snapshot": {
+			"version": "4.1.10",
+			"resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.10.tgz",
+			"integrity": "sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@vitest/pretty-format": "4.1.10",
+				"@vitest/utils": "4.1.10",
+				"magic-string": "^0.30.21",
+				"pathe": "^2.0.3"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
+		"node_modules/@vitest/spy": {
+			"version": "4.1.10",
+			"resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.10.tgz",
+			"integrity": "sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==",
+			"dev": true,
+			"license": "MIT",
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
+		"node_modules/@vitest/utils": {
+			"version": "4.1.10",
+			"resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.10.tgz",
+			"integrity": "sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@vitest/pretty-format": "4.1.10",
+				"convert-source-map": "^2.0.0",
+				"tinyrainbow": "^3.1.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
+		"node_modules/assertion-error": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+			"integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/chai": {
+			"version": "6.2.2",
+			"resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+			"integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/convert-source-map": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+			"integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/detect-libc": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+			"integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/es-module-lexer": {
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.1.tgz",
+			"integrity": "sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/estree-walker": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+			"integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/estree": "^1.0.0"
+			}
+		},
+		"node_modules/expect-type": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+			"integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">=12.0.0"
+			}
+		},
+		"node_modules/fdir": {
+			"version": "6.5.0",
+			"resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+			"integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12.0.0"
+			},
+			"peerDependencies": {
+				"picomatch": "^3 || ^4"
+			},
+			"peerDependenciesMeta": {
+				"picomatch": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/fsevents": {
+			"version": "2.3.3",
+			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+			"integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+			"dev": true,
+			"hasInstallScript": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+			}
+		},
+		"node_modules/lightningcss": {
+			"version": "1.33.0",
+			"resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.33.0.tgz",
+			"integrity": "sha512-WkUDrojuJs0xkgGf2udWxa3yGBRxPtxUkB79i6aCZLRgc7PM8fZe9TosfPDcvEpQZbuFASnHYmRLBLUbmLOIIA==",
+			"dev": true,
+			"license": "MPL-2.0",
+			"dependencies": {
+				"detect-libc": "^2.0.3"
+			},
+			"engines": {
+				"node": ">= 12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			},
+			"optionalDependencies": {
+				"lightningcss-android-arm64": "1.33.0",
+				"lightningcss-darwin-arm64": "1.33.0",
+				"lightningcss-darwin-x64": "1.33.0",
+				"lightningcss-freebsd-x64": "1.33.0",
+				"lightningcss-linux-arm-gnueabihf": "1.33.0",
+				"lightningcss-linux-arm64-gnu": "1.33.0",
+				"lightningcss-linux-arm64-musl": "1.33.0",
+				"lightningcss-linux-x64-gnu": "1.33.0",
+				"lightningcss-linux-x64-musl": "1.33.0",
+				"lightningcss-win32-arm64-msvc": "1.33.0",
+				"lightningcss-win32-x64-msvc": "1.33.0"
+			}
+		},
+		"node_modules/lightningcss-android-arm64": {
+			"version": "1.33.0",
+			"resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.33.0.tgz",
+			"integrity": "sha512-gEpRTalKdosp4Bb8qWtc2iOgE5SeIHlpS1up9bFq2wAyYhl1UdTObYiHe98zEM9SQvSoqQZ1IQD0JNpg3Ml5pg==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MPL-2.0",
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"engines": {
+				"node": ">= 12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/lightningcss-darwin-arm64": {
+			"version": "1.33.0",
+			"resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.33.0.tgz",
+			"integrity": "sha512-Sciaz8eenNTKn9b3t7+xr0ipTp9YxKQY4npwQ3mrRuL0BAVHBLyZxofhaKBAVtzmtRZ/zTyo0/to4B1uWG/Djg==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MPL-2.0",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">= 12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/lightningcss-darwin-x64": {
+			"version": "1.33.0",
+			"resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.33.0.tgz",
+			"integrity": "sha512-Z5UPAxzrjlWNNyGy6i65cJzzvgJ5D3T6wMvs+gWpY9d7qRhANrxqAp6LhxIgZhWEw18RfJTGcRxjuLIBr+m8XQ==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MPL-2.0",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">= 12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/lightningcss-freebsd-x64": {
+			"version": "1.33.0",
+			"resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.33.0.tgz",
+			"integrity": "sha512-QQM/Ti/hQajJwCY+RiWuCZ9sdtI/XQk7nDK5vC8kkdwixezOlDgvDx7+RT+QjK6FcFT4MpsuoBnHIo/O3StRRg==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MPL-2.0",
+			"optional": true,
+			"os": [
+				"freebsd"
+			],
+			"engines": {
+				"node": ">= 12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/lightningcss-linux-arm-gnueabihf": {
+			"version": "1.33.0",
+			"resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.33.0.tgz",
+			"integrity": "sha512-N7FVBe6iS24MlM6R/4RBTxGhQheZGs7tiQ9U32UtF75NzP5Q7xWPRqLBCKxlRQRk3rY1jCIPLzx7WzOhuUIRLQ==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"license": "MPL-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/lightningcss-linux-arm64-gnu": {
+			"version": "1.33.0",
+			"resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.33.0.tgz",
+			"integrity": "sha512-j2v/itmy4HlNxlc6voKXYgBqNi0Ng2LShg4z7GufpEgs05P+2suBVyi9I6YHq5uoVFx9ETin3eCEhLVyXGQnKg==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MPL-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/lightningcss-linux-arm64-musl": {
+			"version": "1.33.0",
+			"resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.33.0.tgz",
+			"integrity": "sha512-yiO5ROMuYQgXbC60yjZU5CYSFZGKXL0HFATXt9mHJn1+zW55oCtMI9NfcVhYLMFDL7gV7oBPon/EmMMGg2OvtQ==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MPL-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/lightningcss-linux-x64-gnu": {
+			"version": "1.33.0",
+			"resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.33.0.tgz",
+			"integrity": "sha512-ar+Ju7LmcN0Jo4FpL4hpFybwNG9/3A/Br5KW2n2jyODg3MEZXaDYADdemoNS+BDNfMgKvylJLj4S5tyRActuAg==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MPL-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/lightningcss-linux-x64-musl": {
+			"version": "1.33.0",
+			"resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.33.0.tgz",
+			"integrity": "sha512-RYiYbkokw0trfKqqzfF55lginwEPrD3OJDfTuJzFs1MK6iFnDenaz1fqLLtX4ITG3OktJQXOeTaw1awrBAlZPw==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MPL-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/lightningcss-win32-arm64-msvc": {
+			"version": "1.33.0",
+			"resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.33.0.tgz",
+			"integrity": "sha512-1K+MPfLSFVpphzpdbfkhlWk6wBrTObBzS2T6db10PNOZgR9GoVsAWzwNyuhUYYbTp23j+4RrncfujZ4uAzXvwA==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MPL-2.0",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">= 12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/lightningcss-win32-x64-msvc": {
+			"version": "1.33.0",
+			"resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.33.0.tgz",
+			"integrity": "sha512-OlEICDx/Xl0FqSp4bry8zFnCvGpig3Gl4gCquvYwHuqJKEC1+n9NgDniFvqHGmMv1ZkqDJrDqKKSykTDX+ehuA==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MPL-2.0",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">= 12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/magic-string": {
+			"version": "0.30.21",
+			"resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+			"integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jridgewell/sourcemap-codec": "^1.5.5"
+			}
+		},
+		"node_modules/nanoid": {
+			"version": "3.3.18",
+			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+			"integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/ai"
+				}
+			],
+			"license": "MIT",
+			"bin": {
+				"nanoid": "bin/nanoid.cjs"
+			},
+			"engines": {
+				"node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+			}
+		},
+		"node_modules/obug": {
+			"version": "2.1.4",
+			"resolved": "https://registry.npmjs.org/obug/-/obug-2.1.4.tgz",
+			"integrity": "sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==",
+			"dev": true,
+			"funding": [
+				"https://github.com/sponsors/sxzz",
+				"https://opencollective.com/debug"
+			],
+			"license": "MIT",
+			"engines": {
+				"node": ">=12.20.0"
+			}
+		},
+		"node_modules/pathe": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+			"integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/picocolors": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+			"integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+			"dev": true,
+			"license": "ISC"
+		},
+		"node_modules/picomatch": {
+			"version": "4.0.5",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+			"integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/jonschlinkert"
+			}
+		},
+		"node_modules/postcss": {
+			"version": "8.5.26",
+			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+			"integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/postcss/"
+				},
+				{
+					"type": "tidelift",
+					"url": "https://tidelift.com/funding/github/npm/postcss"
+				},
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/ai"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"nanoid": "^3.3.17",
+				"picocolors": "^1.1.1",
+				"source-map-js": "^1.2.1"
+			},
+			"engines": {
+				"node": "^10 || ^12 || >=14"
+			}
+		},
+		"node_modules/rolldown": {
+			"version": "1.2.4",
+			"resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.2.4.tgz",
+			"integrity": "sha512-rSr7irW0K7QRWzjdJXqZowkcRdDtjRduh43rBltnVKd0VFq839l1lJoDvGJb6gl7+4rTTCrPWu+YfujUL8Ug7w==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@oxc-project/types": "=0.144.0",
+				"@rolldown/pluginutils": "^1.0.0"
+			},
+			"bin": {
+				"rolldown": "bin/cli.mjs"
+			},
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			},
+			"optionalDependencies": {
+				"@rolldown/binding-android-arm64": "1.2.4",
+				"@rolldown/binding-darwin-arm64": "1.2.4",
+				"@rolldown/binding-darwin-x64": "1.2.4",
+				"@rolldown/binding-freebsd-x64": "1.2.4",
+				"@rolldown/binding-linux-arm-gnueabihf": "1.2.4",
+				"@rolldown/binding-linux-arm64-gnu": "1.2.4",
+				"@rolldown/binding-linux-arm64-musl": "1.2.4",
+				"@rolldown/binding-linux-ppc64-gnu": "1.2.4",
+				"@rolldown/binding-linux-s390x-gnu": "1.2.4",
+				"@rolldown/binding-linux-x64-gnu": "1.2.4",
+				"@rolldown/binding-linux-x64-musl": "1.2.4",
+				"@rolldown/binding-openharmony-arm64": "1.2.4",
+				"@rolldown/binding-win32-arm64-msvc": "1.2.4",
+				"@rolldown/binding-win32-x64-msvc": "1.2.4"
+			}
+		},
+		"node_modules/siginfo": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+			"integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+			"dev": true,
+			"license": "ISC"
+		},
+		"node_modules/source-map-js": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+			"integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/stackback": {
+			"version": "0.0.2",
+			"resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+			"integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/std-env": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/std-env/-/std-env-4.2.0.tgz",
+			"integrity": "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/tinybench": {
+			"version": "2.9.0",
+			"resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+			"integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/tinyexec": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.3.0.tgz",
+			"integrity": "sha512-QKAl9m8gWWGHV8jZcPeym6j+XULi6tOf1mT83WYJ4Lk2ytW/uwAWkrP0uFsdoYMdueVJ0qs26wZ+23xeB4ibNQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/tinyglobby": {
+			"version": "0.2.17",
+			"resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+			"integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"fdir": "^6.5.0",
+				"picomatch": "^4.0.4"
+			},
+			"engines": {
+				"node": ">=12.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/SuperchupuDev"
+			}
+		},
+		"node_modules/tinyrainbow": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.1.tgz",
+			"integrity": "sha512-yau8yJdTt989Mm0Bd/236QnzEiPf2xLLTqUZRUJOo/3CB078LSwzei343DgtJVmfJKJE3TMINY1u42SQsP6mXw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/typescript": {
+			"version": "5.9.3",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+			"integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"bin": {
+				"tsc": "bin/tsc",
+				"tsserver": "bin/tsserver"
+			},
+			"engines": {
+				"node": ">=14.17"
+			}
+		},
+		"node_modules/undici-types": {
+			"version": "7.18.2",
+			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+			"integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/vite": {
+			"version": "8.2.1",
+			"resolved": "https://registry.npmjs.org/vite/-/vite-8.2.1.tgz",
+			"integrity": "sha512-EU/eS7BH3XROHh2YnBefjM6DBKA6ZeMZEYQbj7NLWg5wHYlhB8B/Mayd5XsgWq+NFYccDOTemRpdETWR6Ka/lw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"lightningcss": "^1.33.0",
+				"picomatch": "^4.0.5",
+				"postcss": "^8.5.25",
+				"rolldown": "~1.2.1",
+				"tinyglobby": "^0.2.17"
+			},
+			"bin": {
+				"vite": "bin/vite.js"
+			},
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			},
+			"funding": {
+				"url": "https://github.com/vitejs/vite?sponsor=1"
+			},
+			"optionalDependencies": {
+				"fsevents": "~2.3.3"
+			},
+			"peerDependencies": {
+				"@types/node": "^20.19.0 || >=22.12.0",
+				"@vitejs/devtools": "^0.4.0",
+				"esbuild": "^0.27.0 || ^0.28.0",
+				"jiti": ">=1.21.0",
+				"less": "^4.0.0",
+				"sass": "^1.70.0",
+				"sass-embedded": "^1.70.0",
+				"stylus": ">=0.54.8",
+				"sugarss": "^5.0.0",
+				"terser": "^5.16.0",
+				"tsx": "^4.8.1",
+				"yaml": "^2.4.2"
+			},
+			"peerDependenciesMeta": {
+				"@types/node": {
+					"optional": true
+				},
+				"@vitejs/devtools": {
+					"optional": true
+				},
+				"esbuild": {
+					"optional": true
+				},
+				"jiti": {
+					"optional": true
+				},
+				"less": {
+					"optional": true
+				},
+				"sass": {
+					"optional": true
+				},
+				"sass-embedded": {
+					"optional": true
+				},
+				"stylus": {
+					"optional": true
+				},
+				"sugarss": {
+					"optional": true
+				},
+				"terser": {
+					"optional": true
+				},
+				"tsx": {
+					"optional": true
+				},
+				"yaml": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/vitest": {
+			"version": "4.1.10",
+			"resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.10.tgz",
+			"integrity": "sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@vitest/expect": "4.1.10",
+				"@vitest/mocker": "4.1.10",
+				"@vitest/pretty-format": "4.1.10",
+				"@vitest/runner": "4.1.10",
+				"@vitest/snapshot": "4.1.10",
+				"@vitest/spy": "4.1.10",
+				"@vitest/utils": "4.1.10",
+				"es-module-lexer": "^2.0.0",
+				"expect-type": "^1.3.0",
+				"magic-string": "^0.30.21",
+				"obug": "^2.1.1",
+				"pathe": "^2.0.3",
+				"picomatch": "^4.0.3",
+				"std-env": "^4.0.0-rc.1",
+				"tinybench": "^2.9.0",
+				"tinyexec": "^1.0.2",
+				"tinyglobby": "^0.2.15",
+				"tinyrainbow": "^3.1.0",
+				"vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+				"why-is-node-running": "^2.3.0"
+			},
+			"bin": {
+				"vitest": "vitest.mjs"
+			},
+			"engines": {
+				"node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			},
+			"peerDependencies": {
+				"@edge-runtime/vm": "*",
+				"@opentelemetry/api": "^1.9.0",
+				"@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+				"@vitest/browser-playwright": "4.1.10",
+				"@vitest/browser-preview": "4.1.10",
+				"@vitest/browser-webdriverio": "4.1.10",
+				"@vitest/coverage-istanbul": "4.1.10",
+				"@vitest/coverage-v8": "4.1.10",
+				"@vitest/ui": "4.1.10",
+				"happy-dom": "*",
+				"jsdom": "*",
+				"vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+			},
+			"peerDependenciesMeta": {
+				"@edge-runtime/vm": {
+					"optional": true
+				},
+				"@opentelemetry/api": {
+					"optional": true
+				},
+				"@types/node": {
+					"optional": true
+				},
+				"@vitest/browser-playwright": {
+					"optional": true
+				},
+				"@vitest/browser-preview": {
+					"optional": true
+				},
+				"@vitest/browser-webdriverio": {
+					"optional": true
+				},
+				"@vitest/coverage-istanbul": {
+					"optional": true
+				},
+				"@vitest/coverage-v8": {
+					"optional": true
+				},
+				"@vitest/ui": {
+					"optional": true
+				},
+				"happy-dom": {
+					"optional": true
+				},
+				"jsdom": {
+					"optional": true
+				},
+				"vite": {
+					"optional": false
+				}
+			}
+		},
+		"node_modules/why-is-node-running": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+			"integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"siginfo": "^2.0.0",
+				"stackback": "0.0.2"
+			},
+			"bin": {
+				"why-is-node-running": "cli.js"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		}
+	}
+}

--- a/packages/storage-filesystem/package.json
+++ b/packages/storage-filesystem/package.json
@@ -1,0 +1,35 @@
+{
+	"name": "@lix-js/storage-filesystem",
+	"type": "module",
+	"version": "0.1.0",
+	"license": "MIT",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/opral/lix",
+		"directory": "packages/storage-filesystem"
+	},
+	"exports": {
+		".": {
+			"types": "./dist/index.d.ts",
+			"default": "./dist/index.js"
+		}
+	},
+	"files": [
+		"dist",
+		"README.md"
+	],
+	"scripts": {
+		"build": "npm run clean && tsc -p tsconfig.json",
+		"clean": "node -e \"import('node:fs/promises').then(({ rm }) => rm('dist', { recursive: true, force: true }))\"",
+		"test": "vitest run",
+		"typecheck": "tsc -p tsconfig.test.json --noEmit"
+	},
+	"peerDependencies": {
+		"@lix-js/sdk": "^0.12.0"
+	},
+	"devDependencies": {
+		"@types/node": "^24.10.2",
+		"typescript": "^5.5.4",
+		"vitest": "4.1.10"
+	}
+}

--- a/packages/storage-filesystem/src/filesystem.rs
+++ b/packages/storage-filesystem/src/filesystem.rs
@@ -35,7 +35,6 @@ const FILESYSTEM_PARALLEL_SNAPSHOT_MIN_DIRS: usize = 4;
 struct FilesystemLayout {
     root: PathBuf,
     lix_dir: PathBuf,
-    lix_dir_is_default: bool,
 }
 
 impl FilesystemLayout {
@@ -77,21 +76,40 @@ impl FilesystemLayout {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive]
-pub struct LocalFilesystemOpenOptions {
-    pub root: PathBuf,
-    pub lix_dir: Option<PathBuf>,
-    pub sync_all_files: bool,
+pub struct FilesystemStorageOptions {
+    path: PathBuf,
+    sync_all_files: bool,
 }
 
-impl LocalFilesystemOpenOptions {
-    pub fn new<P>(root: P, sync_all_files: bool) -> Self
+impl FilesystemStorageOptions {
+    pub fn sync_all_files(mut self, sync_all_files: bool) -> Self {
+        self.sync_all_files = sync_all_files;
+        self
+    }
+
+    pub fn open(self) -> Result<FilesystemStorage, LixError> {
+        let layout = prepare_filesystem_layout(&self.path)?;
+        Ok(FilesystemStorage {
+            inner: open_filesystem_rocksdb(&layout)?,
+            layout,
+            sync_all_files: self.sync_all_files,
+            supervisor: Arc::new(Mutex::new(None)),
+        })
+    }
+}
+
+impl FilesystemStorage {
+    #[expect(
+        clippy::new_ret_no_self,
+        reason = "opening filesystem storage is fallible, so new configures and open performs I/O"
+    )]
+    pub fn new<P>(path: P) -> FilesystemStorageOptions
     where
         P: Into<PathBuf>,
     {
-        Self {
-            root: root.into(),
-            lix_dir: None,
-            sync_all_files,
+        FilesystemStorageOptions {
+            path: path.into(),
+            sync_all_files: true,
         }
     }
 }
@@ -103,17 +121,17 @@ struct FilesystemPathFilter {
 
 #[derive(Clone)]
 #[expect(missing_debug_implementations)]
-pub struct LocalFilesystem {
+pub struct FilesystemStorage {
     inner: RocksDBFilesystem,
     layout: FilesystemLayout,
     sync_all_files: bool,
     supervisor: Arc<Mutex<Option<Weak<FilesystemSupervisorInner>>>>,
 }
 
-pub type LocalFilesystemRead<'a> = crate::RocksDBFilesystemRead<'a>;
+pub type FilesystemStorageRead<'a> = crate::RocksDBFilesystemRead<'a>;
 
 #[expect(missing_debug_implementations)]
-pub struct LocalFilesystemWrite {
+pub struct FilesystemStorageWrite {
     inner: crate::RocksDBFilesystemWrite,
     supervisor: Option<Weak<FilesystemSupervisorInner>>,
 }
@@ -125,7 +143,7 @@ struct FilesystemSupervisor {
 
 #[derive(Clone)]
 #[expect(missing_debug_implementations)]
-pub struct LocalFilesystemSync {
+pub struct FilesystemStorageSync {
     supervisor: FilesystemSupervisor,
 }
 
@@ -146,7 +164,7 @@ struct FilesystemWatchPath {
 }
 
 struct FilesystemState {
-    lix: Lix<LocalFilesystem>,
+    lix: Lix<FilesystemStorage>,
     layout: FilesystemLayout,
     path_filter: Mutex<FilesystemPathFilter>,
     sync_lock: tokio::sync::Mutex<()>,
@@ -300,34 +318,13 @@ enum FilesystemEvent {
     Shutdown,
 }
 
-impl LocalFilesystem {
-    pub fn open<P>(dir: P) -> Result<Self, LixError>
-    where
-        P: AsRef<Path>,
-    {
-        Self::open_with_options(LocalFilesystemOpenOptions {
-            root: dir.as_ref().to_path_buf(),
-            lix_dir: None,
-            sync_all_files: true,
-        })
-    }
-
-    pub fn open_with_options(options: LocalFilesystemOpenOptions) -> Result<Self, LixError> {
-        let layout = prepare_filesystem_layout(&options.root, options.lix_dir.as_deref())?;
-        Ok(Self {
-            inner: open_filesystem_rocksdb(&layout)?,
-            layout,
-            sync_all_files: options.sync_all_files,
-            supervisor: Arc::new(Mutex::new(None)),
-        })
-    }
-
+impl FilesystemStorage {
     /// Starts bidirectional filesystem synchronization using another session
     /// on the supplied Lix repository.
     pub async fn start_sync(
         &self,
-        lix: &Lix<LocalFilesystem>,
-    ) -> Result<LocalFilesystemSync, LixError> {
+        lix: &Lix<FilesystemStorage>,
+    ) -> Result<FilesystemStorageSync, LixError> {
         if self
             .supervisor
             .lock()
@@ -357,11 +354,11 @@ impl LocalFilesystem {
             .lock()
             .expect("filesystem supervisor lock should not poison") =
             Some(Arc::downgrade(&supervisor.inner));
-        Ok(LocalFilesystemSync { supervisor })
+        Ok(FilesystemStorageSync { supervisor })
     }
 }
 
-impl LocalFilesystemSync {
+impl FilesystemStorageSync {
     pub async fn import_paths<I, S>(&self, paths: I) -> Result<(), LixError>
     where
         I: IntoIterator<Item = S>,
@@ -382,14 +379,14 @@ impl LocalFilesystemSync {
     }
 }
 
-impl Storage for LocalFilesystem {
+impl Storage for FilesystemStorage {
     type Read<'a>
-        = LocalFilesystemRead<'a>
+        = FilesystemStorageRead<'a>
     where
         Self: 'a;
 
     type Write<'a>
-        = LocalFilesystemWrite
+        = FilesystemStorageWrite
     where
         Self: 'a;
 
@@ -405,7 +402,7 @@ impl Storage for LocalFilesystem {
         opts: WriteOptions,
     ) -> impl Future<Output = Result<Self::Write<'_>, StorageError>> + Send {
         async move {
-            Ok(LocalFilesystemWrite {
+            Ok(FilesystemStorageWrite {
                 inner: self.inner.begin_write(opts).await?,
                 supervisor: self
                     .supervisor
@@ -417,7 +414,7 @@ impl Storage for LocalFilesystem {
     }
 }
 
-impl StorageWrite for LocalFilesystemWrite {
+impl StorageWrite for FilesystemStorageWrite {
     fn put_many(
         &mut self,
         space: StorageSpace,
@@ -462,7 +459,7 @@ impl StorageWrite for LocalFilesystemWrite {
 
 impl FilesystemSupervisor {
     async fn open(
-        lix: Lix<LocalFilesystem>,
+        lix: Lix<FilesystemStorage>,
         layout: FilesystemLayout,
         path_filter: FilesystemPathFilter,
     ) -> Result<Self, LixError> {
@@ -2092,74 +2089,15 @@ fn unsupported_materialization_entry(path: &str, local_path: &Path) -> LixError 
     )
 }
 
-fn prepare_filesystem_layout(
-    root: &Path,
-    lix_dir: Option<&Path>,
-) -> Result<FilesystemLayout, LixError> {
-    ensure_filesystem_root_directory(root)?;
-    let root = std::fs::canonicalize(root)
-        .map_err(|error| io_error("canonicalize filesystem root", root, error))?;
-    let default_lix_dir = root.join(".lix");
-    let requested_lix_dir = lix_dir.map_or_else(|| default_lix_dir.clone(), absolute_path);
-    validate_lix_directory_name(&requested_lix_dir)?;
-    let requested_lix_dir = normalize_path_lexically(&requested_lix_dir);
-    let default_lix_dir = normalize_path_lexically(&default_lix_dir);
-
-    if requested_lix_dir != default_lix_dir && requested_lix_dir.starts_with(&root) {
-        return Err(filesystem_error(format!(
-            "external filesystem .lix path {} must be outside root {}",
-            requested_lix_dir.display(),
-            root.display()
-        )));
-    }
-
-    ensure_filesystem_lix_directory(&requested_lix_dir)?;
-    let canonical_lix_dir = std::fs::canonicalize(&requested_lix_dir).map_err(|error| {
-        io_error(
-            "canonicalize filesystem .lix directory",
-            &requested_lix_dir,
-            error,
-        )
-    })?;
-    if canonical_lix_dir != default_lix_dir && canonical_lix_dir.starts_with(&root) {
-        return Err(filesystem_error(format!(
-            "external filesystem .lix path {} must be outside root {}",
-            canonical_lix_dir.display(),
-            root.display()
-        )));
-    }
-
-    Ok(FilesystemLayout {
-        root,
-        lix_dir_is_default: canonical_lix_dir == default_lix_dir,
-        lix_dir: canonical_lix_dir,
-    })
-}
-
-fn absolute_path(path: &Path) -> PathBuf {
-    if path.is_absolute() {
-        path.to_path_buf()
-    } else {
-        std::env::current_dir()
-            .unwrap_or_else(|_| PathBuf::from("."))
-            .join(path)
-    }
-}
-
-fn normalize_path_lexically(path: &Path) -> PathBuf {
-    let mut normalized = PathBuf::new();
-    for component in path.components() {
-        match component {
-            Component::CurDir => {}
-            Component::ParentDir => {
-                normalized.pop();
-            }
-            Component::Prefix(prefix) => normalized.push(prefix.as_os_str()),
-            Component::RootDir => normalized.push(component.as_os_str()),
-            Component::Normal(segment) => normalized.push(segment),
-        }
-    }
-    normalized
+fn prepare_filesystem_layout(path: &Path) -> Result<FilesystemLayout, LixError> {
+    ensure_filesystem_root_directory(path)?;
+    let root = std::fs::canonicalize(path)
+        .map_err(|error| io_error("canonicalize filesystem path", path, error))?;
+    let lix_dir = root.join(".lix");
+    ensure_filesystem_lix_directory(&lix_dir)?;
+    let lix_dir = std::fs::canonicalize(&lix_dir)
+        .map_err(|error| io_error("canonicalize filesystem .lix directory", &lix_dir, error))?;
+    Ok(FilesystemLayout { root, lix_dir })
 }
 
 fn open_filesystem_rocksdb(layout: &FilesystemLayout) -> Result<RocksDBFilesystem, LixError> {
@@ -2171,11 +2109,7 @@ fn ensure_filesystem_rocksdb_metadata_directory(
     layout: &FilesystemLayout,
 ) -> Result<PathBuf, LixError> {
     ensure_filesystem_lix_directory(&layout.lix_dir)?;
-    if layout.lix_dir_is_default {
-        remove_legacy_filesystem_root_metadata(&layout.root, &layout.lix_dir)?;
-    } else {
-        remove_legacy_filesystem_lix_metadata(&layout.lix_dir)?;
-    }
+    remove_legacy_filesystem_root_metadata(&layout.root, &layout.lix_dir)?;
     let internal_dir = layout.lix_dir.join(".internal");
     reset_legacy_filesystem_internal_directory(&internal_dir)?;
     ensure_metadata_directory(&internal_dir, "filesystem metadata directory")?;
@@ -2397,7 +2331,7 @@ mod tests {
         layout: FilesystemLayout,
         path_filter: FilesystemPathFilter,
     ) -> FilesystemState {
-        let storage = LocalFilesystem {
+        let storage = FilesystemStorage {
             inner: open_filesystem_rocksdb(&layout).unwrap(),
             layout: layout.clone(),
             sync_all_files: path_filter.is_unfiltered(),
@@ -2490,11 +2424,7 @@ mod tests {
         std::fs::create_dir_all(&lix_dir).unwrap();
         std::fs::write(root.join("target.txt"), b"target").unwrap();
         symlink("target.txt", root.join("link.txt")).unwrap();
-        let layout = FilesystemLayout {
-            root,
-            lix_dir,
-            lix_dir_is_default: true,
-        };
+        let layout = FilesystemLayout { root, lix_dir };
 
         let error = write_materialized_file(&layout, "/link.txt", b"replacement")
             .expect_err("a symlink collision must be reported");
@@ -2542,7 +2472,6 @@ mod tests {
         let layout = FilesystemLayout {
             root: std::fs::canonicalize(root).unwrap(),
             lix_dir: std::fs::canonicalize(lix_dir).unwrap(),
-            lix_dir_is_default: true,
         };
         let snapshot = collect_local_snapshot(&layout, &FilesystemPathFilter::default()).unwrap();
 
@@ -2585,7 +2514,7 @@ mod tests {
         std::fs::create_dir_all(root.join("docs")).unwrap();
         std::fs::write(root.join("docs").join("note.markdown"), b"note").unwrap();
 
-        let layout = prepare_filesystem_layout(root, None).unwrap();
+        let layout = prepare_filesystem_layout(root).unwrap();
         std::fs::create_dir_all(layout.lix_dir.join("app_data")).unwrap();
         std::fs::write(
             layout.lix_dir.join("app_data").join("test.bin"),
@@ -2650,7 +2579,7 @@ mod tests {
     #[tokio::test]
     async fn disk_sync_remembers_canonical_snapshot_for_idle_skip() {
         let tempdir = tempfile::tempdir().unwrap();
-        let layout = prepare_filesystem_layout(tempdir.path(), None).unwrap();
+        let layout = prepare_filesystem_layout(tempdir.path()).unwrap();
         let state = open_test_filesystem_state(layout, FilesystemPathFilter::default()).await;
 
         state.sync_disk_to_lix(false).await.unwrap();
@@ -2673,7 +2602,7 @@ mod tests {
     #[tokio::test]
     async fn disk_sync_does_not_reimport_unchanged_materialized_file_deleted_in_lix() {
         let tempdir = tempfile::tempdir().unwrap();
-        let layout = prepare_filesystem_layout(tempdir.path(), None).unwrap();
+        let layout = prepare_filesystem_layout(tempdir.path()).unwrap();
         let state = open_test_filesystem_state(layout, FilesystemPathFilter::default()).await;
 
         state.sync_disk_to_lix(false).await.unwrap();
@@ -2713,7 +2642,7 @@ mod tests {
     #[tokio::test]
     async fn disk_sync_does_not_skip_lix_side_file_content_change() {
         let tempdir = tempfile::tempdir().unwrap();
-        let layout = prepare_filesystem_layout(tempdir.path(), None).unwrap();
+        let layout = prepare_filesystem_layout(tempdir.path()).unwrap();
         let state = open_test_filesystem_state(layout, FilesystemPathFilter::default()).await;
 
         state.sync_disk_to_lix(false).await.unwrap();
@@ -2742,7 +2671,7 @@ mod tests {
     #[tokio::test]
     async fn disk_sync_materialization_preserves_file_changed_after_import() {
         let tempdir = tempfile::tempdir().unwrap();
-        let layout = prepare_filesystem_layout(tempdir.path(), None).unwrap();
+        let layout = prepare_filesystem_layout(tempdir.path()).unwrap();
         let state = open_test_filesystem_state(layout, FilesystemPathFilter::default()).await;
 
         state.sync_disk_to_lix(false).await.unwrap();
@@ -2789,17 +2718,12 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn local_filesystem_sync_disk_to_lix_syncs_repository_files() {
+    async fn filesystem_storage_sync_disk_to_lix_syncs_repository_files() {
         let tempdir = tempfile::tempdir().unwrap();
         std::fs::write(tempdir.path().join("tracked.md"), b"initial").unwrap();
         std::fs::write(tempdir.path().join("ignored.md"), b"ignored").unwrap();
 
-        let storage = LocalFilesystem::open_with_options(LocalFilesystemOpenOptions {
-            root: tempdir.path().to_path_buf(),
-            lix_dir: None,
-            sync_all_files: true,
-        })
-        .unwrap();
+        let storage = FilesystemStorage::new(tempdir.path()).open().unwrap();
         let lix = lix::open_lix().with_storage(storage.clone()).await.unwrap();
         let sync = storage.start_sync(&lix).await.unwrap();
 
@@ -2846,16 +2770,11 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn local_filesystem_sync_disk_to_lix_outlives_lix_session() {
+    async fn filesystem_storage_sync_disk_to_lix_outlives_lix_session() {
         let tempdir = tempfile::tempdir().unwrap();
         std::fs::write(tempdir.path().join("tracked.md"), b"initial").unwrap();
 
-        let storage = LocalFilesystem::open_with_options(LocalFilesystemOpenOptions {
-            root: tempdir.path().to_path_buf(),
-            lix_dir: None,
-            sync_all_files: true,
-        })
-        .unwrap();
+        let storage = FilesystemStorage::new(tempdir.path()).open().unwrap();
         let lix = lix::open_lix().with_storage(storage.clone()).await.unwrap();
         let sync = storage.start_sync(&lix).await.unwrap();
 
@@ -2881,41 +2800,6 @@ mod tests {
                 .unwrap(),
             b"changed"
         );
-        lix.close().await.unwrap();
-    }
-
-    #[tokio::test]
-    async fn external_lix_dir_stores_rocksdb_and_lix_files_outside_root() {
-        let root = tempfile::tempdir().unwrap();
-        let external = tempfile::tempdir().unwrap();
-        let lix_dir = external.path().join(".lix");
-
-        let storage = LocalFilesystem::open_with_options(LocalFilesystemOpenOptions {
-            root: root.path().to_path_buf(),
-            lix_dir: Some(lix_dir.clone()),
-            sync_all_files: true,
-        })
-        .unwrap();
-        let lix = lix::open_lix().with_storage(storage.clone()).await.unwrap();
-        let _sync = storage.start_sync(&lix).await.unwrap();
-
-        lix.execute(
-            "INSERT INTO lix_file (path, content) VALUES ($1, $2)",
-            &[
-                Value::Text("/.lix/app_data/test.bin".to_string()),
-                Value::Blob(b"plugin".to_vec().into()),
-            ],
-        )
-        .await
-        .unwrap();
-
-        assert!(lix_dir.join(".internal").join("rocksdb").is_dir());
-        assert_eq!(
-            std::fs::read(lix_dir.join("app_data").join("test.bin")).unwrap(),
-            b"plugin"
-        );
-        assert!(!root.path().join(".lix").exists());
-
         lix.close().await.unwrap();
     }
 }

--- a/packages/storage-filesystem/src/lib.rs
+++ b/packages/storage-filesystem/src/lib.rs
@@ -6,8 +6,8 @@
 mod filesystem;
 
 pub use filesystem::{
-    LocalFilesystem, LocalFilesystemOpenOptions, LocalFilesystemRead, LocalFilesystemSync,
-    LocalFilesystemWrite,
+    FilesystemStorage, FilesystemStorageOptions, FilesystemStorageRead, FilesystemStorageSync,
+    FilesystemStorageWrite,
 };
 pub use lix_storage_rocksdb::{
     RocksDB as RocksDBFilesystem, RocksDBRead as RocksDBFilesystemRead,

--- a/packages/storage-filesystem/tsconfig.json
+++ b/packages/storage-filesystem/tsconfig.json
@@ -1,0 +1,17 @@
+{
+	"compilerOptions": {
+		"target": "ES2022",
+		"module": "NodeNext",
+		"moduleResolution": "NodeNext",
+		"strict": true,
+		"declaration": true,
+		"declarationMap": true,
+		"sourceMap": true,
+		"outDir": "dist",
+		"rootDir": "js",
+		"verbatimModuleSyntax": true,
+		"skipLibCheck": true
+	},
+	"include": ["js/index.ts"],
+	"exclude": ["dist", "node_modules"]
+}

--- a/packages/storage-filesystem/tsconfig.test.json
+++ b/packages/storage-filesystem/tsconfig.test.json
@@ -1,0 +1,9 @@
+{
+	"extends": "./tsconfig.json",
+	"compilerOptions": {
+		"noEmit": true,
+		"rootDir": "..",
+		"types": ["node", "vitest/globals"]
+	},
+	"include": ["js/**/*.ts"]
+}


### PR DESCRIPTION
## Summary

- add independently versioned `@lix-js/storage-filesystem` next to the `lix-storage-filesystem` Rust crate
- hard-cut `LocalFilesystem` to `FilesystemStorage` across Rust and JavaScript
- simplify Rust to `FilesystemStorage::new(path).sync_all_files(...).open()` and JavaScript to `new FilesystemStorage({ path, syncAllFiles? })`
- remove external `lixDir` support and keep metadata at `<path>/.lix`
- remove filesystem storage exports from `@lix-js/sdk`; the SDK accepts the package through a small structural adapter contract while its native addon continues linking the Rust crate
- build, test, pack, and independently publish the new npm package in the existing JS jobs

## Validation

- `cargo clippy --profile test --workspace --all-targets --all-features -- -D warnings`
- `cargo test -p lix-storage-filesystem` (18 passed)
- focused `lix_e2e` filesystem suite (24 passed)
- rebuilt native SDK plus `vitest run` (131 passed)
- storage package build, typecheck, tests, and `npm pack --dry-run`
- `actionlint` on CI and publish workflows
- changenote and Cargo publish-surface validators
- rebased onto `origin/main` at `898879893`