### PR TITLE
Inline one-caller CAS manifest predicate

### DIFF
--- a/packages/lix/src/binary_cas/context.rs
+++ b/packages/lix/src/binary_cas/context.rs
@@ -79,14 +79,6 @@ impl BinaryCasContext {
         Self
     }
 
-    pub(crate) fn prepared_manifest_is_staged(
-        &self,
-        writes: &StorageWriteSet,
-        blob_id: BlobId,
-    ) -> bool {
-        writes.contains_put(super::kv::BINARY_CAS_MANIFEST_SPACE, blob_id.as_bytes())
-    }
-
     /// Creates a Binary CAS reader over any storage reader.
     ///
     /// The reader can be a read transaction or the active write transaction

--- a/packages/lix/src/transaction/context.rs
+++ b/packages/lix/src/transaction/context.rs
@@ -932,10 +932,10 @@ where
                 "atomic transaction metadata was staged more than once",
             ));
         }
-        if !self
-            .binary_cas
-            .prepared_manifest_is_staged(&writes, blob_id)
-        {
+        if !writes.contains_put(
+            crate::binary_cas::BINARY_CAS_MANIFEST_SPACE,
+            blob_id.as_bytes(),
+        ) {
             return Err(LixError::new(
                 LixError::CODE_INTERNAL_ERROR,
                 "atomic CAS publication is missing its prepared manifest",


### PR DESCRIPTION
## Summary
- remove the one-caller `BinaryCasContext::prepared_manifest_is_staged` wrapper
- keep the atomic CAS publication invariant at its call site

## Validation
- `cargo check -p lix --lib`
- `cargo test -p lix --lib session::media_upload::tests::sequential_parts_survive_a_new_session_and_publish_one_file -- --nocapture`
- `cargo clippy -p lix --all-targets --no-deps`

All passed; only the existing three warnings remain.