### PR TITLE
fix(js-sdk): isolate worker exec arguments

### DIFF
--- a/.changenotes/filter-worker-expose-gc.md
+++ b/.changenotes/filter-worker-expose-gc.md
@@ -4,4 +4,4 @@ type: patch
 
 Fixed Node.js worker startup when the host process uses worker-incompatible runtime flags such as `--expose-gc`.
 
-The JavaScript SDK no longer forwards host runtime flags to its self-contained worker.
+The JavaScript SDK no longer forwards worker-incompatible runtime flags while preserving host security restrictions.

--- a/.changenotes/filter-worker-expose-gc.md
+++ b/.changenotes/filter-worker-expose-gc.md
@@ -1,0 +1,7 @@
+---
+type: patch
+---
+
+Fixed Node.js worker startup when the host process uses worker-incompatible runtime flags such as `--expose-gc`.
+
+The JavaScript SDK no longer forwards host runtime flags to its self-contained worker.

--- a/packages/js-sdk/src/worker/factory.node.test.ts
+++ b/packages/js-sdk/src/worker/factory.node.test.ts
@@ -1,8 +1,25 @@
 import { execFile } from "node:child_process";
 import { promisify } from "node:util";
-import { test } from "vitest";
+import { expect, test } from "vitest";
+import { workerExecArgv } from "./factory.node.js";
 
 const execFileAsync = promisify(execFile);
+
+test("preserves host security arguments", () => {
+	expect(
+		workerExecArgv([
+			"--permission",
+			"--allow-worker",
+			"--allow-fs-read=/workspace",
+			"--expose-gc",
+			"--input-type=module",
+		]),
+	).toEqual([
+		"--permission",
+		"--allow-worker",
+		"--allow-fs-read=/workspace",
+	]);
+});
 
 test("starts when the host has worker-incompatible exec arguments", async () => {
 	await execFileAsync(process.execPath, [

--- a/packages/js-sdk/src/worker/factory.node.test.ts
+++ b/packages/js-sdk/src/worker/factory.node.test.ts
@@ -1,0 +1,33 @@
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import { test } from "vitest";
+
+const execFileAsync = promisify(execFile);
+
+test("starts when the host has worker-incompatible exec arguments", async () => {
+	await execFileAsync(process.execPath, [
+		"--expose-gc",
+		"--input-type=module",
+		"--eval",
+		`const { createWorkerConnection } = await import("./dist/worker/factory.node.js");
+const connection = createWorkerConnection();
+const opened = new Promise((resolve, reject) => {
+	connection.onFatal(reject);
+	connection.onMessage((message) => {
+		if (message.id !== 1) return;
+		if (message.ok) resolve();
+		else reject(new Error(message.error.message));
+	});
+});
+connection.postMessage({
+	id: 1,
+	operation: {
+		kind: "open",
+		storage: { kind: "memory" },
+		telemetryEnabled: false,
+	},
+});
+await opened;
+await connection.terminate();`,
+	]);
+});

--- a/packages/js-sdk/src/worker/factory.node.ts
+++ b/packages/js-sdk/src/worker/factory.node.ts
@@ -10,11 +10,7 @@ import type {
 export function createWorkerConnection(): WorkerConnection {
 	const worker = new Worker(new URL("./entry.node.js", import.meta.url), {
 		name: "lix",
-		execArgv: process.execArgv.filter(
-			(arg, index, args) =>
-				!arg.startsWith("--input-type=") &&
-				!(index > 0 && args[index - 1] === "--input-type"),
-		),
+		execArgv: [],
 	});
 	let terminating = false;
 	return {

--- a/packages/js-sdk/src/worker/factory.node.ts
+++ b/packages/js-sdk/src/worker/factory.node.ts
@@ -10,7 +10,7 @@ import type {
 export function createWorkerConnection(): WorkerConnection {
 	const worker = new Worker(new URL("./entry.node.js", import.meta.url), {
 		name: "lix",
-		execArgv: [],
+		execArgv: workerExecArgv(process.execArgv),
 	});
 	let terminating = false;
 	return {
@@ -39,6 +39,20 @@ export function createWorkerConnection(): WorkerConnection {
 			await worker.terminate();
 		},
 	};
+}
+
+export function workerExecArgv(execArgv: readonly string[]): string[] {
+	const filtered: string[] = [];
+	for (let index = 0; index < execArgv.length; index++) {
+		const arg = execArgv[index];
+		if (arg === "--input-type") {
+			index += 1;
+			continue;
+		}
+		if (arg === "--expose-gc" || arg.startsWith("--input-type=")) continue;
+		filtered.push(arg);
+	}
+	return filtered;
 }
 
 /// Native Lix already owns a dedicated serialized engine actor. Routing it


### PR DESCRIPTION
## Summary

- filter worker-incompatible host arguments before starting the Node.js Lix worker
- preserve host security restrictions such as `--permission`, `--allow-worker`, and filesystem allowlists
- cover worker startup from a host launched with `--expose-gc` and `--input-type=module`
- add a patch changenote

Node workers inherit the host process's execution arguments by default. Some arguments accepted by the host, including VS Code's `--expose-gc`, are rejected by `new Worker({ execArgv })` with `ERR_WORKER_INVALID_EXEC_ARGV`. Lix now removes the incompatible `--expose-gc` and `--input-type` arguments while forwarding all other arguments, including Node permission flags.

This was discovered while packaging SDK 3 in Sherlock: https://github.com/opral/sherlock/issues/224

## Validation

- `npm run build`
- `npm run typecheck`
- `npx vitest run src/worker/factory.node.test.ts` — 2 tests passed