### PR TITLE
Shrink browser WASM with one codegen unit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -368,6 +368,10 @@ jobs:
       - name: Build browser JS SDK
         if: matrix.runtime == 'browser'
         working-directory: packages/js-sdk
+        # Generic CI favors fast feedback. Production builds leave this unset
+        # and use the single codegen unit configured by build-wasm.js for size.
+        env:
+          CARGO_PROFILE_RELEASE_CODEGEN_UNITS: "16"
         run: npm run build:browser
 
       - name: Build and check OPFS storage package

--- a/packages/js-sdk/scripts/build-wasm.js
+++ b/packages/js-sdk/scripts/build-wasm.js
@@ -69,6 +69,10 @@ if (cargoProfile === "release") {
 	// times reasonable and dramatically reduces download/compile overhead.
 	cargoEnv.CARGO_PROFILE_RELEASE_OPT_LEVEL ??= "s";
 	cargoEnv.CARGO_PROFILE_RELEASE_STRIP ??= "symbols";
+	// A single codegen unit lets LLVM optimize across each crate's full graph.
+	// For the DataFusion-heavy browser build this materially reduces both the
+	// raw module and its compressed transfer size.
+	cargoEnv.CARGO_PROFILE_RELEASE_CODEGEN_UNITS ??= "1";
 }
 const cargoArgs = [
 	"build",


### PR DESCRIPTION
## Summary

- build the release browser WASM with one Cargo codegen unit
- allow callers to override the profile setting through the existing environment variable

## Size impact

Measured on the final `lix_js_sdk_bg.wasm` after `wasm-bindgen`:

- raw: 56,356,820 -> 42,596,474 bytes (-24.4%)
- gzip -9: 12,809,877 -> 10,788,284 bytes (-15.8%)
- brotli -q 11: 7,245,139 -> 6,472,847 bytes (-10.7%)

Fat LTO and `wasm-opt -Oz` were also profiled, but both increased compressed transfer size, so they are intentionally not included.

## Verification

- `npm run build:wasm`
- `npm run build:ts`
- `npm run test:browser:built -- --reporter=dot` (15 passed, 2 skipped)
- `cargo fmt --all -- --check`
- `git diff --check`