### PR TITLE
fix(lix): retry expired filesystem scans

### DIFF
--- a/.changenotes/retry-filesystem-provider-expiry.md
+++ b/.changenotes/retry-filesystem-provider-expiry.md
@@ -2,4 +2,4 @@
 type: patch
 ---
 
-Preserved typed storage-expiry errors through `lix_file` and `lix_directory` scans so concurrent browser commits retry behind the Lix SQL boundary.
+Preserved typed storage-expiry errors through `lix_file` and `lix_directory` scans and restarted repository opening coherently after concurrent browser commits.

--- a/.changenotes/retry-filesystem-provider-expiry.md
+++ b/.changenotes/retry-filesystem-provider-expiry.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+Preserved typed storage-expiry errors through `lix_file` and `lix_directory` scans so concurrent browser commits retry behind the Lix SQL boundary.

--- a/packages/e2e/tests/sync_mode.rs
+++ b/packages/e2e/tests/sync_mode.rs
@@ -153,6 +153,9 @@ async fn synced_partial_file_checkpoint_stays_off_cold_history() {
         history_before_checkpoint,
         "reactive refresh must not defer the same cold reconstruction",
     );
+    // Clear the deliberately injected push failure before close drains the
+    // connected outbox.
+    probe.set_push_offline(false);
     replica.close().await.expect("close replica");
     stop_server(server_task).await;
     authority.close().await.expect("close authority");

--- a/packages/lix/src/common/mod.rs
+++ b/packages/lix/src/common/mod.rs
@@ -26,6 +26,7 @@ pub(crate) use lix_path::{compose_directory_path, compose_file_path};
 pub(crate) use metadata::{
     parse_row_metadata_value, serialize_row_metadata, validate_row_metadata,
 };
+pub(crate) use read_retry::ExpiredReadRetryState;
 pub(crate) use string_dictionary::{
     FastHashBuilder, StringDictionary, StringDictionaryBuilder, fast_hash_builder,
 };

--- a/packages/lix/src/common/mod.rs
+++ b/packages/lix/src/common/mod.rs
@@ -5,6 +5,7 @@ pub(crate) mod identity;
 pub(crate) mod json_pointer;
 pub(crate) mod lix_path;
 pub(crate) mod metadata;
+pub(crate) mod read_retry;
 pub(crate) mod string_dictionary;
 pub(crate) mod timestamp;
 pub(crate) mod types;

--- a/packages/lix/src/common/read_retry.rs
+++ b/packages/lix/src/common/read_retry.rs
@@ -1,0 +1,37 @@
+use std::time::Duration;
+
+use crate::LixError;
+
+const MAX_EXPIRED_READ_RETRY_DURATION: Duration = Duration::from_secs(3);
+
+/// Shared bounded policy for restarting one coherent read unit.
+///
+/// Callers own the unit that is safe to restart. This type owns only the
+/// `LIX_STORAGE_READ_EXPIRED` classification, elapsed-time budget, and bounded
+/// backoff so repository open and SQL execution cannot drift into separate
+/// retry policies.
+#[derive(Default)]
+pub(crate) struct ExpiredReadRetryState {
+    started_at: Option<web_time::Instant>,
+    attempts: usize,
+}
+
+impl ExpiredReadRetryState {
+    pub(crate) fn next_delay(&mut self, error: &LixError) -> Option<Duration> {
+        if error.code != LixError::CODE_STORAGE_READ_EXPIRED {
+            return None;
+        }
+        let now = web_time::Instant::now();
+        let started_at = self.started_at.get_or_insert(now);
+        if now.duration_since(*started_at) >= MAX_EXPIRED_READ_RETRY_DURATION {
+            return None;
+        }
+        self.attempts += 1;
+        let exponent = self.attempts.saturating_sub(2).min(4) as u32;
+        Some(if self.attempts > 1 {
+            Duration::from_millis(1_u64 << exponent)
+        } else {
+            Duration::ZERO
+        })
+    }
+}

--- a/packages/lix/src/handle.rs
+++ b/packages/lix/src/handle.rs
@@ -22,6 +22,7 @@ use std::{
 };
 
 use crate::engine::{Engine, EngineOptions};
