### PR TITLE
Make filesystem synchronization storage-owned

### DIFF
--- a/docs/persistence.md
+++ b/docs/persistence.md
@@ -55,14 +55,16 @@ use lix_storage_filesystem::FilesystemStorage;
 
 let storage = FilesystemStorage::new("./repository").open()?;
 let lix = open_lix().with_storage(storage.clone()).await?;
-let sync = storage.start_sync(&lix).await?;
+storage.start_sync(&lix).await?;
 
-sync.sync_disk_to_lix().await?;
+storage.sync_disk_to_lix().await?;
+storage.stop_sync().await?;
 ```
 
-Keep `sync` alive while filesystem synchronization should run. It owns a
-separate session on the existing Lix repository; the storage adapter does not
-open or configure the Lix engine.
+`FilesystemStorage` owns synchronization after `start_sync()` returns. Calling
+`stop_sync()` is optional for normal applications and recommended for tests or
+before reopening the same RocksDB path immediately. Dropping the final storage
+or repository instance performs a best-effort shutdown.
 
 Pass `syncAllFiles: false` to begin with no regular repository files and import
 selected paths with `storage.importPaths(paths)`.

--- a/packages/e2e/tests/e2e.rs
+++ b/packages/e2e/tests/e2e.rs
@@ -27,7 +27,7 @@ use lix::{
     MergeBranchPreviewOptions, MergeConflictChangeKind, SwitchBranchOptions,
 };
 use lix::{Value, open_lix};
-use lix_storage_filesystem::{FilesystemStorage, FilesystemStorageSync};
+use lix_storage_filesystem::FilesystemStorage;
 use lix_storage_rocksdb::RocksDB;
 use lix_storage_slatedb::SlateDB;
 use sha2::{Digest as _, Sha256};
@@ -6173,7 +6173,7 @@ async fn v2_csv_exact_read_replaces_a_stale_actor_after_an_independent_engine_co
         .with_storage(storage_a.clone())
         .await
         .expect("first independent Lix opens");
-    let _sync_a = storage_a
+    storage_a
         .start_sync(&lix_a)
         .await
         .expect("first shared filesystem sync starts");
@@ -6199,7 +6199,7 @@ async fn v2_csv_exact_read_replaces_a_stale_actor_after_an_independent_engine_co
         .with_storage(storage_b.clone())
         .await
         .expect("second independent Lix opens");
-    let _sync_b = storage_b
+    storage_b
         .start_sync(&lix_b)
         .await
         .expect("second shared filesystem sync starts");
@@ -6891,7 +6891,7 @@ fn csv_row_id(rows: &[CsvV2Row], cells: &[&str]) -> String {
 
 struct SyncedFilesystemLix {
     lix: Lix<FilesystemStorage>,
-    _sync: FilesystemStorageSync,
+    _storage: FilesystemStorage,
 }
 
 impl Deref for SyncedFilesystemLix {
@@ -6905,8 +6905,11 @@ impl Deref for SyncedFilesystemLix {
 async fn open_filesystem_lix(path: &Path) -> SyncedFilesystemLix {
     let storage = FilesystemStorage::new(path).open().unwrap();
     let lix = open_lix().with_storage(storage.clone()).await.unwrap();
-    let sync = storage.start_sync(&lix).await.unwrap();
-    SyncedFilesystemLix { lix, _sync: sync }
+    storage.start_sync(&lix).await.unwrap();
+    SyncedFilesystemLix {
+        lix,
+        _storage: storage,
+    }
 }
 
 async fn open_rocksdb_lix(path: &Path) -> Lix<RocksDB> {

--- a/packages/e2e/tests/rust_sdk_api.rs
+++ b/packages/e2e/tests/rust_sdk_api.rs
@@ -4,7 +4,7 @@ use lix::{
     CreateBranchOptions, ExecuteBatchStatement, Lix, LixError, Memory, MergeBranchOptions,
     MergeBranchOutcome, SwitchBranchOptions, Value, open_lix,
 };
-use lix_storage_filesystem::{FilesystemStorage, FilesystemStorageSync};
+use lix_storage_filesystem::FilesystemStorage;
 use std::ops::Deref;
 use std::path::Path;
 use std::sync::{Arc, Mutex};
@@ -729,7 +729,7 @@ async fn filesystem_initialization_wipes_legacy_root_sqlite_and_system_metadata(
 
 struct SyncedFilesystemLix {
     lix: Lix<FilesystemStorage>,
-    _sync: FilesystemStorageSync,
+    _storage: FilesystemStorage,
 }
 
 impl Deref for SyncedFilesystemLix {
@@ -743,8 +743,11 @@ impl Deref for SyncedFilesystemLix {
 async fn open_filesystem_lix(path: &Path) -> SyncedFilesystemLix {
     let storage = FilesystemStorage::new(path).open().unwrap();
     let lix = open_lix().with_storage(storage.clone()).await.unwrap();
-    let sync = storage.start_sync(&lix).await.unwrap();
-    SyncedFilesystemLix { lix, _sync: sync }
+    storage.start_sync(&lix).await.unwrap();
+    SyncedFilesystemLix {
+        lix,
+        _storage: storage,
+    }
 }
 
 async fn open_on_demand_filesystem_lix(path: &Path, file_paths: &[&str]) -> SyncedFilesystemLix {
@@ -753,9 +756,15 @@ async fn open_on_demand_filesystem_lix(path: &Path, file_paths: &[&str]) -> Sync
         .open()
         .unwrap();
     let lix = open_lix().with_storage(storage.clone()).await.unwrap();
-    let sync = storage.start_sync(&lix).await.unwrap();
-    sync.import_paths(file_paths.iter().copied()).await.unwrap();
-    SyncedFilesystemLix { lix, _sync: sync }
+    storage.start_sync(&lix).await.unwrap();
+    storage
+        .import_paths(file_paths.iter().copied())
+        .await
+        .unwrap();
+    SyncedFilesystemLix {
+        lix,
+        _storage: storage,
+    }
 }
 
 #[tokio::test]
@@ -775,11 +784,11 @@ async fn rocksdb_filesystem_storage_allows_same_process_multi_open() {
         .with_storage(storage_b.clone())
         .await
         .expect("second lix opens");
-    let _sync_a = storage_a
+    storage_a
         .start_sync(&lix_a)
         .await
         .expect("first sync starts");
-    let _sync_b = storage_b
+    storage_b
         .start_sync(&lix_b)
         .await
         .expect("second sync starts");

--- a/packages/js-sdk/native/napi.rs
+++ b/packages/js-sdk/native/napi.rs
@@ -9,7 +9,7 @@ use lix::{
     ObserveEvents as RsObserveEvents, RedoReceipt, SwitchBranchOptions as RsSwitchBranchOptions,
     SwitchBranchReceipt, UndoReceipt, Value, open_lix,
 };
-use lix_storage_filesystem::{FilesystemStorage, FilesystemStorageSync};
+use lix_storage_filesystem::FilesystemStorage;
 use napi::JsDeferred;
 use napi::bindgen_prelude::*;
 use napi::threadsafe_function::{ThreadsafeFunction, ThreadsafeFunctionCallMode};
@@ -48,7 +48,7 @@ pub struct NativeLix {
 
 enum NativeLixInner {
     Memory(RsLix<Memory>),
-    FilesystemStorage(RsLix<FilesystemStorage>, FilesystemStorageSync),
+    FilesystemStorage(RsLix<FilesystemStorage>, FilesystemStorage),
 }
 
 enum NativeLixTransactionInner {
@@ -692,7 +692,7 @@ impl NativeLixInner {
         paths: Vec<String>,
     ) -> std::result::Result<(), LixError> {
         match self {
-            Self::FilesystemStorage(_, sync) => sync.import_paths(paths).await,
+            Self::FilesystemStorage(_, storage) => storage.import_paths(paths).await,
             Self::Memory(_) => Err(LixError::new(
                 "LIX_UNSUPPORTED_STORAGE",
                 "importFilesystemPaths requires a filesystem storage",
@@ -722,7 +722,7 @@ impl NativeLixInner {
 
     async fn sync_disk_to_lix(&self) -> std::result::Result<(), LixError> {
         match self {
-            Self::FilesystemStorage(_, sync) => sync.sync_disk_to_lix().await,
+            Self::FilesystemStorage(_, storage) => storage.sync_disk_to_lix().await,
             Self::Memory(_) => Err(LixError::new(
                 "LIX_UNSUPPORTED_STORAGE",
                 "syncDiskToLix requires a filesystem storage",
@@ -733,7 +733,10 @@ impl NativeLixInner {
     async fn close(&self) -> std::result::Result<(), LixError> {
         match self {
             Self::Memory(lix) => lix.close().await,
-            Self::FilesystemStorage(lix, _) => lix.close().await,
+            Self::FilesystemStorage(lix, storage) => {
+                storage.stop_sync().await?;
+                lix.close().await
+            }
         }
     }
 }
@@ -881,8 +884,8 @@ fn open_filesystem_storage_native(
         })?,
         None => rt.block_on(async { open_lix().with_storage(storage.clone()).await })?,
     };
-    let sync = rt.block_on(storage.start_sync(&lix))?;
-    NativeLix::new(NativeLixInner::FilesystemStorage(lix, sync))
+    rt.block_on(storage.start_sync(&lix))?;
+    NativeLix::new(NativeLixInner::FilesystemStorage(lix, storage))
 }
 
 #[napi]

--- a/packages/lix/src/handle.rs
+++ b/packages/lix/src/handle.rs
@@ -123,6 +123,7 @@ where
 {
     lix: &'a Lix<StorageImpl>,
     account_id: Option<String>,
+    branch_id: Option<String>,
 }
 
 impl<'a, StorageImpl> OpenAnotherSessionBuilder<'a, StorageImpl>
@@ -134,6 +135,13 @@ where
     /// This selects an existing account; it does not create one.
     pub fn with_account(mut self, account_id: impl Into<String>) -> Self {
         self.account_id = Some(account_id.into());
+        self
+    }
+
+    /// Opens the additional session on `branch_id` without changing the
+    /// primary session or its persisted branch preference.
+    pub fn with_branch(mut self, branch_id: impl Into<String>) -> Self {
+        self.branch_id = Some(branch_id.into());
         self
     }
 }
@@ -152,7 +160,9 @@ where
         // higher-ranked SQL futures.
         Box::pin(unsafe {
             crate::session::AssumeSendFuture::new(async move {
-                self.lix.open_another_session_inner(self.account_id).await
+                self.lix
+                    .open_another_session_inner(self.account_id, self.branch_id)
+                    .await
             })
         })
     }
@@ -366,12 +376,14 @@ where
         OpenAnotherSessionBuilder {
             lix: self,
             account_id: None,
+            branch_id: None,
         }
     }
 
     async fn open_another_session_inner(
         &self,
         account_id: Option<String>,
+        branch_id: Option<String>,
     ) -> Result<Self, LixError> {
         if self.session.is_closed() {
             return Err(LixError::new(
@@ -379,7 +391,10 @@ where
                 "cannot open another session from a closed Lix handle",
             ));
         }
-        let active_branch_id = self.active_branch_id().await?;
+        let active_branch_id = match branch_id {
+            Some(branch_id) => branch_id,
+            None => self.active_branch_id().await?,
+        };
         let active_account_id = account_id.unwrap_or_else(|| self.active_account_id().to_owned());
         self.open_internal_session(active_branch_id, active_account_id)
             .await
@@ -1261,4 +1276,3 @@ mod assume_send_future_proofs {
         assert_sync::<Lix<S>>();
     }
 }
-

--- a/packages/storage-filesystem/README.md
+++ b/packages/storage-filesystem/README.md
@@ -25,7 +25,11 @@ use lix_storage_filesystem::FilesystemStorage;
 # async fn example() -> Result<(), lix::LixError> {
 let storage = FilesystemStorage::new("./repository").open()?;
 let lix = open_lix().with_storage(storage.clone()).await?;
-let _sync = storage.start_sync(&lix).await?;
+storage.start_sync(&lix).await?;
 # Ok(())
 # }
 ```
