### PR TITLE
chore: remove unused prepared DML counters

### DIFF
--- a/packages/lix/src/prepared_dml.rs
+++ b/packages/lix/src/prepared_dml.rs
@@ -1,5 +1,4 @@
 use std::sync::Arc;
-use std::sync::atomic::{AtomicU64, Ordering};
 
 use crate::{Blob, LixError, Value};
 
@@ -17,9 +16,6 @@ pub(crate) struct PreparedDmlParameterBatch {
     cells: Arc<[PreparedDmlCell]>,
     bytes: Arc<[u8]>,
 }
-
-static PREPARED_DML_BATCH_EXECUTIONS: AtomicU64 = AtomicU64::new(0);
-static PREPARED_DML_BATCH_ROWS: AtomicU64 = AtomicU64::new(0);
 
 #[derive(Clone, Copy, Debug)]
 #[repr(u8)]
@@ -57,21 +53,6 @@ pub(crate) enum PreparedDmlValueRef<'a> {
 }
 
 impl PreparedDmlParameterBatch {
-    pub(crate) fn record_execution(row_count: usize) {
-        PREPARED_DML_BATCH_EXECUTIONS.fetch_add(1, Ordering::Relaxed);
-        PREPARED_DML_BATCH_ROWS.fetch_add(row_count as u64, Ordering::Relaxed);
-    }
-
-    /// Returns and resets page executions and rows. This is an observability
-    /// certificate for real production callers, not a routing switch.
-    #[allow(dead_code)]
-    pub(crate) fn take_execution_counters() -> (u64, u64) {
-        (
-            PREPARED_DML_BATCH_EXECUTIONS.swap(0, Ordering::Relaxed),
-            PREPARED_DML_BATCH_ROWS.swap(0, Ordering::Relaxed),
-        )
-    }
-
     /// Packs owned parameter rows into one compact arena.
     pub(crate) fn from_rows(rows: impl IntoIterator<Item = Vec<Value>>) -> Result<Self, LixError> {
         let mut row_count = 0usize;

--- a/packages/lix/src/sql2/exec/write.rs
+++ b/packages/lix/src/sql2/exec/write.rs
@@ -399,7 +399,6 @@ pub(crate) async fn execute_write_logical_plan_prepared_dml_batch(
     .await
     .map_err(normalize_bound_public_write_error)?
     {
-        PreparedDmlParameterBatch::record_execution(parameter_batch.row_count());
         return Ok(Some(results));
     }
     if let Some(results) = super::bound_public_write::try_execute_row_insert_prepared_batch(
@@ -410,7 +409,6 @@ pub(crate) async fn execute_write_logical_plan_prepared_dml_batch(
     .await
     .map_err(normalize_bound_public_write_error)?
     {
-        PreparedDmlParameterBatch::record_execution(parameter_batch.row_count());
         return Ok(Some(results));
     }
     let results = super::bound_public_write::try_execute_row_update_prepared_batch(
@@ -420,9 +418,6 @@ pub(crate) async fn execute_write_logical_plan_prepared_dml_batch(
     )
     .await
     .map_err(normalize_bound_public_write_error)?;
-    if results.is_some() {
-        PreparedDmlParameterBatch::record_execution(parameter_batch.row_count());
-    }
     Ok(results)
 }
 


### PR DESCRIPTION
## Summary
- delete the unused prepared-DML execution/row atomics and accessor
- remove three production increments that had no readers

The counter snapshot method had no callers anywhere in the repository, so every prepared batch paid two relaxed atomic increments without observable behavior. This preserves the prepared DML API and execution paths.

## Validation
- `cargo test -p lix --lib prepared --no-fail-fast` (17 passed)
- `cargo clippy -p lix --all-targets --all-features -- -D warnings` (run locally; no CI wait needed)