### PR TITLE
Fix release lockfile CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,7 @@
 name: CI
 
 on:
+  workflow_dispatch:
   pull_request:
     types: [opened, reopened, synchronize, ready_for_review]
   push:
@@ -20,7 +21,7 @@ defaults:
 jobs:
   changelog:
     name: Changelog
-    if: github.event_name == 'push' || github.event.pull_request.draft == false
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     runs-on: blacksmith-32vcpu-ubuntu-2404
 
     steps:
@@ -35,7 +36,7 @@ jobs:
 
   cargo-config:
     name: Cargo config (${{ matrix.name }})
-    if: github.event_name == 'push' || github.event.pull_request.draft == false
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     runs-on: ${{ matrix.runner }}
     strategy:
       fail-fast: false
@@ -59,7 +60,7 @@ jobs:
 
   cargo:
     name: Cargo ${{ matrix.name }}
-    if: github.event_name == 'push' || github.event.pull_request.draft == false
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     runs-on: blacksmith-32vcpu-ubuntu-2404
     strategy:
       fail-fast: false
@@ -113,7 +114,7 @@ jobs:
         if: matrix.task == 'clippy'
         run: |
           cargo clippy --profile test --workspace --all-targets --all-features -- -D warnings
-          cargo clippy --manifest-path tooling/Cargo.toml --profile test --workspace --all-targets --all-features -- -D warnings
+          cargo clippy --locked --manifest-path tooling/Cargo.toml --profile test --workspace --all-targets --all-features -- -D warnings
 
       # The one supported configuration nothing else here builds: `cfg(test)`
       # with `storage-benches` OFF, which is exactly what a plain
@@ -170,8 +171,8 @@ jobs:
         if: matrix.task == 'test'
         run: |
           cargo test --profile test --workspace --all-features --no-run
-          cargo test --manifest-path tooling/Cargo.toml --profile test --workspace --exclude lix_e2e --all-features --no-run
-          cargo test --manifest-path tooling/Cargo.toml --profile test -p lix_e2e --features sdk-tests,plugin-tests,server-protocol,storage-benches,slatedb,root-replay-trace --no-run
+          cargo test --locked --manifest-path tooling/Cargo.toml --profile test --workspace --exclude lix_e2e --all-features --no-run
+          cargo test --locked --manifest-path tooling/Cargo.toml --profile test -p lix_e2e --features sdk-tests,plugin-tests,server-protocol,storage-benches,slatedb,root-replay-trace --no-run
 
       - name: Run Rust workspace tests
         # Deliberately no stack-size override here. Production operations and
@@ -187,8 +188,8 @@ jobs:
         if: matrix.task == 'test'
         run: |
           cargo test --profile test --workspace --all-features --no-fail-fast
-          cargo test --manifest-path tooling/Cargo.toml --profile test --workspace --exclude lix_e2e --all-features --no-fail-fast
-          cargo test --manifest-path tooling/Cargo.toml --profile test -p lix_e2e --features sdk-tests,plugin-tests,server-protocol,storage-benches,slatedb,root-replay-trace --no-fail-fast
+          cargo test --locked --manifest-path tooling/Cargo.toml --profile test --workspace --exclude lix_e2e --all-features --no-fail-fast
+          cargo test --locked --manifest-path tooling/Cargo.toml --profile test -p lix_e2e --features sdk-tests,plugin-tests,server-protocol,storage-benches,slatedb,root-replay-trace --no-fail-fast
 
       # Examples are compiled by `--all-targets` but never executed, so the SQL
       # strings inside them are never checked. `checkpoints.rs` selected two
@@ -233,7 +234,7 @@ jobs:
 
   js-sdk-test:
     name: JS SDK ${{ matrix.name }} Test
-    if: github.event_name == 'push' || github.event.pull_request.draft == false
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     runs-on: blacksmith-32vcpu-ubuntu-2404
     strategy:
       fail-fast: false

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -7,6 +7,7 @@ on:
       - main
 
 permissions:
+  actions: write
   contents: write
   pull-requests: write
 
@@ -53,6 +54,13 @@ jobs:
 
             Merging this PR updates `CHANGELOG.md`, bumps lockstep package versions,
             and enables the release workflow to create `v${{ steps.prepare.outputs.version }}` and publish packages.
