### PR TITLE
fix(release): propagate lockstep Cargo path versions atomically

### DIFF
--- a/scripts/release.mjs
+++ b/scripts/release.mjs
@@ -1,5 +1,13 @@
-import { existsSync, readdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
-import { join } from "node:path";
+import {
+	existsSync,
+	readdirSync,
+	readFileSync,
+	renameSync,
+	rmSync,
+	unlinkSync,
+	writeFileSync,
+} from "node:fs";
+import { dirname, join, relative, resolve } from "node:path";
 import { execFileSync } from "node:child_process";
 
 export const CHANGE_TYPES = ["minor", "patch"];
@@ -171,34 +179,257 @@ function indentChangelogDetail(detail) {
 		.join("\n");
 }
 
-export function updateCargoToml(root, version) {
-	let text = readText(root, "Cargo.toml");
-	text = text.replace(
-		/(\[workspace\.package\][\s\S]*?\nversion\s*=\s*")[^"]+(")/,
-		`$1${version}$2`,
+export function updateCargoToml(root, version, { renameManifest = renameSync } = {}) {
+	const manifests = readCargoManifests(root);
+	const rootManifestPath = resolve(root, "Cargo.toml");
+	const rootManifest = manifests.get(rootManifestPath);
+	if (rootManifest === undefined) {
+		throw new Error("Could not find workspace Cargo.toml");
+	}
+	const planned = new Map(manifests);
+	planned.set(
+		rootManifestPath,
+		rootManifest.replace(
+			/(\[workspace\.package\][\s\S]*?\nversion\s*=\s*")[^"]+(")/,
+			`$1${version}$2`,
+		),
 	);
-	text = updateWorkspaceVersionedDependencyRequirements(root, text, version);
-	writeText(root, "Cargo.toml", text);
+
+	const lockstepManifests = workspaceVersionedPackageManifests(manifests);
+	for (const [manifestPath] of manifests) {
+		planned.set(
+			manifestPath,
+			updateVersionedPathDependencyRequirements(
+				manifestPath,
+				planned.get(manifestPath),
+				lockstepManifests,
+				version,
+			),
+		);
+	}
+	assertCargoLockstepVersions(root, planned, version);
+
+	const changed = [...planned].filter(
+		([manifestPath, text]) => text !== manifests.get(manifestPath),
+	);
+	const staged = changed.map(([manifestPath, text], index) => ({
+		manifestPath,
+		stagedPath: join(dirname(manifestPath), `.Cargo.toml.release-${process.pid}-${index}`),
+		text,
+	}));
+	try {
+		for (const { stagedPath, text } of staged) writeFileSync(stagedPath, text);
+		for (const { manifestPath, stagedPath } of staged) {
+			renameManifest(stagedPath, manifestPath);
+		}
+	} catch (error) {
+		for (const [manifestPath] of changed) {
+			writeFileSync(manifestPath, manifests.get(manifestPath));
+		}
+		throw error;
+	} finally {
+		for (const { stagedPath } of staged) {
+			if (existsSync(stagedPath)) unlinkSync(stagedPath);
+		}
+	}
 }
 
-function updateWorkspaceVersionedDependencyRequirements(root, text, version) {
-	return text.replace(
-		/\[workspace\.dependencies\][\s\S]*?(?=\n\[|$)/,
-		(dependencies) =>
-			dependencies.replace(/^[A-Za-z0-9_-]+\s*=\s*\{[^}\n]*\}$/gm, (line) => {
-				const path = line.match(/\bpath\s*=\s*"([^"]+)"/)?.[1];
-				if (!path || !/\bversion\s*=\s*"[^"]+"/.test(line)) return line;
-				const manifestPath = join(root, path, "Cargo.toml");
-				if (!existsSync(manifestPath)) return line;
-				const packageSection = readFileSync(manifestPath, "utf8").match(
-					/\[package\]([\s\S]*?)(?=\n\[|$)/,
-				)?.[1];
-				if (!packageSection || !/^version\.workspace\s*=\s*true\s*$/m.test(packageSection)) {
-					return line;
-				}
-				return line.replace(/(\bversion\s*=\s*")[^"]+(")/, `$1=${version}$2`);
-			}),
+export function validateCargoLockstepVersions(root, version = currentVersion(root)) {
+	assertCargoLockstepVersions(root, readCargoManifests(root), version);
+}
+
+function readCargoManifests(root) {
+	const manifests = new Map();
+	const visit = (directory) => {
+		for (const entry of readdirSync(directory, { withFileTypes: true }).sort((a, b) =>
+			a.name.localeCompare(b.name),
+		)) {
+			if (entry.isDirectory()) {
+				if ([".git", "node_modules", "target"].includes(entry.name)) continue;
+				visit(join(directory, entry.name));
+			} else if (entry.isFile() && entry.name === "Cargo.toml") {
+				const manifestPath = resolve(directory, entry.name);
+				manifests.set(manifestPath, readFileSync(manifestPath, "utf8"));
+			}
+		}
+	};
+	visit(resolve(root));
+	return manifests;
+}
+
+function workspaceVersionedPackageManifests(manifests) {
+	return new Set(
+		[...manifests]
+			.filter(([, text]) => {
+				const packageSection = text.match(/\[package\]([\s\S]*?)(?=\n\[|$)/)?.[1];
+				return packageSection && /^version\.workspace\s*=\s*true\s*$/m.test(packageSection);
+			})
+			.map(([manifestPath]) => manifestPath),
 	);
+}
+
+function updateVersionedPathDependencyRequirements(
+	manifestPath,
+	text,
+	lockstepManifests,
+	version,
+) {
+	const replacements = versionedPathDependencies(manifestPath, text)
+		.filter((dependency) => lockstepManifests.has(dependency.targetManifest))
+		.map((dependency) => ({
+			start: dependency.versionStart,
+			end: dependency.versionEnd,
+			value: `=${version}`,
+		}))
+		.sort((a, b) => b.start - a.start);
+	let next = text;
+	for (const replacement of replacements) {
+		next = `${next.slice(0, replacement.start)}${replacement.value}${next.slice(replacement.end)}`;
+	}
+	return next;
+}
+
+function assertCargoLockstepVersions(root, manifests, version) {
+	const lockstepManifests = workspaceVersionedPackageManifests(manifests);
+	const expected = `=${version}`;
+	const mismatches = [];
+	for (const [manifestPath, text] of manifests) {
+		for (const dependency of versionedPathDependencies(manifestPath, text)) {
+			if (!lockstepManifests.has(dependency.targetManifest)) continue;
+			if (dependency.version === expected) continue;
+			mismatches.push(
+				`${relative(root, manifestPath)}: ${dependency.name} requires ${dependency.version}, expected ${expected}`,
+			);
+		}
+	}
+	if (mismatches.length > 0) {
+		mismatches.sort();
+		throw new Error(`Cargo lockstep path dependency mismatches:\n${mismatches.join("\n")}`);
+	}
+}
+
+function versionedPathDependencies(manifestPath, text) {
+	const dependencies = [];
+	const sections = [...text.matchAll(/^\[([^\]\n]+)\][ \t]*(?:#.*)?$/gm)];
+	for (let index = 0; index < sections.length; index += 1) {
+		const section = sections[index];
+		const sectionName = section[1];
+		const bodyStart = section.index + section[0].length;
+		const bodyEnd = sections[index + 1]?.index ?? text.length;
+		if (isDependencyListSection(sectionName)) {
+			const body = text.slice(bodyStart, bodyEnd);
+			for (const declaration of inlineDependencyDeclarations(body, bodyStart)) {
+				pushVersionedPathDependency(
+					dependencies,
+					manifestPath,
+					declaration.name,
+					text,
+					declaration.start,
+					declaration.end,
+				);
+			}
+			continue;
+		}
+		const dependencyName = dependencySubtableName(sectionName);
+		if (!dependencyName) continue;
+		pushVersionedPathDependency(
+			dependencies,
+			manifestPath,
+			dependencyName,
+			text,
+			bodyStart,
+			bodyEnd,
+		);
+	}
+	return dependencies;
+}
+
+function isDependencyListSection(sectionName) {
+	return /^(?:(?:workspace\.)?(?:dev-|build-)?dependencies|target\..+\.(?:dev-|build-)?dependencies)$/.test(
+		sectionName,
+	);
+}
+
+function dependencySubtableName(sectionName) {
+	return sectionName.match(
+		/^(?:(?:workspace\.)?(?:dev-|build-)?dependencies|target\..+\.(?:dev-|build-)?dependencies)\.([A-Za-z0-9_-]+)$/,
+	)?.[1];
+}
+
+function inlineDependencyDeclarations(body, bodyOffset) {
+	const declarations = [];
+	for (const match of body.matchAll(/^[ \t]*(?:"([^"]+)"|([A-Za-z0-9_-]+))\s*=\s*\{/gm)) {
+		const tableStart = bodyOffset + match.index + match[0].lastIndexOf("{");
+		const tableEnd = inlineTableEnd(body, match.index + match[0].lastIndexOf("{"));
+		if (tableEnd === null) {
+			throw new Error(`Unterminated inline Cargo dependency table for ${match[1] ?? match[2]}`);
+		}
+		declarations.push({
+			name: match[1] ?? match[2],
+			start: tableStart,
+			end: bodyOffset + tableEnd,
+		});
+	}
+	return declarations;
+}
+
+function inlineTableEnd(text, start) {
+	let depth = 0;
+	let quote = null;
+	let escaped = false;
+	let comment = false;
+	for (let index = start; index < text.length; index += 1) {
+		const character = text[index];
+		if (comment) {
+			if (character === "\n") comment = false;
+			continue;
+		}
+		if (quote) {
+			if (quote === '"' && escaped) {
+				escaped = false;
+				continue;
+			}
+			if (quote === '"' && character === "\\") {
+				escaped = true;
+				continue;
+			}
+			if (character === quote) quote = null;
+			continue;
+		}
+		if (character === "#") {
+			comment = true;
+			continue;
+		}
+		if (character === '"' || character === "'") {
+			quote = character;
+			continue;
+		}
+		if (character === "{") depth += 1;
+		if (character === "}" && --depth === 0) return index + 1;
+	}
+	return null;
+}
+
+function pushVersionedPathDependency(
+	dependencies,
+	manifestPath,
+	name,
+	text,
+	start,
+	end,
+) {
+	const declaration = text.slice(start, end);
+	const dependencyPath = declaration.match(/\bpath\s*=\s*"([^"]+)"/)?.[1];
+	const versionMatch = /\bversion\s*=\s*"([^"]+)"/.exec(declaration);
+	if (!dependencyPath || !versionMatch) return;
+	const valueOffset = versionMatch.index + versionMatch[0].lastIndexOf(versionMatch[1]);
+	dependencies.push({
+		name,
+		version: versionMatch[1],
+		versionStart: start + valueOffset,
+		versionEnd: start + valueOffset + versionMatch[1].length,
+		targetManifest: resolve(dirname(manifestPath), dependencyPath, "Cargo.toml"),
+	});
 }
 
 export function updatePackageVersion(root, version) {
@@ -258,6 +489,7 @@ export function prepareRelease(root, { date = new Date().toISOString().slice(0, 
 	const type = highestChangeType(changes);
 	const version = bumpVersion(currentVersion(root), type);
 	updateCargoToml(root, version);
+	validateCargoLockstepVersions(root, version);
 	updatePackageVersion(root, version);
 	updateChangelog(root, version, date, changes);
 	for (const change of changes) {

--- a/scripts/release.test.mjs
+++ b/scripts/release.test.mjs
@@ -1,4 +1,4 @@
-import { mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, readFileSync, renameSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import test from "node:test";
@@ -11,6 +11,7 @@ import {
 	updateCargoToml,
 	updateChangelog,
 	updatePackageVersion,
+	validateCargoLockstepVersions,
 } from "./release.mjs";
 
 test("bumpVersion applies semver changes", () => {
@@ -137,13 +138,18 @@ test("updateCargoToml bumps every lockstep Rust package and exact dependency pin
 	mkdirSync(join(root, "packages", "lix"), { recursive: true });
 	mkdirSync(join(root, "packages", "storage-rocksdb"), { recursive: true });
 	mkdirSync(join(root, "packages", "storage-slatedb"), { recursive: true });
+	mkdirSync(join(root, "packages", "lix-plugin-bindings-column-merger"), { recursive: true });
 	writeFileSync(
 		join(root, "Cargo.toml"),
 		`[workspace.package]\nversion = "0.6.2"\n\n[workspace.dependencies]\nlix_storage_rocksdb = { path = "packages/storage-rocksdb", version = "=0.6.2" }\nlix_storage_slatedb = { path = "packages/storage-slatedb", version = "=0.6.2" }\nlix = { path = "packages/lix", version = "=0.6.2" }\n`,
 	);
 	writeFileSync(
 		join(root, "packages", "lix", "Cargo.toml"),
-		`[package]\nname = "lix"\nversion.workspace = true\n`,
+		`[package]\nname = "lix"\nversion.workspace = true\n\n[dependencies]\nlix-plugin-bindings-column-merger = { path = "../lix-plugin-bindings-column-merger", version = "=0.6.2" }\n`,
+	);
+	writeFileSync(
+		join(root, "packages", "lix-plugin-bindings-column-merger", "Cargo.toml"),
+		`[package]\nname = "lix-plugin-bindings-column-merger"\nversion.workspace = true\n`,
 	);
 	writeFileSync(
 		join(root, "packages", "js-sdk", "Cargo.toml"),
@@ -165,9 +171,77 @@ test("updateCargoToml bumps every lockstep Rust package and exact dependency pin
 	assert.match(rootCargoToml, /lix_storage_rocksdb = \{ path = "packages\/storage-rocksdb", version = "=0\.7\.0"/);
 	assert.match(rootCargoToml, /lix_storage_slatedb = \{ path = "packages\/storage-slatedb", version = "=0\.7\.0"/);
 	assert.match(rootCargoToml, /lix = \{ path = "packages\/lix", version = "=0\.7\.0"/);
-	assert.match(readFileSync(join(root, "packages", "js-sdk", "Cargo.toml"), "utf8"), /lix = \{ path = "\.\.\/lix", version = "=0\.6\.2"/);
+	assert.match(readFileSync(join(root, "packages", "js-sdk", "Cargo.toml"), "utf8"), /lix = \{ path = "\.\.\/lix", version = "=0\.7\.0"/);
 	assert.match(readFileSync(join(root, "packages", "storage-rocksdb", "Cargo.toml"), "utf8"), /version\.workspace = true/);
-	assert.match(readFileSync(join(root, "packages", "storage-rocksdb", "Cargo.toml"), "utf8"), /lix = \{ path = "\.\.\/lix", version = "=0\.6\.2"/);
+	assert.match(readFileSync(join(root, "packages", "storage-rocksdb", "Cargo.toml"), "utf8"), /lix = \{ path = "\.\.\/lix", version = "=0\.7\.0"/);
+	assert.match(
+		readFileSync(join(root, "packages", "lix", "Cargo.toml"), "utf8"),
+		/lix-plugin-bindings-column-merger = \{ path = "\.\.\/lix-plugin-bindings-column-merger", version = "=0\.7\.0"/,
+	);
+	assert.doesNotThrow(() => validateCargoLockstepVersions(root, "0.7.0"));
+});
+
+test("lockstep preflight reports every partial Cargo version bump", () => {
+	const root = mkdtempSync(join(tmpdir(), "lix-release-test-"));
+	for (const packageName of ["app", "binding-a", "binding-b"]) {
+		mkdirSync(join(root, "packages", packageName), { recursive: true });
+	}
+	writeFileSync(
+		join(root, "Cargo.toml"),
+		`[workspace.package]\nversion = "0.12.0"\n`,
+	);
+	writeFileSync(
+		join(root, "packages", "app", "Cargo.toml"),
+		`[package]\nname = "app"\nversion.workspace = true\n\n[dependencies]\nbinding-a = {\n\tpath = "../binding-a",\n\tversion = "=0.11.0",\n}\n\n[dependencies.binding-b]\npath = "../binding-b"\nversion = "=0.10.0"\n`,
+	);
+	for (const packageName of ["binding-a", "binding-b"]) {
+		writeFileSync(
+			join(root, "packages", packageName, "Cargo.toml"),
+			`[package]\nname = "${packageName}"\nversion.workspace = true\n`,
+		);
+	}
+
+	assert.throws(
+		() => validateCargoLockstepVersions(root),
+		(error) => {
+			assert.match(error.message, /binding-a requires =0\.11\.0, expected =0\.12\.0/);
+			assert.match(error.message, /binding-b requires =0\.10\.0, expected =0\.12\.0/);
+			return true;
+		},
+	);
+
+	updateCargoToml(root, "0.12.0");
+	assert.doesNotThrow(() => validateCargoLockstepVersions(root));
+});
+
+test("updateCargoToml restores every manifest after a commit failure", () => {
+	const root = mkdtempSync(join(tmpdir(), "lix-release-test-"));
+	for (const packageName of ["app", "binding"]) {
+		mkdirSync(join(root, "packages", packageName), { recursive: true });
+	}
+	const rootManifest = `[workspace.package]\nversion = "0.11.0"\n`;
+	const appManifest = `[package]\nname = "app"\nversion.workspace = true\n\n[dependencies]\nbinding = { path = "../binding", version = "=0.11.0" }\n`;
+	writeFileSync(join(root, "Cargo.toml"), rootManifest);
+	writeFileSync(join(root, "packages", "app", "Cargo.toml"), appManifest);
+	writeFileSync(
+		join(root, "packages", "binding", "Cargo.toml"),
+		`[package]\nname = "binding"\nversion.workspace = true\n`,
+	);
+
+	let commits = 0;
+	assert.throws(
+		() =>
+			updateCargoToml(root, "0.12.0", {
+				renameManifest(source, destination) {
+					commits += 1;
+					if (commits === 2) throw new Error("injected commit failure");
+					renameSync(source, destination);
+				},
+			}),
+		/injected commit failure/,
+	);
+	assert.equal(readFileSync(join(root, "Cargo.toml"), "utf8"), rootManifest);
+	assert.equal(readFileSync(join(root, "packages", "app", "Cargo.toml"), "utf8"), appManifest);
 });
 
 test("updatePackageVersion pins native optional dependencies", () => {


### PR DESCRIPTION
## Root cause

`prepare-release.mjs` bumps `[workspace.package].version`, but the propagation helper only inspected root `[workspace.dependencies]`. PR #1482 added exact local pins for all three `lix-plugin-bindings-*` packages inside `packages/lix/Cargo.toml`. After the release bump to 0.12.0, those packages inherited 0.12.0 while `lix` still required `=0.11.0`.

Canonical failure:

```text
error: failed to select a version for the requirement `lix-plugin-bindings-column-merger = "=0.11.0"`
candidate versions found which did not match: 0.12.0
required by package `lix v0.12.0`
Command failed: cargo update --workspace
```

The immediate regression was activated by `813fb9152e591d97a3336c507e2891735e0eaab4` in PR #1482. It exposed the pre-existing root-only propagation limitation from `66f2cb44256420174f29741d6d588f78a7a91d1c`.

## Fix

- Discover every Cargo manifest, including nested and tooling workspaces.
- Identify every local package inheriting `version.workspace = true`.
- Atomically plan exact version propagation for every versioned local path dependency across dependency lists, multiline inline declarations, and dependency subtables.
- Validate the complete graph and report every mismatch deterministically before `cargo update --workspace`.
- Stage every changed manifest before commit and restore all originals if a mid-commit rename fails.
- Keep exact requirements exact; no compatibility ranges are introduced.

Scope remains exactly two files:

- `scripts/release.mjs`
- `scripts/release.test.mjs`

## Validation

- `node --test scripts/release.test.mjs`: 12/12 PASS
- Partial-bump fixture reports all stale dependencies: PASS
- Complete-bump fixture: PASS
- Injected second-manifest commit failure restores every original: PASS
- Simulated 0.12 `cargo metadata --no-deps --format-version 1`: PASS
- Simulated 0.12 `cargo update --workspace`: PASS; all 16 lockstep packages updated, including all three plugin bindings
- `node --check scripts/release.mjs`: PASS
- `cargo fmt --all -- --check`: PASS
- `git diff --check`: PASS
- Independent source review: APPROVE

Exact parent: `887b7a45ae732f2d3e0de8c13778dfc9b05f6e4c`
Candidate: `3470e3701f80c08c3d78c2a517f7c78e03a3eff9`
Full-index SHA-256: `11b52742b0ad3adeb1c7faeeb811ea46346be365eb4326f182cd180585426bc6`
Stable patch-id: `d5f98529875c9dc18aaaf88141e03e3a8675eefc`
Evidence report SHA-256: `2c296927922906deeacc0716b2e893f97824ec329838106706fa83e24714c689`
