### PR TITLE
Re-handshake once on SESSION_GONE and SERVER_CLOSED

### DIFF
--- a/packages/js-sdk/src/remote/client.test.ts
+++ b/packages/js-sdk/src/remote/client.test.ts
@@ -1313,6 +1313,51 @@ test("a gone protocol session mutation opens a new handshake and retries", async
 	await lix.close();
 });
 
+test("a closed protocol server opens a new handshake and retries", async () => {
+	let handshakeCalls = 0;
+	let executeCalls = 0;
+	const lix = await openLix({
+		server: {
+			mode: "remote",
+			url: "https://lixray.test/repository",
+			fetch: async (input, init) => {
+				const request = new Request(input, init);
+				const pathname = new URL(request.url).pathname;
+				if (pathname.endsWith("/lix/v1/")) {
+					handshakeCalls += 1;
+					return Response.json({
+						protocolVersion: 2,
+						activeBranchId: "main-id",
+						activeAccountId: "00000000-0000-7000-8000-000000000002",
+						sessionId: `session-${handshakeCalls}`,
+					});
+				}
+				if (request.method === "DELETE") {
+					return new Response(null, { status: 204 });
+				}
+				executeCalls += 1;
+				if (request.headers.get("lix-session-id") === "session-1") {
+					return Response.json(
+						{
+							error: {
+								code: "LIX_ERROR_PROTOCOL_SERVER_CLOSED",
+								message: "the Lix protocol server is closing or closed",
+							},
+						},
+						{ status: 503 },
+					);
+				}
+				return Response.json(emptyExecuteResponse());
+			},
+		},
+	});
+
+	await lix.execute("UPDATE lix_file SET content = $1");
+	expect(handshakeCalls).toBe(2);
+	expect(executeCalls).toBe(2);
+	await lix.close();
+});
+
 test("reopening a gone session restores the pinned active branch", async () => {
 	const handshakeBranches: Array<string | null> = [];
 	let executeCalls = 0;

--- a/packages/js-sdk/src/remote/client.test.ts
+++ b/packages/js-sdk/src/remote/client.test.ts
@@ -1261,9 +1261,163 @@ test("active branch reads reuse the initial handshake without another GET", asyn
 	await lix.close();
 });
 
-test("an expired session mutation is propagated without a new handshake or retry", async () => {
+test("a gone protocol session mutation opens a new handshake and retries", async () => {
 	let handshakeCalls = 0;
 	let executeCalls = 0;
+	const sessionIds: string[] = [];
+	const lix = await openLix({
+		server: {
+			mode: "remote",
+			url: "https://lixray.test/repository",
+			fetch: async (input, init) => {
+				const request = new Request(input, init);
+				const pathname = new URL(request.url).pathname;
+				if (pathname.endsWith("/lix/v1/")) {
+					handshakeCalls += 1;
+					const sessionId = `session-${handshakeCalls}`;
+					sessionIds.push(sessionId);
+					return Response.json({
+						protocolVersion: 2,
+						activeBranchId: "main-id",
+						activeAccountId: "00000000-0000-7000-8000-000000000002",
+						sessionId,
+					});
+				}
+				if (request.method === "DELETE") {
+					expect(request.headers.get("lix-session-id")).toBe("session-2");
+					return new Response(null, { status: 204 });
+				}
+				executeCalls += 1;
+				if (request.headers.get("lix-session-id") === "session-1") {
+					return Response.json(
+						{
+							error: {
+								code: "LIX_ERROR_PROTOCOL_SESSION_GONE",
+								message:
+									"the Lix protocol session is unknown, expired, or closed; open a new client session",
+							},
+						},
+						{ status: 410 },
+					);
+				}
+				return Response.json(emptyExecuteResponse());
+			},
+		},
+	});
+
+	await lix.execute("UPDATE lix_file SET content = $1");
+	expect(handshakeCalls).toBe(2);
+	expect(executeCalls).toBe(2);
+	expect(sessionIds).toEqual(["session-1", "session-2"]);
+	expect(await lix.activeBranchId()).toBe("main-id");
+	await lix.close();
+});
+
+test("reopening a gone session restores the pinned active branch", async () => {
+	const handshakeBranches: Array<string | null> = [];
+	let executeCalls = 0;
+	const lix = await openLix({
+		server: {
+			mode: "remote",
+			url: "https://lixray.test/repository",
+			fetch: async (input, init) => {
+				const request = new Request(input, init);
+				const pathname = new URL(request.url).pathname;
+				if (pathname.endsWith("/lix/v1/")) {
+					const requestedBranch = new URL(request.url).searchParams.get(
+						"activeBranchId",
+					);
+					handshakeBranches.push(requestedBranch);
+					return Response.json({
+						protocolVersion: 2,
+						activeBranchId: requestedBranch ?? "main-id",
+						activeAccountId: "00000000-0000-7000-8000-000000000002",
+						sessionId: `session-${handshakeBranches.length}`,
+					});
+				}
+				if (request.method === "DELETE") {
+					return new Response(null, { status: 204 });
+				}
+				if (pathname.endsWith("/branch/switch")) {
+					return Response.json({ branchId: "draft-id" });
+				}
+				executeCalls += 1;
+				if (request.headers.get("lix-session-id") === "session-1") {
+					return Response.json(
+						{
+							error: {
+								code: "LIX_ERROR_PROTOCOL_SESSION_GONE",
+								message:
+									"the Lix protocol session is unknown, expired, or closed; open a new client session",
+							},
+						},
+						{ status: 410 },
+					);
+				}
+				return Response.json(emptyExecuteResponse());
+			},
+		},
+	});
+
+	await lix.switchBranch({ branchId: "draft-id" });
+	await lix.execute("SELECT 1");
+	expect(handshakeBranches).toEqual([null, "draft-id"]);
+	expect(executeCalls).toBe(2);
+	expect(await lix.activeBranchId()).toBe("draft-id");
+	await lix.close();
+});
+
+test("a gone protocol session that remains gone after reopen is propagated", async () => {
+	let handshakeCalls = 0;
+	let executeCalls = 0;
+	const lix = await openLix({
+		server: {
+			mode: "remote",
+			url: "https://lixray.test/repository",
+			fetch: async (input, init) => {
+				const request = new Request(input, init);
+				const pathname = new URL(request.url).pathname;
+				if (pathname.endsWith("/lix/v1/")) {
+					handshakeCalls += 1;
+					return Response.json({
+						protocolVersion: 2,
+						activeBranchId: "main-id",
+						activeAccountId: "00000000-0000-7000-8000-000000000002",
+						sessionId: `session-${handshakeCalls}`,
+					});
+				}
+				if (request.method === "DELETE") {
+					return new Response(null, { status: 204 });
+				}
+				executeCalls += 1;
+				return Response.json(
+					{
+						error: {
+							code: "LIX_ERROR_PROTOCOL_SESSION_GONE",
+							message:
+								"the Lix protocol session is unknown, expired, or closed; open a new client session",
+						},
+					},
+					{ status: 410 },
+				);
+			},
+		},
+	});
+
+	await expect(
+		lix.execute("UPDATE lix_file SET content = $1"),
+	).rejects.toMatchObject({
+		code: "LIX_ERROR_PROTOCOL_SESSION_GONE",
+		status: 410,
+	});
+	expect(handshakeCalls).toBe(2);
+	expect(executeCalls).toBe(2);
+	await lix.close();
+});
+
+test("a gone protocol session inside a transaction is not retried", async () => {
+	let handshakeCalls = 0;
+	let transactionExecutes = 0;
 	const lix = await openLix({
 		server: {
 			mode: "remote",
@@ -1283,28 +1437,38 @@ test("an expired session mutation is propagated without a new handshake or retry
 				if (request.method === "DELETE") {
 					return new Response(null, { status: 204 });
 				}
-				executeCalls += 1;
-				return Response.json(
-					{
-						error: {
-							code: "LIX_REMOTE_SESSION_EXPIRED",
-							message: "Remote session expired",
+				if (pathname.endsWith("/transaction/begin")) {
+					return Response.json({ transactionId: "transaction-1" });
+				}
+				if (pathname.endsWith("/transaction/rollback")) {
+					return new Response(null, { status: 204 });
+				}
+				if (pathname.endsWith("/transaction/execute")) {
+					transactionExecutes += 1;
+					return Response.json(
+						{
+							error: {
+								code: "LIX_ERROR_PROTOCOL_SESSION_GONE",
+								message:
+									"the Lix protocol session is unknown, expired, or closed; open a new client session",
+							},
 						},
-					},
-					{ status: 410 },
-				);
+						{ status: 410 },
+					);
+				}
+				throw new Error(`unexpected ${request.method} ${pathname}`);
 			},
 		},
 	});
 
-	await expect(
-		lix.execute("UPDATE lix_file SET content = $1"),
-	).rejects.toMatchObject({
-		code: "LIX_REMOTE_SESSION_EXPIRED",
+	const transaction = await lix.beginTransaction();
+	await expect(transaction.execute("SELECT 1")).rejects.toMatchObject({
+		code: "LIX_ERROR_PROTOCOL_SESSION_GONE",
 		status: 410,
 	});
 	expect(handshakeCalls).toBe(1);
-	expect(executeCalls).toBe(1);
+	expect(transactionExecutes).toBe(1);
+	await transaction.rollback();
 	await lix.close();
 });
 

--- a/packages/js-sdk/src/remote/client.ts
+++ b/packages/js-sdk/src/remote/client.ts
@@ -55,6 +55,8 @@ const REQUEST_BLOB_BASE_MAX_ENTRIES = 8;
 // new base is retained, so repeated large-file edits stay bounded.
 const REQUEST_BLOB_BASE_MAX_BYTES = 16 * 1024 * 1024;
 const REMOTE_BLOB_BASE_MISSING = "LIX_REMOTE_BLOB_BASE_MISSING";
+const PROTOCOL_SESSION_GONE_CODE = "LIX_ERROR_PROTOCOL_SESSION_GONE";
+const REMOTE_SESSION_EXPIRED_CODE = "LIX_REMOTE_SESSION_EXPIRED";
 const WIRE_BLOB_JSON_ENVELOPE_BYTES = JSON.stringify({
 	kind: "blob",
 	base64: "",
@@ -91,6 +93,8 @@ class RemoteLixBinding implements LixBinding {
 	#acceptingOperations = true;
 	#operationQueue: Promise<void> = Promise.resolve();
 	#closePromise: Promise<void> | undefined;
+	#reopenPromise: Promise<void> | undefined;
+	#reopening = false;
 
 	constructor(
 		options: RemoteLixServerOptions,
@@ -130,17 +134,15 @@ class RemoteLixBinding implements LixBinding {
 				this.#requestObserveStream(subscriptions, signal),
 			refreshObservation: (subscription) =>
 				this.#refreshObservation(subscription),
+			recoverGoneSession: () => this.#reopenClientSession(),
 		});
 	}
 
 	async open(): Promise<void> {
-		const query = new URLSearchParams();
-		if (this.#initialActiveBranchId !== undefined) {
-			query.set("activeBranchId", this.#initialActiveBranchId);
-		}
-		const path = query.size === 0 ? "" : `?${query}`;
 		const handshake = decodeHandshake(
-			await this.#requestJson(path, { method: "GET" }),
+			await this.#requestJson(this.#handshakePath(this.#initialActiveBranchId), {
+				method: "GET",
+			}),
 		);
 		this.#sessionId = handshake.sessionId;
 		this.#activeBranchId = handshake.activeBranchId;
@@ -536,51 +538,68 @@ class RemoteLixBinding implements LixBinding {
 		responseKind: "json" | "empty" = "json",
 		onRequestAttempt?: () => void,
 	): Promise<unknown> {
-		const headers = new Headers(await resolveHeaders(this.#headers));
-		new Headers(init.headers).forEach((value, name) => headers.set(name, value));
-		if (this.#sessionId === undefined) headers.delete(REMOTE_SESSION_HEADER);
-		else headers.set(REMOTE_SESSION_HEADER, this.#sessionId);
-		headers.set("accept", "application/json");
-		headers.delete("content-encoding");
-		let requestInit = init;
-		if (init.body !== undefined) {
-			headers.set("content-type", "application/json");
-			if (
-				typeof init.body === "string" &&
-				init.body.length >= MIN_COMPRESSIBLE_JSON_BYTES
-			) {
-				const prepared = await prepareJsonRequestBody(init.body);
-				requestInit = { ...init, body: prepared.body };
-				if (prepared.compressed) headers.set("content-encoding", "gzip");
+		let retried = false;
+		for (;;) {
+			const headers = new Headers(await resolveHeaders(this.#headers));
+			new Headers(init.headers).forEach((value, name) =>
+				headers.set(name, value),
+			);
+			if (this.#sessionId === undefined) headers.delete(REMOTE_SESSION_HEADER);
+			else headers.set(REMOTE_SESSION_HEADER, this.#sessionId);
+			headers.set("accept", "application/json");
+			headers.delete("content-encoding");
+			let requestInit = init;
+			if (init.body !== undefined) {
+				headers.set("content-type", "application/json");
+				if (
+					typeof init.body === "string" &&
+					init.body.length >= MIN_COMPRESSIBLE_JSON_BYTES
+				) {
+					const prepared = await prepareJsonRequestBody(init.body);
+					requestInit = { ...init, body: prepared.body };
+					if (prepared.compressed) headers.set("content-encoding", "gzip");
+				}
 			}
-		}
-		let response: Response;
-		const url = new URL(path, this.#baseUrl);
-		const fetchInit = {
-			...requestInit,
-			headers,
-		};
-		// A custom fetch may transmit before throwing, so failures become
-		// ambiguous only once control is handed to it.
-		onRequestAttempt?.();
-		try {
-			response = await this.#fetch(url, fetchInit);
-		} catch (cause) {
-			throw remoteError(
-				"LIX_REMOTE_UNAVAILABLE",
-				"The remote Lix server is unavailable",
-				{ details: { cause: errorMessage(cause) } },
-			);
-		}
-		if (!response.ok) throw await errorFromHttpResponse(response);
-		if (responseKind === "empty" || response.status === 204) return undefined;
-		const text = await response.text();
-		try {
-			return JSON.parse(text);
-		} catch {
-			throw protocolError(
-				`remote response ${response.status} did not contain valid JSON`,
-			);
+			let response: Response;
+			const url = new URL(path, this.#baseUrl);
+			const fetchInit = {
+				...requestInit,
+				headers,
+			};
+			// A custom fetch may transmit before throwing, so failures become
+			// ambiguous only once control is handed to it.
+			onRequestAttempt?.();
+			try {
+				response = await this.#fetch(url, fetchInit);
+			} catch (cause) {
+				throw remoteError(
+					"LIX_REMOTE_UNAVAILABLE",
+					"The remote Lix server is unavailable",
+					{ details: { cause: errorMessage(cause) } },
+				);
+			}
+			if (response.ok) {
+				if (responseKind === "empty" || response.status === 204) {
+					return undefined;
+				}
+				const text = await response.text();
+				try {
+					return JSON.parse(text);
+				} catch {
+					throw protocolError(
+						`remote response ${response.status} did not contain valid JSON`,
+					);
+				}
+			}
+			const error = await errorFromHttpResponse(response);
+			if (
+				retried ||
+				!this.#shouldReopenGoneSession(init, error)
+			) {
+				throw error;
+			}
+			await this.#reopenClientSession();
+			retried = true;
 		}
 	}
 
@@ -718,6 +737,74 @@ class RemoteLixBinding implements LixBinding {
 			}
 			this.#requestBlobBases.set(update.slot, update.base);
 			this.#requestBlobBaseBytes += update.base.bytes.byteLength;
+		}
+	}
+
+	#handshakePath(activeBranchId: string | undefined): string {
+		if (activeBranchId === undefined) return "";
+		const query = new URLSearchParams();
+		query.set("activeBranchId", activeBranchId);
+		return `?${query}`;
+	}
+
+	#canReopenGoneSession(): boolean {
+		return (
+			this.#acceptingOperations &&
+			!this.#reopening &&
+			this.#sessionId !== undefined
+		);
+	}
+
+	#shouldReopenGoneSession(init: RequestInit, error: unknown): boolean {
+		if (!this.#canReopenGoneSession()) return false;
+		if ((init.method ?? "GET").toUpperCase() === "DELETE") return false;
+		if (requestHasTransactionId(init)) return false;
+		return isProtocolSessionGoneError(error);
+	}
+
+	/**
+	 * Protocol sessions are server-owned leases. The server creates one on
+	 * handshake (GET /lix/v1/ without Lix-Session-Id), expires idle unleased
+	 * sessions, evicts idle ones at capacity, and drops the registry on
+	 * runtime recover/restart. The protocol's 410 tells the client to open a
+	 * new session. This is that default path: handshake again, restore the
+	 * pinned branch, restart observations, then retry the failed RPC.
+	 */
+	#reopenClientSession(): Promise<void> {
+		if (this.#reopenPromise !== undefined) return this.#reopenPromise;
+		this.#reopenPromise = this.#reopenClientSessionOnce().finally(() => {
+			this.#reopenPromise = undefined;
+		});
+		return this.#reopenPromise;
+	}
+
+	async #reopenClientSessionOnce(): Promise<void> {
+		this.#assertOpen();
+		this.#reopening = true;
+		const preferredBranchId =
+			this.#activeBranchId ?? this.#initialActiveBranchId;
+		this.#sessionId = undefined;
+		this.#activeAccountId = undefined;
+		try {
+			let handshake;
+			try {
+				handshake = decodeHandshake(
+					await this.#requestJson(this.#handshakePath(preferredBranchId), {
+						method: "GET",
+					}),
+				);
+			} catch (error) {
+				if (preferredBranchId === undefined) throw error;
+				handshake = decodeHandshake(
+					await this.#requestJson("", { method: "GET" }),
+				);
+			}
+			this.#sessionId = handshake.sessionId;
+			this.#activeBranchId = handshake.activeBranchId;
+			this.#activeAccountId = handshake.activeAccountId;
+			this.#observationHub.restart();
+		} finally {
+			this.#reopening = false;
 		}
 	}
 
@@ -998,11 +1085,13 @@ type RemoteObservationHubOptions = {
 	refreshObservation(
 		subscription: ServerProtocolObserveSubscription,
 	): Promise<BindingExecuteResult>;
+	recoverGoneSession(): Promise<void>;
 };
 
 class RemoteObservationHub {
 	readonly #openStream: RemoteObservationHubOptions["openStream"];
 	readonly #refreshObservation: RemoteObservationHubOptions["refreshObservation"];
+	readonly #recoverGoneSession: RemoteObservationHubOptions["recoverGoneSession"];
 	readonly #observations = new Map<string, RemoteObservation>();
 	#nextObservationId = 0;
 	#controller: AbortController | undefined;
@@ -1016,6 +1105,7 @@ class RemoteObservationHub {
 	constructor(options: RemoteObservationHubOptions) {
 		this.#openStream = options.openStream;
 		this.#refreshObservation = options.refreshObservation;
+		this.#recoverGoneSession = options.recoverGoneSession;
 	}
 
 	observe(
@@ -1110,6 +1200,12 @@ class RemoteObservationHub {
 					reconnect = true;
 					return;
 				}
+				if (isProtocolSessionGoneStatus(response.status)) {
+					void response.body?.cancel();
+					await this.#recoverGoneSession();
+					reconnect = true;
+					return;
+				}
 				const error = await errorFromHttpResponse(response);
 				if (this.#isCurrent(generation, controller)) {
 					this.#failStream(error, controller);
@@ -1195,6 +1291,15 @@ class RemoteObservationHub {
 							);
 						}
 						const error = errorFromResponseBody(payload);
+						if (isProtocolSessionGoneError(error)) {
+							await this.#recoverGoneSession();
+							for (const observation of this.#observations.values()) {
+								observation.recover(error);
+							}
+							reconnect = true;
+							controller.abort();
+							return;
+						}
 						const subscriptionId = payload.subscriptionId;
 						if (subscriptionId !== undefined) {
 							if (typeof subscriptionId !== "string") {
@@ -1492,6 +1597,34 @@ function isDefinitiveClientError(error: unknown): boolean {
 
 function isRetryableObserveStatus(status: number): boolean {
 	return status === 408 || status === 429 || status >= 500;
+}
+
+function isProtocolSessionGoneStatus(status: number): boolean {
+	return status === 410;
+}
+
+function isProtocolSessionGoneError(error: unknown): boolean {
+	if (!(error instanceof Error)) return false;
+	const code = errorCode(error);
+	if (
+		code === PROTOCOL_SESSION_GONE_CODE ||
+		code === REMOTE_SESSION_EXPIRED_CODE
+	) {
+		return true;
+	}
+	if (
+		"status" in error &&
+		typeof (error as { status?: unknown }).status === "number" &&
+		isProtocolSessionGoneStatus((error as { status: number }).status)
+	) {
+		return true;
+	}
+	return /open a new client session/i.test(error.message);
+}
+
+function requestHasTransactionId(init: RequestInit): boolean {
+	const value = new Headers(init.headers).get(REMOTE_TRANSACTION_HEADER);
+	return value !== null && value.length > 0;
 }
 
 function isRetryableObserveError(error: unknown): boolean {

--- a/packages/js-sdk/src/remote/client.ts
+++ b/packages/js-sdk/src/remote/client.ts
@@ -56,6 +56,7 @@ const REQUEST_BLOB_BASE_MAX_ENTRIES = 8;
 const REQUEST_BLOB_BASE_MAX_BYTES = 16 * 1024 * 1024;
 const REMOTE_BLOB_BASE_MISSING = "LIX_REMOTE_BLOB_BASE_MISSING";
 const PROTOCOL_SESSION_GONE_CODE = "LIX_ERROR_PROTOCOL_SESSION_GONE";
+const PROTOCOL_SERVER_CLOSED_CODE = "LIX_ERROR_PROTOCOL_SERVER_CLOSED";
 const REMOTE_SESSION_EXPIRED_CODE = "LIX_REMOTE_SESSION_EXPIRED";
 const WIRE_BLOB_JSON_ENVELOPE_BYTES = JSON.stringify({
 	kind: "blob",
@@ -763,12 +764,12 @@ class RemoteLixBinding implements LixBinding {
 	}
 
 	/**
-	 * Protocol sessions are server-owned leases. The server creates one on
-	 * handshake (GET /lix/v1/ without Lix-Session-Id), expires idle unleased
-	 * sessions, evicts idle ones at capacity, and drops the registry on
-	 * runtime recover/restart. The protocol's 410 tells the client to open a
-	 * new session. This is that default path: handshake again, restore the
-	 * pinned branch, restart observations, then retry the failed RPC.
+	 * Protocol sessions are an in-process HashMap on the protocol server.
+	 * They are not durable: idle timeout, capacity eviction, close(), and
+	 * host recover()/recycle wipe the map. 410 SESSION_GONE is a miss;
+	 * 503 SERVER_CLOSED is the same server going away. The contract is
+	 * handshake again (GET /lix/v1/ without Lix-Session-Id), restore the
+	 * pinned branch, restart observations, and retry the failed RPC once.
 	 */
 	#reopenClientSession(): Promise<void> {
 		if (this.#reopenPromise !== undefined) return this.#reopenPromise;
@@ -1195,11 +1196,6 @@ class RemoteObservationHub {
 			streamOpened = true;
 			const initialSubscriptions = new Set(this.#observations.keys());
 			if (!response.ok) {
-				if (isRetryableObserveStatus(response.status)) {
-					void response.body?.cancel();
-					reconnect = true;
-					return;
-				}
 				if (isProtocolSessionGoneStatus(response.status)) {
 					void response.body?.cancel();
 					await this.#recoverGoneSession();
@@ -1207,6 +1203,15 @@ class RemoteObservationHub {
 					return;
 				}
 				const error = await errorFromHttpResponse(response);
+				if (isProtocolSessionGoneError(error)) {
+					await this.#recoverGoneSession();
+					reconnect = true;
+					return;
+				}
+				if (isRetryableObserveStatus(response.status)) {
+					reconnect = true;
+					return;
+				}
 				if (this.#isCurrent(generation, controller)) {
 					this.#failStream(error, controller);
 				}
@@ -1608,6 +1613,7 @@ function isProtocolSessionGoneError(error: unknown): boolean {
 	const code = errorCode(error);
 	if (
 		code === PROTOCOL_SESSION_GONE_CODE ||
+		code === PROTOCOL_SERVER_CLOSED_CODE ||
 		code === REMOTE_SESSION_EXPIRED_CODE
 	) {
 		return true;

--- a/packages/js-sdk/src/remote/observe.test.ts
+++ b/packages/js-sdk/src/remote/observe.test.ts
@@ -1,6 +1,63 @@
 import { expect, test, vi } from "vitest";
 import { openLix } from "../index.js";
 
+test("remote observe reopens a gone protocol session and reconnects", async () => {
+	let handshakeCalls = 0;
+	let observeCalls = 0;
+	const observedSessionIds: Array<string | null> = [];
+	const lix = await openLix({
+		server: {
+			mode: "remote",
+			url: "https://lixray.test/@acme/repository",
+			fetch: async (input, init) => {
+				const request = new Request(input, init);
+				const pathname = new URL(request.url).pathname;
+				if (pathname.endsWith("/lix/v1/")) {
+					handshakeCalls += 1;
+					return Response.json({
+						protocolVersion: 2,
+						activeBranchId: "main-id",
+						activeAccountId: "00000000-0000-7000-8000-000000000002",
+						sessionId: `session-${handshakeCalls}`,
+					});
+				}
+				if (request.method === "DELETE") return closedSession();
+				if (pathname.endsWith("/execute")) {
+					return executeValueResponse("hello");
+				}
+				observeCalls += 1;
+				observedSessionIds.push(request.headers.get("lix-session-id"));
+				if (observeCalls === 1) {
+					return Response.json(
+						{
+							error: {
+								code: "LIX_ERROR_PROTOCOL_SESSION_GONE",
+								message:
+									"the Lix protocol session is unknown, expired, or closed; open a new client session",
+							},
+						},
+						{ status: 410 },
+					);
+				}
+				return sseResponse(
+					sseFrame(
+						"next",
+						multiplexObservePayload("observe-1", "stale", 0, 7),
+					),
+				);
+			},
+		},
+	});
+
+	const events = lix.observe("SELECT $1 AS value", ["hello"]);
+	const initial = await events.next();
+	expect(initial?.result.rows[0]?.get("value")).toBe("hello");
+	expect(handshakeCalls).toBe(2);
+	expect(observedSessionIds).toEqual(["session-1", "session-2"]);
+	events.close();
+	await lix.close();
+});
+
 test("remote observe streams native Lix results", async () => {
 	const requests: Request[] = [];
 	const lix = await openLix({

--- a/packages/js-sdk/src/remote/observe.test.ts
+++ b/packages/js-sdk/src/remote/observe.test.ts
@@ -58,6 +58,59 @@ test("remote observe reopens a gone protocol session and reconnects", async () =
 	await lix.close();
 });
 
+test("remote observe reopens after the protocol server closes", async () => {
+	let handshakeCalls = 0;
+	let observeCalls = 0;
+	const lix = await openLix({
+		server: {
+			mode: "remote",
+			url: "https://lixray.test/@acme/repository",
+			fetch: async (input, init) => {
+				const request = new Request(input, init);
+				const pathname = new URL(request.url).pathname;
+				if (pathname.endsWith("/lix/v1/")) {
+					handshakeCalls += 1;
+					return Response.json({
+						protocolVersion: 2,
+						activeBranchId: "main-id",
+						activeAccountId: "00000000-0000-7000-8000-000000000002",
+						sessionId: `session-${handshakeCalls}`,
+					});
+				}
+				if (request.method === "DELETE") return closedSession();
+				if (pathname.endsWith("/execute")) {
+					return executeValueResponse("hello");
+				}
+				observeCalls += 1;
+				if (observeCalls === 1) {
+					return Response.json(
+						{
+							error: {
+								code: "LIX_ERROR_PROTOCOL_SERVER_CLOSED",
+								message: "the Lix protocol server is closing or closed",
+							},
+						},
+						{ status: 503 },
+					);
+				}
+				return sseResponse(
+					sseFrame(
+						"next",
+						multiplexObservePayload("observe-1", "stale", 0, 7),
+					),
+				);
+			},
+		},
+	});
+
+	const events = lix.observe("SELECT $1 AS value", ["hello"]);
+	const initial = await events.next();
+	expect(initial?.result.rows[0]?.get("value")).toBe("hello");
+	expect(handshakeCalls).toBe(2);
+	events.close();
+	await lix.close();
+});
+
 test("remote observe streams native Lix results", async () => {
 	const requests: Request[] = [];
 	const lix = await openLix({


### PR DESCRIPTION
Protocol sessions are an in-process HashMap. 410 `LIX_ERROR_PROTOCOL_SESSION_GONE` is a miss (unknown / idle-expired / closed id). 503 `LIX_ERROR_PROTOCOL_SERVER_CLOSED` is the same server going away (`close()` / host `recover()`).

The JS remote client now opens a new session by default:

1. `GET /lix/v1/` without `Lix-Session-Id`
2. Restore the pinned branch via `activeBranchId`
3. Restart observations
4. Retry the failed RPC once

Transaction-scoped calls are not retried. Persistent failure after reopen still propagates. Capacity 503 is not treated as session death.

This is the session-death fix. Hosts must not persist the HashMap or remount UI on 410.