### PR TITLE
fix(checkpoint): run browser GC without Tokio

### DIFF
--- a/packages/js-sdk/src/open-lix.browser.test.ts
+++ b/packages/js-sdk/src/open-lix.browser.test.ts
@@ -116,6 +116,32 @@ test("createCheckpoint returns the new active head through browser WASM", async 
 	}
 });
 
+test("checkpoint GC starts without requiring a browser Tokio runtime", async () => {
+	const { openLix } = await import("@lix-js/sdk");
+	const lix = await openLix();
+	try {
+		// The first checkpoint establishes the recovery boundary. Sixteen more
+		// non-empty intervals reach the fresh-repository GC threshold
+		// (16 intervals * yield 1 * denominator 4 = inventory floor 64).
+		for (let sequence = 0; sequence < 17; sequence += 1) {
+			await lix.execute(
+				`INSERT INTO lix_key_value (key, value)
+				 VALUES ($1, $2)
+				 ON CONFLICT (key) DO UPDATE SET value = excluded.value`,
+				["checkpoint-gc-browser-test", sequence],
+			);
+			const checkpoint = await lix.createCheckpoint();
+			expect(checkpoint.commitId).toEqual(expect.any(String));
+		}
+
+		expect((await lix.execute("SELECT 1 AS value")).rows[0]?.get("value")).toBe(
+			1,
+		);
+	} finally {
+		await lix.close();
+	}
+});
+
 test("lix_restore moves the active branch to an ancestor through browser WASM", async () => {
 	const { openLix } = await import("@lix-js/sdk");
 	const lix = await openLix();

--- a/packages/lix/src/gc.rs
+++ b/packages/lix/src/gc.rs
@@ -6,9 +6,9 @@
 //! the same storage write set that publishes the compacted checkpoint.
 
 use std::collections::{BTreeMap, BTreeSet};
-use std::time::Instant;
 
 use bytes::Bytes;
+use web_time::Instant;
 
 use crate::branch::{BranchHeadControl, BranchHeadControlContext, BranchHeadTrackedReachability};
 use crate::changelog::{ChangeId, CommitId, GcLiveSet, GcPlan, GcRoot, GcSweepSet};

--- a/packages/lix/src/session/checkpoint.rs
+++ b/packages/lix/src/session/checkpoint.rs
@@ -171,7 +171,6 @@ where
             // commit relies on storage conflict detection.
             let gc_session = self.clone();
             let gc_coordinator = self.commit_coordinator.clone();
-            #[cfg(not(target_family = "wasm"))]
             if let Err(error) =
                 crate::background_task::spawn("lix-checkpoint-gc", move || async move {
                     gc_session.collect_checkpoint_garbage_best_effort().await;
@@ -181,11 +180,6 @@ where
                 self.commit_coordinator.finish_checkpoint_gc();
                 return Err(error);
             }
-            #[cfg(target_family = "wasm")]
-            tokio::spawn(async move {
-                gc_session.collect_checkpoint_garbage_best_effort().await;
-                gc_coordinator.finish_checkpoint_gc();
-            });
         }
         Ok(outcome.receipt)
     }


### PR DESCRIPTION
## Summary

- schedule checkpoint GC through Lix's runtime-neutral background task abstraction
- use the browser-safe clock while planning repository GC
- cover the deterministic due-GC threshold in real Chromium/Wasm

## Root cause

When checkpoint GC first became due in browser Wasm, `create_checkpoint` called `tokio::spawn` without a Tokio runtime. After routing that task through `wasm_bindgen_futures::spawn_local`, the collector also exposed its use of unsupported `std::time::Instant` on `wasm32-unknown-unknown`. Either trap closed the browser worker while the checkpoint promise was pending.

## Verification

- `cargo fmt --check`
- `cargo test -p lix`
- `cargo test -p lix --features all-simulations`
- `npm run build:browser`
- `npm run test:browser:built`

The browser regression creates 17 non-empty checkpoint intervals, deterministically crossing the fresh-repository GC threshold, then verifies every receipt resolves and the worker remains usable.