### PR TITLE
fix(lix): keep packed recreate checkpoints local

### DIFF
--- a/.changenotes/packed-working-diff-recreate.md
+++ b/.changenotes/packed-working-diff-recreate.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+Kept restarted partial checkpoints over packed replacements on the local working-diff path instead of replaying repository history.

--- a/packages/lix/src/hot_state/tracked_head.rs
+++ b/packages/lix/src/hot_state/tracked_head.rs
@@ -59,7 +59,7 @@ use crate::NullableKeyFilter;
 #[cfg(test)]
 use crate::branch::stage_branch_head_control;
 use crate::branch::{BranchHeadControl, BranchHeadControlContext, BranchHeadTrackedReachability};
-use crate::changelog::{ChangeId, ChangeRecordProjection, ChangelogReader, CommitId};
+use crate::changelog::{ChangeId, ChangeRecordProjection, CommitId};
 use crate::common::{LixTimestamp, SharedStr};
 use crate::hot_state::{
     MaterializedHotStateBatch, MaterializedHotStateBatchBuilder, MaterializedHotStateExactBatch,

--- a/packages/lix/src/hot_state/tracked_head/hot.rs
+++ b/packages/lix/src/hot_state/tracked_head/hot.rs
@@ -5309,7 +5309,9 @@ pub(crate) enum CompleteWorkingDiffMode {
 enum WorkingDiffBaselineAction {
     Continue,
     Reset,
-    Rebase,
+    Rebase {
+        previous_checkpoint_commit_id: CommitId,
+    },
 }
 
 impl HotTrackedSnapshot {
@@ -6605,6 +6607,7 @@ where
         generation: CommitId,
         new_head: CommitId,
         deltas: &[CurrentStateDeltaRef<'_>],
+        previous_checkpoint_commit_id: CommitId,
         checkpoint_commit_id: CommitId,
         coverage: &mut WorkingDiffIndexCoverage,
     ) -> Result<CommitId, LixError> {
@@ -6621,7 +6624,9 @@ where
             false,
             None,
             None,
-            WorkingDiffBaselineAction::Rebase,
+            WorkingDiffBaselineAction::Rebase {
+                previous_checkpoint_commit_id,
+            },
             &BTreeMap::new(),
         )
         .await
@@ -6709,7 +6714,10 @@ where
         working_diff_baseline_action: WorkingDiffBaselineAction,
         certified_live_increments: &BTreeMap<(String, Option<String>), u64>,
     ) -> Result<CommitId, LixError> {
-        if working_diff_baseline_action == WorkingDiffBaselineAction::Rebase
+        if matches!(
+            working_diff_baseline_action,
+            WorkingDiffBaselineAction::Rebase { .. }
+        )
             && working_diff_capture_checkpoint_commit_id.is_none()
         {
             return Err(head_value_error(
@@ -6718,8 +6726,18 @@ where
         }
         let reset_working_diff_baselines =
             working_diff_baseline_action == WorkingDiffBaselineAction::Reset;
-        let rebase_working_diff_baselines =
-            working_diff_baseline_action == WorkingDiffBaselineAction::Rebase;
+        let rebase_working_diff_baselines = matches!(
+            working_diff_baseline_action,
+            WorkingDiffBaselineAction::Rebase { .. }
+        );
+        let predecessor_checkpoint_commit_id = match working_diff_baseline_action {
+            WorkingDiffBaselineAction::Rebase {
+                previous_checkpoint_commit_id,
+            } => Some(previous_checkpoint_commit_id),
+            WorkingDiffBaselineAction::Continue | WorkingDiffBaselineAction::Reset => {
+                working_diff_capture_checkpoint_commit_id
+            }
+        };
         let generation = parent_generation.unwrap_or(new_head);
         let sorted = {
             let _span = tracing::debug_span!(
@@ -6924,7 +6942,7 @@ where
                 created_at: packed_value.created_at,
                 updated_at: packed_value.updated_at,
                 working_diff_baseline: packed_current_base_working_diff_baseline(
-                    working_diff_capture_checkpoint_commit_id,
+                    predecessor_checkpoint_commit_id,
                     *base_checkpoint_commit_id,
                 ),
                 columnar_base_coordinate: base_coordinate.map(|coordinate| {
@@ -6944,7 +6962,7 @@ where
                 self.store,
                 branch_id,
                 generation,
-                working_diff_capture_checkpoint_commit_id,
+                predecessor_checkpoint_commit_id,
                 &packed_previous_keys,
                 ChangeRecordProjection::identity_only(),
             ))
@@ -10065,10 +10083,10 @@ fn packed_working_diff_snapshot(payload: Option<&[u8]>) -> WorkingDiffSlotFinger
 /// Builds a packed-base after candidate from its compact authenticated index.
 ///
 /// The dominant fresh-row case has no before image and therefore needs only
-/// identity and provenance to emit `Added`. A later guard declines the
-/// accelerator when a live before image would require comparing payloads.
-/// Keeping payload slots unresolved avoids loading cold owners for every row
-/// merely to answer the common case.
+/// identity and provenance to emit `Added`. The comparison resolver hydrates
+/// only the rare live/live candidates whose payloads must be compared. Keeping
+/// every other slot unresolved avoids loading cold owners merely to answer the
+/// common case.
 fn packed_compact_working_diff_version(
     value: &crate::tracked_state::TrackedStateIndexValue,
 ) -> WorkingDiffVersion {
@@ -10439,25 +10457,37 @@ async fn hot_working_diff_entries(
             // * `reject_retention_change` forbids flipping retention while any
             //   physical member exists, so a dirty tracked row cannot be
             //   overwritten by an untracked one.
-            // * The scope prefix contains the checkpoint and the generation, so
-            //   a `Clean` baseline or a foreign checkpoint owner cannot appear
-            //   under the scope the epoch names.
+            // * The scope prefix contains the checkpoint and generation, so a
+            //   foreign checkpoint owner cannot appear. A matching packed base
+            //   can add identities beyond the sparse dirty index; its primary
+            //   HOT row may validly be `Clean`, in which case that row is the
+            //   checkpoint before-image for the newer packed value.
             //
             // The finite bypass instead reads *all* primary rows matching a
             // finite identity filter, where clean, untracked, and absent rows
             // are the normal case and skipping them is the classification. It
-            // never sees this population, so keep the strict guard here rather
-            // than relaxing it to match.
+            // never sees this population. Keep the strict guard here apart
+            // from the explicit clean-HOT/packed-overlay case below.
             if after.untracked {
                 return Ok(None);
             }
-            let Some(before) =
-                working_diff_baseline_before(after.working_diff_baseline, checkpoint_commit_id)
-            else {
-                return Ok(None);
-            };
+            let baseline = after.working_diff_baseline;
             let Some(after) = after.working_diff_version() else {
                 return Ok(None);
+            };
+            let before = if baseline == WorkingDiffBaseline::Clean
+                && base_after.is_some_and(|packed| after.commit_id < packed.commit_id)
+            {
+                // A clean HOT row is the checkpoint state itself. When a
+                // newer packed current base overlays it, that row is the exact
+                // before image for comparing the packed replacement.
+                Some(after)
+            } else {
+                let Some(before) = working_diff_baseline_before(baseline, checkpoint_commit_id)
+                else {
+                    return Ok(None);
+                };
+                before
             };
             Some((before, after))
         } else {
@@ -10466,20 +10496,6 @@ async fn hot_working_diff_entries(
         let Some((before, after)) = choose_hot_or_packed_working_diff(hot_after, base_after) else {
             return Ok(None);
         };
-        if before.is_some_and(|before| {
-            !before.deleted
-                && !after.deleted
-                && before.change_id != after.change_id
-                && after.payload_is_unresolved()
-        }) {
-            // A newer packed replacement can overlay a dirty HOT row that was
-            // already present at the checkpoint. Compact packed authority can
-            // prove identity and provenance, but not whether two distinct live
-            // changes have equal payloads. Decline this rare accelerator case
-            // so canonical diff owns the comparison instead of reintroducing
-            // broad historical payload hydration into the common Added path.
-            return Ok(None);
-        }
         let identity = identity.into_row_identity();
         candidates.push((
             TrackedStateKey {
@@ -10608,11 +10624,12 @@ async fn classify_hot_working_diff_entries(
         WorkingDiffVersion,
     )>,
 ) -> Result<Vec<TrackedStateDiffEntry>, LixError> {
-    resolve_working_diff_before_payloads(
+    resolve_working_diff_comparison_payloads(
         store,
         &mut candidates,
         |(key, _, _)| key.clone(),
         |(_, before, _)| before,
+        |(_, _, after)| after,
     )
     .await?;
     let row_count = candidates.len();
@@ -10640,7 +10657,7 @@ async fn classify_hot_working_diff_entry_refs(
         WorkingDiffVersion,
     )>,
 ) -> Result<Vec<TrackedStateDiffEntry>, LixError> {
-    resolve_working_diff_before_payloads(
+    resolve_working_diff_comparison_payloads(
         store,
         &mut candidates,
         |(key, _, _)| TrackedStateKey {
@@ -10649,6 +10666,7 @@ async fn classify_hot_working_diff_entry_refs(
             row_pk: key.row_pk.clone(),
         },
         |(_, before, _)| before,
+        |(_, _, after)| after,
     )
     .await?;
     let row_count = candidates.len();
@@ -10671,7 +10689,7 @@ async fn classify_hot_working_diff_scan_entries(
         WorkingDiffVersion,
     )>,
 ) -> Result<Vec<TrackedStateDiffEntry>, LixError> {
-    resolve_working_diff_before_payloads(
+    resolve_working_diff_comparison_payloads(
         store,
         &mut candidates,
         |(identity, _, _)| TrackedStateKey {
@@ -10680,6 +10698,7 @@ async fn classify_hot_working_diff_scan_entries(
             row_pk: identity.row_pk.clone(),
         },
         |(_, before, _)| before,
+        |(_, _, after)| after,
     )
     .await?;
     let row_count = candidates.len();
@@ -10700,109 +10719,101 @@ async fn classify_hot_working_diff_scan_entries(
     Ok(entries)
 }
 
-/// Hydrates the payload slots of before images that were captured by reference.
+#[derive(Debug, Clone, Copy)]
+enum WorkingDiffPayloadSide {
+    Before,
+    After,
+}
+
+struct PendingWorkingDiffPayload {
+    candidate_index: usize,
+    side: WorkingDiffPayloadSide,
+    key: TrackedStateKey,
+}
+
+/// Hydrates only the payload slots needed to compare two distinct live changes.
 ///
-/// A root-backed baseline stores only the reference to its before image — the
-/// change id plus the commit that owns it — so the write path pays no payload
-/// I/O to capture it. Classification needs the payload itself for exactly one
-/// question the change id cannot answer alone: whether two distinct change
-/// records carry the same payload. Change records are addressed by owning
-/// commit, so pending rows are grouped by commit and fetched one batch per
-/// commit. Identity keys are materialized only for rows that are actually
-/// unresolved, so a diff with no root-backed baselines pays nothing.
-async fn resolve_working_diff_before_payloads<T>(
+/// Root-backed before images and compact packed after images retain identity
+/// and provenance without materializing payloads. Added, removed, and
+/// same-change rows need no payload comparison. For the remaining ambiguous
+/// live/live pairs, resolve every missing side from the local changelog in one
+/// batch, then co-load all exact physical owners that were not locally present.
+/// This keeps one ambiguous packed replacement from degrading the entire
+/// working diff to canonical ancestry replay.
+async fn resolve_working_diff_comparison_payloads<T>(
     store: &(impl StorageAdapterRead + ?Sized),
     candidates: &mut [T],
     key_of: impl Fn(&T) -> TrackedStateKey,
     before_of: impl Fn(&mut T) -> &mut Option<WorkingDiffVersion>,
+    after_of: impl Fn(&mut T) -> &mut WorkingDiffVersion,
 ) -> Result<(), LixError> {
     let mut pending = Vec::new();
     for index in 0..candidates.len() {
-        let Some(version) = before_of(&mut candidates[index]).as_mut() else {
+        let before = *before_of(&mut candidates[index]);
+        let after = *after_of(&mut candidates[index]);
+        let Some(before) = before else {
             continue;
         };
-        if !version.payload_is_unresolved() {
+        if before.deleted || after.deleted || before.change_id == after.change_id {
             continue;
         }
-        if version.deleted {
-            // A tombstone before image has no payload to hydrate, and
-            // classification never consults one for a deleted row.
-            version.resolve_payload_slots(
-                WorkingDiffSlotFingerprint::none(),
-                WorkingDiffSlotFingerprint::none(),
-            );
-            continue;
+        let key = key_of(&candidates[index]);
+        if before.payload_is_unresolved() {
+            pending.push(PendingWorkingDiffPayload {
+                candidate_index: index,
+                side: WorkingDiffPayloadSide::Before,
+                key: key.clone(),
+            });
         }
-        pending.push((index, key_of(&candidates[index])));
+        if after.payload_is_unresolved() {
+            pending.push(PendingWorkingDiffPayload {
+                candidate_index: index,
+                side: WorkingDiffPayloadSide::After,
+                key,
+            });
+        }
     }
     if pending.is_empty() {
         return Ok(());
     }
-    // Snapshot/bootstrap publication keeps change payloads in the standalone
-    // changelog while their physical commit bodies may remain remote. Resolve
-    // that local authority in one batch before asking for any owner commit.
-    let change_ids = pending
+    let requests = pending
         .iter()
-        .map(|(index, _)| {
-            before_of(&mut candidates[*index])
+        .map(|pending| {
+            let version = match pending.side {
+                WorkingDiffPayloadSide::Before => before_of(
+                    &mut candidates[pending.candidate_index],
+                )
                 .as_ref()
-                .expect("pending before images are present")
-                .change_id
+                .expect("pending before image is present"),
+                WorkingDiffPayloadSide::After => {
+                    after_of(&mut candidates[pending.candidate_index])
+                }
+            };
+            crate::tracked_state::AuthoritativeLiveChangeRequest {
+                change_id: version.change_id,
+                source_commit_id: version.commit_id,
+                key: pending.key.clone(),
+                updated_at: version.updated_at,
+            }
         })
         .collect::<Vec<_>>();
-    let local = crate::changelog::ChangelogContext::new()
-        .reader(store)
-        .load_changes(crate::changelog::ChangeLoadRequest {
-            change_ids: &change_ids,
-        })
+    let records = crate::tracked_state::load_authoritative_live_change_records(store, &requests)
         .await?;
-    let mut by_commit = BTreeMap::<CommitId, Vec<(usize, TrackedStateKey)>>::new();
-    for ((index, key), (_, record)) in pending.into_iter().zip(local) {
-        let commit_id = before_of(&mut candidates[index])
-            .as_ref()
-            .expect("pending before images are present")
-            .commit_id;
-        let version = before_of(&mut candidates[index])
+    for (pending, record) in pending.into_iter().zip(records) {
+        let version = match pending.side {
+            WorkingDiffPayloadSide::Before => before_of(
+                &mut candidates[pending.candidate_index],
+            )
             .as_mut()
-            .expect("pending before images are present");
-        if let Some(record) = record.as_ref()
-            && record.schema_key == key.schema_key
-            && record.file_id == key.file_id
-            && record.row_pk == key.row_pk
-            && record.snapshot.is_some()
-            && record.created_at == version.updated_at
-        {
-            version.resolve_payload_slots(
-                packed_working_diff_snapshot(record.snapshot.as_deref()),
-                packed_working_diff_slot(&record.metadata),
-            );
-            continue;
-        }
-        by_commit.entry(commit_id).or_default().push((index, key));
-    }
-    for (commit_id, pending) in by_commit {
-        let (indexes, keys): (Vec<_>, Vec<_>) = pending.into_iter().unzip();
-        let records =
-            crate::tracked_state::load_commit_delta_change_records(store, commit_id, &keys).await?;
-        for (index, record) in indexes.into_iter().zip(records) {
-            let record = record.ok_or_else(|| {
-                head_value_error(
-                    "working-diff baseline references a before image that is missing from its commit",
-                )
-            })?;
-            let version = before_of(&mut candidates[index])
-                .as_mut()
-                .expect("pending before images are present the second time");
-            if record.change_id != version.change_id {
-                return Err(head_value_error(
-                    "working-diff baseline before image does not match its referenced change record",
-                ));
+            .expect("pending before image is present"),
+            WorkingDiffPayloadSide::After => {
+                after_of(&mut candidates[pending.candidate_index])
             }
-            version.resolve_payload_slots(
-                packed_working_diff_snapshot(record.snapshot.as_deref()),
-                packed_working_diff_slot(&record.metadata),
-            );
-        }
+        };
+        version.resolve_payload_slots(
+            packed_working_diff_snapshot(record.snapshot.as_deref()),
+            packed_working_diff_slot(&record.metadata),
+        );
     }
     Ok(())
 }

--- a/packages/lix/src/session/execute.rs
+++ b/packages/lix/src/session/execute.rs
@@ -7630,7 +7630,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn packed_replacement_over_hot_before_declines_compact_working_diff() {
+    async fn packed_replacement_over_hot_before_resolves_compact_working_diff() {
         const ROW_COUNT: usize = 512;
         let session = open_session().await;
         let schema = serde_json::json!({
@@ -7689,6 +7689,28 @@ mod tests {
             ROW_COUNT as u64,
         )
         .await;
+		let branch_id = session.active_branch_id().await.unwrap();
+		let read = session
+			.storage
+			.begin_read(StorageReadOptions::default())
+			.await
+			.unwrap();
+		let control = crate::branch::BranchHeadControlContext::new()
+			.reader(&read)
+			.load(&branch_id)
+			.await
+			.unwrap()
+			.unwrap();
+		drop(read);
+		let checkpoint_commit_id = control
+			.working_diff_checkpoint_commit_id
+			.expect("working checkpoint should be active")
+			.to_string();
+		let head_commit_id = control.head_commit_id.to_string();
+		crate::tracked_state::arm_diff_commits_test_probe(
+			&checkpoint_commit_id,
+			&head_commit_id,
+		);
 
         let diff = session
             .execute(
@@ -7698,8 +7720,16 @@ mod tests {
                 &[],
             )
             .await
-            .expect("ambiguous packed payload comparison should fall back correctly");
+            .expect("ambiguous packed payload comparison should resolve locally");
         assert_eq!(diff.rows()[0].get::<i64>("count").unwrap(), ROW_COUNT as i64);
+		assert_eq!(
+			crate::tracked_state::take_diff_commits_test_probe(
+				&checkpoint_commit_id,
+				&head_commit_id,
+			),
+			0,
+			"packed replacements over clean HOT rows must remain local",
+		);
     }
 
     #[tokio::test]

--- a/packages/lix/src/sync/simulation_tests.rs
+++ b/packages/lix/src/sync/simulation_tests.rs
@@ -965,6 +965,144 @@ async fn partial_file_checkpoint_rebases_hot_epoch(_sim: Simulation) {
     );
 }
 
+async fn packed_recreate_partial_checkpoint_stays_hot(_sim: Simulation) {
+    const PACKED_ROW_COUNT: usize = 512;
+    let authority = fresh_authority().await;
+    write_key_value(&authority, "selected-recreate", "baseline").await;
+    write_key_value(&authority, "remaining", "baseline").await;
+    authority
+        .create_checkpoint()
+        .await
+        .expect("baseline checkpoint should commit");
+    let mut replica = Replica::bootstrap(AuthorityTransport::connected(authority)).await;
+
+    replica
+        .lix
+        .execute(
+            "DELETE FROM lix_key_value WHERE key = 'selected-recreate'",
+            &[],
+        )
+        .await
+        .expect("selected row should leave a HOT checkpoint baseline");
+    replica.write("remaining", "working").await;
+    let mut packed_rows = vec![
+        ExecuteBatchStatement {
+            label: None,
+            sql: "INSERT INTO lix_key_value (key, value) VALUES ($1, $2)".to_owned(),
+            params: vec![
+                Value::Text("selected-recreate".to_owned()),
+                Value::Text("recreated".to_owned()),
+            ],
+        },
+    ];
+    packed_rows.extend((packed_rows.len()..PACKED_ROW_COUNT).map(|index| {
+        ExecuteBatchStatement {
+            label: None,
+            sql: "INSERT INTO lix_key_value (key, value) VALUES ($1, $2)".to_owned(),
+            params: vec![
+                Value::Text(format!("packed-filler-{index:03}")),
+                Value::Text("filler".to_owned()),
+            ],
+        }
+    }));
+    replica
+        .lix
+        .execute_batch(&packed_rows)
+        .await
+        .expect("recreate batch should publish a packed current base");
+    replica.restart().await;
+
+    let branch_id = replica.lix.active_branch_id().await.unwrap();
+    let adapter = replica.lix.storage_adapter();
+    let read = adapter
+        .begin_read(crate::storage_adapter::StorageReadOptions::default())
+        .await
+        .unwrap();
+    let control = crate::branch::BranchHeadControlContext::new()
+        .reader(&read)
+        .load(&branch_id)
+        .await
+        .unwrap()
+        .unwrap();
+    drop(read);
+    let checkpoint_commit_id = control
+        .working_diff_checkpoint_commit_id
+        .expect("working checkpoint should remain active")
+        .to_string();
+    let head_commit_id = control.head_commit_id.to_string();
+    crate::tracked_state::arm_diff_commits_test_probe(&checkpoint_commit_id, &head_commit_id);
+    crate::tracked_state::reset_commit_delta_scan_probe_for_test();
+    let checkpoint = replica
+        .lix
+        .execute(
+            "INSERT INTO lix_create_checkpoint (diff_id) \
+             SELECT diff_id FROM lix_working_diff() \
+             WHERE schema_key = 'lix_key_value' \
+               AND row_pk ->> 0 = 'selected-recreate' \
+             RETURNING commit_id",
+            &[],
+        )
+        .await
+        .expect("packed recreate partial checkpoint should stay HOT");
+    assert_eq!(checkpoint.rows_affected(), 1);
+    assert_eq!(
+        crate::tracked_state::take_diff_commits_test_probe(
+            &checkpoint_commit_id,
+            &head_commit_id,
+        ),
+        0,
+        "one ambiguous packed recreate must not fall back to canonical history",
+    );
+    let (compact_scans, payload_scans) =
+        crate::tracked_state::take_commit_delta_scan_probe_for_test();
+    assert!(compact_scans > 0, "the packed compact route was not exercised");
+    assert_eq!(
+        payload_scans, 0,
+        "partial checkpoint performed a broad commit-payload scan",
+    );
+    let selected_remaining = replica
+        .lix
+        .execute(
+            "SELECT count(*) AS count FROM lix_working_diff() \
+             WHERE schema_key = 'lix_key_value' \
+               AND row_pk ->> 0 = 'selected-recreate'",
+            &[],
+        )
+        .await
+        .unwrap()
+        .rows()[0]
+        .get::<i64>("count")
+        .unwrap();
+    assert_eq!(selected_remaining, 0);
+    let remaining = replica
+        .lix
+        .execute(
+            "SELECT count(*) AS count FROM lix_working_diff() \
+             WHERE schema_key = 'lix_key_value' \
+               AND row_pk ->> 0 = 'remaining'",
+            &[],
+        )
+        .await
+        .unwrap();
+    assert_eq!(
+        remaining.rows()[0].get::<i64>("count").unwrap(),
+        1,
+        "the unselected change must remain dirty",
+    );
+    replica.restart().await;
+    let reopened_remaining = replica
+        .lix
+        .execute(
+            "SELECT count(*) AS count FROM lix_working_diff() \
+             WHERE schema_key = 'lix_key_value' \
+               AND row_pk ->> 0 = 'remaining'",
+            &[],
+        )
+        .await
+        .unwrap();
+    assert_eq!(reopened_remaining.rows()[0].get::<i64>("count").unwrap(), 1);
+}
+
 async fn packed_snapshot_partial_file_checkpoint_stays_payload_local(_sim: Simulation) {
     const HISTORICAL_CHECKPOINT_COUNT: usize = 50;
     const FILE_COUNT: usize = 90;
@@ -1586,6 +1724,10 @@ sync_simulation_test!(
 sync_simulation_test!(
     partial_file_checkpoint_rebases_hot_epoch,
     partial_file_checkpoint_rebases_hot_epoch
+);
+sync_simulation_test!(
+    packed_recreate_partial_checkpoint_stays_hot,
+    packed_recreate_partial_checkpoint_stays_hot
 );
 sync_simulation_test!(
     packed_snapshot_partial_file_checkpoint_stays_payload_local,

--- a/packages/lix/src/tracked_state/mod.rs
+++ b/packages/lix/src/tracked_state/mod.rs
@@ -83,7 +83,8 @@ pub(crate) use storage::{
     take_point_replay_authority_batch_probe_for_test,
 };
 pub(crate) use storage::{
-    CertifiedCommitStateTopologyParent, CommitDeltaChangeLocator, CommitDeltaLiveMembershipCursor,
+    AuthoritativeLiveChangeRequest, CertifiedCommitStateTopologyParent,
+    CommitDeltaChangeLocator, CommitDeltaLiveMembershipCursor,
     CommitDeltaMember, CommitDeltaPointReadCache, CommitDeltaReplacementGeneration,
     CommitDeltaReplacementScope, EnvelopeCertifiedNativeProjectionBatch,
     EnvelopeCertifiedNativeProjectionSegment, ExclusiveRowSnapshotBatch,
@@ -91,7 +92,8 @@ pub(crate) use storage::{
     commit_delta_contains_schema, commit_delta_member_scopes, commit_history_is_deferred,
     complete_state_fence_change_owner_commit_ids, direct_change_locator,
     deferred_commit_history_ids,
-    encode_commit_state_manifest_replacement_for_migration, load_change_record_by_id,
+    encode_commit_state_manifest_replacement_for_migration, load_authoritative_live_change_records,
+    load_change_record_by_id,
     load_commit_delta_change_records, load_commit_delta_change_records_for_owners,
     load_commit_delta_members_with_payloads,
     load_commit_delta_members_with_payloads_for_schemas, load_commit_delta_replay_metadata,

--- a/packages/lix/src/tracked_state/mod.rs
+++ b/packages/lix/src/tracked_state/mod.rs
@@ -94,7 +94,6 @@ pub(crate) use storage::{
     deferred_commit_history_ids,
     encode_commit_state_manifest_replacement_for_migration, load_authoritative_live_change_records,
     load_change_record_by_id,
-    load_commit_delta_change_records, load_commit_delta_change_records_for_owners,
     load_commit_delta_members_with_payloads,
     load_commit_delta_members_with_payloads_for_schemas, load_commit_delta_replay_metadata,
     load_commit_delta_selection_certificate, load_commit_history_members_with_payloads_for_schemas,

--- a/packages/lix/src/tracked_state/storage.rs
+++ b/packages/lix/src/tracked_state/storage.rs
@@ -9247,6 +9247,107 @@ pub(crate) async fn load_commit_delta_change_records_for_owners(
         .collect())
 }
 
+/// The complete address of one live change payload.
+///
+/// The change id addresses the ordinary local changelog. The source commit and
+/// row identity address the immutable physical fallback used by compact or
+/// deferred history. The timestamp prevents a same-identity record from a
+/// different row lifetime from being accepted as the requested payload.
+pub(crate) struct AuthoritativeLiveChangeRequest {
+    pub(crate) change_id: crate::changelog::ChangeId,
+    pub(crate) source_commit_id: CommitId,
+    pub(crate) key: TrackedStateKey,
+    pub(crate) updated_at: crate::common::LixTimestamp,
+}
+
+/// Resolves live payloads from local changelog authority first, then co-loads
+/// only the exact physical owners that were absent or did not match.
+///
+/// Both paths apply the same identity and lifetime validation. Callers decide
+/// which changes need payloads; this function is the single authority policy
+/// for fetching them in request order.
+pub(crate) async fn load_authoritative_live_change_records(
+    store: &(impl StorageAdapterRead + ?Sized),
+    requests: &[AuthoritativeLiveChangeRequest],
+) -> Result<Vec<crate::changelog::ChangeRecord>, LixError> {
+    if requests.is_empty() {
+        return Ok(Vec::new());
+    }
+    let change_ids = requests
+        .iter()
+        .map(|request| request.change_id)
+        .collect::<Vec<_>>();
+    let standalone = ChangelogContext::new()
+        .reader(store)
+        .load_changes(ChangeLoadRequest {
+            change_ids: &change_ids,
+        })
+        .await?;
+    let mut records = vec![None; requests.len()];
+    let mut fallback_indices = Vec::new();
+    for (index, ((request, (change_id, record)), slot)) in requests
+        .iter()
+        .zip(standalone)
+        .zip(records.iter_mut())
+        .enumerate()
+    {
+        if *change_id != request.change_id {
+            return Err(LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                "standalone change batch lost request order",
+            ));
+        }
+        if record
+            .as_ref()
+            .is_some_and(|record| authoritative_live_change_matches(request, record))
+        {
+            *slot = record;
+        } else {
+            fallback_indices.push(index);
+        }
+    }
+    let owner_requests = fallback_indices
+        .iter()
+        .map(|&index| {
+            let request = &requests[index];
+            (request.source_commit_id, request.key.clone())
+        })
+        .collect::<Vec<_>>();
+    let fallback = load_commit_delta_change_records_for_owners(store, &owner_requests).await?;
+    for (index, record) in fallback_indices.into_iter().zip(fallback) {
+        records[index] = record;
+    }
+    requests
+        .iter()
+        .zip(records)
+        .map(|(request, record)| {
+            record
+                .filter(|record| authoritative_live_change_matches(request, record))
+                .ok_or_else(|| {
+                    LixError::new(
+                        LixError::CODE_INTERNAL_ERROR,
+                        format!(
+                            "change '{}' has no authoritative live payload at source commit '{}'",
+                            request.change_id, request.source_commit_id
+                        ),
+                    )
+                })
+        })
+        .collect()
+}
+
+fn authoritative_live_change_matches(
+    request: &AuthoritativeLiveChangeRequest,
+    record: &crate::changelog::ChangeRecord,
+) -> bool {
+    record.change_id == request.change_id
+        && record.schema_key == request.key.schema_key
+        && record.file_id == request.key.file_id
+        && record.row_pk == request.key.row_pk
+        && record.snapshot.is_some()
+        && record.created_at == request.updated_at
+}
+
 /// Marks one known commit's tracked history as intentionally deferred.
 ///
 /// The marker is staged atomically with the commit header. Its presence keeps

--- a/packages/lix/src/transaction/commit.rs
+++ b/packages/lix/src/transaction/commit.rs
@@ -36,8 +36,8 @@ use crate::tracked_state::{
     TrackedStateContext, TrackedStateDeltaRef, TrackedStateFilter, TrackedStateKey,
     TrackedStateKeyRef, TrackedStateReadColumns, TrackedStateRootMutationRef,
     TrackedStateScanRequest, TrackedStateSingleStringReplacementRef, encode_key_ref,
-    load_commit_delta_change_records_for_owners, load_commit_delta_replay_metadata,
-    stage_addressable_commit_deltas, stage_change_locators,
+    AuthoritativeLiveChangeRequest, load_authoritative_live_change_records,
+    load_commit_delta_replay_metadata, stage_addressable_commit_deltas, stage_change_locators,
     stage_ordered_addressable_commit_deltas,
 };
 use crate::transaction::context::PendingRestoreIntent;
@@ -1770,92 +1770,23 @@ async fn load_selected_change_records(
         // HOT tombstones must carry no payload.
         .filter(|change_ref| !change_ref.deleted)
         .collect::<Vec<_>>();
-	// A sync snapshot persists every live payload in the standalone changelog
-	// plane while its owning commit body may intentionally remain cold. Resolve
-	// that local authority in one batch before touching physical commit owners;
-	// probing the owners first turns one checkpoint into a history hydration per
-	// source commit even though every selected payload is already present.
-	//
-	// A single source change can materialize more than one semantic identity.
-	// Only accept the standalone record when it exactly matches this selected
-	// identity; identity-specific rows continue through their physical owner.
-	let change_ids = change_refs
+	let requests = change_refs
 		.iter()
-		.map(|change_ref| change_ref.change_id)
-		.collect::<Vec<_>>();
-	let standalone = ChangelogContext::new()
-		.reader(read)
-		.load_changes(ChangeLoadRequest {
-			change_ids: &change_ids,
+		.map(|change_ref| AuthoritativeLiveChangeRequest {
+			change_id: change_ref.change_id,
+			source_commit_id: change_ref.source_commit_id,
+			key: TrackedStateKey {
+				schema_key: change_ref.schema_key().to_owned(),
+				file_id: change_ref.file_id().map(str::to_owned),
+				row_pk: change_ref.row_pk().clone(),
+			},
+			updated_at: change_ref.updated_at,
 		})
-		.await?;
-	let mut loaded = (0..change_refs.len())
-		.map(|_| None)
-		.collect::<Vec<Option<ChangeRecord>>>();
-	let mut cold_indices = Vec::new();
-	for (index, ((change_ref, (change_id, record)), slot)) in change_refs
-		.iter()
-		.zip(standalone)
-		.zip(loaded.iter_mut())
-		.enumerate()
-	{
-		if *change_id != change_ref.change_id {
-			return Err(LixError::new(
-				LixError::CODE_INTERNAL_ERROR,
-				"standalone selected change batch lost request order",
-			));
-		}
-		if record.as_ref().is_some_and(|record| {
-			selected_change_record_matches(*change_ref, record)
-		}) {
-			*slot = record;
-		} else {
-			cold_indices.push(index);
-		}
-	}
-	let requests = cold_indices
-        .iter()
-		.map(|&index| {
-			let change_ref = change_refs[index];
-            (
-                change_ref.source_commit_id,
-                TrackedStateKey {
-                    schema_key: change_ref.schema_key().to_owned(),
-                    file_id: change_ref.file_id().map(str::to_owned),
-                    row_pk: change_ref.row_pk().clone(),
-                },
-            )
-        })
-        .collect::<Vec<_>>();
-	let cold = load_commit_delta_change_records_for_owners(read, &requests).await?;
-	for (index, record) in cold_indices.into_iter().zip(cold) {
-		loaded[index] = record;
-	}
+		.collect::<Vec<_>>();
+	let loaded = load_authoritative_live_change_records(read, &requests).await?;
 
     let mut records = HashMap::new();
     for (change_ref, record) in change_refs.into_iter().zip(loaded) {
-        let Some(record) = record else {
-            return Err(LixError::new(
-                LixError::CODE_INTERNAL_ERROR,
-                format!(
-                    "selected change '{}' for ({:?}, {:?}, {:?}) has no authoritative payload at source commit '{}'",
-                    change_ref.change_id,
-                    change_ref.schema_key(),
-                    change_ref.file_id(),
-                    change_ref.row_pk(),
-                    change_ref.source_commit_id
-                ),
-            ));
-        };
-		if !selected_change_record_matches(change_ref, &record) {
-            return Err(LixError::new(
-                LixError::CODE_INTERNAL_ERROR,
-                format!(
-                    "selected change '{}' does not match its authoritative source payload",
-                    change_ref.change_id
-                ),
-            ));
-        }
         let key = selected_change_key(change_ref);
         if let Some(existing) = records.insert(key, record.clone())
             && existing != record
@@ -1870,18 +1801,6 @@ async fn load_selected_change_records(
         }
     }
     Ok(records)
-}
-
-fn selected_change_record_matches(
-	change_ref: StagedCommitChangeRef<'_>,
-	record: &ChangeRecord,
-) -> bool {
-	record.change_id == change_ref.change_id
-		&& record.schema_key == change_ref.schema_key()
-		&& record.file_id.as_deref() == change_ref.file_id()
-		&& record.row_pk == *change_ref.row_pk()
-		&& record.snapshot.is_none() == change_ref.deleted
-		&& record.created_at == change_ref.updated_at
 }
 
 fn materialize_selected_change_payloads(
@@ -4625,6 +4544,9 @@ async fn stage_tracked_head(
                     parent_generation,
                     root.commit_id,
                     &deltas,
+                    parent_control
+                        .and_then(|control| control.working_diff_checkpoint_commit_id)
+                        .expect("partial checkpoint requires the previous working-diff epoch"),
                     partial_checkpoint_commit_id,
                     &mut coverage,
                 )


### PR DESCRIPTION
## Summary

- resolve ambiguous packed live/live working-diff payloads from local changelog authority with exact-owner fallback instead of replaying commit history
- use clean HOT rows as checkpoint before-images when a newer packed base overlays them
- preserve the previous working-diff epoch while rebasing unselected rows after restarted partial checkpoints
- centralize authoritative live-payload resolution for working diff and selected checkpoint changes

## Verification

- `cargo fmt --all -- --check`
- `cargo check -p lix --lib`
- `cargo test -p lix --lib sync::simulation_tests:: -- --nocapture` (13 passed)
- `cargo test -p lix --lib working_diff -- --nocapture` (32 passed)
- `cargo test -p lix --lib` (2875 passed, 26 ignored)

No public Lix API changes.