### PR TITLE
fix(js-sdk): recover once from LIX_ERROR_PROTOCOL_SESSION_GONE

### DIFF
--- a/packages/js-sdk/src/remote/client.test.ts
+++ b/packages/js-sdk/src/remote/client.test.ts
@@ -1417,7 +1417,10 @@ test("a second gone protocol session after recovery is not retried", async () =>
 });
 
 test("an active branch read adopts a new session after protocol session gone", async () => {
-	let handshakeCalls = 0;
+	const handshakes: Array<{
+		sessionId: string | null;
+		issuedSessionId?: string;
+	}> = [];
 	const lix = await openLix({
 		server: {
 			mode: "remote",
@@ -1429,14 +1432,20 @@ test("an active branch read adopts a new session after protocol session gone", a
 					return new Response(null, { status: 204 });
 				}
 				if (pathname.endsWith("/lix/v1/")) {
-					handshakeCalls += 1;
 					const presented = request.headers.get("lix-session-id");
-					if (presented !== null) return protocolSessionGone();
+					if (presented !== null) {
+						handshakes.push({ sessionId: presented });
+						return protocolSessionGone();
+					}
+					const issuedSessionId =
+						handshakes.length === 0 ? "session-1" : "session-2";
+					handshakes.push({ sessionId: null, issuedSessionId });
 					return Response.json({
 						protocolVersion: 2,
-						activeBranchId: handshakeCalls === 1 ? "main-id" : "draft-id",
+						activeBranchId:
+							issuedSessionId === "session-1" ? "main-id" : "draft-id",
 						activeAccountId: "00000000-0000-7000-8000-000000000002",
-						sessionId: `session-${handshakeCalls}`,
+						sessionId: issuedSessionId,
 					});
 				}
 				if (pathname.endsWith("/branch/switch")) {
@@ -1453,7 +1462,11 @@ test("an active branch read adopts a new session after protocol session gone", a
 		code: "LIX_SERVER_PROTOCOL_ERROR",
 	});
 	await expect(lix.activeBranchId()).resolves.toBe("draft-id");
-	expect(handshakeCalls).toBe(2);
+	expect(handshakes).toEqual([
+		{ sessionId: null, issuedSessionId: "session-1" },
+		{ sessionId: "session-1" },
+		{ sessionId: null, issuedSessionId: "session-2" },
+	]);
 	await lix.close();
 });
 

--- a/packages/js-sdk/src/remote/client.test.ts
+++ b/packages/js-sdk/src/remote/client.test.ts
@@ -1261,6 +1261,202 @@ test("active branch reads reuse the initial handshake without another GET", asyn
 	await lix.close();
 });
 
+test("execute recovers a gone protocol session once by opening a new handshake", async () => {
+	const requests: Request[] = [];
+	let nextSession = 0;
+	let goneOnce = false;
+	const lix = await openLix({
+		server: {
+			mode: "remote",
+			url: "https://lixray.test/@acme/repository",
+			fetch: async (input, init) => {
+				const request = new Request(input, init);
+				requests.push(request.clone());
+				const pathname = new URL(request.url).pathname;
+				if (pathname.endsWith("/lix/v1/")) {
+					const presented = request.headers.get("lix-session-id");
+					if (presented !== null) {
+						return protocolSessionGone();
+					}
+					nextSession += 1;
+					return Response.json({
+						protocolVersion: 2,
+						activeBranchId: "main-id",
+						activeAccountId: "00000000-0000-7000-8000-000000000002",
+						sessionId: `session-${nextSession}`,
+					});
+				}
+				if (request.method === "DELETE") {
+					return new Response(null, { status: 204 });
+				}
+				if (pathname.endsWith("/execute")) {
+					const sessionId = request.headers.get("lix-session-id");
+					if (sessionId === "session-1" && !goneOnce) {
+						goneOnce = true;
+						return protocolSessionGone();
+					}
+					if (sessionId !== `session-${nextSession}`) {
+						return protocolSessionGone();
+					}
+					return Response.json(emptyExecuteResponse());
+				}
+				throw new Error(`Unexpected request: ${pathname}`);
+			},
+		},
+	});
+
+	await expect(lix.execute("SELECT 1")).resolves.toMatchObject({
+		rowsAffected: 1,
+	});
+	expect(requests.map(describeRemoteRequest)).toEqual([
+		{
+			method: "GET",
+			path: "/@acme/repository/lix/v1/",
+			sessionId: null,
+			activeBranchId: null,
+		},
+		{
+			method: "POST",
+			path: "/@acme/repository/lix/v1/execute",
+			sessionId: "session-1",
+		},
+		{
+			method: "GET",
+			path: "/@acme/repository/lix/v1/",
+			sessionId: null,
+			activeBranchId: "main-id",
+		},
+		{
+			method: "POST",
+			path: "/@acme/repository/lix/v1/execute",
+			sessionId: "session-2",
+		},
+	]);
+	expect(await lix.activeBranchId()).toBe("main-id");
+	await lix.close();
+});
+
+test("execute recovers a closed protocol server once then retries with the new session", async () => {
+	const sessionIds: Array<string | null> = [];
+	let executeCalls = 0;
+	const lix = await openLix({
+		server: {
+			mode: "remote",
+			url: "https://lixray.test/repository",
+			fetch: async (input, init) => {
+				const request = new Request(input, init);
+				const pathname = new URL(request.url).pathname;
+				if (pathname.endsWith("/lix/v1/")) {
+					sessionIds.push(request.headers.get("lix-session-id"));
+					return Response.json({
+						protocolVersion: 2,
+						activeBranchId: "main-id",
+						activeAccountId: "00000000-0000-7000-8000-000000000002",
+						sessionId:
+							request.headers.get("lix-session-id") === null
+								? sessionIds.filter((id) => id === null).length === 1
+									? "session-1"
+									: "session-2"
+								: request.headers.get("lix-session-id"),
+					});
+				}
+				if (request.method === "DELETE") {
+					return new Response(null, { status: 204 });
+				}
+				executeCalls += 1;
+				if (executeCalls === 1) return protocolServerClosed();
+				return Response.json(emptyExecuteResponse());
+			},
+		},
+	});
+
+	await expect(lix.execute("SELECT 1")).resolves.toMatchObject({
+		rowsAffected: 1,
+	});
+	expect(sessionIds).toEqual([null, null]);
+	expect(executeCalls).toBe(2);
+	await lix.close();
+});
+
+test("a second gone protocol session after recovery is not retried", async () => {
+	let handshakeCalls = 0;
+	let executeCalls = 0;
+	const lix = await openLix({
+		server: {
+			mode: "remote",
+			url: "https://lixray.test/repository",
+			fetch: async (input, init) => {
+				const request = new Request(input, init);
+				const pathname = new URL(request.url).pathname;
+				if (pathname.endsWith("/lix/v1/")) {
+					handshakeCalls += 1;
+					expect(request.headers.has("lix-session-id")).toBe(false);
+					return Response.json({
+						protocolVersion: 2,
+						activeBranchId: "main-id",
+						activeAccountId: "00000000-0000-7000-8000-000000000002",
+						sessionId: `session-${handshakeCalls}`,
+					});
+				}
+				if (request.method === "DELETE") {
+					return new Response(null, { status: 204 });
+				}
+				executeCalls += 1;
+				return protocolSessionGone();
+			},
+		},
+	});
+
+	await expect(lix.execute("SELECT 1")).rejects.toMatchObject({
+		code: "LIX_ERROR_PROTOCOL_SESSION_GONE",
+		status: 410,
+	});
+	expect(handshakeCalls).toBe(2);
+	expect(executeCalls).toBe(2);
+	await lix.close();
+});
+
+test("an active branch read adopts a new session after protocol session gone", async () => {
+	let handshakeCalls = 0;
+	const lix = await openLix({
+		server: {
+			mode: "remote",
+			url: "https://lixray.test/@acme/repository",
+			fetch: async (input, init) => {
+				const request = new Request(input, init);
+				const pathname = new URL(request.url).pathname;
+				if (request.method === "DELETE") {
+					return new Response(null, { status: 204 });
+				}
+				if (pathname.endsWith("/lix/v1/")) {
+					handshakeCalls += 1;
+					const presented = request.headers.get("lix-session-id");
+					if (presented !== null) return protocolSessionGone();
+					return Response.json({
+						protocolVersion: 2,
+						activeBranchId: handshakeCalls === 1 ? "main-id" : "draft-id",
+						activeAccountId: "00000000-0000-7000-8000-000000000002",
+						sessionId: `session-${handshakeCalls}`,
+					});
+				}
+				if (pathname.endsWith("/branch/switch")) {
+					return Response.json({ branchId: "malformed-response" });
+				}
+				throw new Error(`Unexpected request: ${pathname}`);
+			},
+		},
+	});
+
+	await expect(
+		lix.switchBranch({ branchId: "draft-id" }),
+	).rejects.toMatchObject({
+		code: "LIX_SERVER_PROTOCOL_ERROR",
+	});
+	await expect(lix.activeBranchId()).resolves.toBe("draft-id");
+	expect(handshakeCalls).toBe(2);
+	await lix.close();
+});
+
 test("an expired session mutation is propagated without a new handshake or retry", async () => {
 	let handshakeCalls = 0;
 	let executeCalls = 0;
@@ -1363,6 +1559,43 @@ function handshakeResponse() {
 		activeAccountId: "00000000-0000-7000-8000-000000000002",
 		sessionId: "session-1",
 	});
+}
+
+function protocolSessionGone() {
+	return Response.json(
+		{
+			error: {
+				code: "LIX_ERROR_PROTOCOL_SESSION_GONE",
+				message:
+					"the Lix protocol session is unknown, expired, or closed; open a new client session",
+			},
+		},
+		{ status: 410 },
+	);
+}
+
+function protocolServerClosed() {
+	return Response.json(
+		{
+			error: {
+				code: "LIX_ERROR_PROTOCOL_SERVER_CLOSED",
+				message: "the Lix protocol server is closing or closed",
+			},
+		},
+		{ status: 503 },
+	);
+}
+
+function describeRemoteRequest(request: Request) {
+	const url = new URL(request.url);
+	return {
+		method: request.method,
+		path: url.pathname,
+		sessionId: request.headers.get("lix-session-id"),
+		...(request.method === "GET"
+			? { activeBranchId: url.searchParams.get("activeBranchId") }
+			: {}),
+	};
 }
 
 function emptyExecuteResponse() {

--- a/packages/js-sdk/src/remote/client.ts
+++ b/packages/js-sdk/src/remote/client.ts
@@ -32,6 +32,7 @@ import {
 	protocolError,
 	record,
 	SERVER_PROTOCOL_PATH,
+	SERVER_PROTOCOL_VERSION,
 	remoteError,
 	type ServerProtocolHandshakeRequest,
 	type ServerProtocolObserveSubscription,
@@ -55,6 +56,8 @@ const REQUEST_BLOB_BASE_MAX_ENTRIES = 8;
 // new base is retained, so repeated large-file edits stay bounded.
 const REQUEST_BLOB_BASE_MAX_BYTES = 16 * 1024 * 1024;
 const REMOTE_BLOB_BASE_MISSING = "LIX_REMOTE_BLOB_BASE_MISSING";
+const PROTOCOL_SESSION_GONE = "LIX_ERROR_PROTOCOL_SESSION_GONE";
+const PROTOCOL_SERVER_CLOSED = "LIX_ERROR_PROTOCOL_SERVER_CLOSED";
 const WIRE_BLOB_JSON_ENVELOPE_BYTES = JSON.stringify({
 	kind: "blob",
 	base64: "",
@@ -87,6 +90,7 @@ class RemoteLixBinding implements LixBinding {
 	#sessionId: string | undefined;
 	#activeBranchId: string | undefined;
 	#activeAccountId: string | undefined;
+	#sessionRecovery: Promise<unknown> | undefined;
 	#requestBlobBaseBytes = 0;
 	#acceptingOperations = true;
 	#operationQueue: Promise<void> = Promise.resolve();
@@ -134,13 +138,8 @@ class RemoteLixBinding implements LixBinding {
 	}
 
 	async open(): Promise<void> {
-		const query = new URLSearchParams();
-		if (this.#initialActiveBranchId !== undefined) {
-			query.set("activeBranchId", this.#initialActiveBranchId);
-		}
-		const path = query.size === 0 ? "" : `?${query}`;
 		const handshake = decodeHandshake(
-			await this.#requestJson(path, { method: "GET" }),
+			await this.#requestJson(this.#handshakePath(), { method: "GET" }),
 		);
 		this.#sessionId = handshake.sessionId;
 		this.#activeBranchId = handshake.activeBranchId;
@@ -536,6 +535,28 @@ class RemoteLixBinding implements LixBinding {
 		responseKind: "json" | "empty" = "json",
 		onRequestAttempt?: () => void,
 	): Promise<unknown> {
+		const deadSessionId = this.#sessionId;
+		try {
+			return await this.#sendJson(path, init, responseKind, onRequestAttempt);
+		} catch (error) {
+			if (
+				!this.#acceptingOperations ||
+				!isRecoverableProtocolSessionLoss(error)
+			) {
+				throw error;
+			}
+			const handshake = await this.#recoverProtocolSession(deadSessionId);
+			if (isHandshakeGet(path, init)) return handshake;
+			return await this.#sendJson(path, init, responseKind, onRequestAttempt);
+		}
+	}
+
+	async #sendJson(
+		path: string,
+		init: RequestInit,
+		responseKind: "json" | "empty" = "json",
+		onRequestAttempt?: () => void,
+	): Promise<unknown> {
 		const headers = new Headers(await resolveHeaders(this.#headers));
 		new Headers(init.headers).forEach((value, name) => headers.set(name, value));
 		if (this.#sessionId === undefined) headers.delete(REMOTE_SESSION_HEADER);
@@ -588,6 +609,33 @@ class RemoteLixBinding implements LixBinding {
 		subscriptions: ServerProtocolObserveSubscription[],
 		signal: AbortSignal,
 	): Promise<Response> {
+		if (this.#sessionRecovery !== undefined) {
+			await this.#sessionRecovery;
+		}
+		const deadSessionId = this.#sessionId;
+		const response = await this.#sendObserveStream(subscriptions, signal);
+		if (response.ok || !this.#acceptingOperations) return response;
+		const error = await peekHttpError(response);
+		if (error === undefined || !isRecoverableProtocolSessionLoss(error)) {
+			return response;
+		}
+		await this.#recoverProtocolSession(deadSessionId);
+		const retry = await this.#sendObserveStream(subscriptions, signal);
+		if (retry.ok) return retry;
+		const retryError = await peekHttpError(retry);
+		if (
+			retryError !== undefined &&
+			isRecoverableProtocolSessionLoss(retryError)
+		) {
+			throw retryError;
+		}
+		return retry;
+	}
+
+	async #sendObserveStream(
+		subscriptions: ServerProtocolObserveSubscription[],
+		signal: AbortSignal,
+	): Promise<Response> {
 		let headers: Headers;
 		try {
 			headers = new Headers(await resolveHeaders(this.#headers));
@@ -630,6 +678,48 @@ class RemoteLixBinding implements LixBinding {
 				{ details: { cause: errorMessage(cause) } },
 			);
 		}
+	}
+
+	#handshakePath(): string {
+		const pinBranch = this.#activeBranchId ?? this.#initialActiveBranchId;
+		if (pinBranch === undefined) return "";
+		const query = new URLSearchParams();
+		query.set("activeBranchId", pinBranch);
+		return `?${query}`;
+	}
+
+	async #recoverProtocolSession(
+		deadSessionId: string | undefined,
+	): Promise<unknown> {
+		if (this.#sessionId !== undefined && this.#sessionId !== deadSessionId) {
+			return this.#currentHandshakeValue();
+		}
+		if (this.#sessionRecovery !== undefined) return this.#sessionRecovery;
+		this.#sessionRecovery = this.#openNewProtocolSession().finally(() => {
+			this.#sessionRecovery = undefined;
+		});
+		return this.#sessionRecovery;
+	}
+
+	async #openNewProtocolSession(): Promise<unknown> {
+		this.#sessionId = undefined;
+		this.#requestBlobBases.clear();
+		this.#requestBlobBaseBytes = 0;
+		const value = await this.#sendJson(this.#handshakePath(), { method: "GET" });
+		const handshake = decodeHandshake(value);
+		this.#sessionId = handshake.sessionId;
+		this.#activeBranchId = handshake.activeBranchId;
+		this.#activeAccountId = handshake.activeAccountId;
+		return value;
+	}
+
+	#currentHandshakeValue(): unknown {
+		return {
+			protocolVersion: SERVER_PROTOCOL_VERSION,
+			activeBranchId: this.#activeBranchId,
+			activeAccountId: this.#activeAccountId,
+			sessionId: this.#sessionId,
+		};
 	}
 
 	async #refreshObservation(
@@ -975,6 +1065,24 @@ function errorCode(error: unknown): string | undefined {
 		: undefined;
 }
 
+function isRecoverableProtocolSessionLoss(error: unknown): boolean {
+	const code = errorCode(error);
+	return code === PROTOCOL_SESSION_GONE || code === PROTOCOL_SERVER_CLOSED;
+}
+
+function isHandshakeGet(path: string, init: RequestInit): boolean {
+	const method = (init.method ?? "GET").toUpperCase();
+	return method === "GET" && (path === "" || path.startsWith("?"));
+}
+
+async function peekHttpError(response: Response): Promise<Error | undefined> {
+	try {
+		return await errorFromHttpResponse(response.clone());
+	} catch {
+		return undefined;
+	}
+}
+
 function copyArrayBuffer(bytes: Uint8Array): ArrayBuffer {
 	const copy = new Uint8Array(bytes.byteLength);
 	copy.set(bytes);
@@ -1195,6 +1303,11 @@ class RemoteObservationHub {
 							);
 						}
 						const error = errorFromResponseBody(payload);
+						if (isRecoverableProtocolSessionLoss(error)) {
+							reconnect = true;
+							controller.abort();
+							return;
+						}
 						const subscriptionId = payload.subscriptionId;
 						if (subscriptionId !== undefined) {
 							if (typeof subscriptionId !== "string") {

--- a/packages/js-sdk/src/remote/observe.test.ts
+++ b/packages/js-sdk/src/remote/observe.test.ts
@@ -588,6 +588,123 @@ test("a local branch switch setup failure preserves a healthy observation", asyn
 	await lix.close();
 });
 
+test("remote observe reconnects after a gone protocol session instead of failing", async () => {
+	const requests: Request[] = [];
+	let nextSession = 0;
+	let observeCalls = 0;
+	const lix = await openLix({
+		server: {
+			mode: "remote",
+			url: "https://lixray.test/@acme/repository",
+			fetch: async (input, init) => {
+				const request = new Request(input, init);
+				requests.push(request.clone());
+				const pathname = new URL(request.url).pathname;
+				if (pathname.endsWith("/lix/v1/")) {
+					if (request.headers.has("lix-session-id")) {
+						return protocolSessionGone();
+					}
+					nextSession += 1;
+					return Response.json({
+						protocolVersion: 2,
+						activeBranchId: "main-id",
+						activeAccountId: "00000000-0000-7000-8000-000000000002",
+						sessionId: `session-${nextSession}`,
+					});
+				}
+				if (request.method === "DELETE") return closedSession();
+				if (pathname.endsWith("/execute")) {
+					return executeValueResponse("recovered");
+				}
+				observeCalls += 1;
+				if (observeCalls === 1) return protocolSessionGone();
+				return heldSseResponse(
+					sseFrame(
+						"next",
+						multiplexObservePayload("observe-1", "stale", 0, 1),
+					),
+					request.signal,
+				);
+			},
+		},
+	});
+
+	const events = lix.observe("SELECT value");
+	expect((await events.next())?.result.rows[0]?.get("value")).toBe(
+		"recovered",
+	);
+	expect(observeCalls).toBe(2);
+	expect(
+		requests
+			.filter((request) => request.method === "GET")
+			.map((request) => ({
+				sessionId: request.headers.get("lix-session-id"),
+				activeBranchId: new URL(request.url).searchParams.get(
+					"activeBranchId",
+				),
+			})),
+	).toEqual([
+		{ sessionId: null, activeBranchId: null },
+		{ sessionId: null, activeBranchId: "main-id" },
+	]);
+	expect(
+		requests
+			.filter((request) =>
+				new URL(request.url).pathname.endsWith("/observe/multiplex"),
+			)
+			.map((request) => request.headers.get("lix-session-id")),
+	).toEqual(["session-1", "session-2"]);
+
+	events.close();
+	await lix.close();
+});
+
+test("remote observe fails if the recovered protocol session is also gone", async () => {
+	vi.useFakeTimers();
+	try {
+		let handshakeCalls = 0;
+		let observeCalls = 0;
+		const lix = await openLix({
+			server: {
+				mode: "remote",
+				url: "https://lixray.test/@acme/repository",
+				fetch: async (input, init) => {
+					const request = new Request(input, init);
+					const pathname = new URL(request.url).pathname;
+					if (pathname.endsWith("/lix/v1/")) {
+						handshakeCalls += 1;
+						expect(request.headers.has("lix-session-id")).toBe(false);
+						return Response.json({
+							protocolVersion: 2,
+							activeBranchId: "main-id",
+							activeAccountId: "00000000-0000-7000-8000-000000000002",
+							sessionId: `session-${handshakeCalls}`,
+						});
+					}
+					if (request.method === "DELETE") return closedSession();
+					observeCalls += 1;
+					return protocolSessionGone();
+				},
+			},
+		});
+
+		const events = lix.observe("SELECT value");
+		await expect(events.next()).rejects.toMatchObject({
+			code: "LIX_ERROR_PROTOCOL_SESSION_GONE",
+			status: 410,
+		});
+		expect(handshakeCalls).toBe(2);
+		expect(observeCalls).toBe(2);
+		await vi.advanceTimersByTimeAsync(10_000);
+		expect(observeCalls).toBe(2);
+
+		events.close();
+		await lix.close();
+	} finally {
+		vi.useRealTimers();
+	}
+});
+
 test("remote observe reconnects retryable failures with fresh headers", async () => {
 	vi.useFakeTimers();
 	try {
@@ -729,6 +846,19 @@ function handshake(): Response {
 		activeAccountId: "00000000-0000-7000-8000-000000000002",
 		sessionId: "session-1",
 	});
+}
+
+function protocolSessionGone(): Response {
+	return Response.json(
+		{
+			error: {
+				code: "LIX_ERROR_PROTOCOL_SESSION_GONE",
+				message:
+					"the Lix protocol session is unknown, expired, or closed; open a new client session",
+			},
+		},
+		{ status: 410 },
+	);
 }
 
 function closedSession(): Response {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Session contract

A Lix Server Protocol session is an **ephemeral in-process capability**, not a user/auth session.

- `GET /lix/v1` with no `Lix-Session-Id` creates a child engine, pins a branch, and issues a token.
- Later execute/observe/file calls must present that token.
- Sessions live in an in-memory HashMap on one protocol server. They are evicted on idle, LRU capacity, or when the host drops the protocol server (worker recycle, idle drop, deploy).
- After eviction, `lease()` returns HTTP 410 `LIX_ERROR_PROTOCOL_SESSION_GONE` (or 503 `LIX_ERROR_PROTOCOL_SERVER_CLOSED` if the server itself is closing).
- Handshake **with** a dead token also 410s. A new session is created only when `GET /lix/v1` **omits** `Lix-Session-Id`.

This is correct server design. Sessions hold live engine children, open transactions, observe streams, and blob caches. They cannot survive process death. This PR does **not** persist sessions on the Rust server and does **not** change idle timeout.

## The flaw

The JS remote client treated that designed, recoverable event as fatal:

- `#requestJson` always attached `#sessionId` and threw on non-OK, with no clear / re-handshake / retry.
- Observe treated only 408/429/5xx as retryable, so 410 failed the stream via `#failStream`.
- `activeBranchId()` / `activeAccountId()` re-GETs with the old token and threw if `handshake.sessionId` changed.

## The fix (JS SDK only)

`RemoteLixBinding` now recovers **once** per failed request, matching the existing `LIX_REMOTE_BLOB_BASE_MISSING` fallback shape:

1. Detect `LIX_ERROR_PROTOCOL_SESSION_GONE` and `LIX_ERROR_PROTOCOL_SERVER_CLOSED`.
2. Clear `#sessionId` and session-scoped blob-base cache.
3. Handshake again: `GET /lix/v1` with **no** `Lix-Session-Id`. If a last-known active branch exists, pin it via `activeBranchId` (same as `open()`).
4. Retry the original request exactly once with the new token. Handshake GETs use the recovery response (the server rejects `activeBranchId` on an existing session).
5. Observe: 410 / `SESSION_GONE` / `SERVER_CLOSED` re-handshakes and reconnects the multiplex stream instead of `#failStream`.
6. A sessionId change after this recovery is adopted, not thrown as "handshake changed sessionId".
7. If the new session also 410s/closes, throw. No loop.
8. Blob-base-missing fallback and header redaction are unchanged. Unrelated 410s (e.g. synthetic `LIX_REMOTE_SESSION_EXPIRED`) stay fatal.

## Tests

- execute 410 `SESSION_GONE` → next `GET /lix/v1` omits the session header and pins the last-known branch → execute retries with the new session and succeeds
- execute 503 `SERVER_CLOSED` recovers once
- a second 410 after recovery still throws (handshake + execute each happen twice)
- observe 410 reconnects after re-handshake instead of failing the subscription
- observe second 410 fails the subscription and does not reconnect in a loop
- `activeBranchId()` adopts a replacement session after `SESSION_GONE` instead of throwing

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-88c6dfd4-3d5a-4b55-b1bb-d69a5bba1765?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-88c6dfd4-3d5a-4b55-b1bb-d69a5bba1765&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

