### PR TITLE
Export commit, storage, and open phases on the production telemetry plane

### DIFF
--- a/.changenotes/export-commit-storage-open-spans.md
+++ b/.changenotes/export-commit-storage-open-spans.md
@@ -2,6 +2,6 @@
 type: patch
 ---
 
-Production traces now show the real commit, storage, notify, checkpoint, and session-open phases.
+Production telemetry now uses one stable eleven-name contract across native tracing and JavaScript callbacks.
 
-The phases that can take tens of milliseconds after a SQL batch already existed as debug-only `lix_perf` spans. They now emit at the same INFO `lix_sql` / `lix` plane as `SQL batch` and `lix.opened`, so a write batch can split materialize vs storage flush vs notify, checkpoint/create carries `commit_id`, and a cold open shows engine and session construction instead of only the instantaneous bind.
+SQL is hard-cut to `lix.sql.query`, `lix.sql.batch`, and `lix.sql.coherent_read_batch`; repository binding is `lix.repository.opened`; cold open is `lix.engine.open` plus `lix.session.open`. Writes expose additive `lix.transaction.materialize`, `lix.transaction.storage`, and `lix.transaction.notify` phases with a shared `lix.commit_cohort_id`. Callback spans use schema v2 and carry trace, span, and parent IDs. Fine-grained `lix_perf` diagnostics remain DEBUG-only.

--- a/.changenotes/export-commit-storage-open-spans.md
+++ b/.changenotes/export-commit-storage-open-spans.md
@@ -1,0 +1,7 @@
+---
+type: patch
+---
+
+Production traces now show the real commit, storage, notify, checkpoint, and session-open phases.
+
+The phases that can take tens of milliseconds after a SQL batch already existed as debug-only `lix_perf` spans. They now emit at the same INFO `lix_sql` / `lix` plane as `SQL batch` and `lix.opened`, so a write batch can split materialize vs storage flush vs notify, checkpoint/create carries `commit_id`, and a cold open shows engine and session construction instead of only the instantaneous bind.

--- a/.changenotes/lix-opened-session-bind.md
+++ b/.changenotes/lix-opened-session-bind.md
@@ -2,6 +2,6 @@
 type: patch
 ---
 
-Added a vendor-neutral `lix.opened` engine span when a client session binds to a Lix.
+Added a vendor-neutral `lix.repository.opened` engine span when a client session binds to a Lix.
 
 In-process `open_lix()` and protocol handshake session creation each emit one span. Protocol roots and cached runtimes opened with `as_protocol_root()` attach a telemetry sink without emitting. Hosts that mint a session against an already-open runtime call `Lix::bind_session()` or `lix::bind_session`.

--- a/packages/e2e/tests/e2e.rs
+++ b/packages/e2e/tests/e2e.rs
@@ -68,6 +68,10 @@ struct StartedPerfSpan {
     started: Instant,
 }
 
