### PR TITLE
ci: speed up Rust test feedback

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,0 +1,11 @@
+[profile.ci]
+fail-fast = false
+slow-timeout = { period = "60s", terminate-after = 5 }
+status-level = "slow"
+final-status-level = "slow"
+
+[profile.ci.junit]
+path = "junit.xml"
+
+[profile.ci-e2e]
+inherits = "ci"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,6 +100,25 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y llvm-dev libclang-dev clang mold
 
+      - name: Install cargo-nextest
+        if: matrix.task == 'test'
+        uses: taiki-e/install-action@v2
+        with:
+          tool: nextest
+
+      # Pull requests restore dependency artifacts seeded by main but never
+      # publish branch-specific target caches. Workspace crates remain
+      # excluded so source changes always rebuild Lix itself.
+      - name: Restore Cargo dependency cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: cargo-${{ matrix.task }}
+          workspaces: |
+            . -> target
+          cache-targets: true
+          cache-workspace-crates: false
+          save-if: ${{ github.ref == 'refs/heads/main' }}
+
       - name: Restore compiler cache
         uses: mozilla-actions/sccache-action@v0.0.10
 
@@ -118,12 +137,13 @@ jobs:
 
       # The one supported configuration nothing else here builds: `cfg(test)`
       # with `storage-benches` OFF, which is exactly what a plain
-      # `cargo test -p lix` — the dev loop `packages/lix/AGENTS.md` documents —
-      # compiles. Every other step has the feature on (`--all-features`), and a
-      # `--no-default-features` check has no test targets at all, so a
+      # `cargo nextest run -p lix` — the dev loop `packages/lix/AGENTS.md`
+      # documents — compiles. Every other step has the feature on
+      # (`--all-features`), and a `--no-default-features` check has no test
+      # targets at all, so a
       # `#[cfg(test)]` item that calls the feature-only `storage_bench` module
-      # breaks `cargo test -p lix` while clippy, the full test matrix and the
-      # `--all-features` build all stay green. Two such call sites had
+      # breaks `cargo nextest run -p lix` while clippy, the full test matrix and
+      # the `--all-features` build all stay green. Two such call sites had
       # accumulated in `gc.rs` before this step existed. `check` rather than
       # `test`: the matrix below already runs the tests, this only has to prove
       # the configuration compiles.
@@ -167,40 +187,48 @@ jobs:
       # instrumentation sources, so it is listed to keep them compiling —
       # dropping it would recreate exactly the `storage_bench.rs` blind spot
       # described above.
-      - name: Compile Rust workspace tests
-        if: matrix.task == 'test'
-        run: |
-          cargo test --profile test --workspace --all-features --no-run
-          cargo test --locked --manifest-path tooling/Cargo.toml --profile test --workspace --exclude lix_e2e --all-features --no-run
-          cargo test --locked --manifest-path tooling/Cargo.toml --profile test -p lix_e2e --features sdk-tests,plugin-tests,server-protocol,storage-benches,slatedb,root-replay-trace --no-run
-
-      - name: Run Rust workspace tests
+      - name: Run Rust workspace tests with nextest
         # Deliberately no stack-size override here. Production operations and
-        # their tests must fit libtest's default worker stack, so the command a
-        # developer runs by hand behaves like CI's.
+        # their tests must fit the default worker stack, so the command a
+        # developer runs by hand behaves like CI's. The checked-in CI profile
+        # runs every test after failures, reports slow tests, and terminates a
+        # test that exceeds five minutes.
         #
-        # `--no-fail-fast` is required, not cosmetic. Without it cargo stops at
-        # the first failing target and never runs the rest, so a single red
-        # crate hides every later one. #1329 broke two tests; the second sat
-        # invisible behind the first for hours because CI could only ever
-        # report one, and it appeared in the logs as a compiled executable that
-        # never ran.
+        # `fail-fast = false` is required, not cosmetic. #1329 broke two tests;
+        # the second sat invisible behind the first for hours because CI could
+        # only ever report one.
         if: matrix.task == 'test'
         run: |
