### PR TITLE
fix(rust): make adapter composition futures Send

### DIFF
--- a/packages/lix/src/handle.rs
+++ b/packages/lix/src/handle.rs
@@ -565,11 +565,15 @@ where
     /// Executes read statements against one coherent storage snapshot and
     /// returns the snapshot metadata required by official storage adapters.
     #[doc(hidden)]
-    pub async fn execute_coherent_read_batch(
+    pub fn execute_coherent_read_batch(
         &self,
         statements: &[(&str, &[Value])],
-    ) -> Result<CoherentReadBatch, LixError> {
-        self.session.execute_coherent_read_batch(statements).await
+    ) -> impl Future<Output = Result<CoherentReadBatch, LixError>> + Send + 'static {
+        let statements = statements
+            .iter()
+            .map(|(sql, params)| ((*sql).to_owned(), (*params).to_vec()))
+            .collect();
+        Arc::clone(&self.session).execute_coherent_read_batch_owned(statements)
     }
 
     /// Executes one prepared DML statement shape for a rectangular parameter
@@ -636,8 +640,10 @@ where
         })
     }
 
-    pub async fn active_branch_id(&self) -> Result<String, LixError> {
-        self.session.active_branch_id().await
+    pub fn active_branch_id(
+        &self,
+    ) -> impl Future<Output = Result<String, LixError>> + Send + 'static {
+        Arc::clone(&self.session).active_branch_id_owned()
     }
 
     pub fn active_account_id(&self) -> &str {

--- a/packages/lix/src/session/context.rs
+++ b/packages/lix/src/session/context.rs
@@ -1,5 +1,6 @@
 #![allow(clippy::match_wild_err_arm, clippy::option_if_let_else)]
 
+use std::future::Future;
 use std::sync::{Arc, RwLock};
 
 use async_trait::async_trait;
@@ -472,6 +473,15 @@ where
             Ok(branch_id) => Ok(branch_id),
             Err(error) => Err(error),
         }
+    }
+
+    pub(crate) fn active_branch_id_owned(
+        self: Arc<Self>,
+    ) -> impl Future<Output = Result<String, LixError>> + Send + 'static {
+        // SAFETY: the future owns its Arc session. Storage read handles are
+        // Send by the Storage contract; the compiler obstruction is the
+        // higher-ranked shared reference carried by a borrowing adapter.
+        unsafe { super::AssumeSendFuture::new(async move { self.active_branch_id().await }) }
     }
 
     #[doc(hidden)]

--- a/packages/lix/src/session/execute.rs
+++ b/packages/lix/src/session/execute.rs
@@ -2055,6 +2055,25 @@ where
         result
     }
 
+    pub(crate) fn execute_coherent_read_batch_owned(
+        self: Arc<Self>,
+        statements: Vec<(String, Vec<Value>)>,
+    ) -> impl Future<Output = Result<CoherentReadBatch, LixError>> + Send + 'static {
+        // SAFETY: the future owns its Arc session and every SQL/parameter
+        // payload. Storage read handles are Send by the Storage contract; the
+        // compiler obstruction is the higher-ranked shared reference carried
+        // by borrowing adapters such as RocksDB snapshots.
+        unsafe {
+            super::AssumeSendFuture::new(async move {
+                let statement_refs = statements
+                    .iter()
+                    .map(|(sql, params)| (sql.as_str(), params.as_slice()))
+                    .collect::<Vec<_>>();
+                self.execute_coherent_read_batch(&statement_refs).await
+            })
+        }
+    }
+
     async fn execute_coherent_read_batch_inner(
         &self,
         statements: &[(&str, &[Value])],

--- a/packages/lix/tests/send_futures.rs
+++ b/packages/lix/tests/send_futures.rs
@@ -20,6 +20,7 @@ async fn public_execution_and_observation_futures_are_send() {
     let lix = open_lix().await.expect("open Lix");
     assert_send_sync::<Lix>();
 
+    assert_send(lix.active_branch_id());
     assert_send(lix.open_another_session());
     assert_send(lix.execute("SELECT 1", &[]));
     assert_send(lix.execute_batch(&[ExecuteBatchStatement {

--- a/packages/storage-filesystem/tests/runtime_contract.rs
+++ b/packages/storage-filesystem/tests/runtime_contract.rs
@@ -1,6 +1,8 @@
 use lix::{Value, open_lix};
 use lix_storage_filesystem::FilesystemStorage;
 
+fn assert_send<T: Send>(_: T) {}
+
 #[test]
 fn open_and_start_sync_work_under_plain_block_on() {
     let root = tempfile::tempdir().expect("temporary filesystem root");
@@ -14,7 +16,8 @@ fn open_and_start_sync_work_under_plain_block_on() {
             .with_storage(storage.clone())
             .await
             .expect("open Lix under plain block_on");
-        let sync = storage
+        assert_send(storage.start_sync(&lix));
+        storage
             .start_sync(&lix)
             .await
             .expect("start sync under plain block_on");
@@ -28,7 +31,10 @@ fn open_and_start_sync_work_under_plain_block_on() {
             .expect("read synchronized file");
         assert_eq!(result.rows().len(), 1);
 
-        drop(sync);
+        storage
+            .stop_sync()
+            .await
+            .expect("stop sync under plain block_on");
         lix.close().await.expect("close Lix");
     });
 }


### PR DESCRIPTION
## Summary

- make owned active-branch and coherent-read adapter futures explicitly `Send + 'static`
- preserve the existing runtime-agnostic execution path without adding a worker thread, cache, fallback, or second authority
- add compile/runtime coverage for filesystem `start_sync` under plain `futures_lite::block_on`

## CI regression fixed

The merged SDK stack exposed a higher-ranked borrowing-adapter limitation while compiling `lix-storage-filesystem`: `start_sync` was rejected as `Send` even though storage read handles satisfy the storage contract. This uses the existing narrowly scoped owned-future wrapper at the adapter boundary.

## Local gates

- `cargo check -p lix-storage-filesystem --all-features`
- `cargo test -p lix --test send_futures --all-features` (4/4)
- `cargo test -p lix-storage-filesystem --test runtime_contract --all-features` (1/1)
- `cargo clippy -p lix --lib --tests --all-features -- -D warnings`
- `cargo clippy -p lix-storage-filesystem --all-targets --all-features -- -D warnings`
- fmt/diff-check

## Bounded performance

20 identical process runs of the filesystem open/start/stop runtime contract:

- baseline mean 94 ms, median 90 ms, median RSS 91,636 KiB
- candidate mean 101 ms, median 100 ms, median RSS 91,554 KiB

Mean latency is +7.5% and RSS is unchanged; the rejected worker-thread approach was not retained.
