### PR TITLE
fix(lix): keep SQL operations on the default test stack

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -171,10 +171,9 @@ jobs:
           cargo test --manifest-path tooling/Cargo.toml --profile test -p lix_e2e --features sdk-tests,plugin-tests,server-protocol,storage-benches,slatedb,root-replay-trace --no-run
 
       - name: Run Rust workspace tests
-        # Deliberately no RUST_MIN_STACK here. Tests that need more than
-        # libtest's 2 MiB worker-stack default must size their own thread
-        # (see `run_on_sized_stack` in the CRUD public-result parity test), so
-        # that the command a developer runs by hand behaves like CI's.
+        # Deliberately no stack-size override here. Production operations and
+        # their tests must fit libtest's default worker stack, so the command a
+        # developer runs by hand behaves like CI's.
         #
         # `--no-fail-fast` is required, not cosmetic. Without it cargo stops at
         # the first failing target and never runs the rest, so a single red

--- a/packages/e2e/tests/tracked_state_crud_public_result.rs
+++ b/packages/e2e/tests/tracked_state_crud_public_result.rs
@@ -20,43 +20,6 @@ async fn serialized_public_result_test() -> tokio::sync::MutexGuard<'static, ()>
     PUBLIC_RESULT_TEST_LOCK.lock().await
 }
 
-/// Stack budget for the OLAP parity bodies below.
-///
-/// These tests build and optimize real DataFusion plans over a seeded fixture.
-/// Plan construction and the optimizer recurse per plan node, and an
-/// unoptimized build needs several times the stack that an optimized one does,
-/// so the bodies overflow libtest's 2 MiB worker-stack default in the `test`
-/// profile while passing in `--release`. Running them on an explicitly sized
-/// thread makes the suite independent of the build profile and of whether
-/// `RUST_MIN_STACK` happens to be exported by the caller.
-const PUBLIC_RESULT_TEST_STACK_SIZE: usize = 32 * 1024 * 1024;
-
-/// Runs an async test body on a thread with [`PUBLIC_RESULT_TEST_STACK_SIZE`]
-/// of stack, driven by a current-thread runtime so the concurrency semantics
-/// match the `#[tokio::test]` default these bodies were written against.
-///
-/// Panics (including assertion failures) propagate to the libtest worker
-/// through the join handle, so a failing assertion still fails the test.
-fn run_on_sized_stack<Body, Fut>(name: &str, body: Body)
-where
-    Body: FnOnce() -> Fut + Send + 'static,
-    Fut: Future<Output = ()>,
-{
-    std::thread::Builder::new()
-        .name(name.to_string())
-        .stack_size(PUBLIC_RESULT_TEST_STACK_SIZE)
-        .spawn(move || {
-            tokio::runtime::Builder::new_current_thread()
-                .enable_all()
-                .build()
-                .expect("build public-result test runtime")
-                .block_on(body());
-        })
-        .expect("spawn public-result test thread")
-        .join()
-        .expect("public-result test body panicked");
-}
-
 #[test]
 fn typed_olap_queries_are_plain_datafusion_selects() {
     use datafusion::sql::parser::DFParser;
@@ -86,11 +49,9 @@ fn typed_olap_queries_are_plain_datafusion_selects() {
     }
 }
 
