### PR TITLE
chore(lix): remove unused replacement ordinal accessor

### DIFF
--- a/packages/lix/src/tracked_state/replacement_part.rs
+++ b/packages/lix/src/tracked_state/replacement_part.rs
@@ -207,9 +207,6 @@ impl ReplacementPartDirectoryEntry {
         self.row_count
     }
 
-    pub(crate) fn end_ordinal(&self) -> u32 {
-        self.first_ordinal + u32::from(self.row_count)
-    }
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]


### PR DESCRIPTION
## Summary
- remove the unreferenced private `ReplacementPartDirectoryEntry::end_ordinal` accessor
- leave replacement-part encoding, routing, and validation unchanged

## Evidence
- no remaining references in source or tests
- `cargo check -p lix --all-features --tests` passes
- encoded replacement-part behavior is covered by existing round-trip/routing tests

Target branch: `simplification`.