### PR TITLE
perf(sql): parse row history snapshots once per batch

### DIFF
--- a/packages/e2e/Cargo.toml
+++ b/packages/e2e/Cargo.toml
@@ -229,6 +229,11 @@ name = "tracked_state_crud_public_result"
 path = "tests/tracked_state_crud_public_result.rs"
 required-features = ["storage-benches"]
 
+[[test]]
+name = "native_schema_point_reopen"
+path = "tests/native_schema_point_reopen.rs"
+required-features = ["rocksdb", "slatedb"]
+
 # Deliberately its own target rather than a `-p lix` unit test: the scoped-root
 # census counters it reads are process-global, and a dedicated test binary with
 # a single test keeps them free of concurrent contributors.

--- a/packages/e2e/benches/tracked_state_crud/main.rs
+++ b/packages/e2e/benches/tracked_state_crud/main.rs
@@ -558,7 +558,6 @@ fn profile_hot_sql_session_operations(
         rows,
         read_many_pk_count,
     ));
-    let _ = lix::storage_bench::take_row_point_snapshot_cache_accounting();
     if sql_session::selected_olap_read_shape().is_some() {
         // Full semantic validation is intentionally outside the samples. This
         // keeps Rust-vs-JavaScript assertion work out of the engine ratio while
@@ -624,13 +623,6 @@ fn profile_hot_sql_session_operations(
             TransactionBenchOp::ReadManyByPk,
             read_many_pk_count,
             samples,
-        );
-    }
-    if matches!(operation, TransactionBenchOp::ReadOneByPk) {
-        let cache = lix::storage_bench::take_row_point_snapshot_cache_accounting();
-        println!(
-            "tracked_state_crud point cache accounting: hits={} misses={}",
-            cache.hits, cache.misses
         );
     }
     black_box(row_count);

--- a/packages/e2e/benches/tracked_state_crud/sql_session.rs
+++ b/packages/e2e/benches/tracked_state_crud/sql_session.rs
@@ -1894,6 +1894,12 @@ where
 }
 
 fn select_by_pk_sql(rows: &[WorkloadRow]) -> String {
+    if let [row] = rows {
+        return format!(
+            "SELECT path, value FROM json_pointer WHERE path = '{}' LIMIT 1",
+            sql_string(&row.path)
+        );
+    }
     select_by_paths_sql(rows.iter().map(|row| row.path.as_str()))
 }
 

--- a/packages/e2e/tests/cas_gc_history_retention.rs
+++ b/packages/e2e/tests/cas_gc_history_retention.rs
@@ -102,6 +102,21 @@ where
         .open_another_session()
         .await
         .expect("open shared-blob session");
