### PR TITLE
Fix manual releases with explicit versions

### DIFF
--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: Version to release and publish, without a leading v
+        description: Version to prepare, release, and publish, without a leading v
         required: true
         type: string
   push:
@@ -28,6 +28,10 @@ jobs:
       release_sha: ${{ steps.version.outputs.release_sha }}
       has_release: ${{ steps.version.outputs.has_release }}
 
+    permissions:
+      contents: write
+      pull-requests: write
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -38,27 +42,64 @@ jobs:
       - name: Validate release version
         id: version
         env:
+          GH_TOKEN: ${{ github.token }}
           MANUAL_VERSION: ${{ inputs.version }}
         run: |
           set -euo pipefail
           release_sha="$GITHUB_SHA"
+          if ! git merge-base --is-ancestor "$GITHUB_SHA" origin/main; then
+            echo "Release source $GITHUB_SHA is not reachable from origin/main." >&2
+            exit 1
+          fi
+
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
             if [[ "$MANUAL_VERSION" == v* ]]; then
               echo "Manual release version must not include a leading v." >&2
               exit 1
             fi
-            tag="$(node scripts/release-tag.mjs "$MANUAL_VERSION" | tail -n 1)"
+            tag="v${MANUAL_VERSION}"
+            if git rev-parse --verify --quiet "refs/tags/${tag}^{commit}" >/dev/null; then
+              echo "$tag already exists; choose a newer manual release version." >&2
+              exit 1
+            fi
+
+            node scripts/prepare-manual-release.mjs "$MANUAL_VERSION"
+            git diff --check
+            git config user.name "github-actions[bot]"
+            git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+            git add -- \
+              .changenotes \
+              CHANGELOG.md \
+              Cargo.lock \
+              Cargo.toml \
+              packages \
+              plugins \
+              tooling/Cargo.lock \
+              tooling/Cargo.toml
+            git commit -m "Release $tag"
+            release_sha="$(git rev-parse HEAD)"
+            manual_branch="manual-release/${tag}"
+            git push --force origin "HEAD:refs/heads/${manual_branch}"
+            existing_manual_pr="$(gh pr list \
+              --repo "$GITHUB_REPOSITORY" \
+              --state open \
+              --head "$manual_branch" \
+              --json number \
+              --jq 'length')"
+            if [ "$existing_manual_pr" = 0 ]; then
+              gh pr create \
+                --repo "$GITHUB_REPOSITORY" \
+                --base main \
+                --head "$manual_branch" \
+                --title "Release $tag" \
+                --body "Manually generated release commit for $tag. Merging this PR keeps main's Cargo, npm, lockfile, changelog, and changenote state aligned with the published release."
+            fi
           else
             tag="$(node scripts/release-tag.mjs | tail -n 1)"
           fi
           if [ -z "$tag" ] || [ "$tag" = "No release tag needed for this commit." ]; then
             echo "has_release=false" >> "$GITHUB_OUTPUT"
             exit 0
-          fi
-
-          if ! git merge-base --is-ancestor "$release_sha" origin/main; then
-            echo "Release source $release_sha is not reachable from origin/main." >&2
-            exit 1
           fi
 
           existing_tag_sha="$(git rev-parse --verify --quiet "refs/tags/${tag}^{commit}" || true)"

--- a/scripts/prepare-manual-release.mjs
+++ b/scripts/prepare-manual-release.mjs
@@ -1,0 +1,15 @@
+#!/usr/bin/env node
+import { prepareManualRelease } from "./release.mjs";
+
+try {
+	const requestedVersion = process.argv[2];
+	if (!requestedVersion) {
+		throw new Error("Usage: node scripts/prepare-manual-release.mjs <version>");
+	}
+	const result = prepareManualRelease(process.cwd(), requestedVersion);
+	console.log(`version=${result.version}`);
+	console.log(`changes=${result.changes.length}`);
+} catch (error) {
+	console.error(error.message);
+	process.exit(1);
+}

--- a/scripts/release.mjs
+++ b/scripts/release.mjs
@@ -63,6 +63,27 @@ export function bumpVersion(version, type) {
 	throw new Error(`Unsupported change type: ${type}`);
 }
 
