### PR TITLE
History: preserve native text in LXCD17 bodies

### DIFF
--- a/packages/e2e/tests/corruption_recovery_qualification.rs
+++ b/packages/e2e/tests/corruption_recovery_qualification.rs
@@ -24,7 +24,7 @@ const CHECKPOINT_FILE_ID: &str = "01920000-0000-7000-8000-000010000000";
 // mismatch, it makes the inventory come back empty.
 const BRANCH_CONTROL_SPACE: &str = "branch.head_control.v11";
 const PLUGIN_CHECKPOINT_SPACE: &str = "plugin.current_checkpoint.v2";
-const COMMIT_MANIFEST_SPACE: &str = "tracked_state.commit_state_manifest.v7";
+const COMMIT_MANIFEST_SPACE: &str = "tracked_state.commit_state_manifest.v8";
 const TREE_CHUNK_SPACE: &str = "tracked_state.tree_chunk";
 const BINARY_CHUNK_SPACE: &str = "binary_cas.chunk";
 

--- a/packages/lix/src/tracked_state/native_history_body.rs
+++ b/packages/lix/src/tracked_state/native_history_body.rs
@@ -12,9 +12,11 @@ use serde_json::Value as JsonValue;
 use crate::row_pk::RowPk;
 use crate::{LixError, storage_codec};
 
-const FORMAT_VERSION: u8 = 1;
-const SEMANTIC_DOMAIN: &str = "lix tracked history native row semantic v1";
-const LAYOUT_DOMAIN: &str = "lix tracked history native row layout v1";
+const FORMAT_VERSION: u8 = 2;
+const SEMANTIC_DOMAIN: &str = "lix tracked history native row semantic v2";
+const LAYOUT_DOMAIN: &str = "lix tracked history native row layout v2";
+const TEXT_ESCAPE: char = '\u{1}';
+const TEXT_ESCAPED_NUL: char = '\u{2}';
 
 #[derive(Debug, Clone, PartialEq, Eq, musli::Encode, musli::Decode)]
 #[musli(packed)]
