### PR TITLE
Fix bootstrap accounts so branches inherit them instead of copying them

### DIFF
--- a/packages/lix/src/handle.rs
+++ b/packages/lix/src/handle.rs
@@ -1081,9 +1081,12 @@ mod tests {
 
     #[tokio::test]
     async fn bootstrap_accounts_are_global_rows_inherited_by_branches() {
+        const AUTHOR_ID: &str = "01920000-0000-7000-8000-0000000006a1";
         let root = open_lix().await.expect("open root Lix");
 
-        // Query bootstrap accounts on the main branch via SQL
+        // SELECT on the default (main) session inherits the two built-ins.
+        // Before this fix those rows were staged onto main as local copies
+        // (`lixcol_global = false`) that shadowed the global rows.
         let accounts = root
             .execute(
                 "SELECT id, name, lixcol_global FROM lix_account ORDER BY name",
@@ -1091,70 +1094,84 @@ mod tests {
             )
             .await
             .expect("query accounts should succeed");
-
         assert_eq!(
             accounts.rows().len(),
             2,
             "should see exactly two bootstrap accounts"
         );
-
         for row in accounts.rows() {
-            let values = row.values();
-            let lixcol_global = &values[2];
-
             assert_eq!(
-                lixcol_global,
+                &row.values()[2],
                 &Value::Boolean(true),
                 "bootstrap account should have lixcol_global=true"
             );
         }
 
-        // Query from the *_by_branch table to verify branch_id
-        let accounts_by_branch = root
+        // Physical copies materialize as `lixcol_global = false`. Unfiltered
+        // `*_by_branch` also *projects* inherited global rows onto every
+        // visible branch with `lixcol_global = true` — that is the same
+        // visibility overlay `ensure_account` uses, not a second seed write.
+        let local_copies = root
             .execute(
-                "SELECT id, name, lixcol_global, lixcol_branch_id \
-                 FROM lix_account_by_branch \
-                 WHERE id IN ($1, $2) \
-                 ORDER BY lixcol_branch_id, name",
+                "SELECT id, lixcol_branch_id FROM lix_account_by_branch \
+                 WHERE id IN ($1, $2) AND lixcol_global = false",
                 &[
                     Value::Text(lix::SYSTEM_ACCOUNT_ID.to_string()),
                     Value::Text(lix::ANONYMOUS_ACCOUNT_ID.to_string()),
                 ],
             )
             .await
-            .expect("query accounts_by_branch should succeed");
-
-        eprintln!("Found {} rows in lix_account_by_branch", accounts_by_branch.rows().len());
-        for row in accounts_by_branch.rows() {
-            let values = row.values();
-            eprintln!("  id={:?}, name={:?}, global={:?}, branch_id={:?}", 
-                     values[0], values[1], values[2], values[3]);
-        }
-
-        assert_eq!(
-            accounts_by_branch.rows().len(),
-            2,
-            "should see exactly two bootstrap accounts in lix_account_by_branch (only on GLOBAL_BRANCH_ID, not duplicated on main)"
+            .expect("query local account copies should succeed");
+        assert!(
+            local_copies.rows().is_empty(),
+            "built-in accounts must not have branch-local copies"
         );
 
-        for row in accounts_by_branch.rows() {
+        let home_rows = root
+            .execute(
+                "SELECT id, name, lixcol_global, lixcol_branch_id \
+                 FROM lix_account_by_branch \
+                 WHERE id IN ($1, $2) AND lixcol_branch_id = $3 \
+                 ORDER BY name",
+                &[
+                    Value::Text(lix::SYSTEM_ACCOUNT_ID.to_string()),
+                    Value::Text(lix::ANONYMOUS_ACCOUNT_ID.to_string()),
+                    Value::Text(lix::GLOBAL_BRANCH_ID.to_string()),
+                ],
+            )
+            .await
+            .expect("query home account rows should succeed");
+        assert_eq!(
+            home_rows.rows().len(),
+            2,
+            "built-in accounts live on GLOBAL_BRANCH_ID"
+        );
+        for row in home_rows.rows() {
             let values = row.values();
-            let lixcol_global = &values[2];
-            let lixcol_branch_id = &values[3];
-
+            assert_eq!(&values[2], &Value::Boolean(true));
             assert_eq!(
-                lixcol_global,
-                &Value::Boolean(true),
-                "bootstrap account should have lixcol_global=true in lix_account_by_branch"
-            );
-            assert_eq!(
-                lixcol_branch_id,
-                &Value::Text(lix::GLOBAL_BRANCH_ID.to_string()),
-                "bootstrap account should have lixcol_branch_id=GLOBAL_BRANCH_ID in lix_account_by_branch"
+                &values[3],
+                &Value::Text(lix::GLOBAL_BRANCH_ID.to_string())
             );
         }
 
-        // Switch to a new branch and verify accounts are still visible as global
+        // A later ensure_account write has the same physical/home shape.
+        root.ensure_account(AUTHOR_ID, "Ada", "human")
+            .await
+            .expect("provision author");
+        let author_copies = root
+            .execute(
+                "SELECT id FROM lix_account_by_branch \
+                 WHERE id = $1 AND lixcol_global = false",
+                &[Value::Text(AUTHOR_ID.to_string())],
+            )
+            .await
+            .expect("query ensure_account copies should succeed");
+        assert!(
+            author_copies.rows().is_empty(),
+            "ensure_account must not create branch-local copies either"
+        );
+
         let draft = root
             .create_branch(CreateBranchOptions {
                 id: None,
@@ -1163,7 +1180,6 @@ mod tests {
             })
             .await
             .expect("create draft branch");
-
         root.switch_branch(SwitchBranchOptions {
             branch_id: draft.id.clone(),
         })
@@ -1177,54 +1193,34 @@ mod tests {
             )
             .await
             .expect("query accounts on draft branch should succeed");
-
         assert_eq!(
             draft_accounts.rows().len(),
-            2,
-            "draft branch should also see the two bootstrap accounts"
+            3,
+            "draft branch should inherit the two built-ins plus the ensure_account row"
         );
-
         for row in draft_accounts.rows() {
-            let values = row.values();
-            let lixcol_global = &values[2];
-
             assert_eq!(
-                lixcol_global,
+                &row.values()[2],
                 &Value::Boolean(true),
-                "bootstrap account should still have lixcol_global=true on draft branch"
+                "inherited account should still have lixcol_global=true on draft"
             );
         }
 
-        // Query from *_by_branch table on draft branch to ensure they are not duplicated
-        let draft_accounts_by_branch = root
+        let draft_local_copies = root
             .execute(
-                "SELECT lixcol_branch_id, COUNT(*) as count \
-                 FROM lix_account_by_branch \
-                 WHERE id IN ($1, $2) \
-                 GROUP BY lixcol_branch_id",
+                "SELECT id FROM lix_account_by_branch \
+                 WHERE id IN ($1, $2, $3) AND lixcol_global = false",
                 &[
                     Value::Text(lix::SYSTEM_ACCOUNT_ID.to_string()),
                     Value::Text(lix::ANONYMOUS_ACCOUNT_ID.to_string()),
+                    Value::Text(AUTHOR_ID.to_string()),
                 ],
             )
             .await
-            .expect("query accounts_by_branch on draft branch should succeed");
-
-        // Should only have rows on GLOBAL_BRANCH_ID, not duplicated on the draft branch
-        assert_eq!(
-            draft_accounts_by_branch.rows().len(),
-            1,
-            "bootstrap accounts should only exist on GLOBAL_BRANCH_ID, not duplicated on draft"
-        );
-
-        let row = &draft_accounts_by_branch.rows()[0];
-        let values = row.values();
-        let lixcol_branch_id = &values[0];
-
-        assert_eq!(
-            lixcol_branch_id,
-            &Value::Text(lix::GLOBAL_BRANCH_ID.to_string()),
-            "bootstrap accounts should only be on GLOBAL_BRANCH_ID"
+            .expect("query draft local copies should succeed");
+        assert!(
+            draft_local_copies.rows().is_empty(),
+            "creating a branch must not copy global accounts onto the new branch"
         );
     }
 }

--- a/packages/lix/src/handle.rs
+++ b/packages/lix/src/handle.rs
@@ -1078,6 +1078,155 @@ mod tests {
             .expect_err("built-in accounts must remain active");
         assert_eq!(error.code, LixError::CODE_INVALID_PARAM);
     }
+
+    #[tokio::test]
+    async fn bootstrap_accounts_are_global_rows_inherited_by_branches() {
+        let root = open_lix().await.expect("open root Lix");
+
+        // Query bootstrap accounts on the main branch via SQL
+        let accounts = root
+            .execute(
+                "SELECT id, name, lixcol_global FROM lix_account ORDER BY name",
+                &[],
+            )
+            .await
+            .expect("query accounts should succeed");
+
+        assert_eq!(
+            accounts.rows().len(),
+            2,
+            "should see exactly two bootstrap accounts"
+        );
+
+        for row in accounts.rows() {
+            let values = row.values();
+            let lixcol_global = &values[2];
+
+            assert_eq!(
+                lixcol_global,
+                &Value::Boolean(true),
+                "bootstrap account should have lixcol_global=true"
+            );
+        }
+
+        // Query from the *_by_branch table to verify branch_id
+        let accounts_by_branch = root
+            .execute(
+                "SELECT id, name, lixcol_global, lixcol_branch_id \
+                 FROM lix_account_by_branch \
+                 WHERE id IN ($1, $2) \
+                 ORDER BY lixcol_branch_id, name",
+                &[
+                    Value::Text(lix::SYSTEM_ACCOUNT_ID.to_string()),
+                    Value::Text(lix::ANONYMOUS_ACCOUNT_ID.to_string()),
+                ],
+            )
+            .await
+            .expect("query accounts_by_branch should succeed");
+
+        eprintln!("Found {} rows in lix_account_by_branch", accounts_by_branch.rows().len());
+        for row in accounts_by_branch.rows() {
+            let values = row.values();
+            eprintln!("  id={:?}, name={:?}, global={:?}, branch_id={:?}", 
+                     values[0], values[1], values[2], values[3]);
+        }
+
+        assert_eq!(
+            accounts_by_branch.rows().len(),
+            2,
+            "should see exactly two bootstrap accounts in lix_account_by_branch (only on GLOBAL_BRANCH_ID, not duplicated on main)"
+        );
+
+        for row in accounts_by_branch.rows() {
+            let values = row.values();
+            let lixcol_global = &values[2];
+            let lixcol_branch_id = &values[3];
+
+            assert_eq!(
+                lixcol_global,
+                &Value::Boolean(true),
+                "bootstrap account should have lixcol_global=true in lix_account_by_branch"
+            );
+            assert_eq!(
+                lixcol_branch_id,
+                &Value::Text(lix::GLOBAL_BRANCH_ID.to_string()),
+                "bootstrap account should have lixcol_branch_id=GLOBAL_BRANCH_ID in lix_account_by_branch"
+            );
+        }
+
+        // Switch to a new branch and verify accounts are still visible as global
+        let draft = root
+            .create_branch(CreateBranchOptions {
+                id: None,
+                name: "draft".to_string(),
+                from_commit_id: None,
+            })
+            .await
+            .expect("create draft branch");
+
+        root.switch_branch(SwitchBranchOptions {
+            branch_id: draft.id.clone(),
+        })
+        .await
+        .expect("switch to draft branch");
+
+        let draft_accounts = root
+            .execute(
+                "SELECT id, name, lixcol_global FROM lix_account ORDER BY name",
+                &[],
+            )
+            .await
+            .expect("query accounts on draft branch should succeed");
+
+        assert_eq!(
+            draft_accounts.rows().len(),
+            2,
+            "draft branch should also see the two bootstrap accounts"
+        );
+
+        for row in draft_accounts.rows() {
+            let values = row.values();
+            let lixcol_global = &values[2];
+
+            assert_eq!(
+                lixcol_global,
+                &Value::Boolean(true),
+                "bootstrap account should still have lixcol_global=true on draft branch"
+            );
+        }
+
+        // Query from *_by_branch table on draft branch to ensure they are not duplicated
+        let draft_accounts_by_branch = root
+            .execute(
+                "SELECT lixcol_branch_id, COUNT(*) as count \
+                 FROM lix_account_by_branch \
+                 WHERE id IN ($1, $2) \
+                 GROUP BY lixcol_branch_id",
+                &[
+                    Value::Text(lix::SYSTEM_ACCOUNT_ID.to_string()),
+                    Value::Text(lix::ANONYMOUS_ACCOUNT_ID.to_string()),
+                ],
+            )
+            .await
+            .expect("query accounts_by_branch on draft branch should succeed");
+
+        // Should only have rows on GLOBAL_BRANCH_ID, not duplicated on the draft branch
+        assert_eq!(
+            draft_accounts_by_branch.rows().len(),
+            1,
+            "bootstrap accounts should only exist on GLOBAL_BRANCH_ID, not duplicated on draft"
+        );
+
+        let row = &draft_accounts_by_branch.rows()[0];
+        let values = row.values();
+        let lixcol_branch_id = &values[0];
+
+        assert_eq!(
+            lixcol_branch_id,
+            &Value::Text(lix::GLOBAL_BRANCH_ID.to_string()),
+            "bootstrap accounts should only be on GLOBAL_BRANCH_ID"
+        );
+    }
 }
 
 

--- a/packages/lix/src/hot_state/tracked_head/hot.rs
+++ b/packages/lix/src/hot_state/tracked_head/hot.rs
@@ -3542,6 +3542,15 @@ fn packed_current_base_working_diff_baseline(
     }
 }
 
+/// Accounts (and checkpoints) are global facts. A root-backed branch must
+/// inherit them from `GLOBAL_BRANCH_ID` rather than restating the commit's
+/// account rows as branch-local copies (`lixcol_global = false`).
+fn root_current_base_row_belongs_on_branch(branch_id: &str, schema_key: &str) -> bool {
+    branch_id == crate::GLOBAL_BRANCH_ID
+        || (schema_key != "lix_account"
+            && schema_key != crate::checkpoint::CHECKPOINT_SCHEMA_KEY)
+}
+
 fn push_root_current_base_row(
     rows: &mut MaterializedHotStateBatchBuilder,
     row: crate::tracked_state::MaterializedTrackedStateRowRef<'_>,
@@ -3677,7 +3686,8 @@ async fn scan_root_current_base_rows(
             &active_generations,
             &stored_controls,
             &mut scope_memo,
-        ) {
+        ) || !root_current_base_row_belongs_on_branch(branch_id, row.schema_key())
+        {
             continue;
         }
         push_root_current_base_row(&mut rows, row, branch_id, active_checkpoint_commit_id);
@@ -3895,7 +3905,7 @@ async fn load_root_current_base_exact(
                         &active_generations,
                         &stored_controls,
                         &mut scope_memo,
-                    )
+                    ) && root_current_base_row_belongs_on_branch(branch_id, row.schema_key())
                 })
                 .map(|row| {
                     let ordinal = u32::try_from(rows.len())

--- a/packages/lix/src/hot_state/tracked_head/hot.rs
+++ b/packages/lix/src/hot_state/tracked_head/hot.rs
@@ -3542,13 +3542,11 @@ fn packed_current_base_working_diff_baseline(
     }
 }
 
-/// Accounts (and checkpoints) are global facts. A root-backed branch must
-/// inherit them from `GLOBAL_BRANCH_ID` rather than restating the commit's
-/// account rows as branch-local copies (`lixcol_global = false`).
+/// Account rows are global facts. A root-backed branch must inherit them
+/// from `GLOBAL_BRANCH_ID` rather than restating the commit's account rows
+/// as branch-local copies (`lixcol_global = false`).
 fn root_current_base_row_belongs_on_branch(branch_id: &str, schema_key: &str) -> bool {
-    branch_id == crate::GLOBAL_BRANCH_ID
-        || (schema_key != "lix_account"
-            && schema_key != crate::checkpoint::CHECKPOINT_SCHEMA_KEY)
+    branch_id == crate::GLOBAL_BRANCH_ID || schema_key != "lix_account"
 }
 
 fn push_root_current_base_row(

--- a/packages/lix/src/init.rs
+++ b/packages/lix/src/init.rs
@@ -480,6 +480,9 @@ where
         let absence_guards = std::collections::BTreeSet::default();
         for branch in &plan.branch_controls {
             let mut head_deltas = tracked_head_deltas.clone();
+            // Checkpoints and built-in accounts are global facts. Staging them
+            // onto main would materialize branch-local copies (`lixcol_global =
+            // false`) that shadow inheritance from GLOBAL_BRANCH_ID.
             if branch.branch_id != GLOBAL_BRANCH_ID {
                 head_deltas.retain(|delta| {
                     delta.schema_key != CHECKPOINT_SCHEMA_KEY
@@ -1088,7 +1091,9 @@ mod tests {
 
     #[tokio::test]
     async fn bootstrap_accounts_are_global_rows_inherited_by_branches() {
-        use crate::storage_adapter::{Memory, StorageAdapter};
+        use crate::branch::BranchHeadControlContext;
+        use crate::hot_state::TrackedHeadContext;
+        use crate::storage_adapter::{Memory, StorageAdapter, StorageReadOptions};
         use crate::tracked_state::TrackedStateContext;
 
         let storage = StorageAdapter::new(Memory::new());
@@ -1097,11 +1102,38 @@ mod tests {
             .await
             .expect("initialize should succeed");
 
-        // Scan accounts at the initial commit (which both branches share).
         let read = storage
-            .begin_read(crate::storage_adapter::StorageReadOptions::default())
+            .begin_read(StorageReadOptions::default())
             .await
             .expect("read should open");
+        let controls = BranchHeadControlContext::new()
+            .reader(&read)
+            .scan()
+            .await
+            .expect("scan branch-head controls");
+        let tracked_head = TrackedHeadContext::new();
+        let mut saw_global = false;
+        for (branch_id, control) in &controls {
+            let has_accounts = tracked_head
+                .reader(&read)
+                .has_schema_rows(branch_id, *control, ACCOUNT_SCHEMA_KEY)
+                .await
+                .expect("schema presence probe should succeed");
+            if branch_id == GLOBAL_BRANCH_ID {
+                saw_global = true;
+                assert!(
+                    has_accounts,
+                    "GLOBAL_BRANCH_ID must physically store bootstrap accounts"
+                );
+            } else {
+                assert!(
+                    !has_accounts,
+                    "branch {branch_id} must not physically store bootstrap accounts"
+                );
+            }
+        }
+        assert!(saw_global, "initialization must publish a global branch");
+
         let mut tracked_reader = tracked_state.reader(read);
         let rows = tracked_reader
             .scan_batch_at_commit(
@@ -1123,8 +1155,6 @@ mod tests {
             2,
             "tracked state should contain exactly two bootstrap accounts"
         );
-
-        // Verify that the accounts were authored in the initial commit
         for row in &account_rows {
             assert_eq!(
                 row.commit_id,

--- a/packages/lix/src/init.rs
+++ b/packages/lix/src/init.rs
@@ -39,6 +39,7 @@ const KEY_VALUE_SCHEMA_KEY: &str = "lix_key_value";
 const LIX_ID_KEY: &str = "lix_id";
 pub(crate) const DEFAULT_BRANCH_KEY: &str = "lix_default_branch_id";
 const REGISTERED_SCHEMA_KEY: &str = "lix_registered_schema";
+const ACCOUNT_SCHEMA_KEY: &str = "lix_account";
 
 /// Repository-wide compatibility gate for physical storage protocols.
 ///
@@ -234,7 +235,7 @@ pub(crate) fn plan_init_seed(functions: FunctionProviderHandle) -> Result<InitSe
         functions.call_uuid_v7(),
         RowPk::uuid_from_canonical(crate::SYSTEM_ACCOUNT_ID)
             .expect("system account ID is a canonical UUID"),
-        "lix_account",
+        ACCOUNT_SCHEMA_KEY,
         account_snapshot(crate::SYSTEM_ACCOUNT_ID, "System", "system")?,
         timestamp,
     );
@@ -242,7 +243,7 @@ pub(crate) fn plan_init_seed(functions: FunctionProviderHandle) -> Result<InitSe
         functions.call_uuid_v7(),
         RowPk::uuid_from_canonical(crate::ANONYMOUS_ACCOUNT_ID)
             .expect("anonymous account ID is a canonical UUID"),
-        "lix_account",
+        ACCOUNT_SCHEMA_KEY,
         account_snapshot(crate::ANONYMOUS_ACCOUNT_ID, "Anonymous", "anonymous")?,
         timestamp,
     );
@@ -480,7 +481,10 @@ where
         for branch in &plan.branch_controls {
             let mut head_deltas = tracked_head_deltas.clone();
             if branch.branch_id != GLOBAL_BRANCH_ID {
-                head_deltas.retain(|delta| delta.schema_key != CHECKPOINT_SCHEMA_KEY);
+                head_deltas.retain(|delta| {
+                    delta.schema_key != CHECKPOINT_SCHEMA_KEY
+                        && delta.schema_key != ACCOUNT_SCHEMA_KEY
+                });
             }
             let mut working_diff_coverage = WorkingDiffIndexCoverage::default();
             tracked_head
@@ -1080,5 +1084,54 @@ mod tests {
 
     fn test_uuid_value(index: usize) -> uuid::Uuid {
         uuid::Uuid::from_u128(0x0192_0000_0000_7000_8000_0000_0000_0000 + index as u128)
+    }
+
+    #[tokio::test]
+    async fn bootstrap_accounts_are_global_rows_inherited_by_branches() {
+        use crate::storage_adapter::{Memory, StorageAdapter};
+        use crate::tracked_state::TrackedStateContext;
+
+        let storage = StorageAdapter::new(Memory::new());
+        let tracked_state = TrackedStateContext::new();
+        let receipt = initialize(storage.clone(), &tracked_state)
+            .await
+            .expect("initialize should succeed");
+
+        // Scan accounts at the initial commit (which both branches share).
+        let read = storage
+            .begin_read(crate::storage_adapter::StorageReadOptions::default())
+            .await
+            .expect("read should open");
+        let mut tracked_reader = tracked_state.reader(read);
+        let rows = tracked_reader
+            .scan_batch_at_commit(
+                &receipt.initial_commit_id,
+                &crate::tracked_state::TrackedStateScanRequest {
+                    filter: crate::tracked_state::TrackedStateFilter {
+                        schema_keys: vec![ACCOUNT_SCHEMA_KEY.to_string()],
+                        ..Default::default()
+                    },
+                    ..Default::default()
+                },
+            )
+            .await
+            .expect("scan should succeed");
+
+        let account_rows = rows.into_rows();
+        assert_eq!(
+            account_rows.len(),
+            2,
+            "tracked state should contain exactly two bootstrap accounts"
+        );
+
+        // Verify that the accounts were authored in the initial commit
+        for row in &account_rows {
+            assert_eq!(
+                row.commit_id,
+                receipt.initial_commit_id,
+                "account {:?} should be in the initial commit",
+                row.row_pk
+            );
+        }
     }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

`lix_account` is a global entity. The built-in `system` and `anonymous` accounts must exist as physical rows only on `GLOBAL_BRANCH_ID` (`lixcol_global = true`, `file_id` NULL). `SELECT FROM lix_account` on any branch inherits those rows. There must be no branch-local copies (`lixcol_global = false`).

Two paths were restating the genesis / `ensure_account` account rows onto non-global branches as local copies. Those copies win the overlay and hide the real global accounts.

Unfiltered `lix_account_by_branch` can still *project* inherited global rows onto each visible branch with `lixcol_global = true`. That is the existing visibility overlay (same as `ensure_account`), not a physical write.

## Cause

1. **Init complete hot generation.** `initialize` cloned every authored seed delta into each branch’s complete hot current state, so `lix_account` was written into main’s `ROW_SPACE` with `global = false`.

2. **Root current-base reconstruction.** `create_branch` publishes a root-backed generation that walks the shared commit’s tracked state. Account rows were restated onto the new branch as `lixcol_global = false`.

## Fix

- Init omits `lix_account` from non-global complete hot generations (same retain that already skipped checkpoints).
- Root current-base serving does not restate `lix_account` rows onto a non-global branch. The overlay inherits them from `GLOBAL_BRANCH_ID`.
- No new APIs. `ensure_account` is unchanged. Existing stores are not re-seeded.

This PR is the account inherit fix only. It does not add a schema-catalog flag or generalize “global-ness” to other tables.

## Tests

- After `openLix`, `SELECT FROM lix_account` on main returns the two built-ins with `lixcol_global = true`.
- No `lixcol_global = false` copies of the built-ins; home rows live on `GLOBAL_BRANCH_ID`.
- `ensure_account` and `create_branch` keep the same inherited shape.
- Physical hot-state probe: only `GLOBAL_BRANCH_ID` stores `lix_account` rows.

## Contract

- `SYSTEM_ACCOUNT_ID` / `ANONYMOUS_ACCOUNT_ID` remain reserved primary keys.
- Built-ins stay undeletable / undisableable.
- User accounts still go through `ensure_account`.
- Opening an existing store does not re-insert the built-ins.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ae93b1f8-71dc-4f74-9624-72848319d3fe?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ae93b1f8-71dc-4f74-9624-72848319d3fe&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

