### PR TITLE
chore(lix): remove dead prepared DML counters

### DIFF
--- a/packages/lix/src/prepared_dml.rs
+++ b/packages/lix/src/prepared_dml.rs
@@ -1,5 +1,4 @@
 use std::sync::Arc;
-use std::sync::atomic::{AtomicU64, Ordering};
 
 use crate::{Blob, LixError, Value};
 
@@ -17,9 +16,6 @@ pub(crate) struct PreparedDmlParameterBatch {
     cells: Arc<[PreparedDmlCell]>,
     bytes: Arc<[u8]>,
 }
-
-static PREPARED_DML_BATCH_EXECUTIONS: AtomicU64 = AtomicU64::new(0);
-static PREPARED_DML_BATCH_ROWS: AtomicU64 = AtomicU64::new(0);
 
 #[derive(Clone, Copy, Debug)]
 #[repr(u8)]
@@ -57,21 +53,6 @@ pub(crate) enum PreparedDmlValueRef<'a> {
 }
 
 impl PreparedDmlParameterBatch {
-    pub(crate) fn record_execution(row_count: usize) {
-        PREPARED_DML_BATCH_EXECUTIONS.fetch_add(1, Ordering::Relaxed);
-        PREPARED_DML_BATCH_ROWS.fetch_add(row_count as u64, Ordering::Relaxed);
-    }
-
-    /// Returns and resets page executions and rows. This is an observability
-    /// certificate for real production callers, not a routing switch.
-    #[allow(dead_code)]
-    pub(crate) fn take_execution_counters() -> (u64, u64) {
-        (
-            PREPARED_DML_BATCH_EXECUTIONS.swap(0, Ordering::Relaxed),
-            PREPARED_DML_BATCH_ROWS.swap(0, Ordering::Relaxed),
-        )
-    }
-
     /// Packs owned parameter rows into one compact arena.
     pub(crate) fn from_rows(rows: impl IntoIterator<Item = Vec<Value>>) -> Result<Self, LixError> {
         let mut row_count = 0usize;

--- a/packages/lix/src/sql2/exec/write.rs
+++ b/packages/lix/src/sql2/exec/write.rs
@@ -399,7 +399,6 @@ pub(crate) async fn execute_write_logical_plan_prepared_dml_batch(
     .await
     .map_err(normalize_bound_public_write_error)?
     {
-        PreparedDmlParameterBatch::record_execution(parameter_batch.row_count());
         return Ok(Some(results));
     }
     if let Some(results) = super::bound_public_write::try_execute_row_insert_prepared_batch(
@@ -410,7 +409,6 @@ pub(crate) async fn execute_write_logical_plan_prepared_dml_batch(
     .await
     .map_err(normalize_bound_public_write_error)?
     {
-        PreparedDmlParameterBatch::record_execution(parameter_batch.row_count());
         return Ok(Some(results));
     }
     let results = super::bound_public_write::try_execute_row_update_prepared_batch(
@@ -420,9 +418,6 @@ pub(crate) async fn execute_write_logical_plan_prepared_dml_batch(
     )
     .await
     .map_err(normalize_bound_public_write_error)?;
-    if results.is_some() {
-        PreparedDmlParameterBatch::record_execution(parameter_batch.row_count());
-    }
     Ok(results)
 }
 


### PR DESCRIPTION
## Summary
- remove the unused prepared-DML execution and row counters
- remove three atomic increments from the prepared write fast paths

## Evidence
- `rg` found no callers of `take_execution_counters`; only the three write-path increments existed
- `cargo check -p lix --lib`
- `cargo test -p lix --lib execute_prepared_dml_batch_preserves_order_absence_and_atomic_errors -- --nocapture`
- `cargo clippy -p lix --all-targets --no-deps`

This is an internal cleanup; prepared DML behavior and the public API are unchanged.