### PR TITLE
feat(sql): add lix_commit_ancestry()

### DIFF
--- a/.changenotes/add-commit-ancestry-sql.md
+++ b/.changenotes/add-commit-ancestry-sql.md
@@ -1,0 +1,7 @@
+---
+type: minor
+---
+
+Added `lix_commit_ancestry()` for querying commits reachable from the active branch through SQL.
+
+The table function defaults to the active branch head, accepts an explicit commit anchor, and reports each reachable commit with its shortest ancestry depth.

--- a/docs/checkpoints.md
+++ b/docs/checkpoints.md
@@ -65,13 +65,15 @@ A runnable Rust version lives at
 
 ## SQL surfaces
 
-Checkpointing has three read-only SQL surfaces:
+Checkpointing and commit reachability use these read-only SQL surfaces:
 
 | Surface | Scope | Columns |
 | :-- | :-- | :-- |
 | `lix_working_diff()` | Active branch | `diff_id`, `row_pk`, `schema_key`, `file_id`, `diff_type`, `before_change_id`, `after_change_id` |
 | `lix_checkpoint` | Repository-global | `id`, `commit_id`, plus the standard `lixcol_*` row columns |
-| `lix_history('lix_checkpoint')` | Revisions reachable from a commit | `id`, `commit_id`, plus the standard history `lixcol_*` columns including `lixcol_depth` |
+| `lix_history('lix_checkpoint'[, commit_id])` | Global row-authorship history | `id`, `commit_id`, plus the standard history `lixcol_*` columns |
+| `lix_commit_ancestry()` | Active branch head | `commit_id`, `depth` |
+| `lix_commit_ancestry(commit_id)` | Explicit commit | `commit_id`, `depth` |
 
 Working-diff relations are scoped to the current session. Open another session
 on another branch to inspect that branch without switching the primary session.
@@ -86,22 +88,27 @@ granularity as `lix_change`. Its heterogeneous envelope exposes source-schema
 identity and change IDs; applications can join the affected `file_id` or row
 identity to typed current-state relations when presenting a composed review.
 
-`lix_checkpoint` holds the checkpoint rows themselves. It carries no ordering
-column. Use `lix_history('lix_checkpoint')` when you need order, because it exposes
-`lixcol_depth`.
+`lix_checkpoint` is a normal immutable global schema. Its current table retains
+checkpoint markers even when a branch restore abandons their commits. Join the
+table with `lix_commit_ancestry()` when you need checkpoints reachable from the
+active branch head:
 
-Depth is commit distance from the anchor commit. A checkpoint has
-`lixcol_depth = 0` only while it is the head; three later auto-commits put that
-checkpoint at depth `3`. Ascending depth is therefore newest-first, but depths
-are not checkpoint ordinals and may have gaps. SQL row order is not implicit, so
-request it explicitly:
+`lix_history('lix_checkpoint'[, commit_id])` remains the normal history of
+those global rows. It follows where checkpoint-row changes were authored; it
+does not interpret a row's `commit_id` as membership in another commit graph.
 
 ```sql
-SELECT id, commit_id, lixcol_depth
-FROM lix_history('lix_checkpoint')
-ORDER BY lixcol_depth;
+SELECT checkpoint.id, checkpoint.commit_id, ancestry.depth
+FROM lix_checkpoint AS checkpoint
+JOIN lix_commit_ancestry() AS ancestry
+  ON ancestry.commit_id = checkpoint.commit_id
+ORDER BY ancestry.depth, checkpoint.commit_id;
 ```
 
-All three surfaces are read-only. Create a checkpoint for every working diff
+The anchor itself has `depth = 0`; parents have depth `1`. A commit reachable
+through multiple merge paths appears once at its shortest depth. SQL row order
+is not implicit, so request it explicitly.
+
+These surfaces are read-only. Create a checkpoint for every working diff
 through `lix.createCheckpoint()`, or checkpoint a SQL-selected subset
 through `lix_create_checkpoint`. See [Diff commands](./diff-commands.md).

