### PR TITLE
simplify: inline RocksDB stored value adapter

### DIFF
--- a/packages/storage-rocksdb/src/rocksdb.rs
+++ b/packages/storage-rocksdb/src/rocksdb.rs
@@ -20,7 +20,7 @@ use lix::storage::{
     BeginScanOptions, Capability, CommitResult, CoreProjection, GetManyRequest, GetManyResult, Key,
     KeyRange, Precondition, PreconditionFailure, ProjectedValue, PutBatch, ReadDurability,
     ReadEntry, ReadOptions, ScanChunk, ScanCursor, ScanOrder, SpaceId, Storage, StorageError,
-    StorageRead, StorageScanSource, StorageSpace, StorageWrite, StoredValue, ValueIntegrity,
+    StorageRead, StorageScanSource, StorageSpace, StorageWrite, ValueIntegrity,
     ValueSemantics, WriteOptions, WriteStats,
 };
 use rocksdb::{
@@ -604,7 +604,7 @@ impl StorageWrite for RocksDBWrite {
                 physical_key.clear();
                 physical_key.extend_from_slice(&space_prefix);
                 physical_key.extend_from_slice(&entry.key.0);
-                let value = stored_value_bytes(entry.value);
+                let value = entry.value.bytes;
                 if space.value_semantics == ValueSemantics::Immutable {
                     if let Some(staged) = self.immutable_values.get(physical_key.as_slice()) {
                         if staged != &value {
@@ -916,10 +916,6 @@ fn column_family_options() -> Options {
     table_options.set_optimize_filters_for_memory(true);
     options.set_block_based_table_factory(&table_options);
     options
-}
-
-fn stored_value_bytes(value: StoredValue) -> Bytes {
-    value.bytes
 }
 
 /// Reclaims the iterator-owned physical key and removes its four-byte space


### PR DESCRIPTION
## Summary
- inline the sole `StoredValue` field projection in the RocksDB scan path
- remove the private identity adapter and its now-unused import
- preserve the returned bytes allocation and scan projection behavior

## Validation
- cargo test -p lix-storage-rocksdb --lib (3 passed)
- cargo clippy -p lix-storage-rocksdb --lib --all-features -- -D warnings