### PR TITLE
fix: retry coherent reads through cross-tab churn

### DIFF
--- a/.changenotes/retry-cross-context-opfs-reads.md
+++ b/.changenotes/retry-cross-context-opfs-reads.md
@@ -1,0 +1,7 @@
+---
+type: patch
+---
+
+Prevented transient cross-tab writes from interrupting coherent SQL reads in browser repositories.
+
+Lix now gives competing OPFS commits time to settle before retrying the complete query, while preserving bounded failure under continuous invalidation.

--- a/packages/lix/src/session/execute.rs
+++ b/packages/lix/src/session/execute.rs
@@ -4,6 +4,7 @@ use std::ops::ControlFlow;
 use std::ops::Range;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex as StdMutex, OnceLock};
+use std::time::Duration;
 
 use crate::binary_cas::BlobId;
 use crate::branch::BranchRefReader;
@@ -5333,7 +5334,9 @@ fn consume_expired_read_retry(retries: &mut usize, error: &LixError) -> bool {
 /// A storage such as browser OPFS may preserve coherent reads by expiring a
 /// multi-call snapshot when a commit lands between calls. Retry once on the
 /// optimistic path, then hold the same collaboration gate used by every Lix
-/// writer so a busy sync bootstrap cannot invalidate all bounded retries.
+/// writer. Repeated expiry can come from another browser context, whose writer
+/// does not share that in-process gate, so bounded backoff gives that writer a
+/// chance to finish instead of exhausting every retry in one event-loop turn.
 async fn retry_expired_read_with_write_quiescence(
     retries: &mut usize,
     error: &LixError,
@@ -5351,6 +5354,10 @@ async fn retry_expired_read_with_write_quiescence(
     tokio::task::yield_now().await;
     if !already_quiesced && guard.is_none() {
         *guard = Some(Arc::clone(write_gate).lock_owned().await);
+    }
+    if *retries > 1 {
+        let exponent = (*retries - 2).min(4) as u32;
+        crate::sync::sleep(Duration::from_millis(1_u64 << exponent)).await;
     }
     true
 }

--- a/packages/lix/src/sync/mod.rs
+++ b/packages/lix/src/sync/mod.rs
@@ -37,6 +37,7 @@ pub use platform::{
     unregister_browser_sync_transport,
 };
 pub(crate) use platform::{SyncTransportBounds, SyncTransportFuture};
+pub(crate) use platform::sleep;
 #[cfg(feature = "server-protocol")]
 pub(crate) use protocol::SyncRefUpdate;
 pub(crate) use protocol::{

--- a/packages/lix/src/sync/platform.rs
+++ b/packages/lix/src/sync/platform.rs
@@ -15,11 +15,15 @@ mod wasm;
 mod wasm_http;
 
 #[cfg(not(target_family = "wasm"))]
-pub(super) use native::{SyncTask, sleep, spawn_sync_task};
+pub(super) use native::{SyncTask, spawn_sync_task};
+#[cfg(not(target_family = "wasm"))]
+pub(crate) use native::sleep;
 #[cfg(not(target_family = "wasm"))]
 pub(super) type HttpSyncTransport = super::http::HttpSyncTransport<reqwest::Client>;
 #[cfg(target_family = "wasm")]
-pub(super) use wasm::{SyncTask, sleep, spawn_sync_task};
+pub(super) use wasm::{SyncTask, spawn_sync_task};
+#[cfg(target_family = "wasm")]
+pub(crate) use wasm::sleep;
 #[cfg(target_family = "wasm")]
 pub(super) type HttpSyncTransport = super::http::HttpSyncTransport<wasm_http::BrowserHttpClient>;
 #[cfg(target_family = "wasm")]

--- a/packages/lix/src/sync/platform/native.rs
+++ b/packages/lix/src/sync/platform/native.rs
@@ -83,7 +83,7 @@ impl SyncTask {
     }
 }
 
-pub(in crate::sync) async fn sleep(duration: Duration) {
+pub(crate) async fn sleep(duration: Duration) {
     tokio::time::sleep(duration).await;
 }
 

--- a/packages/lix/src/sync/platform/wasm.rs
+++ b/packages/lix/src/sync/platform/wasm.rs
@@ -1,13 +1,16 @@
 //! Browser mechanics for the shared synchronization state machine.
 
 use std::future::Future;
-use std::sync::Arc;
+use std::pin::Pin;
+use std::sync::{Arc, Mutex};
 use std::sync::atomic::{AtomicBool, Ordering};
+use std::task::{Context, Poll, Waker};
 use std::time::Duration;
 
-use js_sys::{Function, Promise, Reflect};
+use js_sys::{Function, Reflect};
+use wasm_bindgen::closure::Closure;
 use wasm_bindgen::{JsCast, JsValue};
-use wasm_bindgen_futures::{JsFuture, spawn_local};
+use wasm_bindgen_futures::spawn_local;
 
 use crate::LixError;
 
@@ -38,18 +41,62 @@ impl SyncTask {
     }
 }
 
-pub(in crate::sync) async fn sleep(duration: Duration) {
-    let promise = Promise::new(&mut |resolve, _reject| {
-        let global = js_sys::global();
-        if let Ok(timer) = Reflect::get(&global, &"setTimeout".into())
-            && let Ok(timer) = timer.dyn_into::<Function>()
+pub(crate) fn sleep(duration: Duration) -> impl Future<Output = ()> + Send {
+    let state = Arc::new(BrowserSleepState {
+        done: AtomicBool::new(false),
+        waker: Mutex::new(None),
+    });
+    let callback_state = Arc::clone(&state);
+    let callback = Closure::once_into_js(move || {
+        callback_state.done.store(true, Ordering::Release);
+        if let Ok(mut waker) = callback_state.waker.lock()
+            && let Some(waker) = waker.take()
         {
-            let _ = timer.call2(
-                &global,
-                &resolve,
-                &JsValue::from_f64(duration.as_millis() as f64),
-            );
+            waker.wake();
         }
     });
-    let _ = JsFuture::from(promise).await;
+    let global = js_sys::global();
+    let scheduled = Reflect::get(&global, &"setTimeout".into())
+        .ok()
+        .and_then(|timer| timer.dyn_into::<Function>().ok())
+        .is_some_and(|timer| {
+            timer
+                .call2(
+                    &global,
+                    &callback,
+                    &JsValue::from_f64(duration.as_millis() as f64),
+                )
+                .is_ok()
+        });
+    if !scheduled {
+        state.done.store(true, Ordering::Release);
+    }
+    BrowserSleep { state }
+}
+
+struct BrowserSleepState {
+    done: AtomicBool,
+    waker: Mutex<Option<Waker>>,
+}
+
+struct BrowserSleep {
+    state: Arc<BrowserSleepState>,
+}
+
+impl Future for BrowserSleep {
+    type Output = ();
+
+    fn poll(self: Pin<&mut Self>, context: &mut Context<'_>) -> Poll<Self::Output> {
+        if self.state.done.load(Ordering::Acquire) {
+            return Poll::Ready(());
+        }
+        let Ok(mut waker) = self.state.waker.lock() else {
+            return Poll::Ready(());
+        };
+        if self.state.done.load(Ordering::Acquire) {
+            return Poll::Ready(());
+        }
+        *waker = Some(context.waker().clone());
+        Poll::Pending
+    }
 }

--- a/packages/lix/tests/integration/read_retry.rs
+++ b/packages/lix/tests/integration/read_retry.rs
@@ -1,5 +1,5 @@
 use std::sync::Arc;
-use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::Duration;
 
 use crate::storage::{
@@ -11,7 +11,7 @@ use crate::{ExecuteBatchStatement, Value};
 #[derive(Clone)]
 struct ExpiringReadStorage {
     inner: Memory,
-    expire_next_read_call: Arc<AtomicBool>,
+    remaining_expired_read_calls: Arc<AtomicUsize>,
     expired_calls: Arc<AtomicUsize>,
 }
 
@@ -19,13 +19,23 @@ impl ExpiringReadStorage {
     fn new() -> Self {
         Self {
             inner: Memory::new(),
-            expire_next_read_call: Arc::new(AtomicBool::new(false)),
+            remaining_expired_read_calls: Arc::new(AtomicUsize::new(0)),
             expired_calls: Arc::new(AtomicUsize::new(0)),
         }
     }
 
     fn expire_next_read_call(&self) {
-        self.expire_next_read_call.store(true, Ordering::Release);
+        self.expire_read_calls(1);
+    }
+
+    fn expire_read_calls(&self, count: usize) {
+        self.remaining_expired_read_calls
+            .store(count, Ordering::Release);
+    }
+
+    fn allow_reads(&self) {
+        self.remaining_expired_read_calls
+            .store(0, Ordering::Release);
     }
 
     fn expired_calls(&self) -> usize {
@@ -35,13 +45,19 @@ impl ExpiringReadStorage {
 
 struct ExpiringRead {
     inner: MemoryRead,
-    expire_next_read_call: Arc<AtomicBool>,
+    remaining_expired_read_calls: Arc<AtomicUsize>,
     expired_calls: Arc<AtomicUsize>,
 }
 
 impl ExpiringRead {
     fn expire_if_armed(&self) -> Result<(), StorageError> {
-        if self.expire_next_read_call.swap(false, Ordering::AcqRel) {
+        if self
+            .remaining_expired_read_calls
+            .fetch_update(Ordering::AcqRel, Ordering::Acquire, |remaining| {
+                remaining.checked_sub(1)
+            })
+            .is_ok()
+        {
             self.expired_calls.fetch_add(1, Ordering::AcqRel);
             return Err(StorageError::ReadExpired);
         }
@@ -62,7 +78,7 @@ impl Storage for ExpiringReadStorage {
     async fn begin_read(&self, options: ReadOptions) -> Result<Self::Read<'_>, StorageError> {
         Ok(ExpiringRead {
             inner: self.inner.begin_read(options).await?,
-            expire_next_read_call: Arc::clone(&self.expire_next_read_call),
+            remaining_expired_read_calls: Arc::clone(&self.remaining_expired_read_calls),
             expired_calls: Arc::clone(&self.expired_calls),
         })
     }
@@ -184,6 +200,77 @@ async fn expired_read_waits_for_one_write_quiescent_retry() {
         serde_json::json!(42)
     );
     assert_eq!(storage.expired_calls(), 1);
+}
+
+#[tokio::test]
+async fn expired_read_backs_off_until_cross_context_writer_settles() {
+    let storage = ExpiringReadStorage::new();
+    let lix = crate::open_lix()
+        .with_storage(storage.clone())
+        .await
+        .expect("open Lix");
+    lix.execute(
+        "INSERT INTO lix_key_value (key, value) VALUES ($1, $2)",
+        &[
+            Value::Text("read-external-quiescence".into()),
+            Value::Integer(42),
+        ],
+    )
+    .await
+    .expect("seed value");
+
+    // A writer in another browser context does not share this engine's write
+    // gate. Keep expiring fresh snapshots until that external churn settles.
+    storage.expire_read_calls(64);
+    let settling_storage = storage.clone();
+    tokio::spawn(async move {
+        tokio::time::sleep(Duration::from_millis(20)).await;
+        settling_storage.allow_reads();
+    });
+
+    let result = tokio::time::timeout(
+        Duration::from_secs(1),
+        lix.execute(
+            "SELECT value FROM lix_key_value WHERE key = $1",
+            &[Value::Text("read-external-quiescence".into())],
+        ),
+    )
+    .await
+    .expect("bounded retry should wait for external writes to settle")
+    .expect("expired read should stay behind the SQL API boundary");
+
+    assert_eq!(
+        result.rows()[0].get::<serde_json::Value>("value").unwrap(),
+        serde_json::json!(42)
+    );
+    assert!(
+        storage.expired_calls() > 1,
+        "the regression must exercise repeated cross-context invalidation",
+    );
+}
+
+#[tokio::test]
+async fn perpetually_expired_read_remains_bounded() {
+    let storage = ExpiringReadStorage::new();
+    let lix = crate::open_lix()
+        .with_storage(storage.clone())
+        .await
+        .expect("open Lix");
+
+    storage.expire_read_calls(usize::MAX);
+    let error = tokio::time::timeout(
+        Duration::from_secs(1),
+        lix.execute("SELECT key FROM lix_key_value", &[]),
+    )
+    .await
+    .expect("retry policy must remain bounded")
+    .expect_err("perpetual invalidation must eventually surface");
+
+    assert_eq!(error.code, "LIX_STORAGE_READ_EXPIRED");
+    assert!(
+        storage.expired_calls() > 1,
+        "the bounded path must cover repeated invalidation",
+    );
 }
 
 #[tokio::test]

--- a/packages/storage-opfs/tests/opfs-storage.browser.test.ts
+++ b/packages/storage-opfs/tests/opfs-storage.browser.test.ts
@@ -8,6 +8,7 @@ import { OpfsStorage } from "@lix-js/storage-opfs";
 import { expect, test } from "vitest";
 import {
 	OPFS_RPC_CHANNEL,
+	type OpfsChannelMessage,
 	type OpfsRpcRequest,
 	type OpfsRpcResponse,
 } from "../js/rpc.js";
@@ -348,6 +349,83 @@ test("concurrent engines converge without losing divergent writes", async () => 
 		expect(secondWinner).toBe(firstWinner);
 	} finally {
 		await Promise.all([first.close(), second.close()]);
+	}
+});
+
+test("keeps a complete SQL read coherent during cross-client commit churn", async () => {
+	const name = `lix-opfs-read-churn:${crypto.randomUUID()}`;
+	const monitor = new BroadcastChannel(OPFS_RPC_CHANNEL);
+	const readRequests = new Set<string>();
+	let expiredReads = 0;
+	monitor.onmessage = (event: MessageEvent<OpfsChannelMessage>) => {
+		const message = event.data;
+		if (
+			message.kind === "request" &&
+			message.storageName === name &&
+			["beginRead", "readMany", "scanPage"].includes(message.operation)
+		) {
+			readRequests.add(message.requestId);
+		} else if (
+			message.kind === "response" &&
+			!message.ok &&
+			readRequests.has(message.requestId) &&
+			message.error.code === "LIX_STORAGE_READ_EXPIRED"
+		) {
+			expiredReads += 1;
+		}
+	};
+	const lix = await openLix({ storage: new OpfsStorage({ name }) });
+	const writer = await openProvider(new OpfsStorage({ name }).lixStorage);
+	const churnSpace: LixStorageSpace = {
+		id: 2_000_000_000,
+		name: "cross-client-read-churn",
+		valueSemantics: "mutable",
+		valueIntegrity: "backendVerified",
+	};
+	let releaseFirstCommit!: () => void;
+	const firstCommit = new Promise<void>((resolve) => {
+		releaseFirstCommit = resolve;
+	});
+	try {
+		const commits = (async () => {
+			for (let index = 0; index < 96; index += 1) {
+				const write = await writer.beginWrite({
+					awaitDurable: false,
+					preconditions: [],
+					batchCapacityHintBytes: 8,
+				});
+				await write.putMany(churnSpace, [
+					{ key: keyBytes(index), value: new Uint8Array([index & 0xff]) },
+				]);
+				try {
+					await write.commit();
+				} finally {
+					if (index === 0) releaseFirstCommit();
+				}
+			}
+		})();
+
+		const reads = (async () => {
+			await firstCommit;
+			for (let index = 0; index < 12; index += 1) {
+				const result = await lix.execute(
+					`SELECT 1 AS present FROM lix_directory WHERE lower(path) = lower($1)
+				 UNION ALL
+				 SELECT 1 AS present FROM lix_file WHERE lower(path) = lower($1)
+				 LIMIT 1`,
+					[`/absent-during-churn-${index}.md`],
+				);
+				expect(result.rows).toHaveLength(0);
+			}
+		})();
+		const outcomes = await Promise.allSettled([commits, reads]);
+		for (const outcome of outcomes) {
+			if (outcome.status === "rejected") throw outcome.reason;
+		}
+		expect(expiredReads).toBeGreaterThan(1);
+	} finally {
+		monitor.close();
+		await Promise.all([writer.close(), lix.close()]);
 	}
 });
 


### PR DESCRIPTION
## Summary

- back off whole-statement coherent-read retries when OPFS commits arrive from another browser context
- keep browser delay futures Send-safe without changing the public Lix API
- cover settling and perpetual invalidation plus the exact multi-client directory/file query from LixRay

## Validation

- cargo test -p lix read_retry -- --nocapture
- cargo clippy -p lix --all-targets --all-features -- -D warnings
- @lix-js/sdk browser Wasm build
- @lix-js/storage-opfs typecheck
- @lix-js/storage-opfs browser tests (24/24)
- independent code review: no blockers