-#[test]
-fn typed_olap_shapes_validate_exact_results_on_every_adapter() {
-    run_on_sized_stack("olap-exact-results", || async {
-        validate_exact_olap_shapes().await;
-    });
+#[tokio::test]
+async fn typed_olap_shapes_validate_exact_results_on_every_adapter() {
+    validate_exact_olap_shapes().await;
 }
 
 async fn validate_exact_olap_shapes() {
@@ -117,11 +78,9 @@ async fn validate_exact_olap_shapes() {
     }
 }
 
-#[test]
-fn typed_olap_shapes_validate_above_columnar_publication_threshold() {
-    run_on_sized_stack("olap-above-columnar-threshold", || async {
-        validate_above_columnar_publication_threshold().await;
-    });
+#[tokio::test]
+async fn typed_olap_shapes_validate_above_columnar_publication_threshold() {
+    validate_above_columnar_publication_threshold().await;
 }
 
 async fn validate_above_columnar_publication_threshold() {
@@ -148,12 +107,10 @@ async fn validate_above_columnar_publication_threshold() {
     }
 }
 
-#[test]
-fn typed_olap_shapes_validate_exact_results_after_sparse_and_moderate_mutations() {
-    run_on_sized_stack("post-update-olap-validation", || async {
-        let _test_guard = serialized_public_result_test().await;
-        validate_post_update_olap_shapes().await;
-    });
+#[tokio::test]
+async fn typed_olap_shapes_validate_exact_results_after_sparse_and_moderate_mutations() {
+    let _test_guard = serialized_public_result_test().await;
+    validate_post_update_olap_shapes().await;
 }
 
 async fn validate_post_update_olap_shapes() {
@@ -173,11 +130,9 @@ async fn validate_post_update_olap_shapes() {
     }
 }
 
-#[test]
-fn insert_benchmark_uses_public_batch_on_every_adapter() {
-    run_on_sized_stack("public-parameter-batch", || async {
-        validate_public_parameter_batch().await;
-    });
+#[tokio::test]
+async fn insert_benchmark_uses_public_batch_on_every_adapter() {
+    validate_public_parameter_batch().await;
 }
 
 async fn validate_public_parameter_batch() {
@@ -202,11 +157,9 @@ async fn validate_public_parameter_batch() {
     }
 }
 
-#[test]
-fn public_insert_batches_work_across_sequential_fixtures() {
-    run_on_sized_stack("sequential-public-batches", || async {
-        validate_sequential_public_batches().await;
-    });
+#[tokio::test]
+async fn public_insert_batches_work_across_sequential_fixtures() {
+    validate_sequential_public_batches().await;
 }
 
 async fn validate_sequential_public_batches() {
@@ -234,11 +187,9 @@ async fn validate_sequential_public_batches() {
     assert_eq!(slatedb.insert_all().await, 1);
 }
 
-#[test]
-fn public_insert_batches_work_for_concurrent_fixtures() {
-    run_on_sized_stack("concurrent-public-batches", || async {
-        validate_concurrent_public_batches().await;
-    });
+#[tokio::test]
+async fn public_insert_batches_work_for_concurrent_fixtures() {
+    validate_concurrent_public_batches().await;
 }
 
 async fn validate_concurrent_public_batches() {
@@ -269,8 +220,6 @@ async fn insert_one_counter_fixture(
 /// Regression for the automatic-write future retaining SlateDB's large
 /// adapter-specific open and commit futures on Tokio's default test stack.
 ///
-/// Deliberately NOT wrapped in [`run_on_sized_stack`]: asserting that this
-/// path still fits the default worker stack is the entire point of the test.
 /// It must keep running on whatever stack libtest hands it.
 #[cfg(feature = "slatedb")]
 #[tokio::test]

--- a/packages/lix/src/sql2/exec/datafusion.rs
+++ b/packages/lix/src/sql2/exec/datafusion.rs
@@ -9476,28 +9476,8 @@ mod tests {
         })
     }
 
-    fn run_async_test_with_large_stack(
-        test: impl FnOnce() -> futures_util::future::LocalBoxFuture<'static, ()> + Send + 'static,
-    ) {
-        std::thread::Builder::new()
-            .name("sql2-execute-test".to_string())
-            .stack_size(32 * 1024 * 1024)
-            .spawn(move || {
-                tokio::runtime::Builder::new_current_thread()
-                    .enable_all()
-                    .build()
-                    .expect("test runtime should build")
-                    .block_on(test());
-            })
-            .expect("test thread should spawn")
-            .join()
-            .expect("test thread should join");
-    }
-
-    #[test]
-    fn execute_sql_reads_row_view_from_active_branch() {
-        run_async_test_with_large_stack(|| {
-            Box::pin(async move {
+    #[tokio::test]
+    async fn execute_sql_reads_row_view_from_active_branch() {
                 let ctx = setup_sql2_state_fixture()
                     .await
                     .expect("fixture should initialize");
@@ -9515,14 +9495,10 @@ mod tests {
                 assert_eq!(result.rows.len(), 1);
                 assert_eq!(result.rows[0][0], Value::Text("A".to_string()));
                 assert_eq!(result.rows[0][1], Value::Json(json!(["row-a"]).into()));
-            })
-        });
     }
 
-    #[test]
-    fn execute_sql_reads_row_by_branch_view() {
-        run_async_test_with_large_stack(|| {
-            Box::pin(async move {
+    #[tokio::test]
+    async fn execute_sql_reads_row_by_branch_view() {
                 let ctx = setup_sql2_state_fixture()
                     .await
                     .expect("fixture should initialize");
@@ -9544,14 +9520,10 @@ mod tests {
                     result.rows[0][1],
                     Value::Text("01920000-0000-7000-8000-0000000000b1".to_string())
                 );
-            })
-        });
     }
 
-    #[test]
-    fn execute_sql_reads_lix_directory_by_branch_view() {
-        run_async_test_with_large_stack(|| {
-            Box::pin(async move {
+    #[tokio::test]
+    async fn execute_sql_reads_lix_directory_by_branch_view() {
                 let ctx = setup_sql2_state_fixture()
                     .await
                     .expect("fixture should initialize");
@@ -9574,14 +9546,10 @@ mod tests {
                     result.rows[0][2],
                     Value::Text("01920000-0000-7000-8000-0000000000a1".to_string())
                 );
-            })
-        });
     }
 
-    #[test]
-    fn execute_sql_reads_lix_directory_from_active_branch() {
-        run_async_test_with_large_stack(|| {
-            Box::pin(async move {
+    #[tokio::test]
+    async fn execute_sql_reads_lix_directory_from_active_branch() {
                 let ctx = setup_sql2_state_fixture()
                     .await
                     .expect("fixture should initialize");
@@ -9600,14 +9568,10 @@ mod tests {
                 assert_eq!(result.rows.len(), 1);
                 assert_eq!(result.rows[0][0], Value::Text("/docs".to_string()));
                 assert_eq!(result.rows[0][1], Value::Text("docs".to_string()));
-            })
-        });
     }
 
-    #[test]
-    fn execute_sql_reads_lix_file_by_branch_view() {
-        run_async_test_with_large_stack(|| {
-            Box::pin(async move {
+    #[tokio::test]
+    async fn execute_sql_reads_lix_file_by_branch_view() {
                 let ctx = setup_sql2_state_fixture()
                     .await
                     .expect("fixture should initialize");
@@ -9637,14 +9601,10 @@ mod tests {
                     result.rows[0][3],
                     Value::Text("01920000-0000-7000-8000-0000000000a1".to_string())
                 );
-            })
-        });
     }
 
-    #[test]
-    fn execute_sql_reads_lix_file_from_active_branch() {
-        run_async_test_with_large_stack(|| {
-            Box::pin(async move {
+    #[tokio::test]
+    async fn execute_sql_reads_lix_file_from_active_branch() {
                 let ctx = setup_sql2_state_fixture()
                     .await
                     .expect("fixture should initialize");
@@ -9667,7 +9627,5 @@ mod tests {
                 );
                 assert_eq!(result.rows[0][1], Value::Text("readme.md".to_string()));
                 assert_eq!(result.rows[0][2], Value::Blob(vec![0x41, 0x42].into()));
-            })
-        });
     }
 }

--- a/packages/lix/src/sql_profile/point_join_scan_scaling.rs
+++ b/packages/lix/src/sql_profile/point_join_scan_scaling.rs
@@ -13,16 +13,9 @@
 //! cannot falsify this claim: moving a filter earlier in the plan changes
 //! `scan_rows` while the collection is still being read end to end.
 
-use std::future::Future;
-
 use crate::engine::Engine;
 use crate::session::SessionContext;
 use crate::{Memory, Value};
-
-/// See the identical note in `e2e`'s `tracked_state_crud_public_result`:
-/// building and optimizing real DataFusion plans recurses per plan node and
-/// overflows libtest's 2 MiB worker stack in the `test` profile.
-const POINT_JOIN_TEST_STACK_SIZE: usize = 32 * 1024 * 1024;
 
 const NESTED_BUNDLE_SQL: &str = r#"SELECT bundle.id AS "bundle_id", bundle.declarations AS "bundleDeclarations", message.id AS "message_id", message.locale AS "messageLocale", variant.id AS "variantId", variant.pattern AS "variantPattern" FROM bundle LEFT JOIN message ON message."bundle_id" = bundle.id LEFT JOIN variant ON variant."message_id" = message.id WHERE bundle.id = $1"#;
 
@@ -30,29 +23,8 @@ const NESTED_BUNDLE_SQL: &str = r#"SELECT bundle.id AS "bundle_id", bundle.decla
 /// variant each: one bundle row, two message rows, two variant rows.
 const ANSWER_SIZED_ROWS: u64 = 5;
 
-fn run_on_sized_stack<Body, Fut>(name: &str, body: Body)
-where
-    Body: FnOnce() -> Fut + Send + 'static,
-    Fut: Future<Output = ()>,
-{
-    std::thread::Builder::new()
-        .name(name.to_string())
-        .stack_size(POINT_JOIN_TEST_STACK_SIZE)
-        .spawn(move || {
-            tokio::runtime::Builder::new_current_thread()
-                .enable_all()
-                .build()
-                .expect("build point-join test runtime")
-                .block_on(body());
-        })
-        .expect("spawn point-join test thread")
-        .join()
-        .expect("point-join test body panicked");
-}
-
-#[test]
-fn nested_bundle_point_lookup_reads_rows_proportional_to_its_answer() {
-    run_on_sized_stack("point_join_scan_scaling", || async {
+#[tokio::test]
+async fn nested_bundle_point_lookup_reads_rows_proportional_to_its_answer() {
         let mut examined_by_size = Vec::new();
         for bundles in [10_usize, 500] {
             let session = seeded_session(bundles).await;
@@ -88,12 +60,10 @@ fn nested_bundle_point_lookup_reads_rows_proportional_to_its_answer() {
             small, large,
             "rows examined must not grow with the collections being joined"
         );
-    });
 }
 
-#[test]
-fn nested_bundle_point_lookup_preserves_left_join_null_extension() {
-    run_on_sized_stack("point_join_null_extension", || async {
+#[tokio::test]
+async fn nested_bundle_point_lookup_preserves_left_join_null_extension() {
         let session = seeded_session(4).await;
         // A bundle with no message at all, and a message with no variant. Both
         // are rows the probe-key restriction must not be able to remove.
@@ -160,7 +130,6 @@ fn nested_bundle_point_lookup_preserves_left_join_null_extension() {
             ],
             "a fully populated bundle must produce both of its rows"
         );
-    });
 }
 
 type NestedRow = (String, Option<String>, Option<String>);

--- a/packages/lix/src/storage_adapter/point.rs
+++ b/packages/lix/src/storage_adapter/point.rs
@@ -31,7 +31,11 @@ where
             "exact point-read request cardinality overflowed usize".to_string(),
         ));
     };
-    let result = read.get_many(requests).await?;
+    // Keep adapter-specific point-read futures off the caller's stack. This
+    // boundary is reached from deeply nested authenticated state reads, and
+    // debug builds otherwise retain the concrete RocksDB/SlateDB future in
+    // every enclosing poll frame.
+    let result = Box::pin(read.get_many(requests)).await?;
     if result.values.len() != expected {
         return Err(StorageError::Corruption(format!(
             "exact point read returned {} values for {expected} requested keys in a {}-request batch",

--- a/packages/lix/src/transaction/context.rs
+++ b/packages/lix/src/transaction/context.rs
@@ -3125,9 +3125,9 @@ where
                 reject_external_plugin_registry_rows(&rows)?;
                 let count = rows.len() as u64;
                 let mut file_content = Vec::new();
-                let mut reconciliation = self
-                    .plugin_write_reconciliation(&mut rows, &mut file_content)
-                    .await?;
+                let mut reconciliation =
+                    Box::pin(self.plugin_write_reconciliation(&mut rows, &mut file_content))
+                        .await?;
                 reconciliation.attach_durable_checkpoints(&mut file_content)?;
                 let mut rows = reconciliation.take_reconciled_rows(rows);
                 for (file_key, version) in &reconciliation.materialization_versions {
@@ -3195,13 +3195,14 @@ where
             } => {
                 let mut rows = rows;
                 reject_external_plugin_registry_rows(&rows)?;
-                let mut reconciliation = self
-                    .plugin_write_reconciliation(&mut rows, &mut file_content)
-                    .instrument(tracing::debug_span!(
-                        target: "lix_perf",
-                        "lix.perf.plugin_reconciliation"
-                    ))
-                    .await?;
+                let mut reconciliation = Box::pin(
+                    self.plugin_write_reconciliation(&mut rows, &mut file_content)
+                        .instrument(tracing::debug_span!(
+                            target: "lix_perf",
+                            "lix.perf.plugin_reconciliation"
+                        )),
+                )
+                .await?;
                 reconciliation.attach_durable_checkpoints(&mut file_content)?;
                 let mut rows = reconciliation.take_reconciled_rows(rows);
                 rows.retain_raw(|row| {

--- a/packages/lix/tests/hot_index_range_probe.rs
+++ b/packages/lix/tests/hot_index_range_probe.rs
@@ -23,13 +23,7 @@
 // while `--all-features` stays green. Same line as `preimage_route_census`.
 #![cfg(feature = "storage-benches")]
 
-use std::future::Future;
-
 use lix::{Lix, Memory, Value, open_lix};
-
-/// Building and optimizing real DataFusion plans recurses per plan node and
-/// overflows libtest's 2 MiB worker stack in the `test` profile.
-const RANGE_PROBE_TEST_STACK_SIZE: usize = 32 * 1024 * 1024;
 
 /// The measured query selects a closed interval of three ordinals.
 const ANSWER_ROWS: u64 = 3;
@@ -39,80 +33,58 @@ const ANSWER_ROWS: u64 = 3;
 /// must not move when the collection grows 20x. A scan's would grow with it.
 const COLLECTION_SIZES: [usize; 2] = [10, 200];
 
-fn run_on_sized_stack<Body, Fut>(name: &str, body: Body)
-where
-    Body: FnOnce() -> Fut + Send + 'static,
-    Fut: Future<Output = ()>,
-{
-    std::thread::Builder::new()
-        .name(name.to_string())
-        .stack_size(RANGE_PROBE_TEST_STACK_SIZE)
-        .spawn(move || {
-            tokio::runtime::Builder::new_current_thread()
-                .enable_all()
-                .build()
-                .expect("build range-probe test runtime")
-                .block_on(body());
-        })
-        .expect("spawn range-probe test thread")
-        .join()
-        .expect("range-probe test body panicked");
-}
-
-#[test]
-fn range_seek_reads_candidates_set_by_its_answer_and_refuses_without_an_index() {
-    run_on_sized_stack("hot_index_range_probe", || async {
-        // ---- the access-path claim, as a curve rather than a point ---------
-        let mut candidates_by_size = Vec::new();
-        for rows in COLLECTION_SIZES {
-            let session = seeded_session("range_seek_note", true, rows).await;
-            // Seeding a declared-unique collection probes this same index
-            // during uniqueness validation, so drain immediately before the
-            // measured read or the census describes the writes too.
-            let _ = lix::storage_bench::take_hot_index_probe_census();
-            let answered = ordinal_range_ids(&session, "range_seek_note", 2, 4).await;
-            let census = lix::storage_bench::take_hot_index_probe_census();
-
-            assert_eq!(
-                answered,
-                vec!["n5".to_string(), "n6".to_string(), "n7".to_string()],
-                "ordinals 2,3,4 are the sixth through eighth rows at {rows} rows"
-            );
-            assert!(
-                census.range_probes_engaged >= 1,
-                "the range seek should engage on a declared column at {rows} rows; \
-                 census={census:?}"
-            );
-            candidates_by_size.push(census.range_probe_candidates);
-        }
-
-        // A seek reads entries proportional to its answer. A scan would read
-        // the collection, so this is the assertion that distinguishes them.
-        assert_eq!(
-            candidates_by_size,
-            vec![ANSWER_ROWS, ANSWER_ROWS],
-            "candidates must be set by the {ANSWER_ROWS}-row answer, not by the \
-             collection: {candidates_by_size:?} at sizes {COLLECTION_SIZES:?}"
-        );
-
-        // ---- the refusal: no declaration means no index to seek ------------
-        let session = seeded_session("range_scan_note", false, COLLECTION_SIZES[0]).await;
+#[tokio::test]
+async fn range_seek_reads_candidates_set_by_its_answer_and_refuses_without_an_index() {
+    // ---- the access-path claim, as a curve rather than a point ---------
+    let mut candidates_by_size = Vec::new();
+    for rows in COLLECTION_SIZES {
+        let session = seeded_session("range_seek_note", true, rows).await;
+        // Seeding a declared-unique collection probes this same index
+        // during uniqueness validation, so drain immediately before the
+        // measured read or the census describes the writes too.
         let _ = lix::storage_bench::take_hot_index_probe_census();
-        let answered = ordinal_range_ids(&session, "range_scan_note", 2, 4).await;
-        let miss = lix::storage_bench::take_hot_index_probe_census();
+        let answered = ordinal_range_ids(&session, "range_seek_note", 2, 4).await;
+        let census = lix::storage_bench::take_hot_index_probe_census();
 
         assert_eq!(
             answered,
             vec!["n5".to_string(), "n6".to_string(), "n7".to_string()],
-            "refusing to seek must not change the answer"
+            "ordinals 2,3,4 are the sixth through eighth rows at {rows} rows"
         );
-        // Exact zero is only defensible because this is a dedicated process
-        // and every arm above it ran sequentially.
-        assert_eq!(
-            miss.range_probes_engaged, 0,
-            "an undeclared column has no index entries and must not seek; census={miss:?}"
+        assert!(
+            census.range_probes_engaged >= 1,
+            "the range seek should engage on a declared column at {rows} rows; \
+                 census={census:?}"
         );
-    });
+        candidates_by_size.push(census.range_probe_candidates);
+    }
+
+    // A seek reads entries proportional to its answer. A scan would read
+    // the collection, so this is the assertion that distinguishes them.
+    assert_eq!(
+        candidates_by_size,
+        vec![ANSWER_ROWS, ANSWER_ROWS],
+        "candidates must be set by the {ANSWER_ROWS}-row answer, not by the \
+             collection: {candidates_by_size:?} at sizes {COLLECTION_SIZES:?}"
+    );
+
+    // ---- the refusal: no declaration means no index to seek ------------
+    let session = seeded_session("range_scan_note", false, COLLECTION_SIZES[0]).await;
+    let _ = lix::storage_bench::take_hot_index_probe_census();
+    let answered = ordinal_range_ids(&session, "range_scan_note", 2, 4).await;
+    let miss = lix::storage_bench::take_hot_index_probe_census();
+
+    assert_eq!(
+        answered,
+        vec!["n5".to_string(), "n6".to_string(), "n7".to_string()],
+        "refusing to seek must not change the answer"
+    );
+    // Exact zero is only defensible because this is a dedicated process
+    // and every arm above it ran sequentially.
+    assert_eq!(
+        miss.range_probes_engaged, 0,
+        "an undeclared column has no index entries and must not seek; census={miss:?}"
+    );
 }
 
 async fn ordinal_range_ids(


### PR DESCRIPTION
## Summary

- keep the concrete plugin-reconciliation future off deeply nested SQL write poll frames
- keep adapter-specific `get_many` futures off authenticated point-read call stacks
- remove 32 MiB test-thread wrappers that masked the production defect
- require the real public SQL/DataFusion operations to pass on libtest/Tokio's default worker stack

## Root cause

Normal debug-profile tests overflowed libtest's default 2 MiB worker stack. GDB identified two concrete retained future boundaries rather than expression-depth or row-count recursion:

1. `Transaction::plugin_write_reconciliation` on the public 2,048-row insert path.
2. `StorageAdapterRead::get_many` beneath authenticated mutation-directory reads during SlateDB post-update commit.

The relevant concrete async futures were retained through deep SQL → transaction → authenticated-state poll chains. Boxing at those exact owner boundaries reduces stack retention without changing reads, writes, ordering, errors, corruption validation, or public APIs.

Rejected diagnostics (outer SQL boxing, iterative expression validation, mutation-directory hash/local changes) were fully reverted.

## Before / after

Before, without `RUST_MIN_STACK`:

- `typed_olap_shapes_validate_above_columnar_publication_threshold`: stack overflow / SIGABRT
- `typed_olap_shapes_validate_exact_results_after_sparse_and_moderate_mutations`: stack overflow / SIGABRT

After, still without any stack-size override:

- complete `tracked_state_crud_public_result`: **10/10 pass** across Memory, RocksDB, and SlateDB
- point-join scaling: **2/2 pass**
- direct DataFusion SQL read cluster: **9/9 pass**
- storage point/corruption contracts: **8/8 pass**
- hot-index range probe: **1/1 pass**

The repository has no `RUST_MIN_STACK` setting. Test-only 32 MiB wrappers for these paths were deleted. Unrelated process-isolation, crash-consistency, JS actor, CLI, and Git-replay stack controls remain unchanged.

## Gates

- `cargo fmt --all -- --check`
- `git diff --check origin/main...HEAD`
- `cargo check -p lix --all-features --all-targets`
- `cargo test --manifest-path packages/e2e/Cargo.toml --features storage-benches,slatedb --test tracked_state_crud_public_result -- --nocapture`
- `cargo test -p lix --all-features sql_profile::point_join_scan_scaling:: -- --nocapture`
- `cargo test -p lix --all-features sql2::exec::datafusion::tests::execute_sql_reads_ -- --nocapture`
- `cargo test -p lix --all-features storage_adapter::reader::tests:: -- --nocapture`
- `cargo test -p lix --all-features --test hot_index_range_probe -- --nocapture`

All commands ran without `RUST_MIN_STACK`.

Independent source/performance review: **APPROVE**. Final rebased object was separately verified as an exact seven-file child of merged main with no rebase drift.

## Provenance

- parent: `079f3754bee6d1a74cec6edb057571777db64a50` (PR #1480 merge)
- head: `88820b36819aa06fd3a27be393324262bd5ed8da`
- tree: `71802c6fd726b016e7bf44331f2f4306dbefead5`
- full-index diff SHA-256: `511890cfc92d3b0f2b3ccf9fe2f42a267e428f2a08a5c2a352e09f3ce03cdf80`
- stable patch-id: `93b412c751158193fa5d2bd7b5fa539aea4d1b16`
