### PR TITLE
simplify: remove redundant remote row assertions

### DIFF
--- a/packages/js-sdk/src/remote/server-protocol.ts
+++ b/packages/js-sdk/src/remote/server-protocol.ts
@@ -464,7 +464,7 @@ function applyObserveRowSplice(
 	}
 	let destination = 0;
 	for (let index = 0; index < prefixRows; index += 1) {
-		rows[destination++] = base.rows.rows[index] as NativeLixValue[];
+		rows[destination++] = base.rows.rows[index];
 	}
 	for (let rowIndex = 0; rowIndex < delta.insertRows.length; rowIndex += 1) {
 		const row = delta.insertRows[rowIndex];
@@ -479,7 +479,7 @@ function applyObserveRowSplice(
 		rows[destination++] = row.map((entry) => decodeWireValue(entry));
 	}
 	for (let index = suffixStart; index < base.rows.rows.length; index += 1) {
-		rows[destination++] = base.rows.rows[index] as NativeLixValue[];
+		rows[destination++] = base.rows.rows[index];
 	}
 	return {
 		columns: [...base.rows.columns],


### PR DESCRIPTION
## Summary
- remove two redundant `NativeLixValue[]` assertions from row-delta splicing
- `BindingExecuteResult.rows` already has the exact `NativeLixValue[][]` type

## Validation
- `npx vitest run src/remote/server-protocol.test.ts src/remote/observe.test.ts` (20 passed)
- `git diff --check`

The package-wide typecheck is blocked by missing generated binding import artifacts in this checkout.