@@ -278,7 +280,9 @@ fn body_value(
     let invalid = || body_error(format!("{schema_key}.{name} disagrees with its declared type"));
     Ok(match (kind, value) {
         (_, JsonValue::Null) => BodyValue::Null,
-        (lix_schema::DataType::Text, JsonValue::String(value)) => BodyValue::Text(value.clone()),
+        (lix_schema::DataType::Text, JsonValue::String(value)) => {
+            BodyValue::Text(escape_history_text(value))
+        }
         (lix_schema::DataType::Uuid, JsonValue::String(value)) => {
             BodyValue::Uuid(uuid::Uuid::parse_str(value).map_err(|_| invalid())?)
         }
@@ -307,7 +311,7 @@ fn logical_body_value(
     use lix_schema::value_layout::BodyValue;
     Ok(match value {
         BodyValue::Null => JsonValue::Null,
-        BodyValue::Text(value) => JsonValue::String(value),
+        BodyValue::Text(value) => JsonValue::String(unescape_history_text(&value)?),
         BodyValue::Uuid(value) => JsonValue::String(value.to_string()),
         BodyValue::Int8(value) => JsonValue::from(value),
         BodyValue::Float8(value) => serde_json::Number::from_f64(value)
@@ -321,6 +325,48 @@ fn logical_body_value(
                 .to_rfc3339_opts(chrono::SecondsFormat::Micros, true),
         ),
     })
+}
+
+/// History preserves text values that predate Schema-v1's public NUL policy.
+///
+/// The shared typed-row codec deliberately rejects NUL in newly-authored SQL
+/// `text`, while plugin/file history already contains length-delimited text
+/// with embedded NUL bytes. LXCD17 therefore uses one injective, canonical
+/// history-only transform before invoking that codec. This remains a typed
+/// text slot; it is not JSON, a fallback representation, or a second reader.
+fn escape_history_text(value: &str) -> String {
+    let mut escaped = String::with_capacity(value.len());
+    for character in value.chars() {
+        match character {
+            '\0' => {
+                escaped.push(TEXT_ESCAPE);
+                escaped.push(TEXT_ESCAPED_NUL);
+            }
+            TEXT_ESCAPE => {
+                escaped.push(TEXT_ESCAPE);
+                escaped.push(TEXT_ESCAPE);
+            }
+            character => escaped.push(character),
+        }
+    }
+    escaped
+}
+
+fn unescape_history_text(value: &str) -> Result<String, LixError> {
+    let mut decoded = String::with_capacity(value.len());
+    let mut characters = value.chars();
+    while let Some(character) = characters.next() {
+        if character != TEXT_ESCAPE {
+            decoded.push(character);
+            continue;
+        }
+        match characters.next() {
+            Some(TEXT_ESCAPE) => decoded.push(TEXT_ESCAPE),
+            Some(TEXT_ESCAPED_NUL) => decoded.push('\0'),
+            _ => return Err(body_error("contains a non-canonical text escape")),
+        }
+    }
+    Ok(decoded)
 }
 
 fn body_kind(kind: lix_schema::DataType) -> lix_schema::value_layout::BodyKind {
@@ -428,5 +474,25 @@ mod tests {
         for end in 0..encoded.len() {
             assert!(decode(&row_pk, &encoded[..end]).is_err());
         }
+    }
+
+    #[test]
+    fn native_history_text_losslessly_carries_nul_and_escape_code_points() {
+        let schema = serde_json::json!({
+            "$schema": lix_schema::SCHEMA_V1_URI,
+            "key": "native_history_text",
+            "columns": [
+                {"name":"id", "type":"text", "nullable":false},
+                {"name":"payload", "type":"text", "nullable":false}
+            ],
+            "primary_key": ["id"]
+        });
+        let row_pk = RowPk::from_validated_shared_string("row".into());
+        let text = "{\"id\":\"row\",\"payload\":\"left\\u0000middle\\u0001right\"}";
+        let encoded = encode(&schema, &row_pk, text).expect("encode history text");
+        assert_eq!(
+            decode(&row_pk, &encoded).expect("decode history text"),
+            text
+        );
     }
 }

--- a/packages/lix/src/transaction/commit.rs
+++ b/packages/lix/src/transaction/commit.rs
@@ -7359,7 +7359,7 @@ mod tests {
     // be the drift `storage_spaces` exists to prevent.
     const TRACKED_STATE_COMMIT_STATE_MANIFEST_SPACE: StorageSpace = StorageSpace::immutable(
         TRACKED_STATE_COMMIT_STATE_MANIFEST_SPACE_ID,
-        "tracked_state.commit_state_manifest.v7",
+        "tracked_state.commit_state_manifest.v8",
     );
     // V11 has no tracked-head marker space. Keep the retired v10 ID here only
     // as a negative test sentinel: normal serving and staging must never read


### PR DESCRIPTION
Follow-up to #1486 for two candidate-owned CI findings.

- keeps LXCD17 history self-contained and typed
- adds an injective history-only text transform for pre-existing plugin/file text containing NUL
- bumps the native history body version plus semantic/layout domains
- does not change Schema-v1's public text policy
- no JSON fallback, compatibility decoder, legacy reader, migration, or dual writer
- updates two stale corruption/manifest-space fixtures from v7 to v8

Focused gates:
- native history codec 2/2
- Excalidraw 6/6
- CEB2 Memory/Rocks/Slate 3/3 (+1 ignored benchmark probe)
- atomic plugin import scale 1/1
- Rocks/Slate corruption-reopen 2/2
- lix test-aware all-features check: PASS
- lix all-features Clippy with `-D warnings`: PASS
- independent source/authority review: APPROVE, no P0/P1

Exact provenance:
- parent `6b2dafd7cf912884cb7d260d20d29963bf770a55`
- head `363815c2fe3928f12ca22360b05fd61e16d04a9d`
- tree `fc976cb731a5094b0461fec9ccb0d323f9a8cfc4`
- full-index SHA-256 `67e3d0775b7f5080326a7d97ed18adc8af25937854191d13b0f8a46720c2c1f6`
- stable patch-id `9f7a252c08369cbe4b8e92cb7df3d8c70b18f125`
