### PR TITLE
perf: batch partial checkpoint payload reads

### DIFF
--- a/packages/lix/src/sync/simulation_tests.rs
+++ b/packages/lix/src/sync/simulation_tests.rs
@@ -686,6 +686,79 @@ async fn sparse_partial_checkpoint_uses_hot_working_diff(_sim: Simulation) {
     );
 }
 
+async fn partial_checkpoint_batches_distinct_change_owners(_sim: Simulation) {
+    const OWNER_COUNT: usize = 50;
+    let authority = fresh_authority().await;
+    write_key_value(&authority, "baseline", "shared").await;
+    authority
+        .create_checkpoint()
+        .await
+        .expect("baseline checkpoint should commit");
+    let mut replica = Replica::bootstrap(AuthorityTransport::connected(authority.clone())).await;
+    for index in 0..OWNER_COUNT {
+        write_key_value(
+            &authority,
+            &format!("owner-{index:02}"),
+            &format!("value-{index:02}"),
+        )
+        .await;
+    }
+    replica
+        .pump()
+        .await
+        .expect("replica should import every distinct change owner");
+    let selected_diff_id = replica
+        .lix
+        .execute(
+            "SELECT diff_id FROM lix_working_diff() \
+             WHERE schema_key = 'lix_key_value' \
+               AND row_pk = CAST('[\"owner-00\"]' AS JSONB)",
+            &[],
+        )
+        .await
+        .expect("selected working diff should load")
+        .rows()[0]
+        .get::<String>("diff_id")
+        .expect("selected diff id should decode");
+
+    crate::tracked_state::arm_point_replay_authority_batch_probe_for_test();
+    let checkpoint = replica
+        .lix
+        .execute(
+            "INSERT INTO lix_create_checkpoint (diff_id) SELECT $1 RETURNING commit_id",
+            &[Value::Text(selected_diff_id)],
+        )
+        .await
+        .expect("partial checkpoint should batch selected-change owners");
+    let authority_batches =
+        crate::tracked_state::take_point_replay_authority_batch_probe_for_test();
+
+    assert_eq!(checkpoint.rows_affected(), 1);
+    assert!(
+        authority_batches
+            .iter()
+            .any(|owner_count| *owner_count >= OWNER_COUNT),
+        "the complete selected-change owner set must enter one authority batch: {authority_batches:?}",
+    );
+    assert!(
+        authority_batches.iter().filter(|count| **count == 1).count() <= 8,
+        "partial checkpoint must not fall back to one authority read per owner: {authority_batches:?}",
+    );
+    let remaining = replica
+        .lix
+        .execute(
+            "SELECT count(*) AS count FROM lix_working_diff() \
+             WHERE schema_key = 'lix_key_value'",
+            &[],
+        )
+        .await
+        .expect("remaining working diff should load")
+        .rows()[0]
+        .get::<i64>("count")
+        .expect("remaining count should decode");
+    assert_eq!(remaining, (OWNER_COUNT - 1) as i64);
+}
+
 async fn deterministic_sync_command_traces(_sim: Simulation) {
     for seed in fuzz_seeds(&(0_u64..32).collect::<Vec<_>>()) {
         // Each seed starts from an independent repository, so an override can
@@ -741,6 +814,10 @@ sync_simulation_test!(
 sync_simulation_test!(
     sparse_partial_checkpoint_uses_hot_working_diff,
     sparse_partial_checkpoint_uses_hot_working_diff
+);
+sync_simulation_test!(
+    partial_checkpoint_batches_distinct_change_owners,
+    partial_checkpoint_batches_distinct_change_owners
 );
 
 struct XorShift64(u64);

--- a/packages/lix/src/tracked_state/mod.rs
+++ b/packages/lix/src/tracked_state/mod.rs
@@ -76,6 +76,11 @@ pub(crate) use storage::load_commit_state_authority_ids;
 pub(crate) use storage::stage_commit_state_manifest;
 #[cfg(test)]
 pub(crate) use storage::stage_sweep_unreachable_content_nodes;
+#[cfg(test)]
+pub(crate) use storage::{
+    arm_point_replay_authority_batch_probe_for_test,
+    take_point_replay_authority_batch_probe_for_test,
+};
 pub(crate) use storage::{
     CertifiedCommitStateTopologyParent, CommitDeltaChangeLocator, CommitDeltaLiveMembershipCursor,
     CommitDeltaMember, CommitDeltaPointReadCache, CommitDeltaReplacementGeneration,
@@ -86,7 +91,8 @@ pub(crate) use storage::{
     complete_state_fence_change_owner_commit_ids, direct_change_locator,
     deferred_commit_history_ids,
     encode_commit_state_manifest_replacement_for_migration, load_change_record_by_id,
-    load_commit_delta_change_records, load_commit_delta_members_with_payloads,
+    load_commit_delta_change_records, load_commit_delta_change_records_for_owners,
+    load_commit_delta_members_with_payloads,
     load_commit_delta_members_with_payloads_for_schemas, load_commit_delta_replay_metadata,
     load_commit_delta_selection_certificate, load_commit_history_members_with_payloads_for_schemas,
     has_deferred_commit_history, load_commit_mutation_directory_roots,

--- a/packages/lix/src/tracked_state/storage.rs
+++ b/packages/lix/src/tracked_state/storage.rs
@@ -4776,6 +4776,8 @@ pub(crate) async fn load_point_replay_commit_state(
     store: &(impl StorageAdapterRead + ?Sized),
     commit_id: CommitId,
 ) -> Result<Option<Arc<AuthenticatedReplayCommitStateManifest>>, LixError> {
+    #[cfg(test)]
+    record_point_replay_authority_batch_for_test(1);
     #[cfg(feature = "storage-benches")]
     crate::storage_bench::record_crud_replay_manifest_load();
     let header_keys = [StorageKey(Bytes::from(commit_state_manifest_key(
@@ -4802,6 +4804,95 @@ pub(crate) async fn load_point_replay_commit_state(
         values.next().flatten(),
         values.next().flatten(),
     )
+}
+
+/// Co-loads the shallow replay authority for an operation's complete owner set.
+///
+/// Selected-change materialization commonly addresses rows owned by many
+/// commits. Loading each split header/inventory pair separately turns one
+/// logical point batch into one backend round trip per owner. Keep the
+/// operation-owned authority set outside the small decoded-segment LRU and
+/// authenticate every pair from two aligned point-read groups.
+async fn load_point_replay_commit_states(
+    store: &(impl StorageAdapterRead + ?Sized),
+    commit_ids: &[CommitId],
+) -> Result<Vec<Option<Arc<AuthenticatedReplayCommitStateManifest>>>, LixError> {
+    if commit_ids.is_empty() {
+        return Ok(Vec::new());
+    }
+    #[cfg(test)]
+    record_point_replay_authority_batch_for_test(commit_ids.len());
+    #[cfg(feature = "storage-benches")]
+    for _ in commit_ids {
+        crate::storage_bench::record_crud_replay_manifest_load();
+    }
+    let header_keys = commit_ids
+        .iter()
+        .map(|commit_id| StorageKey(Bytes::from(commit_state_manifest_key(*commit_id))))
+        .collect::<Vec<_>>();
+    let inventory_keys = commit_ids
+        .iter()
+        .map(|commit_id| StorageKey(Bytes::from(commit_mutation_inventory_key(*commit_id))))
+        .collect::<Vec<_>>();
+    let requests = [
+        StorageGetManyRequest {
+            space: TRACKED_STATE_COMMIT_STATE_MANIFEST_SPACE,
+            keys: &header_keys,
+            opts: StorageGetOptions::default(),
+        },
+        StorageGetManyRequest {
+            space: TRACKED_STATE_COMMIT_MUTATION_INVENTORY_SPACE,
+            keys: &inventory_keys,
+            opts: StorageGetOptions::default(),
+        },
+    ];
+    let mut values = exact_get_many(store, &requests).await?.values.into_iter();
+    let headers = values.by_ref().take(commit_ids.len()).collect::<Vec<_>>();
+    let inventories = values.collect::<Vec<_>>();
+    if headers.len() != commit_ids.len() || inventories.len() != commit_ids.len() {
+        return Err(LixError::new(
+            LixError::CODE_INTERNAL_ERROR,
+            "tracked_state replay authority batch returned the wrong cardinality",
+        ));
+    }
+    commit_ids
+        .iter()
+        .copied()
+        .zip(headers)
+        .zip(inventories)
+        .map(|((commit_id, header), inventory)| {
+            decode_point_replay_commit_state_values(commit_id, header, inventory)
+        })
+        .collect()
+}
+
+#[cfg(test)]
+std::thread_local! {
+    static POINT_REPLAY_AUTHORITY_BATCH_PROBE_ACTIVE: std::cell::Cell<bool> = const { std::cell::Cell::new(false) };
+    static POINT_REPLAY_AUTHORITY_BATCH_PROBE: std::cell::RefCell<Vec<usize>> = const { std::cell::RefCell::new(Vec::new()) };
+}
+
+#[cfg(test)]
+fn record_point_replay_authority_batch_for_test(owner_count: usize) {
+    POINT_REPLAY_AUTHORITY_BATCH_PROBE_ACTIVE.with(|active| {
+        if active.get() {
+            POINT_REPLAY_AUTHORITY_BATCH_PROBE.with(|batches| {
+                batches.borrow_mut().push(owner_count);
+            });
+        }
+    });
+}
+
+#[cfg(test)]
+pub(crate) fn arm_point_replay_authority_batch_probe_for_test() {
+    POINT_REPLAY_AUTHORITY_BATCH_PROBE.with(|batches| batches.borrow_mut().clear());
+    POINT_REPLAY_AUTHORITY_BATCH_PROBE_ACTIVE.with(|active| active.set(true));
+}
+
+#[cfg(test)]
+pub(crate) fn take_point_replay_authority_batch_probe_for_test() -> Vec<usize> {
+    POINT_REPLAY_AUTHORITY_BATCH_PROBE_ACTIVE.with(|active| active.set(false));
+    POINT_REPLAY_AUTHORITY_BATCH_PROBE.with(|batches| std::mem::take(&mut *batches.borrow_mut()))
 }
 
 /// Co-loads the semantic commit record and its physical replay authority.
@@ -9138,7 +9229,18 @@ pub(crate) async fn load_commit_delta_change_records(
         .cloned()
         .map(|key| (commit_id, key))
         .collect::<Vec<_>>();
-    Ok(load_owned_commit_delta_entries(store, &requests)
+    load_commit_delta_change_records_for_owners(store, &requests).await
+}
+
+/// Loads exact change records from their already-known physical owners in one
+/// operation-wide batch. Unlike the single-owner convenience wrapper, this
+/// preserves the complete owner set so replay authorities and fallbacks can be
+/// coalesced before any per-owner payload routing begins.
+pub(crate) async fn load_commit_delta_change_records_for_owners(
+    store: &(impl StorageAdapterRead + ?Sized),
+    requests: &[(CommitId, TrackedStateKey)],
+) -> Result<Vec<Option<crate::changelog::ChangeRecord>>, LixError> {
+    Ok(load_owned_commit_delta_entries(store, requests)
         .await?
         .into_iter()
         .map(|entry| entry.map(|entry| entry.change_record))
@@ -11122,8 +11224,24 @@ pub(crate) async fn load_owned_commit_delta_entries(
     requests: &[(CommitId, TrackedStateKey)],
 ) -> Result<Vec<Option<LoadedCommitDeltaEntry>>, LixError> {
     let point_cache = CommitDeltaPointReadCache::default();
-    let mut output =
-        load_local_owned_commit_delta_entries(store, requests, Some(&point_cache)).await?;
+    let owner_commit_ids = requests
+        .iter()
+        .map(|(commit_id, _)| *commit_id)
+        .collect::<BTreeSet<_>>()
+        .into_iter()
+        .collect::<Vec<_>>();
+    let mut authorities = owner_commit_ids
+        .iter()
+        .copied()
+        .zip(load_point_replay_commit_states(store, &owner_commit_ids).await?)
+        .collect::<BTreeMap<_, _>>();
+    let mut output = load_local_owned_commit_delta_entries(
+        store,
+        requests,
+        Some(&point_cache),
+        Some(&authorities),
+    )
+    .await?;
     let mut source_requests = Vec::new();
     let mut source_outputs = Vec::new();
     let mut source_owner_commits = Vec::new();
@@ -11131,7 +11249,7 @@ pub(crate) async fn load_owned_commit_delta_entries(
         if output[request_index].is_some() {
             continue;
         }
-        let Some(state) = point_cache.authority(*commit_id)? else {
+        let Some(state) = authorities.get(commit_id).cloned().flatten() else {
             continue;
         };
         let Some(source_commit_id) = state.mutations.selected_source_commit_id() else {
@@ -11141,14 +11259,36 @@ pub(crate) async fn load_owned_commit_delta_entries(
         source_owner_commits.push(*commit_id);
         source_requests.push((source_commit_id, key.clone()));
     }
-    let selected =
-        load_local_owned_commit_delta_entries(store, &source_requests, Some(&point_cache)).await?;
+    let source_commit_ids = source_requests
+        .iter()
+        .map(|(commit_id, _)| *commit_id)
+        .collect::<BTreeSet<_>>()
+        .into_iter()
+        .filter(|commit_id| !authorities.contains_key(commit_id))
+        .collect::<Vec<_>>();
+    authorities.extend(
+        source_commit_ids
+            .iter()
+            .copied()
+            .zip(load_point_replay_commit_states(store, &source_commit_ids).await?),
+    );
+    let selected = load_local_owned_commit_delta_entries(
+        store,
+        &source_requests,
+        Some(&point_cache),
+        Some(&authorities),
+    )
+    .await?;
     for source_commit_id in source_requests
         .iter()
         .map(|(source_commit_id, _)| *source_commit_id)
         .collect::<BTreeSet<_>>()
     {
-        let source = point_cache.authority(source_commit_id)?.ok_or_else(|| {
+        let source = authorities
+            .get(&source_commit_id)
+            .cloned()
+            .flatten()
+            .ok_or_else(|| {
             replacement_payload_error(
                 "selected-source mutation authority references a missing source",
             )
@@ -11199,6 +11339,7 @@ pub(crate) async fn load_owned_commit_delta_entries_one_ordered_ref(
             commit_id,
             keys,
             Some(point_cache),
+            None,
         )
         .await?;
         if output.iter().all(Option::is_some)
@@ -11231,6 +11372,9 @@ async fn load_local_owned_commit_delta_entries(
     store: &(impl StorageAdapterRead + ?Sized),
     requests: &[(CommitId, TrackedStateKey)],
     point_cache: Option<&CommitDeltaPointReadCache>,
+    authorities: Option<
+        &BTreeMap<CommitId, Option<Arc<AuthenticatedReplayCommitStateManifest>>>,
+    >,
 ) -> Result<Vec<Option<LoadedCommitDeltaEntry>>, LixError> {
     if requests.is_empty() {
         return Ok(Vec::new());
@@ -11252,6 +11396,7 @@ async fn load_local_owned_commit_delta_entries(
             requests[0].0,
             &keys,
             point_cache,
+            authorities,
         ))
         .await;
     }
@@ -11298,6 +11443,7 @@ async fn load_local_owned_commit_delta_entries(
             commit_id,
             &keys,
             point_cache,
+            authorities,
         ))
         .await?;
         for (request_index, unique_index) in output_routes {
@@ -11399,15 +11545,26 @@ async fn load_local_owned_commit_delta_entries_one_ordered(
     commit_id: CommitId,
     keys: &[TrackedStateKeyRef<'_>],
     point_cache: Option<&CommitDeltaPointReadCache>,
+    authorities: Option<
+        &BTreeMap<CommitId, Option<Arc<AuthenticatedReplayCommitStateManifest>>>,
+    >,
 ) -> Result<Vec<Option<LoadedCommitDeltaEntry>>, LixError> {
     #[cfg(feature = "storage-benches")]
     crate::storage_bench::record_commit_delta_ordered_load(keys.len());
-    let cached_state = point_cache
-        .map(|cache| cache.authority(commit_id))
-        .transpose()?
-        .flatten();
-    let state = match cached_state {
+    let preloaded_state = authorities.and_then(|authorities| authorities.get(&commit_id));
+    let cached_state = if preloaded_state.is_some() {
+        None
+    } else {
+        point_cache
+            .map(|cache| cache.authority(commit_id))
+            .transpose()?
+            .flatten()
+    };
+    let state = match preloaded_state.cloned().flatten().or(cached_state) {
         Some(state) => state,
+        None if preloaded_state.is_some() => {
+            return Ok((0..keys.len()).map(|_| None).collect());
+        }
         None => {
             let Some(state) = load_point_replay_commit_state(store, commit_id).await? else {
                 return Ok((0..keys.len()).map(|_| None).collect());
@@ -19718,6 +19875,30 @@ mod tests {
                 .iter()
                 .flatten()
                 .all(|value| value.commit_id == alias_commit)
+        );
+        let owned_requests = keys
+            .iter()
+            .cloned()
+            .map(|key| (alias_commit, key))
+            .collect::<Vec<_>>();
+        let owned = load_owned_commit_delta_entries(&read, &owned_requests)
+            .await
+            .expect("operation-wide alias exact values should load");
+        assert!(owned.iter().all(Option::is_some));
+        assert_eq!(
+            owned
+                .iter()
+                .flatten()
+                .filter(|entry| entry.selected_ref)
+                .count(),
+            2,
+            "the operation authority map must preserve selected-source routing",
+        );
+        assert!(
+            owned
+                .iter()
+                .flatten()
+                .all(|entry| entry.value.commit_id == alias_commit)
         );
 
         let alias_state = super::load_point_replay_commit_state(&read, alias_commit)

--- a/packages/lix/src/transaction/commit.rs
+++ b/packages/lix/src/transaction/commit.rs
@@ -36,7 +36,7 @@ use crate::tracked_state::{
     TrackedStateContext, TrackedStateDeltaRef, TrackedStateFilter, TrackedStateKey,
     TrackedStateKeyRef, TrackedStateReadColumns, TrackedStateRootMutationRef,
     TrackedStateScanRequest, TrackedStateSingleStringReplacementRef, encode_key_ref,
-    load_commit_delta_change_records, load_commit_delta_replay_metadata,
+    load_commit_delta_change_records_for_owners, load_commit_delta_replay_metadata,
     stage_addressable_commit_deltas, stage_change_locators,
     stage_ordered_addressable_commit_deltas,
 };
@@ -1762,90 +1762,85 @@ async fn load_selected_change_records(
     read: &(impl StorageAdapterRead + ?Sized),
     commit_rows: &[FinalizedCommitRow],
 ) -> Result<HashMap<SelectedChangeKey, ChangeRecord>, LixError> {
-    let mut by_source_commit = BTreeMap::<CommitId, Vec<StagedCommitChangeRef<'_>>>::new();
-    for change_ref in commit_rows
+    let change_refs = commit_rows
         .iter()
         .flat_map(|commit| selected_changes(&commit.selected_change_batches))
-    {
         // Identity and timestamps fully describe a selected tombstone.
         // Historical rows may be absent or retain metadata, while checkpoint
         // HOT tombstones must carry no payload.
-        if change_ref.deleted {
-            continue;
-        }
-        by_source_commit
-            .entry(change_ref.source_commit_id)
-            .or_default()
-            .push(change_ref);
-    }
+        .filter(|change_ref| !change_ref.deleted)
+        .collect::<Vec<_>>();
+    let requests = change_refs
+        .iter()
+        .map(|change_ref| {
+            (
+                change_ref.source_commit_id,
+                TrackedStateKey {
+                    schema_key: change_ref.schema_key().to_owned(),
+                    file_id: change_ref.file_id().map(str::to_owned),
+                    row_pk: change_ref.row_pk().clone(),
+                },
+            )
+        })
+        .collect::<Vec<_>>();
+    let loaded = load_commit_delta_change_records_for_owners(read, &requests).await?;
+    let missing_ids = change_refs
+        .iter()
+        .zip(&loaded)
+        .filter_map(|(change_ref, record)| record.is_none().then_some(change_ref.change_id))
+        .collect::<Vec<_>>();
+    let fallback = ChangelogContext::new()
+        .reader(read)
+        .load_changes(ChangeLoadRequest {
+            change_ids: &missing_ids,
+        })
+        .await?
+        .into_iter()
+        .filter_map(|(change_id, record)| record.map(|record| (change_id, record)))
+        .collect::<HashMap<_, _>>();
 
     let mut records = HashMap::new();
-    for (source_commit_id, change_refs) in by_source_commit {
-        let keys = change_refs
-            .iter()
-            .map(|change_ref| TrackedStateKey {
-                schema_key: change_ref.schema_key().to_owned(),
-                file_id: change_ref.file_id().map(str::to_owned),
-                row_pk: change_ref.row_pk().clone(),
-            })
-            .collect::<Vec<_>>();
-        let loaded = load_commit_delta_change_records(read, source_commit_id, &keys).await?;
-        let missing_ids = change_refs
-            .iter()
-            .zip(&loaded)
-            .filter_map(|(change_ref, record)| record.is_none().then_some(change_ref.change_id))
-            .collect::<Vec<_>>();
-        let fallback = ChangelogContext::new()
-            .reader(read)
-            .load_changes(ChangeLoadRequest {
-                change_ids: &missing_ids,
-            })
-            .await?
-            .into_iter()
-            .filter_map(|(change_id, record)| record.map(|record| (change_id, record)))
-            .collect::<HashMap<_, _>>();
-        for (change_ref, record) in change_refs.into_iter().zip(loaded) {
-            let record = record.or_else(|| fallback.get(&change_ref.change_id).cloned());
-            let Some(record) = record else {
-                return Err(LixError::new(
-                    LixError::CODE_INTERNAL_ERROR,
-                    format!(
-                        "selected change '{}' for ({:?}, {:?}, {:?}) has no authoritative payload at source commit '{}'",
-                        change_ref.change_id,
-                        change_ref.schema_key(),
-                        change_ref.file_id(),
-                        change_ref.row_pk(),
-                        source_commit_id
-                    ),
-                ));
-            };
-            if record.change_id != change_ref.change_id
-                || record.schema_key != change_ref.schema_key()
-                || record.file_id.as_deref() != change_ref.file_id()
-                || record.row_pk != *change_ref.row_pk()
-                || record.snapshot.is_none() != change_ref.deleted
-                || record.created_at != change_ref.updated_at
-            {
-                return Err(LixError::new(
-                    LixError::CODE_INTERNAL_ERROR,
-                    format!(
-                        "selected change '{}' does not match its authoritative source payload",
-                        change_ref.change_id
-                    ),
-                ));
-            }
-            let key = selected_change_key(change_ref);
-            if let Some(existing) = records.insert(key, record.clone())
-                && existing != record
-            {
-                return Err(LixError::new(
-                    LixError::CODE_INTERNAL_ERROR,
-                    format!(
-                        "selected change '{}' resolves to conflicting source payloads",
-                        change_ref.change_id
-                    ),
-                ));
-            }
+    for (change_ref, record) in change_refs.into_iter().zip(loaded) {
+        let record = record.or_else(|| fallback.get(&change_ref.change_id).cloned());
+        let Some(record) = record else {
+            return Err(LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                format!(
+                    "selected change '{}' for ({:?}, {:?}, {:?}) has no authoritative payload at source commit '{}'",
+                    change_ref.change_id,
+                    change_ref.schema_key(),
+                    change_ref.file_id(),
+                    change_ref.row_pk(),
+                    change_ref.source_commit_id
+                ),
+            ));
+        };
+        if record.change_id != change_ref.change_id
+            || record.schema_key != change_ref.schema_key()
+            || record.file_id.as_deref() != change_ref.file_id()
+            || record.row_pk != *change_ref.row_pk()
+            || record.snapshot.is_none() != change_ref.deleted
+            || record.created_at != change_ref.updated_at
+        {
+            return Err(LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                format!(
+                    "selected change '{}' does not match its authoritative source payload",
+                    change_ref.change_id
+                ),
+            ));
+        }
+        let key = selected_change_key(change_ref);
+        if let Some(existing) = records.insert(key, record.clone())
+            && existing != record
+        {
+            return Err(LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                format!(
+                    "selected change '{}' resolves to conflicting source payloads",
+                    change_ref.change_id
+                ),
+            ));
         }
     }
     Ok(records)
@@ -6996,7 +6991,7 @@ fn account_has_changes_error(account_id: &str) -> LixError {
 mod tests {
     use std::collections::{BTreeMap, BTreeSet};
     use std::sync::{
-        Arc,
+        Arc, Mutex,
         atomic::{AtomicUsize, Ordering},
     };
 
@@ -7025,6 +7020,44 @@ mod tests {
         ($($row:expr),* $(,)?) => {
             PreparedStateBatch::from_test_rows(vec![$($row),*])
         };
+    }
+
+    struct ChangeBatchCountingRead<R> {
+        inner: R,
+        change_batches: Arc<Mutex<Vec<usize>>>,
+    }
+
+    impl<R> StorageAdapterRead for ChangeBatchCountingRead<R>
+    where
+        R: StorageAdapterRead,
+    {
+        fn snapshot_cache_key(&self) -> Option<u128> {
+            self.inner.snapshot_cache_key()
+        }
+
+        fn get_many(
+            &self,
+            requests: &[crate::storage::GetManyRequest<'_>],
+        ) -> impl Future<Output = Result<GetManyResult, StorageError>> + Send {
+            for request in requests {
+                if request.space == crate::changelog::CHANGE_SPACE {
+                    self.change_batches
+                        .lock()
+                        .expect("change batch counter lock")
+                        .push(request.keys.len());
+                }
+            }
+            self.inner.get_many(requests)
+        }
+
+        fn begin_scan(
+            &self,
+            space: StorageSpace,
+            range: KeyRange,
+            opts: BeginScanOptions,
+        ) -> impl Future<Output = Result<ScanCursor<'_>, StorageError>> + Send {
+            self.inner.begin_scan(space, range, opts)
+        }
     }
 
     fn ts(value: &str) -> LixTimestamp {
@@ -10676,6 +10709,78 @@ mod tests {
             ts("2026-01-01T00:00:00Z"),
         );
         batch.finish()
+    }
+
+    #[tokio::test]
+    async fn selected_change_fallback_batches_standalone_changelog_reads() {
+        const CHANGE_COUNT: usize = 8;
+        let storage = StorageAdapter::new(Memory::new());
+        let timestamp = ts("2026-01-01T00:00:00Z");
+        let changes = (0..CHANGE_COUNT)
+            .map(|index| ChangeRecord {
+                format_version: 2,
+                change_id: change_id(&format!("fallback-change-{index}")),
+                account_id: crate::ANONYMOUS_ACCOUNT_ID.to_owned(),
+                schema_key: "test_schema".to_owned(),
+                row_pk: RowPk::single(format!("fallback-row-{index}")),
+                file_id: None,
+                snapshot: Some(b"{}".to_vec()),
+                metadata: None,
+                created_at: timestamp,
+                origin_key: None,
+            })
+            .collect::<Vec<_>>();
+        let read = storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("fallback fixture read should open");
+        let mut writes = storage.new_write_set();
+        ChangelogContext::new()
+            .writer(&mut &read, &mut writes)
+            .stage_certified_sparse_append(crate::changelog::ChangelogAppend {
+                commits: Vec::new(),
+                changes: changes.clone(),
+            })
+            .await
+            .expect("standalone fallback changes should stage");
+        drop(read);
+        storage
+            .commit_write_set(writes, StorageWriteOptions::default())
+            .await
+            .expect("standalone fallback changes should publish");
+
+        let change_batches = Arc::new(Mutex::new(Vec::new()));
+        let read = ChangeBatchCountingRead {
+            inner: storage
+                .begin_read(StorageReadOptions::default())
+                .await
+                .expect("counted fallback read should open"),
+            change_batches: Arc::clone(&change_batches),
+        };
+        let commit_rows = [FinalizedCommitRow {
+            commit_id: commit_id("fallback-checkpoint"),
+            parent_commit_ids: Vec::new(),
+            created_at: timestamp,
+            selected_change_batches: (0..CHANGE_COUNT)
+                .map(|index| {
+                    selected_change_batch_from(
+                        &format!("fallback-change-{index}"),
+                        &format!("fallback-row-{index}"),
+                        &format!("missing-fallback-owner-{index}"),
+                    )
+                })
+                .collect(),
+        }];
+        let loaded = load_selected_change_records(&read, &commit_rows)
+            .await
+            .expect("standalone selected changes should resolve in one fallback batch");
+
+        assert_eq!(loaded.len(), CHANGE_COUNT);
+        assert_eq!(
+            *change_batches.lock().expect("change batch counter lock"),
+            vec![CHANGE_COUNT],
+            "all missing selected payloads must enter one physical changelog point batch",
+        );
     }
 
     fn tracked_global_row(change_id: &str) -> TestPreparedStateRow {


### PR DESCRIPTION
## Summary

- co-load replay authority for the complete selected-change owner set in one operation-owned batch
- flatten partial-checkpoint selected payload routing and standalone changelog fallback across owners
- preserve selected-source alias routing without relying on the small replay LRU
- keep partial-checkpoint semantics: selected rows commit and unselected working diffs remain

## Profile and regressions

At a 50-owner preview-shaped checkpoint, replay-authority reads are `[50, 1, 1]`: one 50-owner batch plus two bounded checkpoint-bookkeeping reads. The prior route issued one manifest/inventory round trip per owner.

Regressions cover:
- 50 distinct owners, one selected diff, 49 working diffs retained
- selected-source aliases through the operation authority map
- eight forced standalone fallbacks as exactly one physical eight-key CHANGE_SPACE request

## Verification

- `cargo test -p lix --features all-simulations`: 3259 passed, 0 failed, 26 ignored; integrations and doctests green
- `cargo clippy --profile test --workspace --all-targets --all-features -- -D warnings`
- focused post-rebase selected-source/fallback/50-owner regressions
- `cargo fmt --check` and `git diff --check`
- two independent review rounds; final review clean