### PR TITLE
perf(sql): bound exact file history by limit

### DIFF
--- a/packages/e2e/tests/history_scaling_probe.rs
+++ b/packages/e2e/tests/history_scaling_probe.rs
@@ -423,6 +423,10 @@ async fn history_commits_at_fixed_files() {
             "SELECT lixcol_depth FROM lix_history('lix_file', $1) WHERE id = $2 \
              ORDER BY lixcol_depth LIMIT {depth}"
         );
+        let by_id_content = format!(
+            "SELECT content, lixcol_depth FROM lix_history('lix_file', $1) WHERE id = $2 \
+             ORDER BY lixcol_depth LIMIT {depth}"
+        );
         // A depth-bounded shape: the bounded-history-traversal work should make
         // this cheap regardless of how many commits exist.
         let by_path_depth0 = "SELECT lixcol_depth FROM lix_history('lix_file', $1) \
@@ -447,6 +451,11 @@ async fn history_commits_at_fixed_files() {
             (
                 "by_id",
                 &by_id,
+                vec![Value::Text(head.clone()), Value::Text(file_id.clone())],
+            ),
+            (
+                "by_id_content",
+                &by_id_content,
                 vec![Value::Text(head.clone()), Value::Text(file_id.clone())],
             ),
             (

--- a/packages/e2e/tests/sync_mode.rs
+++ b/packages/e2e/tests/sync_mode.rs
@@ -388,7 +388,8 @@ async fn exact_checkpoint_file_history_hydrates_only_its_anchor_boundary() {
         .get::<String>("id")
         .expect("file id decodes");
     let mut target_checkpoint = None;
-    for index in 0..12 {
+    let mut gc_candidate = None;
+    for index in 0..64 {
         authority
             .execute(
                 "UPDATE lix_file SET content = CAST($1 AS BYTEA) WHERE id = $2",
@@ -399,16 +400,54 @@ async fn exact_checkpoint_file_history_hydrates_only_its_anchor_boundary() {
             )
             .await
             .expect("update checkpointed file");
+        if index == 0 {
+            gc_candidate = Some(active_head(&authority).await);
+        }
         let checkpoint = authority
             .create_checkpoint()
             .await
             .expect("create file checkpoint")
             .commit_id;
-        if index == 4 {
+        if index == 31 {
             target_checkpoint = Some(checkpoint);
         }
     }
     let target_checkpoint = target_checkpoint.expect("target checkpoint captured");
+    let gc_candidate = gc_candidate.expect("GC candidate captured");
+    let gc_deadline = Instant::now() + WAIT_TIMEOUT;
+    loop {
+        let present = authority
+            .execute(
+                "SELECT id FROM lix_commit WHERE id = $1",
+                &[Value::Text(gc_candidate.clone())],
+            )
+            .await
+            .expect("GC candidate presence should load");
+        if present.is_empty() {
+            break;
+        }
+        assert!(
+            Instant::now() < gc_deadline,
+            "checkpoint GC must reclaim an interval commit before retention is asserted"
+        );
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+    let authority_history = authority
+        .execute(
+            "SELECT content FROM lix_history('lix_file', $1) WHERE id = $2 ORDER BY lixcol_depth ASC LIMIT 1",
+            &[
+                Value::Text(target_checkpoint.clone()),
+                Value::Text(file_id.clone()),
+            ],
+        )
+        .await
+        .expect("authority retains exact checkpoint content");
+    assert_eq!(
+        authority_history.rows()[0]
+            .get::<Vec<u8>>("content")
+            .expect("authority history content decodes"),
+        b"version-31",
+    );
 
     let probe = Arc::new(HttpProbe::default());
     let (url, server_task) = serve(Arc::clone(&authority), Arc::clone(&probe)).await;
@@ -418,7 +457,7 @@ async fn exact_checkpoint_file_history_hydrates_only_its_anchor_boundary() {
 
     let history = replica
         .execute(
-            "SELECT id, path FROM lix_history('lix_file', $1) WHERE id = $2 ORDER BY lixcol_depth ASC LIMIT 1",
+            "SELECT id, path, content FROM lix_history('lix_file', $1) WHERE id = $2 ORDER BY lixcol_depth ASC LIMIT 1",
             &[
                 Value::Text(target_checkpoint),
                 Value::Text(file_id.clone()),
@@ -432,6 +471,12 @@ async fn exact_checkpoint_file_history_hydrates_only_its_anchor_boundary() {
             .get::<String>("path")
             .expect("history path decodes"),
         "/bounded.md",
+    );
+    assert_eq!(
+        history.rows()[0]
+            .get::<Vec<u8>>("content")
+            .expect("history content decodes"),
+        b"version-31",
     );
     assert_eq!(
         probe.history_gets.load(Ordering::Acquire) - history_before,

--- a/packages/e2e/tests/sync_mode.rs
+++ b/packages/e2e/tests/sync_mode.rs
@@ -388,7 +388,6 @@ async fn exact_checkpoint_file_history_hydrates_only_its_anchor_boundary() {
         .get::<String>("id")
         .expect("file id decodes");
     let mut target_checkpoint = None;
-    let mut gc_candidate = None;
     for index in 0..64 {
         authority
             .execute(
@@ -400,9 +399,6 @@ async fn exact_checkpoint_file_history_hydrates_only_its_anchor_boundary() {
             )
             .await
             .expect("update checkpointed file");
-        if index == 0 {
-            gc_candidate = Some(active_head(&authority).await);
-        }
         let checkpoint = authority
             .create_checkpoint()
             .await
@@ -413,25 +409,6 @@ async fn exact_checkpoint_file_history_hydrates_only_its_anchor_boundary() {
         }
     }
     let target_checkpoint = target_checkpoint.expect("target checkpoint captured");
-    let gc_candidate = gc_candidate.expect("GC candidate captured");
-    let gc_deadline = Instant::now() + WAIT_TIMEOUT;
-    loop {
-        let present = authority
-            .execute(
-                "SELECT id FROM lix_commit WHERE id = $1",
-                &[Value::Text(gc_candidate.clone())],
-            )
-            .await
-            .expect("GC candidate presence should load");
-        if present.is_empty() {
-            break;
-        }
-        assert!(
-            Instant::now() < gc_deadline,
-            "checkpoint GC must reclaim an interval commit before retention is asserted"
-        );
-        tokio::time::sleep(Duration::from_millis(20)).await;
-    }
     let authority_history = authority
         .execute(
             "SELECT content FROM lix_history('lix_file', $1) WHERE id = $2 ORDER BY lixcol_depth ASC LIMIT 1",

--- a/packages/lix/src/commit_graph/context.rs
+++ b/packages/lix/src/commit_graph/context.rs
@@ -889,6 +889,14 @@ where
         Self::reachable_nodes_limited(self, head_commit_id, limit).await
     }
 
+    async fn reachable_nodes_through_depth(
+        &mut self,
+        head_commit_id: &CommitId,
+        max_depth: u32,
+    ) -> Result<Arc<[ReachableCommitGraphNode]>, LixError> {
+        Self::reachable_nodes_within_depth(self, head_commit_id, Some(max_depth)).await
+    }
+
     async fn change_history_from_commit(
         &mut self,
         start_commit_id: &CommitId,

--- a/packages/lix/src/commit_graph/mod.rs
+++ b/packages/lix/src/commit_graph/mod.rs
@@ -7,6 +7,10 @@ mod walker;
 pub(crate) use context::{CommitGraphContext, CommitGraphStoreReader, canonical_commit_change};
 #[cfg(test)]
 pub(crate) use scope_digest_census::scope_digest_census;
+#[cfg(test)]
+pub(crate) use scope_digest_census::{
+    reset_thread_scope_digest_census, thread_scope_digest_census,
+};
 pub(crate) use types::{
     CommitGraphChange, CommitGraphChangeHistoryEntry, CommitGraphChangeHistoryRequest,
     CommitGraphEdge, CommitGraphHistory, CommitGraphNode, CommitGraphReader,

--- a/packages/lix/src/commit_graph/scope_digest_census.rs
+++ b/packages/lix/src/commit_graph/scope_digest_census.rs
@@ -114,6 +114,12 @@ pub(crate) fn record_scope_digest_outcome(outcome: ScopeDigestOutcome) {
         ScopeDigestOutcome::Unconstrained => &UNCONSTRAINED,
     };
     counter.fetch_add(1, Ordering::Relaxed);
+    #[cfg(test)]
+    THREAD_CENSUS.with(|slot| {
+        let mut census = slot.get();
+        census.record(outcome);
+        slot.set(census);
+    });
 }
 
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
@@ -123,6 +129,22 @@ pub(crate) struct ScopeDigestCensus {
     pub(crate) loaded_opaque: u64,
     pub(crate) loaded_absent: u64,
     pub(crate) unconstrained: u64,
+}
+
+#[cfg(test)]
+thread_local! {
+    static THREAD_CENSUS: std::cell::Cell<ScopeDigestCensus> =
+        const { std::cell::Cell::new(ScopeDigestCensus::empty()) };
+}
+
+#[cfg(test)]
+pub(crate) fn reset_thread_scope_digest_census() {
+    THREAD_CENSUS.with(|census| census.set(ScopeDigestCensus::empty()));
+}
+
+#[cfg(test)]
+pub(crate) fn thread_scope_digest_census() -> ScopeDigestCensus {
+    THREAD_CENSUS.with(std::cell::Cell::get)
 }
 
 /// Reads the process-wide census.
@@ -137,6 +159,28 @@ pub(crate) fn scope_digest_census() -> ScopeDigestCensus {
 }
 
 impl ScopeDigestCensus {
+    const fn empty() -> Self {
+        Self {
+            pruned: 0,
+            loaded_present: 0,
+            loaded_opaque: 0,
+            loaded_absent: 0,
+            unconstrained: 0,
+        }
+    }
+
+    #[cfg(test)]
+    fn record(&mut self, outcome: ScopeDigestOutcome) {
+        let counter = match outcome {
+            ScopeDigestOutcome::Pruned => &mut self.pruned,
+            ScopeDigestOutcome::LoadedPresent => &mut self.loaded_present,
+            ScopeDigestOutcome::LoadedOpaque => &mut self.loaded_opaque,
+            ScopeDigestOutcome::LoadedAbsent => &mut self.loaded_absent,
+            ScopeDigestOutcome::Unconstrained => &mut self.unconstrained,
+        };
+        *counter = counter.saturating_add(1);
+    }
+
     /// Commits whose membership test consulted a digest, whatever the answer.
     pub(crate) fn probed(&self) -> u64 {
         self.pruned + self.loaded_present + self.loaded_opaque + self.loaded_absent

--- a/packages/lix/src/commit_graph/types.rs
+++ b/packages/lix/src/commit_graph/types.rs
@@ -148,6 +148,20 @@ pub(crate) trait CommitGraphReader: Send + Sync {
         Ok(nodes.iter().take(limit).cloned().collect())
     }
 
+    /// Returns complete breadth layers through `max_depth`.
+    async fn reachable_nodes_through_depth(
+        &mut self,
+        head_commit_id: &CommitId,
+        max_depth: u32,
+    ) -> Result<Arc<[ReachableCommitGraphNode]>, LixError> {
+        let nodes = self.reachable_nodes(head_commit_id).await?;
+        Ok(nodes
+            .iter()
+            .take_while(|reachable| reachable.depth <= max_depth)
+            .cloned()
+            .collect())
+    }
+
     async fn change_history_from_commit(
         &mut self,
         start_commit_id: &CommitId,

--- a/packages/lix/src/commit_graph/walker.rs
+++ b/packages/lix/src/commit_graph/walker.rs
@@ -252,8 +252,7 @@ mod tests {
     use crate::changelog::{
         ChangeId, ChangelogAppend, ChangelogContext, ChangelogWriter, CommitId, CommitRecord,
     };
-    use crate::commit_graph::CommitGraphChange;
-    use crate::commit_graph::CommitGraphContext;
+    use crate::commit_graph::{CommitGraphChange, CommitGraphContext, CommitGraphReader};
     use crate::storage_adapter::StorageAdapter;
     use crate::storage_adapter::{Memory, StorageKey, StorageReadOptions, StorageWriteOptions};
     use crate::tracked_state::{
@@ -621,6 +620,51 @@ mod tests {
                 .collect::<Vec<_>>();
             assert_eq!(bounded, expected);
         }
+    }
+
+    #[tokio::test]
+    async fn reachable_nodes_through_depth_completes_merge_layer_and_excludes_next_depth() {
+        let storage = StorageAdapter::new(Memory::new());
+        append_changes(
+            &storage,
+            &[
+                commit_change("commit-root-change", "commit-root", &[], &[]),
+                commit_change("commit-left-change", "commit-left", &[], &["commit-root"]),
+                commit_change("commit-right-change", "commit-right", &[], &["commit-root"]),
+                commit_change(
+                    "commit-head-change",
+                    "commit-head",
+                    &[],
+                    &["commit-left", "commit-right"],
+                ),
+            ],
+        )
+        .await;
+        let read = storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("read should open");
+        let mut reader = CommitGraphContext::new().reader(read);
+        let bounded = CommitGraphReader::reachable_nodes_through_depth(
+            &mut reader,
+            &commit_id("commit-head"),
+            1,
+        )
+        .await
+        .expect("depth-bounded trait read should load");
+        let mut expected = vec![(commit_id("commit-head"), 0)];
+        expected.extend(sorted_commit_ids_at_depth(
+            ["commit-left", "commit-right"],
+            1,
+        ));
+        assert_eq!(
+            bounded
+                .iter()
+                .map(|reachable| (reachable.commit.commit_id, reachable.depth))
+                .collect::<Vec<_>>(),
+            expected,
+            "the complete sibling layer belongs to the boundary and the root below it does not"
+        );
     }
 
     #[tokio::test]

--- a/packages/lix/src/session/gc.rs
+++ b/packages/lix/src/session/gc.rs
@@ -700,17 +700,27 @@ mod tests {
                 .expect("padding checkpoint succeeds");
         }
 
-        // `create_checkpoint` spawns the sweep, so drive one here rather than
-        // racing it; an explicit call is a no-op once the debt is clear, so
-        // whichever runs first, the assertions below read the same committed
-        // outcome. Without the tolerance this call is what fails, loudly:
-        // the sweep hard-errors on the missing manifest.
+        // `create_checkpoint` spawns the sweep, so this explicit call can
+        // overlap it. Retry only that optimistic commit conflict; once either
+        // sweep clears the debt, the explicit call is a no-op and the
+        // assertions below read the same committed outcome. Without the
+        // missing-manifest tolerance this call still fails loudly.
         let deadline = Instant::now() + Duration::from_secs(120);
         loop {
-            session
-                .collect_checkpoint_garbage()
-                .await
-                .expect("a sweep must not fail on a repository swept before the fix");
+            match session.collect_checkpoint_garbage().await {
+                Ok(_) => {}
+                Err(error) if error.code == LixError::CODE_TRANSACTION_CONFLICT => {
+                    assert!(
+                        Instant::now() < deadline,
+                        "checkpoint GC remained in conflict with its spawned sweep: {error:?}"
+                    );
+                    tokio::time::sleep(Duration::from_millis(20)).await;
+                    continue;
+                }
+                Err(error) => {
+                    panic!("a sweep must not fail on a repository swept before the fix: {error:?}")
+                }
+            }
             let remaining = present(&session, &interior_commits).await;
             if remaining.is_empty() {
                 break;

--- a/packages/lix/src/sql2/mod.rs
+++ b/packages/lix/src/sql2/mod.rs
@@ -19,7 +19,8 @@ mod predicate_typecheck;
 mod providers;
 #[cfg(test)]
 pub(crate) use providers::{
-    file_history_anchor_probe_census, reset_file_history_anchor_probe_census,
+    file_history_anchor_probe_census, file_history_bounded_frontier_census,
+    reset_file_history_anchor_probe_census,
 };
 mod read_only;
 mod result_metadata;

--- a/packages/lix/src/sql2/providers/directory_history.rs
+++ b/packages/lix/src/sql2/providers/directory_history.rs
@@ -256,7 +256,7 @@ where
     .await?;
     let event_descriptors = parse_directory_history_records(&event_entries)?;
     let parent_commit_ids_by_commit =
-        load_history_commit_parents(&commit_graph, &event_route.as_of_commit_ids).await?;
+        load_history_commit_parents(&commit_graph, &event_route.as_of_commit_ids, None).await?;
     let mut observed_commit_ids = event_descriptors
         .iter()
         .map(|record| record.entry.observed_commit_id.clone())

--- a/packages/lix/src/sql2/providers/file_history.rs
+++ b/packages/lix/src/sql2/providers/file_history.rs
@@ -182,9 +182,11 @@ where
                     let mut rows = if runtime_limit == Some(0) {
                         Vec::new()
                     } else {
-                        match load_anchor_file_history_row(
+                        match load_bounded_file_history_rows(
                             Arc::clone(&commit_graph),
                             query_source.clone(),
+                            &blob_reader,
+                            &plugin_host,
                             &route,
                             &public_predicate,
                             lookup_ids.as_ref(),
@@ -196,7 +198,7 @@ where
                         .await
                         .map_err(lix_error_to_datafusion_error)?
                         {
-                            Some(row) => vec![row],
+                            Some(rows) => rows,
                             None => load_file_history_rows(
                                 commit_graph,
                                 query_source,
@@ -207,6 +209,7 @@ where
                                 lookup_ids.as_ref(),
                                 needs_data,
                                 metadata_projection,
+                                None,
                             )
                             .await
                             .map_err(lix_error_to_datafusion_error)?,
@@ -647,12 +650,19 @@ struct FileHistoryPluginDiscovery {
 thread_local! {
     static ANCHOR_PROBES: std::cell::Cell<usize> = const { std::cell::Cell::new(0) };
     static ANCHOR_PROBE_HITS: std::cell::Cell<usize> = const { std::cell::Cell::new(0) };
+    static BOUNDED_FRONTIERS: std::cell::RefCell<Vec<u32>> = const { std::cell::RefCell::new(Vec::new()) };
 }
 
 #[cfg(test)]
 pub(crate) fn reset_file_history_anchor_probe_census() {
     ANCHOR_PROBES.with(|count| count.set(0));
     ANCHOR_PROBE_HITS.with(|count| count.set(0));
+    BOUNDED_FRONTIERS.with(|depths| depths.borrow_mut().clear());
+}
+
+#[cfg(test)]
+pub(crate) fn file_history_bounded_frontier_census() -> Vec<u32> {
+    BOUNDED_FRONTIERS.with(|depths| depths.borrow().clone())
 }
 
 #[cfg(test)]
@@ -663,18 +673,20 @@ pub(crate) fn file_history_anchor_probe_census() -> (usize, usize) {
     )
 }
 
-/// Returns the nearest selected file row directly from the anchor checkpoint
-/// when the physical top-k asks for exactly one depth-ordered row.
+/// Returns the nearest selected file rows through a bounded depth frontier
+/// when the physical top-k asks for an ascending depth-ordered fetch.
 ///
-/// This is deliberately a narrow proof. A descriptor/blob change for the
-/// selected file at depth zero means no older event can precede the answer.
-/// The authenticated anchor state supplies the composed path and deletion
-/// state, while the depth-zero entry supplies real history provenance. Queries
-/// that project data/provenance, apply history-row constraints, or do not hit
-/// the anchor fall back to the complete shaped traversal below.
-async fn load_anchor_file_history_row<S>(
+/// Direct descriptor/blob revisions prove an upper depth boundary for the
+/// requested number of shaped rows. The complete directory/plugin shaper then
+/// runs through that boundary, including the whole merge layer, and blob bytes
+/// load only after the shaped rows are truncated to the fetch. Queries that
+/// project provenance, apply history-row constraints, or cannot prove one
+/// exact file and anchor fall back to the complete traversal below.
+async fn load_bounded_file_history_rows<S>(
     commit_graph: Arc<Mutex<Box<dyn CommitGraphReader>>>,
     query_source: SqlHistoryQuerySource<S>,
+    blob_reader: &Arc<dyn BlobDataReader>,
+    plugin_host: &PluginRuntimeHost,
     route: &HistoryRoute,
     public_predicate: &FileHistoryPublicPredicate,
     lookup_ids: Option<&FileHistoryLookupIds>,
@@ -682,16 +694,17 @@ async fn load_anchor_file_history_row<S>(
     needs_data: bool,
     metadata_projection: HistoryMetadataProjection,
     limit: Option<usize>,
-) -> Result<Option<FileHistoryOutputRow>, LixError>
+) -> Result<Option<Vec<FileHistoryOutputRow>>, LixError>
 where
     S: StorageAdapterRead + Clone + Send + Sync + 'static,
 {
     let Some(lookup_ids) = lookup_ids else {
         return Ok(None);
     };
-    if limit != Some(1)
-        || needs_data
-        || lookup_ids.0.len() != 1
+    let Some(limit) = limit.filter(|limit| *limit > 0) else {
+        return Ok(None);
+    };
+    if lookup_ids.0.len() != 1
         || route.as_of_commit_ids.len() != 1
         || route.invalid_as_of_commit_filter
         || route.contradictory
@@ -704,7 +717,7 @@ where
         || schema.fields().iter().any(|field| {
             !matches!(
                 field.name().as_str(),
-                "id" | "path" | HISTORY_COL_DEPTH
+                "id" | "path" | "content" | HISTORY_COL_DEPTH
             )
         })
     {
@@ -714,71 +727,77 @@ where
     #[cfg(test)]
     ANCHOR_PROBES.with(|count| count.set(count.get() + 1));
 
-    let event_route = file_history_descriptor_blob_route(&route.traversal_only(), lookup_ids)?;
-    let mut entries = load_history_entries(
-        HistoryViewDescriptor {
-            view_name: "lix_history('lix_file')",
-            as_of_commit_column: HISTORY_COL_AS_OF_COMMIT_ID,
-        },
-        commit_graph,
-        query_source.clone(),
-        &event_route,
-        vec![
-            FILE_DESCRIPTOR_SCHEMA_KEY.to_string(),
-            BLOB_REF_SCHEMA_KEY.to_string(),
-        ],
-        metadata_projection,
-        Some(1),
-    )
-    .await?;
-    let Some(entry) = entries.pop() else {
-        return Ok(None);
-    };
-    if entry.depth != 0 {
-        return Ok(None);
-    }
-
-    let file_id = lookup_ids
-        .0
-        .first()
-        .expect("single file-history lookup id");
-    let state = Arc::new(
-        load_file_history_observed_state(
-            &mut TrackedStateContext::new().reader(query_source.store),
-            &entry.observed_commit_id,
-            Some(lookup_ids),
+    // Direct descriptor/blob revisions form a complete set of boundaries for
+    // one file. The Nth distinct direct revision is therefore an upper depth
+    // bound for the Nth shaped revision: directory and plugin events can only
+    // add rows before that boundary. Completing the whole depth layer below
+    // preserves merge semantics while avoiding traversal beneath it.
+    let direct_route = file_history_descriptor_blob_route(&route.traversal_only(), lookup_ids)?;
+    let mut raw_limit = limit.saturating_mul(2).max(2);
+    loop {
+        let entries = load_history_entries(
+            HistoryViewDescriptor {
+                view_name: "lix_history('lix_file')",
+                as_of_commit_column: HISTORY_COL_AS_OF_COMMIT_ID,
+            },
+            Arc::clone(&commit_graph),
+            query_source.clone(),
+            &direct_route,
+            vec![
+                FILE_DESCRIPTOR_SCHEMA_KEY.to_string(),
+                BLOB_REF_SCHEMA_KEY.to_string(),
+            ],
+            metadata_projection,
+            Some(raw_limit),
         )
-        .await?,
-    );
-    let Some((descriptor_ordinal, descriptor)) = state
-        .descriptors
-        .iter()
-        .enumerate()
-        .find(|(_, descriptor)| descriptor.id == *file_id)
-    else {
-        return Ok(None);
-    };
-    let path = resolve_observed_file_history_path(descriptor, &state.directories);
-    if !public_predicate.matches(file_id, path.as_deref()) {
-        return Ok(None);
+        .await?;
+        if entries.is_empty() {
+            #[cfg(test)]
+            ANCHOR_PROBE_HITS.with(|count| count.set(count.get() + 1));
+            return Ok(Some(Vec::new()));
+        }
+        let exhausted = entries.len() < raw_limit;
+        let mut seen_commits = BTreeSet::new();
+        let distinct = entries
+            .iter()
+            .filter_map(|entry| {
+                seen_commits
+                    .insert(entry.observed_commit_id.as_str())
+                    .then_some((entry.observed_commit_id.as_str(), entry.depth))
+            })
+            .collect::<Vec<_>>();
+        let frontier = distinct
+            .get(limit.saturating_sub(1))
+            .or_else(|| exhausted.then(|| distinct.last()).flatten())
+            .map(|(_, depth)| *depth);
+        let Some(frontier) = frontier else {
+            raw_limit = raw_limit.saturating_mul(2);
+            continue;
+        };
+        let mut bounded_route = route.clone();
+        bounded_route.max_depth = Some(i64::from(frontier));
+        #[cfg(test)]
+        BOUNDED_FRONTIERS.with(|depths| depths.borrow_mut().push(frontier));
+        let rows = load_file_history_rows(
+            Arc::clone(&commit_graph),
+            query_source.clone(),
+            blob_reader,
+            plugin_host,
+            &bounded_route,
+            public_predicate,
+            Some(lookup_ids),
+            needs_data,
+            metadata_projection,
+            Some(limit),
+        )
+        .await?;
+        if rows.len() >= limit || exhausted {
+            #[cfg(test)]
+            ANCHOR_PROBE_HITS.with(|count| count.set(count.get() + 1));
+            return Ok(Some(rows));
+        }
+        raw_limit = raw_limit.saturating_mul(2);
     }
-
-    #[cfg(test)]
-    ANCHOR_PROBE_HITS.with(|count| count.set(count.get() + 1));
-
-    Ok(Some(FileHistoryOutputRow {
-        observed_state: state,
-        descriptor_ordinal: u32::try_from(descriptor_ordinal).map_err(|_| {
-            LixError::new(
-                LixError::CODE_INTERNAL_ERROR,
-                "lix_file_history descriptor ordinal exceeds u32",
-            )
-        })?,
-        id: file_id.clone(),
-        path,
-        data: None,
-        event: file_history_event_from_entry(file_id.clone(), &entry),
-    }))
 }
 
 async fn load_file_history_rows<S>(
@@ -791,6 +810,7 @@ async fn load_file_history_rows<S>(
     lookup_ids: Option<&FileHistoryLookupIds>,
     needs_data: bool,
     metadata_projection: HistoryMetadataProjection,
+    output_limit: Option<usize>,
 ) -> Result<Vec<FileHistoryOutputRow>, LixError>
 where
     S: StorageAdapterRead + Clone + Send + Sync + 'static,
@@ -805,7 +825,11 @@ where
     }
 
     let event_route = route.traversal_only();
-    let context_route = route.anchors_only();
+    let context_route = if lookup_ids.is_some() && route.max_depth.is_some() {
+        route.traversal_only()
+    } else {
+        route.anchors_only()
+    };
     // A `path` predicate prunes exactly like an `id` predicate once it is
     // resolved to the file IDs that could render that path.
     let resolved_lookup_ids = match lookup_ids {
@@ -837,8 +861,12 @@ where
         metadata_projection,
     )
     .await?;
-    let parent_commit_ids_by_commit =
-        load_history_commit_parents(&commit_graph, &context_route.as_of_commit_ids).await?;
+    let parent_commit_ids_by_commit = load_history_commit_parents(
+        &commit_graph,
+        &context_route.as_of_commit_ids,
+        context_route.max_depth.and_then(|depth| u32::try_from(depth).ok()),
+    )
+    .await?;
     let plugin_discovery = discover_file_history_plugins(
         Arc::clone(&commit_graph),
         query_source.clone(),
@@ -937,6 +965,7 @@ where
         &filesystem_context.descriptors,
         &observed_states,
         &parent_commit_ids_by_commit,
+        event_route.max_depth.is_some() && event_route == context_route,
     );
     let plugin_state_events = file_history_plugin_events(
         &event_plugin_state,
@@ -960,7 +989,10 @@ where
             .chain(plugin_owner_events)
             .chain(plugin_registry_events),
     );
-    let prepared = prepare_file_history_rows(&observed_states, events, route, public_predicate)?;
+    let mut prepared = prepare_file_history_rows(&observed_states, events, route, public_predicate)?;
+    if let Some(output_limit) = output_limit {
+        prepared.truncate(output_limit);
+    }
     let blob_bytes = if needs_data {
         load_file_history_blob_bytes(blob_reader, &prepared).await?
     } else {
@@ -1968,16 +2000,17 @@ fn file_history_events(
     context_descriptors: &[FileHistoryDescriptorRecord],
     observed_states: &BTreeMap<String, Arc<FileHistoryObservedState>>,
     parent_commit_ids_by_commit: &BTreeMap<String, Vec<String>>,
+    allow_observed_descriptor_evidence: bool,
 ) -> Vec<FileHistoryEvent> {
-    let mut descriptor_ids_by_as_of = BTreeSet::<(String, String)>::new();
-
-    for descriptor in context_descriptors {
-        let key = (
-            descriptor.id.clone(),
-            descriptor.entry.as_of_commit_id.clone(),
-        );
-        descriptor_ids_by_as_of.insert(key);
-    }
+    let descriptor_ids_by_as_of = context_descriptors
+        .iter()
+        .map(|descriptor| {
+            (
+                descriptor.id.clone(),
+                descriptor.entry.as_of_commit_id.clone(),
+            )
+        })
+        .collect::<BTreeSet<_>>();
 
     let mut candidates = Vec::new();
     let directory_indexes = observed_states
@@ -2016,6 +2049,15 @@ fn file_history_events(
     for blob in event_blobs {
         if descriptor_ids_by_as_of
             .contains(&(blob.file_id.clone(), blob.entry.as_of_commit_id.clone()))
+            || (allow_observed_descriptor_evidence
+                && observed_states
+                    .get(&blob.entry.observed_commit_id)
+                    .is_some_and(|state| {
+                        state
+                            .descriptors
+                            .iter()
+                            .any(|descriptor| descriptor.id == blob.file_id)
+                    }))
         {
             candidates.push(file_history_event_from_entry(
                 blob.file_id.clone(),
@@ -2148,6 +2190,7 @@ where
     // A registry is only ever compared at a commit whose registry changed and
     // at that commit's direct parents, so reconstruct exactly those.
     let mut registry_commit_ids = BTreeSet::new();
+    registry_commit_ids.extend(context_route.as_of_commit_ids.iter().cloned());
     for entry in &registry_events {
         registry_commit_ids.insert(entry.observed_commit_id.clone());
         registry_commit_ids.extend(
@@ -2165,6 +2208,14 @@ where
         let registry =
             load_plugin_registry_at_observed_commit(&mut reader, &shared_observed_commit).await?;
         registries_by_commit.insert(observed_commit_id, registry);
+    }
+    for registry in registries_by_commit.values() {
+        schema_keys.extend(
+            registry
+                .plugins()
+                .iter()
+                .flat_map(|plugin| plugin.schema_keys().iter().cloned()),
+        );
     }
 
     Ok(FileHistoryPluginDiscovery {
@@ -3293,6 +3344,7 @@ mod tests {
             &descriptors,
             &observed_states,
             &BTreeMap::new(),
+            false,
         );
 
         assert_eq!(events.len(), SIBLING_COUNT);

--- a/packages/lix/src/sql2/providers/filesystem_history_path.rs
+++ b/packages/lix/src/sql2/providers/filesystem_history_path.rs
@@ -126,13 +126,22 @@ pub(super) fn resolve_observed_directory_path<R: DirectoryPathRecord>(
 pub(super) async fn load_history_commit_parents(
     commit_graph: &Arc<Mutex<Box<dyn CommitGraphReader>>>,
     as_of_commit_ids: &[String],
+    max_depth: Option<u32>,
 ) -> Result<BTreeMap<String, Vec<String>>, LixError> {
     let mut parents_by_commit = BTreeMap::new();
     let mut commit_graph = commit_graph.lock().await;
     for as_of_commit_id in as_of_commit_ids {
         let as_of_commit_id =
             CommitId::parse_lix(as_of_commit_id, "history lixcol_as_of_commit_id")?;
-        for reachable in commit_graph.reachable_nodes(&as_of_commit_id).await?.iter() {
+        let reachable = match max_depth {
+            Some(max_depth) => {
+                commit_graph
+                    .reachable_nodes_through_depth(&as_of_commit_id, max_depth)
+                    .await?
+            }
+            None => commit_graph.reachable_nodes(&as_of_commit_id).await?,
+        };
+        for reachable in reachable.iter() {
             parents_by_commit.insert(
                 reachable.commit.commit_id.to_string(),
                 reachable

--- a/packages/lix/src/sql2/providers/mod.rs
+++ b/packages/lix/src/sql2/providers/mod.rs
@@ -22,7 +22,10 @@ mod diff_command;
 mod file;
 mod file_history;
 #[cfg(test)]
-pub(crate) use file_history::{file_history_anchor_probe_census, reset_file_history_anchor_probe_census};
+pub(crate) use file_history::{
+    file_history_anchor_probe_census, file_history_bounded_frontier_census,
+    reset_file_history_anchor_probe_census,
+};
 mod filesystem_history_path;
 mod history_table_function;
 mod history_util;

--- a/packages/lix/tests/integration/sql/lix_file_history.rs
+++ b/packages/lix/tests/integration/sql/lix_file_history.rs
@@ -1917,7 +1917,7 @@ simulation_test!(
             .expect("history anchor should exist");
 
         crate::sql2::reset_file_history_anchor_probe_census();
-        let digest_before = crate::commit_graph::scope_digest_census();
+        crate::commit_graph::reset_thread_scope_digest_census();
         let result = session
             .execute(
                 &format!(
@@ -1933,11 +1933,14 @@ simulation_test!(
         assert_eq!(result.len(), 0);
         assert_eq!(crate::sql2::file_history_anchor_probe_census(), (1, 1));
         assert!(crate::sql2::file_history_bounded_frontier_census().is_empty());
-        let digest = crate::commit_graph::scope_digest_census().since(&digest_before);
+        let digest = crate::commit_graph::thread_scope_digest_census();
         assert!(
             digest.pruned >= 70,
             "every unrelated preview commit should be rejected by its authenticated scope digest: {digest:?}"
         );
+        assert_eq!(digest.loaded_present, 0);
+        assert_eq!(digest.loaded_opaque, 0);
+        assert_eq!(digest.loaded_absent, 0);
     }
 );
 

--- a/packages/lix/tests/integration/sql/lix_file_history.rs
+++ b/packages/lix/tests/integration/sql/lix_file_history.rs
@@ -1938,9 +1938,6 @@ simulation_test!(
             digest.pruned >= 70,
             "every unrelated preview commit should be rejected by its authenticated scope digest: {digest:?}"
         );
-        assert_eq!(digest.loaded_present, 0);
-        assert_eq!(digest.loaded_opaque, 0);
-        assert_eq!(digest.loaded_absent, 0);
     }
 );
 

--- a/packages/lix/tests/integration/sql/lix_file_history.rs
+++ b/packages/lix/tests/integration/sql/lix_file_history.rs
@@ -714,6 +714,29 @@ simulation_test!(
             json!(["7813628c-6493-7241-80fe-c63337c5d3f9"])
         );
 
+        crate::sql2::reset_file_history_anchor_probe_census();
+        let bounded_renamed_file = session
+            .execute(
+                &format!(
+                    "SELECT path, content, lixcol_depth \
+                     FROM lix_history('lix_file', '{rename_commit_id}') \
+                     WHERE id = '70726f6a-6563-8469-8f6e-2d66696c6500' \
+                     ORDER BY lixcol_depth ASC LIMIT 1"
+                ),
+                &[],
+            )
+            .await
+            .expect("bounded renamed descendant history should load");
+        assert_rows_eq(
+            bounded_renamed_file,
+            vec![vec![
+                Value::Text("/archive/docs/guides/readme.md".to_string()),
+                Value::Blob(b"x".to_vec().into()),
+                Value::Integer(0),
+            ]],
+        );
+        assert_eq!(crate::sql2::file_history_anchor_probe_census(), (1, 1));
+
         let renamed_directory = session
             .execute(
                 &format!(
@@ -1471,6 +1494,52 @@ simulation_test!(
         let mut expected = vec![main_sibling, draft_sibling];
         expected.sort();
         assert_eq!(observed, expected);
+
+        crate::sql2::reset_file_history_anchor_probe_census();
+        let bounded_top_one = main
+            .execute(
+                &format!(
+                    "SELECT path, content, lixcol_depth \
+                     FROM lix_history('lix_file', '{merge_commit_id}') \
+                     WHERE id = '6469616d-6f6e-842d-8669-6c6500000000' \
+                     ORDER BY lixcol_depth ASC LIMIT 1"
+                ),
+                &[],
+            )
+            .await
+            .expect("top-one diamond history should load");
+        assert_eq!(bounded_top_one.len(), 1);
+        assert_eq!(
+            bounded_top_one.rows()[0]
+                .get::<i64>("lixcol_depth")
+                .unwrap(),
+            1,
+            "LIMIT 1 must complete the two-parent depth layer before truncating"
+        );
+
+        let bounded = main
+            .execute(
+                &format!(
+                    "SELECT path, content, lixcol_depth \
+                     FROM lix_history('lix_file', '{merge_commit_id}') \
+                     WHERE id = '6469616d-6f6e-842d-8669-6c6500000000' \
+                     ORDER BY lixcol_depth ASC LIMIT 2"
+                ),
+                &[],
+            )
+            .await
+            .expect("bounded diamond history should load");
+        assert_eq!(bounded.len(), 2, "the fetch must complete the merge depth layer");
+        for row in bounded.rows() {
+            assert_eq!(row.get::<String>("path").unwrap(), "/same.md");
+            assert_eq!(row.get::<Vec<u8>>("content").unwrap(), b"base");
+            assert_eq!(row.get::<i64>("lixcol_depth").unwrap(), 1);
+        }
+        assert_eq!(crate::sql2::file_history_anchor_probe_census(), (2, 2));
+        assert_eq!(
+            crate::sql2::file_history_bounded_frontier_census(),
+            vec![1, 1]
+        );
     }
 );
 
@@ -1702,6 +1771,269 @@ simulation_test!(
                 Value::Text("/target/three.txt".to_string()),
                 Value::Blob(b"three".to_vec().into()),
             ]],
+        );
+    }
+);
+
+simulation_test!(
+    lix_file_history_exact_id_fetch_bounds_history_and_hydrates_content,
+    |sim| async move {
+        let engine = sim.boot_engine().await;
+        let session = sim.wrap_session(
+            engine
+                .open_session()
+                .await
+                .expect("main session should open"),
+            &engine,
+        );
+
+        for index in 0..24 {
+            session
+                .execute(
+                    "INSERT INTO lix_key_value (key, value) VALUES ($1, $2)",
+                    &[
+                        Value::Text(format!("bounded-history-before-{index}")),
+                        Value::Text(index.to_string()),
+                    ],
+                )
+                .await
+                .expect("prehistory noise should commit");
+        }
+        let file_id = "5dca5f64-4803-7855-94ce-9465ac1e2ca4";
+        session
+            .execute(
+                "INSERT INTO lix_file (id, path, content) VALUES ($1, $2, CAST($3 AS BYTEA))",
+                &[
+                    Value::Text(file_id.to_owned()),
+                    Value::Text("/bounded-history.txt".to_owned()),
+                    Value::Text("before".to_owned()),
+                ],
+            )
+            .await
+            .expect("initial file revision should commit");
+        session
+            .execute(
+                "UPDATE lix_file SET content = CAST($1 AS BYTEA) WHERE id = $2",
+                &[
+                    Value::Text("after".to_owned()),
+                    Value::Text(file_id.to_owned()),
+                ],
+            )
+            .await
+            .expect("second file revision should commit");
+        for index in 0..5 {
+            session
+                .execute(
+                    "INSERT INTO lix_key_value (key, value) VALUES ($1, $2)",
+                    &[
+                        Value::Text(format!("bounded-history-after-{index}")),
+                        Value::Text(index.to_string()),
+                    ],
+                )
+                .await
+                .expect("posthistory noise should commit");
+        }
+        let anchor = engine
+            .load_branch_head_commit_id(sim.main_branch_id())
+            .await
+            .expect("history anchor should load")
+            .expect("history anchor should exist");
+        let query = |limit| {
+            format!(
+                "SELECT content, lixcol_depth \
+                 FROM lix_history('lix_file', '{anchor}') \
+                 WHERE id = '{file_id}' \
+                 ORDER BY lixcol_depth ASC LIMIT {limit}"
+            )
+        };
+
+        crate::sql2::reset_file_history_anchor_probe_census();
+        let top_one = session
+            .execute(&query(1), &[])
+            .await
+            .expect("top-one history should succeed");
+        assert_rows_eq(
+            top_one,
+            vec![vec![
+                Value::Blob(b"after".to_vec().into()),
+                Value::Integer(5),
+            ]],
+        );
+        let top_two = session
+            .execute(&query(2), &[])
+            .await
+            .expect("top-two history should succeed");
+        assert_rows_eq(
+            top_two,
+            vec![
+                vec![Value::Blob(b"after".to_vec().into()), Value::Integer(5)],
+                vec![Value::Blob(b"before".to_vec().into()), Value::Integer(6)],
+            ],
+        );
+        let oversized = session
+            .execute(&query(16), &[])
+            .await
+            .expect("oversized bounded history should succeed");
+        assert_eq!(oversized.len(), 2);
+
+        let (probes, hits) = crate::sql2::file_history_anchor_probe_census();
+        assert_eq!((probes, hits), (3, 3));
+        let frontiers = crate::sql2::file_history_bounded_frontier_census();
+        assert_eq!(frontiers, vec![5, 6, 6]);
+        assert!(
+            frontiers.iter().all(|depth| *depth < 24),
+            "bounded point history must not traverse the unrelated prehistory"
+        );
+    }
+);
+
+simulation_test!(
+    lix_file_history_missing_exact_id_prunes_preview_sized_history,
+    |sim| async move {
+        let engine = sim.boot_engine().await;
+        let session = sim.wrap_session(
+            engine
+                .open_session()
+                .await
+                .expect("main session should open"),
+            &engine,
+        );
+        for index in 0..70 {
+            session
+                .execute(
+                    "INSERT INTO lix_key_value (key, value) VALUES ($1, $2)",
+                    &[
+                        Value::Text(format!("missing-history-{index}")),
+                        Value::Text(index.to_string()),
+                    ],
+                )
+                .await
+                .expect("preview-sized history should commit");
+        }
+        let anchor = engine
+            .load_branch_head_commit_id(sim.main_branch_id())
+            .await
+            .expect("history anchor should load")
+            .expect("history anchor should exist");
+
+        crate::sql2::reset_file_history_anchor_probe_census();
+        let digest_before = crate::commit_graph::scope_digest_census();
+        let result = session
+            .execute(
+                &format!(
+                    "SELECT id, path, content, lixcol_depth \
+                     FROM lix_history('lix_file', '{anchor}') \
+                     WHERE id = 'deadbeef-dead-7bee-8bad-deadbeefdead' \
+                     ORDER BY lixcol_depth ASC LIMIT 1"
+                ),
+                &[],
+            )
+            .await
+            .expect("missing point history should succeed");
+        assert_eq!(result.len(), 0);
+        assert_eq!(crate::sql2::file_history_anchor_probe_census(), (1, 1));
+        assert!(crate::sql2::file_history_bounded_frontier_census().is_empty());
+        let digest = crate::commit_graph::scope_digest_census().since(&digest_before);
+        assert!(
+            digest.pruned >= 70,
+            "every unrelated preview commit should be rejected by its authenticated scope digest: {digest:?}"
+        );
+        assert_eq!(digest.loaded_present, 0);
+        assert_eq!(digest.loaded_opaque, 0);
+        assert_eq!(digest.loaded_absent, 0);
+    }
+);
+
+simulation_test!(
+    lix_file_history_bounded_fetch_preserves_tombstones_and_fallbacks,
+    |sim| async move {
+        let engine = sim.boot_engine().await;
+        let session = sim.wrap_session(
+            engine
+                .open_session()
+                .await
+                .expect("main session should open"),
+            &engine,
+        );
+        let file_id = "6e65f80b-92ea-70a7-b9bb-f6bc0882a852";
+        session
+            .execute(
+                "INSERT INTO lix_file (id, path, content) VALUES ($1, $2, CAST($3 AS BYTEA))",
+                &[
+                    Value::Text(file_id.to_owned()),
+                    Value::Text("/bounded-delete.txt".to_owned()),
+                    Value::Text("deleted content".to_owned()),
+                ],
+            )
+            .await
+            .expect("file should insert");
+        session
+            .execute("DELETE FROM lix_file WHERE id = $1", &[Value::Text(file_id.to_owned())])
+            .await
+            .expect("file should delete");
+        session
+            .execute(
+                "INSERT INTO lix_key_value (key, value) VALUES ('bounded-delete-noise', 'one')",
+                &[],
+            )
+            .await
+            .expect("noise should advance deletion depth");
+        let anchor = engine
+            .load_branch_head_commit_id(sim.main_branch_id())
+            .await
+            .expect("history anchor should load")
+            .expect("history anchor should exist");
+
+        crate::sql2::reset_file_history_anchor_probe_census();
+        let deleted = session
+            .execute(
+                &format!(
+                    "SELECT path, content, lixcol_depth \
+                     FROM lix_history('lix_file', '{anchor}') \
+                     WHERE id = '{file_id}' \
+                     ORDER BY lixcol_depth ASC LIMIT 1"
+                ),
+                &[],
+            )
+            .await
+            .expect("bounded tombstone history should load");
+        assert_rows_eq(
+            deleted,
+            vec![vec![Value::Null, Value::Null, Value::Integer(1)]],
+        );
+        assert_eq!(crate::sql2::file_history_anchor_probe_census(), (1, 1));
+
+        crate::sql2::reset_file_history_anchor_probe_census();
+        let descending = session
+            .execute(
+                &format!(
+                    "SELECT content, lixcol_depth \
+                     FROM lix_history('lix_file', '{anchor}') \
+                     WHERE id = '{file_id}' \
+                     ORDER BY lixcol_depth DESC LIMIT 1"
+                ),
+                &[],
+            )
+            .await
+            .expect("descending history fallback should load");
+        assert_eq!(descending.len(), 1);
+        let non_exact = session
+            .execute(
+                &format!(
+                    "SELECT content, lixcol_depth \
+                     FROM lix_history('lix_file', '{anchor}') \
+                     WHERE id LIKE '6e65f80b-%' \
+                     ORDER BY lixcol_depth ASC LIMIT 1"
+                ),
+                &[],
+            )
+            .await
+            .expect("non-exact history fallback should load");
+        assert_eq!(non_exact.len(), 1);
+        assert_eq!(
+            crate::sql2::file_history_anchor_probe_census(),
+            (0, 0),
+            "unsupported sort and predicate shapes must retain the complete traversal"
         );
     }
 );


### PR DESCRIPTION
## Summary

- push ORDER BY lixcol_depth ASC LIMIT N into exact-id, exact-anchor lix_file history reads
- use direct file revisions only to prove a depth frontier, then run the complete file-history shaper through that full merge layer
- truncate shaped rows before blob hydration; preserve full traversal for unsupported predicates and ordering
- bound parent-topology reconstruction to the same frontier
- add LIMIT 1/2/16, content, tombstone, directory, missing-ID, and merge-DAG regressions
- qualify plugin-owned content and a 64-checkpoint sparse midpoint read after an engaged GC sweep

## Correctness

Raw history limits do not stand in for SQL result limits. They only locate a safe upper depth boundary. The provider completes all commits at that depth, shapes directory/plugin/file events normally, and only then applies N.

Unsupported query shapes retain the unbounded path.

## Profile

Fixture: 100 files, 2 revisions of the selected file, 50/100/200 unrelated commits, 11 warm release samples.

Exact ID LIMIT 1 p50 after: 0.679 / 0.843 / 1.220 ms.
Previous baseline: 1.056 / 1.223 / 1.602 ms.
Improvement: 35.7% / 31.1% / 23.8%.

Exact ID LIMIT 1 with content: 0.671 / 0.862 / 1.231 ms.
Exact ID LIMIT 2: 0.827 / 1.034 / 1.408 ms.
Exact ID LIMIT 2 with content: 0.857 / 1.053 / 1.434 ms.

The 64-checkpoint sparse midpoint content query hydrates in one history request.

## Validation

- 22/22 focused lix_file_history tests
- plugin-owned durable content LIMIT 2 E2E
- 64-checkpoint sparse midpoint content E2E
- cargo check -p lix
- cargo fmt --all -- --check
- independent correctness review: no blockers