-          cargo test --profile test --workspace --all-features --no-fail-fast
-          cargo test --locked --manifest-path tooling/Cargo.toml --profile test --workspace --exclude lix_e2e --all-features --no-fail-fast
-          cargo test --locked --manifest-path tooling/Cargo.toml --profile test -p lix_e2e --features sdk-tests,plugin-tests,server-protocol,storage-benches,slatedb,root-replay-trace --no-fail-fast
+          cargo nextest run --config-file .config/nextest.toml --profile ci --cargo-profile test --workspace --all-features --timings
+          cargo nextest run --config-file .config/nextest.toml --profile ci --locked --manifest-path tooling/Cargo.toml --cargo-profile test --workspace --exclude lix_e2e --all-features --timings
+          cargo nextest run --config-file .config/nextest.toml --profile ci-e2e --locked --manifest-path tooling/Cargo.toml --cargo-profile test -p lix_e2e --features sdk-tests,plugin-tests,server-protocol,storage-benches,slatedb,root-replay-trace --timings
 
-      # Examples are compiled by `--all-targets` but never executed, so the SQL
-      # strings inside them are never checked. `checkpoints.rs` selected two
-      # columns that do not exist on `lix_checkpoint` and clippy stayed green,
-      # while the docs mirrored the same broken query. Running the example is
-      # what makes its SQL a tested claim rather than a compiled string.
-      # `--all-features` matches the compilation above so the artifacts are
-      # reused.
-      - name: Run Rust examples
+      - name: Upload Rust test timing reports
+        if: matrix.task == 'test' && !cancelled()
+        uses: actions/upload-artifact@v4
+        with:
+          name: rust-nextest-junit
+          path: |
+            target/nextest/ci/junit.xml
+            tooling/target/nextest/ci/junit.xml
+            tooling/target/nextest/ci-e2e/junit.xml
+          if-no-files-found: error
+
+      - name: Upload Cargo build timings
+        if: matrix.task == 'test' && !cancelled()
+        uses: actions/upload-artifact@v4
+        with:
+          name: rust-cargo-timings
+          path: target/cargo-timings/*.html
+          if-no-files-found: warn
+
+      # Nextest deliberately does not execute rustdoc tests. Keep their Cargo
+      # feature/package scopes aligned with the nextest runs above.
+      - name: Run Rust doctests
         if: matrix.task == 'test'
-        run: cargo run --profile test -p lix --all-features --example checkpoints
+        run: |
+          cargo test --doc --profile test --workspace --all-features --no-fail-fast
+          cargo test --doc --locked --manifest-path tooling/Cargo.toml --profile test --workspace --exclude lix_e2e --all-features --no-fail-fast
 
       # The e2e test compilation above already builds the real workspace plugin
       # artifacts. This one external fixture covers the distinct risk: whether

--- a/packages/lix/AGENTS.md
+++ b/packages/lix/AGENTS.md
@@ -1,13 +1,15 @@
 ## Lix Engine
 
 - Engine behavior tests use the canonical in-memory storage implementation.
-- During development, `cargo test -p lix` runs the fast base simulation
+- During development, `cargo nextest run -p lix` runs the fast base simulation
   without compiling external storage adapters.
-- Before committing, run `cargo test -p lix --features all-simulations`
-  to exercise both the base and tracked-state-rebuild simulations.
+- Before committing, run
+  `cargo nextest run -p lix --features all-simulations` to exercise both the
+  base and tracked-state-rebuild simulations. Run `cargo test -p lix --doc`
+  separately because nextest does not execute doctests.
 - Storage adapters own their conformance tests. Run the relevant adapter package
-  when its implementation or the engine storage contract changes:
-  `cargo test -p lix_storage_rocksdb` or
-  `cargo test -p lix_storage_slatedb`.
+  with nextest when its implementation or the engine storage contract changes:
+  `cargo nextest run -p lix_storage_rocksdb` or
+  `cargo nextest run -p lix_storage_slatedb`.
 - Engine benchmarks live in `lix_e2e`, whose default backend is
   RocksDB. Use `--all-features` for the complete backend benchmark build.

--- a/packages/lix/examples/checkpoints.rs
+++ b/packages/lix/examples/checkpoints.rs
@@ -30,8 +30,6 @@ async fn main() -> Result<(), LixError> {
         let diff_type = row.get::<String>("diff_type")?;
         println!("{diff_type} {schema_key} {row_pk}");
     }
-    assert_eq!(working_diffs.len(), 1);
-
     let checkpoint = lix.create_checkpoint().await?;
     println!("created checkpoint {}", checkpoint.commit_id);
 
@@ -52,16 +50,10 @@ async fn main() -> Result<(), LixError> {
         let depth = row.get::<i64>("lixcol_depth")?;
         println!("depth {depth}: {commit_id}");
     }
-    assert_eq!(
-        checkpoints.rows()[0].get::<String>("commit_id")?,
-        checkpoint.commit_id
-    );
-
     let remaining = lix
         .execute("SELECT COUNT(*) AS count FROM lix_working_diff()", &[])
         .await?;
     let remaining_count = remaining.rows()[0].get::<i64>("count")?;
-    assert_eq!(remaining_count, 0);
     println!("working diffs after checkpoint: {remaining_count}");
 
     lix.close().await?;

--- a/packages/lix/src/session/execute.rs
+++ b/packages/lix/src/session/execute.rs
@@ -11641,8 +11641,9 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn sequential_complete_update_seals_direct_journal() {
-        const ROW_COUNT: usize = 8_193;
+    async fn sequential_complete_update_publishes_direct_journal() {
+        // This is the smallest collection that enters the production packed-base lane.
+        const ROW_COUNT: usize = 512;
         let session = open_session().await;
         let schema = serde_json::json!({
             "$schema": "https://lix.dev/schema-v1.json",
@@ -11705,13 +11706,13 @@ mod tests {
         let visible = transaction
             .execute(
                 "SELECT path, value FROM direct_journal_seal_probe \
-                 WHERE path IN ('0000', '4096', '8192') ORDER BY path",
+                 WHERE path IN ('0000', '0256', '0511') ORDER BY path",
                 &[],
             )
             .await
-            .expect("point reads must route across immutable journal chunks");
+            .expect("point reads must observe the immutable journal");
         assert_eq!(visible.len(), 3);
-        for (row, expected_path) in visible.rows().iter().zip(["0000", "4096", "8192"]) {
+        for (row, expected_path) in visible.rows().iter().zip(["0000", "0256", "0511"]) {
             assert_eq!(row.get::<String>("path").unwrap(), expected_path);
             assert_eq!(
                 row.get::<serde_json::Value>("value").unwrap(),

--- a/packages/lix/src/transaction/context.rs
+++ b/packages/lix/src/transaction/context.rs
@@ -115,8 +115,9 @@ use crate::transaction::staged_commit_changes::{
     StagedCommitChangeBatch, StagedCommitChangeBatchBuilder,
 };
 use crate::transaction::staging::{
-    ImmutableMutationChunkStage, ImmutableMutationJournalChunk, PreparedStateRowOverlay,
-    PreparedWriteSet, TransactionWriteBuffer, TransactionWriteBufferCheckpoint,
+    ImmutableMutationChunkStage, ImmutableMutationJournalChunk, MUTATION_JOURNAL_CHUNK_MAX_ROWS,
+    PreparedStateRowOverlay, PreparedWriteSet, TransactionWriteBuffer,
+    TransactionWriteBufferCheckpoint,
 };
 use crate::transaction::stale_commit::{
     StaleCommitPlan, StaleRowReconciliationPlan, classify_stale_commit,
@@ -7304,7 +7305,7 @@ where
         let chunk_has_capacity = self
             .mutation_journal
             .as_ref()
-            .is_none_or(|journal| journal.len() < 4_096);
+            .is_none_or(|journal| journal.len() < MUTATION_JOURNAL_CHUNK_MAX_ROWS);
         if !same_origin || !ordered_append || !chunk_has_capacity {
             self.flush_mutation_journal().await?;
         }
@@ -7575,7 +7576,7 @@ where
         let chunk_has_capacity = self
             .mutation_journal
             .as_ref()
-            .is_none_or(|journal| journal.len() < 4_096);
+            .is_none_or(|journal| journal.len() < MUTATION_JOURNAL_CHUNK_MAX_ROWS);
         if !same_program || !same_origin || !ordered_append || !chunk_has_capacity {
             self.flush_mutation_journal().await?;
         }

--- a/packages/lix/src/transaction/staging.rs
+++ b/packages/lix/src/transaction/staging.rs
@@ -48,6 +48,8 @@ use crate::transaction_types::{
 };
 use crate::{LixError, NullableKeyFilter};
 
+pub(crate) const MUTATION_JOURNAL_CHUNK_MAX_ROWS: usize = 4 * 1_024;
+
 /// Transaction-local write buffer after transaction-boundary preparation.
 ///
 /// This is the engine seam between SQL execution and transaction ownership:
@@ -4568,6 +4570,99 @@ mod tests {
         assert_eq!(chunk.identity(0), "a");
         assert_eq!(chunk.identity(1), "b");
         assert_eq!(chunk.identity_arena.len(), 2);
+    }
+
+    #[test]
+    fn immutable_journal_seals_and_routes_across_real_chunk_boundaries() {
+        const ROW_COUNT: usize = 2 * MUTATION_JOURNAL_CHUNK_MAX_ROWS + 1;
+        const BRANCH_ID: &str = "ffffffff-ffff-7fff-bfff-ffffffffffff";
+        const TIMESTAMP: &str = "2026-01-01T00:00:00Z";
+
+        fn chunk(
+            first: usize,
+            end: usize,
+            finalize_tail: bool,
+            compressor: &mut Option<crate::compression::ZstdLevel1Compressor>,
+        ) -> ImmutableMutationJournalChunk {
+            let mut identities = Vec::with_capacity((end - first) * 5);
+            let mut identity_offsets = Vec::with_capacity(end - first);
+            let mut snapshots = Vec::new();
+            let mut snapshot_offsets = Vec::with_capacity(end - first);
+            for row_index in first..end {
+                let identity = format!("{row_index:05}");
+                let start = identities.len();
+                identities.extend_from_slice(identity.as_bytes());
+                identity_offsets.push((start, identities.len()));
+
+                let snapshot = format!(r#"{{"key":"{identity}","value":"replacement"}}"#);
+                let start = snapshots.len();
+                snapshots.extend_from_slice(snapshot.as_bytes());
+                snapshot_offsets.push((start, snapshots.len()));
+            }
+
+            let mut chunk = ImmutableMutationJournalChunk::try_new_single_string_identities(
+                SchemaPlanId::for_test(0),
+                "lix_key_value".into(),
+                BRANCH_ID.into(),
+                None,
+                identities,
+                identity_offsets,
+                snapshots,
+                snapshot_offsets,
+                journal_schema_plan(),
+                None,
+                LixTimestamp::expect_parse("timestamp", TIMESTAMP),
+            )
+            .expect("boundary chunk should build");
+            chunk
+                .seal_replacement_parts(finalize_tail, compressor)
+                .expect("boundary chunk should seal");
+            chunk
+        }
+
+        let staged_writes = test_staged_writes();
+        let mut compressor = None;
+        for (first, end, finalize_tail) in [
+            (0, MUTATION_JOURNAL_CHUNK_MAX_ROWS, false),
+            (
+                MUTATION_JOURNAL_CHUNK_MAX_ROWS,
+                2 * MUTATION_JOURNAL_CHUNK_MAX_ROWS,
+                false,
+            ),
+            (2 * MUTATION_JOURNAL_CHUNK_MAX_ROWS, ROW_COUNT, true),
+        ] {
+            assert!(matches!(
+                staged_writes
+                    .stage_immutable_mutation_chunk(chunk(
+                        first,
+                        end,
+                        finalize_tail,
+                        &mut compressor,
+                    ))
+                    .expect("boundary chunk should stage"),
+                ImmutableMutationChunkStage::Staged
+            ));
+        }
+
+        let journal = staged_writes
+            .ordered_mutations
+            .lock()
+            .expect("ordered journal lock should not be poisoned");
+        let journal = journal.as_ref().expect("ordered journal should exist");
+        assert_eq!(journal.row_count(), ROW_COUNT);
+        assert_eq!(journal.chunks.len(), 3);
+        assert_eq!(journal.sealed_replacement_prefix().0, ROW_COUNT);
+        for expected in ["00000", "04096", "08192"] {
+            let (chunk, row_index) = ordered_mutation_journal_row(
+                journal,
+                BRANCH_ID,
+                "lix_key_value",
+                None,
+                &RowPk::single(expected),
+            )
+            .expect("point lookup should route across journal chunks");
+            assert_eq!(chunk.identity(row_index), expected);
+        }
     }
 
     #[test]

--- a/packages/lix/tests/integration/sql/checkpoint.rs
+++ b/packages/lix/tests/integration/sql/checkpoint.rs
@@ -3,6 +3,89 @@ use serde_json::json;
 
 use super::select_rows;
 
+#[tokio::test(flavor = "current_thread")]
+async fn checkpoints_example_sql_contract() {
+    let lix = crate::open_lix().await.expect("example repository opens");
+
+    lix.execute(
+        "INSERT INTO lix_key_value (key, value) VALUES ($1, $2)",
+        &[
+            Value::Text("checkpoint-demo".to_string()),
+            Value::Text("draft".to_string()),
+        ],
+    )
+    .await
+    .expect("example tracked write succeeds");
+
+    let working_diffs = lix
+        .execute(
+            "SELECT row_pk, schema_key, diff_type
+             FROM lix_working_diff()
+             ORDER BY schema_key, row_pk",
+            &[],
+        )
+        .await
+        .expect("example working diff query succeeds");
+    assert_eq!(working_diffs.len(), 1);
+    assert_eq!(
+        working_diffs.rows()[0]
+            .get::<serde_json::Value>("row_pk")
+            .expect("row_pk is JSON"),
+        json!(["checkpoint-demo"])
+    );
+    assert_eq!(
+        working_diffs.rows()[0]
+            .get::<String>("schema_key")
+            .expect("schema_key is text"),
+        "lix_key_value"
+    );
+    assert_eq!(
+        working_diffs.rows()[0]
+            .get::<String>("diff_type")
+            .expect("diff_type is text"),
+        "added"
+    );
+
+    let checkpoint = lix
+        .create_checkpoint()
+        .await
+        .expect("example checkpoint succeeds");
+    let checkpoints = lix
+        .execute(
+            "SELECT commit_id, lixcol_depth
+             FROM lix_history('lix_checkpoint')
+             ORDER BY lixcol_depth",
+            &[],
+        )
+        .await
+        .expect("example checkpoint history query succeeds");
+    assert_eq!(
+        checkpoints.rows()[0]
+            .get::<String>("commit_id")
+            .expect("commit_id is text"),
+        checkpoint.commit_id
+    );
+    assert_eq!(
+        checkpoints.rows()[0]
+            .get::<i64>("lixcol_depth")
+            .expect("lixcol_depth is an integer"),
+        0
+    );
+
+    let remaining = lix
+        .execute("SELECT COUNT(*) AS count FROM lix_working_diff()", &[])
+        .await
+        .expect("example final working diff query succeeds");
+    assert_eq!(
+        remaining.rows()[0]
+            .get::<i64>("count")
+            .expect("count is an integer"),
+        0
+    );
+
+    lix.close().await.expect("example repository closes");
+}
+
 simulation_test!(
     checkpoint_marks_working_interval_and_projects_sql_surfaces,
     |sim| async move {


### PR DESCRIPTION
## Summary

- replace the oversized end-to-end journal boundary probe with a small production-lane test plus a fast focused chunk-boundary test
- run Rust tests with cargo-nextest, preserving doctests separately and publishing JUnit and Cargo timing artifacts
- cache dependency target artifacts seeded from main
- move the checkpoints example SQL assertions into the existing integration test binary and remove the standalone example run

## Validation

- full nextest workspace scope passed locally before the final extraction
- focused checkpoint example contract passes in 31 ms
- checkpoint example compiles with all features
- rustfmt and git diff --check pass

The PR intentionally optimizes the 90% development/PR path without adding fallback modes or compatibility machinery.