### PR TITLE
chore(lix): gate feature-specific test helpers

### DIFF
--- a/packages/lix/src/common/mod.rs
+++ b/packages/lix/src/common/mod.rs
@@ -12,9 +12,9 @@ pub(crate) mod wire;
 
 pub use error::LixError;
 pub(crate) use exact_batch::{ExactBatch, ExactValue};
-pub use execution_metadata::{
-    ExecuteStatementMetadata, MutationIdentity, RequestBlobSpliceProvenance, VerifiedRequestBlob,
-};
+pub use execution_metadata::{ExecuteStatementMetadata, MutationIdentity, RequestBlobSpliceProvenance};
+#[cfg(feature = "server-protocol")]
+pub(crate) use execution_metadata::VerifiedRequestBlob;
 pub use identity::{BranchId, CanonicalPluginKey, CanonicalSchemaKey, RowPk, FileId};
 pub(crate) use identity::{json_pointer_get, validate_non_empty_identity_value};
 pub(crate) use json_pointer::format_json_pointer;

--- a/packages/lix/src/gc.rs
+++ b/packages/lix/src/gc.rs
@@ -2457,6 +2457,7 @@ mod tests {
         stage_delete_recovery_ref, stage_recovery_ref_rotation,
     };
 
+    #[cfg(feature = "storage-benches")]
     async fn space_inventory<R>(read: &R, space: StorageSpace) -> Vec<(Vec<u8>, Vec<u8>)>
     where
         R: crate::storage_adapter::StorageAdapterRead,


### PR DESCRIPTION
## Summary
- make the server-protocol request blob re-export feature-specific
- compile the GC inventory helper only with storage benchmarks

## Validation
- cargo check -p lix --features all-simulations --tests
- cargo check -p lix --all-features --tests
- cargo clippy -p lix --all-targets --all-features -- -D warnings

This keeps the crate API and runtime behavior unchanged while removing warnings from the default simulation build.