### PR TITLE
feat: add ancestor commit restore

### DIFF
--- a/docs/js-api-reference.md
+++ b/docs/js-api-reference.md
@@ -270,6 +270,18 @@ type CreateCheckpointReceipt = {
 };
 ```
 
+### restore()
+
+```ts
+await lix.restore(commitId);
+```
+
+Moves the active branch HEAD to `commitId`, which must exist and be an ancestor
+of the current HEAD. Restoring the current HEAD is a no-op. Restore does not
+create a commit and is not an undo/redo operation; commits abandoned by the
+move may remain stored until checkpoint-driven garbage collection reclaims
+them.
+
 ### undo() / redo()
 
 ```ts

--- a/docs/server-protocol.md
+++ b/docs/server-protocol.md
@@ -27,7 +27,7 @@ and authentication and forwards requests to it. See [Hosting](./hosting.md).
 | SQL         | `/lix/v1/execute`, `/lix/v1/execute-batch`                                                    |
 | Transaction | `/lix/v1/transaction/{begin,execute,commit,rollback}`                                         |
 | Files       | `/lix/v1/file`, `/lix/v1/file/upsert`, `/lix/v1/file/upsert-batch`                            |
-| Versioning  | `/lix/v1/branch/{create,switch}`, `/lix/v1/checkpoint/create`, `/lix/v1/undo`, `/lix/v1/redo` |
+| Versioning  | `/lix/v1/branch/{create,switch}`, `/lix/v1/checkpoint/create`, `/lix/v1/restore`, `/lix/v1/undo`, `/lix/v1/redo` |
 | Observation | `/lix/v1/observe`, `/lix/v1/observe/multiplex`                                                |
 
 Clients do not construct these paths. `openLix()` appends `/lix/v1/` to the

--- a/packages/js-sdk/native/napi.rs
+++ b/packages/js-sdk/native/napi.rs
@@ -147,6 +147,10 @@ enum LixCommand {
         deferred: NativeCreateBranchDeferred,
     },
     CreateCheckpoint(NativeCreateCheckpointDeferred),
+    Restore {
+        commit_id: String,
+        deferred: NativeUnitDeferred,
+    },
     Undo(NativeUndoDeferred),
     Redo(NativeRedoDeferred),
     SwitchBranch {
@@ -318,6 +322,7 @@ fn reject_pending_lix_commands(receiver: mpsc::Receiver<LixCommand>, error: std:
             LixCommand::ActiveAccountId(deferred) => deferred.reject(to_napi_error(&error)),
             LixCommand::CreateBranch { deferred, .. } => deferred.reject(to_napi_error(&error)),
             LixCommand::CreateCheckpoint(deferred) => deferred.reject(to_napi_error(&error)),
+            LixCommand::Restore { deferred, .. } => deferred.reject(to_napi_error(&error)),
             LixCommand::Undo(deferred) => deferred.reject(to_napi_error(&error)),
             LixCommand::Redo(deferred) => deferred.reject(to_napi_error(&error)),
             LixCommand::SwitchBranch { deferred, .. } => deferred.reject(to_napi_error(&error)),
@@ -417,6 +422,14 @@ fn handle_lix_command(
             let result = rt
                 .block_on(state.lix.create_checkpoint())
                 .map(CreateCheckpointReceiptDto::from);
+            settle_deferred(deferred, result);
+            false
+        }
+        LixCommand::Restore {
+            commit_id,
+            deferred,
+        } => {
+            let result = rt.block_on(state.lix.restore(commit_id));
             settle_deferred(deferred, result);
             false
         }
@@ -558,6 +571,9 @@ fn settle_command_after_close(command: LixCommand) {
         LixCommand::CreateCheckpoint(deferred) => {
             settle_deferred(deferred, Err(lix_closed_error()));
         }
+        LixCommand::Restore { deferred, .. } => {
+            settle_deferred(deferred, Err(lix_closed_error()));
+        }
         LixCommand::Undo(deferred) => settle_deferred(deferred, Err(lix_closed_error())),
         LixCommand::Redo(deferred) => settle_deferred(deferred, Err(lix_closed_error())),
         LixCommand::SwitchBranch { deferred, .. } => {
@@ -691,6 +707,13 @@ impl NativeLixInner {
         match self {
             Self::Memory(lix) => lix.create_checkpoint().await,
             Self::FilesystemStorage(lix, _, _) => lix.create_checkpoint().await,
+        }
+    }
+
+    async fn restore(&self, commit_id: String) -> std::result::Result<(), LixError> {
+        match self {
+            Self::Memory(lix) => lix.restore(commit_id).await,
+            Self::FilesystemStorage(lix, _, _) => lix.restore(commit_id).await,
         }
     }
 
@@ -1144,6 +1167,17 @@ impl NativeLix {
             env.create_deferred()?;
         self.actor
             .send_with_deferred(deferred, LixCommand::CreateCheckpoint);
+        Ok(promise)
+    }
+
+    #[napi(js_name = "restore")]
+    pub fn restore<'env>(&self, env: &'env Env, commit_id: String) -> Result<Object<'env>> {
+        let (deferred, promise): (NativeUnitDeferred, Object<'env>) = env.create_deferred()?;
+        self.actor
+            .send_with_deferred(deferred, |deferred| LixCommand::Restore {
+                commit_id,
+                deferred,
+            });
         Ok(promise)
     }
 

--- a/packages/js-sdk/native/wasm.rs
+++ b/packages/js-sdk/native/wasm.rs
@@ -326,6 +326,11 @@ impl WasmLix {
         })
     }
 
+    #[wasm_bindgen(js_name = restore)]
+    pub async fn restore(&self, commit_id: String) -> Result<(), JsValue> {
+        self.inner.restore(commit_id).await.map_err(lix_error_to_js)
+    }
+
     #[wasm_bindgen(js_name = undo)]
     pub async fn undo(&self) -> Result<JsValue, JsValue> {
         let receipt = self.inner.undo().await.map_err(lix_error_to_js)?;

--- a/packages/js-sdk/native/wasm_remote.rs
+++ b/packages/js-sdk/native/wasm_remote.rs
@@ -261,6 +261,11 @@ impl WasmRemoteLix {
         })
     }
 
+    #[wasm_bindgen(js_name = restore)]
+    pub async fn restore(&self, commit_id: String) -> Result<(), JsValue> {
+        self.inner.restore(commit_id).await.map_err(lix_error_to_js)
+    }
+
     #[wasm_bindgen(js_name = undo)]
     pub async fn undo(&self) -> Result<JsValue, JsValue> {
         let receipt = self.inner.undo().await.map_err(lix_error_to_js)?;

--- a/packages/js-sdk/src/binding-types.ts
+++ b/packages/js-sdk/src/binding-types.ts
@@ -61,6 +61,7 @@ export type LixBinding = {
 	activeAccountId(): Promise<string>;
 	createBranch(options: CreateBranchOptions): Promise<CreateBranchReceipt>;
 	createCheckpoint(): Promise<CreateCheckpointReceipt>;
+	restore(commitId: string): Promise<void>;
 	undo(): Promise<UndoReceipt>;
 	redo(): Promise<RedoReceipt>;
 	switchBranch(options: SwitchBranchOptions): Promise<SwitchBranchReceipt>;

--- a/packages/js-sdk/src/lix.ts
+++ b/packages/js-sdk/src/lix.ts
@@ -171,6 +171,11 @@ export class Lix {
 		return this.#runOperation(() => this.binding.createCheckpoint());
 	}
 
+	/** Moves the active branch HEAD to an ancestor commit without creating a commit. */
+	async restore(commitId: string): Promise<void> {
+		return this.#runOperation(() => this.binding.restore(commitId));
+	}
+
 	async undo(): Promise<UndoReceipt> {
 		return this.#runOperation(() => this.binding.undo());
 	}

--- a/packages/js-sdk/src/open-lix.browser.test.ts
+++ b/packages/js-sdk/src/open-lix.browser.test.ts
@@ -116,6 +116,35 @@ test("createCheckpoint returns the new active head through browser WASM", async 
 	}
 });
 
