### PR TITLE
test(rust): use current JSONB syntax in runtime fixture

### DIFF
--- a/packages/lix/tests/runtime_contract.rs
+++ b/packages/lix/tests/runtime_contract.rs
@@ -60,7 +60,7 @@ fn public_sdk_opens_writes_and_reads_without_a_tokio_runtime() {
     futures_lite::future::block_on(async {
         let lix = open_lix().await.expect("open Lix under plain block_on");
         lix.execute(
-            "INSERT INTO lix_key_value (key, value) VALUES ('executor', lix_json('true'))",
+            "INSERT INTO lix_key_value (key, value) VALUES ('executor', CAST('true' AS JSONB))",
             &[],
         )
         .await


### PR DESCRIPTION
Follow-up to #1474/#1475.

The plain `futures_lite::block_on` runtime contract used the removed `lix_json()` SQL helper and therefore failed before exercising runtime neutrality. Use the current public `CAST(... AS JSONB)` syntax instead.

Gates:
- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo test -p lix --test runtime_contract --all-features public_sdk_opens_writes_and_reads_without_a_tokio_runtime -- --exact` (1/1 PASS)