### PR TITLE
fix(sync): diff sparse checkpoint snapshots

### DIFF
--- a/packages/lix/src/sync/repository.rs
+++ b/packages/lix/src/sync/repository.rs
@@ -10015,6 +10015,57 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn sparse_snapshot_can_diff_from_checkpoint_without_authored_bodies() {
+        let authority = open_lix().await.expect("authority should open");
+        authority
+            .execute(
+                "INSERT INTO lix_file (path, content) VALUES ($1, CAST($2 AS BYTEA))",
+                &[
+                    Value::Text("/history.md".to_owned()),
+                    Value::Text("before".to_owned()),
+                ],
+            )
+            .await
+            .expect("baseline file should commit");
+        let checkpoint = authority
+            .create_checkpoint()
+            .await
+            .expect("checkpoint should commit")
+            .commit_id;
+        authority
+            .execute(
+                "UPDATE lix_file SET content = CAST($1 AS BYTEA) WHERE path = $2",
+                &[
+                    Value::Text("after".to_owned()),
+                    Value::Text("/history.md".to_owned()),
+                ],
+            )
+            .await
+            .expect("post-checkpoint file update should commit");
+        let snapshot = authority
+            .pull_sync_repository(None, 1)
+            .await
+            .expect("snapshot should load");
+        let (_, head) = default_head(&snapshot);
+        let replica = replica_from_snapshot(&authority, &snapshot).await;
+
+        let diff = replica
+            .execute(
+                "SELECT schema_key, diff_type FROM lix_diff($1, $2)",
+                &[Value::Text(checkpoint), Value::Text(head)],
+            )
+            .await
+            .expect("checkpoint diff should use its authenticated sparse snapshot");
+        assert_eq!(diff.rows().len(), 1);
+        assert_eq!(
+            diff.rows()[0]
+                .get::<String>("diff_type")
+                .expect("diff type should decode"),
+            "modified",
+        );
+    }
+
+    #[tokio::test]
     async fn authority_rejects_a_stale_expected_checkpoint_coordinate() {
         let authority = open_lix().await.expect("authority should open");
         write_key_value(&authority, "checkpoint-cas", "baseline").await;

--- a/packages/lix/src/tracked_state/context.rs
+++ b/packages/lix/src/tracked_state/context.rs
@@ -1658,7 +1658,18 @@ where
             by_commit.entry(row.commit_id()).or_default().push(row);
         }
         for (commit_id, commit_rows) in by_commit {
+            // A sparse sync snapshot authenticates every selected row through
+            // a complete-state root while intentionally retaining only a
+            // snapshot row for the commit that originally authored it. The
+            // immutable payload remains routable through the snapshot's
+            // selected fallback locator, but the authored delta index may be
+            // outside even the bounded header frontier. In that case the
+            // authenticated root plus immutable payload is the complete local
+            // authority. If a commit delta is present, it must still match.
             let state = storage::load_point_replay_commit_state(&self.store, commit_id).await?;
+            if state.is_none() {
+                continue;
+            }
             let mut encoded_keys =
                 TrackedStateKeyBatchBuilder::with_row_capacity(commit_rows.len());
             for row in &commit_rows {
@@ -2578,6 +2589,36 @@ where
     /// Packed tracked changes intentionally do not have one global storage key
     /// per change id. Routing through their owning commit avoids scanning every
     /// changelog and commit-delta segment for a sparse diff.
+    async fn fill_sparse_snapshot_change_fallbacks(
+        &self,
+        commit_id: CommitId,
+        change_ids: &[ChangeId],
+        loaded: &mut [Option<ChangeRecord>],
+    ) -> Result<(), LixError> {
+        debug_assert_eq!(change_ids.len(), loaded.len());
+        if !loaded.iter().any(Option::is_none)
+            || storage::load_point_replay_commit_state(&self.store, commit_id)
+                .await?
+                .is_some()
+        {
+            return Ok(());
+        }
+        let missing = change_ids
+            .iter()
+            .zip(loaded.iter())
+            .filter_map(|(change_id, record)| record.is_none().then_some(*change_id))
+            .collect::<Vec<_>>();
+        let mut fallback = storage::load_change_records_by_ids(&self.store, &missing)
+            .await?
+            .into_iter();
+        for record in loaded {
+            if record.is_none() {
+                *record = fallback.next();
+            }
+        }
+        Ok(())
+    }
+
     async fn load_routed_diff_changes(
         &mut self,
         rows: &[&TrackedStateDiffRow],
@@ -2678,6 +2719,15 @@ where
                     }
                 }
             }
+            self.fill_sparse_snapshot_change_fallbacks(
+                commit_id,
+                &commit_rows
+                    .iter()
+                    .map(|row| row.change_id)
+                    .collect::<Vec<_>>(),
+                &mut loaded,
+            )
+            .await?;
             for (row, record) in commit_rows.into_iter().zip(loaded) {
                 let record = record.ok_or_else(|| {
                     LixError::new(
@@ -2784,6 +2834,15 @@ where
                     }
                 }
             }
+            self.fill_sparse_snapshot_change_fallbacks(
+                commit_id,
+                &commit_rows
+                    .iter()
+                    .map(|row| row.change_id())
+                    .collect::<Vec<_>>(),
+                &mut loaded,
+            )
+            .await?;
             for (row, record) in commit_rows.into_iter().zip(loaded) {
                 let record = record.ok_or_else(|| {
                     LixError::new(

--- a/packages/lix/src/tracked_state/storage.rs
+++ b/packages/lix/src/tracked_state/storage.rs
@@ -7693,7 +7693,7 @@ fn hydrate_compact_replacement_direct_run(
     Ok(())
 }
 
-async fn load_change_records_by_ids(
+pub(crate) async fn load_change_records_by_ids(
     store: &(impl StorageAdapterRead + ?Sized),
     change_ids: &[crate::changelog::ChangeId],
 ) -> Result<Vec<crate::changelog::ChangeRecord>, LixError> {


### PR DESCRIPTION
## Summary

- allow identity-only root diffs to use authenticated sparse snapshot rows when the original authored commit body is outside the local frontier
- resolve those rows through the canonical standalone change payload installed by sync bootstrap
- retain strict delta-index validation whenever an authored commit body is locally present
- add a regression covering checkpoint-to-head `lix_diff` on a fresh sparse replica

## Local verification

- `cargo test -p lix sparse_snapshot_can_diff_from_checkpoint_without_authored_bodies`
- `cargo test -p lix` (2,850 passed; 26 ignored)
- `cargo test -p lix --features all-simulations` (3,244 passed; 26 ignored)
- integration tests and doctests from both suites