+test("restore moves the active branch to an ancestor through browser WASM", async () => {
+	const { openLix } = await import("@lix-js/sdk");
+	const lix = await openLix();
+	try {
+		const initial = (
+			await lix.execute("SELECT lix_active_branch_commit_id() AS commit_id")
+		).rows[0]?.get("commit_id") as string;
+		await lix.execute(
+			"INSERT INTO lix_key_value (key, value) VALUES ($1, $2)",
+			["restore-test", "later"],
+		);
+
+		await lix.restore(initial);
+
+		expect(
+			(
+				await lix.execute("SELECT lix_active_branch_commit_id() AS commit_id")
+			).rows[0]?.get("commit_id"),
+		).toBe(initial);
+		expect(
+			(await lix.execute("SELECT * FROM lix_key_value WHERE key = $1", [
+				"restore-test",
+			])).rows,
+		).toHaveLength(0);
+	} finally {
+		await lix.close();
+	}
+});
+
 test("executes a globally ordered union plan in browser WASM", async () => {
 	const { openLix } = await import("@lix-js/sdk");
 	const lix = await openLix();

--- a/packages/js-sdk/src/open-lix.test.ts
+++ b/packages/js-sdk/src/open-lix.test.ts
@@ -267,6 +267,25 @@ test("createCheckpoint returns the new active head through the local worker", as
 	await lix.close();
 });
 
+test("restore moves the active branch to an ancestor through the local worker", async () => {
+	const lix = await openLix();
+	const initial = await activeHeadCommitId(lix);
+	await lix.execute(
+		"INSERT INTO lix_key_value (key, value) VALUES ($1, $2)",
+		["restore-test", "later"],
+	);
+
+	await lix.restore(initial);
+
+	expect(await activeHeadCommitId(lix)).toBe(initial);
+	expect(
+		(await lix.execute("SELECT * FROM lix_key_value WHERE key = $1", [
+			"restore-test",
+		])).rows,
+	).toHaveLength(0);
+	await lix.close();
+});
+
 test("undo and redo roundtrip tracked state through the local worker", async () => {
 	const lix = await openLix();
 	await lix.execute(

--- a/packages/js-sdk/src/remote/client.test.ts
+++ b/packages/js-sdk/src/remote/client.test.ts
@@ -775,6 +775,46 @@ test("remote createCheckpoint posts no body and decodes the receipt", async () =
 	await lix.close();
 });
 
+test("remote restore posts the commit id", async () => {
+	const requests: Request[] = [];
+	const lix = await openLix({
+		server: {
+			mode: "remote",
+			url: "https://lixray.test/@acme/repository",
+			fetch: (async (input: RequestInfo | URL, init?: RequestInit) => {
+				const request = new Request(input, init);
+				requests.push(request.clone());
+				const pathname = new URL(request.url).pathname;
+				if (pathname.endsWith("/lix/v1/")) {
+					return Response.json({
+						protocolVersion: 2,
+						activeBranchId: "main-id",
+						activeAccountId: "00000000-0000-7000-8000-000000000002",
+						sessionId: "session-1",
+					});
+				}
+				if (pathname.endsWith("/restore")) {
+					return new Response(null, { status: 204 });
+				}
+				if (request.method === "DELETE") {
+					return new Response(null, { status: 204 });
+				}
+				throw new Error(`Unexpected request: ${pathname}`);
+			}) as typeof fetch,
+		},
+	});
+
+	await expect(lix.restore("target-commit-id")).resolves.toBeUndefined();
+	const request = requests.find((candidate) =>
+		new URL(candidate.url).pathname.endsWith("/restore"),
+	);
+	expect(request?.method).toBe("POST");
+	expect(request?.headers.get("lix-session-id")).toBe("session-1");
+	expect(await request?.json()).toEqual({ commitId: "target-commit-id" });
+
+	await lix.close();
+});
+
 test("remote undo and redo decode branch-history receipts", async () => {
 	const lix = await openLix({
 		server: {

--- a/packages/js-sdk/src/remote/server-protocol.ts
+++ b/packages/js-sdk/src/remote/server-protocol.ts
@@ -134,6 +134,10 @@ export type ServerProtocolCreateCheckpointResponse = {
 	commitId: string;
 };
 
+export type ServerProtocolRestoreRequest = {
+	commitId: string;
+};
+
 export type ServerProtocolUndoResponse = {
 	branchId: string;
 	targetCommitId: string;

--- a/packages/js-sdk/src/worker/client.ts
+++ b/packages/js-sdk/src/worker/client.ts
@@ -180,6 +180,7 @@ function workerBinding(
 		activeAccountId: () => request({ kind: "activeAccountId" }),
 		createBranch: (options) => request({ kind: "createBranch", options }),
 		createCheckpoint: () => request({ kind: "createCheckpoint" }),
+		restore: (commitId) => request({ kind: "restore", commitId }),
 		undo: () => request({ kind: "undo" }),
 		redo: () => request({ kind: "redo" }),
 		switchBranch: (options) => request({ kind: "switchBranch", options }),

--- a/packages/js-sdk/src/worker/host.ts
+++ b/packages/js-sdk/src/worker/host.ts
@@ -145,6 +145,8 @@ export function startWorkerHost(endpoint: WorkerHostEndpoint): void {
 				return requiredLix(sessionId).createBranch(operation.options);
 			case "createCheckpoint":
 				return requiredLix(sessionId).createCheckpoint();
+			case "restore":
+				return requiredLix(sessionId).restore(operation.commitId);
 			case "undo":
 				return requiredLix(sessionId).undo();
 			case "redo":

--- a/packages/js-sdk/src/worker/protocol.ts
+++ b/packages/js-sdk/src/worker/protocol.ts
@@ -47,6 +47,7 @@ export type WorkerOperation =
 	| { kind: "activeAccountId" }
 	| { kind: "createBranch"; options: CreateBranchOptions }
 	| { kind: "createCheckpoint" }
+	| { kind: "restore"; commitId: string }
 	| { kind: "undo" }
 	| { kind: "redo" }
 	| { kind: "switchBranch"; options: SwitchBranchOptions }

--- a/packages/lix/server-protocol.openapi.yaml
+++ b/packages/lix/server-protocol.openapi.yaml
@@ -197,6 +197,21 @@ paths:
       responses:
         "200": { description: Checkpoint created. }
         default: { $ref: "#/components/responses/Error" }
+  /lix/v1/restore:
+    post:
+      operationId: restore
+      parameters: [{ $ref: "#/components/parameters/RequiredSessionId" }]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [commitId]
+              properties: { commitId: { type: string, minLength: 1 } }
+      responses:
+        "204": { description: Branch restored. }
+        default: { $ref: "#/components/responses/Error" }
   /lix/v1/undo:
     post:
       operationId: undo

--- a/packages/lix/src/branch/lifecycle.rs
+++ b/packages/lix/src/branch/lifecycle.rs
@@ -12,6 +12,7 @@ pub(crate) enum BranchOperation {
     MergeBranch,
     MergeBranchPreview,
     CreateCheckpoint,
+    Restore,
     LoadDefaultBranch,
 }
 
@@ -23,6 +24,7 @@ impl BranchOperation {
             Self::MergeBranch => "merge_branch",
             Self::MergeBranchPreview => "merge_branch_preview",
             Self::CreateCheckpoint => "create_checkpoint",
+            Self::Restore => "restore",
             Self::LoadDefaultBranch => "load_default_branch_id",
         }
     }

--- a/packages/lix/src/handle.rs
+++ b/packages/lix/src/handle.rs
@@ -700,6 +700,11 @@ where
         self.session.create_checkpoint().await
     }
 
+    /// Restores the active branch to `commit_id`, which must be an ancestor of HEAD.
+    pub async fn restore(&self, commit_id: impl Into<String>) -> Result<(), LixError> {
+        self.session.restore(commit_id.into()).await
+    }
+
     /// Reverses the latest undoable tracked commit on this handle's active branch.
     pub async fn undo(&self) -> Result<UndoReceipt, LixError> {
         self.session.undo().await

--- a/packages/lix/src/server_protocol/client/mod.rs
+++ b/packages/lix/src/server_protocol/client/mod.rs
@@ -30,8 +30,8 @@ use wire::{
     CreateBranchResponseBody, CreateCheckpointResponseBody, EmptyBody, ErrorEnvelope,
     ExecuteBatchRequestBody, ExecuteBatchStatementBody, ExecuteOptionsBody, ExecuteRequestBody,
     ExecuteResponseBody, HandshakeResponse, IDEMPOTENCY_KEY_HEADER, RedoResponseBody,
-    SESSION_HEADER, SERVER_PROTOCOL_VERSION, SwitchBranchRequestBody, SwitchBranchResponseBody,
-    TRANSACTION_HEADER, UndoResponseBody, closed_error, encode_engine_values,
+    RestoreRequestBody, SESSION_HEADER, SERVER_PROTOCOL_VERSION, SwitchBranchRequestBody,
+    SwitchBranchResponseBody, TRANSACTION_HEADER, UndoResponseBody, closed_error, encode_engine_values,
     is_recoverable_session_error, protocol_error, remote_error, unsupported_remote_operation,
     validate_session_id,
 };
@@ -637,6 +637,26 @@ impl<H: ProtocolHttp> ClientCore<H> {
                     commit_id: value.commit_id,
                     change_id: String::new(),
                 })
+            })
+            .await
+        })
+        .await
+    }
+
+    pub async fn restore(&self, commit_id: String) -> Result<(), LixError> {
+        self.enqueue(|| async {
+            self.with_session_recovery(|| async {
+                self.request_json::<(), _>(
+                    "POST",
+                    self.join_path("restore")?,
+                    true,
+                    None,
+                    Some(RestoreRequestBody {
+                        commit_id: &commit_id,
+                    }),
+                    "empty",
+                )
+                .await
             })
             .await
         })

--- a/packages/lix/src/server_protocol/client/wire.rs
+++ b/packages/lix/src/server_protocol/client/wire.rs
@@ -153,6 +153,12 @@ pub struct CreateCheckpointResponseBody {
     pub commit_id: String,
 }
 
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RestoreRequestBody<'a> {
+    pub commit_id: &'a str,
+}
+
 #[derive(Debug, Clone, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct UndoResponseBody {

--- a/packages/lix/src/server_protocol/handler.rs
+++ b/packages/lix/src/server_protocol/handler.rs
@@ -288,6 +288,7 @@ pub const SERVER_PROTOCOL_ENDPOINTS: &[(&str, &str)] = &[
     ("POST", "/lix/v1/file/upsert-batch"),
     ("POST", "/lix/v1/branch/create"),
     ("POST", "/lix/v1/checkpoint/create"),
+    ("POST", "/lix/v1/restore"),
     ("POST", "/lix/v1/undo"),
     ("POST", "/lix/v1/redo"),
     ("POST", "/lix/v1/branch/switch"),
@@ -1537,6 +1538,7 @@ where
                 | (&Method::POST, "/lix/v1/execute-batch")
                 | (&Method::POST, "/lix/v1/transaction/execute")
                 | (&Method::POST, "/lix/v1/branch/create")
+                | (&Method::POST, "/lix/v1/restore")
                 | (&Method::POST, "/lix/v1/branch/switch")
                 | (&Method::POST, "/lix/v1/observe")
                 | (&Method::POST, "/lix/v1/observe/multiplex")
@@ -1621,6 +1623,9 @@ where
             }
             (&Method::POST, "/lix/v1/checkpoint/create") => {
                 result_response(create_checkpoint(lease).await)
+            }
+            (&Method::POST, "/lix/v1/restore") => {
+                result_response(restore(lease, json_request!(RestoreRequest)).await)
             }
             (&Method::POST, "/lix/v1/undo") => result_response(undo(lease).await),
             (&Method::POST, "/lix/v1/redo") => result_response(redo(lease).await),
@@ -2757,6 +2762,20 @@ where
     Ok(Json(CreateCheckpointResponse {
         commit_id: receipt.commit_id,
     }))
+}
+
+async fn restore<S>(
+    lease: SessionLease<S>,
+    Json(request): Json<RestoreRequest>,
+) -> Result<StatusCode, ApiError>
+where
+    S: Storage + Clone + Send + Sync + 'static,
+{
+    let commit_id = required_non_empty(request.commit_id, "commitId")?;
+    lease
+        .run_durable(move |lix| async move { lix.restore(commit_id).await })
+        .await?;
+    Ok(StatusCode::NO_CONTENT)
 }
 
 async fn undo<S>(lease: SessionLease<S>) -> Result<Json<UndoResponse>, ApiError>
@@ -3933,6 +3952,12 @@ struct CreateCheckpointResponse {
     commit_id: String,
 }
 
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct RestoreRequest {
+    commit_id: Option<String>,
+}
+
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
 struct UndoResponse {
@@ -4433,6 +4458,7 @@ mod tests {
                 ("POST", "/lix/v1/file/upsert-batch") => "upsertFileBatch",
                 ("POST", "/lix/v1/branch/create") => "createBranch",
                 ("POST", "/lix/v1/checkpoint/create") => "createCheckpoint",
+                ("POST", "/lix/v1/restore") => "restore",
                 ("POST", "/lix/v1/undo") => "undo",
                 ("POST", "/lix/v1/redo") => "redo",
                 ("POST", "/lix/v1/branch/switch") => "switchBranch",
@@ -7529,6 +7555,65 @@ mod tests {
         assert_eq!(
             response_json(head).await["rows"][0][0],
             json!({ "kind": "text", "value": checkpoint_id })
+        );
+    }
+
+    #[tokio::test]
+    async fn restore_moves_the_pinned_branch_to_an_ancestor() {
+        let app = app().await;
+        let (session_id, _) = new_session(&app.router).await;
+        let initial_head = request(
+            &app.router,
+            "POST",
+            "/lix/v1/execute",
+            Some(&session_id),
+            Some(json!({
+                "sql": "SELECT lix_active_branch_commit_id() AS commit_id"
+            })),
+        )
+        .await;
+        let initial_commit_id = response_json(initial_head).await["rows"][0][0]["value"]
+            .as_str()
+            .expect("initial commit id")
+            .to_string();
+
+        let inserted = request(
+            &app.router,
+            "POST",
+            "/lix/v1/execute",
+            Some(&session_id),
+            Some(json!({
+                "sql": "INSERT INTO lix_key_value (key, value) VALUES ('restore-test', 'later')"
+            })),
+        )
+        .await;
+        assert_eq!(inserted.status(), StatusCode::OK);
+
+        let restored = request(
+            &app.router,
+            "POST",
+            "/lix/v1/restore",
+            Some(&session_id),
+            Some(json!({ "commitId": initial_commit_id })),
+        )
+        .await;
+        if restored.status() != StatusCode::NO_CONTENT {
+            panic!("restore failed: {}", response_json(restored).await);
+        }
+
+        let rows = request(
+            &app.router,
+            "POST",
+            "/lix/v1/execute",
+            Some(&session_id),
+            Some(json!({
+                "sql": "SELECT COUNT(*) AS count FROM lix_key_value WHERE key = 'restore-test'"
+            })),
+        )
+        .await;
+        assert_eq!(
+            response_json(rows).await["rows"][0][0],
+            json!({ "kind": "int", "value": 0 })
         );
     }
 

--- a/packages/lix/src/session/gc.rs
+++ b/packages/lix/src/session/gc.rs
@@ -311,6 +311,122 @@ mod tests {
         );
     }
 
+    #[tokio::test]
+    async fn checkpoint_gc_eventually_reclaims_a_commit_orphaned_by_restore() {
+        let (engine, session) = open().await;
+        let branch_id = session.branch.get().expect("session branch resolves");
+
+        session
+            .execute(
+                "INSERT INTO lix_key_value (key, value) VALUES ('restore-gc', 'c')",
+                &[],
+            )
+            .await
+            .expect("C commits");
+        let commit_c = head(&engine, &branch_id).await;
+        session
+            .execute(
+                "UPDATE lix_key_value SET value = 'd' WHERE key = 'restore-gc'",
+                &[],
+            )
+            .await
+            .expect("D commits");
+        let commit_d = head(&engine, &branch_id).await;
+        let commit_d_id = CommitId::parse_lix(&commit_d, "restore GC commit D")
+            .expect("D commit id parses");
+
+        session
+            .restore(commit_c.clone())
+            .await
+            .expect("restore to C succeeds");
+        assert_eq!(head(&engine, &branch_id).await, commit_c);
+        assert_eq!(
+            present(&session, std::slice::from_ref(&commit_d)).await,
+            [commit_d.clone()],
+            "restore must leave D stored until a later garbage-collection sweep"
+        );
+        let read = session
+            .storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("pre-GC read opens");
+        assert!(
+            crate::tracked_state::load_commit_state_manifest(&read, commit_d_id)
+                .await
+                .expect("pre-GC D manifest lookup succeeds")
+                .is_some(),
+            "D must own physical tracked state before this test can prove it is reclaimed"
+        );
+        drop(read);
+
+        // Two non-empty checkpoint intervals make collection debt durable.
+        // Empty checkpoints then cross the staleness backstop deterministically;
+        // they do not manufacture additional garbage or change D's reachability.
+        for round in 0..2 {
+            session
+                .execute(
+                    "INSERT INTO lix_key_value (key, value) VALUES ('restore-gc-live', $1) \
+                     ON CONFLICT (key) DO UPDATE SET value = excluded.value",
+                    &[Value::Jsonb(json!(round).into())],
+                )
+                .await
+                .expect("post-restore write commits");
+            session
+                .create_checkpoint()
+                .await
+                .expect("non-empty checkpoint succeeds");
+        }
+        for _ in 0..RECLAIM_MAX_STALENESS {
+            session
+                .create_checkpoint()
+                .await
+                .expect("padding checkpoint succeeds");
+        }
+
+        // Production schedules this sweep in the background. The explicit
+        // call takes the same repository write gate, so it either performs the
+        // sweep or observes that the scheduled collector already completed it.
+        session
+            .collect_checkpoint_garbage()
+            .await
+            .expect("checkpoint garbage collection succeeds");
+        assert!(
+            present(&session, std::slice::from_ref(&commit_d))
+                .await
+                .is_empty(),
+            "checkpoint GC must reclaim orphaned commit D '{commit_d}'"
+        );
+
+        let read = session
+            .storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("post-GC read opens");
+        assert!(
+            crate::tracked_state::load_commit_state_manifest(&read, commit_d_id)
+                .await
+                .expect("D manifest lookup succeeds")
+                .is_none(),
+            "garbage collection must reclaim D's physical tracked-state manifest too"
+        );
+        drop(read);
+
+        let restored = session
+            .execute(
+                "SELECT value FROM lix_key_value WHERE key = 'restore-gc'",
+                &[],
+            )
+            .await
+            .expect("live restored state reads after GC");
+        assert_eq!(
+            restored.rows()[0]
+                .get::<serde_json::Value>("value")
+                .expect("restored value is JSON"),
+            json!("c"),
+            "collecting D must not damage the live branch descended from C"
+        );
+    }
+
     /// Deletes one commit's physical delta the way the sweep that shipped
     /// before the history-retention fix did, leaving the commit record itself
     /// in place. This is `pub(crate)` on purpose and stays that way: a

--- a/packages/lix/src/session/mod.rs
+++ b/packages/lix/src/session/mod.rs
@@ -23,6 +23,7 @@ pub(crate) mod idempotency;
 pub(crate) mod media_upload;
 mod merge;
 pub(crate) mod observe;
+mod restore;
 mod switch_branch;
 mod transaction;
 mod undo_redo;

--- a/packages/lix/src/session/restore.rs
+++ b/packages/lix/src/session/restore.rs
@@ -1,0 +1,71 @@
+use crate::LixError;
+use crate::branch::{BranchLifecycle, BranchOperation, BranchReferenceRole};
+use crate::storage_adapter::Storage;
+
+use super::context::SessionContext;
+
+impl<StorageImpl> SessionContext<StorageImpl>
+where
+    StorageImpl: Storage + Clone + Send + Sync + 'static,
+{
+    /// Restores the active branch to an ancestor commit.
+    ///
+    /// This moves the branch ref without creating a commit. Commits that were
+    /// reachable only from the previous HEAD remain stored but are no longer
+    /// part of this branch's history.
+    pub async fn restore(&self, commit_id: String) -> Result<(), LixError> {
+        self.with_write_transaction_lending(async move |transaction| {
+            let branch_id = transaction.active_branch_id().to_string();
+            let target_commit_id = BranchLifecycle::parse_commit_id(
+                &commit_id,
+                BranchOperation::Restore,
+                BranchReferenceRole::Target,
+            )?;
+            let head_commit_id = {
+                let reader = transaction.branch_ref_reader().await;
+                BranchLifecycle::new(&reader)
+                    .require_existing_commit_id(
+                        &branch_id,
+                        BranchOperation::Restore,
+                        BranchReferenceRole::Source,
+                    )
+                    .await?
+            };
+
+            let mut commit_graph = transaction.commit_graph_reader().await;
+            BranchLifecycle::require_existing_commit(
+                &mut commit_graph,
+                target_commit_id,
+                BranchOperation::Restore,
+                BranchReferenceRole::Target,
+            )
+            .await?;
+
+            if target_commit_id == head_commit_id {
+                return Ok(());
+            }
+
+            let target_is_ancestor = commit_graph
+                .reachable_nodes(&head_commit_id)
+                .await?
+                .iter()
+                .any(|reachable| reachable.commit.commit_id == target_commit_id);
+            if !target_is_ancestor {
+                return Err(LixError::new(
+                    LixError::CODE_CONSTRAINT_VIOLATION,
+                    format!(
+                        "restore target commit '{target_commit_id}' is not an ancestor of branch '{branch_id}' HEAD '{head_commit_id}'"
+                    ),
+                ));
+            }
+            drop(commit_graph);
+
+            transaction
+                .restore_branch_ref(&branch_id, head_commit_id, target_commit_id)
+                .await?;
+
+            Ok(())
+        })
+        .await
+    }
+}

--- a/packages/lix/src/transaction/commit.rs
+++ b/packages/lix/src/transaction/commit.rs
@@ -52,6 +52,7 @@ use crate::transaction::staged_commit_changes::{
 use crate::transaction::staging::{
     OrderedMutationJournal, PreparedInsertSelection, PreparedWriteSet,
 };
+use crate::transaction::context::PendingRestoreIntent;
 use crate::transaction_types::{PreparedStateBatch, PreparedStateRowRef};
 use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::future::Future;
@@ -165,6 +166,7 @@ pub(crate) async fn commit_prepared_writes(
         &commit_parent_heads,
         read,
         &BTreeMap::new(),
+        &BTreeMap::new(),
         prepared_writes,
     )
     .await?;
@@ -204,6 +206,7 @@ pub(crate) async fn commit_prepared_writes_with_parent_heads(
     commit_parent_heads: &BTreeMap<String, Option<CommitId>>,
     read: &mut impl StorageAdapterRead,
     branch_checkpoint_bridges: &BTreeMap<String, crate::gc::CheckpointRecoveryRef>,
+    restore_targets: &BTreeMap<String, PendingRestoreIntent>,
     prepared_writes: PreparedWriteSet,
 ) -> Result<MaterializedCommit, LixError> {
     Box::pin(validate_active_account_and_account_rows(
@@ -326,6 +329,7 @@ pub(crate) async fn commit_prepared_writes_with_parent_heads(
     // shared parsed column; every later materialization stage consumes this
     // map plus canonical arena slices.
     let explicit_branch_targets = explicit_branch_head_targets(&state_rows)?;
+    validate_restore_targets(&explicit_branch_targets, restore_targets)?;
     let deleted_checkpoint_branches = explicit_branch_targets
         .iter()
         .filter_map(|(branch_id, target)| target.head_commit_id.is_none().then_some(branch_id))
@@ -707,11 +711,14 @@ pub(crate) async fn commit_prepared_writes_with_parent_heads(
     let branch_control_observations =
         observe_branch_head_controls(read, &tracked_roots, &state_rows, &engine_rows).await?;
 
+    validate_restore_observed_heads(restore_targets, &branch_control_observations)?;
+
     reject_explicit_branch_ref_lifecycle_with_untracked_rows(
         read,
         &state_rows,
         &engine_rows,
         &explicit_branch_targets,
+        restore_targets,
         &branch_control_observations,
     )
     .await?;
@@ -805,6 +812,7 @@ pub(crate) async fn commit_prepared_writes_with_parent_heads(
         &state_rows,
         &engine_rows,
         &explicit_branch_targets,
+        restore_targets,
         &insert_selection,
         &prepared_writes.checkpoint_publications,
         branch_checkpoint_bridges,
@@ -5198,33 +5206,109 @@ async fn stage_root_backed_branch_publication(
     head_commit_id: CommitId,
     target: &ExplicitBranchHeadTarget,
     previous_control: Option<BranchHeadControl>,
+    restore: bool,
     stage_initial_working_diff_epoch: bool,
     state_rows: &PreparedStateBatch,
     engine_rows: &[EngineCurrentRow],
     insert_selection: &PreparedInsertSelection,
 ) -> Result<BranchHeadControl, LixError> {
     let tracked_head = TrackedHeadContext::new();
+    let untracked_deltas = state_rows
+        .iter()
+        .filter(|row| {
+            row.untracked
+                && row.branch_id.as_str() == branch_id
+                && row.schema_key != BRANCH_REF_SCHEMA_KEY
+        })
+        .map(current_state_delta_from_state_row)
+        .chain(
+            engine_rows
+                .iter()
+                .filter(|row| row.branch_id == branch_id)
+                .map(|row| Ok(current_state_delta_from_engine_row(row))),
+        )
+        .collect::<Result<Vec<_>, _>>()?;
+    let absence_guards = if insert_selection.is_empty() {
+        BTreeSet::new()
+    } else {
+        state_rows
+            .iter()
+            .enumerate()
+            .filter(|(row_index, row)| {
+                row.untracked
+                    && row.branch_id.as_str() == branch_id
+                    && row.schema_key != BRANCH_REF_SCHEMA_KEY
+                    && row.snapshot.is_some()
+                    && insert_selection.contains(*row_index)
+            })
+            .map(|(_, row)| TrackedStateKey {
+                schema_key: row.schema_key.to_string(),
+                file_id: row.file_id.map(ToString::to_string),
+                row_pk: row.row_pk.clone(),
+            })
+            .collect()
+    };
     // Tracked and untracked rows share one serving generation, so minting a
     // fresh one strands the branch's history-free rows in the old one. A
     // republication that does not move the head therefore keeps its
     // generation; there is nothing new to serve and nothing to copy.
     //
-    // A publication that *does* move the head (or deletes the branch) is
-    // destructive, and `reject_explicit_branch_ref_lifecycle_with_untracked_rows`
-    // already refuses it while branch-local untracked rows exist — so a fresh
-    // generation there is only ever reached with no untracked rows to lose.
-    let reused_generation = previous_control
+    // Generic lifecycle repoints reject branch-local untracked rows. Restore
+    // is the deliberate exception: it publishes the historical tracked
+    // snapshot and copies those history-free rows into one fresh generation.
+    let reused_generation = (!restore)
+        .then_some(previous_control)
+        .flatten()
         .filter(|previous| previous.head_commit_id == head_commit_id)
         .map(|previous| previous.tracked_generation);
     let generation = match reused_generation {
         Some(generation) => generation,
         None => {
             let generation = lifecycle_generation(branch_id, head_commit_id, target.ref_change_id);
-            tracked_head.writer(read, writes).stage_root_current_base(
-                branch_id,
-                generation,
-                head_commit_id,
-            );
+            if restore {
+                let previous = previous_control.ok_or_else(|| {
+                    LixError::new(
+                        LixError::CODE_INTERNAL_ERROR,
+                        format!("restore publication for branch '{branch_id}' has no prior head"),
+                    )
+                })?;
+                let target_rows =
+                    load_persisted_lifecycle_tracked_snapshot(read, branch_id, head_commit_id)
+                        .await?
+                        .into_values()
+                        .collect();
+                let target_snapshot = HotTrackedSnapshot::from_materialized_rows(target_rows)?;
+                let mut coverage = WorkingDiffIndexCoverage::default();
+                tracked_head
+                    .writer(read, writes)
+                    .stage_complete_current_state_with_working_diff(
+                        branch_id,
+                        generation,
+                        target_snapshot,
+                        Some(previous.tracked_generation),
+                        &[],
+                        &untracked_deltas,
+                        &absence_guards,
+                        Some(head_commit_id),
+                        &mut coverage,
+                    )
+                    .await?;
+                stage_tracked_working_diff_epoch(
+                    writes,
+                    branch_id,
+                    TrackedWorkingDiffEpoch {
+                        checkpoint_commit_id: head_commit_id,
+                        generation,
+                        coverage,
+                    },
+                )?;
+            } else {
+                tracked_head.writer(read, writes).stage_root_current_base(
+                    branch_id,
+                    generation,
+                    head_commit_id,
+                );
+            }
             generation
         }
     };
@@ -5248,14 +5332,13 @@ async fn stage_root_backed_branch_publication(
             // revision for every reader holding the previous one.
             Some(control) => next_current_state_revision(control.current_state_revision)?,
         },
-        // A branch is born at a complete authenticated root. Its private
-        // working interval therefore starts at that exact head; no logical
-        // checkpoint row or history scan is needed to recover the cursor.
-        // Explicit lifecycle moves of an existing branch instead keep that
-        // branch's own compaction baseline.
-        working_diff_checkpoint_commit_id: match previous_control {
-            None => Some(head_commit_id),
-            Some(control) => control.working_diff_checkpoint_commit_id,
+        // A branch born at a complete authenticated root and an existing
+        // branch restored to one both start a private working interval at the
+        // exact target. Generic lifecycle moves keep the existing baseline.
+        working_diff_checkpoint_commit_id: match (restore, previous_control) {
+            (true, _) => Some(head_commit_id),
+            (false, None) => Some(head_commit_id),
+            (false, Some(control)) => control.working_diff_checkpoint_commit_id,
         },
         created_at: previous_control.map_or(target.created_at, |control| control.created_at),
         updated_at: target.updated_at,
@@ -5264,47 +5347,12 @@ async fn stage_root_backed_branch_publication(
         // conservative until immutable roots carry schema summaries.
         schema_presence_bloom: [u64::MAX; 4],
     };
-    let untracked_deltas = state_rows
-        .iter()
-        .filter(|row| {
-            row.untracked
-                && row.branch_id.as_str() == branch_id
-                && row.schema_key != BRANCH_REF_SCHEMA_KEY
-        })
-        .map(current_state_delta_from_state_row)
-        .chain(
-            engine_rows
-                .iter()
-                .filter(|row| row.branch_id == branch_id)
-                .map(|row| Ok(current_state_delta_from_engine_row(row))),
-        )
-        .collect::<Result<Vec<_>, _>>()?;
-    if !untracked_deltas.is_empty() {
+    if !restore && !untracked_deltas.is_empty() {
         // A new branch has not consumed its revision yet; an existing branch
         // already advanced one above for this same publication.
         let revision = match previous_control {
             None => next_current_state_revision(control.current_state_revision)?,
             Some(_) => control.current_state_revision,
-        };
-        let absence_guards = if insert_selection.is_empty() {
-            BTreeSet::new()
-        } else {
-            state_rows
-                .iter()
-                .enumerate()
-                .filter(|(row_index, row)| {
-                    row.untracked
-                        && row.branch_id.as_str() == branch_id
-                        && row.schema_key != BRANCH_REF_SCHEMA_KEY
-                        && row.snapshot.is_some()
-                        && insert_selection.contains(*row_index)
-                })
-                .map(|(_, row)| TrackedStateKey {
-                    schema_key: row.schema_key.to_string(),
-                    file_id: row.file_id.map(ToString::to_string),
-                    row_pk: row.row_pk.clone(),
-                })
-                .collect()
         };
         let mut untracked_coverage = WorkingDiffIndexCoverage::default();
         tracked_head
@@ -5334,6 +5382,7 @@ async fn stage_branch_head_control_publications(
     state_rows: &PreparedStateBatch,
     engine_rows: &[EngineCurrentRow],
     explicit_branch_targets: &BTreeMap<String, ExplicitBranchHeadTarget>,
+    restore_targets: &BTreeMap<String, PendingRestoreIntent>,
     insert_selection: &PreparedInsertSelection,
     checkpoint_publications: &[crate::gc::CheckpointPublication],
     branch_checkpoint_bridges: &BTreeMap<String, crate::gc::CheckpointRecoveryRef>,
@@ -5392,6 +5441,9 @@ async fn stage_branch_head_control_publications(
                     head_commit_id,
                     target,
                     existing,
+                    restore_targets
+                        .get(branch_id)
+                        .is_some_and(|intent| intent.target_commit_id == head_commit_id),
                     existing.is_none() && !branch_checkpoint_bridges.contains_key(branch_id),
                     state_rows,
                     engine_rows,
@@ -5722,6 +5774,48 @@ fn explicit_branch_head_targets(
     Ok(targets)
 }
 
+fn validate_restore_targets(
+    explicit_branch_targets: &BTreeMap<String, ExplicitBranchHeadTarget>,
+    restore_targets: &BTreeMap<String, PendingRestoreIntent>,
+) -> Result<(), LixError> {
+    for (branch_id, intent) in restore_targets {
+        let explicit_commit_id = explicit_branch_targets
+            .get(branch_id)
+            .and_then(|target| target.head_commit_id);
+        if explicit_commit_id != Some(intent.target_commit_id) {
+            return Err(LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                format!(
+                    "restore intent for branch '{branch_id}' does not match its staged branch ref"
+                ),
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn validate_restore_observed_heads(
+    restore_targets: &BTreeMap<String, PendingRestoreIntent>,
+    observations: &BTreeMap<String, BranchHeadControlObservation>,
+) -> Result<(), LixError> {
+    for (branch_id, intent) in restore_targets {
+        let observed_head = observations
+            .get(branch_id)
+            .and_then(|observation| observation.control)
+            .map(|control| control.head_commit_id);
+        if observed_head != Some(intent.expected_head_commit_id) {
+            return Err(LixError::new(
+                LixError::CODE_TRANSACTION_CONFLICT,
+                format!(
+                    "branch '{branch_id}' HEAD changed while restoring from '{}' to '{}'",
+                    intent.expected_head_commit_id, intent.target_commit_id
+                ),
+            ));
+        }
+    }
+    Ok(())
+}
+
 /// A destructive branch-ref change cannot preserve branch-local untracked
 /// rows. Deletion would orphan their only serving scope and repointing would
 /// attach them to unrelated tracked history. Assigning the already-published
@@ -5735,10 +5829,21 @@ async fn reject_explicit_branch_ref_lifecycle_with_untracked_rows(
     state_rows: &PreparedStateBatch,
     engine_rows: &[EngineCurrentRow],
     explicit_branch_targets: &BTreeMap<String, ExplicitBranchHeadTarget>,
+    restore_targets: &BTreeMap<String, PendingRestoreIntent>,
     observations: &BTreeMap<String, BranchHeadControlObservation>,
 ) -> Result<(), LixError> {
     let current_state = TrackedHeadContext::new().reader(read);
     for (branch_id, target) in explicit_branch_targets {
+        if target
+            .head_commit_id
+            .is_some_and(|commit_id| {
+                restore_targets
+                    .get(branch_id)
+                    .is_some_and(|intent| intent.target_commit_id == commit_id)
+            })
+        {
+            continue;
+        }
         let Some(existing) = observations
             .get(branch_id)
             .and_then(|observation| observation.control)
@@ -6895,6 +7000,41 @@ mod tests {
         LixTimestamp::expect_parse("timestamp", value)
     }
 
+    #[test]
+    fn restore_rejects_a_commit_time_head_that_differs_from_the_validated_head() {
+        let branch_id = "01960000-0000-7000-8000-0000000000a1";
+        let expected_head = commit_id("restore-validated-head");
+        let target = commit_id("restore-validated-target");
+        let concurrent_head = commit_id("restore-concurrent-head");
+        let restore_targets = BTreeMap::from([(
+            branch_id.to_owned(),
+            PendingRestoreIntent {
+                expected_head_commit_id: expected_head,
+                target_commit_id: target,
+            },
+        )]);
+        let observations = BTreeMap::from([(
+            branch_id.to_owned(),
+            BranchHeadControlObservation {
+                control: Some(BranchHeadControl {
+                    head_commit_id: concurrent_head,
+                    tracked_generation: concurrent_head,
+                    current_state_revision: 1,
+                    working_diff_checkpoint_commit_id: Some(concurrent_head),
+                    created_at: ts("2026-01-01T00:00:00Z"),
+                    updated_at: ts("2026-01-02T00:00:00Z"),
+                    ref_change_id: change_id("restore-concurrent-ref"),
+                    schema_presence_bloom: [0; 4],
+                }),
+                raw_token: None,
+            },
+        )]);
+
+        let error = validate_restore_observed_heads(&restore_targets, &observations)
+            .expect_err("a concurrent branch move must invalidate restore ancestry validation");
+        assert_eq!(error.code, LixError::CODE_TRANSACTION_CONFLICT);
+    }
+
     #[tokio::test]
     async fn branch_creation_owner_publishes_checkpoint_serving_context() {
         let storage = StorageAdapter::new(Memory::new());
@@ -6927,6 +7067,7 @@ mod tests {
             &PreparedStateBatch::new(),
             &[],
             &BTreeMap::from([(branch_id.to_owned(), target)]),
+            &BTreeMap::new(),
             &PreparedInsertSelection::new(),
             &[],
             &BTreeMap::from([(branch_id.to_owned(), bridge.clone())]),

--- a/packages/lix/src/transaction/context.rs
+++ b/packages/lix/src/transaction/context.rs
@@ -266,6 +266,8 @@ where
         && b.atomic_metadata_preconditions.is_empty()
         && a.pending_branch_checkpoint_replacements.is_empty()
         && b.pending_branch_checkpoint_replacements.is_empty()
+        && a.pending_restore_targets.is_empty()
+        && b.pending_restore_targets.is_empty()
         && !a.await_durable_commit
         && !b.await_durable_commit
         && eligible_a
@@ -707,8 +709,18 @@ pub(crate) struct Transaction<StorageImpl: Storage + 'static = Memory> {
     /// delayed to the coherent commit-boundary read so its queue observation
     /// is fenced by the same branch publication batch.
     pending_branch_checkpoint_replacements: BTreeMap<String, CommitId>,
+    /// Existing branches that are being restored to an ancestor. Restore is
+    /// a ref move, but unlike a generic repoint it must carry branch-local
+    /// untracked rows forward and reset the private working-diff epoch.
+    pending_restore_targets: BTreeMap<String, PendingRestoreIntent>,
     plugin_generation_read_guard: Option<tokio::sync::OwnedRwLockReadGuard<()>>,
     plugin_generation_upgrade_guard: Option<tokio::sync::OwnedRwLockWriteGuard<()>>,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) struct PendingRestoreIntent {
+    pub(crate) expected_head_commit_id: CommitId,
+    pub(crate) target_commit_id: CommitId,
 }
 
 struct TransactionMutationJournal {
@@ -1588,6 +1600,7 @@ where
                     pending_file_view_mutations: BTreeMap::new(),
                     pending_plugin_actor_publications: Vec::new(),
                     pending_branch_checkpoint_replacements: BTreeMap::new(),
+                    pending_restore_targets: BTreeMap::new(),
                     plugin_generation_read_guard: None,
                     plugin_generation_upgrade_guard: None,
                 },
@@ -1691,6 +1704,7 @@ where
                 return Err(error);
             }
         };
+        let restore_targets = std::mem::take(&mut transaction.pending_restore_targets);
         let commit_parent_heads = match commit::resolve_prepared_commit_parent_heads(
             transaction.branch_ctx.as_ref(),
             &read,
@@ -1763,6 +1777,7 @@ where
                 &commit_parent_heads,
                 &mut read,
                 &branch_checkpoint_bridges,
+                &restore_targets,
                 prepared_writes,
             )
             .instrument(tracing::debug_span!(
@@ -7600,6 +7615,33 @@ where
             rows,
         })
         .await?;
+        Ok(())
+    }
+
+    /// Stages an ancestor restore for commit-time lifecycle publication.
+    pub(crate) async fn restore_branch_ref(
+        &mut self,
+        branch_id: &str,
+        expected_head_commit_id: CommitId,
+        target_commit_id: CommitId,
+    ) -> Result<(), LixError> {
+        self.advance_branch_ref(branch_id, target_commit_id).await?;
+        if self
+            .pending_restore_targets
+            .insert(
+                branch_id.to_owned(),
+                PendingRestoreIntent {
+                    expected_head_commit_id,
+                    target_commit_id,
+                },
+            )
+            .is_some()
+        {
+            return Err(LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                format!("branch '{branch_id}' staged more than one restore"),
+            ));
+        }
         Ok(())
     }
 

--- a/packages/lix/tests/integration/main.rs
+++ b/packages/lix/tests/integration/main.rs
@@ -22,6 +22,7 @@ mod observe_mutation_revision;
 mod physical_plan_cache;
 mod pooled_session_reuse;
 mod read_retry;
+mod restore;
 mod sql;
 mod storage_accounting;
 mod transaction;

--- a/packages/lix/tests/integration/restore.rs
+++ b/packages/lix/tests/integration/restore.rs
@@ -1,0 +1,349 @@
+use lix::{CreateBranchOptions, LixError, SwitchBranchOptions, Value};
+use serde_json::json;
+
+use crate::support::simulation_test::engine::SimSession;
+
+simulation_test!(
+    restore_moves_only_the_active_branch_to_an_ancestor,
+    |sim| async move {
+        let engine = sim.boot_engine().await;
+        let session = sim.wrap_session(
+            engine.open_session().await.expect("session should open"),
+            &engine,
+        );
+        let initial_commit_id = sim.initial_commit_id().to_string();
+
+        session
+            .execute(
+                "INSERT INTO lix_file (path, content) VALUES ('/a.txt', CAST('a' AS BYTEA))",
+                &[],
+            )
+            .await
+            .expect("first file should commit");
+        let target_commit_id = head(&session).await;
+
+        let other_branch = session
+            .create_branch(CreateBranchOptions {
+                id: None,
+                name: "restore-control".to_string(),
+                from_commit_id: None,
+            })
+            .await
+            .expect("control branch should be created");
+
+        session
+            .execute(
+                "INSERT INTO lix_file (path, content) VALUES ('/b.txt', CAST('b' AS BYTEA))",
+                &[],
+            )
+            .await
+            .expect("second file should commit");
+        let abandoned_head = head(&session).await;
+        let commit_count_before = count(&session, "lix_commit").await;
+
+        session
+            .restore(target_commit_id.clone())
+            .await
+            .expect("ancestor restore should succeed");
+        assert_eq!(head(&session).await, target_commit_id);
+        assert_eq!(count(&session, "lix_commit").await, commit_count_before);
+        assert_eq!(count(&session, "lix_file").await, 1);
+        let files = session
+            .execute("SELECT path FROM lix_file ORDER BY path", &[])
+            .await
+            .expect("files should read");
+        assert_eq!(files.rows()[0].get::<String>("path").unwrap(), "/a.txt");
+        let abandoned_commit = session
+            .execute(
+                "SELECT COUNT(*) AS count FROM lix_commit WHERE id = $1",
+                &[Value::Text(abandoned_head)],
+            )
+            .await
+            .expect("abandoned commit should remain stored");
+        assert_eq!(
+            abandoned_commit.rows()[0].get::<i64>("count").unwrap(),
+            1,
+            "restore must not delete orphaned commits"
+        );
+
+        session
+            .switch_branch(SwitchBranchOptions {
+                branch_id: other_branch.id,
+            })
+            .await
+            .expect("control branch should still exist");
+        assert_eq!(head(&session).await, other_branch.commit_id);
+        assert_eq!(count(&session, "lix_file").await, 1);
+
+        session
+            .restore(initial_commit_id.clone())
+            .await
+            .expect("parentless commit should be restorable");
+        assert_eq!(head(&session).await, initial_commit_id);
+        assert_eq!(count(&session, "lix_file").await, 0);
+    }
+);
+
+simulation_test!(
+    restore_noop_and_errors_leave_head_unchanged,
+    |sim| async move {
+        let engine = sim.boot_engine().await;
+        let session = sim.wrap_session(
+            engine.open_session().await.expect("session should open"),
+            &engine,
+        );
+
+        session
+            .execute(
+                "INSERT INTO lix_key_value (key, value) VALUES ('main', 'one')",
+                &[],
+            )
+            .await
+            .expect("main change should commit");
+        let main_branch_id = session
+            .active_branch_id()
+            .await
+            .expect("main branch id should read");
+        let main_head = head(&session).await;
+        let commit_count = count(&session, "lix_commit").await;
+
+        session
+            .restore(main_head.clone())
+            .await
+            .expect("restoring HEAD should be a no-op");
+        assert_eq!(head(&session).await, main_head);
+        assert_eq!(count(&session, "lix_commit").await, commit_count);
+
+        let missing = "01990000-0000-7000-8000-00000000dead";
+        let missing_error = session
+            .restore(missing)
+            .await
+            .expect_err("missing target should fail");
+        assert_eq!(missing_error.code, LixError::CODE_COMMIT_NOT_FOUND);
+        assert_eq!(head(&session).await, main_head);
+
+        let fork = session
+            .create_branch(CreateBranchOptions {
+                id: None,
+                name: "unrelated-restore-target".to_string(),
+                from_commit_id: None,
+            })
+            .await
+            .expect("fork should be created");
+        session
+            .switch_branch(SwitchBranchOptions {
+                branch_id: fork.id.clone(),
+            })
+            .await
+            .expect("fork should be active");
+        session
+            .execute(
+                "UPDATE lix_key_value SET value = 'fork' WHERE key = 'main'",
+                &[],
+            )
+            .await
+            .expect("fork change should commit");
+        let fork_head = head(&session).await;
+
+        session
+            .switch_branch(SwitchBranchOptions {
+                branch_id: main_branch_id,
+            })
+            .await
+            .expect("main should be active again");
+        let commit_count_before_rejection = count(&session, "lix_commit").await;
+        let error = session
+            .restore(fork_head)
+            .await
+            .expect_err("non-ancestor target should fail");
+        assert_eq!(error.code, LixError::CODE_CONSTRAINT_VIOLATION);
+        assert_eq!(head(&session).await, main_head);
+        assert_eq!(
+            count(&session, "lix_commit").await,
+            commit_count_before_rejection
+        );
+    }
+);
+
+simulation_test!(
+    restore_keeps_checkpoint_rows_for_orphaned_commits,
+    |sim| async move {
+        let engine = sim.boot_engine().await;
+        let session = sim.wrap_session(
+            engine.open_session().await.expect("session should open"),
+            &engine,
+        );
+
+        session
+            .execute(
+                "INSERT INTO lix_key_value (key, value) VALUES ('checkpointed', 'one')",
+                &[],
+            )
+            .await
+            .expect("first value should commit");
+        let first_checkpoint = session
+            .create_checkpoint()
+            .await
+            .expect("first checkpoint should commit");
+        session
+            .execute(
+                "UPDATE lix_key_value SET value = 'two' WHERE key = 'checkpointed'",
+                &[],
+            )
+            .await
+            .expect("second value should commit");
+        let orphaned_checkpoint = session
+            .create_checkpoint()
+            .await
+            .expect("second checkpoint should commit");
+        let commit_count_before = count(&session, "lix_commit").await;
+
+        session
+            .restore(first_checkpoint.commit_id.clone())
+            .await
+            .expect("earlier checkpoint should be restorable");
+
+        assert_eq!(head(&session).await, first_checkpoint.commit_id);
+        assert_eq!(count(&session, "lix_commit").await, commit_count_before);
+        let value = session
+            .execute(
+                "SELECT value FROM lix_key_value WHERE key = 'checkpointed'",
+                &[],
+            )
+            .await
+            .expect("restored value should read");
+        assert_eq!(
+            value.rows()[0].get::<serde_json::Value>("value").unwrap(),
+            json!("one")
+        );
+        let checkpoint_row = session
+            .execute(
+                "SELECT COUNT(*) AS count FROM lix_checkpoint WHERE id = $1",
+                &[Value::Text(orphaned_checkpoint.commit_id)],
+            )
+            .await
+            .expect("orphaned checkpoint row should read");
+        assert_eq!(
+            checkpoint_row.rows()[0].get::<i64>("count").unwrap(),
+            1,
+            "restore must retain checkpoint markers for orphaned commits"
+        );
+
+        let undo_error = session
+            .undo()
+            .await
+            .expect_err("restore target should start a fresh undo interval");
+        assert_eq!(undo_error.code, LixError::CODE_NOTHING_TO_UNDO);
+
+        session
+            .execute(
+                "UPDATE lix_key_value SET value = 'after-restore' WHERE key = 'checkpointed'",
+                &[],
+            )
+            .await
+            .expect("tracked writes should work after restore");
+        session
+            .undo()
+            .await
+            .expect("a new edit after restore should be undoable");
+        let after_undo = session
+            .execute(
+                "SELECT value FROM lix_key_value WHERE key = 'checkpointed'",
+                &[],
+            )
+            .await
+            .expect("state after undo should read");
+        assert_eq!(
+            after_undo.rows()[0]
+                .get::<serde_json::Value>("value")
+                .unwrap(),
+            json!("one"),
+            "undo after restore must reverse the new edit, not the restore"
+        );
+        session
+            .create_checkpoint()
+            .await
+            .expect("checkpoint cursor should remain usable after restore");
+    }
+);
+
+simulation_test!(
+    restore_preserves_branch_local_untracked_rows,
+    |sim| async move {
+        let engine = sim.boot_engine().await;
+        let session = sim.wrap_session(
+            engine.open_session().await.expect("session should open"),
+            &engine,
+        );
+
+        session
+            .execute(
+                "INSERT INTO lix_key_value (key, value) VALUES ('tracked', 'target')",
+                &[],
+            )
+            .await
+            .expect("target state should commit");
+        let target = head(&session).await;
+        session
+            .execute(
+                "UPDATE lix_key_value SET value = 'later' WHERE key = 'tracked'",
+                &[],
+            )
+            .await
+            .expect("later state should commit");
+        session
+            .execute(
+                "INSERT INTO lix_key_value (key, value, lixcol_untracked) VALUES ('local', 'kept', true)",
+                &[],
+            )
+            .await
+            .expect("branch-local untracked state should insert");
+
+        session
+            .restore(target.clone())
+            .await
+            .expect("restore should retain untracked state");
+        assert_eq!(head(&session).await, target);
+
+        let values = session
+            .execute(
+                "SELECT key, value, lixcol_untracked FROM lix_key_value WHERE key IN ('local', 'tracked') ORDER BY key",
+                &[],
+            )
+            .await
+            .expect("restored state should read");
+        assert_eq!(values.rows().len(), 2);
+        assert_eq!(values.rows()[0].get::<String>("key").unwrap(), "local");
+        assert_eq!(
+            values.rows()[0].get::<serde_json::Value>("value").unwrap(),
+            json!("kept")
+        );
+        assert!(values.rows()[0].get::<bool>("lixcol_untracked").unwrap());
+        assert_eq!(values.rows()[1].get::<String>("key").unwrap(), "tracked");
+        assert_eq!(
+            values.rows()[1].get::<serde_json::Value>("value").unwrap(),
+            json!("target")
+        );
+        assert!(!values.rows()[1].get::<bool>("lixcol_untracked").unwrap());
+    }
+);
+
+async fn head(session: &SimSession) -> String {
+    let result = session
+        .execute("SELECT lix_active_branch_commit_id() AS commit_id", &[])
+        .await
+        .expect("HEAD should read");
+    result.rows()[0]
+        .get::<String>("commit_id")
+        .expect("HEAD should be text")
+}
+
+async fn count(session: &SimSession, table: &str) -> i64 {
+    let result = session
+        .execute(&format!("SELECT COUNT(*) AS count FROM {table}"), &[])
+        .await
+        .expect("count should read");
+    result.rows()[0]
+        .get::<i64>("count")
+        .expect("count should be integer")
+}

--- a/packages/lix/tests/integration/support/simulation_test/engine/simulation.rs
+++ b/packages/lix/tests/integration/support/simulation_test/engine/simulation.rs
@@ -2,7 +2,7 @@ use lix::storage::Memory;
 use lix::{
     CreateBranchOptions, CreateBranchReceipt, CreateCheckpointReceipt, ExecuteResult,
     MergeBranchOptions, MergeBranchPreview, MergeBranchPreviewOptions, MergeBranchReceipt,
-    SessionTransaction, SwitchBranchOptions, SwitchBranchReceipt,
+    SessionTransaction, SwitchBranchOptions, SwitchBranchReceipt, UndoReceipt,
 };
 use lix::{LixError, Value};
 use lix::{engine::Engine, init::InitReceipt, session::SessionContext};
@@ -182,6 +182,22 @@ impl SimSession {
 
     pub async fn create_checkpoint(&self) -> Result<CreateCheckpointReceipt, LixError> {
         let result = self.session.create_checkpoint().await;
+        if result.is_ok() {
+            self.sim.rebuild_tracked_state.after_successful_write();
+        }
+        result
+    }
+
+    pub async fn restore(&self, commit_id: impl Into<String>) -> Result<(), LixError> {
+        let result = self.session.restore(commit_id.into()).await;
+        if result.is_ok() {
+            self.sim.rebuild_tracked_state.after_successful_write();
+        }
+        result
+    }
+
+    pub async fn undo(&self) -> Result<UndoReceipt, LixError> {
+        let result = self.session.undo().await;
         if result.is_ok() {
             self.sim.rebuild_tracked_state.after_successful_write();
         }


### PR DESCRIPTION
## Summary

- add Rust `Lix::restore(commit_id)` and JavaScript `lix.restore(commitId)` APIs
- move only the active branch HEAD to an existing ancestor without creating or replaying commits
- expose restore through native, WASM, worker, and remote server-protocol bindings
- retain orphaned commits and checkpoints while allowing normal garbage collection once unreachable
- preserve branch-local untracked state and reject stale concurrent restores

## Validation

- `cargo test -p lix --features all-simulations` (2997 passed, 26 ignored)
- `cargo check -p lix --features server-protocol,server-protocol-client`
- `cargo check -p lix_js_sdk`
- `npm run typecheck` in `packages/js-sdk`
- JS SDK local, remote, and browser test suites
- `cargo clippy -p lix --features all-simulations --lib -- -D warnings`
- `cargo clippy -p lix_js_sdk --all-targets -- -D warnings`
- `git diff --check`

## Semantics

The target must exist and be reachable by walking parents from the current branch HEAD. Restoring to HEAD is a no-op. Other branches are unchanged, no new commit is inserted, and commits/checkpoints beyond the restored HEAD remain stored until ordinary reachability-based GC removes unreferenced data.