### PR TITLE
fix(lix): keep partial checkpoints on hot state

### DIFF
--- a/packages/e2e/tests/e2e.rs
+++ b/packages/e2e/tests/e2e.rs
@@ -5506,6 +5506,96 @@ async fn v3_excalidraw_same_element_branch_merge_uses_canonical_b() {
 }
 
 #[tokio::test]
+async fn partial_checkpoint_rebases_all_plugin_rows_for_one_file() {
+    let lix = open_lix().await.unwrap();
+    install_reference_plugin_in_blank_registry(
+        &lix,
+        "plugin_csv",
+        &build_csv_plugin_archive(),
+        &["csv_table", "csv_row"],
+    )
+    .await;
+    write_file(&lix, "/selected.csv", b"name,value\na,one\nb,two\n".to_vec())
+        .await
+        .unwrap();
+    write_file(
+        &lix,
+        "/remaining.csv",
+        b"name,value\nx,ten\ny,twenty\n".to_vec(),
+    )
+    .await
+    .unwrap();
+    lix.create_checkpoint().await.unwrap();
+    let selected_file_id = file_id_at_path(&lix, "/selected.csv").await;
+    let remaining_file_id = file_id_at_path(&lix, "/remaining.csv").await;
+
+    write_file(
+        &lix,
+        "/selected.csv",
+        b"name,value\na,ONE\nb,TWO\nc,THREE\n".to_vec(),
+    )
+    .await
+    .unwrap();
+    write_file(
+        &lix,
+        "/remaining.csv",
+        b"name,value\nx,TEN\ny,TWENTY\nz,THIRTY\n".to_vec(),
+    )
+    .await
+    .unwrap();
+    let selected_diff_count = lix
+        .execute(
+            "SELECT COUNT(*) AS count FROM lix_working_diff() WHERE file_id = $1",
+            &[Value::Text(selected_file_id.clone())],
+        )
+        .await
+        .unwrap()
+        .rows()[0]
+        .get::<i64>("count")
+        .unwrap();
+    assert!(selected_diff_count > 1, "CSV must fan out beyond lix_file");
+    lix.execute(
+        "INSERT INTO lix_create_checkpoint (diff_id) \
+         SELECT diff_id FROM lix_working_diff() WHERE file_id = $1 \
+         RETURNING commit_id",
+        &[Value::Text(selected_file_id.clone())],
+    )
+    .await
+    .expect("checkpoint all selected plugin rows");
+
+    assert_eq!(
+        lix.execute(
+            "SELECT COUNT(*) AS count FROM lix_working_diff() WHERE file_id = $1",
+            &[Value::Text(selected_file_id.clone())],
+        )
+        .await
+        .unwrap()
+        .rows()[0]
+        .get::<i64>("count")
+        .unwrap(),
+        0,
+    );
+    assert!(
+        lix.execute(
+            "SELECT COUNT(*) AS count FROM lix_working_diff() WHERE file_id = $1",
+            &[Value::Text(remaining_file_id)],
+        )
+        .await
+        .unwrap()
+        .rows()[0]
+        .get::<i64>("count")
+        .unwrap()
+            > 0,
+    );
+    assert_eq!(active_csv_rows(&lix, &selected_file_id).await.len(), 4);
+    assert_eq!(
+        read_file(&lix, "/selected.csv").await.unwrap().unwrap(),
+        b"name,value\na,ONE\nb,TWO\nc,THREE\n",
+    );
+    lix.close().await.unwrap();
+}
+
+#[tokio::test]
 async fn v2_csv_ids_survive_insert_edit_reorder_delete_eviction_and_cold_reopen() {
     let tempdir = tempfile::tempdir().unwrap();
     let archive = build_csv_plugin_archive();

--- a/packages/e2e/tests/sync_mode.rs
+++ b/packages/e2e/tests/sync_mode.rs
@@ -39,9 +39,123 @@ struct HttpProbe {
     chunk_puts: AtomicU64,
     drop_next_push_ack: AtomicBool,
     reject_requests: AtomicBool,
+    reject_pushes: AtomicBool,
     one_way_delay_millis: AtomicU64,
     gated_pushes: AtomicU64,
     push_gate: Mutex<Option<Arc<tokio::sync::Barrier>>>,
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn synced_partial_file_checkpoint_stays_off_cold_history() {
+    let authority = Arc::new(open_lix().await.expect("open authority"));
+    for index in 0..50 {
+        put_value(
+            &authority,
+            &format!("cold-owner-{index:02}"),
+            &format!("baseline-{index:02}"),
+        )
+        .await;
+    }
+    authority
+        .create_checkpoint()
+        .await
+        .expect("checkpoint cold snapshot baseline");
+
+    let probe = Arc::new(HttpProbe::default());
+    let (url, server_task) = serve(Arc::clone(&authority), Arc::clone(&probe)).await;
+    let replica_dir = TempDir::new().expect("replica tempdir");
+    let replica = open_replica(replica_dir.path(), &url).await;
+    probe.set_push_offline(true);
+    let history_after_bootstrap = probe.history_gets.load(Ordering::Acquire);
+
+    for (path, content) in [
+        ("/selected.md", b"selected content".as_slice()),
+        ("/remaining.md", b"remaining content".as_slice()),
+    ] {
+        replica
+            .execute(
+                "INSERT INTO lix_file (path, content) VALUES ($1, $2)",
+                &[
+                    Value::Text(path.to_owned()),
+                    Value::Blob(content.to_vec().into()),
+                ],
+            )
+            .await
+            .expect("create local file");
+    }
+
+    let selected_file_id = replica
+        .execute("SELECT id FROM lix_file WHERE path = '/selected.md'", &[])
+        .await
+        .expect("load selected file id")
+        .rows()[0]
+        .get::<String>("id")
+        .expect("selected file id decodes");
+    assert_eq!(
+        probe.history_gets.load(Ordering::Acquire),
+        history_after_bootstrap,
+        "local file setup must not hydrate additional snapshot history",
+    );
+
+    let history_before_checkpoint = probe.history_gets.load(Ordering::Acquire);
+    let checkpoint = replica
+        .execute(
+            "INSERT INTO lix_create_checkpoint (diff_id) \
+             SELECT diff_id FROM lix_working_diff() WHERE file_id = $1 \
+             RETURNING commit_id",
+            &[Value::Text(selected_file_id.clone())],
+        )
+        .await
+        .expect("partial file checkpoint stays HOT");
+    assert!(
+        checkpoint.rows_affected() > 0,
+        "checkpoint must select the file diff",
+    );
+    assert_eq!(
+        probe.history_gets.load(Ordering::Acquire),
+        history_before_checkpoint,
+        "checkpoint must not reconstruct the snapshot's cold commit owners",
+    );
+    assert_eq!(
+        replica
+            .execute(
+                "SELECT COUNT(*) AS count FROM lix_working_diff() WHERE file_id = $1",
+                &[Value::Text(selected_file_id.clone())],
+            )
+            .await
+            .expect("first reactive working-diff read stays HOT")
+            .rows()[0]
+            .get::<i64>("count")
+            .unwrap(),
+        0,
+    );
+    assert!(
+        replica
+            .execute(
+                "SELECT COUNT(*) AS count FROM lix_working_diff() AS diff \
+                 JOIN lix_file AS file ON file.id = diff.file_id \
+                 WHERE file.path = '/remaining.md'",
+                &[],
+            )
+            .await
+            .expect("unselected file remains dirty")
+            .rows()[0]
+            .get::<i64>("count")
+            .unwrap()
+            > 0,
+    );
+    assert_eq!(
+        read_file_content(&replica, "/selected.md").await.as_deref(),
+        Some(b"selected content".as_slice()),
+    );
+    assert_eq!(
+        probe.history_gets.load(Ordering::Acquire),
+        history_before_checkpoint,
+        "reactive refresh must not defer the same cold reconstruction",
+    );
+    replica.close().await.expect("close replica");
+    stop_server(server_task).await;
+    authority.close().await.expect("close authority");
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
@@ -154,6 +268,10 @@ impl HttpProbe {
 
     fn set_offline(&self, offline: bool) {
         self.reject_requests.store(offline, Ordering::Release);
+    }
+
+    fn set_push_offline(&self, offline: bool) {
+        self.reject_pushes.store(offline, Ordering::Release);
     }
 }
 
@@ -1217,6 +1335,15 @@ where
     tokio::time::sleep(one_way_delay).await;
     let path = parts.uri.path();
     let is_push = parts.method == Method::POST && path == "/lix/v1/sync/push";
+    if is_push && probe.reject_pushes.load(Ordering::Acquire) {
+        return Ok(Response::builder()
+            .status(503)
+            .header(CONTENT_TYPE, "application/json")
+            .body(Full::new(Bytes::from_static(
+                br#"{"error":{"code":"LIX_SYNC_TEST_PUSH_OFFLINE","message":"test push endpoint offline"}}"#,
+            )))
+            .expect("build push-offline response"));
+    }
     let is_delta_pull = parts.method == Method::GET
         && path == "/lix/v1/sync/pull"
         && parts

--- a/packages/lix/src/gc.rs
+++ b/packages/lix/src/gc.rs
@@ -189,6 +189,9 @@ impl CheckpointGcState {
 pub(crate) struct CheckpointPublication {
     pub(crate) recovery_ref: CheckpointRecoveryRef,
     pub(crate) gc_state: CheckpointGcState,
+    /// The selected interval came from the certified HOT working-diff index,
+    /// so a partial checkpoint may rebind its remaining dirty rows in place.
+    pub(crate) hot_working_diff_certified: bool,
 }
 
 #[derive(musli::Encode)]

--- a/packages/lix/src/hot_state/tracked_head/hot.rs
+++ b/packages/lix/src/hot_state/tracked_head/hot.rs
@@ -5305,6 +5305,13 @@ pub(crate) enum CompleteWorkingDiffMode {
     },
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum WorkingDiffBaselineAction {
+    Continue,
+    Reset,
+    Rebase,
+}
+
 impl HotTrackedSnapshot {
     pub(crate) fn from_materialized_rows(
         tracked_rows: Vec<MaterializedTrackedStateRow>,
@@ -6507,7 +6514,7 @@ where
             false,
             None,
             None,
-            false,
+            WorkingDiffBaselineAction::Continue,
             &BTreeMap::new(),
         )
         .await
@@ -6539,7 +6546,7 @@ where
             false,
             None,
             None,
-            false,
+            WorkingDiffBaselineAction::Continue,
             &BTreeMap::new(),
         )
         .await
@@ -6575,7 +6582,7 @@ where
                 false,
                 None,
                 None,
-                true,
+                WorkingDiffBaselineAction::Reset,
                 &BTreeMap::new(),
             )
             .await?;
@@ -6586,19 +6593,38 @@ where
         Ok(generation)
     }
 
-    /// Whether a checkpoint can rotate its working-diff epoch without
-    /// materializing current-state base rows first.
+    /// Carries the unselected part of a partial checkpoint into its new
+    /// working-diff epoch without reconstructing the branch snapshot.
     ///
-    /// Packed-base refs retain the checkpoint epoch in which they were
-    /// published. Readers reinterpret a base as clean when the active epoch
-    /// advances, so rotating the epoch neither scans nor retires those refs.
-    /// Root bases are already checkpoint state and need no rewrite either.
-    pub(crate) async fn can_rotate_checkpoint_epoch(
-        &self,
-        _branch_id: &str,
-        _generation: CommitId,
-    ) -> Result<bool, LixError> {
-        Ok(true)
+    /// Every delta is already dirty in the visible generation. Its immutable
+    /// before-image remains the checkpoint baseline; only the checkpoint id,
+    /// current commit ownership, and sparse dirty index advance.
+    pub(crate) async fn stage_partial_checkpoint_current_state(
+        &mut self,
+        branch_id: &str,
+        generation: CommitId,
+        new_head: CommitId,
+        deltas: &[CurrentStateDeltaRef<'_>],
+        checkpoint_commit_id: CommitId,
+        coverage: &mut WorkingDiffIndexCoverage,
+    ) -> Result<CommitId, LixError> {
+        self.stage_current_state_with_working_diff_inner(
+            branch_id,
+            Some(generation),
+            new_head,
+            deltas,
+            &[],
+            &BTreeSet::new(),
+            None,
+            Some(checkpoint_commit_id),
+            coverage,
+            false,
+            None,
+            None,
+            WorkingDiffBaselineAction::Rebase,
+            &BTreeMap::new(),
+        )
+        .await
     }
 
     /// Stages deltas whose absence was already validated against the coherent
@@ -6640,7 +6666,7 @@ where
                     true,
                     validated_absent_file_id,
                     None,
-                    false,
+                    WorkingDiffBaselineAction::Continue,
                     &BTreeMap::new(),
                 )
                 .await;
@@ -6659,7 +6685,7 @@ where
             true,
             validated_absent_file_id,
             Some(absence_guards),
-            false,
+            WorkingDiffBaselineAction::Continue,
             &BTreeMap::new(),
         )
         .await
@@ -6680,9 +6706,20 @@ where
         absence_guards_validated: bool,
         validated_absent_file_id: Option<&str>,
         borrowed_absence_guards: Option<&[TrackedStateKeyRef<'_>]>,
-        reset_working_diff_baselines: bool,
+        working_diff_baseline_action: WorkingDiffBaselineAction,
         certified_live_increments: &BTreeMap<(String, Option<String>), u64>,
     ) -> Result<CommitId, LixError> {
+        if working_diff_baseline_action == WorkingDiffBaselineAction::Rebase
+            && working_diff_capture_checkpoint_commit_id.is_none()
+        {
+            return Err(head_value_error(
+                "partial-checkpoint rebase requires an active checkpoint",
+            ));
+        }
+        let reset_working_diff_baselines =
+            working_diff_baseline_action == WorkingDiffBaselineAction::Reset;
+        let rebase_working_diff_baselines =
+            working_diff_baseline_action == WorkingDiffBaselineAction::Rebase;
         let generation = parent_generation.unwrap_or(new_head);
         let sorted = {
             let _span = tracing::debug_span!(
@@ -7373,6 +7410,21 @@ where
                     && !delta.untracked
                 {
                     (WorkingDiffBaseline::Clean, false)
+                } else if rebase_working_diff_baselines && !delta.untracked {
+                    let previous = previous
+                        .as_ref()
+                        .map(CertifiedCurrentStatePredecessor::view)
+                        .transpose()?
+                        .ok_or_else(|| {
+                            head_value_error(
+                                "partial-checkpoint remainder has no HOT before-image",
+                            )
+                        })?;
+                    rebase_hot_working_diff_baseline(
+                        working_diff_capture_checkpoint_commit_id
+                            .expect("partial-checkpoint rebase requires a checkpoint"),
+                        previous,
+                    )?
                 } else if working_diff_capture_checkpoint_commit_id.is_some() && !delta.untracked {
                     let previous = previous
                         .as_ref()
@@ -8042,6 +8094,30 @@ fn next_hot_working_diff_baseline(
         }
         WorkingDiffBaseline::Disabled => Err(head_value_error(
             "active checkpoint generation contains a tracked row without a baseline",
+        )),
+    }
+}
+
+fn rebase_hot_working_diff_baseline(
+    checkpoint_commit_id: CommitId,
+    previous: HeadValueView<'_>,
+) -> Result<(WorkingDiffBaseline, bool), LixError> {
+    match previous.working_diff_baseline {
+        WorkingDiffBaseline::BeforeAbsent { .. } => Ok((
+            WorkingDiffBaseline::BeforeAbsent {
+                checkpoint_commit_id,
+            },
+            true,
+        )),
+        WorkingDiffBaseline::BeforePresent { version, .. } => Ok((
+            WorkingDiffBaseline::BeforePresent {
+                checkpoint_commit_id,
+                version,
+            },
+            true,
+        )),
+        WorkingDiffBaseline::Clean | WorkingDiffBaseline::Disabled => Err(head_value_error(
+            "partial-checkpoint remainder is not dirty in the previous epoch",
         )),
     }
 }

--- a/packages/lix/src/sync/simulation_tests.rs
+++ b/packages/lix/src/sync/simulation_tests.rs
@@ -732,27 +732,39 @@ async fn snapshot_partial_checkpoint_uses_local_selected_payloads(_sim: Simulati
 	);
 }
 
-async fn partial_checkpoint_avoids_distinct_cold_change_owners(_sim: Simulation) {
+async fn partial_checkpoint_rebases_hot_epoch_without_cold_history(_sim: Simulation) {
     const OWNER_COUNT: usize = 50;
     let authority = fresh_authority().await;
-    write_key_value(&authority, "baseline", "shared").await;
+    for index in 0..OWNER_COUNT {
+        write_key_value(
+            &authority,
+            &format!("owner-{index:02}"),
+            &format!("baseline-{index:02}"),
+        )
+        .await;
+    }
     authority
         .create_checkpoint()
         .await
         .expect("baseline checkpoint should commit");
     let mut replica = Replica::bootstrap(AuthorityTransport::connected(authority.clone())).await;
+
+    // Every updated payload is present in the replica's current HOT state,
+    // while the fifty physical commits that authored those rows remain cold.
     for index in 0..OWNER_COUNT {
         write_key_value(
             &authority,
             &format!("owner-{index:02}"),
-            &format!("value-{index:02}"),
+            &format!("updated-{index:02}"),
         )
         .await;
     }
     replica
         .pump()
         .await
-        .expect("replica should import every distinct change owner");
+        .expect("replica should import every sparse update");
+
+    crate::tracked_state::arm_point_replay_authority_batch_probe_for_test();
     let selected_diff_id = replica
         .lix
         .execute(
@@ -762,10 +774,14 @@ async fn partial_checkpoint_avoids_distinct_cold_change_owners(_sim: Simulation)
             &[],
         )
         .await
-        .expect("selected working diff should load")
+        .expect("working diff should already be HOT")
         .rows()[0]
         .get::<String>("diff_id")
         .expect("selected diff id should decode");
+    assert!(
+        crate::tracked_state::take_point_replay_authority_batch_probe_for_test().is_empty(),
+        "working-diff classification must not touch cold commit owners",
+    );
 
     crate::tracked_state::arm_point_replay_authority_batch_probe_for_test();
     let checkpoint = replica
@@ -775,15 +791,19 @@ async fn partial_checkpoint_avoids_distinct_cold_change_owners(_sim: Simulation)
             &[Value::Text(selected_diff_id)],
         )
         .await
-        .expect("partial checkpoint should batch selected-change owners");
+        .expect("checkpoint should use the exact selected HOT payload");
     let authority_batches =
         crate::tracked_state::take_point_replay_authority_batch_probe_for_test();
 
     assert_eq!(checkpoint.rows_affected(), 1);
-	assert!(
-		authority_batches.iter().sum::<usize>() <= 8,
-		"snapshot-local checkpointing must not probe the cold selected-owner population: {authority_batches:?}",
-	);
+    let checkpoint_commit_id = checkpoint.rows()[0]
+        .get::<String>("commit_id")
+        .expect("checkpoint commit id should decode");
+    assert!(
+        authority_batches.is_empty(),
+        "checkpoint publication must not re-read cold selected owners: {authority_batches:?}",
+    );
+    crate::tracked_state::arm_point_replay_authority_batch_probe_for_test();
     let remaining = replica
         .lix
         .execute(
@@ -797,6 +817,157 @@ async fn partial_checkpoint_avoids_distinct_cold_change_owners(_sim: Simulation)
         .get::<i64>("count")
         .expect("remaining count should decode");
     assert_eq!(remaining, (OWNER_COUNT - 1) as i64);
+    assert!(
+        crate::tracked_state::take_point_replay_authority_batch_probe_for_test().is_empty(),
+        "the first reactive working-diff read must stay HOT",
+    );
+
+    let checkpoint_state = replica
+        .lix
+        .execute(
+            &format!(
+                "SELECT key, value FROM lix_history('lix_key_value', '{checkpoint_commit_id}') \
+                 WHERE lixcol_depth = 0"
+            ),
+            &[],
+        )
+        .await
+        .expect("partial checkpoint state should remain readable");
+    assert_eq!(checkpoint_state.rows().len(), 1);
+    assert_eq!(
+        checkpoint_state.rows()[0].get::<String>("key").unwrap(),
+        "owner-00",
+    );
+    assert_eq!(
+        checkpoint_state.rows()[0]
+            .get::<serde_json::Value>("value")
+            .unwrap(),
+        serde_json::json!("updated-00"),
+    );
+
+    replica.restart().await;
+    crate::tracked_state::arm_point_replay_authority_batch_probe_for_test();
+    let reopened_remaining = replica
+        .lix
+        .execute("SELECT count(*) AS count FROM lix_working_diff()", &[])
+        .await
+        .expect("reopened working diff should remain HOT")
+        .rows()[0]
+        .get::<i64>("count")
+        .unwrap();
+    assert_eq!(reopened_remaining, (OWNER_COUNT - 1) as i64);
+    assert!(
+        crate::tracked_state::take_point_replay_authority_batch_probe_for_test().is_empty(),
+        "reopened working-diff read must not reconstruct cold owners",
+    );
+}
+
+async fn partial_file_checkpoint_rebases_hot_epoch(_sim: Simulation) {
+    let authority = fresh_authority().await;
+    for path in ["/selected.md", "/remaining.md"] {
+        authority
+            .execute(
+                "INSERT INTO lix_file (path, content) VALUES ($1, $2)",
+                &[
+                    Value::Text(path.to_owned()),
+                    Value::Blob(b"baseline".to_vec().into()),
+                ],
+            )
+            .await
+            .expect("baseline file should commit");
+    }
+    authority
+        .create_checkpoint()
+        .await
+        .expect("baseline checkpoint should commit");
+    let mut replica = Replica::bootstrap(AuthorityTransport::connected(authority.clone())).await;
+
+    for (path, content) in [
+        ("/selected.md", b"selected update".as_slice()),
+        ("/remaining.md", b"remaining update".as_slice()),
+    ] {
+        authority
+            .execute(
+                "UPDATE lix_file SET content = $1 WHERE path = $2",
+                &[
+                    Value::Blob(content.to_vec().into()),
+                    Value::Text(path.to_owned()),
+                ],
+            )
+            .await
+            .expect("file update should commit");
+    }
+    replica
+        .pump()
+        .await
+        .expect("replica should import both file updates");
+
+    let selected_file_id = replica
+        .lix
+        .execute(
+            "SELECT id FROM lix_file WHERE path = '/selected.md'",
+            &[],
+        )
+        .await
+        .expect("selected file should load")
+        .rows()[0]
+        .get::<String>("id")
+        .expect("selected file id should decode");
+    let selected_diff_id = replica
+        .lix
+        .execute(
+            "SELECT diff_id FROM lix_working_diff() WHERE file_id = $1 LIMIT 1",
+            &[Value::Text(selected_file_id)],
+        )
+        .await
+        .expect("selected file diff should load")
+        .rows()[0]
+        .get::<String>("diff_id")
+        .expect("selected file diff id should decode");
+
+    crate::tracked_state::arm_point_replay_authority_batch_probe_for_test();
+    replica
+        .lix
+        .execute(
+            "INSERT INTO lix_create_checkpoint (diff_id) SELECT $1 RETURNING commit_id",
+            &[Value::Text(selected_diff_id)],
+        )
+        .await
+        .expect("partial file checkpoint should stay snapshot-local");
+    let authority_batches =
+        crate::tracked_state::take_point_replay_authority_batch_probe_for_test();
+    assert!(
+        authority_batches.is_empty(),
+        "partial file checkpoint must not re-read cold owners: {authority_batches:?}",
+    );
+
+    let files = replica
+        .lix
+        .execute("SELECT path, content FROM lix_file ORDER BY path", &[])
+        .await
+        .expect("files should remain readable after checkpoint");
+    assert_eq!(
+        files.rows()[0].get::<Vec<u8>>("content").unwrap(),
+        b"remaining update",
+    );
+    assert_eq!(
+        files.rows()[1].get::<Vec<u8>>("content").unwrap(),
+        b"selected update",
+    );
+    let remaining_paths = replica
+        .lix
+        .execute(
+            "SELECT DISTINCT file.path AS path FROM lix_working_diff() AS diff \
+             JOIN lix_file AS file ON file.id = diff.file_id ORDER BY path",
+            &[],
+        )
+        .await
+        .expect("remaining file diff should load");
+    assert_eq!(remaining_paths.rows().len(), 1);
+    assert_eq!(
+        remaining_paths.rows()[0].get::<String>("path").unwrap(),
+        "/remaining.md",
+    );
 }
 
 async fn partial_checkpoint_after_partial_checkpoint_snapshot_stays_hot(_sim: Simulation) {
@@ -913,6 +1084,174 @@ async fn partial_checkpoint_after_partial_checkpoint_snapshot_stays_hot(_sim: Si
 		1,
 		"the second partial checkpoint must retain only the unselected change",
 	);
+}
+
+async fn partial_checkpoint_canonical_fallback_keeps_lifecycle_path(_sim: Simulation) {
+    let authority = fresh_authority().await;
+    write_key_value(&authority, "selected", "baseline").await;
+    write_key_value(&authority, "remaining", "baseline").await;
+    authority.create_checkpoint().await.unwrap();
+    let replica = Replica::bootstrap(AuthorityTransport::connected(authority)).await;
+    replica.write("selected", "selected-update").await;
+    replica.write("remaining", "remaining-update").await;
+
+    let branch_id = replica.lix.active_branch_id().await.unwrap();
+    let adapter = replica.lix.storage_adapter();
+    let read = adapter
+        .begin_read(crate::storage_adapter::StorageReadOptions::default())
+        .await
+        .unwrap();
+    let control = crate::branch::BranchHeadControlContext::new()
+        .reader(&read)
+        .load(&branch_id)
+        .await
+        .unwrap()
+        .unwrap();
+    let checkpoint_commit_id = control.working_diff_checkpoint_commit_id.unwrap();
+    drop(read);
+    let mut writes = adapter.new_write_set();
+    crate::hot_state::stage_tracked_working_diff_epoch(
+        &mut writes,
+        &branch_id,
+        crate::hot_state::TrackedWorkingDiffEpoch {
+            checkpoint_commit_id,
+            generation: control.tracked_generation,
+            coverage: crate::hot_state::WorkingDiffIndexCoverage::default(),
+        },
+    )
+    .unwrap();
+    adapter
+        .commit_write_set(
+            writes,
+            crate::storage_adapter::StorageWriteOptions::default(),
+        )
+        .await
+        .unwrap();
+
+    let read = adapter
+        .begin_read(crate::storage_adapter::StorageReadOptions::default())
+        .await
+        .unwrap();
+    assert!(
+        crate::hot_state::TrackedHeadContext::new()
+            .reader(read)
+            .working_diff_for_control(
+                &branch_id,
+                control,
+                &crate::tracked_state::TrackedStateDiffRequest::default(),
+            )
+            .await
+            .unwrap()
+            .is_none(),
+        "corrupt coverage must force the canonical diff fallback",
+    );
+
+    let selected_diff_id = replica
+        .lix
+        .execute(
+            "SELECT diff_id FROM lix_working_diff() \
+             WHERE schema_key = 'lix_key_value' \
+               AND row_pk = CAST('[\"selected\"]' AS JSONB)",
+            &[],
+        )
+        .await
+        .unwrap()
+        .rows()[0]
+        .get::<String>("diff_id")
+        .unwrap();
+    replica
+        .lix
+        .execute(
+            "INSERT INTO lix_create_checkpoint (diff_id) SELECT $1 RETURNING commit_id",
+            &[Value::Text(selected_diff_id)],
+        )
+        .await
+        .expect("canonical fallback must retain complete lifecycle publication");
+    assert_eq!(
+        replica
+            .lix
+            .execute("SELECT COUNT(*) AS count FROM lix_working_diff()", &[])
+            .await
+            .unwrap()
+            .rows()[0]
+            .get::<i64>("count")
+            .unwrap(),
+        1,
+    );
+}
+
+async fn partial_checkpoint_rebases_unselected_tombstone(_sim: Simulation) {
+    let authority = fresh_authority().await;
+    write_key_value(&authority, "selected", "baseline").await;
+    write_key_value(&authority, "removed", "baseline").await;
+    authority.create_checkpoint().await.unwrap();
+    let mut replica = Replica::bootstrap(AuthorityTransport::connected(authority.clone())).await;
+    write_key_value(&authority, "selected", "selected-update").await;
+    authority
+        .execute("DELETE FROM lix_key_value WHERE key = 'removed'", &[])
+        .await
+        .unwrap();
+    replica.pump().await.unwrap();
+    let selected_diff_id = replica
+        .lix
+        .execute(
+            "SELECT diff_id FROM lix_working_diff() \
+             WHERE schema_key = 'lix_key_value' \
+               AND row_pk = CAST('[\"selected\"]' AS JSONB)",
+            &[],
+        )
+        .await
+        .unwrap()
+        .rows()[0]
+        .get::<String>("diff_id")
+        .unwrap();
+
+    crate::tracked_state::arm_point_replay_authority_batch_probe_for_test();
+    replica
+        .lix
+        .execute(
+            "INSERT INTO lix_create_checkpoint (diff_id) SELECT $1 RETURNING commit_id",
+            &[Value::Text(selected_diff_id)],
+        )
+        .await
+        .unwrap();
+    assert!(
+        crate::tracked_state::take_point_replay_authority_batch_probe_for_test().is_empty(),
+        "partial checkpoint tombstone rebase must stay HOT",
+    );
+    let remaining = replica
+        .lix
+        .execute(
+            "SELECT diff_type, row_pk FROM lix_working_diff() \
+             WHERE schema_key = 'lix_key_value'",
+            &[],
+        )
+        .await
+        .unwrap();
+    assert_eq!(remaining.rows().len(), 1);
+    assert_eq!(remaining.rows()[0].get::<String>("diff_type").unwrap(), "removed");
+    assert_eq!(
+        remaining.rows()[0]
+            .get::<serde_json::Value>("row_pk")
+            .unwrap(),
+        serde_json::json!(["removed"]),
+    );
+    replica.restart().await;
+    assert_eq!(
+        replica
+            .lix
+            .execute(
+                "SELECT COUNT(*) AS count FROM lix_working_diff() \
+                 WHERE diff_type = 'removed'",
+                &[],
+            )
+            .await
+            .unwrap()
+            .rows()[0]
+            .get::<i64>("count")
+            .unwrap(),
+        1,
+    );
 }
 
 async fn stale_partial_checkpoint_epoch_repairs_on_reopen(_sim: Simulation) {
@@ -1077,12 +1416,24 @@ sync_simulation_test!(
 	snapshot_partial_checkpoint_uses_local_selected_payloads
 );
 sync_simulation_test!(
-	partial_checkpoint_avoids_distinct_cold_change_owners,
-	partial_checkpoint_avoids_distinct_cold_change_owners
+	partial_checkpoint_rebases_hot_epoch_without_cold_history,
+	partial_checkpoint_rebases_hot_epoch_without_cold_history
+);
+sync_simulation_test!(
+    partial_file_checkpoint_rebases_hot_epoch,
+    partial_file_checkpoint_rebases_hot_epoch
 );
 sync_simulation_test!(
 	partial_checkpoint_after_partial_checkpoint_snapshot_stays_hot,
 	partial_checkpoint_after_partial_checkpoint_snapshot_stays_hot
+);
+sync_simulation_test!(
+    partial_checkpoint_canonical_fallback_keeps_lifecycle_path,
+    partial_checkpoint_canonical_fallback_keeps_lifecycle_path
+);
+sync_simulation_test!(
+    partial_checkpoint_rebases_unselected_tombstone,
+    partial_checkpoint_rebases_unselected_tombstone
 );
 sync_simulation_test!(
 	stale_partial_checkpoint_epoch_repairs_on_reopen,

--- a/packages/lix/src/transaction/commit.rs
+++ b/packages/lix/src/transaction/commit.rs
@@ -3034,6 +3034,12 @@ struct StagedHotHeads {
     controls: BTreeMap<String, BranchHeadControl>,
 }
 
+#[derive(Clone, Copy)]
+struct CheckpointEpochBinding {
+    commit_id: CommitId,
+    hot_rebase_certified: bool,
+}
+
 /// Returns the commit snapshots that must be materialized before publication.
 /// Normal serial commits and row-only selected refs stay on the
 /// O(changed-rows) hot mutation path. A lifecycle discontinuity (checkpoint,
@@ -3045,7 +3051,7 @@ fn lifecycle_snapshot_commit_ids(
     staged_commits: &BTreeMap<CommitId, StagedChangelogCommit>,
     explicit_branch_targets: &BTreeMap<String, ExplicitBranchHeadTarget>,
     observations: &BTreeMap<String, BranchHeadControlObservation>,
-    checkpoint_epochs: &BTreeMap<String, CommitId>,
+    checkpoint_epochs: &BTreeMap<String, CheckpointEpochBinding>,
 ) -> Result<BTreeSet<CommitId>, LixError> {
     let roots_by_id = tracked_roots
         .iter()
@@ -3070,13 +3076,23 @@ fn lifecycle_snapshot_commit_ids(
             (Some(parent_commit_id), Some(control))
                 if control.head_commit_id == parent_commit_id
         );
-        let checkpoint_can_reuse_generation = checkpoint_epochs.get(&root.branch_id)
-            == Some(&root.commit_id)
+        let checkpoint_can_reuse_generation = checkpoint_epochs
+            .get(&root.branch_id)
+            .is_some_and(|binding| binding.commit_id == root.commit_id)
             && observations
                 .get(&root.branch_id)
                 .and_then(|observation| observation.control)
                 .is_some();
+        let partial_checkpoint_can_reuse_generation = partial_checkpoint_rebase_commit_id(
+            root,
+            staged,
+            staged_commits,
+            observations,
+            checkpoint_epochs,
+        )
+        .is_some();
         if !checkpoint_can_reuse_generation
+            && !partial_checkpoint_can_reuse_generation
             && (!parent_is_published
                 || selected_refs_require_complete_snapshot(&staged.selected_change_batches))
         {
@@ -3128,6 +3144,32 @@ fn selected_refs_require_complete_snapshot(
             FILE_DESCRIPTOR_SCHEMA_KEY | DIRECTORY_DESCRIPTOR_SCHEMA_KEY
         )
     })
+}
+
+fn partial_checkpoint_rebase_commit_id(
+    root: &PendingTrackedRoot,
+    staged: &StagedChangelogCommit,
+    staged_commits: &BTreeMap<CommitId, StagedChangelogCommit>,
+    observations: &BTreeMap<String, BranchHeadControlObservation>,
+    checkpoint_epochs: &BTreeMap<String, CheckpointEpochBinding>,
+) -> Option<CommitId> {
+    let checkpoint = checkpoint_epochs.get(&root.branch_id)?;
+    let checkpoint_commit_id = checkpoint.commit_id;
+    (root.publish_head
+        && root.commit_id != checkpoint_commit_id
+        && root.parent_commit_id == Some(checkpoint_commit_id)
+        && checkpoint.hot_rebase_certified
+        && observations
+            .get(&root.branch_id)
+            .and_then(|observation| observation.control)
+            .is_some()
+        && !selected_refs_require_complete_snapshot(&staged.selected_change_batches)
+        && staged_commits
+            .get(&checkpoint_commit_id)
+            .is_some_and(|checkpoint| {
+                !selected_refs_require_complete_snapshot(&checkpoint.selected_change_batches)
+            }))
+    .then_some(checkpoint_commit_id)
 }
 
 /// Resolves the full tracked view for only the rare lifecycle commits selected
@@ -3627,7 +3669,7 @@ async fn stage_tracked_head(
     certified_fresh_plugin_file_id: Option<&str>,
     explicit_branch_targets: &BTreeMap<String, ExplicitBranchHeadTarget>,
     observations: &BTreeMap<String, BranchHeadControlObservation>,
-    checkpoint_epochs: &BTreeMap<String, CommitId>,
+    checkpoint_epochs: &BTreeMap<String, CheckpointEpochBinding>,
     mutation_inventories: &BTreeMap<CommitId, CommitStateMutationInventory>,
     ordered_addressable_commits: &BTreeSet<CommitId>,
     replacement_generation_commits: &BTreeSet<CommitId>,
@@ -3699,7 +3741,9 @@ async fn stage_tracked_head(
             .get(&root.commit_id)
             .map(Vec::as_slice)
             .unwrap_or_default();
-        let checkpoint_commit_id = checkpoint_epochs.get(&root.branch_id).copied();
+        let checkpoint_commit_id = checkpoint_epochs
+            .get(&root.branch_id)
+            .map(|binding| binding.commit_id);
         let is_checkpoint_publication = checkpoint_commit_id == Some(root.commit_id);
         let certified_columnar_parts = mutation_inventories
             .get(&root.commit_id)
@@ -3726,97 +3770,118 @@ async fn stage_tracked_head(
             if let Some(schema_keys) = transaction_global_schema_keys.as_ref() {
                 writer = writer.with_transaction_global_schema_keys(schema_keys);
             }
-            if writer
-                .can_rotate_checkpoint_epoch(&root.branch_id, parent_generation)
-                .await?
-            {
-                let selected_deleted_rows = staged
+            let selected_deleted_rows = staged
+                .selected_change_batches
+                .iter()
+                .flat_map(StagedCommitChangeBatch::deleted_iter)
+                .map(|change_ref| {
+                    let key = selected_change_key(change_ref);
+                    lifecycle_selected_tracked_row(
+                        change_ref,
+                        root.commit_id,
+                        None,
+                        selected_change_payloads.get(&key),
+                    )
+                })
+                .collect::<Result<Vec<_>, _>>()?;
+            let selected_metadata = selected_deleted_rows
+                .iter()
+                .map(|row| {
+                    row.metadata
+                        .as_deref()
+                        .map(|metadata| {
+                            serde_json::from_str(metadata)
+                                .map(lix_schema::Jsonb::from_value)
+                                .map_err(|error| LixError::unknown(error.to_string()))
+                        })
+                        .transpose()
+                })
+                .collect::<Result<Vec<_>, LixError>>()?;
+            let mut deleted_deltas = tracked_delete_indices_by_commit
+                .get(&root.commit_id)
+                .into_iter()
+                .flatten()
+                .map(|&row_index| current_state_delta_from_state_row(state_rows.row(row_index)))
+                .collect::<Result<Vec<_>, _>>()?;
+            deleted_deltas.extend(
+                staged
                     .selected_change_batches
                     .iter()
                     .flat_map(StagedCommitChangeBatch::deleted_iter)
-                    .map(|change_ref| {
-                        let key = selected_change_key(change_ref);
-                        lifecycle_selected_tracked_row(
-                            change_ref,
-                            root.commit_id,
-                            None,
-                            selected_change_payloads.get(&key),
-                        )
-                    })
-                    .collect::<Result<Vec<_>, _>>()?;
-                let selected_metadata = selected_deleted_rows
-                    .iter()
-                    .map(|row| {
-                        row.metadata
-                            .as_deref()
-                            .map(|metadata| {
-                                serde_json::from_str(metadata)
-                                    .map(lix_schema::Jsonb::from_value)
-                                    .map_err(|error| LixError::unknown(error.to_string()))
-                            })
-                            .transpose()
-                    })
-                    .collect::<Result<Vec<_>, LixError>>()?;
-                let mut deleted_deltas = tracked_delete_indices_by_commit
-                    .get(&root.commit_id)
-                    .into_iter()
-                    .flatten()
-                    .map(|&row_index| current_state_delta_from_state_row(state_rows.row(row_index)))
-                    .collect::<Result<Vec<_>, _>>()?;
-                deleted_deltas.extend(
-                    staged
-                        .selected_change_batches
-                        .iter()
-                        .flat_map(StagedCommitChangeBatch::deleted_iter)
-                        .zip(selected_deleted_rows.iter())
-                        .zip(&selected_metadata)
-                        .map(|((change_ref, row), metadata)| {
-                            crate::hot_state::CurrentStateDeltaRef {
-                                schema_key: &row.schema_key,
-                                file_id: row.file_id.as_deref(),
-                                row_pk: &row.row_pk,
-                                change_id: Some(change_ref.change_id),
-                                commit_id: Some(root.commit_id),
-                                untracked: false,
-                                deleted: true,
-                                created_at: change_ref.created_at,
-                                updated_at: change_ref.updated_at,
-                                snapshot: None,
-                                metadata: metadata.as_ref(),
-                                columnar_base_coordinate: None,
-                            }
-                        }),
-                );
-                let mut coverage = WorkingDiffIndexCoverage::default();
-                let generation = if deleted_deltas.is_empty() {
-                    parent_generation
-                } else {
-                    writer
-                        .stage_checkpoint_current_state(
-                            &root.branch_id,
-                            parent_generation,
-                            root.commit_id,
-                            &deleted_deltas,
-                            &BTreeSet::new(),
-                            checkpoint_commit_id
-                                .expect("checkpoint publication has an epoch commit id"),
-                            &mut coverage,
-                        )
-                        .instrument(tracing::debug_span!(
-                            target: "lix_perf",
-                            "lix.perf.materialization.tracked_head.stage_checkpoint_tombstones"
-                        ))
-                        .await?
-                };
-                let control = normal_branch_head_control(
-                    root,
-                    parent_control,
-                    generation,
-                    checkpoint_commit_id,
-                )?;
-                insert_direct_branch_control(&mut controls, &root.branch_id, control)?;
-                continue;
-            }
+                    .zip(selected_deleted_rows.iter())
+                    .zip(&selected_metadata)
+                    .map(|((change_ref, row), metadata)| {
+                        crate::hot_state::CurrentStateDeltaRef {
+                            schema_key: &row.schema_key,
+                            file_id: row.file_id.as_deref(),
+                            row_pk: &row.row_pk,
+                            change_id: Some(change_ref.change_id),
+                            commit_id: Some(root.commit_id),
+                            untracked: false,
+                            deleted: true,
+                            created_at: change_ref.created_at,
+                            updated_at: change_ref.updated_at,
+                            snapshot: None,
+                            metadata: metadata.as_ref(),
+                            columnar_base_coordinate: None,
+                        }
+                    }),
+            );
+            let mut coverage = WorkingDiffIndexCoverage::default();
+            let generation = if deleted_deltas.is_empty() {
+                parent_generation
+            } else {
+                writer
+                    .stage_checkpoint_current_state(
+                        &root.branch_id,
+                        parent_generation,
+                        root.commit_id,
+                        &deleted_deltas,
+                        &BTreeSet::new(),
+                        checkpoint_commit_id
+                            .expect("checkpoint publication has an epoch commit id"),
+                        &mut coverage,
+                    )
+                    .instrument(tracing::debug_span!(
+                        target: "lix_perf",
+                        "lix.perf.materialization.tracked_head.stage_checkpoint_tombstones"
+                    ))
+                    .await?
+            };
+            let control = normal_branch_head_control(
+                root,
+                parent_control,
+                generation,
+                checkpoint_commit_id,
+            )?;
+            insert_direct_branch_control(&mut controls, &root.branch_id, control)?;
+            continue;
+        }
+
+        // A partial checkpoint publishes an intermediate checkpoint commit
+        // followed by a child containing the still-dirty selected refs. The
+        // visible HOT generation already contains those exact current rows;
+        // rebind their existing before-images to the new checkpoint epoch
+        // instead of rebuilding the complete branch snapshot from history.
+        let partial_checkpoint_commit_id = partial_checkpoint_rebase_commit_id(
+            root,
+            staged,
+            staged_commits,
+            observations,
+            checkpoint_epochs,
+        )
+        .filter(|_| !tracked_snapshots.contains_key(&root.commit_id));
+        if partial_checkpoint_commit_id.is_some()
+            && (!state_row_indices.is_empty()
+                || engine_rows.iter().any(|row| row.branch_id == root.branch_id)
+                || state_rows.iter().any(|row| {
+                    row.untracked && row.branch_id.as_str() == root.branch_id
+                }))
+        {
+            return Err(LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                "partial checkpoint HOT rebase received unrelated current-state mutations",
+            ));
         }
         let selected_materialization = if !staged.selected_change_batches.is_empty()
             && !tracked_snapshots.contains_key(&root.commit_id)
@@ -3949,7 +4014,11 @@ async fn stage_tracked_head(
                 )
             };
         let parent_generation = match (root.parent_commit_id, parent_control) {
-            (_, Some(control)) if is_checkpoint_publication => Some(control.tracked_generation),
+            (_, Some(control))
+                if is_checkpoint_publication || partial_checkpoint_commit_id.is_some() =>
+            {
+                Some(control.tracked_generation)
+            }
             (Some(parent_commit_id), Some(control))
                 if control.head_commit_id == parent_commit_id =>
             {
@@ -4548,7 +4617,23 @@ async fn stage_tracked_head(
             durable_predecessor_count = durable_predecessors.len(),
             "packed current-base route decision"
         );
-        let generation = if is_checkpoint_publication {
+        let generation = if let Some(partial_checkpoint_commit_id) = partial_checkpoint_commit_id {
+            coverage = WorkingDiffIndexCoverage::default();
+            writer
+                .stage_partial_checkpoint_current_state(
+                    &root.branch_id,
+                    parent_generation,
+                    root.commit_id,
+                    &deltas,
+                    partial_checkpoint_commit_id,
+                    &mut coverage,
+                )
+                .instrument(tracing::debug_span!(
+                    target: "lix_perf",
+                    "lix.perf.materialization.tracked_head.stage_partial_checkpoint"
+                ))
+                .await?
+        } else if is_checkpoint_publication {
             // Reaching this point means an immutable packed base prevented
             // the O(deletes) epoch-rotation route above. Materialize it once;
             // retirement makes later checkpoints eligible for lazy rotation.
@@ -4619,7 +4704,17 @@ async fn stage_tracked_head(
             parent_control.as_ref(),
         )
         .await?;
-        if let Some(epoch) = working_diff_epoch {
+        if let Some(checkpoint_commit_id) = partial_checkpoint_commit_id {
+            stage_tracked_working_diff_epoch(
+                writes,
+                &root.branch_id,
+                TrackedWorkingDiffEpoch {
+                    checkpoint_commit_id,
+                    generation,
+                    coverage,
+                },
+            )?;
+        } else if let Some(epoch) = working_diff_epoch {
             let next_epoch = TrackedWorkingDiffEpoch {
                 checkpoint_commit_id: epoch.checkpoint_commit_id,
                 generation,
@@ -5499,7 +5594,8 @@ async fn stage_branch_head_control_publications(
         return Ok(BTreeMap::new());
     }
     for (branch_id, desired) in &mut publications {
-        if let Some(checkpoint_commit_id) = checkpoint_epochs.get(branch_id) {
+        if let Some(checkpoint) = checkpoint_epochs.get(branch_id) {
+            let checkpoint_commit_id = checkpoint.commit_id;
             let control = desired.as_mut().ok_or_else(|| {
                 LixError::new(
                     LixError::CODE_INTERNAL_ERROR,
@@ -5508,7 +5604,7 @@ async fn stage_branch_head_control_publications(
                     ),
                 )
             })?;
-            control.working_diff_checkpoint_commit_id = Some(*checkpoint_commit_id);
+            control.working_diff_checkpoint_commit_id = Some(checkpoint_commit_id);
         }
         let observation = observations.get(branch_id).ok_or_else(|| {
             LixError::new(
@@ -5558,12 +5654,18 @@ async fn stage_branch_head_control_publications(
 
 fn checkpoint_epoch_bindings(
     publications: &[crate::gc::CheckpointPublication],
-) -> Result<BTreeMap<String, CommitId>, LixError> {
+) -> Result<BTreeMap<String, CheckpointEpochBinding>, LixError> {
     let mut bindings = BTreeMap::new();
     for publication in publications {
         let recovery = &publication.recovery_ref;
         if bindings
-            .insert(recovery.branch_id.clone(), recovery.checkpoint_commit_id)
+            .insert(
+                recovery.branch_id.clone(),
+                CheckpointEpochBinding {
+                    commit_id: recovery.checkpoint_commit_id,
+                    hot_rebase_certified: publication.hot_working_diff_certified,
+                },
+            )
             .is_some()
         {
             return Err(LixError::new(
@@ -7287,6 +7389,7 @@ mod tests {
                     interval_has_commits: true,
                 },
                 gc_state: crate::gc::CheckpointGcState::default(),
+                hot_working_diff_certified: false,
             }],
             &BTreeMap::new(),
         )

--- a/packages/lix/src/transaction/context.rs
+++ b/packages/lix/src/transaction/context.rs
@@ -8044,6 +8044,7 @@ where
                     interval_has_commits,
                 },
                 gc_state,
+                hot_working_diff_certified: false,
             })?;
         Ok(commit_id)
     }
@@ -8056,6 +8057,7 @@ where
         interval_has_commits: bool,
         gc_state: CheckpointGcState,
         selected_changes: StagedCommitChangeBatch,
+        hot_working_diff_certified: bool,
     ) -> Result<String, LixError> {
         let commit_id = self
             .staged_writes
@@ -8072,6 +8074,7 @@ where
                     interval_has_commits,
                 },
                 gc_state,
+                hot_working_diff_certified,
             })?;
         Ok(commit_id)
     }
@@ -8587,6 +8590,7 @@ where
                 &TrackedStateDiffRequest::default(),
             )
             .await?;
+        let hot_working_diff_certified = direct_diff.is_some();
         let diff = match direct_diff {
             Some(direct) => direct.diff,
             None => {
@@ -8665,6 +8669,7 @@ where
                 interval_has_commits,
                 gc_state,
                 selected,
+                hot_working_diff_certified,
             )?
         } else {
             let checkpoint_commit_id = self.staged_writes.stage_intermediate_commit(
@@ -8685,6 +8690,7 @@ where
                         interval_has_commits,
                     },
                     gc_state,
+                    hot_working_diff_certified,
                 })?;
             checkpoint_commit_id.to_string()
         };


### PR DESCRIPTION
## Summary

- rebase partial-checkpoint working-diff baselines in the existing HOT generation instead of rebuilding a complete branch snapshot from history
- gate the fast path on the exact certified HOT working-diff selection; canonical fallback and filesystem lifecycle cases retain complete materialization
- keep epoch/certification ownership in one private binding and reuse the ordinary selected-row staging lane
- cover cold snapshot owners, reactive reads, restart, tombstones, canonical fallback, real HTTP history traffic, and CSV plugin fanout

## Performance/correctness evidence

The 50-owner synced regression observes zero additional `/lix/v1/sync/history` requests during partial checkpoint creation and the first reactive `lix_working_diff()` read. The internal causal regression blocks every cold owner replay and still passes through checkpoint, reactive read, and restart.

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --profile test --workspace --all-targets --all-features -- -D warnings`
- `cargo check -p lix --tests`
- `cargo test --profile test --workspace --all-features --no-fail-fast`
- `cargo test --locked --manifest-path tooling/Cargo.toml --profile test -p lix_e2e --features sdk-tests,plugin-tests,server-protocol,storage-benches,slatedb,root-replay-trace --no-fail-fast`

No public Lix API changes.