### PR TITLE
fix(lix): keep uncertified working diffs local

### DIFF
--- a/.changenotes/hot-working-diff-primary-fallback.md
+++ b/.changenotes/hot-working-diff-primary-fallback.md
@@ -1,0 +1,7 @@
+---
+type: patch
+---
+
+Kept browser working-diff reads local when the sparse index cannot certify its coverage.
+
+Lix now falls back to authoritative HOT rows and resolves snapshot-local payloads before hydrating canonical commit history.

--- a/packages/lix/src/engine.rs
+++ b/packages/lix/src/engine.rs
@@ -1684,7 +1684,7 @@ mod tests {
     /// never-existed) and asserts the finite answer equals the broad answer
     /// restricted to that identity.
     #[tokio::test]
-    async fn working_diff_finite_bypass_and_index_scan_agree_on_every_row_state() {
+    async fn working_diff_primary_scan_and_index_scan_agree_on_every_row_state() {
         let storage = Memory::new();
         Engine::initialize(storage.clone())
             .await
@@ -1850,7 +1850,7 @@ mod tests {
             "/never-existed",
         ] {
             let requested_row_pk = format!("[\"{path}\"]");
-            let bypass_before = hits.finite_bypass.load(Ordering::Relaxed);
+            let primary_before = hits.primary_scan.load(Ordering::Relaxed);
             let finite = session
                 .execute(
                     "SELECT row_pk, diff_type FROM lix_working_diff() \
@@ -1861,7 +1861,7 @@ mod tests {
                 .await
                 .expect("finite working-diff read should execute");
             assert!(
-                hits.finite_bypass.load(Ordering::Relaxed) > bypass_before,
+                hits.primary_scan.load(Ordering::Relaxed) > primary_before,
                 "the finite working-diff read for {path} must take the primary-row bypass"
             );
             let finite_rows = finite
@@ -2064,7 +2064,7 @@ mod tests {
         );
 
         for file in files {
-            let bypass_before = hits.finite_bypass.load(Ordering::Relaxed);
+            let primary_before = hits.primary_scan.load(Ordering::Relaxed);
             let scoped = collect(
                 &session
                     .execute(
@@ -2075,7 +2075,7 @@ mod tests {
                     .expect("file-scoped working-diff read should execute"),
             );
             assert!(
-                hits.finite_bypass.load(Ordering::Relaxed) > bypass_before,
+                hits.primary_scan.load(Ordering::Relaxed) > primary_before,
                 "the file-scoped working-diff read for {file} must take the primary-row bypass"
             );
             let want = broad
@@ -2088,7 +2088,7 @@ mod tests {
                 "the file-scoped working-diff bypass disagrees with the index scan for {file}"
             );
 
-            let bypass_before = hits.finite_bypass.load(Ordering::Relaxed);
+            let primary_before = hits.primary_scan.load(Ordering::Relaxed);
             let scoped_schema = collect(
                 &session
                     .execute(
@@ -2102,7 +2102,7 @@ mod tests {
                     .expect("file+schema working-diff read should execute"),
             );
             assert!(
-                hits.finite_bypass.load(Ordering::Relaxed) > bypass_before,
+                hits.primary_scan.load(Ordering::Relaxed) > primary_before,
                 "the file+schema working-diff read for {file} must take the primary-row bypass"
             );
             let want_schema = want

--- a/packages/lix/src/hot_state/tracked_head.rs
+++ b/packages/lix/src/hot_state/tracked_head.rs
@@ -59,7 +59,7 @@ use crate::NullableKeyFilter;
 #[cfg(test)]
 use crate::branch::stage_branch_head_control;
 use crate::branch::{BranchHeadControl, BranchHeadControlContext, BranchHeadTrackedReachability};
-use crate::changelog::{ChangeId, ChangeRecordProjection, CommitId};
+use crate::changelog::{ChangeId, ChangeRecordProjection, ChangelogReader, CommitId};
 use crate::common::{LixTimestamp, SharedStr};
 use crate::hot_state::{
     MaterializedHotStateBatch, MaterializedHotStateBatchBuilder, MaterializedHotStateExactBatch,
@@ -3622,18 +3622,24 @@ mod tests {
             .begin_read(StorageReadOptions::default())
             .await
             .expect("open bad coverage read");
-        assert!(
-            TrackedHeadContext::new()
-                .reader(read)
-                .working_diff_for_control(
-                    branch_id,
-                    control(second_head, checkpoint, no_op_checkpoint),
-                    &TrackedStateDiffRequest::default(),
-                )
-                .await
-                .expect("bad coverage should not error")
-                .is_none(),
-            "bad index coverage must select canonical replay"
+        let recovered = TrackedHeadContext::new()
+            .reader(read)
+            .working_diff_for_control(
+                branch_id,
+                control(second_head, checkpoint, no_op_checkpoint),
+                &TrackedStateDiffRequest::default(),
+            )
+            .await
+            .expect("uncertified coverage should not error")
+            .expect("uncertified derived coverage should use authoritative primary rows");
+        assert_eq!(recovered.diff.entries.len(), 1);
+        assert_eq!(
+            recovered.diff.entries[0]
+                .before
+                .as_ref()
+                .expect("recovered modification has a before row")
+                .change_id,
+            ChangeId::for_test_label("first-change")
         );
     }
 

--- a/packages/lix/src/hot_state/tracked_head/hot.rs
+++ b/packages/lix/src/hot_state/tracked_head/hot.rs
@@ -10082,13 +10082,13 @@ fn packed_working_diff_version(
 #[cfg(test)]
 pub(crate) static WORKING_DIFF_PATH_HITS: WorkingDiffPathHits = WorkingDiffPathHits {
     index_scan: std::sync::atomic::AtomicUsize::new(0),
-    finite_bypass: std::sync::atomic::AtomicUsize::new(0),
+    primary_scan: std::sync::atomic::AtomicUsize::new(0),
 };
 
 #[cfg(test)]
 pub(crate) struct WorkingDiffPathHits {
     pub(crate) index_scan: std::sync::atomic::AtomicUsize,
-    pub(crate) finite_bypass: std::sync::atomic::AtomicUsize,
+    pub(crate) primary_scan: std::sync::atomic::AtomicUsize,
 }
 
 /// Decides whether a working-diff read may skip the `HOT_DIFF` scope scan and
@@ -10228,8 +10228,8 @@ fn decode_hot_file_schema_key_in_scope(key: Bytes, scope: &[u8]) -> Result<Strin
 }
 
 /// Resolves a checkpoint diff from row-local first-before images. Broad diffs
-/// enumerate the sparse dirty-key index; finite PK queries read only the
-/// primary rows that can answer the request.
+/// normally enumerate the sparse dirty-key index; finite PK queries and broad
+/// reads with an uncertified derived index scan authoritative primary rows.
 async fn hot_working_diff_entries(
     store: &(impl StorageAdapterRead + ?Sized),
     branch_id: &str,
@@ -10247,7 +10247,7 @@ async fn hot_working_diff_entries(
         if let Some(bypass) =
             hot_working_diff_bypass_filter(store, branch_id, generation, filter).await?
         {
-            return hot_working_diff_entries_for_finite_filter(
+            return hot_working_diff_entries_from_primary(
                 store,
                 branch_id,
                 checkpoint_commit_id,
@@ -10335,7 +10335,7 @@ async fn hot_working_diff_entries(
             break;
         }
     }
-    for base_ref in packed_refs {
+    for base_ref in &packed_refs {
         if actual_coverage
             .add_encoded_group_key(&base_ref.coverage_key)
             .is_none()
@@ -10378,6 +10378,23 @@ async fn hot_working_diff_entries(
         }
     }
     if actual_coverage != expected_coverage {
+        if packed_refs.is_empty() {
+            // The sparse dirty-key index is a derived accelerator. Complete
+            // HOT primary rows carry the authoritative checkpoint baseline,
+            // so an invalid index certificate must degrade to one local
+            // current-state scan before canonical commit replay is considered.
+            // Snapshot replicas intentionally keep historical commit bodies
+            // cold; replaying them here turns one local read into a request per
+            // checkpoint even though the answer is already in HOT state.
+            return hot_working_diff_entries_from_primary(
+                store,
+                branch_id,
+                checkpoint_commit_id,
+                generation,
+                filter,
+            )
+            .await;
+        }
         return Ok(None);
     }
     let (selected, base_versions): (Vec<_>, Vec<_>) = selected.into_iter().unzip();
@@ -10462,7 +10479,7 @@ fn choose_hot_or_packed_working_diff(
     }
 }
 
-async fn hot_working_diff_entries_for_finite_filter(
+async fn hot_working_diff_entries_from_primary(
     store: &(impl StorageAdapterRead + ?Sized),
     branch_id: &str,
     checkpoint_commit_id: CommitId,
@@ -10471,7 +10488,7 @@ async fn hot_working_diff_entries_for_finite_filter(
 ) -> Result<Option<Vec<TrackedStateDiffEntry>>, LixError> {
     #[cfg(test)]
     WORKING_DIFF_PATH_HITS
-        .finite_bypass
+        .primary_scan
         .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
     let rows = hot_scan_entries(store, branch_id, generation, filter, None, None)
         .await?
@@ -10535,7 +10552,7 @@ async fn hot_working_diff_entries_for_finite_filter(
 /// are dirty, where those same states would be corruption. See the equivalence
 /// argument in `hot_working_diff_entries`; the reachable-state proof is
 /// exercised end to end by
-/// `working_diff_finite_bypass_and_index_scan_agree_on_every_row_state`.
+/// `working_diff_primary_scan_and_index_scan_agree_on_every_row_state`.
 fn finite_working_diff_versions(
     bytes: &Bytes,
     checkpoint_commit_id: CommitId,
@@ -10687,24 +10704,55 @@ async fn resolve_working_diff_before_payloads<T>(
             );
             continue;
         }
-        pending.push(index);
+        pending.push((index, key_of(&candidates[index])));
     }
     if pending.is_empty() {
         return Ok(());
     }
-    let mut by_commit = BTreeMap::<CommitId, Vec<usize>>::new();
-    for index in pending {
+    // Snapshot/bootstrap publication keeps change payloads in the standalone
+    // changelog while their physical commit bodies may remain remote. Resolve
+    // that local authority in one batch before asking for any owner commit.
+    let change_ids = pending
+        .iter()
+        .map(|(index, _)| {
+            before_of(&mut candidates[*index])
+                .as_ref()
+                .expect("pending before images are present")
+                .change_id
+        })
+        .collect::<Vec<_>>();
+    let local = crate::changelog::ChangelogContext::new()
+        .reader(store)
+        .load_changes(crate::changelog::ChangeLoadRequest {
+            change_ids: &change_ids,
+        })
+        .await?;
+    let mut by_commit = BTreeMap::<CommitId, Vec<(usize, TrackedStateKey)>>::new();
+    for ((index, key), (_, record)) in pending.into_iter().zip(local) {
         let commit_id = before_of(&mut candidates[index])
             .as_ref()
             .expect("pending before images are present")
             .commit_id;
-        by_commit.entry(commit_id).or_default().push(index);
+        let version = before_of(&mut candidates[index])
+            .as_mut()
+            .expect("pending before images are present");
+        if let Some(record) = record.as_ref()
+            && record.schema_key == key.schema_key
+            && record.file_id == key.file_id
+            && record.row_pk == key.row_pk
+            && record.snapshot.is_some()
+            && record.created_at == version.updated_at
+        {
+            version.resolve_payload_slots(
+                packed_working_diff_snapshot(record.snapshot.as_deref()),
+                packed_working_diff_slot(&record.metadata),
+            );
+            continue;
+        }
+        by_commit.entry(commit_id).or_default().push((index, key));
     }
-    for (commit_id, indexes) in by_commit {
-        let keys = indexes
-            .iter()
-            .map(|index| key_of(&candidates[*index]))
-            .collect::<Vec<_>>();
+    for (commit_id, pending) in by_commit {
+        let (indexes, keys): (Vec<_>, Vec<_>) = pending.into_iter().unzip();
         let records =
             crate::tracked_state::load_commit_delta_change_records(store, commit_id, &keys).await?;
         for (index, record) in indexes.into_iter().zip(records) {

--- a/packages/lix/src/sync/simulation_tests.rs
+++ b/packages/lix/src/sync/simulation_tests.rs
@@ -913,27 +913,22 @@ async fn partial_file_checkpoint_rebases_hot_epoch(_sim: Simulation) {
         .rows()[0]
         .get::<String>("id")
         .expect("selected file id should decode");
-    let selected_diff_id = replica
+    crate::tracked_state::arm_point_replay_authority_batch_probe_for_test();
+    let checkpoint = replica
         .lix
         .execute(
-            "SELECT diff_id FROM lix_working_diff() WHERE file_id = $1 LIMIT 1",
+            "INSERT INTO lix_create_checkpoint (diff_id) \
+             SELECT diff_id FROM lix_working_diff() \
+             WHERE coalesce( \
+                 file_id, \
+                 CASE WHEN schema_key = 'lix_file_descriptor' THEN row_pk ->> 0 END \
+             ) IN ($1) \
+             RETURNING commit_id",
             &[Value::Text(selected_file_id)],
         )
         .await
-        .expect("selected file diff should load")
-        .rows()[0]
-        .get::<String>("diff_id")
-        .expect("selected file diff id should decode");
-
-    crate::tracked_state::arm_point_replay_authority_batch_probe_for_test();
-    replica
-        .lix
-        .execute(
-            "INSERT INTO lix_create_checkpoint (diff_id) SELECT $1 RETURNING commit_id",
-            &[Value::Text(selected_diff_id)],
-        )
-        .await
         .expect("partial file checkpoint should stay snapshot-local");
+    assert_eq!(checkpoint.rows_affected(), 1);
     let authority_batches =
         crate::tracked_state::take_point_replay_authority_batch_probe_for_test();
     assert!(
@@ -1086,14 +1081,14 @@ async fn partial_checkpoint_after_partial_checkpoint_snapshot_stays_hot(_sim: Si
 	);
 }
 
-async fn partial_checkpoint_canonical_fallback_keeps_lifecycle_path(_sim: Simulation) {
+async fn partial_checkpoint_uncertified_index_uses_hot_primary_fallback(_sim: Simulation) {
     let authority = fresh_authority().await;
     write_key_value(&authority, "selected", "baseline").await;
     write_key_value(&authority, "remaining", "baseline").await;
     authority.create_checkpoint().await.unwrap();
+    write_key_value(&authority, "selected", "selected-update").await;
+    write_key_value(&authority, "remaining", "remaining-update").await;
     let replica = Replica::bootstrap(AuthorityTransport::connected(authority)).await;
-    replica.write("selected", "selected-update").await;
-    replica.write("remaining", "remaining-update").await;
 
     let branch_id = replica.lix.active_branch_id().await.unwrap();
     let adapter = replica.lix.storage_adapter();
@@ -1132,52 +1127,61 @@ async fn partial_checkpoint_canonical_fallback_keeps_lifecycle_path(_sim: Simula
         .begin_read(crate::storage_adapter::StorageReadOptions::default())
         .await
         .unwrap();
-    assert!(
-        crate::hot_state::TrackedHeadContext::new()
-            .reader(read)
-            .working_diff_for_control(
-                &branch_id,
-                control,
-                &crate::tracked_state::TrackedStateDiffRequest::default(),
-            )
-            .await
-            .unwrap()
-            .is_none(),
-        "corrupt coverage must force the canonical diff fallback",
-    );
-
-    let selected_diff_id = replica
-        .lix
-        .execute(
-            "SELECT diff_id FROM lix_working_diff() \
-             WHERE schema_key = 'lix_key_value' \
-               AND row_pk = CAST('[\"selected\"]' AS JSONB)",
-            &[],
+    let direct = crate::hot_state::TrackedHeadContext::new()
+        .reader(read)
+        .working_diff_for_control(
+            &branch_id,
+            control,
+            &crate::tracked_state::TrackedStateDiffRequest::default(),
         )
         .await
         .unwrap()
-        .rows()[0]
-        .get::<String>("diff_id")
-        .unwrap();
+        .expect("authoritative HOT rows must survive an uncertified sparse index");
+    assert_eq!(direct.diff.entries.len(), 2);
+
+    let head_commit_id = control.head_commit_id.to_string();
+    crate::tracked_state::arm_diff_commits_test_probe(
+        &checkpoint_commit_id.to_string(),
+        &head_commit_id,
+    );
+    crate::tracked_state::arm_point_replay_authority_batch_probe_for_test();
     replica
         .lix
         .execute(
-            "INSERT INTO lix_create_checkpoint (diff_id) SELECT $1 RETURNING commit_id",
-            &[Value::Text(selected_diff_id)],
+            // Keep the source intentionally non-pushdownable so the provider
+            // must answer a broad working-diff read before SQL filters it.
+            "INSERT INTO lix_create_checkpoint (diff_id) \
+             SELECT diff_id FROM lix_working_diff() \
+             WHERE coalesce(schema_key, '') = 'lix_key_value' \
+               AND row_pk ->> 0 = 'selected' \
+             RETURNING commit_id",
+            &[],
         )
         .await
-        .expect("canonical fallback must retain complete lifecycle publication");
+        .expect("HOT primary fallback must retain complete lifecycle publication");
     assert_eq!(
-        replica
-            .lix
-            .execute("SELECT COUNT(*) AS count FROM lix_working_diff()", &[])
-            .await
-            .unwrap()
-            .rows()[0]
-            .get::<i64>("count")
-            .unwrap(),
-        1,
+        crate::tracked_state::take_diff_commits_test_probe(
+            &checkpoint_commit_id.to_string(),
+            &head_commit_id,
+        ),
+        0,
+        "an uncertified derived index must not hydrate canonical history while HOT rows are authoritative",
     );
+    assert!(
+        crate::tracked_state::take_point_replay_authority_batch_probe_for_test().is_empty(),
+        "HOT primary fallback must not demand cold owner snapshots",
+    );
+    let remaining = replica
+        .lix
+        .execute(
+            "SELECT row_pk ->> 0 AS key FROM lix_working_diff() \
+             WHERE schema_key = 'lix_key_value'",
+            &[],
+        )
+        .await
+        .unwrap();
+    assert_eq!(remaining.rows().len(), 1);
+    assert_eq!(remaining.rows()[0].get::<String>("key").unwrap(), "remaining");
 }
 
 async fn partial_checkpoint_rebases_unselected_tombstone(_sim: Simulation) {
@@ -1428,8 +1432,8 @@ sync_simulation_test!(
 	partial_checkpoint_after_partial_checkpoint_snapshot_stays_hot
 );
 sync_simulation_test!(
-    partial_checkpoint_canonical_fallback_keeps_lifecycle_path,
-    partial_checkpoint_canonical_fallback_keeps_lifecycle_path
+    partial_checkpoint_uncertified_index_uses_hot_primary_fallback,
+    partial_checkpoint_uncertified_index_uses_hot_primary_fallback
 );
 sync_simulation_test!(
     partial_checkpoint_rebases_unselected_tombstone,


### PR DESCRIPTION
## Summary

- fall back from an uncertified sparse working-diff index to authoritative HOT primary rows when no packed base is active
- hydrate checkpoint before payloads from exact immutable snapshot-local changelog records before loading cold owner commits
- preserve canonical replay for packed-base scopes and local-record misses

## Why

Snapshot-backed browser replicas can have complete HOT current state while sparse index coverage is not certified and historical commit bodies remain remote. A broad `lix_working_diff()` read then replayed one cold owner per historical checkpoint even though the working diff was already answerable locally.

## Validation

- `cargo test -p lix --quiet` (2,872 passed; 26 ignored; all integration tests and doctests passed)
- `cargo test -p lix sync::simulation_tests` (11 passed)
- `cargo check -p lix --all-targets`
- `cargo clippy -p lix --lib --tests`
- `cargo fmt --all -- --check`
- `git diff --check`

The regression uses Atelier’s exact compound file-selection predicate and asserts zero canonical diff replay and zero cold owner-snapshot demand.