### PR TITLE
test(gc): tolerate spawned sweep conflict

### DIFF
--- a/packages/lix/src/session/gc.rs
+++ b/packages/lix/src/session/gc.rs
@@ -424,10 +424,24 @@ mod tests {
                 .expect("padding checkpoint succeeds");
         }
 
-        let plan = session
-            .collect_checkpoint_garbage()
-            .await
-            .expect("the sweep must succeed");
+        // `create_checkpoint` schedules this same sweep best-effort. The
+        // explicit call can therefore prepare from the same snapshot and lose
+        // the optimistic commit race. Retry that expected conflict until one
+        // sweep has committed; every other error still fails the test.
+        let deadline = Instant::now() + Duration::from_secs(5);
+        let plan = loop {
+            match session.collect_checkpoint_garbage().await {
+                Ok(plan) => break plan,
+                Err(error) if error.code == LixError::CODE_TRANSACTION_CONFLICT => {
+                    assert!(
+                        Instant::now() < deadline,
+                        "checkpoint GC remained in conflict with its spawned sweep: {error:?}"
+                    );
+                    tokio::time::sleep(Duration::from_millis(20)).await;
+                }
+                Err(error) => panic!("the sweep must succeed: {error:?}"),
+            }
+        };
 
         let after = committed_state(&session).await;
         let observed_live_manifest_count = if let Some(plan) = plan {


### PR DESCRIPTION
## Problem

The full Lix suite exposed a race in reclaim_trigger_persists_its_estimates_to_committed_storage. create_checkpoint schedules the same best-effort GC sweep that the test later invokes explicitly. If both prepare from the same snapshot, one validly wins and the other returns LIX_TRANSACTION_CONFLICT. The test already documented the competing sweep and accepted its committed result, but it unconditionally expected the explicit call to succeed.

## Fix

Retry only the expected optimistic transaction conflict for at most five seconds with 20 ms spacing. Any other error still fails immediately, and sustained conflict still fails at the deadline. The existing committed-state assertions still require a real persisted sweep result when the automatic collector wins.

This matches the conflict handling already used by the later legacy-GC regression in the same module, with a tighter bound for this small in-memory fixture.

## Validation

- exact regression: 20/20 locally
- cargo fmt check
- git diff check
- independent review: no blocker