### PR TITLE
Collapse no-op rebuild benchmark stats

### DIFF
--- a/packages/lix/src/changelog/bench_support.rs
+++ b/packages/lix/src/changelog/bench_support.rs
@@ -8,7 +8,7 @@ use super::context::ChangelogContext;
 use super::store::{ChangelogReader, ChangelogWriter};
 use super::types::{
     ChangeId, ChangeLoadRequest, ChangeRecord, ChangelogAppend, CommitId, CommitLoadRequest,
-    CommitRecord, RebuildIndexStats,
+    CommitRecord,
 };
 use crate::LixError;
 use crate::row_pk::RowPk;
@@ -473,7 +473,7 @@ pub async fn rebuild_mandatory_indexes<StorageImpl>(
 where
     StorageImpl: BenchStorage + Sync,
 {
-    Ok(RebuildIndexStats::default().into())
+    Ok(BenchRebuildStats::default())
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -685,17 +685,6 @@ impl From<StorageWriteSetStats> for BenchWriteStats {
             puts: stats.staged_puts as usize,
             deletes: stats.staged_deletes as usize,
             bytes_written: stats.written_bytes as usize,
-        }
-    }
-}
-
-impl From<RebuildIndexStats> for BenchRebuildStats {
-    fn from(stats: RebuildIndexStats) -> Self {
-        Self {
-            expected: stats.expected,
-            put: stats.put,
-            deleted: stats.deleted,
-            unchanged: stats.unchanged,
         }
     }
 }

--- a/packages/lix/src/changelog/types.rs
+++ b/packages/lix/src/changelog/types.rs
@@ -788,15 +788,6 @@ pub(crate) struct ChangeScanBatch {
     pub(crate) next_start_after: Option<ChangeId>,
 }
 
-#[cfg(feature = "storage-benches")]
-#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
-pub(crate) struct RebuildIndexStats {
-    pub(crate) expected: usize,
-    pub(crate) put: usize,
-    pub(crate) deleted: usize,
-    pub(crate) unchanged: usize,
-}
-
 #[allow(dead_code)] // Activated by the checkpoint GC integration.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub(crate) enum GcRoot {


### PR DESCRIPTION
## Summary
- return `BenchRebuildStats::default()` directly from the no-op rebuild hook
- remove the duplicate feature-gated `RebuildIndexStats` type and conversion bridge

## Validation
- `cargo check -p lix --lib --features storage-benches`
- `cargo check -p lix --benches --features storage-benches`
- `cargo clippy -p lix --all-targets --no-deps --features storage-benches`

All passed; only the existing `FileRead` dead-method warning remains.