### PR TITLE
simplify: remove dead Markdown bytes alias

### DIFF
--- a/plugins/markdown/src/core.rs
+++ b/plugins/markdown/src/core.rs
@@ -2759,11 +2759,6 @@ impl Document {
         self.bytes.materialize()
     }
 
-    #[cfg(test)]
-    pub(crate) fn accepted_bytes(&self) -> Vec<u8> {
-        self.bytes()
-    }
-
 }
 
 /// A single base-relative text replacement. Keeping this deliberately narrow


### PR DESCRIPTION
## Summary
- remove the unused cfg(test) `accepted_bytes` alias
- retain the live `bytes` accessor used by the Markdown implementation

## Validation
- cargo test -p plugin_markdown --lib (167 passed, 1 ignored)
- cargo clippy -p plugin_markdown --lib --all-features -- -D warnings