### PR TITLE
chore(lix): gate benchmark-only GC imports

### DIFF
--- a/packages/lix/src/gc.rs
+++ b/packages/lix/src/gc.rs
@@ -2428,10 +2428,12 @@ mod tests {
     };
     use crate::storage_adapter::{
         MAX_SCAN_PAGE_ROWS, Memory, PointReadPlan, SharedStorageAdapterRead, StorageAdapter,
-        StorageBeginScanOptions, StorageCoreProjection, StorageGetOptions, StorageKey,
+        StorageBeginScanOptions, StorageGetOptions, StorageKey,
         StoragePrefix, StorageReadOptions, StorageSpace, StorageValue, StorageWriteOptions,
         StorageWriteSet,
     };
+    #[cfg(feature = "storage-benches")]
+    use crate::storage_adapter::StorageCoreProjection;
     use crate::tracked_state::{
         CommitDeltaLifecycleSummary, CommitDeltaReplacementGeneration, CommitDeltaReplacementScope,
         CommitStateManifest, CommitStateMutationInventory, CommitStateReplayDebt,


### PR DESCRIPTION
## Summary
- keep the GC inventory projection import aligned with its storage-bench-only helper

## Validation
- cargo check -p lix --features all-simulations --tests
- cargo clippy -p lix --all-targets --all-features -- -D warnings

The remaining default-build FileRead warnings are public API methods used by the server protocol and are intentionally retained.