### PR TITLE
test(sync): add deterministic replica simulation

### DIFF
--- a/packages/lix/src/sync/mod.rs
+++ b/packages/lix/src/sync/mod.rs
@@ -15,6 +15,8 @@ mod platform;
 mod protocol;
 mod repository;
 mod runtime;
+#[cfg(test)]
+mod simulation_tests;
 
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU8, Ordering};

--- a/packages/lix/src/sync/repository.rs
+++ b/packages/lix/src/sync/repository.rs
@@ -2044,6 +2044,23 @@ where
                         let local = local_coordinates
                             .get(&update.branch_id)
                             .expect("delta branch was loaded once");
+                        let first_update_for_branch =
+                            !branch_chains.contains_key(&update.branch_id);
+                        if first_update_for_branch
+                            && local.0.as_deref() != authoritative
+                            && let Some(authoritative) = authoritative
+                        {
+                            // A divergent local chain can still terminate at
+                            // the authority head that was current when its
+                            // first offline commit was authored. Once this ref
+                            // advances, authoritative_branches no longer names
+                            // that dependency frontier. Retain exactly that
+                            // old tip until the reconciled push acknowledges a
+                            // child whose parent-pruning removes it.
+                            state
+                                .authority_known_commit_ids
+                                .insert(authoritative.to_owned());
+                        }
                         let chain = branch_chains
                             .entry(update.branch_id.clone())
                             .or_insert_with(|| {

--- a/packages/lix/src/sync/runtime.rs
+++ b/packages/lix/src/sync/runtime.rs
@@ -65,12 +65,12 @@ pub(crate) struct PreparedSync {
 }
 
 #[derive(Debug)]
-struct PreparedRepositorySnapshot {
-    metadata: SyncRepositoryPullResponse,
-    commits: Vec<super::SyncCommit>,
-    commit_headers: Vec<super::SyncCommitHeader>,
-    rows: Vec<super::SyncSnapshotRow>,
-    checkpoint_roots: BTreeMap<String, String>,
+pub(super) struct PreparedRepositorySnapshot {
+    pub(super) metadata: SyncRepositoryPullResponse,
+    pub(super) commits: Vec<super::SyncCommit>,
+    pub(super) commit_headers: Vec<super::SyncCommitHeader>,
+    pub(super) rows: Vec<super::SyncSnapshotRow>,
+    pub(super) checkpoint_roots: BTreeMap<String, String>,
 }
 
 /// Performs the fresh-store bootstrap network operation exactly once.
@@ -88,7 +88,7 @@ pub(crate) async fn prepare_sync_mode(
     })
 }
 
-async fn fetch_repository_snapshot<Transport>(
+pub(super) async fn fetch_repository_snapshot<Transport>(
     transport: &Transport,
 ) -> Result<(PreparedRepositorySnapshot, String, String), LixError>
 where
@@ -583,7 +583,7 @@ where
     }
 }
 
