### PR TITLE
Make checkpoint epoch rotation proportional to deletes

### DIFF
--- a/packages/lix/src/engine.rs
+++ b/packages/lix/src/engine.rs
@@ -2182,11 +2182,63 @@ mod tests {
             .begin_read(StorageReadOptions::default())
             .await
             .expect("post-checkpoint inventory read should open");
-        let after = scan_test_space(&read, crate::hot_state::DIFF_SPACE).await;
+        let before_gc = scan_test_space(&read, crate::hot_state::DIFF_SPACE).await;
+        assert!(
+            before_gc.len() > 1,
+            "checkpoint rotation must not synchronously scan and delete the superseded sparse epoch"
+        );
+        let logical = session
+            .execute("SELECT COUNT(*) AS entries FROM lix_working_diff", &[])
+            .await
+            .expect("post-checkpoint logical diff should execute");
         assert_eq!(
-            after.len(),
+            logical.rows()[0]
+                .get::<i64>("entries")
+                .expect("working-diff count should be numeric"),
+            0,
+            "the superseded physical epoch must be unreachable immediately"
+        );
+        assert_eq!(
+            before_gc.len(),
+            3,
+            "the first checkpoint leaves the two superseded branch index records for GC"
+        );
+        drop(read);
+
+        let read = SharedStorageAdapterRead::new(
+            adapter
+                .begin_read(StorageReadOptions::default())
+                .await
+                .expect("working-diff GC read should open"),
+        );
+        let mut gc_writes = adapter.new_write_set();
+        let mut gc_preconditions = Vec::new();
+        crate::gc::stage_repository_gc_with_preconditions(
+            read,
+            &mut gc_writes,
+            &mut gc_preconditions,
+        )
+            .await
+            .expect("repository GC should collect superseded sparse epochs");
+        adapter
+            .commit_write_set(
+                gc_writes,
+                StorageWriteOptions {
+                    preconditions: gc_preconditions,
+                    ..StorageWriteOptions::default()
+                },
+            )
+            .await
+            .expect("working-diff GC should commit");
+        let read = adapter
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("post-GC inventory read should open");
+        let after_gc = scan_test_space(&read, crate::hot_state::DIFF_SPACE).await;
+        assert_eq!(
+            after_gc.len(),
             1,
-            "the superseded branch epoch must be reclaimed; only the repository-global checkpoint row may remain dirty"
+            "GC must reclaim the superseded branch epoch; only the repository-global checkpoint row may remain dirty"
         );
         drop(read);
         session
@@ -2206,7 +2258,7 @@ mod tests {
         let logical = session
             .execute("SELECT COUNT(*) AS entries FROM lix_working_diff", &[])
             .await
-            .expect("post-checkpoint logical diff should execute");
+            .expect("second post-checkpoint logical diff should execute");
         assert_eq!(
             logical.rows()[0]
                 .get::<i64>("entries")

--- a/packages/lix/src/gc.rs
+++ b/packages/lix/src/gc.rs
@@ -21,7 +21,6 @@ use crate::changelog::{ChangeRecord, CommitScanRequest};
 use crate::changelog::{ChangeScanRequest, ChangelogContext, ChangelogReader};
 use crate::commit_graph::CommitGraphContext;
 use crate::hot_state::TrackedHeadContext;
-#[cfg(test)]
 use crate::hot_state::stage_collect_stale_working_diff_indexes;
 use crate::json_store::{JsonRef, JsonSlot, JsonStoreContext};
 #[cfg(test)]
@@ -1581,6 +1580,11 @@ where
     if !reclaimed_semantic_commits.is_empty() {
         writes.seal_changelog_gc();
     }
+
+    // Checkpoint publication rotates the authenticated sparse dirty-index
+    // marker in O(1). Retire every now-unreachable epoch here, under the same
+    // observed branch-control preconditions as the rest of repository GC.
+    stage_collect_stale_working_diff_indexes(&store, writes).await?;
 
     preconditions.extend(staged_preconditions);
     Ok(RepositoryGcPlan {

--- a/packages/lix/src/hot_state/mod.rs
+++ b/packages/lix/src/hot_state/mod.rs
@@ -36,7 +36,6 @@ pub(crate) use tracked_head::TrackedHeadDeltaRef;
 pub(crate) use tracked_head::WORKING_DIFF_PATH_HITS;
 #[cfg(test)]
 pub(crate) use tracked_head::hot_generation_scope_prefix;
-#[cfg(test)]
 pub(crate) use tracked_head::stage_collect_stale_working_diff_indexes;
 pub(crate) use tracked_head::stage_retire_hot_generation;
 // Read only by `#[cfg(test)]` probes, so a features-on *library* build compiles
@@ -67,8 +66,7 @@ pub(crate) use tracked_head::{
     ROW_SPACE, TRACKED_WORKING_DIFF_MARKER_SPACE, TrackedHeadContext, TrackedWorkingDiff,
     TrackedWorkingDiffEpoch, WorkingDiffIndexCoverage, load_certified_rows_at_commit,
     materialize_certified_root_rows, scan_certified_history_rows, stage_certified_row_batches,
-    stage_delete_tracked_working_diff_epoch, stage_hot_index_entries,
-    stage_tracked_working_diff_epoch,
+    stage_hot_index_entries, stage_tracked_working_diff_epoch,
 };
 #[allow(unused_imports)]
 pub(crate) use types::{

--- a/packages/lix/src/hot_state/tracked_head.rs
+++ b/packages/lix/src/hot_state/tracked_head.rs
@@ -49,9 +49,7 @@ pub(crate) struct ColumnarBaseCoordinate {
     pub(crate) row_index: u32,
 }
 
-#[cfg(test)]
-use std::collections::BTreeMap;
-use std::collections::BTreeSet;
+use std::collections::{BTreeMap, BTreeSet};
 use std::sync::Arc;
 
 use bytes::Bytes;
@@ -304,7 +302,6 @@ struct BranchRef<'a> {
 
 #[derive(Debug, Clone, musli::Encode, musli::Decode)]
 #[musli(packed)]
-#[cfg(test)]
 struct BranchRefKey {
     branch_id: String,
 }
@@ -813,7 +810,6 @@ async fn load_tracked_working_diff_epoch(
 /// checkpoint epoch. This deliberately runs only from repository GC: a
 /// checkpoint reset is O(1), while old index prefixes are unreachable as soon
 /// as its marker commits.
-#[cfg(test)]
 pub(crate) async fn stage_collect_stale_working_diff_indexes<S>(
     store: &S,
     writes: &mut StorageWriteSet,
@@ -831,21 +827,6 @@ where
     hot::stage_collect_stale_hot_diff_records(store, writes, &active).await
 }
 
-pub(crate) async fn stage_delete_tracked_working_diff_epoch<S>(
-    store: &S,
-    writes: &mut StorageWriteSet,
-    branch_id: &str,
-    checkpoint_commit_id: CommitId,
-    generation: CommitId,
-) -> Result<(), LixError>
-where
-    S: StorageAdapterRead + ?Sized,
-{
-    hot::stage_delete_hot_diff_scope(store, writes, branch_id, checkpoint_commit_id, generation)
-        .await
-}
-
-#[cfg(test)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 struct ActiveWorkingDiffScope {
     checkpoint_commit_id: CommitId,
@@ -856,7 +837,6 @@ struct ActiveWorkingDiffScope {
 /// authoritative branch control. Broken auxiliary bytes are reclaimed here
 /// rather than turning background GC into a retry loop; normal readers already
 /// select canonical replay for the same cases.
-#[cfg(test)]
 async fn stage_active_working_diff_scopes<S>(
     store: &S,
     writes: &mut StorageWriteSet,
@@ -1476,6 +1456,30 @@ fn effective_hot_commit_id(
     ) {
         (Some(active), Some(owner)) if owner != active => Some(active),
         _ => Some(commit_id),
+    }
+}
+
+/// Returns the checkpoint-canonical creation timestamp without rewriting the
+/// current row when an epoch rotates.
+///
+/// A row first created in the previous interval carries `BeforeAbsent` and is
+/// canonicalized by checkpoint history to its change timestamp. Rows that
+/// existed at the checkpoint retain their original creation timestamp.
+fn effective_hot_created_at(
+    value: HeadValueView<'_>,
+    active_checkpoint_commit_id: Option<CommitId>,
+) -> LixTimestamp {
+    match (
+        active_checkpoint_commit_id,
+        value.working_diff_baseline,
+    ) {
+        (
+            Some(active),
+            WorkingDiffBaseline::BeforeAbsent {
+                checkpoint_commit_id,
+            },
+        ) if checkpoint_commit_id != active => value.updated_at,
+        _ => value.created_at,
     }
 }
 
@@ -2238,7 +2242,7 @@ where
             snapshot_content,
             metadata,
             value.deleted,
-            value.created_at,
+            effective_hot_created_at(value, active_checkpoint_commit_id),
             value.updated_at,
             global,
             value.change_id,

--- a/packages/lix/src/hot_state/tracked_head/hot.rs
+++ b/packages/lix/src/hot_state/tracked_head/hot.rs
@@ -7936,6 +7936,27 @@ where
         Ok(generation)
     }
 
+    /// Whether a checkpoint can rotate its working-diff epoch without
+    /// materializing current-state base rows first.
+    ///
+    /// Immutable packed bases encode interval-relative absent-at-checkpoint
+    /// facts and must take the existing materializing route once. Root bases
+    /// are already the branch's checkpoint state and remain clean under a new
+    /// epoch, so they do not prevent lazy rotation.
+    pub(crate) async fn can_rotate_checkpoint_epoch(
+        &self,
+        branch_id: &str,
+        generation: CommitId,
+    ) -> Result<bool, LixError> {
+        if !packed_current_base_refs(self.store, branch_id, generation)
+            .await?
+            .is_empty()
+        {
+            return Ok(false);
+        }
+        Ok(true)
+    }
+
     /// Stages deltas whose absence was already validated against the coherent
     /// transaction snapshot. The caller must publish the corresponding branch
     /// control with a compare-and-swap precondition from that same snapshot.
@@ -8502,7 +8523,7 @@ where
                 // for modified/removed rows.
                 delta.created_at
             } else {
-                existing.created_at
+                effective_hot_created_at(existing, working_diff_capture_checkpoint_commit_id)
             });
         }
         // A checkpoint often selects immutable change records whose HOT row
@@ -9204,6 +9225,7 @@ fn next_cascade_working_diff_baseline(
             let mut before = previous
                 .working_diff_version()
                 .ok_or_else(|| head_value_error("tracked cascade member has no version"))?;
+            before.created_at = effective_hot_created_at(previous, Some(active_checkpoint_commit_id));
             before.commit_id = active_checkpoint_commit_id;
             Ok((
                 WorkingDiffBaseline::BeforePresent {
@@ -9283,6 +9305,7 @@ fn next_hot_working_diff_baseline(
             let mut before = previous
                 .working_diff_version()
                 .ok_or_else(|| head_value_error("tracked mutation has no working-diff version"))?;
+            before.created_at = effective_hot_created_at(previous, Some(active_checkpoint_commit_id));
             before.commit_id = active_checkpoint_commit_id;
             Ok((
                 WorkingDiffBaseline::BeforePresent {
@@ -13309,7 +13332,6 @@ fn encode_hot_file_schema_key(scope: &[u8], schema_key: &str) -> Vec<u8> {
     key
 }
 
-#[cfg_attr(not(test), expect(dead_code))]
 struct HotDiffSegmentScope {
     branch_id: String,
     checkpoint_commit_id: CommitId,
@@ -13425,7 +13447,6 @@ fn visit_hot_diff_segment(
     Ok(())
 }
 
-#[cfg(test)]
 fn decode_hot_diff_key(bytes: &[u8]) -> Result<(CommitId, HeadIdentity), LixError> {
     let mut offset = 0;
     let (branch_id, branch_terminator) = read_key_string(bytes, &mut offset, "branch id")?;
@@ -13587,7 +13608,6 @@ where
     Ok(deleted)
 }
 
-#[cfg(test)]
 pub(crate) async fn stage_collect_stale_hot_diff_records<S>(
     store: &S,
     writes: &mut StorageWriteSet,
@@ -13641,51 +13661,6 @@ where
                 writes.delete(DIFF_SPACE, entry.key);
             }
         }
-        if !page_has_more {
-            break;
-        }
-    }
-    Ok(())
-}
-
-/// Reclaims one superseded working-diff epoch without scanning any other
-/// branch or checkpoint. A checkpoint already performs work linear in its
-/// selected dirty set; this prefix-local scan keeps reclamation on the same
-/// bound while preventing unreachable epochs from accumulating until GC.
-pub(super) async fn stage_delete_hot_diff_scope<S>(
-    store: &S,
-    writes: &mut StorageWriteSet,
-    branch_id: &str,
-    checkpoint_commit_id: CommitId,
-    generation: CommitId,
-) -> Result<(), LixError>
-where
-    S: StorageAdapterRead + ?Sized,
-{
-    let range = StoragePrefix {
-        bytes: Bytes::from(encode_working_diff_scope_prefix(
-            branch_id,
-            checkpoint_commit_id,
-            generation,
-        )),
-    }
-    .to_range()?;
-    let mut cursor = store
-        .begin_scan(
-            DIFF_SPACE,
-            range,
-            StorageBeginScanOptions {
-                projection: StorageCoreProjection::KeyOnly,
-                ..StorageBeginScanOptions::default()
-            },
-        )
-        .await?;
-    loop {
-        let (page, page_has_more) = cursor
-            .next_page(crate::storage_adapter::MAX_SCAN_PAGE_ROWS)
-            .await?
-            .into_parts();
-        writes.delete_batch(DIFF_SPACE, page.into_iter().map(|entry| entry.key));
         if !page_has_more {
             break;
         }

--- a/packages/lix/src/transaction/commit.rs
+++ b/packages/lix/src/transaction/commit.rs
@@ -26,7 +26,7 @@ use crate::functions::FunctionContext;
 use crate::hot_state::{
     HotStateContext, HotStateRowRequest, HotTrackedSnapshot, MaterializedHotStateRow,
     TrackedHeadContext, TrackedWorkingDiffEpoch, WorkingDiffIndexCoverage,
-    stage_delete_tracked_working_diff_epoch, stage_tracked_working_diff_epoch,
+    stage_tracked_working_diff_epoch,
 };
 use crate::json_store::{
     JSON_INLINE_MAX_BYTES, JsonRef, JsonStoreContext, JsonWritePlacementRef, NormalizedJsonRef,
@@ -763,6 +763,7 @@ pub(crate) async fn commit_prepared_writes_with_parent_heads(
         &row_columnar_write_sets,
         &engine_rows,
         &row_index.tracked_row_indices_by_commit,
+        &row_index.tracked_delete_indices_by_commit,
         &tracked_roots,
         &staged_commits,
         &selected_change_payloads,
@@ -794,11 +795,9 @@ pub(crate) async fn commit_prepared_writes_with_parent_heads(
         );
     }
     stage_checkpoint_working_diff_epochs(
-        read,
         &mut writes,
         &prepared_writes.checkpoint_publications,
         &staged_hot_heads.controls,
-        &branch_control_observations,
     )
     .await?;
     let mut root_backed_branch_publications = BTreeSet::new();
@@ -1078,10 +1077,12 @@ fn json_payloads_from_state_row(
 
 struct PreparedRowIndex {
     tracked_row_indices_by_commit: BTreeMap<CommitId, Vec<RowIndex>>,
+    tracked_delete_indices_by_commit: BTreeMap<CommitId, Vec<RowIndex>>,
 }
 
 fn index_prepared_rows(rows: &PreparedStateBatch) -> Result<PreparedRowIndex, LixError> {
     let mut tracked_row_indices_by_commit = BTreeMap::<CommitId, Vec<RowIndex>>::new();
+    let mut tracked_delete_indices_by_commit = BTreeMap::<CommitId, Vec<RowIndex>>::new();
 
     for (row_index, row) in rows.iter().enumerate() {
         if row.untracked {
@@ -1097,10 +1098,17 @@ fn index_prepared_rows(rows: &PreparedStateBatch) -> Result<PreparedRowIndex, Li
             .entry(*commit_id)
             .or_default()
             .push(row_index);
+        if row.snapshot.is_none() {
+            tracked_delete_indices_by_commit
+                .entry(*commit_id)
+                .or_default()
+                .push(row_index);
+        }
     }
 
     Ok(PreparedRowIndex {
         tracked_row_indices_by_commit,
+        tracked_delete_indices_by_commit,
     })
 }
 
@@ -3655,6 +3663,7 @@ async fn stage_tracked_head(
     row_columnar_write_sets: &crate::hot_state::RowColumnarWriteSets,
     engine_rows: &[EngineCurrentRow],
     tracked_row_indices_by_commit: &BTreeMap<CommitId, Vec<RowIndex>>,
+    tracked_delete_indices_by_commit: &BTreeMap<CommitId, Vec<RowIndex>>,
     tracked_roots: &[PendingTrackedRoot],
     staged_commits: &BTreeMap<CommitId, StagedChangelogCommit>,
     selected_change_payloads: &HashMap<
@@ -3735,9 +3744,130 @@ async fn stage_tracked_head(
             .get(&root.commit_id)
             .map(Vec::as_slice)
             .unwrap_or_default();
+        let checkpoint_commit_id = checkpoint_epochs.get(&root.branch_id).copied();
+        let is_checkpoint_publication = checkpoint_commit_id == Some(root.commit_id);
         let certified_columnar_parts = mutation_inventories
             .get(&root.commit_id)
             .and_then(|inventory| inventory.columnar_parts.as_ref());
+
+        // A checkpoint changes the authenticated epoch/control, not current
+        // row values. Take the O(deletes) route before constructing ordinary
+        // tracked/untracked delta cohorts or selected-row materializations.
+        // The deletion ordinals were built while their typed owners were
+        // produced, so this branch never scans non-deleted members.
+        if is_checkpoint_publication && !tracked_snapshots.contains_key(&root.commit_id) {
+            let parent_generation = parent_control
+                .map(|control| control.tracked_generation)
+                .ok_or_else(|| {
+                    LixError::new(
+                        LixError::CODE_INTERNAL_ERROR,
+                        format!(
+                            "checkpoint hot publication for '{}' lacks a complete parent generation",
+                            root.commit_id
+                        ),
+                    )
+                })?;
+            let mut writer = tracked_head.writer(read, writes);
+            if let Some(schema_keys) = transaction_global_schema_keys.as_ref() {
+                writer = writer.with_transaction_global_schema_keys(schema_keys);
+            }
+            if writer
+                .can_rotate_checkpoint_epoch(&root.branch_id, parent_generation)
+                .await?
+            {
+                let selected_deleted_rows = staged
+                    .selected_change_batches
+                    .iter()
+                    .flat_map(StagedCommitChangeBatch::deleted_iter)
+                    .map(|change_ref| {
+                        let key = selected_change_key(change_ref);
+                        lifecycle_selected_tracked_row(
+                            change_ref,
+                            root.commit_id,
+                            None,
+                            selected_change_payloads.get(&key),
+                        )
+                    })
+                    .collect::<Result<Vec<_>, _>>()?;
+                let selected_snapshots = selected_deleted_rows
+                    .iter()
+                    .map(|row| {
+                        row.snapshot_content.as_deref().map_or(
+                            crate::json_store::JsonSlot::None,
+                            crate::json_store::JsonSlot::from_json,
+                        )
+                    })
+                    .collect::<Vec<_>>();
+                let selected_metadata = selected_deleted_rows
+                    .iter()
+                    .map(|row| {
+                        row.metadata.as_deref().map_or(
+                            crate::json_store::JsonSlot::None,
+                            crate::json_store::JsonSlot::from_json,
+                        )
+                    })
+                    .collect::<Vec<_>>();
+                let mut deleted_deltas = tracked_delete_indices_by_commit
+                    .get(&root.commit_id)
+                    .into_iter()
+                    .flatten()
+                    .map(|&row_index| current_state_delta_from_state_row(state_rows.row(row_index)))
+                    .collect::<Result<Vec<_>, _>>()?;
+                deleted_deltas.extend(
+                    staged
+                        .selected_change_batches
+                        .iter()
+                        .flat_map(StagedCommitChangeBatch::deleted_iter)
+                        .zip(selected_deleted_rows.iter())
+                        .zip(selected_snapshots.iter().zip(&selected_metadata))
+                        .map(|((change_ref, row), (snapshot, metadata))| {
+                            crate::hot_state::CurrentStateDeltaRef {
+                                schema_key: &row.schema_key,
+                                file_id: row.file_id.as_deref(),
+                                row_pk: &row.row_pk,
+                                change_id: Some(change_ref.change_id),
+                                commit_id: Some(root.commit_id),
+                                untracked: false,
+                                deleted: true,
+                                created_at: change_ref.created_at,
+                                updated_at: change_ref.updated_at,
+                                snapshot: snapshot.as_ref_slot(),
+                                metadata: metadata.as_ref_slot(),
+                                columnar_base_coordinate: None,
+                            }
+                        }),
+                );
+                let mut coverage = WorkingDiffIndexCoverage::default();
+                let generation = if deleted_deltas.is_empty() {
+                    parent_generation
+                } else {
+                    writer
+                        .stage_checkpoint_current_state(
+                            &root.branch_id,
+                            parent_generation,
+                            root.commit_id,
+                            &deleted_deltas,
+                            &BTreeSet::new(),
+                            checkpoint_commit_id
+                                .expect("checkpoint publication has an epoch commit id"),
+                            &mut coverage,
+                        )
+                        .instrument(tracing::debug_span!(
+                            target: "lix_perf",
+                            "lix.perf.materialization.tracked_head.stage_checkpoint_tombstones"
+                        ))
+                        .await?
+                };
+                let control = normal_branch_head_control(
+                    root,
+                    parent_control,
+                    generation,
+                    checkpoint_commit_id,
+                )?;
+                insert_direct_branch_control(&mut controls, &root.branch_id, control)?;
+                continue;
+            }
+        }
         let selected_materialization = if !staged.selected_change_batches.is_empty()
             && !tracked_snapshots.contains_key(&root.commit_id)
         {
@@ -3793,8 +3923,6 @@ async fn stage_tracked_head(
                 .filter(|row| row.branch_id == root.branch_id)
                 .map(current_state_delta_from_engine_row),
         );
-        let checkpoint_commit_id = checkpoint_epochs.get(&root.branch_id).copied();
-        let is_checkpoint_publication = checkpoint_commit_id == Some(root.commit_id);
         let can_publish_ordered_packed_current_base = ordered_addressable_commits
             .contains(&root.commit_id)
             && !is_checkpoint_publication
@@ -4460,8 +4588,9 @@ async fn stage_tracked_head(
             "packed current-base route decision"
         );
         let generation = if is_checkpoint_publication {
-            let checkpoint_commit_id =
-                checkpoint_commit_id.expect("checkpoint publication has an epoch commit id");
+            // Reaching this point means an immutable packed base prevented
+            // the O(deletes) epoch-rotation route above. Materialize it once;
+            // retirement makes later checkpoints eligible for lazy rotation.
             coverage = WorkingDiffIndexCoverage::default();
             writer
                 .stage_checkpoint_current_state(
@@ -4470,7 +4599,7 @@ async fn stage_tracked_head(
                     root.commit_id,
                     &deltas,
                     &owned_absence_guards(&absence_guards),
-                    checkpoint_commit_id,
+                    checkpoint_commit_id.expect("checkpoint publication has an epoch commit id"),
                     &mut coverage,
                 )
                 .instrument(tracing::debug_span!(
@@ -4907,11 +5036,9 @@ fn selected_tracked_ref_untracked_collision_error(
 /// hot generation. Unchanged rows were already clean, so rotating to an empty
 /// sparse dirty-key index starts the next epoch without a full-state rewrite.
 async fn stage_checkpoint_working_diff_epochs(
-    read: &(impl StorageAdapterRead + ?Sized),
     writes: &mut StorageWriteSet,
     publications: &[crate::gc::CheckpointPublication],
     controls: &BTreeMap<String, BranchHeadControl>,
-    observations: &BTreeMap<String, BranchHeadControlObservation>,
 ) -> Result<(), LixError> {
     let mut branches = BTreeSet::new();
     for publication in publications {
@@ -4951,22 +5078,9 @@ async fn stage_checkpoint_working_diff_epochs(
         if control.head_commit_id != recovery.checkpoint_commit_id {
             continue;
         }
-        if let Some(previous) = observations
-            .get(&recovery.branch_id)
-            .and_then(|observation| observation.control)
-            && let Some(previous_checkpoint) = previous.working_diff_checkpoint_commit_id
-            && (previous_checkpoint != recovery.checkpoint_commit_id
-                || previous.tracked_generation != control.tracked_generation)
-        {
-            stage_delete_tracked_working_diff_epoch(
-                read,
-                writes,
-                &recovery.branch_id,
-                previous_checkpoint,
-                previous.tracked_generation,
-            )
-            .await?;
-        }
+        // The previous sparse index becomes unreachable when this marker and
+        // branch control commit. Repository GC reclaims stale epoch prefixes;
+        // scanning them here would make checkpoint publication O(D).
         stage_tracked_working_diff_epoch(
             writes,
             &recovery.branch_id,
@@ -6881,14 +6995,9 @@ mod tests {
     #[tokio::test]
     async fn real_checkpoint_without_complete_hot_control_still_fails() {
         let storage = StorageAdapter::new(Memory::new());
-        let read = storage
-            .begin_read(StorageReadOptions::default())
-            .await
-            .expect("checkpoint validation read should open");
         let mut writes = storage.new_write_set();
         let checkpoint = commit_id("missing-hot-checkpoint");
         let error = stage_checkpoint_working_diff_epochs(
-            &read,
             &mut writes,
             &[crate::gc::CheckpointPublication {
                 recovery_ref: crate::gc::CheckpointRecoveryRef {
@@ -6899,7 +7008,6 @@ mod tests {
                 },
                 gc_state: crate::gc::CheckpointGcState::default(),
             }],
-            &BTreeMap::new(),
             &BTreeMap::new(),
         )
         .await

--- a/packages/lix/src/transaction/staged_commit_changes.rs
+++ b/packages/lix/src/transaction/staged_commit_changes.rs
@@ -90,6 +90,10 @@ struct StagedCommitChangeColumns {
     deleted: Vec<bool>,
     created_at: Vec<LixTimestamp>,
     updated_at: Vec<LixTimestamp>,
+    /// Logical row ordinals whose selected change is a deletion. Built once
+    /// while the typed columns are produced so checkpoint publication can
+    /// visit O(deletes) rather than rescan every selected member.
+    deleted_rows: Vec<u32>,
 }
 
 #[derive(Debug, Clone)]
@@ -129,6 +133,7 @@ impl StagedCommitChangeBatchBuilder {
                 deleted: Vec::with_capacity(row_count),
                 created_at: Vec::with_capacity(row_count),
                 updated_at: Vec::with_capacity(row_count),
+                deleted_rows: Vec::new(),
             },
         }
     }
@@ -142,6 +147,12 @@ impl StagedCommitChangeBatchBuilder {
         created_at: LixTimestamp,
         updated_at: LixTimestamp,
     ) {
+        if deleted {
+            self.columns.deleted_rows.push(
+                u32::try_from(self.columns.identities.len())
+                    .expect("staged commit change batch exceeds u32 rows"),
+            );
+        }
         self.columns.identities.push(identity);
         self.columns.source_commit_ids.push(source_commit_id);
         self.columns.change_ids.push(change_id);
@@ -202,6 +213,32 @@ impl StagedCommitChangeBatch {
         (0..self.len()).map(|row_index| self.row(row_index))
     }
 
+    /// Selected deletion members without scanning non-deleted rows.
+    pub(crate) fn deleted_iter(
+        &self,
+    ) -> impl Iterator<Item = StagedCommitChangeRef<'_>> + '_ {
+        self.columns
+            .deleted_rows
+            .iter()
+            .copied()
+            .filter(move |&column_index| {
+                self.selection
+                    .as_ref()
+                    .is_none_or(|selection| selection.binary_search(&column_index).is_ok())
+            })
+            .map(move |column_index| {
+                let logical_index = self.selection.as_ref().map_or(column_index, |selection| {
+                    u32::try_from(
+                        selection
+                            .binary_search(&column_index)
+                            .expect("filtered deleted row belongs to selection"),
+                    )
+                    .expect("selected commit change batch exceeds u32 rows")
+                });
+                self.row(logical_index as usize)
+            })
+    }
+
     fn row(&self, row_index: usize) -> StagedCommitChangeRef<'_> {
         let column_index = self
             .selection
@@ -246,6 +283,7 @@ impl StagedCommitChangeBatch {
             + usize::from(!self.columns.deleted.is_empty())
             + usize::from(!self.columns.created_at.is_empty())
             + usize::from(!self.columns.updated_at.is_empty())
+            + usize::from(!self.columns.deleted_rows.is_empty())
             + usize::from(self.selection.is_some())
     }
 }


### PR DESCRIPTION
## What changed

Checkpoint publication now rotates the authenticated working-diff epoch without scanning or rewriting live dirty rows.

- Prepared/native selected change batches record deletion ordinals once at construction time.
- HOT/root-backed checkpoint publication visits only deleted rows; packed bases retain their one-time materializing fallback.
- Superseded sparse indexes become unreachable with the marker/control publication and are reclaimed by the existing repository-GC writer under exact branch-control preconditions.
- Foreign-epoch mutations preserve canonical before images and `created_at`; tombstone compaction remains intact.

No second state authority, reader, writer, cache, compatibility path, or durable format was added.

## Why

The previous checkpoint path rewrote every dirty current-state row and synchronously scanned/deleted the previous sparse index even though checkpointing does not change current values. On the 10K-disjoint VCS fixture this dominated checkpoint publication.

## Performance

Matched release workload: `tracked_working_diff setup <adapter> <fresh-db> disjoint 10000 1000 10`, followed in a separate process by `checkpoint`.

| Adapter | exact main p50 | candidate p50 | candidate p95 | change |
|---|---:|---:|---:|---:|
| RocksDB | 138.963 ms | 49.896 ms | 53.137 ms | -64.1% |
| SlateDB | 409.319 ms | 111.354 ms | 115.641 ms | -72.8% |

Five candidate samples per adapter; all ten fixtures reported exactly 10,000 populated working diffs before checkpoint and checkpointed successfully.

## Validation

- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo check -p lix --lib --all-features`
- all-features linked test filter `checkpoint_ --nocapture`: 66 passed, 0 failed, 1 ignored measurement probe
- explicit discriminator: logical diff is empty immediately after rotation; stale physical epoch remains before GC; production preconditioned repository GC reclaims it
- independent source/authority review: APPROVE

Frozen evidence report SHA-256: `b701ad54d9c87d39b361c9c14be9bebdf4935354ec7e0e82f7a0a3c7b8d132a2`.

## Provenance

- Parent/main: `d2c634b2aeb780aff46013ec04902fcbb5c6f846`
- Head: `6c0021458c54a1ee4a17c75cf467745f29afac6e`
- Tree: `fb8095bce5a26dd0b6850c6143a7ee7641d072c1`
- Full-index SHA-256: `95b4e212d3f2b11d5c24b99e172747faaa4187bd87f89fc77c99510e06459111`
- Stable patch ID: `7bc6c3ec5e730b8960403156f3ae0b33075fa003`
