### PR TITLE
fix(lix): resolve authored segmented locators

### DIFF
--- a/packages/lix/src/tracked_state/storage.rs
+++ b/packages/lix/src/tracked_state/storage.rs
@@ -19792,8 +19792,8 @@ mod tests {
         stage_commit_deltas(&mut writes, &deltas).expect("packed deltas should stage");
         assert_eq!(
             writes.stats().staged_puts,
-            7,
-            "generic history keeps three read-friendly segments plus an atomic header, catalog, directory root, and semantic owner"
+            8,
+            "generic history keeps four schema-bounded read-friendly segments plus an atomic header, catalog, directory root, and semantic owner"
         );
         storage
             .commit_write_set(writes, StorageWriteOptions::default())

--- a/packages/lix/src/tracked_state/storage.rs
+++ b/packages/lix/src/tracked_state/storage.rs
@@ -7001,6 +7001,12 @@ enum DirectChangeRecordRoute {
     NotOwned(DirectNotOwnedReason),
 }
 
+#[derive(Clone, Copy)]
+enum AuthoredCoordinatePolicy {
+    Reject,
+    MatchExplicitLocator,
+}
+
 impl From<super::mutation_directory::MutationDirectoryNotOwnedReason> for DirectNotOwnedReason {
     fn from(reason: super::mutation_directory::MutationDirectoryNotOwnedReason) -> Self {
         match reason {
@@ -7228,6 +7234,7 @@ async fn route_direct_change_records_for_state(
                     .map(|&index| locators[index])
                     .collect::<Vec<_>>(),
                 runs,
+                AuthoredCoordinatePolicy::Reject,
             )
             .await?
             {
@@ -7302,13 +7309,18 @@ async fn route_direct_change_records_for_state(
                 let locator_index = unique_locator_indices[selector_index];
                 let locator = locators[locator_index];
                 let route = match state.mutations.direct_coordinate_owned(0, locator.ordinal) {
-                    Some(direct) => route_change_at_locator_from_decoded(
-                        &leaf,
-                        &payloads,
-                        locator,
-                        &state.change_account_id,
-                        direct,
-                    )?,
+                    Some(false) => {
+                        DirectChangeRecordRoute::NotOwned(DirectNotOwnedReason::AuthoredCoordinate)
+                    }
+                    Some(true) => DirectChangeRecordRoute::Owned(
+                        decode_change_at_locator_from_decoded(
+                            &leaf,
+                            &payloads,
+                            locator,
+                            &state.change_account_id,
+                        )?
+                        .change_record,
+                    ),
                     None => {
                         return Err(replacement_payload_error(
                             "inline direct coordinate omitted authenticated ownership",
@@ -7421,6 +7433,7 @@ async fn load_physical_direct_change_records(
     coordinates: &[super::mutation_directory::MutationDirectoryDirectCoordinate],
     locators: &[CommitDeltaChangeLocator],
     runs: Vec<super::mutation_directory::MutationDirectoryPartRun>,
+    authored_coordinate_policy: AuthoredCoordinatePolicy,
 ) -> Result<Vec<(usize, DirectChangeRecordRoute)>, LixError> {
     #[cfg(any(test, feature = "storage-benches"))]
     super::mutation_directory::record_direct_external_parts_loaded(runs.len());
@@ -7539,6 +7552,7 @@ async fn load_physical_direct_change_records(
                     locator,
                     &state.change_account_id,
                     direct,
+                    authored_coordinate_policy,
                 )?,
                 None => {
                     return Err(replacement_payload_error(
@@ -7935,6 +7949,7 @@ async fn load_selected_change_records_from_state(
                 &coordinates,
                 &unique_locators,
                 runs,
+                AuthoredCoordinatePolicy::MatchExplicitLocator,
             )
             .await?;
             let mut records = (0..unique_locators.len()).map(|_| None).collect::<Vec<_>>();
@@ -8148,11 +8163,17 @@ fn route_change_at_locator_from_decoded<S>(
     locator: CommitDeltaChangeLocator,
     account_id: &str,
     direct: bool,
+    authored_coordinate_policy: AuthoredCoordinatePolicy,
 ) -> Result<DirectChangeRecordRoute, LixError>
 where
     S: AsRef<[u8]>,
 {
     if !direct {
+        if matches!(authored_coordinate_policy, AuthoredCoordinatePolicy::Reject) {
+            return Ok(DirectChangeRecordRoute::NotOwned(
+                DirectNotOwnedReason::AuthoredCoordinate,
+            ));
+        }
         let ordinal = usize::from(locator.ordinal);
         let Some(entry) = leaf.entry(ordinal) else {
             return Err(replacement_payload_error(
@@ -18049,6 +18070,104 @@ mod tests {
                 .commit_id,
             explicit_commit,
         );
+    }
+
+    async fn assert_equal_id_authored_locator_requires_explicit_authority(
+        label: &str,
+        schemas: [&str; 2],
+        authored_segment_index: usize,
+        authored_ordinal: usize,
+        expected_direct_rows: &[u16],
+    ) {
+        let storage = StorageAdapter::new(Memory::new());
+        let commit_id = CommitId::with_change_address_space(uuid::Uuid::from_u128(
+            0x0192_0000_0000_7000_8000_6789_0000_0000,
+        ));
+        let mut fixtures = packed_commit_delta_fixtures()
+            .into_iter()
+            .take(2)
+            .collect::<Vec<_>>();
+        for (index, fixture) in fixtures.iter_mut().enumerate() {
+            fixture.schema_key = schemas[index].to_string();
+            fixture.row_pk = RowPk::single(format!("{label}-row-{index}"));
+            fixture.deleted = false;
+        }
+        fixtures[1].change_id = super::addressable_change_id(
+            commit_id,
+            authored_segment_index,
+            authored_ordinal,
+        )
+        .expect("authored test id should have direct-address geometry");
+
+        let deltas = commit_delta_refs(commit_id, &fixtures);
+        let mut writes = storage.new_write_set();
+        let staged = stage_addressable_commit_deltas(&mut writes, &deltas, &[true, false])
+            .expect("mixed direct and authored deltas should stage");
+        assert_eq!(
+            staged.mutation_inventory().direct_part_row_counts,
+            expected_direct_rows
+        );
+        assert_eq!(staged.locators.len(), 1);
+        assert_eq!(staged.locators[0].change_id, fixtures[1].change_id);
+        stage_change_locators(&mut writes, &staged.locators);
+        storage
+            .commit_write_set(writes, StorageWriteOptions::default())
+            .await
+            .expect("mixed direct and authored deltas should commit");
+
+        let read = storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("mixed direct and authored read should open");
+        let direct_locator = super::direct_change_locator(fixtures[1].change_id)
+            .expect("authored id should decode as a speculative direct locator");
+        let authority = super::load_direct_change_authority(&read, direct_locator.commit_id)
+            .await
+            .expect("direct authority should load");
+        let super::DirectChangeAuthority::Candidate(authority) = authority else {
+            panic!("mixed commit should publish direct authority");
+        };
+        let routes =
+            super::route_direct_change_records_for_state(&read, &authority, &[direct_locator])
+                .await
+                .expect("speculative direct route should resolve");
+        assert!(matches!(
+            routes.as_slice(),
+            [super::DirectChangeRecordRoute::NotOwned(
+                super::DirectNotOwnedReason::AuthoredCoordinate
+            )]
+        ));
+
+        let loaded = load_change_record_by_id(&read, fixtures[1].change_id)
+            .await
+            .expect("explicit authored locator should read")
+            .expect("explicit authored locator should resolve");
+        assert_eq!(loaded.row_pk, fixtures[1].row_pk);
+        assert_eq!(loaded.change_id, fixtures[1].change_id);
+    }
+
+    #[tokio::test]
+    async fn inline_authored_equal_direct_id_requires_explicit_locator() {
+        assert_equal_id_authored_locator_requires_explicit_authority(
+            "inline-equal-id",
+            ["same", "same"],
+            0,
+            1,
+            &[2],
+        )
+        .await;
+    }
+
+    #[tokio::test]
+    async fn segmented_authored_equal_direct_id_requires_explicit_locator() {
+        assert_equal_id_authored_locator_requires_explicit_authority(
+            "segmented-equal-id",
+            ["alpha", "beta"],
+            1,
+            0,
+            &[1, 1],
+        )
+        .await;
     }
 
     #[test]

--- a/packages/lix/src/tracked_state/storage.rs
+++ b/packages/lix/src/tracked_state/storage.rs
@@ -7302,18 +7302,13 @@ async fn route_direct_change_records_for_state(
                 let locator_index = unique_locator_indices[selector_index];
                 let locator = locators[locator_index];
                 let route = match state.mutations.direct_coordinate_owned(0, locator.ordinal) {
-                    Some(false) => {
-                        DirectChangeRecordRoute::NotOwned(DirectNotOwnedReason::AuthoredCoordinate)
-                    }
-                    Some(true) => DirectChangeRecordRoute::Owned(
-                        decode_change_at_locator_from_decoded(
-                            &leaf,
-                            &payloads,
-                            locator,
-                            &state.change_account_id,
-                        )?
-                        .change_record,
-                    ),
+                    Some(direct) => route_change_at_locator_from_decoded(
+                        &leaf,
+                        &payloads,
+                        locator,
+                        &state.change_account_id,
+                        direct,
+                    )?,
                     None => {
                         return Err(replacement_payload_error(
                             "inline direct coordinate omitted authenticated ownership",
@@ -7538,18 +7533,13 @@ async fn load_physical_direct_change_records(
                 .mutations
                 .direct_coordinate_owned(entry_index as usize, locator.ordinal)
             {
-                Some(false) => {
-                    DirectChangeRecordRoute::NotOwned(DirectNotOwnedReason::AuthoredCoordinate)
-                }
-                Some(true) => DirectChangeRecordRoute::Owned(
-                    decode_change_at_locator_from_decoded(
-                        &leaf,
-                        &payloads,
-                        locator,
-                        &state.change_account_id,
-                    )?
-                    .change_record,
-                ),
+                Some(direct) => route_change_at_locator_from_decoded(
+                    &leaf,
+                    &payloads,
+                    locator,
+                    &state.change_account_id,
+                    direct,
+                )?,
                 None => {
                     return Err(replacement_payload_error(
                         "direct coordinate omitted authenticated ownership",
@@ -8150,6 +8140,36 @@ where
         base_coordinate,
         selected_ref: false,
     })
+}
+
+fn route_change_at_locator_from_decoded<S>(
+    leaf: &DecodedLeafNodeRef,
+    payloads: &CommitDeltaPayloadIndex<S>,
+    locator: CommitDeltaChangeLocator,
+    account_id: &str,
+    direct: bool,
+) -> Result<DirectChangeRecordRoute, LixError>
+where
+    S: AsRef<[u8]>,
+{
+    if !direct {
+        let ordinal = usize::from(locator.ordinal);
+        let Some(entry) = leaf.entry(ordinal) else {
+            return Err(replacement_payload_error(
+                "authored change locator references an absent ordinal",
+            ));
+        };
+        let value = decode_value(entry.value)?;
+        let authored = matches!(payloads.decode(ordinal)?, CommitDeltaPayload::Authored(_));
+        if !authored || value.change_id != locator.change_id {
+            return Ok(DirectChangeRecordRoute::NotOwned(
+                DirectNotOwnedReason::AuthoredCoordinate,
+            ));
+        }
+    }
+    Ok(DirectChangeRecordRoute::Owned(
+        decode_change_at_locator_from_decoded(leaf, payloads, locator, account_id)?.change_record,
+    ))
 }
 
 pub(crate) fn validate_columnar_mutation_manifest(
@@ -17959,7 +17979,11 @@ mod tests {
         let mixed =
             stage_addressable_commit_deltas(&mut writes, &mixed_deltas, &[true, false, true])
                 .expect("mixed addressable deltas should stage");
-        assert_eq!(mixed.mutation_inventory().direct_part_row_counts, vec![3],);
+        assert_eq!(
+            mixed.mutation_inventory().direct_part_row_counts,
+            vec![2, 1],
+            "direct-address inventory follows the alpha and beta schema-bounded segments"
+        );
         assert_eq!(mixed.locators.len(), 1);
         assert_eq!(mixed.locators[0].change_id, fixtures[1].change_id);
         assert_ne!(mixed.assigned_change_ids[0], ChangeId::default());
@@ -21523,7 +21547,11 @@ mod tests {
         let inline_deltas = commit_delta_refs(inline_commit_id, &fixtures[..128]);
         stage_commit_deltas(&mut inline_writes, &inline_deltas)
             .expect("128 generic deltas should fit the history read boundary");
-        assert_eq!(inline_writes.stats().staged_puts, 3);
+        assert_eq!(
+            inline_writes.stats().staged_puts,
+            6,
+            "two schema-bounded segments require an atomic header, catalog, directory root, and semantic owner"
+        );
         storage
             .commit_write_set(inline_writes, StorageWriteOptions::default())
             .await
@@ -21533,7 +21561,11 @@ mod tests {
         let indexed_deltas = commit_delta_refs(indexed_commit_id, &fixtures);
         stage_commit_deltas(&mut indexed_writes, &indexed_deltas)
             .expect("129 generic deltas should use indexed segments");
-        assert_eq!(indexed_writes.stats().staged_puts, 6);
+        assert_eq!(
+            indexed_writes.stats().staged_puts,
+            7,
+            "three schema-bounded segments require an atomic header, catalog, directory root, and semantic owner"
+        );
         storage
             .commit_write_set(indexed_writes, StorageWriteOptions::default())
             .await


### PR DESCRIPTION
## What

Completes the schema-bounded commit-delta invariant introduced in #1582:

- separates speculative direct-address routing from authoritative explicit-locator routing;
- allows only the explicit route to resolve a non-direct coordinate, and only when the payload is authored and its stored ChangeId matches exactly;
- preserves direct-address collision routing even when an authored ChangeId equals the derivable direct ID;
- updates existing physical-layout regressions for schema-bounded segment counts.

## Why

A mixed direct/authored commit that became multi-segment could publish a correct explicit locator, but the segmented reader rejected every non-direct coordinate before checking the explicit authority. A shared routing helper would be too permissive: speculative direct lookup must never claim a clear ownership bit, even on an equal ID.

The fix encodes those as separate policies. No error is caught, suppressed, or rerouted to an alternate storage representation.

## Verification

- inline and segmented equal-ID collision regressions
- mixed authored/direct locator and collision regression
- short-part hole and out-of-range explicit-authority regressions
- packed schema-boundary point/sparse replay regressions
- cargo fmt --all -- --check
- full CI required before merge