-async fn sync_iteration<StorageImpl, Transport>(
+pub(super) async fn sync_iteration<StorageImpl, Transport>(
     lix: &Lix<StorageImpl>,
     remote_id: &str,
     transport: &Transport,
@@ -1082,7 +1082,7 @@ where
     Ok(response)
 }
 
-async fn register_blob_manifests<StorageImpl, Transport>(
+pub(super) async fn register_blob_manifests<StorageImpl, Transport>(
     lix: &Lix<StorageImpl>,
     transport: &Transport,
     commits: &[super::SyncCommit],
@@ -1121,6 +1121,30 @@ where
         lix.put_sync_chunk(&chunk_id, &bytes).await?;
     }
     Ok(())
+}
+
+/// Drives the same lazy history/blob hydration path as a live sync worker.
+/// Kept test-only so deterministic simulations can advance without spawning
+/// background tasks or introducing a second demand implementation.
+#[cfg(test)]
+pub(super) async fn hydrate_error_for_test<StorageImpl, Transport>(
+    lix: &Lix<StorageImpl>,
+    transport: &Transport,
+    error: LixError,
+) -> Result<(), LixError>
+where
+    StorageImpl: Storage + Clone + Send + Sync + 'static,
+    Transport: SyncTransport,
+{
+    match sync_demand_request_for_error(&error)? {
+        Some(SyncDemandRequest::History(ids)) => {
+            hydrate_history_ids(lix, transport, ids.into_iter().collect()).await
+        }
+        Some(SyncDemandRequest::Chunks(ids)) => {
+            hydrate_chunk_ids(lix, transport, ids.into_iter().collect()).await
+        }
+        None => Err(error),
+    }
 }
 
 async fn push_request_blobs<StorageImpl, Transport>(

--- a/packages/lix/src/sync/simulation_tests.rs
+++ b/packages/lix/src/sync/simulation_tests.rs
@@ -1,0 +1,589 @@
+//! Fast deterministic coverage for the distributed sync state machine.
+//!
+//! The authority and replicas are real `Lix<Memory>` repositories. The only
+//! fake is transport delivery: tests advance one complete sync iteration with
+//! `pump()` and can deterministically disconnect or lose one push response.
+
+use std::fmt;
+use std::future::Future;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+
+use crate::engine::Engine;
+use crate::storage::Memory;
+use crate::support::fuzz_seeds;
+use crate::support::simulation_test::engine::{Simulation, SimulationMode, SimulationOptions};
+use crate::{Lix, LixError, Value, open_lix};
+
+use super::runtime::{
+    fetch_repository_snapshot, hydrate_error_for_test, register_blob_manifests, sync_iteration,
+};
+use super::{
+    SyncBlobManifest, SyncBlobRegistration, SyncHistoryResponse, SyncPushRequest, SyncPushResponse,
+    SyncRepositoryPullResponse, SyncRole, SyncSnapshotRowPage, SyncTransport, SyncTransportFuture,
+};
+
+const REMOTE_ID: &str = "memory://deterministic-sync-authority";
+const COMMANDS_PER_SEED: usize = 16;
+
+#[derive(Clone, Default)]
+struct DeliveryScript {
+    offline: Arc<AtomicBool>,
+    lose_next_push_response: Arc<AtomicBool>,
+}
+
+#[derive(Clone)]
+struct AuthorityTransport {
+    authority: Lix<Memory>,
+    script: DeliveryScript,
+}
+
+impl fmt::Debug for AuthorityTransport {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("AuthorityTransport")
+            .field("offline", &self.script.offline.load(Ordering::SeqCst))
+            .finish_non_exhaustive()
+    }
+}
+
+impl AuthorityTransport {
+    fn connected(authority: Lix<Memory>) -> Self {
+        Self {
+            authority,
+            script: DeliveryScript::default(),
+        }
+    }
+
+    fn set_offline(&self, offline: bool) {
+        self.script.offline.store(offline, Ordering::SeqCst);
+    }
+
+    fn lose_next_push_response(&self) {
+        self.script
+            .lose_next_push_response
+            .store(true, Ordering::SeqCst);
+    }
+
+    fn check_connected(&self) -> Result<(), LixError> {
+        if self.script.offline.load(Ordering::SeqCst) {
+            return Err(transport_error("scripted disconnect"));
+        }
+        Ok(())
+    }
+}
+
+impl SyncTransport for AuthorityTransport {
+    fn active_account_id(&self) -> &str {
+        crate::ANONYMOUS_ACCOUNT_ID
+    }
+
+    fn push<'a>(
+        &'a self,
+        request: &'a SyncPushRequest,
+    ) -> SyncTransportFuture<'a, SyncPushResponse> {
+        Box::pin(async move {
+            self.check_connected()?;
+            let response = self.authority.push_sync_repository(request).await?;
+            if self
+                .script
+                .lose_next_push_response
+                .swap(false, Ordering::SeqCst)
+            {
+                return Err(transport_error("scripted lost push response"));
+            }
+            Ok(response)
+        })
+    }
+
+    fn pull(
+        &self,
+        after: Option<u64>,
+        limit: usize,
+    ) -> SyncTransportFuture<'_, SyncRepositoryPullResponse> {
+        Box::pin(async move {
+            self.check_connected()?;
+            self.authority.pull_sync_repository(after, limit).await
+        })
+    }
+
+    fn snapshot_rows<'a>(
+        &'a self,
+        branch_id: &'a str,
+        head_commit_id: &'a str,
+        continuation: Option<&'a str>,
+        limit: usize,
+    ) -> SyncTransportFuture<'a, SyncSnapshotRowPage> {
+        Box::pin(async move {
+            self.check_connected()?;
+            self.authority
+                .pull_sync_snapshot_rows(branch_id, head_commit_id, continuation, limit)
+                .await
+        })
+    }
+
+    fn history<'a>(
+        &'a self,
+        head: &'a str,
+        limit: usize,
+    ) -> SyncTransportFuture<'a, SyncHistoryResponse> {
+        Box::pin(async move {
+            self.check_connected()?;
+            self.authority.sync_history(head, limit).await
+        })
+    }
+
+    fn get_blobs<'a>(
+        &'a self,
+        blob_ids: &'a [String],
+    ) -> SyncTransportFuture<'a, Vec<SyncBlobManifest>> {
+        Box::pin(async move {
+            self.check_connected()?;
+            let mut manifests = Vec::new();
+            for blob_id in blob_ids {
+                if let Some(manifest) = self.authority.get_sync_blob_manifest(blob_id).await? {
+                    manifests.push(manifest);
+                }
+            }
+            Ok(manifests)
+        })
+    }
+
+    fn register_blob<'a>(
+        &'a self,
+        manifest: &'a SyncBlobManifest,
+    ) -> SyncTransportFuture<'a, SyncBlobRegistration> {
+        Box::pin(async move {
+            self.check_connected()?;
+            self.authority.register_sync_blob_manifest(manifest).await
+        })
+    }
+
+    fn get_chunk<'a>(&'a self, chunk_id: &'a str) -> SyncTransportFuture<'a, Option<Vec<u8>>> {
+        Box::pin(async move {
+            self.check_connected()?;
+            self.authority.get_sync_chunk(chunk_id).await
+        })
+    }
+
+    fn put_chunk<'a>(&'a self, chunk_id: &'a str, bytes: &'a [u8]) -> SyncTransportFuture<'a, ()> {
+        Box::pin(async move {
+            self.check_connected()?;
+            self.authority.put_sync_chunk(chunk_id, bytes).await
+        })
+    }
+}
+
+struct Replica {
+    lix: Lix<Memory>,
+    storage: Memory,
+    transport: AuthorityTransport,
+    change_watcher: tokio::sync::watch::Receiver<u64>,
+    _demand_tx: tokio::sync::mpsc::Sender<super::runtime::SyncDemand>,
+    demand_rx: tokio::sync::mpsc::Receiver<super::runtime::SyncDemand>,
+    pending_demands: Vec<super::runtime::SyncDemand>,
+    push_item_limit: usize,
+    pull_item_limit: usize,
+}
+
+impl Replica {
+    async fn bootstrap(transport: AuthorityTransport) -> Self {
+        let (snapshot, authority_lix_id, default_branch_id) = fetch_repository_snapshot(&transport)
+            .await
+            .expect("simulation snapshot should load");
+        let storage = Memory::new();
+        Engine::initialize_with_main_branch_id(storage.clone(), Some(&default_branch_id))
+            .await
+            .expect("simulation replica should initialize");
+        let mut lix = open_lix()
+            .with_storage(storage.clone())
+            .await
+            .expect("simulation replica should open");
+        lix.set_sync_role(SyncRole::Replica)
+            .expect("simulation replica role should install");
+        register_blob_manifests(&lix, &transport, &snapshot.commits, &snapshot.rows)
+            .await
+            .expect("simulation snapshot blob manifests should register");
+        lix.apply_sync_repository_snapshot(
+            REMOTE_ID,
+            transport.active_account_id(),
+            &snapshot.metadata,
+            &snapshot.commits,
+            &snapshot.commit_headers,
+            &snapshot.rows,
+            &snapshot.checkpoint_roots,
+        )
+        .await
+        .expect("simulation snapshot should install");
+        lix.align_repository_identity_for_sync(authority_lix_id)
+            .expect("simulation repository identity should align");
+        lix.align_primary_account_for_sync(transport.active_account_id())
+            .await
+            .expect("simulation account should align");
+        Self::from_open_lix(lix, storage, transport)
+    }
+
+    fn from_open_lix(lix: Lix<Memory>, storage: Memory, transport: AuthorityTransport) -> Self {
+        let change_watcher = lix.sync_mode_state().change_watcher();
+        let (demand_tx, demand_rx) = tokio::sync::mpsc::channel(8);
+        Self {
+            lix,
+            storage,
+            transport,
+            change_watcher,
+            _demand_tx: demand_tx,
+            demand_rx,
+            pending_demands: Vec::new(),
+            push_item_limit: super::MAX_SYNC_REQUEST_ITEMS,
+            pull_item_limit: super::MAX_SYNC_REQUEST_ITEMS,
+        }
+    }
+
+    async fn pump(&mut self) -> Result<(), LixError> {
+        sync_iteration(
+            &self.lix,
+            REMOTE_ID,
+            &self.transport,
+            &mut self.push_item_limit,
+            &mut self.pull_item_limit,
+            &mut self.change_watcher,
+            &mut self.demand_rx,
+            &mut self.pending_demands,
+        )
+        .await
+    }
+
+    async fn restart(&mut self) {
+        let placeholder = open_lix()
+            .await
+            .expect("temporary simulation handle should open");
+        let previous = std::mem::replace(&mut self.lix, placeholder);
+        previous
+            .close()
+            .await
+            .expect("simulation replica should close before restart");
+        drop(previous);
+        let lix = open_lix()
+            .with_storage(self.storage.clone())
+            .await
+            .expect("simulation replica should reopen");
+        lix.set_sync_role(SyncRole::Replica)
+            .expect("reopened simulation replica role should install");
+        *self = Self::from_open_lix(lix, self.storage.clone(), self.transport.clone());
+    }
+
+    async fn write(&self, key: &str, value: &str) {
+        write_key_value(&self.lix, key, value).await;
+    }
+
+    async fn hydrate_and_retry(&self, sql: &str) {
+        let error = self
+            .lix
+            .execute(sql, &[])
+            .await
+            .expect_err("sparse read should request hydration");
+        hydrate_error_for_test(&self.lix, &self.transport, error)
+            .await
+            .expect("simulation demand should hydrate");
+        self.lix
+            .execute(sql, &[])
+            .await
+            .expect("hydrated read should succeed");
+    }
+}
+
+fn transport_error(message: &str) -> LixError {
+    LixError::new(super::http::SYNC_TRANSPORT_ERROR_CODE, message)
+}
+
+async fn write_key_value(lix: &Lix<Memory>, key: &str, value: &str) {
+    lix.execute(
+        "INSERT INTO lix_key_value (key, value) VALUES ($1, $2) \
+         ON CONFLICT (key) DO UPDATE SET value = excluded.value",
+        &[Value::Text(key.to_owned()), Value::Text(value.to_owned())],
+    )
+    .await
+    .expect("simulation write should commit");
+}
+
+async fn hot_digest(lix: &Lix<Memory>) -> Vec<(String, String)> {
+    lix.execute(
+        "SELECT key, value FROM lix_key_value \
+         WHERE lixcol_global = false ORDER BY key",
+        &[],
+    )
+    .await
+    .expect("simulation digest should query")
+    .rows()
+    .iter()
+    .map(|row| {
+        (
+            row.get::<String>("key").expect("digest key"),
+            row.get::<serde_json::Value>("value")
+                .expect("digest value")
+                .to_string(),
+        )
+    })
+    .collect()
+}
+
+async fn converge(authority: &Lix<Memory>, replicas: &mut [&mut Replica]) -> Result<(), LixError> {
+    for _ in 0..12 {
+        for replica in replicas.iter_mut() {
+            replica.pump().await?;
+        }
+        let expected = hot_digest(authority).await;
+        let mut equal = true;
+        for replica in replicas.iter() {
+            equal &= hot_digest(&replica.lix).await == expected;
+        }
+        if equal {
+            return Ok(());
+        }
+    }
+    panic!("replicas did not converge within the deterministic pump budget");
+}
+
+async fn authority_for_simulation(sim: &Simulation) -> Lix<Memory> {
+    let authority = open_lix()
+        .with_storage(sim.storage())
+        .await
+        .expect("simulation authority should open");
+    authority
+        .set_sync_role(SyncRole::Authority)
+        .expect("simulation authority role should install");
+    authority
+}
+
+async fn fresh_authority() -> Lix<Memory> {
+    let authority = open_lix().await.expect("fresh authority should open");
+    authority
+        .set_sync_role(SyncRole::Authority)
+        .expect("fresh authority role should install");
+    authority
+}
+
+fn run_sync_simulation<F, Fut>(case_id: &str, test_fn: F)
+where
+    F: Fn(Simulation) -> Fut,
+    Fut: Future<Output = ()>,
+{
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("sync simulation runtime should build");
+    runtime.block_on(
+        crate::support::simulation_test::engine::run_simulation_test(
+            SimulationMode::Base,
+            SimulationOptions {
+                deterministic: true,
+            },
+            case_id,
+            test_fn,
+        ),
+    );
+}
+
+macro_rules! sync_simulation_test {
+    ($name:ident, $scenario:ident) => {
+        paste::paste! {
+            #[test]
+            fn [<$name _base>]() {
+                run_sync_simulation(
+                    concat!(module_path!(), "::", stringify!($name)),
+                    $scenario,
+                );
+            }
+        }
+    };
+}
+
+async fn deterministic_replica_scenarios(sim: Simulation) {
+    let authority = authority_for_simulation(&sim).await;
+    let mut left = Replica::bootstrap(AuthorityTransport::connected(authority.clone())).await;
+    let mut right = Replica::bootstrap(AuthorityTransport::connected(authority.clone())).await;
+
+    left.write("left", "one").await;
+    left.pump().await.expect("left push should succeed");
+    right.pump().await.expect("right pull should succeed");
+    right.write("right", "two").await;
+    right.pump().await.expect("right push should succeed");
+    converge(&authority, &mut [&mut left, &mut right])
+        .await
+        .expect("two replicas should converge");
+
+    left.transport.lose_next_push_response();
+    left.write("lost-ack", "retry-me").await;
+    let error = left
+        .pump()
+        .await
+        .expect_err("the scripted push response should be lost");
+    assert_eq!(error.code, super::http::SYNC_TRANSPORT_ERROR_CODE);
+    converge(&authority, &mut [&mut left, &mut right])
+        .await
+        .expect("lost acknowledgement should converge");
+    assert_eq!(
+        hot_digest(&authority)
+            .await
+            .iter()
+            .filter(|(key, _)| key == "lost-ack")
+            .count(),
+        1,
+        "idempotent retry must publish one logical row",
+    );
+
+    right.transport.set_offline(true);
+    right.write("offline", "durable-outbox").await;
+    let error = right
+        .pump()
+        .await
+        .expect_err("offline push should remain queued");
+    assert_eq!(error.code, super::http::SYNC_TRANSPORT_ERROR_CODE);
+    right.restart().await;
+    right.transport.set_offline(false);
+    converge(&authority, &mut [&mut left, &mut right])
+        .await
+        .expect("offline restart should converge");
+
+    for index in 0..3 {
+        right
+            .write(&format!("divergent-right-{index}"), "right")
+            .await;
+    }
+    left.write("divergent-left-a", "left").await;
+    left.write("divergent-left-b", "left").await;
+    right.pump().await.expect("right divergence should publish");
+    left.pump()
+        .await
+        .expect("left divergence should pull and reconcile");
+    left.restart().await;
+    right.restart().await;
+    converge(&authority, &mut [&mut left, &mut right])
+        .await
+        .expect("reconciled offline chains should survive restart");
+}
+
+async fn lazy_history_and_binary_cas_scenarios(sim: Simulation) {
+    let authority = authority_for_simulation(&sim).await;
+    write_key_value(&authority, "history-0", "0").await;
+    let cold_commit_id = authority
+        .execute("SELECT lix_active_branch_commit_id() AS id", &[])
+        .await
+        .expect("cold history coordinate should load")
+        .rows()[0]
+        .get::<String>("id")
+        .expect("cold history coordinate should decode");
+    for index in 1..8 {
+        write_key_value(&authority, &format!("history-{index}"), &index.to_string()).await;
+    }
+    authority
+        .create_checkpoint()
+        .await
+        .expect("authority checkpoint should commit");
+    let bytes = vec![b'x'; 96 * 1024];
+    authority
+        .execute(
+            "INSERT INTO lix_file (path, content) VALUES ($1, $2)",
+            &[
+                Value::Text("/large.bin".to_owned()),
+                Value::Blob(bytes.clone().into()),
+            ],
+        )
+        .await
+        .expect("large binary file should commit");
+
+    let replica = Replica::bootstrap(AuthorityTransport::connected(authority.clone())).await;
+    let history_sql = format!("SELECT * FROM lix_history('lix_key_value', '{cold_commit_id}')");
+    replica.hydrate_and_retry(&history_sql).await;
+    replica
+        .hydrate_and_retry("SELECT content FROM lix_file WHERE path = '/large.bin'")
+        .await;
+    let result = replica
+        .lix
+        .execute(
+            "SELECT content FROM lix_file WHERE path = '/large.bin'",
+            &[],
+        )
+        .await
+        .expect("hydrated binary read should succeed");
+    assert_eq!(
+        result.rows()[0]
+            .get::<Vec<u8>>("content")
+            .expect("binary content"),
+        bytes,
+    );
+    let checkpoints = replica
+        .lix
+        .execute("SELECT commit_id FROM lix_checkpoint", &[])
+        .await
+        .expect("checkpoint rows should remain visible");
+    assert!(!checkpoints.rows().is_empty());
+}
+
+async fn deterministic_sync_command_traces(_sim: Simulation) {
+    for seed in fuzz_seeds(&(0_u64..32).collect::<Vec<_>>()) {
+        // Each seed starts from an independent repository, so an override can
+        // reproduce that seed without replaying every smaller seed first.
+        let authority = fresh_authority().await;
+        let mut left = Replica::bootstrap(AuthorityTransport::connected(authority.clone())).await;
+        let mut right = Replica::bootstrap(AuthorityTransport::connected(authority.clone())).await;
+        let mut random = XorShift64::new(seed);
+        for step in 0..COMMANDS_PER_SEED {
+            let command = random.next() % 8;
+            match command {
+                0 | 1 => {
+                    left.write(&format!("seed-{seed}-left-{step}"), "left")
+                        .await
+                }
+                2 | 3 => {
+                    right
+                        .write(&format!("seed-{seed}-right-{step}"), "right")
+                        .await
+                }
+                4 => {
+                    left.pump().await.unwrap_or_else(|error| {
+                        panic!("seed {seed} step {step} left pump failed: {error:?}")
+                    });
+                }
+                5 => {
+                    right.pump().await.unwrap_or_else(|error| {
+                        panic!("seed {seed} step {step} right pump failed: {error:?}")
+                    });
+                }
+                6 => left.restart().await,
+                _ => right.restart().await,
+            }
+        }
+        if let Err(error) = converge(&authority, &mut [&mut left, &mut right]).await {
+            panic!("seed {seed} failed after {COMMANDS_PER_SEED} commands: {error:?}");
+        }
+    }
+}
+
+sync_simulation_test!(
+    deterministic_replica_scenarios,
+    deterministic_replica_scenarios
+);
+sync_simulation_test!(
+    lazy_history_and_binary_cas_scenarios,
+    lazy_history_and_binary_cas_scenarios
+);
+sync_simulation_test!(
+    deterministic_sync_command_traces,
+    deterministic_sync_command_traces
+);
+
+struct XorShift64(u64);
+
+impl XorShift64 {
+    fn new(seed: u64) -> Self {
+        Self(seed.wrapping_add(0x9e37_79b9_7f4a_7c15))
+    }
+
+    fn next(&mut self) -> u64 {
+        self.0 ^= self.0 << 13;
+        self.0 ^= self.0 >> 7;
+        self.0 ^= self.0 << 17;
+        self.0
+    }
+}

