### PR TITLE
fix(sql): index untracked current-state writes

### DIFF
--- a/.changenotes/fix-untracked-indexed-joins.md
+++ b/.changenotes/fix-untracked-indexed-joins.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+Indexed equality reads now include rows written with `lixcol_untracked = true`, fixing point-filtered joins that could previously return null-extended children even though an unfiltered join found them.

--- a/packages/lix/src/sql_profile/point_join_scan_scaling.rs
+++ b/packages/lix/src/sql_profile/point_join_scan_scaling.rs
@@ -132,6 +132,41 @@ async fn nested_bundle_point_lookup_preserves_left_join_null_extension() {
         );
 }
 
+#[tokio::test]
+async fn nested_bundle_point_lookup_reads_untracked_only_rows() {
+    let session = seeded_untracked_session().await;
+    let unfiltered = session
+        .execute(
+            r#"SELECT bundle.id AS bundle_id, message.id AS message_id, variant.id AS variant_id FROM bundle LEFT JOIN message ON message."bundle_id" = bundle.id LEFT JOIN variant ON variant."message_id" = message.id"#,
+            &[],
+        )
+        .await
+        .expect("unfiltered nested bundle query");
+    assert_eq!(unfiltered.rows().len(), 1);
+
+    let filtered = session
+        .execute(
+            r#"SELECT bundle.id AS bundle_id, message.id AS message_id, variant.id AS variant_id FROM bundle LEFT JOIN message ON message."bundle_id" = bundle.id LEFT JOIN variant ON variant."message_id" = message.id WHERE bundle.id = $1"#,
+            &[Value::Text("bundle-untracked".to_string())],
+        )
+        .await
+        .expect("point-filtered nested bundle query");
+    assert_eq!(
+        filtered.rows().len(),
+        1,
+        "an exact parent identity must preserve its untracked child join rows"
+    );
+    let row = &filtered.rows()[0];
+    assert_eq!(
+        text(row.value("message_id").expect("message_id column")),
+        Some("message-untracked".to_string())
+    );
+    assert_eq!(
+        text(row.value("variant_id").expect("variant_id column")),
+        Some("variant-untracked".to_string())
+    );
+}
+
 type NestedRow = (String, Option<String>, Option<String>);
 
 async fn select_ids(session: &SessionContext<Memory>, bundle_id: &str) -> Vec<NestedRow> {
@@ -213,6 +248,46 @@ async fn seeded_session(bundles: usize) -> SessionContext<Memory> {
                 .expect("insert variant");
         }
     }
+    session
+}
+
+async fn seeded_untracked_session() -> SessionContext<Memory> {
+    let storage = Memory::default();
+    Engine::initialize(storage.clone())
+        .await
+        .expect("initialize fixture");
+    let engine = Engine::new(storage).await.expect("open engine");
+    let session = engine.open_session().await.expect("open session");
+    for schema in schemas() {
+        session
+            .execute(
+                "INSERT INTO lix_registered_schema (value) VALUES (CAST($1 AS JSONB))",
+                &[Value::Text(schema.to_string())],
+            )
+            .await
+            .expect("register schema");
+    }
+    session
+        .execute(
+            "INSERT INTO bundle (id, declarations, lixcol_untracked) VALUES ('bundle-untracked', CAST('[]' AS JSONB), true)",
+            &[],
+        )
+        .await
+        .expect("insert untracked bundle");
+    session
+        .execute(
+            r#"INSERT INTO message (id, "bundle_id", locale, selectors, lixcol_untracked) VALUES ('message-untracked', 'bundle-untracked', 'en', CAST('[]' AS JSONB), true)"#,
+            &[],
+        )
+        .await
+        .expect("insert untracked message");
+    session
+        .execute(
+            r#"INSERT INTO variant (id, "message_id", matches, pattern, lixcol_untracked) VALUES ('variant-untracked', 'message-untracked', CAST('[]' AS JSONB), CAST('[]' AS JSONB), true)"#,
+            &[],
+        )
+        .await
+        .expect("insert untracked variant");
     session
 }
 

