### PR TITLE
fix: keep packed working diffs local

### DIFF
--- a/.changenotes/packed-working-diff-local.md
+++ b/.changenotes/packed-working-diff-local.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+Kept packed browser working diffs local by classifying checkpoint additions from their compact current-state authority instead of hydrating historical payload owners.

--- a/packages/lix/src/hot_state/tracked_head.rs
+++ b/packages/lix/src/hot_state/tracked_head.rs
@@ -197,14 +197,13 @@ struct WorkingDiffSlotFingerprint {
 const WORKING_DIFF_SLOT_NONE: u8 = 0;
 const WORKING_DIFF_SLOT_REF: u8 = 1;
 const WORKING_DIFF_SLOT_INLINE: u8 = 2;
-/// The before image is identified by its change id, but its payload slot was
-/// not materialized where the baseline was captured.
+/// A working-diff version is identified by its change id, but its payload slots
+/// were not materialized at the compact authority that supplied it.
 ///
-/// Root current bases are read under `ChangeRecordProjection::identity_only()`
-/// so the write path pays no payload I/O to capture a baseline. The reader
-/// hydrates the referenced change record only for the one question the change
-/// id cannot answer on its own: whether two distinct changes carry the same
-/// payload.
+/// Root before images and compact packed after images both use this marker so
+/// their common identity-only paths pay no payload I/O. A reader either
+/// resolves the payload for comparing two distinct live changes or declines
+/// the accelerator in favor of canonical diff.
 const WORKING_DIFF_SLOT_UNRESOLVED: u8 = 3;
 const WORKING_DIFF_VERSION_BYTES: usize =
     16 + 16 + 1 + 8 + 8 + 1 + JSON_REF_BYTES + 1 + JSON_REF_BYTES;
@@ -1541,9 +1540,8 @@ fn effective_hot_created_at(
 ///
 /// `Unresolved` is deliberately a distinct answer rather than a default. An
 /// accelerator over the canonical diff may answer correctly or decline, but it
-/// must never answer confidently and wrongly, so a caller that has not
-/// hydrated an unresolved before image cannot accidentally read it as
-/// "different".
+/// must never answer confidently and wrongly, so an unresolved version cannot
+/// accidentally compare as "different".
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum WorkingDiffPayloadEquality {
     Equal,
@@ -1553,8 +1551,8 @@ pub(crate) enum WorkingDiffPayloadEquality {
 
 impl WorkingDiffVersion {
     /// True when this version's payload slots were never materialized, so only
-    /// its change id is known. Resolve with `resolve_payload_slots` before
-    /// classifying.
+    /// its change id is known. Resolve before comparing two distinct live
+    /// changes, or decline the accelerator.
     fn payload_is_unresolved(self) -> bool {
         self.snapshot.kind == WORKING_DIFF_SLOT_UNRESOLVED
             || self.metadata.kind == WORKING_DIFF_SLOT_UNRESOLVED

--- a/packages/lix/src/hot_state/tracked_head/hot.rs
+++ b/packages/lix/src/hot_state/tracked_head/hot.rs
@@ -10062,17 +10062,24 @@ fn packed_working_diff_snapshot(payload: Option<&[u8]>) -> WorkingDiffSlotFinger
     )
 }
 
-fn packed_working_diff_version(
-    member: &crate::tracked_state::CommitDeltaMember,
+/// Builds a packed-base after candidate from its compact authenticated index.
+///
+/// The dominant fresh-row case has no before image and therefore needs only
+/// identity and provenance to emit `Added`. A later guard declines the
+/// accelerator when a live before image would require comparing payloads.
+/// Keeping payload slots unresolved avoids loading cold owners for every row
+/// merely to answer the common case.
+fn packed_compact_working_diff_version(
+    value: &crate::tracked_state::TrackedStateIndexValue,
 ) -> WorkingDiffVersion {
     WorkingDiffVersion {
-        change_id: member.value.change_id,
-        commit_id: member.value.commit_id,
-        deleted: member.value.deleted,
-        created_at: member.value.created_at,
-        updated_at: member.value.updated_at,
-        snapshot: packed_working_diff_snapshot(member.change.snapshot.as_deref()),
-        metadata: packed_working_diff_slot(&member.change.metadata),
+        change_id: value.change_id,
+        commit_id: value.commit_id,
+        deleted: value.deleted,
+        created_at: value.created_at,
+        updated_at: value.updated_at,
+        snapshot: WorkingDiffSlotFingerprint::unresolved(),
+        metadata: WorkingDiffSlotFingerprint::unresolved(),
     }
 }
 
@@ -10243,7 +10250,10 @@ async fn hot_working_diff_entries(
         .into_iter()
         .filter(|base| base.checkpoint_commit_id == Some(checkpoint_commit_id))
         .collect::<Vec<_>>();
-    if packed_refs.is_empty() {
+    let has_matching_packed_ref = packed_refs
+        .iter()
+        .any(|base| packed_base_matches_file_filter(base, &filter.file_ids));
+    if !has_matching_packed_ref {
         if let Some(bypass) =
             hot_working_diff_bypass_filter(store, branch_id, generation, filter).await?
         {
@@ -10342,26 +10352,31 @@ async fn hot_working_diff_entries(
         {
             return Ok(None);
         }
-        let Ok(members) = crate::tracked_state::load_commit_delta_members_with_payloads(
-            store,
-            base_ref.commit_id,
-        )
-        .await
+        if !packed_base_matches_file_filter(base_ref, &filter.file_ids) {
+            continue;
+        }
+        let Ok(members) =
+            crate::tracked_state::scan_commit_delta_members(store, base_ref.commit_id).await
         else {
             return Ok(None);
         };
-        for member in members {
-            if !packed_member_matches_filter(&member, filter) {
+        for (key, value) in members {
+            if !packed_identity_matches_filter(
+                &key.schema_key,
+                &key.row_pk,
+                key.file_id.as_deref(),
+                filter,
+            ) {
                 continue;
             }
             let identity = HeadIdentity {
                 branch_id: branch_id.to_string(),
                 generation,
-                schema_key: member.key.schema_key.clone(),
-                row_pk: member.key.row_pk.clone(),
-                file_id: member.key.file_id.clone(),
+                schema_key: key.schema_key,
+                row_pk: key.row_pk,
+                file_id: key.file_id,
             };
-            let version = packed_working_diff_version(&member);
+            let version = packed_compact_working_diff_version(&value);
             match selected.entry(identity) {
                 std::collections::btree_map::Entry::Vacant(entry) => {
                     entry.insert(Some(version));
@@ -10378,7 +10393,7 @@ async fn hot_working_diff_entries(
         }
     }
     if actual_coverage != expected_coverage {
-        if packed_refs.is_empty() {
+        if !has_matching_packed_ref {
             // The sparse dirty-key index is a derived accelerator. Complete
             // HOT primary rows carry the authoritative checkpoint baseline,
             // so an invalid index certificate must degrade to one local
@@ -10451,6 +10466,20 @@ async fn hot_working_diff_entries(
         let Some((before, after)) = choose_hot_or_packed_working_diff(hot_after, base_after) else {
             return Ok(None);
         };
+        if before.is_some_and(|before| {
+            !before.deleted
+                && !after.deleted
+                && before.change_id != after.change_id
+                && after.payload_is_unresolved()
+        }) {
+            // A newer packed replacement can overlay a dirty HOT row that was
+            // already present at the checkpoint. Compact packed authority can
+            // prove identity and provenance, but not whether two distinct live
+            // changes have equal payloads. Decline this rare accelerator case
+            // so canonical diff owns the comparison instead of reintroducing
+            // broad historical payload hydration into the common Added path.
+            return Ok(None);
+        }
         let identity = identity.into_row_identity();
         candidates.push((
             TrackedStateKey {
@@ -10812,11 +10841,10 @@ fn classify_hot_working_diff_entry(
                     before: before_row,
                     after: Some(after_row),
                 })),
-                // Never guess. Every caller hydrates unresolved before images
-                // before classifying, so reaching this arm means a new baseline
-                // source skipped that step.
+                // Never guess. Callers must resolve ambiguous payloads or
+                // decline the accelerator before classification.
                 WorkingDiffPayloadEquality::Unresolved => Err(head_value_error(
-                    "working-diff classification reached an unresolved before image",
+                    "working-diff classification reached an unresolved payload",
                 )),
             }
         }
@@ -11562,8 +11590,8 @@ fn encode_hot_diff_key_parts(
 ///   contributes exactly one group key naming a *commit*
 ///   (`hot_scope_prefix ++ new_head`, see the collection-replacement writer),
 ///   standing for a whole schema collection whose members span every file and
-///   are only recoverable through `load_commit_delta_members_with_payloads`
-///   at read time. Attributing it to file partitions means expanding it per
+///   are recovered from the compact commit-delta member index at read time.
+///   Attributing it to file partitions means expanding it per
 ///   member on the write path — reinstating the per-identity coverage cost
 ///   the manifest exists to remove.
 /// - **A partition-keyed segment is not a packed segment.** A segment batches

--- a/packages/lix/src/session/execute.rs
+++ b/packages/lix/src/session/execute.rs
@@ -7630,6 +7630,79 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn packed_replacement_over_hot_before_declines_compact_working_diff() {
+        const ROW_COUNT: usize = 512;
+        let session = open_session().await;
+        let schema = serde_json::json!({
+            "$schema": "https://lix.dev/schema-v1.json",
+            "key": "packed_replacement_working_diff_probe",
+            "columns": [
+                { "name": "path", "type": "text", "nullable": false },
+                { "name": "value", "type": "text", "nullable": false },
+            ],
+            "primary_key": ["path"],
+        });
+        session
+            .execute(
+                "INSERT INTO lix_registered_schema (schema_key, value) VALUES (CAST($1 AS JSONB) ->> 'key', CAST($1 AS JSONB))",
+                &[Value::Text(schema.to_string())],
+            )
+            .await
+            .unwrap();
+
+        let insert_statements = (0..ROW_COUNT)
+            .map(|row_index| ExecuteBatchStatement {
+                label: None,
+                sql: "INSERT INTO packed_replacement_working_diff_probe (path, value) VALUES ($1, $2)"
+                    .to_owned(),
+                params: vec![
+                    Value::Text(format!("{row_index:04}")),
+                    Value::Text(format!("base-{row_index:04}")),
+                ],
+            })
+            .collect::<Vec<_>>();
+        session.execute_batch(&insert_statements).await.unwrap();
+        session.create_checkpoint().await.unwrap();
+        session
+            .execute(
+                "UPDATE packed_replacement_working_diff_probe SET value = 'hot' WHERE path = '0000'",
+                &[],
+            )
+            .await
+            .unwrap();
+
+        let replacement_statements = (0..ROW_COUNT)
+            .map(|row_index| ExecuteBatchStatement {
+                label: None,
+                sql: "UPDATE packed_replacement_working_diff_probe SET value = $1 WHERE path = $2"
+                    .to_owned(),
+                params: vec![
+                    Value::Text(format!("packed-{row_index:04}")),
+                    Value::Text(format!("{row_index:04}")),
+                ],
+        })
+        .collect::<Vec<_>>();
+        session.execute_batch(&replacement_statements).await.unwrap();
+        assert_current_head_uses_packed_delta_without_columnar_sidecar(
+            &session,
+            "packed_replacement_working_diff_probe",
+            ROW_COUNT as u64,
+        )
+        .await;
+
+        let diff = session
+            .execute(
+                "SELECT count(*) AS count FROM lix_working_diff() \
+                 WHERE schema_key = 'packed_replacement_working_diff_probe' \
+                   AND diff_type = 'modified'",
+                &[],
+            )
+            .await
+            .expect("ambiguous packed payload comparison should fall back correctly");
+        assert_eq!(diff.rows()[0].get::<i64>("count").unwrap(), ROW_COUNT as i64);
+    }
+
+    #[tokio::test]
     async fn ordered_batch_update_preserves_non_uniform_lifecycle_without_journal_admission() {
         let session = open_session().await;
         let schema = serde_json::json!({

--- a/packages/lix/src/sync/simulation_tests.rs
+++ b/packages/lix/src/sync/simulation_tests.rs
@@ -13,7 +13,7 @@ use crate::engine::Engine;
 use crate::storage::Memory;
 use crate::support::fuzz_seeds;
 use crate::support::simulation_test::engine::{Simulation, SimulationMode, SimulationOptions};
-use crate::{Lix, LixError, Value, open_lix};
+use crate::{ExecuteBatchStatement, Lix, LixError, Value, open_lix};
 
 use super::runtime::{
     fetch_repository_snapshot, hydrate_error_for_test, register_blob_manifests, sync_iteration,
@@ -965,6 +965,166 @@ async fn partial_file_checkpoint_rebases_hot_epoch(_sim: Simulation) {
     );
 }
 
+async fn packed_snapshot_partial_file_checkpoint_stays_payload_local(_sim: Simulation) {
+    const HISTORICAL_CHECKPOINT_COUNT: usize = 50;
+    const FILE_COUNT: usize = 90;
+    const PACKED_ROW_COUNT: usize = 512;
+    let authority = fresh_authority().await;
+    for checkpoint_index in 0..HISTORICAL_CHECKPOINT_COUNT {
+        write_key_value(
+            &authority,
+            "history",
+            &format!("checkpoint-{checkpoint_index:02}"),
+        )
+        .await;
+        authority
+            .create_checkpoint()
+            .await
+            .expect("historical checkpoint should commit");
+    }
+    for index in 0..FILE_COUNT {
+        authority
+            .execute(
+                "INSERT INTO lix_file (path, content) VALUES ($1, $2)",
+                &[
+                    Value::Text(format!("/packed-{index:02}.md")),
+                    Value::Blob(format!("packed-{index:02}").into_bytes().into()),
+                ],
+            )
+            .await
+            .expect("post-checkpoint file should commit");
+    }
+    let mut replica = Replica::bootstrap(AuthorityTransport::connected(authority)).await;
+    let packed_rows = (0..PACKED_ROW_COUNT)
+        .map(|index| ExecuteBatchStatement {
+            label: None,
+            sql: "INSERT INTO lix_key_value (key, value) VALUES ($1, $2)".to_owned(),
+            params: vec![
+                Value::Text(format!("packed-row-{index:03}")),
+                Value::Text(format!("value-{index:03}")),
+            ],
+        })
+        .collect::<Vec<_>>();
+    replica
+        .lix
+        .execute_batch(&packed_rows)
+        .await
+        .expect("large post-checkpoint batch should publish a packed current base");
+    replica
+        .lix
+        .execute(
+            "UPDATE lix_file SET content = $1 WHERE path = '/packed-02.md'",
+            &[Value::Blob(b"hot update".to_vec().into())],
+        )
+        .await
+        .expect("packed snapshot should accept a HOT file update");
+    replica
+        .lix
+        .execute("DELETE FROM lix_file WHERE path = '/packed-03.md'", &[])
+        .await
+        .expect("packed snapshot should accept a HOT file delete");
+
+    let mut compact_scan_counts = Vec::new();
+    for (selected_path, expected_remaining) in
+        [("/packed-00.md", FILE_COUNT - 2), ("/packed-01.md", FILE_COUNT - 3)]
+    {
+        let selected_file_id = replica
+            .lix
+            .execute("SELECT id FROM lix_file WHERE path = $1", &[Value::Text(selected_path.to_owned())])
+            .await
+            .expect("selected packed file should be locally readable")
+            .rows()[0]
+            .get::<String>("id")
+            .expect("selected packed file id should decode");
+        crate::tracked_state::reset_commit_delta_scan_probe_for_test();
+        let direct_file_diff = replica
+            .lix
+            .execute(
+                "SELECT count(*) AS count FROM lix_working_diff() WHERE file_id = $1",
+                &[Value::Text(selected_file_id.clone())],
+            )
+            .await
+            .expect("direct file-filtered packed diff should stay local");
+        assert!(
+            direct_file_diff.rows()[0].get::<i64>("count").unwrap() > 0,
+            "selected packed file should have a direct file-scoped diff",
+        );
+        let (direct_compact_scans, payload_scans) =
+            crate::tracked_state::take_commit_delta_scan_probe_for_test();
+        assert_eq!(payload_scans, 0, "direct file filter hydrated payload owners");
+
+        crate::tracked_state::reset_commit_delta_scan_probe_for_test();
+        let checkpoint = replica
+            .lix
+            .execute(
+                "INSERT INTO lix_create_checkpoint (diff_id) \
+                 SELECT diff_id FROM lix_working_diff() \
+                 WHERE coalesce( \
+                     file_id, \
+                     CASE WHEN schema_key = 'lix_file_descriptor' THEN row_pk ->> 0 END \
+                 ) IN ($1) \
+                 RETURNING commit_id",
+                &[Value::Text(selected_file_id.clone())],
+            )
+            .await
+            .expect("packed partial checkpoint should stay local");
+        assert!(checkpoint.rows_affected() > 0);
+        let checkpoint_ids = checkpoint
+            .rows()
+            .iter()
+            .map(|row| row.get::<String>("commit_id").unwrap())
+            .collect::<std::collections::BTreeSet<_>>();
+        assert_eq!(checkpoint_ids.len(), 1, "one partial checkpoint was created");
+        let (checkpoint_compact_scans, payload_scans) =
+            crate::tracked_state::take_commit_delta_scan_probe_for_test();
+        assert_eq!(
+            payload_scans, 0,
+            "partial checkpoint hydrated historical payload owners",
+        );
+        compact_scan_counts.push((direct_compact_scans, checkpoint_compact_scans));
+
+        let selected_remaining = replica
+            .lix
+            .execute(
+                "SELECT count(*) AS count FROM lix_working_diff() \
+                 WHERE coalesce( \
+                     file_id, \
+                     CASE WHEN schema_key = 'lix_file_descriptor' THEN row_pk ->> 0 END \
+                 ) = $1",
+                &[Value::Text(selected_file_id)],
+            )
+            .await
+            .expect("selected packed file diff should be cleared");
+        assert_eq!(
+            selected_remaining.rows()[0].get::<i64>("count").unwrap(),
+            0,
+            "partial checkpoint cleared the wrong file",
+        );
+
+        let remaining = replica
+            .lix
+            .execute(
+                "SELECT count(distinct coalesce( \
+                     file_id, \
+                     CASE WHEN schema_key = 'lix_file_descriptor' THEN row_pk ->> 0 END \
+                 )) AS count \
+                 FROM lix_working_diff()",
+                &[],
+            )
+            .await
+            .expect("remaining packed working diff should stay locally readable")
+            .rows()[0]
+            .get::<i64>("count")
+            .expect("remaining packed file count should decode");
+        assert_eq!(remaining, expected_remaining as i64);
+        replica.restart().await;
+    }
+    assert!(
+        compact_scan_counts[0].0 > 0 && compact_scan_counts[0].1 > 0,
+        "the first direct filter and checkpoint must both traverse compact packed authority",
+    );
+}
+
 async fn partial_checkpoint_after_partial_checkpoint_snapshot_stays_hot(_sim: Simulation) {
 	let authority = fresh_authority().await;
 	write_key_value(&authority, "selected", "baseline").await;
@@ -1426,6 +1586,10 @@ sync_simulation_test!(
 sync_simulation_test!(
     partial_file_checkpoint_rebases_hot_epoch,
     partial_file_checkpoint_rebases_hot_epoch
+);
+sync_simulation_test!(
+    packed_snapshot_partial_file_checkpoint_stays_payload_local,
+    packed_snapshot_partial_file_checkpoint_stays_payload_local
 );
 sync_simulation_test!(
 	partial_checkpoint_after_partial_checkpoint_snapshot_stays_hot,

--- a/packages/lix/src/tracked_state/mod.rs
+++ b/packages/lix/src/tracked_state/mod.rs
@@ -79,6 +79,7 @@ pub(crate) use storage::stage_sweep_unreachable_content_nodes;
 #[cfg(test)]
 pub(crate) use storage::{
     arm_point_replay_authority_batch_probe_for_test,
+    reset_commit_delta_scan_probe_for_test, take_commit_delta_scan_probe_for_test,
     take_point_replay_authority_batch_probe_for_test,
 };
 pub(crate) use storage::{
@@ -100,8 +101,9 @@ pub(crate) use storage::{
     load_local_commit_delta_members_with_payloads, load_local_selected_change_owner_commit_ids,
     load_owned_commit_delta_entries, load_owned_commit_delta_entries_one_ordered_ref,
     load_published_commit_state_topology, load_retained_commit_snapshots_for_schemas,
-    scan_change_records_from_commit_deltas, scan_commit_delta_inventory, scan_commit_delta_values,
-    scan_commit_state_manifest_commit_ids, selected_change_selection_fingerprint,
+    scan_change_records_from_commit_deltas, scan_commit_delta_inventory, scan_commit_delta_members,
+    scan_commit_delta_values, scan_commit_state_manifest_commit_ids,
+    selected_change_selection_fingerprint,
     stage_addressable_commit_deltas, stage_addressable_commit_deltas_with_selected_source,
     stage_certified_commit_state_manifest_with_handle, stage_change_locators,
     stage_commit_deltas_for_commit_state, stage_commit_history_available,

--- a/packages/lix/src/tracked_state/storage.rs
+++ b/packages/lix/src/tracked_state/storage.rs
@@ -9415,6 +9415,21 @@ pub(crate) async fn load_commit_delta_members_with_payloads(
     )
 }
 
+#[cfg(test)]
+std::thread_local! {
+    static COMMIT_DELTA_SCAN_PROBE: std::cell::Cell<(usize, usize)> = const { std::cell::Cell::new((0, 0)) };
+}
+
+#[cfg(test)]
+pub(crate) fn reset_commit_delta_scan_probe_for_test() {
+    COMMIT_DELTA_SCAN_PROBE.with(|probe| probe.set((0, 0)));
+}
+
+#[cfg(test)]
+pub(crate) fn take_commit_delta_scan_probe_for_test() -> (usize, usize) {
+    COMMIT_DELTA_SCAN_PROBE.with(|probe| probe.replace((0, 0)))
+}
+
 /// Loads only the mutations physically authored by one commit, without
 /// expanding a complete-state checkpoint fence into its logical net diff.
 /// Sync uses this together with an authenticated state alias so a checkpoint
@@ -9454,6 +9469,8 @@ pub(crate) async fn load_commit_delta_members_with_payloads_for_schemas(
     file_ids: &[String],
     max_segment_count: usize,
 ) -> Result<Option<Vec<CommitDeltaMember>>, LixError> {
+    #[cfg(test)]
+    COMMIT_DELTA_SCAN_PROBE.with(|probe| probe.set((probe.get().0, probe.get().1 + 1)));
     load_commit_delta_members_with_payloads_for_schemas_impl(
         store,
         commit_id,
@@ -11163,6 +11180,8 @@ pub(crate) async fn scan_commit_delta_members(
     store: &(impl StorageAdapterRead + ?Sized),
     commit_id: CommitId,
 ) -> Result<Vec<(TrackedStateKey, TrackedStateIndexValue)>, LixError> {
+    #[cfg(test)]
+    COMMIT_DELTA_SCAN_PROBE.with(|probe| probe.set((probe.get().0 + 1, probe.get().1)));
     let batch = {
         #[cfg(feature = "storage-benches")]
         let _phase = crate::storage_bench::PlanLoadPhaseScope::enter(


### PR DESCRIPTION
## Summary

- classify packed current-base working diffs from compact authenticated member authority
- preserve scope-global coverage while pruning nonmatching file-scoped packed bases
- decline the accelerator for rare ambiguous packed-over-HOT payload comparisons
- add causal 90-file / 50-checkpoint regressions with compact and payload scan censuses

## Validation

- `cargo test -p lix --features all-simulations` (3271 passed, 26 ignored)
- `cargo test -p lix sync::simulation_tests -- --nocapture` (12 passed)
- `cargo test -p lix packed_snapshot_partial_file_checkpoint_stays_payload_local -- --nocapture`
- `cargo test -p lix packed_replacement_over_hot_before_declines_compact_working_diff -- --nocapture`
- `cargo check -p lix --all-targets`
- `cargo fmt --all -- --check`

Required by opral/lixray#238: its deployed snapshot replica currently hydrates historical payload owners during a partial checkpoint.