### PR TITLE
Flatten tracked leaf entry lookup result

### DIFF
--- a/packages/lix/src/tracked_state/codec.rs
+++ b/packages/lix/src/tracked_state/codec.rs
@@ -176,12 +176,11 @@ impl DecodedLeafNodeRef {
             .map(|span| self.arena.slice(span.key_start..span.key_end))
     }
 
-    #[expect(clippy::unnecessary_wraps)]
-    pub(crate) fn entry(&self, index: usize) -> Result<Option<EncodedLeafEntryRef<'_>>, LixError> {
-        Ok(self.entries.get(index).map(|span| EncodedLeafEntryRef {
+    pub(crate) fn entry(&self, index: usize) -> Option<EncodedLeafEntryRef<'_>> {
+        self.entries.get(index).map(|span| EncodedLeafEntryRef {
             key: &self.arena[span.key_start..span.key_end],
             value: &self.arena[span.value_start..span.value_end],
-        }))
+        })
     }
 
     pub(crate) fn entry_owned(&self, index: usize) -> Option<EncodedLeafEntry> {
@@ -1534,7 +1533,6 @@ fn verify_leaf_round_trip(encoded: &[u8], entries: &[EncodedLeafEntryRef<'_>]) {
     for (index, entry) in entries.iter().enumerate() {
         let round_tripped = decoded
             .entry(index)
-            .expect("leaf round trip entry should read")
             .expect("leaf round trip entry should exist");
         assert_eq!(round_tripped.key, entry.key, "leaf round trip key {index}");
         assert_eq!(
@@ -2274,7 +2272,6 @@ mod tests {
         for (index, (key, value)) in entries.iter().enumerate() {
             let entry = decoded
                 .entry(index)
-                .expect("entry should read")
                 .expect("entry should exist");
             assert_eq!(entry.key, key.as_slice(), "key {index}");
             assert_eq!(entry.value, value.as_slice(), "value {index}");
@@ -3357,7 +3354,6 @@ mod tests {
         assert_eq!(leaf.key(1), Some(b"bravo".as_ref()));
         let second = leaf
             .entry(1)
-            .expect("second entry")
             .expect("second entry exists");
         assert_eq!(second.key, b"bravo");
         assert_eq!(second.value, raw_value(4, 5, 6));
@@ -3376,7 +3372,7 @@ mod tests {
             panic!("expected leaf node");
         };
         assert_eq!(leaf.len(), 0);
-        assert!(leaf.entry(0).expect("missing entry").is_none());
+        assert!(leaf.entry(0).is_none());
     }
 
     #[test]

--- a/packages/lix/src/tracked_state/storage.rs
+++ b/packages/lix/src/tracked_state/storage.rs
@@ -1876,7 +1876,7 @@ impl CommitDeltaLiveMembershipCursor {
             .expect("membership cursor loaded its current immutable part");
         let mut linear_probes = 0_usize;
         while self.next_entry_index < segment.leaf.len() {
-            let entry = segment.leaf.entry(self.next_entry_index)?.ok_or_else(|| {
+            let entry = segment.leaf.entry(self.next_entry_index).ok_or_else(|| {
                 LixError::new(
                     LixError::CODE_INTERNAL_ERROR,
                     "tracked_state packed commit_delta leaf has a missing entry",
@@ -6735,7 +6735,7 @@ where
 {
     let change_id = locator.change_id;
     let ordinal = usize::from(locator.ordinal);
-    let entry = leaf.entry(ordinal)?.ok_or_else(|| {
+    let entry = leaf.entry(ordinal).ok_or_else(|| {
         LixError::new(
             LixError::CODE_INTERNAL_ERROR,
             format!(
@@ -11146,7 +11146,7 @@ fn collect_strict_commit_delta_members(
         // "how much did it return" are distinguishable.
         #[cfg(feature = "storage-benches")]
         crate::storage_bench::record_commit_delta_segment_entry_decoded();
-        let entry = leaf.entry(entry_index)?.ok_or_else(|| {
+        let entry = leaf.entry(entry_index).ok_or_else(|| {
             LixError::new(
                 LixError::CODE_INTERNAL_ERROR,
                 "tracked_state packed commit_delta leaf has a missing entry",
@@ -12456,7 +12456,7 @@ fn visit_commit_delta_leaf(
 ) -> Result<(), LixError> {
     let mut previous_key: Option<&[u8]> = None;
     for entry_index in 0..leaf.len() {
-        let entry = leaf.entry(entry_index)?.ok_or_else(|| {
+        let entry = leaf.entry(entry_index).ok_or_else(|| {
             LixError::new(
                 LixError::CODE_INTERNAL_ERROR,
                 "tracked_state packed commit_delta leaf has a missing entry",
@@ -12492,7 +12492,7 @@ fn find_commit_delta_value(
     let Some(index) = find_commit_delta_entry_index(leaf, target_key)? else {
         return Ok(None);
     };
-    let entry = leaf.entry(index)?.ok_or_else(|| {
+    let entry = leaf.entry(index).ok_or_else(|| {
         LixError::new(
             LixError::CODE_INTERNAL_ERROR,
             "tracked_state packed commit_delta leaf has a missing entry",
@@ -12548,7 +12548,7 @@ fn load_commit_delta_entry_at_index<S>(
 where
     S: AsRef<[u8]>,
 {
-    let entry = leaf.entry(index)?.ok_or_else(|| {
+    let entry = leaf.entry(index).ok_or_else(|| {
         LixError::new(
             LixError::CODE_INTERNAL_ERROR,
             "tracked_state packed commit_delta leaf has a missing entry",
@@ -12616,7 +12616,7 @@ fn find_commit_delta_entry_index(
     target_key: &[u8],
 ) -> Result<Option<usize>, LixError> {
     let lower = commit_delta_entry_lower_bound_from(leaf, target_key, 0)?;
-    let Some(entry) = leaf.entry(lower)? else {
+    let Some(entry) = leaf.entry(lower) else {
         return Ok(None);
     };
     if entry.key != target_key {

--- a/packages/lix/src/tracked_state/tree.rs
+++ b/packages/lix/src/tracked_state/tree.rs
@@ -248,9 +248,7 @@ impl TrackedStateTree {
             match self.load_node(store, &current).await? {
                 DecodedNode::Leaf(leaf) => {
                     let entry = binary_search_leaf_key(&leaf, &encoded_key)?
-                        .map(|index| leaf.entry(index))
-                        .transpose()?
-                        .flatten();
+                        .and_then(|index| leaf.entry(index));
                     return entry.map(|entry| decode_value(entry.value)).transpose();
                 }
                 DecodedNode::Internal(internal) => {
@@ -1653,7 +1651,7 @@ impl TrackedStateTree {
                         if scan_limit_reached(request, rows.len()) {
                             break;
                         }
-                        let entry = leaf.entry(index)?.ok_or_else(|| {
+                        let entry = leaf.entry(index).ok_or_else(|| {
                             LixError::new(
                                 "LIX_ERROR_UNKNOWN",
                                 "tracked-state leaf entry disappeared during scan",
@@ -1728,7 +1726,7 @@ impl TrackedStateTree {
                 DecodedNodeRef::Leaf(leaf) => {
                     for (original_index, encoded_key) in encoded_keys {
                         if let Some(entry_index) = binary_search_leaf_key(&leaf, encoded_key)? {
-                            let entry = leaf.entry(entry_index)?.ok_or_else(|| {
+                            let entry = leaf.entry(entry_index).ok_or_else(|| {
                                 LixError::new(
                                     "LIX_ERROR_UNKNOWN",
                                     "tracked-state leaf entry disappeared during get_many",


### PR DESCRIPTION
## Summary
- make `DecodedLeafNodeRef::entry` return `Option` directly
- remove impossible `Result` propagation from tracked-state tree and storage readers
- preserve all existing missing-entry errors and decode validation

## Validation
- `cargo check -p lix --lib`
- `cargo test -p lix --lib tracked_state:: -- --nocapture` (318 passed)
- `cargo test -p lix --features all-simulations --lib tracked_state:: -- --nocapture` (318 passed)
- `cargo clippy -p lix --all-targets --no-deps`
- `cargo clippy -p lix --all-targets --no-deps --features server-protocol`

Only the existing default-feature `FileRead` dead-method warning remains.