### PR TITLE
Remove public by-branch SQL surfaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## Unreleased
+
+### Breaking
+
+- Removed every public `*_by_branch` SQL relation and the public
+  `lixcol_branch_id` row-routing column. SQL relations now always use the
+  current session's active branch. Open another session to work with another
+  branch, use that session's `lix_working_diff` for uncheckpointed work, and
+  use `lix_diff(from_commit, to_commit)` for commit-to-commit comparison.
+  `lixcol_global` and the global branch remain supported.
+
 ## 0.12.3 - 2026-08-18
 
 ### Patch

--- a/docs/branching.md
+++ b/docs/branching.md
@@ -26,30 +26,25 @@ await lix.switchBranch({ branchId: main });
 
 Use names that fit your product, such as `"Marketing edit"`, `"Q3 pricing draft"`, or `"Agent task 123"`.
 
-## Read branches side by side
+## Work with branches concurrently
 
-Every registered schema `X` gets an `X_by_branch` table with a `lixcol_branch_id` column. Files and directories have the same pattern with `lix_file_by_branch` and `lix_directory_by_branch`.
+SQL relations always read and write the current session's active branch. Open
+another session to work with another branch without switching the primary one:
 
 ```ts
-const sideBySide = await lix.execute(
-  `SELECT b.name, s.title
-	 FROM acme_section_by_branch s
-	 JOIN lix_branch b ON b.id = s.lixcol_branch_id
-	 WHERE s.id = $1
-	   AND s.lixcol_branch_id IN ($2, $3)
-	 ORDER BY b.name`,
-  ["s1", main, draft.id],
-);
+const draftLix = await lix.openAnotherSession({ branchId: draft.id });
+
+const [mainRows, draftRows] = await Promise.all([
+  lix.execute("SELECT id, title FROM acme_section ORDER BY id"),
+  draftLix.execute("SELECT id, title FROM acme_section ORDER BY id"),
+]);
+
+await draftLix.close();
 ```
 
-Rules for `_by_branch` tables:
-
-- `SELECT` can read one or many branches.
-- `INSERT` must include `lixcol_branch_id`.
-- `UPDATE` and `DELETE` must filter by `lixcol_branch_id`.
-- The plain table reads and writes the active branch.
-
-Use `_by_branch` tables for review UIs and side-by-side views. See [SQL Surfaces](./surfaces.md) for the full table map.
+Each session has independent branch selection, transactions, observations, and
+lifecycle. Use `lix_diff(mainCommit, draftCommit)` when the desired result is a
+commit-to-commit change set rather than two current-state result sets.
 
 ## Preview a merge
 

--- a/docs/checkpoints.md
+++ b/docs/checkpoints.md
@@ -65,22 +65,18 @@ A runnable Rust version lives at
 
 ## SQL surfaces
 
-Checkpointing has eight read-only SQL surfaces:
+Checkpointing has five read-only SQL surfaces:
 
 | Surface | Scope | Columns |
 | :-- | :-- | :-- |
 | `lix_working_diff` | Active branch | `diff_id`, `row_pk`, `schema_key`, `file_id`, `diff_type`, `before_change_id`, `after_change_id` |
-| `lix_working_diff_by_branch` | All branches | The same columns plus `lixcol_branch_id` |
 | `lix_file_working_diff` | Active branch | `id`, `path`, `previous_path`, `change_kind` |
-| `lix_file_working_diff_by_branch` | All branches | The same columns plus `lixcol_branch_id` |
 | `lix_directory_working_diff` | Active branch | `id`, `path`, `previous_path`, `change_kind` |
-| `lix_directory_working_diff_by_branch` | All branches | The same columns plus `lixcol_branch_id` |
 | `lix_checkpoint` | Repository-global | `id`, `commit_id`, plus the standard `lixcol_*` row columns |
 | `lix_checkpoint_history()` | Revisions reachable from a commit | `id`, `commit_id`, plus the standard history `lixcol_*` columns including `lixcol_depth` |
 
-Use the unqualified surfaces for the common active-branch workflow. Use their
-`_by_branch` counterparts to inspect multiple branches in one query;
-`lixcol_branch_id` identifies the branch represented by each row.
+Working-diff relations are scoped to the current session. Open another session
+on another branch to inspect that branch without switching the primary session.
 
 `diff_type` is `added`, `modified`, or `removed`. Working diffs compare the
 current branch head with that branch's newest checkpoint. Creating a checkpoint

--- a/docs/diff-commands.md
+++ b/docs/diff-commands.md
@@ -47,9 +47,9 @@ await lix.close();
 
 ## Diff sources
 
-`lix_working_diff` compares the active branch head with its latest checkpoint.
-`lix_working_diff_by_branch` adds `lixcol_branch_id` for cross-branch
-inspection. Their columns are listed in the
+`lix_working_diff` compares the current session's active branch head with its
+latest checkpoint. Open another session on another branch to inspect that
+branch's working diff. Its columns are listed in the
 [checkpoint SQL surfaces table](./checkpoints.md#sql-surfaces).
 
 `lix_diff` compares any two commits. Both commit arguments are required:

--- a/docs/history.md
+++ b/docs/history.md
@@ -42,10 +42,9 @@ For the full surface grid, insert policies, and the
 
 ## Typed row history
 
-A registered application schema such as `acme_task` has two typed relations
-and one history function:
-`acme_task` for the active branch, `acme_task_by_branch` for explicit branch
-scope, and `acme_task_history()` for branch-reachable history.
+A registered application schema such as `acme_task` has one typed current-state
+relation and one history function: `acme_task` for the current session and
+`acme_task_history()` for branch-reachable revision history.
 
 History starts at the active branch head. The user columns are the same typed
 columns exposed by the base relation. Row history adds these system

--- a/docs/lix-for-ai-agents.md
+++ b/docs/lix-for-ai-agents.md
@@ -58,16 +58,20 @@ Use remote mode when the repository runs on a server. See
 
 ## Inspect the work
 
-To review the agent's work before the merge, read the task branch with the `_by_branch` table. Here `acme_task` is an example registered schema; every registered schema gets the same table set:
+To review the agent's work before the merge, open another session on the task
+branch and query the ordinary current-state relation:
 
-```sql
-SELECT id, title, status
-FROM acme_task_by_branch
-WHERE lixcol_branch_id = $1
-ORDER BY id;
+```ts
+const reviewLix = await lix.openAnotherSession({ branchId: task.id });
+const rows = await reviewLix.execute(
+  "SELECT id, title, status FROM acme_task ORDER BY id",
+);
+await reviewLix.close();
 ```
 
-Pass the task branch id as `$1`. `<schema>_history()` anchors to the active branch head. Run it from main and it will not show the agent's unmerged work.
+`<schema>_history()` is revision history anchored to a commit; it is not a
+current-state snapshot replacement. Use the branch-scoped session for current
+rows and `lix_diff()` for a commit-to-commit change set.
 
 Use `lix_registered_schema` to discover available schemas. Use `lix_change` for activity across the whole repository. It is not limited to the active branch.
 

--- a/docs/realtime-collaboration.md
+++ b/docs/realtime-collaboration.md
@@ -65,6 +65,22 @@ let bob = alice
     .await?;
 ```
 
+JavaScript applications use the equivalent `openAnotherSession()` method:
+
+```ts
+const main = await openLix();
+const review = await main.openAnotherSession({
+  branchId: reviewBranchId,
+  accountId: reviewerAccountId,
+});
+```
+
+The returned `Lix` has its own active branch, account, transactions,
+observations, and close lifecycle while sharing the repository storage. Closing
+either handle does not close the other. Remote sessions always use the server's
+authenticated account; `accountId` may only restate that identity in remote
+mode.
+
 ## Live editing and branches
 
 Use the same branch when collaborators should see each other's accepted writes
@@ -84,4 +100,3 @@ Branches and observations solve different problems:
 Lix synchronizes repository data. Cursor positions, selections, typing status,
 and user avatars are temporary presence data. Lix does not provide them. Send
 them through your application's real-time presence service.
-

--- a/docs/schemas.md
+++ b/docs/schemas.md
@@ -67,8 +67,8 @@ VALUES ('acme_section', '{
 }'::jsonb);
 ```
 
-`schema_key` must equal `value.key`. After registration, `acme_section`,
-`acme_section_by_branch`, and `acme_section_history()` expose the typed row.
+`schema_key` must equal `value.key`. After registration, `acme_section` and
+`acme_section_history()` expose the typed current row and its revision history.
 
 ## Contract
 

--- a/docs/surfaces.md
+++ b/docs/surfaces.md
@@ -6,19 +6,20 @@ description: "The application-oriented SQL surfaces in Lix: typed rows, files, d
 
 Lix exposes logical application data through typed SQL relations:
 
-| Data                              | Active branch                | Cross-branch                           | History / diff functions           |
-| :-------------------------------- | :--------------------------- | :------------------------------------- | :--------------------------------- |
-| Registered application row `X` | `<schema>`                   | `<schema>_by_branch`                   | `<schema>_history()`               |
-| Files                             | `lix_file`                   | `lix_file_by_branch`                   | `lix_file_history()`               |
-| Directories                       | `lix_directory`              | `lix_directory_by_branch`              | `lix_directory_history()`          |
-| Working diffs                     | `lix_working_diff`           | `lix_working_diff_by_branch`           | `lix_diff(from_commit, to_commit)` |
-| File working diffs                | `lix_file_working_diff`      | `lix_file_working_diff_by_branch`      | —                                  |
-| Directory working diffs           | `lix_directory_working_diff` | `lix_directory_working_diff_by_branch` | —                                  |
-| Checkpoints                       | `lix_checkpoint`             | —                                    | `lix_checkpoint_history()`         |
+| Data                            | Current session              | History / comparison                   |
+| :------------------------------ | :--------------------------- | :------------------------------------- |
+| Registered application row `X` | `<schema>`                   | `<schema>_history()`                   |
+| Files                           | `lix_file`                   | `lix_file_history()`                   |
+| Directories                     | `lix_directory`              | `lix_directory_history()`              |
+| Working diffs                   | `lix_working_diff`           | `lix_diff(from_commit, to_commit)`     |
+| File working diffs              | `lix_file_working_diff`      | —                                      |
+| Directory working diffs         | `lix_directory_working_diff` | —                                      |
+| Checkpoints                     | `lix_checkpoint`             | `lix_checkpoint_history()`             |
 
 The history functions read revisions reachable from a commit; `lix_diff`
-compares two arbitrary commits. `lix_registered_schema*` provides schema
-discovery and `lix_key_value*` provides shared repository metadata.
+compares two arbitrary commits. `lix_registered_schema` and its history
+function provide schema discovery; `lix_key_value` and its history function
+provide shared repository metadata.
 `lix_change` records repository-wide activity; [History](./history.md)
 documents it together with the history functions.
 
@@ -38,8 +39,8 @@ other segment text is preserved exactly: the engine does not URL-decode,
 case-fold, or Unicode-normalize paths. Filesystem adapters diagnose names that
 the target host cannot represent.
 
-The checkpoint and diff relations are read-only. `lix_working_diff`,
-`lix_working_diff_by_branch`, and `lix_diff()` expose a `diff_id` that can
+The checkpoint and diff relations are read-only. `lix_working_diff` and
+`lix_diff()` expose a `diff_id` that can
 feed the `lix_revert`, `lix_apply`, and `lix_create_checkpoint` command sinks.
 `lix_checkpoint` and the file and directory working-diff relations do not
 carry a `diff_id`. See [Checkpoints](./checkpoints.md) and
@@ -97,8 +98,7 @@ Registering a Schema v1 document with `key: "acme_task"` produces:
 
 | Surface                      | Use for                                                   |
 | :--------------------------- | :-------------------------------------------------------- |
-| `acme_task`                  | Read and mutate tasks on the active branch.               |
-| `acme_task_by_branch`        | Read or mutate tasks with an explicit `lixcol_branch_id`. |
+| `acme_task`                  | Read and mutate tasks in the current session.              |
 | `acme_task_history()`        | Read task revisions reachable from the active head.       |
 | `acme_task_history($commit)` | Read task revisions reachable from an explicit commit.    |
 
@@ -110,8 +110,8 @@ FROM acme_task
 WHERE done = false;
 ```
 
-Lix bookkeeping columns use the `lixcol_*` prefix. The base relation is scoped
-implicitly to the active branch; `_by_branch` adds `lixcol_branch_id`.
+Lix bookkeeping columns use the `lixcol_*` prefix. Relations are scoped to the
+session's active branch. Open another session to work on another branch.
 
 Every public history read calls its table-valued function with zero or one
 commit-id argument; there are no bare history table aliases.
@@ -139,8 +139,8 @@ beginning with `lix_`; their base or generated SQL names occupy the namespace
 reserved for Lix bootstrap schemas. Use an owner-specific prefix such as
 `acme_task`.
 
-`lix_key_value`, `lix_key_value_by_branch`, and `lix_key_value_history()` are
-public for shared repository settings and interoperability metadata.
+`lix_key_value` and `lix_key_value_history()` are public for shared repository
+settings and interoperability metadata.
 
 ## Files
 
@@ -149,7 +149,6 @@ public for shared repository settings and interoperability metadata.
 | Surface              | Use for                                 |
 | :------------------- | :-------------------------------------- |
 | `lix_file`           | Current files on the active branch.     |
-| `lix_file_by_branch` | Files with explicit branch scope.       |
 | `lix_file_history()` | File revisions reachable from a commit. |
 
 User columns are `id`, `path`, `directory_id`, `name`, and `content`.
@@ -185,7 +184,6 @@ Directories use the same three scopes:
 | Surface                   | Use for                                      |
 | :------------------------ | :------------------------------------------- |
 | `lix_directory`           | Current directories on the active branch.    |
-| `lix_directory_by_branch` | Directories with explicit branch scope.      |
 | `lix_directory_history()` | Directory revisions reachable from a commit. |
 
 User columns are `id`, `path`, `parent_id`, and `name`. Directory and file

--- a/packages/js-sdk/native/napi.rs
+++ b/packages/js-sdk/native/napi.rs
@@ -18,7 +18,7 @@ use std::collections::HashMap;
 use std::sync::mpsc::{self, Sender};
 use std::sync::{
     Arc, Mutex,
-    atomic::{AtomicBool, AtomicU64, Ordering},
+    atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering},
 };
 use std::thread;
 use tokio::runtime::{Builder, Runtime};
@@ -48,7 +48,11 @@ pub struct NativeLix {
 
 enum NativeLixInner {
     Memory(RsLix<Memory>),
-    FilesystemStorage(RsLix<FilesystemStorage>, FilesystemStorage),
+    FilesystemStorage(
+        RsLix<FilesystemStorage>,
+        FilesystemStorage,
+        Arc<AtomicUsize>,
+    ),
 }
 
 enum NativeLixTransactionInner {
@@ -66,6 +70,15 @@ enum NativeObserveEventsInner {
 pub struct NativeExecuteOptions {
     #[napi(js_name = "originKey")]
     pub origin_key: Option<String>,
+}
+
+#[napi(object)]
+#[derive(Debug)]
+pub struct NativeOpenAnotherSessionOptions {
+    #[napi(js_name = "branchId")]
+    pub branch_id: Option<String>,
+    #[napi(js_name = "accountId")]
+    pub account_id: Option<String>,
 }
 
 #[napi(object)]
@@ -95,6 +108,7 @@ type NativeDeferred<T> = JsDeferred<T, NativeResolver<T>>;
 type NativeExecuteDeferred = NativeDeferred<ExecuteResult>;
 type NativeExecuteBatchDeferred = NativeDeferred<Vec<ExecuteResult>>;
 type NativeTransactionDeferred = NativeDeferred<NativeLixTransaction>;
+type NativeLixDeferred = NativeDeferred<NativeLix>;
 type NativeStringDeferred = NativeDeferred<String>;
 type NativeCreateBranchDeferred = NativeDeferred<CreateBranchReceiptDto>;
 type NativeCreateCheckpointDeferred = NativeDeferred<CreateCheckpointReceiptDto>;
@@ -106,6 +120,10 @@ type NativeMergeReceiptDeferred = NativeDeferred<MergeBranchReceiptDto>;
 type NativeUnitDeferred = NativeDeferred<()>;
 
 enum LixCommand {
+    OpenAnotherSession {
+        options: NativeOpenAnotherSessionOptions,
+        deferred: NativeLixDeferred,
+    },
     Execute {
         sql: String,
         params: Vec<Value>,
@@ -291,6 +309,9 @@ fn reject_pending_lix_commands(receiver: mpsc::Receiver<LixCommand>, error: std:
     while let Ok(command) = receiver.recv() {
         match command {
             LixCommand::Execute { deferred, .. } => deferred.reject(to_napi_error(&error)),
+            LixCommand::OpenAnotherSession { deferred, .. } => {
+                deferred.reject(to_napi_error(&error))
+            }
             LixCommand::ExecuteBatch { deferred, .. } => deferred.reject(to_napi_error(&error)),
             LixCommand::BeginTransaction { deferred, .. } => deferred.reject(to_napi_error(&error)),
             LixCommand::ActiveBranchId(deferred) => deferred.reject(to_napi_error(&error)),
@@ -327,6 +348,13 @@ fn handle_lix_command(
     command: LixCommand,
 ) -> bool {
     match command {
+        LixCommand::OpenAnotherSession { options, deferred } => {
+            let result = rt
+                .block_on(state.lix.open_another_session(options))
+                .and_then(NativeLix::new);
+            settle_deferred(deferred, result);
+            false
+        }
         LixCommand::Execute {
             sql,
             params,
@@ -506,6 +534,9 @@ fn handle_lix_command(
 fn settle_command_after_close(command: LixCommand) {
     match command {
         LixCommand::Close(deferred) => settle_deferred(deferred, Ok(())),
+        LixCommand::OpenAnotherSession { deferred, .. } => {
+            settle_deferred(deferred, Err(lix_closed_error()));
+        }
         LixCommand::Execute { deferred, .. } | LixCommand::TransactionExecute { deferred, .. } => {
             settle_deferred(deferred, Err(lix_closed_error()));
         }
@@ -575,7 +606,7 @@ impl NativeLixInner {
                     None => execution.await,
                 }
             }
-            Self::FilesystemStorage(lix, _) => {
+            Self::FilesystemStorage(lix, _, _) => {
                 let execution = lix.execute(sql, params);
                 match options {
                     Some(origin_key) => execution.with_origin_key(origin_key).await,
@@ -598,7 +629,7 @@ impl NativeLixInner {
                     None => execution.await,
                 }
             }
-            Self::FilesystemStorage(lix, _) => {
+            Self::FilesystemStorage(lix, _, _) => {
                 let execution = lix.execute_batch(statements);
                 match options {
                     Some(origin_key) => execution.with_origin_key(origin_key).await,
@@ -613,7 +644,7 @@ impl NativeLixInner {
             Self::Memory(lix) => Ok(NativeLixTransactionInner::Memory(
                 lix.begin_transaction().await?,
             )),
-            Self::FilesystemStorage(lix, _) => Ok(NativeLixTransactionInner::FilesystemStorage(
+            Self::FilesystemStorage(lix, _, _) => Ok(NativeLixTransactionInner::FilesystemStorage(
                 lix.begin_transaction().await?,
             )),
         }
@@ -626,7 +657,7 @@ impl NativeLixInner {
     ) -> std::result::Result<NativeObserveEventsInner, LixError> {
         match self {
             Self::Memory(lix) => Ok(NativeObserveEventsInner::Memory(lix.observe(sql, params)?)),
-            Self::FilesystemStorage(lix, _) => Ok(NativeObserveEventsInner::FilesystemStorage(
+            Self::FilesystemStorage(lix, _, _) => Ok(NativeObserveEventsInner::FilesystemStorage(
                 lix.observe(sql, params)?,
             )),
         }
@@ -635,14 +666,14 @@ impl NativeLixInner {
     async fn active_branch_id(&self) -> std::result::Result<String, LixError> {
         match self {
             Self::Memory(lix) => lix.active_branch_id().await,
-            Self::FilesystemStorage(lix, _) => lix.active_branch_id().await,
+            Self::FilesystemStorage(lix, _, _) => lix.active_branch_id().await,
         }
     }
 
     fn active_account_id(&self) -> &str {
         match self {
             Self::Memory(lix) => lix.active_account_id(),
-            Self::FilesystemStorage(lix, _) => lix.active_account_id(),
+            Self::FilesystemStorage(lix, _, _) => lix.active_account_id(),
         }
     }
 
@@ -652,28 +683,28 @@ impl NativeLixInner {
     ) -> std::result::Result<CreateBranchReceipt, LixError> {
         match self {
             Self::Memory(lix) => lix.create_branch(options).await,
-            Self::FilesystemStorage(lix, _) => lix.create_branch(options).await,
+            Self::FilesystemStorage(lix, _, _) => lix.create_branch(options).await,
         }
     }
 
     async fn create_checkpoint(&self) -> std::result::Result<CreateCheckpointReceipt, LixError> {
         match self {
             Self::Memory(lix) => lix.create_checkpoint().await,
-            Self::FilesystemStorage(lix, _) => lix.create_checkpoint().await,
+            Self::FilesystemStorage(lix, _, _) => lix.create_checkpoint().await,
         }
     }
 
     async fn undo(&self) -> std::result::Result<UndoReceipt, LixError> {
         match self {
             Self::Memory(lix) => lix.undo().await,
-            Self::FilesystemStorage(lix, _) => lix.undo().await,
+            Self::FilesystemStorage(lix, _, _) => lix.undo().await,
         }
     }
 
     async fn redo(&self) -> std::result::Result<RedoReceipt, LixError> {
         match self {
             Self::Memory(lix) => lix.redo().await,
-            Self::FilesystemStorage(lix, _) => lix.redo().await,
+            Self::FilesystemStorage(lix, _, _) => lix.redo().await,
         }
     }
 
@@ -683,7 +714,7 @@ impl NativeLixInner {
     ) -> std::result::Result<SwitchBranchReceipt, LixError> {
         match self {
             Self::Memory(lix) => lix.switch_branch(options).await,
-            Self::FilesystemStorage(lix, _) => lix.switch_branch(options).await,
+            Self::FilesystemStorage(lix, _, _) => lix.switch_branch(options).await,
         }
     }
 
@@ -692,7 +723,7 @@ impl NativeLixInner {
         paths: Vec<String>,
     ) -> std::result::Result<(), LixError> {
         match self {
-            Self::FilesystemStorage(_, storage) => storage.import_paths(paths).await,
+            Self::FilesystemStorage(_, storage, _) => storage.import_paths(paths).await,
             Self::Memory(_) => Err(LixError::new(
                 "LIX_UNSUPPORTED_STORAGE",
                 "importFilesystemPaths requires a filesystem storage",
@@ -706,7 +737,7 @@ impl NativeLixInner {
     ) -> std::result::Result<MergeBranchPreview, LixError> {
         match self {
             Self::Memory(lix) => lix.merge_branch_preview(options).await,
-            Self::FilesystemStorage(lix, _) => lix.merge_branch_preview(options).await,
+            Self::FilesystemStorage(lix, _, _) => lix.merge_branch_preview(options).await,
         }
     }
 
@@ -716,13 +747,13 @@ impl NativeLixInner {
     ) -> std::result::Result<MergeBranchReceipt, LixError> {
         match self {
             Self::Memory(lix) => lix.merge_branch(options).await,
-            Self::FilesystemStorage(lix, _) => lix.merge_branch(options).await,
+            Self::FilesystemStorage(lix, _, _) => lix.merge_branch(options).await,
         }
     }
 
     async fn sync_disk_to_lix(&self) -> std::result::Result<(), LixError> {
         match self {
-            Self::FilesystemStorage(_, storage) => storage.sync_disk_to_lix().await,
+            Self::FilesystemStorage(_, storage, _) => storage.sync_disk_to_lix().await,
             Self::Memory(_) => Err(LixError::new(
                 "LIX_UNSUPPORTED_STORAGE",
                 "syncDiskToLix requires a filesystem storage",
@@ -733,9 +764,45 @@ impl NativeLixInner {
     async fn close(&self) -> std::result::Result<(), LixError> {
         match self {
             Self::Memory(lix) => lix.close().await,
-            Self::FilesystemStorage(lix, storage) => {
-                storage.stop_sync().await?;
+            Self::FilesystemStorage(lix, storage, sessions) => {
+                if sessions.fetch_sub(1, Ordering::SeqCst) == 1 {
+                    storage.stop_sync().await?;
+                }
                 lix.close().await
+            }
+        }
+    }
+
+    async fn open_another_session(
+        &self,
+        options: NativeOpenAnotherSessionOptions,
+    ) -> std::result::Result<Self, LixError> {
+        match self {
+            Self::Memory(lix) => {
+                let mut builder = lix.open_another_session();
+                if let Some(branch_id) = options.branch_id {
+                    builder = builder.with_branch(branch_id);
+                }
+                if let Some(account_id) = options.account_id {
+                    builder = builder.with_account(account_id);
+                }
+                Ok(Self::Memory(builder.await?))
+            }
+            Self::FilesystemStorage(lix, storage, sessions) => {
+                let mut builder = lix.open_another_session();
+                if let Some(branch_id) = options.branch_id {
+                    builder = builder.with_branch(branch_id);
+                }
+                if let Some(account_id) = options.account_id {
+                    builder = builder.with_account(account_id);
+                }
+                let opened = builder.await?;
+                sessions.fetch_add(1, Ordering::SeqCst);
+                Ok(Self::FilesystemStorage(
+                    opened,
+                    storage.clone(),
+                    sessions.clone(),
+                ))
             }
         }
     }
@@ -885,7 +952,11 @@ fn open_filesystem_storage_native(
         None => rt.block_on(async { open_lix().with_storage(storage.clone()).await })?,
     };
     rt.block_on(storage.start_sync(&lix))?;
-    NativeLix::new(NativeLixInner::FilesystemStorage(lix, storage))
+    NativeLix::new(NativeLixInner::FilesystemStorage(
+        lix,
+        storage,
+        Arc::new(AtomicUsize::new(1)),
+    ))
 }
 
 #[napi]
@@ -910,6 +981,24 @@ impl NativeLix {
             sync_all_files,
             telemetry_dispatch: optional_telemetry_dispatch(telemetry_dispatch)?,
         }))
+    }
+
+    #[napi(js_name = "openAnotherSession")]
+    pub fn open_another_session<'env>(
+        &self,
+        env: &'env Env,
+        options: Option<NativeOpenAnotherSessionOptions>,
+    ) -> Result<Object<'env>> {
+        let (deferred, promise): (NativeLixDeferred, Object<'env>) = env.create_deferred()?;
+        self.actor
+            .send_with_deferred(deferred, |deferred| LixCommand::OpenAnotherSession {
+                options: options.unwrap_or(NativeOpenAnotherSessionOptions {
+                    branch_id: None,
+                    account_id: None,
+                }),
+                deferred,
+            });
+        Ok(promise)
     }
 
     #[napi]

--- a/packages/js-sdk/native/wasm.rs
+++ b/packages/js-sdk/native/wasm.rs
@@ -1,6 +1,7 @@
 #![allow(missing_debug_implementations)]
 
 use std::cell::{Cell, RefCell};
+use std::rc::Rc;
 use std::sync::Arc;
 
 use futures_util::future::{AbortHandle, Abortable};
@@ -91,6 +92,8 @@ pub async fn benchmark_storage_bridge(
 pub struct WasmLix {
     inner: BrowserLix,
     storage: BrowserStorage,
+    storage_sessions: Rc<Cell<usize>>,
+    closed: Cell<bool>,
 }
 
 #[wasm_bindgen]
@@ -165,7 +168,12 @@ async fn open_browser_storage(
         None => open_lix().with_storage(storage.clone()).await,
     }
     .map_err(lix_error_to_js)?;
-    Ok(WasmLix { inner, storage })
+    Ok(WasmLix {
+        inner,
+        storage,
+        storage_sessions: Rc::new(Cell::new(1)),
+        closed: Cell::new(false),
+    })
 }
 
 struct BrowserTelemetryDispatch(Function);
@@ -185,6 +193,27 @@ pub fn parse_sql_script(sql: String, provided_param_count: usize) -> Result<JsVa
 
 #[wasm_bindgen]
 impl WasmLix {
+    #[wasm_bindgen(js_name = openAnotherSession)]
+    pub async fn open_another_session(&self, options: JsValue) -> Result<WasmLix, JsValue> {
+        let options: OpenAnotherSessionOptionsDto = from_js(options)?;
+        let mut builder = self.inner.open_another_session();
+        if let Some(branch_id) = options.branch_id {
+            builder = builder.with_branch(branch_id);
+        }
+        if let Some(account_id) = options.account_id {
+            builder = builder.with_account(account_id);
+        }
+        let inner = builder.await.map_err(lix_error_to_js)?;
+        self.storage_sessions
+            .set(self.storage_sessions.get().saturating_add(1));
+        Ok(WasmLix {
+            inner,
+            storage: self.storage.clone(),
+            storage_sessions: self.storage_sessions.clone(),
+            closed: Cell::new(false),
+        })
+    }
+
     #[wasm_bindgen(js_name = exportSnapshot)]
     pub async fn export_snapshot(&self) -> Result<Vec<u8>, JsValue> {
         match &self.storage {
@@ -383,11 +412,22 @@ impl WasmLix {
 
     #[wasm_bindgen(js_name = close)]
     pub async fn close(&self) -> Result<(), JsValue> {
-        self.inner.close().await.map_err(lix_error_to_js)?;
-        self.storage
-            .close()
-            .await
-            .map_err(|error| lix_error_to_js(error.into()))
+        if self.closed.replace(true) {
+            return Ok(());
+        }
+        if let Err(error) = self.inner.close().await {
+            self.closed.set(false);
+            return Err(lix_error_to_js(error));
+        }
+        let remaining = self.storage_sessions.get().saturating_sub(1);
+        self.storage_sessions.set(remaining);
+        if remaining == 0 {
+            self.storage
+                .close()
+                .await
+                .map_err(|error| lix_error_to_js(error.into()))?;
+        }
+        Ok(())
     }
 }
 
@@ -475,6 +515,13 @@ impl WasmObserveEvents {
 #[serde(rename_all = "camelCase")]
 struct ExecuteOptionsDto {
     origin_key: Option<String>,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(super) struct OpenAnotherSessionOptionsDto {
+    pub(super) branch_id: Option<String>,
+    pub(super) account_id: Option<String>,
 }
 
 #[derive(Serialize)]
@@ -722,7 +769,9 @@ pub(super) fn values_from_js(value: JsValue) -> Result<Vec<Value>, JsValue> {
         .map_err(lix_error_to_js)
 }
 
-pub(super) fn batch_statements_from_js(value: JsValue) -> Result<Vec<RsExecuteBatchStatement>, JsValue> {
+pub(super) fn batch_statements_from_js(
+    value: JsValue,
+) -> Result<Vec<RsExecuteBatchStatement>, JsValue> {
     if !Array::is_array(&value) {
         return Err(lix_error_to_js(invalid_param(
             "executeBatch statements must be an array",

--- a/packages/js-sdk/native/wasm_remote.rs
+++ b/packages/js-sdk/native/wasm_remote.rs
@@ -18,14 +18,17 @@ use wasm_bindgen::prelude::*;
 use wasm_bindgen_futures::JsFuture;
 
 use super::{
-    CreateBranchOptionsDto, CreateBranchReceiptDto, CreateCheckpointReceiptDto, RedoReceiptDto,
-    SwitchBranchOptionsDto, SwitchBranchReceiptDto, UndoReceiptDto, batch_statements_from_js,
-    execute_result_to_js, from_js, lix_error_to_js, to_js, values_from_js,
+    CreateBranchOptionsDto, CreateBranchReceiptDto, CreateCheckpointReceiptDto,
+    OpenAnotherSessionOptionsDto, RedoReceiptDto, SwitchBranchOptionsDto, SwitchBranchReceiptDto,
+    UndoReceiptDto, batch_statements_from_js, execute_result_to_js, from_js, lix_error_to_js,
+    to_js, values_from_js,
 };
 
 #[wasm_bindgen]
 pub struct WasmRemoteLix {
     inner: ProtocolClient<JsHttp>,
+    http: JsHttp,
+    url: String,
 }
 
 #[wasm_bindgen]
@@ -96,14 +99,56 @@ pub async fn open_remote(
 ) -> Result<WasmRemoteLix, JsValue> {
     console_error_panic_hook::set_once();
     let http = JsHttp { fetch, headers };
-    let inner = open_protocol_client(http, url, initial_active_branch_id)
+    let inner = open_protocol_client(http.clone(), url.clone(), initial_active_branch_id)
         .await
         .map_err(lix_error_to_js)?;
-    Ok(WasmRemoteLix { inner })
+    Ok(WasmRemoteLix { inner, http, url })
 }
 
 #[wasm_bindgen]
 impl WasmRemoteLix {
+    #[wasm_bindgen(js_name = openAnotherSession)]
+    pub async fn open_another_session(&self, options: JsValue) -> Result<WasmRemoteLix, JsValue> {
+        let options: OpenAnotherSessionOptionsDto = from_js(options)?;
+        let parent_account_id = self
+            .inner
+            .active_account_id()
+            .await
+            .map_err(lix_error_to_js)?;
+        if let Some(account_id) = options.account_id
+            && account_id != parent_account_id
+        {
+            return Err(lix_error_to_js(LixError::new(
+                LixError::CODE_INVALID_PARAM,
+                "remote sessions cannot override the authenticated account",
+            )));
+        }
+        let branch_id = match options.branch_id {
+            Some(branch_id) => branch_id,
+            None => self
+                .inner
+                .active_branch_id()
+                .await
+                .map_err(lix_error_to_js)?,
+        };
+        let inner = open_protocol_client(self.http.clone(), self.url.clone(), Some(branch_id))
+            .await
+            .map_err(lix_error_to_js)?;
+        let child_account_id = inner.active_account_id().await.map_err(lix_error_to_js)?;
+        if child_account_id != parent_account_id {
+            let _ = inner.close().await;
+            return Err(lix_error_to_js(LixError::new(
+                LixError::CODE_INVALID_PARAM,
+                "remote session authentication changed while opening another session",
+            )));
+        }
+        Ok(WasmRemoteLix {
+            inner,
+            http: self.http.clone(),
+            url: self.url.clone(),
+        })
+    }
+
     #[wasm_bindgen(js_name = execute)]
     pub async fn execute(
         &self,

--- a/packages/js-sdk/src/binding-types.ts
+++ b/packages/js-sdk/src/binding-types.ts
@@ -12,6 +12,7 @@ import type {
 	SwitchBranchOptions,
 	SwitchBranchReceipt,
 	LixTelemetrySpan,
+	OpenAnotherSessionOptions,
 } from "./types.js";
 import type { NativeLixValue } from "./value.js";
 import type { LixStorageProvider } from "./storage-adapter.js";
@@ -44,6 +45,7 @@ export type BindingBatchStatement = {
 };
 
 export type LixBinding = {
+	openAnotherSession(options: OpenAnotherSessionOptions): Promise<LixBinding>;
 	execute(
 		sql: string,
 		params: BindingParam[],

--- a/packages/js-sdk/src/index.ts
+++ b/packages/js-sdk/src/index.ts
@@ -49,6 +49,7 @@ export type {
 	MergeConflictSide,
 	ObserveEvent,
 	OpenLixOptions,
+	OpenAnotherSessionOptions,
 	LixTelemetryOptions,
 	LixTelemetrySpan,
 	RemoteLixFetch,

--- a/packages/js-sdk/src/lix.ts
+++ b/packages/js-sdk/src/lix.ts
@@ -25,6 +25,7 @@ import type {
 	MergeBranchPreview,
 	MergeBranchReceipt,
 	ObserveEvent,
+	OpenAnotherSessionOptions,
 	SqlParam,
 	SwitchBranchOptions,
 	SwitchBranchReceipt,
@@ -61,6 +62,16 @@ export class Lix {
 	#acceptingOperations = true;
 
 	constructor(private readonly binding: LixBinding) {}
+
+	/** Opens an independent session over the same repository storage. */
+	async openAnotherSession(
+		options: OpenAnotherSessionOptions = {},
+	): Promise<Lix> {
+		assertOpenAnotherSessionOptions(options);
+		return this.#runOperation(
+			async () => new Lix(await this.binding.openAnotherSession(options)),
+		);
+	}
 
 	async execute(
 		sql: string,
@@ -256,6 +267,27 @@ export class Lix {
 		error.name = "LixError";
 		error.code = "LIX_ERROR_CLOSED";
 		throw error;
+	}
+}
+
+function assertOpenAnotherSessionOptions(
+	options: OpenAnotherSessionOptions,
+): void {
+	if (!options || typeof options !== "object" || Array.isArray(options)) {
+		throw new TypeError("openAnotherSession() options must be an object");
+	}
+	for (const [name, value] of [
+		["branchId", options.branchId],
+		["accountId", options.accountId],
+	] as const) {
+		if (
+			value !== undefined &&
+			(typeof value !== "string" || value.length === 0)
+		) {
+			throw new TypeError(
+				`openAnotherSession() ${name} must be a non-empty string`,
+			);
+		}
 	}
 }
 

--- a/packages/js-sdk/src/open-lix.browser.test.ts
+++ b/packages/js-sdk/src/open-lix.browser.test.ts
@@ -75,6 +75,22 @@ test("loads and executes the engine outside the browser main thread", async () =
 	}
 });
 
+test("keeps browser worker sessions independent", async () => {
+	const { openLix } = await import("@lix-js/sdk");
+	const main = await openLix();
+	const mainBranchId = await main.activeBranchId();
+	const draft = await main.createBranch({ name: "Browser draft" });
+	const review = await main.openAnotherSession({ branchId: draft.id });
+
+	expect(await main.activeBranchId()).toBe(mainBranchId);
+	expect(await review.activeBranchId()).toBe(draft.id);
+	await main.close();
+	expect(
+		(await review.execute("SELECT 1 AS value")).rows[0]?.get("value"),
+	).toBe(1);
+	await review.close();
+});
+
 test("createCheckpoint returns the new active head through browser WASM", async () => {
 	const { openLix } = await import("@lix-js/sdk");
 	const lix = await openLix();

--- a/packages/js-sdk/src/open-lix.test.ts
+++ b/packages/js-sdk/src/open-lix.test.ts
@@ -100,6 +100,42 @@ test("openLix opens native storage without telemetry", async () => {
 	await lix.close();
 });
 
+test("openAnotherSession keeps branch and lifecycle independent", async () => {
+	const main = await openLix();
+	const mainBranchId = await main.activeBranchId();
+	const draft = await main.createBranch({ name: "Independent draft" });
+	const review = await main.openAnotherSession({ branchId: draft.id });
+
+	expect(await main.activeBranchId()).toBe(mainBranchId);
+	expect(await review.activeBranchId()).toBe(draft.id);
+	expect(await review.activeAccountId()).toBe(await main.activeAccountId());
+
+	await review.switchBranch({ branchId: mainBranchId });
+	expect(await main.activeBranchId()).toBe(mainBranchId);
+	expect(await review.activeBranchId()).toBe(mainBranchId);
+
+	await main.close();
+	await expect(review.execute("SELECT 1 AS value")).resolves.toBeDefined();
+	await expect(main.openAnotherSession()).rejects.toMatchObject({
+		code: "LIX_ERROR_CLOSED",
+	});
+	await review.close();
+});
+
+test("openAnotherSession validates options and missing branches", async () => {
+	const lix = await openLix();
+	await expect(
+		lix.openAnotherSession({ branchId: "missing-branch" }),
+	).rejects.toMatchObject({ code: "LIX_BRANCH_NOT_FOUND" });
+	await expect(lix.openAnotherSession({ branchId: "" })).rejects.toBeInstanceOf(
+		TypeError,
+	);
+	await expect(lix.openAnotherSession(null as never)).rejects.toBeInstanceOf(
+		TypeError,
+	);
+	await lix.close();
+});
+
 test("openLix exposes the lix-sdk e2e flow", async () => {
 	const lix = await openLix();
 	const mainBranchId = await lix.activeBranchId();
@@ -730,6 +766,25 @@ test("fs storage binds to one open lix at a time", async () => {
 	const reopened = await openLix({ storage });
 	await storage.syncDiskToLix();
 	await reopened.close();
+});
+
+test("fs storage connector routes through a live child session", async () => {
+	const dir = tempFsDir();
+	mkdirSync(dir, { recursive: true });
+	const storage = new FilesystemStorage({ path: dir, syncAllFiles: false });
+	const primary = await openLix({ storage });
+	const child = await primary.openAnotherSession();
+
+	await primary.close();
+	writeFileSync(join(dir, "child.md"), "child");
+	await storage.importPaths(["child.md"]);
+	await storage.syncDiskToLix();
+	expect(
+		new TextDecoder().decode((await readFile(child, "/child.md"))!),
+	).toBe("child");
+
+	await child.close();
+	await expect(storage.syncDiskToLix()).rejects.toThrow("requires an open Lix");
 });
 
 test("fs storage defaults match FilesystemStorage::new(path)", () => {

--- a/packages/js-sdk/src/open-lix.ts
+++ b/packages/js-sdk/src/open-lix.ts
@@ -64,12 +64,13 @@ export async function openLix(options: OpenLixOptions = {}): Promise<Lix> {
 				disconnect,
 				options.telemetry,
 			);
+			const routed = routeStorageBinding(binding);
 			storage.lixStorage.connect({
 				importFilesystemPaths: (paths) =>
-					binding!.importFilesystemPaths(paths),
-				syncDiskToLix: () => binding!.syncDiskToLix(),
+					routed.current().importFilesystemPaths(paths),
+				syncDiskToLix: () => routed.current().syncDiskToLix(),
 			});
-			return new Lix(binding);
+			return new Lix(routed.binding);
 		} catch (error) {
 			disconnect();
 			await binding?.close().catch(() => undefined);
@@ -77,6 +78,43 @@ export async function openLix(options: OpenLixOptions = {}): Promise<Lix> {
 		}
 	}
 	throw new TypeError("openLix() requires a Lix storage adapter");
+}
+
+function routeStorageBinding(root: LixBinding): {
+	binding: LixBinding;
+	current(): LixBinding;
+} {
+	const live = new Set<LixBinding>();
+	const wrap = (binding: LixBinding): LixBinding => {
+		live.add(binding);
+		return new Proxy(binding, {
+			get(target, property, receiver) {
+				if (property === "openAnotherSession") {
+					return async (
+						options: Parameters<LixBinding["openAnotherSession"]>[0],
+					) => wrap(await target.openAnotherSession(options));
+				}
+				if (property === "close") {
+					return async () => {
+						try {
+							await target.close();
+						} finally {
+							live.delete(target);
+						}
+					};
+				}
+				const value = Reflect.get(target, property, receiver) as unknown;
+				return typeof value === "function" ? value.bind(target) : value;
+			},
+		});
+	};
+	return {
+		binding: wrap(root),
+		current: () => {
+			const bindings = [...live];
+			return bindings[bindings.length - 1] ?? root;
+		},
+	};
 }
 
 async function openJsProviderStorage(

--- a/packages/js-sdk/src/remote/client.test.ts
+++ b/packages/js-sdk/src/remote/client.test.ts
@@ -41,6 +41,81 @@ test("Lix Server Protocol handshake requests a restored initial active branch", 
 	await binding.close();
 });
 
+test("openAnotherSession creates an independent remote protocol session", async () => {
+	const accountId = "01920000-0000-7000-8000-000000000601";
+	const handshakes: Request[] = [];
+	let nextSession = 0;
+	const lix = await openLix({
+		server: {
+			mode: "remote",
+			url: "https://lixray.test/@acme/repository",
+			fetch: async (input, init) => {
+				const request = new Request(input, init);
+				if (request.method === "DELETE")
+					return new Response(null, { status: 204 });
+				handshakes.push(request);
+				return Response.json({
+					protocolVersion: 2,
+					activeBranchId:
+						new URL(request.url).searchParams.get("activeBranchId") ??
+						"main-id",
+					activeAccountId: accountId,
+					sessionId: `session-${++nextSession}`,
+				});
+			},
+		},
+	});
+
+	const inherited = await lix.openAnotherSession();
+	const draft = await lix.openAnotherSession({ branchId: "draft-id" });
+	expect(await inherited.activeBranchId()).toBe("main-id");
+	expect(await draft.activeBranchId()).toBe("draft-id");
+	expect(
+		handshakes.map((request) =>
+			new URL(request.url).searchParams.get("activeBranchId"),
+		),
+	).toEqual([null, "main-id", "draft-id"]);
+	await expect(
+		lix.openAnotherSession({ accountId: "another-account" }),
+	).rejects.toMatchObject({ code: "LIX_INVALID_PARAM" });
+
+	await lix.close();
+	expect(await draft.activeBranchId()).toBe("draft-id");
+	await Promise.all([inherited.close(), draft.close()]);
+});
+
+test("openAnotherSession rejects and closes a remote identity mismatch", async () => {
+	const requests: Request[] = [];
+	let handshake = 0;
+	const lix = await openLix({
+		server: {
+			mode: "remote",
+			url: "https://lixray.test/@acme/repository",
+			fetch: async (input, init) => {
+				const request = new Request(input, init);
+				requests.push(request);
+				if (request.method === "DELETE") {
+					return new Response(null, { status: 204 });
+				}
+				handshake += 1;
+				return Response.json({
+					protocolVersion: 2,
+					activeBranchId: "main-id",
+					activeAccountId: handshake === 1 ? "account-a" : "account-b",
+					sessionId: `session-${handshake}`,
+				});
+			},
+		},
+	});
+
+	await expect(lix.openAnotherSession()).rejects.toMatchObject({
+		code: "LIX_INVALID_PARAM",
+	});
+	expect(requests[2]?.method).toBe("DELETE");
+	expect(requests[2]?.headers.get("lix-session-id")).toBe("session-2");
+	await lix.close();
+});
+
 async function requestJson(request: Request): Promise<unknown> {
 	const bytes = new Uint8Array(await request.arrayBuffer());
 	const decoded =

--- a/packages/js-sdk/src/types.ts
+++ b/packages/js-sdk/src/types.ts
@@ -35,6 +35,14 @@ export type OpenLixOptions =
 			telemetry?: never;
 	  };
 
+/** Selects the initial context for an additional independent session. */
+export type OpenAnotherSessionOptions = {
+	/** Defaults to the current branch of the session opening it. */
+	branchId?: string;
+	/** Defaults to the current account. Remote sessions cannot override identity. */
+	accountId?: string;
+};
+
 export type LixValue =
 	| { kind: "null"; value: null }
 	| { kind: "boolean"; value: boolean }

--- a/packages/js-sdk/src/worker/client.ts
+++ b/packages/js-sdk/src/worker/client.ts
@@ -37,11 +37,14 @@ export async function openLixWorker(
 	client ??= new LixWorkerClient();
 	client.beginLease(onDisposed, telemetry);
 	try {
-		await client.request({
-			kind: "open",
-			storage,
-			telemetryEnabled: telemetry !== undefined,
-		});
+		await client.request(
+			{
+				kind: "open",
+				storage,
+				telemetryEnabled: telemetry !== undefined,
+			},
+			0,
+		);
 		return client;
 	} catch (error) {
 		await client.terminate();
@@ -68,42 +71,93 @@ export async function openLixWorkerBinding(
 		const binding = await openDirectLixBinding(storage, telemetryDispatch);
 		if (binding) {
 			if (!onDisposed) return binding;
-			let disposed = false;
-			return new Proxy(binding, {
-				get(target, property, receiver) {
-					if (property === "close") {
-						return async () => {
-							try {
-								await target.close();
-							} finally {
-								if (!disposed) {
-									disposed = true;
-									onDisposed();
-								}
-							}
-						};
-					}
-					const value = Reflect.get(target, property, receiver) as unknown;
-					return typeof value === "function" ? value.bind(target) : value;
-				}
-			});
+			return wrapDirectBinding(binding, new DirectBindingLease(onDisposed));
 		}
 	}
 	const client = await openLixWorker(storage, onDisposed, telemetry);
-	return workerBinding(client);
+	return workerBinding(client, new SharedWorkerLease(client), 0);
 }
 
-function workerBinding(client: LixWorkerClient): LixBinding {
+class DirectBindingLease {
+	private references = 1;
+	constructor(private readonly onDisposed: () => void) {}
+	retain(): void {
+		this.references += 1;
+	}
+	release(): void {
+		this.references -= 1;
+		if (this.references === 0) this.onDisposed();
+	}
+}
+
+function wrapDirectBinding(
+	binding: LixBinding,
+	lease: DirectBindingLease,
+): LixBinding {
+	let closed = false;
+	return new Proxy(binding, {
+		get(target, property, receiver) {
+			if (property === "openAnotherSession") {
+				return async (
+					options: Parameters<LixBinding["openAnotherSession"]>[0],
+				) => {
+					const opened = await target.openAnotherSession(options);
+					lease.retain();
+					return wrapDirectBinding(opened, lease);
+				};
+			}
+			if (property === "close") {
+				return async () => {
+					if (closed) return;
+					try {
+						await target.close();
+					} finally {
+						closed = true;
+						lease.release();
+					}
+				};
+			}
+			const value = Reflect.get(target, property, receiver) as unknown;
+			return typeof value === "function" ? value.bind(target) : value;
+		},
+	});
+}
+
+class SharedWorkerLease {
+	private references = 1;
+	constructor(readonly client: LixWorkerClient) {}
+	retain(): void {
+		this.references += 1;
+	}
+	async release(): Promise<void> {
+		this.references -= 1;
+		if (this.references === 0) await releaseWorker(this.client);
+	}
+}
+
+function workerBinding(
+	client: LixWorkerClient,
+	lease: SharedWorkerLease,
+	sessionId: number,
+): LixBinding {
 	let closed = false;
 	const request: RequestWorker = (operation) => {
 		if (closed) return Promise.reject(workerClosedError());
-		return client.request(operation);
+		return client.request(operation, sessionId);
 	};
 	const notify: NotifyWorker = (notification) => {
 		if (!closed) client.notify(notification);
 	};
 
 	return {
+		openAnotherSession: async (options) => {
+			const openedSessionId = await request<number>({
+				kind: "openAnotherSession",
+				options,
+			});
+			lease.retain();
+			return workerBinding(client, lease, openedSessionId);
+		},
 		execute: (sql, params, options) =>
 			request({ kind: "execute", sql, params, options }),
 		executeBatch: (statements, options) =>
@@ -139,7 +193,7 @@ function workerBinding(client: LixWorkerClient): LixBinding {
 			if (closed) return;
 			await request({ kind: "close" });
 			closed = true;
-			await releaseWorker(client);
+			await lease.release();
 		},
 	};
 }
@@ -217,7 +271,7 @@ export class LixWorkerClient {
 		onDisposed?.();
 	}
 
-	request<T>(operation: WorkerOperation): Promise<T> {
+	request<T>(operation: WorkerOperation, sessionId = 0): Promise<T> {
 		if (this.disposed || !this.leased) {
 			return Promise.reject(workerClosedError());
 		}
@@ -229,7 +283,7 @@ export class LixWorkerClient {
 				reject,
 			});
 			try {
-				this.connection.postMessage({ id, operation });
+				this.connection.postMessage({ id, sessionId, operation });
 			} catch (error) {
 				this.pending.delete(id);
 				if (this.pending.size === 0) this.connection.unref();

--- a/packages/js-sdk/src/worker/factory.node.test.ts
+++ b/packages/js-sdk/src/worker/factory.node.test.ts
@@ -38,6 +38,7 @@ const opened = new Promise((resolve, reject) => {
 });
 connection.postMessage({
 	id: 1,
+	sessionId: 0,
 	operation: {
 		kind: "open",
 		storage: { kind: "memory" },

--- a/packages/js-sdk/src/worker/host.ts
+++ b/packages/js-sdk/src/worker/host.ts
@@ -14,7 +14,8 @@ import {
 } from "./protocol.js";
 
 export function startWorkerHost(endpoint: WorkerHostEndpoint): void {
-	let lix: LixBinding | undefined;
+	const sessions = new Map<number, LixBinding>();
+	let nextSessionId = 1;
 	let nextTransactionId = 1;
 	let nextObserveId = 1;
 	const transactions = new Map<number, LixTransactionBinding>();
@@ -32,7 +33,9 @@ export function startWorkerHost(endpoint: WorkerHostEndpoint): void {
 			return;
 		}
 		finiteQueue = finiteQueue.then(async () => {
-			await respond(message, () => handleFiniteOperation(message.operation));
+			await respond(message, () =>
+				handleFiniteOperation(message.sessionId, message.operation),
+			);
 		});
 	});
 
@@ -73,32 +76,45 @@ export function startWorkerHost(endpoint: WorkerHostEndpoint): void {
 	}
 
 	async function handleFiniteOperation(
+		sessionId: number,
 		operation: WorkerOperation,
 	): Promise<unknown> {
 		switch (operation.kind) {
 			case "open":
-				if (lix) throw workerStateError("Lix worker is already open");
-				lix = await openLixBinding(
-					operation.storage,
-					operation.telemetryEnabled
-						? (span: LixTelemetrySpan) =>
-							endpoint.postMessage({ kind: "telemetry", span })
-						: undefined,
+				if (sessions.size > 0)
+					throw workerStateError("Lix worker is already open");
+				sessions.set(
+					0,
+					await openLixBinding(
+						operation.storage,
+						operation.telemetryEnabled
+							? (span: LixTelemetrySpan) =>
+									endpoint.postMessage({ kind: "telemetry", span })
+							: undefined,
+					),
 				);
 				return undefined;
+			case "openAnotherSession": {
+				const opened = await requiredLix(sessionId).openAnotherSession(
+					operation.options,
+				);
+				const openedSessionId = nextSessionId++;
+				sessions.set(openedSessionId, opened);
+				return openedSessionId;
+			}
 			case "execute":
-				return requiredLix().execute(
+				return requiredLix(sessionId).execute(
 					operation.sql,
 					operation.params,
 					operation.options,
 				);
 			case "executeBatch":
-				return requiredLix().executeBatch(
+				return requiredLix(sessionId).executeBatch(
 					operation.statements,
 					operation.options,
 				);
 			case "beginTransaction": {
-				const transaction = await requiredLix().beginTransaction();
+				const transaction = await requiredLix(sessionId).beginTransaction();
 				const transactionId = nextTransactionId++;
 				transactions.set(transactionId, transaction);
 				return transactionId;
@@ -122,29 +138,29 @@ export function startWorkerHost(endpoint: WorkerHostEndpoint): void {
 				return undefined;
 			}
 			case "activeBranchId":
-				return requiredLix().activeBranchId();
+				return requiredLix(sessionId).activeBranchId();
 			case "activeAccountId":
-				return requiredLix().activeAccountId();
+				return requiredLix(sessionId).activeAccountId();
 			case "createBranch":
-				return requiredLix().createBranch(operation.options);
+				return requiredLix(sessionId).createBranch(operation.options);
 			case "createCheckpoint":
-				return requiredLix().createCheckpoint();
+				return requiredLix(sessionId).createCheckpoint();
 			case "undo":
-				return requiredLix().undo();
+				return requiredLix(sessionId).undo();
 			case "redo":
-				return requiredLix().redo();
+				return requiredLix(sessionId).redo();
 			case "switchBranch":
-				return requiredLix().switchBranch(operation.options);
+				return requiredLix(sessionId).switchBranch(operation.options);
 			case "mergeBranchPreview":
-				return requiredLix().mergeBranchPreview(operation.options);
+				return requiredLix(sessionId).mergeBranchPreview(operation.options);
 			case "mergeBranch":
-				return requiredLix().mergeBranch(operation.options);
+				return requiredLix(sessionId).mergeBranch(operation.options);
 			case "importFilesystemPaths":
-				return requiredLix().importFilesystemPaths(operation.paths);
+				return requiredLix(sessionId).importFilesystemPaths(operation.paths);
 			case "syncDiskToLix":
-				return requiredLix().syncDiskToLix();
+				return requiredLix(sessionId).syncDiskToLix();
 			case "observe": {
-				const events = await requiredLix().observe(
+				const events = await requiredLix(sessionId).observe(
 					operation.sql,
 					operation.params,
 				);
@@ -153,12 +169,9 @@ export function startWorkerHost(endpoint: WorkerHostEndpoint): void {
 				return observeId;
 			}
 			case "close": {
-				const openLix = requiredLix();
+				const openLix = requiredLix(sessionId);
 				await openLix.close();
-				for (const events of observations.values()) events.close();
-				observations.clear();
-				transactions.clear();
-				lix = undefined;
+				sessions.delete(sessionId);
 				return undefined;
 			}
 			case "observe.next":
@@ -172,8 +185,9 @@ export function startWorkerHost(endpoint: WorkerHostEndpoint): void {
 		return events.next();
 	}
 
-	function requiredLix(): LixBinding {
-		if (!lix) throw workerStateError("Lix worker is closed");
+	function requiredLix(sessionId: number): LixBinding {
+		const lix = sessions.get(sessionId);
+		if (!lix) throw workerStateError("Lix session is closed");
 		return lix;
 	}
 

--- a/packages/js-sdk/src/worker/protocol.ts
+++ b/packages/js-sdk/src/worker/protocol.ts
@@ -10,15 +10,18 @@ import type {
 	MergeBranchOptions,
 	SwitchBranchOptions,
 	LixTelemetrySpan,
+	OpenAnotherSessionOptions,
 } from "../types.js";
 
 export type WorkerRequest = {
 	id: number;
+	sessionId: number;
 	operation: WorkerOperation;
 };
 
 export type WorkerOperation =
 	| { kind: "open"; storage: LixStorageConfig; telemetryEnabled: boolean }
+	| { kind: "openAnotherSession"; options: OpenAnotherSessionOptions }
 	| {
 			kind: "execute";
 			sql: string;

--- a/packages/js-sdk/src/workerd.browser.test.ts
+++ b/packages/js-sdk/src/workerd.browser.test.ts
@@ -93,6 +93,21 @@ test("Workerd snapshots reject malformed bytes", async () => {
 	).rejects.toThrow(/invalid in-memory snapshot/);
 });
 
+test("raw Workerd sessions have independent idempotent lifecycles", async () => {
+	const primary = await openMemoryLix();
+	const child = await primary.openAnotherSession({});
+	const nested = await child.openAnotherSession({});
+
+	await primary.close();
+	await primary.close();
+	expect((await child.execute("SELECT 1", noParams)).rows).toHaveLength(1);
+
+	await nested.close();
+	expect((await child.execute("SELECT 1", noParams)).rows).toHaveLength(1);
+	await child.close();
+	await child.close();
+});
+
 test("Workerd executeBatch accepts nested statement parameters", async () => {
 	const lix = await openMemoryLix();
 	try {

--- a/packages/js-sdk/src/workerd.ts
+++ b/packages/js-sdk/src/workerd.ts
@@ -20,6 +20,9 @@ export interface OpenMemoryLixOptions {
 }
 
 export interface WorkerdLixBinding extends LixBinding {
+	openAnotherSession(
+		options: import("./types.js").OpenAnotherSessionOptions,
+	): Promise<WorkerdLixBinding>;
 	exportSnapshot(): Promise<Uint8Array>;
 }
 

--- a/packages/lix/src/account.rs
+++ b/packages/lix/src/account.rs
@@ -184,17 +184,14 @@ mod tests {
 
         let system = lix
             .open_another_session()
+            .with_branch(crate::GLOBAL_BRANCH_ID)
             .with_account(crate::SYSTEM_ACCOUNT_ID)
             .await
             .expect("system session should open");
         system
             .execute(
-                "UPDATE lix_account_by_branch SET status = 'disabled' \
-                 WHERE id = $1 AND lixcol_branch_id = $2",
-                &[
-                    Value::Text(AUTHOR_ID.to_string()),
-                    Value::Text(crate::GLOBAL_BRANCH_ID.to_string()),
-                ],
+                "UPDATE lix_account SET status = 'disabled' WHERE id = $1",
+                &[Value::Text(AUTHOR_ID.to_string())],
             )
             .await
             .expect("disable author");

--- a/packages/lix/src/handle.rs
+++ b/packages/lix/src/handle.rs
@@ -660,21 +660,22 @@ where
         name: &str,
         kind: &str,
     ) -> Result<(), LixError> {
-        let branch_id = Box::pin(self.active_branch_id()).await?;
-        let system =
-            Box::pin(self.open_internal_session(branch_id, lix::SYSTEM_ACCOUNT_ID)).await?;
+        let system = Box::pin(self.open_internal_session(
+            lix::GLOBAL_BRANCH_ID.to_string(),
+            lix::SYSTEM_ACCOUNT_ID,
+        ))
+        .await?;
         system
             .execute(
-                "INSERT INTO lix_account_by_branch \
-                 (id, name, kind, status, lixcol_branch_id, lixcol_global, lixcol_untracked) \
-                 VALUES ($1, $2, $3, 'active', $4, true, false) \
-                 ON CONFLICT (id, lixcol_branch_id) \
+                "INSERT INTO lix_account \
+                 (id, name, kind, status, lixcol_global, lixcol_untracked) \
+                 VALUES ($1, $2, $3, 'active', true, false) \
+                 ON CONFLICT (id) \
                  DO NOTHING",
                 &[
                     Value::Text(id.to_string()),
                     Value::Text(name.to_string()),
                     Value::Text(kind.to_string()),
-                    Value::Text(lix::GLOBAL_BRANCH_ID.to_string()),
                 ],
             )
             .await?;
@@ -1246,17 +1247,14 @@ mod tests {
 
         let system = root
             .open_another_session()
+            .with_branch(lix::GLOBAL_BRANCH_ID)
             .with_account(lix::SYSTEM_ACCOUNT_ID)
             .await
             .expect("open system session");
         system
             .execute(
-                "UPDATE lix_account_by_branch SET name = 'Ada Lovelace' \
-                 WHERE id = $1 AND lixcol_branch_id = $2",
-                &[
-                    Value::Text(AUTHOR_ID.to_string()),
-                    Value::Text(lix::GLOBAL_BRANCH_ID.to_string()),
-                ],
+                "UPDATE lix_account SET name = 'Ada Lovelace' WHERE id = $1",
+                &[Value::Text(AUTHOR_ID.to_string())],
             )
             .await
             .expect("rename account");
@@ -1280,11 +1278,8 @@ mod tests {
 
         system
             .execute(
-                "DELETE FROM lix_account_by_branch WHERE id = $1 AND lixcol_branch_id = $2",
-                &[
-                    Value::Text(UNUSED_ID.to_string()),
-                    Value::Text(lix::GLOBAL_BRANCH_ID.to_string()),
-                ],
+                "DELETE FROM lix_account WHERE id = $1",
+                &[Value::Text(UNUSED_ID.to_string())],
             )
             .await
             .expect("delete unused account");
@@ -1298,11 +1293,8 @@ mod tests {
         assert_eq!(error.code, "LIX_ACCOUNT_NOT_FOUND");
         let error = system
             .execute(
-                "DELETE FROM lix_account_by_branch WHERE id = $1 AND lixcol_branch_id = $2",
-                &[
-                    Value::Text(AUTHOR_ID.to_string()),
-                    Value::Text(lix::GLOBAL_BRANCH_ID.to_string()),
-                ],
+                "DELETE FROM lix_account WHERE id = $1",
+                &[Value::Text(AUTHOR_ID.to_string())],
             )
             .await
             .expect_err("authored changes must restrict account deletion");
@@ -1310,12 +1302,8 @@ mod tests {
 
         system
             .execute(
-                "UPDATE lix_account_by_branch SET status = 'disabled' \
-                 WHERE id = $1 AND lixcol_branch_id = $2",
-                &[
-                    Value::Text(AUTHOR_ID.to_string()),
-                    Value::Text(lix::GLOBAL_BRANCH_ID.to_string()),
-                ],
+                "UPDATE lix_account SET status = 'disabled' WHERE id = $1",
+                &[Value::Text(AUTHOR_ID.to_string())],
             )
             .await
             .expect("disable author");
@@ -1330,12 +1318,8 @@ mod tests {
 
         let error = system
             .execute(
-                "UPDATE lix_account_by_branch SET status = 'disabled' \
-                 WHERE id = $1 AND lixcol_branch_id = $2",
-                &[
-                    Value::Text(lix::ANONYMOUS_ACCOUNT_ID.to_string()),
-                    Value::Text(lix::GLOBAL_BRANCH_ID.to_string()),
-                ],
+                "UPDATE lix_account SET status = 'disabled' WHERE id = $1",
+                &[Value::Text(lix::ANONYMOUS_ACCOUNT_ID.to_string())],
             )
             .await
             .expect_err("built-in accounts must remain active");
@@ -1370,36 +1354,20 @@ mod tests {
             );
         }
 
-        // Physical copies materialize as `lixcol_global = false`. Unfiltered
-        // `*_by_branch` also *projects* inherited global rows onto every
-        // visible branch with `lixcol_global = true` — that is the same
-        // visibility overlay `ensure_account` uses, not a second seed write.
-        let local_copies = root
-            .execute(
-                "SELECT id, lixcol_branch_id FROM lix_account_by_branch \
-                 WHERE id IN ($1, $2) AND lixcol_global = false",
-                &[
-                    Value::Text(lix::SYSTEM_ACCOUNT_ID.to_string()),
-                    Value::Text(lix::ANONYMOUS_ACCOUNT_ID.to_string()),
-                ],
-            )
+        let global = root
+            .open_another_session()
+            .with_branch(lix::GLOBAL_BRANCH_ID)
             .await
-            .expect("query local account copies should succeed");
-        assert!(
-            local_copies.rows().is_empty(),
-            "built-in accounts must not have branch-local copies"
-        );
-
-        let home_rows = root
+            .expect("global session should open");
+        let home_rows = global
             .execute(
-                "SELECT id, name, lixcol_global, lixcol_branch_id \
-                 FROM lix_account_by_branch \
-                 WHERE id IN ($1, $2) AND lixcol_branch_id = $3 \
+                "SELECT id, name, lixcol_global \
+                 FROM lix_account \
+                 WHERE id IN ($1, $2) \
                  ORDER BY name",
                 &[
                     Value::Text(lix::SYSTEM_ACCOUNT_ID.to_string()),
                     Value::Text(lix::ANONYMOUS_ACCOUNT_ID.to_string()),
-                    Value::Text(lix::GLOBAL_BRANCH_ID.to_string()),
                 ],
             )
             .await
@@ -1412,25 +1380,21 @@ mod tests {
         for row in home_rows.rows() {
             let values = row.values();
             assert_eq!(&values[2], &Value::Boolean(true));
-            assert_eq!(&values[3], &Value::Text(lix::GLOBAL_BRANCH_ID.to_string()));
         }
 
         // A later ensure_account write has the same physical/home shape.
         root.ensure_account(AUTHOR_ID, "Ada", "human")
             .await
             .expect("provision author");
-        let author_copies = root
+        let author_rows = global
             .execute(
-                "SELECT id FROM lix_account_by_branch \
-                 WHERE id = $1 AND lixcol_global = false",
+                "SELECT id, lixcol_global FROM lix_account WHERE id = $1",
                 &[Value::Text(AUTHOR_ID.to_string())],
             )
             .await
-            .expect("query ensure_account copies should succeed");
-        assert!(
-            author_copies.rows().is_empty(),
-            "ensure_account must not create branch-local copies either"
-        );
+            .expect("query ensure_account row should succeed");
+        assert_eq!(author_rows.rows().len(), 1);
+        assert_eq!(author_rows.rows()[0].values()[1], Value::Boolean(true));
 
         let draft = root
             .create_branch(CreateBranchOptions {
@@ -1466,22 +1430,6 @@ mod tests {
             );
         }
 
-        let draft_local_copies = root
-            .execute(
-                "SELECT id FROM lix_account_by_branch \
-                 WHERE id IN ($1, $2, $3) AND lixcol_global = false",
-                &[
-                    Value::Text(lix::SYSTEM_ACCOUNT_ID.to_string()),
-                    Value::Text(lix::ANONYMOUS_ACCOUNT_ID.to_string()),
-                    Value::Text(AUTHOR_ID.to_string()),
-                ],
-            )
-            .await
-            .expect("query draft local copies should succeed");
-        assert!(
-            draft_local_copies.rows().is_empty(),
-            "creating a branch must not copy global accounts onto the new branch"
-        );
     }
 }
 

--- a/packages/lix/src/session/execute.rs
+++ b/packages/lix/src/session/execute.rs
@@ -3507,21 +3507,6 @@ where
             }
         }
     }
-
-    #[cfg(test)]
-    pub(crate) async fn scan_hot_state_for_test(
-        &mut self,
-        request: &crate::hot_state::HotStateScanRequest,
-    ) -> Result<crate::hot_state::MaterializedHotStateBatch, LixError> {
-        let _operation_guard = self.begin_session_operation()?;
-        let transaction = self.transaction_mut()?;
-        transaction.flush_prepared_mutations_for_read().await?;
-        <crate::transaction::Transaction<StorageImpl> as sql2::SqlWriteExecutionContext>::scan_hot_state_batch(
-            transaction,
-            request,
-        )
-        .await
-    }
 }
 
 async fn try_execute_transaction_parameter_batch<StorageImpl>(
@@ -3782,11 +3767,6 @@ fn is_acknowledgeable_file_content_read(statement: &DataFusionStatement, params:
     match point_read.table_name.as_str() {
         "lix_file" => {
             equality_columns.len() == 1
-                && (equality_columns.contains("id") || equality_columns.contains("path"))
-        }
-        "lix_file_by_branch" => {
-            equality_columns.len() == 2
-                && equality_columns.contains("lixcol_branch_id")
                 && (equality_columns.contains("id") || equality_columns.contains("path"))
         }
         _ => false,
@@ -8246,7 +8226,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn execute_batch_preserves_later_missing_branch_index() {
+    async fn execute_batch_preserves_later_bind_error_index() {
         let session = open_session().await;
         let schema = serde_json::json!({
             "$schema": "https://lix.dev/schema-v1.json",
@@ -8264,40 +8244,30 @@ mod tests {
             )
             .await
             .unwrap();
-        let active_branch_id = session
-            .execute("SELECT lix_active_branch_id() AS id", &[])
-            .await
-            .unwrap()
-            .rows()[0]
-            .get::<String>("id")
-            .unwrap();
-
-        let sql = "INSERT INTO parameter_insert_branch_probe_by_branch \
-                   (id, value, lixcol_branch_id) VALUES ($1, $2, $3)";
         let error = session
             .execute_batch(&[
                 ExecuteBatchStatement {
                     label: None,
-                    sql: sql.to_string(),
+                    sql: "INSERT INTO parameter_insert_branch_probe (id, value) VALUES ($1, $2)"
+                        .to_string(),
                     params: vec![
                         Value::Text("a".to_string()),
                         Value::Text("value-a".to_string()),
-                        Value::Text(active_branch_id),
                     ],
                 },
                 ExecuteBatchStatement {
                     label: None,
-                    sql: sql.to_string(),
+                    sql: "INSERT INTO parameter_insert_branch_probe (id, missing) VALUES ($1, $2)"
+                        .to_string(),
                     params: vec![
                         Value::Text("b".to_string()),
                         Value::Text("value-b".to_string()),
-                        Value::Text("00000000-0000-7000-8000-000000000404".to_string()),
                     ],
                 },
             ])
             .await
-            .expect_err("the second row's missing branch must retain its statement index");
-        assert_eq!(error.code, LixError::CODE_BRANCH_NOT_FOUND);
+            .expect_err("the second statement's bind error must retain its statement index");
+        assert_eq!(error.code, LixError::CODE_COLUMN_NOT_FOUND);
         assert_eq!(error.details.unwrap()["statementIndex"], 1);
 
         let rows = session

--- a/packages/lix/src/sql2/bind/read.rs
+++ b/packages/lix/src/sql2/bind/read.rs
@@ -28,10 +28,9 @@ pub(crate) fn bind_statement_route(
 }
 
 pub(crate) fn bind_read_statement(
-    sql: &str,
+    _sql: &str,
     statement: &DataFusionStatement,
 ) -> Result<(), LixError> {
-    validate_public_read_sql_surface(sql)?;
     if super::classify::classify_datafusion_statement(statement)
         == super::classify::SqlStatementKind::Write
     {
@@ -42,18 +41,5 @@ pub(crate) fn bind_read_statement(
     }
     super::classify::validate_supported_datafusion_statement_ast(statement)?;
     super::public_udf::validate_public_udf_calls_in_datafusion_statement(statement)?;
-    Ok(())
-}
-
-fn validate_public_read_sql_surface(sql: &str) -> Result<(), LixError> {
-    let normalized = sql.to_ascii_lowercase();
-    if normalized.contains("lixcol_branch_id")
-        && (normalized.contains("= lower(") || normalized.contains(" in (lower("))
-    {
-        return Err(LixError::new(
-            LixError::CODE_UNSUPPORTED_SQL,
-            "public column 'lixcol_branch_id' must be compared directly to a literal or parameter",
-        ));
-    }
     Ok(())
 }

--- a/packages/lix/src/sql2/bind/statement.rs
+++ b/packages/lix/src/sql2/bind/statement.rs
@@ -137,12 +137,9 @@ pub(super) fn bind_insert_bound(
         if !matches!(
             table.surface.kind,
             PublicSurfaceKind::SchemaBase { .. }
-                | PublicSurfaceKind::SchemaByBranch { .. }
                 | PublicSurfaceKind::Branch
                 | PublicSurfaceKind::File
-                | PublicSurfaceKind::FileByBranch
                 | PublicSurfaceKind::Directory
-                | PublicSurfaceKind::DirectoryByBranch
         ) {
             return Err(super::error::unsupported(
                 "INSERT ON CONFLICT is not supported for this SQL surface yet",
@@ -611,7 +608,7 @@ fn bind_insert_input(
     let SetExpr::Values(values) = source.body.as_ref() else {
         if matches!(
             surface_kind,
-            PublicSurfaceKind::SchemaBase { .. } | PublicSurfaceKind::SchemaByBranch { .. }
+            PublicSurfaceKind::SchemaBase { .. }
         ) {
             return Err(super::error::unsupported(
                 "INSERT ... SELECT is not supported for schema SQL surfaces yet",
@@ -1338,8 +1335,7 @@ fn require_write_capability(
                 | PublicSurfaceKind::DirectoryHistory
         ) {
             error = error.with_hint("History views are query-only.");
-        } else if let PublicSurfaceKind::SchemaBase { schema_key }
-        | PublicSurfaceKind::SchemaByBranch { schema_key } = &surface.kind
+        } else if let PublicSurfaceKind::SchemaBase { schema_key } = &surface.kind
             && let Some(hint) = crate::sql2::read_only::read_only_schema_surface_hint(schema_key)
         {
             error = error.with_hint(hint);
@@ -1355,17 +1351,8 @@ fn bound_write_target(kind: &PublicSurfaceKind) -> BoundWriteTarget {
                 schema_key: schema_key.clone(),
             })
         }
-        PublicSurfaceKind::SchemaByBranch { schema_key } => {
-            BoundWriteTarget::Row(RowWriteSurface::ByBranch {
-                schema_key: schema_key.clone(),
-            })
-        }
         PublicSurfaceKind::File => BoundWriteTarget::File(FileWriteSurface::Base),
-        PublicSurfaceKind::FileByBranch => BoundWriteTarget::File(FileWriteSurface::ByBranch),
         PublicSurfaceKind::Directory => BoundWriteTarget::Directory(DirectoryWriteSurface::Base),
-        PublicSurfaceKind::DirectoryByBranch => {
-            BoundWriteTarget::Directory(DirectoryWriteSurface::ByBranch)
-        }
         PublicSurfaceKind::Branch => BoundWriteTarget::Branch,
         PublicSurfaceKind::Revert => {
             BoundWriteTarget::DiffCommand(crate::sql2::DiffCommand::Revert)
@@ -1379,11 +1366,8 @@ fn bound_write_target(kind: &PublicSurfaceKind) -> BoundWriteTarget {
         | PublicSurfaceKind::DirectoryHistory
         | PublicSurfaceKind::Change
         | PublicSurfaceKind::WorkingDiff
-        | PublicSurfaceKind::WorkingDiffByBranch
         | PublicSurfaceKind::FileWorkingDiff
-        | PublicSurfaceKind::FileWorkingDiffByBranch
-        | PublicSurfaceKind::DirectoryWorkingDiff
-        | PublicSurfaceKind::DirectoryWorkingDiffByBranch => {
+        | PublicSurfaceKind::DirectoryWorkingDiff => {
             unreachable!("write capability checked before target binding")
         }
     }
@@ -1395,75 +1379,8 @@ fn bind_write_branch_scope(
     predicate: &BoundPredicate,
     active_branch_id: &str,
 ) -> Result<BranchScope, LixError> {
-    let Some(branch_column) = by_branch_column_name(kind) else {
-        return Ok(bind_base_write_branch_scope(
-            kind,
-            predicate,
-            active_branch_id,
-        ));
-    };
-    let branch_selector = match input {
-        BoundWriteInput::Values(values) => {
-            let mut selector = BranchSelector::Missing;
-            if let Some(column_index) = values.column_index(branch_column) {
-                for row in &values.rows {
-                    let value = &row[column_index];
-                    selector = selector.union(value_branch_selector(value)?);
-                }
-            }
-            selector
-        }
-        BoundWriteInput::None => predicate_branch_selector(predicate, branch_column)?,
-        BoundWriteInput::Query { .. } => Err(super::error::unsupported(
-            "INSERT ... SELECT by-branch writes are not supported",
-        ))?,
-    };
-    by_branch_scope(input, branch_column, branch_selector)
-}
-
-fn by_branch_scope(
-    input: &BoundWriteInput,
-    branch_column: &str,
-    selector: BranchSelector,
-) -> Result<BranchScope, LixError> {
-    match (input, selector) {
-        (_, selector) if selector.is_empty() => Ok(BranchScope::Empty),
-        (BoundWriteInput::Values(_), BranchSelector::Missing) => Err(super::error::unsupported(
-            format!("INSERT into by-branch SQL table requires explicit '{branch_column}'"),
-        )),
-        (BoundWriteInput::Values(_), BranchSelector::Static(branch_ids)) => {
-            Ok(BranchScope::Explicit { branch_ids })
-        }
-        (
-            BoundWriteInput::Values(_),
-            BranchSelector::Dynamic {
-                branch_ids,
-                param_indexes,
-            },
-        ) => Ok(BranchScope::ExplicitDynamic {
-            branch_ids,
-            param_indexes,
-        }),
-        (BoundWriteInput::None, BranchSelector::Missing) => Err(super::error::unsupported(
-            format!("by-branch SQL writes require an explicit '{branch_column}' predicate"),
-        )),
-        (BoundWriteInput::None, BranchSelector::Static(branch_ids)) => {
-            Ok(BranchScope::ExplicitRequired { branch_ids })
-        }
-        (
-            BoundWriteInput::None,
-            BranchSelector::Dynamic {
-                branch_ids,
-                param_indexes,
-            },
-        ) => Ok(BranchScope::ExplicitRequiredDynamic {
-            branch_ids,
-            param_indexes,
-        }),
-        (BoundWriteInput::Query { .. }, _) => Err(super::error::unsupported(
-            "INSERT ... SELECT by-branch writes are not supported",
-        )),
-    }
+    let _ = input;
+    Ok(bind_base_write_branch_scope(kind, predicate, active_branch_id))
 }
 
 fn bind_base_write_branch_scope(
@@ -1478,209 +1395,6 @@ fn bind_base_write_branch_scope(
         return BranchScope::Global;
     }
     active_branch_scope(active_branch_id)
-}
-
-fn by_branch_column_name(kind: &PublicSurfaceKind) -> Option<&'static str> {
-    match kind {
-        PublicSurfaceKind::SchemaByBranch { .. }
-        | PublicSurfaceKind::FileByBranch
-        | PublicSurfaceKind::DirectoryByBranch => Some("lixcol_branch_id"),
-        _ => None,
-    }
-}
-
-#[derive(Clone, Debug, Eq, PartialEq)]
-enum BranchSelector {
-    Missing,
-    Static(BTreeSet<String>),
-    Dynamic {
-        branch_ids: BTreeSet<String>,
-        param_indexes: BTreeSet<usize>,
-    },
-}
-
-impl BranchSelector {
-    fn is_empty(&self) -> bool {
-        matches!(self, Self::Static(branch_ids) if branch_ids.is_empty())
-    }
-
-    fn intersect(self, other: Self) -> Self {
-        match (self, other) {
-            (Self::Missing, selector) | (selector, Self::Missing) => selector,
-            (Self::Static(branch_ids), Self::Dynamic { param_indexes, .. })
-            | (Self::Dynamic { param_indexes, .. }, Self::Static(branch_ids))
-                if branch_ids.is_empty() || param_indexes.is_empty() =>
-            {
-                Self::Static(BTreeSet::new())
-            }
-            (Self::Static(left), Self::Static(right)) => {
-                Self::Static(left.intersection(&right).cloned().collect())
-            }
-            (
-                Self::Dynamic {
-                    mut branch_ids,
-                    mut param_indexes,
-                },
-                Self::Dynamic {
-                    branch_ids: right_branches,
-                    param_indexes: right_params,
-                },
-            ) => {
-                branch_ids.extend(right_branches);
-                param_indexes.extend(right_params);
-                Self::Dynamic {
-                    branch_ids,
-                    param_indexes,
-                }
-            }
-            (
-                Self::Static(mut branch_ids),
-                Self::Dynamic {
-                    branch_ids: right_branches,
-                    param_indexes,
-                },
-            )
-            | (
-                Self::Dynamic {
-                    branch_ids: right_branches,
-                    param_indexes,
-                },
-                Self::Static(mut branch_ids),
-            ) => {
-                branch_ids.extend(right_branches);
-                Self::Dynamic {
-                    branch_ids,
-                    param_indexes,
-                }
-            }
-        }
-    }
-
-    fn union(self, other: Self) -> Self {
-        match (self, other) {
-            (Self::Missing, selector) | (selector, Self::Missing) => selector,
-            (Self::Static(mut left), Self::Static(right)) => {
-                left.extend(right);
-                Self::Static(left)
-            }
-            (
-                Self::Dynamic {
-                    mut branch_ids,
-                    mut param_indexes,
-                },
-                Self::Dynamic {
-                    branch_ids: right_branches,
-                    param_indexes: right_params,
-                },
-            ) => {
-                branch_ids.extend(right_branches);
-                param_indexes.extend(right_params);
-                Self::Dynamic {
-                    branch_ids,
-                    param_indexes,
-                }
-            }
-            (
-                Self::Static(mut branch_ids),
-                Self::Dynamic {
-                    branch_ids: right_branches,
-                    param_indexes,
-                },
-            )
-            | (
-                Self::Dynamic {
-                    branch_ids: right_branches,
-                    param_indexes,
-                },
-                Self::Static(mut branch_ids),
-            ) => {
-                branch_ids.extend(right_branches);
-                Self::Dynamic {
-                    branch_ids,
-                    param_indexes,
-                }
-            }
-        }
-    }
-}
-
-fn predicate_branch_selector(
-    predicate: &BoundPredicate,
-    branch_column: &str,
-) -> Result<BranchSelector, LixError> {
-    match predicate {
-        BoundPredicate::True
-        | BoundPredicate::Like { .. }
-        | BoundPredicate::IsNull(_)
-        | BoundPredicate::IsNotNull(_) => Ok(BranchSelector::Missing),
-        BoundPredicate::False => Ok(BranchSelector::Static(BTreeSet::new())),
-        BoundPredicate::And(predicates) => {
-            let mut result = BranchSelector::Missing;
-            for predicate in predicates {
-                result = result.intersect(predicate_branch_selector(predicate, branch_column)?);
-            }
-            Ok(result)
-        }
-        BoundPredicate::Or(predicates) => {
-            let mut result = BranchSelector::Static(BTreeSet::new());
-            for predicate in predicates {
-                let selector = predicate_branch_selector(predicate, branch_column)?;
-                if selector == BranchSelector::Missing {
-                    return Ok(BranchSelector::Missing);
-                }
-                result = result.union(selector);
-            }
-            Ok(result)
-        }
-        BoundPredicate::Eq(left, right) => {
-            branch_selector_from_binary_exprs(left, right, branch_column)
-                .or_else(|| branch_selector_from_binary_exprs(right, left, branch_column))
-                .transpose()
-                .map(|selector| selector.unwrap_or(BranchSelector::Missing))
-        }
-        BoundPredicate::In { expr, values } => {
-            let BoundExpr::Column(column) = expr else {
-                return Ok(BranchSelector::Missing);
-            };
-            if column.name != branch_column {
-                return Ok(BranchSelector::Missing);
-            }
-            let mut selector = BranchSelector::Missing;
-            for value in values {
-                selector = selector.union(value_branch_selector(value)?);
-            }
-            Ok(selector)
-        }
-    }
-}
-
-fn branch_selector_from_binary_exprs(
-    column_expr: &BoundExpr,
-    value_expr: &BoundExpr,
-    branch_column: &str,
-) -> Option<Result<BranchSelector, LixError>> {
-    let BoundExpr::Column(column) = column_expr else {
-        return None;
-    };
-    if column.name != branch_column {
-        return None;
-    }
-    Some(value_branch_selector(value_expr))
-}
-
-fn value_branch_selector(expr: &BoundExpr) -> Result<BranchSelector, LixError> {
-    match expr {
-        BoundExpr::Literal(BoundLiteral::Text(branch_id)) => {
-            Ok(BranchSelector::Static(BTreeSet::from([branch_id.clone()])))
-        }
-        BoundExpr::Param(param) => Ok(BranchSelector::Dynamic {
-            branch_ids: BTreeSet::new(),
-            param_indexes: BTreeSet::from([param.index]),
-        }),
-        _ => Err(super::error::unsupported(
-            "by-branch SQL write predicates require string branch ids",
-        )),
-    }
 }
 
 fn active_branch_scope(active_branch_id: &str) -> BranchScope {
@@ -1870,7 +1584,7 @@ mod tests {
     #[test]
     fn bind_statement_preserves_update_assignment_and_predicate() {
         let statement = parse_statement(
-            "UPDATE test_state_schema_by_branch SET name = 'next' WHERE lixcol_branch_id = 'branch2'",
+            "UPDATE test_state_schema SET name = 'next' WHERE id = 'row-1'",
         );
         let bound = bind_statement(
             &statement,
@@ -1890,7 +1604,7 @@ mod tests {
         let write = bound;
         assert!(matches!(
             write.target,
-            BoundWriteTarget::Row(RowWriteSurface::ByBranch { .. })
+            BoundWriteTarget::Row(RowWriteSurface::Base { .. })
         ));
         assert_eq!(write.op, BoundWriteOp::Update);
         assert_eq!(write.assignments.len(), 1);
@@ -1904,12 +1618,11 @@ mod tests {
             BoundPredicate::Eq(
                 BoundExpr::Column(ref column),
                 BoundExpr::Literal(BoundLiteral::Text(ref value)),
-            ) if column.name == "lixcol_branch_id" && value == "branch2"
+            ) if column.name == "id" && value == "row-1"
         ));
         assert!(matches!(
             write.branch_scope,
-            BranchScope::ExplicitRequired { ref branch_ids }
-                if branch_ids == &BTreeSet::from(["branch2".to_string()])
+            BranchScope::Active { ref branch_id } if branch_id == "branch1"
         ));
     }
 
@@ -2041,76 +1754,6 @@ mod tests {
     }
 
     #[test]
-    fn bind_statement_binds_by_branch_insert_scope_from_branch_column() {
-        let statement = parse_statement(
-            "INSERT INTO lix_file_by_branch (id, name, lixcol_branch_id) VALUES ('file1', 'a', 'branch2')",
-        );
-        let bound = bind_statement(&statement, &[], "branch1").expect("insert should bind");
-
-        let write = bound;
-        assert!(matches!(
-            write.branch_scope,
-            BranchScope::Explicit { ref branch_ids }
-                if branch_ids == &BTreeSet::from(["branch2".to_string()])
-        ));
-    }
-
-    #[test]
-    fn bind_statement_preserves_parameterized_by_branch_scope_selectors() {
-        let update = bind_statement(
-            &parse_statement(
-                "UPDATE lix_file_by_branch SET name = 'renamed.txt' WHERE id = 'file1' AND lixcol_branch_id = $1",
-            ),
-            &[],
-            "branch1",
-        )
-        .expect("parameterized update branch scope should bind");
-        assert_eq!(
-            update.branch_scope,
-            BranchScope::ExplicitRequiredDynamic {
-                branch_ids: BTreeSet::new(),
-                param_indexes: BTreeSet::from([1])
-            }
-        );
-
-        let insert = bind_statement(
-            &parse_statement(
-                "INSERT INTO lix_file_by_branch (id, name, lixcol_branch_id) VALUES ('file1', 'a', $1)",
-            ),
-            &[],
-            "branch1",
-        )
-        .expect("parameterized insert branch scope should bind");
-        assert_eq!(
-            insert.branch_scope,
-            BranchScope::ExplicitDynamic {
-                branch_ids: BTreeSet::new(),
-                param_indexes: BTreeSet::from([1])
-            }
-        );
-    }
-
-    #[test]
-    fn bind_statement_binds_contradictory_by_branch_selectors_as_empty() {
-        let statement = parse_statement(
-            "DELETE FROM lix_file_by_branch WHERE lixcol_branch_id IN ('v1') AND lixcol_branch_id IN ('v2')",
-        );
-        let bound = bind_statement(&statement, &[], "branch1").expect("delete should bind");
-
-        let write = bound;
-        assert_eq!(write.branch_scope, BranchScope::Empty);
-    }
-
-    #[test]
-    fn bind_statement_binds_false_by_branch_predicate_as_empty() {
-        let statement = parse_statement("DELETE FROM lix_file_by_branch WHERE false");
-        let bound = bind_statement(&statement, &[], "branch1").expect("no-match delete binds");
-
-        let write = bound;
-        assert_eq!(write.branch_scope, BranchScope::Empty);
-    }
-
-    #[test]
     fn bind_statement_binds_false_base_predicates_as_empty() {
         for sql in [
             "DELETE FROM lix_file WHERE false",
@@ -2191,18 +1834,6 @@ mod tests {
     }
 
     #[test]
-    fn bind_statement_rejects_by_branch_writes_without_branch_selector() {
-        let statement = parse_statement(
-            "UPDATE lix_file_by_branch SET name = 'renamed.txt' WHERE id = 'file1'",
-        );
-        let error = bind_statement(&statement, &[], "branch1")
-            .expect_err("by-branch writes should require explicit branch predicate");
-
-        assert_eq!(error.code, LixError::CODE_UNSUPPORTED_SQL);
-        assert!(error.message.contains("require an explicit"));
-    }
-
-    #[test]
     fn bind_statement_binds_delete_like_predicate_and_parameter() {
         let statement = parse_statement("DELETE FROM lix_file WHERE path NOT LIKE $1");
         let bound = bind_statement(&statement, &[], "branch1").expect("DELETE LIKE should bind");
@@ -2221,17 +1852,6 @@ mod tests {
             bound.params.params.keys().copied().collect::<Vec<_>>(),
             vec![1]
         );
-    }
-
-    #[test]
-    fn bind_statement_keeps_like_out_of_by_branch_scope_selection() {
-        let statement =
-            parse_statement("DELETE FROM lix_file_by_branch WHERE lixcol_branch_id LIKE 'draft%'");
-        let error = bind_statement(&statement, &[], "branch1")
-            .expect_err("LIKE must not grant a by-branch write scope");
-
-        assert_eq!(error.code, LixError::CODE_UNSUPPORTED_SQL);
-        assert!(error.message.contains("require an explicit"));
     }
 
     #[test]
@@ -2423,17 +2043,6 @@ mod tests {
                 .message
                 .contains("unsupported SQL parameter placeholder")
         );
-    }
-
-    #[test]
-    fn bind_statement_rejects_read_only_by_branch_columns_as_write_targets() {
-        let statement =
-            parse_statement("UPDATE lix_file_by_branch SET lixcol_branch_id = 'branch2'");
-        let error = bind_statement(&statement, &[], "branch1")
-            .expect_err("by-branch branch columns are filter-only");
-
-        assert_eq!(error.code, LixError::CODE_UNSUPPORTED_SQL);
-        assert!(error.message.contains("is not writable"));
     }
 
     #[test]

--- a/packages/lix/src/sql2/bind/table.rs
+++ b/packages/lix/src/sql2/bind/table.rs
@@ -157,25 +157,6 @@ mod tests {
     }
 
     #[test]
-    fn by_branch_row_exposes_lixcol_branch_id_without_branch_id_alias() {
-        let catalog = catalog();
-        let table = bind_public_table(
-            &catalog,
-            &table_name("SELECT * FROM test_state_schema_by_branch"),
-        )
-        .expect("by-branch row table should bind");
-
-        assert!(matches!(
-            table.surface.kind,
-            PublicSurfaceKind::SchemaByBranch { .. }
-        ));
-        assert!(require_public_column(&table, "lixcol_branch_id").is_ok());
-        let error = require_public_column(&table, "branch_id")
-            .expect_err("by-branch schema surface should not alias branch_id");
-        assert!(error.message.contains("does not exist"));
-    }
-
-    #[test]
     fn quoted_table_names_are_case_sensitive() {
         let catalog = catalog();
 
@@ -236,46 +217,38 @@ mod tests {
             .collect::<Vec<_>>();
         let expected = vec![
             "lix_account",
-            "lix_account_by_branch",
             "lix_account_history",
             "lix_apply",
             "lix_branch",
             "lix_branch_descriptor",
-            "lix_branch_descriptor_by_branch",
             "lix_branch_descriptor_history",
             "lix_branch_ref",
-            "lix_branch_ref_by_branch",
             "lix_branch_ref_history",
             "lix_change",
             "lix_checkpoint",
             "lix_checkpoint_history",
             "lix_commit",
-            "lix_commit_by_branch",
             "lix_commit_edge",
-            "lix_commit_edge_by_branch",
             "lix_create_checkpoint",
             "lix_directory",
-            "lix_directory_by_branch",
             "lix_directory_history",
             "lix_directory_working_diff",
-            "lix_directory_working_diff_by_branch",
             "lix_file",
-            "lix_file_by_branch",
             "lix_file_history",
             "lix_file_working_diff",
-            "lix_file_working_diff_by_branch",
             "lix_key_value",
-            "lix_key_value_by_branch",
             "lix_key_value_history",
             "lix_registered_schema",
-            "lix_registered_schema_by_branch",
             "lix_registered_schema_history",
             "lix_revert",
             "lix_working_diff",
-            "lix_working_diff_by_branch",
         ];
 
         assert_eq!(actual, expected);
+        assert!(
+            actual.iter().all(|name| !name.ends_with("_by_branch")),
+            "the public catalog must not expose explicit-branch table variants"
+        );
     }
 
     #[test]
@@ -283,15 +256,12 @@ mod tests {
         let catalog = PublicCatalog::fixed_system();
         for surface_name in [
             "lix_key_value",
-            "lix_key_value_by_branch",
             "lix_key_value_history",
             "lix_registered_schema",
-            "lix_registered_schema_by_branch",
             "lix_registered_schema_history",
             "lix_checkpoint",
             "lix_checkpoint_history",
             "lix_working_diff",
-            "lix_working_diff_by_branch",
         ] {
             assert!(
                 catalog.surface(surface_name).is_some(),
@@ -299,6 +269,9 @@ mod tests {
             );
         }
         for surface_name in [
+            "lix_key_value_by_branch",
+            "lix_registered_schema_by_branch",
+            "lix_working_diff_by_branch",
             "lix_state",
             "lix_state_by_branch",
             "lix_state_history",

--- a/packages/lix/src/sql2/bind/write.rs
+++ b/packages/lix/src/sql2/bind/write.rs
@@ -45,19 +45,16 @@ pub(crate) enum BoundWriteTarget {
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub(crate) enum RowWriteSurface {
     Base { schema_key: String },
-    ByBranch { schema_key: String },
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub(crate) enum FileWriteSurface {
     Base,
-    ByBranch,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub(crate) enum DirectoryWriteSurface {
     Base,
-    ByBranch,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]

--- a/packages/lix/src/sql2/branch_scope.rs
+++ b/packages/lix/src/sql2/branch_scope.rs
@@ -1,29 +1,16 @@
-use std::collections::BTreeSet;
-
 use datafusion::error::DataFusionError;
-use datafusion::logical_expr::expr::InList;
-use datafusion::logical_expr::{BinaryExpr, Expr, Operator};
-use datafusion::scalar::ScalarValue;
 
 use crate::GLOBAL_BRANCH_ID;
 use crate::LixError;
 use crate::branch::BranchRefReader;
 
-/// Branch scope requested by a SQL surface.
-///
-/// Active surfaces read through one session branch. By-branch surfaces either
-/// read explicitly filtered branches or, without a branch predicate, enumerate
-/// every visible branch scope before handing the request to hot_state.
 pub(crate) enum SqlBranchScope {
     Active(String),
-    Explicit(Vec<String>),
-    AllVisible,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum BranchBinding {
     Active { branch_id: String },
-    Explicit,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -39,48 +26,28 @@ impl BranchBinding {
         }
     }
 
-    pub(crate) fn explicit() -> Self {
-        Self::Explicit
-    }
-
     pub(crate) fn active_branch_id(&self) -> Option<&str> {
         match self {
             Self::Active { branch_id } => Some(branch_id),
-            Self::Explicit => None,
         }
     }
 }
 
 pub(crate) fn resolve_write_branch_scope(
     explicit_global: Option<bool>,
-    explicit_branch_id: Option<String>,
     fallback_branch_id: Option<&str>,
     action: &str,
-    surface: &str,
 ) -> Result<WriteBranchScope, DataFusionError> {
     if explicit_global == Some(true) {
-        if explicit_branch_id
-            .as_deref()
-            .is_some_and(|branch_id| branch_id != GLOBAL_BRANCH_ID)
-        {
-            return Err(DataFusionError::Execution(format!(
-                "{surface} cannot set lixcol_global=true with non-global lixcol_branch_id"
-            )));
-        }
         return Ok(WriteBranchScope {
             branch_id: GLOBAL_BRANCH_ID.to_string(),
             global: true,
         });
     }
 
-    let branch_id = explicit_branch_id
-        .or_else(|| fallback_branch_id.map(ToOwned::to_owned))
-        .ok_or_else(|| DataFusionError::Execution(format!("{action} requires lixcol_branch_id")))?;
-    if explicit_global == Some(false) && branch_id == GLOBAL_BRANCH_ID {
-        return Err(DataFusionError::Execution(format!(
-            "{surface} cannot set lixcol_global=false with global lixcol_branch_id"
-        )));
-    }
+    let branch_id = fallback_branch_id
+        .map(ToOwned::to_owned)
+        .ok_or_else(|| DataFusionError::Execution(format!("{action} requires an active branch")))?;
     Ok(WriteBranchScope {
         global: explicit_global.unwrap_or(branch_id == GLOBAL_BRANCH_ID),
         branch_id,
@@ -90,12 +57,10 @@ pub(crate) fn resolve_write_branch_scope(
 impl SqlBranchScope {
     pub(crate) fn from_provider(
         binding: &BranchBinding,
-        requested_branch_ids: Vec<String>,
+        _requested_branch_ids: Vec<String>,
     ) -> Self {
         match binding {
             BranchBinding::Active { branch_id } => Self::Active(branch_id.clone()),
-            BranchBinding::Explicit if requested_branch_ids.is_empty() => Self::AllVisible,
-            BranchBinding::Explicit => Self::Explicit(requested_branch_ids),
         }
     }
 }
@@ -115,22 +80,6 @@ pub(crate) async fn resolve_sql_branch_scope(
             }
             Ok(vec![branch_id])
         }
-        SqlBranchScope::Explicit(branch_ids) => {
-            for branch_id in &branch_ids {
-                if branch_id == GLOBAL_BRANCH_ID {
-                    continue;
-                }
-                if branch_ref.load_head(branch_id).await?.is_none() {
-                    return Err(LixError::branch_not_found(
-                        branch_id.clone(),
-                        "resolve SQL explicit branch scope",
-                        "requested branch",
-                    ));
-                }
-            }
-            Ok(branch_ids)
-        }
-        SqlBranchScope::AllVisible => visible_branch_ids(branch_ref).await,
     }
 }
 
@@ -146,93 +95,6 @@ pub(crate) async fn resolve_provider_branch_ids(
     .await
 }
 
-pub(crate) fn explicit_branch_ids_from_dml_filters(filters: &[Expr]) -> Vec<String> {
-    filters
-        .iter()
-        .flat_map(branch_ids_from_filter)
-        .collect::<BTreeSet<_>>()
-        .into_iter()
-        .collect()
-}
-
-fn branch_ids_from_filter(expr: &Expr) -> Vec<String> {
-    match expr {
-        Expr::BinaryExpr(binary_expr) if binary_expr.op == Operator::And => {
-            let mut values = branch_ids_from_filter(&binary_expr.left);
-            values.extend(branch_ids_from_filter(&binary_expr.right));
-            values
-        }
-        Expr::BinaryExpr(binary_expr) => branch_id_from_binary_filter(binary_expr)
-            .map(|value| vec![value])
-            .unwrap_or_default(),
-        Expr::InList(in_list) => branch_ids_from_in_list_filter(in_list).unwrap_or_default(),
-        _ => Vec::new(),
-    }
-}
-
-fn branch_id_from_binary_filter(binary_expr: &BinaryExpr) -> Option<String> {
-    if binary_expr.op != Operator::Eq {
-        return None;
-    }
-
-    branch_id_from_column_literal_filter(&binary_expr.left, &binary_expr.right)
-        .or_else(|| branch_id_from_column_literal_filter(&binary_expr.right, &binary_expr.left))
-}
-
-fn branch_ids_from_in_list_filter(in_list: &InList) -> Option<Vec<String>> {
-    if in_list.negated {
-        return None;
-    }
-    let Expr::Column(column) = in_list.expr.as_ref() else {
-        return None;
-    };
-    if column.name != "lixcol_branch_id" {
-        return None;
-    }
-
-    let values = in_list
-        .list
-        .iter()
-        .map(string_expr_literal)
-        .collect::<Option<Vec<_>>>()?;
-    if values.is_empty() {
-        return None;
-    }
-    Some(values)
-}
-
-fn branch_id_from_column_literal_filter(column_expr: &Expr, literal_expr: &Expr) -> Option<String> {
-    let Expr::Column(column) = column_expr else {
-        return None;
-    };
-    if column.name != "lixcol_branch_id" {
-        return None;
-    }
-    string_expr_literal(literal_expr)
-}
-
-fn string_expr_literal(expr: &Expr) -> Option<String> {
-    let Expr::Literal(literal, _) = expr else {
-        return None;
-    };
-    match literal {
-        ScalarValue::Utf8(Some(value))
-        | ScalarValue::Utf8View(Some(value))
-        | ScalarValue::LargeUtf8(Some(value)) => Some(value.clone()),
-        _ => None,
-    }
-}
-
-async fn visible_branch_ids(branch_ref: &dyn BranchRefReader) -> Result<Vec<String>, LixError> {
-    let mut branch_ids = branch_ref
-        .scan_heads()
-        .await?
-        .into_iter()
-        .map(|head| head.branch_id)
-        .collect::<BTreeSet<_>>();
-    branch_ids.insert(GLOBAL_BRANCH_ID.to_string());
-    Ok(branch_ids.into_iter().collect())
-}
 
 #[cfg(test)]
 mod tests {
@@ -268,85 +130,15 @@ mod tests {
         assert!(error.message.contains("branch 'main' was not found"));
     }
 
-    #[tokio::test]
-    async fn explicit_scope_keeps_requested_branches() {
-        let branch_ref = RowsBranchRefReader::new(vec![BranchHead {
-            branch_id: "01920000-0000-7000-8000-0000000000a1".to_string(),
-            commit_id: CommitId::for_test_label("commit-01920000-0000-7000-8000-0000000000a1"),
-        }]);
-        let ids = resolve_provider_branch_ids(
-            &branch_ref,
-            &BranchBinding::explicit(),
-            vec![
-                "01920000-0000-7000-8000-0000000000a1".to_string(),
-                "ffffffff-ffff-7fff-bfff-ffffffffffff".to_string(),
-            ],
-        )
-        .await
-        .expect("scope should resolve");
 
-        assert_eq!(
-            ids,
-            vec![
-                "01920000-0000-7000-8000-0000000000a1".to_string(),
-                "ffffffff-ffff-7fff-bfff-ffffffffffff".to_string()
-            ]
-        );
-    }
 
-    #[tokio::test]
-    async fn explicit_scope_rejects_missing_branch_ref() {
-        let branch_ref = RowsBranchRefReader::new(Vec::new());
-        let error = resolve_provider_branch_ids(
-            &branch_ref,
-            &BranchBinding::explicit(),
-            vec!["missing-branch".to_string()],
-        )
-        .await
-        .expect_err("missing explicit branch should be rejected");
-
-        assert_eq!(error.code, LixError::CODE_BRANCH_NOT_FOUND);
-        assert!(
-            error
-                .message
-                .contains("branch 'missing-branch' was not found")
-        );
-    }
-
-    #[tokio::test]
-    async fn all_visible_scope_loads_branch_refs_and_global() {
-        let branch_ref = RowsBranchRefReader::new(vec![
-            BranchHead {
-                branch_id: "01920000-0000-7000-8000-0000000000b1".to_string(),
-                commit_id: CommitId::for_test_label("commit-01920000-0000-7000-8000-0000000000b1"),
-            },
-            BranchHead {
-                branch_id: "01920000-0000-7000-8000-0000000000a1".to_string(),
-                commit_id: CommitId::for_test_label("commit-01920000-0000-7000-8000-0000000000a1"),
-            },
-        ]);
-        let ids = resolve_provider_branch_ids(&branch_ref, &BranchBinding::explicit(), Vec::new())
-            .await
-            .expect("scope should resolve");
-
-        assert_eq!(
-            ids,
-            vec![
-                "01920000-0000-7000-8000-0000000000a1".to_string(),
-                "01920000-0000-7000-8000-0000000000b1".to_string(),
-                "ffffffff-ffff-7fff-bfff-ffffffffffff".to_string(),
-            ]
-        );
-    }
 
     #[test]
     fn write_scope_uses_fallback_branch_when_branch_is_implicit() {
         let scope = resolve_write_branch_scope(
             None,
-            None,
             Some("active-branch"),
             "INSERT into surface",
-            "surface",
         )
         .expect("scope should resolve");
 
@@ -361,13 +153,13 @@ mod tests {
 
     #[test]
     fn write_scope_requires_branch_without_fallback() {
-        let error = resolve_write_branch_scope(None, None, None, "INSERT into surface", "surface")
+        let error = resolve_write_branch_scope(None, None, "INSERT into surface")
             .expect_err("missing branch should be rejected");
 
         assert!(
             error
                 .to_string()
-                .contains("INSERT into surface requires lixcol_branch_id")
+                .contains("INSERT into surface requires an active branch")
         );
     }
 
@@ -375,10 +167,8 @@ mod tests {
     fn write_scope_derives_global_from_global_branch_id() {
         let scope = resolve_write_branch_scope(
             None,
-            Some(GLOBAL_BRANCH_ID.to_string()),
-            None,
+            Some(GLOBAL_BRANCH_ID),
             "INSERT into surface",
-            "surface",
         )
         .expect("scope should resolve");
 
@@ -388,42 +178,6 @@ mod tests {
                 branch_id: GLOBAL_BRANCH_ID.to_string(),
                 global: true,
             }
-        );
-    }
-
-    #[test]
-    fn write_scope_rejects_non_global_with_global_branch_id() {
-        let error = resolve_write_branch_scope(
-            Some(false),
-            Some(GLOBAL_BRANCH_ID.to_string()),
-            None,
-            "INSERT into surface",
-            "surface",
-        )
-        .expect_err("conflicting global/branch scope should be rejected");
-
-        assert!(
-            error
-                .to_string()
-                .contains("surface cannot set lixcol_global=false with global lixcol_branch_id")
-        );
-    }
-
-    #[test]
-    fn write_scope_rejects_global_with_non_global_branch_id() {
-        let error = resolve_write_branch_scope(
-            Some(true),
-            Some("01920000-0000-7000-8000-0000000000a1".to_string()),
-            None,
-            "INSERT into surface",
-            "surface",
-        )
-        .expect_err("conflicting global/branch scope should be rejected");
-
-        assert!(
-            error
-                .to_string()
-                .contains("surface cannot set lixcol_global=true with non-global lixcol_branch_id")
         );
     }
 

--- a/packages/lix/src/sql2/catalog/registry.rs
+++ b/packages/lix/src/sql2/catalog/registry.rs
@@ -100,18 +100,15 @@ impl PublicCatalog {
     pub(crate) fn surface_schema(&self, table_name: &str) -> Option<SchemaRef> {
         let surface = self.surface(table_name)?;
         Some(match &surface.kind {
-            PublicSurfaceKind::File => filesystem_schema(false, true),
-            PublicSurfaceKind::FileByBranch => filesystem_schema(true, true),
-            PublicSurfaceKind::Directory => filesystem_schema(false, false),
-            PublicSurfaceKind::DirectoryByBranch => filesystem_schema(true, false),
+            PublicSurfaceKind::File => filesystem_schema(true),
+            PublicSurfaceKind::Directory => filesystem_schema(false),
             PublicSurfaceKind::Branch => Arc::new(Schema::new(vec![
                 Field::new("id", DataType::Utf8, false),
                 Field::new("name", DataType::Utf8, false),
                 Field::new("hidden", DataType::Boolean, false),
                 Field::new("commit_id", DataType::Utf8, false),
             ])),
-            PublicSurfaceKind::WorkingDiff => working_diff_schema(false),
-            PublicSurfaceKind::WorkingDiffByBranch => working_diff_schema(true),
+            PublicSurfaceKind::WorkingDiff => working_diff_schema(),
             PublicSurfaceKind::Revert
             | PublicSurfaceKind::Apply
             | PublicSurfaceKind::CreateCheckpoint => Arc::new(Schema::new(vec![Field::new(
@@ -120,11 +117,7 @@ impl PublicCatalog {
                 false,
             )])),
             PublicSurfaceKind::FileWorkingDiff | PublicSurfaceKind::DirectoryWorkingDiff => {
-                filesystem_working_diff_schema(false)
-            }
-            PublicSurfaceKind::FileWorkingDiffByBranch
-            | PublicSurfaceKind::DirectoryWorkingDiffByBranch => {
-                filesystem_working_diff_schema(true)
+                filesystem_working_diff_schema()
             }
             PublicSurfaceKind::Change => Arc::new(Schema::new(vec![
                 Field::new("id", DataType::Utf8, false),
@@ -141,9 +134,6 @@ impl PublicCatalog {
             PublicSurfaceKind::DirectoryHistory => history_filesystem_schema(false),
             PublicSurfaceKind::SchemaBase { schema_key } => {
                 schema_surface_schema(self.schema_spec(schema_key)?, SchemaSurfaceShape::Active)
-            }
-            PublicSurfaceKind::SchemaByBranch { schema_key } => {
-                schema_surface_schema(self.schema_spec(schema_key)?, SchemaSurfaceShape::ByBranch)
             }
             PublicSurfaceKind::SchemaHistory { schema_key } => {
                 schema_surface_schema(self.schema_spec(schema_key)?, SchemaSurfaceShape::History)
@@ -180,25 +170,13 @@ impl PublicCatalog {
         self.insert(surface(
             "lix_file",
             PublicSurfaceKind::File,
-            filesystem_columns(false),
-            SurfaceCapabilities::read_write(),
-        ))?;
-        self.insert(surface(
-            "lix_file_by_branch",
-            PublicSurfaceKind::FileByBranch,
-            filesystem_columns(true),
+            filesystem_columns(),
             SurfaceCapabilities::read_write(),
         ))?;
         self.insert(surface(
             "lix_directory",
             PublicSurfaceKind::Directory,
-            directory_columns(false),
-            SurfaceCapabilities::read_write(),
-        ))?;
-        self.insert(surface(
-            "lix_directory_by_branch",
-            PublicSurfaceKind::DirectoryByBranch,
-            directory_columns(true),
+            directory_columns(),
             SurfaceCapabilities::read_write(),
         ))?;
         self.insert(surface(
@@ -243,21 +221,6 @@ impl PublicCatalog {
             ]),
             SurfaceCapabilities::read_only(),
         ))?;
-        self.insert(surface(
-            "lix_working_diff_by_branch",
-            PublicSurfaceKind::WorkingDiffByBranch,
-            public_columns([
-                ("diff_id", false),
-                ("row_pk", false),
-                ("schema_key", false),
-                ("file_id", true),
-                ("diff_type", false),
-                ("before_change_id", true),
-                ("after_change_id", true),
-                ("lixcol_branch_id", false),
-            ]),
-            SurfaceCapabilities::read_only(),
-        ))?;
         for (name, kind) in [
             ("lix_revert", PublicSurfaceKind::Revert),
             ("lix_apply", PublicSurfaceKind::Apply),
@@ -277,37 +240,22 @@ impl PublicCatalog {
                 },
             ))?;
         }
-        for (name, kind, by_branch) in [
+        for (name, kind) in [
             (
                 "lix_file_working_diff",
                 PublicSurfaceKind::FileWorkingDiff,
-                false,
-            ),
-            (
-                "lix_file_working_diff_by_branch",
-                PublicSurfaceKind::FileWorkingDiffByBranch,
-                true,
             ),
             (
                 "lix_directory_working_diff",
                 PublicSurfaceKind::DirectoryWorkingDiff,
-                false,
-            ),
-            (
-                "lix_directory_working_diff_by_branch",
-                PublicSurfaceKind::DirectoryWorkingDiffByBranch,
-                true,
             ),
         ] {
-            let mut columns = vec![
+            let columns = vec![
                 ("id", false),
                 ("path", true),
                 ("previous_path", true),
                 ("change_kind", false),
             ];
-            if by_branch {
-                columns.push(("lixcol_branch_id", false));
-            }
             self.insert(surface(
                 name,
                 kind,
@@ -357,7 +305,7 @@ impl PublicCatalog {
         }
 
         let mut columns = row_columns(&spec);
-        columns.extend(row_hidden_columns(&spec, false));
+        columns.extend(row_hidden_columns(&spec));
         let capabilities = if crate::sql2::read_only::is_read_only_schema_surface(&spec.schema_key)
         {
             SurfaceCapabilities::read_only()
@@ -373,20 +321,6 @@ impl PublicCatalog {
             columns,
             capabilities.clone(),
         ))?;
-
-        if spec.schema_key != crate::checkpoint::CHECKPOINT_SCHEMA_KEY {
-            let mut by_branch_columns = row_columns(&spec);
-            by_branch_columns.extend(row_hidden_columns(&spec, true));
-
-            self.insert(surface(
-                format!("{}_by_branch", spec.schema_key),
-                PublicSurfaceKind::SchemaByBranch {
-                    schema_key: spec.schema_key.clone(),
-                },
-                by_branch_columns,
-                capabilities,
-            ))?;
-        }
 
         if schema_exposed_as_history_surface(&spec.schema_key) {
             let history_identity_roots = primary_key_roots(&spec);
@@ -418,8 +352,8 @@ impl PublicCatalog {
 }
 
 #[cfg(test)]
-fn working_diff_schema(by_branch: bool) -> SchemaRef {
-    let mut fields = vec![
+fn working_diff_schema() -> SchemaRef {
+    let fields = vec![
         Field::new("diff_id", DataType::Utf8, false),
         json_field("row_pk", false),
         Field::new("schema_key", DataType::Utf8, false),
@@ -428,14 +362,11 @@ fn working_diff_schema(by_branch: bool) -> SchemaRef {
         Field::new("before_change_id", DataType::Utf8, true),
         Field::new("after_change_id", DataType::Utf8, true),
     ];
-    if by_branch {
-        fields.push(Field::new("lixcol_branch_id", DataType::Utf8, false));
-    }
     Arc::new(Schema::new(fields))
 }
 
 #[cfg(test)]
-fn filesystem_schema(by_branch: bool, include_data: bool) -> SchemaRef {
+fn filesystem_schema(include_data: bool) -> SchemaRef {
     let mut fields = if include_data {
         vec![
             Field::new("id", DataType::Utf8, true),
@@ -464,9 +395,6 @@ fn filesystem_schema(by_branch: bool, include_data: bool) -> SchemaRef {
         Field::new("lixcol_untracked", DataType::Boolean, true),
         json_field("lixcol_metadata", true),
     ]);
-    if by_branch {
-        fields.push(Field::new("lixcol_branch_id", DataType::Utf8, false));
-    }
     Arc::new(Schema::new(fields))
 }
 
@@ -556,7 +484,7 @@ fn row_columns(spec: &SchemaSurfaceSpec) -> Vec<PublicColumn> {
         .collect()
 }
 
-fn filesystem_columns(by_branch: bool) -> Vec<PublicColumn> {
+fn filesystem_columns() -> Vec<PublicColumn> {
     let mut columns = vec![
         PublicColumn::public_insert_only("id", false).with_default("uuidv7()"),
         PublicColumn::public("path", false).conditional_on_insert(),
@@ -564,34 +492,27 @@ fn filesystem_columns(by_branch: bool) -> Vec<PublicColumn> {
         PublicColumn::public("name", false).conditional_on_insert(),
         PublicColumn::public("content", false).with_default("CAST('' AS BYTEA)"),
     ];
-    columns.extend(filesystem_hidden_columns(by_branch));
+    columns.extend(filesystem_hidden_columns());
     columns
 }
 
-fn directory_columns(by_branch: bool) -> Vec<PublicColumn> {
+fn directory_columns() -> Vec<PublicColumn> {
     let mut columns = vec![
         PublicColumn::public_insert_only("id", false).with_default("uuidv7()"),
         PublicColumn::public("path", true).conditional_on_insert(),
         PublicColumn::public("parent_id", true).conditional_on_insert(),
         PublicColumn::public("name", false).conditional_on_insert(),
     ];
-    columns.extend(filesystem_hidden_columns(by_branch));
+    columns.extend(filesystem_hidden_columns());
     columns
 }
 
-fn row_hidden_columns(spec: &SchemaSurfaceSpec, by_branch: bool) -> Vec<PublicColumn> {
-    row_system_columns(
-        spec,
-        if by_branch {
-            SchemaSurfaceShape::ByBranch
-        } else {
-            SchemaSurfaceShape::Active
-        },
-    )
+fn row_hidden_columns(spec: &SchemaSurfaceSpec) -> Vec<PublicColumn> {
+    row_system_columns(spec, SchemaSurfaceShape::Active)
 }
 
-fn filesystem_hidden_columns(by_branch: bool) -> Vec<PublicColumn> {
-    let mut columns = vec![
+fn filesystem_hidden_columns() -> Vec<PublicColumn> {
+    vec![
         PublicColumn::hidden("lixcol_row_pk", false),
         PublicColumn::hidden("lixcol_schema_key", false),
         PublicColumn::hidden("lixcol_file_id", true),
@@ -602,11 +523,7 @@ fn filesystem_hidden_columns(by_branch: bool) -> Vec<PublicColumn> {
         PublicColumn::hidden("lixcol_commit_id", true),
         PublicColumn::public_insert_only("lixcol_untracked", false).with_default("FALSE"),
         PublicColumn::public("lixcol_metadata", true).optional_on_insert(),
-    ];
-    if by_branch {
-        columns.push(PublicColumn::public_insert_only("lixcol_branch_id", false));
-    }
-    columns
+    ]
 }
 
 fn row_system_columns(
@@ -620,7 +537,7 @@ fn row_system_columns(
     } else {
         row_pk.conditional_on_insert()
     };
-    let mut columns = vec![
+    vec![
         row_pk,
         PublicColumn::public_read_only("lixcol_schema_key", false),
         PublicColumn::public_insert_only("lixcol_file_id", true).optional_on_insert(),
@@ -631,11 +548,7 @@ fn row_system_columns(
         PublicColumn::public_read_only("lixcol_change_id", true),
         PublicColumn::public_read_only("lixcol_commit_id", true),
         PublicColumn::public_insert_only("lixcol_untracked", false).with_default("FALSE"),
-    ];
-    if variant == SchemaSurfaceShape::ByBranch {
-        columns.push(PublicColumn::public_insert_only("lixcol_branch_id", false));
-    }
-    columns
+    ]
 }
 
 fn row_history_system_columns() -> Vec<PublicColumn> {

--- a/packages/lix/src/sql2/catalog/schema_surface.rs
+++ b/packages/lix/src/sql2/catalog/schema_surface.rs
@@ -17,7 +17,6 @@ use crate::sql2::result_metadata::{json_field, mark_json_field};
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum SchemaSurfaceShape {
     Active,
-    ByBranch,
     History,
 }
 
@@ -374,7 +373,7 @@ pub(crate) fn row_system_fields(shape: SchemaSurfaceShape) -> Vec<Field> {
         ];
     }
 
-    let mut fields = vec![
+    vec![
         json_field("lixcol_row_pk", true),
         Field::new("lixcol_schema_key", DataType::Utf8, false),
         Field::new("lixcol_file_id", DataType::Utf8, true),
@@ -385,11 +384,7 @@ pub(crate) fn row_system_fields(shape: SchemaSurfaceShape) -> Vec<Field> {
         Field::new("lixcol_change_id", DataType::Utf8, true),
         Field::new("lixcol_commit_id", DataType::Utf8, true),
         Field::new("lixcol_untracked", DataType::Boolean, true),
-    ];
-    if shape == SchemaSurfaceShape::ByBranch {
-        fields.push(Field::new("lixcol_branch_id", DataType::Utf8, false));
-    }
-    fields
+    ]
 }
 
 fn arrow_data_type_for_schema_column_type(column_type: SchemaColumnType) -> DataType {

--- a/packages/lix/src/sql2/catalog/surface.rs
+++ b/packages/lix/src/sql2/catalog/surface.rs
@@ -25,23 +25,17 @@ impl PublicSurfaceContract {
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub(crate) enum PublicSurfaceKind {
     SchemaBase { schema_key: String },
-    SchemaByBranch { schema_key: String },
     SchemaHistory { schema_key: String },
     File,
-    FileByBranch,
     FileHistory,
     Directory,
-    DirectoryByBranch,
     DirectoryHistory,
     Branch,
     WorkingDiff,
-    WorkingDiffByBranch,
     Revert,
     Apply,
     CreateCheckpoint,
     FileWorkingDiff,
-    FileWorkingDiffByBranch,
     DirectoryWorkingDiff,
-    DirectoryWorkingDiffByBranch,
     Change,
 }

--- a/packages/lix/src/sql2/exec/bound_public_write.rs
+++ b/packages/lix/src/sql2/exec/bound_public_write.rs
@@ -1953,11 +1953,7 @@ async fn execute_row_write(
     surface: &RowWriteSurface,
     params: &[Value],
 ) -> Result<SqlWriteResult, LixError> {
-    let schema_key = match surface {
-        RowWriteSurface::Base { schema_key } | RowWriteSurface::ByBranch { schema_key } => {
-            schema_key
-        }
-    };
+    let RowWriteSurface::Base { schema_key } = surface;
     reject_read_only_schema_surface(schema_key, row_action(&plan.bound.op))
         .map_err(crate::sql2::error::datafusion_error_to_lix_error)?;
 
@@ -2808,11 +2804,7 @@ pub(crate) fn prepare_path_value_replacement_program_from_logical(
     let BoundWriteTarget::Row(surface) = &plan.bound.target else {
         return None;
     };
-    let schema_key = match surface {
-        RowWriteSurface::Base { schema_key } | RowWriteSurface::ByBranch { schema_key } => {
-            schema_key
-        }
-    };
+    let RowWriteSurface::Base { schema_key } = surface;
     let catalog = ctx.public_catalog().ok()?;
     let spec = catalog.schema_spec(schema_key)?;
     prepare_path_value_replacement_program(ctx, plan, spec)
@@ -3295,7 +3287,6 @@ fn append_row_update_row<'a>(
     )? {
         return Ok(false);
     }
-    reject_projected_global_write(plan, candidate, "UPDATE")?;
     let mut updated = snapshot.clone();
     let mut visible_assignments = Vec::new();
     for assignment in &plan.bound.assignments {
@@ -3369,7 +3360,6 @@ async fn row_delete(
             params,
             active_branch_commit_id,
         )? {
-            reject_projected_global_write(plan, candidate, "DELETE")?;
             if let (Some(returning), Some(rows)) =
                 (plan.bound.returning.as_ref(), returning_rows.as_mut())
             {
@@ -3606,7 +3596,7 @@ async fn stage_rows(
 }
 
 fn validate_insert_conflict_target(
-    plan: &LogicalWritePlan,
+    _plan: &LogicalWritePlan,
     spec: &SchemaSurfaceSpec,
     conflict: &BoundInsertConflict,
 ) -> Result<(), LixError> {
@@ -3617,7 +3607,7 @@ fn validate_insert_conflict_target(
         ));
     }
 
-    let mut expected = spec
+    let expected = spec
         .primary_key_paths
         .iter()
         .map(|path| {
@@ -3630,13 +3620,6 @@ fn validate_insert_conflict_target(
             Ok(path[0].clone())
         })
         .collect::<Result<std::collections::BTreeSet<_>, LixError>>()?;
-    if matches!(
-        plan.bound.target,
-        BoundWriteTarget::Row(RowWriteSurface::ByBranch { .. })
-    ) {
-        expected.insert("lixcol_branch_id".to_string());
-    }
-
     let actual = conflict
         .target_columns
         .iter()
@@ -4067,7 +4050,6 @@ enum InsertColumnTarget {
     Metadata,
     Global,
     Untracked,
-    BranchId,
 }
 
 impl InsertRowLayout {
@@ -4098,7 +4080,6 @@ impl InsertRowLayout {
                     "lixcol_metadata" => InsertColumnTarget::Metadata,
                     "lixcol_global" => InsertColumnTarget::Global,
                     "lixcol_untracked" => InsertColumnTarget::Untracked,
-                    "lixcol_branch_id" => InsertColumnTarget::BranchId,
                     _ => {
                         return Err(LixError::new(
                             LixError::CODE_UNSUPPORTED_SQL,
@@ -5081,7 +5062,6 @@ fn certified_row_insert_rows<'a>(
             let mut metadata = None;
             let mut global = None;
             let mut untracked = None;
-            let mut explicit_branch_id = None;
             for (index, (expr, target)) in row.iter().zip(layout.columns.iter()).enumerate() {
                 if let InsertColumnTarget::Visible { column_type, .. } = target {
                     reject_direct_blob_json_value(expr, *column_type, params)?;
@@ -5158,9 +5138,6 @@ fn certified_row_insert_rows<'a>(
                     }
                     InsertColumnTarget::Untracked => {
                         untracked = bool_value(value, "lixcol_untracked")?;
-                    }
-                    InsertColumnTarget::BranchId => {
-                        explicit_branch_id = text_value(value, "lixcol_branch_id")?;
                     }
                 }
             }
@@ -5254,7 +5231,7 @@ fn certified_row_insert_rows<'a>(
                 metadata,
                 global,
                 untracked: untracked.unwrap_or(false),
-                branch_id: row_branch_id(plan, explicit_branch_id, global)?.into(),
+                branch_id: row_branch_id(plan, global)?.into(),
             };
             if !unique_identities.insert((
                 certified.row_pk.clone(),
@@ -5335,7 +5312,6 @@ fn append_row_insert_row(
     let mut metadata = None;
     let mut global = None;
     let mut untracked = None;
-    let mut explicit_branch_id = None;
     let context = RowEvalContext::insert(&JsonValue::Null, &layout.visible_columns);
 
     for (expr, target) in row.iter().zip(layout.columns.iter()) {
@@ -5408,9 +5384,6 @@ fn append_row_insert_row(
             InsertColumnTarget::Untracked => {
                 untracked = bool_value(value, "lixcol_untracked")?;
             }
-            InsertColumnTarget::BranchId => {
-                explicit_branch_id = text_value(value, "lixcol_branch_id")?;
-            }
         }
     }
 
@@ -5453,7 +5426,7 @@ fn append_row_insert_row(
         row_pk = Some(derived_row_pk);
     }
     let global = global.unwrap_or(false);
-    let branch_id = row_branch_id(plan, explicit_branch_id, global)?;
+    let branch_id = row_branch_id(plan, global)?;
     rows.push_parts(
         row_pk,
         layout.schema_key.as_str().into(),
@@ -5496,27 +5469,6 @@ fn populate_registered_schema_key(
             )
         })?;
     snapshot.insert("schema_key".into(), JsonValue::String(key));
-    Ok(())
-}
-
-fn reject_projected_global_write<'a>(
-    plan: &LogicalWritePlan,
-    row: impl Into<RowLiveRowRef<'a>>,
-    action: &str,
-) -> Result<(), LixError> {
-    let row = row.into();
-    let target_is_by_branch = matches!(
-        &plan.bound.target,
-        BoundWriteTarget::Row(RowWriteSurface::ByBranch { .. })
-    );
-    if target_is_by_branch && row.global() && row.branch_id() != crate::GLOBAL_BRANCH_ID {
-        return Err(LixError::new(
-            LixError::CODE_UNSUPPORTED_SQL,
-            format!(
-                "{action} through a row by-branch surface cannot mutate a projected global row"
-            ),
-        ));
-    }
     Ok(())
 }
 
@@ -5674,12 +5626,6 @@ impl<'a> RowEvalRowRef<'a> {
         }
     }
 
-    fn branch_id(self) -> &'a str {
-        match self {
-            Self::Live(row) => row.branch_id(),
-            Self::Staged(row) => row.branch_id.as_str(),
-        }
-    }
 }
 
 impl<'a> RowEvalContext<'a> {
@@ -6950,9 +6896,6 @@ fn column_eval_value(
             .unwrap_or(RowEvalValue::SqlNull)),
         "lixcol_global" => Ok(RowEvalValue::Json(JsonValue::Bool(row.global()))),
         "lixcol_untracked" => Ok(RowEvalValue::Json(JsonValue::Bool(row.untracked()))),
-        "lixcol_branch_id" => Ok(RowEvalValue::Json(JsonValue::String(
-            row.branch_id().to_string(),
-        ))),
         _ => Ok(RowEvalValue::SqlNull),
     }
 }
@@ -6999,9 +6942,6 @@ fn excluded_column_eval_value(
             .map(|metadata| metadata.unwrap_or(RowEvalValue::SqlNull)),
         "lixcol_global" => Ok(RowEvalValue::Json(JsonValue::Bool(row.global))),
         "lixcol_untracked" => Ok(RowEvalValue::Json(JsonValue::Bool(row.untracked))),
-        "lixcol_branch_id" => Ok(RowEvalValue::Json(JsonValue::String(
-            row.branch_id.to_string(),
-        ))),
         _ => Ok(RowEvalValue::SqlNull),
     }
 }
@@ -7021,15 +6961,6 @@ fn visible_column_eval_value(
 fn scan_branch_ids(scope: &BranchScope) -> Result<Vec<String>, LixError> {
     Ok(match scope {
         BranchScope::Active { branch_id } => vec![branch_id.clone()],
-        BranchScope::Explicit { branch_ids } | BranchScope::ExplicitRequired { branch_ids } => {
-            branch_ids.iter().cloned().collect()
-        }
-        BranchScope::ExplicitDynamic { .. } | BranchScope::ExplicitRequiredDynamic { .. } => {
-            return Err(LixError::new(
-                LixError::CODE_INVALID_PARAM,
-                "parameterized branch scope was not resolved before write execution",
-            ));
-        }
         BranchScope::Global => vec![crate::GLOBAL_BRANCH_ID.to_string()],
         BranchScope::Empty => Vec::new(),
     })
@@ -7037,105 +6968,14 @@ fn scan_branch_ids(scope: &BranchScope) -> Result<Vec<String>, LixError> {
 
 fn row_branch_id(
     plan: &LogicalWritePlan,
-    explicit_branch_id: Option<String>,
     global: bool,
 ) -> Result<String, LixError> {
     if global {
-        let target_branch_ids = insert_target_branch_ids(&plan.bound.branch_scope);
-        let target_is_by_branch = matches!(
-            &plan.bound.target,
-            BoundWriteTarget::Row(RowWriteSurface::ByBranch { .. })
-        );
-        if explicit_branch_id
-            .as_deref()
-            .is_some_and(|branch_id| branch_id != crate::GLOBAL_BRANCH_ID)
-        {
-            return Err(LixError::new(
-                LixError::CODE_TYPE_MISMATCH,
-                "row INSERT cannot combine lixcol_global = true with a non-global lixcol_branch_id",
-            ));
-        }
-        if target_is_by_branch
-            && target_branch_ids.iter().any(|branch_ids| {
-                !branch_ids
-                    .iter()
-                    .any(|branch_id| branch_id == crate::GLOBAL_BRANCH_ID)
-            })
-        {
-            return Err(LixError::new(
-                LixError::CODE_TYPE_MISMATCH,
-                "row INSERT cannot combine lixcol_global = true with a non-global target branch",
-            ));
-        }
         return Ok(crate::GLOBAL_BRANCH_ID.to_string());
-    }
-    if explicit_branch_id.as_deref() == Some(crate::GLOBAL_BRANCH_ID) {
-        return Err(LixError::new(
-            LixError::CODE_TYPE_MISMATCH,
-            "row INSERT with lixcol_branch_id = 'global' must also set lixcol_global = true",
-        ));
-    }
-    let target_is_by_branch = matches!(
-        &plan.bound.target,
-        BoundWriteTarget::Row(RowWriteSurface::ByBranch { .. })
-    );
-    if target_is_by_branch && matches!(plan.bound.branch_scope, BranchScope::Global) {
-        return Err(LixError::new(
-            LixError::CODE_TYPE_MISMATCH,
-            "row INSERT into the global scope must set lixcol_global = true",
-        ));
-    }
-    if let Some(branch_id) = explicit_branch_id {
-        if target_is_by_branch {
-            let target_branch_ids = insert_target_branch_ids(&plan.bound.branch_scope);
-            if let Some(target_branch_ids) = &target_branch_ids {
-                if !target_branch_ids.contains(&branch_id) {
-                    return Err(LixError::new(
-                        LixError::CODE_TYPE_MISMATCH,
-                        format!(
-                            "row INSERT lixcol_branch_id '{branch_id}' does not match the target branch scope"
-                        ),
-                    ));
-                }
-            } else {
-                return Err(LixError::new(
-                    LixError::CODE_TYPE_MISMATCH,
-                    "row INSERT has no target branch scope",
-                ));
-            }
-        }
-        return Ok(branch_id);
     }
     match &plan.bound.branch_scope {
         BranchScope::Active { branch_id } => Ok(branch_id.clone()),
-        BranchScope::ExplicitRequired { branch_ids } | BranchScope::Explicit { branch_ids }
-            if branch_ids.len() == 1 =>
-        {
-            Ok(branch_ids.iter().next().expect("len checked").clone())
-        }
-        BranchScope::ExplicitDynamic { .. } | BranchScope::ExplicitRequiredDynamic { .. } => {
-            Err(LixError::new(
-                LixError::CODE_INVALID_PARAM,
-                "parameterized branch scope was not resolved before write execution",
-            ))
-        }
         BranchScope::Global | BranchScope::Empty => Ok(crate::GLOBAL_BRANCH_ID.to_string()),
-        _ => Err(LixError::new(
-            LixError::CODE_UNSUPPORTED_SQL,
-            "row write requires exactly one target branch",
-        )),
-    }
-}
-
-fn insert_target_branch_ids(scope: &BranchScope) -> Option<Vec<String>> {
-    match scope {
-        BranchScope::Active { branch_id } => Some(vec![branch_id.clone()]),
-        BranchScope::Explicit { branch_ids } | BranchScope::ExplicitRequired { branch_ids } => {
-            Some(branch_ids.iter().cloned().collect())
-        }
-        BranchScope::ExplicitDynamic { .. } | BranchScope::ExplicitRequiredDynamic { .. } => None,
-        BranchScope::Global => Some(vec![crate::GLOBAL_BRANCH_ID.to_string()]),
-        BranchScope::Empty => Some(Vec::new()),
     }
 }
 

--- a/packages/lix/src/sql2/exec/datafusion.rs
+++ b/packages/lix/src/sql2/exec/datafusion.rs
@@ -2012,7 +2012,7 @@ fn validate_bound_write_input(plan: &LogicalWritePlan, params: &[Value]) -> Resu
 
     if !matches!(
         plan.bound.target,
-        BoundWriteTarget::File(FileWriteSurface::Base | FileWriteSurface::ByBranch)
+        BoundWriteTarget::File(FileWriteSurface::Base)
     ) {
         return Ok(());
     }
@@ -2307,13 +2307,10 @@ fn datafusion_write_filters(
     let mut filters =
         datafusion_filters_from_predicate(session, schema, &plan.bound.predicate, params)?;
     if plan.bound.branch_scope == BranchScope::Global {
-        let branch_column = if schema.field_with_name("branch_id").is_ok() {
-            Some("branch_id")
-        } else if schema.field_with_name("lixcol_branch_id").is_ok() {
-            Some("lixcol_branch_id")
-        } else {
-            None
-        };
+        let branch_column = schema
+            .field_with_name("branch_id")
+            .is_ok()
+            .then_some("branch_id");
         let Some(branch_column) = branch_column else {
             let df_schema =
                 DFSchema::try_from(schema.clone()).map_err(datafusion_error_to_lix_error)?;
@@ -2641,19 +2638,8 @@ fn write_target_table_name(plan: &LogicalWritePlan) -> Result<String, LixError> 
         {
             Ok(schema_key.clone())
         }
-        BoundWriteTarget::Row(crate::sql2::bind::write::RowWriteSurface::ByBranch {
-            schema_key,
-        }) if bound_predicate_contains_like(&plan.bound.predicate)
-            || bound_update_contains_binary(plan) =>
-        {
-            Ok(format!("{schema_key}_by_branch"))
-        }
         BoundWriteTarget::File(FileWriteSurface::Base) => Ok("lix_file".to_string()),
-        BoundWriteTarget::File(FileWriteSurface::ByBranch) => Ok("lix_file_by_branch".to_string()),
         BoundWriteTarget::Directory(DirectoryWriteSurface::Base) => Ok("lix_directory".to_string()),
-        BoundWriteTarget::Directory(DirectoryWriteSurface::ByBranch) => {
-            Ok("lix_directory_by_branch".to_string())
-        }
         BoundWriteTarget::Branch => Ok("lix_branch".to_string()),
         BoundWriteTarget::DiffCommand(crate::sql2::DiffCommand::Revert) => {
             Ok("lix_revert".to_string())
@@ -4181,9 +4167,7 @@ mod tests {
                 "lix_branch",
                 "lix_create_checkpoint",
                 "lix_directory",
-                "lix_directory_by_branch",
                 "lix_file",
-                "lix_file_by_branch",
                 "lix_revert",
             ]
         );
@@ -6700,102 +6684,6 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn execute_sql_insert_into_row_by_branch_stages_write() {
-        let blob_reader: Arc<dyn BlobDataReader> = Arc::new(DummyBlobReader);
-        let hot_state = Arc::new(DummyHotStateReader);
-        let staged_writes = Arc::new(Mutex::new(CapturingStagedWrites::default()));
-        let mut ctx = DummySqlWriteExecutionContext {
-            active_branch_id: "01920000-0000-7000-8000-0000000000a1",
-            blob_reader,
-            hot_state,
-            staged_writes: Arc::clone(&staged_writes),
-            schema_definitions: vec![json!({
-                "$schema": "https://lix.dev/schema-v1.json",
-                "key": "test_state_schema",
-                "columns": [
-                    { "name": "id", "type": "text", "nullable": false },
-                    { "name": "value", "type": "text", "nullable": false },
-                ],
-                "primary_key": ["id"],
-            })],
-        };
-
-        let result = execute_write_sql(
-            &mut ctx,
-            "INSERT INTO test_state_schema_by_branch (\
-	     lixcol_row_pk, lixcol_branch_id, id, value\
-	     ) VALUES (CAST('[\"row-c\"]' AS JSONB), '01920000-0000-7000-8000-0000000000b1', 'row-c', 'C')",
-            &[],
-        )
-        .await
-        .expect("INSERT INTO row by-branch surface should stage write");
-
-        assert_eq!(result.columns, vec!["count"]);
-        assert_eq!(result.rows, vec![vec![Value::Integer(1)]]);
-
-        let staged_writes = staged_writes.lock().expect("staged writes lock");
-        assert_eq!(staged_writes.deltas.len(), 1);
-        let overlay = staged_writes.deltas[0]
-            .pending_write_overlay()
-            .expect("staged delta should expose pending overlay");
-        let rows = overlay.visible_semantic_rows(false, "test_state_schema");
-        assert_eq!(rows.len(), 1);
-        assert_eq!(rows[0].row_pk, "[\"row-c\"]");
-        assert_eq!(rows[0].branch_id, "01920000-0000-7000-8000-0000000000b1");
-        assert!(!rows[0].global);
-        assert!(!rows[0].untracked);
-        assert_eq!(
-            rows[0].snapshot_content.as_deref(),
-            Some("{\"id\":\"row-c\",\"value\":\"C\"}")
-        );
-    }
-
-    #[tokio::test]
-    async fn execute_sql_insert_into_row_by_branch_accepts_parameterized_branch_id() {
-        let blob_reader: Arc<dyn BlobDataReader> = Arc::new(DummyBlobReader);
-        let hot_state = Arc::new(DummyHotStateReader);
-        let staged_writes = Arc::new(Mutex::new(CapturingStagedWrites::default()));
-        let mut ctx = DummySqlWriteExecutionContext {
-            active_branch_id: "01920000-0000-7000-8000-0000000000a1",
-            blob_reader,
-            hot_state,
-            staged_writes: Arc::clone(&staged_writes),
-            schema_definitions: vec![json!({
-                "$schema": "https://lix.dev/schema-v1.json",
-                "key": "test_state_schema",
-                "columns": [
-                    { "name": "id", "type": "text", "nullable": false },
-                    { "name": "value", "type": "text", "nullable": false },
-                ],
-                "primary_key": ["id"],
-            })],
-        };
-
-        let result = execute_write_sql(
-            &mut ctx,
-            "INSERT INTO test_state_schema_by_branch (\
-             lixcol_row_pk, lixcol_branch_id, id, value\
-             ) VALUES (CAST('[\"row-c\"]' AS JSONB), $1, 'row-c', 'C')",
-            &[Value::Text(
-                "01920000-0000-7000-8000-0000000000b1".to_string(),
-            )],
-        )
-        .await
-        .expect("parameterized by-branch row insert should stage write");
-
-        assert_eq!(result.rows, vec![vec![Value::Integer(1)]]);
-
-        let staged_writes = staged_writes.lock().expect("staged writes lock");
-        let overlay = staged_writes.deltas[0]
-            .pending_write_overlay()
-            .expect("staged delta should expose pending overlay");
-        let rows = overlay.visible_semantic_rows(false, "test_state_schema");
-        assert_eq!(rows.len(), 1);
-        assert_eq!(rows[0].row_pk, "[\"row-c\"]");
-        assert_eq!(rows[0].branch_id, "01920000-0000-7000-8000-0000000000b1");
-    }
-
-    #[tokio::test]
     async fn execute_sql_insert_into_active_row_defaults_active_branch() {
         let blob_reader: Arc<dyn BlobDataReader> = Arc::new(DummyBlobReader);
         let hot_state = Arc::new(DummyHotStateReader);
@@ -7008,7 +6896,7 @@ mod tests {
         });
         let staged_writes = Arc::new(Mutex::new(CapturingStagedWrites::default()));
         let mut ctx = DummySqlWriteExecutionContext {
-            active_branch_id: "01920000-0000-7000-8000-0000000000a1",
+            active_branch_id: "01920000-0000-7000-8000-0000000000b1",
             blob_reader,
             hot_state,
             staged_writes: Arc::clone(&staged_writes),
@@ -7025,10 +6913,9 @@ mod tests {
 
         let (result, path) = execute_write_sql_trace(
             &mut ctx,
-            "INSERT INTO test_state_schema_by_branch \
-             (id, value, lixcol_branch_id, lixcol_untracked) \
-             VALUES ('target', 'new', '01920000-0000-7000-8000-0000000000b1', true) \
-             ON CONFLICT(id, lixcol_branch_id) DO UPDATE SET value = excluded.value",
+            "INSERT INTO test_state_schema \
+             (id, value, lixcol_untracked) VALUES ('target', 'new', true) \
+             ON CONFLICT(id) DO UPDATE SET value = excluded.value",
             &[],
             WriteExecutorMode::Auto,
         )
@@ -7293,54 +7180,6 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn execute_sql_insert_into_directory_by_branch_stages_write() {
-        let blob_reader: Arc<dyn BlobDataReader> = Arc::new(DummyBlobReader);
-        let hot_state = Arc::new(DummyHotStateReader);
-        let staged_writes = Arc::new(Mutex::new(CapturingStagedWrites::default()));
-        let mut ctx = DummySqlWriteExecutionContext {
-            active_branch_id: "01920000-0000-7000-8000-0000000000a1",
-            blob_reader,
-            hot_state,
-            staged_writes: Arc::clone(&staged_writes),
-            schema_definitions: vec![],
-        };
-
-        let result = execute_write_sql(
-            &mut ctx,
-            "INSERT INTO lix_directory_by_branch (\
-             id, parent_id, name, lixcol_branch_id\
-             ) VALUES ('01920000-0000-7000-8000-0000000000d3', NULL, 'docs', '01920000-0000-7000-8000-0000000000b1')",
-            &[],
-        )
-        .await
-        .expect("INSERT INTO lix_directory_by_branch should stage write");
-
-        assert_eq!(result.columns, vec!["count"]);
-        assert_eq!(result.rows, vec![vec![Value::Integer(1)]]);
-
-        let staged_writes = staged_writes.lock().expect("staged writes lock");
-        assert_eq!(staged_writes.deltas.len(), 1);
-        let overlay = staged_writes.deltas[0]
-            .pending_write_overlay()
-            .expect("staged delta should expose pending overlay");
-        let rows = overlay.visible_semantic_rows(false, "lix_directory_descriptor");
-        assert_eq!(rows.len(), 1);
-        assert_eq!(
-            rows[0].row_pk,
-            "[\"01920000-0000-7000-8000-0000000000d3\"]"
-        );
-        assert_eq!(rows[0].branch_id, "01920000-0000-7000-8000-0000000000b1");
-        assert!(!rows[0].global);
-        assert!(!rows[0].untracked);
-        assert_eq!(
-            rows[0].snapshot_content.as_deref(),
-            Some(
-                "{\"id\":\"01920000-0000-7000-8000-0000000000d3\",\"name\":\"docs\",\"parent_id\":null}"
-            )
-        );
-    }
-
-    #[tokio::test]
     async fn execute_sql_insert_into_active_directory_defaults_active_branch() {
         let blob_reader: Arc<dyn BlobDataReader> = Arc::new(DummyBlobReader);
         let hot_state = Arc::new(DummyHotStateReader);
@@ -7498,113 +7337,6 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn execute_sql_delete_directory_by_branch_stages_tombstone() {
-        let blob_reader: Arc<dyn BlobDataReader> = Arc::new(DummyBlobReader);
-        let hot_state = Arc::new(RowsHotStateReader {
-            rows: vec![
-                live_directory_row(
-                    "01920000-0000-7000-8000-0000000000d3",
-                    "01920000-0000-7000-8000-0000000000a1",
-                    None,
-                    "docs",
-                ),
-                live_directory_row(
-                    "01920000-0000-7000-8000-000000000313",
-                    "01920000-0000-7000-8000-0000000000b1",
-                    Some("01920000-0000-7000-8000-0000000000d3"),
-                    "guides",
-                ),
-            ],
-        });
-        let staged_writes = Arc::new(Mutex::new(CapturingStagedWrites::default()));
-        let mut ctx = DummySqlWriteExecutionContext {
-            active_branch_id: "01920000-0000-7000-8000-0000000000a1",
-            blob_reader,
-            hot_state,
-            staged_writes: Arc::clone(&staged_writes),
-            schema_definitions: vec![],
-        };
-
-        let result = execute_write_sql(
-            &mut ctx,
-            "DELETE FROM lix_directory_by_branch \
-             WHERE id = '01920000-0000-7000-8000-000000000313' AND lixcol_branch_id = '01920000-0000-7000-8000-0000000000b1'",
-            &[],
-        )
-        .await
-        .expect("DELETE lix_directory_by_branch should stage tombstone");
-
-        assert_eq!(result.columns, vec!["count"]);
-        assert_eq!(result.rows, vec![vec![Value::Integer(1)]]);
-
-        let staged_writes = staged_writes.lock().expect("staged writes lock");
-        assert_eq!(staged_writes.deltas.len(), 1);
-        let overlay = staged_writes.deltas[0]
-            .pending_write_overlay()
-            .expect("staged delta should expose pending overlay");
-        let rows = overlay.visible_all_semantic_rows();
-        assert_eq!(rows.len(), 1);
-        assert_eq!(
-            rows[0].row_pk,
-            "[\"01920000-0000-7000-8000-000000000313\"]"
-        );
-        assert_eq!(rows[0].branch_id, "01920000-0000-7000-8000-0000000000b1");
-        assert!(rows[0].tombstone);
-        assert_eq!(rows[0].snapshot_content, None);
-    }
-
-    #[tokio::test]
-    async fn execute_sql_insert_into_file_by_branch_stages_descriptor_write() {
-        let blob_reader: Arc<dyn BlobDataReader> = Arc::new(DummyBlobReader);
-        let hot_state = Arc::new(DummyHotStateReader);
-        let staged_writes = Arc::new(Mutex::new(CapturingStagedWrites::default()));
-        let mut ctx = DummySqlWriteExecutionContext {
-            active_branch_id: "01920000-0000-7000-8000-0000000000a1",
-            blob_reader,
-            hot_state,
-            staged_writes: Arc::clone(&staged_writes),
-            schema_definitions: vec![],
-        };
-
-        let result = execute_write_sql(
-            &mut ctx,
-            "INSERT INTO lix_file_by_branch (\
-             id, directory_id, name, lixcol_branch_id\
-             ) VALUES ('01920000-0000-7000-8000-0000000000d2', '01920000-0000-7000-8000-0000000000d3', 'readme.md', '01920000-0000-7000-8000-0000000000b1')",
-            &[],
-        )
-        .await
-        .expect("INSERT INTO lix_file_by_branch should stage descriptor write");
-
-        assert_eq!(result.columns, vec!["count"]);
-        assert_eq!(result.rows, vec![vec![Value::Integer(1)]]);
-
-        let staged_writes = staged_writes.lock().expect("staged writes lock");
-        assert_eq!(staged_writes.deltas.len(), 1);
-        let overlay = staged_writes.deltas[0]
-            .pending_write_overlay()
-            .expect("staged delta should expose pending overlay");
-        let rows = overlay.visible_semantic_rows(false, "lix_file_descriptor");
-        assert_eq!(rows.len(), 1);
-        assert_eq!(
-            rows[0].row_pk,
-            "[\"01920000-0000-7000-8000-0000000000d2\"]"
-        );
-        assert_eq!(rows[0].branch_id, "01920000-0000-7000-8000-0000000000b1");
-        assert!(!rows[0].global);
-        assert!(!rows[0].untracked);
-        let snapshot: JsonValue =
-            serde_json::from_str(rows[0].snapshot_content.as_deref().unwrap())
-                .expect("descriptor snapshot JSON");
-        assert_eq!(snapshot["id"], "01920000-0000-7000-8000-0000000000d2");
-        assert_eq!(
-            snapshot["directory_id"],
-            "01920000-0000-7000-8000-0000000000d3"
-        );
-        assert_eq!(snapshot["name"], "readme.md");
-    }
-
-    #[tokio::test]
     async fn execute_sql_insert_into_active_file_defaults_active_branch() {
         let blob_reader: Arc<dyn BlobDataReader> = Arc::new(DummyBlobReader);
         let hot_state = Arc::new(DummyHotStateReader);
@@ -7651,7 +7383,7 @@ mod tests {
         let hot_state = Arc::new(RowsHotStateReader {
             rows: vec![live_directory_row(
                 "01920000-0000-7000-8000-0000000000d3",
-                "01920000-0000-7000-8000-0000000000b1",
+                "01920000-0000-7000-8000-0000000000a1",
                 None,
                 "docs",
             )],
@@ -7667,13 +7399,13 @@ mod tests {
 
         let result = execute_write_sql(
             &mut ctx,
-            "INSERT INTO lix_file_by_branch (\
-             id, directory_id, name, content, lixcol_branch_id\
-             ) VALUES ('01920000-0000-7000-8000-0000000000d2', '01920000-0000-7000-8000-0000000000d3', 'readme.md', CAST('AB' AS BYTEA), '01920000-0000-7000-8000-0000000000b1')",
+            "INSERT INTO lix_file (\
+             id, directory_id, name, content\
+             ) VALUES ('01920000-0000-7000-8000-0000000000d2', '01920000-0000-7000-8000-0000000000d3', 'readme.md', CAST('AB' AS BYTEA))",
             &[],
         )
         .await
-        .expect("INSERT INTO lix_file_by_branch should stage descriptor and content writes");
+        .expect("INSERT INTO lix_file should stage descriptor and content writes");
 
         assert_eq!(result.columns, vec!["count"]);
         assert_eq!(result.rows, vec![vec![Value::Integer(1)]]);
@@ -7701,7 +7433,7 @@ mod tests {
         );
         assert_eq!(
             blob_ref_rows[0].branch_id,
-            "01920000-0000-7000-8000-0000000000b1"
+            "01920000-0000-7000-8000-0000000000a1"
         );
         let snapshot: JsonValue =
             serde_json::from_str(blob_ref_rows[0].snapshot_content.as_deref().unwrap())
@@ -8956,7 +8688,6 @@ mod tests {
             "UPDATE lix_file SET content = CAST('A' AS BYTEA) WHERE path = '/readme.md'",
             "UPDATE lix_file SET content = CAST('A' AS BYTEA), name = 'renamed.md' WHERE id = '01920000-0000-7000-8000-0000000000d2'",
             "UPDATE lix_file SET content = content WHERE id = '01920000-0000-7000-8000-0000000000d2'",
-            "UPDATE lix_file_by_branch SET content = CAST('A' AS BYTEA) WHERE id = '01920000-0000-7000-8000-0000000000d2' AND lixcol_branch_id = '01920000-0000-7000-8000-0000000000a1'",
         ] {
             let plan = create_write_logical_plan(&mut ctx, sql)
                 .await
@@ -9090,74 +8821,6 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn execute_sql_delete_file_by_branch_stages_descriptor_tombstone() {
-        let blob_reader: Arc<dyn BlobDataReader> = Arc::new(DummyBlobReader);
-        let hot_state = Arc::new(RowsHotStateReader {
-            rows: vec![
-                live_directory_row(
-                    "01920000-0000-7000-8000-0000000000d3",
-                    "01920000-0000-7000-8000-0000000000a1",
-                    None,
-                    "docs",
-                ),
-                live_directory_row(
-                    "01920000-0000-7000-8000-0000000000d3",
-                    "01920000-0000-7000-8000-0000000000b1",
-                    None,
-                    "docs",
-                ),
-                live_file_row(
-                    "01920000-0000-7000-8000-0000000000d2",
-                    "01920000-0000-7000-8000-0000000000a1",
-                    Some("01920000-0000-7000-8000-0000000000d3"),
-                    "readme.md",
-                ),
-                live_file_row(
-                    "01920000-0000-7000-8000-000000000332",
-                    "01920000-0000-7000-8000-0000000000b1",
-                    Some("01920000-0000-7000-8000-0000000000d3"),
-                    "guide.md",
-                ),
-            ],
-        });
-        let staged_writes = Arc::new(Mutex::new(CapturingStagedWrites::default()));
-        let mut ctx = DummySqlWriteExecutionContext {
-            active_branch_id: "01920000-0000-7000-8000-0000000000a1",
-            blob_reader,
-            hot_state,
-            staged_writes: Arc::clone(&staged_writes),
-            schema_definitions: vec![],
-        };
-
-        let result = execute_write_sql(
-            &mut ctx,
-            "DELETE FROM lix_file_by_branch \
-             WHERE id = '01920000-0000-7000-8000-000000000332' AND lixcol_branch_id = '01920000-0000-7000-8000-0000000000b1'",
-            &[],
-        )
-        .await
-        .expect("DELETE lix_file_by_branch should stage descriptor tombstone");
-
-        assert_eq!(result.columns, vec!["count"]);
-        assert_eq!(result.rows, vec![vec![Value::Integer(1)]]);
-
-        let staged_writes = staged_writes.lock().expect("staged writes lock");
-        assert_eq!(staged_writes.deltas.len(), 1);
-        let overlay = staged_writes.deltas[0]
-            .pending_write_overlay()
-            .expect("staged delta should expose pending overlay");
-        let rows = overlay.visible_all_semantic_rows();
-        assert_eq!(rows.len(), 1);
-        assert_eq!(
-            rows[0].row_pk,
-            "[\"01920000-0000-7000-8000-000000000332\"]"
-        );
-        assert_eq!(rows[0].branch_id, "01920000-0000-7000-8000-0000000000b1");
-        assert!(rows[0].tombstone);
-        assert_eq!(rows[0].snapshot_content, None);
-    }
-
-    #[tokio::test]
     async fn execute_sql_update_schema_surface_stages_rewritten_snapshot() {
         let blob_reader: Arc<dyn BlobDataReader> = Arc::new(DummyBlobReader);
         let hot_state = Arc::new(RowsHotStateReader {
@@ -9213,104 +8876,6 @@ mod tests {
             rows[0].metadata.as_deref(),
             Some("{\"source\":\"row-update\"}")
         );
-    }
-
-    #[tokio::test]
-    async fn execute_sql_delete_row_by_branch_stages_tombstone() {
-        let blob_reader: Arc<dyn BlobDataReader> = Arc::new(DummyBlobReader);
-        let hot_state = Arc::new(RowsHotStateReader {
-            rows: vec![
-                live_row("row-a", "01920000-0000-7000-8000-0000000000a1", "A"),
-                live_row("row-b", "01920000-0000-7000-8000-0000000000b1", "B"),
-            ],
-        });
-        let staged_writes = Arc::new(Mutex::new(CapturingStagedWrites::default()));
-        let mut ctx = DummySqlWriteExecutionContext {
-            active_branch_id: "01920000-0000-7000-8000-0000000000a1",
-            blob_reader,
-            hot_state,
-            staged_writes: Arc::clone(&staged_writes),
-            schema_definitions: vec![json!({
-                "$schema": "https://lix.dev/schema-v1.json",
-                "key": "test_state_schema",
-                "columns": [
-                    { "name": "id", "type": "text", "nullable": false },
-                    { "name": "value", "type": "text", "nullable": false },
-                ],
-                "primary_key": ["id"],
-            })],
-        };
-
-        let result = execute_write_sql(
-            &mut ctx,
-            "DELETE FROM test_state_schema_by_branch \
-             WHERE lixcol_branch_id = $1",
-            &[Value::Text(
-                "01920000-0000-7000-8000-0000000000b1".to_string(),
-            )],
-        )
-        .await
-        .expect("parameterized DELETE row by-branch surface should stage tombstone");
-
-        assert_eq!(result.columns, vec!["count"]);
-        assert_eq!(result.rows, vec![vec![Value::Integer(1)]]);
-
-        let staged_writes = staged_writes.lock().expect("staged writes lock");
-        assert_eq!(staged_writes.deltas.len(), 1);
-        let overlay = staged_writes.deltas[0]
-            .pending_write_overlay()
-            .expect("staged delta should expose pending overlay");
-        let rows = overlay.visible_all_semantic_rows();
-        assert_eq!(rows.len(), 1);
-        assert_eq!(rows[0].row_pk, "[\"row-b\"]");
-        assert_eq!(rows[0].branch_id, "01920000-0000-7000-8000-0000000000b1");
-        assert!(rows[0].tombstone);
-        assert_eq!(rows[0].snapshot_content, None);
-    }
-
-    #[tokio::test]
-    async fn execute_sql_delete_row_by_branch_like_uses_datafusion_and_stages_tombstone() {
-        let (mut ctx, staged_writes, scans) = counting_write_context(vec![
-            live_row("row-a", "01920000-0000-7000-8000-0000000000a1", "A"),
-            live_row("row-b", "01920000-0000-7000-8000-0000000000b1", "Before"),
-            live_row("row-c", "01920000-0000-7000-8000-0000000000b1", "After"),
-        ]);
-        ctx.schema_definitions = vec![json!({
-            "$schema": "https://lix.dev/schema-v1.json",
-                "key": "test_state_schema",
-                "columns": [
-                    { "name": "id", "type": "text", "nullable": false },
-                    { "name": "value", "type": "text", "nullable": false },
-                ],
-                "primary_key": ["id"],
-        })];
-
-        let (result, path) = execute_write_sql_trace(
-            &mut ctx,
-            "DELETE FROM test_state_schema_by_branch \
-             WHERE lixcol_branch_id = $1 AND value LIKE $2",
-            &[
-                Value::Text("01920000-0000-7000-8000-0000000000b1".to_string()),
-                Value::Text("Before%".to_string()),
-            ],
-            WriteExecutorMode::Auto,
-        )
-        .await
-        .expect("DELETE LIKE on a schema surface should stage a tombstone");
-
-        assert_eq!(path, WriteExecutorPath::DataFusion);
-        assert_eq!(result.rows, vec![vec![Value::Integer(1)]]);
-        assert_eq!(scans.load(Ordering::SeqCst), 1);
-
-        let staged_writes = staged_writes.lock().expect("staged writes lock");
-        let overlay = staged_writes.deltas[0]
-            .pending_write_overlay()
-            .expect("staged delta should expose pending overlay");
-        let rows = overlay.visible_all_semantic_rows();
-        assert_eq!(rows.len(), 1);
-        assert_eq!(rows[0].row_pk, "[\"row-b\"]");
-        assert_eq!(rows[0].branch_id, "01920000-0000-7000-8000-0000000000b1");
-        assert!(rows[0].tombstone);
     }
 
     #[tokio::test]
@@ -9498,57 +9063,6 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn execute_sql_reads_row_by_branch_view() {
-                let ctx = setup_sql2_state_fixture()
-                    .await
-                    .expect("fixture should initialize");
-
-                let result = execute_sql(
-                    &ctx,
-                    "SELECT value, lixcol_branch_id \
-                     FROM test_state_schema_by_branch \
-                     WHERE lixcol_branch_id = '01920000-0000-7000-8000-0000000000b1'",
-                    &[],
-                )
-                .await
-                .expect("sql2 execute should read row by-branch view");
-
-                assert_eq!(result.columns, vec!["value", "lixcol_branch_id"]);
-                assert_eq!(result.rows.len(), 1);
-                assert_eq!(result.rows[0][0], Value::Text("B".to_string()));
-                assert_eq!(
-                    result.rows[0][1],
-                    Value::Text("01920000-0000-7000-8000-0000000000b1".to_string())
-                );
-    }
-
-    #[tokio::test]
-    async fn execute_sql_reads_lix_directory_by_branch_view() {
-                let ctx = setup_sql2_state_fixture()
-                    .await
-                    .expect("fixture should initialize");
-
-                let result = execute_sql(
-                    &ctx,
-                    "SELECT path, name, lixcol_branch_id \
-                     FROM lix_directory_by_branch \
-                     WHERE id = '01920000-0000-7000-8000-0000000000d3' AND lixcol_branch_id = '01920000-0000-7000-8000-0000000000a1'",
-                    &[],
-                )
-                .await
-                .expect("sql2 execute should read lix_directory_by_branch");
-
-                assert_eq!(result.columns, vec!["path", "name", "lixcol_branch_id"]);
-                assert_eq!(result.rows.len(), 1);
-                assert_eq!(result.rows[0][0], Value::Text("/docs".to_string()));
-                assert_eq!(result.rows[0][1], Value::Text("docs".to_string()));
-                assert_eq!(
-                    result.rows[0][2],
-                    Value::Text("01920000-0000-7000-8000-0000000000a1".to_string())
-                );
-    }
-
-    #[tokio::test]
     async fn execute_sql_reads_lix_directory_from_active_branch() {
                 let ctx = setup_sql2_state_fixture()
                     .await
@@ -9568,39 +9082,6 @@ mod tests {
                 assert_eq!(result.rows.len(), 1);
                 assert_eq!(result.rows[0][0], Value::Text("/docs".to_string()));
                 assert_eq!(result.rows[0][1], Value::Text("docs".to_string()));
-    }
-
-    #[tokio::test]
-    async fn execute_sql_reads_lix_file_by_branch_view() {
-                let ctx = setup_sql2_state_fixture()
-                    .await
-                    .expect("fixture should initialize");
-
-                let result = execute_sql(
-                    &ctx,
-                    "SELECT path, name, content, lixcol_branch_id \
-                     FROM lix_file_by_branch \
-                     WHERE id = '01920000-0000-7000-8000-0000000000a2' AND lixcol_branch_id = '01920000-0000-7000-8000-0000000000a1'",
-                    &[],
-                )
-                .await
-                .expect("sql2 execute should read lix_file_by_branch");
-
-                assert_eq!(
-                    result.columns,
-                    vec!["path", "name", "content", "lixcol_branch_id"]
-                );
-                assert_eq!(result.rows.len(), 1);
-                assert_eq!(
-                    result.rows[0][0],
-                    Value::Text("/docs/readme.md".to_string())
-                );
-                assert_eq!(result.rows[0][1], Value::Text("readme.md".to_string()));
-                assert_eq!(result.rows[0][2], Value::Blob(vec![0x41, 0x42].into()));
-                assert_eq!(
-                    result.rows[0][3],
-                    Value::Text("01920000-0000-7000-8000-0000000000a1".to_string())
-                );
     }
 
     #[tokio::test]

--- a/packages/lix/src/sql2/exec/write.rs
+++ b/packages/lix/src/sql2/exec/write.rs
@@ -1,6 +1,5 @@
 //! Write execution for bound sql2 plans.
 
-use std::collections::BTreeSet;
 use std::sync::Arc;
 
 use serde_json::json;
@@ -14,11 +13,8 @@ use super::{SqlLogicalPlan, SqlWriteResult};
 use crate::PreparedDmlParameterBatch;
 use crate::common::ExecuteStatementMetadata;
 use crate::sql2::SqlWriteExecutionContext;
-use crate::sql2::bind::expr::{BoundExpr, BoundLiteral};
 use crate::sql2::bind::write::BoundWriteTarget;
 use crate::sql2::plan::LogicalWritePlan;
-use crate::sql2::plan::branch_scope::BranchScope;
-use crate::sql2::plan::predicate::BoundPredicate;
 use crate::{LixError, Value};
 
 #[cfg(test)]
@@ -533,7 +529,7 @@ async fn execute_write_logical_plan_with_mode_inner(
             "expected SQL write logical plan",
         ));
     };
-    let write_plan = resolve_parameterized_branch_scope(write_plan.plan, params)?;
+    let write_plan = write_plan.plan;
     validate_write_parameter_count(&write_plan, params.len())?;
 
     if mode != WriteExecutorModeInner::ForceDataFusion {
@@ -563,267 +559,6 @@ async fn execute_write_logical_plan_with_mode_inner(
     let result =
         super::datafusion::execute_datafusion_write_logical_plan(ctx, &write_plan, params).await?;
     Ok((result, WriteExecutorPath::DataFusion))
-}
-
-fn resolve_parameterized_branch_scope(
-    mut plan: LogicalWritePlan,
-    params: &[Value],
-) -> Result<LogicalWritePlan, LixError> {
-    plan.bound.branch_scope = match plan.bound.branch_scope {
-        BranchScope::ExplicitDynamic {
-            mut branch_ids,
-            param_indexes,
-        } => {
-            insert_branch_param_values(
-                &mut branch_ids,
-                &param_indexes,
-                params,
-                BranchParamNullPolicy::Reject,
-            )?;
-            if branch_ids.is_empty() {
-                BranchScope::Empty
-            } else {
-                BranchScope::Explicit { branch_ids }
-            }
-        }
-        BranchScope::ExplicitRequiredDynamic {
-            mut branch_ids,
-            param_indexes,
-        } => match branch_column_for_target(&plan.bound.target) {
-            Some(branch_column) => {
-                match resolved_predicate_branch_selector(
-                    &plan.bound.predicate,
-                    branch_column,
-                    params,
-                )? {
-                    ResolvedBranchSelector::Static(branch_ids) if branch_ids.is_empty() => {
-                        BranchScope::Empty
-                    }
-                    ResolvedBranchSelector::Static(branch_ids) => {
-                        BranchScope::ExplicitRequired { branch_ids }
-                    }
-                    ResolvedBranchSelector::Missing => {
-                        insert_branch_param_values(
-                            &mut branch_ids,
-                            &param_indexes,
-                            params,
-                            BranchParamNullPolicy::Ignore,
-                        )?;
-                        if branch_ids.is_empty() {
-                            BranchScope::Empty
-                        } else {
-                            BranchScope::ExplicitRequired { branch_ids }
-                        }
-                    }
-                }
-            }
-            None => {
-                insert_branch_param_values(
-                    &mut branch_ids,
-                    &param_indexes,
-                    params,
-                    BranchParamNullPolicy::Ignore,
-                )?;
-                if branch_ids.is_empty() {
-                    BranchScope::Empty
-                } else {
-                    BranchScope::ExplicitRequired { branch_ids }
-                }
-            }
-        },
-        scope => scope,
-    };
-    Ok(plan)
-}
-
-fn branch_column_for_target(target: &BoundWriteTarget) -> Option<&'static str> {
-    match target {
-        BoundWriteTarget::Row(crate::sql2::bind::write::RowWriteSurface::ByBranch {
-            ..
-        })
-        | BoundWriteTarget::File(crate::sql2::bind::write::FileWriteSurface::ByBranch)
-        | BoundWriteTarget::Directory(crate::sql2::bind::write::DirectoryWriteSurface::ByBranch) => {
-            Some("lixcol_branch_id")
-        }
-        _ => None,
-    }
-}
-
-#[derive(Clone, Debug, Eq, PartialEq)]
-enum ResolvedBranchSelector {
-    Missing,
-    Static(BTreeSet<String>),
-}
-
-impl ResolvedBranchSelector {
-    fn union(self, other: Self) -> Self {
-        match (self, other) {
-            (Self::Missing, _) | (_, Self::Missing) => Self::Missing,
-            (Self::Static(mut left), Self::Static(right)) => {
-                left.extend(right);
-                Self::Static(left)
-            }
-        }
-    }
-
-    fn intersect(self, other: Self) -> Self {
-        match (self, other) {
-            (Self::Missing, selector) | (selector, Self::Missing) => selector,
-            (Self::Static(left), Self::Static(right)) => {
-                Self::Static(left.intersection(&right).cloned().collect())
-            }
-        }
-    }
-}
-
-fn resolved_predicate_branch_selector(
-    predicate: &BoundPredicate,
-    branch_column: &str,
-    params: &[Value],
-) -> Result<ResolvedBranchSelector, LixError> {
-    match predicate {
-        BoundPredicate::True => Ok(ResolvedBranchSelector::Missing),
-        BoundPredicate::False => Ok(ResolvedBranchSelector::Static(BTreeSet::new())),
-        BoundPredicate::And(predicates) => {
-            let mut result = ResolvedBranchSelector::Missing;
-            for predicate in predicates {
-                result = result.intersect(resolved_predicate_branch_selector(
-                    predicate,
-                    branch_column,
-                    params,
-                )?);
-            }
-            Ok(result)
-        }
-        BoundPredicate::Or(predicates) => {
-            let mut result = ResolvedBranchSelector::Static(BTreeSet::new());
-            for predicate in predicates {
-                result = result.union(resolved_predicate_branch_selector(
-                    predicate,
-                    branch_column,
-                    params,
-                )?);
-            }
-            Ok(result)
-        }
-        BoundPredicate::Eq(left, right) => {
-            resolved_branch_selector_from_binary_exprs(left, right, branch_column, params)
-                .or_else(|| {
-                    resolved_branch_selector_from_binary_exprs(right, left, branch_column, params)
-                })
-                .transpose()
-                .map(|selector| selector.unwrap_or(ResolvedBranchSelector::Missing))
-        }
-        BoundPredicate::Like { .. } | BoundPredicate::IsNull(_) | BoundPredicate::IsNotNull(_) => {
-            Ok(ResolvedBranchSelector::Missing)
-        }
-        BoundPredicate::In { expr, values } => {
-            let BoundExpr::Column(column) = expr else {
-                return Ok(ResolvedBranchSelector::Missing);
-            };
-            if column.name != branch_column {
-                return Ok(ResolvedBranchSelector::Missing);
-            }
-            let mut result = ResolvedBranchSelector::Static(BTreeSet::new());
-            for value in values {
-                result = result.union(resolved_value_branch_selector(value, params)?);
-            }
-            Ok(result)
-        }
-    }
-}
-
-fn resolved_branch_selector_from_binary_exprs(
-    column_expr: &BoundExpr,
-    value_expr: &BoundExpr,
-    branch_column: &str,
-    params: &[Value],
-) -> Option<Result<ResolvedBranchSelector, LixError>> {
-    let BoundExpr::Column(column) = column_expr else {
-        return None;
-    };
-    if column.name != branch_column {
-        return None;
-    }
-    Some(resolved_value_branch_selector(value_expr, params))
-}
-
-fn resolved_value_branch_selector(
-    expr: &BoundExpr,
-    params: &[Value],
-) -> Result<ResolvedBranchSelector, LixError> {
-    match expr {
-        BoundExpr::Literal(BoundLiteral::Text(branch_id)) => {
-            Ok(ResolvedBranchSelector::Static(BTreeSet::from([
-                branch_id.clone()
-            ])))
-        }
-        BoundExpr::Literal(BoundLiteral::Null) => {
-            Ok(ResolvedBranchSelector::Static(BTreeSet::new()))
-        }
-        BoundExpr::Param(param) => match params.get(param.index.saturating_sub(1)) {
-            Some(Value::Text(branch_id)) => Ok(ResolvedBranchSelector::Static(BTreeSet::from([
-                branch_id.clone(),
-            ]))),
-            Some(Value::Null) => Ok(ResolvedBranchSelector::Static(BTreeSet::new())),
-            Some(_) => Err(LixError::new(
-                LixError::CODE_TYPE_MISMATCH,
-                "by-branch SQL write selectors require text branch-id parameters",
-            )),
-            None => Err(LixError::new(
-                LixError::CODE_INVALID_PARAM,
-                format!(
-                    "SQL branch selector parameter ${} was not provided",
-                    param.index
-                ),
-            )),
-        },
-        _ => Err(LixError::new(
-            LixError::CODE_UNSUPPORTED_SQL,
-            "by-branch SQL write predicates require string branch ids",
-        )),
-    }
-}
-
-fn insert_branch_param_values(
-    branch_ids: &mut BTreeSet<String>,
-    param_indexes: &BTreeSet<usize>,
-    params: &[Value],
-    null_policy: BranchParamNullPolicy,
-) -> Result<(), LixError> {
-    for index in param_indexes {
-        match params.get(index.saturating_sub(1)) {
-            Some(Value::Text(branch_id)) => {
-                branch_ids.insert(branch_id.clone());
-            }
-            Some(Value::Null) if null_policy == BranchParamNullPolicy::Ignore => {}
-            Some(Value::Null) => {
-                return Err(LixError::new(
-                    LixError::CODE_TYPE_MISMATCH,
-                    "INSERT into a by-branch SQL surface requires non-null text branch-id parameters",
-                ));
-            }
-            Some(_) => {
-                return Err(LixError::new(
-                    LixError::CODE_TYPE_MISMATCH,
-                    "by-branch SQL write selectors require text branch-id parameters",
-                ));
-            }
-            None => {
-                return Err(LixError::new(
-                    LixError::CODE_INVALID_PARAM,
-                    format!("SQL branch selector parameter ${index} was not provided"),
-                ));
-            }
-        }
-    }
-    Ok(())
-}
-
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-enum BranchParamNullPolicy {
-    Reject,
-    Ignore,
 }
 
 fn normalize_bound_public_write_error(error: LixError) -> LixError {

--- a/packages/lix/src/sql2/plan/branch_scope.rs
+++ b/packages/lix/src/sql2/plan/branch_scope.rs
@@ -1,23 +1,7 @@
-use std::collections::BTreeSet;
-
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub(crate) enum BranchScope {
     Active {
         branch_id: String,
-    },
-    Explicit {
-        branch_ids: BTreeSet<String>,
-    },
-    ExplicitDynamic {
-        branch_ids: BTreeSet<String>,
-        param_indexes: BTreeSet<usize>,
-    },
-    ExplicitRequired {
-        branch_ids: BTreeSet<String>,
-    },
-    ExplicitRequiredDynamic {
-        branch_ids: BTreeSet<String>,
-        param_indexes: BTreeSet<usize>,
     },
     Global,
     Empty,

--- a/packages/lix/src/sql2/plan/write.rs
+++ b/packages/lix/src/sql2/plan/write.rs
@@ -65,8 +65,6 @@ mod tests {
     use crate::sql2::bind::bind_statement;
     use crate::sql2::parse_statement;
     use crate::sql2::plan::branch_scope::BranchScope;
-    use std::collections::BTreeSet;
-
     #[test]
     fn plan_write_contradiction_does_not_drop_bound_params() {
         let plan = plan_sql(
@@ -87,19 +85,6 @@ mod tests {
             plan.bound.branch_scope,
             BranchScope::Active {
                 branch_id: "branch1".to_string()
-            }
-        );
-    }
-
-    #[test]
-    fn plan_write_keeps_explicit_required_scope_for_by_branch_writes() {
-        let plan =
-            plan_sql("DELETE FROM lix_file_by_branch WHERE lixcol_branch_id IN ('v1', 'v2')");
-
-        assert_eq!(
-            plan.bound.branch_scope,
-            BranchScope::ExplicitRequired {
-                branch_ids: BTreeSet::from(["v1".to_string(), "v2".to_string()])
             }
         );
     }

--- a/packages/lix/src/sql2/providers/directory.rs
+++ b/packages/lix/src/sql2/providers/directory.rs
@@ -33,8 +33,7 @@ use crate::hot_state::{
 };
 use crate::plugin::runtime::{is_plugin_storage_path, reject_normal_plugin_storage_mutation};
 use crate::sql2::branch_scope::{
-    BranchBinding, explicit_branch_ids_from_dml_filters, resolve_provider_branch_ids,
-    resolve_write_branch_scope,
+    BranchBinding, resolve_provider_branch_ids, resolve_write_branch_scope,
 };
 use crate::sql2::predicate_typecheck::{
     canonicalize_json_identity_text_filters, validate_json_predicate_filters,
@@ -49,10 +48,7 @@ use crate::transaction_types::{
     LogicalPrimaryKey, RawWriteBatch, RawWriteRowRef, TransactionJson, TransactionWriteOperation,
     TransactionWriteOrigin,
 };
-use crate::{
-    GLOBAL_BRANCH_ID, LixError, SqlQueryResult, Value, parse_row_metadata_value,
-    serialize_row_metadata,
-};
+use crate::{LixError, SqlQueryResult, Value, parse_row_metadata_value, serialize_row_metadata};
 
 use crate::filesystem::{
     DirectoryDescriptorWriteIntent, DirectoryPathRecord, DirectoryPathResolver,
@@ -87,7 +83,6 @@ const DIRECTORY_SCHEMA_KEY: &str = "lix_directory_descriptor";
 /// directory id as a single-element row primary key.
 const LIX_DIRECTORY_IDENTITY: &[&str] = &["id"];
 const LIX_DIRECTORY_PATH_IDENTITY: &[&str] = &["path"];
-const LIX_DIRECTORY_BY_BRANCH_PATH_IDENTITY: &[&str] = &["path", "lixcol_branch_id"];
 
 /// Executes the exact root-directory listing used by the filesystem API
 /// directly from the shared path index.
@@ -164,49 +159,6 @@ pub(super) async fn register_lix_directory_active_provider(
             functions,
         )),
         WriteAccess::read_only(),
-    )
-}
-
-pub(super) async fn register_lix_directory_by_branch_provider(
-    session: &SessionContext,
-    surface_name: &str,
-    hot_state: Arc<dyn HotStateReader>,
-    filesystem_path_index: Arc<dyn FilesystemPathIndexReader>,
-    branch_ref: Arc<dyn BranchRefReader>,
-    functions: FunctionProviderHandle,
-) -> Result<(), LixError> {
-    register_spec_table(
-        session,
-        surface_name,
-        Arc::new(LixDirectorySpec::by_branch(
-            hot_state,
-            filesystem_path_index,
-            branch_ref,
-            functions,
-        )),
-        WriteAccess::read_only(),
-    )
-}
-
-pub(super) async fn register_by_branch_write_provider(
-    session: &SessionContext,
-    surface_name: &str,
-    write_ctx: SqlWriteContext,
-    branch_ref: Arc<dyn BranchRefReader>,
-) -> Result<(), LixError> {
-    let functions = write_ctx.functions();
-    let hot_state = Arc::new(WriteContextHotStateReader::new(write_ctx.clone()));
-    let filesystem_path_index: Arc<dyn FilesystemPathIndexReader> = hot_state.clone();
-    register_spec_table(
-        session,
-        surface_name,
-        Arc::new(LixDirectorySpec::by_branch(
-            hot_state,
-            filesystem_path_index,
-            branch_ref,
-            functions,
-        )),
-        WriteAccess::write(write_ctx),
     )
 }
 
@@ -300,22 +252,6 @@ impl LixDirectorySpec {
         }
     }
 
-    fn by_branch(
-        hot_state: Arc<dyn HotStateReader>,
-        filesystem_path_index: Arc<dyn FilesystemPathIndexReader>,
-        branch_ref: Arc<dyn BranchRefReader>,
-        functions: FunctionProviderHandle,
-    ) -> Self {
-        Self {
-            schema: lix_directory_by_branch_schema(),
-            hot_state,
-            filesystem_path_index,
-            branch_ref,
-            functions,
-            branch_binding: BranchBinding::explicit(),
-        }
-    }
-
     /// Build the resolver set used by path-based directory writes from the
     /// descriptor index.  The transaction write context serves its revisioned
     /// cache until filesystem descriptors are staged, then safely rebuilds an
@@ -353,12 +289,10 @@ impl LixDirectorySpec {
         }
     }
 
-    /// Resolve the candidate-row scan request for an UPDATE/DELETE, scoped by
-    /// the explicit branch ids from the statement filters.
-    async fn dml_scan_request(&self, filters: &[Expr]) -> Result<HotStateScanRequest> {
+    /// Resolve the candidate-row scan request for an UPDATE/DELETE.
+    async fn dml_scan_request(&self, _filters: &[Expr]) -> Result<HotStateScanRequest> {
         let mut request =
             lix_directory_scan_request(self.branch_binding.active_branch_id(), None, None);
-        request.filter.branch_ids = explicit_branch_ids_from_dml_filters(filters);
         request.filter.branch_ids = resolve_provider_branch_ids(
             self.branch_ref.as_ref(),
             &self.branch_binding,
@@ -418,12 +352,7 @@ impl LixDirectorySpec {
     ) -> Result<DirectoryReturningKey> {
         Ok(DirectoryReturningKey {
             id: required_string_value(batch, row_index, "id")?,
-            branch_id: match self.branch_binding {
-                BranchBinding::Active { .. } => String::new(),
-                BranchBinding::Explicit => {
-                    required_string_value(batch, row_index, "lixcol_branch_id")?
-                }
-            },
+            branch_id: String::new(),
         })
     }
 
@@ -450,19 +379,11 @@ impl LixDirectorySpec {
         if keys.is_empty() {
             return Ok(RecordBatch::new_empty(Arc::clone(&self.schema)));
         }
-        let mut request = lix_directory_scan_request(
+        let request = lix_directory_scan_request(
             self.branch_binding.active_branch_id(),
             Some(self.schema.as_ref()),
             None,
         );
-        if matches!(self.branch_binding, BranchBinding::Explicit) {
-            request.filter.branch_ids = keys
-                .iter()
-                .map(|key| key.branch_id.clone())
-                .collect::<BTreeSet<_>>()
-                .into_iter()
-                .collect();
-        }
         let rows = write_ctx
             .scan_hot_state_batch(&request)
             .await
@@ -1002,10 +923,7 @@ impl UpsertSupport for LixDirectorySpec {
             return Ok(UpsertConflictTarget::id(LIX_DIRECTORY_IDENTITY));
         }
 
-        let path_identity = match self.branch_binding {
-            BranchBinding::Active { .. } => LIX_DIRECTORY_PATH_IDENTITY,
-            BranchBinding::Explicit => LIX_DIRECTORY_BY_BRANCH_PATH_IDENTITY,
-        };
+        let path_identity = LIX_DIRECTORY_PATH_IDENTITY;
         validate_target_columns(
             table_name,
             target_columns,
@@ -1129,14 +1047,6 @@ impl UpsertSupport for LixDirectorySpec {
     ) -> Result<RecordBatch> {
         let mut request =
             lix_directory_scan_request(self.branch_binding.active_branch_id(), None, None);
-        if matches!(self.branch_binding, BranchBinding::Explicit) {
-            request.filter.branch_ids = match target.kind() {
-                UpsertConflictKind::Id => proposed_branch_ids(proposed)?,
-                UpsertConflictKind::Path => {
-                    required_proposed_branch_ids(proposed, "lix_directory")?
-                }
-            };
-        }
         request.filter.branch_ids = resolve_provider_branch_ids(
             self.branch_ref.as_ref(),
             &self.branch_binding,
@@ -1271,31 +1181,6 @@ fn proposed_directory_path_predicate(batch: &RecordBatch) -> Result<FilePathPred
     Ok(FilePathPredicate::In(paths))
 }
 
-fn proposed_branch_ids(batch: &RecordBatch) -> Result<Vec<String>> {
-    let mut branch_ids = BTreeSet::new();
-    for row_index in 0..batch.num_rows() {
-        if let Some(branch_id) = optional_string_value(batch, row_index, "lixcol_branch_id")? {
-            branch_ids.insert(branch_id);
-        }
-    }
-    Ok(branch_ids.into_iter().collect())
-}
-
-fn required_proposed_branch_ids(batch: &RecordBatch, table_name: &str) -> Result<Vec<String>> {
-    let mut branch_ids = BTreeSet::new();
-    for row_index in 0..batch.num_rows() {
-        let branch_id = optional_string_value(batch, row_index, "lixcol_branch_id")?.ok_or_else(
-            || {
-                DataFusionError::Execution(format!(
-                    "INSERT ON CONFLICT (path, lixcol_branch_id) on {table_name} requires non-null lixcol_branch_id"
-                ))
-            },
-        )?;
-        branch_ids.insert(branch_id);
-    }
-    Ok(branch_ids.into_iter().collect())
-}
-
 fn validate_required_paths(batch: &RecordBatch, table_name: &str) -> Result<()> {
     for row_index in 0..batch.num_rows() {
         if optional_string_value(batch, row_index, "path")?.is_none() {
@@ -1312,10 +1197,8 @@ fn lane_name(untracked: bool) -> &'static str {
 }
 
 fn lix_directory_surface_name(branch_binding: &BranchBinding) -> &'static str {
-    match branch_binding {
-        BranchBinding::Active { .. } => "lix_directory",
-        BranchBinding::Explicit => "lix_directory_by_branch",
-    }
+    let _ = branch_binding;
+    "lix_directory"
 }
 
 trait DirectoryLiveRow {
@@ -1329,7 +1212,6 @@ trait DirectoryLiveRow {
     fn commit_id(&self) -> Option<String>;
     fn untracked(&self) -> bool;
     fn metadata(&self) -> Option<String>;
-    fn branch_id(&self) -> &str;
 }
 
 impl DirectoryLiveRow for MaterializedHotStateRow {
@@ -1371,10 +1253,6 @@ impl DirectoryLiveRow for MaterializedHotStateRow {
 
     fn metadata(&self) -> Option<String> {
         self.metadata.as_deref().map(serialize_row_metadata)
-    }
-
-    fn branch_id(&self) -> &str {
-        &self.branch_id
     }
 }
 
@@ -1419,10 +1297,6 @@ impl DirectoryLiveRow for MaterializedHotStateRowRef<'_> {
         (*self)
             .metadata()
             .map(|value| serialize_row_metadata(value))
-    }
-
-    fn branch_id(&self) -> &str {
-        (*self).branch_id()
     }
 }
 
@@ -1536,8 +1410,7 @@ fn lix_directory_update_write_rows_from_batch(
         let parent_id =
             update_optional_string_value(batch, &assignment_values, row_index, "parent_id")?;
         let name = update_required_string_value(batch, &assignment_values, row_index, "name")?;
-        crate::common::validate_lix_path_segment(&name)
-            .map_err(lix_error_to_datafusion_error)?;
+        crate::common::validate_lix_path_segment(&name).map_err(lix_error_to_datafusion_error)?;
         if let Some(directory_id) = id.as_ref() {
             let resolver = path_resolvers
                 .entry(directory_path_resolver_key(&context))
@@ -1771,8 +1644,7 @@ fn lix_directory_write_rows_from_batch_with_options_and_path_resolvers(
 
         let parent_id = optional_string_value(batch, row_index, "parent_id")?;
         let name = required_string_value(batch, row_index, "name")?;
-        crate::common::validate_lix_path_segment(&name)
-            .map_err(lix_error_to_datafusion_error)?;
+        crate::common::validate_lix_path_segment(&name).map_err(lix_error_to_datafusion_error)?;
         if let Some(path_resolvers) = path_resolvers.as_deref_mut() {
             if let Some(directory_id) = id.as_ref() {
                 let resolver = path_resolvers
@@ -1835,9 +1707,7 @@ fn attach_lix_directory_insert_origin(
         let matches = {
             let row = rows.row(index);
             row.schema_key == DIRECTORY_SCHEMA_KEY
-                && row
-                    .row_pk
-                    .and_then(|row_pk| row_pk.as_single_string().ok())
+                && row.row_pk.and_then(|row_pk| row_pk.as_single_string().ok())
                     == Some(directory_id)
         };
         if matches {
@@ -1866,10 +1736,8 @@ fn directory_row_context_from_batch(
             "lixcol_global",
             "INSERT into lix_directory",
         )?,
-        optional_string_value(batch, row_index, "lixcol_branch_id")?,
         branch_binding,
-        "INSERT into lix_directory_by_branch",
-        "lix_directory",
+        "INSERT into lix_directory",
     )?;
 
     Ok(FilesystemRowContext {
@@ -1894,18 +1762,8 @@ fn directory_row_context_from_update(
     branch_binding: Option<&str>,
 ) -> Result<FilesystemRowContext> {
     let explicit_global = optional_bool_value(batch, row_index, "lixcol_global")?;
-    let explicit_branch_id = if explicit_global == Some(true) {
-        Some(GLOBAL_BRANCH_ID.to_string())
-    } else {
-        optional_string_value(batch, row_index, "lixcol_branch_id")?
-    };
-    let scope = resolve_write_branch_scope(
-        explicit_global,
-        explicit_branch_id,
-        branch_binding,
-        "UPDATE into lix_directory_by_branch",
-        "lix_directory",
-    )?;
+    let scope =
+        resolve_write_branch_scope(explicit_global, branch_binding, "UPDATE lix_directory")?;
 
     Ok(FilesystemRowContext {
         branch_id: scope.branch_id,
@@ -2054,7 +1912,6 @@ where
     let mut commit_ids = Vec::new();
     let mut untracked_values = Vec::new();
     let mut metadata_values = Vec::new();
-    let mut branch_ids = Vec::new();
 
     for (directory, path) in directory_rows {
         ids.push(Some(directory.id));
@@ -2071,7 +1928,6 @@ where
         commit_ids.push(directory.live.commit_id());
         untracked_values.push(Some(directory.live.untracked()));
         metadata_values.push(directory.live.metadata());
-        branch_ids.push(Some(directory.live.branch_id().to_owned()));
     }
 
     let mut columns = Vec::<ArrayRef>::with_capacity(schema.fields().len());
@@ -2091,7 +1947,6 @@ where
             "lixcol_commit_id" => Arc::new(StringArray::from(commit_ids.clone())),
             "lixcol_untracked" => Arc::new(BooleanArray::from(untracked_values.clone())),
             "lixcol_metadata" => Arc::new(StringArray::from(metadata_values.clone())),
-            "lixcol_branch_id" => Arc::new(StringArray::from(branch_ids.clone())),
             other => {
                 return Err(LixError::new(
                     "LIX_ERROR_UNKNOWN",
@@ -2362,16 +2217,6 @@ pub(super) fn lix_directory_schema() -> SchemaRef {
     ]))
 }
 
-pub(super) fn lix_directory_by_branch_schema() -> SchemaRef {
-    let mut fields = lix_directory_schema()
-        .fields()
-        .iter()
-        .map(|field| field.as_ref().clone())
-        .collect::<Vec<_>>();
-    fields.push(Field::new("lixcol_branch_id", DataType::Utf8, false));
-    Arc::new(Schema::new(fields))
-}
-
 fn lix_error_to_datafusion_error(error: LixError) -> DataFusionError {
     crate::sql2::error::lix_error_to_datafusion_error(error)
 }
@@ -2414,10 +2259,10 @@ mod tests {
 
     use super::super::spec::{SpecTableProvider, TableSpec};
     use super::{
-        BranchBinding, DirectoryDescriptorRecord, LixDirectorySpec, UpsertConflictTarget,
-        UpsertSupport, derive_directory_paths, lix_directory_by_branch_schema,
-        lix_directory_insert_origin, lix_directory_record_batch,
-        lix_directory_recursive_delete_rows_from_batch, lix_directory_write_rows_from_batch,
+        DirectoryDescriptorRecord, LixDirectorySpec, UpsertConflictTarget, UpsertSupport,
+        derive_directory_paths, lix_directory_insert_origin, lix_directory_record_batch,
+        lix_directory_recursive_delete_rows_from_batch, lix_directory_schema,
+        lix_directory_write_rows_from_batch,
         lix_directory_write_rows_from_batch_with_path_resolvers,
     };
     use crate::filesystem::{
@@ -2530,7 +2375,6 @@ mod tests {
     /// same `stage_insert` path the writable provider uses.
     async fn stage_directory_insert(
         write_ctx: SqlWriteContext,
-        branch_binding: BranchBinding,
         batch: RecordBatch,
     ) -> Result<u64, datafusion::common::DataFusionError> {
         let hot_state = Arc::new(crate::sql2::WriteContextHotStateReader::new(
@@ -2540,21 +2384,13 @@ mod tests {
             write_ctx.clone(),
         ));
         let filesystem_path_index: Arc<dyn FilesystemPathIndexReader> = hot_state.clone();
-        let spec = match branch_binding {
-            BranchBinding::Active { .. } => LixDirectorySpec::active_branch(
-                write_ctx.active_branch_id(),
-                hot_state,
-                filesystem_path_index,
-                branch_ref,
-                test_functions(),
-            ),
-            BranchBinding::Explicit => LixDirectorySpec::by_branch(
-                hot_state,
-                filesystem_path_index,
-                branch_ref,
-                test_functions(),
-            ),
-        };
+        let spec = LixDirectorySpec::active_branch(
+            write_ctx.active_branch_id(),
+            hot_state,
+            filesystem_path_index,
+            branch_ref,
+            test_functions(),
+        );
         spec.stage_insert(&write_ctx, vec![batch]).await
     }
 
@@ -2698,11 +2534,7 @@ mod tests {
         }
     }
 
-    fn live_row(
-        row_pk: &str,
-        branch_id: &str,
-        snapshot_content: &str,
-    ) -> MaterializedHotStateRow {
+    fn live_row(row_pk: &str, branch_id: &str, snapshot_content: &str) -> MaterializedHotStateRow {
         live_filesystem_row(
             row_pk,
             super::DIRECTORY_SCHEMA_KEY,
@@ -2781,45 +2613,23 @@ mod tests {
         Arc::new(StringArray::from(values)) as ArrayRef
     }
 
-    fn directory_insert_batch(include_branch: bool, global: bool) -> RecordBatch {
-        let mut fields = vec![
+    fn directory_insert_batch(global: bool) -> RecordBatch {
+        let fields = vec![
             Field::new("id", DataType::Utf8, false),
             Field::new("parent_id", DataType::Utf8, true),
             Field::new("name", DataType::Utf8, false),
             Field::new("lixcol_global", DataType::Boolean, false),
             Field::new("lixcol_metadata", DataType::Utf8, true),
         ];
-        let mut columns = vec![
+        let columns = vec![
             string_column(vec![Some("01920000-0000-7000-8000-0000000000d3")]),
             string_column(vec![None]),
             string_column(vec![Some("docs")]),
             Arc::new(BooleanArray::from(vec![global])) as ArrayRef,
             string_column(vec![Some("{\"source\":\"directory\"}")]),
         ];
-        if include_branch {
-            fields.push(Field::new("lixcol_branch_id", DataType::Utf8, false));
-            columns.push(string_column(vec![Some(
-                "01920000-0000-7000-8000-0000000000a1",
-            )]));
-        }
         RecordBatch::try_new(Arc::new(Schema::new(fields)), columns)
             .expect("directory insert batch should build")
-    }
-
-    fn directory_path_insert_batch(path: &str) -> RecordBatch {
-        RecordBatch::try_new(
-            Arc::new(Schema::new(vec![
-                Field::new("id", DataType::Utf8, false),
-                Field::new("path", DataType::Utf8, true),
-                Field::new("lixcol_branch_id", DataType::Utf8, false),
-            ])),
-            vec![
-                string_column(vec![Some("01920000-0000-7000-8000-000000000343")]),
-                string_column(vec![Some(path)]),
-                string_column(vec![Some("01920000-0000-7000-8000-0000000000a1")]),
-            ],
-        )
-        .expect("directory path insert batch should build")
     }
 
     fn active_directory_path_insert_batch(path: &str) -> RecordBatch {
@@ -2838,17 +2648,10 @@ mod tests {
 
     fn directory_delete_batch(ids: &[&str]) -> RecordBatch {
         RecordBatch::try_new(
-            Arc::new(Schema::new(vec![
-                Field::new("id", DataType::Utf8, false),
-                Field::new("lixcol_branch_id", DataType::Utf8, false),
-            ])),
-            vec![
-                string_column(ids.iter().copied().map(Some).collect::<Vec<_>>()),
-                string_column(vec![
-                    Some("01920000-0000-7000-8000-0000000000a1");
-                    ids.len()
-                ]),
-            ],
+            Arc::new(Schema::new(vec![Field::new("id", DataType::Utf8, false)])),
+            vec![string_column(
+                ids.iter().copied().map(Some).collect::<Vec<_>>(),
+            )],
         )
         .expect("directory delete batch should build")
     }
@@ -2909,7 +2712,7 @@ mod tests {
         ];
 
         let rows = MaterializedHotStateBatch::from_rows(rows);
-        let batch = lix_directory_record_batch(&lix_directory_by_branch_schema(), &rows)
+        let batch = lix_directory_record_batch(&lix_directory_schema(), &rows)
             .expect("directory batch should build");
 
         assert_eq!(batch.num_rows(), 2);
@@ -2922,16 +2725,6 @@ mod tests {
                 .expect("path is string")
                 .value(1),
             "/docs/guides"
-        );
-        assert_eq!(
-            batch
-                .column_by_name("lixcol_branch_id")
-                .expect("branch column")
-                .as_any()
-                .downcast_ref::<StringArray>()
-                .expect("branch is string")
-                .value(1),
-            "01920000-0000-7000-8000-0000000000a1"
         );
     }
 
@@ -3087,8 +2880,11 @@ mod tests {
 
     #[test]
     fn decodes_directory_insert_into_transaction_write_row() {
-        let rows = lix_directory_write_rows_from_batch(&directory_insert_batch(true, false), None)
-            .expect("directory batch should decode");
+        let rows = lix_directory_write_rows_from_batch(
+            &directory_insert_batch(false),
+            Some("01920000-0000-7000-8000-0000000000a1"),
+        )
+        .expect("directory batch should decode");
 
         assert_eq!(
             rows,
@@ -3125,37 +2921,12 @@ mod tests {
     #[test]
     fn active_directory_insert_defaults_branch_id() {
         let rows = lix_directory_write_rows_from_batch(
-            &directory_insert_batch(false, false),
+            &directory_insert_batch(false),
             Some("branch-active"),
         )
         .expect("active directory batch should decode");
 
         assert_eq!(rows[0].branch_id, "branch-active");
-    }
-
-    #[test]
-    fn by_branch_directory_insert_requires_branch_id_for_non_global_rows() {
-        let error =
-            lix_directory_write_rows_from_batch(&directory_insert_batch(false, false), None)
-                .expect_err("by-branch insert should require branch id");
-
-        assert!(
-            error.to_string().contains("requires lixcol_branch_id"),
-            "unexpected error: {error}"
-        );
-    }
-
-    #[test]
-    fn directory_insert_rejects_global_with_non_global_branch_id() {
-        let error = lix_directory_write_rows_from_batch(&directory_insert_batch(true, true), None)
-            .expect_err("global directory write should reject conflicting branch id");
-
-        assert!(
-            error
-                .to_string()
-                .contains("cannot set lixcol_global=true with non-global lixcol_branch_id"),
-            "unexpected error: {error}"
-        );
     }
 
     #[test]
@@ -3170,8 +2941,8 @@ mod tests {
             .expect("existing directory rows should seed paths");
 
         let rows = lix_directory_write_rows_from_batch_with_path_resolvers(
-            &directory_path_insert_batch("/docs/nested"),
-            None,
+            &active_directory_path_insert_batch("/docs/nested"),
+            Some("01920000-0000-7000-8000-0000000000a1"),
             "lix_directory",
             &mut resolvers,
             &mut test_id_generator(&["should-not-be-used"]),
@@ -3200,7 +2971,7 @@ mod tests {
 
         let (rows, count) = lix_directory_recursive_delete_rows_from_batch(
             &directory_delete_batch(&["01920000-0000-7000-8000-0000000000d3"]),
-            None,
+            Some("01920000-0000-7000-8000-0000000000a1"),
             &visible_filesystems,
         )
         .expect("recursive directory delete should plan");
@@ -3260,7 +3031,7 @@ mod tests {
                 "01920000-0000-7000-8000-0000000000d3",
                 "01920000-0000-7000-8000-000000000313",
             ]),
-            None,
+            Some("01920000-0000-7000-8000-0000000000a1"),
             &visible_filesystems,
         )
         .expect("recursive directory delete should plan");
@@ -3285,8 +3056,8 @@ mod tests {
     async fn directory_insert_sink_stages_decoded_transaction_rows() {
         let mut write_context = CapturingWriteContext::default();
         let write_ctx = SqlWriteContext::new(&mut write_context);
-        let batch = directory_insert_batch(true, false);
-        let count = stage_directory_insert(write_ctx, BranchBinding::explicit(), batch)
+        let batch = directory_insert_batch(false);
+        let count = stage_directory_insert(write_ctx, batch)
             .await
             .expect("directory spec should stage write");
 
@@ -3311,7 +3082,7 @@ mod tests {
                         json!({"source": "directory"})
                     )),
                     origin: Some(lix_directory_insert_origin(
-                        "lix_directory_by_branch",
+                        "lix_directory",
                         "01920000-0000-7000-8000-0000000000d3"
                     )),
                     created_at: None,
@@ -3338,8 +3109,8 @@ mod tests {
             reject_scans: false,
         };
         let write_ctx = SqlWriteContext::new(&mut write_context);
-        let batch = directory_path_insert_batch("/docs/nested");
-        let count = stage_directory_insert(write_ctx, BranchBinding::explicit(), batch)
+        let batch = active_directory_path_insert_batch("/docs/nested");
+        let count = stage_directory_insert(write_ctx, batch)
             .await
             .expect("directory spec should stage path write");
 
@@ -3627,7 +3398,7 @@ mod tests {
             );
             spec.scan_conflict_candidates(
                 &write_ctx,
-                &directory_insert_batch(false, false),
+                &directory_insert_batch(false),
                 &UpsertConflictTarget::id(&["id"]),
             )
             .await

--- a/packages/lix/src/sql2/providers/file.rs
+++ b/packages/lix/src/sql2/providers/file.rs
@@ -55,8 +55,7 @@ use crate::plugin::runtime::{
 };
 use crate::row_pk::RowPk;
 use crate::sql2::branch_scope::{
-    BranchBinding, explicit_branch_ids_from_dml_filters, resolve_provider_branch_ids,
-    resolve_write_branch_scope,
+    BranchBinding, resolve_provider_branch_ids, resolve_write_branch_scope,
 };
 use crate::sql2::dml::InsertSink;
 use crate::sql2::predicate_typecheck::{
@@ -139,54 +138,6 @@ pub(super) async fn register_lix_file_active_provider(
             .with_session_file_views(session_file_views),
         ),
         WriteAccess::read_only(),
-    )
-}
-
-pub(super) async fn register_lix_file_by_branch_provider(
-    session: &SessionContext,
-    surface_name: &str,
-    hot_state: Arc<dyn HotStateReader>,
-    filesystem_path_index: Arc<dyn FilesystemPathIndexReader>,
-    branch_ref: Arc<dyn BranchRefReader>,
-    blob_reader: Arc<dyn BlobDataReader>,
-    plugin_host: PluginRuntimeHost,
-    functions: FunctionProviderHandle,
-    session_file_views: Option<SessionFileViews>,
-) -> Result<(), LixError> {
-    register_spec_table(
-        session,
-        surface_name,
-        Arc::new(
-            LixFileSpec::by_branch(
-                hot_state,
-                filesystem_path_index,
-                branch_ref,
-                blob_reader,
-                plugin_host,
-                functions,
-            )
-            .with_session_file_views(session_file_views),
-        ),
-        WriteAccess::read_only(),
-    )
-}
-
-pub(super) async fn register_by_branch_write_provider(
-    session: &SessionContext,
-    surface_name: &str,
-    write_ctx: SqlWriteContext,
-    branch_ref: Arc<dyn BranchRefReader>,
-    options: SqlWriteSessionOptions,
-) -> Result<(), LixError> {
-    register_spec_table(
-        session,
-        surface_name,
-        Arc::new(LixFileSpec::by_branch_with_write(
-            write_ctx.clone(),
-            branch_ref,
-            options,
-        )),
-        WriteAccess::write(write_ctx),
     )
 }
 
@@ -348,53 +299,6 @@ impl LixFileSpec {
         }
     }
 
-    fn by_branch(
-        hot_state: Arc<dyn HotStateReader>,
-        filesystem_path_index: Arc<dyn FilesystemPathIndexReader>,
-        branch_ref: Arc<dyn BranchRefReader>,
-        blob_reader: Arc<dyn BlobDataReader>,
-        plugin_host: PluginRuntimeHost,
-        functions: FunctionProviderHandle,
-    ) -> Self {
-        Self {
-            schema: lix_file_by_branch_schema(),
-            hot_state,
-            filesystem_path_index,
-            branch_ref,
-            blob_reader,
-            plugin_host,
-            functions,
-            branch_binding: BranchBinding::explicit(),
-            options: SqlWriteSessionOptions::default(),
-            session_file_views: None,
-        }
-    }
-
-    fn by_branch_with_write(
-        write_ctx: SqlWriteContext,
-        branch_ref: Arc<dyn BranchRefReader>,
-        options: SqlWriteSessionOptions,
-    ) -> Self {
-        let functions = write_ctx.functions();
-        let hot_state = Arc::new(WriteContextHotStateReader::new(write_ctx.clone()));
-        let filesystem_path_index: Arc<dyn FilesystemPathIndexReader> = hot_state.clone();
-        let blob_reader = write_ctx.blob_reader();
-        let plugin_host = write_ctx.plugin_host();
-        let session_file_views = write_ctx.session_file_views();
-        Self {
-            schema: lix_file_by_branch_schema(),
-            hot_state,
-            filesystem_path_index,
-            branch_ref,
-            blob_reader,
-            plugin_host,
-            functions,
-            branch_binding: BranchBinding::explicit(),
-            options,
-            session_file_views,
-        }
-    }
-
     fn with_session_file_views(mut self, session_file_views: Option<SessionFileViews>) -> Self {
         self.session_file_views = session_file_views;
         self
@@ -526,14 +430,7 @@ impl LixFileSpec {
         row_index: usize,
     ) -> Result<FileReturningKey> {
         let id = required_string_value(batch, row_index, "id")?;
-        let branch_id = match self.branch_binding {
-            BranchBinding::Active { .. } => String::new(),
-            // This is a readback identity, not a new write context. A global
-            // row is projected into the requested explicit branch with
-            // `lixcol_global = true` and that branch in `lixcol_branch_id`.
-            // Normalizing it as a write would reject the valid projection.
-            BranchBinding::Explicit => required_string_value(batch, row_index, "lixcol_branch_id")?,
-        };
+        let branch_id = String::new();
         Ok(FileReturningKey { id, branch_id })
     }
 
@@ -568,19 +465,11 @@ impl LixFileSpec {
         if keys.is_empty() {
             return Ok(RecordBatch::new_empty(Arc::clone(&self.schema)));
         }
-        let mut request = lix_file_scan_request(
+        let request = lix_file_scan_request(
             self.branch_binding.active_branch_id(),
             Some(self.schema.as_ref()),
             None,
         );
-        if matches!(self.branch_binding, BranchBinding::Explicit) {
-            request.filter.branch_ids = keys
-                .iter()
-                .map(|key| key.branch_id.clone())
-                .collect::<BTreeSet<_>>()
-                .into_iter()
-                .collect();
-        }
         let file_ids = keys
             .iter()
             .map(|key| key.id.clone())
@@ -970,8 +859,7 @@ impl TableSpec for LixFileSpec {
 
     fn filter_pushdown(&self, filter: &Expr) -> TableProviderFilterPushDown {
         let analyzer = LixFileIdFilterAnalyzer;
-        if ExactStringColumnFilterAnalyzer::new("lixcol_branch_id").supports(filter)
-            || analyzer.supports(filter)
+        if analyzer.supports(filter)
             || ExactStringColumnFilterAnalyzer::new("directory_id").supports(filter)
             || is_null_column_filter(filter, "directory_id")
             || contains_column(filter, "path")
@@ -997,9 +885,6 @@ impl TableSpec for LixFileSpec {
             scan_limit,
         );
         let filters = filters.to_vec();
-        if matches!(self.branch_binding, BranchBinding::Explicit) {
-            request.filter.branch_ids = explicit_branch_ids_from_dml_filters(&filters);
-        }
         request.filter.branch_ids = resolve_provider_branch_ids(
             self.branch_ref.as_ref(),
             &self.branch_binding,
@@ -1416,7 +1301,6 @@ impl TableSpec for LixFileSpec {
             || options.returning_columns.contains("content");
         let target_file_ids = file_id_constraint_from_filters(filters)?;
         let mut request = lix_file_scan_request(self.branch_binding.active_branch_id(), None, None);
-        request.filter.branch_ids = explicit_branch_ids_from_dml_filters(filters);
         request.filter.branch_ids = resolve_provider_branch_ids(
             self.branch_ref.as_ref(),
             &self.branch_binding,
@@ -1515,7 +1399,6 @@ impl LixFileSpec {
                 .is_some_and(|returning| returning.required_columns().contains("content"));
         let target_file_ids = file_id_constraint_from_filters(filters)?;
         let mut request = lix_file_scan_request(self.branch_binding.active_branch_id(), None, None);
-        request.filter.branch_ids = explicit_branch_ids_from_dml_filters(filters);
         request.filter.branch_ids = resolve_provider_branch_ids(
             self.branch_ref.as_ref(),
             &self.branch_binding,
@@ -1662,11 +1545,9 @@ impl LixFileSpec {
 }
 
 /// Physical and path identities the upsert driver can match `lix_file` rows
-/// on. Path targets model the visible filesystem identity for active and
-/// by-branch surfaces.
+/// on.
 const LIX_FILE_IDENTITY: &[&str] = &["id"];
 const LIX_FILE_PATH_IDENTITY: &[&str] = &["path"];
-const LIX_FILE_BY_BRANCH_PATH_IDENTITY: &[&str] = &["path", "lixcol_branch_id"];
 
 #[async_trait]
 impl UpsertSupport for LixFileSpec {
@@ -1690,10 +1571,7 @@ impl UpsertSupport for LixFileSpec {
             return Ok(UpsertConflictTarget::id(LIX_FILE_IDENTITY));
         }
 
-        let path_identity = match self.branch_binding {
-            BranchBinding::Active { .. } => LIX_FILE_PATH_IDENTITY,
-            BranchBinding::Explicit => LIX_FILE_BY_BRANCH_PATH_IDENTITY,
-        };
+        let path_identity = LIX_FILE_PATH_IDENTITY;
         validate_target_columns(
             table_name,
             target_columns,
@@ -1854,12 +1732,6 @@ impl UpsertSupport for LixFileSpec {
             ),
         };
         let mut request = lix_file_scan_request(self.branch_binding.active_branch_id(), None, None);
-        if matches!(self.branch_binding, BranchBinding::Explicit) {
-            request.filter.branch_ids = match target.kind() {
-                UpsertConflictKind::Id => proposed_branch_ids(proposed)?,
-                UpsertConflictKind::Path => required_proposed_branch_ids(proposed, "lix_file")?,
-            };
-        }
         request.filter.branch_ids = resolve_provider_branch_ids(
             self.branch_ref.as_ref(),
             &self.branch_binding,
@@ -1980,9 +1852,6 @@ impl UpsertSupport for LixFileSpec {
         // plugins installed for path-move rewrites.
         let target_file_ids = augmented_file_id_constraint(augmented)?;
         let mut request = lix_file_scan_request(self.branch_binding.active_branch_id(), None, None);
-        if matches!(self.branch_binding, BranchBinding::Explicit) {
-            request.filter.branch_ids = augmented_branch_ids(augmented)?;
-        }
         request.filter.branch_ids = resolve_provider_branch_ids(
             self.branch_ref.as_ref(),
             &self.branch_binding,
@@ -2110,38 +1979,6 @@ fn augmented_file_id_constraint(batch: &RecordBatch) -> Result<FileIdConstraint>
         ids.push(required_string_value(batch, row_index, "id")?);
     }
     Ok(FileIdConstraint::from_ids(ids))
-}
-
-/// Distinct explicit `lixcol_branch_id` values in a proposed insert batch
-/// (by-branch surface). Empty when the column is absent or all-null.
-fn proposed_branch_ids(batch: &RecordBatch) -> Result<Vec<String>> {
-    let mut branch_ids = BTreeSet::new();
-    for row_index in 0..batch.num_rows() {
-        if let Some(branch_id) = optional_string_value(batch, row_index, "lixcol_branch_id")? {
-            branch_ids.insert(branch_id);
-        }
-    }
-    Ok(branch_ids.into_iter().collect())
-}
-
-fn required_proposed_branch_ids(batch: &RecordBatch, table_name: &str) -> Result<Vec<String>> {
-    let mut branch_ids = BTreeSet::new();
-    for row_index in 0..batch.num_rows() {
-        let branch_id = optional_string_value(batch, row_index, "lixcol_branch_id")?.ok_or_else(
-            || {
-                DataFusionError::Execution(format!(
-                    "INSERT ON CONFLICT (path, lixcol_branch_id) on {table_name} requires non-null lixcol_branch_id"
-                ))
-            },
-        )?;
-        branch_ids.insert(branch_id);
-    }
-    Ok(branch_ids.into_iter().collect())
-}
-
-/// Distinct `lixcol_branch_id` values carried by an augmented conflict batch.
-fn augmented_branch_ids(batch: &RecordBatch) -> Result<Vec<String>> {
-    proposed_branch_ids(batch)
 }
 
 fn validate_required_paths(batch: &RecordBatch, table_name: &str) -> Result<()> {
@@ -2283,10 +2120,8 @@ impl InsertSink for LixFileInsertSink {
 }
 
 fn lix_file_surface_name(branch_binding: &BranchBinding) -> &'static str {
-    match branch_binding {
-        BranchBinding::Active { .. } => "lix_file",
-        BranchBinding::Explicit => "lix_file_by_branch",
-    }
+    let _ = branch_binding;
+    "lix_file"
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -4357,13 +4192,10 @@ fn file_row_context_from_batch(
     row_index: usize,
     branch_binding: Option<&str>,
 ) -> Result<FilesystemRowContext> {
-    let explicit_branch_id = optional_string_value(batch, row_index, "lixcol_branch_id")?;
     let scope = resolve_write_branch_scope(
         defaultable_bool_insert_value(batch, row_index, "lixcol_global", "INSERT into lix_file")?,
-        explicit_branch_id,
         branch_binding,
-        "INSERT into lix_file_by_branch",
-        "lix_file",
+        "INSERT into lix_file",
     )?;
 
     Ok(FilesystemRowContext {
@@ -4388,18 +4220,7 @@ fn file_row_context_from_update(
     branch_binding: Option<&str>,
 ) -> Result<FilesystemRowContext> {
     let explicit_global = optional_bool_value(batch, row_index, "lixcol_global")?;
-    let explicit_branch_id = if explicit_global == Some(true) {
-        Some(GLOBAL_BRANCH_ID.to_string())
-    } else {
-        optional_string_value(batch, row_index, "lixcol_branch_id")?
-    };
-    let scope = resolve_write_branch_scope(
-        explicit_global,
-        explicit_branch_id,
-        branch_binding,
-        "UPDATE into lix_file_by_branch",
-        "lix_file",
-    )?;
+    let scope = resolve_write_branch_scope(explicit_global, branch_binding, "UPDATE lix_file")?;
 
     Ok(FilesystemRowContext {
         branch_id: scope.branch_id,
@@ -4803,12 +4624,6 @@ fn lix_file_record_batch_from_path_selection(
                     .map(|entry| entry.metadata())
                     .collect::<Vec<_>>(),
             )),
-            "lixcol_branch_id" => Arc::new(StringArray::from(
-                entries
-                    .iter()
-                    .map(|entry| Some(entry.key.branch_id()))
-                    .collect::<Vec<_>>(),
-            )),
             other => {
                 return Err(LixError::new(
                     "LIX_ERROR_UNKNOWN",
@@ -4842,7 +4657,6 @@ struct LixFileRecordBatchRow {
     commit_id: Option<String>,
     untracked: bool,
     metadata: Option<String>,
-    branch_id: String,
 }
 
 #[derive(Default)]
@@ -4862,7 +4676,6 @@ struct LixFileRecordBatchColumns {
     commit_ids: Vec<Option<String>>,
     untracked_values: Vec<Option<bool>>,
     metadata_values: Vec<Option<String>>,
-    branch_ids: Vec<Option<String>>,
 }
 
 impl LixFileRecordBatchColumns {
@@ -4883,7 +4696,6 @@ impl LixFileRecordBatchColumns {
         self.commit_ids.push(row.commit_id);
         self.untracked_values.push(Some(row.untracked));
         self.metadata_values.push(row.metadata);
-        self.branch_ids.push(Some(row.branch_id));
     }
 
     fn into_record_batch(self, schema: &SchemaRef) -> Result<RecordBatch, LixError> {
@@ -4904,7 +4716,6 @@ impl LixFileRecordBatchColumns {
             commit_ids,
             untracked_values,
             metadata_values,
-            branch_ids,
         } = self;
         let ids: ArrayRef = Arc::new(StringArray::from(ids));
         let paths: ArrayRef = Arc::new(StringArray::from(paths));
@@ -4926,7 +4737,6 @@ impl LixFileRecordBatchColumns {
         let commit_ids: ArrayRef = Arc::new(StringArray::from(commit_ids));
         let untracked_values: ArrayRef = Arc::new(BooleanArray::from(untracked_values));
         let metadata_values: ArrayRef = Arc::new(StringArray::from(metadata_values));
-        let branch_ids: ArrayRef = Arc::new(StringArray::from(branch_ids));
 
         let mut columns = Vec::<ArrayRef>::with_capacity(schema.fields().len());
         for field in schema.fields() {
@@ -4946,7 +4756,6 @@ impl LixFileRecordBatchColumns {
                 "lixcol_commit_id" => Arc::clone(&commit_ids),
                 "lixcol_untracked" => Arc::clone(&untracked_values),
                 "lixcol_metadata" => Arc::clone(&metadata_values),
-                "lixcol_branch_id" => Arc::clone(&branch_ids),
                 other => {
                     return Err(LixError::new(
                         "LIX_ERROR_UNKNOWN",
@@ -5061,7 +4870,6 @@ async fn lix_file_record_batch_from_prepared(
             commit_id: live.commit_id().map(|id| id.to_string()),
             untracked: live.untracked(),
             metadata: live.metadata().map(|value| serialize_row_metadata(value)),
-            branch_id: live.branch_id().to_owned(),
         });
     }
 
@@ -6982,16 +6790,6 @@ pub(super) fn lix_file_schema() -> SchemaRef {
     ]))
 }
 
-pub(super) fn lix_file_by_branch_schema() -> SchemaRef {
-    let mut fields = lix_file_schema()
-        .fields()
-        .iter()
-        .map(|field| field.as_ref().clone())
-        .collect::<Vec<_>>();
-    fields.push(Field::new("lixcol_branch_id", DataType::Utf8, false));
-    Arc::new(Schema::new(fields))
-}
-
 fn lix_error_to_datafusion_error(error: LixError) -> DataFusionError {
     crate::sql2::error::lix_error_to_datafusion_error(error)
 }
@@ -7777,111 +7575,6 @@ mod tests {
         assert_eq!(batch.num_columns(), 0);
         assert_eq!(batch.num_rows(), 2);
         assert_eq!(path_index_requests.load(Ordering::SeqCst), 2);
-        assert_eq!(hot_state_scans.load(Ordering::SeqCst), 0);
-    }
-
-    #[tokio::test]
-    async fn by_branch_descriptor_scan_keeps_scope_columns_and_residual_filtering() {
-        let hot_state_scans = Arc::new(AtomicUsize::new(0));
-        let path_index_requests = Arc::new(AtomicUsize::new(0));
-        let mut target = live_file_row(
-            "01920000-0000-7000-8000-000000000522",
-            "01920000-0000-7000-8000-0000000000b1",
-            r#"{"id":"01920000-0000-7000-8000-000000000522","directory_id":null,"name":"readme.md"}"#,
-        );
-        target.untracked = true;
-        let index = Arc::new(
-            path_index_from_rows(vec![
-                live_file_row(
-                    "01920000-0000-7000-8000-000000000482",
-                    "01920000-0000-7000-8000-0000000000a1",
-                    r#"{"id":"01920000-0000-7000-8000-000000000482","directory_id":null,"name":"readme.md"}"#,
-                ),
-                target,
-            ])
-            .expect("filesystem path index should build"),
-        );
-        let spec = LixFileSpec::by_branch(
-            Arc::new(RejectingHotStateReader {
-                scan_count: Arc::clone(&hot_state_scans),
-            }),
-            Arc::new(StaticFilesystemPathIndexReader {
-                index,
-                request_count: Arc::clone(&path_index_requests),
-            }),
-            Arc::new(TestBranchRefReader),
-            Arc::new(StaticBlobReader::from_blobs(Vec::new())),
-            PluginRuntimeHost::new(Arc::new(UnsupportedWasmRuntime)),
-            test_functions(),
-        );
-        let projection = [
-            "id",
-            "lixcol_file_id",
-            "lixcol_global",
-            "lixcol_untracked",
-            "lixcol_created_at",
-            "lixcol_updated_at",
-            "lixcol_branch_id",
-        ]
-        .into_iter()
-        .map(|column_name| {
-            spec.schema()
-                .index_of(column_name)
-                .expect("by-branch descriptor column should exist")
-        })
-        .collect::<Vec<_>>();
-        let filters = vec![eq_filter(
-            "lixcol_branch_id",
-            "01920000-0000-7000-8000-0000000000b1",
-        )];
-
-        let planned = spec
-            .plan_scan(Some(&projection), &filters, Some(1), &ExecutionProps::new())
-            .await
-            .expect("by-branch descriptor scan should plan");
-        let batch = planned
-            .source
-            .load_single_batch()
-            .await
-            .expect("by-branch descriptor scan should load");
-
-        assert_eq!(batch.num_rows(), 1);
-        let string_value = |column_name: &str| {
-            batch
-                .column(batch.schema().index_of(column_name).unwrap())
-                .as_any()
-                .downcast_ref::<StringArray>()
-                .expect("descriptor column should be string data")
-                .value(0)
-        };
-        let boolean_value = |column_name: &str| {
-            batch
-                .column(batch.schema().index_of(column_name).unwrap())
-                .as_any()
-                .downcast_ref::<BooleanArray>()
-                .expect("descriptor column should be boolean data")
-                .value(0)
-        };
-        assert_eq!(string_value("id"), "01920000-0000-7000-8000-000000000522");
-        assert_eq!(
-            string_value("lixcol_file_id"),
-            "01920000-0000-7000-8000-000000000522"
-        );
-        assert!(!boolean_value("lixcol_global"));
-        assert!(boolean_value("lixcol_untracked"));
-        assert_eq!(
-            string_value("lixcol_created_at"),
-            "2026-04-23T00:00:00.000Z"
-        );
-        assert_eq!(
-            string_value("lixcol_updated_at"),
-            "2026-04-23T01:00:00.000Z"
-        );
-        assert_eq!(
-            string_value("lixcol_branch_id"),
-            "01920000-0000-7000-8000-0000000000b1"
-        );
-        assert_eq!(path_index_requests.load(Ordering::SeqCst), 1);
         assert_eq!(hot_state_scans.load(Ordering::SeqCst), 0);
     }
 
@@ -9335,27 +9028,21 @@ mod tests {
         Arc::new(StringArray::from(values)) as ArrayRef
     }
 
-    fn file_insert_batch(include_branch: bool, global: bool) -> RecordBatch {
-        let mut fields = vec![
+    fn file_insert_batch(global: bool) -> RecordBatch {
+        let fields = vec![
             Field::new("id", DataType::Utf8, false),
             Field::new("directory_id", DataType::Utf8, true),
             Field::new("name", DataType::Utf8, false),
             Field::new("lixcol_global", DataType::Boolean, false),
             Field::new("lixcol_metadata", DataType::Utf8, true),
         ];
-        let mut columns = vec![
+        let columns = vec![
             string_column(vec![Some("01920000-0000-7000-8000-0000000000d2")]),
             string_column(vec![Some("01920000-0000-7000-8000-0000000000d3")]),
             string_column(vec![Some("readme.md")]),
             Arc::new(BooleanArray::from(vec![global])) as ArrayRef,
             string_column(vec![Some("{\"source\":\"file\"}")]),
         ];
-        if include_branch {
-            fields.push(Field::new("lixcol_branch_id", DataType::Utf8, false));
-            columns.push(string_column(vec![Some(
-                "01920000-0000-7000-8000-0000000000b1",
-            )]));
-        }
         RecordBatch::try_new(Arc::new(Schema::new(fields)), columns).expect("file insert batch")
     }
 
@@ -9366,14 +9053,12 @@ mod tests {
                 Field::new("directory_id", DataType::Utf8, true),
                 Field::new("name", DataType::Utf8, false),
                 Field::new("content", DataType::Binary, true),
-                Field::new("lixcol_branch_id", DataType::Utf8, false),
             ])),
             vec![
                 string_column(vec![Some("01920000-0000-7000-8000-0000000000d2")]),
                 string_column(vec![Some("01920000-0000-7000-8000-0000000000d3")]),
                 string_column(vec![Some("readme.md")]),
                 Arc::new(BinaryArray::from_vec(vec![b"hello"])) as ArrayRef,
-                string_column(vec![Some("01920000-0000-7000-8000-0000000000b1")]),
             ],
         )
         .expect("file data batch")
@@ -9393,13 +9078,11 @@ mod tests {
                 Field::new("id", DataType::Utf8, false),
                 Field::new("path", DataType::Utf8, false),
                 Field::new("content", DataType::Binary, true),
-                Field::new("lixcol_branch_id", DataType::Utf8, false),
             ])),
             vec![
                 string_column(vec![Some("01920000-0000-7000-8000-0000000000d2")]),
                 string_column(vec![Some(path)]),
                 Arc::new(BinaryArray::from_vec(vec![data.as_slice()])) as ArrayRef,
-                string_column(vec![Some("01920000-0000-7000-8000-0000000000b1")]),
             ],
         )
         .expect("file path data batch")
@@ -9419,13 +9102,11 @@ mod tests {
                 Field::new("id", DataType::Utf8, false),
                 Field::new("path", DataType::Utf8, false),
                 Field::new("content", DataType::Binary, true),
-                Field::new("lixcol_branch_id", DataType::Utf8, false),
             ])),
             vec![
                 string_column(vec![Some("01920000-0000-7000-8000-0000000000d2")]),
                 string_column(vec![Some(path)]),
                 Arc::new(BinaryArray::from_vec(vec![data])) as ArrayRef,
-                string_column(vec![Some("01920000-0000-7000-8000-0000000000b1")]),
             ],
         )
         .expect("file path update batch")
@@ -9437,13 +9118,11 @@ mod tests {
                 Field::new("id", DataType::Utf8, false),
                 Field::new("path", DataType::Utf8, false),
                 Field::new("content", DataType::Binary, true),
-                Field::new("lixcol_branch_id", DataType::Utf8, false),
             ])),
             vec![
                 string_column(vec![Some("01920000-0000-7000-8000-0000000000d2")]),
                 string_column(vec![Some(path)]),
                 Arc::new(BinaryArray::from_vec(vec![b"hello"])) as ArrayRef,
-                string_column(vec![Some("01920000-0000-7000-8000-0000000000b1")]),
             ],
         )
         .expect("file data update batch")
@@ -9457,7 +9136,6 @@ mod tests {
                 Field::new("directory_id", DataType::Utf8, true),
                 Field::new("name", DataType::Utf8, false),
                 Field::new("content", DataType::Binary, true),
-                Field::new("lixcol_branch_id", DataType::Utf8, false),
             ])),
             vec![
                 string_column(vec![Some("01920000-0000-7000-8000-0000000000d2")]),
@@ -9465,7 +9143,6 @@ mod tests {
                 string_column(vec![Some("01920000-0000-7000-8000-0000000000d3")]),
                 string_column(vec![Some("readme.md")]),
                 Arc::new(BinaryArray::from_vec(vec![b"hello"])) as ArrayRef,
-                string_column(vec![Some("01920000-0000-7000-8000-0000000000b1")]),
             ],
         )
         .expect("file descriptor data update batch")
@@ -9480,7 +9157,6 @@ mod tests {
                 Field::new("name", DataType::Utf8, false),
                 Field::new("content", DataType::Binary, true),
                 Field::new("lixcol_metadata", DataType::Utf8, true),
-                Field::new("lixcol_branch_id", DataType::Utf8, false),
             ])),
             vec![
                 string_column(vec![Some("01920000-0000-7000-8000-0000000000d2")]),
@@ -9489,7 +9165,6 @@ mod tests {
                 string_column(vec![Some("readme.md")]),
                 Arc::new(BinaryArray::from_vec(vec![b"updated"])) as ArrayRef,
                 string_column(vec![Some(r#"{"source":"upload"}"#)]),
-                string_column(vec![Some("01920000-0000-7000-8000-0000000000b1")]),
             ],
         )
         .expect("file metadata data update batch")
@@ -9500,12 +9175,10 @@ mod tests {
             Arc::new(Schema::new(vec![
                 Field::new("id", DataType::Utf8, false),
                 Field::new("content", DataType::Binary, true),
-                Field::new("lixcol_branch_id", DataType::Utf8, false),
             ])),
             vec![
                 string_column(vec![Some("01920000-0000-7000-8000-0000000000d2")]),
                 Arc::new(BinaryArray::from_vec(vec![b""])) as ArrayRef,
-                string_column(vec![Some("01920000-0000-7000-8000-0000000000b1")]),
             ],
         )
         .expect("empty file data update batch")
@@ -9526,11 +9199,6 @@ mod tests {
             fields.push(Field::new("path", DataType::Utf8, false));
             columns.push(string_column(vec![Some(path)]));
         }
-        fields.push(Field::new("lixcol_branch_id", DataType::Utf8, false));
-        columns.push(string_column(vec![Some(
-            "01920000-0000-7000-8000-0000000000b1",
-        )]));
-
         RecordBatch::try_new(Arc::new(Schema::new(fields)), columns).expect("file delete batch")
     }
 
@@ -10445,9 +10113,11 @@ mod tests {
 
     #[test]
     fn decodes_file_insert_into_transaction_write_row() {
-        let batch = file_insert_batch(true, false);
+        let batch = file_insert_batch(false);
 
-        let rows = lix_file_write_rows_from_batch(&batch, None).expect("decode file insert");
+        let rows =
+            lix_file_write_rows_from_batch(&batch, Some("01920000-0000-7000-8000-0000000000b1"))
+                .expect("decode file insert");
 
         assert_eq!(rows.len(), 1);
         assert_eq!(
@@ -10473,7 +10143,7 @@ mod tests {
 
     #[test]
     fn active_file_insert_defaults_branch_id() {
-        let batch = file_insert_batch(false, false);
+        let batch = file_insert_batch(false);
 
         let rows =
             lix_file_write_rows_from_batch(&batch, Some("01920000-0000-7000-8000-0000000000a1"))
@@ -10482,33 +10152,6 @@ mod tests {
         assert_eq!(rows.len(), 1);
         assert_eq!(rows[0].branch_id, "01920000-0000-7000-8000-0000000000a1");
     }
-
-    #[test]
-    fn by_branch_file_insert_requires_branch_id_for_non_global_rows() {
-        let batch = file_insert_batch(false, false);
-
-        let error =
-            lix_file_write_rows_from_batch(&batch, None).expect_err("branch id is required");
-
-        assert!(
-            error.to_string().contains("requires lixcol_branch_id"),
-            "unexpected error: {error}"
-        );
-    }
-
-    #[test]
-    fn file_insert_rejects_global_with_non_global_branch_id() {
-        let error = lix_file_write_rows_from_batch(&file_insert_batch(true, true), None)
-            .expect_err("global file write should reject conflicting branch id");
-
-        assert!(
-            error
-                .to_string()
-                .contains("cannot set lixcol_global=true with non-global lixcol_branch_id"),
-            "unexpected error: {error}"
-        );
-    }
-
     #[test]
     fn file_update_accepts_path_assignment() {
         super::validate_lix_file_update_assignments(
@@ -10527,7 +10170,7 @@ mod tests {
                 "/.lix/plugins/nested/plugin_sentinel.lixplugin",
                 plugin_archive("*.sentinel", "plugin_note"),
             ),
-            None,
+            Some("01920000-0000-7000-8000-0000000000b1"),
             "lix_file",
             &mut resolvers,
             &mut test_id_generator(&["should-not-be-used"]),
@@ -10547,7 +10190,7 @@ mod tests {
 
         let error = lix_file_update_stage_from_batch_for_test(
             &path_update_batch_with_path("/.lix/plugins/nested/plugin_sentinel.lixplugin"),
-            None,
+            Some("01920000-0000-7000-8000-0000000000b1"),
             super::LixFileUpdateColumns {
                 data: false,
                 descriptor: super::LixFileDescriptorUpdate::Path,
@@ -10570,7 +10213,7 @@ mod tests {
 
         let error = lix_file_update_stage_from_batch_for_test(
             &path_update_batch_with_path("/.lix/plugins/plugin_sentinel.lixplugin"),
-            None,
+            Some("01920000-0000-7000-8000-0000000000b1"),
             super::LixFileUpdateColumns {
                 data: false,
                 descriptor: super::LixFileDescriptorUpdate::Path,
@@ -10590,7 +10233,7 @@ mod tests {
     fn file_content_update_rejects_invalid_existing_plugin_storage_path() {
         let error = lix_file_update_stage_from_batch_for_test(
             &data_update_batch_with_path("/.lix/plugins/nested/plugin_sentinel.lixplugin"),
-            None,
+            Some("01920000-0000-7000-8000-0000000000b1"),
             super::LixFileUpdateColumns {
                 data: true,
                 descriptor: super::LixFileDescriptorUpdate::None,
@@ -10614,7 +10257,7 @@ mod tests {
                 "lix_plugin_archive::plugin_sentinel",
                 Some("/.lix/plugins/plugin_sentinel.lixplugin"),
             ),
-            None,
+            Some("01920000-0000-7000-8000-0000000000b1"),
             &BTreeSet::new(),
             None,
         )
@@ -10635,7 +10278,7 @@ mod tests {
                 &plugin_storage_archive_file_id("plugin_sentinel"),
                 Some("/.lix/plugins/plugin_sentinel.lixplugin"),
             ),
-            None,
+            Some("01920000-0000-7000-8000-0000000000b1"),
             &BTreeSet::new(),
             Some("plugin_sentinel"),
         )
@@ -10663,7 +10306,7 @@ mod tests {
         ] {
             let error = lix_file_delete_stage_from_batch(
                 &file_delete_batch_with_id_and_path(file_id, Some(path)),
-                None,
+                Some("01920000-0000-7000-8000-0000000000b1"),
                 &BTreeSet::new(),
                 Some("plugin_sentinel"),
             )
@@ -10697,7 +10340,7 @@ mod tests {
 
         let staged = lix_file_update_stage_from_batch_for_test(
             &path_update_batch(),
-            None,
+            Some("01920000-0000-7000-8000-0000000000b1"),
             super::LixFileUpdateColumns {
                 data: false,
                 descriptor: super::LixFileDescriptorUpdate::Path,
@@ -10743,7 +10386,7 @@ mod tests {
 
         let staged = lix_file_update_stage_from_batch_for_test(
             &path_update_batch(),
-            None,
+            Some("01920000-0000-7000-8000-0000000000b1"),
             super::LixFileUpdateColumns {
                 data: false,
                 descriptor: super::LixFileDescriptorUpdate::Path,
@@ -10783,7 +10426,7 @@ mod tests {
 
         let staged = lix_file_update_stage_from_batch_for_test(
             &path_update_batch(),
-            None,
+            Some("01920000-0000-7000-8000-0000000000b1"),
             super::LixFileUpdateColumns {
                 data: false,
                 descriptor: super::LixFileDescriptorUpdate::Path,
@@ -10821,7 +10464,7 @@ mod tests {
 
         let staged = lix_file_update_stage_from_batch_for_test(
             &path_update_batch(),
-            None,
+            Some("01920000-0000-7000-8000-0000000000b1"),
             super::LixFileUpdateColumns {
                 data: false,
                 descriptor: super::LixFileDescriptorUpdate::Path,
@@ -10883,7 +10526,7 @@ mod tests {
 
         let staged = lix_file_update_stage_from_batch_for_test(
             &path_update_batch(),
-            None,
+            Some("01920000-0000-7000-8000-0000000000b1"),
             super::LixFileUpdateColumns {
                 data: true,
                 descriptor: super::LixFileDescriptorUpdate::Path,
@@ -10933,7 +10576,7 @@ mod tests {
 
         let staged = lix_file_update_stage_from_batch_for_test(
             &descriptor_data_update_batch(),
-            None,
+            Some("01920000-0000-7000-8000-0000000000b1"),
             super::LixFileUpdateColumns {
                 data: true,
                 descriptor: super::LixFileDescriptorUpdate::Topology,
@@ -11009,7 +10652,7 @@ mod tests {
         let staged = super::lix_file_update_stage_from_batch(
             &batch,
             &assignment_values,
-            None,
+            Some("01920000-0000-7000-8000-0000000000b1"),
             update_columns,
             &BTreeSet::from([blob_ref_key(
                 "01920000-0000-7000-8000-0000000000b1",
@@ -11044,7 +10687,7 @@ mod tests {
     fn file_content_update_without_path_ignores_materialized_path_column() {
         let staged = lix_file_update_stage_from_batch_for_test(
             &path_update_batch(),
-            None,
+            Some("01920000-0000-7000-8000-0000000000b1"),
             super::LixFileUpdateColumns {
                 data: true,
                 descriptor: super::LixFileDescriptorUpdate::None,
@@ -11068,7 +10711,7 @@ mod tests {
     fn file_content_update_to_empty_ignores_blob_ref_in_other_scope() {
         let staged = lix_file_update_stage_from_batch_with_blob_keys_for_test(
             &empty_data_update_batch(),
-            None,
+            Some("01920000-0000-7000-8000-0000000000b1"),
             super::LixFileUpdateColumns {
                 data: true,
                 descriptor: super::LixFileDescriptorUpdate::None,
@@ -11095,7 +10738,9 @@ mod tests {
     fn file_insert_stages_non_null_data() {
         let batch = data_insert_batch();
 
-        let staged = lix_file_insert_stage_from_batch(&batch, None).expect("decode file content");
+        let staged =
+            lix_file_insert_stage_from_batch(&batch, Some("01920000-0000-7000-8000-0000000000b1"))
+                .expect("decode file content");
 
         assert_eq!(staged.count, 1);
         assert_eq!(staged.state_rows.len(), 2);
@@ -11148,7 +10793,7 @@ mod tests {
         let batch = file_delete_batch();
         let staged = lix_file_delete_stage_from_batch(
             &batch,
-            None,
+            Some("01920000-0000-7000-8000-0000000000b1"),
             &BTreeSet::from([blob_ref_key(
                 "01920000-0000-7000-8000-0000000000b1",
                 false,
@@ -11195,8 +10840,13 @@ mod tests {
     #[test]
     fn file_delete_without_blob_ref_stages_only_descriptor_tombstone() {
         let batch = file_delete_batch();
-        let staged = lix_file_delete_stage_from_batch(&batch, None, &BTreeSet::new(), None)
-            .expect("decode file delete");
+        let staged = lix_file_delete_stage_from_batch(
+            &batch,
+            Some("01920000-0000-7000-8000-0000000000b1"),
+            &BTreeSet::new(),
+            None,
+        )
+        .expect("decode file delete");
 
         assert_eq!(staged.count, 1);
         assert_eq!(staged.state_rows.len(), 1);
@@ -11214,7 +10864,7 @@ mod tests {
         let batch = file_delete_batch();
         let staged = lix_file_delete_stage_from_batch(
             &batch,
-            None,
+            Some("01920000-0000-7000-8000-0000000000b1"),
             &BTreeSet::from([blob_ref_key(
                 "01920000-0000-7000-8000-0000000000a1",
                 false,
@@ -11255,7 +10905,7 @@ mod tests {
 
         let staged = lix_file_insert_stage_from_batch_with_path_resolvers(
             &path_data_insert_batch(),
-            None,
+            Some("01920000-0000-7000-8000-0000000000b1"),
             "lix_file",
             &mut resolvers,
             &mut test_id_generator(&["should-not-be-used"]),
@@ -11290,7 +10940,7 @@ mod tests {
 
         let staged = lix_file_insert_stage_from_batch_with_path_resolvers(
             &path_data_insert_batch(),
-            None,
+            Some("01920000-0000-7000-8000-0000000000b1"),
             "lix_file",
             &mut resolvers,
             &mut test_id_generator(&[
@@ -11321,13 +10971,13 @@ mod tests {
 
     #[tokio::test]
     async fn file_insert_sink_stages_decoded_transaction_rows() {
-        let batch = file_insert_batch(true, false);
+        let batch = file_insert_batch(false);
         let mut write_context = CapturingWriteContext::default();
         let write_ctx = SqlWriteContext::new(&mut write_context);
         let sink = LixFileInsertSink::new(
             write_ctx,
             test_functions(),
-            BranchBinding::explicit(),
+            BranchBinding::active("01920000-0000-7000-8000-0000000000b1"),
             false,
         );
 
@@ -11618,7 +11268,7 @@ mod tests {
         let candidates = spec
             .scan_conflict_candidates(
                 &write_ctx,
-                &file_insert_batch(false, false),
+                &file_insert_batch(false),
                 &UpsertConflictTarget::id(super::LIX_FILE_IDENTITY),
             )
             .await
@@ -12280,8 +11930,12 @@ mod tests {
             ..CapturingWriteContext::default()
         };
         let write_ctx = SqlWriteContext::new(&mut write_context);
-        let sink =
-            LixFileInsertSink::new(write_ctx, test_functions(), BranchBinding::explicit(), true);
+        let sink = LixFileInsertSink::new(
+            write_ctx,
+            test_functions(),
+            BranchBinding::active("01920000-0000-7000-8000-0000000000b1"),
+            true,
+        );
 
         let count = sink
             .write_batches(vec![batch], &Arc::new(TaskContext::default()))
@@ -12342,8 +11996,12 @@ mod tests {
             ..CapturingWriteContext::default()
         };
         let write_ctx = SqlWriteContext::new(&mut write_context);
-        let sink =
-            LixFileInsertSink::new(write_ctx, test_functions(), BranchBinding::explicit(), true);
+        let sink = LixFileInsertSink::new(
+            write_ctx,
+            test_functions(),
+            BranchBinding::active("01920000-0000-7000-8000-0000000000b1"),
+            true,
+        );
 
         let count = sink
             .write_batches(vec![batch], &Arc::new(TaskContext::default()))

--- a/packages/lix/src/sql2/providers/filesystem_working_diff.rs
+++ b/packages/lix/src/sql2/providers/filesystem_working_diff.rs
@@ -35,7 +35,7 @@ const DIRECTORY_DESCRIPTOR_SCHEMA_KEY: &str = "lix_directory_descriptor";
 pub(super) async fn register_filesystem_working_diff_provider<S>(
     session: &datafusion::prelude::SessionContext,
     surface_name: &str,
-    active_branch_id: Option<String>,
+    active_branch_id: String,
     branch_ref: Arc<dyn BranchRefReader>,
     commit_graph: Box<dyn CommitGraphReader>,
     query_source: SqlChangelogQuerySource<S>,
@@ -48,7 +48,6 @@ where
         session,
         surface_name,
         Arc::new(FilesystemWorkingDiffSpec {
-            by_branch: active_branch_id.is_none(),
             active_branch_id,
             branch_ref,
             commit_graph: Arc::new(Mutex::new(commit_graph)),
@@ -66,8 +65,7 @@ pub(super) enum FilesystemWorkingDiffKind {
 }
 
 struct FilesystemWorkingDiffSpec<S> {
-    by_branch: bool,
-    active_branch_id: Option<String>,
+    active_branch_id: String,
     branch_ref: Arc<dyn BranchRefReader>,
     commit_graph: Arc<Mutex<Box<dyn CommitGraphReader>>>,
     store: S,
@@ -80,16 +78,14 @@ where
     S: StorageAdapterRead + Clone + Send + Sync + 'static,
 {
     fn table_name(&self) -> &str {
-        match (self.kind, self.by_branch) {
-            (FilesystemWorkingDiffKind::File, false) => "lix_file_working_diff",
-            (FilesystemWorkingDiffKind::File, true) => "lix_file_working_diff_by_branch",
-            (FilesystemWorkingDiffKind::Directory, false) => "lix_directory_working_diff",
-            (FilesystemWorkingDiffKind::Directory, true) => "lix_directory_working_diff_by_branch",
+        match self.kind {
+            FilesystemWorkingDiffKind::File => "lix_file_working_diff",
+            FilesystemWorkingDiffKind::Directory => "lix_directory_working_diff",
         }
     }
 
     fn schema(&self) -> SchemaRef {
-        filesystem_working_diff_schema(self.by_branch)
+        filesystem_working_diff_schema()
     }
 
     fn table_type(&self) -> TableType {
@@ -100,7 +96,7 @@ where
         if filter
             .column_refs()
             .iter()
-            .any(|column| matches!(column.name.as_str(), "id" | "lixcol_branch_id"))
+            .any(|column| column.name == "id")
         {
             TableProviderFilterPushDown::Inexact
         } else {
@@ -139,8 +135,8 @@ where
                     }
                     let heads = selected_heads(
                         branch_ref.as_ref(),
-                        active_branch_id.as_deref(),
-                        &route.branch_ids,
+                        Some(active_branch_id.as_str()),
+                        &FileIdConstraint::All,
                     )
                     .await
                     .map_err(lix_error_to_datafusion_error)?;
@@ -158,7 +154,6 @@ where
                             &mut tracked,
                             &checkpoint_id.to_string(),
                             &head.commit_id.to_string(),
-                            &head.branch_id,
                             kind,
                         )
                         .await
@@ -183,7 +178,6 @@ where
 
 #[derive(Clone)]
 struct FilesystemWorkingDiffRoute {
-    branch_ids: FileIdConstraint,
     ids: FileIdConstraint,
     contradictory: bool,
 }
@@ -191,13 +185,9 @@ struct FilesystemWorkingDiffRoute {
 impl FilesystemWorkingDiffRoute {
     fn from_filters(filters: &[Expr]) -> Result<Self> {
         let conjuncts = filter_conjuncts(filters);
-        let branch_ids =
-            exact_string_column_constraint_from_filters(&conjuncts, "lixcol_branch_id")?;
         let ids = exact_string_column_constraint_from_filters(&conjuncts, "id")?;
-        let contradictory =
-            matches!(branch_ids, FileIdConstraint::None) || matches!(ids, FileIdConstraint::None);
+        let contradictory = matches!(ids, FileIdConstraint::None);
         Ok(Self {
-            branch_ids,
             ids,
             contradictory,
         })
@@ -228,7 +218,6 @@ async fn load_rows<S>(
     tracked: &mut TrackedStateStoreReader<S>,
     checkpoint_id: &str,
     head_id: &str,
-    branch_id: &str,
     kind: FilesystemWorkingDiffKind,
 ) -> Result<Vec<FilesystemWorkingDiffSqlRow>, LixError>
 where
@@ -310,7 +299,6 @@ where
             path,
             previous_path,
             change_kind,
-            branch_id: branch_id.to_string(),
         });
     }
     Ok(rows)
@@ -527,7 +515,6 @@ struct FilesystemWorkingDiffSqlRow {
     path: Option<String>,
     previous_path: Option<String>,
     change_kind: &'static str,
-    branch_id: String,
 }
 
 static FILESYSTEM_WORKING_DIFF_COLS: ColumnTable<FilesystemWorkingDiffSqlRow> = ColumnTable {
@@ -539,23 +526,16 @@ static FILESYSTEM_WORKING_DIFF_COLS: ColumnTable<FilesystemWorkingDiffSqlRow> = 
             Col::Utf8(|row| row.previous_path.as_deref()),
         ),
         ("change_kind", Col::Utf8(|row| Some(row.change_kind))),
-        (
-            "lixcol_branch_id",
-            Col::Utf8(|row| Some(row.branch_id.as_str())),
-        ),
     ],
 };
 
-pub(crate) fn filesystem_working_diff_schema(by_branch: bool) -> SchemaRef {
-    let mut fields = vec![
+pub(crate) fn filesystem_working_diff_schema() -> SchemaRef {
+    let fields = vec![
         Field::new("id", DataType::Utf8, false),
         Field::new("path", DataType::Utf8, true),
         Field::new("previous_path", DataType::Utf8, true),
         Field::new("change_kind", DataType::Utf8, false),
     ];
-    if by_branch {
-        fields.push(Field::new("lixcol_branch_id", DataType::Utf8, false));
-    }
     Arc::new(Schema::new(fields))
 }
 

--- a/packages/lix/src/sql2/providers/mod.rs
+++ b/packages/lix/src/sql2/providers/mod.rs
@@ -319,18 +319,7 @@ where
                 working_diff::register_working_diff_provider(
                     session,
                     &surface.name,
-                    Some(ctx.active_branch_id().to_string()),
-                    Arc::clone(&branch_ref),
-                    ctx.commit_graph(),
-                    ctx.changelog_query_source(),
-                )
-                .await?;
-            }
-            PublicSurfaceKind::WorkingDiffByBranch => {
-                working_diff::register_working_diff_provider(
-                    session,
-                    &surface.name,
-                    None,
+                    ctx.active_branch_id().to_string(),
                     Arc::clone(&branch_ref),
                     ctx.commit_graph(),
                     ctx.changelog_query_source(),
@@ -341,19 +330,7 @@ where
                 filesystem_working_diff::register_filesystem_working_diff_provider(
                     session,
                     &surface.name,
-                    Some(ctx.active_branch_id().to_string()),
-                    Arc::clone(&branch_ref),
-                    ctx.commit_graph(),
-                    ctx.changelog_query_source(),
-                    filesystem_working_diff::FilesystemWorkingDiffKind::File,
-                )
-                .await?;
-            }
-            PublicSurfaceKind::FileWorkingDiffByBranch => {
-                filesystem_working_diff::register_filesystem_working_diff_provider(
-                    session,
-                    &surface.name,
-                    None,
+                    ctx.active_branch_id().to_string(),
                     Arc::clone(&branch_ref),
                     ctx.commit_graph(),
                     ctx.changelog_query_source(),
@@ -365,19 +342,7 @@ where
                 filesystem_working_diff::register_filesystem_working_diff_provider(
                     session,
                     &surface.name,
-                    Some(ctx.active_branch_id().to_string()),
-                    Arc::clone(&branch_ref),
-                    ctx.commit_graph(),
-                    ctx.changelog_query_source(),
-                    filesystem_working_diff::FilesystemWorkingDiffKind::Directory,
-                )
-                .await?;
-            }
-            PublicSurfaceKind::DirectoryWorkingDiffByBranch => {
-                filesystem_working_diff::register_filesystem_working_diff_provider(
-                    session,
-                    &surface.name,
-                    None,
+                    ctx.active_branch_id().to_string(),
                     Arc::clone(&branch_ref),
                     ctx.commit_graph(),
                     ctx.changelog_query_source(),
@@ -398,20 +363,6 @@ where
                     session,
                     &surface.name,
                     ctx.active_branch_id(),
-                    ctx.hot_state(),
-                    ctx.filesystem_path_index(),
-                    Arc::clone(&branch_ref),
-                    ctx.blob_reader(),
-                    ctx.plugin_host(),
-                    ctx.functions(),
-                    ctx.session_file_views(),
-                )
-                .await?;
-            }
-            PublicSurfaceKind::FileByBranch => {
-                file::register_lix_file_by_branch_provider(
-                    session,
-                    &surface.name,
                     ctx.hot_state(),
                     ctx.filesystem_path_index(),
                     Arc::clone(&branch_ref),
@@ -445,17 +396,6 @@ where
                 )
                 .await?;
             }
-            PublicSurfaceKind::DirectoryByBranch => {
-                directory::register_lix_directory_by_branch_provider(
-                    session,
-                    &surface.name,
-                    ctx.hot_state(),
-                    ctx.filesystem_path_index(),
-                    Arc::clone(&branch_ref),
-                    ctx.functions(),
-                )
-                .await?;
-            }
             PublicSurfaceKind::DirectoryHistory => {
                 directory_history::register_lix_directory_history_surface(
                     session,
@@ -465,9 +405,7 @@ where
                 )
                 .await?;
             }
-            PublicSurfaceKind::SchemaBase { .. }
-            | PublicSurfaceKind::SchemaByBranch { .. }
-            | PublicSurfaceKind::SchemaHistory { .. }
+            PublicSurfaceKind::SchemaBase { .. } | PublicSurfaceKind::SchemaHistory { .. }
             | PublicSurfaceKind::Revert
             | PublicSurfaceKind::Apply
             | PublicSurfaceKind::CreateCheckpoint => {}
@@ -580,27 +518,8 @@ async fn register_write_from_catalog(
                 )
                 .await?;
             }
-            PublicSurfaceKind::FileByBranch => {
-                file::register_by_branch_write_provider(
-                    session,
-                    &surface.name,
-                    write_ctx.clone(),
-                    Arc::clone(&branch_ref),
-                    options.clone(),
-                )
-                .await?;
-            }
             PublicSurfaceKind::Directory => {
                 directory::register_active_write_provider(
-                    session,
-                    &surface.name,
-                    write_ctx.clone(),
-                    Arc::clone(&branch_ref),
-                )
-                .await?;
-            }
-            PublicSurfaceKind::DirectoryByBranch => {
-                directory::register_by_branch_write_provider(
                     session,
                     &surface.name,
                     write_ctx.clone(),
@@ -637,16 +556,11 @@ async fn register_write_from_catalog(
             }
             PublicSurfaceKind::Change
             | PublicSurfaceKind::WorkingDiff
-            | PublicSurfaceKind::WorkingDiffByBranch
             | PublicSurfaceKind::FileWorkingDiff
-            | PublicSurfaceKind::FileWorkingDiffByBranch
             | PublicSurfaceKind::DirectoryWorkingDiff
-            | PublicSurfaceKind::DirectoryWorkingDiffByBranch
             | PublicSurfaceKind::FileHistory
             | PublicSurfaceKind::DirectoryHistory => {}
-            PublicSurfaceKind::SchemaBase { .. }
-            | PublicSurfaceKind::SchemaByBranch { .. }
-            | PublicSurfaceKind::SchemaHistory { .. } => {}
+            PublicSurfaceKind::SchemaBase { .. } | PublicSurfaceKind::SchemaHistory { .. } => {}
         }
     }
     schema::register_row_write_providers(session, write_ctx, branch_ref, catalog, selection)
@@ -847,12 +761,9 @@ mod tests {
                 "lix_change",
                 "lix_directory_history",
                 "lix_directory_working_diff",
-                "lix_directory_working_diff_by_branch",
                 "lix_file_history",
                 "lix_file_working_diff",
-                "lix_file_working_diff_by_branch",
                 "lix_working_diff",
-                "lix_working_diff_by_branch",
                 "phase8_row_history",
             ]
         );
@@ -863,19 +774,16 @@ mod tests {
                 "lix_branch",
                 "lix_create_checkpoint",
                 "lix_directory",
-                "lix_directory_by_branch",
                 "lix_file",
-                "lix_file_by_branch",
                 "lix_revert",
                 "phase8_row",
-                "phase8_row_by_branch",
             ]
         );
         assert_eq!(read_only.len() + writable.len(), catalog.surfaces().count());
-        assert_eq!(all_read + writable.len(), 30, "previous construction count");
+        assert_eq!(all_read + writable.len(), 21, "previous construction count");
         assert_eq!(
             read_only.len() + writable.len(),
-            20,
+            14,
             "new construction count"
         );
     }
@@ -894,7 +802,7 @@ mod tests {
             .map(|surface| surface.name.as_str())
             .collect::<Vec<_>>();
 
-        assert_eq!(all_writable, 8, "previous standalone write count");
+        assert_eq!(all_writable, 6, "previous standalone write count");
         assert_eq!(selected_writable, vec!["lix_file"]);
     }
 
@@ -910,37 +818,17 @@ mod tests {
         assert_surface_schema_matches_provider_schema(
             &catalog,
             "lix_file_working_diff",
-            filesystem_working_diff::filesystem_working_diff_schema(false),
-        );
-        assert_surface_schema_matches_provider_schema(
-            &catalog,
-            "lix_file_working_diff_by_branch",
-            filesystem_working_diff::filesystem_working_diff_schema(true),
+            filesystem_working_diff::filesystem_working_diff_schema(),
         );
         assert_surface_schema_matches_provider_schema(
             &catalog,
             "lix_directory_working_diff",
-            filesystem_working_diff::filesystem_working_diff_schema(false),
-        );
-        assert_surface_schema_matches_provider_schema(
-            &catalog,
-            "lix_directory_working_diff_by_branch",
-            filesystem_working_diff::filesystem_working_diff_schema(true),
-        );
-        assert_surface_schema_matches_provider_schema(
-            &catalog,
-            "lix_file_by_branch",
-            file::lix_file_by_branch_schema(),
+            filesystem_working_diff::filesystem_working_diff_schema(),
         );
         assert_surface_schema_matches_provider_schema(
             &catalog,
             "lix_directory",
             directory::lix_directory_schema(),
-        );
-        assert_surface_schema_matches_provider_schema(
-            &catalog,
-            "lix_directory_by_branch",
-            directory::lix_directory_by_branch_schema(),
         );
         assert_surface_schema_matches_provider_schema(
             &catalog,
@@ -955,12 +843,7 @@ mod tests {
         assert_surface_schema_matches_provider_schema(
             &catalog,
             "lix_working_diff",
-            working_diff::working_diff_schema(false),
-        );
-        assert_surface_schema_matches_provider_schema(
-            &catalog,
-            "lix_working_diff_by_branch",
-            working_diff::working_diff_schema(true),
+            working_diff::working_diff_schema(),
         );
         assert_surface_schema_matches_provider_schema(
             &catalog,
@@ -978,7 +861,7 @@ mod tests {
     fn file_content_surfaces_use_large_binary() {
         let catalog = PublicCatalog::from_visible_schemas(&[]).expect("catalog should build");
 
-        for surface_name in ["lix_file", "lix_file_by_branch", "lix_file_history"] {
+        for surface_name in ["lix_file", "lix_file_history"] {
             let schema = catalog
                 .surface_schema(surface_name)
                 .unwrap_or_else(|| panic!("{surface_name} should be in catalog"));
@@ -1029,12 +912,6 @@ mod tests {
         .expect("row providers should register");
 
         assert_registered_table_schema_matches_catalog(&session, &catalog, "phase8_row").await;
-        assert_registered_table_schema_matches_catalog(
-            &session,
-            &catalog,
-            "phase8_row_by_branch",
-        )
-        .await;
         assert_registered_table_schema_matches_catalog(&session, &catalog, "phase8_row_history")
             .await;
     }

--- a/packages/lix/src/sql2/providers/schema.rs
+++ b/packages/lix/src/sql2/providers/schema.rs
@@ -25,7 +25,6 @@ use serde_json::Value as JsonValue;
 use crate::branch::BranchRefReader;
 use crate::commit_graph::CommitGraphReader;
 use crate::common::SharedStr;
-use crate::row_pk::RowPk;
 use crate::hot_state::MaterializedHotStateBatch;
 #[cfg(test)]
 use crate::hot_state::MaterializedHotStateRow;
@@ -33,16 +32,15 @@ use crate::hot_state::{
     HotStateExactBatchRequest, HotStateExactRowRequest, HotStateFilter, HotStateProjection,
     HotStateReader, HotStateRowFilter, HotStateScanRequest,
 };
+use crate::row_pk::RowPk;
 use crate::sql2::branch_scope::{BranchBinding, resolve_provider_branch_ids};
 use crate::sql2::catalog::{
-    SchemaColumnType, SchemaSurfaceShape, SchemaSurfaceSpec, PublicCatalog, PublicSurfaceKind,
+    PublicCatalog, PublicSurfaceKind, SchemaColumnType, SchemaSurfaceShape, SchemaSurfaceSpec,
     schema_surface_schema,
-};
-use crate::sql2::row_projection::{
-    RowProjectionDecoder, row_projection_error_to_datafusion_error,
 };
 use crate::sql2::error::lix_error_to_datafusion_error;
 use crate::sql2::read_only::reject_read_only_schema_surface;
+use crate::sql2::row_projection::{RowProjectionDecoder, row_projection_error_to_datafusion_error};
 use crate::sql2::value_contract::{json_bigint_value, json_double_value};
 use crate::sql2::write_normalization::{SqlCell, UpdateAssignmentValues, UpdateCell};
 use crate::{GLOBAL_BRANCH_ID, LixError, parse_row_metadata_value};
@@ -150,9 +148,10 @@ pub(crate) async fn execute_exact_schema_batch_read(
         let Some(row) = exact.row(slot) else {
             continue;
         };
-        rows.push(decoder.decode_public_values(
-            row.snapshot_content().map(|snapshot| snapshot.as_bytes()),
-        )?);
+        rows.push(
+            decoder
+                .decode_public_values(row.snapshot_content().map(|snapshot| snapshot.as_bytes()))?,
+        );
     }
     Ok(crate::SqlQueryResult {
         rows,
@@ -192,20 +191,6 @@ where
                         Arc::clone(&hot_state),
                         Arc::clone(&branch_ref),
                         active_branch_id.to_string(),
-                        row_snapshot_reader.clone(),
-                    )),
-                    WriteAccess::read_only(),
-                )?;
-            }
-            PublicSurfaceKind::SchemaByBranch { schema_key } if include_write_surfaces => {
-                let spec = catalog_schema_spec(catalog, schema_key)?;
-                register_spec_table(
-                    ctx,
-                    &surface.name,
-                    Arc::new(SchemaSpec::by_branch(
-                        spec,
-                        Arc::clone(&hot_state),
-                        Arc::clone(&branch_ref),
                         row_snapshot_reader.clone(),
                     )),
                     WriteAccess::read_only(),
@@ -267,19 +252,6 @@ pub(crate) async fn register_row_write_providers(
                     WriteAccess::write(write_ctx.clone()),
                 )?;
             }
-            PublicSurfaceKind::SchemaByBranch { schema_key } => {
-                let spec = catalog_schema_spec(catalog, schema_key)?;
-                register_spec_table(
-                    ctx,
-                    &surface.name,
-                    Arc::new(SchemaSpec::by_branch_with_write(
-                        spec,
-                        write_ctx.clone(),
-                        Arc::clone(&branch_ref),
-                    )),
-                    WriteAccess::write(write_ctx.clone()),
-                )?;
-            }
             _ => {}
         }
     }
@@ -305,7 +277,7 @@ fn catalog_schema_spec(
 
 /// One spec type covers every registered row schema: the runtime
 /// [`SchemaSurfaceSpec`] carries the per-schema column layout, and the
-/// surface name follows the catalog naming for the base/by-branch shapes.
+/// surface name follows the catalog naming for the active shape.
 #[derive(Clone)]
 struct SchemaSpec {
     surface_name: String,
@@ -346,32 +318,6 @@ impl SchemaSpec {
         Self::active(spec, hot_state, branch_ref, active_branch_id, None)
     }
 
-    fn by_branch(
-        spec: Arc<SchemaSurfaceSpec>,
-        hot_state: Arc<dyn HotStateReader>,
-        branch_ref: Arc<dyn BranchRefReader>,
-        row_snapshot_reader: Option<Arc<dyn RowSnapshotReader>>,
-    ) -> Self {
-        Self {
-            surface_name: format!("{}_by_branch", spec.schema_key),
-            schema: schema_surface_schema(&spec, SchemaSurfaceShape::ByBranch),
-            spec,
-            hot_state,
-            row_snapshot_reader,
-            branch_ref,
-            branch_binding: BranchBinding::explicit(),
-        }
-    }
-
-    fn by_branch_with_write(
-        spec: Arc<SchemaSurfaceSpec>,
-        write_ctx: SqlWriteContext,
-        branch_ref: Arc<dyn BranchRefReader>,
-    ) -> Self {
-        let hot_state = Arc::new(WriteContextHotStateReader::new(write_ctx));
-        Self::by_branch(spec, hot_state, branch_ref, None)
-    }
-
     /// Plan-time scan derivation shared by `plan_scan` and the unit tests:
     /// the projected output schema, the live-state scan request (with branch
     /// routing resolved), and the residual snapshot row filters.
@@ -399,16 +345,6 @@ impl SchemaSpec {
             if row_filters.is_empty() { limit } else { None },
             !row_filters.is_empty(),
         );
-        let exact_branch_ids = exact_branch_ids_from_filters(filters)?;
-        // Preserve an exact by-branch selector before resolving an explicit
-        // provider scope. Resolving first would enumerate every branch even
-        // when the DELETE has an exact `lixcol_branch_id = ...` predicate,
-        // and write contexts intentionally only expose point branch-head
-        // lookups. Active surfaces retain their existing post-resolution
-        // filtering behavior so a branch overlay is still constructed first.
-        if matches!(&self.branch_binding, BranchBinding::Explicit) {
-            apply_exact_branch_id_filter(&mut request, exact_branch_ids.clone());
-        }
         request.filter.branch_ids = resolve_provider_branch_ids(
             self.branch_ref.as_ref(),
             &self.branch_binding,
@@ -416,7 +352,6 @@ impl SchemaSpec {
         )
         .await
         .map_err(lix_error_to_datafusion_error)?;
-        apply_exact_branch_id_filter(&mut request, exact_branch_ids);
         apply_exact_row_pk_filters(&mut request, &self.spec, filters)?;
         apply_exact_file_id_filter(&mut request, exact_file_ids_from_filters(filters)?);
         if request.filter.row_pks.is_empty()
@@ -448,19 +383,8 @@ impl SchemaSpec {
                 "UPDATE schema surface RETURNING has invalid lixcol_row_pk: {error}"
             ))
         })?;
-        let branch_id = match self.branch_binding {
-            BranchBinding::Active { .. } => String::new(),
-            BranchBinding::Explicit => required_string_value(
-                batch,
-                row_index,
-                "lixcol_branch_id",
-                "UPDATE schema surface RETURNING",
-            )?,
-        };
-        Ok(RowReturningKey {
-            row_pk,
-            branch_id,
-        })
+        let branch_id = String::new();
+        Ok(RowReturningKey { row_pk, branch_id })
     }
 
     async fn returning_post_image(
@@ -484,14 +408,6 @@ impl SchemaSpec {
             .collect::<BTreeSet<_>>()
             .into_iter()
             .collect();
-        if matches!(self.branch_binding, BranchBinding::Explicit) {
-            request.filter.branch_ids = keys
-                .iter()
-                .map(|key| key.branch_id.clone())
-                .collect::<BTreeSet<_>>()
-                .into_iter()
-                .collect();
-        }
         let rows = WriteContextHotStateReader::new(write_ctx.clone())
             .scan_batch(&request)
             .await
@@ -703,10 +619,7 @@ impl TableSpec for SchemaSpec {
     fn filter_pushdown(&self, filter: &Expr) -> TableProviderFilterPushDown {
         let primary_key_analyzer = RowPrimaryKeyFilterAnalyzer::new(&self.spec);
         let row_filter_analyzer = RowFilterAnalyzer::new(&self.spec);
-        if ExactBranchIdFilterAnalyzer.supports(filter)
-            || ExactFileIdFilterAnalyzer.supports(filter)
-            || primary_key_analyzer.supports(filter)
-        {
+        if ExactFileIdFilterAnalyzer.supports(filter) || primary_key_analyzer.supports(filter) {
             TableProviderFilterPushDown::Exact
         } else if row_filter_analyzer.supports(filter) {
             // Retain a DataFusion residual even when the row-shaped fallback
@@ -788,8 +701,7 @@ impl TableSpec for SchemaSpec {
                 .plan_row_columnar_scan(columnar_request)
                 .await
                 .map_err(lix_error_to_datafusion_error)?
-            && let Some(projection) =
-                row_columnar_projection(&layout.manifest, &schema, &self.spec)
+            && let Some(projection) = row_columnar_projection(&layout.manifest, &schema, &self.spec)
         {
             let group_indices = row_columnar_group_indices(&layout.manifest, &row_filters);
             return Ok(PlannedScan {
@@ -1379,8 +1291,7 @@ fn row_columnar_coordinate_shadow_masks(
             // has no stale base member to suppress.
             continue;
         };
-        let owner =
-            crate::hot_state::row_group_set_id(coordinate.base_commit_id, &spec.schema_key);
+        let owner = crate::hot_state::row_group_set_id(coordinate.base_commit_id, &spec.schema_key);
         if owner != layout.id {
             return exec_err!(
                 "row overlay columnar coordinate belongs to a different immutable base"
@@ -1452,9 +1363,7 @@ fn row_columnar_overlay_batches(
             continue;
         }
         let snapshot = row.snapshot_content.as_deref().ok_or_else(|| {
-            DataFusionError::Execution(
-                "live row columnar overlay row has no snapshot".to_owned(),
-            )
+            DataFusionError::Execution("live row columnar overlay row has no snapshot".to_owned())
         })?;
         if !row_filters.is_empty() {
             let parsed = parse_snapshot_value(std::str::from_utf8(snapshot).map_err(|error| {
@@ -1599,31 +1508,13 @@ fn row_delete_stage_rows_from_batch(
             "DELETE FROM schema surface",
         )?
         .unwrap_or(false);
-        let source_branch_id = optional_string_value(
-            batch,
-            row_index,
-            "lixcol_branch_id",
-            "DELETE FROM schema surface",
-        )?;
-        if matches!(branch_binding, BranchBinding::Explicit)
-            && global
-            && source_branch_id.as_deref() != Some(GLOBAL_BRANCH_ID)
-        {
-            return Err(DataFusionError::Execution(
-                "DELETE through a row by-branch surface cannot mutate a projected global row"
-                    .to_string(),
-            ));
-        }
         let branch_id = if global {
             GLOBAL_BRANCH_ID.to_string()
         } else {
-            source_branch_id
-                .or_else(|| branch_binding.active_branch_id().map(ToOwned::to_owned))
-                .ok_or_else(|| {
-                    DataFusionError::Execution(
-                        "DELETE FROM row by-branch requires lixcol_branch_id".to_string(),
-                    )
-                })?
+            branch_binding
+                .active_branch_id()
+                .expect("active row surface has an active branch")
+                .to_owned()
         };
         let row_pk = RowPk::from_json_array_text(&required_string_value(
             batch,
@@ -1697,31 +1588,13 @@ fn row_update_stage_rows_from_batch(
         let global =
             optional_bool_value(batch, row_index, "lixcol_global", "UPDATE schema surface")?
                 .unwrap_or(false);
-        let source_branch_id = optional_string_value(
-            batch,
-            row_index,
-            "lixcol_branch_id",
-            "UPDATE schema surface",
-        )?;
-        if matches!(branch_binding, BranchBinding::Explicit)
-            && global
-            && source_branch_id.as_deref() != Some(GLOBAL_BRANCH_ID)
-        {
-            return Err(DataFusionError::Execution(
-                "UPDATE through a row by-branch surface cannot mutate a projected global row"
-                    .to_string(),
-            ));
-        }
         let branch_id = if global {
             GLOBAL_BRANCH_ID.to_string()
         } else {
-            source_branch_id
-                .or_else(|| branch_binding.active_branch_id().map(ToOwned::to_owned))
-                .ok_or_else(|| {
-                    DataFusionError::Execution(
-                        "UPDATE row by-branch requires lixcol_branch_id".to_string(),
-                    )
-                })?
+            branch_binding
+                .active_branch_id()
+                .expect("active row surface has an active branch")
+                .to_owned()
         };
         let row_pk = RowPk::from_json_array_text(&required_string_value(
             batch,
@@ -1836,12 +1709,7 @@ fn row_update_json_value(
         }
         SchemaColumnType::Integer => match value {
             ScalarValue::Int64(Some(value)) => Ok(JsonValue::from(value)),
-            other => Err(row_update_type_error(
-                spec,
-                column_name,
-                "BIGINT",
-                &other,
-            )),
+            other => Err(row_update_type_error(spec, column_name, "BIGINT", &other)),
         },
         SchemaColumnType::Number => match value {
             ScalarValue::Float64(Some(value)) => serde_json::Number::from_f64(value)
@@ -1861,12 +1729,7 @@ fn row_update_json_value(
         },
         SchemaColumnType::Boolean => match value {
             ScalarValue::Boolean(Some(value)) => Ok(JsonValue::Bool(value)),
-            other => Err(row_update_type_error(
-                spec,
-                column_name,
-                "BOOLEAN",
-                &other,
-            )),
+            other => Err(row_update_type_error(spec, column_name, "BOOLEAN", &other)),
         },
         SchemaColumnType::Timestamptz => match value {
             ScalarValue::TimestampMicrosecond(Some(value), _) => {
@@ -2247,9 +2110,7 @@ fn row_filter_mentions_primary_key(filter: &RowFilter, primary_key_columns: &[&s
     match filter {
         RowFilter::ColumnEq { column, .. }
         | RowFilter::ColumnIn { column, .. }
-        | RowFilter::ColumnRange { column, .. } => {
-            primary_key_columns.contains(&column.as_str())
-        }
+        | RowFilter::ColumnRange { column, .. } => primary_key_columns.contains(&column.as_str()),
         RowFilter::And(left, right) | RowFilter::Or(left, right) => {
             row_filter_mentions_primary_key(left, primary_key_columns)
                 || row_filter_mentions_primary_key(right, primary_key_columns)
@@ -2272,33 +2133,6 @@ fn primary_key_filter_external_value(
             RowFilterValue::String(value),
         ) => Some(value.clone()),
         _ => None,
-    }
-}
-
-fn exact_branch_ids_from_filters(filters: &[Expr]) -> Result<Option<Vec<String>>> {
-    let analyzer = ExactBranchIdFilterAnalyzer;
-    let mut branch_ids: Option<BTreeSet<String>> = None;
-    for filter in filters {
-        let Some(filter_ids) = analyzer.analyze(filter)? else {
-            continue;
-        };
-        branch_ids = Some(match branch_ids {
-            Some(existing_ids) => existing_ids.intersection(&filter_ids).cloned().collect(),
-            None => filter_ids,
-        });
-    }
-    Ok(branch_ids.map(|ids| ids.into_iter().collect()))
-}
-
-fn apply_exact_branch_id_filter(
-    request: &mut HotStateScanRequest,
-    branch_ids: Option<Vec<String>>,
-) {
-    if let Some(branch_ids) = branch_ids {
-        if branch_ids.is_empty() {
-            request.filter.rows = HotStateRowFilter::None;
-        }
-        request.filter.branch_ids = branch_ids;
     }
 }
 
@@ -2329,7 +2163,10 @@ fn exact_file_ids_from_filters(filters: &[Expr]) -> Result<Option<Vec<ExactFileI
     Ok(file_ids.map(|ids| ids.into_iter().collect()))
 }
 
-fn apply_exact_file_id_filter(request: &mut HotStateScanRequest, file_ids: Option<Vec<ExactFileId>>) {
+fn apply_exact_file_id_filter(
+    request: &mut HotStateScanRequest,
+    file_ids: Option<Vec<ExactFileId>>,
+) {
     if let Some(file_ids) = file_ids {
         if file_ids.is_empty() {
             request.filter.rows = HotStateRowFilter::None;
@@ -2390,8 +2227,7 @@ impl ExactFileIdFilterAnalyzer {
                 let Expr::Column(column) = expression.as_ref() else {
                     return Ok(None);
                 };
-                Ok((column.name == "lixcol_file_id")
-                    .then(|| BTreeSet::from([ExactFileId::Null])))
+                Ok((column.name == "lixcol_file_id").then(|| BTreeSet::from([ExactFileId::Null])))
             }
             _ => Ok(None),
         }
@@ -2449,89 +2285,6 @@ struct RowFilterAnalyzer<'a> {
     spec: &'a SchemaSurfaceSpec,
 }
 
-struct ExactBranchIdFilterAnalyzer;
-
-impl ExactBranchIdFilterAnalyzer {
-    fn supports(&self, expr: &Expr) -> bool {
-        self.analyze(expr)
-            .is_ok_and(|constraint| constraint.is_some())
-    }
-
-    #[expect(clippy::self_only_used_in_recursion)]
-    fn analyze(&self, expr: &Expr) -> Result<Option<BTreeSet<String>>> {
-        match expr {
-            Expr::BinaryExpr(binary_expr) if binary_expr.op == Operator::And => {
-                let Some(left) = self.analyze(&binary_expr.left)? else {
-                    return Ok(None);
-                };
-                let Some(right) = self.analyze(&binary_expr.right)? else {
-                    return Ok(None);
-                };
-                Ok(Some(left.intersection(&right).cloned().collect()))
-            }
-            Expr::BinaryExpr(binary_expr) if binary_expr.op == Operator::Or => {
-                let Some(mut left) = self.analyze(&binary_expr.left)? else {
-                    return Ok(None);
-                };
-                let Some(right) = self.analyze(&binary_expr.right)? else {
-                    return Ok(None);
-                };
-                left.extend(right);
-                Ok(Some(left))
-            }
-            Expr::BinaryExpr(binary_expr) => {
-                Ok(branch_id_from_binary_filter(binary_expr).map(|value| BTreeSet::from([value])))
-            }
-            Expr::InList(in_list) => {
-                Ok(branch_ids_from_in_list_filter(in_list)
-                    .map(|values| values.into_iter().collect()))
-            }
-            _ => Ok(None),
-        }
-    }
-}
-
-fn branch_id_from_binary_filter(binary_expr: &BinaryExpr) -> Option<String> {
-    if binary_expr.op != Operator::Eq {
-        return None;
-    }
-
-    branch_id_from_column_literal_filter(&binary_expr.left, &binary_expr.right)
-        .or_else(|| branch_id_from_column_literal_filter(&binary_expr.right, &binary_expr.left))
-}
-
-fn branch_ids_from_in_list_filter(in_list: &InList) -> Option<Vec<String>> {
-    if in_list.negated {
-        return None;
-    }
-    let Expr::Column(column) = in_list.expr.as_ref() else {
-        return None;
-    };
-    if column.name != "lixcol_branch_id" {
-        return None;
-    }
-
-    let values = in_list
-        .list
-        .iter()
-        .map(string_expr_literal)
-        .collect::<Option<Vec<_>>>()?;
-    if values.is_empty() {
-        return None;
-    }
-    Some(values)
-}
-
-fn branch_id_from_column_literal_filter(column_expr: &Expr, literal_expr: &Expr) -> Option<String> {
-    let Expr::Column(column) = column_expr else {
-        return None;
-    };
-    if column.name != "lixcol_branch_id" {
-        return None;
-    }
-    string_expr_literal(literal_expr)
-}
-
 impl<'a> RowPrimaryKeyFilterAnalyzer<'a> {
     pub(super) fn new(spec: &'a SchemaSurfaceSpec) -> Self {
         Self {
@@ -2557,10 +2310,7 @@ impl<'a> RowPrimaryKeyFilterAnalyzer<'a> {
         let Some(constraint) = self.analyze_constraint(expr)? else {
             return Ok(None);
         };
-        Ok(
-            constraint
-                .into_row_pks(&self.primary_key_columns, &self.primary_key_component_types),
-        )
+        Ok(constraint.into_row_pks(&self.primary_key_columns, &self.primary_key_component_types))
     }
 
     /// Extracts identity constraints that are guaranteed conjuncts while
@@ -2605,8 +2355,8 @@ impl<'a> RowPrimaryKeyFilterAnalyzer<'a> {
                 let Some(right) = self.analyze_constraint(&binary_expr.right)? else {
                     return Ok(None);
                 };
-                let Some(left_ids) = left
-                    .into_row_pks(&self.primary_key_columns, &self.primary_key_component_types)
+                let Some(left_ids) =
+                    left.into_row_pks(&self.primary_key_columns, &self.primary_key_component_types)
                 else {
                     return Ok(None);
                 };
@@ -2704,12 +2454,10 @@ impl<'a> RowFilterAnalyzer<'a> {
             Expr::Column(column) => {
                 let column_name = self.filterable_column_name(&column.name)?;
                 let column = self.spec.visible_column(column_name)?;
-                (column.column_type == SchemaColumnType::Boolean).then(|| {
-                    RowFilter::ColumnEq {
-                        column: column_name.to_string(),
-                        column_type: SchemaColumnType::Boolean,
-                        value: RowFilterValue::Boolean(true),
-                    }
+                (column.column_type == SchemaColumnType::Boolean).then(|| RowFilter::ColumnEq {
+                    column: column_name.to_string(),
+                    column_type: SchemaColumnType::Boolean,
+                    value: RowFilterValue::Boolean(true),
                 })
             }
             Expr::BinaryExpr(binary_expr) if binary_expr.op == Operator::And => {
@@ -2819,11 +2567,7 @@ impl<'a> RowFilterAnalyzer<'a> {
         })
     }
 
-    fn analyze_column_literal(
-        &self,
-        column_expr: &Expr,
-        literal_expr: &Expr,
-    ) -> Option<RowFilter> {
+    fn analyze_column_literal(&self, column_expr: &Expr, literal_expr: &Expr) -> Option<RowFilter> {
         let Expr::Column(column) = column_expr else {
             return None;
         };
@@ -3013,12 +2757,7 @@ impl RowFilter {
                     .fields
                     .iter()
                     .position(|field| field.name == *column)?;
-                row_filter_range_in_statistics(
-                    *op,
-                    value,
-                    &group.columns[index],
-                    group.row_count,
-                )
+                row_filter_range_in_statistics(*op, value, &group.columns[index], group.row_count)
             }
             Self::And(left, right) => match (
                 left.may_match_group(manifest, group),
@@ -3171,9 +2910,7 @@ fn row_scalar_value_cmp(
 ) -> Option<std::cmp::Ordering> {
     use crate::columnar_row_group::RowGroupScalar;
     match (scalar, value) {
-        (RowGroupScalar::Int64(scalar), RowFilterValue::Integer(value)) => {
-            Some(scalar.cmp(value))
-        }
+        (RowGroupScalar::Int64(scalar), RowFilterValue::Integer(value)) => Some(scalar.cmp(value)),
         (RowGroupScalar::String(scalar), RowFilterValue::String(value)) => {
             Some(scalar.as_str().cmp(value.as_str()))
         }
@@ -3201,10 +2938,7 @@ fn row_filter_value_cmp(
     }
 }
 
-fn row_filter_value_literal(
-    expr: &Expr,
-    column_type: SchemaColumnType,
-) -> Option<RowFilterValue> {
+fn row_filter_value_literal(expr: &Expr, column_type: SchemaColumnType) -> Option<RowFilterValue> {
     let Expr::Literal(literal, _) = expr else {
         return None;
     };
@@ -3217,9 +2951,7 @@ fn row_filter_value_literal(
         ScalarValue::UInt8(Some(value)) => Some(RowFilterValue::Integer(i64::from(*value))),
         ScalarValue::UInt16(Some(value)) => Some(RowFilterValue::Integer(i64::from(*value))),
         ScalarValue::UInt32(Some(value)) => Some(RowFilterValue::Integer(i64::from(*value))),
-        ScalarValue::UInt64(Some(value)) => {
-            i64::try_from(*value).ok().map(RowFilterValue::Integer)
-        }
+        ScalarValue::UInt64(Some(value)) => i64::try_from(*value).ok().map(RowFilterValue::Integer),
         ScalarValue::Float32(Some(value)) => Some(RowFilterValue::Number(f64::from(*value))),
         ScalarValue::Float64(Some(value)) => Some(RowFilterValue::Number(*value)),
         ScalarValue::Utf8(Some(value))
@@ -3230,10 +2962,7 @@ fn row_filter_value_literal(
     match (&value, column_type) {
         (RowFilterValue::Boolean(_), SchemaColumnType::Boolean)
         | (RowFilterValue::Integer(_), SchemaColumnType::Integer)
-        | (
-            RowFilterValue::Integer(_) | RowFilterValue::Number(_),
-            SchemaColumnType::Number,
-        )
+        | (RowFilterValue::Integer(_) | RowFilterValue::Number(_), SchemaColumnType::Number)
         | (RowFilterValue::String(_), SchemaColumnType::String) => Some(value),
         _ => None,
     }
@@ -3490,10 +3219,7 @@ fn identity_matches_parts(
 }
 
 #[cfg(test)]
-fn apply_row_filters(
-    rows: &mut Vec<MaterializedHotStateRow>,
-    filters: &[RowFilter],
-) -> Result<()> {
+fn apply_row_filters(rows: &mut Vec<MaterializedHotStateRow>, filters: &[RowFilter]) -> Result<()> {
     if filters.is_empty() {
         return Ok(());
     }
@@ -3761,9 +3487,7 @@ fn row_record_batch(
     }
 
     match projection {
-        RowBatchProjection::ParsedSnapshots => {
-            row_record_batch_from_snapshots(spec, schema, rows)
-        }
+        RowBatchProjection::ParsedSnapshots => row_record_batch_from_snapshots(spec, schema, rows),
         RowBatchProjection::RawTrackedProjection if rows.iter().all(|row| !row.untracked()) => {
             row_record_batch_from_raw_projection(spec, schema, rows)
         }
@@ -4257,19 +3981,19 @@ mod tests {
     use crate::branch::{BranchHead, BranchRefReader};
     use crate::changelog::{ChangeId, CommitId};
     use crate::common::LixTimestamp;
-    use crate::row_pk::RowPk as TestRowPk;
     use crate::hot_state::{
         HotStateFilter, HotStateProjection, HotStateReader, HotStateRowFilter, HotStateScanRequest,
         MaterializedHotStateBatch, MaterializedHotStateRow,
     };
+    use crate::row_pk::RowPk as TestRowPk;
     use crate::sql2::catalog::{
         SchemaColumnType, SchemaSurfaceShape, derive_schema_surface_spec_from_schema,
-        schema_surface_schema, schema_exposed_as_history_surface,
-        schema_exposed_as_schema_surface,
+        schema_exposed_as_history_surface, schema_exposed_as_schema_surface, schema_surface_schema,
     };
 
     struct EmptyHotStateReader;
     struct EmptyBranchRefReader;
+    struct ActiveBranchRefReader;
 
     #[derive(Default)]
     struct TestCachingRowSnapshotReader {
@@ -4336,8 +4060,29 @@ mod tests {
         }
     }
 
+    #[async_trait]
+    impl BranchRefReader for ActiveBranchRefReader {
+        async fn load_head(&self, branch_id: &str) -> Result<Option<BranchHead>, LixError> {
+            Ok((branch_id == "branch-a").then(|| BranchHead {
+                branch_id: branch_id.to_string(),
+                commit_id: CommitId::for_test_label("branch-a-head"),
+            }))
+        }
+
+        async fn scan_heads(&self) -> Result<Vec<BranchHead>, LixError> {
+            Ok(vec![BranchHead {
+                branch_id: "branch-a".to_string(),
+                commit_id: CommitId::for_test_label("branch-a-head"),
+            }])
+        }
+    }
+
     fn empty_branch_ref() -> Arc<dyn BranchRefReader> {
         Arc::new(EmptyBranchRefReader)
+    }
+
+    fn active_branch_ref() -> Arc<dyn BranchRefReader> {
+        Arc::new(ActiveBranchRefReader)
     }
 
     #[derive(Default)]
@@ -4955,24 +4700,6 @@ mod tests {
     }
 
     #[test]
-    fn by_branch_schema_includes_branch_system_column() {
-        let spec = derive_schema_surface_spec_from_schema(&json!({
-            "$schema": "https://lix.dev/schema-v1.json",
-            "key": "project_message",
-            "columns": [
-                { "name": "body", "type": "text", "nullable": false },
-            ],
-            "primary_key": ["body"],
-        }))
-        .expect("schema should derive schema surface spec");
-
-        let schema = schema_surface_schema(&spec, SchemaSurfaceShape::ByBranch);
-        assert!(schema.field_with_name("body").is_ok());
-        assert!(schema.field_with_name("lixcol_row_pk").is_ok());
-        assert!(schema.field_with_name("lixcol_branch_id").is_ok());
-    }
-
-    #[test]
     fn active_schema_excludes_branch_system_column() {
         let spec = derive_schema_surface_spec_from_schema(&json!({
             "$schema": "https://lix.dev/schema-v1.json",
@@ -5038,7 +4765,7 @@ mod tests {
             }))
             .expect("schema should derive schema surface spec"),
         );
-        let schema = schema_surface_schema(&spec, SchemaSurfaceShape::ByBranch);
+        let schema = schema_surface_schema(&spec, SchemaSurfaceShape::Active);
 
         let batch = row_record_batch(
             &spec,
@@ -5088,16 +4815,6 @@ mod tests {
                 .expect("row pk is string")
                 .value(0),
             "[\"row-1\"]"
-        );
-        assert_eq!(
-            batch
-                .column_by_name("lixcol_branch_id")
-                .expect("branch id column")
-                .as_any()
-                .downcast_ref::<StringArray>()
-                .expect("branch id is string")
-                .value(0),
-            "01920000-0000-7000-8000-0000000000a1"
         );
     }
 
@@ -5265,7 +4982,7 @@ mod tests {
             ..live_row()
         };
         let rows = live_batch(vec![branch_row, global_row]);
-        let schema = schema_surface_schema(&spec, SchemaSurfaceShape::ByBranch);
+        let schema = schema_surface_schema(&spec, SchemaSurfaceShape::Active);
         let parsed = row_record_batch(
             &spec,
             Arc::clone(&schema),
@@ -5285,7 +5002,6 @@ mod tests {
             "lixcol_metadata",
             "lixcol_row_pk",
             "lixcol_file_id",
-            "lixcol_branch_id",
             "lixcol_global",
             "lixcol_untracked",
         ] {
@@ -5407,7 +5123,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn provider_registers_as_table_provider() {
+    async fn active_provider_registers_without_branch_system_column() {
         let spec = Arc::new(
             derive_schema_surface_spec_from_schema(&json!({
                 "$schema": "https://lix.dev/schema-v1.json",
@@ -5419,10 +5135,11 @@ mod tests {
             }))
             .expect("schema should derive schema surface spec"),
         );
-        let provider = SpecTableProvider::new(Arc::new(super::SchemaSpec::by_branch(
+        let provider = SpecTableProvider::new(Arc::new(super::SchemaSpec::active(
             spec,
             Arc::new(EmptyHotStateReader) as Arc<dyn HotStateReader>,
-            empty_branch_ref(),
+            active_branch_ref(),
+            "branch-a".to_string(),
             None,
         )));
 
@@ -5430,7 +5147,7 @@ mod tests {
             provider
                 .schema()
                 .field_with_name("lixcol_branch_id")
-                .is_ok()
+                .is_err()
         );
     }
 
@@ -5450,10 +5167,7 @@ mod tests {
             .expect("primary-key filters should analyze")
             .expect("primary-key filters should produce a constraint");
 
-        assert_eq!(
-            row_pks,
-            vec![crate::row_pk::RowPk::single("row-a")]
-        );
+        assert_eq!(row_pks, vec![crate::row_pk::RowPk::single("row-a")]);
     }
 
     #[tokio::test]
@@ -5470,10 +5184,11 @@ mod tests {
             }))
             .expect("file-scoped schema should derive"),
         );
-        let provider = super::SchemaSpec::by_branch(
+        let provider = super::SchemaSpec::active(
             Arc::clone(&spec),
             Arc::new(EmptyHotStateReader) as Arc<dyn HotStateReader>,
-            empty_branch_ref(),
+            active_branch_ref(),
+            "branch-a".to_string(),
             None,
         );
 
@@ -5547,7 +5262,10 @@ mod tests {
             .plan_scan_parts(None, &[null_file_owner], None)
             .await
             .expect("NULL file-owner scan should plan");
-        assert_eq!(request.filter.file_ids, vec![crate::NullableKeyFilter::Null]);
+        assert_eq!(
+            request.filter.file_ids,
+            vec![crate::NullableKeyFilter::Null]
+        );
         assert!(row_filters.is_empty());
 
         // Shapes the seek cannot represent stay unsupported so DataFusion keeps
@@ -5592,10 +5310,11 @@ mod tests {
             &spec.primary_key_component_types,
         )
         .expect("integer identity should encode");
-        let provider = super::SchemaSpec::by_branch(
+        let provider = super::SchemaSpec::active(
             Arc::clone(&spec),
             Arc::new(EmptyHotStateReader) as Arc<dyn HotStateReader>,
-            empty_branch_ref(),
+            active_branch_ref(),
+            "branch-a".to_string(),
             None,
         );
 
@@ -5691,8 +5410,8 @@ mod tests {
             },
         ];
 
-        let (lower, upper) = super::primary_key_range(&spec, &filters)
-            .expect("contiguous typed range should route");
+        let (lower, upper) =
+            super::primary_key_range(&spec, &filters).expect("contiguous typed range should route");
         let lower = lower.expect("lower bound");
         let upper = upper.expect("upper bound");
         assert_eq!(lower.row_pk.clone().into_parts(), vec!["41"]);
@@ -5732,9 +5451,8 @@ mod tests {
         };
 
         assert!(super::primary_key_range(&spec, &[prefix.clone(), lower.clone()]).is_none());
-        let (actual_lower, actual_upper) =
-            super::primary_key_range(&spec, &[prefix, lower, upper])
-                .expect("bounded final component with exact prefix should route");
+        let (actual_lower, actual_upper) = super::primary_key_range(&spec, &[prefix, lower, upper])
+            .expect("bounded final component with exact prefix should route");
         assert_eq!(
             actual_lower.expect("lower").row_pk.into_parts(),
             vec!["docs", "10"]
@@ -5841,10 +5559,11 @@ mod tests {
     #[tokio::test]
     async fn payload_filter_scan_forces_snapshot_and_removes_pushed_limit() {
         let spec = filter_pushdown_spec();
-        let provider = super::SchemaSpec::by_branch(
+        let provider = super::SchemaSpec::active(
             Arc::clone(&spec),
             Arc::new(EmptyHotStateReader) as Arc<dyn HotStateReader>,
-            empty_branch_ref(),
+            active_branch_ref(),
+            "branch-a".to_string(),
             None,
         );
         let row_pk_index = provider
@@ -5881,10 +5600,11 @@ mod tests {
     #[tokio::test]
     async fn unsupported_payload_filter_keeps_limit_and_no_snapshot_projection() {
         let spec = filter_pushdown_spec();
-        let provider = super::SchemaSpec::by_branch(
+        let provider = super::SchemaSpec::active(
             Arc::clone(&spec),
             Arc::new(EmptyHotStateReader) as Arc<dyn HotStateReader>,
-            empty_branch_ref(),
+            active_branch_ref(),
+            "branch-a".to_string(),
             None,
         );
         let row_pk_index = provider
@@ -5919,10 +5639,11 @@ mod tests {
     #[tokio::test]
     async fn integer_filter_does_not_claim_exact_pushdown_for_real_literal() {
         let spec = filter_pushdown_spec();
-        let provider = super::SchemaSpec::by_branch(
+        let provider = super::SchemaSpec::active(
             Arc::clone(&spec),
             Arc::new(EmptyHotStateReader) as Arc<dyn HotStateReader>,
-            empty_branch_ref(),
+            active_branch_ref(),
+            "branch-a".to_string(),
             None,
         );
         let row_pk_index = provider
@@ -6199,10 +5920,8 @@ mod tests {
             column_type: SchemaColumnType::Boolean,
             value: super::RowFilterValue::Boolean(true),
         };
-        let selected = super::row_columnar_group_indices(
-            &encoded.manifest,
-            std::slice::from_ref(&row_filter),
-        );
+        let selected =
+            super::row_columnar_group_indices(&encoded.manifest, std::slice::from_ref(&row_filter));
         let flag_index = encoded
             .manifest
             .fields
@@ -6220,10 +5939,11 @@ mod tests {
             )
         }));
 
-        let provider = super::SchemaSpec::by_branch(
+        let provider = super::SchemaSpec::active(
             Arc::new(spec),
             Arc::new(EmptyHotStateReader) as Arc<dyn HotStateReader>,
-            empty_branch_ref(),
+            active_branch_ref(),
+            "branch-a".to_string(),
             None,
         );
         let expression = Expr::BinaryExpr(BinaryExpr::new(

--- a/packages/lix/src/sql2/providers/working_diff.rs
+++ b/packages/lix/src/sql2/providers/working_diff.rs
@@ -30,7 +30,7 @@ use crate::sql2::error::lix_error_to_datafusion_error;
 pub(super) async fn register_working_diff_provider<S>(
     session: &datafusion::prelude::SessionContext,
     surface_name: &str,
-    active_branch_id: Option<String>,
+    active_branch_id: String,
     branch_ref: Arc<dyn BranchRefReader>,
     commit_graph: Box<dyn CommitGraphReader>,
     query_source: SqlChangelogQuerySource<S>,
@@ -42,7 +42,6 @@ where
         session,
         surface_name,
         Arc::new(WorkingDiffSpec {
-            by_branch: active_branch_id.is_none(),
             active_branch_id,
             branch_ref,
             commit_graph: Arc::new(Mutex::new(commit_graph)),
@@ -53,8 +52,7 @@ where
 }
 
 struct WorkingDiffSpec<S> {
-    by_branch: bool,
-    active_branch_id: Option<String>,
+    active_branch_id: String,
     branch_ref: Arc<dyn BranchRefReader>,
     commit_graph: Arc<Mutex<Box<dyn CommitGraphReader>>>,
     store: S,
@@ -66,15 +64,11 @@ where
     S: StorageAdapterRead + Clone + Send + Sync + 'static,
 {
     fn table_name(&self) -> &str {
-        if self.by_branch {
-            "lix_working_diff_by_branch"
-        } else {
-            "lix_working_diff"
-        }
+        "lix_working_diff"
     }
 
     fn schema(&self) -> SchemaRef {
-        working_diff_schema(self.by_branch)
+        working_diff_schema()
     }
 
     fn table_type(&self) -> TableType {
@@ -85,7 +79,7 @@ where
         if filter.column_refs().iter().any(|column| {
             matches!(
                 column.name.as_str(),
-                "row_pk" | "schema_key" | "file_id" | "lixcol_branch_id"
+                "row_pk" | "schema_key" | "file_id"
             )
         }) {
             TableProviderFilterPushDown::Inexact
@@ -124,8 +118,8 @@ where
                     }
                     let heads = selected_heads(
                         branch_ref.as_ref(),
-                        active_branch_id.as_deref(),
-                        &route.branch_ids,
+                        Some(active_branch_id.as_str()),
+                        &FileIdConstraint::All,
                     )
                     .await
                     .map_err(lix_error_to_datafusion_error)?;
@@ -200,7 +194,6 @@ where
                                 },
                                 before_change_id: entry.before.map(|row| row.change_id.to_string()),
                                 after_change_id: entry.after.map(|row| row.change_id.to_string()),
-                                branch_id: head.branch_id.clone(),
                             });
                             if limit.is_some_and(|limit| rows.len() >= limit) {
                                 break;
@@ -218,7 +211,6 @@ where
 
 #[derive(Clone, Debug)]
 struct WorkingDiffRoute {
-    branch_ids: FileIdConstraint,
     diff_request: TrackedStateDiffRequest,
     contradictory: bool,
 }
@@ -226,8 +218,6 @@ struct WorkingDiffRoute {
 impl WorkingDiffRoute {
     fn from_filters(filters: &[Expr]) -> Result<Self> {
         let conjuncts = filter_conjuncts(filters);
-        let branch_ids =
-            exact_string_column_constraint_from_filters(&conjuncts, "lixcol_branch_id")?;
         let schema_keys = string_constraint_values(exact_string_column_constraint_from_filters(
             &conjuncts,
             "schema_key",
@@ -239,8 +229,7 @@ impl WorkingDiffRoute {
             &conjuncts, "file_id",
         )?);
 
-        let mut contradictory = matches!(branch_ids, FileIdConstraint::None)
-            || schema_keys.as_ref().is_some_and(Vec::is_empty)
+        let mut contradictory = schema_keys.as_ref().is_some_and(Vec::is_empty)
             || row_pk_values.as_ref().is_some_and(Vec::is_empty)
             || file_ids.as_ref().is_some_and(Vec::is_empty);
         let row_pk_filter_is_explicit = row_pk_values.is_some();
@@ -252,7 +241,6 @@ impl WorkingDiffRoute {
         contradictory |= row_pk_filter_is_explicit && row_pks.is_empty();
 
         Ok(Self {
-            branch_ids,
             diff_request: TrackedStateDiffRequest {
                 filter: TrackedStateFilter {
                     schema_keys: schema_keys.unwrap_or_default(),
@@ -281,8 +269,8 @@ fn string_constraint_values(constraint: FileIdConstraint) -> Option<Vec<String>>
     }
 }
 
-pub(super) fn working_diff_schema(by_branch: bool) -> SchemaRef {
-    let mut fields = vec![
+pub(super) fn working_diff_schema() -> SchemaRef {
+    let fields = vec![
         Field::new("diff_id", DataType::Utf8, false),
         json_field("row_pk", false),
         Field::new("schema_key", DataType::Utf8, false),
@@ -291,9 +279,6 @@ pub(super) fn working_diff_schema(by_branch: bool) -> SchemaRef {
         Field::new("before_change_id", DataType::Utf8, true),
         Field::new("after_change_id", DataType::Utf8, true),
     ];
-    if by_branch {
-        fields.push(Field::new("lixcol_branch_id", DataType::Utf8, false));
-    }
     Arc::new(Schema::new(fields))
 }
 
@@ -305,7 +290,6 @@ struct WorkingDiffSqlRow {
     diff_type: &'static str,
     before_change_id: Option<String>,
     after_change_id: Option<String>,
-    branch_id: String,
 }
 
 static WORKING_DIFF_COLS: ColumnTable<WorkingDiffSqlRow> = ColumnTable {
@@ -329,7 +313,6 @@ static WORKING_DIFF_COLS: ColumnTable<WorkingDiffSqlRow> = ColumnTable {
             "after_change_id",
             Col::Utf8(|row| row.after_change_id.as_deref()),
         ),
-        ("lixcol_branch_id", Col::Utf8(|row| Some(&row.branch_id))),
     ],
 };
 
@@ -351,22 +334,17 @@ mod tests {
 
     use crate::NullableKeyFilter;
 
-    use super::{FileIdConstraint, WorkingDiffRoute};
+    use super::WorkingDiffRoute;
 
     #[test]
-    fn routes_exact_branch_and_tracked_identity_filters() {
+    fn routes_exact_tracked_identity_filters() {
         let route = WorkingDiffRoute::from_filters(&[
-            col("lixcol_branch_id").eq(lit("01920000-0000-7000-8000-0000000000a1")),
             col("schema_key").eq(lit("acme_task")),
             col("row_pk").eq(lit("[\"task-a\"]")),
             col("file_id").eq(lit("01920000-0000-7000-8000-0000000000a2")),
         ])
         .expect("exact working-diff filters should route");
 
-        assert_eq!(
-            route.branch_ids,
-            FileIdConstraint::Ids(["01920000-0000-7000-8000-0000000000a1".to_string()].into())
-        );
         assert_eq!(
             route.diff_request.filter.schema_keys,
             vec!["acme_task".to_string()]

--- a/packages/lix/src/sql2/test_support/differential.rs
+++ b/packages/lix/src/sql2/test_support/differential.rs
@@ -2,15 +2,10 @@
 
 #[cfg(test)]
 mod tests {
-    use crate::common::serialize_row_metadata;
-    use crate::row_pk::RowPk;
-    use crate::hot_state::{
-        HotStateFilter, HotStateScanRequest, MaterializedHotStateBatch, MaterializedHotStateRowRef,
-    };
     use crate::session::CreateBranchOptions;
     use crate::sql2::test_support::generators::{
-        ACTIVE_BRANCH_PROBE_ID, DifferentialExpectation, DifferentialParam, DifferentialProbe,
-        DifferentialSqlCase, ExpectedExecution, deterministic_repro_cases, generated_dml_cases,
+        DifferentialExpectation, DifferentialParam, DifferentialProbe, DifferentialSqlCase,
+        ExpectedExecution, deterministic_repro_cases, generated_dml_cases,
     };
     use crate::sql2::{WriteExecutorMode, WriteExecutorPath};
     use crate::storage_adapter::Memory;
@@ -48,7 +43,6 @@ mod tests {
         name: String,
         sql: String,
         params: Vec<Value>,
-        branch_column_indexes: &'static [usize],
     }
 
     #[tokio::test]
@@ -357,11 +351,11 @@ mod tests {
     async fn probe_session_state(
         session: &crate::session::SessionContext,
         probes: &[DifferentialProbe],
-        active_branch_id: &str,
+        _active_branch_id: &str,
     ) -> Vec<ProbeSnapshot> {
         let mut snapshots = Vec::with_capacity(probes.len());
         for probe in probes {
-            let query = probe_query(probe, active_branch_id);
+            let query = probe_query(probe);
             snapshots.push(ProbeSnapshot {
                 name: query.name,
                 rows: session
@@ -375,13 +369,7 @@ mod tests {
                     })
                     .rows()
                     .iter()
-                    .map(|row| {
-                        canonical_probe_values(
-                            row.values(),
-                            active_branch_id,
-                            query.branch_column_indexes,
-                        )
-                    })
+                    .map(|row| row.values().to_vec())
                     .collect(),
             });
         }
@@ -391,17 +379,11 @@ mod tests {
     async fn probe_transaction_state(
         transaction: &mut crate::session::SessionTransaction,
         probes: &[DifferentialProbe],
-        active_branch_id: &str,
+        _active_branch_id: &str,
     ) -> Vec<ProbeSnapshot> {
         let mut snapshots = Vec::with_capacity(probes.len());
         for probe in probes {
-            if let Some(snapshot) =
-                synthetic_staged_by_branch_probe(transaction, probe, active_branch_id).await
-            {
-                snapshots.push(snapshot);
-                continue;
-            }
-            let query = probe_query(probe, active_branch_id);
+            let query = probe_query(probe);
             snapshots.push(ProbeSnapshot {
                 name: query.name,
                 rows: transaction
@@ -415,20 +397,14 @@ mod tests {
                     })
                     .rows()
                     .iter()
-                    .map(|row| {
-                        canonical_probe_values(
-                            row.values(),
-                            active_branch_id,
-                            query.branch_column_indexes,
-                        )
-                    })
+                    .map(|row| row.values().to_vec())
                     .collect(),
             });
         }
         snapshots
     }
 
-    fn probe_query(probe: &DifferentialProbe, active_branch_id: &str) -> ProbeQuery {
+    fn probe_query(probe: &DifferentialProbe) -> ProbeQuery {
         match probe {
             DifferentialProbe::RegisteredSchemaActive => ProbeQuery {
                 name: "lix_registered_schema".to_string(),
@@ -437,34 +413,7 @@ mod tests {
                  ORDER BY lixcol_row_pk"
                     .to_string(),
                 params: Vec::new(),
-                branch_column_indexes: &[],
             },
-            DifferentialProbe::RegisteredSchemaByBranch { branch_ids } => {
-                let mut params = Vec::with_capacity(branch_ids.len());
-                let placeholders = branch_ids
-                    .iter()
-                    .enumerate()
-                    .map(|(index, branch_id)| {
-                        params.push(Value::Text(resolve_probe_branch_id(
-                            branch_id,
-                            active_branch_id,
-                        )));
-                        format!("${}", index + 1)
-                    })
-                    .collect::<Vec<_>>()
-                    .join(", ");
-                ProbeQuery {
-                    name: format!("lix_registered_schema_by_branch:{branch_ids:?}"),
-                    sql: format!(
-                        "SELECT lixcol_row_pk, value, lixcol_branch_id, lixcol_metadata, lixcol_global, lixcol_untracked \
-                         FROM lix_registered_schema_by_branch \
-                         WHERE lixcol_branch_id IN ({placeholders}) \
-                         ORDER BY lixcol_row_pk, lixcol_branch_id"
-                    ),
-                    params,
-                    branch_column_indexes: &[2],
-                }
-            }
             DifferentialProbe::LixFileActive { paths } => {
                 let mut params = Vec::with_capacity(paths.len());
                 let placeholders = paths
@@ -485,144 +434,9 @@ mod tests {
                          ORDER BY path"
                     ),
                     params,
-                    branch_column_indexes: &[],
                 }
             }
         }
     }
 
-    async fn synthetic_staged_by_branch_probe(
-        transaction: &mut crate::session::SessionTransaction,
-        probe: &DifferentialProbe,
-        active_branch_id: &str,
-    ) -> Option<ProbeSnapshot> {
-        match probe {
-            DifferentialProbe::RegisteredSchemaByBranch { branch_ids } => {
-                let rows = scan_transaction_hot_state(
-                    transaction,
-                    "lix_registered_schema",
-                    &[],
-                    branch_ids,
-                    active_branch_id,
-                )
-                .await;
-                Some(ProbeSnapshot {
-                    name: format!("lix_registered_schema_by_branch_staged:{branch_ids:?}"),
-                    rows: registered_schema_by_branch_rows(rows, active_branch_id),
-                })
-            }
-            _ => None,
-        }
-    }
-
-    async fn scan_transaction_hot_state(
-        transaction: &mut crate::session::SessionTransaction,
-        schema_key: &str,
-        row_pks: &[&str],
-        branch_ids: &[&str],
-        active_branch_id: &str,
-    ) -> MaterializedHotStateBatch {
-        transaction
-        .scan_hot_state_for_test(&HotStateScanRequest {
-            filter: HotStateFilter {
-                schema_keys: vec![schema_key.to_string()],
-                row_pks: row_pks
-                    .iter()
-                    .map(|row_pk| RowPk::single(*row_pk))
-                    .collect(),
-                branch_ids: branch_ids
-                    .iter()
-                    .map(|branch_id| resolve_probe_branch_id(branch_id, active_branch_id))
-                    .collect(),
-                ..HotStateFilter::default()
-            },
-            ..HotStateScanRequest::default()
-        })
-        .await
-        .unwrap_or_else(|error| {
-            panic!(
-                "staged live-state differential probe failed for schema '{schema_key}': {error:?}"
-            )
-        })
-    }
-
-    fn registered_schema_by_branch_rows(
-        rows: MaterializedHotStateBatch,
-        active_branch_id: &str,
-    ) -> Vec<Vec<Value>> {
-        let mut ordinals = (0..rows.len()).collect::<Vec<_>>();
-        ordinals.sort_by(|left, right| {
-            let left = rows.row(*left);
-            let right = rows.row(*right);
-            left.row_pk()
-                .cmp(right.row_pk())
-                .then_with(|| left.branch_id().cmp(right.branch_id()))
-        });
-        ordinals
-            .into_iter()
-            .map(|ordinal| {
-                let row = rows.row(ordinal);
-                let value = row
-                    .snapshot_content()
-                    .map(|snapshot| snapshot.as_str())
-                    .and_then(|snapshot| serde_json::from_str::<serde_json::Value>(snapshot).ok())
-                    .and_then(|snapshot| snapshot.get("value").cloned())
-                    .map(|value| {
-                        Value::Text(serde_json::to_string(&value).expect("JSON serializes"))
-                    })
-                    .unwrap_or(Value::Null);
-                canonical_probe_values(
-                    &[
-                        row_pk_value(row),
-                        value,
-                        Value::Text(row.branch_id().to_string()),
-                        row.metadata()
-                            .map(|metadata| metadata.as_str())
-                            .map(serialize_row_metadata)
-                            .map(Value::Text)
-                            .unwrap_or(Value::Null),
-                        Value::Boolean(row.global()),
-                        Value::Boolean(row.untracked()),
-                    ],
-                    active_branch_id,
-                    &[2],
-                )
-            })
-            .collect()
-    }
-
-    fn row_pk_value(row: MaterializedHotStateRowRef<'_>) -> Value {
-        Value::Text(
-            row.row_pk()
-                .as_json_array_text()
-                .expect("materialized row pk should encode"),
-        )
-    }
-
-    fn resolve_probe_branch_id(branch_id: &str, active_branch_id: &str) -> String {
-        if branch_id == ACTIVE_BRANCH_PROBE_ID {
-            active_branch_id.to_string()
-        } else {
-            branch_id.to_string()
-        }
-    }
-
-    fn canonical_probe_values(
-        values: &[Value],
-        active_branch_id: &str,
-        branch_column_indexes: &[usize],
-    ) -> Vec<Value> {
-        values
-            .iter()
-            .enumerate()
-            .map(|(index, value)| match value {
-                Value::Text(text)
-                    if text == active_branch_id && branch_column_indexes.contains(&index) =>
-                {
-                    Value::Text(ACTIVE_BRANCH_PROBE_ID.to_string())
-                }
-                other => other.clone(),
-            })
-            .collect()
-    }
 }

--- a/packages/lix/src/sql2/test_support/generators.rs
+++ b/packages/lix/src/sql2/test_support/generators.rs
@@ -46,7 +46,6 @@ pub(crate) enum DifferentialParam {
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(crate) enum DifferentialProbe {
     RegisteredSchemaActive,
-    RegisteredSchemaByBranch { branch_ids: &'static [&'static str] },
     LixFileActive { paths: &'static [&'static str] },
 }
 
@@ -54,20 +53,7 @@ pub(crate) enum DifferentialProbe {
 const EMPTY_PARAMS: &[DifferentialParam] = &[];
 
 #[cfg(test)]
-pub(crate) const ACTIVE_BRANCH_PROBE_ID: &str = "__active_branch__";
-
-#[cfg(test)]
-const REGISTERED_SCHEMA_PROBE: &[DifferentialProbe] = &[
-    DifferentialProbe::RegisteredSchemaActive,
-    DifferentialProbe::RegisteredSchemaByBranch {
-        branch_ids: &[
-            ACTIVE_BRANCH_PROBE_ID,
-            "ffffffff-ffff-7fff-bfff-ffffffffffff",
-            "01920000-0000-7000-8000-0000000000a1",
-            "01920000-0000-7000-8000-0000000000b1",
-        ],
-    },
-];
+const REGISTERED_SCHEMA_PROBE: &[DifferentialProbe] = &[DifferentialProbe::RegisteredSchemaActive];
 
 #[cfg(test)]
 const FILE_AND_REGISTERED_SCHEMA_PROBES: &[DifferentialProbe] = &[
@@ -175,30 +161,6 @@ pub(crate) fn deterministic_repro_cases() -> Vec<DifferentialSqlCase> {
             expectation: DifferentialExpectation::SemanticParityMayFallback,
             expected_execution: ExpectedExecution::Err {
                 code: "LIX_COLUMN_NOT_FOUND",
-            },
-        },
-        DifferentialSqlCase {
-            seed: "known/by-branch-update-without-branch-predicate".into(),
-            setup_sql: &[],
-            transaction_setup_sql: &[],
-            sql: "UPDATE lix_registered_schema_by_branch SET value = CAST('{\"x-lix-key\":\"x\",\"type\":\"object\"}' AS JSONB)".into(),
-            params: EMPTY_PARAMS,
-            probes: REGISTERED_SCHEMA_PROBE,
-            expectation: DifferentialExpectation::SemanticParityMayFallback,
-            expected_execution: ExpectedExecution::Err {
-                code: "LIX_UNSUPPORTED_SQL",
-            },
-        },
-        DifferentialSqlCase {
-            seed: "known/by-branch-delete-without-branch-predicate".into(),
-            setup_sql: &[],
-            transaction_setup_sql: &[],
-            sql: "DELETE FROM lix_registered_schema_by_branch".into(),
-            params: EMPTY_PARAMS,
-            probes: REGISTERED_SCHEMA_PROBE,
-            expectation: DifferentialExpectation::SemanticParityMayFallback,
-            expected_execution: ExpectedExecution::Err {
-                code: "LIX_UNSUPPORTED_SQL",
             },
         },
         DifferentialSqlCase {

--- a/packages/lix/src/transaction/validation.rs
+++ b/packages/lix/src/transaction/validation.rs
@@ -1204,15 +1204,8 @@ fn filesystem_planner_validated_insert(row: &PreparedValidationRow<'_>) -> bool 
         return false;
     }
     let surface_matches_schema = match row.schema_key() {
-        FILE_DESCRIPTOR_SCHEMA_KEY => {
-            matches!(origin.surface.as_str(), "lix_file" | "lix_file_by_branch")
-        }
-        DIRECTORY_DESCRIPTOR_SCHEMA_KEY => {
-            matches!(
-                origin.surface.as_str(),
-                "lix_directory" | "lix_directory_by_branch"
-            )
-        }
+        FILE_DESCRIPTOR_SCHEMA_KEY => origin.surface.as_str() == "lix_file",
+        DIRECTORY_DESCRIPTOR_SCHEMA_KEY => origin.surface.as_str() == "lix_directory",
         _ => false,
     };
     if !surface_matches_schema {
@@ -3745,9 +3738,9 @@ mod tests {
 
     fn test_stage_json(value: &str) -> StageJson {
         let parsed = test_json_text(value).expect("test staged JSON should parse");
-        crate::transaction_types::stage_json_from_value(
-            TransactionJson::from_value_for_test(parsed),
-        )
+        crate::transaction_types::stage_json_from_value(TransactionJson::from_value_for_test(
+            parsed,
+        ))
     }
 
     fn test_json_text(value: &str) -> Result<serde_json::Value, LixError> {
@@ -4346,19 +4339,9 @@ mod tests {
                 "01920000-0000-7000-8000-000000000202",
             ),
             (
-                "lix_file_by_branch",
-                FILE_DESCRIPTOR_SCHEMA_KEY,
-                "01920000-0000-7000-8000-000000000212",
-            ),
-            (
                 "lix_directory",
                 DIRECTORY_DESCRIPTOR_SCHEMA_KEY,
                 "01920000-0000-7000-8000-000000000203",
-            ),
-            (
-                "lix_directory_by_branch",
-                DIRECTORY_DESCRIPTOR_SCHEMA_KEY,
-                "01920000-0000-7000-8000-000000000213",
             ),
         ] {
             let mut logical_insert = if schema_key == FILE_DESCRIPTOR_SCHEMA_KEY {

--- a/packages/lix/tests/integration/code_structure.rs
+++ b/packages/lix/tests/integration/code_structure.rs
@@ -2786,19 +2786,15 @@ fn sql2_read_session_does_not_register_write_surfaces() {
             "PublicSurfaceKind::Branch",
             "PublicSurfaceKind::Change",
             "PublicSurfaceKind::File",
-            "PublicSurfaceKind::FileByBranch",
             "PublicSurfaceKind::FileHistory",
             "PublicSurfaceKind::Directory",
-            "PublicSurfaceKind::DirectoryByBranch",
             "PublicSurfaceKind::DirectoryHistory",
             "branch::register_lix_branch_read_provider",
             "change::register_lix_change_read_provider",
             "file_history::register_lix_file_history_surface",
             "directory_history::register_lix_directory_history_surface",
             "directory::register_lix_directory_active_provider",
-            "directory::register_lix_directory_by_branch_provider",
             "file::register_lix_file_active_provider",
-            "file::register_lix_file_by_branch_provider",
             "schema::register_row_providers",
         ],
     );
@@ -2860,14 +2856,10 @@ fn sql2_write_session_registers_writable_transaction_surfaces() {
             "catalog.surfaces()",
             "PublicSurfaceKind::Branch",
             "PublicSurfaceKind::File",
-            "PublicSurfaceKind::FileByBranch",
             "PublicSurfaceKind::Directory",
-            "PublicSurfaceKind::DirectoryByBranch",
             "branch::register_write_provider",
             "file::register_active_write_provider",
-            "file::register_by_branch_write_provider",
             "directory::register_active_write_provider",
-            "directory::register_by_branch_write_provider",
             "schema::register_row_write_providers",
         ],
     );
@@ -2933,7 +2925,6 @@ fn sql2_row_provider_registration_is_catalog_driven() {
         &[
             "catalog.surfaces()",
             "PublicSurfaceKind::SchemaBase",
-            "PublicSurfaceKind::SchemaByBranch",
             "PublicSurfaceKind::SchemaHistory",
         ],
     );
@@ -2943,7 +2934,6 @@ fn sql2_row_provider_registration_is_catalog_driven() {
         &[
             "catalog.surfaces()",
             "PublicSurfaceKind::SchemaBase",
-            "PublicSurfaceKind::SchemaByBranch",
         ],
     );
     assert_source_contains_none(

--- a/packages/lix/tests/integration/sql/checkpoint.rs
+++ b/packages/lix/tests/integration/sql/checkpoint.rs
@@ -256,15 +256,25 @@ simulation_test!(
              VALUES ('01930000-0000-7000-8000-000000000001', 'fake')",
             "UPDATE lix_checkpoint SET commit_id = 'fake'",
             "DELETE FROM lix_working_diff",
-            "UPDATE lix_working_diff_by_branch SET diff_type = 'fake'",
             "DELETE FROM lix_file_working_diff",
-            "UPDATE lix_directory_working_diff_by_branch SET change_kind = 'fake'",
+            "UPDATE lix_directory_working_diff SET change_kind = 'fake'",
         ] {
             let error = session
                 .execute(sql, &[])
                 .await
                 .expect_err("checkpoint SQL surface should be read-only");
             assert_eq!(error.code, LixError::CODE_READ_ONLY);
+        }
+
+        for sql in [
+            "SELECT * FROM lix_working_diff_by_branch",
+            "SELECT * FROM lix_directory_working_diff_by_branch",
+        ] {
+            let error = session
+                .execute(sql, &[])
+                .await
+                .expect_err("retired by-branch surfaces must fail closed");
+            assert_eq!(error.code, LixError::CODE_TABLE_NOT_FOUND);
         }
     }
 );

--- a/packages/lix/tests/integration/sql/information_schema.rs
+++ b/packages/lix/tests/integration/sql/information_schema.rs
@@ -2,6 +2,58 @@ use lix::{LixError, Value};
 
 use super::assert_rows_eq;
 
+simulation_test!(public_catalog_has_no_by_branch_surfaces, |sim| async move {
+    let engine = sim.boot_engine().await;
+    let session = sim.wrap_session(
+        engine
+            .open_session()
+            .await
+            .expect("main session should open"),
+        &engine,
+    );
+
+    session
+        .execute(
+            "INSERT INTO lix_registered_schema (value, lixcol_global, lixcol_untracked) \
+             VALUES (CAST('{\"$schema\":\"https://lix.dev/schema-v1.json\",\"key\":\"no_explicit_branch_surface\",\"columns\":[{\"name\":\"id\",\"type\":\"text\",\"nullable\":false}],\"primary_key\":[\"id\"]}' AS JSONB), false, false)",
+            &[],
+        )
+        .await
+        .expect("registered schema insert should succeed");
+
+    let tables = session
+        .execute(
+            "SELECT table_name FROM information_schema.tables \
+             WHERE table_schema = 'public' AND table_name LIKE '%\\_by\\_branch' ESCAPE '\\'",
+            &[],
+        )
+        .await
+        .expect("public table catalog should be readable");
+    assert!(tables.rows().is_empty(), "no explicit-branch tables may remain");
+
+    let columns = session
+        .execute(
+            "SELECT table_name FROM information_schema.columns \
+             WHERE table_schema = 'public' AND column_name = 'lixcol_branch_id'",
+            &[],
+        )
+        .await
+        .expect("public column catalog should be readable");
+    assert!(
+        columns.rows().is_empty(),
+        "no public data relation may expose lixcol_branch_id"
+    );
+
+    let error = session
+        .execute("SELECT * FROM no_explicit_branch_surface_by_branch", &[])
+        .await
+        .expect_err("retired explicit-branch table names must fail closed");
+    assert!(
+        error.message.contains("no_explicit_branch_surface_by_branch"),
+        "the unknown-table error should identify the retired surface: {error:?}"
+    );
+});
+
 simulation_test!(
     information_schema_never_exposes_raw_snapshot_content,
     |sim| async move {
@@ -321,26 +373,7 @@ simulation_test!(
             )
             .await
             .expect("by-branch contract query should succeed");
-        assert_rows_eq(
-            by_branch_contract,
-            vec![
-                vec![
-                    Value::Text("engine_column_contract_by_branch".to_string()),
-                    Value::Text("NO".to_string()),
-                    Value::Text("REQUIRED".to_string()),
-                ],
-                vec![
-                    Value::Text("lix_directory_by_branch".to_string()),
-                    Value::Text("NO".to_string()),
-                    Value::Text("REQUIRED".to_string()),
-                ],
-                vec![
-                    Value::Text("lix_file_by_branch".to_string()),
-                    Value::Text("NO".to_string()),
-                    Value::Text("REQUIRED".to_string()),
-                ],
-            ],
-        );
+        assert_rows_eq(by_branch_contract, vec![]);
 
         let identity_contract = session
             .execute(

--- a/packages/lix/tests/integration/sql/lix_branch.rs
+++ b/packages/lix/tests/integration/sql/lix_branch.rs
@@ -493,12 +493,18 @@ simulation_test!(
              WHERE id = '73716c2d-6272-816e-8368-2d6c6f636100'",
         )
         .await;
-        session
+        let branch_session = sim.wrap_session(
+            engine
+                .open_session_at("73716c2d-6272-816e-8368-2d6c6f636100")
+                .await
+                .expect("branch session should open"),
+            &engine,
+        );
+        branch_session
             .execute(
-                "INSERT INTO lix_key_value_by_branch \
-                 (key, value, lixcol_branch_id, lixcol_global, lixcol_untracked) \
-                 VALUES ('73716c2d-6272-816e-8368-2d6c6f636100', 'draft', \
-                         '73716c2d-6272-816e-8368-2d6c6f636100', false, true)",
+                "INSERT INTO lix_key_value \
+                 (key, value, lixcol_global, lixcol_untracked) \
+                 VALUES ('73716c2d-6272-816e-8368-2d6c6f636100', 'draft', false, true)",
                 &[],
             )
             .await
@@ -593,22 +599,27 @@ simulation_test!(
             )
             .await
             .expect("branch insert should succeed");
-        session
+        let branch_session = sim.wrap_session(
+            engine
+                .open_session_at("73716c2d-6272-816e-8368-2d7265637201")
+                .await
+                .expect("branch session should open"),
+            &engine,
+        );
+        branch_session
             .execute(
-                "INSERT INTO lix_key_value_by_branch \
-                 (key, value, lixcol_branch_id, lixcol_global, lixcol_untracked) \
-                 VALUES ('73716c2d-6272-816e-8368-2d7265637201', 'old', \
-                         '73716c2d-6272-816e-8368-2d7265637201', false, false)",
+                "INSERT INTO lix_key_value \
+                 (key, value, lixcol_global, lixcol_untracked) \
+                 VALUES ('73716c2d-6272-816e-8368-2d7265637201', 'old', false, false)",
                 &[],
             )
             .await
             .expect("tracked branch-local row should insert");
         assert_eq!(
             count_rows(
-                &session,
-                "SELECT COUNT(*) FROM lix_key_value_by_branch \
-                 WHERE key = '73716c2d-6272-816e-8368-2d7265637201' \
-                   AND lixcol_branch_id = '73716c2d-6272-816e-8368-2d7265637201'",
+                &branch_session,
+                "SELECT COUNT(*) FROM lix_key_value \
+                 WHERE key = '73716c2d-6272-816e-8368-2d7265637201'",
             )
             .await,
             1
@@ -632,10 +643,15 @@ simulation_test!(
 
         assert_eq!(
             count_rows(
-                &session,
-                "SELECT COUNT(*) FROM lix_key_value_by_branch \
-                 WHERE key = '73716c2d-6272-816e-8368-2d7265637201' \
-                   AND lixcol_branch_id = '73716c2d-6272-816e-8368-2d7265637201'",
+                &sim.wrap_session(
+                    engine
+                        .open_session_at("73716c2d-6272-816e-8368-2d7265637201")
+                        .await
+                        .expect("recreated branch session should open"),
+                    &engine,
+                ),
+                "SELECT COUNT(*) FROM lix_key_value \
+                 WHERE key = '73716c2d-6272-816e-8368-2d7265637201'",
             )
             .await,
             0,

--- a/packages/lix/tests/integration/sql/lix_commit.rs
+++ b/packages/lix/tests/integration/sql/lix_commit.rs
@@ -1,6 +1,6 @@
 use std::collections::BTreeSet;
 
-use lix::{CreateBranchOptions, Value};
+use lix::{CreateBranchOptions, LixError, Value};
 
 use super::select_rows;
 
@@ -15,12 +15,6 @@ simulation_test!(
                 .expect("main session should open"),
             &engine,
         );
-
-        let initial_head = engine
-            .load_branch_head_commit_id(sim.main_branch_id())
-            .await
-            .expect("branch head should load")
-            .expect("branch head should exist");
 
         session
             .execute(
@@ -84,84 +78,13 @@ simulation_test!(
             ]]
         );
 
-        let by_branch_rows = select_rows(
-            &session,
-            &format!(
-                "SELECT id, lixcol_branch_id, lixcol_global, lixcol_untracked \
-                 FROM lix_commit_by_branch \
-                 WHERE id IN ('{initial_head}', '{first_head}', '{second_head}') \
-                 ORDER BY id, lixcol_branch_id"
-            ),
-        )
-        .await;
-        assert!(by_branch_rows.contains(&vec![
-            Value::Text(initial_head.clone()),
-            Value::Text(sim.main_branch_id().to_string()),
-            Value::Boolean(true),
-            Value::Boolean(false),
-        ]));
-        assert!(by_branch_rows.contains(&vec![
-            Value::Text(initial_head),
-            Value::Text("ffffffff-ffff-7fff-bfff-ffffffffffff".to_string()),
-            Value::Boolean(true),
-            Value::Boolean(false),
-        ]));
-        assert!(by_branch_rows.contains(&vec![
-            Value::Text(first_head.clone()),
-            Value::Text(sim.main_branch_id().to_string()),
-            Value::Boolean(true),
-            Value::Boolean(false),
-        ]));
-        assert!(by_branch_rows.contains(&vec![
-            Value::Text(first_head.clone()),
-            Value::Text("ffffffff-ffff-7fff-bfff-ffffffffffff".to_string()),
-            Value::Boolean(true),
-            Value::Boolean(false),
-        ]));
-        assert!(by_branch_rows.contains(&vec![
-            Value::Text(second_head.clone()),
-            Value::Text(sim.main_branch_id().to_string()),
-            Value::Boolean(true),
-            Value::Boolean(false),
-        ]));
-        assert!(by_branch_rows.contains(&vec![
-            Value::Text(second_head.clone()),
-            Value::Text("ffffffff-ffff-7fff-bfff-ffffffffffff".to_string()),
-            Value::Boolean(true),
-            Value::Boolean(false),
-        ]));
-
-        let edge_by_branch_rows = select_rows(
-            &session,
-            &format!(
-                "SELECT parent_id, child_id, parent_order, lixcol_branch_id, lixcol_global, lixcol_untracked \
-                 FROM lix_commit_edge_by_branch \
-                 WHERE child_id = '{second_head}' \
-                 ORDER BY lixcol_branch_id"
-            ),
-        )
-        .await;
-        assert_eq!(
-            edge_by_branch_rows,
-            vec![
-                vec![
-                    Value::Text(first_head.clone()),
-                    Value::Text(second_head.clone()),
-                    Value::Integer(0),
-                    Value::Text(sim.main_branch_id().to_string()),
-                    Value::Boolean(true),
-                    Value::Boolean(false),
-                ],
-                vec![
-                    Value::Text(first_head),
-                    Value::Text(second_head),
-                    Value::Integer(0),
-                    Value::Text("ffffffff-ffff-7fff-bfff-ffffffffffff".to_string()),
-                    Value::Boolean(true),
-                    Value::Boolean(false),
-                ],
-            ]
-        );
+        for table in ["lix_commit_by_branch", "lix_commit_edge_by_branch"] {
+            let error = session
+                .execute(&format!("SELECT * FROM {table}"), &[])
+                .await
+                .expect_err("retired by-branch commit surfaces must fail closed");
+            assert_eq!(error.code, LixError::CODE_TABLE_NOT_FOUND);
+        }
     }
 );
 
@@ -250,85 +173,6 @@ simulation_test!(
     }
 );
 
-simulation_test!(
-    lix_commit_derived_by_branch_surfaces_match_commit_row_projection,
-    |sim| async move {
-        let engine = sim.boot_engine().await;
-        let main = sim.wrap_session(
-            engine
-                .open_session()
-                .await
-                .expect("main session should open"),
-            &engine,
-        );
-
-        main.execute(
-            "INSERT INTO lix_key_value (key, value) VALUES ('main-edge-probe', 'main')",
-            &[],
-        )
-        .await
-        .expect("main write should succeed");
-
-        main.create_branch(CreateBranchOptions {
-            id: Some("01930000-0000-7000-8000-000000000007".to_string()),
-            name: "Edge Probe A".to_string(),
-            from_commit_id: Some(sim.initial_commit_id().to_string()),
-        })
-        .await
-        .expect("01930000-0000-7000-8000-000000000007 should be created from the initial commit");
-        main.create_branch(CreateBranchOptions {
-            id: Some("01930000-0000-7000-8000-000000000008".to_string()),
-            name: "Edge Probe B".to_string(),
-            from_commit_id: Some(sim.initial_commit_id().to_string()),
-        })
-        .await
-        .expect("01930000-0000-7000-8000-000000000008 should be created from the initial commit");
-
-        let branch_a = sim.wrap_session(
-            engine
-                .open_session_at("01930000-0000-7000-8000-000000000007")
-                .await
-                .expect("01930000-0000-7000-8000-000000000007 session should open"),
-            &engine,
-        );
-        branch_a
-            .execute(
-                "INSERT INTO lix_key_value (key, value) VALUES ('edge-probe-a-only', 'a')",
-                &[],
-            )
-            .await
-            .expect("01930000-0000-7000-8000-000000000007 write should succeed");
-
-        let branch_b = sim.wrap_session(
-            engine
-                .open_session_at("01930000-0000-7000-8000-000000000008")
-                .await
-                .expect("01930000-0000-7000-8000-000000000008 session should open"),
-            &engine,
-        );
-        branch_b
-            .execute(
-                "INSERT INTO lix_key_value (key, value) VALUES ('edge-probe-b-only', 'b')",
-                &[],
-            )
-            .await
-            .expect("01930000-0000-7000-8000-000000000008 write should succeed");
-
-        let global_edges =
-            commit_edges_by_branch(&main, "ffffffff-ffff-7fff-bfff-ffffffffffff").await;
-        for branch_id in [
-            sim.main_branch_id(),
-            "01930000-0000-7000-8000-000000000007",
-            "01930000-0000-7000-8000-000000000008",
-        ] {
-            let actual_edges = commit_edges_by_branch(&main, branch_id).await;
-            assert_eq!(
-                actual_edges, global_edges,
-                "lix_commit_edge_by_branch should project derived global edges for {branch_id}"
-            );
-        }
-    }
-);
 
 simulation_test!(
     lix_commit_surfaces_match_canonical_schema_definitions,
@@ -343,11 +187,8 @@ simulation_test!(
         );
 
         for (schema_key, tables) in [
-            ("lix_commit", vec!["lix_commit", "lix_commit_by_branch"]),
-            (
-                "lix_commit_edge",
-                vec!["lix_commit_edge", "lix_commit_edge_by_branch"],
-            ),
+            ("lix_commit", vec!["lix_commit"]),
+            ("lix_commit_edge", vec!["lix_commit_edge"]),
         ] {
             let schema_properties = builtin_schema_property_names(schema_key);
             for table in tables {
@@ -375,9 +216,7 @@ simulation_test!(
 
         for table in [
             "lix_commit",
-            "lix_commit_by_branch",
             "lix_commit_edge",
-            "lix_commit_edge_by_branch",
         ] {
             let rows = select_rows(&session, &format!("SELECT count(*) FROM {table}")).await;
             assert_single_count(rows, table);
@@ -402,24 +241,6 @@ fn text_value(value: &Value) -> String {
         panic!("expected text value, got {value:?}");
     };
     value.clone()
-}
-
-async fn commit_edges_by_branch(
-    session: &crate::support::simulation_test::engine::SimSession,
-    branch_id: &str,
-) -> BTreeSet<(String, String)> {
-    select_rows(
-        session,
-        &format!(
-            "SELECT parent_id, child_id \
-             FROM lix_commit_edge_by_branch \
-             WHERE lixcol_branch_id = '{branch_id}'"
-        ),
-    )
-    .await
-    .into_iter()
-    .map(|row| (text_value(&row[0]), text_value(&row[1])))
-    .collect()
 }
 
 fn builtin_schema_property_names(schema_key: &str) -> BTreeSet<String> {

--- a/packages/lix/tests/integration/sql/lix_directory.rs
+++ b/packages/lix/tests/integration/sql/lix_directory.rs
@@ -342,55 +342,6 @@ simulation_test!(
     }
 );
 
-simulation_test!(
-    lix_directory_by_branch_insert_duplicate_id_reports_lix_directory_by_branch,
-    |sim| async move {
-        let engine = sim.boot_engine().await;
-        let session = sim.wrap_session(
-            engine
-                .open_session()
-                .await
-                .expect("main session should open"),
-            &engine,
-        );
-        let branch_id = sim.main_branch_id();
-
-        session
-            .execute(
-                &format!(
-                    "INSERT INTO lix_directory_by_branch \
-                     (id, path, lixcol_branch_id) \
-                     VALUES ('73616d65-2d64-8972-8000-000000000000', '/a', '{branch_id}')"
-                ),
-                &[],
-            )
-            .await
-            .expect("first by-branch directory insert should succeed");
-
-        let error = session
-            .execute(
-                &format!(
-                    "INSERT INTO lix_directory_by_branch \
-                     (id, path, lixcol_branch_id) \
-                     VALUES ('73616d65-2d64-8972-8000-000000000000', '/b', '{branch_id}')"
-                ),
-                &[],
-            )
-            .await
-            .expect_err("duplicate by-branch directory id insert should be rejected");
-
-        assert_eq!(error.code, LixError::CODE_UNIQUE);
-        assert!(
-            error.message.contains("table 'lix_directory_by_branch'")
-                && error
-                    .message
-                    .contains("id '73616d65-2d64-8972-8000-000000000000'")
-                && !error.message.contains("table 'lix_directory':")
-                && !error.message.contains("lix_directory_descriptor"),
-            "unexpected error: {error:?}"
-        );
-    }
-);
 
 simulation_test!(
     lix_directory_path_insert_rejects_existing_file_entry,
@@ -779,11 +730,17 @@ simulation_test!(
             .await
             .expect("branch-local directory should be a distinct storage namespace");
 
-        let global_file = session
+        let global_session = sim.wrap_session(
+            engine
+                .open_session_at("ffffffff-ffff-7fff-bfff-ffffffffffff")
+                .await
+                .expect("global session should open"),
+            &engine,
+        );
+        let global_file = global_session
             .execute(
-                "SELECT id, path, lixcol_branch_id, lixcol_global \
-                 FROM lix_file_by_branch \
-                 WHERE id = '676c6f62-616c-8d66-896c-652d666f6f00' AND lixcol_branch_id = 'ffffffff-ffff-7fff-bfff-ffffffffffff'",
+                "SELECT id, path, lixcol_global FROM lix_file \
+                 WHERE id = '676c6f62-616c-8d66-896c-652d666f6f00'",
                 &[],
             )
             .await
@@ -878,58 +835,6 @@ simulation_test!(
     }
 );
 
-simulation_test!(
-    lix_directory_by_branch_expands_global_rows,
-    |sim| async move {
-        let engine = sim.boot_engine().await;
-        let session = sim.wrap_session(
-            engine
-                .open_session()
-                .await
-                .expect("main session should open"),
-            &engine,
-        );
-
-        session
-            .execute(
-                "INSERT INTO lix_directory (id, path, lixcol_global, lixcol_untracked) \
-                 VALUES ('6469722d-676c-8f62-816c-2d6f76657200', '/shared', true, false)",
-                &[],
-            )
-            .await
-            .expect("global directory insert should succeed");
-
-        let result = session
-            .execute(
-                "SELECT id, path, lixcol_branch_id, lixcol_global, lixcol_untracked \
-                 FROM lix_directory_by_branch \
-                 WHERE id = '6469722d-676c-8f62-816c-2d6f76657200' \
-                 ORDER BY lixcol_branch_id",
-                &[],
-            )
-            .await
-            .expect("directory by-branch read should succeed");
-        assert_rows_eq(
-            result,
-            vec![
-                vec![
-                    Value::Text("6469722d-676c-8f62-816c-2d6f76657200".to_string()),
-                    Value::Text("/shared".to_string()),
-                    Value::Text(sim.main_branch_id().to_string()),
-                    Value::Boolean(true),
-                    Value::Boolean(false),
-                ],
-                vec![
-                    Value::Text("6469722d-676c-8f62-816c-2d6f76657200".to_string()),
-                    Value::Text("/shared".to_string()),
-                    Value::Text("ffffffff-ffff-7fff-bfff-ffffffffffff".to_string()),
-                    Value::Boolean(true),
-                    Value::Boolean(false),
-                ],
-            ],
-        );
-    }
-);
 
 simulation_test!(
     lix_directory_global_path_insert_reuses_existing_global_directory,
@@ -1425,93 +1330,7 @@ simulation_test!(
     }
 );
 
-simulation_test!(
-    lix_directory_by_branch_insert_on_conflict_path_branch_do_nothing,
-    |sim| async move {
-        let engine = sim.boot_engine().await;
-        let session = sim.wrap_session(
-            engine
-                .open_session()
-                .await
-                .expect("main session should open"),
-            &engine,
-        );
-        let branch_id = sim.main_branch_id();
 
-        session
-            .execute(
-                &format!(
-                    "INSERT INTO lix_directory_by_branch \
-                     (id, path, lixcol_branch_id) \
-                     VALUES ('6469722d-6272-816e-8368-2d7061746800', '/branch-dir', '{branch_id}')"
-                ),
-                &[],
-            )
-            .await
-            .expect("seed by-branch directory insert should succeed");
-
-        let result = session
-            .execute(
-                &format!(
-                    "INSERT INTO lix_directory_by_branch \
-                     (path, lixcol_branch_id) \
-                     VALUES ('/branch-dir', '{branch_id}') \
-                     ON CONFLICT (path, lixcol_branch_id) DO NOTHING"
-                ),
-                &[],
-            )
-            .await
-            .expect("by-branch directory path upsert should succeed");
-        assert_eq!(result.rows_affected(), 0);
-
-        let read = session
-            .execute(
-                "SELECT id FROM lix_directory WHERE path = '/branch-dir'",
-                &[],
-            )
-            .await
-            .expect("directory read should succeed");
-        assert_rows_eq(
-            read,
-            vec![vec![Value::Text(
-                "6469722d-6272-816e-8368-2d7061746800".to_string(),
-            )]],
-        );
-    }
-);
-
-simulation_test!(
-    lix_directory_by_branch_insert_on_conflict_path_without_branch_target_rejects,
-    |sim| async move {
-        let engine = sim.boot_engine().await;
-        let session = sim.wrap_session(
-            engine
-                .open_session()
-                .await
-                .expect("main session should open"),
-            &engine,
-        );
-        let branch_id = sim.main_branch_id();
-
-        let error = session
-            .execute(
-                &format!(
-                    "INSERT INTO lix_directory_by_branch \
-                     (path, lixcol_branch_id) \
-                     VALUES ('/dir-reject', '{branch_id}') \
-                     ON CONFLICT (path) DO NOTHING"
-                ),
-                &[],
-            )
-            .await
-            .expect_err("by-branch path-only target should be rejected");
-        assert!(
-            error
-                .message
-                .contains("path identity columns (path, lixcol_branch_id)")
-        );
-    }
-);
 
 simulation_test!(
     lix_directory_insert_on_conflict_path_rejects_missing_path,
@@ -1605,11 +1424,17 @@ simulation_test!(
             .expect("path upsert should update visible global directory");
         assert_eq!(result.rows_affected(), 1);
 
-        let read = session
+        let global_session = sim.wrap_session(
+            engine
+                .open_session_at("ffffffff-ffff-7fff-bfff-ffffffffffff")
+                .await
+                .expect("global session should open"),
+            &engine,
+        );
+        let read = global_session
             .execute(
-                "SELECT id, lixcol_metadata, lixcol_global, lixcol_branch_id \
-                 FROM lix_directory_by_branch \
-                 WHERE id = '6469722d-676c-8f62-816c-2d7061746800' AND lixcol_branch_id = 'ffffffff-ffff-7fff-bfff-ffffffffffff'",
+                "SELECT id, lixcol_metadata, lixcol_global FROM lix_directory \
+                 WHERE id = '6469722d-676c-8f62-816c-2d7061746800'",
                 &[],
             )
             .await
@@ -1620,7 +1445,6 @@ simulation_test!(
                 Value::Text("6469722d-676c-8f62-816c-2d7061746800".to_string()),
                 Value::Jsonb(json!({"version": 2}).into()),
                 Value::Boolean(true),
-                Value::Text("ffffffff-ffff-7fff-bfff-ffffffffffff".to_string()),
             ]],
         );
     }

--- a/packages/lix/tests/integration/sql/lix_file.rs
+++ b/packages/lix/tests/integration/sql/lix_file.rs
@@ -580,30 +580,6 @@ simulation_test!(
     }
 );
 
-simulation_test!(
-    lix_file_by_branch_read_rejects_dynamic_branch_id_operand,
-    |sim| async move {
-        let engine = sim.boot_engine().await;
-        let session = sim.wrap_session(
-            engine
-                .open_session()
-                .await
-                .expect("main session should open"),
-            &engine,
-        );
-
-        let error = session
-            .execute(
-                "SELECT id FROM lix_file_by_branch WHERE lixcol_branch_id = lower('main')",
-                &[],
-            )
-            .await
-            .expect_err("public branch id predicate should only accept literal/param operands");
-
-        assert_eq!(error.code, LixError::CODE_UNSUPPORTED_SQL);
-        assert!(error.message.contains("public column 'lixcol_branch_id'"));
-    }
-);
 
 simulation_test!(
     lix_file_path_insert_preserves_long_opaque_segments,
@@ -1820,55 +1796,6 @@ simulation_test!(
     }
 );
 
-simulation_test!(
-    lix_file_by_branch_insert_duplicate_id_reports_lix_file_by_branch,
-    |sim| async move {
-        let engine = sim.boot_engine().await;
-        let session = sim.wrap_session(
-            engine
-                .open_session()
-                .await
-                .expect("main session should open"),
-            &engine,
-        );
-        let branch_id = sim.main_branch_id();
-
-        session
-            .execute(
-                &format!(
-                    "INSERT INTO lix_file_by_branch \
-                     (id, path, content, lixcol_branch_id) \
-                     VALUES ('73616d65-2d66-896c-8500-000000000000', '/a.bin', CAST('byte-01' AS BYTEA), '{branch_id}')"
-                ),
-                &[],
-            )
-            .await
-            .expect("first by-branch file insert should succeed");
-
-        let error = session
-            .execute(
-                &format!(
-                    "INSERT INTO lix_file_by_branch \
-                     (id, path, content, lixcol_branch_id) \
-                     VALUES ('73616d65-2d66-896c-8500-000000000000', '/b.bin', CAST('byte-02' AS BYTEA), '{branch_id}')"
-                ),
-                &[],
-            )
-            .await
-            .expect_err("duplicate by-branch file id insert should be rejected");
-
-        assert_eq!(error.code, LixError::CODE_UNIQUE);
-        assert!(
-            error.message.contains("table 'lix_file_by_branch'")
-                && error
-                    .message
-                    .contains("id '73616d65-2d66-896c-8500-000000000000'")
-                && !error.message.contains("table 'lix_file':")
-                && !error.message.contains("lix_binary_blob_ref"),
-            "unexpected error: {error:?}"
-        );
-    }
-);
 
 simulation_test!(
     lix_file_path_insert_rejects_existing_directory_entry,
@@ -3079,55 +3006,6 @@ simulation_test!(
     }
 );
 
-simulation_test!(lix_file_by_branch_expands_global_rows, |sim| async move {
-    let engine = sim.boot_engine().await;
-    let session = sim.wrap_session(
-        engine
-            .open_session()
-            .await
-            .expect("main session should open"),
-        &engine,
-    );
-
-    session
-        .execute(
-            "INSERT INTO lix_file (id, path, content, lixcol_global, lixcol_untracked) \
-             VALUES ('66696c65-2d67-8c6f-8261-6c2d6f766500', '/global.txt', CAST('g' AS BYTEA), true, false)",
-            &[],
-        )
-        .await
-        .expect("global file insert should succeed");
-
-    let result = session
-        .execute(
-            "SELECT id, path, lixcol_branch_id, lixcol_global, lixcol_untracked \
-             FROM lix_file_by_branch \
-             WHERE id = '66696c65-2d67-8c6f-8261-6c2d6f766500' \
-             ORDER BY lixcol_branch_id",
-            &[],
-        )
-        .await
-        .expect("file by-branch read should succeed");
-    assert_rows_eq(
-        result,
-        vec![
-            vec![
-                Value::Text("66696c65-2d67-8c6f-8261-6c2d6f766500".to_string()),
-                Value::Text("/global.txt".to_string()),
-                Value::Text(sim.main_branch_id().to_string()),
-                Value::Boolean(true),
-                Value::Boolean(false),
-            ],
-            vec![
-                Value::Text("66696c65-2d67-8c6f-8261-6c2d6f766500".to_string()),
-                Value::Text("/global.txt".to_string()),
-                Value::Text("ffffffff-ffff-7fff-bfff-ffffffffffff".to_string()),
-                Value::Boolean(true),
-                Value::Boolean(false),
-            ],
-        ],
-    );
-});
 
 simulation_test!(
     lix_file_global_path_insert_reuses_existing_global_directory,
@@ -3539,94 +3417,7 @@ simulation_test!(
     }
 );
 
-simulation_test!(
-    lix_file_by_branch_insert_on_conflict_path_branch_updates_existing,
-    |sim| async move {
-        let engine = sim.boot_engine().await;
-        let session = sim.wrap_session(
-            engine
-                .open_session()
-                .await
-                .expect("main session should open"),
-            &engine,
-        );
-        let branch_id = sim.main_branch_id();
 
-        session
-            .execute(
-                &format!(
-                    "INSERT INTO lix_file_by_branch \
-                     (id, path, content, lixcol_branch_id) \
-                     VALUES ('66696c65-2d62-8261-8e63-682d70617400', '/docs/branch.md', CAST('old' AS BYTEA), '{branch_id}')"
-                ),
-                &[],
-            )
-            .await
-            .expect("seed by-branch insert should succeed");
-
-        let result = session
-            .execute(
-                &format!(
-                    "INSERT INTO lix_file_by_branch \
-                     (path, content, lixcol_branch_id) \
-                     VALUES ('/docs/branch.md', CAST('new' AS BYTEA), '{branch_id}') \
-                     ON CONFLICT (path, lixcol_branch_id) DO UPDATE SET content = excluded.content"
-                ),
-                &[],
-            )
-            .await
-            .expect("by-branch path upsert should succeed");
-        assert_eq!(result.rows_affected(), 1);
-
-        let read = session
-            .execute(
-                "SELECT id, content FROM lix_file WHERE path = '/docs/branch.md'",
-                &[],
-            )
-            .await
-            .expect("file read should succeed");
-        assert_rows_eq(
-            read,
-            vec![vec![
-                Value::Text("66696c65-2d62-8261-8e63-682d70617400".to_string()),
-                Value::Blob(b"new".to_vec().into()),
-            ]],
-        );
-    }
-);
-
-simulation_test!(
-    lix_file_by_branch_insert_on_conflict_path_without_branch_target_rejects,
-    |sim| async move {
-        let engine = sim.boot_engine().await;
-        let session = sim.wrap_session(
-            engine
-                .open_session()
-                .await
-                .expect("main session should open"),
-            &engine,
-        );
-        let branch_id = sim.main_branch_id();
-
-        let error = session
-            .execute(
-                &format!(
-                    "INSERT INTO lix_file_by_branch \
-                     (path, content, lixcol_branch_id) \
-                     VALUES ('/docs/reject.md', CAST('byte-00' AS BYTEA), '{branch_id}') \
-                     ON CONFLICT (path) DO UPDATE SET content = excluded.content"
-                ),
-                &[],
-            )
-            .await
-            .expect_err("by-branch path-only target should be rejected");
-        assert!(
-            error
-                .message
-                .contains("path identity columns (path, lixcol_branch_id)")
-        );
-    }
-);
 
 simulation_test!(
     lix_file_insert_on_conflict_path_rejects_missing_path,
@@ -3720,11 +3511,17 @@ simulation_test!(
             .expect("path upsert should update visible global file");
         assert_eq!(result.rows_affected(), 1);
 
-        let read = session
+        let global_session = sim.wrap_session(
+            engine
+                .open_session_at("ffffffff-ffff-7fff-bfff-ffffffffffff")
+                .await
+                .expect("global session should open"),
+            &engine,
+        );
+        let read = global_session
             .execute(
-                "SELECT id, content, lixcol_global, lixcol_branch_id \
-                 FROM lix_file_by_branch \
-                 WHERE id = '66696c65-2d67-8c6f-8261-6c2d70617400' AND lixcol_branch_id = 'ffffffff-ffff-7fff-bfff-ffffffffffff'",
+                "SELECT id, content, lixcol_global FROM lix_file \
+                 WHERE id = '66696c65-2d67-8c6f-8261-6c2d70617400'",
                 &[],
             )
             .await
@@ -3735,7 +3532,6 @@ simulation_test!(
                 Value::Text("66696c65-2d67-8c6f-8261-6c2d70617400".to_string()),
                 Value::Blob(b"new".to_vec().into()),
                 Value::Boolean(true),
-                Value::Text("ffffffff-ffff-7fff-bfff-ffffffffffff".to_string()),
             ]],
         );
     }
@@ -3924,24 +3720,19 @@ simulation_test!(
                 .expect("main session should open"),
             &engine,
         );
-        let branch_id = sim.main_branch_id();
-
         session
             .execute(
-                "INSERT INTO lix_file_by_branch \
-                 (id, path, content, lixcol_global, lixcol_branch_id) \
-                 VALUES ('6c616e65-2d66-896c-8500-000000000000', '/global.md', CAST('byte-01' AS BYTEA), true, 'ffffffff-ffff-7fff-bfff-ffffffffffff')",
+                "INSERT INTO lix_file \
+                 (id, path, content, lixcol_global) \
+                 VALUES ('6c616e65-2d66-896c-8500-000000000000', '/global.md', CAST('byte-01' AS BYTEA), true)",
                 &[],
             )
             .await
             .expect("global lane file should insert");
         session
             .execute(
-                &format!(
-                    "INSERT INTO lix_file_by_branch \
-                     (id, path, content, lixcol_branch_id) \
-                     VALUES ('6c616e65-2d66-896c-8500-000000000000', '/branch.md', CAST('byte-02' AS BYTEA), '{branch_id}')"
-                ),
+                "INSERT INTO lix_file (id, path, content) \
+                 VALUES ('6c616e65-2d66-896c-8500-000000000000', '/branch.md', CAST('byte-02' AS BYTEA))",
                 &[],
             )
             .await
@@ -3977,10 +3768,8 @@ simulation_test!(
 
         let deleted = transaction
             .execute(
-                &format!(
-                    "DELETE FROM lix_file_by_branch \
-                     WHERE id = '6c616e65-2d66-896c-8500-000000000000' AND lixcol_branch_id = '{branch_id}'"
-                ),
+                "DELETE FROM lix_file \
+                 WHERE id = '6c616e65-2d66-896c-8500-000000000000'",
                 &[],
             )
             .await

--- a/packages/lix/tests/integration/sql/lix_key_value.rs
+++ b/packages/lix/tests/integration/sql/lix_key_value.rs
@@ -343,51 +343,6 @@ simulation_test!(
     }
 );
 
-simulation_test!(
-    lix_key_value_by_branch_on_conflict_upserts_global_row,
-    |sim| async move {
-        let engine = sim.boot_engine().await;
-        let session = sim.wrap_session(
-            engine
-                .open_session()
-                .await
-                .expect("main session should open"),
-            &engine,
-        );
-
-        session
-            .execute(
-                "INSERT INTO lix_key_value_by_branch \
-             (key, value, lixcol_branch_id, lixcol_global, lixcol_untracked) \
-             VALUES ('kv-upsert-global', 'first', 'ffffffff-ffff-7fff-bfff-ffffffffffff', true, true) \
-             ON CONFLICT(key, lixcol_branch_id) DO UPDATE SET value = excluded.value",
-                &[],
-            )
-            .await
-            .expect("initial global upsert should insert");
-
-        session
-            .execute(
-                "INSERT INTO lix_key_value_by_branch \
-             (key, value, lixcol_branch_id, lixcol_global, lixcol_untracked) \
-             VALUES ('kv-upsert-global', 'second', 'ffffffff-ffff-7fff-bfff-ffffffffffff', true, true) \
-             ON CONFLICT(key, lixcol_branch_id) DO UPDATE SET value = excluded.value",
-                &[],
-            )
-            .await
-            .expect("second global upsert should update");
-
-        let result = session
-            .execute(
-                "SELECT value FROM lix_key_value_by_branch \
-             WHERE key = 'kv-upsert-global' AND lixcol_branch_id = 'ffffffff-ffff-7fff-bfff-ffffffffffff'",
-                &[],
-            )
-            .await
-            .expect("select should succeed");
-        assert_single_text(result, "\"second\"");
-    }
-);
 
 fn assert_single_text(result: ExecuteResult, expected: &str) {
     let row_set = result;

--- a/packages/lix/tests/integration/sql/lix_registered_schema.rs
+++ b/packages/lix/tests/integration/sql/lix_registered_schema.rs
@@ -433,16 +433,11 @@ simulation_test!(
 
         for surface_name in [
             "lix_key_value",
-            "lix_key_value_by_branch",
             "lix_registered_schema",
-            "lix_registered_schema_by_branch",
             "lix_checkpoint",
             "lix_working_diff",
-            "lix_working_diff_by_branch",
             "lix_file_working_diff",
-            "lix_file_working_diff_by_branch",
             "lix_directory_working_diff",
-            "lix_directory_working_diff_by_branch",
         ] {
             assert!(
                 public_table_names.contains(surface_name),
@@ -469,6 +464,11 @@ simulation_test!(
             ],
         );
         for surface_name in [
+            "lix_key_value_by_branch",
+            "lix_registered_schema_by_branch",
+            "lix_working_diff_by_branch",
+            "lix_file_working_diff_by_branch",
+            "lix_directory_working_diff_by_branch",
             "lix_binary_blob_ref",
             "lix_binary_blob_ref_by_branch",
             "lix_binary_blob_ref_history",
@@ -739,55 +739,6 @@ simulation_test!(
     }
 );
 
-simulation_test!(
-    row_by_branch_insert_rejects_target_branch_without_schema,
-    |sim| async move {
-        let engine = sim.boot_engine().await;
-        let main = sim.wrap_session(
-            engine
-                .open_session_at(sim.main_branch_id())
-                .await
-                .expect("main session should open"),
-            &engine,
-        );
-
-        main.create_branch(CreateBranchOptions {
-            id: Some("01930000-0000-7000-8000-000000000015".to_string()),
-            name: "Schemaless Target".to_string(),
-            from_commit_id: None,
-        })
-        .await
-        .expect("target branch should be created before schema registration");
-
-        main.execute(
-            "INSERT INTO lix_registered_schema (value, lixcol_global, lixcol_untracked) \
-             VALUES (\
-             CAST('{\"$schema\":\"https://lix.dev/schema-v1.json\",\"key\":\"engine_poison_schema\",\"columns\":[{\"name\":\"id\",\"type\":\"text\",\"nullable\":false},{\"name\":\"name\",\"type\":\"text\",\"nullable\":false}],\"primary_key\":[\"id\"]}' AS JSONB),\
-             false,\
-             false\
-             )",
-            &[],
-        )
-        .await
-        .expect("schema should be visible on active main");
-
-        let error = main
-            .execute(
-                "INSERT INTO engine_poison_schema_by_branch \
-                 (id, name, lixcol_branch_id, lixcol_untracked) \
-                 VALUES ('poison-1', 'Poisoned', '01930000-0000-7000-8000-000000000015', true)",
-                &[],
-            )
-            .await
-            .expect_err("_by_branch write must use the target branch schema catalog");
-
-        assert_eq!(error.code, LixError::CODE_SCHEMA_DEFINITION);
-        assert!(
-            error.message.contains("engine_poison_schema"),
-            "unexpected error: {error:?}"
-        );
-    }
-);
 
 simulation_test!(
     registered_schema_identity_is_scoped_per_branch,
@@ -997,86 +948,6 @@ simulation_test!(
     }
 );
 
-simulation_test!(
-    row_by_branch_insert_rejects_fk_graph_when_target_branch_lacks_schemas,
-    |sim| async move {
-        let engine = sim.boot_engine().await;
-        let main = sim.wrap_session(
-            engine
-                .open_session_at(sim.main_branch_id())
-                .await
-                .expect("main session should open"),
-            &engine,
-        );
-
-        main.create_branch(CreateBranchOptions {
-            id: Some("01930000-0000-7000-8000-000000000013".to_string()),
-            name: "FK Schemaless Target".to_string(),
-            from_commit_id: None,
-        })
-        .await
-        .expect("target branch should be created before FK schemas");
-
-        main.execute(
-            "INSERT INTO lix_registered_schema (value, lixcol_global, lixcol_untracked) \
-             VALUES (\
-             CAST('{\"$schema\":\"https://lix.dev/schema-v1.json\",\"key\":\"engine_fk_parent_schema\",\"columns\":[{\"name\":\"id\",\"type\":\"text\",\"nullable\":false}],\"primary_key\":[\"id\"]}' AS JSONB),\
-             false,\
-             false\
-             )",
-            &[],
-        )
-        .await
-        .expect("parent schema should register on active main");
-
-        main.execute(
-            "INSERT INTO lix_registered_schema (value, lixcol_global, lixcol_untracked) \
-             VALUES (\
-             CAST('{\"$schema\":\"https://lix.dev/schema-v1.json\",\"key\":\"engine_fk_child_schema\",\"columns\":[{\"name\":\"id\",\"type\":\"text\",\"nullable\":false},{\"name\":\"parent_id\",\"type\":\"text\",\"nullable\":false}],\"primary_key\":[\"id\"],\"foreign_keys\":[{\"columns\":[\"parent_id\"],\"references\":{\"schema_key\":\"engine_fk_parent_schema\",\"columns\":[\"id\"]}}]}' AS JSONB),\
-             false,\
-             false\
-             )",
-            &[],
-        )
-        .await
-        .expect("child schema should register on active main");
-
-        let parent_result = main
-            .execute(
-                "INSERT INTO engine_fk_parent_schema_by_branch \
-                 (id, lixcol_branch_id, lixcol_untracked) \
-                 VALUES ('parent-1', '01930000-0000-7000-8000-000000000013', true)",
-                &[],
-            )
-            .await;
-
-        if let Err(error) = parent_result {
-            assert_eq!(error.code, LixError::CODE_SCHEMA_DEFINITION);
-            assert!(
-                error.message.contains("engine_fk_parent_schema"),
-                "unexpected error: {error:?}"
-            );
-            return;
-        }
-
-        let error = main
-            .execute(
-                "INSERT INTO engine_fk_child_schema_by_branch \
-                 (id, parent_id, lixcol_branch_id, lixcol_untracked) \
-                 VALUES ('child-1', 'parent-1', '01930000-0000-7000-8000-000000000013', true)",
-                &[],
-            )
-            .await
-            .expect_err("FK-valid active graph must not be insertable into a schemaless target");
-
-        assert_eq!(error.code, LixError::CODE_SCHEMA_DEFINITION);
-        assert!(
-            error.message.contains("engine_fk_child_schema")
-                || error.message.contains("engine_fk_parent_schema"),
-            "unexpected error: {error:?}"
-        );
-    }
-);
 
 simulation_test!(
     registered_row_insert_applies_defaulted_primary_key,
@@ -1199,89 +1070,6 @@ simulation_test!(
     }
 );
 
-simulation_test!(row_by_branch_expands_global_rows, |sim| async move {
-    let engine = sim.boot_engine().await;
-    let global_session = sim.wrap_session(
-        engine
-            .open_session_at("ffffffff-ffff-7fff-bfff-ffffffffffff")
-            .await
-            .expect("global session should open"),
-        &engine,
-    );
-    let session = sim.wrap_session(
-        engine
-            .open_session()
-            .await
-            .expect("main session should open"),
-        &engine,
-    );
-
-    global_session
-        .execute(
-            "INSERT INTO lix_registered_schema (value, lixcol_global, lixcol_untracked) \
-             VALUES (\
-             CAST('{\"$schema\":\"https://lix.dev/schema-v1.json\",\"key\":\"engine_overlay_schema\",\"columns\":[{\"name\":\"id\",\"type\":\"text\",\"nullable\":false},{\"name\":\"name\",\"type\":\"text\",\"nullable\":false}],\"primary_key\":[\"id\"]}' AS JSONB),\
-             true,\
-             false\
-             )",
-            &[],
-        )
-        .await
-        .expect("global registered schema insert should succeed");
-
-    session
-        .execute(
-            "INSERT INTO lix_registered_schema (value, lixcol_global, lixcol_untracked) \
-             VALUES (\
-             CAST('{\"$schema\":\"https://lix.dev/schema-v1.json\",\"key\":\"engine_overlay_schema\",\"columns\":[{\"name\":\"id\",\"type\":\"text\",\"nullable\":false},{\"name\":\"name\",\"type\":\"text\",\"nullable\":false}],\"primary_key\":[\"id\"]}' AS JSONB),\
-             false,\
-             false\
-             )",
-            &[],
-        )
-        .await
-        .expect("registered schema insert should succeed");
-
-    session
-        .execute(
-            "INSERT INTO engine_overlay_schema \
-                 (id, name, lixcol_global, lixcol_untracked) \
-                 VALUES ('row-global-overlay', 'Global Row', true, false)",
-            &[],
-        )
-        .await
-        .expect("global row insert should succeed");
-
-    let result = session
-        .execute(
-            "SELECT id, name, lixcol_branch_id, lixcol_global, lixcol_untracked \
-                 FROM engine_overlay_schema_by_branch \
-                 WHERE lixcol_row_pk = CAST('[\"row-global-overlay\"]' AS JSONB) \
-                 ORDER BY lixcol_branch_id",
-            &[],
-        )
-        .await
-        .expect("row by-branch read should succeed");
-    assert_rows_eq(
-        result,
-        vec![
-            vec![
-                Value::Text("row-global-overlay".to_string()),
-                Value::Text("Global Row".to_string()),
-                Value::Text(sim.main_branch_id().to_string()),
-                Value::Boolean(true),
-                Value::Boolean(false),
-            ],
-            vec![
-                Value::Text("row-global-overlay".to_string()),
-                Value::Text("Global Row".to_string()),
-                Value::Text("ffffffff-ffff-7fff-bfff-ffffffffffff".to_string()),
-                Value::Boolean(true),
-                Value::Boolean(false),
-            ],
-        ],
-    );
-});
 
 simulation_test!(
     global_row_insert_rejects_active_only_schema,
@@ -1703,16 +1491,14 @@ simulation_test!(
             .expect_err("base row table should not expose lixcol_branch_id");
         assert_eq!(error.code, LixError::CODE_COLUMN_NOT_FOUND);
 
-        let result = main
+        let result = draft
             .execute(
-                "SELECT name \
-                 FROM engine_base_branch_filter_schema_by_branch \
-                 WHERE lixcol_row_pk = CAST('[\"row-1\"]' AS JSONB) \
-                   AND lixcol_branch_id = '01930000-0000-7000-8000-00000000000d'",
+                "SELECT name FROM engine_base_branch_filter_schema \
+                 WHERE lixcol_row_pk = CAST('[\"row-1\"]' AS JSONB)",
                 &[],
             )
             .await
-            .expect("by-branch query should succeed");
+            .expect("draft branch query should succeed");
         assert_rows_eq(result, vec![vec![Value::Text("draft".to_string())]]);
     }
 );
@@ -1760,16 +1546,21 @@ simulation_test!(
             .expect_err("base row table should not expose lixcol_branch_id");
         assert_eq!(error.code, LixError::CODE_COLUMN_NOT_FOUND);
 
-        let result = main
+        let draft = sim.wrap_session(
+            engine
+                .open_session_at("01930000-0000-7000-8000-00000000000e")
+                .await
+                .expect("draft session should open"),
+            &engine,
+        );
+        let result = draft
             .execute(
-                "SELECT name \
-                 FROM engine_base_insert_branch_schema_by_branch \
-                 WHERE lixcol_row_pk = CAST('[\"row-1\"]' AS JSONB) \
-                   AND lixcol_branch_id = '01930000-0000-7000-8000-00000000000e'",
+                "SELECT name FROM engine_base_insert_branch_schema \
+                 WHERE lixcol_row_pk = CAST('[\"row-1\"]' AS JSONB)",
                 &[],
             )
             .await
-            .expect("by-branch query should succeed");
+            .expect("draft branch query should succeed");
         assert_rows_eq(result, vec![]);
     }
 );
@@ -1948,322 +1739,26 @@ simulation_test!(
             .expect_err("base row table should not expose lixcol_branch_id");
         assert_eq!(error.code, LixError::CODE_COLUMN_NOT_FOUND);
 
-        let result = main
+        let draft = sim.wrap_session(
+            engine
+                .open_session_at("01930000-0000-7000-8000-00000000000e")
+                .await
+                .expect("draft session should open"),
+            &engine,
+        );
+        let result = draft
             .execute(
-                "SELECT id \
-                 FROM engine_base_branch_insert_schema_by_branch \
-                 WHERE lixcol_branch_id = '01930000-0000-7000-8000-00000000000e'",
+                "SELECT id FROM engine_base_branch_insert_schema",
                 &[],
             )
             .await
-            .expect("by-branch query should succeed");
+            .expect("draft branch query should succeed");
         assert_rows_eq(result, Vec::<Vec<Value>>::new());
     }
 );
 
-simulation_test!(
-    typed_row_by_branch_delete_requires_explicit_branch_filter,
-    |sim| async move {
-        let engine = sim.boot_engine().await;
-        let main = sim.wrap_session(
-            engine
-                .open_session_at(sim.main_branch_id())
-                .await
-                .expect("main session should open"),
-            &engine,
-        );
 
-        main.execute(
-            "INSERT INTO lix_registered_schema (value, lixcol_global, lixcol_untracked) \
-             VALUES (\
-             CAST('{\"$schema\":\"https://lix.dev/schema-v1.json\",\"key\":\"engine_by_branch_delete_scope_schema\",\"columns\":[{\"name\":\"id\",\"type\":\"text\",\"nullable\":false},{\"name\":\"name\",\"type\":\"text\",\"nullable\":false}],\"primary_key\":[\"id\"]}' AS JSONB),\
-             false,\
-             false\
-             )",
-            &[],
-        )
-        .await
-        .expect("registered schema insert should succeed");
 
-        main.create_branch(CreateBranchOptions {
-            id: Some("01930000-0000-7000-8000-000000000010".to_string()),
-            name: "By-branch Delete Draft".to_string(),
-            from_commit_id: None,
-        })
-        .await
-        .expect("draft branch should be created after schema registration");
-
-        main.execute(
-            "INSERT INTO engine_by_branch_delete_scope_schema \
-             (id, name, lixcol_global, lixcol_untracked) \
-             VALUES ('row-1', 'main', false, false)",
-            &[],
-        )
-        .await
-        .expect("main row insert should succeed");
-
-        let draft = sim.wrap_session(
-            engine
-                .open_session_at("01930000-0000-7000-8000-000000000010")
-                .await
-                .expect("draft session should open"),
-            &engine,
-        );
-        draft
-            .execute(
-                "INSERT INTO engine_by_branch_delete_scope_schema \
-                 (id, name, lixcol_global, lixcol_untracked) \
-                 VALUES ('row-1', 'draft', false, false)",
-                &[],
-            )
-            .await
-            .expect("draft row insert should succeed");
-
-        main.execute(
-            "DELETE FROM engine_by_branch_delete_scope_schema_by_branch \
-             WHERE lixcol_row_pk = '[\"row-1\"]'",
-            &[],
-        )
-        .await
-        .expect_err("_by_branch delete should not delete all branches without a branch filter");
-
-        let result = main
-            .execute(
-                &format!(
-                    "SELECT name, lixcol_branch_id \
-                 FROM engine_by_branch_delete_scope_schema_by_branch \
-                 WHERE lixcol_row_pk = CAST('[\"row-1\"]' AS JSONB) \
-                   AND lixcol_branch_id IN ('{}', '01930000-0000-7000-8000-000000000010') \
-                 ORDER BY name",
-                    sim.main_branch_id()
-                ),
-                &[],
-            )
-            .await
-            .expect("by-branch query should succeed");
-        assert_rows_eq(
-            result,
-            vec![
-                vec![
-                    Value::Text("draft".to_string()),
-                    Value::Text("01930000-0000-7000-8000-000000000010".to_string()),
-                ],
-                vec![
-                    Value::Text("main".to_string()),
-                    Value::Text(sim.main_branch_id().to_string()),
-                ],
-            ],
-        );
-    }
-);
-
-simulation_test!(
-    typed_row_by_branch_update_requires_explicit_branch_filter,
-    |sim| async move {
-        let engine = sim.boot_engine().await;
-        let main = sim.wrap_session(
-            engine
-                .open_session_at(sim.main_branch_id())
-                .await
-                .expect("main session should open"),
-            &engine,
-        );
-
-        main.execute(
-            "INSERT INTO lix_registered_schema (value, lixcol_global, lixcol_untracked) \
-             VALUES (\
-             CAST('{\"$schema\":\"https://lix.dev/schema-v1.json\",\"key\":\"engine_by_branch_update_scope_schema\",\"columns\":[{\"name\":\"id\",\"type\":\"text\",\"nullable\":false},{\"name\":\"name\",\"type\":\"text\",\"nullable\":false}],\"primary_key\":[\"id\"]}' AS JSONB),\
-             false,\
-             false\
-             )",
-            &[],
-        )
-        .await
-        .expect("registered schema insert should succeed");
-
-        main.create_branch(CreateBranchOptions {
-            id: Some("01930000-0000-7000-8000-000000000011".to_string()),
-            name: "By-branch Update Draft".to_string(),
-            from_commit_id: None,
-        })
-        .await
-        .expect("draft branch should be created after schema registration");
-
-        main.execute(
-            "INSERT INTO engine_by_branch_update_scope_schema \
-             (id, name, lixcol_global, lixcol_untracked) \
-             VALUES ('row-1', 'main', false, false)",
-            &[],
-        )
-        .await
-        .expect("main row insert should succeed");
-
-        let draft = sim.wrap_session(
-            engine
-                .open_session_at("01930000-0000-7000-8000-000000000011")
-                .await
-                .expect("draft session should open"),
-            &engine,
-        );
-        draft
-            .execute(
-                "INSERT INTO engine_by_branch_update_scope_schema \
-                 (id, name, lixcol_global, lixcol_untracked) \
-                 VALUES ('row-1', 'draft', false, false)",
-                &[],
-            )
-            .await
-            .expect("draft row insert should succeed");
-
-        main.execute(
-            "UPDATE engine_by_branch_update_scope_schema_by_branch \
-             SET name = 'updated-all' \
-             WHERE lixcol_row_pk = '[\"row-1\"]'",
-            &[],
-        )
-        .await
-        .expect_err("_by_branch update should not update all branches without a branch filter");
-
-        let result = main
-            .execute(
-                &format!(
-                    "SELECT name, lixcol_branch_id \
-                 FROM engine_by_branch_update_scope_schema_by_branch \
-                 WHERE lixcol_row_pk = CAST('[\"row-1\"]' AS JSONB) \
-                   AND lixcol_branch_id IN ('{}', '01930000-0000-7000-8000-000000000011') \
-                 ORDER BY name",
-                    sim.main_branch_id()
-                ),
-                &[],
-            )
-            .await
-            .expect("by-branch query should succeed");
-        assert_rows_eq(
-            result,
-            vec![
-                vec![
-                    Value::Text("draft".to_string()),
-                    Value::Text("01930000-0000-7000-8000-000000000011".to_string()),
-                ],
-                vec![
-                    Value::Text("main".to_string()),
-                    Value::Text(sim.main_branch_id().to_string()),
-                ],
-            ],
-        );
-    }
-);
-
-simulation_test!(
-    typed_row_by_branch_dml_rejects_branch_id_alias,
-    |sim| async move {
-        let engine = sim.boot_engine().await;
-        let main = sim.wrap_session(
-            engine
-                .open_session_at(sim.main_branch_id())
-                .await
-                .expect("main session should open"),
-            &engine,
-        );
-
-        main.execute(
-            "INSERT INTO lix_registered_schema (value, lixcol_global, lixcol_untracked) \
-             VALUES (\
-             CAST('{\"$schema\":\"https://lix.dev/schema-v1.json\",\"key\":\"engine_by_branch_alias_scope_schema\",\"columns\":[{\"name\":\"id\",\"type\":\"text\",\"nullable\":false},{\"name\":\"name\",\"type\":\"text\",\"nullable\":false}],\"primary_key\":[\"id\"]}' AS JSONB),\
-             false,\
-             false\
-             )",
-            &[],
-        )
-        .await
-        .expect("registered schema insert should succeed");
-
-        main.create_branch(CreateBranchOptions {
-            id: Some("01930000-0000-7000-8000-00000000000f".to_string()),
-            name: "By-branch Alias Draft".to_string(),
-            from_commit_id: None,
-        })
-        .await
-        .expect("draft branch should be created after schema registration");
-
-        main.execute(
-            "INSERT INTO engine_by_branch_alias_scope_schema \
-             (id, name, lixcol_global, lixcol_untracked) \
-             VALUES ('row-1', 'main', false, false)",
-            &[],
-        )
-        .await
-        .expect("main row insert should succeed");
-
-        let draft = sim.wrap_session(
-            engine
-                .open_session_at("01930000-0000-7000-8000-00000000000f")
-                .await
-                .expect("draft session should open"),
-            &engine,
-        );
-        draft
-            .execute(
-                "INSERT INTO engine_by_branch_alias_scope_schema \
-                 (id, name, lixcol_global, lixcol_untracked) \
-                 VALUES ('row-1', 'draft', false, false)",
-                &[],
-            )
-            .await
-            .expect("draft row insert should succeed");
-
-        let update_error = main
-            .execute(
-                "UPDATE engine_by_branch_alias_scope_schema_by_branch \
-                 SET name = 'updated-via-alias' \
-                 WHERE lixcol_row_pk = '[\"row-1\"]' \
-                   AND branch_id = '01930000-0000-7000-8000-00000000000f'",
-                &[],
-            )
-            .await
-            .expect_err("_by_branch update should not accept branch_id alias");
-        assert_eq!(update_error.code, LixError::CODE_COLUMN_NOT_FOUND);
-
-        let delete_error = main
-            .execute(
-                "DELETE FROM engine_by_branch_alias_scope_schema_by_branch \
-                 WHERE lixcol_row_pk = '[\"row-1\"]' \
-                   AND branch_id = '01930000-0000-7000-8000-00000000000f'",
-                &[],
-            )
-            .await
-            .expect_err("_by_branch delete should not accept branch_id alias");
-        assert_eq!(delete_error.code, LixError::CODE_COLUMN_NOT_FOUND);
-
-        let result = main
-            .execute(
-                &format!(
-                    "SELECT name, lixcol_branch_id \
-                 FROM engine_by_branch_alias_scope_schema_by_branch \
-                 WHERE lixcol_row_pk = CAST('[\"row-1\"]' AS JSONB) \
-                   AND lixcol_branch_id IN ('{}', '01930000-0000-7000-8000-00000000000f') \
-                 ORDER BY name",
-                    sim.main_branch_id()
-                ),
-                &[],
-            )
-            .await
-            .expect("by-branch query should succeed");
-        assert_rows_eq(
-            result,
-            vec![
-                vec![
-                    Value::Text("draft".to_string()),
-                    Value::Text("01930000-0000-7000-8000-00000000000f".to_string()),
-                ],
-                vec![
-                    Value::Text("main".to_string()),
-                    Value::Text(sim.main_branch_id().to_string()),
-                ],
-            ],
-        );
-    }
-);
 
 simulation_test!(
     typed_row_update_rejects_duplicate_assignments,

--- a/packages/lix/tests/integration/sql/write_returning.rs
+++ b/packages/lix/tests/integration/sql/write_returning.rs
@@ -140,28 +140,11 @@ simulation_test!(
         assert_eq!(no_op.columns(), ["id", "title"]);
         assert!(no_op.rows().is_empty());
 
-        let by_branch = session
-            .execute(
-                "INSERT INTO returning_task_by_branch (id, title, lixcol_branch_id) \
-                 VALUES ('01920000-0000-7000-8000-000000000002', 'By branch', $1) \
-                 RETURNING id, title, lixcol_branch_id",
-                &[Value::Text(sim.main_branch_id().to_string())],
-            )
-            .await
-            .expect("by-branch row INSERT RETURNING should succeed");
-        assert_rows_eq(
-            by_branch,
-            vec![vec![
-                Value::Text("01920000-0000-7000-8000-000000000002".to_string()),
-                Value::Text("By branch".to_string()),
-                Value::Text(sim.main_branch_id().to_string()),
-            ]],
-        );
     }
 );
 
 simulation_test!(
-    filesystem_and_branch_surfaces_return_postimages_for_insert_update_and_upsert,
+    filesystem_and_branch_catalog_surfaces_return_postimages_for_insert_update_and_upsert,
     |sim| async move {
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
@@ -329,129 +312,6 @@ simulation_test!(
             ]],
         );
 
-        let explicit_branch_id = sim.main_branch_id().to_string();
-        let inserted_file_by_branch = session
-            .execute(
-                "INSERT INTO lix_file_by_branch (path, content, lixcol_branch_id) \
-                 VALUES ('/returning-by-branch-file.txt', CAST('byte-01' AS BYTEA), $1) \
-                 RETURNING id, path, lixcol_branch_id",
-                &[Value::Text(explicit_branch_id.clone())],
-            )
-            .await
-            .expect("by-branch file INSERT RETURNING should succeed");
-        let [
-            Value::Text(file_by_branch_id),
-            Value::Text(file_by_branch_path),
-            Value::Text(returned_branch_id),
-        ] = inserted_file_by_branch.rows()[0].values()
-        else {
-            panic!("by-branch file INSERT RETURNING should expose its postimage")
-        };
-        assert_eq!(file_by_branch_path, "/returning-by-branch-file.txt");
-        assert_eq!(returned_branch_id, &explicit_branch_id);
-        let file_by_branch_id = file_by_branch_id.clone();
-
-        let upserted_file_by_branch = session
-            .execute(
-                "INSERT INTO lix_file_by_branch (path, content, lixcol_branch_id) \
-                 VALUES ('/returning-by-branch-file.txt', $2, $1) \
-                 ON CONFLICT (path, lixcol_branch_id) DO UPDATE SET content = excluded.content \
-                 RETURNING id, content, lixcol_branch_id",
-                &[
-                    Value::Text(explicit_branch_id.clone()),
-                    Value::Blob(vec![2].into()),
-                ],
-            )
-            .await
-            .expect("by-branch file UPSERT RETURNING should expose its postimage");
-        assert_rows_eq(
-            upserted_file_by_branch,
-            vec![vec![
-                Value::Text(file_by_branch_id),
-                Value::Blob(vec![2].into()),
-                Value::Text(explicit_branch_id.clone()),
-            ]],
-        );
-
-        let global_file_id = "72657475-726e-896e-872d-676c6f62616c";
-        session
-            .execute(
-                "INSERT INTO lix_file_by_branch \
-                 (id, path, content, lixcol_global, lixcol_branch_id) \
-                 VALUES ($1, '/returning-global-file.txt', CAST('byte-01' AS BYTEA), true, \
-                         'ffffffff-ffff-7fff-bfff-ffffffffffff')",
-                &[Value::Text(global_file_id.to_string())],
-            )
-            .await
-            .expect("global file seed should succeed");
-
-        // A global file is rendered in an explicit branch with that consumer
-        // branch's id. RETURNING must preserve that readback identity rather
-        // than re-validate the rendered row as a new global write.
-        let updated_global_projection = session
-            .execute(
-                "UPDATE lix_file_by_branch SET content = CAST('byte-03' AS BYTEA) \
-                 WHERE id = $1 AND lixcol_branch_id = $2 \
-                 RETURNING id, path, lixcol_branch_id, lixcol_global",
-                &[
-                    Value::Text(global_file_id.to_string()),
-                    Value::Text(explicit_branch_id.clone()),
-                ],
-            )
-            .await
-            .expect("global file projection UPDATE RETURNING should succeed");
-        assert_rows_eq(
-            updated_global_projection,
-            vec![vec![
-                Value::Text(global_file_id.to_string()),
-                Value::Text("/returning-global-file.txt".to_string()),
-                Value::Text(explicit_branch_id.clone()),
-                Value::Boolean(true),
-            ]],
-        );
-
-        let inserted_directory_by_branch = session
-            .execute(
-                "INSERT INTO lix_directory_by_branch (path, lixcol_branch_id) \
-                 VALUES ('/returning-by-branch-directory', $1) \
-                 RETURNING id, path, lixcol_branch_id",
-                &[Value::Text(explicit_branch_id.clone())],
-            )
-            .await
-            .expect("by-branch directory INSERT RETURNING should succeed");
-        let [
-            Value::Text(directory_by_branch_id),
-            Value::Text(directory_by_branch_path),
-            Value::Text(returned_branch_id),
-        ] = inserted_directory_by_branch.rows()[0].values()
-        else {
-            panic!("by-branch directory INSERT RETURNING should expose its postimage")
-        };
-        assert_eq!(directory_by_branch_path, "/returning-by-branch-directory");
-        assert_eq!(returned_branch_id, &explicit_branch_id);
-        let directory_by_branch_id = directory_by_branch_id.clone();
-
-        let upserted_directory_by_branch = session
-            .execute(
-                "INSERT INTO lix_directory_by_branch (id, path, lixcol_branch_id) \
-                 VALUES ($1, '/returning-by-branch-directory-upserted', $2) \
-                 ON CONFLICT (id) DO UPDATE SET path = excluded.path \
-                 RETURNING id, path, lixcol_branch_id",
-                &[
-                    Value::Text(directory_by_branch_id.clone()),
-                    Value::Text(explicit_branch_id.clone()),
-                ],
-            )
-            .await
-            .expect("by-branch directory UPSERT RETURNING should expose its postimage");
-        assert_rows_eq(
-            upserted_directory_by_branch,
-            vec![vec![
-                Value::Text(directory_by_branch_id),
-                Value::Text("/returning-by-branch-directory-upserted".to_string()),
-                Value::Text(explicit_branch_id),
-            ]],
-        );
     }
 );
 

--- a/packages/lix/tests/integration/transaction.rs
+++ b/packages/lix/tests/integration/transaction.rs
@@ -679,13 +679,16 @@ async fn existing_session_ignores_later_default_branch_corruption() {
         .await
         .expect("initialized storage should create an engine");
     let session = engine.open_session().await.expect("session should open");
+    let global_session = engine
+        .open_session_at("ffffffff-ffff-7fff-bfff-ffffffffffff")
+        .await
+        .expect("global session should open");
 
-    session
+    global_session
         .execute(
-            "UPDATE lix_key_value_by_branch \
+            "UPDATE lix_key_value \
              SET value = '6d697373-696e-872d-8272-616e63680000' \
-             WHERE key = 'lix_default_branch_id' \
-               AND lixcol_branch_id = 'ffffffff-ffff-7fff-bfff-ffffffffffff'",
+             WHERE key = 'lix_default_branch_id'",
             &[],
         )
         .await
@@ -759,13 +762,16 @@ async fn existing_session_writes_to_its_selected_branch() {
         .await
         .expect("initialized storage should create an engine");
     let session = engine.open_session().await.expect("session should open");
+    let global_session = engine
+        .open_session_at("ffffffff-ffff-7fff-bfff-ffffffffffff")
+        .await
+        .expect("global session should open");
 
-    session
+    global_session
         .execute(
-            "UPDATE lix_key_value_by_branch \
+            "UPDATE lix_key_value \
              SET value = '6d697373-696e-872d-8272-616e63680000' \
-             WHERE key = 'lix_default_branch_id' \
-               AND lixcol_branch_id = 'ffffffff-ffff-7fff-bfff-ffffffffffff'",
+             WHERE key = 'lix_default_branch_id'",
             &[],
         )
         .await

--- a/packages/storage-rocksdb/tests/storage/native_file_read.rs
+++ b/packages/storage-rocksdb/tests/storage/native_file_read.rs
@@ -1,7 +1,7 @@
 //! RocksDB coverage for the public SQL file-read surface.
 
 use lix::storage::Storage;
-use lix::{Lix, Value, open_lix};
+use lix::{GLOBAL_BRANCH_ID, Lix, Value, open_lix};
 use lix_storage_rocksdb::RocksDB;
 
 #[tokio::test]
@@ -19,27 +19,29 @@ async fn public_file_read_works_with_rocksdb() {
 
     // Public reads retain active-branch precedence when a global file has an
     // active branch-local overlay at the same logical path.
-    let active_branch_id = lix.active_branch_id().await.expect("active branch");
+    let global = lix
+        .open_another_session()
+        .with_branch(GLOBAL_BRANCH_ID)
+        .await
+        .expect("open global session");
+    global
+        .execute(
+            "INSERT INTO lix_file (id, path, content, lixcol_global) \
+         VALUES ($1, $2, $3, true)",
+            &[
+                Value::Text("630c8282-b934-7fd8-89df-6b093f08f3e3".to_owned()),
+                Value::Text("/native/overlap.bin".to_owned()),
+                Value::Blob(b"global".to_vec().into()),
+            ],
+        )
+        .await
+        .expect("insert global overlap fixture");
     lix.execute(
-        "INSERT INTO lix_file_by_branch \
-         (id, path, content, lixcol_global, lixcol_branch_id) \
-         VALUES ($1, $2, $3, true, 'ffffffff-ffff-7fff-bfff-ffffffffffff')",
-        &[
-            Value::Text("630c8282-b934-7fd8-89df-6b093f08f3e3".to_owned()),
-            Value::Text("/native/overlap.bin".to_owned()),
-            Value::Blob(b"global".to_vec().into()),
-        ],
-    )
-    .await
-    .expect("insert global overlap fixture");
-    lix.execute(
-        "INSERT INTO lix_file_by_branch \
-         (id, path, content, lixcol_branch_id) VALUES ($1, $2, $3, $4)",
+        "INSERT INTO lix_file (id, path, content) VALUES ($1, $2, $3)",
         &[
             Value::Text("630c8282-b934-7fd8-89df-6b093f08f3e3".to_owned()),
             Value::Text("/native/overlap.bin".to_owned()),
             Value::Blob(b"local".to_vec().into()),
-            Value::Text(active_branch_id),
         ],
     )
     .await

--- a/packages/storage-rocksdb/tests/storage/native_file_upsert.rs
+++ b/packages/storage-rocksdb/tests/storage/native_file_upsert.rs
@@ -1,7 +1,7 @@
 //! RocksDB coverage for public SQL file writes and atomic batches.
 
 use lix::storage::Storage;
-use lix::{ExecuteBatchStatement, Lix, Value, open_lix};
+use lix::{ExecuteBatchStatement, GLOBAL_BRANCH_ID, Lix, Value, open_lix};
 use lix_storage_rocksdb::RocksDB;
 
 #[tokio::test]
@@ -51,27 +51,29 @@ async fn public_file_upsert_works_with_rocksdb() {
     assert_eq!(active_branch_commit_id(&lix).await, head_before_error);
 
     // SQL upserts target the active overlay while preserving the global row.
-    let active_branch_id = lix.active_branch_id().await.expect("active branch");
+    let global = lix
+        .open_another_session()
+        .with_branch(GLOBAL_BRANCH_ID)
+        .await
+        .expect("open global session");
+    global
+        .execute(
+            "INSERT INTO lix_file (id, path, content, lixcol_global) \
+         VALUES ($1, $2, $3, true)",
+            &[
+                Value::Text("abc1de5c-4b72-748d-84df-8fc7b1beedda".to_owned()),
+                Value::Text("/native/overlap.bin".to_owned()),
+                Value::Blob(b"g".to_vec().into()),
+            ],
+        )
+        .await
+        .expect("insert global overlap fixture");
     lix.execute(
-        "INSERT INTO lix_file_by_branch \
-         (id, path, content, lixcol_global, lixcol_branch_id) \
-         VALUES ($1, $2, $3, true, 'ffffffff-ffff-7fff-bfff-ffffffffffff')",
-        &[
-            Value::Text("abc1de5c-4b72-748d-84df-8fc7b1beedda".to_owned()),
-            Value::Text("/native/overlap.bin".to_owned()),
-            Value::Blob(b"g".to_vec().into()),
-        ],
-    )
-    .await
-    .expect("insert global overlap fixture");
-    lix.execute(
-        "INSERT INTO lix_file_by_branch \
-         (id, path, content, lixcol_branch_id) VALUES ($1, $2, $3, $4)",
+        "INSERT INTO lix_file (id, path, content) VALUES ($1, $2, $3)",
         &[
             Value::Text("abc1de5c-4b72-748d-84df-8fc7b1beedda".to_owned()),
             Value::Text("/native/overlap.bin".to_owned()),
             Value::Blob(b"l".to_vec().into()),
-            Value::Text(active_branch_id.clone()),
         ],
     )
     .await
@@ -85,20 +87,8 @@ async fn public_file_upsert_works_with_rocksdb() {
     )
     .await
     .expect("update active overlay through SQL batch");
-    assert_file_content_by_branch(
-        &lix,
-        "abc1de5c-4b72-748d-84df-8fc7b1beedda",
-        &active_branch_id,
-        b"updated",
-    )
-    .await;
-    assert_file_content_by_branch(
-        &lix,
-        "abc1de5c-4b72-748d-84df-8fc7b1beedda",
-        "ffffffff-ffff-7fff-bfff-ffffffffffff",
-        b"g",
-    )
-    .await;
+    assert_file_content_by_session(&lix, "abc1de5c-4b72-748d-84df-8fc7b1beedda", b"updated").await;
+    assert_file_content_by_session(&global, "abc1de5c-4b72-748d-84df-8fc7b1beedda", b"g").await;
 }
 
 const UPSERT_SQL: &str = "INSERT INTO lix_file (path, content) VALUES ($1, $2) \
@@ -206,18 +196,14 @@ where
     );
 }
 
-async fn assert_file_content_by_branch<S>(lix: &Lix<S>, id: &str, branch_id: &str, expected: &[u8])
+async fn assert_file_content_by_session<S>(lix: &Lix<S>, id: &str, expected: &[u8])
 where
     S: Storage + Clone + Send + Sync + 'static,
 {
     let result = lix
         .execute(
-            "SELECT content FROM lix_file_by_branch \
-             WHERE id = $1 AND lixcol_branch_id = $2",
-            &[
-                Value::Text(id.to_owned()),
-                Value::Text(branch_id.to_owned()),
-            ],
+            "SELECT content FROM lix_file WHERE id = $1",
+            &[Value::Text(id.to_owned())],
         )
         .await
         .expect("read branch file");


### PR DESCRIPTION
## Summary
- remove every public *_by_branch relation and lixcol_branch_id routing path
- scope base SQL surfaces exclusively to each session active branch while preserving lixcol_global and the global branch
- add Lix.openAnotherSession across native, WASM, worker, Workerd, and remote transports
- migrate tests and docs to sessions, working diffs, and commit diffs

## Breaking behavior
This is a hard cut with no compatibility aliases. Use a second session for another branch. Existing retired relation names fail closed.

## Validation
- cargo check -p lix
- cargo test -p lix --lib (2598 passed, 0 failed, 26 ignored)
- cargo test -p lix --features all-simulations (all passing)
- JS SDK Rust check, WASM build, TypeScript build/typecheck
- native lifecycle/filesystem tests, remote suite 37/37, raw WASM lifecycle regression
- two independent review rounds, final gate passed

Atelier and Lixray have coordinated follow-up pull requests. Flashtype is intentionally unchanged.