### PR TITLE
Remove empty GC repair set

### DIFF
--- a/packages/lix/src/changelog/mod.rs
+++ b/packages/lix/src/changelog/mod.rs
@@ -37,4 +37,4 @@ pub(crate) use types::{
     CommitScanRequest, TransactionChangeRecordRef, TransactionChangelogAppend,
     commit_row_snapshot_json, next_first_parent_jump,
 };
-pub(crate) use types::{GcLiveSet, GcPlan, GcRepairSet, GcRoot, GcSweepSet};
+pub(crate) use types::{GcLiveSet, GcPlan, GcRoot, GcSweepSet};

--- a/packages/lix/src/changelog/types.rs
+++ b/packages/lix/src/changelog/types.rs
@@ -823,14 +823,10 @@ pub(crate) struct GcSweepSet {
 }
 
 #[derive(Clone, Debug, Default, Eq, PartialEq)]
-pub(crate) struct GcRepairSet {}
-
-#[derive(Clone, Debug, Default, Eq, PartialEq)]
 pub(crate) struct GcPlan {
     pub(crate) roots: Vec<GcRoot>,
     pub(crate) live: GcLiveSet,
     pub(crate) sweep: GcSweepSet,
-    pub(crate) repair: GcRepairSet,
 }
 
 /// Canonical derived `lix_commit` row snapshot.

--- a/packages/lix/src/gc.rs
+++ b/packages/lix/src/gc.rs
@@ -14,7 +14,7 @@ use crate::branch::{
     BranchHeadControl, BranchHeadControlContext, BranchHeadTrackedReachability,
     branch_head_control_precondition,
 };
-use crate::changelog::{ChangeId, CommitId, GcLiveSet, GcPlan, GcRepairSet, GcRoot, GcSweepSet};
+use crate::changelog::{ChangeId, CommitId, GcLiveSet, GcPlan, GcRoot, GcSweepSet};
 #[cfg(test)]
 use crate::changelog::{ChangeRecord, CommitScanRequest};
 #[cfg(any(test, feature = "storage-benches"))]
@@ -1608,7 +1608,6 @@ where
                 changes: Vec::new(),
                 json_payloads: sweep_json_payloads,
             },
-            repair: GcRepairSet::default(),
         },
         sweep: RepositoryGcSweep {
             live_manifest_count,
@@ -2261,7 +2260,6 @@ where
             changes: sweep_changes,
             json_payloads: sweep_json_payloads,
         },
-        repair: GcRepairSet::default(),
     })
 }
 


### PR DESCRIPTION
## Summary
- delete the field-less `GcRepairSet` type
- remove the unread `GcPlan.repair` field and its construction/re-export plumbing

## Validation
- `cargo check -p lix --lib`
- `cargo test -p lix --lib gc:: -- --nocapture` (32 passed)
- `cargo clippy -p lix --all-targets --no-deps`

Only the existing three warnings remain.