### PR TITLE
fix(sync): hydrate checkpoint history precisely

### DIFF
--- a/packages/lix/src/sync/repository.rs
+++ b/packages/lix/src/sync/repository.rs
@@ -4814,6 +4814,60 @@ where
         Ok(pending)
     }
 
+    pub(crate) async fn sync_checkpoint_history_demand_ids(
+        &self,
+        commit_ids: &BTreeSet<String>,
+    ) -> Result<BTreeSet<String>, LixError> {
+        if commit_ids.is_empty() {
+            return Ok(BTreeSet::new());
+        }
+        let requested = commit_ids
+            .iter()
+            .map(|commit_id| {
+                let parsed =
+                    CommitId::parse_lix(commit_id, "sync checkpoint history demand commit id")?;
+                Ok((
+                    RowPk::uuid_from_canonical(&parsed.to_string())
+                        .expect("a canonical commit UUID is a canonical checkpoint row key"),
+                    commit_id.clone(),
+                ))
+            })
+            .collect::<Result<Vec<_>, LixError>>()?;
+        let adapter = self.storage_adapter();
+        let read = adapter.begin_read(StorageReadOptions::default()).await?;
+        let Some(global) = BranchHeadControlContext::new()
+            .reader(&read)
+            .load(crate::GLOBAL_BRANCH_ID)
+            .await?
+        else {
+            return Ok(BTreeSet::new());
+        };
+        let mut tracked = TrackedStateContext::new().reader(&read);
+        let rows = tracked
+            .scan_batch_at_commit(
+                &global.head_commit_id.to_string(),
+                &TrackedStateScanRequest {
+                    filter: TrackedStateFilter {
+                        schema_keys: vec![crate::checkpoint::CHECKPOINT_SCHEMA_KEY.to_owned()],
+                        row_pks: requested.iter().map(|(row_pk, _)| row_pk.clone()).collect(),
+                        ..TrackedStateFilter::default()
+                    },
+                    limit: Some(requested.len()),
+                    ..TrackedStateScanRequest::default()
+                },
+            )
+            .await?;
+        Ok(rows
+            .iter()
+            .filter_map(|row| {
+                requested
+                    .iter()
+                    .find(|(row_pk, _)| row_pk == row.row_pk())
+                    .map(|(_, commit_id)| commit_id.clone())
+            })
+            .collect())
+    }
+
     async fn complete_live_root_at_commit(
         &self,
         read: &(impl StorageAdapterRead + ?Sized),

--- a/packages/lix/src/sync/runtime.rs
+++ b/packages/lix/src/sync/runtime.rs
@@ -139,8 +139,9 @@ where
                 .map(|head| (branch.branch_id.as_str(), head))
         })
         .collect::<Vec<_>>();
+    let precise_history_heads = BTreeSet::new();
     let (history, mut rows) = futures_util::try_join!(
-        fetch_history_objects(transport, head_ids, 1, None),
+        fetch_history_objects(transport, head_ids, 1, None, &precise_history_heads),
         fetch_snapshot_rows(transport, &branch_targets),
     )?;
     let mut checkpoint_targets = Vec::new();
@@ -956,11 +957,18 @@ where
     if pending.is_empty() {
         return Ok(());
     }
+    // The hot global checkpoint catalog is part of bootstrap, even when the
+    // checkpoint bodies remain deferred. A point read of one of those known
+    // checkpoints needs exactly that authenticated boundary; fetching nearby
+    // checkpoint snapshots only adds latency. Non-checkpoint history demands
+    // keep wide pages so full file-history walks remain bounded in round trips.
+    let precise_heads = lix.sync_checkpoint_history_demand_ids(&pending).await?;
     let fetched = fetch_history_objects(
         transport,
         pending,
         super::MAX_SYNC_HISTORY_PAGE_SIZE,
         Some(SYNC_DEMAND_MAX_BOUNDARIES_PER_PAGE),
+        &precise_heads,
     )
     .await?;
     let boundary_targets = fetched
@@ -988,6 +996,7 @@ async fn fetch_history_objects<Transport>(
     pending: BTreeSet<String>,
     requested_page_limit: usize,
     max_boundaries_per_page: Option<usize>,
+    precise_heads: &BTreeSet<String>,
 ) -> Result<FetchedHistory, LixError>
 where
     Transport: SyncTransport,