+
+The storage owns synchronization until `storage.stop_sync().await?` or until
+the final storage/repository instance is dropped. Explicitly stopping is useful
+for tests and before immediately reopening the same path.

--- a/packages/storage-filesystem/examples/sync_repository.rs
+++ b/packages/storage-filesystem/examples/sync_repository.rs
@@ -12,17 +12,18 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     runtime.block_on(async move {
         let storage = FilesystemStorage::new(&root).open()?;
         let lix = open_lix().with_storage(storage.clone()).await?;
-        let sync = storage.start_sync(&lix).await?;
+        storage.start_sync(&lix).await?;
 
-        // Import changes already present on disk immediately. The returned
-        // sync handle also keeps watching while it remains alive.
-        sync.sync_disk_to_lix().await?;
+        // Import changes already present on disk immediately. The storage
+        // keeps watching until explicitly stopped or finally dropped.
+        storage.sync_disk_to_lix().await?;
 
         let files = lix
             .execute("SELECT path FROM lix_file ORDER BY path", &[])
             .await?;
         println!("{} repository files", files.rows().len());
 
+        storage.stop_sync().await?;
         lix.close().await?;
         Ok::<_, lix::LixError>(())
     })?;

--- a/packages/storage-filesystem/src/filesystem.rs
+++ b/packages/storage-filesystem/src/filesystem.rs
@@ -15,7 +15,7 @@ use lix::storage::{
     CommitResult, Key, KeyRange, PutBatch, ReadOptions, Storage, StorageError, StorageSpace,
     StorageWrite, WriteOptions,
 };
