### PR TITLE
Expose filesystem timestamps in SQL

### DIFF
--- a/docs/surfaces.md
+++ b/docs/surfaces.md
@@ -26,7 +26,9 @@ documents it together with the history functions.
 `lix_file` represents regular file contents only. Its public columns are `id`,
 `path`, `directory_id`, `name`, and `content`, plus the standard `lixcol_*`
 bookkeeping columns. `path` is an absolute, literal UTF-8 path and `content` is
-the file's bytes. Path characters such as spaces, `%`, `#`, `?`, and `@` are
+the file's bytes. `lixcol_created_at` and `lixcol_updated_at` are public,
+read-only timestamps on both `lix_file` and `lix_directory`. Path characters
+such as spaces, `%`, `#`, `?`, and `@` are
 not URL-encoded. Lix does not represent symbolic
 links, device nodes, sockets, or other non-regular filesystem entries as
 `lix_file` rows. Executable and

--- a/packages/lix/src/sql2/bind/statement.rs
+++ b/packages/lix/src/sql2/bind/statement.rs
@@ -1876,6 +1876,8 @@ mod tests {
                 "content",
                 "lixcol_global",
                 "lixcol_change_id",
+                "lixcol_created_at",
+                "lixcol_updated_at",
                 "lixcol_untracked",
                 "lixcol_metadata",
                 "deleted_path",

--- a/packages/lix/src/sql2/bind/table.rs
+++ b/packages/lix/src/sql2/bind/table.rs
@@ -174,6 +174,10 @@ mod tests {
         let table = bind_public_table(&catalog, &table_name("SELECT * FROM lix_file"))
             .expect("lix_file should bind");
 
+        require_public_column(&table, "lixcol_created_at")
+            .expect("filesystem created timestamp should be public");
+        require_public_column(&table, "lixcol_updated_at")
+            .expect("filesystem updated timestamp should be public");
         let error = require_public_column(&table, "lixcol_schema_key")
             .expect_err("hidden column should not bind");
         assert!(error.message.contains("not part of public SQL surface"));

--- a/packages/lix/src/sql2/catalog/registry.rs
+++ b/packages/lix/src/sql2/catalog/registry.rs
@@ -492,7 +492,7 @@ fn filesystem_columns() -> Vec<PublicColumn> {
         PublicColumn::public("name", false).conditional_on_insert(),
         PublicColumn::public("content", false).with_default("CAST('' AS BYTEA)"),
     ];
-    columns.extend(filesystem_hidden_columns());
+    columns.extend(filesystem_system_columns());
     columns
 }
 
@@ -503,7 +503,7 @@ fn directory_columns() -> Vec<PublicColumn> {
         PublicColumn::public("parent_id", true).conditional_on_insert(),
         PublicColumn::public("name", false).conditional_on_insert(),
     ];
-    columns.extend(filesystem_hidden_columns());
+    columns.extend(filesystem_system_columns());
     columns
 }
 
@@ -511,15 +511,15 @@ fn row_hidden_columns(spec: &SchemaSurfaceSpec) -> Vec<PublicColumn> {
     row_system_columns(spec, SchemaSurfaceShape::Active)
 }
 
-fn filesystem_hidden_columns() -> Vec<PublicColumn> {
+fn filesystem_system_columns() -> Vec<PublicColumn> {
     vec![
         PublicColumn::hidden("lixcol_row_pk", false),
         PublicColumn::hidden("lixcol_schema_key", false),
         PublicColumn::hidden("lixcol_file_id", true),
         PublicColumn::public_insert_only("lixcol_global", false).with_default("FALSE"),
         PublicColumn::public_read_only("lixcol_change_id", true),
-        PublicColumn::hidden("lixcol_created_at", false),
-        PublicColumn::hidden("lixcol_updated_at", false),
+        PublicColumn::public_read_only("lixcol_created_at", false),
+        PublicColumn::public_read_only("lixcol_updated_at", false),
         PublicColumn::hidden("lixcol_commit_id", true),
         PublicColumn::public_insert_only("lixcol_untracked", false).with_default("FALSE"),
         PublicColumn::public("lixcol_metadata", true).optional_on_insert(),

--- a/packages/lix/tests/integration/sql/lix_directory.rs
+++ b/packages/lix/tests/integration/sql/lix_directory.rs
@@ -5,6 +5,72 @@ use serde_json::json;
 
 use super::assert_rows_eq;
 
+simulation_test!(lix_directory_exposes_public_timestamps, |sim| async move {
+    let engine = sim.boot_engine().await;
+    let session = sim.wrap_session(
+        engine
+            .open_session()
+            .await
+            .expect("main session should open"),
+        &engine,
+    );
+    let directory_id = "6469722d-7469-8d65-8374-616d70730000";
+
+    session
+        .execute(
+            &format!("INSERT INTO lix_directory (id, path) VALUES ('{directory_id}', '/before')"),
+            &[],
+        )
+        .await
+        .expect("directory insert should succeed");
+    let initial = session
+        .execute(
+            &format!(
+                "SELECT lixcol_created_at, lixcol_updated_at \
+                     FROM lix_directory WHERE id = '{directory_id}'"
+            ),
+            &[],
+        )
+        .await
+        .expect("directory timestamps should be public");
+    let created_at = initial.rows()[0]
+        .get::<String>("lixcol_created_at")
+        .expect("created timestamp should be text");
+    let updated_at = initial.rows()[0]
+        .get::<String>("lixcol_updated_at")
+        .expect("updated timestamp should be text");
+
+    session
+        .execute(
+            &format!("UPDATE lix_directory SET path = '/after' WHERE id = '{directory_id}'"),
+            &[],
+        )
+        .await
+        .expect("directory rename should succeed");
+    let renamed = session
+        .execute(
+            &format!(
+                "SELECT lixcol_created_at, lixcol_updated_at \
+                     FROM lix_directory WHERE id = '{directory_id}'"
+            ),
+            &[],
+        )
+        .await
+        .expect("renamed directory timestamps should be public");
+    assert_eq!(
+        renamed.rows()[0]
+            .get::<String>("lixcol_created_at")
+            .expect("created timestamp should be text"),
+        created_at,
+    );
+    assert_ne!(
+        renamed.rows()[0]
+            .get::<String>("lixcol_updated_at")
+            .expect("updated timestamp should be text"),
+        updated_at,
+    );
+});
+
 simulation_test!(
     lix_directory_path_insert_preserves_long_opaque_segments,
     |sim| async move {


### PR DESCRIPTION
## Summary

- expose lixcol_created_at and lixcol_updated_at as public read-only columns on lix_file and lix_directory
- include the timestamps in wildcard RETURNING projections and information_schema
- document the filesystem timestamp contract and add directory lifecycle coverage

## Why

Lixray orders and renders repository entries using lixcol_updated_at, but the filesystem providers exposed the values internally while the public SQL catalog marked them hidden.

## Validation

- cargo test -p lix public_timestamps
- cargo test -p lix information_schema_exposes_executable_lix_column_contract
- cargo test -p lix --features all-simulations (2,991 passed, 0 failed, 26 ignored)
- doc tests and integration test binaries passed