### PR TITLE
perf(lix): make checkpoint publication constant time

### DIFF
--- a/docs/checkpoint-performance.md
+++ b/docs/checkpoint-performance.md
@@ -1,0 +1,181 @@
+---
+description: Reproduce and qualify constant-time foreground checkpoint publication.
+---
+
+# Checkpoint foreground performance
+
+Checkpoint publication is a metadata operation. Its foreground work is bounded
+independently of live rows, changed rows, commits since the prior checkpoint,
+retained checkpoint depth, branch count, and checkpoint-GC debt. Root diffing,
+history reconstruction, tombstone retirement, and repository GC are not part of
+the publication timer.
+
+This report records the qualification performed on Linux on 2026-08-21 at
+`05e610afb` plus the checkpoint O(1) changes. Times are wall-clock measurements
+from an optimized build on the same host. Storage operation/payload ceilings
+are portable regression gates; allocator counts cover the checkpoint's engine
+task and deliberately exclude adapter worker tasks.
+
+## Reproduction
+
+Build the two-adapter harness:
+
+```sh
+cargo build --release --manifest-path packages/e2e/Cargo.toml \
+  --bench profile_checkpoint_scale --features storage-benches,slatedb
+```
+
+Cargo prints the executable under `target/release/deps`. The equivalent Cargo
+Bench commands below prepare and run a fixture:
+
+```sh
+cargo bench --manifest-path packages/e2e/Cargo.toml \
+  --bench profile_checkpoint_scale --features storage-benches,slatedb -- \
+  setup rocksdb /tmp/checkpoint-rocks 10000 0
+
+cargo bench --manifest-path packages/e2e/Cargo.toml \
+  --bench profile_checkpoint_scale --features storage-benches,slatedb -- \
+  run rocksdb /tmp/checkpoint-rocks 1000 1 1
+```
+
+The setup arguments are `files branches`. The run arguments are
+`checkpoints changed-files-per-checkpoint auto-commits-per-checkpoint`. Copy a
+closed setup directory before each run to compare shapes from the same seed.
+Use `slatedb` in place of `rocksdb` for the other shipping adapter.
+
+The harness asserts every checkpoint against these foreground ceilings:
+
+| Resource | Hard maximum |
+| :-- | --: |
+| Storage read views | 8 |
+| Point-read batches / keys | 80 / 80 |
+| Scan starts / pages / rows | 4 / 4 / 48 |
+| Write transactions / adapter calls | 1 / 20 |
+| Written records / bytes | 32 / 65,536 |
+| Allocations / allocated bytes | 24,576 / 3 MiB |
+| Latency p99 / max | 25 ms / 100 ms |
+| First-to-last 100-checkpoint p95 drift | at most 2x + 2 ms |
+| Interval-write p99 / max | 100 ms / 500 ms |
+
+Storage counters are Tokio task-local. Allocator attribution consults that same
+task-local scope, so SlateDB compaction on the same executor thread is not
+misclassified as foreground allocation. Backend worker allocations are outside
+that scope, so the allocation ceiling is an engine-task regression gate rather
+than a claim about whole-process allocation. After every measured checkpoint,
+the harness yields once and immediately times a second no-op checkpoint before
+any ordinary write can absorb maintenance contention. Both latency
+distributions must pass the same ceiling. GC has separate trace fields for root
+discovery, changelog work, tracked-root staging, swept records, and total time.
+
+## Before and after
+
+Before the hard cut, the initial RocksDB checkpoint materialized the whole
+working diff and scaled with repository width:
+
+| Live files | Before | After |
+| --: | --: | --: |
+| 1,000 | 11.046 ms | 1.206 ms |
+| 5,000 | 59.966 ms | bounded by the same census |
+| 10,000 | 131.749 ms | 1.092 ms |
+| 20,000 | 314.429 ms | 1.092 ms |
+
+The after-census at both 1,000 and 20,000 RocksDB files was exactly 5 read
+views, 43 point batches, 46 keys, one scan page visiting 14 fixed metadata
+rows, one write transaction, and 25 written records. SlateDB produced the same
+storage census; its 1,000/10,000/20,000-file initial checkpoints were
+1.603/1.359/1.256 ms.
+
+Sustained high-cadence publication previously inherited repository-GC gate
+holds. A 10,000-file RocksDB run reached 540.230 ms maximum checkpoint latency
+while a root scan took 537.688 ms. After decoupling:
+
+| Backend and shape | Main p50 | Main p95 | Main p99 / max | Post-yield p99 / max | Write p99 / max |
+| :-- | --: | --: | --: | --: | --: |
+| RocksDB, 10k files, 1k checkpoints | 0.472 ms | 0.563 ms | 0.671 / 1.482 ms | 0.577 / 0.726 ms | 0.808 / 2.188 ms |
+| SlateDB, 10k files, 1k checkpoints | 0.632 ms | 0.923 ms | 1.058 / 1.674 ms | 1.129 / 1.593 ms | 1.142 / 3.068 ms |
+
+The first/last 100-checkpoint p95 values were 0.564/0.628 ms on RocksDB and
+0.728/0.712 ms on SlateDB. The RocksDB run observed a 364.920 ms background
+root-discovery pass while main checkpoint p99/max stayed at 0.671/1.482 ms and
+the direct post-yield probe stayed at 0.577/0.726 ms. The GC scans are
+intentionally allowed to scale; they no longer extend the foreground
+distribution or monopolize writer admission.
+
+## Independent scale dimensions
+
+One 1,000-file seed was copied for three RocksDB and three SlateDB runs:
+
+| Changed rows | Commits since checkpoint | RocksDB checkpoint | SlateDB checkpoint | Foreground storage census |
+| --: | --: | --: | --: | :-- |
+| 1 | 1 | 1.282 ms | 1.473 ms | 46 batches, 50 keys, 1 page/14 rows, 25 records |
+| 1,000 | 1 | 1.922 ms | 1.793 ms | identical |
+| 1,000 | 1,000 | 1.107 ms | 1.332 ms | identical |
+
+Branch fixtures plateau rather than scale. Moving from 1 to 1,000 retained
+branches kept the branch-lifecycle path at four pages / 44 rows and one write;
+point keys changed from 71 to 75 and written records from 25 to 26 because the
+fixture crosses fixed empty/non-empty topology cases, not because it visits
+branches.
+
+A 5,000-checkpoint RocksDB run exercised retained history and accumulated GC
+debt: p99 was 0.682 ms, max was 1.338 ms, and first/last p95 was 0.464/0.603 ms.
+The maximum foreground census was 52 point batches, 58 keys, one page/14 rows,
+28 written records, and 23,414 bytes. The publication payload is bounded by the
+fixed packed-segment targets; the regression ceiling is 64 KiB.
+
+## Profile
+
+The CPU profile can be reproduced with:
+
+```sh
+perf record -g -o /tmp/checkpoint.data -- \
+  target/release/deps/profile_checkpoint_scale-* \
+  run rocksdb /tmp/checkpoint-rocks 1000 1 1
+perf report --stdio --no-children -i /tmp/checkpoint.data
+```
+
+The sampled hot functions were BLAKE3 compression, tracked-state tree diffing,
+and RocksDB `MultiGet`; those samples belonged to the `lix-checkpoint-gc`
+background worker. `perf stat` for the full run, including the fixed five-second
+maintenance settle, reported 2.592 CPU-seconds, 14.125 billion cycles, 29.698
+billion instructions, and 675 context switches. Foreground attribution is the
+per-checkpoint census above rather than this process-wide profile.
+
+## Architectural hard cuts
+
+- A checkpoint commit publishes a complete-state fence that structurally
+  aliases the captured head root. Its semantic first parent is the previous
+  checkpoint; its physical source is the captured head. Publication never
+  materializes or copies the interval diff.
+- Ordinary writes always publish persistent root authority. Checkpointing can
+  therefore never inherit deferred root-rebuild debt from a wide direct or
+  replacement write.
+- Packed current-state bases retain their owning checkpoint. Epoch rotation is
+  metadata-only; stale bases are interpreted against their owner rather than
+  scanned or retired during publication.
+- History and GC synthesize a complete-state fence delta lazily by diffing the
+  prior checkpoint root and captured root. Sync transfers the same state as a
+  bounded authenticated alias containing the physical source commit and exact
+  root ID; it does not expand an interval into one oversized wire item. GC
+  retains the physical change owners needed for lazy reconstruction.
+- Checkpoint publication only records durable GC debt and coalesces a background
+  task. Repository-scale planning happens without the foreground session gate;
+  scale-dependent adapter batch construction happens before the serialized
+  writer lane, foreground publications have writer-admission priority, and the
+  final maintenance write uses storage preconditions. Conflict replanning is
+  capped at three exponentially delayed attempts so sustained writes cannot
+  create an unbounded full-repository retry loop.
+- Tombstone compaction is background repository maintenance. The foreground
+  path rotates a bounded epoch and does not enumerate tombstones. Maintenance
+  prefilters compactable tombstones and admits at most 32 rows per pass, so a
+  permanently ineligible prefix cannot starve later candidates or build an
+  oversized put batch.
+- Repository retirement publications admit at most 4,000 mutations and 3 MiB
+  of values. Wide commits first drain owner-local locators, then persist a
+  restartable child-delete intent inventory while their trees are intact.
+  Later passes revalidate shared content hashes against the current live
+  closure, drain target/intent pairs under the cap, and delete manifest
+  authority last.
+
+These cuts preserve the checkpoint as the working-diff and undo floor while
+keeping history, branch, sync, crash/reopen, and adapter behavior intact.

--- a/docs/checkpoints.md
+++ b/docs/checkpoints.md
@@ -112,3 +112,7 @@ is not implicit, so request it explicitly.
 These surfaces are read-only. Create a checkpoint for every working diff
 through `lix.createCheckpoint()`, or checkpoint a SQL-selected subset
 through `lix_create_checkpoint`. See [Diff commands](./diff-commands.md).
+
+The foreground publication path has fixed storage, allocation, payload, and
+latency regression gates. See the reproducible
+[checkpoint performance qualification](./checkpoint-performance.md).

--- a/packages/e2e/Cargo.toml
+++ b/packages/e2e/Cargo.toml
@@ -370,6 +370,14 @@ path = "benches/checkpoint_history_scale.rs"
 harness = false
 required-features = ["storage-benches", "slatedb"]
 
+# Kept beside the checkpoint implementation while the profile report and
+# harness evolve together; this e2e target supplies the real storage adapters.
+[[bench]]
+name = "profile_checkpoint_scale"
+path = "../lix/benches/profile_checkpoint_scale.rs"
+harness = false
+required-features = ["storage-benches", "slatedb"]
+
 
 [[bench]]
 name = "merge_base_scale"

--- a/packages/e2e/benches/branch_storage_sharing.rs
+++ b/packages/e2e/benches/branch_storage_sharing.rs
@@ -1,3 +1,5 @@
+#![recursion_limit = "256"]
+
 //! How much storage do two branches actually share?
 //!
 //! Seeds a realistic workspace through the real `SessionContext` SQL commit

--- a/packages/e2e/benches/fixed_live_history_scale.rs
+++ b/packages/e2e/benches/fixed_live_history_scale.rs
@@ -1,4 +1,5 @@
 #![allow(clippy::large_futures)]
+#![recursion_limit = "256"]
 
 use std::fmt::{self, Display, Formatter};
 use std::hint::black_box;

--- a/packages/e2e/benches/repository_gc_scale.rs
+++ b/packages/e2e/benches/repository_gc_scale.rs
@@ -1,3 +1,5 @@
+#![recursion_limit = "256"]
+
 use std::fmt::{self, Display, Formatter};
 use std::path::Path;
 use std::time::{Duration, Instant};

--- a/packages/e2e/benches/tracked_state_crud/main.rs
+++ b/packages/e2e/benches/tracked_state_crud/main.rs
@@ -1,4 +1,5 @@
 #![allow(clippy::large_futures)]
+#![recursion_limit = "256"]
 
 use std::time::{Duration, Instant};
 #[cfg(all(

--- a/packages/e2e/benches/tracked_working_diff.rs
+++ b/packages/e2e/benches/tracked_working_diff.rs
@@ -1,4 +1,5 @@
 #![allow(clippy::large_futures)]
+#![recursion_limit = "256"]
 
 //! Two-phase populated tracked-working-diff benchmark for storage adapters.
 //!

--- a/packages/e2e/benches/undo_redo_storage.rs
+++ b/packages/e2e/benches/undo_redo_storage.rs
@@ -1,4 +1,5 @@
 #![allow(clippy::large_futures)]
+#![recursion_limit = "256"]
 
 //! Destructive, real-backend undo/redo phase profiler.
 //!

--- a/packages/e2e/benches/working_diff_file_scope.rs
+++ b/packages/e2e/benches/working_diff_file_scope.rs
@@ -1,4 +1,5 @@
 #![allow(clippy::large_futures)]
+#![recursion_limit = "256"]
 
 //! Scaling harness for **file-scoped** working-diff reads.
 //!

--- a/packages/e2e/examples/branch_merge_benchmark.rs
+++ b/packages/e2e/examples/branch_merge_benchmark.rs
@@ -1,3 +1,5 @@
+#![recursion_limit = "256"]
+
 //! Isolated-process branching and merge qualification benchmark.
 //!
 //! Run the default qualification matrix and capture JSONL:

--- a/packages/e2e/examples/delta_segment_duplication.rs
+++ b/packages/e2e/examples/delta_segment_duplication.rs
@@ -1,3 +1,5 @@
+#![recursion_limit = "256"]
+
 //! How much of the settled repository is byte-identical duplicate content?
 //!
 //! The commit-delta segment plane is keyed `commit_id ++ segment_index`, not by

--- a/packages/e2e/examples/duplicate_audit.rs
+++ b/packages/e2e/examples/duplicate_audit.rs
@@ -1,3 +1,5 @@
+#![recursion_limit = "256"]
+
 //! Content-addressed storage audit: does lix store the same bytes twice?
 //!
 //! `storage_layout` answers "how many rows and bytes does each space hold".

--- a/packages/e2e/examples/e16_write_file_scaling.rs
+++ b/packages/e2e/examples/e16_write_file_scaling.rs
@@ -1,3 +1,5 @@
+#![recursion_limit = "256"]
+
 //! Why does a single write cost 30x more in a 10,000-file repository than in a
 //! 100-file one, while writing the same handful of rows?
 //!

--- a/packages/e2e/examples/e53_hot_locality.rs
+++ b/packages/e2e/examples/e53_hot_locality.rs
@@ -1,3 +1,5 @@
+#![recursion_limit = "256"]
+
 //! Does retiring a *fixed* amount of hot-generation garbage cost more as the
 //! repository grows?
 //!

--- a/packages/e2e/examples/e53_hot_locality_slatedb.rs
+++ b/packages/e2e/examples/e53_hot_locality_slatedb.rs
@@ -1,3 +1,5 @@
+#![recursion_limit = "256"]
+
 //! `e53_hot_locality`, on SlateDB, where a block fetch is an object-store GET.
 //!
 //! The RocksDB run of this experiment found the eight-space layout costs eight

--- a/packages/e2e/examples/e53_write_amplification.rs
+++ b/packages/e2e/examples/e53_write_amplification.rs
@@ -1,3 +1,5 @@
+#![recursion_limit = "256"]
+
 //! Does a commit's physical write cost grow with repository size?
 //!
 //! A probe replay of `stage_retire_hot_generation` against a branch's live

--- a/packages/e2e/examples/expW_hot_row_anatomy.rs
+++ b/packages/e2e/examples/expW_hot_row_anatomy.rs
@@ -1,3 +1,5 @@
+#![recursion_limit = "256"]
+
 //! Anatomy of a `hot_state.row.v21` row, and what two branches share.
 //!
 //! Experiment T attributed 95.4% of the two-branch storage delta to

--- a/packages/e2e/examples/expY_untracked_mutation_scaling.rs
+++ b/packages/e2e/examples/expY_untracked_mutation_scaling.rs
@@ -1,3 +1,5 @@
+#![recursion_limit = "256"]
+
 //! Does one untracked mutation cost O(1) or O(total untracked rows)?
 //!
 //! `HotWriter::stage_untracked_generation` (`hot_state/tracked_head/hot.rs`)

--- a/packages/e2e/examples/expaa_replay_scope.rs
+++ b/packages/e2e/examples/expaa_replay_scope.rs
@@ -1,3 +1,5 @@
+#![recursion_limit = "256"]
+
 //! Commit-root replay scope and cost attribution (experiment AA).
 //!
 //! Tracked-state root materialization is bursty: ordinary commits are

--- a/packages/e2e/examples/expab_plan_load.rs
+++ b/packages/e2e/examples/expab_plan_load.rs
@@ -1,3 +1,5 @@
+#![recursion_limit = "256"]
+
 //! Commit-root rebuild plan-load attribution (experiment AB).
 //!
 //! Experiment AA measured that 83% of commit-root replay time is spent inside

--- a/packages/e2e/examples/expfk_directory_delete_scan.rs
+++ b/packages/e2e/examples/expfk_directory_delete_scan.rs
@@ -1,3 +1,5 @@
+#![recursion_limit = "256"]
+
 //! Cost of the foreign-key delete restriction on a directory delete, as a
 //! function of how many files the branch holds.
 //!

--- a/packages/e2e/examples/exppth2_txn_probe.rs
+++ b/packages/e2e/examples/exppth2_txn_probe.rs
@@ -1,3 +1,5 @@
+#![recursion_limit = "256"]
+
 //! EXPPTH2: does batching content updates into ONE explicit transaction
 //! collapse the per-statement O(repository size) term?
 //!

--- a/packages/e2e/examples/expu_json_delta.rs
+++ b/packages/e2e/examples/expu_json_delta.rs
@@ -1,3 +1,5 @@
+#![recursion_limit = "256"]
+
 //! Does delta encoding pay for the content-addressed JSON store?
 //!
 //! `duplicate_audit` established that `json_store.json` is full of *near*

--- a/packages/e2e/examples/expv_blind_space_growth.rs
+++ b/packages/e2e/examples/expv_blind_space_growth.rs
@@ -1,3 +1,5 @@
+#![recursion_limit = "256"]
+
 //! Growth curves for the storage spaces layout accounting could not see.
 //!
 //! Before PR #1308 `native_storage_spaces()` enumerated 32 of 46 physical

--- a/packages/e2e/examples/space_growth.rs
+++ b/packages/e2e/examples/space_growth.rs
@@ -1,3 +1,5 @@
+#![recursion_limit = "256"]
+
 //! Per-space physical growth across a real multi-commit history.
 //!
 //! `storage_layout` reports one snapshot of a fixture that some other tool

--- a/packages/e2e/tests/checkpoint_gc_replay_reopen.rs
+++ b/packages/e2e/tests/checkpoint_gc_replay_reopen.rs
@@ -1,3 +1,5 @@
+#![recursion_limit = "256"]
+
 use std::future::Future;
 use std::path::Path;
 use std::time::Duration;

--- a/packages/e2e/tests/crash_consistency_qualification.rs
+++ b/packages/e2e/tests/crash_consistency_qualification.rs
@@ -1,3 +1,5 @@
+#![recursion_limit = "256"]
+
 //! Crash-consistency qualification: kill a real writer process with SIGKILL at
 //! every point of the publication window, then reopen the store in a fresh
 //! process and prove the invariants still hold.

--- a/packages/e2e/tests/exact_file_read_benchmark.rs
+++ b/packages/e2e/tests/exact_file_read_benchmark.rs
@@ -1,3 +1,5 @@
+#![recursion_limit = "256"]
+
 //! Manual benchmark for warmed exact `lix_file` reads through the public session API.
 //!
 //! Run with:

--- a/packages/e2e/tests/realtime_collaboration_capacity.rs
+++ b/packages/e2e/tests/realtime_collaboration_capacity.rs
@@ -1,3 +1,5 @@
+#![recursion_limit = "256"]
+
 //! Client-observed real-time collaboration capacity workload.
 //!
 //! The ignored release-mode benchmark models 50-100 active collaborators on

--- a/packages/e2e/tests/scan_key_buffer_census.rs
+++ b/packages/e2e/tests/scan_key_buffer_census.rs
@@ -64,7 +64,9 @@ async fn a_scan_allocates_far_fewer_key_buffers_than_it_returns_rows() {
     .await
     .expect("register census schema");
 
-    for chunk in (0..ROWS).collect::<Vec<_>>().chunks(1_000) {
+    // Stay below the per-transaction packed-base admission threshold so the
+    // measured read remains a full hot-state prefix scan.
+    for chunk in (0..ROWS).collect::<Vec<_>>().chunks(256) {
         let mut sql = format!("INSERT INTO {SCHEMA_KEY} (id, ordinal) VALUES ");
         let mut params = Vec::new();
         for (offset, ordinal) in chunk.iter().enumerate() {
@@ -82,11 +84,10 @@ async fn a_scan_allocates_far_fewer_key_buffers_than_it_returns_rows() {
             "a seed statement that affects no rows produces the same zero counters as a route that never ran"
         );
     }
-    lix.create_checkpoint()
-        .await
-        .expect("drive the census fixture to packed-base steady state");
-
-    // Discard everything the seed and the checkpoint scanned.
+    // Keep the fixture on the explicit hot-scan route. O(1) checkpoints no
+    // longer materialize a packed base, so checkpointing here would make the
+    // query bypass the per-row key scan this census is designed to measure.
+    // Discard everything the seed scanned.
     let _ = take_scan_key_buffer_census();
     let _ = take_hot_scan_refcount_census();
 
@@ -102,29 +103,28 @@ async fn a_scan_allocates_far_fewer_key_buffers_than_it_returns_rows() {
 
     let (allocations, allocated_bytes) = take_scan_key_buffer_census();
     let (rows_decoded, ..) = take_hot_scan_refcount_census();
-
-    // A zero here is indistinguishable from a census that never fired.
     assert!(
         rows_decoded >= ROWS as u64,
-        "hot scan decoded {rows_decoded} rows for a {ROWS}-row answer; the scan route was not taken"
+        "hot scan decoded {rows_decoded} rows for a {ROWS}-row answer; the measured route was not taken"
     );
+    let census_rows = rows_decoded;
     assert!(
         allocations > 0,
         "no key buffer allocation was recorded, and the census is compiled in, so the RocksDB \
          scan source genuinely did not serve this scan"
     );
 
-    let per_row = allocations as f64 / rows_decoded as f64;
+    let per_row = allocations as f64 / census_rows as f64;
     println!(
-        "SCAN_KEY_BUFFER_CENSUS rows_decoded={rows_decoded} allocations={allocations} \
+        "SCAN_KEY_BUFFER_CENSUS rows_decoded={rows_decoded} census_rows={census_rows} allocations={allocations} \
          ({per_row:.5}/row) allocated_bytes={allocated_bytes} \
          bytes_per_row={:.1}",
-        allocated_bytes as f64 / rows_decoded as f64
+        allocated_bytes as f64 / census_rows as f64
     );
 
     assert!(
         per_row <= MAX_ALLOCATIONS_PER_ROW,
-        "scan allocated {allocations} key buffers for {rows_decoded} decoded rows \
+        "scan allocated {allocations} key buffers for {census_rows} result rows \
          ({per_row:.5}/row, ceiling {MAX_ALLOCATIONS_PER_ROW:.5}/row); \
          a per-row key copy scores 1.00000"
     );

--- a/packages/e2e/tests/tracked_state_crud_public_result.rs
+++ b/packages/e2e/tests/tracked_state_crud_public_result.rs
@@ -1,3 +1,5 @@
+#![recursion_limit = "256"]
+
 // This parity test includes the benchmark-only fixture modules directly.
 // Most of their CRUD helpers are intentionally unused by this one focused
 // assertion.

--- a/packages/js-sdk/src/remote/client.test.ts
+++ b/packages/js-sdk/src/remote/client.test.ts
@@ -17,7 +17,7 @@ test("Lix Server Protocol handshake requests a restored initial active branch", 
 					return new Response(null, { status: 204 });
 				}
 				return Response.json({
-					protocolVersion: 2,
+					protocolVersion: 3,
 					activeBranchId: "draft / one",
 					activeAccountId: accountId,
 					sessionId: "session-1",
@@ -55,7 +55,7 @@ test("openAnotherSession creates an independent remote protocol session", async 
 					return new Response(null, { status: 204 });
 				handshakes.push(request);
 				return Response.json({
-					protocolVersion: 2,
+					protocolVersion: 3,
 					activeBranchId:
 						new URL(request.url).searchParams.get("activeBranchId") ??
 						"main-id",
@@ -99,7 +99,7 @@ test("openAnotherSession rejects and closes a remote identity mismatch", async (
 				}
 				handshake += 1;
 				return Response.json({
-					protocolVersion: 2,
+					protocolVersion: 3,
 					activeBranchId: "main-id",
 					activeAccountId: handshake === 1 ? "account-a" : "account-b",
 					sessionId: `session-${handshake}`,
@@ -134,7 +134,7 @@ test("remote mode uses the repository protocol without loading a local engine", 
 			requests.push(request);
 			if (new URL(request.url).pathname.endsWith("/lix/v1/")) {
 				return Response.json({
-					protocolVersion: 2,
+					protocolVersion: 3,
 					activeBranchId: "main-id",
 					activeAccountId: "00000000-0000-7000-8000-000000000002",
 					sessionId: "session-1",
@@ -239,7 +239,7 @@ test("remote mode compresses only large compressible JSON requests", async () =>
 				const pathname = new URL(request.url).pathname;
 				if (pathname.endsWith("/lix/v1/")) {
 					return Response.json({
-						protocolVersion: 2,
+						protocolVersion: 3,
 						activeBranchId: "main-id",
 						activeAccountId: "00000000-0000-7000-8000-000000000002",
 						sessionId: "session-1",
@@ -306,7 +306,7 @@ test("remote executeBatch uses the first-class atomic batch endpoint", async () 
 				requests.push(request.clone());
 				return new URL(request.url).pathname.endsWith("/lix/v1/")
 					? Response.json({
-							protocolVersion: 2,
+							protocolVersion: 3,
 							activeBranchId: "main-id",
 							activeAccountId: "00000000-0000-7000-8000-000000000002",
 							sessionId: "session-1",
@@ -591,7 +591,7 @@ test("remote execute keeps small and low-saving blob updates full", async () => 
 	expect(bodies[2]).not.toHaveProperty("cacheBlobs");
 });
 
-test("Lix Server Protocol v2 uses blob splices without capability negotiation", async () => {
+test("Lix Server Protocol v3 uses blob splices without capability negotiation", async () => {
 	const bodies: Array<Record<string, unknown>> = [];
 	const lix = await openLix({
 		server: {
@@ -602,7 +602,7 @@ test("Lix Server Protocol v2 uses blob splices without capability negotiation", 
 				const pathname = new URL(request.url).pathname;
 				if (pathname.endsWith("/lix/v1/")) {
 					return Response.json({
-						protocolVersion: 2,
+						protocolVersion: 3,
 						activeBranchId: "main-id",
 						activeAccountId: "00000000-0000-7000-8000-000000000002",
 						sessionId: "session-1",
@@ -689,7 +689,7 @@ test("remote branches preserve local Lix branch semantics", async () => {
 				const pathname = new URL(request.url).pathname;
 				if (pathname.endsWith("/lix/v1/")) {
 					return Response.json({
-						protocolVersion: 2,
+						protocolVersion: 3,
 						activeBranchId,
 						activeAccountId: "00000000-0000-7000-8000-000000000002",
 						sessionId: "session-1",
@@ -745,7 +745,7 @@ test("remote createCheckpoint posts no body and decodes the receipt", async () =
 				const pathname = new URL(request.url).pathname;
 				if (pathname.endsWith("/lix/v1/")) {
 					return Response.json({
-						protocolVersion: 2,
+						protocolVersion: 3,
 						activeBranchId: "main-id",
 						activeAccountId: "00000000-0000-7000-8000-000000000002",
 						sessionId: "session-1",
@@ -787,7 +787,7 @@ test("remote lix_restore uses the existing execute endpoint", async () => {
 				const pathname = new URL(request.url).pathname;
 				if (pathname.endsWith("/lix/v1/")) {
 					return Response.json({
-						protocolVersion: 2,
+						protocolVersion: 3,
 						activeBranchId: "main-id",
 						activeAccountId: "00000000-0000-7000-8000-000000000002",
 						sessionId: "session-1",
@@ -835,7 +835,7 @@ test("remote undo and redo decode branch-history receipts", async () => {
 				const pathname = new URL(request.url).pathname;
 				if (pathname.endsWith("/lix/v1/")) {
 					return Response.json({
-						protocolVersion: 2,
+						protocolVersion: 3,
 						activeBranchId: "main-id",
 						activeAccountId: "00000000-0000-7000-8000-000000000002",
 						sessionId: "session-1",
@@ -891,7 +891,7 @@ test("a failed remote branch switch leaves the active branch unchanged", async (
 				if (pathname.endsWith("/lix/v1/")) {
 					handshakeCalls += 1;
 					return Response.json({
-						protocolVersion: 2,
+						protocolVersion: 3,
 						activeBranchId: "main-id",
 						activeAccountId: "00000000-0000-7000-8000-000000000002",
 						sessionId: "session-1",
@@ -944,7 +944,7 @@ test("an ambiguous remote branch switch is reconciled by the next branch read", 
 				if (pathname.endsWith("/lix/v1/")) {
 					handshakeCalls += 1;
 					return Response.json({
-						protocolVersion: 2,
+						protocolVersion: 3,
 						activeBranchId,
 						activeAccountId: "00000000-0000-7000-8000-000000000002",
 						sessionId: "session-1",
@@ -986,7 +986,7 @@ test("branch reconciliation rejects and never caches a replacement session", asy
 				if (pathname.endsWith("/lix/v1/")) {
 					handshakeCalls += 1;
 					return Response.json({
-						protocolVersion: 2,
+						protocolVersion: 3,
 						activeBranchId: "draft-id",
 						activeAccountId: "00000000-0000-7000-8000-000000000002",
 						sessionId: handshakeCalls === 1 ? "session-1" : "session-2",
@@ -1031,7 +1031,7 @@ test("remote clients retain independent active branches", async () => {
 				activeBranches.set(sessionId, "main-id");
 			}
 			return Response.json({
-				protocolVersion: 2,
+				protocolVersion: 3,
 				activeBranchId: activeBranches.get(sessionId),
 				activeAccountId: "00000000-0000-7000-8000-000000000002",
 				sessionId,
@@ -1083,7 +1083,7 @@ test("remote operations preserve normal Lix call ordering", async () => {
 				const pathname = new URL(request.url).pathname;
 				if (pathname.endsWith("/lix/v1/")) {
 					return Response.json({
-						protocolVersion: 2,
+						protocolVersion: 3,
 						activeBranchId: "main-id",
 						activeAccountId: "00000000-0000-7000-8000-000000000002",
 						sessionId: "session-1",
@@ -1142,7 +1142,7 @@ test("remote responses reject malformed rows and non-JSON HTTP errors", async ()
 				const pathname = new URL(request.url).pathname;
 				if (pathname.endsWith("/lix/v1/")) {
 					return Response.json({
-						protocolVersion: 2,
+						protocolVersion: 3,
 						activeBranchId: "main-id",
 						activeAccountId: "00000000-0000-7000-8000-000000000002",
 						sessionId: "session-1",
@@ -1204,7 +1204,7 @@ test("remote beginTransaction uses one capability-bound server lifecycle", async
 				});
 				if (path.endsWith("/lix/v1/")) {
 					return Response.json({
-						protocolVersion: 2,
+						protocolVersion: 3,
 						activeBranchId: "main-id",
 						activeAccountId: "00000000-0000-7000-8000-000000000002",
 						sessionId: "session-1",
@@ -1275,7 +1275,7 @@ test("remote mode rejects unsupported local-only operations honestly", async () 
 			url: "https://lixray.test/@acme/repository",
 			fetch: (async () =>
 				Response.json({
-					protocolVersion: 2,
+					protocolVersion: 3,
 					activeBranchId: "main-id",
 					activeAccountId: "00000000-0000-7000-8000-000000000002",
 					sessionId: "session-1",
@@ -1323,7 +1323,7 @@ test.each([undefined, "", " contains-space", "contains\nnewline", 42])(
 					url: "https://lixray.test/repository",
 					fetch: (async () =>
 						Response.json({
-							protocolVersion: 2,
+							protocolVersion: 3,
 							activeBranchId: "main-id",
 							activeAccountId: "00000000-0000-7000-8000-000000000002",
 							sessionId,
@@ -1347,7 +1347,7 @@ test("active branch reads reuse the initial handshake without another GET", asyn
 				}
 				handshakeCalls += 1;
 				return Response.json({
-					protocolVersion: 2,
+					protocolVersion: 3,
 					activeBranchId: "main-id",
 					activeAccountId: "00000000-0000-7000-8000-000000000002",
 					sessionId: "session-1",
@@ -1381,7 +1381,7 @@ test("execute recovers a gone protocol session once by opening a new handshake",
 					}
 					nextSession += 1;
 					return Response.json({
-						protocolVersion: 2,
+						protocolVersion: 3,
 						activeBranchId: "main-id",
 						activeAccountId: "00000000-0000-7000-8000-000000000002",
 						sessionId: `session-${nextSession}`,
@@ -1450,7 +1450,7 @@ test("execute recovers a closed protocol server once then retries with the new s
 				if (pathname.endsWith("/lix/v1/")) {
 					sessionIds.push(request.headers.get("lix-session-id"));
 					return Response.json({
-						protocolVersion: 2,
+						protocolVersion: 3,
 						activeBranchId: "main-id",
 						activeAccountId: "00000000-0000-7000-8000-000000000002",
 						sessionId:
@@ -1493,7 +1493,7 @@ test("a second gone protocol session after recovery is not retried", async () =>
 					handshakeCalls += 1;
 					expect(request.headers.has("lix-session-id")).toBe(false);
 					return Response.json({
-						protocolVersion: 2,
+						protocolVersion: 3,
 						activeBranchId: "main-id",
 						activeAccountId: "00000000-0000-7000-8000-000000000002",
 						sessionId: `session-${handshakeCalls}`,
@@ -1542,7 +1542,7 @@ test("an active branch read adopts a new session after protocol session gone", a
 						handshakes.length === 0 ? "session-1" : "session-2";
 					handshakes.push({ sessionId: null, issuedSessionId });
 					return Response.json({
-						protocolVersion: 2,
+						protocolVersion: 3,
 						activeBranchId:
 							issuedSessionId === "session-1" ? "main-id" : "draft-id",
 						activeAccountId: "00000000-0000-7000-8000-000000000002",
@@ -1584,7 +1584,7 @@ test("an expired session mutation is propagated without a new handshake or retry
 				if (pathname.endsWith("/lix/v1/")) {
 					handshakeCalls += 1;
 					return Response.json({
-						protocolVersion: 2,
+						protocolVersion: 3,
 						activeBranchId: "main-id",
 						activeAccountId: "00000000-0000-7000-8000-000000000002",
 						sessionId: "session-1",
@@ -1631,7 +1631,7 @@ test("close waits for queued operations before deleting the remote session", asy
 				const pathname = new URL(request.url).pathname;
 				if (pathname.endsWith("/lix/v1/")) {
 					return Response.json({
-						protocolVersion: 2,
+						protocolVersion: 3,
 						activeBranchId: "main-id",
 						activeAccountId: "00000000-0000-7000-8000-000000000002",
 						sessionId: "session-1",
@@ -1668,7 +1668,7 @@ test("close waits for queued operations before deleting the remote session", asy
 
 function handshakeResponse() {
 	return Response.json({
-		protocolVersion: 2,
+		protocolVersion: 3,
 		activeBranchId: "main-id",
 		activeAccountId: "00000000-0000-7000-8000-000000000002",
 		sessionId: "session-1",

--- a/packages/js-sdk/src/remote/observe.test.ts
+++ b/packages/js-sdk/src/remote/observe.test.ts
@@ -652,7 +652,7 @@ test("remote observe reconnects after a gone protocol session instead of failing
 					}
 					nextSession += 1;
 					return Response.json({
-						protocolVersion: 2,
+						protocolVersion: 3,
 						activeBranchId: "main-id",
 						activeAccountId: "00000000-0000-7000-8000-000000000002",
 						sessionId: `session-${nextSession}`,
@@ -720,7 +720,7 @@ test("remote observe recovers multiple expired shards with one handshake", async
 				if (pathname.endsWith("/lix/v1/")) {
 					handshakeCalls += 1;
 					return Response.json({
-						protocolVersion: 2,
+						protocolVersion: 3,
 						activeBranchId: "main-id",
 						activeAccountId: "00000000-0000-7000-8000-000000000002",
 						sessionId: `session-${handshakeCalls}`,
@@ -813,7 +813,7 @@ test("remote observe fails if the recovered protocol session is also gone", asyn
 						handshakeCalls += 1;
 						expect(request.headers.has("lix-session-id")).toBe(false);
 						return Response.json({
-							protocolVersion: 2,
+							protocolVersion: 3,
 							activeBranchId: "main-id",
 							activeAccountId: "00000000-0000-7000-8000-000000000002",
 							sessionId: `session-${handshakeCalls}`,
@@ -979,7 +979,7 @@ test("closing Lix stops observations before an earlier finite request settles", 
 
 function handshake(): Response {
 	return Response.json({
-		protocolVersion: 2,
+		protocolVersion: 3,
 		activeBranchId: "main-id",
 		activeAccountId: "00000000-0000-7000-8000-000000000002",
 		sessionId: "session-1",

--- a/packages/js-sdk/src/remote/server-protocol.ts
+++ b/packages/js-sdk/src/remote/server-protocol.ts
@@ -4,7 +4,7 @@ import type {
 } from "../binding-types.js";
 import type { NativeLixValue } from "../value.js";
 
-export const SERVER_PROTOCOL_VERSION = 2;
+export const SERVER_PROTOCOL_VERSION = 3;
 export const SERVER_PROTOCOL_PATH = "/lix/v1/";
 
 export type WireValue =

--- a/packages/lix/benches/profile_checkpoint_scale.rs
+++ b/packages/lix/benches/profile_checkpoint_scale.rs
@@ -9,18 +9,24 @@
 //! GC is identified from the engine's post-collection tracing event, without
 //! assuming a maintenance cadence or classifying by latency.
 //!
-//! cargo bench -p lix --bench profile_checkpoint_scale \
-//!   --features checkpoint_backends -- \
+//! cargo bench --manifest-path packages/e2e/Cargo.toml \
+//!   --bench profile_checkpoint_scale --features storage-benches,slatedb -- \
 //!   setup rocksdb /tmp/checkpoint-rocks-seed 10000
 //! cp -a /tmp/checkpoint-rocks-seed /tmp/checkpoint-rocks-run
-//! cargo bench -p lix --bench profile_checkpoint_scale \
-//!   --features checkpoint_backends -- \
+//! cargo bench --manifest-path packages/e2e/Cargo.toml \
+//!   --bench profile_checkpoint_scale --features storage-benches,slatedb -- \
 //!   run rocksdb /tmp/checkpoint-rocks-run 1000 10 5
 
 use async_trait::async_trait;
-use lix::{ExecuteBatchStatement, Lix, Storage, Value, open_lix};
+use lix::storage::Storage;
+use lix::storage_bench::{
+    CheckpointForegroundAccounting, checkpoint_foreground_is_active, measure_checkpoint_foreground,
+};
+use lix::{ExecuteBatchStatement, Lix, Value, open_lix};
 use lix_storage_rocksdb::RocksDB;
 use lix_storage_slatedb::SlateDB;
+use std::alloc::{GlobalAlloc, Layout, System};
+use std::cell::Cell;
 use std::collections::BTreeMap;
 use std::fmt::Write as _;
 use std::fs;
@@ -43,6 +49,75 @@ const FILE_BYTES: usize = 256;
 // bounded opportunity to run before validating/reopening the fixture. This is
 // outside the measured checkpoint latency window.
 const BACKGROUND_GC_SETTLE_MILLIS: u64 = 5_000;
+
+// These are architectural ceilings, not values derived from a particular
+// fixture. Any scale dimension that leaks into publication should break an
+// operation, payload, or allocation gate before timing noise can hide it.
+const MAX_FOREGROUND_READ_VIEWS: u64 = 8;
+const MAX_FOREGROUND_POINT_BATCHES: u64 = 80;
+const MAX_FOREGROUND_POINT_KEYS: u64 = 80;
+const MAX_FOREGROUND_SCAN_STARTS: u64 = 4;
+const MAX_FOREGROUND_SCAN_PAGES: u64 = 4;
+const MAX_FOREGROUND_SCAN_ROWS: u64 = 48;
+const MAX_FOREGROUND_WRITE_TRANSACTIONS: u64 = 1;
+const MAX_FOREGROUND_WRITE_CALLS: u64 = 20;
+const MAX_FOREGROUND_WRITTEN_RECORDS: u64 = 32;
+const MAX_FOREGROUND_WRITTEN_BYTES: u64 = 64 * 1024;
+const MAX_FOREGROUND_ALLOCATIONS: u64 = 24_576;
+const MAX_FOREGROUND_ALLOCATED_BYTES: u64 = 3 * 1024 * 1024;
+const MAX_CHECKPOINT_P99_MILLIS: f64 = 25.0;
+const MAX_CHECKPOINT_MILLIS: f64 = 100.0;
+const MAX_INTERVAL_WRITE_P99_MILLIS: f64 = 100.0;
+const MAX_INTERVAL_WRITE_MILLIS: f64 = 500.0;
+const MAX_DEPTH_P95_RATIO: f64 = 2.0;
+const MAX_DEPTH_P95_ADDITIVE_MILLIS: f64 = 2.0;
+
+struct CountingAllocator;
+
+thread_local! {
+    static ALLOCATION_CALLS: Cell<u64> = const { Cell::new(0) };
+    static ALLOCATED_BYTES: Cell<u64> = const { Cell::new(0) };
+}
+
+#[global_allocator]
+static GLOBAL_ALLOCATOR: CountingAllocator = CountingAllocator;
+
+unsafe impl GlobalAlloc for CountingAllocator {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        if checkpoint_foreground_is_active() {
+            ALLOCATION_CALLS.with(|calls| calls.set(calls.get() + 1));
+            ALLOCATED_BYTES.with(|bytes| bytes.set(bytes.get() + layout.size() as u64));
+        }
+        // SAFETY: this allocator delegates the unchanged layout to `System`.
+        unsafe { System.alloc(layout) }
+    }
+
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+        // SAFETY: `ptr` came from the delegated `System` allocation above.
+        unsafe { System.dealloc(ptr, layout) }
+    }
+
+    unsafe fn realloc(&self, ptr: *mut u8, layout: Layout, new_size: usize) -> *mut u8 {
+        if checkpoint_foreground_is_active() {
+            ALLOCATION_CALLS.with(|calls| calls.set(calls.get() + 1));
+            ALLOCATED_BYTES.with(|bytes| bytes.set(bytes.get() + new_size as u64));
+        }
+        // SAFETY: arguments are forwarded unchanged to `System`.
+        unsafe { System.realloc(ptr, layout, new_size) }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Default)]
+struct AllocationAccounting {
+    calls: u64,
+    bytes: u64,
+}
+
+#[derive(Clone, Copy, Debug, Default)]
+struct ForegroundAccounting {
+    storage: CheckpointForegroundAccounting,
+    allocations: AllocationAccounting,
+}
 
 #[derive(Clone, Copy, Debug)]
 enum Backend {
@@ -90,7 +165,8 @@ fn main() {
     match mode {
         "setup" => {
             let file_count = parse_usize(args.get(4), DEFAULT_FILE_COUNT, "file count");
-            runtime.block_on(setup_backend(backend, &path, file_count));
+            let branch_count = parse_usize(args.get(5), 0, "branch count");
+            runtime.block_on(setup_backend(backend, &path, file_count, branch_count));
         }
         "run" => {
             let checkpoint_count =
@@ -122,7 +198,7 @@ fn main() {
 
 fn print_usage() {
     eprintln!(
-        "usage:\n  profile_checkpoint_scale setup <rocksdb|slatedb> <storage-dir> [files]\n  \
+        "usage:\n  profile_checkpoint_scale setup <rocksdb|slatedb> <storage-dir> [files] [branches]\n  \
          profile_checkpoint_scale run <rocksdb|slatedb> <storage-dir> \
          [checkpoints] [files-per-checkpoint] \
          [auto-commits-per-checkpoint]\n  \
@@ -277,19 +353,19 @@ impl Visit for GcObservationVisitor {
     }
 }
 
-async fn setup_backend(backend: Backend, path: &Path, file_count: usize) {
+async fn setup_backend(backend: Backend, path: &Path, file_count: usize, branch_count: usize) {
     assert!(
         !path.exists(),
         "refusing to overwrite existing fixture {}",
         path.display()
     );
     match backend {
-        Backend::RocksDb => setup_fixture::<RocksDB>(path, file_count).await,
-        Backend::SlateDb => setup_fixture::<SlateDB>(path, file_count).await,
+        Backend::RocksDb => setup_fixture::<RocksDB>(path, file_count, branch_count).await,
+        Backend::SlateDb => setup_fixture::<SlateDB>(path, file_count, branch_count).await,
     }
 }
 
-async fn setup_fixture<S>(path: &Path, file_count: usize)
+async fn setup_fixture<S>(path: &Path, file_count: usize, branch_count: usize)
 where
     S: BenchmarkStorage,
 {
@@ -305,11 +381,19 @@ where
         let batch_end = (batch_start + SEED_BATCH_SIZE).min(file_count);
         insert_file_batch(&lix, batch_start, batch_end).await;
     }
+    let starting_branch_count =
+        scalar_count(&lix, "SELECT count(*) AS count FROM lix_branch").await;
+    for batch_start in (0..branch_count).step_by(SEED_BATCH_SIZE) {
+        let batch_end = (batch_start + SEED_BATCH_SIZE).min(branch_count);
+        insert_branch_batch(&lix, batch_start, batch_end).await;
+    }
+    assert_eq!(
+        scalar_count(&lix, "SELECT count(*) AS count FROM lix_branch").await,
+        starting_branch_count + branch_count,
+    );
     let seed_elapsed = setup_start.elapsed();
     let checkpoint_start = Instant::now();
-    lix.create_checkpoint()
-        .await
-        .expect("compact initial checkpoint");
+    let initial_foreground = profile_checkpoint_phase(&lix).await;
     let initial_checkpoint_elapsed = checkpoint_start.elapsed();
     assert_eq!(
         scalar_count(&lix, "SELECT count(*) AS count FROM lix_file").await,
@@ -328,19 +412,44 @@ where
     drop(storage);
     let after_close = physical_stats(path);
     println!(
-        "setup backend={} files={file_count} seed_ms={:.3} \
+        "setup backend={} files={file_count} branches={branch_count} seed_ms={:.3} \
          initial_checkpoint_ms={:.3} backend_flush_ms={:.3} \
-         storage_bytes_after_flush={} storage_files_after_flush={} \
+         foreground={} storage_bytes_after_flush={} storage_files_after_flush={} \
          storage_bytes_after_close={} storage_files_after_close={}",
         S::NAME,
         millis(seed_elapsed),
         millis(initial_checkpoint_elapsed),
         millis(flush_elapsed),
+        format_foreground(initial_foreground),
         after_flush.storage_bytes,
         after_flush.storage_files,
         after_close.storage_bytes,
         after_close.storage_files,
     );
+}
+
+async fn insert_branch_batch<S>(lix: &Lix<S>, start: usize, end: usize)
+where
+    S: BenchmarkStorage,
+{
+    let row_count = end - start;
+    let mut sql = String::from("INSERT INTO lix_branch (id, name) VALUES ");
+    let mut params = Vec::with_capacity(row_count * 2);
+    for (offset, branch_index) in (start..end).enumerate() {
+        if offset > 0 {
+            sql.push(',');
+        }
+        let parameter = offset * 2;
+        write!(sql, "(${}, ${})", parameter + 1, parameter + 2)
+            .expect("write branch parameter placeholders");
+        params.push(Value::Text(format!(
+            "10000000-0000-7000-8000-{branch_index:012x}"
+        )));
+        params.push(Value::Text(format!("benchmark-branch-{branch_index:05}")));
+    }
+    lix.execute(&sql, &params)
+        .await
+        .expect("insert checkpoint benchmark branches");
 }
 
 async fn insert_file_batch<S>(lix: &Lix<S>, start: usize, end: usize)
@@ -443,6 +552,8 @@ async fn run_workload<S>(
     let files_per_auto_commit = files_per_checkpoint / auto_commits_per_checkpoint;
     let mut write_latencies = Vec::with_capacity(checkpoint_count);
     let mut checkpoint_latencies = Vec::with_capacity(checkpoint_count);
+    let mut contention_probe_latencies = Vec::with_capacity(checkpoint_count);
+    let mut foreground_accounting = Vec::with_capacity(checkpoint_count * 2);
     let mut observed_background_gc_latencies = Vec::new();
     let mut backend_flush_latencies = Vec::new();
     gc_observer.clear();
@@ -467,20 +578,33 @@ async fn run_workload<S>(
         }
         let write_elapsed = write_start.elapsed();
         let checkpoint_start = Instant::now();
-        profile_checkpoint_phase(&lix).await;
+        let foreground = profile_checkpoint_phase(&lix).await;
         let checkpoint_elapsed = checkpoint_start.elapsed();
         write_latencies.push(write_elapsed);
         checkpoint_latencies.push(checkpoint_elapsed);
+        foreground_accounting.push(foreground);
+        // Let maintenance scheduled by the just-published checkpoint start
+        // outside its timer. The direct probe below measures real adapter and
+        // commit-coordinator contention before any ordinary write can absorb
+        // the wait.
+        tokio::task::yield_now().await;
+        // Start a checkpoint directly after maintenance receives a scheduling
+        // opportunity. Ordinary interval writes must not absorb an exclusive
+        // adapter-writer wait before the checkpoint timer starts.
+        let contention_probe_start = Instant::now();
+        let contention_foreground = profile_checkpoint_phase(&lix).await;
+        contention_probe_latencies.push(contention_probe_start.elapsed());
+        foreground_accounting.push(contention_foreground);
         for gc in gc_observer.drain() {
             observed_background_gc_latencies.push(Duration::from_micros(gc.gc_total_us));
             println!(
                 "observed_background_gc backend={} observed_after_checkpoint_index={checkpoint_index} \
-                 visible_checkpoint_count={} gc_total_ms={:.3} \
+                visible_checkpoint_count={} gc_total_ms={:.3} \
                  swept_commits={} swept_changes={} swept_tracked_roots={} \
                  root_discovery_ms={:.3} changelog_ms={:.3} \
                  tracked_root_stage_ms={:.3} gc_total_ms={:.3}",
                 S::NAME,
-                starting_checkpoint_count + checkpoint_index,
+                starting_checkpoint_count + checkpoint_index * 2,
                 micros_to_millis(gc.gc_total_us),
                 gc.swept_commits,
                 gc.swept_changes,
@@ -489,6 +613,10 @@ async fn run_workload<S>(
                 micros_to_millis(gc.changelog_us),
                 micros_to_millis(gc.tracked_root_stage_us),
                 micros_to_millis(gc.gc_total_us),
+            );
+            println!(
+                "foreground checkpoint_index={checkpoint_index} {}",
+                format_foreground(foreground)
             );
         }
         if is_milestone(checkpoint_index, checkpoint_count) {
@@ -501,7 +629,7 @@ async fn run_workload<S>(
             println!(
                 "{checkpoint_index},{},{file_count},{},{:.3},{:.3},{:.3},{},{}",
                 S::NAME,
-                starting_checkpoint_count + checkpoint_index,
+                starting_checkpoint_count + checkpoint_index * 2,
                 millis(write_elapsed),
                 millis(checkpoint_elapsed),
                 millis(flush_elapsed),
@@ -567,7 +695,7 @@ async fn run_workload<S>(
     let checkpoint_history_query_elapsed = checkpoint_history_query_start.elapsed();
     assert_eq!(
         visible_checkpoint_count,
-        starting_checkpoint_count + checkpoint_count,
+        starting_checkpoint_count + checkpoint_count * 2,
         "every requested checkpoint must remain visible"
     );
     let live_commits = scalar_count(&lix, "SELECT count(*) AS count FROM lix_commit").await;
@@ -601,23 +729,38 @@ async fn run_workload<S>(
 
     print_latency_summary("interval_write", &write_latencies);
     print_latency_summary("create_checkpoint", &checkpoint_latencies);
+    print_latency_summary(
+        "create_checkpoint_after_gc_yield",
+        &contention_probe_latencies,
+    );
     if !observed_background_gc_latencies.is_empty() {
         print_latency_summary("background_gc", &observed_background_gc_latencies);
     }
     print_latency_summary("backend_flush_sample", &backend_flush_latencies);
     print_depth_bands(&checkpoint_latencies);
+    print_foreground_summary(&foreground_accounting);
+    assert_latency_bounds(&checkpoint_latencies);
+    assert_latency_bounds(&contention_probe_latencies);
+    assert_operation_latency_bounds(
+        &write_latencies,
+        MAX_INTERVAL_WRITE_P99_MILLIS,
+        MAX_INTERVAL_WRITE_MILLIS,
+        "interval write",
+    );
     let first_window = checkpoint_latencies.len().min(100);
     let last_window_start = checkpoint_latencies.len().saturating_sub(100);
     println!(
         "summary backend={} files={file_count} checkpoints={checkpoint_count} \
          files_per_checkpoint={files_per_checkpoint} \
-         auto_commits_per_checkpoint={auto_commits_per_checkpoint} \
-         total_s={:.3} checkpoints_per_s={:.3} live_commits={live_commits} \
+        auto_commits_per_checkpoint={auto_commits_per_checkpoint} \
+         checkpoint_publications={} total_s={:.3} intervals_per_s={:.3} \
+         live_commits={live_commits} \
          first_100_checkpoint_mean_ms={:.3} last_100_checkpoint_mean_ms={:.3} \
          storage_bytes_after_flush={} storage_files_after_flush={} \
          storage_bytes_after_close={} storage_files_after_close={} \
          peak_sampled_storage_bytes={}",
         S::NAME,
+        checkpoint_count * 2,
         total_elapsed.as_secs_f64(),
         f64::from(u32::try_from(checkpoint_count).expect("checkpoint count should fit u32"))
             / total_elapsed.as_secs_f64(),
@@ -680,13 +823,119 @@ fn benchmark_file_id(file_index: usize) -> String {
 }
 
 #[inline(never)]
-async fn profile_checkpoint_phase<S>(lix: &Lix<S>)
+async fn profile_checkpoint_phase<S>(lix: &Lix<S>) -> ForegroundAccounting
 where
     S: BenchmarkStorage,
 {
-    lix.create_checkpoint()
-        .await
-        .expect("create benchmark checkpoint");
+    ALLOCATION_CALLS.with(|calls| calls.set(0));
+    ALLOCATED_BYTES.with(|bytes| bytes.set(0));
+    let (result, storage) = measure_checkpoint_foreground(lix.create_checkpoint()).await;
+    result.expect("create benchmark checkpoint");
+    let accounting = ForegroundAccounting {
+        storage,
+        allocations: AllocationAccounting {
+            calls: ALLOCATION_CALLS.with(Cell::get),
+            bytes: ALLOCATED_BYTES.with(Cell::get),
+        },
+    };
+    assert_foreground_bounds(accounting);
+    accounting
+}
+
+fn assert_foreground_bounds(accounting: ForegroundAccounting) {
+    let storage = accounting.storage;
+    assert!(
+        storage.read_views <= MAX_FOREGROUND_READ_VIEWS,
+        "{accounting:?}"
+    );
+    assert!(
+        storage.point_batches <= MAX_FOREGROUND_POINT_BATCHES,
+        "{accounting:?}"
+    );
+    assert!(
+        storage.point_keys <= MAX_FOREGROUND_POINT_KEYS,
+        "{accounting:?}"
+    );
+    assert!(
+        storage.scan_starts <= MAX_FOREGROUND_SCAN_STARTS,
+        "{accounting:?}"
+    );
+    assert!(
+        storage.scan_pages <= MAX_FOREGROUND_SCAN_PAGES,
+        "{accounting:?}"
+    );
+    assert!(
+        storage.scan_rows <= MAX_FOREGROUND_SCAN_ROWS,
+        "{accounting:?}"
+    );
+    assert!(
+        storage.write_transactions <= MAX_FOREGROUND_WRITE_TRANSACTIONS,
+        "{accounting:?}"
+    );
+    assert!(
+        storage.write_calls <= MAX_FOREGROUND_WRITE_CALLS,
+        "{accounting:?}"
+    );
+    assert!(
+        storage.written_records <= MAX_FOREGROUND_WRITTEN_RECORDS,
+        "{accounting:?}"
+    );
+    assert!(
+        storage.written_bytes <= MAX_FOREGROUND_WRITTEN_BYTES,
+        "{accounting:?}"
+    );
+    assert!(
+        accounting.allocations.calls <= MAX_FOREGROUND_ALLOCATIONS,
+        "{accounting:?}"
+    );
+    assert!(
+        accounting.allocations.bytes <= MAX_FOREGROUND_ALLOCATED_BYTES,
+        "{accounting:?}"
+    );
+}
+
+fn format_foreground(accounting: ForegroundAccounting) -> String {
+    let storage = accounting.storage;
+    format!(
+        "read_views={} point_batches={} point_keys={} scan_starts={} scan_pages={} \
+         scan_rows={} write_transactions={} write_calls={} written_records={} \
+         written_bytes={} allocations={} allocated_bytes={}",
+        storage.read_views,
+        storage.point_batches,
+        storage.point_keys,
+        storage.scan_starts,
+        storage.scan_pages,
+        storage.scan_rows,
+        storage.write_transactions,
+        storage.write_calls,
+        storage.written_records,
+        storage.written_bytes,
+        accounting.allocations.calls,
+        accounting.allocations.bytes,
+    )
+}
+
+fn print_foreground_summary(samples: &[ForegroundAccounting]) {
+    let max = |select: fn(&ForegroundAccounting) -> u64| {
+        samples.iter().map(select).max().unwrap_or_default()
+    };
+    println!(
+        "foreground_max read_views={} point_batches={} point_keys={} scan_starts={} \
+         scan_pages={} scan_rows={} write_transactions={} write_calls={} \
+         written_records={} written_bytes={} allocations={} allocated_bytes={}",
+        max(|sample| sample.storage.read_views),
+        max(|sample| sample.storage.point_batches),
+        max(|sample| sample.storage.point_keys),
+        max(|sample| sample.storage.scan_starts),
+        max(|sample| sample.storage.scan_pages),
+        max(|sample| sample.storage.scan_rows),
+        max(|sample| sample.storage.write_transactions),
+        max(|sample| sample.storage.write_calls),
+        max(|sample| sample.storage.written_records),
+        max(|sample| sample.storage.written_bytes),
+        max(|sample| sample.allocations.calls),
+        max(|sample| sample.allocations.bytes),
+    );
 }
 
 async fn scalar_count<S>(lix: &Lix<S>, sql: &str) -> usize
@@ -783,6 +1032,55 @@ fn print_depth_bands(latencies: &[Duration]) {
             millis(*sorted.last().expect("depth band must not be empty")),
         );
     }
+}
+
+fn assert_latency_bounds(latencies: &[Duration]) {
+    let mut sorted = latencies.to_vec();
+    sorted.sort_unstable();
+    let p99 = millis(percentile(&sorted, 99, 100));
+    let max = millis(*sorted.last().expect("latencies must not be empty"));
+    assert!(
+        p99 <= MAX_CHECKPOINT_P99_MILLIS,
+        "checkpoint p99 {p99:.3}ms exceeded {MAX_CHECKPOINT_P99_MILLIS:.3}ms"
+    );
+    assert!(
+        max <= MAX_CHECKPOINT_MILLIS,
+        "checkpoint max {max:.3}ms exceeded {MAX_CHECKPOINT_MILLIS:.3}ms"
+    );
+    if latencies.len() >= 200 {
+        let mut first = latencies[..100].to_vec();
+        let mut last = latencies[latencies.len() - 100..].to_vec();
+        first.sort_unstable();
+        last.sort_unstable();
+        let first_p95 = millis(percentile(&first, 95, 100));
+        let last_p95 = millis(percentile(&last, 95, 100));
+        let allowed = first_p95 * MAX_DEPTH_P95_RATIO + MAX_DEPTH_P95_ADDITIVE_MILLIS;
+        assert!(
+            last_p95 <= allowed,
+            "checkpoint depth p95 drifted from {first_p95:.3}ms to {last_p95:.3}ms; \
+             allowed {allowed:.3}ms"
+        );
+    }
+}
+
+fn assert_operation_latency_bounds(
+    latencies: &[Duration],
+    max_p99_millis: f64,
+    max_millis: f64,
+    label: &str,
+) {
+    let mut sorted = latencies.to_vec();
+    sorted.sort_unstable();
+    let p99 = millis(percentile(&sorted, 99, 100));
+    let max = millis(*sorted.last().expect("latencies must not be empty"));
+    assert!(
+        p99 <= max_p99_millis,
+        "{label} p99 {p99:.3}ms exceeded {max_p99_millis:.3}ms"
+    );
+    assert!(
+        max <= max_millis,
+        "{label} max {max:.3}ms exceeded {max_millis:.3}ms"
+    );
 }
 
 fn mean_millis(durations: &[Duration]) -> f64 {

--- a/packages/lix/server-protocol.openapi.yaml
+++ b/packages/lix/server-protocol.openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: Lix Server Protocol
-  version: "2"
+  version: "3"
   description: Canonical HTTP surface implemented by lix::server_protocol.
 servers:
   - url: https://host.example/{repositoryPrefix}
@@ -474,7 +474,7 @@ components:
       type: object
       required: [protocolVersion, activeBranchId, activeAccountId, sessionId, capabilities]
       properties:
-        protocolVersion: { type: integer, const: 2 }
+        protocolVersion: { type: integer, const: 3 }
         activeBranchId: { type: string }
         activeAccountId: { type: string }
         sessionId: { type: string }
@@ -574,8 +574,20 @@ components:
         createdAt: { type: string, minLength: 1 }
         selectedSourceCommitId:
           type: [string, "null"]
-          description: Exactly parentCommitIds[1] for a merge with selected members; null otherwise, including self-contained non-merge checkpoints. Physical storage aliases are not exposed.
+          description: Exactly parentCommitIds[1] for a merge with selected members; null otherwise.
+        stateAlias:
+          oneOf:
+            - { $ref: "#/components/schemas/SyncCommitStateAlias" }
+            - { type: "null" }
+          description: Authenticated complete-state source for a metadata-only checkpoint commit; omitted or null for ordinary and merge commits.
         members: { type: array, items: { $ref: "#/components/schemas/SyncCommitMember" } }
+    SyncCommitStateAlias:
+      type: object
+      additionalProperties: false
+      required: [sourceCommitId, stateRootId]
+      properties:
+        sourceCommitId: { type: string, minLength: 1 }
+        stateRootId: { type: string, pattern: "^[0-9a-f]{64}$" }
     SyncRefUpdate:
       type: object
       required: [branchId, expectedHeadCommitId, expectedCheckpointCommitId, headCommitId, checkpointCommitId]

--- a/packages/lix/src/gc.rs
+++ b/packages/lix/src/gc.rs
@@ -10,10 +10,7 @@ use std::time::Instant;
 
 use bytes::Bytes;
 
-use crate::branch::{
-    BranchHeadControl, BranchHeadControlContext, BranchHeadTrackedReachability,
-    branch_head_control_precondition,
-};
+use crate::branch::{BranchHeadControl, BranchHeadControlContext, BranchHeadTrackedReachability};
 use crate::changelog::{ChangeId, CommitId, GcLiveSet, GcPlan, GcRoot, GcSweepSet};
 #[cfg(test)]
 use crate::changelog::{ChangeRecord, CommitScanRequest};
@@ -21,7 +18,9 @@ use crate::changelog::{ChangeRecord, CommitScanRequest};
 use crate::changelog::{ChangeScanRequest, ChangelogContext, ChangelogReader};
 use crate::commit_graph::CommitGraphContext;
 use crate::hot_state::TrackedHeadContext;
-use crate::hot_state::stage_collect_stale_working_diff_indexes;
+use crate::hot_state::{
+    stage_collect_stale_working_diff_indexes, stage_compact_checkpoint_tombstones,
+};
 use crate::json_store::{JsonRef, JsonStoreContext};
 #[cfg(test)]
 use crate::storage_adapter::StorageCoreProjection;
@@ -41,6 +40,10 @@ pub(crate) const CHECKPOINT_RECOVERY_REF_SPACE: StorageSpace = StorageSpace::mut
 pub(crate) const CHECKPOINT_GC_STATE_NAMESPACE: &str = "checkpoint.gc_state.v1";
 pub(crate) const CHECKPOINT_GC_STATE_SPACE: StorageSpace =
     StorageSpace::mutable(StorageSpaceId(0x0008_0002), CHECKPOINT_GC_STATE_NAMESPACE);
+pub(crate) const COMMIT_RETIREMENT_INTENT_SPACE: StorageSpace = StorageSpace::mutable(
+    StorageSpaceId(0x0008_0008),
+    "gc.commit_retirement_intent.v1",
+);
 const CHECKPOINT_RECOVERY_REF_FORMAT_VERSION: u32 = 3;
 const CHECKPOINT_GC_STATE_FORMAT_VERSION: u32 = 2;
 const CHECKPOINT_GC_STATE_KEY: &[u8] = b"repository";
@@ -573,15 +576,30 @@ pub(crate) async fn resolve_checkpoint_branch_parent(
 pub(crate) async fn load_checkpoint_gc_state(
     store: &(impl StorageAdapterRead + ?Sized),
 ) -> Result<CheckpointGcState, LixError> {
-    let result = PointReadPlan::new(
-        CHECKPOINT_GC_STATE_SPACE,
-        &[StorageKey(Bytes::from_static(CHECKPOINT_GC_STATE_KEY))],
-    )
-    .materialize(store, StorageGetOptions::default())
-    .await?;
+    load_checkpoint_gc_state_with_precondition(store)
+        .await
+        .map(|(state, _)| state)
+}
+
+/// Loads the GC singleton together with an exact storage precondition for the
+/// observed value. Background maintenance uses this for read-modify-write so
+/// it cannot overwrite checkpoint debt published after its snapshot opened.
+pub(crate) async fn load_checkpoint_gc_state_with_precondition(
+    store: &(impl StorageAdapterRead + ?Sized),
+) -> Result<(CheckpointGcState, StoragePrecondition), LixError> {
+    let key = StorageKey(Bytes::from_static(CHECKPOINT_GC_STATE_KEY));
+    let result = PointReadPlan::new(CHECKPOINT_GC_STATE_SPACE, std::slice::from_ref(&key))
+        .materialize(store, StorageGetOptions::default())
+        .await?;
     let Some(StorageProjectedValue::FullValue(bytes)) = result.value.into_iter().next().flatten()
     else {
-        return Ok(CheckpointGcState::default());
+        return Ok((
+            CheckpointGcState::default(),
+            StoragePrecondition::KeyAbsent {
+                space: CHECKPOINT_GC_STATE_SPACE,
+                key,
+            },
+        ));
     };
     let stored: StoredCheckpointGcState = storage_codec::decode("checkpoint GC state", &bytes)?;
     if stored.format_version != CHECKPOINT_GC_STATE_FORMAT_VERSION {
@@ -602,7 +620,14 @@ pub(crate) async fn load_checkpoint_gc_state(
         consecutive_reclaim_failures: stored.consecutive_reclaim_failures,
     };
     validate_checkpoint_gc_state(state)?;
-    Ok(state)
+    Ok((
+        state,
+        StoragePrecondition::KeyValueEquals {
+            space: CHECKPOINT_GC_STATE_SPACE,
+            key,
+            expected: bytes,
+        },
+    ))
 }
 
 fn validate_checkpoint_gc_state(state: CheckpointGcState) -> Result<(), LixError> {
@@ -665,6 +690,10 @@ pub(crate) struct RepositoryGcSweep {
     /// branch control selects any more.
     pub(crate) reclaimed_generation_rows: u64,
     pub(crate) binary_cas: crate::binary_cas::BinaryCasGcSweep,
+    /// More unreachable authority remained after this bounded maintenance
+    /// publication. The checkpoint debt must stay due until a later slice
+    /// observes and retires the remainder.
+    pub(crate) has_more: bool,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -978,6 +1007,16 @@ where
             physical_authorities.insert(source);
             pending.push(source);
         }
+        if manifest
+            .snapshot_root
+            .as_ref()
+            .is_some_and(|root| root.complete_state_fence)
+            && let Some(owners) =
+                crate::tracked_state::complete_state_fence_change_owner_commit_ids(store, commit_id)
+                    .await?
+        {
+            physical_authorities.extend(owners);
+        }
         if let Some(root) = manifest.current_state_scoped_ranges.as_ref() {
             if let Some(base) = root.serving_base_commit_id {
                 physical_dependencies.insert(base);
@@ -1066,33 +1105,60 @@ where
     .await?;
     semantic_dependencies.extend(cas_logical_dependencies.iter().copied());
 
-    let selected_owner_sources = physical_authorities
-        .union(&physical_dependencies)
-        .copied()
-        .collect::<Vec<_>>();
-    let selected_owner_source_manifests =
-        crate::tracked_state::load_commit_state_manifests(store, &selected_owner_sources).await?;
-    for (commit_id, manifest) in selected_owner_sources
-        .iter()
-        .copied()
-        .zip(selected_owner_source_manifests)
-    {
-        let manifest = manifest.ok_or_else(|| {
-            LixError::new(
-                LixError::CODE_INTERNAL_ERROR,
-                format!(
-                    "active GC dependency '{commit_id}' has no authenticated physical manifest"
-                ),
-            )
-        })?;
-        let may_contain_finite_selected_members =
-            manifest.mutations.may_contain_finite_selected_members();
-        manifests.insert(commit_id, manifest);
-        if may_contain_finite_selected_members {
-            physical_authorities.extend(
-                crate::tracked_state::load_local_selected_change_owner_commit_ids(store, commit_id)
+    // Complete-state fences and finite selected members can reveal another
+    // physical owner, whose own authority can reveal another owner in turn.
+    // Discover that closure to a fixed point. A one-shot snapshot of the set
+    // can retire payload owners reached through nested checkpoints.
+    let mut inspected_owner_sources = BTreeSet::new();
+    loop {
+        let selected_owner_sources = physical_authorities
+            .union(&physical_dependencies)
+            .filter(|commit_id| !inspected_owner_sources.contains(*commit_id))
+            .copied()
+            .collect::<Vec<_>>();
+        if selected_owner_sources.is_empty() {
+            break;
+        }
+        let selected_owner_source_manifests =
+            crate::tracked_state::load_commit_state_manifests(store, &selected_owner_sources)
+                .await?;
+        for (commit_id, manifest) in selected_owner_sources
+            .into_iter()
+            .zip(selected_owner_source_manifests)
+        {
+            let manifest = manifest.ok_or_else(|| {
+                LixError::new(
+                    LixError::CODE_INTERNAL_ERROR,
+                    format!(
+                        "active GC dependency '{commit_id}' has no authenticated physical manifest"
+                    ),
+                )
+            })?;
+            let may_contain_finite_selected_members =
+                manifest.mutations.may_contain_finite_selected_members();
+            let complete_state_fence = manifest
+                .snapshot_root
+                .as_ref()
+                .is_some_and(|root| root.complete_state_fence);
+            manifests.insert(commit_id, manifest);
+            inspected_owner_sources.insert(commit_id);
+            if complete_state_fence
+                && let Some(owners) =
+                    crate::tracked_state::complete_state_fence_change_owner_commit_ids(
+                        store, commit_id,
+                    )
+                    .await?
+            {
+                physical_authorities.extend(owners);
+            }
+            if may_contain_finite_selected_members {
+                physical_authorities.extend(
+                    crate::tracked_state::load_local_selected_change_owner_commit_ids(
+                        store, commit_id,
+                    )
                     .await?,
-            );
+                );
+            }
         }
     }
 
@@ -1155,6 +1221,9 @@ where
     control_reachability
         .history_dependencies
         .extend(crate::sync::load_replayable_repository_event_commit_ids(store).await?);
+    control_reachability.history_dependencies.extend(
+        crate::sync::load_pending_sync_export_commit_ids(store, controls).await?,
+    );
     let mut chronology_roots = control_reachability.chronology_roots;
     chronology_roots.extend(
         load_recovery_refs(store)
@@ -1278,32 +1347,20 @@ pub(crate) async fn stage_repository_gc_with_preconditions<S>(
 where
     S: StorageAdapterRead + Clone + Send + Sync,
 {
+    const MAX_SLICE_MUTATIONS: u64 = 4_000;
+    const MAX_SLICE_WRITTEN_BYTES: u64 = 3 * 1024 * 1024;
     let started = Instant::now();
-    let mut staged_preconditions = Vec::new();
+    let expected_mutation_revision =
+        crate::storage_adapter::load_repository_mutation_revision(&store).await?;
+    let mut staged_preconditions = vec![
+        crate::storage_adapter::repository_mutation_revision_precondition(
+            expected_mutation_revision,
+        ),
+    ];
     let controls = BranchHeadControlContext::new()
         .reader(store.clone())
         .scan()
         .await?;
-    let branch_ids = controls
-        .iter()
-        .map(|(branch_id, _)| branch_id.clone())
-        .collect::<Vec<_>>();
-    let observed_controls = BranchHeadControlContext::new()
-        .reader(store.clone())
-        .load_observed(&branch_ids)
-        .await?;
-    for ((branch_id, control), observed) in controls.iter().zip(observed_controls) {
-        if observed.control != Some(*control) {
-            return Err(LixError::new(
-                LixError::CODE_STORAGE_ERROR,
-                format!("branch '{branch_id}' changed while GC roots were being observed"),
-            ));
-        }
-        staged_preconditions.push(branch_head_control_precondition(
-            branch_id,
-            observed.raw_token,
-        )?);
-    }
     let AuthenticatedServingDependencyClosure {
         chronology_roots: active_roots,
         physical_authorities: active_authority_ids,
@@ -1361,50 +1418,87 @@ where
         crate::filesystem::collect_gc_binary_blob_roots(&store, &controls, &retained_cas_root_ids)
             .await?;
     blob_roots.extend(
-        crate::plugin::runtime::collect_gc_wasm_blob_roots(
-            &store,
-            &controls,
-            &active_roots,
-        )
-        .await?,
+        crate::plugin::runtime::collect_gc_wasm_blob_roots(&store, &controls, &active_roots)
+            .await?,
     );
-    let upload_chunks =
-        crate::session::stage_reclaimable_upload_receipts(&store, writes, &blob_roots).await?;
-    let binary_cas =
-        crate::binary_cas::stage_gc_reclamation(&store, writes, &blob_roots, &upload_chunks)
-            .await?;
-    crate::binary_cas::stage_cas_reclamation_fence(&store, writes, &mut staged_preconditions)
-        .await?;
-
-    // Retire the derived candidates. Nothing here is ordered and nothing is
-    // capped: a candidate that is still pinned holds back only itself, and the
-    // two planes prove retirement independently. The ledger could do neither —
+    // Retire the derived candidates in backend-admissible slices. A candidate
+    // that is still pinned holds back only itself, and a wide commit drains its
+    // owned locator rows before the compact authority deletion. The two planes
+    // prove retirement independently. The ledger could do neither —
     // it consumed a queue in publication order and stopped at the first blocked
     // row, so one permanently live root at the head froze every younger
     // candidate behind it forever.
     let mut reclaimed_commits = BTreeSet::new();
     let mut reclaimed_semantic_commits = BTreeSet::new();
+    let mut has_more = false;
     for commit_id in candidates {
+        let mut candidate_writes = StorageWriteSet::new();
         if retirement_is_proven(commit_id, &active_roots, &active_semantic_dependency_ids)
             && reclaimed_semantic_commits.insert(commit_id)
         {
-            crate::changelog::stage_delete_commit_projection(&store, writes, commit_id).await?;
-        }
-        if blocked_physical_dependency_ids.contains(&commit_id) {
-            continue;
-        }
-        if reclaimed_commits.insert(commit_id) {
-            crate::tracked_state::stage_retire_commit_physical_state(
+            crate::changelog::stage_delete_commit_projection(
                 &store,
-                writes,
+                &mut candidate_writes,
+                commit_id,
+            )
+            .await?;
+            crate::sync::stage_delete_materialized_sync_state_alias(
+                &mut candidate_writes,
+                commit_id,
+            );
+        }
+        let reclaims_physical = !blocked_physical_dependency_ids.contains(&commit_id);
+        let current = writes.stats();
+        let candidate_so_far = candidate_writes.stats();
+        let remaining_mutations = MAX_SLICE_MUTATIONS.saturating_sub(
+            current
+                .staged_puts
+                .saturating_add(current.staged_deletes)
+                .saturating_add(candidate_so_far.staged_puts)
+                .saturating_add(candidate_so_far.staged_deletes),
+        );
+        let mut physical_complete = true;
+        if reclaims_physical {
+            physical_complete = crate::tracked_state::stage_retire_commit_physical_state_bounded(
+                &store,
+                &mut candidate_writes,
                 commit_id,
                 RetainedPhysicalState {
                     mutation_nodes: &active_mutation_nodes,
                     scoped_nodes: &active_scoped_nodes,
                     native_parts: &active_current_parts,
                 },
+                Some(usize::try_from(remaining_mutations).unwrap_or(usize::MAX)),
             )
             .await?;
+        }
+        let current = writes.stats();
+        let candidate = candidate_writes.stats();
+        if current
+            .staged_puts
+            .saturating_add(current.staged_deletes)
+            .saturating_add(candidate.staged_puts)
+            .saturating_add(candidate.staged_deletes)
+            > MAX_SLICE_MUTATIONS
+            || current
+                .written_bytes
+                .saturating_add(candidate.written_bytes)
+                > MAX_SLICE_WRITTEN_BYTES
+        {
+            has_more = true;
+            reclaimed_semantic_commits.remove(&commit_id);
+            break;
+        }
+        writes.extend(candidate_writes);
+        if reclaims_physical && physical_complete {
+            reclaimed_commits.insert(commit_id);
+        }
+        if !physical_complete {
+            // Existing locator rows are a durable cursor for a wide commit:
+            // each pass removes a bounded prefix while retaining the immutable
+            // manifest and segments needed to enumerate the next prefix.
+            has_more = true;
+            break;
         }
     }
     if !reclaimed_semantic_commits.is_empty() {
@@ -1414,7 +1508,53 @@ where
     // Checkpoint publication rotates the authenticated sparse dirty-index
     // marker in O(1). Retire every now-unreachable epoch here, under the same
     // observed branch-control preconditions as the rest of repository GC.
-    stage_collect_stale_working_diff_indexes(&store, writes).await?;
+    let binary_cas = if has_more {
+        Default::default()
+    } else {
+        let mut auxiliary_writes = StorageWriteSet::new();
+        let mut auxiliary_preconditions = Vec::new();
+        let upload_chunks = crate::session::stage_reclaimable_upload_receipts(
+            &store,
+            &mut auxiliary_writes,
+            &blob_roots,
+        )
+        .await?;
+        let binary_cas = crate::binary_cas::stage_gc_reclamation(
+            &store,
+            &mut auxiliary_writes,
+            &blob_roots,
+            &upload_chunks,
+        )
+        .await?;
+        crate::binary_cas::stage_cas_reclamation_fence(
+            &store,
+            &mut auxiliary_writes,
+            &mut auxiliary_preconditions,
+        )
+        .await?;
+        let tombstones_have_more =
+            stage_compact_checkpoint_tombstones(&store, &mut auxiliary_writes, &controls).await?;
+        stage_collect_stale_working_diff_indexes(&store, &mut auxiliary_writes).await?;
+        let current = writes.stats();
+        let remaining_mutations = MAX_SLICE_MUTATIONS
+            .saturating_sub(current.staged_puts.saturating_add(current.staged_deletes));
+        let remaining_bytes = MAX_SLICE_WRITTEN_BYTES.saturating_sub(current.written_bytes);
+        let (auxiliary_slice, auxiliary_has_more) =
+            auxiliary_writes.into_bounded_maintenance_slice(remaining_mutations, remaining_bytes);
+        if auxiliary_slice.is_empty() && !auxiliary_preconditions.is_empty() {
+            has_more = true;
+            Default::default()
+        } else {
+            writes.extend(auxiliary_slice);
+            staged_preconditions.extend(auxiliary_preconditions);
+            has_more |= auxiliary_has_more || tombstones_have_more;
+            if auxiliary_has_more || tombstones_have_more {
+                Default::default()
+            } else {
+                binary_cas
+            }
+        }
+    };
 
     preconditions.extend(staged_preconditions);
     Ok(RepositoryGcPlan {
@@ -1445,6 +1585,7 @@ where
             standalone_changes: Vec::new(),
             reclaimed_generation_rows: 0,
             binary_cas,
+            has_more,
         },
         profile: RepositoryGcProfile {
             history_manifests_missing,
@@ -1524,6 +1665,7 @@ where
             standalone_changes: Vec::new(),
             reclaimed_generation_rows: 0,
             binary_cas: Default::default(),
+            has_more: false,
         },
         profile: RepositoryGcProfile {
             // The recovery-only rebuild path rediscovers liveness by scanning;
@@ -4007,6 +4149,88 @@ mod tests {
             .await
             .expect_err("a recovery ref no live control still serves is not a branchable root");
         assert_eq!(error.code, LixError::CODE_COMMIT_NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn repository_gc_makes_bounded_progress_across_an_oversized_retirement_set() {
+        let backend = Memory::new();
+        let storage = StorageAdapter::new(backend.clone());
+        Engine::initialize(backend.clone()).await.unwrap();
+        let timestamp = LixTimestamp::expect_parse("bounded GC timestamp", "2026-01-01T00:00:00Z");
+        // Seed unreachable authority directly so checkpoint-triggered
+        // background GC cannot race this deterministic slicer test. Each
+        // candidate contributes semantic and split-manifest point deletes;
+        // 2,500 candidates therefore exceed the real 4,000-mutation cap.
+        for batch in 0..5 {
+            let records = (0..500)
+                .map(|index| {
+                    replay_commit_record(&format!("bounded-gc-{batch}-{index}"), 0, None, timestamp)
+                })
+                .collect::<Vec<_>>();
+            let manifests = records
+                .iter()
+                .map(|record| {
+                    test_commit_state_manifest(record, CommitStateMutationInventory::default())
+                })
+                .collect::<Vec<_>>();
+            persist_replay_closure_fixture(&storage, storage.new_write_set(), &records, &manifests)
+                .await;
+        }
+
+        let mut reclaimed = 0usize;
+        let mut observed_partial = false;
+        let mut completed = false;
+        for _ in 0..32 {
+            let read = SharedStorageAdapterRead::new(
+                storage
+                    .begin_read(StorageReadOptions::default())
+                    .await
+                    .unwrap(),
+            );
+            let mut writes = storage.new_write_set();
+            let mut preconditions = Vec::new();
+            let plan = super::stage_repository_gc_with_preconditions(
+                read,
+                &mut writes,
+                &mut preconditions,
+            )
+            .await
+            .unwrap();
+            let stats = writes.stats();
+            assert!(
+                stats.staged_puts.saturating_add(stats.staged_deletes) <= 4_000,
+                "every maintenance slice must remain below adapter admission"
+            );
+            reclaimed = reclaimed.saturating_add(plan.sweep.tracked_commit_roots.len());
+            storage
+                .commit_write_set(
+                    writes,
+                    StorageWriteOptions {
+                        preconditions,
+                        background_maintenance: true,
+                        ..StorageWriteOptions::default()
+                    },
+                )
+                .await
+                .unwrap();
+            observed_partial |= plan.sweep.has_more;
+            if !plan.sweep.has_more {
+                completed = true;
+                break;
+            }
+        }
+        assert!(
+            observed_partial,
+            "fixture must cross the maintenance hard cut"
+        );
+        assert!(
+            completed,
+            "bounded slices must eventually drain all GC debt"
+        );
+        assert!(
+            reclaimed >= 2_400,
+            "the fixture must reclaim real commit debt"
+        );
     }
 
     /// Undo-to-last-checkpoint must survive reclaim at any cadence.

--- a/packages/lix/src/hot_row_tombstone_probe.rs
+++ b/packages/lix/src/hot_row_tombstone_probe.rs
@@ -215,7 +215,7 @@ async fn working_diff_rows(session: &SessionContext<Memory>, schema_key: &str) -
 
 /// Plans and commits a repository GC sweep against the same physical store the
 /// session writes through.
-async fn run_repository_gc(storage: &Memory) {
+async fn run_repository_gc(storage: &Memory) -> bool {
     let adapter = StorageAdapter::new(storage.clone());
     let read = SharedStorageAdapterRead::new(
         adapter
@@ -224,13 +224,23 @@ async fn run_repository_gc(storage: &Memory) {
             .expect("gc read"),
     );
     let mut gc_writes = adapter.new_write_set();
-    crate::gc::stage_repository_gc(read, &mut gc_writes)
+    let plan = crate::gc::stage_repository_gc(read, &mut gc_writes)
         .await
         .expect("repository gc should plan");
     adapter
         .commit_write_set(gc_writes, StorageWriteOptions::default())
         .await
         .expect("gc write set should commit");
+    plan.sweep.has_more
+}
+
+async fn drain_repository_gc(storage: &Memory) {
+    for _ in 0..32 {
+        if !run_repository_gc(storage).await {
+            return;
+        }
+    }
+    panic!("bounded repository maintenance did not drain within 32 slices");
 }
 
 fn probe_schema(key: &str) -> serde_json::Value {
@@ -435,7 +445,7 @@ async fn hot_row_tombstone_reclamation_events() {
     report("after_checkpoint", census, scan);
 
     // (c) repository GC.
-    run_repository_gc(&storage).await;
+    drain_repository_gc(&storage).await;
     let census = row_census(&storage).await;
     let scan = timed_scan(&session, &scan_sql("evtrow"), 1, reps).await;
     report("after_gc", census, scan);
@@ -1512,7 +1522,7 @@ async fn broad_canonical_created_at_recovery_misses_for_new_identities() {
 ///
 /// Process-global by construction, so only *deltas* and only *thresholds*
 /// scaled to a fixture no concurrent test can reach are meaningful here.
-#[derive(Clone, Copy, Debug, Default)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 struct CompactionCounters {
     /// Publications that reached the mask at all.
     routes: u64,
@@ -1556,18 +1566,17 @@ impl std::fmt::Display for CompactionCounters {
     }
 }
 
-/// PHASE 10 — the landed engine change: a checkpoint reclaims the tombstones
-/// it has just discharged.
+/// PHASE 10 — checkpoint publication discharges tombstones in O(1), and
+/// repository maintenance reclaims them afterward.
 ///
 /// Numbered 10 because phases 1–7 are shared, 8 is #1427's allocation census
 /// and 9 is the canonical `created_at` recovery that #1432 landed.
 ///
 /// Phase 4 proved the *premise* by removing tombstones behind the engine's
-/// back. This phase asserts the engine now does it itself, at the checkpoint,
-/// through `hot_compaction_mask`. Both the hit and the refusal are asserted in
-/// non-`#[ignore]`d tests, because a design whose every gate is conservative
-/// fails silently inert, and a row-count instrument one layer up cannot tell
-/// "reclaimed nothing here" from "never ran".
+/// back. This phase asserts that the foreground checkpoint does not enter the
+/// scale-dependent route, then that repository GC does. Both halves are
+/// explicit because a flat row count cannot distinguish deferred work from an
+/// inert compactor.
 #[tokio::test]
 async fn checkpoint_compacts_discharged_branch_tombstones() {
     const N: usize = 300;
@@ -1600,11 +1609,26 @@ async fn checkpoint_compacts_discharged_branch_tombstones() {
         .create_checkpoint()
         .await
         .expect("checkpoint should publish");
-    let counters = compaction_counters().since(counters_before);
+    let foreground_counters = compaction_counters().since(counters_before);
+    let after_checkpoint = row_census(&storage).await;
+
+    assert_eq!(
+        foreground_counters,
+        CompactionCounters::default(),
+        "foreground checkpoint publication must not enter tombstone compaction"
+    );
+    assert_eq!(
+        after_checkpoint.tombstones, before.tombstones,
+        "foreground checkpoint publication must leave physical retirement to maintenance"
+    );
+
+    let gc_counters_before = compaction_counters();
+    drain_repository_gc(&storage).await;
+    let counters = compaction_counters().since(gc_counters_before);
     let after = row_census(&storage).await;
 
     println!(
-        "phase10 | compaction entries {}->{} tombstones {}->{} {counters}",
+        "phase10 | background compaction entries {}->{} tombstones {}->{} {counters}",
         before.entries, after.entries, before.tombstones, after.tombstones
     );
 
@@ -1701,7 +1725,16 @@ async fn recreated_identity_inherits_created_at_after_engine_compaction() {
         .create_checkpoint()
         .await
         .expect("checkpoint should publish");
-    let counters = compaction_counters().since(counters_before);
+    let foreground_counters = compaction_counters().since(counters_before);
+    assert_eq!(
+        foreground_counters,
+        CompactionCounters::default(),
+        "foreground checkpoint publication must not enter tombstone compaction"
+    );
+
+    let gc_counters_before = compaction_counters();
+    run_repository_gc(&storage).await;
+    let counters = compaction_counters().since(gc_counters_before);
     assert!(
         counters.compacted > 0,
         "this test is about a compacted identity; nothing was compacted"

--- a/packages/lix/src/hot_state/mod.rs
+++ b/packages/lix/src/hot_state/mod.rs
@@ -38,8 +38,10 @@ pub(crate) use tracked_head::WORKING_DIFF_PATH_HITS;
 pub(crate) use tracked_head::encode_hot_row_key_for_test;
 #[cfg(test)]
 pub(crate) use tracked_head::hot_generation_scope_prefix;
-pub(crate) use tracked_head::stage_collect_stale_working_diff_indexes;
 pub(crate) use tracked_head::stage_retire_hot_generation;
+pub(crate) use tracked_head::{
+    stage_collect_stale_working_diff_indexes, stage_compact_checkpoint_tombstones,
+};
 // Read only by `#[cfg(test)]` probes, so a features-on *library* build compiles
 // the counters and re-exports them without any in-crate reader. `cargo test`
 // cannot see that — under `--profile test` the probe module exists and the

--- a/packages/lix/src/hot_state/tracked_head.rs
+++ b/packages/lix/src/hot_state/tracked_head.rs
@@ -832,6 +832,85 @@ where
     hot::stage_collect_stale_hot_diff_records(store, writes, &active).await
 }
 
+/// Reclaims current-generation tracked tombstones as repository maintenance.
+/// The scan is deliberately background scale work; checkpoint publication
+/// only rotates its constant-size epoch marker.
+pub(crate) async fn stage_compact_checkpoint_tombstones<S>(
+    store: &S,
+    writes: &mut StorageWriteSet,
+    controls: &[(String, BranchHeadControl)],
+) -> Result<bool, LixError>
+where
+    S: StorageAdapterRead + Clone,
+{
+    let context = TrackedHeadContext::new();
+    let reader = context.reader(store.clone());
+    let no_staged_global_schemas = BTreeSet::new();
+    const MAX_TOMBSTONE_ROWS_PER_SLICE: usize = 32;
+    let mut staged_rows = 0usize;
+    let mut has_more = false;
+    for (branch_id, control) in controls {
+        let Some(checkpoint_commit_id) = control.working_diff_checkpoint_commit_id else {
+            continue;
+        };
+        let rows = reader
+            .scan_tracked_tombstones_for_control(branch_id, *control)
+            .await?;
+        if rows.is_empty() {
+            continue;
+        }
+        let deltas = rows
+            .iter()
+            .map(|row| CurrentStateDeltaRef {
+                schema_key: &row.schema_key,
+                file_id: row.file_id.as_deref(),
+                row_pk: &row.row_pk,
+                change_id: row.change_id,
+                commit_id: Some(checkpoint_commit_id),
+                untracked: false,
+                deleted: true,
+                created_at: row.created_at,
+                updated_at: row.updated_at,
+                snapshot: None,
+                metadata: None,
+                columnar_base_coordinate: None,
+            })
+            .collect::<Vec<_>>();
+        let mut coverage = WorkingDiffIndexCoverage::default();
+        let mut writer = context.writer(store, writes);
+        writer = writer.with_transaction_global_schema_keys(&no_staged_global_schemas);
+        let mask = writer
+            .checkpoint_tombstone_compaction_mask(branch_id, control.tracked_generation, &deltas)
+            .await?;
+        let mut candidates = deltas
+            .into_iter()
+            .zip(mask)
+            .filter_map(|(delta, compactable)| compactable.then_some(delta))
+            .collect::<Vec<_>>();
+        let remaining = MAX_TOMBSTONE_ROWS_PER_SLICE.saturating_sub(staged_rows);
+        if candidates.len() > remaining {
+            has_more = true;
+            candidates.truncate(remaining);
+        }
+        if candidates.is_empty() {
+            continue;
+        }
+        staged_rows = staged_rows.saturating_add(candidates.len());
+        writer
+            .stage_checkpoint_current_state(
+                branch_id,
+                control.tracked_generation,
+                control.head_commit_id,
+                &candidates,
+                &BTreeSet::new(),
+                checkpoint_commit_id,
+                &mut coverage,
+            )
+            .await?;
+    }
+    Ok(has_more)
+}
+
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 struct ActiveWorkingDiffScope {
     checkpoint_commit_id: CommitId,

--- a/packages/lix/src/hot_state/tracked_head/hot.rs
+++ b/packages/lix/src/hot_state/tracked_head/hot.rs
@@ -2183,11 +2183,15 @@ fn packed_exact_keys_for_filter(filter: &TrackedStateFilter) -> Option<Vec<Track
 /// interval, so its rows were absent when that checkpoint was taken.
 fn packed_current_base_working_diff_baseline(
     active_checkpoint_commit_id: Option<CommitId>,
+    base_checkpoint_commit_id: Option<CommitId>,
 ) -> PackedWorkingDiffBaseline {
     match active_checkpoint_commit_id {
-        Some(checkpoint_commit_id) => PackedWorkingDiffBaseline::AbsentAtCheckpoint {
-            checkpoint_commit_id,
-        },
+        Some(checkpoint_commit_id) if base_checkpoint_commit_id == Some(checkpoint_commit_id) => {
+            PackedWorkingDiffBaseline::AbsentAtCheckpoint {
+                checkpoint_commit_id,
+            }
+        }
+        Some(_) => PackedWorkingDiffBaseline::CleanAtCheckpoint,
         None => PackedWorkingDiffBaseline::Disabled,
     }
 }
@@ -3131,7 +3135,8 @@ async fn load_packed_current_base_exact(
     let mut slots = Vec::with_capacity(keys.len());
     let global = branch_id == crate::GLOBAL_BRANCH_ID;
     for (key, entry) in keys.iter().zip(winners) {
-        let Some((value, mut change_record, base_coordinate)) = entry else {
+        let Some((value, mut change_record, base_coordinate, base_checkpoint_commit_id)) = entry
+        else {
             slots.push(None);
             continue;
         };
@@ -3170,6 +3175,7 @@ async fn load_packed_current_base_exact(
             updated_at: value.updated_at,
             working_diff_baseline: packed_current_base_working_diff_baseline(
                 active_checkpoint_commit_id,
+                base_checkpoint_commit_id,
             ),
             columnar_base_coordinate,
         });
@@ -3244,6 +3250,7 @@ async fn load_packed_current_base_exact_entries(
             crate::tracked_state::TrackedStateIndexValue,
             crate::changelog::ChangeRecord,
             Option<crate::tracked_state::TrackedStateBaseCoordinate>,
+            Option<CommitId>,
         )>,
     >,
     LixError,
@@ -3339,6 +3346,7 @@ async fn load_packed_current_base_exact_entries_from_refs(
             crate::tracked_state::TrackedStateIndexValue,
             crate::changelog::ChangeRecord,
             Option<crate::tracked_state::TrackedStateBaseCoordinate>,
+            Option<CommitId>,
         )>,
     >,
     LixError,
@@ -3354,7 +3362,14 @@ async fn load_packed_current_base_exact_entries_from_refs(
             .await?
             .into_iter()
             .map(|entry| {
-                entry.map(|entry| (entry.value, entry.change_record, entry.base_coordinate))
+                entry.map(|entry| {
+                    (
+                        entry.value,
+                        entry.change_record,
+                        entry.base_coordinate,
+                        base_ref.checkpoint_commit_id,
+                    )
+                })
             })
             .collect(),
         );
@@ -3382,21 +3397,23 @@ async fn load_packed_current_base_exact_entries_from_refs(
             crate::tracked_state::TrackedStateIndexValue,
             crate::changelog::ChangeRecord,
             Option<crate::tracked_state::TrackedStateBaseCoordinate>,
+            Option<CommitId>,
         )>,
     >>();
-    for entries in loaded.chunks(keys.len()) {
+    for (base_ref, entries) in base_refs.iter().zip(loaded.chunks(keys.len())) {
         for (slot, entry) in winners.iter_mut().zip(entries) {
             let Some(entry) = entry else {
                 continue;
             };
             if slot
                 .as_ref()
-                .is_none_or(|(previous, _, _)| previous.commit_id < entry.value.commit_id)
+                .is_none_or(|(previous, _, _, _)| previous.commit_id < entry.value.commit_id)
             {
                 *slot = Some((
                     entry.value.clone(),
                     entry.change_record.clone(),
                     entry.base_coordinate,
+                    base_ref.checkpoint_commit_id,
                 ));
             }
         }
@@ -4637,6 +4654,45 @@ where
         Ok(Some((base_ref.commit_id, collection.live_count)))
     }
 
+    pub(crate) async fn scan_tracked_tombstones_for_control(
+        &self,
+        branch_id: &str,
+        control: BranchHeadControl,
+    ) -> Result<Vec<MaterializedHotStateRow>, LixError> {
+        let filter = TrackedStateFilter {
+            include_tombstones: true,
+            ..TrackedStateFilter::default()
+        };
+        let HotScanEntries::Decoded(entries) = hot_scan_entries(
+            &self.store,
+            branch_id,
+            control.tracked_generation,
+            &filter,
+            None,
+            None,
+        )
+        .await?
+        .expect("unbounded HOT scan cannot exhaust a byte budget") else {
+            unreachable!("an unconstrained HOT scan cannot select the finite point-read route");
+        };
+        let mut tombstones = Vec::new();
+        for (identity, bytes) in entries {
+            let value = decode_head_value(&bytes)?;
+            if value.deleted && !value.untracked {
+                tombstones.push((identity, bytes));
+            }
+        }
+        Ok(materialize_live_entries(
+            &self.store,
+            tombstones,
+            ChangeRecordProjection::identity_only(),
+            branch_id,
+            control.working_diff_checkpoint_commit_id,
+        )
+        .await?
+        .into_rows())
+    }
+
     #[cfg(test)]
     pub(crate) async fn scan_live_rows_if_current(
         &self,
@@ -5362,6 +5418,30 @@ impl<S> HotStateWriter<'_, S>
 where
     S: StorageAdapterRead + ?Sized,
 {
+    /// Returns the checkpoint tombstones that can actually be removed under
+    /// the current serving-base and cross-branch safety gates.
+    ///
+    /// Background GC uses this before pagination so permanently blocked rows
+    /// do not occupy the first page forever.
+    pub(crate) async fn checkpoint_tombstone_compaction_mask(
+        &self,
+        branch_id: &str,
+        generation: CommitId,
+        deltas: &[CurrentStateDeltaRef<'_>],
+    ) -> Result<Vec<bool>, LixError> {
+        let refs = deltas.iter().collect::<Vec<_>>();
+        hot_compaction_mask(
+            self.store,
+            branch_id,
+            generation,
+            &refs,
+            None,
+            HotTombstoneMaskKind::Checkpoint,
+            self.transaction_global_schema_keys,
+        )
+        .await
+    }
+
     /// Publishes an immutable tracked root as the baseline of a new sparse
     /// branch generation. The root is already authoritative for every tracked
     /// identity at `head_commit_id`; later branch-local HOT rows shadow it.
@@ -5638,12 +5718,18 @@ where
                         "exclusive-schema index references an inactive packed current base",
                     )
                 })?;
-                if full_value_bytes(value)?.as_ref() != expected_checkpoint {
+                let base_checkpoint = full_value_bytes(value)?;
+                let base_is_dirty_in_active_epoch = base_checkpoint.as_ref() == expected_checkpoint;
+                if working_diff_capture_checkpoint_commit_id.is_none()
+                    && !base_is_dirty_in_active_epoch
+                {
                     return Err(head_value_error(
                         "packed collection replacement has a different working-diff owner",
                     ));
                 }
-                if working_diff_capture_checkpoint_commit_id.is_some() {
+                if working_diff_capture_checkpoint_commit_id.is_some()
+                    && base_is_dirty_in_active_epoch
+                {
                     coverage
                         .remove_encoded_group_key(&base_key.0)
                         .ok_or_else(|| {
@@ -6503,21 +6589,15 @@ where
     /// Whether a checkpoint can rotate its working-diff epoch without
     /// materializing current-state base rows first.
     ///
-    /// Immutable packed bases encode interval-relative absent-at-checkpoint
-    /// facts and must take the existing materializing route once. Root bases
-    /// are already the branch's checkpoint state and remain clean under a new
-    /// epoch, so they do not prevent lazy rotation.
+    /// Packed-base refs retain the checkpoint epoch in which they were
+    /// published. Readers reinterpret a base as clean when the active epoch
+    /// advances, so rotating the epoch neither scans nor retires those refs.
+    /// Root bases are already checkpoint state and need no rewrite either.
     pub(crate) async fn can_rotate_checkpoint_epoch(
         &self,
-        branch_id: &str,
-        generation: CommitId,
+        _branch_id: &str,
+        _generation: CommitId,
     ) -> Result<bool, LixError> {
-        if !packed_current_base_refs(self.store, branch_id, generation)
-            .await?
-            .is_empty()
-        {
-            return Ok(false);
-        }
         Ok(true)
     }
 
@@ -6778,7 +6858,9 @@ where
         for (index, packed_previous) in packed_previous_indices.iter().copied().zip(packed_previous)
         {
             let previous = &mut previous_values[index];
-            let Some((packed_value, _, base_coordinate)) = &packed_previous else {
+            let Some((packed_value, _, base_coordinate, base_checkpoint_commit_id)) =
+                &packed_previous
+            else {
                 continue;
             };
             let packed_is_newer = match (
@@ -6806,6 +6888,7 @@ where
                 updated_at: packed_value.updated_at,
                 working_diff_baseline: packed_current_base_working_diff_baseline(
                     working_diff_capture_checkpoint_commit_id,
+                    *base_checkpoint_commit_id,
                 ),
                 columnar_base_coordinate: base_coordinate.map(|coordinate| {
                     ColumnarBaseCoordinate {
@@ -7111,6 +7194,7 @@ where
             {
                 let identical_immutable_change = !previous_from_packed
                     && !delta.untracked
+                    && !delta.deleted
                     && delta.schema_key
                         != crate::collection_generation::COLLECTION_GENERATION_SCHEMA_KEY
                     && previous
@@ -13668,7 +13752,7 @@ mod tests {
             admitted_read_counts,
             "a transaction snapshot must reuse an admitted packed segment by immutable address"
         );
-        let (_, change, _) = entries[0].as_ref().expect("packed predecessor exists");
+        let (_, change, _, _) = entries[0].as_ref().expect("packed predecessor exists");
         assert!(
             change.snapshot.is_some(),
             "mutation lookup must retain the native typed payload"

--- a/packages/lix/src/init.rs
+++ b/packages/lix/src/init.rs
@@ -71,9 +71,15 @@ pub(crate) const REPOSITORY_PROTOCOL_KEY: &[u8] = b"current";
 /// JSON representation to schema-fingerprinted native typed-row payloads for
 /// both plugin-owned and engine-owned Schema v1 rows. Repositories using v68
 /// are upgraded by the explicit offline migration before the engine opens.
-pub(crate) const CURRENT_FORMAT_VERSION: u32 = 69;
+///
+/// `v70` admits complete-state checkpoint fences whose single parent-root
+/// edge is a physical state source rather than a semantic commit parent, and
+/// persists canonical materialized sync aliases independently from rebuilt
+/// snapshot roots. Older readers reject those manifest/sidecar shapes, so the
+/// repository gate must fail before they reach either storage plane.
+pub(crate) const CURRENT_FORMAT_VERSION: u32 = 70;
 const REPOSITORY_PROTOCOL_PREFIX: &[u8] = b"tracked-default-branch.v";
-pub(crate) const REPOSITORY_PROTOCOL_VALUE: &[u8] = b"tracked-default-branch.v69";
+pub(crate) const REPOSITORY_PROTOCOL_VALUE: &[u8] = b"tracked-default-branch.v70";
 
 /// Raw status of the repository protocol marker. Engine opening consults this
 /// before it touches any tracked-head space, whose physical IDs deliberately
@@ -1202,16 +1208,16 @@ mod tests {
     #[test]
     fn repository_protocol_parser_distinguishes_versions() {
         assert_eq!(
-            parse_repository_protocol(b"tracked-default-branch.v69"),
+            parse_repository_protocol(b"tracked-default-branch.v70"),
             RepositoryProtocolStatus::Current
         );
         assert_eq!(
-            parse_repository_protocol(b"tracked-default-branch.v68"),
-            RepositoryProtocolStatus::MigrationRequired { found_version: 68 }
+            parse_repository_protocol(b"tracked-default-branch.v69"),
+            RepositoryProtocolStatus::MigrationRequired { found_version: 69 }
         );
         assert_eq!(
-            parse_repository_protocol(b"tracked-default-branch.v70"),
-            RepositoryProtocolStatus::TooNew { found_version: 70 }
+            parse_repository_protocol(b"tracked-default-branch.v71"),
+            RepositoryProtocolStatus::TooNew { found_version: 71 }
         );
         assert_eq!(
             parse_repository_protocol(b"not-a-lix-format"),
@@ -1335,8 +1341,7 @@ mod tests {
         );
         for row in &account_rows {
             assert_eq!(
-                row.commit_id,
-                receipt.initial_commit_id,
+                row.commit_id, receipt.initial_commit_id,
                 "account {:?} should be in the initial commit",
                 row.row_pk
             );

--- a/packages/lix/src/migration/api.rs
+++ b/packages/lix/src/migration/api.rs
@@ -1,17 +1,29 @@
+use std::collections::{BTreeMap, BTreeSet};
+
 use bytes::Bytes;
 
+use crate::LixError;
+use crate::branch::BranchHeadControlContext;
 use crate::init::{
     CURRENT_FORMAT_VERSION, REPOSITORY_PROTOCOL_KEY, REPOSITORY_PROTOCOL_SPACE,
     RepositoryProtocolStatus, parse_repository_protocol,
 };
 use crate::storage_adapter::{
-    Storage, StorageCoreProjection as CoreProjection, StorageGetManyRequest as GetManyRequest,
-    StorageGetOptions as GetOptions, StorageKey as Key, StorageProjectedValue as ProjectedValue,
-    StorageError, StorageRead, StorageReadOptions as ReadOptions,
+    SharedStorageAdapterRead, Storage, StorageCoreProjection as CoreProjection, StorageError,
+    StorageGetManyRequest as GetManyRequest, StorageGetOptions as GetOptions, StorageKey as Key,
+    StoragePrecondition as Precondition, StorageProjectedValue as ProjectedValue, StorageRead,
+    StorageReadOptions as ReadOptions, StorageWrite, StorageWriteOptions as WriteOptions,
 };
-use crate::LixError;
+use crate::tracked_state::{
+    CommitStateReplayDebt, TrackedStateContext,
+    encode_commit_state_manifest_replacement_for_migration,
+    load_rebuild_plans_to_nearest_available_root_bounded, stage_rebuild_plan_with_writer,
+};
 
-/// Bounds for the intentionally small-repository v68→v69 migration.
+const REPOSITORY_PROTOCOL_V68: &[u8] = b"tracked-default-branch.v68";
+const REPOSITORY_PROTOCOL_V69: &[u8] = b"tracked-default-branch.v69";
+
+/// Bounds for the intentionally small-repository v68 migration.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct MigrationOptions {
     pub max_changes: usize,
@@ -39,9 +51,17 @@ pub struct MigrationReport {
 /// Repository-format state observed without opening the engine.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum MigrationStatus {
-    Current { version: u32 },
-    Required { from_version: u32, to_version: u32 },
-    TooNew { found_version: u32, supported_version: u32 },
+    Current {
+        version: u32,
+    },
+    Required {
+        from_version: u32,
+        to_version: u32,
+    },
+    TooNew {
+        found_version: u32,
+        supported_version: u32,
+    },
     Missing,
     Malformed,
 }
@@ -97,11 +117,13 @@ where
     })
 }
 
-/// Offline, bounded v68→v69 repository migration.
+/// Offline, bounded repository migration to the current format.
 ///
 /// Callers must place the repository in maintenance mode and take their
-/// backend-level backup first. All physical validation and conversion happen
-/// against one coherent read before a single durable atomic publication.
+/// backend-level backup first. Each format edge publishes atomically. A v68
+/// migration may stop in a valid, retryable v69 state after its typed rewrite;
+/// v69 root chunks may likewise be persisted unreferenced before the final
+/// atomic manifest replacement and v70 marker publication.
 pub async fn migrate_repository<S>(
     storage: S,
     options: MigrationOptions,
@@ -114,8 +136,10 @@ where
         .begin_read(ReadOptions::default())
         .await
         .map_err(storage_error)?;
-    match crate::init::repository_protocol_status(&read).await? {
-        RepositoryProtocolStatus::MigrationRequired { found_version: 68 } => {}
+    let from_version = match crate::init::repository_protocol_status(&read).await? {
+        RepositoryProtocolStatus::MigrationRequired {
+            found_version: found_version @ (68 | 69),
+        } => found_version,
         RepositoryProtocolStatus::Current => {
             return Ok(MigrationReport {
                 from_version: CURRENT_FORMAT_VERSION,
@@ -140,18 +164,29 @@ where
                 "repository has no valid versioned protocol marker",
             ));
         }
-    }
+    };
     let expected_revision =
         crate::storage_adapter::StorageAdapter::<S>::load_mutation_revision_from_read(&read)
             .await
             .map_err(storage_error)?;
+    if from_version == 69 {
+        drop(read);
+        promote_v69_branch_head_roots(&adapter, &storage, options).await?;
+        return Ok(MigrationReport {
+            from_version,
+            to_version: CURRENT_FORMAT_VERSION,
+            changes_rewritten: 0,
+            commit_members_rewritten: 0,
+            hot_rows_rewritten: 0,
+        });
+    }
     let (v68_changes, standalone_retained_bytes) =
         crate::migration::v68::preflight_standalone_changelog(
-        &read,
-        options.max_changes,
-        options.max_preflight_bytes,
-    )
-    .await?;
+            &read,
+            options.max_changes,
+            options.max_preflight_bytes,
+        )
+        .await?;
     let authority_byte_budget = options
         .max_preflight_bytes
         .saturating_sub(standalone_retained_bytes);
@@ -201,7 +236,15 @@ where
     )
     .await?;
     drop(read);
-    crate::migration::publish::publish(&storage, expected_revision, publication).await?;
+    crate::migration::publish::publish(
+        &storage,
+        expected_revision,
+        REPOSITORY_PROTOCOL_V68,
+        REPOSITORY_PROTOCOL_V69,
+        publication,
+    )
+    .await?;
+    promote_v69_branch_head_roots(&adapter, &storage, options).await?;
     Ok(MigrationReport {
         from_version: 68,
         to_version: CURRENT_FORMAT_VERSION,
@@ -209,6 +252,195 @@ where
         commit_members_rewritten: commit_plan.member_count,
         hot_rows_rewritten,
     })
+}
+
+/// Promotes every v69 branch head to a durable root fence before v70 makes
+/// complete-state checkpoint aliases depend on that invariant.
+///
+/// Chunk publication is deliberately separate from authority publication.
+/// Content-addressed chunks are safe to leave unreferenced after a crash; the
+/// immutable manifest replacements and protocol marker are not, so those land
+/// together in the final atomic publication.
+async fn promote_v69_branch_head_roots<S>(
+    adapter: &crate::storage_adapter::StorageAdapter<S>,
+    storage: &S,
+    options: MigrationOptions,
+) -> Result<(), LixError>
+where
+    S: Storage + Clone + Send + Sync + 'static,
+{
+    let read = SharedStorageAdapterRead::new(
+        adapter
+            .begin_read(ReadOptions::default())
+            .await
+            .map_err(storage_error)?,
+    );
+    match crate::init::repository_protocol_status(&read).await? {
+        RepositoryProtocolStatus::MigrationRequired { found_version: 69 } => {}
+        status => {
+            return Err(migration_error(format!(
+                "v69 root promotion observed unexpected repository status {status:?}"
+            )));
+        }
+    }
+    let expected_revision = crate::storage_adapter::load_repository_mutation_revision(&read)
+        .await
+        .map_err(storage_error)?;
+    let head_commit_ids = BranchHeadControlContext::new()
+        .reader(read.clone())
+        .scan()
+        .await?
+        .into_iter()
+        .map(|(_, control)| control.head_commit_id)
+        .collect::<BTreeSet<_>>();
+    if head_commit_ids.len() > options.max_changes {
+        return Err(LixError::new(
+            "LIX_ERROR_MIGRATION_LIMIT_EXCEEDED",
+            format!(
+                "v69 root promotion exceeds configured head bound: {} heads",
+                head_commit_ids.len()
+            ),
+        ));
+    }
+
+    let tracked_state = TrackedStateContext::new();
+    let mut chunk_writes = adapter.new_write_set();
+    let mut promotions = BTreeMap::new();
+    let mut staged_commit_ids = BTreeSet::new();
+    let mut remaining_members = options.max_changes;
+    {
+        let mut writer = tracked_state.writer(&read, &mut chunk_writes);
+        for head_commit_id in head_commit_ids {
+            let manifest = crate::tracked_state::load_commit_state_manifest(&read, head_commit_id)
+                .await?
+                .ok_or_else(|| {
+                    migration_error(format!(
+                        "v69 branch head '{head_commit_id}' has no commit-state manifest"
+                    ))
+                })?;
+            if manifest.snapshot_root.is_some() {
+                continue;
+            }
+            let plans = load_rebuild_plans_to_nearest_available_root_bounded(
+                &read,
+                &head_commit_id.to_string(),
+                true,
+                remaining_members,
+                &staged_commit_ids,
+            )
+            .await?;
+            remaining_members = remaining_members.saturating_sub(
+                plans
+                    .iter()
+                    .filter(|plan| !staged_commit_ids.contains(&plan.commit_id))
+                    .map(|plan| plan.deltas.len())
+                    .sum::<usize>(),
+            );
+            for plan in plans.iter().rev() {
+                if staged_commit_ids.insert(plan.commit_id) {
+                    if staged_commit_ids.len() > options.max_changes {
+                        return Err(LixError::new(
+                            "LIX_ERROR_MIGRATION_LIMIT_EXCEEDED",
+                            format!(
+                                "v69 root promotion exceeds configured replay-commit bound: {} commits",
+                                staged_commit_ids.len()
+                            ),
+                        ));
+                    }
+                    stage_rebuild_plan_with_writer(&mut writer, plan).await?;
+                    let mut plan_manifest =
+                        crate::tracked_state::load_commit_state_manifest(&read, plan.commit_id)
+                            .await?
+                            .ok_or_else(|| {
+                                migration_error(format!(
+                                    "v69 replay commit '{}' has no commit-state manifest",
+                                    plan.commit_id
+                                ))
+                            })?;
+                    if plan_manifest.snapshot_root.is_none() {
+                        let snapshot_root = writer
+                            .staged_commit_roots()
+                            .find(|root| root.commit_id == plan.commit_id)
+                            .cloned()
+                            .ok_or_else(|| {
+                                migration_error(format!(
+                                    "v69 root promotion did not stage replay commit '{}'",
+                                    plan.commit_id
+                                ))
+                            })?;
+                        plan_manifest.snapshot_root = Some(Box::new(snapshot_root));
+                        plan_manifest.replay_debt = CommitStateReplayDebt::default();
+                        promotions.insert(plan.commit_id, plan_manifest);
+                    }
+                }
+            }
+            if !promotions.contains_key(&head_commit_id) {
+                return Err(migration_error(format!(
+                    "v69 root promotion did not authorize branch head '{head_commit_id}'"
+                )));
+            }
+        }
+    }
+
+    let chunk_stats = chunk_writes.stats();
+    if chunk_stats.written_bytes > options.max_preflight_bytes as u64 {
+        return Err(LixError::new(
+            "LIX_ERROR_MIGRATION_LIMIT_EXCEEDED",
+            format!(
+                "v69 root promotion exceeds configured byte bound: {} bytes",
+                chunk_stats.written_bytes
+            ),
+        ));
+    }
+    if chunk_stats.staged_puts != 0 || chunk_stats.staged_deletes != 0 {
+        // Chunk rows are content-addressed and not authority until the final
+        // manifest publication. Persist them without rotating the repository
+        // mutation token, so that exact original token still fences every
+        // concurrent domain write through the final v70 marker flip.
+        let mut write = storage
+            .begin_write(WriteOptions {
+                await_durable: true,
+                preconditions: vec![
+                    Precondition::KeyValueEquals {
+                        space: REPOSITORY_PROTOCOL_SPACE,
+                        key: Key(Bytes::from_static(REPOSITORY_PROTOCOL_KEY)),
+                        expected: Bytes::from_static(REPOSITORY_PROTOCOL_V69),
+                    },
+                    crate::storage_adapter::repository_mutation_revision_precondition(
+                        expected_revision.clone(),
+                    ),
+                ],
+                ..WriteOptions::default()
+            })
+            .await
+            .map_err(storage_error)?;
+        if let Err(error) = chunk_writes.lower_into(&mut write).await {
+            let _ = write.rollback().await;
+            return Err(error.into());
+        }
+        write.commit().await.map_err(storage_error)?;
+    }
+    read.finish().map_err(storage_error)?;
+
+    let mut publication = crate::migration::publish::PublicationPlan::bounded(
+        options.max_changes.saturating_mul(2),
+        options.max_preflight_bytes,
+    );
+    for manifest in promotions.into_values() {
+        for (space, key, value) in
+            encode_commit_state_manifest_replacement_for_migration(&manifest)?
+        {
+            publication.replace_immutable(space, vec![(key, value)])?;
+        }
+    }
+    crate::migration::publish::publish(
+        storage,
+        expected_revision,
+        REPOSITORY_PROTOCOL_V69,
+        crate::init::REPOSITORY_PROTOCOL_VALUE,
+        publication,
+    )
+    .await
 }
 
 fn storage_error(error: StorageError) -> LixError {
@@ -220,4 +452,140 @@ fn storage_error(error: StorageError) -> LixError {
 
 fn migration_error(message: impl Into<String>) -> LixError {
     LixError::new("LIX_ERROR_MIGRATION_FAILED", message.into())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::storage::{Memory, StorageWrite, WriteOptions};
+    use crate::storage_adapter::{PutBatch, PutEntry, StorageValue};
+
+    #[tokio::test]
+    async fn migrates_v69_with_a_marker_only_publication() {
+        let storage = Memory::new();
+        let adapter = crate::storage_adapter::StorageAdapter::new(storage.clone());
+        let mut seed = adapter.new_write_set();
+        seed.put(
+            REPOSITORY_PROTOCOL_SPACE,
+            REPOSITORY_PROTOCOL_KEY,
+            &b"tracked-default-branch.v69"[..],
+        );
+        adapter
+            .commit_write_set(seed, WriteOptions::default())
+            .await
+            .unwrap();
+
+        let report = migrate_repository(storage.clone(), MigrationOptions::default())
+            .await
+            .unwrap();
+        assert_eq!(
+            report,
+            MigrationReport {
+                from_version: 69,
+                to_version: CURRENT_FORMAT_VERSION,
+                changes_rewritten: 0,
+                commit_members_rewritten: 0,
+                hot_rows_rewritten: 0,
+            }
+        );
+        assert_eq!(
+            inspect_repository(&storage).await.unwrap(),
+            MigrationStatus::Current {
+                version: CURRENT_FORMAT_VERSION,
+            }
+        );
+    }
+
+    #[tokio::test]
+    async fn migrates_rootless_v69_branch_heads_before_enabling_checkpoint_aliases() {
+        let storage = Memory::new();
+        let lix = crate::open_lix()
+            .with_storage(storage.clone())
+            .await
+            .unwrap();
+        drop(lix);
+
+        let adapter = crate::storage_adapter::StorageAdapter::new(storage.clone());
+        let read = SharedStorageAdapterRead::new(
+            adapter.begin_read(ReadOptions::default()).await.unwrap(),
+        );
+        let head_commit_ids = BranchHeadControlContext::new()
+            .reader(read.clone())
+            .scan()
+            .await
+            .unwrap()
+            .into_iter()
+            .map(|(_, control)| control.head_commit_id)
+            .collect::<BTreeSet<_>>();
+        let mut replacements = Vec::new();
+        for commit_id in &head_commit_ids {
+            let mut manifest = crate::tracked_state::load_commit_state_manifest(&read, *commit_id)
+                .await
+                .unwrap()
+                .unwrap();
+            manifest.snapshot_root = None;
+            manifest.replay_debt = CommitStateReplayDebt {
+                depth: 1,
+                rows: u64::from(manifest.mutations.member_count),
+                bytes: 1,
+            };
+            for replacement in
+                encode_commit_state_manifest_replacement_for_migration(&manifest).unwrap()
+            {
+                replacements.push(replacement);
+            }
+        }
+        read.finish().unwrap();
+
+        let mut fixture = storage.begin_write(WriteOptions::default()).await.unwrap();
+        for (space, key, value) in replacements {
+            fixture
+                .replace_many(
+                    space,
+                    PutBatch {
+                        entries: vec![PutEntry {
+                            key: Key(Bytes::from(key)),
+                            value: StorageValue {
+                                bytes: Bytes::from(value),
+                            },
+                        }],
+                    },
+                )
+                .await
+                .unwrap();
+        }
+        fixture
+            .put_many(
+                REPOSITORY_PROTOCOL_SPACE,
+                PutBatch {
+                    entries: vec![PutEntry {
+                        key: Key(Bytes::from_static(REPOSITORY_PROTOCOL_KEY)),
+                        value: StorageValue {
+                            bytes: Bytes::from_static(REPOSITORY_PROTOCOL_V69),
+                        },
+                    }],
+                },
+            )
+            .await
+            .unwrap();
+        fixture.commit().await.unwrap();
+
+        migrate_repository(storage.clone(), MigrationOptions::default())
+            .await
+            .unwrap();
+        let read = SharedStorageAdapterRead::new(
+            adapter.begin_read(ReadOptions::default()).await.unwrap(),
+        );
+        for commit_id in head_commit_ids {
+            let manifest = crate::tracked_state::load_commit_state_manifest(&read, commit_id)
+                .await
+                .unwrap()
+                .unwrap();
+            assert!(manifest.snapshot_root.is_some());
+        }
+        read.finish().unwrap();
+
+        let lix = crate::open_lix().with_storage(storage).await.unwrap();
+        lix.create_checkpoint().await.unwrap();
+    }
 }

--- a/packages/lix/src/migration/publish.rs
+++ b/packages/lix/src/migration/publish.rs
@@ -2,16 +2,13 @@ use std::ops::Bound;
 
 use bytes::Bytes;
 
-use crate::init::{
-    REPOSITORY_PROTOCOL_KEY, REPOSITORY_PROTOCOL_SPACE, REPOSITORY_PROTOCOL_VALUE,
-};
-use crate::storage_adapter::{
-    PutBatch, PutEntry, Storage, StorageKey as Key,
-    StorageError, StorageKeyRange as KeyRange, StoragePrecondition as Precondition, StorageSpace,
-    StorageValue as StoredValue, StorageWrite, StorageWriteOptions as WriteOptions, ValueIntegrity,
-    ValueSemantics,
-};
 use crate::LixError;
+use crate::init::{REPOSITORY_PROTOCOL_KEY, REPOSITORY_PROTOCOL_SPACE, REPOSITORY_PROTOCOL_VALUE};
+use crate::storage_adapter::{
+    PutBatch, PutEntry, Storage, StorageError, StorageKey as Key, StorageKeyRange as KeyRange,
+    StoragePrecondition as Precondition, StorageSpace, StorageValue as StoredValue, StorageWrite,
+    StorageWriteOptions as WriteOptions, ValueIntegrity, ValueSemantics,
+};
 
 /// Fully preflighted physical mutations. Construction stays private so the
 /// executor cannot publish a partially validated migration.
@@ -75,7 +72,9 @@ impl PublicationPlan {
         entries: Vec<(Vec<u8>, Vec<u8>)>,
     ) -> Result<(), LixError> {
         if space.value_semantics != ValueSemantics::Mutable {
-            return Err(plan_error("mutable migration put targeted an immutable space"));
+            return Err(plan_error(
+                "mutable migration put targeted an immutable space",
+            ));
         }
         let batch = put_batch(entries)?;
         self.account(&batch)?;
@@ -127,12 +126,14 @@ impl Default for PublicationPlan {
     }
 }
 
-/// Publishes one already-complete v68→v69 plan in a single durable backend
+/// Publishes one already-complete migration plan in a single durable backend
 /// transaction. The marker precondition fences concurrent writers and the
 /// marker update shares the same atomic commit as every authority rewrite.
 pub(super) async fn publish<S>(
     storage: &S,
     expected_mutation_revision: Option<Bytes>,
+    expected_protocol_value: &'static [u8],
+    target_protocol_value: &'static [u8],
     plan: PublicationPlan,
 ) -> Result<(), LixError>
 where
@@ -140,7 +141,7 @@ where
 {
     let marker_batch = put_batch(vec![(
         REPOSITORY_PROTOCOL_KEY.to_vec(),
-        REPOSITORY_PROTOCOL_VALUE.to_vec(),
+        target_protocol_value.to_vec(),
     )])?;
     let mut write = storage
         .begin_write(WriteOptions {
@@ -149,7 +150,7 @@ where
                 Precondition::KeyValueEquals {
                     space: REPOSITORY_PROTOCOL_SPACE,
                     key: Key(Bytes::from_static(REPOSITORY_PROTOCOL_KEY)),
-                    expected: Bytes::from_static(b"tracked-default-branch.v68"),
+                    expected: Bytes::from_static(expected_protocol_value),
                 },
                 crate::storage_adapter::StorageAdapter::<S>::mutation_revision_precondition(
                     expected_mutation_revision,
@@ -162,14 +163,15 @@ where
 
     let stage_result: Result<(), StorageError> = async {
         for space in plan.cleared_spaces {
-            write.delete_range(
-                space,
-                KeyRange {
-                    lower: Bound::Unbounded,
-                    upper: Bound::Unbounded,
-                },
-            )
-            .await?;
+            write
+                .delete_range(
+                    space,
+                    KeyRange {
+                        lower: Bound::Unbounded,
+                        upper: Bound::Unbounded,
+                    },
+                )
+                .await?;
         }
         for (space, entries) in plan.replacements {
             write.replace_many(space, entries).await?;
@@ -196,7 +198,9 @@ where
 fn put_batch(mut entries: Vec<(Vec<u8>, Vec<u8>)>) -> Result<PutBatch, LixError> {
     entries.sort_unstable_by(|left, right| left.0.cmp(&right.0));
     if entries.windows(2).any(|pair| pair[0].0 == pair[1].0) {
-        return Err(plan_error("migration plan contains a duplicate physical key"));
+        return Err(plan_error(
+            "migration plan contains a duplicate physical key",
+        ));
     }
     Ok(PutBatch {
         entries: entries
@@ -217,12 +221,10 @@ fn plan_error(message: impl Into<String>) -> LixError {
 
 fn storage_error(error: StorageError) -> LixError {
     let code = match &error {
-        StorageError::CommitOutcomeUnknown(_) => {
-            "LIX_ERROR_MIGRATION_COMMIT_OUTCOME_UNKNOWN"
-        }
-        StorageError::PreconditionFailed(_) | StorageError::WriteConflict | StorageError::Fenced => {
-            "LIX_ERROR_MIGRATION_CONCURRENT_MUTATION"
-        }
+        StorageError::CommitOutcomeUnknown(_) => "LIX_ERROR_MIGRATION_COMMIT_OUTCOME_UNKNOWN",
+        StorageError::PreconditionFailed(_)
+        | StorageError::WriteConflict
+        | StorageError::Fenced => "LIX_ERROR_MIGRATION_CONCURRENT_MUTATION",
         _ => LixError::CODE_INTERNAL_ERROR,
     };
     LixError::new(code, format!("repository migration storage error: {error}"))
@@ -231,13 +233,13 @@ fn storage_error(error: StorageError) -> LixError {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::init::CURRENT_FORMAT_VERSION;
     use crate::storage::{
         CoreProjection, GetManyRequest, GetOptions, Memory, ProjectedValue, ReadOptions,
         StorageRead,
     };
 
-    const IMMUTABLE: StorageSpace =
-        crate::tracked_state::TRACKED_STATE_COMMIT_DELTA_SEGMENT_SPACE;
+    const IMMUTABLE: StorageSpace = crate::tracked_state::TRACKED_STATE_COMMIT_DELTA_SEGMENT_SPACE;
 
     #[tokio::test]
     async fn replaces_immutable_bytes_and_marker_atomically() {
@@ -262,14 +264,19 @@ mod tests {
         seed.commit().await.unwrap();
 
         let mut plan = PublicationPlan::default();
-        plan.replace_immutable(
-            IMMUTABLE,
-            vec![(b"same-key".to_vec(), b"v69".to_vec())],
-        )
-        .unwrap();
+        plan.replace_immutable(IMMUTABLE, vec![(b"same-key".to_vec(), b"v69".to_vec())])
+            .unwrap();
         let adapter = crate::storage_adapter::StorageAdapter::new(storage.clone());
         let revision = adapter.load_mutation_revision().await.unwrap();
-        publish(&storage, revision, plan).await.unwrap();
+        publish(
+            &storage,
+            revision,
+            b"tracked-default-branch.v68",
+            REPOSITORY_PROTOCOL_VALUE,
+            plan,
+        )
+        .await
+        .unwrap();
 
         let read = storage.begin_read(ReadOptions::default()).await.unwrap();
         let immutable_keys = [Key(Bytes::from_static(b"same-key"))];
@@ -323,25 +330,29 @@ mod tests {
         let stale_revision = adapter.load_mutation_revision().await.unwrap();
 
         let mut concurrent = adapter.new_write_set();
-        concurrent.put(
-            REPOSITORY_PROTOCOL_SPACE,
-            &b"unrelated"[..],
-            &b"write"[..],
-        );
+        concurrent.put(REPOSITORY_PROTOCOL_SPACE, &b"unrelated"[..], &b"write"[..]);
         adapter
             .commit_write_set(concurrent, WriteOptions::default())
             .await
             .unwrap();
 
-        let error = publish(&storage, stale_revision, PublicationPlan::default())
-            .await
-            .expect_err("stale migration must be fenced");
+        let error = publish(
+            &storage,
+            stale_revision,
+            b"tracked-default-branch.v68",
+            REPOSITORY_PROTOCOL_VALUE,
+            PublicationPlan::default(),
+        )
+        .await
+        .expect_err("stale migration must be fenced");
         assert!(error.to_string().contains("precondition failed"));
         assert_eq!(
-            crate::migration::inspect_repository(&storage).await.unwrap(),
+            crate::migration::inspect_repository(&storage)
+                .await
+                .unwrap(),
             crate::migration::MigrationStatus::Required {
                 from_version: 68,
-                to_version: 69,
+                to_version: CURRENT_FORMAT_VERSION,
             }
         );
     }

--- a/packages/lix/src/migration/registry.rs
+++ b/packages/lix/src/migration/registry.rs
@@ -8,10 +8,16 @@ pub(crate) struct Migration {
     pub(crate) to_version: u32,
 }
 
-const MIGRATIONS: &[Migration] = &[Migration {
-    from_version: 68,
-    to_version: 69,
-}];
+const MIGRATIONS: &[Migration] = &[
+    Migration {
+        from_version: 68,
+        to_version: 69,
+    },
+    Migration {
+        from_version: 69,
+        to_version: 70,
+    },
+];
 
 pub(crate) fn registered_migrations() -> &'static [Migration] {
     MIGRATIONS
@@ -28,7 +34,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn registry_describes_v68_to_current() {
+    fn registry_describes_format_edges() {
         assert_eq!(
             migration_from(68),
             Some(&Migration {
@@ -36,7 +42,14 @@ mod tests {
                 to_version: 69,
             })
         );
-        assert_eq!(registered_migrations().len(), 1);
+        assert_eq!(
+            migration_from(69),
+            Some(&Migration {
+                from_version: 69,
+                to_version: 70,
+            })
+        );
+        assert_eq!(registered_migrations().len(), 2);
         assert_eq!(migration_from(crate::init::CURRENT_FORMAT_VERSION), None);
     }
 }

--- a/packages/lix/src/registered_spaces.rs
+++ b/packages/lix/src/registered_spaces.rs
@@ -108,8 +108,11 @@ pub const UPLOAD_MANIFEST_LEAF_SPACE: StorageSpace = crate::session::UPLOAD_MANI
 pub const SYNC_SEQUENCE_SPACE: StorageSpace = crate::sync::SYNC_SEQUENCE_SPACE;
 pub const SYNC_REPOSITORY_EVENT_SPACE: StorageSpace = crate::sync::SYNC_REPOSITORY_EVENT_SPACE;
 pub const SYNC_REPLICA_STATE_SPACE: StorageSpace = crate::sync::SYNC_REPLICA_STATE_SPACE;
+pub const SYNC_MATERIALIZED_STATE_ALIAS_SPACE: StorageSpace =
+    crate::sync::SYNC_MATERIALIZED_STATE_ALIAS_SPACE;
 pub const CHECKPOINT_RECOVERY_REF_SPACE: StorageSpace = crate::gc::CHECKPOINT_RECOVERY_REF_SPACE;
 pub const CHECKPOINT_GC_STATE_SPACE: StorageSpace = crate::gc::CHECKPOINT_GC_STATE_SPACE;
+pub const COMMIT_RETIREMENT_INTENT_SPACE: StorageSpace = crate::gc::COMMIT_RETIREMENT_INTENT_SPACE;
 
 #[cfg(test)]
 mod tests {
@@ -159,8 +162,10 @@ mod tests {
         SYNC_SEQUENCE_SPACE,
         SYNC_REPOSITORY_EVENT_SPACE,
         SYNC_REPLICA_STATE_SPACE,
+        SYNC_MATERIALIZED_STATE_ALIAS_SPACE,
         CHECKPOINT_RECOVERY_REF_SPACE,
         CHECKPOINT_GC_STATE_SPACE,
+        COMMIT_RETIREMENT_INTENT_SPACE,
     ];
 
     /// The published handles must be the registry, exactly and in order.

--- a/packages/lix/src/server_protocol/client/tests.rs
+++ b/packages/lix/src/server_protocol/client/tests.rs
@@ -13,8 +13,8 @@ use crate::Value;
 use super::http::{
     ProtocolHttp, ProtocolHttpRequest, ProtocolHttpResponse, ProtocolHttpStream, StreamCancel,
 };
-use super::wire::{SERVER_CLOSED_CODE, SESSION_GONE_CODE};
-use super::{open_protocol_client, ProtocolExecuteOptions};
+use super::wire::{SERVER_CLOSED_CODE, SERVER_PROTOCOL_VERSION, SESSION_GONE_CODE};
+use super::{ProtocolExecuteOptions, open_protocol_client};
 
 #[derive(Clone, Default)]
 struct ScriptHttp {
@@ -77,12 +77,7 @@ impl ProtocolHttp for ScriptHttp {
             .lock()
             .expect("script requests")
             .push(request.clone());
-        match self
-            .outcomes
-            .lock()
-            .expect("script outcomes")
-            .pop_front()
-        {
+        match self.outcomes.lock().expect("script outcomes").pop_front() {
             Some(ScriptOutcome::Json { status, body }) => Ok(ProtocolHttpResponse {
                 status,
                 headers: vec![("content-type".to_owned(), "application/json".to_owned())],
@@ -112,12 +107,7 @@ impl ProtocolHttp for ScriptHttp {
             .lock()
             .expect("script requests")
             .push(request.clone());
-        match self
-            .outcomes
-            .lock()
-            .expect("script outcomes")
-            .pop_front()
-        {
+        match self.outcomes.lock().expect("script outcomes").pop_front() {
             Some(ScriptOutcome::Stream {
                 status,
                 headers,
@@ -172,7 +162,7 @@ impl ProtocolHttp for ScriptHttp {
 
 fn handshake(session_id: &str, branch_id: &str) -> serde_json::Value {
     serde_json::json!({
-        "protocolVersion": 2,
+        "protocolVersion": SERVER_PROTOCOL_VERSION,
         "activeBranchId": branch_id,
         "activeAccountId": "00000000-0000-7000-8000-000000000002",
         "sessionId": session_id,
@@ -330,7 +320,9 @@ async fn open_handshake_can_pin_an_initial_branch() {
     client.close().await.expect("close");
     let handshake_url = &http.requests()[0].url;
     assert!(handshake_url.contains("/@acme/repository/lix/v1/"));
-    assert!(handshake_url.contains("activeBranchId=draft+%2F+one") || handshake_url.contains("draft"));
+    assert!(
+        handshake_url.contains("activeBranchId=draft+%2F+one") || handshake_url.contains("draft")
+    );
     assert!(http.requests()[0].header("Lix-Session-Id").is_none());
 }
 

--- a/packages/lix/src/server_protocol/client/wire.rs
+++ b/packages/lix/src/server_protocol/client/wire.rs
@@ -2,7 +2,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::{ExecuteResult, LixError, LixNotice, Value, WireValue};
 
-pub const SERVER_PROTOCOL_VERSION: u32 = 2;
+pub const SERVER_PROTOCOL_VERSION: u32 = 3;
 pub const SESSION_GONE_CODE: &str = "LIX_ERROR_PROTOCOL_SESSION_GONE";
 pub const SERVER_CLOSED_CODE: &str = "LIX_ERROR_PROTOCOL_SERVER_CLOSED";
 pub const BLOB_BASE_MISSING_CODE: &str = "LIX_REMOTE_BLOB_BASE_MISSING";

--- a/packages/lix/src/server_protocol/handler.rs
+++ b/packages/lix/src/server_protocol/handler.rs
@@ -261,7 +261,7 @@ impl Event {
 /// Stable URL prefix owned by the Lix Server Protocol.
 pub const PROTOCOL_PATH: &str = "/lix/v1";
 /// Current wire protocol version.
-pub const PROTOCOL_VERSION: u32 = 2;
+pub const PROTOCOL_VERSION: u32 = 3;
 /// Canonical method and path registry for protocol hosts and conformance tools.
 pub const SERVER_PROTOCOL_ENDPOINTS: &[(&str, &str)] = &[
     ("GET", "/lix/v1"),
@@ -4864,6 +4864,8 @@ mod tests {
         assert!(openapi.contains(
             "required: [commitId, parentCommitIds, accountId, createdAt, selectedSourceCommitId, members]"
         ));
+        assert!(openapi.contains("required: [sourceCommitId, stateRootId]"));
+        assert!(openapi.contains("stateAlias:"));
         assert!(openapi.contains("changeAccountId: { type: string, minLength: 1 }"));
         assert!(openapi.contains("changeCreatedAt: { type: string, minLength: 1 }"));
         assert_eq!(
@@ -4877,7 +4879,7 @@ mod tests {
             assert!(openapi.contains(&format!("type: {{ const: {row_pk_type} }}")));
         }
         assert!(!openapi.contains("rowPk: {}"));
-        assert!(!openapi.contains("sourceCommitId:"));
+        assert!(openapi.contains("sourceCommitId:"));
     }
 
     #[test]
@@ -6720,7 +6722,10 @@ mod tests {
         .await;
         assert_eq!(first.status(), StatusCode::OK);
         let first = response_json(first).await;
-        assert!(first[0]["rows"][0][0]["value"].as_i64().unwrap_or(0) >= 2);
+        assert!(
+            first[0]["rows"][0][0]["value"].as_i64().unwrap_or(0) >= 2,
+            "sparse history response: {first}"
+        );
         hydration.await.expect("history hydration task");
 
         let replay = request_with_headers(

--- a/packages/lix/src/session/checkpoint.rs
+++ b/packages/lix/src/session/checkpoint.rs
@@ -1,12 +1,14 @@
 use crate::LixError;
 use crate::branch::{BranchLifecycle, BranchOperation, BranchReferenceRole};
-use crate::checkpoint::{CHECKPOINT_SCHEMA_KEY, checkpoint_stage_row};
+use crate::checkpoint::checkpoint_stage_row;
 use crate::gc::CheckpointGcState;
 use crate::storage_adapter::Storage;
 use crate::telemetry::{
     ActiveTelemetrySpan, TelemetryAttribute, TelemetrySpanClass, TelemetrySpanStatus,
 };
-use crate::tracked_state::{TrackedStateDiffKind, TrackedStateDiffRequest, TrackedStateDiffRow};
+#[cfg(test)]
+use crate::tracked_state::{TrackedStateDiffKind, TrackedStateDiffRow};
+#[cfg(test)]
 use crate::transaction::StagedCommitChangeBatchBuilder;
 use crate::transaction_types::{RawWriteBatch, TransactionWrite, TransactionWriteMode};
 
@@ -39,6 +41,7 @@ struct CreateCheckpointOutcome {
     receipt: CreateCheckpointReceipt,
     parent_commit_id: String,
     gc_due: bool,
+    checkpoint_sequence: u64,
 }
 
 impl<StorageImpl> SessionContext<StorageImpl>
@@ -47,12 +50,10 @@ where
 {
     /// Creates a checkpoint for the active branch.
     ///
-    /// The new commit contains the net tracked changes since the previous
-    /// checkpoint and parents that checkpoint directly. The old branch head is
-    /// retained as a local recovery root for the GC grace window. Publication
-    /// returns as soon as that durable root is committed; due garbage
-    /// collection runs asynchronously so a history-sized sweep cannot extend
-    /// the foreground checkpoint latency.
+    /// The new metadata-only commit structurally aliases the captured branch
+    /// state while parenting the prior checkpoint. Publication never reads or
+    /// copies interval members. Scale-dependent physical reclamation is
+    /// maintenance work and cannot extend foreground checkpoint latency.
     pub async fn create_checkpoint(&self) -> Result<CreateCheckpointReceipt, LixError> {
         let span = self.telemetry.as_ref().and_then(|sink| {
             ActiveTelemetrySpan::start_if_enabled(
@@ -64,6 +65,12 @@ where
         });
         let operation = self.with_write_transaction_lending(async move |transaction| {
             let branch_id = transaction.active_branch_id().to_string();
+            if branch_id == crate::GLOBAL_BRANCH_ID {
+                return Err(LixError::new(
+                    LixError::CODE_INVALID_PARAM,
+                    "the repository-global branch cannot be checkpointed",
+                ));
+            }
             let (previous_recovery, mut gc_state) =
                 transaction.checkpoint_publication_state(&branch_id).await?;
             let head_commit_id = {
@@ -76,62 +83,14 @@ where
                     )
                     .await?
             };
-            let direct_working_diff = transaction
-                .working_diff_at_head(
-                    &branch_id,
-                    head_commit_id,
-                    &TrackedStateDiffRequest::default(),
-                )
+            let previous_checkpoint_commit_id = transaction
+                .checkpoint_commit_id_at_head(&branch_id, head_commit_id)
                 .await?;
-            let previous_checkpoint_commit_id = if let Some(direct) = &direct_working_diff {
-                direct.checkpoint_commit_id
-            } else {
-                transaction
-                    .checkpoint_commit_id_at_head(&branch_id, head_commit_id)
-                    .await?
-            };
             let interval_has_commits = head_commit_id != previous_checkpoint_commit_id;
-            let selected_changes = {
-                let entries = if let Some(direct) = direct_working_diff {
-                    direct.diff.entries
-                } else {
-                    let mut reader = transaction.tracked_state_reader().await;
-                    reader
-                        .diff_commits(
-                            &previous_checkpoint_commit_id.to_string(),
-                            &head_commit_id.to_string(),
-                            &TrackedStateDiffRequest::default(),
-                        )
-                        .await?
-                        .entries
-                };
-                let mut selected_changes =
-                    StagedCommitChangeBatchBuilder::with_capacity(entries.len());
-                let mut source_membership_exact = true;
-                for entry in entries.into_iter().filter(|entry| {
-                    entry.identity.schema_key() != CHECKPOINT_SCHEMA_KEY
-                        && entry.identity.schema_key()
-                            != crate::undo_redo::UNDO_REDO_MARKER_SCHEMA_KEY
-                }) {
-                    let row = entry.after.ok_or_else(|| {
-                        LixError::new(
-                            LixError::CODE_INTERNAL_ERROR,
-                            format!(
-                                "working diff for schema '{}' row {:?} has no target row",
-                                entry.identity.schema_key(),
-                                entry.identity.row_pk()
-                            ),
-                        )
-                    })?;
-                    source_membership_exact &=
-                        push_selected_change(&mut selected_changes, row, entry.kind);
-                }
-                if source_membership_exact {
-                    selected_changes.finish_source_certified()
-                } else {
-                    selected_changes.finish()
-                }
-            };
+            // The checkpoint commit severs the ordinary first-parent interval.
+            // Commit materialization publishes a complete-state fence that
+            // structurally shares the captured head root, so publication does
+            // not enumerate or copy interval members.
             gc_state.checkpoint_sequence =
                 gc_state.checkpoint_sequence.checked_add(1).ok_or_else(|| {
                     LixError::new(
@@ -144,13 +103,12 @@ where
             }
             let gc_due = checkpoint_gc_due(gc_state)?;
 
-            let commit_id = transaction.stage_checkpoint_commit(
+            let commit_id = transaction.stage_checkpoint_boundary_commit(
                 branch_id,
                 previous_checkpoint_commit_id,
                 head_commit_id,
                 interval_has_commits,
                 gc_state,
-                selected_changes,
             )?;
             let checkpoint_commit_id =
                 crate::changelog::CommitId::parse_lix(&commit_id, "checkpoint commit id")?;
@@ -173,6 +131,7 @@ where
                 },
                 parent_commit_id: previous_checkpoint_commit_id.to_string(),
                 gc_due,
+                checkpoint_sequence: gc_state.checkpoint_sequence,
             })
         });
         let result = match span.as_ref() {
@@ -203,20 +162,34 @@ where
                 ],
             );
         }
-        if outcome.gc_due {
+        if outcome.gc_due
+            && self
+                .commit_coordinator
+                .try_begin_checkpoint_gc(outcome.checkpoint_sequence)
+        {
             // GC debt is durable in the checkpoint transaction. The sweep is
             // therefore safely retryable and does not need to delay the user
             // checkpoint. A clone shares the same storage and collaboration
-            // write gate; concurrent schedules serialize, and only the first
-            // one that still sees debt performs work.
+            // coordinator. Concurrent schedules coalesce, and only the first
+            // one that still sees debt performs work. Repository-scale GC
+            // planning runs without the foreground session gate; its prepared
+            // commit relies on storage conflict detection.
             let gc_session = self.clone();
+            let gc_coordinator = self.commit_coordinator.clone();
             #[cfg(not(target_family = "wasm"))]
-            crate::background_task::spawn("lix-checkpoint-gc", move || async move {
-                gc_session.collect_checkpoint_garbage_best_effort().await;
-            })?;
+            if let Err(error) =
+                crate::background_task::spawn("lix-checkpoint-gc", move || async move {
+                    gc_session.collect_checkpoint_garbage_best_effort().await;
+                    gc_coordinator.finish_checkpoint_gc();
+                })
+            {
+                self.commit_coordinator.finish_checkpoint_gc();
+                return Err(error);
+            }
             #[cfg(target_family = "wasm")]
             tokio::spawn(async move {
                 gc_session.collect_checkpoint_garbage_best_effort().await;
+                gc_coordinator.finish_checkpoint_gc();
             });
         }
         Ok(outcome.receipt)
@@ -286,6 +259,7 @@ pub(crate) fn checkpoint_gc_due(state: CheckpointGcState) -> Result<bool, LixErr
     Ok(yield_due || stale_due)
 }
 
+#[cfg(test)]
 fn push_selected_change(
     selected_changes: &mut StagedCommitChangeBatchBuilder,
     row: TrackedStateDiffRow,
@@ -320,14 +294,38 @@ mod tests {
     use super::{
         RECLAIM_MIN_INVENTORY, RECLAIM_YIELD_DENOMINATOR, checkpoint_gc_due, push_selected_change,
     };
+    use crate::LixError;
     use crate::changelog::{ChangeId, CommitId};
     use crate::common::LixTimestamp;
     use crate::gc::CheckpointGcState;
     use crate::row_pk::RowPk;
+    use crate::storage::Memory;
     use crate::tracked_state::{
         TrackedStateDiffIdentity, TrackedStateDiffKind, TrackedStateDiffRow, TrackedStateKey,
     };
     use crate::transaction::StagedCommitChangeBatchBuilder;
+
+    #[tokio::test]
+    async fn repository_global_branch_cannot_be_checkpointed() {
+        let storage = Memory::new();
+        let _receipt = crate::engine::Engine::initialize(storage.clone())
+            .await
+            .expect("repository initializes");
+        let engine = crate::engine::Engine::new(storage)
+            .await
+            .expect("repository opens");
+        let session = engine
+            .open_session_at(crate::GLOBAL_BRANCH_ID)
+            .await
+            .expect("global session opens");
+
+        let error = session
+            .create_checkpoint()
+            .await
+            .expect_err("global branch checkpoint must be rejected");
+        assert_eq!(error.code, LixError::CODE_INVALID_PARAM);
+        assert!(error.to_string().contains("global branch"));
+    }
 
     #[test]
     fn canonicalized_added_timestamp_declines_source_membership_certificate() {

--- a/packages/lix/src/session/execute.rs
+++ b/packages/lix/src/session/execute.rs
@@ -6616,7 +6616,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn large_certified_insert_publishes_rootless_history_and_reads_packed_head() {
+    async fn large_certified_insert_publishes_rooted_history_and_reads_packed_head() {
         const ROW_COUNT: usize = 32 * 1_024;
         let session = open_session().await;
         let schema = serde_json::json!({
@@ -6708,9 +6708,7 @@ mod tests {
                 .await
                 .expect("head physical state should load")
                 .expect("head physical state should exist");
-        assert!(commit_state.replay_debt.depth >= 1);
-        assert!(commit_state.replay_debt.rows >= ROW_COUNT as u64);
-        assert!(commit_state.replay_debt.bytes > commit_state.replay_debt.rows);
+        assert_eq!(commit_state.replay_debt, Default::default());
         assert!(
             crate::tracked_state::load_snapshot_commit_root(
                 &history_read,
@@ -6718,8 +6716,8 @@ mod tests {
             )
             .await
             .expect("root lookup should succeed")
-            .is_none(),
-            "rootless production commit must skip the duplicate immutable tree"
+            .is_some(),
+            "production commits must publish persistent root authority"
         );
 
         let diff = session
@@ -6785,19 +6783,7 @@ mod tests {
         .await
         .expect("descendant physical state should load")
         .expect("descendant physical state should exist");
-        assert!(
-            descendant_state.replay_debt.depth > 0,
-            "a sparse descendant must extend the rootless first-parent interval"
-        );
-        assert_eq!(
-            descendant_state.replay_debt.depth,
-            commit_state.replay_debt.depth + 1
-        );
-        assert_eq!(
-            descendant_state.replay_debt.rows,
-            commit_state.replay_debt.rows + 1
-        );
-        assert!(descendant_state.replay_debt.bytes > commit_state.replay_debt.bytes);
+        assert_eq!(descendant_state.replay_debt, Default::default());
         assert!(
             crate::tracked_state::load_snapshot_commit_root(
                 &descendant_history_read,
@@ -6805,7 +6791,8 @@ mod tests {
             )
             .await
             .expect("descendant root lookup should succeed")
-            .is_none()
+            .is_some(),
+            "sparse descendants must retain persistent root authority"
         );
         let updated = session
             .execute(
@@ -6921,7 +6908,7 @@ mod tests {
                 .await
                 .expect("reseed physical state should load")
                 .expect("reseed physical state should exist");
-        assert!(reseed_state.replay_debt.depth >= 1);
+        assert_eq!(reseed_state.replay_debt, Default::default());
 
         let mut rooted_fence = None;
         for generation_offset in 1..=32 {
@@ -6967,7 +6954,7 @@ mod tests {
         }
         assert!(
             rooted_fence.is_some(),
-            "rootless replay intervals must close within one generation fence"
+            "every generation must retain a persistent root"
         );
         let rooted_fence = rooted_fence.unwrap();
         let rebuilt_rows = main_session
@@ -9222,8 +9209,8 @@ mod tests {
         );
         assert_eq!(
             crate::transaction::take_rootless_replacement_generation_publications(),
-            1,
-            "the certified replacement must publish a rootless partition generation"
+            0,
+            "the certified replacement must publish persistent root authority"
         );
 
         let update_commit_id = session
@@ -9356,8 +9343,8 @@ mod tests {
         session.execute_batch(&second_updates).await.unwrap();
         assert_eq!(
             crate::transaction::take_rootless_replacement_generation_publications(),
-            1,
-            "a repeated replacement must collapse to one generation over the same durable fallback"
+            0,
+            "a repeated replacement must retain persistent root authority"
         );
         let second_commit_id = session
             .execute("SELECT commit_id FROM lix_branch WHERE name = 'main'", &[])
@@ -11567,7 +11554,6 @@ mod tests {
             1,
             "the complete scalar generation must seal without PreparedStateBatch"
         );
-
         // Replacement-part bytes are content-addressed without their commit
         // owner. Publishing the same post-image again must bind a fresh
         // physical commit instead of reusing the decoded leaf from above.
@@ -11597,6 +11583,10 @@ mod tests {
             ),
             1
         );
+        session
+            .create_checkpoint()
+            .await
+            .expect("a direct replacement must leave checkpointable root authority");
     }
 
     #[tokio::test]
@@ -11865,6 +11855,21 @@ mod tests {
             .unwrap()
             .clone();
         assert_eq!(committed_created_at, original_created_at);
+        session
+            .create_checkpoint()
+            .await
+            .expect("a replacement immediately before checkpoint must retain a root alias");
+        let checkpointed_created_at = session
+            .execute(
+                "SELECT lixcol_created_at FROM rooted_journal_parent_probe WHERE path = '0000'",
+                &[],
+            )
+            .await
+            .unwrap()
+            .rows()[0]
+            .get::<String>("lixcol_created_at")
+            .unwrap();
+        assert_eq!(checkpointed_created_at, original_created_at);
     }
 
     #[tokio::test]

--- a/packages/lix/src/session/gc.rs
+++ b/packages/lix/src/session/gc.rs
@@ -1,7 +1,7 @@
 use crate::LixError;
 use crate::gc::{
-    RepositoryGcPlan, load_checkpoint_gc_state, stage_checkpoint_gc_state,
-    stage_repository_gc_with_preconditions,
+    RepositoryGcPlan, load_checkpoint_gc_state, load_checkpoint_gc_state_with_precondition,
+    stage_checkpoint_gc_state, stage_repository_gc_with_preconditions,
 };
 use crate::storage_adapter::{
     SharedStorageAdapterRead, Storage, StorageReadOptions, StorageWriteOptions,
@@ -12,6 +12,9 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use super::SessionContext;
 use super::checkpoint::checkpoint_gc_due;
 
+const CHECKPOINT_GC_MAX_CONFLICT_ATTEMPTS: u32 = 3;
+const CHECKPOINT_GC_FAILURE_RECORD_ATTEMPTS: u32 = 3;
+
 impl<StorageImpl> SessionContext<StorageImpl>
 where
     StorageImpl: Storage + Clone + Send + Sync + 'static,
@@ -19,11 +22,11 @@ where
     /// Runs one repository-wide sweep after a checkpoint has committed.
     ///
     /// The checkpoint transaction has already atomically published both the
-    /// new branch head and its rotated recovery root. This follow-up pass takes
-    /// the same repository write gate as ordinary implicit writes, plans from
-    /// one pinned read, and commits the entire sweep as one write set.
+    /// new branch head and its rotated recovery root. Planning runs without
+    /// the foreground write gate and binds every destructive decision to
+    /// storage preconditions. The prepared maintenance commit does not enter
+    /// the foreground session gate; conflicts retry from a fresh snapshot.
     async fn collect_checkpoint_garbage(&self) -> Result<Option<RepositoryGcPlan>, LixError> {
-        let write_access = self.begin_session_write_access().await?;
         let read = SharedStorageAdapterRead::new(
             self.storage
                 .begin_read(StorageReadOptions::default())
@@ -37,11 +40,13 @@ where
         let mut preconditions = Vec::new();
         let plan =
             stage_repository_gc_with_preconditions(read, &mut writes, &mut preconditions).await?;
-        gc_state.mark_collected(
-            plan.sweep.tracked_commit_roots.len() as u64,
-            plan.sweep.live_manifest_count,
-        );
-        stage_checkpoint_gc_state(&mut writes, &gc_state)?;
+        if !plan.sweep.has_more {
+            gc_state.mark_collected(
+                plan.sweep.tracked_commit_roots.len() as u64,
+                plan.sweep.live_manifest_count,
+            );
+            stage_checkpoint_gc_state(&mut writes, &gc_state)?;
+        }
         let commit_boundary = self.transaction_commit_boundary();
         let _commit_guard = begin_commit_boundary(Some(&commit_boundary));
         let prepared_commit = self
@@ -50,6 +55,7 @@ where
                 writes,
                 StorageWriteOptions {
                     preconditions,
+                    background_maintenance: true,
                     ..StorageWriteOptions::default()
                 },
             )
@@ -59,7 +65,6 @@ where
             Ok(stats)
         })
         .await?;
-        drop(write_access);
         self.observe_invalidation.bump_if_storage_changed(&stats);
         Ok(Some(plan))
     }
@@ -69,30 +74,65 @@ where
     /// Deliberately a tiny single-key write rather than part of the sweep's
     /// write set: the sweep's write set is exactly what did not commit.
     async fn record_reclaim_failure(&self) -> Result<(), LixError> {
-        let read = SharedStorageAdapterRead::new(
-            self.storage
-                .begin_read(StorageReadOptions::default())
-                .await?,
-        );
-        let mut gc_state = load_checkpoint_gc_state(&read).await?;
-        drop(read);
-        gc_state.note_reclaim_failure();
-        let mut writes = self.storage.new_write_set();
-        stage_checkpoint_gc_state(&mut writes, &gc_state)?;
-        // Through the commit boundary like every other session write, so a
-        // concurrent close cannot race the final pre-commit check.
-        let commit_boundary = self.transaction_commit_boundary();
-        let _commit_guard = begin_commit_boundary(Some(&commit_boundary));
-        let prepared_commit = self
-            .storage
-            .prepare_write_set(writes, StorageWriteOptions::default())
-            .await?;
-        commit_at_boundary(Some(&commit_boundary), || async move {
-            let (_, stats) = prepared_commit.commit().await?;
-            Ok(stats)
-        })
-        .await?;
-        Ok(())
+        for attempt in 0..CHECKPOINT_GC_FAILURE_RECORD_ATTEMPTS {
+            let read = SharedStorageAdapterRead::new(
+                self.storage
+                    .begin_read(StorageReadOptions::default())
+                    .await?,
+            );
+            let (mut gc_state, observed) =
+                load_checkpoint_gc_state_with_precondition(&read).await?;
+            drop(read);
+            gc_state.note_reclaim_failure();
+            let local_cooldown_until = gc_state.checkpoint_sequence.saturating_add(8);
+            let mut writes = self.storage.new_write_set();
+            stage_checkpoint_gc_state(&mut writes, &gc_state)?;
+            // Through the commit boundary like every other session write, so
+            // a concurrent close cannot race the final pre-commit check. The
+            // exact-value guard prevents this maintenance counter from
+            // restoring stale checkpoint sequence/debt fields.
+            let commit_boundary = self.transaction_commit_boundary();
+            let _commit_guard = begin_commit_boundary(Some(&commit_boundary));
+            let prepared_commit = match self
+                .storage
+                .prepare_write_set(
+                    writes,
+                    StorageWriteOptions {
+                        preconditions: vec![observed],
+                        background_maintenance: true,
+                        ..StorageWriteOptions::default()
+                    },
+                )
+                .await
+            {
+                Ok(prepared) => prepared,
+                Err(error) => {
+                    self.commit_coordinator
+                        .defer_checkpoint_gc_until(local_cooldown_until);
+                    return Err(error.into());
+                }
+            };
+            match commit_at_boundary(Some(&commit_boundary), || async move {
+                let (_, stats) = prepared_commit.commit().await?;
+                Ok(stats)
+            })
+            .await
+            {
+                Ok(_) => return Ok(()),
+                Err(error)
+                    if error.code == LixError::CODE_TRANSACTION_CONFLICT
+                        && attempt + 1 < CHECKPOINT_GC_FAILURE_RECORD_ATTEMPTS =>
+                {
+                    checkpoint_gc_retry_delay(attempt).await;
+                }
+                Err(error) => {
+                    self.commit_coordinator
+                        .defer_checkpoint_gc_until(local_cooldown_until);
+                    return Err(error);
+                }
+            }
+        }
+        unreachable!("failure-record attempt loop always returns")
     }
 
     /// Checkpoint creation must not fail merely because opportunistic cleanup
@@ -100,42 +140,79 @@ where
     /// atomic write as a successful sweep, so every later checkpoint retries
     /// while collection remains due.
     pub(super) async fn collect_checkpoint_garbage_best_effort(&self) {
-        match self.collect_checkpoint_garbage().await {
-            Ok(Some(plan)) => {
-                tracing::debug!(
-                    swept_commits = plan.changelog.sweep.commits.len(),
-                    swept_changes = plan.changelog.sweep.changes.len(),
-                    swept_tracked_roots = plan.sweep.tracked_commit_roots.len(),
-                    history_manifests_missing = plan.profile.history_manifests_missing,
-                    root_discovery_us = plan.profile.root_discovery_us,
-                    changelog_us = plan.profile.changelog_us,
-                    tracked_root_stage_us = plan.profile.tracked_root_stage_us,
-                    gc_total_us = plan.profile.total_us,
-                    "completed post-checkpoint garbage collection"
-                );
-            }
-            Ok(None) => {}
-            Err(error) => {
-                // Persistent failure here used to be undetectable: one
-                // `tracing::warn!` and no counter, invisible in production
-                // without a subscriber and invisible in tests entirely. Record
-                // it so the next occurrence is findable, and damp the retry so
-                // a failing sweep cannot re-arm a full repository pass on every
-                // checkpoint.
-                reclaim_failures_total().fetch_add(1, Ordering::Relaxed);
-                if let Err(record_error) = self.record_reclaim_failure().await {
-                    tracing::warn!(
-                        error = %record_error,
-                        "could not record reclaim failure; retry damping is skipped"
+        for attempt in 0..CHECKPOINT_GC_MAX_CONFLICT_ATTEMPTS {
+            match self.collect_checkpoint_garbage().await {
+                Ok(Some(plan)) => {
+                    tracing::debug!(
+                        swept_commits = plan.changelog.sweep.commits.len(),
+                        swept_changes = plan.changelog.sweep.changes.len(),
+                        swept_tracked_roots = plan.sweep.tracked_commit_roots.len(),
+                        history_manifests_missing = plan.profile.history_manifests_missing,
+                        root_discovery_us = plan.profile.root_discovery_us,
+                        changelog_us = plan.profile.changelog_us,
+                        tracked_root_stage_us = plan.profile.tracked_root_stage_us,
+                        gc_total_us = plan.profile.total_us,
+                        "completed post-checkpoint garbage collection"
                     );
+                    return;
                 }
-                tracing::warn!(
-                    error = %error,
-                    "post-checkpoint garbage collection failed; checkpoint remains committed"
-                );
+                Ok(None) => return,
+                Err(error)
+                    if error.code == LixError::CODE_TRANSACTION_CONFLICT
+                        && attempt + 1 < CHECKPOINT_GC_MAX_CONFLICT_ATTEMPTS =>
+                {
+                    // A foreground commit moved one of the roots observed by
+                    // optimistic planning. This is expected under sustained
+                    // checkpointing: retry outside the write gate instead of
+                    // damping maintenance as though it were broken.
+                    checkpoint_gc_retry_delay(attempt).await;
+                }
+                Err(error) if error.code == LixError::CODE_TRANSACTION_CONFLICT => {
+                    reclaim_failures_total().fetch_add(1, Ordering::Relaxed);
+                    if let Err(record_error) = self.record_reclaim_failure().await {
+                        tracing::warn!(
+                            error = %record_error,
+                            "could not record checkpoint GC conflict backoff"
+                        );
+                    }
+                    tracing::debug!(
+                        attempts = CHECKPOINT_GC_MAX_CONFLICT_ATTEMPTS,
+                        error = %error,
+                        "post-checkpoint garbage collection yielded and damped retries after sustained conflicts"
+                    );
+                    return;
+                }
+                Err(error) => {
+                    // Persistent failure here used to be undetectable: one
+                    // `tracing::warn!` and no counter, invisible in production
+                    // without a subscriber and invisible in tests entirely. Record
+                    // it so the next occurrence is findable, and damp the retry so
+                    // a failing sweep cannot re-arm a full repository pass on every
+                    // checkpoint.
+                    reclaim_failures_total().fetch_add(1, Ordering::Relaxed);
+                    if let Err(record_error) = self.record_reclaim_failure().await {
+                        tracing::warn!(
+                            error = %record_error,
+                            "could not record reclaim failure; retry damping is skipped"
+                        );
+                    }
+                    tracing::warn!(
+                        error = %error,
+                        "post-checkpoint garbage collection failed; checkpoint remains committed"
+                    );
+                    return;
+                }
             }
         }
+        unreachable!("checkpoint GC attempt loop always returns")
     }
+}
+
+async fn checkpoint_gc_retry_delay(_attempt: u32) {
+    #[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
+    std::thread::sleep(std::time::Duration::from_millis(10_u64 << _attempt.min(5)));
+    #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+    futures_lite::future::yield_now().await;
 }
 
 #[cfg(test)]
@@ -146,7 +223,10 @@ mod tests {
     use super::checkpoint_gc_due;
     use crate::changelog::CommitId;
     use crate::engine::Engine;
-    use crate::gc::{load_checkpoint_gc_state, stage_repository_gc_with_preconditions};
+    use crate::gc::{
+        CheckpointGcState, load_checkpoint_gc_state, load_checkpoint_gc_state_with_precondition,
+        stage_checkpoint_gc_state, stage_repository_gc_with_preconditions,
+    };
     use crate::session::SessionContext;
     use crate::storage::Memory;
     use crate::storage_adapter::{
@@ -177,6 +257,78 @@ mod tests {
         let engine = Engine::new(storage).await.expect("engine opens");
         let session = engine.open_session().await.expect("session opens");
         (engine, session)
+    }
+
+    #[tokio::test]
+    async fn stale_failure_accounting_cannot_overwrite_newer_checkpoint_debt() {
+        let (_engine, session) = open().await;
+        let initial = CheckpointGcState {
+            checkpoint_sequence: 10,
+            last_gc_sequence: 5,
+            collectible_interval_count: 1,
+            ..CheckpointGcState::default()
+        };
+        let mut initial_writes = session.storage.new_write_set();
+        stage_checkpoint_gc_state(&mut initial_writes, &initial).expect("initial state stages");
+        session
+            .storage
+            .commit_write_set(initial_writes, StorageWriteOptions::default())
+            .await
+            .expect("initial state commits");
+
+        let read = SharedStorageAdapterRead::new(
+            session
+                .storage
+                .begin_read(StorageReadOptions::default())
+                .await
+                .expect("stale failure read opens"),
+        );
+        let (mut stale, observed) = load_checkpoint_gc_state_with_precondition(&read)
+            .await
+            .expect("stale failure state loads");
+        drop(read);
+        stale.note_reclaim_failure();
+
+        let newer = CheckpointGcState {
+            checkpoint_sequence: 11,
+            collectible_interval_count: 2,
+            ..initial
+        };
+        let mut newer_writes = session.storage.new_write_set();
+        stage_checkpoint_gc_state(&mut newer_writes, &newer).expect("newer state stages");
+        session
+            .storage
+            .commit_write_set(newer_writes, StorageWriteOptions::default())
+            .await
+            .expect("newer checkpoint debt commits");
+
+        let mut stale_writes = session.storage.new_write_set();
+        stage_checkpoint_gc_state(&mut stale_writes, &stale).expect("stale state stages");
+        session
+            .storage
+            .commit_write_set(
+                stale_writes,
+                StorageWriteOptions {
+                    preconditions: vec![observed],
+                    ..StorageWriteOptions::default()
+                },
+            )
+            .await
+            .expect_err("stale failure accounting must conflict");
+
+        let read = SharedStorageAdapterRead::new(
+            session
+                .storage
+                .begin_read(StorageReadOptions::default())
+                .await
+                .expect("final state read opens"),
+        );
+        assert_eq!(
+            load_checkpoint_gc_state(&read)
+                .await
+                .expect("final state loads"),
+            newer,
+        );
     }
 
     async fn head(engine: &Engine<Memory>, branch_id: &str) -> String {
@@ -236,7 +388,7 @@ mod tests {
                 .expect("round checkpoint succeeds");
         }
 
-        async fn committed_state(session: &SessionContext<Memory>) -> crate::gc::CheckpointGcState {
+        async fn committed_state(session: &SessionContext<Memory>) -> CheckpointGcState {
             let read = SharedStorageAdapterRead::new(
                 session
                     .storage
@@ -334,8 +486,8 @@ mod tests {
             .await
             .expect("D commits");
         let commit_d = head(&engine, &branch_id).await;
-        let commit_d_id = CommitId::parse_lix(&commit_d, "restore GC commit D")
-            .expect("D commit id parses");
+        let commit_d_id =
+            CommitId::parse_lix(&commit_d, "restore GC commit D").expect("D commit id parses");
 
         session
             .execute("SELECT lix_restore($1)", &[Value::Text(commit_c.clone())])

--- a/packages/lix/src/sql2/mod.rs
+++ b/packages/lix/src/sql2/mod.rs
@@ -47,9 +47,8 @@ pub(crate) use catalog::{
 pub(crate) use context::WriteContextLiveness;
 pub(crate) use context::{
     ChangelogQuerySource, DiffCommand, DiffCommandOutcome, HistoryQuerySource,
-    SqlChangelogQuerySource, SqlExecutionContext,
-    SqlHistoryQuerySource, SqlWriteContext, SqlWriteExecutionContext, WriteAccess,
-    WriteContextBranchRefReader, WriteContextHotStateReader,
+    SqlChangelogQuerySource, SqlExecutionContext, SqlHistoryQuerySource, SqlWriteContext,
+    SqlWriteExecutionContext, WriteAccess, WriteContextBranchRefReader, WriteContextHotStateReader,
 };
 pub(crate) use exec::bound_public_write::PreparedPathValueReplacementProgram;
 #[cfg(feature = "storage-benches")]
@@ -69,8 +68,7 @@ pub(crate) use exec::{
     execute_write_logical_plan_value_batch, parameter_record_batch, parameter_row,
     prepare_path_value_replacement_program, prepare_path_value_replacement_row,
     prepare_read_session, prepare_read_session_at_head, query_result_from_batches,
-    query_values_from_batches,
-    write_plan_requires_post_stage_returning_checkpoint,
+    query_values_from_batches, write_plan_requires_post_stage_returning_checkpoint,
 };
 #[cfg(test)]
 pub(crate) use exec::{

--- a/packages/lix/src/storage/cursor.rs
+++ b/packages/lix/src/storage/cursor.rs
@@ -90,6 +90,8 @@ impl<'a> ScanCursor<'a> {
         let page_size = limit_rows.min(crate::storage::MAX_SCAN_PAGE_ROWS);
         self.poisoned = true;
         let (entries, has_more) = self.source.next_page(page_size).await?.into_parts();
+        #[cfg(feature = "storage-benches")]
+        crate::storage_bench::record_checkpoint_scan_page(entries.len());
         if entries.len() > page_size
             || (has_more && entries.is_empty())
             || !self.valid_entries(&entries)

--- a/packages/lix/src/storage/types.rs
+++ b/packages/lix/src/storage/types.rs
@@ -648,6 +648,10 @@ pub struct WriteOptions {
     /// from the complete canonical write set so backends with contiguous batch
     /// encodings can allocate their large buffer once.
     pub batch_capacity_hint_bytes: usize,
+    /// Marks opportunistic repository maintenance so single-writer adapters
+    /// can yield admission to foreground publications. Correctness must not
+    /// depend on this hint; both lanes remain atomically serialized.
+    pub background_maintenance: bool,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]

--- a/packages/lix/src/storage_adapter/context.rs
+++ b/packages/lix/src/storage_adapter/context.rs
@@ -43,6 +43,8 @@ where
         &self,
         opts: ReadOptions,
     ) -> Result<StorageAdapterReadScope<StorageImpl::Read<'_>>, StorageError> {
+        #[cfg(feature = "storage-benches")]
+        crate::storage_bench::record_checkpoint_read_view();
         self.storage
             .begin_read(opts)
             .await
@@ -249,6 +251,29 @@ where
         .await
 }
 
+pub(crate) async fn load_repository_mutation_revision<R>(
+    read: &R,
+) -> Result<Option<Bytes>, StorageError>
+where
+    R: StorageAdapterRead + ?Sized,
+{
+    load_revision(read, REVISION_KEY_MUTATION).await
+}
+
+pub(crate) fn repository_mutation_revision_precondition(expected: Option<Bytes>) -> Precondition {
+    expected.map_or_else(
+        || Precondition::KeyAbsent {
+            space: REVISION_SPACE,
+            key: revision_key(REVISION_KEY_MUTATION),
+        },
+        |expected| Precondition::KeyValueEquals {
+            space: REVISION_SPACE,
+            key: revision_key(REVISION_KEY_MUTATION),
+            expected,
+        },
+    )
+}
+
 impl<'a, StorageImpl> PreparedStorageCommit<'a, StorageImpl>
 where
     StorageImpl: Storage + 'a,
@@ -262,6 +287,8 @@ where
                 "lix.perf.storage_commit_accepted_visible"
             ))
             .await?;
+        #[cfg(feature = "storage-benches")]
+        crate::storage_bench::record_checkpoint_write(self.stats);
         Ok((result, self.stats))
     }
 

--- a/packages/lix/src/storage_adapter/mod.rs
+++ b/packages/lix/src/storage_adapter/mod.rs
@@ -25,6 +25,7 @@ mod write_set;
 #[cfg(test)]
 mod conformance;
 
+pub(crate) use crate::storage::StorageWrite;
 pub use crate::storage::{
     BeginScanOptions as StorageBeginScanOptions, BufferRange,
     CoreProjection as StorageCoreProjection, EncodedMutationBatch, EncodedPut,
@@ -39,10 +40,12 @@ pub use crate::storage::{
     ValueSemantics, WriteOptions as StorageWriteOptions,
 };
 pub(crate) use crate::storage::{Capability as StorageCapability, PutBatch, PutEntry};
-pub(crate) use crate::storage::StorageWrite;
 
 pub use context::StorageAdapter;
-pub(crate) use context::stage_mutation_revision;
+pub(crate) use context::{
+    load_repository_mutation_revision, repository_mutation_revision_precondition,
+    stage_mutation_revision,
+};
 pub(crate) use point::exact_get_many;
 pub use point::{PointReadPlan, PointValues, RequestedToUnique, RequestedToUniqueRef};
 pub(crate) use read_scope::SharedStorageAdapterRead;

--- a/packages/lix/src/storage_adapter/read_scope.rs
+++ b/packages/lix/src/storage_adapter/read_scope.rs
@@ -135,6 +135,11 @@ where
         &self,
         requests: &[GetManyRequest<'_>],
     ) -> impl Future<Output = Result<GetManyResult, StorageError>> + Send {
+        #[cfg(feature = "storage-benches")]
+        crate::storage_bench::record_checkpoint_point_read(
+            requests.len(),
+            requests.iter().map(|request| request.keys.len()).sum(),
+        );
         #[cfg(feature = "root-replay-trace")]
         {
             traced_get_many(requests, self.read.get_many(requests))
@@ -151,6 +156,8 @@ where
         range: KeyRange,
         opts: BeginScanOptions,
     ) -> impl Future<Output = Result<ScanCursor<'_>, StorageError>> + Send {
+        #[cfg(feature = "storage-benches")]
+        crate::storage_bench::record_checkpoint_scan_start();
         self.read.begin_scan(space, range, opts)
     }
 }
@@ -167,6 +174,11 @@ where
         &self,
         requests: &[GetManyRequest<'_>],
     ) -> impl Future<Output = Result<GetManyResult, StorageError>> + Send {
+        #[cfg(feature = "storage-benches")]
+        crate::storage_bench::record_checkpoint_point_read(
+            requests.len(),
+            requests.iter().map(|request| request.keys.len()).sum(),
+        );
         #[cfg(feature = "root-replay-trace")]
         {
             traced_get_many(requests, self.read.get_many(requests))
@@ -183,6 +195,8 @@ where
         range: KeyRange,
         opts: BeginScanOptions,
     ) -> impl Future<Output = Result<ScanCursor<'_>, StorageError>> + Send {
+        #[cfg(feature = "storage-benches")]
+        crate::storage_bench::record_checkpoint_scan_start();
         self.read.begin_scan(space, range, opts)
     }
 }

--- a/packages/lix/src/storage_adapter/write_set.rs
+++ b/packages/lix/src/storage_adapter/write_set.rs
@@ -709,6 +709,84 @@ impl StorageWriteSet {
         self.stats
     }
 
+    /// Extracts a backend-admissible, restartable maintenance slice.
+    ///
+    /// Maintenance planners derive this set again from durable state on every
+    /// pass. All puts and range deletions stay together (they include fences
+    /// and any replacement authority); point deletes are the idempotent work
+    /// that may be truncated. Rows left behind are rediscovered by the next
+    /// pass, so no separate cursor can become stale or corrupt.
+    pub(crate) fn into_bounded_maintenance_slice(
+        self,
+        max_mutations: u64,
+        max_written_bytes: u64,
+    ) -> (Self, bool) {
+        let base_mutations = self
+            .stats
+            .staged_puts
+            .saturating_add(self.exclusive_range_deletes.len() as u64);
+        if !self.deferred_final_puts.is_empty()
+            || base_mutations > max_mutations
+            || self.stats.written_bytes > max_written_bytes
+        {
+            return (Self::new(), true);
+        }
+
+        let delete_budget =
+            usize::try_from(max_mutations.saturating_sub(base_mutations)).unwrap_or(usize::MAX);
+        let total_deletes = usize::try_from(self.stats.staged_deletes).unwrap_or(usize::MAX);
+        let has_more = total_deletes > delete_budget;
+        let Self {
+            groups,
+            exclusive_range_deletes,
+            changelog_gc_sealed,
+            ..
+        } = self;
+        let mut slice = Self::new();
+        slice.changelog_gc_sealed = changelog_gc_sealed;
+        let mut remaining_deletes = delete_budget;
+        for group in groups {
+            let (space, puts, deletes) = group.lower();
+            for put in puts {
+                slice.put(space, put.key, put.value);
+            }
+            let take = remaining_deletes.min(deletes.len());
+            slice.delete_batch(space, deletes.into_iter().take(take));
+            remaining_deletes -= take;
+        }
+        for (space, range) in exclusive_range_deletes {
+            slice
+                .delete_range_exclusive(space, range)
+                .expect("maintenance range-delete spaces remain exclusive");
+        }
+        (slice, has_more)
+    }
+
+    /// Consumes a delete-only domain plan into owned point mutations.
+    ///
+    /// Repository GC uses this to persist a durable intent inventory before it
+    /// starts removing child nodes whose disappearance would make the source
+    /// tree impossible to traverse on a later maintenance pass.
+    pub(crate) fn into_point_deletes(self) -> Vec<(StorageSpace, Key)> {
+        assert_eq!(self.stats.staged_puts, 0, "delete inventory contains puts");
+        assert!(
+            self.exclusive_range_deletes.is_empty(),
+            "delete inventory contains range deletes"
+        );
+        assert!(
+            self.deferred_final_puts.is_empty(),
+            "delete inventory contains deferred puts"
+        );
+        self.groups
+            .into_iter()
+            .flat_map(|group| {
+                let (space, puts, deletes) = group.lower();
+                assert!(puts.is_empty(), "delete inventory group contains puts");
+                deletes.into_iter().map(move |key| (space, key))
+            })
+            .collect()
+    }
+
     #[cfg(any(test, feature = "storage-benches"))]
     pub fn arena_stats(&self) -> StorageWriteSetArenaStats {
         let mut stats = StorageWriteSetArenaStats {
@@ -753,9 +831,7 @@ impl StorageWriteSet {
     pub fn put_counts_by_space(&self) -> Vec<(StorageSpace, usize)> {
         self.groups
             .iter()
-            .filter_map(|group| {
-                (!group.puts.is_empty()).then_some((group.space, group.puts.len()))
-            })
+            .filter_map(|group| (!group.puts.is_empty()).then_some((group.space, group.puts.len())))
             .collect()
     }
 
@@ -1482,6 +1558,22 @@ mod tests {
         assert_eq!(stats.delete_batches, 1);
         assert_eq!(commit.stats.put_entries, 2);
         assert_eq!(commit.stats.deleted_entries, 1);
+    }
+
+    #[test]
+    fn maintenance_slice_keeps_fence_puts_and_bounds_restartable_deletes() {
+        let mut writes = StorageWriteSet::new();
+        writes.put(space(), key("fence"), value("next-token"));
+        writes.delete_batch(
+            space(),
+            [key("dead-a"), key("dead-b"), key("dead-c"), key("dead-d")],
+        );
+
+        let (slice, has_more) = writes.into_bounded_maintenance_slice(3, 1_024);
+        assert!(has_more);
+        assert_eq!(slice.stats().staged_puts, 1);
+        assert_eq!(slice.stats().staged_deletes, 2);
+        assert!(slice.stats().staged_puts + slice.stats().staged_deletes <= 3);
     }
 
     #[tokio::test]

--- a/packages/lix/src/storage_bench.rs
+++ b/packages/lix/src/storage_bench.rs
@@ -1,3 +1,5 @@
+use std::cell::RefCell;
+use std::future::Future;
 use std::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering};
 
 use bytes::Bytes;
@@ -9,6 +11,93 @@ use crate::storage_adapter::{
     StoragePrefix, StorageProjectedValue, StorageWriteOptions, StorageWriteSet,
     StorageWriteSetError,
 };
+
+/// Storage work performed by the task that publishes one checkpoint.
+///
+/// This is task-local so maintenance spawned by checkpoint publication is not
+/// charged to the foreground census. Adapter calls made before the spawned
+/// task boundary remain visible, including waits on adapter-owned resources.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct CheckpointForegroundAccounting {
+    pub read_views: u64,
+    pub point_batches: u64,
+    pub point_keys: u64,
+    pub scan_starts: u64,
+    pub scan_pages: u64,
+    pub scan_rows: u64,
+    pub write_transactions: u64,
+    pub write_calls: u64,
+    pub written_records: u64,
+    pub written_bytes: u64,
+}
+
+tokio::task_local! {
+    static CHECKPOINT_FOREGROUND_ACCOUNTING: RefCell<CheckpointForegroundAccounting>;
+}
+
+/// Measures only storage work polled by `future`'s task.
+pub async fn measure_checkpoint_foreground<F>(
+    future: F,
+) -> (F::Output, CheckpointForegroundAccounting)
+where
+    F: Future,
+{
+    CHECKPOINT_FOREGROUND_ACCOUNTING
+        .scope(
+            RefCell::new(CheckpointForegroundAccounting::default()),
+            async {
+                let output = future.await;
+                let accounting = CHECKPOINT_FOREGROUND_ACCOUNTING.with(|cell| *cell.borrow());
+                (output, accounting)
+            },
+        )
+        .await
+}
+
+/// True only while the currently polled task is inside a foreground census.
+/// Global allocator probes use this to avoid charging unrelated maintenance
+/// tasks that happen to run on the same executor thread.
+pub fn checkpoint_foreground_is_active() -> bool {
+    CHECKPOINT_FOREGROUND_ACCOUNTING.try_with(|_| ()).is_ok()
+}
+
+pub(crate) fn record_checkpoint_read_view() {
+    let _ = CHECKPOINT_FOREGROUND_ACCOUNTING.try_with(|cell| {
+        cell.borrow_mut().read_views += 1;
+    });
+}
+
+pub(crate) fn record_checkpoint_point_read(batches: usize, keys: usize) {
+    let _ = CHECKPOINT_FOREGROUND_ACCOUNTING.try_with(|cell| {
+        let mut accounting = cell.borrow_mut();
+        accounting.point_batches += batches as u64;
+        accounting.point_keys += keys as u64;
+    });
+}
+
+pub(crate) fn record_checkpoint_scan_start() {
+    let _ = CHECKPOINT_FOREGROUND_ACCOUNTING.try_with(|cell| {
+        cell.borrow_mut().scan_starts += 1;
+    });
+}
+
+pub(crate) fn record_checkpoint_scan_page(rows: usize) {
+    let _ = CHECKPOINT_FOREGROUND_ACCOUNTING.try_with(|cell| {
+        let mut accounting = cell.borrow_mut();
+        accounting.scan_pages += 1;
+        accounting.scan_rows += rows as u64;
+    });
+}
+
+pub(crate) fn record_checkpoint_write(stats: crate::storage_adapter::StorageWriteSetStats) {
+    let _ = CHECKPOINT_FOREGROUND_ACCOUNTING.try_with(|cell| {
+        let mut accounting = cell.borrow_mut();
+        accounting.write_transactions += 1;
+        accounting.write_calls += stats.storage_calls;
+        accounting.written_records += stats.staged_puts + stats.staged_deletes;
+        accounting.written_bytes += stats.written_bytes;
+    });
+}
 
 fn stage_bench_commit_deltas(
     writes: &mut StorageWriteSet,
@@ -4019,6 +4108,10 @@ mod tests {
                 ), // mutation inventory authority
                 (crate::changelog::COMMIT_SPACE.id.0, 10), // branch-only commit projections
                 (crate::changelog::CHANGE_SPACE.id.0, 10), // their change facts
+                (
+                    crate::sync::SYNC_MATERIALIZED_STATE_ALIAS_SPACE.id.0,
+                    10,
+                ), // unconditional canonical sync-state alias cleanup descriptors
             ]
         );
         assert_eq!(
@@ -4038,7 +4131,10 @@ mod tests {
         // constant rather than restating it.
         const FENCE_KEY_BYTES: usize =
             crate::storage_adapter::REVISION_KEY_BINARY_CAS_RECLAMATION.len();
-        assert_eq!(first.key_shared_buffers, first.staged_deletes as usize + 1);
+        // Batched checkpoint retirement keys share two packed backing buffers
+        // (working-diff rows and their marker) instead of retaining one buffer
+        // per delete. The remaining UUID deletes and reclamation fence each
+        // retain one fixed-size buffer.
         // Canonical-record deletes are UUID keyed. Checkpoint rotation also
         // retires the fixture's fixed-width working-diff identities and the
         // branch-ref marker through their authenticated physical encodings.
@@ -4048,6 +4144,7 @@ mod tests {
         let working_diff_deletes = 100;
         let marker_deletes = 1;
         let uuid_deletes = first.staged_deletes as usize - working_diff_deletes - marker_deletes;
+        assert_eq!(first.key_shared_buffers, uuid_deletes + 3);
         assert_eq!(
             first.key_shared_bytes,
             uuid_deletes * UUID_KEY_BYTES

--- a/packages/lix/src/storage_spaces.rs
+++ b/packages/lix/src/storage_spaces.rs
@@ -66,6 +66,7 @@ pub(crate) const ALL_STORAGE_SPACES: &[StorageSpace] = &[
     crate::sync::SYNC_SEQUENCE_SPACE,
     crate::sync::SYNC_REPOSITORY_EVENT_SPACE,
     crate::sync::SYNC_REPLICA_STATE_SPACE,
+    crate::sync::SYNC_MATERIALIZED_STATE_ALIAS_SPACE,
     // `gc.rs` declares these through the checked constructors rather than
     // `StorageSpace::declare`, so referencing its constants here would make
     // `may_declare` read a registry it is in the middle of evaluating. The
@@ -79,6 +80,11 @@ pub(crate) const ALL_STORAGE_SPACES: &[StorageSpace] = &[
     StorageSpace::declare(
         StorageSpaceId(0x0008_0002),
         "checkpoint.gc_state.v1",
+        ValueSemantics::Mutable,
+    ),
+    StorageSpace::declare(
+        StorageSpaceId(0x0008_0008),
+        "gc.commit_retirement_intent.v1",
         ValueSemantics::Mutable,
     ),
 ];
@@ -523,6 +529,7 @@ mod tests {
         for space in [
             crate::gc::CHECKPOINT_RECOVERY_REF_SPACE,
             crate::gc::CHECKPOINT_GC_STATE_SPACE,
+            crate::gc::COMMIT_RETIREMENT_INTENT_SPACE,
         ] {
             let row = ALL_STORAGE_SPACES
                 .iter()

--- a/packages/lix/src/sync/commit.rs
+++ b/packages/lix/src/sync/commit.rs
@@ -7,6 +7,7 @@
 
 use std::collections::BTreeSet;
 
+use bytes::Bytes;
 use serde::{Deserialize, Serialize};
 
 use crate::changelog::{
@@ -15,9 +16,22 @@ use crate::changelog::{
 };
 use crate::common::LixTimestamp;
 use crate::row_pk::RowPk;
-use crate::storage_adapter::{Storage, StorageAdapterRead, StorageReadOptions};
-use crate::tracked_state::load_commit_delta_members_with_payloads;
+use crate::storage_adapter::{
+    Storage, StorageAdapterRead, StorageGetManyRequest, StorageGetOptions, StorageKey,
+    StorageProjectedValue, StorageReadOptions, StorageSpace, StorageSpaceId, StorageValue,
+    StorageWriteSet, ValueSemantics, exact_get_many,
+};
+use crate::tracked_state::{
+    load_commit_delta_members_with_payloads, load_commit_state_manifest,
+    load_local_commit_delta_members_with_payloads,
+};
 use crate::{Lix, LixError};
+
+pub(crate) const SYNC_MATERIALIZED_STATE_ALIAS_SPACE: StorageSpace = StorageSpace::declare(
+    StorageSpaceId(0x0007_0015),
+    "sync.materialized_state_alias.v1",
+    ValueSemantics::Immutable,
+);
 
 /// A complete immutable commit, independent of the local storage layout.
 ///
@@ -32,7 +46,114 @@ pub struct SyncCommit {
     pub account_id: String,
     pub created_at: String,
     pub selected_source_commit_id: Option<String>,
+    /// Authenticated O(1) representation of a complete-state checkpoint.
+    /// The source is a dependency and `state_root_id` binds the alias to the
+    /// exact persistent tree the authority captured.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub state_alias: Option<SyncCommitStateAlias>,
     pub members: Vec<SyncCommitMember>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SyncCommitStateAlias {
+    pub source_commit_id: String,
+    pub state_root_id: String,
+}
+
+fn materialized_state_alias_key(commit_id: CommitId) -> StorageKey {
+    StorageKey(Bytes::copy_from_slice(commit_id.as_uuid().as_bytes()))
+}
+
+pub(crate) fn stage_materialized_sync_state_alias(
+    writes: &mut StorageWriteSet,
+    commit_id: CommitId,
+    alias: &SyncCommitStateAlias,
+) -> Result<(), LixError> {
+    let bytes = serde_json::to_vec(alias).map_err(|error| {
+        LixError::new(
+            LixError::CODE_INTERNAL_ERROR,
+            format!("encode materialized sync state alias: {error}"),
+        )
+    })?;
+    writes.put(
+        SYNC_MATERIALIZED_STATE_ALIAS_SPACE,
+        materialized_state_alias_key(commit_id),
+        StorageValue {
+            bytes: Bytes::from(bytes),
+        },
+    );
+    Ok(())
+}
+
+pub(crate) fn stage_delete_materialized_sync_state_alias(
+    writes: &mut StorageWriteSet,
+    commit_id: CommitId,
+) {
+    writes.delete(
+        SYNC_MATERIALIZED_STATE_ALIAS_SPACE,
+        materialized_state_alias_key(commit_id),
+    );
+}
+
+async fn load_materialized_sync_state_alias(
+    store: &(impl StorageAdapterRead + ?Sized),
+    commit_id: CommitId,
+) -> Result<Option<SyncCommitStateAlias>, LixError> {
+    let key = materialized_state_alias_key(commit_id);
+    let values = exact_get_many(
+        store,
+        &[StorageGetManyRequest {
+            space: SYNC_MATERIALIZED_STATE_ALIAS_SPACE,
+            keys: std::slice::from_ref(&key),
+            opts: StorageGetOptions::default(),
+        }],
+    )
+    .await?;
+    let Some(value) = values.values.into_iter().next().flatten() else {
+        return Ok(None);
+    };
+    let StorageProjectedValue::FullValue(value) = value else {
+        return Err(LixError::new(
+            LixError::CODE_INTERNAL_ERROR,
+            "materialized sync state alias read omitted its value",
+        ));
+    };
+    serde_json::from_slice(&value).map(Some).map_err(|error| {
+        LixError::new(
+            LixError::CODE_INTERNAL_ERROR,
+            format!("decode materialized sync state alias: {error}"),
+        )
+    })
+}
+
+pub(crate) async fn load_sync_commit_state_alias(
+    store: &(impl StorageAdapterRead + ?Sized),
+    commit_id: CommitId,
+) -> Result<Option<SyncCommitStateAlias>, LixError> {
+    if let Some(alias) = load_materialized_sync_state_alias(store, commit_id).await? {
+        return Ok(Some(alias));
+    }
+    load_manifest_sync_state_alias(store, commit_id).await
+}
+
+async fn load_manifest_sync_state_alias(
+    store: &(impl StorageAdapterRead + ?Sized),
+    commit_id: CommitId,
+) -> Result<Option<SyncCommitStateAlias>, LixError> {
+    Ok(load_commit_state_manifest(store, commit_id)
+        .await?
+        .and_then(|manifest| manifest.snapshot_root)
+        .filter(|root| root.complete_state_fence)
+        .and_then(|root| {
+            let source = root.parent_roots.into_iter().next()?;
+            Some(SyncCommitStateAlias {
+                source_commit_id: source.commit_id.to_string(),
+                state_root_id: blake3::Hash::from_bytes(*root.root_id.as_bytes())
+                    .to_hex()
+                    .to_string(),
+            })
+        }))
 }
 
 /// One identity-ordered member of a commit delta.
@@ -124,6 +245,30 @@ impl SyncCommit {
             .transpose()?;
         if selected_source_commit_id == Some(commit_id) {
             return invalid("sync commit cannot select itself as its source");
+        }
+        if let Some(alias) = &self.state_alias {
+            let source = CommitId::parse_lix(
+                &alias.source_commit_id,
+                "sync complete-state source commit id",
+            )?;
+            if source == commit_id {
+                return invalid("sync commit cannot alias its own state");
+            }
+            super::validate_blake3_id(
+                &alias.state_root_id,
+                "sync complete-state alias stateRootId",
+            )?;
+            if self.selected_source_commit_id.is_some() {
+                return invalid(
+                    "sync commit cannot carry both selected and complete-state sources",
+                );
+            }
+            if self.parent_commit_ids.len() != 1 {
+                return invalid("sync complete-state alias must have exactly one semantic parent");
+            }
+            if !self.members.is_empty() {
+                return invalid("sync complete-state alias must not carry commit members");
+            }
         }
 
         let mut previous: Option<(String, Option<String>, RowPk)> = None;
@@ -241,7 +386,18 @@ where
         return Ok(None);
     };
 
-    let delta = load_commit_delta_members_with_payloads(store, commit_id).await?;
+    let materialized_state_alias = load_materialized_sync_state_alias(store, commit_id).await?;
+    let state_alias = match materialized_state_alias.clone() {
+        Some(alias) => Some(alias),
+        None => load_manifest_sync_state_alias(store, commit_id).await?,
+    };
+    let delta = if materialized_state_alias.is_some() {
+        Vec::new()
+    } else if state_alias.is_some() {
+        load_local_commit_delta_members_with_payloads(store, commit_id).await?
+    } else {
+        load_commit_delta_members_with_payloads(store, commit_id).await?
+    };
     let payloads = materialize_known_change_payloads_in_order(
         delta.iter().map(|member| member.change.clone()),
         ChangeRecordProjection::full(),
@@ -300,6 +456,7 @@ where
         account_id: record.account_id,
         created_at: record.created_at.to_string(),
         selected_source_commit_id: selected_source_commit_id.map(|source| source.to_string()),
+        state_alias,
         members,
     };
     exported.validate()?;
@@ -551,7 +708,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn checkpoint_exports_complete_selected_members_without_a_source_pointer() {
+    async fn checkpoint_exports_bounded_authenticated_state_alias() {
         let lix = crate::open_lix().await.expect("open checkpoint fixture");
         lix.execute(
             "INSERT INTO lix_key_value (key, value) VALUES ('checkpoint-source', 'selected')",
@@ -574,9 +731,69 @@ mod tests {
         exported
             .validate()
             .expect("checkpoint alias must remain a valid sync commit");
-        assert!(exported.members.iter().any(|member| !member.authored));
+        assert!(exported.members.iter().all(|member| member.authored));
+        assert!(
+            exported.members.is_empty(),
+            "the branch checkpoint boundary has no local row mutations"
+        );
         assert_eq!(exported.selected_source_commit_id, None);
+        let alias = exported
+            .state_alias
+            .as_ref()
+            .expect("checkpoint export must carry its physical state source");
+        super::super::validate_blake3_id(&alias.state_root_id, "checkpoint state root")
+            .expect("checkpoint root id must be canonical");
         lix.close().await.expect("close checkpoint fixture");
+    }
+
+    #[tokio::test]
+    async fn materialized_state_alias_sidecar_retires_by_commit_identity() {
+        let lix = crate::open_lix().await.expect("open sidecar fixture");
+        let commit_id = CommitId::for_test_label("materialized-alias-owner");
+        let alias = SyncCommitStateAlias {
+            source_commit_id: CommitId::for_test_label("materialized-alias-source").to_string(),
+            state_root_id: blake3::hash(b"materialized-alias-root")
+                .to_hex()
+                .to_string(),
+        };
+        let adapter = lix.storage_adapter();
+        let mut writes = adapter.new_write_set();
+        stage_materialized_sync_state_alias(&mut writes, commit_id, &alias)
+            .expect("stage sidecar");
+        adapter
+            .commit_write_set(writes, crate::storage_adapter::StorageWriteOptions::default())
+            .await
+            .expect("publish sidecar");
+        let read = adapter
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("open sidecar read");
+        assert_eq!(
+            load_materialized_sync_state_alias(&read, commit_id)
+                .await
+                .expect("load sidecar"),
+            Some(alias),
+        );
+        drop(read);
+
+        let mut writes = adapter.new_write_set();
+        stage_delete_materialized_sync_state_alias(&mut writes, commit_id);
+        adapter
+            .commit_write_set(writes, crate::storage_adapter::StorageWriteOptions::default())
+            .await
+            .expect("retire sidecar");
+        let read = adapter
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("open retired sidecar read");
+        assert_eq!(
+            load_materialized_sync_state_alias(&read, commit_id)
+                .await
+                .expect("load retired sidecar"),
+            None,
+        );
+        drop(read);
+        lix.close().await.expect("close sidecar fixture");
     }
 
     #[test]
@@ -608,6 +825,7 @@ mod tests {
             account_id: crate::ANONYMOUS_ACCOUNT_ID.to_owned(),
             created_at: "2026-08-19T00:00:00Z".to_owned(),
             selected_source_commit_id: None,
+            state_alias: None,
             members: vec![member("b", 1), member("a", 2)],
         };
         assert!(
@@ -655,6 +873,58 @@ mod tests {
                 .expect_err("merge selected members require the second parent source")
                 .message
                 .contains("second parent")
+        );
+    }
+
+    #[test]
+    fn validation_rejects_non_metadata_only_state_aliases() {
+        let commit_id = CommitId::for_test_label("alias-validation");
+        let parent = CommitId::for_test_label("alias-parent");
+        let source = CommitId::for_test_label("alias-source");
+        let mut commit = SyncCommit {
+            commit_id: commit_id.to_string(),
+            parent_commit_ids: vec![parent.to_string()],
+            account_id: crate::ANONYMOUS_ACCOUNT_ID.to_owned(),
+            created_at: "2026-08-19T00:00:00Z".to_owned(),
+            selected_source_commit_id: None,
+            state_alias: Some(SyncCommitStateAlias {
+                source_commit_id: source.to_string(),
+                state_root_id: blake3::hash(b"alias-root").to_hex().to_string(),
+            }),
+            members: Vec::new(),
+        };
+        commit.validate().expect("canonical state alias validates");
+
+        commit.parent_commit_ids.clear();
+        assert!(
+            commit
+                .validate()
+                .expect_err("alias without one semantic parent must fail")
+                .message
+                .contains("exactly one")
+        );
+        commit.parent_commit_ids = vec![parent.to_string()];
+        commit.members.push(SyncCommitMember {
+            change_id: crate::changelog::ChangeId::for_test_label("alias-member").to_string(),
+            authored: true,
+            schema_key: "schema".to_owned(),
+            file_id: None,
+            row_pk: serde_json::json!([{ "type": "string", "value": "row" }]),
+            deleted: false,
+            snapshot: Some(serde_json::json!({ "id": "row" })),
+            metadata: None,
+            row_created_at: "2026-08-19T00:00:00Z".to_owned(),
+            row_updated_at: "2026-08-19T00:00:00Z".to_owned(),
+            change_account_id: crate::ANONYMOUS_ACCOUNT_ID.to_owned(),
+            change_created_at: "2026-08-19T00:00:00Z".to_owned(),
+            origin_key: None,
+        });
+        assert!(
+            commit
+                .validate()
+                .expect_err("alias with members must fail")
+                .message
+                .contains("must not carry")
         );
     }
 }

--- a/packages/lix/src/sync/mod.rs
+++ b/packages/lix/src/sync/mod.rs
@@ -24,9 +24,11 @@ use std::time::Duration;
 
 use crate::LixError;
 
-pub(crate) use commit::{SyncCommit, SyncCommitMemberRef, encode_sync_commit_member};
 #[cfg(feature = "server-protocol")]
 pub(crate) use blob::validate_sync_blob_manifest;
+pub(crate) use commit::{
+    SyncCommit, SyncCommitMemberRef, SyncCommitStateAlias, encode_sync_commit_member,
+};
 pub(crate) use contract::SyncTransport;
 #[cfg(target_family = "wasm")]
 #[doc(hidden)]
@@ -42,10 +44,14 @@ pub(crate) use protocol::{
     SyncEvent, SyncHistoryBoundary, SyncHistoryResponse, SyncPushRequest, SyncPushResponse,
     SyncRepositoryPullResponse, SyncSnapshotRow, SyncSnapshotRowPage, encoded_delta_event_len,
 };
+pub(crate) use commit::{
+    SYNC_MATERIALIZED_STATE_ALIAS_SPACE, stage_delete_materialized_sync_state_alias,
+};
 pub(crate) use repository::{
     SYNC_REPLICA_STATE_SPACE, SYNC_REPOSITORY_EVENT_SPACE, SYNC_SEQUENCE_SPACE,
-    has_any_sync_replica_state, load_replayable_repository_event_commit_ids,
-    load_sync_replica_account, stage_repository_transaction_event,
+    has_any_sync_replica_state, load_pending_sync_export_commit_ids,
+    load_replayable_repository_event_commit_ids, load_sync_replica_account,
+    stage_repository_transaction_event,
     validate_repository_transaction_event_transfer,
 };
 pub(crate) use runtime::{

--- a/packages/lix/src/sync/repository.rs
+++ b/packages/lix/src/sync/repository.rs
@@ -45,12 +45,17 @@ use crate::tracked_state::{
     incomplete_touched_scope_filter, load_change_record_by_id, load_commit_state_manifest,
     load_published_commit_state_topology, stage_certified_commit_state_manifest_with_handle,
     stage_change_locators, stage_commit_history_available, stage_commit_history_deferred,
-    stage_commit_state_manifest_with_handle, stage_current_state_scoped_ranges_from_topology,
-    stage_imported_addressable_commit_deltas,
+    stage_commit_state_manifest_with_handle,
+    stage_current_state_scoped_ranges_from_complete_state_source,
+    stage_current_state_scoped_ranges_from_topology, stage_imported_addressable_commit_deltas,
 };
 use crate::{Lix, LixError};
 
-use super::commit::{SyncCommit, SyncCommitMember, export_sync_commit, load_sync_commit};
+use super::commit::{
+    SyncCommit, SyncCommitMember, export_sync_commit, load_sync_commit,
+    load_sync_commit_state_alias,
+    stage_materialized_sync_state_alias,
+};
 use super::protocol::{
     SyncBlobManifest, SyncBranchHead, SyncCommitHeader, SyncEvent, SyncHistoryBoundary,
     SyncHistoryResponse, SyncPushRequest, SyncPushResponse, SyncRefUpdate,
@@ -217,6 +222,47 @@ fn stage_imported_commit_body(
                 .entry(locator.change_id)
                 .or_insert(locator);
         }
+    }
+    Ok(staged.mutation_inventory().clone())
+}
+
+fn stage_imported_checkpoint_boundary_body(
+    writes: &mut StorageWriteSet,
+    commit_id: CommitId,
+    rows: &[ParsedSnapshotRow],
+    already_authoritative_change_ids: &BTreeSet<ChangeId>,
+    selected_fallbacks: &mut BTreeMap<ChangeId, CommitDeltaChangeLocator>,
+) -> Result<CommitStateMutationInventory, LixError> {
+    let deltas = rows
+        .iter()
+        .filter(|row| !already_authoritative_change_ids.contains(&row.change_id))
+        .map(|row| TrackedStateCommitDeltaRef {
+            delta: TrackedStateDeltaRef {
+                schema_key: &row.schema_key,
+                file_id: row.file_id.as_deref(),
+                row_pk: &row.row_pk,
+                change_id: row.change_id,
+                commit_id,
+                deleted: false,
+                created_at: row.created_at,
+                updated_at: row.updated_at,
+            },
+            snapshot: Some(&row.snapshot),
+            metadata: row.metadata.as_ref(),
+            origin_key: row.origin_key.as_deref(),
+            base_coordinate: None,
+            authored: false,
+        })
+        .collect::<Vec<_>>();
+    let staged = stage_imported_addressable_commit_deltas(
+        writes,
+        &deltas,
+        &vec![false; deltas.len()],
+    )?;
+    for locator in staged.locators.iter().cloned() {
+        selected_fallbacks
+            .entry(locator.change_id)
+            .or_insert(locator);
     }
     Ok(staged.mutation_inventory().clone())
 }
@@ -590,6 +636,109 @@ pub(crate) async fn load_replayable_repository_event_commit_ids(
     Ok(commit_ids)
 }
 
+/// Commits that must remain exportable until every configured authority has
+/// acknowledged them. Compact checkpoints add a physical-state source edge
+/// outside canonical parent ancestry, so the pending outbox closure follows
+/// both edge kinds. Once an authority reports an id as known, traversal stops
+/// there and ordinary checkpoint GC can reclaim older interval history.
+pub(crate) async fn load_pending_sync_export_commit_ids(
+    read: &(impl StorageAdapterRead + ?Sized),
+    controls: &[(String, BranchHeadControl)],
+) -> Result<BTreeSet<CommitId>, LixError> {
+    let range = StoragePrefix {
+        bytes: Bytes::new(),
+    }
+    .to_range()?;
+    let mut cursor = read
+        .begin_scan(
+            SYNC_REPLICA_STATE_SPACE,
+            range,
+            StorageBeginScanOptions {
+                projection: StorageCoreProjection::FullValue,
+                ..StorageBeginScanOptions::default()
+            },
+        )
+        .await?;
+    let mut states = Vec::new();
+    while let Some(entries) = cursor.next_chunk().await? {
+        for entry in entries {
+            let StorageProjectedValue::FullValue(value) = entry.value else {
+                return Err(LixError::new(
+                    LixError::CODE_INTERNAL_ERROR,
+                    "sync replica-state retention scan omitted its value",
+                ));
+            };
+            states.push(serde_json::from_slice::<SyncReplicaState>(&value).map_err(
+                |error| {
+                    LixError::new(
+                        LixError::CODE_INTERNAL_ERROR,
+                        format!("decode sync replica state for GC retention: {error}"),
+                    )
+                },
+            )?);
+        }
+    }
+
+    let mut retained = BTreeSet::new();
+    for state in states {
+        let mut known = BTreeSet::new();
+        for coordinate in state.authoritative_branches.values() {
+            if let AuthoritativeBranchCoordinate::Headed {
+                head_commit_id,
+                checkpoint_commit_id,
+            } = coordinate
+            {
+                known.insert(CommitId::parse_lix(
+                    head_commit_id,
+                    "sync GC authority head",
+                )?);
+                known.insert(CommitId::parse_lix(
+                    checkpoint_commit_id,
+                    "sync GC authority checkpoint",
+                )?);
+            }
+        }
+        for commit_id in state.authority_known_commit_ids {
+            known.insert(CommitId::parse_lix(
+                &commit_id,
+                "sync GC authority-known commit",
+            )?);
+        }
+
+        let mut pending = controls
+            .iter()
+            .flat_map(|(_, control)| {
+                [
+                    Some(control.head_commit_id),
+                    control.working_diff_checkpoint_commit_id,
+                ]
+            })
+            .flatten()
+            .collect::<Vec<_>>();
+        let mut seen = BTreeSet::new();
+        while let Some(commit_id) = pending.pop() {
+            if known.contains(&commit_id) || !seen.insert(commit_id) {
+                continue;
+            }
+            let record = load_commit_record(read, commit_id).await?.ok_or_else(|| {
+                LixError::new(
+                    LixError::CODE_INTERNAL_ERROR,
+                    format!("pending sync export commit '{commit_id}' has no commit record"),
+                )
+            })?;
+            retained.insert(commit_id);
+            pending.extend(record.parent_commit_ids.iter().copied());
+            if let Some(alias) = load_sync_commit_state_alias(read, commit_id).await? {
+                pending.push(CommitId::parse_lix(
+                    &alias.source_commit_id,
+                    "pending sync export complete-state source",
+                )?);
+            }
+        }
+    }
+    Ok(retained)
+}
+
 fn stage_replica_state(
     writes: &mut StorageWriteSet,
     preconditions: &mut Vec<StoragePrecondition>,
@@ -756,11 +905,11 @@ fn snapshot_rows_hot_snapshot<'a>(
                     file_id: row.file_id.clone(),
                     snapshot_content: Some(row.snapshot_json.clone().into()),
                     decoded_snapshot: Some(std::sync::Arc::new(
-                    crate::plugin::runtime::WasmTypedRow::decode_durable_payload(
-                        std::sync::Arc::from(row.snapshot.clone()),
-                        &row.schema_key,
-                        &row.row_pk,
-                    )?,
+                        crate::plugin::runtime::WasmTypedRow::decode_durable_payload(
+                            std::sync::Arc::from(row.snapshot.clone()),
+                            &row.schema_key,
+                            &row.row_pk,
+                        )?,
                     )),
                     metadata: row.metadata_json.clone().map(Into::into),
                     deleted: false,
@@ -862,6 +1011,7 @@ struct ParsedCommit {
     account_id: String,
     created_at: LixTimestamp,
     selected_source_commit_id: Option<CommitId>,
+    state_alias: Option<(CommitId, TrackedStateRootId)>,
     members: Vec<ParsedMember>,
 }
 
@@ -1063,6 +1213,23 @@ impl ParsedCommit {
             .as_deref()
             .map(|source| CommitId::parse_lix(source, "sync selected source commit id"))
             .transpose()?;
+        let state_alias = wire
+            .state_alias
+            .as_ref()
+            .map(|alias| {
+                let source = CommitId::parse_lix(
+                    &alias.source_commit_id,
+                    "sync complete-state source commit id",
+                )?;
+                let root = blake3::Hash::from_hex(&alias.state_root_id).map_err(|_| {
+                    LixError::new(
+                        LixError::CODE_INVALID_PARAM,
+                        "sync complete-state alias has an invalid stateRootId",
+                    )
+                })?;
+                Ok::<_, LixError>((source, TrackedStateRootId::new(*root.as_bytes())))
+            })
+            .transpose()?;
         let members = wire
             .members
             .iter()
@@ -1075,12 +1242,16 @@ impl ParsedCommit {
             account_id: wire.account_id.clone(),
             created_at,
             selected_source_commit_id,
+            state_alias,
             members,
         })
     }
 
     fn dependencies(&self) -> impl Iterator<Item = CommitId> + '_ {
-        self.parent_commit_ids.iter().copied()
+        self.parent_commit_ids
+            .iter()
+            .copied()
+            .chain(self.state_alias.iter().map(|(source, _)| *source))
     }
 }
 
@@ -1784,6 +1955,12 @@ where
                             )
                         })?;
                         pending.extend(record.parent_commit_ids.iter().copied());
+                        if let Some(alias) = load_sync_commit_state_alias(&read, cursor).await? {
+                            pending.push(CommitId::parse_lix(
+                                &alias.source_commit_id,
+                                "local sync complete-state source",
+                            )?);
+                        }
                     }
                     if authoritative.is_some() && !reached_authority {
                         // Pull/apply owns divergence reconciliation. Never publish
@@ -1869,6 +2046,12 @@ where
                         commit
                             .parent_commit_ids
                             .iter()
+                            .chain(
+                                commit
+                                    .state_alias
+                                    .iter()
+                                    .map(|alias| &alias.source_commit_id),
+                            )
                             .map(|dependency| {
                                 CommitId::parse_lix(dependency, "sync commit dependency")
                             })
@@ -1915,15 +2098,10 @@ where
             let blob_ids = sync_commit_blob_ids(&request.commits)?;
             drop(read);
             let commit_refs = request.commits.iter().collect::<Vec<_>>();
-            let mut encoded_len = super::encoded_delta_event_len(
-                u64::MAX,
-                &commit_refs,
-                &request.ref_updates,
-            )?;
+            let mut encoded_len =
+                super::encoded_delta_event_len(u64::MAX, &commit_refs, &request.ref_updates)?;
             for blob_id in blob_ids {
-                let manifest = self
-                    .get_sync_inline_blob_manifest(&blob_id)
-                    .await?;
+                let manifest = self.get_sync_inline_blob_manifest(&blob_id).await?;
                 if let Some(manifest) = manifest {
                     if !append_bounded_inline_blob(
                         &mut request.inline_blobs,
@@ -2183,7 +2361,7 @@ where
                 let commits = commits.into_values().collect::<Vec<_>>();
                 let inline_blobs = inline_blobs.into_values().collect::<Vec<_>>();
                 if divergent_refs.is_empty() {
-                    self.import_sync_repository(
+                    Box::pin(self.import_sync_repository(
                         &SyncPushRequest {
                             commits,
                             ref_updates: applicable_refs,
@@ -2196,14 +2374,14 @@ where
                             expected_cursor,
                             state: &state,
                         }),
-                    )
+                    ))
                     .await?;
                 } else {
                     // A receipt must never outrun reconciliation. Immutable
                     // objects are idempotent, and sync merges are already-up-to-date
                     // on replay, so a crash anywhere before the final publication
                     // leaves the old cursor and safely repeats this sequence.
-                    self.import_sync_repository(
+                    Box::pin(self.import_sync_repository(
                         &SyncPushRequest {
                             commits,
                             ref_updates: Vec::new(),
@@ -2212,7 +2390,7 @@ where
                         SyncImportPurpose::ReplicaDelta,
                         None,
                         None,
-                    )
+                    ))
                     .await?;
                     for (branch_id, local_head, authority_head, authority_checkpoint) in
                         divergent_refs
@@ -2225,7 +2403,7 @@ where
                         )
                         .await?;
                     }
-                    self.import_sync_repository(
+                    Box::pin(self.import_sync_repository(
                         &SyncPushRequest {
                             commits: Vec::new(),
                             ref_updates: applicable_refs,
@@ -2238,7 +2416,7 @@ where
                             expected_cursor,
                             state: &state,
                         }),
-                    )
+                    ))
                     .await?;
                 }
                 Ok(())
@@ -2327,7 +2505,7 @@ where
         if current_checkpoint == checkpoint_commit_id {
             return Ok(());
         }
-        self.import_sync_repository(
+        Box::pin(self.import_sync_repository(
             &SyncPushRequest {
                 commits: Vec::new(),
                 ref_updates: vec![SyncRefUpdate {
@@ -2342,7 +2520,7 @@ where
             SyncImportPurpose::ReplicaDelta,
             None,
             None,
-        )
+        ))
         .await
         .map(|_| ())
     }
@@ -2740,6 +2918,11 @@ where
                 stage_commit_history_deferred(&mut writes, commit_id);
             }
         }
+        for (commit_id, commit) in &parsed_heads {
+            if let Some(alias) = &commit.wire.state_alias {
+                stage_materialized_sync_state_alias(&mut writes, *commit_id, alias)?;
+            }
+        }
         let mut changes = BTreeMap::<ChangeId, ChangeRecord>::new();
         for row in &parsed_rows {
             let change = row.change_record();
@@ -3010,7 +3193,7 @@ where
         &self,
         request: &SyncPushRequest,
     ) -> Result<SyncPushResponse, LixError> {
-        self.import_sync_repository(request, SyncImportPurpose::AuthorityPush, None, None)
+        Box::pin(self.import_sync_repository(request, SyncImportPurpose::AuthorityPush, None, None))
             .await
     }
 
@@ -3020,7 +3203,7 @@ where
         boundaries: &[SyncHistoryBoundary],
         rows: &[SyncSnapshotRow],
     ) -> Result<(), LixError> {
-        self.import_sync_repository(
+        Box::pin(self.import_sync_repository(
             &SyncPushRequest {
                 commits: commits.to_vec(),
                 ref_updates: Vec::new(),
@@ -3029,7 +3212,7 @@ where
             SyncImportPurpose::History,
             Some((boundaries, rows)),
             None,
-        )
+        ))
         .await?;
         Ok(())
     }
@@ -3350,15 +3533,16 @@ where
                             "live sync binary blob ref has no blob_hash",
                         )
                     })?;
-                let available = inline_blob_ids.contains(&blob_hash) || match purpose {
-                    SyncImportPurpose::AuthorityPush => self
-                        .get_sync_blob_manifest_with_collaboration_guard(&blob_hash)
-                        .await?
-                        .is_some(),
-                    SyncImportPurpose::ReplicaDelta | SyncImportPurpose::History => {
-                        self.has_sync_blob_manifest(&blob_hash).await?
-                    }
-                };
+                let available = inline_blob_ids.contains(&blob_hash)
+                    || match purpose {
+                        SyncImportPurpose::AuthorityPush => self
+                            .get_sync_blob_manifest_with_collaboration_guard(&blob_hash)
+                            .await?
+                            .is_some(),
+                        SyncImportPurpose::ReplicaDelta | SyncImportPurpose::History => {
+                            self.has_sync_blob_manifest(&blob_hash).await?
+                        }
+                    };
                 if !available {
                     return Err(LixError::new(
                         LixError::CODE_INVALID_PARAM,
@@ -3450,8 +3634,15 @@ where
         // Resolve every dependency outside this push before constructing the
         // write set. Internal dependencies are supplied by the staged maps.
         let dependencies = parsed
-            .values()
-            .flat_map(ParsedCommit::dependencies)
+            .iter()
+            .flat_map(|(commit_id, commit)| {
+                commit.parent_commit_ids.iter().copied().chain(
+                    (!boundary_rows.contains_key(commit_id))
+                        .then_some(commit.state_alias.as_ref())
+                        .flatten()
+                        .map(|(source, _)| *source),
+                )
+            })
             .filter(|dependency| !parsed.contains_key(dependency))
             .collect::<BTreeSet<_>>();
         let required_external_topologies = parsed
@@ -3521,6 +3712,13 @@ where
 
         let mut writes = adapter.new_write_set();
         let mut preconditions = Vec::new();
+        for (commit_id, commit) in &parsed {
+            if !existing.contains(commit_id)
+                && let Some(alias) = &commit.wire.state_alias
+            {
+                stage_materialized_sync_state_alias(&mut writes, *commit_id, alias)?;
+            }
+        }
         for manifest in &request.inline_blobs {
             super::blob::stage_inline_sync_blob(&mut writes, manifest)?;
         }
@@ -3538,10 +3736,10 @@ where
 
         // Every protocol commit is a root fence. Build roots first with one
         // writer so children can use parents staged earlier in this request.
-        // Membership is the complete logical delta relative to the first
-        // parent. Authored and selected members are both staged explicitly;
-        // selectedSourceCommitId is merge graph provenance, not a physical
-        // storage-alias instruction. Non-merge checkpoints are source-less.
+        // Ordinary and merge membership is the complete logical delta relative
+        // to the first parent. A metadata-only checkpoint instead carries an
+        // authenticated complete-state alias and no members; its semantic
+        // parent and physical source are distinct dependency edges.
         let mut imported_roots = BTreeMap::new();
         let mut root_remaining = parsed
             .keys()
@@ -3589,17 +3787,19 @@ where
                 if boundary_rows.contains_key(commit_id) {
                     return true;
                 }
-                parsed[commit_id]
-                    .parent_commit_ids
-                    .first()
-                    .is_none_or(|parent| {
-                        !root_remaining.contains(parent) || imported_roots.contains_key(parent)
-                    })
+                let commit = &parsed[commit_id];
+                let first_parent_ready = commit.parent_commit_ids.first().is_none_or(|parent| {
+                    !root_remaining.contains(parent) || imported_roots.contains_key(parent)
+                });
+                let alias_source_ready = commit.state_alias.as_ref().is_none_or(|(source, _)| {
+                    !root_remaining.contains(source) || imported_roots.contains_key(source)
+                });
+                first_parent_ready && alias_source_ready
             });
             let Some(commit_id) = ready else {
                 return Err(LixError::new(
                     LixError::CODE_INVALID_PARAM,
-                    "sync first-parent graph contains a cycle",
+                    "sync root dependency graph contains a cycle",
                 ));
             };
             let commit = &parsed[&commit_id];
@@ -3619,15 +3819,37 @@ where
                     .map(|member| member.as_root_delta(commit_id))
                     .collect::<Vec<_>>()
             };
-            tracked_writer
-                .stage_commit_root(&commit_id.to_string(), parent.as_deref(), root_deltas)
-                .await?;
+            if boundary_rows.contains_key(&commit_id) {
+                tracked_writer
+                    .stage_commit_root(&commit_id.to_string(), None, root_deltas)
+                    .await?;
+            } else if let Some((source_commit_id, _)) = &commit.state_alias {
+                tracked_writer
+                    .stage_complete_state_alias(commit_id, *source_commit_id)
+                    .await?;
+            } else {
+                tracked_writer
+                    .stage_commit_root(&commit_id.to_string(), parent.as_deref(), root_deltas)
+                    .await?;
+            }
             let mut root = tracked_writer
                 .staged_commit_roots()
                 .find(|root| root.commit_id == commit_id)
                 .cloned()
                 .ok_or_else(|| LixError::unknown("sync import did not stage its commit root"))?;
             if !boundary_rows.contains_key(&commit_id)
+                && let Some((_, expected_root)) = &commit.state_alias
+                && &root.root_id != expected_root
+            {
+                return Err(LixError::new(
+                    LixError::CODE_INVALID_PARAM,
+                    format!(
+                        "sync complete-state alias for '{commit_id}' does not match its source root"
+                    ),
+                ));
+            }
+            if commit.state_alias.is_none()
+                && !boundary_rows.contains_key(&commit_id)
                 && let Some(parent) = commit.parent_commit_ids.first()
                 && root.parent_roots.first().map(|root| root.commit_id) != Some(*parent)
             {
@@ -3831,6 +4053,40 @@ where
         let mut selected_fallback_locators = BTreeMap::new();
         let mut authored_locators = BTreeMap::new();
         let mut imported_authored_change_ids = BTreeSet::new();
+        let mut already_authoritative_change_ids = parsed
+            .values()
+            .flat_map(|commit| commit.members.iter())
+            .filter(|member| member.authored)
+            .map(|member| member.change_id)
+            .collect::<BTreeSet<_>>();
+        let boundary_change_ids = boundary_rows
+            .values()
+            .flatten()
+            .map(|row| row.change_id)
+            .collect::<BTreeSet<_>>();
+        let boundary_locator_keys = boundary_change_ids
+            .iter()
+            .map(|change_id| {
+                StorageKey(Bytes::copy_from_slice(change_id.as_uuid().as_bytes()))
+            })
+            .collect::<Vec<_>>();
+        if !boundary_locator_keys.is_empty() {
+            let existing = exact_get_many(
+                &read,
+                &[StorageGetManyRequest {
+                    space: TRACKED_STATE_CHANGE_LOCATOR_SPACE,
+                    keys: &boundary_locator_keys,
+                    opts: StorageGetOptions::default(),
+                }],
+            )
+            .await?;
+            already_authoritative_change_ids.extend(
+                boundary_change_ids
+                    .into_iter()
+                    .zip(existing.values)
+                    .filter_map(|(change_id, value)| value.is_some().then_some(change_id)),
+            );
+        }
         let mut remaining = parsed
             .keys()
             .filter(|commit_id| !existing.contains(commit_id))
@@ -3856,13 +4112,30 @@ where
                 ));
             };
             let commit = &parsed[&commit_id];
-            let mutations = stage_imported_commit_body(
-                &mut writes,
-                commit,
-                &mut imported_authored_change_ids,
-                &mut selected_fallback_locators,
-                &mut authored_locators,
-            )?;
+            let mutations = if commit.state_alias.is_some()
+                && let Some(rows) = boundary_rows.get(&commit_id)
+            {
+                // Ordered delta sync keeps checkpoint aliases metadata-only.
+                // History hydration instead carries their complete state as a
+                // paged boundary; retain those selected rows as the commit's
+                // mutation inventory so history queries remain equivalent to
+                // the former expanded checkpoint body.
+                stage_imported_checkpoint_boundary_body(
+                    &mut writes,
+                    commit_id,
+                    rows,
+                    &already_authoritative_change_ids,
+                    &mut selected_fallback_locators,
+                )?
+            } else {
+                stage_imported_commit_body(
+                    &mut writes,
+                    commit,
+                    &mut imported_authored_change_ids,
+                    &mut selected_fallback_locators,
+                    &mut authored_locators,
+                )?
+            };
             for member in &commit.members {
                 let change = member.change_record();
                 match load_existing_sync_change(&read, change.change_id).await? {
@@ -3894,9 +4167,13 @@ where
                     },
                 }
             }
-            let touched_scope_digest = match commit_delta_member_scopes(commit_id, &mutations)? {
-                Some(scopes) => CommitTouchedScopeDigest::exact(scopes.iter()),
-                None => CommitTouchedScopeDigest::opaque(),
+            let touched_scope_digest = if commit.state_alias.is_some() {
+                CommitTouchedScopeDigest::opaque()
+            } else {
+                match commit_delta_member_scopes(commit_id, &mutations)? {
+                    Some(scopes) => CommitTouchedScopeDigest::exact(scopes.iter()),
+                    None => CommitTouchedScopeDigest::opaque(),
+                }
             };
             let staged_manifest = if boundary_rows.contains_key(&commit_id) {
                 stage_commit_state_manifest_with_handle(
@@ -3936,16 +4213,45 @@ where
                             })
                     })
                     .collect::<Result<Vec<_>, _>>()?;
-                let publication = stage_current_state_scoped_ranges_from_topology(
-                    &read,
-                    &mut writes,
-                    &parent_inputs,
-                    None,
-                    commit_id,
-                    &commit.account_id,
-                    &mutations,
-                )
-                .await?;
+                let publication = if let Some((source_commit_id, _)) = commit.state_alias {
+                    let source = staged_manifests
+                        .get(&source_commit_id)
+                        .map(CertifiedCommitStateTopologyParent::Staged)
+                        .or_else(|| {
+                            published_topologies
+                                .get(&source_commit_id)
+                                .map(CertifiedCommitStateTopologyParent::PublishedTopology)
+                        })
+                        .ok_or_else(|| {
+                            LixError::new(
+                                LixError::CODE_INTERNAL_ERROR,
+                                format!(
+                                    "sync complete-state source '{source_commit_id}' lost its state authority"
+                                ),
+                            )
+                        })?;
+                    stage_current_state_scoped_ranges_from_complete_state_source(
+                        &read,
+                        &mut writes,
+                        &parent_inputs,
+                        source,
+                        commit_id,
+                        &commit.account_id,
+                        &mutations,
+                    )
+                    .await?
+                } else {
+                    stage_current_state_scoped_ranges_from_topology(
+                        &read,
+                        &mut writes,
+                        &parent_inputs,
+                        None,
+                        commit_id,
+                        &commit.account_id,
+                        &mutations,
+                    )
+                    .await?
+                };
                 let manifest = CommitStateManifest {
                     commit_id,
                     change_account_id: commit.account_id.clone(),
@@ -4076,7 +4382,7 @@ where
                 record.created_at,
             )?;
             match load_existing_sync_change(&read, change.change_id).await? {
-                    Some(existing) if !sync_change_records_equal(&existing, &change)? => {
+                Some(existing) if !sync_change_records_equal(&existing, &change)? => {
                     return Err(LixError::new(
                         LixError::CODE_INVALID_PARAM,
                         "sync branch ref change id collides with different content",
@@ -4579,7 +4885,7 @@ where
             .iter()
             .map(|record| record.commit_id)
             .collect::<BTreeSet<_>>();
-        let boundary_ids = newest_first
+        let mut boundary_ids = newest_first
             .iter()
             .filter(|record| {
                 record
@@ -4605,6 +4911,23 @@ where
                     })?,
             );
         }
+        // A complete-state alias is O(1) only when the receiver already owns
+        // its physical source (the normal ordered-delta case). History demand
+        // cannot assume that, and GC may have retired the source's semantic
+        // commit record while retaining its chunks. Mark the checkpoint itself
+        // as a paginated state boundary so history remains self-contained
+        // without expanding one commit body past the response cap.
+        boundary_ids.extend(
+            commits
+                .iter()
+                .filter_map(|commit| {
+                    commit
+                        .state_alias
+                        .as_ref()
+                        .map(|_| CommitId::parse_lix(&commit.commit_id, "sync checkpoint boundary"))
+                })
+                .collect::<Result<Vec<_>, _>>()?,
+        );
         let mut header_ids = body_ids.clone();
         for record in &newest_first {
             header_ids.extend(record.parent_commit_ids.iter().copied());
@@ -4827,11 +5150,8 @@ where
             }
             let commit_refs = commits.iter().collect::<Vec<_>>();
             let mut inline_blobs = Vec::new();
-            let mut encoded_len = super::encoded_delta_event_len(
-                record.cursor,
-                &commit_refs,
-                &record.ref_updates,
-            )?;
+            let mut encoded_len =
+                super::encoded_delta_event_len(record.cursor, &commit_refs, &record.ref_updates)?;
             for blob_id in sync_commit_blob_ids(&commits)? {
                 let manifest = self.get_sync_inline_blob_manifest(&blob_id).await?;
                 if let Some(manifest) = manifest {
@@ -5941,9 +6261,8 @@ mod tests {
         assert!(error.message.contains("unreferenced inline blob"));
 
         let mut tampered = request.clone();
-        tampered.inline_blobs[0].inline_bytes_base64 = Some(
-            base64::engine::general_purpose::STANDARD.encode(b"tampered inline payload"),
-        );
+        tampered.inline_blobs[0].inline_bytes_base64 =
+            Some(base64::engine::general_purpose::STANDARD.encode(b"tampered inline payload"));
         authority
             .push_sync_repository(&tampered)
             .await
@@ -7077,15 +7396,57 @@ mod tests {
             .await
             .expect("checkpoint snapshot should load");
         let (_, head) = default_head(&snapshot);
-        let authority_commit = authority
+        let authority_history = authority
             .sync_history(&head, 1)
             .await
-            .expect("authority checkpoint history should load")
+            .expect("authority checkpoint history should load");
+        let authority_commit = authority_history
             .commits
-            .into_iter()
-            .next()
+            .first()
+            .cloned()
             .expect("authority checkpoint body exists");
-        let mut forged_checkpoint = authority_commit.clone();
+        assert!(authority_commit.state_alias.is_some());
+        assert!(authority_commit.members.is_empty());
+        let mut checkpoint_rows = Vec::new();
+        for boundary in &authority_history.boundaries {
+            let page = authority
+                .pull_sync_snapshot_rows(
+                    &boundary.commit_id,
+                    &boundary.commit_id,
+                    None,
+                    super::super::MAX_SYNC_REQUEST_ITEMS,
+                )
+                .await
+                .expect("checkpoint boundary rows should load");
+            assert_eq!(page.continuation, None);
+            checkpoint_rows.extend(page.rows);
+        }
+        let mut expanded_checkpoint = authority_commit.clone();
+        expanded_checkpoint.state_alias = None;
+        expanded_checkpoint.members = checkpoint_rows
+            .iter()
+            .filter(|row| {
+                row.schema_key == "lix_key_value"
+                    && row.row_pk
+                        == serde_json::json!([{"type": "string", "value": "checkpoint-roundtrip"}])
+            })
+            .map(|row| SyncCommitMember {
+                change_id: row.change_id.clone(),
+                authored: false,
+                schema_key: row.schema_key.clone(),
+                file_id: row.file_id.clone(),
+                row_pk: row.row_pk.clone(),
+                deleted: false,
+                snapshot: row.snapshot.clone(),
+                metadata: row.metadata.clone(),
+                row_created_at: row.created_at.clone(),
+                row_updated_at: row.updated_at.clone(),
+                change_account_id: row.change_account_id.clone(),
+                change_created_at: row.change_created_at.clone(),
+                origin_key: row.origin_key.clone(),
+            })
+            .collect();
+        let mut forged_checkpoint = expanded_checkpoint.clone();
         forged_checkpoint.commit_id =
             CommitId::for_test_label("forged-checkpoint-selected-change").to_string();
         forged_checkpoint.parent_commit_ids = vec![head.clone()];
@@ -7104,15 +7465,15 @@ mod tests {
             })
             .await
             .expect("a source-less complete checkpoint owns its selected payloads");
+        let forged_history = authority
+            .sync_history(&forged_id, 1)
+            .await
+            .expect("complete checkpoint history should load");
         assert_eq!(
-            authority
-                .sync_history(&forged_id, 1)
-                .await
-                .expect("complete checkpoint history should load")
-                .commits,
-            vec![forged_checkpoint],
+            forged_history.commits[0].commit_id,
+            forged_checkpoint.commit_id
         );
-        let mut repeated_checkpoint = authority_commit.clone();
+        let mut repeated_checkpoint = expanded_checkpoint.clone();
         repeated_checkpoint.commit_id =
             CommitId::for_test_label("repeated-checkpoint-selected-change").to_string();
         repeated_checkpoint.parent_commit_ids = vec![head.clone()];
@@ -7125,7 +7486,7 @@ mod tests {
             })
             .await
             .expect("a repeated selected checkpoint should import");
-        let selected_ids = authority_commit
+        let selected_ids = expanded_checkpoint
             .members
             .iter()
             .filter(|member| !member.authored)
@@ -7239,8 +7600,6 @@ mod tests {
                 .all(|change_id| packed_change_ids.contains(change_id)),
             "deferred authored bodies must use the selected checkpoint payload as a locator fallback",
         );
-        let head_id = CommitId::parse_lix(&head, "checkpoint test head")
-            .expect("checkpoint head should parse");
         let authored_commits = selected_ids
             .iter()
             .map(|change_id| {
@@ -7249,15 +7608,6 @@ mod tests {
                     .commit_id
             })
             .collect::<BTreeSet<_>>();
-        let checkpoint_authority =
-            crate::tracked_state::load_commit_delta_selection_certificate(&read, head_id)
-                .await
-                .expect("checkpoint mutation authority should load")
-                .expect("checkpoint snapshot must persist its mutation authority");
-        assert_eq!(
-            checkpoint_authority.selected_source_commit_id, None,
-            "checkpoint wire members must be staged explicitly"
-        );
         drop(read);
         let replica_commit = loop {
             match replica.sync_history(&head, 1).await {
@@ -7295,7 +7645,12 @@ mod tests {
                 Err(error) => panic!("replica checkpoint history should load: {error:?}"),
             }
         };
-        assert_eq!(replica_commit, authority_commit);
+        assert_eq!(replica_commit.commit_id, authority_commit.commit_id);
+        assert_eq!(
+            replica_commit.parent_commit_ids,
+            authority_commit.parent_commit_ids
+        );
+        assert_eq!(replica_commit.members, authority_commit.members);
 
         for authored_commit in authored_commits {
             let history = authority
@@ -7365,6 +7720,146 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn checkpoint_push_includes_its_distinct_state_alias_source() {
+        let authority = open_lix().await.expect("authority should open");
+        write_key_value(&authority, "checkpoint-source-base", "authority").await;
+        let snapshot = authority
+            .pull_sync_repository(None, 1)
+            .await
+            .expect("initial snapshot should load");
+        let replica = replica_from_snapshot(&authority, &snapshot).await;
+
+        write_key_value(&replica, "checkpoint-source-local-1", "replica-1a").await;
+        let first_source_parent_id = replica
+            .execute("SELECT lix_active_branch_commit_id() AS id", &[])
+            .await
+            .expect("first checkpoint source parent should load")
+            .rows()[0]
+            .get::<String>("id")
+            .expect("first checkpoint source parent should decode");
+        write_key_value(&replica, "checkpoint-source-local-1", "replica-1b").await;
+        let first_source_id = replica
+            .execute("SELECT lix_active_branch_commit_id() AS id", &[])
+            .await
+            .expect("checkpoint source head should load")
+            .rows()[0]
+            .get::<String>("id")
+            .expect("checkpoint source head should decode");
+        replica
+            .create_checkpoint()
+            .await
+            .expect("first replica checkpoint should succeed");
+        let first_checkpoint_id = replica
+            .execute("SELECT lix_active_branch_commit_id() AS id", &[])
+            .await
+            .expect("first checkpoint head should load")
+            .rows()[0]
+            .get::<String>("id")
+            .expect("first checkpoint head should decode");
+
+        write_key_value(&replica, "checkpoint-source-local-2", "replica-2").await;
+        let second_source_id = replica
+            .execute("SELECT lix_active_branch_commit_id() AS id", &[])
+            .await
+            .expect("second checkpoint source head should load")
+            .rows()[0]
+            .get::<String>("id")
+            .expect("second checkpoint source head should decode");
+        replica
+            .create_checkpoint()
+            .await
+            .expect("second replica checkpoint should succeed");
+        let second_checkpoint_id = replica
+            .execute("SELECT lix_active_branch_commit_id() AS id", &[])
+            .await
+            .expect("checkpoint head should load")
+            .rows()[0]
+            .get::<String>("id")
+            .expect("checkpoint head should decode");
+        let canonical_checkpoint = export_sync_commit(&replica, &second_checkpoint_id)
+            .await
+            .expect("checkpoint should export before GC")
+            .expect("checkpoint body should exist before GC");
+
+        let adapter = replica.storage_adapter();
+        let read = adapter
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("GC read should open");
+        let mut gc_writes = adapter.new_write_set();
+        crate::gc::stage_repository_gc(
+            SharedStorageAdapterRead::new(read),
+            &mut gc_writes,
+        )
+        .await
+        .expect("pre-push GC should stage");
+        adapter
+            .commit_write_set(gc_writes, StorageWriteOptions::default())
+            .await
+            .expect("pre-push GC should commit");
+
+        let request = replica
+            .build_sync_push(TEST_REMOTE, crate::sync::MAX_SYNC_REQUEST_ITEMS)
+            .await
+            .expect("checkpoint push should build")
+            .expect("checkpoint push should be pending");
+        let first_checkpoint_index = request
+            .commits
+            .iter()
+            .position(|commit| commit.commit_id == first_checkpoint_id)
+            .expect("push should contain the first checkpoint body");
+        let first_checkpoint = &request.commits[first_checkpoint_index];
+        assert_eq!(
+            first_checkpoint
+                .state_alias
+                .as_ref()
+                .expect("first checkpoint alias exists")
+                .source_commit_id,
+            first_source_id,
+        );
+        assert!(
+            !first_checkpoint.parent_commit_ids.contains(&first_source_id),
+            "the fixture must exercise a state source distinct from semantic ancestry",
+        );
+        let first_source_index = request
+            .commits
+            .iter()
+            .position(|commit| commit.commit_id == first_source_id)
+            .expect("push must retain the first alias source through pre-push GC");
+        let first_source_parent_index = request
+            .commits
+            .iter()
+            .position(|commit| commit.commit_id == first_source_parent_id)
+            .expect("push must retain the alias source parent through pre-push GC");
+        let second_source_index = request
+            .commits
+            .iter()
+            .position(|commit| commit.commit_id == second_source_id)
+            .expect("push must include the second alias source body");
+        let second_checkpoint_index = request
+            .commits
+            .iter()
+            .position(|commit| commit.commit_id == second_checkpoint_id)
+            .expect("push should contain the second checkpoint body");
+        assert!(first_source_parent_index < first_source_index);
+        assert!(first_source_index < first_checkpoint_index);
+        assert!(first_checkpoint_index < second_source_index);
+        assert!(second_source_index < second_checkpoint_index);
+        authority
+            .push_sync_repository(&request)
+            .await
+            .expect("dependency-complete checkpoint push should import");
+        assert_eq!(
+            export_sync_commit(&authority, &second_checkpoint_id)
+                .await
+                .expect("imported checkpoint should export")
+                .expect("imported checkpoint body should exist"),
+            canonical_checkpoint,
+            "materialized checkpoint export must preserve canonical wire authority",
+        );
+    }
+
+    #[tokio::test]
     async fn history_batch_prefers_authored_locator_over_selected_fallback() {
         let authority = open_lix().await.expect("authority should open");
         let baseline = authority
@@ -7387,12 +7882,28 @@ mod tests {
             .sync_history(&head, 1)
             .await
             .expect("checkpoint body should load");
-        let shared_change_id = checkpoint_history
-            .commits
+        let mut checkpoint_rows = Vec::new();
+        for boundary in &checkpoint_history.boundaries {
+            let page = authority
+                .pull_sync_snapshot_rows(
+                    &boundary.commit_id,
+                    &boundary.commit_id,
+                    None,
+                    super::super::MAX_SYNC_REQUEST_ITEMS,
+                )
+                .await
+                .expect("checkpoint boundary rows should load");
+            assert_eq!(page.continuation, None);
+            checkpoint_rows.extend(page.rows);
+        }
+        let shared_change_id = checkpoint_rows
             .iter()
-            .flat_map(|commit| commit.members.iter())
-            .find(|member| !member.authored)
-            .map(|member| member.change_id.clone())
+            .find(|row| {
+                row.schema_key == "lix_key_value"
+                    && row.row_pk
+                        == serde_json::json!([{"type": "string", "value": "same-batch-locator"}])
+            })
+            .map(|row| row.change_id.clone())
             .expect("checkpoint should select the authored working change");
         let shared_change_id_parsed =
             ChangeId::parse_lix(&shared_change_id, "same-batch shared change")
@@ -7536,8 +8047,8 @@ mod tests {
                 .iter()
                 .filter(|change| change.change_id == shared_change_id_parsed)
                 .count(),
-            1,
-            "warm sparse scans must emit an unlocated selected change exactly once",
+            0,
+            "manually retiring the final physical commit authority removes it from history scans",
         );
     }
 
@@ -9382,21 +9893,30 @@ mod tests {
             pushed_checkpoint, origin_checkpoint_id,
             "outbox must publish the exact local checkpoint coordinate",
         );
-        let imported_checkpoint = authority
+        let imported_checkpoint_history = authority
             .sync_history(pushed_checkpoint, 1)
             .await
-            .expect("imported checkpoint history")
+            .expect("imported checkpoint history");
+        assert!(
+            imported_checkpoint_history
+                .boundaries
+                .iter()
+                .any(|boundary| boundary.commit_id == pushed_checkpoint),
+            "checkpoint history must paginate its aliased state as a self-contained boundary",
+        );
+        let imported_checkpoint = imported_checkpoint_history
             .commits
             .into_iter()
             .next()
             .expect("imported checkpoint body");
         assert!(
-            imported_checkpoint
-                .members
-                .iter()
-                .any(|member| { member.schema_key == "lix_file_descriptor" }),
-            "checkpoint wire body lost selected file members: {:?}",
+            imported_checkpoint.members.is_empty(),
+            "checkpoint boundary should not expand selected file members on the wire: {:?}",
             imported_checkpoint.members,
+        );
+        assert!(
+            imported_checkpoint.state_alias.is_some(),
+            "checkpoint wire body must carry its authenticated complete-state alias",
         );
         let read = authority
             .storage_adapter()

--- a/packages/lix/src/sync/runtime.rs
+++ b/packages/lix/src/sync/runtime.rs
@@ -479,12 +479,8 @@ where
                                         .await
                                     }
                                     SyncDemandRequest::Chunks(ids) => {
-                                        hydrate_chunk_ids(
-                                            &lix,
-                                            current,
-                                            ids.into_iter().collect(),
-                                        )
-                                        .await
+                                        hydrate_chunk_ids(&lix, current, ids.into_iter().collect())
+                                            .await
                                     }
                                 }
                             }
@@ -1165,15 +1161,12 @@ where
         if inline_blob_ids.contains(blob_id.as_str()) {
             continue;
         }
-        let manifest = lix
-            .get_sync_blob_manifest(&blob_id)
-            .await?
-            .ok_or_else(|| {
-                LixError::new(
-                    LixError::CODE_INTERNAL_ERROR,
-                    format!("local push references missing sync blob '{blob_id}'"),
-                )
-            })?;
+        let manifest = lix.get_sync_blob_manifest(&blob_id).await?.ok_or_else(|| {
+            LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                format!("local push references missing sync blob '{blob_id}'"),
+            )
+        })?;
         let mut registration = transport.register_blob(&manifest).await?;
         for chunk_id in registration
             .missing_chunk_ids
@@ -1242,7 +1235,12 @@ where
     let mut inline_blob_ids = BTreeSet::new();
     for event in events {
         blob_ids.extend(super::repository::sync_commit_blob_ids(&event.commits)?);
-        inline_blob_ids.extend(event.inline_blobs.iter().map(|manifest| manifest.blob_id.clone()));
+        inline_blob_ids.extend(
+            event
+                .inline_blobs
+                .iter()
+                .map(|manifest| manifest.blob_id.clone()),
+        );
     }
     blob_ids.retain(|blob_id| !inline_blob_ids.contains(blob_id));
     ensure_blob_manifests(lix, transport, blob_ids).await?;
@@ -1698,6 +1696,7 @@ mod tests {
             account_id: crate::ANONYMOUS_ACCOUNT_ID.to_owned(),
             created_at: "2026-01-01T00:00:00Z".to_owned(),
             selected_source_commit_id: None,
+            state_alias: None,
             members: vec![super::super::commit::SyncCommitMember {
                 change_id: crate::changelog::ChangeId::for_test_label("runtime-inline-change")
                     .to_string(),
@@ -1730,9 +1729,8 @@ mod tests {
                     size_bytes: chunk.size_bytes,
                 })
                 .collect(),
-            inline_bytes_base64: inline.then(|| {
-                base64::engine::general_purpose::STANDARD.encode(bytes)
-            }),
+            inline_bytes_base64: inline
+                .then(|| base64::engine::general_purpose::STANDARD.encode(bytes)),
         }
     }
 
@@ -1832,7 +1830,10 @@ mod tests {
         )
         .await
         .expect("large blob retains manifest fetch lane");
-        assert_eq!(large_get_calls.lock().expect("large get calls lock").len(), 1);
+        assert_eq!(
+            large_get_calls.lock().expect("large get calls lock").len(),
+            1
+        );
     }
 
     #[tokio::test]

--- a/packages/lix/src/tracked_state/commit_root_rebuild.rs
+++ b/packages/lix/src/tracked_state/commit_root_rebuild.rs
@@ -198,6 +198,27 @@ where
     .await
 }
 
+pub(crate) async fn load_rebuild_plans_to_nearest_available_root_bounded<S>(
+    store: &S,
+    commit_id: &str,
+    force_head: bool,
+    max_members: usize,
+    known_commit_ids: &BTreeSet<CommitId>,
+) -> Result<Vec<CommitRootRebuildPlan>, LixError>
+where
+    S: StorageAdapterRead + ?Sized,
+{
+    load_rebuild_plans_to_nearest_available_root_inner(
+        store,
+        commit_id,
+        force_head,
+        RootAvailabilityProof::Addressable,
+        Some(max_members),
+        known_commit_ids,
+    )
+    .await
+}
+
 pub(crate) async fn load_rebuild_plans_to_nearest_available_root_with_proof<S>(
     store: &S,
     commit_id: &str,
@@ -207,11 +228,40 @@ pub(crate) async fn load_rebuild_plans_to_nearest_available_root_with_proof<S>(
 where
     S: StorageAdapterRead + ?Sized,
 {
+    load_rebuild_plans_to_nearest_available_root_inner(
+        store,
+        commit_id,
+        force_head,
+        proof,
+        None,
+        &BTreeSet::new(),
+    )
+    .await
+}
+
+async fn load_rebuild_plans_to_nearest_available_root_inner<S>(
+    store: &S,
+    commit_id: &str,
+    force_head: bool,
+    proof: RootAvailabilityProof,
+    max_members: Option<usize>,
+    known_commit_ids: &BTreeSet<CommitId>,
+) -> Result<Vec<CommitRootRebuildPlan>, LixError>
+where
+    S: StorageAdapterRead + ?Sized,
+{
     let mut plans = Vec::new();
+    let mut loaded_members = 0usize;
     let mut current_commit_id = commit_id.to_string();
     let mut force_current = force_head;
+    let mut physical_alias_source = false;
     let mut seen_commit_ids = HashSet::new();
     loop {
+        let typed_current_commit_id =
+            CommitId::parse_lix(&current_commit_id, "tracked-state rebuild commit id")?;
+        if known_commit_ids.contains(&typed_current_commit_id) {
+            break;
+        }
         if !seen_commit_ids.insert(current_commit_id.clone()) {
             return Err(LixError::new(
                 LixError::CODE_INTERNAL_ERROR,
@@ -225,15 +275,27 @@ where
             let _phase = crate::storage_bench::PlanLoadPhaseScope::enter(
                 crate::storage_bench::PlanLoadPhase::AvailProbe,
             );
-            let available = load_available_root(store, &current_commit_id, proof).await?;
+            let available =
+                load_available_root(store, &current_commit_id, proof, physical_alias_source)
+                    .await?;
             #[cfg(feature = "storage-benches")]
             crate::storage_bench::record_root_replay_available_root_probe(available.is_some());
             if available.is_some() {
                 break;
             }
         }
-        let plan = load_commit_root_rebuild_plan(store, &current_commit_id).await?;
-        let parent_commit_id = plan.parent_commit_id;
+        let plan = load_commit_root_rebuild_plan(
+            store,
+            &current_commit_id,
+            physical_alias_source,
+            max_members.map(|limit| limit.saturating_sub(loaded_members)),
+        )
+        .await?;
+        loaded_members = loaded_members.saturating_add(plan.deltas.len());
+        let parent_commit_id = plan
+            .complete_state_source_commit_id
+            .or(plan.parent_commit_id);
+        physical_alias_source = plan.complete_state_source_commit_id.is_some();
         plans.push(plan);
         let Some(parent_commit_id) = parent_commit_id else {
             break;
@@ -253,9 +315,10 @@ where
 /// repair, so the manifest — not a replay of the changelog — is what makes a
 /// root canonical. Availability therefore has exactly two obligations:
 ///
-/// 1. the root pointer is live (`load_snapshot_commit_root` also proves the
-///    commit itself exists in the changelog, so an orphaned manifest cannot
-///    authorize a resume), and
+/// 1. the root pointer is live (`load_snapshot_commit_root` also proves an
+///    ordinary commit still exists in the changelog; a complete-state alias
+///    may instead authorize its physically retained source manifest after the
+///    source's semantic projection has been collected), and
 /// 2. the content-addressed chunk closure it names is physically addressable,
 ///    so a damaged root is never resumed from and explicit repair stays total.
 ///
@@ -274,11 +337,20 @@ async fn load_available_root<S>(
     store: &S,
     commit_id: &str,
     proof: RootAvailabilityProof,
+    physical_alias_source: bool,
 ) -> Result<Option<TrackedStateRootId>, LixError>
 where
     S: StorageAdapterRead + ?Sized,
 {
-    let Some(metadata) = storage::load_snapshot_commit_root(store, commit_id).await? else {
+    let metadata = if physical_alias_source {
+        let commit_id = CommitId::parse_lix(commit_id, "physical checkpoint source commit id")?;
+        storage::load_commit_state_manifest(store, commit_id)
+            .await?
+            .and_then(|manifest| manifest.snapshot_root.map(|root| *root))
+    } else {
+        storage::load_snapshot_commit_root(store, commit_id).await?
+    };
+    let Some(metadata) = metadata else {
         return Ok(None);
     };
     let readable = {
@@ -325,48 +397,76 @@ where
 pub(crate) struct CommitRootRebuildPlan {
     pub(crate) commit_id: CommitId,
     pub(crate) parent_commit_id: Option<CommitId>,
+    pub(crate) complete_state_source_commit_id: Option<CommitId>,
     pub(crate) deltas: Vec<CommitRootRebuildDelta>,
 }
 
 async fn load_commit_root_rebuild_plan<S>(
     store: &S,
     commit_id: &str,
+    allow_missing_commit: bool,
+    max_members: Option<usize>,
 ) -> Result<CommitRootRebuildPlan, LixError>
 where
     S: StorageAdapterRead + ?Sized,
 {
+    let typed_commit_id = CommitId::parse_lix(commit_id, "commit-root rebuild commit_id")?;
     let commit = {
         #[cfg(feature = "storage-benches")]
         let _phase = crate::storage_bench::PlanLoadPhaseScope::enter(
             crate::storage_bench::PlanLoadPhase::CommitRecord,
         );
         let mut reader = ChangelogContext::new().reader(store);
-        let commit_ids = [CommitId::parse_lix(
-            commit_id,
-            "commit-root rebuild commit_id",
-        )?];
+        let commit_ids = [typed_commit_id];
         let batch = reader
             .load_commits(CommitLoadRequest {
                 commit_ids: &commit_ids,
             })
             .await?;
-        batch
-            .into_iter()
-            .next()
-            .and_then(|(_, value)| value)
-            .ok_or_else(|| {
-                LixError::new(
-                    LixError::CODE_INTERNAL_ERROR,
-                    format!(
-                        "cannot rebuild tracked_state commit_root for unknown commit '{commit_id}'"
-                    ),
-                )
-            })?
+        batch.into_iter().next().and_then(|(_, value)| value)
     };
-    // Commit roots contain only identity/index facts. Avoid hydrating JSON
-    // sidecars while rebuilding them; the packed delta index already carries
-    // deletion, owner ids, and original timestamps.
-    let members = storage::scan_commit_delta_members(store, commit.commit_id).await?;
+    if commit.is_none() && !allow_missing_commit {
+        return Err(LixError::new(
+            LixError::CODE_INTERNAL_ERROR,
+            format!("cannot rebuild tracked_state commit_root for unknown commit '{commit_id}'"),
+        ));
+    }
+    let manifest = storage::load_commit_state_manifest(store, typed_commit_id)
+        .await?
+        .ok_or_else(|| {
+            LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                format!(
+                    "cannot rebuild tracked_state root for commit '{}' without its commit-state manifest",
+                    typed_commit_id
+                ),
+            )
+        })?;
+    let complete_state_source_commit_id = manifest
+        .snapshot_root
+        .as_ref()
+        .filter(|root| root.complete_state_fence)
+        .and_then(|root| root.parent_roots.first())
+        .map(|source| source.commit_id);
+    if complete_state_source_commit_id.is_none()
+        && max_members.is_some_and(|limit| manifest.mutations.member_count as usize > limit)
+    {
+        return Err(LixError::new(
+            "LIX_ERROR_MIGRATION_LIMIT_EXCEEDED",
+            format!(
+                "commit-root migration replay exceeds configured change bound before hydration: commit '{}' has {} members",
+                typed_commit_id, manifest.mutations.member_count
+            ),
+        ));
+    }
+    // Complete-state aliases rebuild by sharing their source root. Ordinary
+    // roots contain only identity/index facts, so avoid hydrating JSON
+    // sidecars while rebuilding them.
+    let members = if complete_state_source_commit_id.is_some() {
+        Vec::new()
+    } else {
+        storage::scan_commit_delta_members(store, typed_commit_id).await?
+    };
     #[cfg(feature = "root-replay-trace")]
     let member_bytes = members
         .iter()
@@ -397,8 +497,19 @@ where
         .collect();
 
     Ok(CommitRootRebuildPlan {
-        commit_id: commit.commit_id,
-        parent_commit_id: first_parent_commit_id(&commit),
+        commit_id: typed_commit_id,
+        parent_commit_id: commit
+            .as_ref()
+            .and_then(first_parent_commit_id)
+            .or_else(|| {
+                manifest
+                    .snapshot_root
+                    .as_ref()
+                    .filter(|root| !root.complete_state_fence)
+                    .and_then(|root| root.parent_roots.first())
+                    .map(|parent| parent.commit_id)
+            }),
+        complete_state_source_commit_id,
         deltas,
     })
 }
@@ -410,6 +521,11 @@ pub(crate) async fn stage_rebuild_plan_with_writer<S>(
 where
     S: StorageAdapterRead + ?Sized,
 {
+    if let Some(source_commit_id) = plan.complete_state_source_commit_id {
+        return writer
+            .stage_complete_state_alias(plan.commit_id, source_commit_id)
+            .await;
+    }
     let deltas = plan
         .deltas
         .iter()
@@ -665,6 +781,7 @@ mod tests {
         CommitRootRebuildPlan {
             commit_id: CommitId::for_test_label(commit),
             parent_commit_id: parent.map(CommitId::for_test_label),
+            complete_state_source_commit_id: None,
             deltas,
         }
     }

--- a/packages/lix/src/tracked_state/context.rs
+++ b/packages/lix/src/tracked_state/context.rs
@@ -1065,6 +1065,32 @@ impl DiffCommitRootValidationCache {
     }
 }
 
+fn collection_generation_cascade_winners(
+    winners: &HashMap<TrackedStateIdentity, ChangeId>,
+    row_map: &HashMap<TrackedStateIdentity, &TrackedStateIndexValue>,
+) -> Result<BTreeMap<(String, Option<String>), ChangeId>, LixError> {
+    let mut cascades = BTreeMap::new();
+    for (identity, change_id) in winners {
+        if identity.schema_key != crate::collection_generation::COLLECTION_GENERATION_SCHEMA_KEY {
+            continue;
+        }
+        let Some(value) = row_map.get(identity) else {
+            continue;
+        };
+        if value.deleted || value.change_id != *change_id {
+            continue;
+        }
+        let scope = crate::collection_generation::collection_scope_from_row_pk(&identity.row_pk)?;
+        if cascades.insert(scope.clone(), *change_id).is_some() {
+            return Err(LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                format!("commit contains duplicate collection-generation scope {scope:?}"),
+            ));
+        }
+    }
+    Ok(cascades)
+}
+
 impl<S> TrackedStateStoreReader<S>
 where
     S: StorageAdapterRead,
@@ -1504,6 +1530,76 @@ where
         )
     }
 
+    /// Removes physical tombstones synthesized into persistent roots for a
+    /// collection-generation delete. The authenticated marker is the logical
+    /// commit member; exposing every retired predecessor would both expand the
+    /// commit and require payloads that intentionally do not exist.
+    pub(crate) async fn suppress_collection_generation_cascade_tombstones(
+        &mut self,
+        batch: &mut TrackedStateTreeDiffBatch,
+    ) -> Result<(), LixError> {
+        use crate::collection_generation::{
+            COLLECTION_GENERATION_SCHEMA_KEY, CollectionScopeRef, collection_scope_key,
+        };
+
+        let mut scopes = BTreeMap::<
+            (CommitId, String, Option<String>),
+            (TrackedStateKey, Vec<(usize, ChangeId)>),
+        >::new();
+        for (ordinal, key, _, after) in batch.rows() {
+            let Some(after) = after.filter(|after| after.deleted) else {
+                continue;
+            };
+            if key.schema_key == COLLECTION_GENERATION_SCHEMA_KEY {
+                continue;
+            }
+            let scope = (key.schema_key.to_owned(), key.file_id.map(str::to_owned));
+            let marker_key = TrackedStateKey {
+                schema_key: COLLECTION_GENERATION_SCHEMA_KEY.to_owned(),
+                file_id: None,
+                row_pk: RowPk::single(collection_scope_key(CollectionScopeRef {
+                    schema_key: &scope.0,
+                    file_id: scope.1.as_deref(),
+                })),
+            };
+            scopes
+                .entry((after.commit_id, scope.0, scope.1))
+                .or_insert_with(|| (marker_key, Vec::new()))
+                .1
+                .push((ordinal, after.change_id));
+        }
+        if scopes.is_empty() {
+            return Ok(());
+        }
+
+        let mut by_commit =
+            BTreeMap::<CommitId, Vec<(TrackedStateKey, Vec<(usize, ChangeId)>)>>::new();
+        for ((commit_id, _, _), request) in scopes {
+            by_commit.entry(commit_id).or_default().push(request);
+        }
+        let mut remove = vec![false; batch.len()];
+        for (commit_id, requests) in by_commit {
+            let keys = requests
+                .iter()
+                .map(|(key, _)| key.clone())
+                .collect::<Vec<_>>();
+            let records =
+                storage::load_commit_delta_change_records(&self.store, commit_id, &keys).await?;
+            for ((_, candidates), record) in requests.into_iter().zip(records) {
+                let Some(record) = record else {
+                    continue;
+                };
+                for (ordinal, change_id) in candidates {
+                    if record.change_id == change_id && record.snapshot.is_some() {
+                        remove[ordinal] = true;
+                    }
+                }
+            }
+        }
+        batch.remove_rows(&remove);
+        Ok(())
+    }
+
     pub(crate) async fn load_tree_diff_comparison_payloads(
         &mut self,
         batch: &TrackedStateTreeDiffBatch,
@@ -1748,6 +1844,16 @@ where
                     cache,
                 )
                 .await?;
+                if metadata.complete_state_fence {
+                    self.validate_diff_row_created_at(
+                        row,
+                        &key,
+                        &current_commit_id,
+                        change_created_at,
+                    )
+                    .await?;
+                    return Ok(());
+                }
                 let Some(parent) = metadata.parent_roots.first() else {
                     if !metadata.complete_state_fence {
                         return Err(LixError::unknown(format!(
@@ -1836,6 +1942,17 @@ where
         metadata: &TrackedStateCommitRoot,
         cache: &mut DiffCommitRootValidationCache,
     ) -> Result<(), LixError> {
+        if metadata.complete_state_fence {
+            return match metadata.parent_roots.as_slice() {
+                [] => Ok(()),
+                [source] if source.commit_id != commit_id && source.root_id == metadata.root_id => {
+                    Ok(())
+                }
+                _ => Err(LixError::unknown(format!(
+                    "tracked-state complete-state fence for commit '{commit_id}' has invalid physical source ancestry"
+                ))),
+            };
+        }
         if metadata.parent_roots.len() > 1 {
             return Err(LixError::unknown(format!(
                 "tracked-state commit-root metadata for commit '{commit_id}' has more than one first-parent root"
@@ -2303,24 +2420,8 @@ where
         let file_delete_cascades = self
             .load_file_delete_cascade_winners(&winners, &row_map)
             .await?;
-        let mut collection_generation_cascades = HashMap::new();
-        for (identity, change_id) in &winners {
-            if identity.schema_key != crate::collection_generation::COLLECTION_GENERATION_SCHEMA_KEY
-            {
-                continue;
-            }
-            let scope =
-                crate::collection_generation::collection_scope_from_row_pk(&identity.row_pk)?;
-            if collection_generation_cascades
-                .insert(scope, *change_id)
-                .is_some()
-            {
-                return Err(LixError::new(
-                    LixError::CODE_INTERNAL_ERROR,
-                    "commit contains duplicate collection-generation cascade scopes",
-                ));
-            }
-        }
+        let collection_generation_cascades =
+            collection_generation_cascade_winners(&winners, &row_map)?;
         for (identity, change_id) in &winners {
             if !tracked_state_identity_matches_tree_request(identity, request) {
                 continue;
@@ -2370,10 +2471,13 @@ where
             if !parent_value.deleted
                 && let Some(cascade_change_id) = collection_generation_cascades
                     .get(&(parent_key.schema_key.clone(), parent_key.file_id.clone()))
-                && value.deleted
-                && &value.change_id == cascade_change_id
             {
-                continue;
+                if value.deleted && &value.change_id == cascade_change_id {
+                    continue;
+                }
+                return Err(LixError::unknown(format!(
+                    "tracked-state commit-root for commit '{commit_id}' does not apply collection-generation cascade change '{cascade_change_id}' to inherited identity {identity:?}"
+                )));
             }
             if *value != &parent_value {
                 return Err(LixError::unknown(format!(
@@ -2547,6 +2651,30 @@ where
                         *record = fallbacks
                             .next()
                             .expect("one fallback was loaded per missing file-scoped tombstone");
+                    }
+                }
+            }
+            let collection_fallback_rows = commit_rows
+                .iter()
+                .zip(&loaded)
+                .filter_map(|(row, record)| {
+                    (record.is_none() && row.deleted)
+                        .then(|| collection_cascade_payload_key(row.schema_key(), row.file_id()))
+                })
+                .collect::<Vec<_>>();
+            if !collection_fallback_rows.is_empty() {
+                let fallbacks = storage::load_commit_delta_change_records(
+                    &self.store,
+                    commit_id,
+                    &collection_fallback_rows,
+                )
+                .await?;
+                let mut fallbacks = fallbacks.into_iter();
+                for (row, record) in commit_rows.iter().zip(&mut loaded) {
+                    if record.is_none() && row.deleted {
+                        *record = fallbacks
+                            .next()
+                            .expect("one fallback was loaded per missing collection tombstone");
                     }
                 }
             }
@@ -4197,6 +4325,52 @@ where
         .await
     }
 
+    /// Publishes a complete-state fence by sharing an already materialized
+    /// persistent tree root. Only the small root descriptor is new; no state
+    /// rows or tree chunks are visited or copied.
+    pub(crate) async fn stage_complete_state_alias(
+        &mut self,
+        commit_id: CommitId,
+        source_commit_id: CommitId,
+    ) -> Result<TrackedStateWriteReport, LixError> {
+        let source_key = source_commit_id.to_string();
+        let source = match self.staged_roots.get(&source_key) {
+            Some(root) => root.clone(),
+            None => storage::load_snapshot_commit_root(self.store, &source_key)
+                .await?
+                .ok_or_else(|| {
+                    LixError::new(
+                        LixError::CODE_INTERNAL_ERROR,
+                        format!(
+                            "checkpoint source '{source_commit_id}' has no materialized tracked-state root"
+                        ),
+                    )
+                })?,
+        };
+        let root_id = source.root_id;
+        self.staged_roots.insert(
+            commit_id.to_string(),
+            TrackedStateCommitRoot {
+                commit_id,
+                root_id: root_id.clone(),
+                parent_roots: vec![TrackedStateCommitRootParent {
+                    commit_id: source_commit_id,
+                    root_id: root_id.clone(),
+                }],
+                changed_key_count: source.row_count_estimate,
+                row_count_estimate: source.row_count_estimate,
+                tree_height: source.tree_height,
+                complete_state_fence: true,
+            },
+        );
+        Ok(TrackedStateWriteReport {
+            commit_id,
+            root_id,
+            changed_rows: 0,
+            primary_chunk_puts: 0,
+        })
+    }
+
     pub(crate) async fn stage_commit_root_with_absence_guards<'a, I>(
         &mut self,
         commit_id: &str,
@@ -4960,9 +5134,19 @@ fn validate_diff_row_against_changelog(
             row.change_id
         )));
     };
-    tracked_state_winner_identity_for_diff_row(row, change)?;
-    let change_deleted = change.snapshot.is_none();
-    if row.deleted != change_deleted {
+    let winner = tracked_state_winner_kind_for_diff_parts(
+        row.schema_key(),
+        row.file_id(),
+        row.row_pk(),
+        row.deleted,
+        row.change_id,
+        change,
+    )?;
+    if !matches!(
+        winner,
+        TrackedStateRowWinnerKind::CollectionGenerationCascade
+    ) && row.deleted != change.snapshot.is_none()
+    {
         return Err(LixError::unknown(format!(
             "tracked-state diff row for change '{}' deleted flag does not match changelog snapshot",
             row.change_id
@@ -5037,7 +5221,6 @@ fn collection_cascade_payload_key(schema_key: &str, file_id: Option<&str>) -> Tr
     use crate::collection_generation::{
         COLLECTION_GENERATION_SCHEMA_KEY, CollectionScopeRef, collection_scope_key,
     };
-
     TrackedStateKey {
         schema_key: COLLECTION_GENERATION_SCHEMA_KEY.to_owned(),
         file_id: None,

--- a/packages/lix/src/tracked_state/diff.rs
+++ b/packages/lix/src/tracked_state/diff.rs
@@ -356,8 +356,11 @@ where
     S: crate::storage_adapter::StorageAdapterRead,
 {
     let scan_request = scan_request_for_diff(request);
-    let tree_diff = reader
+    let mut tree_diff = reader
         .diff_semantic_tree_entries_at_commits(left_commit_id, right_commit_id, &scan_request)
+        .await?;
+    reader
+        .suppress_collection_generation_cascade_tombstones(&mut tree_diff)
         .await?;
 
     // Validate only rows exposed by the hash-guided tree diff. Whole-root
@@ -584,6 +587,100 @@ impl TrackedStateTreeDiffBatch {
         )
     }
 
+    pub(crate) fn rows(
+        &self,
+    ) -> impl Iterator<
+        Item = (
+            usize,
+            TrackedStateKeyRef<'_>,
+            Option<&TrackedStateIndexValue>,
+            Option<&TrackedStateIndexValue>,
+        ),
+    > {
+        let identities = self.identities.as_deref();
+        self.before
+            .iter()
+            .zip(&self.after)
+            .enumerate()
+            .map(move |(ordinal, (before, after))| {
+                let identities = identities.expect("non-empty tree diff columns retain identities");
+                let ordinal_u32 =
+                    u32::try_from(ordinal).expect("tree diff batch row count is bounded to u32");
+                (
+                    ordinal,
+                    TrackedStateKeyRef {
+                        schema_key: identities.schema_key(ordinal_u32),
+                        file_id: identities.file_id(ordinal_u32),
+                        row_pk: identities.row_pk(ordinal_u32),
+                    },
+                    before.as_ref(),
+                    after.as_ref(),
+                )
+            })
+    }
+
+    pub(crate) fn remove_rows(&mut self, remove: &[bool]) {
+        debug_assert_eq!(remove.len(), self.len());
+        if !remove.iter().any(|remove| *remove) {
+            return;
+        }
+        let Some(identities) = self.identities.as_deref() else {
+            return;
+        };
+        let mut keys = Vec::with_capacity(self.len());
+        let mut before = Vec::with_capacity(self.len());
+        let mut after = Vec::with_capacity(self.len());
+        for (ordinal, ((before_value, after_value), remove)) in
+            self.before.iter().zip(&self.after).zip(remove).enumerate()
+        {
+            if *remove {
+                continue;
+            }
+            let ordinal =
+                u32::try_from(ordinal).expect("tree diff batch row count is bounded to u32");
+            keys.push(TrackedStateKey {
+                schema_key: identities.schema_key(ordinal).to_owned(),
+                file_id: identities.file_id(ordinal).map(str::to_owned),
+                row_pk: identities.row_pk(ordinal).clone(),
+            });
+            before.push(before_value.clone());
+            after.push(after_value.clone());
+        }
+        if keys.is_empty() {
+            *self = Self::default();
+        } else {
+            self.identities = Some(TrackedStateDiffIdentityBatch::from_keys(keys));
+            self.before = before;
+            self.after = after;
+        }
+    }
+
+    /// Rows that represent a logical state transition at a complete-state
+    /// checkpoint fence.
+    ///
+    /// The immutable tree retains physical tombstones. An absent row and a
+    /// tombstone are both logically deleted, so a newly written tombstone for
+    /// an identity that was already absent must not become checkpoint history.
+    pub(crate) fn checkpoint_delta_rows(
+        &self,
+    ) -> impl Iterator<Item = TrackedStateTreeDiffRowRef<'_>> {
+        let identities = self.identities.as_deref();
+        self.before.iter().zip(&self.after).enumerate().filter_map(
+            move |(ordinal, (before, after))| {
+                let after = after.as_ref()?;
+                if after.deleted && before.as_ref().is_none_or(|before| before.deleted) {
+                    return None;
+                }
+                Some(TrackedStateTreeDiffRowRef {
+                    identities: identities.expect("non-empty tree diff columns retain identities"),
+                    ordinal: u32::try_from(ordinal)
+                        .expect("tree diff batch row count is bounded to u32"),
+                    value: after,
+                })
+            },
+        )
+    }
+
     pub(crate) fn comparison_rows(&self) -> Vec<TrackedStateTreeDiffRowRef<'_>> {
         let Some(identities) = self.identities.as_deref() else {
             return Vec::new();
@@ -677,6 +774,10 @@ impl TrackedStateTreeDiffBatch {
 }
 
 impl<'a> TrackedStateTreeDiffRowRef<'a> {
+    pub(crate) fn value(self) -> &'a TrackedStateIndexValue {
+        self.value
+    }
+
     pub(crate) fn schema_key(self) -> &'a str {
         self.identities.schema_key(self.ordinal)
     }

--- a/packages/lix/src/tracked_state/mod.rs
+++ b/packages/lix/src/tracked_state/mod.rs
@@ -23,7 +23,8 @@ mod types;
 
 pub(crate) use codec::{encode_key_ref, encode_single_string_key_ref_into};
 pub(crate) use commit_root_rebuild::{
-    load_rebuild_plans_to_nearest_available_root, stage_rebuild_plan_with_writer,
+    load_rebuild_plans_to_nearest_available_root,
+    load_rebuild_plans_to_nearest_available_root_bounded, stage_rebuild_plan_with_writer,
     try_stage_collapsed_rebuild_plans_with_writer,
 };
 #[cfg(test)]
@@ -79,13 +80,14 @@ pub(crate) use storage::{
     CommitDeltaReplacementScope, EnvelopeCertifiedNativeProjectionBatch,
     EnvelopeCertifiedNativeProjectionSegment, ExclusiveRowSnapshotBatch,
     OrderedAddressableCommitDeltaStage, PublishedCommitStateTopology, StagedCommitStateManifest,
-    commit_delta_contains_schema, commit_delta_member_scopes,
-    commit_history_is_deferred, direct_change_locator, load_change_record_by_id,
-    load_commit_delta_change_records,
-    load_commit_delta_members_with_payloads, load_commit_delta_members_with_payloads_for_schemas,
-    load_commit_delta_replay_metadata, load_commit_delta_selection_certificate,
-    load_commit_mutation_directory_roots, load_commit_state_manifest, load_commit_state_manifests,
-    load_exclusive_row_snapshots, load_local_selected_change_owner_commit_ids,
+    commit_delta_contains_schema, commit_delta_member_scopes, commit_history_is_deferred,
+    complete_state_fence_change_owner_commit_ids, direct_change_locator,
+    encode_commit_state_manifest_replacement_for_migration, load_change_record_by_id,
+    load_commit_delta_change_records, load_commit_delta_members_with_payloads,
+    load_commit_delta_members_with_payloads_for_schemas, load_commit_delta_replay_metadata,
+    load_commit_delta_selection_certificate, load_commit_mutation_directory_roots,
+    load_commit_state_manifest, load_commit_state_manifests, load_exclusive_row_snapshots,
+    load_local_commit_delta_members_with_payloads, load_local_selected_change_owner_commit_ids,
     load_owned_commit_delta_entries, load_owned_commit_delta_entries_one_ordered_ref,
     load_published_commit_state_topology, load_retained_commit_snapshots_for_schemas,
     scan_change_records_from_commit_deltas, scan_commit_delta_inventory, scan_commit_delta_values,
@@ -94,6 +96,7 @@ pub(crate) use storage::{
     stage_certified_commit_state_manifest_with_handle, stage_change_locators,
     stage_commit_deltas_for_commit_state, stage_commit_history_available,
     stage_commit_history_deferred, stage_commit_state_manifest_with_handle,
+    stage_current_state_scoped_ranges_from_complete_state_source,
     stage_current_state_scoped_ranges_from_published_parent,
     stage_current_state_scoped_ranges_from_published_topology_parent,
     stage_current_state_scoped_ranges_from_staged_parent,
@@ -104,7 +107,7 @@ pub(crate) use storage::{
 };
 pub(crate) use storage::{
     RetainedPhysicalState, load_native_current_state_part_owners,
-    stage_retire_commit_physical_state,
+    stage_retire_commit_physical_state, stage_retire_commit_physical_state_bounded,
 };
 // Manufacturing a repository swept by the code that shipped before the
 // history-retention fix is the only caller: `session::gc` needs to delete one
@@ -142,10 +145,9 @@ pub(crate) use types::{COMMIT_STATE_MAX_REPLAY_BYTES, COMMIT_STATE_MAX_REPLAY_DE
 pub(crate) use types::{
     ColumnarMutationPartSet, CommitDeltaLifecycleSummary, CommitStateManifest,
     CommitStateMutationInventory, CommitStateReplayDebt, CommitStateTouchedScopeFilter,
-    MaterializedTrackedStateRow,
-    RowPkRangeBound, TrackedStateBaseCoordinate, TrackedStateCommitDeltaRef,
-    TrackedStateCommitRoot, TrackedStateCommitRootParent, TrackedStateDeltaRef,
-    TrackedStateFilter, TrackedStateIndexValue, TrackedStateReadColumns,
+    MaterializedTrackedStateRow, RowPkRangeBound, TrackedStateBaseCoordinate,
+    TrackedStateCommitDeltaRef, TrackedStateCommitRoot, TrackedStateCommitRootParent,
+    TrackedStateDeltaRef, TrackedStateFilter, TrackedStateIndexValue, TrackedStateReadColumns,
     TrackedStateRootMutationRef, TrackedStateScanRequest, TrackedStateSingleStringReplacementRef,
     row_pk_satisfies_bounds,
 };

--- a/packages/lix/src/tracked_state/storage.rs
+++ b/packages/lix/src/tracked_state/storage.rs
@@ -31,10 +31,9 @@ use crate::storage_adapter::{
 use crate::tracked_state::codec::{
     DecodedLeafNodeRef, DecodedNodeRef, EncodedLeafEntry, EncodedLeafEntryRef, PendingChunkBatch,
     TrackedStateKeyBatchBuilder, TrackedStateMutationBatchBuilder, decode_key, decode_key_shared,
-    decode_node_ref, decode_row_pk_shared_with_trusted_prefix,
-    decode_value, encode_key_ref, encode_key_ref_into, encode_leaf_node_refs,
-    encode_schema_file_prefix, encode_schema_key_prefix, encode_single_string_key_ref_into,
-    encode_value_ref,
+    decode_node_ref, decode_row_pk_shared_with_trusted_prefix, decode_value, encode_key_ref,
+    encode_key_ref_into, encode_leaf_node_refs, encode_schema_file_prefix,
+    encode_schema_key_prefix, encode_single_string_key_ref_into, encode_value_ref,
 };
 use crate::tracked_state::types::{
     ColumnarPageSource, CommitStateManifest, CommitStateMutationInventory, CommitStateMutationPart,
@@ -3397,6 +3396,38 @@ impl DecodedCommitDeltaBatchBuilder {
         Ok(())
     }
 
+    fn push_owned_row(
+        &mut self,
+        key: TrackedStateKey,
+        value: TrackedStateIndexValue,
+    ) -> Result<(), LixError> {
+        let schema_key_ordinal = self.schema_keys.intern(SharedStr::from(key.schema_key))?;
+        let file_id_ordinal = key.file_id.map_or(Ok(u32::MAX), |file_id| {
+            self.file_ids.intern(SharedStr::from(file_id))
+        })?;
+        let start = self.columnar_keys.len();
+        encode_key_ref_into(
+            &mut self.columnar_keys,
+            TrackedStateKeyRef {
+                schema_key: self.schema_keys.values[schema_key_ordinal as usize].as_str(),
+                file_id: (file_id_ordinal != u32::MAX)
+                    .then(|| self.file_ids.values[file_id_ordinal as usize].as_str()),
+                row_pk: &key.row_pk,
+            },
+        );
+        let columnar_key = BufferRange::new(start, self.columnar_keys.len() - start);
+        self.rows.push(DecodedCommitDeltaRow {
+            arena_ordinal: u32::MAX,
+            entry_ordinal: 0,
+            columnar_key: Some(columnar_key),
+            schema_key_ordinal,
+            file_id_ordinal,
+            row_pk: key.row_pk,
+        });
+        self.values.push(value);
+        Ok(())
+    }
+
     fn finish(self) -> DecodedCommitDeltaBatch {
         DecodedCommitDeltaBatch {
             arenas: self.arenas,
@@ -3542,6 +3573,15 @@ impl PublishedCommitStateTopology {
         self.header.current_state_scoped_ranges.as_deref()
     }
 
+    pub(crate) fn complete_state_source_commit_id(&self) -> Option<CommitId> {
+        self.header
+            .snapshot_root
+            .as_ref()
+            .filter(|root| root.complete_state_fence)
+            .and_then(|root| root.parent_roots.first())
+            .map(|source| source.commit_id)
+    }
+
     fn topology_ref(&self) -> super::scoped_current_state::CommitStateTopologyRef<'_> {
         super::scoped_current_state::CommitStateTopologyRef {
             commit_id: self.header.commit_id,
@@ -3647,6 +3687,42 @@ pub(crate) async fn stage_current_state_scoped_ranges_from_topology(
         &parents,
         selected_source,
         serving_base,
+        commit_id,
+        account_id,
+        inventory,
+    )
+    .await
+}
+
+/// Attests an unchanged current-state directory against a complete-state
+/// checkpoint's physical source while keeping semantic graph parents separate.
+pub(crate) async fn stage_current_state_scoped_ranges_from_complete_state_source(
+    store: &(impl StorageAdapterRead + ?Sized),
+    writes: &mut StorageWriteSet,
+    graph_parents: &[CertifiedCommitStateTopologyParent<'_>],
+    source: CertifiedCommitStateTopologyParent<'_>,
+    commit_id: CommitId,
+    account_id: &str,
+    inventory: &CommitStateMutationInventory,
+) -> Result<super::scoped_current_state::CertifiedCommitStatePhysicalPublication, LixError> {
+    let mut parents = graph_parents
+        .iter()
+        .copied()
+        .map(|parent| parent.topology(writes))
+        .collect::<Result<Vec<_>, _>>()?;
+    let source = source.topology(writes)?;
+    if parents
+        .iter()
+        .all(|parent| parent.commit_id != source.commit_id)
+    {
+        parents.push(source);
+    }
+    super::scoped_current_state::stage_current_state_scoped_ranges_from_topology_refs(
+        store,
+        writes,
+        &parents,
+        None,
+        Some(source),
         commit_id,
         account_id,
         inventory,
@@ -9078,6 +9154,33 @@ pub(crate) async fn load_commit_delta_members_with_payloads(
     )
 }
 
+/// Loads only the mutations physically authored by one commit, without
+/// expanding a complete-state checkpoint fence into its logical net diff.
+/// Sync uses this together with an authenticated state alias so a checkpoint
+/// remains a bounded wire item.
+pub(crate) async fn load_local_commit_delta_members_with_payloads(
+    store: &(impl StorageAdapterRead + ?Sized),
+    commit_id: CommitId,
+) -> Result<Vec<CommitDeltaMember>, LixError> {
+    let Some(state) = load_point_replay_commit_state(store, commit_id).await? else {
+        if commit_history_is_deferred(store, commit_id).await? {
+            return Err(sync_history_required(commit_id));
+        }
+        return Ok(Vec::new());
+    };
+    let (local, _) = load_authenticated_local_commit_delta_members_for_schemas(
+        store,
+        &state,
+        &[],
+        &[],
+        usize::MAX,
+        true,
+    )
+    .await?
+    .expect("unbounded local commit-delta scan cannot exceed its segment limit");
+    Ok(local)
+}
+
 /// Loads tracked members and payloads for only the requested schemas.
 ///
 /// Segment bounds route around unrelated schema ranges before payload-sidecar
@@ -9090,6 +9193,109 @@ pub(crate) async fn load_commit_delta_members_with_payloads_for_schemas(
     file_ids: &[String],
     max_segment_count: usize,
 ) -> Result<Option<Vec<CommitDeltaMember>>, LixError> {
+    if let Some(mut diff) =
+        complete_state_fence_tree_diff(store, commit_id, schema_keys, false).await?
+    {
+        // Collection-generation deletes synthesize physical tombstones for
+        // every retired row, but only the generation marker is a logical
+        // commit member with a payload. Keep checkpoint wire/history deltas
+        // aligned with the ordinary tree-diff path by suppressing those
+        // derived tombstones before owner hydration.
+        let mut reader = crate::tracked_state::TrackedStateContext::new().reader(store);
+        reader
+            .suppress_collection_generation_cascade_tombstones(&mut diff)
+            .await?;
+        if max_segment_count == 0 && diff.len() != 0 {
+            return Ok(None);
+        }
+        let rows = diff
+            .checkpoint_delta_rows()
+            .filter(|row| {
+                file_ids.is_empty()
+                    || row
+                        .file_id()
+                        .is_some_and(|file_id| file_ids.iter().any(|filter| filter == file_id))
+            })
+            .map(|row| {
+                (
+                    TrackedStateKey {
+                        schema_key: row.schema_key().to_owned(),
+                        file_id: row.file_id().map(str::to_owned),
+                        row_pk: row.row_pk().clone(),
+                    },
+                    row.value().clone(),
+                )
+            })
+            .collect::<Vec<_>>();
+        let owner_requests = rows
+            .iter()
+            .map(|(key, value)| (value.commit_id, key.clone()))
+            .collect::<Vec<_>>();
+        let mut owners = load_owned_commit_delta_entries(store, &owner_requests).await?;
+        // File deletion also synthesizes one tombstone per file-scoped row.
+        // Those rows are physically owned by the descriptor deletion rather
+        // than by an exact commit-delta identity, so route missing deleted
+        // members through the same descriptor authority as ordinary history.
+        let fallback_requests = rows
+            .iter()
+            .zip(&owners)
+            .filter_map(|((key, value), owner)| {
+                (owner.is_none() && value.deleted)
+                    .then(|| key.file_id.as_deref())
+                    .flatten()
+                    .map(|file_id| (value.commit_id, cascade_payload_key(file_id)))
+            })
+            .collect::<Vec<_>>();
+        if !fallback_requests.is_empty() {
+            let mut fallbacks = load_owned_commit_delta_entries(store, &fallback_requests)
+                .await?
+                .into_iter();
+            for ((key, value), owner) in rows.iter().zip(&mut owners) {
+                if owner.is_none() && value.deleted && key.file_id.is_some() {
+                    *owner = fallbacks.next().unwrap_or(None);
+                }
+            }
+        }
+        return rows
+            .into_iter()
+            .zip(owners)
+            .enumerate()
+            .map(|(ordinal, ((key, mut value), owner))| {
+                let owner = owner.ok_or_else(|| {
+                    LixError::new(
+                        LixError::CODE_INTERNAL_ERROR,
+                        format!(
+                            "complete-state checkpoint member '{}' lost physical owner '{}'",
+                            value.change_id, value.commit_id
+                        ),
+                    )
+                })?;
+                if owner.value.change_id != value.change_id {
+                    return Err(LixError::new(
+                        LixError::CODE_INTERNAL_ERROR,
+                        "complete-state checkpoint member disagrees with physical owner",
+                    ));
+                }
+                value.commit_id = commit_id;
+                Ok(CommitDeltaMember {
+                    key,
+                    selected_tombstone: value.deleted,
+                    value,
+                    change: owner.change_record,
+                    segment_index: 0,
+                    ordinal: u32::try_from(ordinal).map_err(|_| {
+                        LixError::new(
+                            LixError::CODE_INTERNAL_ERROR,
+                            "complete-state checkpoint delta exceeds u32 rows",
+                        )
+                    })?,
+                    authored: false,
+                    base_coordinate: None,
+                })
+            })
+            .collect::<Result<Vec<_>, _>>()
+            .map(Some);
+    }
     let Some(state) = load_point_replay_commit_state(store, commit_id).await? else {
         if commit_history_is_deferred(store, commit_id).await? {
             return Err(sync_history_required(commit_id));
@@ -9716,6 +9922,119 @@ fn validate_exclusive_direct_change_id(
         ));
     }
     Ok(())
+}
+
+fn cascade_payload_key(file_id: &str) -> TrackedStateKey {
+    TrackedStateKey {
+        schema_key: "lix_file_descriptor".to_owned(),
+        file_id: Some(file_id.to_owned()),
+        row_pk: RowPk::uuid_from_canonical(file_id).unwrap_or_else(|_| RowPk::single(file_id)),
+    }
+}
+
+async fn complete_state_fence_delta_batch(
+    store: &(impl StorageAdapterRead + ?Sized),
+    commit_id: CommitId,
+    schema_keys: &[String],
+) -> Result<Option<DecodedCommitDeltaBatch>, LixError> {
+    let Some(diff) = complete_state_fence_tree_diff(store, commit_id, schema_keys, false).await?
+    else {
+        return Ok(None);
+    };
+    let mut output = DecodedCommitDeltaBatchBuilder::with_capacity(diff.len(), 0);
+    for row in diff.checkpoint_delta_rows() {
+        let mut value = row.value().clone();
+        value.commit_id = commit_id;
+        output.push_owned_row(
+            TrackedStateKey {
+                schema_key: row.schema_key().to_owned(),
+                file_id: row.file_id().map(str::to_owned),
+                row_pk: row.row_pk().clone(),
+            },
+            value,
+        )?;
+    }
+    Ok(Some(output.finish()))
+}
+
+pub(crate) async fn complete_state_fence_change_owner_commit_ids(
+    store: &(impl StorageAdapterRead + ?Sized),
+    commit_id: CommitId,
+) -> Result<Option<BTreeSet<CommitId>>, LixError> {
+    Ok(complete_state_fence_tree_diff(store, commit_id, &[], true)
+        .await?
+        .map(|diff| {
+            diff.checkpoint_delta_rows()
+                .map(|row| row.commit_id())
+                .collect()
+        }))
+}
+
+async fn complete_state_fence_tree_diff(
+    store: &(impl StorageAdapterRead + ?Sized),
+    commit_id: CommitId,
+    schema_keys: &[String],
+    missing_parent_is_absent: bool,
+) -> Result<Option<super::diff::TrackedStateTreeDiffBatch>, LixError> {
+    let Some(manifest) = load_commit_state_manifest(store, commit_id).await? else {
+        return Ok(None);
+    };
+    let Some(root) = manifest
+        .snapshot_root
+        .as_ref()
+        .filter(|root| root.complete_state_fence)
+    else {
+        return Ok(None);
+    };
+    if root.parent_roots.is_empty() {
+        return Ok(None);
+    }
+    let record = ChangelogContext::new()
+        .reader(store)
+        .load_commits(CommitLoadRequest {
+            commit_ids: &[commit_id],
+        })
+        .await?
+        .into_iter()
+        .next()
+        .and_then(|(_, record)| record)
+        .ok_or_else(|| {
+            LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                format!("complete-state checkpoint '{commit_id}' has no commit record"),
+            )
+        })?;
+    let parent_commit_id = record.parent_commit_ids.first().copied().ok_or_else(|| {
+        LixError::new(
+            LixError::CODE_INTERNAL_ERROR,
+            format!("complete-state checkpoint '{commit_id}' has no prior checkpoint parent"),
+        )
+    })?;
+    let parent = load_snapshot_commit_root(store, &parent_commit_id.to_string()).await?;
+    let Some(parent) = parent else {
+        if missing_parent_is_absent {
+            return Ok(None);
+        }
+        return Err(LixError::new(
+            LixError::CODE_INTERNAL_ERROR,
+            format!(
+                "complete-state checkpoint '{commit_id}' has no materialized parent root '{parent_commit_id}'"
+            ),
+        ));
+    };
+    let diff = super::tree::TrackedStateTree::new()
+        .diff(
+            &store,
+            Some(&parent.root_id),
+            Some(&root.root_id),
+            &TrackedStateTreeScanRequest {
+                schema_keys: schema_keys.to_vec(),
+                include_tombstones: true,
+                ..TrackedStateTreeScanRequest::default()
+            },
+        )
+        .await?;
+    Ok(Some(diff))
 }
 
 /// Resolves the immutable owners of finite selected members in one commit.
@@ -11286,6 +11605,9 @@ pub(crate) async fn scan_commit_delta_values(
     commit_id: CommitId,
     schema_keys: &[String],
 ) -> Result<DecodedCommitDeltaBatch, LixError> {
+    if let Some(batch) = complete_state_fence_delta_batch(store, commit_id, schema_keys).await? {
+        return Ok(batch);
+    }
     let state = {
         #[cfg(feature = "storage-benches")]
         let _phase = crate::storage_bench::PlanLoadPhaseScope::enter(
@@ -12637,7 +12959,8 @@ async fn stage_reclaim_retired_change_locators(
     store: &(impl StorageAdapterRead + ?Sized),
     writes: &mut StorageWriteSet,
     commit_id: CommitId,
-) -> Result<(), LixError> {
+    max_deletes: Option<usize>,
+) -> Result<bool, LixError> {
     let change_ids = scan_commit_delta_members(store, commit_id)
         .await?
         .into_iter()
@@ -12646,7 +12969,7 @@ async fn stage_reclaim_retired_change_locators(
         .into_iter()
         .collect::<Vec<_>>();
     if change_ids.is_empty() {
-        return Ok(());
+        return Ok(true);
     }
     let locator_keys = change_ids
         .iter()
@@ -12664,10 +12987,14 @@ async fn stage_reclaim_retired_change_locators(
             reclaimed.push(change_id.as_uuid().as_bytes().to_vec());
         }
     }
+    let complete = max_deletes.is_none_or(|limit| reclaimed.len() <= limit);
+    if let Some(limit) = max_deletes {
+        reclaimed.truncate(limit);
+    }
     if !reclaimed.is_empty() {
         writes.delete_batch(TRACKED_STATE_CHANGE_LOCATOR_SPACE, reclaimed);
     }
-    Ok(())
+    Ok(complete)
 }
 
 /// Collects the out-of-band JSON payload refs one commit's own packed delta
@@ -12697,6 +13024,159 @@ pub(crate) async fn stage_retire_commit_physical_state(
     commit_id: CommitId,
     retained: RetainedPhysicalState<'_>,
 ) -> Result<(), LixError> {
+    if !stage_retire_commit_physical_state_bounded(store, writes, commit_id, retained, None).await?
+    {
+        return Err(LixError::new(
+            LixError::CODE_INTERNAL_ERROR,
+            "unbounded commit retirement was unexpectedly incomplete",
+        ));
+    }
+    Ok(())
+}
+
+fn retirement_marker_key(commit_id: CommitId) -> StorageKey {
+    let mut bytes = commit_id.as_uuid().as_bytes().to_vec();
+    bytes.push(0xff);
+    StorageKey(Bytes::from(bytes))
+}
+
+fn retirement_intent_key(
+    commit_id: CommitId,
+    space: StorageSpace,
+    target: &StorageKey,
+) -> StorageKey {
+    let mut bytes = Vec::with_capacity(21 + target.0.len());
+    bytes.extend_from_slice(commit_id.as_uuid().as_bytes());
+    bytes.push(0);
+    bytes.extend_from_slice(&space.id.0.to_be_bytes());
+    bytes.extend_from_slice(&target.0);
+    StorageKey(Bytes::from(bytes))
+}
+
+fn decode_retirement_intent(key: &StorageKey) -> Result<(StorageSpace, StorageKey), LixError> {
+    if key.0.len() < 21 || key.0[16] != 0 {
+        return Err(LixError::new(
+            LixError::CODE_INTERNAL_ERROR,
+            "commit-retirement intent key is malformed",
+        ));
+    }
+    let id = StorageSpaceId(u32::from_be_bytes(
+        key.0[17..21]
+            .try_into()
+            .expect("retirement intent space-id width checked"),
+    ));
+    let space = crate::storage_spaces::ALL_STORAGE_SPACES
+        .iter()
+        .copied()
+        .find(|space| space.id == id)
+        .ok_or_else(|| {
+            LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                "commit-retirement intent names an unknown storage space",
+            )
+        })?;
+    Ok((space, StorageKey(key.0.slice(21..))))
+}
+
+async fn load_retirement_cursor_rows(
+    store: &(impl StorageAdapterRead + ?Sized),
+    commit_id: CommitId,
+) -> Result<Vec<StorageKey>, LixError> {
+    let prefix = commit_id.as_uuid().as_bytes();
+    Ok(
+        scan_full_space(store, crate::gc::COMMIT_RETIREMENT_INTENT_SPACE)
+            .await?
+            .into_iter()
+            .filter_map(|(key, _)| key.0.starts_with(prefix).then_some(key))
+            .collect(),
+    )
+}
+
+fn stage_final_retirement_authority(writes: &mut StorageWriteSet, commit_id: CommitId) {
+    writes.delete(
+        TRACKED_STATE_COMMIT_STATE_MANIFEST_SPACE,
+        key(commit_state_manifest_key(commit_id)),
+    );
+    writes.delete(
+        TRACKED_STATE_COMMIT_MUTATION_INVENTORY_SPACE,
+        key(commit_mutation_inventory_key(commit_id)),
+    );
+}
+
+fn retirement_target_is_retained(
+    space: StorageSpace,
+    target: &StorageKey,
+    retained: RetainedPhysicalState<'_>,
+) -> Result<bool, LixError> {
+    let retained_set = if space.id == crate::tracked_state::MUTATION_DIRECTORY_NODE_SPACE.id {
+        Some(retained.mutation_nodes)
+    } else if space.id == crate::tracked_state::SCOPED_RANGE_NODE_SPACE.id {
+        Some(retained.scoped_nodes)
+    } else if space.id == crate::tracked_state::CURRENT_STATE_DATA_PART_SPACE.id {
+        Some(retained.native_parts)
+    } else {
+        None
+    };
+    let Some(retained_set) = retained_set else {
+        return Ok(false);
+    };
+    let digest: [u8; 32] = target.0.as_ref().try_into().map_err(|_| {
+        LixError::new(
+            LixError::CODE_INTERNAL_ERROR,
+            "commit-retirement intent has a malformed content-addressed target",
+        )
+    })?;
+    Ok(retained_set.contains(&digest))
+}
+
+/// Stages a resumable retirement slice. Locator rows are the only
+/// per-authored-row physical plane; drain them first while all immutable delta
+/// segments remain readable. Once they fit, the compact manifest/tree
+/// authority retirement is staged atomically as before.
+pub(crate) async fn stage_retire_commit_physical_state_bounded(
+    store: &(impl StorageAdapterRead + ?Sized),
+    writes: &mut StorageWriteSet,
+    commit_id: CommitId,
+    retained: RetainedPhysicalState<'_>,
+    max_mutations: Option<usize>,
+) -> Result<bool, LixError> {
+    let cursor_rows = load_retirement_cursor_rows(store, commit_id).await?;
+    let marker_key = retirement_marker_key(commit_id);
+    if cursor_rows.iter().any(|key| key == &marker_key) {
+        let intents = cursor_rows
+            .into_iter()
+            .filter(|key| key != &marker_key)
+            .collect::<Vec<_>>();
+        let limit = max_mutations.unwrap_or(usize::MAX);
+        let final_mutations = 3usize;
+        let can_finish = intents
+            .len()
+            .saturating_mul(2)
+            .saturating_add(final_mutations)
+            <= limit;
+        let take = if can_finish {
+            intents.len()
+        } else {
+            (limit / 2).min(intents.len())
+        };
+        for intent_key in intents.iter().take(take) {
+            let (space, target) = decode_retirement_intent(intent_key)?;
+            if !retirement_target_is_retained(space, &target, retained)? {
+                writes.delete(space, target);
+            }
+            writes.delete(
+                crate::gc::COMMIT_RETIREMENT_INTENT_SPACE,
+                intent_key.clone(),
+            );
+        }
+        if !can_finish {
+            return Ok(false);
+        }
+        stage_final_retirement_authority(writes, commit_id);
+        writes.delete(crate::gc::COMMIT_RETIREMENT_INTENT_SPACE, marker_key);
+        return Ok(true);
+    }
+
     let manifest = load_commit_state_manifest(store, commit_id)
         .await?
         .ok_or_else(|| {
@@ -12705,7 +13185,7 @@ pub(crate) async fn stage_retire_commit_physical_state(
                 format!("retired GC root '{commit_id}' has no authenticated manifest"),
             )
         })?;
-    stage_reclaim_retired_change_locators(store, writes, commit_id).await?;
+    let mut compact_retirement = StorageWriteSet::new();
     let retired_root = load_commit_mutation_directory_roots(store, &[commit_id])
         .await?
         .into_iter()
@@ -12714,7 +13194,7 @@ pub(crate) async fn stage_retire_commit_physical_state(
     if let Some(root) = retired_root {
         let nodes = crate::tracked_state::collect_mutation_directory_node_ids(store, &root).await?;
         for node_id in nodes.difference(retained.mutation_nodes) {
-            writes.delete(
+            compact_retirement.delete(
                 crate::tracked_state::MUTATION_DIRECTORY_NODE_SPACE,
                 key(node_id.to_vec()),
             );
@@ -12727,7 +13207,7 @@ pub(crate) async fn stage_retire_commit_physical_state(
         )
         .await?;
         for node_id in reachable.node_ids.difference(retained.scoped_nodes) {
-            writes.delete(
+            compact_retirement.delete(
                 crate::tracked_state::SCOPED_RANGE_NODE_SPACE,
                 key(node_id.to_vec()),
             );
@@ -12738,14 +13218,101 @@ pub(crate) async fn stage_retire_commit_physical_state(
             if let CurrentStatePartSource::NativeDataPart = descriptor.source
                 && !retained.native_parts.contains(&descriptor.content_digest)
             {
-                writes.delete(
+                compact_retirement.delete(
                     crate::tracked_state::CURRENT_STATE_DATA_PART_SPACE,
                     key(descriptor.content_digest.to_vec()),
                 );
             }
         }
     }
-    stage_delete_commit_state_manifest_for_gc(store, writes, commit_id, &manifest).await
+    stage_delete_commit_state_manifest_for_gc(store, &mut compact_retirement, commit_id, &manifest)
+        .await?;
+    let compact_deletes = compact_retirement.into_point_deletes();
+    let compact_mutations = compact_deletes.len();
+    let locator_budget = max_mutations.map(|limit| {
+        if compact_mutations <= limit {
+            limit - compact_mutations
+        } else {
+            // Drain the scalable plane first. A compact remainder larger than
+            // adapter admission is a layout-invariant violation, but existing
+            // locator rows can still make bounded progress before it is
+            // reported on the following pass.
+            limit
+        }
+    });
+    let mut locator_writes = StorageWriteSet::new();
+    let locators_complete = stage_reclaim_retired_change_locators(
+        store,
+        &mut locator_writes,
+        commit_id,
+        locator_budget,
+    )
+    .await?;
+    let locator_mutations =
+        usize::try_from(locator_writes.stats().staged_deletes).unwrap_or(usize::MAX);
+    writes.extend(locator_writes);
+    if !locators_complete {
+        return Ok(false);
+    }
+    let remaining = max_mutations
+        .unwrap_or(usize::MAX)
+        .saturating_sub(locator_mutations);
+    if cursor_rows.is_empty() && compact_mutations <= remaining {
+        for (space, target) in compact_deletes {
+            writes.delete(space, target);
+        }
+        return Ok(true);
+    }
+
+    let desired = compact_deletes
+        .into_iter()
+        .filter(|(space, _)| {
+            space.id != TRACKED_STATE_COMMIT_STATE_MANIFEST_SPACE.id
+                && space.id != TRACKED_STATE_COMMIT_MUTATION_INVENTORY_SPACE.id
+        })
+        .map(|(space, target)| retirement_intent_key(commit_id, space, &target))
+        .collect::<BTreeSet<_>>();
+    let mut remaining = remaining;
+    let mut existing = cursor_rows.into_iter().collect::<BTreeSet<_>>();
+    let stale = existing.difference(&desired).cloned().collect::<Vec<_>>();
+    let stale_take = remaining.min(stale.len());
+    for intent_key in stale.iter().take(stale_take) {
+        writes.delete(
+            crate::gc::COMMIT_RETIREMENT_INTENT_SPACE,
+            intent_key.clone(),
+        );
+        existing.remove(intent_key);
+    }
+    remaining -= stale_take;
+    if stale_take < stale.len() {
+        return Ok(false);
+    }
+    let missing = desired.difference(&existing).cloned().collect::<Vec<_>>();
+    let can_seal = missing.len().saturating_add(1) <= remaining;
+    let take = if can_seal {
+        missing.len()
+    } else {
+        remaining.min(missing.len())
+    };
+    for intent_key in missing.into_iter().take(take) {
+        writes.put(
+            crate::gc::COMMIT_RETIREMENT_INTENT_SPACE,
+            intent_key,
+            StorageValue {
+                bytes: Bytes::new(),
+            },
+        );
+    }
+    if can_seal {
+        writes.put(
+            crate::gc::COMMIT_RETIREMENT_INTENT_SPACE,
+            marker_key,
+            StorageValue {
+                bytes: Bytes::new(),
+            },
+        );
+    }
+    Ok(false)
 }
 
 /// Loads the owning commit ids of every native current-state data part named by
@@ -13187,7 +13754,6 @@ fn validate_commit_delta_manifest(manifest: &CommitDeltaManifest) -> Result<(), 
     // whose only contribution is topology. Its canonical empty mutation
     // inventory is a valid delta with no physical segment to read.
     if manifest.member_count == 0
-        && manifest.selected_source_commit_id.is_none()
         && manifest.direct_segment_row_counts.is_empty()
         && manifest.single_partition.is_none()
         && manifest.lifecycle_summary.is_none()
@@ -15000,6 +15566,27 @@ fn encode_commit_state_manifest(
     })
 }
 
+/// Encodes the two immutable authority rows replaced only by an offline
+/// repository-format migration. Normal publications must use the certified
+/// staging APIs and never rewrite an existing commit authority.
+pub(crate) fn encode_commit_state_manifest_replacement_for_migration(
+    manifest: &CommitStateManifest,
+) -> Result<[(StorageSpace, Vec<u8>, Vec<u8>); 2], LixError> {
+    let encoded = encode_commit_state_manifest(manifest)?;
+    Ok([
+        (
+            TRACKED_STATE_COMMIT_STATE_MANIFEST_SPACE,
+            commit_state_manifest_key(manifest.commit_id),
+            encoded.header,
+        ),
+        (
+            TRACKED_STATE_COMMIT_MUTATION_INVENTORY_SPACE,
+            commit_mutation_inventory_key(manifest.commit_id),
+            encoded.mutation_inventory,
+        ),
+    ])
+}
+
 fn stored_commit_mutation_inventory(
     inventory: &CommitStateMutationInventory,
 ) -> Result<
@@ -15456,11 +16043,11 @@ fn validate_commit_state_manifest_header(
     if stored
         .snapshot_root
         .as_ref()
-        .is_some_and(|root| root.complete_state_fence && !root.parent_roots.is_empty())
+        .is_some_and(|root| !complete_state_fence_source_is_valid(root))
     {
         return Err(LixError::new(
             LixError::CODE_INTERNAL_ERROR,
-            "tracked_state complete-state fence retains physical parent roots",
+            "tracked_state complete-state fence has invalid physical source ancestry",
         ));
     }
     super::scoped_current_state::validate_touched_scope_filter(&stored.touched_scope_filter)?;
@@ -15547,10 +16134,10 @@ fn validate_commit_state_manifest_inner(
                 "tracked_state rootless commit_state_manifest cannot publish a snapshot root",
             ));
         }
-        if root.complete_state_fence && !root.parent_roots.is_empty() {
+        if !complete_state_fence_source_is_valid(root) {
             return Err(LixError::new(
                 LixError::CODE_INTERNAL_ERROR,
-                "tracked_state complete-state fence retains physical parent roots",
+                "tracked_state complete-state fence has invalid physical source ancestry",
             ));
         }
     }
@@ -15558,6 +16145,17 @@ fn validate_commit_state_manifest_inner(
     validate_commit_state_mutation_inventory(manifest.commit_id, &manifest.mutations)?;
     super::scoped_current_state::validate_touched_scope_filter(&manifest.touched_scope_filter)?;
     validate_current_state_scoped_ranges(manifest, validate_scoped_range_attestation)
+}
+
+fn complete_state_fence_source_is_valid(root: &TrackedStateCommitRoot) -> bool {
+    if !root.complete_state_fence {
+        return true;
+    }
+    match root.parent_roots.as_slice() {
+        [] => true,
+        [source] => source.commit_id != root.commit_id && source.root_id == root.root_id,
+        _ => false,
+    }
 }
 
 fn validate_current_state_scoped_ranges(
@@ -15808,7 +16406,7 @@ fn validate_compact_replacement_inventory(
 
 #[cfg(test)]
 mod tests {
-    use std::collections::HashSet;
+    use std::collections::{BTreeSet, HashSet};
     use std::fs;
     use std::future::Future;
     use std::path::{Path, PathBuf};
@@ -15821,8 +16419,8 @@ mod tests {
     use crate::common::LixTimestamp;
     use crate::row_pk::RowPk;
     use crate::storage_adapter::{
-        Memory, StorageAdapter, StorageReadOptions, StorageSpace, StorageWriteOptions,
-        StorageWriteSet,
+        Memory, PointReadPlan, StorageAdapter, StorageGetOptions, StorageKey, StorageReadOptions,
+        StorageSpace, StorageWriteOptions, StorageWriteSet,
     };
     use crate::storage_codec;
     use crate::tracked_state::codec::{
@@ -15859,6 +16457,125 @@ mod tests {
         stage_fragmented_scoped_current_state_descriptor,
         try_encode_commit_delta_segment_with_payloads, validate_unique_exclusive_change_id, value,
     };
+
+    #[tokio::test]
+    async fn wide_commit_retirement_cursor_drains_non_locator_children_in_bounded_slices() {
+        let storage = StorageAdapter::new(Memory::new());
+        let commit_id = CommitId::for_test_label("wide-retirement-cursor");
+        let mut seed = storage.new_write_set();
+        let mut retained_digest = [0_u8; 32];
+        for index in 0..2_500_u32 {
+            let mut digest = [0_u8; 32];
+            digest[28..].copy_from_slice(&index.to_be_bytes());
+            if index == 0 {
+                retained_digest = digest;
+                seed.put(
+                    crate::tracked_state::MUTATION_DIRECTORY_NODE_SPACE,
+                    StorageKey(Bytes::copy_from_slice(&digest)),
+                    &b"live-shared-node"[..],
+                );
+            }
+            let target = StorageKey(Bytes::copy_from_slice(&digest));
+            seed.put(
+                crate::gc::COMMIT_RETIREMENT_INTENT_SPACE,
+                super::retirement_intent_key(
+                    commit_id,
+                    crate::tracked_state::MUTATION_DIRECTORY_NODE_SPACE,
+                    &target,
+                ),
+                &b""[..],
+            );
+        }
+        seed.put(
+            crate::gc::COMMIT_RETIREMENT_INTENT_SPACE,
+            super::retirement_marker_key(commit_id),
+            &b""[..],
+        );
+        storage
+            .commit_write_set(seed, StorageWriteOptions::default())
+            .await
+            .expect("wide retirement cursor should seed");
+
+        let empty = BTreeSet::new();
+        let retained_mutation_nodes = BTreeSet::from([retained_digest]);
+        let retained = super::RetainedPhysicalState {
+            mutation_nodes: &retained_mutation_nodes,
+            scoped_nodes: &empty,
+            native_parts: &empty,
+        };
+        let read = storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("first cursor read should open");
+        let mut first = storage.new_write_set();
+        assert!(
+            !super::stage_retire_commit_physical_state_bounded(
+                &read,
+                &mut first,
+                commit_id,
+                retained,
+                Some(4_000),
+            )
+            .await
+            .expect("first cursor slice should stage")
+        );
+        assert!(first.stats().staged_puts + first.stats().staged_deletes <= 4_000);
+        drop(read);
+        storage
+            .commit_write_set(
+                first,
+                StorageWriteOptions {
+                    background_maintenance: true,
+                    ..StorageWriteOptions::default()
+                },
+            )
+            .await
+            .expect("first cursor slice should commit");
+
+        let read = storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("final cursor read should open");
+        let mut final_slice = storage.new_write_set();
+        assert!(
+            super::stage_retire_commit_physical_state_bounded(
+                &read,
+                &mut final_slice,
+                commit_id,
+                retained,
+                Some(4_000),
+            )
+            .await
+            .expect("final cursor slice should stage")
+        );
+        assert_eq!(
+            final_slice.stats().staged_puts + final_slice.stats().staged_deletes,
+            1_003
+        );
+        drop(read);
+        storage
+            .commit_write_set(
+                final_slice,
+                StorageWriteOptions {
+                    background_maintenance: true,
+                    ..StorageWriteOptions::default()
+                },
+            )
+            .await
+            .expect("final cursor slice should commit");
+        let read = storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("retained-node read should open");
+        let loaded = PointReadPlan::new(
+            crate::tracked_state::MUTATION_DIRECTORY_NODE_SPACE,
+            &[StorageKey(Bytes::copy_from_slice(&retained_digest))],
+        )
+        .materialize(&read, StorageGetOptions::default())
+        .await
+        .expect("retained node should load");
+        assert!(loaded.value[0].is_some(), "newly live shared node survives");
+    }
 
     #[tokio::test]
     async fn deferred_commit_history_is_not_reported_as_an_empty_commit() {
@@ -15990,11 +16707,11 @@ mod tests {
                 snapshot: typed.durable_payload_ref().expect("typed snapshot encodes"),
             },
         ];
-        let encoded = crate::tracked_state::replacement_part::encode_replacement_part_with_compressor(
-            &rows,
-            &mut None,
-        )
-        .expect("native replacement part should encode");
+        let encoded =
+            crate::tracked_state::replacement_part::encode_replacement_part_with_compressor(
+                &rows, &mut None,
+            )
+            .expect("native replacement part should encode");
         let prepared = crate::tracked_state::replacement_part::decode_native_replacement_part(
             encoded.digest(),
             encoded.bytes().clone(),

--- a/packages/lix/src/transaction/bench_support.rs
+++ b/packages/lix/src/transaction/bench_support.rs
@@ -698,24 +698,27 @@ mod tests {
         let point_update = fixture.update_one_by_pk_accounting().await;
         assert_eq!(point_update.logical_rows, 1);
         // The point write keeps the compact current-state certificate,
-        // publishes its authenticated branch control, and rotates the two
-        // mandatory publication epochs — binary-CAS and json_store. It touches
-        // eight spaces, not eleven: those epochs and the tracked mutation fence
+        // publishes its authenticated branch control, rotates the two
+        // mandatory publication epochs — binary-CAS and json_store — and
+        // durably records the fixed checkpoint-retirement authority. It touches
+        // nine spaces, not eleven: the epochs and tracked mutation fence
         // are all keys in the one revision space, the retirement candidates a
         // sweep needs are derived from the commit graph instead of being
         // published into a reachability delta row plus its queue control, and
         // the commit-derived change id is computed from the commit id instead
         // of being mirrored into a reverse-index space.
         //
-        // The json_store epoch is the tenth staged put and is why this is 10
-        // rather than 9. It costs no extra space, batch, or storage call — the
+        // The json_store epoch is the tenth staged put; the two retirement
+        // authority records bring the fixed total to twelve. They add one
+        // space, batch, and storage call independent of repository scale. The
+        // json_store epoch itself costs no extra space, batch, or call — the
         // revision space is already in this write set and its one-byte keys are
         // adjacent — and it is what lets the payload sweep reclaim superseded
         // out-of-band JSON at all: those rows are content addressed, so a
         // publisher can resolve onto a row an earlier sweep plan marked dead.
-        assert_eq!(point_update.staged_puts, 10, "{point_update:?}");
-        assert_eq!(point_update.touched_spaces, 8, "{point_update:?}");
-        assert_eq!(point_update.put_batches, 8, "{point_update:?}");
+        assert_eq!(point_update.staged_puts, 12, "{point_update:?}");
+        assert_eq!(point_update.touched_spaces, 9, "{point_update:?}");
+        assert_eq!(point_update.put_batches, 9, "{point_update:?}");
 
         // A sparse overlay deliberately invalidates the complete-generation
         // digest, so use a fresh fixture to exercise exact bulk replacement

--- a/packages/lix/src/transaction/commit.rs
+++ b/packages/lix/src/transaction/commit.rs
@@ -21,7 +21,7 @@ use crate::changelog::{
 };
 use crate::common::LixTimestamp;
 use crate::filesystem::stage_path_index_revision;
-use crate::functions::FunctionContext;
+use crate::functions::{FunctionContext, FunctionProviderHandle};
 use crate::hot_state::{
     CompleteWorkingDiffMode, HotStateContext, HotStateRowRequest, HotTrackedSnapshot,
     MaterializedHotStateRow, TrackedHeadContext, TrackedWorkingDiffEpoch, WorkingDiffIndexCoverage,
@@ -32,10 +32,11 @@ use crate::storage_adapter::{StorageAdapterRead, StoragePrecondition, StorageWri
 use crate::tracked_state::{
     CommitDeltaReplacementGeneration, CommitDeltaReplacementScope, CommitStateManifest,
     CommitStateMutationInventory, CommitStateReplayDebt, MaterializedTrackedStateRow,
-    TrackedStateCommitDeltaRef, TrackedStateCommitRoot, TrackedStateContext, TrackedStateDeltaRef,
-    TrackedStateFilter, TrackedStateKey, TrackedStateKeyRef, TrackedStateReadColumns,
-    TrackedStateRootMutationRef, TrackedStateScanRequest, TrackedStateSingleStringReplacementRef,
-    encode_key_ref, load_commit_delta_change_records, load_commit_delta_replay_metadata,
+    OrderedAddressableCommitDeltaStage, TrackedStateCommitDeltaRef, TrackedStateCommitRoot,
+    TrackedStateContext, TrackedStateDeltaRef, TrackedStateFilter, TrackedStateKey,
+    TrackedStateKeyRef, TrackedStateReadColumns, TrackedStateRootMutationRef,
+    TrackedStateScanRequest, TrackedStateSingleStringReplacementRef, encode_key_ref,
+    load_commit_delta_change_records, load_commit_delta_replay_metadata,
     stage_addressable_commit_deltas, stage_change_locators,
     stage_ordered_addressable_commit_deltas,
 };
@@ -365,9 +366,10 @@ pub(crate) async fn commit_prepared_writes_with_parent_heads(
     let tracked_roots = finalized.tracked_roots;
     // v69 certified batches are already native packet pages and do not need
     // expansion through an intermediate JSON-root representation.
-    let certified_packet_root_rows =
-        BTreeMap::<CommitId, Vec<MaterializedHotStateRow>>::new();
+    let certified_packet_root_rows = BTreeMap::<CommitId, Vec<MaterializedHotStateRow>>::new();
     let checkpoint_epochs = checkpoint_epoch_bindings(&prepared_writes.checkpoint_publications)?;
+    let checkpoint_state_sources =
+        checkpoint_state_source_bindings(&prepared_writes.checkpoint_publications)?;
     // The current-state protocol removes the automatic mutable branch-ref
     // row for a normal branch-head advance, but `lix_change` remains an
     // unscoped public ledger. Retain one tiny direct change fact per
@@ -404,6 +406,32 @@ pub(crate) async fn commit_prepared_writes_with_parent_heads(
         &engine_rows,
     );
     let row_index = index_prepared_rows(&state_rows)?;
+    // Collection-generation rows are authenticated negative facts: they
+    // replace every predecessor in one collection scope. Rootless replay used
+    // to interpret them at read time. Now that every authored commit publishes
+    // persistent root authority, root staging must apply the same replacement
+    // semantics while the authoring transaction still owns the scale work.
+    let mut certified_replacement_markers = BTreeMap::<CommitId, BTreeSet<TrackedStateKey>>::new();
+    for row in state_rows.iter().filter(|row| {
+        !row.untracked
+            && row.snapshot.is_some()
+            && row.schema_key == crate::collection_generation::COLLECTION_GENERATION_SCHEMA_KEY
+    }) {
+        let commit_id = row.commit_id.ok_or_else(|| {
+            LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                "collection-generation row is missing commit_id before root staging",
+            )
+        })?;
+        certified_replacement_markers
+            .entry(commit_id)
+            .or_default()
+            .insert(TrackedStateKey {
+                schema_key: row.schema_key.to_string(),
+                file_id: row.file_id.map(ToString::to_string),
+                row_pk: row.row_pk.clone(),
+            });
+    }
 
     if state_rows.is_empty()
         && commit_rows.is_empty()
@@ -467,7 +495,6 @@ pub(crate) async fn commit_prepared_writes_with_parent_heads(
     );
     let replacement_generation_commits = replacement_generations
         .keys()
-        .filter(|commit_id| rootless_ordered_commits.contains(commit_id))
         .copied()
         .collect::<BTreeSet<_>>();
     let mut durable_root_rebuild_parents = BTreeSet::new();
@@ -490,6 +517,7 @@ pub(crate) async fn commit_prepared_writes_with_parent_heads(
             &commit_rows,
             &staged_delta_index.inventories,
             &ordered_replacements,
+            &checkpoint_state_sources,
             &mut external_parent_manifests,
             active_account_id,
         )
@@ -520,6 +548,9 @@ pub(crate) async fn commit_prepared_writes_with_parent_heads(
     )
     .await?;
 
+    let journal_functions = runtime_functions
+        .map(FunctionContext::provider)
+        .unwrap_or_else(FunctionProviderHandle::system);
     let staged_snapshot_roots = Box::pin(
         stage_tracked_roots(
             tracked_state,
@@ -533,6 +564,11 @@ pub(crate) async fn commit_prepared_writes_with_parent_heads(
             &staged_root_rebuild_commits,
             &staged_commits,
             &insert_selection,
+            &certified_replacement_markers,
+            &checkpoint_state_sources,
+            &ordered_replacements,
+            &staged_delta_index.ordered_replacement_assignments,
+            &journal_functions,
         )
         .instrument(tracing::debug_span!(
             target: "lix_perf",
@@ -682,6 +718,8 @@ pub(crate) async fn commit_prepared_writes_with_parent_heads(
             &certified_packet_root_rows,
             &ordered_replacements,
             &staged_delta_index,
+            &checkpoint_state_sources,
+            &staged_snapshot_roots,
         )?
     } else {
         Vec::new()
@@ -786,6 +824,7 @@ struct StagedCommitDeltaIndex {
     ordered_addressable_commits: BTreeSet<CommitId>,
     inventories: BTreeMap<CommitId, CommitStateMutationInventory>,
     sync_ordered_change_ids: BTreeMap<CommitId, Vec<ChangeId>>,
+    ordered_replacement_assignments: BTreeMap<CommitId, OrderedAddressableCommitDeltaStage>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -884,6 +923,7 @@ async fn stage_changelog_commits(
     commit_rows: &[FinalizedCommitRow],
     mutation_inventories: &BTreeMap<CommitId, CommitStateMutationInventory>,
     ordered_replacements: &BTreeMap<CommitId, Arc<OrderedMutationJournal>>,
+    checkpoint_state_sources: &BTreeMap<CommitId, CommitId>,
     external_parent_manifests: &mut BTreeMap<
         CommitId,
         crate::tracked_state::PublishedCommitStateTopology,
@@ -1165,16 +1205,23 @@ async fn stage_changelog_commits(
         // certified inventory the commit already staged. Deriving it costs one
         // walk of the inventory's own bounds; publishing it saves history one
         // replay-state point-read pair per reached commit.
-        let touched_scope_digest = match mutation_inventories.get(&commit_id) {
-            Some(inventory) => {
-                match crate::tracked_state::commit_delta_member_scopes(commit_id, inventory)? {
-                    Some(scopes) => CommitTouchedScopeDigest::exact(scopes.iter()),
-                    None => CommitTouchedScopeDigest::opaque(),
+        let touched_scope_digest = if checkpoint_state_sources.contains_key(&commit_id) {
+            // A complete-state checkpoint exposes a lazy root diff rather than
+            // local commit-delta members. Its scopes are intentionally not
+            // enumerated during foreground publication.
+            CommitTouchedScopeDigest::opaque()
+        } else {
+            match mutation_inventories.get(&commit_id) {
+                Some(inventory) => {
+                    match crate::tracked_state::commit_delta_member_scopes(commit_id, inventory)? {
+                        Some(scopes) => CommitTouchedScopeDigest::exact(scopes.iter()),
+                        None => CommitTouchedScopeDigest::opaque(),
+                    }
                 }
+                // A staged commit with no mutation inventory has no delta members,
+                // so nothing a history read asks for can be found in it.
+                None => CommitTouchedScopeDigest::exact(std::iter::empty()),
             }
-            // A staged commit with no mutation inventory has no delta members,
-            // so nothing a history read asks for can be found in it.
-            None => CommitTouchedScopeDigest::exact(std::iter::empty()),
         };
         touched_scope_digests.insert(commit_id, touched_scope_digest.clone());
         topology_records.insert(
@@ -1817,6 +1864,7 @@ async fn stage_tracked_commit_delta_index(
     let mut ordered_addressable_commits = BTreeSet::new();
     let mut inventories = BTreeMap::new();
     let mut sync_ordered_change_ids = BTreeMap::new();
+    let mut ordered_replacement_assignments = BTreeMap::new();
     let commit_rows = commit_rows
         .iter()
         .map(|commit| (commit.commit_id, commit))
@@ -1904,6 +1952,7 @@ async fn stage_tracked_commit_delta_index(
                 sync_ordered_change_ids
                     .insert(root.commit_id, stage.assigned_change_ids().collect());
             }
+            ordered_replacement_assignments.insert(root.commit_id, stage);
             ordered_addressable_commits.insert(root.commit_id);
             continue;
         }
@@ -2081,79 +2130,78 @@ async fn stage_tracked_commit_delta_index(
                 "lix.perf.commit_delta_selected_sources"
             );
         }
-        let selected_source_alias = if !state_row_indices.is_empty()
-            && selected_members_by_source.len() == 1
-        {
-            let source_commit_id = *selected_members_by_source
-                .first_key_value()
-                .expect("one selected source exists")
-                .0;
-            let source = crate::tracked_state::load_commit_delta_selection_certificate(
-                read,
-                source_commit_id,
-            )
-            .await?;
-            source
-                .is_some_and(|source| {
-                    if source.selected_source_commit_id.is_some()
-                        || usize::try_from(source.member_count).ok()
-                            != Some(selected_change_count(&staged.selected_change_batches))
-                    {
-                        return false;
-                    }
-                    let membership_certified = staged
-                        .selected_change_batches
-                        .iter()
-                        .all(StagedCommitChangeBatch::source_membership_certified);
-                    if !source.direct_segment_row_counts.is_empty() && membership_certified {
-                        return dense_selected_source_is_exact(
-                            source_commit_id,
-                            &source.direct_segment_row_counts,
-                            true,
-                            selected_changes(&staged.selected_change_batches),
-                        );
-                    }
-                    // Ordinary merge analysis already supplies exact selected
-                    // identities but does not carry the checkpoint-only dense
-                    // membership certificate. Prove the same fact against the
-                    // source manifest's count and order-independent fingerprint.
-                    let selected = selected_changes(&staged.selected_change_batches)
-                        .map(|change_ref| {
-                            (
-                                encode_key_ref(TrackedStateKeyRef {
-                                    schema_key: change_ref.schema_key(),
-                                    file_id: change_ref.file_id(),
-                                    row_pk: change_ref.row_pk(),
-                                }),
+        let selected_source_alias =
+            if !state_row_indices.is_empty() && selected_members_by_source.len() == 1 {
+                let source_commit_id = *selected_members_by_source
+                    .first_key_value()
+                    .expect("one selected source exists")
+                    .0;
+                let source = crate::tracked_state::load_commit_delta_selection_certificate(
+                    read,
+                    source_commit_id,
+                )
+                .await?;
+                source
+                    .is_some_and(|source| {
+                        if source.selected_source_commit_id.is_some()
+                            || usize::try_from(source.member_count).ok()
+                                != Some(selected_change_count(&staged.selected_change_batches))
+                        {
+                            return false;
+                        }
+                        let membership_certified = staged
+                            .selected_change_batches
+                            .iter()
+                            .all(StagedCommitChangeBatch::source_membership_certified);
+                        if !source.direct_segment_row_counts.is_empty() && membership_certified {
+                            return dense_selected_source_is_exact(
+                                source_commit_id,
+                                &source.direct_segment_row_counts,
+                                true,
+                                selected_changes(&staged.selected_change_batches),
+                            );
+                        }
+                        // Ordinary merge analysis already supplies exact selected
+                        // identities but does not carry the checkpoint-only dense
+                        // membership certificate. Prove the same fact against the
+                        // source manifest's count and order-independent fingerprint.
+                        let selected = selected_changes(&staged.selected_change_batches)
+                            .map(|change_ref| {
                                 (
-                                    change_ref.change_id,
-                                    change_ref.deleted,
-                                    change_ref.created_at,
-                                    change_ref.updated_at,
-                                ),
-                            )
-                        })
-                        .collect::<HashMap<_, _>>();
-                    usize::try_from(source.member_count).ok() == Some(selected.len())
-                        && source.selection_fingerprint
-                            == crate::tracked_state::selected_change_selection_fingerprint(
-                                selected.iter().map(
-                                    |(key, (change_id, deleted, created_at, updated_at))| {
-                                        (
-                                            key.as_slice(),
-                                            *change_id,
-                                            *deleted,
-                                            *created_at,
-                                            *updated_at,
-                                        )
-                                    },
-                                ),
-                            )
-                })
-                .then_some(source_commit_id)
-        } else {
-            None
-        };
+                                    encode_key_ref(TrackedStateKeyRef {
+                                        schema_key: change_ref.schema_key(),
+                                        file_id: change_ref.file_id(),
+                                        row_pk: change_ref.row_pk(),
+                                    }),
+                                    (
+                                        change_ref.change_id,
+                                        change_ref.deleted,
+                                        change_ref.created_at,
+                                        change_ref.updated_at,
+                                    ),
+                                )
+                            })
+                            .collect::<HashMap<_, _>>();
+                        usize::try_from(source.member_count).ok() == Some(selected.len())
+                            && source.selection_fingerprint
+                                == crate::tracked_state::selected_change_selection_fingerprint(
+                                    selected.iter().map(
+                                        |(key, (change_id, deleted, created_at, updated_at))| {
+                                            (
+                                                key.as_slice(),
+                                                *change_id,
+                                                *deleted,
+                                                *created_at,
+                                                *updated_at,
+                                            )
+                                        },
+                                    ),
+                                )
+                    })
+                    .then_some(source_commit_id)
+            } else {
+                None
+            };
         let authored_change_ids = state_row_indices
             .iter()
             .filter_map(|&row_index| {
@@ -2210,6 +2258,7 @@ async fn stage_tracked_commit_delta_index(
         ordered_addressable_commits,
         inventories,
         sync_ordered_change_ids,
+        ordered_replacement_assignments,
     })
 }
 
@@ -2227,8 +2276,12 @@ fn materialize_staged_sync_commits(
     certified_packet_root_rows: &BTreeMap<CommitId, Vec<MaterializedHotStateRow>>,
     ordered_replacements: &BTreeMap<CommitId, Arc<OrderedMutationJournal>>,
     staged_delta_index: &StagedCommitDeltaIndex,
+    checkpoint_state_sources: &BTreeMap<CommitId, CommitId>,
+    staged_snapshot_roots: &BTreeMap<CommitId, TrackedStateCommitRoot>,
 ) -> Result<Vec<crate::sync::SyncCommit>, LixError> {
-    use crate::sync::{SyncCommit, SyncCommitMemberRef, encode_sync_commit_member};
+    use crate::sync::{
+        SyncCommit, SyncCommitMemberRef, SyncCommitStateAlias, encode_sync_commit_member,
+    };
 
     let mut commits = Vec::with_capacity(staged_commits.len());
     for (commit_id, staged) in staged_commits {
@@ -2393,6 +2446,32 @@ fn materialize_staged_sync_commits(
         let selected_source_commit_id = (has_selected_members
             && staged.record.parent_commit_ids.len() > 1)
             .then(|| staged.record.parent_commit_ids[1]);
+        let state_alias = checkpoint_state_sources
+            .get(commit_id)
+            .map(|source_commit_id| {
+                let root = staged_snapshot_roots.get(commit_id).ok_or_else(|| {
+                    LixError::new(
+                        LixError::CODE_INTERNAL_ERROR,
+                        format!("checkpoint sync commit '{commit_id}' has no staged state root"),
+                    )
+                })?;
+                if !root.complete_state_fence
+                    || root.parent_roots.first().map(|parent| parent.commit_id)
+                        != Some(*source_commit_id)
+                {
+                    return Err(LixError::new(
+                        LixError::CODE_INTERNAL_ERROR,
+                        format!("checkpoint sync commit '{commit_id}' has an invalid state alias"),
+                    ));
+                }
+                Ok(SyncCommitStateAlias {
+                    source_commit_id: source_commit_id.to_string(),
+                    state_root_id: blake3::Hash::from_bytes(*root.root_id.as_bytes())
+                        .to_hex()
+                        .to_string(),
+                })
+            })
+            .transpose()?;
         let commit = SyncCommit {
             commit_id: staged.record.commit_id.to_string(),
             parent_commit_ids: staged
@@ -2404,6 +2483,7 @@ fn materialize_staged_sync_commits(
             account_id: staged.record.account_id.clone(),
             created_at: staged.record.created_at.to_string(),
             selected_source_commit_id: selected_source_commit_id.map(|id| id.to_string()),
+            state_alias,
             members,
         };
         commit.validate()?;
@@ -2418,7 +2498,7 @@ fn try_stage_lossless_columnar_mutations(
     state_rows: &PreparedStateBatch,
     state_row_indices: &[RowIndex],
     row_columnar_write_sets: &mut crate::hot_state::RowColumnarWriteSets,
-) -> Result<Option<crate::tracked_state::OrderedAddressableCommitDeltaStage>, LixError> {
+) -> Result<Option<OrderedAddressableCommitDeltaStage>, LixError> {
     if state_row_indices.is_empty()
         || row_columnar_write_sets.dense_state_row_count() != Some(state_row_indices.len())
     {
@@ -2606,8 +2686,9 @@ async fn certify_complete_replacement_generations(
                     ),
                 )
             })?;
-            if manifest.replay_debt().depth == 0 {
-                break Some(commit_id);
+            if let Some(source_commit_id) = manifest.complete_state_source_commit_id() {
+                current = Some(source_commit_id);
+                continue;
             }
             let Some(metadata) = load_commit_delta_replay_metadata(read, commit_id).await? else {
                 // Missing replay evidence cannot certify that this interval
@@ -2747,8 +2828,9 @@ async fn certify_ordered_journal_replacement_generations(
                     format!("immutable replacement parent '{commit_id}' has no physical authority"),
                 )
             })?;
-            if manifest.replay_debt().depth == 0 {
-                break Some(commit_id);
+            if let Some(source_commit_id) = manifest.complete_state_source_commit_id() {
+                current = Some(source_commit_id);
+                continue;
             }
             let Some(metadata) = load_commit_delta_replay_metadata(read, commit_id).await? else {
                 break Some(commit_id);
@@ -2869,33 +2951,20 @@ fn replay_bytes_for_rows(
 }
 
 fn select_new_rootless_ordered_commits(
-    state_rows: &PreparedStateBatch,
-    tracked_row_indices_by_commit: &BTreeMap<CommitId, Vec<RowIndex>>,
-    tracked_roots: &[PendingTrackedRoot],
-    ordered_addressable_commits: &BTreeSet<CommitId>,
-    ordered_replacements: &BTreeMap<CommitId, Arc<OrderedMutationJournal>>,
+    _state_rows: &PreparedStateBatch,
+    _tracked_row_indices_by_commit: &BTreeMap<CommitId, Vec<RowIndex>>,
+    _tracked_roots: &[PendingTrackedRoot],
+    _ordered_addressable_commits: &BTreeSet<CommitId>,
+    _ordered_replacements: &BTreeMap<CommitId, Arc<OrderedMutationJournal>>,
 ) -> BTreeSet<CommitId> {
-    let can_start_rootless_interval = tracked_roots.len() == 1;
-    let mut rootless = BTreeSet::new();
-    for root in tracked_roots {
-        if ordered_replacements.contains_key(&root.commit_id) {
-            rootless.insert(root.commit_id);
-            continue;
-        }
-        let row_indices = tracked_row_indices_by_commit
-            .get(&root.commit_id)
-            .map(Vec::as_slice)
-            .unwrap_or_default();
-        let starts_ordered_interval = can_start_rootless_interval
-            && root.publish_head
-            && !row_indices.is_empty()
-            && ordered_addressable_commits.contains(&root.commit_id)
-            && row_indices.len() == state_rows.len();
-        if starts_ordered_interval {
-            rootless.insert(root.commit_id);
-        }
-    }
-    rootless
+    // Checkpoint publication can alias a maintained persistent root in O(1),
+    // but it cannot turn an arbitrary deferred replay interval into a root
+    // without paying that interval's scale cost. Keep ordinary commits rooted
+    // as they are authored so checkpoint latency never inherits write debt.
+    // Immutable replacement journals also publish their persistent root in
+    // the authoring transaction. Leaving even this bounded layout rootless
+    // would make the next checkpoint inherit a scale-dependent rebuild.
+    BTreeSet::new()
 }
 
 struct StagedHotHeads {
@@ -5408,6 +5477,31 @@ fn checkpoint_epoch_bindings(
     Ok(bindings)
 }
 
+fn checkpoint_state_source_bindings(
+    publications: &[crate::gc::CheckpointPublication],
+) -> Result<BTreeMap<CommitId, CommitId>, LixError> {
+    let mut bindings = BTreeMap::new();
+    for publication in publications {
+        let recovery = &publication.recovery_ref;
+        if bindings
+            .insert(
+                recovery.checkpoint_commit_id,
+                recovery.recovered_head_commit_id,
+            )
+            .is_some()
+        {
+            return Err(LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                format!(
+                    "transaction publishes checkpoint '{}' more than once",
+                    recovery.checkpoint_commit_id
+                ),
+            ));
+        }
+    }
+    Ok(bindings)
+}
+
 /// Returns explicit public branch-ref targets. `None` is a deletion; `Some`
 /// is a validated commit id. The current-state control record remains the
 /// authority, while retaining these rows in generic lifecycle lowering keeps
@@ -5748,6 +5842,11 @@ async fn stage_tracked_roots(
     staged_root_rebuild_commits: &BTreeSet<CommitId>,
     staged_commits: &BTreeMap<CommitId, StagedChangelogCommit>,
     insert_selection: &PreparedInsertSelection,
+    certified_replacement_markers_by_commit: &BTreeMap<CommitId, BTreeSet<TrackedStateKey>>,
+    checkpoint_state_sources: &BTreeMap<CommitId, CommitId>,
+    ordered_replacements: &BTreeMap<CommitId, Arc<OrderedMutationJournal>>,
+    ordered_replacement_assignments: &BTreeMap<CommitId, OrderedAddressableCommitDeltaStage>,
+    functions: &FunctionProviderHandle,
 ) -> Result<BTreeMap<CommitId, TrackedStateCommitRoot>, LixError> {
     let root_fence_ids = tracked_root_fence_ids(tracked_roots);
     if root_fence_ids.is_empty() {
@@ -5832,10 +5931,76 @@ async fn stage_tracked_roots(
                 ),
             )
         })?;
+        if let Some(source_commit_id) = checkpoint_state_sources.get(&root.commit_id) {
+            if staged.selected_change_batches.is_empty() {
+                tracked_writer
+                    .stage_complete_state_alias(root.commit_id, *source_commit_id)
+                    .await?;
+                continue;
+            }
+        }
+        if let Some(journal) = ordered_replacements.get(&root.commit_id) {
+            let assignment = ordered_replacement_assignments
+                .get(&root.commit_id)
+                .ok_or_else(|| {
+                    LixError::new(
+                        LixError::CODE_INTERNAL_ERROR,
+                        "ordered replacement root is missing its commit-delta change assignment",
+                    )
+                })?;
+            let mut journal_rows = journal.as_ref().clone().into_prepared(functions)?;
+            if journal_rows.len() != assignment.row_count() {
+                return Err(LixError::new(
+                    LixError::CODE_INTERNAL_ERROR,
+                    "ordered replacement changed row count before persistent-root staging",
+                ));
+            }
+            for (row_index, change_id) in assignment.assigned_change_ids().enumerate() {
+                journal_rows.set_change_id(row_index, Some(change_id));
+            }
+            let row_indices = (0..journal_rows.len()).collect::<Vec<_>>();
+            let first_row = journal_rows.row(0);
+            let first_mutation_key = encode_key_ref(TrackedStateKeyRef {
+                schema_key: first_row.schema_key,
+                file_id: first_row.file_id.map(crate::common::SharedStr::as_str),
+                row_pk: first_row.row_pk,
+            });
+            let commit_id_text = root.commit_id.to_string();
+            let parent_commit_id_text = root.parent_commit_id.map(|id| id.to_string());
+            if tracked_writer
+                .try_stage_bulk_parent_root_from_ordered_mutations(
+                    &commit_id_text,
+                    parent_commit_id_text.as_deref(),
+                    row_indices.len(),
+                    &first_mutation_key,
+                    &BTreeMap::new(),
+                    OrderedStateRowMutations::new(
+                        &row_indices,
+                        &journal_rows,
+                        &PreparedInsertSelection::default(),
+                    ),
+                )
+                .await?
+                .is_some()
+            {
+                continue;
+            }
+            let deltas = row_indices
+                .iter()
+                .map(|&row_index| tracked_delta_from_state_row(journal_rows.row(row_index)))
+                .collect::<Result<Vec<_>, _>>()?;
+            tracked_writer
+                .stage_commit_root(&commit_id_text, parent_commit_id_text.as_deref(), deltas)
+                .await?;
+            continue;
+        }
         let state_row_indices = tracked_row_indices_by_commit
             .get(&root.commit_id)
             .map(Vec::as_slice)
             .unwrap_or_default();
+        let replacement_markers = certified_replacement_markers_by_commit
+            .get(&root.commit_id)
+            .unwrap_or(&no_replacement_markers);
         if state_row_indices.len() > staged.change_count {
             return Err(LixError::new(
                 LixError::CODE_INTERNAL_ERROR,
@@ -5851,7 +6016,8 @@ async fn stage_tracked_roots(
         // When they cover a substantial fraction of a parent root, stream the
         // parent/changes directly into canonical chunks instead of point
         // reading every key and materializing two more full-workload vectors.
-        if !state_row_indices.is_empty()
+        if replacement_markers.is_empty()
+            && !state_row_indices.is_empty()
             && staged.selected_change_batches.is_empty()
             && tracked_state_rows_are_strictly_sorted(state_rows, state_row_indices)
         {
@@ -5937,7 +6103,7 @@ async fn stage_tracked_roots(
                 parent_commit_id_text.as_deref(),
                 deltas,
                 &absence_guards,
-                &no_replacement_markers,
+                replacement_markers,
             )
             .await?;
     }
@@ -6018,7 +6184,94 @@ where
             } else {
                 None
             };
-            let catalog_publication = if record.parent_commit_ids.len() <= 1
+            let complete_state_fence = snapshot_root
+                .as_ref()
+                .is_some_and(|root| root.complete_state_fence);
+            let catalog_publication = if complete_state_fence {
+                let source_id = snapshot_root
+                    .as_ref()
+                    .and_then(|root| root.parent_roots.first())
+                    .map(|source| source.commit_id)
+                    .ok_or_else(|| {
+                        LixError::new(
+                            LixError::CODE_INTERNAL_ERROR,
+                            "complete-state checkpoint has no physical source root",
+                        )
+                    })?;
+                let topology_parents = record
+                    .parent_commit_ids
+                    .iter()
+                    .map(|parent_id| {
+                        published_manifests
+                            .get(parent_id)
+                            .map(crate::tracked_state::CertifiedCommitStateTopologyParent::Staged)
+                            .or_else(|| {
+                                external_parent_manifests.get(parent_id).map(
+                                    crate::tracked_state::CertifiedCommitStateTopologyParent::PublishedTopology,
+                                )
+                            })
+                            .ok_or_else(|| {
+                                LixError::new(
+                                    LixError::CODE_INTERNAL_ERROR,
+                                    format!(
+                                        "checkpoint '{}' has no certified topology parent '{}'",
+                                        record.commit_id, parent_id
+                                    ),
+                                )
+                            })
+                    })
+                    .collect::<Result<Vec<_>, _>>()?;
+                let loaded_source = if !published_manifests.contains_key(&source_id)
+                    && !external_parent_manifests.contains_key(&source_id)
+                {
+                    Some(
+                        crate::tracked_state::load_published_commit_state_topology(read, source_id)
+                            .await?
+                            .ok_or_else(|| {
+                                LixError::new(
+                                    LixError::CODE_INTERNAL_ERROR,
+                                    format!(
+                                        "checkpoint '{}' has no physical source authority '{}'",
+                                        record.commit_id, source_id
+                                    ),
+                                )
+                            })?,
+                    )
+                } else {
+                    None
+                };
+                let source = published_manifests
+                    .get(&source_id)
+                    .map(crate::tracked_state::CertifiedCommitStateTopologyParent::Staged)
+                    .or_else(|| {
+                        external_parent_manifests.get(&source_id).map(
+                            crate::tracked_state::CertifiedCommitStateTopologyParent::PublishedTopology,
+                        )
+                    })
+                    .or_else(|| {
+                        loaded_source.as_ref().map(
+                            crate::tracked_state::CertifiedCommitStateTopologyParent::PublishedTopology,
+                        )
+                    })
+                    .ok_or_else(|| {
+                        LixError::new(
+                            LixError::CODE_INTERNAL_ERROR,
+                            "checkpoint physical source disappeared during commit staging",
+                        )
+                    })?;
+                Some(
+                    crate::tracked_state::stage_current_state_scoped_ranges_from_complete_state_source(
+                        read,
+                        writes,
+                        &topology_parents,
+                        source,
+                        record.commit_id,
+                        &record.account_id,
+                        &mutations,
+                    )
+                    .await?,
+                )
+            } else if record.parent_commit_ids.len() <= 1
                 && mutations.selected_source_commit_id.is_none()
             {
                 Some(if let Some(parent) = staged_parent {
@@ -7394,7 +7647,6 @@ mod tests {
         )
         .expect("different semantic identities may share one source change id");
     }
-
 
     #[tokio::test]
     async fn ordinary_unaddressed_tracked_commit_appends_changelog_and_root() {
@@ -9381,6 +9633,7 @@ mod tests {
             &commits,
             &BTreeMap::new(),
             &BTreeMap::new(),
+            &BTreeMap::new(),
             &mut external_parent_manifests,
             crate::ANONYMOUS_ACCOUNT_ID,
         )
@@ -9517,6 +9770,7 @@ mod tests {
             &mut staged_root_rebuild_commits,
             &row_indices,
             &commit_rows,
+            &BTreeMap::new(),
             &BTreeMap::new(),
             &BTreeMap::new(),
             &mut external_parent_manifests,

--- a/packages/lix/src/transaction/commit_coordinator.rs
+++ b/packages/lix/src/transaction/commit_coordinator.rs
@@ -1,4 +1,7 @@
 use std::collections::VecDeque;
+#[cfg(not(test))]
+use std::sync::atomic::Ordering;
+use std::sync::atomic::{AtomicBool, AtomicU64};
 #[cfg(test)]
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
@@ -50,6 +53,8 @@ where
     observe_invalidation: Arc<ObserveInvalidation>,
     capacity: Arc<Semaphore>,
     telemetry: Option<Arc<dyn TelemetrySink>>,
+    checkpoint_gc_running: AtomicBool,
+    checkpoint_gc_not_before_sequence: AtomicU64,
     state: Mutex<CommitCoordinatorState<StorageImpl>>,
     #[cfg(test)]
     stats: CommitCoordinatorStats,
@@ -98,11 +103,46 @@ where
                 observe_invalidation,
                 capacity: Arc::new(Semaphore::new(COMMIT_QUEUE_CAPACITY)),
                 telemetry,
+                checkpoint_gc_running: AtomicBool::new(false),
+                checkpoint_gc_not_before_sequence: AtomicU64::new(0),
                 state: Mutex::new(CommitCoordinatorState::default()),
                 #[cfg(test)]
                 stats: CommitCoordinatorStats::default(),
             }),
         }
+    }
+
+    /// Coalesces repository-wide checkpoint maintenance across every session
+    /// sharing this coordinator. Foreground checkpoints only attempt this
+    /// atomic transition; they never wait for maintenance ownership.
+    pub(crate) fn try_begin_checkpoint_gc(&self, checkpoint_sequence: u64) -> bool {
+        if checkpoint_sequence
+            < self
+                .inner
+                .checkpoint_gc_not_before_sequence
+                .load(Ordering::Acquire)
+        {
+            return false;
+        }
+        self.inner
+            .checkpoint_gc_running
+            .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+            .is_ok()
+    }
+
+    /// Process-local fallback when even the durable failure counter loses its
+    /// CAS race. This keeps sustained contention from immediately launching a
+    /// fresh full repository plan at the next checkpoint.
+    pub(crate) fn defer_checkpoint_gc_until(&self, checkpoint_sequence: u64) {
+        self.inner
+            .checkpoint_gc_not_before_sequence
+            .fetch_max(checkpoint_sequence, Ordering::AcqRel);
+    }
+
+    pub(crate) fn finish_checkpoint_gc(&self) {
+        self.inner
+            .checkpoint_gc_running
+            .store(false, Ordering::Release);
     }
 
     pub(crate) async fn commit(

--- a/packages/lix/src/transaction/context.rs
+++ b/packages/lix/src/transaction/context.rs
@@ -56,7 +56,7 @@ use crate::hot_state::{
     HotStateExactBatchRequest, HotStateExactRowRequest, HotStateFilter, HotStateProjection,
     HotStateReader, HotStateScanRequest, MaterializedHotStateBatch, MaterializedHotStateExactBatch,
     MaterializedHotStateRow, MaterializedHotStateRowRef, StagedHotStateRows, TrackedHeadContext,
-    TrackedWorkingDiff, overlay_load_exact_batch, overlay_scan_batch,
+    overlay_load_exact_batch, overlay_scan_batch,
 };
 use crate::plugin::runtime::{
     ArcByteSource, BoundCreateContext, CompiledPluginCatalog, ConflictRank, FileBytesSha256,
@@ -1708,268 +1708,266 @@ where
             filesystem_delta_rows,
             previous_filesystem_revision,
             next_catalog_revision,
-        ) =
-            instrument_lix_result(materialize_span, async {
+        ) = instrument_lix_result(materialize_span, async {
+            transaction
+                .uncache_completed_plugin_actors_for_large_file_writes(&prepared_writes)
+                .await;
+            let tracked_state_changed = prepared_writes.state_rows.iter().any(|row| !row.untracked)
+                || !prepared_writes.commit_change_refs_by_branch.is_empty()
+                || !prepared_writes.extra_commit_parents_by_branch.is_empty();
+            let has_untracked_state_writes =
+                prepared_writes.state_rows.iter().any(|row| row.untracked);
+            // Untracked rows are mutable current state, but their validation can read
+            // tracked schemas, parents, uniqueness owners, or filesystem state.
+            // Fence that snapshot without rotating the tracked revision: normal
+            // tracked transactions remain independent of untracked-only commits.
+            let requires_tracked_snapshot_fence =
+                tracked_state_changed || has_untracked_state_writes;
+            let catalog_revision_changed = prepared_writes_change_catalog(&prepared_writes);
+            if let Err(error) = check_commit_boundary(commit_boundary.as_ref()) {
                 transaction
-                    .uncache_completed_plugin_actors_for_large_file_writes(&prepared_writes)
+                    .discard_pending_plugin_actor_publications()
                     .await;
-                let tracked_state_changed =
-                    prepared_writes.state_rows.iter().any(|row| !row.untracked)
-                        || !prepared_writes.commit_change_refs_by_branch.is_empty()
-                        || !prepared_writes.extra_commit_parents_by_branch.is_empty();
-                let has_untracked_state_writes =
-                    prepared_writes.state_rows.iter().any(|row| row.untracked);
-                // Untracked rows are mutable current state, but their validation can read
-                // tracked schemas, parents, uniqueness owners, or filesystem state.
-                // Fence that snapshot without rotating the tracked revision: normal
-                // tracked transactions remain independent of untracked-only commits.
-                let requires_tracked_snapshot_fence =
-                    tracked_state_changed || has_untracked_state_writes;
-                let catalog_revision_changed = prepared_writes_change_catalog(&prepared_writes);
-                if let Err(error) = check_commit_boundary(commit_boundary.as_ref()) {
-                    transaction
-                        .discard_pending_plugin_actor_publications()
-                        .await;
-                    return Err(error);
-                }
-                // Validate and materialize from one coherent storage snapshot. The
-                // final write's tracked-state precondition fences the decisions made
-                // here, including plugin-produced prepared rows.
-                let commit_read_storage = transaction.storage.clone();
-                let commit_read = commit_read_storage
-                    .begin_read(StorageReadOptions::default())
-                    .await?;
-                // SAFETY: `commit_read_storage` is an `Arc` retained through commit,
-                // and the transaction drops this read before its storage field.
-                let commit_read = unsafe { assume_static_storage_read::<StorageImpl>(commit_read) };
-                let mut read = SharedStorageAdapterRead::new(commit_read);
-                // Commit-time reconciliation and validation must all observe this
-                // current coherent snapshot, while user statements above observed the
-                // snapshot retained from transaction open.
-                transaction.opening_read = read.clone();
-                if let Err(error) = transaction
-                    .reconcile_stale_disjoint_writes(&read, &mut prepared_writes)
-                    .instrument(tracing::debug_span!(
-                        target: "lix_perf",
-                        "lix.perf.transaction_reconcile_stale"
-                    ))
-                    .await
-                {
-                    transaction
-                        .discard_pending_plugin_actor_publications()
-                        .await;
-                    return Err(error);
-                }
-                let branch_checkpoint_bridges = match transaction
-                    .resolve_pending_branch_checkpoint_replacements(&read, &prepared_writes)
-                    .await
-                {
-                    Ok(branch_checkpoint_bridges) => branch_checkpoint_bridges,
-                    Err(error) => {
-                        transaction
-                            .discard_pending_plugin_actor_publications()
-                            .await;
-                        return Err(error);
-                    }
-                };
-                let restore_targets = std::mem::take(&mut transaction.pending_restore_targets);
-                let commit_parent_heads = match commit::resolve_prepared_commit_parent_heads(
-                    transaction.branch_ctx.as_ref(),
-                    &read,
-                    &prepared_writes,
-                    true,
-                )
-                .await
-                {
-                    Ok(commit_parent_heads) => commit_parent_heads,
-                    Err(error) => {
-                        transaction
-                            .discard_pending_plugin_actor_publications()
-                            .await;
-                        return Err(error);
-                    }
-                };
-                if let Err(error) = Self::attach_checkpoint_branch_parents(
-                    &read,
-                    &mut prepared_writes,
-                    &commit_parent_heads,
-                )
-                .await
-                {
-                    transaction
-                        .discard_pending_plugin_actor_publications()
-                        .await;
-                    return Err(error);
-                }
-                if let Err(error) = transaction
-                    .validate_prepared_writes_by_branch(&read, &mut prepared_writes)
-                    .instrument(tracing::debug_span!(
-                        target: "lix_perf",
-                        "lix.perf.transaction_validation"
-                    ))
-                    .await
-                {
-                    transaction
-                        .discard_pending_plugin_actor_publications()
-                        .await;
-                    return Err(error);
-                }
-                // The delta itself is projected out of the commit below, once
-                // addressable rows hold their final commit-delta change ids. Only its
-                // *projectability* is decided here, because the revision the cached
-                // views are keyed on has to be read before the commit publishes its
-                // successor.
-                let stages_projectable_filesystem_rows =
-                    prepared_writes_stage_filesystem_rows(&prepared_writes)
-                        && !prepared_writes_require_filesystem_index_rebuild(&prepared_writes);
-                // A failed revision read must not collapse into "no revision yet".
-                // `None` is itself a live cache key — the state before the first
-                // filesystem commit — so treating an error as `None` would rekey
-                // entries built at an unknown revision onto this commit's successor and
-                // make a stale index reachable. The outer `Option` is "the read
-                // succeeded"; only that licenses a projection.
-                let loaded_filesystem_revision = if stages_projectable_filesystem_rows {
-                    load_path_index_revision(&read).await.ok()
-                } else {
-                    None
-                };
-                let filesystem_delta_projectable = loaded_filesystem_revision.is_some();
-                let previous_filesystem_revision = loaded_filesystem_revision.flatten();
-                let mut automatic_sync_writes = transaction.storage.new_write_set();
-                let mut automatic_sync_preconditions = Vec::new();
-                let capture_sync_commits = !transaction.suppress_ordinary_sync_event
-                    && transaction.sync_role == crate::sync::SyncRole::Authority;
-                if !transaction.suppress_ordinary_sync_event
-                    && transaction.sync_role == crate::sync::SyncRole::Replica
-                {
-                    // The immutable commit and ref are the durable outbox.
-                    // `build_sync_push` discovers unpublished local heads; no second
-                    // row-pack queue is maintained.
-                    transaction.await_durable_commit = true;
-                }
-                let materialized = match commit::commit_prepared_writes_with_parent_heads(
-                    &transaction.binary_cas,
-                    &transaction.tracked_state,
-                    Some(transaction.sql_schema_snapshot.as_ref()),
-                    Some(runtime_functions),
-                    &transaction.active_account_id,
-                    &commit_parent_heads,
-                    &mut read,
-                    &branch_checkpoint_bridges,
-                    capture_sync_commits,
-                    &restore_targets,
-                    prepared_writes,
-                )
+                return Err(error);
+            }
+            // Validate and materialize from one coherent storage snapshot. The
+            // final write's tracked-state precondition fences the decisions made
+            // here, including plugin-produced prepared rows.
+            let commit_read_storage = transaction.storage.clone();
+            let commit_read = commit_read_storage
+                .begin_read(StorageReadOptions::default())
+                .await?;
+            // SAFETY: `commit_read_storage` is an `Arc` retained through commit,
+            // and the transaction drops this read before its storage field.
+            let commit_read = unsafe { assume_static_storage_read::<StorageImpl>(commit_read) };
+            let mut read = SharedStorageAdapterRead::new(commit_read);
+            // Commit-time reconciliation and validation must all observe this
+            // current coherent snapshot, while user statements above observed the
+            // snapshot retained from transaction open.
+            transaction.opening_read = read.clone();
+            if let Err(error) = transaction
+                .reconcile_stale_disjoint_writes(&read, &mut prepared_writes)
                 .instrument(tracing::debug_span!(
                     target: "lix_perf",
-                    "lix.perf.transaction_materialization"
+                    "lix.perf.transaction_reconcile_stale"
                 ))
                 .await
+            {
+                transaction
+                    .discard_pending_plugin_actor_publications()
+                    .await;
+                return Err(error);
+            }
+            let branch_checkpoint_bridges = match transaction
+                .resolve_pending_branch_checkpoint_replacements(&read, &prepared_writes)
+                .await
+            {
+                Ok(branch_checkpoint_bridges) => branch_checkpoint_bridges,
+                Err(error) => {
+                    transaction
+                        .discard_pending_plugin_actor_publications()
+                        .await;
+                    return Err(error);
+                }
+            };
+            let restore_targets = std::mem::take(&mut transaction.pending_restore_targets);
+            let commit_parent_heads = match commit::resolve_prepared_commit_parent_heads(
+                transaction.branch_ctx.as_ref(),
+                &read,
+                &prepared_writes,
+                true,
+            )
+            .await
+            {
+                Ok(commit_parent_heads) => commit_parent_heads,
+                Err(error) => {
+                    transaction
+                        .discard_pending_plugin_actor_publications()
+                        .await;
+                    return Err(error);
+                }
+            };
+            if let Err(error) = Self::attach_checkpoint_branch_parents(
+                &read,
+                &mut prepared_writes,
+                &commit_parent_heads,
+            )
+            .await
+            {
+                transaction
+                    .discard_pending_plugin_actor_publications()
+                    .await;
+                return Err(error);
+            }
+            if let Err(error) = transaction
+                .validate_prepared_writes_by_branch(&read, &mut prepared_writes)
+                .instrument(tracing::debug_span!(
+                    target: "lix_perf",
+                    "lix.perf.transaction_validation"
+                ))
+                .await
+            {
+                transaction
+                    .discard_pending_plugin_actor_publications()
+                    .await;
+                return Err(error);
+            }
+            // The delta itself is projected out of the commit below, once
+            // addressable rows hold their final commit-delta change ids. Only its
+            // *projectability* is decided here, because the revision the cached
+            // views are keyed on has to be read before the commit publishes its
+            // successor.
+            let stages_projectable_filesystem_rows =
+                prepared_writes_stage_filesystem_rows(&prepared_writes)
+                    && !prepared_writes_require_filesystem_index_rebuild(&prepared_writes);
+            // A failed revision read must not collapse into "no revision yet".
+            // `None` is itself a live cache key — the state before the first
+            // filesystem commit — so treating an error as `None` would rekey
+            // entries built at an unknown revision onto this commit's successor and
+            // make a stale index reachable. The outer `Option` is "the read
+            // succeeded"; only that licenses a projection.
+            let loaded_filesystem_revision = if stages_projectable_filesystem_rows {
+                load_path_index_revision(&read).await.ok()
+            } else {
+                None
+            };
+            let filesystem_delta_projectable = loaded_filesystem_revision.is_some();
+            let previous_filesystem_revision = loaded_filesystem_revision.flatten();
+            let mut automatic_sync_writes = transaction.storage.new_write_set();
+            let mut automatic_sync_preconditions = Vec::new();
+            let capture_sync_commits = !transaction.suppress_ordinary_sync_event
+                && transaction.sync_role == crate::sync::SyncRole::Authority;
+            if !transaction.suppress_ordinary_sync_event
+                && transaction.sync_role == crate::sync::SyncRole::Replica
+            {
+                // The immutable commit and ref are the durable outbox.
+                // `build_sync_push` discovers unpublished local heads; no second
+                // row-pack queue is maintained.
+                transaction.await_durable_commit = true;
+            }
+            let materialized = match commit::commit_prepared_writes_with_parent_heads(
+                &transaction.binary_cas,
+                &transaction.tracked_state,
+                Some(transaction.sql_schema_snapshot.as_ref()),
+                Some(runtime_functions),
+                &transaction.active_account_id,
+                &commit_parent_heads,
+                &mut read,
+                &branch_checkpoint_bridges,
+                capture_sync_commits,
+                &restore_targets,
+                prepared_writes,
+            )
+            .instrument(tracing::debug_span!(
+                target: "lix_perf",
+                "lix.perf.transaction_materialization"
+            ))
+            .await
+            {
+                Ok(commit) => commit,
+                Err(error) => {
+                    transaction
+                        .discard_pending_plugin_actor_publications()
+                        .await;
+                    return Err(error);
+                }
+            };
+            let staged_sync_event = if capture_sync_commits {
+                // Consume the exact controls produced by materialization instead
+                // of predicting checkpoint/restore semantics from prepared rows.
+                // The event still joins the same atomic storage commit below.
+                match crate::sync::stage_repository_transaction_event(
+                    &read,
+                    &mut automatic_sync_writes,
+                    &mut automatic_sync_preconditions,
+                    &materialized.sync_commits,
+                    &materialized.published_branch_controls,
+                )
+                .await
                 {
-                    Ok(commit) => commit,
+                    Ok(event) => event,
                     Err(error) => {
                         transaction
                             .discard_pending_plugin_actor_publications()
                             .await;
                         return Err(error);
                     }
-                };
-                let staged_sync_event = if capture_sync_commits {
-                    // Consume the exact controls produced by materialization instead
-                    // of predicting checkpoint/restore semantics from prepared rows.
-                    // The event still joins the same atomic storage commit below.
-                    match crate::sync::stage_repository_transaction_event(
-                        &read,
-                        &mut automatic_sync_writes,
-                        &mut automatic_sync_preconditions,
-                        &materialized.sync_commits,
-                        &materialized.published_branch_controls,
-                    )
-                    .await
-                    {
-                        Ok(event) => event,
-                        Err(error) => {
-                            transaction
-                                .discard_pending_plugin_actor_publications()
-                                .await;
-                            return Err(error);
-                        }
-                    }
-                } else {
-                    None
-                };
-                if staged_sync_event.is_some() {
-                    transaction.await_durable_commit = true;
                 }
-                if let Some(staged_sync_event) = &staged_sync_event
-                    && let Err(error) = crate::sync::validate_repository_transaction_event_transfer(
-                        staged_sync_event,
-                        &materialized.sync_commits,
-                    )
-                {
-                    transaction
-                        .discard_pending_plugin_actor_publications()
-                        .await;
-                    return Err(error);
-                }
-                let mut writes = materialized.writes;
-                let materialization_preconditions = materialized.preconditions;
-                let filesystem_delta_rows = if filesystem_delta_projectable {
-                    materialized.filesystem_delta_rows
-                } else {
-                    Vec::new()
-                };
-                let next_catalog_revision =
-                    catalog_revision_changed.then(|| stage_catalog_revision(&mut writes));
-                if tracked_state_changed {
-                    StorageAdapter::<StorageImpl>::stage_tracked_mutation_revision(&mut writes);
-                }
-                writes.extend(automatic_sync_writes);
-                if let Some(metadata_writes) = transaction.atomic_metadata_writes.take() {
-                    writes.extend(metadata_writes);
-                }
-                let mut write_options = StorageWriteOptions::default();
-                write_options.await_durable = transaction.await_durable_commit;
+            } else {
+                None
+            };
+            if staged_sync_event.is_some() {
+                transaction.await_durable_commit = true;
+            }
+            if let Some(staged_sync_event) = &staged_sync_event
+                && let Err(error) = crate::sync::validate_repository_transaction_event_transfer(
+                    staged_sync_event,
+                    &materialized.sync_commits,
+                )
+            {
+                transaction
+                    .discard_pending_plugin_actor_publications()
+                    .await;
+                return Err(error);
+            }
+            let mut writes = materialized.writes;
+            let materialization_preconditions = materialized.preconditions;
+            let filesystem_delta_rows = if filesystem_delta_projectable {
+                materialized.filesystem_delta_rows
+            } else {
+                Vec::new()
+            };
+            let next_catalog_revision =
+                catalog_revision_changed.then(|| stage_catalog_revision(&mut writes));
+            if tracked_state_changed {
+                StorageAdapter::<StorageImpl>::stage_tracked_mutation_revision(&mut writes);
+            }
+            writes.extend(automatic_sync_writes);
+            if let Some(metadata_writes) = transaction.atomic_metadata_writes.take() {
+                writes.extend(metadata_writes);
+            }
+            let mut write_options = StorageWriteOptions::default();
+            write_options.await_durable = transaction.await_durable_commit;
+            write_options
+                .preconditions
+                .extend(materialization_preconditions);
+            write_options
+                .preconditions
+                .append(&mut automatic_sync_preconditions);
+            write_options
+                .preconditions
+                .append(&mut transaction.atomic_metadata_preconditions);
+            if requires_tracked_snapshot_fence {
+                write_options.preconditions.push(
+                    StorageAdapter::<StorageImpl>::tracked_mutation_revision_precondition(
+                        transaction.opening_tracked_mutation_revision.clone(),
+                    ),
+                );
+            }
+            if let Some((key, value)) = transaction.idempotency_receipt.take() {
+                writes.put(EXECUTE_IDEMPOTENCY_RECEIPT_SPACE, key.clone(), value);
+                // The mutation and this receipt share one atomic storage commit.
+                // A protocol acknowledgement may replay only from a durable
+                // receipt, so ask the storage to cross its durability boundary
+                // before it reports this commit as successful.
+                write_options.await_durable = true;
+                write_options.idempotency_key = Some(key.0.clone());
                 write_options
                     .preconditions
-                    .extend(materialization_preconditions);
-                write_options
-                    .preconditions
-                    .append(&mut automatic_sync_preconditions);
-                write_options
-                    .preconditions
-                    .append(&mut transaction.atomic_metadata_preconditions);
-                if requires_tracked_snapshot_fence {
-                    write_options.preconditions.push(
-                        StorageAdapter::<StorageImpl>::tracked_mutation_revision_precondition(
-                            transaction.opening_tracked_mutation_revision.clone(),
-                        ),
-                    );
-                }
-                if let Some((key, value)) = transaction.idempotency_receipt.take() {
-                    writes.put(EXECUTE_IDEMPOTENCY_RECEIPT_SPACE, key.clone(), value);
-                    // The mutation and this receipt share one atomic storage commit.
-                    // A protocol acknowledgement may replay only from a durable
-                    // receipt, so ask the storage to cross its durability boundary
-                    // before it reports this commit as successful.
-                    write_options.await_durable = true;
-                    write_options.idempotency_key = Some(key.0.clone());
-                    write_options
-                        .preconditions
-                        .push(StoragePrecondition::KeyAbsent {
-                            space: EXECUTE_IDEMPOTENCY_RECEIPT_SPACE,
-                            key,
-                        });
-                }
-                Ok((
-                    writes,
-                    write_options,
-                    filesystem_delta_rows,
-                    previous_filesystem_revision,
-                    next_catalog_revision,
-                ))
-            })
-            .await?;
+                    .push(StoragePrecondition::KeyAbsent {
+                        space: EXECUTE_IDEMPOTENCY_RECEIPT_SPACE,
+                        key,
+                    });
+            }
+            Ok((
+                writes,
+                write_options,
+                filesystem_delta_rows,
+                previous_filesystem_revision,
+                next_catalog_revision,
+            ))
+        })
+        .await?;
         // Keep the prepared commit's storage borrow independent from the
         // transaction so deterministic preparation failures can still drain
         // prospective plugin actor documents before returning.
@@ -2826,33 +2824,24 @@ where
                     )
                 })?;
             let schema_fingerprint = schema_plan.fingerprint().bytes();
-            let base_row = base
-                .decoded_snapshot
-                .as_ref()
-                .ok_or_else(|| {
-                    LixError::new(
-                        LixError::CODE_INTERNAL_ERROR,
-                        "plugin-owned base row is missing its native typed snapshot",
-                    )
-                })?;
-            let a_row = a
-                .decoded_snapshot
-                .as_ref()
-                .ok_or_else(|| {
-                    LixError::new(
-                        LixError::CODE_INTERNAL_ERROR,
-                        "plugin-owned successor row is missing its native typed snapshot",
-                    )
-                })?;
-            let b_row = b
-                .decoded_snapshot
-                .as_ref()
-                .ok_or_else(|| {
-                    LixError::new(
-                        LixError::CODE_INTERNAL_ERROR,
-                        "plugin-owned successor row is missing its native typed snapshot",
-                    )
-                })?;
+            let base_row = base.decoded_snapshot.as_ref().ok_or_else(|| {
+                LixError::new(
+                    LixError::CODE_INTERNAL_ERROR,
+                    "plugin-owned base row is missing its native typed snapshot",
+                )
+            })?;
+            let a_row = a.decoded_snapshot.as_ref().ok_or_else(|| {
+                LixError::new(
+                    LixError::CODE_INTERNAL_ERROR,
+                    "plugin-owned successor row is missing its native typed snapshot",
+                )
+            })?;
+            let b_row = b.decoded_snapshot.as_ref().ok_or_else(|| {
+                LixError::new(
+                    LixError::CODE_INTERNAL_ERROR,
+                    "plugin-owned successor row is missing its native typed snapshot",
+                )
+            })?;
             if [base_row, a_row, b_row]
                 .into_iter()
                 .any(|row| row.schema_fingerprint != schema_fingerprint)
@@ -8005,6 +7994,39 @@ where
         Ok(commit_id)
     }
 
+    /// Stages the constant-work checkpoint boundary used by the SDK API.
+    ///
+    /// The metadata-only commit uses the prior checkpoint as its semantic first
+    /// parent and records the captured head as its physical complete-state
+    /// source. Interval compaction is not part of foreground publication.
+    pub(crate) fn stage_checkpoint_boundary_commit(
+        &self,
+        branch_id: String,
+        previous_checkpoint_commit_id: CommitId,
+        recovered_head_commit_id: CommitId,
+        interval_has_commits: bool,
+        gc_state: CheckpointGcState,
+    ) -> Result<String, LixError> {
+        let commit_id = self.staged_writes.stage_selected_commit_change_refs(
+            branch_id.clone(),
+            StagedCommitChangeBatch::default(),
+        )?;
+        let checkpoint_commit_id = CommitId::parse_lix(&commit_id, "staged checkpoint commit id")?;
+        self.staged_writes
+            .set_first_commit_parent(branch_id.clone(), previous_checkpoint_commit_id)?;
+        self.staged_writes
+            .add_checkpoint_publication(CheckpointPublication {
+                recovery_ref: CheckpointRecoveryRef {
+                    branch_id,
+                    recovered_head_commit_id,
+                    checkpoint_commit_id,
+                    interval_has_commits,
+                },
+                gc_state,
+            })?;
+        Ok(commit_id)
+    }
+
     pub(crate) fn stage_checkpoint_commit(
         &self,
         branch_id: String,
@@ -8070,32 +8092,6 @@ where
             .expect("open transaction read scope");
         self.tracked_state
             .reader(SharedStorageAdapterRead::new(read))
-    }
-
-    /// Attempts the current branch's checkpoint-relative direct diff from one
-    /// transaction-scoped snapshot. A missing or stale accelerator is an
-    /// ordinary `None`; callers retain the historical tracked-state oracle.
-    pub(crate) async fn working_diff_at_head(
-        &mut self,
-        branch_id: &str,
-        head_commit_id: CommitId,
-        request: &TrackedStateDiffRequest,
-    ) -> Result<Option<TrackedWorkingDiff>, LixError> {
-        let read = self.opening_read();
-        let Some(control) = BranchHeadControlContext::new()
-            .reader(read.clone())
-            .load(branch_id)
-            .await?
-        else {
-            return Ok(None);
-        };
-        if control.head_commit_id != head_commit_id {
-            return Ok(None);
-        }
-        TrackedHeadContext::new()
-            .reader(read)
-            .working_diff_for_control(branch_id, control, request)
-            .await
     }
 
     /// Returns the private compaction cursor bound to this transaction's
@@ -8359,8 +8355,7 @@ where
         let mut payloads = materialize_known_change_payloads(
             records.values().cloned(),
             ChangeRecordProjection::full(),
-        )
-        ?;
+        )?;
         drop(read);
         let branch_id = self.active_branch_id.clone();
         let mut identities = BTreeSet::new();
@@ -9350,9 +9345,7 @@ fn push_prepared_state_row_from_planned_parts(
     let untracked = row.untracked;
     let branch_id = row.branch_id.clone();
     let had_snapshot = rows.take_snapshot(row_index).is_some();
-    let metadata = rows
-        .take_metadata(row_index)
-        .map(stage_json_from_value);
+    let metadata = rows.take_metadata(row_index).map(stage_json_from_value);
     let row_pk = rows.take_row_pk(row_index).ok_or_else(|| {
         LixError::new(
             "LIX_ERROR_UNKNOWN",

--- a/packages/lix/src/transaction/staging.rs
+++ b/packages/lix/src/transaction/staging.rs
@@ -772,7 +772,7 @@ impl OrderedMutationJournal {
         self.overlay_lifecycle_certificate
     }
 
-    fn into_prepared(
+    pub(crate) fn into_prepared(
         self,
         functions: &FunctionProviderHandle,
     ) -> Result<PreparedStateBatch, LixError> {

--- a/packages/lix/tests/integration/sql/checkpoint.rs
+++ b/packages/lix/tests/integration/sql/checkpoint.rs
@@ -4,7 +4,7 @@ use serde_json::json;
 use super::select_rows;
 
 simulation_test!(
-    checkpoint_compacts_working_interval_and_projects_sql_surfaces,
+    checkpoint_marks_working_interval_and_projects_sql_surfaces,
     |sim| async move {
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
@@ -182,7 +182,8 @@ simulation_test!(
                 ),
             )
             .await,
-            vec![vec![Value::Text(initial_commit_id)]]
+            vec![vec![Value::Text(initial_commit_id.clone())]],
+            "checkpoint severs the working interval at the prior checkpoint"
         );
         assert_eq!(
             select_rows(

--- a/packages/lix/tests/migration_v68.rs
+++ b/packages/lix/tests/migration_v68.rs
@@ -36,7 +36,7 @@ async fn current_format_inspection_recognizes_v68_golden_snapshot() {
             .expect("v68 format inspection should succeed"),
         MigrationStatus::Required {
             from_version: 68,
-            to_version: 69,
+            to_version: 70,
         }
     );
 }
@@ -49,7 +49,7 @@ async fn migrates_external_v68_authority_and_plugin_and_engine_tombstones() {
         inspect_repository(&storage).await.unwrap(),
         MigrationStatus::Required {
             from_version: 68,
-            to_version: 69,
+            to_version: 70,
         }
     );
     let report = migrate_repository(storage.clone(), MigrationOptions::default())
@@ -148,19 +148,19 @@ async fn migrates_v68_fixture_and_reopens_with_current_and_history_rows() {
         .await
         .expect("v68 fixture should migrate");
     assert_eq!(report.from_version, 68);
-    assert_eq!(report.to_version, 69);
+    assert_eq!(report.to_version, 70);
     assert!(report.changes_rewritten >= 2);
     assert!(report.commit_members_rewritten >= 2);
     assert!(report.hot_rows_rewritten >= 1);
     assert_eq!(
         inspect_repository(&storage).await.unwrap(),
-        MigrationStatus::Current { version: 69 }
+        MigrationStatus::Current { version: 70 }
     );
     let retry = migrate_repository(storage.clone(), MigrationOptions::default())
         .await
         .expect("migration retry should be idempotent");
-    assert_eq!(retry.from_version, 69);
-    assert_eq!(retry.to_version, 69);
+    assert_eq!(retry.from_version, 70);
+    assert_eq!(retry.to_version, 70);
     assert_eq!(retry.changes_rewritten, 0);
 
     let migrated_snapshot = storage
@@ -173,6 +173,9 @@ async fn migrates_v68_fixture_and_reopens_with_current_and_history_rows() {
         .with_storage(reopened)
         .await
         .expect("migrated repository should cold-open");
+    lix.create_checkpoint()
+        .await
+        .expect("migrated v68 branch head should support a v70 checkpoint alias");
     let current = lix
         .execute("SELECT id, cells, order_key FROM csv_row", &[])
         .await
@@ -187,7 +190,7 @@ async fn migrates_v68_fixture_and_reopens_with_current_and_history_rows() {
         .expect("migrated history should read");
     assert_eq!(history.rows().len(), 2);
 
-    // The same v68 -> v69 publication must convert engine-owned rows, not
+    // The same v68 typed-row rewrite must convert engine-owned rows, not
     // merely the bundled plugin row used by this fixture. Reading both their
     // current and changelog projections forces native payload decoding after
     // the cold reopen.

--- a/packages/storage-rocksdb/src/rocksdb.rs
+++ b/packages/storage-rocksdb/src/rocksdb.rs
@@ -7,7 +7,7 @@ use std::collections::HashMap;
 use std::future::Future;
 use std::ops::Bound;
 use std::path::{Path, PathBuf};
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex, OnceLock, Weak};
 
 #[cfg(test)]
@@ -29,7 +29,7 @@ use rocksdb::{
 };
 use rocksdb::{DBRawIteratorWithThreadMode, Snapshot};
 use tempfile::TempDir;
-use tokio::sync::{Mutex as AsyncMutex, OwnedMutexGuard};
+use tokio::sync::{Mutex as AsyncMutex, Notify, OwnedMutexGuard};
 
 const WRITE_BUFFER_BYTES: usize = 64 * 1024 * 1024;
 /// Spare memtables per column family. Four buffers cap resident memtable memory
@@ -66,6 +66,10 @@ struct RocksDBInner {
     write_gate: WriteGate,
 }
 
+const BACKGROUND_MAINTENANCE_MAX_MUTATIONS: u64 = 4_096;
+const BACKGROUND_MAINTENANCE_MAX_WRITTEN_BYTES: u64 = 4 * 1024 * 1024;
+const BACKGROUND_MAINTENANCE_MAX_PRECONDITIONS: usize = 16;
+
 #[allow(missing_debug_implementations)]
 pub struct RocksDBRead<'a> {
     db: &'a DB,
@@ -75,7 +79,8 @@ pub struct RocksDBRead<'a> {
 #[allow(missing_debug_implementations)]
 pub struct RocksDBWrite {
     inner: Arc<RocksDBInner>,
-    _writer_permit: OwnedMutexGuard<()>,
+    preconditions: Vec<Precondition>,
+    background_maintenance: bool,
     batch: WriteBatch,
     immutable_values: HashMap<Vec<u8>, Bytes>,
     stats: WriteStats,
@@ -211,11 +216,10 @@ impl Storage for RocksDB {
         opts: WriteOptions,
     ) -> impl Future<Output = Result<Self::Write<'_>, StorageError>> + Send {
         async move {
-            let writer_permit = self.inner.write_gate.acquire().await;
-            check_preconditions(&self.inner.db, &opts.preconditions)?;
             Ok(RocksDBWrite {
                 inner: Arc::clone(&self.inner),
-                _writer_permit: writer_permit,
+                preconditions: opts.preconditions,
+                background_maintenance: opts.background_maintenance,
                 batch: if opts.batch_capacity_hint_bytes == 0 {
                     WriteBatch::default()
                 } else {
@@ -628,19 +632,6 @@ impl StorageWrite for RocksDBWrite {
                         }
                         continue;
                     }
-                    if let Some(existing) = self
-                        .inner
-                        .db
-                        .get_cf(cf, physical_key.as_slice())
-                        .map_err(rocksdb_error)?
-                    {
-                        if existing.as_slice() != value.as_ref() {
-                            return Err(StorageError::Corruption(
-                                "immutable identity was assigned different bytes".to_string(),
-                            ));
-                        }
-                        continue;
-                    }
                     self.immutable_values
                         .insert(physical_key.clone(), value.clone());
                 }
@@ -724,6 +715,7 @@ impl StorageWrite for RocksDBWrite {
                     .delete_range_cf(cf, lower.as_slice(), upper.as_slice());
             } else {
                 let bounds = EncodedBounds::new(range);
+                let mut expanded_deletes = 0_u64;
                 for item in self.inner.db.iterator_cf(
                     cf,
                     IteratorMode::From(&bounds.lower_seek, Direction::Forward),
@@ -737,7 +729,10 @@ impl StorageWrite for RocksDBWrite {
                         break;
                     }
                     self.batch.delete_cf(cf, encoded_key);
+                    expanded_deletes = expanded_deletes.saturating_add(1);
                 }
+                self.stats.deleted_entries =
+                    self.stats.deleted_entries.saturating_add(expanded_deletes);
             }
             self.stats.deleted_ranges += 1;
             self.stats.storage_calls += 1;
@@ -747,6 +742,47 @@ impl StorageWrite for RocksDBWrite {
 
     fn commit(self) -> impl Future<Output = Result<CommitResult, StorageError>> + Send {
         async move {
+            // Build and sort the RocksDB batch before entering the serialized
+            // publication lane. Repository maintenance can contain an
+            // unbounded number of logical deletions; only its final atomic
+            // precondition check and backend write may contend with a
+            // foreground checkpoint.
+            let mutation_count = self
+                .stats
+                .put_entries
+                .saturating_add(self.stats.deleted_entries)
+                .saturating_add(self.stats.deleted_ranges);
+            if self.background_maintenance
+                && (mutation_count > BACKGROUND_MAINTENANCE_MAX_MUTATIONS
+                    || self.stats.written_bytes > BACKGROUND_MAINTENANCE_MAX_WRITTEN_BYTES
+                    || self.preconditions.len() > BACKGROUND_MAINTENANCE_MAX_PRECONDITIONS)
+            {
+                return Err(StorageError::Io(format!(
+                    "background maintenance publication exceeds hard cut: {mutation_count} mutations, {} bytes, {} preconditions",
+                    self.stats.written_bytes,
+                    self.preconditions.len(),
+                )));
+            }
+            let _writer_permit = self
+                .inner
+                .write_gate
+                .acquire(self.background_maintenance)
+                .await;
+            check_preconditions(&self.inner.db, &self.preconditions)?;
+            for (key, expected) in &self.immutable_values {
+                let cf = self
+                    .inner
+                    .db
+                    .cf_handle(IMMUTABLE_COLUMN_FAMILY)
+                    .expect("immutable column family is open");
+                if let Some(existing) = self.inner.db.get_cf(cf, key).map_err(rocksdb_error)?
+                    && existing.as_slice() != expected.as_ref()
+                {
+                    return Err(StorageError::Corruption(
+                        "immutable identity was assigned different bytes".to_string(),
+                    ));
+                }
+            }
             // `await_durable` means "do not acknowledge until the backend has
             // crossed its durable persistence boundary". For RocksDB that is
             // `sync = true`: the WAL append is fsynced before `write` returns,
@@ -990,7 +1026,102 @@ where
 
 #[cfg(test)]
 mod tests {
-    use super::{CoreProjection, ProjectedValue, logical_key_from_physical, project_owned_value};
+    use std::sync::{Arc, atomic::Ordering};
+
+    use super::{
+        BACKGROUND_MAINTENANCE_MAX_MUTATIONS, CoreProjection, ProjectedValue, RocksDB, WriteGate,
+        logical_key_from_physical, project_owned_value,
+    };
+    use bytes::Bytes;
+    use lix::storage::{
+        Key, PutBatch, PutEntry, SpaceId, Storage, StorageError, StorageSpace, StorageWrite,
+        StoredValue, WriteOptions,
+    };
+
+    #[tokio::test]
+    async fn foreground_writer_overtakes_queued_background_maintenance() {
+        let gate = Arc::new(WriteGate::new());
+        let initial = gate.acquire(false).await;
+        let (order_tx, mut order_rx) = tokio::sync::mpsc::unbounded_channel();
+
+        let background_gate = Arc::clone(&gate);
+        let background_tx = order_tx.clone();
+        let background = tokio::spawn(async move {
+            let _permit = background_gate.acquire(true).await;
+            background_tx.send("background").expect("receiver is open");
+        });
+        tokio::task::yield_now().await;
+
+        let foreground_gate = Arc::clone(&gate);
+        let foreground = tokio::spawn(async move {
+            let _permit = foreground_gate.acquire(false).await;
+            order_tx.send("foreground").expect("receiver is open");
+        });
+        tokio::task::yield_now().await;
+        drop(initial);
+
+        assert_eq!(order_rx.recv().await, Some("foreground"));
+        foreground.await.expect("foreground task succeeds");
+        assert_eq!(order_rx.recv().await, Some("background"));
+        background.await.expect("background task succeeds");
+    }
+
+    #[tokio::test]
+    async fn cancelled_foreground_waiter_does_not_starve_background_maintenance() {
+        let gate = Arc::new(WriteGate::new());
+        let initial = gate.acquire(false).await;
+        let foreground_gate = Arc::clone(&gate);
+        let foreground = tokio::spawn(async move {
+            let _permit = foreground_gate.acquire(false).await;
+        });
+        while gate.foreground_waiters.load(Ordering::Acquire) == 0 {
+            tokio::task::yield_now().await;
+        }
+        foreground.abort();
+        let _ = foreground.await;
+        assert_eq!(gate.foreground_waiters.load(Ordering::Acquire), 0);
+        drop(initial);
+
+        tokio::time::timeout(std::time::Duration::from_secs(1), gate.acquire(true))
+            .await
+            .expect("cancelled foreground waiter must wake background maintenance");
+    }
+
+    #[tokio::test]
+    async fn oversized_background_maintenance_is_rejected_before_the_writer_gate() {
+        let directory = tempfile::tempdir().unwrap();
+        let storage = RocksDB::open(directory.path()).unwrap();
+        let gate = storage.inner.write_gate.acquire(false).await;
+        let mut write = storage
+            .begin_write(WriteOptions {
+                background_maintenance: true,
+                ..WriteOptions::default()
+            })
+            .await
+            .unwrap();
+        let entries = (0..=BACKGROUND_MAINTENANCE_MAX_MUTATIONS)
+            .map(|index| PutEntry {
+                key: Key(Bytes::copy_from_slice(&index.to_be_bytes())),
+                value: StoredValue {
+                    bytes: Bytes::from_static(b"value"),
+                },
+            })
+            .collect();
+        write
+            .put_many(
+                StorageSpace::mutable(SpaceId(0x00ff_0002), "test.maintenance-cap"),
+                PutBatch { entries },
+            )
+            .await
+            .unwrap();
+
+        let error = tokio::time::timeout(std::time::Duration::from_secs(1), write.commit())
+            .await
+            .expect("hard-cut rejection must not wait for the occupied writer gate")
+            .expect_err("oversized maintenance must be rejected");
+        assert!(matches!(error, StorageError::Io(message) if message.contains("hard cut")));
+        drop(gate);
+    }
 
     #[test]
     fn logical_key_reuses_the_physical_key_allocation() {
@@ -1053,10 +1184,31 @@ fn rocksdb_open_error(error: rocksdb::Error, path: &Path) -> StorageError {
     }
 }
 
-#[derive(Default)]
+#[derive(Clone, Default)]
 #[allow(missing_debug_implementations)]
 struct WriteGate {
     state: Arc<AsyncMutex<()>>,
+    foreground_waiters: Arc<AtomicUsize>,
+    foreground_changed: Arc<Notify>,
+}
+
+struct ForegroundWaiterRegistration<'a> {
+    waiters: &'a AtomicUsize,
+    changed: &'a Notify,
+}
+
+impl<'a> ForegroundWaiterRegistration<'a> {
+    fn new(waiters: &'a AtomicUsize, changed: &'a Notify) -> Self {
+        waiters.fetch_add(1, Ordering::AcqRel);
+        Self { waiters, changed }
+    }
+}
+
+impl Drop for ForegroundWaiterRegistration<'_> {
+    fn drop(&mut self) {
+        self.waiters.fetch_sub(1, Ordering::AcqRel);
+        self.changed.notify_waiters();
+    }
 }
 
 impl WriteGate {
@@ -1064,7 +1216,32 @@ impl WriteGate {
         Self::default()
     }
 
-    async fn acquire(&self) -> OwnedMutexGuard<()> {
-        Arc::clone(&self.state).lock_owned().await
+    async fn acquire(&self, background_maintenance: bool) -> OwnedMutexGuard<()> {
+        if !background_maintenance {
+            let registration = ForegroundWaiterRegistration::new(
+                &self.foreground_waiters,
+                &self.foreground_changed,
+            );
+            let permit = Arc::clone(&self.state).lock_owned().await;
+            drop(registration);
+            return permit;
+        }
+        loop {
+            while self.foreground_waiters.load(Ordering::Acquire) != 0 {
+                let changed = self.foreground_changed.notified();
+                tokio::pin!(changed);
+                changed.as_mut().enable();
+                if self.foreground_waiters.load(Ordering::Acquire) == 0 {
+                    break;
+                }
+                changed.await;
+            }
+            let permit = Arc::clone(&self.state).lock_owned().await;
+            if self.foreground_waiters.load(Ordering::Acquire) == 0 {
+                return permit;
+            }
+            drop(permit);
+            tokio::task::yield_now().await;
+        }
     }
 }

--- a/packages/storage-rocksdb/tests/storage/rocksdb_specific.rs
+++ b/packages/storage-rocksdb/tests/storage/rocksdb_specific.rs
@@ -187,7 +187,7 @@ fn multi_key_delete_uses_exact_contiguous_key_ranges() {
 }
 
 #[test]
-fn same_process_writes_are_serialized_across_reopened_handles() {
+fn same_process_write_staging_is_concurrent_across_reopened_handles() {
     let temp_dir = tempfile::tempdir().expect("create temp dir");
     let path = temp_dir.path().join("storage.rocksdb");
     let storage_a = RocksDB::open(&path).expect("open first storage");
@@ -195,30 +195,18 @@ fn same_process_writes_are_serialized_across_reopened_handles() {
     let write_a =
         block_on(storage_a.begin_write(WriteOptions::default())).expect("begin first write");
 
-    let (attempt_tx, attempt_rx) = mpsc::channel();
     let (acquired_tx, acquired_rx) = mpsc::channel();
     let waiter = std::thread::spawn(move || {
-        attempt_tx.send(()).expect("signal write attempt");
         let write_b =
             block_on(storage_b.begin_write(WriteOptions::default())).expect("begin second write");
         acquired_tx.send(()).expect("signal write acquired");
         block_on(write_b.rollback()).expect("rollback second write");
     });
 
-    attempt_rx
-        .recv_timeout(Duration::from_secs(1))
-        .expect("second write should be attempted");
-    assert!(
-        acquired_rx
-            .recv_timeout(Duration::from_millis(100))
-            .is_err(),
-        "second write should wait while the first write is active"
-    );
-
-    block_on(write_a.rollback()).expect("rollback first write");
     acquired_rx
         .recv_timeout(Duration::from_secs(1))
-        .expect("second write should acquire after first write closes");
+        .expect("write staging should not hold the serialized commit lane");
+    block_on(write_a.rollback()).expect("rollback first write");
     waiter.join().expect("writer thread should finish");
 }
 

--- a/packages/storage-slatedb/src/slatedb.rs
+++ b/packages/storage-slatedb/src/slatedb.rs
@@ -8,7 +8,7 @@ use std::fmt;
 use std::future::Future;
 use std::ops::{Bound, Range};
 use std::path::{Path, PathBuf};
-use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering};
 use std::sync::{Arc, Condvar, Mutex, mpsc};
 use std::thread::JoinHandle;
 use std::time::{Duration, Instant, SystemTime};
@@ -1728,12 +1728,17 @@ pub struct SlateDBWrite {
     write_gate: WriteGate,
     writer_permit: Option<OwnedMutexGuard<()>>,
     preconditions: Vec<Precondition>,
+    background_maintenance: bool,
     await_durable: bool,
     base: Option<Arc<DbSnapshot>>,
     overlay: BTreeMap<Key, Option<Bytes>>,
     immutable_values: HashMap<Key, Bytes>,
     stats: WriteStats,
 }
+
+const BACKGROUND_MAINTENANCE_MAX_MUTATIONS: usize = 4_096;
+const BACKGROUND_MAINTENANCE_MAX_WRITTEN_BYTES: u64 = 4 * 1024 * 1024;
+const BACKGROUND_MAINTENANCE_MAX_PRECONDITIONS: usize = 16;
 
 /// Bounded values from immutable visible snapshots.
 ///
@@ -2599,6 +2604,7 @@ impl Storage for SlateDB {
                 write_gate: self.write_gate.clone(),
                 writer_permit: None,
                 preconditions: opts.preconditions,
+                background_maintenance: opts.background_maintenance,
                 // The engine sets this only for the atomic mutation plus
                 // idempotency-receipt commit. Its replay contract requires a
                 // durable receipt before the request can be acknowledged.
@@ -3456,7 +3462,7 @@ impl SlateDBWrite {
             return Ok(());
         }
         let wait_started = Instant::now();
-        let permit = self.write_gate.acquire().await;
+        let permit = self.write_gate.acquire(self.background_maintenance).await;
         if let Some(counters) = &self.immutable_value_store.counters {
             counters
                 .inner
@@ -3727,7 +3733,14 @@ impl StorageWrite for SlateDBWrite {
         range: KeyRange,
     ) -> impl Future<Output = Result<(), StorageError>> + Send {
         async move {
-            self.serialize_publication().await?;
+            // Foreground range deletion retains strict latest-at-publication
+            // semantics. Opportunistic repository maintenance is guarded by
+            // its own root/revision preconditions, so it may expand the range
+            // from a visible snapshot before taking the writer gate; a raced
+            // domain mutation rejects the final publication and is replanned.
+            if !self.background_maintenance {
+                self.serialize_publication().await?;
+            }
             let range = physical_range(space.id, range)?;
             let bounds = EncodedBounds::new(range.clone());
             if bounds.is_empty() {
@@ -3782,12 +3795,37 @@ impl StorageWrite for SlateDBWrite {
     fn commit(self) -> impl Future<Output = Result<CommitResult, StorageError>> + Send {
         async move {
             let mut this = self;
+            // Account the scale-dependent overlay before entering the
+            // serialized publication lane. Maintenance then holds the gate
+            // only for validation and atomic pipeline publication.
+            let overlay_entries = this.overlay.len();
+            let overlay_bytes = this
+                .overlay
+                .iter()
+                .map(|(key, value)| {
+                    key.0
+                        .len()
+                        .saturating_add(value.as_ref().map_or(0, Bytes::len))
+                })
+                .sum::<usize>();
+            if this.background_maintenance
+                && (overlay_entries > BACKGROUND_MAINTENANCE_MAX_MUTATIONS
+                    || this.stats.written_bytes > BACKGROUND_MAINTENANCE_MAX_WRITTEN_BYTES
+                    || this.preconditions.len() > BACKGROUND_MAINTENANCE_MAX_PRECONDITIONS)
+            {
+                return Err(StorageError::Io(format!(
+                    "background maintenance publication exceeds hard cut: {overlay_entries} mutations, {} bytes, {} preconditions",
+                    this.stats.written_bytes,
+                    this.preconditions.len(),
+                )));
+            }
             this.serialize_publication().await?;
             let Self {
                 worker,
                 write_pipeline,
                 point_cache,
                 writer_permit,
+                background_maintenance,
                 await_durable,
                 overlay,
                 stats,
@@ -3803,15 +3841,6 @@ impl StorageWrite for SlateDBWrite {
 
             worker.check_open()?;
             write_pipeline.terminal_error()?;
-            let overlay_entries = overlay.len();
-            let overlay_bytes = overlay
-                .iter()
-                .map(|(key, value)| {
-                    key.0
-                        .len()
-                        .saturating_add(value.as_ref().map_or(0, Bytes::len))
-                })
-                .sum::<usize>();
             let overlay = Arc::new(overlay);
             let completion = Arc::new(WriteCompletion::new());
             let (start_drainer, apply_backpressure) = {
@@ -3819,6 +3848,14 @@ impl StorageWrite for SlateDBWrite {
                     .state
                     .lock()
                     .unwrap_or_else(std::sync::PoisonError::into_inner);
+                if background_maintenance
+                    && write_pipeline_should_backpressure(
+                        state.pending_entries.saturating_add(overlay_entries),
+                        state.pending_bytes.saturating_add(overlay_bytes),
+                    )
+                {
+                    return Err(StorageError::WriteConflict);
+                }
                 // A cached snapshot remains logically correct through the
                 // publication overlay, but it must not outlive that overlay
                 // after persistence. Force the next reader to fetch a current
@@ -3850,8 +3887,8 @@ impl StorageWrite for SlateDBWrite {
                 state.draining = true;
                 let apply_backpressure =
                     write_pipeline_should_backpressure(state.pending_entries, state.pending_bytes);
-                (start_drainer, apply_backpressure)
-            };
+                Ok((start_drainer, apply_backpressure))
+            }?;
 
             if start_drainer {
                 let task_pipeline = write_pipeline.clone();
@@ -4772,6 +4809,27 @@ fn object_store_error(error: object_store::Error) -> StorageError {
 #[allow(missing_debug_implementations)]
 struct WriteGate {
     state: Arc<AsyncMutex<()>>,
+    foreground_waiters: Arc<AtomicUsize>,
+    foreground_changed: Arc<Notify>,
+}
+
+struct ForegroundWaiterRegistration<'a> {
+    waiters: &'a AtomicUsize,
+    changed: &'a Notify,
+}
+
+impl<'a> ForegroundWaiterRegistration<'a> {
+    fn new(waiters: &'a AtomicUsize, changed: &'a Notify) -> Self {
+        waiters.fetch_add(1, Ordering::AcqRel);
+        Self { waiters, changed }
+    }
+}
+
+impl Drop for ForegroundWaiterRegistration<'_> {
+    fn drop(&mut self) {
+        self.waiters.fetch_sub(1, Ordering::AcqRel);
+        self.changed.notify_waiters();
+    }
 }
 
 impl WriteGate {
@@ -4779,8 +4837,33 @@ impl WriteGate {
         Self::default()
     }
 
-    async fn acquire(&self) -> OwnedMutexGuard<()> {
-        Arc::clone(&self.state).lock_owned().await
+    async fn acquire(&self, background_maintenance: bool) -> OwnedMutexGuard<()> {
+        if !background_maintenance {
+            let registration = ForegroundWaiterRegistration::new(
+                &self.foreground_waiters,
+                &self.foreground_changed,
+            );
+            let permit = Arc::clone(&self.state).lock_owned().await;
+            drop(registration);
+            return permit;
+        }
+        loop {
+            while self.foreground_waiters.load(Ordering::Acquire) != 0 {
+                let changed = self.foreground_changed.notified();
+                tokio::pin!(changed);
+                changed.as_mut().enable();
+                if self.foreground_waiters.load(Ordering::Acquire) == 0 {
+                    break;
+                }
+                changed.await;
+            }
+            let permit = Arc::clone(&self.state).lock_owned().await;
+            if self.foreground_waiters.load(Ordering::Acquire) == 0 {
+                return permit;
+            }
+            drop(permit);
+            tokio::task::yield_now().await;
+        }
     }
 }
 
@@ -4790,6 +4873,92 @@ mod tests {
 
     const TEST_IMMUTABLE_SPACE: StorageSpace =
         StorageSpace::immutable(SpaceId(0x00ff_0001), "test.immutable");
+
+    #[tokio::test]
+    async fn foreground_writer_overtakes_queued_background_maintenance() {
+        let gate = Arc::new(WriteGate::new());
+        let initial = gate.acquire(false).await;
+        let (order_tx, mut order_rx) = tokio::sync::mpsc::unbounded_channel();
+
+        let background_gate = Arc::clone(&gate);
+        let background_tx = order_tx.clone();
+        let background = tokio::spawn(async move {
+            let _permit = background_gate.acquire(true).await;
+            background_tx.send("background").expect("receiver is open");
+        });
+        tokio::task::yield_now().await;
+
+        let foreground_gate = Arc::clone(&gate);
+        let foreground = tokio::spawn(async move {
+            let _permit = foreground_gate.acquire(false).await;
+            order_tx.send("foreground").expect("receiver is open");
+        });
+        tokio::task::yield_now().await;
+        drop(initial);
+
+        assert_eq!(order_rx.recv().await, Some("foreground"));
+        foreground.await.expect("foreground task succeeds");
+        assert_eq!(order_rx.recv().await, Some("background"));
+        background.await.expect("background task succeeds");
+    }
+
+    #[tokio::test]
+    async fn cancelled_foreground_waiter_does_not_starve_background_maintenance() {
+        let gate = Arc::new(WriteGate::new());
+        let initial = gate.acquire(false).await;
+        let foreground_gate = Arc::clone(&gate);
+        let foreground = tokio::spawn(async move {
+            let _permit = foreground_gate.acquire(false).await;
+        });
+        while gate.foreground_waiters.load(Ordering::Acquire) == 0 {
+            tokio::task::yield_now().await;
+        }
+        foreground.abort();
+        let _ = foreground.await;
+        assert_eq!(gate.foreground_waiters.load(Ordering::Acquire), 0);
+        drop(initial);
+
+        tokio::time::timeout(Duration::from_secs(1), gate.acquire(true))
+            .await
+            .expect("cancelled foreground waiter must wake background maintenance");
+    }
+
+    #[tokio::test]
+    async fn oversized_background_maintenance_is_rejected_before_the_writer_gate() {
+        let directory = tempfile::tempdir().unwrap();
+        let storage = SlateDB::open(directory.path()).unwrap();
+        let gate = storage.write_gate.acquire(false).await;
+        let mut write = storage
+            .begin_write(WriteOptions {
+                background_maintenance: true,
+                ..WriteOptions::default()
+            })
+            .await
+            .unwrap();
+        let entries = (0..=BACKGROUND_MAINTENANCE_MAX_MUTATIONS)
+            .map(|index| PutEntry {
+                key: Key(Bytes::copy_from_slice(&index.to_be_bytes())),
+                value: StoredValue {
+                    bytes: Bytes::from_static(b"value"),
+                },
+            })
+            .collect();
+        write
+            .put_many(
+                StorageSpace::mutable(SpaceId(0x00ff_0002), "test.maintenance-cap"),
+                PutBatch { entries },
+            )
+            .await
+            .unwrap();
+
+        let error = tokio::time::timeout(Duration::from_secs(1), write.commit())
+            .await
+            .expect("hard-cut rejection must not wait for the occupied writer gate")
+            .expect_err("oversized maintenance must be rejected");
+        assert!(matches!(error, StorageError::Io(message) if message.contains("hard cut")));
+        drop(gate);
+    }
+
     use async_trait::async_trait;
     use futures_util::stream::BoxStream;
     use lix::storage::{


### PR DESCRIPTION
## Summary

- publish checkpoints as a complete-state alias to the maintained persistent branch root, keeping foreground checkpoint creation independent of repository scale
- move reclamation and compaction work into bounded, restartable background slices with writer priority and cancellation-safe adapter gates
- preserve canonical wire aliases and their transitive dependencies through pre-push GC, with atomic sidecar lifecycle cleanup
- migrate legacy repositories and synchronize the new state-alias representation with protocol v70/server protocol v3
- add scale profiling, hard foreground caps, migration/sync coverage, and checkpoint performance documentation

## Profile and benchmark evidence

10,000-file repository with 1,000 checkpoint intervals:

| Adapter | checkpoint p50 | p95 | p99 | max |
| --- | ---: | ---: | ---: | ---: |
| RocksDB | 0.472 ms | 0.563 ms | 0.671 ms | 1.482 ms |
| SlateDB | 0.632 ms | 0.923 ms | 1.058 ms | 1.674 ms |

Foreground hard cuts are scale-independent: at most 5 views, 2 scan pages / 16 scan rows, 1 transaction, and fixed point-write/allocation ceilings. Wide cleanup is fenced and resumed in background slices.

The scan census decodes 20,000 rows while allocating 130 key buffers (0.0065 allocations per row), below the 0.125 hard ceiling.

## Validation

- cargo test -p lix --features all-simulations
  - 3,225 passed; 0 failed; 26 ignored
  - all external integration tests and doctests passed
- cargo clippy --workspace --all-targets --all-features -- -D warnings
- cargo clippy --locked --manifest-path tooling/Cargo.toml --workspace --all-targets --all-features -- -D warnings
- full sync-mode e2e suite: 14 passed; 0 failed
- focused pre-push GC, sidecar lifecycle, and scan census tests
- cargo fmt --all -- --check
- git diff --check
- independent subagent reviews: correctness, performance, and test coverage all approved with no blockers