-use lix::{Lix, LixError, LixPath, SYSTEM_ACCOUNT_ID, SwitchBranchOptions, Value, open_lix};
+use lix::{Lix, LixError, LixPath, SYSTEM_ACCOUNT_ID, Value, open_lix};
 use notify_debouncer_full::notify::{Config, RecommendedWatcher, RecursiveMode};
 use notify_debouncer_full::{DebounceEventResult, Debouncer, RecommendedCache, new_debouncer_opt};
 use tokio::sync::oneshot;
@@ -145,6 +145,11 @@ struct FilesystemSupervisor {
 
 struct FilesystemSyncLifecycle {
     state: Mutex<FilesystemSyncState>,
+}
+
+struct FilesystemSyncStartup {
+    lifecycle: Arc<FilesystemSyncLifecycle>,
+    completed: bool,
 }
 
 enum FilesystemSyncState {
@@ -327,37 +332,10 @@ enum FilesystemEvent {
 impl FilesystemStorage {
     /// Starts bidirectional filesystem synchronization owned by this storage.
     pub async fn start_sync(&self, lix: &Lix<FilesystemStorage>) -> Result<(), LixError> {
-        {
-            let mut state = self
-                .sync_lifecycle
-                .state
-                .lock()
-                .expect("filesystem sync lifecycle lock should not poison");
-            if !matches!(*state, FilesystemSyncState::Stopped) {
-                return Err(LixError::new(
-                    "LIX_FILESYSTEM_SYNC_ALREADY_STARTED",
-                    "filesystem synchronization is already running",
-                ));
-            }
-            *state = FilesystemSyncState::Starting;
-        }
-
-        let result = self.open_supervisor(lix).await;
-        let mut state = self
-            .sync_lifecycle
-            .state
-            .lock()
-            .expect("filesystem sync lifecycle lock should not poison");
-        match result {
-            Ok(supervisor) => {
-                *state = FilesystemSyncState::Started(supervisor);
-                Ok(())
-            }
-            Err(error) => {
-                *state = FilesystemSyncState::Stopped;
-                Err(error)
-            }
-        }
+        let startup = FilesystemSyncStartup::begin(Arc::clone(&self.sync_lifecycle))?;
+        let supervisor = self.open_supervisor(lix).await?;
+        startup.complete(supervisor);
+        Ok(())
     }
 
     /// Stops synchronization and waits for its worker and internal Lix session.
@@ -417,15 +395,9 @@ impl FilesystemStorage {
         // writes from recursively requesting another filesystem sync.
         let primary = open_lix().with_storage(self.inner.clone()).await?;
         let active_branch_id = lix.active_branch_id().await?;
-        if primary.active_branch_id().await? != active_branch_id {
-            primary
-                .switch_branch(SwitchBranchOptions {
-                    branch_id: active_branch_id,
-                })
-                .await?;
-        }
         let sync_lix = primary
             .open_another_session()
+            .with_branch(active_branch_id)
             .with_account(SYSTEM_ACCOUNT_ID)
             .await?;
         primary.close().await?;
@@ -448,6 +420,54 @@ impl FilesystemStorage {
             _ => Err(filesystem_error(
                 "filesystem synchronization is not running",
             )),
+        }
+    }
+}
+
+impl FilesystemSyncStartup {
+    fn begin(lifecycle: Arc<FilesystemSyncLifecycle>) -> Result<Self, LixError> {
+        {
+            let mut state = lifecycle
+                .state
+                .lock()
+                .expect("filesystem sync lifecycle lock should not poison");
+            if !matches!(*state, FilesystemSyncState::Stopped) {
+                return Err(LixError::new(
+                    "LIX_FILESYSTEM_SYNC_ALREADY_STARTED",
+                    "filesystem synchronization is already running",
+                ));
+            }
+            *state = FilesystemSyncState::Starting;
+        }
+        Ok(Self {
+            lifecycle,
+            completed: false,
+        })
+    }
+
+    fn complete(mut self, supervisor: FilesystemSupervisor) {
+        *self
+            .lifecycle
+            .state
+            .lock()
+            .expect("filesystem sync lifecycle lock should not poison") =
+            FilesystemSyncState::Started(supervisor);
+        self.completed = true;
+    }
+}
+
+impl Drop for FilesystemSyncStartup {
+    fn drop(&mut self) {
+        if self.completed {
+            return;
+        }
+        let mut state = self
+            .lifecycle
+            .state
+            .lock()
+            .expect("filesystem sync lifecycle lock should not poison");
+        if matches!(*state, FilesystemSyncState::Starting) {
+            *state = FilesystemSyncState::Stopped;
         }
     }
 }
@@ -2913,6 +2933,65 @@ mod tests {
         storage.start_sync(&lix).await.unwrap();
         storage.stop_sync().await.unwrap();
         lix.close().await.unwrap();
+    }
+
+    #[test]
+    fn cancelled_filesystem_sync_start_restores_stopped_state() {
+        let lifecycle = Arc::new(FilesystemSyncLifecycle {
+            state: Mutex::new(FilesystemSyncState::Stopped),
+        });
+        let startup = FilesystemSyncStartup::begin(Arc::clone(&lifecycle)).unwrap();
+        assert!(matches!(
+            *lifecycle.state.lock().unwrap(),
+            FilesystemSyncState::Starting
+        ));
+
+        // Dropping this guard models cancellation while open_supervisor awaits.
+        drop(startup);
+        assert!(matches!(
+            *lifecycle.state.lock().unwrap(),
+            FilesystemSyncState::Stopped
+        ));
+
+        // A later attempt can acquire the lifecycle again.
+        drop(FilesystemSyncStartup::begin(lifecycle).unwrap());
+    }
+
+    #[tokio::test]
+    async fn filesystem_sync_on_secondary_branch_does_not_change_primary_preference() {
+        let tempdir = tempfile::tempdir().unwrap();
+        let storage = FilesystemStorage::new(tempdir.path()).open().unwrap();
+        let primary = open_lix().with_storage(storage.clone()).await.unwrap();
+        let primary_branch_id = primary.active_branch_id().await.unwrap();
+        let branch = primary
+            .create_branch(lix::CreateBranchOptions {
+                id: None,
+                name: "sync-secondary".to_string(),
+                from_commit_id: None,
+            })
+            .await
+            .unwrap();
+        let secondary = primary.open_another_session().await.unwrap();
+        secondary
+            .switch_branch(lix::SwitchBranchOptions {
+                branch_id: branch.id,
+            })
+            .await
+            .unwrap();
+
+        storage.start_sync(&secondary).await.unwrap();
+        storage.stop_sync().await.unwrap();
+        secondary.close().await.unwrap();
+        primary.close().await.unwrap();
+        drop(secondary);
+        drop(primary);
+
+        let reopened = open_lix().with_storage(storage).await.unwrap();
+        assert_eq!(
+            reopened.active_branch_id().await.unwrap(),
+            primary_branch_id
+        );
+        reopened.close().await.unwrap();
     }
 
     #[tokio::test]

--- a/packages/storage-filesystem/src/filesystem.rs
+++ b/packages/storage-filesystem/src/filesystem.rs
@@ -15,7 +15,7 @@ use lix::storage::{
     CommitResult, Key, KeyRange, PutBatch, ReadOptions, Storage, StorageError, StorageSpace,
     StorageWrite, WriteOptions,
 };
-use lix::{Lix, LixError, LixPath, SYSTEM_ACCOUNT_ID, Value};
+use lix::{Lix, LixError, LixPath, SYSTEM_ACCOUNT_ID, SwitchBranchOptions, Value, open_lix};
 use notify_debouncer_full::notify::{Config, RecommendedWatcher, RecursiveMode};
 use notify_debouncer_full::{DebounceEventResult, Debouncer, RecommendedCache, new_debouncer_opt};
 use tokio::sync::oneshot;
@@ -93,7 +93,9 @@ impl FilesystemStorageOptions {
             inner: open_filesystem_rocksdb(&layout)?,
             layout,
             sync_all_files: self.sync_all_files,
-            supervisor: Arc::new(Mutex::new(None)),
+            sync_lifecycle: Arc::new(FilesystemSyncLifecycle {
+                state: Mutex::new(FilesystemSyncState::Stopped),
+            }),
         })
     }
 }