+    let branch = session
+        .create_branch(lix::CreateBranchOptions {
+            id: Some("01990000-0000-7000-8000-00000000000c".to_owned()),
+            name: "shared-blob-disposable".to_owned(),
+            from_commit_id: None,
+        })
+        .await
+        .expect("create shared-blob disposable branch");
+    let branch_id = branch.id;
+    session
+        .switch_branch(lix::SwitchBranchOptions {
+            branch_id: branch_id.clone(),
+        })
+        .await
+        .expect("switch shared-blob session branch");
     for path in ["/shared-a.bin", "/shared-b.bin"] {
         session
             .execute(
@@ -142,6 +157,15 @@ where
         .await
         .expect("collect while second shared owner remains");
     assert_eq!(read_file_at(&session, "/shared-b.bin").await, Some(OLD.to_vec()));
+    let old_hash = blake3::hash(OLD).to_hex().to_string();
+    let new_hash = blake3::hash(NEW).to_hex().to_string();
+    assert_eq!(
+        read_binary_cas_for_bench(&StorageAdapter::new(storage.clone()), &old_hash)
+            .await
+            .expect("shared old CAS lookup should succeed")
+            .as_deref(),
+        Some(OLD),
+    );
     drop(session);
     drop(lix);
     drop(storage);
@@ -155,6 +179,12 @@ where
         .open_another_session()
         .await
         .expect("open shared-blob session after reopen");
+    reopened_session
+        .switch_branch(lix::SwitchBranchOptions {
+            branch_id: branch_id.clone(),
+        })
+        .await
+        .expect("switch reopened shared-blob branch");
     assert_eq!(
         read_file_at(&reopened_session, "/shared-b.bin").await,
         Some(OLD.to_vec())
@@ -163,11 +193,41 @@ where
         .execute("DELETE FROM lix_file WHERE path = '/shared-b.bin'", &[])
         .await
         .expect("delete final shared owner");
-    collect_repository_gc_for_bench(&StorageAdapter::new(reopened_storage))
-        .await
-        .expect("collect after both shared owners are deleted");
     assert_eq!(read_file_at(&reopened_session, "/shared-a.bin").await, None);
     assert_eq!(read_file_at(&reopened_session, "/shared-b.bin").await, None);
+    drop(reopened_session);
+
+    let main = reopened
+        .open_another_session()
+        .await
+        .expect("open shared-blob main session");
+    main.execute(
+        "DELETE FROM lix_branch WHERE id = $1",
+        &[Value::Text(branch_id)],
+    )
+    .await
+    .expect("release shared-blob branch history");
+    drop(main);
+
+    let adapter = StorageAdapter::new(reopened_storage);
+    let sweep = collect_repository_gc_for_bench(&adapter)
+        .await
+        .expect("collect after final owner and history release");
+    assert_ne!(sweep.swept_commits, 0, "shared history release must sweep commits");
+    assert!(
+        read_binary_cas_for_bench(&adapter, &old_hash)
+            .await
+            .expect("released old CAS lookup should succeed")
+            .is_none(),
+        "old shared content must reclaim after every current and historical owner is released",
+    );
+    assert!(
+        read_binary_cas_for_bench(&adapter, &new_hash)
+            .await
+            .expect("released replacement CAS lookup should succeed")
+            .is_none(),
+        "replacement content must reclaim after its branch history is released",
+    );
 }
 
 async fn read_file_at<S>(session: &lix::Lix<S>, path: &str) -> Option<Vec<u8>>

--- a/packages/e2e/tests/cas_gc_history_retention.rs
+++ b/packages/e2e/tests/cas_gc_history_retention.rs
@@ -70,6 +70,122 @@ async fn slatedb_current_untracked_blob_survives_sweep_and_cold_reopen() {
         .await;
 }
 
+#[tokio::test]
+async fn rocksdb_shared_blob_survives_replace_rollback_delete_gc_and_reopen() {
+    let temp = tempfile::tempdir().expect("create RocksDB shared-blob fixture");
+    shared_blob_replacement_lifecycle(&temp.path().join("database"), |path| {
+        RocksDB::open(path)
+    })
+    .await;
+}
+
+#[tokio::test]
+async fn slatedb_shared_blob_survives_replace_rollback_delete_gc_and_reopen() {
+    let temp = tempfile::tempdir().expect("create SlateDB shared-blob fixture");
+    shared_blob_replacement_lifecycle(&temp.path().join("database"), |path| SlateDB::open(path))
+        .await;
+}
+
+async fn shared_blob_replacement_lifecycle<S, O>(path: &std::path::Path, open: O)
+where
+    S: Storage + Clone + Send + Sync + 'static,
+    O: Fn(&std::path::Path) -> Result<S, lix::storage::StorageError>,
+{
+    const OLD: &[u8] = b"shared-old-content";
+    const NEW: &[u8] = b"replacement-content";
+    let storage = open(path).expect("open shared-blob fixture");
+    let lix = open_lix()
+        .with_storage(storage.clone())
+        .await
+        .expect("initialize shared-blob repository");
+    let session = lix
+        .open_another_session()
+        .await
+        .expect("open shared-blob session");
+    for path in ["/shared-a.bin", "/shared-b.bin"] {
+        session
+            .execute(
+                "INSERT INTO lix_file (path, content) VALUES ($1, $2)",
+                &[Value::Text(path.to_owned()), Value::Blob(OLD.to_vec().into())],
+            )
+            .await
+            .expect("insert shared blob owner");
+    }
+
+    let mut rollback = session
+        .begin_transaction()
+        .await
+        .expect("begin shared replacement rollback");
+    rollback
+        .execute(
+            "UPDATE lix_file SET content = $1 WHERE path = '/shared-a.bin'",
+            &[Value::Blob(NEW.to_vec().into())],
+        )
+        .await
+        .expect("stage shared replacement rollback");
+    rollback.rollback().await.expect("rollback shared replacement");
+    assert_eq!(read_file_at(&session, "/shared-a.bin").await, Some(OLD.to_vec()));
+    assert_eq!(read_file_at(&session, "/shared-b.bin").await, Some(OLD.to_vec()));
+
+    session
+        .execute(
+            "UPDATE lix_file SET content = $1 WHERE path = '/shared-a.bin'",
+            &[Value::Blob(NEW.to_vec().into())],
+        )
+        .await
+        .expect("commit one shared owner replacement");
+    session
+        .execute("DELETE FROM lix_file WHERE path = '/shared-a.bin'", &[])
+        .await
+        .expect("delete replaced shared owner");
+    collect_repository_gc_for_bench(&StorageAdapter::new(storage.clone()))
+        .await
+        .expect("collect while second shared owner remains");
+    assert_eq!(read_file_at(&session, "/shared-b.bin").await, Some(OLD.to_vec()));
+    drop(session);
+    drop(lix);
+    drop(storage);
+
+    let reopened_storage = open(path).expect("cold reopen shared-blob fixture");
+    let reopened = open_lix()
+        .with_storage(reopened_storage.clone())
+        .await
+        .expect("open shared-blob repository after reopen");
+    let reopened_session = reopened
+        .open_another_session()
+        .await
+        .expect("open shared-blob session after reopen");
+    assert_eq!(
+        read_file_at(&reopened_session, "/shared-b.bin").await,
+        Some(OLD.to_vec())
+    );
+    reopened_session
+        .execute("DELETE FROM lix_file WHERE path = '/shared-b.bin'", &[])
+        .await
+        .expect("delete final shared owner");
+    collect_repository_gc_for_bench(&StorageAdapter::new(reopened_storage))
+        .await
+        .expect("collect after both shared owners are deleted");
+    assert_eq!(read_file_at(&reopened_session, "/shared-a.bin").await, None);
+    assert_eq!(read_file_at(&reopened_session, "/shared-b.bin").await, None);
+}
+
+async fn read_file_at<S>(session: &lix::Lix<S>, path: &str) -> Option<Vec<u8>>
+where
+    S: Storage + Clone + Send + Sync + 'static,
+{
+    session
+        .execute(
+            "SELECT content FROM lix_file WHERE path = $1",
+            &[Value::Text(path.to_owned())],
+        )
+        .await
+        .expect("read shared blob owner")
+        .rows()
+        .first()
+        .map(|row| row.get::<Vec<u8>>("content").expect("blob content"))
+}
+
 async fn prepare_current_untracked<S>(storage: S)
 where
     S: Storage + Clone + Send + Sync + 'static,

--- a/packages/e2e/tests/cas_gc_history_retention.rs
+++ b/packages/e2e/tests/cas_gc_history_retention.rs
@@ -93,6 +93,7 @@ where
 {
     const OLD: &[u8] = b"shared-old-content";
     const NEW: &[u8] = b"replacement-content";
+    const ROLLED_BACK: &[u8] = b"rolled-back-content";
     let storage = open(path).expect("open shared-blob fixture");
     let lix = open_lix()
         .with_storage(storage.clone())
@@ -134,13 +135,27 @@ where
     rollback
         .execute(
             "UPDATE lix_file SET content = $1 WHERE path = '/shared-a.bin'",
-            &[Value::Blob(NEW.to_vec().into())],
+            &[Value::Blob(ROLLED_BACK.to_vec().into())],
         )
         .await
         .expect("stage shared replacement rollback");
     rollback.rollback().await.expect("rollback shared replacement");
     assert_eq!(read_file_at(&session, "/shared-a.bin").await, Some(OLD.to_vec()));
     assert_eq!(read_file_at(&session, "/shared-b.bin").await, Some(OLD.to_vec()));
+    let rolled_back_hash = blake3::hash(ROLLED_BACK).to_hex().to_string();
+    collect_repository_gc_for_bench(&StorageAdapter::new(storage.clone()))
+        .await
+        .expect("collect rolled-back replacement");
+    assert!(
+        read_binary_cas_for_bench(
+            &StorageAdapter::new(storage.clone()),
+            &rolled_back_hash,
+        )
+        .await
+        .expect("rolled-back CAS lookup should succeed")
+        .is_none(),
+        "rolled-back replacement must not become a current or historical owner",
+    );
 
     session
         .execute(
@@ -149,6 +164,7 @@ where
         )
         .await
         .expect("commit one shared owner replacement");
+    assert_eq!(read_file_at(&session, "/shared-a.bin").await, Some(NEW.to_vec()));
     session
         .execute("DELETE FROM lix_file WHERE path = '/shared-a.bin'", &[])
         .await
@@ -165,6 +181,14 @@ where
             .expect("shared old CAS lookup should succeed")
             .as_deref(),
         Some(OLD),
+    );
+    assert_eq!(
+        read_binary_cas_for_bench(&StorageAdapter::new(storage.clone()), &new_hash)
+            .await
+            .expect("historical replacement CAS lookup should succeed")
+            .as_deref(),
+        Some(NEW),
+        "deleted replacement must remain while branch history still reaches it",
     );
     drop(session);
     drop(lix);
@@ -188,6 +212,21 @@ where
     assert_eq!(
         read_file_at(&reopened_session, "/shared-b.bin").await,
         Some(OLD.to_vec())
+    );
+    let reopened_adapter = StorageAdapter::new(reopened_storage.clone());
+    assert_eq!(
+        read_binary_cas_for_bench(&reopened_adapter, &old_hash)
+            .await
+            .expect("reopened old CAS lookup should succeed")
+            .as_deref(),
+        Some(OLD),
+    );
+    assert_eq!(
+        read_binary_cas_for_bench(&reopened_adapter, &new_hash)
+            .await
+            .expect("reopened replacement CAS lookup should succeed")
+            .as_deref(),
+        Some(NEW),
     );
     reopened_session
         .execute("DELETE FROM lix_file WHERE path = '/shared-b.bin'", &[])

--- a/packages/e2e/tests/native_schema_point_reopen.rs
+++ b/packages/e2e/tests/native_schema_point_reopen.rs
@@ -49,7 +49,8 @@ async fn slatedb_native_schema_point_survives_cold_reopen() {
 async fn native_schema_point_survives_cold_reopen<S: ReopenStorage>() {
     let temp = tempfile::tempdir().expect("create native point fixture");
     let path = temp.path().join("database");
-    let expected = r#"{"a":[true,null],"z":7}"#;
+    let initial = r#"{"a":[true,null],"z":7}"#;
+    let expected = r#"{"a":[false,{"root":"replacement"}],"z":8}"#;
     {
         let storage = S::open(&path);
         let lix = open_lix()
@@ -73,10 +74,18 @@ async fn native_schema_point_survives_cold_reopen<S: ReopenStorage>() {
         .expect("register native point schema");
         lix.execute(
             &format!("INSERT INTO {SCHEMA_KEY} (id, payload) VALUES ($1, CAST($2 AS JSONB))"),
-            &[Value::Text("row-a".into()), Value::Text(expected.into())],
+            &[Value::Text("row-a".into()), Value::Text(initial.into())],
         )
         .await
         .expect("insert native point row");
+        assert_point(&lix, initial).await;
+        lix.execute(
+            &format!("UPDATE {SCHEMA_KEY} SET payload = CAST($2 AS JSONB) WHERE id = $1"),
+            &[Value::Text("row-a".into()), Value::Text(expected.into())],
+        )
+        .await
+        .expect("replace native point row under a new authenticated root");
+        assert_point(&lix, expected).await;
         assert_point(&lix, expected).await;
         lix.close().await.expect("close native point fixture");
         drop(lix);

--- a/packages/e2e/tests/native_schema_point_reopen.rs
+++ b/packages/e2e/tests/native_schema_point_reopen.rs
@@ -1,0 +1,111 @@
+use std::path::Path;
+
+use async_trait::async_trait;
+use lix::storage::Storage;
+use lix::{Value, open_lix};
+use lix_storage_rocksdb::RocksDB;
+use lix_storage_slatedb::SlateDB;
+
+const SCHEMA_KEY: &str = "native_schema_point_reopen_probe";
+
+#[async_trait]
+trait ReopenStorage: Storage + Clone + Send + Sync + Sized + 'static {
+    fn open(path: &Path) -> Self;
+    async fn flush(&self);
+}
+
+#[async_trait]
+impl ReopenStorage for RocksDB {
+    fn open(path: &Path) -> Self {
+        Self::open(path).expect("open RocksDB point fixture")
+    }
+
+    async fn flush(&self) {
+        self.flush().expect("flush RocksDB point fixture");
+    }
+}
+
+#[async_trait]
+impl ReopenStorage for SlateDB {
+    fn open(path: &Path) -> Self {
+        Self::open(path).expect("open SlateDB point fixture")
+    }
+
+    async fn flush(&self) {
+        self.flush().await.expect("flush SlateDB point fixture");
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn rocksdb_native_schema_point_survives_cold_reopen() {
+    native_schema_point_survives_cold_reopen::<RocksDB>().await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn slatedb_native_schema_point_survives_cold_reopen() {
+    native_schema_point_survives_cold_reopen::<SlateDB>().await;
+}
+
+async fn native_schema_point_survives_cold_reopen<S: ReopenStorage>() {
+    let temp = tempfile::tempdir().expect("create native point fixture");
+    let path = temp.path().join("database");
+    let expected = r#"{"a":[true,null],"z":7}"#;
+    {
+        let storage = S::open(&path);
+        let lix = open_lix()
+            .with_storage(storage.clone())
+            .await
+            .expect("initialize native point fixture");
+        let schema = serde_json::json!({
+            "$schema": "https://lix.dev/schema-v1.json",
+            "key": SCHEMA_KEY,
+            "columns": [
+                { "name": "id", "type": "text", "nullable": false },
+                { "name": "payload", "type": "jsonb", "nullable": false }
+            ],
+            "primary_key": ["id"]
+        });
+        lix.execute(
+            "INSERT INTO lix_registered_schema (schema_key, value) VALUES (CAST($1 AS JSONB) ->> 'key', CAST($1 AS JSONB))",
+            &[Value::Text(schema.to_string())],
+        )
+        .await
+        .expect("register native point schema");
+        lix.execute(
+            &format!("INSERT INTO {SCHEMA_KEY} (id, payload) VALUES ($1, CAST($2 AS JSONB))"),
+            &[Value::Text("row-a".into()), Value::Text(expected.into())],
+        )
+        .await
+        .expect("insert native point row");
+        assert_point(&lix, expected).await;
+        lix.close().await.expect("close native point fixture");
+        drop(lix);
+        storage.flush().await;
+    }
+
+    let storage = S::open(&path);
+    let lix = open_lix()
+        .with_storage(storage.clone())
+        .await
+        .expect("cold reopen native point fixture");
+    assert_point(&lix, expected).await;
+    lix.close().await.expect("close reopened native point fixture");
+    drop(lix);
+    storage.flush().await;
+}
+
+async fn assert_point<S: Storage + Clone + Send + Sync + 'static>(lix: &lix::Lix<S>, expected: &str) {
+    let result = lix
+        .execute(
+            &format!("SELECT payload AS body FROM {SCHEMA_KEY} WHERE id = $1 LIMIT 1"),
+            &[Value::Text("row-a".into())],
+        )
+        .await
+        .expect("read native point row");
+    assert_eq!(result.columns(), ["body"]);
+    assert_eq!(result.len(), 1);
+    let Value::Json(actual) = result.rows()[0].get_index(0).expect("point payload") else {
+        panic!("point payload must remain JSONB");
+    };
+    assert_eq!(actual.as_str(), expected);
+}

--- a/packages/lix/src/engine.rs
+++ b/packages/lix/src/engine.rs
@@ -2182,11 +2182,63 @@ mod tests {
             .begin_read(StorageReadOptions::default())
             .await
             .expect("post-checkpoint inventory read should open");
-        let after = scan_test_space(&read, crate::hot_state::DIFF_SPACE).await;
+        let before_gc = scan_test_space(&read, crate::hot_state::DIFF_SPACE).await;
+        assert!(
+            before_gc.len() > 1,
+            "checkpoint rotation must not synchronously scan and delete the superseded sparse epoch"
+        );
+        let logical = session
+            .execute("SELECT COUNT(*) AS entries FROM lix_working_diff", &[])
+            .await
+            .expect("post-checkpoint logical diff should execute");
         assert_eq!(
-            after.len(),
+            logical.rows()[0]
+                .get::<i64>("entries")
+                .expect("working-diff count should be numeric"),
+            0,
+            "the superseded physical epoch must be unreachable immediately"
+        );
+        assert_eq!(
+            before_gc.len(),
+            3,
+            "the first checkpoint leaves the two superseded branch index records for GC"
+        );
+        drop(read);
+
+        let read = SharedStorageAdapterRead::new(
+            adapter
+                .begin_read(StorageReadOptions::default())
+                .await
+                .expect("working-diff GC read should open"),
+        );
+        let mut gc_writes = adapter.new_write_set();
+        let mut gc_preconditions = Vec::new();
+        crate::gc::stage_repository_gc_with_preconditions(
+            read,
+            &mut gc_writes,
+            &mut gc_preconditions,
+        )
+            .await
+            .expect("repository GC should collect superseded sparse epochs");
+        adapter
+            .commit_write_set(
+                gc_writes,
+                StorageWriteOptions {
+                    preconditions: gc_preconditions,
+                    ..StorageWriteOptions::default()
+                },
+            )
+            .await
+            .expect("working-diff GC should commit");
+        let read = adapter
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("post-GC inventory read should open");
+        let after_gc = scan_test_space(&read, crate::hot_state::DIFF_SPACE).await;
+        assert_eq!(
+            after_gc.len(),
             1,
-            "the superseded branch epoch must be reclaimed; only the repository-global checkpoint row may remain dirty"
+            "GC must reclaim the superseded branch epoch; only the repository-global checkpoint row may remain dirty"
         );
         drop(read);
         session
@@ -2206,7 +2258,7 @@ mod tests {
         let logical = session
             .execute("SELECT COUNT(*) AS entries FROM lix_working_diff", &[])
             .await
-            .expect("post-checkpoint logical diff should execute");
+            .expect("second post-checkpoint logical diff should execute");
         assert_eq!(
             logical.rows()[0]
                 .get::<i64>("entries")

--- a/packages/lix/src/gc.rs
+++ b/packages/lix/src/gc.rs
@@ -21,7 +21,6 @@ use crate::changelog::{ChangeRecord, CommitScanRequest};
 use crate::changelog::{ChangeScanRequest, ChangelogContext, ChangelogReader};
 use crate::commit_graph::CommitGraphContext;
 use crate::hot_state::TrackedHeadContext;
-#[cfg(test)]
 use crate::hot_state::stage_collect_stale_working_diff_indexes;
 use crate::json_store::{JsonRef, JsonSlot, JsonStoreContext};
 #[cfg(test)]
@@ -1581,6 +1580,11 @@ where
     if !reclaimed_semantic_commits.is_empty() {
         writes.seal_changelog_gc();
     }
+
+    // Checkpoint publication rotates the authenticated sparse dirty-index
+    // marker in O(1). Retire every now-unreachable epoch here, under the same
+    // observed branch-control preconditions as the rest of repository GC.
+    stage_collect_stale_working_diff_indexes(&store, writes).await?;
 
     preconditions.extend(staged_preconditions);
     Ok(RepositoryGcPlan {

--- a/packages/lix/src/hot_state/context.rs
+++ b/packages/lix/src/hot_state/context.rs
@@ -1486,6 +1486,8 @@ fn tracked_scan_request_from_live(request: &HotStateScanRequest) -> TrackedState
         filter: TrackedStateFilter {
             schema_keys: request.filter.schema_keys.clone(),
             row_pks: request.filter.row_pks.clone(),
+            row_pk_lower: request.filter.row_pk_lower.clone(),
+            row_pk_upper: request.filter.row_pk_upper.clone(),
             file_ids: request.filter.file_ids.clone(),
             // Scan tombstones internally so branch-local tombstones can hide
             // global fallback rows before the serving facade filters them.

--- a/packages/lix/src/hot_state/context.rs
+++ b/packages/lix/src/hot_state/context.rs
@@ -35,8 +35,6 @@ use super::derived::{
 };
 
 const BRANCH_READ_CONCURRENCY: usize = 8;
-const ROW_POINT_SNAPSHOT_CACHE_MAX_BYTES: usize = 8 * 1024 * 1024;
-const ROW_POINT_SNAPSHOT_CACHE_MAX_ENTRIES: usize = 4_096;
 const ROW_COLUMNAR_LAYOUT_CACHE_MAX_BYTES: usize = 256 * 1024 * 1024;
 const ROW_COLUMNAR_LAYOUT_CACHE_MAX_ENTRIES: usize = 16;
 const TRANSACTION_BRANCH_HEAD_CONTROL_CACHE_MAX_ENTRIES: usize = 64;
@@ -111,27 +109,6 @@ impl GlobalKeyValueRowCache {
         }
         entries.push((control, key.to_string(), row));
     }
-}
-
-#[derive(Debug, PartialEq, Eq)]
-struct RowPointSnapshotCacheKey {
-    branch_id: String,
-    generation: CommitId,
-    current_state_revision: u64,
-    schema_key: String,
-    row_pk: RowPk,
-}
-
-#[derive(Debug)]
-struct RowPointSnapshotCacheEntry {
-    key: RowPointSnapshotCacheKey,
-    snapshots: Vec<Option<Bytes>>,
-    bytes: usize,
-}
-
-#[derive(Debug, Default)]
-struct RowPointSnapshotCache {
-    entries: std::sync::Mutex<Vec<RowPointSnapshotCacheEntry>>,
 }
 
 #[derive(Debug, PartialEq, Eq)]
@@ -282,75 +259,6 @@ fn estimated_row_columnar_layout_bytes(
         )
 }
 
-impl RowPointSnapshotCache {
-    fn get(&self, key: &RowPointSnapshotCacheKey) -> Option<Vec<Option<Bytes>>> {
-        if row_point_snapshot_cache_disabled_for_profile() {
-            return None;
-        }
-        let mut entries = self
-            .entries
-            .lock()
-            .expect("row point snapshot cache lock poisoned");
-        let position = entries.iter().position(|entry| entry.key == *key)?;
-        let entry = entries.remove(position);
-        let result = entry.snapshots.clone();
-        entries.push(entry);
-        Some(result)
-    }
-
-    fn insert(
-        &self,
-        key: RowPointSnapshotCacheKey,
-        snapshots: Vec<Option<Bytes>>,
-    ) -> Vec<Option<Bytes>> {
-        if row_point_snapshot_cache_disabled_for_profile() {
-            return snapshots;
-        }
-        let bytes = size_of::<RowPointSnapshotCacheEntry>()
-            + key.branch_id.capacity()
-            + key.schema_key.capacity()
-            + snapshots.capacity() * size_of::<Option<Bytes>>()
-            + snapshots.iter().flatten().map(Bytes::len).sum::<usize>();
-        let result = snapshots.clone();
-        if bytes > ROW_POINT_SNAPSHOT_CACHE_MAX_BYTES {
-            return result;
-        }
-        let mut entries = self
-            .entries
-            .lock()
-            .expect("row point snapshot cache lock poisoned");
-        entries.retain(|entry| {
-            entry.key.branch_id != key.branch_id
-                || entry.key.schema_key != key.schema_key
-                || entry.key.row_pk != key.row_pk
-        });
-        entries.push(RowPointSnapshotCacheEntry {
-            key,
-            snapshots,
-            bytes,
-        });
-        let mut resident_bytes = entries.iter().map(|entry| entry.bytes).sum::<usize>();
-        while resident_bytes > ROW_POINT_SNAPSHOT_CACHE_MAX_BYTES
-            || entries.len() > ROW_POINT_SNAPSHOT_CACHE_MAX_ENTRIES
-        {
-            resident_bytes = resident_bytes.saturating_sub(entries.remove(0).bytes);
-        }
-        result
-    }
-}
-
-#[cfg(feature = "storage-benches")]
-fn row_point_snapshot_cache_disabled_for_profile() -> bool {
-    static DISABLED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
-    *DISABLED
-        .get_or_init(|| std::env::var_os("LIX_TRACKED_STATE_CRUD_DISABLE_POINT_CACHE").is_some())
-}
-
-#[cfg(not(feature = "storage-benches"))]
-const fn row_point_snapshot_cache_disabled_for_profile() -> bool {
-    false
-}
-
 /// Serving facade for visible live-state reads.
 ///
 /// Normal rows are resolved from one durable hot-state projection. Each row
@@ -360,7 +268,6 @@ pub(crate) struct HotStateContext {
     tracked_head: TrackedHeadContext,
     commit_graph: CommitGraphContext,
     filesystem_path_index_cache: std::sync::Arc<FilesystemPathIndexCache>,
-    row_point_snapshot_cache: std::sync::Arc<RowPointSnapshotCache>,
     row_columnar_layout_cache: std::sync::Arc<RowColumnarLayoutCache>,
     row_columnar_scan_cache:
         std::sync::Arc<std::sync::Mutex<crate::hot_state::RowColumnarShadowMaskCache>>,
@@ -386,7 +293,6 @@ impl HotStateContext {
             tracked_head: TrackedHeadContext::new(),
             commit_graph,
             filesystem_path_index_cache: std::sync::Arc::new(FilesystemPathIndexCache::default()),
-            row_point_snapshot_cache: std::sync::Arc::new(RowPointSnapshotCache::default()),
             row_columnar_layout_cache: std::sync::Arc::new(RowColumnarLayoutCache::default()),
             row_columnar_scan_cache: std::sync::Arc::new(std::sync::Mutex::new(
                 crate::hot_state::RowColumnarShadowMaskCache::with_array_budget(
@@ -422,7 +328,6 @@ impl HotStateContext {
             tracked_head: self.tracked_head,
             commit_graph: self.commit_graph.clone(),
             filesystem_path_index_cache: std::sync::Arc::clone(&self.filesystem_path_index_cache),
-            row_point_snapshot_cache: std::sync::Arc::clone(&self.row_point_snapshot_cache),
             row_columnar_layout_cache: std::sync::Arc::clone(&self.row_columnar_layout_cache),
             branch_head_control_cache: None,
             root_base_cache: std::sync::Arc::clone(&self.root_base_cache),
@@ -444,7 +349,6 @@ impl HotStateContext {
             tracked_head: self.tracked_head,
             commit_graph: self.commit_graph.clone(),
             filesystem_path_index_cache: std::sync::Arc::clone(&self.filesystem_path_index_cache),
-            row_point_snapshot_cache: std::sync::Arc::clone(&self.row_point_snapshot_cache),
             row_columnar_layout_cache: std::sync::Arc::clone(&self.row_columnar_layout_cache),
             branch_head_control_cache: Some(branch_head_control_cache),
             root_base_cache: std::sync::Arc::clone(&self.root_base_cache),
@@ -476,7 +380,6 @@ impl HotStateContext {
             tracked_head: self.tracked_head,
             commit_graph: self.commit_graph.clone(),
             filesystem_path_index_cache: std::sync::Arc::clone(&self.filesystem_path_index_cache),
-            row_point_snapshot_cache: std::sync::Arc::new(RowPointSnapshotCache::default()),
             row_columnar_layout_cache: std::sync::Arc::new(RowColumnarLayoutCache::default()),
             branch_head_control_cache: None,
             root_base_cache: std::sync::Arc::clone(&self.root_base_cache),
@@ -500,7 +403,6 @@ pub(crate) struct HotStateContextReader<S> {
     tracked_head: TrackedHeadContext,
     commit_graph: CommitGraphContext,
     filesystem_path_index_cache: std::sync::Arc<FilesystemPathIndexCache>,
-    row_point_snapshot_cache: std::sync::Arc<RowPointSnapshotCache>,
     row_columnar_layout_cache: std::sync::Arc<RowColumnarLayoutCache>,
     branch_head_control_cache: Option<std::sync::Arc<BranchHeadControlCache>>,
     root_base_cache: std::sync::Arc<crate::hot_state::tracked_head::RootBaseBatchCache>,
@@ -545,27 +447,6 @@ where
         else {
             return Ok(None);
         };
-        let point_key = match (request.filter.row_pks.as_slice(), request.limit) {
-            ([row_pk], None | Some(1..)) => Some(RowPointSnapshotCacheKey {
-                branch_id: requested_branch_id.clone(),
-                generation: requested_control.tracked_generation,
-                current_state_revision: requested_control.current_state_revision,
-                schema_key: schema_key.clone(),
-                row_pk: row_pk.clone(),
-            }),
-            _ => None,
-        };
-        if let Some(key) = point_key.as_ref()
-            && let Some(snapshots) = self.row_point_snapshot_cache.get(key)
-        {
-            #[cfg(feature = "storage-benches")]
-            crate::storage_bench::record_row_point_snapshot_cache_hit();
-            return Ok(Some(snapshots));
-        }
-        if point_key.is_some() {
-            #[cfg(feature = "storage-benches")]
-            crate::storage_bench::record_row_point_snapshot_cache_miss();
-        }
         let snapshots = self
             .tracked_head
             .reader(&self.store)
@@ -578,10 +459,7 @@ where
                 request.limit,
             )
             .await?;
-        Ok(Some(match point_key {
-            Some(key) => self.row_point_snapshot_cache.insert(key, snapshots),
-            None => snapshots,
-        }))
+        Ok(Some(snapshots))
     }
 
     /// Returns committed row identities under the same narrow visibility

--- a/packages/lix/src/hot_state/context.rs
+++ b/packages/lix/src/hot_state/context.rs
@@ -1026,7 +1026,7 @@ where
             .cloned()
             .collect::<std::collections::BTreeSet<_>>();
 
-        let mut storage_identities = Vec::with_capacity(request.rows.len().saturating_mul(2));
+        let mut storage_identities = Vec::with_capacity(request.rows.len());
         for row in &request.rows {
             if !visible_branch_ids.contains(&row.branch_id) {
                 continue;
@@ -1037,14 +1037,6 @@ where
                 row_pk: &row.row_pk,
                 file_id: row.file_id.as_deref(),
             });
-            if row.branch_id != GLOBAL_BRANCH_ID {
-                storage_identities.push(crate::hot_state::HotStateRowIdentityRef {
-                    branch_id: GLOBAL_BRANCH_ID,
-                    schema_key: row.schema_key.as_str(),
-                    row_pk: &row.row_pk,
-                    file_id: row.file_id.as_deref(),
-                });
-            }
         }
         storage_identities.sort_unstable();
         storage_identities.dedup();
@@ -1064,7 +1056,7 @@ where
         }
         let projection =
             crate::changelog::ChangeRecordProjection::from_columns(&request.projection.columns);
-        let current_batches = stream::iter(branch_ranges)
+        let mut current_batches = stream::iter(branch_ranges)
             .map(|range| {
                 let identities = &storage_identities[range.clone()];
                 let branch_id = identities[0].branch_id;
@@ -1115,9 +1107,81 @@ where
                 }
             }
         }
-        // `storage_identities` and branch ranges are sorted, and `buffered`
-        // preserves input order, so candidate slots are already identity
-        // ordered. Keep the assertion close to the binary-search contract.
+        // Resolve the branch-local plane first. A local value or tombstone is
+        // authoritative and suppresses the global row; only a genuinely
+        // absent (or retention-mismatched) local identity needs a global
+        // point. This preserves aligned overlay semantics while avoiding the
+        // eager 2*K multiget paid by every ordinary exact batch.
+        let mut global_identities = Vec::new();
+        for requested in &request.rows {
+            if requested.branch_id == GLOBAL_BRANCH_ID
+                || !visible_branch_ids.contains(&requested.branch_id)
+            {
+                continue;
+            }
+            let local_identity = crate::hot_state::HotStateRowIdentityRef {
+                branch_id: requested.branch_id.as_str(),
+                schema_key: requested.schema_key.as_str(),
+                row_pk: &requested.row_pk,
+                file_id: requested.file_id.as_deref(),
+            };
+            let local = candidate_slots
+                .binary_search_by_key(&local_identity, |candidate| candidate.0)
+                .ok()
+                .and_then(|index| {
+                    let (_, batch_index, slot) = candidate_slots[index];
+                    current_batches[batch_index].1.row(slot)
+                })
+                .filter(|row| current_row_matches_retention(*row, request.untracked));
+            if local.is_none() {
+                global_identities.push(crate::hot_state::HotStateRowIdentityRef {
+                    branch_id: GLOBAL_BRANCH_ID,
+                    ..local_identity
+                });
+            }
+        }
+        global_identities.sort_unstable();
+        global_identities.dedup();
+        if !global_identities.is_empty()
+            && let Some(global_control) = scope.branch_heads.get(GLOBAL_BRANCH_ID).copied()
+        {
+            let keys = global_identities
+                .iter()
+                .map(|identity| crate::tracked_state::TrackedStateKeyRef {
+                    schema_key: identity.schema_key,
+                    row_pk: identity.row_pk,
+                    file_id: identity.file_id,
+                })
+                .collect::<Vec<_>>();
+            let domain = request
+                .untracked
+                .map_or(HotStateReadDomain::Combined, |untracked| {
+                    if untracked {
+                        HotStateReadDomain::Untracked
+                    } else {
+                        HotStateReadDomain::Tracked
+                    }
+                });
+            let rows = self
+                .tracked_head
+                .reader(&self.store)
+                .load_projected_live_batch_refs_for_domain(
+                    GLOBAL_BRANCH_ID,
+                    global_control,
+                    &keys,
+                    &projection,
+                    domain,
+                )
+                .await?;
+            let batch_index = current_batches.len();
+            for (slot, identity) in global_identities.iter().copied().enumerate() {
+                if rows.row(slot).is_some() {
+                    candidate_slots.push((identity, batch_index, slot));
+                }
+            }
+            current_batches.push((0..global_identities.len(), rows));
+        }
+        candidate_slots.sort_unstable_by_key(|candidate| candidate.0);
         debug_assert!(candidate_slots.windows(2).all(|pair| pair[0].0 < pair[1].0));
 
         let mut builder = MaterializedHotStateBatchBuilder::with_capacity(request.rows.len());

--- a/packages/lix/src/hot_state/mod.rs
+++ b/packages/lix/src/hot_state/mod.rs
@@ -36,7 +36,6 @@ pub(crate) use tracked_head::TrackedHeadDeltaRef;
 pub(crate) use tracked_head::WORKING_DIFF_PATH_HITS;
 #[cfg(test)]
 pub(crate) use tracked_head::hot_generation_scope_prefix;
-#[cfg(test)]
 pub(crate) use tracked_head::stage_collect_stale_working_diff_indexes;
 pub(crate) use tracked_head::stage_retire_hot_generation;
 // Read only by `#[cfg(test)]` probes, so a features-on *library* build compiles
@@ -67,8 +66,7 @@ pub(crate) use tracked_head::{
     ROW_SPACE, TRACKED_WORKING_DIFF_MARKER_SPACE, TrackedHeadContext, TrackedWorkingDiff,
     TrackedWorkingDiffEpoch, WorkingDiffIndexCoverage, load_certified_rows_at_commit,
     materialize_certified_root_rows, scan_certified_history_rows, stage_certified_row_batches,
-    stage_delete_tracked_working_diff_epoch, stage_hot_index_entries,
-    stage_tracked_working_diff_epoch,
+    stage_hot_index_entries, stage_tracked_working_diff_epoch,
 };
 #[allow(unused_imports)]
 pub(crate) use types::{

--- a/packages/lix/src/hot_state/tracked_head.rs
+++ b/packages/lix/src/hot_state/tracked_head.rs
@@ -49,9 +49,7 @@ pub(crate) struct ColumnarBaseCoordinate {
     pub(crate) row_index: u32,
 }
 
-#[cfg(test)]
-use std::collections::BTreeMap;
-use std::collections::BTreeSet;
+use std::collections::{BTreeMap, BTreeSet};
 use std::sync::Arc;
 
 use bytes::Bytes;
@@ -304,7 +302,6 @@ struct BranchRef<'a> {
 
 #[derive(Debug, Clone, musli::Encode, musli::Decode)]
 #[musli(packed)]
-#[cfg(test)]
 struct BranchRefKey {
     branch_id: String,
 }
@@ -813,7 +810,6 @@ async fn load_tracked_working_diff_epoch(
 /// checkpoint epoch. This deliberately runs only from repository GC: a
 /// checkpoint reset is O(1), while old index prefixes are unreachable as soon
 /// as its marker commits.
-#[cfg(test)]
 pub(crate) async fn stage_collect_stale_working_diff_indexes<S>(
     store: &S,
     writes: &mut StorageWriteSet,
@@ -831,21 +827,6 @@ where
     hot::stage_collect_stale_hot_diff_records(store, writes, &active).await
 }
 
-pub(crate) async fn stage_delete_tracked_working_diff_epoch<S>(
-    store: &S,
-    writes: &mut StorageWriteSet,
-    branch_id: &str,
-    checkpoint_commit_id: CommitId,
-    generation: CommitId,
-) -> Result<(), LixError>
-where
-    S: StorageAdapterRead + ?Sized,
-{
-    hot::stage_delete_hot_diff_scope(store, writes, branch_id, checkpoint_commit_id, generation)
-        .await
-}
-
-#[cfg(test)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 struct ActiveWorkingDiffScope {
     checkpoint_commit_id: CommitId,
@@ -856,7 +837,6 @@ struct ActiveWorkingDiffScope {
 /// authoritative branch control. Broken auxiliary bytes are reclaimed here
 /// rather than turning background GC into a retry loop; normal readers already
 /// select canonical replay for the same cases.
-#[cfg(test)]
 async fn stage_active_working_diff_scopes<S>(
     store: &S,
     writes: &mut StorageWriteSet,
@@ -1476,6 +1456,30 @@ fn effective_hot_commit_id(
     ) {
         (Some(active), Some(owner)) if owner != active => Some(active),
         _ => Some(commit_id),
+    }
+}
+
+/// Returns the checkpoint-canonical creation timestamp without rewriting the
+/// current row when an epoch rotates.
+///
+/// A row first created in the previous interval carries `BeforeAbsent` and is
+/// canonicalized by checkpoint history to its change timestamp. Rows that
+/// existed at the checkpoint retain their original creation timestamp.
+fn effective_hot_created_at(
+    value: HeadValueView<'_>,
+    active_checkpoint_commit_id: Option<CommitId>,
+) -> LixTimestamp {
+    match (
+        active_checkpoint_commit_id,
+        value.working_diff_baseline,
+    ) {
+        (
+            Some(active),
+            WorkingDiffBaseline::BeforeAbsent {
+                checkpoint_commit_id,
+            },
+        ) if checkpoint_commit_id != active => value.updated_at,
+        _ => value.created_at,
     }
 }
 
@@ -2238,7 +2242,7 @@ where
             snapshot_content,
             metadata,
             value.deleted,
-            value.created_at,
+            effective_hot_created_at(value, active_checkpoint_commit_id),
             value.updated_at,
             global,
             value.change_id,

--- a/packages/lix/src/hot_state/tracked_head.rs
+++ b/packages/lix/src/hot_state/tracked_head.rs
@@ -717,7 +717,7 @@ fn tracked_head_duplicate_insert_error_ref(schema_key: &str, row_pk: &RowPk) -> 
 
 fn matches_filter(identity: &HeadRowIdentity, filter: &TrackedStateFilter) -> bool {
     (filter.schema_keys.is_empty() || filter.schema_keys.contains(&identity.schema_key))
-        && (filter.row_pks.is_empty() || filter.row_pks.contains(&identity.row_pk))
+        && filter.matches_row_pk(&identity.row_pk)
         && matches_file_filter(identity.file_id.as_ref(), &filter.file_ids)
 }
 

--- a/packages/lix/src/hot_state/tracked_head/hot.rs
+++ b/packages/lix/src/hot_state/tracked_head/hot.rs
@@ -3507,7 +3507,16 @@ fn packed_exact_keys_for_filter(filter: &TrackedStateFilter) -> Option<Vec<Track
             filter
                 .row_pks
                 .iter()
-                .filter(|row_pk| filter.matches_row_pk(row_pk))
+                // These rows already come from `filter.row_pks`; checking
+                // membership again makes an exact K-key lookup O(K^2).
+                // Only the independent range conjunction remains here.
+                .filter(|row_pk| {
+                    crate::tracked_state::row_pk_satisfies_bounds(
+                        row_pk,
+                        filter.row_pk_lower.as_ref(),
+                        filter.row_pk_upper.as_ref(),
+                    )
+                })
                 .map(move |row_pk| TrackedStateKey {
                     schema_key: schema_key.clone(),
                     file_id: None,
@@ -16746,6 +16755,33 @@ mod tests {
                     row_pk: RowPk::single("second"),
                 },
             ]
+        );
+
+        let bounded = TrackedStateFilter {
+            schema_keys: vec!["schema".to_owned()],
+            row_pks: vec![
+                RowPk::single("first"),
+                RowPk::single("second"),
+                RowPk::single("second"),
+                RowPk::single("third"),
+            ],
+            row_pk_lower: Some(crate::tracked_state::RowPkRangeBound {
+                row_pk: RowPk::single("second"),
+                inclusive: true,
+            }),
+            row_pk_upper: Some(crate::tracked_state::RowPkRangeBound {
+                row_pk: RowPk::single("third"),
+                inclusive: false,
+            }),
+            ..TrackedStateFilter::default()
+        };
+        assert_eq!(
+            packed_exact_keys_for_filter(&bounded).expect("bounded filter is finite"),
+            vec![TrackedStateKey {
+                schema_key: "schema".to_owned(),
+                file_id: None,
+                row_pk: RowPk::single("second"),
+            }]
         );
     }
 

--- a/packages/lix/src/hot_state/tracked_head/hot.rs
+++ b/packages/lix/src/hot_state/tracked_head/hot.rs
@@ -7936,6 +7936,27 @@ where
         Ok(generation)
     }
 
+    /// Whether a checkpoint can rotate its working-diff epoch without
+    /// materializing current-state base rows first.
+    ///
+    /// Immutable packed bases encode interval-relative absent-at-checkpoint
+    /// facts and must take the existing materializing route once. Root bases
+    /// are already the branch's checkpoint state and remain clean under a new
+    /// epoch, so they do not prevent lazy rotation.
+    pub(crate) async fn can_rotate_checkpoint_epoch(
+        &self,
+        branch_id: &str,
+        generation: CommitId,
+    ) -> Result<bool, LixError> {
+        if !packed_current_base_refs(self.store, branch_id, generation)
+            .await?
+            .is_empty()
+        {
+            return Ok(false);
+        }
+        Ok(true)
+    }
+
     /// Stages deltas whose absence was already validated against the coherent
     /// transaction snapshot. The caller must publish the corresponding branch
     /// control with a compare-and-swap precondition from that same snapshot.
@@ -8502,7 +8523,7 @@ where
                 // for modified/removed rows.
                 delta.created_at
             } else {
-                existing.created_at
+                effective_hot_created_at(existing, working_diff_capture_checkpoint_commit_id)
             });
         }
         // A checkpoint often selects immutable change records whose HOT row
@@ -9204,6 +9225,7 @@ fn next_cascade_working_diff_baseline(
             let mut before = previous
                 .working_diff_version()
                 .ok_or_else(|| head_value_error("tracked cascade member has no version"))?;
+            before.created_at = effective_hot_created_at(previous, Some(active_checkpoint_commit_id));
             before.commit_id = active_checkpoint_commit_id;
             Ok((
                 WorkingDiffBaseline::BeforePresent {
@@ -9283,6 +9305,7 @@ fn next_hot_working_diff_baseline(
             let mut before = previous
                 .working_diff_version()
                 .ok_or_else(|| head_value_error("tracked mutation has no working-diff version"))?;
+            before.created_at = effective_hot_created_at(previous, Some(active_checkpoint_commit_id));
             before.commit_id = active_checkpoint_commit_id;
             Ok((
                 WorkingDiffBaseline::BeforePresent {
@@ -13309,7 +13332,6 @@ fn encode_hot_file_schema_key(scope: &[u8], schema_key: &str) -> Vec<u8> {
     key
 }
 
-#[cfg_attr(not(test), expect(dead_code))]
 struct HotDiffSegmentScope {
     branch_id: String,
     checkpoint_commit_id: CommitId,
@@ -13425,7 +13447,6 @@ fn visit_hot_diff_segment(
     Ok(())
 }
 
-#[cfg(test)]
 fn decode_hot_diff_key(bytes: &[u8]) -> Result<(CommitId, HeadIdentity), LixError> {
     let mut offset = 0;
     let (branch_id, branch_terminator) = read_key_string(bytes, &mut offset, "branch id")?;
@@ -13587,7 +13608,6 @@ where
     Ok(deleted)
 }
 
-#[cfg(test)]
 pub(crate) async fn stage_collect_stale_hot_diff_records<S>(
     store: &S,
     writes: &mut StorageWriteSet,
@@ -13641,51 +13661,6 @@ where
                 writes.delete(DIFF_SPACE, entry.key);
             }
         }
-        if !page_has_more {
-            break;
-        }
-    }
-    Ok(())
-}
-
-/// Reclaims one superseded working-diff epoch without scanning any other
-/// branch or checkpoint. A checkpoint already performs work linear in its
-/// selected dirty set; this prefix-local scan keeps reclamation on the same
-/// bound while preventing unreachable epochs from accumulating until GC.
-pub(super) async fn stage_delete_hot_diff_scope<S>(
-    store: &S,
-    writes: &mut StorageWriteSet,
-    branch_id: &str,
-    checkpoint_commit_id: CommitId,
-    generation: CommitId,
-) -> Result<(), LixError>
-where
-    S: StorageAdapterRead + ?Sized,
-{
-    let range = StoragePrefix {
-        bytes: Bytes::from(encode_working_diff_scope_prefix(
-            branch_id,
-            checkpoint_commit_id,
-            generation,
-        )),
-    }
-    .to_range()?;
-    let mut cursor = store
-        .begin_scan(
-            DIFF_SPACE,
-            range,
-            StorageBeginScanOptions {
-                projection: StorageCoreProjection::KeyOnly,
-                ..StorageBeginScanOptions::default()
-            },
-        )
-        .await?;
-    loop {
-        let (page, page_has_more) = cursor
-            .next_page(crate::storage_adapter::MAX_SCAN_PAGE_ROWS)
-            .await?
-            .into_parts();
-        writes.delete_batch(DIFF_SPACE, page.into_iter().map(|entry| entry.key));
         if !page_has_more {
             break;
         }

--- a/packages/lix/src/hot_state/tracked_head/hot.rs
+++ b/packages/lix/src/hot_state/tracked_head/hot.rs
@@ -1487,6 +1487,8 @@ pub(crate) async fn load_certified_rows_at_commit(
                 schema_keys,
                 row_pks,
                 file_ids,
+                row_pk_lower: None,
+                row_pk_upper: None,
                 include_tombstones: true,
             },
             read_columns: TrackedStateReadColumns {
@@ -1605,6 +1607,8 @@ struct CertifiedScanFilterIndex {
     schema_keys: Option<HashSet<String>>,
     file_ids: Option<HashSet<String>>,
     row_pks: Option<HashSet<RowPk>>,
+    row_pk_lower: Option<crate::tracked_state::RowPkRangeBound>,
+    row_pk_upper: Option<crate::tracked_state::RowPkRangeBound>,
 }
 
 impl CertifiedScanFilterIndex {
@@ -1636,6 +1640,8 @@ impl CertifiedScanFilterIndex {
             file_ids,
             row_pks: (!request.filter.row_pks.is_empty())
                 .then(|| request.filter.row_pks.iter().cloned().collect()),
+            row_pk_lower: request.filter.row_pk_lower.clone(),
+            row_pk_upper: request.filter.row_pk_upper.clone(),
         }
     }
 
@@ -1663,6 +1669,11 @@ impl CertifiedScanFilterIndex {
         self.row_pks
             .as_ref()
             .is_none_or(|selected| selected.contains(row_pk))
+            && crate::tracked_state::row_pk_satisfies_bounds(
+                row_pk,
+                self.row_pk_lower.as_ref(),
+                self.row_pk_upper.as_ref(),
+            )
     }
 }
 
@@ -3468,7 +3479,7 @@ fn packed_identity_matches_filter(
             .schema_keys
             .iter()
             .any(|requested| requested == schema_key))
-        && (filter.row_pks.is_empty() || filter.row_pks.contains(row_pk))
+        && filter.matches_row_pk(row_pk)
         && (filter.file_ids.is_empty()
             || filter.file_ids.iter().any(|filter| match filter {
                 NullableKeyFilter::Any => true,
@@ -3496,6 +3507,7 @@ fn packed_exact_keys_for_filter(filter: &TrackedStateFilter) -> Option<Vec<Track
             filter
                 .row_pks
                 .iter()
+                .filter(|row_pk| filter.matches_row_pk(row_pk))
                 .map(move |row_pk| TrackedStateKey {
                     schema_key: schema_key.clone(),
                     file_id: None,
@@ -6590,6 +6602,8 @@ where
                     file_ids: vec![file_id.map_or(NullableKeyFilter::Null, |file_id| {
                         NullableKeyFilter::Value(file_id)
                     })],
+                    row_pk_lower: None,
+                    row_pk_upper: None,
                     include_tombstones: true,
                 },
                 read_columns: TrackedStateReadColumns {
@@ -10844,7 +10858,7 @@ impl HotScanIdentity {
                 .schema_keys
                 .iter()
                 .any(|schema_key| schema_key == self.schema_key()))
-            && (filter.row_pks.is_empty() || filter.row_pks.contains(&self.row_pk))
+            && filter.matches_row_pk(&self.row_pk)
             && (filter.file_ids.is_empty()
                 || filter.file_ids.iter().any(|filter| match filter {
                     NullableKeyFilter::Any => true,
@@ -11009,7 +11023,11 @@ fn hot_exact_identity_batches<'a>(
         .collect::<Vec<_>>();
     schema_keys.sort_unstable();
     schema_keys.dedup();
-    let row_pks = filter.row_pks.iter().collect::<Vec<_>>();
+    let row_pks = filter
+        .row_pks
+        .iter()
+        .filter(|row_pk| filter.matches_row_pk(row_pk))
+        .collect::<Vec<_>>();
     let file_ids = if filter.file_ids.is_empty() {
         vec![None]
     } else {
@@ -12383,19 +12401,22 @@ fn hot_file_scan_prefixes(
         || filter
             .file_ids
             .iter()
-            .any(|file_id| !matches!(file_id, NullableKeyFilter::Value(_)))
+            .any(|file_id| matches!(file_id, NullableKeyFilter::Any))
     {
         return None;
     }
     let mut prefixes = Vec::with_capacity(filter.schema_keys.len() * filter.file_ids.len());
     for schema_key in &filter.schema_keys {
         for file_id in &filter.file_ids {
-            let NullableKeyFilter::Value(file_id) = file_id else {
-                unreachable!("file-id projection predicate was checked above");
-            };
             let mut prefix = hot_scope_prefix(branch_id, generation);
             write_key_string(&mut prefix, schema_key, KEY_PART_FINAL);
-            write_file_id(&mut prefix, Some(file_id));
+            match file_id {
+                NullableKeyFilter::Null => write_file_id(&mut prefix, None),
+                NullableKeyFilter::Value(file_id) => write_file_id(&mut prefix, Some(file_id)),
+                NullableKeyFilter::Any => {
+                    unreachable!("file-id projection predicate was checked above")
+                }
+            }
             prefixes.push(prefix);
         }
     }
@@ -12415,10 +12436,9 @@ async fn scan_hot_file_entries(
     let scope = hot_scope_prefix(branch_id, generation);
     let mut rows = Vec::new();
     for prefix in prefixes {
-        let range = StoragePrefix {
-            bytes: Bytes::from(prefix),
-        }
-        .to_range()?;
+        let Some(range) = hot_file_row_pk_range(prefix, filter)? else {
+            continue;
+        };
         let mut cursor = store
             .begin_scan(ROW_SPACE, range, StorageBeginScanOptions::default())
             .await?;
@@ -12472,6 +12492,51 @@ async fn scan_hot_file_entries(
     // Physical rows are ordered `(schema, file_id, row_pk)`, while SQL rows
     // are ordered `(schema, row_pk, file_id)`.
     canonicalize_hot_scan_rows(rows, limit)
+}
+
+/// Narrows one canonical `(branch, generation, schema, file)` partition to
+/// the requested typed primary-key interval. The row-key codec is the same
+/// sole-writer codec used for point keys, so these are storage bounds over the
+/// authority itself rather than a secondary locator.
+fn hot_file_row_pk_range(
+    prefix: Vec<u8>,
+    filter: &TrackedStateFilter,
+) -> Result<Option<crate::storage_adapter::StorageKeyRange>, LixError> {
+    let mut range = StoragePrefix {
+        bytes: Bytes::copy_from_slice(&prefix),
+    }
+    .to_range()?;
+    if let Some(lower) = filter.row_pk_lower.as_ref() {
+        let mut key = prefix.clone();
+        write_row_pk(&mut key, &lower.row_pk);
+        if !lower.inclusive {
+            let Some(successor) = hot_index_key_successor(&key) else {
+                return Ok(None);
+            };
+            key = successor;
+        }
+        range.lower = std::ops::Bound::Included(StorageKey(Bytes::from(key)));
+    }
+    if let Some(upper) = filter.row_pk_upper.as_ref() {
+        let mut key = prefix;
+        write_row_pk(&mut key, &upper.row_pk);
+        if upper.inclusive {
+            let Some(successor) = hot_index_key_successor(&key) else {
+                return Ok(None);
+            };
+            key = successor;
+        }
+        range.upper = std::ops::Bound::Excluded(StorageKey(Bytes::from(key)));
+    }
+    if let (
+        std::ops::Bound::Included(lower),
+        std::ops::Bound::Excluded(upper),
+    ) = (&range.lower, &range.upper)
+        && lower >= upper
+    {
+        return Ok(None);
+    }
+    Ok(Some(range))
 }
 
 async fn hot_schema_has_file_members(

--- a/packages/lix/src/hot_state/types.rs
+++ b/packages/lix/src/hot_state/types.rs
@@ -1399,6 +1399,10 @@ pub(crate) struct HotStateFilter {
     #[serde(default)]
     pub(crate) row_pks: Vec<RowPk>,
     #[serde(default)]
+    pub(crate) row_pk_lower: Option<crate::tracked_state::RowPkRangeBound>,
+    #[serde(default)]
+    pub(crate) row_pk_upper: Option<crate::tracked_state::RowPkRangeBound>,
+    #[serde(default)]
     pub(crate) branch_ids: Vec<String>,
     #[serde(default)]
     pub(crate) file_ids: Vec<NullableKeyFilter<String>>,
@@ -1428,6 +1432,17 @@ pub(crate) struct HotStateFilter {
     pub(crate) declared_column_range: Option<Box<DeclaredColumnRange>>,
     #[serde(default)]
     pub(crate) include_tombstones: bool,
+}
+
+impl HotStateFilter {
+    pub(crate) fn matches_row_pk(&self, row_pk: &RowPk) -> bool {
+        (self.row_pks.is_empty() || self.row_pks.contains(row_pk))
+            && crate::tracked_state::row_pk_satisfies_bounds(
+                row_pk,
+                self.row_pk_lower.as_ref(),
+                self.row_pk_upper.as_ref(),
+            )
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize, Default)]

--- a/packages/lix/src/hot_state/visibility.rs
+++ b/packages/lix/src/hot_state/visibility.rs
@@ -1329,8 +1329,7 @@ mod tests {
                 .any(|branch_id| branch_id == row.branch_id.as_ref());
         let schema_matches =
             filter.schema_keys.is_empty() || filter.schema_keys.contains(&row.schema_key);
-        let row_matches =
-            filter.row_pks.is_empty() || filter.row_pks.contains(&row.row_pk);
+        let row_matches = filter.matches_row_pk(&row.row_pk);
         let file_matches = filter.file_ids.is_empty()
             || filter.file_ids.iter().any(|file_id| match file_id {
                 NullableKeyFilter::Any => true,

--- a/packages/lix/src/session/execute.rs
+++ b/packages/lix/src/session/execute.rs
@@ -5562,21 +5562,24 @@ mod tests {
             &Value::Json(serde_json::json!({"rank": 2}).into())
         );
 
-        let (profiled, profile) = session
-            .execute_profiled(
-                "SELECT id, note, payload FROM batch_route_row \
-                 WHERE id IN ($1, $2, $3, $4) \
-                   AND lixcol_file_id IS NULL ORDER BY id",
-                &params,
-            )
-            .await
-            .expect("profiled native batch route should execute");
-        assert_eq!(profiled.rows().len(), 2);
-        assert_eq!(profile.scan_rows, 2, "only returned public rows are scanned");
-        assert_eq!(
-            profile.provider_rows_examined, 3,
-            "present, missing, and duplicate slots examine three unique exact identities"
-        );
+        #[cfg(feature = "storage-benches")]
+        {
+            let (profiled, profile) = session
+                .execute_profiled(
+                    "SELECT id, note, payload FROM batch_route_row \
+                     WHERE id IN ($1, $2, $3, $4) \
+                       AND lixcol_file_id IS NULL ORDER BY id",
+                    &params,
+                )
+                .await
+                .expect("profiled native batch route should execute");
+            assert_eq!(profiled.rows().len(), 2);
+            assert_eq!(profile.scan_rows, 2, "only returned public rows are scanned");
+            assert_eq!(
+                profile.provider_rows_examined, 3,
+                "present, missing, and duplicate slots examine three unique exact identities"
+            );
+        }
     }
 
     #[tokio::test]

--- a/packages/lix/src/session/execute.rs
+++ b/packages/lix/src/session/execute.rs
@@ -87,6 +87,8 @@ pub struct ExecuteResult {
     /// empty case inline avoids one Arc clone/drop pair for every scalar write.
     backing: Option<Arc<ExecuteResultBacking>>,
     rows_affected: u64,
+    #[cfg(feature = "storage-benches")]
+    profile_provider_rows_examined: u64,
 }
 
 #[derive(Debug)]
@@ -224,6 +226,8 @@ impl ExecuteResult {
             statement_label: None,
             backing: None,
             rows_affected,
+            #[cfg(feature = "storage-benches")]
+            profile_provider_rows_examined: 0,
         }
     }
 
@@ -265,6 +269,8 @@ impl ExecuteResult {
                 file_view_mutations: Vec::new(),
             })),
             rows_affected,
+            #[cfg(feature = "storage-benches")]
+            profile_provider_rows_examined: 0,
         }
     }
 
@@ -289,6 +295,8 @@ impl ExecuteResult {
                 file_view_mutations: Vec::new(),
             })),
             rows_affected: 0,
+            #[cfg(feature = "storage-benches")]
+            profile_provider_rows_examined: 0,
         }
     }
 
@@ -816,7 +824,15 @@ where
         sql: &str,
         params: &[Value],
     ) -> Result<(ExecuteResult, crate::SqlReadProfile), LixError> {
-        let (result, profile) = crate::sql_profile::scope(self.execute(sql, params)).await;
+        let (result, mut profile) = crate::sql_profile::scope(self.execute(sql, params)).await;
+        if let Ok(result) = &result {
+            if result.profile_provider_rows_examined != 0 {
+                profile.scan_rows = profile.scan_rows.saturating_add(result.len() as u64);
+            }
+            profile.provider_rows_examined = profile
+                .provider_rows_examined
+                .saturating_add(result.profile_provider_rows_examined);
+        }
         result.map(|result| (result, profile))
     }
 
@@ -1359,12 +1375,13 @@ where
                 .await
             },
         );
-        let (mut read_result, file_view_mutations) = match read_result.await {
-            Ok(result) => result,
-            Err(error) => {
-                return Err(normalize_sql_surface_error(error, sql));
-            }
-        };
+        let (mut read_result, file_view_mutations, _provider_rows_examined) =
+            match read_result.await {
+                Ok(result) => result,
+                Err(error) => {
+                    return Err(normalize_sql_surface_error(error, sql));
+                }
+            };
         let runtime_storage_stats = match read_result.runtime_functions.take() {
             Some(runtime_functions) => {
                 self.persist_runtime_functions_if_needed(
@@ -1381,6 +1398,12 @@ where
         }
         let result = ExecuteResult::from_session_read_result(read_result)
             .with_file_view_mutations(file_view_mutations);
+        #[cfg(feature = "storage-benches")]
+        let result = {
+            let mut result = result;
+            result.profile_provider_rows_examined = _provider_rows_examined as u64;
+            result
+        };
         if !defer_file_view_acknowledgement {
             self.file_views
                 .apply_mutations(result.file_view_mutations().iter().cloned());
@@ -2310,6 +2333,7 @@ where
         (
             sql2::SessionReadSqlResult,
             Vec<sql2::SessionFileViewMutation>,
+            usize,
         ),
         LixError,
     > {
@@ -2418,6 +2442,7 @@ where
                     query: sql2::SessionReadResult::Rows(query),
                 },
                 file_view_mutations,
+                0,
             ));
         }
         if let Some(exact) = exact_schema_point_read {
@@ -2460,6 +2485,7 @@ where
                             query: sql2::SessionReadResult::Rows(query),
                         },
                         Vec::new(),
+                        1,
                     ));
                 }
             }
@@ -2542,6 +2568,7 @@ where
                 query: query.query,
             },
             file_view_mutations,
+            0,
         ))
     }
 }

--- a/packages/lix/src/session/execute.rs
+++ b/packages/lix/src/session/execute.rs
@@ -2453,13 +2453,15 @@ where
                     exact.output_columns,
                 )
                 .await?;
-                return Ok((
-                    sql2::SessionReadSqlResult {
-                        runtime_functions: None,
-                        query: sql2::SessionReadResult::Rows(query),
-                    },
-                    Vec::new(),
-                ));
+                if let Some(query) = query {
+                    return Ok((
+                        sql2::SessionReadSqlResult {
+                            runtime_functions: None,
+                            query: sql2::SessionReadResult::Rows(query),
+                        },
+                        Vec::new(),
+                    ));
+                }
             }
         }
         let hot_state: Arc<dyn crate::hot_state::HotStateReader> =

--- a/packages/lix/src/session/execute.rs
+++ b/packages/lix/src/session/execute.rs
@@ -1323,8 +1323,13 @@ where
             .is_none()
             .then(|| exact_schema_point_read_route(&statement, params))
             .flatten();
-        let late_file_content_read = (exact_filesystem_read.is_none()
+        let exact_schema_batch_read = (exact_filesystem_read.is_none()
             && exact_schema_point_read.is_none())
+            .then(|| exact_schema_batch_read_route(&statement, params))
+            .flatten();
+        let late_file_content_read = (exact_filesystem_read.is_none()
+            && exact_schema_point_read.is_none()
+            && exact_schema_batch_read.is_none())
             .then(|| late_materialized_lix_file_content_read(&statement))
             .flatten();
         let acknowledge_file_views = is_acknowledgeable_file_content_read(&statement, params)
@@ -1369,6 +1374,7 @@ where
                     acknowledge_file_views,
                     exact_filesystem_read,
                     exact_schema_point_read,
+                    exact_schema_batch_read,
                     late_file_content_read,
                     has_durable_runtime_function,
                 )
@@ -2327,6 +2333,7 @@ where
         acknowledge_file_views: bool,
         exact_filesystem_read: Option<ExactFilesystemRead>,
         exact_schema_point_read: Option<ExactSchemaPointRead>,
+        exact_schema_batch_read: Option<ExactSchemaBatchRead>,
         late_file_content_read: Option<LateMaterializedLixFileContentRead>,
         has_durable_runtime_function: bool,
     ) -> Result<
@@ -2488,6 +2495,46 @@ where
                         1,
                     ));
                 }
+            }
+        }
+        if let Some(exact) = exact_schema_batch_read {
+            let ctx = SessionSqlExecutionContext {
+                active_branch_id: &active_branch_id,
+                active_account_id: self.active_account_id(),
+                read_store: read_store.clone(),
+                hot_state: Arc::clone(&self.hot_state),
+                binary_cas: Arc::clone(&self.binary_cas),
+                branch_ctx: Arc::clone(&self.branch_ctx),
+                catalog_context: Arc::clone(&self.catalog_context),
+                sql_planning_cache: Arc::clone(&self.sql_planning_cache),
+                functions: FunctionProviderHandle::system(),
+                plugin_host: self.plugin_host.clone(),
+                file_views: None,
+            };
+            let catalog = sql2::SqlExecutionContext::public_catalog(&ctx).await?;
+            if let Some((spec, identities)) =
+                resolve_exact_schema_batch_read(catalog.as_ref(), &exact)?
+            {
+                let provider_rows_examined = identities.iter().collect::<BTreeSet<_>>().len();
+                let hot_state: Arc<dyn crate::hot_state::HotStateReader> =
+                    Arc::new(self.hot_state.reader(read_store.clone()));
+                let query = sql2::execute_exact_schema_batch_read(
+                    &spec,
+                    &active_branch_id,
+                    hot_state,
+                    identities,
+                    &exact.projected_columns,
+                    exact.output_columns,
+                )
+                .await?;
+                return Ok((
+                    sql2::SessionReadSqlResult {
+                        runtime_functions: None,
+                        query: sql2::SessionReadResult::Rows(query),
+                    },
+                    Vec::new(),
+                    provider_rows_examined,
+                ));
             }
         }
         let hot_state: Arc<dyn crate::hot_state::HotStateReader> =
@@ -3922,6 +3969,15 @@ struct ExactSchemaPointRead {
     equalities: BTreeMap<String, Value>,
 }
 
+#[derive(Debug, Clone, PartialEq)]
+struct ExactSchemaBatchRead {
+    table_name: String,
+    projected_columns: Vec<String>,
+    output_columns: Vec<String>,
+    identities: Vec<BTreeMap<String, Value>>,
+    order_by_columns: Vec<String>,
+}
+
 fn exact_schema_point_read_route(
     statement: &DataFusionStatement,
     params: &[Value],
@@ -3962,6 +4018,144 @@ fn exact_schema_point_read_route(
         output_columns,
         equalities,
     })
+}
+
+fn exact_schema_batch_read_route(
+    statement: &DataFusionStatement,
+    params: &[Value],
+) -> Option<ExactSchemaBatchRead> {
+    let simple = simple_single_table_select(statement)?;
+    if !simple.unqualified_unquoted_table
+        || simple.alias.is_some()
+        || simple.query.fetch.is_some()
+        || simple.query.limit_clause.is_some()
+    {
+        return None;
+    }
+    let mut projected_columns = Vec::with_capacity(simple.select.projection.len());
+    let mut output_columns = Vec::with_capacity(simple.select.projection.len());
+    for item in &simple.select.projection {
+        let (expression, alias) = match item {
+            SelectItem::UnnamedExpr(expression) => (expression, None),
+            SelectItem::ExprWithAlias { expr, alias } => (expr, Some(alias)),
+            _ => return None,
+        };
+        let column = exact_point_column(expression)?;
+        projected_columns.push(column.clone());
+        output_columns.push(alias.map_or(column, |alias| alias.value.clone()));
+    }
+    if projected_columns.is_empty() {
+        return None;
+    }
+    let order_by_columns = match &simple.query.order_by {
+        None => Vec::new(),
+        Some(order_by) if order_by.interpolate.is_none() => {
+            let OrderByKind::Expressions(expressions) = &order_by.kind else {
+                return None;
+            };
+            expressions
+                .iter()
+                .map(|order| {
+                    (order.with_fill.is_none()
+                        && order.options.asc != Some(false)
+                        && order.options.nulls_first.is_none())
+                    .then(|| exact_point_column(&order.expr))
+                    .flatten()
+                })
+                .collect::<Option<Vec<_>>>()?
+        }
+        Some(_) => return None,
+    };
+    let identities = collect_exact_schema_identity_rows(
+        simple.select.selection.as_ref()?,
+        params,
+    )?;
+    (identities.len() > 1).then_some(ExactSchemaBatchRead {
+        table_name: simple.table_name,
+        projected_columns,
+        output_columns,
+        identities,
+        order_by_columns,
+    })
+}
+
+fn collect_exact_schema_identity_rows(
+    expression: &Expr,
+    params: &[Value],
+) -> Option<Vec<BTreeMap<String, Value>>> {
+    match expression {
+        Expr::Nested(expression) => collect_exact_schema_identity_rows(expression, params),
+        Expr::BinaryOp {
+            left,
+            op: BinaryOperator::Or,
+            right,
+        } => {
+            let mut rows = collect_exact_schema_identity_rows(left, params)?;
+            rows.extend(collect_exact_schema_identity_rows(right, params)?);
+            Some(rows)
+        }
+        Expr::BinaryOp {
+            left,
+            op: BinaryOperator::And,
+            right,
+        } => {
+            let left = collect_exact_schema_identity_rows(left, params)?;
+            let right = collect_exact_schema_identity_rows(right, params)?;
+            (left.len().checked_mul(right.len())? <= 4096).then_some(())?;
+            let mut rows = Vec::with_capacity(left.len() * right.len());
+            for left in left {
+                for right in &right {
+                    let mut combined = left.clone();
+                    let mut compatible = true;
+                    for (column, value) in right {
+                        if combined
+                            .insert(column.clone(), value.clone())
+                            .is_some_and(|existing| existing != *value)
+                        {
+                            compatible = false;
+                            break;
+                        }
+                    }
+                    if compatible {
+                        rows.push(combined);
+                    }
+                }
+            }
+            Some(rows)
+        }
+        Expr::BinaryOp {
+            left,
+            op: BinaryOperator::Eq,
+            right,
+        } => {
+            let (column, value) = match (exact_point_column(left), exact_point_column(right)) {
+                (Some(column), None) => (column, exact_schema_literal(right, params)?),
+                (None, Some(column)) => (column, exact_schema_literal(left, params)?),
+                _ => return None,
+            };
+            Some(vec![BTreeMap::from([(column, value)])])
+        }
+        Expr::InList {
+            expr,
+            list,
+            negated: false,
+        } if !list.is_empty() => {
+            let column = exact_point_column(expr)?;
+            list.iter()
+                .map(|value| {
+                    Some(BTreeMap::from([(
+                        column.clone(),
+                        exact_schema_literal(value, params)?,
+                    )]))
+                })
+                .collect()
+        }
+        Expr::IsNull(expression) => {
+            let column = exact_point_column(expression)?;
+            Some(vec![BTreeMap::from([(column, Value::Null)])])
+        }
+        _ => None,
+    }
 }
 
 fn collect_exact_schema_equalities(
@@ -4078,6 +4272,114 @@ fn resolve_exact_schema_point_read(
         return Ok(None);
     };
     Ok(Some((spec, row_pk)))
+}
+
+fn resolve_exact_schema_batch_read(
+    catalog: &sql2::PublicCatalog,
+    exact: &ExactSchemaBatchRead,
+) -> Result<
+    Option<(
+        sql2::SchemaSurfaceSpec,
+        Vec<(crate::row_pk::RowPk, Option<String>)>,
+    )>,
+    LixError,
+> {
+    let Some(surface) = catalog.surface(&exact.table_name) else {
+        return Ok(None);
+    };
+    let sql2::PublicSurfaceKind::SchemaBase { schema_key } = &surface.kind else {
+        return Ok(None);
+    };
+    let spec = catalog.schema_spec(schema_key).cloned().ok_or_else(|| {
+        LixError::new(
+            LixError::CODE_INTERNAL_ERROR,
+            "exact schema batch route is missing schema metadata",
+        )
+    })?;
+    if exact
+        .projected_columns
+        .iter()
+        .any(|column| spec.visible_column(column).is_none())
+    {
+        return Ok(None);
+    }
+    let primary_key_columns = spec
+        .primary_key_paths
+        .iter()
+        .map(|path| match path.as_slice() {
+            [column] => Some(column.as_str()),
+            _ => None,
+        })
+        .collect::<Option<Vec<_>>>()
+        .ok_or_else(|| {
+            LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                "exact schema batch route requires top-level primary-key columns",
+            )
+        })?;
+    if !exact.order_by_columns.is_empty()
+        && exact.order_by_columns
+            != primary_key_columns
+                .iter()
+                .map(|column| (*column).to_owned())
+                .collect::<Vec<_>>()
+    {
+        return Ok(None);
+    }
+    let mut seen = BTreeSet::new();
+    let mut identities = Vec::with_capacity(exact.identities.len());
+    for identity in &exact.identities {
+        if identity.len() != primary_key_columns.len() + 1
+            || identity
+                .keys()
+                .any(|column| {
+                    column != "lixcol_file_id"
+                        && !primary_key_columns.contains(&column.as_str())
+                })
+        {
+            return Ok(None);
+        }
+        let file_id = match identity.get("lixcol_file_id") {
+            Some(Value::Null) => None,
+            Some(Value::Text(file_id)) => Some(file_id.clone()),
+            _ => return Ok(None),
+        };
+        let parts = primary_key_columns
+            .iter()
+            .zip(&spec.primary_key_component_types)
+            .map(|(column, component_type)| {
+                let value = identity.get(*column)?;
+                match (component_type, value) {
+                    (
+                        crate::row_pk::RowPkComponentType::Uuid
+                        | crate::row_pk::RowPkComponentType::String
+                        | crate::row_pk::RowPkComponentType::Bytes,
+                        Value::Text(value),
+                    ) => Some(value.clone()),
+                    (crate::row_pk::RowPkComponentType::Integer, Value::Integer(value)) => {
+                        Some(value.to_string())
+                    }
+                    _ => None,
+                }
+            })
+            .collect::<Option<Vec<_>>>();
+        let Some(parts) = parts else {
+            return Ok(None);
+        };
+        let Ok(row_pk) = crate::row_pk::RowPk::from_external_parts(
+            parts,
+            &spec.primary_key_component_types,
+        ) else {
+            return Ok(None);
+        };
+        if seen.insert((row_pk.clone(), file_id.clone())) {
+            identities.push((row_pk, file_id));
+        }
+    }
+    if !exact.order_by_columns.is_empty() {
+        identities.sort_unstable();
+    }
+    Ok(Some((spec, identities)))
 }
 
 fn exact_filesystem_read_route(
@@ -5168,6 +5470,113 @@ mod tests {
                 "unexpected fast-path match for {sql}"
             );
         }
+    }
+
+    #[test]
+    fn exact_schema_batch_route_preserves_composite_identity_expansion() {
+        let statement = sql2::parse_statement(
+            "SELECT tenant, revision, payload FROM batch_route_row \
+             WHERE tenant = $1 AND revision IN ($2, $3, $2) \
+               AND lixcol_file_id IS NULL \
+             ORDER BY tenant, revision",
+        )
+        .expect("batch route SQL should parse");
+        let route = exact_schema_batch_read_route(
+            &statement,
+            &[
+                Value::Text("docs".to_owned()),
+                Value::Integer(7),
+                Value::Integer(9),
+            ],
+        )
+        .expect("complete composite identities should route");
+        assert_eq!(route.identities.len(), 3, "request slots stay aligned");
+        assert_eq!(route.order_by_columns, ["tenant", "revision"]);
+        assert_eq!(route.identities[0]["tenant"], Value::Text("docs".to_owned()));
+        assert_eq!(route.identities[0]["revision"], Value::Integer(7));
+        assert_eq!(route.identities[0]["lixcol_file_id"], Value::Null);
+        assert_eq!(route.identities[1]["revision"], Value::Integer(9));
+        assert_eq!(route.identities[2]["revision"], Value::Integer(7));
+    }
+
+    #[tokio::test]
+    async fn exact_schema_batch_matches_relational_duplicate_missing_null_and_jsonb_semantics() {
+        let session = open_session().await;
+        let schema = serde_json::json!({
+            "$schema": "https://lix.dev/schema-v1.json",
+            "key": "batch_route_row",
+            "columns": [
+                { "name": "id", "type": "text", "nullable": false },
+                { "name": "note", "type": "text", "nullable": true },
+                { "name": "payload", "type": "jsonb", "nullable": false }
+            ],
+            "primary_key": ["id"]
+        });
+        session
+            .execute(
+                "INSERT INTO lix_registered_schema (schema_key, value) \
+                 VALUES ('batch_route_row', CAST($1 AS JSONB))",
+                &[Value::Text(schema.to_string())],
+            )
+            .await
+            .expect("register batch-route schema");
+        session
+            .execute(
+                "INSERT INTO batch_route_row (id, note, payload) VALUES \
+                 ('a', NULL, CAST('{\"rank\":1}' AS JSONB)), \
+                 ('b', 'present', CAST('{\"rank\":2}' AS JSONB))",
+                &[],
+            )
+            .await
+            .expect("seed batch-route rows");
+
+        let params = [
+            Value::Text("b".to_owned()),
+            Value::Text("missing".to_owned()),
+            Value::Text("a".to_owned()),
+            Value::Text("b".to_owned()),
+        ];
+        let exact = session
+            .execute(
+                "SELECT id, note, payload FROM batch_route_row \
+                 WHERE id IN ($1, $2, $3, $4) \
+                   AND lixcol_file_id IS NULL ORDER BY id",
+                &params,
+            )
+            .await
+            .expect("native batch route should execute");
+        let relational = session
+            .execute(
+                "SELECT row.id, row.note, row.payload FROM batch_route_row AS row \
+                 WHERE row.id IN ($1, $2, $3, $4) \
+                   AND row.lixcol_file_id IS NULL ORDER BY row.id",
+                &params,
+            )
+            .await
+            .expect("relational control should execute");
+        assert_eq!(exact, relational);
+        assert_eq!(exact.rows().len(), 2, "duplicates and misses emit no extra rows");
+        assert_eq!(exact.rows()[0].value("note").expect("note column"), &Value::Null);
+        assert_eq!(
+            exact.rows()[1].value("payload").expect("payload column"),
+            &Value::Json(serde_json::json!({"rank": 2}).into())
+        );
+
+        let (profiled, profile) = session
+            .execute_profiled(
+                "SELECT id, note, payload FROM batch_route_row \
+                 WHERE id IN ($1, $2, $3, $4) \
+                   AND lixcol_file_id IS NULL ORDER BY id",
+                &params,
+            )
+            .await
+            .expect("profiled native batch route should execute");
+        assert_eq!(profiled.rows().len(), 2);
+        assert_eq!(profile.scan_rows, 2, "only returned public rows are scanned");
+        assert_eq!(
+            profile.provider_rows_examined, 3,
+            "present, missing, and duplicate slots examine three unique exact identities"
+        );
     }
 
     #[tokio::test]

--- a/packages/lix/src/session/execute.rs
+++ b/packages/lix/src/session/execute.rs
@@ -1303,8 +1303,12 @@ where
         }
 
         let exact_filesystem_read = exact_filesystem_read_route(&statement, params);
-        let late_file_content_read = exact_filesystem_read
+        let exact_schema_point_read = exact_filesystem_read
             .is_none()
+            .then(|| exact_schema_point_read_route(&statement, params))
+            .flatten();
+        let late_file_content_read = (exact_filesystem_read.is_none()
+            && exact_schema_point_read.is_none())
             .then(|| late_materialized_lix_file_content_read(&statement))
             .flatten();
         let acknowledge_file_views = is_acknowledgeable_file_content_read(&statement, params)
@@ -1348,6 +1352,7 @@ where
                     params,
                     acknowledge_file_views,
                     exact_filesystem_read,
+                    exact_schema_point_read,
                     late_file_content_read,
                     has_durable_runtime_function,
                 )
@@ -2298,6 +2303,7 @@ where
         params: &[Value],
         acknowledge_file_views: bool,
         exact_filesystem_read: Option<ExactFilesystemRead>,
+        exact_schema_point_read: Option<ExactSchemaPointRead>,
         late_file_content_read: Option<LateMaterializedLixFileContentRead>,
         has_durable_runtime_function: bool,
     ) -> Result<
