### PR TITLE
Stop bounded file history probes at LIMIT N

### DIFF
--- a/packages/lix/src/sql2/mod.rs
+++ b/packages/lix/src/sql2/mod.rs
@@ -20,7 +20,7 @@ mod providers;
 #[cfg(test)]
 pub(crate) use providers::{
     file_history_anchor_probe_census, file_history_bounded_frontier_census,
-    reset_file_history_anchor_probe_census,
+    file_history_raw_probe_limit_census, reset_file_history_anchor_probe_census,
 };
 mod read_only;
 mod result_metadata;

--- a/packages/lix/src/sql2/providers/file_history.rs
+++ b/packages/lix/src/sql2/providers/file_history.rs
@@ -650,6 +650,7 @@ struct FileHistoryPluginDiscovery {
 thread_local! {
     static ANCHOR_PROBES: std::cell::Cell<usize> = const { std::cell::Cell::new(0) };
     static ANCHOR_PROBE_HITS: std::cell::Cell<usize> = const { std::cell::Cell::new(0) };
+    static RAW_PROBE_LIMITS: std::cell::RefCell<Vec<usize>> = const { std::cell::RefCell::new(Vec::new()) };
     static BOUNDED_FRONTIERS: std::cell::RefCell<Vec<u32>> = const { std::cell::RefCell::new(Vec::new()) };
 }
 
@@ -657,7 +658,13 @@ thread_local! {
 pub(crate) fn reset_file_history_anchor_probe_census() {
     ANCHOR_PROBES.with(|count| count.set(0));
     ANCHOR_PROBE_HITS.with(|count| count.set(0));
+    RAW_PROBE_LIMITS.with(|limits| limits.borrow_mut().clear());
     BOUNDED_FRONTIERS.with(|depths| depths.borrow_mut().clear());
+}
+
+#[cfg(test)]
+pub(crate) fn file_history_raw_probe_limit_census() -> Vec<usize> {
+    RAW_PROBE_LIMITS.with(|limits| limits.borrow().clone())
 }
 
 #[cfg(test)]
@@ -733,8 +740,14 @@ where
     // add rows before that boundary. Completing the whole depth layer below
     // preserves merge semantics while avoiding traversal beneath it.
     let direct_route = file_history_descriptor_blob_route(&route.traversal_only(), lookup_ids)?;
-    let mut raw_limit = limit.saturating_mul(2).max(2);
+    // Ask for exactly the requested number first. Descriptor and blob entries
+    // can share a commit, so the distinct-revision check below doubles only
+    // when those duplicates leave us short. Starting at 2N makes sparse files
+    // traverse past a sufficient frontier merely to satisfy probe overfetch.
+    let mut raw_limit = limit;
     loop {
+        #[cfg(test)]
+        RAW_PROBE_LIMITS.with(|limits| limits.borrow_mut().push(raw_limit));
         let entries = load_history_entries(
             HistoryViewDescriptor {
                 view_name: "lix_history('lix_file')",

--- a/packages/lix/src/sql2/providers/mod.rs
+++ b/packages/lix/src/sql2/providers/mod.rs
@@ -24,7 +24,7 @@ mod file_history;
 #[cfg(test)]
 pub(crate) use file_history::{
     file_history_anchor_probe_census, file_history_bounded_frontier_census,
-    reset_file_history_anchor_probe_census,
+    file_history_raw_probe_limit_census, reset_file_history_anchor_probe_census,
 };
 mod filesystem_history_path;
 mod history_table_function;

--- a/packages/lix/tests/integration/sql/lix_file_history.rs
+++ b/packages/lix/tests/integration/sql/lix_file_history.rs
@@ -1811,6 +1811,11 @@ simulation_test!(
             )
             .await
             .expect("initial file revision should commit");
+        let initial_anchor = engine
+            .load_branch_head_commit_id(sim.main_branch_id())
+            .await
+            .expect("initial history anchor should load")
+            .expect("initial history anchor should exist");
         session
             .execute(
                 "UPDATE lix_file SET content = CAST($1 AS BYTEA) WHERE id = $2",
@@ -1878,11 +1883,36 @@ simulation_test!(
 
         let (probes, hits) = crate::sql2::file_history_anchor_probe_census();
         assert_eq!((probes, hits), (3, 3));
+        assert_eq!(
+            crate::sql2::file_history_raw_probe_limit_census(),
+            vec![1, 2, 16],
+            "the direct probe must begin at LIMIT N and expand only when duplicate entries leave fewer than N revisions",
+        );
         let frontiers = crate::sql2::file_history_bounded_frontier_census();
         assert_eq!(frontiers, vec![5, 6, 6]);
         assert!(
             frontiers.iter().all(|depth| *depth < 24),
             "bounded point history must not traverse the unrelated prehistory"
+        );
+
+        crate::sql2::reset_file_history_anchor_probe_census();
+        let duplicate_direct_entries = session
+            .execute(
+                &format!(
+                    "SELECT content, lixcol_depth \
+                     FROM lix_history('lix_file', '{initial_anchor}') \
+                     WHERE id = '{file_id}' \
+                     ORDER BY lixcol_depth ASC LIMIT 2"
+                ),
+                &[],
+            )
+            .await
+            .expect("duplicate direct entries should expand the raw probe");
+        assert_eq!(duplicate_direct_entries.len(), 1);
+        assert_eq!(
+            crate::sql2::file_history_raw_probe_limit_census(),
+            vec![2, 4],
+            "descriptor and blob entries at one commit must trigger adaptive expansion",
         );
     }
 );


### PR DESCRIPTION
## Summary

- start exact depth-ordered lix_file history probes at the requested LIMIT N instead of overfetching 2N
- retain adaptive doubling when descriptor and blob entries from one commit collapse to fewer than N distinct revisions
- add causal probe census coverage for LIMIT 1, 2, and 16 plus duplicate-entry expansion

## Why

A plugin-owned CSV file has only one direct descriptor or blob entry in the shallow range. A LIMIT 1 probe requested two raw entries and traversed sparse history trying to find a second entry that did not exist. On the LixRay PR preview repository this took about 28.2 seconds. With this change, fresh sync-replica runs resolve the same CSV history lookup in 3.13 to 3.31 ms.

## Validation

- focused lix_file_history suite: 17 of 17 passed
- exact LIMIT N regression: initial probe sizes 1, 2, 16 and duplicate expansion 2, 4
- fresh native sync profiles against LixRay PR 238 preview
- three independent reviews: no blockers
