### PR TITLE
fix(lix): keep partial checkpoint diffs hot

### DIFF
--- a/.changenotes/keep-partial-checkpoints-hot.md
+++ b/.changenotes/keep-partial-checkpoints-hot.md
@@ -1,0 +1,7 @@
+---
+type: patch
+---
+
+Kept partial checkpoints on the history-free working-diff path.
+
+Lix now carries unselected changes into the new checkpoint epoch atomically, avoiding cold history reconstruction and sync hydration on the next write or partial checkpoint.

--- a/packages/lix/src/engine.rs
+++ b/packages/lix/src/engine.rs
@@ -1,12 +1,19 @@
+use std::collections::BTreeSet;
 use std::sync::Arc;
 
 use crate::GLOBAL_BRANCH_ID;
 use crate::binary_cas::BinaryCasContext;
-use crate::branch::{BranchContext, BranchRefReader};
+use crate::branch::{
+    BranchContext, BranchHeadControlContext, BranchRefReader, branch_head_control_precondition,
+    stage_branch_head_control,
+};
 use crate::catalog::{CatalogContext, CatalogFingerprint};
 use crate::changelog::COMMIT_SPACE;
 use crate::commit_graph::CommitGraphContext;
-use crate::hot_state::HotStateContext;
+use crate::hot_state::{
+    CompleteWorkingDiffMode, HotStateContext, HotTrackedSnapshot, TrackedHeadContext,
+    TrackedWorkingDiffEpoch, WorkingDiffIndexCoverage, stage_tracked_working_diff_epoch,
+};
 use crate::hot_state::HotStateRowRequest;
 use crate::init::InitReceipt;
 use crate::observe_coordinator::ObserveCoordinator;
@@ -21,14 +28,16 @@ use crate::sql2::SqlPlanningCache;
 use crate::storage_adapter::Storage;
 use crate::storage_adapter::{
     SharedStorageAdapterRead, StorageBeginScanOptions, StorageCoreProjection, StoragePrefix,
-    StorageReadOptions, StorageWriteOptions,
+    StorageError, StorageReadOptions, StorageWriteOptions, StorageWriteSetError,
 };
 use crate::storage_adapter::{StorageAdapter, StorageWriteSet};
 use crate::sync::SyncModeState;
 use crate::telemetry::{
     ActiveTelemetrySpan, ENGINE_OPEN, SESSION_OPEN, TelemetrySink, instrument_lix_result,
 };
-use crate::tracked_state::TrackedStateContext;
+use crate::tracked_state::{
+    TrackedStateContext, TrackedStateFilter, TrackedStateReadColumns, TrackedStateScanRequest,
+};
 use crate::transaction::CommitCoordinator;
 use crate::{LixError, NullableKeyFilter};
 
