### PR TITLE
typed-slot writer: a byte-valued payload channel through the head value

### DIFF
--- a/packages/lix/src/hot_state/tracked_head.rs
+++ b/packages/lix/src/hot_state/tracked_head.rs
@@ -1321,17 +1321,26 @@ fn working_diff_error(message: &str) -> LixError {
 /// 50..54  snapshot payload byte length (big endian u32)
 /// 54..58  metadata payload byte length (big endian u32)
 /// 58      columnar base-coordinate presence (0 or 1)
-/// 59..    snapshot payload, metadata payload, then an optional fixed
+/// 59      payload encoding: bit 0 snapshot is a typed-slot record, bit 1
+///          metadata is. Zero means both payloads are JSON text.
+/// 60..    snapshot payload, metadata payload, then an optional fixed
 ///          checkpoint before-image, then an optional 24-byte base coordinate
 /// ```
 ///
 /// Slot payloads are either inline UTF-8 JSON, a fixed 32-byte `JsonRef`, or
 /// that same fingerprint followed by inline JSON for dirty working-diff rows.
+///
+/// An inline payload is additionally either JSON text or a *typed-slot record*
+/// (`hot_state::typed_slots`), whose fixed-width number payloads are not valid
+/// UTF-8 and so cannot travel through the `&str`-typed inline slot. Which one a
+/// row carries is stated by the payload-encoding byte and is never inferred
+/// from the payload's own bytes: a format that guesses its own discriminant has
+/// no way to fail loudly when the guess is wrong.
 /// Persisting fingerprints only while a row is dirty keeps repeated diff
 /// classification independent of payload size without taxing checkpointed
 /// current state.
-const HEAD_VALUE_VERSION: u8 = 9;
-const HEAD_VALUE_HEADER_BYTES: usize = 59;
+const HEAD_VALUE_VERSION: u8 = 10;
+const HEAD_VALUE_HEADER_BYTES: usize = 60;
 const COLUMNAR_BASE_COORDINATE_BYTES: usize = 16 + 4 + 4;
 const HEAD_VALUE_DELETED: u8 = 0b0000_0001;
 const HEAD_VALUE_SNAPSHOT_SHIFT: u8 = 1;
@@ -1344,6 +1353,8 @@ const HEAD_SLOT_NONE: u8 = 0;
 const HEAD_SLOT_REF: u8 = 1;
 const HEAD_SLOT_INLINE: u8 = 2;
 const HEAD_SLOT_INLINE_FINGERPRINTED: u8 = 3;
+const HEAD_PAYLOAD_TYPED_SNAPSHOT: u8 = 0b0000_0001;
+const HEAD_PAYLOAD_TYPED_METADATA: u8 = 0b0000_0010;
 const HEAD_WORKING_DIFF_DISABLED: u8 = 0;
 const HEAD_WORKING_DIFF_CLEAN: u8 = 1;
 const HEAD_WORKING_DIFF_BEFORE_ABSENT: u8 = 2;
@@ -1356,7 +1367,13 @@ enum HeadSlotView<'a> {
     None,
     Ref(JsonRef),
     Inline(&'a str),
-    InlineFingerprinted { json_ref: JsonRef, json: &'a str },
+    InlineFingerprinted {
+        json_ref: JsonRef,
+        json: &'a str,
+    },
+    /// A typed-slot record. Not UTF-8, and deliberately a separate variant
+    /// rather than a reinterpretation of `Inline`.
+    Typed(&'a [u8]),
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -1558,7 +1575,65 @@ fn working_diff_slot_fingerprint(slot: HeadSlotView<'_>) -> WorkingDiffSlotFinge
             kind: WORKING_DIFF_SLOT_INLINE,
             hash: *json_ref.as_hash_array(),
         },
+        // The fingerprint must agree across the two representations, because a
+        // row's before-image may be stored as JSON text while its current
+        // version is a typed record. It does, and only because reconstruction
+        // is byte-identical to the text the record replaced: hashing the
+        // reconstruction is hashing the same bytes the JSON slot would have
+        // hashed. An unresolvable record answers `unresolved` rather than
+        // guessing -- an accelerator may decline, but must never be confidently
+        // wrong.
+        HeadSlotView::Typed(record) => match typed_slot_canonical_json(record) {
+            Ok(json) => WorkingDiffSlotFingerprint {
+                kind: WORKING_DIFF_SLOT_INLINE,
+                hash: *JsonRef::for_content(json.as_bytes()).as_hash_array(),
+            },
+            Err(_) => WorkingDiffSlotFingerprint::unresolved(),
+        },
     }
+}
+
+/// Rebuilds the JSON text a typed-slot record was encoded from.
+///
+/// The layout comes from the record's own fingerprint, so no schema key has to
+/// be threaded to a read site, and a record whose layout this binary does not
+/// know is an error rather than a positional misread.
+fn typed_slot_canonical_json(record: &[u8]) -> Result<String, LixError> {
+    let parsed = crate::hot_state::typed_slots::TypedSlotsRef::parse(record)
+        .map_err(|error| head_value_error(&format!("typed snapshot slot: {error}")))?;
+    let layout =
+        crate::hot_state::typed_slots::builtin_layout_for_fingerprint(parsed.layout_fingerprint())
+            .ok_or_else(|| {
+            head_value_error("typed snapshot slot names a column layout this build does not know")
+        })?;
+    parsed
+        .to_canonical_json(layout)
+        .map_err(|error| head_value_error(&format!("typed snapshot slot: {error}")))
+}
+
+/// Encodes one snapshot as a typed-slot record, or declines.
+///
+/// Declining is always safe: the row is then stored as JSON text exactly as it
+/// is today. The key check is the load-bearing one -- `encode_typed_slots`
+/// writes a slot per *declared* column, so a key the layout does not declare
+/// would be silently dropped. Closed schemas make that unreachable, and this
+/// check is what makes it a mechanism rather than a reading of the schema
+/// files.
+fn typed_snapshot_record(
+    layout: &crate::hot_state::typed_slots::TypedSlotLayout,
+    json: &str,
+) -> Option<Vec<u8>> {
+    let serde_json::Value::Object(map) = serde_json::from_str::<serde_json::Value>(json).ok()?
+    else {
+        return None;
+    };
+    if map.keys().any(|key| layout.index_of(key).is_none()) {
+        return None;
+    }
+    let record = crate::hot_state::typed_slots::encode_typed_slots(layout, &map).ok()?;
+    #[cfg(test)]
+    crate::hot_state::typed_slots::record_typed_slot_record_written();
+    Some(record)
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -1569,6 +1644,7 @@ enum HeadSlotEncode<'a> {
         json_ref: Option<JsonRef>,
         json: &'a str,
     },
+    Typed(&'a [u8]),
 }
 
 impl<'a> From<JsonSlotRef<'a>> for HeadSlotEncode<'a> {
@@ -1597,6 +1673,7 @@ impl<'a> From<HeadSlotView<'a>> for HeadSlotEncode<'a> {
                 json_ref: Some(json_ref),
                 json,
             },
+            HeadSlotView::Typed(record) => Self::Typed(record),
         }
     }
 }
