### PR TITLE
fix(lix): segment mixed-schema commit deltas

### DIFF
--- a/packages/lix/src/session/execute.rs
+++ b/packages/lix/src/session/execute.rs
@@ -7861,6 +7861,70 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn execute_batch_commits_rows_from_multiple_typed_schemas() {
+        let session = open_session().await;
+        let first_schema = serde_json::json!({
+            "$schema": "https://lix.dev/schema-v1.json",
+            "key": "mixed_batch_first",
+            "columns": [
+                { "name": "id", "type": "text", "nullable": false },
+                { "name": "value", "type": "text", "nullable": false },
+            ],
+            "primary_key": ["id"],
+        });
+        let second_schema = serde_json::json!({
+            "$schema": "https://lix.dev/schema-v1.json",
+            "key": "mixed_batch_second",
+            "columns": [
+                { "name": "id", "type": "text", "nullable": false },
+                { "name": "value", "type": "text", "nullable": false },
+                { "name": "enabled", "type": "boolean", "nullable": false },
+            ],
+            "primary_key": ["id"],
+        });
+        for schema in [first_schema, second_schema] {
+            session
+                .execute(
+                    "INSERT INTO lix_registered_schema (schema_key, value) VALUES (CAST($1 AS JSONB) ->> 'key', CAST($1 AS JSONB))",
+                    &[Value::Text(schema.to_string())],
+                )
+                .await
+                .expect("register typed schema");
+        }
+
+        session
+            .execute_batch(&[
+                ExecuteBatchStatement {
+                    label: None,
+                    sql: "INSERT INTO mixed_batch_first (id, value) VALUES ($1, $2)".to_owned(),
+                    params: vec![
+                        Value::Text("first".to_owned()),
+                        Value::Text("one".to_owned()),
+                    ],
+                },
+                ExecuteBatchStatement {
+                    label: None,
+                    sql: "INSERT INTO mixed_batch_second (id, value, enabled) VALUES ($1, $2, $3)".to_owned(),
+                    params: vec![
+                        Value::Text("second".to_owned()),
+                        Value::Text("two".to_owned()),
+                        Value::Boolean(true),
+                    ],
+                },
+            ])
+            .await
+            .expect("one logical batch may atomically commit several typed schemas");
+
+        for table in ["mixed_batch_first", "mixed_batch_second"] {
+            let result = session
+                .execute(&format!("SELECT COUNT(*) AS count FROM {table}"), &[])
+                .await
+                .expect("read committed mixed-schema row");
+            assert_eq!(result.rows()[0].get::<i64>("count").unwrap(), 1);
+        }
+    }
+
+    #[tokio::test]
     async fn certified_replacement_batch_revalidates_after_staged_schema_amendment() {
         let session = open_session().await;
         let schema = serde_json::json!({

--- a/packages/lix/src/tracked_state/storage.rs
+++ b/packages/lix/src/tracked_state/storage.rs
@@ -6487,8 +6487,19 @@ fn stage_commit_deltas_inner(
     let mut segment_start = 0usize;
     let mut sidecar_compressor = None;
     while segment_start < entries.len() {
-        let mut segment_end =
+        let segment_limit =
             (segment_start + GENERIC_COMMIT_DELTA_SEGMENT_MAX_ROWS).min(entries.len());
+        let first = crate::tracked_state::codec::decode_key_borrowed(
+            &entries[segment_start].key,
+        )?;
+        let schema_prefix = encode_schema_key_prefix(first.schema_key.as_ref());
+        // Native projection certificates have one schema fingerprint and one
+        // field layout. Preserve that physical invariant at construction time:
+        // a logical commit may span schemas, but an immutable segment may not.
+        let mut segment_end = entries[segment_start + 1..segment_limit]
+            .iter()
+            .position(|entry| !entry.key.starts_with(&schema_prefix))
+            .map_or(segment_limit, |offset| segment_start + 1 + offset);
         let segment_index = encoded_segments.len();
         let (encoded, assigned_entries, segment_assignments) = loop {
             let mut candidate = entries[segment_start..segment_end].to_vec();


### PR DESCRIPTION
## Problem

A tracked `executeBatch` containing rows from multiple Schema v1 tables fails durable commit-delta certification when their field layouts differ. This breaks inlang nested inserts, which atomically write bundle, message, and variant rows.

## Fix

Preserve the homogeneous-schema invariant at the physical storage boundary: sorted logical commit rows are split into immutable commit-delta segments at encoded schema-key boundaries. The logical transaction remains atomic and native projection certification remains strict.

No validation fallback is introduced.

## Regression test

Adds an end-to-end test that registers two typed schemas with different layouts, writes both in one `executeBatch`, and verifies both rows commit.

Locally verified:

```
cargo fmt --all -- --check
git diff --check
cargo test -p lix execute_batch_commits_rows_from_multiple_typed_schemas --lib
```