### PR TITLE
Remove JSON context loader facade

### DIFF
--- a/packages/lix/src/changelog/materialization.rs
+++ b/packages/lix/src/changelog/materialization.rs
@@ -289,14 +289,12 @@ where
     if json_refs.is_empty() {
         return Ok(Vec::new());
     }
-    Ok(JsonStoreContext::new()
-        .load_bytes_many(
-            store,
-            JsonLoadRequestRef {
-                refs: json_refs,
-                scope: JsonReadScopeRef::OutOfBand,
-            },
-        )
+    let mut reader = JsonStoreContext::new().reader(store);
+    Ok(reader
+        .load_bytes_many(JsonLoadRequestRef {
+            refs: json_refs,
+            scope: JsonReadScopeRef::OutOfBand,
+        })
         .await?
         .into_values())
 }

--- a/packages/lix/src/hot_state/tracked_head.rs
+++ b/packages/lix/src/hot_state/tracked_head.rs
@@ -2258,14 +2258,12 @@ where
     if json_refs.is_empty() {
         return Ok(rows.finish());
     }
-    let mut json_values = JsonStoreContext::new()
-        .load_bytes_many(
-            store,
-            JsonLoadRequestRef {
-                refs: &json_refs,
-                scope: JsonReadScopeRef::OutOfBand,
-            },
-        )
+    let mut json_reader = JsonStoreContext::new().reader(store);
+    let mut json_values = json_reader
+        .load_bytes_many(JsonLoadRequestRef {
+            refs: &json_refs,
+            scope: JsonReadScopeRef::OutOfBand,
+        })
         .await?
         .into_values();
     for (index, deferred) in deferred.into_iter().enumerate() {

--- a/packages/lix/src/hot_state/tracked_head/hot.rs
+++ b/packages/lix/src/hot_state/tracked_head/hot.rs
@@ -4323,14 +4323,12 @@ async fn scan_packed_current_base_rows(
     if json_refs.is_empty() {
         return Ok(rows.finish());
     }
-    let mut json_values = JsonStoreContext::new()
-        .load_bytes_many(
-            store,
-            JsonLoadRequestRef {
-                refs: &json_refs,
-                scope: JsonReadScopeRef::OutOfBand,
-            },
-        )
+    let mut json_reader = JsonStoreContext::new().reader(store);
+    let mut json_values = json_reader
+        .load_bytes_many(JsonLoadRequestRef {
+            refs: &json_refs,
+            scope: JsonReadScopeRef::OutOfBand,
+        })
         .await?
         .into_values();
     for (index, deferred) in deferred.into_iter().enumerate() {
@@ -4551,14 +4549,12 @@ async fn load_packed_current_base_exact(
         }
     }
     if !json_refs.is_empty() {
-        let mut json_values = JsonStoreContext::new()
-            .load_bytes_many(
-                store,
-                JsonLoadRequestRef {
-                    refs: &json_refs,
-                    scope: JsonReadScopeRef::OutOfBand,
-                },
-            )
+        let mut json_reader = JsonStoreContext::new().reader(store);
+        let mut json_values = json_reader
+            .load_bytes_many(JsonLoadRequestRef {
+                refs: &json_refs,
+                scope: JsonReadScopeRef::OutOfBand,
+            })
             .await?
             .into_values();
         for (index, deferred) in deferred.into_iter().enumerate() {
@@ -5833,14 +5829,12 @@ where
             )));
         }
         if !deferred_refs.is_empty() {
-            let loaded = JsonStoreContext::new()
-                .load_bytes_many(
-                    &self.store,
-                    JsonLoadRequestRef {
-                        refs: &deferred_refs,
-                        scope: JsonReadScopeRef::OutOfBand,
-                    },
-                )
+            let mut json_reader = JsonStoreContext::new().reader(&self.store);
+            let loaded = json_reader
+                .load_bytes_many(JsonLoadRequestRef {
+                    refs: &deferred_refs,
+                    scope: JsonReadScopeRef::OutOfBand,
+                })
                 .await?
                 .into_values();
             for (row_index, value) in deferred_rows.into_iter().zip(loaded) {

--- a/packages/lix/src/json_store/context.rs
+++ b/packages/lix/src/json_store/context.rs
@@ -31,16 +31,6 @@ impl JsonStoreContext {
     pub(crate) fn writer(&self) -> JsonStoreWriter {
         JsonStoreWriter::new()
     }
-
-    pub(crate) async fn load_bytes_many(
-        &self,
-        store: &(impl StorageAdapterRead + ?Sized),
-        request: JsonLoadRequestRef<'_>,
-    ) -> Result<JsonLoadBatch, LixError> {
-        store::load_json_bytes_many_in_scope(store, request.refs, request.scope)
-            .await
-            .map(JsonLoadBatch::new)
-    }
 }
 
 pub(crate) struct JsonStoreReader<S> {
@@ -239,14 +229,12 @@ mod tests {
             .begin_read(StorageReadOptions::default())
             .await
             .expect("read should open");
-        let loaded = JsonStoreContext::new()
-            .load_bytes_many(
-                &read,
-                JsonLoadRequestRef {
-                    refs: &refs,
-                    scope: JsonReadScopeRef::OutOfBand,
-                },
-            )
+        let mut reader = JsonStoreContext::new().reader(read);
+        let loaded = reader
+            .load_bytes_many(JsonLoadRequestRef {
+                refs: &refs,
+                scope: JsonReadScopeRef::OutOfBand,
+            })
             .await
             .expect("shared JSON batch should decode")
             .into_values();

--- a/packages/lix/src/storage_bench.rs
+++ b/packages/lix/src/storage_bench.rs
@@ -3369,14 +3369,12 @@ where
         .into_iter()
         .map(crate::json_store::JsonRef::from_hash_bytes)
         .collect::<Vec<_>>();
-    let loaded = crate::json_store::JsonStoreContext::new()
-        .load_bytes_many(
-            read,
-            crate::json_store::JsonLoadRequestRef {
-                refs: &json_refs,
-                scope: crate::json_store::JsonReadScopeRef::OutOfBand,
-            },
-        )
+    let mut json_reader = crate::json_store::JsonStoreContext::new().reader(read);
+    let loaded = json_reader
+        .load_bytes_many(crate::json_store::JsonLoadRequestRef {
+            refs: &json_refs,
+            scope: crate::json_store::JsonReadScopeRef::OutOfBand,
+        })
         .await?;
     for value in loaded.into_values().into_iter().flatten() {
         if let Ok(value) = serde_json::from_slice::<serde_json::Value>(&value) {

--- a/packages/lix/src/tracked_state/context.rs
+++ b/packages/lix/src/tracked_state/context.rs
@@ -7913,14 +7913,12 @@ mod tests {
             crate::json_store::JsonRef::for_content(at_threshold.as_bytes()),
             crate::json_store::JsonRef::for_content(over_threshold.as_bytes()),
         ];
-        let stored = crate::json_store::JsonStoreContext::new()
-            .load_bytes_many(
-                &read,
-                crate::json_store::JsonLoadRequestRef {
-                    refs: &json_refs,
-                    scope: crate::json_store::JsonReadScopeRef::OutOfBand,
-                },
-            )
+        let mut json_reader = crate::json_store::JsonStoreContext::new().reader(&read);
+        let stored = json_reader
+            .load_bytes_many(crate::json_store::JsonLoadRequestRef {
+                refs: &json_refs,
+                scope: crate::json_store::JsonReadScopeRef::OutOfBand,
+            })
             .await
             .expect("json_store boundary rows should load")
             .into_values();

--- a/packages/lix/src/transaction/commit.rs
+++ b/packages/lix/src/transaction/commit.rs
@@ -7679,14 +7679,12 @@ mod tests {
             certified.change.snapshot,
             crate::json_store::JsonSlot::Ref(large_snapshot_ref)
         );
-        let loaded = JsonStoreContext::new()
-            .load_bytes_many(
-                &read,
-                crate::json_store::JsonLoadRequestRef {
-                    refs: &[large_snapshot_ref],
-                    scope: crate::json_store::JsonReadScopeRef::OutOfBand,
-                },
-            )
+        let mut json_reader = JsonStoreContext::new().reader(&read);
+        let loaded = json_reader
+            .load_bytes_many(crate::json_store::JsonLoadRequestRef {
+                refs: &[large_snapshot_ref],
+                scope: crate::json_store::JsonReadScopeRef::OutOfBand,
+            })
             .await
             .expect("large certified JSON ref should resolve")
             .into_values();


### PR DESCRIPTION
## Summary
- remove the stateless `JsonStoreContext::load_bytes_many` facade
- route its internal callers through the existing `JsonStoreReader`

## Validation
- `cargo check -p lix --lib`
- `cargo test -p lix --lib json_store::context::tests::stage_batch_deduplicates_into_one_key_and_value_arena -- --nocapture`
- `cargo check -p lix --lib --features storage-benches`
- `cargo clippy -p lix --all-targets --no-deps`

All passed; no loader behavior or batching code changed.