### PR TITLE
Prototype repository-owned Cedar file permissions

### DIFF
--- a/.changenotes/cedar-permission-grants.md
+++ b/.changenotes/cedar-permission-grants.md
@@ -1,0 +1,7 @@
+---
+type: minor
+---
+
+Added repository-owned Cedar permissions with a global `lix_permission_grant` sharing model.
+
+Tracked grants now express account, group, or anonymous access to repositories, directories, files, tables, and rows. The grants are shared across every branch and remain extensible through repository-authored Cedar policies.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -95,6 +95,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ar_archive_writer"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73cd58deff2140a0a8eae87e417bd01db68a33e148aa93d1e8cd837e55e312b6"
+dependencies = [
+ "object",
+]
+
+[[package]]
 name = "arbitrary"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -105,6 +114,12 @@ name = "arrayref"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb"
+
+[[package]]
+name = "arrayvec"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
 
 [[package]]
 name = "arrayvec"
@@ -256,7 +271,7 @@ dependencies = [
  "arrow-schema",
  "chrono",
  "half",
- "indexmap",
+ "indexmap 2.14.0",
  "itoa",
  "lexical-core",
  "memchr",
@@ -335,6 +350,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ascii-canvas"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef1e3e699d84ab1b0911a1010c5c106aa34ae89aeac103be5ce0c3859db1e891"
+dependencies = [
+ "term",
+]
+
+[[package]]
 name = "async-channel"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -390,7 +414,7 @@ checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -407,7 +431,7 @@ checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -452,6 +476,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "beef"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a8241f3ebb85c056b509d4327ad0358fbbba6ffb340bf388f26350aeda225b1"
+
+[[package]]
 name = "bigdecimal"
 version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -479,8 +509,23 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex",
- "syn",
+ "syn 2.0.117",
 ]
+
+[[package]]
+name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
 name = "bitflags"