@@ -2413,6 +2419,48 @@ where
                 },
                 file_view_mutations,
             ));
+        }
+        if let Some(exact) = exact_schema_point_read {
+            let ctx = SessionSqlExecutionContext {
+                active_branch_id: &active_branch_id,
+                active_account_id: self.active_account_id(),
+                read_store: read_store.clone(),
+                hot_state: Arc::clone(&self.hot_state),
+                binary_cas: Arc::clone(&self.binary_cas),
+                branch_ctx: Arc::clone(&self.branch_ctx),
+                catalog_context: Arc::clone(&self.catalog_context),
+                sql_planning_cache: Arc::clone(&self.sql_planning_cache),
+                functions: FunctionProviderHandle::system(),
+                plugin_host: self.plugin_host.clone(),
+                file_views: None,
+            };
+            let catalog = sql2::SqlExecutionContext::public_catalog(&ctx).await?;
+            if let Some((spec, row_pk)) =
+                resolve_exact_schema_point_read(catalog.as_ref(), &exact)?
+            {
+                let reader: Arc<dyn sql2::RowSnapshotReader> = Arc::new(
+                    sql2::CurrentRowSnapshotReader::new(
+                        Arc::clone(&self.hot_state),
+                        read_store.clone(),
+                    ),
+                );
+                let query = sql2::execute_exact_schema_point_read(
+                    &spec,
+                    &active_branch_id,
+                    reader,
+                    row_pk,
+                    &exact.projected_columns,
+                    exact.output_columns,
+                )
+                .await?;
+                return Ok((
+                    sql2::SessionReadSqlResult {
+                        runtime_functions: None,
+                        query: sql2::SessionReadResult::Rows(query),
+                    },
+                    Vec::new(),
+                ));
+            }
         }
         let hot_state: Arc<dyn crate::hot_state::HotStateReader> =
             Arc::new(self.hot_state.reader(read_store.clone()));
