### PR TITLE
chore(lix): flatten branch ref context

### DIFF
--- a/packages/lix/src/branch/context.rs
+++ b/packages/lix/src/branch/context.rs
@@ -1,24 +1,18 @@
-use std::sync::Arc;
-
 use crate::storage_adapter::StorageAdapterRead;
 
 use super::BranchRefReader;
-use super::refs::BranchRefContext;
+use super::refs::BranchRefStoreReader;
 
 /// Aggregate entrypoint for branch-domain services.
 ///
 /// Today this owns the moving-ref subsystem. Descriptor helpers are re-exported
 /// by `branch`; future branch APIs can grow here without making session or
 /// SQL code depend directly on ref storage details.
-pub(crate) struct BranchContext {
-    refs: Arc<BranchRefContext>,
-}
+pub(crate) struct BranchContext;
 
 impl BranchContext {
     pub(crate) fn new() -> Self {
-        Self {
-            refs: Arc::new(BranchRefContext::new()),
-        }
+        Self
     }
 
     /// Creates a branch-ref reader over a caller-provided KV store.
@@ -26,6 +20,6 @@ impl BranchContext {
     where
         S: StorageAdapterRead,
     {
-        self.refs.reader(store)
+        BranchRefStoreReader::new(store)
     }
 }

--- a/packages/lix/src/branch/refs.rs
+++ b/packages/lix/src/branch/refs.rs
@@ -2,29 +2,6 @@ use crate::LixError;
 use crate::branch::{BranchHead, BranchHeadControlContext, BranchRefReader};
 use crate::storage_adapter::StorageAdapterRead;
 
-/// Typed access to moving branch heads stored in the direct control plane.
-///
-/// The control record is deliberately below live-state visibility, keeping
-/// the dependency acyclic: `branch-control -> tracked-head -> live-state`.
-pub(super) struct BranchRefContext {}
-
-impl BranchRefContext {
-    pub(super) fn new() -> Self {
-        Self {}
-    }
-
-    /// Creates a branch-ref reader over a caller-provided KV store.
-    #[expect(clippy::unused_self)]
-    pub(super) fn reader<S>(&self, store: S) -> BranchRefStoreReader<S>
-    where
-        S: StorageAdapterRead,
-    {
-        BranchRefStoreReader {
-            controls: BranchHeadControlContext::new().reader(store),
-        }
-    }
-}
-
 /// Read side for branch heads.
 pub(super) struct BranchRefStoreReader<S>
 where
@@ -37,6 +14,12 @@ impl<S> BranchRefStoreReader<S>
 where
     S: StorageAdapterRead,
 {
+    pub(super) fn new(store: S) -> Self {
+        Self {
+            controls: BranchHeadControlContext::new().reader(store),
+        }
+    }
+
     pub(crate) async fn load_head(&self, branch_id: &str) -> Result<Option<BranchHead>, LixError> {
         Ok(self
             .controls
@@ -89,14 +72,12 @@ mod tests {
     #[tokio::test]
     async fn load_head_returns_none_when_missing() {
         let storage = StorageAdapter::new(Memory::new());
-        let branch_ref = test_branch_ref();
         let read = storage
             .begin_read(StorageReadOptions::default())
             .await
             .expect("read should open");
 
-        let head = branch_ref
-            .reader(read)
+        let head = BranchRefStoreReader::new(read)
             .load_head("missing-branch")
             .await
             .expect("missing branch ref should load cleanly");
@@ -107,7 +88,6 @@ mod tests {
     #[tokio::test]
     async fn advance_head_writes_direct_control() {
         let storage = StorageAdapter::new(Memory::new());
-        let branch_ref = BranchRefContext::new();
 
         stage_branch_head(&storage, "01920000-0000-7000-8000-0000000000a1", "commit-a")
             .await
@@ -117,8 +97,7 @@ mod tests {
             .begin_read(StorageReadOptions::default())
             .await
             .expect("read should open");
-        let head = branch_ref
-            .reader(read)
+        let head = BranchRefStoreReader::new(read)
             .load_head("01920000-0000-7000-8000-0000000000a1")
             .await
             .expect("branch head should load")
@@ -130,7 +109,6 @@ mod tests {
     #[tokio::test]
     async fn scan_heads_returns_sorted_branch_heads() {
         let storage = StorageAdapter::new(Memory::new());
-        let branch_ref = test_branch_ref();
 
         stage_branch_head(&storage, "01920000-0000-7000-8000-0000000000b1", "commit-b")
             .await
@@ -143,8 +121,7 @@ mod tests {
             .begin_read(StorageReadOptions::default())
             .await
             .expect("read should open");
-        let heads = branch_ref
-            .reader(read)
+        let heads = BranchRefStoreReader::new(read)
             .scan_heads()
             .await
             .expect("heads should scan");
@@ -162,10 +139,6 @@ mod tests {
                 },
             ]
         );
-    }
-
-    fn test_branch_ref() -> BranchRefContext {
-        BranchRefContext::new()
     }
 
     async fn stage_branch_head(


### PR DESCRIPTION
## Summary
- remove the empty `BranchRefContext` wrapper
- make `BranchContext` a zero-sized domain handle
- construct `BranchRefStoreReader` directly

## Evidence
- the wrapper held no state and only forwarded to `BranchHeadControlContext`
- `cargo check -p lix --lib`
- `cargo test -p lix --lib branch::refs::tests -- --nocapture` (3 passed)
- `cargo clippy -p lix --all-targets --no-deps`

The branch-ref behavior and public API are unchanged.