### PR TITLE
perf(lix): short-circuit empty filesystem diff scans

### DIFF
--- a/packages/lix/src/sql2/providers/filesystem_working_diff.rs
+++ b/packages/lix/src/sql2/providers/filesystem_working_diff.rs
@@ -132,7 +132,7 @@ where
                     self.kind,
                 ),
                 move |(active_branch_id, branch_ref, _commit_graph, store, schema, route, kind)| async move {
-                    if route.contradictory {
+                    if limit == Some(0) || route.contradictory {
                         return FILESYSTEM_WORKING_DIFF_COLS
                             .build(schema, &[])
                             .map_err(batch_error);


### PR DESCRIPTION
## Summary
- avoid branch-head and checkpoint reads for `LIMIT 0` filesystem-working-diff scans
- preserve contradictory filters and all nonzero behavior

## Evidence
- `cargo test --locked -p lix --lib sql2::providers::filesystem_working_diff --no-fail-fast` compiles and passes (no tests currently registered)
- `cargo clippy --locked -p lix --all-targets --all-features -- -D warnings` passes
- no public API or result-shape changes

Target branch: `simplification`.