@@ -125,7 +127,7 @@ pub struct FilesystemStorage {
     inner: RocksDBFilesystem,
     layout: FilesystemLayout,
     sync_all_files: bool,
-    supervisor: Arc<Mutex<Option<Weak<FilesystemSupervisorInner>>>>,
+    sync_lifecycle: Arc<FilesystemSyncLifecycle>,
 }
 
 pub type FilesystemStorageRead<'a> = crate::RocksDBFilesystemRead<'a>;
@@ -141,10 +143,14 @@ struct FilesystemSupervisor {
     inner: Arc<FilesystemSupervisorInner>,
 }
 
-#[derive(Clone)]
-#[expect(missing_debug_implementations)]
-pub struct FilesystemStorageSync {
-    supervisor: FilesystemSupervisor,
+struct FilesystemSyncLifecycle {
+    state: Mutex<FilesystemSyncState>,
+}
+
+enum FilesystemSyncState {
+    Stopped,
+    Starting,
+    Started(FilesystemSupervisor),
 }
 
 struct FilesystemSupervisorInner {
@@ -164,7 +170,7 @@ struct FilesystemWatchPath {
 }
 
 struct FilesystemState {
-    lix: Lix<FilesystemStorage>,
+    lix: Lix<RocksDBFilesystem>,
     layout: FilesystemLayout,
     path_filter: Mutex<FilesystemPathFilter>,
     sync_lock: tokio::sync::Mutex<()>,
@@ -319,52 +325,75 @@ enum FilesystemEvent {
 }
 
 impl FilesystemStorage {
-    /// Starts bidirectional filesystem synchronization using another session
-    /// on the supplied Lix repository.
-    pub async fn start_sync(
-        &self,
-        lix: &Lix<FilesystemStorage>,
-    ) -> Result<FilesystemStorageSync, LixError> {
-        if self
-            .supervisor
-            .lock()
-            .expect("filesystem supervisor lock should not poison")
-            .as_ref()
-            .and_then(Weak::upgrade)
-            .is_some()
+    /// Starts bidirectional filesystem synchronization owned by this storage.
+    pub async fn start_sync(&self, lix: &Lix<FilesystemStorage>) -> Result<(), LixError> {
         {
-            return Err(LixError::new(
-                "LIX_FILESYSTEM_SYNC_ALREADY_STARTED",
-                "filesystem synchronization is already running",
-            ));
+            let mut state = self
+                .sync_lifecycle
+                .state
+                .lock()
+                .expect("filesystem sync lifecycle lock should not poison");
+            if !matches!(*state, FilesystemSyncState::Stopped) {
+                return Err(LixError::new(
+                    "LIX_FILESYSTEM_SYNC_ALREADY_STARTED",
+                    "filesystem synchronization is already running",
+                ));
+            }
+            *state = FilesystemSyncState::Starting;
         }
 
-        let sync_lix = lix
-            .open_another_session()
-            .with_account(SYSTEM_ACCOUNT_ID)
-            .await?;
-        let supervisor = FilesystemSupervisor::open(
-            sync_lix,
-            self.layout.clone(),
-            FilesystemPathFilter::from_sync_all_files(self.sync_all_files),
-        )
-        .await?;
-        *self
-            .supervisor
+        let result = self.open_supervisor(lix).await;
+        let mut state = self
+            .sync_lifecycle
+            .state
             .lock()
-            .expect("filesystem supervisor lock should not poison") =
-            Some(Arc::downgrade(&supervisor.inner));
-        Ok(FilesystemStorageSync { supervisor })
+            .expect("filesystem sync lifecycle lock should not poison");
+        match result {
+            Ok(supervisor) => {
+                *state = FilesystemSyncState::Started(supervisor);
+                Ok(())
+            }
+            Err(error) => {
+                *state = FilesystemSyncState::Stopped;
+                Err(error)
+            }
+        }
     }
-}
 
-impl FilesystemStorageSync {
+    /// Stops synchronization and waits for its worker and internal Lix session.
+    ///
+    /// This is optional for normal applications, which may rely on dropping the
+    /// final storage clone. It is recommended for tests and before immediately
+    /// reopening the same repository path.
+    pub async fn stop_sync(&self) -> Result<(), LixError> {
+        let supervisor = {
+            let mut state = self
+                .sync_lifecycle
+                .state
+                .lock()
+                .expect("filesystem sync lifecycle lock should not poison");
+            match std::mem::replace(&mut *state, FilesystemSyncState::Stopped) {
+                FilesystemSyncState::Stopped => return Ok(()),
+                FilesystemSyncState::Starting => {
+                    *state = FilesystemSyncState::Starting;
+                    return Err(LixError::new(
+                        "LIX_FILESYSTEM_SYNC_STARTING",
+                        "filesystem synchronization is still starting",
+                    ));
+                }
+                FilesystemSyncState::Started(supervisor) => supervisor,
+            }
+        };
+        supervisor.shutdown();
+        Ok(())
+    }
+
     pub async fn import_paths<I, S>(&self, paths: I) -> Result<(), LixError>
     where
         I: IntoIterator<Item = S>,
         S: AsRef<str>,
     {
-        self.supervisor
+        self.running_supervisor()?
             .import_paths(
                 paths
                     .into_iter()
@@ -375,7 +404,65 @@ impl FilesystemStorageSync {
     }
 
     pub async fn sync_disk_to_lix(&self) -> Result<(), LixError> {
-        self.supervisor.sync_disk_to_lix().await
+        self.running_supervisor()?.sync_disk_to_lix().await
+    }
+
+    async fn open_supervisor(
+        &self,
+        lix: &Lix<FilesystemStorage>,
+    ) -> Result<FilesystemSupervisor, LixError> {
+        // The supervisor intentionally uses the underlying RocksDB adapter,
+        // not FilesystemStorage. This breaks the ownership cycle
+        // storage -> supervisor -> Lix session -> storage and prevents its own
+        // writes from recursively requesting another filesystem sync.
+        let primary = open_lix().with_storage(self.inner.clone()).await?;
+        let active_branch_id = lix.active_branch_id().await?;
+        if primary.active_branch_id().await? != active_branch_id {
+            primary
+                .switch_branch(SwitchBranchOptions {
+                    branch_id: active_branch_id,
+                })
+                .await?;
+        }
+        let sync_lix = primary
+            .open_another_session()
+            .with_account(SYSTEM_ACCOUNT_ID)
+            .await?;
+        primary.close().await?;
+        FilesystemSupervisor::open(
+            sync_lix,
+            self.layout.clone(),
+            FilesystemPathFilter::from_sync_all_files(self.sync_all_files),
+        )
+        .await
+    }
+
+    fn running_supervisor(&self) -> Result<FilesystemSupervisor, LixError> {
+        let state = self
+            .sync_lifecycle
+            .state
+            .lock()
+            .expect("filesystem sync lifecycle lock should not poison");
+        match &*state {
+            FilesystemSyncState::Started(supervisor) => Ok(supervisor.clone()),
+            _ => Err(filesystem_error(
+                "filesystem synchronization is not running",
+            )),
+        }
+    }
+}
+
+impl Drop for FilesystemSyncLifecycle {
+    fn drop(&mut self) {
+        let state = self
+            .state
+            .get_mut()
+            .expect("filesystem sync lifecycle lock should not poison");
+        if let FilesystemSyncState::Started(supervisor) =
+            std::mem::replace(state, FilesystemSyncState::Stopped)
+        {
+            supervisor.shutdown();
+        }
     }
 }
 
@@ -405,10 +492,9 @@ impl Storage for FilesystemStorage {
             Ok(FilesystemStorageWrite {
                 inner: self.inner.begin_write(opts).await?,
                 supervisor: self
-                    .supervisor
-                    .lock()
-                    .expect("filesystem supervisor lock should not poison")
-                    .clone(),
+                    .running_supervisor()
+                    .ok()
+                    .map(|supervisor| Arc::downgrade(&supervisor.inner)),
             })
         }
     }
@@ -458,8 +544,12 @@ impl StorageWrite for FilesystemStorageWrite {
 }
 
 impl FilesystemSupervisor {
+    fn shutdown(self) {
+        self.inner.shutdown();
+    }
+
     async fn open(
-        lix: Lix<FilesystemStorage>,
+        lix: Lix<RocksDBFilesystem>,
         layout: FilesystemLayout,
         path_filter: FilesystemPathFilter,
     ) -> Result<Self, LixError> {
@@ -2335,9 +2425,14 @@ mod tests {
             inner: open_filesystem_rocksdb(&layout).unwrap(),
             layout: layout.clone(),
             sync_all_files: path_filter.is_unfiltered(),
-            supervisor: Arc::new(Mutex::new(None)),
+            sync_lifecycle: Arc::new(FilesystemSyncLifecycle {
+                state: Mutex::new(FilesystemSyncState::Stopped),
+            }),
         };
-        let lix = lix::open_lix().with_storage(storage).await.unwrap();
+        let lix = open_lix()
+            .with_storage(storage.inner.clone())
+            .await
+            .unwrap();
         FilesystemState {
             lix,
             layout,
@@ -2724,13 +2819,13 @@ mod tests {
         std::fs::write(tempdir.path().join("ignored.md"), b"ignored").unwrap();
 
         let storage = FilesystemStorage::new(tempdir.path()).open().unwrap();
-        let lix = lix::open_lix().with_storage(storage.clone()).await.unwrap();
-        let sync = storage.start_sync(&lix).await.unwrap();
+        let lix = open_lix().with_storage(storage.clone()).await.unwrap();
+        storage.start_sync(&lix).await.unwrap();
 
         std::fs::write(tempdir.path().join("tracked.md"), b"changed").unwrap();
         std::fs::write(tempdir.path().join("ignored.md"), b"changed").unwrap();
 
-        sync.sync_disk_to_lix().await.unwrap();
+        storage.sync_disk_to_lix().await.unwrap();
 
         let tracked = lix
             .execute(
@@ -2775,15 +2870,15 @@ mod tests {
         std::fs::write(tempdir.path().join("tracked.md"), b"initial").unwrap();
 
         let storage = FilesystemStorage::new(tempdir.path()).open().unwrap();
-        let lix = lix::open_lix().with_storage(storage.clone()).await.unwrap();
-        let sync = storage.start_sync(&lix).await.unwrap();
+        let lix = open_lix().with_storage(storage.clone()).await.unwrap();
+        storage.start_sync(&lix).await.unwrap();
 
         lix.close().await.unwrap();
         std::fs::write(tempdir.path().join("tracked.md"), b"changed").unwrap();
 
-        sync.sync_disk_to_lix().await.unwrap();
+        storage.sync_disk_to_lix().await.unwrap();
 
-        let lix = lix::open_lix().with_storage(storage).await.unwrap();
+        let lix = open_lix().with_storage(storage).await.unwrap();
         let tracked = lix
             .execute(
                 "SELECT content FROM lix_file WHERE path = $1",
@@ -2801,5 +2896,58 @@ mod tests {
             b"changed"
         );
         lix.close().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn filesystem_storage_owns_start_stop_and_restart_lifecycle() {
+        let tempdir = tempfile::tempdir().unwrap();
+        let storage = FilesystemStorage::new(tempdir.path()).open().unwrap();
+        let lix = open_lix().with_storage(storage.clone()).await.unwrap();
+
+        storage.start_sync(&lix).await.unwrap();
+        let repeated = storage.start_sync(&lix).await.unwrap_err();
+        assert_eq!(repeated.code, "LIX_FILESYSTEM_SYNC_ALREADY_STARTED");
+
+        storage.stop_sync().await.unwrap();
+        storage.stop_sync().await.unwrap();
+        storage.start_sync(&lix).await.unwrap();
+        storage.stop_sync().await.unwrap();
+        lix.close().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn filesystem_storage_stop_allows_immediate_reopen() {
+        let tempdir = tempfile::tempdir().unwrap();
+        let storage = FilesystemStorage::new(tempdir.path()).open().unwrap();
+        let lix = open_lix().with_storage(storage.clone()).await.unwrap();
+        storage.start_sync(&lix).await.unwrap();
+        storage.stop_sync().await.unwrap();
+        lix.close().await.unwrap();
+        drop(lix);
+        drop(storage);
+
+        let reopened = FilesystemStorage::new(tempdir.path()).open().unwrap();
+        let lix = open_lix().with_storage(reopened.clone()).await.unwrap();
+        reopened.start_sync(&lix).await.unwrap();
+        reopened.stop_sync().await.unwrap();
+        lix.close().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn filesystem_storage_final_drop_breaks_supervisor_cycle() {
+        let tempdir = tempfile::tempdir().unwrap();
+        let storage = FilesystemStorage::new(tempdir.path()).open().unwrap();
+        let lifecycle = Arc::downgrade(&storage.sync_lifecycle);
+        let lix = open_lix().with_storage(storage.clone()).await.unwrap();
+        storage.start_sync(&lix).await.unwrap();
+
+        lix.close().await.unwrap();
+        drop(lix);
+        drop(storage);
+
+        assert!(
+            lifecycle.upgrade().is_none(),
+            "the internally retained supervisor must not form an ownership cycle"
+        );
     }
 }

--- a/packages/storage-filesystem/src/lib.rs
+++ b/packages/storage-filesystem/src/lib.rs
@@ -6,8 +6,7 @@
 mod filesystem;
 
 pub use filesystem::{
-    FilesystemStorage, FilesystemStorageOptions, FilesystemStorageRead, FilesystemStorageSync,
-    FilesystemStorageWrite,
+    FilesystemStorage, FilesystemStorageOptions, FilesystemStorageRead, FilesystemStorageWrite,
 };
 pub use lix_storage_rocksdb::{
     RocksDB as RocksDBFilesystem, RocksDBRead as RocksDBFilesystemRead,


### PR DESCRIPTION
## Summary

- make `FilesystemStorage` retain its synchronization supervisor internally
- change `start_sync(&lix)` to return `Result<()>` and add idempotent `stop_sync()` for deterministic shutdown
- remove the public `FilesystemStorageSync` guard and migrate Rust/native call sites
- break the ownership cycle by running the supervisor's private Lix session directly on the underlying RocksDB adapter
- document optional explicit shutdown and best-effort final-drop behavior

## Behavior

- dropping the temporary result of `start_sync()` can no longer stop synchronization
- a repeated `start_sync()` fails with `LIX_FILESYSTEM_SYNC_ALREADY_STARTED`
- `stop_sync()` waits for the worker and internal Lix session to close; repeated stops are harmless
- dropping the final storage/repository instance performs best-effort shutdown
- JS/native `close()` now explicitly stops filesystem synchronization before closing Lix

This intentionally has no backwards-compatible guard wrapper.

## Validation

- `cargo test -p lix-storage-filesystem` — 23 passed, including cancellation recovery and secondary-branch preference preservation
- `cargo check -p lix-storage-filesystem --all-targets`
- `cargo check -p lix_e2e --tests`
- `cargo check -p lix_js_sdk --all-targets`
- `cargo fmt -p lix-storage-filesystem -- --check`
- `git diff --check`

The feature-heavy Rust SDK E2E runtime build was stopped during its cold compile because the `/tmp` build volume reached 2.4 GiB free; it emitted no candidate diagnostic before termination. The affected E2E and native crates compile successfully, and the adapter lifecycle/reopen behavior is covered directly in the 23-test adapter suite.