### PR TITLE
chore(lix): remove fallible tracked-state key lookup

### DIFF
--- a/packages/lix/src/tracked_state/codec.rs
+++ b/packages/lix/src/tracked_state/codec.rs
@@ -191,12 +191,10 @@ impl DecodedLeafNodeRef {
         })
     }
 
-    #[expect(clippy::unnecessary_wraps)]
-    pub(crate) fn key(&self, index: usize) -> Result<Option<&[u8]>, LixError> {
-        Ok(self
-            .entries
+    pub(crate) fn key(&self, index: usize) -> Option<&[u8]> {
+        self.entries
             .get(index)
-            .map(|span| &self.arena[span.key_start..span.key_end]))
+            .map(|span| &self.arena[span.key_start..span.key_end])
     }
 
     /// Materializes per-entry buffers only for mutation paths that need to
@@ -3356,7 +3354,7 @@ mod tests {
             panic!("expected leaf node");
         };
         assert_eq!(leaf.len(), 2);
-        assert_eq!(leaf.key(1).expect("second key"), Some(b"bravo".as_ref()));
+        assert_eq!(leaf.key(1), Some(b"bravo".as_ref()));
         let second = leaf
             .entry(1)
             .expect("second entry")

--- a/packages/lix/src/tracked_state/storage.rs
+++ b/packages/lix/src/tracked_state/storage.rs
@@ -2267,7 +2267,6 @@ impl<'a> DecodedCommitDeltaRowRef<'a> {
         }
         self.batch.arenas[row.arena_ordinal as usize]
             .key(row.entry_ordinal as usize)
-            .expect("decoded commit-delta key lookup cannot fail")
             .expect("decoded commit-delta row references an existing leaf entry")
     }
 }
@@ -9407,7 +9406,7 @@ async fn load_local_owned_commit_delta_entries_one_ordered(
                 .expect("peeked routed lookup remains available");
             let encoded_key = &encoded_keys[encoded_key];
             while leaf_index < leaf.len()
-                && leaf.key(leaf_index)?.ok_or_else(|| {
+                && leaf.key(leaf_index).ok_or_else(|| {
                     LixError::new(
                         LixError::CODE_INTERNAL_ERROR,
                         "tracked_state packed commit_delta leaf has a missing key",
@@ -9416,7 +9415,7 @@ async fn load_local_owned_commit_delta_entries_one_ordered(
             {
                 leaf_index += 1;
             }
-            let Some(leaf_key) = leaf.key(leaf_index)? else {
+            let Some(leaf_key) = leaf.key(leaf_index) else {
                 continue;
             };
             if leaf_key == encoded_key {
@@ -9984,7 +9983,7 @@ fn decoded_commit_delta_row_key<'a>(
                 "selected-source commit delta references a missing arena",
             )
         })?
-        .key(row.entry_ordinal as usize)?
+        .key(row.entry_ordinal as usize)
         .ok_or_else(|| {
             LixError::new(
                 LixError::CODE_INTERNAL_ERROR,
@@ -12634,7 +12633,7 @@ fn commit_delta_entry_lower_bound_from(
     let mut upper = leaf.len();
     while lower < upper {
         let middle = lower + (upper - lower) / 2;
-        let key = leaf.key(middle)?.ok_or_else(|| {
+        let key = leaf.key(middle).ok_or_else(|| {
             LixError::new(
                 LixError::CODE_INTERNAL_ERROR,
                 "tracked_state packed commit_delta leaf has a missing key",

--- a/packages/lix/src/tracked_state/tree.rs
+++ b/packages/lix/src/tracked_state/tree.rs
@@ -177,7 +177,7 @@ impl TrackedStateTree {
                     let mut high = leaf.len();
                     while low < high {
                         let mid = low + (high - low) / 2;
-                        let key = leaf.key(mid)?.ok_or_else(|| {
+                        let key = leaf.key(mid).ok_or_else(|| {
                             LixError::new(
                                 LixError::CODE_STORAGE_ERROR,
                                 "tracked-state leaf key disappeared during lower-bound seek",
@@ -2382,7 +2382,7 @@ fn binary_search_leaf_key(
     let mut high = leaf.len();
     while low < high {
         let mid = low + (high - low) / 2;
-        let key = leaf.key(mid)?.ok_or_else(|| {
+        let key = leaf.key(mid).ok_or_else(|| {
             LixError::new(
                 "LIX_ERROR_UNKNOWN",
                 "tracked-state leaf key disappeared during binary search",


### PR DESCRIPTION
## Summary
- change the decoded leaf key accessor from `Result<Option<_>, _>` to `Option<_>`
- remove redundant `?` propagation at its callers

## Evidence
- the accessor only sliced validated in-memory spans and never returned an error
- `cargo check -p lix --lib`
- `cargo test -p lix --lib tracked_state::codec::tests -- --nocapture` (46 passed)
- `cargo clippy -p lix --all-targets --no-deps`

This is an internal codec cleanup; storage bytes, behavior, and public API are unchanged.