### PR TITLE
perf(lix): short-circuit empty diff scans

### DIFF
--- a/packages/lix/src/sql2/providers/diff.rs
+++ b/packages/lix/src/sql2/providers/diff.rs
@@ -145,7 +145,7 @@ where
                     self.to_commit_id.clone(),
                 ),
                 move |(store, schema, route, from_commit_id, to_commit_id)| async move {
-                    if route.contradictory {
+                    if limit == Some(0) || route.contradictory {
                         return DIFF_COLS.build(schema, &[]).map_err(diff_batch_error);
                     }
                     let mut tracked = TrackedStateContext::new().reader(store);


### PR DESCRIPTION
## Summary
- avoid computing tracked-state diffs for `LIMIT 0`
- preserve contradictory-filter handling and all nonzero diff behavior

## Evidence
- `cargo test --locked -p lix --lib sql2::providers::diff --no-fail-fast` passes (no provider tests currently registered)
- `cargo clippy --locked -p lix --all-targets --all-features -- -D warnings` passes
- no public API or result-shape changes

Target branch: `simplification`.