### PR TITLE
chore(lix): remove unused StageJson context

### DIFF
--- a/packages/lix/src/transaction/commit.rs
+++ b/packages/lix/src/transaction/commit.rs
@@ -7546,7 +7546,6 @@ mod tests {
                     serde_json::from_str(large_snapshot.as_str())
                         .expect("large ordinary snapshot should parse"),
                 ),
-                "mixed certified ordinary snapshot",
             )),
             None,
             None,
@@ -8765,7 +8764,6 @@ mod tests {
             crate::transaction_types::TransactionJson::from_value_for_test(
                 serde_json::json!({ "value": 2 }),
             ),
-            "second rootless tracked row snapshot",
         ));
         let mut read = storage
             .begin_read(StorageReadOptions::default())
@@ -8814,7 +8812,6 @@ mod tests {
             crate::transaction_types::TransactionJson::from_value_for_test(
                 serde_json::json!({ "value": 3 }),
             ),
-            "third rootless tracked row snapshot",
         ));
         let mut read = storage
             .begin_read(StorageReadOptions::default())
@@ -10701,7 +10698,6 @@ mod tests {
                 "blob_hash": blob_id.to_hex(),
                 "size_bytes": payload.len(),
             })),
-            "ordinary CAS epoch test blob reference",
         ));
         PreparedWriteSet {
             insert_selection: PreparedInsertSelection::new(),
@@ -10841,7 +10837,6 @@ mod tests {
                 crate::transaction_types::TransactionJson::from_value_for_test(
                     serde_json::json!({ "value": 1 }),
                 ),
-                "test tracked row snapshot",
             )),
             metadata: None,
             origin: None,
@@ -10874,7 +10869,6 @@ mod tests {
             crate::transaction_types::TransactionJson::from_value_for_test(
                 serde_json::json!({ "value": "untracked" }),
             ),
-            "test untracked row snapshot",
         ));
         TestPreparedStateRow {
             change_id: Some(ChangeId::for_test_label(change_id)),
@@ -10897,7 +10891,6 @@ mod tests {
                 "id": branch_id,
                 "commit_id": commit_id(target_commit_label).to_string(),
             })),
-            "test direct branch-ref snapshot",
         ));
         row
     }
@@ -10914,7 +10907,6 @@ mod tests {
             crate::transaction_types::TransactionJson::from_value_for_test(
                 serde_json::json!({ "key": key, "value": value }),
             ),
-            "test untracked key-value snapshot",
         ));
         row
     }

