### PR TITLE
simplify: inline Wasmtime cache directory lookup

### DIFF
--- a/packages/lix/src/plugin/runtime/default/mod.rs
+++ b/packages/lix/src/plugin/runtime/default/mod.rs
@@ -54,7 +54,7 @@ fn create_engine(consume_fuel: bool, epoch_interruption: bool) -> wasmtime::Resu
 /// deterministic.
 fn configure_component_cache(config: &mut Config) -> wasmtime::Result<()> {
     let mut cache_config = CacheConfig::new();
-    let directory = lix_wasmtime_cache_dir()?;
+    let directory = lix_wasmtime_cache_dir_from(env::var_os(LIX_WASMTIME_CACHE_DIR_ENV))?;
     let explicitly_configured = directory.is_some();
     if let Some(directory) = directory {
         cache_config.with_directory(directory);
@@ -70,10 +70,6 @@ fn configure_component_cache(config: &mut Config) -> wasmtime::Result<()> {
         Err(error) => return Err(error),
     }
     Ok(())
-}
-
-fn lix_wasmtime_cache_dir() -> wasmtime::Result<Option<PathBuf>> {
-    lix_wasmtime_cache_dir_from(env::var_os(LIX_WASMTIME_CACHE_DIR_ENV))
 }
 
 fn lix_wasmtime_cache_dir_from(directory: Option<OsString>) -> wasmtime::Result<Option<PathBuf>> {


### PR DESCRIPTION
## Summary
- inline the sole production call to the Wasmtime cache-directory environment lookup
- retain the parameterized path validator used by focused tests
- preserve cache configuration and error behavior

## Validation
- cargo test -p lix --all-features --lib plugin::runtime::default --no-fail-fast
- cargo clippy -p lix --all-targets --all-features -- -D warnings