### PR TITLE
fix(rust): flatten embedding futures and use default stacks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -395,6 +395,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-executor"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c96bf972d85afc50bf5ab8fe2d54d1586b4e0b46c97c50a0c9e71e2f7bcd812a"
+dependencies = [
+ "async-task",
+ "concurrent-queue",
+ "fastrand",
+ "futures-lite",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
 name = "async-lock"
 version = "3.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -426,6 +440,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "async-task"
+version = "4.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
 
 [[package]]
 name = "async-trait"
@@ -3042,6 +3062,7 @@ name = "lix"
 version = "0.11.0"
 dependencies = [
  "ahash",
+ "async-executor",
  "async-stream",
  "async-trait",
  "base64",

--- a/packages/lix/Cargo.toml
+++ b/packages/lix/Cargo.toml
@@ -165,6 +165,7 @@ wasmtime = { version = "45", default-features = false, features = ["cache", "com
 wasmtime-wasi = { version = "45", default-features = false, features = ["p2"], optional = true }
 
 [dev-dependencies]
+async-executor = "1"
 criterion = { package = "codspeed-criterion-compat", version = "4" }
 flate2 = "1"
 http-body-util = "0.1"

--- a/packages/lix/src/background_task.rs
+++ b/packages/lix/src/background_task.rs
@@ -5,11 +5,6 @@ use crate::LixError;
 /// Runs engine-owned background work without borrowing the embedding
 /// application's async runtime.
 ///
-/// The temporary stack size preserves the existing execution envelope while
-/// the separate default-stack hard cut removes deep poll stacks. Runtime
-/// neutrality must not silently become a stack-size behavior change.
-const BACKGROUND_TASK_STACK_BYTES: usize = 16 * 1024 * 1024;
-
 pub(crate) fn spawn<Factory, F>(name: &str, factory: Factory) -> Result<(), LixError>
 where
     Factory: FnOnce() -> F + Send + 'static,
@@ -17,7 +12,6 @@ where
 {
     std::thread::Builder::new()
         .name(name.to_owned())
-        .stack_size(BACKGROUND_TASK_STACK_BYTES)
         .spawn(move || futures_lite::future::block_on(factory()))
         .map(|_| ())
         .map_err(|error| {

--- a/packages/lix/src/handle.rs
+++ b/packages/lix/src/handle.rs
@@ -261,21 +261,9 @@ where
 /// Clones share the active branch, transaction exclusion, file-view state,
 /// and close lifecycle.
 ///
-/// # Spawning a query onto a runtime
-///
-/// `tokio::spawn` on a future that contains [`Lix::execute`] can fail to
-/// compile with `overflow evaluating the requirement ...: Send`. The query
-/// futures nest deeply enough that proving the `Send` obligation exceeds
-/// rustc's default recursion limit. This is a compile-time limit, not a
-/// soundness problem, and the limit is per-crate — so it has to be raised in
-/// **your** crate, at the top of its root module:
-///
-/// ```ignore
-/// #![recursion_limit = "2048"]
-/// ```
-///
-/// Awaiting the query directly, or driving it with `futures::join!`, does not
-/// hit this.
+/// Public operation builders erase their internal future type, so embedding
+/// applications can spawn composed Lix flows without raising rustc's
+/// recursion limit.
 #[derive(Clone)]
 #[expect(missing_debug_implementations)]
 pub struct Lix<StorageImpl = Memory>

--- a/packages/lix/tests/send_futures.rs
+++ b/packages/lix/tests/send_futures.rs
@@ -1,9 +1,19 @@
-#![recursion_limit = "256"]
-
 use lix::{ExecuteBatchStatement, Lix, SwitchBranchOptions, open_lix};
 
 fn assert_send<T: Send>(_: T) {}
 fn assert_send_sync<T: Send + Sync>() {}
+
+#[test]
+fn composed_open_execute_close_spawns_on_a_non_tokio_multithreaded_executor() {
+    let executor = async_executor::Executor::new();
+    executor
+        .spawn(async move {
+            let lix = open_lix().await.expect("open Lix");
+            lix.execute("SELECT 1", &[]).await.expect("execute query");
+            lix.close().await.expect("close Lix");
+        })
+        .detach();
+}
 
 #[tokio::test]
 async fn public_execution_and_observation_futures_are_send() {

--- a/packages/storage-filesystem/src/filesystem.rs
+++ b/packages/storage-filesystem/src/filesystem.rs
@@ -7,6 +7,7 @@ use std::collections::{BTreeMap, BTreeSet};
 use std::fmt::Write as _;
 use std::future::Future;
 use std::path::{Component, Path, PathBuf};
+use std::pin::Pin;
 use std::sync::{Arc, Mutex, Weak, mpsc};
 use std::thread::{self, JoinHandle};
 use std::time::Duration;
@@ -331,11 +332,16 @@ enum FilesystemEvent {
 
 impl FilesystemStorage {
     /// Starts bidirectional filesystem synchronization owned by this storage.
-    pub async fn start_sync(&self, lix: &Lix<FilesystemStorage>) -> Result<(), LixError> {
-        let startup = FilesystemSyncStartup::begin(Arc::clone(&self.sync_lifecycle))?;
-        let supervisor = self.open_supervisor(lix).await?;
-        startup.complete(supervisor);
-        Ok(())
+    pub fn start_sync<'a>(
+        &'a self,
+        lix: &'a Lix<FilesystemStorage>,
+    ) -> Pin<Box<dyn Future<Output = Result<(), LixError>> + Send + 'a>> {
+        Box::pin(async move {
+            let startup = FilesystemSyncStartup::begin(Arc::clone(&self.sync_lifecycle))?;
+            let supervisor = self.open_supervisor(lix).await?;
+            startup.complete(supervisor);
+            Ok(())
+        })
     }
 
     /// Stops synchronization and waits for its worker and internal Lix session.


### PR DESCRIPTION
## Summary

- remove the downstream recursion-limit requirement and its public documentation
- compile composed `open_lix`/execute/close flows on Tokio and an independent multithreaded executor without a crate-level recursion attribute
- erase `FilesystemStorage::start_sync` behind an explicit boxed `Send` future
- run Lix-owned background workers on the platform default thread stack instead of forcing 16 MiB
- retain ordinary `#[test]` plain-`block_on` open/write/read/close coverage

Stacked on #1474, which first removes the embedding Tokio-runtime requirement. #1472 is the stable-Cargo workspace prerequisite.

## Gates

- cfg(test)-inclusive Clippy on parent stack: PASS with `cargo clippy -p lix --lib --tests --all-features -- -D warnings`
- external crate with no `recursion_limit`: Tokio spawn + `async-executor::Executor::spawn` composed open/execute/close compile PASS
- `cargo test -p lix --test runtime_contract --no-default-features public_sdk_opens_writes_and_reads_without_a_tokio_runtime`: PASS on platform default stack, 1/1, 0.05s
- `git diff --check`: PASS
- `start_sync` now exposes `Pin<Box<dyn Future<...> + Send>>`; package check remained infrastructure-capped compiling `librocksdb-sys` C++ before reaching the Rust package, so no Filesystem execution claim is made from this host

## Scope note

Lix's public operation builders were already boxed `Send` futures; this cut removes the downstream recursion directive and closes the remaining composed `start_sync` boundary. It does not introduce a compatibility adapter or a second execution path.

## Identity

- parent: `8d78766a2c12633e9ad1a1d14011211f34a31faa`
- head: `05ed424eaa9eae8dcb37e2255082f6e5025ed494`
- tree: `c39bb2452dfc8cdececc42469bfac1c0b491b159`
- diff SHA-256: `22dfbc37184a8dd9faaac08c7f067d2091e7576a0a13614a2f5a459730895eb3`
- format-patch SHA-256: `7d105bf869bceb2aad093a8cf43be70296a24c684d7a3c0920dc23d9bd6aacff`