@@ -1625,6 +1702,41 @@ fn append_head_value(
     bytes: &mut Vec<u8>,
     value: &HeadValueRef<'_>,
 ) -> Result<std::ops::Range<usize>, LixError> {
+    append_head_value_with_typed_layout(bytes, value, None)
+}
+
+/// Stages one head row, encoding its snapshot as a typed-slot record when the
+/// caller resolved a layout for the row's schema.
+///
+/// The typed record replaces the row's *stored* snapshot payload only. Change
+/// records are content-addressed by their JSON text and are untouched by this;
+/// what changes is the representation of current state in the head, which is a
+/// copy.
+fn append_head_value_with_typed_layout(
+    bytes: &mut Vec<u8>,
+    value: &HeadValueRef<'_>,
+    typed_layout: Option<&crate::hot_state::typed_slots::TypedSlotLayout>,
+) -> Result<std::ops::Range<usize>, LixError> {
+    let snapshot: HeadSlotEncode<'_> = value.snapshot.into();
+    // A dirty working-diff row prefixes its inline payload with the JSON
+    // fingerprint; that lane keeps JSON text rather than growing a second
+    // framing this round.
+    let fingerprint_inline = matches!(
+        value.working_diff_baseline,
+        WorkingDiffBaseline::BeforeAbsent { .. } | WorkingDiffBaseline::BeforePresent { .. }
+    );
+    let typed_record = match (typed_layout, snapshot) {
+        (Some(layout), HeadSlotEncode::Inline { json, .. })
+            if !value.deleted && !fingerprint_inline =>
+        {
+            typed_snapshot_record(layout, json)
+        }
+        _ => None,
+    };
+    let snapshot = match typed_record.as_deref() {
+        Some(record) => HeadSlotEncode::Typed(record),
+        None => snapshot,
+    };
     append_head_value_parts(
         bytes,
         HeadValueEncode {
@@ -1634,7 +1746,7 @@ fn append_head_value(
             deleted: value.deleted,
             created_at: value.created_at,
             updated_at: value.updated_at,
-            snapshot: value.snapshot.into(),
+            snapshot,
             metadata: value.metadata.into(),
             columnar_base_coordinate: value.columnar_base_coordinate,
             working_diff_baseline: value.working_diff_baseline,
@@ -1781,6 +1893,14 @@ fn append_head_value_parts(
             .to_be_bytes(),
     );
     bytes.push(u8::from(value.columnar_base_coordinate.is_some()));
+    let mut payload_encoding = 0_u8;
+    if matches!(value.snapshot, HeadSlotEncode::Typed(_)) {
+        payload_encoding |= HEAD_PAYLOAD_TYPED_SNAPSHOT;
+    }
+    if matches!(value.metadata, HeadSlotEncode::Typed(_)) {
+        payload_encoding |= HEAD_PAYLOAD_TYPED_METADATA;
+    }
+    bytes.push(payload_encoding);
     append_slot_payload(bytes, value.snapshot, fingerprint_inline);
     append_slot_payload(bytes, value.metadata, fingerprint_inline);
     match value.working_diff_baseline {
@@ -1819,7 +1939,7 @@ fn encoded_slot_kind(slot: HeadSlotEncode<'_>, fingerprint_inline: bool) -> u8 {
         HeadSlotEncode::None => HEAD_SLOT_NONE,
         HeadSlotEncode::Ref(_) => HEAD_SLOT_REF,
         HeadSlotEncode::Inline { .. } if fingerprint_inline => HEAD_SLOT_INLINE_FINGERPRINTED,
-        HeadSlotEncode::Inline { .. } => HEAD_SLOT_INLINE,
+        HeadSlotEncode::Inline { .. } | HeadSlotEncode::Typed(_) => HEAD_SLOT_INLINE,
     }
 }
 
@@ -1831,6 +1951,7 @@ fn encoded_slot_len(slot: HeadSlotEncode<'_>, fingerprint_inline: bool) -> usize
             JSON_REF_BYTES.saturating_add(json.len())
         }
         HeadSlotEncode::Inline { json, .. } => json.len(),
+        HeadSlotEncode::Typed(record) => record.len(),
     }
 }
 
@@ -1844,6 +1965,7 @@ fn append_slot_payload(bytes: &mut Vec<u8>, slot: HeadSlotEncode<'_>, fingerprin
             bytes.extend_from_slice(json.as_bytes());
         }
         HeadSlotEncode::Inline { json, .. } => bytes.extend_from_slice(json.as_bytes()),
+        HeadSlotEncode::Typed(record) => bytes.extend_from_slice(record),
     }
 }
 