@@ -291,10 +300,13 @@ where
             ActiveTelemetrySpan::start_if_enabled(sink, &SESSION_OPEN, Vec::new())
         });
         instrument_lix_result(span, async move {
+            let active_branch_id = active_branch_id.into();
             let active_account_id = active_account_id.into();
             self.validate_active_account(&active_account_id).await?;
+            self.repair_stale_working_diff_epoch(&active_branch_id)
+                .await?;
             Ok(SessionContext::new(
-                SessionBranch::new(active_branch_id.into()),
+                SessionBranch::new(active_branch_id),
                 active_account_id,
                 self.storage(),
                 Arc::clone(&self.hot_state),
@@ -331,7 +343,22 @@ where
         instrument_lix_result(span, async move {
             let active_account_id = active_account_id.into();
             self.validate_active_account(&active_account_id).await?;
-            SessionContext::open_default(
+            let read = SharedStorageAdapterRead::new(
+                self.storage
+                    .begin_read(StorageReadOptions::default())
+                    .await?,
+            );
+            let active_branch_id = crate::session::load_default_branch_id_from_index(
+                self.hot_state.as_ref(),
+                self.branch_ctx.as_ref(),
+                &read,
+            )
+            .await?;
+            drop(read);
+            self.repair_stale_working_diff_epoch(&active_branch_id)
+                .await?;
+            Ok(SessionContext::new(
+                SessionBranch::new(active_branch_id),
                 active_account_id,
                 self.storage(),
                 Arc::clone(&self.hot_state),
@@ -348,10 +375,162 @@ where
                 self.sync_mode.clone(),
                 self.plugin_host.clone(),
                 self.telemetry.clone(),
-            )
-            .await
+            ))
         })
         .await
+    }
+
+    /// Repairs the private working-diff projection produced by the former
+    /// partial-checkpoint publication path. The branch control is the durable
+    /// authority for `(head, checkpoint)`; HOT rows and their sparse epoch are
+    /// derived serving state, so rebuilding them does not alter repository
+    /// history or any public API surface.
+    async fn repair_stale_working_diff_epoch(&self, branch_id: &str) -> Result<(), LixError> {
+        // Healthy session opens must not serialize behind writes or sync
+        // imports. Read the two private coordinates optimistically and take
+        // the write gate only when repair may actually be necessary.
+        let read = SharedStorageAdapterRead::new(
+            self.storage
+                .begin_read(StorageReadOptions::default())
+                .await?,
+        );
+        let control = BranchHeadControlContext::new()
+            .reader(read.clone())
+            .load(branch_id)
+            .await?;
+        let Some(control) = control else {
+            return Ok(());
+        };
+        let Some(checkpoint_commit_id) = control.working_diff_checkpoint_commit_id else {
+            return Ok(());
+        };
+        let epoch = TrackedHeadContext::new()
+            .reader(read)
+            .working_diff_epoch(branch_id)
+            .await?;
+        if epoch.as_ref().is_some_and(|epoch| {
+            epoch.checkpoint_commit_id == checkpoint_commit_id
+                && epoch.generation == control.tracked_generation
+        }) {
+            return Ok(());
+        }
+
+        let _write_guard = self.collaboration_write_gate.lock().await;
+        for _attempt in 0..3 {
+            let read = SharedStorageAdapterRead::new(
+                self.storage
+                    .begin_read(StorageReadOptions::default())
+                    .await?,
+            );
+            let mut observations = BranchHeadControlContext::new()
+                .reader(read.clone())
+                .load_observed(&[branch_id.to_owned()])
+                .await?;
+            let observation = observations
+                .pop()
+                .expect("one requested branch produces one observation");
+            let Some(mut control) = observation.control else {
+                return Ok(());
+            };
+            let Some(checkpoint_commit_id) = control.working_diff_checkpoint_commit_id else {
+                return Ok(());
+            };
+            let epoch = TrackedHeadContext::new()
+                .reader(read.clone())
+                .working_diff_epoch(branch_id)
+                .await?;
+            if epoch.as_ref().is_some_and(|epoch| {
+                epoch.checkpoint_commit_id == checkpoint_commit_id
+                    && epoch.generation == control.tracked_generation
+            }) {
+                return Ok(());
+            }
+
+            let current = load_repair_hot_snapshot(
+                &read,
+                branch_id,
+                control.head_commit_id,
+            )
+            .await?;
+            let checkpoint = load_repair_hot_snapshot(
+                &read,
+                branch_id,
+                checkpoint_commit_id,
+            )
+            .await?;
+            let generation = crate::changelog::CommitId::with_change_address_space(
+                uuid::Uuid::now_v7(),
+            );
+            let mut coverage = WorkingDiffIndexCoverage::default();
+            let mut writes = self.storage.new_write_set();
+            let (_, schema_keys) = TrackedHeadContext::new()
+                .writer(&read, &mut writes)
+                .stage_complete_current_state_with_working_diff(
+                    branch_id,
+                    generation,
+                    current,
+                    Some(control.tracked_generation),
+                    &[],
+                    &[],
+                    &BTreeSet::new(),
+                    if control.head_commit_id == checkpoint_commit_id {
+                        CompleteWorkingDiffMode::ResetClean
+                    } else {
+                        CompleteWorkingDiffMode::Rebase {
+                            checkpoint_commit_id,
+                            checkpoint,
+                        }
+                    },
+                    &mut coverage,
+                )
+                .await?;
+            stage_tracked_working_diff_epoch(
+                &mut writes,
+                branch_id,
+                TrackedWorkingDiffEpoch {
+                    checkpoint_commit_id,
+                    generation,
+                    coverage,
+                },
+            )?;
+            control.tracked_generation = generation;
+            control.current_state_revision = control
+                .current_state_revision
+                .checked_add(1)
+                .ok_or_else(|| LixError::unknown("branch current-state revision overflowed"))?;
+            control.reset_schema_presence();
+            control.note_schemas(schema_keys.iter().map(String::as_str));
+            stage_branch_head_control(&mut writes, branch_id, control)?;
+            let preconditions = vec![branch_head_control_precondition(
+                branch_id,
+                observation.raw_token,
+            )?];
+            drop(read);
+            match self
+                .storage
+                .commit_write_set(
+                    writes,
+                    StorageWriteOptions {
+                        preconditions,
+                        ..StorageWriteOptions::default()
+                    },
+                )
+                .await
+            {
+                Ok(_) => {
+                    self.observe_invalidation.bump();
+                    return Ok(());
+                }
+                Err(StorageWriteSetError::Storage(
+                    StorageError::WriteConflict | StorageError::PreconditionFailed(_),
+                )) => continue,
+                Err(error) => return Err(error.into()),
+            }
+        }
+        Err(LixError::new(
+            LixError::CODE_TRANSACTION_CONFLICT,
+            format!("branch '{branch_id}' changed while repairing its working-diff epoch"),
+        ))
     }
 
     /// Rebuilds the tracked serving commit root for one branch from changelog.
@@ -469,6 +648,35 @@ where
         }
         Ok(())
     }
+}
+
+async fn load_repair_hot_snapshot(
+    read: &(impl crate::storage_adapter::StorageAdapterRead + ?Sized),
+    branch_id: &str,
+    commit_id: crate::changelog::CommitId,
+) -> Result<HotTrackedSnapshot, LixError> {
+    let rows = TrackedStateContext::new()
+        .reader(read)
+        .scan_batch_at_commit(
+            &commit_id.to_string(),
+            &TrackedStateScanRequest {
+                filter: TrackedStateFilter {
+                    include_tombstones: true,
+                    ..TrackedStateFilter::default()
+                },
+                read_columns: TrackedStateReadColumns::default(),
+                limit: None,
+            },
+        )
+        .await?
+        .into_rows()
+        .into_iter()
+        .filter(|row| {
+            branch_id == GLOBAL_BRANCH_ID
+                || row.schema_key != crate::checkpoint::CHECKPOINT_SCHEMA_KEY
+        })
+        .collect();
+    HotTrackedSnapshot::from_materialized_rows(rows)
 }
 
 async fn assert_initialized<StorageImpl>(
@@ -631,6 +839,22 @@ mod tests {
 
     async fn register_global_json_pointer_schema(session: &SessionContext<Memory>) {
         register_json_pointer_schema_in_scope(session, true).await;
+    }
+
+    #[tokio::test]
+    async fn healthy_session_open_does_not_wait_for_the_write_gate() {
+        let storage = Memory::new();
+        Engine::initialize(storage.clone())
+            .await
+            .expect("engine should initialize");
+        let engine = Engine::new(storage).await.expect("engine should open");
+        let gate = engine.collaboration_write_gate();
+        let _held_write = gate.lock().await;
+
+        tokio::time::timeout(std::time::Duration::from_secs(1), engine.open_session())
+            .await
+            .expect("healthy session open must not wait for the write gate")
+            .expect("healthy session should open");
     }
 
     #[tokio::test]

--- a/packages/lix/src/session/context.rs
+++ b/packages/lix/src/session/context.rs
@@ -31,7 +31,7 @@ use crate::sql2::{
     SqlExecutionContext, SqlHistoryQuerySource, SqlPlanningCache,
 };
 use crate::storage_adapter::Storage;
-use crate::storage_adapter::{Memory, StorageReadOptions, StorageWriteSetStats};
+use crate::storage_adapter::{Memory, StorageWriteSetStats};
 use crate::storage_adapter::{SharedStorageAdapterRead, StorageAdapter, StorageAdapterRead};
 use crate::sync::SyncModeState;
 use crate::telemetry::{
@@ -179,51 +179,6 @@ impl<StorageImpl> SessionContext<StorageImpl>
 where
     StorageImpl: Storage + Clone + Send + Sync + 'static,
 {
-    pub(crate) async fn open_default(
-        active_account_id: String,
-        storage: StorageAdapter<StorageImpl>,
-        hot_state: Arc<HotStateContext>,
-        tracked_state: Arc<TrackedStateContext>,
-        binary_cas: Arc<BinaryCasContext>,
-        branch_ctx: Arc<BranchContext>,
-        catalog_context: Arc<CatalogContext>,
-        sql_planning_cache: Arc<SqlPlanningCache<CatalogFingerprint>>,
-        deterministic_runtime_gate: Arc<tokio::sync::Mutex<()>>,
-        collaboration_write_gate: Arc<tokio::sync::Mutex<()>>,
-        commit_coordinator: Arc<CommitCoordinator<StorageImpl>>,
-        observe_coordinator: Arc<ObserveCoordinator>,
-        observe_invalidation: Arc<ObserveInvalidation>,
-        sync_mode: SyncModeState,
-        plugin_host: PluginRuntimeHost,
-        telemetry: Option<Arc<dyn TelemetrySink>>,
-    ) -> Result<Self, LixError> {
-        let read =
-            SharedStorageAdapterRead::new(storage.begin_read(StorageReadOptions::default()).await?);
-        let branch_id =
-            load_default_branch_id_from_index(hot_state.as_ref(), branch_ctx.as_ref(), &read)
-                .await?;
-        drop(read);
-        Ok(Self::new(
-            SessionBranch::new(branch_id),
-            active_account_id,
-            storage,
-            hot_state,
-            tracked_state,
-            binary_cas,
-            branch_ctx,
-            catalog_context,
-            sql_planning_cache,
-            deterministic_runtime_gate,
-            collaboration_write_gate,
-            commit_coordinator,
-            observe_coordinator,
-            observe_invalidation,
-            sync_mode,
-            plugin_host,
-            telemetry,
-        ))
-    }
-
     pub(crate) fn new(
         branch: SessionBranch,
         active_account_id: String,

--- a/packages/lix/src/sync/simulation_tests.rs
+++ b/packages/lix/src/sync/simulation_tests.rs
@@ -759,6 +759,223 @@ async fn partial_checkpoint_batches_distinct_change_owners(_sim: Simulation) {
     assert_eq!(remaining, (OWNER_COUNT - 1) as i64);
 }
 
+async fn partial_checkpoint_after_partial_checkpoint_snapshot_stays_hot(_sim: Simulation) {
+	let authority = fresh_authority().await;
+	write_key_value(&authority, "selected", "baseline").await;
+	write_key_value(&authority, "remaining", "baseline").await;
+	authority.create_checkpoint().await.unwrap();
+	let mut replica = Replica::bootstrap(AuthorityTransport::connected(authority)).await;
+	replica.write("selected", "local-selected").await;
+	replica.write("remaining", "local-remaining").await;
+	let first_selected_diff_id = replica
+		.lix
+		.execute(
+			"SELECT diff_id FROM lix_working_diff() \
+			 WHERE schema_key = 'lix_key_value' \
+			   AND row_pk = CAST('[\"selected\"]' AS JSONB)",
+			&[],
+		)
+		.await
+		.unwrap()
+		.rows()[0]
+		.get::<String>("diff_id")
+		.unwrap();
+	replica
+		.lix
+		.execute(
+			"INSERT INTO lix_create_checkpoint (diff_id) SELECT $1 RETURNING commit_id",
+			&[Value::Text(first_selected_diff_id)],
+		)
+		.await
+		.unwrap();
+	replica.pump().await.unwrap();
+
+	assert_eq!(
+		replica
+			.lix
+			.execute("SELECT COUNT(*) AS count FROM lix_working_diff()", &[])
+			.await
+			.unwrap()
+			.rows()[0]
+			.get::<i64>("count")
+			.unwrap(),
+		1,
+		"the unselected change must remain dirty after the first partial checkpoint",
+	);
+
+	// The next write used to fail because the branch control pointed at the new
+	// checkpoint while the sparse working-diff epoch still pointed at the old
+	// checkpoint and generation.
+	replica.write("selected", "local-selected-again").await;
+	let selected_diff_id = replica
+		.lix
+		.execute(
+			"SELECT diff_id FROM lix_working_diff() \
+			 WHERE schema_key = 'lix_key_value' \
+			   AND row_pk = CAST('[\"selected\"]' AS JSONB)",
+			&[],
+		)
+		.await
+		.unwrap()
+		.rows()[0]
+		.get::<String>("diff_id")
+		.unwrap();
+	let head_commit_id = replica
+		.lix
+		.execute("SELECT lix_active_branch_commit_id() AS id", &[])
+		.await
+		.unwrap()
+		.rows()[0]
+		.get::<String>("id")
+		.unwrap();
+	let branch_id = replica.lix.active_branch_id().await.unwrap();
+	let adapter = replica.lix.storage_adapter();
+	let read = adapter
+		.begin_read(crate::storage_adapter::StorageReadOptions::default())
+		.await
+		.unwrap();
+	let checkpoint_commit_id = crate::checkpoint::checkpoint_commit_id_at_head(
+		&read,
+		&branch_id,
+		crate::changelog::CommitId::parse_lix(&head_commit_id, "partial snapshot head").unwrap(),
+	)
+	.await
+	.unwrap()
+	.to_string();
+	drop(read);
+	crate::tracked_state::arm_diff_commits_test_probe(&checkpoint_commit_id, &head_commit_id);
+
+	replica
+		.lix
+		.execute(
+			"INSERT INTO lix_create_checkpoint (diff_id) SELECT $1 RETURNING commit_id",
+			&[Value::Text(selected_diff_id)],
+		)
+		.await
+		.unwrap();
+	assert_eq!(
+		crate::tracked_state::take_diff_commits_test_probe(
+			&checkpoint_commit_id,
+			&head_commit_id,
+		),
+		0,
+		"a partial-checkpoint snapshot must not reconstruct working diff history",
+	);
+	assert_eq!(
+		replica
+			.lix
+			.execute("SELECT COUNT(*) AS count FROM lix_working_diff()", &[])
+			.await
+			.unwrap()
+			.rows()[0]
+			.get::<i64>("count")
+			.unwrap(),
+		1,
+		"the second partial checkpoint must retain only the unselected change",
+	);
+}
+
+async fn stale_partial_checkpoint_epoch_repairs_on_reopen(_sim: Simulation) {
+	let authority = fresh_authority().await;
+	write_key_value(&authority, "selected", "baseline").await;
+	write_key_value(&authority, "remaining", "baseline").await;
+	authority.create_checkpoint().await.unwrap();
+	let mut replica = Replica::bootstrap(AuthorityTransport::connected(authority)).await;
+	let branch_id = replica.lix.active_branch_id().await.unwrap();
+	let adapter = replica.lix.storage_adapter();
+	let read = adapter
+		.begin_read(crate::storage_adapter::StorageReadOptions::default())
+		.await
+		.unwrap();
+	let old_epoch = crate::hot_state::TrackedHeadContext::new()
+		.reader(&read)
+		.working_diff_epoch(&branch_id)
+		.await
+		.unwrap()
+		.unwrap();
+	drop(read);
+
+	replica.write("selected", "local-selected").await;
+	replica.write("remaining", "local-remaining").await;
+	let selected_diff_id = replica
+		.lix
+		.execute(
+			"SELECT diff_id FROM lix_working_diff() \
+			 WHERE schema_key = 'lix_key_value' \
+			   AND row_pk = CAST('[\"selected\"]' AS JSONB)",
+			&[],
+		)
+		.await
+		.unwrap()
+		.rows()[0]
+		.get::<String>("diff_id")
+		.unwrap();
+	replica
+		.lix
+		.execute(
+			"INSERT INTO lix_create_checkpoint (diff_id) SELECT $1 RETURNING commit_id",
+			&[Value::Text(selected_diff_id)],
+		)
+		.await
+		.unwrap();
+	replica.pump().await.unwrap();
+
+	let read = adapter
+		.begin_read(crate::storage_adapter::StorageReadOptions::default())
+		.await
+		.unwrap();
+	let control = crate::branch::BranchHeadControlContext::new()
+		.reader(&read)
+		.load(&branch_id)
+		.await
+		.unwrap()
+		.unwrap();
+	drop(read);
+	let checkpoint_commit_id = control
+		.working_diff_checkpoint_commit_id
+		.unwrap()
+		.to_string();
+	let head_commit_id = control.head_commit_id.to_string();
+	let mut writes = adapter.new_write_set();
+	crate::hot_state::stage_tracked_working_diff_epoch(
+		&mut writes,
+		&branch_id,
+		old_epoch,
+	)
+	.unwrap();
+	adapter
+		.commit_write_set(
+			writes,
+			crate::storage_adapter::StorageWriteOptions::default(),
+		)
+		.await
+		.unwrap();
+	crate::tracked_state::arm_diff_commits_test_probe(&checkpoint_commit_id, &head_commit_id);
+
+	replica.restart().await;
+	assert_eq!(
+		crate::tracked_state::take_diff_commits_test_probe(
+			&checkpoint_commit_id,
+			&head_commit_id,
+		),
+		0,
+		"reopening must repair the stale derived epoch directly from rooted snapshots",
+	);
+	assert_eq!(
+		replica
+			.lix
+			.execute("SELECT COUNT(*) AS count FROM lix_working_diff()", &[])
+			.await
+			.unwrap()
+			.rows()[0]
+			.get::<i64>("count")
+			.unwrap(),
+		1,
+		"reopen repair must retain the unselected change",
+	);
+	replica.write("selected", "after-reopen").await;
+}
+
 async fn deterministic_sync_command_traces(_sim: Simulation) {
     for seed in fuzz_seeds(&(0_u64..32).collect::<Vec<_>>()) {
         // Each seed starts from an independent repository, so an override can
@@ -818,6 +1035,14 @@ sync_simulation_test!(
 sync_simulation_test!(
     partial_checkpoint_batches_distinct_change_owners,
     partial_checkpoint_batches_distinct_change_owners
+);
+sync_simulation_test!(
+	partial_checkpoint_after_partial_checkpoint_snapshot_stays_hot,
+	partial_checkpoint_after_partial_checkpoint_snapshot_stays_hot
+);
+sync_simulation_test!(
+	stale_partial_checkpoint_epoch_repairs_on_reopen,
+	stale_partial_checkpoint_epoch_repairs_on_reopen
 );
 
 struct XorShift64(u64);

--- a/packages/lix/src/transaction/commit.rs
+++ b/packages/lix/src/transaction/commit.rs
@@ -3953,8 +3953,30 @@ async fn stage_tracked_head(
                 lifecycle_generation(&root.branch_id, root.commit_id, root.ref_change_id);
             let mut coverage = WorkingDiffIndexCoverage::default();
             let owned_absence_guards = owned_absence_guards(&absence_guards);
+            let partial_checkpoint_epoch = checkpoint_commit_id
+                .filter(|checkpoint_commit_id| *checkpoint_commit_id != root.commit_id);
             let working_diff_mode = match (checkpoint_commit_id, working_diff_epoch.as_ref()) {
-                (Some(_), _) => CompleteWorkingDiffMode::ResetClean,
+                (Some(checkpoint_commit_id), _) if checkpoint_commit_id == root.commit_id => {
+                    CompleteWorkingDiffMode::ResetClean
+                }
+                (Some(checkpoint_commit_id), _) => {
+                    let checkpoint = tracked_snapshots
+                        .get(&checkpoint_commit_id)
+                        .cloned()
+                        .ok_or_else(|| {
+                            LixError::new(
+                                LixError::CODE_INTERNAL_ERROR,
+                                format!(
+                                    "partial checkpoint child '{}' is missing checkpoint snapshot '{}'",
+                                    root.commit_id, checkpoint_commit_id
+                                ),
+                            )
+                        })?;
+                    CompleteWorkingDiffMode::Rebase {
+                        checkpoint_commit_id,
+                        checkpoint,
+                    }
+                }
                 (None, Some(epoch)) => {
                     let checkpoint = load_persisted_lifecycle_tracked_snapshot(
                         read,
@@ -3988,12 +4010,16 @@ async fn stage_tracked_head(
                     &mut coverage,
                 )
                 .await?;
-            if let Some(epoch) = &working_diff_epoch {
+            if let Some(checkpoint_commit_id) = partial_checkpoint_epoch.or(
+                working_diff_epoch
+                    .as_ref()
+                    .map(|epoch| epoch.checkpoint_commit_id),
+            ) {
                 stage_tracked_working_diff_epoch(
                     writes,
                     &root.branch_id,
                     TrackedWorkingDiffEpoch {
-                        checkpoint_commit_id: epoch.checkpoint_commit_id,
+                        checkpoint_commit_id,
                         generation,
                         coverage,
                     },
@@ -4955,10 +4981,10 @@ async fn stage_checkpoint_working_diff_epochs(
             ));
         }
         // A partial checkpoint publishes a child head whose unselected
-        // changes remain dirty relative to the intermediate checkpoint. The
-        // empty HOT epoch is valid only when the checkpoint itself is the
-        // published head; otherwise the historical diff path reconstructs
-        // the remaining working diff from the two durable roots.
+        // changes remain dirty relative to the intermediate checkpoint.
+        // `stage_tracked_head` rebases that child and stages its sparse epoch
+        // while both lifecycle snapshots are available in the transaction.
+        // The empty epoch here is valid only for a fully clean checkpoint.
         if control.head_commit_id != recovery.checkpoint_commit_id {
             continue;
         }


### PR DESCRIPTION
## Summary

- atomically rebase a partial checkpoint child against its in-transaction checkpoint snapshot
- stage the new sparse working-diff epoch with the same checkpoint cursor and generation as branch control
- lazily repair repositories that persisted the former stale derived epoch when the affected branch session opens
- keep healthy session opens independent of the collaboration write gate

This changes only private HOT serving state. It does not change the public Lix API, SQL surfaces, schemas, repository history, or return types.

## Regression coverage

- two consecutive synced partial checkpoints stay on the hot path and call `diff_commits` zero times
- a deliberately stale persisted epoch repairs on reopen without history reconstruction, retains the unselected change, and accepts the next write
- a healthy session open completes while the collaboration write gate is held

## Local verification

- `cargo test -p lix sync::simulation_tests -- --nocapture`
- `cargo test -p lix engine::tests -- --nocapture`
- `cargo test -p lix session::context::tests -- --nocapture`
- `cargo clippy --profile test --workspace --all-targets --all-features -- -D warnings`
- `node scripts/validate-changes.mjs`
- `cargo fmt --all -- --check`
- `git diff --check`