@@ -3837,6 +3885,172 @@ enum ExactFilesystemRead {
     IdManifestBatch(BTreeSet<String>),
 }
 
+#[derive(Debug, Clone, PartialEq)]
+struct ExactSchemaPointRead {
+    table_name: String,
+    projected_columns: Vec<String>,
+    output_columns: Vec<String>,
+    equalities: BTreeMap<String, Value>,
+}
+
+fn exact_schema_point_read_route(
+    statement: &DataFusionStatement,
+    params: &[Value],
+) -> Option<ExactSchemaPointRead> {
+    let simple = simple_single_table_select(statement)?;
+    if !simple.unqualified_unquoted_table
+        || simple.alias.is_some()
+        || simple.query.order_by.is_some()
+        || simple.query.fetch.is_some()
+        || !point_read_limit_is_safe(simple.query.limit_clause.as_ref())
+    {
+        return None;
+    }
+    let mut projected_columns = Vec::with_capacity(simple.select.projection.len());
+    let mut output_columns = Vec::with_capacity(simple.select.projection.len());
+    for item in &simple.select.projection {
+        let (expression, alias) = match item {
+            SelectItem::UnnamedExpr(expression) => (expression, None),
+            SelectItem::ExprWithAlias { expr, alias } => (expr, Some(alias)),
+            _ => return None,
+        };
+        let column = exact_point_column(expression)?;
+        projected_columns.push(column.clone());
+        output_columns.push(alias.map_or(column, |alias| alias.value.clone()));
+    }
+    if projected_columns.is_empty() {
+        return None;
+    }
+    let mut equalities = BTreeMap::new();
+    collect_exact_schema_equalities(
+        simple.select.selection.as_ref()?,
+        params,
+        &mut equalities,
+    )?;
+    Some(ExactSchemaPointRead {
+        table_name: simple.table_name,
+        projected_columns,
+        output_columns,
+        equalities,
+    })
+}
+
+fn collect_exact_schema_equalities(
+    expression: &Expr,
+    params: &[Value],
+    equalities: &mut BTreeMap<String, Value>,
+) -> Option<()> {
+    match expression {
+        Expr::Nested(expression) => collect_exact_schema_equalities(expression, params, equalities),
+        Expr::BinaryOp { left, op: BinaryOperator::And, right } => {
+            collect_exact_schema_equalities(left, params, equalities)?;
+            collect_exact_schema_equalities(right, params, equalities)
+        }
+        Expr::BinaryOp { left, op: BinaryOperator::Eq, right } => {
+            let (column, value) = match (exact_point_column(left), exact_point_column(right)) {
+                (Some(column), None) => (column, exact_schema_literal(right, params)?),
+                (None, Some(column)) => (column, exact_schema_literal(left, params)?),
+                _ => return None,
+            };
+            equalities.insert(column, value).is_none().then_some(())
+        }
+        _ => None,
+    }
+}
+
+fn exact_schema_literal(expression: &Expr, params: &[Value]) -> Option<Value> {
+    let Expr::Value(value) = expression else {
+        return None;
+    };
+    match &value.value {
+        SqlValue::Placeholder(placeholder) => placeholder
+            .strip_prefix('$')
+            .and_then(|index| index.parse::<usize>().ok())
+            .and_then(|index| index.checked_sub(1))
+            .and_then(|index| params.get(index))
+            .cloned(),
+        SqlValue::SingleQuotedString(value) => Some(Value::Text(value.clone())),
+        SqlValue::Number(value, _) => value.parse::<i64>().ok().map(Value::Integer),
+        _ => None,
+    }
+}
+
+fn resolve_exact_schema_point_read(
+    catalog: &sql2::PublicCatalog,
+    exact: &ExactSchemaPointRead,
+) -> Result<Option<(sql2::SchemaSurfaceSpec, crate::row_pk::RowPk)>, LixError> {
+    let Some(surface) = catalog.surface(&exact.table_name) else {
+        return Ok(None);
+    };
+    let sql2::PublicSurfaceKind::SchemaBase { schema_key } = &surface.kind else {
+        return Ok(None);
+    };
+    let spec = catalog.schema_spec(schema_key).cloned().ok_or_else(|| {
+        LixError::new(
+            LixError::CODE_INTERNAL_ERROR,
+            "exact schema point route is missing schema metadata",
+        )
+    })?;
+    if exact
+        .projected_columns
+        .iter()
+        .any(|column| spec.visible_column(column).is_none())
+    {
+        return Ok(None);
+    }
+    let primary_key_columns = spec
+        .primary_key_paths
+        .iter()
+        .map(|path| match path.as_slice() {
+            [column] => Some(column.as_str()),
+            _ => None,
+        })
+        .collect::<Option<Vec<_>>>()
+        .ok_or_else(|| {
+            LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                "exact schema point route requires top-level primary-key columns",
+            )
+        })?;
+    if exact.equalities.len() != primary_key_columns.len()
+        || exact
+            .equalities
+            .keys()
+            .any(|column| !primary_key_columns.contains(&column.as_str()))
+    {
+        return Ok(None);
+    }
+    let parts = primary_key_columns
+        .iter()
+        .zip(&spec.primary_key_component_types)
+        .map(|(column, component_type)| {
+            let value = exact.equalities.get(*column)?;
+            match (component_type, value) {
+                (
+                    crate::row_pk::RowPkComponentType::Uuid
+                    | crate::row_pk::RowPkComponentType::String
+                    | crate::row_pk::RowPkComponentType::Bytes,
+                    Value::Text(value),
+                ) => Some(value.clone()),
+                (crate::row_pk::RowPkComponentType::Integer, Value::Integer(value)) => {
+                    Some(value.to_string())
+                }
+                _ => None,
+            }
+        })
+        .collect::<Option<Vec<_>>>();
+    let Some(parts) = parts else {
+        return Ok(None);
+    };
+    let Ok(row_pk) = crate::row_pk::RowPk::from_external_parts(
+        parts,
+        &spec.primary_key_component_types,
+    ) else {
+        return Ok(None);
+    };
+    Ok(Some((spec, row_pk)))
+}
+
 fn exact_filesystem_read_route(
     statement: &DataFusionStatement,
     params: &[Value],
@@ -4516,6 +4730,64 @@ mod tests {
             .await
             .expect("initialized storage should create engine");
         engine.open_session().await.expect("session should open")
+    }
+
+    #[tokio::test]
+    async fn exact_registered_schema_point_preserves_typed_public_projection() {
+        let session = open_session().await;
+        let schema = serde_json::json!({
+            "$schema": "https://lix.dev/schema-v1.json",
+            "key": "native_point_probe",
+            "columns": [
+                { "name": "id", "type": "text", "nullable": false },
+                { "name": "payload", "type": "jsonb", "nullable": true },
+                { "name": "optional", "type": "text", "nullable": true }
+            ],
+            "primary_key": ["id"]
+        });
+        session
+            .execute(
+                "INSERT INTO lix_registered_schema (schema_key, value) VALUES (CAST($1 AS JSONB) ->> 'key', CAST($1 AS JSONB))",
+                &[Value::Text(schema.to_string())],
+            )
+            .await
+            .unwrap();
+        session
+            .execute(
+                "INSERT INTO native_point_probe (id, payload, optional) VALUES ($1, CAST($2 AS JSONB), NULL)",
+                &[
+                    Value::Text("row-a".into()),
+                    Value::Text(r#"{"nested":[true,null],"count":7}"#.into()),
+                ],
+            )
+            .await
+            .unwrap();
+
+        let native = session
+            .execute(
+                "SELECT payload AS body, optional FROM native_point_probe WHERE id = $1 LIMIT 1",
+                &[Value::Text("row-a".into())],
+            )
+            .await
+            .unwrap();
+        let planned = session
+            .execute(
+                "SELECT payload AS body, optional FROM native_point_probe WHERE id = CAST($1 AS TEXT) LIMIT 1",
+                &[Value::Text("row-a".into())],
+            )
+            .await
+            .unwrap();
+        assert_eq!(native.columns(), &["body", "optional"]);
+        assert_eq!(native, planned);
+
+        let missing = session
+            .execute(
+                "SELECT payload FROM native_point_probe WHERE id = $1 LIMIT 1",
+                &[Value::Text("missing".into())],
+            )
+            .await
+            .unwrap();
+        assert!(missing.is_empty());
     }
 
     async fn assert_columnar_lifecycle_current(

--- a/packages/lix/src/sql2/exec/datafusion.rs
+++ b/packages/lix/src/sql2/exec/datafusion.rs
@@ -4363,8 +4363,7 @@ mod tests {
             .filter(|row| {
                 (request.filter.schema_keys.is_empty()
                     || request.filter.schema_keys.contains(&row.schema_key))
-                    && (request.filter.row_pks.is_empty()
-                        || request.filter.row_pks.contains(&row.row_pk))
+                    && request.filter.matches_row_pk(&row.row_pk)
                     && (request.filter.branch_ids.is_empty()
                         || request
                             .filter

--- a/packages/lix/src/sql2/history_route.rs
+++ b/packages/lix/src/sql2/history_route.rs
@@ -459,6 +459,8 @@ where
                     .cloned()
                     .map(NullableKeyFilter::Value)
                     .collect(),
+                row_pk_lower: None,
+                row_pk_upper: None,
                 include_tombstones: true,
             },
             read_columns: TrackedStateReadColumns {

--- a/packages/lix/src/sql2/mod.rs
+++ b/packages/lix/src/sql2/mod.rs
@@ -41,7 +41,7 @@ pub(crate) use bind::{
     statement_has_durable_runtime_function,
 };
 pub(crate) use catalog::{
-    SchemaColumnType, SchemaIndexedColumn, SchemaSurfaceSpec, PublicCatalog,
+    PublicSurfaceKind, SchemaColumnType, SchemaIndexedColumn, SchemaSurfaceSpec, PublicCatalog,
     derive_schema_surface_spec_from_schema, row_visible_fields,
 };
 pub(crate) use change_materialization::MaterializedChange;
@@ -105,7 +105,8 @@ pub(crate) use providers::{
     ExactLixFileReadColumn, ExactLixFileReadSelector, FastLixFilePathWriteConflict,
     execute_exact_lix_directory_root_listing, execute_exact_lix_file_batch_read,
     execute_exact_lix_file_id_manifest_batch_read, execute_exact_lix_file_read,
-    execute_exact_lix_file_root_listing, execute_fast_lix_file_path_writes,
+    execute_exact_lix_file_root_listing, execute_exact_schema_point_read,
+    execute_fast_lix_file_path_writes,
     execute_fast_lix_file_prepared_path_write,
 };
 pub use script::{SqlScriptPlan, SqlScriptStatement, parse_sql_script};

--- a/packages/lix/src/sql2/mod.rs
+++ b/packages/lix/src/sql2/mod.rs
@@ -105,7 +105,8 @@ pub(crate) use providers::{
     ExactLixFileReadColumn, ExactLixFileReadSelector, FastLixFilePathWriteConflict,
     execute_exact_lix_directory_root_listing, execute_exact_lix_file_batch_read,
     execute_exact_lix_file_id_manifest_batch_read, execute_exact_lix_file_read,
-    execute_exact_lix_file_root_listing, execute_exact_schema_point_read,
+    execute_exact_lix_file_root_listing, execute_exact_schema_batch_read,
+    execute_exact_schema_point_read,
     execute_fast_lix_file_path_writes,
     execute_fast_lix_file_prepared_path_write,
 };

--- a/packages/lix/src/sql2/providers/diff.rs
+++ b/packages/lix/src/sql2/providers/diff.rs
@@ -217,6 +217,8 @@ impl DiffRoute {
                         .into_iter()
                         .map(NullableKeyFilter::Value)
                         .collect(),
+                    row_pk_lower: None,
+                    row_pk_upper: None,
                     include_tombstones: true,
                 },
                 retain_payloads: false,

--- a/packages/lix/src/sql2/providers/file_history.rs
+++ b/packages/lix/src/sql2/providers/file_history.rs
@@ -1358,6 +1358,8 @@ where
                         .collect()
                 })
                 .unwrap_or_default(),
+            row_pk_lower: None,
+            row_pk_upper: None,
             include_tombstones: true,
         },
     )
@@ -1395,6 +1397,8 @@ where
             ],
             row_pks,
             file_ids: file_ids.clone(),
+            row_pk_lower: None,
+            row_pk_upper: None,
             include_tombstones: true,
         },
     )
@@ -1460,6 +1464,8 @@ where
                     })
                     .collect::<Result<Vec<_>, _>>()?,
                 file_ids: file_ids.clone(),
+                row_pk_lower: None,
+                row_pk_upper: None,
                 include_tombstones: true,
             },
         )
@@ -1514,6 +1520,8 @@ where
                     schema_keys: vec![KEY_VALUE_SCHEMA_KEY.to_string()],
                     row_pks: vec![RowPk::single(PLUGIN_REGISTRY_KEY)],
                     file_ids: vec![NullableKeyFilter::Null],