+export function manualReleaseVersion(current, requested) {
+	const pattern = /^(\d+)\.(\d+)\.(\d+)$/;
+	const currentMatch = current.match(pattern);
+	const requestedMatch = requested.match(pattern);
+	if (!requestedMatch) {
+		throw new Error(`Unsupported manual release version: ${requested}`);
+	}
+	if (!currentMatch) {
+		throw new Error(`Unsupported current version: ${current}`);
+	}
+	const currentParts = currentMatch.slice(1).map(Number);
+	const requestedParts = requestedMatch.slice(1).map(Number);
+	const firstDifference = requestedParts.findIndex(
+		(part, index) => part !== currentParts[index],
+	);
+	if (firstDifference === -1 || requestedParts[firstDifference] < currentParts[firstDifference]) {
+		throw new Error(`Manual release version ${requested} must be greater than ${current}`);
+	}
+	return requested;
+}
+
 export function changeFiles(root) {
 	const dir = join(root, ".changenotes");
 	if (!existsSync(dir)) return [];
@@ -519,6 +540,26 @@ export function prepareRelease(root, { date = new Date().toISOString().slice(0, 
 	}
 	updateCargoLockfiles(root);
 	return { version, type, changes };
+}
+
+export function prepareManualRelease(
+	root,
+	requestedVersion,
+	{ date = new Date().toISOString().slice(0, 10), runCargo = execFileSync } = {},
+) {
+	const version = manualReleaseVersion(currentVersion(root), requestedVersion);
+	const changes = loadChanges(root);
+	updateCargoToml(root, version);
+	validateCargoLockstepVersions(root, version);
+	updatePackageVersion(root, version);
+	if (changes.length > 0) {
+		updateChangelog(root, version, date, changes);
+		for (const change of changes) {
+			rmSync(join(root, change.path));
+		}
+	}
+	updateCargoLockfiles(root, { runCargo });
+	return { version, changes };
 }
 
 export function releaseTagForHead(root) {

--- a/scripts/release.test.mjs
+++ b/scripts/release.test.mjs
@@ -8,6 +8,7 @@ import {
 	bumpVersion,
 	changelogEntry,
 	loadChanges,
+	manualReleaseVersion,
 	updateCargoToml,
 	updateCargoLockfiles,
 	updateChangelog,
@@ -49,6 +50,18 @@ test("bumpVersion applies semver changes", () => {
 	assert.equal(bumpVersion("0.6.0", "patch"), "0.6.1");
 	assert.equal(bumpVersion("0.6.0", "minor"), "0.7.0");
 	assert.equal(bumpVersion("0.6.0", "major"), "1.0.0");
+});
+
+test("manualReleaseVersion accepts an explicit newer stable version", () => {
+	assert.equal(manualReleaseVersion("0.12.3", "0.14.0"), "0.14.0");
+	assert.equal(manualReleaseVersion("0.12.3", "1.0.0"), "1.0.0");
+});
+
+test("manualReleaseVersion rejects malformed or non-incrementing versions", () => {
+	assert.throws(() => manualReleaseVersion("0.12.3", "v0.14.0"), /Unsupported manual release/);
+	assert.throws(() => manualReleaseVersion("0.12.3", "0.14"), /Unsupported manual release/);
+	assert.throws(() => manualReleaseVersion("0.12.3", "0.12.3"), /must be greater/);
+	assert.throws(() => manualReleaseVersion("0.12.3", "0.11.9"), /must be greater/);
 });
 
 test("loadChanges validates and parses fragments", () => {


### PR DESCRIPTION
Manual workflow dispatch now treats the requested version as the release source of truth.

It creates a release commit that updates Cargo/npm metadata and lockfiles, consumes changenotes into the changelog, publishes from that exact commit, and opens a PR to keep `main` aligned with the published source.

The requested version must be stable semver, omit the leading `v`, and be newer than the current workspace version.

Validated with `node --test scripts/release.test.mjs` and a full `0.14.0` preparation dry run.