### PR TITLE
simplify: inline active transaction close error

### DIFF
--- a/packages/js-sdk/src/lix.ts
+++ b/packages/js-sdk/src/lix.ts
@@ -205,7 +205,12 @@ export class Lix {
 	async close(): Promise<void> {
 		if (!this.closePromise) {
 			if (this.#transactionsOpening > 0 || this.#activeTransactions > 0) {
-				throw activeTransactionCloseError();
+				const error = new Error(
+					"cannot close Lix while an explicit transaction is active",
+				) as Error & { code: string };
+				error.name = "LixError";
+				error.code = "LIX_INVALID_TRANSACTION_STATE";
+				throw error;
 			}
 			// Flip the public lifecycle gate before the first await. Operations that
 			// already entered the gate are allowed to finish; later calls fail closed.
@@ -252,15 +257,6 @@ export class Lix {
 		error.code = "LIX_ERROR_CLOSED";
 		throw error;
 	}
-}
-
-function activeTransactionCloseError(): Error & { code: string } {
-	const error = new Error(
-		"cannot close Lix while an explicit transaction is active",
-	) as Error & { code: string };
-	error.name = "LixError";
-	error.code = "LIX_INVALID_TRANSACTION_STATE";
-	return error;
 }
 
 export class ObserveEvents {


### PR DESCRIPTION
## Summary
- inline the active-transaction close error at its only call site
- remove the private error-construction helper
- preserve the exact message, name, and public error code

## Validation
- npx vitest run src/lix-lifecycle.test.ts (4 passed)