@@ -495,7 +540,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2468ef7d57b3fb7e16b576e8377cdbde2320c60e1491e961d11da40fc4f02a2d"
 dependencies = [
  "arrayref",
- "arrayvec",
+ "arrayvec 0.7.6",
  "cc",
  "cfg-if",
  "constant_time_eq",
@@ -509,6 +554,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "borsh"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a88b7ea17d208c4193f2c1e6de3c35fe71f98c96982d5ced308bdcc749ff6e1f"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+]
+
+[[package]]
+name = "bs58"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf88ba1141d185c399bee5288d850d63b8369520c1eafc32a0430b5b6c287bf4"
+dependencies = [
+ "tinyvec",
 ]
 
 [[package]]
@@ -642,6 +706,92 @@ dependencies = [
 ]
 
 [[package]]
+name = "cedar-policy"
+version = "4.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66528d723936b74550dd541451545b3c669c08256c72bb4f8fb89cfb17179d85"
+dependencies = [
+ "cedar-policy-core",
+ "cedar-policy-formatter",
+ "cedar-policy-validator",
+ "itertools 0.13.0",
+ "lalrpop-util",
+ "lazy_static",
+ "miette",
+ "nonempty",
+ "ref-cast",
+ "semver",
+ "serde",
+ "serde_json",
+ "serde_with",
+ "smol_str",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "cedar-policy-core"
+version = "4.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82426ffab9728d7fffc9eb0b574215c1b3b112b13c9877e63a9322018dc5c847"
+dependencies = [
+ "either",
+ "itertools 0.13.0",
+ "lalrpop",
+ "lalrpop-util",
+ "lazy_static",
+ "miette",
+ "nonempty",
+ "ref-cast",
+ "regex",
+ "rustc_lexer",
+ "serde",
+ "serde_json",
+ "serde_with",
+ "smol_str",
+ "stacker",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "cedar-policy-formatter"
+version = "4.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28c1ddaa5e08e193d42f70dbfd447790c9f0bec24e76f0d3ed0424181f655107"
+dependencies = [
+ "cedar-policy-core",
+ "itertools 0.13.0",
+ "lazy_static",
+ "logos",
+ "miette",
+ "pretty",
+ "regex",
+ "smol_str",
+]
+
+[[package]]
+name = "cedar-policy-validator"
+version = "4.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55ef5924ac6f2d366a0d33a90c06750a19d3fb1ea03dccb53c53c0de304def19"
+dependencies = [
+ "cedar-policy-core",
+ "itertools 0.13.0",
+ "lalrpop",
+ "lalrpop-util",
+ "lazy_static",
+ "miette",
+ "nonempty",
+ "ref-cast",
+ "serde",
+ "serde_json",
+ "serde_with",
+ "smol_str",
+ "stacker",
+ "thiserror 1.0.69",
+ "unicode-security",
+]
+
+[[package]]
 name = "cexpr"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -686,9 +836,9 @@ dependencies = [
 
 [[package]]
 name = "chrono"
-version = "0.4.44"
+version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
+checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
 dependencies = [
  "iana-time-zone",
  "js-sys",
@@ -855,7 +1005,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a65ebfec4fb190b6f90e944a817d60499ee0744e582530e2c9900a22e591d9a"
 dependencies = [
  "unicode-segmentation",
- "unicode-width",
+ "unicode-width 0.2.2",
 ]
 
 [[package]]
@@ -1194,6 +1344,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d765eb1c0bda10d31e0ea185f5ee15da532d60b0912d2bd1441783439e749c5"
 
 [[package]]
+name = "darling"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
+dependencies = [
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "dashmap"
 version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1316,7 +1500,7 @@ dependencies = [
  "chrono",
  "half",
  "hashbrown 0.16.1",
- "indexmap",
+ "indexmap 2.14.0",
  "itertools 0.14.0",
  "libc",
  "log",
@@ -1482,7 +1666,7 @@ dependencies = [
  "datafusion-functions-aggregate-common",
  "datafusion-functions-window-common",
  "datafusion-physical-expr-common",
- "indexmap",
+ "indexmap 2.14.0",
  "itertools 0.14.0",
  "paste",
  "serde_json",
@@ -1497,7 +1681,7 @@ checksum = "7d7c3adf3db8bf61e92eb90cb659c8e8b734593a8f7c8e12a843c7ddba24b87e"
 dependencies = [
  "arrow",
  "datafusion-common",
- "indexmap",
+ "indexmap 2.14.0",
  "itertools 0.14.0",
  "paste",
 ]
@@ -1642,7 +1826,7 @@ checksum = "2e367e6a71051d0ebdd29b2f85d12059b38b1d1f172c6906e80016da662226bd"
 dependencies = [
  "datafusion-doc",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1657,7 +1841,7 @@ dependencies = [
  "datafusion-expr",
  "datafusion-expr-common",
  "datafusion-physical-expr",
- "indexmap",
+ "indexmap 2.14.0",
  "itertools 0.14.0",
  "log",
  "regex",
@@ -1679,11 +1863,11 @@ dependencies = [
  "datafusion-physical-expr-common",
  "half",
  "hashbrown 0.16.1",
- "indexmap",
+ "indexmap 2.14.0",
  "itertools 0.14.0",
  "parking_lot",
  "paste",
- "petgraph",
+ "petgraph 0.8.3",
  "tokio",
 ]
 
@@ -1714,7 +1898,7 @@ dependencies = [
  "datafusion-common",
  "datafusion-expr-common",
  "hashbrown 0.16.1",
- "indexmap",
+ "indexmap 2.14.0",
  "itertools 0.14.0",
  "parking_lot",
 ]
@@ -1760,7 +1944,7 @@ dependencies = [
  "futures",
  "half",
  "hashbrown 0.16.1",
- "indexmap",
+ "indexmap 2.14.0",
  "itertools 0.14.0",
  "log",
  "num-traits",
@@ -1812,7 +1996,7 @@ dependencies = [
  "datafusion-common",
  "datafusion-expr",
  "datafusion-functions-nested",
- "indexmap",
+ "indexmap 2.14.0",
  "log",
  "regex",
  "sqlparser",
@@ -1820,11 +2004,11 @@ dependencies = [
 
 [[package]]
 name = "deranged"
-version = "0.5.5"
+version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ececcb659e7ba858fb4f10388c250a7252eb0a27373f1a72b8748afdd248e587"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
- "powerfmt",
+ "serde_core",
 ]
 
 [[package]]
@@ -1866,7 +2050,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1889,10 +2073,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "either"
-version = "1.15.0"
+name = "dyn-clone"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
+
+[[package]]
+name = "either"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e5e8f6c15a24b9a3ee5efec809ccd006d3b30e8b3bb63c39af737c7f87daa1d"
 
 [[package]]
 name = "embedded-io"
@@ -1905,6 +2095,15 @@ name = "embedded-io"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
+
+[[package]]
+name = "ena"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eabffdaee24bd1bf95c5ef7cec31260444317e72ea56c4c91750e8b7ee58d5f1"
+dependencies = [
+ "log",
+]
 
 [[package]]
 name = "encoding_rs"
@@ -2150,7 +2349,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2255,7 +2454,7 @@ checksum = "0bf7f043f89559805f8c7cacc432749b2fa0d0a0a9ee46ce47164ed5ba7f126c"
 dependencies = [
  "fnv",
  "hashbrown 0.16.1",
- "indexmap",
+ "indexmap 2.14.0",
  "stable_deref_trait",
 ]
 
@@ -2301,6 +2500,12 @@ dependencies = [
  "num-traits",
  "zerocopy",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
@@ -2516,6 +2721,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
 
 [[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
 name = "idna"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2534,6 +2745,17 @@ checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
+]
+
+[[package]]
+name = "indexmap"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
+dependencies = [
+ "autocfg",
+ "hashbrown 0.12.3",
+ "serde",
 ]
 
 [[package]]
@@ -2627,6 +2849,15 @@ dependencies = [
 
 [[package]]
 name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
@@ -2656,10 +2887,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "392c70591e8749fe235ddaf513e6f58b26bce3dcc16524cecc8936f75afa161e"
 dependencies = [
  "jiff-static",
+ "jiff-tzdb-platform",
  "log",
  "portable-atomic",
  "portable-atomic-util",
  "serde_core",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -2670,7 +2903,22 @@ checksum = "47b605b0c050d845fc355bb11eb3f9a8deddc218ea60c76e61aa1f2adfb2c96a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "jiff-tzdb"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "142bd39932ad231f10513df9ab62661fead8719872150b7ad02a2df79f4e141e"
+
+[[package]]
+name = "jiff-tzdb-platform"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "875a5a69ac2bab1a891711cf5eccbec1ce0341ea805560dcd90b7a2e925132e8"
+dependencies = [
+ "jiff-tzdb",
 ]
 
 [[package]]
@@ -2696,6 +2944,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "keccak"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb26cec98cce3a3d96cbb7bced3c4b16e3d13f27ec56dbd62cbc8f39cfb9d653"
+dependencies = [
+ "cpufeatures 0.2.17",
+]
+
+[[package]]
 name = "kqueue"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2713,6 +2970,38 @@ checksum = "07293a4e297ac234359b510362495713f75ea345d5307140414f20c69ffeb087"
 dependencies = [
  "bitflags",
  "libc",
+]
+
+[[package]]
+name = "lalrpop"
+version = "0.22.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba4ebbd48ce411c1d10fb35185f5a51a7bfa3d8b24b4e330d30c9e3a34129501"
+dependencies = [
+ "ascii-canvas",
+ "bit-set",
+ "ena",
+ "itertools 0.14.0",
+ "lalrpop-util",
+ "petgraph 0.7.1",
+ "pico-args",
+ "regex",
+ "regex-syntax",
+ "sha3",
+ "string_cache",
+ "term",
+ "unicode-xid",
+ "walkdir",
+]
+
+[[package]]
+name = "lalrpop-util"
+version = "0.22.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5baa5e9ff84f1aefd264e6869907646538a52147a755d494517a8007fb48733"
+dependencies = [
+ "regex-automata",
+ "rustversion",
 ]
 
 [[package]]
@@ -2882,6 +3171,7 @@ dependencies = [
  "base64",
  "blake3",
  "bytes",
+ "cedar-policy-core",
  "chrono",
  "codspeed-criterion-compat",
  "datafusion",
@@ -3033,6 +3323,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
+name = "logos"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7251356ef8cb7aec833ddf598c6cb24d17b689d20b993f9d11a3d764e34e6458"
+dependencies = [
+ "logos-derive",
+]
+
+[[package]]
+name = "logos-codegen"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59f80069600c0d66734f5ff52cc42f2dabd6b29d205f333d61fd7832e9e9963f"
+dependencies = [
+ "beef",
+ "fnv",
+ "lazy_static",
+ "proc-macro2",
+ "quote",
+ "regex-syntax",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "logos-derive"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24fb722b06a9dc12adb0963ed585f19fc61dc5413e6a9be9422ef92c091e731d"
+dependencies = [
+ "logos-codegen",
+]
+
+[[package]]
 name = "loom"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3080,7 +3403,7 @@ checksum = "59a9dbbfc75d2688ed057456ce8a3ee3f48d12eec09229f560f3643b9f275653"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3111,6 +3434,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ad38eb12aea514a0466ea40a80fd8cc83637065948eb4a426e4aa46261175227"
 dependencies = [
  "rustix",
+]
+
+[[package]]
+name = "miette"
+version = "7.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f98efec8807c63c752b5bd61f862c165c115b0a35685bdcfd9238c7aeb592b7"
+dependencies = [
+ "cfg-if",
+ "miette-derive",
+ "serde",
+ "unicode-width 0.1.14",
+]
+
+[[package]]
+name = "miette-derive"
+version = "7.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db5b29714e950dbb20d5e6f74f9dcec4edbcc1067bb7f8ed198c097b8c1a818b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3199,7 +3545,7 @@ checksum = "ff6dea70dccfc68fd441c128bdaf31c454542676f750f095465640367fd94118"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3236,7 +3582,7 @@ dependencies = [
  "napi-derive-backend",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3249,7 +3595,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "semver",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3260,6 +3606,12 @@ checksum = "8eb602b84d7c1edae45e50bbf1374696548f36ae179dfa667f577e384bb90c2b"
 dependencies = [
  "libloading 0.9.0",
 ]
+
+[[package]]
+name = "new_debug_unreachable"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
 
 [[package]]
 name = "nix"
@@ -3288,6 +3640,12 @@ dependencies = [
  "memchr",
  "minimal-lexical",
 ]
+
+[[package]]
+name = "nonempty"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "303e8749c804ccd6ca3b428de7fe0d86cb86bc7606bc15291f100fd487960bb8"
 
 [[package]]
 name = "notify"
@@ -3368,9 +3726,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.2.0"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf97ec579c3c42f953ef76dbf8d55ac91fb219dde70e49aa4a6b7d74e9919050"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
 
 [[package]]
 name = "num-integer"
@@ -3418,7 +3776,7 @@ checksum = "2e5a6c098c7a3b6547378093f5cc30bc54fd361ce711e05293a5cc589562739b"
 dependencies = [
  "crc32fast",
  "hashbrown 0.17.1",
- "indexmap",
+ "indexmap 2.14.0",
  "memchr",
 ]
 
@@ -3509,7 +3867,7 @@ dependencies = [
  "proc-macro2",
  "proc-macro2-diagnostics",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3567,7 +3925,7 @@ dependencies = [
  "proc-macro2",
  "proc-macro2-diagnostics",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3578,13 +3936,23 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "petgraph"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3672b37090dbd86368a4145bc067582552b29c27377cad4e0a306c97f9bd7772"
+dependencies = [
+ "fixedbitset",
+ "indexmap 2.14.0",
+]
+
+[[package]]
+name = "petgraph"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8701b58ea97060d5e5b155d383a69952a60943f0e6dfe30b04c287beb0b27455"
 dependencies = [
  "fixedbitset",
  "hashbrown 0.15.5",
- "indexmap",
+ "indexmap 2.14.0",
  "serde",
 ]
 
@@ -3594,7 +3962,16 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "913273894cec178f401a31ec4b656318d95473527be05c0752cc41cdc32be8b7"
 dependencies = [
- "phf_shared",
+ "phf_shared 0.12.1",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
+dependencies = [
+ "siphasher",
 ]
 
 [[package]]
@@ -3605,6 +3982,12 @@ checksum = "06005508882fb681fd97892ecff4b7fd0fee13ef1aa569f8695dae7ab9099981"
 dependencies = [
  "siphasher",
 ]
+
+[[package]]
+name = "pico-args"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5be167a7af36ee22fe3115051bc51f6e6c7054c9348e28deb4f49bd6f705a315"
 
 [[package]]
 name = "pin-project-lite"
@@ -3650,6 +4033,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
 dependencies = [
  "plotters-backend",
+]
+
+[[package]]
+name = "plugin_cedar"
+version = "0.12.3"
+dependencies = [
+ "cedar-policy",
+ "lix",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -3765,13 +4158,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "precomputed-hash"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
+
+[[package]]
+name = "pretty"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d22152487193190344590e4f30e219cf3fe140d9e7a3fdb683d82aa2c5f4156"
+dependencies = [
+ "arrayvec 0.5.2",
+ "typed-arena",
+ "unicode-width 0.2.2",
+]
+
+[[package]]
 name = "prettyplease"
 version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3791,9 +4201,19 @@ checksum = "af066a9c399a26e020ada66a034357a868728e72cd426f3adcd35f80d88d88c8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "version_check",
  "yansi",
+]
+
+[[package]]
+name = "psm"
+version = "0.1.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4dcd034599e63b970727f70d79e02d62390a4a84f7c6b827c27c46d5ac3fa622"
+dependencies = [
+ "ar_archive_writer",
+ "cc",
 ]
 
 [[package]]
@@ -3816,7 +4236,7 @@ checksum = "53009b033747e0d79a76549a744da58e84c9da8076492c7e6d491fdc6cc41b95"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3936,6 +4356,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "ref-cast"
+version = "1.0.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "216e8f773d7923bcba9ceb86a86c93cabb3903a11872fc3f138c49630e50b96d"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c9283685feec7d69af75fb0e858d5e7378f33fe4fc699383b2916ab9273e03c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
+]
+
+[[package]]
 name = "regalloc2"
 version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3951,9 +4391,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.12.3"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+checksum = "f020237b6c8eed93db2e2cb53c00c60a8e1bc73da7d073199a1180401450218d"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -3963,9 +4403,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.14"
+version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+checksum = "ad8553b9b26413251cbf30e620595c7a41b3887f03da04579c0e6b0d6a06b4b2"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -3974,9 +4414,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.9"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a96887878f22d7bad8a3b6dc5b7440e0ada9a245242924394987b21cf2210a4c"
+checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "rocksdb"
@@ -3994,7 +4434,7 @@ version = "1.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be2a24f50780bc85f09cc6ac299bdf1424302742d77221106859c9d8b102126a"
 dependencies = [
- "arrayvec",
+ "arrayvec 0.7.6",
  "num-traits",
 ]
 
@@ -4009,6 +4449,15 @@ name = "rustc-hash"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
+
+[[package]]
+name = "rustc_lexer"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c86aae0c77166108c01305ee1a36a1e77289d7dc6ca0a3cd91ff4992de2d16a5"
+dependencies = [
+ "unicode-xid",
+]
 
 [[package]]
 name = "rustc_version"
@@ -4070,6 +4519,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "schemars"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cd191f9397d57d581cddd31014772520aa448f65ef991055d7f61582c65165f"
+dependencies = [
+ "dyn-clone",
+ "ref-cast",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "687274d293b6cdc6e73e0fee520bf2049650090d7164f87672d212a3c530cf4a"
+dependencies = [
+ "dyn-clone",
+ "ref-cast",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "scoped-tls"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4083,9 +4556,9 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "semver"
-version = "1.0.27"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 dependencies = [
  "serde",
  "serde_core",
@@ -4139,7 +4612,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4148,6 +4621,7 @@ version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
 dependencies = [
+ "indexmap 2.14.0",
  "itoa",
  "memchr",
  "serde",
@@ -4186,12 +4660,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_with"
+version = "3.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee78f1fbe43ac4a0e47aadb3dbd357b69eb0d3793e948624cd03dd2750ab1c0a"
+dependencies = [
+ "base64",
+ "bs58",
+ "chrono",
+ "hex",
+ "indexmap 1.9.3",
+ "indexmap 2.14.0",
+ "jiff",
+ "schemars 0.9.0",
+ "schemars 1.2.2",
+ "serde_core",
+ "serde_json",
+ "serde_with_macros",
+ "time",
+]
+
+[[package]]
+name = "serde_with_macros"
+version = "3.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8705578779c2b6bd90d84d66eb2e206b708b1a4d7b9f17641b293545bf1c7e46"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "serde_yaml"
 version = "0.9.34+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
 dependencies = [
- "indexmap",
+ "indexmap 2.14.0",
  "itoa",
  "ryu",
  "serde",
@@ -4213,6 +4720,16 @@ dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
  "digest",
+]
+
+[[package]]
+name = "sha3"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77fd7028345d415a4034cf8777cd4f8ab1851274233b45f84e3d955502d93874"
+dependencies = [
+ "digest",
+ "keccak",
 ]
 
 [[package]]
@@ -4353,6 +4870,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "smol_str"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4aaa7368fcf4852a4c2dd92df0cace6a71f2091ca0a23391ce7f3a31833f1523"
+dependencies = [
+ "borsh",
+ "serde_core",
+]
+
+[[package]]
 name = "socket2"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4380,7 +4907,7 @@ checksum = "a6dd45d8fc1c79299bfbb7190e42ccbbdf6a5f52e4a6ad98d92357ea965bd289"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4388,6 +4915,19 @@ name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
+name = "stacker"
+version = "0.1.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "707f49d46706bacf8a2b00d51dace3f9de527c13eec3778f570c411f89e69967"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "libc",
+ "psm",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "static_assertions"
@@ -4406,10 +4946,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "string_cache"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf776ba3fa74f83bf4b63c3dcbbf82173db2632ed8452cb2d891d33f459de70f"
+dependencies = [
+ "new_debug_unreachable",
+ "parking_lot",
+ "phf_shared 0.11.3",
+ "precomputed-hash",
+]
+
+[[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
 name = "syn"
 version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4424,7 +4993,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4467,6 +5036,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "term"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8c27177b12a6399ffc08b98f76f7c9a1f4fe9fc967c784c5a071fa8d93cf7e1"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "termcolor"
 version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4501,7 +5079,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4512,7 +5090,7 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4526,21 +5104,33 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.46"
+version = "0.3.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9da98b7d9b7dad93488a84b8248efc35352b0b2657397d4167e7ad67e5d535e5"
+checksum = "cdb87b95ec50ddfa440816d227a17b2ccbdda963a316a727fda0fc4334f7d134"
 dependencies = [
  "deranged",
  "num-conv",
  "powerfmt",
+ "serde_core",
  "time-core",
+ "time-macros",
 ]
 
 [[package]]
 name = "time-core"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
+
+[[package]]
+name = "time-macros"
+version = "0.2.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e689342a48d2ea927c87ea50cabf8594854bf940e9310208848d680d668ed85"
+dependencies = [
+ "num-conv",
+ "time-core",
+]
 
 [[package]]
 name = "tiny-keccak"
@@ -4572,6 +5162,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinyvec"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb4ebadaa0af04fab11ae01eb5f9fdb5f9c5b875506e210e71c07873528baa7f"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
 name = "tokio"
 version = "1.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4595,7 +5200,7 @@ checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4643,7 +5248,7 @@ version = "0.9.12+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf92845e79fc2e2def6a5d828f0801e29a2f8acc037becc5ab08595c7d5e9863"
 dependencies = [
- "indexmap",
+ "indexmap 2.14.0",
  "serde_core",
  "serde_spanned 1.1.1",
  "toml_datetime 0.7.5+spec-1.1.0",
@@ -4676,7 +5281,7 @@ version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
 dependencies = [
- "indexmap",
+ "indexmap 2.14.0",
  "serde",
  "serde_spanned 0.6.9",
  "toml_datetime 0.6.11",
@@ -4725,7 +5330,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4774,6 +5379,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ea3136b675547379c4bd395ca6b938e5ad3c3d20fad76e7fe85f9e0d011419c"
 
 [[package]]
+name = "typed-arena"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6af6ae20167a9ece4bcb41af5b80f8a1f1df981f6391189ce00fd257af04126a"
+
+[[package]]
 name = "typed-path"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4812,10 +5423,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
 
 [[package]]
+name = "unicode-normalization"
+version = "0.1.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fd4f6878c9cb28d874b009da9e8d183b5abc80117c40bbd187a1fde336be6e8"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
+name = "unicode-script"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "383ad40bb927465ec0ce7720e033cb4ca06912855fc35db31b5755d0de75b1ee"
+
+[[package]]
+name = "unicode-security"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e4ddba1535dd35ed8b61c52166b7155d7f4e4b8847cec6f48e71dc66d8b5e50"
+dependencies = [
+ "unicode-normalization",
+ "unicode-script",
+]
+
+[[package]]
 name = "unicode-segmentation"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
+
+[[package]]
+name = "unicode-width"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 
 [[package]]
 name = "unicode-width"
@@ -4961,7 +5603,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "wasm-bindgen-shared",
 ]
 
@@ -5011,7 +5653,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
 dependencies = [
  "anyhow",
- "indexmap",
+ "indexmap 2.14.0",
  "wasm-encoder 0.244.0",
  "wasmparser 0.244.0",
 ]
@@ -5023,7 +5665,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "665fe59e56cc9b419ca6fcca56673e3421d1a5011e3b65caf6b726fd9e041d10"
 dependencies = [
  "anyhow",
- "indexmap",
+ "indexmap 2.14.0",
  "wasm-encoder 0.247.0",
  "wasmparser 0.247.0",
 ]
@@ -5036,7 +5678,7 @@ checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
  "bitflags",
  "hashbrown 0.15.5",
- "indexmap",
+ "indexmap 2.14.0",
  "semver",
 ]
 
@@ -5048,7 +5690,7 @@ checksum = "8e6fb4c2bee46c5ea4d40f8cdb5c131725cd976718ec56f1c8e82fbde5fa2a80"
 dependencies = [
  "bitflags",
  "hashbrown 0.17.1",
- "indexmap",
+ "indexmap 2.14.0",
  "semver",
  "serde",
 ]
@@ -5061,7 +5703,7 @@ checksum = "aa4439c5eee9df71ee0c6efb37f63b1fcb1fec38f85f5142c54e7ed05d33091a"
 dependencies = [
  "bitflags",
  "hashbrown 0.17.1",
- "indexmap",
+ "indexmap 2.14.0",
  "semver",
  "serde",
 ]
@@ -5133,7 +5775,7 @@ dependencies = [
  "cranelift-entity",
  "gimli",
  "hashbrown 0.17.1",
- "indexmap",
+ "indexmap 2.14.0",
  "log",
  "object",
  "postcard",
@@ -5180,7 +5822,7 @@ dependencies = [
  "anyhow",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "wasmtime-internal-component-util",
  "wasmtime-internal-wit-bindgen",
  "wit-parser 0.248.0",
@@ -5288,7 +5930,7 @@ checksum = "2c660c5b091648cffdd84a34dc24ffcdb9d027f9048fe7bd5e01896adbd0935f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5317,7 +5959,7 @@ dependencies = [
  "anyhow",
  "bitflags",
  "heck 0.5.0",
- "indexmap",
+ "indexmap 2.14.0",
  "wit-parser 0.248.0",
 ]
 
@@ -5500,7 +6142,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5511,7 +6153,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5820,9 +6462,9 @@ checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
 dependencies = [
  "anyhow",
  "heck 0.5.0",
- "indexmap",
+ "indexmap 2.14.0",
  "prettyplease",
- "syn",
+ "syn 2.0.117",
  "wasm-metadata 0.244.0",
  "wit-bindgen-core 0.51.0",
  "wit-component 0.244.0",
@@ -5836,9 +6478,9 @@ checksum = "b5007dae772945b7a5003d69d90a3a4a78929d41f19d004e980c4259a6af4484"
 dependencies = [
  "anyhow",
  "heck 0.5.0",
- "indexmap",
+ "indexmap 2.14.0",
  "prettyplease",
- "syn",
+ "syn 2.0.117",
  "wasm-metadata 0.247.0",
  "wit-bindgen-core 0.57.1",
  "wit-component 0.247.0",
@@ -5854,7 +6496,7 @@ dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "wit-bindgen-core 0.51.0",
  "wit-bindgen-rust 0.51.0",
 ]
@@ -5870,7 +6512,7 @@ dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "wit-bindgen-core 0.57.1",
  "wit-bindgen-rust 0.57.1",
 ]
@@ -5883,7 +6525,7 @@ checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
  "bitflags",
- "indexmap",
+ "indexmap 2.14.0",
  "log",
  "serde",
  "serde_derive",
@@ -5902,7 +6544,7 @@ checksum = "9d567162a6b9843080e5e0053f696623ff694bae8ae017c9ec536d1873bbe3d8"
 dependencies = [
  "anyhow",
  "bitflags",
- "indexmap",
+ "indexmap 2.14.0",
  "log",
  "serde",
  "serde_derive",
@@ -5921,7 +6563,7 @@ checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
 dependencies = [
  "anyhow",
  "id-arena",
- "indexmap",
+ "indexmap 2.14.0",
  "log",
  "semver",
  "serde",
@@ -5940,7 +6582,7 @@ dependencies = [
  "anyhow",
  "hashbrown 0.17.1",
  "id-arena",
- "indexmap",
+ "indexmap 2.14.0",
  "log",
  "semver",
  "serde",
@@ -5959,7 +6601,7 @@ dependencies = [
  "anyhow",
  "hashbrown 0.17.1",
  "id-arena",
- "indexmap",
+ "indexmap 2.14.0",
  "log",
  "semver",
  "serde",
@@ -6006,7 +6648,7 @@ checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "synstructure",
 ]
 
@@ -6027,7 +6669,7 @@ checksum = "1328722bbf2115db7e19d69ebcc15e795719e2d66b60827c6a69a117365e37a0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -6047,7 +6689,7 @@ checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "synstructure",
 ]
 
@@ -6081,7 +6723,7 @@ checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -6092,7 +6734,7 @@ checksum = "2d04a6b5381502aa6087c94c669499eb1602eb9c5e8198e534de571f7154809b"
 dependencies = [
  "crc32fast",
  "flate2",
- "indexmap",
+ "indexmap 2.14.0",
  "memchr",
  "typed-path",
 ]

--- a/packages/js-sdk/scripts/build-bundled-plugins.js
+++ b/packages/js-sdk/scripts/build-bundled-plugins.js
@@ -67,6 +67,8 @@ const cargoArgs = [
 	"--manifest-path",
 	join(repoRoot, "Cargo.toml"),
 	"-p",
+	"plugin_cedar",
+	"-p",
 	"plugin_csv",
 	"-p",
 	"plugin_markdown",
@@ -77,6 +79,23 @@ cargoArgs.push("--profile", profile);
 await run("cargo", cargoArgs);
 
 await mkdir(outDir, { recursive: true });
+await writeBundledPlugin({
+	crateName: "plugin_cedar",
+	fileName: "plugin_cedar.lixplugin",
+	files: [
+		["manifest.json", join(repoRoot, "plugins", "cedar", "manifest.json")],
+		[
+			"schema/cedar_permission_source.json",
+			join(
+				repoRoot,
+				"plugins",
+				"cedar",
+				"schema",
+				"cedar_permission_source.json",
+			),
+		],
+	],
+});
 await writeBundledPlugin({
 	crateName: "plugin_csv",
 	fileName: "plugin_csv.lixplugin",

--- a/packages/js-sdk/src/bundled-plugins.ts
+++ b/packages/js-sdk/src/bundled-plugins.ts
@@ -6,6 +6,10 @@ export type BundledPluginArchive = {
 
 const BUNDLED_PLUGIN_MANIFEST = [
 	{
+		key: "plugin_cedar",
+		fileName: "plugin_cedar.lixplugin",
+	},
+	{
 		key: "plugin_markdown",
 		fileName: "plugin_markdown.lixplugin",
 	},

--- a/packages/js-sdk/src/open-lix.test.ts
+++ b/packages/js-sdk/src/open-lix.test.ts
@@ -981,16 +981,71 @@ test("SQL plugin archive upsert installs bundled plugin archive schemas", async 
 	const schemas = await lix.execute(
 		"SELECT table_name \
 		 FROM information_schema.tables \
-		 WHERE table_name IN ($1, $2, $3) \
+		 WHERE table_name IN ($1, $2, $3, $4) \
 		 ORDER BY table_name",
-		["csv_row", "csv_table", "markdown_node"],
+		[
+			"cedar_permission_source",
+			"csv_row",
+			"csv_table",
+			"markdown_node",
+		],
 	);
 	expect(schemas.rows.map((row) => row.get("table_name"))).toEqual([
+		"cedar_permission_source",
 		"csv_row",
 		"csv_table",
 		"markdown_node",
 	]);
 
+	await lix.close();
+});
+
+test("bundled Cedar plugin projects canonical files into read-only rows", async () => {
+	const lix = await openLix();
+	const cedar = (await bundledPluginArchives()).find(
+		(plugin) => plugin.key === "plugin_cedar",
+	);
+	if (!cedar) throw new Error("expected bundled Cedar plugin");
+	await upsertPluginArchive(lix, cedar.key, cedar.archiveBytes);
+
+	const encoder = new TextEncoder();
+	await writeFile(
+		lix,
+		"/.lix/permissions/schema.cedarschema",
+		encoder.encode(
+			'entity Account; entity File; action "view" appliesTo { principal: Account, resource: File };',
+		),
+	);
+	await writeFile(
+		lix,
+		"/.lix/permissions/publications.cedar",
+		encoder.encode(""),
+	);
+	await writeFile(
+		lix,
+		"/.lix/permissions/entities.cedar.json",
+		encoder.encode("[]"),
+	);
+
+	const projected = await lix.execute(
+		"SELECT kind, path, source FROM cedar_permission_source ORDER BY path",
+	);
+	expect(projected.rows.map((row) => row.get("kind"))).toEqual([
+		"entities",
+		"policy",
+		"schema",
+	]);
+	expect(projected.rows.map((row) => row.get("path"))).toEqual([
+		"/.lix/permissions/entities.cedar.json",
+		"/.lix/permissions/publications.cedar",
+		"/.lix/permissions/schema.cedarschema",
+	]);
+
+	await expect(
+		lix.execute(
+			"UPDATE cedar_permission_source SET source = '' WHERE kind = 'schema'",
+		),
+	).rejects.toThrow(/read-only/i);
 	await lix.close();
 });
 

--- a/packages/lix-schema/fixtures/current/lix_permission_grant.json
+++ b/packages/lix-schema/fixtures/current/lix_permission_grant.json
@@ -1,0 +1,63 @@
+{
+  "$schema": "https://lix.dev/schema-v1.json",
+  "key": "lix_permission_grant",
+  "columns": [
+    {
+      "name": "id",
+      "type": "uuid",
+      "nullable": false,
+      "default_expression": "uuidv7()"
+    },
+    {
+      "name": "principal_type",
+      "type": "text",
+      "nullable": false,
+      "description": "The kind of principal receiving access: account, group, or anonymous."
+    },
+    {
+      "name": "principal_id",
+      "type": "text",
+      "nullable": true,
+      "description": "The account or group identifier. Null only for the anonymous principal."
+    },
+    {
+      "name": "access_level",
+      "type": "text",
+      "nullable": false,
+      "description": "The standard access level: viewer, commenter, contributor, editor, or manager."
+    },
+    {
+      "name": "resource_type",
+      "type": "text",
+      "nullable": false,
+      "description": "The resource scope: repository, directory, file, table, or row."
+    },
+    {
+      "name": "directory_id",
+      "type": "uuid",
+      "nullable": true,
+      "description": "The stable directory identifier for a directory grant."
+    },
+    {
+      "name": "file_id",
+      "type": "uuid",
+      "nullable": true,
+      "description": "The stable file identifier for file, table, and row grants."
+    },
+    {
+      "name": "schema_key",
+      "type": "text",
+      "nullable": true,
+      "description": "The schema key for table and row grants."
+    },
+    {
+      "name": "row_pk",
+      "type": "jsonb",
+      "nullable": true,
+      "description": "The canonical primary-key tuple for a row grant."
+    }
+  ],
+  "primary_key": [
+    "id"
+  ]
+}

--- a/packages/lix-schema/tests/schema_v1.rs
+++ b/packages/lix-schema/tests/schema_v1.rs
@@ -82,5 +82,5 @@ fn official_migrations_all_validate() {
         from_json(&input).unwrap();
         count += 1;
     }
-    assert_eq!(count, 24);
+    assert_eq!(count, 25);
 }

--- a/packages/lix/Cargo.toml
+++ b/packages/lix/Cargo.toml
@@ -153,6 +153,7 @@ futures-lite = "2"
 tokio = { version = "1", features = ["rt", "sync"] }
 tracing = "0.1"
 blake3 = "1"
+cedar-policy-core = { version = "=4.2.2", default-features = false }
 fastcdc = "3"
 xxhash-rust = { version = "0.8", features = ["xxh3"] }
 base64 = "0.22"

--- a/packages/lix/src/authorization.rs
+++ b/packages/lix/src/authorization.rs
@@ -1,0 +1,193 @@
+//! Repository-owned Cedar policy evaluation.
+//!
+//! The canonical inputs are ordinary files under `/.lix/permissions`. This
+//! module deliberately contains no host or Lixray policy: it only maps Lix's
+//! stable principal/action/resource request into Cedar and evaluates the
+//! repository's policy set.
+
+use cedar_policy_core::{
+    ast::{Context, EntityUID, EntityUIDEntry, Request},
+    authorizer::{Authorizer, Decision},
+    entities::{Entities, EntityJsonParser, NoEntitiesSchema, TCComputation},
+    extensions::Extensions,
+    parser,
+};
+
+use crate::LixError;
+
+pub(crate) const PERMISSIONS_DIRECTORY: &str = "/.lix/permissions/";
+pub(crate) const SCHEMA_PATH: &str = "/.lix/permissions/schema.cedarschema";
+pub(crate) const ENTITIES_PATH: &str = "/.lix/permissions/entities.cedar.json";
+
+/// Result of repository authorization. Repositories without a Cedar schema
+/// are inactive so existing repositories retain their pre-prototype behavior.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum AuthorizationDecision {
+    Inactive,
+    Allow,
+    Deny,
+}
+
+#[derive(Debug)]
+pub(crate) struct AuthorizationDocuments<'a> {
+    pub schema: &'a str,
+    pub policies: &'a str,
+    pub entities: Option<&'a str>,
+}
+
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct AuthorizationRequest<'a> {
+    pub principal_id: &'a str,
+    pub action: &'a str,
+    pub resource_type: &'a str,
+    pub resource_id: &'a str,
+}
+
+pub(crate) fn authorize(
+    documents: AuthorizationDocuments<'_>,
+    input: AuthorizationRequest<'_>,
+) -> Result<AuthorizationDecision, LixError> {
+    // The schema file is the activation marker and is validated by the Cedar
+    // projection plugin. Core intentionally links only the Cedar evaluator:
+    // the full validator enables `serde_json/preserve_order` transitively and
+    // changes Lix's canonical JSON representation through feature unification.
+    let _schema = documents.schema;
+    let policies = parser::parse_policyset(documents.policies)
+        .map_err(|error| invalid_policy("policies", error))?;
+
+    let entities = match documents.entities {
+        Some(source) => EntityJsonParser::new(
+            None::<&NoEntitiesSchema>,
+            Extensions::all_available(),
+            TCComputation::ComputeNow,
+        )
+        .from_json_str(source)
+        .map_err(|error| invalid_policy("entities", error))?,
+        None => Entities::new(),
+    };
+    let request = Request::new_unchecked(
+        EntityUIDEntry::known(entity_uid("Account", input.principal_id)?, None),
+        EntityUIDEntry::known(entity_uid("Action", input.action)?, None),
+        EntityUIDEntry::known(entity_uid(input.resource_type, input.resource_id)?, None),
+        Some(Context::empty()),
+    );
+    let response = Authorizer::new().is_authorized(request, &policies, &entities);
+    Ok(match response.decision {
+        Decision::Allow => AuthorizationDecision::Allow,
+        Decision::Deny => AuthorizationDecision::Deny,
+    })
+}
+
+fn entity_uid(entity_type: &str, id: &str) -> Result<EntityUID, LixError> {
+    EntityUID::with_eid_and_type(entity_type, id)
+        .map_err(|error| invalid_policy("entity_type", error))
+}
+
+fn invalid_policy(kind: &'static str, error: impl std::fmt::Display) -> LixError {
+    LixError::new(
+        LixError::CODE_INVALID_PERMISSION_POLICY,
+        format!("invalid Cedar {kind}: {error}"),
+    )
+    .with_details(serde_json::json!({ "kind": kind }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{AuthorizationDecision, AuthorizationDocuments, AuthorizationRequest, authorize};
+
+    const SCHEMA: &str = r#"
+        entity Account in [Team];
+        entity Team;
+        entity File;
+        entity Repository;
+
+        action "view" appliesTo { principal: Account, resource: [File, Repository] };
+        action "share" appliesTo { principal: Account, resource: File };
+        action "managePolicies" appliesTo { principal: Account, resource: Repository };
+        action "executeSql" appliesTo { principal: Account, resource: Repository };
+    "#;
+
+    fn request<'a>(principal: &'a str, file: &'a str) -> AuthorizationRequest<'a> {
+        AuthorizationRequest {
+            principal_id: principal,
+            action: "view",
+            resource_type: "File",
+            resource_id: file,
+        }
+    }
+
+    #[test]
+    fn defaults_to_deny_and_allows_an_explicit_publication() {
+        let documents = AuthorizationDocuments {
+            schema: SCHEMA,
+            policies: r#"
+                permit (
+                    principal == Account::"00000000-0000-7000-8000-000000000002",
+                    action == Action::"view",
+                    resource == File::"01920000-0000-7000-8000-000000000001"
+                );
+            "#,
+            entities: None,
+        };
+        assert_eq!(
+            authorize(
+                documents,
+                request(
+                    "00000000-0000-7000-8000-000000000002",
+                    "01920000-0000-7000-8000-000000000001"
+                )
+            )
+            .unwrap(),
+            AuthorizationDecision::Allow
+        );
+
+        let documents = AuthorizationDocuments {
+            schema: SCHEMA,
+            policies: "",
+            entities: None,
+        };
+        assert_eq!(
+            authorize(
+                documents,
+                request(
+                    "00000000-0000-7000-8000-000000000002",
+                    "01920000-0000-7000-8000-000000000001"
+                )
+            )
+            .unwrap(),
+            AuthorizationDecision::Deny
+        );
+    }
+
+    #[test]
+    fn company_defined_parent_relationship_changes_access_without_code() {
+        let documents = AuthorizationDocuments {
+            schema: SCHEMA,
+            policies: r#"
+                permit (
+                    principal in Team::"reviewers",
+                    action == Action::"view",
+                    resource
+                );
+            "#,
+            entities: Some(
+                r#"[{
+                    "uid": { "type": "Account", "id": "01920000-0000-7000-8000-0000000000aa" },
+                    "attrs": {},
+                    "parents": [{ "type": "Team", "id": "reviewers" }]
+                }]"#,
+            ),
+        };
+        assert_eq!(
+            authorize(
+                documents,
+                request(
+                    "01920000-0000-7000-8000-0000000000aa",
+                    "01920000-0000-7000-8000-000000000001"
+                )
+            )
+            .unwrap(),
+            AuthorizationDecision::Allow
+        );
+    }
+}

--- a/packages/lix/src/authorization.rs
+++ b/packages/lix/src/authorization.rs
@@ -78,6 +78,53 @@ pub(crate) fn authorize(
     })
 }
 
+/// Converts one applicable standard grant into Cedar source. The caller
+/// resolves resource inheritance; Cedar still evaluates the principal (and in
+/// particular group membership), action, custom permits, and custom forbids.
+pub(crate) fn default_grant_policy(
+    principal_type: &str,
+    principal_id: Option<&str>,
+    action: &str,
+    resource_type: &str,
+    resource_id: &str,
+) -> Result<String, LixError> {
+    let (principal_operator, principal) = match principal_type {
+        "account" => (
+            "==",
+            entity_uid(
+                "Account",
+                principal_id.ok_or_else(|| {
+                    invalid_policy("grant", "account grant is missing principal_id")
+                })?,
+            )?,
+        ),
+        "anonymous" => (
+            "==",
+            entity_uid("Account", crate::ANONYMOUS_ACCOUNT_ID)?,
+        ),
+        "group" => (
+            "in",
+            entity_uid(
+                "Group",
+                principal_id.ok_or_else(|| {
+                    invalid_policy("grant", "group grant is missing principal_id")
+                })?,
+            )?,
+        ),
+        other => {
+            return Err(invalid_policy(
+                "grant",
+                format!("unsupported principal type '{other}'"),
+            ));
+        }
+    };
+    let action = entity_uid("Action", action)?;
+    let resource = entity_uid(resource_type, resource_id)?;
+    Ok(format!(
+        "permit (principal {principal_operator} {principal}, action == {action}, resource == {resource});"
+    ))
+}
+
 fn entity_uid(entity_type: &str, id: &str) -> Result<EntityUID, LixError> {
     EntityUID::with_eid_and_type(entity_type, id)
         .map_err(|error| invalid_policy("entity_type", error))
@@ -93,7 +140,10 @@ fn invalid_policy(kind: &'static str, error: impl std::fmt::Display) -> LixError
 
 #[cfg(test)]
 mod tests {
-    use super::{AuthorizationDecision, AuthorizationDocuments, AuthorizationRequest, authorize};
+    use super::{
+        AuthorizationDecision, AuthorizationDocuments, AuthorizationRequest, authorize,
+        default_grant_policy,
+    };
 
     const SCHEMA: &str = r#"
         entity Account in [Team];
@@ -188,6 +238,36 @@ mod tests {
             )
             .unwrap(),
             AuthorizationDecision::Allow
+        );
+    }
+
+    #[test]
+    fn default_grants_are_cedar_policies_and_custom_forbids_win() {
+        let grant = default_grant_policy(
+            "anonymous",
+            None,
+            "view",
+            "File",
+            "01920000-0000-7000-8000-000000000001",
+        )
+        .unwrap();
+        let policies = format!(
+            "{grant}\nforbid (principal, action == Action::\"view\", resource == File::\"01920000-0000-7000-8000-000000000001\");"
+        );
+        assert_eq!(
+            authorize(
+                AuthorizationDocuments {
+                    schema: SCHEMA,
+                    policies: &policies,
+                    entities: None,
+                },
+                request(
+                    crate::ANONYMOUS_ACCOUNT_ID,
+                    "01920000-0000-7000-8000-000000000001",
+                ),
+            )
+            .unwrap(),
+            AuthorizationDecision::Deny
         );
     }
 }

--- a/packages/lix/src/common/error.rs
+++ b/packages/lix/src/common/error.rs
@@ -72,6 +72,13 @@ impl LixError {
     /// A SQL write targeted a read-only internal/component surface.
     pub const CODE_READ_ONLY: &'static str = "LIX_ERROR_READ_ONLY";
 
+    /// Cedar denied an authorization request for the active account.
+    pub const CODE_PERMISSION_DENIED: &'static str = "LIX_PERMISSION_DENIED";
+
+    /// Repository-owned Cedar schema, policy, or entity data is invalid.
+    pub const CODE_INVALID_PERMISSION_POLICY: &'static str =
+        "LIX_INVALID_PERMISSION_POLICY";
+
     /// SQL syntax is valid, but the feature is intentionally outside the Lix
     /// SQL surface.
     pub const CODE_UNSUPPORTED_SQL: &'static str = "LIX_UNSUPPORTED_SQL";

--- a/packages/lix/src/engine.rs
+++ b/packages/lix/src/engine.rs
@@ -1053,6 +1053,35 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn system_session_can_reassert_an_exact_built_in_schema() {
+        let storage = Memory::new();
+        Engine::initialize(storage.clone())
+            .await
+            .expect("engine should initialize");
+        let engine = Engine::new(storage)
+            .await
+            .expect("initialized engine should open");
+        let session = engine
+            .open_session_at_with_account(GLOBAL_BRANCH_ID, crate::SYSTEM_ACCOUNT_ID)
+            .await
+            .expect("global system session should open");
+        let schema = crate::schema::seed_schema_definition("lix_permission_grant")
+            .expect("permission grant builtin");
+
+        session
+            .execute(
+                "UPDATE lix_registered_schema \
+                 SET value = CAST($1 AS JSONB) \
+                 WHERE schema_key = 'lix_permission_grant'",
+                &[crate::Value::Text(
+                    serde_json::to_string(schema).expect("encode schema"),
+                )],
+            )
+            .await
+            .expect("system should be allowed to reassert an exact built-in schema");
+    }
+
+    #[tokio::test]
     async fn tracked_row_fast_path_serves_broad_sql_rows() {
         let storage = Memory::new();
         Engine::initialize(storage.clone())

--- a/packages/lix/src/engine.rs
+++ b/packages/lix/src/engine.rs
@@ -186,66 +186,88 @@ where
     }
 
     /// Adds trusted built-in schemas introduced after a repository was
-    /// created. This is catalog evolution, not a physical storage migration:
-    /// the registration is an ordinary tracked global fact authored by the
-    /// system account, so it follows the same history and synchronization
-    /// rules as the schemas seeded during initialization.
+    /// created. This is catalog evolution, not a physical storage migration.
+    /// Initialization registers built-ins in the global catalog and in every
+    /// branch-local catalog; upgrades mirror that shape so the schema is
+    /// immediately writable on existing branches. The registrations remain
+    /// ordinary tracked facts authored by the system account.
     async fn ensure_builtin_schema_registrations(&self) -> Result<(), LixError> {
-        let read = SharedStorageAdapterRead::new(
-            self.storage
-                .begin_read(StorageReadOptions::default())
-                .await?,
-        );
-        let reader = self.hot_state.reader(read);
-        let mut missing = Vec::new();
+        let mut builtins = Vec::new();
         for schema in crate::schema::seed_schema_definitions() {
             let key = crate::schema::schema_key_from_definition(schema)?;
-            let row = reader
-                .load_row(&HotStateRowRequest {
-                    schema_key: "lix_registered_schema".to_string(),
-                    branch_id: GLOBAL_BRANCH_ID.to_string(),
-                    row_pk: crate::schema::registered_schema_row_pk(&key.schema_key)?,
-                    file_id: NullableKeyFilter::Null,
-                })
-                .await?;
-            if row.is_none() {
-                missing.push((
-                    key.schema_key,
-                    serde_json::to_string(schema).map_err(|error| {
-                        LixError::new(
-                            LixError::CODE_INTERNAL_ERROR,
-                            format!("could not encode built-in schema registration: {error}"),
-                        )
-                    })?,
-                ));
-            }
-        }
-        if missing.is_empty() {
-            return Ok(());
+            builtins.push((
+                key.schema_key,
+                serde_json::to_string(schema).map_err(|error| {
+                    LixError::new(
+                        LixError::CODE_INTERNAL_ERROR,
+                        format!("could not encode built-in schema registration: {error}"),
+                    )
+                })?,
+            ));
         }
 
-        let session = self
+        let global_session = self
             .open_session_at_with_account(GLOBAL_BRANCH_ID, crate::SYSTEM_ACCOUNT_ID)
             .await?;
-        let mut sql = String::from(
-            "INSERT INTO lix_registered_schema \
-             (schema_key, value, lixcol_global, lixcol_untracked) VALUES ",
-        );
-        let mut params = Vec::with_capacity(missing.len() * 2);
-        for (index, (schema_key, schema_json)) in missing.into_iter().enumerate() {
-            if index > 0 {
-                sql.push_str(", ");
-            }
-            let key_param = index * 2 + 1;
-            let value_param = key_param + 1;
-            sql.push_str(&format!(
-                "(${key_param}, CAST(${value_param} AS JSONB), true, false)"
-            ));
-            params.push(crate::Value::Text(schema_key));
-            params.push(crate::Value::Text(schema_json));
+        let branch_rows = global_session
+            .execute("SELECT id FROM lix_branch ORDER BY id", &[])
+            .await?;
+        let mut branch_ids = std::collections::BTreeSet::from([GLOBAL_BRANCH_ID.to_string()]);
+        for row in branch_rows.rows() {
+            branch_ids.insert(row.get::<String>("id")?);
         }
-        sql.push_str(" ON CONFLICT (schema_key) DO NOTHING");
-        session.execute(&sql, &params).await?;
+
+        for branch_id in branch_ids {
+            let session = self
+                .open_session_at_with_account(&branch_id, crate::SYSTEM_ACCOUNT_ID)
+                .await?;
+            let is_global_catalog = branch_id == GLOBAL_BRANCH_ID;
+            let registered = session
+                .execute(
+                    "SELECT value ->> 'key' AS schema_key \
+                     FROM lix_registered_schema_by_branch \
+                     WHERE lixcol_branch_id = $1 \
+                       AND lixcol_global = $2 \
+                       AND lixcol_untracked = false",
+                    &[
+                        crate::Value::Text(branch_id),
+                        crate::Value::Boolean(is_global_catalog),
+                    ],
+                )
+                .await?
+                .rows()
+                .iter()
+                .map(|row| row.get::<String>("schema_key"))
+                .collect::<Result<std::collections::BTreeSet<_>, _>>()?;
+            let missing = builtins
+                .iter()
+                .filter(|(schema_key, _)| !registered.contains(schema_key))
+                .collect::<Vec<_>>();
+            if missing.is_empty() {
+                continue;
+            }
+
+            let mut sql = String::from(
+                "INSERT INTO lix_registered_schema \
+                 (schema_key, value, lixcol_global, lixcol_untracked) VALUES ",
+            );
+            let mut params = Vec::with_capacity(missing.len() * 2);
+            for (index, (schema_key, schema_json)) in missing.into_iter().enumerate() {
+                if index > 0 {
+                    sql.push_str(", ");
+                }
+                let key_param = index * 2 + 1;
+                let value_param = key_param + 1;
+                sql.push_str(&format!(
+                    "(${key_param}, CAST(${value_param} AS JSONB), \
+                     {is_global_catalog}, false)"
+                ));
+                params.push(crate::Value::Text(schema_key.clone()));
+                params.push(crate::Value::Text(schema_json.clone()));
+            }
+            sql.push_str(" ON CONFLICT (schema_key) DO NOTHING");
+            session.execute(&sql, &params).await?;
+        }
         Ok(())
     }
 

--- a/packages/lix/src/engine.rs
+++ b/packages/lix/src/engine.rs
@@ -164,7 +164,7 @@ where
             Arc::clone(&collaboration_write_gate),
             Arc::clone(&observe_invalidation),
         ));
-        Ok(Self {
+        let engine = Self {
             binary_cas: Arc::new(BinaryCasContext::new()),
             storage,
             tracked_state,
@@ -180,7 +180,73 @@ where
             plugin_host,
             telemetry: options.telemetry,
             lix_id,
-        })
+        };
+        engine.ensure_builtin_schema_registrations().await?;
+        Ok(engine)
+    }
+
+    /// Adds trusted built-in schemas introduced after a repository was
+    /// created. This is catalog evolution, not a physical storage migration:
+    /// the registration is an ordinary tracked global fact authored by the
+    /// system account, so it follows the same history and synchronization
+    /// rules as the schemas seeded during initialization.
+    async fn ensure_builtin_schema_registrations(&self) -> Result<(), LixError> {
+        let read = SharedStorageAdapterRead::new(
+            self.storage
+                .begin_read(StorageReadOptions::default())
+                .await?,
+        );
+        let reader = self.hot_state.reader(read);
+        let mut missing = Vec::new();
+        for schema in crate::schema::seed_schema_definitions() {
+            let key = crate::schema::schema_key_from_definition(schema)?;
+            let row = reader
+                .load_row(&HotStateRowRequest {
+                    schema_key: "lix_registered_schema".to_string(),
+                    branch_id: GLOBAL_BRANCH_ID.to_string(),
+                    row_pk: crate::schema::registered_schema_row_pk(&key.schema_key)?,
+                    file_id: NullableKeyFilter::Null,
+                })
+                .await?;
+            if row.is_none() {
+                missing.push((
+                    key.schema_key,
+                    serde_json::to_string(schema).map_err(|error| {
+                        LixError::new(
+                            LixError::CODE_INTERNAL_ERROR,
+                            format!("could not encode built-in schema registration: {error}"),
+                        )
+                    })?,
+                ));
+            }
+        }
+        if missing.is_empty() {
+            return Ok(());
+        }
+
+        let session = self
+            .open_session_at_with_account(GLOBAL_BRANCH_ID, crate::SYSTEM_ACCOUNT_ID)
+            .await?;
+        let mut sql = String::from(
+            "INSERT INTO lix_registered_schema \
+             (schema_key, value, lixcol_global, lixcol_untracked) VALUES ",
+        );
+        let mut params = Vec::with_capacity(missing.len() * 2);
+        for (index, (schema_key, schema_json)) in missing.into_iter().enumerate() {
+            if index > 0 {
+                sql.push_str(", ");
+            }
+            let key_param = index * 2 + 1;
+            let value_param = key_param + 1;
+            sql.push_str(&format!(
+                "(${key_param}, CAST(${value_param} AS JSONB), true, false)"
+            ));
+            params.push(crate::Value::Text(schema_key));
+            params.push(crate::Value::Text(schema_json));
+        }
+        sql.push_str(" ON CONFLICT (schema_key) DO NOTHING");
+        session.execute(&sql, &params).await?;
+        Ok(())
     }
 
     pub(crate) fn storage(&self) -> StorageAdapter<StorageImpl> {

--- a/packages/lix/src/handle.rs
+++ b/packages/lix/src/handle.rs
@@ -652,6 +652,20 @@ where
         );
     }
 
+    /// Evaluates the active account against the repository's Cedar policy.
+    /// Repositories without `/.lix/permissions/schema.cedarschema` report an
+    /// inactive decision and retain their existing behavior.
+    pub async fn authorize(
+        &self,
+        action: &str,
+        resource_type: &str,
+        resource_id: &str,
+    ) -> Result<crate::AuthorizationDecision, LixError> {
+        self.session
+            .authorize(action, resource_type, resource_id)
+            .await
+    }
+
     /// Creates an active global account if it does not exist. Existing mutable
     /// account fields are deliberately left unchanged.
     pub(crate) async fn ensure_account(

--- a/packages/lix/src/lib.rs
+++ b/packages/lix/src/lib.rs
@@ -48,6 +48,7 @@ macro_rules! engine_surface {
 #[cfg(not(all(target_arch = "wasm32", target_os = "wasi", target_env = "p2")))]
 engine_surface! {
 pub(crate) mod account;
+pub(crate) mod authorization;
 mod binary_cas;
 pub(crate) mod branch;
 mod background_task;
@@ -152,6 +153,7 @@ pub use schema::{
 pub use lix_schema as schema_v1;
 
 pub use common::LixError;
+pub use authorization::AuthorizationDecision;
 pub use common::{Blob, Json, LixNotice, NullableKeyFilter, SharedStr, SqlQueryResult, Value};
 pub use common::{BranchId, CanonicalPluginKey, CanonicalSchemaKey, RowPk, FileId};
 pub use common::{LixPath, validate_lix_path_segment};

--- a/packages/lix/src/module_layers.rs
+++ b/packages/lix/src/module_layers.rs
@@ -96,6 +96,10 @@ const UNLAYERED_MODULES: &[(&str, &str)] = &[
         "background_task",
         "executor-neutral engine worker plumbing, no repository semantics",
     ),
+    (
+        "authorization",
+        "repository policy parsing and Cedar evaluation; not yet placed",
+    ),
     ("catalog", "not yet analysed"),
     ("domain", "pure predicates, no owned invariant"),
     ("engine", "entry point; reaches everywhere by design"),

--- a/packages/lix/src/schema/builtin/lix_permission_grant.json
+++ b/packages/lix/src/schema/builtin/lix_permission_grant.json
@@ -1,0 +1,63 @@
+{
+  "$schema": "https://lix.dev/schema-v1.json",
+  "key": "lix_permission_grant",
+  "columns": [
+    {
+      "name": "id",
+      "type": "uuid",
+      "nullable": false,
+      "default_expression": "uuidv7()"
+    },
+    {
+      "name": "principal_type",
+      "type": "text",
+      "nullable": false,
+      "description": "The kind of principal receiving access: account, group, or anonymous."
+    },
+    {
+      "name": "principal_id",
+      "type": "text",
+      "nullable": true,
+      "description": "The account or group identifier. Null only for the anonymous principal."
+    },
+    {
+      "name": "access_level",
+      "type": "text",
+      "nullable": false,
+      "description": "The standard access level: viewer, commenter, contributor, editor, or manager."
+    },
+    {
+      "name": "resource_type",
+      "type": "text",
+      "nullable": false,
+      "description": "The resource scope: repository, directory, file, table, or row."
+    },
+    {
+      "name": "directory_id",
+      "type": "uuid",
+      "nullable": true,
+      "description": "The stable directory identifier for a directory grant."
+    },
+    {
+      "name": "file_id",
+      "type": "uuid",
+      "nullable": true,
+      "description": "The stable file identifier for file, table, and row grants."
+    },
+    {
+      "name": "schema_key",
+      "type": "text",
+      "nullable": true,
+      "description": "The schema key for table and row grants."
+    },
+    {
+      "name": "row_pk",
+      "type": "jsonb",
+      "nullable": true,
+      "description": "The canonical primary-key tuple for a row grant."
+    }
+  ],
+  "primary_key": [
+    "id"
+  ]
+}

--- a/packages/lix/src/schema/builtin/mod.rs
+++ b/packages/lix/src/schema/builtin/mod.rs
@@ -4,6 +4,7 @@ use std::sync::OnceLock;
 const LIX_REGISTERED_SCHEMA_KEY: &str = "lix_registered_schema";
 const LIX_KEY_VALUE_SCHEMA_KEY: &str = "lix_key_value";
 const LIX_ACCOUNT_SCHEMA_KEY: &str = "lix_account";
+const LIX_PERMISSION_GRANT_SCHEMA_KEY: &str = "lix_permission_grant";
 const LIX_CHANGE_SCHEMA_KEY: &str = "lix_change";
 const LIX_COMMIT_SCHEMA_KEY: &str = "lix_commit";
 const LIX_BRANCH_DESCRIPTOR_SCHEMA_KEY: &str = "lix_branch_descriptor";
@@ -19,6 +20,7 @@ const LIX_COLLECTION_GENERATION_SCHEMA_KEY: &str = "lix_collection_generation";
 const LIX_REGISTERED_SCHEMA_JSON: &str = include_str!("lix_registered_schema.json");
 const LIX_KEY_VALUE_SCHEMA_JSON: &str = include_str!("lix_key_value.json");
 const LIX_ACCOUNT_SCHEMA_JSON: &str = include_str!("lix_account.json");
+const LIX_PERMISSION_GRANT_SCHEMA_JSON: &str = include_str!("lix_permission_grant.json");
 const LIX_CHANGE_SCHEMA_JSON: &str = include_str!("lix_change.json");
 const LIX_COMMIT_SCHEMA_JSON: &str = include_str!("lix_commit.json");
 const LIX_BRANCH_DESCRIPTOR_SCHEMA_JSON: &str = include_str!("lix_branch_descriptor.json");
@@ -34,6 +36,7 @@ const LIX_COLLECTION_GENERATION_SCHEMA_JSON: &str = include_str!("lix_collection
 static LIX_REGISTERED_SCHEMA: OnceLock<JsonValue> = OnceLock::new();
 static LIX_KEY_VALUE_SCHEMA: OnceLock<JsonValue> = OnceLock::new();
 static LIX_ACCOUNT_SCHEMA: OnceLock<JsonValue> = OnceLock::new();
+static LIX_PERMISSION_GRANT_SCHEMA: OnceLock<JsonValue> = OnceLock::new();
 static LIX_CHANGE_SCHEMA: OnceLock<JsonValue> = OnceLock::new();
 static LIX_COMMIT_SCHEMA: OnceLock<JsonValue> = OnceLock::new();
 static LIX_BRANCH_DESCRIPTOR_SCHEMA: OnceLock<JsonValue> = OnceLock::new();
@@ -50,6 +53,7 @@ const BUILTIN_SCHEMA_KEYS: &[&str] = &[
     LIX_REGISTERED_SCHEMA_KEY,
     LIX_KEY_VALUE_SCHEMA_KEY,
     LIX_ACCOUNT_SCHEMA_KEY,
+    LIX_PERMISSION_GRANT_SCHEMA_KEY,
     LIX_CHANGE_SCHEMA_KEY,
     LIX_COMMIT_SCHEMA_KEY,
     LIX_BRANCH_DESCRIPTOR_SCHEMA_KEY,
@@ -92,6 +96,14 @@ pub(super) fn seed_schema_definition(schema_key: &str) -> Option<&'static JsonVa
         LIX_ACCOUNT_SCHEMA_KEY => Some(
             LIX_ACCOUNT_SCHEMA
                 .get_or_init(|| parse_builtin_schema("lix_account.json", LIX_ACCOUNT_SCHEMA_JSON)),
+        ),
+        LIX_PERMISSION_GRANT_SCHEMA_KEY => Some(
+            LIX_PERMISSION_GRANT_SCHEMA.get_or_init(|| {
+                parse_builtin_schema(
+                    "lix_permission_grant.json",
+                    LIX_PERMISSION_GRANT_SCHEMA_JSON,
+                )
+            }),
         ),
         LIX_CHANGE_SCHEMA_KEY => Some(
             LIX_CHANGE_SCHEMA

--- a/packages/lix/src/server_protocol/handler.rs
+++ b/packages/lix/src/server_protocol/handler.rs
@@ -3613,6 +3613,7 @@ fn status_for_lix_error(error: &LixError) -> StatusCode {
         | LixError::CODE_COMMIT_NOT_FOUND
         | LixError::CODE_TABLE_NOT_FOUND
         | LixError::CODE_COLUMN_NOT_FOUND => StatusCode::NOT_FOUND,
+        LixError::CODE_PERMISSION_DENIED => StatusCode::FORBIDDEN,
         LixError::CODE_CLOSED | LixError::CODE_STORAGE_FENCED | LixError::CODE_STORAGE_CLOSED => {
             StatusCode::CONFLICT
         }
@@ -7049,6 +7050,77 @@ mod tests {
                 .to_bytes()
                 .is_empty()
         );
+    }
+
+    #[tokio::test]
+    async fn binary_file_read_enforces_repository_cedar_policy() {
+        let app = app().await;
+        let (session_id, _) = new_session(&app.router).await;
+        let public_file_id = "01920000-0000-7000-8000-000000000101";
+        let private_file_id = "01920000-0000-7000-8000-000000000102";
+        let schema = r#"
+            entity Account;
+            entity File;
+            action "view" appliesTo { principal: Account, resource: File };
+        "#;
+        let policies = format!(
+            r#"permit (
+                principal == Account::"{}",
+                action == Action::"view",
+                resource == File::"{public_file_id}"
+            );"#,
+            lix::ANONYMOUS_ACCOUNT_ID
+        );
+        let seeded = request(
+            &app.router,
+            "POST",
+            "/lix/v1/execute",
+            Some(&session_id),
+            Some(json!({
+                "sql": "INSERT INTO lix_file (id, path, content) VALUES ($1, '/public.txt', CAST('public' AS BYTEA)), ($2, '/private.txt', CAST('private' AS BYTEA)), ($3, '/.lix/permissions/schema.cedarschema', CAST($4 AS BYTEA)), ($5, '/.lix/permissions/publications.cedar', CAST($6 AS BYTEA))",
+                "params": [
+                    { "kind": "text", "value": public_file_id },
+                    { "kind": "text", "value": private_file_id },
+                    { "kind": "text", "value": "01920000-0000-7000-8000-000000000103" },
+                    { "kind": "text", "value": schema },
+                    { "kind": "text", "value": "01920000-0000-7000-8000-000000000104" },
+                    { "kind": "text", "value": policies }
+                ]
+            })),
+        )
+        .await;
+        assert_eq!(seeded.status(), StatusCode::OK);
+
+        let allowed = request(
+            &app.router,
+            "GET",
+            "/lix/v1/file?path=%2Fpublic.txt",
+            Some(&session_id),
+            None,
+        )
+        .await;
+        assert_eq!(allowed.status(), StatusCode::OK);
+        assert_eq!(
+            allowed
+                .into_body()
+                .collect()
+                .await
+                .expect("public file body")
+                .to_bytes()
+                .as_ref(),
+            b"public"
+        );
+
+        let denied = request(
+            &app.router,
+            "GET",
+            "/lix/v1/file?path=%2Fprivate.txt",
+            Some(&session_id),
+            None,
+        )
+        .await;
+        assert_eq!(denied.status(), StatusCode::FORBIDDEN);
+        assert_eq!(error_code(denied).await, LixError::CODE_PERMISSION_DENIED);
     }
 
     #[tokio::test]

--- a/packages/lix/src/session/authorization.rs
+++ b/packages/lix/src/session/authorization.rs
@@ -14,6 +14,9 @@ const LOAD_AUTHORIZATION_DOCUMENTS_SQL: &str = "SELECT path, content FROM lix_fi
      ORDER BY path";
 const LOAD_PROJECTED_AUTHORIZATION_DOCUMENTS_SQL: &str =
     "SELECT kind, path, source FROM cedar_permission_source ORDER BY path";
+const LOAD_PERMISSION_GRANTS_SQL: &str = "SELECT principal_type, principal_id, access_level, \
+     resource_type, directory_id, file_id, schema_key, row_pk \
+     FROM lix_permission_grant ORDER BY id";
 
 impl<StorageImpl> SessionContext<StorageImpl>
 where
@@ -25,9 +28,18 @@ where
         resource_type: &str,
         resource_id: &str,
     ) -> Result<AuthorizationDecision, LixError> {
-        let Some(documents) = self.load_authorization_documents().await? else {
+        let Some(mut documents) = self.load_authorization_documents().await? else {
             return Ok(AuthorizationDecision::Inactive);
         };
+        let default_grants = self
+            .load_applicable_default_grant_policies(action, resource_type, resource_id)
+            .await?;
+        if !default_grants.is_empty() {
+            documents
+                .policies
+                .push_str("// source: lix_permission_grant default adapter\n");
+            documents.policies.push_str(&default_grants);
+        }
         crate::authorization::authorize(
             AuthorizationDocuments {
                 schema: &documents.schema,
@@ -99,6 +111,346 @@ where
             }
             Err(error) => Err(error),
         }
+    }
+
+    async fn load_applicable_default_grant_policies(
+        &self,
+        action: &str,
+        resource_type: &str,
+        resource_id: &str,
+    ) -> Result<String, LixError> {
+        let requested = RequestedPermissionResource::parse(resource_type, resource_id);
+        let directory_ancestry = self.load_directory_ancestry(&requested).await?;
+        let result = self.execute(LOAD_PERMISSION_GRANTS_SQL, &[]).await?;
+        let mut policies = String::new();
+        for row in result.rows() {
+            let grant = PermissionGrant::from_result(&result, row)?;
+            if !default_access_level_allows(&grant.access_level, action)
+                || !grant.resource.applies_to(&requested, &directory_ancestry)
+            {
+                continue;
+            }
+            policies.push_str(&crate::authorization::default_grant_policy(
+                &grant.principal_type,
+                grant.principal_id.as_deref(),
+                action,
+                resource_type,
+                resource_id,
+            )?);
+            policies.push('\n');
+        }
+        Ok(policies)
+    }
+
+    async fn load_directory_ancestry(
+        &self,
+        requested: &RequestedPermissionResource,
+    ) -> Result<std::collections::BTreeSet<String>, LixError> {
+        let mut next = match requested {
+            RequestedPermissionResource::Directory { directory_id } => {
+                Some(directory_id.clone())
+            }
+            RequestedPermissionResource::File { file_id }
+            | RequestedPermissionResource::Table { file_id, .. }
+            | RequestedPermissionResource::Row { file_id, .. } => {
+                let result = self
+                    .execute(
+                        "SELECT directory_id FROM lix_file WHERE id = $1",
+                        &[Value::Text(file_id.clone())],
+                    )
+                    .await?;
+                match result.rows().first() {
+                    Some(row) => nullable_text(&result, row, "directory_id")?,
+                    None => None,
+                }
+            }
+            RequestedPermissionResource::Repository
+            | RequestedPermissionResource::Other => None,
+        };
+        let mut ancestry = std::collections::BTreeSet::new();
+        while let Some(directory_id) = next {
+            if !ancestry.insert(directory_id.clone()) {
+                return Err(invalid_document("directory permission ancestry contains a cycle"));
+            }
+            let result = self
+                .execute(
+                    "SELECT parent_id FROM lix_directory WHERE id = $1",
+                    &[Value::Text(directory_id)],
+                )
+                .await?;
+            next = match result.rows().first() {
+                Some(row) => nullable_text(&result, row, "parent_id")?,
+                None => None,
+            };
+        }
+        Ok(ancestry)
+    }
+}
+
+#[derive(Debug)]
+struct PermissionGrant {
+    principal_type: String,
+    principal_id: Option<String>,
+    access_level: String,
+    resource: GrantPermissionResource,
+}
+
+impl PermissionGrant {
+    fn from_result(result: &super::ExecuteResult, row: &crate::Row) -> Result<Self, LixError> {
+        let resource_type = required_text(result, row, "resource_type")?;
+        let directory_id = nullable_text(result, row, "directory_id")?;
+        let file_id = nullable_text(result, row, "file_id")?;
+        let schema_key = nullable_text(result, row, "schema_key")?;
+        let row_pk = nullable_json(result, row, "row_pk")?;
+        let resource = match resource_type.as_str() {
+            "repository" => GrantPermissionResource::Repository,
+            "directory" => GrantPermissionResource::Directory {
+                directory_id: directory_id.ok_or_else(|| {
+                    invalid_document("directory permission grant has no directory_id")
+                })?,
+            },
+            "file" => GrantPermissionResource::File {
+                file_id: file_id
+                    .ok_or_else(|| invalid_document("file permission grant has no file_id"))?,
+            },
+            "table" => GrantPermissionResource::Table {
+                file_id: file_id
+                    .ok_or_else(|| invalid_document("table permission grant has no file_id"))?,
+                schema_key: schema_key.ok_or_else(|| {
+                    invalid_document("table permission grant has no schema_key")
+                })?,
+            },
+            "row" => GrantPermissionResource::Row {
+                file_id: file_id
+                    .ok_or_else(|| invalid_document("row permission grant has no file_id"))?,
+                schema_key: schema_key
+                    .ok_or_else(|| invalid_document("row permission grant has no schema_key"))?,
+                row_pk: row_pk
+                    .ok_or_else(|| invalid_document("row permission grant has no row_pk"))?,
+            },
+            other => {
+                return Err(invalid_document(format!(
+                    "permission grant has unknown resource_type '{other}'"
+                )));
+            }
+        };
+        Ok(Self {
+            principal_type: required_text(result, row, "principal_type")?,
+            principal_id: nullable_text(result, row, "principal_id")?,
+            access_level: required_text(result, row, "access_level")?,
+            resource,
+        })
+    }
+}
+
+#[derive(Debug)]
+enum GrantPermissionResource {
+    Repository,
+    Directory {
+        directory_id: String,
+    },
+    File {
+        file_id: String,
+    },
+    Table {
+        file_id: String,
+        schema_key: String,
+    },
+    Row {
+        file_id: String,
+        schema_key: String,
+        row_pk: serde_json::Value,
+    },
+}
+
+impl GrantPermissionResource {
+    fn applies_to(
+        &self,
+        requested: &RequestedPermissionResource,
+        directory_ancestry: &std::collections::BTreeSet<String>,
+    ) -> bool {
+        match self {
+            Self::Repository => true,
+            Self::Directory { directory_id } => directory_ancestry.contains(directory_id),
+            Self::File { file_id } => requested.file_id() == Some(file_id.as_str()),
+            Self::Table {
+                file_id,
+                schema_key,
+            } => requested.table_identity() == Some((schema_key.as_str(), file_id.as_str())),
+            Self::Row {
+                file_id,
+                schema_key,
+                row_pk,
+            } => {
+                requested.row_identity()
+                    == Some((schema_key.as_str(), file_id.as_str(), row_pk))
+            }
+        }
+    }
+}
+
+#[derive(Debug)]
+enum RequestedPermissionResource {
+    Repository,
+    Directory {
+        directory_id: String,
+    },
+    File {
+        file_id: String,
+    },
+    Table {
+        schema_key: String,
+        file_id: String,
+    },
+    Row {
+        schema_key: String,
+        file_id: String,
+        row_pk: serde_json::Value,
+    },
+    Other,
+}
+
+impl RequestedPermissionResource {
+    fn parse(resource_type: &str, resource_id: &str) -> Self {
+        match resource_type {
+            "Repository" if resource_id == "repository" => Self::Repository,
+            "Directory" => Self::Directory {
+                directory_id: resource_id.to_string(),
+            },
+            "File" => Self::File {
+                file_id: resource_id.to_string(),
+            },
+            "Table" => parse_table_resource_id(resource_id)
+                .map(|(schema_key, file_id)| Self::Table {
+                    schema_key,
+                    file_id,
+                })
+                .unwrap_or(Self::Other),
+            "Row" => parse_row_resource_id(resource_id)
+                .map(|(schema_key, file_id, row_pk)| Self::Row {
+                    schema_key,
+                    file_id,
+                    row_pk,
+                })
+                .unwrap_or(Self::Other),
+            _ => Self::Other,
+        }
+    }
+
+    fn file_id(&self) -> Option<&str> {
+        match self {
+            Self::File { file_id } | Self::Table { file_id, .. } | Self::Row { file_id, .. } => {
+                Some(file_id)
+            }
+            _ => None,
+        }
+    }
+
+    fn table_identity(&self) -> Option<(&str, &str)> {
+        match self {
+            Self::Table {
+                schema_key,
+                file_id,
+            }
+            | Self::Row {
+                schema_key,
+                file_id,
+                ..
+            } => Some((schema_key, file_id)),
+            _ => None,
+        }
+    }
+
+    fn row_identity(&self) -> Option<(&str, &str, &serde_json::Value)> {
+        match self {
+            Self::Row {
+                schema_key,
+                file_id,
+                row_pk,
+            } => Some((schema_key, file_id, row_pk)),
+            _ => None,
+        }
+    }
+}
+
+fn parse_table_resource_id(resource_id: &str) -> Option<(String, String)> {
+    let serde_json::Value::Array(parts) = serde_json::from_str(resource_id).ok()? else {
+        return None;
+    };
+    match parts.as_slice() {
+        [serde_json::Value::String(schema_key), serde_json::Value::String(file_id)] => {
+            Some((schema_key.clone(), file_id.clone()))
+        }
+        _ => None,
+    }
+}
+
+fn parse_row_resource_id(resource_id: &str) -> Option<(String, String, serde_json::Value)> {
+    let serde_json::Value::Array(parts) = serde_json::from_str(resource_id).ok()? else {
+        return None;
+    };
+    match parts.as_slice() {
+        [serde_json::Value::String(schema_key), serde_json::Value::String(file_id), row_pk] => {
+            Some((schema_key.clone(), file_id.clone(), row_pk.clone()))
+        }
+        _ => None,
+    }
+}
+
+fn default_access_level_allows(access_level: &str, action: &str) -> bool {
+    let minimum = match action {
+        "view" => 0,
+        "comment" => 1,
+        "create" => 2,
+        "edit" | "delete" | "share" | "publish" => 3,
+        "createBranch" | "merge" | "manageMembers" | "managePolicies" | "executeSql" => 4,
+        _ => return false,
+    };
+    let actual = match access_level {
+        "viewer" => 0,
+        "commenter" => 1,
+        "contributor" => 2,
+        "editor" => 3,
+        "manager" => 4,
+        _ => return false,
+    };
+    actual >= minimum
+}
+
+fn required_text(
+    result: &super::ExecuteResult,
+    row: &crate::Row,
+    column: &str,
+) -> Result<String, LixError> {
+    nullable_text(result, row, column)?
+        .ok_or_else(|| invalid_document(format!("permission grant {column} is null")))
+}
+
+fn nullable_text(
+    result: &super::ExecuteResult,
+    row: &crate::Row,
+    column: &str,
+) -> Result<Option<String>, LixError> {
+    match result.get(row, column) {
+        Some(Value::Text(value)) => Ok(Some(value.clone())),
+        Some(Value::Null) => Ok(None),
+        _ => Err(invalid_document(format!(
+            "permission grant {column} is not text or null"
+        ))),
+    }
+}
+
+fn nullable_json(
+    result: &super::ExecuteResult,
+    row: &crate::Row,
+    column: &str,
+) -> Result<Option<serde_json::Value>, LixError> {
+    match result.get(row, column) {
+        Some(Value::Jsonb(value)) => Ok(Some(value.to_value())),
+        Some(Value::Null) => Ok(None),
+        _ => Err(invalid_document(format!(
+            "permission grant {column} is not JSON or null"
+        ))),
     }
 }
 
@@ -253,6 +605,101 @@ mod tests {
         .unwrap();
         let denied = lix.read_file_content("/public.md", None).await.unwrap_err();
         assert_eq!(denied.code, LixError::CODE_PERMISSION_DENIED);
+    }
+
+    #[tokio::test]
+    async fn global_permission_grants_drive_default_cedar_file_access() {
+        let lix = open_lix().await.unwrap();
+        lix.execute(
+            "INSERT INTO lix_file (id, path, content) VALUES \
+             ($1, '/public.md', CAST('public' AS BYTEA)), \
+             ($2, '/private.md', CAST('private' AS BYTEA)), \
+             ($3, '/.lix/permissions/schema.cedarschema', CAST($4 AS BYTEA)), \
+             ($5, '/.lix/permissions/default.cedar', CAST('' AS BYTEA))",
+            &[
+                Value::Text(PUBLIC_ID.into()),
+                Value::Text(PRIVATE_ID.into()),
+                Value::Text("01920000-0000-7000-8000-000000000013".into()),
+                Value::Text(schema().into()),
+                Value::Text("01920000-0000-7000-8000-000000000014".into()),
+            ],
+        )
+        .await
+        .unwrap();
+        lix.execute(
+            "INSERT INTO lix_permission_grant \
+             (id, principal_type, access_level, resource_type, file_id, lixcol_global) \
+             VALUES ('01920000-0000-7000-8000-000000000015', 'anonymous', 'viewer', 'file', $1, true)",
+            &[Value::Text(PUBLIC_ID.into())],
+        )
+        .await
+        .unwrap();
+
+        let public = lix.read_file_content("/public.md", None).await.unwrap();
+        assert_eq!(public.unwrap().into_content().as_ref(), b"public");
+        let denied = lix
+            .read_file_content("/private.md", None)
+            .await
+            .unwrap_err();
+        assert_eq!(denied.code, LixError::CODE_PERMISSION_DENIED);
+
+        lix.execute(
+            "UPDATE lix_permission_grant SET resource_type = 'repository', file_id = NULL \
+             WHERE id = '01920000-0000-7000-8000-000000000015'",
+            &[],
+        )
+        .await
+        .unwrap();
+        let private = lix.read_file_content("/private.md", None).await.unwrap();
+        assert_eq!(private.unwrap().into_content().as_ref(), b"private");
+    }
+
+    #[tokio::test]
+    async fn directory_grants_cover_descendant_files() {
+        let lix = open_lix().await.unwrap();
+        lix.execute(
+            "INSERT INTO lix_file (id, path, content) VALUES \
+             ($1, '/shared/reports/q1.md', CAST('q1' AS BYTEA)), \
+             ($2, '/outside.md', CAST('outside' AS BYTEA)), \
+             ($3, '/.lix/permissions/schema.cedarschema', CAST($4 AS BYTEA))",
+            &[
+                Value::Text(PUBLIC_ID.into()),
+                Value::Text(PRIVATE_ID.into()),
+                Value::Text("01920000-0000-7000-8000-000000000023".into()),
+                Value::Text(schema().into()),
+            ],
+        )
+        .await
+        .unwrap();
+        let shared = lix
+            .execute(
+                "SELECT id FROM lix_directory WHERE path = '/shared'",
+                &[],
+            )
+            .await
+            .unwrap();
+        let Value::Text(shared_id) = &shared.rows()[0].values()[0] else {
+            panic!("shared directory id should be text");
+        };
+        lix.execute(
+            "INSERT INTO lix_permission_grant \
+             (id, principal_type, access_level, resource_type, directory_id, lixcol_global) \
+             VALUES ('01920000-0000-7000-8000-000000000025', 'anonymous', 'viewer', 'directory', $1, true)",
+            &[Value::Text(shared_id.clone())],
+        )
+        .await
+        .unwrap();
+
+        let q1 = lix
+            .read_file_content("/shared/reports/q1.md", None)
+            .await
+            .unwrap();
+        assert_eq!(q1.unwrap().into_content().as_ref(), b"q1");
+        let outside = lix
+            .read_file_content("/outside.md", None)
+            .await
+            .unwrap_err();
+        assert_eq!(outside.code, LixError::CODE_PERMISSION_DENIED);
     }
 
     fn schema() -> &'static str {

--- a/packages/lix/src/session/authorization.rs
+++ b/packages/lix/src/session/authorization.rs
@@ -1,0 +1,279 @@
+use crate::authorization::{
+    AuthorizationDecision, AuthorizationDocuments, AuthorizationRequest, ENTITIES_PATH,
+    PERMISSIONS_DIRECTORY, SCHEMA_PATH,
+};
+use crate::storage_adapter::Storage;
+use crate::{LixError, Value};
+
+use super::SessionContext;
+
+const LOAD_AUTHORIZATION_DOCUMENTS_SQL: &str = "SELECT path, content FROM lix_file \
+     WHERE path = '/.lix/permissions/schema.cedarschema' \
+        OR path = '/.lix/permissions/entities.cedar.json' \
+        OR path LIKE '/.lix/permissions/%.cedar' \
+     ORDER BY path";
+const LOAD_PROJECTED_AUTHORIZATION_DOCUMENTS_SQL: &str =
+    "SELECT kind, path, source FROM cedar_permission_source ORDER BY path";
+
+impl<StorageImpl> SessionContext<StorageImpl>
+where
+    StorageImpl: Storage + Clone + Send + Sync + 'static,
+{
+    pub(crate) async fn authorize(
+        &self,
+        action: &str,
+        resource_type: &str,
+        resource_id: &str,
+    ) -> Result<AuthorizationDecision, LixError> {
+        let Some(documents) = self.load_authorization_documents().await? else {
+            return Ok(AuthorizationDecision::Inactive);
+        };
+        crate::authorization::authorize(
+            AuthorizationDocuments {
+                schema: &documents.schema,
+                policies: &documents.policies,
+                entities: documents.entities.as_deref(),
+            },
+            AuthorizationRequest {
+                principal_id: self.active_account_id(),
+                action,
+                resource_type,
+                resource_id,
+            },
+        )
+    }
+
+    pub(crate) async fn require_file_view(&self, path: &str) -> Result<(), LixError> {
+        let result = self
+            .execute(
+                "SELECT id FROM lix_file WHERE path = $1",
+                &[Value::Text(path.into())],
+            )
+            .await?;
+        let Some(row) = result.rows().first() else {
+            return Ok(());
+        };
+        let Some(Value::Text(file_id)) = result.get(row, "id") else {
+            return Err(LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                "file authorization lookup returned an invalid id",
+            ));
+        };
+        match self.authorize("view", "File", file_id).await? {
+            AuthorizationDecision::Inactive | AuthorizationDecision::Allow => Ok(()),
+            AuthorizationDecision::Deny => Err(LixError::new(
+                LixError::CODE_PERMISSION_DENIED,
+                "Cedar denied access to the requested file",
+            )
+            .with_details(serde_json::json!({
+                "principal": self.active_account_id(),
+                "action": "view",
+                "resource_type": "File",
+                "resource_id": file_id,
+            }))),
+        }
+    }
+
+    async fn load_authorization_documents(
+        &self,
+    ) -> Result<Option<OwnedAuthorizationDocuments>, LixError> {
+        match self
+            .execute(LOAD_PROJECTED_AUTHORIZATION_DOCUMENTS_SQL, &[])
+            .await
+        {
+            Ok(result) => match documents_from_projection(&result)? {
+                Some(documents) => Ok(Some(documents)),
+                // Installing a plugin and observing its schema must never turn
+                // a repository with canonical policy files into fail-open.
+                // Projection rebuilds are asynchronous with respect to some
+                // installation paths, so consult the files when no projected
+                // schema is available yet.
+                None => {
+                    let result = self.execute(LOAD_AUTHORIZATION_DOCUMENTS_SQL, &[]).await?;
+                    documents_from_files(&result)
+                }
+            },
+            Err(error) if error.code == LixError::CODE_TABLE_NOT_FOUND => {
+                let result = self.execute(LOAD_AUTHORIZATION_DOCUMENTS_SQL, &[]).await?;
+                documents_from_files(&result)
+            }
+            Err(error) => Err(error),
+        }
+    }
+}
+
+fn documents_from_projection(
+    result: &super::ExecuteResult,
+) -> Result<Option<OwnedAuthorizationDocuments>, LixError> {
+    let mut schema = None;
+    let mut entities = None;
+    let mut policy_sources = Vec::new();
+    for row in result.rows() {
+        let Some(Value::Text(kind)) = result.get(row, "kind") else {
+            return Err(invalid_document(
+                "Cedar projection returned an invalid kind",
+            ));
+        };
+        let Some(Value::Text(path)) = result.get(row, "path") else {
+            return Err(invalid_document(
+                "Cedar projection returned an invalid path",
+            ));
+        };
+        let Some(Value::Text(source)) = result.get(row, "source") else {
+            return Err(invalid_document(format!(
+                "Cedar projection for {path} returned invalid source"
+            )));
+        };
+        match kind.as_str() {
+            "schema" => schema = Some(source.clone()),
+            "entities" => entities = Some(source.clone()),
+            "policy" => policy_sources.push((path.clone(), source.clone())),
+            _ => {
+                return Err(invalid_document(format!(
+                    "Cedar projection for {path} returned unknown kind '{kind}'"
+                )));
+            }
+        }
+    }
+    assemble_documents(schema, entities, policy_sources)
+}
+
+fn documents_from_files(
+    result: &super::ExecuteResult,
+) -> Result<Option<OwnedAuthorizationDocuments>, LixError> {
+    let mut schema = None;
+    let mut entities = None;
+    let mut policy_sources = Vec::new();
+    for row in result.rows() {
+        let Some(Value::Text(path)) = result.get(row, "path") else {
+            return Err(invalid_document(
+                "authorization query returned an invalid path",
+            ));
+        };
+        let source = match result.get(row, "content") {
+            Some(Value::Blob(content)) => std::str::from_utf8(content.as_ref())
+                .map_err(|error| invalid_document(format!("{path} is not UTF-8: {error}")))?
+                .to_owned(),
+            Some(Value::Null) => String::new(),
+            _ => {
+                return Err(invalid_document(format!(
+                    "{path} did not contain file bytes"
+                )));
+            }
+        };
+        if path == SCHEMA_PATH {
+            schema = Some(source);
+        } else if path == ENTITIES_PATH {
+            entities = Some(source);
+        } else if path.starts_with(PERMISSIONS_DIRECTORY) && path.ends_with(".cedar") {
+            policy_sources.push((path.clone(), source));
+        }
+    }
+    assemble_documents(schema, entities, policy_sources)
+}
+
+fn assemble_documents(
+    schema: Option<String>,
+    entities: Option<String>,
+    mut policy_sources: Vec<(String, String)>,
+) -> Result<Option<OwnedAuthorizationDocuments>, LixError> {
+    let Some(schema) = schema else {
+        return Ok(None);
+    };
+    policy_sources.sort_unstable_by(|left, right| left.0.cmp(&right.0));
+    let mut policies = String::new();
+    for (path, source) in policy_sources {
+        policies.push_str("// source: ");
+        policies.push_str(&path);
+        policies.push('\n');
+        policies.push_str(&source);
+        policies.push('\n');
+    }
+    Ok(Some(OwnedAuthorizationDocuments {
+        schema,
+        policies,
+        entities,
+    }))
+}
+
+#[derive(Debug)]
+struct OwnedAuthorizationDocuments {
+    schema: String,
+    policies: String,
+    entities: Option<String>,
+}
+
+fn invalid_document(message: impl Into<String>) -> LixError {
+    LixError::new(LixError::CODE_INVALID_PERMISSION_POLICY, message)
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{ANONYMOUS_ACCOUNT_ID, LixError, Value, open_lix};
+
+    const PUBLIC_ID: &str = "01920000-0000-7000-8000-000000000001";
+    const PRIVATE_ID: &str = "01920000-0000-7000-8000-000000000002";
+
+    #[tokio::test]
+    async fn exact_file_reads_are_private_by_default_and_policy_driven() {
+        let lix = open_lix().await.unwrap();
+        lix.execute(
+            "INSERT INTO lix_file (id, path, content) VALUES \
+             ($1, '/public.md', CAST('public' AS BYTEA)), \
+             ($2, '/private.md', CAST('private' AS BYTEA)), \
+             ($3, '/.lix/permissions/schema.cedarschema', CAST($4 AS BYTEA)), \
+             ($5, '/.lix/permissions/publications.cedar', CAST($6 AS BYTEA))",
+            &[
+                Value::Text(PUBLIC_ID.into()),
+                Value::Text(PRIVATE_ID.into()),
+                Value::Text("01920000-0000-7000-8000-000000000003".into()),
+                Value::Text(schema().into()),
+                Value::Text("01920000-0000-7000-8000-000000000004".into()),
+                Value::Text(publication(PUBLIC_ID).into()),
+            ],
+        )
+        .await
+        .unwrap();
+
+        let public = lix.read_file_content("/public.md", None).await.unwrap();
+        assert_eq!(public.unwrap().into_content().as_ref(), b"public");
+
+        let denied = lix
+            .read_file_content("/private.md", None)
+            .await
+            .unwrap_err();
+        assert_eq!(denied.code, LixError::CODE_PERMISSION_DENIED);
+
+        lix.execute(
+            "UPDATE lix_file SET content = CAST('' AS BYTEA) \
+             WHERE path = '/.lix/permissions/publications.cedar'",
+            &[],
+        )
+        .await
+        .unwrap();
+        let denied = lix.read_file_content("/public.md", None).await.unwrap_err();
+        assert_eq!(denied.code, LixError::CODE_PERMISSION_DENIED);
+    }
+
+    fn schema() -> &'static str {
+        r#"
+            entity Account;
+            entity File;
+            entity Repository;
+            action "view" appliesTo { principal: Account, resource: [File, Repository] };
+            action "share" appliesTo { principal: Account, resource: File };
+            action "managePolicies" appliesTo { principal: Account, resource: Repository };
+            action "executeSql" appliesTo { principal: Account, resource: Repository };
+        "#
+    }
+
+    fn publication(file_id: &str) -> String {
+        format!(
+            r#"permit (
+                principal == Account::"{ANONYMOUS_ACCOUNT_ID}",
+                action == Action::"view",
+                resource == File::"{file_id}"
+            );"#
+        )
+    }
+}

--- a/packages/lix/src/session/execute.rs
+++ b/packages/lix/src/session/execute.rs
@@ -1178,6 +1178,14 @@ where
         // SQL remains available for callers that intentionally need broader
         // `lix_file` predicates or legacy path shapes.
         crate::common::LixPath::try_from_file_path(&path)?;
+        // SAFETY: `require_file_view` only performs ordinary session SQL reads
+        // and Cedar evaluation. Both own their values across suspension; the
+        // higher-ranked storage read lifetime is the same compiler limitation
+        // already covered by this module's send-future proofs.
+        Box::pin(unsafe {
+            super::AssumeSendFuture::new(self.require_file_view(&path))
+        })
+        .await?;
 
         let paths = BTreeSet::from([path]);
         let _operation_guard = self.begin_waitable_session_operation().await?;

--- a/packages/lix/src/session/mod.rs
+++ b/packages/lix/src/session/mod.rs
@@ -15,6 +15,7 @@ use std::pin::Pin;
 use std::task::{Context, Poll};
 
 mod checkpoint;
+mod authorization;
 mod context;
 mod create_branch;
 mod execute;

--- a/packages/lix/src/transaction/commit.rs
+++ b/packages/lix/src/transaction/commit.rs
@@ -206,6 +206,7 @@ pub(crate) async fn commit_prepared_writes_with_parent_heads(
     branch_checkpoint_bridges: &BTreeMap<String, crate::gc::CheckpointRecoveryRef>,
     prepared_writes: PreparedWriteSet,
 ) -> Result<MaterializedCommit, LixError> {
+    validate_prepared_permission_grant_rows(&prepared_writes)?;
     Box::pin(validate_active_account_and_account_rows(
         read,
         &prepared_writes,
@@ -3375,6 +3376,7 @@ async fn build_lifecycle_tracked_snapshots(
 }
 
 const ACCOUNT_SCHEMA_KEY: &str = "lix_account";
+const PERMISSION_GRANT_SCHEMA_KEY: &str = "lix_permission_grant";
 const FILE_DESCRIPTOR_SCHEMA_KEY: &str = "lix_file_descriptor";
 const DIRECTORY_DESCRIPTOR_SCHEMA_KEY: &str = "lix_directory_descriptor";
 
@@ -6775,6 +6777,149 @@ fn validate_prepared_account_rows(prepared_writes: &PreparedWriteSet) -> Result<
         }
     }
     Ok(())
+}
+
+/// Permission grants are repository-wide facts. They are tracked on the
+/// global branch so every working branch observes one authorization boundary
+/// and permission edits never become ordinary branch merge inputs.
+fn validate_prepared_permission_grant_rows(
+    prepared_writes: &PreparedWriteSet,
+) -> Result<(), LixError> {
+    for row in prepared_writes
+        .state_rows
+        .iter()
+        .filter(|row| row.schema_key.as_str() == PERMISSION_GRANT_SCHEMA_KEY)
+    {
+        if row.branch_id.as_str() != crate::GLOBAL_BRANCH_ID
+            || !row.global
+            || row.untracked
+            || row.file_id.is_some()
+        {
+            return Err(invalid_permission_grant(
+                "lix_permission_grant rows must be tracked global rows on the global branch",
+            ));
+        }
+
+        let Some(snapshot) = row.snapshot else {
+            continue;
+        };
+        let value: serde_json::Value =
+            serde_json::from_str(snapshot.normalized()).map_err(|error| {
+                LixError::new(
+                    LixError::CODE_INTERNAL_ERROR,
+                    format!("lix_permission_grant row has invalid JSON: {error}"),
+                )
+            })?;
+        validate_permission_grant_value(&value)?;
+    }
+    Ok(())
+}
+
+fn validate_permission_grant_value(value: &serde_json::Value) -> Result<(), LixError> {
+    let principal_type = required_permission_grant_text(value, "principal_type")?;
+    let principal_id = optional_permission_grant_text(value, "principal_id")?;
+    match principal_type {
+        "anonymous" if principal_id.is_some() => {
+            return Err(invalid_permission_grant(
+                "anonymous permission grants must not set principal_id",
+            ));
+        }
+        "account" | "group" if principal_id.is_none_or(str::is_empty) => {
+            return Err(invalid_permission_grant(format!(
+                "{principal_type} permission grants require principal_id"
+            )));
+        }
+        "account" => {
+            RowPk::uuid_from_canonical(principal_id.expect("account id checked above")).map_err(
+                |_| invalid_permission_grant("account principal_id must be a canonical UUID"),
+            )?;
+        }
+        "group" | "anonymous" => {}
+        _ => {
+            return Err(invalid_permission_grant(format!(
+                "unsupported permission principal_type '{principal_type}'"
+            )));
+        }
+    }
+
+    let access_level = required_permission_grant_text(value, "access_level")?;
+    if !matches!(
+        access_level,
+        "viewer" | "commenter" | "contributor" | "editor" | "manager"
+    ) {
+        return Err(invalid_permission_grant(format!(
+            "unsupported permission access_level '{access_level}'"
+        )));
+    }
+
+    let resource_type = required_permission_grant_text(value, "resource_type")?;
+    let directory_id = optional_permission_grant_text(value, "directory_id")?;
+    let file_id = optional_permission_grant_text(value, "file_id")?;
+    let schema_key = optional_permission_grant_text(value, "schema_key")?;
+    let row_pk = value.get("row_pk").filter(|value| !value.is_null());
+
+    let valid_shape = match resource_type {
+        "repository" => {
+            directory_id.is_none() && file_id.is_none() && schema_key.is_none() && row_pk.is_none()
+        }
+        "directory" => {
+            directory_id.is_some() && file_id.is_none() && schema_key.is_none() && row_pk.is_none()
+        }
+        "file" => {
+            directory_id.is_none() && file_id.is_some() && schema_key.is_none() && row_pk.is_none()
+        }
+        "table" => {
+            directory_id.is_none()
+                && file_id.is_some()
+                && schema_key.is_some_and(|key| !key.is_empty())
+                && row_pk.is_none()
+        }
+        "row" => {
+            directory_id.is_none()
+                && file_id.is_some()
+                && schema_key.is_some_and(|key| !key.is_empty())
+                && row_pk.is_some_and(|pk| {
+                    pk.as_array().is_some_and(|components| !components.is_empty())
+                })
+        }
+        _ => {
+            return Err(invalid_permission_grant(format!(
+                "unsupported permission resource_type '{resource_type}'"
+            )));
+        }
+    };
+    if !valid_shape {
+        return Err(invalid_permission_grant(format!(
+            "permission resource columns do not match resource_type '{resource_type}'"
+        )));
+    }
+    Ok(())
+}
+
+fn required_permission_grant_text<'a>(
+    value: &'a serde_json::Value,
+    field: &str,
+) -> Result<&'a str, LixError> {
+    optional_permission_grant_text(value, field)?.ok_or_else(|| {
+        invalid_permission_grant(format!("permission grant requires {field}"))
+    })
+}
+
+fn optional_permission_grant_text<'a>(
+    value: &'a serde_json::Value,
+    field: &str,
+) -> Result<Option<&'a str>, LixError> {
+    match value.get(field) {
+        None | Some(serde_json::Value::Null) => Ok(None),
+        Some(serde_json::Value::String(value)) => Ok(Some(value)),
+        Some(_) => Err(invalid_permission_grant(format!(
+            "permission grant {field} must be text or null"
+        ))),
+    }
+}
+
+fn invalid_permission_grant(message: impl Into<String>) -> LixError {
+    LixError::new(LixError::CODE_INVALID_PARAM, message)
 }
 
 async fn validate_account_deletions(

--- a/packages/lix/src/transaction/context.rs
+++ b/packages/lix/src/transaction/context.rs
@@ -6399,6 +6399,7 @@ where
                     catalog,
                     functions.clone(),
                     &mut default_timestamp,
+                    self.active_account_id == crate::SYSTEM_ACCOUNT_ID,
                 )?;
                 scalar_facts.push(plan_prepared_row_scalars(
                     rows.row(index),
@@ -6481,6 +6482,7 @@ where
                     row.snapshot.map(TransactionJson::value),
                     Domain::schema_catalog(row.schema_scope_branch_id().to_string(), row.untracked),
                     catalog,
+                    self.active_account_id == crate::SYSTEM_ACCOUNT_ID,
                 )?;
             }
             for &index in &row_indices {
@@ -6490,6 +6492,7 @@ where
                     catalog,
                     functions.clone(),
                     &mut default_timestamp,
+                    self.active_account_id == crate::SYSTEM_ACCOUNT_ID,
                 )?);
             }
             // Preserve the historical domain-by-domain provider/error order:

--- a/packages/lix/src/transaction/context.rs
+++ b/packages/lix/src/transaction/context.rs
@@ -6625,6 +6625,10 @@ where
                     &hot_state,
                 )
                 .with_staged_commit_ids(staged_commit_ids.clone());
+                if self.active_account_id == crate::SYSTEM_ACCOUNT_ID {
+                    validation_input =
+                        validation_input.with_reserved_builtin_registration();
+                }
                 if self.trust_filesystem_planner {
                     validation_input = validation_input.with_trusted_filesystem_planner();
                 }

--- a/packages/lix/src/transaction/normalization.rs
+++ b/packages/lix/src/transaction/normalization.rs
@@ -52,6 +52,7 @@ pub(crate) fn normalize_raw_write_row_in_place(
     schema_catalog: &mut TransactionCatalog,
     functions: FunctionProviderHandle,
     default_timestamp: &mut Option<crate::common::LixTimestamp>,
+    allow_reserved_builtin_registration: bool,
 ) -> Result<NormalizedRowFacts, LixError> {
     populate_registered_schema_snapshot(rows, row_index)?;
     let row = rows.row(row_index);
@@ -218,6 +219,7 @@ pub(crate) fn normalize_raw_write_row_in_place(
             normalized_snapshot.as_ref().map(TransactionJson::value),
             schema_domain,
             schema_catalog,
+            allow_reserved_builtin_registration,
         )?;
     }
 
@@ -486,6 +488,7 @@ pub(crate) fn remember_pending_registered_schema(
     snapshot: Option<&JsonValue>,
     domain: Domain,
     schema_catalog: &mut TransactionCatalog,
+    allow_reserved_builtin_registration: bool,
 ) -> Result<(), LixError> {
     let Some(snapshot) = snapshot else {
         return Err(LixError::new(
@@ -509,10 +512,27 @@ pub(crate) fn remember_pending_registered_schema(
         validate_lix_schema(registered_schema_definition, snapshot)?;
     }
     let (key, schema) = schema_from_registered_snapshot(snapshot)?;
-    reject_reserved_schema_namespace(&key)?;
+    if allow_reserved_builtin_registration {
+        validate_reserved_builtin_registration(&key, &schema)?;
+    } else {
+        reject_reserved_schema_namespace(&key)?;
+    }
     validate_lix_schema_definition(&schema)?;
     schema_catalog.insert_schema_for_domain(domain, key, schema)?;
     Ok(())
+}
+
+fn validate_reserved_builtin_registration(
+    key: &SchemaKey,
+    schema: &JsonValue,
+) -> Result<(), LixError> {
+    if !PublicCatalog::runtime_schema_key_uses_reserved_namespace(&key.schema_key) {
+        return Ok(());
+    }
+    if crate::schema::seed_schema_definition(&key.schema_key) == Some(schema) {
+        return Ok(());
+    }
+    reject_reserved_schema_namespace(key)
 }
 
 pub(crate) fn reject_reserved_schema_namespace(key: &SchemaKey) -> Result<(), LixError> {
@@ -903,6 +923,39 @@ mod tests {
     }
 
     #[test]
+    fn normalization_allows_the_system_to_register_an_exact_built_in_schema() {
+        let mut catalog = catalog_with(vec![
+            seed_schema_definition(REGISTERED_SCHEMA_KEY)
+                .expect("registered schema builtin")
+                .clone(),
+        ]);
+        let schema = seed_schema_definition("lix_permission_grant")
+            .expect("permission grant builtin")
+            .clone();
+        let registered = TransactionWriteRow {
+            row_pk: None,
+            schema_key: REGISTERED_SCHEMA_KEY.into(),
+            snapshot: Some(transaction_json(json!({ "value": schema }))),
+            ..base_stage_row()
+        };
+        let mut rows = RawWriteBatch::with_capacity(1);
+        rows.push(registered);
+        let mut default_timestamp = None;
+
+        normalize_raw_write_row_in_place(
+            &mut rows,
+            0,
+            &mut catalog,
+            functions(),
+            &mut default_timestamp,
+            true,
+        )
+        .expect("the system may register the shipped built-in definition verbatim");
+
+        assert!(catalog.snapshot().contains("lix_permission_grant"));
+    }
+
+    #[test]
     fn normalization_allows_application_owned_schema_key() {
         let mut catalog = catalog_with(vec![
             seed_schema_definition(REGISTERED_SCHEMA_KEY)
@@ -1118,6 +1171,7 @@ mod tests {
             catalog,
             functions,
             &mut default_timestamp,
+            false,
         )?;
         Ok(rows.into_rows().pop().expect("single normalized test row"))
     }

--- a/packages/lix/src/transaction/normalization.rs
+++ b/packages/lix/src/transaction/normalization.rs
@@ -522,7 +522,7 @@ pub(crate) fn remember_pending_registered_schema(
     Ok(())
 }
 
-fn validate_reserved_builtin_registration(
+pub(crate) fn validate_reserved_builtin_registration(
     key: &SchemaKey,
     schema: &JsonValue,
 ) -> Result<(), LixError> {

--- a/packages/lix/src/transaction/validation.rs
+++ b/packages/lix/src/transaction/validation.rs
@@ -38,7 +38,9 @@ use crate::schema::{SchemaKey, validate_lix_schema, validate_lix_schema_definiti
 use crate::schema::{
     format_lix_schema_validation_errors, schema_from_registered_snapshot, validate_schema_amendment,
 };
-use crate::transaction::normalization::reject_reserved_schema_namespace;
+use crate::transaction::normalization::{
+    reject_reserved_schema_namespace, validate_reserved_builtin_registration,
+};
 use crate::transaction::staging::duplicate_insert_identity_message;
 use crate::transaction::staging::{
     PreparedInsertRef, PreparedValidationRow, PreparedWriteSet, PreparedWriteValidationSet,
@@ -67,6 +69,7 @@ pub(crate) struct TransactionValidationInput<'a> {
     hot_state: &'a dyn HotStateReader,
     staged_commit_ids: BTreeSet<CommitId>,
     trust_filesystem_planner: bool,
+    allow_reserved_builtin_registration: bool,
 }
 
 impl<'a> TransactionValidationInput<'a> {
@@ -81,6 +84,7 @@ impl<'a> TransactionValidationInput<'a> {
             hot_state,
             staged_commit_ids: BTreeSet::new(),
             trust_filesystem_planner: false,
+            allow_reserved_builtin_registration: false,
         }
     }
 
@@ -94,6 +98,11 @@ impl<'a> TransactionValidationInput<'a> {
     /// validation because their planner snapshot can become stale.
     pub(crate) fn with_trusted_filesystem_planner(mut self) -> Self {
         self.trust_filesystem_planner = true;
+        self
+    }
+
+    pub(crate) fn with_reserved_builtin_registration(mut self) -> Self {
+        self.allow_reserved_builtin_registration = true;
         self
     }
 
@@ -858,8 +867,12 @@ async fn validate_registered_schema_identity_is_canonical(
         let pending_snapshot = pending_row
             .snapshot_json()
             .expect("pending registered schema row has snapshot_content");
-        let (key, _) = schema_from_registered_snapshot(pending_snapshot)?;
-        reject_reserved_schema_namespace(&key)?;
+        let (key, schema) = schema_from_registered_snapshot(pending_snapshot)?;
+        if input.allow_reserved_builtin_registration {
+            validate_reserved_builtin_registration(&key, &schema)?;
+        } else {
+            reject_reserved_schema_namespace(&key)?;
+        }
 
         let committed_rows = load_committed_constraint_rows(
             input.hot_state,

--- a/packages/lix/tests/integration/sql.rs
+++ b/packages/lix/tests/integration/sql.rs
@@ -107,6 +107,7 @@ mod lix_file;
 mod lix_file_history;
 mod lix_json;
 mod lix_key_value;
+mod lix_permission_grant;
 mod lix_registered_schema;
 mod metadata;
 mod read_only;

--- a/packages/lix/tests/integration/sql/lix_permission_grant.rs
+++ b/packages/lix/tests/integration/sql/lix_permission_grant.rs
@@ -1,0 +1,149 @@
+use lix::{CreateBranchOptions, LixError, Value};
+
+const GRANT_ID: &str = "01940000-0000-7000-8000-000000000001";
+const DRAFT_ID: &str = "01940000-0000-7000-8000-000000000002";
+
+simulation_test!(permission_grants_are_tracked_global_and_visible_from_every_branch, |sim| async move {
+    let engine = sim.boot_engine().await;
+    let main = sim.wrap_session(
+        engine.open_session().await.expect("main session should open"),
+        &engine,
+    );
+
+    main.execute(
+        "INSERT INTO lix_permission_grant \
+         (id, principal_type, principal_id, access_level, resource_type, lixcol_global) \
+         VALUES ($1, 'account', $2, 'manager', 'repository', true)",
+        &[
+            Value::Text(GRANT_ID.to_string()),
+            Value::Text(lix::SYSTEM_ACCOUNT_ID.to_string()),
+        ],
+    )
+    .await
+    .expect("tracked global permission grant should insert");
+
+    main.create_branch(CreateBranchOptions {
+        id: Some(DRAFT_ID.to_string()),
+        name: "Permission visibility draft".to_string(),
+        from_commit_id: None,
+    })
+    .await
+    .expect("draft branch should be created");
+    let draft = sim.wrap_session(
+        engine
+            .open_session_at(DRAFT_ID)
+            .await
+            .expect("draft session should open"),
+        &engine,
+    );
+
+    for session in [&main, &draft] {
+        let result = session
+            .execute(
+                "SELECT access_level, lixcol_global, lixcol_untracked \
+                 FROM lix_permission_grant WHERE id = $1",
+                &[Value::Text(GRANT_ID.to_string())],
+            )
+            .await
+            .expect("permission grant should be inherited by every branch");
+        assert_eq!(
+            result.rows()[0].values(),
+            &[
+                Value::Text("manager".to_string()),
+                Value::Boolean(true),
+                Value::Boolean(false),
+            ]
+        );
+    }
+
+    let physical = main
+        .execute(
+            "SELECT lixcol_branch_id FROM lix_permission_grant_by_branch \
+             WHERE id = $1 AND lixcol_branch_id = $2 AND lixcol_global = true",
+            &[
+                Value::Text(GRANT_ID.to_string()),
+                Value::Text(lix::GLOBAL_BRANCH_ID.to_string()),
+            ],
+        )
+        .await
+        .expect("permission grant home branch should be readable");
+    assert_eq!(
+        physical.rows()[0].values(),
+        &[Value::Text(lix::GLOBAL_BRANCH_ID.to_string())]
+    );
+});
+
+simulation_test!(permission_grants_reject_non_global_untracked_and_malformed_rows, |sim| async move {
+    let engine = sim.boot_engine().await;
+    let session = sim.wrap_session(
+        engine.open_session().await.expect("main session should open"),
+        &engine,
+    );
+
+    let local = session
+        .execute(
+            "INSERT INTO lix_permission_grant \
+             (id, principal_type, principal_id, access_level, resource_type) \
+             VALUES ('01940000-0000-7000-8000-000000000010', 'account', $1, 'viewer', 'repository')",
+            &[Value::Text(lix::SYSTEM_ACCOUNT_ID.to_string())],
+        )
+        .await
+        .expect_err("branch-local permission grant must fail");
+    assert_eq!(local.code, LixError::CODE_INVALID_PARAM);
+    assert!(local.message.contains("tracked global rows"));
+
+    let untracked = session
+        .execute(
+            "INSERT INTO lix_permission_grant \
+             (id, principal_type, principal_id, access_level, resource_type, lixcol_global, lixcol_untracked) \
+             VALUES ('01940000-0000-7000-8000-000000000011', 'account', $1, 'viewer', 'repository', true, true)",
+            &[Value::Text(lix::SYSTEM_ACCOUNT_ID.to_string())],
+        )
+        .await
+        .expect_err("untracked permission grant must fail");
+    assert_eq!(untracked.code, LixError::CODE_INVALID_PARAM);
+    assert!(untracked.message.contains("tracked global rows"));
+
+    let malformed = session
+        .execute(
+            "INSERT INTO lix_permission_grant \
+             (id, principal_type, access_level, resource_type, lixcol_global) \
+             VALUES ('01940000-0000-7000-8000-000000000012', 'anonymous', 'viewer', 'file', true)",
+            &[],
+        )
+        .await
+        .expect_err("file grant without file_id must fail");
+    assert_eq!(malformed.code, LixError::CODE_INVALID_PARAM);
+    assert!(malformed.message.contains("resource columns"));
+});
+
+simulation_test!(permission_grants_model_repository_directory_file_table_and_row, |sim| async move {
+    let engine = sim.boot_engine().await;
+    let session = sim.wrap_session(
+        engine.open_session().await.expect("main session should open"),
+        &engine,
+    );
+
+    session
+        .execute(
+            "INSERT INTO lix_permission_grant \
+             (id, principal_type, principal_id, access_level, resource_type, directory_id, file_id, schema_key, row_pk, lixcol_global) VALUES \
+             ('01940000-0000-7000-8000-000000000020', 'account', $1, 'manager', 'repository', NULL, NULL, NULL, NULL, true), \
+             ('01940000-0000-7000-8000-000000000021', 'group', 'sales', 'contributor', 'directory', '01940000-0000-7000-8000-000000000030', NULL, NULL, NULL, true), \
+             ('01940000-0000-7000-8000-000000000022', 'anonymous', NULL, 'viewer', 'file', NULL, '01940000-0000-7000-8000-000000000031', NULL, NULL, true), \
+             ('01940000-0000-7000-8000-000000000023', 'group', 'agency', 'viewer', 'table', NULL, '01940000-0000-7000-8000-000000000031', 'lead', NULL, true), \
+             ('01940000-0000-7000-8000-000000000024', 'account', $1, 'commenter', 'row', NULL, '01940000-0000-7000-8000-000000000031', 'lead', CAST('[\"lead-123\"]' AS JSONB), true)",
+            &[Value::Text(lix::SYSTEM_ACCOUNT_ID.to_string())],
+        )
+        .await
+        .expect("all canonical permission resource shapes should insert");
+
+    let result = session
+        .execute(
+            "SELECT resource_type FROM lix_permission_grant ORDER BY resource_type",
+            &[],
+        )
+        .await
+        .expect("permission resource shapes should read");
+    assert_eq!(result.len(), 5);
+});

--- a/packages/lix/tests/integration/sql/lix_registered_schema.rs
+++ b/packages/lix/tests/integration/sql/lix_registered_schema.rs
@@ -410,6 +410,7 @@ simulation_test!(
             "lix_directory_descriptor",
             "lix_file_descriptor",
             "lix_key_value",
+            "lix_permission_grant",
             "lix_registered_schema",
         ] {
             assert!(

--- a/plugins/cedar/Cargo.toml
+++ b/plugins/cedar/Cargo.toml
@@ -1,0 +1,27 @@
+[package]
+name = "plugin_cedar"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+description = "Cedar permission-file projection for Lix"
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
+documentation.workspace = true
+readme = "README.md"
+keywords.workspace = true
+categories.workspace = true
+rust-version.workspace = true
+publish = false
+
+[lints]
+workspace = true
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+cedar-policy = { version = "=4.2.2", default-features = false }
+lix = { workspace = true, default-features = true }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"

--- a/plugins/cedar/README.md
+++ b/plugins/cedar/README.md
@@ -14,10 +14,28 @@ session's active account with `Action::"view"` and the file's stable
 `File::"<lix_file.id>"` identity. Cedar's default deny therefore keeps every
 other file private. Renaming a file does not invalidate a publication.
 
-The projection does not use a `lix_*` key because that namespace is reserved
-for trusted core schemas. Promoting this prototype to a built-in
-`lix_cedar_*` surface requires either a core-owned projection or an explicit
-trusted-plugin registration path.
+`lix_permission_grant` is the core-owned standard sharing model. Every grant is
+a tracked global row on `GLOBAL_BRANCH_ID`, inherited into every working
+branch. Its principal is an account, group, or anonymous; its access level is
+viewer, commenter, contributor, editor, or manager; and its resource is one of
+repository, directory, file, table, or row. File-scoped database identities are
+represented as `Table(schema_key, file_id)` and
+`Row(schema_key, file_id, row_pk)`.
+
+The generic authorization API uses compact JSON tuples as canonical Cedar
+entity IDs: `[schema_key,file_id]` for `Table` and
+`[schema_key,file_id,row_pk]` for `Row`. The `row_pk` component is itself the
+canonical Lix primary-key tuple.
+
+The default adapter turns applicable grants into Cedar permits. Repository
+policy files remain part of the same policy set, so custom permits can add
+company-specific behavior and Cedar `forbid` policies override a standard
+grant. A repository can also ignore the standard model by storing no grant
+rows and expressing its authorization entirely in Cedar files.
+
+The source projection deliberately remains `cedar_permission_source`, not a
+`lix_*` table: that namespace is reserved for trusted core schemas, while the
+projection is plugin-owned and read-only.
 
 ## Prototype boundaries
 
@@ -29,7 +47,7 @@ trusted-plugin registration path.
   representation through Cargo feature unification; it remains isolated in
   this WASI plugin.
 - Policy loading and the protected file read are not yet one storage snapshot.
-- Policy edits are not yet guarded by `Action::"managePolicies"`.
+- Grant and policy edits are not yet guarded by `Action::"managePolicies"`.
 - The plugin validates individual source files. Core parses the complete policy
   set before using it, but cross-file static validation against the schema is
   not implemented in this prototype.

--- a/plugins/cedar/README.md
+++ b/plugins/cedar/README.md
@@ -1,0 +1,35 @@
+# Cedar permission prototype
+
+This plugin projects canonical permission files under `/.lix/permissions/`
+into the read-only `cedar_permission_source` row surface. Files remain the only
+editable source of truth:
+
+- `schema.cedarschema` defines the repository's entity and action model.
+- Any `*.cedar` files form one policy set.
+- Optional `entities.cedar.json` defines relationships such as company teams.
+
+Lix core consumes the projection when the plugin is installed and falls back
+to the same files directly when it is not. Structured file reads authorize the
+session's active account with `Action::"view"` and the file's stable
+`File::"<lix_file.id>"` identity. Cedar's default deny therefore keeps every
+other file private. Renaming a file does not invalidate a publication.
+
+The projection does not use a `lix_*` key because that namespace is reserved
+for trusted core schemas. Promoting this prototype to a built-in
+`lix_cedar_*` surface requires either a core-owned projection or an explicit
+trusted-plugin registration path.
+
+## Prototype boundaries
+
+- Anonymous SQL is disabled by the Lixray integration; arbitrary SQL is not
+  policy-filtered.
+- Policy compilation is not cached yet.
+- Core links only `cedar-policy-core` 4.2.2. The full Cedar validator enables
+  `serde_json/preserve_order` transitively, changing Lix's canonical JSON
+  representation through Cargo feature unification; it remains isolated in
+  this WASI plugin.
+- Policy loading and the protected file read are not yet one storage snapshot.
+- Policy edits are not yet guarded by `Action::"managePolicies"`.
+- The plugin validates individual source files. Core parses the complete policy
+  set before using it, but cross-file static validation against the schema is
+  not implemented in this prototype.

--- a/plugins/cedar/manifest.json
+++ b/plugins/cedar/manifest.json
@@ -1,0 +1,11 @@
+{
+  "key": "plugin_cedar",
+  "file_match": {
+    "path_glob": "/.lix/permissions/*",
+    "content": "text"
+  },
+  "entry": "plugin.wasm",
+  "schemas": [
+    "schema/cedar_permission_source.json"
+  ]
+}

--- a/plugins/cedar/schema/cedar_permission_source.json
+++ b/plugins/cedar/schema/cedar_permission_source.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "https://lix.dev/schema-v1.json",
+  "key": "cedar_permission_source",
+  "description": "Read-only projection of one canonical Cedar permission file.",
+  "columns": [
+    {
+      "name": "id",
+      "type": "uuid",
+      "nullable": false
+    },
+    {
+      "name": "kind",
+      "type": "text",
+      "nullable": false
+    },
+    {
+      "name": "path",
+      "type": "text",
+      "nullable": false
+    },
+    {
+      "name": "source",
+      "type": "text",
+      "nullable": false
+    }
+  ],
+  "primary_key": [
+    "id"
+  ]
+}

--- a/plugins/cedar/src/lib.rs
+++ b/plugins/cedar/src/lib.rs
@@ -1,0 +1,151 @@
+//! Canonical Cedar files to transparent, read-only Lix rows.
+#![cfg_attr(
+    not(all(target_arch = "wasm32", target_os = "wasi", target_env = "p2")),
+    allow(dead_code)
+)]
+
+use cedar_policy::{Entities, PolicySet, Schema};
+use lix::plugin as sdk;
+use serde::{Deserialize, Serialize};
+use std::str::FromStr;
+
+struct CedarPlugin;
+
+const SCHEMA_KEY: &str = "cedar_permission_source";
+
+#[derive(Debug, Deserialize, Serialize)]
+struct SourceRow {
+    id: String,
+    kind: String,
+    path: String,
+    source: String,
+}
+
+impl sdk::FileProjection for CedarPlugin {
+    fn parse(input: sdk::ParseInput<'_>, output: &mut sdk::RowOutput<'_, '_>) -> sdk::Result<()> {
+        emit_source(input.file_id, input.path, input.file.read_all()?, output)
+    }
+
+    fn parse_changes(
+        input: sdk::ParseChangesInput<'_>,
+        output: &mut sdk::RowChangeOutput<'_, '_>,
+    ) -> sdk::Result<()> {
+        let mut bytes = input.before.read_all()?;
+        let mut edits = input.file_edits.iter().cloned().collect::<Vec<_>>();
+        edits.sort_unstable_by_key(|edit| std::cmp::Reverse(edit.offset));
+        for edit in edits {
+            let start = usize::try_from(edit.offset)
+                .map_err(|_| sdk::Error::limit_exceeded("Cedar edit offset is too large"))?;
+            let delete_len = usize::try_from(edit.delete_len)
+                .map_err(|_| sdk::Error::limit_exceeded("Cedar edit length is too large"))?;
+            let end = start
+                .checked_add(delete_len)
+                .filter(|end| *end <= bytes.len())
+                .ok_or_else(|| sdk::Error::invalid_input("Cedar edit range is invalid"))?;
+            bytes.splice(start..end, edit.insert.iter().copied());
+        }
+        let mut replacement = output.replace_all_rows()?;
+        emit_source(input.file_id, input.after_path, bytes, &mut replacement)
+    }
+
+    fn serialize(
+        mut input: sdk::SerializeInput<'_>,
+        output: &mut sdk::FileOutput<'_, '_>,
+    ) -> sdk::Result<()> {
+        let row = input
+            .rows
+            .next()?
+            .ok_or_else(|| sdk::Error::invalid_input("Cedar source row is missing"))?;
+        if input.rows.next()?.is_some() {
+            return Err(sdk::Error::invalid_input(
+                "Cedar source projection must contain exactly one row",
+            ));
+        }
+        let source: SourceRow = serde_json::from_slice(&row.snapshot)
+            .map_err(|error| sdk::Error::invalid_input(format!("invalid Cedar row: {error}")))?;
+        validate_source(&source.path, &source.source)?;
+        output.write(source.source.as_bytes())
+    }
+
+    fn serialize_changes(
+        _input: sdk::SerializeChangesInput<'_>,
+        _output: &mut sdk::FileEditOutput<'_, '_>,
+    ) -> sdk::Result<()> {
+        Err(sdk::Error::invalid_input(
+            "cedar_permission_source rows are read-only; edit /.lix/permissions files",
+        ))
+    }
+}
+
+fn emit_source(
+    file_id: &str,
+    path: &str,
+    bytes: Vec<u8>,
+    output: &mut sdk::RowOutput<'_, '_>,
+) -> sdk::Result<()> {
+    let source = String::from_utf8(bytes).map_err(|error| {
+        sdk::Error::invalid_input(format!("Cedar source is not UTF-8: {error}"))
+    })?;
+    let kind = validate_source(path, &source)?;
+    let snapshot = serde_json::to_vec(&SourceRow {
+        id: file_id.to_owned(),
+        kind: kind.to_owned(),
+        path: path.to_owned(),
+        source,
+    })
+    .map_err(|error| sdk::Error::internal(format!("could not encode Cedar row: {error}")))?;
+    output.upsert(SCHEMA_KEY, &[file_id.to_owned()], &snapshot)
+}
+
+fn validate_source(path: &str, source: &str) -> sdk::Result<&'static str> {
+    if path.ends_with(".cedarschema") {
+        let (_schema, warnings) = Schema::from_cedarschema_str(source).map_err(|error| {
+            sdk::Error::invalid_input(format!("invalid Cedar schema in {path}: {error}"))
+        })?;
+        let _warnings = warnings.collect::<Vec<_>>();
+        Ok("schema")
+    } else if path.ends_with(".cedar.json") {
+        Entities::from_json_str(source, None).map_err(|error| {
+            sdk::Error::invalid_input(format!("invalid Cedar entities in {path}: {error}"))
+        })?;
+        Ok("entities")
+    } else if path.ends_with(".cedar") {
+        PolicySet::from_str(source).map_err(|error| {
+            sdk::Error::invalid_input(format!("invalid Cedar policies in {path}: {error}"))
+        })?;
+        Ok("policy")
+    } else {
+        Err(sdk::Error::invalid_input(format!(
+            "unsupported permission file '{path}'"
+        )))
+    }
+}
+
+lix::plugin::export_capabilities! {
+    file_projection: CedarPlugin,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::validate_source;
+
+    #[test]
+    fn validates_each_canonical_source_kind() {
+        assert_eq!(
+            validate_source("/.lix/permissions/schema.cedarschema", "entity Account;").unwrap(),
+            "schema"
+        );
+        assert_eq!(
+            validate_source(
+                "/.lix/permissions/publications.cedar",
+                "permit(principal, action, resource);"
+            )
+            .unwrap(),
+            "policy"
+        );
+        assert_eq!(
+            validate_source("/.lix/permissions/entities.cedar.json", "[]").unwrap(),
+            "entities"
+        );
+    }
+}


### PR DESCRIPTION
## Prototype goal

Prove whether repository-owned Cedar policies make file sharing maintainable while leaving the policy model extensible to each company.

## What this proves

- Canonical policy files live under `/.lix/permissions/` and are normal versioned Lix files.
- Standard sharing is stored in the built-in `lix_permission_grant` resource model.
- Grant rows are always tracked and global: their authoritative state lives on the global branch and is visible from every working branch.
- Grants cover repository, directory, file, table, and row resources, using stable IDs rather than paths.
- Default access levels (`viewer`, `commenter`, `contributor`, `editor`, `manager`) are translated into Cedar permits.
- Repository-authored Cedar remains authoritative and extensible; a custom `forbid` can override a standard grant.
- Exact structured file reads authorize the active account against the stable `lix_file.id`, so renames preserve grants.
- Cedar default-deny keeps unlisted files private.
- Existing repositories register newly shipped built-in schemas on open, in both the global catalog and every existing branch-local catalog.
- Reserved `lix_*` registrations remain protected: only the system account may install a definition, and only when it exactly matches a shipped built-in schema.
- A bundled WASI plugin validates Cedar source files and exposes transparent, read-only `cedar_permission_source` rows.

## Resource identity

- repository: the repository ID
- directory: stable `lix_directory_descriptor.id`
- file: stable `lix_file.id`
- table: canonical `[schema_key, file_id]`
- row: canonical `[schema_key, file_id, row_pk]`

Directory and file grants inherit to descendants. File grants cover the tables and rows owned by that file; table grants cover their rows.

## Maintainability findings

- Directly linking the full `cedar-policy` crate is not safe for Lix today: its validator enables `serde_json/preserve_order`, which changes Lix canonical JSON through Cargo feature unification.
- The engine links `cedar-policy-core = 4.2.2`; the full validator stays isolated in the WASI plugin.
- Browser SDK raw WASM: 54,652,323 B baseline -> 54,684,440 B prototype (+32,117 B, about 31 KiB).
- Cedar validator/projection WASI plugin: 5,321,730 B raw.

## Intentionally deferred

- Same-snapshot authorization + protected read
- Compiled policy/entity cache
- `managePolicies` enforcement and creator bootstrap/recovery
- Arbitrary SQL or row-level filtering
- Whole-policy-set static schema validation
- Share/unshare convenience API and UI

## Verification

- `cargo test -p lix-schema`
- `cargo test -p lix permission_grants --no-fail-fast`
- `cargo test -p lix authorization --no-fail-fast`
- system-session built-in upgrade regression test
- ordinary-session reserved namespace rejection test
- live existing-repository upgrade through Lixray
- browser JS SDK release WASM build and native binding build
