### PR TITLE
fix(storage-opfs): batch point reads and suppress retry replays

### DIFF
--- a/.changenotes/batch-opfs-point-reads.md
+++ b/.changenotes/batch-opfs-point-reads.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+OPFS-backed Lix repositories now batch point reads through SQLite and suppress delayed retry replays after an owner request completes. This keeps checkpointing and other bounded foreground operations responsive while multiple browser clients bootstrap the same repository.

--- a/packages/storage-opfs/js/owner.ts
+++ b/packages/storage-opfs/js/owner.ts
@@ -23,32 +23,45 @@ type BackendEntry = {
 const backends = new Map<string, BackendEntry>();
 const channel = new BroadcastChannel(OPFS_RPC_CHANNEL);
 const inFlightRequests = new Map<string, Promise<void>>();
+const completedRequests = new Map<string, number>();
 const MAX_WARM_IDLE_BACKENDS = 2;
+const COMPLETED_REQUEST_TTL_MS = 30_000;
 
 setInterval(() => {
-	const cutoff = Date.now() - 15_000;
+	const now = Date.now();
+	const cutoff = now - 15_000;
 	for (const [name, entry] of backends) {
 		for (const [clientId, lastSeen] of entry.clients) {
 			if (lastSeen < cutoff) entry.clients.delete(clientId);
 		}
 		scheduleIdleClose(name, entry);
 	}
+	pruneCompletedRequests(now);
 }, 5_000);
 
 channel.onmessage = (event: MessageEvent<OpfsRpcRequest>) => {
 	const request = event.data;
 	if (!request || request.kind !== "request") return;
 	// BroadcastChannel retries can deliver the same request while a SQLite
-	// operation is still running. Do not enqueue duplicate reads/commits.
-	if (inFlightRequests.has(request.requestId)) return;
-	const pending = dispatch(request);
+	// operation is still running, and queued retry events can arrive after it
+	// completes. Retain completed IDs past the client's retry deadline so one
+	// logical read cannot be replayed into an ever-growing owner backlog.
+	if (
+		inFlightRequests.has(request.requestId) ||
+		completedRequests.has(request.requestId)
+	) {
+		return;
+	}
+	const pending = dispatch(request).then((responded) => {
+		if (responded) rememberCompletedRequest(request.requestId);
+	});
 	inFlightRequests.set(request.requestId, pending);
 	void pending
 		.finally(() => inFlightRequests.delete(request.requestId))
 		.catch(() => undefined);
 };
 
-async function dispatch(request: OpfsRpcRequest): Promise<void> {
+async function dispatch(request: OpfsRpcRequest): Promise<boolean> {
 	const entry = getEntry(request.storageName);
 	if (request.operation === "close") {
 		entry.clients.delete(request.clientId);
@@ -60,7 +73,7 @@ async function dispatch(request: OpfsRpcRequest): Promise<void> {
 			ok: true,
 			result: undefined,
 		});
-		return;
+		return true;
 	}
 	entry.clients.set(request.clientId, Date.now());
 	if (entry.idleTimer) {
@@ -80,8 +93,9 @@ async function dispatch(request: OpfsRpcRequest): Promise<void> {
 				ok: false,
 				error: serializeError(entry.fatalError),
 			});
+			return true;
 		}
-		return;
+		return false;
 	}
 	const operation = entry.queue.then(async () => {
 		switch (request.operation) {
@@ -139,6 +153,7 @@ async function dispatch(request: OpfsRpcRequest): Promise<void> {
 			ok: true,
 			result,
 		});
+		return true;
 	} catch (error) {
 		postResponse({
 			kind: "response",
@@ -147,6 +162,20 @@ async function dispatch(request: OpfsRpcRequest): Promise<void> {
 			ok: false,
 			error: serializeError(error),
 		});
+		return true;
+	}
+}
+
+function rememberCompletedRequest(requestId: string): void {
+	completedRequests.set(requestId, Date.now());
+	pruneCompletedRequests(Date.now());
+}
+
+function pruneCompletedRequests(now: number): void {
+	const cutoff = now - COMPLETED_REQUEST_TTL_MS;
+	for (const [requestId, completedAt] of completedRequests) {
+		if (completedAt >= cutoff) break;
+		completedRequests.delete(requestId);
 	}
 }
 

--- a/packages/storage-opfs/js/provider.ts
+++ b/packages/storage-opfs/js/provider.ts
@@ -59,6 +59,10 @@ type BrowserNavigator = {
 
 const SQLITE_VFS_NAME_PREFIX = "lix-opfs-sahpool-";
 const SQLITE_VFS_DIRECTORY = "/lix/sqlite-sahpool";
+// Keep point reads comfortably below SQLite's conservative 999-variable
+// ceiling while collapsing hundreds of JS/Wasm bind-step-reset crossings into
+// a handful of indexed joins.
+const READ_MANY_KEYS_PER_QUERY = 300;
 const SQLITE_SCHEMA = `
 PRAGMA journal_mode = WAL;
 PRAGMA synchronous = NORMAL;
@@ -170,25 +174,56 @@ export class OpfsBackend implements LixStorageProvider {
 		generation: number,
 	): Array<LixStorageProjectedValue | null> {
 		this.#assertGeneration(generation);
+		const entries = requests.flatMap((request) =>
+			request.keys.map((key) => ({
+				spaceId: request.space.id,
+				key,
+				projection: request.options.projection,
+			})),
+		);
 		const values: Array<LixStorageProjectedValue | null> = [];
-		for (const request of requests) {
-			const statement = this.#database.prepare(
-				"SELECT value FROM lix_entries WHERE space = ? AND key = ?",
-			);
-			try {
-				for (const key of request.keys) {
-					statement.bind([request.space.id, key]);
-					if (!statement.step()) {
-						values.push(null);
-					} else if (request.options.projection === "keyOnly") {
-						values.push({ kind: "keyOnly" });
-					} else {
-						values.push({ kind: "fullValue", value: copyBlob(statement.get(0)) });
-					}
-					statement.reset(true);
+		for (
+			let offset = 0;
+			offset < entries.length;
+			offset += READ_MANY_KEYS_PER_QUERY
+		) {
+			const chunk = entries.slice(offset, offset + READ_MANY_KEYS_PER_QUERY);
+			const requestedRows = chunk
+				.map((_, index) => `(${index}, ?, ?, ?)`)
+				.join(", ");
+			const bindings: SqliteValue[] = [];
+			for (const entry of chunk) {
+				bindings.push(
+					entry.spaceId,
+					entry.key,
+					entry.projection === "fullValue" ? 1 : 0,
+				);
+			}
+			const rows: SqliteValue[][] = [];
+			this.#database.exec({
+				sql: `WITH requested(ordinal, space, key, wants_value) AS (
+					VALUES ${requestedRows}
+				)
+				SELECT entries.value IS NOT NULL,
+					CASE WHEN requested.wants_value = 1 THEN entries.value END
+				FROM requested
+				LEFT JOIN lix_entries AS entries
+					ON entries.space = requested.space AND entries.key = requested.key
+				ORDER BY requested.ordinal`,
+				bind: bindings,
+				rowMode: "array",
+				resultRows: rows,
+			});
+			for (let index = 0; index < rows.length; index += 1) {
+				const row = rows[index]!;
+				const entry = chunk[index]!;
+				if (row[0] !== 1) {
+					values.push(null);
+				} else if (entry.projection === "keyOnly") {
+					values.push({ kind: "keyOnly" });
+				} else {
+					values.push({ kind: "fullValue", value: copyBlob(row[1]) });
 				}
-			} finally {
-				statement.finalize();
 			}
 		}
 		this.#assertGeneration(generation);

--- a/packages/storage-opfs/tests/opfs-storage.browser.test.ts
+++ b/packages/storage-opfs/tests/opfs-storage.browser.test.ts
@@ -1,6 +1,16 @@
-import { openLix } from "@lix-js/sdk";
+import {
+	openLix,
+	type LixStorageProvider,
+	type LixStorageProviderRegistration,
+	type LixStorageSpace,
+} from "@lix-js/sdk";
 import { OpfsStorage } from "@lix-js/storage-opfs";
 import { expect, test } from "vitest";
+import {
+	OPFS_RPC_CHANNEL,
+	type OpfsRpcRequest,
+	type OpfsRpcResponse,
+} from "../js/rpc.js";
 import { restoreSynchronousModeBestEffort } from "../js/sqlite-cleanup.js";
 
 test("does not replace a committed result with a synchronous cleanup error", () => {
@@ -130,6 +140,136 @@ test("opens distinct repositories in parallel workers", async () => {
 		expect(await keyValue(reopenedRight, "repository-isolation")).toBe("right");
 	} finally {
 		await Promise.all([reopenedLeft.close(), reopenedRight.close()]);
+	}
+});
+
+test("preserves mixed projection order across batched point reads", async () => {
+	const storage = new OpfsStorage({
+		name: `lix-opfs-batched-read:${crypto.randomUUID()}`,
+	});
+	const provider = await openProvider(storage.lixStorage);
+	const space: LixStorageSpace = {
+		id: 41,
+		name: "batched-read",
+		valueSemantics: "mutable",
+		valueIntegrity: "backendVerified",
+	};
+	const otherSpace: LixStorageSpace = {
+		...space,
+		id: 42,
+		name: "batched-read-other-space",
+	};
+	const entries = Array.from({ length: 650 }, (_, index) => ({
+		key: keyBytes(index),
+		value: new Uint8Array([index & 0xff, index >>> 8]),
+	}));
+	const emptyValueEntry = { key: keyBytes(700), value: new Uint8Array() };
+	const otherSpaceEntry = {
+		key: entries[12]!.key,
+		value: new Uint8Array([42]),
+	};
+	try {
+		const write = await provider.beginWrite({
+			awaitDurable: false,
+			preconditions: [],
+			batchCapacityHintBytes: entries.length * 6,
+		});
+		await write.putMany(space, [...entries, emptyValueEntry]);
+		await write.putMany(otherSpace, [otherSpaceEntry]);
+		await write.commit();
+
+		const read = await provider.beginRead({
+			consistency: "snapshot",
+			durability: "visible",
+		});
+		const requests = [
+			{
+				space,
+				keys: entries.slice(0, 299).map((entry) => entry.key),
+				options: { projection: "fullValue" },
+			},
+			{
+				space,
+				keys: [entries[12]!.key, keyBytes(999)],
+				options: { projection: "keyOnly" },
+			},
+			{
+				space: otherSpace,
+				keys: [entries[12]!.key, keyBytes(999)],
+				options: { projection: "fullValue" },
+			},
+			{
+				space,
+				keys: entries.slice(299).map((entry) => entry.key),
+				options: { projection: "keyOnly" },
+			},
+			{
+				space,
+				keys: [entries[12]!.key, emptyValueEntry.key],
+				options: { projection: "fullValue" },
+			},
+		] satisfies Parameters<typeof read.getMany>[0];
+		const values = await read.getMany(requests);
+
+		const expected = [
+			...entries.slice(0, 299).map((entry) => ({
+				kind: "fullValue",
+				value: entry.value,
+			})),
+			{ kind: "keyOnly" },
+			null,
+			{ kind: "fullValue", value: otherSpaceEntry.value },
+			null,
+			...entries.slice(299).map(() => ({ kind: "keyOnly" } as const)),
+			{ kind: "fullValue", value: entries[12]!.value },
+			{ kind: "fullValue", value: emptyValueEntry.value },
+		];
+		expect(values).toEqual(expected);
+	} finally {
+		await provider.close();
+	}
+});
+
+test("does not replay a request after its owner response completes", async () => {
+	const storageName = `lix-opfs-completed-request:${crypto.randomUUID()}`;
+	const lix = await openLix({
+		storage: new OpfsStorage({ name: storageName }),
+	});
+	const channel = new BroadcastChannel(OPFS_RPC_CHANNEL);
+	const request: OpfsRpcRequest = {
+		kind: "request",
+		requestId: crypto.randomUUID(),
+		clientId: crypto.randomUUID(),
+		storageName,
+		operation: "open",
+		payload: undefined,
+	};
+	const responses: OpfsRpcResponse[] = [];
+	channel.onmessage = (event: MessageEvent<OpfsRpcResponse>) => {
+		if (
+			event.data.kind === "response" &&
+			event.data.requestId === request.requestId
+		) {
+			responses.push(event.data);
+		}
+	};
+	try {
+		channel.postMessage(request);
+		await expect
+			.poll(() => responses.length, { timeout: 2_000 })
+			.toBe(1);
+		channel.postMessage(request);
+		// A unique request from the same sender is a deterministic FIFO barrier.
+		// The old owner re-executed the duplicate and emitted its second response
+		// before this barrier; the completed-ID cache drops it instead.
+		await postRpcAndWait(channel, {
+			...request,
+			requestId: crypto.randomUUID(),
+		});
+		expect(responses).toHaveLength(1);
+	} finally {
+		channel.close();
+		await lix.close();
 	}
 });
 
@@ -275,4 +415,42 @@ async function keyValues(
 		keys,
 	);
 	return result.rows.map((row) => [row.get("key"), row.get("value")]);
+}
+
+function keyBytes(index: number): Uint8Array {
+	const key = new Uint8Array(4);
+	new DataView(key.buffer).setUint32(0, index, false);
+	return key;
+}
+
+async function openProvider(
+	registration: LixStorageProviderRegistration,
+): Promise<LixStorageProvider> {
+	const module = (await import(/* @vite-ignore */ registration.moduleUrl)) as {
+		createLixStorageProvider(options: unknown): Promise<LixStorageProvider>;
+	};
+	return module.createLixStorageProvider(registration.options);
+}
+
+function postRpcAndWait(
+	channel: BroadcastChannel,
+	request: OpfsRpcRequest,
+): Promise<OpfsRpcResponse> {
+	return withTimeout(
+		new Promise((resolve) => {
+			const listener = (event: MessageEvent<OpfsRpcResponse>) => {
+				if (
+					event.data.kind !== "response" ||
+					event.data.requestId !== request.requestId
+				) {
+					return;
+				}
+				channel.removeEventListener("message", listener);
+				resolve(event.data);
+			};
+			channel.addEventListener("message", listener);
+			channel.postMessage(request);
+		}),
+		2_000,
+	);
 }


### PR DESCRIPTION
## Problem

A preview-sized LixRay repository exposed a 44.5 second local checkpoint action even though the checkpoint algorithm itself is bounded. Profiling isolated two OPFS RPC amplifiers:

- readMany performed one SQLite bind/step/reset cycle per key;
- clients retry reads every 50 ms, while the owner forgot a request ID immediately after responding. Retry messages queued during synchronous SQLite work could therefore replay the completed operation into the serial owner queue.

## Fix

- Flatten readMany requests and query indexed point keys in 300-key / 900-bind SQLite batches.
- Preserve request order, duplicates, misses, spaces, and keyOnly/fullValue projections.
- Retain completed request IDs for 30 seconds, beyond the 15-second client retry horizon.
- Only retain IDs for workers that actually responded, preserving relay and owner-handoff behavior.

## Causal coverage

- Browser coverage crosses the 299/300 batch boundary and checks mixed spaces, duplicate keys, both projections, both miss projections, and an empty value.
- A same-sender FIFO RPC barrier deterministically proves a completed request is not replayed. The old implementation emits a second response before the barrier; the fixed implementation suppresses it.

## Profile

Exact 10,000-key OPFS point read, same local browser and data:

- before: 677 ms for the read; 9.663 s for the test while delayed retry replays drained;
- after: 59.6 ms for the read; 273 ms end-to-end.

That is about 11x faster for the point read and 35x faster end-to-end, with the replay backlog removed.

## Validation

- storage-opfs typecheck
- focused Chromium suite: 10/10
- full OPFS browser suite: 23/23
- packed production Vite smoke
- all four OPFS benchmarks
- multi-tab observer and owner-failover benchmarks
- build and package dry run
- independent reviews: no remaining correctness blockers