### PR TITLE
refactor(lix): name migration APIs after Lix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ### Breaking
 
+- Renamed the Rust repository migration functions from `inspect_repository` and
+  `migrate_repository` to `inspect_lix` and `migrate_lix`. Migration remains an
+  explicit offline operation before `open_lix()`.
 - Removed the `@lix-js/sdk/workerd` entry point, its direct in-isolate WASM
   snapshot bindings, and the now-unused synchronous WASM initializer.
 - Removed the public SQL script-parsing API (`parse_sql_script` /

--- a/packages/lix/src/init.rs
+++ b/packages/lix/src/init.rs
@@ -166,7 +166,7 @@ pub(crate) fn migration_required_error(found_version: u32) -> LixError {
     LixError::new(
         "LIX_ERROR_REPOSITORY_MIGRATION_REQUIRED",
         format!(
-            "repository format v{found_version} must be migrated to v{CURRENT_FORMAT_VERSION} with lix::migration::migrate_repository before opening"
+            "repository format v{found_version} must be migrated to v{CURRENT_FORMAT_VERSION} with lix::migration::migrate_lix before opening"
         ),
     )
 }

--- a/packages/lix/src/migration/api.rs
+++ b/packages/lix/src/migration/api.rs
@@ -71,7 +71,7 @@ pub enum MigrationStatus {
 ///
 /// This is read-only and intentionally understands only the format marker;
 /// migration preflight performs the deeper physical validation.
-pub async fn inspect_repository<S>(storage: &S) -> Result<MigrationStatus, LixError>
+pub async fn inspect_lix<S>(storage: &S) -> Result<MigrationStatus, LixError>
 where
     S: Storage + ?Sized,
 {
@@ -125,7 +125,7 @@ where
 /// migration may stop in a valid, retryable v69 state after its typed rewrite;
 /// chronology-root chunks may likewise be persisted unreferenced before each
 /// edge's final atomic manifest replacement and marker publication.
-pub async fn migrate_repository<S>(
+pub async fn migrate_lix<S>(
     storage: S,
     options: MigrationOptions,
 ) -> Result<MigrationReport, LixError>
@@ -531,7 +531,7 @@ mod tests {
             .await
             .unwrap();
 
-        let report = migrate_repository(storage.clone(), MigrationOptions::default())
+        let report = migrate_lix(storage.clone(), MigrationOptions::default())
             .await
             .unwrap();
         assert_eq!(
@@ -545,7 +545,7 @@ mod tests {
             }
         );
         assert_eq!(
-            inspect_repository(&storage).await.unwrap(),
+            inspect_lix(&storage).await.unwrap(),
             MigrationStatus::Current {
                 version: CURRENT_FORMAT_VERSION,
             }
@@ -717,7 +717,7 @@ mod tests {
         .await
         .unwrap();
         assert_eq!(
-            inspect_repository(&storage).await.unwrap(),
+            inspect_lix(&storage).await.unwrap(),
             MigrationStatus::Required {
                 from_version: 70,
                 to_version: 71,
@@ -731,7 +731,7 @@ mod tests {
         )
         .await;
 
-        migrate_repository(storage.clone(), MigrationOptions::default())
+        migrate_lix(storage.clone(), MigrationOptions::default())
             .await
             .unwrap();
         let lix = crate::open_lix()
@@ -753,13 +753,13 @@ mod tests {
             .await;
 
         assert_eq!(
-            inspect_repository(&storage).await.unwrap(),
+            inspect_lix(&storage).await.unwrap(),
             MigrationStatus::Required {
                 from_version: 70,
                 to_version: 71,
             }
         );
-        let report = migrate_repository(storage.clone(), MigrationOptions::default())
+        let report = migrate_lix(storage.clone(), MigrationOptions::default())
             .await
             .unwrap();
         assert_eq!(report.from_version, 70);

--- a/packages/lix/src/migration/mod.rs
+++ b/packages/lix/src/migration/mod.rs
@@ -1,7 +1,22 @@
 //! Repository-format migration API.
 //!
 //! This module describes migration edges independently from their physical
-//! implementation. Normal repository opening never runs migrations.
+//! implementation. Normal repository opening never runs migrations. Inspect
+//! and migrate closed repositories explicitly before opening an engine:
+//!
+//! ```no_run
+//! # async fn example(storage: lix::Memory) -> Result<(), lix::LixError> {
+//! use lix::migration::{MigrationOptions, MigrationStatus, inspect_lix, migrate_lix};
+//!
+//! if matches!(inspect_lix(&storage).await?, MigrationStatus::Required { .. }) {
+//!     migrate_lix(storage.clone(), MigrationOptions::default()).await?;
+//! }
+//!
+//! let lix = lix::open_lix().with_storage(storage).await?;
+//! # lix.close().await?;
+//! # Ok(())
+//! # }
+//! ```
 
 mod api;
 mod commit_plan;
@@ -16,5 +31,5 @@ pub(crate) mod v68;
 mod v68_to_v69_rows;
 
 pub use api::{
-    MigrationOptions, MigrationReport, MigrationStatus, inspect_repository, migrate_repository,
+    MigrationOptions, MigrationReport, MigrationStatus, inspect_lix, migrate_lix,
 };

--- a/packages/lix/src/migration/publish.rs
+++ b/packages/lix/src/migration/publish.rs
@@ -347,7 +347,7 @@ mod tests {
         .expect_err("stale migration must be fenced");
         assert!(error.to_string().contains("precondition failed"));
         assert_eq!(
-            crate::migration::inspect_repository(&storage)
+            crate::migration::inspect_lix(&storage)
                 .await
                 .unwrap(),
             crate::migration::MigrationStatus::Required {

--- a/packages/lix/tests/migration_v68.rs
+++ b/packages/lix/tests/migration_v68.rs
@@ -15,7 +15,7 @@
 //! The temporary helper and baseline patches are intentionally not retained.
 
 use lix::Memory;
-use lix::migration::{MigrationOptions, MigrationStatus, inspect_repository, migrate_repository};
+use lix::migration::{MigrationOptions, MigrationStatus, inspect_lix, migrate_lix};
 use lix::open_lix;
 
 const V68_SNAPSHOT: &[u8] = include_bytes!("fixtures/v68_bundled_csv_history.snapshot");
@@ -31,7 +31,7 @@ async fn current_format_inspection_recognizes_v68_golden_snapshot() {
     let storage = Memory::from_snapshot(V68_SNAPSHOT).expect("v68 golden snapshot should decode");
 
     assert_eq!(
-        inspect_repository(&storage)
+        inspect_lix(&storage)
             .await
             .expect("v68 format inspection should succeed"),
         MigrationStatus::Required {
@@ -46,13 +46,13 @@ async fn migrates_external_v68_authority_and_plugin_and_engine_tombstones() {
     let storage = Memory::from_snapshot(V68_EXTERNAL_TOMBSTONES)
         .expect("external v68 golden snapshot should decode");
     assert_eq!(
-        inspect_repository(&storage).await.unwrap(),
+        inspect_lix(&storage).await.unwrap(),
         MigrationStatus::Required {
             from_version: 68,
             to_version: 71,
         }
     );
-    let report = migrate_repository(storage.clone(), MigrationOptions::default())
+    let report = migrate_lix(storage.clone(), MigrationOptions::default())
         .await
         .expect("external v68 authority should migrate");
     assert!(report.commit_members_rewritten >= 704);
@@ -144,7 +144,7 @@ async fn migrates_v68_fixture_and_reopens_with_current_and_history_rows() {
         panic!("normal engine open must require migration");
     };
     assert_eq!(open_error.code, "LIX_ERROR_REPOSITORY_MIGRATION_REQUIRED");
-    let report = migrate_repository(storage.clone(), MigrationOptions::default())
+    let report = migrate_lix(storage.clone(), MigrationOptions::default())
         .await
         .expect("v68 fixture should migrate");
     assert_eq!(report.from_version, 68);
@@ -153,10 +153,10 @@ async fn migrates_v68_fixture_and_reopens_with_current_and_history_rows() {
     assert!(report.commit_members_rewritten >= 2);
     assert!(report.hot_rows_rewritten >= 1);
     assert_eq!(
-        inspect_repository(&storage).await.unwrap(),
+        inspect_lix(&storage).await.unwrap(),
         MigrationStatus::Current { version: 71 }
     );
-    let retry = migrate_repository(storage.clone(), MigrationOptions::default())
+    let retry = migrate_lix(storage.clone(), MigrationOptions::default())
         .await
         .expect("migration retry should be idempotent");
     assert_eq!(retry.from_version, 71);


### PR DESCRIPTION
## Summary

- hard-rename the Rust migration APIs from `inspect_repository` / `migrate_repository` to `inspect_lix` / `migrate_lix`
- keep repository migration explicit and offline before `open_lix()`; normal opening still never migrates
- document the canonical inspect → migrate → open flow and update the migration-required diagnostic

This intentionally adds no compatibility aliases, automatic-open behavior, storage lifecycle API, backup policy, or server orchestration. Those responsibilities remain outside this small Rust API naming hard cut.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p lix --test migration_v68`
- `cargo test -p lix`
- `cargo test -p lix --features all-simulations`
- `cargo test --locked --manifest-path tooling/Cargo.toml --profile test --workspace --exclude lix_e2e --all-features --no-run`