@@ -995,8 +1004,12 @@ where
     let mut commits = BTreeMap::new();
     let mut commit_headers = BTreeMap::new();
     let mut boundaries = BTreeMap::new();
-    let mut history_page_limit = requested_page_limit;
     for head in pending {
+        let mut history_page_limit = if precise_heads.contains(&head) {
+            1
+        } else {
+            requested_page_limit
+        };
         let response = loop {
             let response =
                 fetch_history_page_adaptive(transport, &head, &mut history_page_limit).await?;
@@ -2500,6 +2513,7 @@ mod tests {
             BTreeSet::from([head.clone()]),
             super::super::MAX_SYNC_HISTORY_PAGE_SIZE,
             None,
+            &BTreeSet::new(),
         )
         .await
         .expect("deep head fetch succeeds");
@@ -3205,6 +3219,63 @@ mod tests {
             smaller_history_demand_page_limit(1, 1, 5, 4),
             None,
             "one indivisible merge commit retains all required boundaries",
+        );
+    }
+
+    #[tokio::test]
+    async fn hot_checkpoint_catalog_classifies_precise_history_demands() {
+        let lix = open_lix().await.expect("lix opens");
+        let checkpoint = lix
+            .create_checkpoint()
+            .await
+            .expect("checkpoint is created")
+            .commit_id;
+        let ordinary = uuid::Uuid::now_v7().to_string();
+        let requested = BTreeSet::from([checkpoint.clone(), ordinary]);
+
+        assert_eq!(
+            lix.sync_checkpoint_history_demand_ids(&requested)
+                .await
+                .expect("hot checkpoint catalog is readable"),
+            BTreeSet::from([checkpoint]),
+        );
+    }
+
+    #[tokio::test]
+    async fn precise_checkpoint_history_demand_skips_wide_page_probes() {
+        let (_replica, parent, _head, commits, commit_headers, history_boundaries, boundary_rows) =
+            history_fixture().await;
+        let calls = Arc::new(Mutex::new(Vec::new()));
+        let transport = HistoryTransport {
+            commits,
+            missing: BTreeSet::new(),
+            calls: Arc::clone(&calls),
+            max_history_items: Some(1),
+            fail_first_history: false,
+            commit_headers,
+            history_boundaries,
+            boundary_rows,
+            blobs: BTreeMap::new(),
+            blob_calls: Arc::new(Mutex::new(Vec::new())),
+            chunks: BTreeMap::new(),
+            chunk_calls: Arc::new(Mutex::new(Vec::new())),
+        };
+
+        let precise_heads = BTreeSet::from([parent.clone()]);
+        let fetched = fetch_history_objects(
+            &transport,
+            BTreeSet::from([parent.clone()]),
+            super::super::MAX_SYNC_HISTORY_PAGE_SIZE,
+            Some(SYNC_DEMAND_MAX_BOUNDARIES_PER_PAGE),
+            &precise_heads,
+        )
+        .await
+        .expect("precise history fetch succeeds");
+        assert_eq!(fetched.commits.len(), 1);
+        assert_eq!(
+            *calls.lock().expect("history calls lock"),
+            vec![vec![parent]],
+            "known checkpoint demand starts at one commit without probing a wide page",
         );
     }
 


### PR DESCRIPTION
## Summary
- classify demanded checkpoint IDs from the already-hot global checkpoint catalog
- fetch a known checkpoint as one authenticated boundary instead of hydrating neighboring full snapshots
- retain adaptive wide pages for non-checkpoint file-history walks
- cover precise page selection while retaining the 105-commit bounded-history E2E contract

## Tests
- `cargo test -p lix`
- `cargo test -p lix --features all-simulations`
- `cargo fmt --all -- --check`
- `cargo test --locked --manifest-path tooling/Cargo.toml --profile test -p lix_e2e --features sdk-tests,plugin-tests,server-protocol,storage-benches,slatedb,root-replay-trace --test sync_mode fresh_replica_lists_checkpoints_then_hydrates_file_history_in_bounded_pages`