--- a/packages/lix/src/transaction/commit.rs
+++ b/packages/lix/src/transaction/commit.rs
@@ -1663,6 +1663,36 @@ fn hot_index_writes_for_commit(
     (entries, witnesses)
 }
 
+/// Publishes the indexed view of one branch's current-state mutations into
+/// the same generation and write set as the rows themselves.
+///
+/// Retention is deliberately absent from this boundary: tracked and untracked
+/// rows share one serving generation, so a completeness witness is sound only
+/// when both publication paths pass through this funnel.
+async fn stage_hot_index_writes_for_commit(
+    read: &(impl StorageAdapterRead + ?Sized),
+    writes: &mut StorageWriteSet,
+    state_rows: &PreparedStateBatch,
+    branch_id: &str,
+    generation: CommitId,
+    parent_control: Option<&BranchHeadControl>,
+) -> Result<(), LixError> {
+    let (entries, witnesses) =
+        hot_index_writes_for_commit(state_rows, branch_id, parent_control);
+    if entries.is_empty() && witnesses.is_empty() {
+        return Ok(());
+    }
+    crate::hot_state::stage_hot_index_entries(
+        read,
+        writes,
+        branch_id,
+        generation,
+        &entries,
+        &witnesses,
+    )
+    .await
+}
+
 fn current_state_delta_from_state_row(
     row: PreparedStateRowRef<'_>,
 ) -> Result<crate::hot_state::CurrentStateDeltaRef<'_>, LixError> {
@@ -4521,19 +4551,15 @@ async fn stage_tracked_head(
         // The index plane is staged from this commit's own rows, so it is
         // correct whichever physical route above published them, and it lands
         // in the same write set as the rows themselves.
-        let (index_entries, index_witnesses) =
-            hot_index_writes_for_commit(state_rows, &root.branch_id, parent_control.as_ref());
-        if !index_entries.is_empty() || !index_witnesses.is_empty() {
-            crate::hot_state::stage_hot_index_entries(
-                read,
-                writes,
-                &root.branch_id,
-                generation,
-                &index_entries,
-                &index_witnesses,
-            )
-            .await?;
-        }
+        stage_hot_index_writes_for_commit(
+            read,
+            writes,
+            state_rows,
+            &root.branch_id,
+            generation,
+            parent_control.as_ref(),
+        )
+        .await?;
         if let Some(epoch) = working_diff_epoch {
             let next_epoch = TrackedWorkingDiffEpoch {
                 checkpoint_commit_id: epoch.checkpoint_commit_id,
@@ -4661,6 +4687,22 @@ async fn stage_tracked_head(
                 )
                 .await?;
         }
+        // The hot index describes the unified current-state generation, not
+        // just its tracked members. Schema registration may already have
+        // published a completeness witness for an empty indexed collection;
+        // every later untracked mutation must therefore append its index
+        // entries before the same control revision becomes visible. Skipping
+        // this on the history-free path leaves a valid-looking witness over a
+        // stale index and turns indexed equality probes into false negatives.
+        stage_hot_index_writes_for_commit(
+            read,
+            writes,
+            state_rows,
+            branch_id,
+            control.tracked_generation,
+            Some(&control),
+        )
+        .await?;
         control.current_state_revision = next_revision;
         control.note_schemas(deltas.iter().map(|delta| delta.schema_key));
         insert_direct_branch_control(&mut controls, branch_id, control)?;


### PR DESCRIPTION
## Root cause

Schema registration can publish a completeness witness for an empty foreign-key index. Untracked-only writes updated current state without publishing matching hot-index entries, leaving that stale witness authoritative. Exact parent-key propagation then produced false-negative child probes and null-extended LEFT JOIN rows.

## Fix

Route tracked and untracked current-state mutations through the same same-generation hot-index publication funnel. No query rewrite, compatibility path, or public API change.

## Regression

Adds an all-untracked parent/child/grandchild fixture and proves that unfiltered and parent-PK-filtered LEFT JOINs return the same concrete child IDs.

## Verification

- focused regression: 1 passed
- point-join provider suite: 3 passed
- transaction publication suite: 39 passed
- untracked SQL suite: 8 passed
- hot-index tests: 1 passed, 3 measurement probes ignored
- cargo fmt / diff check clean