--- a/docs/sql-functions.md
+++ b/docs/sql-functions.md
@@ -56,6 +56,16 @@ WHERE id = 't1'
 ORDER BY lixcol_depth;
 ```
 
+`lix_commit_ancestry()` returns the active head at depth `0` and every
+reachable ancestor once at its shortest depth. Pass one commit ID to use an
+explicit graph anchor:
+
+```sql
+SELECT commit_id, depth
+FROM lix_commit_ancestry($1)
+ORDER BY depth, commit_id;
+```
+
 `lix_restore` is a command-shaped mutation and must be the statement's only
 projection:
 

--- a/docs/surfaces.md
+++ b/docs/surfaces.md
@@ -12,9 +12,11 @@ Lix exposes logical application data through typed SQL relations:
 | Files                           | `lix_file`                   | `lix_history('lix_file')`                   |
 | Directories                     | `lix_directory`              | `lix_history('lix_directory')`              |
 | Working diffs                   | `lix_working_diff()`         | `lix_diff(from_commit, to_commit)`     |
-| Checkpoints                     | `lix_checkpoint`             | `lix_history('lix_checkpoint')`             |
+| Checkpoints                     | `lix_checkpoint`             | `lix_history('lix_checkpoint')` for row-authorship history |
+| Commit graph                    | `lix_commit`, `lix_commit_edge` | `lix_commit_ancestry()` for active-head reachability |
 
-The history functions read revisions reachable from a commit; `lix_diff`
+The history functions read row revisions reachable from a commit;
+`lix_commit_ancestry()` reads the reachable commit set, and `lix_diff`
 compares two arbitrary commits. `lix_registered_schema` and its history
 function provide schema discovery; `lix_key_value` and its history function
 provide shared repository metadata.

--- a/packages/lix/src/commit_graph/context.rs
+++ b/packages/lix/src/commit_graph/context.rs
@@ -199,6 +199,36 @@ where
             .await
     }
 
+    /// Walks only the complete nearest-depth layers needed to satisfy `limit`.
+    pub(crate) async fn reachable_nodes_limited(
+        &mut self,
+        head_commit_id: &CommitId,
+        limit: usize,
+    ) -> Result<Arc<[ReachableCommitGraphNode]>, LixError> {
+        if limit == 0 {
+            return Ok(Arc::from([]));
+        }
+        if let Some(nodes) = self.reachable_nodes_cache.get(&(*head_commit_id, None)) {
+            return Ok(nodes.iter().take(limit).cloned().collect());
+        }
+        let mut walk = ReachableWalk::new(*head_commit_id);
+        let mut nodes = Vec::new();
+        while let Some(layer) = walk.next_layer(self).await? {
+            let depth = layer.depth;
+            nodes.extend(
+                layer
+                    .commits
+                    .into_iter()
+                    .map(|commit| ReachableCommitGraphNode { commit, depth }),
+            );
+            if nodes.len() >= limit {
+                break;
+            }
+        }
+        nodes.truncate(limit);
+        Ok(Arc::from(nodes))
+    }
+
     /// Walks from `head_commit_id` and stops once `max_depth` is complete.
     async fn reachable_nodes_within_depth(
         &mut self,
@@ -820,6 +850,14 @@ where
         head_commit_id: &CommitId,
     ) -> Result<Arc<[ReachableCommitGraphNode]>, LixError> {
         Self::reachable_nodes(self, head_commit_id).await
+    }
+
+    async fn reachable_nodes_limited(
+        &mut self,
+        head_commit_id: &CommitId,
+        limit: usize,
+    ) -> Result<Arc<[ReachableCommitGraphNode]>, LixError> {
+        Self::reachable_nodes_limited(self, head_commit_id, limit).await
     }
 
     async fn change_history_from_commit(

--- a/packages/lix/src/commit_graph/types.rs
+++ b/packages/lix/src/commit_graph/types.rs
@@ -137,6 +137,17 @@ pub(crate) trait CommitGraphReader: Send + Sync {
         head_commit_id: &CommitId,
     ) -> Result<Arc<[ReachableCommitGraphNode]>, LixError>;
 
+    /// Returns the nearest reachable nodes while avoiding traversal below the
+    /// complete breadth layer that satisfies `limit` when supported.
+    async fn reachable_nodes_limited(
+        &mut self,
+        head_commit_id: &CommitId,
+        limit: usize,
+    ) -> Result<Arc<[ReachableCommitGraphNode]>, LixError> {
+        let nodes = self.reachable_nodes(head_commit_id).await?;
+        Ok(nodes.iter().take(limit).cloned().collect())
+    }
+
     async fn change_history_from_commit(
         &mut self,
         start_commit_id: &CommitId,

--- a/packages/lix/src/session/execute.rs
+++ b/packages/lix/src/session/execute.rs
@@ -5322,6 +5322,92 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn lix_restore_repairs_a_legacy_missing_checkpoint_cursor() {
+        let session = open_session().await;
+        let branch_id = session
+            .active_branch_id()
+            .await
+            .expect("active branch should load");
+        let restore_target = session
+            .execute("SELECT lix_active_branch_commit_id() AS commit_id", &[])
+            .await
+            .expect("initial head should read")
+            .rows()[0]
+            .get::<String>("commit_id")
+            .expect("initial head should be text");
+        session
+            .execute(
+                "INSERT INTO lix_key_value (key, value) VALUES ('legacy-cursor', 'later')",
+                &[],
+            )
+            .await
+            .expect("later state should commit");
+
+        let read = session
+            .storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("branch control read should open");
+        let mut control = crate::branch::BranchHeadControlContext::new()
+            .reader(&read)
+            .load(&branch_id)
+            .await
+            .expect("branch control should read")
+            .expect("active branch control should exist");
+        control.working_diff_checkpoint_commit_id = None;
+        drop(read);
+        let mut corrupt = session.storage.new_write_set();
+        crate::branch::stage_branch_head_control(&mut corrupt, &branch_id, control)
+            .expect("legacy cursor corruption should stage");
+        session
+            .storage
+            .commit_write_set(corrupt, StorageWriteOptions::default())
+            .await
+            .expect("legacy cursor corruption should commit");
+
+        let broken = session
+            .execute("SELECT * FROM lix_working_diff()", &[])
+            .await
+            .expect_err("legacy branch should reproduce the missing-cursor failure");
+        assert!(broken.message.contains("has no checkpoint cursor"));
+
+        let restored = session
+            .execute(
+                "SELECT lix_restore($1)",
+                &[Value::Text(restore_target.clone())],
+            )
+            .await
+            .expect("restore should repair the legacy branch atomically");
+        assert_eq!(
+            restored.rows()[0].get::<String>("lix_restore").unwrap(),
+            restore_target
+        );
+        let working_diff = session
+            .execute("SELECT * FROM lix_working_diff()", &[])
+            .await
+            .expect("working diff should read after repair");
+        assert!(working_diff.rows().is_empty());
+
+        let read = session
+            .storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("repaired branch control read should open");
+        let repaired = crate::branch::BranchHeadControlContext::new()
+            .reader(&read)
+            .load(&branch_id)
+            .await
+            .expect("repaired branch control should read")
+            .expect("repaired branch control should exist");
+        assert_eq!(
+            repaired
+                .working_diff_checkpoint_commit_id
+                .map(|commit_id| commit_id.to_string()),
+            Some(restore_target)
+        );
+    }
+
+    #[tokio::test]
     async fn exact_registered_schema_point_preserves_typed_public_projection() {
         let session = open_session().await;
         let schema = serde_json::json!({

--- a/packages/lix/src/sql2/bind/classify.rs
+++ b/packages/lix/src/sql2/bind/classify.rs
@@ -72,7 +72,7 @@ fn validate_supported_query(query: &Query) -> Result<(), LixError> {
     if query.with.as_ref().is_some_and(|with| with.recursive) {
         return Err(
             unsupported_sql_error("recursive CTEs are not supported by Lix SQL").with_hint(
-                "Use explicit commit graph surfaces such as lix_commit and lix_commit_edge, or a typed <schema>_history surface, instead of WITH RECURSIVE.",
+                "Use lix_commit_ancestry() for transitive commit traversal, explicit graph surfaces such as lix_commit and lix_commit_edge for topology, or a typed history surface instead of WITH RECURSIVE.",
             ),
         );
     }

--- a/packages/lix/src/sql2/bind/statement.rs
+++ b/packages/lix/src/sql2/bind/statement.rs
@@ -1452,7 +1452,8 @@ fn bound_write_target(kind: &PublicSurfaceKind) -> BoundWriteTarget {
         }
         PublicSurfaceKind::Change
         | PublicSurfaceKind::WorkingDiff
-        | PublicSurfaceKind::HistoryFunction => {
+        | PublicSurfaceKind::HistoryFunction
+        | PublicSurfaceKind::CommitAncestryFunction => {
             unreachable!("write capability checked before target binding")
         }
     }

--- a/packages/lix/src/sql2/bind/table.rs
+++ b/packages/lix/src/sql2/bind/table.rs
@@ -226,6 +226,7 @@ mod tests {
             "lix_change",
             "lix_checkpoint",
             "lix_commit",
+            "lix_commit_ancestry",
             "lix_commit_edge",
             "lix_create_checkpoint",
             "lix_directory",

--- a/packages/lix/src/sql2/catalog/registry.rs
+++ b/packages/lix/src/sql2/catalog/registry.rs
@@ -118,7 +118,9 @@ impl PublicCatalog {
                 Field::new("commit_id", DataType::Utf8, false),
             ])),
             PublicSurfaceKind::WorkingDiff => working_diff_schema(),
-            PublicSurfaceKind::HistoryFunction => return None,
+            PublicSurfaceKind::HistoryFunction | PublicSurfaceKind::CommitAncestryFunction => {
+                return None;
+            }
             PublicSurfaceKind::Revert
             | PublicSurfaceKind::Apply
             | PublicSurfaceKind::CreateCheckpoint => Arc::new(Schema::new(vec![Field::new(
@@ -245,6 +247,12 @@ impl PublicCatalog {
         self.insert(surface(
             "lix_history",
             PublicSurfaceKind::HistoryFunction,
+            Vec::new(),
+            SurfaceCapabilities::read_only(),
+        ))?;
+        self.insert(surface(
+            "lix_commit_ancestry",
+            PublicSurfaceKind::CommitAncestryFunction,
             Vec::new(),
             SurfaceCapabilities::read_only(),
         ))?;

--- a/packages/lix/src/sql2/catalog/surface.rs
+++ b/packages/lix/src/sql2/catalog/surface.rs
@@ -43,6 +43,7 @@ pub(crate) enum PublicSurfaceKind {
     Directory,
     Branch,
     HistoryFunction,
+    CommitAncestryFunction,
     WorkingDiff,
     Revert,
     Apply,

--- a/packages/lix/src/sql2/exec/datafusion.rs
+++ b/packages/lix/src/sql2/exec/datafusion.rs
@@ -2877,11 +2877,14 @@ fn bind_table_function_parameters(
             else {
                 return ControlFlow::Continue(());
             };
-            let public_function_name = ["lix_history", "lix_working_diff", "lix_diff"]
-                .into_iter()
-                .find(|candidate| {
-                    crate::sql2::parse::object_name_is_public_function(name, candidate)
-                });
+            let public_function_name = [
+                "lix_history",
+                "lix_working_diff",
+                "lix_diff",
+                "lix_commit_ancestry",
+            ]
+            .into_iter()
+            .find(|candidate| crate::sql2::parse::object_name_is_public_function(name, candidate));
             let is_history = public_function_name == Some("lix_history");
             if let Some(function_name) = public_function_name {
                 // DataFusion's table-function registry is case-sensitive and
@@ -3029,7 +3032,7 @@ fn validate_supported_logical_plan(plan: &LogicalPlan) -> Result<(), LixError> {
                 "recursive CTEs are not supported by Lix SQL",
             )
             .with_hint(
-                "Use explicit commit graph surfaces such as lix_commit and lix_commit_edge, or a typed <schema>_history surface, instead of WITH RECURSIVE.",
+                "Use lix_commit_ancestry() for transitive commit traversal, explicit graph surfaces such as lix_commit and lix_commit_edge for topology, or a typed history surface instead of WITH RECURSIVE.",
             ));
         }
         _ => {}

--- a/packages/lix/src/sql2/information_schema.rs
+++ b/packages/lix/src/sql2/information_schema.rs
@@ -205,6 +205,11 @@ impl LixInformationSchemaProvider {
 
         for (name, signature, provider_schema) in [
             (
+                "lix_commit_ancestry",
+                "() | (commit_id TEXT)",
+                super::providers::commit_ancestry_schema(),
+            ),
+            (
                 "lix_working_diff",
                 "()",
                 super::providers::working_diff_schema(),

--- a/packages/lix/src/sql2/providers/commit_ancestry.rs
+++ b/packages/lix/src/sql2/providers/commit_ancestry.rs
@@ -1,0 +1,206 @@
+use std::fmt;
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use datafusion::arrow::datatypes::{DataType, Field, Schema, SchemaRef};
+use datafusion::catalog::{TableFunctionImpl, TableProvider};
+use datafusion::common::{DataFusionError, Result};
+use datafusion::datasource::TableType;
+use datafusion::execution::context::ExecutionProps;
+use datafusion::logical_expr::{Expr, TableProviderFilterPushDown};
+use tokio::sync::Mutex;
+
+use crate::changelog::CommitId;
+use crate::commit_graph::CommitGraphReader;
+use crate::sql2::error::lix_error_to_datafusion_error;
+
+use super::columns::{Col, ColumnTable, ColumnTableError};
+use super::spec::{PlannedScan, SpecTableProvider, TableSpec, projected_schema, scan_row_source};
+
+pub(super) fn register_commit_ancestry_function(
+    session: &datafusion::prelude::SessionContext,
+    surface_name: &str,
+    active_branch_commit_id: String,
+    commit_graph: Box<dyn CommitGraphReader>,
+) {
+    session.register_udtf(
+        surface_name,
+        Arc::new(CommitAncestryFunction {
+            name: surface_name.to_string(),
+            active_branch_commit_id,
+            commit_graph: Arc::new(Mutex::new(commit_graph)),
+        }),
+    );
+}
+
+struct CommitAncestryFunction {
+    name: String,
+    active_branch_commit_id: String,
+    commit_graph: Arc<Mutex<Box<dyn CommitGraphReader>>>,
+}
+
+impl fmt::Debug for CommitAncestryFunction {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("CommitAncestryFunction")
+            .field("name", &self.name)
+            .field("active_branch_commit_id", &self.active_branch_commit_id)
+            .finish_non_exhaustive()
+    }
+}
+
+impl TableFunctionImpl for CommitAncestryFunction {
+    fn call(&self, args: &[Expr]) -> Result<Arc<dyn TableProvider>> {
+        let anchor_commit_id = match args {
+            [] => self.active_branch_commit_id.clone(),
+            [anchor] => commit_id_argument(anchor)?,
+            _ => {
+                return Err(DataFusionError::Plan(format!(
+                    "{} expects zero arguments or one commit ID argument",
+                    self.name
+                )));
+            }
+        };
+        Ok(Arc::new(SpecTableProvider::new(Arc::new(
+            CommitAncestrySpec {
+                anchor_commit_id,
+                commit_graph: Arc::clone(&self.commit_graph),
+            },
+        ))))
+    }
+}
+
+fn commit_id_argument(argument: &Expr) -> Result<String> {
+    let Expr::Literal(value, _) = argument else {
+        return Err(DataFusionError::Plan(
+            "lix_commit_ancestry argument must be a commit ID literal or parameter".to_string(),
+        ));
+    };
+    value
+        .try_as_str()
+        .flatten()
+        .map(ToString::to_string)
+        .ok_or_else(|| {
+            DataFusionError::Plan(
+                "lix_commit_ancestry argument must be a non-null text commit ID".to_string(),
+            )
+        })
+}
+
+struct CommitAncestrySpec {
+    anchor_commit_id: String,
+    commit_graph: Arc<Mutex<Box<dyn CommitGraphReader>>>,
+}
+
+#[async_trait]
+impl TableSpec for CommitAncestrySpec {
+    fn table_name(&self) -> &str {
+        "lix_commit_ancestry"
+    }
+
+    fn schema(&self) -> SchemaRef {
+        commit_ancestry_schema()
+    }
+
+    fn table_type(&self) -> TableType {
+        TableType::View
+    }
+
+    fn filter_pushdown(&self, _filter: &Expr) -> TableProviderFilterPushDown {
+        TableProviderFilterPushDown::Unsupported
+    }
+
+    async fn plan_scan(
+        &self,
+        projection: Option<&Vec<usize>>,
+        _filters: &[Expr],
+        limit: Option<usize>,
+        _props: &ExecutionProps,
+    ) -> Result<PlannedScan> {
+        let schema = projected_schema(&commit_ancestry_schema(), projection);
+        Ok(PlannedScan {
+            schema: Arc::clone(&schema),
+            ordering: None,
+            source: scan_row_source(
+                Arc::clone(&schema),
+                (
+                    self.anchor_commit_id.clone(),
+                    Arc::clone(&self.commit_graph),
+                    schema,
+                ),
+                move |(anchor_commit_id, commit_graph, schema)| async move {
+                    if limit == Some(0) {
+                        return ANCESTRY_COLS
+                            .build(schema, &[])
+                            .map_err(ancestry_batch_error);
+                    }
+                    let anchor_commit_id = CommitId::parse(&anchor_commit_id).map_err(|error| {
+                        lix_error_to_datafusion_error(crate::LixError::new(
+                            crate::LixError::CODE_INVALID_PARAM,
+                            format!("lix_commit_ancestry anchor must be a UUID commit id: {error}"),
+                        ))
+                    })?;
+                    let reachable = match limit {
+                        Some(limit) => {
+                            commit_graph
+                                .lock()
+                                .await
+                                .reachable_nodes_limited(&anchor_commit_id, limit)
+                                .await
+                        }
+                        None => {
+                            commit_graph
+                                .lock()
+                                .await
+                                .reachable_nodes(&anchor_commit_id)
+                                .await
+                        }
+                    }
+                    .map_err(lix_error_to_datafusion_error)?;
+                    let rows = reachable
+                        .iter()
+                        .take(limit.unwrap_or(usize::MAX))
+                        .map(|node| CommitAncestryRow {
+                            commit_id: node.commit.commit_id.to_string(),
+                            depth: i64::from(node.depth),
+                        })
+                        .collect::<Vec<_>>();
+                    ANCESTRY_COLS
+                        .build(schema, &rows)
+                        .map_err(ancestry_batch_error)
+                },
+            ),
+        })
+    }
+}
+
+pub(crate) fn commit_ancestry_schema() -> SchemaRef {
+    Arc::new(Schema::new(vec![
+        Field::new("commit_id", DataType::Utf8, false),
+        Field::new("depth", DataType::Int64, false),
+    ]))
+}
+
+struct CommitAncestryRow {
+    commit_id: String,
+    depth: i64,
+}
+
+static ANCESTRY_COLS: ColumnTable<CommitAncestryRow> = ColumnTable {
+    columns: &[
+        ("commit_id", Col::Utf8(|row| Some(&row.commit_id))),
+        ("depth", Col::I64(|row| Some(row.depth))),
+    ],
+};
+
+fn ancestry_batch_error(error: ColumnTableError) -> DataFusionError {
+    match error {
+        ColumnTableError::UnsupportedColumn(column) => {
+            DataFusionError::Execution(format!("unsupported lix_commit_ancestry column '{column}'"))
+        }
+        ColumnTableError::Arrow(error) | ColumnTableError::ArrowZeroColumn(error) => {
+            DataFusionError::from(error)
+        }
+        ColumnTableError::Row(error) => lix_error_to_datafusion_error(error),
+    }
+}

--- a/packages/lix/src/sql2/providers/mod.rs
+++ b/packages/lix/src/sql2/providers/mod.rs
@@ -12,6 +12,8 @@ mod branch;
 mod branch_selection;
 mod change;
 mod columns;
+mod commit_ancestry;
+pub(crate) use commit_ancestry::commit_ancestry_schema;
 mod diff;
 mod directory;
 mod directory_history;
@@ -385,7 +387,7 @@ where
         }
     });
     let history_query_source = if needs_history_query_source {
-        let active_branch_commit_id = active_branch_commit_id.ok_or_else(|| {
+        let active_branch_commit_id = active_branch_commit_id.clone().ok_or_else(|| {
             LixError::branch_not_found(
                 ctx.active_branch_id(),
                 "register SQL history providers",
@@ -458,6 +460,21 @@ where
                     ctx.changelog_query_source(),
                 )
                 .await?;
+            }
+            PublicSurfaceKind::CommitAncestryFunction => {
+                let active_branch_commit_id = active_branch_commit_id.clone().ok_or_else(|| {
+                    LixError::branch_not_found(
+                        ctx.active_branch_id(),
+                        "register lix_commit_ancestry",
+                        "active branch",
+                    )
+                })?;
+                commit_ancestry::register_commit_ancestry_function(
+                    session,
+                    &surface.name,
+                    active_branch_commit_id,
+                    ctx.commit_graph(),
+                );
             }
             PublicSurfaceKind::File => {
                 file::register_lix_file_active_provider(
@@ -683,7 +700,8 @@ async fn register_write_from_catalog(
             }
             PublicSurfaceKind::Change
             | PublicSurfaceKind::WorkingDiff
-            | PublicSurfaceKind::HistoryFunction => {}
+            | PublicSurfaceKind::HistoryFunction
+            | PublicSurfaceKind::CommitAncestryFunction => {}
             PublicSurfaceKind::SchemaBase { .. } => {}
         }
     }
@@ -924,7 +942,12 @@ mod tests {
 
         assert_eq!(
             read_only,
-            vec!["lix_change", "lix_history", "lix_working_diff"]
+            vec![
+                "lix_change",
+                "lix_commit_ancestry",
+                "lix_history",
+                "lix_working_diff",
+            ]
         );
         assert_eq!(
             writable,
@@ -939,8 +962,8 @@ mod tests {
             ]
         );
         assert_eq!(read_only.len() + writable.len(), catalog.surfaces().count());
-        assert_eq!(all_read + writable.len(), 17, "construction count");
-        assert_eq!(read_only.len() + writable.len(), 10, "surface count");
+        assert_eq!(all_read + writable.len(), 18, "construction count");
+        assert_eq!(read_only.len() + writable.len(), 11, "surface count");
     }
 
     #[test]

--- a/packages/lix/tests/integration/sql/checkpoint.rs
+++ b/packages/lix/tests/integration/sql/checkpoint.rs
@@ -279,6 +279,96 @@ simulation_test!(
 );
 
 simulation_test!(
+    checkpoint_history_as_of_branch_head_follows_global_row_authorship,
+    |sim| async move {
+        let engine = sim.boot_engine().await;
+        let session = sim.wrap_session(
+            engine.open_session().await.expect("session should open"),
+            &engine,
+        );
+        let initial_commit_id = sim.initial_commit_id().to_string();
+
+        session
+            .execute(
+                "INSERT INTO lix_key_value (key, value) VALUES ('checkpoint-history', 'one')",
+                &[],
+            )
+            .await
+            .expect("first value should commit");
+        let first_checkpoint = session
+            .create_checkpoint()
+            .await
+            .expect("first checkpoint should commit");
+
+        session
+            .execute(
+                "UPDATE lix_key_value SET value = 'two' WHERE key = 'checkpoint-history'",
+                &[],
+            )
+            .await
+            .expect("second value should commit");
+        let abandoned_checkpoint = session
+            .create_checkpoint()
+            .await
+            .expect("second checkpoint should commit");
+
+        session
+            .execute(
+                "SELECT lix_restore($1)",
+                &[Value::Text(first_checkpoint.commit_id.clone())],
+            )
+            .await
+            .expect("restore to first checkpoint should succeed");
+
+        let global_rows = select_rows(
+            &session,
+            "SELECT commit_id FROM lix_checkpoint ORDER BY commit_id",
+        )
+        .await;
+        assert!(
+            global_rows.contains(&vec![Value::Text(abandoned_checkpoint.commit_id.clone())]),
+            "the normal global table must retain the abandoned checkpoint marker"
+        );
+
+        let reachable_history = select_rows(
+            &session,
+            &format!(
+                "SELECT commit_id FROM lix_history('lix_checkpoint', '{}') \
+                 ORDER BY lixcol_depth",
+                first_checkpoint.commit_id
+            ),
+        )
+        .await;
+        assert_eq!(
+            reachable_history,
+            vec![vec![Value::Text(initial_commit_id)]],
+            "history follows global checkpoint-row authorship; it does not treat a row's commit_id as active-branch graph membership"
+        );
+
+        let reachable_checkpoints = select_rows(
+            &session,
+            "SELECT checkpoint.commit_id, ancestry.depth \
+             FROM lix_checkpoint AS checkpoint \
+             JOIN lix_commit_ancestry() AS ancestry \
+               ON ancestry.commit_id = checkpoint.commit_id \
+             ORDER BY ancestry.depth, checkpoint.commit_id",
+        )
+        .await;
+        assert_eq!(
+            reachable_checkpoints,
+            vec![
+                vec![Value::Text(first_checkpoint.commit_id), Value::Integer(0)],
+                vec![
+                    Value::Text(sim.initial_commit_id().to_string()),
+                    Value::Integer(1)
+                ],
+            ],
+            "joining normal checkpoint rows with active-head ancestry must expose exactly the restorable checkpoint timeline"
+        );
+    }
+);
+
+simulation_test!(
     working_diff_reports_net_tracked_adds_and_removals_after_a_revert,
     |sim| async move {
         let engine = sim.boot_engine().await;

--- a/packages/lix/tests/integration/sql/history_conformance.rs
+++ b/packages/lix/tests/integration/sql/history_conformance.rs
@@ -788,6 +788,7 @@ simulation_test!(history_discovery_has_no_suffix_surfaces, |sim| async move {
         )
         .await,
         vec![
+            vec![Value::Text("lix_commit_ancestry".to_string())],
             vec![Value::Text("lix_diff".to_string())],
             vec![Value::Text("lix_history".to_string())],
             vec![Value::Text("lix_working_diff".to_string())],

--- a/packages/lix/tests/integration/sql/lix_commit.rs
+++ b/packages/lix/tests/integration/sql/lix_commit.rs
@@ -1,6 +1,6 @@
 use std::collections::BTreeSet;
 
-use lix::{CreateBranchOptions, LixError, Value};
+use lix::{CreateBranchOptions, LixError, MergeBranchOptions, Value};
 
 use super::select_rows;
 
@@ -173,6 +173,259 @@ simulation_test!(
     }
 );
 
+simulation_test!(
+    lix_commit_ancestry_defaults_to_active_head_and_accepts_explicit_anchor,
+    |sim| async move {
+        let engine = sim.boot_engine().await;
+        let session = sim.wrap_session(
+            engine.open_session().await.expect("session should open"),
+            &engine,
+        );
+        let initial_commit_id = sim.initial_commit_id().to_string();
+
+        session
+            .execute(
+                "INSERT INTO lix_key_value (key, value) VALUES ('ancestry', 'one')",
+                &[],
+            )
+            .await
+            .expect("first commit should succeed");
+        let first_head = engine
+            .load_branch_head_commit_id(sim.main_branch_id())
+            .await
+            .expect("head should load")
+            .expect("head should exist");
+        session
+            .execute(
+                "UPDATE lix_key_value SET value = 'two' WHERE key = 'ancestry'",
+                &[],
+            )
+            .await
+            .expect("second commit should succeed");
+        let second_head = engine
+            .load_branch_head_commit_id(sim.main_branch_id())
+            .await
+            .expect("head should load")
+            .expect("head should exist");
+
+        assert_eq!(
+            select_rows(
+                &session,
+                "SELECT commit_id, depth FROM lix_commit_ancestry() ORDER BY depth, commit_id",
+            )
+            .await,
+            vec![
+                vec![Value::Text(second_head.clone()), Value::Integer(0)],
+                vec![Value::Text(first_head.clone()), Value::Integer(1)],
+                vec![Value::Text(initial_commit_id.clone()), Value::Integer(2)],
+            ]
+        );
+
+        let explicit = session
+            .execute(
+                "SELECT commit_id, depth FROM lix_commit_ancestry($1) ORDER BY depth, commit_id",
+                &[Value::Text(first_head.clone())],
+            )
+            .await
+            .expect("parameterized explicit ancestry should read");
+        assert_eq!(
+            explicit
+                .rows()
+                .iter()
+                .map(|row| row.values().to_vec())
+                .collect::<Vec<_>>(),
+            vec![
+                vec![Value::Text(first_head.clone()), Value::Integer(0)],
+                vec![Value::Text(initial_commit_id), Value::Integer(1)],
+            ]
+        );
+
+        session
+            .execute("SELECT lix_restore($1)", &[Value::Text(first_head.clone())])
+            .await
+            .expect("restore should succeed");
+        let restored = select_rows(
+            &session,
+            "SELECT commit_id, depth FROM lix_commit_ancestry() ORDER BY depth, commit_id",
+        )
+        .await;
+        assert_eq!(
+            restored[0],
+            vec![Value::Text(first_head.clone()), Value::Integer(0)]
+        );
+        assert!(
+            restored
+                .iter()
+                .all(|row| row[0] != Value::Text(second_head.clone())),
+            "zero-argument ancestry must stop exposing an abandoned descendant after restore"
+        );
+
+        let function_contract = select_rows(
+            &session,
+            "SELECT argument_signature, result_column, data_type, is_nullable \
+             FROM information_schema.table_functions \
+             WHERE function_name = 'lix_commit_ancestry' \
+             ORDER BY ordinal_position",
+        )
+        .await;
+        assert_eq!(
+            function_contract,
+            vec![
+                vec![
+                    Value::Text("() | (commit_id TEXT)".to_string()),
+                    Value::Text("commit_id".to_string()),
+                    Value::Text("TEXT".to_string()),
+                    Value::Text("NO".to_string()),
+                ],
+                vec![
+                    Value::Text("() | (commit_id TEXT)".to_string()),
+                    Value::Text("depth".to_string()),
+                    Value::Text("BIGINT".to_string()),
+                    Value::Text("NO".to_string()),
+                ],
+            ]
+        );
+
+        for sql in [
+            "SELECT * FROM lix_commit_ancestry(NULL)",
+            "SELECT * FROM lix_commit_ancestry(1)",
+            "SELECT * FROM lix_commit_ancestry('a', 'b')",
+        ] {
+            let error = session
+                .execute(sql, &[])
+                .await
+                .expect_err("invalid ancestry call should fail closed");
+            assert_eq!(error.code, LixError::CODE_PARSE_ERROR, "{sql}");
+        }
+        let malformed = session
+            .execute("SELECT * FROM lix_commit_ancestry('not-a-commit-id')", &[])
+            .await
+            .expect_err("malformed ancestry anchor should fail");
+        assert_eq!(malformed.code, LixError::CODE_INVALID_PARAM);
+        let missing = session
+            .execute(
+                "SELECT * FROM lix_commit_ancestry('01990000-0000-7000-8000-00000000dead')",
+                &[],
+            )
+            .await
+            .expect_err("unknown ancestry anchor should fail");
+        assert_eq!(missing.code, LixError::CODE_COMMIT_NOT_FOUND);
+
+        assert_eq!(
+            select_rows(&session, "SELECT * FROM lix_commit_ancestry() LIMIT 1").await,
+            vec![vec![Value::Text(first_head.clone()), Value::Integer(0)]],
+            "a bounded ancestry scan should return only the active anchor"
+        );
+
+        assert_eq!(
+            select_rows(
+                &session,
+                "SELECT commit_id, depth FROM PUBLIC.LIX_COMMIT_ANCESTRY() ORDER BY depth, commit_id",
+            )
+            .await,
+            restored,
+            "public schema and unquoted case normalization must preserve table-function semantics"
+        );
+    }
+);
+
+simulation_test!(
+    lix_commit_ancestry_deduplicates_merge_ancestors_at_shortest_depth,
+    |sim| async move {
+        let engine = sim.boot_engine().await;
+        let main = sim.wrap_session(
+            engine
+                .open_session()
+                .await
+                .expect("main session should open"),
+            &engine,
+        );
+        let initial_commit_id = sim.initial_commit_id().to_string();
+        let draft_id = "01930000-0000-7000-8000-000000000076";
+        main.create_branch(CreateBranchOptions {
+            id: Some(draft_id.to_string()),
+            name: "ancestry draft".to_string(),
+            from_commit_id: None,
+        })
+        .await
+        .expect("draft branch should be created");
+        let draft = sim.wrap_session(
+            engine
+                .open_session_at(draft_id)
+                .await
+                .expect("draft session should open"),
+            &engine,
+        );
+
+        main.execute(
+            "INSERT INTO lix_key_value (key, value) VALUES ('ancestry-main', 'main')",
+            &[],
+        )
+        .await
+        .expect("main commit should succeed");
+        let main_parent = engine
+            .load_branch_head_commit_id(sim.main_branch_id())
+            .await
+            .expect("main head should load")
+            .expect("main head should exist");
+        draft
+            .execute(
+                "INSERT INTO lix_key_value (key, value) VALUES ('ancestry-draft', 'draft')",
+                &[],
+            )
+            .await
+            .expect("draft commit should succeed");
+        let draft_parent = engine
+            .load_branch_head_commit_id(draft_id)
+            .await
+            .expect("draft head should load")
+            .expect("draft head should exist");
+
+        assert_eq!(
+            select_rows(
+                &main,
+                &format!(
+                    "SELECT commit_id, depth FROM lix_commit_ancestry('{draft_parent}') \
+                     ORDER BY depth, commit_id"
+                ),
+            )
+            .await,
+            vec![
+                vec![Value::Text(draft_parent.clone()), Value::Integer(0)],
+                vec![Value::Text(initial_commit_id.clone()), Value::Integer(1)],
+            ],
+            "an explicit anchor may be outside the active branch ancestry"
+        );
+
+        main.merge_branch(MergeBranchOptions {
+            source_branch_id: draft_id.to_string(),
+        })
+        .await
+        .expect("divergent branch merge should succeed");
+        let merge_head = engine
+            .load_branch_head_commit_id(sim.main_branch_id())
+            .await
+            .expect("merge head should load")
+            .expect("merge head should exist");
+        let mut parents = [main_parent, draft_parent];
+        parents.sort();
+
+        assert_eq!(
+            select_rows(
+                &main,
+                "SELECT commit_id, depth FROM lix_commit_ancestry() ORDER BY depth, commit_id",
+            )
+            .await,
+            vec![
+                vec![Value::Text(merge_head), Value::Integer(0)],
+                vec![Value::Text(parents[0].clone()), Value::Integer(1)],
+                vec![Value::Text(parents[1].clone()), Value::Integer(1)],
+                vec![Value::Text(initial_commit_id), Value::Integer(2)],
+            ],
+            "the shared root must appear once at its shortest merge distance"
+        );
+    }
+);
 
 simulation_test!(
     lix_commit_surfaces_match_canonical_schema_definitions,
@@ -214,10 +467,7 @@ simulation_test!(
             &engine,
         );
 
-        for table in [
-            "lix_commit",
-            "lix_commit_edge",
-        ] {
+        for table in ["lix_commit", "lix_commit_edge"] {
             let rows = select_rows(&session, &format!("SELECT count(*) FROM {table}")).await;
             assert_single_count(rows, table);
         }


### PR DESCRIPTION
## Summary

- add `lix_commit_ancestry()` as a SQL table function over the commit graph
- default the anchor to the active branch head, with an optional explicit commit ID
- return each reachable commit once with its shortest ancestry depth
- document checkpoint reachability through an ancestry join instead of branch-specific graph surfaces
- add restore recovery coverage for a legacy branch with a missing checkpoint cursor

## Why

Checkpoint markers are repository-global and intentionally survive branch movement. Callers that need checkpoints reachable from the active branch should join their commit IDs against the active branch ancestry. Exposing that traversal directly avoids special checkpoint-table semantics and `_by_branch` graph APIs.

## Verification

- `cargo test -p lix --features all-simulations --no-fail-fast`
- `git diff --check`

`cargo fmt --all -- --check` still reports four pre-existing formatting differences on `origin/main` in `packages/lix/build.rs`, `packages/storage-rocksdb/src/rocksdb.rs`, `plugins/json/src/lib.rs`, and `plugins/markdown/src/core.rs`; this PR does not modify those files.