+
+      - name: Run CI for release changes
+        if: steps.prepare.outputs.has_release == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TARGET_BRANCH: release/v${{ steps.prepare.outputs.version }}
+        run: gh workflow run ci.yml --ref "$TARGET_BRANCH"
 
       - name: Close superseded release PRs
         if: steps.prepare.outputs.has_release == 'true'

--- a/scripts/release.mjs
+++ b/scripts/release.mjs
@@ -470,6 +470,20 @@ export function updatePackageVersion(root, version) {
 	}
 }
 
+export function updateCargoLockfiles(root, { runCargo = execFileSync } = {}) {
+	for (const manifestPath of ["Cargo.toml", "tooling/Cargo.toml"]) {
+		if (!existsSync(join(root, manifestPath))) continue;
+		runCargo(
+			"cargo",
+			["update", "--workspace", "--manifest-path", manifestPath],
+			{
+				cwd: root,
+				stdio: "inherit",
+			},
+		);
+	}
+}
+
 export function updateChangelog(root, version, date, changes) {
 	const path = "CHANGELOG.md";
 	const existing = existsSync(join(root, path)) ? readText(root, path).trimEnd() : "# Changelog\n";
@@ -495,10 +509,7 @@ export function prepareRelease(root, { date = new Date().toISOString().slice(0, 
 	for (const change of changes) {
 		rmSync(join(root, change.path));
 	}
-	execFileSync("cargo", ["update", "--workspace"], {
-		cwd: root,
-		stdio: "inherit",
-	});
+	updateCargoLockfiles(root);
 	return { version, type, changes };
 }
 

--- a/scripts/release.test.mjs
+++ b/scripts/release.test.mjs
@@ -9,10 +9,41 @@ import {
 	changelogEntry,
 	loadChanges,
 	updateCargoToml,
+	updateCargoLockfiles,
 	updateChangelog,
 	updatePackageVersion,
 	validateCargoLockstepVersions,
 } from "./release.mjs";
+
+test("updateCargoLockfiles refreshes the root and tooling workspaces", () => {
+	const root = mkdtempSync(join(tmpdir(), "lix-release-test-"));
+	mkdirSync(join(root, "tooling"));
+	writeFileSync(join(root, "Cargo.toml"), "[workspace]\n");
+	writeFileSync(join(root, "tooling", "Cargo.toml"), "[workspace]\n");
+	const calls = [];
+
+	updateCargoLockfiles(root, {
+		runCargo(command, args, options) {
+			calls.push({ command, args, options });
+		},
+	});
+
+	assert.deepEqual(
+		calls.map(({ command, args, options }) => ({ command, args, cwd: options.cwd })),
+		[
+			{
+				command: "cargo",
+				args: ["update", "--workspace", "--manifest-path", "Cargo.toml"],
+				cwd: root,
+			},
+			{
+				command: "cargo",
+				args: ["update", "--workspace", "--manifest-path", "tooling/Cargo.toml"],
+				cwd: root,
+			},
+		],
+	);
+});
 
 test("bumpVersion applies semver changes", () => {
 	assert.equal(bumpVersion("0.6.0", "patch"), "0.6.1");


### PR DESCRIPTION
## Summary

- regenerate both the root and tooling Cargo lockfiles during release preparation
- run every tooling workspace clippy/test command with `--locked`
- explicitly dispatch CI for bot-generated release branches
- cover the two-workspace lockfile update in the release-script tests

## Root cause

The release generator recursively bumped exact path dependencies in `tooling/Cargo.toml`, but ran `cargo update --workspace` only for the root workspace. That left `tooling/Cargo.lock` stale, as seen in release PR https://github.com/opral/lix/pull/1554.

Existing tooling CI commands omitted `--locked`, so Cargo repaired the lockfile only inside the runner instead of reporting the repository drift. Release PRs created with `GITHUB_TOKEN` also did not trigger the normal `pull_request` workflow, leaving #1554 with no checks.

Once merged, the release-PR workflow will regenerate #1554 from main with the tooling lockfile and explicitly start its CI workflow.

## Validation

- `node --test scripts/release.test.mjs` — 13 tests passed
- `node scripts/validate-publish-surface.mjs`
- reproduced the original failure with `cargo check --locked --manifest-path tooling/Cargo.toml -p lix_cli`
- ran `node scripts/prepare-release.mjs` end-to-end in an isolated worktree; the generated release now includes `tooling/Cargo.lock` with all 12 lockstep packages at 0.12.3

No changenote: this changes repository release automation and CI only.