@@ -1890,13 +2012,19 @@ fn decode_head_value(bytes: &[u8]) -> Result<HeadValueView<'_>, LixError> {
     let metadata_end = snapshot_end
         .checked_add(metadata_len)
         .ok_or_else(|| head_value_error("metadata payload length overflow"))?;
+    let payload_encoding = bytes[59];
+    if payload_encoding & !(HEAD_PAYLOAD_TYPED_SNAPSHOT | HEAD_PAYLOAD_TYPED_METADATA) != 0 {
+        return Err(head_value_error("invalid payload encoding byte"));
+    }
     let snapshot = decode_slot(
         snapshot_kind,
+        payload_encoding & HEAD_PAYLOAD_TYPED_SNAPSHOT != 0,
         &bytes[HEAD_VALUE_HEADER_BYTES..snapshot_end],
         "snapshot",
     )?;
     let metadata = decode_slot(
         metadata_kind,
+        payload_encoding & HEAD_PAYLOAD_TYPED_METADATA != 0,
         &bytes[snapshot_end..metadata_end],
         "metadata",
     )?;
@@ -2044,7 +2172,23 @@ fn read_u32(bytes: &[u8], field: &str) -> Result<u32, LixError> {
     Ok(u32::from_be_bytes(bytes))
 }
 
