### PR TITLE
Classify public SQL surfaces

### DIFF
--- a/.changenotes/classify-sql-surfaces.md
+++ b/.changenotes/classify-sql-surfaces.md
@@ -1,0 +1,7 @@
+---
+type: minor
+---
+
+Added `information_schema.lix_surfaces` for discovering whether each public SQL surface is a relation, table function, command sink, or scalar function, including whether a relation is a base or view.
+
+The catalog also reports read and write capabilities, includes `lix_diff` and `lix_restore`, and classifies composed file, directory, branch, and change relations as views.

--- a/.changenotes/restore-sql.md
+++ b/.changenotes/restore-sql.md
@@ -2,6 +2,6 @@
 type: minor
 ---
 
-Added `SELECT lix_restore(commit_id)` to move the active branch head to an ancestor commit without creating a new commit.
+Added the `lix_restore` command sink to move the active branch head to an ancestor commit without creating a new commit.
 
-Restore is available through the existing `execute()` API on local and remote sessions. Orphaned commits remain eligible for ordinary garbage collection, while checkpoint rows are retained.
+Call it with `INSERT INTO lix_restore (commit_id) VALUES (...)`. Restore is available through the existing `execute()` API on local and remote sessions. Orphaned commits remain eligible for ordinary garbage collection, while checkpoint rows are retained.

--- a/docs/sql-functions.md
+++ b/docs/sql-functions.md
@@ -12,7 +12,6 @@ operators; there are no public `lix_json_*` functions.
 | `lix_active_account_id()` | text | Active SQL-session account. |
 | `lix_active_branch_id()` | text | Active branch. |
 | `lix_active_branch_commit_id()` | text | Active branch head pinned for the statement. |
-| `lix_restore(commit_id)` | text | Move the active branch head to an ancestor commit. |
 | `uuidv7()` | uuid | Generate a UUIDv7 value. |
 | `CURRENT_TIMESTAMP` | timestamptz | Transaction-start instant at microsecond precision. |
 
@@ -66,15 +65,16 @@ FROM lix_commit_ancestry($1)
 ORDER BY depth, commit_id;
 ```
 
-`lix_restore` is a command-shaped mutation and must be the statement's only
-projection:
+`lix_restore` is an insert-only command sink:
 
 ```sql