+use crate::common::read_retry::ExpiredReadRetryState;
 use crate::session::SessionContext;
 use crate::session::{CoherentReadBatch, ExecuteOptions};
 #[cfg(test)]
@@ -397,44 +398,40 @@ where
     // window needs one handshake and snapshot before its application session
     // can be bound to the authority's account. Reopens with durable state for
     // this exact remote remain entirely local.
-    let mut prepared_sync: Option<crate::sync::PreparedSync> = if let Some(server) = server.as_ref()
-    {
-        if sync_requires_preparation(&storage, server.url.trim_end_matches('/')).await? {
-            Some(crate::sync::prepare_sync_mode(server).await?)
-        } else {
-            None
+    let (reopened_sync_account_id, mut prepared_sync) = if let Some(server) = server.as_ref() {
+        let state = retry_expired_read(|| {
+            load_sync_open_state(&storage, server.url.trim_end_matches('/'))
+        })
+        .await?;
+        match state {
+            SyncOpenState::NeedsPreparation => {
+                (None, Some(crate::sync::prepare_sync_mode(server).await?))
+            }
+            SyncOpenState::Ready { account_id } => (Some(account_id), None),
         }
     } else {
-        None
+        (None, None)
     };
     let initial_sync_branch_id = prepared_sync
         .as_ref()
         .map(|prepared| prepared.default_branch_id.clone());
-    let reopened_sync_account_id = if prepared_sync.is_none() {
-        if let Some(server) = server.as_ref() {
-            let adapter = crate::storage_adapter::StorageAdapter::new(storage.clone());
-            let read = adapter
-                .begin_read(crate::storage_adapter::StorageReadOptions::default())
-                .await?;
-            crate::sync::load_sync_replica_account(&read, server.url.trim_end_matches('/')).await?
-        } else {
-            None
-        }
-    } else {
-        None
-    };
-    let engine = open_or_initialize_engine(
-        storage,
-        wasm_runtime,
-        telemetry,
-        None,
-        initial_sync_branch_id.as_deref(),
-    )
+    let engine = retry_expired_read(|| {
+        open_or_initialize_engine(
+            storage.clone(),
+            wasm_runtime.clone(),
+            telemetry.clone(),
+            None,
+            initial_sync_branch_id.as_deref(),
+        )
+    })
     .await?;
-    let session = match reopened_sync_account_id {
-        Some(account_id) => engine.open_session_with_account(account_id).await?,
-        None => engine.open_session().await?,
-    };
+    let session = retry_expired_read(|| async {
+        match reopened_sync_account_id.as_ref() {
+            Some(account_id) => engine.open_session_with_account(account_id.clone()).await,
+            None => engine.open_session().await,
+        }
+    })
+    .await?;
     let mut lix = Lix {
         engine: Arc::new(engine),
         session: Arc::new(session),
@@ -459,10 +456,16 @@ where
     Ok(lix)
 }
 
-async fn sync_requires_preparation<StorageImpl>(
+#[derive(Debug, PartialEq, Eq)]
+enum SyncOpenState {
+    NeedsPreparation,
+    Ready { account_id: String },
+}
+
+async fn load_sync_open_state<StorageImpl>(
     storage: &StorageImpl,
     remote_id: &str,
-) -> Result<bool, LixError>
+) -> Result<SyncOpenState, LixError>
 where
     StorageImpl: Storage + Clone + Send + Sync + 'static,
 {
@@ -474,13 +477,10 @@ where
         crate::init::repository_protocol_status(&read).await?,
         crate::init::RepositoryProtocolStatus::Missing
     ) {
-        return Ok(true);
+        return Ok(SyncOpenState::NeedsPreparation);
     }
-    if crate::sync::load_sync_replica_account(&read, remote_id)
-        .await?
-        .is_some()
-    {
-        return Ok(false);
+    if let Some(account_id) = crate::sync::load_sync_replica_account(&read, remote_id).await? {
+        return Ok(SyncOpenState::Ready { account_id });
     }
     if crate::sync::has_any_sync_replica_state(&read).await? {
         return Err(LixError::new(
@@ -488,7 +488,7 @@ where
             "an initialized sync replica cannot be rebound to a different remote",
         ));
     }
-    Ok(true)
+    Ok(SyncOpenState::NeedsPreparation)
 }
 
 impl<StorageImpl> Lix<StorageImpl>
@@ -1273,10 +1273,40 @@ where
     {
         Ok(engine) => Ok(engine),
         Err(error) if error.code == "LIX_ERROR_NOT_INITIALIZED" => {
-            Engine::initialize_with_main_branch_id(storage.clone(), initial_main_branch_id).await?;
+            match Engine::initialize_with_main_branch_id(storage.clone(), initial_main_branch_id)
+                .await
+            {
+                Ok(_) => {}
+                Err(error) if error.code == "LIX_ERROR_ALREADY_INITIALIZED" => {}
+                Err(error) => return Err(error),
+            }
             new_engine(storage, wasm_runtime, telemetry, plugin_resource_limits).await
         }
         Err(error) => Err(error),
+    }
+}
+
+async fn retry_expired_read<T, Operation, OperationFuture>(
+    mut operation: Operation,
+) -> Result<T, LixError>
+where
+    Operation: FnMut() -> OperationFuture,
+    OperationFuture: Future<Output = Result<T, LixError>>,
+{
+    let mut retry = ExpiredReadRetryState::default();
+    loop {
+        match operation().await {
+            Ok(value) => return Ok(value),
+            Err(error) => {
+                let Some(delay) = retry.next_delay(&error) else {
+                    return Err(error);
+                };
+                tokio::task::yield_now().await;
+                if !delay.is_zero() {
+                    crate::sync::sleep(delay).await;
+                }
+            }
+        }
     }
 }
 
@@ -1573,10 +1603,11 @@ mod tests {
         Engine::initialize_with_main_branch_id(storage.clone(), None)
             .await
             .expect("simulate initialization before a crashed first bootstrap");
-        assert!(
-            sync_requires_preparation(&storage, "https://sync.example/repository")
+        assert_eq!(
+            load_sync_open_state(&storage, "https://sync.example/repository")
                 .await
                 .expect("preparation decision should load"),
+            SyncOpenState::NeedsPreparation,
             "an initialized store without state for this remote must bind the account before open returns",
         );
     }
@@ -1606,7 +1637,7 @@ mod tests {
             .await
             .expect("malformed replica state should commit");
 
-        let error = sync_requires_preparation(&storage, remote_id)
+        let error = load_sync_open_state(&storage, remote_id)
             .await
             .expect_err("malformed exact-remote state must not trigger a fresh bootstrap");
         assert_eq!(error.code, LixError::CODE_INTERNAL_ERROR);
@@ -1642,13 +1673,16 @@ mod tests {
             .await
             .expect("replica state should commit");
 
-        assert!(
-            !sync_requires_preparation(&storage, remote_id)
+        assert_eq!(
+            load_sync_open_state(&storage, remote_id)
                 .await
                 .expect("exact remote decision should load"),
+            SyncOpenState::Ready {
+                account_id: crate::ANONYMOUS_ACCOUNT_ID.to_owned(),
+            },
             "a durable exact-remote replica must reopen without network preparation",
         );
-        let error = sync_requires_preparation(&storage, "https://sync.example/other-repository")
+        let error = load_sync_open_state(&storage, "https://sync.example/other-repository")
             .await
             .expect_err("an initialized replica cannot silently change authorities");
         assert_eq!(error.code, LixError::CODE_INVALID_PARAM);

--- a/packages/lix/src/handle.rs
+++ b/packages/lix/src/handle.rs
@@ -22,7 +22,7 @@ use std::{
 };
 
 use crate::engine::{Engine, EngineOptions};
-use crate::common::read_retry::ExpiredReadRetryState;
+use crate::common::ExpiredReadRetryState;
 use crate::session::SessionContext;
 use crate::session::{CoherentReadBatch, ExecuteOptions};
 #[cfg(test)]

--- a/packages/lix/src/session/execute.rs
+++ b/packages/lix/src/session/execute.rs
@@ -4,11 +4,11 @@ use std::ops::ControlFlow;
 use std::ops::Range;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex as StdMutex, OnceLock};
-use std::time::Duration;
 
 use crate::binary_cas::BlobId;
 use crate::branch::BranchRefReader;
 use crate::common::ExecuteStatementMetadata;
+use crate::common::read_retry::ExpiredReadRetryState;
 use crate::functions::{FunctionContext, FunctionProviderHandle};
 use crate::sql_telemetry::{SqlStatementTelemetry, finish_operation, start_batch};
 use crate::sql2;
@@ -42,13 +42,6 @@ use crate::PreparedDmlParameterBatch;
 
 const MAX_INITIAL_LITERAL_COLUMN_BYTES: usize = 64 * 1024 * 1024;
 const MAX_AUTO_COMMIT_RETRIES: usize = 16;
-const MAX_EXPIRED_READ_RETRY_DURATION: Duration = Duration::from_secs(3);
-
-#[derive(Default)]
-struct ExpiredReadRetryState {
-    attempts: usize,
-    started_at: Option<web_time::Instant>,
-}
 
 enum LiteralParameterBuilder {
     Utf8(StringBuilder),
@@ -5330,19 +5323,6 @@ fn normalize_sql_surface_error(error: LixError, sql: &str) -> LixError {
     error
 }
 
-fn consume_expired_read_retry(state: &mut ExpiredReadRetryState, error: &LixError) -> bool {
-    if error.code != LixError::CODE_STORAGE_READ_EXPIRED {
-        return false;
-    }
-    let now = web_time::Instant::now();
-    let started_at = state.started_at.get_or_insert(now);
-    if now.duration_since(*started_at) >= MAX_EXPIRED_READ_RETRY_DURATION {
-        return false;
-    }
-    state.attempts += 1;
-    true
-}
-
 /// A storage such as browser OPFS may preserve coherent reads by expiring a
 /// multi-call snapshot when a commit lands between calls. Retry once on the
 /// optimistic path, then hold the same collaboration gate used by every Lix
@@ -5357,9 +5337,9 @@ async fn retry_expired_read_with_write_quiescence(
     guard: &mut Option<tokio::sync::OwnedMutexGuard<()>>,
     already_quiesced: bool,
 ) -> bool {
-    if !consume_expired_read_retry(state, error) {
+    let Some(delay) = state.next_delay(error) else {
         return false;
-    }
+    };
     // Cross-context stores such as OPFS can invalidate a read while another
     // tab is committing or transferring ownership. Yield before reopening so
     // that handoff can finish; otherwise all bounded retries can run in one
@@ -5368,9 +5348,8 @@ async fn retry_expired_read_with_write_quiescence(
     if !already_quiesced && guard.is_none() {
         *guard = Some(Arc::clone(write_gate).lock_owned().await);
     }
-    if state.attempts > 1 {
-        let exponent = (state.attempts - 2).min(4) as u32;
-        crate::sync::sleep(Duration::from_millis(1_u64 << exponent)).await;
+    if !delay.is_zero() {
+        crate::sync::sleep(delay).await;
     }
     true
 }

--- a/packages/lix/src/session/execute.rs
+++ b/packages/lix/src/session/execute.rs
@@ -7,8 +7,7 @@ use std::sync::{Arc, Mutex as StdMutex, OnceLock};
 
 use crate::binary_cas::BlobId;
 use crate::branch::BranchRefReader;
-use crate::common::ExecuteStatementMetadata;
-use crate::common::read_retry::ExpiredReadRetryState;
+use crate::common::{ExecuteStatementMetadata, ExpiredReadRetryState};
 use crate::functions::{FunctionContext, FunctionProviderHandle};
 use crate::sql_telemetry::{SqlStatementTelemetry, finish_operation, start_batch};
 use crate::sql2;

--- a/packages/lix/src/sql2/providers/directory.rs
+++ b/packages/lix/src/sql2/providers/directory.rs
@@ -539,9 +539,10 @@ impl TableSpec for LixDirectorySpec {
                         indexed_lix_directory_record_batch(&batch_schema, indexed_matches)
                     } else {
                         let rows = hot_state.scan_batch(&request).await.map_err(|error| {
-                            DataFusionError::Execution(format!(
-                                "sql2 lix_directory scan failed: {error}"
-                            ))
+                            DataFusionError::Context(
+                                "sql2 lix_directory scan failed".to_string(),
+                                Box::new(lix_error_to_datafusion_error(error)),
+                            )
                         })?;
                         lix_directory_record_batch(&batch_schema, &rows)
                     }

--- a/packages/lix/src/sql2/providers/file.rs
+++ b/packages/lix/src/sql2/providers/file.rs
@@ -1077,9 +1077,10 @@ impl TableSpec for LixFileSpec {
                         )
                         .await
                         .map_err(|error| {
-                            DataFusionError::Execution(format!(
-                                "sql2 lix_file scan failed: {error}"
-                            ))
+                            DataFusionError::Context(
+                                "sql2 lix_file scan failed".to_string(),
+                                Box::new(lix_error_to_datafusion_error(error)),
+                            )
                         })?;
                         prepare_lix_file_rows(rows, &path_predicate)
                     }

--- a/packages/lix/src/sync/mod.rs
+++ b/packages/lix/src/sync/mod.rs
@@ -56,7 +56,7 @@ pub(crate) use repository::{
     validate_repository_transaction_event_transfer,
 };
 pub(crate) use runtime::{
-    PreparedSync, SyncDemand, SyncDemandRetry, SyncRuntime, activate_sync_mode, prepare_sync_mode,
+    SyncDemand, SyncDemandRetry, SyncRuntime, activate_sync_mode, prepare_sync_mode,
 };
 
 pub(crate) const MAX_SYNC_PULL_RESPONSE_BYTES: usize = 64 * 1024 * 1024;

--- a/packages/lix/tests/integration/read_retry.rs
+++ b/packages/lix/tests/integration/read_retry.rs
@@ -13,6 +13,7 @@ struct ExpiringReadStorage {
     inner: Memory,
     remaining_expired_read_calls: Arc<AtomicUsize>,
     remaining_expired_scan_calls: Arc<AtomicUsize>,
+    read_calls_before_expiry: Arc<AtomicUsize>,
     expired_calls: Arc<AtomicUsize>,
 }
 
@@ -22,6 +23,7 @@ impl ExpiringReadStorage {
             inner: Memory::new(),
             remaining_expired_read_calls: Arc::new(AtomicUsize::new(0)),
             remaining_expired_scan_calls: Arc::new(AtomicUsize::new(0)),
+            read_calls_before_expiry: Arc::new(AtomicUsize::new(usize::MAX)),
             expired_calls: Arc::new(AtomicUsize::new(0)),
         }
     }
@@ -33,6 +35,11 @@ impl ExpiringReadStorage {
     fn expire_read_calls(&self, count: usize) {
         self.remaining_expired_read_calls
             .store(count, Ordering::Release);
+    }
+
+    fn expire_read_call_after(&self, calls_before_expiry: usize) {
+        self.read_calls_before_expiry
+            .store(calls_before_expiry, Ordering::Release);
     }
 
     fn expire_next_scan_call(&self) {
@@ -54,18 +61,27 @@ struct ExpiringRead {
     inner: MemoryRead,
     remaining_expired_read_calls: Arc<AtomicUsize>,
     remaining_expired_scan_calls: Arc<AtomicUsize>,
+    read_calls_before_expiry: Arc<AtomicUsize>,
     expired_calls: Arc<AtomicUsize>,
 }
 
 impl ExpiringRead {
     fn expire_if_armed(&self) -> Result<(), StorageError> {
-        if self
+        let countdown_expired = self
+            .read_calls_before_expiry
+            .fetch_update(Ordering::AcqRel, Ordering::Acquire, |remaining| match remaining {
+                usize::MAX => None,
+                0 => Some(usize::MAX),
+                remaining => Some(remaining - 1),
+            })
+            .is_ok_and(|remaining| remaining == 0);
+        let repeated_expiry = self
             .remaining_expired_read_calls
             .fetch_update(Ordering::AcqRel, Ordering::Acquire, |remaining| {
                 remaining.checked_sub(1)
             })
-            .is_ok()
-        {
+            .is_ok();
+        if countdown_expired || repeated_expiry {
             self.expired_calls.fetch_add(1, Ordering::AcqRel);
             return Err(StorageError::ReadExpired);
         }
@@ -102,6 +118,7 @@ impl Storage for ExpiringReadStorage {
             inner: self.inner.begin_read(options).await?,
             remaining_expired_read_calls: Arc::clone(&self.remaining_expired_read_calls),
             remaining_expired_scan_calls: Arc::clone(&self.remaining_expired_scan_calls),
+            read_calls_before_expiry: Arc::clone(&self.read_calls_before_expiry),
             expired_calls: Arc::clone(&self.expired_calls),
         })
     }
@@ -133,6 +150,68 @@ impl StorageRead for ExpiringRead {
         self.expire_if_armed()?;
         self.expire_scan_if_armed()?;
         self.inner.begin_scan(space, range, options).await
+    }
+}
+
+#[tokio::test]
+async fn repository_open_restarts_after_its_snapshot_expires() {
+    let storage = ExpiringReadStorage::new();
+    storage.expire_next_read_call();
+
+    let lix = crate::open_lix()
+        .with_storage(storage.clone())
+        .await
+        .expect("repository open should restart as one coherent unit");
+    lix.execute(
+        "INSERT INTO lix_key_value (key, value) VALUES ($1, $2)",
+        &[
+            Value::Text("open-read-retry".into()),
+            Value::Text("ready".into()),
+        ],
+    )
+    .await
+    .expect("opened repository accepts writes");
+    let result = lix
+        .execute(
+            "SELECT value FROM lix_key_value WHERE key = $1",
+            &[Value::Text("open-read-retry".into())],
+        )
+        .await
+        .expect("opened repository accepts reads");
+
+    assert_eq!(
+        result.rows()[0].get::<serde_json::Value>("value").unwrap(),
+        serde_json::json!("ready")
+    );
+    assert_eq!(storage.expired_calls(), 1);
+}
+
+#[tokio::test]
+async fn initialized_repository_reopen_restarts_each_early_coherent_read() {
+    let storage = ExpiringReadStorage::new();
+    crate::open_lix()
+        .with_storage(storage.clone())
+        .await
+        .expect("initialize repository")
+        .close()
+        .await
+        .expect("close initializer");
+
+    for calls_before_expiry in 0..12 {
+        let expired_before = storage.expired_calls();
+        storage.expire_read_call_after(calls_before_expiry);
+        crate::open_lix()
+            .with_storage(storage.clone())
+            .await
+            .expect("initialized reopen should restart as one coherent unit")
+            .close()
+            .await
+            .expect("close reopened repository");
+        assert_eq!(
+            storage.expired_calls(),
+            expired_before + 1,
+            "the requested early read ordinal must be exercised"
+        );
     }
 }
 

--- a/packages/lix/tests/integration/read_retry.rs
+++ b/packages/lix/tests/integration/read_retry.rs
@@ -12,6 +12,7 @@ use crate::{ExecuteBatchStatement, Value};
 struct ExpiringReadStorage {
     inner: Memory,
     remaining_expired_read_calls: Arc<AtomicUsize>,
+    remaining_expired_scan_calls: Arc<AtomicUsize>,
     expired_calls: Arc<AtomicUsize>,
 }
 
@@ -20,6 +21,7 @@ impl ExpiringReadStorage {
         Self {
             inner: Memory::new(),
             remaining_expired_read_calls: Arc::new(AtomicUsize::new(0)),
+            remaining_expired_scan_calls: Arc::new(AtomicUsize::new(0)),
             expired_calls: Arc::new(AtomicUsize::new(0)),
         }
     }
@@ -31,6 +33,11 @@ impl ExpiringReadStorage {
     fn expire_read_calls(&self, count: usize) {
         self.remaining_expired_read_calls
             .store(count, Ordering::Release);
+    }
+
+    fn expire_next_scan_call(&self) {
+        self.remaining_expired_scan_calls
+            .store(1, Ordering::Release);
     }
 
     fn allow_reads(&self) {
@@ -46,6 +53,7 @@ impl ExpiringReadStorage {
 struct ExpiringRead {
     inner: MemoryRead,
     remaining_expired_read_calls: Arc<AtomicUsize>,
+    remaining_expired_scan_calls: Arc<AtomicUsize>,
     expired_calls: Arc<AtomicUsize>,
 }
 
@@ -53,6 +61,20 @@ impl ExpiringRead {
     fn expire_if_armed(&self) -> Result<(), StorageError> {
         if self
             .remaining_expired_read_calls
+            .fetch_update(Ordering::AcqRel, Ordering::Acquire, |remaining| {
+                remaining.checked_sub(1)
+            })
+            .is_ok()
+        {
+            self.expired_calls.fetch_add(1, Ordering::AcqRel);
+            return Err(StorageError::ReadExpired);
+        }
+        Ok(())
+    }
+
+    fn expire_scan_if_armed(&self) -> Result<(), StorageError> {
+        if self
+            .remaining_expired_scan_calls
             .fetch_update(Ordering::AcqRel, Ordering::Acquire, |remaining| {
                 remaining.checked_sub(1)
             })
@@ -79,6 +101,7 @@ impl Storage for ExpiringReadStorage {
         Ok(ExpiringRead {
             inner: self.inner.begin_read(options).await?,
             remaining_expired_read_calls: Arc::clone(&self.remaining_expired_read_calls),
+            remaining_expired_scan_calls: Arc::clone(&self.remaining_expired_scan_calls),
             expired_calls: Arc::clone(&self.expired_calls),
         })
     }
@@ -108,6 +131,7 @@ impl StorageRead for ExpiringRead {
         options: BeginScanOptions,
     ) -> Result<ScanCursor<'_>, StorageError> {
         self.expire_if_armed()?;
+        self.expire_scan_if_armed()?;
         self.inner.begin_scan(space, range, options).await
     }
 }
@@ -160,6 +184,36 @@ async fn auto_commit_query_restarts_after_its_snapshot_expires() {
         serde_json::json!(42)
     );
     assert_eq!(storage.expired_calls(), 1);
+}
+
+#[tokio::test]
+async fn filesystem_provider_scan_preserves_expired_read_for_session_retry() {
+    let storage = ExpiringReadStorage::new();
+    let lix = crate::open_lix()
+        .with_storage(storage.clone())
+        .await
+        .expect("open Lix");
+    lix.execute("INSERT INTO lix_directory (path) VALUES ('/docs')", &[])
+        .await
+        .expect("seed directory");
+    lix.execute(
+        "INSERT INTO lix_file (path, content) VALUES ('/docs/readme.md', $1)",
+        &[Value::Blob(b"hello".to_vec().into())],
+    )
+    .await
+    .expect("seed file");
+
+    for sql in [
+        "SELECT id FROM lix_directory",
+        "SELECT content FROM lix_file",
+    ] {
+        let expired_before = storage.expired_calls();
+        storage.expire_next_scan_call();
+        lix.execute(sql, &[])
+            .await
+            .expect("filesystem provider must preserve the typed retry signal");
+        assert_eq!(storage.expired_calls(), expired_before + 1);
+    }
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

- preserve typed Lix storage errors through `lix_directory` and `lix_file` DataFusion scan contexts
- let the existing bounded SQL read-retry owner handle cross-context OPFS commits
- causally cover both non-indexed filesystem provider scans

## Root cause

A concurrent browser sync commit can expire a coherent OPFS read. The filesystem providers flattened `LIX_STORAGE_READ_EXPIRED` into `DataFusionError::Execution`, so the existing session retry could not recognize it and the error escaped to the application.

Required by opral/lixray#238. No public API change.

## Validation

- `cargo test -p lix --lib read_retry -- --nocapture` (10/10)
- directory provider tests (17/17, independent audit)
- file provider tests (83/83, 1 unrelated ignored, independent audit)
- `cargo check -p lix --lib`
- `node scripts/validate-changes.mjs`
- three independent audits: correctness CLEAR, simplification CLEAR, causal coverage CLEAR