### PR TITLE
fix(history): bound checkpoint file point lookups

### DIFF
--- a/packages/e2e/tests/sync_mode.rs
+++ b/packages/e2e/tests/sync_mode.rs
@@ -373,6 +373,76 @@ async fn fresh_replica_lists_checkpoints_then_hydrates_file_history_in_bounded_p
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn exact_checkpoint_file_history_hydrates_only_its_anchor_boundary() {
+    let authority = Arc::new(open_lix().await.expect("open authority"));
+    let inserted = authority
+        .execute(
+            "INSERT INTO lix_file (path, content) VALUES ('/bounded.md', CAST('version-00' AS BYTEA)) RETURNING id",
+            &[],
+        )
+        .await
+        .expect("create checkpointed file");
+    let file_id = inserted.rows()[0]
+        .get::<String>("id")
+        .expect("file id decodes");
+    let mut target_checkpoint = None;
+    for index in 0..12 {
+        authority
+            .execute(
+                "UPDATE lix_file SET content = CAST($1 AS BYTEA) WHERE id = $2",
+                &[
+                    Value::Text(format!("version-{index:02}")),
+                    Value::Text(file_id.clone()),
+                ],
+            )
+            .await
+            .expect("update checkpointed file");
+        let checkpoint = authority
+            .create_checkpoint()
+            .await
+            .expect("create file checkpoint")
+            .commit_id;
+        if index == 4 {
+            target_checkpoint = Some(checkpoint);
+        }
+    }
+    let target_checkpoint = target_checkpoint.expect("target checkpoint captured");
+
+    let probe = Arc::new(HttpProbe::default());
+    let (url, server_task) = serve(Arc::clone(&authority), Arc::clone(&probe)).await;
+    let replica_dir = TempDir::new().expect("replica tempdir");
+    let replica = open_replica(replica_dir.path(), &url).await;
+    let history_before = probe.history_gets.load(Ordering::Acquire);
+
+    let history = replica
+        .execute(
+            "SELECT id, path FROM lix_history('lix_file', $1) WHERE id = $2 ORDER BY lixcol_depth ASC LIMIT 1",
+            &[
+                Value::Text(target_checkpoint),
+                Value::Text(file_id.clone()),
+            ],
+        )
+        .await
+        .expect("exact checkpoint file history hydrates");
+    assert_eq!(history.rows().len(), 1);
+    assert_eq!(
+        history.rows()[0]
+            .get::<String>("path")
+            .expect("history path decodes"),
+        "/bounded.md",
+    );
+    assert_eq!(
+        probe.history_gets.load(Ordering::Acquire) - history_before,
+        1,
+        "a depth-ordered point lookup should hydrate only the selected checkpoint",
+    );
+
+    replica.close().await.expect("close replica");
+    stop_server(server_task).await;
+    authority.close().await.expect("close authority");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn fresh_bootstrap_pages_more_than_one_window_of_hot_rows() {
     let authority = Arc::new(open_lix().await.expect("open authority"));
     let statements = (0..OFFLINE_COMMIT_COUNT)

--- a/packages/lix/src/sql2/mod.rs
+++ b/packages/lix/src/sql2/mod.rs
@@ -17,6 +17,10 @@ mod plan;
 mod planning_cache;
 mod predicate_typecheck;
 mod providers;
+#[cfg(test)]
+pub(crate) use providers::{
+    file_history_anchor_probe_census, reset_file_history_anchor_probe_census,
+};
 mod read_only;
 mod result_metadata;
 mod row_batch;

--- a/packages/lix/src/sql2/providers/file_history.rs
+++ b/packages/lix/src/sql2/providers/file_history.rs
@@ -30,7 +30,9 @@ use super::columns::{Col, ColumnTable, ColumnTableError};
 use super::history_util::{
     ObservedTrackedStateOrdinal, ObservedTrackedStateRows, row_pk_json_array,
 };
-use super::spec::{PlannedScan, SpecTableProvider, TableSpec, projected_schema, scan_row_source};
+use super::spec::{
+    PlannedScan, SpecTableProvider, TableSpec, fetchable_scan_row_source, projected_schema,
+};
 use crate::sql2::SqlHistoryQuerySource;
 use crate::sql2::change_materialization::MaterializedChange;
 use crate::sql2::history_projection::{HistoryIdentityProjection, tombstone_identity_column_value};
@@ -145,10 +147,14 @@ where
         let metadata_projection = HistoryMetadataProjection::from_scan(&schema, filters);
         let public_predicate = FileHistoryPublicPredicate::from_filters(filters);
         let lookup_ids = FileHistoryLookupIds::from_public_predicate(&public_predicate);
+        let ordering = (lookup_ids.as_ref().is_some_and(|ids| ids.0.len() == 1)
+            && route.as_of_commit_ids.len() == 1
+            && schema.field_with_name(HISTORY_COL_DEPTH).is_ok())
+        .then(|| HISTORY_COL_DEPTH.to_string());
         Ok(PlannedScan {
             schema: Arc::clone(&schema),
-            ordering: None,
-            source: scan_row_source(
+            ordering,
+            source: fetchable_scan_row_source(
                 Arc::clone(&schema),
                 (
                     Arc::clone(&self.commit_graph),
@@ -161,6 +167,7 @@ where
                     schema,
                     metadata_projection,
                 ),
+                limit,
                 move |(
                     commit_graph,
                     query_source,
@@ -171,25 +178,41 @@ where
                     lookup_ids,
                     schema,
                     metadata_projection,
-                )| async move {
-                    let mut rows = if limit == Some(0) {
+                ), runtime_limit| async move {
+                    let mut rows = if runtime_limit == Some(0) {
                         Vec::new()
                     } else {
-                        load_file_history_rows(
-                            commit_graph,
-                            query_source,
-                            &blob_reader,
-                            &plugin_host,
+                        match load_anchor_file_history_row(
+                            Arc::clone(&commit_graph),
+                            query_source.clone(),
                             &route,
                             &public_predicate,
                             lookup_ids.as_ref(),
+                            &schema,
                             needs_data,
                             metadata_projection,
+                            runtime_limit,
                         )
                         .await
                         .map_err(lix_error_to_datafusion_error)?
+                        {
+                            Some(row) => vec![row],
+                            None => load_file_history_rows(
+                                commit_graph,
+                                query_source,
+                                &blob_reader,
+                                &plugin_host,
+                                &route,
+                                &public_predicate,
+                                lookup_ids.as_ref(),
+                                needs_data,
+                                metadata_projection,
+                            )
+                            .await
+                            .map_err(lix_error_to_datafusion_error)?,
+                        }
                     };
-                    if let Some(limit) = limit {
+                    if let Some(limit) = runtime_limit {
                         rows.truncate(limit);
                     }
                     LIX_FILE_HISTORY_COLS
@@ -618,6 +641,144 @@ struct FileHistoryPluginDiscovery {
     registries_by_commit: BTreeMap<String, PluginRegistry>,
     parent_commit_ids_by_commit: BTreeMap<String, Vec<String>>,
     registry_events: Vec<HistoryEntry>,
+}
+
+#[cfg(test)]
+thread_local! {
+    static ANCHOR_PROBES: std::cell::Cell<usize> = const { std::cell::Cell::new(0) };
+    static ANCHOR_PROBE_HITS: std::cell::Cell<usize> = const { std::cell::Cell::new(0) };
+}
+
+#[cfg(test)]
+pub(crate) fn reset_file_history_anchor_probe_census() {
+    ANCHOR_PROBES.with(|count| count.set(0));
+    ANCHOR_PROBE_HITS.with(|count| count.set(0));
+}
+
+#[cfg(test)]
+pub(crate) fn file_history_anchor_probe_census() -> (usize, usize) {
+    (
+        ANCHOR_PROBES.with(std::cell::Cell::get),
+        ANCHOR_PROBE_HITS.with(std::cell::Cell::get),
+    )
+}
+
+/// Returns the nearest selected file row directly from the anchor checkpoint
+/// when the physical top-k asks for exactly one depth-ordered row.
+///
+/// This is deliberately a narrow proof. A descriptor/blob change for the
+/// selected file at depth zero means no older event can precede the answer.
+/// The authenticated anchor state supplies the composed path and deletion
+/// state, while the depth-zero entry supplies real history provenance. Queries
+/// that project data/provenance, apply history-row constraints, or do not hit
+/// the anchor fall back to the complete shaped traversal below.
+async fn load_anchor_file_history_row<S>(
+    commit_graph: Arc<Mutex<Box<dyn CommitGraphReader>>>,
+    query_source: SqlHistoryQuerySource<S>,
+    route: &HistoryRoute,
+    public_predicate: &FileHistoryPublicPredicate,
+    lookup_ids: Option<&FileHistoryLookupIds>,
+    schema: &SchemaRef,
+    needs_data: bool,
+    metadata_projection: HistoryMetadataProjection,
+    limit: Option<usize>,
+) -> Result<Option<FileHistoryOutputRow>, LixError>
+where
+    S: StorageAdapterRead + Clone + Send + Sync + 'static,
+{
+    let Some(lookup_ids) = lookup_ids else {
+        return Ok(None);
+    };
+    if limit != Some(1)
+        || needs_data
+        || lookup_ids.0.len() != 1
+        || route.as_of_commit_ids.len() != 1
+        || route.invalid_as_of_commit_filter
+        || route.contradictory
+        || !route.row_pks.is_empty()
+        || !route.resolved_row_pks.is_empty()
+        || !route.schema_keys.is_empty()
+        || !route.file_ids.is_empty()
+        || route.min_depth.is_some()
+        || route.max_depth.is_some()
+        || schema.fields().iter().any(|field| {
+            !matches!(
+                field.name().as_str(),
+                "id" | "path" | HISTORY_COL_DEPTH
+            )
+        })
+    {
+        return Ok(None);
+    }
+
+    #[cfg(test)]
+    ANCHOR_PROBES.with(|count| count.set(count.get() + 1));
+
+    let event_route = file_history_descriptor_blob_route(&route.traversal_only(), lookup_ids)?;
+    let mut entries = load_history_entries(
+        HistoryViewDescriptor {
+            view_name: "lix_history('lix_file')",
+            as_of_commit_column: HISTORY_COL_AS_OF_COMMIT_ID,
+        },
+        commit_graph,
+        query_source.clone(),
+        &event_route,
+        vec![
+            FILE_DESCRIPTOR_SCHEMA_KEY.to_string(),
+            BLOB_REF_SCHEMA_KEY.to_string(),
+        ],
+        metadata_projection,
+        Some(1),
+    )
+    .await?;
+    let Some(entry) = entries.pop() else {
+        return Ok(None);
+    };
+    if entry.depth != 0 {
+        return Ok(None);
+    }
+
+    let file_id = lookup_ids
+        .0
+        .first()
+        .expect("single file-history lookup id");
+    let state = Arc::new(
+        load_file_history_observed_state(
+            &mut TrackedStateContext::new().reader(query_source.store),
+            &entry.observed_commit_id,
+            Some(lookup_ids),
+        )
+        .await?,
+    );
+    let Some((descriptor_ordinal, descriptor)) = state
+        .descriptors
+        .iter()
+        .enumerate()
+        .find(|(_, descriptor)| descriptor.id == *file_id)
+    else {
+        return Ok(None);
+    };
+    let path = resolve_observed_file_history_path(descriptor, &state.directories);
+    if !public_predicate.matches(file_id, path.as_deref()) {
+        return Ok(None);
+    }
+
+    #[cfg(test)]
+    ANCHOR_PROBE_HITS.with(|count| count.set(count.get() + 1));
+
+    Ok(Some(FileHistoryOutputRow {
+        observed_state: state,
+        descriptor_ordinal: u32::try_from(descriptor_ordinal).map_err(|_| {
+            LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                "lix_file_history descriptor ordinal exceeds u32",
+            )
+        })?,
+        id: file_id.clone(),
+        path,
+        data: None,
+        event: file_history_event_from_entry(file_id.clone(), &entry),
+    }))
 }
 
 async fn load_file_history_rows<S>(

--- a/packages/lix/src/sql2/providers/mod.rs
+++ b/packages/lix/src/sql2/providers/mod.rs
@@ -21,6 +21,8 @@ pub(crate) use diff::{diff_schema, register_diff_function};
 mod diff_command;
 mod file;
 mod file_history;
+#[cfg(test)]
+pub(crate) use file_history::{file_history_anchor_probe_census, reset_file_history_anchor_probe_census};
 mod filesystem_history_path;
 mod history_table_function;
 mod history_util;

--- a/packages/lix/src/sql2/providers/spec.rs
+++ b/packages/lix/src/sql2/providers/spec.rs
@@ -67,12 +67,15 @@ pub(super) type RowSource = Arc<dyn Fn() -> BoxFuture<'static, Result<RecordBatc
 pub(super) type BatchStreamSource =
     Arc<dyn Fn(usize, Arc<TaskContext>) -> Result<SendableRecordBatchStream> + Send + Sync>;
 
+type ScanFetchRebind = Arc<dyn Fn(Option<usize>) -> ScanSource + Send + Sync>;
+
 #[derive(Clone)]
 pub(super) struct ScanSource {
     partition_count: usize,
     statistics: Arc<Vec<Statistics>>,
     source_statistics: Option<Statistics>,
     open: BatchStreamSource,
+    fetch_rebind: Option<ScanFetchRebind>,
 }
 
 impl ScanSource {
@@ -100,7 +103,12 @@ impl ScanSource {
             statistics: Arc::new(statistics),
             source_statistics,
             open: Arc::new(open),
+            fetch_rebind: None,
         }
+    }
+
+    fn with_fetch(&self, fetch: Option<usize>) -> Option<Self> {
+        self.fetch_rebind.as_ref().map(|rebind| rebind(fetch))
     }
 
     fn open(
@@ -170,6 +178,61 @@ where
             stream,
         )))
     })
+}
+
+/// Adapt a materializing loader that can use an execution-time fetch bound.
+///
+/// `ORDER BY ... LIMIT` is lowered to a physical top-k after table planning,
+/// so its bound is not present in [`TableSpec::plan_scan`]. DataFusion offers
+/// it later through [`ExecutionPlan::with_fetch`]; this source can be rebuilt
+/// with that bound without making an unbounded scan pretend it already knew
+/// the query's final cardinality.
+pub(super) fn fetchable_scan_row_source<S, F, Fut>(
+    schema: SchemaRef,
+    state: S,
+    initial_fetch: Option<usize>,
+    f: F,
+) -> ScanSource
+where
+    S: Clone + Send + Sync + 'static,
+    F: Fn(S, Option<usize>) -> Fut + Send + Sync + 'static,
+    Fut: Future<Output = Result<RecordBatch>> + Send + 'static,
+{
+    fetchable_scan_row_source_inner(schema, state, initial_fetch, Arc::new(f))
+}
+
+fn fetchable_scan_row_source_inner<S, F, Fut>(
+    schema: SchemaRef,
+    state: S,
+    fetch: Option<usize>,
+    f: Arc<F>,
+) -> ScanSource
+where
+    S: Clone + Send + Sync + 'static,
+    F: Fn(S, Option<usize>) -> Fut + Send + Sync + 'static,
+    Fut: Future<Output = Result<RecordBatch>> + Send + 'static,
+{
+    let load = row_source((state.clone(), Arc::clone(&f)), move |(state, f)| {
+        f(state, fetch)
+    });
+    let stream_schema = Arc::clone(&schema);
+    let mut source = batch_stream_source(Arc::clone(&schema), 1, move |_partition, _context| {
+        let load = Arc::clone(&load);
+        let stream = stream::once(async move { load().await });
+        Ok(Box::pin(RecordBatchStreamAdapter::new(
+            Arc::clone(&stream_schema),
+            stream,
+        )))
+    });
+    source.fetch_rebind = Some(Arc::new(move |fetch| {
+        fetchable_scan_row_source_inner(
+            Arc::clone(&schema),
+            state.clone(),
+            fetch,
+            Arc::clone(&f),
+        )
+    }));
+    source
 }
 
 /// Build a storage-originating streaming scan source.
@@ -1401,6 +1464,30 @@ impl ExecutionPlan for SpecScanExec {
             )));
         }
         Ok(self)
+    }
+
+    fn with_fetch(&self, fetch: Option<usize>) -> Option<Arc<dyn ExecutionPlan>> {
+        let source = self.source.with_fetch(fetch)?;
+        if source.partition_count != self.source.partition_count {
+            return None;
+        }
+        let mut physical_cache_key = self.physical_cache_key.clone();
+        physical_cache_key.limit = fetch;
+        Some(Arc::new(Self {
+            table: Arc::clone(&self.table),
+            schema: Arc::clone(&self.schema),
+            source,
+            fragment_ranges: Arc::clone(&self.fragment_ranges),
+            properties: Arc::clone(&self.properties),
+            statement_cache_key: None,
+            physical_cache_key,
+            target_partitions: self.target_partitions,
+            probe_binding: self.probe_binding.clone(),
+        }))
+    }
+
+    fn fetch(&self) -> Option<usize> {
+        self.physical_cache_key.limit
     }
 
     fn execute(

--- a/packages/lix/src/sync/repository.rs
+++ b/packages/lix/src/sync/repository.rs
@@ -10162,6 +10162,8 @@ mod tests {
         assert_eq!(checkpoint, snapshot_head);
         let replica = replica_from_snapshot(&authority, &snapshot).await;
 
+        crate::sql2::reset_file_history_anchor_probe_census();
+
         let history = loop {
             match replica
                 .execute(
@@ -10219,6 +10221,13 @@ mod tests {
                 Err(error) => panic!("checkpoint history should load: {error:?}"),
             }
         };
+        let (anchor_probes, anchor_probe_hits) =
+            crate::sql2::file_history_anchor_probe_census();
+        assert!(anchor_probes >= 1, "top-k history should probe its anchor");
+        assert_eq!(
+            anchor_probe_hits, 1,
+            "the selected checkpoint change should resolve at the anchor"
+        );
         assert_eq!(history.rows().len(), 1);
         assert_eq!(
             history.rows()[0]


### PR DESCRIPTION
## Summary

- carry DataFusion physical top-k fetch bounds into fetch-aware virtual-table sources
- advertise the existing depth ordering for exact single-file, single-anchor history scans
- resolve `ORDER BY lixcol_depth ASC LIMIT 1` from a depth-zero descriptor/blob change at the authenticated checkpoint, while preserving the complete traversal fallback for every other shape
- add native and HTTP regressions proving the point lookup hydrates only its selected checkpoint boundary

This fixes the LixRay preview checkpoint history stall without an application workaround: the previous provider applied `LIMIT 1` only after walking every reachable checkpoint.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p lix` (2,855 passed, 0 failed; integration and doctests green)
- `cargo test -p lix --features all-simulations` (3,249 passed, 0 failed; integration and doctests green)
- `cargo test --manifest-path packages/e2e/Cargo.toml --features "sdk-tests server-protocol" --test sync_mode exact_checkpoint_file_history_hydrates_only_its_anchor_boundary -- --nocapture`