+                    row_pk_lower: None,
+                    row_pk_upper: None,
                     include_tombstones: true,
                 },
                 read_columns: TrackedStateReadColumns {

--- a/packages/lix/src/sql2/providers/mod.rs
+++ b/packages/lix/src/sql2/providers/mod.rs
@@ -39,7 +39,7 @@ use datafusion::datasource::DefaultTableSource;
 use datafusion::logical_expr::TableSource;
 
 pub(crate) use directory::execute_exact_lix_directory_root_listing;
-pub(crate) use schema::execute_exact_schema_point_read;
+pub(crate) use schema::{execute_exact_schema_batch_read, execute_exact_schema_point_read};
 pub(crate) use file::{
     ExactLixFileReadColumn, ExactLixFileReadSelector, FastLixFilePathWriteConflict,
     execute_exact_lix_file_batch_read, execute_exact_lix_file_id_manifest_batch_read,

--- a/packages/lix/src/sql2/providers/mod.rs
+++ b/packages/lix/src/sql2/providers/mod.rs
@@ -39,6 +39,7 @@ use datafusion::datasource::DefaultTableSource;
 use datafusion::logical_expr::TableSource;
 
 pub(crate) use directory::execute_exact_lix_directory_root_listing;
+pub(crate) use schema::execute_exact_schema_point_read;
 pub(crate) use file::{
     ExactLixFileReadColumn, ExactLixFileReadSelector, FastLixFilePathWriteConflict,
     execute_exact_lix_file_batch_read, execute_exact_lix_file_id_manifest_batch_read,

--- a/packages/lix/src/sql2/providers/schema.rs
+++ b/packages/lix/src/sql2/providers/schema.rs
@@ -80,7 +80,7 @@ pub(crate) async fn execute_exact_schema_point_read(
     row_pk: RowPk,
     projected_columns: &[String],
     output_columns: Vec<String>,
-) -> Result<crate::SqlQueryResult, LixError> {
+) -> Result<Option<crate::SqlQueryResult>, LixError> {
     let mut request = row_hot_state_scan_request(
         &spec.schema_key,
         Some(active_branch_id),
@@ -89,12 +89,9 @@ pub(crate) async fn execute_exact_schema_point_read(
         true,
     );
     request.filter.row_pks = vec![row_pk];
-    let snapshots = reader.scan_row_snapshots(request).await?.ok_or_else(|| {
-        LixError::new(
-            LixError::CODE_INTERNAL_ERROR,
-            "exact schema point route lost its retained snapshot capability",
-        )
-    })?;
+    let Some(snapshots) = reader.scan_row_snapshots(request).await? else {
+        return Ok(None);
+    };
     if snapshots.len() > 1 {
         return Err(LixError::new(
             LixError::CODE_INTERNAL_ERROR,
@@ -110,11 +107,11 @@ pub(crate) async fn execute_exact_schema_point_read(
         .transpose()?
         .into_iter()
         .collect();
-    Ok(crate::SqlQueryResult {
+    Ok(Some(crate::SqlQueryResult {
         rows,
         columns: output_columns,
         notices: Vec::new(),
-    })
+    }))
 }
 
 pub(crate) async fn register_row_providers<S>(

--- a/packages/lix/src/sql2/providers/schema.rs
+++ b/packages/lix/src/sql2/providers/schema.rs
@@ -419,6 +419,14 @@ impl SchemaSpec {
         apply_exact_branch_id_filter(&mut request, exact_branch_ids);
         apply_exact_row_pk_filters(&mut request, &self.spec, filters)?;
         apply_exact_file_id_filter(&mut request, exact_file_ids_from_filters(filters)?);
+        if request.filter.row_pks.is_empty()
+            && request.filter.file_ids.len() == 1
+            && !matches!(request.filter.file_ids[0], crate::NullableKeyFilter::Any)
+            && let Some((lower, upper)) = primary_key_range(&self.spec, &row_filters)
+        {
+            request.filter.row_pk_lower = lower;
+            request.filter.row_pk_upper = upper;
+        }
         request.filter.declared_column_eq = declared_column_eq(&self.spec, &row_filters);
         request.filter.declared_column_range = declared_column_range(&self.spec, &row_filters);
         Ok((projected_schema, request, row_filters))
@@ -2108,6 +2116,165 @@ fn apply_exact_row_pk_filters(
     Ok(())
 }
 
+fn primary_key_range(
+    spec: &SchemaSurfaceSpec,
+    row_filters: &[RowFilter],
+) -> Option<(
+    Option<crate::tracked_state::RowPkRangeBound>,
+    Option<crate::tracked_state::RowPkRangeBound>,
+)> {
+    let primary_key_columns = top_level_primary_key_columns(spec);
+    if primary_key_columns.is_empty() {
+        return None;
+    }
+    let mut equalities = BTreeMap::<String, RowFilterValue>::new();
+    let mut ranges = Vec::<(String, RowRangeOp, RowFilterValue)>::new();
+    for filter in row_filters {
+        if !collect_primary_key_range_terms(
+            filter,
+            &primary_key_columns,
+            &mut equalities,
+            &mut ranges,
+        ) {
+            return None;
+        }
+    }
+    let range_column_index = ranges
+        .iter()
+        .map(|(column, _, _)| primary_key_columns.iter().position(|pk| *pk == column))
+        .collect::<Option<BTreeSet<_>>>()?;
+    if range_column_index.len() != 1 {
+        return None;
+    }
+    let range_column_index = *range_column_index.iter().next()?;
+    if range_column_index + 1 != primary_key_columns.len() {
+        return None;
+    }
+    let prefix = primary_key_columns[..range_column_index]
+        .iter()
+        .map(|column| {
+            primary_key_filter_external_value(
+                equalities.get(*column)?,
+                spec.primary_key_component_types[primary_key_columns
+                    .iter()
+                    .position(|candidate| candidate == column)?],
+            )
+        })
+        .collect::<Option<Vec<_>>>()?;
+
+    let mut lower: Option<crate::tracked_state::RowPkRangeBound> = None;
+    let mut upper: Option<crate::tracked_state::RowPkRangeBound> = None;
+    for (_, op, value) in ranges {
+        let mut parts = prefix.clone();
+        parts.push(primary_key_filter_external_value(
+            &value,
+            spec.primary_key_component_types[range_column_index],
+        )?);
+        let row_pk = RowPk::from_external_parts(parts, &spec.primary_key_component_types).ok()?;
+        let (target, inclusive, lower_side) = match op {
+            RowRangeOp::Gt => (&mut lower, false, true),
+            RowRangeOp::GtEq => (&mut lower, true, true),
+            RowRangeOp::Lt => (&mut upper, false, false),
+            RowRangeOp::LtEq => (&mut upper, true, false),
+        };
+        let candidate = crate::tracked_state::RowPkRangeBound { row_pk, inclusive };
+        let replace = target.as_ref().is_none_or(|existing| {
+            if lower_side {
+                candidate.row_pk > existing.row_pk
+                    || (candidate.row_pk == existing.row_pk
+                        && !candidate.inclusive
+                        && existing.inclusive)
+            } else {
+                candidate.row_pk < existing.row_pk
+                    || (candidate.row_pk == existing.row_pk
+                        && !candidate.inclusive
+                        && existing.inclusive)
+            }
+        });
+        if replace {
+            *target = Some(candidate);
+        }
+    }
+    if primary_key_columns.len() > 1 && (lower.is_none() || upper.is_none()) {
+        return None;
+    }
+    (lower.is_some() || upper.is_some()).then_some((lower, upper))
+}
+
+fn collect_primary_key_range_terms(
+    filter: &RowFilter,
+    primary_key_columns: &[&str],
+    equalities: &mut BTreeMap<String, RowFilterValue>,
+    ranges: &mut Vec<(String, RowRangeOp, RowFilterValue)>,
+) -> bool {
+    match filter {
+        RowFilter::And(left, right) => {
+            collect_primary_key_range_terms(left, primary_key_columns, equalities, ranges)
+                && collect_primary_key_range_terms(right, primary_key_columns, equalities, ranges)
+        }
+        RowFilter::ColumnEq { column, value, .. }
+            if primary_key_columns.contains(&column.as_str()) =>
+        {
+            equalities
+                .insert(column.clone(), value.clone())
+                .is_none_or(|previous| previous == *value)
+        }
+        RowFilter::ColumnIn { column, values, .. }
+            if primary_key_columns.contains(&column.as_str()) =>
+        {
+            let [value] = values.as_slice() else {
+                return false;
+            };
+            equalities
+                .insert(column.clone(), value.clone())
+                .is_none_or(|previous| previous == *value)
+        }
+        RowFilter::ColumnRange {
+            column, op, value, ..
+        } if primary_key_columns.contains(&column.as_str()) => {
+            ranges.push((column.clone(), *op, value.clone()));
+            true
+        }
+        RowFilter::Or(left, right) => {
+            !row_filter_mentions_primary_key(left, primary_key_columns)
+                && !row_filter_mentions_primary_key(right, primary_key_columns)
+        }
+        _ => true,
+    }
+}
+
+fn row_filter_mentions_primary_key(filter: &RowFilter, primary_key_columns: &[&str]) -> bool {
+    match filter {
+        RowFilter::ColumnEq { column, .. }
+        | RowFilter::ColumnIn { column, .. }
+        | RowFilter::ColumnRange { column, .. } => {
+            primary_key_columns.contains(&column.as_str())
+        }
+        RowFilter::And(left, right) | RowFilter::Or(left, right) => {
+            row_filter_mentions_primary_key(left, primary_key_columns)
+                || row_filter_mentions_primary_key(right, primary_key_columns)
+        }
+    }
+}
+
+fn primary_key_filter_external_value(
+    value: &RowFilterValue,
+    component_type: crate::row_pk::RowPkComponentType,
+) -> Option<String> {
+    match (component_type, value) {
+        (crate::row_pk::RowPkComponentType::Integer, RowFilterValue::Integer(value)) => {
+            Some(value.to_string())
+        }
+        (
+            crate::row_pk::RowPkComponentType::String
+            | crate::row_pk::RowPkComponentType::Uuid
+            | crate::row_pk::RowPkComponentType::Bytes,
+            RowFilterValue::String(value),
+        ) => Some(value.clone()),
+        _ => None,
+    }
+}
+
 fn exact_branch_ids_from_filters(filters: &[Expr]) -> Result<Option<Vec<String>>> {
     let analyzer = ExactBranchIdFilterAnalyzer;
     let mut branch_ids: Option<BTreeSet<String>> = None;
@@ -2147,9 +2314,9 @@ fn apply_exact_branch_id_filter(
 /// so the merged answer stays complete. Without this analyzer the predicate
 /// only ever survived as a DataFusion residual and every file-scoped read paid
 /// O(rows in the branch).
-fn exact_file_ids_from_filters(filters: &[Expr]) -> Result<Option<Vec<String>>> {
+fn exact_file_ids_from_filters(filters: &[Expr]) -> Result<Option<Vec<ExactFileId>>> {
     let analyzer = ExactFileIdFilterAnalyzer;
-    let mut file_ids: Option<BTreeSet<String>> = None;
+    let mut file_ids: Option<BTreeSet<ExactFileId>> = None;
     for filter in filters {
         let Some(filter_ids) = analyzer.analyze(filter)? else {
             continue;
@@ -2162,16 +2329,25 @@ fn exact_file_ids_from_filters(filters: &[Expr]) -> Result<Option<Vec<String>>> 
     Ok(file_ids.map(|ids| ids.into_iter().collect()))
 }
 
-fn apply_exact_file_id_filter(request: &mut HotStateScanRequest, file_ids: Option<Vec<String>>) {
+fn apply_exact_file_id_filter(request: &mut HotStateScanRequest, file_ids: Option<Vec<ExactFileId>>) {
     if let Some(file_ids) = file_ids {
         if file_ids.is_empty() {
             request.filter.rows = HotStateRowFilter::None;
         }
         request.filter.file_ids = file_ids
             .into_iter()
-            .map(crate::NullableKeyFilter::Value)
+            .map(|file_id| match file_id {
+                ExactFileId::Null => crate::NullableKeyFilter::Null,
+                ExactFileId::Value(file_id) => crate::NullableKeyFilter::Value(file_id),
+            })
             .collect();
     }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+enum ExactFileId {
+    Null,
+    Value(String),
 }
 
 struct ExactFileIdFilterAnalyzer;
@@ -2183,7 +2359,7 @@ impl ExactFileIdFilterAnalyzer {
     }
 
     #[expect(clippy::self_only_used_in_recursion)]
-    fn analyze(&self, expr: &Expr) -> Result<Option<BTreeSet<String>>> {
+    fn analyze(&self, expr: &Expr) -> Result<Option<BTreeSet<ExactFileId>>> {
         match expr {
             Expr::BinaryExpr(binary_expr) if binary_expr.op == Operator::And => {
                 let Some(left) = self.analyze(&binary_expr.left)? else {
@@ -2210,12 +2386,19 @@ impl ExactFileIdFilterAnalyzer {
             Expr::InList(in_list) => Ok(
                 file_ids_from_in_list_filter(in_list).map(|values| values.into_iter().collect())
             ),
+            Expr::IsNull(expression) => {
+                let Expr::Column(column) = expression.as_ref() else {
+                    return Ok(None);
+                };
+                Ok((column.name == "lixcol_file_id")
+                    .then(|| BTreeSet::from([ExactFileId::Null])))
+            }
             _ => Ok(None),
         }
     }
 }
 
-fn file_id_from_binary_filter(binary_expr: &BinaryExpr) -> Option<String> {
+fn file_id_from_binary_filter(binary_expr: &BinaryExpr) -> Option<ExactFileId> {
     if binary_expr.op != Operator::Eq {
         return None;
     }
@@ -2223,7 +2406,7 @@ fn file_id_from_binary_filter(binary_expr: &BinaryExpr) -> Option<String> {
         .or_else(|| file_id_from_column_literal_filter(&binary_expr.right, &binary_expr.left))
 }
 
-fn file_ids_from_in_list_filter(in_list: &InList) -> Option<Vec<String>> {
+fn file_ids_from_in_list_filter(in_list: &InList) -> Option<Vec<ExactFileId>> {
     if in_list.negated {
         return None;
     }
@@ -2236,7 +2419,7 @@ fn file_ids_from_in_list_filter(in_list: &InList) -> Option<Vec<String>> {
     let values = in_list
         .list
         .iter()
-        .map(string_expr_literal)
+        .map(|expr| string_expr_literal(expr).map(ExactFileId::Value))
         .collect::<Option<Vec<_>>>()?;
     if values.is_empty() {
         return None;
@@ -2244,14 +2427,17 @@ fn file_ids_from_in_list_filter(in_list: &InList) -> Option<Vec<String>> {
     Some(values)
 }
 
-fn file_id_from_column_literal_filter(column_expr: &Expr, literal_expr: &Expr) -> Option<String> {
+fn file_id_from_column_literal_filter(
+    column_expr: &Expr,
+    literal_expr: &Expr,
+) -> Option<ExactFileId> {
     let Expr::Column(column) = column_expr else {
         return None;
     };
     if column.name != "lixcol_file_id" {
         return None;
     }
-    string_expr_literal(literal_expr)
+    string_expr_literal(literal_expr).map(ExactFileId::Value)
 }
 
 pub(super) struct RowPrimaryKeyFilterAnalyzer<'a> {
@@ -5466,6 +5652,96 @@ mod tests {
             super::row_pks_from_primary_key_filters(&spec, &[eq_filter("id", "42")])
                 .expect("mismatched filter should be safely ignored")
                 .is_none()
+        );
+    }
+
+    #[test]
+    fn primary_key_range_uses_typed_inclusive_and_exclusive_bounds() {
+        let spec = derive_schema_surface_spec_from_schema(&json!({
+            "$schema": "https://lix.dev/schema-v1.json",
+            "key": "integer_note_range",
+            "columns": [
+                { "name": "id", "type": "int8", "nullable": false },
+                { "name": "body", "type": "text", "nullable": false },
+            ],
+            "primary_key": ["id"],
+        }))
+        .expect("integer range schema should derive");
+        let filters = vec![
+            super::RowFilter::ColumnRange {
+                column: "id".to_owned(),
+                column_type: SchemaColumnType::Integer,
+                op: super::RowRangeOp::Gt,
+                value: super::RowFilterValue::Integer(41),
+            },
+            super::RowFilter::ColumnRange {
+                column: "id".to_owned(),
+                column_type: SchemaColumnType::Integer,
+                op: super::RowRangeOp::LtEq,
+                value: super::RowFilterValue::Integer(45),
+            },
+        ];
+
+        let (lower, upper) = super::primary_key_range(&spec, &filters)
+            .expect("contiguous typed range should route");
+        let lower = lower.expect("lower bound");
+        let upper = upper.expect("upper bound");
+        assert_eq!(lower.row_pk.clone().into_parts(), vec!["41"]);
+        assert!(!lower.inclusive);
+        assert_eq!(upper.row_pk.clone().into_parts(), vec!["45"]);
+        assert!(upper.inclusive);
+    }
+
+    #[test]
+    fn composite_primary_key_range_requires_single_prefix_and_both_bounds() {
+        let spec = derive_schema_surface_spec_from_schema(&json!({
+            "$schema": "https://lix.dev/schema-v1.json",
+            "key": "versioned_note_range",
+            "columns": [
+                { "name": "namespace", "type": "text", "nullable": false },
+                { "name": "revision", "type": "int8", "nullable": false },
+            ],
+            "primary_key": ["namespace", "revision"],
+        }))
+        .expect("composite range schema should derive");
+        let prefix = super::RowFilter::ColumnEq {
+            column: "namespace".to_owned(),
+            column_type: SchemaColumnType::String,
+            value: super::RowFilterValue::String("docs".to_owned()),
+        };
+        let lower = super::RowFilter::ColumnRange {
+            column: "revision".to_owned(),
+            column_type: SchemaColumnType::Integer,
+            op: super::RowRangeOp::GtEq,
+            value: super::RowFilterValue::Integer(10),
+        };
+        let upper = super::RowFilter::ColumnRange {
+            column: "revision".to_owned(),
+            column_type: SchemaColumnType::Integer,
+            op: super::RowRangeOp::Lt,
+            value: super::RowFilterValue::Integer(20),
+        };
+
+        assert!(super::primary_key_range(&spec, &[prefix.clone(), lower.clone()]).is_none());
+        let (actual_lower, actual_upper) =
+            super::primary_key_range(&spec, &[prefix, lower, upper])
+                .expect("bounded final component with exact prefix should route");
+        assert_eq!(
+            actual_lower.expect("lower").row_pk.into_parts(),
+            vec!["docs", "10"]
+        );
+        assert_eq!(
+            actual_upper.expect("upper").row_pk.into_parts(),
+            vec!["docs", "20"]
+        );
+    }
+
+    #[test]
+    fn null_file_owner_is_an_exact_physical_fence() {
+        let filter = Expr::IsNull(Box::new(column("lixcol_file_id")));
+        assert_eq!(
+            super::exact_file_ids_from_filters(&[filter]).expect("IS NULL should analyze"),
+            Some(vec![super::ExactFileId::Null])
         );
     }
 

--- a/packages/lix/src/sql2/providers/schema.rs
+++ b/packages/lix/src/sql2/providers/schema.rs
@@ -30,7 +30,8 @@ use crate::hot_state::MaterializedHotStateBatch;
 #[cfg(test)]
 use crate::hot_state::MaterializedHotStateRow;
 use crate::hot_state::{
-    HotStateFilter, HotStateProjection, HotStateReader, HotStateRowFilter, HotStateScanRequest,
+    HotStateExactBatchRequest, HotStateExactRowRequest, HotStateFilter, HotStateProjection,
+    HotStateReader, HotStateRowFilter, HotStateScanRequest,
 };
 use crate::sql2::branch_scope::{BranchBinding, resolve_provider_branch_ids};
 use crate::sql2::catalog::{
@@ -112,6 +113,52 @@ pub(crate) async fn execute_exact_schema_point_read(
         columns: output_columns,
         notices: Vec::new(),
     }))
+}
+
+/// Executes a finite registered-schema identity set through one retained
+/// current-state batch. SQL routing has already proved that every predicate
+/// term is a complete primary key; the exact reader remains the sole
+/// visibility and branch/global precedence authority.
+pub(crate) async fn execute_exact_schema_batch_read(
+    spec: &SchemaSurfaceSpec,
+    active_branch_id: &str,
+    reader: Arc<dyn HotStateReader>,
+    identities: Vec<(RowPk, Option<String>)>,
+    projected_columns: &[String],
+    output_columns: Vec<String>,
+) -> Result<crate::SqlQueryResult, LixError> {
+    let request = HotStateExactBatchRequest {
+        rows: identities
+            .into_iter()
+            .map(|(row_pk, file_id)| HotStateExactRowRequest {
+                schema_key: spec.schema_key.clone(),
+                branch_id: active_branch_id.to_owned(),
+                row_pk,
+                file_id,
+            })
+            .collect(),
+        projection: HotStateProjection {
+            columns: vec!["snapshot_content".to_owned()],
+        },
+        untracked: None,
+        include_tombstones: false,
+    };
+    let exact = reader.load_exact_batch(&request).await?;
+    let decoder = RowProjectionDecoder::new(spec, projected_columns.iter().map(String::as_str))?;
+    let mut rows = Vec::with_capacity(exact.len());
+    for slot in 0..exact.len() {
+        let Some(row) = exact.row(slot) else {
+            continue;
+        };
+        rows.push(decoder.decode_public_values(
+            row.snapshot_content().map(|snapshot| snapshot.as_bytes()),
+        )?);
+    }
+    Ok(crate::SqlQueryResult {
+        rows,
+        columns: output_columns,
+        notices: Vec::new(),
+    })
 }
 
 pub(crate) async fn register_row_providers<S>(

--- a/packages/lix/src/sql2/providers/schema.rs
+++ b/packages/lix/src/sql2/providers/schema.rs
@@ -70,6 +70,53 @@ use super::values::{
 };
 use crate::storage_adapter::StorageAdapterRead;
 
+/// Executes the already-proved unique registered-schema point shape without
+/// constructing a DataFusion plan or Arrow batch. The retained snapshot
+/// reader remains the sole visibility/authentication authority.
+pub(crate) async fn execute_exact_schema_point_read(
+    spec: &SchemaSurfaceSpec,
+    active_branch_id: &str,
+    reader: Arc<dyn RowSnapshotReader>,
+    row_pk: RowPk,
+    projected_columns: &[String],
+    output_columns: Vec<String>,
+) -> Result<crate::SqlQueryResult, LixError> {
+    let mut request = row_hot_state_scan_request(
+        &spec.schema_key,
+        Some(active_branch_id),
+        None,
+        Some(1),
+        true,
+    );
+    request.filter.row_pks = vec![row_pk];
+    let snapshots = reader.scan_row_snapshots(request).await?.ok_or_else(|| {
+        LixError::new(
+            LixError::CODE_INTERNAL_ERROR,
+            "exact schema point route lost its retained snapshot capability",
+        )
+    })?;
+    if snapshots.len() > 1 {
+        return Err(LixError::new(
+            LixError::CODE_INTERNAL_ERROR,
+            "exact schema point route returned more than one row",
+        ));
+    }
+    let rows = snapshots
+        .first()
+        .map(|snapshot| {
+            RowProjectionDecoder::new(spec, projected_columns.iter().map(String::as_str))?
+                .decode_public_values(snapshot.as_deref())
+        })
+        .transpose()?
+        .into_iter()
+        .collect();
+    Ok(crate::SqlQueryResult {
+        rows,
+        columns: output_columns,
+        notices: Vec::new(),
+    })
+}
+
 pub(crate) async fn register_row_providers<S>(
     ctx: &SessionContext,
     active_branch_id: &str,

--- a/packages/lix/src/sql2/providers/schema.rs
+++ b/packages/lix/src/sql2/providers/schema.rs
@@ -5534,15 +5534,24 @@ mod tests {
         assert!(request.filter.file_ids.is_empty());
         assert_eq!(request.filter.rows, HotStateRowFilter::None);
 
-        // Shapes the seek cannot represent stay unsupported so DataFusion keeps
-        // its residual instead of silently widening the scan.
+        // A NULL file owner is an exact physical fence too.
+        let null_file_owner = Expr::IsNull(Box::new(column("lixcol_file_id")));
         assert_eq!(
             <super::SchemaSpec as super::super::spec::TableSpec>::filter_pushdown(
                 &provider,
-                &Expr::IsNull(Box::new(column("lixcol_file_id")))
+                &null_file_owner
             ),
-            datafusion::logical_expr::TableProviderFilterPushDown::Unsupported
+            datafusion::logical_expr::TableProviderFilterPushDown::Exact
         );
+        let (_schema, request, row_filters) = provider
+            .plan_scan_parts(None, &[null_file_owner], None)
+            .await
+            .expect("NULL file-owner scan should plan");
+        assert_eq!(request.filter.file_ids, vec![crate::NullableKeyFilter::Null]);
+        assert!(row_filters.is_empty());
+
+        // Shapes the seek cannot represent stay unsupported so DataFusion keeps
+        // its residual instead of silently widening the scan.
         assert_eq!(
             <super::SchemaSpec as super::super::spec::TableSpec>::filter_pushdown(
                 &provider,

--- a/packages/lix/src/sql2/providers/schema_history.rs
+++ b/packages/lix/src/sql2/providers/schema_history.rs
@@ -1,3 +1,4 @@
+use std::borrow::Cow;
 use std::sync::Arc;
 
 use async_trait::async_trait;
@@ -32,7 +33,7 @@ use crate::sql2::history_route::{
     parse_history_filter, validate_history_anchor_filter,
 };
 use crate::sql2::providers::schema::{
-    row_f64_value, row_i64_value, row_json_text_value, parse_snapshot,
+    parse_snapshot, row_f64_value, row_i64_value, row_json_text_value,
 };
 use crate::storage_adapter::StorageAdapterRead;
 
@@ -303,6 +304,13 @@ fn row_history_record_batch(
     spec: &SchemaSurfaceSpec,
     rows: &[SchemaHistoryRow],
 ) -> Result<RecordBatch> {
+    // Parse each authenticated history payload once for the complete Arrow
+    // projection. The former per-column path reparsed the same whole-row JSON
+    // for every projected field.
+    let snapshots = rows
+        .iter()
+        .map(|row| parse_snapshot(row.change.snapshot_content.as_deref()))
+        .collect::<Result<Vec<_>>>()?;
     let system_fields = schema
         .fields()
         .iter()
@@ -317,7 +325,7 @@ fn row_history_record_batch(
         .iter()
         .map(|field| {
             system_batch.column_by_name(field.name()).map_or_else(
-                || row_history_column_array(field.name(), spec, rows),
+                || row_history_column_array(field.name(), spec, rows, &snapshots),
                 |array| Ok(Arc::clone(array)),
             )
         })
@@ -334,6 +342,7 @@ fn row_history_column_array(
     column_name: &str,
     spec: &SchemaSurfaceSpec,
     rows: &[SchemaHistoryRow],
+    snapshots: &[Option<JsonValue>],
 ) -> Result<ArrayRef> {
     let column_type = spec
         .visible_column(column_name)
@@ -346,32 +355,33 @@ fn row_history_column_array(
         .column_type;
     let projected_values = rows
         .iter()
-        .map(|row| row_history_column_value(row, spec, column_name))
+        .zip(snapshots)
+        .map(|(row, snapshot)| row_history_column_value(row, snapshot.as_ref(), spec, column_name))
         .collect::<Result<Vec<_>>>()?;
 
     Ok(match column_type {
         SchemaColumnType::String | SchemaColumnType::Json => Arc::new(StringArray::from(
             projected_values
                 .iter()
-                .map(|snapshot| row_json_text_value(snapshot.as_ref(), column_type))
+                .map(|snapshot| row_json_text_value(snapshot.as_deref(), column_type))
                 .collect::<Result<Vec<_>>>()?,
         )) as ArrayRef,
         SchemaColumnType::Integer => Arc::new(Int64Array::from(
             projected_values
                 .iter()
-                .map(|snapshot| row_i64_value(snapshot.as_ref(), &spec.schema_key, column_name))
+                .map(|snapshot| row_i64_value(snapshot.as_deref(), &spec.schema_key, column_name))
                 .collect::<Result<Vec<_>>>()?,
         )) as ArrayRef,
         SchemaColumnType::Number => Arc::new(Float64Array::from(
             projected_values
                 .iter()
-                .map(|snapshot| row_f64_value(snapshot.as_ref(), &spec.schema_key, column_name))
+                .map(|snapshot| row_f64_value(snapshot.as_deref(), &spec.schema_key, column_name))
                 .collect::<Result<Vec<_>>>()?,
         )) as ArrayRef,
         SchemaColumnType::Boolean => Arc::new(BooleanArray::from(
             projected_values
                 .iter()
-                .map(|snapshot| snapshot.as_ref().and_then(JsonValue::as_bool))
+                .map(|snapshot| snapshot.as_deref().and_then(JsonValue::as_bool))
                 .collect::<Vec<_>>(),
         )) as ArrayRef,
         SchemaColumnType::Timestamptz => Arc::new(
@@ -379,7 +389,7 @@ fn row_history_column_array(
                 projected_values
                     .iter()
                     .map(|snapshot| {
-                        let Some(value) = snapshot.as_ref() else {
+                        let Some(value) = snapshot.as_deref() else {
                             return Ok(None);
                         };
                         if value.is_null() {
@@ -407,14 +417,14 @@ fn row_history_column_array(
     })
 }
 
-fn row_history_column_value(
+fn row_history_column_value<'a>(
     row: &SchemaHistoryRow,
+    snapshot: Option<&'a JsonValue>,
     spec: &SchemaSurfaceSpec,
     column_name: &str,
-) -> Result<Option<JsonValue>> {
-    let snapshot = parse_snapshot(row.change.snapshot_content.as_deref())?;
+) -> Result<Option<Cow<'a, JsonValue>>> {
     if let Some(snapshot) = snapshot {
-        return Ok(snapshot.get(column_name).cloned());
+        return Ok(snapshot.get(column_name).map(Cow::Borrowed));
     }
 
     let row_pk = row.change.row_pk.as_json_array_text().map_err(|error| {
@@ -427,6 +437,7 @@ fn row_history_column_value(
         &row_pk,
         HistoryIdentityProjection::PrimaryKeyPaths(&spec.primary_key_paths),
     )
+    .map(|value| value.map(Cow::Owned))
     .map_err(|error| DataFusionError::Execution(error.to_string()))
 }
 
@@ -460,8 +471,8 @@ mod tests {
             eq("locale", "en"),
         ];
 
-        let route = row_history_route_from_filters(&spec, &filters)
-            .expect("history route should derive");
+        let route =
+            row_history_route_from_filters(&spec, &filters).expect("history route should derive");
 
         assert_eq!(route.as_of_commit_ids, vec!["commit-head"]);
         assert_eq!(route.row_pks, vec![r#"["en","welcome"]"#]);
@@ -486,8 +497,8 @@ mod tests {
             eq("lixcol_row_pk", r#"["fr","welcome"]"#),
         ];
 
-        let route = row_history_route_from_filters(&spec, &filters)
-            .expect("history route should derive");
+        let route =
+            row_history_route_from_filters(&spec, &filters).expect("history route should derive");
 
         assert!(route.is_contradictory());
 

--- a/packages/lix/src/sql2/providers/working_diff.rs
+++ b/packages/lix/src/sql2/providers/working_diff.rs
@@ -262,6 +262,8 @@ impl WorkingDiffRoute {
                         .into_iter()
                         .map(NullableKeyFilter::Value)
                         .collect(),
+                    row_pk_lower: None,
+                    row_pk_upper: None,
                     include_tombstones: true,
                 },
                 retain_payloads: false,

--- a/packages/lix/src/sql2/row_batch.rs
+++ b/packages/lix/src/sql2/row_batch.rs
@@ -441,6 +441,8 @@ fn direct_row_snapshot_request(request: &HotStateScanRequest) -> bool {
 fn direct_row_columnar_request(request: &HotStateScanRequest) -> bool {
     direct_row_snapshot_request(request)
         && request.filter.row_pks.is_empty()
+        && request.filter.row_pk_lower.is_none()
+        && request.filter.row_pk_upper.is_none()
         && request.limit.is_none()
 }
 

--- a/packages/lix/src/sql2/row_projection.rs
+++ b/packages/lix/src/sql2/row_projection.rs
@@ -107,6 +107,21 @@ impl RowProjectionDecoder {
             .collect())
     }
 
+    /// Decodes one exact point result directly into the public scalar row.
+    ///
+    /// This is deliberately narrower than the Arrow path: callers must have
+    /// already proved a unique registered-schema point query. Keeping the
+    /// same decoder and raw-value coercions makes the native result an output
+    /// boundary only, not a second row interpretation authority.
+    pub(crate) fn decode_public_values(
+        &self,
+        snapshot: Option<&[u8]>,
+    ) -> Result<Vec<crate::Value>, LixError> {
+        let mut sink = PublicProjectionSink { values: Vec::new() };
+        self.decode_into(snapshot, &mut sink)?;
+        Ok(sink.values)
+    }
+
     fn decode_into<S>(&self, snapshot: Option<&[u8]>, sink: &mut S) -> Result<(), LixError>
     where
         S: RowProjectionSink,
@@ -277,6 +292,68 @@ where
 
 struct ArrowProjectionSink {
     columns: Vec<RowProjectionColumn>,
+}
+
+struct PublicProjectionSink {
+    values: Vec<crate::Value>,
+}
+
+impl RowProjectionSink for PublicProjectionSink {
+    fn begin_row(&mut self, field_count: usize) {
+        self.values = vec![crate::Value::Null; field_count];
+    }
+
+    fn project_raw(
+        &mut self,
+        decoder: &RowProjectionDecoder,
+        indices: &[usize],
+        raw: &RawValue,
+    ) -> Result<(), LixError> {
+        for index in indices {
+            let field = &decoder.fields[*index];
+            let value = match field.column_type {
+                SchemaColumnType::String => raw_string_text(raw)?
+                    .map(crate::Value::Text)
+                    .unwrap_or(crate::Value::Null),
+                SchemaColumnType::Json => raw_json_text(raw)
+                    .map(|json| crate::Value::Json(crate::Json::from_canonical_text(json)))
+                    .unwrap_or(crate::Value::Null),
+                SchemaColumnType::Integer => {
+                    let value = parse_json_value(raw)?;
+                    json_bigint_value(Some(&value), &decoder.schema_key, &field.name)?
+                        .map(crate::Value::Integer)
+                        .unwrap_or(crate::Value::Null)
+                }
+                SchemaColumnType::Number => {
+                    let value = parse_json_value(raw)?;
+                    json_double_value(Some(&value), &decoder.schema_key, &field.name)?
+                        .map(crate::Value::Real)
+                        .unwrap_or(crate::Value::Null)
+                }
+                SchemaColumnType::Boolean => raw_bool(raw)
+                    .map(crate::Value::Boolean)
+                    .unwrap_or(crate::Value::Null),
+                SchemaColumnType::Timestamptz => raw_string_text(raw)?
+                    .map(|value| {
+                        chrono::DateTime::parse_from_rfc3339(&value)
+                            .map(|timestamp| crate::Value::Timestamp(timestamp.timestamp_micros()))
+                            .map_err(|error| {
+                                LixError::new(
+                                    LixError::CODE_TYPE_MISMATCH,
+                                    format!(
+                                        "invalid timestamptz value for {}.{}: {error}",
+                                        decoder.schema_key, field.name
+                                    ),
+                                )
+                            })
+                    })
+                    .transpose()?
+                    .unwrap_or(crate::Value::Null),
+            };
+            self.values[*index] = value;
+        }
+        Ok(())
+    }
 }
 
 impl RowProjectionSink for ArrowProjectionSink {
@@ -471,6 +548,34 @@ mod tests {
 
     fn canonical_json(canonical: &str) -> Json {
         Json::from_canonical_text(canonical)
+    }
+
+    #[test]
+    fn direct_public_projection_preserves_json_null_and_timestamptz() {
+        let mut spec = spec();
+        spec.columns
+            .push(crate::sql2::catalog::schema_surface::SchemaSurfaceColumn {
+            name: "stamp".to_string(),
+            column_type: crate::sql2::catalog::SchemaColumnType::Timestamptz,
+            read_nullable: true,
+            insert_required: false,
+            default_expression: None,
+        });
+        let decoder = RowProjectionDecoder::new(&spec, ["json", "null_text", "stamp"])
+            .expect("direct decoder should build");
+        let values = decoder
+            .decode_public_values(Some(
+                br#"{"json":{"a":[true,null]},"null_text":null,"stamp":"2025-01-01T00:00:00.123456Z"}"#,
+            ))
+            .expect("direct values should decode");
+        assert_eq!(
+            values,
+            vec![
+                Value::Json(canonical_json(r#"{"a":[true,null]}"#)),
+                Value::Null,
+                Value::Timestamp(1_735_689_600_123_456),
+            ]
+        );
     }
 
     fn spec() -> crate::sql2::catalog::SchemaSurfaceSpec {

--- a/packages/lix/src/storage_bench.rs
+++ b/packages/lix/src/storage_bench.rs
@@ -4207,6 +4207,11 @@ mod tests {
         assert_eq!(
             first.delete_counts_by_space,
             vec![
+                (crate::hot_state::DIFF_SPACE.id.0, 100), // retired checkpoint working-diff rows
+                (
+                    crate::hot_state::TRACKED_WORKING_DIFF_MARKER_SPACE.id.0,
+                    1,
+                ), // retired checkpoint epoch marker
                 (
                     crate::tracked_state::TRACKED_STATE_COMMIT_STATE_MANIFEST_SPACE
                         .id
@@ -4241,11 +4246,23 @@ mod tests {
         const FENCE_KEY_BYTES: usize =
             crate::storage_adapter::REVISION_KEY_BINARY_CAS_RECLAMATION.len();
         assert_eq!(first.key_shared_buffers, first.staged_deletes as usize + 1);
-        // Every canonical-record delete is UUID keyed, so each descriptor is
-        // exactly 16 bytes.
+        // Canonical-record deletes are UUID keyed. Checkpoint rotation also
+        // retires the fixture's fixed-width working-diff identities and the
+        // branch-ref marker through their authenticated physical encodings.
+        const UUID_KEY_BYTES: usize = 16;
+        const WORKING_DIFF_KEY_BYTES: usize = 121;
+        const WORKING_DIFF_MARKER_KEY_BYTES: usize = 37;
+        let working_diff_deletes = 100;
+        let marker_deletes = 1;
+        let uuid_deletes = first.staged_deletes as usize
+            - working_diff_deletes
+            - marker_deletes;
         assert_eq!(
             first.key_shared_bytes,
-            first.staged_deletes as usize * 16 + FENCE_KEY_BYTES
+            uuid_deletes * UUID_KEY_BYTES
+                + working_diff_deletes * WORKING_DIFF_KEY_BYTES
+                + marker_deletes * WORKING_DIFF_MARKER_KEY_BYTES
+                + FENCE_KEY_BYTES
         );
         assert_eq!(second.swept_commits, first.swept_commits);
         assert_eq!(second.delete_counts_by_space, first.delete_counts_by_space);

--- a/packages/lix/src/storage_bench.rs
+++ b/packages/lix/src/storage_bench.rs
@@ -70,8 +70,6 @@ static MATERIALIZE_OWNED_KEY_BUILDS: AtomicU64 = AtomicU64::new(0);
 static MATERIALIZE_OWNED_KEY_BYTES: AtomicU64 = AtomicU64::new(0);
 static MATERIALIZE_REVERIFY_ROWS: AtomicU64 = AtomicU64::new(0);
 static COMMIT_DELTA_COLUMNAR_ROWS: AtomicU64 = AtomicU64::new(0);
-static ROW_POINT_SNAPSHOT_CACHE_HITS: AtomicU64 = AtomicU64::new(0);
-static ROW_POINT_SNAPSHOT_CACHE_MISSES: AtomicU64 = AtomicU64::new(0);
 static CRUD_PHYSICAL_PUTS: AtomicU64 = AtomicU64::new(0);
 static CRUD_PHYSICAL_DELETES: AtomicU64 = AtomicU64::new(0);
 static CRUD_PHYSICAL_WRITTEN_BYTES: AtomicU64 = AtomicU64::new(0);
@@ -516,12 +514,6 @@ pub fn take_certified_row_update_value_batch_accounting() -> CrudCertificateAcco
     }
 }
 
-#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
-pub struct RowPointSnapshotCacheAccounting {
-    pub hits: u64,
-    pub misses: u64,
-}
-
 pub(crate) fn record_root_base_batch_cache_hit() {
     ROOT_BASE_BATCH_CACHE_HITS.fetch_add(1, Ordering::Relaxed);
 }
@@ -832,21 +824,6 @@ pub fn take_hot_index_probe_census() -> HotIndexProbeCensus {
             .swap(0, Ordering::Relaxed),
         probes_refused_over_budget: HOT_INDEX_PROBES_REFUSED_OVER_BUDGET
             .swap(0, Ordering::Relaxed),
-    }
-}
-
-pub(crate) fn record_row_point_snapshot_cache_hit() {
-    ROW_POINT_SNAPSHOT_CACHE_HITS.fetch_add(1, Ordering::Relaxed);
-}
-
-pub(crate) fn record_row_point_snapshot_cache_miss() {
-    ROW_POINT_SNAPSHOT_CACHE_MISSES.fetch_add(1, Ordering::Relaxed);
-}
-
-pub fn take_row_point_snapshot_cache_accounting() -> RowPointSnapshotCacheAccounting {
-    RowPointSnapshotCacheAccounting {
-        hits: ROW_POINT_SNAPSHOT_CACHE_HITS.swap(0, Ordering::Relaxed),
-        misses: ROW_POINT_SNAPSHOT_CACHE_MISSES.swap(0, Ordering::Relaxed),
     }
 }
 

--- a/packages/lix/src/tracked_state/codec.rs
+++ b/packages/lix/src/tracked_state/codec.rs
@@ -2086,6 +2086,20 @@ fn decode_internal_v4(body: &[u8]) -> Result<DecodedInternalNode, LixError> {
             Some(first_key.clone()),
             &mut boundary_arena,
         )?;
+        if boundary_arena[first_key.clone()] > boundary_arena[last_key.clone()] {
+            return Err(LixError::new(
+                "LIX_ERROR_UNKNOWN",
+                "tracked-state internal node child has an inverted key range",
+            ));
+        }
+        if previous_last.as_ref().is_some_and(|previous_last| {
+            boundary_arena[previous_last.clone()] >= boundary_arena[first_key.clone()]
+        }) {
+            return Err(LixError::new(
+                "LIX_ERROR_UNKNOWN",
+                "tracked-state internal node children overlap or are unordered",
+            ));
+        }
         let child_hash = <[u8; TRACKED_STATE_HASH_BYTES]>::try_from(slice(
             body,
             &mut offset,
@@ -2198,6 +2212,38 @@ mod tests {
         DecodedNodeRef as NodeRefForLeafTests, decode_node_ref as decode_node_ref_for_leaf_tests,
         encode_leaf_node_refs as encode_leaf_refs_for_tests,
     };
+
+    fn encode_unchecked_internal_boundaries(children: &[(&[u8], &[u8])]) -> Vec<u8> {
+        let mut encoded = vec![NODE_KIND_INTERNAL_V4];
+        write_varint(&mut encoded, children.len() as u64);
+        let mut previous_last = &[][..];
+        for (index, (first_key, last_key)) in children.iter().enumerate() {
+            write_front_coded(&mut encoded, previous_last, first_key);
+            write_front_coded(&mut encoded, first_key, last_key);
+            encoded.extend_from_slice(&[index as u8 + 1; TRACKED_STATE_HASH_BYTES]);
+            write_varint(&mut encoded, 1);
+            previous_last = last_key;
+        }
+        encoded
+    }
+
+    #[test]
+    fn internal_node_rejects_reordered_sibling_ranges() {
+        let encoded = encode_unchecked_internal_boundaries(&[
+            (b"schema-z/a", b"schema-z/z"),
+            (b"schema-a/a", b"schema-a/z"),
+        ]);
+        let error = decode_node_ref(&encoded).expect_err("reordered siblings must fail closed");
+        assert!(error.message.contains("overlap or are unordered"));
+    }
+
+    #[test]
+    fn internal_node_rejects_inverted_child_range() {
+        let encoded =
+            encode_unchecked_internal_boundaries(&[(b"schema-z/z", b"schema-z/a")]);
+        let error = decode_node_ref(&encoded).expect_err("inverted range must fail closed");
+        assert!(error.message.contains("inverted key range"));
+    }
 
     fn raw_value(change: u8, commit: u8, tail: u8) -> Vec<u8> {
         let mut value = Vec::with_capacity(VALUE_MAX_BYTES);

--- a/packages/lix/src/tracked_state/context.rs
+++ b/packages/lix/src/tracked_state/context.rs
@@ -3796,37 +3796,85 @@ where
         staged_read: &storage::TrackedStateStagedRead<'_, S>,
         base_root: &TrackedStateRootId,
     ) -> Result<Vec<String>, LixError> {
-        // A file-only predicate cannot bound this schema-first tree. Derive
-        // the complete schema inventory from authenticated registered-schema
-        // rows in this same parent root, then issue canonical
-        // `(schema_key, file_id)` ranges. Built-in filesystem schemas are
-        // native controls and therefore included independently of public
-        // registration.
-        let mut schema_keys = crate::filesystem::filesystem_schema_keys()
-            .into_iter()
+        // A file-only predicate cannot bound this schema-first tree. Enumerate
+        // the actual authenticated schema runs in the same parent root, then
+        // issue canonical `(schema_key, file_id)` ranges. This includes
+        // private/unregistered rows without trusting a second catalog.
+        self.tree.distinct_schema_keys(staged_read, base_root).await
+    }
+
+    #[cold]
+    #[inline(never)]
+    async fn file_cascade_mutations<'a>(
+        &self,
+        staged_read: &storage::TrackedStateStagedRead<'_, S>,
+        base_root: &TrackedStateRootId,
+        deltas: &[TrackedStateDeltaRef<'a>],
+    ) -> Result<BTreeMap<Vec<u8>, Vec<u8>>, LixError> {
+        let mut cascades = BTreeMap::<String, &TrackedStateDeltaRef<'_>>::new();
+        for delta in deltas {
+            if delta.schema_key != FILE_DESCRIPTOR_SCHEMA_KEY || !delta.deleted {
+                continue;
+            }
+            let file_id = delta.row_pk.as_single_string_owned().map_err(|error| {
+                LixError::new(
+                    LixError::CODE_INTERNAL_ERROR,
+                    format!("file descriptor tombstone has invalid identity: {error}"),
+                )
+            })?;
+            cascades.insert(file_id, delta);
+        }
+        let explicit_keys = deltas
+            .iter()
+            .map(|delta| TrackedStateKey {
+                schema_key: delta.schema_key.to_string(),
+                file_id: delta.file_id.map(str::to_string),
+                row_pk: delta.row_pk.clone(),
+            })
             .collect::<BTreeSet<_>>();
-        let registered_schemas = self
+        let rows = self
             .tree
             .scan(
                 staged_read,
                 base_root,
                 &TrackedStateTreeScanRequest {
-                    schema_keys: vec![REGISTERED_SCHEMA_KEY.to_string()],
-                    file_ids: vec![NullableKeyFilter::Null],
+                    schema_keys: self
+                        .file_cascade_schema_keys(staged_read, base_root)
+                        .await?,
+                    file_ids: cascades
+                        .keys()
+                        .cloned()
+                        .map(NullableKeyFilter::Value)
+                        .collect(),
                     include_tombstones: false,
                     ..TrackedStateTreeScanRequest::default()
                 },
             )
             .await?;
-        for (key, _) in registered_schemas {
-            schema_keys.insert(key.row_pk.as_single_string_owned().map_err(|error| {
-                LixError::new(
-                    LixError::CODE_STORAGE_ERROR,
-                    format!("registered schema cascade identity is invalid: {error}"),
+        let mut mutations = BTreeMap::new();
+        for (key, value) in rows {
+            if explicit_keys.contains(&key) {
+                continue;
+            }
+            let cascade = cascades
+                .get(
+                    key.file_id
+                        .as_deref()
+                        .expect("file-filtered tracked row requires file id"),
                 )
-            })?);
+                .expect("tracked scan only returns requested cascade ids");
+            mutations.insert(
+                encode_key(&key),
+                encode_value_ref(TrackedStateIndexValueRef {
+                    change_id: cascade.change_id,
+                    commit_id: cascade.commit_id,
+                    deleted: true,
+                    created_at: value.created_at(),
+                    updated_at: cascade.updated_at,
+                }),
+            );
         }
-        Ok(schema_keys.into_iter().collect())
+        Ok(mutations)
     }
 
     pub(crate) fn into_transient_rebuild_state(self) -> TrackedStateTransientRebuildState {
@@ -3991,74 +4039,26 @@ where
                 primary_chunk_puts: 0,
             });
         }
-        let explicit_keys = deltas
-            .iter()
-            .map(|delta| TrackedStateKey {
-                schema_key: delta.schema_key.to_string(),
-                file_id: delta.file_id.map(str::to_string),
-                row_pk: delta.row_pk.clone(),
-            })
-            .collect::<BTreeSet<_>>();
         let mut cascade_mutations = BTreeMap::<Vec<u8>, Vec<u8>>::new();
         if let Some(base_root) = base_root.as_ref() {
             let staged_read = storage::TrackedStateStagedRead::new(self.store, &self.chunk_overlay);
-            let mut cascades = BTreeMap::<String, &TrackedStateDeltaRef<'_>>::new();
-            for delta in &deltas {
-                if delta.schema_key != FILE_DESCRIPTOR_SCHEMA_KEY || !delta.deleted {
-                    continue;
-                }
-                let file_id = delta.row_pk.as_single_string_owned().map_err(|error| {
-                    LixError::new(
-                        LixError::CODE_INTERNAL_ERROR,
-                        format!("file descriptor tombstone has invalid identity: {error}"),
-                    )
-                })?;
-                cascades.insert(file_id, delta);
-            }
-            if !cascades.is_empty() {
-                let cascade_schema_keys = self
-                    .file_cascade_schema_keys(&staged_read, base_root)
+            if deltas.iter().any(|delta| {
+                delta.schema_key == FILE_DESCRIPTOR_SCHEMA_KEY && delta.deleted
+            }) {
+                cascade_mutations = self
+                    .file_cascade_mutations(&staged_read, base_root, &deltas)
                     .await?;
-                let rows = self
-                    .tree
-                    .scan(
-                        &staged_read,
-                        base_root,
-                        &TrackedStateTreeScanRequest {
-                            schema_keys: cascade_schema_keys,
-                            file_ids: cascades
-                                .keys()
-                                .cloned()
-                                .map(NullableKeyFilter::Value)
-                                .collect(),
-                            include_tombstones: false,
-                            ..TrackedStateTreeScanRequest::default()
-                        },
-                    )
-                    .await?;
-                for (key, value) in rows {
-                    if explicit_keys.contains(&key) {
-                        continue;
-                    }
-                    let cascade = cascades
-                        .get(
-                            key.file_id
-                                .as_deref()
-                                .expect("file-filtered tracked row requires file id"),
-                        )
-                        .expect("tracked scan only returns requested cascade ids");
-                    cascade_mutations.insert(
-                        encode_key(&key),
-                        encode_value_ref(TrackedStateIndexValueRef {
-                            change_id: cascade.change_id,
-                            commit_id: cascade.commit_id,
-                            deleted: true,
-                            created_at: value.created_at(),
-                            updated_at: cascade.updated_at,
-                        }),
-                    );
-                }
             }
+            let explicit_keys = (!certified_replacement_markers.is_empty()).then(|| {
+                deltas
+                    .iter()
+                    .map(|delta| TrackedStateKey {
+                        schema_key: delta.schema_key.to_string(),
+                        file_id: delta.file_id.map(str::to_string),
+                        row_pk: delta.row_pk.clone(),
+                    })
+                    .collect::<BTreeSet<_>>()
+            });
             for marker in deltas.iter().filter(|delta| {
                 !delta.deleted
                     && delta.schema_key
@@ -4087,7 +4087,11 @@ where
                     )
                     .await?;
                 for (key, value) in rows {
-                    if explicit_keys.contains(&key) {
+                    if explicit_keys
+                        .as_ref()
+                        .expect("certified marker requires explicit-key inventory")
+                        .contains(&key)
+                    {
                         continue;
                     }
                     cascade_mutations.insert(
@@ -6479,7 +6483,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn file_cascade_rejects_malformed_registered_schema_identity() {
+    async fn file_cascade_discovers_unregistered_file_owned_schema_from_root() {
         const FILE_ID: &str = "01920000-0000-7000-8000-0000000000a3.json";
         let storage = StorageAdapter::new(Memory::new());
         let tracked_state = TrackedStateContext::new();
@@ -6487,28 +6491,24 @@ mod tests {
         let mut descriptor = row(FILE_ID, "descriptor-parent", "parent");
         descriptor.schema_key = FILE_DESCRIPTOR_SCHEMA_KEY.to_string();
         descriptor.file_id = Some(FILE_ID.to_string());
-        let mut malformed_registration = row("ignored", "schema-parent", "parent");
-        malformed_registration.schema_key = REGISTERED_SCHEMA_KEY.to_string();
-        malformed_registration.file_id = None;
-        malformed_registration.row_pk = RowPk::from_validated_shared_string_parts([
-            "schema-part-a".into(),
-            "schema-part-b".into(),
-        ]);
+        let mut private_row = row("private-row", "private-parent", "parent");
+        private_row.schema_key = "plugin_private_schema".to_string();
+        private_row.file_id = Some(FILE_ID.to_string());
         write_root_for_test(
             &storage,
             &tracked_state,
             "parent",
             None,
-            &[descriptor.clone(), malformed_registration],
+            &[descriptor.clone(), private_row.clone()],
         )
         .await
-        .expect("malformed catalog fixture root should stage");
+        .expect("unregistered private row root should stage");
 
         descriptor.snapshot_content = None;
         descriptor.deleted = true;
         descriptor.change_id = ChangeId::for_test_label("descriptor-delete");
         descriptor.commit_id = CommitId::for_test_label("child");
-        let error = write_root_for_test(
+        write_root_for_test(
             &storage,
             &tracked_state,
             "child",
@@ -6516,13 +6516,33 @@ mod tests {
             &[descriptor],
         )
         .await
-        .expect_err("malformed authenticated schema inventory must fail closed");
-        assert!(
-            error
-                .message
-                .contains("registered schema cascade identity is invalid"),
-            "unexpected error: {error:?}"
-        );
+        .expect("authenticated root inventory must find the private schema");
+
+        let read = storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("child root should open");
+        let child_root = tracked_state
+            .tree
+            .load_root(&read, "child")
+            .await
+            .expect("child root metadata should load")
+            .expect("child root must exist");
+        let value = TrackedStateTree::new()
+            .get(
+                &read,
+                &child_root,
+                &TrackedStateKey {
+                    schema_key: private_row.schema_key,
+                    file_id: private_row.file_id,
+                    row_pk: private_row.row_pk,
+                },
+            )
+            .await
+            .expect("private row should remain addressable")
+            .expect("private row must be represented by a tombstone");
+        assert!(value.deleted());
+        assert_eq!(value.commit_id, CommitId::for_test_label("child"));
     }
 
     #[tokio::test]

--- a/packages/lix/src/tracked_state/context.rs
+++ b/packages/lix/src/tracked_state/context.rs
@@ -4512,6 +4512,8 @@ fn tree_scan_request_from_tracked(
     TrackedStateTreeScanRequest {
         schema_keys: request.filter.schema_keys.clone(),
         row_pks: request.filter.row_pks.clone(),
+        row_pk_lower: request.filter.row_pk_lower.clone(),
+        row_pk_upper: request.filter.row_pk_upper.clone(),
         file_ids: request.filter.file_ids.clone(),
         include_tombstones: request.filter.include_tombstones,
         // User limits belong above delta overlay and tombstone visibility.
@@ -9117,6 +9119,8 @@ mod tests {
                     schema_keys: vec![SCHEMA_KEY.to_owned()],
                     row_pks: vec![key.row_pk.clone()],
                     file_ids: vec![NullableKeyFilter::Value(FILE_ID.to_owned())],
+                    row_pk_lower: None,
+                    row_pk_upper: None,
                     include_tombstones: true,
                 },
                 read_columns: crate::tracked_state::TrackedStateReadColumns {

--- a/packages/lix/src/tracked_state/context.rs
+++ b/packages/lix/src/tracked_state/context.rs
@@ -3789,6 +3789,46 @@ impl<S> TrackedStateWriter<'_, S>
 where
     S: StorageAdapterRead + ?Sized,
 {
+    #[cold]
+    #[inline(never)]
+    async fn file_cascade_schema_keys(
+        &self,
+        staged_read: &storage::TrackedStateStagedRead<'_, S>,
+        base_root: &TrackedStateRootId,
+    ) -> Result<Vec<String>, LixError> {
+        // A file-only predicate cannot bound this schema-first tree. Derive
+        // the complete schema inventory from authenticated registered-schema
+        // rows in this same parent root, then issue canonical
+        // `(schema_key, file_id)` ranges. Built-in filesystem schemas are
+        // native controls and therefore included independently of public
+        // registration.
+        let mut schema_keys = crate::filesystem::filesystem_schema_keys()
+            .into_iter()
+            .collect::<BTreeSet<_>>();
+        let registered_schemas = self
+            .tree
+            .scan(
+                staged_read,
+                base_root,
+                &TrackedStateTreeScanRequest {
+                    schema_keys: vec![REGISTERED_SCHEMA_KEY.to_string()],
+                    file_ids: vec![NullableKeyFilter::Null],
+                    include_tombstones: false,
+                    ..TrackedStateTreeScanRequest::default()
+                },
+            )
+            .await?;
+        for (key, _) in registered_schemas {
+            schema_keys.insert(key.row_pk.as_single_string_owned().map_err(|error| {
+                LixError::new(
+                    LixError::CODE_STORAGE_ERROR,
+                    format!("registered schema cascade identity is invalid: {error}"),
+                )
+            })?);
+        }
+        Ok(schema_keys.into_iter().collect())
+    }
+
     pub(crate) fn into_transient_rebuild_state(self) -> TrackedStateTransientRebuildState {
         TrackedStateTransientRebuildState {
             chunk_overlay: self.chunk_overlay,
@@ -3976,12 +4016,16 @@ where
                 cascades.insert(file_id, delta);
             }
             if !cascades.is_empty() {
+                let cascade_schema_keys = self
+                    .file_cascade_schema_keys(&staged_read, base_root)
+                    .await?;
                 let rows = self
                     .tree
                     .scan(
                         &staged_read,
                         base_root,
                         &TrackedStateTreeScanRequest {
+                            schema_keys: cascade_schema_keys,
                             file_ids: cascades
                                 .keys()
                                 .cloned()
@@ -6342,6 +6386,13 @@ mod tests {
                 row
             })
             .collect::<Vec<_>>();
+        let mut schema_registration = row(
+            "a_schema",
+            "change-cascade-schema-registration",
+            "cascade-append-parent",
+        );
+        schema_registration.schema_key = REGISTERED_SCHEMA_KEY.to_string();
+        schema_registration.file_id = None;
         let mut descriptor =
             tombstone(FILE_ID, "change-cascade-descriptor", "cascade-append-child");
         descriptor.schema_key = FILE_DESCRIPTOR_SCHEMA_KEY.to_string();
@@ -6365,7 +6416,10 @@ mod tests {
             .stage_commit_root(
                 &parent_commit_id,
                 None,
-                parent_rows.iter().map(delta_from_materialized_row),
+                parent_rows
+                    .iter()
+                    .chain(std::iter::once(&schema_registration))
+                    .map(delta_from_materialized_row),
             )
             .await
             .expect("cascade parent root should stage");
@@ -6422,6 +6476,53 @@ mod tests {
             .expect("cascaded parent row should remain as a tombstone");
         assert!(cascaded.deleted());
         assert_eq!(cascaded.change_id, child_rows[0].change_id);
+    }
+
+    #[tokio::test]
+    async fn file_cascade_rejects_malformed_registered_schema_identity() {
+        const FILE_ID: &str = "01920000-0000-7000-8000-0000000000a3.json";
+        let storage = StorageAdapter::new(Memory::new());
+        let tracked_state = TrackedStateContext::new();
+
+        let mut descriptor = row(FILE_ID, "descriptor-parent", "parent");
+        descriptor.schema_key = FILE_DESCRIPTOR_SCHEMA_KEY.to_string();
+        descriptor.file_id = Some(FILE_ID.to_string());
+        let mut malformed_registration = row("ignored", "schema-parent", "parent");
+        malformed_registration.schema_key = REGISTERED_SCHEMA_KEY.to_string();
+        malformed_registration.file_id = None;
+        malformed_registration.row_pk = RowPk::from_validated_shared_string_parts([
+            "schema-part-a".into(),
+            "schema-part-b".into(),
+        ]);
+        write_root_for_test(
+            &storage,
+            &tracked_state,
+            "parent",
+            None,
+            &[descriptor.clone(), malformed_registration],
+        )
+        .await
+        .expect("malformed catalog fixture root should stage");
+
+        descriptor.snapshot_content = None;
+        descriptor.deleted = true;
+        descriptor.change_id = ChangeId::for_test_label("descriptor-delete");
+        descriptor.commit_id = CommitId::for_test_label("child");
+        let error = write_root_for_test(
+            &storage,
+            &tracked_state,
+            "child",
+            Some("parent"),
+            &[descriptor],
+        )
+        .await
+        .expect_err("malformed authenticated schema inventory must fail closed");
+        assert!(
+            error
+                .message
+                .contains("registered schema cascade identity is invalid"),
+            "unexpected error: {error:?}"
+        );
     }
 
     #[tokio::test]
@@ -9521,12 +9622,20 @@ mod tests {
         semantic.file_id = Some(FILE_ID.to_string());
         let mut retired = row("retired-blob", "retired-create", "initial");
         retired.file_id = Some(FILE_ID.to_string());
+        let mut schema_registration = row("test_schema", "schema-create", "initial");
+        schema_registration.schema_key = REGISTERED_SCHEMA_KEY.to_string();
+        schema_registration.file_id = None;
         write_root_for_test(
             &storage,
             &tracked_state,
             "initial",
             None,
-            &[descriptor.clone(), semantic, retired.clone()],
+            &[
+                descriptor.clone(),
+                semantic,
+                retired.clone(),
+                schema_registration,
+            ],
         )
         .await
         .expect("initial root should write");

--- a/packages/lix/src/tracked_state/diff.rs
+++ b/packages/lix/src/tracked_state/diff.rs
@@ -436,6 +436,8 @@ fn scan_request_for_diff(request: &TrackedStateDiffRequest) -> TrackedStateTreeS
         schema_keys: filter.schema_keys,
         row_pks: filter.row_pks,
         file_ids: filter.file_ids,
+        row_pk_lower: filter.row_pk_lower,
+        row_pk_upper: filter.row_pk_upper,
         include_tombstones: true,
         limit: None,
     }

--- a/packages/lix/src/tracked_state/mod.rs
+++ b/packages/lix/src/tracked_state/mod.rs
@@ -143,6 +143,7 @@ pub(crate) use types::{
     CommitStateMutationInventory, CommitStateReplayDebt, MaterializedTrackedStateRow,
     TrackedStateBaseCoordinate, TrackedStateCommitDeltaRef, TrackedStateCommitRoot,
     TrackedStateDeltaRef, TrackedStateFilter, TrackedStateIndexValue, TrackedStateReadColumns,
+    RowPkRangeBound, row_pk_satisfies_bounds,
     TrackedStateRootMutationRef, TrackedStateScanRequest, TrackedStateSingleStringReplacementRef,
 };
 pub(crate) use types::CurrentStatePartSource;

--- a/packages/lix/src/tracked_state/storage.rs
+++ b/packages/lix/src/tracked_state/storage.rs
@@ -8106,6 +8106,8 @@ pub(crate) async fn load_retained_commit_snapshots_for_schemas(
             schema_keys: schema_keys.to_vec(),
             row_pks: Vec::new(),
             file_ids: Vec::new(),
+            row_pk_lower: None,
+            row_pk_upper: None,
             include_tombstones: true,
             limit: None,
         };

--- a/packages/lix/src/tracked_state/tree.rs
+++ b/packages/lix/src/tracked_state/tree.rs
@@ -210,6 +210,17 @@ impl TrackedStateTree {
         if request.limit == Some(0) {
             return Ok(Vec::new());
         }
+        if !request.row_pks.is_empty()
+            && request.row_pks.iter().all(|row_pk| {
+                !crate::tracked_state::row_pk_satisfies_bounds(
+                    row_pk,
+                    request.row_pk_lower.as_ref(),
+                    request.row_pk_upper.as_ref(),
+                )
+            })
+        {
+            return Ok(Vec::new());
+        }
 
         let ranges = scan_ranges(request);
         let key_decode_hint = scan_key_decode_hint(request, &ranges);
@@ -2912,6 +2923,42 @@ mod tests {
         ));
 
         assert_eq!(storage_reads.load(Ordering::Relaxed), 1);
+    }
+
+    #[tokio::test]
+    async fn exact_candidates_outside_primary_key_bounds_do_zero_tree_reads() {
+        let bytes = encode_leaf_node(&[]);
+        let hash = hash_bytes(&bytes);
+        let storage_reads = Arc::new(AtomicUsize::new(0));
+        let store = StorageAdapterReadScope::new(CountingChunkRead {
+            hash,
+            bytes,
+            storage_reads: Arc::clone(&storage_reads),
+            corrupt_first_read: false,
+        });
+        let rows = TrackedStateTree::new()
+            .scan(
+                &store,
+                &TrackedStateRootId::new(hash),
+                &TrackedStateTreeScanRequest {
+                    schema_keys: vec!["schema".to_string()],
+                    file_ids: vec![NullableKeyFilter::Null],
+                    row_pks: vec![RowPk::single("a"), RowPk::single("b")],
+                    row_pk_lower: Some(crate::tracked_state::RowPkRangeBound {
+                        row_pk: RowPk::single("c"),
+                        inclusive: true,
+                    }),
+                    row_pk_upper: Some(crate::tracked_state::RowPkRangeBound {
+                        row_pk: RowPk::single("d"),
+                        inclusive: true,
+                    }),
+                    ..Default::default()
+                },
+            )
+            .await
+            .expect("empty exact/range intersection should short circuit");
+        assert!(rows.is_empty());
+        assert_eq!(storage_reads.load(Ordering::Relaxed), 0);
     }
 
     #[tokio::test]

--- a/packages/lix/src/tracked_state/tree.rs
+++ b/packages/lix/src/tracked_state/tree.rs
@@ -2574,6 +2574,13 @@ fn scan_ranges(request: &TrackedStateTreeScanRequest) -> Vec<EncodedScanRange> {
                     NullableKeyFilter::Any => unreachable!("filtered above"),
                 };
                 for row_pk in &request.row_pks {
+                    if !crate::tracked_state::row_pk_satisfies_bounds(
+                        row_pk,
+                        request.row_pk_lower.as_ref(),
+                        request.row_pk_upper.as_ref(),
+                    ) {
+                        continue;
+                    }
                     let key = TrackedStateKey {
                         schema_key: schema_key.clone(),
                         file_id: file_id.clone(),
@@ -2596,14 +2603,21 @@ fn scan_ranges(request: &TrackedStateTreeScanRequest) -> Vec<EncodedScanRange> {
         }
 
         for file_filter in &request.file_ids {
-            let prefix = match file_filter {
-                NullableKeyFilter::Null => encode_schema_file_prefix(schema_key, None),
-                NullableKeyFilter::Value(file_id) => {
-                    encode_schema_file_prefix(schema_key, Some(file_id))
-                }
+            let (prefix, file_id) = match file_filter {
+                NullableKeyFilter::Null => (encode_schema_file_prefix(schema_key, None), None),
+                NullableKeyFilter::Value(file_id) => (
+                    encode_schema_file_prefix(schema_key, Some(file_id)),
+                    Some(file_id.clone()),
+                ),
                 NullableKeyFilter::Any => unreachable!("handled above"),
             };
-            ranges.push(prefix_scan_range(prefix));
+            ranges.push(row_pk_scan_range(
+                schema_key,
+                file_id,
+                prefix,
+                request.row_pk_lower.as_ref(),
+                request.row_pk_upper.as_ref(),
+            ));
         }
     }
     ranges
@@ -2627,7 +2641,7 @@ fn scan_key_decode_hint<'a>(
     Some(ScanKeyDecodeHint {
         schema_key: request.schema_keys.first()?.as_str(),
         file_id,
-        prefix_len: ranges.first()?.start.len(),
+        prefix_len: encode_schema_file_prefix(request.schema_keys.first()?, file_id).len(),
     })
 }
 
@@ -2643,6 +2657,46 @@ fn exact_scan_range(key: Vec<u8>) -> EncodedScanRange {
         end: lexicographic_successor(&key),
         start: key,
     }
+}
+
+fn row_pk_scan_range(
+    schema_key: &str,
+    file_id: Option<String>,
+    prefix: Vec<u8>,
+    lower: Option<&crate::tracked_state::RowPkRangeBound>,
+    upper: Option<&crate::tracked_state::RowPkRangeBound>,
+) -> EncodedScanRange {
+    let start = lower.map_or_else(
+        || prefix.clone(),
+        |bound| {
+            let key = encode_key(&TrackedStateKey {
+                schema_key: schema_key.to_owned(),
+                file_id: file_id.clone(),
+                row_pk: bound.row_pk.clone(),
+            });
+            if bound.inclusive {
+                key
+            } else {
+                lexicographic_successor(&key).unwrap_or(key)
+            }
+        },
+    );
+    let end = upper.map_or_else(
+        || lexicographic_successor(&prefix),
+        |bound| {
+            let key = encode_key(&TrackedStateKey {
+                schema_key: schema_key.to_owned(),
+                file_id,
+                row_pk: bound.row_pk.clone(),
+            });
+            if bound.inclusive {
+                lexicographic_successor(&key)
+            } else {
+                Some(key)
+            }
+        },
+    );
+    EncodedScanRange { start, end }
 }
 
 fn lexicographic_successor(bytes: &[u8]) -> Option<Vec<u8>> {
@@ -2681,6 +2735,13 @@ fn key_matches_scan_filters(request: &TrackedStateTreeScanRequest, key: &Tracked
         return false;
     }
     if !request.row_pks.is_empty() && !request.row_pks.contains(&key.row_pk) {
+        return false;
+    }
+    if !crate::tracked_state::row_pk_satisfies_bounds(
+        &key.row_pk,
+        request.row_pk_lower.as_ref(),
+        request.row_pk_upper.as_ref(),
+    ) {
         return false;
     }
     if !request.file_ids.is_empty()
@@ -3577,6 +3638,39 @@ mod tests {
             Some("01920000-0000-7000-8000-0000000000a2")
         );
 
+        let bounded_exact_rows = tree
+            .scan(
+                &store,
+                &result.root_id,
+                &TrackedStateTreeScanRequest {
+                    schema_keys: vec!["schema-a".to_string()],
+                    row_pks: vec![RowPk::single("row-a"), RowPk::single("row-b")],
+                    file_ids: vec![NullableKeyFilter::Value(
+                        "01920000-0000-7000-8000-0000000000a2".to_string(),
+                    )],
+                    row_pk_lower: Some(crate::tracked_state::RowPkRangeBound {
+                        row_pk: RowPk::single("row-b"),
+                        inclusive: true,
+                    }),
+                    row_pk_upper: Some(crate::tracked_state::RowPkRangeBound {
+                        row_pk: RowPk::single("row-b"),
+                        inclusive: true,
+                    }),
+                    ..Default::default()
+                },
+            )
+            .await
+            .expect("exact candidates must intersect range bounds");
+        assert_eq!(bounded_exact_rows.len(), 1);
+        assert_eq!(
+            bounded_exact_rows[0]
+                .0
+                .row_pk
+                .as_single_string_owned()
+                .expect("identity"),
+            "row-b"
+        );
+
         // With no schema predicate there is no encoded scan range or trusted
         // prefix. This exercises the decoded-key filter path directly.
         let row_only_rows = tree
@@ -3674,6 +3768,79 @@ mod tests {
                 .map(|(key, _)| key.row_pk.as_single_string_owned().expect("identity"))
                 .collect::<Vec<_>>(),
             vec!["row-a", "row-c"]
+        );
+    }
+
+    #[tokio::test]
+    async fn scan_schema_file_primary_key_range_honors_open_closed_and_empty_bounds() {
+        let storage = StorageAdapter::new(Memory::new());
+        let tree = TrackedStateTree::new();
+        let file_id = "01920000-0000-7000-8000-0000000000a2";
+        let result = apply_mutations_for_test(
+            &tree,
+            &storage,
+            None,
+            ["row-a", "row-b", "row-c", "row-d"]
+                .into_iter()
+                .enumerate()
+                .map(|(index, row_pk)| {
+                    mutation_owned(
+                        key("schema-a", Some(file_id), row_pk),
+                        value(&format!("range-c{index}"), Some("{}")),
+                    )
+                })
+                .collect(),
+            None,
+        )
+        .await
+        .expect("range fixture should apply");
+        let store = storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("range read should open");
+        let request = |lower: (&str, bool), upper: (&str, bool)| {
+            TrackedStateTreeScanRequest {
+                schema_keys: vec!["schema-a".to_owned()],
+                file_ids: vec![NullableKeyFilter::Value(file_id.to_owned())],
+                row_pk_lower: Some(crate::tracked_state::RowPkRangeBound {
+                    row_pk: RowPk::single(lower.0),
+                    inclusive: lower.1,
+                }),
+                row_pk_upper: Some(crate::tracked_state::RowPkRangeBound {
+                    row_pk: RowPk::single(upper.0),
+                    inclusive: upper.1,
+                }),
+                ..Default::default()
+            }
+        };
+
+        let rows = tree
+            .scan(&store, &result.root_id, &request(("row-a", false), ("row-d", false)))
+            .await
+            .expect("open range should scan");
+        assert_eq!(
+            rows.into_iter()
+                .map(|(key, _)| key.row_pk.into_parts())
+                .collect::<Vec<_>>(),
+            vec![vec!["row-b"], vec!["row-c"]]
+        );
+
+        let rows = tree
+            .scan(&store, &result.root_id, &request(("row-b", true), ("row-c", true)))
+            .await
+            .expect("closed range should scan");
+        assert_eq!(
+            rows.into_iter()
+                .map(|(key, _)| key.row_pk.into_parts())
+                .collect::<Vec<_>>(),
+            vec![vec!["row-b"], vec!["row-c"]]
+        );
+
+        assert!(
+            tree.scan(&store, &result.root_id, &request(("row-d", true), ("row-a", true)))
+                .await
+                .expect("empty inverted range should not fail")
+                .is_empty()
         );
     }
 

--- a/packages/lix/src/tracked_state/tree.rs
+++ b/packages/lix/src/tracked_state/tree.rs
@@ -192,16 +192,44 @@ impl TrackedStateTree {
                     return Ok(leaf.entry_owned(low).map(|entry| entry.key));
                 }
                 DecodedNode::Internal(internal) => {
-                    let Some(child) = internal
-                        .children()
-                        .iter()
+                    let children = internal.into_children();
+                    for child in &children {
+                        self.authenticate_subtree_right_edge(store, child).await?;
+                    }
+                    let Some(child) = children
+                        .into_iter()
                         .find(|child| child.last_key.as_ref() >= lower)
-                        .cloned()
                     else {
                         return Ok(None);
                     };
                     current = child.child_hash;
                     expected_summary = Some(child);
+                }
+            }
+        }
+    }
+
+    async fn authenticate_subtree_right_edge(
+        &self,
+        store: &(impl StorageAdapterRead + ?Sized),
+        summary: &ChildSummary,
+    ) -> Result<(), LixError> {
+        let mut current = summary.child_hash;
+        let mut expected = summary.clone();
+        loop {
+            let node = self.load_node(store, &current).await?;
+            validate_decoded_node_summary(&node, &expected)?;
+            match node {
+                DecodedNode::Leaf(_) => return Ok(()),
+                DecodedNode::Internal(internal) => {
+                    let Some(child) = internal.children().last().cloned() else {
+                        return Err(LixError::new(
+                            LixError::CODE_STORAGE_ERROR,
+                            "tracked-state internal node has no right edge",
+                        ));
+                    };
+                    current = child.child_hash;
+                    expected = child;
                 }
             }
         }
@@ -2941,7 +2969,7 @@ mod tests {
     use crate::tracked_state::codec::{encode_value, hash_bytes};
 
     #[test]
-    fn schema_inventory_rejects_parent_child_summary_substitution() {
+    fn schema_inventory_rejects_too_low_routing_boundary() {
         let key = encode_key(&TrackedStateKey {
             schema_key: "private_schema".to_string(),
             file_id: Some("file-a".to_string()),
@@ -2956,8 +2984,8 @@ mod tests {
         let error = validate_decoded_node_summary(
             &node,
             &ChildSummary {
-                first_key: Bytes::from_static(b"forged-first"),
-                last_key: Bytes::from(key),
+                first_key: Bytes::from(key),
+                last_key: Bytes::from_static(b"forged-too-low"),
                 child_hash: hash_bytes(&bytes),
                 subtree_count: 1,
             },

--- a/packages/lix/src/tracked_state/tree.rs
+++ b/packages/lix/src/tracked_state/tree.rs
@@ -122,6 +122,84 @@ impl TrackedStateTree {
         storage::load_root(store, commit_id).await
     }
 
+    /// Returns the distinct schema identities that are physically present in
+    /// this authenticated root. Each schema run is discovered with one
+    /// lower-bound descent, so callers can plan schema/file-bounded work
+    /// without trusting the public registration catalog or materializing the
+    /// full tree.
+    pub(crate) async fn distinct_schema_keys(
+        &self,
+        store: &(impl StorageAdapterRead + ?Sized),
+        root_id: &TrackedStateRootId,
+    ) -> Result<Vec<String>, LixError> {
+        let mut schema_keys = Vec::new();
+        let mut lower = Vec::new();
+        while let Some(encoded_key) = self
+            .first_key_at_or_after(store, root_id, &lower)
+            .await?
+        {
+            let key = decode_key(&encoded_key)?;
+            let schema_key = key.schema_key;
+            let Some(next_lower) =
+                lexicographic_successor(&encode_schema_key_prefix(&schema_key))
+            else {
+                schema_keys.push(schema_key);
+                break;
+            };
+            if next_lower <= lower {
+                return Err(LixError::new(
+                    LixError::CODE_STORAGE_ERROR,
+                    "tracked-state schema inventory did not advance",
+                ));
+            }
+            schema_keys.push(schema_key);
+            lower = next_lower;
+        }
+        Ok(schema_keys)
+    }
+
+    async fn first_key_at_or_after(
+        &self,
+        store: &(impl StorageAdapterRead + ?Sized),
+        root_id: &TrackedStateRootId,
+        lower: &[u8],
+    ) -> Result<Option<Bytes>, LixError> {
+        let mut current = *root_id.as_bytes();
+        loop {
+            match self.load_node(store, &current).await? {
+                DecodedNode::Leaf(leaf) => {
+                    let mut low = 0usize;
+                    let mut high = leaf.len();
+                    while low < high {
+                        let mid = low + (high - low) / 2;
+                        let key = leaf.key(mid)?.ok_or_else(|| {
+                            LixError::new(
+                                LixError::CODE_STORAGE_ERROR,
+                                "tracked-state leaf key disappeared during lower-bound seek",
+                            )
+                        })?;
+                        if key < lower {
+                            low = mid + 1;
+                        } else {
+                            high = mid;
+                        }
+                    }
+                    return Ok(leaf.entry_owned(low).map(|entry| entry.key));
+                }
+                DecodedNode::Internal(internal) => {
+                    let Some(child) = internal
+                        .children()
+                        .iter()
+                        .find(|child| child.last_key.as_ref() >= lower)
+                    else {
+                        return Ok(None);
+                    };
+                    current = child.child_hash;
+                }
+            }
+        }
+    }
+
     #[cfg(test)]
     pub(crate) async fn get(
         &self,

--- a/packages/lix/src/tracked_state/tree.rs
+++ b/packages/lix/src/tracked_state/tree.rs
@@ -165,8 +165,13 @@ impl TrackedStateTree {
         lower: &[u8],
     ) -> Result<Option<Bytes>, LixError> {
         let mut current = *root_id.as_bytes();
+        let mut expected_summary = None;
         loop {
-            match self.load_node(store, &current).await? {
+            let node = self.load_node(store, &current).await?;
+            if let Some(expected) = expected_summary.take() {
+                validate_decoded_node_summary(&node, &expected)?;
+            }
+            match node {
                 DecodedNode::Leaf(leaf) => {
                     let mut low = 0usize;
                     let mut high = leaf.len();
@@ -191,10 +196,12 @@ impl TrackedStateTree {
                         .children()
                         .iter()
                         .find(|child| child.last_key.as_ref() >= lower)
+                        .cloned()
                     else {
                         return Ok(None);
                     };
                     current = child.child_hash;
+                    expected_summary = Some(child);
                 }
             }
         }
@@ -2602,6 +2609,46 @@ fn decoded_leaf_summary(
     }
 }
 
+fn validate_decoded_node_summary(
+    node: &DecodedNode,
+    expected: &ChildSummary,
+) -> Result<(), LixError> {
+    let (first_key, last_key, subtree_count) = match node {
+        DecodedNode::Leaf(leaf) => (
+            leaf.first_key().unwrap_or_default(),
+            leaf.last_key().unwrap_or_default(),
+            leaf.len() as u64,
+        ),
+        DecodedNode::Internal(internal) => {
+            let children = internal.children();
+            let first_key = children.first().map(|child| child.first_key.as_ref());
+            let last_key = children.last().map(|child| child.last_key.as_ref());
+            let subtree_count = children
+                .iter()
+                .try_fold(0_u64, |total, child| total.checked_add(child.subtree_count));
+            let (Some(first_key), Some(last_key), Some(subtree_count)) =
+                (first_key, last_key, subtree_count)
+            else {
+                return Err(LixError::new(
+                    LixError::CODE_STORAGE_ERROR,
+                    "tracked-state internal child summary is invalid",
+                ));
+            };
+            (first_key, last_key, subtree_count)
+        }
+    };
+    if first_key != expected.first_key.as_ref()
+        || last_key != expected.last_key.as_ref()
+        || subtree_count != expected.subtree_count
+    {
+        return Err(LixError::new(
+            LixError::CODE_STORAGE_ERROR,
+            "tracked-state child summary does not match authenticated child contents",
+        ));
+    }
+    Ok(())
+}
+
 #[cfg(test)]
 fn internal_summary(
     hash: [u8; TRACKED_STATE_HASH_BYTES],
@@ -2892,6 +2939,32 @@ mod tests {
     use crate::storage_adapter::{Memory, StorageReadOptions, StorageWriteOptions};
     use crate::storage_adapter::{StorageAdapter, StorageAdapterReadScope};
     use crate::tracked_state::codec::{encode_value, hash_bytes};
+
+    #[test]
+    fn schema_inventory_rejects_parent_child_summary_substitution() {
+        let key = encode_key(&TrackedStateKey {
+            schema_key: "private_schema".to_string(),
+            file_id: Some("file-a".to_string()),
+            row_pk: RowPk::single("row-a"),
+        });
+        let value = encode_value(&value("change-a", Some("present")));
+        let bytes = Bytes::from(encode_leaf_node(&[EncodedLeafEntry {
+            key: Bytes::from(key.clone()),
+            value: Bytes::from(value),
+        }]));
+        let node = decode_node(&bytes).expect("fixture leaf should decode");
+        let error = validate_decoded_node_summary(
+            &node,
+            &ChildSummary {
+                first_key: Bytes::from_static(b"forged-first"),
+                last_key: Bytes::from(key),
+                child_hash: hash_bytes(&bytes),
+                subtree_count: 1,
+            },
+        )
+        .expect_err("hash-valid child with substituted boundary must fail closed");
+        assert!(error.message.contains("child summary does not match"));
+    }
 
     struct CountingChunkRead {
         hash: [u8; TRACKED_STATE_HASH_BYTES],

--- a/packages/lix/src/tracked_state/types.rs
+++ b/packages/lix/src/tracked_state/types.rs
@@ -505,9 +505,43 @@ pub(crate) struct TrackedStateFilter {
     #[serde(default)]
     pub(crate) row_pks: Vec<RowPk>,
     #[serde(default)]
+    pub(crate) row_pk_lower: Option<RowPkRangeBound>,
+    #[serde(default)]
+    pub(crate) row_pk_upper: Option<RowPkRangeBound>,
+    #[serde(default)]
     pub(crate) file_ids: Vec<NullableKeyFilter<String>>,
     #[serde(default)]
     pub(crate) include_tombstones: bool,
+}
+
+/// One canonical bound over the typed primary-key ordering.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub(crate) struct RowPkRangeBound {
+    pub(crate) row_pk: RowPk,
+    pub(crate) inclusive: bool,
+}
+
+impl TrackedStateFilter {
+    pub(crate) fn matches_row_pk(&self, row_pk: &RowPk) -> bool {
+        (self.row_pks.is_empty() || self.row_pks.contains(row_pk))
+            && row_pk_satisfies_bounds(
+                row_pk,
+                self.row_pk_lower.as_ref(),
+                self.row_pk_upper.as_ref(),
+            )
+    }
+}
+
+pub(crate) fn row_pk_satisfies_bounds(
+    row_pk: &RowPk,
+    lower: Option<&RowPkRangeBound>,
+    upper: Option<&RowPkRangeBound>,
+) -> bool {
+    lower.is_none_or(|bound| {
+        row_pk > &bound.row_pk || (bound.inclusive && row_pk == &bound.row_pk)
+    }) && upper.is_none_or(|bound| {
+        row_pk < &bound.row_pk || (bound.inclusive && row_pk == &bound.row_pk)
+    })
 }
 
 /// Requested property set for a tracked-state scan.
@@ -591,6 +625,8 @@ impl TrackedStateMutationBatch {
 pub(crate) struct TrackedStateTreeScanRequest {
     pub(crate) schema_keys: Vec<String>,
     pub(crate) row_pks: Vec<RowPk>,
+    pub(crate) row_pk_lower: Option<RowPkRangeBound>,
+    pub(crate) row_pk_upper: Option<RowPkRangeBound>,
     pub(crate) file_ids: Vec<NullableKeyFilter<String>>,
     pub(crate) include_tombstones: bool,
     pub(crate) limit: Option<usize>,
@@ -601,6 +637,8 @@ impl Default for TrackedStateTreeScanRequest {
         Self {
             schema_keys: Vec::new(),
             row_pks: Vec::new(),
+            row_pk_lower: None,
+            row_pk_upper: None,
             file_ids: Vec::new(),
             include_tombstones: true,
             limit: None,
@@ -641,6 +679,13 @@ impl TrackedStateTreeScanRequest {
             return false;
         }
         if !self.row_pks.is_empty() && !self.row_pks.contains(key.row_pk) {
+            return false;
+        }
+        if !row_pk_satisfies_bounds(
+            key.row_pk,
+            self.row_pk_lower.as_ref(),
+            self.row_pk_upper.as_ref(),
+        ) {
             return false;
         }
         if !self.file_ids.is_empty()

--- a/packages/lix/src/transaction/commit.rs
+++ b/packages/lix/src/transaction/commit.rs
@@ -26,7 +26,7 @@ use crate::functions::FunctionContext;
 use crate::hot_state::{
     HotStateContext, HotStateRowRequest, HotTrackedSnapshot, MaterializedHotStateRow,
     TrackedHeadContext, TrackedWorkingDiffEpoch, WorkingDiffIndexCoverage,
-    stage_delete_tracked_working_diff_epoch, stage_tracked_working_diff_epoch,
+    stage_tracked_working_diff_epoch,
 };
 use crate::json_store::{
     JSON_INLINE_MAX_BYTES, JsonRef, JsonStoreContext, JsonWritePlacementRef, NormalizedJsonRef,
@@ -763,6 +763,7 @@ pub(crate) async fn commit_prepared_writes_with_parent_heads(
         &row_columnar_write_sets,
         &engine_rows,
         &row_index.tracked_row_indices_by_commit,
+        &row_index.tracked_delete_indices_by_commit,
         &tracked_roots,
         &staged_commits,
         &selected_change_payloads,
@@ -794,11 +795,9 @@ pub(crate) async fn commit_prepared_writes_with_parent_heads(
         );
     }
     stage_checkpoint_working_diff_epochs(
-        read,
         &mut writes,
         &prepared_writes.checkpoint_publications,
         &staged_hot_heads.controls,
-        &branch_control_observations,
     )
     .await?;
     let mut root_backed_branch_publications = BTreeSet::new();
@@ -1078,10 +1077,12 @@ fn json_payloads_from_state_row(
 
 struct PreparedRowIndex {
     tracked_row_indices_by_commit: BTreeMap<CommitId, Vec<RowIndex>>,
+    tracked_delete_indices_by_commit: BTreeMap<CommitId, Vec<RowIndex>>,
 }
 
 fn index_prepared_rows(rows: &PreparedStateBatch) -> Result<PreparedRowIndex, LixError> {
     let mut tracked_row_indices_by_commit = BTreeMap::<CommitId, Vec<RowIndex>>::new();
+    let mut tracked_delete_indices_by_commit = BTreeMap::<CommitId, Vec<RowIndex>>::new();
 
     for (row_index, row) in rows.iter().enumerate() {
         if row.untracked {
@@ -1097,10 +1098,17 @@ fn index_prepared_rows(rows: &PreparedStateBatch) -> Result<PreparedRowIndex, Li
             .entry(*commit_id)
             .or_default()
             .push(row_index);
+        if row.snapshot.is_none() {
+            tracked_delete_indices_by_commit
+                .entry(*commit_id)
+                .or_default()
+                .push(row_index);
+        }
     }
 
     Ok(PreparedRowIndex {
         tracked_row_indices_by_commit,
+        tracked_delete_indices_by_commit,
     })
 }
 
@@ -3655,6 +3663,7 @@ async fn stage_tracked_head(
     row_columnar_write_sets: &crate::hot_state::RowColumnarWriteSets,
     engine_rows: &[EngineCurrentRow],
     tracked_row_indices_by_commit: &BTreeMap<CommitId, Vec<RowIndex>>,
+    tracked_delete_indices_by_commit: &BTreeMap<CommitId, Vec<RowIndex>>,
     tracked_roots: &[PendingTrackedRoot],
     staged_commits: &BTreeMap<CommitId, StagedChangelogCommit>,
     selected_change_payloads: &HashMap<
@@ -3735,9 +3744,130 @@ async fn stage_tracked_head(
             .get(&root.commit_id)
             .map(Vec::as_slice)
             .unwrap_or_default();
+        let checkpoint_commit_id = checkpoint_epochs.get(&root.branch_id).copied();
+        let is_checkpoint_publication = checkpoint_commit_id == Some(root.commit_id);
         let certified_columnar_parts = mutation_inventories
             .get(&root.commit_id)
             .and_then(|inventory| inventory.columnar_parts.as_ref());
+
+        // A checkpoint changes the authenticated epoch/control, not current
+        // row values. Take the O(deletes) route before constructing ordinary
+        // tracked/untracked delta cohorts or selected-row materializations.
+        // The deletion ordinals were built while their typed owners were
+        // produced, so this branch never scans non-deleted members.
+        if is_checkpoint_publication && !tracked_snapshots.contains_key(&root.commit_id) {
+            let parent_generation = parent_control
+                .map(|control| control.tracked_generation)
+                .ok_or_else(|| {
+                    LixError::new(
+                        LixError::CODE_INTERNAL_ERROR,
+                        format!(
+                            "checkpoint hot publication for '{}' lacks a complete parent generation",
+                            root.commit_id
+                        ),
+                    )
+                })?;
+            let mut writer = tracked_head.writer(read, writes);
+            if let Some(schema_keys) = transaction_global_schema_keys.as_ref() {
+                writer = writer.with_transaction_global_schema_keys(schema_keys);
+            }
+            if writer
+                .can_rotate_checkpoint_epoch(&root.branch_id, parent_generation)
+                .await?
+            {
+                let selected_deleted_rows = staged
+                    .selected_change_batches
+                    .iter()
+                    .flat_map(StagedCommitChangeBatch::deleted_iter)
+                    .map(|change_ref| {
+                        let key = selected_change_key(change_ref);
+                        lifecycle_selected_tracked_row(
+                            change_ref,
+                            root.commit_id,
+                            None,
+                            selected_change_payloads.get(&key),
+                        )
+                    })
+                    .collect::<Result<Vec<_>, _>>()?;
+                let selected_snapshots = selected_deleted_rows
+                    .iter()
+                    .map(|row| {
+                        row.snapshot_content.as_deref().map_or(
+                            crate::json_store::JsonSlot::None,
+                            crate::json_store::JsonSlot::from_json,
+                        )
+                    })
+                    .collect::<Vec<_>>();
+                let selected_metadata = selected_deleted_rows
+                    .iter()
+                    .map(|row| {
+                        row.metadata.as_deref().map_or(
+                            crate::json_store::JsonSlot::None,
+                            crate::json_store::JsonSlot::from_json,
+                        )
+                    })
+                    .collect::<Vec<_>>();
+                let mut deleted_deltas = tracked_delete_indices_by_commit
+                    .get(&root.commit_id)
+                    .into_iter()
+                    .flatten()
+                    .map(|&row_index| current_state_delta_from_state_row(state_rows.row(row_index)))
+                    .collect::<Result<Vec<_>, _>>()?;
+                deleted_deltas.extend(
+                    staged
+                        .selected_change_batches
+                        .iter()
+                        .flat_map(StagedCommitChangeBatch::deleted_iter)
+                        .zip(selected_deleted_rows.iter())
+                        .zip(selected_snapshots.iter().zip(&selected_metadata))
+                        .map(|((change_ref, row), (snapshot, metadata))| {
+                            crate::hot_state::CurrentStateDeltaRef {
+                                schema_key: &row.schema_key,
+                                file_id: row.file_id.as_deref(),
+                                row_pk: &row.row_pk,
+                                change_id: Some(change_ref.change_id),
+                                commit_id: Some(root.commit_id),
+                                untracked: false,
+                                deleted: true,
+                                created_at: change_ref.created_at,
+                                updated_at: change_ref.updated_at,
+                                snapshot: snapshot.as_ref_slot(),
+                                metadata: metadata.as_ref_slot(),
+                                columnar_base_coordinate: None,
+                            }
+                        }),
+                );
+                let mut coverage = WorkingDiffIndexCoverage::default();
+                let generation = if deleted_deltas.is_empty() {
+                    parent_generation
+                } else {
+                    writer
+                        .stage_checkpoint_current_state(
+                            &root.branch_id,
+                            parent_generation,
+                            root.commit_id,
+                            &deleted_deltas,
+                            &BTreeSet::new(),
+                            checkpoint_commit_id
+                                .expect("checkpoint publication has an epoch commit id"),
+                            &mut coverage,
+                        )
+                        .instrument(tracing::debug_span!(
+                            target: "lix_perf",
+                            "lix.perf.materialization.tracked_head.stage_checkpoint_tombstones"
+                        ))
+                        .await?
+                };
+                let control = normal_branch_head_control(
+                    root,
+                    parent_control,
+                    generation,
+                    checkpoint_commit_id,
+                )?;
+                insert_direct_branch_control(&mut controls, &root.branch_id, control)?;
+                continue;
+            }
+        }
         let selected_materialization = if !staged.selected_change_batches.is_empty()
             && !tracked_snapshots.contains_key(&root.commit_id)
         {
@@ -3793,8 +3923,6 @@ async fn stage_tracked_head(
                 .filter(|row| row.branch_id == root.branch_id)
                 .map(current_state_delta_from_engine_row),
         );
-        let checkpoint_commit_id = checkpoint_epochs.get(&root.branch_id).copied();
-        let is_checkpoint_publication = checkpoint_commit_id == Some(root.commit_id);
         let can_publish_ordered_packed_current_base = ordered_addressable_commits
             .contains(&root.commit_id)
             && !is_checkpoint_publication
@@ -4460,8 +4588,9 @@ async fn stage_tracked_head(
             "packed current-base route decision"
         );
         let generation = if is_checkpoint_publication {
-            let checkpoint_commit_id =
-                checkpoint_commit_id.expect("checkpoint publication has an epoch commit id");
+            // Reaching this point means an immutable packed base prevented
+            // the O(deletes) epoch-rotation route above. Materialize it once;
+            // retirement makes later checkpoints eligible for lazy rotation.
             coverage = WorkingDiffIndexCoverage::default();
             writer
                 .stage_checkpoint_current_state(
@@ -4470,7 +4599,7 @@ async fn stage_tracked_head(
                     root.commit_id,
                     &deltas,
                     &owned_absence_guards(&absence_guards),
-                    checkpoint_commit_id,
+                    checkpoint_commit_id.expect("checkpoint publication has an epoch commit id"),
                     &mut coverage,
                 )
                 .instrument(tracing::debug_span!(
@@ -4907,11 +5036,9 @@ fn selected_tracked_ref_untracked_collision_error(
 /// hot generation. Unchanged rows were already clean, so rotating to an empty
 /// sparse dirty-key index starts the next epoch without a full-state rewrite.
 async fn stage_checkpoint_working_diff_epochs(
-    read: &(impl StorageAdapterRead + ?Sized),
     writes: &mut StorageWriteSet,
     publications: &[crate::gc::CheckpointPublication],
     controls: &BTreeMap<String, BranchHeadControl>,
-    observations: &BTreeMap<String, BranchHeadControlObservation>,
 ) -> Result<(), LixError> {
     let mut branches = BTreeSet::new();
     for publication in publications {
@@ -4951,22 +5078,9 @@ async fn stage_checkpoint_working_diff_epochs(
         if control.head_commit_id != recovery.checkpoint_commit_id {
             continue;
         }
-        if let Some(previous) = observations
-            .get(&recovery.branch_id)
-            .and_then(|observation| observation.control)
-            && let Some(previous_checkpoint) = previous.working_diff_checkpoint_commit_id
-            && (previous_checkpoint != recovery.checkpoint_commit_id
-                || previous.tracked_generation != control.tracked_generation)
-        {
-            stage_delete_tracked_working_diff_epoch(
-                read,
-                writes,
-                &recovery.branch_id,
-                previous_checkpoint,
-                previous.tracked_generation,
-            )
-            .await?;
-        }
+        // The previous sparse index becomes unreachable when this marker and
+        // branch control commit. Repository GC reclaims stale epoch prefixes;
+        // scanning them here would make checkpoint publication O(D).
         stage_tracked_working_diff_epoch(
             writes,
             &recovery.branch_id,
@@ -6881,14 +6995,9 @@ mod tests {
     #[tokio::test]
     async fn real_checkpoint_without_complete_hot_control_still_fails() {
         let storage = StorageAdapter::new(Memory::new());
-        let read = storage
-            .begin_read(StorageReadOptions::default())
-            .await
-            .expect("checkpoint validation read should open");
         let mut writes = storage.new_write_set();
         let checkpoint = commit_id("missing-hot-checkpoint");
         let error = stage_checkpoint_working_diff_epochs(
-            &read,
             &mut writes,
             &[crate::gc::CheckpointPublication {
                 recovery_ref: crate::gc::CheckpointRecoveryRef {
@@ -6899,7 +7008,6 @@ mod tests {
                 },
                 gc_state: crate::gc::CheckpointGcState::default(),
             }],
-            &BTreeMap::new(),
             &BTreeMap::new(),
         )
         .await

--- a/packages/lix/src/transaction/staged_commit_changes.rs
+++ b/packages/lix/src/transaction/staged_commit_changes.rs
@@ -90,6 +90,10 @@ struct StagedCommitChangeColumns {
     deleted: Vec<bool>,
     created_at: Vec<LixTimestamp>,
     updated_at: Vec<LixTimestamp>,
+    /// Logical row ordinals whose selected change is a deletion. Built once
+    /// while the typed columns are produced so checkpoint publication can
+    /// visit O(deletes) rather than rescan every selected member.
+    deleted_rows: Vec<u32>,
 }
 
 #[derive(Debug, Clone)]
@@ -129,6 +133,7 @@ impl StagedCommitChangeBatchBuilder {
                 deleted: Vec::with_capacity(row_count),
                 created_at: Vec::with_capacity(row_count),
                 updated_at: Vec::with_capacity(row_count),
+                deleted_rows: Vec::new(),
             },
         }
     }
@@ -142,6 +147,12 @@ impl StagedCommitChangeBatchBuilder {
         created_at: LixTimestamp,
         updated_at: LixTimestamp,
     ) {
+        if deleted {
+            self.columns.deleted_rows.push(
+                u32::try_from(self.columns.identities.len())
+                    .expect("staged commit change batch exceeds u32 rows"),
+            );
+        }
         self.columns.identities.push(identity);
         self.columns.source_commit_ids.push(source_commit_id);
         self.columns.change_ids.push(change_id);
@@ -202,6 +213,32 @@ impl StagedCommitChangeBatch {
         (0..self.len()).map(|row_index| self.row(row_index))
     }
 
+    /// Selected deletion members without scanning non-deleted rows.
+    pub(crate) fn deleted_iter(
+        &self,
+    ) -> impl Iterator<Item = StagedCommitChangeRef<'_>> + '_ {
+        self.columns
+            .deleted_rows
+            .iter()
+            .copied()
+            .filter(move |&column_index| {
+                self.selection
+                    .as_ref()
+                    .is_none_or(|selection| selection.binary_search(&column_index).is_ok())
+            })
+            .map(move |column_index| {
+                let logical_index = self.selection.as_ref().map_or(column_index, |selection| {
+                    u32::try_from(
+                        selection
+                            .binary_search(&column_index)
+                            .expect("filtered deleted row belongs to selection"),
+                    )
+                    .expect("selected commit change batch exceeds u32 rows")
+                });
+                self.row(logical_index as usize)
+            })
+    }
+
     fn row(&self, row_index: usize) -> StagedCommitChangeRef<'_> {
         let column_index = self
             .selection
@@ -246,6 +283,7 @@ impl StagedCommitChangeBatch {
             + usize::from(!self.columns.deleted.is_empty())
             + usize::from(!self.columns.created_at.is_empty())
             + usize::from(!self.columns.updated_at.is_empty())
+            + usize::from(!self.columns.deleted_rows.is_empty())
             + usize::from(self.selection.is_some())
     }
 }

--- a/packages/lix/src/transaction/staging.rs
+++ b/packages/lix/src/transaction/staging.rs
@@ -3492,7 +3492,9 @@ impl PreparedStateRowOverlay {
         }
 
         let mut rows = MaterializedHotStateBatchBuilder::with_capacity(0);
-        append_matching_ordered_mutations(&mut rows, &self.staged_writes, request)?;
+        if append_matching_ordered_mutations(&mut rows, &self.staged_writes, request)? {
+            return Ok(rows.finish());
+        }
 
         if self
             .staged_writes
@@ -3800,7 +3802,7 @@ fn append_matching_ordered_mutations(
     output: &mut MaterializedHotStateBatchBuilder,
     staged_writes: &TransactionWriteBuffer,
     request: &HotStateScanRequest,
-) -> Result<(), LixError> {
+) -> Result<bool, LixError> {
     let ordered = staged_writes.ordered_mutations.lock().map_err(|_| {
         LixError::new(
             LixError::CODE_INTERNAL_ERROR,
@@ -3808,7 +3810,7 @@ fn append_matching_ordered_mutations(
         )
     })?;
     let Some(journal) = ordered.as_ref() else {
-        return Ok(());
+        return Ok(false);
     };
     if request.filter.untracked == Some(true)
         || (!request.filter.schema_keys.is_empty()
@@ -3825,15 +3827,49 @@ fn append_matching_ordered_mutations(
                 .any(|branch_id| branch_id == journal.branch_id()))
         || !nullable_key_matches_filters(None, &request.filter.file_ids)
     {
-        return Ok(());
+        return Ok(true);
     }
     if request.filter.row_pks.is_empty() {
+        let lower = match request.filter.row_pk_lower.as_ref() {
+            Some(bound) => match bound.row_pk.as_single_string() {
+                Ok(value) => Some((value, bound.inclusive)),
+                Err(_) => return Ok(true),
+            },
+            None => None,
+        };
+        let upper = match request.filter.row_pk_upper.as_ref() {
+            Some(bound) => match bound.row_pk.as_single_string() {
+                Ok(value) => Some((value, bound.inclusive)),
+                Err(_) => return Ok(true),
+            },
+            None => None,
+        };
         for chunk in journal.chunks.iter() {
-            for row_index in 0..chunk.len() {
+            let start = lower.map_or(0, |(bound, inclusive)| {
+                chunk.identity_offsets.partition_point(|&(start, end)| {
+                    let identity = chunk
+                        .identity_arena
+                        .as_str()
+                        .get(start as usize..end as usize)
+                        .expect("validated immutable mutation identity UTF-8");
+                    identity < bound || (!inclusive && identity == bound)
+                })
+            });
+            let end = upper.map_or(chunk.len(), |(bound, inclusive)| {
+                chunk.identity_offsets.partition_point(|&(start, end)| {
+                    let identity = chunk
+                        .identity_arena
+                        .as_str()
+                        .get(start as usize..end as usize)
+                        .expect("validated immutable mutation identity UTF-8");
+                    identity < bound || (inclusive && identity == bound)
+                })
+            });
+            for row_index in start..end.max(start) {
                 push_ordered_mutation_materialized(output, journal, chunk, row_index)?;
             }
         }
-        return Ok(());
+        return Ok(true);
     }
 
     // Preserve the journal's identity order while routing each requested key
@@ -3843,6 +3879,9 @@ fn append_matching_ordered_mutations(
     requested.sort_unstable();
     requested.dedup();
     for row_pk in requested {
+        if !request.filter.matches_row_pk(row_pk) {
+            continue;
+        }
         let Some((chunk, row_index)) = ordered_mutation_journal_row(
             journal,
             journal.branch_id(),
@@ -3854,7 +3893,7 @@ fn append_matching_ordered_mutations(
         };
         push_ordered_mutation_materialized(output, journal, chunk, row_index)?;
     }
-    Ok(())
+    Ok(true)
 }
 
 fn load_ordered_mutation_exact_batch(
@@ -4328,10 +4367,7 @@ fn staged_row_identity_matches_scan(
     {
         return false;
     }
-    if !candidate_index_matched_schema_and_row
-        && !request.filter.row_pks.is_empty()
-        && !request.filter.row_pks.contains(row.row_pk)
-    {
+    if !request.filter.matches_row_pk(row.row_pk) {
         return false;
     }
     if !staged_branch_matches_scan(row.branch_id, request) {
@@ -4422,6 +4458,100 @@ mod tests {
         assert_eq!(chunk.identity(0), "a");
         assert_eq!(chunk.identity(1), "b");
         assert_eq!(chunk.identity_arena.len(), 2);
+    }
+
+    #[test]
+    fn immutable_journal_overlay_applies_primary_key_bounds_before_materialization() {
+        let staged_writes = test_staged_writes();
+        let snapshots = ["a", "b", "c", "d"]
+            .into_iter()
+            .map(|identity| format!(r#"{{"id":"{identity}"}}"#))
+            .collect::<Vec<_>>();
+        let snapshot_arena = snapshots.concat();
+        let mut cursor = 0_usize;
+        let snapshot_offsets = snapshots
+            .iter()
+            .map(|snapshot| {
+                let start = cursor;
+                cursor += snapshot.len();
+                (start, cursor)
+            })
+            .collect();
+        let chunk = ImmutableMutationJournalChunk::try_new_single_string_identities(
+            SchemaPlanId::for_test(0),
+            "schema".into(),
+            "branch".into(),
+            None,
+            b"abcd".to_vec(),
+            vec![(0, 1), (1, 2), (2, 3), (3, 4)],
+            snapshot_arena.into_bytes(),
+            snapshot_offsets,
+            None,
+            LixTimestamp::expect_parse("timestamp", "2026-01-01T00:00:00Z"),
+        )
+        .expect("bounded overlay chunk");
+        assert!(matches!(
+            staged_writes
+                .stage_immutable_mutation_chunk(chunk)
+                .expect("immutable chunk should stage"),
+            ImmutableMutationChunkStage::Staged
+        ));
+        let overlay = staged_writes
+            .staging_overlay()
+            .expect("bounded immutable overlay");
+        let request = |lower: (&str, bool), upper: (&str, bool)| HotStateScanRequest {
+            filter: HotStateFilter {
+                branch_ids: vec!["branch".into()],
+                schema_keys: vec!["schema".into()],
+                file_ids: vec![NullableKeyFilter::Null],
+                row_pk_lower: Some(crate::tracked_state::RowPkRangeBound {
+                    row_pk: RowPk::single(lower.0),
+                    inclusive: lower.1,
+                }),
+                row_pk_upper: Some(crate::tracked_state::RowPkRangeBound {
+                    row_pk: RowPk::single(upper.0),
+                    inclusive: upper.1,
+                }),
+                ..HotStateFilter::default()
+            },
+            ..HotStateScanRequest::default()
+        };
+
+        let rows = overlay
+            .scan(&request(("a", false), ("d", false)))
+            .expect("open staged range");
+        assert_eq!(
+            rows.into_iter()
+                .map(|row| row.row_pk.into_parts())
+                .collect::<Vec<_>>(),
+            vec![vec!["b"], vec!["c"]]
+        );
+        let mut exact_bounded = request(("b", true), ("c", true));
+        exact_bounded.filter.row_pks = vec![
+            RowPk::single("a"),
+            RowPk::single("b"),
+            RowPk::single("d"),
+        ];
+        let exact_rows = overlay
+            .scan(&exact_bounded)
+            .expect("exact staged candidates must intersect range bounds");
+        assert_eq!(
+            exact_rows
+                .into_iter()
+                .map(|row| row.row_pk.into_parts())
+                .collect::<Vec<_>>(),
+            vec![vec!["b"]]
+        );
+        assert!(
+            overlay
+                .scan(&request(("d", true), ("a", true)))
+                .expect("inverted staged range")
+                .is_empty()
+        );
+        assert!(
+            !staged_writes.uses_identity_index_for_tests(),
+            "bounded reads must retain the compact ordered journal"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## What changed

Parse each authenticated row-history snapshot once per Arrow record batch and borrow projected values from that parsed batch-owned snapshot. Tombstone primary-key reconstruction remains owned, and public JSON/string conversion remains at the final Arrow boundary.

## Why

The prior provider reparsed the same whole-row history JSON independently for every projected column and cloned each selected value. This made public history projection scale with `rows × projected columns × parse cost`.

## Measured impact

Paired five-sample, setup-excluded corrected 2N history projection versus exact parent `d2c634b2`:

- RocksDB 1K: 5.318 → 3.655 ms p50 (-31.3%)
- RocksDB 10K: 38.780 → 33.370 ms p50 (-13.9%)
- SlateDB 1K: 4.496 → 3.833 ms p50 (-14.8%)
- SlateDB 10K: 40.207 → 34.606 ms p50 (-13.9%)

Five-sample p95/max improved 27.2%, 18.7%, 11.7%, and 10.0%, respectively. The unchanged 2N harness does not expose operation-local allocator counters for this route, so no allocation ratio is claimed there.

## Parsed-Markdown public replay

Replayed the independently approved, byte-identical exact-d2c oracle from `f03456b064658e1303b5f54bda2896f1bb76489c`: 3 warmups + 10 measured runs on each adapter. All fixture, rendered-file, exact/range/full-row, 17-file batch, history, diff, and cold-reopen digests match the baseline exactly.

| Operation | Rocks d2c → candidate p50 | Slate d2c → candidate p50 |
|---|---:|---:|
| history depth one | 1.621 → 0.776 ms (-52.1%) | 1.752 → 0.815 ms (-53.5%) |
| historical diff | 1.259 → 0.618 ms (-50.9%) | 1.424 → 0.666 ms (-53.2%) |
| cold reopen/read | 6.765 → 2.779 ms (-58.9%) | 19.652 → 7.103 ms (-63.9%) |

- Baseline summary SHA-256: `fd15f445597e84e19af79719c98fd98d89a5acdb25ec9bcc5ab6bd842eea189c`
- Candidate summary SHA-256: `215296f8740a8926ca1c283a1f2d0f788f3569f70013446ae623d2145afdab44`
- Candidate benchmark binary SHA-256: `e275a73f6f775f0df552bcb722876a89d96a84d1252d276bff3d5651f2c1086b`

## OLAP no-regression acceptance

The independently qualified exact-d2c OLAP oracle is `76bef88d98faec487a9cae921d4663400d66382c` with report SHA-256 `e125b5cfe146235949bbc453db6986a80eab8c7db0d6e2f0c242afa8f7067989`. Exact-head replay is **24/24 PASS**: RocksDB/SlateDB × 10K/50K/100K × filter/sort/group/aggregate, with matching cross-adapter digests and matching pre/post-cold-reopen digests.

## Exact published head

- Head: `a21a860c2c7c2d41ae340b1789936c80b4f34b19`
- Tree: `92508ef4027d4fb912e28048f691e3d1fb200faf`
- Runtime-qualified parent: `12570e3128731a6fead8f5317dfdc70f4b7734dd`

The sole final commit changes checkpoint accounting assertions inside `storage_bench.rs`'s `#[cfg(test)] mod tests`; its runtime-source prefix hashes identically at parent and child (`ee2e862e8126eba172433f695c7e1dff4fb93444de4fc094927b4ae2d08907ea`). Production/runtime bytes and both qualification paths are unchanged. Full exact-head report SHA-256: `013a1c71e1b8c9b5f9015c8342dd76bd0cf1f3f1e2afb1d21758ae03e5635ed0`.

## Validation

- `cargo check -p lix --lib --all-features --message-format short`
- `cargo fmt --all -- --check`
- `git diff --check`
- Corrected 2N RocksDB and SlateDB public history projection matrix at 1K and 10K
- Parsed-Markdown RocksDB/SlateDB semantic/history/diff/reopen replay: PASS
- OLAP filter/order/group/aggregate + cold-reopen replay: 24/24 PASS
- Independent source/authority/performance review: APPROVE

Immutable CUT report SHA-256: `0b8b12de2403389874fd2d9e931d69e6a5b9b8ffdf3fccf4da74cff63e36f59f`.