--- a/packages/lix/tests/integration/support/simulation_test/engine/simulation.rs
+++ b/packages/lix/tests/integration/support/simulation_test/engine/simulation.rs
@@ -98,6 +98,12 @@ impl Simulation {
         &self.receipt.main_branch_id
     }
 
+    /// Returns the backing in-memory repository for subsystem simulations
+    /// which need to open their own public `Lix` handle.
+    pub(crate) fn storage(&self) -> Memory {
+        self.storage.clone()
+    }
+
     pub(crate) fn finish(&self) {
         self.assertions.finish_mode(self.mode);
     }


### PR DESCRIPTION
Follow-up to #1556. GitHub reports one commit and only the sync simulation/fix files against `main`.

## What this adds

- A deterministic in-memory authority + two-replica scenario runner around the real shared sync state machine.
- Explicit `pump()` scheduling with scripted disconnect and lost-push-response faults; no sleeps, virtual clock, HTTP server, or second sync model.
- 32 fixed seeds with 16 write/pump/restart commands each. `LIX_FUZZ_SEEDS` and `LIX_FUZZ_SEED_START` retain the existing wider-soak workflow.
- Handwritten coverage for bootstrap/convergence, idempotent lost acknowledgements, durable offline outbox restart, concurrent divergence + restart, lazy history, checkpoint visibility, and lazy BLAKE3 CAS hydration.

## Bug found and fixed

The runner found that a remote ref advance could replace the replica's recorded authority head while an offline local chain still used the old tip as its dependency frontier. After reconciliation and restart, outbox traversal could then fail with `local sync head ... has no commit record`.

The replica now retains exactly that displaced authority tip until the reconciled child is acknowledged; existing parent pruning removes it afterward, keeping the state bounded.

## CI cost

The three focused suites complete in about 2.7 seconds after compilation on this runner.

## Verification

- `cargo test -p lix --lib sync::simulation_tests:: --no-fail-fast`
- `cargo test -p lix --no-fail-fast`
- `cargo test -p lix --features all-simulations --no-fail-fast`
- `cargo clippy -p lix --features all-simulations --lib --tests --no-deps`

The full all-simulations suite passed once. A final repeat hit the unrelated existing `hot_row_tombstone_probe::broad_canonical_created_at_recovery_misses_for_new_identities` parallel-test flake (expected 0 cache hits, observed 1); its isolated rerun passed immediately. All sync simulations passed in every run.