### PR TITLE
chore(lix): remove impossible StageJson result

### DIFF
--- a/packages/lix/src/transaction/commit.rs
+++ b/packages/lix/src/transaction/commit.rs
@@ -20,7 +20,6 @@ use crate::changelog::{
     TransactionChangelogAppend,
 };
 use crate::common::LixTimestamp;
-use crate::row_pk::RowPk;
 use crate::filesystem::stage_path_index_revision;
 use crate::functions::FunctionContext;
 use crate::hot_state::{
@@ -31,6 +30,7 @@ use crate::hot_state::{
 use crate::json_store::{
     JSON_INLINE_MAX_BYTES, JsonRef, JsonStoreContext, JsonWritePlacementRef, NormalizedJsonRef,
 };
+use crate::row_pk::RowPk;
 use crate::storage_adapter::{StorageAdapterRead, StoragePrecondition, StorageWriteSet};
 #[cfg(test)]
 use crate::tracked_state::stage_commit_state_manifest;
@@ -354,11 +354,8 @@ pub(crate) async fn commit_prepared_writes_with_parent_heads(
         deleted_checkpoint_files.remove(&(write.branch_id.clone(), write.file_id.clone()));
     }
     let mut insert_selection = prepared_writes.insert_selection;
-    let mut row_columnar_write_sets = prepare_row_columnar_write_sets(
-        &mut state_rows,
-        &insert_selection,
-        row_schema_catalog,
-    )?;
+    let mut row_columnar_write_sets =
+        prepare_row_columnar_write_sets(&mut state_rows, &insert_selection, row_schema_catalog)?;
     release_validated_canonical_value_columns(&mut state_rows);
     if !prepared_writes.file_content_writes.is_empty() {
         let mut blob_writer = binary_cas.writer_skipping_existing_chunks(&*read, &mut writes);
@@ -906,10 +903,13 @@ pub(crate) async fn commit_prepared_writes_with_parent_heads(
     })
 }
 
-fn certified_batch_requires_root_expansion(batch: &crate::plugin::runtime::WasmCertifiedRowBatch) -> bool {
+fn certified_batch_requires_root_expansion(
+    batch: &crate::plugin::runtime::WasmCertifiedRowBatch,
+) -> bool {
     !matches!(
         batch.format,
-        crate::plugin::runtime::HOST_CERTIFIED_PACKET_FORMAT | crate::plugin::runtime::HOST_CERTIFIED_ZSTD_PACKET_FORMAT
+        crate::plugin::runtime::HOST_CERTIFIED_PACKET_FORMAT
+            | crate::plugin::runtime::HOST_CERTIFIED_ZSTD_PACKET_FORMAT
     )
 }
 
@@ -2504,15 +2504,16 @@ async fn stage_tracked_commit_delta_index(
             let row = state_rows.row(row_index);
             addressable.push(row.addressable_change_id);
             let mut delta = tracked_commit_delta_from_state_row(row)?;
-            delta.base_coordinate = row_columnar_write_sets
-                .state_row_location(row_index)
-                .map(
-                    |location| crate::tracked_state::TrackedStateBaseCoordinate {
-                        base_commit_id: root.commit_id,
-                        group_index: location.group_index,
-                        row_index: location.row_index,
-                    },
-                );
+            delta.base_coordinate =
+                row_columnar_write_sets
+                    .state_row_location(row_index)
+                    .map(
+                        |location| crate::tracked_state::TrackedStateBaseCoordinate {
+                            base_commit_id: root.commit_id,
+                            group_index: location.group_index,
+                            row_index: location.row_index,
+                        },
+                    );
             deltas.push(delta);
         }
         for (row, json_refs) in certified_root_rows.iter().zip(certified_root_json_refs) {
@@ -2748,11 +2749,8 @@ fn try_stage_lossless_columnar_mutations(
     }
     let parts = crate::tracked_state::ColumnarMutationPartSet {
         owner_commit_id: *commit_id.as_uuid().as_bytes(),
-        row_group_set_id: crate::hot_state::row_group_set_id(
-            commit_id,
-            first.schema_key.as_str(),
-        )
-        .as_bytes(),
+        row_group_set_id: crate::hot_state::row_group_set_id(commit_id, first.schema_key.as_str())
+            .as_bytes(),
         manifest_digest: encoded.manifest.content_digest()?,
         schema_key: first.schema_key.to_string(),
         row_count: u32::try_from(state_row_indices.len()).map_err(|_| {
@@ -3712,8 +3710,13 @@ async fn stage_tracked_head(
     let mut controls = BTreeMap::new();
     let mut deferred_fresh_hot_plans = Vec::new();
     let mut exclusive_certified_columnar_publication = false;
-    let transaction_global_schema_keys =
-        global_branch_schema_keys(state_rows, engine_rows, tracked_roots, staged_commits, &tracked_snapshots);
+    let transaction_global_schema_keys = global_branch_schema_keys(
+        state_rows,
+        engine_rows,
+        tracked_roots,
+        staged_commits,
+        &tracked_snapshots,
+    );
 
     for root in tracked_roots_parent_first(tracked_roots)?
         .into_iter()
@@ -5577,10 +5580,9 @@ fn prepare_row_columnar_write_sets(
                     crate::hot_state::RowColumnarWriteSets::with_dense_state_rows(row_count)
                 }
                 crate::sql2::RowGroupLocations::Explicit(locations) => {
-                    let mut encoded =
-                        crate::hot_state::RowColumnarWriteSets::with_state_row_count(
-                            state_rows.len(),
-                        );
+                    let mut encoded = crate::hot_state::RowColumnarWriteSets::with_state_row_count(
+                        state_rows.len(),
+                    );
                     for (state_row_index, location) in locations.into_iter().enumerate() {
                         encoded.set_state_row_location(state_row_index, location);
                     }
@@ -5592,8 +5594,7 @@ fn prepare_row_columnar_write_sets(
         }
     }
     if let Some((commit_id, schema_key, snapshots)) = state_rows.dense_row_columnar_input() {
-        let Some(schema) = row_schema_catalog.and_then(|catalog| catalog.schema(schema_key))
-        else {
+        let Some(schema) = row_schema_catalog.and_then(|catalog| catalog.schema(schema_key)) else {
             return Ok(crate::hot_state::RowColumnarWriteSets::new());
         };
         let Ok(spec) = crate::sql2::derive_schema_surface_spec_from_schema(schema) else {
@@ -7540,16 +7541,13 @@ mod tests {
             RowPk::single("ordinary"),
             "ordinary_schema".into(),
             None,
-            Some(
-                crate::transaction_types::stage_json_from_value(
-                    crate::transaction_types::TransactionJson::from_value_for_test(
-                        serde_json::from_str(large_snapshot.as_str())
-                            .expect("large ordinary snapshot should parse"),
-                    ),
-                    "mixed certified ordinary snapshot",
-                )
-                .expect("ordinary snapshot should stage"),
-            ),
+            Some(crate::transaction_types::stage_json_from_value(
+                crate::transaction_types::TransactionJson::from_value_for_test(
+                    serde_json::from_str(large_snapshot.as_str())
+                        .expect("large ordinary snapshot should parse"),
+                ),
+                "mixed certified ordinary snapshot",
+            )),
             None,
             None,
             None,
@@ -8763,15 +8761,12 @@ mod tests {
         second.commit_id = Some(commit_id("rootless-second-commit"));
         second.created_at = ts("2026-01-02T00:00:00Z");
         second.updated_at = second.created_at;
-        second.snapshot = Some(
-            crate::transaction_types::stage_json_from_value(
-                crate::transaction_types::TransactionJson::from_value_for_test(
-                    serde_json::json!({ "value": 2 }),
-                ),
-                "second rootless tracked row snapshot",
-            )
-            .expect("second snapshot should stage"),
-        );
+        second.snapshot = Some(crate::transaction_types::stage_json_from_value(
+            crate::transaction_types::TransactionJson::from_value_for_test(
+                serde_json::json!({ "value": 2 }),
+            ),
+            "second rootless tracked row snapshot",
+        ));
         let mut read = storage
             .begin_read(StorageReadOptions::default())
             .await
@@ -8815,15 +8810,12 @@ mod tests {
         third.commit_id = Some(commit_id("rootless-third-commit"));
         third.created_at = ts("2026-01-03T00:00:00Z");
         third.updated_at = third.created_at;
-        third.snapshot = Some(
-            crate::transaction_types::stage_json_from_value(
-                crate::transaction_types::TransactionJson::from_value_for_test(
-                    serde_json::json!({ "value": 3 }),
-                ),
-                "third rootless tracked row snapshot",
-            )
-            .expect("third snapshot should stage"),
-        );
+        third.snapshot = Some(crate::transaction_types::stage_json_from_value(
+            crate::transaction_types::TransactionJson::from_value_for_test(
+                serde_json::json!({ "value": 3 }),
+            ),
+            "third rootless tracked row snapshot",
+        ));
         let mut read = storage
             .begin_read(StorageReadOptions::default())
             .await
@@ -10703,17 +10695,14 @@ mod tests {
         row.row_pk = RowPk::single(file_id);
         row.schema_key = "lix_binary_blob_ref".into();
         row.file_id = Some(file_id.into());
-        row.snapshot = Some(
-            crate::transaction_types::stage_json_from_value(
-                crate::transaction_types::TransactionJson::from_value_for_test(serde_json::json!({
-                    "id": file_id,
-                    "blob_hash": blob_id.to_hex(),
-                    "size_bytes": payload.len(),
-                })),
-                "ordinary CAS epoch test blob reference",
-            )
-            .expect("ordinary file blob reference should stage"),
-        );
+        row.snapshot = Some(crate::transaction_types::stage_json_from_value(
+            crate::transaction_types::TransactionJson::from_value_for_test(serde_json::json!({
+                "id": file_id,
+                "blob_hash": blob_id.to_hex(),
+                "size_bytes": payload.len(),
+            })),
+            "ordinary CAS epoch test blob reference",
+        ));
         PreparedWriteSet {
             insert_selection: PreparedInsertSelection::new(),
             state_rows: prepared_rows![row],
@@ -10848,15 +10837,12 @@ mod tests {
             row_pk: RowPk::single("row-1"),
             schema_key: "test_schema".into(),
             file_id: None,
-            snapshot: Some(
-                crate::transaction_types::stage_json_from_value(
-                    crate::transaction_types::TransactionJson::from_value_for_test(
-                        serde_json::json!({ "value": 1 }),
-                    ),
-                    "test tracked row snapshot",
-                )
-                .expect("test snapshot should stage"),
-            ),
+            snapshot: Some(crate::transaction_types::stage_json_from_value(
+                crate::transaction_types::TransactionJson::from_value_for_test(
+                    serde_json::json!({ "value": 1 }),
+                ),
+                "test tracked row snapshot",
+            )),
             metadata: None,
             origin: None,
             origin_key: None,
@@ -10884,15 +10870,12 @@ mod tests {
 
     fn untracked_global_row(change_id: &str) -> TestPreparedStateRow {
         let mut row = tracked_global_row(change_id);
-        row.snapshot = Some(
-            crate::transaction_types::stage_json_from_value(
-                crate::transaction_types::TransactionJson::from_value_for_test(
-                    serde_json::json!({ "value": "untracked" }),
-                ),
-                "test untracked row snapshot",
-            )
-            .expect("test snapshot should stage"),
-        );
+        row.snapshot = Some(crate::transaction_types::stage_json_from_value(
+            crate::transaction_types::TransactionJson::from_value_for_test(
+                serde_json::json!({ "value": "untracked" }),
+            ),
+            "test untracked row snapshot",
+        ));
         TestPreparedStateRow {
             change_id: Some(ChangeId::for_test_label(change_id)),
             commit_id: None,
@@ -10909,16 +10892,13 @@ mod tests {
         let mut row = untracked_global_row(change_id);
         row.row_pk = RowPk::single(branch_id);
         row.schema_key = BRANCH_REF_SCHEMA_KEY.into();
-        row.snapshot = Some(
-            crate::transaction_types::stage_json_from_value(
-                crate::transaction_types::TransactionJson::from_value_for_test(serde_json::json!({
-                    "id": branch_id,
-                    "commit_id": commit_id(target_commit_label).to_string(),
-                })),
-                "test direct branch-ref snapshot",
-            )
-            .expect("branch-ref snapshot should stage"),
-        );
+        row.snapshot = Some(crate::transaction_types::stage_json_from_value(
+            crate::transaction_types::TransactionJson::from_value_for_test(serde_json::json!({
+                "id": branch_id,
+                "commit_id": commit_id(target_commit_label).to_string(),
+            })),
+            "test direct branch-ref snapshot",
+        ));
         row
     }
 
@@ -10930,15 +10910,12 @@ mod tests {
         let mut row = untracked_global_row(change_id);
         row.row_pk = RowPk::single(key);
         row.schema_key = "lix_key_value".into();
-        row.snapshot = Some(
-            crate::transaction_types::stage_json_from_value(
-                crate::transaction_types::TransactionJson::from_value_for_test(
-                    serde_json::json!({ "key": key, "value": value }),
-                ),
-                "test untracked key-value snapshot",
-            )
-            .expect("test key-value snapshot should stage"),
-        );
+        row.snapshot = Some(crate::transaction_types::stage_json_from_value(
+            crate::transaction_types::TransactionJson::from_value_for_test(
+                serde_json::json!({ "key": key, "value": value }),
+            ),
+            "test untracked key-value snapshot",
+        ));
         row
     }
 

--- a/packages/lix/src/transaction/context.rs
+++ b/packages/lix/src/transaction/context.rs
@@ -8888,12 +8888,10 @@ fn push_prepared_state_row_from_planned_parts(
     let branch_id = row.branch_id.clone();
     let snapshot = rows
         .take_snapshot(row_index)
-        .map(|value| stage_json_from_value(value, "prepared row snapshot_content"))
-        .transpose()?;
+        .map(|value| stage_json_from_value(value, "prepared row snapshot_content"));
     let metadata = rows
         .take_metadata(row_index)
-        .map(|value| stage_json_from_value(value, "prepared row metadata"))
-        .transpose()?;
+        .map(|value| stage_json_from_value(value, "prepared row metadata"));
     let row_pk = rows.take_row_pk(row_index).ok_or_else(|| {
         LixError::new(
             "LIX_ERROR_UNKNOWN",

--- a/packages/lix/src/transaction/staging.rs
+++ b/packages/lix/src/transaction/staging.rs
@@ -4527,11 +4527,8 @@ mod tests {
             vec![vec!["b"], vec!["c"]]
         );
         let mut exact_bounded = request(("b", true), ("c", true));
-        exact_bounded.filter.row_pks = vec![
-            RowPk::single("a"),
-            RowPk::single("b"),
-            RowPk::single("d"),
-        ];
+        exact_bounded.filter.row_pks =
+            vec![RowPk::single("a"), RowPk::single("b"), RowPk::single("d")];
         let exact_rows = overlay
             .scan(&exact_bounded)
             .expect("exact staged candidates must intersect range bounds");
@@ -6544,8 +6541,7 @@ mod tests {
         let snapshot = stage_json_from_value(
             TransactionJson::from_value_for_test(serde_json::json!({ "key": key, "value": value })),
             "test staged row snapshot_content",
-        )
-        .expect("test snapshot should prepare");
+        );
         TestPreparedStateRow {
             schema_plan_id: SchemaPlanId::for_test(0),
             facts: PreparedRowFacts::default(),

--- a/packages/lix/src/transaction/validation.rs
+++ b/packages/lix/src/transaction/validation.rs
@@ -26,13 +26,13 @@ use crate::common::{json_pointer_get, validate_row_metadata};
 #[cfg(test)]
 use crate::domain::DomainFileScope;
 use crate::domain::{Domain, DomainRowIdentity, committed_row_ref_is_exact_branch_scoped};
-use crate::row_pk::{RowPk, RowPkError, canonical_json_text};
 use crate::hot_state::{
     HotStateExactBatchRequest, HotStateExactRowRequest, HotStateFilter, HotStateProjection,
     HotStateReadDomain, HotStateReader, HotStateScanRequest, MaterializedHotStateBatch,
     MaterializedHotStateRowRef,
 };
 use crate::plugin::runtime::PLUGIN_OWNER_KEY;
+use crate::row_pk::{RowPk, RowPkError, canonical_json_text};
 #[cfg(test)]
 use crate::schema::{SchemaKey, validate_lix_schema, validate_lix_schema_definition};
 use crate::schema::{
@@ -2304,9 +2304,8 @@ impl PendingConstraintIndexes {
                 pointer_group: unique_paths.clone(),
                 value,
             };
-            if let Some(existing_row_pk) = self
-                .unique_values
-                .insert(key.clone(), row.row_pk().clone())
+            if let Some(existing_row_pk) =
+                self.unique_values.insert(key.clone(), row.row_pk().clone())
             {
                 if existing_row_pk != *row.row_pk() {
                     return Err(LixError::new(
@@ -2567,9 +2566,7 @@ fn validate_pending_delete_restrictions(
                         schema_key: tombstone.identity.schema_key_owned(),
                         domain,
                         pointer_group: primary_key_paths.clone(),
-                        value: UniqueConstraintValue::from_row_pk(
-                            tombstone.identity.row_pk(),
-                        ),
+                        value: UniqueConstraintValue::from_row_pk(tombstone.identity.row_pk()),
                     })
                 })
                 .collect::<Vec<_>>();
@@ -3752,7 +3749,6 @@ mod tests {
             TransactionJson::from_value_for_test(parsed),
             "test staged JSON",
         )
-        .expect("test staged JSON should prepare")
     }
 
     fn test_json_text(value: &str) -> Result<serde_json::Value, LixError> {
@@ -4849,10 +4845,7 @@ mod tests {
         let staged_writes = PreparedWriteSet {
             state_rows: prepared_rows![
                 pending_registered_schema_row("pending_schema"),
-                staged_row(
-                    "pending_schema",
-                    Some(json!({ "id": "row-1" }).to_string()),
-                ),
+                staged_row("pending_schema", Some(json!({ "id": "row-1" }).to_string()),),
             ],
             ..empty_staged_write_set()
         };
@@ -6586,8 +6579,7 @@ mod tests {
                 .to_string(),
             ),
         );
-        row.row_pk =
-            RowPk::uuid_from_canonical(file_id).expect("fixture file ID should be a UUID");
+        row.row_pk = RowPk::uuid_from_canonical(file_id).expect("fixture file ID should be a UUID");
         row.file_id = Some(file_id.into());
         row.branch_id = branch_id.into();
         row.global = branch_id == crate::GLOBAL_BRANCH_ID;
@@ -7801,11 +7793,7 @@ mod tests {
         row
     }
 
-    fn nullable_unique_row(
-        row_pk: &str,
-        scope: Option<&str>,
-        name: &str,
-    ) -> TestPreparedStateRow {
+    fn nullable_unique_row(row_pk: &str, scope: Option<&str>, name: &str) -> TestPreparedStateRow {
         let mut row = staged_row(
             "nullable_unique_schema",
             Some(
@@ -7872,8 +7860,7 @@ mod tests {
                 .to_string(),
             ),
         );
-        row.row_pk =
-            RowPk::uuid_from_canonical(file_id).expect("fixture file ID should be a UUID");
+        row.row_pk = RowPk::uuid_from_canonical(file_id).expect("fixture file ID should be a UUID");
         row.file_id = Some(file_id.into());
         row.branch_id = branch_id.into();
         row.global = branch_id == crate::GLOBAL_BRANCH_ID;

--- a/packages/lix/src/transaction_types.rs
+++ b/packages/lix/src/transaction_types.rs
@@ -13,12 +13,14 @@ use crate::binary_cas::{
 use crate::catalog::SchemaPlanId;
 use crate::changelog::{ChangeId, CommitId};
 use crate::common::{LixTimestamp, MutationIdentity, RequestBlobSpliceProvenance, SharedStr};
-use crate::row_pk::RowPk;
 use crate::functions::FunctionProviderHandle;
 use crate::hot_state::{CertifiedCurrentStatePredecessor, MaterializedHotStateRow};
 use crate::json_store::JsonRef;
+use crate::plugin::runtime::{
+    WasmCanonicalJson, WasmCanonicalJsonCertificateRef, WasmCertifiedRowBatch,
+};
+use crate::row_pk::RowPk;
 use crate::tracked_state::OrderedAddressableCommitDeltaStage;
-use crate::plugin::runtime::{WasmCanonicalJson, WasmCanonicalJsonCertificateRef, WasmCertifiedRowBatch};
 use bytes::Bytes;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use serde_json::Value as JsonValue;
@@ -647,10 +649,7 @@ impl CertifiedParameterBatch {
         })
     }
 
-    pub(crate) fn with_row_columnar(
-        mut self,
-        row_columnar: crate::sql2::EncodedRowGroups,
-    ) -> Self {
+    pub(crate) fn with_row_columnar(mut self, row_columnar: crate::sql2::EncodedRowGroups) -> Self {
         self.row_columnar = Some(row_columnar);
         self
     }
@@ -774,7 +773,7 @@ impl CertifiedParameterBatch {
             json.push(stage_json_from_value(
                 snapshot,
                 "certified parameter snapshot_content",
-            )?);
+            ));
         }
         let string_index = strings
             .iter()
@@ -1324,7 +1323,7 @@ impl RawWriteBatch {
                 )
             })?;
             let snapshot =
-                stage_json_from_value(snapshot, "certified prepared row snapshot_content")?;
+                stage_json_from_value(snapshot, "certified prepared row snapshot_content");
             prepared_row_pks.push(row_pk);
             json.push(snapshot);
             let untracked = slot.flags & RAW_WRITE_UNTRACKED != 0;
@@ -2429,11 +2428,7 @@ impl PartialEq for StageJson {
 
 impl Eq for StageJson {}
 
-#[expect(clippy::unnecessary_wraps)]
-pub(crate) fn stage_json_from_value(
-    value: TransactionJson,
-    _context: &str,
-) -> Result<StageJson, LixError> {
+pub(crate) fn stage_json_from_value(value: TransactionJson, _context: &str) -> StageJson {
     // Inline values carry their bytes as the authoritative durable payload.
     // Computing and retaining a content hash for every small row only to
     // discard it at `JsonSlotRef::Inline` doubled the canonical-byte walk on
@@ -2467,7 +2462,7 @@ pub(crate) fn stage_json_from_value(
         }
         TransactionJsonStorage::CanonicalBatch(value) => StageJsonStorage::CanonicalBatch(value),
     };
-    Ok(StageJson { storage, json_ref })
+    StageJson { storage, json_ref }
 }
 
 /// Coalesces decoded JSON values into one Arrow-style values column plus one
@@ -3600,8 +3595,7 @@ impl PreparedStateBatch {
         other.expand_dense_certified_parameter();
         self.certified_tracked_keys_strictly_ordered = false;
         self.complete_collection_replacement = None;
-        let row_base =
-            u32::try_from(self.row_pks.len()).expect("prepared row column must fit u32");
+        let row_base = u32::try_from(self.row_pks.len()).expect("prepared row column must fit u32");
         let json_base = u32::try_from(self.json.len()).expect("prepared JSON column must fit u32");
         let predecessor_base = u32::try_from(self.durable_predecessors.len())
             .expect("prepared predecessor column must fit u32");
@@ -3966,8 +3960,7 @@ impl PreparedStateBatch {
     }
 
     fn push_row_pk(&mut self, value: RowPk) -> u32 {
-        let index =
-            u32::try_from(self.row_pks.len()).expect("prepared row column must fit u32");
+        let index = u32::try_from(self.row_pks.len()).expect("prepared row column must fit u32");
         self.row_pks.push(value);
         index
     }
@@ -4836,25 +4829,19 @@ mod tests {
         let batch = PreparedStateBatch::from_test_rows(vec![
             prepared_fixture_row(
                 "a",
-                Some(
-                    stage_json_from_value(
-                        TransactionJson::from_canonical_batch(first),
-                        "insert fixture",
-                    )
-                    .expect("insert fixture should stage"),
-                ),
+                Some(stage_json_from_value(
+                    TransactionJson::from_canonical_batch(first),
+                    "insert fixture",
+                )),
                 TransactionWriteOperation::Insert,
                 &origin_key,
             ),
             prepared_fixture_row(
                 "b",
-                Some(
-                    stage_json_from_value(
-                        TransactionJson::from_canonical_batch(second),
-                        "update fixture",
-                    )
-                    .expect("update fixture should stage"),
-                ),
+                Some(stage_json_from_value(
+                    TransactionJson::from_canonical_batch(second),
+                    "update fixture",
+                )),
                 TransactionWriteOperation::Update,
                 &origin_key,
             ),
@@ -4901,7 +4888,6 @@ mod tests {
                 TransactionJson::from_certified_shared_normalized_row_content(value.into()),
                 "compaction fixture",
             )
-            .expect("fixture should stage")
         };
         let mut batch = PreparedStateBatch::from_test_rows(vec![
             prepared_fixture_row(
@@ -4946,11 +4932,7 @@ mod tests {
             r#"{"id":"a","version":64}"#
         );
         assert_eq!(
-            batch
-                .row(1)
-                .row_pk
-                .as_single_string()
-                .expect("scalar pk"),
+            batch.row(1).row_pk.as_single_string().expect("scalar pk"),
             "b"
         );
     }
@@ -5021,15 +5003,13 @@ mod tests {
                     format!(r#"{{"id":"row-{index}"}}"#).into(),
                 ),
                 "capacity snapshot",
-            )
-            .expect("snapshot should stage");
+            );
             let metadata = stage_json_from_value(
                 TransactionJson::from_certified_shared_normalized_row_content(
                     format!(r#"{{"row":{index}}}"#).into(),
                 ),
                 "capacity metadata",
-            )
-            .expect("metadata should stage");
+            );
             batch.push_test_row(TestPreparedStateRow {
                 schema_plan_id: SchemaPlanId::for_test(0),
                 facts: PreparedRowFacts::default(),
@@ -5138,8 +5118,7 @@ mod tests {
         );
         assert!(transaction_json.row_content_certified());
 
-        let staged = stage_json_from_value(transaction_json, "certified test row")
-            .expect("certified JSON should prepare");
+        let staged = stage_json_from_value(transaction_json, "certified test row");
         assert_eq!(
             staged.value(),
             &serde_json::json!({"path": "/a", "value": {"nested": true}})
@@ -5161,8 +5140,7 @@ mod tests {
         let staged = stage_json_from_value(
             TransactionJson::from_certified_normalized_row_content(normalized.into()),
             "large certified test row",
-        )
-        .expect("large certified JSON should prepare");
+        );
 
         assert!(!staged.is_inline());
         assert_eq!(staged.json_ref, expected);
@@ -5183,8 +5161,7 @@ mod tests {
         let batch_row = batch.pop().expect("canonical row");
         let transaction_json = TransactionJson::from_canonical_batch(batch_row.clone());
 
-        let staged =
-            stage_json_from_value(transaction_json, "canonical batch row").expect("stage JSON");
+        let staged = stage_json_from_value(transaction_json, "canonical batch row");
         let staged_batch_row = staged
             .canonical_batch_row()
             .expect("staging must retain canonical batch ownership");
@@ -5218,8 +5195,7 @@ mod tests {
         let mut staged = stage_json_from_value(
             TransactionJson::from_canonical_batch(batch_row),
             "validated canonical batch row",
-        )
-        .expect("stage JSON");
+        );
 
         assert!(staged.release_validated_canonical_value_column());
         assert!(!staged.release_validated_canonical_value_column());
@@ -5238,8 +5214,7 @@ mod tests {
             transaction_json.value(),
             &serde_json::json!({"id": "row-1", "value": "hello"})
         );
-        let mut staged = stage_json_from_value(transaction_json, "shared canonical row")
-            .expect("shared canonical JSON should stage");
+        let mut staged = stage_json_from_value(transaction_json, "shared canonical row");
         assert!(staged.retains_decoded_value_for_tests());
 
         assert!(staged.release_validated_canonical_value_column());
@@ -5271,15 +5246,12 @@ mod tests {
                 .map(|(index, source)| {
                     prepared_fixture_row(
                         &format!("row-{index}"),
-                        Some(
-                            stage_json_from_value(
-                                TransactionJson::from_certified_normalized_row_content(Arc::clone(
-                                    source,
-                                )),
-                                "certified direct replacement",
-                            )
-                            .expect("certified direct JSON should stage"),
-                        ),
+                        Some(stage_json_from_value(
+                            TransactionJson::from_certified_normalized_row_content(Arc::clone(
+                                source,
+                            )),
+                            "certified direct replacement",
+                        )),
                         TransactionWriteOperation::Update,
                         &origin_key,
                     )
@@ -5336,10 +5308,10 @@ mod tests {
                 .map(|(index, snapshot)| {
                     prepared_fixture_row(
                         &format!("row-{index}"),
-                        Some(
-                            stage_json_from_value(snapshot, "certified transaction arena")
-                                .expect("certified JSON should stage"),
-                        ),
+                        Some(stage_json_from_value(
+                            snapshot,
+                            "certified transaction arena",
+                        )),
                         TransactionWriteOperation::Insert,
                         &origin_key,
                     )
@@ -5412,8 +5384,7 @@ mod tests {
         .expect("certified transaction arena")
         .pop()
         .expect("certified row");
-        let mut staged =
-            stage_json_from_value(snapshot, "certified transaction arena").expect("staged JSON");
+        let mut staged = stage_json_from_value(snapshot, "certified transaction arena");
 
         assert!(!staged.retains_decoded_value_for_tests());
         assert_eq!(staged.value()["id"], "row-1");
@@ -5453,13 +5424,10 @@ mod tests {
                 .map(|(index, value)| {
                     prepared_fixture_row(
                         &format!("row-{index}"),
-                        Some(
-                            stage_json_from_value(
-                                TransactionJson::from_canonical_batch(value),
-                                "sparse canonical fixture",
-                            )
-                            .expect("fixture should stage"),
-                        ),
+                        Some(stage_json_from_value(
+                            TransactionJson::from_canonical_batch(value),
+                            "sparse canonical fixture",
+                        )),
                         TransactionWriteOperation::Update,
                         &origin_key,
                     )
@@ -5533,13 +5501,10 @@ mod tests {
                 .map(|(index, value)| {
                     prepared_fixture_row(
                         &format!("row-{index}"),
-                        Some(
-                            stage_json_from_value(
-                                TransactionJson::from_canonical_batch(value),
-                                "skewed canonical fixture",
-                            )
-                            .expect("fixture should stage"),
-                        ),
+                        Some(stage_json_from_value(
+                            TransactionJson::from_canonical_batch(value),
+                            "skewed canonical fixture",
+                        )),
                         TransactionWriteOperation::Update,
                         &origin_key,
                     )


### PR DESCRIPTION
## Summary
- return `StageJson` directly from the infallible staging constructor
- remove redundant `?`, `transpose`, and test-side `expect` handling

## Evidence
- the constructor had an explicit `clippy::unnecessary_wraps` allowance and no error path
- `cargo check -p lix --lib`
- `cargo test -p lix --lib transaction_types::tests -- --nocapture` (31 passed)
- `cargo test -p lix --lib --no-run`
- `cargo clippy -p lix --all-targets --no-deps`

The existing context label is retained for a separate cleanup; JSON staging semantics and public API are unchanged.