-fn decode_slot<'a>(kind: u8, bytes: &'a [u8], field: &str) -> Result<HeadSlotView<'a>, LixError> {
+fn decode_slot<'a>(
+    kind: u8,
+    typed: bool,
+    bytes: &'a [u8],
+    field: &str,
+) -> Result<HeadSlotView<'a>, LixError> {
+    if typed {
+        // The typed payload rides the inline slot kind and is distinguished by
+        // the header's encoding byte. Any other kind with the typed bit set is
+        // a corrupt row, not a payload to reinterpret.
+        return match kind {
+            HEAD_SLOT_INLINE => Ok(HeadSlotView::Typed(bytes)),
+            _ => Err(head_value_error(&format!(
+                "{field} is marked as a typed-slot record but carries slot kind {kind}"
+            ))),
+        };
+    }
     match kind {
         HEAD_SLOT_NONE if bytes.is_empty() => Ok(HeadSlotView::None),
         HEAD_SLOT_NONE => Err(head_value_error(&format!(
@@ -2223,7 +2367,7 @@ where
             &mut deferred,
             row_index,
             DeferredJsonField::Snapshot,
-        );
+        )?;
         let metadata = materialize_live_slot(
             !value.deleted && projection.metadata,
             &bytes,
@@ -2232,7 +2376,7 @@ where
             &mut deferred,
             row_index,
             DeferredJsonField::Metadata,
-        );
+        )?;
         identity.push_materialized(
             &mut rows,
             snapshot_content,
@@ -2296,12 +2440,26 @@ fn materialize_live_slot(
     deferred: &mut Vec<DeferredJson>,
     row_index: usize,
     field: DeferredJsonField,
-) -> Option<SharedStr> {
+) -> Result<Option<SharedStr>, LixError> {
     if !include {
-        return None;
+        return Ok(None);
     }
-    match slot {
+    Ok(match slot {
         HeadSlotView::None => None,
+        // Reconstruction on demand is what lets a typed record serve the
+        // existing text consumers unchanged. It is byte-identical to the
+        // normalized text it replaced, so content addressing over the result is
+        // unaffected -- that property is a correctness precondition here, not a
+        // nicety.
+        HeadSlotView::Typed(record) => {
+            let json = typed_slot_canonical_json(record)?;
+            #[cfg(test)]
+            crate::hot_state::typed_slots::record_typed_slot_read_served();
+            Some(
+                SharedStr::from_utf8(Bytes::from(json.into_bytes()))
+                    .expect("reconstructed canonical JSON is UTF-8"),
+            )
+        }
         HeadSlotView::Inline(json) | HeadSlotView::InlineFingerprinted { json, .. } => {
             #[cfg(feature = "storage-benches")]
             crate::storage_bench::record_hot_scan_value_handle_clone();
@@ -2319,7 +2477,7 @@ fn materialize_live_slot(
             });
             None
         }
-    }
+    })
 }
 
 #[cfg(test)]
@@ -2490,6 +2648,115 @@ mod tests {
             .expect("working diff must be current")
     }
 
+    /// A read served out of a stored typed-slot record, and the byte-identity
+    /// the whole staged landing rests on.
+    ///
+    /// The counter is the point. A decode branch that exists but is never taken
+    /// looks exactly like a live one in a diff, so engagement is asserted from
+    /// the counter the read path increments, with a positive control -- a schema
+    /// carrying a JSON-declared column -- taking the other route in the same
+    /// run.
+    #[test]
+    fn a_head_row_for_an_all_scalar_schema_is_stored_typed_and_read_back_byte_identically() {
+        use crate::hot_state::typed_slots::{
+            TYPED_SLOT_READS_SERVED, TYPED_SLOT_RECORDS_WRITTEN, builtin_layout_for_schema_key,
+        };
+        use std::sync::atomic::Ordering;
+
+        let json = r#"{"id":"account-1","kind":"human","name":"Ada","status":"active"}"#;
+        let value = HeadValueRef {
+            change_id: Some(ChangeId::for_test_label("typed-change")),
+            commit_id: Some(CommitId::for_test_label("typed-commit")),
+            untracked: false,
+            deleted: false,
+            created_at: ts("2026-01-01T00:00:00Z"),
+            updated_at: ts("2026-01-02T00:00:00Z"),
+            snapshot: JsonSlotRef::Inline(json),
+            metadata: JsonSlotRef::None,
+            columnar_base_coordinate: None,
+            working_diff_baseline: WorkingDiffBaseline::Disabled,
+        };
+
+        let writes_before = TYPED_SLOT_RECORDS_WRITTEN.load(Ordering::Relaxed);
+        let reads_before = TYPED_SLOT_READS_SERVED.load(Ordering::Relaxed);
+
+        let mut typed_bytes = Vec::new();
+        append_head_value_with_typed_layout(
+            &mut typed_bytes,
+            &value,
+            builtin_layout_for_schema_key("lix_account"),
+        )
+        .expect("stage a typed head row");
+        assert!(
+            TYPED_SLOT_RECORDS_WRITTEN.load(Ordering::Relaxed) > writes_before,
+            "the writer did not encode a typed record"
+        );
+        // The discriminant is in the header, never inferred from the payload.
+        assert_eq!(
+            typed_bytes[59] & HEAD_PAYLOAD_TYPED_SNAPSHOT,
+            HEAD_PAYLOAD_TYPED_SNAPSHOT
+        );
+        assert_ne!(typed_bytes[HEAD_VALUE_HEADER_BYTES], b'{');
+
+        let typed_bytes = Bytes::from(typed_bytes);
+        let decoded = decode_head_value(&typed_bytes).expect("decode a typed head row");
+        assert!(matches!(decoded.snapshot, HeadSlotView::Typed(_)));
+
+        let mut json_refs = Vec::new();
+        let mut deferred = Vec::new();
+        let snapshot = materialize_live_slot(
+            true,
+            &typed_bytes,
+            decoded.snapshot,
+            &mut json_refs,
+            &mut deferred,
+            0,
+            DeferredJsonField::Snapshot,
+        )
+        .expect("materialize a typed row")
+        .expect("snapshot view");
+        // Content addressing hashes this text, so a reconstruction that differs
+        // by one byte is a correctness break rather than a slow path.
+        assert_eq!(snapshot.as_str(), json);
+        assert!(
+            TYPED_SLOT_READS_SERVED.load(Ordering::Relaxed) > reads_before,
+            "the read was not served out of a typed record"
+        );
+
+        // Positive control, same run: `lix_key_value.value` is arbitrary JSON by
+        // design, so that schema has no layout and the same call stores text.
+        let control_json = r#"{"key":"k","value":{"nested":true}}"#;
+        let control = HeadValueRef {
+            snapshot: JsonSlotRef::Inline(control_json),
+            ..value
+        };
+        let mut control_bytes = Vec::new();
+        append_head_value_with_typed_layout(
+            &mut control_bytes,
+            &control,
+            builtin_layout_for_schema_key("lix_key_value"),
+        )
+        .expect("stage a json head row");
+        assert_eq!(control_bytes[59] & HEAD_PAYLOAD_TYPED_SNAPSHOT, 0);
+        let control_bytes = Bytes::from(control_bytes);
+        let control_decoded = decode_head_value(&control_bytes).expect("decode a json head row");
+        assert_eq!(control_decoded.snapshot, HeadSlotView::Inline(control_json));
+    }
+
+    /// The dirty/clean transition compares payload fingerprints, and a row's
+    /// before-image may be stored as text while its current version is typed.
+    #[test]
+    fn a_typed_slot_fingerprints_identically_to_the_json_text_it_replaced() {
+        let json = r#"{"id":"account-1","kind":"human","name":"Ada","status":"active"}"#;
+        let layout = crate::hot_state::typed_slots::builtin_layout_for_schema_key("lix_account")
+            .expect("lix_account has a typed-slot layout");
+        let record = typed_snapshot_record(layout, json).expect("typed record");
+        assert_eq!(
+            working_diff_slot_fingerprint(HeadSlotView::Typed(&record)),
+            working_diff_slot_fingerprint(HeadSlotView::Inline(json))
+        );
+    }
+
     #[test]
     fn v8_value_codec_roundtrips_clean_inline_ref_and_base_coordinate() {
         let snapshot_ref = JsonRef::from_hash_bytes([7; JSON_REF_BYTES]);
@@ -2563,6 +2830,7 @@ mod tests {
             0,
             DeferredJsonField::Snapshot,
         )
+        .expect("materialize snapshot")
         .expect("snapshot view");
         let metadata = materialize_live_slot(
             true,
@@ -2573,6 +2841,7 @@ mod tests {
             0,
             DeferredJsonField::Metadata,
         )
+        .expect("materialize metadata")
         .expect("metadata view");
 
         assert!(snapshot.shares_buffer_with(&metadata));

--- a/packages/lix/src/hot_state/tracked_head/hot.rs
+++ b/packages/lix/src/hot_state/tracked_head/hot.rs
@@ -527,7 +527,7 @@ impl DeferredFinalPutSource for DeferredFreshHotSource {
             let delta = self.state_rows.row(row_index).delta;
             key_ranges.push(append_hot_mutation_identity(&mut key_bytes, &scope, &delta));
             value_ranges.push(
-                append_head_value(
+                append_head_value_with_typed_layout(
                     &mut value_bytes,
                     &delta.value_ref(
                         delta.created_at,
@@ -538,6 +538,9 @@ impl DeferredFinalPutSource for DeferredFreshHotSource {
                         } else {
                             WorkingDiffBaseline::Disabled
                         },
+                    ),
+                    crate::hot_state::typed_slots::builtin_layout_for_schema_key(
+                        delta.schema_key,
                     ),
                 )
                 .expect("deferred fresh hot rows were validated before staging"),
@@ -8785,7 +8788,13 @@ where
                             delta,
                             previous.as_ref(),
                         )?;
-                        Some(append_head_value(&mut next_value_bytes, &value)?)
+                        Some(append_head_value_with_typed_layout(
+                    &mut next_value_bytes,
+                    &value,
+                    crate::hot_state::typed_slots::builtin_layout_for_schema_key(
+                        delta.schema_key,
+                    ),
+                )?)
                     },
                 );
             }

--- a/packages/lix/src/hot_state/typed_slots.rs
+++ b/packages/lix/src/hot_state/typed_slots.rs
@@ -15,13 +15,19 @@
 //!
 //! ```text
 //!  0        format version (1)
-//!  1..3     declared column count (big endian u16)
-//!  3..3+9n  directory, 9 bytes per declared column, in layout order:
+//!  1..9     layout fingerprint (blake3 prefix over the declared columns)
+//!  9..11    declared column count (big endian u16)
+//!  11..11+9n directory, 9 bytes per declared column, in layout order:
 //!               [0]    slot tag
 //!               [1..5] payload offset within the payload area (big endian u32)
 //!               [5..9] payload byte length (big endian u32)
-//!  3+9n..   payload area
+//!  11+9n..  payload area
 //! ```
+//!
+//! The layout fingerprint is what makes resolving a layout a *mechanism*
+//! rather than a convention. A reader that looked the layout up by schema key
+//! and got a different column set than the writer used would decode every slot
+//! at the wrong name, silently. Reconstruction refuses instead.
 //!
 //! Column *names* are not stored. A reader resolves a name to a slot index once
 //! per batch against the schema layout, then indexes the directory directly, so
@@ -70,7 +76,9 @@ use serde_json::{Map as JsonMap, Number as JsonNumber, Value as JsonValue};
 /// stored-format change.
 pub(crate) const TYPED_SLOTS_VERSION: u8 = 1;
 
-const HEADER_BYTES: usize = 3;
+const HEADER_BYTES: usize = 11;
+/// Bytes of the layout digest carried in the header, at offset 1.
+pub(crate) const LAYOUT_FINGERPRINT_BYTES: usize = 8;
 const DIRECTORY_ENTRY_BYTES: usize = 9;
 
 const TAG_NULL: u8 = 0;
@@ -131,6 +139,19 @@ pub(crate) enum DeclaredType {
 impl DeclaredType {
     pub(crate) fn is_scalar(self) -> bool {
         !matches!(self, Self::Json)
+    }
+
+    /// Stable discriminant for the layout fingerprint. Written into stored
+    /// records, so these numbers are a format constant and must not be
+    /// renumbered without a `REPOSITORY_PROTOCOL_VALUE` bump.
+    fn fingerprint_tag(self) -> u8 {
+        match self {
+            Self::String => 1,
+            Self::Integer => 2,
+            Self::Number => 3,
+            Self::Boolean => 4,
+            Self::Json => 5,
+        }
     }
 }
 
@@ -223,6 +244,24 @@ impl TypedSlotLayout {
         self.columns.get(index).map(|(_, declared)| *declared)
     }
 
+    /// A digest of the declared columns, in layout order.
+    ///
+    /// Every record carries this, and reconstruction refuses a layout whose
+    /// fingerprint does not match the record's. That converts "the registry
+    /// handed back the columns the writer used" from something a reader has to
+    /// trust into something it checks.
+    pub(crate) fn fingerprint(&self) -> [u8; LAYOUT_FINGERPRINT_BYTES] {
+        let mut hasher = blake3::Hasher::new();
+        for (name, declared) in &self.columns {
+            hasher.update(&(name.len() as u64).to_be_bytes());
+            hasher.update(name.as_bytes());
+            hasher.update(&[declared.fingerprint_tag()]);
+        }
+        let mut fingerprint = [0_u8; LAYOUT_FINGERPRINT_BYTES];
+        fingerprint.copy_from_slice(&hasher.finalize().as_bytes()[..LAYOUT_FINGERPRINT_BYTES]);
+        fingerprint
+    }
+
     /// True when every declared column is scalar, so no slot in this layout
     /// carries JSON text.
     pub(crate) fn is_all_scalar(&self) -> bool {
@@ -270,6 +309,7 @@ pub(crate) fn encode_typed_slots(
     let directory_bytes = layout.len() * DIRECTORY_ENTRY_BYTES;
     let mut bytes = Vec::with_capacity(HEADER_BYTES + directory_bytes + snapshot.len() * 16);
     bytes.push(TYPED_SLOTS_VERSION);
+    bytes.extend_from_slice(&layout.fingerprint());
     let count = u16::try_from(layout.len()).map_err(|_| {
         TypedSlotError::new("typed slot layout exceeds the u16 column count the header carries")
     })?;
@@ -409,7 +449,10 @@ impl<'a> TypedSlotsRef<'a> {
                 bytes[0]
             )));
         }
-        let count = usize::from(u16::from_be_bytes([bytes[1], bytes[2]]));
+        let count = usize::from(u16::from_be_bytes([
+            bytes[1 + LAYOUT_FINGERPRINT_BYTES],
+            bytes[2 + LAYOUT_FINGERPRINT_BYTES],
+        ]));
         let payload_start = HEADER_BYTES + count * DIRECTORY_ENTRY_BYTES;
         if bytes.len() < payload_start {
             return Err(TypedSlotError::new(
@@ -449,6 +492,13 @@ impl<'a> TypedSlotsRef<'a> {
 
     pub(crate) fn len(&self) -> usize {
         self.count
+    }
+
+    /// The digest of the layout this record was encoded against.
+    pub(crate) fn layout_fingerprint(&self) -> [u8; LAYOUT_FINGERPRINT_BYTES] {
+        let mut fingerprint = [0_u8; LAYOUT_FINGERPRINT_BYTES];
+        fingerprint.copy_from_slice(&self.bytes[1..1 + LAYOUT_FINGERPRINT_BYTES]);
+        fingerprint
     }
 
     fn directory_entry(&self, index: usize) -> (u8, usize, usize) {
@@ -569,6 +619,11 @@ impl<'a> TypedSlotsRef<'a> {
     }
 
     pub(crate) fn to_json_value(&self, layout: &TypedSlotLayout) -> Result<JsonValue> {
+        if layout.fingerprint() != self.layout_fingerprint() {
+            return Err(TypedSlotError::new(
+                "typed slot record was written against a different column layout",
+            ));
+        }
         if layout.len() != self.count {
             return Err(TypedSlotError::new(format!(
                 "typed slot record has {} slots but its layout declares {}",
@@ -637,6 +692,203 @@ fn utf8<'a>(payload: &'a [u8], index: usize) -> Result<&'a str> {
 /// them.
 pub(crate) fn typed_slots_fingerprint(bytes: &[u8]) -> [u8; 32] {
     *blake3::hash(bytes).as_bytes()
+}
+
+/// Typed-slot layouts for the crate's built-in schemas.
+///
+/// The layouts are derived from the schema definitions compiled into this
+/// binary (`schema/builtin/*.json`, `include_str!`-ed), so a layout is a
+/// deterministic function of the binary rather than of repository content or
+/// of the order in which surfaces happened to be built. Two consequences that
+/// this design leans on:
+///
+/// * A change to a built-in schema changes the layout, hence the fingerprint,
+///   hence the stored bytes — which is a stored-format change and is carried by
+///   `REPOSITORY_PROTOCOL_VALUE` like any other.
+/// * A reader never has to trust that a schema-key lookup returned the writer's
+///   columns: `to_json_value` compares the fingerprint the record carries
+///   against the layout it was handed and refuses on a mismatch.
+///
+/// Only schemas that are closed (`additionalProperties: false`) and whose every
+/// declared property is scalar get a layout. A schema carrying a JSON-declared
+/// column is skipped entirely here: the format supports a verbatim `Json` slot,
+/// but the writer this registry feeds is deliberately scoped to the all-scalar
+/// case for now.
+struct BuiltinTypedSlotLayouts {
+    by_schema_key: BTreeMap<String, TypedSlotLayout>,
+    by_fingerprint: BTreeMap<[u8; LAYOUT_FINGERPRINT_BYTES], String>,
+}
+
+static BUILTIN_LAYOUTS: std::sync::OnceLock<BuiltinTypedSlotLayouts> = std::sync::OnceLock::new();
+
+fn builtin_layouts() -> &'static BuiltinTypedSlotLayouts {
+    BUILTIN_LAYOUTS.get_or_init(|| {
+        let mut by_schema_key = BTreeMap::new();
+        let mut by_fingerprint = BTreeMap::new();
+        for definition in crate::schema::seed_schema_definitions() {
+            let Some((schema_key, layout)) = layout_from_schema_definition(definition) else {
+                continue;
+            };
+            let fingerprint = layout.fingerprint();
+            if by_fingerprint
+                .insert(fingerprint, schema_key.clone())
+                .is_some()
+            {
+                // Two built-in schemas with identical column sets would be
+                // indistinguishable to a reader resolving by fingerprint, and
+                // their records reconstruct identically, so this is not a
+                // correctness hazard. It is still surprising enough to keep the
+                // first registration rather than silently rebinding.
+                continue;
+            }
+            by_schema_key.insert(schema_key, layout);
+        }
+        BuiltinTypedSlotLayouts {
+            by_schema_key,
+            by_fingerprint,
+        }
+    })
+}
+
+fn declared_type_from_json_schema_type(declared: &JsonValue) -> Option<DeclaredType> {
+    match declared.get("type")?.as_str()? {
+        "string" => Some(DeclaredType::String),
+        "integer" => Some(DeclaredType::Integer),
+        "number" => Some(DeclaredType::Number),
+        "boolean" => Some(DeclaredType::Boolean),
+        _ => None,
+    }
+}
+
+fn layout_from_schema_definition(definition: &JsonValue) -> Option<(String, TypedSlotLayout)> {
+    let schema_key = definition.get("x-lix-key")?.as_str()?.to_string();
+    if definition.get("additionalProperties") != Some(&JsonValue::Bool(false)) {
+        return None;
+    }
+    let properties = definition.get("properties")?.as_object()?;
+    if properties.is_empty() {
+        return None;
+    }
+    // Sorted by name so the layout order does not depend on whether serde_json
+    // preserves object order in this build.
+    let mut columns: Vec<(String, DeclaredType)> = Vec::with_capacity(properties.len());
+    for (name, declared) in properties {
+        let declared = declared_type_from_json_schema_type(declared)?;
+        columns.push((name.clone(), declared));
+    }
+    columns.sort_by(|left, right| left.0.cmp(&right.0));
+    let layout = TypedSlotLayout::new(columns).ok()?;
+    debug_assert!(layout.is_all_scalar());
+    Some((schema_key, layout))
+}
+
+/// The typed-slot layout for a built-in schema, or `None` when that schema is
+/// not one this format writes typed records for.
+pub(crate) fn builtin_layout_for_schema_key(schema_key: &str) -> Option<&'static TypedSlotLayout> {
+    builtin_layouts().by_schema_key.get(schema_key)
+}
+
+/// The layout a stored record was encoded against, resolved from the record's
+/// own fingerprint.
+///
+/// A read path needs no schema key at all: the record says which layout it
+/// belongs to, and an unknown fingerprint is an error rather than a guess.
+pub(crate) fn builtin_layout_for_fingerprint(
+    fingerprint: [u8; LAYOUT_FINGERPRINT_BYTES],
+) -> Option<&'static TypedSlotLayout> {
+    let layouts = builtin_layouts();
+    let schema_key = layouts.by_fingerprint.get(&fingerprint)?;
+    layouts.by_schema_key.get(schema_key)
+}
+
+/// Counts reads that were served out of a stored typed-slot record.
+///
+/// A decode branch that exists but is never taken is worse than an admitted
+/// gap, so the tests assert on this counter rather than on the branch being
+/// present in the source.
+#[cfg(test)]
+pub(crate) static TYPED_SLOT_READS_SERVED: std::sync::atomic::AtomicU64 =
+    std::sync::atomic::AtomicU64::new(0);
+
+/// Counts typed-slot records handed to the storage encoder.
+#[cfg(test)]
+pub(crate) static TYPED_SLOT_RECORDS_WRITTEN: std::sync::atomic::AtomicU64 =
+    std::sync::atomic::AtomicU64::new(0);
+
+#[cfg(test)]
+pub(crate) fn record_typed_slot_read_served() {
+    TYPED_SLOT_READS_SERVED.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+}
+
+#[cfg(test)]
+pub(crate) fn record_typed_slot_record_written() {
+    TYPED_SLOT_RECORDS_WRITTEN.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+}
+
+#[cfg(test)]
+mod registry_tests {
+    use super::*;
+
+    #[test]
+    fn a_builtin_all_scalar_schema_has_a_layout_and_a_json_declared_one_does_not() {
+        let account = builtin_layout_for_schema_key("lix_account")
+            .expect("lix_account declares only scalar columns");
+        assert!(account.is_all_scalar());
+        assert_eq!(account.index_of("id").is_some(), true);
+        // `lix_key_value.value` is arbitrary JSON by design, so that schema is
+        // deliberately not written as a typed record.
+        assert!(builtin_layout_for_schema_key("lix_key_value").is_none());
+    }
+
+    #[test]
+    fn a_record_resolves_its_own_layout_from_its_fingerprint() {
+        let layout = builtin_layout_for_schema_key("lix_account").expect("layout");
+        let snapshot = object(
+            r#"{"id":"account-1","kind":"human","name":"Ada","status":"active"}"#,
+        );
+        let bytes = encode_typed_slots(layout, &snapshot).expect("encode");
+        let record = TypedSlotsRef::parse(&bytes).expect("parse");
+        let resolved = builtin_layout_for_fingerprint(record.layout_fingerprint())
+            .expect("the record names a layout this binary knows");
+        assert_eq!(resolved, layout);
+        assert_eq!(
+            record.to_canonical_json(resolved).expect("reconstruct"),
+            r#"{"id":"account-1","kind":"human","name":"Ada","status":"active"}"#
+        );
+    }
+
+    #[test]
+    fn reconstruction_refuses_a_layout_the_record_was_not_written_against() {
+        let layout = builtin_layout_for_schema_key("lix_account").expect("layout");
+        let snapshot = object(
+            r#"{"id":"account-1","kind":"human","name":"Ada","status":"active"}"#,
+        );
+        let bytes = encode_typed_slots(layout, &snapshot).expect("encode");
+        let record = TypedSlotsRef::parse(&bytes).expect("parse");
+        // Same column count, same declared types, different names: a positional
+        // decode against it would silently emit the wrong keys.
+        let impostor = TypedSlotLayout::new([
+            ("id".to_string(), DeclaredType::String),
+            ("kind".to_string(), DeclaredType::String),
+            ("name".to_string(), DeclaredType::String),
+            ("state".to_string(), DeclaredType::String),
+        ])
+        .expect("impostor layout");
+        let error = record
+            .to_canonical_json(&impostor)
+            .expect_err("a mismatched layout must be refused");
+        assert!(
+            error.message().contains("different column layout"),
+            "unexpected error: {error}"
+        );
+    }
+
+    fn object(json: &str) -> JsonMap<String, JsonValue> {
+        match serde_json::from_str::<JsonValue>(json).expect("valid json") {
+            JsonValue::Object(map) => map,
+            other => panic!("expected an object, got {other}"),
+        }
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Stacked on **#1465** (`e-tslots`, draft, not merged). #1465 landed the typed-slot record format, its decode path and the byte-identity property; it deliberately shipped **no writer**, because the payload channel is `str`-typed end to end and a decode branch keyed on the existing `&str` channel could never be taken. This PR opens the byte-valued channel and writes through it.

## 1. The byte-valued payload channel

Head value **v9 → v10**, adding one header byte at offset 59:

```text
 58   columnar base-coordinate presence (0 or 1)
 59   payload encoding: bit 0 snapshot is a typed-slot record, bit 1 metadata is
 60.. snapshot payload, metadata payload, ...
```

A row is JSON text **or** typed bytes, and which one is **stated in the header, never inferred from the payload**. `TypedSlotsRef::looks_like_record` (a content sniff, from #1465) exists but is not what the storage path keys on: a format that guesses its own discriminant has no way to fail loudly when the guess is wrong.

`HeadSlotView::Typed(&[u8])` / `HeadSlotEncode::Typed(&[u8])` are new variants alongside `Inline(&str)` rather than a reinterpretation of it. Fixed-width numeric payloads are not valid UTF-8, so this is not optional.

The flags byte was already full (deleted, 2×2 slot kinds, untracked, 2 working-diff bits), which is why the discriminant is a new byte rather than a fifth slot kind.

## 2. The writer, and the route to a read

`append_head_value_with_typed_layout` encodes the snapshot as a typed record when the caller resolves a layout for the row's schema. It is wired into the two staging lanes that construct a head value from a live delta — `stage_current_state_with_working_diff_inner` (`hot.rs`, the lane an ordinary `INSERT`/`UPDATE` reaches at commit) and the deferred fresh-hot page builder — both of which have `delta.schema_key` in scope. Every other head-write site keeps its existing signature and writes JSON text.

Two gates on the writer, both mechanisms rather than readings of the schema files:

* **Layouts come from the compiled-in built-in schemas** (`schema/builtin/*.json`, already `include_str!`-ed), restricted to schemas that are closed (`additionalProperties: false`) and whose every declared property is scalar. A layout is therefore a deterministic function of the binary, not of repository content or of the order in which SQL surfaces happened to be built. Of the 14 built-in schemas, the all-scalar ones get typed records; `lix_key_value` does not, because `value` is arbitrary JSON by design.
* **The writer refuses a snapshot carrying a key the layout does not declare.** `encode_typed_slots` writes one slot per *declared* column, so an undeclared key would be silently dropped. Closed schemas make that unreachable; the check is what makes it unreachable *by mechanism*. Declining is always safe — the row is stored as JSON text exactly as today.

### The record now names its own layout

The record header carries an 8-byte **layout fingerprint** (blake3 over the declared names and types, in layout order). Two consequences:

* A read site needs **no schema key at all**: `builtin_layout_for_fingerprint` resolves the record's own layout, so nothing has to be threaded down to materialization.
* `to_json_value` **refuses** a layout whose fingerprint does not match the record's. Without it, a lookup that returned a different column set would decode every slot at the wrong name, silently. `reconstruction_refuses_a_layout_the_record_was_not_written_against` pins this with a same-arity, same-types, different-names impostor — the case a length check cannot catch.

## 3. Reconstruction on demand

`materialize_live_slot` reconstructs canonical JSON from a typed record, so `snapshot_content` still hands every one of its **817 references across 40+ files** the text they expect and **nothing else in this PR has to change**. That is only sound because of #1465's result: reconstruction is byte-identical to the normalized text the record replaced. Content addressing hashes that text, so this is a correctness precondition, not a performance nicety, and this PR keeps a test that fails if it diverges by one byte.

The working-diff fingerprint follows from the same property. `working_diff_slot_fingerprint` hashes the reconstruction of a typed slot, so a row whose before-image is stored as text and whose current version is typed still classifies **Equal** on equal content. An unresolvable record answers `unresolved` rather than guessing — an accelerator may decline, but must never be confidently wrong.

## Evidence

Deterministic, host-independent, no timings.

`a_head_row_for_an_all_scalar_schema_is_stored_typed_and_read_back_byte_identically` stages a `lix_account` row through the writer and reads it back:

| | assertion |
|---|---|
| writer engaged | `TYPED_SLOT_RECORDS_WRITTEN` moved |
| stored form | header byte 59 has the typed bit; the payload does not start with `{` |
| decoded form | `HeadSlotView::Typed(_)` |
| **read served from the record** | `TYPED_SLOT_READS_SERVED` moved |
| **text handed to consumers** | byte-identical to the JSON that was written |

The counters are the point: a decode branch that exists but is never taken looks exactly like a live one in a diff. The **positive control runs in the same test** — `lix_key_value` has a JSON-declared column, so it has no layout, takes the JSON route, and its stored row decodes back to `HeadSlotView::Inline`.

`a_typed_slot_fingerprints_identically_to_the_json_text_it_replaced` pins the dirty/clean agreement described above.

## What is not here

**No performance claim, and no measurement.** In this staged landing the text is reconstructed at materialization, so a typed read pays a reconstruction the JSON read does not; the residue another experiment put at 255–320 ns/row (~48–53% of parse cost, on selective scans) is only available once the *filter* path reads slots directly and the text consumers stop asking for text. That is the next step, not this one. **Anything said here about that residue is inferred-not-run.**

Also untouched: `parse_snapshot_filter_columns`, the entity provider's filter path, `storage_codec.rs`, `tracked_state/*` (owned elsewhere this round).

## Protocol

**This change requires a `REPOSITORY_PROTOCOL_VALUE` bump.** Unlike #1465, which was inert on stored bytes, a writer means head values are genuinely v10 and carry typed payloads — an existing repository must be rejected, not degraded. **The value is deliberately left at `tracked-default-branch.v68` here**, because this round applies one bump once at integration; four separate bumps would be four mutually incompatible repositories.

Note that a change to a built-in schema now also changes a stored layout fingerprint. That is a stored-format change and is carried by the same bump.

## Gate

Scope re-derived from the base sha's own `ci.yml`, then run wider: `cargo check -p lix --no-default-features`, `cargo check -p lix --tests`, `cargo check --workspace --all-targets --all-features` and a `--test-threads=1` test1 lane are none of them CI steps at that sha. Gate evidence, including the new tests asserted by emitted name, is posted as a comment on this PR.