--- a/packages/lix/src/transaction/context.rs
+++ b/packages/lix/src/transaction/context.rs
@@ -8888,10 +8888,10 @@ fn push_prepared_state_row_from_planned_parts(
     let branch_id = row.branch_id.clone();
     let snapshot = rows
         .take_snapshot(row_index)
-        .map(|value| stage_json_from_value(value, "prepared row snapshot_content"));
+        .map(stage_json_from_value);
     let metadata = rows
         .take_metadata(row_index)
-        .map(|value| stage_json_from_value(value, "prepared row metadata"));
+        .map(stage_json_from_value);
     let row_pk = rows.take_row_pk(row_index).ok_or_else(|| {
         LixError::new(
             "LIX_ERROR_UNKNOWN",

--- a/packages/lix/src/transaction/staging.rs
+++ b/packages/lix/src/transaction/staging.rs
@@ -6540,7 +6540,6 @@ mod tests {
     fn state_row(key: &str, value: &str) -> TestPreparedStateRow {
         let snapshot = stage_json_from_value(
             TransactionJson::from_value_for_test(serde_json::json!({ "key": key, "value": value })),
-            "test staged row snapshot_content",
         );
         TestPreparedStateRow {
             schema_plan_id: SchemaPlanId::for_test(0),

--- a/packages/lix/src/transaction/validation.rs
+++ b/packages/lix/src/transaction/validation.rs
@@ -3747,7 +3747,6 @@ mod tests {
         let parsed = test_json_text(value).expect("test staged JSON should parse");
         crate::transaction_types::stage_json_from_value(
             TransactionJson::from_value_for_test(parsed),
-            "test staged JSON",
         )
     }
 

--- a/packages/lix/src/transaction_types.rs
+++ b/packages/lix/src/transaction_types.rs
@@ -770,10 +770,7 @@ impl CertifiedParameterBatch {
         });
         let mut json = Vec::with_capacity(row_count);
         for snapshot in snapshots {
-            json.push(stage_json_from_value(
-                snapshot,
-                "certified parameter snapshot_content",
-            ));
+            json.push(stage_json_from_value(snapshot));
         }
         let string_index = strings
             .iter()
@@ -1322,8 +1319,7 @@ impl RawWriteBatch {
                     "certified transaction row is missing snapshot_content",
                 )
             })?;
-            let snapshot =
-                stage_json_from_value(snapshot, "certified prepared row snapshot_content");
+            let snapshot = stage_json_from_value(snapshot);
             prepared_row_pks.push(row_pk);
             json.push(snapshot);
             let untracked = slot.flags & RAW_WRITE_UNTRACKED != 0;
@@ -2428,7 +2424,7 @@ impl PartialEq for StageJson {
 
 impl Eq for StageJson {}
 
-pub(crate) fn stage_json_from_value(value: TransactionJson, _context: &str) -> StageJson {
+pub(crate) fn stage_json_from_value(value: TransactionJson) -> StageJson {
     // Inline values carry their bytes as the authoritative durable payload.
     // Computing and retaining a content hash for every small row only to
     // discard it at `JsonSlotRef::Inline` doubled the canonical-byte walk on
@@ -4831,7 +4827,6 @@ mod tests {
                 "a",
                 Some(stage_json_from_value(
                     TransactionJson::from_canonical_batch(first),
-                    "insert fixture",
                 )),
                 TransactionWriteOperation::Insert,
                 &origin_key,
@@ -4840,7 +4835,6 @@ mod tests {
                 "b",
                 Some(stage_json_from_value(
                     TransactionJson::from_canonical_batch(second),
-                    "update fixture",
                 )),
                 TransactionWriteOperation::Update,
                 &origin_key,
@@ -4886,7 +4880,6 @@ mod tests {
         let staged_snapshot = |value: String| {
             stage_json_from_value(
                 TransactionJson::from_certified_shared_normalized_row_content(value.into()),
-                "compaction fixture",
             )
         };
         let mut batch = PreparedStateBatch::from_test_rows(vec![
@@ -5002,13 +4995,11 @@ mod tests {
                 TransactionJson::from_certified_shared_normalized_row_content(
                     format!(r#"{{"id":"row-{index}"}}"#).into(),
                 ),
-                "capacity snapshot",
             );
             let metadata = stage_json_from_value(
                 TransactionJson::from_certified_shared_normalized_row_content(
                     format!(r#"{{"row":{index}}}"#).into(),
                 ),
-                "capacity metadata",
             );
             batch.push_test_row(TestPreparedStateRow {
                 schema_plan_id: SchemaPlanId::for_test(0),
@@ -5118,7 +5109,7 @@ mod tests {
         );
         assert!(transaction_json.row_content_certified());
 
-        let staged = stage_json_from_value(transaction_json, "certified test row");
+        let staged = stage_json_from_value(transaction_json);
         assert_eq!(
             staged.value(),
             &serde_json::json!({"path": "/a", "value": {"nested": true}})
@@ -5139,7 +5130,6 @@ mod tests {
         let expected = JsonRef::for_content(normalized.as_bytes());
         let staged = stage_json_from_value(
             TransactionJson::from_certified_normalized_row_content(normalized.into()),
-            "large certified test row",
         );
 
         assert!(!staged.is_inline());
@@ -5161,7 +5151,7 @@ mod tests {
         let batch_row = batch.pop().expect("canonical row");
         let transaction_json = TransactionJson::from_canonical_batch(batch_row.clone());
 
-        let staged = stage_json_from_value(transaction_json, "canonical batch row");
+        let staged = stage_json_from_value(transaction_json);
         let staged_batch_row = staged
             .canonical_batch_row()
             .expect("staging must retain canonical batch ownership");
@@ -5194,7 +5184,6 @@ mod tests {
         let source = batch_row.normalized_shared();
         let mut staged = stage_json_from_value(
             TransactionJson::from_canonical_batch(batch_row),
-            "validated canonical batch row",
         );
 
         assert!(staged.release_validated_canonical_value_column());
@@ -5214,7 +5203,7 @@ mod tests {
             transaction_json.value(),
             &serde_json::json!({"id": "row-1", "value": "hello"})
         );
-        let mut staged = stage_json_from_value(transaction_json, "shared canonical row");
+        let mut staged = stage_json_from_value(transaction_json);
         assert!(staged.retains_decoded_value_for_tests());
 
         assert!(staged.release_validated_canonical_value_column());
@@ -5250,7 +5239,6 @@ mod tests {
                             TransactionJson::from_certified_normalized_row_content(Arc::clone(
                                 source,
                             )),
-                            "certified direct replacement",
                         )),
                         TransactionWriteOperation::Update,
                         &origin_key,
@@ -5310,7 +5298,6 @@ mod tests {
                         &format!("row-{index}"),
                         Some(stage_json_from_value(
                             snapshot,
-                            "certified transaction arena",
                         )),
                         TransactionWriteOperation::Insert,
                         &origin_key,
@@ -5384,7 +5371,7 @@ mod tests {
         .expect("certified transaction arena")
         .pop()
         .expect("certified row");
-        let mut staged = stage_json_from_value(snapshot, "certified transaction arena");
+        let mut staged = stage_json_from_value(snapshot);
 
         assert!(!staged.retains_decoded_value_for_tests());
         assert_eq!(staged.value()["id"], "row-1");
@@ -5426,7 +5413,6 @@ mod tests {
                         &format!("row-{index}"),
                         Some(stage_json_from_value(
                             TransactionJson::from_canonical_batch(value),
-                            "sparse canonical fixture",
                         )),
                         TransactionWriteOperation::Update,
                         &origin_key,
@@ -5503,7 +5489,6 @@ mod tests {
                         &format!("row-{index}"),
                         Some(stage_json_from_value(
                             TransactionJson::from_canonical_batch(value),
-                            "skewed canonical fixture",
                         )),
                         TransactionWriteOperation::Update,
                         &origin_key,


### PR DESCRIPTION
## Summary
- remove the unused context label from `stage_json_from_value`
- simplify all internal call sites to the one-argument constructor

## Evidence
- the context was unused after the constructor became infallible
- `cargo check -p lix --lib`
- `cargo test -p lix --lib --no-run`
- `cargo clippy -p lix --all-targets --no-deps`

This is an internal API cleanup with no runtime behavior or public API change.