### PR TITLE
perf(lix): short-circuit empty change scans

### DIFF
--- a/packages/lix/src/sql2/providers/change.rs
+++ b/packages/lix/src/sql2/providers/change.rs
@@ -159,7 +159,11 @@ where
                 .await
                 .map(|change| change.into_iter().collect());
         }
-        ChangeScanRoute::All => {}
+        ChangeScanRoute::All => {
+            if limit == Some(0) {
+                return Ok(Vec::new());
+            }
+        }
     }
     let packed_changes =
         crate::tracked_state::scan_change_records_from_commit_deltas(&store).await?;


### PR DESCRIPTION
## Summary
- return an empty change batch immediately for an unfiltered `LIMIT 0` scan
- avoid changelog, commit-graph, sorting, and JSON work when no rows can be returned

## Evidence
- the pushed limit is only present on the unfiltered `All` route; exact-id routes remain unchanged
- `cargo test --locked -p lix --lib sql2::providers::change --no-fail-fast` (3 passed)
- `cargo clippy --locked -p lix --all-targets --all-features -- -D warnings` passes
- SQL result semantics and public API are unchanged

Target branch: `simplification`.