### PR TITLE
fix(lix): stabilize cross-context OPFS handoff

### DIFF
--- a/packages/js-sdk/src/worker/client.test.ts
+++ b/packages/js-sdk/src/worker/client.test.ts
@@ -1,14 +1,15 @@
-import { expect, test } from "vitest";
+import { expect, test, vi } from "vitest";
 import type {
 	WorkerConnection,
 	WorkerInput,
 	WorkerResponse,
 } from "./protocol.js";
-import { LixWorkerClient } from "./client.js";
+import { BindingLease, LixWorkerClient, workerBinding } from "./client.js";
 import { responseFromSyncFetch } from "./host.js";
 
-function fakeConnection() {
+function fakeConnection(options: { terminate?: () => Promise<void> } = {}) {
 	const sent: WorkerInput[] = [];
+	let terminateCount = 0;
 	let onMessage: (message: WorkerResponse) => void = () => undefined;
 	const connection: WorkerConnection = {
 		postMessage(message) {
@@ -20,9 +21,81 @@ function fakeConnection() {
 		onFatal() {},
 		ref() {},
 		unref() {},
-		async terminate() {},
+		async terminate() {
+			terminateCount += 1;
+			await options.terminate?.();
+		},
 	};
-	return { connection, sent, emit: (message: WorkerResponse) => onMessage(message) };
+	return {
+		connection,
+		sent,
+		emit: (message: WorkerResponse) => onMessage(message),
+		terminateCount: () => terminateCount,
+	};
+}
+
+test("failed close terminates the worker before releasing its binding", async () => {
+	const termination = deferred<void>();
+	const events: string[] = [];
+	const transport = fakeConnection({
+		terminate: async () => {
+			events.push("worker termination started");
+			await termination.promise;
+			events.push("worker termination finished");
+		},
+	});
+	const client = new LixWorkerClient(transport.connection);
+	client.beginLease();
+	let released = false;
+	const binding = workerBinding(
+		client,
+		new BindingLease(() => {
+			released = true;
+			events.push("binding released");
+		}),
+		0,
+	);
+
+	const closing = binding.close();
+	const request = transport.sent.find(
+		(message): message is Extract<WorkerInput, { id: number }> =>
+			"id" in message && message.operation.kind === "close",
+	);
+	if (!request) throw new Error("expected a worker close request");
+	transport.emit({
+		id: request.id,
+		ok: false,
+		error: {
+			name: "LixError",
+			message: "sync drain failed",
+			code: "LIX_ERROR_SYNC",
+		},
+	});
+
+	await vi.waitFor(() => {
+		expect(events).toEqual(["worker termination started"]);
+	});
+	expect(released).toBe(false);
+	termination.resolve();
+	await expect(closing).rejects.toThrow("sync drain failed");
+	expect(transport.terminateCount()).toBe(1);
+	expect(client.isDisposed).toBe(true);
+	expect(released).toBe(true);
+	expect(events).toEqual([
+		"worker termination started",
+		"worker termination finished",
+		"binding released",
+	]);
+});
+
+function deferred<T>() {
+	let resolve!: (value: T | PromiseLike<T>) => void;
+	let reject!: (reason?: unknown) => void;
+	const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+		resolve = resolvePromise;
+		reject = rejectPromise;
+	});
+	return { promise, resolve, reject };
 }
 
 test("browser sync resolves fresh headers for reconnect requests", async () => {

--- a/packages/js-sdk/src/worker/client.ts
+++ b/packages/js-sdk/src/worker/client.ts
@@ -193,7 +193,8 @@ function wrapTelemetryParentTransaction(
 	};
 }
 
-class BindingLease {
+/** @internal Exported only for worker lifecycle tests. */
+export class BindingLease {
 	private references = 1;
 	constructor(private readonly releaseLast: () => void | Promise<void>) {}
 	retain(): void {
@@ -238,7 +239,8 @@ function wrapDirectBinding(
 	});
 }
 
-function workerBinding(
+/** @internal Exported only for worker lifecycle tests. */
+export function workerBinding(
 	client: LixWorkerClient,
 	lease: BindingLease,
 	sessionId: number,
@@ -295,9 +297,18 @@ function workerBinding(
 		syncDiskToLix: () => request({ kind: "syncDiskToLix" }),
 		close: async () => {
 			if (closed) return;
-			await request({ kind: "close" });
-			closed = true;
-			await lease.release();
+			try {
+				await request({ kind: "close" });
+			} catch (error) {
+				// A failed semantic close may leave the worker host retaining its OPFS
+				// session. Terminating the worker is the ownership backstop before an
+				// outer caller can safely release its cross-tab lock.
+				await client.terminate().catch(() => undefined);
+				throw error;
+			} finally {
+				closed = true;
+				await lease.release();
+			}
 		},
 	};
 }

--- a/packages/lix/src/session/execute.rs
+++ b/packages/lix/src/session/execute.rs
@@ -37,11 +37,18 @@ use tracing::Instrument as _;
 use super::context::{SessionContext, SessionSqlExecutionContext};
 use super::idempotency::{ExecuteIdempotencyReceipt, load_receipt};
 use super::transaction::{SessionTransaction, transaction_state_error};
-use super::{ExecuteIdempotency, MAX_EXPIRED_READ_RETRIES};
+use super::ExecuteIdempotency;
 use crate::PreparedDmlParameterBatch;
 
 const MAX_INITIAL_LITERAL_COLUMN_BYTES: usize = 64 * 1024 * 1024;
 const MAX_AUTO_COMMIT_RETRIES: usize = 16;
+const MAX_EXPIRED_READ_RETRY_DURATION: Duration = Duration::from_secs(3);
+
+#[derive(Default)]
+struct ExpiredReadRetryState {
+    attempts: usize,
+    started_at: Option<web_time::Instant>,
+}
 
 enum LiteralParameterBuilder {
     Utf8(StringBuilder),
@@ -1259,7 +1266,7 @@ where
 
         let paths = BTreeSet::from([path]);
         let _operation_guard = self.begin_waitable_session_operation().await?;
-        let mut expired_read_retries = 0;
+        let mut expired_read_retries = ExpiredReadRetryState::default();
         let mut read_quiescence_guard = None;
         loop {
             let read_scope = match self.storage.begin_read(StorageReadOptions::default()).await {
@@ -1514,7 +1521,7 @@ where
         } else {
             None
         };
-        let mut expired_read_retries = 0;
+        let mut expired_read_retries = ExpiredReadRetryState::default();
         let mut read_quiescence_guard = None;
         let reads_already_quiesced = runtime_write_access.is_some();
         let (mut read_result, file_view_mutations, _provider_rows_examined) = loop {
@@ -2229,7 +2236,7 @@ where
                 || late_materialized_lix_file_content_read(parsed).is_some()
         });
         let _operation_guard = self.begin_waitable_session_operation().await?;
-        let mut expired_read_retries = 0;
+        let mut expired_read_retries = ExpiredReadRetryState::default();
         let mut read_quiescence_guard = None;
         loop {
             let read_scope = match self.storage.begin_read(StorageReadOptions::default()).await {
@@ -2411,7 +2418,7 @@ where
         });
 
         let _operation_guard = self.begin_waitable_session_operation().await?;
-        let mut expired_read_retries = 0;
+        let mut expired_read_retries = ExpiredReadRetryState::default();
         let mut read_quiescence_guard = None;
         loop {
             let read_scope = match self.storage.begin_read(StorageReadOptions::default()).await {
@@ -5323,11 +5330,16 @@ fn normalize_sql_surface_error(error: LixError, sql: &str) -> LixError {
     error
 }
 
-fn consume_expired_read_retry(retries: &mut usize, error: &LixError) -> bool {
-    if error.code != LixError::CODE_STORAGE_READ_EXPIRED || *retries >= MAX_EXPIRED_READ_RETRIES {
+fn consume_expired_read_retry(state: &mut ExpiredReadRetryState, error: &LixError) -> bool {
+    if error.code != LixError::CODE_STORAGE_READ_EXPIRED {
         return false;
     }
-    *retries += 1;
+    let now = web_time::Instant::now();
+    let started_at = state.started_at.get_or_insert(now);
+    if now.duration_since(*started_at) >= MAX_EXPIRED_READ_RETRY_DURATION {
+        return false;
+    }
+    state.attempts += 1;
     true
 }
 
@@ -5335,16 +5347,17 @@ fn consume_expired_read_retry(retries: &mut usize, error: &LixError) -> bool {
 /// multi-call snapshot when a commit lands between calls. Retry once on the
 /// optimistic path, then hold the same collaboration gate used by every Lix
 /// writer. Repeated expiry can come from another browser context, whose writer
-/// does not share that in-process gate, so bounded backoff gives that writer a
-/// chance to finish instead of exhausting every retry in one event-loop turn.
+/// does not share that in-process gate, so an elapsed-time budget with bounded
+/// backoff gives an ownership handoff time to finish without allowing a broken
+/// storage implementation to retry forever.
 async fn retry_expired_read_with_write_quiescence(
-    retries: &mut usize,
+    state: &mut ExpiredReadRetryState,
     error: &LixError,
     write_gate: &Arc<tokio::sync::Mutex<()>>,
     guard: &mut Option<tokio::sync::OwnedMutexGuard<()>>,
     already_quiesced: bool,
 ) -> bool {
-    if !consume_expired_read_retry(retries, error) {
+    if !consume_expired_read_retry(state, error) {
         return false;
     }
     // Cross-context stores such as OPFS can invalidate a read while another
@@ -5355,8 +5368,8 @@ async fn retry_expired_read_with_write_quiescence(
     if !already_quiesced && guard.is_none() {
         *guard = Some(Arc::clone(write_gate).lock_owned().await);
     }
-    if *retries > 1 {
-        let exponent = (*retries - 2).min(4) as u32;
+    if state.attempts > 1 {
+        let exponent = (state.attempts - 2).min(4) as u32;
         crate::sync::sleep(Duration::from_millis(1_u64 << exponent)).await;
     }
     true

--- a/packages/lix/src/session/mod.rs
+++ b/packages/lix/src/session/mod.rs
@@ -14,8 +14,6 @@ use std::future::Future;
 use std::pin::Pin;
 use std::task::{Context, Poll};
 
-const MAX_EXPIRED_READ_RETRIES: usize = 16;
-
 mod checkpoint;
 mod context;
 mod create_branch;

--- a/packages/lix/tests/integration/read_retry.rs
+++ b/packages/lix/tests/integration/read_retry.rs
@@ -221,15 +221,18 @@ async fn expired_read_backs_off_until_cross_context_writer_settles() {
 
     // A writer in another browser context does not share this engine's write
     // gate. Keep expiring fresh snapshots until that external churn settles.
-    storage.expire_read_calls(64);
+    storage.expire_read_calls(usize::MAX);
     let settling_storage = storage.clone();
     tokio::spawn(async move {
-        tokio::time::sleep(Duration::from_millis(20)).await;
+        // A cross-context browser commit can include OPFS durability and a
+        // remote push before the next coherent read generation is available.
+        // Keep this longer than the old count-derived ~1 second retry window.
+        tokio::time::sleep(Duration::from_secs(2)).await;
         settling_storage.allow_reads();
     });
 
     let result = tokio::time::timeout(
-        Duration::from_secs(1),
+        Duration::from_secs(4),
         lix.execute(
             "SELECT value FROM lix_key_value WHERE key = $1",
             &[Value::Text("read-external-quiescence".into())],
@@ -244,8 +247,8 @@ async fn expired_read_backs_off_until_cross_context_writer_settles() {
         serde_json::json!(42)
     );
     assert!(
-        storage.expired_calls() > 1,
-        "the regression must exercise repeated cross-context invalidation",
+        storage.expired_calls() > 64,
+        "the regression must cross the old count-derived retry cap",
     );
 }
 
@@ -259,7 +262,7 @@ async fn perpetually_expired_read_remains_bounded() {
 
     storage.expire_read_calls(usize::MAX);
     let error = tokio::time::timeout(
-        Duration::from_secs(1),
+        Duration::from_secs(4),
         lix.execute("SELECT key FROM lix_key_value", &[]),
     )
     .await


### PR DESCRIPTION
## Summary

- keep coherent SQL reads behind the Lix API during ordinary cross-context OPFS commits and ownership transfer
- replace the count-derived retry cap with a bounded three-second elapsed-time policy and short capped backoff
- terminate a worker after semantic close failure before its binding lease can release OPFS ownership
- add causal retry and failed-close regressions

## Evidence

LixRay PR #238 exposed LIX_STORAGE_READ_EXPIRED from a lix_directory scan while a peer committed. The packed production OPFS benchmark then reproduced owner-failover tails beyond the old roughly 959 ms cap. The local fixed run measured owner failover at 165.6 ms p50 and 1612.7 ms p95 across ten samples.

## Verification

- cargo fmt --all -- --check
- cargo test -p lix --all-features --lib read_retry -- --nocapture (9/9, including more than 64 expirations)
- cargo clippy -p lix --all-targets --all-features -- -D warnings
- npm exec -- vitest run src/worker/client.test.ts src/lix-lifecycle.test.ts (12/12)
- npm run typecheck in packages/js-sdk
- npm run build and npm run benchmark:multi-tab in packages/storage-opfs
