### PR TITLE
chore(lix): remove unused transition counter facade

### DIFF
--- a/packages/lix/src/engine.rs
+++ b/packages/lix/src/engine.rs
@@ -26,7 +26,6 @@ use crate::storage_adapter::{StorageAdapter, StorageWriteSet};
 use crate::telemetry::TelemetrySink;
 use crate::tracked_state::TrackedStateContext;
 use crate::transaction::CommitCoordinator;
-use crate::plugin::runtime::WasmTransitionCounters;
 use crate::plugin::runtime::{UnsupportedWasmRuntime, WasmRuntime};
 use crate::{LixError, NullableKeyFilter};
 
@@ -274,22 +273,6 @@ where
             self.telemetry.clone(),
         )
         .await
-    }
-
-    /// Returns process-local work accumulated by completed v2 transitions on
-    /// this engine. The snapshot is shared by every session cloned from it.
-    #[doc(hidden)]
-    #[allow(dead_code)]
-    pub(crate) fn plugin_transition_counters(&self) -> WasmTransitionCounters {
-        self.plugin_host.transition_counters()
-    }
-
-    /// Resets the process-local v2 transition aggregate used by profiling and
-    /// invariant tests. This does not mutate durable repository state.
-    #[doc(hidden)]
-    #[allow(dead_code)]
-    pub(crate) fn reset_plugin_transition_counters(&self) {
-        self.plugin_host.reset_transition_counters();
     }
 
     /// Rebuilds the tracked serving commit root for one branch from changelog.

--- a/packages/lix/src/handle.rs
+++ b/packages/lix/src/handle.rs
@@ -3,7 +3,6 @@
 #![cfg_attr(test, allow(dead_code))]
 
 use lix::plugin::runtime::WasmRuntime;
-use lix::plugin::runtime::WasmTransitionCounters;
 use lix::storage::Storage;
 use lix::telemetry::TelemetrySink;
 use lix::{
@@ -685,16 +684,6 @@ where
         self.session.close().await
     }
 
-    /// Returns engine-local transition counters for profiling and
-    /// production invariant monitoring.
-    pub(crate) fn plugin_transition_counters(&self) -> WasmTransitionCounters {
-        self.engine.plugin_transition_counters()
-    }
-
-    /// Starts a new engine-local transition measurement window.
-    pub(crate) fn reset_plugin_transition_counters(&self) {
-        self.engine.reset_plugin_transition_counters();
-    }
 }
 
 #[expect(missing_debug_implementations)]


### PR DESCRIPTION
## Summary
- remove the private engine and handle wrappers for plugin transition counters
- retain the runtime host counters and their internal aggregation tests

## Evidence
- the wrapper methods had zero call sites outside their own definitions
- `cargo check -p lix --all-features --tests` passes
- `cargo clippy -p lix --all-targets --all-features -- -D warnings` passes
- public handle API and runtime behavior are unchanged

Target branch: `simplification`.