-SELECT lix_restore($1);
+INSERT INTO lix_restore (commit_id)
+VALUES ($1)
+RETURNING commit_id;
 ```
 
 The commit must exist and be an ancestor of the active branch head. The
-function returns the restored commit ID. It creates no commit, leaves other
+command returns the restored commit ID. It creates no commit, leaves other
 branches untouched, preserves branch-local untracked rows, and starts a fresh
 undo interval. A restore cannot be combined with another write in the same
 transaction and must be the final statement before commit or rollback.

--- a/docs/surfaces.md
+++ b/docs/surfaces.md
@@ -72,6 +72,43 @@ History functions are discoverable through
 and result columns. They do not appear in `information_schema.tables` or
 `information_schema.columns`.
 
+Query `information_schema.lix_surfaces` to distinguish the complete Lix-owned
+public SQL contract without relying on naming conventions. `surface_class` is
+one of `RELATION`, `TABLE_FUNCTION`, `COMMAND_SINK`, or `SCALAR_FUNCTION`;
+`relation_kind` distinguishes `BASE` from `VIEW`. Registered schema relations
+are bases, while the composed `lix_file`, `lix_directory`, `lix_branch`, and
+`lix_change` projections are views. The capability columns report which SQL
+operations each surface accepts:
+
+```sql
+SELECT surface_name, surface_class, relation_kind, can_read, can_insert
+FROM information_schema.lix_surfaces
+ORDER BY surface_name;
+```
+
+The fixed Lix surfaces are classified as follows. Every additional registered
+schema contributes another `RELATION` / `BASE` surface.
+
+| Class | Fixed surfaces |
+| --- | --- |
+| Relation / base | `lix_account`, `lix_checkpoint`, `lix_commit`, `lix_commit_edge`, `lix_key_value`, `lix_registered_schema` |
+| Relation / view | `lix_branch`, `lix_change`, `lix_directory`, `lix_file` |
+| Table function | `lix_commit_ancestry`, `lix_diff`, `lix_history`, `lix_working_diff` |
+| Command sink | `lix_apply`, `lix_create_checkpoint`, `lix_restore`, `lix_revert` |
+| Scalar function | `lix_active_account_id`, `lix_active_branch_commit_id`, `lix_active_branch_id`, `uuidv7` |
+
+Standard SQL value expressions such as `CURRENT_TIMESTAMP` are supported SQL
+syntax, not Lix-owned scalar-function surfaces, and are therefore omitted from
+`information_schema.lix_surfaces`.
+
+Classify by SQL shape, not merely by whether data is computed dynamically.
+Unparameterized, table-shaped projections are views. Row producers invoked in
+the `FROM` clause with function syntax are table functions, including the
+zero-argument, active-branch-scoped `lix_working_diff()`. Side-effecting
+operations are command sinks and use `INSERT`; they are not table functions.
+This keeps commands out of relation and function discovery even when a command
+supports `RETURNING`.
+
 JSON-backed columns are SQL `TEXT` and are marked with
 `lix_value_kind = 'JSONB'`. `is_nullable` describes values returned by reads;
 `column_default` and `lix_insert_policy` separately describe whether a write

--- a/packages/js-sdk/src/open-lix.browser.test.ts
+++ b/packages/js-sdk/src/open-lix.browser.test.ts
@@ -154,7 +154,10 @@ test("lix_restore moves the active branch to an ancestor through browser WASM", 
 			["restore-test", "later"],
 		);
 
-		await lix.execute("SELECT lix_restore($1)", [initial]);
+		await lix.execute(
+			"INSERT INTO lix_restore (commit_id) VALUES ($1) RETURNING commit_id",
+			[initial],
+		);
 
 		expect(
 			(

--- a/packages/js-sdk/src/open-lix.test.ts
+++ b/packages/js-sdk/src/open-lix.test.ts
@@ -402,7 +402,10 @@ test("lix_restore moves the active branch to an ancestor through the local worke
 		["restore-test", "later"],
 	);
 
-	await lix.execute("SELECT lix_restore($1)", [initial]);
+	await lix.execute(
+		"INSERT INTO lix_restore (commit_id) VALUES ($1) RETURNING commit_id",
+		[initial],
+	);
 
 	expect(await activeHeadCommitId(lix)).toBe(initial);
 	expect(

--- a/packages/js-sdk/src/remote/client.test.ts
+++ b/packages/js-sdk/src/remote/client.test.ts
@@ -795,9 +795,9 @@ test("remote lix_restore uses the existing execute endpoint", async () => {
 				}
 				if (pathname.endsWith("/execute")) {
 					return Response.json({
-						columns: ["lix_restore"],
+						columns: ["commit_id"],
 						rows: [[{ kind: "text", value: "target-commit-id" }]],
-						rowsAffected: 0,
+						rowsAffected: 1,
 						notices: [],
 					});
 				}
@@ -810,7 +810,10 @@ test("remote lix_restore uses the existing execute endpoint", async () => {
 	});
 
 	await expect(
-		lix.execute("SELECT lix_restore($1)", ["target-commit-id"]),
+		lix.execute(
+			"INSERT INTO lix_restore (commit_id) VALUES ($1) RETURNING commit_id",
+			["target-commit-id"],
+		),
 	).resolves.toBeDefined();
 	const request = requests.find((candidate) =>
 		new URL(candidate.url).pathname.endsWith("/execute"),
@@ -818,7 +821,7 @@ test("remote lix_restore uses the existing execute endpoint", async () => {
 	expect(request?.method).toBe("POST");
 	expect(request?.headers.get("lix-session-id")).toBe("session-1");
 	expect(await request?.json()).toMatchObject({
-		sql: "SELECT lix_restore($1)",
+		sql: "INSERT INTO lix_restore (commit_id) VALUES ($1) RETURNING commit_id",
 		params: [{ kind: "text", value: "target-commit-id" }],
 	});
 

--- a/packages/lix/src/session/execute.rs
+++ b/packages/lix/src/session/execute.rs
@@ -5445,13 +5445,13 @@ mod tests {
 
         let restored = session
             .execute(
-                "SELECT lix_restore($1)",
+                "INSERT INTO lix_restore (commit_id) VALUES ($1) RETURNING commit_id",
                 &[Value::Text(restore_target.clone())],
             )
             .await
             .expect("restore should repair the legacy branch atomically");
         assert_eq!(
-            restored.rows()[0].get::<String>("lix_restore").unwrap(),
+            restored.rows()[0].get::<String>("commit_id").unwrap(),
             restore_target
         );
         let working_diff = session

--- a/packages/lix/src/session/gc.rs
+++ b/packages/lix/src/session/gc.rs
@@ -504,7 +504,10 @@ mod tests {
             CommitId::parse_lix(&commit_d, "restore GC commit D").expect("D commit id parses");
 
         session
-            .execute("SELECT lix_restore($1)", &[Value::Text(commit_c.clone())])
+            .execute(
+                "INSERT INTO lix_restore (commit_id) VALUES ($1)",
+                &[Value::Text(commit_c.clone())],
+            )
             .await
             .expect("restore to C succeeds");
         assert_eq!(head(&engine, &branch_id).await, commit_c);

--- a/packages/lix/src/sql2/bind/public_udf.rs
+++ b/packages/lix/src/sql2/bind/public_udf.rs
@@ -8,6 +8,7 @@ use datafusion::sql::sqlparser::ast::{
 use datafusion::sql::sqlparser::parser::Parser;
 
 use crate::LixError;
+use crate::sql2::catalog::PUBLIC_SCALAR_FUNCTION_NAMES;
 
 #[cfg(test)]
 pub(crate) fn validate_public_udf_calls(sql: &str) -> Result<(), LixError> {
@@ -54,49 +55,9 @@ fn validate_public_function_call(function: &Function) -> Result<(), LixError> {
     let arity = function_arity(&function.args);
 
     match name {
-        "current_timestamp" | "uuidv7" | "lix_active_branch_id" | "lix_active_branch_commit_id" => {
-            expect_exact_arity(name, arity, 0)
-        }
-        "lix_restore" => expect_exact_arity(name, arity, 1),
+        "current_timestamp" => expect_exact_arity(name, arity, 0),
+        name if PUBLIC_SCALAR_FUNCTION_NAMES.contains(&name) => expect_exact_arity(name, arity, 0),
         _ => Ok(()),
-    }
-}
-
-pub(crate) fn statement_has_restore_function(statement: &DataFusionStatement) -> bool {
-    let mut visitor = RestoreFunctionVisitor { found: false };
-    visit_datafusion_statement_for_restore_function(statement, &mut visitor);
-    visitor.found
-}
-
-struct RestoreFunctionVisitor {
-    found: bool,
-}
-
-impl Visitor for RestoreFunctionVisitor {
-    type Break = ();
-
-    fn pre_visit_expr(&mut self, expr: &Expr) -> ControlFlow<Self::Break> {
-        if matches!(expr, Expr::Function(function) if public_lix_function_name(function) == Some("lix_restore"))
-        {
-            self.found = true;
-            return ControlFlow::Break(());
-        }
-        ControlFlow::Continue(())
-    }
-}
-
-fn visit_datafusion_statement_for_restore_function(
-    statement: &DataFusionStatement,
-    visitor: &mut RestoreFunctionVisitor,
-) {
-    match statement {
-        DataFusionStatement::Statement(statement) => {
-            let _ = statement.visit(visitor);
-        }
-        DataFusionStatement::Explain(explain) => {
-            visit_datafusion_statement_for_restore_function(explain.statement.as_ref(), visitor);
-        }
-        _ => {}
     }
 }
 
@@ -189,14 +150,17 @@ fn public_lix_function_name(function: &Function) -> Option<&'static str> {
         ObjectNamePart::Identifier(ident) => ident.value.as_str(),
         ObjectNamePart::Function(_) => return None,
     };
-    match ident.to_ascii_lowercase().as_str() {
-        "current_timestamp" | "__lix_current_timestamp" => Some("current_timestamp"),
-        "uuidv7" => Some("uuidv7"),
-        "lix_active_branch_id" => Some("lix_active_branch_id"),
-        "lix_active_branch_commit_id" => Some("lix_active_branch_commit_id"),
-        "lix_restore" => Some("lix_restore"),
-        _ => None,
+    let normalized = ident.to_ascii_lowercase();
+    if matches!(
+        normalized.as_str(),
+        "current_timestamp" | "__lix_current_timestamp"
+    ) {
+        return Some("current_timestamp");
     }
+    PUBLIC_SCALAR_FUNCTION_NAMES
+        .iter()
+        .copied()
+        .find(|name| *name == normalized)
 }
 
 fn function_arity(args: &FunctionArguments) -> usize {

--- a/packages/lix/src/sql2/bind/read.rs
+++ b/packages/lix/src/sql2/bind/read.rs
@@ -17,9 +17,6 @@ pub(crate) enum BoundStatementRoute {
 pub(crate) fn bind_statement_route(
     statement: &DataFusionStatement,
 ) -> Result<BoundStatementRoute, LixError> {
-    if super::public_udf::statement_has_restore_function(statement) {
-        return Ok(BoundStatementRoute::Write);
-    }
     match super::classify::classify_datafusion_statement(statement) {
         super::classify::SqlStatementKind::Read => Ok(BoundStatementRoute::Read),
         super::classify::SqlStatementKind::Write => Ok(BoundStatementRoute::Write),

--- a/packages/lix/src/sql2/bind/statement.rs
+++ b/packages/lix/src/sql2/bind/statement.rs
@@ -4,9 +4,9 @@ use std::ops::ControlFlow;
 use datafusion::sql::parser::Statement as DataFusionStatement;
 use datafusion::sql::sqlparser::ast::{
     AssignmentTarget, BinaryOperator, CastKind, ConflictTarget, DataType as SqlDataType, Delete,
-    Expr, FromTable, Function, FunctionArg, FunctionArgExpr, FunctionArguments, GroupByExpr,
-    Insert, ObjectName, ObjectNamePart, OnConflictAction, OnInsert, Query, SelectFlavor,
-    SelectItem, SetExpr, Statement as SqlStatement, TableFactor, TableObject, TableWithJoins,
+    Expr, FromTable, Function, FunctionArg, FunctionArgExpr, FunctionArguments, Insert, ObjectName,
+    ObjectNamePart, OnConflictAction, OnInsert, Query, SelectItem, SetExpr,
+    Statement as SqlStatement, TableFactor, TableObject, TableWithJoins,
     UnaryOperator, Update, Value, Visit, Visitor, WildcardAdditionalOptions,
 };
 #[cfg(test)]
@@ -69,7 +69,6 @@ fn bind_sql_statement(
         SqlStatement::Insert(insert) => bind_insert_bound(insert, catalog, active_branch_id),
         SqlStatement::Update(update) => bind_update_bound(update, catalog, active_branch_id),
         SqlStatement::Delete(delete) => bind_delete_bound(delete, catalog, active_branch_id),
-        SqlStatement::Query(query) => bind_restore_bound(query, active_branch_id),
         SqlStatement::Explain { .. } => Err(super::error::unsupported(
             "EXPLAIN statements are not supported by SQL write binding",
         )),
@@ -77,104 +76,6 @@ fn bind_sql_statement(
             "sql2 bound statement pipeline is not wired yet",
         )),
     }
-}
-
-fn bind_restore_bound(query: &Query, active_branch_id: &str) -> Result<BoundWrite, LixError> {
-    if query.with.is_some()
-        || query.order_by.is_some()
-        || query.limit_clause.is_some()
-        || query.fetch.is_some()
-        || !query.locks.is_empty()
-        || query.for_clause.is_some()
-        || query.settings.is_some()
-        || query.format_clause.is_some()
-        || !query.pipe_operators.is_empty()
-    {
-        return Err(restore_shape_error());
-    }
-    let SetExpr::Select(select) = query.body.as_ref() else {
-        return Err(restore_shape_error());
-    };
-    if select.flavor != SelectFlavor::Standard
-        || select.optimizer_hint.is_some()
-        || select.distinct.is_some()
-        || select.select_modifiers.is_some()
-        || select.top.is_some()
-        || select.exclude.is_some()
-        || select.into.is_some()
-        || !select.from.is_empty()
-        || !select.lateral_views.is_empty()
-        || select.selection.is_some()
-        || select.prewhere.is_some()
-        || !select.connect_by.is_empty()
-        || !matches!(&select.group_by, GroupByExpr::Expressions(items, modifiers) if items.is_empty() && modifiers.is_empty())
-        || !select.cluster_by.is_empty()
-        || !select.distribute_by.is_empty()
-        || !select.sort_by.is_empty()
-        || select.having.is_some()
-        || !select.named_window.is_empty()
-        || select.qualify.is_some()
-        || select.value_table_mode.is_some()
-    {
-        return Err(restore_shape_error());
-    }
-    let [projection] = select.projection.as_slice() else {
-        return Err(restore_shape_error());
-    };
-    let SelectItem::UnnamedExpr(expression) = projection else {
-        return Err(restore_shape_error());
-    };
-    let Expr::Function(function) = expression else {
-        return Err(restore_shape_error());
-    };
-    reject_unsupported_function_modifiers(function)?;
-    if !is_unqualified_unquoted_function(function, "lix_restore") {
-        return Err(restore_shape_error());
-    }
-    let args = function_args(&function.args)?;
-    if args.len() != 1 {
-        return Err(LixError::new(
-            LixError::CODE_INVALID_PARAM,
-            "lix_restore requires exactly 1 argument",
-        ));
-    }
-    let mut params = ParamBinder::default();
-    let commit_id = match args[0] {
-        Expr::Value(value) => match &value.value {
-            Value::Placeholder(name) => BoundExpr::Param(params.bind(name)?),
-            Value::SingleQuotedString(value) => {
-                BoundExpr::Literal(BoundLiteral::Text(value.clone()))
-            }
-            _ => {
-                return Err(LixError::new(
-                    LixError::CODE_TYPE_MISMATCH,
-                    "lix_restore commit id must be text",
-                ));
-            }
-        },
-        _ => return Err(restore_shape_error()),
-    };
-    Ok(BoundWrite {
-        target: BoundWriteTarget::Restore { commit_id },
-        op: BoundWriteOp::Update,
-        input: BoundWriteInput::None,
-        predicate: BoundPredicate::True,
-        assignments: Vec::new(),
-        conflict: None,
-        returning: None,
-        params: params.into_map(),
-        branch_scope: active_branch_scope(active_branch_id),
-    })
-}
-
-fn is_unqualified_unquoted_function(function: &Function, expected: &str) -> bool {
-    matches!(function.name.0.as_slice(), [ObjectNamePart::Identifier(ident)] if ident.quote_style.is_none() && ident.value.eq_ignore_ascii_case(expected))
-}
-
-fn restore_shape_error() -> LixError {
-    super::error::unsupported(
-        "lix_restore is a command and must be called as SELECT lix_restore(<commit_id>)",
-    )
 }
 
 pub(super) fn bind_insert_bound(
@@ -252,8 +153,9 @@ pub(super) fn bind_insert_bound(
         &BoundPredicate::True,
         active_branch_id,
     )?;
+    let target = bound_insert_target(&table.surface.kind, &input)?;
     Ok(BoundWrite {
-        target: bound_write_target(&table.surface.kind),
+        target,
         op: BoundWriteOp::Insert,
         input,
         predicate: BoundPredicate::True,
@@ -407,7 +309,10 @@ fn bind_insert_returning(
 
     if !matches!(
         table.surface.kind,
-        PublicSurfaceKind::Revert | PublicSurfaceKind::Apply | PublicSurfaceKind::CreateCheckpoint
+        PublicSurfaceKind::Revert
+            | PublicSurfaceKind::Apply
+            | PublicSurfaceKind::CreateCheckpoint
+            | PublicSurfaceKind::Restore
     ) {
         return bind_returning(table, Some(returning), params, "INSERT");
     }
@@ -419,14 +324,14 @@ fn bind_insert_returning(
             SelectItem::ExprWithAlias { expr, alias } => (expr, normalize_identifier(alias)),
             SelectItem::Wildcard(_) | SelectItem::QualifiedWildcard(_, _) => {
                 return Err(super::error::unsupported(
-                    "diff command INSERT RETURNING only supports commit_id",
+                    "command sink INSERT RETURNING only supports commit_id",
                 ));
             }
         };
         let expr = bind_expr(table, sql_expr, params)?;
         if !matches!(&expr, BoundExpr::Column(column) if column.name == "commit_id") {
             return Err(super::error::unsupported(
-                "diff command INSERT RETURNING only supports commit_id",
+                "command sink INSERT RETURNING only supports commit_id",
             ));
         }
         items.push(BoundReturningItem { expr, output_name });
@@ -1453,10 +1358,44 @@ fn bound_write_target(kind: &PublicSurfaceKind) -> BoundWriteTarget {
         PublicSurfaceKind::Change
         | PublicSurfaceKind::WorkingDiff
         | PublicSurfaceKind::HistoryFunction
+        | PublicSurfaceKind::DiffFunction
+        | PublicSurfaceKind::Restore
         | PublicSurfaceKind::CommitAncestryFunction => {
             unreachable!("write capability checked before target binding")
         }
     }
+}
+
+fn bound_insert_target(
+    kind: &PublicSurfaceKind,
+    input: &BoundWriteInput,
+) -> Result<BoundWriteTarget, LixError> {
+    if !matches!(kind, PublicSurfaceKind::Restore) {
+        return Ok(bound_write_target(kind));
+    }
+    let BoundWriteInput::Values(values) = input else {
+        return Err(super::error::unsupported(
+            "lix_restore requires exactly one INSERT ... VALUES row",
+        ));
+    };
+    let Some(commit_id_index) = values.column_index("commit_id") else {
+        return Err(super::error::unsupported(
+            "lix_restore requires the commit_id column",
+        ));
+    };
+    let [row] = values.rows.as_slice() else {
+        return Err(super::error::unsupported(
+            "lix_restore requires exactly one INSERT ... VALUES row",
+        ));
+    };
+    let Some(commit_id) = row.get(commit_id_index) else {
+        return Err(super::error::unsupported(
+            "lix_restore requires the commit_id column",
+        ));
+    };
+    Ok(BoundWriteTarget::Restore {
+        commit_id: commit_id.clone(),
+    })
 }
 
 fn bind_write_branch_scope(
@@ -1529,14 +1468,16 @@ mod tests {
     use datafusion::sql::parser::Statement as DataFusionStatement;
 
     #[test]
-    fn bind_statement_binds_exact_restore_command() {
-        let statement = parse_statement("SELECT lix_restore($1)");
+    fn bind_statement_binds_restore_command_sink() {
+        let statement = parse_statement(
+            "INSERT INTO lix_restore (commit_id) VALUES ($1) RETURNING commit_id",
+        );
         let bound = bind_statement(&statement, &[], "branch1").expect("restore should bind");
 
         assert!(matches!(
             bound.target,
             BoundWriteTarget::Restore {
-                commit_id: BoundExpr::Param(BoundParamRef { index: 1 })
+                commit_id: BoundExpr::Param(BoundParamRef { index: 1 }),
             }
         ));
         assert_eq!(
@@ -1548,18 +1489,11 @@ mod tests {
     }
 
     #[test]
-    fn bind_statement_rejects_composed_restore_calls() {
-        for sql in [
-            "SELECT lix_restore($1), 1",
-            "SELECT upper(lix_restore($1))",
-            "SELECT lix_restore($1) AS restored",
-            "SELECT lix_restore($1) FROM lix_commit",
-            "SELECT lix_restore($1) WHERE true",
-        ] {
-            let error = bind_statement(&parse_statement(sql), &[], "branch1")
-                .expect_err("composed restore must fail");
-            assert_eq!(error.code, LixError::CODE_UNSUPPORTED_SQL, "{sql}");
-        }
+    fn bind_statement_rejects_removed_restore_scalar_syntax() {
+        let sql = "SELECT lix_restore($1)";
+        let error = bind_statement(&parse_statement(sql), &[], "branch1")
+            .expect_err("the removed scalar-shaped restore command must fail");
+        assert_eq!(error.code, LixError::CODE_UNSUPPORTED_SQL);
     }
 
     #[test]

--- a/packages/lix/src/sql2/bind/table.rs
+++ b/packages/lix/src/sql2/bind/table.rs
@@ -229,11 +229,13 @@ mod tests {
             "lix_commit_ancestry",
             "lix_commit_edge",
             "lix_create_checkpoint",
+            "lix_diff",
             "lix_directory",
             "lix_file",
             "lix_history",
             "lix_key_value",
             "lix_registered_schema",
+            "lix_restore",
             "lix_revert",
             "lix_working_diff",
         ];

--- a/packages/lix/src/sql2/catalog/mod.rs
+++ b/packages/lix/src/sql2/catalog/mod.rs
@@ -13,5 +13,6 @@ pub(crate) use schema_surface::{
     schema_exposed_as_schema_surface, schema_surface_schema,
 };
 pub(crate) use surface::{
-    PublicHistoryContract, PublicHistoryKind, PublicSurfaceContract, PublicSurfaceKind,
+    PublicHistoryContract, PublicHistoryKind, PublicRelationKind, PublicScalarFunctionContract,
+    PublicSurfaceClass, PublicSurfaceContract, PublicSurfaceKind, PUBLIC_SCALAR_FUNCTION_NAMES,
 };

--- a/packages/lix/src/sql2/catalog/registry.rs
+++ b/packages/lix/src/sql2/catalog/registry.rs
@@ -8,8 +8,9 @@ use serde_json::Value as JsonValue;
 use crate::LixError;
 
 use super::{
-    PublicColumn, PublicHistoryContract, PublicHistoryKind, PublicSurfaceContract,
-    PublicSurfaceKind, SurfaceCapabilities,
+    PublicColumn, PublicHistoryContract, PublicHistoryKind, PublicRelationKind,
+    PublicScalarFunctionContract, PublicSurfaceClass, PublicSurfaceContract, PublicSurfaceKind,
+    SurfaceCapabilities, PUBLIC_SCALAR_FUNCTION_NAMES,
 };
 use crate::sql2::catalog::schema_surface_schema;
 use crate::sql2::catalog::{
@@ -27,6 +28,7 @@ use crate::sql2::result_metadata::json_field;
 #[derive(Clone, Debug, Default)]
 pub(crate) struct PublicCatalog {
     surfaces: BTreeMap<String, PublicSurfaceContract>,
+    scalar_functions: BTreeMap<String, PublicScalarFunctionContract>,
     history: BTreeMap<String, PublicHistoryContract>,
     schema_specs: BTreeMap<String, SchemaSurfaceSpec>,
 }
@@ -68,13 +70,41 @@ impl PublicCatalog {
     }
 
     pub(crate) fn insert(&mut self, surface: PublicSurfaceContract) -> Result<(), LixError> {
-        if self.surfaces.contains_key(&surface.name) {
+        if !surface.kind.accepts_class(surface.class) {
+            return Err(LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                format!(
+                    "public SQL surface '{}' has incompatible class {:?} and semantic kind {:?}",
+                    surface.name, surface.class, surface.kind
+                ),
+            ));
+        }
+        if self.surfaces.contains_key(&surface.name)
+            || self.scalar_functions.contains_key(&surface.name)
+        {
             return Err(LixError::new(
                 LixError::CODE_SCHEMA_DEFINITION,
                 format!("duplicate public SQL surface '{}'", surface.name),
             ));
         }
         self.surfaces.insert(surface.name.clone(), surface);
+        Ok(())
+    }
+
+    fn insert_scalar_function(&mut self, name: &str) -> Result<(), LixError> {
+        if self.surfaces.contains_key(name) || self.scalar_functions.contains_key(name) {
+            return Err(LixError::new(
+                LixError::CODE_SCHEMA_DEFINITION,
+                format!("duplicate public SQL surface '{name}'"),
+            ));
+        }
+        self.scalar_functions.insert(
+            name.to_string(),
+            PublicScalarFunctionContract {
+                name: name.to_string(),
+                class: PublicSurfaceClass::ScalarFunction,
+            },
+        );
         Ok(())
     }
 
@@ -92,6 +122,12 @@ impl PublicCatalog {
 
     pub(crate) fn surfaces(&self) -> impl Iterator<Item = &PublicSurfaceContract> {
         self.surfaces.values()
+    }
+
+    pub(crate) fn scalar_functions(
+        &self,
+    ) -> impl Iterator<Item = &PublicScalarFunctionContract> {
+        self.scalar_functions.values()
     }
 
     pub(crate) fn history_relations(&self) -> impl Iterator<Item = &PublicHistoryContract> {
@@ -118,13 +154,20 @@ impl PublicCatalog {
                 Field::new("commit_id", DataType::Utf8, false),
             ])),
             PublicSurfaceKind::WorkingDiff => working_diff_schema(),
-            PublicSurfaceKind::HistoryFunction | PublicSurfaceKind::CommitAncestryFunction => {
+            PublicSurfaceKind::HistoryFunction
+            | PublicSurfaceKind::DiffFunction
+            | PublicSurfaceKind::CommitAncestryFunction => {
                 return None;
             }
             PublicSurfaceKind::Revert
             | PublicSurfaceKind::Apply
             | PublicSurfaceKind::CreateCheckpoint => Arc::new(Schema::new(vec![Field::new(
                 "diff_id",
+                DataType::Utf8,
+                false,
+            )])),
+            PublicSurfaceKind::Restore => Arc::new(Schema::new(vec![Field::new(
+                "commit_id",
                 DataType::Utf8,
                 false,
             )])),
@@ -192,18 +235,21 @@ impl PublicCatalog {
     fn insert_system_surfaces(&mut self) -> Result<(), LixError> {
         self.insert(surface(
             "lix_file",
+            PublicSurfaceClass::Relation(PublicRelationKind::View),
             PublicSurfaceKind::File,
             filesystem_columns(),
             SurfaceCapabilities::read_write(),
         ))?;
         self.insert(surface(
             "lix_directory",
+            PublicSurfaceClass::Relation(PublicRelationKind::View),
             PublicSurfaceKind::Directory,
             directory_columns(),
             SurfaceCapabilities::read_write(),
         ))?;
         self.insert(surface(
             "lix_branch",
+            PublicSurfaceClass::Relation(PublicRelationKind::View),
             PublicSurfaceKind::Branch,
             vec![
                 PublicColumn::public_insert_only("id", false),
@@ -216,6 +262,7 @@ impl PublicCatalog {
         ))?;
         self.insert(surface(
             "lix_change",
+            PublicSurfaceClass::Relation(PublicRelationKind::View),
             PublicSurfaceKind::Change,
             public_columns([
                 ("id", false),
@@ -232,6 +279,7 @@ impl PublicCatalog {
         ))?;
         self.insert(surface(
             "lix_working_diff",
+            PublicSurfaceClass::TableFunction,
             PublicSurfaceKind::WorkingDiff,
             public_columns([
                 ("diff_id", false),
@@ -246,12 +294,21 @@ impl PublicCatalog {
         ))?;
         self.insert(surface(
             "lix_history",
+            PublicSurfaceClass::TableFunction,
             PublicSurfaceKind::HistoryFunction,
             Vec::new(),
             SurfaceCapabilities::read_only(),
         ))?;
         self.insert(surface(
+            "lix_diff",
+            PublicSurfaceClass::TableFunction,
+            PublicSurfaceKind::DiffFunction,
+            Vec::new(),
+            SurfaceCapabilities::read_only(),
+        ))?;
+        self.insert(surface(
             "lix_commit_ancestry",
+            PublicSurfaceClass::TableFunction,
             PublicSurfaceKind::CommitAncestryFunction,
             Vec::new(),
             SurfaceCapabilities::read_only(),
@@ -263,6 +320,7 @@ impl PublicCatalog {
         ] {
             self.insert(surface(
                 name,
+                PublicSurfaceClass::CommandSink,
                 kind,
                 vec![
                     PublicColumn::public_insert_only("diff_id", false),
@@ -274,6 +332,20 @@ impl PublicCatalog {
                     delete: false,
                 },
             ))?;
+        }
+        self.insert(surface(
+            "lix_restore",
+            PublicSurfaceClass::CommandSink,
+            PublicSurfaceKind::Restore,
+            vec![PublicColumn::public_insert_only("commit_id", false)],
+            SurfaceCapabilities {
+                insert: true,
+                update: false,
+                delete: false,
+            },
+        ))?;
+        for name in PUBLIC_SCALAR_FUNCTION_NAMES {
+            self.insert_scalar_function(name)?;
         }
         self.insert_history(PublicHistoryContract {
             relation_name: "lix_file".to_string(),
@@ -322,6 +394,7 @@ impl PublicCatalog {
 
         self.insert(surface(
             &spec.schema_key,
+            PublicSurfaceClass::Relation(PublicRelationKind::Base),
             PublicSurfaceKind::SchemaBase {
                 schema_key: spec.schema_key.clone(),
             },
@@ -433,6 +506,7 @@ fn history_filesystem_schema(include_data: bool) -> SchemaRef {
 
 fn surface(
     name: impl Into<String>,
+    class: PublicSurfaceClass,
     kind: PublicSurfaceKind,
     columns: Vec<PublicColumn>,
     capabilities: SurfaceCapabilities,
@@ -444,6 +518,7 @@ fn surface(
         .collect();
     PublicSurfaceContract {
         name: name.into(),
+        class,
         kind,
         columns,
         capabilities,

--- a/packages/lix/src/sql2/catalog/surface.rs
+++ b/packages/lix/src/sql2/catalog/surface.rs
@@ -3,10 +3,49 @@ use super::{PublicColumn, SurfaceCapabilities};
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub(crate) struct PublicSurfaceContract {
     pub(crate) name: String,
+    pub(crate) class: PublicSurfaceClass,
     pub(crate) kind: PublicSurfaceKind,
     pub(crate) columns: Vec<PublicColumn>,
     pub(crate) capabilities: SurfaceCapabilities,
 }
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum PublicRelationKind {
+    Base,
+    View,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum PublicSurfaceClass {
+    Relation(PublicRelationKind),
+    TableFunction,
+    CommandSink,
+    ScalarFunction,
+}
+
+impl PublicSurfaceClass {
+    pub(crate) fn sql_name(self) -> &'static str {
+        match self {
+            Self::Relation(_) => "RELATION",
+            Self::TableFunction => "TABLE_FUNCTION",
+            Self::CommandSink => "COMMAND_SINK",
+            Self::ScalarFunction => "SCALAR_FUNCTION",
+        }
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct PublicScalarFunctionContract {
+    pub(crate) name: String,
+    pub(crate) class: PublicSurfaceClass,
+}
+
+pub(crate) const PUBLIC_SCALAR_FUNCTION_NAMES: [&str; 4] = [
+    "lix_active_account_id",
+    "lix_active_branch_commit_id",
+    "lix_active_branch_id",
+    "uuidv7",
+];
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub(crate) struct PublicHistoryContract {
@@ -43,10 +82,31 @@ pub(crate) enum PublicSurfaceKind {
     Directory,
     Branch,
     HistoryFunction,
+    DiffFunction,
     CommitAncestryFunction,
     WorkingDiff,
     Revert,
     Apply,
     CreateCheckpoint,
+    Restore,
     Change,
+}
+
+impl PublicSurfaceKind {
+    pub(crate) fn accepts_class(&self, class: PublicSurfaceClass) -> bool {
+        match self {
+            Self::SchemaBase { .. }
+            | Self::File
+            | Self::Directory
+            | Self::Branch
+            | Self::Change => matches!(class, PublicSurfaceClass::Relation(_)),
+            Self::HistoryFunction
+            | Self::DiffFunction
+            | Self::CommitAncestryFunction
+            | Self::WorkingDiff => class == PublicSurfaceClass::TableFunction,
+            Self::Revert | Self::Apply | Self::CreateCheckpoint | Self::Restore => {
+                class == PublicSurfaceClass::CommandSink
+            }
+        }
+    }
 }

--- a/packages/lix/src/sql2/exec/bound_public_write.rs
+++ b/packages/lix/src/sql2/exec/bound_public_write.rs
@@ -1813,16 +1813,27 @@ pub(crate) async fn try_execute_bound_public_write(
         BoundWriteTarget::Restore { commit_id } => {
             let commit_id = eval_restore_commit_id(commit_id, params)?;
             ctx.restore_active_branch(commit_id.clone()).await?;
-            Ok(BoundPublicWriteExecution::Executed(
+            let result = if let Some(returning) = &plan.bound.returning {
                 SqlWriteResult::returning(
-                    0,
+                    1,
                     crate::SqlQueryResult {
-                        columns: vec!["lix_restore".to_string()],
-                        rows: vec![vec![Value::Text(commit_id)]],
+                        columns: returning
+                            .items
+                            .iter()
+                            .map(|item| item.output_name.clone())
+                            .collect(),
+                        rows: vec![returning
+                            .items
+                            .iter()
+                            .map(|_| Value::Text(commit_id.clone()))
+                            .collect()],
                         notices: Vec::new(),
                     },
-                ),
-            ))
+                )
+            } else {
+                SqlWriteResult::affected(1)
+            };
+            Ok(BoundPublicWriteExecution::Executed(result))
         }
         BoundWriteTarget::Row(surface) if bound_public_write_shape_supported(plan) => {
             execute_row_write(ctx, plan, surface, params)

--- a/packages/lix/src/sql2/information_schema.rs
+++ b/packages/lix/src/sql2/information_schema.rs
@@ -2,7 +2,7 @@ use std::any::Any;
 use std::sync::{Arc, Weak};
 
 use async_trait::async_trait;
-use datafusion::arrow::array::{ArrayRef, StringArray, UInt64Array};
+use datafusion::arrow::array::{ArrayRef, BooleanArray, StringArray, UInt64Array};
 use datafusion::arrow::datatypes::{DataType, Field, Schema, SchemaRef};
 use datafusion::arrow::record_batch::RecordBatch;
 use datafusion::catalog::information_schema::{
@@ -15,11 +15,15 @@ use datafusion::prelude::SessionContext;
 
 use crate::LixError;
 
-use super::catalog::{PublicCatalog, PublicColumnInsertPolicy};
+use super::catalog::{
+    PublicCatalog, PublicColumnInsertPolicy, PublicRelationKind, PublicSurfaceClass,
+    PublicSurfaceKind,
+};
 use super::result_metadata::field_is_json;
 
 const LIX_VALUE_KIND_JSONB: &str = "JSONB";
 const TABLE_FUNCTIONS: &str = "table_functions";
+const LIX_SURFACES: &str = "lix_surfaces";
 
 /// Installs Lix's SQL-level column contract while retaining DataFusion's other
 /// standard information-schema views.
@@ -128,12 +132,14 @@ impl LixInformationSchemaProvider {
             for table_name in INFORMATION_SCHEMA_TABLES
                 .iter()
                 .copied()
-                .chain(std::iter::once(TABLE_FUNCTIONS))
+                .chain([TABLE_FUNCTIONS, LIX_SURFACES])
             {
                 let table_schema = if table_name == "columns" {
                     Arc::clone(&schema)
                 } else if table_name == TABLE_FUNCTIONS {
                     table_functions_schema()
+                } else if table_name == LIX_SURFACES {
+                    lix_surfaces_schema()
                 } else {
                     delegate
                         .table(table_name)
@@ -203,27 +209,35 @@ impl LixInformationSchemaProvider {
             }
         }
 
-        for (name, signature, provider_schema) in [
-            (
-                "lix_commit_ancestry",
-                "() | (commit_id TEXT)",
-                super::providers::commit_ancestry_schema(),
-            ),
-            (
-                "lix_working_diff",
-                "()",
-                super::providers::working_diff_schema(),
-            ),
-            (
-                "lix_diff",
-                "(from_commit_id TEXT, to_commit_id TEXT)",
-                super::providers::diff_schema(),
-            ),
-        ] {
+        for surface in self
+            .public_catalog
+            .surfaces()
+            .filter(|surface| surface.class == PublicSurfaceClass::TableFunction)
+        {
+            let (signature, provider_schema) = match surface.kind {
+                PublicSurfaceKind::HistoryFunction => continue,
+                PublicSurfaceKind::CommitAncestryFunction => (
+                    "() | (commit_id TEXT)",
+                    super::providers::commit_ancestry_schema(),
+                ),
+                PublicSurfaceKind::WorkingDiff => {
+                    ("()", super::providers::working_diff_schema())
+                }
+                PublicSurfaceKind::DiffFunction => (
+                    "(from_commit_id TEXT, to_commit_id TEXT)",
+                    super::providers::diff_schema(),
+                ),
+                _ => {
+                    return Err(DataFusionError::Execution(format!(
+                        "table function '{}' has a non-function semantic kind",
+                        surface.name
+                    )));
+                }
+            };
             for (position, field) in provider_schema.fields().iter().enumerate() {
                 function_catalog.push(self.public_catalog_name.clone());
                 function_schema.push(self.public_schema_name.clone());
-                function_name.push(name.to_string());
+                function_name.push(surface.name.clone());
                 source_relation.push(None);
                 argument_signature.push(signature.to_string());
                 result_column.push(field.name().clone());
@@ -251,6 +265,70 @@ impl LixInformationSchemaProvider {
         )?;
         Ok(Arc::new(MemTable::try_new(schema, vec![vec![batch]])?))
     }
+
+    fn lix_surfaces_table(&self) -> Result<Arc<dyn TableProvider>> {
+        let schema = lix_surfaces_schema();
+        let mut surface_catalog = Vec::new();
+        let mut surface_schema = Vec::new();
+        let mut surface_name = Vec::new();
+        let mut surface_class = Vec::new();
+        let mut relation_kind = Vec::new();
+        let mut can_read = Vec::new();
+        let mut can_insert = Vec::new();
+        let mut can_update = Vec::new();
+        let mut can_delete = Vec::new();
+        let mut is_side_effecting = Vec::new();
+
+        for surface in self.public_catalog.surfaces() {
+            surface_catalog.push(self.public_catalog_name.clone());
+            surface_schema.push(self.public_schema_name.clone());
+            surface_name.push(surface.name.clone());
+            surface_class.push(surface.class.sql_name().to_string());
+            relation_kind.push(match surface.class {
+                PublicSurfaceClass::Relation(PublicRelationKind::Base) => {
+                    Some("BASE".to_string())
+                }
+                PublicSurfaceClass::Relation(PublicRelationKind::View) => {
+                    Some("VIEW".to_string())
+                }
+                _ => None,
+            });
+            can_read.push(!matches!(surface.class, PublicSurfaceClass::CommandSink));
+            can_insert.push(surface.capabilities.insert);
+            can_update.push(surface.capabilities.update);
+            can_delete.push(surface.capabilities.delete);
+            is_side_effecting.push(matches!(surface.class, PublicSurfaceClass::CommandSink));
+        }
+        for function in self.public_catalog.scalar_functions() {
+            surface_catalog.push(self.public_catalog_name.clone());
+            surface_schema.push(self.public_schema_name.clone());
+            surface_name.push(function.name.clone());
+            surface_class.push(function.class.sql_name().to_string());
+            relation_kind.push(None);
+            can_read.push(true);
+            can_insert.push(false);
+            can_update.push(false);
+            can_delete.push(false);
+            is_side_effecting.push(false);
+        }
+
+        let batch = RecordBatch::try_new(
+            Arc::clone(&schema),
+            vec![
+                Arc::new(StringArray::from(surface_catalog)),
+                Arc::new(StringArray::from(surface_schema)),
+                Arc::new(StringArray::from(surface_name)),
+                Arc::new(StringArray::from(surface_class)),
+                Arc::new(StringArray::from(relation_kind)),
+                Arc::new(BooleanArray::from(can_read)),
+                Arc::new(BooleanArray::from(can_insert)),
+                Arc::new(BooleanArray::from(can_update)),
+                Arc::new(BooleanArray::from(can_delete)),
+                Arc::new(BooleanArray::from(is_side_effecting)),
+            ],
+        )?;
+        Ok(Arc::new(MemTable::try_new(schema, vec![vec![batch]])?))
+    }
 }
 
 #[async_trait]
@@ -263,7 +341,7 @@ impl SchemaProvider for LixInformationSchemaProvider {
         INFORMATION_SCHEMA_TABLES
             .iter()
             .map(|name| (*name).to_string())
-            .chain(std::iter::once(TABLE_FUNCTIONS.to_string()))
+            .chain([TABLE_FUNCTIONS.to_string(), LIX_SURFACES.to_string()])
             .collect()
     }
 
@@ -273,6 +351,9 @@ impl SchemaProvider for LixInformationSchemaProvider {
         }
         if name.eq_ignore_ascii_case(TABLE_FUNCTIONS) {
             return self.table_functions_table().map(Some);
+        }
+        if name.eq_ignore_ascii_case(LIX_SURFACES) {
+            return self.lix_surfaces_table().map(Some);
         }
         let catalog_list = self.catalog_list.upgrade().ok_or_else(|| {
             DataFusionError::Execution("SQL catalog closed while reading information_schema".into())
@@ -287,6 +368,7 @@ impl SchemaProvider for LixInformationSchemaProvider {
             .iter()
             .any(|candidate| candidate.eq_ignore_ascii_case(name))
             || name.eq_ignore_ascii_case(TABLE_FUNCTIONS)
+            || name.eq_ignore_ascii_case(LIX_SURFACES)
     }
 }
 
@@ -302,6 +384,21 @@ fn table_functions_schema() -> SchemaRef {
         Field::new("is_nullable", DataType::Utf8, false),
         Field::new("data_type", DataType::Utf8, false),
         Field::new("lix_value_kind", DataType::Utf8, true),
+    ]))
+}
+
+fn lix_surfaces_schema() -> SchemaRef {
+    Arc::new(Schema::new(vec![
+        Field::new("surface_catalog", DataType::Utf8, false),
+        Field::new("surface_schema", DataType::Utf8, false),
+        Field::new("surface_name", DataType::Utf8, false),
+        Field::new("surface_class", DataType::Utf8, false),
+        Field::new("relation_kind", DataType::Utf8, true),
+        Field::new("can_read", DataType::Boolean, false),
+        Field::new("can_insert", DataType::Boolean, false),
+        Field::new("can_update", DataType::Boolean, false),
+        Field::new("can_delete", DataType::Boolean, false),
+        Field::new("is_side_effecting", DataType::Boolean, false),
     ]))
 }
 

--- a/packages/lix/src/sql2/providers/branch.rs
+++ b/packages/lix/src/sql2/providers/branch.rs
@@ -6,6 +6,7 @@ use datafusion::arrow::array::{BooleanArray, StringArray};
 use datafusion::arrow::datatypes::{DataType, Field, Schema, SchemaRef};
 use datafusion::arrow::record_batch::RecordBatch;
 use datafusion::common::{DataFusionError, Result, ScalarValue};
+use datafusion::datasource::TableType;
 use datafusion::execution::context::ExecutionProps;
 use datafusion::logical_expr::expr::InList;
 use datafusion::logical_expr::{BinaryExpr, Expr, Operator, TableProviderFilterPushDown};
@@ -102,6 +103,10 @@ impl TableSpec for BranchSpec {
 
     fn schema(&self) -> SchemaRef {
         lix_branch_schema()
+    }
+
+    fn table_type(&self) -> TableType {
+        TableType::View
     }
 
     fn upsert_support(&self) -> Option<&dyn UpsertSupport> {

--- a/packages/lix/src/sql2/providers/change.rs
+++ b/packages/lix/src/sql2/providers/change.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 use async_trait::async_trait;
 use datafusion::arrow::datatypes::{DataType, Field, Schema, SchemaRef};
 use datafusion::common::{DataFusionError, Result, ScalarValue};
+use datafusion::datasource::TableType;
 use datafusion::execution::context::ExecutionProps;
 use datafusion::logical_expr::{Expr, Operator, TableProviderFilterPushDown};
 
@@ -63,6 +64,10 @@ where
 
     fn schema(&self) -> SchemaRef {
         lix_change_schema()
+    }
+
+    fn table_type(&self) -> TableType {
+        TableType::View
     }
 
     fn filter_pushdown(&self, filter: &Expr) -> TableProviderFilterPushDown {

--- a/packages/lix/src/sql2/providers/diff_command.rs
+++ b/packages/lix/src/sql2/providers/diff_command.rs
@@ -5,6 +5,7 @@ use datafusion::arrow::array::{Array, StringArray};
 use datafusion::arrow::datatypes::{DataType, Field, Schema, SchemaRef};
 use datafusion::arrow::record_batch::RecordBatch;
 use datafusion::common::{DataFusionError, Result};
+use datafusion::datasource::TableType;
 use datafusion::execution::context::ExecutionProps;
 use datafusion::logical_expr::Expr;
 use datafusion::physical_plan::ExecutionPlan;
@@ -45,6 +46,13 @@ impl TableSpec for DiffCommandSpec {
 
     fn schema(&self) -> SchemaRef {
         command_schema()
+    }
+
+    fn table_type(&self) -> TableType {
+        // A command sink is closest to an insertable view in the standard
+        // information schema. Lix's exact classification is exposed through
+        // information_schema.lix_surfaces.
+        TableType::View
     }
 
     async fn plan_scan(

--- a/packages/lix/src/sql2/providers/directory.rs
+++ b/packages/lix/src/sql2/providers/directory.rs
@@ -14,6 +14,7 @@ use datafusion::arrow::array::{ArrayRef, BooleanArray, RecordBatchOptions, Strin
 use datafusion::arrow::datatypes::{DataType, Field, Schema, SchemaRef};
 use datafusion::arrow::record_batch::RecordBatch;
 use datafusion::common::{DFSchema, DataFusionError, Result, ScalarValue};
+use datafusion::datasource::TableType;
 use datafusion::execution::context::ExecutionProps;
 use datafusion::logical_expr::{Expr, TableProviderFilterPushDown};
 use datafusion::physical_expr::{PhysicalExpr, create_physical_expr};
@@ -430,6 +431,10 @@ impl TableSpec for LixDirectorySpec {
 
     fn schema(&self) -> SchemaRef {
         Arc::clone(&self.schema)
+    }
+
+    fn table_type(&self) -> TableType {
+        TableType::View
     }
 
     fn filter_pushdown(&self, _filter: &Expr) -> TableProviderFilterPushDown {
@@ -3480,7 +3485,7 @@ mod tests {
         )));
         assert_eq!(
             provider.table_type(),
-            datafusion::datasource::TableType::Base
+            datafusion::datasource::TableType::View
         );
     }
 }

--- a/packages/lix/src/sql2/providers/file.rs
+++ b/packages/lix/src/sql2/providers/file.rs
@@ -21,6 +21,7 @@ use datafusion::arrow::array::{
 use datafusion::arrow::datatypes::{DataType, Field, Schema, SchemaRef};
 use datafusion::arrow::record_batch::RecordBatch;
 use datafusion::common::{DFSchema, DataFusionError, Result, ScalarValue};
+use datafusion::datasource::TableType;
 use datafusion::execution::TaskContext;
 use datafusion::execution::context::ExecutionProps;
 use datafusion::logical_expr::expr::{InList, Like};
@@ -860,6 +861,10 @@ impl TableSpec for LixFileSpec {
 
     fn schema(&self) -> SchemaRef {
         Arc::clone(&self.schema)
+    }
+
+    fn table_type(&self) -> TableType {
+        TableType::View
     }
 
     fn filter_pushdown(&self, filter: &Expr) -> TableProviderFilterPushDown {

--- a/packages/lix/src/sql2/providers/mod.rs
+++ b/packages/lix/src/sql2/providers/mod.rs
@@ -510,9 +510,11 @@ where
             }
             PublicSurfaceKind::SchemaBase { .. }
             | PublicSurfaceKind::HistoryFunction
+            | PublicSurfaceKind::DiffFunction
             | PublicSurfaceKind::Revert
             | PublicSurfaceKind::Apply
-            | PublicSurfaceKind::CreateCheckpoint => {}
+            | PublicSurfaceKind::CreateCheckpoint
+            | PublicSurfaceKind::Restore => {}
         }
     }
     schema::register_row_providers(
@@ -706,7 +708,9 @@ async fn register_write_from_catalog(
             PublicSurfaceKind::Change
             | PublicSurfaceKind::WorkingDiff
             | PublicSurfaceKind::HistoryFunction
-            | PublicSurfaceKind::CommitAncestryFunction => {}
+            | PublicSurfaceKind::DiffFunction
+            | PublicSurfaceKind::CommitAncestryFunction
+            | PublicSurfaceKind::Restore => {}
             PublicSurfaceKind::SchemaBase { .. } => {}
         }
     }
@@ -950,6 +954,7 @@ mod tests {
             vec![
                 "lix_change",
                 "lix_commit_ancestry",
+                "lix_diff",
                 "lix_history",
                 "lix_working_diff",
             ]
@@ -962,13 +967,14 @@ mod tests {
                 "lix_create_checkpoint",
                 "lix_directory",
                 "lix_file",
+                "lix_restore",
                 "lix_revert",
                 "phase8_row",
             ]
         );
         assert_eq!(read_only.len() + writable.len(), catalog.surfaces().count());
-        assert_eq!(all_read + writable.len(), 18, "construction count");
-        assert_eq!(read_only.len() + writable.len(), 11, "surface count");
+        assert_eq!(all_read + writable.len(), 21, "construction count");
+        assert_eq!(read_only.len() + writable.len(), 13, "surface count");
     }
 
     #[test]
@@ -985,7 +991,7 @@ mod tests {
             .map(|surface| surface.name.as_str())
             .collect::<Vec<_>>();
 
-        assert_eq!(all_writable, 6, "previous standalone write count");
+        assert_eq!(all_writable, 7, "standalone write count");
         assert_eq!(selected_writable, vec!["lix_file"]);
     }
 

--- a/packages/lix/src/sync/repository.rs
+++ b/packages/lix/src/sync/repository.rs
@@ -7192,7 +7192,7 @@ mod tests {
             .expect("abandoned head should decode");
         authority
             .execute(
-                "SELECT lix_restore($1)",
+                "INSERT INTO lix_restore (commit_id) VALUES ($1)",
                 &[Value::Text(target_head.clone())],
             )
             .await

--- a/packages/lix/tests/integration/restore.rs
+++ b/packages/lix/tests/integration/restore.rs
@@ -3,6 +3,9 @@ use serde_json::json;
 
 use crate::support::simulation_test::engine::SimSession;
 
+const RESTORE_SQL: &str =
+    "INSERT INTO lix_restore (commit_id) VALUES ($1) RETURNING commit_id";
+
 simulation_test!(
     restore_moves_only_the_active_branch_to_an_ancestor,
     |sim| async move {
@@ -285,41 +288,29 @@ simulation_test!(
             .expect("D commits");
         let commit_d = head(&session).await;
 
-        let wrong_arity = session
-            .execute("SELECT lix_restore()", &[])
-            .await
-            .expect_err("wrong restore arity must fail");
-        assert_eq!(wrong_arity.code, LixError::CODE_INVALID_PARAM);
-        assert_eq!(head(&session).await, commit_d);
-
-        for (sql, params) in [
-            (
-                "SELECT upper(lix_restore($1))",
-                vec![Value::Text(commit_c.clone())],
-            ),
-            (
-                "SELECT lix_restore($1), 1",
-                vec![Value::Text(commit_c.clone())],
-            ),
+        for sql in [
+            "SELECT lix_restore()",
+            "SELECT upper(lix_restore($1))",
+            "SELECT lix_restore($1)",
+            "SELECT lix_restore($1), 1",
         ] {
-            let error = session
-                .execute(sql, &params)
+            session
+                .execute(sql, &[Value::Text(commit_c.clone())])
                 .await
-                .expect_err("composed restore SQL must fail");
-            assert_eq!(error.code, LixError::CODE_UNSUPPORTED_SQL, "{sql}");
+                .expect_err("removed scalar restore syntax must fail");
             assert_eq!(head(&session).await, commit_d, "{sql}");
         }
 
         for value in [Value::Null, Value::Integer(1)] {
             let error = session
-                .execute("SELECT lix_restore($1)", &[value])
+                .execute(RESTORE_SQL, &[value])
                 .await
                 .expect_err("non-text restore target must fail");
             assert_eq!(error.code, LixError::CODE_TYPE_MISMATCH);
             assert_eq!(head(&session).await, commit_d);
         }
         let missing_param = session
-            .execute("SELECT lix_restore($1)", &[])
+            .execute(RESTORE_SQL, &[])
             .await
             .expect_err("missing restore parameter must fail");
         assert_eq!(missing_param.code, LixError::CODE_INVALID_PARAM);
@@ -330,7 +321,7 @@ simulation_test!(
             .await
             .expect("transaction should begin");
         rolled_back
-            .execute("SELECT lix_restore($1)", &[Value::Text(commit_c.clone())])
+            .execute(RESTORE_SQL, &[Value::Text(commit_c.clone())])
             .await
             .expect("transaction restore should stage");
         rolled_back
@@ -351,7 +342,7 @@ simulation_test!(
             .await
             .expect("earlier write should stage");
         let restore_after_write = write_first
-            .execute("SELECT lix_restore($1)", &[Value::Text(commit_c.clone())])
+            .execute(RESTORE_SQL, &[Value::Text(commit_c.clone())])
             .await
             .expect_err("restore cannot follow another write");
         assert_eq!(restore_after_write.code, "LIX_INVALID_TRANSACTION_STATE");
@@ -379,7 +370,7 @@ simulation_test!(
             .await
             .expect("transaction should begin");
         transaction
-            .execute("SELECT lix_restore($1)", &[Value::Text(commit_c.clone())])
+            .execute(RESTORE_SQL, &[Value::Text(commit_c.clone())])
             .await
             .expect("first restore should stage");
         let stale_read_error = transaction
@@ -388,7 +379,7 @@ simulation_test!(
             .expect_err("reads after restore must be rejected");
         assert_eq!(stale_read_error.code, "LIX_INVALID_TRANSACTION_STATE");
         let second_error = transaction
-            .execute("SELECT lix_restore($1)", &[Value::Text(commit_d.clone())])
+            .execute(RESTORE_SQL, &[Value::Text(commit_d.clone())])
             .await
             .expect_err("a second restore in one transaction should fail");
         assert_eq!(second_error.code, "LIX_INVALID_TRANSACTION_STATE");
@@ -472,14 +463,11 @@ async fn head(session: &SimSession) -> String {
 
 async fn restore(session: &SimSession, commit_id: &str) -> Result<(), LixError> {
     let result = session
-        .execute(
-            "SELECT lix_restore($1)",
-            &[Value::Text(commit_id.to_string())],
-        )
+        .execute(RESTORE_SQL, &[Value::Text(commit_id.to_string())])
         .await?;
-    assert_eq!(result.columns(), &["lix_restore"]);
+    assert_eq!(result.columns(), &["commit_id"]);
     assert_eq!(
-        result.rows()[0].get::<String>("lix_restore").unwrap(),
+        result.rows()[0].get::<String>("commit_id").unwrap(),
         commit_id
     );
     Ok(())

--- a/packages/lix/tests/integration/sql/checkpoint.rs
+++ b/packages/lix/tests/integration/sql/checkpoint.rs
@@ -315,7 +315,7 @@ simulation_test!(
 
         session
             .execute(
-                "SELECT lix_restore($1)",
+                "INSERT INTO lix_restore (commit_id) VALUES ($1)",
                 &[Value::Text(first_checkpoint.commit_id.clone())],
             )
             .await

--- a/packages/lix/tests/integration/sql/information_schema.rs
+++ b/packages/lix/tests/integration/sql/information_schema.rs
@@ -2,6 +2,114 @@ use lix::{LixError, Value};
 
 use super::assert_rows_eq;
 
+simulation_test!(lix_surfaces_classifies_the_public_sql_contract, |sim| async move {
+    let engine = sim.boot_engine().await;
+    let session = sim.wrap_session(
+        engine
+            .open_session()
+            .await
+            .expect("main session should open"),
+        &engine,
+    );
+
+    let surfaces = session
+        .execute(
+            "SELECT surface_name, surface_class, relation_kind, can_read, can_insert, is_side_effecting \
+             FROM information_schema.lix_surfaces \
+             WHERE surface_name IN (\
+               'lix_active_branch_id', 'lix_create_checkpoint', 'lix_diff',\
+               'lix_file', 'lix_restore', 'lix_working_diff'\
+             ) \
+             ORDER BY surface_name",
+            &[],
+        )
+        .await
+        .expect("the unified Lix surface catalog should be readable");
+
+    assert_rows_eq(
+        surfaces,
+        vec![
+            vec![
+                Value::Text("lix_active_branch_id".to_string()),
+                Value::Text("SCALAR_FUNCTION".to_string()),
+                Value::Null,
+                Value::Boolean(true),
+                Value::Boolean(false),
+                Value::Boolean(false),
+            ],
+            vec![
+                Value::Text("lix_create_checkpoint".to_string()),
+                Value::Text("COMMAND_SINK".to_string()),
+                Value::Null,
+                Value::Boolean(false),
+                Value::Boolean(true),
+                Value::Boolean(true),
+            ],
+            vec![
+                Value::Text("lix_diff".to_string()),
+                Value::Text("TABLE_FUNCTION".to_string()),
+                Value::Null,
+                Value::Boolean(true),
+                Value::Boolean(false),
+                Value::Boolean(false),
+            ],
+            vec![
+                Value::Text("lix_file".to_string()),
+                Value::Text("RELATION".to_string()),
+                Value::Text("VIEW".to_string()),
+                Value::Boolean(true),
+                Value::Boolean(true),
+                Value::Boolean(false),
+            ],
+            vec![
+                Value::Text("lix_restore".to_string()),
+                Value::Text("COMMAND_SINK".to_string()),
+                Value::Null,
+                Value::Boolean(false),
+                Value::Boolean(true),
+                Value::Boolean(true),
+            ],
+            vec![
+                Value::Text("lix_working_diff".to_string()),
+                Value::Text("TABLE_FUNCTION".to_string()),
+                Value::Null,
+                Value::Boolean(true),
+                Value::Boolean(false),
+                Value::Boolean(false),
+            ],
+        ],
+    );
+
+    let relations = session
+        .execute(
+            "SELECT table_name, table_type \
+             FROM information_schema.tables \
+             WHERE table_schema = 'public' \
+               AND table_name IN ('lix_change', 'lix_file', 'lix_key_value') \
+             ORDER BY table_name",
+            &[],
+        )
+        .await
+        .expect("standard relation classification should be readable");
+    assert_rows_eq(
+        relations,
+        vec![
+            vec![
+                Value::Text("lix_change".to_string()),
+                Value::Text("VIEW".to_string()),
+            ],
+            vec![
+                Value::Text("lix_file".to_string()),
+                Value::Text("VIEW".to_string()),
+            ],
+            vec![
+                Value::Text("lix_key_value".to_string()),
+                Value::Text("BASE TABLE".to_string()),
+            ],
+        ],
+    );
+});
+
 simulation_test!(public_catalog_hides_internal_branch_surfaces, |sim| async move {
     let engine = sim.boot_engine().await;
     let session = sim.wrap_session(

--- a/packages/lix/tests/integration/sql/lix_commit.rs
+++ b/packages/lix/tests/integration/sql/lix_commit.rs
@@ -241,7 +241,10 @@ simulation_test!(
         );
 
         session
-            .execute("SELECT lix_restore($1)", &[Value::Text(first_head.clone())])
+            .execute(
+                "INSERT INTO lix_restore (commit_id) VALUES ($1)",
+                &[Value::Text(first_head.clone())],
+            )
             .await
             .expect("restore should succeed");
         let restored = select_rows(

--- a/packages/lix/tests/integration/support/simulation_test/engine/simulation.rs
+++ b/packages/lix/tests/integration/support/simulation_test/engine/simulation.rs
@@ -448,16 +448,8 @@ fn classify_statement(sql: &str) -> StatementKind {
         return classify_statement(inner);
     }
 
-    let (keyword, rest) = first_keyword_and_rest(sql);
+    let (keyword, _rest) = first_keyword_and_rest(sql);
     match keyword.as_str() {
-        "SELECT"
-            if rest
-                .trim_start()
-                .to_ascii_lowercase()
-                .starts_with("lix_restore") =>
-        {
-            StatementKind::Write
-        }
         "SELECT" | "WITH" | "VALUES" | "FROM" | "TABLE" | "EXPLAIN" => StatementKind::Read,
         "INSERT" | "UPDATE" | "DELETE" => StatementKind::Write,
         _ => StatementKind::Utility,
@@ -542,7 +534,7 @@ mod tests {
     fn classify_statement_splits_reads_writes_and_utility() {
         assert_eq!(classify_statement("SELECT 1"), StatementKind::Read);
         assert_eq!(
-            classify_statement("SELECT lix_restore($1)"),
+            classify_statement("INSERT INTO lix_restore (commit_id) VALUES ($1)"),
             StatementKind::Write
         );
         assert_eq!(


### PR DESCRIPTION
## Summary

- classify Lix SQL surfaces as relations (base/view), table functions, command sinks, or scalar functions
- expose the Lix-owned contract through information_schema.lix_surfaces and standard BASE TABLE/VIEW metadata
- make lix_restore an insert-only command sink and remove SELECT lix_restore(...) compatibility
- migrate Rust and JavaScript SDK callers to INSERT ... RETURNING

## Design

Classification follows SQL shape, not whether a surface is dynamic. Parameterized row sources are table functions; unparameterized projections are relations/views; mutations are command sinks. No _by_branch public surfaces are introduced.

## Verification

- cargo fmt --all -- --check
- cargo test -p lix --lib (2,878 passed after assertion updates; long stress test passed separately)
- focused restore, catalog, provider, and information-schema tests
- all-simulation variants for surface classification and restore transaction semantics
- three independent sub-agent reviews, with Pareto/API findings addressed
