### PR TITLE
fix: use working diff for partial checkpoints

### DIFF
--- a/packages/lix/src/sync/simulation_tests.rs
+++ b/packages/lix/src/sync/simulation_tests.rs
@@ -520,6 +520,172 @@ async fn lazy_history_and_binary_cas_scenarios(sim: Simulation) {
     assert!(!checkpoints.rows().is_empty());
 }
 
+async fn sparse_partial_checkpoint_uses_hot_working_diff(_sim: Simulation) {
+    let authority = fresh_authority().await;
+    write_key_value(&authority, "selected", "baseline").await;
+    write_key_value(&authority, "remaining", "baseline").await;
+    authority
+        .create_checkpoint()
+        .await
+        .expect("baseline checkpoint should commit");
+    let mut replica = Replica::bootstrap(AuthorityTransport::connected(authority.clone())).await;
+
+    // Advance the shared checkpoint only after this replica bootstrapped. The
+    // following interval therefore arrives through sparse delta
+    // reconciliation instead of the initial complete checkpoint snapshot.
+    write_key_value(&authority, "selected", "checkpointed").await;
+    write_key_value(&authority, "remaining", "checkpointed").await;
+    authority
+        .create_checkpoint()
+        .await
+        .expect("remote checkpoint should commit");
+    replica
+        .pump()
+        .await
+        .expect("replica should import the remote checkpoint");
+
+    for index in 0..24 {
+        write_key_value(&authority, "selected", &format!("selected-{index}")).await;
+        write_key_value(&authority, "remaining", &format!("remaining-{index}")).await;
+    }
+    replica
+        .pump()
+        .await
+        .expect("replica should import the sparse working interval");
+
+    let selected_diff_id = replica
+        .lix
+        .execute(
+            "SELECT diff_id FROM lix_working_diff() \
+             WHERE schema_key = 'lix_key_value' \
+               AND row_pk = CAST('[\"selected\"]' AS JSONB)",
+            &[],
+        )
+        .await
+        .expect("selected working diff should be hot")
+        .rows()[0]
+        .get::<String>("diff_id")
+        .expect("selected diff id should decode");
+    let head_commit_id_text = replica
+        .lix
+        .execute("SELECT lix_active_branch_commit_id() AS id", &[])
+        .await
+        .expect("working head coordinate should load")
+        .rows()[0]
+        .get::<String>("id")
+        .expect("working head coordinate should decode");
+    let branch_id = replica
+        .lix
+        .active_branch_id()
+        .await
+        .expect("active branch id should load");
+    let adapter = replica.lix.storage_adapter();
+    let checkpoint_read = adapter
+        .begin_read(crate::storage_adapter::StorageReadOptions::default())
+        .await
+        .expect("checkpoint cursor read should open");
+    let head_commit_id = crate::changelog::CommitId::parse_lix(
+        &head_commit_id_text,
+        "working head fixture",
+    )
+    .expect("working head id should be canonical");
+    let checkpoint_commit_id = crate::checkpoint::checkpoint_commit_id_at_head(
+        &checkpoint_read,
+        &branch_id,
+        head_commit_id,
+    )
+    .await
+    .expect("working checkpoint coordinate should load")
+    .to_string();
+    drop(checkpoint_read);
+
+    // The selected diff id is frozen before the checkpoint command. Probe the
+    // canonical endpoint diff directly: a selective checkpoint must consume
+    // the already-certified hot working diff and never reconstruct the same
+    // interval through diff_commits(checkpoint, head).
+    crate::tracked_state::arm_diff_commits_test_probe(
+        &checkpoint_commit_id,
+        &head_commit_id_text,
+    );
+
+    let checkpoint = replica
+        .lix
+        .execute(
+            "INSERT INTO lix_create_checkpoint (diff_id) SELECT $1 RETURNING commit_id",
+            &[Value::Text(selected_diff_id)],
+        )
+        .await
+        .expect("partial checkpoint should use the hot working-diff authority");
+    assert_eq!(
+        crate::tracked_state::take_diff_commits_test_probe(
+            &checkpoint_commit_id,
+            &head_commit_id_text,
+        ),
+        0,
+        "partial checkpoint must not reconstruct the certified working diff",
+    );
+    assert_eq!(checkpoint.rows_affected(), 1);
+    let checkpoint_commit_id = checkpoint.rows()[0]
+        .get::<String>("commit_id")
+        .expect("checkpoint commit id should decode");
+
+    let checkpoint_state = replica
+        .lix
+        .execute(
+            &format!(
+                "SELECT key, value FROM lix_history('lix_key_value', '{checkpoint_commit_id}') \
+                 WHERE lixcol_depth = 0 ORDER BY key"
+            ),
+            &[],
+        )
+        .await
+        .expect("partial checkpoint state should remain readable");
+    let checkpoint_values = checkpoint_state
+        .rows()
+        .iter()
+        .map(|row| {
+            (
+                row.get::<String>("key").expect("checkpoint state key"),
+                row.get::<serde_json::Value>("value")
+                    .expect("checkpoint state value"),
+            )
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(
+        checkpoint_values,
+        vec![("selected".to_owned(), serde_json::json!("selected-23"))]
+    );
+
+    let remaining = replica
+        .lix
+        .execute(
+            "SELECT row_pk FROM lix_working_diff() \
+             WHERE schema_key = 'lix_key_value' ORDER BY row_pk",
+            &[],
+        )
+        .await
+        .expect("unselected working diff should remain readable");
+    assert_eq!(remaining.rows().len(), 1);
+    assert_eq!(
+        remaining.rows()[0]
+            .get::<serde_json::Value>("row_pk")
+            .expect("remaining row key"),
+        serde_json::json!(["remaining"]),
+    );
+    let final_values = hot_digest(&replica.lix)
+        .await
+        .into_iter()
+        .filter(|(key, _)| key == "remaining" || key == "selected")
+        .collect::<Vec<_>>();
+    assert_eq!(
+        final_values,
+        vec![
+            ("remaining".to_owned(), "\"remaining-23\"".to_owned()),
+            ("selected".to_owned(), "\"selected-23\"".to_owned()),
+        ]
+    );
+}
+
 async fn deterministic_sync_command_traces(_sim: Simulation) {
     for seed in fuzz_seeds(&(0_u64..32).collect::<Vec<_>>()) {
         // Each seed starts from an independent repository, so an override can
@@ -571,6 +737,10 @@ sync_simulation_test!(
 sync_simulation_test!(
     deterministic_sync_command_traces,
     deterministic_sync_command_traces
+);
+sync_simulation_test!(
+    sparse_partial_checkpoint_uses_hot_working_diff,
+    sparse_partial_checkpoint_uses_hot_working_diff
 );
 
 struct XorShift64(u64);

--- a/packages/lix/src/tracked_state/diff.rs
+++ b/packages/lix/src/tracked_state/diff.rs
@@ -5,6 +5,8 @@ use std::collections::HashMap;
 use std::fmt;
 use std::hash::{Hash, Hasher};
 use std::sync::{Arc, OnceLock};
+#[cfg(test)]
+use std::sync::Mutex;
 
 use crate::LixError;
 use crate::changelog::{ChangeId, CommitId};
@@ -15,6 +17,40 @@ use crate::tracked_state::types::{
     TrackedStateIndexValue, TrackedStateKey, TrackedStateKeyRef, TrackedStateTreeScanRequest,
 };
 use crate::tracked_state::{TrackedStateFilter, TrackedStateStoreReader};
+
+#[cfg(test)]
+static DIFF_COMMITS_TEST_PROBES: OnceLock<Mutex<HashMap<(String, String), u64>>> = OnceLock::new();
+
+#[cfg(test)]
+pub(crate) fn arm_diff_commits_test_probe(left: &str, right: &str) {
+    DIFF_COMMITS_TEST_PROBES
+        .get_or_init(|| Mutex::new(HashMap::new()))
+        .lock()
+        .expect("diff-commits test probe lock should remain available")
+        .insert((left.to_owned(), right.to_owned()), 0);
+}
+
+#[cfg(test)]
+pub(crate) fn take_diff_commits_test_probe(left: &str, right: &str) -> u64 {
+    DIFF_COMMITS_TEST_PROBES
+        .get_or_init(|| Mutex::new(HashMap::new()))
+        .lock()
+        .expect("diff-commits test probe lock should remain available")
+        .remove(&(left.to_owned(), right.to_owned()))
+        .expect("diff-commits test probe should be armed")
+}
+
+#[cfg(test)]
+fn record_diff_commits_test_probe(left: &str, right: &str) {
+    if let Some(probes) = DIFF_COMMITS_TEST_PROBES.get()
+        && let Some(count) = probes
+            .lock()
+            .expect("diff-commits test probe lock should remain available")
+            .get_mut(&(left.to_owned(), right.to_owned()))
+    {
+        *count += 1;
+    }
+}
 
 /// Filter for comparing two tracked-state commit roots.
 #[derive(Debug, Clone, PartialEq)]
@@ -355,6 +391,8 @@ pub(crate) async fn diff_commits<S>(
 where
     S: crate::storage_adapter::StorageAdapterRead,
 {
+    #[cfg(test)]
+    record_diff_commits_test_probe(left_commit_id, right_commit_id);
     let scan_request = scan_request_for_diff(request);
     let mut tree_diff = reader
         .diff_semantic_tree_entries_at_commits(left_commit_id, right_commit_id, &scan_request)

--- a/packages/lix/src/tracked_state/mod.rs
+++ b/packages/lix/src/tracked_state/mod.rs
@@ -10,6 +10,8 @@ mod context;
 mod current_state_data_part;
 pub(crate) mod current_state_envelope;
 mod diff;
+#[cfg(test)]
+pub(crate) use diff::{arm_diff_commits_test_probe, take_diff_commits_test_probe};
 mod diff_id;
 mod merge;
 pub(crate) mod mutation_directory;

--- a/packages/lix/src/transaction/context.rs
+++ b/packages/lix/src/transaction/context.rs
@@ -8556,18 +8556,49 @@ where
             .load_branch_head(&branch_id)
             .await?
             .ok_or_else(|| LixError::branch_not_found(&branch_id, "create checkpoint", "target"))?;
-        let previous_checkpoint_commit_id = self
-            .checkpoint_commit_id_at_head(&branch_id, head_commit_id)
-            .await?;
-        let diff = {
-            let mut tracked = self.tracked_state_reader().await;
-            tracked
-                .diff_commits(
-                    &previous_checkpoint_commit_id.to_string(),
-                    &head_commit_id.to_string(),
-                    &TrackedStateDiffRequest::default(),
+        let control = BranchHeadControlContext::new()
+            .reader(self.opening_read())
+            .load(&branch_id)
+            .await?
+            .ok_or_else(|| {
+                LixError::branch_not_found(&branch_id, "create checkpoint", "target")
+            })?;
+        if control.head_commit_id != head_commit_id {
+            return Err(LixError::new(
+                LixError::CODE_TRANSACTION_CONFLICT,
+                format!(
+                    "branch '{branch_id}' head changed while loading its checkpoint cursor"
+                ),
+            ));
+        }
+        let previous_checkpoint_commit_id = control
+            .working_diff_checkpoint_commit_id
+            .ok_or_else(|| {
+                LixError::new(
+                    LixError::CODE_INTERNAL_ERROR,
+                    format!("branch '{branch_id}' has no checkpoint cursor"),
                 )
-                .await?
+            })?;
+        let direct_diff = TrackedHeadContext::new()
+            .reader(self.opening_read())
+            .working_diff_for_control(
+                &branch_id,
+                control,
+                &TrackedStateDiffRequest::default(),
+            )
+            .await?;
+        let diff = match direct_diff {
+            Some(direct) => direct.diff,
+            None => {
+                let mut tracked = self.tracked_state_reader().await;
+                tracked
+                    .diff_commits(
+                        &previous_checkpoint_commit_id.to_string(),
+                        &head_commit_id.to_string(),
+                        &TrackedStateDiffRequest::default(),
+                    )
+                    .await?
+            }
         };
         let requested = diff_ids.iter().cloned().collect::<BTreeSet<_>>();
         if requested.len() != diff_ids.len() {


### PR DESCRIPTION
## Problem

Selective checkpoint creation receives diff IDs from `lix_working_diff()`, but recomputes the same checkpoint-to-head diff with `diff_commits`. On sparse replicas this can demand cold immutable endpoint state and trigger sequential sync history hydration even though the certified hot working-diff epoch is already authoritative.

## Fix

- Load the branch control from the transaction opening snapshot.
- Validate it matches the selected head and checkpoint cursor.
- Consume the certified hot working diff when available.
- Retain canonical endpoint diffing only as the existing missing/invalid-index fallback.

## Causal regression

The regression freezes a selected diff ID before checkpoint execution and probes the exact `diff_commits(checkpoint, head)` pair. It asserts zero reconstruction calls, verifies the selected checkpoint history, verifies the unselected row remains in the working diff, and verifies final current values.

A/B:
- old implementation + new test: expected failure (`left: 1`, `right: 0`)
- this implementation: pass (`0` endpoint reconstructions)

## Local verification

- `cargo test -p lix sparse_partial_checkpoint_uses_hot_working_diff -- --nocapture`
- `cargo test -p lix checkpoint -- --nocapture` (77 passed)
- `cargo test -p lix sync::simulation_tests -- --nocapture` (4 passed)
- `cargo test -p lix --features all-simulations` (3,257 unit tests passed; integration and docs passed)
- `cargo check -p lix --tests`
- `cargo clippy --profile test -p lix --all-targets --all-features -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`

## Profile

Warm release microbenchmark stayed in the same low-millisecond range: 100 rows median 2.36ms before / 2.58ms after; 1,000 rows median 10.51ms before / 12.45ms after. The sparse causal boundary changes from requiring endpoint reconstruction/hydration to zero `diff_commits(checkpoint, head)` calls.