### PR TITLE
fix(gc): retain checkpoint history blobs

### DIFF
--- a/packages/e2e/tests/plugin_gc.rs
+++ b/packages/e2e/tests/plugin_gc.rs
@@ -43,6 +43,56 @@ async fn repository_gc_keeps_plugin_wasm_for_cold_runtime_execution() {
 }
 
 #[tokio::test]
+async fn repository_gc_keeps_graph_reachable_file_history_content() {
+    let memory = Memory::new();
+    let lix = open_lix().with_storage(memory.clone()).await.unwrap();
+    write_file(&lix, "/history.txt", b"before gc").await;
+    let file_id = lix
+        .execute(
+            "SELECT id FROM lix_file WHERE path = '/history.txt'",
+            &[],
+        )
+        .await
+        .unwrap()
+        .rows()[0]
+        .get::<String>("id")
+        .unwrap();
+    let historical_checkpoint = lix.create_checkpoint().await.unwrap().commit_id;
+    write_file(&lix, "/history.txt", b"after gc").await;
+    lix.create_checkpoint().await.unwrap();
+
+    let storage = StorageAdapter::new(memory);
+    let orphan_hash = write_binary_cas_for_bench(&storage, b"history-gc-orphan")
+        .await
+        .unwrap();
+    collect_repository_gc_for_bench(&storage).await.unwrap();
+    assert!(
+        read_binary_cas_for_bench(&storage, &orphan_hash)
+            .await
+            .unwrap()
+            .is_none(),
+        "the test must run a reclaiming CAS sweep"
+    );
+
+    let history = lix
+        .execute(
+            "SELECT content FROM lix_history('lix_file', $1) \
+             WHERE id = $2 ORDER BY lixcol_depth ASC LIMIT 1",
+            &[
+                Value::Text(historical_checkpoint),
+                Value::Text(file_id),
+            ],
+        )
+        .await
+        .unwrap();
+    assert_eq!(
+        history.rows()[0].get::<Vec<u8>>("content").unwrap(),
+        b"before gc",
+    );
+    lix.close().await.unwrap();
+}
+
+#[tokio::test]
 async fn repository_gc_reclaims_plugin_wasm_after_final_registry_root_releases() {
     let memory = Memory::new();
     let lix = open_lix().with_storage(memory.clone()).await.unwrap();

--- a/packages/lix/src/gc.rs
+++ b/packages/lix/src/gc.rs
@@ -967,12 +967,14 @@ where
     let graph_reachable_manifests =
         crate::tracked_state::load_commit_state_manifests(store, &graph_reachable_ids).await?;
     let mut history_manifests_missing = 0u64;
+    let mut graph_reachable_with_manifests = BTreeSet::new();
     for (commit_id, manifest) in graph_reachable_ids
         .into_iter()
         .zip(graph_reachable_manifests)
     {
         if manifest.is_some() {
             physical_dependencies.insert(commit_id);
+            graph_reachable_with_manifests.insert(commit_id);
         } else {
             history_manifests_missing += 1;
         }
@@ -985,8 +987,15 @@ where
              permanently truncated and cannot be recovered"
         );
     }
-    semantic_dependencies.extend(graph_reachable);
     let mut cas_logical_dependencies = history_dependencies;
+    // File history materializes binary payloads from the state selected at
+    // each graph-reachable commit. Keeping the commit delta but sweeping its
+    // blob turns a valid historical row into `content = NULL` and prevents a
+    // sparse replica from hydrating that checkpoint. The checkpoint chain is
+    // already the compacted, observable history boundary, so its CAS roots
+    // must have the same reachability lifetime as its row-history deltas.
+    cas_logical_dependencies.extend(graph_reachable_with_manifests);
+    semantic_dependencies.extend(graph_reachable);
     let mut manifests = BTreeMap::new();
     let mut pending = chronology_roots.iter().copied().collect::<Vec<_>>();
     while let Some(commit_id) = pending.pop() {
@@ -2537,6 +2546,10 @@ mod tests {
     /// `last_gc_sequence`, which only a *successful* sweep advances, so the
     /// due-predicate would latch: every later checkpoint would pay for a
     /// doomed full-repository sweep, forever.
+    ///
+    /// The CAS closure must preserve the same tolerance. Adding the missing
+    /// graph commit as a binary-root authority would make blob-root discovery
+    /// demand the already-reclaimed manifest and reintroduce this latch.
     #[tokio::test]
     async fn ordinary_gc_tolerates_and_counts_history_reclaimed_before_the_fix() {
         let plan = history_retention_fixture(false).await;


### PR DESCRIPTION
## Summary

- retain binary CAS roots referenced by graph-reachable checkpoint history
- preserve legacy compatibility by excluding reachable commits whose physical manifests were already reclaimed
- add a reclaim-engaged regression proving historical file content survives GC

## Why

GC already retains graph-reachable commit deltas because lix_history reads them, but its CAS root set omitted those same commits. After a sweep, historical file rows remained visible while content became NULL; sparse hydration then failed with LIX_ERROR_SYNC_CAS_NOT_FOUND.

## Validation

- repository_gc_keeps_graph_reachable_file_history_content
- ordinary_gc_retains_the_delta_of_a_graph_reachable_commit
- ordinary_gc_tolerates_and_counts_history_reclaimed_before_the_fix
- cargo check -p lix
- cargo fmt --all -- --check