### PR TITLE
simplify: remove unused remote protocol helper

### DIFF
--- a/packages/js-sdk/src/remote/server-protocol.ts
+++ b/packages/js-sdk/src/remote/server-protocol.ts
@@ -550,10 +550,6 @@ export function record(
 	return value as Record<string, unknown>;
 }
 
-function isRecord(value: unknown): value is Record<string, unknown> {
-	return Boolean(value) && typeof value === "object" && !Array.isArray(value);
-}
-
 function decodeWireValue(value: unknown): NativeLixValue {
 	const wire = record(value, "wire value");
 	switch (wire.kind) {


### PR DESCRIPTION
## Summary
- remove the private `isRecord` helper from the JS server-protocol decoder
- static call-site census found only its definition, so the helper has no behavior or API reachability

## Validation
- `npx vitest run src/remote/server-protocol.test.ts src/remote/observe.test.ts` (20 passed)
- package-local `tsc` is blocked by missing generated `#binding`/`#worker-factory` artifacts; the focused protocol source tests pass

Draft while simplification work continues.