+fn is_exported_or_debug_perf_target(target: &str) -> bool {
+    matches!(target, "lix_perf" | "lix_sql")
+}
+
 fn is_import_perf_span(name: &str) -> bool {
     matches!(
         name,
@@ -169,7 +173,8 @@ where
     S: Subscriber + for<'lookup> LookupSpan<'lookup>,
 {
     fn register_callsite(&self, metadata: &'static tracing::Metadata<'static>) -> Interest {
-        if metadata.target() == "lix_perf" && is_import_perf_span(metadata.name()) {
+        if is_exported_or_debug_perf_target(metadata.target()) && is_import_perf_span(metadata.name())
+        {
             Interest::always()
         } else {
             Interest::never()

--- a/packages/js-sdk/native/telemetry.rs
+++ b/packages/js-sdk/native/telemetry.rs
@@ -8,6 +8,10 @@ use serde::Serialize;
 pub(crate) struct TelemetrySpanDto {
     schema_version: u8,
     name: &'static str,
+    trace_id: String,
+    span_id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    parent_span_id: Option<String>,
     started_at_unix_ms: f64,
     duration_ms: f64,
     status: &'static str,
@@ -30,13 +34,17 @@ impl From<CompletedTelemetrySpan> for TelemetrySpanDto {
             attributes.insert(attribute.key, value);
         }
         Self {
-            schema_version: 1,
+            schema_version: 2,
             name: span.start.name,
+            trace_id: span.start.trace_id,
+            span_id: span.start.span_id,
+            parent_span_id: span.start.parent_span_id,
             started_at_unix_ms: span.start.started_at_unix_ms as f64,
             duration_ms: span.end.duration_ns as f64 / 1_000_000.0,
             status: match span.end.status {
                 TelemetrySpanStatus::Ok => "ok",
                 TelemetrySpanStatus::Error => "error",
+                TelemetrySpanStatus::Cancelled => "cancelled",
             },
             attributes,
         }

--- a/packages/js-sdk/src/open-lix.test.ts
+++ b/packages/js-sdk/src/open-lix.test.ts
@@ -137,11 +137,13 @@ test("openLix forwards opt-in SQL telemetry from the engine", async () => {
 	await lix.execute("SELECT 'private-value' AS value, 42 AS number");
 	const span = await received;
 	expect(span).toMatchObject({
-		schemaVersion: 1,
+		schemaVersion: 2,
 		name: "lix.sql.query",
 		status: "ok",
 	});
 	expect(span.durationMs).toBeGreaterThanOrEqual(0);
+	expect(span.traceId).toMatch(/^[0-9a-f]{32}$/u);
+	expect(span.spanId).toMatch(/^[0-9a-f]{16}$/u);
 	expect(span.attributes["db.query.text"]).toBe(
 		"SELECT ? AS value, ? AS number",
 	);

--- a/packages/js-sdk/src/types.ts
+++ b/packages/js-sdk/src/types.ts
@@ -25,11 +25,14 @@ export type SyncLixServerOptions = {
 };
 
 export type LixTelemetrySpan = {
-	schemaVersion: 1;
+	schemaVersion: 2;
 	name: string;
+	traceId: string;
+	spanId: string;
+	parentSpanId?: string;
 	startedAtUnixMs: number;
 	durationMs: number;
-	status: "ok" | "error";
+	status: "ok" | "error" | "cancelled";
 	attributes: Record<string, string | number | boolean>;
 };
 

--- a/packages/lix/src/engine.rs
+++ b/packages/lix/src/engine.rs
@@ -29,6 +29,7 @@ use crate::telemetry::TelemetrySink;
 use crate::tracked_state::TrackedStateContext;
 use crate::transaction::CommitCoordinator;
 use crate::{LixError, NullableKeyFilter};
+use tracing::Instrument as _;
 
 #[derive(Clone)]
 pub(crate) struct Engine<StorageImpl: Storage + 'static = crate::storage_adapter::Memory> {
@@ -149,53 +150,60 @@ where
         storage: StorageImpl,
         options: EngineOptions,
     ) -> Result<Self, LixError> {
-        let storage = StorageAdapter::new(storage);
-        let wasm_runtime = options
-            .wasm_runtime
-            .unwrap_or_else(|| Arc::new(UnsupportedWasmRuntime));
-        let plugin_host = PluginRuntimeHost::new_with_limits(
-            wasm_runtime,
-            options.plugin_max_memory_bytes,
-            options.plugin_max_live_stores,
-        )?;
+        async move {
+            let storage = StorageAdapter::new(storage);
+            let wasm_runtime = options
+                .wasm_runtime
+                .unwrap_or_else(|| Arc::new(UnsupportedWasmRuntime));
+            let plugin_host = PluginRuntimeHost::new_with_limits(
+                wasm_runtime,
+                options.plugin_max_memory_bytes,
+                options.plugin_max_live_stores,
+            )?;
 
-        let tracked_state = Arc::new(TrackedStateContext::new());
-        let commit_graph = CommitGraphContext::new();
-        let hot_state = Arc::new(HotStateContext::new(
-            tracked_state.as_ref().clone(),
-            commit_graph,
-        ));
-        let branch_ctx = Arc::new(BranchContext::new());
-        let lix_id = assert_initialized(storage.clone(), hot_state.as_ref()).await?;
+            let tracked_state = Arc::new(TrackedStateContext::new());
+            let commit_graph = CommitGraphContext::new();
+            let hot_state = Arc::new(HotStateContext::new(
+                tracked_state.as_ref().clone(),
+                commit_graph,
+            ));
+            let branch_ctx = Arc::new(BranchContext::new());
+            let lix_id = assert_initialized(storage.clone(), hot_state.as_ref()).await?;
 
-        // SessionContext::execute later projects these stable state contexts into one
-        // execution-scoped SQL context, optionally wrapped by a transaction
-        // overlay for writes.
+            // SessionContext::execute later projects these stable state contexts into one
+            // execution-scoped SQL context, optionally wrapped by a transaction
+            // overlay for writes.
 
-        let collaboration_write_gate = Arc::new(tokio::sync::Mutex::new(()));
-        let observe_invalidation = Arc::new(ObserveInvalidation::new());
-        let commit_coordinator = Arc::new(CommitCoordinator::new(
-            Arc::clone(&collaboration_write_gate),
-            Arc::clone(&observe_invalidation),
-        ));
-        Ok(Self {
-            binary_cas: Arc::new(BinaryCasContext::new()),
-            storage,
-            tracked_state,
-            hot_state,
-            branch_ctx,
-            catalog_context: Arc::new(CatalogContext::new()),
-            sql_planning_cache: Arc::new(SqlPlanningCache::default()),
-            deterministic_runtime_gate: Arc::new(tokio::sync::Mutex::new(())),
-            collaboration_write_gate,
-            commit_coordinator,
-            observe_coordinator: Arc::new(ObserveCoordinator::new()),
-            observe_invalidation,
-            sync_mode: SyncModeState::default(),
-            plugin_host,
-            telemetry: options.telemetry,
-            lix_id,
-        })
+            let collaboration_write_gate = Arc::new(tokio::sync::Mutex::new(()));
+            let observe_invalidation = Arc::new(ObserveInvalidation::new());
+            let commit_coordinator = Arc::new(CommitCoordinator::new(
+                Arc::clone(&collaboration_write_gate),
+                Arc::clone(&observe_invalidation),
+            ));
+            Ok(Self {
+                binary_cas: Arc::new(BinaryCasContext::new()),
+                storage,
+                tracked_state,
+                hot_state,
+                branch_ctx,
+                catalog_context: Arc::new(CatalogContext::new()),
+                sql_planning_cache: Arc::new(SqlPlanningCache::default()),
+                deterministic_runtime_gate: Arc::new(tokio::sync::Mutex::new(())),
+                collaboration_write_gate,
+                commit_coordinator,
+                observe_coordinator: Arc::new(ObserveCoordinator::new()),
+                observe_invalidation,
+                sync_mode: SyncModeState::default(),
+                plugin_host,
+                telemetry: options.telemetry,
+                lix_id,
+            })
+        }
+        .instrument(tracing::info_span!(
+            target: "lix",
+            "lix.engine.open"
+        ))
+        .await
     }
 
     pub(crate) fn storage(&self) -> StorageAdapter<StorageImpl> {
@@ -278,27 +286,34 @@ where
         active_branch_id: impl Into<String>,
         active_account_id: impl Into<String>,
     ) -> Result<SessionContext<StorageImpl>, LixError> {
-        let active_account_id = active_account_id.into();
-        self.validate_active_account(&active_account_id).await?;
-        Ok(SessionContext::new(
-            SessionBranch::new(active_branch_id.into()),
-            active_account_id,
-            self.storage(),
-            Arc::clone(&self.hot_state),
-            Arc::clone(&self.tracked_state),
-            Arc::clone(&self.binary_cas),
-            Arc::clone(&self.branch_ctx),
-            Arc::clone(&self.catalog_context),
-            Arc::clone(&self.sql_planning_cache),
-            Arc::clone(&self.deterministic_runtime_gate),
-            Arc::clone(&self.collaboration_write_gate),
-            Arc::clone(&self.commit_coordinator),
-            Arc::clone(&self.observe_coordinator),
-            Arc::clone(&self.observe_invalidation),
-            self.sync_mode.clone(),
-            self.plugin_host.clone(),
-            self.telemetry.clone(),
+        async move {
+            let active_account_id = active_account_id.into();
+            self.validate_active_account(&active_account_id).await?;
+            Ok(SessionContext::new(
+                SessionBranch::new(active_branch_id.into()),
+                active_account_id,
+                self.storage(),
+                Arc::clone(&self.hot_state),
+                Arc::clone(&self.tracked_state),
+                Arc::clone(&self.binary_cas),
+                Arc::clone(&self.branch_ctx),
+                Arc::clone(&self.catalog_context),
+                Arc::clone(&self.sql_planning_cache),
+                Arc::clone(&self.deterministic_runtime_gate),
+                Arc::clone(&self.collaboration_write_gate),
+                Arc::clone(&self.commit_coordinator),
+                Arc::clone(&self.observe_coordinator),
+                Arc::clone(&self.observe_invalidation),
+                self.sync_mode.clone(),
+                self.plugin_host.clone(),
+                self.telemetry.clone(),
+            ))
+        }
+        .instrument(tracing::info_span!(
+            target: "lix",
+            "lix.session.open"
         ))
+        .await
     }
 
     pub(crate) async fn open_session(&self) -> Result<SessionContext<StorageImpl>, LixError> {
@@ -310,26 +325,33 @@ where
         &self,
         active_account_id: impl Into<String>,
     ) -> Result<SessionContext<StorageImpl>, LixError> {
-        let active_account_id = active_account_id.into();
-        self.validate_active_account(&active_account_id).await?;
-        SessionContext::open_default(
-            active_account_id,
-            self.storage(),
-            Arc::clone(&self.hot_state),
-            Arc::clone(&self.tracked_state),
-            Arc::clone(&self.binary_cas),
-            Arc::clone(&self.branch_ctx),
-            Arc::clone(&self.catalog_context),
-            Arc::clone(&self.sql_planning_cache),
-            Arc::clone(&self.deterministic_runtime_gate),
-            Arc::clone(&self.collaboration_write_gate),
-            Arc::clone(&self.commit_coordinator),
-            Arc::clone(&self.observe_coordinator),
-            Arc::clone(&self.observe_invalidation),
-            self.sync_mode.clone(),
-            self.plugin_host.clone(),
-            self.telemetry.clone(),
-        )
+        async move {
+            let active_account_id = active_account_id.into();
+            self.validate_active_account(&active_account_id).await?;
+            SessionContext::open_default(
+                active_account_id,
+                self.storage(),
+                Arc::clone(&self.hot_state),
+                Arc::clone(&self.tracked_state),
+                Arc::clone(&self.binary_cas),
+                Arc::clone(&self.branch_ctx),
+                Arc::clone(&self.catalog_context),
+                Arc::clone(&self.sql_planning_cache),
+                Arc::clone(&self.deterministic_runtime_gate),
+                Arc::clone(&self.collaboration_write_gate),
+                Arc::clone(&self.commit_coordinator),
+                Arc::clone(&self.observe_coordinator),
+                Arc::clone(&self.observe_invalidation),
+                self.sync_mode.clone(),
+                self.plugin_host.clone(),
+                self.telemetry.clone(),
+            )
+            .await
+        }
+        .instrument(tracing::info_span!(
+            target: "lix",
+            "lix.session.open"
+        ))
         .await
     }
 

--- a/packages/lix/src/engine.rs
+++ b/packages/lix/src/engine.rs
@@ -25,11 +25,12 @@ use crate::storage_adapter::{
 };
 use crate::storage_adapter::{StorageAdapter, StorageWriteSet};
 use crate::sync::SyncModeState;
-use crate::telemetry::TelemetrySink;
+use crate::telemetry::{
+    ActiveTelemetrySpan, TelemetrySink, TelemetrySpanClass, instrument_lix_result,
+};
 use crate::tracked_state::TrackedStateContext;
 use crate::transaction::CommitCoordinator;
 use crate::{LixError, NullableKeyFilter};
-use tracing::Instrument as _;
 
 #[derive(Clone)]
 pub(crate) struct Engine<StorageImpl: Storage + 'static = crate::storage_adapter::Memory> {
@@ -150,7 +151,15 @@ where
         storage: StorageImpl,
         options: EngineOptions,
     ) -> Result<Self, LixError> {
-        async move {
+        let span = options.telemetry.as_ref().and_then(|sink| {
+            ActiveTelemetrySpan::start_if_enabled(
+                sink,
+                TelemetrySpanClass::Lifecycle,
+                "lix.engine.open",
+                Vec::new(),
+            )
+        });
+        instrument_lix_result(span, async move {
             let storage = StorageAdapter::new(storage);
             let wasm_runtime = options
                 .wasm_runtime
@@ -179,6 +188,7 @@ where
             let commit_coordinator = Arc::new(CommitCoordinator::new(
                 Arc::clone(&collaboration_write_gate),
                 Arc::clone(&observe_invalidation),
+                options.telemetry.clone(),
             ));
             Ok(Self {
                 binary_cas: Arc::new(BinaryCasContext::new()),
@@ -198,11 +208,7 @@ where
                 telemetry: options.telemetry,
                 lix_id,
             })
-        }
-        .instrument(tracing::info_span!(
-            target: "lix",
-            "lix.engine.open"
-        ))
+        })
         .await
     }
 
@@ -286,7 +292,15 @@ where
         active_branch_id: impl Into<String>,
         active_account_id: impl Into<String>,
     ) -> Result<SessionContext<StorageImpl>, LixError> {
-        async move {
+        let span = self.telemetry.as_ref().and_then(|sink| {
+            ActiveTelemetrySpan::start_if_enabled(
+                sink,
+                TelemetrySpanClass::Lifecycle,
+                "lix.session.open",
+                Vec::new(),
+            )
+        });
+        instrument_lix_result(span, async move {
             let active_account_id = active_account_id.into();
             self.validate_active_account(&active_account_id).await?;
             Ok(SessionContext::new(
@@ -308,11 +322,7 @@ where
                 self.plugin_host.clone(),
                 self.telemetry.clone(),
             ))
-        }
-        .instrument(tracing::info_span!(
-            target: "lix",
-            "lix.session.open"
-        ))
+        })
         .await
     }
 
@@ -325,7 +335,15 @@ where
         &self,
         active_account_id: impl Into<String>,
     ) -> Result<SessionContext<StorageImpl>, LixError> {
-        async move {
+        let span = self.telemetry.as_ref().and_then(|sink| {
+            ActiveTelemetrySpan::start_if_enabled(
+                sink,
+                TelemetrySpanClass::Lifecycle,
+                "lix.session.open",
+                Vec::new(),
+            )
+        });
+        instrument_lix_result(span, async move {
             let active_account_id = active_account_id.into();
             self.validate_active_account(&active_account_id).await?;
             SessionContext::open_default(
@@ -347,11 +365,7 @@ where
                 self.telemetry.clone(),
             )
             .await
-        }
-        .instrument(tracing::info_span!(
-            target: "lix",
-            "lix.session.open"
-        ))
+        })
         .await
     }
 

--- a/packages/lix/src/handle.rs
+++ b/packages/lix/src/handle.rs
@@ -610,38 +610,46 @@ where
         active_account_id: impl Into<String>,
         suppress_sync_outbox: bool,
     ) -> Result<Self, LixError> {
-        if self.session.is_closed() {
-            return Err(LixError::new(
-                LixError::CODE_CLOSED,
-                "cannot open a session from a closed Lix handle",
-            ));
+        use tracing::Instrument as _;
+        async move {
+            if self.session.is_closed() {
+                return Err(LixError::new(
+                    LixError::CODE_CLOSED,
+                    "cannot open a session from a closed Lix handle",
+                ));
+            }
+            let active_branch_id = active_branch_id.into();
+            if self
+                .engine
+                .load_branch_head_commit_id(&active_branch_id)
+                .await?
+                .is_none()
+            {
+                return Err(LixError::branch_not_found(
+                    active_branch_id,
+                    "open_another_session",
+                    "target",
+                ));
+            }
+            let session = self
+                .engine
+                .open_session_at_with_account(active_branch_id, active_account_id)
+                .await?;
+            let mut session = session;
+            session.set_sync_outbox_suppressed(suppress_sync_outbox);
+            Ok(Self {
+                engine: self.engine.clone(),
+                session: Arc::new(session),
+                primary_switch_gate: None,
+                sync_lease: None,
+                sync_demand_tx: self.sync_demand_tx.clone(),
+            })
         }
-        let active_branch_id = active_branch_id.into();
-        if self
-            .engine
-            .load_branch_head_commit_id(&active_branch_id)
-            .await?
-            .is_none()
-        {
-            return Err(LixError::branch_not_found(
-                active_branch_id,
-                "open_another_session",
-                "target",
-            ));
-        }
-        let session = self
-            .engine
-            .open_session_at_with_account(active_branch_id, active_account_id)
-            .await?;
-        let mut session = session;
-        session.set_sync_outbox_suppressed(suppress_sync_outbox);
-        Ok(Self {
-            engine: self.engine.clone(),
-            session: Arc::new(session),
-            primary_switch_gate: None,
-            sync_lease: None,
-            sync_demand_tx: self.sync_demand_tx.clone(),
-        })
+        .instrument(tracing::info_span!(
+            target: "lix",
+            "lix.session.open"
+        ))
+        .await
     }
 
     /// Executes one PostgreSQL-dialect SQL statement against this Lix session.

--- a/packages/lix/src/handle.rs
+++ b/packages/lix/src/handle.rs
@@ -610,46 +610,38 @@ where
         active_account_id: impl Into<String>,
         suppress_sync_outbox: bool,
     ) -> Result<Self, LixError> {
-        use tracing::Instrument as _;
-        async move {
-            if self.session.is_closed() {
-                return Err(LixError::new(
-                    LixError::CODE_CLOSED,
-                    "cannot open a session from a closed Lix handle",
-                ));
-            }
-            let active_branch_id = active_branch_id.into();
-            if self
-                .engine
-                .load_branch_head_commit_id(&active_branch_id)
-                .await?
-                .is_none()
-            {
-                return Err(LixError::branch_not_found(
-                    active_branch_id,
-                    "open_another_session",
-                    "target",
-                ));
-            }
-            let session = self
-                .engine
-                .open_session_at_with_account(active_branch_id, active_account_id)
-                .await?;
-            let mut session = session;
-            session.set_sync_outbox_suppressed(suppress_sync_outbox);
-            Ok(Self {
-                engine: self.engine.clone(),
-                session: Arc::new(session),
-                primary_switch_gate: None,
-                sync_lease: None,
-                sync_demand_tx: self.sync_demand_tx.clone(),
-            })
+        if self.session.is_closed() {
+            return Err(LixError::new(
+                LixError::CODE_CLOSED,
+                "cannot open a session from a closed Lix handle",
+            ));
         }
-        .instrument(tracing::info_span!(
-            target: "lix",
-            "lix.session.open"
-        ))
-        .await
+        let active_branch_id = active_branch_id.into();
+        if self
+            .engine
+            .load_branch_head_commit_id(&active_branch_id)
+            .await?
+            .is_none()
+        {
+            return Err(LixError::branch_not_found(
+                active_branch_id,
+                "open_another_session",
+                "target",
+            ));
+        }
+        let session = self
+            .engine
+            .open_session_at_with_account(active_branch_id, active_account_id)
+            .await?;
+        let mut session = session;
+        session.set_sync_outbox_suppressed(suppress_sync_outbox);
+        Ok(Self {
+            engine: self.engine.clone(),
+            session: Arc::new(session),
+            primary_switch_gate: None,
+            sync_lease: None,
+            sync_demand_tx: self.sync_demand_tx.clone(),
+        })
     }
 
     /// Executes one PostgreSQL-dialect SQL statement against this Lix session.

--- a/packages/lix/src/handle.rs
+++ b/packages/lix/src/handle.rs
@@ -119,7 +119,7 @@ impl<StorageImpl> OpenLixBuilder<StorageImpl> {
         self
     }
 
-    /// Attaches a sink (if any) without emitting `lix.opened`.
+    /// Attaches a sink (if any) without emitting `lix.repository.opened`.
     ///
     /// Use this when the handle is only a protocol root or cached runtime
     /// that later protocol sessions inherit. Handshake session creation and
@@ -1310,8 +1310,8 @@ where
 mod tests {
     use super::*;
     use lix::telemetry::{
-        CallbackTelemetrySink, CompletedTelemetrySpan, TelemetrySink, TelemetrySpanEnd,
-        TelemetrySpanHandle, TelemetrySpanKind, TelemetrySpanStart,
+        CallbackTelemetrySink, CompletedTelemetrySpan, TelemetrySink, TelemetrySpanClass,
+        TelemetrySpanEnd, TelemetrySpanHandle, TelemetrySpanStart,
     };
     use std::sync::{
         Mutex,
@@ -1321,7 +1321,7 @@ mod tests {
     fn opened_spans(spans: &[CompletedTelemetrySpan]) -> Vec<&CompletedTelemetrySpan> {
         spans
             .iter()
-            .filter(|span| span.start.kind == TelemetrySpanKind::LixOpened)
+            .filter(|span| span.start.name == "lix.repository.opened")
             .collect()
     }
 
@@ -1363,7 +1363,7 @@ mod tests {
         let spans = spans.lock().expect("spans");
         let opened = opened_spans(&spans);
         assert_eq!(opened.len(), 1);
-        assert_eq!(opened[0].start.name, "lix.opened");
+        assert_eq!(opened[0].start.name, "lix.repository.opened");
         assert_eq!(attribute_string(opened[0], "lix.id"), Some(lix.lix_id()));
         assert_eq!(
             attribute_string(opened[0], "lix.branch_id"),
@@ -1374,9 +1374,7 @@ mod tests {
             Some(lix.active_account_id())
         );
         assert!(
-            spans
-                .iter()
-                .any(|span| span.start.kind == TelemetrySpanKind::SqlQuery),
+            spans.iter().any(|span| span.start.name == "lix.sql.query"),
             "SQL spans still work after an opened span"
         );
     }
@@ -1391,7 +1389,7 @@ mod tests {
     #[tokio::test]
     async fn disabled_opened_kind_does_no_opened_span_work() {
         struct SqlOnlySink {
-            started: Mutex<Vec<TelemetrySpanKind>>,
+            started: Mutex<Vec<&'static str>>,
         }
 
         impl SqlOnlySink {
@@ -1401,17 +1399,16 @@ mod tests {
         }
 
         impl TelemetrySink for SqlOnlySink {
-            fn enabled(&self, kind: TelemetrySpanKind) -> bool {
-                !matches!(kind, TelemetrySpanKind::LixOpened)
+            fn enabled(&self, _class: TelemetrySpanClass, name: &'static str) -> bool {
+                name != "lix.repository.opened"
             }
 
             fn start_span(&self, start: TelemetrySpanStart) -> Box<dyn TelemetrySpanHandle> {
                 assert_ne!(
-                    start.kind,
-                    TelemetrySpanKind::LixOpened,
+                    start.name, "lix.repository.opened",
                     "disabled opened spans must not be started"
                 );
-                self.started.lock().expect("started").push(start.kind);
+                self.started.lock().expect("started").push(start.name);
                 Box::new(NoopHandle)
             }
         }
@@ -1435,12 +1432,8 @@ mod tests {
             .expect("open Lix");
         lix.execute("SELECT 1", &[]).await.expect("execute");
         let started = sink.started.lock().expect("started");
-        assert!(
-            started
-                .iter()
-                .all(|kind| *kind != TelemetrySpanKind::LixOpened)
-        );
-        assert!(started.contains(&TelemetrySpanKind::SqlQuery));
+        assert!(started.iter().all(|name| *name != "lix.repository.opened"));
+        assert!(started.contains(&"lix.sql.query"));
     }
 
     #[tokio::test]
@@ -1461,9 +1454,7 @@ mod tests {
         let spans = spans.lock().expect("spans");
         assert!(opened_spans(&spans).is_empty());
         assert!(
-            spans
-                .iter()
-                .any(|span| span.start.kind == TelemetrySpanKind::SqlQuery),
+            spans.iter().any(|span| span.start.name == "lix.sql.query"),
             "SQL spans still work on a protocol root"
         );
     }
@@ -1486,7 +1477,7 @@ mod tests {
         let spans = spans.lock().expect("spans");
         let opened = opened_spans(&spans);
         assert_eq!(opened.len(), 1);
-        assert_eq!(opened[0].start.name, "lix.opened");
+        assert_eq!(opened[0].start.name, "lix.repository.opened");
         assert_eq!(attribute_string(opened[0], "lix.id"), Some(lix.lix_id()));
     }
 
@@ -1513,7 +1504,11 @@ mod tests {
         let spans = spans.lock().expect("spans");
         let opened = opened_spans(&spans);
         assert_eq!(opened.len(), 3);
-        assert!(opened.iter().all(|span| span.start.name == "lix.opened"));
+        assert!(
+            opened
+                .iter()
+                .all(|span| span.start.name == "lix.repository.opened")
+        );
         assert!(
             opened
                 .iter()

--- a/packages/lix/src/server_protocol/handler.rs
+++ b/packages/lix/src/server_protocol/handler.rs
@@ -4795,7 +4795,6 @@ mod tests {
     };
     use lix::{Blob, Memory, open_lix};
     use serde_json::{Value as JsonValue, json};
-    use std::collections::BTreeMap;
     use std::io::Write as _;
     use std::sync::{Arc, Mutex, atomic::AtomicBool};
     use tracing::Subscriber;
@@ -5089,7 +5088,7 @@ mod tests {
         id: tracing::span::Id,
         parent: Option<tracing::span::Id>,
         name: &'static str,
-        fields: BTreeMap<String, String>,
+        fields: std::collections::BTreeMap<String, String>,
     }
 
     #[derive(Clone, Default)]
@@ -5098,7 +5097,7 @@ mod tests {
     }
 
     struct FieldVisitor<'a> {
-        fields: &'a mut BTreeMap<String, String>,
+        fields: &'a mut std::collections::BTreeMap<String, String>,
     }
 
     impl tracing::field::Visit for FieldVisitor<'_> {
@@ -5129,7 +5128,7 @@ mod tests {
                     .then(|| context.current_span().id().cloned())
                     .flatten()
             });
-            let mut fields = BTreeMap::new();
+            let mut fields = std::collections::BTreeMap::new();
             attributes.record(&mut FieldVisitor {
                 fields: &mut fields,
             });

--- a/packages/lix/src/server_protocol/handler.rs
+++ b/packages/lix/src/server_protocol/handler.rs
@@ -11012,10 +11012,63 @@ mod tests {
         assert!(!session_id.is_empty());
 
         let spans = spans.lock().expect("capture spans");
-        require_span(&spans, "lix.session.open");
+        assert_eq!(
+            spans
+                .iter()
+                .filter(|span| span.name == "lix.session.open")
+                .count(),
+            1,
+            "one protocol handshake must open exactly one internal session"
+        );
         assert!(
             spans.iter().all(|span| span.name != "lix.engine.open"),
             "warm handshake must not reopen the protocol-root engine"
+        );
+        assert_no_bound_parameter_or_bytea_fields(&spans);
+    }
+
+    #[tokio::test]
+    async fn explicit_transaction_exports_one_transaction_notify_span() {
+        let capture = CaptureLayer::default();
+        let spans = Arc::clone(&capture.spans);
+        let _subscriber =
+            tracing::subscriber::set_default(tracing_subscriber::registry().with(capture));
+        let app = app_with_tracing_telemetry().await;
+        let (session_id, _) = new_session(&app.router).await;
+        let transaction_id = begin_remote_transaction(&app.router, &session_id).await;
+        let staged = remote_transaction_request(
+            &app.router,
+            "POST",
+            "/lix/v1/transaction/execute",
+            &session_id,
+            &transaction_id,
+            Some(json!({
+                "sql": "INSERT INTO lix_key_value (key, value) VALUES ('notify-span', '1')"
+            })),
+        )
+        .await;
+        assert_eq!(staged.status(), StatusCode::OK);
+        spans.lock().expect("capture spans").clear();
+
+        let committed = remote_transaction_request(
+            &app.router,
+            "POST",
+            "/lix/v1/transaction/commit",
+            &session_id,
+            &transaction_id,
+            None,
+        )
+        .await;
+        assert_eq!(committed.status(), StatusCode::NO_CONTENT);
+
+        let spans = spans.lock().expect("capture spans");
+        assert_eq!(
+            spans
+                .iter()
+                .filter(|span| span.name == "lix.perf.transaction_notify")
+                .count(),
+            1,
+            "an explicit transaction must emit one per-transaction notify span"
         );
         assert_no_bound_parameter_or_bytea_fields(&spans);
     }

--- a/packages/lix/src/server_protocol/handler.rs
+++ b/packages/lix/src/server_protocol/handler.rs
@@ -1633,7 +1633,9 @@ where
                 observe_multiplex(lease, json_request!(MultiplexObserveRequest)).await,
             ),
             (_, known)
-                if SERVER_PROTOCOL_ENDPOINTS.iter().any(|(_, path)| *path == known) =>
+                if SERVER_PROTOCOL_ENDPOINTS
+                    .iter()
+                    .any(|(_, path)| *path == known) =>
             {
                 method_not_allowed()
             }
@@ -2238,11 +2240,8 @@ fn ensure_sync_push_event_fits(
     max_bytes: usize,
 ) -> Result<(), ApiError> {
     let commits = request.commits.iter().collect::<Vec<_>>();
-    let encoded_len = crate::sync::encoded_delta_event_len(
-        u64::MAX,
-        &commits,
-        &request.ref_updates,
-    )?;
+    let encoded_len =
+        crate::sync::encoded_delta_event_len(u64::MAX, &commits, &request.ref_updates)?;
     if encoded_len > max_bytes {
         return Err(ApiError::sync_push_event_too_large(max_bytes));
     }
@@ -2436,8 +2435,7 @@ async fn sync_register_blob<S>(
 where
     S: Storage + Clone + Send + Sync + 'static,
 {
-    validate_sync_blob_manifest(&manifest)
-        .map_err(|error| ApiError::bad_request(error.message))?;
+    validate_sync_blob_manifest(&manifest).map_err(|error| ApiError::bad_request(error.message))?;
     let registration = lease
         .run_durable(move |lix| async move { lix.register_sync_blob_manifest(&manifest).await })
         .await?;
@@ -4797,6 +4795,7 @@ mod tests {
     };
     use lix::{Blob, Memory, open_lix};
     use serde_json::{Value as JsonValue, json};
+    use std::collections::BTreeMap;
     use std::io::Write as _;
     use std::sync::{Arc, Mutex, atomic::AtomicBool};
     use tracing::Subscriber;
@@ -5087,13 +5086,31 @@ mod tests {
 
     #[derive(Clone, Debug)]
     struct CapturedSpan {
+        id: tracing::span::Id,
         parent: Option<tracing::span::Id>,
         name: &'static str,
+        fields: BTreeMap<String, String>,
     }
 
     #[derive(Clone, Default)]
     struct CaptureLayer {
         spans: Arc<Mutex<Vec<CapturedSpan>>>,
+    }
+
+    struct FieldVisitor<'a> {
+        fields: &'a mut BTreeMap<String, String>,
+    }
+
+    impl tracing::field::Visit for FieldVisitor<'_> {
+        fn record_debug(&mut self, field: &tracing::field::Field, value: &dyn std::fmt::Debug) {
+            self.fields
+                .insert(field.name().to_string(), format!("{value:?}"));
+        }
+
+        fn record_str(&mut self, field: &tracing::field::Field, value: &str) {
+            self.fields
+                .insert(field.name().to_string(), value.to_string());
+        }
     }
 
     impl<S> Layer<S> for CaptureLayer
@@ -5103,7 +5120,7 @@ mod tests {
         fn on_new_span(
             &self,
             attributes: &tracing::span::Attributes<'_>,
-            _id: &tracing::span::Id,
+            id: &tracing::span::Id,
             context: LayerContext<'_, S>,
         ) {
             let parent = attributes.parent().cloned().or_else(|| {
@@ -5112,13 +5129,33 @@ mod tests {
                     .then(|| context.current_span().id().cloned())
                     .flatten()
             });
+            let mut fields = BTreeMap::new();
+            attributes.record(&mut FieldVisitor {
+                fields: &mut fields,
+            });
             self.spans
                 .lock()
                 .expect("capture spans")
                 .push(CapturedSpan {
+                    id: id.clone(),
                     parent,
                     name: attributes.metadata().name(),
+                    fields,
                 });
+        }
+
+        fn on_record(
+            &self,
+            id: &tracing::span::Id,
+            values: &tracing::span::Record<'_>,
+            _context: LayerContext<'_, S>,
+        ) {
+            let mut spans = self.spans.lock().expect("capture spans");
+            if let Some(span) = spans.iter_mut().rev().find(|span| span.id == *id) {
+                values.record(&mut FieldVisitor {
+                    fields: &mut span.fields,
+                });
+            }
         }
     }
 
@@ -9116,10 +9153,7 @@ mod tests {
         .await;
         assert_eq!(response.status(), StatusCode::NOT_FOUND);
         assert_eq!(error_code(response).await, LixError::CODE_BRANCH_NOT_FOUND);
-        assert_eq!(
-            app.server.inner.registry.lock().await.len(),
-            before
-        );
+        assert_eq!(app.server.inner.registry.lock().await.len(), before);
     }
 
     #[tokio::test]
@@ -10841,6 +10875,169 @@ mod tests {
         assert_eq!(sql_span.parent.as_ref(), Some(&protocol_span_id));
     }
 
+    fn require_span<'a>(spans: &'a [CapturedSpan], name: &str) -> &'a CapturedSpan {
+        spans
+            .iter()
+            .find(|span| span.name == name)
+            .unwrap_or_else(|| {
+                let names = spans.iter().map(|span| span.name).collect::<Vec<_>>();
+                panic!("missing exported span {name}, captured {names:?}")
+            })
+    }
+
+    fn assert_no_bound_parameter_or_bytea_fields(spans: &[CapturedSpan]) {
+        for span in spans {
+            for (key, value) in &span.fields {
+                assert!(
+                    !key.contains("param") && !key.contains("bytea") && !key.contains("BYTEA"),
+                    "span {} leaked parameter/byte field {key}={value}",
+                    span.name
+                );
+                assert!(
+                    !value.contains("BYTEA") && !key.ends_with(".parameters"),
+                    "span {} leaked parameter/byte value {key}={value}",
+                    span.name
+                );
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn execute_batch_write_exports_materialize_storage_and_notify() {
+        let capture = CaptureLayer::default();
+        let spans = Arc::clone(&capture.spans);
+        let _subscriber =
+            tracing::subscriber::set_default(tracing_subscriber::registry().with(capture));
+        let app = app_with_tracing_telemetry().await;
+        let (session_id, _) = new_session(&app.router).await;
+        spans.lock().expect("capture spans").clear();
+
+        let response = request(
+            &app.router,
+            "POST",
+            "/lix/v1/execute-batch",
+            Some(&session_id),
+            Some(json!({
+                "statements": [
+                    {
+                        "sql": "INSERT INTO lix_key_value (key, value) VALUES ('exported-span', '1')",
+                        "params": []
+                    }
+                ]
+            })),
+        )
+        .await;
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let spans = spans.lock().expect("capture spans");
+        let batch = require_span(&spans, "lix.sql.batch");
+        require_span(&spans, "lix.sql.query");
+        let materialize = require_span(&spans, "lix.perf.transaction_materialization");
+        let storage_commit = require_span(&spans, "lix.perf.transaction_storage_commit");
+        require_span(&spans, "lix.perf.storage_commit_accepted_visible");
+        let notify = require_span(&spans, "lix.perf.transaction_notify");
+        assert_eq!(materialize.parent.as_ref(), Some(&batch.id));
+        assert_eq!(storage_commit.parent.as_ref(), Some(&batch.id));
+        assert_eq!(notify.parent.as_ref(), Some(&batch.id));
+        assert_no_bound_parameter_or_bytea_fields(&spans);
+    }
+
+    #[tokio::test]
+    async fn checkpoint_create_exports_engine_parent_commit_children_and_commit_id() {
+        let capture = CaptureLayer::default();
+        let spans = Arc::clone(&capture.spans);
+        let _subscriber =
+            tracing::subscriber::set_default(tracing_subscriber::registry().with(capture));
+        let app = app_with_tracing_telemetry().await;
+        let (session_id, _) = new_session(&app.router).await;
+        let write = request(
+            &app.router,
+            "POST",
+            "/lix/v1/execute",
+            Some(&session_id),
+            Some(json!({
+                "sql": "INSERT INTO lix_key_value (key, value) VALUES ('checkpoint-span', '1')",
+                "params": []
+            })),
+        )
+        .await;
+        assert_eq!(write.status(), StatusCode::OK);
+        spans.lock().expect("capture spans").clear();
+
+        let response = request(
+            &app.router,
+            "POST",
+            "/lix/v1/checkpoint/create",
+            Some(&session_id),
+            None,
+        )
+        .await;
+        assert_eq!(response.status(), StatusCode::OK);
+        let commit_id = response_json(response).await["commitId"]
+            .as_str()
+            .expect("commitId")
+            .to_string();
+
+        let spans = spans.lock().expect("capture spans");
+        let checkpoint = require_span(&spans, "lix.checkpoint.create");
+        assert_eq!(
+            checkpoint.fields.get("lix.commit_id").map(String::as_str),
+            Some(commit_id.as_str())
+        );
+        assert!(
+            checkpoint
+                .fields
+                .get("lix.parent_commit_id")
+                .is_some_and(|parent| !parent.is_empty() && parent != &commit_id),
+            "checkpoint span should record the parent commit, got {:?}",
+            checkpoint.fields.get("lix.parent_commit_id")
+        );
+        let materialize = require_span(&spans, "lix.perf.transaction_materialization");
+        let storage_commit = require_span(&spans, "lix.perf.transaction_storage_commit");
+        assert_eq!(materialize.parent.as_ref(), Some(&checkpoint.id));
+        assert_eq!(storage_commit.parent.as_ref(), Some(&checkpoint.id));
+        assert_no_bound_parameter_or_bytea_fields(&spans);
+    }
+
+    #[tokio::test]
+    async fn handshake_exports_session_open_separate_from_opened_bind() {
+        let capture = CaptureLayer::default();
+        let spans = Arc::clone(&capture.spans);
+        let _subscriber =
+            tracing::subscriber::set_default(tracing_subscriber::registry().with(capture));
+        let app = app_with_tracing_telemetry().await;
+        spans.lock().expect("capture spans").clear();
+
+        let (session_id, _) = new_session(&app.router).await;
+        assert!(!session_id.is_empty());
+
+        let spans = spans.lock().expect("capture spans");
+        require_span(&spans, "lix.session.open");
+        assert!(
+            spans.iter().all(|span| span.name != "lix.engine.open"),
+            "warm handshake must not reopen the protocol-root engine"
+        );
+        assert_no_bound_parameter_or_bytea_fields(&spans);
+    }
+
+    #[tokio::test]
+    async fn cold_open_lix_exports_engine_and_session_open() {
+        let capture = CaptureLayer::default();
+        let spans = Arc::clone(&capture.spans);
+        let _subscriber =
+            tracing::subscriber::set_default(tracing_subscriber::registry().with(capture));
+        let _lix = open_lix().await.expect("open lix");
+
+        let spans = spans.lock().expect("capture spans");
+        require_span(&spans, "lix.engine.open");
+        require_span(&spans, "lix.session.open");
+        assert!(
+            spans.iter().all(|span| span.name != "lix.opened"),
+            "lix.opened stays bind-only and requires an attached sink"
+        );
+        assert_no_bound_parameter_or_bytea_fields(&spans);
+    }
+
     #[tokio::test]
     async fn idle_timeout_expires_a_session_with_gone() {
         let app = app_with_options(ServerProtocolOptions {
@@ -10894,7 +11091,11 @@ mod tests {
             ..ServerProtocolOptions::default()
         })
         .await;
-        let pending = app.server.inner.session_open_gate.reserve(1)
+        let pending = app
+            .server
+            .inner
+            .session_open_gate
+            .reserve(1)
             .expect("reserve pending session open");
         assert!(!app.server.is_idle());
 
@@ -10906,7 +11107,10 @@ mod tests {
         drop(pending);
         assert!(app.server.is_idle());
         drop(
-            app.server.inner.session_open_gate.reserve(1)
+            app.server
+                .inner
+                .session_open_gate
+                .reserve(1)
                 .expect("released reservation can be reused"),
         );
     }
@@ -10914,7 +11118,11 @@ mod tests {
     #[tokio::test]
     async fn close_waits_for_pending_session_opens_before_closing_the_root() {
         let app = app().await;
-        let pending = app.server.inner.session_open_gate.reserve(1)
+        let pending = app
+            .server
+            .inner
+            .session_open_gate
+            .reserve(1)
             .expect("reserve pending session open");
         let server = app.server.clone();
         let closing = tokio::spawn(async move { server.close().await });
@@ -11015,7 +11223,11 @@ mod tests {
     #[tokio::test]
     async fn cancelled_close_caller_does_not_cancel_server_shutdown() {
         let app = app().await;
-        let pending = app.server.inner.session_open_gate.reserve(1)
+        let pending = app
+            .server
+            .inner
+            .session_open_gate
+            .reserve(1)
             .expect("reserve pending session open");
         let server = app.server.clone();
         let closing = tokio::spawn(async move { server.close().await });
@@ -11082,10 +11294,7 @@ mod tests {
         })
         .await
         .expect("all session opens should reach the storage barrier concurrently");
-        assert_eq!(
-            server.inner.registry.lock().await.len(),
-            SESSION_COUNT
-        );
+        assert_eq!(server.inner.registry.lock().await.len(), SESSION_COUNT);
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 8)]
@@ -11790,12 +11999,7 @@ mod tests {
         let (session_id, _) = new_session(&app.router).await;
         let child = {
             let registry = app.server.inner.registry.lock().await;
-            Arc::clone(
-                &registry
-                    .get(&session_id)
-                    .expect("registered child")
-                    .lix,
-            )
+            Arc::clone(&registry.get(&session_id).expect("registered child").lix)
         };
         let root = Arc::clone(&app.server.inner.root);
 

--- a/packages/lix/src/server_protocol/handler.rs
+++ b/packages/lix/src/server_protocol/handler.rs
@@ -1343,7 +1343,7 @@ where
     /// Creates a protocol server with the default session limits.
     ///
     /// Open `root` with [`lix::OpenLixBuilder::as_protocol_root`] so attaching
-    /// a sink does not emit `lix.opened` for the internal handle. Handshake
+    /// a sink does not emit `lix.repository.opened` for the internal handle. Handshake
     /// session creation remains the client bind.
     pub fn new(root: Arc<Lix<S>>) -> Self {
         Self::with_options(root, ServerProtocolOptions::default())
@@ -4790,9 +4790,7 @@ mod tests {
         MemoryWrite, PutBatch, ReadDurability, ReadOptions, ScanCursor, SpaceId, Storage,
         StorageError, StorageRead, StorageSpace, StorageWrite, WriteOptions,
     };
-    use lix::telemetry::{
-        CallbackTelemetrySink, CompletedTelemetrySpan, TelemetrySpanKind, TracingTelemetrySink,
-    };
+    use lix::telemetry::{CallbackTelemetrySink, CompletedTelemetrySpan, TracingTelemetrySink};
     use lix::{Blob, Memory, open_lix};
     use serde_json::{Value as JsonValue, json};
     use std::io::Write as _;
@@ -7241,7 +7239,7 @@ mod tests {
     fn opened_spans(spans: &[CompletedTelemetrySpan]) -> Vec<&CompletedTelemetrySpan> {
         spans
             .iter()
-            .filter(|span| span.start.kind == TelemetrySpanKind::LixOpened)
+            .filter(|span| span.start.name == "lix.repository.opened")
             .collect()
     }
 
@@ -7293,9 +7291,7 @@ mod tests {
             let spans = spans.lock().expect("spans");
             assert_eq!(opened_spans(&spans).len(), 1);
             assert!(
-                spans
-                    .iter()
-                    .any(|span| span.start.kind == TelemetrySpanKind::SqlQuery),
+                spans.iter().any(|span| span.start.name == "lix.sql.query"),
                 "SQL spans still work after handshake bind"
             );
         }
@@ -10931,13 +10927,21 @@ mod tests {
         let spans = spans.lock().expect("capture spans");
         let batch = require_span(&spans, "lix.sql.batch");
         require_span(&spans, "lix.sql.query");
-        let materialize = require_span(&spans, "lix.perf.transaction_materialization");
-        let storage_commit = require_span(&spans, "lix.perf.transaction_storage_commit");
-        require_span(&spans, "lix.perf.storage_commit_accepted_visible");
-        let notify = require_span(&spans, "lix.perf.transaction_notify");
+        let materialize = require_span(&spans, "lix.transaction.materialize");
+        let storage_commit = require_span(&spans, "lix.transaction.storage");
+        let notify = require_span(&spans, "lix.transaction.notify");
         assert_eq!(materialize.parent.as_ref(), Some(&batch.id));
         assert_eq!(storage_commit.parent.as_ref(), Some(&batch.id));
         assert_eq!(notify.parent.as_ref(), Some(&batch.id));
+        let cohort_id = materialize
+            .fields
+            .get("lix.commit_cohort_id")
+            .expect("materialize cohort id");
+        assert_eq!(
+            storage_commit.fields.get("lix.commit_cohort_id"),
+            Some(cohort_id)
+        );
+        assert_eq!(notify.fields.get("lix.commit_cohort_id"), Some(cohort_id));
         assert_no_bound_parameter_or_bytea_fields(&spans);
     }
 
@@ -10991,8 +10995,8 @@ mod tests {
             "checkpoint span should record the parent commit, got {:?}",
             checkpoint.fields.get("lix.parent_commit_id")
         );
-        let materialize = require_span(&spans, "lix.perf.transaction_materialization");
-        let storage_commit = require_span(&spans, "lix.perf.transaction_storage_commit");
+        let materialize = require_span(&spans, "lix.transaction.materialize");
+        let storage_commit = require_span(&spans, "lix.transaction.storage");
         assert_eq!(materialize.parent.as_ref(), Some(&checkpoint.id));
         assert_eq!(storage_commit.parent.as_ref(), Some(&checkpoint.id));
         assert_no_bound_parameter_or_bytea_fields(&spans);
@@ -11064,7 +11068,7 @@ mod tests {
         assert_eq!(
             spans
                 .iter()
-                .filter(|span| span.name == "lix.perf.transaction_notify")
+                .filter(|span| span.name == "lix.transaction.notify")
                 .count(),
             1,
             "an explicit transaction must emit one per-transaction notify span"
@@ -11078,14 +11082,21 @@ mod tests {
         let spans = Arc::clone(&capture.spans);
         let _subscriber =
             tracing::subscriber::set_default(tracing_subscriber::registry().with(capture));
-        let _lix = open_lix().await.expect("open lix");
+        let _lix = open_lix()
+            .with_telemetry(Arc::new(TracingTelemetrySink::new()))
+            .await
+            .expect("open lix");
 
         let spans = spans.lock().expect("capture spans");
         require_span(&spans, "lix.engine.open");
         require_span(&spans, "lix.session.open");
-        assert!(
-            spans.iter().all(|span| span.name != "lix.opened"),
-            "lix.opened stays bind-only and requires an attached sink"
+        assert_eq!(
+            spans
+                .iter()
+                .filter(|span| span.name == "lix.repository.opened")
+                .count(),
+            1,
+            "the public session binds exactly once"
         );
         assert_no_bound_parameter_or_bytea_fields(&spans);
     }

--- a/packages/lix/src/session/checkpoint.rs
+++ b/packages/lix/src/session/checkpoint.rs
@@ -3,10 +3,12 @@ use crate::branch::{BranchLifecycle, BranchOperation, BranchReferenceRole};
 use crate::checkpoint::{CHECKPOINT_SCHEMA_KEY, checkpoint_stage_row};
 use crate::gc::CheckpointGcState;
 use crate::storage_adapter::Storage;
+use crate::telemetry::{
+    ActiveTelemetrySpan, TelemetryAttribute, TelemetrySpanClass, TelemetrySpanStatus,
+};
 use crate::tracked_state::{TrackedStateDiffKind, TrackedStateDiffRequest, TrackedStateDiffRow};
 use crate::transaction::StagedCommitChangeBatchBuilder;
 use crate::transaction_types::{RawWriteBatch, TransactionWrite, TransactionWriteMode};
-use tracing::Instrument as _;
 
 use super::context::SessionContext;
 
@@ -52,130 +54,155 @@ where
     /// collection runs asynchronously so a history-sized sweep cannot extend
     /// the foreground checkpoint latency.
     pub async fn create_checkpoint(&self) -> Result<CreateCheckpointReceipt, LixError> {
-        let span = tracing::info_span!(
-            target: "lix",
-            "lix.checkpoint.create",
-            "lix.commit_id" = tracing::field::Empty,
-            "lix.parent_commit_id" = tracing::field::Empty,
-        );
-        let outcome = self
-            .with_write_transaction_lending(async move |transaction| {
-                let branch_id = transaction.active_branch_id().to_string();
-                let (previous_recovery, mut gc_state) =
-                    transaction.checkpoint_publication_state(&branch_id).await?;
-                let head_commit_id = {
-                    let reader = transaction.branch_ref_reader().await;
-                    BranchLifecycle::new(&reader)
-                        .require_existing_commit_id(
-                            &branch_id,
-                            BranchOperation::CreateCheckpoint,
-                            BranchReferenceRole::Target,
+        let span = self.telemetry.as_ref().and_then(|sink| {
+            ActiveTelemetrySpan::start_if_enabled(
+                sink,
+                TelemetrySpanClass::Lifecycle,
+                "lix.checkpoint.create",
+                Vec::new(),
+            )
+        });
+        let operation = self.with_write_transaction_lending(async move |transaction| {
+            let branch_id = transaction.active_branch_id().to_string();
+            let (previous_recovery, mut gc_state) =
+                transaction.checkpoint_publication_state(&branch_id).await?;
+            let head_commit_id = {
+                let reader = transaction.branch_ref_reader().await;
+                BranchLifecycle::new(&reader)
+                    .require_existing_commit_id(
+                        &branch_id,
+                        BranchOperation::CreateCheckpoint,
+                        BranchReferenceRole::Target,
+                    )
+                    .await?
+            };
+            let direct_working_diff = transaction
+                .working_diff_at_head(
+                    &branch_id,
+                    head_commit_id,
+                    &TrackedStateDiffRequest::default(),
+                )
+                .await?;
+            let previous_checkpoint_commit_id = if let Some(direct) = &direct_working_diff {
+                direct.checkpoint_commit_id
+            } else {
+                transaction
+                    .checkpoint_commit_id_at_head(&branch_id, head_commit_id)
+                    .await?
+            };
+            let interval_has_commits = head_commit_id != previous_checkpoint_commit_id;
+            let selected_changes = {
+                let entries = if let Some(direct) = direct_working_diff {
+                    direct.diff.entries
+                } else {
+                    let mut reader = transaction.tracked_state_reader().await;
+                    reader
+                        .diff_commits(
+                            &previous_checkpoint_commit_id.to_string(),
+                            &head_commit_id.to_string(),
+                            &TrackedStateDiffRequest::default(),
                         )
                         .await?
+                        .entries
                 };
-                let direct_working_diff = transaction
-                    .working_diff_at_head(
-                        &branch_id,
-                        head_commit_id,
-                        &TrackedStateDiffRequest::default(),
-                    )
-                    .await?;
-                let previous_checkpoint_commit_id = if let Some(direct) = &direct_working_diff {
-                    direct.checkpoint_commit_id
-                } else {
-                    transaction
-                        .checkpoint_commit_id_at_head(&branch_id, head_commit_id)
-                        .await?
-                };
-                let interval_has_commits = head_commit_id != previous_checkpoint_commit_id;
-                let selected_changes = {
-                    let entries = if let Some(direct) = direct_working_diff {
-                        direct.diff.entries
-                    } else {
-                        let mut reader = transaction.tracked_state_reader().await;
-                        reader
-                            .diff_commits(
-                                &previous_checkpoint_commit_id.to_string(),
-                                &head_commit_id.to_string(),
-                                &TrackedStateDiffRequest::default(),
-                            )
-                            .await?
-                            .entries
-                    };
-                    let mut selected_changes =
-                        StagedCommitChangeBatchBuilder::with_capacity(entries.len());
-                    let mut source_membership_exact = true;
-                    for entry in entries.into_iter().filter(|entry| {
-                        entry.identity.schema_key() != CHECKPOINT_SCHEMA_KEY
-                            && entry.identity.schema_key()
-                                != crate::undo_redo::UNDO_REDO_MARKER_SCHEMA_KEY
-                    }) {
-                        let row = entry.after.ok_or_else(|| {
-                            LixError::new(
-                                LixError::CODE_INTERNAL_ERROR,
-                                format!(
-                                    "working diff for schema '{}' row {:?} has no target row",
-                                    entry.identity.schema_key(),
-                                    entry.identity.row_pk()
-                                ),
-                            )
-                        })?;
-                        source_membership_exact &=
-                            push_selected_change(&mut selected_changes, row, entry.kind);
-                    }
-                    if source_membership_exact {
-                        selected_changes.finish_source_certified()
-                    } else {
-                        selected_changes.finish()
-                    }
-                };
-                gc_state.checkpoint_sequence =
-                    gc_state.checkpoint_sequence.checked_add(1).ok_or_else(|| {
+                let mut selected_changes =
+                    StagedCommitChangeBatchBuilder::with_capacity(entries.len());
+                let mut source_membership_exact = true;
+                for entry in entries.into_iter().filter(|entry| {
+                    entry.identity.schema_key() != CHECKPOINT_SCHEMA_KEY
+                        && entry.identity.schema_key()
+                            != crate::undo_redo::UNDO_REDO_MARKER_SCHEMA_KEY
+                }) {
+                    let row = entry.after.ok_or_else(|| {
                         LixError::new(
                             LixError::CODE_INTERNAL_ERROR,
-                            "checkpoint sequence overflow",
+                            format!(
+                                "working diff for schema '{}' row {:?} has no target row",
+                                entry.identity.schema_key(),
+                                entry.identity.row_pk()
+                            ),
                         )
                     })?;
-                if let Some(previous_recovery) = previous_recovery {
-                    gc_state.add_collectible_interval(previous_recovery.interval_has_commits);
+                    source_membership_exact &=
+                        push_selected_change(&mut selected_changes, row, entry.kind);
                 }
-                let gc_due = checkpoint_gc_due(gc_state)?;
+                if source_membership_exact {
+                    selected_changes.finish_source_certified()
+                } else {
+                    selected_changes.finish()
+                }
+            };
+            gc_state.checkpoint_sequence =
+                gc_state.checkpoint_sequence.checked_add(1).ok_or_else(|| {
+                    LixError::new(
+                        LixError::CODE_INTERNAL_ERROR,
+                        "checkpoint sequence overflow",
+                    )
+                })?;
+            if let Some(previous_recovery) = previous_recovery {
+                gc_state.add_collectible_interval(previous_recovery.interval_has_commits);
+            }
+            let gc_due = checkpoint_gc_due(gc_state)?;
 
-                let commit_id = transaction.stage_checkpoint_commit(
-                    branch_id,
-                    previous_checkpoint_commit_id,
-                    head_commit_id,
-                    interval_has_commits,
-                    gc_state,
-                    selected_changes,
-                )?;
-                let checkpoint_commit_id =
-                    crate::changelog::CommitId::parse_lix(&commit_id, "checkpoint commit id")?;
-                let change_id = transaction.functions().call_uuid_v7().to_string();
-                let mut checkpoint_rows = RawWriteBatch::with_capacity(1);
-                checkpoint_rows.push(checkpoint_stage_row(
-                    &checkpoint_commit_id,
-                    change_id.clone(),
-                ));
-                transaction
-                    .stage_write(TransactionWrite::Rows {
-                        mode: TransactionWriteMode::Replace,
-                        rows: checkpoint_rows,
-                    })
-                    .await?;
-                Ok(CreateCheckpointOutcome {
-                    receipt: CreateCheckpointReceipt {
-                        commit_id,
-                        change_id,
-                    },
-                    parent_commit_id: previous_checkpoint_commit_id.to_string(),
-                    gc_due,
+            let commit_id = transaction.stage_checkpoint_commit(
+                branch_id,
+                previous_checkpoint_commit_id,
+                head_commit_id,
+                interval_has_commits,
+                gc_state,
+                selected_changes,
+            )?;
+            let checkpoint_commit_id =
+                crate::changelog::CommitId::parse_lix(&commit_id, "checkpoint commit id")?;
+            let change_id = transaction.functions().call_uuid_v7().to_string();
+            let mut checkpoint_rows = RawWriteBatch::with_capacity(1);
+            checkpoint_rows.push(checkpoint_stage_row(
+                &checkpoint_commit_id,
+                change_id.clone(),
+            ));
+            transaction
+                .stage_write(TransactionWrite::Rows {
+                    mode: TransactionWriteMode::Replace,
+                    rows: checkpoint_rows,
                 })
+                .await?;
+            Ok(CreateCheckpointOutcome {
+                receipt: CreateCheckpointReceipt {
+                    commit_id,
+                    change_id,
+                },
+                parent_commit_id: previous_checkpoint_commit_id.to_string(),
+                gc_due,
             })
-            .instrument(span.clone())
-            .await?;
-        span.record("lix.commit_id", outcome.receipt.commit_id.as_str());
-        span.record("lix.parent_commit_id", outcome.parent_commit_id.as_str());
+        });
+        let result = match span.as_ref() {
+            Some(span) => span.instrument(operation).await,
+            None => operation.await,
+        };
+        let outcome = match result {
+            Ok(outcome) => outcome,
+            Err(error) => {
+                if let Some(span) = span {
+                    span.finish(
+                        TelemetrySpanStatus::Error,
+                        vec![TelemetryAttribute::string("error.type", error.code.clone())],
+                    );
+                }
+                return Err(error);
+            }
+        };
+        if let Some(span) = span {
+            span.finish(
+                TelemetrySpanStatus::Ok,
+                vec![
+                    TelemetryAttribute::string("lix.commit_id", outcome.receipt.commit_id.clone()),
+                    TelemetryAttribute::string(
+                        "lix.parent_commit_id",
+                        outcome.parent_commit_id.clone(),
+                    ),
+                ],
+            );
+        }
         if outcome.gc_due {
             // GC debt is durable in the checkpoint transaction. The sweep is
             // therefore safely retryable and does not need to delay the user

--- a/packages/lix/src/session/checkpoint.rs
+++ b/packages/lix/src/session/checkpoint.rs
@@ -6,6 +6,7 @@ use crate::storage_adapter::Storage;
 use crate::tracked_state::{TrackedStateDiffKind, TrackedStateDiffRequest, TrackedStateDiffRow};
 use crate::transaction::StagedCommitChangeBatchBuilder;
 use crate::transaction_types::{RawWriteBatch, TransactionWrite, TransactionWriteMode};
+use tracing::Instrument as _;
 
 use super::context::SessionContext;
 
@@ -34,6 +35,7 @@ const RECLAIM_MAX_STALENESS: u64 = 64;
 
 struct CreateCheckpointOutcome {
     receipt: CreateCheckpointReceipt,
+    parent_commit_id: String,
     gc_due: bool,
 }
 
@@ -50,6 +52,12 @@ where
     /// collection runs asynchronously so a history-sized sweep cannot extend
     /// the foreground checkpoint latency.
     pub async fn create_checkpoint(&self) -> Result<CreateCheckpointReceipt, LixError> {
+        let span = tracing::info_span!(
+            target: "lix",
+            "lix.checkpoint.create",
+            "lix.commit_id" = tracing::field::Empty,
+            "lix.parent_commit_id" = tracing::field::Empty,
+        );
         let outcome = self
             .with_write_transaction_lending(async move |transaction| {
                 let branch_id = transaction.active_branch_id().to_string();
@@ -160,10 +168,14 @@ where
                         commit_id,
                         change_id,
                     },
+                    parent_commit_id: previous_checkpoint_commit_id.to_string(),
                     gc_due,
                 })
             })
+            .instrument(span.clone())
             .await?;
+        span.record("lix.commit_id", outcome.receipt.commit_id.as_str());
+        span.record("lix.parent_commit_id", outcome.parent_commit_id.as_str());
         if outcome.gc_due {
             // GC debt is durable in the checkpoint transaction. The sweep is
             // therefore safely retryable and does not need to delay the user

--- a/packages/lix/src/session/context.rs
+++ b/packages/lix/src/session/context.rs
@@ -32,7 +32,7 @@ use crate::sql2::{
     SqlExecutionContext, SqlHistoryQuerySource, SqlPlanningCache,
 };
 use crate::storage_adapter::Storage;
-use crate::storage_adapter::{Memory, StorageReadOptions};
+use crate::storage_adapter::{Memory, StorageReadOptions, StorageWriteSetStats};
 use crate::storage_adapter::{SharedStorageAdapterRead, StorageAdapter, StorageAdapterRead};
 use crate::sync::SyncModeState;
 use crate::telemetry::TelemetrySink;
@@ -414,8 +414,8 @@ where
             Some(
                 Arc::clone(&self.collaboration_write_gate)
                     .lock_owned()
-                    .instrument(tracing::debug_span!(
-                        target: "lix_perf",
+                    .instrument(tracing::info_span!(
+                        target: "lix_sql",
                         "lix.perf.collaboration_gate_wait"
                     ))
                     .await,
@@ -530,8 +530,8 @@ where
             Arc::clone(&self.sql_planning_cache),
             self.file_views.clone(),
         ))
-        .instrument(tracing::debug_span!(
-            target: "lix_perf",
+        .instrument(tracing::info_span!(
+            target: "lix_sql",
             "lix.perf.transaction_open"
         ))
         .await?;
@@ -548,8 +548,8 @@ where
         let runtime_functions = opened.runtime_functions;
 
         match f(&mut transaction)
-            .instrument(tracing::debug_span!(
-                target: "lix_perf",
+            .instrument(tracing::info_span!(
+                target: "lix_sql",
                 "lix.perf.transaction_plan_and_stage"
             ))
             .await
@@ -561,16 +561,7 @@ where
                 crate::storage_bench::record_crud_physical_writes(outcome.storage_stats);
                 let after_commit_result = after_commit(&value);
                 drop(write_access);
-                self.observe_invalidation
-                    .bump_if_storage_changed(&outcome.storage_stats);
-                // The server sync endpoint long-polls on canonical-head
-                // movement. Notify only after the storage commit has crossed
-                // its boundary so a woken pull can always observe the event
-                // it was waiting for. Suppressed internal replica sessions
-                // must not wake their own worker while applying a pull.
-                if !self.sync_outbox_suppressed {
-                    self.sync_mode.notify_sync_change();
-                }
+                self.notify_after_storage_commit(&outcome.storage_stats);
                 after_commit_result?;
                 Ok(value)
             }
@@ -587,6 +578,28 @@ where
         &self,
     ) -> crate::transaction::TransactionCommitBoundary {
         self.transaction_manager.transaction_commit_boundary()
+    }
+
+    /// Wakes observers and sync long-polls after a durable storage commit.
+    ///
+    /// Named so this work cannot hide inside `transaction.commit()` self-time
+    /// on the production-exported `lix_sql` plane.
+    pub(super) fn notify_after_storage_commit(&self, storage_stats: &StorageWriteSetStats) {
+        let _span = tracing::info_span!(
+            target: "lix_sql",
+            "lix.perf.transaction_notify"
+        )
+        .entered();
+        self.observe_invalidation
+            .bump_if_storage_changed(storage_stats);
+        // The server sync endpoint long-polls on canonical-head movement.
+        // Notify only after the storage commit has crossed its boundary so a
+        // woken pull can always observe the event it was waiting for.
+        // Suppressed internal replica sessions must not wake their own worker
+        // while applying a pull.
+        if !self.sync_outbox_suppressed {
+            self.sync_mode.notify_sync_change();
+        }
     }
 }
 
@@ -608,8 +621,8 @@ impl SessionWriteAccess {
             self.collaboration_write_guard = Some(
                 Arc::clone(collaboration_write_gate)
                     .lock_owned()
-                    .instrument(tracing::debug_span!(
-                        target: "lix_perf",
+                    .instrument(tracing::info_span!(
+                        target: "lix_sql",
                         "lix.perf.collaboration_gate_wait"
                     ))
                     .await,

--- a/packages/lix/src/session/context.rs
+++ b/packages/lix/src/session/context.rs
@@ -35,7 +35,10 @@ use crate::storage_adapter::Storage;
 use crate::storage_adapter::{Memory, StorageReadOptions, StorageWriteSetStats};
 use crate::storage_adapter::{SharedStorageAdapterRead, StorageAdapter, StorageAdapterRead};
 use crate::sync::SyncModeState;
-use crate::telemetry::TelemetrySink;
+use crate::telemetry::{
+    ActiveTelemetrySpan, TelemetryAttribute, TelemetrySink, TelemetrySpanClass,
+    TelemetrySpanStatus, instrument_value,
+};
 use crate::tracked_state::TrackedStateContext;
 use crate::transaction::{CertifiedHistoryStoreReader, Transaction, open_transaction};
 
@@ -411,14 +414,23 @@ where
         serialize_collaboration_write: bool,
     ) -> Result<SessionWriteAccess, LixError> {
         let collaboration_write_guard = if serialize_collaboration_write {
+            let span = self.telemetry.as_ref().and_then(|sink| {
+                ActiveTelemetrySpan::start_if_enabled(
+                    sink,
+                    TelemetrySpanClass::Performance,
+                    "lix.transaction.wait",
+                    vec![TelemetryAttribute::string(
+                        "lix.wait.reason",
+                        "collaboration_write_gate",
+                    )],
+                )
+            });
             Some(
-                Arc::clone(&self.collaboration_write_gate)
-                    .lock_owned()
-                    .instrument(tracing::info_span!(
-                        target: "lix_sql",
-                        "lix.perf.collaboration_gate_wait"
-                    ))
-                    .await,
+                instrument_value(
+                    span,
+                    Arc::clone(&self.collaboration_write_gate).lock_owned(),
+                )
+                .await,
             )
         } else {
             None
@@ -530,8 +542,8 @@ where
             Arc::clone(&self.sql_planning_cache),
             self.file_views.clone(),
         ))
-        .instrument(tracing::info_span!(
-            target: "lix_sql",
+        .instrument(tracing::debug_span!(
+            target: "lix_perf",
             "lix.perf.transaction_open"
         ))
         .await?;
@@ -548,8 +560,8 @@ where
         let runtime_functions = opened.runtime_functions;
 
         match f(&mut transaction)
-            .instrument(tracing::info_span!(
-                target: "lix_sql",
+            .instrument(tracing::debug_span!(
+                target: "lix_perf",
                 "lix.perf.transaction_plan_and_stage"
             ))
             .await
@@ -561,7 +573,10 @@ where
                 crate::storage_bench::record_crud_physical_writes(outcome.storage_stats);
                 let after_commit_result = after_commit(&value);
                 drop(write_access);
-                self.notify_after_storage_commit(&outcome.storage_stats);
+                self.notify_after_storage_commit(
+                    &outcome.storage_stats,
+                    outcome.commit_cohort_id.as_deref(),
+                );
                 after_commit_result?;
                 Ok(value)
             }
@@ -584,12 +599,27 @@ where
     ///
     /// Named so this work cannot hide inside `transaction.commit()` self-time
     /// on the production-exported `lix_sql` plane.
-    pub(super) fn notify_after_storage_commit(&self, storage_stats: &StorageWriteSetStats) {
-        let _span = tracing::info_span!(
-            target: "lix_sql",
-            "lix.perf.transaction_notify"
-        )
-        .entered();
+    pub(super) fn notify_after_storage_commit(
+        &self,
+        storage_stats: &StorageWriteSetStats,
+        commit_cohort_id: Option<&str>,
+    ) {
+        let mut attributes = vec![TelemetryAttribute::u64("lix.transaction.count", 1)];
+        if let Some(commit_cohort_id) = commit_cohort_id {
+            attributes.push(TelemetryAttribute::string(
+                "lix.commit_cohort_id",
+                commit_cohort_id,
+            ));
+        }
+        let span = self.telemetry.as_ref().and_then(|sink| {
+            ActiveTelemetrySpan::start_if_enabled(
+                sink,
+                TelemetrySpanClass::Performance,
+                "lix.transaction.notify",
+                attributes,
+            )
+        });
+        let _entered = span.as_ref().map(ActiveTelemetrySpan::enter);
         self.observe_invalidation
             .bump_if_storage_changed(storage_stats);
         // The server sync endpoint long-polls on canonical-head movement.
@@ -599,6 +629,10 @@ where
         // while applying a pull.
         if !self.sync_outbox_suppressed {
             self.sync_mode.notify_sync_change();
+        }
+        drop(_entered);
+        if let Some(span) = span {
+            span.finish(TelemetrySpanStatus::Ok, Vec::new());
         }
     }
 }
@@ -618,14 +652,16 @@ impl SessionWriteAccess {
         collaboration_write_gate: &Arc<tokio::sync::Mutex<()>>,
     ) {
         if self.collaboration_write_guard.is_none() {
+            let span = ActiveTelemetrySpan::start_current(
+                TelemetrySpanClass::Performance,
+                "lix.transaction.wait",
+                vec![TelemetryAttribute::string(
+                    "lix.wait.reason",
+                    "collaboration_write_gate",
+                )],
+            );
             self.collaboration_write_guard = Some(
-                Arc::clone(collaboration_write_gate)
-                    .lock_owned()
-                    .instrument(tracing::info_span!(
-                        target: "lix_sql",
-                        "lix.perf.collaboration_gate_wait"
-                    ))
-                    .await,
+                instrument_value(span, Arc::clone(collaboration_write_gate).lock_owned()).await,
             );
         }
     }

--- a/packages/lix/src/session/execute.rs
+++ b/packages/lix/src/session/execute.rs
@@ -17,7 +17,6 @@ use crate::storage_adapter::{
     SharedStorageAdapterRead, StorageAdapter, StorageAdapterRead, StorageAdapterReadScope,
     StorageReadDurability, StorageReadOptions, StorageWriteOptions, StorageWriteSet,
 };
-use crate::telemetry::TelemetrySpanKind;
 use crate::transaction::{begin_commit_boundary, commit_at_boundary};
 use crate::{Blob, LixError, LixNotice, SqlQueryResult, Value};
 use datafusion::arrow::array::{ArrayRef, LargeStringBuilder, StringBuilder};
@@ -1816,11 +1815,7 @@ where
         idempotency: Option<ExecuteIdempotency>,
         require_idempotency_for_writes: bool,
     ) -> Result<Vec<ExecuteResult>, LixError> {
-        let telemetry = start_batch(
-            self.telemetry.as_ref(),
-            TelemetrySpanKind::SqlBatch,
-            statements.len(),
-        );
+        let telemetry = start_batch(self.telemetry.as_ref(), "lix.sql.batch", statements.len());
         let operation = self.execute_batch_with_options_inner(
             statements,
             options,
@@ -2275,7 +2270,7 @@ where
     ) -> Result<CoherentReadBatch, LixError> {
         let telemetry = start_batch(
             self.telemetry.as_ref(),
-            TelemetrySpanKind::SqlCoherentReadBatch,
+            "lix.sql.coherent_read_batch",
             statements.len(),
         );
         let operation = self.execute_coherent_read_batch_inner(statements);
@@ -5308,9 +5303,7 @@ mod tests {
     use super::*;
     use crate::changelog::{ChangelogContext, ChangelogReader, CommitLoadRequest};
     use crate::row_pk::RowPk;
-    use crate::telemetry::{
-        CallbackTelemetrySink, CompletedTelemetrySpan, TelemetrySpanKind, TelemetryValue,
-    };
+    use crate::telemetry::{CallbackTelemetrySink, CompletedTelemetrySpan, TelemetryValue};
     use crate::transaction_types::{RawWriteBatch, TransactionJson, TransactionWriteRow};
     use crate::{
         Memory,
@@ -10178,12 +10171,21 @@ mod tests {
             .unwrap();
 
         let spans = spans.lock().expect("telemetry span lock");
+        let batch_span = spans
+            .iter()
+            .find(|span| span.start.name == "lix.sql.batch")
+            .expect("batch span");
         let query_spans = spans
             .iter()
-            .filter(|span| span.start.kind == TelemetrySpanKind::SqlQuery)
+            .filter(|span| span.start.name == "lix.sql.query")
             .collect::<Vec<_>>();
         assert_eq!(query_spans.len(), 2);
         for (index, span) in query_spans.into_iter().enumerate() {
+            assert_eq!(span.start.trace_id, batch_span.start.trace_id);
+            assert_eq!(
+                span.start.parent_span_id.as_deref(),
+                Some(batch_span.start.span_id.as_str())
+            );
             assert!(span.start.attributes.iter().any(|attribute| {
                 attribute.key == "lix.sql.fingerprint"
                     && matches!(&attribute.value, TelemetryValue::String(value) if !value.is_empty())

--- a/packages/lix/src/session/transaction.rs
+++ b/packages/lix/src/session/transaction.rs
@@ -177,15 +177,22 @@ where
         drop(operation_guard);
         let outcome = result?;
         drop(self.write_access.take());
-        self.observe_invalidation
-            .bump_if_storage_changed(&outcome.storage_stats);
-        // Explicit transactions publish the same canonical event lane as
-        // automatic writes. Wake server long-polls only after the durable
-        // commit so readers never race a still-staged event. Suppressed
-        // internal replica transactions are excluded for the same reason as
-        // automatic sync-apply sessions.
-        if !self.session.sync_outbox_suppressed {
-            self.sync_mode.notify_sync_change();
+        {
+            let _span = tracing::info_span!(
+                target: "lix_sql",
+                "lix.perf.transaction_notify"
+            )
+            .entered();
+            self.observe_invalidation
+                .bump_if_storage_changed(&outcome.storage_stats);
+            // Explicit transactions publish the same canonical event lane as
+            // automatic writes. Wake server long-polls only after the durable
+            // commit so readers never race a still-staged event. Suppressed
+            // internal replica transactions are excluded for the same reason as
+            // automatic sync-apply sessions.
+            if !self.session.sync_outbox_suppressed {
+                self.sync_mode.notify_sync_change();
+            }
         }
         Ok(())
     }

--- a/packages/lix/src/session/transaction.rs
+++ b/packages/lix/src/session/transaction.rs
@@ -8,7 +8,9 @@ use crate::observe_invalidation::ObserveInvalidation;
 use crate::sql2::SqlPlanningCache;
 use crate::storage_adapter::Memory;
 use crate::storage_adapter::Storage;
-use crate::telemetry::TelemetrySink;
+use crate::telemetry::{
+    ActiveTelemetrySpan, TelemetryAttribute, TelemetrySink, TelemetrySpanClass, TelemetrySpanStatus,
+};
 use tokio::sync::Notify;
 
 use crate::LixError;
@@ -178,11 +180,22 @@ where
         let outcome = result?;
         drop(self.write_access.take());
         {
-            let _span = tracing::info_span!(
-                target: "lix_sql",
-                "lix.perf.transaction_notify"
-            )
-            .entered();
+            let notify = already_serialized
+                .then(|| {
+                    ActiveTelemetrySpan::start_current(
+                        TelemetrySpanClass::Performance,
+                        "lix.transaction.notify",
+                        vec![
+                            TelemetryAttribute::u64("lix.transaction.count", 1),
+                            TelemetryAttribute::string(
+                                "lix.commit_cohort_id",
+                                outcome.commit_cohort_id.clone().unwrap_or_default(),
+                            ),
+                        ],
+                    )
+                })
+                .flatten();
+            let _entered = notify.as_ref().map(ActiveTelemetrySpan::enter);
             self.observe_invalidation
                 .bump_if_storage_changed(&outcome.storage_stats);
             // Explicit transactions publish the same canonical event lane as
@@ -192,6 +205,10 @@ where
             // automatic sync-apply sessions.
             if !self.session.sync_outbox_suppressed {
                 self.sync_mode.notify_sync_change();
+            }
+            drop(_entered);
+            if let Some(notify) = notify {
+                notify.finish(TelemetrySpanStatus::Ok, Vec::new());
             }
         }
         Ok(())

--- a/packages/lix/src/sql_telemetry.rs
+++ b/packages/lix/src/sql_telemetry.rs
@@ -2,8 +2,8 @@ use std::future::Future;
 use std::sync::Arc;
 
 use crate::telemetry::{
-    ActiveTelemetrySpan, TelemetryAttribute, TelemetrySink, TelemetrySpanKind, TelemetrySpanStart,
-    TelemetrySpanStatus, unix_time_ms,
+    ActiveTelemetrySpan, TelemetryAttribute, TelemetrySink, TelemetrySpanClass, TelemetrySpanStart,
+    TelemetrySpanStatus,
 };
 use crate::{ExecuteResult, LixError};
 
@@ -21,7 +21,7 @@ impl SqlStatementTelemetry {
         batch_index: Option<usize>,
     ) -> Option<Self> {
         let sink = sink?;
-        if !sink.enabled(TelemetrySpanKind::SqlQuery) {
+        if !sink.enabled(TelemetrySpanClass::Sql, "lix.sql.query") {
             return None;
         }
         Some(Self {
@@ -54,7 +54,7 @@ fn statement_start(
     let operation = query_operation(&query_text);
     let fingerprint = blake3::hash(query_text.as_bytes()).to_hex().to_string();
     let mut attributes = vec![
-        TelemetryAttribute::string("otel.name", operation.clone()),
+        TelemetryAttribute::string("otel.name", "lix.sql.query"),
         TelemetryAttribute::string("otel.kind", "internal"),
         TelemetryAttribute::string("db.system.name", "lix"),
         TelemetryAttribute::string("db.operation.name", operation.clone()),
@@ -69,12 +69,7 @@ fn statement_start(
             u64::try_from(batch_index).unwrap_or(u64::MAX),
         ));
     }
-    TelemetrySpanStart {
-        kind: TelemetrySpanKind::SqlQuery,
-        name: "lix.sql.query",
-        started_at_unix_ms: unix_time_ms(),
-        attributes,
-    }
+    TelemetrySpanStart::new(TelemetrySpanClass::Sql, "lix.sql.query", attributes)
 }
 
 fn statement_end(
@@ -104,30 +99,25 @@ fn statement_end(
 
 pub(crate) fn start_batch(
     sink: Option<&Arc<dyn TelemetrySink>>,
-    kind: TelemetrySpanKind,
+    name: &'static str,
     size: usize,
 ) -> Option<ActiveTelemetrySpan> {
     let sink = sink?;
-    if !sink.enabled(kind) {
+    if !sink.enabled(TelemetrySpanClass::Sql, name) {
         return None;
     }
-    let (name, display_name, execution_kind) = match kind {
-        TelemetrySpanKind::SqlBatch => ("lix.sql.batch", "SQL batch", "batch"),
-        TelemetrySpanKind::SqlCoherentReadBatch => (
-            "lix.sql.coherent_read_batch",
-            "SQL coherent read batch",
-            "coherent_read_batch",
-        ),
-        TelemetrySpanKind::SqlQuery | TelemetrySpanKind::LixOpened => return None,
+    let execution_kind = match name {
+        "lix.sql.batch" => "batch",
+        "lix.sql.coherent_read_batch" => "coherent_read_batch",
+        _ => return None,
     };
     Some(ActiveTelemetrySpan::start(
         sink,
-        TelemetrySpanStart {
-            kind,
+        TelemetrySpanStart::new(
+            TelemetrySpanClass::Sql,
             name,
-            started_at_unix_ms: unix_time_ms(),
-            attributes: vec![
-                TelemetryAttribute::string("otel.name", display_name),
+            vec![
+                TelemetryAttribute::string("otel.name", name),
                 TelemetryAttribute::string("otel.kind", "internal"),
                 TelemetryAttribute::string("db.system.name", "lix"),
                 TelemetryAttribute::u64(
@@ -136,7 +126,7 @@ pub(crate) fn start_batch(
                 ),
                 TelemetryAttribute::string("lix.execution.kind", execution_kind),
             ],
-        },
+        ),
     ))
 }
 

--- a/packages/lix/src/storage_adapter/context.rs
+++ b/packages/lix/src/storage_adapter/context.rs
@@ -97,8 +97,8 @@ where
         let mut write = self
             .storage
             .begin_write(opts)
-            .instrument(tracing::debug_span!(
-                target: "lix_perf",
+            .instrument(tracing::info_span!(
+                target: "lix_sql",
                 "lix.perf.storage_writer_wait"
             ))
             .await
@@ -116,8 +116,8 @@ where
             }
             Ok::<_, StorageWriteSetError>(stats)
         }
-        .instrument(tracing::debug_span!(
-            target: "lix_perf",
+        .instrument(tracing::info_span!(
+            target: "lix_sql",
             "lix.perf.storage_lowering"
         ))
         .await;
@@ -243,8 +243,8 @@ where
         let result = self
             .write
             .commit()
-            .instrument(tracing::debug_span!(
-                target: "lix_perf",
+            .instrument(tracing::info_span!(
+                target: "lix_sql",
                 "lix.perf.storage_commit_accepted_visible"
             ))
             .await?;

--- a/packages/lix/src/storage_adapter/context.rs
+++ b/packages/lix/src/storage_adapter/context.rs
@@ -97,8 +97,8 @@ where
         let mut write = self
             .storage
             .begin_write(opts)
-            .instrument(tracing::info_span!(
-                target: "lix_sql",
+            .instrument(tracing::debug_span!(
+                target: "lix_perf",
                 "lix.perf.storage_writer_wait"
             ))
             .await
@@ -116,8 +116,8 @@ where
             }
             Ok::<_, StorageWriteSetError>(stats)
         }
-        .instrument(tracing::info_span!(
-            target: "lix_sql",
+        .instrument(tracing::debug_span!(
+            target: "lix_perf",
             "lix.perf.storage_lowering"
         ))
         .await;
@@ -243,8 +243,8 @@ where
         let result = self
             .write
             .commit()
-            .instrument(tracing::info_span!(
-                target: "lix_sql",
+            .instrument(tracing::debug_span!(
+                target: "lix_perf",
                 "lix.perf.storage_commit_accepted_visible"
             ))
             .await?;

--- a/packages/lix/src/telemetry.rs
+++ b/packages/lix/src/telemetry.rs
@@ -139,6 +139,12 @@ impl TelemetrySpanHandle for CallbackTelemetrySpan {
 }
 
 /// Explicit adapter from engine telemetry into the Rust `tracing` ecosystem.
+///
+/// Production subscribers export INFO `lix_sql` (SQL batch / query) and INFO
+/// `lix` (`lix.opened`). Commit, storage, notify, checkpoint, and session /
+/// engine-open phases that can take tens of milliseconds use those same
+/// targets at INFO so they appear in the same tree. Debug-only `lix_perf`
+/// micro-phases stay off the production plane.
 #[derive(Debug, Default, Clone, Copy)]
 pub struct TracingTelemetrySink;
 
@@ -455,10 +461,12 @@ mod tests {
             attribute_string(&started[0], "lix.account_id"),
             Some("account-id")
         );
-        assert!(started[0]
-            .attributes
-            .iter()
-            .all(|attribute| attribute.key.starts_with("lix.")));
+        assert!(
+            started[0]
+                .attributes
+                .iter()
+                .all(|attribute| attribute.key.starts_with("lix."))
+        );
     }
 
     #[test]

--- a/packages/lix/src/telemetry.rs
+++ b/packages/lix/src/telemetry.rs
@@ -1,16 +1,19 @@
+use std::cell::RefCell;
 use std::future::Future;
 use std::pin::Pin;
-use std::sync::Arc;
+use std::sync::{
+    Arc,
+    atomic::{AtomicU64, Ordering},
+};
 use std::task::{Context, Poll};
 
-/// A stable category that lets sinks filter spans before Lix builds attributes.
+/// A stable, coarse category that lets sinks filter telemetry without making
+/// every Lix operation a public Rust enum variant.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum TelemetrySpanKind {
-    SqlQuery,
-    SqlBatch,
-    SqlCoherentReadBatch,
-    /// A client session bound to a Lix. Not engine construction or cache-admit.
-    LixOpened,
+pub enum TelemetrySpanClass {
+    Sql,
+    Lifecycle,
+    Performance,
 }
 
 /// One vendor-neutral telemetry attribute.
@@ -46,16 +49,38 @@ pub enum TelemetryValue {
 /// Information available when an engine operation begins.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct TelemetrySpanStart {
-    pub kind: TelemetrySpanKind,
+    pub class: TelemetrySpanClass,
     pub name: &'static str,
+    pub trace_id: String,
+    pub span_id: String,
+    pub parent_span_id: Option<String>,
     pub started_at_unix_ms: u64,
     pub attributes: Vec<TelemetryAttribute>,
+}
+
+impl TelemetrySpanStart {
+    pub fn new(
+        class: TelemetrySpanClass,
+        name: &'static str,
+        attributes: Vec<TelemetryAttribute>,
+    ) -> Self {
+        Self {
+            class,
+            name,
+            trace_id: String::new(),
+            span_id: String::new(),
+            parent_span_id: None,
+            started_at_unix_ms: unix_time_ms(),
+            attributes,
+        }
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum TelemetrySpanStatus {
     Ok,
     Error,
+    Cancelled,
 }
 
 /// Information available when an engine operation finishes.
@@ -75,9 +100,9 @@ pub struct CompletedTelemetrySpan {
 
 /// Per-engine telemetry destination. Lix never installs a global exporter.
 pub trait TelemetrySink: Send + Sync {
-    /// Called before Lix sanitizes or fingerprints SQL. Returning false makes
-    /// the disabled path avoid all telemetry-specific work.
-    fn enabled(&self, _kind: TelemetrySpanKind) -> bool {
+    /// Called before Lix builds attributes. The class is deliberately coarse;
+    /// `name` is the stable telemetry contract.
+    fn enabled(&self, _class: TelemetrySpanClass, _name: &'static str) -> bool {
         true
     }
 
@@ -141,7 +166,7 @@ impl TelemetrySpanHandle for CallbackTelemetrySpan {
 /// Explicit adapter from engine telemetry into the Rust `tracing` ecosystem.
 ///
 /// Production subscribers export INFO `lix_sql` (SQL batch / query) and INFO
-/// `lix` (`lix.opened`). Commit, storage, notify, checkpoint, and session /
+/// `lix` (`lix.repository.opened`). Commit, storage, notify, checkpoint, and session /
 /// engine-open phases that can take tens of milliseconds use those same
 /// targets at INFO so they appear in the same tree. Debug-only `lix_perf`
 /// micro-phases stay off the production plane.
@@ -155,14 +180,12 @@ impl TracingTelemetrySink {
 }
 
 impl TelemetrySink for TracingTelemetrySink {
-    fn enabled(&self, kind: TelemetrySpanKind) -> bool {
-        match kind {
-            TelemetrySpanKind::SqlQuery
-            | TelemetrySpanKind::SqlBatch
-            | TelemetrySpanKind::SqlCoherentReadBatch => {
+    fn enabled(&self, class: TelemetrySpanClass, _name: &'static str) -> bool {
+        match class {
+            TelemetrySpanClass::Sql | TelemetrySpanClass::Performance => {
                 tracing::enabled!(target: "lix_sql", tracing::Level::INFO)
             }
-            TelemetrySpanKind::LixOpened => {
+            TelemetrySpanClass::Lifecycle => {
                 tracing::enabled!(target: "lix", tracing::Level::INFO)
             }
         }
@@ -191,13 +214,23 @@ impl TelemetrySpanHandle for TracingTelemetrySpan {
         for attribute in &end.attributes {
             record_attribute(&self.span, attribute);
         }
+        self.span.record(
+            "otel.status_code",
+            match end.status {
+                TelemetrySpanStatus::Ok => "OK",
+                TelemetrySpanStatus::Error | TelemetrySpanStatus::Cancelled => "ERROR",
+            },
+        );
+        if end.status == TelemetrySpanStatus::Cancelled {
+            self.span.record("error.type", "cancelled");
+        }
         drop(self);
     }
 }
 
 fn tracing_span(start: &TelemetrySpanStart) -> tracing::Span {
-    let span = match start.kind {
-        TelemetrySpanKind::SqlQuery => tracing::info_span!(
+    let span = match start.name {
+        "lix.sql.query" => tracing::info_span!(
             target: "lix_sql",
             "lix.sql.query",
             "otel.name" = tracing::field::Empty,
@@ -214,7 +247,7 @@ fn tracing_span(start: &TelemetrySpanStart) -> tracing::Span {
             "error.type" = tracing::field::Empty,
             "otel.status_code" = tracing::field::Empty,
         ),
-        TelemetrySpanKind::SqlBatch => tracing::info_span!(
+        "lix.sql.batch" => tracing::info_span!(
             target: "lix_sql",
             "lix.sql.batch",
             "otel.name" = tracing::field::Empty,
@@ -225,7 +258,7 @@ fn tracing_span(start: &TelemetrySpanStart) -> tracing::Span {
             "error.type" = tracing::field::Empty,
             "otel.status_code" = tracing::field::Empty,
         ),
-        TelemetrySpanKind::SqlCoherentReadBatch => tracing::info_span!(
+        "lix.sql.coherent_read_batch" => tracing::info_span!(
             target: "lix_sql",
             "lix.sql.coherent_read_batch",
             "otel.name" = tracing::field::Empty,
@@ -236,18 +269,93 @@ fn tracing_span(start: &TelemetrySpanStart) -> tracing::Span {
             "error.type" = tracing::field::Empty,
             "otel.status_code" = tracing::field::Empty,
         ),
-        TelemetrySpanKind::LixOpened => tracing::info_span!(
+        "lix.repository.opened" => tracing::info_span!(
             target: "lix",
-            "lix.opened",
+            "lix.repository.opened",
             "lix.id" = tracing::field::Empty,
             "lix.branch_id" = tracing::field::Empty,
             "lix.account_id" = tracing::field::Empty,
+            "otel.status_code" = tracing::field::Empty,
         ),
+        "lix.engine.open" => lifecycle_tracing_span("lix.engine.open"),
+        "lix.session.open" => lifecycle_tracing_span("lix.session.open"),
+        "lix.checkpoint.create" => tracing::info_span!(
+            target: "lix",
+            "lix.checkpoint.create",
+            "lix.commit_id" = tracing::field::Empty,
+            "lix.parent_commit_id" = tracing::field::Empty,
+            "error.type" = tracing::field::Empty,
+            "otel.status_code" = tracing::field::Empty,
+        ),
+        "lix.transaction.wait" => performance_tracing_span("lix.transaction.wait"),
+        "lix.transaction.materialize" => performance_tracing_span("lix.transaction.materialize"),
+        "lix.transaction.storage" => performance_tracing_span("lix.transaction.storage"),
+        "lix.transaction.notify" => performance_tracing_span("lix.transaction.notify"),
+        _ => {
+            debug_assert!(false, "unknown production telemetry span: {}", start.name);
+            tracing::Span::none()
+        }
     };
     for attribute in &start.attributes {
         record_attribute(&span, attribute);
     }
     span
+}
+
+fn lifecycle_tracing_span(name: &'static str) -> tracing::Span {
+    match name {
+        "lix.engine.open" => tracing::info_span!(
+            target: "lix",
+            "lix.engine.open",
+            "error.type" = tracing::field::Empty,
+            "otel.status_code" = tracing::field::Empty,
+        ),
+        "lix.session.open" => tracing::info_span!(
+            target: "lix",
+            "lix.session.open",
+            "error.type" = tracing::field::Empty,
+            "otel.status_code" = tracing::field::Empty,
+        ),
+        _ => tracing::Span::none(),
+    }
+}
+
+fn performance_tracing_span(name: &'static str) -> tracing::Span {
+    match name {
+        "lix.transaction.wait" => tracing::info_span!(
+            target: "lix_sql",
+            "lix.transaction.wait",
+            "lix.commit_cohort_id" = tracing::field::Empty,
+            "lix.wait.reason" = tracing::field::Empty,
+            "error.type" = tracing::field::Empty,
+            "otel.status_code" = tracing::field::Empty,
+        ),
+        "lix.transaction.materialize" => tracing::info_span!(
+            target: "lix_sql",
+            "lix.transaction.materialize",
+            "lix.commit_cohort_id" = tracing::field::Empty,
+            "lix.transaction.count" = tracing::field::Empty,
+            "error.type" = tracing::field::Empty,
+            "otel.status_code" = tracing::field::Empty,
+        ),
+        "lix.transaction.storage" => tracing::info_span!(
+            target: "lix_sql",
+            "lix.transaction.storage",
+            "lix.commit_cohort_id" = tracing::field::Empty,
+            "lix.transaction.count" = tracing::field::Empty,
+            "error.type" = tracing::field::Empty,
+            "otel.status_code" = tracing::field::Empty,
+        ),
+        "lix.transaction.notify" => tracing::info_span!(
+            target: "lix_sql",
+            "lix.transaction.notify",
+            "lix.commit_cohort_id" = tracing::field::Empty,
+            "lix.transaction.count" = tracing::field::Empty,
+            "error.type" = tracing::field::Empty,
+            "otel.status_code" = tracing::field::Empty,
+        ),
+        _ => tracing::Span::none(),
+    }
 }
 
 fn record_attribute(span: &tracing::Span, attribute: &TelemetryAttribute) {
@@ -258,17 +366,166 @@ fn record_attribute(span: &tracing::Span, attribute: &TelemetryAttribute) {
     };
 }
 
+#[derive(Clone)]
+pub(crate) struct TelemetryContext {
+    sink: Arc<dyn TelemetrySink>,
+    trace_id: String,
+    span_id: String,
+    commit_cohort_id: Option<String>,
+}
+
+thread_local! {
+    static CURRENT_TELEMETRY: RefCell<Vec<TelemetryContext>> = const { RefCell::new(Vec::new()) };
+}
+
+static NEXT_TELEMETRY_ID: AtomicU64 = AtomicU64::new(1);
+
+fn next_span_id() -> String {
+    format!("{:016x}", NEXT_TELEMETRY_ID.fetch_add(1, Ordering::Relaxed))
+}
+
+pub(crate) fn next_commit_cohort_id() -> String {
+    next_span_id()
+}
+
+fn next_trace_id() -> String {
+    format!("{:016x}{}", unix_time_ms(), next_span_id())
+}
+
+fn current_context_for(sink: &Arc<dyn TelemetrySink>) -> Option<TelemetryContext> {
+    CURRENT_TELEMETRY.with(|current| {
+        current
+            .borrow()
+            .last()
+            .filter(|context| Arc::ptr_eq(&context.sink, sink))
+            .cloned()
+    })
+}
+
+pub(crate) fn current_telemetry_context() -> Option<TelemetryContext> {
+    CURRENT_TELEMETRY.with(|current| current.borrow().last().cloned())
+}
+
+pub(crate) fn current_commit_cohort_id() -> Option<String> {
+    current_telemetry_context().and_then(|context| context.commit_cohort_id)
+}
+
+struct CurrentTelemetryGuard;
+
+impl Drop for CurrentTelemetryGuard {
+    fn drop(&mut self) {
+        CURRENT_TELEMETRY.with(|current| {
+            current.borrow_mut().pop();
+        });
+    }
+}
+
+impl TelemetryContext {
+    pub(crate) fn root(sink: Arc<dyn TelemetrySink>) -> Self {
+        Self {
+            sink,
+            trace_id: next_trace_id(),
+            span_id: String::new(),
+            commit_cohort_id: None,
+        }
+    }
+
+    pub(crate) fn with_commit_cohort_id(mut self, commit_cohort_id: String) -> Self {
+        self.commit_cohort_id = Some(commit_cohort_id);
+        self
+    }
+
+    fn enter(&self) -> CurrentTelemetryGuard {
+        CURRENT_TELEMETRY.with(|current| current.borrow_mut().push(self.clone()));
+        CurrentTelemetryGuard
+    }
+
+    pub(crate) fn instrument<F>(&self, future: F) -> TelemetryContextFuture<'_, F>
+    where
+        F: Future,
+    {
+        TelemetryContextFuture {
+            future: Box::pin(future),
+            context: self,
+        }
+    }
+}
+
+pub(crate) struct TelemetryContextFuture<'a, F> {
+    future: Pin<Box<F>>,
+    context: &'a TelemetryContext,
+}
+
+impl<F: Future> Future for TelemetryContextFuture<'_, F> {
+    type Output = F::Output;
+
+    fn poll(mut self: Pin<&mut Self>, task: &mut Context<'_>) -> Poll<Self::Output> {
+        let _entered = self.context.enter();
+        self.future.as_mut().poll(task)
+    }
+}
+
 pub(crate) struct ActiveTelemetrySpan {
-    handle: Box<dyn TelemetrySpanHandle>,
+    handle: Option<Box<dyn TelemetrySpanHandle>>,
     started: web_time::Instant,
+    context: TelemetryContext,
 }
 
 impl ActiveTelemetrySpan {
-    pub(crate) fn start(sink: &Arc<dyn TelemetrySink>, start: TelemetrySpanStart) -> Self {
-        Self {
-            handle: sink.start_span(start),
-            started: web_time::Instant::now(),
+    pub(crate) fn start(sink: &Arc<dyn TelemetrySink>, mut start: TelemetrySpanStart) -> Self {
+        let parent = current_context_for(sink);
+        if start.class == TelemetrySpanClass::Performance
+            && !start
+                .attributes
+                .iter()
+                .any(|attribute| attribute.key == "lix.commit_cohort_id")
+            && let Some(commit_cohort_id) = parent
+                .as_ref()
+                .and_then(|parent| parent.commit_cohort_id.as_deref())
+        {
+            start.attributes.push(TelemetryAttribute::string(
+                "lix.commit_cohort_id",
+                commit_cohort_id,
+            ));
         }
+        start.trace_id = parent
+            .as_ref()
+            .map_or_else(next_trace_id, |parent| parent.trace_id.clone());
+        start.span_id = next_span_id();
+        start.parent_span_id = parent
+            .as_ref()
+            .filter(|parent| !parent.span_id.is_empty())
+            .map(|parent| parent.span_id.clone());
+        let context = TelemetryContext {
+            sink: Arc::clone(sink),
+            trace_id: start.trace_id.clone(),
+            span_id: start.span_id.clone(),
+            commit_cohort_id: parent.and_then(|parent| parent.commit_cohort_id),
+        };
+        Self {
+            handle: Some(sink.start_span(start)),
+            started: web_time::Instant::now(),
+            context,
+        }
+    }
+
+    pub(crate) fn start_if_enabled(
+        sink: &Arc<dyn TelemetrySink>,
+        class: TelemetrySpanClass,
+        name: &'static str,
+        attributes: Vec<TelemetryAttribute>,
+    ) -> Option<Self> {
+        sink.enabled(class, name)
+            .then(|| Self::start(sink, TelemetrySpanStart::new(class, name, attributes)))
+    }
+
+    pub(crate) fn start_current(
+        class: TelemetrySpanClass,
+        name: &'static str,
+        attributes: Vec<TelemetryAttribute>,
+    ) -> Option<Self> {
+        let context = current_telemetry_context()?;
+        Self::start_if_enabled(&context.sink, class, name, attributes)
     }
 
     pub(crate) fn instrument<F>(&self, future: F) -> TelemetryInstrumentedFuture<'_, F>
@@ -277,23 +534,98 @@ impl ActiveTelemetrySpan {
     {
         TelemetryInstrumentedFuture {
             future: Box::pin(future),
-            handle: self.handle.as_ref(),
+            span: self,
         }
     }
 
-    pub(crate) fn finish(self, status: TelemetrySpanStatus, attributes: Vec<TelemetryAttribute>) {
+    pub(crate) fn finish(
+        mut self,
+        status: TelemetrySpanStatus,
+        attributes: Vec<TelemetryAttribute>,
+    ) {
         let duration_ns = u64::try_from(self.started.elapsed().as_nanos()).unwrap_or(u64::MAX);
-        self.handle.finish(TelemetrySpanEnd {
+        if let Some(handle) = self.handle.take() {
+            handle.finish(TelemetrySpanEnd {
+                duration_ns,
+                status,
+                attributes,
+            });
+        }
+    }
+
+    pub(crate) fn enter(&self) -> ActiveTelemetryEnterGuard<'_> {
+        let current = self.context.enter();
+        let sink = self
+            .handle
+            .as_ref()
+            .expect("active telemetry span has a handle")
+            .enter();
+        ActiveTelemetryEnterGuard {
+            _sink: sink,
+            _current: current,
+        }
+    }
+}
+
+pub(crate) async fn instrument_lix_result<T, F>(
+    span: Option<ActiveTelemetrySpan>,
+    future: F,
+) -> Result<T, crate::LixError>
+where
+    F: Future<Output = Result<T, crate::LixError>>,
+{
+    let result = match span.as_ref() {
+        Some(span) => span.instrument(future).await,
+        None => future.await,
+    };
+    if let Some(span) = span {
+        match &result {
+            Ok(_) => span.finish(TelemetrySpanStatus::Ok, Vec::new()),
+            Err(error) => span.finish(
+                TelemetrySpanStatus::Error,
+                vec![TelemetryAttribute::string("error.type", error.code.clone())],
+            ),
+        }
+    }
+    result
+}
+
+pub(crate) async fn instrument_value<T, F>(span: Option<ActiveTelemetrySpan>, future: F) -> T
+where
+    F: Future<Output = T>,
+{
+    let value = match span.as_ref() {
+        Some(span) => span.instrument(future).await,
+        None => future.await,
+    };
+    if let Some(span) = span {
+        span.finish(TelemetrySpanStatus::Ok, Vec::new());
+    }
+    value
+}
+
+impl Drop for ActiveTelemetrySpan {
+    fn drop(&mut self) {
+        let Some(handle) = self.handle.take() else {
+            return;
+        };
+        let duration_ns = u64::try_from(self.started.elapsed().as_nanos()).unwrap_or(u64::MAX);
+        handle.finish(TelemetrySpanEnd {
             duration_ns,
-            status,
-            attributes,
+            status: TelemetrySpanStatus::Cancelled,
+            attributes: Vec::new(),
         });
     }
 }
 
+pub(crate) struct ActiveTelemetryEnterGuard<'a> {
+    _sink: Box<dyn TelemetrySpanEnterGuard + 'a>,
+    _current: CurrentTelemetryGuard,
+}
+
 pub(crate) struct TelemetryInstrumentedFuture<'a, F> {
     future: Pin<Box<F>>,
-    handle: &'a dyn TelemetrySpanHandle,
+    span: &'a ActiveTelemetrySpan,
 }
 
 impl<F> Future for TelemetryInstrumentedFuture<'_, F>
@@ -303,7 +635,7 @@ where
     type Output = F::Output;
 
     fn poll(mut self: Pin<&mut Self>, context: &mut Context<'_>) -> Poll<Self::Output> {
-        let _entered = self.handle.enter();
+        let _entered = self.span.enter();
         self.future.as_mut().poll(context)
     }
 }
@@ -318,7 +650,7 @@ pub(crate) fn unix_time_ms() -> u64 {
 
 /// Records that a client session has bound to a Lix.
 ///
-/// This is the only place that starts a [`TelemetrySpanKind::LixOpened`] span.
+/// This is the only place that emits `lix.repository.opened`.
 /// Handshake session creation and in-process [`crate::open_lix`] call it.
 /// Protocol roots opened with [`crate::OpenLixBuilder::as_protocol_root`]
 /// skip it so a cached runtime can inherit a sink without emitting.
@@ -326,7 +658,7 @@ pub(crate) fn unix_time_ms() -> u64 {
 /// context, cache hit) should call the same helper instead of opening another
 /// engine.
 ///
-/// No-op when `sink` is absent or `enabled(LixOpened)` is false. Those paths
+/// No-op when `sink` is absent or lifecycle telemetry is disabled. Those paths
 /// do not build attributes or timestamps.
 pub fn bind_session(
     sink: Option<&Arc<dyn TelemetrySink>>,
@@ -337,7 +669,7 @@ pub fn bind_session(
     let Some(sink) = sink else {
         return;
     };
-    if !sink.enabled(TelemetrySpanKind::LixOpened) {
+    if !sink.enabled(TelemetrySpanClass::Lifecycle, "lix.repository.opened") {
         return;
     }
     let mut attributes = vec![
@@ -349,12 +681,11 @@ pub fn bind_session(
     }
     let span = ActiveTelemetrySpan::start(
         sink,
-        TelemetrySpanStart {
-            kind: TelemetrySpanKind::LixOpened,
-            name: "lix.opened",
-            started_at_unix_ms: unix_time_ms(),
+        TelemetrySpanStart::new(
+            TelemetrySpanClass::Lifecycle,
+            "lix.repository.opened",
             attributes,
-        },
+        ),
     );
     span.finish(TelemetrySpanStatus::Ok, Vec::new());
 }
@@ -368,7 +699,7 @@ mod tests {
         opened_enabled: bool,
         sql_enabled: bool,
         started: Mutex<Vec<TelemetrySpanStart>>,
-        enabled_kinds: Mutex<Vec<TelemetrySpanKind>>,
+        enabled_names: Mutex<Vec<&'static str>>,
     }
 
     impl RecordingSink {
@@ -377,7 +708,7 @@ mod tests {
                 opened_enabled,
                 sql_enabled: true,
                 started: Mutex::new(Vec::new()),
-                enabled_kinds: Mutex::new(Vec::new()),
+                enabled_names: Mutex::new(Vec::new()),
             }
         }
 
@@ -387,13 +718,11 @@ mod tests {
     }
 
     impl TelemetrySink for RecordingSink {
-        fn enabled(&self, kind: TelemetrySpanKind) -> bool {
-            self.enabled_kinds.lock().expect("enabled kinds").push(kind);
-            match kind {
-                TelemetrySpanKind::LixOpened => self.opened_enabled,
-                TelemetrySpanKind::SqlQuery
-                | TelemetrySpanKind::SqlBatch
-                | TelemetrySpanKind::SqlCoherentReadBatch => self.sql_enabled,
+        fn enabled(&self, class: TelemetrySpanClass, name: &'static str) -> bool {
+            self.enabled_names.lock().expect("enabled names").push(name);
+            match class {
+                TelemetrySpanClass::Lifecycle => self.opened_enabled,
+                TelemetrySpanClass::Sql | TelemetrySpanClass::Performance => self.sql_enabled,
             }
         }
 
@@ -437,8 +766,8 @@ mod tests {
         let trait_sink = Arc::clone(&sink).into_sink();
         bind_session(Some(&trait_sink), "lix-id", "branch-id", Some("account-id"));
         assert_eq!(
-            *sink.enabled_kinds.lock().expect("enabled kinds"),
-            [TelemetrySpanKind::LixOpened]
+            *sink.enabled_names.lock().expect("enabled names"),
+            ["lix.repository.opened"]
         );
         assert!(sink.started.lock().expect("started spans").is_empty());
     }
@@ -450,8 +779,8 @@ mod tests {
         bind_session(Some(&trait_sink), "lix-id", "branch-id", Some("account-id"));
         let started = sink.started.lock().expect("started spans").clone();
         assert_eq!(started.len(), 1);
-        assert_eq!(started[0].kind, TelemetrySpanKind::LixOpened);
-        assert_eq!(started[0].name, "lix.opened");
+        assert_eq!(started[0].class, TelemetrySpanClass::Lifecycle);
+        assert_eq!(started[0].name, "lix.repository.opened");
         assert_eq!(attribute_string(&started[0], "lix.id"), Some("lix-id"));
         assert_eq!(
             attribute_string(&started[0], "lix.branch_id"),

--- a/packages/lix/src/telemetry.rs
+++ b/packages/lix/src/telemetry.rs
@@ -567,41 +567,99 @@ impl ActiveTelemetrySpan {
     }
 }
 
-pub(crate) async fn instrument_lix_result<T, F>(
+/// Instruments `future` without growing the caller's async state machine.
+///
+/// An `async fn` wrapper would store `F` in every caller. Combined with
+/// `tokio`/`futures_lite` `block_on` pinning that future on a 2 MiB worker
+/// or coordinator thread, engine-open and commit phases overflowed
+/// `deterministic_replica_scenarios`. Boxing here keeps the wrapper
+/// pointer-sized whether or not a span is active.
+pub(crate) fn instrument_lix_result<T, F>(
     span: Option<ActiveTelemetrySpan>,
     future: F,
-) -> Result<T, crate::LixError>
+) -> InstrumentLixResult<F>
 where
     F: Future<Output = Result<T, crate::LixError>>,
 {
-    let result = match span.as_ref() {
-        Some(span) => span.instrument(future).await,
-        None => future.await,
-    };
-    if let Some(span) = span {
-        match &result {
-            Ok(_) => span.finish(TelemetrySpanStatus::Ok, Vec::new()),
-            Err(error) => span.finish(
-                TelemetrySpanStatus::Error,
-                vec![TelemetryAttribute::string("error.type", error.code.clone())],
-            ),
-        }
+    InstrumentLixResult {
+        future: Box::pin(future),
+        span,
     }
-    result
 }
 
-pub(crate) async fn instrument_value<T, F>(span: Option<ActiveTelemetrySpan>, future: F) -> T
+pub(crate) fn instrument_value<T, F>(
+    span: Option<ActiveTelemetrySpan>,
+    future: F,
+) -> InstrumentValue<F>
 where
     F: Future<Output = T>,
 {
-    let value = match span.as_ref() {
-        Some(span) => span.instrument(future).await,
-        None => future.await,
-    };
-    if let Some(span) = span {
-        span.finish(TelemetrySpanStatus::Ok, Vec::new());
+    InstrumentValue {
+        future: Box::pin(future),
+        span,
     }
-    value
+}
+
+pub(crate) struct InstrumentLixResult<F> {
+    future: Pin<Box<F>>,
+    span: Option<ActiveTelemetrySpan>,
+}
+
+impl<T, F> Future for InstrumentLixResult<F>
+where
+    F: Future<Output = Result<T, crate::LixError>>,
+{
+    type Output = Result<T, crate::LixError>;
+
+    fn poll(self: Pin<&mut Self>, context: &mut Context<'_>) -> Poll<Self::Output> {
+        let this = self.get_mut();
+        let entered = this.span.as_ref().map(ActiveTelemetrySpan::enter);
+        let result = this.future.as_mut().poll(context);
+        drop(entered);
+        match result {
+            Poll::Ready(result) => {
+                if let Some(span) = this.span.take() {
+                    match &result {
+                        Ok(_) => span.finish(TelemetrySpanStatus::Ok, Vec::new()),
+                        Err(error) => span.finish(
+                            TelemetrySpanStatus::Error,
+                            vec![TelemetryAttribute::string("error.type", error.code.clone())],
+                        ),
+                    }
+                }
+                Poll::Ready(result)
+            }
+            Poll::Pending => Poll::Pending,
+        }
+    }
+}
+
+pub(crate) struct InstrumentValue<F> {
+    future: Pin<Box<F>>,
+    span: Option<ActiveTelemetrySpan>,
+}
+
+impl<T, F> Future for InstrumentValue<F>
+where
+    F: Future<Output = T>,
+{
+    type Output = T;
+
+    fn poll(self: Pin<&mut Self>, context: &mut Context<'_>) -> Poll<Self::Output> {
+        let this = self.get_mut();
+        let entered = this.span.as_ref().map(ActiveTelemetrySpan::enter);
+        let result = this.future.as_mut().poll(context);
+        drop(entered);
+        match result {
+            Poll::Ready(value) => {
+                if let Some(span) = this.span.take() {
+                    span.finish(TelemetrySpanStatus::Ok, Vec::new());
+                }
+                Poll::Ready(value)
+            }
+            Poll::Pending => Poll::Pending,
+        }
+    }
 }
 
 impl Drop for ActiveTelemetrySpan {

--- a/packages/lix/src/transaction/commit_coordinator.rs
+++ b/packages/lix/src/transaction/commit_coordinator.rs
@@ -3,7 +3,7 @@ use std::collections::VecDeque;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
 use tokio::sync::{Semaphore, oneshot};
-use tracing::Instrument as _;
+use tracing::{Instrument as _, instrument::WithSubscriber as _};
 
 use super::{
     Transaction, TransactionCommitOutcome, commit_transaction_cohort,
@@ -13,6 +13,10 @@ use crate::LixError;
 use crate::functions::FunctionContext;
 use crate::observe_invalidation::ObserveInvalidation;
 use crate::storage_adapter::Storage;
+use crate::telemetry::{
+    ActiveTelemetrySpan, TelemetryAttribute, TelemetryContext, TelemetrySink, TelemetrySpanClass,
+    TelemetrySpanStatus, current_telemetry_context, next_commit_cohort_id,
+};
 
 const COMMIT_QUEUE_CAPACITY: usize = 256;
 const COMMIT_COHORT_CAPACITY: usize = 256;
@@ -24,6 +28,9 @@ where
     runtime_functions: FunctionContext,
     result: oneshot::Sender<Result<TransactionCommitOutcome, LixError>>,
     file_cohort_eligible: bool,
+    telemetry_context: Option<TelemetryContext>,
+    tracing_parent: tracing::Span,
+    tracing_dispatch: tracing::Dispatch,
     _capacity: tokio::sync::OwnedSemaphorePermit,
 }
 
@@ -42,6 +49,7 @@ where
     collaboration_write_gate: Arc<tokio::sync::Mutex<()>>,
     observe_invalidation: Arc<ObserveInvalidation>,
     capacity: Arc<Semaphore>,
+    telemetry: Option<Arc<dyn TelemetrySink>>,
     state: Mutex<CommitCoordinatorState<StorageImpl>>,
     #[cfg(test)]
     stats: CommitCoordinatorStats,
@@ -82,12 +90,14 @@ where
     pub(crate) fn new(
         collaboration_write_gate: Arc<tokio::sync::Mutex<()>>,
         observe_invalidation: Arc<ObserveInvalidation>,
+        telemetry: Option<Arc<dyn TelemetrySink>>,
     ) -> Self {
         Self {
             inner: Arc::new(CommitCoordinatorInner {
                 collaboration_write_gate,
                 observe_invalidation,
                 capacity: Arc::new(Semaphore::new(COMMIT_QUEUE_CAPACITY)),
+                telemetry,
                 state: Mutex::new(CommitCoordinatorState::default()),
                 #[cfg(test)]
                 stats: CommitCoordinatorStats::default(),
@@ -105,12 +115,21 @@ where
             .await
             .map_err(|_| coordinator_closed())?;
         let file_cohort_eligible = transaction_is_file_cohort_eligible(&transaction);
+        let telemetry_context = current_telemetry_context().or_else(|| {
+            self.inner
+                .telemetry
+                .as_ref()
+                .map(|sink| TelemetryContext::root(Arc::clone(sink)))
+        });
         let (result, receive) = oneshot::channel();
         let leads = self.enqueue(CommitRequest {
             transaction,
             runtime_functions,
             result,
             file_cohort_eligible,
+            telemetry_context,
+            tracing_parent: tracing::Span::current(),
+            tracing_dispatch: tracing::dispatcher::get_default(Clone::clone),
             _capacity: capacity,
         });
         if leads {
@@ -213,23 +232,54 @@ where
                     cohort_size = cohort.len(),
                 ))
                 .await;
-            let mut senders = Vec::with_capacity(cohort.len());
+            let transaction_count = cohort.len();
+            let telemetry_context = cohort
+                .first()
+                .and_then(|request| request.telemetry_context.clone())
+                .map(|context| context.with_commit_cohort_id(next_commit_cohort_id()));
+            let tracing_parent = cohort.first().map_or_else(tracing::Span::none, |request| {
+                request.tracing_parent.clone()
+            });
+            let tracing_dispatch = cohort
+                .first()
+                .map(|request| request.tracing_dispatch.clone());
+            let mut senders = Vec::with_capacity(transaction_count);
             let mut inputs = Vec::with_capacity(cohort.len());
             for request in cohort {
                 senders.push((request.result, request._capacity));
                 inputs.push((request.transaction, request.runtime_functions));
             }
-            let mut outcomes = Box::pin(commit_transaction_cohort(inputs)).await;
-            if let Some(outcome) = outcomes.iter().find_map(|result| result.as_ref().ok()) {
-                let _span = tracing::info_span!(
-                    target: "lix_sql",
-                    "lix.perf.transaction_cohort_notify"
-                )
-                .entered();
-                self.inner
-                    .observe_invalidation
-                    .bump_if_storage_changed(&outcome.storage_stats);
+            let commit_and_notify = async {
+                let outcomes = Box::pin(commit_transaction_cohort(inputs)).await;
+                if let Some(outcome) = outcomes.iter().find_map(|result| result.as_ref().ok()) {
+                    let notify = ActiveTelemetrySpan::start_current(
+                        TelemetrySpanClass::Performance,
+                        "lix.transaction.notify",
+                        vec![TelemetryAttribute::u64(
+                            "lix.transaction.count",
+                            u64::try_from(transaction_count).unwrap_or(u64::MAX),
+                        )],
+                    );
+                    let _entered = notify.as_ref().map(ActiveTelemetrySpan::enter);
+                    self.inner
+                        .observe_invalidation
+                        .bump_if_storage_changed(&outcome.storage_stats);
+                    drop(_entered);
+                    if let Some(notify) = notify {
+                        notify.finish(TelemetrySpanStatus::Ok, Vec::new());
+                    }
+                }
+                outcomes
             }
+            .instrument(tracing_parent);
+            let commit_and_notify = match tracing_dispatch {
+                Some(dispatch) => commit_and_notify.with_subscriber(dispatch),
+                None => commit_and_notify.with_current_subscriber(),
+            };
+            let mut outcomes = match telemetry_context.as_ref() {
+                Some(context) => Box::pin(context.instrument(commit_and_notify)).await,
+                None => Box::pin(commit_and_notify).await,
+            };
             for outcome in outcomes.iter_mut().flatten() {
                 *outcome = TransactionCommitOutcome::default();
             }
@@ -308,6 +358,7 @@ mod tests {
         let coordinator = CommitCoordinator::<Memory>::new(
             Arc::new(tokio::sync::Mutex::new(())),
             Arc::new(ObserveInvalidation::new()),
+            None,
         );
         assert_eq!(coordinator.stats(), (0, 0, 0));
     }

--- a/packages/lix/src/transaction/commit_coordinator.rs
+++ b/packages/lix/src/transaction/commit_coordinator.rs
@@ -145,7 +145,10 @@ where
     fn spawn_driver(&self) -> Result<(), LixError> {
         let coordinator = self.clone();
         crate::background_task::spawn("lix-commit-coordinator", move || async move {
-            coordinator.drive().await;
+            // `background_task` block_on-pins this future on a default 2 MiB
+            // thread. Keep `drive` itself on the heap so commit wrappers cannot
+            // inflate that stack.
+            Box::pin(coordinator.drive()).await;
         })
     }
 

--- a/packages/lix/src/transaction/commit_coordinator.rs
+++ b/packages/lix/src/transaction/commit_coordinator.rs
@@ -221,6 +221,11 @@ where
             }
             let mut outcomes = Box::pin(commit_transaction_cohort(inputs)).await;
             if let Some(outcome) = outcomes.iter().find_map(|result| result.as_ref().ok()) {
+                let _span = tracing::info_span!(
+                    target: "lix_sql",
+                    "lix.perf.transaction_notify"
+                )
+                .entered();
                 self.inner
                     .observe_invalidation
                     .bump_if_storage_changed(&outcome.storage_stats);

--- a/packages/lix/src/transaction/commit_coordinator.rs
+++ b/packages/lix/src/transaction/commit_coordinator.rs
@@ -223,7 +223,7 @@ where
             if let Some(outcome) = outcomes.iter().find_map(|result| result.as_ref().ok()) {
                 let _span = tracing::info_span!(
                     target: "lix_sql",
-                    "lix.perf.transaction_notify"
+                    "lix.perf.transaction_cohort_notify"
                 )
                 .entered();
                 self.inner

--- a/packages/lix/src/transaction/context.rs
+++ b/packages/lix/src/transaction/context.rs
@@ -1798,8 +1798,8 @@ where
             &restore_targets,
             prepared_writes,
         )
-        .instrument(tracing::debug_span!(
-            target: "lix_perf",
+        .instrument(tracing::info_span!(
+            target: "lix_sql",
             "lix.perf.transaction_materialization"
         ))
         .await
@@ -1908,8 +1908,8 @@ where
         crate::storage_bench::record_crud_write_set_arena(&writes);
         let prepared_commit = match commit_storage
             .prepare_write_set(writes, write_options)
-            .instrument(tracing::debug_span!(
-                target: "lix_perf",
+            .instrument(tracing::info_span!(
+                target: "lix_sql",
                 "lix.perf.transaction_storage_prepare"
             ))
             .await
@@ -1936,8 +1936,8 @@ where
             );
             Ok(stats)
         })
-        .instrument(tracing::debug_span!(
-            target: "lix_perf",
+        .instrument(tracing::info_span!(
+            target: "lix_sql",
             "lix.perf.transaction_storage_commit"
         ))
         .await?;

--- a/packages/lix/src/transaction/context.rs
+++ b/packages/lix/src/transaction/context.rs
@@ -95,6 +95,7 @@ use crate::storage_adapter::{
     REVISION_KEY_CATALOG, REVISION_KEY_TRACKED_MUTATION, SharedStorageAdapterRead, StorageAdapter,
     StorageAdapterRead, StorageAdapterReadScope, load_revisions,
 };
+use crate::telemetry::{ActiveTelemetrySpan, TelemetrySpanClass, instrument_lix_result};
 use crate::tracked_state::{
     TrackedStateContext, TrackedStateDiffKind, TrackedStateDiffRequest, TrackedStateKey,
     TrackedStateScanRequest, TrackedStateStoreReader,
@@ -216,6 +217,7 @@ use crate::plugin::runtime::{
     WasmOpenRowsInput, WasmPluginSelection, WasmRowChange, WasmRowKey, WasmRowUpdate,
     WasmTransitionLimits,
 };
+use crate::telemetry::TelemetryAttribute;
 use crate::transaction::validation::{
     TransactionValidationInput, fresh_plugin_file_import_certificate,
     prepared_tracked_rows_have_row_local_certificates, validate_certified_fresh_plugin_file_import,
@@ -228,6 +230,7 @@ mod cohort;
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub(crate) struct TransactionCommitOutcome {
     pub(crate) storage_stats: StorageWriteSetStats,
+    pub(crate) commit_cohort_id: Option<String>,
 }
 
 /// Commits one coordinator-owned cohort in queue order.
@@ -1636,7 +1639,7 @@ where
             }
         };
         transaction
-            .commit_prepared(runtime_functions, prepared_writes)
+            .commit_prepared(runtime_functions, prepared_writes, 1)
             .await
     }
 
@@ -1644,342 +1647,387 @@ where
         mut self,
         runtime_functions: &FunctionContext,
         mut prepared_writes: PreparedWriteSet,
+        transaction_count: usize,
     ) -> Result<TransactionCommitOutcome, LixError> {
         #[cfg(feature = "storage-benches")]
         let _phase =
             crate::storage_bench::enter_crud_phase(crate::storage_bench::CRUD_PHASE_COMMIT);
         let transaction = &mut self;
+        let commit_cohort_id = crate::telemetry::current_commit_cohort_id()
+            .unwrap_or_else(crate::telemetry::next_commit_cohort_id);
         let commit_boundary = transaction.commit_boundary.clone();
-        transaction
-            .uncache_completed_plugin_actors_for_large_file_writes(&prepared_writes)
-            .await;
-        let tracked_state_changed = prepared_writes.state_rows.iter().any(|row| !row.untracked)
-            || !prepared_writes.commit_change_refs_by_branch.is_empty()
-            || !prepared_writes.extra_commit_parents_by_branch.is_empty();
-        let has_untracked_state_writes = prepared_writes.state_rows.iter().any(|row| row.untracked);
-        // Untracked rows are mutable current state, but their validation can read
-        // tracked schemas, parents, uniqueness owners, or filesystem state.
-        // Fence that snapshot without rotating the tracked revision: normal
-        // tracked transactions remain independent of untracked-only commits.
-        let requires_tracked_snapshot_fence = tracked_state_changed || has_untracked_state_writes;
-        let catalog_revision_changed = prepared_writes_change_catalog(&prepared_writes);
         let _commit_guard = begin_commit_boundary(commit_boundary.as_ref());
-        if let Err(error) = check_commit_boundary(commit_boundary.as_ref()) {
-            transaction
-                .discard_pending_plugin_actor_publications()
-                .await;
-            return Err(error);
-        }
-        // Validate and materialize from one coherent storage snapshot. The
-        // final write's tracked-state precondition fences the decisions made
-        // here, including plugin-produced prepared rows.
-        let commit_read_storage = transaction.storage.clone();
-        let commit_read = commit_read_storage
-            .begin_read(StorageReadOptions::default())
-            .await?;
-        // SAFETY: `commit_read_storage` is an `Arc` retained through commit,
-        // and the transaction drops this read before its storage field.
-        let commit_read = unsafe { assume_static_storage_read::<StorageImpl>(commit_read) };
-        let mut read = SharedStorageAdapterRead::new(commit_read);
-        // Commit-time reconciliation and validation must all observe this
-        // current coherent snapshot, while user statements above observed the
-        // snapshot retained from transaction open.
-        transaction.opening_read = read.clone();
-        if let Err(error) = transaction
-            .reconcile_stale_disjoint_writes(&read, &mut prepared_writes)
-            .instrument(tracing::debug_span!(
-                target: "lix_perf",
-                "lix.perf.transaction_reconcile_stale"
-            ))
-            .await
-        {
-            transaction
-                .discard_pending_plugin_actor_publications()
-                .await;
-            return Err(error);
-        }
-        let branch_checkpoint_bridges = match transaction
-            .resolve_pending_branch_checkpoint_replacements(&read, &prepared_writes)
-            .await
-        {
-            Ok(branch_checkpoint_bridges) => branch_checkpoint_bridges,
-            Err(error) => {
+        let materialize_span = ActiveTelemetrySpan::start_current(
+            TelemetrySpanClass::Performance,
+            "lix.transaction.materialize",
+            vec![
+                TelemetryAttribute::u64(
+                    "lix.transaction.count",
+                    u64::try_from(transaction_count).unwrap_or(u64::MAX),
+                ),
+                TelemetryAttribute::string("lix.commit_cohort_id", commit_cohort_id.clone()),
+            ],
+        );
+        let (writes, write_options, filesystem_delta_rows, previous_filesystem_revision) =
+            instrument_lix_result(materialize_span, async {
                 transaction
-                    .discard_pending_plugin_actor_publications()
+                    .uncache_completed_plugin_actors_for_large_file_writes(&prepared_writes)
                     .await;
-                return Err(error);
-            }
-        };
-        let restore_targets = std::mem::take(&mut transaction.pending_restore_targets);
-        let commit_parent_heads = match commit::resolve_prepared_commit_parent_heads(
-            transaction.branch_ctx.as_ref(),
-            &read,
-            &prepared_writes,
-            true,
-        )
-        .await
-        {
-            Ok(commit_parent_heads) => commit_parent_heads,
-            Err(error) => {
-                transaction
-                    .discard_pending_plugin_actor_publications()
-                    .await;
-                return Err(error);
-            }
-        };
-        if let Err(error) = Self::attach_checkpoint_branch_parents(
-            &read,
-            &mut prepared_writes,
-            &commit_parent_heads,
-        )
-        .await
-        {
-            transaction
-                .discard_pending_plugin_actor_publications()
-                .await;
-            return Err(error);
-        }
-        if let Err(error) = transaction
-            .validate_prepared_writes_by_branch(&read, &mut prepared_writes)
-            .instrument(tracing::debug_span!(
-                target: "lix_perf",
-                "lix.perf.transaction_validation"
-            ))
-            .await
-        {
-            transaction
-                .discard_pending_plugin_actor_publications()
-                .await;
-            return Err(error);
-        }
-        // The delta itself is projected out of the commit below, once
-        // addressable rows hold their final commit-delta change ids. Only its
-        // *projectability* is decided here, because the revision the cached
-        // views are keyed on has to be read before the commit publishes its
-        // successor.
-        let stages_projectable_filesystem_rows =
-            prepared_writes_stage_filesystem_rows(&prepared_writes)
-                && !prepared_writes_require_filesystem_index_rebuild(&prepared_writes);
-        // A failed revision read must not collapse into "no revision yet".
-        // `None` is itself a live cache key — the state before the first
-        // filesystem commit — so treating an error as `None` would rekey
-        // entries built at an unknown revision onto this commit's successor and
-        // make a stale index reachable. The outer `Option` is "the read
-        // succeeded"; only that licenses a projection.
-        let loaded_filesystem_revision = if stages_projectable_filesystem_rows {
-            load_path_index_revision(&read).await.ok()
-        } else {
-            None
-        };
-        let filesystem_delta_projectable = loaded_filesystem_revision.is_some();
-        let previous_filesystem_revision = loaded_filesystem_revision.flatten();
-        let mut automatic_sync_writes = transaction.storage.new_write_set();
-        let mut automatic_sync_preconditions = Vec::new();
-        let capture_sync_commits = !transaction.suppress_ordinary_sync_event
-            && transaction.sync_role == crate::sync::SyncRole::Authority;
-        if !transaction.suppress_ordinary_sync_event
-            && transaction.sync_role == crate::sync::SyncRole::Replica
-        {
-            // The immutable commit and ref are the durable outbox.
-            // `build_sync_push` discovers unpublished local heads; no second
-            // row-pack queue is maintained.
-            transaction.await_durable_commit = true;
-        }
-        let materialized = match commit::commit_prepared_writes_with_parent_heads(
-            &transaction.binary_cas,
-            &transaction.tracked_state,
-            Some(transaction.sql_schema_snapshot.as_ref()),
-            Some(runtime_functions),
-            &transaction.active_account_id,
-            &commit_parent_heads,
-            &mut read,
-            &branch_checkpoint_bridges,
-            capture_sync_commits,
-            &restore_targets,
-            prepared_writes,
-        )
-        .instrument(tracing::info_span!(
-            target: "lix_sql",
-            "lix.perf.transaction_materialization"
-        ))
-        .await
-        {
-            Ok(commit) => commit,
-            Err(error) => {
-                transaction
-                    .discard_pending_plugin_actor_publications()
-                    .await;
-                return Err(error);
-            }
-        };
-        let staged_sync_event = if capture_sync_commits {
-            // Consume the exact controls produced by materialization instead
-            // of predicting checkpoint/restore semantics from prepared rows.
-            // The event still joins the same atomic storage commit below.
-            match crate::sync::stage_repository_transaction_event(
-                &read,
-                &mut automatic_sync_writes,
-                &mut automatic_sync_preconditions,
-                &materialized.sync_commits,
-                &materialized.published_branch_controls,
-            )
-            .await
-            {
-                Ok(event) => event,
-                Err(error) => {
+                let tracked_state_changed =
+                    prepared_writes.state_rows.iter().any(|row| !row.untracked)
+                        || !prepared_writes.commit_change_refs_by_branch.is_empty()
+                        || !prepared_writes.extra_commit_parents_by_branch.is_empty();
+                let has_untracked_state_writes =
+                    prepared_writes.state_rows.iter().any(|row| row.untracked);
+                // Untracked rows are mutable current state, but their validation can read
+                // tracked schemas, parents, uniqueness owners, or filesystem state.
+                // Fence that snapshot without rotating the tracked revision: normal
+                // tracked transactions remain independent of untracked-only commits.
+                let requires_tracked_snapshot_fence =
+                    tracked_state_changed || has_untracked_state_writes;
+                let catalog_revision_changed = prepared_writes_change_catalog(&prepared_writes);
+                if let Err(error) = check_commit_boundary(commit_boundary.as_ref()) {
                     transaction
                         .discard_pending_plugin_actor_publications()
                         .await;
                     return Err(error);
                 }
-            }
-        } else {
-            None
-        };
-        if staged_sync_event.is_some() {
-            transaction.await_durable_commit = true;
-        }
-        if let Some(staged_sync_event) = &staged_sync_event
-            && let Err(error) = crate::sync::validate_repository_transaction_event_transfer(
-                staged_sync_event,
-                &materialized.sync_commits,
-            )
-        {
-            transaction
-                .discard_pending_plugin_actor_publications()
-                .await;
-            return Err(error);
-        }
-        let mut writes = materialized.writes;
-        let materialization_preconditions = materialized.preconditions;
-        let filesystem_delta_rows = if filesystem_delta_projectable {
-            materialized.filesystem_delta_rows
-        } else {
-            Vec::new()
-        };
-        if catalog_revision_changed {
-            stage_catalog_revision(&mut writes);
-        }
-        if tracked_state_changed {
-            StorageAdapter::<StorageImpl>::stage_tracked_mutation_revision(&mut writes);
-        }
-        writes.extend(automatic_sync_writes);
-        if let Some(metadata_writes) = transaction.atomic_metadata_writes.take() {
-            writes.extend(metadata_writes);
-        }
-        let mut write_options = StorageWriteOptions::default();
-        write_options.await_durable = transaction.await_durable_commit;
-        write_options
-            .preconditions
-            .extend(materialization_preconditions);
-        write_options
-            .preconditions
-            .append(&mut automatic_sync_preconditions);
-        write_options
-            .preconditions
-            .append(&mut transaction.atomic_metadata_preconditions);
-        if requires_tracked_snapshot_fence {
-            write_options.preconditions.push(
-                StorageAdapter::<StorageImpl>::tracked_mutation_revision_precondition(
-                    transaction.opening_tracked_mutation_revision.clone(),
-                ),
-            );
-        }
-        if let Some((key, value)) = transaction.idempotency_receipt.take() {
-            writes.put(EXECUTE_IDEMPOTENCY_RECEIPT_SPACE, key.clone(), value);
-            // The mutation and this receipt share one atomic storage commit.
-            // A protocol acknowledgement may replay only from a durable
-            // receipt, so ask the storage to cross its durability boundary
-            // before it reports this commit as successful.
-            write_options.await_durable = true;
-            write_options.idempotency_key = Some(key.0.clone());
-            write_options
-                .preconditions
-                .push(StoragePrecondition::KeyAbsent {
-                    space: EXECUTE_IDEMPOTENCY_RECEIPT_SPACE,
-                    key,
-                });
-        }
+                // Validate and materialize from one coherent storage snapshot. The
+                // final write's tracked-state precondition fences the decisions made
+                // here, including plugin-produced prepared rows.
+                let commit_read_storage = transaction.storage.clone();
+                let commit_read = commit_read_storage
+                    .begin_read(StorageReadOptions::default())
+                    .await?;
+                // SAFETY: `commit_read_storage` is an `Arc` retained through commit,
+                // and the transaction drops this read before its storage field.
+                let commit_read = unsafe { assume_static_storage_read::<StorageImpl>(commit_read) };
+                let mut read = SharedStorageAdapterRead::new(commit_read);
+                // Commit-time reconciliation and validation must all observe this
+                // current coherent snapshot, while user statements above observed the
+                // snapshot retained from transaction open.
+                transaction.opening_read = read.clone();
+                if let Err(error) = transaction
+                    .reconcile_stale_disjoint_writes(&read, &mut prepared_writes)
+                    .instrument(tracing::debug_span!(
+                        target: "lix_perf",
+                        "lix.perf.transaction_reconcile_stale"
+                    ))
+                    .await
+                {
+                    transaction
+                        .discard_pending_plugin_actor_publications()
+                        .await;
+                    return Err(error);
+                }
+                let branch_checkpoint_bridges = match transaction
+                    .resolve_pending_branch_checkpoint_replacements(&read, &prepared_writes)
+                    .await
+                {
+                    Ok(branch_checkpoint_bridges) => branch_checkpoint_bridges,
+                    Err(error) => {
+                        transaction
+                            .discard_pending_plugin_actor_publications()
+                            .await;
+                        return Err(error);
+                    }
+                };
+                let restore_targets = std::mem::take(&mut transaction.pending_restore_targets);
+                let commit_parent_heads = match commit::resolve_prepared_commit_parent_heads(
+                    transaction.branch_ctx.as_ref(),
+                    &read,
+                    &prepared_writes,
+                    true,
+                )
+                .await
+                {
+                    Ok(commit_parent_heads) => commit_parent_heads,
+                    Err(error) => {
+                        transaction
+                            .discard_pending_plugin_actor_publications()
+                            .await;
+                        return Err(error);
+                    }
+                };
+                if let Err(error) = Self::attach_checkpoint_branch_parents(
+                    &read,
+                    &mut prepared_writes,
+                    &commit_parent_heads,
+                )
+                .await
+                {
+                    transaction
+                        .discard_pending_plugin_actor_publications()
+                        .await;
+                    return Err(error);
+                }
+                if let Err(error) = transaction
+                    .validate_prepared_writes_by_branch(&read, &mut prepared_writes)
+                    .instrument(tracing::debug_span!(
+                        target: "lix_perf",
+                        "lix.perf.transaction_validation"
+                    ))
+                    .await
+                {
+                    transaction
+                        .discard_pending_plugin_actor_publications()
+                        .await;
+                    return Err(error);
+                }
+                // The delta itself is projected out of the commit below, once
+                // addressable rows hold their final commit-delta change ids. Only its
+                // *projectability* is decided here, because the revision the cached
+                // views are keyed on has to be read before the commit publishes its
+                // successor.
+                let stages_projectable_filesystem_rows =
+                    prepared_writes_stage_filesystem_rows(&prepared_writes)
+                        && !prepared_writes_require_filesystem_index_rebuild(&prepared_writes);
+                // A failed revision read must not collapse into "no revision yet".
+                // `None` is itself a live cache key — the state before the first
+                // filesystem commit — so treating an error as `None` would rekey
+                // entries built at an unknown revision onto this commit's successor and
+                // make a stale index reachable. The outer `Option` is "the read
+                // succeeded"; only that licenses a projection.
+                let loaded_filesystem_revision = if stages_projectable_filesystem_rows {
+                    load_path_index_revision(&read).await.ok()
+                } else {
+                    None
+                };
+                let filesystem_delta_projectable = loaded_filesystem_revision.is_some();
+                let previous_filesystem_revision = loaded_filesystem_revision.flatten();
+                let mut automatic_sync_writes = transaction.storage.new_write_set();
+                let mut automatic_sync_preconditions = Vec::new();
+                let capture_sync_commits = !transaction.suppress_ordinary_sync_event
+                    && transaction.sync_role == crate::sync::SyncRole::Authority;
+                if !transaction.suppress_ordinary_sync_event
+                    && transaction.sync_role == crate::sync::SyncRole::Replica
+                {
+                    // The immutable commit and ref are the durable outbox.
+                    // `build_sync_push` discovers unpublished local heads; no second
+                    // row-pack queue is maintained.
+                    transaction.await_durable_commit = true;
+                }
+                let materialized = match commit::commit_prepared_writes_with_parent_heads(
+                    &transaction.binary_cas,
+                    &transaction.tracked_state,
+                    Some(transaction.sql_schema_snapshot.as_ref()),
+                    Some(runtime_functions),
+                    &transaction.active_account_id,
+                    &commit_parent_heads,
+                    &mut read,
+                    &branch_checkpoint_bridges,
+                    capture_sync_commits,
+                    &restore_targets,
+                    prepared_writes,
+                )
+                .instrument(tracing::debug_span!(
+                    target: "lix_perf",
+                    "lix.perf.transaction_materialization"
+                ))
+                .await
+                {
+                    Ok(commit) => commit,
+                    Err(error) => {
+                        transaction
+                            .discard_pending_plugin_actor_publications()
+                            .await;
+                        return Err(error);
+                    }
+                };
+                let staged_sync_event = if capture_sync_commits {
+                    // Consume the exact controls produced by materialization instead
+                    // of predicting checkpoint/restore semantics from prepared rows.
+                    // The event still joins the same atomic storage commit below.
+                    match crate::sync::stage_repository_transaction_event(
+                        &read,
+                        &mut automatic_sync_writes,
+                        &mut automatic_sync_preconditions,
+                        &materialized.sync_commits,
+                        &materialized.published_branch_controls,
+                    )
+                    .await
+                    {
+                        Ok(event) => event,
+                        Err(error) => {
+                            transaction
+                                .discard_pending_plugin_actor_publications()
+                                .await;
+                            return Err(error);
+                        }
+                    }
+                } else {
+                    None
+                };
+                if staged_sync_event.is_some() {
+                    transaction.await_durable_commit = true;
+                }
+                if let Some(staged_sync_event) = &staged_sync_event
+                    && let Err(error) = crate::sync::validate_repository_transaction_event_transfer(
+                        staged_sync_event,
+                        &materialized.sync_commits,
+                    )
+                {
+                    transaction
+                        .discard_pending_plugin_actor_publications()
+                        .await;
+                    return Err(error);
+                }
+                let mut writes = materialized.writes;
+                let materialization_preconditions = materialized.preconditions;
+                let filesystem_delta_rows = if filesystem_delta_projectable {
+                    materialized.filesystem_delta_rows
+                } else {
+                    Vec::new()
+                };
+                if catalog_revision_changed {
+                    stage_catalog_revision(&mut writes);
+                }
+                if tracked_state_changed {
+                    StorageAdapter::<StorageImpl>::stage_tracked_mutation_revision(&mut writes);
+                }
+                writes.extend(automatic_sync_writes);
+                if let Some(metadata_writes) = transaction.atomic_metadata_writes.take() {
+                    writes.extend(metadata_writes);
+                }
+                let mut write_options = StorageWriteOptions::default();
+                write_options.await_durable = transaction.await_durable_commit;
+                write_options
+                    .preconditions
+                    .extend(materialization_preconditions);
+                write_options
+                    .preconditions
+                    .append(&mut automatic_sync_preconditions);
+                write_options
+                    .preconditions
+                    .append(&mut transaction.atomic_metadata_preconditions);
+                if requires_tracked_snapshot_fence {
+                    write_options.preconditions.push(
+                        StorageAdapter::<StorageImpl>::tracked_mutation_revision_precondition(
+                            transaction.opening_tracked_mutation_revision.clone(),
+                        ),
+                    );
+                }
+                if let Some((key, value)) = transaction.idempotency_receipt.take() {
+                    writes.put(EXECUTE_IDEMPOTENCY_RECEIPT_SPACE, key.clone(), value);
+                    // The mutation and this receipt share one atomic storage commit.
+                    // A protocol acknowledgement may replay only from a durable
+                    // receipt, so ask the storage to cross its durability boundary
+                    // before it reports this commit as successful.
+                    write_options.await_durable = true;
+                    write_options.idempotency_key = Some(key.0.clone());
+                    write_options
+                        .preconditions
+                        .push(StoragePrecondition::KeyAbsent {
+                            space: EXECUTE_IDEMPOTENCY_RECEIPT_SPACE,
+                            key,
+                        });
+                }
+                Ok((
+                    writes,
+                    write_options,
+                    filesystem_delta_rows,
+                    previous_filesystem_revision,
+                ))
+            })
+            .await?;
         // Keep the prepared commit's storage borrow independent from the
         // transaction so deterministic preparation failures can still drain
         // prospective plugin actor documents before returning.
         let commit_storage = transaction.storage.clone();
         #[cfg(feature = "storage-benches")]
         crate::storage_bench::record_crud_write_set_arena(&writes);
-        let prepared_commit = match commit_storage
-            .prepare_write_set(writes, write_options)
-            .instrument(tracing::info_span!(
-                target: "lix_sql",
-                "lix.perf.transaction_storage_prepare"
-            ))
-            .await
-        {
-            Ok(prepared_commit) => prepared_commit,
-            Err(error) => {
-                transaction
-                    .discard_pending_plugin_actor_publications()
-                    .await;
-                return Err(error.into());
-            }
-        };
-        let storage_stats = commit_at_boundary(commit_boundary.as_ref(), || async move {
-            let (_commit, stats) = prepared_commit.commit().await?;
-            #[cfg(feature = "storage-benches")]
-            crate::storage_bench::record_crud_ownership(
-                crate::storage_bench::CRUD_OWNERSHIP_ADAPTER,
-                stats.staged_puts.saturating_add(stats.staged_deletes) as usize,
-                0,
-                stats.written_bytes as usize,
-                stats.put_batches.saturating_add(stats.delete_batches) as usize,
-                stats.storage_calls as usize,
-                stats.touched_spaces as usize,
-            );
-            Ok(stats)
-        })
-        .instrument(tracing::info_span!(
-            target: "lix_sql",
-            "lix.perf.transaction_storage_commit"
-        ))
-        .await?;
-        let post_commit_read_storage = transaction.storage.clone();
-        if !filesystem_delta_rows.is_empty()
-            && incremental_filesystem_index_enabled()
-            && let Ok(next_read) = post_commit_read_storage
-                .begin_read(StorageReadOptions::default())
+        let storage_span = ActiveTelemetrySpan::start_current(
+            TelemetrySpanClass::Performance,
+            "lix.transaction.storage",
+            vec![
+                TelemetryAttribute::u64(
+                    "lix.transaction.count",
+                    u64::try_from(transaction_count).unwrap_or(u64::MAX),
+                ),
+                TelemetryAttribute::string("lix.commit_cohort_id", commit_cohort_id.clone()),
+            ],
+        );
+        let storage_stats = instrument_lix_result(storage_span, async {
+            let prepared_commit = match commit_storage
+                .prepare_write_set(writes, write_options)
+                .instrument(tracing::debug_span!(
+                    target: "lix_perf",
+                    "lix.perf.transaction_storage_prepare"
+                ))
                 .await
-        {
-            let next_read = SharedStorageAdapterRead::new(next_read);
-            if let Ok(next_revision) = load_path_index_revision(&next_read).await {
-                transaction.hot_state.advance_filesystem_path_indexes(
-                    previous_filesystem_revision.as_deref(),
-                    next_revision.as_deref(),
-                    &filesystem_delta_rows,
-                );
-            }
-        }
-        for publication in std::mem::take(&mut transaction.pending_plugin_actor_publications) {
-            let session_key = publication.session_key().clone();
-            match publication.publish().await {
-                Ok((key, view)) => {
+            {
+                Ok(prepared_commit) => prepared_commit,
+                Err(error) => {
                     transaction
-                        .pending_file_view_mutations
-                        .insert(key.clone(), SessionFileViewMutation::Set { key, view });
+                        .discard_pending_plugin_actor_publications()
+                        .await;
+                    return Err(error.into());
                 }
-                Err(_) => {
-                    // Actor/materialization publication is derived state. A
-                    // durable commit remains successful; revoke the private
-                    // view so the next exact read cold-opens safely.
-                    transaction.pending_file_view_mutations.insert(
-                        session_key.clone(),
-                        SessionFileViewMutation::Remove { key: session_key },
+            };
+            let storage_stats = commit_at_boundary(commit_boundary.as_ref(), || async move {
+                let (_commit, stats) = prepared_commit.commit().await?;
+                #[cfg(feature = "storage-benches")]
+                crate::storage_bench::record_crud_ownership(
+                    crate::storage_bench::CRUD_OWNERSHIP_ADAPTER,
+                    stats.staged_puts.saturating_add(stats.staged_deletes) as usize,
+                    0,
+                    stats.written_bytes as usize,
+                    stats.put_batches.saturating_add(stats.delete_batches) as usize,
+                    stats.storage_calls as usize,
+                    stats.touched_spaces as usize,
+                );
+                Ok(stats)
+            })
+            .instrument(tracing::debug_span!(
+                target: "lix_perf",
+                "lix.perf.transaction_storage_commit"
+            ))
+            .await?;
+            let post_commit_read_storage = transaction.storage.clone();
+            if !filesystem_delta_rows.is_empty()
+                && incremental_filesystem_index_enabled()
+                && let Ok(next_read) = post_commit_read_storage
+                    .begin_read(StorageReadOptions::default())
+                    .await
+            {
+                let next_read = SharedStorageAdapterRead::new(next_read);
+                if let Ok(next_revision) = load_path_index_revision(&next_read).await {
+                    transaction.hot_state.advance_filesystem_path_indexes(
+                        previous_filesystem_revision.as_deref(),
+                        next_revision.as_deref(),
+                        &filesystem_delta_rows,
                     );
                 }
             }
-        }
-        transaction.session_file_views.apply_mutations(
-            std::mem::take(&mut transaction.pending_file_view_mutations).into_values(),
-        );
-        Ok(TransactionCommitOutcome { storage_stats })
+            for publication in std::mem::take(&mut transaction.pending_plugin_actor_publications) {
+                let session_key = publication.session_key().clone();
+                match publication.publish().await {
+                    Ok((key, view)) => {
+                        transaction
+                            .pending_file_view_mutations
+                            .insert(key.clone(), SessionFileViewMutation::Set { key, view });
+                    }
+                    Err(_) => {
+                        // Actor/materialization publication is derived state. A
+                        // durable commit remains successful; revoke the private
+                        // view so the next exact read cold-opens safely.
+                        transaction.pending_file_view_mutations.insert(
+                            session_key.clone(),
+                            SessionFileViewMutation::Remove { key: session_key },
+                        );
+                    }
+                }
+            }
+            transaction.session_file_views.apply_mutations(
+                std::mem::take(&mut transaction.pending_file_view_mutations).into_values(),
+            );
+            Ok(storage_stats)
+        })
+        .await?;
+        Ok(TransactionCommitOutcome {
+            storage_stats,
+            commit_cohort_id: Some(commit_cohort_id),
+        })
     }
 
     /// Large import documents are more valuable as transient parser state than

--- a/packages/lix/src/transaction/context/cohort.rs
+++ b/packages/lix/src/transaction/context/cohort.rs
@@ -244,7 +244,7 @@ where
     }
     let result = leader
         .transaction
-        .commit_prepared(&leader.runtime_functions, merged_writes)
+        .commit_prepared(&leader.runtime_functions, merged_writes, member_count)
         .instrument(tracing::debug_span!(
             target: "lix_transaction",
             "lix.transaction.commit_cohort.execute",
@@ -641,7 +641,7 @@ where
         outcomes.push(
             member
                 .transaction
-                .commit_prepared(&member.runtime_functions, member.prepared_writes)
+                .commit_prepared(&member.runtime_functions, member.prepared_writes, 1)
                 .await,
         );
     }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Production traces for write batches currently show `SQL batch` plus per-statement children, then hundreds of milliseconds of honest self-time / idle. That wait is `transaction.commit()` (materialize + SlateDB `db.flush()` when `await_durable` is set). The phases already existed as `debug_span!(target: "lix_perf")`, so PostHog never saw them.

This is the hard cut: one vendor-neutral production contract, exported at the same INFO level as `SQL batch` / `lix.sql.query`. No opaque `lix.transaction.commit` wrapper.

## Production span contract

**SQL** — `lix.sql.query`, `lix.sql.batch`, `lix.sql.coherent_read_batch`

**Repository bind** — `lix.repository.opened` (bind-only; not engine open)

**Cold open** — `lix.engine.open`, `lix.session.open`

**Writes** — additive children after statement spans:

- `lix.transaction.materialize`
- `lix.transaction.storage`
- `lix.transaction.notify`

Shared `lix.commit_cohort_id` on the write phases. Checkpoint/create is `lix.checkpoint.create` with `lix.commit_id` and `lix.parent_commit_id`.

Fine-grained `lix_perf` diagnostics stay DEBUG-only. No bound SQL parameters or BYTEA.

## Tests

Protocol CaptureLayer tests assert the exported names/attributes on write `execute-batch`, `checkpoint/create`, handshake session open, and cold `open_lix()`. Existing telemetry tests are unchanged.

`instrument_lix_result` / `instrument_value` now box the inner future instead of embedding it in an `async fn` state machine, so engine-open and commit stay on the default 2 MiB worker / coordinator stack. This unblocks `sync::simulation_tests::deterministic_replica_scenarios_base` from #1577.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ee1a5dea-b81f-4e4a-9fd1-67b6b06fce3e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ee1a5dea-b81f-4e4a-9fd1-67b6b06fce3e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

